### PR TITLE
If the reset quiz options is disabled, only show the "Complete/Save Q…

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -1757,7 +1757,7 @@ class Sensei_Lesson {
 			),
 			array(
 				'id' 			=> 'enable_quiz_reset',
-				'label'			=> esc_html__( 'Allow user to retake the quiz once completed', 'woothemes-sensei' ),
+				'label'			=> esc_html__( 'Allow user to retake the quiz', 'woothemes-sensei' ),
 				'description'	=> esc_html__( 'Enables the quiz reset button.', 'woothemes-sensei' ),
 				'type'			=> 'checkbox',
 				'default'		=> '',

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -1757,7 +1757,7 @@ class Sensei_Lesson {
 			),
 			array(
 				'id' 			=> 'enable_quiz_reset',
-				'label'			=> esc_html__( 'Allow user to retake the quiz', 'woothemes-sensei' ),
+				'label'			=> esc_html__( 'Allow user to retake the quiz once completed', 'woothemes-sensei' ),
 				'description'	=> esc_html__( 'Enables the quiz reset button.', 'woothemes-sensei' ),
 				'type'			=> 'checkbox',
 				'default'		=> '',

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1292,7 +1292,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
                     value="<?php echo esc_attr(  wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
              <!--#end Action Nonce's -->
 
-             <?php if ( '' == $user_quiz_grade) { ?>
+             <?php if ( '' == $user_quiz_grade && 'ungraded' !== $user_lesson_status->comment_approved ) { ?>
 
                  <span><input type="submit" name="quiz_complete" class="quiz-submit complete" value="<?php  _e( 'Complete Quiz', 'woothemes-sensei' ); ?>"/></span>
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1292,7 +1292,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
                     value="<?php echo esc_attr(  wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
              <!--#end Action Nonce's -->
 
-             <?php if ( '' == $user_quiz_grade && 'ungraded' !== $user_lesson_status->comment_approved ) { ?>
+             <?php if ( '' == $user_quiz_grade && ( ! $user_lesson_status || 'ungraded' !== $user_lesson_status->comment_approved ) ) { ?>
 
                  <span><input type="submit" name="quiz_complete" class="quiz-submit complete" value="<?php  _e( 'Complete Quiz', 'woothemes-sensei' ); ?>"/></span>
 


### PR DESCRIPTION
…uiz" buttons when the quiz is ungraded (i.e. already submitted for grading). This fixes https://github.com/Automattic/sensei/issues/1538.

Here's the behaviour after the patch:
- Case no reset allowed:
  <img width="708" alt="screen shot 2016-10-22 at 18 05 12" src="https://cloud.githubusercontent.com/assets/1620929/19620641/3800c02c-9882-11e6-93e8-7c1d18cbb0d8.png">
  Quiz not taken, buttons Complete/Save should appear.
  <img width="430" alt="screen shot 2016-10-22 at 18 04 51" src="https://cloud.githubusercontent.com/assets/1620929/19620640/3800b528-9882-11e6-9042-31d07afdb4c8.png">
  Quiz taken, no buttons should appear.
  <img width="533" alt="screen shot 2016-10-22 at 18 05 05" src="https://cloud.githubusercontent.com/assets/1620929/19620639/37ff6a60-9882-11e6-8c58-21b03e2311a8.png">
- Case reset allowed:
  <img width="704" alt="screen shot 2016-10-22 at 18 05 43" src="https://cloud.githubusercontent.com/assets/1620929/19620644/3806181a-9882-11e6-9a99-5894881e38a7.png">
  Quiz not taken, buttons Complete/Save should appear, but also the Reset button (per settings).
  <img width="423" alt="screen shot 2016-10-22 at 18 05 30" src="https://cloud.githubusercontent.com/assets/1620929/19620643/3804d306-9882-11e6-95f4-aa7c180fa937.png">
  Quiz taken, only the Reset button should appear (per settings).
  <img width="542" alt="screen shot 2016-10-22 at 18 05 23" src="https://cloud.githubusercontent.com/assets/1620929/19620642/3802a356-9882-11e6-9ae4-f412f61e0111.png">
