### PR TITLE
When a teacer saves a course, retain already assigned product

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -289,7 +289,9 @@ class Sensei_Course {
 				$html .= '</p>'."\n";
 
 			} else {
-
+				if ( !empty( $select_course_woocommerce_product ) ) {
+					$html .= '<input type="hidden" name="course_woocommerce_product" value="'. absint( $select_course_woocommerce_product ) . '">';
+				}
                 $html .= '<p>' . "\n";
 					$html .= esc_html( __( 'No products exist yet.', 'woothemes-sensei' ) ) . "\n";
 				$html .= '</p>'."\n";


### PR DESCRIPTION
Currently, teachers cannot assign products to courses.
Unfortunately, when teachers edit and save a course linked to a product, its
`course_woocommerce_product` meta is overwritten by the empty string.

This commit mitigates this by keeping the
product id in a hidden form field.

Closes #1493