### PR TITLE
Fix grading count of lessons by querying lessons instead of quiz IDs.

### DIFF
--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -735,12 +735,7 @@ class Sensei_Teacher {
 
                 foreach(  $course_lessons as $lesson ){
 
-                    $quiz_id = Sensei()->lesson->lesson_quizzes( $lesson->ID );
-                    if( !empty( $quiz_id ) ) {
-
-                        array_push( $quiz_scope, $quiz_id );
-
-                    }
+                    array_push( $quiz_scope, $lesson->ID );
 
                 }
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/1641.

Test case:
1. Create a course with a lesson and a quiz using Teacher role.
2. With another user, start taking the course and finish the quiz.
3. With teacher role, go to Sensei > Grading.
Expected: In the top where there are counts, they should match the actual entries. For example, if 2 users were graded it should say "Graded (2)". <img width="396" alt="screen shot 2016-11-17 at 18 35 10" src="https://cloud.githubusercontent.com/assets/1620929/20400336/96acc3a6-acf4-11e6-8ee3-48751bde394b.png">
4. Repeat steps 3 with admin role, expectation results should be the same.