### PR TITLE
Course and Lesson Videos: pass video content through the_content

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2931,26 +2931,20 @@ class Sensei_Course {
 
         global $post;
 
-	    if ( ! is_singular( 'course' )  ) {
-		    return;
-	    }
+	if ( ! is_singular( 'course' )  ) {
+		return;
+	}
 
         // Get the meta info
         $course_video_embed = get_post_meta( $post->ID, '_course_video_embed', true );
 
-        if ( 'http' == substr( $course_video_embed, 0, 4) ) {
-
-            $course_video_embed = wp_oembed_get( esc_url( $course_video_embed ) );
-
-        } // End If Statement
-
-        if ( '' != $course_video_embed ) { ?>
-
-            <div class="course-video">
-                <?php echo wp_kses( do_shortcode( $course_video_embed ), self::$allowed_html ); ?>
-            </div>
-
-        <?php } // End If Statement
+	if ( '' != $course_video_embed ) {
+		printf(
+			'<div class="course-video">%s</div>',
+			/** This filter is already documented in core. wp-includes/post-template.php */
+			apply_filters( 'the_content', $course_video_embed )
+		);
+	}
     }
 
     /**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2922,30 +2922,30 @@ class Sensei_Course {
 
     }// end the_course_enrolment_actions
 
-    /**
-     * Output the course video inside the loop.
-     *
-     * @since 1.9.0
-     */
-    public static function the_course_video(){
+	/**
+	 * Output the course video inside the loop.
+	 *
+	 * @since 1.9.0
+	 */
+	 public static function the_course_video() {
 
-        global $post;
+		global $post;
 
-	if ( ! is_singular( 'course' )  ) {
-		return;
+		if ( ! is_singular( 'course' )  ) {
+			return;
+		}
+
+		// Get the meta info
+		$course_video_embed = get_post_meta( $post->ID, '_course_video_embed', true );
+
+		if ( '' != $course_video_embed ) {
+			printf(
+				'<div class="course-video">%s</div>',
+				/** This filter is already documented in core. wp-includes/post-template.php */
+				apply_filters( 'the_content', $course_video_embed )
+			);
+		}
 	}
-
-        // Get the meta info
-        $course_video_embed = get_post_meta( $post->ID, '_course_video_embed', true );
-
-	if ( '' != $course_video_embed ) {
-		printf(
-			'<div class="course-video">%s</div>',
-			/** This filter is already documented in core. wp-includes/post-template.php */
-			apply_filters( 'the_content', $course_video_embed )
-		);
-	}
-    }
 
     /**
      * Output the title for the single lesson page

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -890,14 +890,15 @@ class Sensei_Frontend {
 	public function sensei_lesson_video( $post_id = 0 ) {
 		if ( 0 < intval( $post_id ) && sensei_can_user_view_lesson( $post_id ) ) {
 			$lesson_video_embed = get_post_meta( $post_id, '_lesson_video_embed', true );
-			if ( 'http' == substr( $lesson_video_embed, 0, 4) ) {
-        		// V2 - make width and height a setting for video embed
-        		$lesson_video_embed = wp_oembed_get( esc_url( $lesson_video_embed )/*, array( 'width' => 100 , 'height' => 100)*/ );
-        	} // End If Statement
-        	if ( '' != $lesson_video_embed ) {
-        	?><div class="video"><?php echo wp_kses( do_shortcode( html_entity_decode( $lesson_video_embed ) ), $this->allowed_html ); ?></div><?php
-        	} // End If Statement
-        } // End If Statement
+
+	        	if ( '' != $lesson_video_embed ) {
+				printf(
+					'<div class="video">%s</div>',
+					/** This filter is already documented in core. wp-includes/post-template.php */
+					apply_filters( 'the_content', $lesson_video_embed )
+				);
+			}
+	        } // End If Statement
 	} // End sensei_lesson_video()
 
 	public function sensei_complete_lesson_button() {

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -891,14 +891,15 @@ class Sensei_Frontend {
 		if ( 0 < intval( $post_id ) && sensei_can_user_view_lesson( $post_id ) ) {
 			$lesson_video_embed = get_post_meta( $post_id, '_lesson_video_embed', true );
 
-	        	if ( '' != $lesson_video_embed ) {
+			if ( '' != $lesson_video_embed ) {
 				printf(
 					'<div class="video">%s</div>',
 					/** This filter is already documented in core. wp-includes/post-template.php */
 					apply_filters( 'the_content', $lesson_video_embed )
 				);
 			}
-	        } // End If Statement
+
+		} // End If Statement
 	} // End sensei_lesson_video()
 
 	public function sensei_complete_lesson_button() {


### PR DESCRIPTION
Fixes #1560

- Passing all video content through the `the_content` filter allows us to process any shortcodes that may have been used when entering the video embed code in the lesson editor.

The use of `wp_kses` to sanitize `_course_video_embed` and `_lesson_video_embed` is still a problem, though. Plugins like Jetpack hook into `pre_kses` to transform iFrames into shortcodes. As a result, consider the following scenario:

1. Enable Jetpack and its Shortcode Embeds module.
2. Go to Lessons, and edit a lesson.
3. Paste a Vimeo iFrame embed code, like `<iframe src="https://player.vimeo.com/video/98084869" width="640" height="360" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>`
4. Save your lesson.
5. The iFrame code is transformed into a `[vimeo]` shortcode.
6. With the patch attached to this PR, the shortcode will be processed, so it's all good.
7. Now, a few months later, deactivate Jetpack.
8. All your lesson videos will stop working, because you don't have a plugin to process those shortcodes anymore. If the iFrame embed code had stayed an iFrame, you wouldn't have that issue.

Maybe instead of just patching the bug as I've done here, we should refactor the way we sanitize that video content in the first place? 