### PR TITLE
Add/bulk recalculate completion

### DIFF
--- a/includes/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/class-sensei-learners-admin-bulk-actions-controller.php
@@ -13,6 +13,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
     const REMOVE_FROM_COURSE = 'remove_from_course';
     const RESET_COURSE = 'reset_course';
 	const COMPLETE_COURSE = 'complete_course';
+	const RECALCULATE_COURSE_COMPLETION = 'recalculate_course_completion';
 	/**
      * @var array|null we only do these actions
      */
@@ -99,7 +100,8 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
                 self::ADD_TO_COURSE => __( 'Assign to Course(s)', 'woothemes-sensei' ),
                 self::REMOVE_FROM_COURSE => __( 'Unassign from Course(s)', 'woothemes-sensei' ),
                 self::RESET_COURSE => __( 'Reset Course(s)', 'woothemes-sensei' ),
-				self::COMPLETE_COURSE => __( 'Complete Course(s)', 'woothemes-sensei' ),
+				self::COMPLETE_COURSE => __( 'Recalculate Course(s) Completion (notify on complete)', 'woothemes-sensei' ),
+				self::RECALCULATE_COURSE_COMPLETION => __( 'Recalculate Course(s) Completion (do not notify on complete)', 'woothemes-sensei' ),
             );
         }
         return (array)apply_filters( 'sensei_learners_admin_get_known_bulk_actions', $this->known_bulk_actions );
@@ -165,6 +167,14 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 						continue;
 					}
 					Sensei_Utils::user_complete_course( $course_id, $user_id );
+				}
+
+				if ( self::RECALCULATE_COURSE_COMPLETION === $sensei_bulk_action ) {
+					if ( false === Sensei_Utils::user_started_course( $course_id, $user_id ) || Sensei_Utils::user_completed_course( $course_id, $user_id )  ) {
+						continue;
+					}
+					$trigger_completion = false;
+					Sensei_Utils::user_complete_course( $course_id, $user_id, $trigger_completion );
 				}
             }
         }


### PR DESCRIPTION
Users an now recalculate course completion percentages and either send or not send learner notifications upon completion:

* the notify one, will trigger any actions that happen on course end (emails, certificates etc)
* the other one will just update learner data and set the course status to complete without not sending any notifications

Can be accesses under Sensei > Learner Management > Bulk Learner Actions

![screen shot 2017-07-28 at 17 37 56](https://user-images.githubusercontent.com/500744/28722192-900da874-73bb-11e7-8b91-e319328e5f71.png)
