### PR TITLE
Delete Sensei pages on plugin deletion

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -11,6 +11,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once dirname( __FILE__ ) . '/class-sensei-settings-api.php';
+require_once dirname( __FILE__ ) . '/class-sensei-settings.php';
+
 /**
  * Methods for cleaning up all plugin data.
  *
@@ -61,6 +64,7 @@ class Sensei_Data_Cleaner {
 	 */
 	public static function cleanup_all() {
 		self::cleanup_custom_post_types();
+		self::cleanup_pages();
 		self::cleanup_options();
 	}
 
@@ -92,6 +96,27 @@ class Sensei_Data_Cleaner {
 	private static function cleanup_options() {
 		foreach ( self::$options as $option ) {
 			delete_option( $option );
+		}
+	}
+
+	/**
+	 * Cleanup data for pages.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_pages() {
+		$settings = new Sensei_Settings();
+
+		// Trash the Course Archive page.
+		$course_archive_page_id = $settings->get( 'course_page' );
+		if ( $course_archive_page_id ) {
+			wp_trash_post( $course_archive_page_id );
+		}
+
+		// Trash the My Courses page.
+		$my_courses_page_id = $settings->get( 'my_course_page' );
+		if ( $my_courses_page_id ) {
+			wp_trash_post( $my_courses_page_id );
 		}
 	}
 }


### PR DESCRIPTION
Contributes to #2034

This PR, on plugin deletion, trashes the pages that are set up in Sensei as the Course Archive page, and the My Courses page.

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.

- Ensure that the tests pass.

- Delete the Sensei plugin.

- Look at your Pages. All pages should be intact except for the Course Archive page, and the My Courses page. They should be trashed.

- Please also test on a multisite installation. When the plugin is deleted from the Network Admin, the pages should be trashed across all sites.