### PR TITLE
Correctly cast returns of sensei_check_for_activity as arrays for consistency

### DIFF
--- a/classes/class-woothemes-sensei-analysis-course.php
+++ b/classes/class-woothemes-sensei-analysis-course.php
@@ -521,7 +521,7 @@ class WooThemes_Sensei_Analysis_Course_List_Table extends WooThemes_Sensei_List_
 		}
 		$statuses = WooThemes_Sensei_Utils::sensei_check_for_activity( $activity_args, true );
 		// Need to always return an array, even with only 1 item
-		if ( 1 == $this->total_items ) {
+		if ( !is_array($statuses) ) {
 			$statuses = array( $statuses );
 		}
 		return $statuses;

--- a/classes/class-woothemes-sensei-analysis-lesson.php
+++ b/classes/class-woothemes-sensei-analysis-lesson.php
@@ -316,7 +316,7 @@ class WooThemes_Sensei_Analysis_Lesson_List_Table extends WooThemes_Sensei_List_
 		}
 		$statuses = WooThemes_Sensei_Utils::sensei_check_for_activity( $activity_args, true );
 		// Need to always return an array, even with only 1 item
-		if ( 1 == $this->total_items ) {
+		if ( !is_array($statuses) ) {
 			$statuses = array( $statuses );
 		}
 		return $statuses;

--- a/classes/class-woothemes-sensei-analysis-user-profile.php
+++ b/classes/class-woothemes-sensei-analysis-user-profile.php
@@ -279,6 +279,10 @@ class WooThemes_Sensei_Analysis_User_Profile_List_Table extends WooThemes_Sensei
 			$activity_args['offset'] = $new_paged * $activity_args['number'];
 		}
 		$statuses = WooThemes_Sensei_Utils::sensei_check_for_activity( $activity_args, true );
+		// Need to always return an array, even with only 1 item
+		if ( !is_array($statuses) ) {
+			$statuses = array( $statuses );
+		}
 
 		return $statuses;
 	} // End get_course_statuses()

--- a/classes/class-woothemes-sensei-grading-main.php
+++ b/classes/class-woothemes-sensei-grading-main.php
@@ -215,7 +215,7 @@ class WooThemes_Sensei_Grading_Main extends WooThemes_Sensei_List_Table {
 		}
 		$statuses = WooThemes_Sensei_Utils::sensei_check_for_activity( $activity_args, true );
 		// Need to always return an array, even with only 1 item
-		if ( 1 == $total_statuses ) {
+		if ( !is_array($statuses) ) {
 			$statuses = array( $statuses );
 		}
 		$this->total_items = $total_statuses;

--- a/classes/class-woothemes-sensei-learners-main.php
+++ b/classes/class-woothemes-sensei-learners-main.php
@@ -431,7 +431,7 @@ class WooThemes_Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 		}
 		$learners = WooThemes_Sensei_Utils::sensei_check_for_activity( $activity_args, true );
 		// Need to always return an array, even with only 1 item
-		if ( 1 == $total_learners ) {
+		if ( !is_array($learners) ) {
 			$learners = array( $learners );
 		}
 		$this->total_items = $total_learners;

--- a/classes/class-woothemes-sensei-utils.php
+++ b/classes/class-woothemes-sensei-utils.php
@@ -230,6 +230,10 @@ class WooThemes_Sensei_Utils {
 		global $woothemes_sensei;
 
 		$comments = WooThemes_Sensei_Utils::sensei_check_for_activity( $args, true );
+		// Need to always use an array, even with only 1 item
+		if ( !is_array($comments) ) {
+			$comments = array( $comments );
+		}
 
 		$post_ids = array();
 		// Count comments
@@ -1506,6 +1510,10 @@ class WooThemes_Sensei_Utils {
 			if ( version_compare($wp_version, '4.1', '>=') ) {
 				$lesson_status_args['post__in'] = $lesson_ids;
 				$all_lesson_statuses = WooThemes_Sensei_Utils::sensei_check_for_activity( $lesson_status_args, true );
+				// Need to always return an array, even with only 1 item
+				if ( !is_array($all_lesson_statuses) ) {
+					$all_lesson_statuses = array( $all_lesson_statuses );
+				}
 			}
 			// ...otherwise check each one
 			else {


### PR DESCRIPTION
Fixes issues where a single entry is returned and the various screens etc display empty rows etc.
