### PR TITLE
Fix order status search criteria to wc-completed instead of wc-complete

### DIFF
--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -1764,7 +1764,7 @@ Class Sensei_WC{
 			'post_type' => 'shop_order',
 			'meta_key'    => '_customer_user',
 			'meta_value'  => intval( $user_id ),
-			'post_status' => array('wc-complete', 'wc-processing'),
+			'post_status' => array('wc-completed', 'wc-processing'),
 		);
 
 		// possibly change the product type


### PR DESCRIPTION
This PR is to fix **get_user_product_orders** static method located in **includes/class-sensei-wc.php** that search for user orders by order status with wrong value , **Woocommerce** completed status is **wc-completed** not **wc-complete**