### PR TITLE
Only consider published lessons when calculating completion percentages

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1457,12 +1457,13 @@ class Sensei_Utils {
 	}
 
 	/**
-	 * Checks if a user has completed a course by checking every lesson status
+	 * Checks if a user has completed a course by checking every lesson status,
+	 * and then updates the course metadata with that information.
 	 *
 	 * @since  1.7.0
 	 * @param  integer $course_id Course ID
 	 * @param  integer $user_id   User ID
-	 * @return int
+	 * @return mixed boolean or comment_ID
 	 */
 	public static function user_complete_course( $course_id = 0, $user_id = 0 ) {
 		global  $wp_version;
@@ -1483,7 +1484,7 @@ class Sensei_Utils {
 				);
 
 			// Grab all of this Courses' lessons, looping through each...
-			$lesson_ids = Sensei()->course->course_lessons( $course_id, 'any', 'ids' );
+			$lesson_ids = Sensei()->course->course_lessons( $course_id, 'publish', 'ids' );
 			$total_lessons = count( $lesson_ids );
 				// ...if course completion not set to 'passed', and all lessons are complete or graded,
 				// ......then all lessons are 'passed'


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/1621.

Test case:
1. Create a course.
2. Navigate to the course overview (e.g. http://localhost/wordpress/course/test-course/), and take the course.
Expected = Actual: <img width="765" alt="screen shot 2016-11-05 at 20 18 51" src="https://cloud.githubusercontent.com/assets/1620929/20032927/181d65b2-a395-11e6-9e1a-ad06c5a57c9d.png">
3. Add a draft lesson to the course.
4. Add a published lesson with a quiz to the course.
5. Complete the quiz created in previous step.
6. Navigate to the course overview (e.g. http://localhost/wordpress/course/test-course/)
Expected: <img width="768" alt="screen shot 2016-11-05 at 20 17 51" src="https://cloud.githubusercontent.com/assets/1620929/20032930/2637833a-a395-11e6-9aaa-a122b3bd0b32.png">
Actual: <img width="764" alt="screen shot 2016-11-05 at 20 18 27" src="https://cloud.githubusercontent.com/assets/1620929/20032933/301d5a1e-a395-11e6-9617-2eed51cc3261.png">