### PR TITLE
Update usage tracking base code

### DIFF
--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -78,12 +78,15 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 			return true;
 		}
 		$third_party_plugins = array(
-			'all-in-one-seo-pack',
+			'woocommerce',
+			'woothemes-updater',
+			'woocommerce-subscriptions',
+			'woocommerce-memberships',
+			'woocommerce-product-vendors',
 			'polylang',
 			'jetpack',
-			'wordpress-seo', // Yoast.
-			'sitepress-multilingual-cms', // WPML.
-			'bibblio-related-posts', // Related Posts for WordPress.
+			'sitepress-multilingual-cms',
+			'wp-quicklatex',
 		);
 		if ( in_array( $plugin_slug, $third_party_plugins, true ) ) {
 			return true;

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -73,6 +73,24 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 		);
 	}
 
+	protected function do_track_plugin( $plugin_slug ) {
+		if ( 1 === preg_match( '/^sensei/', $plugin_slug ) ) {
+			return true;
+		}
+		$third_party_plugins = array(
+			'all-in-one-seo-pack',
+			'polylang',
+			'jetpack',
+			'wordpress-seo', // Yoast.
+			'sitepress-multilingual-cms', // WPML.
+			'bibblio-related-posts', // Related Posts for WordPress.
+		);
+		if ( in_array( $plugin_slug, $third_party_plugins, true ) ) {
+			return true;
+		}
+		return false;
+	}
+
 
 	/*
 	 * Hooks.

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -74,7 +74,7 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	}
 
 	protected function do_track_plugin( $plugin_slug ) {
-		if ( 1 === preg_match( '/^sensei/', $plugin_slug ) ) {
+		if ( 1 === preg_match( '/(^sensei|\-sensei$)/', $plugin_slug ) ) {
 			return true;
 		}
 		$third_party_plugins = array(

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -38,6 +38,10 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 		return 'sensei';
 	}
 
+	protected function get_text_domain() {
+		return 'woothemes-sensei';
+	}
+
 	protected function get_tracking_enabled() {
 		return Sensei()->settings->get( self::SENSEI_SETTING_NAME ) || false;
 	}

--- a/includes/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
+++ b/includes/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
@@ -18,6 +18,10 @@ class Usage_Tracking_Test_Subclass extends Sensei_Usage_Tracking_Base {
 		return 'testing';
 	}
 
+	public function get_text_domain() {
+		return 'text-domain';
+	}
+
 	public function get_tracking_enabled() {
 		return get_option( self::TRACKING_ENABLED_OPTION_NAME ) || false;
 	}
@@ -32,5 +36,32 @@ class Usage_Tracking_Test_Subclass extends Sensei_Usage_Tracking_Base {
 
 	public function opt_in_dialog_text() {
 		return 'Please enable Usage Tracking!';
+	}
+
+	public function do_track_plugin( $plugin_slug ) {
+		if ( in_array( $plugin_slug, array( 'hello', 'test', 'my-favorite-plugin' ), true ) ) {
+			return true;
+		}
+		return false;
+	}
+
+	protected function get_plugins() {
+		return array(
+			'Hello.php'                                 => array(
+				'Version' => '1.0.0',
+			),
+			'jetpack/jetpack.php'                       => array(
+				'Version' => '1.1.1',
+			),
+			'test-dev/test.php'                         => array(
+				'Version' => '1.1.1',
+			),
+			'test/test.php'                             => array(
+				'Version' => '1.0.0',
+			),
+			'my-favorite-plugin/my-favorite-plugin.php' => array(
+				'Version' => '1.0.0',
+			),
+		);
 	}
 }

--- a/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -9,16 +9,18 @@ Usage_Tracking_Test_Subclass::get_instance();
 /**
  * Usage Tracking tests. Please update the prefix to something unique to your
  * plugin.
+ *
+ * @group usage-tracking
  */
 class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
