### PR TITLE
learner management pagination

### DIFF
--- a/classes/class-woothemes-sensei-learners-main.php
+++ b/classes/class-woothemes-sensei-learners-main.php
@@ -311,11 +311,6 @@ class WooThemes_Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 
 		$total = count( $user_ids );
 
-		$offset = '';
-		if ( isset( $_GET['paged'] ) && 0 < intval( $_GET['paged'] ) ) {
-			$offset = $this->per_page * ( $_GET['paged'] - 1 );
-		} // End If Statement
-
 		// Don't run the query if there are no users taking this course.
 		if ( empty($user_ids) ) return false;
 
@@ -327,7 +322,6 @@ class WooThemes_Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 		$args = array(
 			'number' => $total,
 			'include' => $user_ids,
-			'offset' => $offset,
 			'search' => $search,
 			'fields' => 'all_with_meta'
 		);

--- a/classes/class-woothemes-sensei-list-table.php
+++ b/classes/class-woothemes-sensei-list-table.php
@@ -193,6 +193,8 @@ class WooThemes_Sensei_List_Table extends WP_List_Table {
 			$total_items = count ( $this->user_ids );
 		} else {
 			$total_items = count( $this->items );
+			// Subset for pagination
+			$this->items = array_slice($this->items,(($current_page-1)*$per_page),$per_page);
 			$this->set_pagination_args( array(
 				'total_items' => $total_items,
 				'per_page' => $per_page,


### PR DESCRIPTION
The error here was that the code made use of an offset and the array_splice to strip the learners and only show what is needed for this page.Only one of the two are needed.

The offset method was removed as the the WP_table_list class needs the total number of lessons to determine the page numbers and create the correct pagination. If only a subset is passed the class method it calculates incorrectly. After setting up the pagination the array of users can be sliced up to serve only what's needed based on the current pagination.

All yours @hlashbrooke  :)
