### PR TITLE
Show lesson tags in Gutenberg editor

### DIFF
--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -588,6 +588,7 @@ class Sensei_PostTypes {
 		$args = array(
 			'hierarchical' => false,
 			'labels' => $labels,
+			'show_in_rest' => true,
 			'show_ui' => true,
 			'query_var' => true,
 			'show_in_nav_menus' => true,
@@ -783,7 +784,7 @@ class Sensei_PostTypes {
 
 	/**
 	 * Adds a 'Edit Quiz' link to the admin bar when viewing a Quiz linked to a corresponding Lesson
-	 * 
+	 *
 	 * @since  1.7.0
      * @param WP_Admin_Bar $bar
 	 * @return void


### PR DESCRIPTION
Adjust the `lesson-tag` taxonomy configuration so that it will be included in the WP REST API and picked up by Gutenberg automatically.

## Testing

With the Gutenberg plugin installed, browse to a lesson in the WordPress admin. You should see _Lesson Tags_ in the _Categories & Tags_ section of the sidebar:

![screen shot 2018-02-27 at 1 39 48 pm](https://user-images.githubusercontent.com/1190420/36747815-01b7b644-1bc4-11e8-81fc-1cb7c1726634.jpg)

Try adding and removing some lesson tags to confirm they work.