### PR TITLE
Add the option to disable HTML security for Video embeds (Course/Lesson)

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -377,12 +377,16 @@ class Sensei_Course {
 		global $post;
 
 		$course_video_embed = get_post_meta( $post->ID, '_course_video_embed', true );
+		$course_video_embed = Sensei_Wp_Kses::maybe_sanitize( $course_video_embed, self::$allowed_html );
 
 		$html = '';
 
 		$html .= '<label class="screen-reader-text" for="course_video_embed">' . __( 'Video Embed Code', 'woothemes-sensei' ) . '</label>';
-		$html .= '<textarea rows="5" cols="50" name="course_video_embed" tabindex="6" id="course-video-embed">' . Sensei_Wp_Kses::wp_kses( $course_video_embed, self::$allowed_html ) . '</textarea>';
-		$html .= '<p>' .  __( 'Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above.', 'woothemes-sensei' ) . '</p>';
+		$html .= '<textarea rows="5" cols="50" name="course_video_embed" tabindex="6" id="course-video-embed">';
+
+		$html .= $course_video_embed . '</textarea><p>';
+
+		$html .= __( 'Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above.', 'woothemes-sensei' ) . '</p>';
 
 		echo $html;
 
@@ -447,8 +451,9 @@ class Sensei_Course {
 		// Get the meta key.
 		$meta_key = '_' . $post_key;
 		// Get the posted data and sanitize it for use as an HTML class.
-		if ( 'course_video_embed' == $post_key) {
-			$new_meta_value = wp_kses( $_POST[$post_key], self::$allowed_html );
+		if ( 'course_video_embed' == $post_key ) {
+			$new_meta_value = ( isset( $_POST[ $post_key ] ) ) ? $_POST[ $post_key ] : '';
+			$new_meta_value = Sensei_Wp_Kses::maybe_sanitize( $new_meta_value, self::$allowed_html );
 		} else {
 			$new_meta_value = ( isset( $_POST[$post_key] ) ? sanitize_html_class( $_POST[$post_key] ) : '' );
 		} // End If Statement
@@ -2932,10 +2937,14 @@ class Sensei_Course {
 
         } // End If Statement
 
+	$course_video_embed = do_shortcode( $course_video_embed );
+
+	$course_video_embed = Sensei_Wp_Kses::maybe_sanitize( $course_video_embed, self::$allowed_html );
+
         if ( '' != $course_video_embed ) { ?>
 
             <div class="course-video">
-                <?php echo Sensei_Wp_Kses::wp_kses( do_shortcode( $course_video_embed ), self::$allowed_html ); ?>
+                <?php echo $course_video_embed; ?>
             </div>
 
         <?php } // End If Statement

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -889,8 +889,12 @@ class Sensei_Frontend {
         		// V2 - make width and height a setting for video embed
         		$lesson_video_embed = wp_oembed_get( esc_url( $lesson_video_embed ) );
         	} // End If Statement
+
+		$lesson_video_embed = do_shortcode( html_entity_decode( $lesson_video_embed ) );
+		$lesson_video_embed = Sensei_Wp_Kses::maybe_sanitize( $lesson_video_embed, $this->allowed_html );
+
         	if ( '' != $lesson_video_embed ) {
-				?><div class="video"><?php echo Sensei_Wp_Kses::wp_kses( do_shortcode( html_entity_decode( $lesson_video_embed ) ), $this->allowed_html ); ?></div><?php
+				?><div class="video"><?php echo $lesson_video_embed; ?></div><?php
         	} // End If Statement
         } // End If Statement
 	} // End sensei_lesson_video()

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -158,6 +158,8 @@ class Sensei_Lesson {
 		$complexity_array   = $this->lesson_complexities();
 		$lesson_video_embed = get_post_meta( $post->ID, '_lesson_video_embed', true );
 
+		$lesson_video_embed = Sensei_Wp_Kses::maybe_sanitize( $lesson_video_embed, $this->allowed_html );
+
 		$html = '';
 		// Lesson Length
 		$html .= '<p><label for="lesson_length">' . esc_html__( 'Lesson Length in minutes', 'woothemes-sensei' ) . ': </label>';
@@ -172,7 +174,10 @@ class Sensei_Lesson {
 		$html .= '</select></p>' . "\n";
 
 		$html .= '<p><label for="lesson_video_embed">' . esc_html__( 'Video Embed Code', 'woothemes-sensei' ) . ':</label><br/>' . "\n";
-		$html .= '<textarea rows="5" cols="50" name="lesson_video_embed" tabindex="6" id="course-video-embed">' . Sensei_Wp_Kses::wp_kses( $lesson_video_embed, $this->allowed_html ) . '</textarea></p>' . "\n";
+		$html .= '<textarea rows="5" cols="50" name="lesson_video_embed" tabindex="6" id="course-video-embed">';
+
+		$html .= $lesson_video_embed . '</textarea></p>' . "\n";
+
 		$html .= '<p>' .  esc_html__( 'Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above.', 'woothemes-sensei' ) . '</p>';
 
 		echo $html;
@@ -500,7 +505,8 @@ class Sensei_Lesson {
 
 		// Get the posted data and sanitize it for use as an HTML class.
 		if ( 'lesson_video_embed' == $post_key) {
-			$new_meta_value = wp_kses( $_POST[ $post_key ], $this->allowed_html );
+			$new_meta_value = isset( $_POST[ $post_key ] ) ? $_POST[ $post_key ] : '';
+			$new_meta_value = Sensei_Wp_Kses::maybe_sanitize( $new_meta_value, $this->allowed_html );
 		} else {
 			$new_meta_value = ( isset( $_POST[$post_key] ) ? sanitize_html_class( $_POST[$post_key] ) : '' );
 		} // End If Statement

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -219,6 +219,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 								'section' => 'default-settings'
 								);
 
+		$fields['sensei_video_embed_html_sanitization_disable'] = array(
+								'name' => __( 'Disable HTML security', 'woothemes-sensei' ),
+								'description' => __( 'Allow all kind of HTML tags in Video Embed. Security Caution: Enabling this indicates a risk of XSS attacks!', 'woothemes-sensei' ),
+								'type' => 'checkbox',
+								'default' => false,
+								'section' => 'default-settings'
+								);
+
     	// Course Settings
 
     	$fields['course_completion'] = array(

--- a/includes/class-sensei-wp-kses.php
+++ b/includes/class-sensei-wp-kses.php
@@ -67,4 +67,18 @@ class Sensei_Wp_Kses {
             'width'    => array(),
         );
     }
+
+	/**
+	 * Will act as a sanitization or an identity function, depending on HTML security settings.
+	 *
+	 * @param string $content Content
+	 * @param array $allowed_html
+	 * @return string Content
+	 */
+	public static function maybe_sanitize( $content, $allowed_html )
+	{
+		$html_security = ! Sensei()->settings->get( 'sensei_video_embed_html_sanitization_disable' );
+
+		return $html_security ? self::wp_kses( $content, $allowed_html ) : $content;
+	}
 }


### PR DESCRIPTION
Addresses several issues: https://github.com/Automattic/sensei/issues/1625, https://github.com/Automattic/sensei/issues/1613.

**Test case 1:**
1. Go to Sensei > Settings > General and check `Disable HTML security` <img width="971" alt="screen shot 2016-11-08 at 15 36 01" src="https://cloud.githubusercontent.com/assets/1620929/20103158/1b765cd8-a5c9-11e6-9968-a26ceaed5c64.png">
2. Create a new course and use the following code for video embed: `<script>alert("Hello!");</script>`
Expected: After Save, the code in the video embed should remain. <img width="233" alt="screen shot 2016-11-08 at 15 39 23" src="https://cloud.githubusercontent.com/assets/1620929/20103249/8c5b25be-a5c9-11e6-885a-dba92423a911.png">
3. View the course
Expected: You should get a javascript alert
<img width="428" alt="screen shot 2016-11-08 at 15 40 08" src="https://cloud.githubusercontent.com/assets/1620929/20103295/a8c548c4-a5c9-11e6-840a-bf62473f5490.png">

**Test case 2:**
1. Go to Sensei > Settings > General and uncheck `Disable HTML security` <img width="965" alt="screen shot 2016-11-08 at 15 35 57" src="https://cloud.githubusercontent.com/assets/1620929/20103154/17b6fd14-a5c9-11e6-8056-1c934682318b.png">
2. Create a new course and use the following code for video embed: `<script>alert("Hello!");</script>`
Expected: After Save, the code in the video embed should just say `alert("Hello!");`. <img width="242" alt="screen shot 2016-11-08 at 15 36 57" src="https://cloud.githubusercontent.com/assets/1620929/20103191/3cbfe526-a5c9-11e6-948a-12a5368b4f79.png">
3. View the course
Expected: It should read `alert("Hello!");` in the video embed place. You should not get a javascript alert. <img width="357" alt="screen shot 2016-11-08 at 15 38 26" src="https://cloud.githubusercontent.com/assets/1620929/20103224/6c6caad4-a5c9-11e6-913c-dbac332ba7d6.png">
Expected: For existing courses that already had the script tag within them, opening them through wp-admin or the frontend should not execute the script and the tag should be stripped.

Repeat test case 1 and test case 2 for lessons.