### PR TITLE
Allow Memberships to Control Course Access

### DIFF
--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -611,6 +611,13 @@ class Sensei_Settings extends Sensei_Settings_API {
 		} // End If Statement
 
 		if ( Sensei_WC_Memberships::is_wc_memberships_active() ) {
+			$fields['sensei_wc_memberships_restrict_course_video'] = array(
+				'name' => __( 'Restrict course video', 'woothemes-sensei' ),
+				'description' => __( 'Used when you don\'t want the course video to be viewable by non-members', 'woothemes-sensei' ),
+				'type' => 'checkbox',
+				'default' => false,
+				'section' => 'sensei-wc-memberships-settings'
+			);
 			$fields['sensei_wc_memberships_auto_start_courses'] = array(
 				'name' => __( 'Auto-start courses belonging to a membership', 'woothemes-sensei' ),
 				'description' => __( 'Automatically start courses belonging to a WC Membership when activated', 'woothemes-sensei' ),

--- a/includes/class-sensei-wc-memberships.php
+++ b/includes/class-sensei-wc-memberships.php
@@ -37,6 +37,9 @@ class Sensei_WC_Memberships {
 
 		add_action( 'wc_memberships_user_membership_status_changed', array( __CLASS__, 'start_courses_associated_with_membership' ) );
 		add_action( 'wc_memberships_user_membership_saved', array( __CLASS__, 'on_wc_memberships_user_membership_saved' ), 10, 2 );
+		// Adds Memberships restrictions support to Sensei Lessons and Optionally, Course Videos.
+		add_action( 'wp', array( __CLASS__, 'restrict_lesson_details' ) );
+		add_action( 'wp', array( __CLASS__, 'restrict_course_videos' ) );
 	}
 
 	/**
@@ -222,5 +225,68 @@ class Sensei_WC_Memberships {
 	 */
 	public static function is_my_courses_page( $post_id ) {
 		return is_page() && intval( Sensei()->settings->get( 'my_course_page' ) ) === intval( $post_id );
+	}
+
+	/**
+	 * Required: Restrict lesson videos & quiz links until the member has access to the lesson.
+	 * Used to ensure content dripping from Memberships is compatible with Sensei.
+	 *
+	 * This will also remove the "complete lesson" button until the lesson is available.
+	 */
+	function restrict_lesson_details() {
+		global $post;
+
+		// sanity checks.
+		if ( ! function_exists( 'wc_memberships_get_user_access_start_time' ) || ! function_exists( 'Sensei' ) || 'lesson' !== get_post_type( $post ) ) {
+			return;
+		}
+
+		// if access start time isn't set, or is after the current date, remove the video.
+		if ( ! wc_memberships_get_user_access_start_time( get_current_user_id(), 'view', array(
+			'lesson' => $post->ID,
+		) )
+			|| current_time( 'timestamp' ) < wc_memberships_get_user_access_start_time( get_current_user_id(), 'view', array(
+				'lesson' => $post->ID,
+			) ) ) {
+
+			remove_action( 'sensei_single_lesson_content_inside_after',  array( 'Sensei_Lesson', 'footer_quiz_call_to_action' ) );
+			remove_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'user_lesson_quiz_status_message' ), 20 );
+
+			remove_action( 'sensei_lesson_video',           array( Sensei()->frontend, 'sensei_lesson_video' ), 10, 1 );
+			remove_action( 'sensei_lesson_meta',            array( Sensei()->frontend, 'sensei_lesson_meta' ), 10 );
+			remove_action( 'sensei_complete_lesson_button', array( Sensei()->frontend, 'sensei_complete_lesson_button' ) );
+		}
+	}
+
+
+	/**
+	 * Optional: Restrict course videos unless the member has access.
+	 * Used if you don't want to show course previews to non-members.
+	 */
+	function restrict_course_videos() {
+		global $post;
+
+		// sanity checks.
+		if ( ! function_exists( 'wc_memberships_get_user_access_start_time' ) || ! function_exists( 'Sensei' ) || 'course' !== get_post_type( $post ) ) {
+			return;
+		}
+
+		$restrict_course_video = (bool) Sensei()->settings->get( 'sensei_wc_memberships_restrict_course_video' );
+
+		if ( ! $restrict_course_video ) {
+			return;
+		}
+
+		// if access start time isn't set, or is after the current date, remove the video.
+		if ( ! wc_memberships_get_user_access_start_time( get_current_user_id(), 'view', array(
+			'course' => $post->ID,
+		) )
+			|| current_time( 'timestamp' ) < wc_memberships_get_user_access_start_time( get_current_user_id(), 'view', array(
+				'course' => $post->ID,
+			) ) ) {
+
+			remove_action( 'sensei_single_course_content_inside_before',  array( 'Sensei_Course', 'the_course_video' ), 40 );
+			remove_action( 'sensei_no_permissions_inside_before_content', array( 'Sensei_Course', 'the_course_video' ), 40 );
+		}
 	}
 }

