### PR TITLE
avoid PHP Notices, always check is_main_query() *before* conditionals

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3029,7 +3029,7 @@ class Sensei_Course {
      */
     public static function alter_course_category_order( $query ){
 
-        if( ! is_tax( 'course-category' ) || ! $query->is_main_query() ){
+        if( ! $query->is_main_query() || ! is_tax( 'course-category' ) ) {
             return $query;
         }
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -740,7 +740,7 @@ class Sensei_Frontend {
      * @param WP_Query $query
      */
 	public function lesson_tag_archive_filter( $query ) {
-    	if( is_tax( 'lesson-tag' ) && $query->is_main_query() ) {
+    	if( $query->is_main_query() && is_tax( 'lesson-tag' ) ) {
     		// Limit to lessons only
     		$query->set( 'post_type', 'lesson' );
 

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -412,7 +412,7 @@ class Sensei_Messages {
 
 		if( is_admin() ) return;
 
-		if( is_post_type_archive( $this->post_type ) && $query->is_main_query() ) {
+		if( $query->is_main_query() && is_post_type_archive( $this->post_type ) ) {
 			wp_get_current_user();
 			$username = $current_user->user_login;
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -536,7 +536,7 @@ class Sensei_Core_Modules
      */
     public function module_archive_filter($query)
     {
-        if (is_tax($this->taxonomy) && $query->is_main_query()) {
+        if ( $query->is_main_query() && is_tax($this->taxonomy) ) {
 
 
             // Limit to lessons only


### PR DESCRIPTION
WooCommerce Memberships 1.7 runs some early checks for content restriction
permissions via `get_posts()`, triggering `pre_get_posts` action early. This
causes Sensei to spit out a list of noisy Notices on every request.

`is_tax() was called incorrectly. Conditional query tags do not work
before the query is run. Before then, they always return false. Please see
Debugging in WordPress for more information. (This message was added in
version 3.1.0.)`

Example traceback:

```
is_tax()
    wp-content/plugins/sensei.git/includes/class-sensei-course.php:3010
Sensei_Course::alter_course_category_order()
    wp-includes/plugin.php:600
    do_action_ref_array('pre_get_posts')
    wp-includes/query.php:2503
WP_Query->get_posts()
    wp-includes/query.php:4050
WP_Query->query()
    wp-includes/post.php:1595
get_posts()
    wp-content/plugins/woocommerce-memberships/includes/class-wc-memberships-membership-plans.php:145
WC_Memberships_Membership_Plans->get_membership_plans()
    wp-content/plugins/woocommerce-memberships/includes/functions/wc-memberships-functions-membership-plans.php:49
wc_memberships_get_membership_plans()
    wp-content/plugins/woocommerce-memberships/includes/class-wc-memberships-user-memberships.php:303
WC_Memberships_User_Memberships->is_user_member()
    wp-content/plugins/woocommerce-memberships/includes/functions/wc-memberships-functions-user-memberships.php:116
wc_memberships_is_user_member()
    wp-content/plugins/woocommerce-memberships/includes/class-wc-memberships-member-discounts.php:94
WC_Memberships_Member_Discounts->__construct()
    wp-content/plugins/woocommerce-freshbooks/lib/skyverge/woocommerce/class-sv-wc-plugin.php:556
SV_WC_Plugin->load_class()
    wp-content/plugins/woocommerce-memberships/woocommerce-memberships.php:160
WC_Memberships->includes()
    wp-includes/plugin.php:524
    do_action('sv_wc_framework_plugins_loaded')
    wp-content/plugins/woocommerce-freshbooks/lib/skyverge/woocommerce/class-sv-wc-framework-bootstrap.php:190
SV_WC_Framework_Bootstrap->load_framework_plugins()
    wp-includes/plugin.php:524
    do_action('plugins_loaded')
    wp-settings.php:295Plugin: woocommerce-freshbooks
```
