### PR TITLE
Delete Sensei options on plugin deletion

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -34,12 +34,34 @@ class Sensei_Data_Cleaner {
 	);
 
 	/**
+	 * Options to be deleted.
+	 *
+	 * @var $options
+	 */
+	private static $options = array(
+		'sensei_installed',
+		'sensei_course_order',
+		'skip_install_sensei_pages',
+		'sensei_flush_rewrite_rules',
+		'sensei_needs_language_pack_install',
+		'woothemes_sensei_language_pack_version',
+		'woothemes-sensei-version',
+		'sensei_usage_tracking_opt_in_hide',
+		'woothemes-sensei-upgrades',
+		'woothemes-sensei-settings',
+		'sensei_courses_page_id',
+		'woothemes-sensei_courses_page_id',
+		'woothemes-sensei_user_dashboard_page_id',
+	);
+
+	/**
 	 * Cleanup all data.
 	 *
 	 * @access public
 	 */
 	public static function cleanup_all() {
 		self::cleanup_custom_post_types();
+		self::cleanup_options();
 	}
 
 	/**
@@ -59,6 +81,17 @@ class Sensei_Data_Cleaner {
 			foreach ( $items as $item ) {
 				wp_trash_post( $item );
 			}
+		}
+	}
+
+	/**
+	 * Cleanup data for options.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_options() {
+		foreach ( self::$options as $option ) {
+			delete_option( $option );
 		}
 	}
 }

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -83,4 +83,30 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 			$this->assertNotEquals( 'trash', $post->post_status, 'Non-Sensei post should not be trashed' );
 		}
 	}
+
+	/**
+	 * Ensure the Sensei options are deleted and the others aren't.
+	 *
+	 * @covers Sensei_Data_Cleaner::cleanup_all
+	 * @covers Sensei_Data_Cleaner::cleanup_options
+	 */
+	public function testSenseiOptionsDeleted() {
+		// Set a couple Sensei options.
+		update_option( 'sensei_usage_tracking_opt_in_hide', '1' );
+		update_option( 'woothemes-sensei-version', '1.10.0' );
+
+		// Set a couple other options.
+		update_option( 'my_option_1', 'Value 1' );
+		update_option( 'my_option_2', 'Value 2' );
+
+		Sensei_Data_Cleaner::cleanup_all();
+
+		// Ensure the Sensei options are deleted.
+		$this->assertFalse( get_option( 'sensei_usage_tracking_opt_in_hide' ) );
+		$this->assertFalse( get_option( 'woothemes-sensei-version' ) );
+
+		// Ensure the non-Sensei options are intact.
+		$this->assertEquals( 'Value 1', get_option( 'my_option_1' ) );
+		$this->assertEquals( 'Value 2', get_option( 'my_option_2' ) );
+	}
 }


### PR DESCRIPTION
Contributes to #2034

This PR, on plugin deletion, deletes all options in the database associated with Sensei. The options include:

- `sensei_installed`
- `sensei_course_order`
- `skip_install_sensei_pages`
- `sensei_flush_rewrite_rules`
- `sensei_needs_language_pack_install`
- `woothemes_sensei_language_pack_version`
- `woothemes-sensei-version`
- `sensei_usage_tracking_opt_in_hide`
- `woothemes-sensei-upgrades`
- `woothemes-sensei-settings`
- `sensei_courses_page_id`
- `woothemes-sensei_courses_page_id`
- `woothemes-sensei_user_dashboard_page_id`

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.

- Ensure that the tests pass.

- Delete the Sensei plugin.

- Inspect the database and look at the `wp_options` table. All options should be intact except for the ones listed above. Those should be deleted.

- Please also test on a multisite installation. When the plugin is deleted from the Network Admin, the pages should be trashed across all sites.