### PR TITLE
Add course usage tracking

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -24,6 +24,7 @@ class Sensei_Usage_Tracking_Data {
 		return array(
 			'courses' => wp_count_posts( 'course' )->publish,
 			'courses_with_video' => self::get_courses_with_video_count(),
+			'courses_with_disabled_notification' => self::get_courses_with_disabled_notification_count(),
 			'learners' => self::get_learner_count(),
 			'lessons' => wp_count_posts( 'lesson' )->publish,
 			'messages' => wp_count_posts( 'sensei_message' )->publish,
@@ -52,6 +53,27 @@ class Sensei_Usage_Tracking_Data {
 					'compare' => '!=',
 				)
 			)
+		) );
+
+		return $query->post_count;
+	}
+
+	/**
+	 * Get the number of courses that have disabled notifications.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return int Number of courses.
+	 */
+	private static function get_courses_with_disabled_notification_count() {
+		$query = new WP_Query( array(
+			'post_type' => 'course',
+			'meta_query' => array(
+				array(
+					'key' => 'disable_notification',
+					'value' => true,
+				)
+			),
 		) );
 
 		return $query->post_count;

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -23,9 +23,9 @@ class Sensei_Usage_Tracking_Data {
 	public static function get_usage_data() {
 		return array(
 			'courses' => wp_count_posts( 'course' )->publish,
-			'courses_with_video' => self::get_courses_with_video_count(),
-			'courses_with_disabled_notification' => self::get_courses_with_disabled_notification_count(),
-			'courses_with_prerequisite' => self::get_courses_with_prerequisite_count(),
+			'course_videos' => self::get_course_videos_count(),
+			'course_no_notifications' => self::get_course_no_notifications_count(),
+			'course_prereqs' => self::get_course_prereqs_count(),
 			'featured_courses' => self::get_featured_courses_count(),
 			'learners' => self::get_learner_count(),
 			'lessons' => wp_count_posts( 'lesson' )->publish,
@@ -45,7 +45,7 @@ class Sensei_Usage_Tracking_Data {
 	 *
 	 * @return int Number of courses.
 	 */
-	private static function get_courses_with_video_count() {
+	private static function get_course_videos_count() {
 		$query = new WP_Query( array(
 			'post_type' => 'course',
 			'fields' => 'ids',
@@ -68,7 +68,7 @@ class Sensei_Usage_Tracking_Data {
 	 *
 	 * @return int Number of courses.
 	 */
-	private static function get_courses_with_disabled_notification_count() {
+	private static function get_course_no_notifications_count() {
 		$query = new WP_Query( array(
 			'post_type' => 'course',
 			'fields' => 'ids',
@@ -90,7 +90,7 @@ class Sensei_Usage_Tracking_Data {
 	 *
 	 * @return int Number of courses.
 	 */
-	private static function get_courses_with_prerequisite_count() {
+	private static function get_course_prereqs_count() {
 		$query = new WP_Query( array(
 			'post_type' => 'course',
 			'fields' => 'ids',

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -96,7 +96,12 @@ class Sensei_Usage_Tracking_Data {
 					'key' => '_course_prerequisite',
 					'value' => '',
 					'compare' => '!=',
-				)
+				),
+				array(
+					'key' => '_course_prerequisite',
+					'value' => '0',
+					'compare' => '!=',
+				),
 			),
 		) );
 

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -26,6 +26,7 @@ class Sensei_Usage_Tracking_Data {
 			'courses_with_video' => self::get_courses_with_video_count(),
 			'courses_with_disabled_notification' => self::get_courses_with_disabled_notification_count(),
 			'courses_with_prerequisite' => self::get_courses_with_prerequisite_count(),
+			'featured_courses' => self::get_featured_courses_count(),
 			'learners' => self::get_learner_count(),
 			'lessons' => wp_count_posts( 'lesson' )->publish,
 			'messages' => wp_count_posts( 'sensei_message' )->publish,
@@ -95,6 +96,27 @@ class Sensei_Usage_Tracking_Data {
 					'key' => '_course_prerequisite',
 					'value' => '',
 					'compare' => '!=',
+				)
+			),
+		) );
+
+		return $query->post_count;
+	}
+
+	/**
+	 * Get the number of courses that are featured.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return int Number of courses.
+	 */
+	private static function get_featured_courses_count() {
+		$query = new WP_Query( array(
+			'post_type' => 'course',
+			'meta_query' => array(
+				array(
+					'key' => '_course_featured',
+					'value' => 'featured',
 				)
 			),
 		) );

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -57,7 +57,7 @@ class Sensei_Usage_Tracking_Data {
 			)
 		) );
 
-		return $query->post_count;
+		return $query->found_posts;
 	}
 
 	/**
@@ -78,7 +78,7 @@ class Sensei_Usage_Tracking_Data {
 			),
 		) );
 
-		return $query->post_count;
+		return $query->found_posts;
 	}
 
 	/**
@@ -105,7 +105,7 @@ class Sensei_Usage_Tracking_Data {
 			),
 		) );
 
-		return $query->post_count;
+		return $query->found_posts;
 	}
 
 	/**
@@ -126,7 +126,7 @@ class Sensei_Usage_Tracking_Data {
 			),
 		) );
 
-		return $query->post_count;
+		return $query->found_posts;
 	}
 
 	/**

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -23,6 +23,7 @@ class Sensei_Usage_Tracking_Data {
 	public static function get_usage_data() {
 		return array(
 			'courses' => wp_count_posts( 'course' )->publish,
+			'courses_with_video' => self::get_courses_with_video_count(),
 			'learners' => self::get_learner_count(),
 			'lessons' => wp_count_posts( 'lesson' )->publish,
 			'messages' => wp_count_posts( 'sensei_message' )->publish,
@@ -32,6 +33,28 @@ class Sensei_Usage_Tracking_Data {
 			'questions' => wp_count_posts( 'question' )->publish,
 			'teachers' => self::get_teacher_count(),
 		);
+	}
+
+	/**
+	 * Get the number of courses that have a video set.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return int Number of courses.
+	 */
+	private static function get_courses_with_video_count() {
+		$query = new WP_Query( array(
+			'post_type' => 'course',
+			'meta_query' => array(
+				array(
+					'key' => '_course_video_embed',
+					'value' => '',
+					'compare' => '!=',
+				)
+			)
+		) );
+
+		return $query->post_count;
 	}
 
 	/**

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -25,6 +25,7 @@ class Sensei_Usage_Tracking_Data {
 			'courses' => wp_count_posts( 'course' )->publish,
 			'courses_with_video' => self::get_courses_with_video_count(),
 			'courses_with_disabled_notification' => self::get_courses_with_disabled_notification_count(),
+			'courses_with_prerequisite' => self::get_courses_with_prerequisite_count(),
 			'learners' => self::get_learner_count(),
 			'lessons' => wp_count_posts( 'lesson' )->publish,
 			'messages' => wp_count_posts( 'sensei_message' )->publish,
@@ -72,6 +73,28 @@ class Sensei_Usage_Tracking_Data {
 				array(
 					'key' => 'disable_notification',
 					'value' => true,
+				)
+			),
+		) );
+
+		return $query->post_count;
+	}
+
+	/**
+	 * Get the number of courses that have a prerequisite.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return int Number of courses.
+	 */
+	private static function get_courses_with_prerequisite_count() {
+		$query = new WP_Query( array(
+			'post_type' => 'course',
+			'meta_query' => array(
+				array(
+					'key' => '_course_prerequisite',
+					'value' => '',
+					'compare' => '!=',
 				)
 			),
 		) );

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -48,6 +48,7 @@ class Sensei_Usage_Tracking_Data {
 	private static function get_courses_with_video_count() {
 		$query = new WP_Query( array(
 			'post_type' => 'course',
+			'fields' => 'ids',
 			'meta_query' => array(
 				array(
 					'key' => '_course_video_embed',
@@ -70,6 +71,7 @@ class Sensei_Usage_Tracking_Data {
 	private static function get_courses_with_disabled_notification_count() {
 		$query = new WP_Query( array(
 			'post_type' => 'course',
+			'fields' => 'ids',
 			'meta_query' => array(
 				array(
 					'key' => 'disable_notification',
@@ -91,6 +93,7 @@ class Sensei_Usage_Tracking_Data {
 	private static function get_courses_with_prerequisite_count() {
 		$query = new WP_Query( array(
 			'post_type' => 'course',
+			'fields' => 'ids',
 			'meta_query' => array(
 				array(
 					'key' => '_course_prerequisite',
@@ -118,6 +121,7 @@ class Sensei_Usage_Tracking_Data {
 	private static function get_featured_courses_count() {
 		$query = new WP_Query( array(
 			'post_type' => 'course',
+			'fields' => 'ids',
 			'meta_query' => array(
 				array(
 					'key' => '_course_featured',

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -286,6 +286,9 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			update_post_meta( $course_id, '_course_prerequisite', $course_ids_without_prereq[0] );
 		}
 
+		// Another value for no prereq
+		update_post_meta( $course_ids_without_prereq[1], '_course_prerequisite', '0' );
+
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertArrayHasKey( 'courses_with_prerequisite', $usage_data, 'Key' );

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -212,4 +212,34 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'teachers', $usage_data, 'Key' );
 		$this->assertEquals( $teachers, $usage_data['teachers'], 'Count' );
 	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_courses_with_video_count
+	 */
+	public function testGetCoursesWithVideoCount() {
+		$with_video = 2;
+
+		// Create some published and unpublished courses.
+		$course_ids_without_video = $this->factory->post->create_many( 3, array(
+			'post_type' => 'course',
+		) );
+		$course_ids_with_video = $this->factory->post->create_many( $with_video, array(
+			'post_type' => 'course',
+		) );
+
+		// Set video on courses
+		foreach ( $course_ids_with_video as $course_id ) {
+			update_post_meta( $course_id, '_course_video_embed', '<iframe src="video.com"></iframe' );
+		}
+
+		// Set some non-null values on the others
+		update_post_meta( $course_ids_without_video[0], '_course_video_embed', '' );
+		update_post_meta( $course_ids_without_video[1], '_course_video_embed', '   ' );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'courses_with_video', $usage_data, 'Key' );
+		$this->assertEquals( $with_video, $usage_data['courses_with_video'], 'Count' );
+	}
 }

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -220,7 +220,6 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetCoursesWithVideoCount() {
 		$with_video = 2;
 
-		// Create some published and unpublished courses.
 		$course_ids_without_video = $this->factory->post->create_many( 3, array(
 			'post_type' => 'course',
 		) );
@@ -250,7 +249,6 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetCoursesWithDisabledNotificationCount() {
 		$with_disabled_notification = 2;
 
-		// Create some published and unpublished courses.
 		$course_ids_without_disabled = $this->factory->post->create_many( 3, array(
 			'post_type' => 'course',
 		) );
@@ -258,7 +256,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			'post_type' => 'course',
 		) );
 
-		// Set video on courses
+		// Disable notifications
 		foreach ( $course_ids_with_disabled as $course_id ) {
 			update_post_meta( $course_id, 'disable_notification', true );
 		}
@@ -276,7 +274,6 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetCoursesWithPrerequisiteCount() {
 		$with_prereq = 2;
 
-		// Create some published and unpublished courses.
 		$course_ids_without_prereq = $this->factory->post->create_many( 3, array(
 			'post_type' => 'course',
 		) );
@@ -284,7 +281,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			'post_type' => 'course',
 		) );
 
-		// Set video on courses
+		// Set prerequisite on courses
 		foreach ( $course_ids_with_prereq as $course_id ) {
 			update_post_meta( $course_id, '_course_prerequisite', $course_ids_without_prereq[0] );
 		}
@@ -293,5 +290,30 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'courses_with_prerequisite', $usage_data, 'Key' );
 		$this->assertEquals( $with_prereq, $usage_data['courses_with_prerequisite'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_featured_courses_count
+	 */
+	public function testGetFeaturedCoursesCount() {
+		$featured = 2;
+
+		$non_featured_course_ids = $this->factory->post->create_many( 3, array(
+			'post_type' => 'course',
+		) );
+		$featured_course_ids = $this->factory->post->create_many( $featured, array(
+			'post_type' => 'course',
+		) );
+
+		// Set courses to featured
+		foreach ( $featured_course_ids as $course_id ) {
+			update_post_meta( $course_id, '_course_featured', 'featured' );
+		}
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'featured_courses', $usage_data, 'Key' );
+		$this->assertEquals( $featured, $usage_data['featured_courses'], 'Count' );
 	}
 }

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -268,4 +268,30 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'courses_with_disabled_notification', $usage_data, 'Key' );
 		$this->assertEquals( $with_disabled_notification, $usage_data['courses_with_disabled_notification'], 'Count' );
 	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_courses_with_prerequisite count
+	 */
+	public function testGetCoursesWithPrerequisiteCount() {
+		$with_prereq = 2;
+
+		// Create some published and unpublished courses.
+		$course_ids_without_prereq = $this->factory->post->create_many( 3, array(
+			'post_type' => 'course',
+		) );
+		$course_ids_with_prereq = $this->factory->post->create_many( $with_prereq, array(
+			'post_type' => 'course',
+		) );
+
+		// Set video on courses
+		foreach ( $course_ids_with_prereq as $course_id ) {
+			update_post_meta( $course_id, '_course_prerequisite', $course_ids_without_prereq[0] );
+		}
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'courses_with_prerequisite', $usage_data, 'Key' );
+		$this->assertEquals( $with_prereq, $usage_data['courses_with_prerequisite'], 'Count' );
+	}
 }

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -242,4 +242,30 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'courses_with_video', $usage_data, 'Key' );
 		$this->assertEquals( $with_video, $usage_data['courses_with_video'], 'Count' );
 	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_courses_with_disabled_notification_count
+	 */
+	public function testGetCoursesWithDisabledNotificationCount() {
+		$with_disabled_notification = 2;
+
+		// Create some published and unpublished courses.
+		$course_ids_without_disabled = $this->factory->post->create_many( 3, array(
+			'post_type' => 'course',
+		) );
+		$course_ids_with_disabled = $this->factory->post->create_many( $with_disabled_notification, array(
+			'post_type' => 'course',
+		) );
+
+		// Set video on courses
+		foreach ( $course_ids_with_disabled as $course_id ) {
+			update_post_meta( $course_id, 'disable_notification', true );
+		}
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'courses_with_disabled_notification', $usage_data, 'Key' );
+		$this->assertEquals( $with_disabled_notification, $usage_data['courses_with_disabled_notification'], 'Count' );
+	}
 }

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -238,8 +238,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'courses_with_video', $usage_data, 'Key' );
-		$this->assertEquals( $with_video, $usage_data['courses_with_video'], 'Count' );
+		$this->assertArrayHasKey( 'course_videos', $usage_data, 'Key' );
+		$this->assertEquals( $with_video, $usage_data['course_videos'], 'Count' );
 	}
 
 	/**
@@ -263,8 +263,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'courses_with_disabled_notification', $usage_data, 'Key' );
-		$this->assertEquals( $with_disabled_notification, $usage_data['courses_with_disabled_notification'], 'Count' );
+		$this->assertArrayHasKey( 'course_no_notifications', $usage_data, 'Key' );
+		$this->assertEquals( $with_disabled_notification, $usage_data['course_no_notifications'], 'Count' );
 	}
 
 	/**
@@ -291,8 +291,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'courses_with_prerequisite', $usage_data, 'Key' );
-		$this->assertEquals( $with_prereq, $usage_data['courses_with_prerequisite'], 'Count' );
+		$this->assertArrayHasKey( 'course_prereqs', $usage_data, 'Key' );
+		$this->assertEquals( $with_prereq, $usage_data['course_prereqs'], 'Count' );
 	}
 
 	/**


### PR DESCRIPTION
Adds the following values to the usage tracking data:

- Number of courses with a video
- Number of courses for which notifications are disabled
- Number of courses with a prerequisite
- Number of courses that are featured

## Testing

- Ensure the phpunit tests pass

- Log to Tracks and check for the following keys:
  - `courses_with_video`
  - `courses_with_disabled_notification`
  - `courses_with_prerequisite`
  - `featured_courses`
