### PR TITLE
Hide the message "You have already added this Course to your cart" and add a new filter to hide it as well.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,8 @@
  * Fix - Fixing incorrect text domain references
  * Fix - Fixing chosen input widths
  * Fix - Fixing learner profile URL when site URL is different from home URL
+ * Tweak - hide the message "You have already added this Course to your cart" message if the user is enroled in the course and add a new filter: hide_sensei_woocommerce_in_cart_message, to allow the user to remove the notice completely
+
 
 2014.06.30 - version 1.6.1
  * Fix - Making sure Learner Management page shows for users with 'manage_sensei_grades' capability

--- a/classes/class-woothemes-sensei-frontend.php
+++ b/classes/class-woothemes-sensei-frontend.php
@@ -1725,14 +1725,16 @@ class WooThemes_Sensei_Frontend {
 	} // End sensei_course_meta_video()
 
 	public function sensei_woocommerce_in_cart_message() {
-		global $post, $woocommerce;
-		$wc_post_id = absint( get_post_meta( $post->ID, '_course_woocommerce_product', true ) );
-
-		if ( 0 < intval( $wc_post_id ) ) {
-			if ( sensei_check_if_product_is_in_cart( $wc_post_id ) ) {
-				echo '<div class="sensei-message info">' . sprintf(  __('You have already added this Course to your cart. Please %1$s to access the course.', 'woothemes-sensei') . '</div>', '<a class="cart-complete" href="' . $woocommerce->cart->get_checkout_url() . '" title="' . __('complete the purchase', 'woothemes-sensei') . '">' . __('complete the purchase', 'woothemes-sensei') . '</a>' );
+			global $post, $woocommerce ;
+			$wc_post_id = absint( get_post_meta( $post->ID, '_course_woocommerce_product', true ) );
+			$current_user = wp_get_current_user();
+			$show_this_message = ! apply_filters('hide_sensei_woocommerce_in_cart_message', false );
+			if ( 0 < intval( $wc_post_id ) ) {
+	            $user_taking_course = WooThemes_Sensei_Utils::sensei_check_for_activity( array( 'post_id' => $post->ID, 'user_id' => $current_user->ID, 'type' => 'sensei_course_start' ) );
+				if ( $show_this_message && sensei_check_if_product_is_in_cart( $wc_post_id ) && !$user_taking_course ) {
+					echo '<div class="sensei-message info">' . sprintf(  __('You have already added this Course to your cart. Please %1$s to access the course.', 'woothemes-sensei') . '</div>', '<a class="cart-complete" href="' . $woocommerce->cart->get_checkout_url() . '" title="' . __('complete the purchase', 'woothemes-sensei') . '">' . __('complete the purchase', 'woothemes-sensei') . '</a>' );
+				} // End If Statement
 			} // End If Statement
-		} // End If Statement
 
 	} // End sensei_woocommerce_in_cart_message()
 


### PR DESCRIPTION
This message is should not be shown if the user is already enrolled in the course: 
![screen shot 2014-07-25 at 9 45 33 am](https://cloud.githubusercontent.com/assets/1713474/3696680/a48df38e-1393-11e4-9700-46dca230d7ff.png)

Hide the message "You have already added this Course to your cart" message if the user is enroled in the course and add a new filter: hide_sensei_woocommerce_in_cart_message, to allow the user to remove the notice completely

I've also update the changelog.txt with the new tweak.
