### PR TITLE
Remove duplicate completion hook call

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -444,8 +444,6 @@ class Sensei_Learner_Management {
 
 					// Updates the Course status and it's meta data
 					Sensei_Utils::user_complete_course( $course_id, $user_id );
-
-					do_action( 'sensei_user_course_end', $user_id, $course_id );
 				}
 
 			break;


### PR DESCRIPTION
'sensei_user_course_end' is already hooked in
Sensei_Utils::user_complete_course

We don't need to call it anywhere else. Related to
https://github.com/woocommerce/sensei-certificates/issues/118