### PR TITLE
Add lesson information tracking

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -318,8 +318,8 @@ class Sensei_Usage_Tracking_Data {
 			'meta_query' => array(
 				array(
 					'key' => '_lesson_video_embed',
-					'value' => '',
-					'compare' => '!=',
+					'value' => '[^[:space:]]',
+					'compare' => 'REGEXP',
 				)
 			)
 		) );

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -33,6 +33,9 @@ class Sensei_Usage_Tracking_Data {
 			'lesson_modules' => self::get_lesson_module_count(),
 			'lesson_prereqs' => self::get_lesson_prerequisite_count(),
 			'lesson_previews' => self::get_lesson_preview_count(),
+			'lesson_length' => self::get_lesson_has_length_count(),
+			'lesson_complexity' => self::get_lesson_with_complexity_count(),
+			'lesson_videos' => self::get_lesson_with_video_count(),
 			'messages' => wp_count_posts( 'sensei_message' )->publish,
 			'modules' => wp_count_terms( 'module' ),
 			'modules_max' => self::get_max_module_count(),
@@ -248,6 +251,75 @@ class Sensei_Usage_Tracking_Data {
 				array(
 					'taxonomy' => 'module',
 					'operator' => 'EXISTS'
+				)
+			)
+		) );
+
+		return $query->found_posts;
+	}
+
+	/**
+	 * Get the number of lessons for which the "lesson length" has been set.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return int Number of lessons.
+	 **/
+	private static function get_lesson_has_length_count() {
+		$query = new WP_Query( array(
+			'post_type' => 'lesson',
+			'fields' => 'ids',
+			'meta_query' => array(
+				array(
+					'key' => '_lesson_length',
+					'value' => '',
+					'compare' => '!=',
+				)
+			)
+		) );
+
+		return $query->found_posts;
+	}
+
+	/**
+	 * Get the number of lessons for which the "lesson complexity" has been set.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return int Number of lessons.
+	 **/
+	private static function get_lesson_with_complexity_count() {
+		$query = new WP_Query( array(
+			'post_type' => 'lesson',
+			'fields' => 'ids',
+			'meta_query' => array(
+				array(
+					'key' => '_lesson_complexity',
+					'value' => '',
+					'compare' => '!=',
+				)
+			)
+		) );
+
+		return $query->found_posts;
+	}
+
+	/**
+	 * Get the number of lessons that have a video.
+	 *
+	 * @since 1.9.20
+	 *
+	 * @return int Number of lessons.
+	 **/
+	private static function get_lesson_with_video_count() {
+		$query = new WP_Query( array(
+			'post_type' => 'lesson',
+			'fields' => 'ids',
+			'meta_query' => array(
+				array(
+					'key' => '_lesson_video_embed',
+					'value' => '',
+					'compare' => '!=',
 				)
 			)
 		) );

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -583,4 +583,86 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'featured_courses', $usage_data, 'Key' );
 		$this->assertEquals( $featured, $usage_data['featured_courses'], 'Count' );
 	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_lesson_has_length_count
