### PR TITLE
Fix file names for coding standards

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -370,7 +370,7 @@ class Sensei_Question {
 
 	/**
 	 * Given a question ID, return the grade that can be achieved.
-	 * 
+	 *
 	 * @since 1.9
 	 *
 	 * @param int $question_id
@@ -411,8 +411,13 @@ class Sensei_Question {
      * @param $question_type
      */
     public static function load_question_template( $question_type ){
+		$template_loaded = Sensei_Templates::get_template( 'single-quiz/question_type-' . $question_type . '.php' );
 
-        Sensei_Templates::get_template  ( 'single-quiz/question_type-' . $question_type . '.php' );
+		if ( ! $template_loaded ) {
+			Sensei_Templates::get_template( 'single-quiz/question-type-' . $question_type . '.php' );
+		} else {
+			_deprecated_file( 'question_type-' . $question_type . '.php', '1.9.8', 'question-type-' . $question_type . '.php' );
+		}
     }
 
     /**
@@ -631,7 +636,7 @@ class Sensei_Question {
          * Allow dynamic overriding of whether to show question answers or not
          *
          * @since 1.9.7
-         * 
+         *
          * @param boolean $show_answers
          * @param integer $question_id
          * @param integer $quiz_id

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -828,7 +828,7 @@ class Sensei_Teacher {
         }
 
         // load the email class
-        include('emails/class-sensei-email-teacher-new-course-assignment.php');
+        include( __DIR__ . '/emails/class-sensei-email-teacher-new-course-assignment.php' );
         $email = new Sensei_Email_Teacher_New_Course_Assignment();
         $email->trigger( $teacher_id, $course_id );
 

--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -75,7 +75,7 @@ class Sensei_Templates {
 
         $located = self::locate_template( $template_name, $template_path, $default_path );
 
-        if( ! empty( $located ) ){
+        if( ! empty( $located ) ) {
 
             do_action( 'sensei_before_template_part', $template_name, $template_path, $located );
 
@@ -83,7 +83,10 @@ class Sensei_Templates {
 
             do_action( 'sensei_after_template_part', $template_name, $template_path, $located );
 
+			return true;
         }
+
+		return false;
 
     } // end get template
 

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -135,7 +135,7 @@ class Sensei_Updates
 
                 foreach ($_POST['checked'] as $key => $function_name) {
 
-                    if( ! isset(  $_POST[ $function_name.'_nonce_field' ] ) 
+                    if( ! isset(  $_POST[ $function_name.'_nonce_field' ] )
                         || ! wp_verify_nonce( $_POST[ $function_name.'_nonce_field' ] , 'run_'.$function_name ) ){
 
                         wp_die(
@@ -1854,7 +1854,7 @@ class Sensei_Updates
      */
     public  function enhance_teacher_role ( ) {
 
-        require_once('class-sensei-teacher.php');
+        require_once( __DIR__ . '/class-sensei-teacher.php' );
         $teacher = new Sensei_Teacher();
         $teacher->create_role();
         return true;

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -753,7 +753,7 @@ class Sensei_Main {
      */
     public function load_class ( $class_name = '' ) {
         if ( '' != $class_name && '' != $this->token ) {
-            require_once( 'class-' . esc_attr( $this->token ) . '-' . esc_attr( $class_name ) . '.php' );
+            require_once( __DIR__ . '/class-' . esc_attr( $this->token ) . '-' . esc_attr( $class_name ) . '.php' );
         } // End If Statement
     } // End load_class()
 
@@ -889,7 +889,7 @@ class Sensei_Main {
             add_filter( 'sensei_answer_text', 'latex_markup' );
         }
     }
-    
+
 	/**
 	 * Checks that the WP QuickLaTeX plugin has been activated to support LaTeX within question titles and answers
 	 *
@@ -917,7 +917,7 @@ class Sensei_Main {
             &&  'Sensei_Modules' != get_class( $sensei_modules ) ) {
 
             //Load the modules class
-            require_once( 'class-sensei-modules.php');
+            require_once( __DIR__ . '/class-sensei-modules.php');
             Sensei()->modules = new Sensei_Core_Modules( $this->file );
 
         }else{
@@ -1168,7 +1168,7 @@ class Sensei_Main {
                 $custom_actions['support'] = sprintf( '<a href="%s" target="_blank">%s</a>', $this->get_support_url(), esc_html_x( 'Support', 'noun', 'woothemes-sensei' ) );
             }
 
-            // add the links to the front of the actions list   
+            // add the links to the front of the actions list
             return array_merge( $custom_actions, $actions );
         }
 
@@ -1236,7 +1236,7 @@ class Sensei_Main {
 
         /**
          * Returns the admin configuration url for the admin general configuration page
-         * 
+         *
          * @return string admin configuration url for the admin general configuration page
          */
         public function get_general_configuration_url() {

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -78,7 +78,13 @@ if ( ! defined( 'ABSPATH' ) ){ exit; } // Exit if accessed directly
 	  */
 	 function quiz_question_type( $question_type = 'multiple-choice' ) {
 
-         Sensei_Templates::get_template( 'single-quiz/question_type-' . $question_type . '.php' );
+		$template_loaded = Sensei_Templates::get_template( 'single-quiz/question_type-' . $question_type . '.php' );
+
+		if ( ! $template_loaded ) {
+			Sensei_Templates::get_template( 'single-quiz/question-type-' . $question_type . '.php' );
+		} else {
+			_deprecated_file( 'question_type-' . $question_type . '.php', '1.9.8', 'question-type-' . $question_type . '.php' );
+		}
 
 	 } // End lesson_single_meta()
 

--- a/includes/theme-integrations/theme-integration-loader.php
+++ b/includes/theme-integrations/theme-integration-loader.php
@@ -95,7 +95,7 @@ class Sensei_Theme_Integration_Loader {
                 return;
             }
             include_once( $supported_theme_class_file );
-            include_once( 'twentytwelve.php' );
+            include_once( __DIR__ . '/twentytwelve.php' );
             //initialize the class or exit if there is no class for this theme
             if( ! class_exists( $supported_theme_class_name ) ){
                 return;

--- a/templates/single-quiz/question-type-boolean.php
+++ b/templates/single-quiz/question-type-boolean.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * The Template for displaying True/False ( Boolean ) Question type.
  *
+ * Override this template by copying it to yourtheme/sensei/single-quiz/question-type-boolean.php
+ *
  * @author 		Automattic
  * @package 	Sensei
  * @category    Templates

--- a/templates/single-quiz/question-type-file-upload.php
+++ b/templates/single-quiz/question-type-file-upload.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * The Template for displaying File Upload Questions.
  *
- * Override this template by copying it to yourtheme/sensei/single-quiz/question_type-file-upload.php
+ * Override this template by copying it to yourtheme/sensei/single-quiz/question-type-file-upload.php
  *
  * @author 		Automattic
  * @package 	Sensei

--- a/templates/single-quiz/question-type-gap-fill.php
+++ b/templates/single-quiz/question-type-gap-fill.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * The Template for displaying Gap Fill Line Questions.
  *
- * Override this template by copying it to yourtheme/sensei/single-quiz/question_type-gap-fill.php
+ * Override this template by copying it to yourtheme/sensei/single-quiz/question-type-gap-fill.php
  *
  * @author 		Automattic
  * @package 	Sensei

--- a/templates/single-quiz/question-type-multi-line.php
+++ b/templates/single-quiz/question-type-multi-line.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * The Template for displaying Multi Line Questions.
  *
- * Override this template by copying it to yourtheme/sensei/single-quiz/question_type-multi-line.php
+ * Override this template by copying it to yourtheme/sensei/single-quiz/question-type-multi-line.php
  *
  * @author 		Automattic
  * @package 	Sensei
@@ -29,5 +29,3 @@ if ( ! defined( 'ABSPATH' ) ) exit;
                                                 'sensei_question[' . $question_data[ 'ID' ] . ']' );
 
 ?>
-
-

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -3,6 +3,8 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * The Template for displaying Multiple Choice Questions.
  *
+ * Override this template by copying it to yourtheme/sensei/single-quiz/question-type-multiple-choice.php
+ *
  * @author 		Automattic
  * @package 	Sensei
  * @category    Templates
@@ -48,6 +50,3 @@ foreach( $question_data[ 'answer_options' ] as $id => $option ) {
 <?php } // End For Loop ?>
 
 </ul>
-
-
-

--- a/templates/single-quiz/question-type-single-line.php
+++ b/templates/single-quiz/question-type-single-line.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
 /**
  * The Template for displaying Single Line Questions.
  *
- * Override this template by copying it to yourtheme/sensei/single-quiz/question_type-single-line.php
+ * Override this template by copying it to yourtheme/sensei/single-quiz/question-type-single-line.php
  *
  * @author 		Automattic
  * @package 	Sensei

--- a/woothemes-sensei.php
+++ b/woothemes-sensei.php
@@ -28,6 +28,7 @@ Domain path: /lang/
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+<<<<<<< HEAD
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 require_once( __DIR__ . '/includes/class-sensei-autoloader.php' );
@@ -69,11 +70,9 @@ add_action( 'init', array( 'Sensei_WC', 'load_woocommerce_integration_hooks' ) )
 
 /**
  * Load all Template hooks
-*/
+ */
 if ( ! is_admin() ) {
-
 	require_once( __DIR__ . '/includes/hooks/template.php' );
-
 }
 
 /**

--- a/woothemes-sensei.php
+++ b/woothemes-sensei.php
@@ -27,9 +27,10 @@ Domain path: /lang/
 	along with this program; if not, write to the Free Software
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
-
-<<<<<<< HEAD
-if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+*
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 require_once( __DIR__ . '/includes/class-sensei-autoloader.php' );
 require_once( __DIR__ . '/includes/lib/woo-functions.php' );

--- a/woothemes-sensei.php
+++ b/woothemes-sensei.php
@@ -14,101 +14,100 @@ Domain path: /lang/
 */
 /*  Copyright 2013  WooThemes  (email : info@woothemes.com)
 
-    This program is free software; you can redistribute it and/or modify
-    it under the terms of the GNU General Public License, version 2, as
-    published by the Free Software Foundation.
+	This program is free software; you can redistribute it and/or modify
+	it under the terms of the GNU General Public License, version 2, as
+	published by the Free Software Foundation.
 
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
+	This program is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	GNU General Public License for more details.
 
-    You should have received a copy of the GNU General Public License
-    along with this program; if not, write to the Free Software
-    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+	You should have received a copy of the GNU General Public License
+	along with this program; if not, write to the Free Software
+	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-	if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
+if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
-    require_once( 'includes/class-sensei-autoloader.php' );
-    require_once( 'includes/lib/woo-functions.php' );
-    require_once( 'includes/sensei-functions.php' );
+require_once( __DIR__ . '/includes/class-sensei-autoloader.php' );
+require_once( __DIR__ . '/includes/lib/woo-functions.php' );
+require_once( __DIR__ . '/includes/sensei-functions.php' );
 
-    /**
-     * Load Sensei Template Functions
-     *
-     * @since 1.9.8
-     */
-    function sensei_load_template_functions() {
-        require_once( 'includes/template-functions.php' );
-    }
+/**
+ * Load Sensei Template Functions
+ *
+ * @since 1.9.8
+ */
+function sensei_load_template_functions() {
+	if ( ! is_admin() ) {
+		require_once( __DIR__ . '/includes/template-functions.php' );
+	}
+}
+add_action( 'after_setup_theme', 'sensei_load_template_functions' );
 
-    add_action( 'after_setup_theme', 'sensei_load_template_functions' );
+/**
+ * Returns the global Sensei Instance.
+ *
+ * @since 1.8.0
+ */
+function Sensei(){
+	return Sensei_Main::instance();
+}
 
-    /**
-     * Returns the global Sensei Instance.
-     *
-     * @since 1.8.0
-     */
-    function Sensei(){
+// set the sensei version number
+Sensei()->version = '1.9.7';
 
-        return Sensei_Main::instance();
+//backwards compatibility
+global $woothemes_sensei;
+$woothemes_sensei = Sensei();
 
-    }
+/**
+* Hook in WooCommerce functionality
+*/
+add_action( 'init', array( 'Sensei_WC', 'load_woocommerce_integration_hooks' ) );
 
-	// set the sensei version number
-    Sensei()->version = '1.9.7';
+/**
+ * Load all Template hooks
+*/
+if ( ! is_admin() ) {
 
-    //backwards compatibility
-    global $woothemes_sensei;
-    $woothemes_sensei = Sensei();
+	require_once( __DIR__ . '/includes/hooks/template.php' );
 
-    /**
-    * Hook in WooCommerce functionality
-    */
-	add_action('init', array( 'Sensei_WC', 'load_woocommerce_integration_hooks' ) );
+}
 
-    /**
-     * Load all Template hooks
-    */
-    if(! is_admin() ){
+/**
+ * Plugin updates
+ * @since  1.0.1
+ */
+woothemes_queue_update( plugin_basename( __FILE__ ), 'bad2a02a063555b7e2bee59924690763', 152116 );
 
-        require_once( 'includes/hooks/template.php' );
+/**
+ * Sensei Activation Hook registration
+ * @since 1.8.0
+ */
+register_activation_hook( __FILE__, 'activate_sensei' );
 
-    }
+/**
+ * Activate_sensei
+ *
+ * All the activation checks needed to ensure Sensei is ready for use
+ * @since 1.8.0
+ */
+function activate_sensei() {
 
-    /**
-     * Plugin updates
-     * @since  1.0.1
-     */
-    woothemes_queue_update( plugin_basename( __FILE__ ), 'bad2a02a063555b7e2bee59924690763', 152116 );
+	// create the teacher role on activation and ensure that it has all the needed capabilities
+	Sensei()->teacher->create_role();
 
-    /**
-     * Sensei Activation Hook registration
-     * @since 1.8.0
-     */
-    register_activation_hook( __FILE__, 'activate_sensei' );
+	//Setup all the role capabilities needed
+	Sensei()->updates->add_sensei_caps();
+	Sensei()->updates->add_editor_caps();
+	Sensei()->updates->assign_role_caps();
 
-    /**
-     * Activate_sensei
-     *
-     * All the activation checks needed to ensure Sensei is ready for use
-     * @since 1.8.0
-     */
-    function activate_sensei () {
+	//Flush rules
+	add_action( 'activated_plugin' , array( 'Sensei_Main','activation_flush_rules' ), 10 );
 
-        // create the teacher role on activation and ensure that it has all the needed capabilities
-        Sensei()->teacher->create_role();
+	//Load the Welcome Screen
+	add_action( 'activated_plugin' , array( 'Sensei_Welcome','redirect' ), 20 );
 
-        //Setup all the role capabilities needed
-        Sensei()->updates->add_sensei_caps();
-        Sensei()->updates->add_editor_caps();
-        Sensei()->updates->assign_role_caps();
-
-        //Flush rules
-        add_action( 'activated_plugin' , array( 'Sensei_Main','activation_flush_rules' ), 10 );
-
-        //Load the Welcome Screen
-        add_action( 'activated_plugin' , array( 'Sensei_Welcome','redirect' ), 20 );
-
-    }// end activate_sensei
+}

--- a/woothemes-sensei.php
+++ b/woothemes-sensei.php
@@ -27,7 +27,6 @@ Domain path: /lang/
 	along with this program; if not, write to the Free Software
 	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
-*
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }


### PR DESCRIPTION
Changing some files names for coding standards and adding `__DIR__` for includes/required.

Also load old templates in case they are still used, but raise a deprecated file error message.
