### PR TITLE
i18n Audit

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,15 +9,16 @@
  * 3) Run gulp to mifiy javascript and css using the 'gulp' command.
  */
 
-var gulp      = require( 'gulp' );
-var rename    = require( 'gulp-rename' );
-var uglify    = require( 'gulp-uglify' );
-var minifyCSS = require( 'gulp-minify-css' );
-var chmod     = require( 'gulp-chmod' );
-var del       = require( 'del' );
-var sass      = require( 'gulp-sass' );
-var wpPot     = require( 'gulp-wp-pot' );
-var sort      = require( 'gulp-sort' );
+var gulp            = require( 'gulp' );
+var rename          = require( 'gulp-rename' );
+var uglify          = require( 'gulp-uglify' );
+var minifyCSS       = require( 'gulp-minify-css' );
+var chmod           = require( 'gulp-chmod' );
+var del             = require( 'del' );
+var sass            = require( 'gulp-sass' );
+var wpPot           = require( 'gulp-wp-pot' );
+var sort            = require( 'gulp-sort' );
+var checktextdomain = require( 'gulp-checktextdomain' );
 
 var paths = {
 	scripts: ['assets/js/*.js' ],
@@ -70,4 +71,27 @@ gulp.task( 'pot', function() {
 			bugReport: 'https://www.transifex.com/woothemes/sensei-by-woothemes/'
 		}) )
 		.pipe( gulp.dest( 'lang' ) );