+	 */
+	public function testGetLessonHasLengthCount() {
+		$lessons_with_length = 3;
+
+		// Create some lessons
+		$lesson_without_length_ids = $this->factory->post->create_many( 2, array(
+			'post_type' => 'lesson',
+		) );
+		$lesson_with_length_ids = $this->factory->post->create_many( $lessons_with_length, array(
+			'post_type' => 'lesson',
+		) );
+
+		// Set lesson length
+		foreach ( $lesson_with_length_ids as $lesson_id ) {
+			update_post_meta( $lesson_id, '_lesson_length', '15' );
+		}
+		update_post_meta( $lesson_without_length_ids[0], '_lesson_length', '' );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'lesson_length', $usage_data, 'Key' );
+		$this->assertEquals( $lessons_with_length, $usage_data['lesson_length'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_lesson_with_complexity_count
+	 */
+	public function testGetLessonWithComplexityCount() {
+		$lessons_with_complexity = 3;
+
+		// Create some lessons
+		$lesson_without_complexity_ids = $this->factory->post->create_many( 2, array(
+			'post_type' => 'lesson',
+		) );
+		$lesson_with_complexity_ids = $this->factory->post->create_many( $lessons_with_complexity, array(
+			'post_type' => 'lesson',
+		) );
+
+		// Set lesson complexity
+		foreach ( $lesson_with_complexity_ids as $lesson_id ) {
+			update_post_meta( $lesson_id, '_lesson_complexity', '15' );
+		}
+		update_post_meta( $lesson_without_complexity_ids[0], '_lesson_complexity', '' );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'lesson_complexity', $usage_data, 'Key' );
+		$this->assertEquals( $lessons_with_complexity, $usage_data['lesson_complexity'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_lesson_with_video_count
+	 */
+	public function testGetLessonWithVideoCount() {
+		$lessons_with_video = 3;
+
+		// Create some lessons
+		$lesson_without_video_ids = $this->factory->post->create_many( 2, array(
+			'post_type' => 'lesson',
+		) );
+		$lesson_with_video_ids = $this->factory->post->create_many( $lessons_with_video, array(
+			'post_type' => 'lesson',
+		) );
+
+		// Set lesson complexity
+		foreach ( $lesson_with_video_ids as $lesson_id ) {
+			update_post_meta( $lesson_id, '_lesson_video_embed', '<iframe src="http://example.com/video"></iframe>' );
+		}
+		update_post_meta( $lesson_without_video_ids[0], '_lesson_video_embed', '' );
+		update_post_meta( $lesson_without_video_ids[1], '_lesson_video_embed', '    ' );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'lesson_videos', $usage_data, 'Key' );
+		$this->assertEquals( $lessons_with_video, $usage_data['lesson_videos'], 'Count' );
+	}
 }

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -643,22 +643,24 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_lesson_with_video_count
 	 */
 	public function testGetLessonWithVideoCount() {
-		$lessons_with_video = 3;
+		$lessons_with_video = 4;
 
 		// Create some lessons
-		$lesson_without_video_ids = $this->factory->post->create_many( 2, array(
+		$lesson_without_video_ids = $this->factory->post->create_many( 4, array(
 			'post_type' => 'lesson',
 		) );
 		$lesson_with_video_ids = $this->factory->post->create_many( $lessons_with_video, array(
 			'post_type' => 'lesson',
 		) );
 
-		// Set lesson complexity
-		foreach ( $lesson_with_video_ids as $lesson_id ) {
-			update_post_meta( $lesson_id, '_lesson_video_embed', '<iframe src="http://example.com/video"></iframe>' );
-		}
+		// Set lesson videos
+		update_post_meta( $lesson_with_video_ids[0], '_lesson_video_embed', '<iframe src="http://example.com/video"></iframe>' );
+		update_post_meta( $lesson_with_video_ids[1], '_lesson_video_embed', '<iframe> </iframe>' );
+		update_post_meta( $lesson_with_video_ids[2], '_lesson_video_embed', 'blah' );
+		update_post_meta( $lesson_with_video_ids[3], '_lesson_video_embed', 'blah with spaces' );
 		update_post_meta( $lesson_without_video_ids[0], '_lesson_video_embed', '' );
 		update_post_meta( $lesson_without_video_ids[1], '_lesson_video_embed', '    ' );
+		update_post_meta( $lesson_without_video_ids[2], '_lesson_video_embed', "\t\n" );
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -628,7 +628,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Set lesson complexity
 		foreach ( $lesson_with_complexity_ids as $lesson_id ) {
-			update_post_meta( $lesson_id, '_lesson_complexity', '15' );
+			update_post_meta( $lesson_id, '_lesson_complexity', 'Hard' );
 		}
 		update_post_meta( $lesson_without_complexity_ids[0], '_lesson_complexity', '' );
 


### PR DESCRIPTION
Adds the following values to the usage tracking data:

- Number of lessons with a length set
- Number of lessons with a complexity set
- Number of lessons with an embed video

## Testing

- Ensure the phpunit tests pass

- Log to Tracks and check for the following keys:
  - `lesson_length`
  - `lesson_complexity`
  - `lesson_videos`
