### PR TITLE
Easier administration for a quiz, add link to admin bar

### DIFF
--- a/classes/class-woothemes-sensei-posttypes.php
+++ b/classes/class-woothemes-sensei-posttypes.php
@@ -79,6 +79,8 @@ class WooThemes_Sensei_PostTypes {
 		if ( is_admin() ) {
 			add_action('admin_menu', array( $this, 'sensei_admin_menu_items' ), 9);
 		} // End If Statement
+		// Add 'Edit Quiz' link to admin bar
+		add_action( 'admin_bar_menu', array( $this, 'quiz_admin_bar_menu' ), 81 );
 
 	} // End __construct()
 
@@ -698,6 +700,26 @@ class WooThemes_Sensei_PostTypes {
 		} // End For Loop
 
 	} // End set_role_cap_defaults()
+
+	/**
+	 * Adds a 'Edit Quiz' link to the admin bar when viewing a Quiz linked to a corresponding Lesson
+	 * 
+	 * @since  1.7.0
+	 * @return void
+	 */
+	public function quiz_admin_bar_menu( $bar ) {
+		if ( is_single() && 'quiz' == get_queried_object()->post_type ) {
+			$lesson_id = get_post_meta( get_queried_object()->ID, '_quiz_lesson', true );
+			if ( $lesson_id ) {
+				$object_type = get_post_type_object('quiz');
+				$bar->add_menu( array(
+					'id' => 'edit',
+					'title' => $object_type->labels->edit_item,
+					'href' => get_edit_post_link( $lesson_id ),
+				) );
+			}
+		}
+	}
 
 	/**
 	 * load_class loads in class files


### PR DESCRIPTION
Adds a 'Edit Quiz' link to the admin bar when viewing a Quiz linked to a corresponding Lesson. Because otherwise when you've viewing a quiz you have to traverse to the lesson first on the frontend to then edit, or find it within the admin screens. Very useful if someone sends you a link to a quiz they are having problems with.
