### PR TITLE
Only show the lessons title when there are actually lessons defined.

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2645,8 +2645,8 @@ class Sensei_Course {
         // title should be Other Lessons if there are lessons belonging to models.
         $title = __('Other Lessons', 'woothemes-sensei');
 
-        // show lessons if the number of lesson in the course is the same as those that isn't assigned to a module
-        if( count( $course_lessons ) == count( $none_module_lessons )  ){
+        // show header if there are lessons the number of lesson in the course is the same as those that isn't assigned to a module
+        if ( ! empty( $course_lessons ) && count( $course_lessons ) == count( $none_module_lessons ) ) {
 
             $title = __('Lessons', 'woothemes-sensei');
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/1463.

When there are no lessons:
<img width="409" alt="screen shot 2016-10-24 at 15 04 04" src="https://cloud.githubusercontent.com/assets/1620929/19646746/30476708-99fb-11e6-9820-59f08a8ff851.png">

When there are lessons:
<img width="405" alt="screen shot 2016-10-24 at 15 04 29" src="https://cloud.githubusercontent.com/assets/1620929/19646747/3048e740-99fb-11e6-8d2b-c3801254e121.png">
