### PR TITLE
Implement button for starting a Lesson, similarly to starting a Course

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -55,6 +55,7 @@ class Sensei_Frontend {
 
 		add_action( 'sensei_lesson_meta', array( $this, 'sensei_lesson_meta' ), 10 );
 		add_action( 'sensei_single_course_content_inside_before', array( $this, 'sensei_course_start' ), 10 );
+		add_action( 'sensei_single_lesson_content_inside_before', array( $this, 'sensei_lesson_start' ), 10 );
 
 		add_filter( 'the_title', array( $this, 'sensei_lesson_preview_title' ), 10, 2 );
 
@@ -901,6 +902,10 @@ class Sensei_Frontend {
 			return;
 		}
 
+		if ( ! Sensei_Utils::user_started_lesson( $lesson_id, get_current_user_id() ) ) {
+			return;
+		}
+
 		if( false === Sensei()->lesson->lesson_has_quiz_with_questions_and_pass_required( $lesson_id ) ) {
 			?>
 			<form class="lesson_button_form" method="POST" action="<?php echo esc_url( get_permalink() ); ?>">
@@ -1174,6 +1179,9 @@ class Sensei_Frontend {
 		return $title;
 	} // sensei_lesson_preview_title
 
+	/**
+	 * Action for starting course.
+	 */
 	public function sensei_course_start() {
 		global $post, $current_user;
 
@@ -1200,6 +1208,36 @@ class Sensei_Frontend {
 			} // End If Statement
 		} // End If Statement
 	} // End sensei_course_start()
+
+	/**
+	 * Action for starting lesson.
+	 */
+	public function sensei_lesson_start() {
+		global $post, $current_user;
+
+		// Check if the user is taking the lesson
+		$is_user_taking_lesson = Sensei_Utils::user_started_lesson( $post->ID, $current_user->ID );
+		// Handle user starting the lesson
+		if ( isset( $_POST['lesson_start'] )
+		    && wp_verify_nonce( $_POST['woothemes_sensei_start_lesson_noonce'], 'woothemes_sensei_start_lesson_noonce' )
+		    && ! $is_user_taking_lesson ) {
+
+			// Start the lesson
+			$activity_logged = Sensei_Utils::user_start_lesson( $current_user->ID, $post->ID );
+			$this->data = new stdClass();
+			$this->data->is_user_taking_lesson = false;
+			if ( $activity_logged ) {
+				$this->data->is_user_taking_lesson = true;
+
+				// Refresh page to avoid re-posting
+				?>
+
+			    <script type="text/javascript"> window.location = '<?php echo get_permalink( $post->ID ); ?>'; </script>
+
+			    <?php
+			} // End If Statement
+		} // End If Statement
+	} // End sensei_lesson_start()
 
     /**
      * @deprecated since 1.9.0

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -681,7 +681,9 @@ class Sensei_Utils {
 			$status = 'in-progress';
 
 			// Note: When this action runs the lesson status may not yet exist
-			do_action( 'sensei_user_lesson_start', $user_id, $lesson_id );
+			if ( ! $complete ) {
+				do_action( 'sensei_user_lesson_start', $user_id, $lesson_id );
+			}
 
 			if( $complete ) {
 

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -231,6 +231,7 @@ add_action( 'sensei_quiz_question_inside_after', array( 'Sensei_Templates', 'dep
  *
  *
  ***************************/
+add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'the_lesson_enrolment_actions' ), 30 );
 //@since 1.9.0
 // deprecate the main content hook on the single lesson page
 add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Templates', 'deprecate_lesson_single_main_content_hook' ), 20);

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -123,6 +123,22 @@ if ( ! defined( 'ABSPATH' ) ){ exit; } // Exit if accessed directly
     	} // End If Statement
 	} // End sensei_start_course_form()
 
+	/**
+	 * sensei_start_lesson_form function.
+	 *
+	 * @access public
+	 * @param mixed $lesson_id
+	 * @return void
+	 */
+	function sensei_start_lesson_form( $lesson_id ) {
+		?>
+		<form method="POST" action="<?php echo esc_url( get_permalink( $lesson_id ) ); ?>">
+				<input type="hidden" name="<?php echo esc_attr( 'woothemes_sensei_start_lesson_noonce' ); ?>" id="<?php echo esc_attr( 'woothemes_sensei_start_lesson_noonce' ); ?>" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_start_lesson_noonce' ) ); ?>" />
+		<span><input name="lesson_start" type="submit" class="lesson-start" value="<?php _e( 'Start taking this Lesson', 'woothemes-sensei' ); ?>"/></span>
+
+		</form>
+		<?php
+	} // End sensei_start_lesson_form()
 
 	/**
 	 * sensei_wc_add_to_cart function.
@@ -946,7 +962,6 @@ function sensei_can_user_view_lesson( $lesson_id = '', $user_id = ''  ){
 
     }
 
-
     $access_permission = false;
 
     if ( ! Sensei()->settings->get('access_permission')  || sensei_all_access() ) {
@@ -955,7 +970,10 @@ function sensei_can_user_view_lesson( $lesson_id = '', $user_id = ''  ){
 
     }
 
-    $can_user_view_lesson = $access_permission || ( $user_can_access_lesson && $pre_requisite_complete ) || $is_preview;
+	$is_user_taking_lesson = Sensei_Utils::user_started_lesson( $lesson_id, $user_id );
+
+	$can_user_view_lesson = $is_user_taking_lesson
+		|| $access_permission || ( $user_can_access_lesson && $pre_requisite_complete ) || $is_preview;
 
     /**
      * Filter the can user view lesson function


### PR DESCRIPTION
Fixes #2043.

This PR:
- Implements a button "Start lesson", similarly to how we have "Start course" (by copying existing methods from course)
- Won't show any lesson details unless lesson is started
- Will only call `sensei_user_lesson_start` when course is actually started