### PR TITLE
Fix PHP 7.2.x warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ cache:
   - "$HOME/.composer/cache"
 matrix:
   include:
+  - php: 7.2
+    env: WP_VERSION=latest
   - php: 7.1
     env: WP_VERSION=latest
   - php: 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,19 +19,19 @@ cache:
   - "$HOME/.composer/cache"
 matrix:
   include:
-  - php: 7.2
+  - php: "7.2"
     env: WP_VERSION=latest
-  - php: 7.1
+  - php: "7.1"
     env: WP_VERSION=latest
-  - php: 7.0
+  - php: "7.0"
     env: WP_VERSION=latest
-  - php: 5.6
+  - php: "5.6"
     env: WP_VERSION=4.4
-  - php: 5.6
+  - php: "5.6"
     env: WP_VERSION=latest
-  - php: 5.6
+  - php: "5.6"
     env: WP_VERSION=trunk
-  - php: 5.3
+  - php: "5.3"
     env: WP_VERSION=latest
     dist: precise
 before_script:

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2450,7 +2450,8 @@ class Sensei_Lesson {
 				$question_right_answer = $question_right_answers;
 			}
 		} // End If Statement
-		$right_answer_count = count( $question_right_answer );
+
+		$right_answer_count = is_array( $question_right_answer ) ? count( $question_right_answer ) : 1;
 
 		// Remove empty values and reindex the array
 		if ( is_array( $question_wrong_answers ) ) {

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -440,9 +440,9 @@ class Sensei_Usage_Tracking_Data {
 			)
 		);
 		$courses       = $query->posts;
-		$total_courses = count( $courses );
+		$total_courses = is_array( $courses ) ? count( $courses ) : 0;
 
-		for ( $i = 0; $i < $total_courses; $i++ ) {
+		for( $i = 0; $i < $total_courses; $i++ ) {
 			// Get modules for this course.
 			$module_count = wp_count_terms(
 				'module', array(

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -370,7 +370,7 @@ if ( ! defined( 'ABSPATH' ) ){ exit; } // Exit if accessed directly
 		$course_id           = Sensei()->lesson->get_course_id( $lesson_id );
 		$modules_and_lessons = sensei_get_modules_and_lessons( $course_id );
 
-		if ( count( $modules_and_lessons > 0 ) ) {
+		if ( is_array( $modules_and_lessons ) && count( $modules_and_lessons ) > 0 ) {
 			$found = false;
 
 			foreach ( $modules_and_lessons as $item ) {

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -302,7 +302,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertArrayHasKey( 'modules', $usage_data, 'Key' );
-		$this->assertEquals( count( $this->modules ), $usage_data['modules'], 'Count' );
+		$this->assertEquals( 0, $usage_data['modules'], 'Count' );
 	}
 
 	/**


### PR DESCRIPTION
More and more people appear to be using PHP 7.2 as questions about compatibility are popping up with greater frequency. This PR adds PHP 7.2 to the build and addresses any breakages.

In particular, it fixes the following warning:
```
Warning: count(): Parameter must be an array or an object that implements Countable
```

Note that this PR does not check for all possible violations of the above function, only those that were breaking the build.

## Testing
On a site running PHP 7.2.x, check that:
1. When adding a multiple choice question to a lesson quiz that has more than one right answer, the value for `_right_answer_count` in the `wp_postmeta` table equals the number of right answers that were added. For example, the following question would have `_right_answer_count` set to 2:
![screen shot 2018-03-20 at 10 52 40 am](https://user-images.githubusercontent.com/1190420/37662178-d7bdb540-2c2c-11e8-877a-4833edfe1e25.jpg)
All other question types should have this value set to 1. (_Note: In earlier versions of PHP, when the count parameter was neither an array nor an object with implemented Countable interface, 1 was returned._)
2. When there are no courses, usage tracking logs 0 for `modules_min`.
3. Navigating modules and lessons in a course still works.