### PR TITLE
Be more consistent with the display of questions with regard to slashes and other formatting

### DIFF
--- a/assets/js/lesson-metadata.js
+++ b/assets/js/lesson-metadata.js
@@ -630,8 +630,8 @@ jQuery(document).ready( function($) {
 	 			dataToPost += 'course_prerequisite' + '=' + jQuery( '#course-prerequisite-options' ).val();
 	 			dataToPost += '&course_woocommerce_product' + '=' + jQuery( '#course-woocommerce-product-options' ).val();
 	 			dataToPost += '&course_category' + '=' + jQuery( '#course-category-options' ).val();
-	 			dataToPost += '&course_title' + '=' + encodeURIComponent( jQuery( '#course-title' ).attr( 'value' ) );
-	 			dataToPost += '&course_content' + '=' + encodeURIComponent( jQuery( '#course-content' ).attr( 'value' ) );
+	 			dataToPost += '&course_title' + '=' + jQuery( '#course-title' ).attr( 'value' );
+	 			dataToPost += '&course_content' + '=' + jQuery( '#course-content' ).attr( 'value' );
 	 			dataToPost += '&action=add';
 	 			// Perform the AJAX call.
 	 			jQuery.post(
@@ -788,13 +788,13 @@ jQuery(document).ready( function($) {
 			// Handle Required Fields
 			jQuery( '#add-new-question' ).find( 'div.question_required_fields' ).find( 'input' ).each( function() {
 	 			if ( jQuery( this ).attr( 'type' ) != 'radio' ) {
-	 				dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( this ).attr( 'value' ) );
+	 				dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + jQuery( this ).attr( 'value' );
 	 			} // End If Statement
  			});
 
 			// Handle textarea required field
 			if ( jQuery( '#add-new-question' ).find( 'div.question_required_fields' ).find( 'textarea' ).val() != '' ) {
-	 			dataToPost += '&' + jQuery( '#add-new-question' ).find( 'div.question_required_fields' ).find( 'textarea' ).attr( 'name' ) + '=' +  encodeURIComponent( jQuery( '#add-new-question' ).find( 'div.question_required_fields' ).find( 'textarea' ).val() );
+	 			dataToPost += '&' + jQuery( '#add-new-question' ).find( 'div.question_required_fields' ).find( 'textarea' ).attr( 'name' ) + '=' + jQuery( '#add-new-question' ).find( 'div.question_required_fields' ).find( 'textarea' ).val();
 	 		} // End If Statement
 
 	 		// Handle Question Input Fields
@@ -808,15 +808,15 @@ jQuery(document).ready( function($) {
 	 					radioCount++;
 	 				} // End If Statement
  				} else {
- 					dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( this ).attr( 'value' ) );
+ 					dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + jQuery( this ).attr( 'value' );
  				} // End If Statement
 	 		});
 	 		// Handle Question Textarea Fields
 	 		if ( jQuery( '#add_question_right_answer_essay' ).val() != '' && divFieldsClass == 'question_essay_fields' ) {
-	 			dataToPost += '&' + jQuery( '#add_question_right_answer_essay' ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( '#add_question_right_answer_essay' ).val() );
+	 			dataToPost += '&' + jQuery( '#add_question_right_answer_essay' ).attr( 'name' ) + '=' + jQuery( '#add_question_right_answer_essay' ).val();
 	 		} // End If Statement
  			if ( jQuery( '#add_question_right_answer_multiline' ).val() != '' && divFieldsClass == 'question_multiline_fields' ) {
- 				dataToPost += '&' + jQuery( '#add_question_right_answer_multiline' ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( '#add_question_right_answer_multiline' ).val() );
+ 				dataToPost += '&' + jQuery( '#add_question_right_answer_multiline' ).attr( 'name' ) + '=' + jQuery( '#add_question_right_answer_multiline' ).val();
 	 		} // End If Statement
 	 		dataToPost += '&' + 'question_type' + '=' + questionType;
 	 		dataToPost += '&' + 'question_category' + '=' + questionCategory;
@@ -958,7 +958,7 @@ jQuery(document).ready( function($) {
  			dataToPost += 'quiz_id' + '=' + jQuery( '#quiz_id' ).attr( 'value' );
  			dataToPost += '&action=save';
  			jQuery( this ).closest( 'td' ).children( 'input' ).each( function() {
- 				dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( this ).attr( 'value' ) );
+ 				dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + jQuery( this ).attr( 'value' );
  			});
  			tableRowId = jQuery( this ).closest('td').find('span.question_original_counter').text();
  			if ( jQuery( this ).closest('td').find( 'input.question_type' ).val() != '' ) {
@@ -991,13 +991,13 @@ jQuery(document).ready( function($) {
 			// Handle Required Fields
 			jQuery( this ).closest('td').find( 'div.question_required_fields' ).find( 'input' ).each( function() {
 	 			if ( jQuery( this ).attr( 'type' ) != 'radio' ) {
-	 				dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( this ).attr( 'value' ) );
+	 				dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + jQuery( this ).attr( 'value' );
 	 			} // End If Statement
  			});
 
 			// Handle textarea required field
 			if ( jQuery( this ).closest('td').find( 'div.question_required_fields' ).find( 'textarea' ).val() != '' ) {
-	 			dataToPost += '&' +  jQuery(this).closest('td').find( 'div.question_required_fields' ).find( 'textarea' ).attr( 'name' ) + '=' +  encodeURIComponent( jQuery(this).closest('td').find( 'div.question_required_fields' ).find( 'textarea' ).val() );
+	 			dataToPost += '&' +  jQuery(this).closest('td').find( 'div.question_required_fields' ).find( 'textarea' ).attr( 'name' ) + '=' + jQuery(this).closest('td').find( 'div.question_required_fields' ).find( 'textarea' ).val();
 	 		} // End If Statement
 
 	 		// Handle Question Input Fields
@@ -1010,17 +1010,17 @@ jQuery(document).ready( function($) {
 	 					radioCount++;
 	 				} // End If Statement
  				} else {
- 					dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( this ).attr( 'value' ) );
+ 					dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + jQuery( this ).attr( 'value' );
  				} // End If Statement
 	 		});
 
 	 		// Handle Question Textarea Fields
 	 		if ( jQuery(this).closest('td').find( 'div.' + divFieldsClass ).find( 'textarea' ).val() != '' && divFieldsClass == 'question_multiline_fields' ) {
-	 			dataToPost += '&' +  jQuery(this).closest('td').find( 'div.' + divFieldsClass ).find( 'textarea' ).attr( 'name' ) + '=' +  encodeURIComponent( jQuery(this).closest('td').find( 'div.' + divFieldsClass ).find( 'textarea' ).val() );
+	 			dataToPost += '&' +  jQuery(this).closest('td').find( 'div.' + divFieldsClass ).find( 'textarea' ).attr( 'name' ) + '=' + jQuery(this).closest('td').find( 'div.' + divFieldsClass ).find( 'textarea' ).val();
 	 		} // End If Statement
 	 		if ( divFieldsClass == 'question_fileupload_fields' ) {
 	 			jQuery(this).closest('td').find( 'div.' + divFieldsClass ).find( 'textarea' ).each( function() {
-	 				dataToPost += '&' +  jQuery(this).attr( 'name' ) + '=' +  encodeURIComponent( jQuery(this).val() );
+	 				dataToPost += '&' +  jQuery(this).attr( 'name' ) + '=' + jQuery(this).val();
 	 			});
 	 		} // End If Statement
 

--- a/classes/class-woothemes-sensei-lesson.php
+++ b/classes/class-woothemes-sensei-lesson.php
@@ -815,9 +815,9 @@ class WooThemes_Sensei_Lesson {
 				if( 'quiz' == $context ) {
 					$html .= '<tr>';
 						if( $question_type != 'category' ) {
-
+							$question = get_post( $question_id );
 							$html .= '<td class="table-count question-number question-count-column"><span class="number">' . $question_counter . '</span></td>';
-							$html .= '<td>' . esc_html( get_the_title( $question_id ) ) . '</td>';
+							$html .= '<td>' . esc_html( $question->post_title ) . '</td>';
 							$html .= '<td class="question-grade-column">' . esc_html( $question_grade ) . '</td>';
 							$question_types_filtered = ucwords( str_replace( array( '-', 'boolean' ), array( ' ', __( 'True/False', 'woothemes-sensei' ) ), $question_type ) );
 							$html .= '<td>' . esc_html( $question_types_filtered ) . '</td>';
@@ -850,6 +850,7 @@ class WooThemes_Sensei_Lesson {
 						$edit_class = 'hidden';
 					}
 
+					$question = get_post( $question_id );
 					$html .= '<tr class="question-quick-edit ' . esc_attr( $edit_class ) . '">';
 						$html .= '<td colspan="5">';
 							$html .= '<span class="hidden question_original_counter">' . $question_counter . '</span>';
@@ -858,15 +859,14 @@ class WooThemes_Sensei_Lesson {
 						    	// Question title
 						    	$html .= '<div>';
 							    	$html .= '<label for="question_' . $question_counter . '">' . __( 'Question:', 'woothemes-sensei' ) . '</label> ';
-							    	$html .= '<input type="text" id="question_' . $question_counter . '" name="question" value="' . esc_attr( htmlspecialchars( get_the_title( $question_id ) ) ) . '" size="25" class="widefat" />';
+							    	$html .= '<input type="text" id="question_' . $question_counter . '" name="question" value="' . esc_attr( htmlspecialchars( $question->post_title ) ) . '" size="25" class="widefat" />';
 						    	$html .= '</div>';
 
 						    	// Question description
 						    	$html .= '<div>';
 							    	$html .= '<label for="question_' . $question_counter . '_desc">' . __( 'Question Description (optional):', 'woothemes-sensei' ) . '</label> ';
 						    	$html .= '</div>';
-									$full_question = get_post( $question_id );
-							    	$html .= '<textarea id="question_' . $question_counter . '_desc" name="question_description" class="widefat" rows="4">' . esc_textarea( $full_question->post_content ) . '</textarea>';
+							    	$html .= '<textarea id="question_' . $question_counter . '_desc" name="question_description" class="widefat" rows="4">' . esc_textarea( $question->post_content ) . '</textarea>';
 
 						    	// Question grade
 						    	$html .= '<div>';
@@ -1829,11 +1829,8 @@ class WooThemes_Sensei_Lesson {
 		$data = $_POST['data'];
 		$question_data = array();
 		parse_str($data, $question_data);
-		// WP slashes all incoming data regardless of Magic Quotes setting (see wp_magic_quotes()),
-		// except AJAX encoded POST data bypasses this, so ensure consistancy for lesson_save_question()
-		$question_title = $question_data['question']; // Don't slash the title, backup...
-		$question_data = wp_slash( $question_data );
-		$question_data['question'] = $question_title; // ...and reset
+		// WP slashes all incoming data regardless of Magic Quotes setting (see wp_magic_quotes()), except AJAX
+		// encoded POST data bypasses this, so ensure consistancy for lesson_save_question() but not doing anything
 		// Save the question
 		$return = false;
 		// Question Save and Delete logic

--- a/templates/single-quiz/question_type-boolean.php
+++ b/templates/single-quiz/question_type-boolean.php
@@ -72,7 +72,7 @@ if( 0 < intval( $question_media ) ) {
 // Merge right and wrong answers and randomize
 array_push( $question_wrong_answers, $question_right_answer );
 shuffle($question_wrong_answers);
-$question_text = $question_item->post_title;
+$question_text = get_the_title( $question_item );
 $question_description = apply_filters( 'the_content', $question_item->post_content, $question_item->ID );
 
 $answer_message = false;

--- a/templates/single-quiz/question_type-file-upload.php
+++ b/templates/single-quiz/question_type-file-upload.php
@@ -94,7 +94,7 @@ if( 0 < intval( $question_media ) ) {
 	}
 }
 
-$question_text = $question_item->post_title;
+$question_text = get_the_title( $question_item );
 $question_description = apply_filters( 'the_content', $question_item->post_content, $question_item->ID );
 
 $answer_message = false;

--- a/templates/single-quiz/question_type-gap-fill.php
+++ b/templates/single-quiz/question_type-gap-fill.php
@@ -67,7 +67,7 @@ if( 0 < intval( $question_media ) ) {
 }
 
 // Gap Fill data
-$question_text = $question_item->post_title;
+$question_text = get_the_title( $question_item );
 $question_description = apply_filters( 'the_content', $question_item->post_content, $question_item->ID );
 
 $gapfill_array = explode( '||', $question_right_answer );

--- a/templates/single-quiz/question_type-multi-line.php
+++ b/templates/single-quiz/question_type-multi-line.php
@@ -70,7 +70,7 @@ if( 0 < intval( $question_media ) ) {
 // Merge right and wrong answers and randomize
 array_push( $question_wrong_answers, $question_right_answer );
 shuffle($question_wrong_answers);
-$question_text = $question_item->post_title;
+$question_text = get_the_title( $question_item );
 $question_description = apply_filters( 'the_content', $question_item->post_content, $question_item->ID );
 
 $answer_message = false;

--- a/templates/single-quiz/question_type-multiple-choice.php
+++ b/templates/single-quiz/question_type-multiple-choice.php
@@ -118,7 +118,7 @@ if( ! $question_grade || $question_grade == '' ) {
 $user_answer_entry = WooThemes_Sensei_Utils::sensei_check_for_activity( array( 'post_id' => $question_id, 'user_id' => $current_user->ID, 'type' => 'sensei_user_answer' ), true );
 $user_question_grade = WooThemes_Sensei_Utils::sensei_get_user_question_grade( $user_answer_entry );
 
-$question_text = $question_item->post_title;
+$question_text = get_the_title( $question_item );
 $question_description = apply_filters( 'the_content', $question_item->post_content, $question_item->ID );
 
 $answer_message = false;

--- a/templates/single-quiz/question_type-single-line.php
+++ b/templates/single-quiz/question_type-single-line.php
@@ -70,7 +70,7 @@ if( 0 < intval( $question_media ) ) {
 // Merge right and wrong answers and randomize
 array_push( $question_wrong_answers, $question_right_answer );
 shuffle($question_wrong_answers);
-$question_text = $question_item->post_title;
+$question_text = get_the_title( $question_item );
 $question_description = apply_filters( 'the_content', $question_item->post_content, $question_item->ID );
 
 $answer_message = false;


### PR DESCRIPTION
Effectively fixes #648. 
- This removes all use of encodeURIComponent within lesson-metadata.js (which was on all text inputs except answer_feedback (which is why that didn't seem to have a problem) as passing the data through jQuery.post causes it to do any formatting needed. 
- No longer wp_slash incoming question data on the AJAX call.
- When building the question panel for lesson admin, display question title directly rather than use get_the_title()
- On frontend templates do the opposite, use get_the_title() for all question titles to ensure quotes etc get formatted correctly.

**Note:** lesson-metadata.min.js needs to be regenerated. Don't know the correct settings for it.
