### PR TITLE
Hardcode DAY_IN_SECONDS to avoid continuous sending of data on old WP installations

### DIFF
--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -291,8 +291,9 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * @param array $schedules the existing cron schedules.
 	 **/
 	public function add_usage_tracking_two_week_schedule( $schedules ) {
+		$day_in_seconds = 86400;
 		$schedules[ $this->get_prefix() . '_usage_tracking_two_weeks' ] = array(
-			'interval' => 15 * DAY_IN_SECONDS,
+			'interval' => 15 * $day_in_seconds,
 			'display'  => esc_html__( 'Every Two Weeks', 'a8c-usage-tracking' ),
 		);
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/2010

On an old version of WP that does not define `DAY_IN_SECONDS`, usage data is sent continuously instead of once every two weeks. This PR should prevent that by hardcoding the value.

## Testing

- Ensure that tests pass

- Deactivate the plugin. The Cron job should be unscheduled. Then reactivate the plugin, and it should be scheduled to run in 2 weeks