### PR TITLE
Add Course Title Filter on my-courses

### DIFF
--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -373,7 +373,15 @@ class Sensei_Templates {
         $html= '';
         $html .= '<'. $title_html_tag .' class="'. $title_classes .'" >';
         $html .= '<a href="' . get_permalink( $post->ID ) . '" >';
-        $html .= $post->post_title ;
+		/**
+		 * Alters the course title
+		 *
+		 * @since 1.9.16
+		 *
+		 * @param string $course_title The Course Title.
+		 */
+		$course_title = (string) apply_filters( 'sensei_course_the_title', $post->post_title );
+        $html .= $course_title;
         $html .= '</a>';
         $html .= '</'. $title_html_tag. '>';
         echo $html;


### PR DESCRIPTION
Users can now override the title output via a filter

example

```php
<?php

add_filter( 'sensei_course_the_title', function ( $course_title ) {
	return 'Start Here > ' . $course_title;
} );
```

closes #1796