### PR TITLE
Fix file names for coding standards

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,18 @@
 *** Sensei Changelog ***
 
+2016.09.29 - version 1.9.7
+* Improve Module taxonomy labels
+* Fix - Lesson doesn't appear on Course archive until ordering is resaved
+* Fix - Errors when duplicating course with lessons
+* Fix - Add modules-frontend.css to sensei_disable_styles filter
+* Fix - Grade unanswered questions too
+* Fix - Paypal "Cancel and return" causing a fatal error
+* Fix - Do not create duplicate membership rules on save
+* Fix - Random users not being assigned to courses after purchase
+* Fix - "Quiz saved" notice not appearing
+* Various security fixes
+
+- version 1.9.6
 * Fix - Fixed an issue prevent Modern Tribe's The Event Calendar from functioning properly.
 * Fix - Ensure the question grade is shown inline with questions.
 * Fix - Prevent a PHP notice when calling question results.

--- a/changelog.txt
+++ b/changelog.txt
@@ -12,7 +12,7 @@
 * Fix - "Quiz saved" notice not appearing
 * Various security fixes
 
-- version 1.9.6
+2016.05.05 - version 1.9.6
 * Fix - Fixed an issue prevent Modern Tribe's The Event Calendar from functioning properly.
 * Fix - Ensure the question grade is shown inline with questions.
 * Fix - Prevent a PHP notice when calling question results.

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -814,8 +814,12 @@ class Sensei_Admin {
 					$data = '';
 
 					if( $post_id ) {
-						$data = get_post_meta( $post_id, '_' . $field['id'], true );
-						if( ! $data && isset( $field['default'] ) ) {
+						if ( 'plain-text' !== $field['type'] ) {
+							$data = get_post_meta( $post_id, '_' . $field['id'], true );
+							if( ! $data && isset( $field['default'] ) ) {
+								$data = $field['default'];
+							}
+						} else {
 							$data = $field['default'];
 						}
 					} else {
@@ -828,9 +832,8 @@ class Sensei_Admin {
 						}
 					}
 
-					$disabled = '';
-					if( isset( $field['disabled'] ) && $field['disabled'] ) {
-						$disabled = disabled( $field['disabled'], true, false );
+					if ( ! isset( $field['disabled'] ) ) {
+						$field['disabled'] = false;
 					}
 
 					if( 'hidden' != $field['type'] ) {
@@ -857,13 +860,21 @@ class Sensei_Admin {
 							}
 
 							switch( $field['type'] ) {
+								case 'plain-text':
+									$html .= '<strong>' . esc_html( $data ) . '</strong>';
+									break;
 								case 'text':
 								case 'password':
-									$html .= '<input id="' . esc_attr( $field['id'] ) . '" type="' . $field['type'] . '" name="' . esc_attr( $field['id'] ) . '" placeholder="' . esc_attr( $field['placeholder'] ) . '" value="' . $data . '" ' . $disabled . ' />' . "\n";
+									$html .= '<input id="' . esc_attr( $field['id'] ) . '" ';
+									$html .= 'type="' . esc_attr( $field['type'] ) . '" ';
+									$html .= 'name="' . esc_attr( $field['id'] ) . '" ';
+									$html .= 'placeholder="' . esc_attr( $field['placeholder'] ) . '" ';
+									$html .= 'value="' . esc_attr( $data ) . '" ';
+									$html .= disabled( $field['disabled'], true, false );
+									$html .= ' />' . "\n";
 								break;
 
 								case 'number':
-
 									$min = '';
 									if( isset( $field['min'] ) ) {
 										$min = 'min="' . esc_attr( $field['min'] ) . '"';
@@ -874,11 +885,24 @@ class Sensei_Admin {
 										$max = 'max="' . esc_attr( $field['max'] ) . '"';
 									}
 
-									$html .= '<input id="' . esc_attr( $field['id'] ) . '" type="' . $field['type'] . '" name="' . esc_attr( $field['id'] ) . '" placeholder="' . esc_attr( $field['placeholder'] ) . '" value="' . $data . '" ' . $min . '  ' . $max . ' class="small-text" ' . $disabled . ' />' . "\n";
+									$html .= '<input id="' . esc_attr( $field['id'] ) . '" ';
+									$html .= 'type="' . esc_attr( $field['type'] ) . '" ';
+									$html .= 'name="' . esc_attr( $field['id'] ) . '" ';
+									$html .= 'placeholder="' . esc_attr( $field['placeholder'] ) . '" ';
+									$html .= 'value="' . esc_attr( $data ) . '" ';
+									$html .= $min . '  ' . $max . ' '; // $min and $max are escaped above, for better readibility
+									$html .= 'class="small-text" ';
+									$html .= disabled( $field['disabled'], true, false );
+									$html .= ' />' . "\n";
 								break;
 
 								case 'textarea':
-									$html .= '<textarea id="' . esc_attr( $field['id'] ) . '" rows="5" cols="50" name="' . esc_attr( $field['id'] ) . '" placeholder="' . esc_attr( $field['placeholder'] ) . '" ' . $disabled . '>' . $data . '</textarea><br/>'. "\n";
+									$html .= '<textarea id="' . esc_attr( $field['id'] ) . '" ';
+									$html .= 'rows="5" cols="50" ';
+									$html .= 'name="' . esc_attr( $field['id'] ) . '" ';
+									$html .= 'placeholder="' . esc_attr( $field['placeholder'] ) . '" ';
+									$html .= disabled( $field['disabled'], true, false );
+									$html .= '>' . strip_tags( $data ) . '</textarea><br/>'. "\n";
 								break;
 
 								case 'checkbox':
@@ -897,8 +921,13 @@ class Sensei_Admin {
                                         $checked_value = 1;
                                         $data = intval( $data );
                                     }
-									$checked = checked( $checked_value, $data, false );
-									$html .= '<input id="' . esc_attr( $field['id'] ) . '" type="' . $field['type'] . '" name="' . esc_attr( $field['id'] ) . '" ' . $checked . ' ' . $disabled . '/>' . "\n";
+
+									$html .= '<input id="' . esc_attr( $field['id'] ) . '" ';
+									$html .= 'type="' . esc_attr( $field['type'] ) . '" ';
+									$html .= 'name="' . esc_attr( $field['id'] ) . '" ';
+									$html .= checked( $checked_value, $data, false );
+									$html .= disabled( $field['disabled'], true, false );
+									$html .= " /> \n";
 								break;
 
 								case 'checkbox_multi':
@@ -907,7 +936,16 @@ class Sensei_Admin {
 										if( in_array( $k, $data ) ) {
 											$checked = true;
 										}
-										$html .= '<label for="' . esc_attr( $field['id'] . '_' . $k ) . '"><input type="checkbox" ' . checked( $checked, true, false ) . ' name="' . esc_attr( $field['id'] ) . '[]" value="' . esc_attr( $k ) . '" id="' . esc_attr( $field['id'] . '_' . $k ) . '" ' . $disabled . ' /> ' . $v . '</label> ' . "\n";
+
+										$html .= '<label for="' . esc_attr( $field['id'] . '_' . $k ) . '">';
+											$html .= '<input type="checkbox" ';
+											$html .= checked( $checked, true, false ) . ' ';
+											$html .= 'name="' . esc_attr( $field['id'] ) . '[]" ';
+											$html .= 'value="' . esc_attr( $k ) . '" ';
+											$html .= 'id="' . esc_attr( $field['id'] . '_' . $k ) . '" ';
+											$html .= disabled( $field['disabled'], true, false );
+											$html .= ' /> ' . esc_html( $v );
+										$html .= "</label> \n";
 									}
 								break;
 
@@ -917,36 +955,63 @@ class Sensei_Admin {
 										if( $k == $data ) {
 											$checked = true;
 										}
-										$html .= '<label for="' . esc_attr( $field['id'] . '_' . $k ) . '"><input type="radio" ' . checked( $checked, true, false ) . ' name="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $k ) . '" id="' . esc_attr( $field['id'] . '_' . $k ) . '" ' . $disabled . ' /> ' . $v . '</label> ' . "\n";
+
+										$html .= '<label for="' . esc_attr( $field['id'] . '_' . $k ) . '">';
+											$html .= '<input type="radio" ';
+											$html .= checked( $checked, true, false ) . ' ';
+											$html .= 'name="' . esc_attr( $field['id'] ) . '" ';
+											$html .= 'value="' . esc_attr( $k ) . '" ';
+											$html .= 'id="' . esc_attr( $field['id'] . '_' . $k ) . '" ';
+											$html .= disabled( $field['disabled'], true, false );
+											$html .= ' /> ' . esc_html( $v );
+										$html .= "</label> \n";
 									}
 								break;
 
 								case 'select':
-									$html .= '<select name="' . esc_attr( $field['id'] ) . '" id="' . esc_attr( $field['id'] ) . '" ' . $disabled . '>' . "\n";
+									$html .= '<select name="' . esc_attr( $field['id'] ) . '" ';
+									$html .= 'id="' . esc_attr( $field['id'] ) . '" ';
+									$html .= disabled( $field['disabled'], true, false );
+									$html .= ">\n";
+
 									foreach( $field['options'] as $k => $v ) {
 										$selected = false;
 										if( $k == $data ) {
 											$selected = true;
 										}
-										$html .= '<option ' . selected( $selected, true, false ) . ' value="' . esc_attr( $k ) . '">' . $v . '</option>' . "\n";
+
+										$html .= '<option ' . selected( $selected, true, false ) . ' ';
+										$html .= 'value="' . esc_attr( $k ) . '">' . esc_html( $v ) . "</option>\n";
 									}
-									$html .= '</select><br/>' . "\n";
+
+									$html .= "</select><br/>\n";
 								break;
 
 								case 'select_multi':
-									$html .= '<select name="' . esc_attr( $field['id'] ) . '[]" id="' . esc_attr( $field['id'] ) . '" multiple="multiple" ' . $disabled . '>' . "\n";
+									$html .= '<select name="' . esc_attr( $field['id'] ) . '[]" ';
+									$html .= 'id="' . esc_attr( $field['id'] ) . '" multiple="multiple" ';
+									$html .= disabled( $field['disabled'], true, false );
+									$html .= ">\n";
+
 									foreach( $field['options'] as $k => $v ) {
 										$selected = false;
 										if( in_array( $k, $data ) ) {
 											$selected = true;
 										}
-										$html .= '<option ' . selected( $selected, true, false ) . ' value="' . esc_attr( $k ) . '" />' . $v . '</option>' . "\n";
+										$html .= '<option ' . selected( $selected, true, false ) . ' ';
+										$html .= 'value="' . esc_attr( $k ) . '" />' . esc_html( $v ) . "</option>\n";
 									}
-									$html .= '</select> . "\n"';
+
+									$html .= "</select>\n";
 								break;
 
 								case 'hidden':
-									$html .= '<input id="' . esc_attr( $field['id'] ) . '" type="' . $field['type'] . '" name="' . esc_attr( $field['id'] ) . '" value="' . $data . '" ' . $disabled . '/>' . "\n";
+									$html .= '<input id="' . esc_attr( $field['id'] ) . '" ';
+									$html .= 'type="' . esc_attr( $field['type'] ) . '" ';
+									$html .= 'name="' . esc_attr( $field['id'] ) . '" ';
+									$html .= 'value="' . esc_attr( $data ) . '" ';
+									$html .= disabled( $field['disabled'], true, false );
+									$html .= "/>\n";
 								break;
 
 							}
@@ -960,14 +1025,13 @@ class Sensei_Admin {
 						}
 
 					if( 'hidden' != $field['type'] ) {
-						$html .= '</p>' . "\n";
+						$html .= "</p>\n";
 					}
 
 				}
 
-			$html .= '</div>' . "\n";
-
-		$html .= '</div>' . "\n";
+			$html .= "</div>\n";
+		$html .= "</div>\n";
 
 		return $html;
 	}
@@ -982,7 +1046,7 @@ class Sensei_Admin {
 		wp_enqueue_script( 'woothemes-sensei-settings', esc_url( Sensei()->plugin_url . 'assets/js/settings' . $suffix . '.js' ), array( 'jquery', 'jquery-ui-sortable' ), Sensei()->version );
 
 		?><div id="course-order" class="wrap course-order">
-		<h2><?php _e( 'Order Courses', 'woothemes-sensei' ); ?></h2><?php
+		<h2><?php esc_html_e( 'Order Courses', 'woothemes-sensei' ); ?></h2><?php
 
 		$html = '';
 
@@ -991,7 +1055,7 @@ class Sensei_Admin {
 
 			if( $ordered ) {
 				$html .= '<div class="updated fade">' . "\n";
-				$html .= '<p>' . __( 'The course order has been saved.', 'woothemes-sensei' ) . '</p>' . "\n";
+				$html .= '<p>' . esc_html__( 'The course order has been saved.', 'woothemes-sensei' ) . '</p>' . "\n";
 				$html .= '</div>' . "\n";
 			}
 		}
@@ -1032,7 +1096,7 @@ class Sensei_Admin {
 			$html .= '</ul>' . "\n";
 
 			$html .= '<input type="hidden" name="course-order" value="' . esc_attr( $order_string ) . '" />' . "\n";
-			$html .= '<input type="submit" class="button-primary" value="' . __( 'Save course order', 'woothemes-sensei' ) . '" />' . "\n";
+			$html .= '<input type="submit" class="button-primary" value="' . esc_attr__( 'Save course order', 'woothemes-sensei' ) . '" />' . "\n";
 		}
 
 		echo $html;
@@ -1055,7 +1119,7 @@ class Sensei_Admin {
 			if( $course_id ) {
 
 				$update_args = array(
-					'ID' => $course_id,
+					'ID'         => absint( $course_id ),
 					'menu_order' => $i,
 				);
 
@@ -1088,17 +1152,17 @@ class Sensei_Admin {
 
 			if( $ordered ) {
 				$html .= '<div class="updated fade">' . "\n";
-				$html .= '<p>' . __( 'The lesson order has been saved.', 'woothemes-sensei' ) . '</p>' . "\n";
+				$html .= '<p>' . esc_html__( 'The lesson order has been saved.', 'woothemes-sensei' ) . '</p>' . "\n";
 				$html .= '</div>' . "\n";
 			}
 		}
 
 		$args = array(
-			'post_type' => 'course',
-			'post_status' => array('publish', 'draft', 'future', 'private'),
+			'post_type'      => 'course',
+			'post_status'    => array('publish', 'draft', 'future', 'private'),
 			'posts_per_page' => -1,
-			'orderby' => 'name',
-			'order' => 'ASC',
+			'orderby'        => 'name',
+			'order'          => 'ASC',
 		);
 		$courses = get_posts( $args );
 
@@ -1106,7 +1170,7 @@ class Sensei_Admin {
 		$html .= '<input type="hidden" name="post_type" value="lesson" />' . "\n";
 		$html .= '<input type="hidden" name="page" value="lesson-order" />' . "\n";
 		$html .= '<select id="lesson-order-course" name="course_id">' . "\n";
-		$html .= '<option value="">' . __( 'Select a course', 'woothemes-sensei' ) . '</option>' . "\n";
+		$html .= '<option value="">' . esc_html__( 'Select a course', 'woothemes-sensei' ) . '</option>' . "\n";
 
 		foreach( $courses as $course ) {
 			$course_id = '';
@@ -1117,7 +1181,7 @@ class Sensei_Admin {
 		}
 
 		$html .= '</select>' . "\n";
-		$html .= '<input type="submit" class="button-primary lesson-order-select-course-submit" value="' . __( 'Select', 'woothemes-sensei' ) . '" />' . "\n";
+		$html .= '<input type="submit" class="button-primary lesson-order-select-course-submit" value="' . esc_attr__( 'Select', 'woothemes-sensei' ) . '" />' . "\n";
 		$html .= '</form>' . "\n";
 
 		$html .= '<script type="text/javascript">' . "\n";
@@ -1139,34 +1203,34 @@ class Sensei_Admin {
                 foreach( $modules as $module ) {
 
                     $args = array(
-                        'post_type' => 'lesson',
-                        'post_status' => 'publish',
+                        'post_type'      => 'lesson',
+                        'post_status'    => 'publish',
                         'posts_per_page' => -1,
-                        'meta_query' => array(
+                        'meta_query'     => array(
                             array(
-                                'key' => '_lesson_course',
-                                'value' => intval( $course_id ),
+                                'key'     => '_lesson_course',
+                                'value'   => intval( $course_id ),
                                 'compare' => '='
                             )
                         ),
                         'tax_query' => array(
                             array(
                                 'taxonomy' => Sensei()->modules->taxonomy,
-                                'field' => 'id',
-                                'terms' => intval( $module->term_id )
+                                'field'    => 'id',
+                                'terms'    => intval( $module->term_id )
                             )
                         ),
-                        'meta_key' => '_order_module_' . $module->term_id,
-                        'orderby' => 'meta_value_num date',
-                        'order' => 'ASC',
+                        'meta_key'         => '_order_module_' . $module->term_id,
+                        'orderby'          => 'meta_value_num date',
+                        'order'            => 'ASC',
                         'suppress_filters' => 0
                     );
 
                     $lessons = get_posts( $args );
 
                     if( count( $lessons ) > 0 ) {
-                        $html .= '<h3>' . $module->name . '</h3>' . "\n";
-                        $html .= '<ul class="sortable-lesson-list" data-module_id="' . $module->term_id . '">' . "\n";
+                        $html .= '<h3>' . esc_html( $module->name ) . '</h3>' . "\n";
+                        $html .= '<ul class="sortable-lesson-list" data-module_id="' . esc_attr( $module->term_id ) . '">' . "\n";
 
                         $count = 0;
                         foreach( $lessons as $lesson ) {
@@ -1178,14 +1242,14 @@ class Sensei_Admin {
                                 $class .= ' alternate';
                             }
 
-                            $html .= '<li class="' . esc_attr( $class ) . '"><span rel="' . esc_attr( $lesson->ID ) . '" style="width: 100%;"> ' . $lesson->post_title . '</span></li>' . "\n";
+                            $html .= '<li class="' . esc_attr( $class ) . '"><span rel="' . esc_attr( $lesson->ID ) . '" style="width: 100%;"> ' . esc_html( $lesson->post_title ) . '</span></li>' . "\n";
 
                             $displayed_lessons[] = $lesson->ID;
                         }
 
                         $html .= '</ul>' . "\n";
 
-                        $html .= '<input type="hidden" name="lesson-order-module-' . $module->term_id . '" value="" />' . "\n";
+                        $html .= '<input type="hidden" name="lesson-order-module-' . esc_attr( $module->term_id ) . '" value="" />' . "\n";
                     }
                 }
 
@@ -1203,7 +1267,7 @@ class Sensei_Admin {
                     }
 
 					if( 0 < count( $displayed_lessons ) ) {
-						$html .= '<h3>' . __( 'Other Lessons', 'woothemes-sensei' ) . '</h3>' . "\n";
+						$html .= '<h3>' . esc_html__( 'Other Lessons', 'woothemes-sensei' ) . '</h3>' . "\n";
 					}
 
 					$html .= '<ul class="sortable-lesson-list" data-module_id="0">' . "\n";
@@ -1227,21 +1291,21 @@ class Sensei_Admin {
 							$class .= ' alternate';
 
 						}
-						$html .= '<li class="' . esc_attr( $class ) . '"><span rel="' . esc_attr( $lesson->ID ) . '" style="width: 100%;"> ' . $lesson->post_title . '</span></li>' . "\n";
+						$html .= '<li class="' . esc_attr( $class ) . '"><span rel="' . esc_attr( $lesson->ID ) . '" style="width: 100%;"> ' . esc_html( $lesson->post_title ) . '</span></li>' . "\n";
 
 						$displayed_lessons[] = $lesson->ID;
 					}
 					$html .= '</ul>' . "\n";
 				} else {
 					if( 0 == count( $displayed_lessons ) ) {
-						$html .= '<p><em>' . __( 'There are no lessons in this course.', 'woothemes-sensei' ) . '</em></p>';
+						$html .= '<p><em>' . esc_html__( 'There are no lessons in this course.', 'woothemes-sensei' ) . '</em></p>';
 					}
 				}
 
 				if( 0 < count( $displayed_lessons ) ) {
 					$html .= '<input type="hidden" name="lesson-order" value="' . esc_attr( $order_string ) . '" />' . "\n";
-					$html .= '<input type="hidden" name="course_id" value="' . $course_id . '" />' . "\n";
-					$html .= '<input type="submit" class="button-primary" value="' . __( 'Save lesson order', 'woothemes-sensei' ) . '" />' . "\n";
+					$html .= '<input type="hidden" name="course_id" value="' . esc_attr( $course_id ) . '" />' . "\n";
+					$html .= '<input type="submit" class="button-primary" value="' . esc_html__( 'Save lesson order', 'woothemes-sensei' ) . '" />' . "\n";
 				}
 			}
 		}
@@ -1316,12 +1380,12 @@ class Sensei_Admin {
 		global $nav_menu_selected_id;
 
 		$menu_items = array(
-			'#senseicourses' => __( 'Courses', 'woothemes-sensei' ),
-			'#senseilessons' => __( 'Lessons', 'woothemes-sensei' ),
-			'#senseimycourses' => __( 'My Courses', 'woothemes-sensei' ),
+			'#senseicourses'        => __( 'Courses', 'woothemes-sensei' ),
+			'#senseilessons'        => __( 'Lessons', 'woothemes-sensei' ),
+			'#senseimycourses'      => __( 'My Courses', 'woothemes-sensei' ),
 			'#senseilearnerprofile' => __( 'My Profile', 'woothemes-sensei' ),
-			'#senseimymessages' => __( 'My Messages', 'woothemes-sensei' ),
-			'#senseiloginlogout' => __( 'Login', 'woothemes-sensei' ) . '|' . __( 'Logout', 'woothemes-sensei' )
+			'#senseimymessages'     => __( 'My Messages', 'woothemes-sensei' ),
+			'#senseiloginlogout'    => __( 'Login', 'woothemes-sensei' ) . '|' . __( 'Logout', 'woothemes-sensei' )
 		);
 
 		$menu_items_obj = array();
@@ -1348,7 +1412,7 @@ class Sensei_Admin {
 			<div id="tabs-panel-sensei-links-all" class="tabs-panel tabs-panel-view-all tabs-panel-active">
 
 				<ul id="sensei-linkschecklist" class="list:sensei-links categorychecklist form-no-clear">
-					<?php echo walk_nav_menu_tree( array_map( 'wp_setup_nav_menu_item', $menu_items_obj ), 0, (object)array( 'walker' => $walker ) ); ?>
+					<?php echo walk_nav_menu_tree( array_map( 'wp_setup_nav_menu_item', $menu_items_obj ), 0, (object) array( 'walker' => $walker ) ); ?>
 				</ul>
 
 			</div>
@@ -1408,21 +1472,23 @@ class Sensei_Admin {
 
             <div id="message" class="error sensei-message sensei-connect">
                     <p>
-                        <?php
-                        echo sprintf( __('%s Your theme does not declare Sensei support %s, if you encounter layout issues
-                                            please read our integration guide or choose a %s Sensei theme %s', 'woothemes-sensei' ),
-	                                        '<strong>',
-	                                        '</strong>',
-                                            '<a href="http://www.woothemes.com/product-category/themes/sensei-themes/">',
-	                                        '</a>'
-                                );
-                        ?>
+                        <strong>
+
+                            <?php esc_html_e( 'Your theme does not declare Sensei support', 'woothemes-sensei' ); ?>
+
+                        </strong> &#8211;
+
+                        <?php esc_html_e( 'if you encounter layout issues please read our integration guide or choose a ', 'woothemes-sensei' ); ?>
+
+                        <a href="http://www.woothemes.com/product-category/themes/sensei-themes/"> <?php esc_html_e( 'Sensei theme', 'woothemes-sensei' ) ?> </a>
+
                         :)
+
                     </p>
                     <p class="submit">
                         <a href="<?php echo esc_url( apply_filters( 'sensei_docs_url', 'http://docs.woothemes.com/document/sensei-and-theme-compatibility/', 'theme-compatibility' ) ); ?>" class="button-primary">
 
-                            <?php _e( 'Theme Integration Guide', 'woothemes-sensei' ); ?></a> <a class="skip button" href="<?php echo esc_url( add_query_arg( 'sensei_hide_notice', 'theme_check' ) ); ?>"><?php _e( 'Hide this notice', 'woothemes-sensei' ); ?>
+                            <?php esc_html_e( 'Theme Integration Guide', 'woothemes-sensei' ); ?></a> <a class="skip button" href="<?php echo esc_url( add_query_arg( 'sensei_hide_notice', 'theme_check' ) ); ?>"><?php esc_html_e( 'Hide this notice', 'woothemes-sensei' ); ?>
 
                         </a>
                     </p>

--- a/includes/class-sensei-course-results.php
+++ b/includes/class-sensei-course-results.php
@@ -27,7 +27,12 @@ class Sensei_Course_Results {
 
 		// Setup permalink structure for course results
 		add_action( 'init', array( $this, 'setup_permastruct' ) );
+
+		// Support older WordPress theme (< 4.4)
 		add_filter( 'wp_title', array( $this, 'page_title' ), 10, 2 );
+
+		// Support newer WordPress theme (>= 4.4)
+		add_filter( 'document_title_parts', array( $this, 'page_title' ), 10, 2 );
 
 		// Load course results
 		add_action( 'sensei_course_results_content_inside_before', array( $this, 'deprecate_course_result_info_hook' ), 10 );
@@ -49,7 +54,7 @@ class Sensei_Course_Results {
 
 	/**
 	 * Adding page title for course results page
-	 * @param  string $title Original title
+	 * @param  mixed  $title Original title
 	 * @param  string $sep   Seeparator string
 	 * @return string        Modified title
 	 */
@@ -57,7 +62,12 @@ class Sensei_Course_Results {
 		global $wp_query;
 		if( isset( $wp_query->query_vars['course_results'] ) ) {
 			$course = get_page_by_path( $wp_query->query_vars['course_results'], OBJECT, 'course' );
-			$title = __( 'Course Results: ', 'woothemes-sensei' ) . $course->post_title . ' ' . $sep . ' ';
+			$modified_title = __( 'Course Results: ', 'woothemes-sensei' ) . $course->post_title . ' ' . $sep . ' ';
+			if ( is_array( $title ) ) {
+				$title['title'] = $modified_title;
+			} else {
+				$title = $modified_title;
+			}
 		}
 		return $title;
 	}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3102,7 +3102,7 @@ class Sensei_Course {
 	function allow_course_archive_on_front_page( $query ) {
 		// Bail if it's clear we're not looking at a static front page or if the $running flag is
 		// set @see https://github.com/Automattic/sensei/issues/1438 and https://github.com/Automattic/sensei/issues/1491
-		if ( ! $query->is_main_query() || ! ( is_page() && is_front_page() ) || is_admin() ) {
+		if ( ! $query->is_main_query() || ! $this->is_home_and_front_page_is_page( $query ) || is_admin() ) {
 			return;
 		}
 
@@ -3143,6 +3143,11 @@ class Sensei_Course {
 		$query->is_singular          = 0;
 		$query->is_post_type_archive = 1;
 		$query->is_archive           = 1;
+	}
+
+	private function is_home_and_front_page_is_page($query ) {
+		return $query->is_home() && 'page' == get_option( 'show_on_front') && get_option( 'page_on_front' ) &&
+		       $query->get( 'page_id' ) && get_option( 'page_on_front' ) == $query->get( 'page_id' );
 	}
 
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3101,8 +3101,8 @@ class Sensei_Course {
 	 */
 	function allow_course_archive_on_front_page( $query ) {
 		// Bail if it's clear we're not looking at a static front page or if the $running flag is
-		// set @see https://github.com/Automattic/sensei/issues/1438
-		if ( ! $query->is_main_query() || ! is_page() || is_admin() ) {
+		// set @see https://github.com/Automattic/sensei/issues/1438 and https://github.com/Automattic/sensei/issues/1491
+		if ( ! $query->is_main_query() || ! ( is_page() && is_front_page() ) || is_admin() ) {
 			return;
 		}
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -385,7 +385,7 @@ class Sensei_Course {
 		$html = '';
 
 		$html .= '<label class="screen-reader-text" for="course_video_embed">' . __( 'Video Embed Code', 'woothemes-sensei' ) . '</label>';
-		$html .= '<textarea rows="5" cols="50" name="course_video_embed" tabindex="6" id="course-video-embed">' . wp_kses( $course_video_embed, self::$allowed_html ) . '</textarea>';
+		$html .= '<textarea rows="5" cols="50" name="course_video_embed" tabindex="6" id="course-video-embed">' . Sensei_Utils::wp_kses( $course_video_embed, self::$allowed_html ) . '</textarea>';
 		$html .= '<p>' .  __( 'Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above.', 'woothemes-sensei' ) . '</p>';
 
 		echo $html;
@@ -2947,7 +2947,7 @@ class Sensei_Course {
         if ( '' != $course_video_embed ) { ?>
 
             <div class="course-video">
-                <?php echo wp_kses( do_shortcode( $course_video_embed ), self::$allowed_html ); ?>
+                <?php echo Sensei_Utils::wp_kses( do_shortcode( $course_video_embed ), self::$allowed_html ); ?>
             </div>
 
         <?php } // End If Statement

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -29,6 +29,11 @@ class Sensei_Course {
     public  $my_courses_page;
 
 	/**
+	 * @var array The HTML allowed for message boxes.
+	 */
+	public static $allowed_html;
+
+	/**
 	 * Constructor.
 	 * @since  1.0.0
 	 */
@@ -49,6 +54,22 @@ class Sensei_Course {
 		} else {
 			$this->my_courses_page = false;
 		} // End If Statement
+
+		self::$allowed_html = array(
+			'embed'  => array(),
+			'iframe' => array(
+				'width'           => array(),
+				'height'          => array(),
+				'src'             => array(),
+				'frameborder'     => array(),
+				'allowfullscreen' => array(),
+			),
+			'video'  => array(
+				'width'  => array(),
+				'height' => array(),
+				'src'    => array(),
+			),
+		);
 
 		// Update course completion upon completion of a lesson
 		add_action( 'sensei_user_lesson_end', array( $this, 'update_status_after_lesson_change' ), 10, 2 );
@@ -364,7 +385,7 @@ class Sensei_Course {
 		$html = '';
 
 		$html .= '<label class="screen-reader-text" for="course_video_embed">' . __( 'Video Embed Code', 'woothemes-sensei' ) . '</label>';
-		$html .= '<textarea rows="5" cols="50" name="course_video_embed" tabindex="6" id="course-video-embed">' . $course_video_embed . '</textarea>';
+		$html .= '<textarea rows="5" cols="50" name="course_video_embed" tabindex="6" id="course-video-embed">' . wp_kses( $course_video_embed, self::$allowed_html ) . '</textarea>';
 		$html .= '<p>' .  __( 'Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above.', 'woothemes-sensei' ) . '</p>';
 
 		echo $html;
@@ -431,7 +452,7 @@ class Sensei_Course {
 		$meta_key = '_' . $post_key;
 		// Get the posted data and sanitize it for use as an HTML class.
 		if ( 'course_video_embed' == $post_key) {
-			$new_meta_value = esc_html( $_POST[$post_key] );
+			$new_meta_value = wp_kses( $_POST[$post_key], self::$allowed_html );
 		} else {
 			$new_meta_value = ( isset( $_POST[$post_key] ) ? sanitize_html_class( $_POST[$post_key] ) : '' );
 		} // End If Statement
@@ -503,7 +524,7 @@ class Sensei_Course {
 
     public function course_manage_meta_box_content () {
         global $post;
-        
+
         $manage_url = esc_url( add_query_arg( array( 'page' => 'sensei_learners', 'course_id' => $post->ID, 'view' => 'learners' ), admin_url( 'admin.php') ) );
 
         $grading_url = esc_url( add_query_arg( array( 'page' => 'sensei_grading', 'course_id' => $post->ID, 'view' => 'learners' ), admin_url( 'admin.php') ) );
@@ -2913,6 +2934,7 @@ class Sensei_Course {
 	    if ( ! is_singular( 'course' )  ) {
 		    return;
 	    }
+
         // Get the meta info
         $course_video_embed = get_post_meta( $post->ID, '_course_video_embed', true );
 
@@ -2925,7 +2947,7 @@ class Sensei_Course {
         if ( '' != $course_video_embed ) { ?>
 
             <div class="course-video">
-                <?php echo do_shortcode( html_entity_decode( $course_video_embed ) ); ?>
+                <?php echo wp_kses( do_shortcode( $course_video_embed ), self::$allowed_html ); ?>
             </div>
 
         <?php } // End If Statement

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -15,12 +15,29 @@ class Sensei_Frontend {
 
 	public $messages;
 	public $data;
+	public $allowed_html;
 
 	/**
 	 * Constructor.
 	 * @since  1.0.0
 	 */
 	public function __construct () {
+
+		$this->allowed_html = array(
+			'embed'  => array(),
+			'iframe' => array(
+				'width'           => array(),
+				'height'          => array(),
+				'src'             => array(),
+				'frameborder'     => array(),
+				'allowfullscreen' => array(),
+			),
+			'video'  => array(
+				'width'  => array(),
+				'height' => array(),
+				'src'    => array(),
+			),
+		);
 
 		// Template output actions
 		add_action( 'sensei_before_main_content', array( $this, 'sensei_output_content_wrapper' ), 10 );
@@ -878,7 +895,7 @@ class Sensei_Frontend {
         		$lesson_video_embed = wp_oembed_get( esc_url( $lesson_video_embed )/*, array( 'width' => 100 , 'height' => 100)*/ );
         	} // End If Statement
         	if ( '' != $lesson_video_embed ) {
-        	?><div class="video"><?php echo do_shortcode( html_entity_decode( $lesson_video_embed ) ); ?></div><?php
+        	?><div class="video"><?php echo wp_kses( do_shortcode( html_entity_decode( $lesson_video_embed ) ), $this->allowed_html ); ?></div><?php
         	} // End If Statement
         } // End If Statement
 	} // End sensei_lesson_video()
@@ -1280,7 +1297,7 @@ class Sensei_Frontend {
 			} else {
 				// Than its real product set it's id to item_id
 				$item_id = $item['product_id'];
-			} 
+			}
 
             if ( $item_id > 0 ) {
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -895,7 +895,7 @@ class Sensei_Frontend {
         		$lesson_video_embed = wp_oembed_get( esc_url( $lesson_video_embed )/*, array( 'width' => 100 , 'height' => 100)*/ );
         	} // End If Statement
         	if ( '' != $lesson_video_embed ) {
-        	?><div class="video"><?php echo wp_kses( do_shortcode( html_entity_decode( $lesson_video_embed ) ), $this->allowed_html ); ?></div><?php
+				?><div class="video"><?php echo Sensei_Utils::wp_kses( do_shortcode( html_entity_decode( $lesson_video_embed ) ), $this->allowed_html ); ?></div><?php
         	} // End If Statement
         } // End If Statement
 	} // End sensei_lesson_video()

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -206,7 +206,15 @@ class Sensei_Grading_User_Quiz {
                                     $_user_answer = htmlspecialchars_decode( nl2br( $_user_answer ) );
                                 }
 
-								echo esc_html( apply_filters( 'sensei_answer_text', $_user_answer ) ) . "<br>";
+								$_user_answer = wp_kses( apply_filters( 'sensei_answer_text', $_user_answer ), array(
+									'a' => array(
+										'href' => array(),
+										'title' => array(),
+										'target' => array(),
+									)
+								) );
+
+								echo $_user_answer . "<br>";
 							}
 						?></p>
 						<div class="right-answer">

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -203,12 +203,10 @@ class Sensei_Grading_User_Quiz {
 							foreach ( $user_answer_content as $_user_answer ) {
 
                                 if( 'multi-line' == Sensei()->question->get_question_type( $question->ID ) ){
-
-                                    $_user_answer = htmlspecialchars_decode( nl2br( esc_html($_user_answer) ) );
-
+                                    $_user_answer = htmlspecialchars_decode( nl2br( $_user_answer ) );
                                 }
 
-								echo apply_filters( 'sensei_answer_text', $_user_answer ) . "<br>";
+								echo esc_html( apply_filters( 'sensei_answer_text', $_user_answer ) ) . "<br>";
 							}
 						?></p>
 						<div class="right-answer">

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3896,7 +3896,7 @@ class Sensei_Lesson {
      */
     public static function limit_archive_content ( $content ){
 
-        if( is_archive('lesson') && Sensei()->settings->get('access_permission') ){
+        if( is_post_type_archive('lesson') && Sensei()->settings->get('access_permission') ){
 
             return wp_trim_words( $content, $num_words = 30, $more = '…' );
         }

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 class Sensei_Lesson {
 	public $token;
 	public $meta_fields;
+	public $allowed_html;
 
 	/**
 	 * Constructor.
@@ -27,6 +28,22 @@ class Sensei_Lesson {
 		$this->meta_fields = array( 'lesson_prerequisite', 'lesson_course', 'lesson_preview', 'lesson_length', 'lesson_complexity', 'lesson_video_embed' );
 
         $this->question_order = '';
+
+		$this->allowed_html = array(
+			'embed'  => array(),
+			'iframe' => array(
+				'width'           => array(),
+				'height'          => array(),
+				'src'             => array(),
+				'frameborder'     => array(),
+				'allowfullscreen' => array(),
+			),
+			'video'  => array(
+				'width'  => array(),
+				'height' => array(),
+				'src'    => array(),
+			),
+		);
 
 		// Admin actions
 		if ( is_admin() ) {
@@ -150,9 +167,9 @@ class Sensei_Lesson {
 	public function lesson_info_meta_box_content () {
 		global $post;
 
-		$lesson_length = get_post_meta( $post->ID, '_lesson_length', true );
-		$lesson_complexity = get_post_meta( $post->ID, '_lesson_complexity', true );
-		$complexity_array = $this->lesson_complexities();
+		$lesson_length      = get_post_meta( $post->ID, '_lesson_length', true );
+		$lesson_complexity  = get_post_meta( $post->ID, '_lesson_complexity', true );
+		$complexity_array   = $this->lesson_complexities();
 		$lesson_video_embed = get_post_meta( $post->ID, '_lesson_video_embed', true );
 
 		$html = '';
@@ -163,13 +180,13 @@ class Sensei_Lesson {
 		$html .= '<p><label for="lesson_complexity">' . __( 'Lesson Complexity', 'woothemes-sensei' ) . ': </label>';
 		$html .= '<select id="lesson-complexity-options" name="lesson_complexity" class="chosen_select lesson-complexity-select">';
 			$html .= '<option value="">' . __( 'None', 'woothemes-sensei' ) . '</option>';
-			foreach ($complexity_array as $key => $value){
+			foreach ( $complexity_array as $key => $value ){
 				$html .= '<option value="' . esc_attr( $key ) . '"' . selected( $key, $lesson_complexity, false ) . '>' . esc_html( $value ) . '</option>' . "\n";
 			} // End For Loop
 		$html .= '</select></p>' . "\n";
 
 		$html .= '<p><label for="lesson_video_embed">' . __( 'Video Embed Code', 'woothemes-sensei' ) . ':</label><br/>' . "\n";
-		$html .= '<textarea rows="5" cols="50" name="lesson_video_embed" tabindex="6" id="course-video-embed">' . $lesson_video_embed . '</textarea></p>' . "\n";
+		$html .= '<textarea rows="5" cols="50" name="lesson_video_embed" tabindex="6" id="course-video-embed">' . wp_kses( $lesson_video_embed, $this->allowed_html ) . '</textarea></p>' . "\n";
 		$html .= '<p>' .  __( 'Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above.', 'woothemes-sensei' ) . '</p>';
 
 		echo $html;
@@ -497,7 +514,7 @@ class Sensei_Lesson {
 
 		// Get the posted data and sanitize it for use as an HTML class.
 		if ( 'lesson_video_embed' == $post_key) {
-			$new_meta_value = esc_html( $_POST[$post_key] );
+			$new_meta_value = wp_kses( $_POST[ $post_key ], $this->allowed_html );
 		} else {
 			$new_meta_value = ( isset( $_POST[$post_key] ) ? sanitize_html_class( $_POST[$post_key] ) : '' );
 		} // End If Statement
@@ -661,7 +678,7 @@ class Sensei_Lesson {
 			if ( 0 == $quiz_id ) {
 				$html .= '<p>';
 					// Default message and Add a Quiz button
-					$html .= esc_html( __( 'Once you have saved your lesson you will be able to add questions.', 'woothemes-sensei' ) );
+					$html .=  __( 'Once you have saved your lesson you will be able to add questions.', 'woothemes-sensei' );
 				$html .= '</p>';
 			}
 
@@ -692,7 +709,7 @@ class Sensei_Lesson {
 			}
 
 			// Inner DIV
-			$html .= '<div id="add-quiz-metadata"' . $quiz_class . '>';
+			$html .= '<div id="add-quiz-metadata"' .  $quiz_class . '>';
 
 				// Quiz ID
 				$html .= '<input type="hidden" name="quiz_id" id="quiz_id" value="' . esc_attr( $quiz_id ) . '" />';
@@ -700,14 +717,14 @@ class Sensei_Lesson {
 				// Default Message
 				if ( 0 == $quiz_id ) {
 					$html .= '<p class="save-note">';
-						$html .= esc_html( __( 'Please save your lesson in order to add questions to your quiz.', 'woothemes-sensei' ) );
+						$html .= __( 'Please save your lesson in order to add questions to your quiz.', 'woothemes-sensei' );
 					$html .= '</p>';
 				} // End If Statement
 
 			$html .= '</div>';
 
 			// Question Container DIV
-			$html .= '<div id="add-question-main"' . $quiz_class . '>';
+			$html .= '<div id="add-question-main"' . esc_attr( $quiz_class ) . '>';
 				// Inner DIV
 				$html .= '<div id="add-question-metadata">';
 
@@ -753,7 +770,7 @@ class Sensei_Lesson {
 						$this->question_order = '';
 					}
 
-					$html .= '<input type="hidden" id="question-order" name="question-order" value="' . $this->question_order . '" />';
+					$html .= '<input type="hidden" id="question-order" name="question-order" value="' . esc_attr( $this->question_order ) . '" />';
 
 				$html .= '</div>';
 
@@ -837,6 +854,7 @@ class Sensei_Lesson {
 
 		if( $question_id ) {
 
+            $question_grade ='';
 			if( $question_type != 'category' ) {
 
 				$question_grade = Sensei()->question->get_question_grade( $question_id );
@@ -884,18 +902,18 @@ class Sensei_Lesson {
 				if( ! $question_type ) { $question_type = 'multiple-choice'; }
 			}
 
-			$html .= '<tbody class="' . $question_class . '">';
+			$html .= '<tbody class="' . esc_attr( $question_class ) . '">';
 
 				if( 'quiz' == $context ) {
 					$html .= '<tr>';
 						if( $question_type != 'category' ) {
 							$question = get_post( $question_id );
-							$html .= '<td class="table-count question-number question-count-column"><span class="number">' . $question_counter . '</span></td>';
+							$html .= '<td class="table-count question-number question-count-column"><span class="number">' . esc_html( $question_counter ) . '</span></td>';
 							$html .= '<td>' . esc_html( $question->post_title ) . '</td>';
 							$html .= '<td class="question-grade-column">' . esc_html( $question_grade ) . '</td>';
 							$question_types_filtered = ucwords( str_replace( array( '-', 'boolean' ), array( ' ', __( 'True/False', 'woothemes-sensei' ) ), $question_type ) );
 							$html .= '<td>' . esc_html( $question_types_filtered ) . '</td>';
-							$html .= '<td><a title="' . esc_attr( __( 'Edit Question', 'woothemes-sensei' ) ) . '" href="#question_' . $question_counter .'" class="question_table_edit">' . esc_html( __( 'Edit', 'woothemes-sensei' ) ) . '</a> <a title="' . esc_attr( __( 'Remove Question', 'woothemes-sensei' ) ) . '" href="#add-question-metadata" class="question_table_delete">' . esc_html( __( 'Remove', 'woothemes-sensei' ) ) . '</a></td>';
+							$html .= '<td><a title="' . esc_attr__( 'Edit Question', 'woothemes-sensei' )  . '" href="#question_' . esc_attr( $question_counter ) .'" class="question_table_edit">' . esc_html__( 'Edit', 'woothemes-sensei' ) . '</a> <a title="' . esc_attr__( 'Remove Question', 'woothemes-sensei' ) . '" href="#add-question-metadata" class="question_table_delete">' . esc_html__( 'Remove', 'woothemes-sensei' ) . '</a></td>';
 
 						} else {
 
@@ -907,11 +925,11 @@ class Sensei_Lesson {
 							}
 							$row_title = sprintf( __( 'Selected from \'%1$s\' ', 'woothemes-sensei' ), $multiple_data[0] );
 
-							$html .= '<td class="table-count question-number question-count-column"><span class="number hidden">' . $question_counter . '</span><span class="hidden total-number">' . $multiple_data[1] . '</span><span class="row-numbers">' . esc_html( $row_numbers ) . '</span></td>';
+							$html .= '<td class="table-count question-number question-count-column"><span class="number hidden">' . esc_html( $question_counter ) . '</span><span class="hidden total-number">' . esc_html( $multiple_data[1] ) . '</span><span class="row-numbers">' . esc_html( $row_numbers ) . '</span></td>';
 							$html .= '<td>' . esc_html( $row_title ) . '</td>';
 							$html .= '<td class="question-grade-column"></td>';
-							$html .= '<td><input type="hidden" name="question_id" class="row_question_id" id="question_' . $question_counter . '_id" value="' . $question_id . '" /></td>';
-							$html .= '<td><a title="' . esc_attr( __( 'Edit Question', 'woothemes-sensei' ) ) . '" href="#question_' . $question_counter .'" class="question_table_edit" style="visibility:hidden;">' . esc_html( __( 'Edit', 'woothemes-sensei' ) ) . '</a> <a title="' . esc_attr( __( 'Remove Question(s)', 'woothemes-sensei' ) ) . '" href="#add-question-metadata" class="question_multiple_delete" rel="' . $question_id . '">' . esc_html( __( 'Remove', 'woothemes-sensei' ) ) . '</a></td>';
+							$html .= '<td><input type="hidden" name="question_id" class="row_question_id" id="question_' . esc_attr( $question_counter ) . '_id" value="' . esc_attr( $question_id ) . '" /></td>';
+							$html .= '<td><a title="' . esc_attr__( 'Edit Question', 'woothemes-sensei' ) . '" href="#question_' . esc_attr( $question_counter ) .'" class="question_table_edit" style="visibility:hidden;">' . esc_html__( 'Edit', 'woothemes-sensei' ) . '</a> <a title="' . esc_attr__( 'Remove Question(s)', 'woothemes-sensei' )  . '" href="#add-question-metadata" class="question_multiple_delete" rel="' . esc_attr( $question_id ) . '">' . esc_html__( 'Remove', 'woothemes-sensei' ) . '</a></td>';
 
 						}
 					$html .= '</tr>';
@@ -927,55 +945,55 @@ class Sensei_Lesson {
 					$question = get_post( $question_id );
 					$html .= '<tr class="question-quick-edit ' . esc_attr( $edit_class ) . '">';
 						$html .= '<td colspan="5">';
-							$html .= '<span class="hidden question_original_counter">' . $question_counter . '</span>';
+							$html .= '<span class="hidden question_original_counter">' . esc_attr( $question_counter ) . '</span>';
 					    	$html .= '<div class="question_required_fields">';
 
 						    	// Question title
 						    	$html .= '<div>';
-							    	$html .= '<label for="question_' . $question_counter . '">' . __( 'Question:', 'woothemes-sensei' ) . '</label> ';
-							    	$html .= '<input type="text" id="question_' . $question_counter . '" name="question" value="' . esc_attr( htmlspecialchars( $question->post_title ) ) . '" size="25" class="widefat" />';
+							    	$html .= '<label for="question_' . esc_attr( $question_counter ) . '">' . __( 'Question:', 'woothemes-sensei' ) . '</label> ';
+							    	$html .= '<input type="text" id="question_' . esc_attr( $question_counter ) . '" name="question" value="' . esc_attr( htmlspecialchars( $question->post_title ) ) . '" size="25" class="widefat" />';
 						    	$html .= '</div>';
 
 						    	// Question description
 						    	$html .= '<div>';
-							    	$html .= '<label for="question_' . $question_counter . '_desc">' . __( 'Question Description (optional):', 'woothemes-sensei' ) . '</label> ';
+							    	$html .= '<label for="question_' . esc_attr( $question_counter ) . '_desc">' . __( 'Question Description (optional):', 'woothemes-sensei' ) . '</label> ';
 						    	$html .= '</div>';
-							    	$html .= '<textarea id="question_' . $question_counter . '_desc" name="question_description" class="widefat" rows="4">' . esc_textarea( $question->post_content ) . '</textarea>';
+							    	$html .= '<textarea id="question_' . esc_attr( $question_counter ) . '_desc" name="question_description" class="widefat" rows="4">' . esc_textarea( $question->post_content ) . '</textarea>';
 
 						    	// Question grade
 						    	$html .= '<div>';
-							    	$html .= '<label for="question_' . $question_counter . '_grade">' . __( 'Question grade:', 'woothemes-sensei' ) . '</label> ';
-							    	$html .= '<input type="number" id="question_' . $question_counter . '_grade" class="question_grade small-text" name="question_grade" min="0" value="' . $question_grade . '" />';
+							    	$html .= '<label for="question_' . esc_attr( $question_counter ) . '_grade">' . __( 'Question grade:', 'woothemes-sensei' ) . '</label> ';
+							    	$html .= '<input type="number" id="question_' . esc_attr( $question_counter ) . '_grade" class="question_grade small-text" name="question_grade" min="0" value="' . esc_attr( $question_grade ) . '" />';
 						    	$html .= '</div>';
 
 						    	// Random order
 						    	if( $question_type == 'multiple-choice' ) {
 						    		$html .= '<div>';
-						    			$html .= '<label for="' . $question_counter . '_random_order"><input type="checkbox" name="random_order" class="random_order" id="' . $question_counter . '_random_order" value="yes" ' . checked( $random_order, 'yes', false ) . ' /> ' . __( 'Randomise answer order', 'woothemes-sensei' ) . '</label>';
+						    			$html .= '<label for="' . esc_attr( $question_counter ) . '_random_order"><input type="checkbox" name="random_order" class="random_order" id="' . esc_attr( $question_counter ) . '_random_order" value="yes" ' . checked( $random_order, 'yes', false ) . ' /> ' . __( 'Randomise answer order', 'woothemes-sensei' ) . '</label>';
 						    		$html .= '</div>';
 						    	}
 
 						    	// Question media
 						    	$html .= '<div>';
-							    	$html .= '<label for="question_' . $question_counter . '_media_button">' . __( 'Question media:', 'woothemes-sensei' ) . '</label><br/>';
-							    	$html .= '<button id="question_' . $question_counter . '_media_button" class="upload_media_file_button button-secondary" data-uploader_title="' . __( 'Add file to question', 'woothemes-sensei' ) . '" data-uploader_button_text="' . __( 'Add to question', 'woothemes-sensei' ) . '">' . $question_media_add_button . '</button>';
-							    	$html .= '<button id="question_' . $question_counter . '_media_button_delete" class="delete_media_file_button button-secondary ' . $question_media_delete_class . '">' . __( 'Delete file', 'woothemes-sensei' ) . '</button><br/>';
-							    	$html .= '<span id="question_' . $question_counter . '_media_link" class="question_media_link ' . $question_media_link_class . '">' . $question_media_link . '</span>';
-							    	$html .= '<br/><img id="question_' . $question_counter . '_media_preview" class="question_media_preview ' . $question_media_thumb_class . '" src="' . $question_media_thumb . '" /><br/>';
-							    	$html .= '<input type="hidden" id="question_' . $question_counter . '_media" class="question_media" name="question_media" value="' . $question_media . '" />';
+							    	$html .= '<label for="question_' . esc_attr( $question_counter ) . '_media_button">' . __( 'Question media:', 'woothemes-sensei' ) . '</label><br/>';
+							    	$html .= '<button id="question_' . esc_attr( $question_counter ) . '_media_button" class="upload_media_file_button button-secondary" data-uploader_title="' . esc_attr__( 'Add file to question', 'woothemes-sensei' ) . '" data-uploader_button_text="' . esc_attr__( 'Add to question', 'woothemes-sensei' ) . '">' . esc_html($question_media_add_button) . '</button>';
+							    	$html .= '<button id="question_' . esc_attr( $question_counter ) . '_media_button_delete" class="delete_media_file_button button-secondary ' . esc_attr( $question_media_delete_class ) . '">' . __( 'Delete file', 'woothemes-sensei' ) . '</button><br/>';
+							    	$html .= '<span id="question_' . esc_attr( $question_counter ) . '_media_link" class="question_media_link ' . esc_attr( $question_media_link_class ) . '">' . esc_html( $question_media_link ). '</span>';
+							    	$html .= '<br/><img id="question_' . esc_attr( $question_counter ) . '_media_preview" class="question_media_preview ' . esc_attr( $question_media_thumb_class ) . '" src="' . esc_html( $question_media_thumb ) . '" /><br/>';
+							    	$html .= '<input type="hidden" id="question_' . esc_attr( $question_counter ) . '_media" class="question_media" name="question_media" value="' . esc_attr( $question_media ) . '" />';
 						    	$html .= '</div>';
 
 						    $html .= '</div>';
 
 						    $html .= $this->quiz_panel_question_field( $question_type, $question_id, $question_counter );
 
-						    $html .= '<input type="hidden" id="question_' . $question_counter . '_question_type" class="question_type" name="question_type" value="' . $question_type . '" />';
-							$html .= '<input type="hidden" name="question_id" class="row_question_id" id="question_' . $question_counter . '_id" value="' . $question_id . '" />';
+						    $html .= '<input type="hidden" id="question_' . esc_attr( $question_counter ) . '_question_type" class="question_type" name="question_type" value="' . esc_attr( $question_type ) . '" />';
+							$html .= '<input type="hidden" name="question_id" class="row_question_id" id="question_' . esc_attr( $question_counter ) . '_id" value="' . esc_attr( $question_id ). '" />';
 
 							if( 'quiz' == $context ) {
 					    		$html .= '<div class="update-question">';
-						    		$html .= '<a href="#question-edit-cancel" class="lesson_question_cancel" title="' . esc_attr( __( 'Cancel', 'woothemes-sensei' ) ) . '">' . __( 'Cancel', 'woothemes-sensei' ) . '</a> ';
-						    		$html .= '<a title="' . esc_attr( __( 'Update Question', 'woothemes-sensei' ) ) . '" href="#add-question-metadata" class="question_table_save button button-highlighted">' . esc_html( __( 'Update', 'woothemes-sensei' ) ) . '</a>';
+						    		$html .= '<a href="#question-edit-cancel" class="lesson_question_cancel" title="' . esc_attr__( 'Cancel', 'woothemes-sensei' ) . '">' . __( 'Cancel', 'woothemes-sensei' ) . '</a> ';
+						    		$html .= '<a title="' . esc_attr__( 'Update Question', 'woothemes-sensei' ) . '" href="#add-question-metadata" class="question_table_save button button-highlighted">' . esc_html__( 'Update', 'woothemes-sensei' ) . '</a>';
 					    		$html .= '</div>';
 					    	}
 
@@ -1001,10 +1019,10 @@ class Sensei_Lesson {
 
 			if( 'quiz' == $context ) {
 	    		$html .= '<h2 class="nav-tab-wrapper add-question-tabs">';
-	    			$html .= '<a id="tab-new" class="nav-tab nav-tab-active">' . __( 'New Question'  , 'woothemes-sensei' ) . '</a>';
-	    			$html .= '<a id="tab-existing" class="nav-tab">' . __( 'Existing Questions'  , 'woothemes-sensei' ) . '</a>';
+	    			$html .= '<a id="tab-new" class="nav-tab nav-tab-active">' . esc_html__( 'New Question'  , 'woothemes-sensei' ) . '</a>';
+	    			$html .= '<a id="tab-existing" class="nav-tab">' . esc_html__( 'Existing Questions'  , 'woothemes-sensei' ) . '</a>';
                     if ( ! empty( $question_cats ) && ! is_wp_error( $question_cats )  && ! Sensei()->teacher->is_admin_teacher() ) {
-	    				$html .= '<a id="tab-multiple" class="nav-tab">' . __( 'Category Questions'  , 'woothemes-sensei' ) . '</a>';
+	    				$html .= '<a id="tab-multiple" class="nav-tab">' . esc_html__( 'Category Questions'  , 'woothemes-sensei' ) . '</a>';
 	    			}
 	    		$html .= '</h2>';
 	    	}
@@ -1012,24 +1030,24 @@ class Sensei_Lesson {
 	    	$html .= '<div class="tab-content" id="tab-new-content">';
 
 	    		if( 'quiz' == $context ) {
-	    			$html .= '<p><em>' . sprintf( __( 'Add a new question to this quiz - your question will also be added to the %1$squestion bank%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'edit.php?post_type=question' ) . '">', '</a>' ) . '</em></p>';
+	    			$html .= '<p><em>' . sprintf( __( 'Add a new question to this quiz - your question will also be added to the %1$squestion bank%2$s.', 'woothemes-sensei' ), '<a href="' . esc_url( admin_url( 'edit.php?post_type=question' ) ) . '">', '</a>' ) . '</em></p>';
 	    		}
 
 				$html .= '<div class="question">';
 					$html .= '<div class="question_required_fields">';
 
 						// Question title
-						$html .= '<p><label>' . __( 'Question:'  , 'woothemes-sensei' ) . '</label> ';
+						$html .= '<p><label>' . esc_html__( 'Question:'  , 'woothemes-sensei' ) . '</label> ';
 	  					$html .= '<input type="text" id="add_question" name="question" value="" size="25" class="widefat" /></p>';
 
 						// Question description
 						$html .= '<p>';
-							$html .= '<label for="question_desc">' . __( 'Question Description (optional):', 'woothemes-sensei' ) . '</label> ';
+							$html .= '<label for="question_desc">' . esc_html__( 'Question Description (optional):', 'woothemes-sensei' ) . '</label> ';
 						$html .= '</p>';
 						$html .= '<textarea id="question_desc" name="question_description" class="widefat" rows="4"></textarea>';
 
 	  					// Question type
-						$html .= '<p><label>' . __( 'Question Type:' , 'woothemes-sensei' ) . '</label> ';
+						$html .= '<p><label>' . esc_html__( 'Question Type:' , 'woothemes-sensei' ) . '</label> ';
 						$html .= '<select id="add-question-type-options" name="question_type" class="chosen_select widefat question-type-select">' . "\n";
 							foreach ( $question_types as $type => $label ) {
 								$html .= '<option value="' . esc_attr( $type ) . '">' . esc_html( $label ) . '</option>' . "\n";
@@ -1039,9 +1057,9 @@ class Sensei_Lesson {
 						// Question category
 						if( 'quiz' == $context ) {
 							if ( ! empty( $question_cats ) && ! is_wp_error( $question_cats ) ) {
-								$html .= '<p><label>' . __( 'Question Category:' , 'woothemes-sensei' ) . '</label> ';
+								$html .= '<p><label>' . esc_html__( 'Question Category:' , 'woothemes-sensei' ) . '</label> ';
 								$html .= '<select id="add-question-category-options" name="question_category" class="chosen_select widefat question-category-select">' . "\n";
-								$html .= '<option value="">' . __( 'None', 'woothemes-sensei' ) . '</option>' . "\n";
+								$html .= '<option value="">' . esc_html__( 'None', 'woothemes-sensei' ) . '</option>' . "\n";
 								foreach( $question_cats as $cat ) {
 									$html .= '<option value="' . esc_attr( $cat->term_id ) . '">' . esc_html( $cat->name ) . '</option>';
 								} // End For Loop
@@ -1050,19 +1068,19 @@ class Sensei_Lesson {
 						}
 
 	  					// Question grade
-						$html .= '<p><label>' . __( 'Question Grade:'  , 'woothemes-sensei' ) . '</label> ';
+						$html .= '<p><label>' . esc_html__( 'Question Grade:'  , 'woothemes-sensei' ) . '</label> ';
 						$html .= '<input type="number" id="add-question-grade" name="question_grade" class="small-text" min="0" value="1" /></p>' . "\n";
 
 						// Random order
 						$html .= '<p class="add_question_random_order">';
-			    			$html .= '<label for="add_random_order"><input type="checkbox" name="random_order" class="random_order" id="add_random_order" value="yes" checked="checked" /> ' . __( 'Randomise answer order', 'woothemes-sensei' ) . '</label>';
+			    			$html .= '<label for="add_random_order"><input type="checkbox" name="random_order" class="random_order" id="add_random_order" value="yes" checked="checked" /> ' . esc_html__( 'Randomise answer order', 'woothemes-sensei' ) . '</label>';
 			    		$html .= '</p>';
 
 			    		// Question media
 						$html .= '<p>';
-					    	$html .= '<label for="question_add_new_media_button">' . __( 'Question media:', 'woothemes-sensei' ) . '</label><br/>';
-					    	$html .= '<button id="question_add_new_media_button" class="upload_media_file_button button-secondary" data-uploader_title="' . __( 'Add file to question', 'woothemes-sensei' ) . '" data-uploader_button_text="' . __( 'Add to question', 'woothemes-sensei' ) . '">' . __( 'Add file', 'woothemes-sensei' ) . '</button>';
-					    	$html .= '<button id="question_add_new_media_button_delete" class="delete_media_file_button button-secondary hidden">' . __( 'Delete file', 'woothemes-sensei' ) . '</button><br/>';
+					    	$html .= '<label for="question_add_new_media_button">' . esc_html__( 'Question media:', 'woothemes-sensei' ) . '</label><br/>';
+					    	$html .= '<button id="question_add_new_media_button" class="upload_media_file_button button-secondary" data-uploader_title="' . esc_attr__( 'Add file to question', 'woothemes-sensei' ) . '" data-uploader_button_text="' . esc_attr__( 'Add to question', 'woothemes-sensei' ) . '">' . esc_html__( 'Add file', 'woothemes-sensei' ) . '</button>';
+					    	$html .= '<button id="question_add_new_media_button_delete" class="delete_media_file_button button-secondary hidden">' . esc_html__( 'Delete file', 'woothemes-sensei' ) . '</button><br/>';
 					    	$html .= '<span id="question_add_new_media_link" class="question_media_link hidden"></span>';
 					    	$html .= '<br/><img id="question_add_new_media_preview" class="question_media_preview hidden" src="" /><br/>';
 					    	$html .= '<input type="hidden" id="question_add_new_media" class="question_media" name="question_media" value="" />';
@@ -1077,7 +1095,7 @@ class Sensei_Lesson {
 
 				if( 'quiz' == $context ) {
 					$html .= '<div class="add-question">';
-			    		$html .= '<a title="' . esc_attr( __( 'Add Question', 'woothemes-sensei' ) ) . '" href="#add-question-metadata" class="add_question_save button button-primary button-highlighted">' . esc_html( __( 'Add Question', 'woothemes-sensei' ) ) . '</a>';
+			    		$html .= '<a title="' . esc_attr__( 'Add Question', 'woothemes-sensei' ) . '" href="#add-question-metadata" class="add_question_save button button-primary button-highlighted">' . esc_html__( 'Add Question', 'woothemes-sensei' ) . '</a>';
 		    		$html .= '</div>';
 		    	}
 
@@ -1087,7 +1105,7 @@ class Sensei_Lesson {
 
 			    $html .= '<div class="tab-content hidden" id="tab-existing-content">';
 
-			    	$html .= '<p><em>' . sprintf( __( 'Add an existing question to this quiz from the %1$squestion bank%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'edit.php?post_type=question' ) . '">', '</a>' ) . '</em></p>';
+			    	$html .= '<p><em>' . sprintf( __( 'Add an existing question to this quiz from the %1$squestion bank%2$s.', 'woothemes-sensei' ), '<a href="' . esc_url( admin_url( 'edit.php?post_type=question' ) ) . '">', '</a>' ) . '</em></p>';
 
 			    	$html .= '<div id="existing-filters" class="alignleft actions">
 			    				<select id="existing-status">
@@ -1107,8 +1125,8 @@ class Sensei_Lesson {
 										$html .= '<option value="' . esc_attr( $cat->slug ) . '">' . esc_html( $cat->name ) . '</option>';
 									}
     				$html .= '</select>
-    							<input type="text" id="existing-search" placeholder="' . __( 'Search', 'woothemes-sensei' ) . '" />
-    							<a class="button" id="existing-filter-button">' . __( 'Filter', 'woothemes-sensei' ) . '</a>
+    							<input type="text" id="existing-search" placeholder="' . esc_attr__( 'Search', 'woothemes-sensei' ) . '" />
+    							<a class="button" id="existing-filter-button">' . esc_html__( 'Filter', 'woothemes-sensei' ) . '</a>
 			    			</div>';
 
 			    	$html .= '<table id="existing-table" class="widefat">';
@@ -1154,7 +1172,7 @@ class Sensei_Lesson {
 			    	$html .= '</div>';
 
 			    	$html .= '<div class="existing-actions">';
-			    		$html .= '<a title="' . esc_attr( __( 'Add Selected Question(s)', 'woothemes-sensei' ) ) . '" class="add_existing_save button button-primary button-highlighted">' . esc_html( __( 'Add Selected Question(s)', 'woothemes-sensei' ) ) . '</a></p>';
+			    		$html .= '<a title="' . esc_attr__( 'Add Selected Question(s)', 'woothemes-sensei' ) . '" class="add_existing_save button button-primary button-highlighted">' . esc_html__( 'Add Selected Question(s)', 'woothemes-sensei' ) . '</a></p>';
 			    	$html .= '</div>';
 
 			    $html .= '</div>';
@@ -1180,7 +1198,7 @@ class Sensei_Lesson {
 			}
 
 		$html .= '</div>';
-		
+
 		/**
 		 * Filter the quiz panel add html
 		 *
@@ -1190,7 +1208,7 @@ class Sensei_Lesson {
 		 * @param string	$context
 		 */
 		$html = apply_filters( 'sensei_quiz_panel_add', $html, $context );
-		
+
 		return $html;
 	}
 
@@ -1398,7 +1416,7 @@ class Sensei_Lesson {
 
 			switch ( $question_type ) {
 				case 'multiple-choice':
-					$html .= '<div class="question_default_fields multiple-choice-answers ' . str_replace( ' hidden', '', $question_class ) . '">';
+					$html .= '<div class="question_default_fields multiple-choice-answers ' . esc_attr( str_replace( ' hidden', '', $question_class ) ) . '">';
 
 						$right_answers = (array) $right_answer;
 						// Calculate total right answers available (defaults to 1)
@@ -1413,7 +1431,7 @@ class Sensei_Lesson {
 							if ( !isset( $right_answers[ $i ] ) ) { $right_answers[ $i ] = ''; }
 							$right_answer_id = $this->get_answer_id( $right_answers[ $i ] );
 							// Right Answer
-							$right_answer = '<label class="answer" for="question_' . $question_counter . '_right_answer_' . $i . '"><span>' . __( 'Right:' , 'woothemes-sensei' ) . '</span> <input rel="' . esc_attr( $right_answer_id ) . '" type="text" id="question_' . $question_counter . '_right_answer_' . $i . '" name="question_right_answers[]" value="' . esc_attr( $right_answers[ $i ] ) . '" size="25" class="question_answer widefat" /> <a class="remove_answer_option"></a></label>';
+							$right_answer = '<label class="answer" for="question_' . esc_attr( $question_counter ) . '_right_answer_' . $i . '"><span>' . __( 'Right:' , 'woothemes-sensei' ) . '</span> <input rel="' . esc_attr( $right_answer_id ) . '" type="text" id="question_' . esc_attr( $question_counter ). '_right_answer_' . esc_attr( $i ) . '" name="question_right_answers[]" value="' . esc_attr( $right_answers[ $i ] ) . '" size="25" class="question_answer widefat" /> <a class="remove_answer_option"></a></label>';
 							if( $question_id ) {
 								$answers[ $right_answer_id ] = $right_answer;
 							} else {
@@ -1434,8 +1452,8 @@ class Sensei_Lesson {
                         foreach ( $wrong_answers as $i => $answer ){
 
                             $answer_id = $this->get_answer_id( $answer );
-                            $wrong_answer = '<label class="answer" for="question_' . $question_counter . '_wrong_answer_' . $i . '"><span>' . __( 'Wrong:' , 'woothemes-sensei' ) ;
-                            $wrong_answer .= '</span> <input rel="' . esc_attr( $answer_id ) . '" type="text" id="question_' . $question_counter . '_wrong_answer_' . $i ;
+                            $wrong_answer = '<label class="answer" for="question_' .esc_attr( $question_counter ) . '_wrong_answer_' . esc_attr( $i ) . '"><span>' . __( 'Wrong:' , 'woothemes-sensei' ) ;
+                            $wrong_answer .= '</span> <input rel="' . esc_attr( $answer_id ) . '" type="text" id="question_' . esc_attr( $question_counter ) . '_wrong_answer_' . esc_attr( $i ) ;
                             $wrong_answer .= '" name="question_wrong_answers[]" value="' . esc_attr( $answer ) . '" size="25" class="question_answer widefat" /> <a class="remove_answer_option"></a></label>';
                             if( $question_id ) {
 
@@ -1470,13 +1488,13 @@ class Sensei_Lesson {
 				    		$html .= $answer;
 				    	}
 
-				    	$html .= '<input type="hidden" class="answer_order" name="answer_order" value="' . $answer_order_string . '" />';
-				    	$html .= '<span class="hidden right_answer_count">' . $total_right . '</span>';
-				    	$html .= '<span class="hidden wrong_answer_count">' . $total_wrong . '</span>';
+				    	$html .= '<input type="hidden" class="answer_order" name="answer_order" value="' . esc_attr( $answer_order_string ) . '" />';
+				    	$html .= '<span class="hidden right_answer_count">' . esc_html( $total_right ). '</span>';
+				    	$html .= '<span class="hidden wrong_answer_count">' . esc_html($total_wrong) . '</span>';
 
 				    	$html .= '<div class="add_answer_options">';
-					    	$html .= '<a class="add_right_answer_option add_answer_option button" rel="' . $question_counter . '">' . __( 'Add right answer', 'woothemes-sensei' ) . '</a>';
-					    	$html .= '<a class="add_wrong_answer_option add_answer_option button" rel="' . $question_counter . '">' . __( 'Add wrong answer', 'woothemes-sensei' ) . '</a>';
+					    	$html .= '<a class="add_right_answer_option add_answer_option button" rel="' . esc_attr( $question_counter ) . '">' . __( 'Add right answer', 'woothemes-sensei' ) . '</a>';
+					    	$html .= '<a class="add_wrong_answer_option add_answer_option button" rel="' . esc_attr( $question_counter ) . '">' . __( 'Add wrong answer', 'woothemes-sensei' ) . '</a>';
 				    	$html .= '</div>';
 
                         $html .= $this->quiz_panel_question_feedback( $question_counter, $question_id , 'multiple-choice' );
@@ -1486,13 +1504,13 @@ class Sensei_Lesson {
 				case 'boolean':
 					$html .= '<div class="question_boolean_fields ' . $question_class . '">';
 						if( $question_id ) {
-							$field_name = 'question_' . $question_id . '_right_answer_boolean';
+							$field_name = 'question_' . esc_attr( $question_id ) . '_right_answer_boolean';
 						} else {
 							$field_name = 'question_right_answer_boolean';
 							$right_answer = 'true';
 						}
-						$html .= '<label for="question_' . $question_id . '_boolean_true"><input id="question_' . $question_id . '_boolean_true" type="radio" name="' . $field_name . '" value="true" '. checked( $right_answer, 'true', false ) . ' /> ' . __( 'True', 'woothemes-sensei' ) . '</label>';
-						$html .= '<label for="question_' . $question_id . '_boolean_false"><input id="question_' . $question_id . '_boolean_false" type="radio" name="' . $field_name . '" value="false" '. checked( $right_answer, 'false', false ) . ' /> ' . __( 'False', 'woothemes-sensei' ) . '</label>';
+						$html .= '<label for="question_' . esc_attr( $question_id ) . '_boolean_true"><input id="question_' . esc_attr( $question_id ) . '_boolean_true" type="radio" name="' . esc_attr( $field_name ) . '" value="true" '. checked( $right_answer, 'true', false ) . ' /> ' . __( 'True', 'woothemes-sensei' ) . '</label>';
+						$html .= '<label for="question_' . $question_id . '_boolean_false"><input id="question_' . esc_attr( $question_id ) . '_boolean_false" type="radio" name="' . esc_attr( $field_name )  . '" value="false" '. checked( $right_answer, 'false', false ) . ' /> ' . __( 'False', 'woothemes-sensei' ) . '</label>';
 
                     $html .= $this->quiz_panel_question_feedback( $question_counter, $question_id, 'boolean' );
 
@@ -1503,47 +1521,47 @@ class Sensei_Lesson {
 					if ( isset( $gapfill_array[0] ) ) { $gapfill_pre = $gapfill_array[0]; } else { $gapfill_pre = ''; }
 					if ( isset( $gapfill_array[1] ) ) { $gapfill_gap = $gapfill_array[1]; } else { $gapfill_gap = ''; }
 					if ( isset( $gapfill_array[2] ) ) { $gapfill_post = $gapfill_array[2]; } else { $gapfill_post = ''; }
-					$html .= '<div class="question_gapfill_fields ' . $question_class . '">';
+					$html .= '<div class="question_gapfill_fields ' . esc_attr( $question_class ) . '">';
 						// Fill in the Gaps
 						$html .= '<label>' . __( 'Text before the Gap:' , 'woothemes-sensei' ) . '</label> ';
-						$html .= '<input type="text" id="question_' . $question_counter . '_add_question_right_answer_gapfill_pre" name="add_question_right_answer_gapfill_pre" value="' . $gapfill_pre . '" size="25" class="widefat gapfill-field" />';
+						$html .= '<input type="text" id="question_' . esc_attr( $question_counter )  . '_add_question_right_answer_gapfill_pre" name="add_question_right_answer_gapfill_pre" value="' . esc_attr( $gapfill_pre ) . '" size="25" class="widefat gapfill-field" />';
 	  					$html .= '<label>' . __( 'The Gap:' , 'woothemes-sensei' ) . '</label> ';
-	  					$html .= '<input type="text" id="question_' . $question_counter . '_add_question_right_answer_gapfill_gap" name="add_question_right_answer_gapfill_gap" value="' . $gapfill_gap . '" size="25" class="widefat gapfill-field" />';
+	  					$html .= '<input type="text" id="question_' . esc_attr( $question_counter ) . '_add_question_right_answer_gapfill_gap" name="add_question_right_answer_gapfill_gap" value="' . esc_attr( $gapfill_gap ) . '" size="25" class="widefat gapfill-field" />';
 	  					$html .= '<label>' . __( 'Text after the Gap:' , 'woothemes-sensei' ) . '</label> ';
-	  					$html .= '<input type="text" id="question_' . $question_counter . '_add_question_right_answer_gapfill_post" name="add_question_right_answer_gapfill_post" value="' . $gapfill_post . '" size="25" class="widefat gapfill-field" />';
+	  					$html .= '<input type="text" id="question_' . esc_attr( $question_counter ) . '_add_question_right_answer_gapfill_post" name="add_question_right_answer_gapfill_post" value="' . esc_attr( $gapfill_post ) . '" size="25" class="widefat gapfill-field" />';
 	  					$html .= '<label>' . __( 'Preview:' , 'woothemes-sensei' ) . '</label> ';
-	  					$html .= '<p class="gapfill-preview">' . $gapfill_pre . '&nbsp;<u>' . $gapfill_gap . '</u>&nbsp;' . $gapfill_post . '</p>';
+	  					$html .= '<p class="gapfill-preview">' . esc_html( $gapfill_pre ) . '&nbsp;<u>' . esc_html( $gapfill_gap ) . '</u>&nbsp;' . esc_html( $gapfill_post ) . '</p>';
 	  				$html .= '</div>';
 				break;
 				case 'multi-line':
-					$html .= '<div class="question_multiline_fields ' . $question_class . '">';
+					$html .= '<div class="question_multiline_fields ' . esc_attr( $question_class ) . '">';
 						// Guides for grading
 						if( $question_counter ) {
-							$field_id = 'question_' . $question_counter . '_add_question_right_answer_multiline';
+							$field_id = 'question_' . esc_attr( $question_counter ) . '_add_question_right_answer_multiline';
 						} else {
 							$field_id = 'add_question_right_answer_multiline';
 						}
 						$html .= '<label>' . __( 'Guide/Teacher Notes for grading the answer' , 'woothemes-sensei' ) . '</label> ';
-						$html .= '<textarea id="' . $field_id . '" name="add_question_right_answer_multiline" rows="4" cols="40" class="widefat">' . $right_answer . '</textarea>';
+						$html .= '<textarea id="' . esc_attr( $field_id ) . '" name="add_question_right_answer_multiline" rows="4" cols="40" class="widefat">' . esc_textarea( $right_answer ) . '</textarea>';
 					$html .= '</div>';
 				break;
 				case 'single-line':
-					$html .= '<div class="question_singleline_fields ' . $question_class . '">';
+					$html .= '<div class="question_singleline_fields ' . esc_attr( $question_class ) . '">';
 						// Recommended Answer
 						if( $question_counter ) {
-							$field_id = 'question_' . $question_counter . '_add_question_right_answer_singleline';
+							$field_id = 'question_' . esc_attr( $question_counter ) . '_add_question_right_answer_singleline';
 						} else {
 							$field_id = 'add_question_right_answer_singleline';
 						}
 						$html .= '<label>' . __( 'Recommended Answer' , 'woothemes-sensei' ) . '</label> ';
-						$html .= '<input type="text" id="' . $field_id . '" name="add_question_right_answer_singleline" value="' . $right_answer . '" size="25" class="widefat" />';
+						$html .= '<input type="text" id="' . esc_attr( $field_id ) . '" name="add_question_right_answer_singleline" value="' . esc_attr( $right_answer ) . '" size="25" class="widefat" />';
 					$html .= '</div>';
 				break;
 				case 'file-upload':
-					$html .= '<div class="question_fileupload_fields ' . $question_class . '">';
+					$html .= '<div class="question_fileupload_fields ' . esc_attr( $question_class ) . '">';
 						if( $question_counter ) {
-							$right_field_id = 'question_' . $question_counter . '_add_question_right_answer_fileupload';
-							$wrong_field_id = 'question_' . $question_counter . '_add_question_wrong_answer_fileupload';
+							$right_field_id = 'question_' . esc_attr( $question_counter ) . '_add_question_right_answer_fileupload';
+							$wrong_field_id = 'question_' . esc_attr( $question_counter ) . '_add_question_wrong_answer_fileupload';
 						} else {
 							$right_field_id = 'add_question_right_answer_fileupload';
 							$wrong_field_id = 'add_question_wrong_answer_fileupload';
@@ -1554,11 +1572,11 @@ class Sensei_Lesson {
 							$wrong_answer = $wrong_answers[0];
 						}
 						$html .= '<label>' . __( 'Description for student explaining what needs to be uploaded' , 'woothemes-sensei' ) . '</label> ';
-						$html .= '<textarea id="' . $wrong_field_id . '" name="add_question_wrong_answer_fileupload" rows="4" cols="40" class="widefat">' . $wrong_answer . '</textarea>';
+						$html .= '<textarea id="' . esc_attr( $wrong_field_id ) . '" name="add_question_wrong_answer_fileupload" rows="4" cols="40" class="widefat">' . esc_textarea( $wrong_answer ) . '</textarea>';
 
 						// Guides for grading
 						$html .= '<label>' . __( 'Guide/Teacher Notes for grading the upload' , 'woothemes-sensei' ) . '</label> ';
-						$html .= '<textarea id="' . $right_field_id . '" name="add_question_right_answer_fileupload" rows="4" cols="40" class="widefat">' . $right_answer . '</textarea>';
+						$html .= '<textarea id="' . esc_attr( $right_field_id ) . '" name="add_question_right_answer_fileupload" rows="4" cols="40" class="widefat">' . esc_textarea( $right_answer ) . '</textarea>';
 					$html .= '</div>';
 				break;
 			}
@@ -1590,9 +1608,9 @@ class Sensei_Lesson {
 			$feedback = get_post_meta( $question_id, '_answer_feedback', true );
 		}
 
-		$html = '<p title="' . __( 'This feedback will be automatically displayed to the student once they have completed the quiz.', 'woothemes-sensei' ) . '">';
-		$html .= '<label for="' . $field_name . '">' . __( 'Answer Feedback' , 'woothemes-sensei' ) . ':</label>';
-		$html .= '<textarea id="' . $field_name . '" name="' . $field_name . '" rows="4" cols="40" class="answer_feedback widefat">' . $feedback . '</textarea>';
+		$html = '<p title="' . esc_attr__( 'This feedback will be automatically displayed to the student once they have completed the quiz.', 'woothemes-sensei' ) . '">';
+		$html .= '<label for="' . esc_attr( $field_name ) . '">' . __( 'Answer Feedback' , 'woothemes-sensei' ) . ':</label>';
+		$html .= '<textarea id="' . esc_attr( $field_name )  . '" name="' . esc_attr( $field_name )  . '" rows="4" cols="40" class="answer_feedback widefat">' . esc_textarea( $feedback ) . '</textarea>';
 		$html .= '</p>';
 
 		return $html;
@@ -1660,7 +1678,7 @@ class Sensei_Lesson {
 		if( $quiz_id ) {
 			$html .= $this->quiz_settings_panel( $lesson_id, $quiz_id );
 		} else {
-			$html .= '<p><em>' . __( 'There is no quiz for this lesson yet - please add one in the \'Quiz Questions\' box.', 'woothemes-sensei' ) . '</em></p>';
+			$html .= '<p><em>' . esc_html__( 'There is no quiz for this lesson yet - please add one in the \'Quiz Questions\' box.', 'woothemes-sensei' ) . '</em></p>';
 		}
 
 		echo $html;
@@ -1785,7 +1803,7 @@ class Sensei_Lesson {
 
 			// Load the lessons script
             wp_enqueue_media();
-			wp_enqueue_script( 'sensei-lesson-metadata', Sensei()->plugin_url . 'assets/js/lesson-metadata' . $suffix . '.js', array( 'jquery', 'sensei-core-select2' ,'jquery-ui-sortable' ), Sensei()->version, true );
+			wp_enqueue_script( 'sensei-lesson-metadata', Sensei()->plugin_url . 'assets/js/lesson-metadata' . $suffix . '.js', array( 'jquery', 'sensei-core-select2' ,'jquery-ui-sortable','underscore'), Sensei()->version, true );
 			wp_enqueue_script( 'sensei-lesson-chosen', Sensei()->plugin_url . 'assets/chosen/chosen.jquery' . $suffix . '.js', array( 'jquery' ), Sensei()->version, true );
 			wp_enqueue_script( 'sensei-chosen-ajax', Sensei()->plugin_url . 'assets/chosen/ajax-chosen.jquery' . $suffix . '.js', array( 'jquery', 'sensei-lesson-chosen' ), Sensei()->version, true );
 
@@ -1943,7 +1961,7 @@ class Sensei_Lesson {
 		// Question Save and Delete logic
 		if ( isset( $question_data['action'] ) && ( $question_data['action'] == 'delete' ) ) {
 			// Delete the Question
-			$return = $this->lesson_remove_question($question_data);
+			$return = $this->lesson_delete_question($question_data);
 		} else {
 			// Save the Question
 			if ( isset( $question_data['quiz_id'] ) && ( 0 < absint( $question_data['quiz_id'] ) ) ) {
@@ -2031,27 +2049,20 @@ class Sensei_Lesson {
 		} // End If Statement
 
 		if( ! wp_verify_nonce( $nonce, 'lesson_remove_multiple_questions_nonce' )
-        || ! current_user_can( 'edit_lessons' ) || ! isset( $_POST['data'] ) ) {
+        || ! current_user_can( 'edit_lessons' ) ) {
 			die('');
 		} // End If Statement
 
 		// Parse POST data
+		$data = $_POST['data'];
 		$question_data = array();
-		parse_str( $_POST['data'], $question_data );
+		parse_str( $data, $question_data );
 
-		$question_id_to_remove      = $question_data['question_id'];
-		$quiz_id_to_be_removed_from = $question_data['quiz_id'];
-
-		// remove the question from the lesson quiz
-		$quizzes = get_post_meta( $question_id_to_remove, '_quiz_id', false );
-		foreach( $quizzes as $quiz_id ) {
-			if( $quiz_id == $quiz_id_to_be_removed_from  ) {
-				delete_post_meta( $question_id_to_remove, '_quiz_id', $quiz_id );
-				die( 'Deleted' );
-			}
+		if( is_array( $question_data ) ) {
+			wp_delete_post( $question_data['question_id'], true );
 		}
 
-		die('');
+		die( 'Deleted' );
 	}
 
 	public function get_question_category_limit() {
@@ -2510,36 +2521,33 @@ class Sensei_Lesson {
 
 
 	/**
-	 * Remove question from lesson
+	 * lesson_delete_question function.
 	 *
 	 * @access private
 	 * @param array $data (default: array())
 	 * @return boolean
 	 */
-	private function lesson_remove_question( $data = array() ) {
+	private function lesson_delete_question( $data = array() ) {
 
 		// Get which question to delete
 		$question_id = 0;
 		if ( isset( $data[ 'question_id' ] ) && ( 0 < absint( $data[ 'question_id' ] ) ) ) {
 			$question_id = absint( $data[ 'question_id' ] );
 		} // End If Statement
+		// Delete the question
+		if ( 0 < $question_id ) {
+			$quizzes = get_post_meta( $question_id, '_quiz_id', false );
 
-		if ( empty( $question_id ) ) {
-			return false;
-		}
-
-		// remove the question from the lesson quiz
-		$quizzes = get_post_meta( $question_id, '_quiz_id', false );
-
-		foreach( $quizzes as $quiz_id ) {
-			if( $quiz_id == $data['quiz_id'] ) {
-				delete_post_meta( $question_id, '_quiz_id', $quiz_id );
+			foreach( $quizzes as $quiz_id ) {
+				if( $quiz_id == $data['quiz_id'] ) {
+					delete_post_meta( $question_id, '_quiz_id', $quiz_id );
+				}
 			}
-		}
 
-		return true;
-
-	}
+			return true;
+		} // End If Statement
+		return false;
+	} // End lesson_delete_question()
 
 
 	/**
@@ -2812,28 +2820,25 @@ class Sensei_Lesson {
 
         // Save the questions that will be asked for the current user
         // this happens only once per user/quiz, unless the user resets the quiz
-        if( ! is_admin() && $user_lesson_status ){
+        if( ! is_admin() ){
 
-        	// user lesson status can return as an array.
-        	if ( is_array( $user_lesson_status ) ) {
-        		$comment_ID = $user_lesson_status[0]->comment_ID;
+            if( $user_lesson_status ) {
 
-	        } else {
-		        $comment_ID = $user_lesson_status->comment_ID;
-	        }
+                $questions_asked = get_comment_meta($user_lesson_status->comment_ID, 'questions_asked', true);
+                if ( empty($questions_asked) && $user_lesson_status) {
 
-            $questions_asked = get_comment_meta($comment_ID, 'questions_asked', true);
-            if ( empty( $questions_asked ) && $user_lesson_status) {
+                    $questions_asked = array();
+                    foreach ($questions as $question) {
 
-                $questions_asked = array();
+                        $questions_asked[] = $question->ID;
 
-                foreach ($questions as $question) {
-                    $questions_asked[] = $question->ID;
+                    }
+
+                    // save the questions asked id
+                    $questions_asked_csv = implode(',', $questions_asked);
+                    update_comment_meta($user_lesson_status->comment_ID, 'questions_asked', $questions_asked_csv);
+
                 }
-
-                // save the questions asked id
-                $questions_asked_csv = implode(',', $questions_asked);
-                update_comment_meta($comment_ID, 'questions_asked', $questions_asked_csv);
             }
         }
 
@@ -2903,7 +2908,7 @@ class Sensei_Lesson {
 		// Get Width and Height settings
 		if ( ( $width == '100' ) && ( $height == '100' ) ) {
 
-			if ( is_singular( 'lesson' ) || !empty( $lesson_id  ) ) {
+			if ( is_singular( 'lesson' ) ) {
 
 				if ( ! $widget && ! Sensei()->settings->settings[ 'lesson_single_image_enable' ] ) {
 
@@ -2934,34 +2939,25 @@ class Sensei_Lesson {
 
 		} // End If Statement
 
-		$img_element = '';
+		$img_url = '';
 
 		if ( has_post_thumbnail( $lesson_id ) ) {
 
-			// Get Featured Image
-			$img_element = get_the_post_thumbnail( $lesson_id, array( $width, $height ), array( 'class' => 'woo-image thumbnail alignleft') );
+   			// Get Featured Image
+   			$img_url = get_the_post_thumbnail( $lesson_id, array( $width, $height ), array( 'class' => 'woo-image thumbnail alignleft') );
 
  		} else {
 
  			// Display Image Placeholder if none
 			if ( Sensei()->settings->settings[ 'placeholder_images_enable' ] ) {
 
-                $img_element = apply_filters( 'sensei_lesson_placeholder_image_url', '<img src="http://placehold.it/' . $width . 'x' . $height . '" class="woo-image thumbnail alignleft" />' );
+                $img_url = apply_filters( 'sensei_lesson_placeholder_image_url', '<img src="http://placehold.it/' . $width . 'x' . $height . '" class="woo-image thumbnail alignleft" />' );
 
 			} // End If Statement
 
 		} // End If Statement
 
-		if ( is_singular( 'lesson' ) ) {
-
-			$html .=  $img_element;
-
-		} else {
-
-			$html .= '<a href="' . get_permalink( $lesson_id ) . '" title="' . esc_attr( get_post_field( 'post_title', $lesson_id ) ) . '">' . $img_element . '</a>';
-
-		}
-
+		$html .= '<a href="' . get_permalink( $lesson_id ) . '" title="' . esc_attr( get_post_field( 'post_title', $lesson_id ) ) . '">' . $img_url . '</a>';
 
 		return $html;
 
@@ -3108,8 +3104,8 @@ class Sensei_Lesson {
                     //
                     $pass_required_options = array(
                         '-1' => $no_change_text,
-                         '0' => __( 'No', 'woothemes-sensei' ),
-                         '1' => __( 'Yes', 'woothemes-sensei' ),
+                         '0' => __('No','woothemes'),
+                         '1' => __('Yes','woothemes'),
                     );
 
                     $pass_required_select_attributes = array( 'name'=> 'pass_required',
@@ -3129,8 +3125,8 @@ class Sensei_Lesson {
                     //
                     $quiz_reset_select__options = array(
                         '-1' => $no_change_text,
-                        '0' => __( 'No', 'woothemes-sensei' ),
-                        '1' => __( 'Yes', 'woothemes-sensei' ),
+                        '0' => __('No','woothemes'),
+                        '1' => __('Yes','woothemes'),
                     );
                     $quiz_reset_name_id = 'sensei-edit-enable-quiz-reset';
                     $quiz_reset_select_attributes = array( 'name'=> 'enable_quiz_reset', 'id'=>$quiz_reset_name_id, 'class'=>' ' );
@@ -3382,7 +3378,7 @@ class Sensei_Lesson {
         <header>
             <h2>
                 <a href="<?php echo esc_url_raw( get_permalink( $lesson_id ) ) ?>"
-                   title="<?php echo esc_attr( $heading_link_title ) ?>" >
+                   title="<?php esc_attr_e( $heading_link_title ) ?>" >
                     <?php echo $count_markup. get_the_title( $lesson_id ) . $preview_label; ?>
                 </a>
             </h2>
@@ -3412,7 +3408,7 @@ class Sensei_Lesson {
 
                 }
 
-                if ( Sensei_Utils::user_completed_lesson( $lesson_id, get_current_user_id() ) ) {
+                if ( $single_lesson_complete ) {
 
                     $meta_html .= '<span class="lesson-status complete">' .__( 'Complete', 'woothemes-sensei' ) .'</span>';
 
@@ -3557,7 +3553,13 @@ class Sensei_Lesson {
         $user_taking_course = Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id() );
 
         if ( $pre_requisite_complete && $is_preview && !$user_taking_course ) {
+            ?>
 
+            <div class="sensei-message alert">
+                <?php echo Sensei()->permissions_message['message']; ?>
+            </div>
+
+            <?php
 
         }// end if
 
@@ -3579,84 +3581,72 @@ class Sensei_Lesson {
             return;
 
         }
-
         ?>
 
         <section class="course-signup lesson-meta">
 
             <?php
-
-            global $current_user;
             $wc_post_id = (int) get_post_meta( $course_id, '_course_woocommerce_product', true );
 
-            if ( Sensei_WC::is_woocommerce_active() && Sensei_WC::is_course_purchasable( $course_id ) ) {
+            if ( Sensei_WC::is_woocommerce_active() && ( 0 < $wc_post_id ) ) {
 
-                if( is_user_logged_in() && ! Sensei_Utils::user_started_course( $course_id, $current_user->ID )  ) {
+                global $current_user;
+                if( is_user_logged_in() ) {
+                    wp_get_current_user();
 
-	                    $a_element = '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . __( 'Sign Up', 'woothemes-sensei' )  . '">';
-	                    $a_element .= __( 'course', 'woothemes-sensei' );
-	                    $a_element .= '</a>';
+                    $course_purchased = Sensei_Utils::sensei_customer_bought_product( $current_user->user_email, $current_user->ID, $wc_post_id );
 
-	                    if( Sensei_Utils::is_preview_lesson( get_the_ID()  ) ){
+                    if( $course_purchased ) {
 
-		                    $message = sprintf( __( 'This is a preview lesson. Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $a_element );
+                        $prereq_course_id = get_post_meta( $course_id, '_course_prerequisite',true );
+                        $course_link = '<a href="' . esc_url( get_permalink( $prereq_course_id ) ) . '" title="' . esc_attr( get_the_title( $prereq_course_id ) ) . '">' . __( 'the previous course', 'woothemes-sensei' )  . '</a>';
+                        ?>
+                            <div class="sensei-message info">
 
-	                    }else{
+                                <?php  echo sprintf( __( 'Please complete %1$s before starting the lesson.', 'woothemes-sensei' ), $course_link ); ?>
 
-		                    $message = sprintf( __( 'Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $a_element );
+                            </div>
 
-	                    }
+                    <?php } else { ?>
 
-	                    Sensei()->notices->add_notice( $message, 'info' );
+                        <div class="sensei-message info">
 
-                }
+                            <?php
+                            $course_link = '<a href="' . esc_url( get_permalink( $course_id ) )
+                                            . '"title="' . __( 'Sign Up', 'woothemes-sensei' )
+                                            . '">' . __( 'course', 'woothemes-sensei' )
+                                            . '</a>';
 
-	            if( ! is_user_logged_in() ) {
+                            echo  sprintf( __( 'Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $course_link );
 
-	                $a_element = '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . __( 'Sign Up', 'woothemes-sensei' )  . '">';
-	                $a_element .= __( 'course', 'woothemes-sensei' );
-	                $a_element .= '</a>';
+                            ?>
 
-	                if( Sensei_Utils::is_preview_lesson( get_the_ID()  ) ){
+                        </div>
+                    <?php } ?>
 
-						$message = sprintf( __( 'This is a preview lesson. Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $a_element );
+                <?php } else { ?>
 
-					}else{
+                    <div class="sensei-message info"><?php echo sprintf( __( 'Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . __( 'Sign Up', 'woothemes-sensei' )  . '">' . __( 'course', 'woothemes-sensei' ) . '</a>' ); ?></div>
 
-						$message = sprintf( __( 'Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $a_element );
+                <?php } ?>
 
-					}
+            <?php } else { ?>
 
-					Sensei()->notices->add_notice( $message, 'alert' );
+            <?php if( ! Sensei_Utils::user_started_course( $course_id, get_current_user_id() ) &&  sensei_is_login_required() )  : ?>
 
-	            }
+                <div class="sensei-message info">
+                    <?php
+                    $course_link =  '<a href="'
+                                        . esc_url( get_permalink( $course_id ) )
+                                        . '" title="' . __( 'Sign Up', 'woothemes-sensei' )
+                                        . '">' . __( 'course', 'woothemes-sensei' )
+                                    . '</a>';
 
-            } else { ?>
+                    echo sprintf( __( 'Please sign up for the %1$s before starting the lesson.', 'woothemes-sensei' ),  $course_link );
+                    ?>
+                </div>
 
-	            <?php if( ! Sensei_Utils::user_started_course( $course_id, get_current_user_id() ) &&  sensei_is_login_required() )  : ?>
-
-	                <div class="sensei-message alert">
-	                    <?php
-	                    $course_link =  '<a href="'
-	                                        . esc_url( get_permalink( $course_id ) )
-	                                        . '" title="' . __( 'Sign Up', 'woothemes-sensei' )
-	                                        . '">' . __( 'course', 'woothemes-sensei' )
-	                                    . '</a>';
-
-						if ( Sensei_Utils::is_preview_lesson( get_the_ID( ) ) ) {
-
-							echo sprintf( __( 'This is a preview lesson. Please sign up for the %1$s to access all lessons.', 'woothemes-sensei' ),  $course_link );
-
-						} else {
-
-							echo sprintf( __( 'Please sign up for the %1$s before starting the lesson.', 'woothemes-sensei' ),  $course_link );
-
-						}
-
-	                    ?>
-	                </div>
-
-	            <?php endif; ?>
+            <?php endif; ?>
 
             <?php } // End If Statement ?>
 
@@ -3677,7 +3667,7 @@ class Sensei_Lesson {
         if ( ! WooThemes_Sensei_Lesson::is_prerequisite_complete(  get_the_ID(), get_current_user_id() ) && $lesson_has_pre_requisite ) {
 
             $prerequisite_lesson_link  = '<a href="' . esc_url( get_permalink( $lesson_prerequisite ) ) . '" title="' . esc_attr(  sprintf( __( 'You must first complete: %1$s', 'woothemes-sensei' ), get_the_title( $lesson_prerequisite ) ) ) . '">' . get_the_title( $lesson_prerequisite ). '</a>';
-            Sensei()->notices->add_notice( sprintf( __( 'You must first complete %1$s before viewing this Lesson', 'woothemes-sensei' ), $prerequisite_lesson_link ), 'info');
+            echo sprintf( __( 'You must first complete %1$s before viewing this Lesson', 'woothemes-sensei' ), $prerequisite_lesson_link );
 
         }
 
@@ -3705,21 +3695,7 @@ class Sensei_Lesson {
 
         $before_html = '<header class="archive-header"><h1>';
         $after_html = '</h1></header>';
-
-	    $title= '';
-	    if ( is_post_type_archive( 'lesson' ) ){
-
-	        $title = __( 'Lessons Archive', 'woothemes-sensei' );
-
-	    } elseif ( is_tax( 'module' ) ) {
-
-		    global $wp_query;
-		    $term = $wp_query->get_queried_object();
-		    $title = $term->name;
-
-	    }
-
-        $html = $before_html . $title . $after_html;
+        $html = $before_html .  __( 'Lessons Archive', 'woothemes-sensei' ) . $after_html;
 
         echo apply_filters( 'sensei_lesson_archive_title', $html );
 
@@ -3793,12 +3769,6 @@ class Sensei_Lesson {
 
         $lesson_id                 =  empty( $lesson_id ) ?  get_the_ID() : $lesson_id;
         $user_id                   = empty( $lesson_id ) ?  get_current_user_id() : $user_id;
-
-
-	    if ( ! sensei_can_user_view_lesson( $lesson_id, $user_id ) ) {
-		    return;
-	    }
-
         $lesson_prerequisite       = (int) get_post_meta( $lesson_id, '_lesson_prerequisite', true );
         $lesson_course_id          = (int) get_post_meta( $lesson_id, '_lesson_course', true );
         $quiz_id                   = Sensei()->lesson->lesson_quizzes( $lesson_id );
@@ -3811,7 +3781,6 @@ class Sensei_Lesson {
             $show_actions = Sensei_Utils::user_completed_lesson( $lesson_prerequisite, $user_id );
 
         }
-
         ?>
 
         <footer>
@@ -3863,11 +3832,16 @@ class Sensei_Lesson {
      */
     public static function output_comments(){
 
+        if( ! is_user_logged_in() ){
+            return;
+        }
+
+        $pre_requisite_complete = Sensei()->lesson->is_prerequisite_complete( get_the_ID(), get_current_user_id() );
         $course_id = Sensei()->lesson->get_course_id( get_the_ID() );
         $allow_comments = Sensei()->settings->settings[ 'lesson_comments' ];
         $user_taking_course = Sensei_Utils::user_started_course($course_id );
 
-        $lesson_allow_comments = $allow_comments  && $user_taking_course;
+        $lesson_allow_comments = $allow_comments && $pre_requisite_complete  && $user_taking_course;
 
         if (  $lesson_allow_comments || is_singular( 'sensei_message' ) ) {
 
@@ -3903,11 +3877,7 @@ class Sensei_Lesson {
             // Display lesson quiz status message
             if ( $has_user_completed_lesson || $has_quiz_questions ) {
                 $status = Sensei_Utils::sensei_user_quiz_status_message( $lesson_id, $user_id, true );
-
-	            if( ! empty( $status['message']  ) ){
-	                echo '<div class="sensei-message ' . $status['box_class'] . '">' . $status['message'] . '</div>';
-                }
-
+                echo '<div class="sensei-message ' . $status['box_class'] . '">' . $status['message'] . '</div>';
                 if( $has_quiz_questions ) {
                    // echo $status['extra'];
                 } // End If Statement
@@ -3926,7 +3896,7 @@ class Sensei_Lesson {
      */
     public static function limit_archive_content ( $content ){
 
-        if( is_post_type_archive( 'lesson' ) && Sensei()->settings->get('access_permission') ){
+        if( is_archive('lesson') && Sensei()->settings->get('access_permission') ){
 
             return wp_trim_words( $content, $num_words = 30, $more = '…' );
         }
@@ -3934,24 +3904,6 @@ class Sensei_Lesson {
         return $content;
 
     } // end limit_archive_content
-
-    /**
-     * Returns all publised lesson ID's
-     *
-     * @since 1.9.0
-     * @return array
-     */
-    public static function get_all_lesson_ids(){
-
-        return get_posts( array(
-            'post_type'=>'lesson',
-            'fields'=>'ids',
-            'post_status' => 'publish',
-            'numberposts' => 4000, // legacy support
-            'post_per_page' => 4000
-        ));
-
-    }
 
 } // End Class
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -186,7 +186,7 @@ class Sensei_Lesson {
 		$html .= '</select></p>' . "\n";
 
 		$html .= '<p><label for="lesson_video_embed">' . esc_html__( 'Video Embed Code', 'woothemes-sensei' ) . ':</label><br/>' . "\n";
-		$html .= '<textarea rows="5" cols="50" name="lesson_video_embed" tabindex="6" id="course-video-embed">' . wp_kses( $lesson_video_embed, $this->allowed_html ) . '</textarea></p>' . "\n";
+		$html .= '<textarea rows="5" cols="50" name="lesson_video_embed" tabindex="6" id="course-video-embed">' . Sensei_Utils::wp_kses( $lesson_video_embed, $this->allowed_html ) . '</textarea></p>' . "\n";
 		$html .= '<p>' .  esc_html__( 'Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above.', 'woothemes-sensei' ) . '</p>';
 
 		echo $html;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -129,22 +129,22 @@ class Sensei_Lesson {
 	public function meta_box_setup () {
 
 		// Add Meta Box for Prerequisite Lesson
-		add_meta_box( 'lesson-prerequisite', __( 'Lesson Prerequisite', 'woothemes-sensei' ), array( $this, 'lesson_prerequisite_meta_box_content' ), $this->token, 'side', 'default' );
+		add_meta_box( 'lesson-prerequisite', esc_html__( 'Lesson Prerequisite', 'woothemes-sensei' ), array( $this, 'lesson_prerequisite_meta_box_content' ), $this->token, 'side', 'default' );
 
 		// Add Meta Box for Lesson Course
-		add_meta_box( 'lesson-course', __( 'Lesson Course', 'woothemes-sensei' ), array( $this, 'lesson_course_meta_box_content' ), $this->token, 'side', 'default' );
+		add_meta_box( 'lesson-course', esc_html__( 'Lesson Course', 'woothemes-sensei' ), array( $this, 'lesson_course_meta_box_content' ), $this->token, 'side', 'default' );
 
 		// Add Meta Box for Lesson Preview
-		add_meta_box( 'lesson-preview', __( 'Lesson Preview', 'woothemes-sensei' ), array( $this, 'lesson_preview_meta_box_content' ), $this->token, 'side', 'default' );
+		add_meta_box( 'lesson-preview', esc_html__( 'Lesson Preview', 'woothemes-sensei' ), array( $this, 'lesson_preview_meta_box_content' ), $this->token, 'side', 'default' );
 
 		// Add Meta Box for Lesson Information
-		add_meta_box( 'lesson-info', __( 'Lesson Information', 'woothemes-sensei' ), array( $this, 'lesson_info_meta_box_content' ), $this->token, 'normal', 'default' );
+		add_meta_box( 'lesson-info', esc_html__( 'Lesson Information', 'woothemes-sensei' ), array( $this, 'lesson_info_meta_box_content' ), $this->token, 'normal', 'default' );
 
 		// Add Meta Box for Quiz Settings
-		add_meta_box( 'lesson-quiz-settings', __( 'Quiz Settings', 'woothemes-sensei' ), array( $this, 'lesson_quiz_settings_meta_box_content' ), $this->token, 'normal', 'default' );
+		add_meta_box( 'lesson-quiz-settings', esc_html__( 'Quiz Settings', 'woothemes-sensei' ), array( $this, 'lesson_quiz_settings_meta_box_content' ), $this->token, 'normal', 'default' );
 
 		// Add Meta Box for Lesson Quiz Questions
-		add_meta_box( 'lesson-quiz', __( 'Quiz Questions', 'woothemes-sensei' ), array( $this, 'lesson_quiz_meta_box_content' ), $this->token, 'normal', 'default' );
+		add_meta_box( 'lesson-quiz', esc_html__( 'Quiz Questions', 'woothemes-sensei' ), array( $this, 'lesson_quiz_meta_box_content' ), $this->token, 'normal', 'default' );
 
 		// Remove "Custom Settings" meta box.
 		remove_meta_box( 'woothemes-settings', $this->token, 'normal' );
@@ -174,20 +174,20 @@ class Sensei_Lesson {
 
 		$html = '';
 		// Lesson Length
-		$html .= '<p><label for="lesson_length">' . __( 'Lesson Length in minutes', 'woothemes-sensei' ) . ': </label>';
+		$html .= '<p><label for="lesson_length">' . esc_html__( 'Lesson Length in minutes', 'woothemes-sensei' ) . ': </label>';
 		$html .= '<input type="number" id="lesson-length" name="lesson_length" class="small-text" value="' . esc_attr( $lesson_length ) . '" /></p>' . "\n";
 		// Lesson Complexity
-		$html .= '<p><label for="lesson_complexity">' . __( 'Lesson Complexity', 'woothemes-sensei' ) . ': </label>';
+		$html .= '<p><label for="lesson_complexity">' . esc_html__( 'Lesson Complexity', 'woothemes-sensei' ) . ': </label>';
 		$html .= '<select id="lesson-complexity-options" name="lesson_complexity" class="chosen_select lesson-complexity-select">';
-			$html .= '<option value="">' . __( 'None', 'woothemes-sensei' ) . '</option>';
+			$html .= '<option value="">' . esc_html__( 'None', 'woothemes-sensei' ) . '</option>';
 			foreach ( $complexity_array as $key => $value ){
 				$html .= '<option value="' . esc_attr( $key ) . '"' . selected( $key, $lesson_complexity, false ) . '>' . esc_html( $value ) . '</option>' . "\n";
 			} // End For Loop
 		$html .= '</select></p>' . "\n";
 
-		$html .= '<p><label for="lesson_video_embed">' . __( 'Video Embed Code', 'woothemes-sensei' ) . ':</label><br/>' . "\n";
+		$html .= '<p><label for="lesson_video_embed">' . esc_html__( 'Video Embed Code', 'woothemes-sensei' ) . ':</label><br/>' . "\n";
 		$html .= '<textarea rows="5" cols="50" name="lesson_video_embed" tabindex="6" id="course-video-embed">' . wp_kses( $lesson_video_embed, $this->allowed_html ) . '</textarea></p>' . "\n";
-		$html .= '<p>' .  __( 'Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above.', 'woothemes-sensei' ) . '</p>';
+		$html .= '<p>' .  esc_html__( 'Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above.', 'woothemes-sensei' ) . '</p>';
 
 		echo $html;
 
@@ -217,13 +217,13 @@ class Sensei_Lesson {
 		$html .= wp_nonce_field( 'sensei-save-post-meta','woo_' . $this->token . '_nonce', true, false  );
 		if ( count( $posts_array ) > 0 ) {
 			$html .= '<select id="lesson-prerequisite-options" name="lesson_prerequisite" class="chosen_select widefat">' . "\n";
-			$html .= '<option value="">' . __( 'None', 'woothemes-sensei' ) . '</option>';
+			$html .= '<option value="">' . esc_html__( 'None', 'woothemes-sensei' ) . '</option>';
 				foreach ($posts_array as $post_item){
 					$html .= '<option value="' . esc_attr( absint( $post_item->ID ) ) . '"' . selected( $post_item->ID, $select_lesson_prerequisite, false ) . '>' . esc_html( $post_item->post_title ) . '</option>' . "\n";
 				} // End For Loop
 			$html .= '</select>' . "\n";
 		} else {
-			$html .= '<p>' . esc_html( __( 'No lessons exist yet. Please add some first.', 'woothemes-sensei' ) ) . '</p>';
+			$html .= '<p>' . esc_html__( 'No lessons exist yet. Please add some first.', 'woothemes-sensei' ) . '</p>';
 		} // End If Statement
 		// Output the HTML
 		echo $html;
@@ -248,7 +248,7 @@ class Sensei_Lesson {
 	 	} // End If Statement
 
 	 	$html .= '<label for="lesson_preview">';
-	 	$html .= '<input type="checkbox" id="lesson_preview" name="lesson_preview" value="preview" ' . $checked . '>&nbsp;' . __( 'Allow this lesson to be viewed without purchase/login', 'woothemes-sensei' ) . '<br>';
+	 	$html .= '<input type="checkbox" id="lesson_preview" name="lesson_preview" value="preview" ' . $checked . '>&nbsp;' . esc_html__( 'Allow this lesson to be viewed without purchase/login', 'woothemes-sensei' ) . '<br>';
 
 		// Output the HTML
 		echo $html;
@@ -579,22 +579,22 @@ class Sensei_Lesson {
 				$html .= '<div id="lesson-course-actions">';
 					$html .= '<p>';
 						// Add a course action link
-						$html .= '<a id="lesson-course-add" href="#course-add" class="lesson-add-course">+ ' . __('Add New Course', 'woothemes-sensei' ) . '</a>';
+						$html .= '<a id="lesson-course-add" href="#course-add" class="lesson-add-course">+ ' . esc_html__('Add New Course', 'woothemes-sensei' ) . '</a>';
 					$html .= '</p>';
 				$html .= '</div>';
 				// Add a course input fields
 				$html .= '<div id="lesson-course-details" class="hidden">';
 					$html .= '<p>';
 						// Course Title input
-						$html .= '<label>' . __( 'Course Title' , 'woothemes-sensei' ) . '</label> ';
+						$html .= '<label>' . esc_html__( 'Course Title' , 'woothemes-sensei' ) . '</label> ';
 	  					$html .= '<input type="text" id="course-title" name="course_title" value="" size="25" class="widefat" />';
 	  					// Course Description input
-	  					$html .= '<label>' . __( 'Description' , 'woothemes-sensei' ) . '</label> ';
+	  					$html .= '<label>' . esc_html__( 'Description' , 'woothemes-sensei' ) . '</label> ';
 	  					$html .= '<textarea rows="10" cols="40" id="course-content" name="course_content" value="" size="300" class="widefat"></textarea>';
 	  					// Course Prerequisite
-	  					$html .= '<label>' . __( 'Course Prerequisite' , 'woothemes-sensei' ) . '</label> ';
+	  					$html .= '<label>' . esc_html__( 'Course Prerequisite' , 'woothemes-sensei' ) . '</label> ';
 	  					$html .= '<select id="course-prerequisite-options" name="course_prerequisite" class="chosen_select widefat">' . "\n";
-							$html .= '<option value="">' . __( 'None', 'woothemes-sensei' ) . '</option>';
+							$html .= '<option value="">' . esc_html__( 'None', 'woothemes-sensei' ) . '</option>';
 							foreach ($posts_array as $post_item){
 								$html .= '<option value="' . esc_attr( absint( $post_item->ID ) ) . '">' . esc_html( $post_item->post_title ) . '</option>' . "\n";
 							} // End For Loop
@@ -620,9 +620,9 @@ class Sensei_Lesson {
 	    											'suppress_filters' 	=> 0
 													);
 							$products_array = get_posts( $product_args );
-							$html .= '<label>' . __( 'WooCommerce Product' , 'woothemes-sensei' ) . '</label> ';
+							$html .= '<label>' . esc_html__( 'WooCommerce Product' , 'woothemes-sensei' ) . '</label> ';
 	  						$html .= '<select id="course-woocommerce-product-options" name="course_woocommerce_product" class="chosen_select widefat">' . "\n";
-								$html .= '<option value="-">' . __( 'None', 'woothemes-sensei' ) . '</option>';
+								$html .= '<option value="-">' . esc_html__( 'None', 'woothemes-sensei' ) . '</option>';
 								$prev_parent_id = 0;
 								foreach ($products_array as $products_item){
 
@@ -655,14 +655,14 @@ class Sensei_Lesson {
 							$html .= '<input type="hidden" name="course_woocommerce_product" id="course-woocommerce-product-options" value="-" />';
 						}
 						// Course Category
-	  					$html .= '<label>' . __( 'Course Category' , 'woothemes-sensei' ) . '</label> ';
-	  					$cat_args = array( 'echo' => false, 'hierarchical' => true, 'show_option_none' => __( 'None', 'woothemes-sensei' ), 'taxonomy' => 'course-category', 'orderby' => 'name', 'id' => 'course-category-options', 'name' => 'course_category', 'class' => 'widefat' );
+	  					$html .= '<label>' . esc_html__( 'Course Category' , 'woothemes-sensei' ) . '</label> ';
+	  					$cat_args = array( 'echo' => false, 'hierarchical' => true, 'show_option_none' => esc_html__( 'None', 'woothemes-sensei' ), 'taxonomy' => 'course-category', 'orderby' => 'name', 'id' => 'course-category-options', 'name' => 'course_category', 'class' => 'widefat' );
 						$html .= wp_dropdown_categories(apply_filters('widget_course_categories_dropdown_args', $cat_args)) . "\n";
 	  					// Save the course action button
-	  					$html .= '<a title="' . esc_attr( __( 'Save Course', 'woothemes-sensei' ) ) . '" href="#add-course-metadata" class="lesson_course_save button button-highlighted">' . esc_html( __( 'Add Course', 'woothemes-sensei' ) ) . '</a>';
+	  					$html .= '<a title="' . esc_attr__( 'Save Course', 'woothemes-sensei' ) . '" href="#add-course-metadata" class="lesson_course_save button button-highlighted">' . esc_html__( 'Add Course', 'woothemes-sensei' ) . '</a>';
 						$html .= '&nbsp;&nbsp;&nbsp;';
 						// Cancel action link
-						$html .= '<a href="#course-add-cancel" class="lesson_course_cancel">' . __( 'Cancel', 'woothemes-sensei' ) . '</a>';
+						$html .= '<a href="#course-add-cancel" class="lesson_course_cancel">' . esc_html__( 'Cancel', 'woothemes-sensei' ) . '</a>';
 					$html .= '</p>';
 				$html .= '</div>';
 			} // End If Statement
@@ -678,7 +678,7 @@ class Sensei_Lesson {
 			if ( 0 == $quiz_id ) {
 				$html .= '<p>';
 					// Default message and Add a Quiz button
-					$html .=  __( 'Once you have saved your lesson you will be able to add questions.', 'woothemes-sensei' );
+					$html .= esc_html__( 'Once you have saved your lesson you will be able to add questions.', 'woothemes-sensei' );
 				$html .= '</p>';
 			}
 
@@ -709,7 +709,7 @@ class Sensei_Lesson {
 			}
 
 			// Inner DIV
-			$html .= '<div id="add-quiz-metadata"' .  $quiz_class . '>';
+			$html .= '<div id="add-quiz-metadata"' . esc_attr( $quiz_class ) . '>';
 
 				// Quiz ID
 				$html .= '<input type="hidden" name="quiz_id" id="quiz_id" value="' . esc_attr( $quiz_id ) . '" />';
@@ -717,7 +717,7 @@ class Sensei_Lesson {
 				// Default Message
 				if ( 0 == $quiz_id ) {
 					$html .= '<p class="save-note">';
-						$html .= __( 'Please save your lesson in order to add questions to your quiz.', 'woothemes-sensei' );
+						$html .= esc_html__( 'Please save your lesson in order to add questions to your quiz.', 'woothemes-sensei' );
 					$html .= '</p>';
 				} // End If Statement
 
@@ -735,19 +735,19 @@ class Sensei_Lesson {
 								<thead>
 								    <tr>
 								        <th class="question-count-column">#</th>
-								        <th>' . __( 'Question', 'woothemes-sensei' ) . '</th>
-								        <th style="width:45px;">' . __( 'Grade', 'woothemes-sensei' ) . '</th>
-								        <th style="width:125px;">' . __( 'Type', 'woothemes-sensei' ) . '</th>
-								        <th style="width:125px;">' . __( 'Action', 'woothemes-sensei' ) . '</th>
+								        <th>' . esc_html__( 'Question', 'woothemes-sensei' ) . '</th>
+								        <th style="width:45px;">' . esc_html__( 'Grade', 'woothemes-sensei' ) . '</th>
+								        <th style="width:125px;">' . esc_html__( 'Type', 'woothemes-sensei' ) . '</th>
+								        <th style="width:125px;">' . esc_html__( 'Action', 'woothemes-sensei' ) . '</th>
 								    </tr>
 								</thead>
 								<tfoot>
 								    <tr>
 									    <th class="question-count-column">#</th>
-									    <th>' . __( 'Question', 'woothemes-sensei' ) . '</th>
-									    <th>' . __( 'Grade', 'woothemes-sensei' ) . '</th>
-									    <th>' . __( 'Type', 'woothemes-sensei' ) . '</th>
-									    <th>' . __( 'Action', 'woothemes-sensei' ) . '</th>
+									    <th>' . esc_html__( 'Question', 'woothemes-sensei' ) . '</th>
+									    <th>' . esc_html__( 'Grade', 'woothemes-sensei' ) . '</th>
+									    <th>' . esc_html__( 'Type', 'woothemes-sensei' ) . '</th>
+									    <th>' . esc_html__( 'Action', 'woothemes-sensei' ) . '</th>
 								    </tr>
 								</tfoot>';
 
@@ -756,7 +756,7 @@ class Sensei_Lesson {
 
 					$html .= '<tbody id="no-questions-message" class="' . esc_attr( $message_class ) . '">';
 						$html .= '<tr>';
-							$html .= '<td colspan="5">' . __( 'There are no Questions for this Quiz yet. Please add some below.', 'woothemes-sensei' ) . '</td>';
+							$html .= '<td colspan="5">' . esc_html__( 'There are no Questions for this Quiz yet. Please add some below.', 'woothemes-sensei' ) . '</td>';
 						$html .= '</tr>';
 					$html .= '</tbody>';
 
@@ -854,7 +854,6 @@ class Sensei_Lesson {
 
 		if( $question_id ) {
 
-            $question_grade ='';
 			if( $question_type != 'category' ) {
 
 				$question_grade = Sensei()->question->get_question_grade( $question_id );
@@ -862,7 +861,7 @@ class Sensei_Lesson {
 				$question_media = get_post_meta( $question_id, '_question_media', true );
 				$question_media_type = $question_media_thumb = $question_media_link = $question_media_title = '';
 				$question_media_thumb_class = $question_media_link_class = $question_media_delete_class = 'hidden';
-				$question_media_add_button = __( 'Add file', 'woothemes-sensei' );
+				$question_media_add_button = esc_html__( 'Add file', 'woothemes-sensei' );
 				if( 0 < intval( $question_media ) ) {
 					$mimetype = get_post_mime_type( $question_media );
 					if( $mimetype ) {
@@ -885,11 +884,11 @@ class Sensei_Lesson {
 									$question_media_filename = basename( $question_media_url );
 									$question_media_title = $question_media_filename;
 								}
-								$question_media_link = '<a class="' . $question_media_type . '" href="' . esc_url( $question_media_url ) . '" target="_blank">' . $question_media_title . '</a>';
+								$question_media_link = '<a class="' . esc_attr( $question_media_type ) . '" href="' . esc_url( $question_media_url ) . '" target="_blank">' . esc_html( $question_media_title ) . '</a>';
 								$question_media_link_class = '';
 							}
 
-							$question_media_add_button = __( 'Change file', 'woothemes-sensei' );
+							$question_media_add_button = esc_html__( 'Change file', 'woothemes-sensei' );
 						}
 					}
 				}
@@ -913,7 +912,7 @@ class Sensei_Lesson {
 							$html .= '<td class="question-grade-column">' . esc_html( $question_grade ) . '</td>';
 							$question_types_filtered = ucwords( str_replace( array( '-', 'boolean' ), array( ' ', __( 'True/False', 'woothemes-sensei' ) ), $question_type ) );
 							$html .= '<td>' . esc_html( $question_types_filtered ) . '</td>';
-							$html .= '<td><a title="' . esc_attr__( 'Edit Question', 'woothemes-sensei' )  . '" href="#question_' . esc_attr( $question_counter ) .'" class="question_table_edit">' . esc_html__( 'Edit', 'woothemes-sensei' ) . '</a> <a title="' . esc_attr__( 'Remove Question', 'woothemes-sensei' ) . '" href="#add-question-metadata" class="question_table_delete">' . esc_html__( 'Remove', 'woothemes-sensei' ) . '</a></td>';
+							$html .= '<td><a title="' . esc_attr__( 'Edit Question', 'woothemes-sensei' ) . '" href="#question_' . esc_attr( $question_counter ) .'" class="question_table_edit">' . esc_html__( 'Edit', 'woothemes-sensei' ) . '</a> <a title="' . esc_attr__( 'Remove Question', 'woothemes-sensei' ) . '" href="#add-question-metadata" class="question_table_delete">' . esc_html__( 'Remove', 'woothemes-sensei' ) . '</a></td>';
 
 						} else {
 
@@ -923,13 +922,13 @@ class Sensei_Lesson {
 							} else {
 								$row_numbers = $question_counter . ' - ' . $end_number;
 							}
-							$row_title = sprintf( __( 'Selected from \'%1$s\' ', 'woothemes-sensei' ), $multiple_data[0] );
+							$row_title = sprintf( esc_html__( 'Selected from \'%1$s\' ', 'woothemes-sensei' ), $multiple_data[0] );
 
 							$html .= '<td class="table-count question-number question-count-column"><span class="number hidden">' . esc_html( $question_counter ) . '</span><span class="hidden total-number">' . esc_html( $multiple_data[1] ) . '</span><span class="row-numbers">' . esc_html( $row_numbers ) . '</span></td>';
 							$html .= '<td>' . esc_html( $row_title ) . '</td>';
 							$html .= '<td class="question-grade-column"></td>';
 							$html .= '<td><input type="hidden" name="question_id" class="row_question_id" id="question_' . esc_attr( $question_counter ) . '_id" value="' . esc_attr( $question_id ) . '" /></td>';
-							$html .= '<td><a title="' . esc_attr__( 'Edit Question', 'woothemes-sensei' ) . '" href="#question_' . esc_attr( $question_counter ) .'" class="question_table_edit" style="visibility:hidden;">' . esc_html__( 'Edit', 'woothemes-sensei' ) . '</a> <a title="' . esc_attr__( 'Remove Question(s)', 'woothemes-sensei' )  . '" href="#add-question-metadata" class="question_multiple_delete" rel="' . esc_attr( $question_id ) . '">' . esc_html__( 'Remove', 'woothemes-sensei' ) . '</a></td>';
+							$html .= '<td><a title="' . esc_attr__( 'Edit Question', 'woothemes-sensei' ) . '" href="#question_' . esc_attr( $question_counter ) .'" class="question_table_edit" style="visibility:hidden;">' . esc_html__( 'Edit', 'woothemes-sensei' ) . '</a> <a title="' . esc_attr__( 'Remove Question(s)', 'woothemes-sensei' ) . '" href="#add-question-metadata" class="question_multiple_delete" rel="' . esc_attr( $question_id ) . '">' . esc_html__( 'Remove', 'woothemes-sensei' ) . '</a></td>';
 
 						}
 					$html .= '</tr>';
@@ -945,41 +944,41 @@ class Sensei_Lesson {
 					$question = get_post( $question_id );
 					$html .= '<tr class="question-quick-edit ' . esc_attr( $edit_class ) . '">';
 						$html .= '<td colspan="5">';
-							$html .= '<span class="hidden question_original_counter">' . esc_attr( $question_counter ) . '</span>';
+							$html .= '<span class="hidden question_original_counter">' . esc_html( $question_counter ) . '</span>';
 					    	$html .= '<div class="question_required_fields">';
 
 						    	// Question title
 						    	$html .= '<div>';
-							    	$html .= '<label for="question_' . esc_attr( $question_counter ) . '">' . __( 'Question:', 'woothemes-sensei' ) . '</label> ';
+							    	$html .= '<label for="question_' . esc_attr( $question_counter ) . '">' . esc_html__( 'Question:', 'woothemes-sensei' ) . '</label> ';
 							    	$html .= '<input type="text" id="question_' . esc_attr( $question_counter ) . '" name="question" value="' . esc_attr( htmlspecialchars( $question->post_title ) ) . '" size="25" class="widefat" />';
 						    	$html .= '</div>';
 
 						    	// Question description
 						    	$html .= '<div>';
-							    	$html .= '<label for="question_' . esc_attr( $question_counter ) . '_desc">' . __( 'Question Description (optional):', 'woothemes-sensei' ) . '</label> ';
+							    	$html .= '<label for="question_' . esc_attr( $question_counter ) . '_desc">' . esc_html__( 'Question Description (optional):', 'woothemes-sensei' ) . '</label> ';
 						    	$html .= '</div>';
 							    	$html .= '<textarea id="question_' . esc_attr( $question_counter ) . '_desc" name="question_description" class="widefat" rows="4">' . esc_textarea( $question->post_content ) . '</textarea>';
 
 						    	// Question grade
 						    	$html .= '<div>';
-							    	$html .= '<label for="question_' . esc_attr( $question_counter ) . '_grade">' . __( 'Question grade:', 'woothemes-sensei' ) . '</label> ';
+							    	$html .= '<label for="question_' . esc_attr( $question_counter ) . '_grade">' . esc_html__( 'Question grade:', 'woothemes-sensei' ) . '</label> ';
 							    	$html .= '<input type="number" id="question_' . esc_attr( $question_counter ) . '_grade" class="question_grade small-text" name="question_grade" min="0" value="' . esc_attr( $question_grade ) . '" />';
 						    	$html .= '</div>';
 
 						    	// Random order
 						    	if( $question_type == 'multiple-choice' ) {
 						    		$html .= '<div>';
-						    			$html .= '<label for="' . esc_attr( $question_counter ) . '_random_order"><input type="checkbox" name="random_order" class="random_order" id="' . esc_attr( $question_counter ) . '_random_order" value="yes" ' . checked( $random_order, 'yes', false ) . ' /> ' . __( 'Randomise answer order', 'woothemes-sensei' ) . '</label>';
+						    			$html .= '<label for="' . esc_attr( $question_counter ) . '_random_order"><input type="checkbox" name="random_order" class="random_order" id="' . esc_attr( $question_counter ) . '_random_order" value="yes" ' . checked( $random_order, 'yes', false ) . ' /> ' . esc_html__( 'Randomise answer order', 'woothemes-sensei' ) . '</label>';
 						    		$html .= '</div>';
 						    	}
 
 						    	// Question media
 						    	$html .= '<div>';
-							    	$html .= '<label for="question_' . esc_attr( $question_counter ) . '_media_button">' . __( 'Question media:', 'woothemes-sensei' ) . '</label><br/>';
-							    	$html .= '<button id="question_' . esc_attr( $question_counter ) . '_media_button" class="upload_media_file_button button-secondary" data-uploader_title="' . esc_attr__( 'Add file to question', 'woothemes-sensei' ) . '" data-uploader_button_text="' . esc_attr__( 'Add to question', 'woothemes-sensei' ) . '">' . esc_html($question_media_add_button) . '</button>';
-							    	$html .= '<button id="question_' . esc_attr( $question_counter ) . '_media_button_delete" class="delete_media_file_button button-secondary ' . esc_attr( $question_media_delete_class ) . '">' . __( 'Delete file', 'woothemes-sensei' ) . '</button><br/>';
-							    	$html .= '<span id="question_' . esc_attr( $question_counter ) . '_media_link" class="question_media_link ' . esc_attr( $question_media_link_class ) . '">' . esc_html( $question_media_link ). '</span>';
-							    	$html .= '<br/><img id="question_' . esc_attr( $question_counter ) . '_media_preview" class="question_media_preview ' . esc_attr( $question_media_thumb_class ) . '" src="' . esc_html( $question_media_thumb ) . '" /><br/>';
+							    	$html .= '<label for="question_' . esc_attr( $question_counter ) . '_media_button">' . esc_html__( 'Question media:', 'woothemes-sensei' ) . '</label><br/>';
+							    	$html .= '<button id="question_' . esc_attr( $question_counter ) . '_media_button" class="upload_media_file_button button-secondary" data-uploader_title="' . esc_attr__( 'Add file to question', 'woothemes-sensei' ) . '" data-uploader_button_text="' . esc_attr__( 'Add to question', 'woothemes-sensei' ) . '">' . esc_html( $question_media_add_button ) . '</button>';
+							    	$html .= '<button id="question_' . esc_attr( $question_counter ) . '_media_button_delete" class="delete_media_file_button button-secondary ' . esc_attr( $question_media_delete_class ) . '">' . esc_html__( 'Delete file', 'woothemes-sensei' ) . '</button><br/>';
+							    	$html .= '<span id="question_' . esc_attr( $question_counter ) . '_media_link" class="question_media_link ' . esc_attr( $question_media_link_class ) . '">' . esc_html( $question_media_link ) . '</span>';
+							    	$html .= '<br/><img id="question_' . esc_attr( $question_counter ) . '_media_preview" class="question_media_preview ' . esc_attr( $question_media_thumb_class ) . '" src="' . esc_url( $question_media_thumb ) . '" /><br/>';
 							    	$html .= '<input type="hidden" id="question_' . esc_attr( $question_counter ) . '_media" class="question_media" name="question_media" value="' . esc_attr( $question_media ) . '" />';
 						    	$html .= '</div>';
 
@@ -988,11 +987,11 @@ class Sensei_Lesson {
 						    $html .= $this->quiz_panel_question_field( $question_type, $question_id, $question_counter );
 
 						    $html .= '<input type="hidden" id="question_' . esc_attr( $question_counter ) . '_question_type" class="question_type" name="question_type" value="' . esc_attr( $question_type ) . '" />';
-							$html .= '<input type="hidden" name="question_id" class="row_question_id" id="question_' . esc_attr( $question_counter ) . '_id" value="' . esc_attr( $question_id ). '" />';
+							$html .= '<input type="hidden" name="question_id" class="row_question_id" id="question_' . esc_attr( $question_counter ) . '_id" value="' . esc_attr( $question_id ) . '" />';
 
 							if( 'quiz' == $context ) {
 					    		$html .= '<div class="update-question">';
-						    		$html .= '<a href="#question-edit-cancel" class="lesson_question_cancel" title="' . esc_attr__( 'Cancel', 'woothemes-sensei' ) . '">' . __( 'Cancel', 'woothemes-sensei' ) . '</a> ';
+						    		$html .= '<a href="#question-edit-cancel" class="lesson_question_cancel" title="' . esc_attr__( 'Cancel', 'woothemes-sensei' ) . '">' . esc_html__( 'Cancel', 'woothemes-sensei' ) . '</a> ';
 						    		$html .= '<a title="' . esc_attr__( 'Update Question', 'woothemes-sensei' ) . '" href="#add-question-metadata" class="question_table_save button button-highlighted">' . esc_html__( 'Update', 'woothemes-sensei' ) . '</a>';
 					    		$html .= '</div>';
 					    	}
@@ -1030,7 +1029,7 @@ class Sensei_Lesson {
 	    	$html .= '<div class="tab-content" id="tab-new-content">';
 
 	    		if( 'quiz' == $context ) {
-	    			$html .= '<p><em>' . sprintf( __( 'Add a new question to this quiz - your question will also be added to the %1$squestion bank%2$s.', 'woothemes-sensei' ), '<a href="' . esc_url( admin_url( 'edit.php?post_type=question' ) ) . '">', '</a>' ) . '</em></p>';
+	    			$html .= '<p><em>' . sprintf( esc_html__( 'Add a new question to this quiz - your question will also be added to the %1$squestion bank%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'edit.php?post_type=question' ) . '">', '</a>' ) . '</em></p>';
 	    		}
 
 				$html .= '<div class="question">';
@@ -1105,22 +1104,22 @@ class Sensei_Lesson {
 
 			    $html .= '<div class="tab-content hidden" id="tab-existing-content">';
 
-			    	$html .= '<p><em>' . sprintf( __( 'Add an existing question to this quiz from the %1$squestion bank%2$s.', 'woothemes-sensei' ), '<a href="' . esc_url( admin_url( 'edit.php?post_type=question' ) ) . '">', '</a>' ) . '</em></p>';
+			    	$html .= '<p><em>' . sprintf( esc_html__( 'Add an existing question to this quiz from the %1$squestion bank%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'edit.php?post_type=question' ) . '">', '</a>' ) . '</em></p>';
 
 			    	$html .= '<div id="existing-filters" class="alignleft actions">
 			    				<select id="existing-status">
-			    					<option value="all">' . __( 'All', 'woothemes-sensei' ) . '</option>
-			    					<option value="unused">' . __( 'Unused', 'woothemes-sensei' ) . '</option>
-			    					<option value="used">' . __( 'Used', 'woothemes-sensei' ) . '</option>
+			    					<option value="all">' . esc_html__( 'All', 'woothemes-sensei' ) . '</option>
+			    					<option value="unused">' . esc_html__( 'Unused', 'woothemes-sensei' ) . '</option>
+			    					<option value="used">' . esc_html__( 'Used', 'woothemes-sensei' ) . '</option>
 			    				</select>
 			    				<select id="existing-type">
-			    					<option value="">' . __( 'All Types', 'woothemes-sensei' ) . '</option>';
+			    					<option value="">' . esc_html__( 'All Types', 'woothemes-sensei' ) . '</option>';
 							    	foreach ( $question_types as $type => $label ) {
 										$html .= '<option value="' . esc_attr( $type ) . '">' . esc_html( $label ) . '</option>';
 									}
     				$html .= '</select>
     							<select id="existing-category">
-			    					<option value="">' . __( 'All Categories', 'woothemes-sensei' ) . '</option>';
+			    					<option value="">' . esc_html__( 'All Categories', 'woothemes-sensei' ) . '</option>';
 				    				foreach( $question_cats as $cat ) {
 										$html .= '<option value="' . esc_attr( $cat->slug ) . '">' . esc_html( $cat->name ) . '</option>';
 									}
@@ -1134,17 +1133,17 @@ class Sensei_Lesson {
 			    		$html .= '<thead>
 									    <tr>
 									        <th scope="col" class="column-cb check-column"><input type="checkbox" /></th>
-									        <th scope="col">' . __( 'Question', 'woothemes-sensei' ) . '</th>
-									        <th scope="col">' . __( 'Type', 'woothemes-sensei' ) . '</th>
-									        <th scope="col">' . __( 'Category', 'woothemes-sensei' ) . '</th>
+									        <th scope="col">' . esc_html__( 'Question', 'woothemes-sensei' ) . '</th>
+									        <th scope="col">' . esc_html__( 'Type', 'woothemes-sensei' ) . '</th>
+									        <th scope="col">' . esc_html__( 'Category', 'woothemes-sensei' ) . '</th>
 									    </tr>
 									</thead>
 									<tfoot>
 									    <tr>
 										    <th scope="col" class="check-column"><input type="checkbox" /></th>
-									        <th scope="col">' . __( 'Question', 'woothemes-sensei' ) . '</th>
-									        <th scope="col">' . __( 'Type', 'woothemes-sensei' ) . '</th>
-									        <th scope="col">' . __( 'Category', 'woothemes-sensei' ) . '</th>
+									        <th scope="col">' . esc_html__( 'Question', 'woothemes-sensei' ) . '</th>
+									        <th scope="col">' . esc_html__( 'Type', 'woothemes-sensei' ) . '</th>
+									        <th scope="col">' . esc_html__( 'Category', 'woothemes-sensei' ) . '</th>
 									    </tr>
 									</tfoot>';
 						$html .= '<tbody id="existing-questions">';
@@ -1168,7 +1167,7 @@ class Sensei_Lesson {
 
 			    	$html .= '<div id="existing-pagination">';
 			    		$html .= '<input type="hidden" id="existing-page" value="1" />';
-			    		$html .= '<a class="prev no-paging">&larr; ' . __( 'Previous', 'woothemes-sensei') . '</a> <a class="next ' . esc_attr( $next_class ) . '">' . __( 'Next', 'woothemes-sensei') . ' &rarr;</a>';
+			    		$html .= '<a class="prev no-paging">&larr; ' . esc_html__( 'Previous', 'woothemes-sensei') . '</a> <a class="next ' . esc_attr( $next_class ) . '">' . esc_html__( 'Next', 'woothemes-sensei') . ' &rarr;</a>';
 			    	$html .= '</div>';
 
 			    	$html .= '<div class="existing-actions">';
@@ -1180,18 +1179,18 @@ class Sensei_Lesson {
 			    if ( ! empty( $question_cats ) && ! is_wp_error( $question_cats ) ) {
 				    $html .= '<div class="tab-content hidden" id="tab-multiple-content">';
 
-				    	$html .= '<p><em>' . sprintf( __( 'Add any number of questions from a specified category. Edit your question categories %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'edit-tags.php?taxonomy=question-category&post_type=question' ) . '">', '</a>' ) . '</em></p>';
+				    	$html .= '<p><em>' . sprintf( esc_html__( 'Add any number of questions from a specified category. Edit your question categories %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'edit-tags.php?taxonomy=question-category&post_type=question' ) . '">', '</a>' ) . '</em></p>';
 
 						$html .= '<p><select id="add-multiple-question-category-options" name="multiple_category" class="chosen_select widefat question-category-select">' . "\n";
-						$html .= '<option value="">' . __( 'Select a Question Category', 'woothemes-sensei' ) . '</option>' . "\n";
+						$html .= '<option value="">' . esc_html__( 'Select a Question Category', 'woothemes-sensei' ) . '</option>' . "\n";
 						foreach( $question_cats as $cat ) {
 							$html .= '<option value="' . esc_attr( $cat->term_id ) . '">' . esc_html( $cat->name ) . '</option>';
 						} // End For Loop
 						$html .= '</select></p>' . "\n";
 
-						$html .= '<p>' . __( 'Number of questions:', 'woothemes-sensei' ) . ' <input type="number" min="1" value="1" max="1" id="add-multiple-question-count" class="small-text"/>';
+						$html .= '<p>' . esc_html__( 'Number of questions:', 'woothemes-sensei' ) . ' <input type="number" min="1" value="1" max="1" id="add-multiple-question-count" class="small-text"/>';
 
-						$html .= '<a title="' . esc_attr( __( 'Add Question(s)', 'woothemes-sensei' ) ) . '" class="add_multiple_save button button-primary button-highlighted">' . esc_html( __( 'Add Question(s)', 'woothemes-sensei' ) ) . '</a></p>';
+						$html .= '<a title="' . esc_attr__( 'Add Question(s)', 'woothemes-sensei' ) . '" class="add_multiple_save button button-primary button-highlighted">' . esc_html__( 'Add Question(s)', 'woothemes-sensei' ) . '</a></p>';
 
 				    $html .= '</div>';
 				}
@@ -1312,7 +1311,7 @@ class Sensei_Lesson {
 		$question_cat_list = strip_tags( get_the_term_list( $question_id, 'question-category', '', ', ', '' ) );
 
 		$html .= '<tr class="' . esc_attr( $existing_class ) . '">
-					<td class="cb"><input type="checkbox" value="' . $question_id . '" class="existing-item" /></td>
+					<td class="cb"><input type="checkbox" value="' . esc_attr( $question_id ) . '" class="existing-item" /></td>
 					<td>' . get_the_title( $question_id ) . '</td>
 					<td>' . esc_html( $question_type ) . '</td>
 					<td>' . esc_html( $question_cat_list ) . '</td>
@@ -1379,7 +1378,7 @@ class Sensei_Lesson {
 
 			if( ! $html ) {
 				$html = '<tr class="alternate">
-								<td class="no-results" colspan="4"><em>' . __( 'There are no questions matching your search.', 'woothemes-sensei' ) . '</em></td>
+								<td class="no-results" colspan="4"><em>' . esc_html__( 'There are no questions matching your search.', 'woothemes-sensei' ) . '</em></td>
 							  </tr>';
 			}
 
@@ -1431,7 +1430,7 @@ class Sensei_Lesson {
 							if ( !isset( $right_answers[ $i ] ) ) { $right_answers[ $i ] = ''; }
 							$right_answer_id = $this->get_answer_id( $right_answers[ $i ] );
 							// Right Answer
-							$right_answer = '<label class="answer" for="question_' . esc_attr( $question_counter ) . '_right_answer_' . $i . '"><span>' . __( 'Right:' , 'woothemes-sensei' ) . '</span> <input rel="' . esc_attr( $right_answer_id ) . '" type="text" id="question_' . esc_attr( $question_counter ). '_right_answer_' . esc_attr( $i ) . '" name="question_right_answers[]" value="' . esc_attr( $right_answers[ $i ] ) . '" size="25" class="question_answer widefat" /> <a class="remove_answer_option"></a></label>';
+							$right_answer = '<label class="answer" for="question_' . esc_attr( $question_counter ) . '_right_answer_' . $i . '"><span>' . esc_html__( 'Right:' , 'woothemes-sensei' ) . '</span> <input rel="' . esc_attr( $right_answer_id ) . '" type="text" id="question_' . esc_attr( $question_counter ) . '_right_answer_' . esc_attr( $i ) . '" name="question_right_answers[]" value="' . esc_attr( $right_answers[ $i ] ) . '" size="25" class="question_answer widefat" /> <a class="remove_answer_option"></a></label>';
 							if( $question_id ) {
 								$answers[ $right_answer_id ] = $right_answer;
 							} else {
@@ -1452,7 +1451,7 @@ class Sensei_Lesson {
                         foreach ( $wrong_answers as $i => $answer ){
 
                             $answer_id = $this->get_answer_id( $answer );
-                            $wrong_answer = '<label class="answer" for="question_' .esc_attr( $question_counter ) . '_wrong_answer_' . esc_attr( $i ) . '"><span>' . __( 'Wrong:' , 'woothemes-sensei' ) ;
+                            $wrong_answer = '<label class="answer" for="question_' . esc_attr( $question_counter ) . '_wrong_answer_' . esc_attr( $i ) . '"><span>' . esc_html__( 'Wrong:' , 'woothemes-sensei' ) ;
                             $wrong_answer .= '</span> <input rel="' . esc_attr( $answer_id ) . '" type="text" id="question_' . esc_attr( $question_counter ) . '_wrong_answer_' . esc_attr( $i ) ;
                             $wrong_answer .= '" name="question_wrong_answers[]" value="' . esc_attr( $answer ) . '" size="25" class="question_answer widefat" /> <a class="remove_answer_option"></a></label>';
                             if( $question_id ) {
@@ -1489,12 +1488,12 @@ class Sensei_Lesson {
 				    	}
 
 				    	$html .= '<input type="hidden" class="answer_order" name="answer_order" value="' . esc_attr( $answer_order_string ) . '" />';
-				    	$html .= '<span class="hidden right_answer_count">' . esc_html( $total_right ). '</span>';
-				    	$html .= '<span class="hidden wrong_answer_count">' . esc_html($total_wrong) . '</span>';
+				    	$html .= '<span class="hidden right_answer_count">' . esc_html( $total_right ) . '</span>';
+				    	$html .= '<span class="hidden wrong_answer_count">' . esc_html( $total_wrong ) . '</span>';
 
 				    	$html .= '<div class="add_answer_options">';
-					    	$html .= '<a class="add_right_answer_option add_answer_option button" rel="' . esc_attr( $question_counter ) . '">' . __( 'Add right answer', 'woothemes-sensei' ) . '</a>';
-					    	$html .= '<a class="add_wrong_answer_option add_answer_option button" rel="' . esc_attr( $question_counter ) . '">' . __( 'Add wrong answer', 'woothemes-sensei' ) . '</a>';
+					    	$html .= '<a class="add_right_answer_option add_answer_option button" rel="' . esc_attr( $question_counter ) . '">' . esc_html__( 'Add right answer', 'woothemes-sensei' ) . '</a>';
+					    	$html .= '<a class="add_wrong_answer_option add_answer_option button" rel="' . esc_attr( $question_counter ) . '">' . esc_html__( 'Add wrong answer', 'woothemes-sensei' ) . '</a>';
 				    	$html .= '</div>';
 
                         $html .= $this->quiz_panel_question_feedback( $question_counter, $question_id , 'multiple-choice' );
@@ -1502,15 +1501,15 @@ class Sensei_Lesson {
 			    	$html .= '</div>';
 				break;
 				case 'boolean':
-					$html .= '<div class="question_boolean_fields ' . $question_class . '">';
+					$html .= '<div class="question_boolean_fields ' . esc_attr( $question_class ) . '">';
 						if( $question_id ) {
 							$field_name = 'question_' . esc_attr( $question_id ) . '_right_answer_boolean';
 						} else {
 							$field_name = 'question_right_answer_boolean';
 							$right_answer = 'true';
 						}
-						$html .= '<label for="question_' . esc_attr( $question_id ) . '_boolean_true"><input id="question_' . esc_attr( $question_id ) . '_boolean_true" type="radio" name="' . esc_attr( $field_name ) . '" value="true" '. checked( $right_answer, 'true', false ) . ' /> ' . __( 'True', 'woothemes-sensei' ) . '</label>';
-						$html .= '<label for="question_' . $question_id . '_boolean_false"><input id="question_' . esc_attr( $question_id ) . '_boolean_false" type="radio" name="' . esc_attr( $field_name )  . '" value="false" '. checked( $right_answer, 'false', false ) . ' /> ' . __( 'False', 'woothemes-sensei' ) . '</label>';
+						$html .= '<label for="question_' . esc_attr( $question_id ) . '_boolean_true"><input id="question_' . esc_attr( $question_id ) . '_boolean_true" type="radio" name="' . esc_attr( $field_name ) . '" value="true" '. checked( $right_answer, 'true', false ) . ' /> ' . esc_html__( 'True', 'woothemes-sensei' ) . '</label>';
+						$html .= '<label for="question_' . esc_attr( $question_id ) . '_boolean_false"><input id="question_' . esc_attr( $question_id ) . '_boolean_false" type="radio" name="' . esc_attr( $field_name ) . '" value="false" '. checked( $right_answer, 'false', false ) . ' /> ' . esc_html__( 'False', 'woothemes-sensei' ) . '</label>';
 
                     $html .= $this->quiz_panel_question_feedback( $question_counter, $question_id, 'boolean' );
 
@@ -1523,13 +1522,13 @@ class Sensei_Lesson {
 					if ( isset( $gapfill_array[2] ) ) { $gapfill_post = $gapfill_array[2]; } else { $gapfill_post = ''; }
 					$html .= '<div class="question_gapfill_fields ' . esc_attr( $question_class ) . '">';
 						// Fill in the Gaps
-						$html .= '<label>' . __( 'Text before the Gap:' , 'woothemes-sensei' ) . '</label> ';
-						$html .= '<input type="text" id="question_' . esc_attr( $question_counter )  . '_add_question_right_answer_gapfill_pre" name="add_question_right_answer_gapfill_pre" value="' . esc_attr( $gapfill_pre ) . '" size="25" class="widefat gapfill-field" />';
-	  					$html .= '<label>' . __( 'The Gap:' , 'woothemes-sensei' ) . '</label> ';
+						$html .= '<label>' . esc_html__( 'Text before the Gap:' , 'woothemes-sensei' ) . '</label> ';
+						$html .= '<input type="text" id="question_' . esc_attr( $question_counter ) . '_add_question_right_answer_gapfill_pre" name="add_question_right_answer_gapfill_pre" value="' . esc_attr( $gapfill_pre ) . '" size="25" class="widefat gapfill-field" />';
+	  					$html .= '<label>' . esc_html__( 'The Gap:' , 'woothemes-sensei' ) . '</label> ';
 	  					$html .= '<input type="text" id="question_' . esc_attr( $question_counter ) . '_add_question_right_answer_gapfill_gap" name="add_question_right_answer_gapfill_gap" value="' . esc_attr( $gapfill_gap ) . '" size="25" class="widefat gapfill-field" />';
-	  					$html .= '<label>' . __( 'Text after the Gap:' , 'woothemes-sensei' ) . '</label> ';
+	  					$html .= '<label>' . esc_html__( 'Text after the Gap:' , 'woothemes-sensei' ) . '</label> ';
 	  					$html .= '<input type="text" id="question_' . esc_attr( $question_counter ) . '_add_question_right_answer_gapfill_post" name="add_question_right_answer_gapfill_post" value="' . esc_attr( $gapfill_post ) . '" size="25" class="widefat gapfill-field" />';
-	  					$html .= '<label>' . __( 'Preview:' , 'woothemes-sensei' ) . '</label> ';
+	  					$html .= '<label>' . esc_html__( 'Preview:' , 'woothemes-sensei' ) . '</label> ';
 	  					$html .= '<p class="gapfill-preview">' . esc_html( $gapfill_pre ) . '&nbsp;<u>' . esc_html( $gapfill_gap ) . '</u>&nbsp;' . esc_html( $gapfill_post ) . '</p>';
 	  				$html .= '</div>';
 				break;
@@ -1541,7 +1540,7 @@ class Sensei_Lesson {
 						} else {
 							$field_id = 'add_question_right_answer_multiline';
 						}
-						$html .= '<label>' . __( 'Guide/Teacher Notes for grading the answer' , 'woothemes-sensei' ) . '</label> ';
+						$html .= '<label>' . esc_html__( 'Guide/Teacher Notes for grading the answer' , 'woothemes-sensei' ) . '</label> ';
 						$html .= '<textarea id="' . esc_attr( $field_id ) . '" name="add_question_right_answer_multiline" rows="4" cols="40" class="widefat">' . esc_textarea( $right_answer ) . '</textarea>';
 					$html .= '</div>';
 				break;
@@ -1553,7 +1552,7 @@ class Sensei_Lesson {
 						} else {
 							$field_id = 'add_question_right_answer_singleline';
 						}
-						$html .= '<label>' . __( 'Recommended Answer' , 'woothemes-sensei' ) . '</label> ';
+						$html .= '<label>' . esc_html__( 'Recommended Answer' , 'woothemes-sensei' ) . '</label> ';
 						$html .= '<input type="text" id="' . esc_attr( $field_id ) . '" name="add_question_right_answer_singleline" value="' . esc_attr( $right_answer ) . '" size="25" class="widefat" />';
 					$html .= '</div>';
 				break;
@@ -1571,11 +1570,11 @@ class Sensei_Lesson {
 						if( isset( $wrong_answers[0] ) ) {
 							$wrong_answer = $wrong_answers[0];
 						}
-						$html .= '<label>' . __( 'Description for student explaining what needs to be uploaded' , 'woothemes-sensei' ) . '</label> ';
+						$html .= '<label>' . esc_html__( 'Description for student explaining what needs to be uploaded' , 'woothemes-sensei' ) . '</label> ';
 						$html .= '<textarea id="' . esc_attr( $wrong_field_id ) . '" name="add_question_wrong_answer_fileupload" rows="4" cols="40" class="widefat">' . esc_textarea( $wrong_answer ) . '</textarea>';
 
 						// Guides for grading
-						$html .= '<label>' . __( 'Guide/Teacher Notes for grading the upload' , 'woothemes-sensei' ) . '</label> ';
+						$html .= '<label>' . esc_html__( 'Guide/Teacher Notes for grading the upload' , 'woothemes-sensei' ) . '</label> ';
 						$html .= '<textarea id="' . esc_attr( $right_field_id ) . '" name="add_question_right_answer_fileupload" rows="4" cols="40" class="widefat">' . esc_textarea( $right_answer ) . '</textarea>';
 					$html .= '</div>';
 				break;
@@ -1600,7 +1599,7 @@ class Sensei_Lesson {
         }// end if
 
 		if( $question_counter ) {
-			$field_name = 'answer_' . $question_counter . '_feedback';
+			$field_name = 'answer_' . esc_attr( $question_counter ) . '_feedback';
 		}
 
 		$feedback = '';
@@ -1609,8 +1608,8 @@ class Sensei_Lesson {
 		}
 
 		$html = '<p title="' . esc_attr__( 'This feedback will be automatically displayed to the student once they have completed the quiz.', 'woothemes-sensei' ) . '">';
-		$html .= '<label for="' . esc_attr( $field_name ) . '">' . __( 'Answer Feedback' , 'woothemes-sensei' ) . ':</label>';
-		$html .= '<textarea id="' . esc_attr( $field_name )  . '" name="' . esc_attr( $field_name )  . '" rows="4" cols="40" class="answer_feedback widefat">' . esc_textarea( $feedback ) . '</textarea>';
+		$html .= '<label for="' . esc_attr( $field_name ) . '">' . esc_html__( 'Answer Feedback' , 'woothemes-sensei' ) . ':</label>';
+		$html .= '<textarea id="' . esc_attr( $field_name ) . '" name="' . esc_attr( $field_name ) . '" rows="4" cols="40" class="answer_feedback widefat">' . esc_textarea( $feedback ) . '</textarea>';
 		$html .= '</p>';
 
 		return $html;
@@ -1727,15 +1726,15 @@ class Sensei_Lesson {
 		$settings = array(
 			array(
 				'id' 			=> 'pass_required',
-				'label'			=> __( 'Pass required to complete lesson', 'woothemes-sensei' ),
-				'description'	=> __( 'The passmark must be achieved before the lesson is complete.', 'woothemes-sensei' ),
+				'label'			=> esc_html__( 'Pass required to complete lesson', 'woothemes-sensei' ),
+				'description'	=> esc_html__( 'The passmark must be achieved before the lesson is complete.', 'woothemes-sensei' ),
 				'type'			=> 'checkbox',
 				'default'		=> '',
 				'checked'		=> 'on',
 			),
 			array(
 				'id' 			=> 'quiz_passmark',
-				'label'			=> __( 'Quiz passmark percentage', 'woothemes-sensei' ),
+				'label'			=> esc_html__( 'Quiz passmark percentage', 'woothemes-sensei' ),
 				'description'	=> '',
 				'type'			=> 'number',
 				'default'		=> 0,
@@ -1746,17 +1745,17 @@ class Sensei_Lesson {
 			),
 			array(
 				'id' 			=> 'show_questions',
-				'label'			=> __( 'Number of questions to show', 'woothemes-sensei' ),
-				'description'	=> __( 'Show a random selection of questions from this quiz each time a student views it.', 'woothemes-sensei' ),
+				'label'			=> esc_html__( 'Number of questions to show', 'woothemes-sensei' ),
+				'description'	=> esc_html__( 'Show a random selection of questions from this quiz each time a student views it.', 'woothemes-sensei' ),
 				'type'			=> 'number',
 				'default'		=> '',
-				'placeholder'	=> __( 'All', 'woothemes-sensei' ),
+				'placeholder'	=> esc_html__( 'All', 'woothemes-sensei' ),
 				'min'			=> 1,
 				'max'			=> $question_count,
 			),
 			array(
 				'id' 			=> 'random_question_order',
-				'label'			=> __( 'Randomise question order', 'woothemes-sensei' ),
+				'label'			=> esc_html__( 'Randomise question order', 'woothemes-sensei' ),
 				'description'	=> '',
 				'type'			=> 'checkbox',
 				'default'		=> 'no',
@@ -1764,16 +1763,16 @@ class Sensei_Lesson {
 			),
 			array(
 				'id' 			=> 'quiz_grade_type',
-				'label'			=> __( 'Grade quiz automatically', 'woothemes-sensei' ),
-				'description'	=> __( 'Grades quiz and displays answer explanation immediately after completion. Only applicable if quiz is limited to Multiple Choice, True/False and Gap Fill questions. Questions that have a grade of zero are skipped during autograding.', 'woothemes-sensei' ),
+				'label'			=> esc_html__( 'Grade quiz automatically', 'woothemes-sensei' ),
+				'description'	=> esc_html__( 'Grades quiz and displays answer explanation immediately after completion. Only applicable if quiz is limited to Multiple Choice, True/False and Gap Fill questions. Questions that have a grade of zero are skipped during autograding.', 'woothemes-sensei' ),
 				'type'			=> 'checkbox',
 				'default'		=> 'auto',
 				'checked'		=> 'auto',
 			),
 			array(
 				'id' 			=> 'enable_quiz_reset',
-				'label'			=> __( 'Allow user to retake the quiz', 'woothemes-sensei' ),
-				'description'	=> __( 'Enables the quiz reset button.', 'woothemes-sensei' ),
+				'label'			=> esc_html__( 'Allow user to retake the quiz', 'woothemes-sensei' ),
+				'description'	=> esc_html__( 'Enables the quiz reset button.', 'woothemes-sensei' ),
 				'type'			=> 'checkbox',
 				'default'		=> '',
 				'checked'		=> 'on',
@@ -1803,7 +1802,7 @@ class Sensei_Lesson {
 
 			// Load the lessons script
             wp_enqueue_media();
-			wp_enqueue_script( 'sensei-lesson-metadata', Sensei()->plugin_url . 'assets/js/lesson-metadata' . $suffix . '.js', array( 'jquery', 'sensei-core-select2' ,'jquery-ui-sortable','underscore'), Sensei()->version, true );
+			wp_enqueue_script( 'sensei-lesson-metadata', Sensei()->plugin_url . 'assets/js/lesson-metadata' . $suffix . '.js', array( 'jquery', 'sensei-core-select2' ,'jquery-ui-sortable' ), Sensei()->version, true );
 			wp_enqueue_script( 'sensei-lesson-chosen', Sensei()->plugin_url . 'assets/chosen/chosen.jquery' . $suffix . '.js', array( 'jquery' ), Sensei()->version, true );
 			wp_enqueue_script( 'sensei-chosen-ajax', Sensei()->plugin_url . 'assets/chosen/ajax-chosen.jquery' . $suffix . '.js', array( 'jquery', 'sensei-lesson-chosen' ), Sensei()->version, true );
 
@@ -1813,8 +1812,26 @@ class Sensei_Lesson {
             }
 
 			// Localise script
-			$translation_strings = array( 'right_colon' => __( 'Right:', 'woothemes-sensei' ), 'wrong_colon' => __( 'Wrong:', 'woothemes-sensei' ), 'add_file' => __( 'Add file', 'woothemes-sensei' ), 'change_file' => __( 'Change file', 'woothemes-sensei' ), 'confirm_remove' => __( 'Are you sure you want to remove this question?', 'woothemes-sensei' ), 'confirm_remove_multiple' => __( 'Are you sure you want to remove these questions?', 'woothemes-sensei' ), 'too_many_for_cat' => __( 'You have selected more questions than this category contains - please reduce the number of questions that you are adding.', 'woothemes-sensei' ) );
-			$ajax_vars = array( 'lesson_update_question_nonce' => wp_create_nonce( 'lesson_update_question_nonce' ), 'lesson_add_course_nonce' => wp_create_nonce( 'lesson_add_course_nonce' ), 'lesson_update_grade_type_nonce' => wp_create_nonce( 'lesson_update_grade_type_nonce' ), 'lesson_update_question_order_nonce' => wp_create_nonce( 'lesson_update_question_order_nonce' ), 'lesson_update_question_order_random_nonce' => wp_create_nonce( 'lesson_update_question_order_random_nonce' ), 'lesson_add_multiple_questions_nonce' => wp_create_nonce( 'lesson_add_multiple_questions_nonce' ), 'lesson_remove_multiple_questions_nonce' => wp_create_nonce( 'lesson_remove_multiple_questions_nonce' ), 'lesson_add_existing_questions_nonce' => wp_create_nonce( 'lesson_add_existing_questions_nonce' ), 'filter_existing_questions_nonce' => wp_create_nonce( 'filter_existing_questions_nonce' ) );
+			$translation_strings = array(
+				'right_colon' => esc_html__( 'Right:', 'woothemes-sensei' ),
+				'wrong_colon' => esc_html__( 'Wrong:', 'woothemes-sensei' ),
+				'add_file' => esc_html__( 'Add file', 'woothemes-sensei' ),
+				'change_file' => esc_html__( 'Change file', 'woothemes-sensei' ),
+				'confirm_remove' => esc_html__( 'Are you sure you want to remove this question?','woothemes-sensei' ), 'confirm_remove_multiple' => esc_html__( 'Are you sure you want to remove these questions?', 'woothemes-sensei' ),
+				'too_many_for_cat' => esc_html__( 'You have selected more questions than this category contains - please reduce the number of questions that you are adding.', 'woothemes-sensei' )
+			);
+
+			$ajax_vars = array(
+				'lesson_update_question_nonce' => wp_create_nonce( 'lesson_update_question_nonce' ),
+				'lesson_add_course_nonce' => wp_create_nonce( 'lesson_add_course_nonce' ),
+				'lesson_update_grade_type_nonce' => wp_create_nonce( 'lesson_update_grade_type_nonce' ), 'lesson_update_question_order_nonce' => wp_create_nonce( 'lesson_update_question_order_nonce' ),
+				'lesson_update_question_order_random_nonce' => wp_create_nonce( 'lesson_update_question_order_random_nonce' ),
+				'lesson_add_multiple_questions_nonce' => wp_create_nonce( 'lesson_add_multiple_questions_nonce' ),
+				'lesson_remove_multiple_questions_nonce' => wp_create_nonce( 'lesson_remove_multiple_questions_nonce' ),
+				'lesson_add_existing_questions_nonce' => wp_create_nonce( 'lesson_add_existing_questions_nonce' ),
+				'filter_existing_questions_nonce' => wp_create_nonce( 'filter_existing_questions_nonce' )
+			);
+
 			$data = array_merge( $translation_strings, $ajax_vars );
 			wp_localize_script( 'sensei-lesson-metadata', 'woo_localized_data', $data );
 
@@ -1884,13 +1901,13 @@ class Sensei_Lesson {
 			case 'lesson-course':
 				$lesson_course_id = get_post_meta( $id, '_lesson_course', true);
 				if ( 0 < absint( $lesson_course_id ) ) {
-					echo '<a href="' . esc_url( get_edit_post_link( absint( $lesson_course_id ) ) ) . '" title="' . esc_attr( sprintf( __( 'Edit %s', 'woothemes-sensei' ), get_the_title( absint( $lesson_course_id ) ) ) ) . '">' . get_the_title( absint( $lesson_course_id ) ) . '</a>';
+					echo '<a href="' . esc_url( get_edit_post_link( absint( $lesson_course_id ) ) ) . '" title="' . sprintf( esc_attr__( 'Edit %s', 'woothemes-sensei' ), get_the_title( absint( $lesson_course_id ) ) ) . '">' . get_the_title( absint( $lesson_course_id ) ) . '</a>';
 				} // End If Statement
 			break;
 			case 'lesson-prerequisite':
 				$lesson_prerequisite_id = get_post_meta( $id, '_lesson_prerequisite', true);
 				if ( 0 < absint( $lesson_prerequisite_id ) ) {
-					echo '<a href="' . esc_url( get_edit_post_link( absint( $lesson_prerequisite_id ) ) ) . '" title="' . esc_attr( sprintf( __( 'Edit %s', 'woothemes-sensei' ), get_the_title( absint( $lesson_prerequisite_id ) ) ) ) . '">' . get_the_title( absint( $lesson_prerequisite_id ) ) . '</a>';
+					echo '<a href="' . esc_url( get_edit_post_link( absint( $lesson_prerequisite_id ) ) ) . '" title="' . sprintf( esc_attr__( 'Edit %s', 'woothemes-sensei' ), get_the_title( absint( $lesson_prerequisite_id ) ) ) . '">' . get_the_title( absint( $lesson_prerequisite_id ) ) . '</a>';
 				} // End If Statement
 			break;
 			default:
@@ -1961,7 +1978,7 @@ class Sensei_Lesson {
 		// Question Save and Delete logic
 		if ( isset( $question_data['action'] ) && ( $question_data['action'] == 'delete' ) ) {
 			// Delete the Question
-			$return = $this->lesson_delete_question($question_data);
+			$return = $this->lesson_remove_question($question_data);
 		} else {
 			// Save the Question
 			if ( isset( $question_data['quiz_id'] ) && ( 0 < absint( $question_data['quiz_id'] ) ) ) {
@@ -2017,7 +2034,7 @@ class Sensei_Lesson {
 				$post_data = array(
 					'post_content' => '',
 					'post_status' => 'publish',
-					'post_title' => sprintf( __( '%1$s Question(s) from %2$s', 'woothemes-sensei' ), $question_number, $cat->name ),
+					'post_title' => sprintf( esc_html__( '%1$s Question(s) from %2$s', 'woothemes-sensei' ), $question_number, $cat->name ),
 					'post_type' => 'multiple_question'
 				);
 
@@ -2049,20 +2066,27 @@ class Sensei_Lesson {
 		} // End If Statement
 
 		if( ! wp_verify_nonce( $nonce, 'lesson_remove_multiple_questions_nonce' )
-        || ! current_user_can( 'edit_lessons' ) ) {
+        || ! current_user_can( 'edit_lessons' ) || ! isset( $_POST['data'] ) ) {
 			die('');
 		} // End If Statement
 
 		// Parse POST data
-		$data = $_POST['data'];
 		$question_data = array();
-		parse_str( $data, $question_data );
+		parse_str( $_POST['data'], $question_data );
 
-		if( is_array( $question_data ) ) {
-			wp_delete_post( $question_data['question_id'], true );
+		$question_id_to_remove      = $question_data['question_id'];
+		$quiz_id_to_be_removed_from = $question_data['quiz_id'];
+
+		// remove the question from the lesson quiz
+		$quizzes = get_post_meta( $question_id_to_remove, '_quiz_id', false );
+		foreach( $quizzes as $quiz_id ) {
+			if( $quiz_id == $quiz_id_to_be_removed_from  ) {
+				delete_post_meta( $question_id_to_remove, '_quiz_id', $quiz_id );
+				die( 'Deleted' );
+			}
 		}
 
-		die( 'Deleted' );
+		die('');
 	}
 
 	public function get_question_category_limit() {
@@ -2521,33 +2545,36 @@ class Sensei_Lesson {
 
 
 	/**
-	 * lesson_delete_question function.
+	 * Remove question from lesson
 	 *
 	 * @access private
 	 * @param array $data (default: array())
 	 * @return boolean
 	 */
-	private function lesson_delete_question( $data = array() ) {
+	private function lesson_remove_question( $data = array() ) {
 
 		// Get which question to delete
 		$question_id = 0;
 		if ( isset( $data[ 'question_id' ] ) && ( 0 < absint( $data[ 'question_id' ] ) ) ) {
 			$question_id = absint( $data[ 'question_id' ] );
 		} // End If Statement
-		// Delete the question
-		if ( 0 < $question_id ) {
-			$quizzes = get_post_meta( $question_id, '_quiz_id', false );
 
-			foreach( $quizzes as $quiz_id ) {
-				if( $quiz_id == $data['quiz_id'] ) {
-					delete_post_meta( $question_id, '_quiz_id', $quiz_id );
-				}
+		if ( empty( $question_id ) ) {
+			return false;
+		}
+
+		// remove the question from the lesson quiz
+		$quizzes = get_post_meta( $question_id, '_quiz_id', false );
+
+		foreach( $quizzes as $quiz_id ) {
+			if( $quiz_id == $data['quiz_id'] ) {
+				delete_post_meta( $question_id, '_quiz_id', $quiz_id );
 			}
+		}
 
-			return true;
-		} // End If Statement
-		return false;
-	} // End lesson_delete_question()
+		return true;
+
+	}
 
 
 	/**
@@ -2559,9 +2586,9 @@ class Sensei_Lesson {
 	public function lesson_complexities() {
 
 		// V2 - make filter for this array
-        $lesson_complexities = array( 	'easy' => __( 'Easy', 'woothemes-sensei' ),
-									'std' => __( 'Standard', 'woothemes-sensei' ),
-									'hard' => __( 'Hard', 'woothemes-sensei' )
+        $lesson_complexities = array( 	'easy' => esc_html__( 'Easy', 'woothemes-sensei' ),
+									'std' => esc_html__( 'Standard', 'woothemes-sensei' ),
+									'hard' => esc_html__( 'Hard', 'woothemes-sensei' )
 									);
 
 		return $lesson_complexities;
@@ -2820,25 +2847,28 @@ class Sensei_Lesson {
 
         // Save the questions that will be asked for the current user
         // this happens only once per user/quiz, unless the user resets the quiz
-        if( ! is_admin() ){
+        if( ! is_admin() && $user_lesson_status ){
 
-            if( $user_lesson_status ) {
+        	// user lesson status can return as an array.
+        	if ( is_array( $user_lesson_status ) ) {
+        		$comment_ID = $user_lesson_status[0]->comment_ID;
 
-                $questions_asked = get_comment_meta($user_lesson_status->comment_ID, 'questions_asked', true);
-                if ( empty($questions_asked) && $user_lesson_status) {
+	        } else {
+		        $comment_ID = $user_lesson_status->comment_ID;
+	        }
 
-                    $questions_asked = array();
-                    foreach ($questions as $question) {
+            $questions_asked = get_comment_meta($comment_ID, 'questions_asked', true);
+            if ( empty( $questions_asked ) && $user_lesson_status) {
 
-                        $questions_asked[] = $question->ID;
+                $questions_asked = array();
 
-                    }
-
-                    // save the questions asked id
-                    $questions_asked_csv = implode(',', $questions_asked);
-                    update_comment_meta($user_lesson_status->comment_ID, 'questions_asked', $questions_asked_csv);
-
+                foreach ($questions as $question) {
+                    $questions_asked[] = $question->ID;
                 }
+
+                // save the questions asked id
+                $questions_asked_csv = implode(',', $questions_asked);
+                update_comment_meta($comment_ID, 'questions_asked', $questions_asked_csv);
             }
         }
 
@@ -2908,7 +2938,7 @@ class Sensei_Lesson {
 		// Get Width and Height settings
 		if ( ( $width == '100' ) && ( $height == '100' ) ) {
 
-			if ( is_singular( 'lesson' ) ) {
+			if ( is_singular( 'lesson' ) || !empty( $lesson_id  ) ) {
 
 				if ( ! $widget && ! Sensei()->settings->settings[ 'lesson_single_image_enable' ] ) {
 
@@ -2939,25 +2969,34 @@ class Sensei_Lesson {
 
 		} // End If Statement
 
-		$img_url = '';
+		$img_element = '';
 
 		if ( has_post_thumbnail( $lesson_id ) ) {
 
-   			// Get Featured Image
-   			$img_url = get_the_post_thumbnail( $lesson_id, array( $width, $height ), array( 'class' => 'woo-image thumbnail alignleft') );
+			// Get Featured Image
+			$img_element = get_the_post_thumbnail( $lesson_id, array( $width, $height ), array( 'class' => 'woo-image thumbnail alignleft') );
 
  		} else {
 
  			// Display Image Placeholder if none
 			if ( Sensei()->settings->settings[ 'placeholder_images_enable' ] ) {
 
-                $img_url = apply_filters( 'sensei_lesson_placeholder_image_url', '<img src="http://placehold.it/' . $width . 'x' . $height . '" class="woo-image thumbnail alignleft" />' );
+                $img_element = apply_filters( 'sensei_lesson_placeholder_image_url', '<img src="http://placehold.it/' . esc_attr( $width ) . 'x' . esc_attr( $height ) . '" class="woo-image thumbnail alignleft" />' );
 
 			} // End If Statement
 
 		} // End If Statement
 
-		$html .= '<a href="' . get_permalink( $lesson_id ) . '" title="' . esc_attr( get_post_field( 'post_title', $lesson_id ) ) . '">' . $img_url . '</a>';
+		if ( is_singular( 'lesson' ) ) {
+
+			$html .=  $img_element;
+
+		} else {
+
+			$html .= '<a href="' . get_permalink( $lesson_id ) . '" title="' . esc_attr( get_post_field( 'post_title', $lesson_id ) ) . '">' . $img_element . '</a>';
+
+		}
+
 
 		return $html;
 
@@ -3057,7 +3096,7 @@ class Sensei_Lesson {
         <fieldset class="sensei-edit-field-set inline-edit-lesson">
             <div class="sensei-inline-edit-col column-<?php echo $column_name ?>">
                     <?php
-                    echo '<h4>' . __('Lesson Information', 'woothemes-sensei') . '</h4>';
+                    echo '<h4>' . esc_html__('Lesson Information', 'woothemes-sensei') . '</h4>';
                     // create a nonce field to be  used as a security measure when saving the data
                     wp_nonce_field( 'bulk-edit-lessons', '_edit_lessons_nonce' );
                     wp_nonce_field( 'sensei-save-post-meta','woo_' . $this->token . '_nonce'  );
@@ -3065,7 +3104,7 @@ class Sensei_Lesson {
                     // unchanged option - we need this in because
                     // the default option in bulk edit should not be empty. If it is
                     // the user will erase data they didn't want to touch.
-                    $no_change_text = '-- ' . __('No Change', 'woothemes-sensei') . ' --';
+                    $no_change_text = '-- ' . esc_html__('No Change', 'woothemes-sensei') . ' --';
 
                     //
                     //course selection
@@ -3081,7 +3120,7 @@ class Sensei_Lesson {
                     $course_options['-1']=  $no_change_text;
                     $course_attributes = array( 'name'=> 'lesson_course', 'id'=>'sensei-edit-lesson-course' , 'class'=>' ' );
                     $course_field =  Sensei_Utils::generate_drop_down( '-1', $course_options, $course_attributes );
-                    echo $this->generate_all_lessons_edit_field( __('Lesson Course', 'woothemes-sensei'),   $course_field  );
+                    echo $this->generate_all_lessons_edit_field( esc_html__('Lesson Course', 'woothemes-sensei'),   $course_field  );
 
                     //
                     // lesson complexity selection
@@ -3091,7 +3130,7 @@ class Sensei_Lesson {
                     $lesson_complexities['-1']=  $no_change_text;
                     $complexity_dropdown_attributes = array( 'name'=> 'lesson_complexity', 'id'=>'sensei-edit-lesson-complexity' , 'class'=>' ');
                     $complexity_filed =  Sensei_Utils::generate_drop_down( '-1', $lesson_complexities, $complexity_dropdown_attributes );
-                    echo $this->generate_all_lessons_edit_field( __('Lesson Complexity', 'woothemes-sensei'),   $complexity_filed  );
+                    echo $this->generate_all_lessons_edit_field( esc_html__('Lesson Complexity', 'woothemes-sensei'),   $complexity_filed  );
 
                     ?>
 
@@ -3104,34 +3143,34 @@ class Sensei_Lesson {
                     //
                     $pass_required_options = array(
                         '-1' => $no_change_text,
-                         '0' => __('No','woothemes'),
-                         '1' => __('Yes','woothemes'),
+                         '0' => esc_html__( 'No', 'woothemes-sensei' ),
+                         '1' => esc_html__( 'Yes', 'woothemes-sensei' ),
                     );
 
                     $pass_required_select_attributes = array( 'name'=> 'pass_required',
                                                                 'id'=> 'sensei-edit-lesson-pass-required',
                                                                 'class'=>' '   );
                     $require_pass_field =  Sensei_Utils::generate_drop_down( '-1', $pass_required_options, $pass_required_select_attributes, false );
-                    echo $this->generate_all_lessons_edit_field( __('Pass required', 'woothemes-sensei'),   $require_pass_field  );
+                    echo $this->generate_all_lessons_edit_field( esc_html__('Pass required', 'woothemes-sensei'),   $require_pass_field  );
 
                     //
                     // Quiz pass percentage
                     //
                     $quiz_pass_percentage_field = '<input name="quiz_passmark" id="sensei-edit-quiz-pass-percentage" type="number" />';
-                    echo $this->generate_all_lessons_edit_field( __('Pass Percentage', 'woothemes-sensei'), $quiz_pass_percentage_field  );
+                    echo $this->generate_all_lessons_edit_field( esc_html__('Pass Percentage', 'woothemes-sensei'), $quiz_pass_percentage_field  );
 
                     //
                     // Enable quiz reset button
                     //
                     $quiz_reset_select__options = array(
                         '-1' => $no_change_text,
-                        '0' => __('No','woothemes'),
-                        '1' => __('Yes','woothemes'),
+                        '0' => esc_html__( 'No', 'woothemes-sensei' ),
+                        '1' => esc_html__( 'Yes', 'woothemes-sensei' ),
                     );
                     $quiz_reset_name_id = 'sensei-edit-enable-quiz-reset';
                     $quiz_reset_select_attributes = array( 'name'=> 'enable_quiz_reset', 'id'=>$quiz_reset_name_id, 'class'=>' ' );
                     $quiz_reset_field =  Sensei_Utils::generate_drop_down( '-1', $quiz_reset_select__options, $quiz_reset_select_attributes, false );
-                    echo $this->generate_all_lessons_edit_field( __('Enable quiz reset button', 'woothemes-sensei'), $quiz_reset_field  );
+                    echo $this->generate_all_lessons_edit_field( esc_html__('Enable quiz reset button', 'woothemes-sensei'), $quiz_reset_field  );
 
                     ?>
             </div>
@@ -3154,7 +3193,7 @@ class Sensei_Lesson {
 
         $html = '';
         $html = '<div class="inline-edit-group" >';
-        $html .=  '<span class="title">'. $title .'</span> ';
+        $html .=  '<span class="title">'. esc_html( $title ) .'</span> ';
         $html .= '<span class="input-text-wrap">';
         $html .= $field;
         $html .= '</span>';
@@ -3354,7 +3393,7 @@ class Sensei_Lesson {
         if ( $is_preview && !$is_user_taking_course ) {
 
             $preview_label = Sensei()->frontend->sensei_lesson_preview_title_text( $lesson_id);
-            $preview_label = '<span class="preview-heading">' . $preview_label . '</span>';
+            $preview_label = '<span class="preview-heading">' . esc_html( $preview_label ) . '</span>';
 
         }
 
@@ -3368,17 +3407,17 @@ class Sensei_Lesson {
          */
         if( apply_filters( 'sensei_show_lesson_numbers', false ) ) {
 
-            $count_markup =  '<span class="lesson-number">' . $loop_lesson_number. '</span>';
+            $count_markup =  '<span class="lesson-number">' . esc_html( $loop_lesson_number ) . '</span>';
 
         }
 
-        $heading_link_title = sprintf( __( 'Start %s', 'woothemes-sensei' ), get_the_title( $lesson_id ) );
+        $heading_link_title = sprintf( esc_html__( 'Start %s', 'woothemes-sensei' ), get_the_title( $lesson_id ) );
 
         ?>
         <header>
             <h2>
-                <a href="<?php echo esc_url_raw( get_permalink( $lesson_id ) ) ?>"
-                   title="<?php esc_attr_e( $heading_link_title ) ?>" >
+                <a href="<?php echo esc_url( get_permalink( $lesson_id ) ) ?>"
+                   title="<?php echo esc_attr( $heading_link_title ) ?>" >
                     <?php echo $count_markup. get_the_title( $lesson_id ) . $preview_label; ?>
                 </a>
             </h2>
@@ -3393,28 +3432,28 @@ class Sensei_Lesson {
                 $lesson_length = get_post_meta( $lesson_id, '_lesson_length', true );
                 if ( '' != $lesson_length ) {
 
-                    $meta_html .= '<span class="lesson-length">' .  __( 'Length: ', 'woothemes-sensei' ) . $lesson_length . __( ' minutes', 'woothemes-sensei' ) . '</span>';
+                    $meta_html .= '<span class="lesson-length">' .  esc_html__( 'Length: ', 'woothemes-sensei' ) . esc_html( $lesson_length ) . esc_html__( ' minutes', 'woothemes-sensei' ) . '</span>';
 
                 }
 
                 if ( Sensei()->settings->get( 'lesson_author' ) ) {
 
-                    $meta_html .= '<span class="lesson-author">' .  __( 'Author: ', 'woothemes-sensei' ) . '<a href="' . get_author_posts_url( absint( get_post()->post_author ) ) . '" title="' . esc_attr( $user_info->display_name ) . '">' . esc_html( $user_info->display_name ) . '</a></span>';
+                    $meta_html .= '<span class="lesson-author">' .  esc_html__( 'Author: ', 'woothemes-sensei' ) . '<a href="' . get_author_posts_url( absint( get_post()->post_author ) ) . '" title="' . esc_attr( $user_info->display_name ) . '">' . esc_html( $user_info->display_name ) . '</a></span>';
 
                 } // End If Statement
                 if ( '' != $lesson_complexity ) {
 
-                    $meta_html .= '<span class="lesson-complexity">' .  __( 'Complexity: ', 'woothemes-sensei' ) . $lesson_complexity .'</span>';
+                    $meta_html .= '<span class="lesson-complexity">' .  esc_html__( 'Complexity: ', 'woothemes-sensei' ) . $lesson_complexity .'</span>';
 
                 }
 
-                if ( $single_lesson_complete ) {
+                if ( Sensei_Utils::user_completed_lesson( $lesson_id, get_current_user_id() ) ) {
 
                     $meta_html .= '<span class="lesson-status complete">' .__( 'Complete', 'woothemes-sensei' ) .'</span>';
 
                 } elseif ( $user_lesson_status ) {
 
-                    $meta_html .= '<span class="lesson-status in-progress">' . __( 'In Progress', 'woothemes-sensei' ) .'</span>';
+                    $meta_html .= '<span class="lesson-status in-progress">' . esc_html__( 'In Progress', 'woothemes-sensei' ) .'</span>';
 
                 } // End If Statement
 
@@ -3553,13 +3592,7 @@ class Sensei_Lesson {
         $user_taking_course = Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id() );
 
         if ( $pre_requisite_complete && $is_preview && !$user_taking_course ) {
-            ?>
 
-            <div class="sensei-message alert">
-                <?php echo Sensei()->permissions_message['message']; ?>
-            </div>
-
-            <?php
 
         }// end if
 
@@ -3581,72 +3614,84 @@ class Sensei_Lesson {
             return;
 
         }
+
         ?>
 
         <section class="course-signup lesson-meta">
 
             <?php
+
+            global $current_user;
             $wc_post_id = (int) get_post_meta( $course_id, '_course_woocommerce_product', true );
 
-            if ( Sensei_WC::is_woocommerce_active() && ( 0 < $wc_post_id ) ) {
+            if ( Sensei_WC::is_woocommerce_active() && Sensei_WC::is_course_purchasable( $course_id ) ) {
 
-                global $current_user;
-                if( is_user_logged_in() ) {
-                    wp_get_current_user();
+                if( is_user_logged_in() && ! Sensei_Utils::user_started_course( $course_id, $current_user->ID )  ) {
 
-                    $course_purchased = Sensei_Utils::sensei_customer_bought_product( $current_user->user_email, $current_user->ID, $wc_post_id );
+	                    $a_element = '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr__( 'Sign Up', 'woothemes-sensei' )  . '">';
+	                    $a_element .= esc_html__( 'course', 'woothemes-sensei' );
+	                    $a_element .= '</a>';
 
-                    if( $course_purchased ) {
+	                    if( Sensei_Utils::is_preview_lesson( get_the_ID()  ) ){
 
-                        $prereq_course_id = get_post_meta( $course_id, '_course_prerequisite',true );
-                        $course_link = '<a href="' . esc_url( get_permalink( $prereq_course_id ) ) . '" title="' . esc_attr( get_the_title( $prereq_course_id ) ) . '">' . __( 'the previous course', 'woothemes-sensei' )  . '</a>';
-                        ?>
-                            <div class="sensei-message info">
+		                    $message = sprintf( esc_html__( 'This is a preview lesson. Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $a_element );
 
-                                <?php  echo sprintf( __( 'Please complete %1$s before starting the lesson.', 'woothemes-sensei' ), $course_link ); ?>
+	                    }else{
 
-                            </div>
+		                    $message = sprintf( esc_html__( 'Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $a_element );
 
-                    <?php } else { ?>
+	                    }
 
-                        <div class="sensei-message info">
+	                    Sensei()->notices->add_notice( $message, 'info' );
 
-                            <?php
-                            $course_link = '<a href="' . esc_url( get_permalink( $course_id ) )
-                                            . '"title="' . __( 'Sign Up', 'woothemes-sensei' )
-                                            . '">' . __( 'course', 'woothemes-sensei' )
-                                            . '</a>';
+                }
 
-                            echo  sprintf( __( 'Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $course_link );
+	            if( ! is_user_logged_in() ) {
 
-                            ?>
+	                $a_element = '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr__( 'Sign Up', 'woothemes-sensei' )  . '">';
+	                $a_element .= esc_html__( 'course', 'woothemes-sensei' );
+	                $a_element .= '</a>';
 
-                        </div>
-                    <?php } ?>
+	                if( Sensei_Utils::is_preview_lesson( get_the_ID()  ) ){
 
-                <?php } else { ?>
+						$message = sprintf( esc_html__( 'This is a preview lesson. Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $a_element );
 
-                    <div class="sensei-message info"><?php echo sprintf( __( 'Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . __( 'Sign Up', 'woothemes-sensei' )  . '">' . __( 'course', 'woothemes-sensei' ) . '</a>' ); ?></div>
+					}else{
 
-                <?php } ?>
+						$message = sprintf( esc_html__( 'Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $a_element );
 
-            <?php } else { ?>
+					}
 
-            <?php if( ! Sensei_Utils::user_started_course( $course_id, get_current_user_id() ) &&  sensei_is_login_required() )  : ?>
+					Sensei()->notices->add_notice( $message, 'alert' );
 
-                <div class="sensei-message info">
-                    <?php
-                    $course_link =  '<a href="'
-                                        . esc_url( get_permalink( $course_id ) )
-                                        . '" title="' . __( 'Sign Up', 'woothemes-sensei' )
-                                        . '">' . __( 'course', 'woothemes-sensei' )
-                                    . '</a>';
+	            }
 
-                    echo sprintf( __( 'Please sign up for the %1$s before starting the lesson.', 'woothemes-sensei' ),  $course_link );
-                    ?>
-                </div>
+            } else { ?>
 
-            <?php endif; ?>
+	            <?php if( ! Sensei_Utils::user_started_course( $course_id, get_current_user_id() ) &&  sensei_is_login_required() )  : ?>
+
+	                <div class="sensei-message alert">
+	                    <?php
+	                    $course_link =  '<a href="'
+	                                        . esc_url( get_permalink( $course_id ) )
+	                                        . '" title="' . esc_attr__( 'Sign Up', 'woothemes-sensei' )
+	                                        . '">' . esc_html__( 'course', 'woothemes-sensei' )
+	                                    . '</a>';
+
+						if ( Sensei_Utils::is_preview_lesson( get_the_ID( ) ) ) {
+
+							echo sprintf( esc_html__( 'This is a preview lesson. Please sign up for the %1$s to access all lessons.', 'woothemes-sensei' ),  $course_link );
+
+						} else {
+
+							echo sprintf( esc_html__( 'Please sign up for the %1$s before starting the lesson.', 'woothemes-sensei' ),  $course_link );
+
+						}
+
+	                    ?>
+	                </div>
+
+	            <?php endif; ?>
 
             <?php } // End If Statement ?>
 
@@ -3666,8 +3711,8 @@ class Sensei_Lesson {
         $lesson_has_pre_requisite = $lesson_prerequisite > 0;
         if ( ! WooThemes_Sensei_Lesson::is_prerequisite_complete(  get_the_ID(), get_current_user_id() ) && $lesson_has_pre_requisite ) {
 
-            $prerequisite_lesson_link  = '<a href="' . esc_url( get_permalink( $lesson_prerequisite ) ) . '" title="' . esc_attr(  sprintf( __( 'You must first complete: %1$s', 'woothemes-sensei' ), get_the_title( $lesson_prerequisite ) ) ) . '">' . get_the_title( $lesson_prerequisite ). '</a>';
-            echo sprintf( __( 'You must first complete %1$s before viewing this Lesson', 'woothemes-sensei' ), $prerequisite_lesson_link );
+            $prerequisite_lesson_link  = '<a href="' . esc_url( get_permalink( $lesson_prerequisite ) ) . '" title="' . sprintf( esc_attr__( 'You must first complete: %1$s', 'woothemes-sensei' ), get_the_title( $lesson_prerequisite ) ) . '">' . get_the_title( $lesson_prerequisite ). '</a>';
+            Sensei()->notices->add_notice( sprintf( esc_html__( 'You must first complete %1$s before viewing this Lesson', 'woothemes-sensei' ), $prerequisite_lesson_link ), 'info');
 
         }
 
@@ -3695,7 +3740,21 @@ class Sensei_Lesson {
 
         $before_html = '<header class="archive-header"><h1>';
         $after_html = '</h1></header>';
-        $html = $before_html .  __( 'Lessons Archive', 'woothemes-sensei' ) . $after_html;
+
+	    $title= '';
+	    if ( is_post_type_archive( 'lesson' ) ){
+
+	        $title = esc_html__( 'Lessons Archive', 'woothemes-sensei' );
+
+	    } elseif ( is_tax( 'module' ) ) {
+
+		    global $wp_query;
+		    $term = $wp_query->get_queried_object();
+		    $title = $term->name;
+
+	    }
+
+        $html = $before_html . $title . $after_html;
 
         echo apply_filters( 'sensei_lesson_archive_title', $html );
 
@@ -3769,6 +3828,12 @@ class Sensei_Lesson {
 
         $lesson_id                 =  empty( $lesson_id ) ?  get_the_ID() : $lesson_id;
         $user_id                   = empty( $lesson_id ) ?  get_current_user_id() : $user_id;
+
+
+	    if ( ! sensei_can_user_view_lesson( $lesson_id, $user_id ) ) {
+		    return;
+	    }
+
         $lesson_prerequisite       = (int) get_post_meta( $lesson_id, '_lesson_prerequisite', true );
         $lesson_course_id          = (int) get_post_meta( $lesson_id, '_lesson_course', true );
         $quiz_id                   = Sensei()->lesson->lesson_quizzes( $lesson_id );
@@ -3781,6 +3846,7 @@ class Sensei_Lesson {
             $show_actions = Sensei_Utils::user_completed_lesson( $lesson_prerequisite, $user_id );
 
         }
+
         ?>
 
         <footer>
@@ -3795,10 +3861,10 @@ class Sensei_Lesson {
                     <p>
 
                         <a class="button"
-                           href="<?php echo esc_url_raw( get_permalink( $quiz_id ) ); ?>"
-                           title="<?php _e( 'View the Lesson Quiz', 'woothemes-sensei'  ); ?>">
+                           href="<?php echo esc_url( get_permalink( $quiz_id ) ); ?>"
+                           title="<?php esc_attr_e( 'View the Lesson Quiz', 'woothemes-sensei'  ); ?>">
 
-                            <?php  _e( 'View the Lesson Quiz', 'woothemes-sensei' ); ?>
+                            <?php  esc_html_e( 'View the Lesson Quiz', 'woothemes-sensei' ); ?>
 
                         </a>
 
@@ -3832,16 +3898,11 @@ class Sensei_Lesson {
      */
     public static function output_comments(){
 
-        if( ! is_user_logged_in() ){
-            return;
-        }
-
-        $pre_requisite_complete = Sensei()->lesson->is_prerequisite_complete( get_the_ID(), get_current_user_id() );
         $course_id = Sensei()->lesson->get_course_id( get_the_ID() );
         $allow_comments = Sensei()->settings->settings[ 'lesson_comments' ];
         $user_taking_course = Sensei_Utils::user_started_course($course_id );
 
-        $lesson_allow_comments = $allow_comments && $pre_requisite_complete  && $user_taking_course;
+        $lesson_allow_comments = $allow_comments  && $user_taking_course;
 
         if (  $lesson_allow_comments || is_singular( 'sensei_message' ) ) {
 
@@ -3877,7 +3938,11 @@ class Sensei_Lesson {
             // Display lesson quiz status message
             if ( $has_user_completed_lesson || $has_quiz_questions ) {
                 $status = Sensei_Utils::sensei_user_quiz_status_message( $lesson_id, $user_id, true );
-                echo '<div class="sensei-message ' . $status['box_class'] . '">' . $status['message'] . '</div>';
+
+	            if( ! empty( $status['message']  ) ){
+	                echo '<div class="sensei-message ' . esc_attr( $status['box_class'] ) . '">' . esc_html( $status['message'] ) . '</div>';
+                }
+
                 if( $has_quiz_questions ) {
                    // echo $status['extra'];
                 } // End If Statement
@@ -3896,14 +3961,31 @@ class Sensei_Lesson {
      */
     public static function limit_archive_content ( $content ){
 
-        if( is_post_type_archive('lesson') && Sensei()->settings->get('access_permission') ){
-
+        if ( is_post_type_archive( 'lesson' ) && Sensei()->settings->get('access_permission') ) {
             return wp_trim_words( $content, $num_words = 30, $more = '…' );
         }
 
         return $content;
 
     } // end limit_archive_content
+
+    /**
+     * Returns all publised lesson ID's
+     *
+     * @since 1.9.0
+     * @return array
+     */
+    public static function get_all_lesson_ids(){
+
+        return get_posts( array(
+            'post_type'=>'lesson',
+            'fields'=>'ids',
+            'post_status' => 'publish',
+            'numberposts' => 4000, // legacy support
+            'post_per_page' => 4000
+        ));
+
+    }
 
 } // End Class
 

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -24,12 +24,32 @@ class Sensei_Notices{
 	protected $has_printed;
 
 	/**
-	*  constructor 
+	 * @var array The HTML allowed for message boxes.
+	 */
+	protected $allowed_html;
+
+	/**
+	*  constructor
  	*/
 	public function __construct(){
 		//initialize the notices variable
 		$this->notices = array();
 		$this->has_printed = false;
+		$this->allowed_html = array(
+			'embed'  => array(),
+			'iframe' => array(
+				'width'           => array(),
+				'height'          => array(),
+				'src'             => array(),
+				'frameborder'     => array(),
+				'allowfullscreen' => array(),
+			),
+			'video'  => array(
+				'width'  => array(),
+				'height' => array(),
+				'src'    => array(),
+			),
+		);
 	}
 
 	/**
@@ -64,9 +84,9 @@ class Sensei_Notices{
 			foreach ($this->notices  as  $notice) {
 
 				$classes = 'sensei-message '. $notice['type'];
-				$html = '<div class="'. $classes . '">'. $notice['content'] . '</div>';
+				$html = '<div class="'. esc_attr( $classes ) . '">'. wp_kses( $notice['content'], $this->allowed_html ) . '</div>';
 
-				echo $html; 
+				echo $html;
 			}
 			// empty the notice queue to avoid reprinting the same notices
 			$this->clear_notices();
@@ -79,8 +99,8 @@ class Sensei_Notices{
 	} // end print_notice()
 
 	/**
-	*  Clear all notices  
-	* 
+	*  Clear all notices
+	*
 	* @return void
 	*/
 	public function clear_notices(){

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -49,6 +49,10 @@ class Sensei_Notices{
 				'height' => array(),
 				'src'    => array(),
 			),
+			'a' => array(
+				'href'  => array(),
+				'title' => array()
+			)
 		);
 	}
 

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -370,7 +370,7 @@ class Sensei_Question {
 
 	/**
 	 * Given a question ID, return the grade that can be achieved.
-	 * 
+	 *
 	 * @since 1.9
 	 *
 	 * @param int $question_id
@@ -411,8 +411,13 @@ class Sensei_Question {
      * @param $question_type
      */
     public static function load_question_template( $question_type ){
+		$template_loaded = Sensei_Templates::get_template( 'single-quiz/question_type-' . $question_type . '.php' );
 
-        Sensei_Templates::get_template  ( 'single-quiz/question_type-' . $question_type . '.php' );
+		if ( ! $template_loaded ) {
+			Sensei_Templates::get_template( 'single-quiz/question-type-' . $question_type . '.php' );
+		} else {
+			_deprecated_file( 'question_type-' . $question_type . '.php', '1.9.8', 'question-type-' . $question_type . '.php' );
+		}
     }
 
     /**
@@ -631,7 +636,7 @@ class Sensei_Question {
          * Allow dynamic overriding of whether to show question answers or not
          *
          * @since 1.9.7
-         * 
+         *
          * @param boolean $show_answers
          * @param integer $question_id
          * @param integer $quiz_id

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -828,7 +828,7 @@ class Sensei_Teacher {
         }
 
         // load the email class
-        include('emails/class-sensei-email-teacher-new-course-assignment.php');
+        include( __DIR__ . '/emails/class-sensei-email-teacher-new-course-assignment.php' );
         $email = new Sensei_Email_Teacher_New_Course_Assignment();
         $email->trigger( $teacher_id, $course_id );
 

--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -75,7 +75,7 @@ class Sensei_Templates {
 
         $located = self::locate_template( $template_name, $template_path, $default_path );
 
-        if( ! empty( $located ) ){
+        if( ! empty( $located ) ) {
 
             do_action( 'sensei_before_template_part', $template_name, $template_path, $located );
 
@@ -83,7 +83,10 @@ class Sensei_Templates {
 
             do_action( 'sensei_after_template_part', $template_name, $template_path, $located );
 
+			return true;
         }
+
+		return false;
 
     } // end get template
 

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -135,7 +135,7 @@ class Sensei_Updates
 
                 foreach ($_POST['checked'] as $key => $function_name) {
 
-                    if( ! isset(  $_POST[ $function_name.'_nonce_field' ] ) 
+                    if( ! isset(  $_POST[ $function_name.'_nonce_field' ] )
                         || ! wp_verify_nonce( $_POST[ $function_name.'_nonce_field' ] , 'run_'.$function_name ) ){
 
                         wp_die(
@@ -1854,7 +1854,7 @@ class Sensei_Updates
      */
     public  function enhance_teacher_role ( ) {
 
-        require_once('class-sensei-teacher.php');
+        require_once( __DIR__ . '/class-sensei-teacher.php' );
         $teacher = new Sensei_Teacher();
         $teacher->create_role();
         return true;

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 /**
@@ -1059,7 +1059,7 @@ class Sensei_Utils {
 				$course_passmark = ( $total_passmark / $lesson_count );
 			}
 		}
-		
+
 		/**
 		 * Filter the course pass mark
 		 *
@@ -1116,7 +1116,7 @@ class Sensei_Utils {
 			}
 
 		}
-		
+
 		/**
 		 * Filter the user total grade for course
 		 *

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2332,6 +2332,28 @@ class Sensei_Utils {
         return $merged_array;
     }
 
+	/**
+	 * Essentially a copy of wp_kses() with a custom hook
+	 * see https://github.com/Automattic/sensei/issues/1560
+	 * @param $string
+	 * @param $allowed_html
+	 * @param array $allowed_protocols
+	 * @return string
+	 */
+	public static function wp_kses($string, $allowed_html, $allowed_protocols = array() ) {
+		if ( empty( $allowed_protocols ) ) {
+			$allowed_protocols = wp_allowed_protocols();
+		}
+		$string = wp_kses_no_null( $string, array( 'slash_zero' => 'keep' ) );
+		$string = wp_kses_js_entities($string);
+		$string = wp_kses_normalize_entities($string);
+		/**
+		 * Filter content similar to pre_kses
+		 */
+		$string = apply_filters( 'sensei_pre_kses', $string, $allowed_html, $allowed_protocols );
+		return wp_kses_split($string, $allowed_html, $allowed_protocols);
+	}
+
 } // End Class
 
 /**

--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -331,7 +331,11 @@ Class Sensei_WC{
 			$active_courses = array( $active_courses );
 		}
 
-		$active_course_ids = array_map( function ($c) { return $c->comment_post_ID; }, $active_courses );
+		$active_course_ids = array();
+
+		foreach ( $active_courses as $c ) {
+			$active_course_ids[] = $c->comment_post_ID;
+		}
 
 		$orders_query = new WP_Query( array(
 			'post_type'   => 'shop_order',
@@ -353,7 +357,11 @@ Class Sensei_WC{
 			$user_order_ids = array( $user_order_ids );
 		}
 
-		$user_orders = array_map( function ( $order_data ) { return new WC_Order( $order_data ); }, $user_order_ids );
+		$user_orders = array();
+
+		foreach ( $user_order_ids as $order_data ) {
+			$user_orders[] =  new WC_Order( $order_data );
+		}
 
 		foreach ( $user_orders as $user_order ) {
 			foreach ($user_order->get_items() as $item) {
@@ -363,7 +371,7 @@ Class Sensei_WC{
 					$item_id = $item['product_id'];
 				}
 
-				$product = Sensei()->sensei_get_woocommerce_product_object( $item_id );
+				$product = self::get_product_object( $item_id );
 
 				$product_courses = Sensei()->course->get_product_courses( $product->id );
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -753,7 +753,7 @@ class Sensei_Main {
      */
     public function load_class ( $class_name = '' ) {
         if ( '' != $class_name && '' != $this->token ) {
-            require_once( 'class-' . esc_attr( $this->token ) . '-' . esc_attr( $class_name ) . '.php' );
+            require_once( __DIR__ . '/class-' . esc_attr( $this->token ) . '-' . esc_attr( $class_name ) . '.php' );
         } // End If Statement
     } // End load_class()
 
@@ -889,7 +889,7 @@ class Sensei_Main {
             add_filter( 'sensei_answer_text', 'latex_markup' );
         }
     }
-    
+
 	/**
 	 * Checks that the WP QuickLaTeX plugin has been activated to support LaTeX within question titles and answers
 	 *
@@ -917,7 +917,7 @@ class Sensei_Main {
             &&  'Sensei_Modules' != get_class( $sensei_modules ) ) {
 
             //Load the modules class
-            require_once( 'class-sensei-modules.php');
+            require_once( __DIR__ . '/class-sensei-modules.php');
             Sensei()->modules = new Sensei_Core_Modules( $this->file );
 
         }else{
@@ -1168,7 +1168,7 @@ class Sensei_Main {
                 $custom_actions['support'] = sprintf( '<a href="%s" target="_blank">%s</a>', $this->get_support_url(), esc_html_x( 'Support', 'noun', 'woothemes-sensei' ) );
             }
 
-            // add the links to the front of the actions list   
+            // add the links to the front of the actions list
             return array_merge( $custom_actions, $actions );
         }
 
@@ -1236,7 +1236,7 @@ class Sensei_Main {
 
         /**
          * Returns the admin configuration url for the admin general configuration page
-         * 
+         *
          * @return string admin configuration url for the admin general configuration page
          */
         public function get_general_configuration_url() {

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -381,7 +381,7 @@ if ( ! defined( 'ABSPATH' ) ){ exit; } // Exit if accessed directly
 */
 function sensei_has_user_completed_prerequisite_lesson( $current_lesson_id, $user_id ) {
 
-    return WooThemes_Sensei_Lesson::is_pre_requisite_complete( $current_lesson_id, $user_id );
+    return WooThemes_Sensei_Lesson::is_prerequisite_complete( $current_lesson_id, $user_id );
 
 } // End sensei_has_user_completed_prerequisite_lesson()
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -78,7 +78,13 @@ if ( ! defined( 'ABSPATH' ) ){ exit; } // Exit if accessed directly
 	  */
 	 function quiz_question_type( $question_type = 'multiple-choice' ) {
 
-         Sensei_Templates::get_template( 'single-quiz/question_type-' . $question_type . '.php' );
+		$template_loaded = Sensei_Templates::get_template( 'single-quiz/question_type-' . $question_type . '.php' );
+
+		if ( ! $template_loaded ) {
+			Sensei_Templates::get_template( 'single-quiz/question-type-' . $question_type . '.php' );
+		} else {
+			_deprecated_file( 'question_type-' . $question_type . '.php', '1.9.8', 'question-type-' . $question_type . '.php' );
+		}
 
 	 } // End lesson_single_meta()
 

--- a/includes/theme-integrations/theme-integration-loader.php
+++ b/includes/theme-integrations/theme-integration-loader.php
@@ -95,7 +95,7 @@ class Sensei_Theme_Integration_Loader {
                 return;
             }
             include_once( $supported_theme_class_file );
-            include_once( 'twentytwelve.php' );
+            include_once( __DIR__ . '/twentytwelve.php' );
             //initialize the class or exit if there is no class for this theme
             if( ! class_exists( $supported_theme_class_name ) ){
                 return;

--- a/lang/woothemes-sensei.pot
+++ b/lang/woothemes-sensei.pot
@@ -13,8 +13,7 @@ msgstr ""
 "X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-SearchPathExcluded-0: *.js\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n\n"
-
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 #: includes/admin/class-sensei-learner-management.php:26
 msgid "Learner Management"
 msgstr ""
@@ -47,7 +46,7 @@ msgstr ""
 msgid "Sensei Activation"
 msgstr ""
 
-#: includes/admin/class-sensei-welcome.php:67
+#: includes/admin/class-sensei-welcome.php:67, includes/admin/class-sensei-welcome.php:266
 msgid "Welcome to Sensei"
 msgstr ""
 
@@ -56,50 +55,46 @@ msgid "Go to Sensei Settings"
 msgstr ""
 
 #: includes/admin/class-sensei-welcome.php:271
-msgid "Welcome to Sensei %s"
-msgstr ""
-
-#: includes/admin/class-sensei-welcome.php:276
 msgid "Thanks, all done!"
 msgstr ""
 
-#: includes/admin/class-sensei-welcome.php:278
+#: includes/admin/class-sensei-welcome.php:273
 msgid "Thank you for updating to the latest version!"
 msgstr ""
 
-#: includes/admin/class-sensei-welcome.php:280
+#: includes/admin/class-sensei-welcome.php:275
 msgid "Thanks for installing!"
 msgstr ""
 
-#: includes/admin/class-sensei-welcome.php:283
-msgid "%s We hope you enjoy using Sensei %s."
+#: includes/admin/class-sensei-welcome.php:278
+msgid "%s We hope you enjoy using Sensei."
 msgstr ""
 
-#: includes/admin/class-sensei-welcome.php:289
+#: includes/admin/class-sensei-welcome.php:284
 msgid "Sensei by WooThemes"
 msgstr ""
 
-#: includes/admin/class-sensei-welcome.php:292
+#: includes/admin/class-sensei-welcome.php:287
 msgid "Version %s"
 msgstr ""
 
-#: includes/admin/class-sensei-welcome.php:297, includes/class-sensei-admin.php:358, includes/class-sensei-settings.php:32
+#: includes/admin/class-sensei-welcome.php:292, includes/class-sensei-admin.php:358, includes/class-sensei-settings.php:32
 msgid "Settings"
 msgstr ""
 
-#: includes/admin/class-sensei-welcome.php:298, includes/class-sensei.php:1160
+#: includes/admin/class-sensei-welcome.php:293, includes/class-sensei.php:1163
 msgid "Docs"
 msgstr ""
 
-#: includes/admin/class-sensei-welcome.php:303
+#: includes/admin/class-sensei-welcome.php:298
 msgid "What's New"
 msgstr ""
 
-#: includes/class-sensei-admin.php:86, includes/class-sensei-admin.php:86, includes/class-sensei-admin.php:985
+#: includes/class-sensei-admin.php:86, includes/class-sensei-admin.php:86, includes/class-sensei-admin.php:1049
 msgid "Order Courses"
 msgstr ""
 
-#: includes/class-sensei-admin.php:87, includes/class-sensei-admin.php:87, includes/class-sensei-admin.php:1081
+#: includes/class-sensei-admin.php:87, includes/class-sensei-admin.php:87, includes/class-sensei-admin.php:1145
 msgid "Order Lessons"
 msgstr ""
 
@@ -112,7 +107,7 @@ msgctxt "page_slug"
 msgid "courses-overview"
 msgstr ""
 
-#: includes/class-sensei-admin.php:240, includes/class-sensei-admin.php:1319, includes/class-sensei-analysis-overview-list-table.php:637, includes/class-sensei-analysis-user-profile-list-table.php:288, includes/class-sensei-course.php:2522, includes/class-sensei-posttypes.php:604, includes/class-sensei-posttypes.php:604, includes/class-sensei-settings.php:109
+#: includes/class-sensei-admin.php:240, includes/class-sensei-admin.php:1383, includes/class-sensei-analysis-overview-list-table.php:637, includes/class-sensei-analysis-user-profile-list-table.php:288, includes/class-sensei-course.php:2544, includes/class-sensei-posttypes.php:604, includes/class-sensei-posttypes.php:604, includes/class-sensei-settings.php:109
 msgid "Courses"
 msgstr ""
 
@@ -121,7 +116,7 @@ msgctxt "page_slug"
 msgid "my-courses"
 msgstr ""
 
-#: includes/class-sensei-admin.php:244, includes/class-sensei-admin.php:1321, widgets/widget-woothemes-sensei-course-component.php:637
+#: includes/class-sensei-admin.php:244, includes/class-sensei-admin.php:1385, widgets/widget-woothemes-sensei-course-component.php:637
 msgid "My Courses"
 msgstr ""
 
@@ -157,7 +152,7 @@ msgstr ""
 msgid "Install"
 msgstr ""
 
-#: includes/class-sensei-admin.php:395, includes/class-sensei-admin.php:1425
+#: includes/class-sensei-admin.php:395, includes/class-sensei-admin.php:1491
 msgid "Hide this notice"
 msgstr ""
 
@@ -193,73 +188,83 @@ msgstr ""
 msgid "Please supply a %1$s ID."
 msgstr ""
 
+#: includes/class-sensei-admin.php:613
+msgid "(Duplicate)"
+msgstr ""
+
 #: includes/class-sensei-admin.php:699
 msgid "Show all courses"
 msgstr ""
 
-#: includes/class-sensei-admin.php:994
+#: includes/class-sensei-admin.php:1058
 msgid "The course order has been saved."
 msgstr ""
 
-#: includes/class-sensei-admin.php:1035
+#: includes/class-sensei-admin.php:1099
 msgid "Save course order"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1091
+#: includes/class-sensei-admin.php:1155
 msgid "The lesson order has been saved."
 msgstr ""
 
-#: includes/class-sensei-admin.php:1109, includes/class-sensei-grading-main.php:329, includes/class-sensei-grading.php:459, includes/class-sensei-modules.php:864
+#: includes/class-sensei-admin.php:1173, includes/class-sensei-grading-main.php:329, includes/class-sensei-grading.php:459, includes/class-sensei-modules.php:864
 msgid "Select a course"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1120, includes/class-sensei-modules.php:877
+#: includes/class-sensei-admin.php:1184, includes/class-sensei-modules.php:877
 msgid "Select"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1206, includes/class-sensei-course.php:2613, templates/course-results/lessons.php:105
+#: includes/class-sensei-admin.php:1270, includes/class-sensei-course.php:2635, templates/course-results/lessons.php:105
 msgid "Other Lessons"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1237
+#: includes/class-sensei-admin.php:1301
 msgid "There are no lessons in this course."
 msgstr ""
 
-#: includes/class-sensei-admin.php:1244
+#: includes/class-sensei-admin.php:1308
 msgid "Save lesson order"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1320, includes/class-sensei-analysis-overview-list-table.php:46, includes/class-sensei-analysis-overview-list-table.php:638, includes/class-sensei-course.php:1321, includes/class-sensei-course.php:1458, includes/class-sensei-course.php:2021, includes/class-sensei-course.php:2618, includes/class-sensei-frontend.php:979, includes/class-sensei-learners-main.php:543, includes/class-sensei-modules.php:1007, includes/class-sensei-posttypes.php:605, includes/class-sensei-posttypes.php:605, includes/class-sensei-settings.php:114, includes/shortcodes/class-sensei-legacy-shortcodes.php:357, templates/course-results/lessons.php:30, templates/single-course/modules.php:78, widgets/widget-woothemes-sensei-category-courses.php:385, widgets/widget-woothemes-sensei-course-component.php:607
+#: includes/class-sensei-admin.php:1384, includes/class-sensei-analysis-overview-list-table.php:46, includes/class-sensei-analysis-overview-list-table.php:638, includes/class-sensei-course.php:1343, includes/class-sensei-course.php:1480, includes/class-sensei-course.php:2043, includes/class-sensei-course.php:2640, includes/class-sensei-frontend.php:996, includes/class-sensei-learners-main.php:543, includes/class-sensei-modules.php:1007, includes/class-sensei-posttypes.php:605, includes/class-sensei-posttypes.php:605, includes/class-sensei-settings.php:114, includes/shortcodes/class-sensei-legacy-shortcodes.php:357, templates/course-results/lessons.php:30, templates/single-course/modules.php:81, widgets/widget-woothemes-sensei-category-courses.php:385, widgets/widget-woothemes-sensei-course-component.php:607
 msgid "Lessons"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1322
+#: includes/class-sensei-admin.php:1386
 msgid "My Profile"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1323, includes/class-sensei-course.php:1559, includes/class-sensei-messages.php:636, includes/class-sensei-messages.php:713
+#: includes/class-sensei-admin.php:1387, includes/class-sensei-course.php:1581, includes/class-sensei-messages.php:604, includes/class-sensei-messages.php:681
 msgid "My Messages"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1324, includes/class-sensei-frontend.php:423, templates/user/login-form.php:25, templates/user/login-form.php:67
+#: includes/class-sensei-admin.php:1388, includes/class-sensei-frontend.php:440, templates/user/login-form.php:25, templates/user/login-form.php:67
 msgid "Login"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1324, includes/class-sensei-frontend.php:421
+#: includes/class-sensei-admin.php:1388, includes/class-sensei-frontend.php:438
 msgid "Logout"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1357
+#: includes/class-sensei-admin.php:1421
 msgid "Add to Menu"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1412
-msgid ""
-"%s Your theme does not declare Sensei support %s, if you encounter layout issues\n"
-"                                            please read our integration guide or choose a %s Sensei theme %s"
+#: includes/class-sensei-admin.php:1477
+msgid "Your theme does not declare Sensei support"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1425
+#: includes/class-sensei-admin.php:1481
+msgid "if you encounter layout issues please read our integration guide or choose a "
+msgstr ""
+
+#: includes/class-sensei-admin.php:1483
+msgid "Sensei theme"
+msgstr ""
+
+#: includes/class-sensei-admin.php:1491
 msgid "Theme Integration Guide"
 msgstr ""
 
@@ -287,7 +292,7 @@ msgstr ""
 msgid "Lesson"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:74, includes/class-sensei-analysis-lesson-list-table.php:46, includes/class-sensei-analysis-user-profile-list-table.php:45, includes/class-sensei-grading-main.php:64, includes/class-sensei-lesson.php:679, includes/class-sensei-lesson.php:688
+#: includes/class-sensei-analysis-course-list-table.php:74, includes/class-sensei-analysis-lesson-list-table.php:46, includes/class-sensei-analysis-user-profile-list-table.php:45, includes/class-sensei-grading-main.php:64, includes/class-sensei-lesson.php:739, includes/class-sensei-lesson.php:748
 msgid "Grade"
 msgstr ""
 
@@ -295,7 +300,7 @@ msgstr ""
 msgid "Learners"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:82, includes/class-sensei-analysis-course-list-table.php:296, includes/class-sensei-analysis-course-list-table.php:353, includes/class-sensei-analysis-lesson-list-table.php:199, includes/class-sensei-analysis-overview-list-table.php:47, includes/class-sensei-analysis-overview-list-table.php:57, includes/class-sensei-analysis-user-profile-list-table.php:201, includes/class-sensei-course.php:2809, includes/class-sensei-grading-main.php:228, includes/class-sensei-learners-main.php:250, includes/class-sensei-modules.php:606, includes/template-functions.php:621
+#: includes/class-sensei-analysis-course-list-table.php:82, includes/class-sensei-analysis-course-list-table.php:296, includes/class-sensei-analysis-course-list-table.php:353, includes/class-sensei-analysis-lesson-list-table.php:199, includes/class-sensei-analysis-overview-list-table.php:47, includes/class-sensei-analysis-overview-list-table.php:57, includes/class-sensei-analysis-user-profile-list-table.php:201, includes/class-sensei-course.php:2831, includes/class-sensei-grading-main.php:228, includes/class-sensei-learners-main.php:250, includes/class-sensei-modules.php:606, includes/template-functions.php:621
 msgid "Completed"
 msgstr ""
 
@@ -303,7 +308,7 @@ msgstr ""
 msgid "Average Grade"
 msgstr ""
 
-#: includes/class-sensei-analysis-course-list-table.php:301, includes/class-sensei-analysis-course-list-table.php:382, includes/class-sensei-analysis-lesson-list-table.php:228, includes/class-sensei-analysis-user-profile-list-table.php:208, includes/class-sensei-course.php:2827, includes/class-sensei-grading-main.php:248, includes/class-sensei-grading-main.php:420, includes/class-sensei-learners-main.php:254, includes/class-sensei-lesson.php:3360
+#: includes/class-sensei-analysis-course-list-table.php:301, includes/class-sensei-analysis-course-list-table.php:382, includes/class-sensei-analysis-lesson-list-table.php:228, includes/class-sensei-analysis-user-profile-list-table.php:208, includes/class-sensei-course.php:2849, includes/class-sensei-grading-main.php:248, includes/class-sensei-grading-main.php:420, includes/class-sensei-learners-main.php:254, includes/class-sensei-lesson.php:3417
 msgid "In Progress"
 msgstr ""
 
@@ -383,11 +388,11 @@ msgstr ""
 msgid "Date Registered"
 msgstr ""
 
-#: includes/class-sensei-analysis-overview-list-table.php:67, includes/class-sensei-course.php:1568, includes/shortcodes/class-sensei-shortcode-user-courses.php:370
+#: includes/class-sensei-analysis-overview-list-table.php:67, includes/class-sensei-course.php:1590, includes/shortcodes/class-sensei-shortcode-user-courses.php:370
 msgid "Active Courses"
 msgstr ""
 
-#: includes/class-sensei-analysis-overview-list-table.php:68, includes/class-sensei-course.php:1569, includes/shortcodes/class-sensei-shortcode-user-courses.php:371
+#: includes/class-sensei-analysis-overview-list-table.php:68, includes/class-sensei-course.php:1591, includes/shortcodes/class-sensei-shortcode-user-courses.php:371
 msgid "Completed Courses"
 msgstr ""
 
@@ -440,337 +445,341 @@ msgstr ""
 msgid "Course Results: "
 msgstr ""
 
-#: includes/class-sensei-course.php:146, includes/class-sensei-lesson.php:563
+#: includes/class-sensei-course.php:168, includes/class-sensei-lesson.php:623
 msgid "WooCommerce Product"
 msgstr ""
 
-#: includes/class-sensei-course.php:149, includes/class-sensei-lesson.php:535
+#: includes/class-sensei-course.php:171, includes/class-sensei-lesson.php:595
 msgid "Course Prerequisite"
 msgstr ""
 
-#: includes/class-sensei-course.php:151
+#: includes/class-sensei-course.php:173
 msgid "Featured Course"
 msgstr ""
 
-#: includes/class-sensei-course.php:153
+#: includes/class-sensei-course.php:175
 msgid "Course Video"
 msgstr ""
 
-#: includes/class-sensei-course.php:155
+#: includes/class-sensei-course.php:177
 msgid "Course Lessons"
 msgstr ""
 
-#: includes/class-sensei-course.php:157
+#: includes/class-sensei-course.php:179
 msgid "Course Management"
 msgstr ""
 
-#: includes/class-sensei-course.php:162
+#: includes/class-sensei-course.php:184
 msgid "Course Notifications"
 msgstr ""
 
-#: includes/class-sensei-course.php:202, includes/class-sensei-course.php:313, includes/class-sensei-course.php:588, includes/class-sensei-lesson.php:164, includes/class-sensei-lesson.php:202, includes/class-sensei-lesson.php:537, includes/class-sensei-lesson.php:565, includes/class-sensei-lesson.php:599, includes/class-sensei-lesson.php:1001, includes/class-sensei-modules.php:198, includes/class-sensei-utils.php:2157
+#: includes/class-sensei-course.php:224, includes/class-sensei-course.php:335, includes/class-sensei-course.php:610, includes/class-sensei-lesson.php:182, includes/class-sensei-lesson.php:220, includes/class-sensei-lesson.php:597, includes/class-sensei-lesson.php:625, includes/class-sensei-lesson.php:659, includes/class-sensei-lesson.php:1062, includes/class-sensei-modules.php:198, includes/class-sensei-utils.php:2194
 msgid "None"
 msgstr ""
 
-#: includes/class-sensei-course.php:223
+#: includes/class-sensei-course.php:245
 msgid "Variation #"
 msgstr ""
 
-#: includes/class-sensei-course.php:260, includes/class-sensei-course.php:260, includes/class-sensei-course.php:270
+#: includes/class-sensei-course.php:282, includes/class-sensei-course.php:282, includes/class-sensei-course.php:292
 msgid "Add a Product"
 msgstr ""
 
-#: includes/class-sensei-course.php:270, includes/class-sensei-course.php:276
+#: includes/class-sensei-course.php:292, includes/class-sensei-course.php:298
 msgid "No products exist yet."
 msgstr ""
 
-#: includes/class-sensei-course.php:270
+#: includes/class-sensei-course.php:292
 msgid "Please add some first"
 msgstr ""
 
-#: includes/class-sensei-course.php:319
+#: includes/class-sensei-course.php:341
 msgid "No courses exist yet. Please add some first."
 msgstr ""
 
-#: includes/class-sensei-course.php:346
+#: includes/class-sensei-course.php:368
 msgid "Feature this course"
 msgstr ""
 
-#: includes/class-sensei-course.php:365, includes/class-sensei-lesson.php:170
+#: includes/class-sensei-course.php:387, includes/class-sensei-lesson.php:188
 msgid "Video Embed Code"
 msgstr ""
 
-#: includes/class-sensei-course.php:367, includes/class-sensei-lesson.php:172
+#: includes/class-sensei-course.php:389, includes/class-sensei-lesson.php:190
 msgid "Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above."
 msgstr ""
 
-#: includes/class-sensei-course.php:473, includes/class-sensei-course.php:560, includes/class-sensei-course.php:580, includes/class-sensei-lesson.php:1816, includes/class-sensei-lesson.php:1822, includes/class-sensei-posttypes.php:630
+#: includes/class-sensei-course.php:495, includes/class-sensei-course.php:582, includes/class-sensei-course.php:602, includes/class-sensei-lesson.php:1887, includes/class-sensei-lesson.php:1893, includes/class-sensei-posttypes.php:630
 msgid "Edit %s"
 msgstr ""
 
-#: includes/class-sensei-course.php:473
+#: includes/class-sensei-course.php:495
 msgid "Edit this lesson"
 msgstr ""
 
-#: includes/class-sensei-course.php:482
+#: includes/class-sensei-course.php:504
 msgid "No lessons exist yet for this course."
 msgstr ""
 
-#: includes/class-sensei-course.php:485
+#: includes/class-sensei-course.php:507
 msgid "Add a Lesson"
 msgstr ""
 
-#: includes/class-sensei-course.php:486
+#: includes/class-sensei-course.php:508
 msgid "Please add some."
 msgstr ""
 
-#: includes/class-sensei-course.php:511
+#: includes/class-sensei-course.php:533
 msgid "Manage Learners"
 msgstr ""
 
-#: includes/class-sensei-course.php:513
+#: includes/class-sensei-course.php:535
 msgid "Manage Grading"
 msgstr ""
 
-#: includes/class-sensei-course.php:529
+#: includes/class-sensei-course.php:551
 msgctxt "column name"
 msgid "Course Title"
 msgstr ""
 
-#: includes/class-sensei-course.php:530
+#: includes/class-sensei-course.php:552
 msgctxt "column name"
 msgid "Pre-requisite Course"
 msgstr ""
 
-#: includes/class-sensei-course.php:532
+#: includes/class-sensei-course.php:554
 msgctxt "column name"
 msgid "WooCommerce Product"
 msgstr ""
 
-#: includes/class-sensei-course.php:534
+#: includes/class-sensei-course.php:556
 msgctxt "column name"
 msgid "Category"
 msgstr ""
 
-#: includes/class-sensei-course.php:1305, includes/class-sensei-course.php:1452, includes/class-sensei-course.php:2013, includes/class-sensei-frontend.php:977, includes/class-sensei-frontend.php:1130, includes/shortcodes/class-sensei-legacy-shortcodes.php:353, widgets/widget-woothemes-sensei-category-courses.php:379, widgets/widget-woothemes-sensei-course-component.php:589, widgets/widget-woothemes-sensei-lesson-component.php:389
+#: includes/class-sensei-course.php:1327, includes/class-sensei-course.php:1474, includes/class-sensei-course.php:2035, includes/class-sensei-frontend.php:994, includes/class-sensei-frontend.php:1147, includes/shortcodes/class-sensei-legacy-shortcodes.php:353, widgets/widget-woothemes-sensei-category-courses.php:379, widgets/widget-woothemes-sensei-course-component.php:589, widgets/widget-woothemes-sensei-lesson-component.php:389
 msgid "by "
 msgstr ""
 
-#: includes/class-sensei-course.php:1325, includes/class-sensei-course.php:1464, includes/class-sensei-course.php:2025, includes/class-sensei-frontend.php:981, includes/shortcodes/class-sensei-legacy-shortcodes.php:361
+#: includes/class-sensei-course.php:1347, includes/class-sensei-course.php:1486, includes/class-sensei-course.php:2047, includes/class-sensei-frontend.php:998, includes/shortcodes/class-sensei-legacy-shortcodes.php:361
 msgid "in %s"
 msgstr ""
 
-#: includes/class-sensei-course.php:1328, includes/class-sensei-course.php:2035
+#: includes/class-sensei-course.php:1350, includes/class-sensei-course.php:2057
 msgid "%1$d of %2$d lessons completed"
 msgstr ""
 
-#: includes/class-sensei-course.php:1356, includes/class-sensei-course.php:2101, includes/class-sensei-frontend.php:790
+#: includes/class-sensei-course.php:1378, includes/class-sensei-course.php:2123, includes/class-sensei-frontend.php:807
 msgid "Mark as Complete"
 msgstr ""
 
-#: includes/class-sensei-course.php:1381, includes/class-sensei-course.php:2132, includes/class-sensei-frontend.php:824
+#: includes/class-sensei-course.php:1403, includes/class-sensei-course.php:2154, includes/class-sensei-frontend.php:841
 msgid "Delete Course"
 msgstr ""
 
-#: includes/class-sensei-course.php:1406, includes/class-sensei-course.php:1517, includes/class-sensei-lesson.php:1110
+#: includes/class-sensei-course.php:1428, includes/class-sensei-course.php:1539, includes/class-sensei-lesson.php:1171
 msgid "Previous"
 msgstr ""
 
-#: includes/class-sensei-course.php:1421, includes/class-sensei-course.php:1532, includes/class-sensei-lesson.php:1110, includes/class-sensei-updates.php:247
+#: includes/class-sensei-course.php:1443, includes/class-sensei-course.php:1554, includes/class-sensei-lesson.php:1171, includes/class-sensei-updates.php:247
 msgid "Next"
 msgstr ""
 
-#: includes/class-sensei-course.php:1486, includes/class-sensei-course.php:2139, includes/class-sensei-course.php:2817
+#: includes/class-sensei-course.php:1508, includes/class-sensei-course.php:2161, includes/class-sensei-course.php:2839
 msgid "View results"
 msgstr ""
 
-#: includes/class-sensei-course.php:1541, includes/shortcodes/class-sensei-shortcode-user-courses.php:211, widgets/widget-woothemes-sensei-course-component.php:495
+#: includes/class-sensei-course.php:1563, includes/shortcodes/class-sensei-shortcode-user-courses.php:211, widgets/widget-woothemes-sensei-course-component.php:495
 msgid "You have no active courses."
 msgstr ""
 
-#: includes/class-sensei-course.php:1542, includes/shortcodes/class-sensei-shortcode-user-courses.php:192
+#: includes/class-sensei-course.php:1564, includes/shortcodes/class-sensei-shortcode-user-courses.php:192
 msgid "You have not completed any courses yet."
 msgstr ""
 
-#: includes/class-sensei-course.php:1544
+#: includes/class-sensei-course.php:1566
 msgid "This learner has no active courses."
 msgstr ""
 
-#: includes/class-sensei-course.php:1545
+#: includes/class-sensei-course.php:1567
 msgid "This learner has not completed any courses yet."
 msgstr ""
 
-#: includes/class-sensei-course.php:1558, includes/class-sensei-messages.php:712
+#: includes/class-sensei-course.php:1580, includes/class-sensei-messages.php:680
 msgid "View & reply to private messages sent to your course & lesson teachers."
 msgstr ""
 
-#: includes/class-sensei-course.php:1592, includes/shortcodes/class-sensei-shortcode-user-courses.php:215
+#: includes/class-sensei-course.php:1614, includes/shortcodes/class-sensei-shortcode-user-courses.php:215
 msgid "Start a Course!"
 msgstr ""
 
-#: includes/class-sensei-course.php:1713
+#: includes/class-sensei-course.php:1735
 msgid "Currently completed %s lesson of %s in total"
 msgid_plural "Currently completed %s lessons of %s in total"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-sensei-course.php:1908
+#: includes/class-sensei-course.php:1930
 msgid "Disable notifications on this course ?"
 msgstr ""
 
-#: includes/class-sensei-course.php:1989, includes/class-sensei-frontend.php:988, includes/shortcodes/class-sensei-legacy-shortcodes.php:375
+#: includes/class-sensei-course.php:2011, includes/class-sensei-frontend.php:1005, includes/shortcodes/class-sensei-legacy-shortcodes.php:375
 msgid "Preview this course"
 msgstr ""
 
-#: includes/class-sensei-course.php:1991, includes/shortcodes/class-sensei-legacy-shortcodes.php:373
+#: includes/class-sensei-course.php:2013, includes/shortcodes/class-sensei-legacy-shortcodes.php:373
 msgid "(%d preview lessons)"
 msgstr ""
 
-#: includes/class-sensei-course.php:2320
+#: includes/class-sensei-course.php:2342
 msgid "Sort by newest first"
 msgstr ""
 
-#: includes/class-sensei-course.php:2321
+#: includes/class-sensei-course.php:2343
 msgid "Sort by title A-Z"
 msgstr ""
 
-#: includes/class-sensei-course.php:2374, includes/class-sensei-grading-main.php:417, includes/class-sensei-lesson.php:1051, includes/class-sensei-lesson.php:1682, includes/class-sensei-settings-api.php:119
+#: includes/class-sensei-course.php:2396, includes/class-sensei-grading-main.php:417, includes/class-sensei-lesson.php:1112, includes/class-sensei-lesson.php:1753, includes/class-sensei-settings-api.php:119
 msgid "All"
 msgstr ""
 
-#: includes/class-sensei-course.php:2375
+#: includes/class-sensei-course.php:2397
 msgid "Featured"
 msgstr ""
 
-#: includes/class-sensei-course.php:2502
+#: includes/class-sensei-course.php:2524
 msgid "%1$s Archives: %2$s"
 msgstr ""
 
-#: includes/class-sensei-course.php:2510, includes/shortcodes/class-sensei-legacy-shortcodes.php:104, widgets/widget-woothemes-sensei-course-component.php:67
+#: includes/class-sensei-course.php:2532, includes/shortcodes/class-sensei-legacy-shortcodes.php:104, widgets/widget-woothemes-sensei-course-component.php:67
 msgid "New Courses"
 msgstr ""
 
-#: includes/class-sensei-course.php:2513, includes/shortcodes/class-sensei-legacy-shortcodes.php:76, widgets/widget-woothemes-sensei-course-component.php:69
+#: includes/class-sensei-course.php:2535, includes/shortcodes/class-sensei-legacy-shortcodes.php:76, widgets/widget-woothemes-sensei-course-component.php:69
 msgid "Featured Courses"
 msgstr ""
 
-#: includes/class-sensei-course.php:2516, includes/shortcodes/class-sensei-legacy-shortcodes.php:90, widgets/widget-woothemes-sensei-course-component.php:83
+#: includes/class-sensei-course.php:2538, includes/shortcodes/class-sensei-legacy-shortcodes.php:90, widgets/widget-woothemes-sensei-course-component.php:83
 msgid "Free Courses"
 msgstr ""
 
-#: includes/class-sensei-course.php:2519, includes/shortcodes/class-sensei-legacy-shortcodes.php:61, widgets/widget-woothemes-sensei-course-component.php:85
+#: includes/class-sensei-course.php:2541, includes/shortcodes/class-sensei-legacy-shortcodes.php:61, widgets/widget-woothemes-sensei-course-component.php:85
 msgid "Paid Courses"
 msgstr ""
 
-#: includes/class-sensei-course.php:2835, includes/class-sensei-wc.php:873
+#: includes/class-sensei-course.php:2857, includes/class-sensei-wc.php:962
 msgid "log in"
 msgstr ""
 
-#: includes/class-sensei-course.php:2836, includes/class-sensei-wc.php:900
+#: includes/class-sensei-course.php:2858, includes/class-sensei-wc.php:989
 msgid "Or %1$s to access your purchased courses"
 msgstr ""
 
-#: includes/class-sensei-course.php:2848
+#: includes/class-sensei-course.php:2870
 msgid "or %slog in%s to view this course."
 msgstr ""
 
-#: includes/class-sensei-course.php:2884, includes/class-sensei-frontend.php:1079, includes/class-sensei-frontend.php:1107, includes/class-sensei-templates.php:693
+#: includes/class-sensei-course.php:2906, includes/class-sensei-frontend.php:1096, includes/class-sensei-frontend.php:1124, includes/class-sensei-templates.php:693
 msgid "Register"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:663
+#: includes/class-sensei-course.php:3005, includes/class-sensei-lesson.php:1139, includes/class-sensei-lesson.php:1147
+msgid "Category"
+msgstr ""
+
+#: includes/class-sensei-frontend.php:680
 msgid "Back to: "
 msgstr ""
 
-#: includes/class-sensei-frontend.php:673, includes/class-sensei-modules.php:496
+#: includes/class-sensei-frontend.php:690, includes/class-sensei-modules.php:496
 msgid "Back to the course"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:681
+#: includes/class-sensei-frontend.php:698
 msgid "Back to the lesson"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:715
+#: includes/class-sensei-frontend.php:732
 msgid "Lesson tags: %1$s"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:739
+#: includes/class-sensei-frontend.php:756
 msgid "Lesson tag: %1$s"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:769
+#: includes/class-sensei-frontend.php:786
 msgid "Lesson Reset Successfully."
 msgstr ""
 
-#: includes/class-sensei-frontend.php:819
+#: includes/class-sensei-frontend.php:836
 msgid "%1$s marked as complete."
 msgstr ""
 
-#: includes/class-sensei-frontend.php:829
+#: includes/class-sensei-frontend.php:846
 msgid "%1$s deleted."
 msgstr ""
 
-#: includes/class-sensei-frontend.php:918
+#: includes/class-sensei-frontend.php:935
 msgid "Complete Lesson"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:949
+#: includes/class-sensei-frontend.php:966
 msgid "Reset Lesson"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:987
+#: includes/class-sensei-frontend.php:1004
 msgid "You can access %d of this course's lessons for free"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1049, templates/archive-course.php:38
+#: includes/class-sensei-frontend.php:1066, templates/archive-course.php:38
 msgid "No courses found that match your selection."
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1086
+#: includes/class-sensei-frontend.php:1103
 msgid "Username"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1091
+#: includes/class-sensei-frontend.php:1108
 msgid "Email address"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1096, templates/user/login-form.php:48
+#: includes/class-sensei-frontend.php:1113, templates/user/login-form.php:48
 msgid "Password"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1101
+#: includes/class-sensei-frontend.php:1118
 msgid "Anti-spam"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1133, widgets/widget-woothemes-sensei-lesson-component.php:397
+#: includes/class-sensei-frontend.php:1150, widgets/widget-woothemes-sensei-lesson-component.php:397
 msgid "Part of: %s"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1133, widgets/widget-woothemes-sensei-lesson-component.php:397
+#: includes/class-sensei-frontend.php:1150, widgets/widget-woothemes-sensei-lesson-component.php:397
 msgid "View course"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1143
+#: includes/class-sensei-frontend.php:1160
 msgid " (Preview)"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1149
+#: includes/class-sensei-frontend.php:1166
 msgid " (Free Preview)"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1236, includes/class-sensei-wc.php:419
+#: includes/class-sensei-frontend.php:1253, includes/class-sensei-wc.php:508
 msgid "You have already added this Course to your cart. Please %1$s to access the course."
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1236, includes/class-sensei-frontend.php:1236, includes/class-sensei-wc.php:417
+#: includes/class-sensei-frontend.php:1253, includes/class-sensei-frontend.php:1253, includes/class-sensei-wc.php:506
 msgid "complete the purchase"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1757
+#: includes/class-sensei-frontend.php:1774
 msgid "Incorrect login details"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1761
+#: includes/class-sensei-frontend.php:1778
 msgid "Please enter your username and password"
 msgstr ""
 
@@ -798,11 +807,11 @@ msgstr ""
 msgid "Reset filter"
 msgstr ""
 
-#: includes/class-sensei-grading-user-quiz.php:64, includes/class-sensei-grading-user-quiz.php:245
+#: includes/class-sensei-grading-user-quiz.php:64, includes/class-sensei-grading-user-quiz.php:243
 msgid "__Grade:"
 msgstr ""
 
-#: includes/class-sensei-grading-user-quiz.php:64, includes/class-sensei-grading-user-quiz.php:245
+#: includes/class-sensei-grading-user-quiz.php:64, includes/class-sensei-grading-user-quiz.php:243
 msgid "Grade:"
 msgstr ""
 
@@ -814,27 +823,27 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: includes/class-sensei-grading-user-quiz.php:69, includes/class-sensei-grading-user-quiz.php:250
+#: includes/class-sensei-grading-user-quiz.php:69, includes/class-sensei-grading-user-quiz.php:248
 msgid "__Auto grade"
 msgstr ""
 
-#: includes/class-sensei-grading-user-quiz.php:69, includes/class-sensei-grading-user-quiz.php:250
+#: includes/class-sensei-grading-user-quiz.php:69, includes/class-sensei-grading-user-quiz.php:248
 msgid "Auto grade"
 msgstr ""
 
-#: includes/class-sensei-grading-user-quiz.php:70, includes/class-sensei-grading-user-quiz.php:251
+#: includes/class-sensei-grading-user-quiz.php:70, includes/class-sensei-grading-user-quiz.php:249
 msgid "__Reset"
 msgstr ""
 
-#: includes/class-sensei-grading-user-quiz.php:70, includes/class-sensei-grading-user-quiz.php:251
+#: includes/class-sensei-grading-user-quiz.php:70, includes/class-sensei-grading-user-quiz.php:249
 msgid "Reset"
 msgstr ""
 
-#: includes/class-sensei-grading-user-quiz.php:95, includes/class-sensei-grading-user-quiz.php:106, includes/class-sensei-question.php:42, includes/class-sensei-question.php:1092
+#: includes/class-sensei-grading-user-quiz.php:95, includes/class-sensei-grading-user-quiz.php:106, includes/class-sensei-question.php:42, includes/class-sensei-question.php:1109
 msgid "Multiple Choice"
 msgstr ""
 
-#: includes/class-sensei-grading-user-quiz.php:100, includes/class-sensei-lesson.php:853, includes/class-sensei-question.php:43
+#: includes/class-sensei-grading-user-quiz.php:100, includes/class-sensei-lesson.php:914, includes/class-sensei-question.php:43
 msgid "True/False"
 msgstr ""
 
@@ -862,15 +871,15 @@ msgstr ""
 msgid "Question %d: "
 msgstr ""
 
-#: includes/class-sensei-grading-user-quiz.php:215
+#: includes/class-sensei-grading-user-quiz.php:213
 msgid "Correct answer"
 msgstr ""
 
-#: includes/class-sensei-grading-user-quiz.php:225
+#: includes/class-sensei-grading-user-quiz.php:223
 msgid "Grading Notes"
 msgstr ""
 
-#: includes/class-sensei-grading-user-quiz.php:226
+#: includes/class-sensei-grading-user-quiz.php:224
 msgid "Add notes here..."
 msgstr ""
 
@@ -938,11 +947,11 @@ msgstr ""
 msgid "No results found"
 msgstr ""
 
-#: includes/class-sensei-learners-main.php:237, includes/class-sensei.php:650
+#: includes/class-sensei-learners-main.php:237, includes/class-sensei.php:653
 msgid "lesson"
 msgstr ""
 
-#: includes/class-sensei-learners-main.php:243, includes/class-sensei-lesson.php:3536, includes/class-sensei-lesson.php:3556, includes/class-sensei-lesson.php:3582, includes/class-sensei-utils.php:1319, includes/class-sensei.php:574, includes/class-sensei.php:611, includes/class-sensei.php:666, includes/class-sensei.php:678
+#: includes/class-sensei-learners-main.php:243, includes/class-sensei-lesson.php:3617, includes/class-sensei-lesson.php:3629, includes/class-sensei-lesson.php:3642, includes/class-sensei-utils.php:1344, includes/class-sensei.php:577, includes/class-sensei.php:614, includes/class-sensei.php:669, includes/class-sensei.php:681
 msgid "course"
 msgstr ""
 
@@ -954,7 +963,7 @@ msgstr ""
 msgid "Manage learners"
 msgstr ""
 
-#: includes/class-sensei-learners-main.php:504, includes/class-sensei-lesson.php:598
+#: includes/class-sensei-learners-main.php:504, includes/class-sensei-lesson.php:658
 msgid "Course Category"
 msgstr ""
 
@@ -994,478 +1003,474 @@ msgstr ""
 msgid "Learner will also be added to the course '%1$s' if they are not already taking it."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:114
+#: includes/class-sensei-lesson.php:132
 msgid "Lesson Prerequisite"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:117, includes/class-sensei-lesson.php:3027
+#: includes/class-sensei-lesson.php:135, includes/class-sensei-lesson.php:3084
 msgid "Lesson Course"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:120
+#: includes/class-sensei-lesson.php:138
 msgid "Lesson Preview"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:123, includes/class-sensei-lesson.php:3003
+#: includes/class-sensei-lesson.php:141, includes/class-sensei-lesson.php:3060
 msgid "Lesson Information"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:126, includes/class-sensei-lesson.php:3041
+#: includes/class-sensei-lesson.php:144, includes/class-sensei-lesson.php:3098
 msgid "Quiz Settings"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:129
+#: includes/class-sensei-lesson.php:147
 msgid "Quiz Questions"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:159
+#: includes/class-sensei-lesson.php:177
 msgid "Lesson Length in minutes"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:162, includes/class-sensei-lesson.php:3037
+#: includes/class-sensei-lesson.php:180, includes/class-sensei-lesson.php:3094
 msgid "Lesson Complexity"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:208
+#: includes/class-sensei-lesson.php:226
 msgid "No lessons exist yet. Please add some first."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:233
+#: includes/class-sensei-lesson.php:251
 msgid "Allow this lesson to be viewed without purchase/login"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:522
+#: includes/class-sensei-lesson.php:582
 msgid "Add New Course"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:529
+#: includes/class-sensei-lesson.php:589
 msgid "Course Title"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:532
+#: includes/class-sensei-lesson.php:592
 msgid "Description"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:602
+#: includes/class-sensei-lesson.php:662
 msgid "Save Course"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:602
+#: includes/class-sensei-lesson.php:662
 msgid "Add Course"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:605, includes/class-sensei-lesson.php:934, includes/class-sensei-lesson.php:934
+#: includes/class-sensei-lesson.php:665, includes/class-sensei-lesson.php:995, includes/class-sensei-lesson.php:995
 msgid "Cancel"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:621
+#: includes/class-sensei-lesson.php:681
 msgid "Once you have saved your lesson you will be able to add questions."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:660
+#: includes/class-sensei-lesson.php:720
 msgid "Please save your lesson in order to add questions to your quiz."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:678, includes/class-sensei-lesson.php:687, includes/class-sensei-lesson.php:1076, includes/class-sensei-lesson.php:1084, includes/class-sensei-posttypes.php:607, includes/class-sensei-question.php:116
+#: includes/class-sensei-lesson.php:738, includes/class-sensei-lesson.php:747, includes/class-sensei-lesson.php:1137, includes/class-sensei-lesson.php:1145, includes/class-sensei-posttypes.php:607, includes/class-sensei-question.php:116
 msgid "Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:680, includes/class-sensei-lesson.php:689, includes/class-sensei-lesson.php:1077, includes/class-sensei-lesson.php:1085, includes/class-sensei-updates.php:286, includes/class-sensei-updates.php:294
+#: includes/class-sensei-lesson.php:740, includes/class-sensei-lesson.php:749, includes/class-sensei-lesson.php:1138, includes/class-sensei-lesson.php:1146, includes/class-sensei-updates.php:286, includes/class-sensei-updates.php:294
 msgid "Type"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:681, includes/class-sensei-lesson.php:690, includes/class-sensei-updates.php:287, includes/class-sensei-updates.php:295
+#: includes/class-sensei-lesson.php:741, includes/class-sensei-lesson.php:750, includes/class-sensei-updates.php:287, includes/class-sensei-updates.php:295
 msgid "Action"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:699
+#: includes/class-sensei-lesson.php:759
 msgid "There are no Questions for this Quiz yet. Please add some below."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:804, includes/class-sensei-lesson.php:1021, includes/class-sensei-lesson.php:1745
+#: includes/class-sensei-lesson.php:865, includes/class-sensei-lesson.php:1082, includes/class-sensei-lesson.php:1816
 msgid "Add file"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:831, includes/class-sensei-lesson.php:1745
+#: includes/class-sensei-lesson.php:892, includes/class-sensei-lesson.php:1816
 msgid "Change file"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:855, includes/class-sensei-lesson.php:871
+#: includes/class-sensei-lesson.php:916, includes/class-sensei-lesson.php:932
 msgid "Edit Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:855, includes/class-sensei-lesson.php:871
+#: includes/class-sensei-lesson.php:916, includes/class-sensei-lesson.php:932
 msgid "Edit"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:855
+#: includes/class-sensei-lesson.php:916
 msgid "Remove Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:855, includes/class-sensei-lesson.php:871
+#: includes/class-sensei-lesson.php:916, includes/class-sensei-lesson.php:932
 msgid "Remove"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:865
+#: includes/class-sensei-lesson.php:926
 msgid "Selected from '%1$s' "
 msgstr ""
 
-#: includes/class-sensei-lesson.php:871
+#: includes/class-sensei-lesson.php:932
 msgid "Remove Question(s)"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:892, includes/class-sensei-lesson.php:979
+#: includes/class-sensei-lesson.php:953, includes/class-sensei-lesson.php:1040
 msgid "Question:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:898, includes/class-sensei-lesson.php:984
+#: includes/class-sensei-lesson.php:959, includes/class-sensei-lesson.php:1045
 msgid "Question Description (optional):"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:904
+#: includes/class-sensei-lesson.php:965
 msgid "Question grade:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:911, includes/class-sensei-lesson.php:1015
+#: includes/class-sensei-lesson.php:972, includes/class-sensei-lesson.php:1076
 msgid "Randomise answer order"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:917, includes/class-sensei-lesson.php:1020
+#: includes/class-sensei-lesson.php:978, includes/class-sensei-lesson.php:1081
 msgid "Question media:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:918, includes/class-sensei-lesson.php:1021
+#: includes/class-sensei-lesson.php:979, includes/class-sensei-lesson.php:1082
 msgid "Add file to question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:918, includes/class-sensei-lesson.php:1021
+#: includes/class-sensei-lesson.php:979, includes/class-sensei-lesson.php:1082
 msgid "Add to question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:919, includes/class-sensei-lesson.php:1022
+#: includes/class-sensei-lesson.php:980, includes/class-sensei-lesson.php:1083
 msgid "Delete file"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:935
+#: includes/class-sensei-lesson.php:996
 msgid "Update Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:935, includes/class-sensei-updates.php:285, includes/class-sensei-updates.php:293
+#: includes/class-sensei-lesson.php:996, includes/class-sensei-updates.php:285, includes/class-sensei-updates.php:293
 msgid "Update"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:961
+#: includes/class-sensei-lesson.php:1022
 msgid "New Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:962
+#: includes/class-sensei-lesson.php:1023
 msgid "Existing Questions"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:964
+#: includes/class-sensei-lesson.php:1025
 msgid "Category Questions"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:972
+#: includes/class-sensei-lesson.php:1033
 msgid "Add a new question to this quiz - your question will also be added to the %1$squestion bank%2$s."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:989
+#: includes/class-sensei-lesson.php:1050
 msgid "Question Type:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:999
+#: includes/class-sensei-lesson.php:1060
 msgid "Question Category:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1010
+#: includes/class-sensei-lesson.php:1071
 msgid "Question Grade:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1037, includes/class-sensei-lesson.php:1037
+#: includes/class-sensei-lesson.php:1098, includes/class-sensei-lesson.php:1098
 msgid "Add Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1047
+#: includes/class-sensei-lesson.php:1108
 msgid "Add an existing question to this quiz from the %1$squestion bank%2$s."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1052
+#: includes/class-sensei-lesson.php:1113
 msgid "Unused"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1053
+#: includes/class-sensei-lesson.php:1114
 msgid "Used"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1056
+#: includes/class-sensei-lesson.php:1117
 msgid "All Types"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1062
+#: includes/class-sensei-lesson.php:1123
 msgid "All Categories"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1067
+#: includes/class-sensei-lesson.php:1128
 msgid "Search"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1068
+#: includes/class-sensei-lesson.php:1129
 msgid "Filter"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1078, includes/class-sensei-lesson.php:1086
-msgid "Category"
-msgstr ""
-
-#: includes/class-sensei-lesson.php:1114, includes/class-sensei-lesson.php:1114
+#: includes/class-sensei-lesson.php:1175, includes/class-sensei-lesson.php:1175
 msgid "Add Selected Question(s)"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1122
+#: includes/class-sensei-lesson.php:1183
 msgid "Add any number of questions from a specified category. Edit your question categories %1$shere%2$s."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1125
+#: includes/class-sensei-lesson.php:1186
 msgid "Select a Question Category"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1131
+#: includes/class-sensei-lesson.php:1192
 msgid "Number of questions:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1133, includes/class-sensei-lesson.php:1133
+#: includes/class-sensei-lesson.php:1194, includes/class-sensei-lesson.php:1194
 msgid "Add Question(s)"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1311
+#: includes/class-sensei-lesson.php:1382
 msgid "There are no questions matching your search."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1363, includes/class-sensei-lesson.php:1745
+#: includes/class-sensei-lesson.php:1434, includes/class-sensei-lesson.php:1816
 msgid "Right:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1384, includes/class-sensei-lesson.php:1745
+#: includes/class-sensei-lesson.php:1455, includes/class-sensei-lesson.php:1816
 msgid "Wrong:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1425
+#: includes/class-sensei-lesson.php:1496
 msgid "Add right answer"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1426
+#: includes/class-sensei-lesson.php:1497
 msgid "Add wrong answer"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1441, templates/single-quiz/question_type-boolean.php:81
+#: includes/class-sensei-lesson.php:1512, templates/single-quiz/question_type-boolean.php:81
 msgid "True"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1442, templates/single-quiz/question_type-boolean.php:85
+#: includes/class-sensei-lesson.php:1513, templates/single-quiz/question_type-boolean.php:85
 msgid "False"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1455
+#: includes/class-sensei-lesson.php:1526
 msgid "Text before the Gap:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1457
+#: includes/class-sensei-lesson.php:1528
 msgid "The Gap:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1459
+#: includes/class-sensei-lesson.php:1530
 msgid "Text after the Gap:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1461
+#: includes/class-sensei-lesson.php:1532
 msgid "Preview:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1473
+#: includes/class-sensei-lesson.php:1544
 msgid "Guide/Teacher Notes for grading the answer"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1485
+#: includes/class-sensei-lesson.php:1556
 msgid "Recommended Answer"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1503
+#: includes/class-sensei-lesson.php:1574
 msgid "Description for student explaining what needs to be uploaded"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1507
+#: includes/class-sensei-lesson.php:1578
 msgid "Guide/Teacher Notes for grading the upload"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1540
+#: includes/class-sensei-lesson.php:1611
 msgid "This feedback will be automatically displayed to the student once they have completed the quiz."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1541
+#: includes/class-sensei-lesson.php:1612
 msgid "Answer Feedback"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1610
+#: includes/class-sensei-lesson.php:1681
 msgid "There is no quiz for this lesson yet - please add one in the 'Quiz Questions' box."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1659
+#: includes/class-sensei-lesson.php:1730
 msgid "Pass required to complete lesson"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1660
+#: includes/class-sensei-lesson.php:1731
 msgid "The passmark must be achieved before the lesson is complete."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1667
+#: includes/class-sensei-lesson.php:1738
 msgid "Quiz passmark percentage"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1678
+#: includes/class-sensei-lesson.php:1749
 msgid "Number of questions to show"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1679
+#: includes/class-sensei-lesson.php:1750
 msgid "Show a random selection of questions from this quiz each time a student views it."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1688
+#: includes/class-sensei-lesson.php:1759
 msgid "Randomise question order"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1696
+#: includes/class-sensei-lesson.php:1767
 msgid "Grade quiz automatically"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1697
+#: includes/class-sensei-lesson.php:1768
 msgid "Grades quiz and displays answer explanation immediately after completion. Only applicable if quiz is limited to Multiple Choice, True/False and Gap Fill questions. Questions that have a grade of zero are skipped during autograding."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1704
+#: includes/class-sensei-lesson.php:1775
 msgid "Allow user to retake the quiz"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1705
+#: includes/class-sensei-lesson.php:1776
 msgid "Enables the quiz reset button."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1745
+#: includes/class-sensei-lesson.php:1816
 msgid "Are you sure you want to remove this question?"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1745
+#: includes/class-sensei-lesson.php:1816
 msgid "Are you sure you want to remove these questions?"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1745
+#: includes/class-sensei-lesson.php:1816
 msgid "You have selected more questions than this category contains - please reduce the number of questions that you are adding."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1789
+#: includes/class-sensei-lesson.php:1860
 msgctxt "column name"
 msgid "Lesson Title"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1790
+#: includes/class-sensei-lesson.php:1861
 msgctxt "column name"
 msgid "Course"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1791
+#: includes/class-sensei-lesson.php:1862
 msgctxt "column name"
 msgid "Pre-requisite Lesson"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1949
+#: includes/class-sensei-lesson.php:2020
 msgid "%1$s Question(s) from %2$s"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2501
+#: includes/class-sensei-lesson.php:2562
 msgid "Easy"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2502
+#: includes/class-sensei-lesson.php:2563
 msgid "Standard"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2503
+#: includes/class-sensei-lesson.php:2564
 msgid "Hard"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3011
+#: includes/class-sensei-lesson.php:3068
 msgid "No Change"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3058
+#: includes/class-sensei-lesson.php:3115
 msgid "Pass required"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3064
+#: includes/class-sensei-lesson.php:3121
 msgid "Pass Percentage"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3077
+#: includes/class-sensei-lesson.php:3134
 msgid "Enable quiz reset button"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3318, templates/course-results/lessons.php:74, templates/course-results/lessons.php:131
+#: includes/class-sensei-lesson.php:3375, templates/course-results/lessons.php:74, templates/course-results/lessons.php:131
 msgid "Start %s"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3339
+#: includes/class-sensei-lesson.php:3396
 msgid "Length: "
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3339
+#: includes/class-sensei-lesson.php:3396
 msgid " minutes"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3345
+#: includes/class-sensei-lesson.php:3402
 msgid "Author: "
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3350
+#: includes/class-sensei-lesson.php:3407
 msgid "Complexity: "
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3356
+#: includes/class-sensei-lesson.php:3413
 msgid "Complete"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3535, includes/class-sensei-lesson.php:3555, includes/class-sensei-lesson.php:3581, includes/class-sensei-utils.php:1235, includes/class-sensei-utils.php:1318
+#: includes/class-sensei-lesson.php:3602
+msgid "the previous course"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:3606
+msgid "Please complete %1$s before starting the lesson."
+msgstr ""
+
+#: includes/class-sensei-lesson.php:3616, includes/class-sensei-lesson.php:3629, includes/class-sensei-lesson.php:3641, includes/class-sensei-utils.php:1260, includes/class-sensei-utils.php:1343
 msgid "Sign Up"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3541, includes/class-sensei-lesson.php:3561
-msgid "This is a preview lesson. Please purchase the %1$s before starting the lesson."
-msgstr ""
-
-#: includes/class-sensei-lesson.php:3545, includes/class-sensei-lesson.php:3565
+#: includes/class-sensei-lesson.php:3620, includes/class-sensei-lesson.php:3629
 msgid "Please purchase the %1$s before starting the lesson."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3587, includes/class-sensei.php:621
-msgid "This is a preview lesson. Please sign up for the %1$s to access all lessons."
-msgstr ""
-
-#: includes/class-sensei-lesson.php:3591, includes/class-sensei.php:624
+#: includes/class-sensei-lesson.php:3645, includes/class-sensei.php:627
 msgid "Please sign up for the %1$s before starting the lesson."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3618
+#: includes/class-sensei-lesson.php:3669
 msgid "You must first complete: %1$s"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3619
+#: includes/class-sensei-lesson.php:3670
 msgid "You must first complete %1$s before viewing this Lesson"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3651
+#: includes/class-sensei-lesson.php:3698
 msgid "Lessons Archive"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3769, includes/class-sensei-lesson.php:3771
+#: includes/class-sensei-lesson.php:3799, includes/class-sensei-lesson.php:3801
 msgid "View the Lesson Quiz"
 msgstr ""
 
@@ -1477,91 +1482,79 @@ msgstr ""
 msgid "No items found."
 msgstr ""
 
-#: includes/class-sensei-messages.php:70, includes/class-sensei-messages.php:70, includes/class-sensei-posttypes.php:609, includes/class-sensei-posttypes.php:609
+#: includes/class-sensei-messages.php:67, includes/class-sensei-messages.php:67, includes/class-sensei-posttypes.php:609, includes/class-sensei-posttypes.php:609
 msgid "Messages"
 msgstr ""
 
-#: includes/class-sensei-messages.php:78
+#: includes/class-sensei-messages.php:75
 msgid "Message Information"
 msgstr ""
 
-#: includes/class-sensei-messages.php:88
+#: includes/class-sensei-messages.php:85
 msgid "Message sent by:"
 msgstr ""
 
-#: includes/class-sensei-messages.php:89
+#: includes/class-sensei-messages.php:86
 msgid "The username of the learner who sent this message."
 msgstr ""
 
 #: includes/class-sensei-messages.php:92
-msgid "Learner username"
-msgstr ""
-
-#: includes/class-sensei-messages.php:96
 msgid "Message received by:"
 msgstr ""
 
-#: includes/class-sensei-messages.php:97
+#: includes/class-sensei-messages.php:93
 msgid "The username of the teacher who received this message."
 msgstr ""
 
-#: includes/class-sensei-messages.php:100
-msgid "Teacher username"
-msgstr ""
-
-#: includes/class-sensei-messages.php:118
-msgid "Select %1$s"
-msgstr ""
-
-#: includes/class-sensei-messages.php:125
+#: includes/class-sensei-messages.php:108
 msgid "Message from %1$s:"
 msgstr ""
 
-#: includes/class-sensei-messages.php:126
+#: includes/class-sensei-messages.php:109
 msgid "The %1$s to which this message relates."
 msgstr ""
 
-#: includes/class-sensei-messages.php:185
+#: includes/class-sensei-messages.php:143
 msgid "Contact Lesson Teacher"
 msgstr ""
 
-#: includes/class-sensei-messages.php:187
+#: includes/class-sensei-messages.php:145
 msgid "Contact Course Teacher"
 msgstr ""
 
-#: includes/class-sensei-messages.php:189
+#: includes/class-sensei-messages.php:147
 msgid "Contact Teacher"
 msgstr ""
 
-#: includes/class-sensei-messages.php:219
+#: includes/class-sensei-messages.php:179
 msgid "Your private message has been sent."
 msgstr ""
 
-#: includes/class-sensei-messages.php:224
+#: includes/class-sensei-messages.php:184
 msgid "Send Private Message"
 msgstr ""
 
-#: includes/class-sensei-messages.php:230
+#: includes/class-sensei-messages.php:190
 msgid "Enter your private message."
 msgstr ""
 
-#: includes/class-sensei-messages.php:237
+#: includes/class-sensei-messages.php:195
 msgid "Send Message"
 msgstr ""
 
-#: includes/class-sensei-messages.php:481
+#: includes/class-sensei-messages.php:449
 msgid "You are not allowed to view this message."
 msgstr ""
 
-#: includes/class-sensei-messages.php:498
+#: includes/class-sensei-messages.php:466
 msgid "Please log in to view your messages."
 msgstr ""
 
-#: includes/class-sensei-messages.php:573, includes/class-sensei-messages.php:689
+#: includes/class-sensei-messages.php:541, includes/class-sensei-messages.php:657
 msgid "Sent by %1$s on %2$s."
 msgstr ""
 
-#: includes/class-sensei-messages.php:594, includes/class-sensei-messages.php:659
+#: includes/class-sensei-messages.php:562, includes/class-sensei-messages.php:627
 msgid "Re: %1$s"
 msgstr ""
 
@@ -1585,7 +1578,7 @@ msgstr ""
 msgid "Course(s)"
 msgstr ""
 
-#: includes/class-sensei-modules.php:279, includes/class-sensei-modules.php:1318
+#: includes/class-sensei-modules.php:279, includes/class-sensei-modules.php:1328
 msgid "Search for courses"
 msgstr ""
 
@@ -1617,7 +1610,7 @@ msgstr ""
 msgid "Previous module"
 msgstr ""
 
-#: includes/class-sensei-modules.php:825, includes/class-sensei-modules.php:825, includes/class-sensei-modules.php:1350, includes/class-sensei-modules.php:1539, includes/class-sensei-modules.php:1549
+#: includes/class-sensei-modules.php:825, includes/class-sensei-modules.php:825, includes/class-sensei-modules.php:1360, includes/class-sensei-modules.php:1550, includes/class-sensei-modules.php:1560
 msgid "Modules"
 msgstr ""
 
@@ -1645,40 +1638,44 @@ msgstr ""
 msgid "Order modules"
 msgstr ""
 
-#: includes/class-sensei-modules.php:1069, includes/class-sensei-modules.php:1121, includes/class-sensei-modules.php:1540
+#: includes/class-sensei-modules.php:1069, includes/class-sensei-modules.php:1121, includes/class-sensei-modules.php:1551
 msgid "Module"
 msgstr ""
 
-#: includes/class-sensei-modules.php:1541
+#: includes/class-sensei-modules.php:1552
 msgid "Search Modules"
 msgstr ""
 
-#: includes/class-sensei-modules.php:1542
+#: includes/class-sensei-modules.php:1553
 msgid "All Modules"
 msgstr ""
 
-#: includes/class-sensei-modules.php:1543
+#: includes/class-sensei-modules.php:1554
 msgid "Parent Module"
 msgstr ""
 
-#: includes/class-sensei-modules.php:1544
+#: includes/class-sensei-modules.php:1555
 msgid "Parent Module:"
 msgstr ""
 
-#: includes/class-sensei-modules.php:1545
+#: includes/class-sensei-modules.php:1556
 msgid "Edit Module"
 msgstr ""
 
-#: includes/class-sensei-modules.php:1546
+#: includes/class-sensei-modules.php:1557
 msgid "Update Module"
 msgstr ""
 
-#: includes/class-sensei-modules.php:1547
+#: includes/class-sensei-modules.php:1558
 msgid "Add New Module"
 msgstr ""
 
-#: includes/class-sensei-modules.php:1548
+#: includes/class-sensei-modules.php:1559
 msgid "New Module Name"
+msgstr ""
+
+#: includes/class-sensei-modules.php:1561
+msgid "No modules found."
 msgstr ""
 
 #: includes/class-sensei-posttypes.php:120
@@ -1962,7 +1959,7 @@ msgctxt "taxonomy archive slug"
 msgid "lesson-tag"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:606, includes/class-sensei-quiz.php:1124
+#: includes/class-sensei-posttypes.php:606, includes/class-sensei-quiz.php:1131
 msgid "Quiz"
 msgstr ""
 
@@ -2111,31 +2108,35 @@ msgstr ""
 msgid "All categories"
 msgstr ""
 
-#: includes/class-sensei-question.php:718
+#: includes/class-sensei-question.php:735
 msgid "Incorrect - Right Answer:"
 msgstr ""
 
-#: includes/class-sensei-question.php:728
+#: includes/class-sensei-question.php:745
 msgid "Grade: %d"
+msgstr ""
+
+#: includes/class-sensei-question.php:877
+msgid "Maximum upload file size: %d%s"
 msgstr ""
 
 #: includes/class-sensei-quiz.php:203
 msgid "Quiz Saved Successfully."
 msgstr ""
 
-#: includes/class-sensei-quiz.php:509
+#: includes/class-sensei-quiz.php:516
 msgid "Quiz Reset Successfully."
 msgstr ""
 
-#: includes/class-sensei-quiz.php:1276
+#: includes/class-sensei-quiz.php:1297
 msgid "Complete Quiz"
 msgstr ""
 
-#: includes/class-sensei-quiz.php:1278
+#: includes/class-sensei-quiz.php:1299
 msgid "Save Quiz"
 msgstr ""
 
-#: includes/class-sensei-quiz.php:1284
+#: includes/class-sensei-quiz.php:1305
 msgid "Reset Quiz"
 msgstr ""
 
@@ -2615,23 +2616,23 @@ msgstr ""
 msgid "Select a Page:"
 msgstr ""
 
-#: includes/class-sensei-teacher.php:117, includes/class-sensei-teacher.php:227, includes/class-sensei-teacher.php:1100, includes/class-sensei-updates.php:933
+#: includes/class-sensei-teacher.php:117, includes/class-sensei-teacher.php:227, includes/class-sensei-teacher.php:1104, includes/class-sensei-updates.php:933
 msgid "Teacher"
 msgstr ""
 
-#: includes/class-sensei-teacher.php:888
+#: includes/class-sensei-teacher.php:890
 msgid "New course created."
 msgstr ""
 
-#: includes/class-sensei-teacher.php:899
+#: includes/class-sensei-teacher.php:901
 msgid "New course created by"
 msgstr ""
 
-#: includes/class-sensei-teacher.php:1249
+#: includes/class-sensei-teacher.php:1253
 msgid "Show all teachers"
 msgstr ""
 
-#: includes/class-sensei-teacher.php:1555
+#: includes/class-sensei-teacher.php:1559
 msgid "All courses by %s"
 msgstr ""
 
@@ -2943,83 +2944,83 @@ msgstr ""
 msgid "Sensei activity type %s is no longer used."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1153
+#: includes/class-sensei-utils.php:1170
 msgid "You have not started this course yet."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1165
+#: includes/class-sensei-utils.php:1182
 msgid "You have passed this course with a grade of %1$d%%."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1169
+#: includes/class-sensei-utils.php:1186
 msgid "You require %1$d%% to pass this course. Your grade is %2$s%%."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1194
+#: includes/class-sensei-utils.php:1211
 msgid "You have not taken this lesson's quiz yet"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1235
+#: includes/class-sensei-utils.php:1260
 msgid "Please sign up for %1$sthe course%2$s before taking this quiz"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1241
+#: includes/class-sensei-utils.php:1266
 msgid "You must be logged in to take this quiz"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1251
+#: includes/class-sensei-utils.php:1276
 msgid "Congratulations! You have passed this lesson."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1255
+#: includes/class-sensei-utils.php:1280
 msgid "Congratulations! You have completed this lesson."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1260
+#: includes/class-sensei-utils.php:1285
 msgid "Congratulations! You have passed this lesson's quiz achieving %s%%"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1262
+#: includes/class-sensei-utils.php:1287
 msgid "Congratulations! You have passed this quiz achieving %s%%"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1273
+#: includes/class-sensei-utils.php:1298
 msgid "Next Lesson"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1285
+#: includes/class-sensei-utils.php:1310
 msgid "You have completed this lesson's quiz and it will be graded soon. %1$sView the lesson quiz%2$s"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1287
+#: includes/class-sensei-utils.php:1312
 msgid "You have completed this quiz and it will be graded soon. You require %1$s%% to pass."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1295
+#: includes/class-sensei-utils.php:1320
 msgid "You require %1$d%% to pass this lesson's quiz. Your grade is %2$s%%"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1297
+#: includes/class-sensei-utils.php:1322
 msgid "You require %1$d%% to pass this quiz. Your grade is %2$s%%"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1308
+#: includes/class-sensei-utils.php:1333
 msgid "You require %1$d%% to pass this lesson's quiz."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1310
+#: includes/class-sensei-utils.php:1335
 msgid "You require %1$d%% to pass this quiz."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1324
+#: includes/class-sensei-utils.php:1349
 msgid "Please purchase the %1$s before taking this quiz."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1328
+#: includes/class-sensei-utils.php:1353
 msgid "Please sign up for the %1$s before taking this quiz."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1340, includes/class-sensei-utils.php:1340
+#: includes/class-sensei-utils.php:1365, includes/class-sensei-utils.php:1365
 msgid "View the lesson quiz"
 msgstr ""
 
@@ -3031,144 +3032,144 @@ msgstr ""
 msgid "Free"
 msgstr ""
 
-#: includes/class-sensei-wc.php:378
+#: includes/class-sensei-wc.php:467
 msgctxt "Purchase thank you note on Checkout page. The course link(s) will be show"
 msgid "You have purchased the following course:"
 msgid_plural "You have purchased the following courses:"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-sensei-wc.php:416
+#: includes/class-sensei-wc.php:505
 msgid "complete purchase"
 msgstr ""
 
-#: includes/class-sensei-wc.php:812
+#: includes/class-sensei-wc.php:901
 msgid "Purchase this Course"
 msgstr ""
 
-#: includes/class-sensei-wc.php:880
+#: includes/class-sensei-wc.php:969
 msgid "This course is already in your cart, please proceed to %1$s, to gain access."
 msgstr ""
 
-#: includes/class-sensei-wc.php:1121
+#: includes/class-sensei-wc.php:1214
 msgid "Course details"
 msgstr ""
 
-#: includes/class-sensei-wc.php:1163
+#: includes/class-sensei-wc.php:1256
 msgid "View course: %1$s"
 msgstr ""
 
-#: includes/class-sensei-wc.php:1619
+#: includes/class-sensei-wc.php:1705
 msgid "No active subscription"
 msgstr ""
 
-#: includes/class-sensei-wc.php:1620
+#: includes/class-sensei-wc.php:1706
 msgid "Sorry, you do not have an access to this content without an active subscription."
 msgstr ""
 
-#: includes/class-sensei.php:575
+#: includes/class-sensei.php:578
 msgid "Please complete the previous %1$s before taking this course."
 msgstr ""
 
-#: includes/class-sensei.php:579
+#: includes/class-sensei.php:582
 msgid "Or %1$s login %2$s to access your purchased courses"
 msgstr ""
 
-#: includes/class-sensei.php:610, includes/class-sensei.php:649, includes/class-sensei.php:665, includes/class-sensei.php:677
+#: includes/class-sensei.php:613, includes/class-sensei.php:652, includes/class-sensei.php:668, includes/class-sensei.php:680
 msgid "Restricted Access"
 msgstr ""
 
-#: includes/class-sensei.php:615
+#: includes/class-sensei.php:618
 msgid "This is a preview lesson. Please purchase the %1$s to access all lessons."
 msgstr ""
 
-#: includes/class-sensei.php:617
+#: includes/class-sensei.php:620
 msgid "Please purchase the %1$s before starting this Lesson."
 msgstr ""
 
-#: includes/class-sensei.php:651
+#: includes/class-sensei.php:624
+msgid "This is a preview lesson. Please sign up for the %1$s to access all lessons."
+msgstr ""
+
+#: includes/class-sensei.php:654
 msgid "Please complete the previous %1$s before taking this Quiz."
 msgstr ""
 
-#: includes/class-sensei.php:669
+#: includes/class-sensei.php:672
 msgid "Please purchase the %1$s before starting this Quiz."
 msgstr ""
 
-#: includes/class-sensei.php:671
+#: includes/class-sensei.php:674
 msgid "Please sign up for the %1$s before starting this Quiz."
 msgstr ""
 
-#: includes/class-sensei.php:679
+#: includes/class-sensei.php:682
 msgid "Please sign up for the %1$s before taking this Quiz."
 msgstr ""
 
-#: includes/class-sensei.php:1165
+#: includes/class-sensei.php:1168
 msgctxt "noun"
 msgid "Support"
 msgstr ""
 
-#: includes/class-sensei.php:1181
+#: includes/class-sensei.php:1184
 msgctxt "plugin action link"
 msgid "Configure"
 msgstr ""
 
-#: includes/emails/class-sensei-email-teacher-new-course-assignment.php:39
-msgid "[%1$s] You have been assigned to a course"
-msgstr ""
-
-#: includes/emails/class-sensei-email-teacher-new-course-assignment.php:40
+#: includes/emails/class-sensei-email-teacher-new-course-assignment.php:57
 msgid "Course assigned to you"
 msgstr ""
 
-#: includes/emails/class-sensei-email-teacher-new-course-assignment.php:57
+#: includes/emails/class-sensei-email-teacher-new-course-assignment.php:58
 msgid "New course assigned to you"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-learner-completed-course.php:33
+#: includes/emails/class-woothemes-sensei-email-learner-completed-course.php:60
 msgid "[%1$s] You have completed a course"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-learner-completed-course.php:34
+#: includes/emails/class-woothemes-sensei-email-learner-completed-course.php:61
 msgid "You have completed a course"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-learner-completed-course.php:58, includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php:62, includes/emails/class-woothemes-sensei-email-teacher-completed-course.php:59
+#: includes/emails/class-woothemes-sensei-email-learner-completed-course.php:65, includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php:69, includes/emails/class-woothemes-sensei-email-teacher-completed-course.php:65
 msgid "passed"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-learner-completed-course.php:60, includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php:60, includes/emails/class-woothemes-sensei-email-teacher-completed-course.php:61
+#: includes/emails/class-woothemes-sensei-email-learner-completed-course.php:67, includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php:67, includes/emails/class-woothemes-sensei-email-teacher-completed-course.php:67
 msgid "failed"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php:32
+#: includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php:62
 msgid "[%1$s] Your quiz has been graded"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php:33
+#: includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php:63
 msgid "Your quiz has been graded"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php:69
+#: includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php:76
 msgid "[%1$s] You have completed a quiz"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php:70
+#: includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php:77
 msgid "You have completed a quiz"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-new-message-reply.php:60
+#: includes/emails/class-woothemes-sensei-email-new-message-reply.php:94
 msgid "[%1$s] You have a new message"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-new-message-reply.php:61
+#: includes/emails/class-woothemes-sensei-email-new-message-reply.php:95
 msgid "You have received a reply to your private message"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-teacher-completed-course.php:33
+#: includes/emails/class-woothemes-sensei-email-teacher-completed-course.php:61
 msgid "[%1$s] Your student has completed a course"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-teacher-completed-course.php:34
+#: includes/emails/class-woothemes-sensei-email-teacher-completed-course.php:62
 msgid "Your student has completed a course"
 msgstr ""
 
@@ -3180,27 +3181,27 @@ msgstr ""
 msgid "Your student has completed a lesson"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-teacher-new-message.php:32
+#: includes/emails/class-woothemes-sensei-email-teacher-new-message.php:57
 msgid "[%1$s] You have received a new private message"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-teacher-new-message.php:33
+#: includes/emails/class-woothemes-sensei-email-teacher-new-message.php:58
 msgid "Your student has sent you a private message"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-teacher-quiz-submitted.php:31
+#: includes/emails/class-woothemes-sensei-email-teacher-quiz-submitted.php:63
 msgid "[%1$s] Your student has submitted a quiz for grading"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-teacher-quiz-submitted.php:32
+#: includes/emails/class-woothemes-sensei-email-teacher-quiz-submitted.php:64
 msgid "Your student has submitted a quiz for grading"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-teacher-started-course.php:31
+#: includes/emails/class-woothemes-sensei-email-teacher-started-course.php:56
 msgid "[%1$s] Your student has started a course"
 msgstr ""
 
-#: includes/emails/class-woothemes-sensei-email-teacher-started-course.php:32
+#: includes/emails/class-woothemes-sensei-email-teacher-started-course.php:57
 msgid "Your student has started a course"
 msgstr ""
 
@@ -3226,6 +3227,10 @@ msgstr ""
 
 #: includes/shortcodes/class-sensei-shortcode-lesson-page.php:87
 msgid "No posts found."
+msgstr ""
+
+#: includes/shortcodes/class-sensei-shortcode-unpurchased-courses.php:134
+msgid "You must be logged in to view the non-purchased courses. Click here to %slogin%s."
 msgstr ""
 
 #: includes/shortcodes/class-sensei-shortcode-user-messages.php:76
@@ -3344,7 +3349,7 @@ msgstr ""
 msgid "The user requested does not exist."
 msgstr ""
 
-#: templates/single-course/modules.php:96
+#: templates/single-course/modules.php:99
 msgid "Free Preview"
 msgstr ""
 

--- a/templates/single-quiz/question-type-boolean.php
+++ b/templates/single-quiz/question-type-boolean.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * The Template for displaying True/False ( Boolean ) Question type.
  *
+ * Override this template by copying it to yourtheme/sensei/single-quiz/question-type-boolean.php
+ *
  * @author 		Automattic
  * @package 	Sensei
  * @category    Templates

--- a/templates/single-quiz/question-type-file-upload.php
+++ b/templates/single-quiz/question-type-file-upload.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * The Template for displaying File Upload Questions.
  *
- * Override this template by copying it to yourtheme/sensei/single-quiz/question_type-file-upload.php
+ * Override this template by copying it to yourtheme/sensei/single-quiz/question-type-file-upload.php
  *
  * @author 		Automattic
  * @package 	Sensei

--- a/templates/single-quiz/question-type-gap-fill.php
+++ b/templates/single-quiz/question-type-gap-fill.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * The Template for displaying Gap Fill Line Questions.
  *
- * Override this template by copying it to yourtheme/sensei/single-quiz/question_type-gap-fill.php
+ * Override this template by copying it to yourtheme/sensei/single-quiz/question-type-gap-fill.php
  *
  * @author 		Automattic
  * @package 	Sensei

--- a/templates/single-quiz/question-type-multi-line.php
+++ b/templates/single-quiz/question-type-multi-line.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * The Template for displaying Multi Line Questions.
  *
- * Override this template by copying it to yourtheme/sensei/single-quiz/question_type-multi-line.php
+ * Override this template by copying it to yourtheme/sensei/single-quiz/question-type-multi-line.php
  *
  * @author 		Automattic
  * @package 	Sensei
@@ -29,5 +29,3 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                                                 'sensei_question[' . $question_data[ 'ID' ] . ']' );
 
 ?>
-
-

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * The Template for displaying Multiple Choice Questions.
  *
+ * Override this template by copying it to yourtheme/sensei/single-quiz/question-type-multiple-choice.php
+ *
  * @author 		Automattic
  * @package 	Sensei
  * @category    Templates
@@ -48,6 +50,3 @@ foreach( $question_data[ 'answer_options' ] as $id => $option ) {
 <?php } // End For Loop ?>
 
 </ul>
-
-
-

--- a/templates/single-quiz/question-type-single-line.php
+++ b/templates/single-quiz/question-type-single-line.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * The Template for displaying Single Line Questions.
  *
- * Override this template by copying it to yourtheme/sensei/single-quiz/question_type-single-line.php
+ * Override this template by copying it to yourtheme/sensei/single-quiz/question-type-single-line.php
  *
  * @author 		Automattic
  * @package 	Sensei

--- a/woothemes-sensei.php
+++ b/woothemes-sensei.php
@@ -28,6 +28,7 @@ Domain path: /lang/
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+<<<<<<< HEAD
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 require_once( __DIR__ . '/includes/class-sensei-autoloader.php' );
@@ -69,11 +70,9 @@ add_action( 'init', array( 'Sensei_WC', 'load_woocommerce_integration_hooks' ) )
 
 /**
  * Load all Template hooks
-*/
+ */
 if ( ! is_admin() ) {
-
 	require_once( __DIR__ . '/includes/hooks/template.php' );
-
 }
 
 /**

--- a/woothemes-sensei.php
+++ b/woothemes-sensei.php
@@ -3,11 +3,12 @@
 Plugin Name: Sensei
 Plugin URI: http://www.woothemes.com/products/sensei/
 Description: A course management plugin that offers the smoothest platform for helping you teach anything.
+Version: 1.9.7
 Author: WooThemes
 Author URI: http://www.woothemes.com/
 License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 Requires at least: 4.1
-Tested up to: 4.5
+Tested up to: 4.6.1
 Text Domain: woothemes-sensei
 Domain path: /lang/
 */
@@ -49,7 +50,7 @@ Domain path: /lang/
     }
 
 	// set the sensei version number
-    Sensei()->version = '1.9.6';
+    Sensei()->version = '1.9.7';
 
     //backwards compatibility
     global $woothemes_sensei;

--- a/woothemes-sensei.php
+++ b/woothemes-sensei.php
@@ -27,9 +27,10 @@ Domain path: /lang/
 	along with this program; if not, write to the Free Software
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
-
-<<<<<<< HEAD
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+*
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 require_once( __DIR__ . '/includes/class-sensei-autoloader.php' );
 require_once( __DIR__ . '/includes/lib/woo-functions.php' );

--- a/woothemes-sensei.php
+++ b/woothemes-sensei.php
@@ -34,9 +34,16 @@ Domain path: /lang/
     require_once( 'includes/lib/woo-functions.php' );
     require_once( 'includes/sensei-functions.php' );
 
-    if ( ! is_admin() ) {
+    /**
+     * Load Sensei Template Functions
+     *
+     * @since 1.9.8
+     */
+    function sensei_load_template_functions() {
         require_once( 'includes/template-functions.php' );
     }
+
+    add_action( 'after_setup_theme', 'sensei_load_template_functions' );
 
     /**
      * Returns the global Sensei Instance.

--- a/woothemes-sensei.php
+++ b/woothemes-sensei.php
@@ -14,101 +14,100 @@ Domain path: /lang/
 */
 /*  Copyright 2013  WooThemes  (email : info@woothemes.com)
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License, version 2, as
-    published by the Free Software Foundation.
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License, version 2, as
+	published by the Free Software Foundation.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-	if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-    require_once( 'includes/class-sensei-autoloader.php' );
-    require_once( 'includes/lib/woo-functions.php' );
-    require_once( 'includes/sensei-functions.php' );
+require_once( __DIR__ . '/includes/class-sensei-autoloader.php' );
+require_once( __DIR__ . '/includes/lib/woo-functions.php' );
+require_once( __DIR__ . '/includes/sensei-functions.php' );
 
-    /**
-     * Load Sensei Template Functions
-     *
-     * @since 1.9.8
-     */
-    function sensei_load_template_functions() {
-        require_once( 'includes/template-functions.php' );
-    }
+/**
+ * Load Sensei Template Functions
+ *
+ * @since 1.9.8
+ */
+function sensei_load_template_functions() {
+	if ( ! is_admin() ) {
+		require_once( __DIR__ . '/includes/template-functions.php' );
+	}
+}
+add_action( 'after_setup_theme', 'sensei_load_template_functions' );
 
-    add_action( 'after_setup_theme', 'sensei_load_template_functions' );
+/**
+ * Returns the global Sensei Instance.
+ *
+ * @since 1.8.0
+ */
+function Sensei(){
+	return Sensei_Main::instance();
+}
 
-    /**
-     * Returns the global Sensei Instance.
-     *
-     * @since 1.8.0
-     */
-    function Sensei(){
+// set the sensei version number
+Sensei()->version = '1.9.7';
 
-        return Sensei_Main::instance();
+//backwards compatibility
+global $woothemes_sensei;
+$woothemes_sensei = Sensei();
 
-    }
+/**
+* Hook in WooCommerce functionality
+*/
+add_action( 'init', array( 'Sensei_WC', 'load_woocommerce_integration_hooks' ) );
 
-	// set the sensei version number
-    Sensei()->version = '1.9.7';
+/**
+ * Load all Template hooks
+*/
+if ( ! is_admin() ) {
 
-    //backwards compatibility
-    global $woothemes_sensei;
-    $woothemes_sensei = Sensei();
+	require_once( __DIR__ . '/includes/hooks/template.php' );
 
-    /**
-    * Hook in WooCommerce functionality
-    */
-	add_action('init', array( 'Sensei_WC', 'load_woocommerce_integration_hooks' ) );
+}
 
-    /**
-     * Load all Template hooks
-    */
-    if(! is_admin() ){
+/**
+ * Plugin updates
+ * @since  1.0.1
+ */
+woothemes_queue_update( plugin_basename( __FILE__ ), 'bad2a02a063555b7e2bee59924690763', 152116 );
 
-        require_once( 'includes/hooks/template.php' );
+/**
+ * Sensei Activation Hook registration
+ * @since 1.8.0
+ */
+register_activation_hook( __FILE__, 'activate_sensei' );
 
-    }
+/**
+ * Activate_sensei
+ *
+ * All the activation checks needed to ensure Sensei is ready for use
+ * @since 1.8.0
+ */
+function activate_sensei() {
 
-    /**
-     * Plugin updates
-     * @since  1.0.1
-     */
-    woothemes_queue_update( plugin_basename( __FILE__ ), 'bad2a02a063555b7e2bee59924690763', 152116 );
+	// create the teacher role on activation and ensure that it has all the needed capabilities
+	Sensei()->teacher->create_role();
 
-    /**
-     * Sensei Activation Hook registration
-     * @since 1.8.0
-     */
-    register_activation_hook( __FILE__, 'activate_sensei' );
+	//Setup all the role capabilities needed
+	Sensei()->updates->add_sensei_caps();
+	Sensei()->updates->add_editor_caps();
+	Sensei()->updates->assign_role_caps();
 
-    /**
-     * Activate_sensei
-     *
-     * All the activation checks needed to ensure Sensei is ready for use
-     * @since 1.8.0
-     */
-    function activate_sensei () {
+	//Flush rules
+	add_action( 'activated_plugin' , array( 'Sensei_Main','activation_flush_rules' ), 10 );
 
-        // create the teacher role on activation and ensure that it has all the needed capabilities
-        Sensei()->teacher->create_role();
+	//Load the Welcome Screen
+	add_action( 'activated_plugin' , array( 'Sensei_Welcome','redirect' ), 20 );
 
-        //Setup all the role capabilities needed
-        Sensei()->updates->add_sensei_caps();
-        Sensei()->updates->add_editor_caps();
-        Sensei()->updates->assign_role_caps();
-
-        //Flush rules
-        add_action( 'activated_plugin' , array( 'Sensei_Main','activation_flush_rules' ), 10 );
-
-        //Load the Welcome Screen
-        add_action( 'activated_plugin' , array( 'Sensei_Welcome','redirect' ), 20 );
-
-    }// end activate_sensei
+}


### PR DESCRIPTION
Changing some files names for coding standards and adding `__DIR__` for includes/required.

Also load old templates in case they are still used, but raise a deprecated file error message.

cc @dllh 