### PR TITLE
Allow user to change question points text formatting 

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -131,11 +131,8 @@ class Sensei_Frontend {
 	 * @return void
 	 */
 	public function enqueue_scripts () {
+		$disable_js = Sensei_Utils::get_setting_as_flag( 'js_disable', 'sensei_settings_js_disable' );
 
-		$disable_js = false;
-		if ( isset( Sensei()->settings->settings[ 'js_disable' ] ) ) {
-			$disable_js = Sensei()->settings->settings[ 'js_disable' ];
-		} // End If Statement
 		if ( ! $disable_js ) {
 
 			$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
@@ -168,13 +165,7 @@ class Sensei_Frontend {
 	 */
 	public function enqueue_styles () {
 
-		$disable_styles = false;
-		if ( isset( Sensei()->settings->settings[ 'styles_disable' ] ) ) {
-			$disable_styles = Sensei()->settings->settings[ 'styles_disable' ];
-		} // End If Statement
-
-		// Add filter for theme overrides
-		$disable_styles = apply_filters( 'sensei_disable_styles', $disable_styles );
+		$disable_styles = Sensei_Utils::get_setting_as_flag( 'styles_disable', 'sensei_disable_styles' );
 
 		if ( ! $disable_styles ) {
 
@@ -1493,22 +1484,20 @@ class Sensei_Frontend {
 
 				$items = $order->get_items();
 				foreach( $items as $item ) {
-
-                    $product = wc_get_product( $item['product_id'] );
+					$product_id = Sensei_WC_Utils::get_item_id_from_item( $item );
+                    $product = wc_get_product( $product_id );
 
                     // handle product bundles
-                    if( is_object( $product ) &&  $product->is_type('bundle') ){
+                    if( is_object( $product ) &&  $product->is_type('bundle') ) {
 
-                        $bundled_product = new WC_Product_Bundle( $product->id );
+                        $bundled_product = new WC_Product_Bundle( Sensei_WC_Utils::get_product_id( $product ) );
                         $bundled_items = $bundled_product->get_bundled_items();
 
-                        foreach( $bundled_items as $bundled_item ){
-
+                        foreach ( $bundled_items as $bundled_item ) {
                             if( $bundled_item->product_id == $course_product_id ) {
                                 Sensei_Utils::user_start_course( $user_id, $course_id );
                                 return;
                             }
-
                         }
 
                     } else {

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -451,18 +451,13 @@ class Sensei_Question {
          * hook document in class-woothemes-sensei-message.php the_title()
          */
         $title = apply_filters( 'sensei_single_title', $title, 'question');
-		$styles_disabled = $disable_styles = Sensei_Utils::get_setting_as_flag( 'styles_disable', 'sensei_disable_styles' );
+		
 		$question_grade = Sensei()->question->get_question_grade( $question_id );
 
         $title_html  = '<span class="question question-title">';
         $title_html .= $title;
-		if ( false === $styles_disabled ) {
-			$title_html .= '<span class="grade">' . $question_grade . '</span>';
-			$title_html .='</span>';
-		} else {
-			$title_html .= ' [' . sprintf( esc_html__( 'Question Point Value: %s', 'woothemes-sensei' ), $question_grade ) . ']';
-		}
-
+		$title_html .= Sensei()->view_helper->format_question_points( $question_grade );
+		$title_html .='</span>';
 
         return $title_html;
     }

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -451,11 +451,18 @@ class Sensei_Question {
          * hook document in class-woothemes-sensei-message.php the_title()
          */
         $title = apply_filters( 'sensei_single_title', $title, 'question');
+		$styles_disabled = $disable_styles = Sensei_Utils::get_setting_as_flag( 'styles_disable', 'sensei_disable_styles' );
+		$question_grade = Sensei()->question->get_question_grade( $question_id );
 
         $title_html  = '<span class="question question-title">';
         $title_html .= $title;
-        $title_html .= '<span class="grade">' . Sensei()->question->get_question_grade( $question_id ) . '</span>';
-        $title_html .='</span>';
+		if ( false === $styles_disabled ) {
+			$title_html .= '<span class="grade">' . $question_grade . '</span>';
+			$title_html .='</span>';
+		} else {
+			$title_html .= ' (' . sprintf( esc_html__( 'Question Point Value: %s', 'woothemes-sensei' ), $question_grade ) . ')';
+		}
+
 
         return $title_html;
     }

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -460,7 +460,7 @@ class Sensei_Question {
 			$title_html .= '<span class="grade">' . $question_grade . '</span>';
 			$title_html .='</span>';
 		} else {
-			$title_html .= ' (' . sprintf( esc_html__( 'Question Point Value: %s', 'woothemes-sensei' ), $question_grade ) . ')';
+			$title_html .= ' [' . sprintf( esc_html__( 'Question Point Value: %s', 'woothemes-sensei' ), $question_grade ) . ']';
 		}
 
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -217,6 +217,13 @@ class Sensei_Settings extends Sensei_Settings_API {
 								'default' => false,
 								'section' => 'default-settings'
 								);
+		$fields['quiz_question_points_format'] = array(
+								'name' => __( 'Quiz question points format', 'woothemes-sensei' ),
+								'description' => __( 'Set the quiz question points format (be sure to include an `%s`)', 'woothemes-sensei' ),
+								'type' => 'text',
+								'default' => '[Points: %s]',
+								'section' => 'default-settings'
+								);
 
 		$fields['js_disable'] = array(
 								'name' => __( 'Disable Sensei Javascript', 'woothemes-sensei' ),

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2404,6 +2404,21 @@ class Sensei_Utils {
 		self::sensei_remove_user_from_course( $course_id, $user_id );
 		return self::user_start_course( $user_id, $course_id );
 	}
+
+	/**
+	 * @param $setting_name string
+	 * @param null|string $filter_to_apply
+	 * @return bool
+	 */
+	public static function get_setting_as_flag($setting_name, $filter_to_apply = null ) {
+		$setting_on = false;
+
+		if ( isset( Sensei()->settings->settings[ $setting_name ] ) ) {
+			$setting_on = (bool)Sensei()->settings->settings[ $setting_name ];
+		}
+
+		return ( null !== $filter_to_apply ) ? (bool)apply_filters($filter_to_apply, $setting_on) : $setting_on;
+	}
 } // End Class
 
 /**

--- a/includes/class-sensei-view-helper.php
+++ b/includes/class-sensei-view-helper.php
@@ -1,0 +1,25 @@
+<?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+
+/**
+ * View Formatting helper, all formatiing logic should be here
+ * Class Sensei_View_Helper
+ */
+class Sensei_View_Helper {
+    public function format_question_points( $points ) {
+        $styles_disabled = (bool)Sensei_Utils::get_setting_as_flag( 'styles_disable', 'sensei_disable_styles' );
+        $format = '[%s]';
+        if ( isset( Sensei()->settings->settings[ 'quiz_question_points_format' ] ) ) {
+            $maybe_format = Sensei()->settings->settings[ 'quiz_question_points_format' ];
+            if ( false !== strpos( $maybe_format, '%s' ) ) {
+                $format = esc_html__( $maybe_format );
+            }
+        }
+        $formatted_points = !empty( $format ) ? sprintf( $format, $points ) : $points;
+        return $styles_disabled ? $formatted_points : '<span class="grade">' . $formatted_points . '</span>';
+    }
+}

--- a/includes/class-sensei-view-helper.php
+++ b/includes/class-sensei-view-helper.php
@@ -11,7 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_View_Helper {
     public function format_question_points( $points ) {
-        $styles_disabled = (bool)Sensei_Utils::get_setting_as_flag( 'styles_disable', 'sensei_disable_styles' );
         $format = '[%s]';
         if ( isset( Sensei()->settings->settings[ 'quiz_question_points_format' ] ) ) {
             $maybe_format = Sensei()->settings->settings[ 'quiz_question_points_format' ];
@@ -20,6 +19,6 @@ class Sensei_View_Helper {
             }
         }
         $formatted_points = !empty( $format ) ? sprintf( $format, $points ) : $points;
-        return $styles_disabled ? $formatted_points : '<span class="grade">' . $formatted_points . '</span>';
+        return '<span class="grade">' . $formatted_points . '</span>';
     }
 }

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -155,6 +155,11 @@ class Sensei_Main {
     private $shortcode_loader;
 
     /**
+     * @var Sensei_View_Helper
+     */
+    public $view_helper;
+
+    /**
      * Constructor method.
      * @param  string $file The base file of the plugin.
      * @since  1.0.0
@@ -316,6 +321,8 @@ class Sensei_Main {
 
         // Load Learner Management Functionality
         $this->learners = new Sensei_Learner_Management( $this->main_plugin_file_name );
+
+        $this->view_helper = new Sensei_View_Helper();
 
         // Differentiate between administration and frontend logic.
         if ( is_admin() ) {
@@ -1334,4 +1341,5 @@ class Sensei_Main {
  * @ignore only for backward compatibility
  * @since 1.9.0
  */
-class Woothemes_Sensei extends Sensei_Main{ }
+class Woothemes_Sensei extends Sensei_Main {
+}


### PR DESCRIPTION
Add setting to change the question points formatting/wording. Falls back to `[]` if the string is not properly formatted (doesn't contain `%s`)

Frontend with styles enabled

![screen shot 2017-03-24 at 11 01 32](https://cloud.githubusercontent.com/assets/500744/24291572/68e9a7d6-1081-11e7-99db-69d14b373d62.png)

Setting

![screen shot 2017-03-24 at 11 01 12](https://cloud.githubusercontent.com/assets/500744/24291573/68f063e6-1081-11e7-9dd8-84cf188f38b5.png)


Closes #1456 #1727