### PR TITLE
Shift frontend->sensei_completed_course() logic to Course object. 

### DIFF
--- a/classes/class-woothemes-sensei-course.php
+++ b/classes/class-woothemes-sensei-course.php
@@ -56,7 +56,43 @@ class WooThemes_Sensei_Course {
 			$this->my_courses_page = false;
 		} // End If Statement
 
+		// Update course completion upon completion of a lesson
+		add_action( 'sensei_user_lesson_end', array( $this, 'update_status_after_lesson_change' ), 10, 2 );
+		// Update course completion upon reset of a lesson
+		add_action( 'sensei_user_lesson_reset', array( $this, 'update_status_after_lesson_change' ), 10, 2 );
+		// Update course completion upon grading of a quiz
+		add_action( 'sensei_user_quiz_grade', array( $this, 'update_status_after_quiz_submission' ), 10, 2 );
+
 	} // End __construct()
+
+	/**
+	 * Fires when a quiz has been graded to check if the Course status needs changing
+	 * 
+	 * @param type $user_id
+	 * @param type $quiz_id
+	 */
+	public function update_status_after_quiz_submission( $user_id, $quiz_id ) {
+		if ( intval( $user_id ) > 0 && intval( $quiz_id ) > 0 ) {
+			$lesson_id = get_post_meta( $quiz_id, '_quiz_lesson', true );
+			$this->update_status_after_lesson_change( $user_id, $lesson_id );
+		}
+	}
+
+	/**
+	 * Fires when a lesson has changed to check if the Course status needs changing
+	 * 
+	 * @param int $user_id
+	 * @param int $lesson_id
+	 */
+	public function update_status_after_lesson_change( $user_id, $lesson_id ) {
+		if ( intval( $user_id ) > 0 && intval( $lesson_id ) > 0 ) {
+			$course_id = get_post_meta( $lesson_id, '_lesson_course', true );
+			if ( intval( $course_id ) > 0 ) { 
+				// Updates the Course status and it's meta data
+				WooThemes_Sensei_Utils::user_complete_course( $course_id, $user_id );
+			}
+		}
+	}
 
 	/**
 	 * meta_box_setup function.

--- a/classes/class-woothemes-sensei-learners.php
+++ b/classes/class-woothemes-sensei-learners.php
@@ -296,13 +296,12 @@ class WooThemes_Sensei_Learners {
 
 				case 'course':
 					$removed = WooThemes_Sensei_Utils::sensei_remove_user_from_course( $post_id, $user_id );
+					do_action( 'sensei_user_course_reset', $user_id, $post_id );
 				break;
 
 				case 'lesson':
 					$removed = WooThemes_Sensei_Utils::sensei_remove_user_from_lesson( $post_id, $user_id );
-					$course_id = get_post_meta( $post_id, '_lesson_course', true );
-					// Updates the Course status and it's meta data
-					WooThemes_Sensei_Utils::user_complete_course( $course_id, $user_id );
+					do_action( 'sensei_user_lesson_reset', $user_id, $post_id );
 				break;
 
 			}

--- a/classes/class-woothemes-sensei-utils.php
+++ b/classes/class-woothemes-sensei-utils.php
@@ -632,18 +632,6 @@ class WooThemes_Sensei_Utils {
 
 			$quiz_passmark = absint( get_post_meta( $quiz_id, '_quiz_passmark', true ) );
 
-			if( $quiz_passmark ) {
-				if( $grade >= $quiz_passmark ) {
-					$status = 'passed';
-				} else {
-					$status = 'failed';
-				}
-			} else {
-				$status = 'graded';
-			}
-
-			WooThemes_Sensei_Utils::update_lesson_status( $user_id, $lesson_id, $status );
-
 			do_action( 'sensei_user_quiz_grade', $user_id, $quiz_id, $grade, $quiz_passmark, $quiz_grade_type );
 		}
 
@@ -1812,15 +1800,6 @@ class WooThemes_Sensei_Utils {
 			}
 
 			do_action( 'sensei_lesson_status_updated', $status, $user_id, $lesson_id, $comment_id );
-
-			if( in_array( $status, array( 'complete', 'passed' ) ) ) {
-
-				$course_id = get_post_meta( $lesson_id, '_lesson_course', true );
-
-				WooThemes_Sensei_Utils::user_complete_course( $course_id, $user_id );
-
-				do_action( 'sensei_user_lesson_end', $user_id, $lesson_id );
-			}
 		}
 		return $comment_id;
 	}


### PR DESCRIPTION
Fixes #759, fixes #747, changes #707

Notes on changes:
- Logic within Utils::sensei_grade_quiz() which directly updated lesson_status has been removed (stops duplication)
- Logic within Utils::update_lesson_status() which directly called user_complete_course() and called 'sensei_user_lesson_end' has been removed, it will only update the lesson status (again stops duplication)
- Frontend->sensei_complete_quiz() no longer directly calls update_course_status()
- Frontend->sensei_complete_lesson() no longer directly calls update_course_status()
- Logic from Frontend->sensei_completed_course() has been shifted to the Course post type object, taking inspiration from the direction the Quiz post type object will be going. 
- Actions are added within the Learner management when removing a user from a Lesson (and a Course)
- New Course checks are actioned after every lesson end, lesson reset and quiz grading.
- Grading->process_grading() has had to duplicate some logic from Frontend->sensei_complete_quiz() to ensure lesson status and actions are correctly triggered. This logic I would move to the Quiz post type object in the future (an aspect of #618 i'd say).
