### PR TITLE
Tracking lesson start on first loading lesson

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -379,6 +379,19 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
             $reset_allowed = 1;
         }
 
+        //Logging lesson end time
+        $metadata = array();
+        $metadata['lesson_end'] =  get_comment_meta( $user_lesson_status->comment_ID, 'lesson_end', true );
+        $metadata['quiz_start'] =  get_comment_meta( $user_lesson_status->comment_ID, 'quiz_start', true );
+        if($metadata['lesson_end']==0){
+            $metadata['lesson_end'] = current_time('mysql');
+        }
+        if($metadata['quiz_start']==0){
+            $metadata['quiz_start'] = current_time('mysql');
+        }
+
+        $activity_logged = Sensei_Utils::update_lesson_status( $current_user->ID, $lesson_id, $user_lesson_status->comment_approved, $metadata );
+
         // Build frontend data object for backwards compatibility
         // using this is no longer recommended
         $this->data->user_quiz_grade = $user_quiz_grade;// Sensei_Quiz::get_user_quiz_grade( $lesson_id, get_current_user_id() );
@@ -619,9 +632,14 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
                  $lesson_status = 'graded';
 
              }
-
              $lesson_metadata['grade'] = $grade; // Technically already set as part of "WooThemes_Sensei_Utils::sensei_grade_quiz_auto()" above
 
+             // Log quiz end
+             $lesson_metadata['quiz_end'] =  get_comment_meta( $user_lesson_status->comment_ID, 'quiz_end', true );
+             $lesson_metadata['num_quiz_attempts'] =  get_comment_meta( $user_lesson_status->comment_ID, 'num_quiz_attempts', true ) + 1;
+             if($lesson_metadata['quiz_end']==0){
+                 $lesson_metadata['quiz_end'] = current_time('mysql');
+             }
          } // end if ! is_wp_error( $grade ...
 
          Sensei_Utils::update_lesson_status( $user_id, $lesson_id, $lesson_status, $lesson_metadata );

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -896,6 +896,10 @@ function sensei_the_single_lesson_meta(){
         || Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id())
         || $is_preview ) {
         ?>
+		<?php if(!$is_preview){
+			do_action( 'lesson_start_status');
+		}
+		?>
         <section class="lesson-meta">
             <?php
             if( apply_filters( 'sensei_video_position', 'top', get_the_ID() ) == 'bottom' ) {
@@ -910,8 +914,8 @@ function sensei_the_single_lesson_meta(){
                 || Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id()) ) {
 
                 sensei_do_deprecated_action( 'sensei_lesson_quiz_meta','1.9.0', 'sensei_single_lesson_content_inside_before' ,array( get_the_ID(), get_current_user_id() )  );
-
             } ?>
+
         </section>
 
         <?php do_action( 'sensei_lesson_back_link', $lesson_course_id ); ?>


### PR DESCRIPTION
Also tracking lesson ended, quiz start, quiz end, number of times lesson has been viewed and number of quiz attempts.

Lesson end is logged either on user pressing "Comlete Lesson" button, or on going to quiz.
Quiz start is logged on first viewing the quiz
Quiz end is logged when user submits answer to quiz, number of quiz attempts is also increased at this time.

Connected to issue [#1430](https://github.com/Automattic/sensei/issues/1430)

Have not yet been able to do Unit Test.
