### PR TITLE
Unpublished products should never be purchasable

### DIFF
--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -1688,6 +1688,10 @@ class Sensei_WC {
 
 		$course_product = wc_get_product( $course_product_id );
 
+		if ( 'publish' !== $course_product->get_status() ) {
+			return false;
+		}
+
 		return $course_product->is_purchasable();
 
 	}


### PR DESCRIPTION
Fixes #1916

Admins used to see buttons for purchasing trashed products. 

Testing instruction in issue.