### PR TITLE
Don't show the contact button if corresponding setting is not selected

### DIFF
--- a/includes/class-sensei-emails.php
+++ b/includes/class-sensei-emails.php
@@ -407,6 +407,9 @@ class Sensei_Emails {
 		if( $send ) {
 			$email = $this->emails['teacher-new-message'];
 			$email->trigger( $message_id );
+		} else {
+			wp_safe_redirect( esc_url_raw( add_query_arg( array( 'send' => 'complete' ) ) ) );
+			exit;
 		}
 	}
 


### PR DESCRIPTION
Addresses #1745.

~~It's not clear to me why the _A learner sends a private message to a teacher_ setting is needed when we already have the _Disable Private Messages_ setting. Is there a difference between the two? If so, then we should clarify the language better as it's not obvious. If they're the same, then we should get rid of the redundant setting.~~

Update: _A learner sends a private message to a teacher_ only disables the email notification. Messages can still be sent and viewed in the Messages section of wp-admin.

## Testing
1. In the _General_ settings, ensure that the _Disable Private Messages_ checkbox is **not** selected. 
2. In the _Email Notifications_ settings, ensure the _A learner sends a private message to a teacher_ setting is **not** selected.
3. Browse to a specific course.
4. Click the _Contact Course Teacher_ button.
5. Enter a private message and click the _Send Message_ button.
6. The confirmation message _Your private message has been sent._ should appear:
![confirmation-message](https://user-images.githubusercontent.com/1190420/31122961-fa0c38f6-a80b-11e7-9a3f-159ad12326ea.jpg)
7. The message should be visible in the _Messages_ section of WP Admin, but an email containing the message should **not** be sent.