--- a/includes/class-sensei-wc-memberships.php
+++ b/includes/class-sensei-wc-memberships.php
@@ -1,5 +1,20 @@
 <?php
+/**
+ * Sensei WooCommerce Memberships Integration
+ *
+ * All functions needed to integrate Sensei and WooCommerce Memberships
+ *
+ * @package Access-Management
+ * @author Automattic
+ */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_WC_Memberships
+ */
 class Sensei_WC_Memberships {
 	const WC_MEMBERSHIPS_PLUGIN_PATH = 'woocommerce-memberships/woocommerce-memberships.php';
 
@@ -7,6 +22,7 @@ class Sensei_WC_Memberships {
 
 	/**
 	 * Load WC Memberships integration hooks if WC Memberships is active
+	 *
 	 * @return void
 	 */
 	public static function load_wc_memberships_integration_hooks() {
@@ -23,6 +39,13 @@ class Sensei_WC_Memberships {
 		add_action( 'wc_memberships_user_membership_saved', array( __CLASS__, 'on_wc_memberships_user_membership_saved' ), 10, 2 );
 	}
 
+	/**
+	 * Is Course Access Restricted.
+	 *
+	 * @param bool $access_restricted Access Restricted.
+	 * @param int  $course_id Course ID.
+	 * @return bool
+	 */
 	public static function is_course_access_restricted( $access_restricted, $course_id ) {
 		if ( false === self::is_wc_memberships_active() ) {
 			return $access_restricted;
@@ -31,23 +54,35 @@ class Sensei_WC_Memberships {
 		return self::is_content_restricted( $course_id );
 	}
 
+	/**
+	 * Is content restricted?
+	 *
+	 * @param int $object_id The object id.
+	 * @return bool
+	 */
 	private static function is_content_restricted( $object_id ) {
 		if ( get_current_user_id() > 0 ) {
-			$access_restricted = !current_user_can( self::WC_MEMBERSHIPS_VIEW_RESTRICTED_POST_CONTENT, $object_id );
+			$access_restricted = ! current_user_can( self::WC_MEMBERSHIPS_VIEW_RESTRICTED_POST_CONTENT, $object_id );
 			return $access_restricted;
 		}
 
 		return wc_memberships_is_post_content_restricted( $object_id );
 	}
 
+	/**
+	 * Add Notice.
+	 *
+	 * @param string $content The content.
+	 * @return string
+	 */
 	public static function add_wc_memberships_notice( $content = '' ) {
 		global $post;
 		if ( false === self::is_wc_memberships_active() ) {
 			return $content;
 		}
 
-		if ( isset( $post->ID ) && !in_array( get_post_type( $post->ID ), array( 'course', 'lesson', 'quiz' ), true ) ||
-			 !self::is_content_restricted( $post->ID ) ) {
+		if ( isset( $post->ID ) && ! in_array( get_post_type( $post->ID ), array( 'course', 'lesson', 'quiz' ), true ) ||
+			 ! self::is_content_restricted( $post->ID ) ) {
 			return $content;
 		}
 		$message = wc_memberships()->get_frontend_instance()->get_content_restricted_message( $post->ID );
@@ -55,20 +90,25 @@ class Sensei_WC_Memberships {
 	}
 
 	/**
+	 * Display Start Course form to members only.
+	 *
 	 * Applied to the `sensei_display_start_course_form` filter to determine
 	 * if the 'start taking this course' form should be displayed for a given course.
 	 * If a course has membership rules, restrict to active logged in members.
 	 *
-	 * @param $course_id the course in question
-	 * @return int|bool the course id or false in case a restriction applies
+	 * @param bool $should_display Should Display.
+	 * @param int  $course_id The course in question.
+	 *
+	 * @return bool|int The course id or false in case a restriction applies.
 	 */
 	public static function display_start_course_form_to_members_only( $should_display, $course_id ) {
 
-		return !self::is_course_access_restricted( $should_display, $course_id );
+		return ! self::is_course_access_restricted( $should_display, $course_id );
 	}
 
 	/**
 	 * Determine if WC Memberships is installed and active
+	 *
 	 * @return bool
 	 */
 	public static function is_wc_memberships_active() {
@@ -76,25 +116,26 @@ class Sensei_WC_Memberships {
 			'WC_Memberships',
 			self::WC_MEMBERSHIPS_PLUGIN_PATH
 		);
-    }
+	}
 
 	/**
 	 * Start courses associated with new membership
 	 * so they show up on "my courses".
 	 *
 	 * Hooked into wc_memberships_user_membership_saved and wc_memberships_user_membership_created
-	 * @param $membership_plan
-	 * @param array $args
+	 *
+	 * @param mixed $membership_plan The Membership Plan.
+	 * @param array $args The args.
 	 */
 	public static function on_wc_memberships_user_membership_saved( $membership_plan, $args = array() ) {
 		$user_membership_id = isset( $args['user_membership_id'] ) ? absint( $args['user_membership_id'] ) : null;
 
-		if ( !$user_membership_id ) {
+		if ( ! $user_membership_id ) {
 			return;
 		}
 
 		$user_membership = wc_memberships_get_user_membership( $user_membership_id );
-		return self::start_courses_associated_with_membership( $user_membership );
+		self::start_courses_associated_with_membership( $user_membership );
 	}
 
 	/**
@@ -103,7 +144,7 @@ class Sensei_WC_Memberships {
 	 *
 	 * Hooked into wc_memberships_user_membership_status_changed
 	 *
-	 * @param WC_Memberships_User_Membership $user_membership the user membership
+	 * @param WC_Memberships_User_Membership $user_membership The user membership.
 	 */
 	public static function start_courses_associated_with_membership( $user_membership ) {
 
@@ -126,11 +167,6 @@ class Sensei_WC_Memberships {
 			return;
 		}
 
-		if ( false === self::is_user_active_member( $user_id, $membership_plan->get_id() ) ) {
-			// User is Inactive so just Bail for now
-			return;
-		}
-
 		$restricted_content = $membership_plan->get_restricted_content();
 
 		foreach ( $restricted_content->get_posts() as $maybe_course ) {
@@ -141,9 +177,10 @@ class Sensei_WC_Memberships {
 			$course_id = $maybe_course->ID;
 
 			/**
-			 * filter sensei_wc_memberships_auto_start_course
-			 * determine if we should automatically start users on a specific course that is part of a user membership
-			 * and has not started yet.
+			 * Filter sensei_wc_memberships_auto_start_course
+			 *
+			 * Determine if we should automatically start users on a specific course
+			 * that is part of a user membership and has not started yet.
 			 *
 			 * @param bool $auto_start_courses
 			 * @param WC_Memberships_User_Membership $user_membership the user membership
@@ -159,11 +196,17 @@ class Sensei_WC_Memberships {
 		}
 	}
 
+	/**
+	 * Should we auto start any Courses thie Membership controls access to?
+	 *
+	 * @param WC_Memberships_User_Membership $user_membership User Membership.
+	 * @return bool
+	 */
 	private static function should_auto_start_membership_courses( $user_membership ) {
 		$auto_start_courses = (bool) Sensei()->settings->get( 'sensei_wc_memberships_auto_start_courses' );
 
 		/**
-		 * determine if we should automatically start users on any courses that are part of this user membership;
+		 * Determine if we should automatically start users on any courses that are part of this user membership;
 		 *
 		 * @param bool $auto_start_courses
 		 * @param WC_Memberships_User_Membership $user_membership the user membership
@@ -171,40 +214,13 @@ class Sensei_WC_Memberships {
 		return (bool) apply_filters( 'sensei_wc_memberships_auto_start_courses', $auto_start_courses, $user_membership );
 	}
 
-	public static function is_my_courses_page( $post_id ) {
-		return is_page() && intval( Sensei()->settings->get( 'my_course_page' ) ) === intval( $post_id );
-	}
-
 	/**
-	 * @param int $user_id
-	 * @param int $membership_plan_id
+	 * Is My Courses Page
+	 *
+	 * @param int $post_id Post Id.
 	 * @return bool
 	 */
-	private static function is_user_active_member( $user_id, $membership_plan_id )
-	{
-		if ( true === version_compare(wc_memberships()->get_version(), '1.7.0', '>=') ) {
-			/**
-			 * Sensei WC Memberships "start_courses_associated_with_membership_skip_cache" Filter
-			 *
-			 * Overrides `wc_memberships_is_user_active_member` cache control on WC Memberships >= 1.7.0
-			 * Busts cache when false. We default to false, as this is triggered on membership save/status-change and we don't want stale info
-			 *
-			 * @since 1.9.13
-			 *
-			 * @param bool $use_cache (default false)
-			 * @param int $user_id
-			 * @param int $membership_plan
-			 */
-			$use_cache = (bool)apply_filters(
-				'sensei_wc_memberships_start_courses_associated_with_membership_skip_cache',
-				false,
-				$user_id,
-				$membership_plan_id
-			);
-
-			return wc_memberships_is_user_active_member($user_id, $membership_plan_id, $use_cache);
-		} else {
-			return wc_memberships_is_user_active_member($user_id, $membership_plan_id);
-		}
+	public static function is_my_courses_page( $post_id ) {
+		return is_page() && intval( Sensei()->settings->get( 'my_course_page' ) ) === intval( $post_id );
 	}
 }


### PR DESCRIPTION
see #1814,
#1813

- Removed the self::is_user_active_member check (#1813)
- PHPCS `Sensei_WC_Memberships`
- Added functions from #1814 to `Sensei_WC_Memberships`
- Added Setting to control Course Video Access 

![screen shot 2017-05-24 at 15 05 45](https://cloud.githubusercontent.com/assets/500744/26402325/898aafa8-4092-11e7-877a-74b90b6b7ead.png)

cc: @danjjohnson @MindyPostoff @bekarice

fixes #1813
fixes #1814