### PR TITLE
Simplify CSS for displaying answer feedback

### DIFF
--- a/assets/css/frontend/sensei.css
+++ b/assets/css/frontend/sensei.css
@@ -310,9 +310,7 @@ a.sensei-certificate-link {
           vertical-align: middle; }
     .quiz form ol#sensei-quiz-list li .answer_message {
       position: relative;
-      right: 0;
-      width: 100%;
-      text-align: right; }
+      width: 100%; }
       .quiz form ol#sensei-quiz-list li .answer_message span {
         text-align: right; }
       .quiz form ol#sensei-quiz-list li .answer_message.user_right {

--- a/assets/css/frontend/sensei.css
+++ b/assets/css/frontend/sensei.css
@@ -309,11 +309,9 @@ a.sensei-certificate-link {
         .quiz form ol#sensei-quiz-list li ul li label {
           vertical-align: middle; }
     .quiz form ol#sensei-quiz-list li .answer_message {
-      position: absolute;
+      position: relative;
       right: 0;
-      top: 50%;
-      width: 50%;
-      z-index: 2;
+      width: 100%;
       text-align: right; }
       .quiz form ol#sensei-quiz-list li .answer_message span {
         text-align: right; }
@@ -341,13 +339,6 @@ a.sensei-certificate-link {
         padding: 10px;
         font-size: 85%;
         text-align: left; }
-    .quiz form ol#sensei-quiz-list li.essay-paste .answer_message, .quiz form ol#sensei-quiz-list li.gap-fill .answer_message, .quiz form ol#sensei-quiz-list li.multi-line .answer_message, .quiz form ol#sensei-quiz-list li.single-line .answer_message {
-      position: relative;
-      width: 100%;
-      margin: 10px 0;
-      text-align: right; }
-      .quiz form ol#sensei-quiz-list li.essay-paste .answer_message .notes, .quiz form ol#sensei-quiz-list li.gap-fill .answer_message .notes, .quiz form ol#sensei-quiz-list li.multi-line .answer_message .notes, .quiz form ol#sensei-quiz-list li.single-line .answer_message .notes {
-        width: 50%; }
 
 .quiz form input.quiz-submit {
   margin-right: 10px; }

--- a/assets/css/frontend/sensei.scss
+++ b/assets/css/frontend/sensei.scss
@@ -303,11 +303,9 @@ a.sensei-certificate-link {
           }
         }
         .answer_message {
-          position: absolute;
+          position: relative;
           right: 0;
-          top: 50%;
-          width: 50%;
-          z-index: 2;
+          width: 100%;
           text-align: right;
           span {
             text-align: right;
@@ -334,17 +332,6 @@ a.sensei-certificate-link {
             padding: 10px;
             font-size: 85%;
             text-align: left;
-          }
-        }
-        &.essay-paste, &.gap-fill, &.multi-line, &.single-line {
-          .answer_message {
-            position: relative;
-            width: 100%;
-            margin: 10px 0;
-            text-align: right;
-            .notes {
-              width: 50%;
-            }
           }
         }
       }

--- a/assets/css/frontend/sensei.scss
+++ b/assets/css/frontend/sensei.scss
@@ -304,9 +304,7 @@ a.sensei-certificate-link {
         }
         .answer_message {
           position: relative;
-          right: 0;
           width: 100%;
-          text-align: right;
           span {
             text-align: right;
           }

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -199,8 +199,8 @@ add_action( 'sensei_quiz_question_inside_before', array( 'Sensei_Question','the_
 add_action( 'sensei_quiz_question_inside_before', array( 'Sensei_Question','the_question_hidden_fields' ), 40 );
 
 //@since 1.9.0
-// hook in incorrect / correct message above questions if the quiz has been graded
-add_action( 'sensei_quiz_question_inside_before', array( 'Sensei_Question', 'the_answer_result_indication' ), 50 );
+// hook in incorrect / correct message below questions if the quiz has been graded
+add_action( 'sensei_quiz_question_inside_after', array( 'Sensei_Question', 'the_answer_result_indication' ) );
 
 //@since 1.9.0
 // add answer grading feedback at the bottom of the question


### PR DESCRIPTION
Fixes #1685 

Previously, answer feedback for multiple choice and true/false questions
was being displayed alongside the answer choices. However, that was
causing text to overlap in some cases.

Now, we simply display the answer feedback under the question for all
question types.

~~This is not quite as pretty for the typical case, so I'm not sure if it's the solution we want to run with. But it's a proposal for one fairly simple way to solve the issue.~~ It's prettier now 😄 

@pgk would you mind taking a look at this? It's my first Sensei PR 🎉 so I appreciate your feedback! 😄 

## Questions with long descriptions

### Before

<img width="1818" alt="screen shot on 2017-09-07 at 16 40 18" src="https://user-images.githubusercontent.com/842193/30181906-480293f0-93eb-11e7-9e2c-082bdb13720c.png">

---

### After

<img width="1790" alt="screen shot on 2017-09-08 at 15 35 39" src="https://user-images.githubusercontent.com/842193/30226160-6897ca8e-94ab-11e7-93b9-87fce81ff332.png">

---

## Questions without long descriptions (i.e. the ones that worked fine before)

### Before

<img width="1788" alt="screen shot on 2017-09-07 at 16 41 04" src="https://user-images.githubusercontent.com/842193/30181925-5d87e0c2-93eb-11e7-8c6b-5a33b347885a.png">

---

### After

<img width="1788" alt="screen shot on 2017-09-08 at 15 36 10" src="https://user-images.githubusercontent.com/842193/30226181-77fb550e-94ab-11e7-9c27-4a8b74136384.png">
