### PR TITLE
Fix Bug: Clicking complete doesn't grant access to the next lesson

### DIFF
--- a/templates/content-single-lesson.php
+++ b/templates/content-single-lesson.php
@@ -57,7 +57,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 							break;
 
 							case 'complete':
-								$user_lesson_end = WooThemes_Sensei_Utils::sensei_get_activity_value( array( 'post_id' => $lesson_prerequisite, 'user_id' => $current_user->ID, 'type' => 'sensei_lesson_start', 'field' => 'comment_content' ) );
+								$user_lesson_end = WooThemes_Sensei_Utils::sensei_get_activity_value( array( 'post_id' => $lesson_prerequisite, 'user_id' => $current_user->ID, 'type' => 'sensei_lesson_end', 'field' => 'comment_content' ) );
 								if ( ! $user_lesson_end || $user_lesson_end == '' || strlen( $user_lesson_end ) == 0 ) {
 									$view_lesson = false;
 								}


### PR DESCRIPTION
The issues was that the query was set to look for sensei_lesson_start on the pre-requisite. The correct type to query should be sensei_lesson_end
