### PR TITLE
Add filter for showing answers

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -700,22 +700,20 @@ class Sensei_Question {
 			return;
 		}
 
-		if ( ! Sensei_Quiz::is_pass_required( $lesson_id ) ) {
-			self::output_result_indication( $lesson_id, $question_item->ID);
-			return;
-		}
-
 		$user_quiz_grade          = Sensei_Quiz::get_user_quiz_grade( $lesson_id, get_current_user_id() );
 		$quiz_required_pass_grade = intval( get_post_meta($quiz_id, '_quiz_passmark', true) );
-		$user_passed              =  $user_quiz_grade >= $quiz_required_pass_grade;
+		$user_passed              = $user_quiz_grade >= $quiz_required_pass_grade;
 
-		if ( $user_passed ) {
-			self::output_result_indication( $lesson_id, $question_item->ID);
-			return;
+		$show_answers = false;
+		if( ! Sensei_Quiz::is_pass_required( $lesson_id ) || $user_passed || ! Sensei_Quiz::is_reset_allowed( $lesson_id ) ) {
+			$show_answers = true;
 		}
 
-		if ( ! Sensei_Quiz::is_reset_allowed( $lesson_id ) ) {
-			self::output_result_indication( $lesson_id, $question_item->ID);
+		// This filter is documented in self::answer_feedback_notes()
+		$show_answers = apply_filters( 'sensei_question_show_answers', $show_answers, $question_item->ID, $quiz_id, $lesson_id, get_current_user_id() );
+
+		if( $show_answers ) {
+			Sensei_Question::output_result_indication( $lesson_id, $question_item->ID);
 			return;
 		}
 	}

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -620,9 +620,15 @@ class Sensei_Question {
 
 	    $quiz_required_pass_grade = intval( get_post_meta($quiz_id, '_quiz_passmark', true) );
 	    $failed_and_reset_not_allowed =  $user_quiz_grade < $quiz_required_pass_grade && ! $reset_quiz_allowed && $quiz_graded;
-
+	
+		$show_answers = false;
 	    if ( $quiz_graded || $failed_and_reset_not_allowed ) {
-
+	    	$show_answers = true;
+	    }
+	    
+	    $show_answers = apply_filters( 'sensei_question_show_answers', $show_answers, $question_id, $quiz_id, $lesson_id, get_current_user_id() );
+		
+		if( $show_answers ) {
             $answer_notes = Sensei()->quiz->get_user_question_feedback( $lesson_id, $question_id, get_current_user_id() );
 
             if( $answer_notes ) { ?>

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -620,14 +620,27 @@ class Sensei_Question {
 
 	    $quiz_required_pass_grade = intval( get_post_meta($quiz_id, '_quiz_passmark', true) );
 	    $failed_and_reset_not_allowed =  $user_quiz_grade < $quiz_required_pass_grade && ! $reset_quiz_allowed && $quiz_graded;
-	
+
+		// Check if answers must be shown
 		$show_answers = false;
 	    if ( $quiz_graded || $failed_and_reset_not_allowed ) {
 	    	$show_answers = true;
 	    }
-	    
+
+	    /**
+         * Allow dynamic overriding of whether to show question answers or not
+         *
+         * @since 1.9.7
+         * 
+         * @param boolean $show_answers
+         * @param integer $question_id
+         * @param integer $quiz_id
+         * @param integer $lesson_id
+         * @param integer $user_id
+         */
 	    $show_answers = apply_filters( 'sensei_question_show_answers', $show_answers, $question_id, $quiz_id, $lesson_id, get_current_user_id() );
-		
+
+		// Show answers if allowed
 		if( $show_answers ) {
             $answer_notes = Sensei()->quiz->get_user_question_feedback( $lesson_id, $question_id, get_current_user_id() );
 


### PR DESCRIPTION
The current logic dictates that the correct answers will only be shown if the user has passed the quiz or if they have failed quiz, but they are not allowed to retake it. Some use cases (e.g. internal training sites) require that the correct answers must be shown even if the user did not pass the quiz, but they are still allowed to retake it.

This PR adds a `sensei_question_show_answers` filter that allows site owners to override the default behaviour here. The filter receives the question ID, quiz ID, lesson ID and user ID as arguments, so it can be tailored to specific lessons/quizzes/questions/users as needed. By default, the current rules are still obeyed, so this filter will not affect existing setups. Instead, it just allows for a little bit of additional flexibility going forward.