### PR TITLE
Lock down wp-admin access when editing post_type quiz.

### DIFF
--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -276,6 +276,9 @@ class Sensei_PostTypes {
             ),
 		    'map_meta_cap' => true,
 		    'capability_type' => 'quiz',
+			'capabilities' => array(
+				'edit_published_posts' => 'do_not_allow',
+			),
 		    'has_archive' => false,
 		    'hierarchical' => false,
 		    'menu_position' => 20, // Below "Pages"


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/1468.

Now when we try to edit any of the posts that have `post_type === 'quiz'`, we get this:
<img width="550" alt="screen shot 2016-10-30 at 02 34 25" src="https://cloud.githubusercontent.com/assets/1620929/19833868/73f7ded6-9e49-11e6-9841-06f2d5d34fe4.png">

Additionally, the list view is still working so that people can "debug" IDs and stuff, as proposed in one of the comments on the issue:
<img width="565" alt="screen shot 2016-10-30 at 02 34 08" src="https://cloud.githubusercontent.com/assets/1620929/19833870/8e2e37fa-9e49-11e6-97cf-fd0526406b54.png">
