### PR TITLE
Add password strength when registering.

### DIFF
--- a/assets/js/password-strength-meter.js
+++ b/assets/js/password-strength-meter.js
@@ -1,0 +1,64 @@
+function checkPasswordStrength( $pwd, $strengthStatus, $submitBtn ) {
+    var pwd = $pwd.val();
+
+    // every time a letter is typed, reset the submit button and the strength meter status
+    // disable the submit button
+    $submitBtn.attr( 'disabled', 'disabled' );
+    $strengthStatus.removeClass( 'short bad good strong empty' );
+
+    if (pwd === '') {
+        $strengthStatus.addClass( 'empty' ).html( pwsL10n.empty );
+        return;
+    }
+
+    // calculate the password strength
+    var pwdStrength = wp.passwordStrength.meter( pwd, wp.passwordStrength.userInputBlacklist() );
+
+    // check the password strength
+    switch ( pwdStrength ) {
+
+        case 2:
+            $strengthStatus.addClass( 'bad' ).html( pwsL10n.bad );
+            break;
+
+        case 3:
+            $strengthStatus.addClass( 'good' ).html( pwsL10n.good );
+            break;
+
+        case 4:
+            $strengthStatus.addClass( 'strong' ).html( pwsL10n.strong );
+            $submitBtn.removeAttr( 'disabled' );
+            break;
+
+        case 5:
+            $strengthStatus.addClass( 'short' ).html( pwsL10n.mismatch );
+            break;
+
+        default:
+            $strengthStatus.addClass( 'short' ).html( pwsL10n.short );
+    }
+
+    return pwdStrength;
+}
+
+jQuery( document ).ready( function( $ ) {
+    var runCheck = function() {
+        if ( typeof window.zxcvbn !== 'function' ) {
+            setTimeout( runCheck, 50 );
+        } else {
+            return checkPasswordStrength(
+                $( 'input[name=sensei_reg_password]' ),
+                $( '#sensei_password_strength' ),
+                $( 'input[name=register]' )
+            );
+        }
+    };
+
+    // run the check initially to handle the empty password case
+    runCheck();
+
+    // trigger the checkPasswordStrength
+    $( 'body' ).on( 'keyup', 'input[name=sensei_reg_password]', function() {
+        runCheck();
+    });
+});

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -153,6 +153,17 @@ class Sensei_Frontend {
 
             }
 
+			wp_enqueue_script( 'password-strength-meter' );
+			wp_enqueue_script( 'sensei-password-strength-meter', Sensei()->plugin_url . 'assets/js/password-strength-meter.js', array( 'password-strength-meter' ), Sensei()->version );
+
+			wp_localize_script( 'sensei-password-strength-meter', 'pwsL10n', array(
+				'empty'    => __( 'Please enter a password', 'woothemes-sensei' ),
+				'short'    => __( 'Very weak', 'woothemes-sensei' ),
+				'bad'      => __( 'Weak', 'woothemes-sensei' ),
+				'good'     => __( 'Medium', 'woothemes-sensei' ),
+				'strong'   => __( 'Strong', 'woothemes-sensei' ),
+				'mismatch' => __( 'Mismatch', 'woothemes-sensei' )
+			) );
 
 			// Allow additional scripts to be loaded
 			do_action( 'sensei_additional_scripts' );
@@ -1107,6 +1118,8 @@ class Sensei_Frontend {
 						<p class="form-row form-row-wide">
 							<label for="sensei_reg_password"><?php _e( 'Password', 'woothemes-sensei' ); ?> <span class="required">*</span></label>
 							<input type="password" class="input-text" name="sensei_reg_password" id="sensei_reg_password" value="<?php if ( ! empty( $_POST['sensei_reg_password'] ) ) echo esc_attr( $_POST['sensei_reg_password'] ); ?>" />
+							<span id="sensei_password_strength"></span>
+							<p class="description indicator-hint"><?php echo wp_get_password_hint(); ?></p>
 						</p>
 
 						<!-- Spam Trap -->


### PR DESCRIPTION
Details are discussed in the issue https://github.com/Automattic/sensei/issues/1202, specifically [here](https://github.com/Automattic/sensei/issues/1202#issuecomment-260336554).

With these changes, here is how the registration form will look like:
<img width="773" alt="screen shot 2016-11-14 at 17 22 22" src="https://cloud.githubusercontent.com/assets/1620929/20272680/f9387c12-aa8e-11e6-9ad2-e9d9fc08a583.png">

When entering a password:
<img width="761" alt="screen shot 2016-11-14 at 17 22 27" src="https://cloud.githubusercontent.com/assets/1620929/20272689/001e25c2-aa8f-11e6-9899-96cf5a0bd42c.png">

When entering a password that is validated successfully:
<img width="761" alt="screen shot 2016-11-14 at 17 22 37" src="https://cloud.githubusercontent.com/assets/1620929/20272710/07f6116a-aa8f-11e6-8c07-e670d2464c81.png">