### PR TITLE
Fix lesson image not displaying on course page

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2930,7 +2930,7 @@ class Sensei_Lesson {
 		// Get Width and Height settings
 		if ( ( $width == '100' ) && ( $height == '100' ) ) {
 
-			if ( is_singular( 'lesson' ) || !empty( $lesson_id  ) ) {
+			if ( is_singular( 'lesson' ) ) {
 
 				if ( ! $widget && ! Sensei()->settings->settings[ 'lesson_single_image_enable' ] ) {
 


### PR DESCRIPTION
Fix for #1378 and #1414.

## Testing

_Image_
1. In settings, ensure the _Output the Lesson Image on the Single Course Page_ box is checked.
2. Add a featured image to a lesson in a course.
3. Navigate to the course page of that course on the front-end.
4. The featured image for the lesson added in step 2 should appear.
5. In settings, uncheck the _Output the Lesson Image on the Single Course Page_ box.
6. The featured image for the lesson added in step 2 should **not** appear.

_Image Size_
1. Change the values of _Image Width - Course Lessons_ and _Image Height - Course Lessons_ in settings.
2. Regenerate thumbnails.
3. Navigate to the course page that has a lesson with a featured image.
4. Ensure the featured image is displayed at the dimensions specified in step 1.