### PR TITLE
Inherit button colours from theme

### DIFF
--- a/assets/css/frontend/sensei.css
+++ b/assets/css/frontend/sensei.css
@@ -341,9 +341,6 @@ a.sensei-certificate-link {
 .quiz form input.quiz-submit {
   margin-right: 10px; }
 
-.quiz input.quiz-submit.complete, .lesson input.quiz-submit.complete {
-  background: #63a95f; }
-
 .quiz input.quiz-submit.reset, .lesson input.quiz-submit.reset {
   background: #ed6c6c; }
 
@@ -746,8 +743,6 @@ section.entry span.course-price {
 .quiz button.button {
   display: inline-block;
   padding: 5px 20px 4px;
-  border: none;
-  color: #fff;
   text-align: center;
   text-shadow: none;
   text-decoration: none;
@@ -776,7 +771,6 @@ section.entry span.course-price {
   -moz-background-clip: padding;
   -webkit-background-clip: padding-box;
   background-clip: padding-box;
-  background: #52a8e8;
   -webkit-box-shadow: none;
   -moz-box-shadow: none;
   box-shadow: none; }
@@ -805,9 +799,7 @@ section.entry span.course-price {
   .quiz input[type=submit]:hover,
   .quiz input.button:hover,
   .quiz button.button:hover {
-    text-decoration: none;
-    color: #fff;
-    background: #3b9de5; }
+    text-decoration: none; }
   .course-container a.button:active, .course-container a.button:visited:active,
   .course-container a.comment-reply-link:active,
   .course-container #commentform #submit:active,
@@ -833,7 +825,6 @@ section.entry span.course-price {
   .quiz input[type=submit]:active,
   .quiz input.button:active,
   .quiz button.button:active {
-    border-color: #005393;
     -webkit-box-shadow: inset 0 0 7px rgba(0, 0, 0, 0.3), 0 1px 0 white;
     -moz-box-shadow: inset 0 0 7px rgba(0, 0, 0, 0.3), 0 1px 0 white;
     box-shadow: inset 0 0 7px rgba(0, 0, 0, 0.3), 0 1px 0 white; }

--- a/assets/css/frontend/sensei.css
+++ b/assets/css/frontend/sensei.css
@@ -89,7 +89,6 @@ a.view-results-link,
 a.sensei-certificate-link {
   display: inline-block;
   padding: .236em .857em;
-  background: #e6e6e6;
   float: right;
   margin-left: .236em;
   padding: .382em 1em;
@@ -98,7 +97,6 @@ a.sensei-certificate-link {
   -moz-background-clip: padding;
   -webkit-background-clip: padding-box;
   background-clip: padding-box;
-  color: #fff;
   font-weight: bold;
   text-decoration: none; }
 
@@ -125,6 +123,9 @@ a.sensei-certificate-link {
       position: relative;
       top: .2em;
       margin-bottom: 0.618em; }
+    #main .course .course-meta .view-results, #main .course-container .course-meta .view-results {
+      background: #e6e6e6;
+      color: #fff; }
   #main .course .sensei-course-meta, #main .course-container .sensei-course-meta {
     font-style: italic;
     font-size: .9em;
@@ -715,6 +716,15 @@ section.entry span.course-price {
     .sensei p.sensei-message a.next-lesson:hover, .sensei div.sensei-message a.next-lesson:hover, .course-container p.sensei-message a.next-lesson:hover, .course-container div.sensei-message a.next-lesson:hover, .course p.sensei-message a.next-lesson:hover, .course div.sensei-message a.next-lesson:hover, .lesson p.sensei-message a.next-lesson:hover, .lesson div.sensei-message a.next-lesson:hover, .quiz p.sensei-message a.next-lesson:hover, .quiz div.sensei-message a.next-lesson:hover, .learner-info p.sensei-message a.next-lesson:hover, .learner-info div.sensei-message a.next-lesson:hover {
       background: #63a95f;
       color: #fff; }
+
+.button {
+  color: #fff;
+  background: #52a8e8; }
+  .button:hover {
+    color: #fff;
+    background: #3b9de5; }
+  .button:visited {
+    color: #fff; }
 
 .course-container a.button, .course-container a.button:visited,
 .course-container a.comment-reply-link,

--- a/assets/css/frontend/sensei.scss
+++ b/assets/css/frontend/sensei.scss
@@ -809,6 +809,10 @@ section.entry span.course-price { padding-left: 10px; }
     color: #fff;
     background: darken($color_links, 5%);
   }
+
+  &:visited {
+    color: #fff;
+  }
 }
 
 .course-container, .course, .lesson, .quiz  {

--- a/assets/css/frontend/sensei.scss
+++ b/assets/css/frontend/sensei.scss
@@ -57,12 +57,10 @@ a.view-results-link,
 a.sensei-certificate-link {
   display: inline-block;
   padding: .236em .857em;
-  background: $border_main;
   float: right;
   margin-left: .236em;
   padding: .382em 1em;
   @include border_radius(5px);
-  color: #fff;
   font-weight: bold;
   text-decoration: none;
 }
@@ -86,6 +84,11 @@ a.sensei-certificate-link {
       position: relative;
       top: .2em;
       margin-bottom: 0.618em;
+    }
+
+    .view-results {
+      background: $border_main;
+      color: #fff;
     }
   }
   .sensei-course-meta  {

--- a/assets/css/frontend/sensei.scss
+++ b/assets/css/frontend/sensei.scss
@@ -342,9 +342,6 @@ a.sensei-certificate-link {
 
 .quiz, .lesson  {
   input.quiz-submit  {
-    &.complete  {
-      background: $success;
-    }
     &.reset  {
       background: $error;
     }
@@ -811,8 +808,6 @@ section.entry span.course-price { padding-left: 10px; }
   button.button {
     display: inline-block;
     padding: 5px 20px 4px;
-    border: none;
-    color: #fff;
     text-align: center;
     text-shadow: none;
     text-decoration: none;
@@ -829,19 +824,15 @@ section.entry span.course-price { padding-left: 10px; }
     -webkit-appearance: none;
 
     @include border_radius(5px);
-    background: $color_links;
     -webkit-box-shadow: none;
     -moz-box-shadow: none;
     box-shadow: none;
 
     &:hover {
       text-decoration: none;
-      color: #fff;
-      background: darken($color_links, 5%);
     }
 
     &:active {
-      border-color: $color_links - #555;
       -webkit-box-shadow: inset 0 0 7px hsla(0,0%,0%,.3),
       0 1px 0 hsla(0, 100%, 100%, 1);
       -moz-box-shadow: inset 0 0 7px hsla(0,0%,0%,.3),

--- a/assets/css/frontend/sensei.scss
+++ b/assets/css/frontend/sensei.scss
@@ -801,6 +801,16 @@ section.entry span.course-price { padding-left: 10px; }
   }
 }
 
+.button {
+  color: #fff;
+  background: $color_links;
+
+  &:hover {
+    color: #fff;
+    background: darken($color_links, 5%);
+  }
+}
+
 .course-container, .course, .lesson, .quiz  {
   a.button, a.button:visited,
   a.comment-reply-link,


### PR DESCRIPTION
See p6rkRX-qU-p2 for more details, but essentially this requires communicating with our users before releasing, as they will undoubtedly wonder why their buttons have changed:

> Prior to release, we could let both HEs and our users know what we are planning to do, how it will potentially affect them, and what they can do if they don’t like the changes. We can also put this in a major release since it’s essentially a breaking change.

I think we should also look into ways that other plugins handle this. Surely we're not the first plugin to struggle with this issue?

---
Fixes #1507.

Currently, Sensei's buttons are blue with white text:

![original-button](https://user-images.githubusercontent.com/1190420/31171804-0af9fcd4-a8cf-11e7-97ad-da0c710a741d.jpg)

It's difficult for a theme to override these button colours because the selectors Sensei uses are more specific than those of the theme, and hence Sensei's styles win. Because we want to inherit from the `.button` class of the theme for a more consistent UI, this PR removes any colour, background colour or border colour properties for buttons.

The following buttons were changed:

- Login (seen when not logged in and going to _My Courses_)
- Start Taking This Course
- Contact Course Teacher
- Contact Lesson Teacher
- Contact Teacher
- View the Lesson Quiz
- Complete Lesson
- Complete Quiz
- Save Quiz
- Send Message
- View Results (on _My Courses_ > _Active Courses_, but not on the single course page for a completed course)

It's possible there may be others I have missed.

The _In Progress_, _Completed_, _View Results_ and _Next Lesson_ buttons were not changed.

## Testing

1. Ensure you are using the Storefront theme.
2. Go to the Customizer and click on Buttons.
3. Set the _Background Color_ and _Text Color_ to something other than blue and white, respectively:
![customizing-buttons](https://user-images.githubusercontent.com/1190420/31172426-7fff0766-a8d1-11e7-8267-2500f9976e03.jpg)
4. On the front-end, the button colours should correspond to what you have set in the Customizer:
![contact-lesson-teacher](https://user-images.githubusercontent.com/1190420/31172123-461d0ca6-a8d0-11e7-870e-74d06eea3e12.jpg)
5. Hover over the buttons to ensure there is no sign of the blue background and white text.
6. Switch to using a different theme. Any theme that does not specify styling for the `button` class will use Sensei's default styling of white text on a blue background. Note that this only applies for those elements that are using the `button` class. It does not apply for `<input type="submit">` elements. Those elements will be styled as per the theme. For example, in the Twenty Sixteen theme, this results in 2 different colours for the "View the Lesson Quiz" and "Complete Lesson" buttons. This makes sense since most themes would likely want to style submit buttons differently from other buttons:
![two-different-colours](https://user-images.githubusercontent.com/1190420/31226416-032c2d80-a9a4-11e7-9921-1b1d9a995ff6.jpg)