### PR TITLE
Fix Fatal Jetpack removing module taxonomy

### DIFF
--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -369,6 +369,12 @@ class Sensei_Teacher {
             return;
         }
 
+		if ( ! taxonomy_exists( 'module' ) ) {
+			// If for some reason the `module` taxonomy is not present (normally it is), register it now.
+			// This mitigates a Jetpack-introduced bug.
+			Sensei()->modules->setup_modules_taxonomy();
+		}
+
         $terms_selected_on_course = wp_get_object_terms( $course_id, 'module' );
 
         if( empty( $terms_selected_on_course ) ){


### PR DESCRIPTION
When Latest Jetpack is activated and connected, on course author update,
updating course module author fails because the module taxonomy is not
registered, while it is registered when jeptack is not activated.

As a way to mitigate this, we check and register the taxonomy if it is
absent.

