### PR TITLE
Conditionally link to module in lesson breadcrumb

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -510,7 +510,11 @@ class Sensei_Core_Modules
 			if (has_term('', $this->taxonomy, $post->ID)) {
 				$module = $this->get_lesson_module($post->ID);
 				if( $module ) {
-					$html .= ' ' . $separator . ' <a href="' . esc_url($module->url) . '" title="' .  __('Back to the module', 'woothemes-sensei') . '">' . $module->name . '</a>';
+					if ( $this->do_link_to_module( $module ) ) {
+						$html .= ' ' . $separator . ' <a href="' . esc_url( $module->url ) . '" title="' . __( 'Back to the module', 'woothemes-sensei' ) . '">' . $module->name . '</a>';
+					} else {
+						$html .= ' ' . $separator . ' ' . $module->name;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #2064 

## Proposed Changes
- Only link to the module in the breadcrumb when it is helpful.

## Testing Instructions
- Set up a course with multiple modules and lessons. Leave some module descriptions empty while filling in the others. Make sure your theme isn't overriding `taxonomy-module.php`.
- View a lesson with a module that _has_ a description and verify the link still exists to the module in the breadcrumb.
- View a lesson with a module that _does not_ have a description and verify just the title (no link) shows in the breadcrumb.
