### PR TITLE
Tweak Lesson Information meta box for Gutenberg

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -130,10 +130,7 @@ class Sensei_Lesson {
 		) );
 
 		// Add Gutenberg-specific Meta Box for Lesson Information
-		add_filter( 'filter_gutenberg_meta_boxes', function( $boxes ) {
-			add_meta_box( 'lesson-info-gt', esc_html__( 'Lesson Information for Gutenberg', 'woothemes-sensei' ), array( $this, 'lesson_info_meta_box_content_gutenberg' ), $this->token, 'side', 'high' );
-			return $boxes;
-		} );
+		add_filter( 'filter_gutenberg_meta_boxes', array( $this, 'add_gutenberg_meta_boxes' ) );
 
 		// Add Meta Box for Quiz Settings
 		add_meta_box( 'lesson-quiz-settings', esc_html__( 'Quiz Settings', 'woothemes-sensei' ), array( $this, 'lesson_quiz_settings_meta_box_content' ), $this->token, 'normal', 'default' );
@@ -152,6 +149,18 @@ class Sensei_Lesson {
 
 	} // End meta_box_setup()
 
+
+	/**
+	 * Add metaboxes specific to Gutenberg. Used with the
+	 * filter_gutenberg_meta_boxes filter.
+	 *
+	 * @param array $boxes the existing metaboxes.
+	 * @return the existing metaboxes.
+	 */
+	public function add_gutenberg_meta_boxes( $boxes ) {
+		add_meta_box( 'lesson-info-gt', esc_html__( 'Lesson Information for Gutenberg', 'woothemes-sensei' ), array( $this, 'lesson_info_meta_box_content_gutenberg' ), $this->token, 'side', 'high' );
+		return $boxes;
+	}
 
 	/**
 	 * lesson_info_meta_box_content function.
@@ -173,10 +182,10 @@ class Sensei_Lesson {
 
 		$html = '';
 		// Lesson Length
-		$html .= '<p><label for="lesson_length">' . esc_html__( 'Lesson Length in minutes', 'woothemes-sensei' ) . ': </label>';
+		$html .= '<p><label for="lesson_length">' . esc_html__( 'Length (minutes)', 'woothemes-sensei' ) . ': </label>';
 		$html .= '<input type="number" id="lesson-length" name="lesson_length" class="small-text" value="' . esc_attr( $lesson_length ) . '" /></p>' . "\n";
 		// Lesson Complexity
-		$html .= '<p><label for="lesson_complexity">' . esc_html__( 'Lesson Complexity', 'woothemes-sensei' ) . ': </label>';
+		$html .= '<p><label for="lesson_complexity">' . esc_html__( 'Complexity', 'woothemes-sensei' ) . ': </label>';
 		$html .= '<select id="lesson-complexity-options" name="lesson_complexity" class="chosen_select lesson-complexity-select">';
 			$html .= '<option value="">' . esc_html__( 'None', 'woothemes-sensei' ) . '</option>';
 			foreach ( $complexity_array as $key => $value ){

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -124,8 +124,16 @@ class Sensei_Lesson {
 		// Add Meta Box for Lesson Preview
 		add_meta_box( 'lesson-preview', esc_html__( 'Lesson Preview', 'woothemes-sensei' ), array( $this, 'lesson_preview_meta_box_content' ), $this->token, 'side', 'default' );
 
-		// Add Meta Box for Lesson Information
-		add_meta_box( 'lesson-info', esc_html__( 'Lesson Information', 'woothemes-sensei' ), array( $this, 'lesson_info_meta_box_content' ), $this->token, 'normal', 'default' );
+		// Add Classic Editor Meta Box for Lesson Information
+		add_meta_box( 'lesson-info', esc_html__( 'Lesson Information', 'woothemes-sensei' ), array( $this, 'lesson_info_meta_box_content' ), $this->token, 'normal', 'default', array(
+			'__back_compat_meta_box' => true,
+		) );
+
+		// Add Gutenberg-specific Meta Box for Lesson Information
+		add_filter( 'filter_gutenberg_meta_boxes', function( $boxes ) {
+			add_meta_box( 'lesson-info-gt', esc_html__( 'Lesson Information for Gutenberg', 'woothemes-sensei' ), array( $this, 'lesson_info_meta_box_content_gutenberg' ), $this->token, 'side', 'high' );
+			return $boxes;
+		} );
 
 		// Add Meta Box for Quiz Settings
 		add_meta_box( 'lesson-quiz-settings', esc_html__( 'Quiz Settings', 'woothemes-sensei' ), array( $this, 'lesson_quiz_settings_meta_box_content' ), $this->token, 'normal', 'default' );
@@ -149,9 +157,11 @@ class Sensei_Lesson {
 	 * lesson_info_meta_box_content function.
 	 *
 	 * @access public
+	 *
+	 * @param bool $show_empty_video_embeds whether to show the video embed field if it is empty.
 	 * @return void
 	 */
