### PR TITLE
Send usage data immediately when enabled through opt-in dialog

### DIFF
--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -44,6 +44,9 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 
 	protected function set_tracking_enabled( $enable ) {
 		Sensei()->settings->set( self::SENSEI_SETTING_NAME, $enable );
+
+		// Refresh settings in-memory so we get the right value.
+		Sensei()->settings->get_settings();
 	}
 
 	protected function current_user_can_manage_tracking() {

--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -384,6 +384,7 @@ abstract class Sensei_Usage_Tracking_Base {
 		$enable_tracking = isset( $_POST['enable_tracking'] ) && '1' === $_POST['enable_tracking'];
 		$this->set_tracking_enabled( $enable_tracking );
 		$this->hide_tracking_opt_in();
+		$this->send_usage_data();
 		wp_die();
 	}
 

--- a/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -95,6 +95,32 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure usage data is sent when tracking is enabled.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::_handle_tracking_opt_in
+	 */
+	public function testAjaxRequestEnableTrackingSendsData() {
+		$this->setupAjaxRequest();
+		$_POST['enable_tracking'] = '1';
+
+		// Count the number of network requests
+		$count = 0;
+		add_filter( 'pre_http_request', function() use ( &$count ) {
+			$count++;
+			return new WP_Error();
+		} );
+
+		try {
+			$this->usage_tracking->handle_tracking_opt_in();
+		} catch ( WP_Die_Exception $e ) {
+			$wp_die_args = $e->get_wp_die_args();
+			$this->assertEquals( array(), $wp_die_args['args'], 'wp_die call has no non-success status' );
+		}
+
+		$this->assertEquals( 1, $count, 'Data was sent on usage tracking enable' );
+	}
+
+	/**
 	 * Ensure tracking is disabled through ajax request.
 	 *
 	 * @covers {Prefix}_Usage_Tracking::_handle_tracking_opt_in


### PR DESCRIPTION
Fixes #2011 

This way, there will not be a lag time of two weeks before the first data comes in.

Note that this does not work when usage tracking is enabled through the Settings page. Only the opt-in dialog.

## Testing

- Disable Usage Tracking, and unhide the dialog - `delete_option( 'sensei_usage_tracking_opt_in_hide' );`

- Enable Usage Tracking through the dialog. Usage data should be sent to Tracks immediately.