### PR TITLE
Change some Usage Tracking strings to facilitate making the class more generic later

### DIFF
--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -150,7 +150,7 @@ class Sensei_Usage_Tracking {
 	function add_two_weeks( $schedules ) {
 		$schedules['sensei_usage_tracking_two_weeks'] = array(
 			'interval' => 15 * DAY_IN_SECONDS,
-			'display'  => esc_html__( 'Every Two Weeks', 'usage-tracking' ),
+			'display'  => esc_html__( 'Every Two Weeks', 'woothemes-sensei' ),
 		);
 
 		return $schedules;
@@ -221,10 +221,10 @@ class Sensei_Usage_Tracking {
 				</p>
 				<p>
 					<button class="button button-primary" data-enable-tracking="yes">
-						<?php _e( 'Enable Usage Tracking', 'usage-tracking' ) ?>
+						<?php _e( 'Enable Usage Tracking', 'woothemes-sensei' ) ?>
 					</button>
 					<button class="button" data-enable-tracking="no">
-						<?php _e( 'Disable Usage Tracking', 'usage-tracking' ) ?>
+						<?php _e( 'Disable Usage Tracking', 'woothemes-sensei' ) ?>
 					</button>
 					<span id="progress" class="spinner alignleft"></span>
 				</p>
@@ -237,13 +237,13 @@ class Sensei_Usage_Tracking {
 				</p>
 			</div>
 			<div id="sensei-usage-tracking-enable-success" class="notice notice-success hidden">
-				<p><?php _e( 'Usage data enabled. Thank you!', 'usage-tracking' ) ?></p>
+				<p><?php _e( 'Usage data enabled. Thank you!', 'woothemes-sensei' ) ?></p>
 			</div>
 			<div id="sensei-usage-tracking-disable-success" class="notice notice-success hidden">
-				<p><?php _e( 'Disabled usage tracking.', 'usage-tracking' ) ?></p>
+				<p><?php _e( 'Disabled usage tracking.', 'woothemes-sensei' ) ?></p>
 			</div>
 			<div id="sensei-usage-tracking-failure" class="notice notice-error hidden">
-				<p><?php _e( 'Something went wrong. Please try again later.', 'usage-tracking' ) ?></p>
+				<p><?php _e( 'Something went wrong. Please try again later.', 'woothemes-sensei' ) ?></p>
 			</div>
 		<?php
 		}

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -27,7 +27,7 @@ class Sensei_Usage_Tracking {
 
 	private static $hide_tracking_opt_in_option_name = 'sensei_usage_tracking_opt_in_hide';
 
-	private static $job_name = 'sensei_core_jobs_usage_tracking_send_data';
+	private static $job_name = 'sensei_usage_tracking_send_usage_data';
 
 	/**
 	 * Initialize the class and set its properties.
@@ -50,7 +50,7 @@ class Sensei_Usage_Tracking {
 	 **/
 	public static function send_event( $event, $properties = array(), $event_timestamp = null ) {
 		$pixel = 'http://pixel.wp.com/t.gif';
-		$prefix = apply_filters( 'sensei_usage_tracking_prefix', self::$prefix );
+		$prefix = apply_filters( 'sensei_usage_tracking_event_name_prefix', self::$prefix );
 		$event_name = $prefix . str_replace( $prefix, '', $event );
 		$user = wp_get_current_user();
 
@@ -80,7 +80,7 @@ class Sensei_Usage_Tracking {
 			'timeout'     => 1,
 			'redirection' => 2,
 			'httpversion' => '1.1',
-			'user-agent'  => 'sensei_plugin_usage_1',
+			'user-agent'  => 'sensei_usage_tracking',
 		) );
 
 		if ( is_wp_error( $response ) ) {
@@ -98,7 +98,7 @@ class Sensei_Usage_Tracking {
 
 	public static function maybe_schedule_tracking_task() {
 		if ( ! wp_next_scheduled( self::$job_name ) ) {
-			wp_schedule_event( time(), 'sensei_two_weeks', self::$job_name );
+			wp_schedule_event( time(), 'sensei_usage_tracking_two_weeks', self::$job_name );
 		}
 	}
 
@@ -148,9 +148,9 @@ class Sensei_Usage_Tracking {
 	}
 
 	function add_two_weeks( $schedules ) {
-		$schedules['sensei_two_weeks'] = array(
+		$schedules['sensei_usage_tracking_two_weeks'] = array(
 			'interval' => 15 * DAY_IN_SECONDS,
-			'display'  => esc_html__( 'Every Two Weeks', 'woothemes-sensei' ),
+			'display'  => esc_html__( 'Every Two Weeks', 'usage-tracking' ),
 		);
 
 		return $schedules;
@@ -221,10 +221,10 @@ class Sensei_Usage_Tracking {
 				</p>
 				<p>
 					<button class="button button-primary" data-enable-tracking="yes">
-						<?php _e( 'Enable Usage Tracking', 'woothemes-sensei' ) ?>
+						<?php _e( 'Enable Usage Tracking', 'usage-tracking' ) ?>
 					</button>
 					<button class="button" data-enable-tracking="no">
-						<?php _e( 'Disable Usage Tracking', 'woothemes-sensei' ) ?>
+						<?php _e( 'Disable Usage Tracking', 'usage-tracking' ) ?>
 					</button>
 					<span id="progress" class="spinner alignleft"></span>
 				</p>
@@ -237,13 +237,13 @@ class Sensei_Usage_Tracking {
 				</p>
 			</div>
 			<div id="sensei-usage-tracking-enable-success" class="notice notice-success hidden">
-				<p><?php _e( 'Usage data enabled. Thank you!', 'woothemes-sensei' ) ?></p>
+				<p><?php _e( 'Usage data enabled. Thank you!', 'usage-tracking' ) ?></p>
 			</div>
 			<div id="sensei-usage-tracking-disable-success" class="notice notice-success hidden">
-				<p><?php _e( 'Disabled usage tracking.', 'woothemes-sensei' ) ?></p>
+				<p><?php _e( 'Disabled usage tracking.', 'usage-tracking' ) ?></p>
 			</div>
 			<div id="sensei-usage-tracking-failure" class="notice notice-error hidden">
-				<p><?php _e( 'Something went wrong. Please try again later.', 'woothemes-sensei' ) ?></p>
+				<p><?php _e( 'Something went wrong. Please try again later.', 'usage-tracking' ) ?></p>
 			</div>
 		<?php
 		}

--- a/tests/unit-tests/test-class-usage-tracking.php
+++ b/tests/unit-tests/test-class-usage-tracking.php
@@ -19,7 +19,7 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	 */
 	public function testCronJobActionAdded() {
 		$this->usage_tracking->hook();
-		$this->assertTrue( !! has_action( 'sensei_core_jobs_usage_tracking_send_data', array( $this->usage_tracking, 'maybe_send_usage_data' ) ) );
+		$this->assertTrue( !! has_action( 'sensei_usage_tracking_send_usage_data', array( $this->usage_tracking, 'maybe_send_usage_data' ) ) );
 	}
 
 	/**
@@ -29,21 +29,21 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	 */
 	public function testMaybeScheduleTrackingTask() {
 		// Make sure it's cleared initially
-		wp_clear_scheduled_hook( 'sensei_core_jobs_usage_tracking_send_data' );
+		wp_clear_scheduled_hook( 'sensei_usage_tracking_send_usage_data' );
 
 		// Record how many times the event is scheduled
 		$event_count = 0;
 		add_filter( 'schedule_event', function( $event ) use ( &$event_count ) {
-			if ( $event->hook === 'sensei_core_jobs_usage_tracking_send_data' ) {
+			if ( $event->hook === 'sensei_usage_tracking_send_usage_data' ) {
 				$event_count++;
 			}
 			return $event;
 		} );
 
 		// Should successfully schedule the task
-		$this->assertFalse( wp_get_schedule( 'sensei_core_jobs_usage_tracking_send_data' ), 'Not scheduled initial' );
+		$this->assertFalse( wp_get_schedule( 'sensei_usage_tracking_send_usage_data' ), 'Not scheduled initial' );
 		$this->usage_tracking->maybe_schedule_tracking_task();
-		$this->assertNotFalse( wp_get_schedule( 'sensei_core_jobs_usage_tracking_send_data' ), 'Schedules a job' );
+		$this->assertNotFalse( wp_get_schedule( 'sensei_usage_tracking_send_usage_data' ), 'Schedules a job' );
 		$this->assertEquals( 1, $event_count, 'Schedules only one job' );
 
 		// Should not duplicate when called again


### PR DESCRIPTION
Changed the cron job name to the format `{prefix}_usage_tracking_{job_name}`. When the usage tracking functionality becomes more generic, that will be the format, and it's easier to change it before release!

Also changed a filter and user agent string.

~Changed the i18n domain for a few strings that are Usage Tracking specific, so they don't need to be translated separately for each plugin that uses this functionality.~

## Testing

Mainly, just make sure the cron job still gets set up properly and works the way it should.

Also ensure the tests still pass.