+	private $event_counts       = array();
+	private $track_http_request = array();
 
 	public function setUp() {
 		parent::setUp();
 		// Update the class name here to match the Usage Tracking class.
 		$this->usage_tracking = Usage_Tracking_Test_Subclass::get_instance();
-		$this->usage_tracking->set_callback( function() {
-			return array( 'testing' => true );
-		} );
+		$this->usage_tracking->set_callback( array( $this, 'basicDataCallback' ) );
 	}
 
 	/**
@@ -40,24 +42,18 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 		wp_clear_scheduled_hook( $this->usage_tracking->get_prefix() . '_usage_tracking_send_usage_data' );
 
 		// Record how many times the event is scheduled
-		$prefix = $this->usage_tracking->get_prefix();
-		$event_count = 0;
-		add_filter( 'schedule_event', function( $event ) use ( &$event_count, $prefix ) {
-			if ( $event->hook === $prefix . '_usage_tracking_send_usage_data' ) {
-				$event_count++;
-			}
-			return $event;
-		} );
+		$this->event_counts['schedule_event'] = 0;
+		add_filter( 'schedule_event', array( $this, 'countScheduleEvent' ) );
 
 		// Should successfully schedule the task
 		$this->assertFalse( wp_get_schedule( $this->usage_tracking->get_prefix() . '_usage_tracking_send_usage_data' ), 'Not scheduled initial' );
 		$this->usage_tracking->schedule_tracking_task();
 		$this->assertNotFalse( wp_get_schedule( $this->usage_tracking->get_prefix() . '_usage_tracking_send_usage_data' ), 'Schedules a job' );
-		$this->assertEquals( 1, $event_count, 'Schedules only one job' );
+		$this->assertEquals( 1, $this->event_counts['schedule_event'], 'Schedules only one job' );
 
 		// Should not duplicate when called again
 		$this->usage_tracking->schedule_tracking_task();
-		$this->assertEquals( 1, $event_count, 'Does not schedule an additional job' );
+		$this->assertEquals( 1, $this->event_counts['schedule_event'], 'Does not schedule an additional job' );
 	}
 
 	/* Test ajax request cases */
@@ -104,11 +100,8 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 		$_POST['enable_tracking'] = '1';
 
 		// Count the number of network requests
-		$count = 0;
-		add_filter( 'pre_http_request', function() use ( &$count ) {
-			$count++;
-			return new WP_Error();
-		} );
+		$this->event_counts['http_request'] = 0;
+		add_filter( 'pre_http_request', array( $this, 'countHttpRequest' ) );
 
 		try {
 			$this->usage_tracking->handle_tracking_opt_in();
@@ -117,7 +110,7 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 			$this->assertEquals( array(), $wp_die_args['args'], 'wp_die call has no non-success status' );
 		}
 
