### PR TITLE
Ensure limit is non-empty and greater than or equal to 1 before using to...

### DIFF
--- a/widgets/widget-woothemes-sensei-course-component.php
+++ b/widgets/widget-woothemes-sensei-course-component.php
@@ -209,7 +209,7 @@ class WooThemes_Sensei_Course_Component_Widget extends WP_Widget {
 		$posts_array = array();
 
 		// course_query() is buggy, it doesn't honour the 1st arg if includes are provided, so instead slice the includes
-		if ( intval( $instance['limit'] ) < count($course_ids) ) {
+		if ( !empty($instance['limit']) && intval( $instance['limit'] ) >= 1 && intval( $instance['limit'] ) < count($course_ids) ) {
 			$course_ids = array_slice( $course_ids, 0, intval( $instance['limit'] ) ); // This does mean the order by is effectively ignored
 		}
 		if ( ! empty( $course_ids ) ) {


### PR DESCRIPTION
... slice. Fixes #694 with empty active/completed Courses due to empty limit in widget options
