### PR TITLE
Add new function to get a module ID, and use it in module hooks.

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -662,6 +662,41 @@ function sensei_the_module_status(){
 
 }
 
+/**
+ * Get the module ID.
+ * This must be used within the Sensei module loop.
+ *
+ * @since 1.9.6
+ *
+ * @return int $id Module ID.
+ */
+function sensei_get_the_module_id() {
+	global $sensei_modules_loop;
+
+	$module_term_id = $sensei_modules_loop['current_module']->term_id;
+
+	/**
+	 * Filter the module ID.
+	 *
+	 * This fires within the sensei_get_the_module_id function.
+	 *
+	 * @since 1.9.6
+	 *
+	 * @param int $module_term_id Module ID.
+	 */
+	return apply_filters( 'sensei_the_module_id', $module_term_id );
+}
+
+/**
+ * Print out the current module ID
+ * @since 1.9.6
+ */
+function sensei_the_module_id(){
+
+	echo sensei_get_the_module_id();
+
+}
+
 /************************
  *
  * Single Quiz Functions

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -666,7 +666,7 @@ function sensei_the_module_status(){
  * Get the module ID.
  * This must be used within the Sensei module loop.
  *
- * @since 1.9.6
+ * @since 1.9.7
  *
  * @return int $id Module ID.
  */
@@ -680,7 +680,7 @@ function sensei_get_the_module_id() {
 	 *
 	 * This fires within the sensei_get_the_module_id function.
 	 *
-	 * @since 1.9.6
+	 * @since 1.9.7
 	 *
 	 * @param int $module_term_id Module ID.
 	 */
@@ -689,7 +689,7 @@ function sensei_get_the_module_id() {
 
 /**
  * Print out the current module ID
- * @since 1.9.6
+ * @since 1.9.7
  */
 function sensei_the_module_id(){
 

--- a/templates/single-course/modules.php
+++ b/templates/single-course/modules.php
@@ -46,10 +46,13 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                  * are no modules to show.
                  *
                  * @since 1.9.0
+                 * @since 1.9.6 Added the module ID to the parameters.
                  *
                  * @hooked Sensei()->modules->course_modules_title - 20
+                 *
+                 * @param int sensei_get_the_module_id() Module ID.
                  */
-                do_action('sensei_single_course_modules_inside_before');
+                do_action( 'sensei_single_course_modules_inside_before', sensei_get_the_module_id() );
 
                 ?>
 
@@ -118,9 +121,11 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                  * This hook will not trigger if there are no modules to show.
                  *
                  * @since 1.9.0
+                 * @since 1.9.6 Added the module ID to the parameters.
                  *
+                 * @param int sensei_get_the_module_id() Module ID.
                  */
-                do_action('sensei_single_course_modules_inside_after');
+                do_action( 'sensei_single_course_modules_inside_after', sensei_get_the_module_id() );
 
                 ?>
 

--- a/templates/single-course/modules.php
+++ b/templates/single-course/modules.php
@@ -46,7 +46,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                  * are no modules to show.
                  *
                  * @since 1.9.0
-                 * @since 1.9.6 Added the module ID to the parameters.
+                 * @since 1.9.7 Added the module ID to the parameters.
                  *
                  * @hooked Sensei()->modules->course_modules_title - 20
                  *
@@ -121,7 +121,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                  * This hook will not trigger if there are no modules to show.
                  *
                  * @since 1.9.0
-                 * @since 1.9.6 Added the module ID to the parameters.
+                 * @since 1.9.7 Added the module ID to the parameters.
                  *
                  * @param int sensei_get_the_module_id() Module ID.
                  */


### PR DESCRIPTION
- `sensei_get_the_module_id()` and `sensei_the_module_id()` can be used when wanting to build a custom module list.
- Adding the module ID to the 2 actions used in the module template allow third-parties to add specific elements to the module list, like a thumbnail for each module, like so:

```php
function jeherve_add_image_module( $module_id ) {
	if ( 28 == $module_id ) {
		printf(
			'<div class="module-thumbnail"><img src="%s" /></div>',
			esc_url( 'http://f.cl.ly/items/3z0o2k2F3w0D0p0k1Y35/cool.gif' )
		);
	} else {
		echo 'nothing';
	}
}
add_action( 'sensei_single_course_modules_inside_before', 'jeherve_add_image_module' );
```