### PR TITLE
Use UTC for memberships access time comparison

### DIFF
--- a/includes/class-sensei-wc-memberships.php
+++ b/includes/class-sensei-wc-memberships.php
@@ -250,7 +250,7 @@ class Sensei_WC_Memberships {
 		) )
 			|| current_time( 'timestamp', true ) < wc_memberships_get_user_access_start_time( get_current_user_id(), 'view', array(
 				'lesson' => $post->ID,
-			) ), true ) {
+			), true ) ) {
 
 			remove_action( 'sensei_single_lesson_content_inside_after',  array( 'Sensei_Lesson', 'footer_quiz_call_to_action' ) );
 			remove_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'user_lesson_quiz_status_message' ), 20 );
@@ -286,7 +286,7 @@ class Sensei_WC_Memberships {
 		) )
 			|| current_time( 'timestamp', true ) < wc_memberships_get_user_access_start_time( get_current_user_id(), 'view', array(
 				'course' => $post->ID,
-			) ), true ) {
+			), true ) ) {
 
 			remove_action( 'sensei_single_course_content_inside_before',  array( 'Sensei_Course', 'the_course_video' ), 40 );
 			remove_action( 'sensei_no_permissions_inside_before_content', array( 'Sensei_Course', 'the_course_video' ), 40 );

--- a/includes/class-sensei-wc-memberships.php
+++ b/includes/class-sensei-wc-memberships.php
@@ -248,9 +248,9 @@ class Sensei_WC_Memberships {
 		if ( ! wc_memberships_get_user_access_start_time( get_current_user_id(), 'view', array(
 			'lesson' => $post->ID,
 		) )
-			|| current_time( 'timestamp' ) < wc_memberships_get_user_access_start_time( get_current_user_id(), 'view', array(
+			|| current_time( 'timestamp', true ) < wc_memberships_get_user_access_start_time( get_current_user_id(), 'view', array(
 				'lesson' => $post->ID,
-			) ) ) {
+			) ), true ) {
 
 			remove_action( 'sensei_single_lesson_content_inside_after',  array( 'Sensei_Lesson', 'footer_quiz_call_to_action' ) );
 			remove_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'user_lesson_quiz_status_message' ), 20 );
@@ -284,9 +284,9 @@ class Sensei_WC_Memberships {
 		if ( ! wc_memberships_get_user_access_start_time( get_current_user_id(), 'view', array(
 			'course' => $post->ID,
 		) )
-			|| current_time( 'timestamp' ) < wc_memberships_get_user_access_start_time( get_current_user_id(), 'view', array(
+			|| current_time( 'timestamp', true ) < wc_memberships_get_user_access_start_time( get_current_user_id(), 'view', array(
 				'course' => $post->ID,
-			) ) ) {
+			) ), true ) {
 
 			remove_action( 'sensei_single_course_content_inside_before',  array( 'Sensei_Course', 'the_course_video' ), 40 );
 			remove_action( 'sensei_no_permissions_inside_before_content', array( 'Sensei_Course', 'the_course_video' ), 40 );


### PR DESCRIPTION
Work around an issue where unrestricted lessons and courses are restricted for all users due to unexpected Daylight Saving Time (DST) handling by WooCommerce.

The issue only happens when the site is using an UTC offset (such as UTC+10) for site the timezone and WooCommerce tries to guess the timezone based on the offset, and the resulting timezone (such as Melbourne/Australia) is using DST and DST is in effect.

What happens is, current_time() will correctly use the UTC offset (ignoring DST, as UTC offsets don't use DST by definition) to get the local timestamp, whereas Memberships will adjust the access start timestamp based on wc_timezone_string(), which uses the timezone string (Melbourne/Australia), adding +1 hour to the access start time, so the current time and access start time are always 1 hour apart (but should be exactly the same).

Simply using UTC timestamps will work around this issue.