### PR TITLE
Get learner profiles by login, not slug

### DIFF
--- a/templates/learner-profile.php
+++ b/templates/learner-profile.php
@@ -40,7 +40,7 @@ do_action( 'sensei_learner_profile_content_before' );
         do_action( 'sensei_learner_profile_inside_content_before' );
         ?>
 
-        <?php  $learner_user = get_user_by( 'slug', get_query_var('learner_profile') );  // get requested learner object ?>
+        <?php  $learner_user = get_user_by( 'login', get_query_var('learner_profile') );  // get requested learner object ?>
 
         <?php if(  is_a( $learner_user, 'WP_User' ) ){ ?>
 


### PR DESCRIPTION
Now this matches our "get_user_by" call here:

https://github.com/Automattic/sensei/blob/version/1.9.16/includes/class-sensei-wc.php#L367

... and fixes #1418.