-		$this->assertEquals( 1, $count, 'Data was sent on usage tracking enable' );
+		$this->assertEquals( 2, $this->event_counts['http_request'], 'Data was sent on usage tracking enable' );
 	}
 
 	/**
@@ -202,7 +195,7 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	public function testSendEvent() {
 		$event      = 'my_event';
 		$properties = array(
-			'button_clicked' => 'my_button'
+			'button_clicked' => 'my_button',
 		);
 		$timestamp  = '1234';
 
@@ -211,33 +204,35 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 		// Capture the network request, save the request URL and arguments, and
 		// simulate a WP_Error
-		$request_params = null;
-		$request_url    = null;
-		add_filter( 'pre_http_request', function( $preempt, $r, $url ) use ( &$request_params, &$request_url ) {
-			$request_params = $r;
-			$request_url    = $url;
-			return new WP_Error();
-		}, 10, 3 );
+		$this->track_http_request['request_params'] = null;
+		$this->track_http_request['request_url']    = null;
+		add_filter( 'pre_http_request', array( $this, 'trackHttpRequest' ), 10, 3 );
 
 		$this->usage_tracking->send_event( 'my_event', $properties, $timestamp );
 
-		$parsed_url = parse_url( $request_url );
+		$parsed_url = parse_url( $this->track_http_request['request_url'] );
 
 		$this->assertEquals( 'pixel.wp.com', $parsed_url['host'], 'Host' );
 		$this->assertEquals( '/t.gif', $parsed_url['path'], 'Path' );
 
 		$query = array();
 		parse_str( $parsed_url['query'], $query );
-		$this->assertArraySubset( array(
-			'button_clicked' => 'my_button',
-			'admin_email'    => 'admin@example.org',
-			'_ut'            => $this->usage_tracking->get_prefix() . ':site_url',
-			'_ui'            => 'http://example.org',
-			'_ul'            => '',
-			'_en'            => $this->usage_tracking->get_prefix() . '_my_event',
-			'_ts'            => '1234000',
-			'_'              => '_',
-		), $query, 'Query parameters' );
+
+		// Older versions (for PHP 5.2) of PHPUnit do not have this method
+		if ( method_exists( $this, 'assertArraySubset' ) ) {
+			$this->assertArraySubset(
+				array(
+					'button_clicked' => 'my_button',
+					'admin_email'    => 'admin@example.org',
+					'_ut'            => $this->usage_tracking->get_prefix() . ':site_url',
+					'_ui'            => 'http://example.org',
+					'_ul'            => '',
+					'_en'            => $this->usage_tracking->get_prefix() . '_my_event',
+					'_ts'            => '1234000',
+					'_'              => '_',
+				), $query, 'Query parameters'
+			);
+		}
 	}
 
 	/**
@@ -249,7 +244,7 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	public function testSendEventWithTrackingDisabled() {
 		$event      = 'my_event';
 		$properties = array(
-			'button_clicked' => 'my_button'
+			'button_clicked' => 'my_button',
 		);
 		$timestamp  = '1234';
 
@@ -257,14 +252,11 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 		$this->usage_tracking->set_tracking_enabled( false );
 
 		// Count network requests
-		$count = 0;
-		add_filter( 'pre_http_request', function() use ( &$count ) {
-			$count++;
-			return new WP_Error();
-		} );
+		$this->event_counts['http_request'] = 0;
+		add_filter( 'pre_http_request', array( $this, 'countHttpRequest' ) );
 
 		$this->usage_tracking->send_event( 'my_event', $properties, $timestamp );
-		$this->assertEquals( 0, $count, 'No request when disabled' );
+		$this->assertEquals( 0, $this->event_counts['http_request'], 'No request when disabled' );
 	}
 
 	/**
@@ -273,23 +265,19 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	 * @covers {Prefix}_Usage_Tracking::maybe_send_usage_data
 	 */
 	public function testSendUsageData() {
-		$count = 0;
-
 		// Count the number of network requests
-		add_filter( 'pre_http_request', function() use ( &$count ) {
-			$count++;
-			return new WP_Error();
-		} );
+		$this->event_counts['http_request'] = 0;
+		add_filter( 'pre_http_request', array( $this, 'countHttpRequest' ) );
 
 		// Setting is not set, ensure the request is not sent.
 		$this->usage_tracking->send_usage_data();
-		$this->assertEquals( 0, $count, 'Request not sent when Usage Tracking disabled' );
+		$this->assertEquals( 0, $this->event_counts['http_request'], 'Request not sent when Usage Tracking disabled' );
 
 		// Set the setting and ensure request is sent.
 		$this->usage_tracking->set_tracking_enabled( true );
 
 		$this->usage_tracking->send_usage_data();
-		$this->assertEquals( 1, $count, 'Request sent when Usage Tracking enabled' );
+		$this->assertEquals( 2, $this->event_counts['http_request'], 'Request sent when Usage Tracking enabled' );
 	}
 
 	/* Tests for tracking opt in dialog */
@@ -349,6 +337,69 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 	/* END tests for tracking opt in dialog */
 
