### PR TITLE
Remove Course/Lesson creation from Frontend class as already created in ...

### DIFF
--- a/classes/class-woothemes-sensei-course.php
+++ b/classes/class-woothemes-sensei-course.php
@@ -830,7 +830,7 @@ class WooThemes_Sensei_Course {
 		$course_quizzes = array();
 
 		if( $course_id ) {
-			$lesson_ids = $woothemes_sensei->frontend->course->course_lessons( $course_id, 'any', 'ids' );
+			$lesson_ids = $woothemes_sensei->post_types->course->course_lessons( $course_id, 'any', 'ids' );
 
 			foreach( $lesson_ids as $lesson_id ) {
 				$has_questions = get_post_meta( $lesson_id, '_quiz_has_questions', true );
@@ -838,8 +838,8 @@ class WooThemes_Sensei_Course {
 					return true;
 				}
 				elseif ( $has_questions ) {
-					$quiz_id = $woothemes_sensei->frontend->lesson->lesson_quizzes( $lesson_id );
-//					$questions = $woothemes_sensei->frontend->lesson->lesson_quiz_questions( $quiz_id );
+					$quiz_id = $woothemes_sensei->post_types->lesson->lesson_quizzes( $lesson_id );
+//					$questions = $woothemes_sensei->post_types->lesson->lesson_quiz_questions( $quiz_id );
 //					if( count( $questions ) > 0 ) {
 						$course_quizzes[] = $quiz_id;
 //					}
@@ -1074,7 +1074,7 @@ class WooThemes_Sensei_Course {
 			}
 			foreach ( $active_courses as $course_item ) {
 
-				$course_lessons = $woothemes_sensei->frontend->course->course_lessons( $course_item->ID );
+				$course_lessons = $woothemes_sensei->post_types->course->course_lessons( $course_item->ID );
 				$lessons_completed = 0;
 				foreach ( $course_lessons as $lesson ) {
 					if ( WooThemes_Sensei_Utils::user_completed_lesson( $lesson->ID, $user->ID ) ) {
@@ -1246,7 +1246,7 @@ class WooThemes_Sensei_Course {
 						$complete_html .= '<div class="meter green"><span style="width: 100%">100%</span></div>';
 
 						if( $manage ) {
-							$has_quizzes = count( $woothemes_sensei->frontend->course->course_quizzes( $course_item->ID ) ) > 0 ? true : false;
+							$has_quizzes = count( $woothemes_sensei->post_types->course->course_quizzes( $course_item->ID ) ) > 0 ? true : false;
 							// Output only if there is content to display
 							if ( has_filter( 'sensei_results_links' ) || false != $has_quizzes ) {
 								$complete_html .= '<p class="sensei-results-links">';

--- a/classes/class-woothemes-sensei-frontend.php
+++ b/classes/class-woothemes-sensei-frontend.php
@@ -39,8 +39,6 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  */
 class WooThemes_Sensei_Frontend {
 	public $token;
-	public $course;
-	public $lesson;
 	public $messages;
 	public $data;
 
@@ -114,9 +112,6 @@ class WooThemes_Sensei_Frontend {
 		// Fix pagination for course archive pages when filtering by course type
 		add_filter( 'pre_get_posts', array( $this, 'sensei_course_archive_pagination' ) );
 
-		// Load post type classes
-		$this->course = new WooThemes_Sensei_Course();
-		$this->lesson = new WooThemes_Sensei_Lesson();
 		// Scripts and Styles
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 		add_action( 'wp_head', array( $this, 'enqueue_scripts' ) );
@@ -166,6 +161,26 @@ class WooThemes_Sensei_Frontend {
 	public function init () {
 
 	} // End init()
+
+	/**
+	 * Graceful fallback for course and lesson variables on Frontend object
+	 *
+	 * @param string $key Key to get.
+	 * @since  1.7.3
+	 * @return array|mixed
+	 */
+	public function __get( $key ) {
+		global $woothemes_sensei;
+
+		if ( 'lesson' == $key || 'course' == $key ) {
+			if ( WP_DEBUG ) {
+				trigger_error( sprintf( '$woothemes_sensei->frontend->%1$s has been <strong>deprecated</strong> since version %2$s! Please use $woothemes_sensei->post_types->%1$s to access the instance.', $key, '1.7.3' ) );
+			}
+			return $woothemes_sensei->post_types->$key;
+		}
+
+		return null;
+	}
 
 	/**
 	 * Enqueue frontend JavaScripts.
@@ -536,10 +551,11 @@ class WooThemes_Sensei_Frontend {
 	 * @return void
 	 */
 	function sensei_course_image( $course_id, $width = '100', $height = '100', $return = false ) {
+		global $woothemes_sensei;
     	if ( $return ) {
-			return $this->course->course_image( $course_id, $width, $height );
+			return $woothemes_sensei->post_types->course->course_image( $course_id, $width, $height );
 		} else {
-			echo $this->course->course_image( $course_id, $width, $height );
+			echo $woothemes_sensei->post_types->course->course_image( $course_id, $width, $height );
 		} // End If Statement
 	} // End sensei_course_image()
 
@@ -549,10 +565,11 @@ class WooThemes_Sensei_Frontend {
 	 * @return void
 	 */
 	function sensei_lesson_image( $lesson_id, $width = '100', $height = '100', $return = false, $widget = false ) {
+		global $woothemes_sensei;
 		if ( $return ) {
-			return $this->lesson->lesson_image( $lesson_id, $width, $height, $widget );
+			return $woothemes_sensei->post_types->lesson->lesson_image( $lesson_id, $width, $height, $widget );
 		} else {
-			echo $this->lesson->lesson_image( $lesson_id, $width, $height, $widget );
+			echo $woothemes_sensei->post_types->lesson->lesson_image( $lesson_id, $width, $height, $widget );
 		} // End If Statement
 	} // End sensei_lesson_image()
 
@@ -830,7 +847,7 @@ class WooThemes_Sensei_Frontend {
 	} // End sensei_complete_lesson()
 
 	public function sensei_complete_course() {
-		global $post, $current_user, $wp_query;
+		global $post, $woothemes_sensei, $current_user, $wp_query;
 		if ( isset( $_POST['course_complete'] ) && wp_verify_nonce( $_POST[ 'woothemes_sensei_complete_course_noonce' ], 'woothemes_sensei_complete_course_noonce' ) ) {
 
 			$sanitized_submit = esc_html( $_POST['course_complete'] );
@@ -849,7 +866,7 @@ class WooThemes_Sensei_Frontend {
 
 					if ( $activity_logged ) {
 						// Get all course lessons
-						$course_lesson_ids = $this->course->course_lessons( $sanitized_course_id, 'any', 'ids' );
+						$course_lesson_ids = $woothemes_sensei->post_types->course->course_lessons( $sanitized_course_id, 'any', 'ids' );
 						// Mark all quiz user meta lessons as complete
 						foreach ( $course_lesson_ids as $lesson_item_id ){
 							// Mark lesson as complete
@@ -898,7 +915,7 @@ class WooThemes_Sensei_Frontend {
 		$grade = 0;
 
 		// Get Quiz Questions
-		$lesson_quiz_questions = $woothemes_sensei->frontend->lesson->lesson_quiz_questions( $post->ID );
+		$lesson_quiz_questions = $woothemes_sensei->post_types->lesson->lesson_quiz_questions( $post->ID );
 
 		$quiz_lesson_id = absint( get_post_meta( $post->ID, '_quiz_lesson', true ) );
 
@@ -1063,7 +1080,7 @@ class WooThemes_Sensei_Frontend {
 		$user_answers = array();
 
 		if ( 0 < intval( $lesson_id ) ) {
-			$lesson_quiz_questions = $woothemes_sensei->frontend->lesson->lesson_quiz_questions( $lesson_id );
+			$lesson_quiz_questions = $woothemes_sensei->post_types->lesson->lesson_quiz_questions( $lesson_id );
 			foreach( $lesson_quiz_questions as $question ) {
 				$answer = maybe_unserialize( base64_decode( WooThemes_Sensei_Utils::sensei_get_activity_value( array( 'post_id' => $question->ID, 'user_id' => $current_user->ID, 'type' => 'sensei_user_answer', 'field' => 'comment_content' ) ) ) );
 				$user_answers[ $question->ID ] = $answer;
@@ -1101,7 +1118,7 @@ class WooThemes_Sensei_Frontend {
 		$quiz_id = 0;
 
 		// Lesson quizzes
-		$quiz_id = $woothemes_sensei->frontend->lesson->lesson_quizzes( $post->ID );
+		$quiz_id = $woothemes_sensei->post_types->lesson->lesson_quizzes( $post->ID );
 		$pass_required = true;
 		if( $quiz_id ) {
 			// Get quiz pass setting
@@ -1123,7 +1140,7 @@ class WooThemes_Sensei_Frontend {
 		$quiz_id = 0;
 
 		// Lesson quizzes
-		$quiz_id = $woothemes_sensei->frontend->lesson->lesson_quizzes( $post->ID );
+		$quiz_id = $woothemes_sensei->post_types->lesson->lesson_quizzes( $post->ID );
 		$reset_allowed = true;
 		if( $quiz_id ) {
 			// Get quiz pass setting
@@ -1146,7 +1163,7 @@ class WooThemes_Sensei_Frontend {
 		$lesson_course_id = (int) get_post_meta( $post_id, '_lesson_course', true );
 
 		// Lesson Quiz Meta
-		$quiz_id = $woothemes_sensei->frontend->lesson->lesson_quizzes( $post_id );
+		$quiz_id = $woothemes_sensei->post_types->lesson->lesson_quizzes( $post_id );
 		$has_user_completed_lesson = WooThemes_Sensei_Utils::user_completed_lesson( $post_id, $user_id );
 		$show_actions = is_user_logged_in() ? true : false;
 
@@ -1484,7 +1501,7 @@ class WooThemes_Sensei_Frontend {
 				// Success message
 		   		if ( $completed_course ) { ?>
 		   			<div class="status completed"><?php echo apply_filters( 'sensei_complete_text', __( 'Completed', 'woothemes-sensei' ) ); ?></div>
-		   			<?php if( $woothemes_sensei->frontend->course->course_quizzes( $post->ID, true ) ) { ?>
+		   			<?php if( $woothemes_sensei->post_types->course->course_quizzes( $post->ID, true ) ) { ?>
 		   				<p class="sensei-results-links">
 		   				<?php
 		   				$results_link = '<a class="view-results" href="' . $woothemes_sensei->course_results->get_permalink( $post->ID ) . '">' . apply_filters( 'sensei_view_results_text', __( 'View results', 'woothemes-sensei' ) ) . '</a>';

--- a/templates/loop-lesson.php
+++ b/templates/loop-lesson.php
@@ -38,7 +38,7 @@ $lesson_count = 1;
 						}
 					} // End If Statement
 
-                    $complexity_array = $woothemes_sensei->frontend->lesson->lesson_complexities();
+                    $complexity_array = $woothemes_sensei->post_types->lesson->lesson_complexities();
                     $lesson_length = get_post_meta( $post_id, '_lesson_length', true );
                     $lesson_complexity = get_post_meta( $post_id, '_lesson_complexity', true );
                     if ( '' != $lesson_complexity ) { $lesson_complexity = $complexity_array[$lesson_complexity]; }

--- a/templates/single-course/course-lessons.php
+++ b/templates/single-course/course-lessons.php
@@ -16,7 +16,7 @@ global $post, $woothemes_sensei, $current_user;
 $html = '';
 // Get Course Lessons
 $lessons_completed = 0;
-$course_lessons = $woothemes_sensei->frontend->course->course_lessons( $post->ID );
+$course_lessons = $woothemes_sensei->post_types->course->course_lessons( $post->ID );
 $total_lessons = count( $course_lessons );
 // Check if the user is taking the course
 
@@ -60,7 +60,7 @@ if ( 0 < $total_lessons ) {
 			} // End If Statement
 
     	    // Get Lesson data
-    	    $complexity_array = $woothemes_sensei->frontend->lesson->lesson_complexities();
+    	    $complexity_array = $woothemes_sensei->post_types->lesson->lesson_complexities();
     	    $lesson_length = get_post_meta( $lesson_item->ID, '_lesson_length', true );
     	    $lesson_complexity = get_post_meta( $lesson_item->ID, '_lesson_complexity', true );
     	    if ( '' != $lesson_complexity ) { $lesson_complexity = $complexity_array[$lesson_complexity]; }


### PR DESCRIPTION
...PostTypes, add graceful fallback. Fixes #747 for me and should work towards #548 (unless sensei->post_types is getting dropped). 

Can't use $woothemes_sensei global within the __construct of Frontend (e.g. `$this->course = $woothemes->post_types->course;`) as it doesn't exist at that point! Thus the fallback uses magic __get() on the Frontend to pass the object through so it won't break anything. 
