### PR TITLE
Get question usage stats

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -31,8 +31,8 @@ class Sensei_Usage_Tracking_Data {
 			'modules_max' => self::get_max_module_count(),
 			'modules_min' => self::get_min_module_count(),
 			'questions' => wp_count_posts( 'question' )->publish,
-			'random_order' => self::get_random_order_count(),
 			'question_media' => self::get_question_media_count(),
+			'question_random_order' => self::get_question_random_order_count(),
 			'teachers' => self::get_teacher_count(),
 		);
 
@@ -214,7 +214,7 @@ class Sensei_Usage_Tracking_Data {
 	 *
 	 * @return int Number of multiple choice questions with randomized answers.
 	 **/
-	private static function get_random_order_count() {
+	private static function get_question_random_order_count() {
 		$count = 0;
 		$query = new WP_Query( array(
 			'post_type' => 'question',

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -215,6 +215,7 @@ class Sensei_Usage_Tracking_Data {
 		$count = 0;
 		$query = new WP_Query( array(
 			'post_type' => 'question',
+			'posts_per_page' => -1,
 			'fields' => 'ids',
 			'meta_query' => array(
 				array(

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -32,6 +32,7 @@ class Sensei_Usage_Tracking_Data {
 			'modules_min' => self::get_min_module_count(),
 			'questions' => wp_count_posts( 'question' )->publish,
 			'random_order' => self::get_random_order_count(),
+			'question_media' => self::get_question_media_count(),
 			'teachers' => self::get_teacher_count(),
 		);
 
@@ -173,6 +174,33 @@ class Sensei_Usage_Tracking_Data {
 
 			if ( array_key_exists( $key, $count ) ) {
 				$count[$key]++;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Get the total number of published questions that have media.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return array Number of published questions with media.
+	 **/
+	private static function get_question_media_count() {
+		$count = 0;
+
+		$query = new WP_Query( array(
+			'post_type' => 'question',
+			'fields' => 'ids'
+		) );
+		$questions = $query->posts;
+
+		foreach ( $questions as $question ) {
+			$question_media = get_post_meta( $question, '_question_media', true );
+
+			if ( intval( $question_media ) > 0 ) {
+				$count++;
 			}
 		}
 

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -164,6 +164,7 @@ class Sensei_Usage_Tracking_Data {
 
 		$query = new WP_Query( array(
 			'post_type' => 'question',
+			'posts_per_page' => -1,
 			'fields' => 'ids'
 		) );
 		$questions = $query->posts;
@@ -192,6 +193,7 @@ class Sensei_Usage_Tracking_Data {
 
 		$query = new WP_Query( array(
 			'post_type' => 'question',
+			'posts_per_page' => -1,
 			'fields' => 'ids'
 		) );
 		$questions = $query->posts;
@@ -218,6 +220,7 @@ class Sensei_Usage_Tracking_Data {
 		$count = 0;
 		$query = new WP_Query( array(
 			'post_type' => 'question',
+			'posts_per_page' => -1,
 			'fields' => 'ids',
 		) );
 		$questions = $query->posts;

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -159,7 +159,7 @@ class Sensei_Usage_Tracking_Data {
 		$question_types = Sensei()->question->question_types();
 
 		foreach ( $question_types as $key=>$value ) {
-			$count[self::get_question_type_key( $key )] = 0;
+			$count[ self::get_question_type_key( $key ) ] = 0;
 		}
 
 		$query = new WP_Query( array(
@@ -174,7 +174,7 @@ class Sensei_Usage_Tracking_Data {
 			$key = self::get_question_type_key( $question_type );
 
 			if ( array_key_exists( $key, $count ) ) {
-				$count[$key]++;
+				$count[ $key ]++;
 			}
 		}
 

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -31,6 +31,7 @@ class Sensei_Usage_Tracking_Data {
 			'modules_max' => self::get_max_module_count(),
 			'modules_min' => self::get_min_module_count(),
 			'questions' => wp_count_posts( 'question' )->publish,
+			'random_order' => self::get_random_order_count(),
 			'teachers' => self::get_teacher_count(),
 		);
 
@@ -172,6 +173,41 @@ class Sensei_Usage_Tracking_Data {
 
 			if ( array_key_exists( $key, $count ) ) {
 				$count[$key]++;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * Get the total number of multiple choice questions where "Randomise answer order" is checked.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return int Number of multiple choice questions with randomized answers.
+	 **/
+	private static function get_random_order_count() {
+		$count = 0;
+		$query = new WP_Query( array(
+			'post_type' => 'question',
+			'fields' => 'ids',
+		) );
+		$questions = $query->posts;
+
+		foreach ( $questions as $question ) {
+			$question_type = Sensei()->question->get_question_type( $question );
+
+			/*
+			 * Random answer order is only applicable for multiple choice questions.
+			 * Since it's possible that other question types could have a random answer order set,
+			 * let's explicitly handle multiple choice.
+			 */
+			if ( $question_type === 'multiple-choice' ) {
+				$random_order = get_post_meta( $question, '_random_order', true );
+
+				if ( $random_order === 'yes' ) {
+					$count++;
+				}
 			}
 		}
 

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -189,24 +189,19 @@ class Sensei_Usage_Tracking_Data {
 	 * @return array Number of published questions with media.
 	 **/
 	private static function get_question_media_count() {
-		$count = 0;
-
 		$query = new WP_Query( array(
 			'post_type' => 'question',
-			'posts_per_page' => -1,
-			'fields' => 'ids'
+			'fields' => 'ids',
+			'meta_query' => array(
+				array(
+					'key' => '_question_media',
+					'value' => 0,
+					'compare' => '>',
+				)
+			)
 		) );
-		$questions = $query->posts;
 
-		foreach ( $questions as $question ) {
-			$question_media = get_post_meta( $question, '_question_media', true );
-
-			if ( intval( $question_media ) > 0 ) {
-				$count++;
-			}
-		}
-
-		return $count;
+		return $query->found_posts;
 	}
 
 	/**
@@ -220,8 +215,14 @@ class Sensei_Usage_Tracking_Data {
 		$count = 0;
 		$query = new WP_Query( array(
 			'post_type' => 'question',
-			'posts_per_page' => -1,
 			'fields' => 'ids',
+			'meta_query' => array(
+				array(
+					'key' => '_random_order',
+					'value' => 'yes',
+					'compare' => '=',
+				)
+			)
 		) );
 		$questions = $query->posts;
 
@@ -234,11 +235,7 @@ class Sensei_Usage_Tracking_Data {
 			 * let's explicitly handle multiple choice.
 			 */
 			if ( $question_type === 'multiple-choice' ) {
-				$random_order = get_post_meta( $question, '_random_order', true );
-
-				if ( $random_order === 'yes' ) {
-					$count++;
-				}
+				$count++;
 			}
 		}
 

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -258,6 +258,67 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_random_order_count
+	 */
+	public function testGetRandomOrderCount() {
+		// Create some questions.
+		$questions[] = $this->factory->post->create_many( 3, array(
+			'post_type' => 'question',
+			'post_status' => 'publish',
+		) );
+
+		// Set the type of each question to be multiple choice.
+		wp_set_post_terms( $questions[0][0], array( 'multiple-choice' ), 'question-type' );
+		wp_set_post_terms( $questions[0][1], array( 'multiple-choice' ), 'question-type' );
+		wp_set_post_terms( $questions[0][2], array( 'multiple-choice' ), 'question-type' );
+
+		// Set the random answer order.
+		add_post_meta( $questions[0][0], '_random_order', 'yes' );
+		add_post_meta( $questions[0][1], '_random_order', 'no' );
+		add_post_meta( $questions[0][2], '_random_order', 'yes' );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'random_order', $usage_data, 'Key' );
+		$this->assertEquals( 2, $usage_data['random_order'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_random_order_count
+	 */
+	public function testGetRandomOrderCountMultipleChoiceOnly() {
+		// Create some questions.
+		$questions[] = $this->factory->post->create_many( 6, array(
+			'post_type' => 'question',
+			'post_status' => 'publish',
+		) );
+
+		// Create a question of each type.
+		wp_set_post_terms( $questions[0][0], array( 'multiple-choice' ), 'question-type' );
+		wp_set_post_terms( $questions[0][1], array( 'multi-line' ), 'question-type' );
+		wp_set_post_terms( $questions[0][2], array( 'single-line' ), 'question-type' );
+		wp_set_post_terms( $questions[0][3], array( 'boolean' ), 'question-type' );
+		wp_set_post_terms( $questions[0][4], array( 'file-upload' ), 'question-type' );
+		wp_set_post_terms( $questions[0][5], array( 'gap-fill' ), 'question-type' );
+
+
+		// Turn on random answer order for non-multiple choice questions.
+		add_post_meta( $questions[0][0], '_random_order', 'no' );
+		add_post_meta( $questions[0][1], '_random_order', 'yes' );
+		add_post_meta( $questions[0][2], '_random_order', 'yes' );
+		add_post_meta( $questions[0][3], '_random_order', 'yes' );
+		add_post_meta( $questions[0][4], '_random_order', 'yes' );
+		add_post_meta( $questions[0][5], '_random_order', 'yes' );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'random_order', $usage_data, 'Key' );
+		$this->assertEquals( 0, $usage_data['random_order'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_teacher_count
 	 */
 	public function testGetUsageDataTeachers() {

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -258,6 +258,50 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_question_media_count
+	 */
+	public function testGetUsageDataQuestionMediaCount() {
+		// Create some questions.
+		$questions = $this->factory->post->create_many( 5, array(
+			'post_type' => 'question',
+			'post_status' => 'publish',
+		) );
+		// Create some media.
+		$media = $this->factory->attachment->create_many( 3, array(
+			'post_type' => 'question',
+			'post_status' => 'publish',
+		) );
+
+		// Attach media to some questions.
+		add_post_meta( $questions[0], '_question_media', $media[0] );
+		add_post_meta( $questions[1], '_question_media', $media[1] );
+		add_post_meta( $questions[2], '_question_media', $media[2] );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'question_media', $usage_data, 'Key' );
+		$this->assertEquals( 3, $usage_data['question_media'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_question_media_count
+	 */
+	public function testGetUsageDataQuestionMediaCountNoMedia() {
+		// Create some questions, but don't attach any media.
+		$questions = $this->factory->post->create_many( 5, array(
+			'post_type' => 'question',
+			'post_status' => 'publish',
+		) );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'question_media', $usage_data, 'Key' );
+		$this->assertEquals( 0, $usage_data['question_media'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_random_order_count
 	 */
 	public function testGetRandomOrderCount() {

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -198,6 +198,66 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_question_type_count
+	 * @covers Sensei_Usage_Tracking_Data::get_question_type_key
+	 */
+	public function testGetUsageDataQuestionTypes() {
+		// Create some questions.
+		$questions = $this->factory->post->create_many( 10, array(
+			'post_type' => 'question',
+			'post_status' => 'publish',
+		) );
+
+		// Set the type of each question.
+		wp_set_post_terms( $questions[0], array( 'multiple-choice' ), 'question-type' );
+		wp_set_post_terms( $questions[1], array( 'multi-line' ), 'question-type' );
+		wp_set_post_terms( $questions[2], array( 'multiple-choice' ), 'question-type' );
+		wp_set_post_terms( $questions[3], array( 'multi-line' ), 'question-type' );
+		wp_set_post_terms( $questions[4], array( 'multiple-choice' ), 'question-type' );
+		wp_set_post_terms( $questions[5], array( 'gap-fill' ), 'question-type' );
+		wp_set_post_terms( $questions[6], array( 'single-line' ), 'question-type' );
+		wp_set_post_terms( $questions[7], array( 'boolean' ), 'question-type' );
+		wp_set_post_terms( $questions[8], array( 'multi-line' ), 'question-type' );
+		wp_set_post_terms( $questions[9], array( 'boolean' ), 'question-type' );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'question_multiple_choice', $usage_data, 'Multiple choice key' );
+		$this->assertArrayHasKey( 'question_gap_fill', $usage_data, 'Gap fill key' );
+		$this->assertArrayHasKey( 'question_boolean', $usage_data, 'Boolean key' );
+		$this->assertArrayHasKey( 'question_single_line', $usage_data, 'Single line key' );
+		$this->assertArrayHasKey( 'question_multi_line', $usage_data, 'Multi line key' );
+		$this->assertArrayHasKey( 'question_file_upload', $usage_data, 'File upload key' );
+
+		$this->assertEquals( 3, $usage_data['question_multiple_choice'], 'Multiple choice count' );
+		$this->assertEquals( 1, $usage_data['question_gap_fill'], 'Gap fill count' );
+		$this->assertEquals( 2, $usage_data['question_boolean'], 'Boolean count' );
+		$this->assertEquals( 1, $usage_data['question_single_line'], 'Single line count' );
+		$this->assertEquals( 3, $usage_data['question_multi_line'], 'Multi line count' );
+		$this->assertEquals( 0, $usage_data['question_file_upload'], 'File upload count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_question_type_count
+	 */
+	public function testGetUsageDataQuestionTypesInvalidType() {
+		// Create a question.
+		$questions = $this->factory->post->create( array(
+			'post_type' => 'question',
+			'post_status' => 'publish',
+		) );
+
+		// Set the question to use an invalid type.
+		wp_set_post_terms( $questions[0], array( 'automattic' ), 'question-type' );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayNotHasKey( 'question_automattic', $usage_data, 'Multiple choice key' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_teacher_count
 	 */
 	public function testGetUsageDataTeachers() {

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -306,25 +306,25 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 */
 	public function testGetRandomOrderCount() {
 		// Create some questions.
-		$questions[] = $this->factory->post->create_many( 3, array(
+		$questions = $this->factory->post->create_many( 3, array(
 			'post_type' => 'question',
 			'post_status' => 'publish',
 		) );
 
 		// Set the type of each question to be multiple choice.
-		wp_set_post_terms( $questions[0][0], array( 'multiple-choice' ), 'question-type' );
-		wp_set_post_terms( $questions[0][1], array( 'multiple-choice' ), 'question-type' );
-		wp_set_post_terms( $questions[0][2], array( 'multiple-choice' ), 'question-type' );
+		wp_set_post_terms( $questions[0], array( 'multiple-choice' ), 'question-type' );
+		wp_set_post_terms( $questions[1], array( 'multiple-choice' ), 'question-type' );
+		wp_set_post_terms( $questions[2], array( 'multiple-choice' ), 'question-type' );
 
 		// Set the random answer order.
-		add_post_meta( $questions[0][0], '_random_order', 'yes' );
-		add_post_meta( $questions[0][1], '_random_order', 'no' );
-		add_post_meta( $questions[0][2], '_random_order', 'yes' );
+		add_post_meta( $questions[0], '_random_order', 'yes' );
+		add_post_meta( $questions[1], '_random_order', 'no' );
+		add_post_meta( $questions[2], '_random_order', 'yes' );
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'random_order', $usage_data, 'Key' );
-		$this->assertEquals( 2, $usage_data['random_order'], 'Count' );
+		$this->assertArrayHasKey( 'question_random_order', $usage_data, 'Key' );
+		$this->assertEquals( 2, $usage_data['question_random_order'], 'Count' );
 	}
 
 	/**
@@ -333,32 +333,31 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 */
 	public function testGetRandomOrderCountMultipleChoiceOnly() {
 		// Create some questions.
-		$questions[] = $this->factory->post->create_many( 6, array(
+		$questions = $this->factory->post->create_many( 6, array(
 			'post_type' => 'question',
 			'post_status' => 'publish',
 		) );
 
 		// Create a question of each type.
-		wp_set_post_terms( $questions[0][0], array( 'multiple-choice' ), 'question-type' );
-		wp_set_post_terms( $questions[0][1], array( 'multi-line' ), 'question-type' );
-		wp_set_post_terms( $questions[0][2], array( 'single-line' ), 'question-type' );
-		wp_set_post_terms( $questions[0][3], array( 'boolean' ), 'question-type' );
-		wp_set_post_terms( $questions[0][4], array( 'file-upload' ), 'question-type' );
-		wp_set_post_terms( $questions[0][5], array( 'gap-fill' ), 'question-type' );
-
+		wp_set_post_terms( $questions[0], array( 'multiple-choice' ), 'question-type' );
+		wp_set_post_terms( $questions[1], array( 'multi-line' ), 'question-type' );
+		wp_set_post_terms( $questions[2], array( 'single-line' ), 'question-type' );
+		wp_set_post_terms( $questions[3], array( 'boolean' ), 'question-type' );
+		wp_set_post_terms( $questions[4], array( 'file-upload' ), 'question-type' );
+		wp_set_post_terms( $questions[5], array( 'gap-fill' ), 'question-type' );
 
 		// Turn on random answer order for non-multiple choice questions.
-		add_post_meta( $questions[0][0], '_random_order', 'no' );
-		add_post_meta( $questions[0][1], '_random_order', 'yes' );
-		add_post_meta( $questions[0][2], '_random_order', 'yes' );
-		add_post_meta( $questions[0][3], '_random_order', 'yes' );
-		add_post_meta( $questions[0][4], '_random_order', 'yes' );
-		add_post_meta( $questions[0][5], '_random_order', 'yes' );
+		add_post_meta( $questions[0], '_random_order', 'no' );
+		add_post_meta( $questions[1], '_random_order', 'yes' );
+		add_post_meta( $questions[2], '_random_order', 'yes' );
+		add_post_meta( $questions[3], '_random_order', 'yes' );
+		add_post_meta( $questions[4], '_random_order', 'yes' );
+		add_post_meta( $questions[5], '_random_order', 'yes' );
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'random_order', $usage_data, 'Key' );
-		$this->assertEquals( 0, $usage_data['random_order'], 'Count' );
+		$this->assertArrayHasKey( 'question_random_order', $usage_data, 'Key' );
+		$this->assertEquals( 0, $usage_data['question_random_order'], 'Count' );
 	}
 
 	/**


### PR DESCRIPTION
This PR logs the following usage tracking data:

- Total number of published questions of each type:
  - Multiple Choice
  - True/False
  - Gap Fill
  - Single Line
  - Multi Line
  - File Upload
- Total number of published questions where _Randomise answer order_ is checked
- Total number of published questions that have media

## Testing

1. Check that the tests run.
2. Check that `question_media`, `question_random_order` and counts for each of the question types (`question_boolean`, `question_file_upload`, `question_gap_fill`, `question_multi_line`, `question_multiple_choice` and `question_single_line`) are correctly logged in Tracks.