+	/* Tests for system data */
+
+	/**
+	 * Tests the basic structure for collected system data.
+	 *
+	 * @covers {Prefix}_Usage_Tracking::get_system_data
+	 * @group track-system-data
+	 */
+	public function testSystemDataStructure() {
+		global $wp_version;
+
+		$system_data = $this->usage_tracking->get_system_data();
+
+		$this->assertInternalType( 'array', $system_data, 'System data must be returned as an array' );
+
+		$this->assertArrayHasKey( 'wp_version', $system_data, '`wp_version` key must exist in system data' );
+		$this->assertEquals( $wp_version, $system_data['wp_version'], '`wp_version` does not match expected value' );
+
+		$this->assertArrayHasKey( 'php_version', $system_data, '`php_version` key must exist in system data' );
+		$this->assertEquals( PHP_VERSION, $system_data['php_version'], '`php_version` does not match expected value' );
+
+		$this->assertArrayHasKey( 'locale', $system_data, '`locale` key must exist in system data' );
+		$this->assertEquals( get_locale(), $system_data['locale'], '`locale` does not match expected value' );
+
+		$this->assertArrayHasKey( 'multisite', $system_data, '`multisite` key must exist in system data' );
+		$this->assertEquals( is_multisite(), $system_data['multisite'], '`multisite` does not match expected value' );
+
+		/**
+		 * Current active theme.
+		 *
+		 * @var WP_Theme $theme
+		 */
+		$theme = wp_get_theme();
+
+		$this->assertArrayHasKey( 'active_theme', $system_data, '`active_theme` key must exist in system data' );
+		$this->assertEquals( $theme['Name'], $system_data['active_theme'], '`active_theme` does not match expected value' );
+
+		$this->assertArrayHasKey( 'active_theme_version', $system_data, '`active_theme_version` key must exist in system data' );
+		$this->assertEquals( $theme['Version'], $system_data['active_theme_version'], '`active_theme_version` does not match expected value' );
+
+		$this->assertArrayHasKey( 'plugin_my_favorite_plugin', $system_data, '`plugin_my_favorite_plugin` key must exist in system data' );
+		$this->assertEquals( '1.0.0', $system_data['plugin_my_favorite_plugin'], '`plugin_my_favorite_plugin` does not match expected value' );
+
+		$this->assertArrayHasKey( 'plugin_hello', $system_data, '`plugin_hello` key must exist in system data' );
+		$this->assertEquals( '1.0.0', $system_data['plugin_my_favorite_plugin'], '`plugin_hello` does not match expected value' );
+
+		$this->assertArrayHasKey( 'plugin_test', $system_data, '`plugin_test` key must exist in system data' );
+		$this->assertEquals( '1.0.0', $system_data['plugin_test'], '`plugin_test` does not match expected value' );
+
+		$this->assertArrayNotHasKey( 'plugin_jetpack', $system_data, '`plugin_jetpack` key must NOT exist in system data' );
+		$this->assertArrayNotHasKey( 'plugin_test_dev', $system_data, '`plugin_test_dev` key must NOT exist in system data' );
+
+		$plugin_prefix_count = 0;
+		foreach ( $system_data as $key => $value ) {
+			if ( 1 === preg_match( '/^plugin_/', $key ) ) {
+				$plugin_prefix_count++;
+			}
+		}
+
+		$this->assertEquals( 3, $plugin_prefix_count );
+	}
+
+	/* END tests for system data */
 
 	/****** Helper methods ******/
 
