### PR TITLE
Allow shortcodes in course/lesson video embed codes

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2915,7 +2915,7 @@ class Sensei_Course {
         if ( '' != $course_video_embed ) { ?>
 
             <div class="course-video">
-                <?php echo html_entity_decode($course_video_embed); ?>
+                <?php echo do_shortcode( html_entity_decode( $course_video_embed ) ); ?>
             </div>
 
         <?php } // End If Statement

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -878,7 +878,7 @@ class Sensei_Frontend {
         		$lesson_video_embed = wp_oembed_get( esc_url( $lesson_video_embed )/*, array( 'width' => 100 , 'height' => 100)*/ );
         	} // End If Statement
         	if ( '' != $lesson_video_embed ) {
-        	?><div class="video"><?php echo html_entity_decode($lesson_video_embed); ?></div><?php
+        	?><div class="video"><?php echo do_shortcode( html_entity_decode( $lesson_video_embed ) ); ?></div><?php
         	} // End If Statement
         } // End If Statement
 	} // End sensei_lesson_video()


### PR DESCRIPTION
Some video services (e.g., [Ooyala](https://wordpress.org/plugins/ooyala-video-browser/)) have plugins that provide shortcodes to make embedding videos easier.

This change enables shortcode parsing for the content of course and lesson video embed codes. This makes it so a user can paste something like `[ooyala code="xxxxx"]` into the video embed code box and have it parsed properly.