### PR TITLE
removes the duplicate appply_filter to call to a WP core hook 

### DIFF
--- a/classes/class-woothemes-sensei-frontend.php
+++ b/classes/class-woothemes-sensei-frontend.php
@@ -1933,7 +1933,7 @@ class WooThemes_Sensei_Frontend {
 		global $post;
 
 		if( is_search() && in_array( $post->post_type, array( 'course', 'lesson' ) ) ) {
-			$content = '<p class="course-excerpt">' . apply_filters( 'get_the_excerpt', $post->post_excerpt ) . '</p>';
+			$content = '<p class="course-excerpt">' . $post->post_excerpt . '</p>';
 		}
 
 		return $content;


### PR DESCRIPTION
Remove the apply filter and simply return the content without applying the filter as WP core already allows the excerpt to be filter outside our function.

closes #491