@@ -357,7 +408,7 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	 */
 	private function setupAjaxRequest() {
 		// Simulate an ajax request
-		add_filter( 'wp_doing_ajax', function() { return true; } );
+		add_filter( 'wp_doing_ajax', '__return_true' );
 
 		// Set up nonce
 		$_REQUEST['nonce'] = wp_create_nonce( 'tracking-opt-in' );
@@ -367,13 +418,7 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 
 		// When wp_die is called, save the args and throw an exception to stop
 		// execution.
-		add_filter( 'wp_die_ajax_handler', function() {
-			return function( $message, $title, $args ) {
-				$e = new WP_Die_Exception( 'wp_die called' );
-				$e->set_wp_die_args( $message, $title, $args );
-				throw $e;
-			};
-		} );
+		add_filter( 'wp_die_ajax_handler', array( $this, 'ajaxDieHandler' ) );
 	}
 
 	/**
@@ -402,5 +447,82 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 		} else {
 			$user->remove_cap( 'manage_usage_tracking' );
 		}
+	}
+
+	/**
+	 * Callback helpers.
+	 */
+
+	/**
+	 * Basic callback for usage data.
+	 *
+	 * @return array
+	 */
+	public function basicDataCallback() {
+		return array( 'testing' => true );
+	}
+
+	/**
+	 * Sets the die handler for ajax request.
+	 *
+	 * @return array
+	 */
+	public function ajaxDieHandler() {
+		return array( $this, 'ajaxDieHandlerCallback' );
+	}
+
+	/**
+	 * Error handler for ajax requests.
+	 *
+	 * @param string $message
+	 * @param string $title
+	 * @param array  $args
+	 *
+	 * @throws WP_Die_Exception
+	 */
+	public function ajaxDieHandlerCallback( $message, $title, $args ) {
+		$e = new WP_Die_Exception( 'wp_die called' );
+		$e->set_wp_die_args( $message, $title, $args );
+		throw $e;
+	}
+
+	/**
+	 * Count the number of times an event is scheduled.
+	 *
+	 * @param object $event
+	 *
+	 * @return object
+	 */
+	public function countScheduleEvent( $event ) {
+		$prefix = $this->usage_tracking->get_prefix();
+		if ( $event->hook === $prefix . '_usage_tracking_send_usage_data' ) {
+			$this->event_counts['schedule_event']++;
+		}
+		return $event;
+	}
+
+	/**
+	 * Count the number of HTTP requests.
+	 *
+	 * @return WP_Error
+	 */
+	public function countHttpRequest() {
+		$this->event_counts['http_request']++;
+		return new WP_Error();
+	}
+
+	/**
+	 * Track HTTP request params and URL.
+	 *
+	 * @param string $preempt
+	 * @param array  $r
+	 * @param string $url
+	 *
+	 * @return WP_Error
+	 */
+	public function trackHttpRequest( $preempt, $r, $url ) {
+		$this->track_http_request['request_params'] = $r;
+		$this->track_http_request['request_url']    = $url;
+		return new WP_Error();
 	}
 }

--- a/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -1,7 +1,7 @@
 <?php
 
-include dirname( __FILE__ ) . '/support/class-usage-tracking-test-subclass.php';
-include dirname( __FILE__ ) . '/support/wp-die-exception.php';
+require_once dirname( __FILE__ ) . '/support/class-usage-tracking-test-subclass.php';
+require_once dirname( __FILE__ ) . '/support/wp-die-exception.php';
 
 // Ensure instance is set up before PHPUnit starts removing hooks.
 Usage_Tracking_Test_Subclass::get_instance();

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,9 +18,7 @@
     <testsuites>
         <testsuite name="Sensei Test Suite">
             <directory suffix=".php">./tests/</directory>
-        </testsuite>
-        <testsuite name="Usage Tracking Test Suite">
-            <directory suffix=".php">./lib/usage_tracking/tests/</directory>
+            <directory suffix=".php">./includes/lib/usage-tracking/tests/</directory>
         </testsuite>
     </testsuites>
     <filter>


### PR DESCRIPTION
Copied in the latest Usage Tracking changes from WP Job Manager. See the following PR's for an understanding of the changes:

- Automattic/WP-Job-Manager#1324
- Automattic/WP-Job-Manager#1326
- Automattic/WP-Job-Manager#1332
- Automattic/WP-Job-Manager#1343
- Automattic/WP-Job-Manager#1345
- Automattic/WP-Job-Manager#1347
- Automattic/WP-Job-Manager#1364

Note: for the `do_track_plugin` function, I'm just doing the same thing here as we do for WP Job Manager (except that we look for the `sensei` prefix). Are there other plugins we may want to look for here?

## Testing

- Walk through the steps for enabling, disabling, and sending Usage Tracking data. It should all still work. Note that adding the following code snippet will allow you to test without actually sending data to Tracks:

```php
add_filter( 'pre_http_request', function( $preempt, $r, $url ) {
  if ( preg_match( "/pixel\.wp\.com\/t\.gif/", $url ) ) {
	error_log( "------ Cancelling request ------" );
	error_log( $url );
	error_log( "------ DONE cancelling request ------" );
	return true;
  }
  return false;
}, 10, 3 );
```

- Run the usage tracking tests and ensure they pass.

- When sending usage data, ensure that the `sensei_system_log` is sent, along with `sensei_stats_log`.