### PR TITLE
Preserve course modules on author change

### DIFF
--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -429,7 +429,9 @@ class Sensei_Teacher {
                 wp_set_object_terms( $course_id, $term_id , 'module', true );
 
                 // remove old term
-                wp_remove_object_terms( $course_id, $term->term_id, 'module' );
+                if ( $term_id !== $term->term_id ) {
+                    wp_remove_object_terms( $course_id, $term->term_id, 'module' );
+                }
 
                 // update the lessons within the current module term
                 $lessons = Sensei()->course->course_lessons( $course_id );


### PR DESCRIPTION
Fixes #1661 
Replaces #1662 (Along with the PR #1920)

To test, create a course assigned to modules that have lessons. Change the author to someone else. Verify the course module remains assigned to the course.