### PR TITLE
Lesson: Allow Completing if Quiz has no questions

### DIFF
--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -423,7 +423,8 @@ class Sensei_Analysis_Course_List_Table extends WooThemes_Sensei_List_Table {
 					$lesson_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_completions', $lesson_args, $item ) );
 
 					$lesson_average_grade = __('n/a', 'woothemes-sensei');
-					if ( false != get_post_meta($item->ID, '_quiz_has_questions', true) ) {
+
+					if ( false != Sensei_Lesson::lesson_quiz_has_questions( $item->ID ) ) {
 						// Get Percent Complete
 						$grade_args = array(
 								'post_id' => $item->ID,

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -343,7 +343,7 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 				$course_title = $course_id ? get_the_title( $course_id ) : '';
 
 				$lesson_average_grade = __('n/a', 'woothemes-sensei');
-				if ( false != get_post_meta($item->ID, '_quiz_has_questions', true) ) {
+				if ( false != Sensei_Lesson::lesson_quiz_has_questions( $item->ID ) ) {
 					// Get Percent Complete
 					$grade_args = array( 
 							'post_id' => $item->ID,

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1031,7 +1031,7 @@ class Sensei_Course {
 			$lesson_ids = Sensei()->course->course_lessons( $course_id, 'any', 'ids' );
 
 			foreach( $lesson_ids as $lesson_id ) {
-				$has_questions = get_post_meta( $lesson_id, '_quiz_has_questions', true );
+				$has_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
 				if ( $has_questions && $boolean_check ) {
 					return true;
 				}

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -894,21 +894,15 @@ class Sensei_Frontend {
 		global  $post;
 
 		$quiz_id = 0;
+		$lesson_id = $post->ID;
 
 		//make sure user is taking course
-		$course_id = Sensei()->lesson->get_course_id( $post->ID );
+		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
 		if( ! Sensei_Utils::user_started_course( $course_id, get_current_user_id() ) ){
 			return;
 		}
 
-		// Lesson quizzes
-		$quiz_id = Sensei()->lesson->lesson_quizzes( $post->ID );
-		$pass_required = true;
-		if( $quiz_id ) {
-			// Get quiz pass setting
-	    	$pass_required = get_post_meta( $quiz_id, '_pass_required', true );
-	    }
-		if( ! $quiz_id || ( $quiz_id && ! $pass_required ) ) {
+		if( false === Sensei()->lesson->lesson_has_quiz_with_questions_and_pass_required( $lesson_id ) ) {
 			?>
 			<form class="lesson_button_form" method="POST" action="<?php echo esc_url( get_permalink() ); ?>">
 	            <input type="hidden"

--- a/includes/class-sensei-learners-main.php
+++ b/includes/class-sensei-learners-main.php
@@ -297,7 +297,7 @@ class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 				$a_title = sprintf( __( 'Edit &#8220;%s&#8221;' ), $title );
 
 				$grading_action = '';
-				if ( get_post_meta( $item->ID, '_quiz_has_questions', true ) ) {
+				if ( Sensei_Lesson::lesson_quiz_has_questions( $item->ID ) ) {
 					$grading_action = ' <a class="button" href="' . esc_url( add_query_arg( array( 'page' => 'sensei_grading', 'lesson_id' => $item->ID, 'course_id' => $this->course_id ), admin_url( 'admin.php' ) ) ) . '">' . __( 'Grading', 'woothemes-sensei' ) . '</a>';
 				}
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3846,8 +3846,7 @@ class Sensei_Lesson {
 			<?php
 			if( $show_actions && $quiz_id && Sensei()->access_settings() ) {
 
-				$has_quiz_questions = get_post_meta( $lesson_id, '_quiz_has_questions', true );
-				if( $has_quiz_questions ) {
+				if( self::lesson_quiz_has_questions( $lesson_id ) ) {
 					?>
 
 					<p>
@@ -3923,7 +3922,7 @@ class Sensei_Lesson {
 
 		if ( $quiz_id && is_user_logged_in()
 			&& Sensei_Utils::user_started_course( $lesson_course_id, $user_id ) ) {
-			$has_quiz_questions = get_post_meta( $lesson_id, '_quiz_has_questions', true );
+			$has_quiz_questions = self::lesson_quiz_has_questions( $lesson_id );
 
 			// Display lesson quiz status message
 			if ( $has_user_completed_lesson || $has_quiz_questions ) {
@@ -3991,7 +3990,7 @@ class Sensei_Lesson {
 		    return false;
         }
 
-		$has_quiz_questions = (bool)get_post_meta( $lesson_id, '_quiz_has_questions', true );
+		$has_quiz_questions = self::lesson_quiz_has_questions( $lesson_id );
 		if ( false === $has_quiz_questions ) {
 		    return false;
         }
@@ -3999,6 +3998,16 @@ class Sensei_Lesson {
 		$pass_required = (bool) get_post_meta( $quiz_id, '_pass_required', true );
 
 		return $pass_required;
+    }
+
+	/**
+     * Lesson Quiz Has Questions
+     *
+	 * @param int $lesson_id Lesson.
+	 * @return bool
+	 */
+    public static function lesson_quiz_has_questions( $lesson_id ) {
+		return (bool) get_post_meta( $lesson_id, '_quiz_has_questions', true );
     }
 
 } // End Class

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3923,8 +3923,6 @@ class Sensei_Lesson {
 
 		if ( $quiz_id && is_user_logged_in()
 			&& Sensei_Utils::user_started_course( $lesson_course_id, $user_id ) ) {
-
-			$no_quiz_count = 0;
 			$has_quiz_questions = get_post_meta( $lesson_id, '_quiz_has_questions', true );
 
 			// Display lesson quiz status message
@@ -3978,6 +3976,30 @@ class Sensei_Lesson {
 		));
 
 	}
+
+	/**
+     * Checks if a lesson has a "Complete" quiz that requires the passmark to be achieved
+     * before progressing. A complete quiz has at least one question.
+     *
+	 * @param int $lesson_id The Lesson.
+	 * @return bool
+	 */
+    public function lesson_has_quiz_with_questions_and_pass_required( $lesson_id ) {
+		// Lesson quizzes
+		$quiz_id = $this->lesson_quizzes( $lesson_id );
+		if ( empty( $quiz_id ) ) {
+		    return false;
+        }
+
+		$has_quiz_questions = (bool)get_post_meta( $lesson_id, '_quiz_has_questions', true );
+		if ( false === $has_quiz_questions ) {
+		    return false;
+        }
+
+		$pass_required = (bool) get_post_meta( $quiz_id, '_pass_required', true );
+
+		return $pass_required;
+    }
 
 } // End Class
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1074,7 +1074,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
          $lesson_id = $this->get_lesson_id($post->ID);
 
-         $has_questions = get_post_meta( $lesson_id, '_quiz_has_questions', true );
+         $has_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
 
          $lesson = get_post($lesson_id);
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -685,7 +685,7 @@ class Sensei_Utils {
 
 			if( $complete ) {
 
-				$has_questions = get_post_meta( $lesson_id, '_quiz_has_questions', true );
+				$has_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
 				if ( $has_questions ) {
 					$status = 'passed'; // Force a pass
 					$metadata['grade'] = 0;
@@ -1108,7 +1108,7 @@ class Sensei_Utils {
 			foreach( $lessons as $lesson ) {
 
 				// Check for lesson having questions, thus a quiz, thus having a grade
-				$has_questions = get_post_meta( $lesson->ID, '_quiz_has_questions', true );
+				$has_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson->ID );
 				if ( $has_questions ) {
 					$user_lesson_status = Sensei_Utils::user_lesson_status( $lesson->ID, $user_id );
 
@@ -1266,7 +1266,7 @@ class Sensei_Utils {
 			$pass_required = get_post_meta( $quiz_id, '_pass_required', true );
 
 			// Quiz questions
-			$has_quiz_questions = get_post_meta( $lesson_id, '_quiz_has_questions', true );
+			$has_quiz_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
 
 			if ( ! $started_course ) {
 

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -58,7 +58,7 @@ global $course;
                 foreach( $lessons as $lesson ) {
 
                     $lesson_grade = 'n/a';
-                    $has_questions = get_post_meta( $lesson->ID, '_quiz_has_questions', true );
+                    $has_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson->ID );
                     if ( $has_questions ) {
                         $lesson_status = Sensei_Utils::user_lesson_status( $lesson->ID, get_current_user_id() );
                         // Get user quiz grade
@@ -112,7 +112,7 @@ global $course;
 
                 <?php
                 $lesson_grade = 'n/a';
-                $has_questions = get_post_meta( $lesson->ID, '_quiz_has_questions', true );
+                $has_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson->ID );
                 if ( $has_questions ) {
                     $lesson_status = Sensei_Utils::user_lesson_status( $lesson->ID, get_current_user_id());
                     // Get user quiz grade


### PR DESCRIPTION
Even if "The passmark must be achieved before the lesson is complete" is
enabled, If the quiz has no questions we should display the Complete
Lesson button.

fixes #1860