### PR TITLE
Get lesson usage stats

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -25,6 +25,7 @@ class Sensei_Usage_Tracking_Data {
 			'courses' => wp_count_posts( 'course' )->publish,
 			'learners' => self::get_learner_count(),
 			'lessons' => wp_count_posts( 'lesson' )->publish,
+			'lesson_modules' => self::get_lesson_module_count(),
 			'lesson_prereqs' => self::get_lesson_prerequisite_count(),
 			'lesson_previews' => self::get_lesson_preview_count(),
 			'messages' => wp_count_posts( 'sensei_message' )->publish,
@@ -124,6 +125,29 @@ class Sensei_Usage_Tracking_Data {
 
 		return $query->found_posts;
 	}
+
+	/**
+	 * Get the total number of published lessons that are associated with a module.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return array Number of published lessons associated with a module.
+	 **/
+	private static function get_lesson_module_count() {
+		$query = new WP_Query( array(
+			'post_type' => 'lesson',
+			'fields' => 'ids',
+			'tax_query' => array(
+				array(
+					'taxonomy' => 'module',
+					'operator' => 'EXISTS'
+				)
+			)
+		) );
+
+		return $query->found_posts;
+	}
+
 
 	/**
 	 * Get the total number of modules for the published course that has the greatest

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -26,6 +26,7 @@ class Sensei_Usage_Tracking_Data {
 			'learners' => self::get_learner_count(),
 			'lessons' => wp_count_posts( 'lesson' )->publish,
 			'lesson_prereqs' => self::get_lesson_prerequisite_count(),
+			'lesson_previews' => self::get_lesson_preview_count(),
 			'messages' => wp_count_posts( 'sensei_message' )->publish,
 			'modules' => wp_count_terms( 'module' ),
 			'modules_max' => self::get_max_module_count(),
@@ -94,6 +95,29 @@ class Sensei_Usage_Tracking_Data {
 					'key' => '_lesson_prerequisite',
 					'value' => 0,
 					'compare' => '>',
+				)
+			)
+		) );
+
+		return $query->found_posts;
+	}
+
+	/**
+	 * Get the total number of published lessons that enable previewing.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return array Number of published lessons that enable previewing.
+	 **/
+	private static function get_lesson_preview_count() {
+		$query = new WP_Query( array(
+			'post_type' => 'lesson',
+			'fields' => 'ids',
+			'meta_query' => array(
+				array(
+					'key' => '_lesson_preview',
+					'value' => '',
+					'compare' => '!=',
 				)
 			)
 		) );

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -25,6 +25,7 @@ class Sensei_Usage_Tracking_Data {
 			'courses' => wp_count_posts( 'course' )->publish,
 			'learners' => self::get_learner_count(),
 			'lessons' => wp_count_posts( 'lesson' )->publish,
+			'lesson_prereqs' => self::get_lesson_prerequisite_count(),
 			'messages' => wp_count_posts( 'sensei_message' )->publish,
 			'modules' => wp_count_terms( 'module' ),
 			'modules_max' => self::get_max_module_count(),
@@ -75,6 +76,29 @@ class Sensei_Usage_Tracking_Data {
 		}
 
 		return $learner_count;
+	}
+
+	/**
+	 * Get the total number of published lessons that have a prerequisite set.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return array Number of published lessons with a prerequisite.
+	 **/
+	private static function get_lesson_prerequisite_count() {
+		$query = new WP_Query( array(
+			'post_type' => 'lesson',
+			'fields' => 'ids',
+			'meta_query' => array(
+				array(
+					'key' => '_lesson_prerequisite',
+					'value' => 0,
+					'compare' => '>',
+				)
+			)
+		) );
+
+		return $query->found_posts;
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -116,6 +116,45 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->assertEquals( $published, $usage_data['lessons'], 'Count' );
 	}
 
+		/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_lesson_prerequisite_count
+	 */
+	public function testGetLessonPrerequisiteCount() {
+		// Create some lessons.
+		$lessons = $this->factory->post->create_many( 5, array(
+			'post_status' => 'publish',
+			'post_type' => 'lesson',
+		) );
+
+		// Make some lessons prerequisites of others.
+		add_post_meta( $lessons[1], '_lesson_prerequisite', $lessons[0] );
+		add_post_meta( $lessons[2], '_lesson_prerequisite', $lessons[1] );
+		add_post_meta( $lessons[3], '_lesson_prerequisite', $lessons[2] );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'lesson_prereqs', $usage_data, 'Key' );
+		$this->assertEquals( 3, $usage_data['lesson_prereqs'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_lesson_prerequisite_count
+	 */
+	public function testGetLessonPrerequisiteCountNoPrerequisites() {
+		// Create some lessons, but don't add any prerequisites.
+		$lessons = $this->factory->post->create_many( 5, array(
+			'post_status' => 'publish',
+			'post_type' => 'lesson',
+		) );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'lesson_prereqs', $usage_data, 'Key' );
+		$this->assertEquals( 0, $usage_data['lesson_prereqs'], 'Count' );
+	}
+
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 */

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -41,6 +41,20 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		);
 	}
 
+	// Create some published and unpublished lessons.
+	private function createLessons() {
+		$drafts = $this->factory->post->create_many( 2, array(
+			'post_status' => 'draft',
+			'post_type' => 'lesson',
+		) );
+		$published = $this->factory->post->create_many( 3, array(
+			'post_status' => 'publish',
+			'post_type' => 'lesson',
+		) );
+
+		return array_merge( $drafts, $published );
+	}
+
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 */
@@ -98,44 +112,30 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 */
 	public function testGetUsageDataLessons() {
-		$published = 3;
-
-		// Create some published and unpublished lessons.
-		$this->factory->post->create_many( 2, array(
-			'post_status' => 'draft',
-			'post_type' => 'lesson',
-		) );
-		$this->factory->post->create_many( $published, array(
-			'post_status' => 'publish',
-			'post_type' => 'lesson',
-		) );
+		$this->createLessons();
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertArrayHasKey( 'lessons', $usage_data, 'Key' );
-		$this->assertEquals( $published, $usage_data['lessons'], 'Count' );
+		$this->assertEquals( 3, $usage_data['lessons'], 'Count' );
 	}
 
-		/**
+	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_lesson_prerequisite_count
 	 */
 	public function testGetLessonPrerequisiteCount() {
-		// Create some lessons.
-		$lessons = $this->factory->post->create_many( 5, array(
-			'post_status' => 'publish',
-			'post_type' => 'lesson',
-		) );
+		$lessons = $this->createLessons();
 
 		// Make some lessons prerequisites of others.
-		add_post_meta( $lessons[1], '_lesson_prerequisite', $lessons[0] );
-		add_post_meta( $lessons[2], '_lesson_prerequisite', $lessons[1] );
-		add_post_meta( $lessons[3], '_lesson_prerequisite', $lessons[2] );
+		add_post_meta( $lessons[1], '_lesson_prerequisite', $lessons[0] );	// Draft
+		add_post_meta( $lessons[2], '_lesson_prerequisite', $lessons[1] );	// Published
+		add_post_meta( $lessons[3], '_lesson_prerequisite', $lessons[2] );	// Published
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertArrayHasKey( 'lesson_prereqs', $usage_data, 'Key' );
-		$this->assertEquals( 3, $usage_data['lesson_prereqs'], 'Count' );
+		$this->assertEquals( 2, $usage_data['lesson_prereqs'], 'Count' );
 	}
 
 	/**
@@ -143,11 +143,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_lesson_prerequisite_count
 	 */
 	public function testGetLessonPrerequisiteCountNoPrerequisites() {
-		// Create some lessons, but don't add any prerequisites.
-		$lessons = $this->factory->post->create_many( 5, array(
-			'post_status' => 'publish',
-			'post_type' => 'lesson',
-		) );
+		$lessons = $this->createLessons();
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -153,6 +153,37 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_lesson_preview_count
+	 */
+	public function testGetLessonPreviewCount() {
+		$lessons = $this->createLessons();
+
+		// Turn on previews for some lessons.
+		add_post_meta( $lessons[0], '_lesson_preview', 'preview' ); // Draft
+		add_post_meta( $lessons[2], '_lesson_preview', 'preview' ); // Published
+		add_post_meta( $lessons[3], '_lesson_preview', 'preview' ); // Published
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'lesson_previews', $usage_data, 'Key' );
+		$this->assertEquals( 2, $usage_data['lesson_previews'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_lesson_preview_count
+	 */
+	public function testGetLessonPreviewCountNoPreviews() {
+		$lessons = $this->createLessons();
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'lesson_previews', $usage_data, 'Key' );
+		$this->assertEquals( 0, $usage_data['lesson_previews'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 */
 	public function testGetUsageDataMessages() {
 		$published = 10;

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -182,6 +182,38 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->assertEquals( 0, $usage_data['lesson_previews'], 'Count' );
 	}
 
+		/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_lesson_module_count
+	 */
+	public function testGetLessonModuleCount() {
+		$lessons = $this->createLessons();
+		$terms = $this->factory->term->create_many( 3, array( 'taxonomy' => 'module' ) );
+
+		// Assign modules to some lessons.
+		wp_set_object_terms( $lessons[0], $terms[0], 'module', false ); // Draft
+		wp_set_object_terms( $lessons[2], $terms[1], 'module', false ); // Published
+		wp_set_object_terms( $lessons[4], $terms[2], 'module', false ); // Published
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'lesson_modules', $usage_data, 'Key' );
+		$this->assertEquals( 2, $usage_data['lesson_modules'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_lesson_module_count
+	 */
+	public function testGetLessonModuleCountNoModules() {
+		$lessons = $this->createLessons();
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'lesson_modules', $usage_data, 'Key' );
+		$this->assertEquals( 0, $usage_data['lesson_modules'], 'Count' );
+	}
+
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 */


### PR DESCRIPTION
This PR logs the following usage tracking data:

- Total number of published lessons that have:
  - _Lesson Prerequisite_ set to something other than _None_
  - _Allow this lesson to be viewed without purchase/login_ checked
  - _Lesson Module_ set to something other than _None_

## Testing

1. Check that the tests run.
2. Check that lesson data is correctly logged in Tracks.