### PR TITLE
LM courses now link to LM itself, not Edit Courses

### DIFF
--- a/includes/class-woothemes-sensei-learners-main.php
+++ b/includes/class-woothemes-sensei-learners-main.php
@@ -333,7 +333,7 @@ class WooThemes_Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 				}
 
 				$column_data = apply_filters( 'sensei_learners_main_column_data', array(
-						'title' => '<strong><a class="row-title" href="' . esc_url( add_query_arg( array( 'page' => 'sensei_learners', 'course_id' => $item->ID, 'view' => 'learners' ), admin_url( 'admin.php?') ) )  . '" title="' . esc_attr( $a_title ) . '">' . $title . '</a></strong>',
+						'title' => '<strong><a class="row-title" href="' . esc_url( add_query_arg( array( 'page' => 'sensei_learners', 'course_id' => $item->ID, 'view' => 'learners' ), admin_url( 'admin.php') ) )  . '" title="' . esc_attr( $a_title ) . '">' . $title . '</a></strong>',
 						'num_learners' => $course_learners,
 						'updated' => $item->post_modified,
 						'actions' => '<a class="button" href="' . esc_url( add_query_arg( array( 'page' => $this->page_slug, 'course_id' => $item->ID, 'view' => 'learners' ), admin_url( 'admin.php' ) ) ) . '">' . __( 'Manage learners', 'woothemes-sensei' ) . '</a> ' . $grading_action,

--- a/includes/class-woothemes-sensei-learners-main.php
+++ b/includes/class-woothemes-sensei-learners-main.php
@@ -333,7 +333,7 @@ class WooThemes_Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 				}
 
 				$column_data = apply_filters( 'sensei_learners_main_column_data', array(
-						'title' => '<strong><a class="row-title" href="' . admin_url( 'post.php?action=edit&post=' . $item->ID ) . '" title="' . esc_attr( $a_title ) . '">' . $title . '</a></strong>',
+						'title' => '<strong><a class="row-title" href="' . esc_url( add_query_arg( array( 'page' => 'sensei_learners', 'course_id' => $item->ID, 'view' => 'learners' ), admin_url( 'admin.php?') ) )  . '" title="' . esc_attr( $a_title ) . '">' . $title . '</a></strong>',
 						'num_learners' => $course_learners,
 						'updated' => $item->post_modified,
 						'actions' => '<a class="button" href="' . esc_url( add_query_arg( array( 'page' => $this->page_slug, 'course_id' => $item->ID, 'view' => 'learners' ), admin_url( 'admin.php' ) ) ) . '">' . __( 'Manage learners', 'woothemes-sensei' ) . '</a> ' . $grading_action,


### PR DESCRIPTION
Fixes #916 

> I think there must be a subscript for editing like in the normal all courses:
manage learners || edit course

I didn't create two links like this in the `title` column, because we already have a `Manage Learners` button for each row in the `actions` column. 

If we want to link to Edit Course screen from here, maybe we can add an `Edit Content` button next to the existing buttons?