### PR TITLE
Course Admin: Show the add lesson link even when the course has lessons

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -525,13 +525,13 @@ class Sensei_Course {
 
 		}
 		$html .= '<p>';
-		if ( count( $posts_array ) == 0 ) {
+		if ( 0 === count( $posts_array ) ) {
 		    $html .= esc_html__( 'No lessons exist yet for this course.', 'woothemes-sensei' ) . "\n";
 		} else {
 			$html .= '<hr />';
         }
         $html .= '<a href="' . $add_lesson_admin_url
-            . '" title="' . esc_attr( __( 'Add a Lesson', 'woothemes-sensei' ) ) . '">';
+            . '" title="' . esc_attr__( 'Add a Lesson', 'woothemes-sensei' ) . '">';
 		if ( count( $posts_array ) < 1 ) {
 			$html .= esc_html__( 'Please add some.', 'woothemes-sensei' );
 		} else {

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -506,6 +506,9 @@ class Sensei_Course {
                  . esc_attr( 'woo_' . $this->token . '_noonce' )
                  . '" value="' . esc_attr( wp_create_nonce( plugin_basename(__FILE__) ) ) . '" />';
 
+		$course_id = ( 0 < $post->ID ) ? '&course_id=' . $post->ID : '';
+		$add_lesson_admin_url = admin_url( 'post-new.php?post_type=lesson' . $course_id );
+
 		if ( count( $posts_array ) > 0 ) {
 
 			foreach ($posts_array as $post_item){
@@ -519,17 +522,26 @@ class Sensei_Course {
 
 			} // End For Loop
 
+
+		}
+		$html .= '<p>';
+		if ( count( $posts_array ) == 0 ) {
+		    $html .= esc_html__( 'No lessons exist yet for this course.', 'woothemes-sensei' ) . "\n";
 		} else {
-			$course_id = '';
-			if ( 0 < $post->ID ) { $course_id = '&course_id=' . $post->ID; }
-			$html .= '<p>' . esc_html( __( 'No lessons exist yet for this course.', 'woothemes-sensei' ) ) . "\n";
+			$html .= '<hr />';
+        }
+        $html .= '<a href="' . $add_lesson_admin_url
+            . '" title="' . esc_attr( __( 'Add a Lesson', 'woothemes-sensei' ) ) . '">';
+		if ( count( $posts_array ) < 1 ) {
+			$html .= esc_html__( 'Please add some.', 'woothemes-sensei' );
+		} else {
 
-				$html .= '<a href="' . admin_url( 'post-new.php?post_type=lesson' . $course_id )
-                         . '" title="' . esc_attr( __( 'Add a Lesson', 'woothemes-sensei' ) ) . '">'
-                         . __( 'Please add some.', 'woothemes-sensei' ) . '</a>' . "\n";
+			$html .=  esc_html__( '+ Add Another Lesson', 'woothemes-sensei' );
+        }
 
-			$html .= '</p>'."\n";
-		} // End If Statement
+
+        $html .= '</a></p>';
+
 
 		echo $html;
 


### PR DESCRIPTION
While I can add a lesson to a course that has none, I should be able to do the same when it has some.

This PR Adds a link for creating a new Lesson for a course even when the course *has* Lessons.

Looks like this 

![screen shot 2017-10-03 at 18 10 05](https://user-images.githubusercontent.com/500744/31132711-2f33ef9c-a866-11e7-8fa7-f34c54a84b55.png)


