### PR TITLE
Updated to use include and not include_once

### DIFF
--- a/classes/class-woothemes-sensei-emails.php
+++ b/classes/class-woothemes-sensei-emails.php
@@ -205,7 +205,7 @@ class WooThemes_Sensei_Emails {
 		ob_start();
 
 		do_action( 'sensei_before_email_template', $email_template );
-		include_once( $template );
+		include( $template );
 		do_action( 'sensei_after_email_template', $email_template );
 
 		return ob_get_clean();


### PR DESCRIPTION
Use include and not include once so that multiple emails can be sent out.

@hlashbrooke this fixes the changes applied here: #620 
