### PR TITLE
Delete data on uninstall

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Defines a class with methods for cleaning up plugin data. To be used when
+ * the plugin is deleted.
+ *
+ * @package Core
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	// Exit if accessed directly.
+	exit;
+}
+
+/**
+ * Methods for cleaning up all plugin data.
+ *
+ * @author Automattic
+ * @since 1.10.0
+ */
+class Sensei_Data_Cleaner {
+
+	const CUSTOM_POST_TYPES = array(
+		'course',
+		'lesson',
+		'quiz',
+		'question',
+		'multiple_question',
+		'sensei_message',
+	);
+
+	/**
+	 * Cleanup all data.
+	 *
+	 * @access public
+	 */
+	public static function cleanup_all() {
+		self::cleanup_custom_post_types();
+	}
+
+	/**
+	 * Cleanup data for custom post types.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_custom_post_types() {
+		foreach ( self::CUSTOM_POST_TYPES as $post_type ) {
+			$items = get_posts( array(
+				'post_type'   => $post_type,
+				'post_status' => 'any',
+				'numberposts' => -1,
+				'fields'      => 'ids',
+			) );
+
+			foreach ( $items as $item ) {
+				wp_trash_post( $item );
+			}
+		}
+	}
+}

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -19,7 +19,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Data_Cleaner {
 
-	const CUSTOM_POST_TYPES = array(
+	/**
+	 * Custom post types to be deleted.
+	 *
+	 * @var $custom_post_types
+	 */
+	private static $custom_post_types = array(
 		'course',
 		'lesson',
 		'quiz',
@@ -43,7 +48,7 @@ class Sensei_Data_Cleaner {
 	 * @access private
 	 */
 	private static function cleanup_custom_post_types() {
-		foreach ( self::CUSTOM_POST_TYPES as $post_type ) {
+		foreach ( self::$custom_post_types as $post_type ) {
 			$items = get_posts( array(
 				'post_type'   => $post_type,
 				'post_status' => 'any',

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -1,0 +1,86 @@
+<?php
+
+require 'includes/class-sensei-data-cleaner.php';
+
+class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
+	// Posts.
+	private $post_ids;
+	private $biography_ids;
+	private $course_ids;
+	private $lesson_ids;
+
+	/**
+	 * Add some posts to run tests against. Any that are associated with Sensei
+	 * should be trashed on cleanup. The other should not be trashed.
+	 */
+	private function setupPosts() {
+		// Create some regular posts.
+		$this->post_ids = $this->factory->post->create_many( 2, array(
+			'post_status' => 'publish',
+			'post_type'   => 'post',
+		) );
+
+		// Create an unrelated CPT to ensure its posts do not get deleted.
+		register_post_type( 'biography', array(
+			'label'       => 'Biographies',
+			'description' => 'A biography of a famous person (for testing)',
+			'public'      => true,
+		) );
+		$this->biography_ids = $this->factory->post->create_many( 4, array(
+			'post_status' => 'publish',
+			'post_type'   => 'biography',
+		) );
+
+		// Create some Sensei posts.
+		$this->course_ids = $this->factory->post->create_many( 8, array(
+			'post_status' => 'publish',
+			'post_type'   => 'course',
+		) );
+
+		$this->lesson_ids = $this->factory->post->create_many( 16, array(
+			'post_status' => 'publish',
+			'post_type'   => 'lesson',
+		) );
+	}
+
+	/**
+	 * Set up for tests.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->setupPosts();
+	}
+
+	/**
+	 * Ensure the Sensei posts are moved to trash.
+	 *
+	 * @covers Sensei_Data_Cleaner::cleanup_all
+	 * @covers Sensei_Data_Cleaner::cleanup_custom_post_types
+	 */
+	public function testSenseiPostsTrashed() {
+		Sensei_Data_Cleaner::cleanup_all();
+
+		$ids = array_merge( $this->course_ids, $this->lesson_ids );
+		foreach ( $ids as $id ) {
+			$post = get_post( $id );
+			$this->assertEquals( 'trash', $post->post_status, 'Sensei post should be trashed' );
+		}
+	}
+
+	/**
+	 * Ensure the non-Sensei posts are not moved to trash.
+	 *
+	 * @covers Sensei_Data_Cleaner::cleanup_all
+	 * @covers Sensei_Data_Cleaner::cleanup_custom_post_types
+	 */
+	public function testOtherPostsUntouched() {
+		Sensei_Data_Cleaner::cleanup_all();
+
+		$ids = array_merge( $this->post_ids, $this->biography_ids );
+		foreach ( $ids as $id ) {
+			$post = get_post( $id );
+			$this->assertNotEquals( 'trash', $post->post_status, 'Non-Sensei post should not be trashed' );
+		}
+	}
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -10,21 +10,24 @@
  * @author WooThemes
  * @since 1.0.0
  */
-if( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) exit();
+
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit();
+}
 
 $token = 'woothemes-sensei';
 delete_option( 'skip_install_sensei_pages' );
 delete_option( 'sensei_installed' );
 
-// Cleanup all data
-include( 'includes/class-sensei-data-cleaner.php' );
+// Cleanup all data.
+require 'includes/class-sensei-data-cleaner.php';
 
 if ( ! is_multisite() ) {
 	Sensei_Data_Cleaner::cleanup_all();
 } else {
 	global $wpdb;
 
-	$blog_ids = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
+	$blog_ids         = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
 	$original_blog_id = get_current_blog_id();
 
 	foreach ( $blog_ids as $blog_id ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -18,4 +18,19 @@ delete_option( 'sensei_installed' );
 
 // Cleanup all data
 include( 'includes/class-sensei-data-cleaner.php' );
-Sensei_Data_Cleaner::cleanup_all();
+
+if ( ! is_multisite() ) {
+	Sensei_Data_Cleaner::cleanup_all();
+} else {
+	global $wpdb;
+
+	$blog_ids = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
+	$original_blog_id = get_current_blog_id();
+
+	foreach ( $blog_ids as $blog_id ) {
+		switch_to_blog( $blog_id );
+		Sensei_Data_Cleaner::cleanup_all();
+	}
+
+	switch_to_blog( $original_blog_id );
+}

--- a/uninstall.php
+++ b/uninstall.php
@@ -15,3 +15,7 @@ if( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) exit();
 $token = 'woothemes-sensei';
 delete_option( 'skip_install_sensei_pages' );
 delete_option( 'sensei_installed' );
+
+// Cleanup all data
+include( 'includes/class-sensei-data-cleaner.php' );
+Sensei_Data_Cleaner::cleanup_all();


### PR DESCRIPTION
Added initial functionality to delete data when Sensei is uninstalled. This is for GDPR compliance (see #2034).

This first PR moves all posts of Sensei's Custom Post Types to the Trash.

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.

- Ensure that the tests pass.

- Delete the Sensei plugin.

- Look at your Posts, Pages, and other CPT's from other plugins. Ensure they have not been deleted or trashed.

- Inspect the database. All posts of type `course`, `lesson`, `quiz`, `question`, `multiple_question`, and `sensei_message` should have the status `trash`.

- If Sensei is reinstalled and activated, you should be able to see those posts in your Trash and restore them.

- Please also test on a multisite installation. When the plugin is deleted from the Network Admin, the data should be trashed across all sites.