### PR TITLE
Allow empty answers when saving a quiz

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -134,6 +134,13 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
         global $post;
         $lesson_id = $this->get_lesson_id( $post->ID );
         $quiz_answers = $_POST[ 'sensei_question' ];
+
+        // Get question keys
+		$quiz_questions = array_fill_keys( wp_list_pluck( $lesson_quiz_questions, 'ID' ), null);
+
+		// Merge user answers and question ids with no value
+		$quiz_answers = $quiz_answers + $quiz_questions;
+
         // call the save function
         self::save_user_answers( $quiz_answers, $_FILES , $lesson_id  , get_current_user_id() );
 


### PR DESCRIPTION
If user saves a quiz that contains (for example multiple choice) question with no answer, unanswered questions aren't saved to the database.

When user returns to the quiz, only questions that already have the answer are shown and other have been disappeared.

This commit fixes the issue by merging user answers with question keys before quiz is saved to the database.