+});
+
+gulp.task ( 'textdomain' , function() {
+	return gulp.src( [ '**/*.php', '!node_modules/**'] )
+		.pipe( checktextdomain({
+			text_domain: 'woothemes-sensei',
+			keywords: [
+				'__:1,2d',
+				'_e:1,2d',
+				'_x:1,2c,3d',
+				'esc_html__:1,2d',
+				'esc_html_e:1,2d',
+				'esc_html_x:1,2c,3d',
+				'esc_attr__:1,2d',
+				'esc_attr_e:1,2d',
+				'esc_attr_x:1,2c,3d',
+				'_ex:1,2c,3d',
+				'_n:1,2,4d',
+				'_nx:1,2,4c,5d',
+				'_n_noop:1,2,3d',
+				'_nx_noop:1,2,3c,4d'
+			]
+		}));
 });

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2979,7 +2979,7 @@ class Sensei_Course {
 
         if( ! empty($term) ){
 
-            $title = __('Category') . ' ' . $term->name;
+            $title = __( 'Category', 'woothemes-sensei' ) . ' ' . $term->name;
 
         }else{
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2012,7 +2012,7 @@ class Sensei_Course {
 
             <span class="course-author"><?php _e( 'by ', 'woothemes-sensei' ); ?>
 
-                <a href="<?php esc_attr_e( get_author_posts_url( $course->post_author ) ); ?>" title="<?php esc_attr_e( $author_display_name ); ?>"><?php esc_attr_e( $author_display_name   ); ?></a>
+                <a href="<?php echo esc_attr( get_author_posts_url( $course->post_author ) ); ?>" title="<?php echo esc_attr( $author_display_name ); ?>"><?php echo esc_attr( $author_display_name ); ?></a>
 
             </span>
 
@@ -2087,12 +2087,12 @@ class Sensei_Course {
                 <form method="POST" action="<?php  echo esc_url( remove_query_arg( array( 'active_page', 'completed_page' ) ) ); ?>">
 
                     <input type="hidden"
-                           name="<?php esc_attr_e( 'woothemes_sensei_complete_course_noonce' ) ?>"
-                           id="<?php  esc_attr_e( 'woothemes_sensei_complete_course_noonce' ); ?>"
-                           value="<?php esc_attr_e( wp_create_nonce( 'woothemes_sensei_complete_course_noonce' ) ); ?>"
+                           name="<?php echo esc_attr( 'woothemes_sensei_complete_course_noonce' ) ?>"
+                           id="<?php  echo esc_attr( 'woothemes_sensei_complete_course_noonce' ); ?>"
+                           value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_course_noonce' ) ); ?>"
                         />
 
-                    <input type="hidden" name="course_complete_id" id="course-complete-id" value="<?php esc_attr_e( intval( $course->ID ) ); ?>" />
+                    <input type="hidden" name="course_complete_id" id="course-complete-id" value="<?php echo esc_attr( intval( $course->ID ) ); ?>" />
 
                     <?php if ( 0 < absint( count( Sensei()->course->course_lessons( $course->ID ) ) )
                         && Sensei()->settings->settings['course_completion'] == 'complete'

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1084,17 +1084,17 @@ class Sensei_Frontend {
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_username"><?php _e( 'Username', 'woothemes-sensei' ); ?> <span class="required">*</span></label>
-							<input type="text" class="input-text" name="sensei_reg_username" id="sensei_reg_username" value="<?php if ( ! empty( $_POST['sensei_reg_username'] ) ) esc_attr_e( $_POST['sensei_reg_username'] ); ?>" />
+							<input type="text" class="input-text" name="sensei_reg_username" id="sensei_reg_username" value="<?php if ( ! empty( $_POST['sensei_reg_username'] ) ) echo esc_attr( $_POST['sensei_reg_username'] ); ?>" />
 						</p>
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_email"><?php _e( 'Email address', 'woothemes-sensei' ); ?> <span class="required">*</span></label>
-							<input type="email" class="input-text" name="sensei_reg_email" id="sensei_reg_email" value="<?php if ( ! empty( $_POST['sensei_reg_email'] ) ) esc_attr_e( $_POST['sensei_reg_email'] ); ?>" />
+							<input type="email" class="input-text" name="sensei_reg_email" id="sensei_reg_email" value="<?php if ( ! empty( $_POST['sensei_reg_email'] ) ) echo esc_attr( $_POST['sensei_reg_email'] ); ?>" />
 						</p>
 
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_password"><?php _e( 'Password', 'woothemes-sensei' ); ?> <span class="required">*</span></label>
-							<input type="password" class="input-text" name="sensei_reg_password" id="sensei_reg_password" value="<?php if ( ! empty( $_POST['sensei_reg_password'] ) ) esc_attr_e( $_POST['sensei_reg_password'] ); ?>" />
+							<input type="password" class="input-text" name="sensei_reg_password" id="sensei_reg_password" value="<?php if ( ! empty( $_POST['sensei_reg_password'] ) ) echo esc_attr( $_POST['sensei_reg_password'] ); ?>" />
 						</p>
 
 						<!-- Spam Trap -->

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1692,7 +1692,7 @@ class Sensei_Frontend {
 		// Check the e-mail address
 		$email_error_notice = '';
 		if ( $new_user_email == '' ) {
-			$email_error_notice = __( '<strong>ERROR</strong>: Please type your e-mail address.' );
+			$email_error_notice = __( '<strong>ERROR</strong>: Please enter an email address.' );
 		} elseif ( ! is_email( $new_user_email ) ) {
 			$email_error_notice = __( '<strong>ERROR</strong>: The email address isn&#8217;t correct.' );
 		} elseif ( email_exists( $new_user_email ) ) {
@@ -1709,14 +1709,14 @@ class Sensei_Frontend {
 
 		// exit on email address error
 		if( empty( $new_user_password ) ){
-			Sensei()->notices->add_notice(  __( '<strong>ERROR</strong>: The password field may not be empty, please enter a secure password.' )  , 'alert');
+			Sensei()->notices->add_notice(  __( '<strong>ERROR</strong>: The password field is empty.' )  , 'alert');
 			return;
 		}
 
 		// register user
 		$user_id = wp_create_user( $new_user_name, $new_user_password, $new_user_email );
 		if ( ! $user_id || is_wp_error( $user_id ) ) {
-			Sensei()->notices->add_notice( sprintf( __( '<strong>ERROR</strong>: Couldn\'t register you&hellip; please contact the <a href="mailto:%s">webmaster</a> !' ), get_option( 'admin_email' ) ), 'alert');
+			Sensei()->notices->add_notice( sprintf( __( '<strong>ERROR</strong>: Couldn&#8217;t register you&hellip; please contact the <a href="mailto:%s">webmaster</a> !' ), get_option( 'admin_email' ) ), 'alert');
 		}
 
 		// notify the user

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -56,10 +56,10 @@ class Sensei_Grading_User_Quiz {
         $lesson_id = $this->lesson_id;
         $user_id = $this->user_id;
 
-		?><form name="<?php esc_attr_e( 'quiz_' . $this->quiz_id ); ?>" action="" method="post">
+		?><form name="<?php echo esc_attr( 'quiz_' . $this->quiz_id ); ?>" action="" method="post">
 			<?php wp_nonce_field( 'sensei_manual_grading', '_wp_sensei_manual_grading_nonce' ); ?>
-			<input type="hidden" name="sensei_manual_grade" value="<?php esc_attr_e( $this->quiz_id ); ?>" />
-			<input type="hidden" name="sensei_grade_next_learner" value="<?php esc_attr_e( $this->user_id ); ?>" />
+			<input type="hidden" name="sensei_manual_grade" value="<?php echo esc_attr( $this->quiz_id ); ?>" />
+			<input type="hidden" name="sensei_grade_next_learner" value="<?php echo esc_attr( $this->user_id ); ?>" />
 			<div class="total_grade_display">
 				<span><?php esc_attr_e( __( 'Grade:', 'woothemes-sensei' ) ); ?></span>
 				<span class="total_grade_total"><?php echo $user_quiz_grade_total; ?></span> / <span class="quiz_grade_total"><?php echo $quiz_grade_total; ?></span> (<span class="total_grade_percent"><?php echo $quiz_grade; ?></span>%)
@@ -182,17 +182,17 @@ class Sensei_Grading_User_Quiz {
 				$user_question_grade = 0;
 			}
 
-			?><div class="postbox question_box <?php esc_attr_e( $type ); ?> <?php esc_attr_e( $grade_type ); ?> <?php esc_attr_e( $graded_class ); ?>" id="<?php esc_attr_e( 'question_' . $question_id . '_box' ); ?>">
+			?><div class="postbox question_box <?php echo esc_attr( $type ); ?> <?php echo esc_attr( $grade_type ); ?> <?php echo esc_attr( $graded_class ); ?>" id="<?php echo esc_attr( 'question_' . $question_id . '_box' ); ?>">
 				<div class="handlediv" title="Click to toggle"><br></div>
 				<h3 class="hndle"><span><?php echo $question_title; ?></span></h3>
 				<div class="inside">
 					<div class="sensei-grading-actions">
 						<div class="actions">
-							<input type="hidden" class="question_id" value="<?php esc_attr_e( $question_id ); ?>" />
+							<input type="hidden" class="question_id" value="<?php echo esc_attr( $question_id ); ?>" />
 							<input type="hidden" class="question_total_grade" name="question_total_grade" value="<?php echo esc_attr( $question_grade_total ); ?>" />
-							<span class="grading-mark icon_right"><input type="radio" class="<?php esc_attr_e( 'question_' . $question_id . '_right_option' ); ?>" name="<?php esc_attr_e( 'question_' . $question_id ); ?>" value="right" <?php checked( $graded_class, 'user_right', true ); ?> /></span>
-							<span class="grading-mark icon_wrong"><input type="radio" class="<?php esc_attr_e( 'question_' . $question_id . '_wrong_option' ); ?>" name="<?php esc_attr_e( 'question_' . $question_id ); ?>" value="wrong" <?php checked( $graded_class, 'user_wrong', true ); ?> /></span>
-							<input type="number" class="question-grade" name="<?php esc_attr_e( 'question_' . $question_id . '_grade' ); ?>" id="<?php esc_attr_e( 'question_' . $question_id . '_grade' ); ?>" value="<?php echo esc_attr( $user_question_grade ); ?>" min="0" max="<?php echo esc_attr( $question_grade_total ); ?>" />
+							<span class="grading-mark icon_right"><input type="radio" class="<?php echo esc_attr( 'question_' . $question_id . '_right_option' ); ?>" name="<?php echo esc_attr( 'question_' . $question_id ); ?>" value="right" <?php checked( $graded_class, 'user_right', true ); ?> /></span>
+							<span class="grading-mark icon_wrong"><input type="radio" class="<?php echo esc_attr( 'question_' . $question_id . '_wrong_option' ); ?>" name="<?php echo esc_attr( 'question_' . $question_id ); ?>" value="wrong" <?php checked( $graded_class, 'user_wrong', true ); ?> /></span>
+							<input type="number" class="question-grade" name="<?php echo esc_attr( 'question_' . $question_id . '_grade' ); ?>" id="<?php echo esc_attr( 'question_' . $question_id . '_grade' ); ?>" value="<?php echo esc_attr( $user_question_grade ); ?>" min="0" max="<?php echo esc_attr( $question_grade_total ); ?>" />
 							<span class="question-grade-total"><?php echo $question_grade_total; ?></span>
 						</div>
 					</div>
@@ -223,7 +223,7 @@ class Sensei_Grading_User_Quiz {
 						</div>
 						<div class="answer-notes">
 							<h5><?php _e( 'Grading Notes', 'woothemes-sensei' ) ?></h5>
-							<textarea class="correct-answer" name="questions_feedback[<?php esc_attr_e( $question_id ); ?>]" placeholder="<?php _e( 'Add notes here...', 'woothemes-sensei' ) ?>"><?php echo $question_answer_notes; ?></textarea>
+							<textarea class="correct-answer" name="questions_feedback[<?php echo esc_attr( $question_id ); ?>]" placeholder="<?php _e( 'Add notes here...', 'woothemes-sensei' ) ?>"><?php echo $question_answer_notes; ?></textarea>
 						</div>
 					</div>
 				</div>
@@ -236,11 +236,11 @@ class Sensei_Grading_User_Quiz {
 			$all_graded = 'yes';
 		}
 
-		?>  <input type="hidden" name="total_grade" id="total_grade" value="<?php esc_attr_e( $user_quiz_grade_total ); ?>" />
-			<input type="hidden" name="total_questions" id="total_questions" value="<?php esc_attr_e( $count ); ?>" />
-			<input type="hidden" name="quiz_grade_total" id="quiz_grade_total" value="<?php esc_attr_e( $quiz_grade_total ); ?>" />
-			<input type="hidden" name="total_graded_questions" id="total_graded_questions" value="<?php esc_attr_e( $graded_count ); ?>" />
-			<input type="hidden" name="all_questions_graded" id="all_questions_graded" value="<?php esc_attr_e( $all_graded ); ?>" />
+		?>  <input type="hidden" name="total_grade" id="total_grade" value="<?php echo esc_attr( $user_quiz_grade_total ); ?>" />
+			<input type="hidden" name="total_questions" id="total_questions" value="<?php echo esc_attr( $count ); ?>" />
+			<input type="hidden" name="quiz_grade_total" id="quiz_grade_total" value="<?php echo esc_attr( $quiz_grade_total ); ?>" />
+			<input type="hidden" name="total_graded_questions" id="total_graded_questions" value="<?php echo esc_attr( $graded_count ); ?>" />
+			<input type="hidden" name="all_questions_graded" id="all_questions_graded" value="<?php echo esc_attr( $all_graded ); ?>" />
 			<div class="total_grade_display">
 				<span><?php esc_attr_e( __( 'Grade:', 'woothemes-sensei' ) ); ?></span>
 				<span class="total_grade_total"><?php echo $user_quiz_grade_total; ?></span> / <span class="quiz_grade_total"><?php echo $quiz_grade_total; ?></span> (<span class="total_grade_percent"><?php echo $quiz_grade; ?></span>%)

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3047,8 +3047,8 @@ class Sensei_Lesson {
                     //
                     $pass_required_options = array(
                         '-1' => $no_change_text,
-                         '0' => __('No','woothemes'),
-                         '1' => __('Yes','woothemes'),
+                         '0' => __( 'No', 'woothemes-sensei' ),
+                         '1' => __( 'Yes', 'woothemes-sensei' ),
                     );
 
                     $pass_required_select_attributes = array( 'name'=> 'pass_required',
@@ -3068,8 +3068,8 @@ class Sensei_Lesson {
                     //
                     $quiz_reset_select__options = array(
                         '-1' => $no_change_text,
-                        '0' => __('No','woothemes'),
-                        '1' => __('Yes','woothemes'),
+                        '0' => __( 'No', 'woothemes-sensei' ),
+                        '1' => __( 'Yes', 'woothemes-sensei' ),
                     );
                     $quiz_reset_name_id = 'sensei-edit-enable-quiz-reset';
                     $quiz_reset_select_attributes = array( 'name'=> 'enable_quiz_reset', 'id'=>$quiz_reset_name_id, 'class'=>' ' );

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3321,7 +3321,7 @@ class Sensei_Lesson {
         <header>
             <h2>
                 <a href="<?php echo esc_url_raw( get_permalink( $lesson_id ) ) ?>"
-                   title="<?php esc_attr_e( $heading_link_title ) ?>" >
+                   title="<?php echo esc_attr( $heading_link_title ) ?>" >
                     <?php echo $count_markup. get_the_title( $lesson_id ) . $preview_label; ?>
                 </a>
             </h2>

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -587,7 +587,7 @@ class Sensei_Question {
         ?>
 
             <input type="hidden" name="question_id_<?php $question_id;?>" value="<?php $question_id;?>" />
-            <input type="hidden" name="questions_asked[]" value="<?php esc_attr_e( $question_id ); ?>" />
+            <input type="hidden" name="questions_asked[]" value="<?php echo esc_attr( $question_id ); ?>" />
 
         <?php
     }
@@ -735,7 +735,7 @@ class Sensei_Question {
 		}
 
 		?>
-		<div class="answer_message <?php esc_attr_e( $answer_message_class ); ?>">
+		<div class="answer_message <?php echo esc_attr( $answer_message_class ); ?>">
 
 			<span><?php echo $answer_message; ?></span>
 

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -857,7 +857,7 @@ class Sensei_Question {
                 $upload_size_unit = (int) $upload_size_unit;
 
             }
-            $max_upload_size = sprintf( __( 'Maximum upload file size: %d%s' ), esc_html( $upload_size_unit ), esc_html( $sizes[ $u ] ) );
+            $max_upload_size = sprintf( __( 'Maximum upload file size: %d%s', 'woothemes-sensei' ), esc_html( $upload_size_unit ), esc_html( $sizes[ $u ] ) );
 
             // Assemble all the data needed by the file upload template
             $question_data[ 'answer_media_url' ]      = $answer_media_url;

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -140,7 +140,7 @@ class Sensei_Updates
 
                         wp_die(
                             '<h1>' . __( 'Cheatin&#8217; uh?' ) . '</h1>' .
-                            '<p>' . __( 'The nonce supplied in order to run this update function is invalid','woothemes-sensei') . '</p>',
+                            '<p>' . __( 'The nonce supplied in order to run this update function is invalid', 'woothemes-sensei' ) . '</p>',
                             403
                         );
 
@@ -189,7 +189,7 @@ class Sensei_Updates
 
                     wp_die(
                         '<h1>' . __( 'Cheatin&#8217; uh?' ) . '</h1>' .
-                        '<p>' . __( 'The nonce supplied in order to run this update function is invalid','woothemes-sensei') . '</p>',
+                        '<p>' . __( 'The nonce supplied in order to run this update function is invalid', 'woothemes-sensei' ) . '</p>',
                         403
                     );
 

--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -875,7 +875,7 @@ Class Sensei_WC{
 
 		if ( self::is_product_in_cart( $wc_product_id ) ) {
 
-			$cart_link = '<a href="' . wc_get_checkout_url() . '" title="' . __( 'Checkout','woocommerce' ) . '">' . __( 'checkout', 'woocommerce' ) . '</a>';
+			$cart_link = '<a href="' . wc_get_checkout_url() . '" title="' . __( 'Checkout', 'woocommerce' ) . '">' . __( 'checkout', 'woocommerce' ) . '</a>';
 
 			$message = sprintf( __( 'This course is already in your cart, please proceed to %1$s, to gain access.', 'woothemes-sensei' ), $cart_link );
 			?>

--- a/includes/shortcodes/class-sensei-shortcode-unpurchased-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-unpurchased-courses.php
@@ -131,7 +131,7 @@ class Sensei_Shortcode_Unpurchased_Courses implements Sensei_Shortcode_Interface
             $anchor_before = '<a href="' . esc_url( sensei_user_login_url() ) . '" >';
             $anchor_after = '</a>';
             $notice = sprintf(
-                __('You must be logged in to view the non-purchased courses. Click here to %slogin%s.'),
+                __('You must be logged in to view the non-purchased courses. Click here to %slogin%s.', 'woothemes-sensei' ),
                 $anchor_before,
                 $anchor_after
             );

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -210,7 +210,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
                 <?php _e( 'You have no active courses.', 'woothemes-sensei' ); ?>
 
-                <a href="<?php esc_attr_e( Sensei_Course::get_courses_page_url() ); ?>">
+                <a href="<?php echo esc_attr( Sensei_Course::get_courses_page_url() ); ?>">
 
                     <?php  _e( 'Start a Course!', 'woothemes-sensei' ); ?>
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -520,7 +520,7 @@ function sensei_module_has_lessons(){
  */
 function sensei_the_module_title_attribute(){
 
-	esc_attr_e( sensei_get_the_module_title() );
+	echo esc_attr( sensei_get_the_module_title() );
 
 }
 
@@ -759,7 +759,7 @@ function sensei_the_question_class(){
 
     }// end foreach
 
-    esc_attr_e( trim( $html_classes ) );
+    echo esc_attr( trim( $html_classes ) );
 
 }
 

--- a/package.json
+++ b/package.json
@@ -11,15 +11,17 @@
   "main": "gulpfile.js",
   "devDependencies": {
     "del": "^2.1.0",
+    "fs-extra": "*",
     "gulp": "^3.9.0",
+    "gulp-checktextdomain": "^1.0.2",
     "gulp-chmod": "^1.3.0",
     "gulp-minify-css": "^1.2.1",
     "gulp-rename": "^1.2.2",
+    "gulp-sass": "^2.1.0",
     "gulp-sort": "^1.1.1",
     "gulp-uglify": "^1.5.1",
     "gulp-wp-pot": "^1.1.1",
-    "orchestrator": "^0.3.7",
-    "gulp-sass": "^2.1.0"
+    "orchestrator": "^0.3.7"
   },
   "engines": {
     "node": ">=0.8.0",

--- a/templates/content-course.php
+++ b/templates/content-course.php
@@ -84,4 +84,4 @@ if ( ! defined( 'ABSPATH' ) ) exit;
     ?>
 
 
-</li> <!-- article .(<?php esc_attr_e( join( ' ', get_post_class( array( 'course', 'post' ) ) ) ); ?>  -->
+</li> <!-- article .(<?php echo esc_attr( join( ' ', get_post_class( array( 'course', 'post' ) ) ) ); ?>  -->

--- a/templates/content-lesson.php
+++ b/templates/content-lesson.php
@@ -78,4 +78,4 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
     </section> <!-- article .lesson-content -->
 
-</article> <!-- article .(<?php esc_attr_e( join( ' ', get_post_class( array( 'lesson', 'post' ) ) ) ); ?>  -->
+</article> <!-- article .(<?php echo esc_attr( join( ' ', get_post_class( array( 'lesson', 'post' ) ) ) ); ?>  -->

--- a/templates/content-message.php
+++ b/templates/content-message.php
@@ -77,4 +77,4 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
     </section> <!-- article .message-content -->
 
-</article> <!-- article .(<?php esc_attr_e( join( ' ', get_post_class( array( 'sensei_message', 'post' ) ) ) ); ?>  -->
+</article> <!-- article .(<?php echo sc_attr( join( ' ', get_post_class( array( 'sensei_message', 'post' ) ) ) ); ?>  -->

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -31,7 +31,7 @@ global $course;
 
     </header>
 
-    <article class="<?php  esc_attr_e( join( ' ', get_post_class( array( 'course', 'post' ), $course->ID ) ) ); ?> ">
+    <article class="<?php echo esc_attr( join( ' ', get_post_class( array( 'course', 'post' ), $course->ID ) ) ); ?> ">
 
         <?php
 
@@ -73,7 +73,7 @@ global $course;
                         <a href="<?php echo esc_url_raw( get_permalink( $lesson->ID ) ); ?>"
                            title="<?php echo esc_attr_e( sprintf( __( 'Start %s', 'woothemes-sensei' ), $lesson->post_title ) ); ?>">
 
-                            <?php esc_html_e( $lesson->post_title ); ?>
+                            <?php echo esc_html( $lesson->post_title ); ?>
 
                         </a>
 

--- a/templates/single-quiz/question_type-boolean.php
+++ b/templates/single-quiz/question_type-boolean.php
@@ -64,7 +64,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 
     ?>
 
-    <li class="<?php esc_attr_e( $answer_class ); ?>">
+    <li class="<?php echo esc_attr( $answer_class ); ?>">
 
         <input type="radio"
                id="<?php echo esc_attr( 'question_' . $question_data[ 'ID' ]  ) . '-option-'. $option_value; ?>"

--- a/templates/single-quiz/question_type-multiple-choice.php
+++ b/templates/single-quiz/question_type-multiple-choice.php
@@ -30,7 +30,7 @@ foreach( $question_data[ 'answer_options' ] as $id => $option ) {
 
     ?>
 
-    <li class="<?php esc_attr_e( $option[ 'option_class' ] ); ?>">
+    <li class="<?php echo esc_attr( $option[ 'option_class' ] ); ?>">
         <input type="<?php echo $option[ 'type' ]; ?>"
                id="<?php echo esc_attr( 'question_' . $question_data['ID'] ) . '-option-' . $count; ?>"
                name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>[]"


### PR DESCRIPTION
After an user report of a missing text domain, I audited the rest of the core plugin. This PR includes

* Added gulp `checktextdomain` module. Usage: `gulp textdomain` after a `npm install`.
* Updated various instances of `esc_attr_e` seemingly being used instead of `echo esc_attr`.
* Added `woothemes-sensei` in a few places that were missing/incorrect.
* When using strings from Core, there were a couple of instances that Core changed the string. Updated.
* A couple minor whitespace updates while I was poking around.