-	public function lesson_info_meta_box_content () {
+	public function lesson_info_meta_box_content( $show_empty_video_embeds = true ) {
 		global $post;
 
 		$lesson_length      = get_post_meta( $post->ID, '_lesson_length', true );
@@ -174,16 +184,28 @@ class Sensei_Lesson {
 			} // End For Loop
 		$html .= '</select></p>' . "\n";
 
-		$html .= '<p><label for="lesson_video_embed">' . esc_html__( 'Video Embed Code', 'woothemes-sensei' ) . ':</label><br/>' . "\n";
-		$html .= '<textarea rows="5" cols="50" name="lesson_video_embed" tabindex="6" id="course-video-embed">';
+		if ( $show_empty_video_embeds || $lesson_video_embed ) {
+			$html .= '<p><label for="lesson_video_embed">' . esc_html__( 'Video Embed Code', 'woothemes-sensei' ) . ':</label><br/>' . "\n";
+			$html .= '<textarea rows="5" cols="50" name="lesson_video_embed" tabindex="6" id="course-video-embed">';
 
-		$html .= $lesson_video_embed . '</textarea></p>' . "\n";
+			$html .= $lesson_video_embed . '</textarea></p>' . "\n";
 
-		$html .= '<p>' .  esc_html__( 'Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above.', 'woothemes-sensei' ) . '</p>';
+			$html .= '<p>' .  esc_html__( 'Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above.', 'woothemes-sensei' ) . '</p>';
+		}
 
 		echo $html;
 
 	} // End lesson_info_meta_box_content()
+
+	/**
+	 * Lesson metabox for Gutenberg.
+	 *
+	 * @return void
+	 */
+	public function lesson_info_meta_box_content_gutenberg() {
+		// Use the same meta box but do not display the video embed unless it has content.
+		$this->lesson_info_meta_box_content( false );
+	}
 
 	/**
 	 * lesson_prerequisite_meta_box_content function.


### PR DESCRIPTION
Fixes #2048 

A few notes:

- First, there doesn't seem to be a great way to display a meta box only when Gutenberg is enabled. I've worked around it by (improperly) using the `filter_gutenberg_meta_boxes` filter, but this feels like a hack, not a proper solution. I think the long-term solution is probably to move away from meta boxes entirely, but I'm not sure what the right solution is yet. Should this info be in a block instead? Does that make sense for meta info that may or may not be displayed?

- The Video Embed field is removed in Gutenberg. The idea is that users should be able to use a video block within the lesson content instead. If, however, there is a video embed present on an old Lesson, then the field will be shown. Only the empty ones are hidden.

- The text changes (`Length (minutes)` and `Complexity`) are changed in both versions of the meta box.

## Testing

- Create a new Lesson with the Gutenberg plugin installed. You should see the new metabox, with the new wording, and no video embed at the top of the "Extended Settings" section of the sidebar.

- Create a new Lesson with the classic editor. You should see the old metabox as it was, with the video embed field, but also with the new wording.

- Open some existing lessons in the Gutenberg editor. The video embed field should be visible for those with a video embed code set, and should not be visible otherwise.