### PR TITLE
Learner Profiles: display correct url pattern when wp in custom folder

### DIFF
--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -462,7 +462,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		// Learner Profile settings
 
 		$profile_url_base = apply_filters( 'sensei_learner_profiles_url_base', __( 'learner', 'woothemes-sensei') );
-		$profile_url_example = trailingslashit( get_site_url() ) . $profile_url_base . '/%username%';
+		$profile_url_example = trailingslashit( get_home_url() ) . $profile_url_base . '/%username%';
 
 		$fields['learner_profile_enable'] = array(
 							'name' => __( 'Public learner profiles', 'woothemes-sensei' ),


### PR DESCRIPTION
Fixes #1881