### PR TITLE
Don't count comment_types excluded by WC

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -844,9 +844,12 @@ class Sensei_Main {
         }
 
         $statuses = array( '' ); // Default to the WP normal comments
+        // WC excludes these so exclude them too
+        $wc_statuses_to_exclude = array( 'order_note', 'webhook_delivery' );
         $stati = $wpdb->get_results( "SELECT comment_type FROM {$wpdb->comments} GROUP BY comment_type", ARRAY_A );
         foreach ( (array) $stati AS $status ) {
-            if ( 'sensei_' != substr($status['comment_type'], 0, 7 ) ) {
+            if ( 'sensei_' != substr($status['comment_type'], 0, 7 ) &&
+                ! in_array( $status['comment_type'], $wc_statuses_to_exclude ) ) {
                 $statuses[] = $status['comment_type'];
             }
         }


### PR DESCRIPTION
WC 3.0.0 excludes certain comment types

https://github.com/woocommerce/woocommerce/blob/3.0.0/includes/class-wc-comments.php#L278

we should do that too

Test:

* With wc 3.0.0 installed, Comment counts remain the same when sensei is
active/inactive