### PR TITLE
Show course prerequisite message in case there is such.

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3076,13 +3076,22 @@ class Sensei_Course {
         $course_prerequisite_id = get_post_meta( $course_id, '_course_prerequisite', true );
 
         // if it has a pre requisite course check it
+		$prerequisite_complete = true;
+
         if( ! empty(  $course_prerequisite_id ) ){
 
-            return Sensei_Utils::user_completed_course( $course_prerequisite_id, get_current_user_id() );
+			$prerequisite_complete = Sensei_Utils::user_completed_course( $course_prerequisite_id, get_current_user_id() );
 
         }
 
-        return true;
+		/**
+		 * Filter course prerequisite complete
+		 *
+		 * @since 1.9.10
+		 * @param bool $prerequisite_complete
+		 * @param int $course_id
+		 */
+        return apply_filters( 'sensei_course_is_prerequisite_complete', $prerequisite_complete, $course_id );
 
     }// end is_prerequisite_complete
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3167,6 +3167,26 @@ class Sensei_Course {
 		return $page_on_front == $page_id;
 	}
 
+	/**
+	 * Show a message telling the user to complete the previous course if they haven't done so yet
+	 *
+	 * @since 1.9.10
+	 */
+	public static function prerequisite_complete_message() {
+		if ( ! self::is_prerequisite_complete( get_the_ID(), get_current_user_id() ) ) {
+			$course_prerequisite_id = (int) get_post_meta( get_the_ID(), '_course_prerequisite', true );
+			$prerequisite_course_link = '<a href="' . esc_url( get_permalink( $course_prerequisite_id ) )
+				. '" title="'
+				. sprintf(
+					esc_attr__( 'You must first complete: %1$s', 'woothemes-sensei' ),
+					get_the_title( $course_prerequisite_id ) )
+				 . '">' . get_the_title( $course_prerequisite_id ). '</a>';
+
+			Sensei()->notices->add_notice( sprintf(
+				esc_html__( 'You must first complete %1$s before viewing this course', 'woothemes-sensei' ),
+				$prerequisite_course_link ), 'info');
+		}
+	}
 
 }// End Class
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3174,13 +3174,14 @@ class Sensei_Course {
 	 */
 	public static function prerequisite_complete_message() {
 		if ( ! self::is_prerequisite_complete( get_the_ID(), get_current_user_id() ) ) {
-			$course_prerequisite_id = (int) get_post_meta( get_the_ID(), '_course_prerequisite', true );
+			$course_prerequisite_id = absint( get_post_meta( get_the_ID(), '_course_prerequisite', true ) );
+			$course_title = get_the_title( $course_prerequisite_id );
 			$prerequisite_course_link = '<a href="' . esc_url( get_permalink( $course_prerequisite_id ) )
 				. '" title="'
 				. sprintf(
 					esc_attr__( 'You must first complete: %1$s', 'woothemes-sensei' ),
-					get_the_title( $course_prerequisite_id ) )
-				 . '">' . get_the_title( $course_prerequisite_id ). '</a>';
+					$course_title )
+				 . '">' . $course_title . '</a>';
 
 			Sensei()->notices->add_notice( sprintf(
 				esc_html__( 'You must first complete %1$s before viewing this course', 'woothemes-sensei' ),

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3192,9 +3192,19 @@ class Sensei_Course {
 					$course_title )
 				 . '">' . $course_title . '</a>';
 
-			Sensei()->notices->add_notice( sprintf(
+			$complete_prerequisite_message = sprintf(
 				esc_html__( 'You must first complete %1$s before viewing this course', 'woothemes-sensei' ),
-				$prerequisite_course_link ), 'info');
+				$prerequisite_course_link );
+
+			/**
+			 * Filter sensei_course_complete_prerequisite_message.
+			 *
+			 * @since 1.9.10
+			 * @param string $complete_prerequisite_message the message to filter
+			 */
+			$filtered_message = apply_filters( 'sensei_course_complete_prerequisite_message', $complete_prerequisite_message );
+
+			Sensei()->notices->add_notice( $filtered_message, 'info' );
 		}
 	}
 

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -266,6 +266,10 @@ add_action( 'sensei_single_lesson_content_inside_after', array( 'Sensei_Template
 // hook in the lesson prerequisite completion message
 add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'prerequisite_complete_message' ), 20 );
 
+// @since 1.9.10
+// hook in the course prerequisite completion message
+add_action( 'sensei_single_course_content_inside_before', array( 'Sensei_Course', 'prerequisite_complete_message' ), 20 );
+
 // @since 1.9.0
 // hook the single lesson course_signup_link
 add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'course_signup_link' ), 30 );


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/1426.

After this PR, this is what we get for a course that has a prerequisite:
<img width="766" alt="screen shot 2016-10-25 at 01 43 27" src="https://cloud.githubusercontent.com/assets/1620929/19667960/78b05456-9a54-11e6-9e6d-aa02c072bf63.png">

While previously it was showing like this:
<img width="377" alt="screen shot 2016-10-25 at 01 43 59" src="https://cloud.githubusercontent.com/assets/1620929/19667965/858169c2-9a54-11e6-87c3-4214e9a04ee2.png">
