### PR TITLE
Grade also unanswered questions

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -318,6 +318,13 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
         global $post, $current_user;
         $lesson_id = $this->get_lesson_id( $post->ID );
         $quiz_answers = $_POST[ 'sensei_question' ];
+        $lesson_quiz_questions = Sensei()->lesson->lesson_quiz_questions( $post->ID );
+
+        // Get question keys
+        $quiz_questions = array_fill_keys( wp_list_pluck( $lesson_quiz_questions, 'ID' ), null);
+
+        // Merge user answers and question ids with no value
+        $quiz_answers = $quiz_answers + $quiz_questions;
 
         self::submit_answers_for_grading( $quiz_answers, $_FILES ,  $lesson_id  , $current_user->ID );
 


### PR DESCRIPTION
Problem description: if a quiz contains three multiple choice questions and user answers only two of them, unanswered question will not be graded, because $_POST variable doesn't contain its ID.

I think this is **critical** issue, because user can pass the quiz without answering all of the questions correctly.

This commit solves the issue by merging user answers with quiz questions keys so that all questions will be graded.