### PR TITLE
Add unit tests for Usage Tracking class

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -61,6 +61,8 @@ class Sensei_Unit_Tests_Bootstrap {
 	public function includes() {
 		// factories
 		require_once( $this->tests_dir . '/framework/factories/Sensei-Factory.php' );
+		// support files
+		require_once( $this->tests_dir . '/framework/support/wp-die-exception.php' );
 	}
 	/**
 	 * Get the single class instance.

--- a/tests/framework/support/wp-die-exception.php
+++ b/tests/framework/support/wp-die-exception.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Class for testing with wp_die. Instead of actually dying, add a hook for the
+ * appropriate handler and return a function that throws this exception
+ * instead, with the args set if desired. E.g.:
+ *
+ * ```
+ * add_filter( 'wp_die_ajax_handler', function() {
+ *     return function( $message, $title, $args ) {
+ *         $e = new WP_Die_Exception( 'wp_die called' );
+ *         $e->set_wp_die_args( $message, $title, $args );
+ *         throw $e;
+ *     };
+ * } );
+ * ```
+ *
+ * Then write tests like so:
+ *
+ * ```
+ * try {
+ *     function_calling_wp_die();
+ * } catch ( WP_Die_Exception $e ) {
+ *     $this->assertEquals( 403, $wp_die_args['args']['response'] );
+ * }
+ * ```
+ */
+class WP_Die_Exception extends Exception {
+	private $wp_die_args = null;
+
+	public function set_wp_die_args( $message, $title, $args ) {
+		$this->wp_die_args = array(
+			'message' => $message,
+			'title'   => $title,
+			'args'    => $args,
+		);
+	}
+
+	public function get_wp_die_args() {
+		return $this->wp_die_args;
+	}
+}

--- a/tests/unit-tests/test-class-usage-tracking.php
+++ b/tests/unit-tests/test-class-usage-tracking.php
@@ -3,7 +3,9 @@
 class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
-		$this->usage_tracking = new Sensei_Usage_Tracking();
+		$this->usage_tracking = new Sensei_Usage_Tracking( function() {
+			return array( 'testing' => true );
+		} );
 	}
 
 	public function tearDown() {

--- a/tests/unit-tests/test-class-usage-tracking.php
+++ b/tests/unit-tests/test-class-usage-tracking.php
@@ -12,6 +12,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 	/**
 	 * Ensure cron job action is set up.
+	 *
+	 * @covers Sensei_Usage_Tracking::hook
 	 */
 	public function testCronJobActionAdded() {
 		$this->usage_tracking->hook();
@@ -20,6 +22,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 	/**
 	 * Ensure scheduling function works properly.
+	 *
+	 * @covers Sensei_Usage_Tracking::maybe_schedule_tracking_task
 	 */
 	public function testMaybeScheduleTrackingTask() {
 		// Make sure it's cleared initially
@@ -49,6 +53,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 	/**
 	 * Ensure ajax hook is set up properly.
+	 *
+	 * @covers Sensei_Usage_Tracking::hook
 	 */
 	public function testAjaxRequestSetup() {
 		$this->usage_tracking->hook();
@@ -57,6 +63,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 	/**
 	 * Ensure tracking is enabled through ajax request.
+	 *
+	 * @covers Sensei_Usage_Tracking::handle_tracking_opt_in
 	 */
 	public function testAjaxRequestEnableTracking() {
 		$this->setupAjaxRequest();
@@ -81,6 +89,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 	/**
 	 * Ensure tracking is disabled through ajax request.
+	 *
+	 * @covers Sensei_Usage_Tracking::handle_tracking_opt_in
 	 */
 	public function testAjaxRequestDisableTracking() {
 		$this->setupAjaxRequest();
@@ -105,6 +115,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 	/**
 	 * Ensure ajax request fails on nonce failure and does not update option.
+	 *
+	 * @covers Sensei_Usage_Tracking::handle_tracking_opt_in
 	 */
 	public function testAjaxRequestFailedNonce() {
 		$this->setupAjaxRequest();
@@ -129,6 +141,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 	/**
 	 * Ensure ajax request fails on authorization failure and does not update option.
+	 *
+	 * @covers Sensei_Usage_Tracking::handle_tracking_opt_in
 	 */
 	public function testAjaxRequestFailedAuth() {
 		$this->setupAjaxRequest();
@@ -158,6 +172,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	/**
 	 * Ensure that a request is made to the correct URL with the given
 	 * properties and the default properties.
+	 *
+	 * @covers Sensei_Usage_Tracking::send_event
 	 */
 	public function testSendEvent() {
 		$event      = 'my_event';
@@ -199,6 +215,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 	/**
 	 * Ensure that the request is only sent when the setting is enabled.
+	 *
+	 * @covers Sensei_Usage_Tracking::maybe_send_usage_data
 	 */
 	public function testMaybeSendUsageData() {
 		$count = 0;
@@ -226,6 +244,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	/**
 	 * When setting is not set, dialog is not hidden, and user has capability,
 	 * we should see the dialog and Enable Usage Tracking button.
+	 *
+	 * @covers Sensei_Usage_Tracking::maybe_display_tracking_opt_in
 	 */
 	public function testDisplayTrackingOptIn() {
 		$this->setupOptInDialog();
@@ -236,6 +256,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 	/**
 	 * When setting is already set, dialog should not appear.
+	 *
+	 * @covers Sensei_Usage_Tracking::maybe_display_tracking_opt_in
 	 */
 	public function testDoNotDisplayTrackingOptInWhenSettingEnabled() {
 		$this->setupOptInDialog();
@@ -248,6 +270,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 	/**
 	 * When option is set to hide the dialog, it should not appear.
+	 *
+	 * @covers Sensei_Usage_Tracking::maybe_display_tracking_opt_in
 	 */
 	public function testDoNotDisplayTrackingOptInWhenDialogHidden() {
 		$this->setupOptInDialog();
@@ -260,6 +284,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	/**
 	 * When user does not have permission to manage usage tracking, dialog
 	 * should not appear.
+	 *
+	 * @covers Sensei_Usage_Tracking::maybe_display_tracking_opt_in
 	 */
 	public function testDoNotDisplayTrackingOptInWhenUserNotAuthorized() {
 		$this->setupOptInDialog();

--- a/tests/unit-tests/test-class-usage-tracking.php
+++ b/tests/unit-tests/test-class-usage-tracking.php
@@ -1,0 +1,318 @@
+<?php
+
+class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
+	public function setup() {
+		parent::setup();
+		$this->factory = new Sensei_Factory();
+		$this->usage_tracking = new Sensei_Usage_Tracking();
+	}
+
+	public function teardown() {
+		parent::teardown();
+	}
+
+	/**
+	 * Ensure cron job action is set up.
+	 */
+	public function test_cron_job_action_added() {
+		$this->usage_tracking->hook();
+		$this->assertTrue( !! has_action( 'sensei_core_jobs_usage_tracking_send_data', array( $this->usage_tracking, 'maybe_send_usage_data' ) ) );
+	}
+
+	/**
+	 * Ensure scheduling function works properly.
+	 */
+	public function test_maybe_schedule_tracking_task() {
+		// Make sure it's cleared initially
+		wp_clear_scheduled_hook( 'sensei_core_jobs_usage_tracking_send_data' );
+
+		// Record how many times the event is scheduled
+		$event_count = 0;
+		add_filter( 'schedule_event', function( $event ) use ( &$event_count ) {
+			if ( $event->hook === 'sensei_core_jobs_usage_tracking_send_data' ) {
+				$event_count++;
+			}
+			return $event;
+		} );
+
+		// Should successfully schedule the task
+		$this->assertFalse( wp_get_schedule( 'sensei_core_jobs_usage_tracking_send_data' ) );
+		$this->usage_tracking->maybe_schedule_tracking_task();
+		$this->assertNotFalse( wp_get_schedule( 'sensei_core_jobs_usage_tracking_send_data' ) );
+		$this->assertEquals( 1, $event_count );
+
+		// Should not duplicate when called again
+		$this->usage_tracking->maybe_schedule_tracking_task();
+		$this->assertEquals( 1, $event_count );
+	}
+
+	/* Test ajax request cases */
+
+	/**
+	 * Ensure ajax hook is set up properly.
+	 */
+	public function test_ajax_request_setup() {
+		$this->usage_tracking->hook();
+		$this->assertTrue( !! has_action( 'wp_ajax_handle_tracking_opt_in', array( $this->usage_tracking, 'handle_tracking_opt_in' ) ) );
+	}
+
+	/**
+	 * Ensure tracking is enabled through ajax request.
+	 */
+	public function test_ajax_request_enable_tracking() {
+		$this->setup_ajax_request();
+		$_POST['enable_tracking'] = '1';
+
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
+		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+
+		try {
+			$this->usage_tracking->handle_tracking_opt_in();
+		} catch ( WP_Die_Exception $e ) {
+			$wp_die_args = $e->get_wp_die_args();
+			$this->assertEquals( array(), $wp_die_args['args'] );
+		}
+
+		// Refresh settings
+		Sensei()->settings->get_settings();
+
+		$this->assertTrue( Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
+		$this->assertTrue( get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+	}
+
+	/**
+	 * Ensure tracking is disabled through ajax request.
+	 */
+	public function test_ajax_request_disable_tracking() {
+		$this->setup_ajax_request();
+		$_POST['enable_tracking'] = '0';
+
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
+		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+
+		try {
+			$this->usage_tracking->handle_tracking_opt_in();
+		} catch ( WP_Die_Exception $e ) {
+			$wp_die_args = $e->get_wp_die_args();
+			$this->assertEquals( array(), $wp_die_args['args'] );
+		}
+
+		// Refresh settings
+		Sensei()->settings->get_settings();
+
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
+		$this->assertTrue( get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+	}
+
+	/**
+	 * Ensure ajax request fails on nonce failure and does not update option.
+	 */
+	public function test_ajax_request_failed_nonce() {
+		$this->setup_ajax_request();
+		$_REQUEST['nonce'] = 'invalid_nonce_1234';
+
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
+		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+
+		try {
+			$this->usage_tracking->handle_tracking_opt_in();
+		} catch ( WP_Die_Exception $e ) {
+			$wp_die_args = $e->get_wp_die_args();
+			$this->assertEquals( 403, $wp_die_args['args']['response'] );
+		}
+
+		// Refresh settings
+		Sensei()->settings->get_settings();
+
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
+		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+	}
+
+	/**
+	 * Ensure ajax request fails on authorization failure and does not update option.
+	 */
+	public function test_ajax_request_failed_auth() {
+		$this->setup_ajax_request();
+
+		$user = wp_get_current_user();
+		$user->remove_cap( 'manage_sensei' );
+
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
+		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+
+		try {
+			$this->usage_tracking->handle_tracking_opt_in();
+		} catch ( WP_Die_Exception $e ) {
+			$wp_die_args = $e->get_wp_die_args();
+			$this->assertEquals( 403, $wp_die_args['args']['response'] );
+		}
+
+		// Refresh settings
+		Sensei()->settings->get_settings();
+
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
+		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+	}
+
+	/**
+	 * Helpers for ajax request.
+	 */
+	private function setup_ajax_request() {
+		// Simulate an ajax request
+		add_filter( 'wp_doing_ajax', function() { return true; } );
+
+		// Set up nonce
+		$_REQUEST['nonce'] = wp_create_nonce( 'tracking-opt-in' );
+
+		// Set manage_sensei cap on current user
+		$user = wp_get_current_user();
+		$user->add_cap( 'manage_sensei' );
+
+		// Reset the in-memory settings
+		Sensei()->settings->get_settings();
+
+		// When wp_die is called, save the args and throw an exception to stop
+		// execution.
+		add_filter( 'wp_die_ajax_handler', function() {
+			return function( $message, $title, $args ) {
+				$e = new WP_Die_Exception( 'wp_die called' );
+				$e->set_wp_die_args( $message, $title, $args );
+				throw $e;
+			};
+		} );
+	}
+
+	/* END test ajax request cases */
+
+	/**
+	 * Ensure that a request is made to the correct URL with the given
+	 * properties and the default properties.
+	 */
+	public function test_send_event() {
+		$event      = 'my_event';
+		$properties = array(
+			'button_clicked' => 'my_button'
+		);
+		$timestamp  = '1234';
+
+		// Capture the network request, save the request URL and arguments, and
+		// simulate a WP_Error
+		$request_params = null;
+		$request_url    = null;
+		add_filter( 'pre_http_request', function( $preempt, $r, $url ) use ( &$request_params, &$request_url ) {
+			$request_params = $r;
+			$request_url    = $url;
+			return new WP_Error();
+		}, 10, 3 );
+
+		Sensei_Usage_Tracking::send_event( 'my_event', $properties, $timestamp );
+
+		$parsed_url = parse_url( $request_url );
+
+		$this->assertEquals( 'pixel.wp.com', $parsed_url['host'] );
+		$this->assertEquals( '/t.gif', $parsed_url['path'] );
+
+		$query = array();
+		parse_str( $parsed_url['query'], $query );
+		$this->assertArraySubset( array(
+			'button_clicked' => 'my_button',
+			'admin_email'    => 'admin@example.org',
+			'_ut'            => 'sensei:site_url',
+			'_ui'            => 'http://example.org',
+			'_ul'            => '',
+			'_en'            => 'sensei_my_event',
+			'_ts'            => '1234000',
+			'_'              => '_',
+		), $query );
+	}
+
+	/**
+	 * Ensure that the request is only sent when the setting is enabled.
+	 */
+	public function test_maybe_send_usage_data() {
+		$count = 0;
+
+		// Count the number of network requests
+		add_filter( 'pre_http_request', function() use ( &$count ) {
+			$count++;
+			return new WP_Error();
+		} );
+
+		// Setting is not set, ensure the request is not sent.
+		Sensei_Usage_Tracking::maybe_send_usage_data();
+		$this->assertEquals( 0, $count );
+
+		// Set the setting and ensure request is sent.
+		Sensei()->settings->set( 'sensei_usage_tracking_enabled', true );
+		Sensei()->settings->get_settings();
+
+		Sensei_Usage_Tracking::maybe_send_usage_data();
+		$this->assertEquals( 1, $count );
+	}
+
+	/* Tests for tracking opt in dialog */
+
+	/**
+	 * When setting is not set, dialog is not hidden, and user has capability,
+	 * we should see the dialog and Enable Usage Tracking button.
+	 */
+	public function test_display_tracking_opt_in() {
+		$this->setup_opt_in_dialog();
+
+		$this->expectOutputRegex( '/Enable Usage Tracking/' );
+		$this->usage_tracking->maybe_display_tracking_opt_in();
+	}
+
+	/**
+	 * When setting is already set, dialog should not appear.
+	 */
+	public function test_do_not_display_tracking_opt_in_when_setting_enabled() {
+		$this->setup_opt_in_dialog();
+		Sensei()->settings->set( 'sensei_usage_tracking_enabled', true );
+		Sensei()->settings->get_settings();
+
+		$this->expectOutputString( '' );
+		$this->usage_tracking->maybe_display_tracking_opt_in();
+	}
+
+	/**
+	 * When option is set to hide the dialog, it should not appear.
+	 */
+	public function test_do_not_display_tracking_opt_in_when_dialog_hidden() {
+		$this->setup_opt_in_dialog();
+		update_option( 'sensei_usage_tracking_opt_in_hide', true );
+
+		$this->expectOutputString( '' );
+		$this->usage_tracking->maybe_display_tracking_opt_in();
+	}
+
+	/**
+	 * When user does not have permission to manage usage tracking, dialog
+	 * should not appear.
+	 */
+	public function test_do_not_display_tracking_opt_in_when_user_not_authorized() {
+		$this->setup_opt_in_dialog();
+		$user = wp_get_current_user();
+		$user->remove_cap( 'manage_sensei' );
+
+		$this->expectOutputString( '' );
+		$this->usage_tracking->maybe_display_tracking_opt_in();
+	}
+
+	/**
+	 * Helper method to set up tracking opt-in dialog.
+	 */
+	private function setup_opt_in_dialog() {
+		// Set manage_sensei cap on current user
+		$user = wp_get_current_user();
+		$user->add_cap( 'manage_sensei' );
+
+		// Ensure setting is not set
+		Sensei()->settings->set( 'sensei_usage_tracking_enabled', false );
+
+		// Reset the in-memory settings
+		Sensei()->settings->get_settings();
+	}
+
+	/* END tests for tracking opt in dialog */
+}

--- a/tests/unit-tests/test-class-usage-tracking.php
+++ b/tests/unit-tests/test-class-usage-tracking.php
@@ -230,14 +230,14 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 		} );
 
 		// Setting is not set, ensure the request is not sent.
-		Sensei_Usage_Tracking::maybe_send_usage_data();
+		$this->usage_tracking->maybe_send_usage_data();
 		$this->assertEquals( 0, $count, 'Request not sent when Usage Tracking disabled' );
 
 		// Set the setting and ensure request is sent.
 		Sensei()->settings->set( 'sensei_usage_tracking_enabled', true );
 		Sensei()->settings->get_settings();
 
-		Sensei_Usage_Tracking::maybe_send_usage_data();
+		$this->usage_tracking->maybe_send_usage_data();
 		$this->assertEquals( 1, $count, 'Request sent when Usage Tracking enabled' );
 	}
 

--- a/tests/unit-tests/test-class-usage-tracking.php
+++ b/tests/unit-tests/test-class-usage-tracking.php
@@ -39,14 +39,14 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 		} );
 
 		// Should successfully schedule the task
-		$this->assertFalse( wp_get_schedule( 'sensei_core_jobs_usage_tracking_send_data' ) );
+		$this->assertFalse( wp_get_schedule( 'sensei_core_jobs_usage_tracking_send_data' ), 'Not scheduled initial' );
 		$this->usage_tracking->maybe_schedule_tracking_task();
-		$this->assertNotFalse( wp_get_schedule( 'sensei_core_jobs_usage_tracking_send_data' ) );
-		$this->assertEquals( 1, $event_count );
+		$this->assertNotFalse( wp_get_schedule( 'sensei_core_jobs_usage_tracking_send_data' ), 'Schedules a job' );
+		$this->assertEquals( 1, $event_count, 'Schedules only one job' );
 
 		// Should not duplicate when called again
 		$this->usage_tracking->maybe_schedule_tracking_task();
-		$this->assertEquals( 1, $event_count );
+		$this->assertEquals( 1, $event_count, 'Does not schedule an additional job' );
 	}
 
 	/* Test ajax request cases */
@@ -70,21 +70,21 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 		$this->setupAjaxRequest();
 		$_POST['enable_tracking'] = '1';
 
-		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
-		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ), 'Usage tracking initially disabled' );
+		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ), 'Dialog initially shown' );
 
 		try {
 			$this->usage_tracking->handle_tracking_opt_in();
 		} catch ( WP_Die_Exception $e ) {
 			$wp_die_args = $e->get_wp_die_args();
-			$this->assertEquals( array(), $wp_die_args['args'] );
+			$this->assertEquals( array(), $wp_die_args['args'], 'wp_die call has no non-success status' );
 		}
 
 		// Refresh settings
 		Sensei()->settings->get_settings();
 
-		$this->assertTrue( Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
-		$this->assertTrue( get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+		$this->assertTrue( Sensei()->settings->get( 'sensei_usage_tracking_enabled' ), 'Usage tracking enabled' );
+		$this->assertTrue( get_option( 'sensei_usage_tracking_opt_in_hide' ), 'Dialog hidden' );
 	}
 
 	/**
@@ -96,21 +96,21 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 		$this->setupAjaxRequest();
 		$_POST['enable_tracking'] = '0';
 
-		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
-		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ), 'Usage tracking initially disabled' );
+		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ), 'Dialog initially shown' );
 
 		try {
 			$this->usage_tracking->handle_tracking_opt_in();
 		} catch ( WP_Die_Exception $e ) {
 			$wp_die_args = $e->get_wp_die_args();
-			$this->assertEquals( array(), $wp_die_args['args'] );
+			$this->assertEquals( array(), $wp_die_args['args'], 'wp_die call has no non-success status' );
 		}
 
 		// Refresh settings
 		Sensei()->settings->get_settings();
 
-		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
-		$this->assertTrue( get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ), 'Usage tracking disabled' );
+		$this->assertTrue( get_option( 'sensei_usage_tracking_opt_in_hide' ), 'Dialog hidden' );
 	}
 
 	/**
@@ -122,21 +122,21 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 		$this->setupAjaxRequest();
 		$_REQUEST['nonce'] = 'invalid_nonce_1234';
 
-		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
-		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ), 'Usage tracking initially disabled' );
+		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ), 'Dialog initially shown' );
 
 		try {
 			$this->usage_tracking->handle_tracking_opt_in();
 		} catch ( WP_Die_Exception $e ) {
 			$wp_die_args = $e->get_wp_die_args();
-			$this->assertEquals( 403, $wp_die_args['args']['response'] );
+			$this->assertEquals( 403, $wp_die_args['args']['response'], 'wp_die called has "Forbidden" status' );
 		}
 
 		// Refresh settings
 		Sensei()->settings->get_settings();
 
-		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
-		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ), 'Usage tracking disabled' );
+		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ), 'Dialog not hidden' );
 	}
 
 	/**
@@ -150,21 +150,21 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 		$user = wp_get_current_user();
 		$user->remove_cap( 'manage_sensei' );
 
-		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
-		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ), 'Usage tracking initially disabled' );
+		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ), 'Dialog initially shown' );
 
 		try {
 			$this->usage_tracking->handle_tracking_opt_in();
 		} catch ( WP_Die_Exception $e ) {
 			$wp_die_args = $e->get_wp_die_args();
-			$this->assertEquals( 403, $wp_die_args['args']['response'] );
+			$this->assertEquals( 403, $wp_die_args['args']['response'], 'wp_die called has "Forbidden" status' );
 		}
 
 		// Refresh settings
 		Sensei()->settings->get_settings();
 
-		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ) );
-		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+		$this->assertFalse( !! Sensei()->settings->get( 'sensei_usage_tracking_enabled' ), 'Usage tracking disabled' );
+		$this->assertFalse( !! get_option( 'sensei_usage_tracking_opt_in_hide' ), 'Dialog not hidden' );
 	}
 
 	/* END test ajax request cases */
@@ -196,8 +196,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 		$parsed_url = parse_url( $request_url );
 
-		$this->assertEquals( 'pixel.wp.com', $parsed_url['host'] );
-		$this->assertEquals( '/t.gif', $parsed_url['path'] );
+		$this->assertEquals( 'pixel.wp.com', $parsed_url['host'], 'Host' );
+		$this->assertEquals( '/t.gif', $parsed_url['path'], 'Path' );
 
 		$query = array();
 		parse_str( $parsed_url['query'], $query );
@@ -210,7 +210,7 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 			'_en'            => 'sensei_my_event',
 			'_ts'            => '1234000',
 			'_'              => '_',
-		), $query );
+		), $query, 'Query parameters' );
 	}
 
 	/**
@@ -229,14 +229,14 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 		// Setting is not set, ensure the request is not sent.
 		Sensei_Usage_Tracking::maybe_send_usage_data();
-		$this->assertEquals( 0, $count );
+		$this->assertEquals( 0, $count, 'Request not sent when Usage Tracking disabled' );
 
 		// Set the setting and ensure request is sent.
 		Sensei()->settings->set( 'sensei_usage_tracking_enabled', true );
 		Sensei()->settings->get_settings();
 
 		Sensei_Usage_Tracking::maybe_send_usage_data();
-		$this->assertEquals( 1, $count );
+		$this->assertEquals( 1, $count, 'Request sent when Usage Tracking enabled' );
 	}
 
 	/* Tests for tracking opt in dialog */

--- a/tests/unit-tests/test-template-functions.php
+++ b/tests/unit-tests/test-template-functions.php
@@ -41,7 +41,8 @@ class Sensei_Template_Functions_Test extends WP_UnitTestCase {
 	 */
 	public function testGetNavigationModuleURL() {
 		$course_id = $this->factory->get_course_with_modules();
-		$module = wp_get_post_terms( $course_id, 'module' )[0];
+		$modules = wp_get_post_terms( $course_id, 'module' );
+		$module = $modules[0];
 		$url = sensei_get_navigation_url( $course_id, $module );
 
 		$this->assertEquals( get_term_link( $module, 'module' ) . '&course_id=' . $course_id, $url );
@@ -64,7 +65,8 @@ class Sensei_Template_Functions_Test extends WP_UnitTestCase {
 	 */
 	public function testGetNavigationModuleText() {
 		$course_id = $this->factory->get_course_with_modules();
-		$module = wp_get_post_terms( $course_id, 'module' )[0];
+		$modules = wp_get_post_terms( $course_id, 'module' );
+		$module = $modules[0];
 		$text = sensei_get_navigation_link_text( $module );
 
 		$this->assertEquals( $module->name, $text );
@@ -88,7 +90,8 @@ class Sensei_Template_Functions_Test extends WP_UnitTestCase {
 	public function testGetPrevNextLessons() {
 		$course_id = $this->factory->get_course_with_modules();
 		$lessons = $this->factory->get_lessons();
-		$previous = wp_get_post_terms( $course_id, 'module' )[0];
+		$modules = wp_get_post_terms( $course_id, 'module' );
+		$previous = $modules[0];
 		$current = get_post( $lessons[0] );
 		$next = get_post( $lessons[1] );
 		$nav_links = sensei_get_prev_next_lessons( $current->ID );
@@ -116,7 +119,8 @@ class Sensei_Template_Functions_Test extends WP_UnitTestCase {
 
 		$course_id = $this->factory->get_course_with_modules();
 		$lessons = $this->factory->get_lessons();
-		$current = wp_get_post_terms( $course_id, 'module' )[0];
+		$modules = wp_get_post_terms( $course_id, 'module' );
+		$current = $modules[0];
 		$next = get_post( $lessons[0] );
 
 		// Set test up so that it thinks we're on the module page.


### PR DESCRIPTION
Primarily testing generic functionality such as:

- cron job setup and execution
- ajax handler for enabling/disabling tracking
- sending the tracking request to Tracks when tracking is enabled
- displaying tracking opt-in dialog when appropriate

As this is my first significant test suite written for a plugin, I would appreciate any comments/suggestions regarding best practices.

Please ensure the tests pass in your dev environment. They pass on my two VM's (PHP 7.1 and 5.3) and on Circle CI (PHP 5.4). My VM's and CI are running against the latest version of WordPress, AFAICT.