### PR TITLE
Fix issue preventing course author from syncing with lesson author

### DIFF
--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -479,7 +479,7 @@ class Sensei_Teacher {
 		}
 
 		// get a list of course lessons
-		$lessons = Sensei()->course->course_lessons( $course_id );
+		$lessons = Sensei()->course->course_lessons( $course_id, null );
 
 		if ( empty( $lessons )  || ! is_array( $lessons ) ) {
 			return false;

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -86,7 +86,7 @@ class Sensei_Teacher {
 		add_filter( 'ajax_query_attachments_args', array( $this, 'restrict_media_library_modal' ), 10, 1 );
 
 		// update lesson owner to course teacher before insert
-		add_filter( 'wp_insert_post_data',  array( $this, 'update_lesson_teacher' ), '99', 2 );
+		add_filter( 'wp_insert_post_data',  array( $this, 'update_lesson_teacher' ), 99, 2 );
 
 		// If a Teacher logs in, redirect to /wp-admin/
 		add_filter( 'wp_login', array( $this, 'teacher_login_redirect' ) , 10, 2 );
@@ -485,6 +485,9 @@ class Sensei_Teacher {
 			return false;
 		}
 
+		// Temporarily remove the author match filter
+		remove_filter( 'wp_insert_post_data',  array( $this, 'update_lesson_teacher' ), 99 );
+
 		// update each lesson and quiz author
 		foreach ( $lessons as $lesson ) {
 
@@ -517,6 +520,9 @@ class Sensei_Teacher {
 				) );
 			}
 		} // End foreach().
+
+		// Reinstate the author match filter
+		add_filter( 'wp_insert_post_data',  array( $this, 'update_lesson_teacher' ), 99, 2 );
 
 		return true;
 


### PR DESCRIPTION
Fixes: #1632 

This PR makes the change in course author sync with _unpublished_ lessons and also fixes an issue that prevented lesson authors from being changed before the course author was changed.

Test:
1) Create a course with at least two lessons. One lesson can be unpublished and one published.  
2) Locate the new entries (course, lessons, and all the quizzes associated with the lessons) in the `{$prefix}_posts` MySQL table.
3) Update the course author in WP admin (right side of course editor) to a different user.
4) Verify `post_author` changed for all relevant post entries in the `{$prefix}_posts` MySQL table.
