### PR TITLE
Update registration process

### DIFF
--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -167,6 +167,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 								'section' => 'default-settings'
 								);
 
+		$fields['auto_generate_password'] = array(
+								'name' => __( 'Registration process', 'woothemes-sensei' ),
+								'description' => __( 'Automatically generate passwords for users.', 'woothemes-sensei', 'woothemes-sensei' ),
+								'type' => 'checkbox',
+								'default' => false,
+								'section' => 'default-settings'
+								);
+
 		$fields['messages_disable'] = array(
 								'name' => __( 'Disable Private Messages', 'woothemes-sensei' ),
 								'description' => __( 'Disable the private message functions between learners and teachers.', 'woothemes-sensei' ),


### PR DESCRIPTION
Details are discussed in the issue https://github.com/Automattic/sensei/issues/1202, specifically [here](https://github.com/Automattic/sensei/issues/1202#issuecomment-260336554).

The current PR implements the following option: <img width="737" alt="screen shot 2016-11-14 at 15 02 46" src="https://cloud.githubusercontent.com/assets/1620929/20267520/75a85d08-aa7b-11e6-9bfd-6cac62f3598c.png">

If this option is enabled, the registration process does not show the Password editbox:
<img width="476" alt="screen shot 2016-11-14 at 15 04 04" src="https://cloud.githubusercontent.com/assets/1620929/20267566/9a7d65f6-aa7b-11e6-92cd-0c6015b99a3e.png">

If this option is disabled, the registration process shows the Password editbox as previously: <img width="478" alt="screen shot 2016-11-14 at 15 04 38" src="https://cloud.githubusercontent.com/assets/1620929/20267589/ade2c758-aa7b-11e6-998a-d917d6372d41.png">

In each case, after registering users will be automatically logged in and sent an e-mail containing their credentials.