### PR TITLE
Prevent 'Enter' from submitting a quiz

### DIFF
--- a/templates/single-quiz.php
+++ b/templates/single-quiz.php
@@ -37,7 +37,7 @@
 
 	        <?php if ( sensei_quiz_has_questions() ): ?>
 
-	            <form method="POST" action="<?php echo esc_url_raw( get_permalink() ); ?>" enctype="multipart/form-data">
+	            <form method="POST" action="<?php echo esc_url_raw( get_permalink() ); ?>" enctype="multipart/form-data" onkeypress="return event.keyCode !== 13;">
 
 	                <?php
 


### PR DESCRIPTION
This PR prevents `Enter` from submitting a quiz when pressed. ( #1654 )

# Testing

Open a quiz with at least one single-line text field and try pressing enter - it shouldn't trigger the form to submit.