### PR TITLE
Delete taxonomy data on plugin deletion

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -36,6 +36,15 @@ class Sensei_Data_Cleaner {
 		'sensei_message',
 	);
 
+	const TAXONOMIES = array(
+		'module',
+		'course-category',
+		'quiz-type',
+		'question-type',
+		'question-category',
+		'lesson-tag',
+	);
+
 	/**
 	 * Options to be deleted.
 	 *
@@ -65,6 +74,7 @@ class Sensei_Data_Cleaner {
 	public static function cleanup_all() {
 		self::cleanup_custom_post_types();
 		self::cleanup_pages();
+		self::cleanup_taxonomies();
 		self::cleanup_options();
 	}
 
@@ -117,6 +127,32 @@ class Sensei_Data_Cleaner {
 		$my_courses_page_id = $settings->get( 'my_course_page' );
 		if ( $my_courses_page_id ) {
 			wp_trash_post( $my_courses_page_id );
+		}
+	}
+
+	/**
+	 * Cleanup data for taxonomies.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_taxonomies() {
+		global $wpdb;
+
+		foreach ( self::TAXONOMIES as $taxonomy ) {
+			$terms = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT term_id, term_taxonomy_id FROM $wpdb->term_taxonomy WHERE taxonomy = %s",
+					$taxonomy
+				)
+			);
+
+			// Delete all data for each term.
+			foreach ( $terms as $term ) {
+				$wpdb->delete( $wpdb->term_relationships, array( 'term_taxonomy_id' => $term->term_taxonomy_id ) );
+				$wpdb->delete( $wpdb->term_taxonomy, array( 'term_taxonomy_id' => $term->term_taxonomy_id ) );
+				$wpdb->delete( $wpdb->terms, array( 'term_id' => $term->term_id ) );
+				$wpdb->delete( $wpdb->termmeta, array( 'term_id' => $term->term_id ) );
+			}
 		}
 	}
 }

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -36,7 +36,12 @@ class Sensei_Data_Cleaner {
 		'sensei_message',
 	);
 
-	const TAXONOMIES = array(
+	/**
+	 * Taxonomies to be deleted.
+	 *
+	 * @var $taxonomies
+	 */
+	private static $taxonomies = array(
 		'module',
 		'course-category',
 		'quiz-type',
@@ -138,7 +143,7 @@ class Sensei_Data_Cleaner {
 	private static function cleanup_taxonomies() {
 		global $wpdb;
 
-		foreach ( self::TAXONOMIES as $taxonomy ) {
+		foreach ( self::$taxonomies as $taxonomy ) {
 			$terms = $wpdb->get_results(
 				$wpdb->prepare(
 					"SELECT term_id, term_taxonomy_id FROM $wpdb->term_taxonomy WHERE taxonomy = %s",

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -342,7 +342,7 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			array( $this->biography_ids[1] ),
 			$this->getPostIdsWithTerm( $this->ages[1]['term_id'], 'age' ),
-			'"Old" should not be deleted'
+			'"New" should not be deleted'
 		);
 	}
 

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -21,7 +21,7 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 
 	/**
 	 * Add some posts to run tests against. Any that are associated with Sensei
-	 * should be trashed on cleanup. The other should not be trashed.
+	 * should be trashed on cleanup. The others should not be trashed.
 	 */
 	private function setupPosts() {
 		// Create some regular posts.
@@ -53,6 +53,10 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 		) );
 	}
 
+	/**
+	 * Add some taxonomies to run tests against. Any that are associated with
+	 * Sensei should be deleted on cleanup. The others should not be deleted.
+	 */
 	private function setupTaxonomyTerms() {
 		// Setup some modules.
 		$this->modules = array();
@@ -342,7 +346,7 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 		);
 	}
 
-	// Helpers
+	/* Helper functions. */
 
 	private function getPostIdsWithTerm( $term_id, $taxonomy ) {
 		return get_posts( array(

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -317,17 +317,27 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 			'Category 1 should not be deleted'
 		);
 
-		// Check "Category 2".
+		// Check "Category 2". Sort the arrays because the ordering doesn't
+		// matter.
+		$expected = array( $this->post_ids[0], $this->biography_ids[2] );
+		$actual   = $this->getPostIdsWithTerm( $this->categories[1]['term_id'], 'category' );
+		sort( $expected );
+		sort( $actual );
 		$this->assertEquals(
-			array( $this->post_ids[0], $this->biography_ids[2] ),
-			$this->getPostIdsWithTerm( $this->categories[1]['term_id'], 'category' ),
+			$expected,
+			$actual,
 			'Category 2 should not be deleted'
 		);
 
-		// Check "Category 3".
+		// Check "Category 3". Sort the arrays because the ordering doesn't
+		// matter.
+		$expected = array( $this->post_ids[0], $this->biography_ids[2] );
+		$actual   = $this->getPostIdsWithTerm( $this->categories[2]['term_id'], 'category' );
+		sort( $expected );
+		sort( $actual );
 		$this->assertEquals(
-			array( $this->post_ids[0], $this->biography_ids[2] ),
-			$this->getPostIdsWithTerm( $this->categories[2]['term_id'], 'category' ),
+			$expected,
+			$actual,
 			'Category 3 should not be deleted'
 		);
 

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -14,6 +14,11 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 	private $course_archive_page_id;
 	private $my_courses_page_id;
 
+	// Taxonomies.
+	private $modules;
+	private $categories;
+	private $ages;
+
 	/**
 	 * Add some posts to run tests against. Any that are associated with Sensei
 	 * should be trashed on cleanup. The other should not be trashed.
@@ -46,6 +51,87 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 			'post_status' => 'publish',
 			'post_type'   => 'lesson',
 		) );
+	}
+
+	private function setupTaxonomyTerms() {
+		// Setup some modules.
+		$this->modules = array();
+
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$this->modules[] = wp_insert_term( 'Module ' . $i, 'module' );
+		}
+
+		wp_set_object_terms( $this->course_ids[0],
+			array(
+				$this->modules[0]['term_id'],
+				$this->modules[1]['term_id'],
+			),
+			'module'
+		);
+		wp_set_object_terms( $this->course_ids[1],
+			array(
+				$this->modules[1]['term_id'],
+				$this->modules[2]['term_id'],
+			),
+			'module'
+		);
+		wp_set_object_terms( $this->course_ids[2],
+			array(
+				$this->modules[0]['term_id'],
+				$this->modules[1]['term_id'],
+				$this->modules[2]['term_id'],
+			),
+			'module'
+		);
+
+		// Setup some categories.
+		$this->categories = array();
+
+		for ( $i = 1; $i <= 3; $i++ ) {
+			$this->categories[] = wp_insert_term( 'Category ' . $i, 'category' );
+		}
+
+		wp_set_object_terms( $this->course_ids[0],
+			array(
+				$this->categories[0]['term_id'],
+				$this->categories[1]['term_id'],
+			),
+			'category'
+		);
+		wp_set_object_terms( $this->post_ids[0],
+			array(
+				$this->categories[1]['term_id'],
+				$this->categories[2]['term_id'],
+			),
+			'category'
+		);
+		wp_set_object_terms( $this->biography_ids[2],
+			array(
+				$this->categories[0]['term_id'],
+				$this->categories[1]['term_id'],
+				$this->categories[2]['term_id'],
+			),
+			'category'
+		);
+
+		// Setup a custom taxonomy.
+		register_taxonomy( 'age', 'biography' );
+
+		$this->ages = array(
+			wp_insert_term( 'Old', 'age' ),
+			wp_insert_term( 'New', 'age' ),
+		);
+
+		wp_set_object_terms( $this->biography_ids[0], $this->ages[0]['term_id'], 'age' );
+		wp_set_object_terms( $this->biography_ids[1], $this->ages[1]['term_id'], 'age' );
+
+		// Add a piece of termmeta for every term.
+		$terms = array_merge( $this->modules, $this->categories, $this->ages );
+		foreach ( $terms as $term ) {
+			$key   = 'the_term_id';
+			$value = 'The ID is ' . $term['term_id'];
+			update_term_meta( $term['term_id'], $key, $value );
+		}
 	}
 
 	/**
@@ -85,6 +171,7 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 
 		$this->setupPosts();
 		$this->setupPages();
+		$this->setupTaxonomyTerms();
 	}
 
 	/**
@@ -160,5 +247,114 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 		foreach ( $this->regular_page_ids as $page_id ) {
 			$this->assertNotEquals( 'trash', get_post_status( $page_id ), 'Regular page should not be trashed' );
 		}
+	}
+
+	/**
+	 * Ensure the data for Sensei taxonomies and terms are deleted.
+	 *
+	 * @covers Sensei_Data_Cleaner::cleanup_all
+	 * @covers Sensei_Data_Cleaner::cleanup_taxonomies
+	 */
+	public function testSenseiTaxonomiesDeleted() {
+		global $wpdb;
+
+		Sensei_Data_Cleaner::cleanup_all();
+
+		foreach ( $this->modules as $module ) {
+			$term_id          = $module['term_id'];
+			$term_taxonomy_id = $module['term_taxonomy_id'];
+
+			// Ensure the data is deleted from all the relevant DB tables.
+			$this->assertEquals( array(), $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT * from $wpdb->termmeta WHERE term_id = %s",
+					$term_id
+				)
+			), 'Sensei term meta should be deleted' );
+
+			$this->assertEquals( array(), $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT * from $wpdb->terms WHERE term_id = %s",
+					$term_id
+				)
+			), 'Sensei term should be deleted' );
+
+			$this->assertEquals( array(), $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT * from $wpdb->term_taxonomy WHERE term_taxonomy_id = %s",
+					$term_taxonomy_id
+				)
+			), 'Sensei term taxonomy should be deleted' );
+
+			$this->assertEquals( array(), $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT * from $wpdb->term_relationships WHERE term_taxonomy_id = %s",
+					$term_taxonomy_id
+				)
+			), 'Sensei term relationships should be deleted' );
+		}
+	}
+
+	/**
+	 * Ensure the data for non-Sensei taxonomies and terms are not deleted.
+	 *
+	 * @covers Sensei_Data_Cleaner::cleanup_all
+	 * @covers Sensei_Data_Cleaner::cleanup_taxonomies
+	 */
+	public function testOtherTaxonomiesUntouched() {
+		global $wpdb;
+
+		Sensei_Data_Cleaner::cleanup_all();
+
+		// Check "Category 1".
+		$this->assertEquals(
+			array( $this->biography_ids[2] ),
+			$this->getPostIdsWithTerm( $this->categories[0]['term_id'], 'category' ),
+			'Category 1 should not be deleted'
+		);
+
+		// Check "Category 2".
+		$this->assertEquals(
+			array( $this->post_ids[0], $this->biography_ids[2] ),
+			$this->getPostIdsWithTerm( $this->categories[1]['term_id'], 'category' ),
+			'Category 2 should not be deleted'
+		);
+
+		// Check "Category 3".
+		$this->assertEquals(
+			array( $this->post_ids[0], $this->biography_ids[2] ),
+			$this->getPostIdsWithTerm( $this->categories[2]['term_id'], 'category' ),
+			'Category 3 should not be deleted'
+		);
+
+		// Check "Old" biographies.
+		$this->assertEquals(
+			array( $this->biography_ids[0] ),
+			$this->getPostIdsWithTerm( $this->ages[0]['term_id'], 'age' ),
+			'"Old" should not be deleted'
+		);
+
+		// Check "New" biographies.
+		$this->assertEquals(
+			array( $this->biography_ids[1] ),
+			$this->getPostIdsWithTerm( $this->ages[1]['term_id'], 'age' ),
+			'"Old" should not be deleted'
+		);
+	}
+
+	// Helpers
+
+	private function getPostIdsWithTerm( $term_id, $taxonomy ) {
+		return get_posts( array(
+			'fields'    => 'ids',
+			'post_type' => 'any',
+			'tax_query' => array(
+				array(
+					'field'    => 'term_id',
+					'terms'    => $term_id,
+					'taxonomy' => $taxonomy,
+				),
+			),
+		) );
 	}
 }


### PR DESCRIPTION
Builds upon #2068 and contributes to https://github.com/Automattic/sensei/issues/2034

This PR deletes all taxonomy data: term meta, terms, term taxonomies, and term relationships.

Note that this data is deleted directly from the database and this cannot be undone! I've aimed to make this code simple, with some key automated tests, so we don't inadvertently delete data that we shouldn't. We should make sure to test it carefully.

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.

- Ensure that the tests pass.

- Delete the Sensei plugin.

- Look at your Categories, Tags, and taxonomies from other plugins. Ensure they have not been deleted.

- Inspect the database. All items in the `termmeta`, `terms`, `term_relationships` and `term_taxonomy` tables that were related to Sensei (e.g. Modules) should be removed.

- Please also test on a multisite installation. When the plugin is deleted from the Network Admin, the data should be deleted across all sites.