### PR TITLE
Fix cases where purchased course is not added to my-courses

### DIFF
--- a/includes/hooks/woocommerce.php
+++ b/includes/hooks/woocommerce.php
@@ -30,6 +30,12 @@ add_action('sensei_before_main_content', array('Sensei_WC', 'do_single_course_wc
  ******************************/
 add_filter( 'sensei_can_user_view_lesson', array( 'Sensei_WC','alter_can_user_view_lesson' ), 20, 3 );
 
+/**
+ * Before my courses
+ */
+add_filter( 'sensei_my_courses_before', array( 'Sensei_WC','assign_user_to_unassigned_purchased_courses' ) );
+
+
 /******************************
  *
  * Order and checkout hooks


### PR DESCRIPTION
Introduced static method Sensei_WC::assign_user_to_unassigned_purchased_courses,
hooked to `sensei_my_courses_before`. It looks for purchased courses
not associated with the current user and starts them.

Refs #1352 #1417

Concerns:

* The hook used is `sensei_my_courses_before`. This hook fires after the user's courses have been fetched from the db and as such, any fixes will not show unless a user refreshes.
* Are there any other places we should be calling/hooking the new mehod?
