### PR TITLE
Show courses and lessons under wp/v2 REST API

### DIFF
--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -127,7 +127,10 @@ class Sensei_PostTypes {
             'has_archive'         => $this->get_course_post_type_archive_slug(),
 		    'hierarchical'        => false,
 		    'menu_position'       => 51,
-		    'supports'            => array( 'title', 'editor', 'excerpt', 'thumbnail' )
+		    'supports'            => array( 'title', 'editor', 'excerpt', 'thumbnail' ),
+			'show_in_rest' => true,
+			'rest_base' => 'courses',
+			'rest_controller_class' => 'WP_REST_Posts_Controller',
 		);
 
         /**
@@ -228,7 +231,10 @@ class Sensei_PostTypes {
 		    'has_archive' => true,
 		    'hierarchical' => false,
 		    'menu_position' => 52,
-		    'supports' => $supports_array
+		    'supports' => $supports_array,
+			'show_in_rest' => true,
+			'rest_base' => 'lessons',
+			'rest_controller_class' => 'WP_REST_Posts_Controller',
 		);
 
         /**


### PR DESCRIPTION
see https://developer.wordpress.org/rest-api/extending-the-rest-api/adding-rest-api-support-for-custom-content-types/

Testing

- You can get HTTP 200 `/wp-json/wp/v2/courses` and `/wp-json/wp/v2/lessons`

Pros:

- Makes them available for things like indexing.

Cons:

- They are shown as normal posts.
- No metadata fields
- Default post dto is complicated.
- Behaviour unknown in anything other than a GET request
- Permissions are the same as any post

Overall, it is an ok short-term solution.

Screenshots:

![screen shot 2017-06-08 at 16 58 53](https://user-images.githubusercontent.com/500744/26932294-cc6c614c-4c6b-11e7-93f2-3beabb0f3724.png)


![screen shot 2017-06-08 at 16 57 28](https://user-images.githubusercontent.com/500744/26932241-a47b46e4-4c6b-11e7-83df-57eb84c3dcd7.png)