### PR TITLE
Rename featured_courses prop

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -27,7 +27,7 @@ class Sensei_Usage_Tracking_Data {
 			'course_videos' => self::get_course_videos_count(),
 			'course_no_notifications' => self::get_course_no_notifications_count(),
 			'course_prereqs' => self::get_course_prereqs_count(),
-			'featured_courses' => self::get_featured_courses_count(),
+			'course_featured' => self::get_course_featured_count(),
 			'learners' => self::get_learner_count(),
 			'lessons' => wp_count_posts( 'lesson' )->publish,
 			'lesson_modules' => self::get_lesson_module_count(),
@@ -130,7 +130,7 @@ class Sensei_Usage_Tracking_Data {
 	 *
 	 * @return int Number of courses.
 	 */
-	private static function get_featured_courses_count() {
+	private static function get_course_featured_count() {
 		$query = new WP_Query( array(
 			'post_type' => 'course',
 			'fields' => 'ids',

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -561,7 +561,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
-	 * @covers Sensei_Usage_Tracking_Data::get_featured_courses_count
+	 * @covers Sensei_Usage_Tracking_Data::get_course_featured_count
 	 */
 	public function testGetFeaturedCoursesCount() {
 		$featured = 2;
@@ -580,8 +580,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'featured_courses', $usage_data, 'Key' );
-		$this->assertEquals( $featured, $usage_data['featured_courses'], 'Count' );
+		$this->assertArrayHasKey( 'course_featured', $usage_data, 'Key' );
+		$this->assertEquals( $featured, $usage_data['course_featured'], 'Count' );
 	}
 
 	/**


### PR DESCRIPTION
Rename `featured_courses` prop in order to make it easier to scan related event props in Tracks.

## Testing

Ensure `course_featured` is logged to Tracks instead of `featured_courses`.