### PR TITLE
My-Courses: Tabs as Filters

### DIFF
--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -62,15 +62,15 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	protected $status;
 
 	/**
-     * Are we in my-courses?
-     *
+	 * Are we in my-courses?
+	 *
 	 * @var bool
 	 */
 	private $in_my_courses_page = false;
 
 	/**
-     * Current Page ID
-     *
+	 * Current Page ID
+	 *
 	 * @var int
 	 */
 	private $page_id = 0;
@@ -85,6 +85,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	 */
 	public function __construct( $attributes, $content, $shortcode ) {
 		global $wp_query;
+		$attributes = shortcode_atts( array(), $attributes, $shortcode );
 		$this->page_id = $wp_query->get_queried_object_id();
 		if ( ! isset( $attributes['status'] ) && $this->is_my_courses() ) {
 			$this->in_my_courses_page = true;


### PR DESCRIPTION
As It stands, the tabbed interface and the way it is implemented, is confusing.

1. Pagination is broken (and if you set it to a custom number, it is ignored)
2. Because the way the above works, at any given page you might get no active or no complete courses at all but on the next there might be more.

This PR is the first of a two-part enhancement. It's goal is to have the tabs work as filters

![screen shot 2017-10-03 at 16 24 50](https://user-images.githubusercontent.com/500744/31127553-ff720c8e-a857-11e7-89ac-6751f6ca3c9f.png)

When I click on another tab, that filter activates. 

The follow up PR will do some progressive enhancement, by fetching the filter results via ajax and pushing the new state to browser history.

### Testing

Just go to My-Courses and play around with the tabs. One specific concern of mine is that maybe those should look more like a radio button or a select. For now they look similar to what was already there.

closes #1914 
closes #1657
closes #1711