### PR TITLE
Hide the course video when the user can't view the course

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2877,6 +2877,11 @@ class Sensei_Course {
 	    if ( ! is_singular( 'course' )  ) {
 		    return;
 	    }
+
+		if ( ! sensei_can_user_view_course() ) {
+			return;
+		}
+
         // Get the meta info
         $course_video_embed = get_post_meta( $post->ID, '_course_video_embed', true );
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2536,33 +2536,7 @@ class Sensei_Course {
 
         }
 
-        // Content Access Permissions
-        $access_permission = false;
-
-        if ( ! Sensei()->settings->get('access_permission')  || sensei_all_access() ) {
-
-            $access_permission = true;
-
-        } // End If Statement
-
-        // Check if the user is taking the course
-        $is_user_taking_course = Sensei_Utils::user_started_course( get_the_ID(), get_current_user_id() );
-
-        if(Sensei_WC::is_woocommerce_active()) {
-
-            $wc_post_id = get_post_meta( get_the_ID(), '_course_woocommerce_product', true );
-            $product = Sensei()->sensei_get_woocommerce_product_object( $wc_post_id );
-
-            $has_product_attached = isset ( $product ) && is_object ( $product );
-
-        } else {
-
-            $has_product_attached = false;
-
-        }
-
-        if ( ( is_user_logged_in() && $is_user_taking_course )
-            || ( $access_permission && !$has_product_attached)
+        if ( sensei_can_user_view_course()
             || 'full' == Sensei()->settings->get( 'course_single_content_display' ) ) {
 
 	        // compensate for core providing and empty $content

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -359,6 +359,68 @@ if ( ! defined( 'ABSPATH' ) ){ exit; } // Exit if accessed directly
 	} // End sensei_has_user_completed_lesson()
 
 /**
+ * Determine whether a user can view a course.
+ *
+ * @since x.x.x
+ *
+ * @param int $course_id
+ * @param int $user_id
+ * @return bool
+ */
+function sensei_can_user_view_course( $course_id = 0, $user_id = 0 )
+{
+	if( empty( $course_id ) ){
+
+		$course_id = get_the_ID();
+
+	}
+
+    if( empty( $user_id ) ){
+
+        $user_id = get_current_user_id();
+
+    }
+
+	// Content Access Permissions
+	$access_permission = false;
+
+	if ( ! Sensei()->settings->get('access_permission')  || sensei_all_access() ) {
+
+		$access_permission = true;
+
+	} // End If Statement
+
+	// Check if the user is taking the course
+	$is_user_taking_course = Sensei_Utils::user_started_course( $course_id, $user_id );
+
+	if ( Sensei_WC::is_woocommerce_active() ) {
+
+		$wc_post_id = get_post_meta( $course_id, '_course_woocommerce_product', true );
+		$product = Sensei()->sensei_get_woocommerce_product_object( $wc_post_id );
+
+		$has_product_attached = isset ( $product ) && is_object ( $product );
+
+	} else {
+
+		$has_product_attached = false;
+
+	}
+
+	$can_user_view_course = ( ( is_user_logged_in() && $is_user_taking_course ) || ( $access_permission && ! $has_product_attached ) );
+
+    /**
+     * Filter the can user view course function
+     *
+     * @since x.x.x
+     *
+     * @param bool $can_user_view_course
+     * @param string $course_id
+     * @param string $user_id
+     */
+    return apply_filters( 'sensei_can_user_view_course', $can_user_view_course, $course_id, $user_id );
+}
+
+/**
  * Determine if a user has completed the pre-requisite lesson.
  *
  * @uses


### PR DESCRIPTION
This is similar to issue #1405. When the user is logged out or hasn't started the course, they can still view the course video (even though they can't view the rest of the course content).

I noticed there wasn't a course equivalent of `sensei_can_user_view_lesson()`, so I moved the code that determined whether the user should be able to view the course content from `Sensei_Course::single_course_content` into a new `sensei_can_user_view_course()` function. Then I updated `Sensei_Course::the_course_video` to call that function before outputting the course video.

The course content display behavior should remain exactly the same after these changes, but the video will now be hidden when the user doesn't have access to the course.