### PR TITLE
Don't allow users to buy duplicate courses

### DIFF
--- a/includes/hooks/woocommerce.php
+++ b/includes/hooks/woocommerce.php
@@ -88,3 +88,11 @@ add_action( 'woocommerce_order_status_cancelled',     array( 'Sensei_WC', 'cance
 add_filter( 'pre_option_woocommerce_enable_guest_checkout', array( 'Sensei_WC', 'disable_guest_checkout' ) );
 // Mark orders with virtual products as complete rather then stay processing
 add_filter( 'woocommerce_payment_complete_order_status',    array( 'Sensei_WC', 'virtual_order_payment_complete' ), 10, 2 );
+
+/************************************
+ *
+ * Add To Cart
+ *
+ ************************************/
+// fail to add to cart if user already taking course. 
+add_action( 'woocommerce_add_to_cart', array( 'Sensei_WC', 'do_not_add_course_to_cart_if_user_taking_course' ), 10, 6 );


### PR DESCRIPTION
fixes #1823

A message will be displayed when trying to buy a course the user is already taking

![screen shot 2017-07-06 at 19 04 16](https://user-images.githubusercontent.com/500744/27920769-5b4e30fc-627e-11e7-9e6d-f7397fe4eef4.png)

cc @danjjohnson 