### PR TITLE
Answer ids

### DIFF
--- a/classes/class-woothemes-sensei-lesson.php
+++ b/classes/class-woothemes-sensei-lesson.php
@@ -1467,7 +1467,7 @@ class WooThemes_Sensei_Lesson {
 		$answer_id = '';
 
 		if( $answer ) {
-			$answer_id = strtolower( str_replace( array( ',', ' ', '-', '&', '\'', '"', '`', '?', ':', ';', '!', '<', '>', '/', '.' ), '', stripslashes( $answer ) ) );
+			$answer_id = md5( $answer );
 		}
 
 		return $answer_id;


### PR DESCRIPTION
We have math based questions and answers and the current generation of answer ids causes answers such as "3" and "-3" to not both show in the admin, even though they are in the database.
