### PR TITLE
Fix the "start taking this course" button when generated from a different page

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -113,7 +113,7 @@ if ( ! defined( 'ABSPATH' ) ){ exit; } // Exit if accessed directly
 		$prerequisite_complete = sensei_check_prerequisite_course( $course_id );
 
 		if ( $prerequisite_complete ) {
-		?><form method="POST" action="<?php echo esc_url( get_permalink() ); ?>">
+		?><form method="POST" action="<?php echo esc_url( get_permalink( $course_id ) ); ?>">
 
     			<input type="hidden" name="<?php echo esc_attr( 'woothemes_sensei_start_course_noonce' ); ?>" id="<?php echo esc_attr( 'woothemes_sensei_start_course_noonce' ); ?>" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_start_course_noonce' ) ); ?>" />
 


### PR DESCRIPTION
This change makes the form action URL point to the specified course's permalink rather than the current post's permalink.

Currently, if you call `sensei_start_course_form(1234)` from a page other than the course page itself, the form action will be the current post's permalink, and the "start taking this course" button will not work.