### PR TITLE
Add missing search-button-text filter

### DIFF
--- a/includes/class-sensei-list-table.php
+++ b/includes/class-sensei-list-table.php
@@ -117,7 +117,7 @@ class Sensei_List_Table extends WP_List_Table {
 				}
 			}
 			?>
-			<?php $this->search_box( __( 'Search Users' ,'woothemes-sensei' ), 'search_id'); ?>
+			<?php $this->search_box( apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users' ,'woothemes-sensei' ) ), 'search_id' ); ?>
 		</form><?php
 	} // End table_search_form()
 


### PR DESCRIPTION
Not sure when this filter went missing, but it was still there back in 1.7.3, and it's still referred to in five different files.

edit by @dwainm: 
Fixes  #1302