### PR TITLE
Reduce potential for query conflicts

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -100,7 +100,7 @@ class Sensei_Course {
         add_action('save_post', array( 'Sensei_Course', 'flush_rewrite_rules' ) );
 
 		// Allow course archive to be setup as the home page
-		if ( ! empty( get_option( 'page_on_front' ) ) ) {
+		if ( (int) get_option( 'page_on_front' ) > 0 ) {
 			add_action( 'pre_get_posts', array( $this, 'allow_course_archive_on_front_page' ) );
 		}
 	} // End __construct()


### PR DESCRIPTION
Hey all,

We've hit some further conflicts when The Events Calendar and Sensei run side by side. The work already done in #1438 definitely improved things, but the same core problem still occurs if (for example) The Events Calendar widgets are in place beside a static page.

This change resolves that problem and so far as I can establish keeps things functioning as expected in the `allow_course_archive_on_front_page()` method.

Summary:

* Only hook `allow_course_archive_on_front_page()` when required (ie, if a static front page is set)
* Avoid unhooking/rehooking self from within the same action, to avoid issues re this [core WP bug](https://core.trac.wordpress.org/ticket/17817)
* Shuffles the logic a little to further avoid running an extra query until it's really necessary

#1438