### PR TITLE
Makes sure the 'sensei_recent_comments_widget_filter' doesn't override other arguments on the filter.

### DIFF
--- a/inc/woothemes-sensei-template.php
+++ b/inc/woothemes-sensei-template.php
@@ -452,7 +452,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 	 * @return void
 	 */
 	function sensei_recent_comments_widget_filter( $widget_args = array() ) {
-		$widget_args = array( 'post_type' => array( 'post', 'page' ) );
+		if ( ! isset( $widget_args['post_type'] ) ) $widget_args['post_type'] = array( 'post', 'page' );
 		return $widget_args;
 	} // End sensei_recent_comments_widget_filter()
 	add_filter( 'widget_comments_args', 'sensei_recent_comments_widget_filter', 10, 1 );


### PR DESCRIPTION
Regarding https://woothemes.zendesk.com/agent/#/tickets/25788

This filter wasn't respecting other arguments already specified on the filter, and was overriding all arguments. This pull remedies this.
