### PR TITLE
Fix lessons not displaying on order screen

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1300,7 +1300,7 @@ class Sensei_Admin {
 
                         // if lesson belongs to one fo the course modules then exclude it here
                         // as it is listed above
-                        if( has_term( $module_items_ids, 'module', $lesson->ID )  ){
+                        if( !empty($module_items_ids) && has_term( $module_items_ids, 'module', $lesson->ID )  ){
 
                             continue;
 


### PR DESCRIPTION
Sometimes `$module_items_ids` contains an empty array which causes the lesson to not be displayed in some cases.