### PR TITLE
Don't include empty modules in course navigation

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -259,14 +259,17 @@ if ( ! defined( 'ABSPATH' ) ){ exit; } // Exit if accessed directly
 		// Add all modules and lessons for the current course to an array.
 		if ( ! empty( $course_modules ) ) {
 			foreach( (array) $course_modules as $module ) {
-				$modules_and_lessons[] = $module;
 				$module_lessons = Sensei()->modules->get_lessons( $course_id, $module->term_id );
 
-				if ( count( $module_lessons ) > 0 ) {
-					foreach ( $module_lessons as $lesson_item ) {
-						$modules_and_lessons[] = $lesson_item;
-						$lesson_ids[] = $lesson_item->ID;
-					}
+				if ( count( $module_lessons ) === 0 ) {
+					continue;
+				}
+
+				$modules_and_lessons[] = $module;
+
+				foreach ( $module_lessons as $lesson_item ) {
+					$modules_and_lessons[] = $lesson_item;
+					$lesson_ids[] = $lesson_item->ID;
 				}
 			}
 		}


### PR DESCRIPTION
If a course contains a module that does not have any lessons, that module should not be included in the course navigation.

Testing

1. Add a module that has not been assigned any lessons to a course.
2. On the front-end, step through the navigation links for that course and ensure that the empty module is not included in the navigation links.