### PR TITLE
Ignore orphaned product variations on course/lesson editor product dropdown

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -239,6 +239,12 @@ class Sensei_Course {
 					if ( 'product_variation' == $post_item->post_type ) {
 
 						$product_object = Sensei_WC_Utils::get_product( $post_item->ID );
+
+						if ( empty( $product_object ) ) {
+							// Product variation has been orphaned. Treat it like it has also been deleted.
+							continue;
+						}
+
 						$parent_id = wp_get_post_parent_id( $post_item->ID );
 
                         if( sensei_check_woocommerce_version( '2.1' ) ) {

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -257,12 +257,9 @@ class Sensei_Course {
 						}
 
                         $product_name = ucwords( $formatted_variation );
-                        if( empty( $product_name ) ){
-
-                            $product_name = __( 'Variation #', 'woothemes-sensei' ) . $product_object->variation_id;
-
+                        if ( empty( $product_name ) ) {
+                            $product_name = __( 'Variation #', 'woothemes-sensei' ) . Sensei_WC_Utils::get_product_variation_id( $product_object );
                         }
-
 					} else {
 
 						$parent_id = false;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -620,6 +620,10 @@ class Sensei_Lesson {
 
 									if ( 'product_variation' == $products_item->post_type ) {
 										$product_object = Sensei_WC_Utils::get_product( $products_item->ID );
+										if ( empty( $product_object ) ) {
+											// Product variation has been orphaned. Treat it like it has also been deleted.
+											continue;
+										}
 										$parent_id = Sensei_WC_Utils::get_product_id( $product_object );
 										$product_name = ucwords( Sensei_WC_Utils::get_formatted_variation( Sensei_WC_Utils::get_variation_data( $product_object ), true ) );
 									} else {
@@ -639,7 +643,7 @@ class Sensei_Lesson {
 										$html .= '</optgroup>';
 									}
 
-									$html .= '<option value="' . esc_attr( absint( $products_item->ID ) ) . '">' . esc_html( $products_item->post_title ) . '</option>' . "\n";
+									$html .= '<option value="' . esc_attr( absint( $products_item->ID ) ) . '">' . esc_html( $product_name ) . '</option>' . "\n";
 								} // End For Loop
 							$html .= '</select>' . "\n";
 						} else {


### PR DESCRIPTION
Fixes: #1789 

This ignores orphaned product variations on course/lesson editor WooCommerce product dropdowns.

Related to this issue:
woocommerce/woocommerce#12774