### PR TITLE
Fix 'number' parameter not working for [sensei_user_courses] shortcode

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2267,7 +2267,7 @@ class Sensei_Course {
              * @since 1.9.0
              * @param integer $posts_per_page default 10
              */
-            $query->set( 'posts_per_page', apply_filters( 'sensei_my_courses_per_page', 10 ) );
+            $query->set( 'posts_per_page', apply_filters( 'sensei_my_courses_per_page', $query->get( 'posts_per_page', 10 ) ) );
 
         }
 


### PR DESCRIPTION
Fixes #2030.

## Testing
- Add `[sensei_user_courses number="2"]` to the _My Courses_ page.
- Start taking at least 3 courses (i.e. one more than the value of the `number` parameter).
- Browse to _My Courses_ and ensure that the number of courses shown on the page matches the value of the `number` parameter. Additional courses should be accessible via the pagination links.
- Change the shortcode to `[sensei_user_courses]` (i.e. remove the `number` parameter).
- Start taking at least 11 courses.
- Browse to _My Courses_ and ensure that only 10 courses are visible. If there are more courses, they should be accessible via the pagination links.