### PR TITLE
Use wp_kses instead of esc_html

### DIFF
--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -206,7 +206,15 @@ class Sensei_Grading_User_Quiz {
                                     $_user_answer = htmlspecialchars_decode( nl2br( $_user_answer ) );
                                 }
 
-								echo esc_html( apply_filters( 'sensei_answer_text', $_user_answer ) ) . "<br>";
+								$_user_answer = wp_kses( apply_filters( 'sensei_answer_text', $_user_answer ), array(
+									'a' => array(
+										'href' => array(),
+										'title' => array(),
+										'target' => array(),
+									)
+								) );
+
+								echo $_user_answer . "<br>";
 							}
 						?></p>
 						<div class="right-answer">


### PR DESCRIPTION
Replace esc_html with wp_kses to allow linking to the uploaded file. wp_kses allows only to use a tags with href, title and target attributes. Any other HTML will be escaped.

![](http://cld.wthms.co/IODq/2ECS5nbw+)

Closes #1568

cc @danjjohnson 