### PR TITLE
Change purchase button text when a course is free

### DIFF
--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -813,6 +813,22 @@ class Sensei_WC {
 		return get_posts( $paid_course_query_args );
 	}
 
+	public static function purchase_course_default_button_text( $product ) {
+
+		$price = $product->get_price();
+
+		$product_is_free = wc_price( $price ) == wc_price( 0 );
+
+		if ( $product_is_free ) {
+			$button_text = __( 'Register for this Course', 'woothemes-sensei' );
+		} else {
+			$button_text = __( 'Purchase this Course', 'woothemes-sensei' );
+		}
+
+		return $product->get_price_html() . ' - ' . $button_text;
+
+	}
+
 	/**
 	 * Show the WooCommerce add to cart button for the  current course
 	 *
@@ -889,7 +905,8 @@ class Sensei_WC {
 			<?php } ?>
 
 			<button type="submit" class="single_add_to_cart_button button alt">
-				<?php $button_text = $product->get_price_html() . ' - ' . __( 'Purchase this Course', 'woothemes-sensei' ); ?>
+				<?php $button_text = Sensei_WC::purchase_course_default_button_text( $product ); ?>
+
 				<?php
 				/**
 				 * Filter Add to Cart button text

--- a/lang/woothemes-sensei.pot
+++ b/lang/woothemes-sensei.pot
@@ -14,6 +14,7 @@ msgstr ""
 "X-Poedit-SearchPath-0: .\n"
 "X-Poedit-SearchPathExcluded-0: *.js\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
 #: includes/admin/class-sensei-learner-management.php:28
 msgid "Learner Management"
 msgstr ""
@@ -703,11 +704,11 @@ msgstr ""
 msgid "Paid Courses"
 msgstr ""
 
-#: includes/class-sensei-course.php:2878, includes/class-sensei-wc.php:953
+#: includes/class-sensei-course.php:2878, includes/class-sensei-wc.php:968
 msgid "log in"
 msgstr ""
 
-#: includes/class-sensei-course.php:2879, includes/class-sensei-wc.php:980
+#: includes/class-sensei-course.php:2879, includes/class-sensei-wc.php:995
 msgid "Or %1$s to access your purchased courses"
 msgstr ""
 
@@ -3231,23 +3232,27 @@ msgstr[1] ""
 msgid "complete purchase"
 msgstr ""
 
-#: includes/class-sensei-wc.php:892
+#: includes/class-sensei-wc.php:821
+msgid "Register for this Course"
+msgstr ""
+
+#: includes/class-sensei-wc.php:823
 msgid "Purchase this Course"
 msgstr ""
 
-#: includes/class-sensei-wc.php:960
+#: includes/class-sensei-wc.php:975
 msgid "This course is already in your cart, please proceed to %1$s, to gain access."
 msgstr ""
 
-#: includes/class-sensei-wc.php:1156
+#: includes/class-sensei-wc.php:1171
 msgid "Course details"
 msgstr ""
 
-#: includes/class-sensei-wc.php:1188
+#: includes/class-sensei-wc.php:1203
 msgid "View course: %1$s"
 msgstr ""
 
-#: includes/class-sensei-wc.php:1694
+#: includes/class-sensei-wc.php:1709
 msgid "The product you are buying contains a course you are already taking"
 msgstr ""
 


### PR DESCRIPTION
Fixes #720 

This relates to the button the user sees when viewing a course that is linked to a WooCommerce product, and that the user has not purchased or started yet.

Previously we would get text on the button like this for a free course (i.e. a product with a price of 0):

"$0.00 - Purchase this Course"

Now a free course has the following text:

"$0.00 - Register for this Course"

I went down a bit of a rabbit hole trying to write unit tests because of the WooCommerce integration. I posted on the P2 - p6rkRX-qL-p2