### PR TITLE
Fix issue with slashes in gap fill question answers

### DIFF
--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -262,18 +262,18 @@ class Sensei_Grading {
 		global  $wp_version;
 
 		$title = $this->name;
-		if ( isset( $_GET['course_id'] ) ) { 
+		if ( isset( $_GET['course_id'] ) ) {
 			$course_id = intval( $_GET['course_id'] );
 			if ( version_compare($wp_version, '4.1', '>=') ) {
 				$title .= '<span class="course-title">&gt;&nbsp;&nbsp;'.get_the_title( $course_id ).'</span>';
 			}
 			else {
-				$title .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;%s</span>', get_the_title( $course_id ) ); 
+				$title .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;%s</span>', get_the_title( $course_id ) );
 			}
 		}
-		if ( isset( $_GET['lesson_id'] ) ) { 
+		if ( isset( $_GET['lesson_id'] ) ) {
 			$lesson_id = intval( $_GET['lesson_id'] );
-			$title .= '&nbsp;&nbsp;<span class="lesson-title">&gt;&nbsp;&nbsp;' . get_the_title( intval( $lesson_id ) ) . '</span>'; 
+			$title .= '&nbsp;&nbsp;<span class="lesson-title">&gt;&nbsp;&nbsp;' . get_the_title( intval( $lesson_id ) ) . '</span>';
 		}
 		if ( isset( $_GET['user_id'] ) && 0 < intval( $_GET['user_id'] ) ) {
 
@@ -295,7 +295,7 @@ class Sensei_Grading {
 		global  $wp_version;
 
 		$title =  $this->name;
-		if ( isset( $_GET['quiz_id'] ) ) { 
+		if ( isset( $_GET['quiz_id'] ) ) {
 			$quiz_id = intval( $_GET['quiz_id'] );
 			$lesson_id = get_post_meta( $quiz_id, '_quiz_lesson', true );
 			$course_id = get_post_meta( $lesson_id, '_lesson_course', true );
@@ -304,7 +304,7 @@ class Sensei_Grading {
 				$title .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 			}
 			else {
-				$title .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;%s</span>', get_the_title( $course_id ) ); 
+				$title .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;%s</span>', get_the_title( $course_id ) );
 			}
 			$url = add_query_arg( array( 'page' => $this->page_slug, 'lesson_id' => $lesson_id ), admin_url( 'admin.php' ) );
 			$title .= sprintf( '&nbsp;&nbsp;<span class="lesson-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $lesson_id ) );
@@ -913,59 +913,25 @@ class Sensei_Grading {
          */
         $do_case_sensitive_comparison = apply_filters('sensei_gap_fill_case_sensitive_grading', false );
 
-        if( $do_case_sensitive_comparison ){
+		$regex_modifier = '';
+		if ( $do_case_sensitive_comparison ) {
+			$is_exact_answer_match = trim( $user_answer ) === trim( $gapfill_array[1] );
+		} else {
+			$is_exact_answer_match = trim( strtolower( $user_answer ) ) === trim( strtolower( $gapfill_array[1] ) );
+			$regex_modifier = 'i';
+		}
 
-            // Case Sensitive Check that the 'gap' is "exactly" equal to the given answer
-            if ( trim(($gapfill_array[1])) == trim( $user_answer ) ) {
+		$regex_answer_check = '/' . addcslashes( $gapfill_array[1], '/' ) . '/' . $regex_modifier;
 
-                return Sensei()->question->get_question_grade( $question_id );
+		if (
+			$is_exact_answer_match
+			|| 1 === @preg_match( $regex_answer_check, $user_answer )
+		) {
+			return Sensei()->question->get_question_grade( $question_id );
+		}
 
-            } else if (@preg_match('/' . $gapfill_array[1] . '/i', null) !== FALSE) {
-
-                if (preg_match('/' . $gapfill_array[1] . '/i', $user_answer)) {
-
-                    return Sensei()->question->get_question_grade($question_id);
-
-                }else{
-
-                    return false;
-
-                }
-
-            }else{
-
-                return false;
-
-            }
-
-        }else{
-
-            // Case Sensitive Check that the 'gap' is "exactly" equal to the given answer
-            if ( trim(strtolower($gapfill_array[1])) == trim(strtolower( $user_answer )) ) {
-
-               return Sensei()->question->get_question_grade( $question_id );
-
-            } else if (@preg_match('/' . $gapfill_array[1] . '/i', null) !== FALSE) {
-
-                if (preg_match('/' . $gapfill_array[1] . '/i', $user_answer)) {
-
-                    return  Sensei()->question->get_question_grade( $question_id );
-
-                }else{
-
-                    return false;
-
-                }
-
-            }else{
-
-                return false;
-
-            }
-
-        }
-
-    }
+		return false;
+	}
 
     /**
      * Counts the lessons that have been graded manually and automatically

--- a/tests/framework/factories/Sensei-Factory.php
+++ b/tests/framework/factories/Sensei-Factory.php
@@ -394,7 +394,7 @@ class Sensei_Factory extends  WP_UnitTest_Factory{
         foreach( range( 0, ( $number - 1 ) )  as $count ) {
 
             //make sure that at least on question from each type is included
-            if( $count < ( count( $question_types ) )  ){
+            if( $count < count( $question_types ) ){
 
                 //setup the question type at the current index
                 $type =  $question_type_slugs[ $count ];
@@ -407,52 +407,7 @@ class Sensei_Factory extends  WP_UnitTest_Factory{
 
             }
 
-            $test_question_data = array(
-                'question_type' => $type ,
-                'question_category' => 'undefined' ,
-                'action' => 'add',
-                'question' => 'Is this a sample' . $type  . ' question ? _ ' . rand() ,
-                'question_grade' => '1' ,
-                'answer_feedback' => 'Answer Feedback sample ' . rand() ,
-                'question_description' => ' Basic description for the question' ,
-                'question_media' => '' ,
-                'answer_order' => '' ,
-                'random_order' => 'yes' ,
-                'question_count' => $number
-            );
-
-            // setup the right / wrong answers base on the question type
-            if ('multiple-choice' == $type ) {
-
-                $test_question_data['question_right_answers'] = array( 'right' ) ;
-                $test_question_data['question_wrong_answers'] = array( 'wrong1', 'wrong2',  'wrong3' )  ;
-
-            } elseif ('boolean' == $type ) {
-
-                $test_question_data[ 'question_right_answer_boolean' ] = true;
-
-            } elseif ( 'single-line' == $type  ) {
-
-                $test_question_data[ 'add_question_right_answer_singleline' ] = '';
-
-            } elseif ( 'gap-fill' == $type ) {
-
-                $test_question_data[ 'add_question_right_answer_gapfill_pre' ] = '';
-                $test_question_data[ 'add_question_right_answer_gapfill_gap' ] = '';
-                $test_question_data[ 'add_question_right_answer_gapfill_post'] = '';
-
-            } elseif ( 'multi-line' == $type  ) {
-
-                $test_question_data [ 'add_question_right_answer_multiline' ] = '';
-
-            } elseif ( 'file-upload' == $type ) {
-
-                $test_question_data [ 'add_question_right_answer_fileupload'] = '';
-                $test_question_data [ 'add_question_wrong_answer_fileupload' ] = '';
-
-            }
-
-            $sample_questions[] = $test_question_data;
+            $sample_questions[] = $this->get_sample_question_data( $type, $number );
         }
 
         // create the requested number tests from the sample questions
@@ -473,6 +428,54 @@ class Sensei_Factory extends  WP_UnitTest_Factory{
         return $chosen_questions;
 
     }// end generate_and_attach_questions
+
+	public function get_sample_question_data( $type, $number = 0 ) {
+		$test_question_data = array(
+			'question_type' => $type ,
+			'question_category' => 'undefined' ,
+			'action' => 'add',
+			'question' => 'Is this a sample' . $type  . ' question ? _ ' . rand() ,
+			'question_grade' => '1' ,
+			'answer_feedback' => 'Answer Feedback sample ' . rand() ,
+			'question_description' => ' Basic description for the question' ,
+			'question_media' => '' ,
+			'answer_order' => '' ,
+			'random_order' => 'yes' ,
+			'question_count' => $number
+		);
+
+		// setup the right / wrong answers base on the question type
+		if ('multiple-choice' == $type ) {
+
+			$test_question_data['question_right_answers'] = array( 'right' ) ;
+			$test_question_data['question_wrong_answers'] = array( 'wrong1', 'wrong2',  'wrong3' )  ;
+
+		} elseif ('boolean' == $type ) {
+
+			$test_question_data[ 'question_right_answer_boolean' ] = true;
+
+		} elseif ( 'single-line' == $type  ) {
+
+			$test_question_data[ 'add_question_right_answer_singleline' ] = '';
+
+		} elseif ( 'gap-fill' == $type ) {
+
+			$test_question_data[ 'add_question_right_answer_gapfill_pre' ] = '';
+			$test_question_data[ 'add_question_right_answer_gapfill_gap' ] = '';
+			$test_question_data[ 'add_question_right_answer_gapfill_post'] = '';
+
+		} elseif ( 'multi-line' == $type  ) {
+
+			$test_question_data [ 'add_question_right_answer_multiline' ] = '';
+
+		} elseif ( 'file-upload' == $type ) {
+
+			$test_question_data [ 'add_question_right_answer_fileupload'] = '';
+			$test_question_data [ 'add_question_wrong_answer_fileupload' ] = '';
+
+		}
+		return $test_question_data;
+	}
 
     /**
      * This functions take answers submitted by a user, extracts ones that is of type file-upload

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -1,14 +1,6 @@
 <?php
 
 class Sensei_Class_Grading_Test extends WP_UnitTestCase {
-
-    /**
-     * Constructor function
-     */
-    public function __construct(){
-        parent::__construct();
-    }
-
     /**
      * setup function
      *
@@ -33,4 +25,111 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
         $this->assertTrue(isset(Sensei()->grading), 'Sensei Grading class is not loaded');
 
     } // end testClassInstance
+
+	/**
+	 * Data source for ::testGradeGapFillQuestionRegEx
+	 * @return array
+	 */
+	public function gradeGapFillQuestions() {
+		return array(
+			'simple-partial-word-case-insensitive' => array(
+				'correct|Answer|simple',
+				array( 'correct|Answer|simple', 'Correct', 'answer', 'correct', 'answer|simple' ),
+				array( 'r|s', '|', 'bad' ),
+				false,
+			),
+			'complete-word-only' => array(
+				'^correct|Answer|simple$',
+				array( 'Correct', 'answer', 'correct' ),
+				array( 'incorrect' ),
+				false,
+			),
+			'simple-case-sensitive' => array(
+				'correct|Answer|simple',
+				array( 'simple', 'Answer', 'correct' ),
+				array( 'r|s', '|', 'Correct', 'answer' ),
+				true,
+			),
+			// See: https://github.com/Automattic/sensei/issues/1721
+			'with-forward-slash' => array(
+				'some|text|1.4|13/4',
+				array( 'some|text|1.4|13/4', 'some', 'text', '1.4', '13/4' ),
+				array( 'Some', 'Text', '4|13', '4' ),
+				true,
+			),
+			'with-several-forward-slash' => array(
+				'some|text|1.4|13/4|13//3',
+				array( 'some', 'text', '1.4', '13/4', '13//3' ),
+				array( 'Some', 'Text', '4|13', '4', '13' ),
+				true,
+			),
+			'all-valid' => array(
+				'.+',
+				array( 'some', 'text', 'dinosaur', '1', '0' ),
+				array(),
+				false,
+			),
+			'all-words-ending-in-s' => array(
+				'^[a-z]+s$',
+				array( 'chickens', 'precious', 'dinosaurs' ),
+				array( 'pie', 'beer', 'bread', 'spacepeople', '20' ),
+				false,
+			),
+			'all-basic-integers' => array(
+				'^[0-9]+$',
+				array( '1', 1, '200', '34' ),
+				array( '2e10', '2.2', 4.4, 'monkey', '' ),
+				false,
+			),
+			'invalid-regex' => array(
+				'[some|text|1.4|13/4',
+				array( '[some|text|1.4|13/4' ),
+				array( 'Some', 'Text', '4|13', '4', 'some', 'text', '1.4', '13/4'  ),
+				false,
+			),
+		);
+	} // end gradeGapFillQuestions
+
+	/**
+	 * @dataProvider gradeGapFillQuestions
+	 * @covers Sensei_Grading::grade_gap_fill_question
+	 * @since 1.9.18
+	 */
+	public function testGradeGapFillQuestionRegEx( $answer, $found, $not_found, $case_sensitive ) {
+		// Set up question
+		$question_id = $this->getTestQuestion( 'gap-fill' );
+		$this->assertNotFalse( $question_id );
+		update_post_meta( $question_id, '_question_right_answer', 'pre||' . $answer . '||post' );
+		if ( $case_sensitive ) {
+			remove_filter( 'sensei_gap_fill_case_sensitive_grading', '__return_false' );
+			add_filter( 'sensei_gap_fill_case_sensitive_grading', '__return_true' );
+		} else {
+			remove_filter( 'sensei_gap_fill_case_sensitive_grading', '__return_true' );
+			add_filter( 'sensei_gap_fill_case_sensitive_grading', '__return_false' );
+		}
+		foreach ( $found as $found_item ) {
+			$response = Sensei_Grading::grade_gap_fill_question( $question_id, $found_item );
+			$this->assertEquals( 1, $response, "Expecting {$found_item} to match {$answer}" );
+		}
+		foreach ( $not_found as $not_found_item ) {
+			$response = Sensei_Grading::grade_gap_fill_question( $question_id, $not_found_item );
+			$this->assertFalse( $response, "Expecting {$not_found_item} to not match {$answer}" );
+		}
+	} // end testGradeGapFillQuestionRegEx
+
+	/**
+	 * Get a test question.
+	 *
+	 * @param string $question_type
+	 * @return bool|int
+	 */
+	private function getTestQuestion( $question_type ) {
+		$lesson_id = $this->factory->get_random_lesson_id();
+		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+
+		$question = $this->factory->get_sample_question_data( $question_type );
+		$question[ 'quiz_id' ] = $quiz_id;
+		$question[ 'post_author'] = get_post( $quiz_id )->post_author;
+		return Sensei()->lesson->lesson_save_question( $question );
+	} // end getTestQuestion
 }// end Class


### PR DESCRIPTION
Fixes #1721 

This PR:
- Fixes the issue in #1721 
- Fixes issue where comparison was being done case-insensitively when `sensei_gap_fill_case_sensitive_grading` filtered to true. 
- Adds tests for `Sensei_Grading::grade_gap_fill_question()`

Testing: See #1721 