### PR TITLE
Remove the page-attributes metabox from lesson because it is redundant.

### DIFF
--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -201,7 +201,7 @@ class Sensei_PostTypes {
 	 */
 	public function setup_lesson_post_type () {
 
-		$supports_array = array( 'title', 'editor', 'excerpt', 'thumbnail', 'page-attributes' );
+		$supports_array = array( 'title', 'editor', 'excerpt', 'thumbnail' );
 		$allow_comments = false;
 		if ( isset( Sensei()->settings->settings[ 'lesson_comments' ] ) ) {
 			$allow_comments = Sensei()->settings->settings[ 'lesson_comments' ];


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/1635.

Before PR:
<img width="290" alt="screen shot 2016-11-12 at 14 35 29" src="https://cloud.githubusercontent.com/assets/1620929/20238164/4f800c4e-a8e5-11e6-88f3-9bc72949f372.png">
After PR:
<img width="290" alt="screen shot 2016-11-12 at 14 35 43" src="https://cloud.githubusercontent.com/assets/1620929/20238165/4faa353c-a8e5-11e6-99c3-45c04e44f563.png">

I also tried creating a course with 2 lessons and switched their order through Lessons > Order Lessons, but this had no effect on the Order of the Attributes metabox in the edit screen.

Additionally I traced it back on Git and it seems it was there since the beginning.