### PR TITLE
Hide the lesson video when the user can't view the lesson

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -871,7 +871,7 @@ class Sensei_Frontend {
 	} // End sensei_frontend_messages()
 
 	public function sensei_lesson_video( $post_id = 0 ) {
-		if ( 0 < intval( $post_id ) ) {
+		if ( 0 < intval( $post_id ) && sensei_can_user_view_lesson( $post_id ) ) {
 			$lesson_video_embed = get_post_meta( $post_id, '_lesson_video_embed', true );
 			if ( 'http' == substr( $lesson_video_embed, 0, 4) ) {
         		// V2 - make width and height a setting for video embed


### PR DESCRIPTION
When the `sensei_video_position` filter returns "bottom", the `sensei_can_user_view_lesson()` check is skipped and the video is displayed even when the user is logged out or when they haven't started taking the course.

When `sensei_video_position` returns the default value of "top", [single-lesson.php](https://github.com/Automattic/sensei/blob/master/templates/single-lesson.php#L42) correctly checks `sensei_can_user_view_lesson()` before outputting the video. This change makes the behavior when `sensei_video_position` returns "bottom" match the behavior when it returns "top".

(Note that all of this only applies when the "Users must be logged in to view Course and Lesson content" option is enabled.)