### PR TITLE
Remove whitespace from translatable strings

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1342,7 +1342,7 @@ class Sensei_Course {
                     && ( Sensei()->settings->settings[ 'course_author' ] ) ) {
 
                     $active_html .= '<span class="course-author">'
-                        . __( 'by ', 'woothemes-sensei' )
+                        . __( 'by', 'woothemes-sensei' )
                         . '<a href="' . esc_url( get_author_posts_url( absint( $course_item->post_author ) ) )
                         . '" title="' . esc_attr( $user_info->display_name ) . '">'
                         . esc_html( $user_info->display_name )
@@ -1489,7 +1489,7 @@ class Sensei_Course {
 		    		    	// Author
 		    		    	$user_info = get_userdata( absint( $course_item->post_author ) );
 		    		    	if ( isset( Sensei()->settings->settings[ 'course_author' ] ) && ( Sensei()->settings->settings[ 'course_author' ] ) ) {
-		    		    		$complete_html .= '<span class="course-author">' . __( 'by ', 'woothemes-sensei' ) . '<a href="' . esc_url( get_author_posts_url( absint( $course_item->post_author ) ) ) . '" title="' . esc_attr( $user_info->display_name ) . '">' . esc_html( $user_info->display_name ) . '</a></span>';
+		    		    		$complete_html .= '<span class="course-author">' . __( 'by', 'woothemes-sensei' ) . '<a href="' . esc_url( get_author_posts_url( absint( $course_item->post_author ) ) ) . '" title="' . esc_attr( $user_info->display_name ) . '">' . esc_html( $user_info->display_name ) . '</a></span>';
 		    		    	} // End If Statement
 
 		    		    	// Lesson count for this author
@@ -2050,7 +2050,7 @@ class Sensei_Course {
 
         if ( isset( Sensei()->settings->settings[ 'course_author' ] ) && ( Sensei()->settings->settings[ 'course_author' ] ) ) {?>
 
-            <span class="course-author"><?php _e( 'by ', 'woothemes-sensei' ); ?>
+            <span class="course-author"><?php _e( 'by', 'woothemes-sensei' ); ?>
 
                 <a href="<?php echo esc_attr( get_author_posts_url( $course->post_author ) ); ?>" title="<?php echo esc_attr( $author_display_name ); ?>"><?php echo esc_attr( $author_display_name ); ?></a>
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -981,7 +981,7 @@ class Sensei_Frontend {
 		?><section class="entry">
         	<p class="sensei-course-meta">
            	<?php if ( isset( Sensei()->settings->settings[ 'course_author' ] ) && ( Sensei()->settings->settings[ 'course_author' ] ) ) { ?>
-		   	<span class="course-author"><?php _e( 'by ', 'woothemes-sensei' ); ?><?php the_author_link(); ?></span>
+		   	<span class="course-author"><?php _e( 'by', 'woothemes-sensei' ); ?><?php the_author_link(); ?></span>
 		   	<?php } // End If Statement ?>
 		   	<span class="course-lesson-count"><?php echo Sensei()->course->course_lesson_count( $post_id ) . '&nbsp;' . __( 'Lessons', 'woothemes-sensei' ); ?></span>
 		   	<?php if ( '' != $category_output ) { ?>
@@ -1134,7 +1134,7 @@ class Sensei_Frontend {
 		?><section class="entry">
             <p class="sensei-course-meta">
 			    <?php if ( isset( Sensei()->settings->settings[ 'lesson_author' ] ) && ( Sensei()->settings->settings[ 'lesson_author' ] ) ) { ?>
-			    <span class="course-author"><?php _e( 'by ', 'woothemes-sensei' ); ?><?php the_author_link(); ?></span>
+			    <span class="course-author"><?php _e( 'by', 'woothemes-sensei' ); ?><?php the_author_link(); ?></span>
 			    <?php } ?>
                 <?php if ( 0 < intval( $lesson_course_id ) ) { ?>
                 <span class="lesson-course"><?php echo '&nbsp;' . sprintf( __( 'Part of: %s', 'woothemes-sensei' ), '<a href="' . esc_url( get_permalink( $lesson_course_id ) ) . '" title="' . __( 'View course', 'woothemes-sensei' ) . '"><em>' . get_the_title( $lesson_course_id ) . '</em></a>' ); ?></span>

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1062,13 +1062,13 @@ class Sensei_Frontend {
 
 	public function sensei_lesson_preview_title_text( $course_id ) {
 
-		$preview_text = __( ' (Preview)', 'woothemes-sensei' );
+		$preview_text = __( '(Preview)', 'woothemes-sensei' );
 
 		//if this is a paid course
 		if ( Sensei_WC::is_woocommerce_active() ) {
     	    $wc_post_id = get_post_meta( $course_id, '_course_woocommerce_product', true );
     	    if ( 0 < $wc_post_id ) {
-    	    	$preview_text = __( ' (Free Preview)', 'woothemes-sensei' );
+    	    	$preview_text = __( '(Free Preview)', 'woothemes-sensei' );
     	    } // End If Statement
     	}
     	return $preview_text;

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -48,12 +48,9 @@ class Sensei_Frontend {
 		add_action( 'sensei_complete_lesson_button', array( $this, 'sensei_complete_lesson_button' ) );
 		add_action( 'sensei_reset_lesson_button', array( $this, 'sensei_reset_lesson_button' ) );
 
-		add_action( 'sensei_course_archive_meta', array( $this, 'sensei_course_archive_meta' ) );
-
 		add_action( 'sensei_lesson_tag_main_content', array( $this, 'sensei_lesson_archive_main_content' ), 10 );
 		add_action( 'sensei_no_permissions_main_content', array( $this, 'sensei_no_permissions_main_content' ), 10 );
 
-		add_action( 'sensei_lesson_meta', array( $this, 'sensei_lesson_meta' ), 10 );
 		add_action( 'sensei_single_course_content_inside_before', array( $this, 'sensei_course_start' ), 10 );
 
 		add_filter( 'the_title', array( $this, 'sensei_lesson_preview_title' ), 10, 2 );
@@ -969,34 +966,6 @@ class Sensei_Frontend {
 
 	} // End sensei_lesson_quiz_meta()
 
-	public function sensei_course_archive_meta() {
-		global  $post;
-		// Meta data
-		$post_id = get_the_ID();
-		$post_title = get_the_title();
-		$author_display_name = get_the_author();
-		$author_id = get_the_author_meta('ID');
-		$category_output = get_the_term_list( $post_id, 'course-category', '', ', ', '' );
-		$free_lesson_count = intval( Sensei()->course->course_lesson_preview_count( $post_id ) );
-		?><section class="entry">
-        	<p class="sensei-course-meta">
-           	<?php if ( isset( Sensei()->settings->settings[ 'course_author' ] ) && ( Sensei()->settings->settings[ 'course_author' ] ) ) { ?>
-		   	<span class="course-author"><?php _e( 'by ', 'woothemes-sensei' ); ?><?php the_author_link(); ?></span>
-		   	<?php } // End If Statement ?>
-		   	<span class="course-lesson-count"><?php echo Sensei()->course->course_lesson_count( $post_id ) . '&nbsp;' . __( 'Lessons', 'woothemes-sensei' ); ?></span>
-		   	<?php if ( '' != $category_output ) { ?>
-		   	<span class="course-category"><?php echo sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ); ?></span>
-		   	<?php } // End If Statement ?>
-		   	<?php sensei_simple_course_price( $post_id ); ?>
-        	</p>
-        	<p class="course-excerpt"><?php the_excerpt(); ?></p>
-        	<?php if ( 0 < $free_lesson_count ) {
-                $free_lessons = sprintf( __( 'You can access %d of this course\'s lessons for free', 'woothemes-sensei' ), $free_lesson_count ); ?>
-                <p class="sensei-free-lessons"><a href="<?php echo get_permalink( $post_id ); ?>"><?php _e( 'Preview this course', 'woothemes-sensei' ) ?></a> - <?php echo $free_lessons; ?></p>
-            <?php } ?>
-		</section><?php
-	} // End sensei_course_archive_meta()
-
     /**
      * @deprecated since 1.9.0
      */
@@ -1024,42 +993,6 @@ class Sensei_Frontend {
 	public function sensei_no_permissions_main_content() {
         _deprecated_function( 'Sensei_Frontend::sensei_no_permissions_main_content', 'This method is no longer needed' );
 	} // End sensei_no_permissions_main_content()
-
-	public function sensei_course_category_main_content() {
-		global $post;
-		if ( have_posts() ) { ?>
-
-			<section id="main-course" class="course-container">
-
-                <?php do_action( 'sensei_course_archive_header' ); ?>
-
-                <?php while ( have_posts() ) { the_post(); ?>
-
-                    <article class="<?php echo join( ' ', get_post_class( array( 'course', 'post' ), get_the_ID() ) ); ?>">
-
-	    			    <?php sensei_do_deprecated_action('sensei_course_image','1.9.0', 'sensei_single_course_content_inside_before', get_the_ID() ); ?>
-
-	    			    <?php sensei_do_deprecated_action( 'sensei_course_archive_course_title','1.9.0','sensei_course_content_inside_before', $post ); ?>
-
-	    			    <?php do_action( 'sensei_course_archive_meta' ); ?>
-
-	    		    </article>
-
-                <?php } // End While Loop ?>
-
-	    	</section>
-
-		<?php } else { ?>
-
-			<p>
-
-                <?php _e( 'No courses found that match your selection.', 'woothemes-sensei' ); ?>
-
-            </p>
-
-		<?php } // End If Statement
-
-	} // End sensei_course_category_main_content()
 
 	public function sensei_login_form() {
 		?>
@@ -1126,24 +1059,6 @@ class Sensei_Frontend {
 
 		<?php
 	} // End sensei_login_form()
-
-	public function sensei_lesson_meta( $post_id = 0 ) {
-		global $post;
-		if ( 0 < intval( $post_id ) ) {
-		$lesson_course_id = absint( get_post_meta( $post_id, '_lesson_course', true ) );
-		?><section class="entry">
-            <p class="sensei-course-meta">
-			    <?php if ( isset( Sensei()->settings->settings[ 'lesson_author' ] ) && ( Sensei()->settings->settings[ 'lesson_author' ] ) ) { ?>
-			    <span class="course-author"><?php _e( 'by ', 'woothemes-sensei' ); ?><?php the_author_link(); ?></span>
-			    <?php } ?>
-                <?php if ( 0 < intval( $lesson_course_id ) ) { ?>
-                <span class="lesson-course"><?php echo '&nbsp;' . sprintf( __( 'Part of: %s', 'woothemes-sensei' ), '<a href="' . esc_url( get_permalink( $lesson_course_id ) ) . '" title="' . __( 'View course', 'woothemes-sensei' ) . '"><em>' . get_the_title( $lesson_course_id ) . '</em></a>' ); ?></span>
-                <?php } ?>
-            </p>
-            <p class="lesson-excerpt"><?php the_excerpt( ); ?></p>
-		</section><?php
-		} // End If Statement
-	} // sensei_lesson_meta()
 
 	public function sensei_lesson_preview_title_text( $course_id ) {
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -48,9 +48,12 @@ class Sensei_Frontend {
 		add_action( 'sensei_complete_lesson_button', array( $this, 'sensei_complete_lesson_button' ) );
 		add_action( 'sensei_reset_lesson_button', array( $this, 'sensei_reset_lesson_button' ) );
 
+		add_action( 'sensei_course_archive_meta', array( $this, 'sensei_course_archive_meta' ) );
+
 		add_action( 'sensei_lesson_tag_main_content', array( $this, 'sensei_lesson_archive_main_content' ), 10 );
 		add_action( 'sensei_no_permissions_main_content', array( $this, 'sensei_no_permissions_main_content' ), 10 );
 
+		add_action( 'sensei_lesson_meta', array( $this, 'sensei_lesson_meta' ), 10 );
 		add_action( 'sensei_single_course_content_inside_before', array( $this, 'sensei_course_start' ), 10 );
 
 		add_filter( 'the_title', array( $this, 'sensei_lesson_preview_title' ), 10, 2 );
@@ -966,6 +969,34 @@ class Sensei_Frontend {
 
 	} // End sensei_lesson_quiz_meta()
 
+	public function sensei_course_archive_meta() {
+		global  $post;
+		// Meta data
+		$post_id = get_the_ID();
+		$post_title = get_the_title();
+		$author_display_name = get_the_author();
+		$author_id = get_the_author_meta('ID');
+		$category_output = get_the_term_list( $post_id, 'course-category', '', ', ', '' );
+		$free_lesson_count = intval( Sensei()->course->course_lesson_preview_count( $post_id ) );
+		?><section class="entry">
+        	<p class="sensei-course-meta">
+           	<?php if ( isset( Sensei()->settings->settings[ 'course_author' ] ) && ( Sensei()->settings->settings[ 'course_author' ] ) ) { ?>
+		   	<span class="course-author"><?php _e( 'by ', 'woothemes-sensei' ); ?><?php the_author_link(); ?></span>
+		   	<?php } // End If Statement ?>
+		   	<span class="course-lesson-count"><?php echo Sensei()->course->course_lesson_count( $post_id ) . '&nbsp;' . __( 'Lessons', 'woothemes-sensei' ); ?></span>
+		   	<?php if ( '' != $category_output ) { ?>
+		   	<span class="course-category"><?php echo sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ); ?></span>
+		   	<?php } // End If Statement ?>
+		   	<?php sensei_simple_course_price( $post_id ); ?>
+        	</p>
+        	<p class="course-excerpt"><?php the_excerpt(); ?></p>
+        	<?php if ( 0 < $free_lesson_count ) {
+                $free_lessons = sprintf( __( 'You can access %d of this course\'s lessons for free', 'woothemes-sensei' ), $free_lesson_count ); ?>
+                <p class="sensei-free-lessons"><a href="<?php echo get_permalink( $post_id ); ?>"><?php _e( 'Preview this course', 'woothemes-sensei' ) ?></a> - <?php echo $free_lessons; ?></p>
+            <?php } ?>
+		</section><?php
+	} // End sensei_course_archive_meta()
+
     /**
      * @deprecated since 1.9.0
      */
@@ -993,6 +1024,42 @@ class Sensei_Frontend {
 	public function sensei_no_permissions_main_content() {
         _deprecated_function( 'Sensei_Frontend::sensei_no_permissions_main_content', 'This method is no longer needed' );
 	} // End sensei_no_permissions_main_content()
+
+	public function sensei_course_category_main_content() {
+		global $post;
+		if ( have_posts() ) { ?>
+
+			<section id="main-course" class="course-container">
+
+                <?php do_action( 'sensei_course_archive_header' ); ?>
+
+                <?php while ( have_posts() ) { the_post(); ?>
+
+                    <article class="<?php echo join( ' ', get_post_class( array( 'course', 'post' ), get_the_ID() ) ); ?>">
+
+	    			    <?php sensei_do_deprecated_action('sensei_course_image','1.9.0', 'sensei_single_course_content_inside_before', get_the_ID() ); ?>
+
+	    			    <?php sensei_do_deprecated_action( 'sensei_course_archive_course_title','1.9.0','sensei_course_content_inside_before', $post ); ?>
+
+	    			    <?php do_action( 'sensei_course_archive_meta' ); ?>
+
+	    		    </article>
+
+                <?php } // End While Loop ?>
+
+	    	</section>
+
+		<?php } else { ?>
+
+			<p>
+
+                <?php _e( 'No courses found that match your selection.', 'woothemes-sensei' ); ?>
+
+            </p>
+
+		<?php } // End If Statement
+
+	} // End sensei_course_category_main_content()
 
 	public function sensei_login_form() {
 		?>
@@ -1059,6 +1126,24 @@ class Sensei_Frontend {
 
 		<?php
 	} // End sensei_login_form()
+
+	public function sensei_lesson_meta( $post_id = 0 ) {
+		global $post;
+		if ( 0 < intval( $post_id ) ) {
+		$lesson_course_id = absint( get_post_meta( $post_id, '_lesson_course', true ) );
+		?><section class="entry">
+            <p class="sensei-course-meta">
+			    <?php if ( isset( Sensei()->settings->settings[ 'lesson_author' ] ) && ( Sensei()->settings->settings[ 'lesson_author' ] ) ) { ?>
+			    <span class="course-author"><?php _e( 'by ', 'woothemes-sensei' ); ?><?php the_author_link(); ?></span>
+			    <?php } ?>
+                <?php if ( 0 < intval( $lesson_course_id ) ) { ?>
+                <span class="lesson-course"><?php echo '&nbsp;' . sprintf( __( 'Part of: %s', 'woothemes-sensei' ), '<a href="' . esc_url( get_permalink( $lesson_course_id ) ) . '" title="' . __( 'View course', 'woothemes-sensei' ) . '"><em>' . get_the_title( $lesson_course_id ) . '</em></a>' ); ?></span>
+                <?php } ?>
+            </p>
+            <p class="lesson-excerpt"><?php the_excerpt( ); ?></p>
+		</section><?php
+		} // End If Statement
+	} // sensei_lesson_meta()
 
 	public function sensei_lesson_preview_title_text( $course_id ) {
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3424,18 +3424,18 @@ class Sensei_Lesson {
 				$lesson_length = get_post_meta( $lesson_id, '_lesson_length', true );
 				if ( '' != $lesson_length ) {
 
-					$meta_html .= '<span class="lesson-length">' .  esc_html__( 'Length: ', 'woothemes-sensei' ) . esc_html( $lesson_length ) . esc_html__( ' minutes', 'woothemes-sensei' ) . '</span>';
+					$meta_html .= '<span class="lesson-length">' .  esc_html__( 'Length:', 'woothemes-sensei' ) . ' ' . esc_html( $lesson_length ) . ' ' . esc_html__( 'minutes', 'woothemes-sensei' ) . '</span>';
 
 				}
 
 				if ( Sensei()->settings->get( 'lesson_author' ) ) {
 
-					$meta_html .= '<span class="lesson-author">' .  esc_html__( 'Author: ', 'woothemes-sensei' ) . '<a href="' . get_author_posts_url( absint( get_post()->post_author ) ) . '" title="' . esc_attr( $user_info->display_name ) . '">' . esc_html( $user_info->display_name ) . '</a></span>';
+					$meta_html .= '<span class="lesson-author">' . esc_html__( 'Author:', 'woothemes-sensei' ) . ' ' . '<a href="' . get_author_posts_url( absint( get_post()->post_author ) ) . '" title="' . esc_attr( $user_info->display_name ) . '">' . esc_html( $user_info->display_name ) . '</a></span>';
 
 				} // End If Statement
 				if ( '' != $lesson_complexity ) {
 
-					$meta_html .= '<span class="lesson-complexity">' .  esc_html__( 'Complexity: ', 'woothemes-sensei' ) . $lesson_complexity .'</span>';
+					$meta_html .= '<span class="lesson-complexity">' .  esc_html__( 'Complexity:', 'woothemes-sensei' ) . ' ' . $lesson_complexity .'</span>';
 
 				}
 

--- a/includes/class-sensei-wc-memberships.php
+++ b/includes/class-sensei-wc-memberships.php
@@ -256,6 +256,7 @@ class Sensei_WC_Memberships {
 			remove_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'user_lesson_quiz_status_message' ), 20 );
 
 			remove_action( 'sensei_lesson_video',           array( Sensei()->frontend, 'sensei_lesson_video' ), 10, 1 );
+			remove_action( 'sensei_lesson_meta',            array( Sensei()->frontend, 'sensei_lesson_meta' ), 10 );
 			remove_action( 'sensei_complete_lesson_button', array( Sensei()->frontend, 'sensei_complete_lesson_button' ) );
 		}
 	}

--- a/includes/class-sensei-wc-memberships.php
+++ b/includes/class-sensei-wc-memberships.php
@@ -256,7 +256,6 @@ class Sensei_WC_Memberships {
 			remove_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'user_lesson_quiz_status_message' ), 20 );
 
 			remove_action( 'sensei_lesson_video',           array( Sensei()->frontend, 'sensei_lesson_video' ), 10, 1 );
-			remove_action( 'sensei_lesson_meta',            array( Sensei()->frontend, 'sensei_lesson_meta' ), 10 );
 			remove_action( 'sensei_complete_lesson_button', array( Sensei()->frontend, 'sensei_complete_lesson_button' ) );
 		}
 	}

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -352,7 +352,7 @@ class Sensei_Legacy_Shortcodes {
                         <?php if ( isset( Sensei()->settings->settings[ 'course_author' ] ) && ( Sensei()->settings->settings[ 'course_author' ] ) ) { ?>
                             <span class="course-author">
                             	<?php _e( 'by', 'woothemes-sensei' ); ?>
-                            	<a href="<?php echo $author_link; ?>" title="<?php echo esc_attr( $author_display_name ); ?>">
+                            	<a href="<?php echo esc_url( $author_link ); ?>" title="<?php echo esc_attr( $author_display_name ); ?>">
                             		<?php echo esc_html( $author_display_name   ); ?>
                             	</a>
                             </span>

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -350,7 +350,12 @@ class Sensei_Legacy_Shortcodes {
                     <p class="sensei-course-meta">
 
                         <?php if ( isset( Sensei()->settings->settings[ 'course_author' ] ) && ( Sensei()->settings->settings[ 'course_author' ] ) ) { ?>
-                            <span class="course-author"><?php _e( 'by ', 'woothemes-sensei' ); ?><a href="<?php echo $author_link; ?>" title="<?php echo esc_attr( $author_display_name ); ?>"><?php echo esc_html( $author_display_name   ); ?></a></span>
+                            <span class="course-author">
+                            	<?php _e( 'by', 'woothemes-sensei' ); ?>
+                            	<a href="<?php echo $author_link; ?>" title="<?php echo esc_attr( $author_display_name ); ?>">
+                            		<?php echo esc_html( $author_display_name   ); ?>
+                            	</a>
+                            </span>
                         <?php } // End If Statement ?>
 
                         <span class="course-lesson-count">

--- a/widgets/widget-woothemes-sensei-category-courses.php
+++ b/widgets/widget-woothemes-sensei-category-courses.php
@@ -187,7 +187,12 @@ class WooThemes_Sensei_Category_Courses_Widget extends WP_Widget {
 		    		<a href="<?php echo esc_url( get_permalink( $post_id ) ); ?>" title="<?php echo esc_attr( $post_title ); ?>"><?php echo $post_title; ?></a>
 		    		<br />
 		    		<?php if ( isset( Sensei()->settings->settings[ 'course_author' ] ) && ( Sensei()->settings->settings[ 'course_author' ] ) ) { ?>
-    					<span class="course-author"><?php _e( 'by ', 'woothemes-sensei' ); ?><a href="<?php echo esc_url( $author_link ); ?>" title="<?php echo esc_attr( $author_display_name ); ?>"><?php echo esc_html( $author_display_name ); ?></a></span>
+    					<span class="course-author">
+    						<?php _e( 'by', 'woothemes-sensei' ); ?>
+    						<a href="<?php echo esc_url( $author_link ); ?>" title="<?php echo esc_attr( $author_display_name ); ?>">
+    							<?php echo esc_html( $author_display_name ); ?>
+    						</a>
+    					</span>
     					<br />
     				<?php } // End If Statement ?>
     				<span class="course-lesson-count"><?php echo Sensei()->course->course_lesson_count( $post_id ) . '&nbsp;' .  __( 'Lessons', 'woothemes-sensei' ); ?></span>

--- a/widgets/widget-woothemes-sensei-course-component.php
+++ b/widgets/widget-woothemes-sensei-course-component.php
@@ -292,7 +292,7 @@ class WooThemes_Sensei_Course_Component_Widget extends WP_Widget {
 
 					<?php if ( isset( Sensei()->settings->settings[ 'course_author' ] ) && ( Sensei()->settings->settings[ 'course_author' ] ) ) { ?>
 						<span class="course-author">
-							<?php _e( 'by ', 'woothemes-sensei' ); ?>
+							<?php _e( 'by', 'woothemes-sensei' ); ?>
 							<a href="<?php echo esc_url( $author_link ); ?>" title="<?php echo esc_attr( $author_display_name ); ?>">
 								<?php echo esc_html( $author_display_name ); ?>
 							</a>

--- a/widgets/widget-woothemes-sensei-lesson-component.php
+++ b/widgets/widget-woothemes-sensei-lesson-component.php
@@ -192,7 +192,12 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
 		    		<a href="<?php echo esc_url( get_permalink( $post_id ) ); ?>" title="<?php echo esc_attr( $post_title ); ?>"><?php echo $post_title; ?></a>
 		    		<br />
 		    		<?php if ( isset( Sensei()->settings->settings[ 'lesson_author' ] ) && ( Sensei()->settings->settings[ 'lesson_author' ] ) ) { ?>
-    					<span class="course-author"><?php _e( 'by ', 'woothemes-sensei' ); ?><a href="<?php echo esc_url( $author_link ); ?>" title="<?php echo esc_attr( $author_display_name ); ?>"><?php echo esc_html( $author_display_name ); ?></a></span>
+    					<span class="course-author">
+    						<?php _e( 'by', 'woothemes-sensei' ); ?>
+    						<a href="<?php echo esc_url( $author_link ); ?>" title="<?php echo esc_attr( $author_display_name ); ?>">
+    							<?php echo esc_html( $author_display_name ); ?>
+    						</a>
+    					</span>
     					<br />
     				<?php } // End If Statement ?>
     				<?php if ( 0 < $lesson_course_id ) { ?>


### PR DESCRIPTION
This PR fixes #1478 by eliminating extraneous whitespace in translatable strings.

# Testing
Check that the UI on the front-end still looks good and has spaces in the appropriate places:

## Lessons in Individual Course
![course-lessons](https://user-images.githubusercontent.com/1190420/29077417-150f23fa-7c26-11e7-818f-9724f1f956ad.jpg)

## My Courses
![my-courses](https://user-images.githubusercontent.com/1190420/29077182-7dc4ba78-7c25-11e7-8fa5-a4da99a4d10e.jpg)

## Legacy `[freecourses]` Shortcode
![legacy-shortcode](https://user-images.githubusercontent.com/1190420/29081545-de42817c-7c30-11e7-8dd8-5b3fb044d5af.jpg)

## Category Courses Widget
![category-courses-widget](https://user-images.githubusercontent.com/1190420/29082404-5f6f816c-7c33-11e7-9edc-456fd20a2cdf.jpg)

## Course Component Widget
![course-component-widget](https://user-images.githubusercontent.com/1190420/29084315-9e8d7d1c-7c39-11e7-9b16-d0a264001772.jpg)

## Lesson Component Widget
![lesson-component-widget](https://user-images.githubusercontent.com/1190420/29084608-911e86ca-7c3a-11e7-94bb-e293456e0270.jpg)

## Preview
![preview](https://user-images.githubusercontent.com/1190420/29085727-306f1606-7c3e-11e7-9666-5316d1769857.jpg)

## Free Preview
![free-preview](https://user-images.githubusercontent.com/1190420/29085735-35ab33de-7c3e-11e7-8695-262bd015d03b.jpg)
