### PR TITLE
Decouple usage data from the usage tracking functionality

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -21,14 +21,14 @@ class Sensei_Usage_Tracking_Data {
 	 * @return array Usage data.
 	 **/
 	public function get_usage_data() {
-		return (array) apply_filters( 'sensei_usage_tracking_data', array(
+		return array(
 			'courses' => wp_count_posts( 'course' )->publish,
 			'learners' => $this->get_learner_count(),
 			'lessons' => wp_count_posts( 'lesson' )->publish,
 			'messages' => wp_count_posts( 'sensei_message' )->publish,
 			'questions' => wp_count_posts( 'question' )->publish,
 			'teachers' => $this->get_teacher_count(),
-		) );
+		);
 	}
 
 	/**

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -20,14 +20,14 @@ class Sensei_Usage_Tracking_Data {
 	 *
 	 * @return array Usage data.
 	 **/
-	public function get_usage_data() {
-		return array(
+	public static function get_usage_data() {
+ 		return array(
 			'courses' => wp_count_posts( 'course' )->publish,
-			'learners' => $this->get_learner_count(),
+			'learners' => self::get_learner_count(),
 			'lessons' => wp_count_posts( 'lesson' )->publish,
 			'messages' => wp_count_posts( 'sensei_message' )->publish,
 			'questions' => wp_count_posts( 'question' )->publish,
-			'teachers' => $this->get_teacher_count(),
+			'teachers' => self::get_teacher_count(),
 		);
 	}
 
@@ -38,7 +38,7 @@ class Sensei_Usage_Tracking_Data {
 	 *
 	 * @return int Number of teachers.
 	 **/
-	private function get_teacher_count() {
+	private static function get_teacher_count() {
 		$teacher_query = new WP_User_Query( array( 'role' => 'teacher' ) );
 
 		return $teacher_query->total_users;
@@ -51,7 +51,7 @@ class Sensei_Usage_Tracking_Data {
 	 *
 	 * @return int Number of learners.
 	 **/
-	private function get_learner_count() {
+	private static function get_learner_count() {
 		$learner_count = 0;
 		$args['fields'] = array( 'ID' );
 		$user_query = new WP_User_Query( $args );

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Usage tracking data
+ **/
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Supplies the usage tracking data for logging.
+ *
+ * @package Usage Tracking
+ * @since 1.9.20
+ */
+class Sensei_Usage_Tracking_Data {
+	/**
+	 * Get the usage tracking data to send.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return array Usage data.
+	 **/
+	public function get_usage_data() {
+		return (array) apply_filters( 'sensei_usage_tracking_data', array(
+			'courses' => wp_count_posts( 'course' )->publish,
+			'learners' => $this->get_learner_count(),
+			'lessons' => wp_count_posts( 'lesson' )->publish,
+			'messages' => wp_count_posts( 'sensei_message' )->publish,
+			'questions' => wp_count_posts( 'question' )->publish,
+			'teachers' => $this->get_teacher_count(),
+		) );
+	}
+
+	/**
+	 * Get the number of teachers.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return int Number of teachers.
+	 **/
+	private function get_teacher_count() {
+		$teacher_query = new WP_User_Query( array( 'role' => 'teacher' ) );
+
+		return $teacher_query->total_users;
+	}
+
+	/**
+	 * Get the total number of learners enrolled in at least one course.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return int Number of learners.
+	 **/
+	private function get_learner_count() {
+		$learner_count = 0;
+		$args['fields'] = array( 'ID' );
+		$user_query = new WP_User_Query( $args );
+		$learners = $user_query->get_results();
+
+		foreach( $learners as $learner ) {
+			$course_args = array(
+				'user_id' => $learner->ID,
+				'type' => 'sensei_course_status',
+				'status' => 'any',
+			);
+
+			$course_count = Sensei_Utils::sensei_check_for_activity( $course_args );
+
+			if ( $course_count > 0 ) {
+				$learner_count++;
+			}
+		}
+
+		return $learner_count;
+	}
+}

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -10,6 +10,17 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Usage Tracking
  */
 class Sensei_Usage_Tracking {
+	/**
+	 * @var string $callback_class Name of the class that contains the callback function for the
+	 *                             usage tracking job.
+	 **/
+	private $callback_class;
+
+	/**
+	 * @var string $callback_method Name of the method that serves as the callback function for the
+	 *                              usage tracking job.
+	 **/
+	private $callback_method;
 
 	/**
 	 * @var string
@@ -24,6 +35,18 @@ class Sensei_Usage_Tracking {
 	private static $hide_tracking_opt_in_option_name = 'sensei_usage_tracking_opt_in_hide';
 
 	private static $job_name = 'sensei_core_jobs_usage_tracking_send_data';
+
+	/**
+	 * Initialize the class and set its properties.
+	 *
+	 * @since 1.9.20
+	 * @param string $callback_class  Callback class name
+	 * @param string $callback_method Callback method name
+	 **/
+	function __construct( $callback_class, $callback_method ) {
+		$this->callback_class = $callback_class;
+		$this->callback_method = $callback_method;
+	}
 
 	/**
 	 * Send an event or stat.
@@ -150,64 +173,13 @@ class Sensei_Usage_Tracking {
 			return;
 		}
 
-		/**
-		 * Define data to send. Add or remove array keys and values.
-		 *
-		 * @param array $usage_data The data to send.
-		 *
-		 * @return array The array should be key/value. All values will be urlencoded
-		 **/
-		$usage_data = (array) apply_filters( 'sensei_usage_tracking_usage_data', array(
-			'courses' => wp_count_posts( 'course' )->publish,
-			'learners' => self::get_learner_count(),
-			'lessons' => wp_count_posts( 'lesson' )->publish,
-			'messages' => wp_count_posts( 'sensei_message' )->publish,
-			'questions' => wp_count_posts( 'question' )->publish,
-			'teachers' => self::get_teacher_count(),
-		) );
+		$class = new $this->callback_class();
+		$method = $this->callback_method;
+		$usage_data = $class->$method();
 
-		$resp = self::send_event( 'stats_log', $usage_data );
-
-		return $resp;
-	}
-
-	/**
-	 * Get the number of teachers.
-	 *
-	 * @return int Number of teachers.
-	 **/
-	public static function get_teacher_count() {
-		$teacher_query = new WP_User_Query( array( 'role' => 'teacher' ) );
-
-		return $teacher_query->total_users;
-	}
-
-	/**
-	 * Get the total number of learners enrolled in at least one course.
-	 *
-	 * @return int Number of learners.
-	 **/
-	public static function get_learner_count() {
-		$learner_count = 0;
-		$args['fields'] = array( 'ID' );
-		$user_query = new WP_User_Query( $args );
-		$learners = $user_query->get_results();
-
-		foreach( $learners as $learner ) {
-			$course_args = array(
-				'user_id' => $learner->ID,
-				'type' => 'sensei_course_status',
-				'status' => 'any',
-			);
-
-			$course_count = Sensei_Utils::sensei_check_for_activity( $course_args );
-
-			if ( $course_count > 0 ) {
-				$learner_count++;
-			}
+		if ( is_array( $usage_data ) ) {
+			return self::send_event( 'stats_log', $usage_data );
 		}
-
-		return $learner_count;
 	}
 
 	function render_usage_tracking_page() {

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -349,7 +349,7 @@ class Sensei_Main {
 
 		$this->view_helper = new Sensei_View_Helper();
 
-		$this->usage_tracking = new Sensei_Usage_Tracking();
+		$this->usage_tracking = new Sensei_Usage_Tracking( 'Sensei_Usage_Tracking_Data', 'get_usage_data' );
 		$this->usage_tracking->hook();
 
 		// Ensure tracking job is scheduled. If the user does not opt in, no

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -349,7 +349,7 @@ class Sensei_Main {
 
 		$this->view_helper = new Sensei_View_Helper();
 
-		$this->usage_tracking = new Sensei_Usage_Tracking( 'Sensei_Usage_Tracking_Data', 'get_usage_data' );
+		$this->usage_tracking = new Sensei_Usage_Tracking( array( 'Sensei_Usage_Tracking_Data', 'get_usage_data' ) );
 		$this->usage_tracking->hook();
 
 		// Ensure tracking job is scheduled. If the user does not opt in, no

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -1,0 +1,151 @@
+<?php
+
+class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
+	public function setup() {
+		parent::setUp();
+
+		$this->usage_tracking_data = new Sensei_Usage_Tracking_Data();
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 */
+	public function testGetUsageDataCourses() {
+		$published = 4;
+
+		// Create some published and unpublished courses.
+		$this->factory->post->create_many( 2, array(
+			'post_status' => 'draft',
+			'post_type' => 'course',
+		) );
+		$this->factory->post->create_many( $published, array(
+			'post_status' => 'publish',
+			'post_type' => 'course',
+		) );
+
+		$usage_data = $this->usage_tracking_data->get_usage_data();
+
+		$this->assertArrayHasKey( 'courses', $usage_data, 'Key' );
+		$this->assertEquals( $published, $usage_data['courses'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_learner_count
+	 */
+	public function testGetUsageDataLearners() {
+		// Create some users.
+		$subscribers = $this->factory->user->create_many( 8, array( 'role' => 'subscriber' ) );
+		$editors = $this->factory->user->create_many( 3, array( 'role' => 'editor' ) );
+
+		// Create some courses.
+		$course_ids = $this->factory->post->create_many( 2, array(
+			'post_status' => 'publish',
+			'post_type' => 'course',
+		) );
+
+		// Enroll some users in both courses.
+		foreach( $subscribers as $subscriber ) {
+			$this->factory->comment->create( array(
+				'user_id' => $subscriber,
+				'comment_post_ID' => $course_ids[0],
+				'comment_type' => 'sensei_course_status',
+			) );
+
+			$this->factory->comment->create( array(
+				'user_id' => $subscriber,
+				'comment_post_ID' => $course_ids[1],
+				'comment_type' => 'sensei_course_status',
+			) );
+		}
+
+		$usage_data = $this->usage_tracking_data->get_usage_data();
+
+		// Despite being enrolled in multiple courses, a learner is only counted once.
+		$this->assertArrayHasKey( 'learners', $usage_data, 'Key' );
+		$this->assertEquals( count( $subscribers ), $usage_data['learners'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 */
+	public function testGetUsageDataLessons() {
+		$published = 3;
+
+		// Create some published and unpublished lessons.
+		$this->factory->post->create_many( 2, array(
+			'post_status' => 'draft',
+			'post_type' => 'lesson',
+		) );
+		$this->factory->post->create_many( $published, array(
+			'post_status' => 'publish',
+			'post_type' => 'lesson',
+		) );
+
+		$usage_data = $this->usage_tracking_data->get_usage_data();
+
+		$this->assertArrayHasKey( 'lessons', $usage_data, 'Key' );
+		$this->assertEquals( $published, $usage_data['lessons'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 */
+	public function testGetUsageDataMessages() {
+		$published = 10;
+
+		// Create some published and unpublished messages.
+		$this->factory->post->create_many( 5, array(
+			'post_status' => 'pending',
+			'post_type' => 'sensei_message',
+		) );
+		$this->factory->post->create_many( $published, array(
+			'post_status' => 'publish',
+			'post_type' => 'sensei_message',
+		) );
+
+		$usage_data = $this->usage_tracking_data->get_usage_data();
+
+		$this->assertArrayHasKey( 'messages', $usage_data, 'Key' );
+		$this->assertEquals( $published, $usage_data['messages'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 */
+	public function testGetUsageDataQuestions() {
+		$published = 15;
+
+		// Create some published and unpublished questions.
+		$this->factory->post->create_many( 12, array(
+			'post_status' => 'private',
+			'post_type' => 'question',
+		) );
+		$this->factory->post->create_many( $published, array(
+			'post_status' => 'publish',
+			'post_type' => 'question',
+		) );
+
+		$usage_data = $this->usage_tracking_data->get_usage_data();
+
+		$this->assertArrayHasKey( 'questions', $usage_data, 'Key' );
+		$this->assertEquals( $published, $usage_data['questions'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_teacher_count
+	 */
+	public function testGetUsageDataTeachers() {
+		$teachers = 3;
+
+		// Create some users and teachers.
+		$this->factory->user->create_many( 10, array( 'role' => 'subscriber' ) );
+		$this->factory->user->create_many( $teachers, array( 'role' => 'teacher' ) );
+
+		$usage_data = $this->usage_tracking_data->get_usage_data();
+
+		$this->assertArrayHasKey( 'teachers', $usage_data, 'Key' );
+		$this->assertEquals( $teachers, $usage_data['teachers'], 'Count' );
+	}
+}

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -1,12 +1,6 @@
 <?php
 
 class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
-	public function setup() {
-		parent::setUp();
-
-		$this->usage_tracking_data = new Sensei_Usage_Tracking_Data();
-	}
-
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 */
@@ -23,7 +17,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			'post_type' => 'course',
 		) );
 
-		$usage_data = $this->usage_tracking_data->get_usage_data();
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertArrayHasKey( 'courses', $usage_data, 'Key' );
 		$this->assertEquals( $published, $usage_data['courses'], 'Count' );
@@ -59,7 +53,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			) );
 		}
 
-		$usage_data = $this->usage_tracking_data->get_usage_data();
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		// Despite being enrolled in multiple courses, a learner is only counted once.
 		$this->assertArrayHasKey( 'learners', $usage_data, 'Key' );
@@ -82,7 +76,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			'post_type' => 'lesson',
 		) );
 
-		$usage_data = $this->usage_tracking_data->get_usage_data();
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertArrayHasKey( 'lessons', $usage_data, 'Key' );
 		$this->assertEquals( $published, $usage_data['lessons'], 'Count' );
@@ -104,7 +98,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			'post_type' => 'sensei_message',
 		) );
 
-		$usage_data = $this->usage_tracking_data->get_usage_data();
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertArrayHasKey( 'messages', $usage_data, 'Key' );
 		$this->assertEquals( $published, $usage_data['messages'], 'Count' );
@@ -126,7 +120,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			'post_type' => 'question',
 		) );
 
-		$usage_data = $this->usage_tracking_data->get_usage_data();
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertArrayHasKey( 'questions', $usage_data, 'Key' );
 		$this->assertEquals( $published, $usage_data['questions'], 'Count' );
@@ -143,7 +137,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->factory->user->create_many( 10, array( 'role' => 'subscriber' ) );
 		$this->factory->user->create_many( $teachers, array( 'role' => 'teacher' ) );
 
-		$usage_data = $this->usage_tracking_data->get_usage_data();
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertArrayHasKey( 'teachers', $usage_data, 'Key' );
 		$this->assertEquals( $teachers, $usage_data['teachers'], 'Count' );


### PR DESCRIPTION
This PR decouples the retrieval of the usage tracking data from the actual usage tracking functionality. This will facilitate being able to reuse the usage tracking functionality across other plugins.

## Testing

1. Check that the tests run.
2. Check that usage tracking data is still logged to Tracks.