### PR TITLE
Add in missing conversion of results from sensei_check_for_activity to arrays

### DIFF
--- a/classes/class-woothemes-sensei-updates.php
+++ b/classes/class-woothemes-sensei-updates.php
@@ -562,12 +562,14 @@ class WooThemes_Sensei_Updates {
 
 				// Get current user answers
 				$comments = WooThemes_Sensei_Utils::sensei_check_for_activity( array( 'post_id' => $quiz_id, 'type' => 'sensei_quiz_answers' ), true  );
-				if( is_array( $comments ) ) {
-					foreach ( $comments as $comment ) {
-						$user_id = $comment->user_id;
-						$content = maybe_unserialize( base64_decode( $comment->comment_content ) );
-						$old_user_answers[ $quiz_id ][ $user_id ] = $content;
-					}
+				// Need to always return an array, even with only 1 item
+				if ( !is_array($comments) ) {
+					$comments = array( $comments );
+				}
+				foreach ( $comments as $comment ) {
+					$user_id = $comment->user_id;
+					$content = maybe_unserialize( base64_decode( $comment->comment_content ) );
+					$old_user_answers[ $quiz_id ][ $user_id ] = $content;
 				}
 
 				// Get correct answers

--- a/widgets/widget-woothemes-sensei-course-component.php
+++ b/widgets/widget-woothemes-sensei-course-component.php
@@ -188,11 +188,19 @@ class WooThemes_Sensei_Course_Component_Widget extends WP_Widget {
 		$course_ids = array();
 		if ( 'activecourses' == esc_attr( $instance['component'] ) ) {
 			$courses = WooThemes_Sensei_Utils::sensei_check_for_activity( array( 'user_id' => $current_user->ID, 'type' => 'sensei_course_status', 'status' => 'in-progress' ), true );
+			// Need to always return an array, even with only 1 item
+			if ( !is_array($courses) ) {
+				$courses = array( $courses );
+			}
 			foreach( $courses AS $course_id ) {
 				$course_ids[] = $course_id;
 			}
 		} elseif( 'completedcourses' == esc_attr( $instance['component'] ) ) {
 			$courses = WooThemes_Sensei_Utils::sensei_check_for_activity( array( 'user_id' => $current_user->ID, 'type' => 'sensei_course_status', 'status' => 'complete' ), true );
+			// Need to always return an array, even with only 1 item
+			if ( !is_array($courses) ) {
+				$courses = array( $courses );
+			}
 			foreach( $courses AS $course_id ) {
 				$course_ids[] = $course_id;
 			}


### PR DESCRIPTION
Running a search across the whole of Sensei for use of sensei_check_for_activity where the comments are returned (rather than counted) gave 3 instances where the results weren't checked and put into an array. This fixes this, which in turn fixes #694. 
