### PR TITLE
Exclude modules from course navigation when not appropriate

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -567,7 +567,7 @@ class Sensei_Core_Modules
 	 *
 	 * @return bool True if taxonomy template has been overridden.
 	 */
-	public function is_module_tax_template_overriden() {
+	protected function is_module_tax_template_overriden() {
 		$file = 'taxonomy-module.php';
 		$find = array( $file, Sensei()->template_url . $file );
 		$template = locate_template( $find );

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -544,7 +544,7 @@ class Sensei_Core_Modules
 			if ( ! empty( $description ) ) {
 				$do_link_to_module = true;
 			} else {
-				$do_link_to_module = $this->is_module_tax_template_overriden();
+				$do_link_to_module = $this->is_module_tax_template_overridden();
 			}
 		}
 
@@ -567,13 +567,13 @@ class Sensei_Core_Modules
 	 *
 	 * @return bool True if taxonomy template has been overridden.
 	 */
-	protected function is_module_tax_template_overriden() {
+	protected function is_module_tax_template_overridden() {
 		$file = 'taxonomy-module.php';
 		$find = array( $file, Sensei()->template_url . $file );
 		$template = locate_template( $find );
 
 		return (bool) $template;
-	} // End is_module_tax_template_overriden()
+	} // End is_module_tax_template_overridden()
 
 	/**
 	 * Set lesson archive template to display on module taxonomy archive page

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -525,6 +525,57 @@ class Sensei_Core_Modules
 	}
 
 	/**
+	 * Check if we should link to a module in the course outline.
+	 *
+	 * True if there is a module description or if the `taxonomy-module.php` template has been overridden.
+	 *
+	 * @since 1.10.0
+	 *
+	 * @param WP_Term $module
+	 * @param bool    $link_to_current Set to true to disable checks for currently displayed module. Default false.
+	 * @return bool
+	 */
+	public function do_link_to_module( WP_Term $module, $link_to_current = false ) {
+		// Perhaps don't link to module when on the module page already.
+		if ( ! $link_to_current && is_tax( 'module', $module->term_id ) ) {
+			$do_link_to_module = false;
+		} else {
+			$description = trim( $module->description );
+			if ( ! empty( $description ) ) {
+				$do_link_to_module = true;
+			} else {
+				$do_link_to_module = $this->is_module_tax_template_overriden();
+			}
+		}
+
+		/**
+		 * Determine if a particular module should be linked to.
+		 *
+		 * @since 1.10.0
+		 *
+		 * @param bool    $do_link_to_module  True if module should be linked to.
+		 * @param WP_Term $module             Module to check if it should be linked to.
+		 * @param bool    $link_to_current    Allow for linking to the currently displayed module.
+		 */
+		return apply_filters( 'sensei_do_link_to_module', $do_link_to_module, $module, $link_to_current );
+	} // End do_link_to_module()
+
+	/**
+	 * Checks if a module taxonomy template file has been overridden.
+	 *
+	 * @since 1.10.0
+	 *
+	 * @return bool True if taxonomy template has been overridden.
+	 */
+	public function is_module_tax_template_overriden() {
+		$file = 'taxonomy-module.php';
+		$find = array( $file, Sensei()->template_url . $file );
+		$template = locate_template( $find );
+
+		return (bool) $template;
+	} // End is_module_tax_template_overriden()
+
+	/**
 	 * Set lesson archive template to display on module taxonomy archive page
 	 *
 	 * @since 1.8.0

--- a/tests/unit-tests/test-template-functions.php
+++ b/tests/unit-tests/test-template-functions.php
@@ -135,7 +135,10 @@ class Sensei_Template_Functions_Test extends WP_UnitTestCase {
 		$previous = $modules[0];
 		$current = get_post( $lessons[0] );
 		$next = get_post( $lessons[1] );
+
+		add_filter( 'sensei_do_link_to_module', '__return_true' );
 		$nav_links = sensei_get_prev_next_lessons( $current->ID );
+		remove_filter( 'sensei_do_link_to_module', '__return_true' );
 
 		// Previous - Module
 		$this->assertArrayHasKey( 'previous', $nav_links, 'Previous - Key' );
@@ -143,6 +146,30 @@ class Sensei_Template_Functions_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'name', $nav_links['previous'], 'Previous - Name key' );
 		$this->assertEquals( get_term_link( $previous, 'module' ) . '&course_id=' . $course_id, $nav_links['previous']['url'], 'Previous - URL' );
 		$this->assertEquals( $previous->name, $nav_links['previous']['name'], 'Previous - Name' );
+
+		// Next - Lesson
+		$this->assertArrayHasKey( 'next', $nav_links, 'Next - Key' );
+		$this->assertArrayHasKey( 'url', $nav_links['next'], 'Next - URL key' );
+		$this->assertArrayHasKey( 'name', $nav_links['next'], 'Next - Name key' );
+		$this->assertEquals( get_permalink( $next->ID ), $nav_links['next']['url'], 'Next - URL' );
+		$this->assertEquals( $next->post_title, $nav_links['next']['name'], 'Next - Name' );
+	}
+
+	/**
+	 * @covers sensei_get_prev_next_lessons
+	 */
+	public function testGetPrevNextLessonsNoModules() {
+		$course_id = $this->factory->get_course_with_modules();
+		$lessons = $this->factory->get_lessons();
+		$current = get_post( $lessons[0] );
+		$next = get_post( $lessons[1] );
+
+		add_filter( 'sensei_do_link_to_module', '__return_false' );
+		$nav_links = sensei_get_prev_next_lessons( $current->ID );
+		remove_filter( 'sensei_do_link_to_module', '__return_false' );
+
+		// Previous - Module
+		$this->assertArrayNotHasKey( 'previous', $nav_links, 'Previous - Key' );
 
 		// Next - Lesson
 		$this->assertArrayHasKey( 'next', $nav_links, 'Next - Key' );


### PR DESCRIPTION
Fixes #2009 

## Changes proposed
- Introduces new public method: `Sensei_Core_Modules::do_link_to_module()`
- Refactors `sensei_get_prev_next_lessons()` to check if a module should be linked before including it in course navigation.
- Updates tests for `sensei_get_prev_next_lessons()` and adds new tests for new public method.

## Testing instructions
- Ensure unit tests pass.
- Verify satisfying conditions from issue #2009 are met.