### PR TITLE
Update the code to reflect the new WooCommerce order status changes also remove the call to show message .closes #728

### DIFF
--- a/classes/class-woothemes-sensei-utils.php
+++ b/classes/class-woothemes-sensei-utils.php
@@ -376,7 +376,7 @@ class WooThemes_Sensei_Utils {
 
 		foreach ( $orders as $order_id ) {
 			$order = new WC_Order( $order_id->ID );
-			if ( $order->status == 'completed' ) {
+			if ( $order->post_status == 'wc-completed' ) {
 				if ( 0 < sizeof( $order->get_items() ) ) {
 					foreach( $order->get_items() as $item ) {
 

--- a/classes/class-woothemes-sensei.php
+++ b/classes/class-woothemes-sensei.php
@@ -273,7 +273,7 @@ class WooThemes_Sensei {
 	public function virtual_order_payment_complete( $order_status, $order_id ) {
 		$order = new WC_Order( $order_id );
 		if ( ! isset ( $order ) ) return;
-		if ( $order_status == 'processing' && ( $order->status == 'on-hold' || $order->status == 'pending' || $order->status == 'failed' ) ) {
+		if ( $order_status == 'wc-processing' && ( $order->post_status == 'wc-on-hold' || $order->post_status == 'wc-pending' || $order->post_status == 'wc-failed' ) ) {
 			$virtual_order = true;
 
 			if ( count( $order->get_items() ) > 0 ) {
@@ -972,13 +972,17 @@ class WooThemes_Sensei {
 	 * sensei_woocommerce_email_course_details adds detail to email
 	 * @since   1.4.5
 	 * @access  public
-	 * @param   integer $order_id order ID
+	 * @param   WC_Order $order
 	 * @return  void
 	 */
 	public function sensei_woocommerce_email_course_details( $order ) {
 		global $woocommerce, $woothemes_sensei;
 
-		if( 'completed' != $order->status ) return;
+		// exit early if not wc-completed or wc-processing
+		if( 'wc-completed' != $order->post_status
+			&& 'wc-processing' != $order->post_status  ) {
+			return;
+		}
 
 		$order_items = $order->get_items();
 		$order_id = $order->id;


### PR DESCRIPTION
@danjjohnson this also updates the status make use wc-\* and $order->post_status instead of $order->status
