### PR TITLE
Add usage tracking for active and completed courses

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -24,6 +24,7 @@ class Sensei_Usage_Tracking_Data {
 		$question_type_count = self::get_question_type_count();
 		$usage_data = array(
 			'courses' => wp_count_posts( 'course' )->publish,
+			'course_completed' => self::get_course_completed_count(),
 			'course_videos' => self::get_course_videos_count(),
 			'course_no_notifications' => self::get_course_no_notifications_count(),
 			'course_prereqs' => self::get_course_prereqs_count(),
@@ -47,6 +48,22 @@ class Sensei_Usage_Tracking_Data {
 		);
 
 		return array_merge( $question_type_count, $usage_data );
+	}
+
+	/**
+	 * Get the total number of completed courses across all learners.
+	 *
+	 * @since 1.10.0
+	 *
+	 * @return int Number of completed courses.
+	 **/
+	private static function get_course_completed_count() {
+		$course_args = array(
+			'type'   => 'sensei_course_status',
+			'status' => 'complete',
+		);
+
+		return Sensei_Utils::sensei_check_for_activity( $course_args );
 	}
 
 	/**

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * Usage tracking data
+ *
+ * @package Usage Tracking
  **/
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -22,30 +25,30 @@ class Sensei_Usage_Tracking_Data {
 	 **/
 	public static function get_usage_data() {
 		$question_type_count = self::get_question_type_count();
-		$usage_data = array(
-			'courses' => wp_count_posts( 'course' )->publish,
-			'course_active' => self::get_course_active_count(),
-			'course_completed' => self::get_course_completed_count(),
-			'course_videos' => self::get_course_videos_count(),
+		$usage_data          = array(
+			'courses'                 => wp_count_posts( 'course' )->publish,
+			'course_active'           => self::get_course_active_count(),
+			'course_completed'        => self::get_course_completed_count(),
+			'course_videos'           => self::get_course_videos_count(),
 			'course_no_notifications' => self::get_course_no_notifications_count(),
-			'course_prereqs' => self::get_course_prereqs_count(),
-			'course_featured' => self::get_course_featured_count(),
-			'learners' => self::get_learner_count(),
-			'lessons' => wp_count_posts( 'lesson' )->publish,
-			'lesson_modules' => self::get_lesson_module_count(),
-			'lesson_prereqs' => self::get_lesson_prerequisite_count(),
-			'lesson_previews' => self::get_lesson_preview_count(),
-			'lesson_length' => self::get_lesson_has_length_count(),
-			'lesson_complexity' => self::get_lesson_with_complexity_count(),
-			'lesson_videos' => self::get_lesson_with_video_count(),
-			'messages' => wp_count_posts( 'sensei_message' )->publish,
-			'modules' => wp_count_terms( 'module' ),
-			'modules_max' => self::get_max_module_count(),
-			'modules_min' => self::get_min_module_count(),
-			'questions' => wp_count_posts( 'question' )->publish,
-			'question_media' => self::get_question_media_count(),
-			'question_random_order' => self::get_question_random_order_count(),
-			'teachers' => self::get_teacher_count(),
+			'course_prereqs'          => self::get_course_prereqs_count(),
+			'course_featured'         => self::get_course_featured_count(),
+			'learners'                => self::get_learner_count(),
+			'lessons'                 => wp_count_posts( 'lesson' )->publish,
+			'lesson_modules'          => self::get_lesson_module_count(),
+			'lesson_prereqs'          => self::get_lesson_prerequisite_count(),
+			'lesson_previews'         => self::get_lesson_preview_count(),
+			'lesson_length'           => self::get_lesson_has_length_count(),
+			'lesson_complexity'       => self::get_lesson_with_complexity_count(),
+			'lesson_videos'           => self::get_lesson_with_video_count(),
+			'messages'                => wp_count_posts( 'sensei_message' )->publish,
+			'modules'                 => wp_count_terms( 'module' ),
+			'modules_max'             => self::get_max_module_count(),
+			'modules_min'             => self::get_min_module_count(),
+			'questions'               => wp_count_posts( 'question' )->publish,
+			'question_media'          => self::get_question_media_count(),
+			'question_random_order'   => self::get_question_random_order_count(),
+			'teachers'                => self::get_teacher_count(),
 		);
 
 		return array_merge( $question_type_count, $usage_data );
@@ -59,7 +62,7 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Number of active courses.
 	 **/
 	private static function get_course_active_count() {
-		$course_args = array(
+		$course_args     = array(
 			'type'   => 'sensei_course_status',
 			'status' => 'any',
 		);
@@ -92,18 +95,20 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Number of courses.
 	 */
 	private static function get_course_videos_count() {
-		// Match video strings with at least one non-space character
-		$query = new WP_Query( array(
-			'post_type' => 'course',
-			'fields' => 'ids',
-			'meta_query' => array(
-				array(
-					'key' => '_course_video_embed',
-					'value' => '[^[:space:]]',
-					'compare' => 'REGEXP',
-				)
+		// Match video strings with at least one non-space character.
+		$query = new WP_Query(
+			array(
+				'post_type'  => 'course',
+				'fields'     => 'ids',
+				'meta_query' => array(
+					array(
+						'key'     => '_course_video_embed',
+						'value'   => '[^[:space:]]',
+						'compare' => 'REGEXP',
+					),
+				),
 			)
-		) );
+		);
 
 		return $query->found_posts;
 	}
@@ -116,16 +121,18 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Number of courses.
 	 */
 	private static function get_course_no_notifications_count() {
-		$query = new WP_Query( array(
-			'post_type' => 'course',
-			'fields' => 'ids',
-			'meta_query' => array(
-				array(
-					'key' => 'disable_notification',
-					'value' => true,
-				)
-			),
-		) );
+		$query = new WP_Query(
+			array(
+				'post_type'  => 'course',
+				'fields'     => 'ids',
+				'meta_query' => array(
+					array(
+						'key'   => 'disable_notification',
+						'value' => true,
+					),
+				),
+			)
+		);
 
 		return $query->found_posts;
 	}
@@ -138,22 +145,24 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Number of courses.
 	 */
 	private static function get_course_prereqs_count() {
-		$query = new WP_Query( array(
-			'post_type' => 'course',
-			'fields' => 'ids',
-			'meta_query' => array(
-				array(
-					'key' => '_course_prerequisite',
-					'value' => '',
-					'compare' => '!=',
+		$query = new WP_Query(
+			array(
+				'post_type'  => 'course',
+				'fields'     => 'ids',
+				'meta_query' => array(
+					array(
+						'key'     => '_course_prerequisite',
+						'value'   => '',
+						'compare' => '!=',
+					),
+					array(
+						'key'     => '_course_prerequisite',
+						'value'   => '0',
+						'compare' => '!=',
+					),
 				),
-				array(
-					'key' => '_course_prerequisite',
-					'value' => '0',
-					'compare' => '!=',
-				),
-			),
-		) );
+			)
+		);
 
 		return $query->found_posts;
 	}
@@ -166,16 +175,18 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Number of courses.
 	 */
 	private static function get_course_featured_count() {
-		$query = new WP_Query( array(
-			'post_type' => 'course',
-			'fields' => 'ids',
-			'meta_query' => array(
-				array(
-					'key' => '_course_featured',
-					'value' => 'featured',
-				)
-			),
-		) );
+		$query = new WP_Query(
+			array(
+				'post_type'  => 'course',
+				'fields'     => 'ids',
+				'meta_query' => array(
+					array(
+						'key'   => '_course_featured',
+						'value' => 'featured',
+					),
+				),
+			)
+		);
 
 		return $query->found_posts;
 	}
@@ -188,10 +199,12 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Number of teachers.
 	 **/
 	private static function get_teacher_count() {
-		$teacher_query = new WP_User_Query( array(
-			'fields' => 'ID',
-			'role' => 'teacher',
-		) );
+		$teacher_query = new WP_User_Query(
+			array(
+				'fields' => 'ID',
+				'role'   => 'teacher',
+			)
+		);
 
 		return $teacher_query->total_users;
 	}
@@ -205,14 +218,14 @@ class Sensei_Usage_Tracking_Data {
 	 **/
 	private static function get_learner_count() {
 		$learner_count = 0;
-		$user_query = new WP_User_Query( array( 'fields' => 'ID' ) );
-		$learners = $user_query->get_results();
+		$user_query    = new WP_User_Query( array( 'fields' => 'ID' ) );
+		$learners      = $user_query->get_results();
 
-		foreach( $learners as $learner ) {
+		foreach ( $learners as $learner ) {
 			$course_args = array(
 				'user_id' => $learner,
-				'type' => 'sensei_course_status',
-				'status' => 'any',
+				'type'    => 'sensei_course_status',
+				'status'  => 'any',
 			);
 
 			$course_count = Sensei_Utils::sensei_check_for_activity( $course_args );
@@ -233,17 +246,19 @@ class Sensei_Usage_Tracking_Data {
 	 * @return array Number of published lessons with a prerequisite.
 	 **/
 	private static function get_lesson_prerequisite_count() {
-		$query = new WP_Query( array(
-			'post_type' => 'lesson',
-			'fields' => 'ids',
-			'meta_query' => array(
-				array(
-					'key' => '_lesson_prerequisite',
-					'value' => 0,
-					'compare' => '>',
-				)
+		$query = new WP_Query(
+			array(
+				'post_type'  => 'lesson',
+				'fields'     => 'ids',
+				'meta_query' => array(
+					array(
+						'key'     => '_lesson_prerequisite',
+						'value'   => 0,
+						'compare' => '>',
+					),
+				),
 			)
-		) );
+		);
 
 		return $query->found_posts;
 	}
@@ -256,17 +271,19 @@ class Sensei_Usage_Tracking_Data {
 	 * @return array Number of published lessons that enable previewing.
 	 **/
 	private static function get_lesson_preview_count() {
-		$query = new WP_Query( array(
-			'post_type' => 'lesson',
-			'fields' => 'ids',
-			'meta_query' => array(
-				array(
-					'key' => '_lesson_preview',
-					'value' => '',
-					'compare' => '!=',
-				)
+		$query = new WP_Query(
+			array(
+				'post_type'  => 'lesson',
+				'fields'     => 'ids',
+				'meta_query' => array(
+					array(
+						'key'     => '_lesson_preview',
+						'value'   => '',
+						'compare' => '!=',
+					),
+				),
 			)
-		) );
+		);
 
 		return $query->found_posts;
 	}
@@ -279,16 +296,18 @@ class Sensei_Usage_Tracking_Data {
 	 * @return array Number of published lessons associated with a module.
 	 **/
 	private static function get_lesson_module_count() {
-		$query = new WP_Query( array(
-			'post_type' => 'lesson',
-			'fields' => 'ids',
-			'tax_query' => array(
-				array(
-					'taxonomy' => 'module',
-					'operator' => 'EXISTS'
-				)
+		$query = new WP_Query(
+			array(
+				'post_type' => 'lesson',
+				'fields'    => 'ids',
+				'tax_query' => array(
+					array(
+						'taxonomy' => 'module',
+						'operator' => 'EXISTS',
+					),
+				),
 			)
-		) );
+		);
 
 		return $query->found_posts;
 	}
@@ -301,17 +320,19 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Number of lessons.
 	 **/
 	private static function get_lesson_has_length_count() {
-		$query = new WP_Query( array(
-			'post_type' => 'lesson',
-			'fields' => 'ids',
-			'meta_query' => array(
-				array(
-					'key' => '_lesson_length',
-					'value' => '',
-					'compare' => '!=',
-				)
+		$query = new WP_Query(
+			array(
+				'post_type'  => 'lesson',
+				'fields'     => 'ids',
+				'meta_query' => array(
+					array(
+						'key'     => '_lesson_length',
+						'value'   => '',
+						'compare' => '!=',
+					),
+				),
 			)
-		) );
+		);
 
 		return $query->found_posts;
 	}
@@ -324,17 +345,19 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Number of lessons.
 	 **/
 	private static function get_lesson_with_complexity_count() {
-		$query = new WP_Query( array(
-			'post_type' => 'lesson',
-			'fields' => 'ids',
-			'meta_query' => array(
-				array(
-					'key' => '_lesson_complexity',
-					'value' => '',
-					'compare' => '!=',
-				)
+		$query = new WP_Query(
+			array(
+				'post_type'  => 'lesson',
+				'fields'     => 'ids',
+				'meta_query' => array(
+					array(
+						'key'     => '_lesson_complexity',
+						'value'   => '',
+						'compare' => '!=',
+					),
+				),
 			)
-		) );
+		);
 
 		return $query->found_posts;
 	}
@@ -347,17 +370,19 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Number of lessons.
 	 **/
 	private static function get_lesson_with_video_count() {
-		$query = new WP_Query( array(
-			'post_type' => 'lesson',
-			'fields' => 'ids',
-			'meta_query' => array(
-				array(
-					'key' => '_lesson_video_embed',
-					'value' => '[^[:space:]]',
-					'compare' => 'REGEXP',
-				)
+		$query = new WP_Query(
+			array(
+				'post_type'  => 'lesson',
+				'fields'     => 'ids',
+				'meta_query' => array(
+					array(
+						'key'     => '_lesson_video_embed',
+						'value'   => '[^[:space:]]',
+						'compare' => 'REGEXP',
+					),
+				),
 			)
-		) );
+		);
 
 		return $query->found_posts;
 	}
@@ -372,18 +397,22 @@ class Sensei_Usage_Tracking_Data {
 	 **/
 	private static function get_max_module_count() {
 		$max_modules = 0;
-		$query = new WP_Query( array(
-			'post_type' => 'course',
-			'posts_per_page' => -1,
-			'fields' => 'ids',
-		) );
-		$courses = $query->posts;
+		$query       = new WP_Query(
+			array(
+				'post_type'      => 'course',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+		$courses     = $query->posts;
 
-		foreach( $courses as $course ) {
+		foreach ( $courses as $course ) {
 			// Get modules for this course.
-			$module_count = wp_count_terms( 'module', array(
-				'object_ids' => $course,
-			) );
+			$module_count = wp_count_terms(
+				'module', array(
+					'object_ids' => $course,
+				)
+			);
 
 			if ( $max_modules < $module_count ) {
 				$max_modules = $module_count;
@@ -402,22 +431,27 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Minimum modules count.
 	 **/
 	private static function get_min_module_count() {
-		$min_modules = 0;
-		$query = new WP_Query( array(
-			'post_type' => 'course',
-			'posts_per_page' => -1,
-			'fields' => 'ids',
-		) );
-		$courses = $query->posts;
+		$min_modules   = 0;
+		$query         = new WP_Query(
+			array(
+				'post_type'      => 'course',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
+		$courses       = $query->posts;
+		$total_courses = count( $courses );
 
-		for( $i = 0; $i < count( $courses ); $i++ ) {
+		for ( $i = 0; $i < $total_courses; $i++ ) {
 			// Get modules for this course.
-			$module_count = wp_count_terms( 'module', array(
-				'object_ids' => $courses[$i],
-			) );
+			$module_count = wp_count_terms(
+				'module', array(
+					'object_ids' => $courses[ $i ],
+				)
+			);
 
 			// Set the starting count.
-			if ( $i === 0 ) {
+			if ( 0 === $i ) {
 				$min_modules = $module_count;
 				continue;
 			}
@@ -438,23 +472,25 @@ class Sensei_Usage_Tracking_Data {
 	 * @return array Number of published questions of each type.
 	 **/
 	private static function get_question_type_count() {
-		$count = array();
+		$count          = array();
 		$question_types = Sensei()->question->question_types();
 
-		foreach ( $question_types as $key=>$value ) {
+		foreach ( $question_types as $key => $value ) {
 			$count[ self::get_question_type_key( $key ) ] = 0;
 		}
 
-		$query = new WP_Query( array(
-			'post_type' => 'question',
-			'posts_per_page' => -1,
-			'fields' => 'ids'
-		) );
+		$query     = new WP_Query(
+			array(
+				'post_type'      => 'question',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+			)
+		);
 		$questions = $query->posts;
 
 		foreach ( $questions as $question ) {
 			$question_type = Sensei()->question->get_question_type( $question );
-			$key = self::get_question_type_key( $question_type );
+			$key           = self::get_question_type_key( $question_type );
 
 			if ( array_key_exists( $key, $count ) ) {
 				$count[ $key ]++;
@@ -472,17 +508,19 @@ class Sensei_Usage_Tracking_Data {
 	 * @return array Number of published questions with media.
 	 **/
 	private static function get_question_media_count() {
-		$query = new WP_Query( array(
-			'post_type' => 'question',
-			'fields' => 'ids',
-			'meta_query' => array(
-				array(
-					'key' => '_question_media',
-					'value' => 0,
-					'compare' => '>',
-				)
+		$query = new WP_Query(
+			array(
+				'post_type'  => 'question',
+				'fields'     => 'ids',
+				'meta_query' => array(
+					array(
+						'key'     => '_question_media',
+						'value'   => 0,
+						'compare' => '>',
+					),
+				),
 			)
-		) );
+		);
 
 		return $query->found_posts;
 	}
@@ -495,19 +533,21 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Number of multiple choice questions with randomized answers.
 	 **/
 	private static function get_question_random_order_count() {
-		$count = 0;
-		$query = new WP_Query( array(
-			'post_type' => 'question',
-			'posts_per_page' => -1,
-			'fields' => 'ids',
-			'meta_query' => array(
-				array(
-					'key' => '_random_order',
-					'value' => 'yes',
-					'compare' => '=',
-				)
+		$count     = 0;
+		$query     = new WP_Query(
+			array(
+				'post_type'      => 'question',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'meta_query'     => array(
+					array(
+						'key'     => '_random_order',
+						'value'   => 'yes',
+						'compare' => '=',
+					),
+				),
 			)
-		) );
+		);
 		$questions = $query->posts;
 
 		foreach ( $questions as $question ) {
@@ -518,7 +558,7 @@ class Sensei_Usage_Tracking_Data {
 			 * Since it's possible that other question types could have a random answer order set,
 			 * let's explicitly handle multiple choice.
 			 */
-			if ( $question_type === 'multiple-choice' ) {
+			if ( 'multiple-choice' === $question_type ) {
 				$count++;
 			}
 		}
@@ -531,6 +571,8 @@ class Sensei_Usage_Tracking_Data {
 	 * Tracks naming conventions.
 	 *
 	 * @since 1.9.20
+	 *
+	 * @param string $key Question type.
 	 *
 	 * @return array Question type key.
 	 **/

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -24,6 +24,7 @@ class Sensei_Usage_Tracking_Data {
 		$question_type_count = self::get_question_type_count();
 		$usage_data = array(
 			'courses' => wp_count_posts( 'course' )->publish,
+			'course_active' => self::get_course_active_count(),
 			'course_completed' => self::get_course_completed_count(),
 			'course_videos' => self::get_course_videos_count(),
 			'course_no_notifications' => self::get_course_no_notifications_count(),
@@ -48,6 +49,23 @@ class Sensei_Usage_Tracking_Data {
 		);
 
 		return array_merge( $question_type_count, $usage_data );
+	}
+
+	/**
+	 * Get the total number of active courses across all learners.
+	 *
+	 * @since 1.10.0
+	 *
+	 * @return int Number of active courses.
+	 **/
+	private static function get_course_active_count() {
+		$course_args = array(
+			'type'   => 'sensei_course_status',
+			'status' => 'any',
+		);
+		$courses_started = Sensei_Utils::sensei_check_for_activity( $course_args );
+
+		return $courses_started - self::get_course_completed_count();
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -5,10 +5,12 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	private $modules;
 
 	private function setupCoursesAndModules() {
-		$this->course_ids = $this->factory->post->create_many( 3, array(
-			'post_status' => 'publish',
-			'post_type' => 'course',
-		) );
+		$this->course_ids = $this->factory->post->create_many(
+			3, array(
+				'post_status' => 'publish',
+				'post_type'   => 'course',
+			)
+		);
 
 		$this->modules = array();
 
@@ -17,21 +19,24 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		}
 
 		// Add modules to courses.
-		wp_set_object_terms( $this->course_ids[0],
+		wp_set_object_terms(
+			$this->course_ids[0],
 			array(
 				$this->modules[0]['term_id'],
 				$this->modules[1]['term_id'],
 			),
 			'module'
 		);
-		wp_set_object_terms( $this->course_ids[1],
+		wp_set_object_terms(
+			$this->course_ids[1],
 			array(
 				$this->modules[1]['term_id'],
 				$this->modules[2]['term_id'],
 			),
 			'module'
 		);
-		wp_set_object_terms( $this->course_ids[2],
+		wp_set_object_terms(
+			$this->course_ids[2],
 			array(
 				$this->modules[0]['term_id'],
 				$this->modules[1]['term_id'],
@@ -43,45 +48,57 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 	// Create some published and unpublished lessons.
 	private function createLessons() {
-		$drafts = $this->factory->post->create_many( 2, array(
-			'post_status' => 'draft',
-			'post_type' => 'lesson',
-		) );
-		$published = $this->factory->post->create_many( 3, array(
-			'post_status' => 'publish',
-			'post_type' => 'lesson',
-		) );
+		$drafts    = $this->factory->post->create_many(
+			2, array(
+				'post_status' => 'draft',
+				'post_type'   => 'lesson',
+			)
+		);
+		$published = $this->factory->post->create_many(
+			3, array(
+				'post_status' => 'publish',
+				'post_type'   => 'lesson',
+			)
+		);
 
 		return array_merge( $drafts, $published );
 	}
 
-	// Enroll users in some courses.
+	/**
+	 * Enroll users in some courses.
+	 */
 	private function enrollUsers() {
 		// Create some users.
 		$users = $this->factory->user->create_many( 5, array( 'role' => 'subscriber' ) );
 
 		// Enroll users in some courses.
-		foreach( $users as $user ) {
-			$this->factory->comment->create( array(
-				'user_id' => $user,
-				'comment_post_ID' => $this->course_ids[0],
-				'comment_type' => 'sensei_course_status',
-				'comment_approved' => 'in-progress',
-			) );
+		foreach ( $users as $user ) {
+			$this->factory->comment->create(
+				array(
+					'user_id'          => $user,
+					'comment_post_ID'  => $this->course_ids[0],
+					'comment_type'     => 'sensei_course_status',
+					'comment_approved' => 'in-progress',
+				)
+			);
 
-			$this->factory->comment->create( array(
-				'user_id' => $user,
-				'comment_post_ID' => $this->course_ids[1],
-				'comment_type' => 'sensei_course_status',
-				'comment_approved' => 'complete',
-			) );
+			$this->factory->comment->create(
+				array(
+					'user_id'          => $user,
+					'comment_post_ID'  => $this->course_ids[1],
+					'comment_type'     => 'sensei_course_status',
+					'comment_approved' => 'complete',
+				)
+			);
 
-			$this->factory->comment->create( array(
-				'user_id' => $user,
-				'comment_post_ID' => $this->course_ids[2],
-				'comment_type' => 'sensei_course_status',
-				'comment_approved' => 'in-progress',
-			) );
+			$this->factory->comment->create(
+				array(
+					'user_id'          => $user,
+					'comment_post_ID'  => $this->course_ids[2],
+					'comment_type'     => 'sensei_course_status',
+					'comment_approved' => 'in-progress',
+				)
+			);
 		}
 	}
 
@@ -92,14 +109,18 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$published = 4;
 
 		// Create some published and unpublished courses.
-		$this->factory->post->create_many( 2, array(
-			'post_status' => 'draft',
-			'post_type' => 'course',
-		) );
-		$this->factory->post->create_many( $published, array(
-			'post_status' => 'publish',
-			'post_type' => 'course',
-		) );
+		$this->factory->post->create_many(
+			2, array(
+				'post_status' => 'draft',
+				'post_type'   => 'course',
+			)
+		);
+		$this->factory->post->create_many(
+			$published, array(
+				'post_status' => 'publish',
+				'post_type'   => 'course',
+			)
+		);
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
@@ -114,21 +135,25 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetUsageDataLearners() {
 		// Create some users.
 		$subscribers = $this->factory->user->create_many( 8, array( 'role' => 'subscriber' ) );
-		$editors = $this->factory->user->create_many( 3, array( 'role' => 'editor' ) );
+		$editors     = $this->factory->user->create_many( 3, array( 'role' => 'editor' ) );
 
 		// Enroll some users in multiple courses.
-		foreach( $subscribers as $subscriber ) {
-			$this->factory->comment->create( array(
-				'user_id' => $subscriber,
-				'comment_post_ID' => $this->course_ids[0],
-				'comment_type' => 'sensei_course_status',
-			) );
+		foreach ( $subscribers as $subscriber ) {
+			$this->factory->comment->create(
+				array(
+					'user_id'         => $subscriber,
+					'comment_post_ID' => $this->course_ids[0],
+					'comment_type'    => 'sensei_course_status',
+				)
+			);
 
-			$this->factory->comment->create( array(
-				'user_id' => $subscriber,
-				'comment_post_ID' => $this->course_ids[1],
-				'comment_type' => 'sensei_course_status',
-			) );
+			$this->factory->comment->create(
+				array(
+					'user_id'         => $subscriber,
+					'comment_post_ID' => $this->course_ids[1],
+					'comment_type'    => 'sensei_course_status',
+				)
+			);
 		}
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
@@ -158,9 +183,9 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$lessons = $this->createLessons();
 
 		// Make some lessons prerequisites of others.
-		add_post_meta( $lessons[1], '_lesson_prerequisite', $lessons[0] );	// Draft
-		add_post_meta( $lessons[2], '_lesson_prerequisite', $lessons[1] );	// Published
-		add_post_meta( $lessons[3], '_lesson_prerequisite', $lessons[2] );	// Published
+		add_post_meta( $lessons[1], '_lesson_prerequisite', $lessons[0] );  // Draft
+		add_post_meta( $lessons[2], '_lesson_prerequisite', $lessons[1] );  // Published
+		add_post_meta( $lessons[3], '_lesson_prerequisite', $lessons[2] );  // Published
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
@@ -213,12 +238,12 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	}
 
 		/**
-	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
-	 * @covers Sensei_Usage_Tracking_Data::get_lesson_module_count
-	 */
+		 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+		 * @covers Sensei_Usage_Tracking_Data::get_lesson_module_count
+		 */
 	public function testGetLessonModuleCount() {
 		$lessons = $this->createLessons();
-		$terms = $this->factory->term->create_many( 3, array( 'taxonomy' => 'module' ) );
+		$terms   = $this->factory->term->create_many( 3, array( 'taxonomy' => 'module' ) );
 
 		// Assign modules to some lessons.
 		wp_set_object_terms( $lessons[0], $terms[0], 'module', false ); // Draft
@@ -251,14 +276,18 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$published = 10;
 
 		// Create some published and unpublished messages.
-		$this->factory->post->create_many( 5, array(
-			'post_status' => 'pending',
-			'post_type' => 'sensei_message',
-		) );
-		$this->factory->post->create_many( $published, array(
-			'post_status' => 'publish',
-			'post_type' => 'sensei_message',
-		) );
+		$this->factory->post->create_many(
+			5, array(
+				'post_status' => 'pending',
+				'post_type'   => 'sensei_message',
+			)
+		);
+		$this->factory->post->create_many(
+			$published, array(
+				'post_status' => 'publish',
+				'post_type'   => 'sensei_message',
+			)
+		);
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
@@ -309,14 +338,18 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$published = 15;
 
 		// Create some published and unpublished questions.
-		$this->factory->post->create_many( 12, array(
-			'post_status' => 'private',
-			'post_type' => 'question',
-		) );
-		$this->factory->post->create_many( $published, array(
-			'post_status' => 'publish',
-			'post_type' => 'question',
-		) );
+		$this->factory->post->create_many(
+			12, array(
+				'post_status' => 'private',
+				'post_type'   => 'question',
+			)
+		);
+		$this->factory->post->create_many(
+			$published, array(
+				'post_status' => 'publish',
+				'post_type'   => 'question',
+			)
+		);
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
@@ -331,10 +364,12 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 */
 	public function testGetUsageDataQuestionTypes() {
 		// Create some questions.
-		$questions = $this->factory->post->create_many( 10, array(
-			'post_type' => 'question',
-			'post_status' => 'publish',
-		) );
+		$questions = $this->factory->post->create_many(
+			10, array(
+				'post_type'   => 'question',
+				'post_status' => 'publish',
+			)
+		);
 
 		// Set the type of each question.
 		wp_set_post_terms( $questions[0], array( 'multiple-choice' ), 'question-type' );
@@ -371,10 +406,12 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 */
 	public function testGetUsageDataQuestionTypesInvalidType() {
 		// Create a question.
-		$questions = $this->factory->post->create( array(
-			'post_type' => 'question',
-			'post_status' => 'publish',
-		) );
+		$questions = $this->factory->post->create(
+			array(
+				'post_type'   => 'question',
+				'post_status' => 'publish',
+			)
+		);
 
 		// Set the question to use an invalid type.
 		wp_set_post_terms( $questions[0], array( 'automattic' ), 'question-type' );
@@ -390,15 +427,19 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 */
 	public function testGetUsageDataQuestionMediaCount() {
 		// Create some questions.
-		$questions = $this->factory->post->create_many( 5, array(
-			'post_type' => 'question',
-			'post_status' => 'publish',
-		) );
+		$questions = $this->factory->post->create_many(
+			5, array(
+				'post_type'   => 'question',
+				'post_status' => 'publish',
+			)
+		);
 		// Create some media.
-		$media = $this->factory->attachment->create_many( 3, array(
-			'post_type' => 'question',
-			'post_status' => 'publish',
-		) );
+		$media = $this->factory->attachment->create_many(
+			3, array(
+				'post_type'   => 'question',
+				'post_status' => 'publish',
+			)
+		);
 
 		// Attach media to some questions.
 		add_post_meta( $questions[0], '_question_media', $media[0] );
@@ -417,10 +458,12 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 */
 	public function testGetUsageDataQuestionMediaCountNoMedia() {
 		// Create some questions, but don't attach any media.
-		$questions = $this->factory->post->create_many( 5, array(
-			'post_type' => 'question',
-			'post_status' => 'publish',
-		) );
+		$questions = $this->factory->post->create_many(
+			5, array(
+				'post_type'   => 'question',
+				'post_status' => 'publish',
+			)
+		);
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
@@ -434,10 +477,12 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 */
 	public function testGetRandomOrderCount() {
 		// Create some questions.
-		$questions = $this->factory->post->create_many( 3, array(
-			'post_type' => 'question',
-			'post_status' => 'publish',
-		) );
+		$questions = $this->factory->post->create_many(
+			3, array(
+				'post_type'   => 'question',
+				'post_status' => 'publish',
+			)
+		);
 
 		// Set the type of each question to be multiple choice.
 		wp_set_post_terms( $questions[0], array( 'multiple-choice' ), 'question-type' );
@@ -461,10 +506,12 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 */
 	public function testGetRandomOrderCountMultipleChoiceOnly() {
 		// Create some questions.
-		$questions = $this->factory->post->create_many( 6, array(
-			'post_type' => 'question',
-			'post_status' => 'publish',
-		) );
+		$questions = $this->factory->post->create_many(
+			6, array(
+				'post_type'   => 'question',
+				'post_status' => 'publish',
+			)
+		);
 
 		// Create a question of each type.
 		wp_set_post_terms( $questions[0], array( 'multiple-choice' ), 'question-type' );
@@ -506,6 +553,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Count of active courses.
+	 *
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_course_active_count
 	 */
@@ -519,6 +568,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Count of completed courses.
+	 *
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_course_completed_count
 	 */
@@ -538,12 +589,16 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetCoursesWithVideoCount() {
 		$with_video = 4;
 
-		$course_ids_without_video = $this->factory->post->create_many( 3, array(
-			'post_type' => 'course',
-		) );
-		$course_ids_with_video = $this->factory->post->create_many( $with_video, array(
-			'post_type' => 'course',
-		) );
+		$course_ids_without_video = $this->factory->post->create_many(
+			3, array(
+				'post_type' => 'course',
+			)
+		);
+		$course_ids_with_video    = $this->factory->post->create_many(
+			$with_video, array(
+				'post_type' => 'course',
+			)
+		);
 
 		// Set video on courses
 		update_post_meta( $course_ids_with_video[0], '_course_video_embed', '<iframe src="video.com"></iframe>' );
@@ -569,12 +624,16 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetCoursesWithDisabledNotificationCount() {
 		$with_disabled_notification = 2;
 
-		$course_ids_without_disabled = $this->factory->post->create_many( 3, array(
-			'post_type' => 'course',
-		) );
-		$course_ids_with_disabled = $this->factory->post->create_many( $with_disabled_notification, array(
-			'post_type' => 'course',
-		) );
+		$course_ids_without_disabled = $this->factory->post->create_many(
+			3, array(
+				'post_type' => 'course',
+			)
+		);
+		$course_ids_with_disabled    = $this->factory->post->create_many(
+			$with_disabled_notification, array(
+				'post_type' => 'course',
+			)
+		);
 
 		// Disable notifications
 		foreach ( $course_ids_with_disabled as $course_id ) {
@@ -594,12 +653,16 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetCoursesWithPrerequisiteCount() {
 		$with_prereq = 2;
 
-		$course_ids_without_prereq = $this->factory->post->create_many( 3, array(
-			'post_type' => 'course',
-		) );
-		$course_ids_with_prereq = $this->factory->post->create_many( $with_prereq, array(
-			'post_type' => 'course',
-		) );
+		$course_ids_without_prereq = $this->factory->post->create_many(
+			3, array(
+				'post_type' => 'course',
+			)
+		);
+		$course_ids_with_prereq    = $this->factory->post->create_many(
+			$with_prereq, array(
+				'post_type' => 'course',
+			)
+		);
 
 		// Set prerequisite on courses
 		foreach ( $course_ids_with_prereq as $course_id ) {
@@ -622,12 +685,16 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetFeaturedCoursesCount() {
 		$featured = 2;
 
-		$non_featured_course_ids = $this->factory->post->create_many( 3, array(
-			'post_type' => 'course',
-		) );
-		$featured_course_ids = $this->factory->post->create_many( $featured, array(
-			'post_type' => 'course',
-		) );
+		$non_featured_course_ids = $this->factory->post->create_many(
+			3, array(
+				'post_type' => 'course',
+			)
+		);
+		$featured_course_ids     = $this->factory->post->create_many(
+			$featured, array(
+				'post_type' => 'course',
+			)
+		);
 
 		// Set courses to featured
 		foreach ( $featured_course_ids as $course_id ) {
@@ -648,12 +715,16 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$lessons_with_length = 3;
 
 		// Create some lessons
-		$lesson_without_length_ids = $this->factory->post->create_many( 2, array(
-			'post_type' => 'lesson',
-		) );
-		$lesson_with_length_ids = $this->factory->post->create_many( $lessons_with_length, array(
-			'post_type' => 'lesson',
-		) );
+		$lesson_without_length_ids = $this->factory->post->create_many(
+			2, array(
+				'post_type' => 'lesson',
+			)
+		);
+		$lesson_with_length_ids    = $this->factory->post->create_many(
+			$lessons_with_length, array(
+				'post_type' => 'lesson',
+			)
+		);
 
 		// Set lesson length
 		foreach ( $lesson_with_length_ids as $lesson_id ) {
@@ -675,12 +746,16 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$lessons_with_complexity = 3;
 
 		// Create some lessons
-		$lesson_without_complexity_ids = $this->factory->post->create_many( 2, array(
-			'post_type' => 'lesson',
-		) );
-		$lesson_with_complexity_ids = $this->factory->post->create_many( $lessons_with_complexity, array(
-			'post_type' => 'lesson',
-		) );
+		$lesson_without_complexity_ids = $this->factory->post->create_many(
+			2, array(
+				'post_type' => 'lesson',
+			)
+		);
+		$lesson_with_complexity_ids    = $this->factory->post->create_many(
+			$lessons_with_complexity, array(
+				'post_type' => 'lesson',
+			)
+		);
 
 		// Set lesson complexity
 		foreach ( $lesson_with_complexity_ids as $lesson_id ) {
@@ -702,12 +777,16 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$lessons_with_video = 4;
 
 		// Create some lessons
-		$lesson_without_video_ids = $this->factory->post->create_many( 4, array(
-			'post_type' => 'lesson',
-		) );
-		$lesson_with_video_ids = $this->factory->post->create_many( $lessons_with_video, array(
-			'post_type' => 'lesson',
-		) );
+		$lesson_without_video_ids = $this->factory->post->create_many(
+			4, array(
+				'post_type' => 'lesson',
+			)
+		);
+		$lesson_with_video_ids    = $this->factory->post->create_many(
+			$lessons_with_video, array(
+				'post_type' => 'lesson',
+			)
+		);
 
 		// Set lesson videos
 		update_post_meta( $lesson_with_video_ids[0], '_lesson_video_embed', '<iframe src="http://example.com/video"></iframe>' );

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -55,6 +55,36 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		return array_merge( $drafts, $published );
 	}
 
+	// Enroll users in some courses.
+	private function enrollUsers() {
+		// Create some users.
+		$users = $this->factory->user->create_many( 5, array( 'role' => 'subscriber' ) );
+
+		// Enroll users in some courses.
+		foreach( $users as $user ) {
+			$this->factory->comment->create( array(
+				'user_id' => $user,
+				'comment_post_ID' => $this->course_ids[0],
+				'comment_type' => 'sensei_course_status',
+				'comment_approved' => 'in-progress',
+			) );
+
+			$this->factory->comment->create( array(
+				'user_id' => $user,
+				'comment_post_ID' => $this->course_ids[1],
+				'comment_type' => 'sensei_course_status',
+				'comment_approved' => 'complete',
+			) );
+
+			$this->factory->comment->create( array(
+				'user_id' => $user,
+				'comment_post_ID' => $this->course_ids[2],
+				'comment_type' => 'sensei_course_status',
+				'comment_approved' => 'in-progress',
+			) );
+		}
+	}
+
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 */
@@ -473,6 +503,19 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		$this->assertArrayHasKey( 'teachers', $usage_data, 'Key' );
 		$this->assertEquals( $teachers, $usage_data['teachers'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_course_completed_count
+	 */
+	public function testGetCourseCompletedCount() {
+		$this->enrollUsers();
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'course_completed', $usage_data, 'Key' );
+		$this->assertEquals( 5, $usage_data['course_completed'], 'Count' );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -507,6 +507,19 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_course_active_count
+	 */
+	public function testGetCourseActiveCount() {
+		$this->enrollUsers();
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'course_active', $usage_data, 'Key' );
+		$this->assertEquals( 10, $usage_data['course_active'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_course_completed_count
 	 */
 	public function testGetCourseCompletedCount() {


### PR DESCRIPTION
This PR logs the following usage tracking data:

- Total number of active courses across all learners
- Total number of completed courses across all learners

## Testing
1. Check that `course_completed` is correctly logged in Tracks. Completed data should match what shows in _Sensei_ > _Analysis_ > _Total Completed Courses_.
2. Check that `course_active` is correctly logged in Tracks. Active data can be found in in _Sensei_ > _Analysis_ by summing the values in the _Active Courses_ column.