### PR TITLE
Clean up extended settings in Gutenberg Lesson editor

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -115,11 +115,11 @@ class Sensei_Lesson {
 	 */
 	public function meta_box_setup () {
 
-		// Add Meta Box for Prerequisite Lesson
-		add_meta_box( 'lesson-prerequisite', esc_html__( 'Prerequisite', 'woothemes-sensei' ), array( $this, 'lesson_prerequisite_meta_box_content' ), $this->token, 'side', 'default' );
-
 		// Add Meta Box for Lesson Course
 		add_meta_box( 'lesson-course', esc_html__( 'Course', 'woothemes-sensei' ), array( $this, 'lesson_course_meta_box_content' ), $this->token, 'side', 'default' );
+
+		// Add Meta Box for Prerequisite Lesson
+		add_meta_box( 'lesson-prerequisite', esc_html__( 'Prerequisite', 'woothemes-sensei' ), array( $this, 'lesson_prerequisite_meta_box_content' ), $this->token, 'side', 'default' );
 
 		// Add Meta Box for Lesson Preview
 		add_meta_box( 'lesson-preview', esc_html__( 'Preview', 'woothemes-sensei' ), array( $this, 'lesson_preview_meta_box_content' ), $this->token, 'side', 'default' );

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -119,10 +119,10 @@ class Sensei_Lesson {
 		add_meta_box( 'lesson-course', esc_html__( 'Course', 'woothemes-sensei' ), array( $this, 'lesson_course_meta_box_content' ), $this->token, 'side', 'default' );
 
 		// Add Meta Box for Prerequisite Lesson
-		add_meta_box( 'lesson-prerequisite', esc_html__( 'Prerequisite', 'woothemes-sensei' ), array( $this, 'lesson_prerequisite_meta_box_content' ), $this->token, 'side', 'default' );
+		add_meta_box( 'lesson-prerequisite', esc_html__( 'Prerequisite', 'woothemes-sensei' ), array( $this, 'lesson_prerequisite_meta_box_content' ), $this->token, 'side', 'low' );
 
 		// Add Meta Box for Lesson Preview
-		add_meta_box( 'lesson-preview', esc_html__( 'Preview', 'woothemes-sensei' ), array( $this, 'lesson_preview_meta_box_content' ), $this->token, 'side', 'default' );
+		add_meta_box( 'lesson-preview', esc_html__( 'Preview', 'woothemes-sensei' ), array( $this, 'lesson_preview_meta_box_content' ), $this->token, 'side', 'low' );
 
 		// Add Meta Box for Lesson Information
 		add_meta_box( 'lesson-info', esc_html__( 'Lesson Information', 'woothemes-sensei' ), array( $this, 'lesson_info_meta_box_content' ), $this->token, 'normal', 'default' );

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -208,7 +208,7 @@ class Sensei_Lesson {
 		$html = '';
 		$html .= wp_nonce_field( 'sensei-save-post-meta','woo_' . $this->token . '_nonce', true, false  );
 		if ( count( $posts_array ) > 0 ) {
-			$html .= '<select id="lesson-prerequisite-options" name="lesson_prerequisite" class="chosen_select widefat">' . "\n";
+			$html .= '<select id="lesson-prerequisite-options" name="lesson_prerequisite" class="chosen_select widefat" style="width: 100%">' . "\n";
 			$html .= '<option value="">' . esc_html__( 'None', 'woothemes-sensei' ) . '</option>';
 				foreach ($posts_array as $post_item){
 					$html .= '<option value="' . esc_attr( absint( $post_item->ID ) ) . '"' . selected( $post_item->ID, $select_lesson_prerequisite, false ) . '>' . esc_html( $post_item->post_title ) . '</option>' . "\n";
@@ -577,8 +577,9 @@ class Sensei_Lesson {
 
 		// Select the course for the lesson
 		$drop_down_args = array(
-			'name'=>'lesson_course',
-			'id' => 'lesson-course-options'
+			'name'  => 'lesson_course',
+			'id'    => 'lesson-course-options',
+			'style' => 'width: 100%',
 		);
 
 		$courses = WooThemes_Sensei_Course::get_all_courses();
@@ -607,7 +608,7 @@ class Sensei_Lesson {
 						$html .= '<textarea rows="10" cols="40" id="course-content" name="course_content" value="" size="300" class="widefat"></textarea>';
 						// Course Prerequisite
 						$html .= '<label>' . esc_html__( 'Course Prerequisite' , 'woothemes-sensei' ) . '</label> ';
-						$html .= '<select id="course-prerequisite-options" name="course_prerequisite" class="chosen_select widefat">' . "\n";
+						$html .= '<select id="course-prerequisite-options" name="course_prerequisite" class="chosen_select widefat" style="width: 100%">' . "\n";
 							$html .= '<option value="">' . esc_html__( 'None', 'woothemes-sensei' ) . '</option>';
 							foreach ($posts_array as $post_item){
 								$html .= '<option value="' . esc_attr( absint( $post_item->ID ) ) . '">' . esc_html( $post_item->post_title ) . '</option>' . "\n";
@@ -635,7 +636,7 @@ class Sensei_Lesson {
 													);
 							$products_array = get_posts( $product_args );
 							$html .= '<label>' . esc_html__( 'WooCommerce Product' , 'woothemes-sensei' ) . '</label> ';
-							$html .= '<select id="course-woocommerce-product-options" name="course_woocommerce_product" class="chosen_select widefat">' . "\n";
+							$html .= '<select id="course-woocommerce-product-options" name="course_woocommerce_product" class="chosen_select widefat" style="width: 100%">' . "\n";
 								$html .= '<option value="-">' . esc_html__( 'None', 'woothemes-sensei' ) . '</option>';
 								$prev_parent_id = 0;
 								foreach ($products_array as $products_item){

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -116,13 +116,13 @@ class Sensei_Lesson {
 	public function meta_box_setup () {
 
 		// Add Meta Box for Prerequisite Lesson
-		add_meta_box( 'lesson-prerequisite', esc_html__( 'Lesson Prerequisite', 'woothemes-sensei' ), array( $this, 'lesson_prerequisite_meta_box_content' ), $this->token, 'side', 'default' );
+		add_meta_box( 'lesson-prerequisite', esc_html__( 'Prerequisite', 'woothemes-sensei' ), array( $this, 'lesson_prerequisite_meta_box_content' ), $this->token, 'side', 'default' );
 
 		// Add Meta Box for Lesson Course
-		add_meta_box( 'lesson-course', esc_html__( 'Lesson Course', 'woothemes-sensei' ), array( $this, 'lesson_course_meta_box_content' ), $this->token, 'side', 'default' );
+		add_meta_box( 'lesson-course', esc_html__( 'Course', 'woothemes-sensei' ), array( $this, 'lesson_course_meta_box_content' ), $this->token, 'side', 'default' );
 
 		// Add Meta Box for Lesson Preview
-		add_meta_box( 'lesson-preview', esc_html__( 'Lesson Preview', 'woothemes-sensei' ), array( $this, 'lesson_preview_meta_box_content' ), $this->token, 'side', 'default' );
+		add_meta_box( 'lesson-preview', esc_html__( 'Preview', 'woothemes-sensei' ), array( $this, 'lesson_preview_meta_box_content' ), $this->token, 'side', 'default' );
 
 		// Add Meta Box for Lesson Information
 		add_meta_box( 'lesson-info', esc_html__( 'Lesson Information', 'woothemes-sensei' ), array( $this, 'lesson_info_meta_box_content' ), $this->token, 'normal', 'default' );

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -152,7 +152,7 @@ class Sensei_Core_Modules
 			remove_meta_box($this->taxonomy . 'div', 'lesson', 'side');
 
 			// Add custom meta box to limit module selection to one per lesson
-			add_meta_box($this->taxonomy . '_select', __('Lesson Module', 'woothemes-sensei'), array($this, 'lesson_module_metabox'), 'lesson', 'side', 'default');
+			add_meta_box($this->taxonomy . '_select', __('Module', 'woothemes-sensei'), array($this, 'lesson_module_metabox'), 'lesson', 'side', 'default');
 
 		}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -219,7 +219,7 @@ class Sensei_Core_Modules
 
 		// Build the HTML to output
 		if ( is_array( $modules ) && count( $modules ) > 0) {
-			$html .= '<select id="lesson-module-options" name="lesson_module" class="widefat">' . "\n";
+			$html .= '<select id="lesson-module-options" name="lesson_module" class="widefat" style="width: 100%">' . "\n";
 			$html .= '<option value="">' . __('None', 'woothemes-sensei') . '</option>';
 			foreach ($modules as $module) {
 				$html .= '<option value="' . esc_attr(absint($module->term_id)) . '"' . selected($module->term_id, $lesson_module, false) . '>' . esc_html( $module->name ) . '</option>' . "\n";


### PR DESCRIPTION
Fixes #2047

Reordered and renamed metaboxes, and fixed the widths of the dropdowns.

Some notes:

- The Module metabox is added in a different class from the rest, which makes it non-trivial to change the order as specified in #2047. I could do it, but it would either take some hacking or a big refactor (not worth it). For now, I've left it at the bottom. The top would not make much sense, because the options change based on the value of the Course metabox.

- I fixed the widths of the dropdowns by forcing `width: 100%` on the select box (as per this SO thread). The problem is the Select2 lib not being able to size itself properly when it is initially hidden. There may be further issues when users move the metaboxes around, but we might want to tackle that in a further issue, with a more forward-thinking solution.

- I did not find anything obvious in Gutenberg that would replace the Select2 library. But probably we should also give this some more thought in the future.