### PR TITLE
Fix an issue with is_course_purchasable() for courses that aren't associated with products

### DIFF
--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -1797,7 +1797,13 @@ Class Sensei_WC{
 		if( ! self::is_woocommerce_active() ){
 			return false;
 		}
-		$course_product = wc_get_product( self::get_course_product_id( $course_id ) );
+
+		$course_product_id = self::get_course_product_id( $course_id );
+
+		if ( ! $course_product_id )
+			return false;
+
+		$course_product = wc_get_product( $course_product_id );
 
 		return $course_product->is_purchasable();
 


### PR DESCRIPTION
This fixes an issue with viewing courses that the user has not yet started which are not associated with any products.

Background: in the current version of WooCommerce, `wc_get_product()` will return an object for the specified post even if it isn't actually a product post. If `Sensei_WC::get_course_product_id` returns `false`, then `Sensei_WC::is_course_purchasable()` will pass `false` to `wc_get_product()`, making it return the current course wrapped in a `WC_Product_Simple` object. It then calls `is_purchasable()` on the "product" (which is actually a course) returned by `wc_get_product()`.

I've submitted a pull request to fix the behavior in `wc_get_product()` (woothemes/woocommerce#10629), but when that function returns `false` then a fatal error will be thrown when `is_course_purchasable` attempts to call `is_purchasable()` on `false`.

This commit fixes the behavior in both the current version of WooCommerce and after my proposed change. If `get_course_product_id` returns false, then it will no longer even attempt to retrieve a WooCommerce product object or check whether it is purchasable.