### PR TITLE
Update name of WooThemes Updater plugin in notices

### DIFF
--- a/includes/lib/woo-functions.php
+++ b/includes/lib/woo-functions.php
@@ -60,13 +60,13 @@ if ( ! class_exists( 'WooThemes_Updater' ) && ! function_exists( 'woothemes_upda
 		$install_url = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=' . $slug ), 'install-plugin_' . $slug );
 		$activate_url = 'plugins.php?action=activate&plugin=' . urlencode( 'woothemes-updater/woothemes-updater.php' ) . '&plugin_status=all&paged=1&s&_wpnonce=' . urlencode( wp_create_nonce( 'activate-plugin_woothemes-updater/woothemes-updater.php' ) );
 
-		$message = '<a href="' . esc_url( $install_url ) . '">Install the WooThemes Updater plugin</a> to get updates for your WooThemes plugins.';
+		$message = '<a href="' . esc_url( $install_url ) . '">Install the WooCommerce Helper plugin</a> to get updates for Sensei and your other WooCommerce plugins.';
 		$is_downloaded = false;
 		$plugins = array_keys( get_plugins() );
 		foreach ( $plugins as $plugin ) {
 			if ( strpos( $plugin, 'woothemes-updater.php' ) !== false ) {
 				$is_downloaded = true;
-				$message = '<a href="' . esc_url( admin_url( $activate_url ) ) . '">Activate the WooThemes Updater plugin</a> to get updates for your WooThemes plugins.';
+				$message = '<a href="' . esc_url( admin_url( $activate_url ) ) . '">Activate the WooCommerce Helper plugin</a> to get updates for Sensei and your other WooCommerce plugins.';
 			}
 		}
 		echo '<div class="updated fade"><p>' . $message . '</p></div>' . "\n";


### PR DESCRIPTION
### Then
When first activating Sensei you may see this notice:

![installer-old](https://user-images.githubusercontent.com/1190420/31177459-195ee7d4-a8e4-11e7-8375-5c3c5b15dbc6.jpg)

Clicking the install link takes you to this screen (on a multi-site install):

![install-plugin-old](https://user-images.githubusercontent.com/1190420/31177512-491c117c-a8e4-11e7-8a16-923de8dc196e.jpg)

This installs the _WooCommerce Helper_ plugin, which is confusing because I expected the _WooThemes Updater_ plugin to be installed as per the notice.

You then get this notice to activate the plugin:

![activate-old](https://user-images.githubusercontent.com/1190420/31177565-71609cde-a8e4-11e7-890e-3758cc38b787.jpg)

### Now
Since _WooThemes Updater_ appears to have been renamed to _WooCommerce Helper_, and WooThemes is now WooCommerce, this PR updates the notices as per the following:

![installer-new](https://user-images.githubusercontent.com/1190420/31177687-c18750ae-a8e4-11e7-890b-5d5609f58b3e.jpg)
![activate-new](https://user-images.githubusercontent.com/1190420/31177693-c453f490-a8e4-11e7-8cdb-242776309e48.jpg)

The only problem is the screen which installs the plugin as it says that it's installing _WooThemes Updater_ again:

![install-plugin-new](https://user-images.githubusercontent.com/1190420/31177716-d1bf5d72-a8e4-11e7-9371-38581e4015e3.jpg)

However, given the install screen is a screen that the user is likely only going to see once, I think that it's an acceptable trade-off. Probably this notice shouldn't be seen on this screen in the first place.

## Testing

1. Ensure that the _WooCommerce Helper_ plugin is not installed.
2. Confirm that you see the new install notice.
3. Click the _Install the WooCommerce Helper plugin_ link.
4. Once the plugin is installed, click on _Plugins_ in the sidebar.
5. Confirm that you see the new activation notice and that the _WooCommerce Helper_ plugin has been installed.