### PR TITLE
Load template functions on `after_setup_theme`

### DIFF
--- a/woothemes-sensei.php
+++ b/woothemes-sensei.php
@@ -34,9 +34,16 @@ Domain path: /lang/
     require_once( 'includes/lib/woo-functions.php' );
     require_once( 'includes/sensei-functions.php' );
 
-    if ( ! is_admin() ) {
+    /**
+     * Load Sensei Template Functions
+     *
+     * @since 1.9.8
+     */
+    function sensei_load_template_functions() {
         require_once( 'includes/template-functions.php' );
     }
+
+    add_action( 'after_setup_theme', 'sensei_load_template_functions' );
 
     /**
      * Returns the global Sensei Instance.


### PR DESCRIPTION
Not loading the template functions when is_admin is true, breaks the functionality of certain plugins like ElasticPress. 

This commit addresses this by hooking into `after_setup_theme`, like [woocommerce](https://github.com/woocommerce/woocommerce/blob/master/woocommerce.php#L166). 