### PR TITLE
Questions displaying in random order even with lesson option set to not

### DIFF
--- a/classes/class-woothemes-sensei-lesson.php
+++ b/classes/class-woothemes-sensei-lesson.php
@@ -2530,7 +2530,7 @@ class WooThemes_Sensei_Lesson {
 						$qargs = array(
 							'post_type' 		=> 'question',
 							'numberposts' 		=> $question_number,
-							'orderby'         	=> 'rand',
+							'orderby'         	=> $orderby,
 							'tax_query'			=> array(
 								array(
 									'taxonomy'  => 'question-category',


### PR DESCRIPTION
Questions loaded from the question bank are always displayed randomly
rather than using the question order setting from the lesson. This
fixes that.
