### PR TITLE
Fix the counting of courses with videos

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -54,14 +54,15 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Number of courses.
 	 */
 	private static function get_course_videos_count() {
+		// Match video strings with at least one non-space character
 		$query = new WP_Query( array(
 			'post_type' => 'course',
 			'fields' => 'ids',
 			'meta_query' => array(
 				array(
 					'key' => '_course_video_embed',
-					'value' => '',
-					'compare' => '!=',
+					'value' => '[\S]',
+					'compare' => 'REGEXP',
 				)
 			)
 		) );

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -61,8 +61,8 @@ class Sensei_Usage_Tracking_Data {
 			'meta_query' => array(
 				array(
 					'key' => '_course_video_embed',
-					'value' => '[[:space:]]',
-					'compare' => 'NOT REGEXP',
+					'value' => '[^[:space:]]',
+					'compare' => 'REGEXP',
 				)
 			)
 		) );

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -61,8 +61,8 @@ class Sensei_Usage_Tracking_Data {
 			'meta_query' => array(
 				array(
 					'key' => '_course_video_embed',
-					'value' => '\S',
-					'compare' => 'REGEXP',
+					'value' => '[[:space:]]',
+					'compare' => 'NOT REGEXP',
 				)
 			)
 		) );

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -61,7 +61,7 @@ class Sensei_Usage_Tracking_Data {
 			'meta_query' => array(
 				array(
 					'key' => '_course_video_embed',
-					'value' => '[\S]',
+					'value' => '\S',
 					'compare' => 'REGEXP',
 				)
 			)

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -490,9 +490,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		) );
 
 		// Set video on courses
-		foreach ( $course_ids_with_video as $course_id ) {
-			update_post_meta( $course_id, '_course_video_embed', '<iframe src="video.com"></iframe>' );
-		}
+		update_post_meta( $course_ids_with_video[0], '_course_video_embed', '<iframe src="video.com"></iframe>' );
+		update_post_meta( $course_ids_with_video[1], '_course_video_embed', 'blah' );
 
 		// Set some non-null values on the others
 		update_post_meta( $course_ids_without_video[0], '_course_video_embed', '' );

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -491,12 +491,13 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Set video on courses
 		foreach ( $course_ids_with_video as $course_id ) {
-			update_post_meta( $course_id, '_course_video_embed', '<iframe src="video.com"></iframe' );
+			update_post_meta( $course_id, '_course_video_embed', '<iframe src="video.com"></iframe>' );
 		}
 
 		// Set some non-null values on the others
 		update_post_meta( $course_ids_without_video[0], '_course_video_embed', '' );
 		update_post_meta( $course_ids_without_video[1], '_course_video_embed', '   ' );
+		update_post_meta( $course_ids_without_video[2], '_course_video_embed', "\t\n" );
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -480,7 +480,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_courses_with_video_count
 	 */
 	public function testGetCoursesWithVideoCount() {
-		$with_video = 2;
+		$with_video = 4;
 
 		$course_ids_without_video = $this->factory->post->create_many( 3, array(
 			'post_type' => 'course',
@@ -491,7 +491,9 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Set video on courses
 		update_post_meta( $course_ids_with_video[0], '_course_video_embed', '<iframe src="video.com"></iframe>' );
-		update_post_meta( $course_ids_with_video[1], '_course_video_embed', 'blah' );
+		update_post_meta( $course_ids_with_video[1], '_course_video_embed', '<iframe></iframe>' );
+		update_post_meta( $course_ids_with_video[2], '_course_video_embed', 'blah' );
+		update_post_meta( $course_ids_with_video[3], '_course_video_embed', 'blah with spaces' );
 
 		// Set some non-null values on the others
 		update_post_meta( $course_ids_without_video[0], '_course_video_embed', '' );


### PR DESCRIPTION
We now count a course as having a video only if it contains at least one non-whitespace character in the video embed field.

## Testing

- Add courses with various values in their Video Embed field. Include some that only have various types of whitespace characters, such as spaces, tabs, and newlines.

- Ensure that the count of courses with videos (for usage tracking) matches the number of videos that have at least one _non-whitespace character_ in their video field.