### PR TITLE
Fix deprecation notice in settings api

### DIFF
--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -300,7 +300,6 @@ class Sensei_Settings_API {
 
         ?>
         <div id="woothemes-sensei" class="wrap <?php echo esc_attr($this->token); ?>">
-        <?php screen_icon('woothemes-sensei'); ?>
         <h1><?php echo esc_html($this->name); ?><?php if ('' != $this->settings_version) {
                 echo ' <span class="version">' . $this->settings_version . '</span>';
             } ?></h1>


### PR DESCRIPTION
```php

! ) Notice: screen_icon is <strong>deprecated</strong> since version 3.8.0 with no alternative available. in /Users/pgk/Sites/wplocal.dev/web/wp/wp-includes/functions.php on line 3840
--


1 | 0.0030 | 370000 | {main}( ) | .../admin.php:0
2 | 2.1592 | 8930008 | do_action( ) | .../admin.php:222
3 | 2.1592 | 8930384 | WP_Hook->do_action( ) | .../plugin.php:453
4 | 2.1592 | 8930384 | WP_Hook->apply_filters( ) | .../class-wp-hook.php:310
5 | 2.1592 | 8931512 | Sensei_Settings->settings_screen( ) | .../class-wp-hook.php:286
6 | 2.1593 | 8931512 | screen_icon( ) | .../class-sensei-settings-api.php:303
7 | 2.1593 | 8931512 | _deprecated_function( ) | .../deprecated.php:1226
8 | 2.1594 | 8931832 | trigger_error ( ) | .../functions.php:3840


```