### PR TITLE
Allow link html on Sensei notices refs #1574

### DIFF
--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -49,6 +49,10 @@ class Sensei_Notices{
 				'height' => array(),
 				'src'    => array(),
 			),
+			'a' => array(
+				'href'  => array(),
+				'title' => array()
+			)
 		);
 	}
 


### PR DESCRIPTION
Allow link (`a`) tags for Sensei notices