### PR TITLE
[WIP] Add test run back into CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -29,10 +29,12 @@ dependencies:
       - mysql -e 'CREATE DATABASE wordpress_test;' -uroot;
       # Clone sensei-coding-standard
       - git clone https://github.com/Automattic/sensei-coding-standard.git $SENSEI_CODING_STANDARD_DIR;
+      # Install compatible version of phpunit for PHP 5.6
+      - cd $plugin_dir ; mkdir -p bin ; wget -O ./bin/phpunit https://phar.phpunit.de/phpunit-5.phar
 
 ## tests override
 test:
   override:
   #run tests with coverage
   - cd $SENSEI_CODING_STANDARD_DIR; php bin/phpcs.phar --report-full --report-summary --standard=Sensei $plugin_loc
-  - cd $plugin_loc; phpunit
+  - cd $plugin_loc; php ./bin/phpunit

--- a/circle.yml
+++ b/circle.yml
@@ -35,3 +35,4 @@ test:
   override:
   #run tests with coverage
   - cd $SENSEI_CODING_STANDARD_DIR; php bin/phpcs.phar --report-full --report-summary --standard=Sensei $plugin_loc
+  - cd $plugin_loc; phpunit


### PR DESCRIPTION
It seems that the actual running of the tests was inadvertently removed from CI. This PR adds it back in!

Before this PR: https://circleci.com/gh/Automattic/sensei/1125 (note that under the Testing section near the bottom, all that happens is the phpcs checks, but phpunit is never run)

With this PR: _(Can't get them running yet)_