### PR TITLE
Delete transient data from database on plugin deletion

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -189,6 +189,19 @@ class Sensei_Data_Cleaner {
 	);
 
 	/**
+	 * Transient names (as MySQL regexes) to be deleted. The prefixes
+	 * "_transient_" and "_transient_timeout_" will be prepended.
+	 *
+	 * @var $transients
+	 */
+	private static $transients = array(
+		'sensei_[0-9]+_none_module_lessons',
+		'sensei_answers_[0-9]+_[0-9]+',
+		'sensei_answers_feedback_[0-9]+_[0-9]+',
+		'quiz_grades_[0-9]+_[0-9]+',
+	);
+
+	/**
 	 * Cleanup all data.
 	 *
 	 * @access public
@@ -198,6 +211,7 @@ class Sensei_Data_Cleaner {
 		self::cleanup_pages();
 		self::cleanup_taxonomies();
 		self::cleanup_roles_and_caps();
+		self::cleanup_transients();
 		self::cleanup_options();
 	}
 
@@ -312,6 +326,26 @@ class Sensei_Data_Cleaner {
 				$wpdb->delete( $wpdb->term_taxonomy, array( 'term_taxonomy_id' => $term->term_taxonomy_id ) );
 				$wpdb->delete( $wpdb->terms, array( 'term_id' => $term->term_id ) );
 				$wpdb->delete( $wpdb->termmeta, array( 'term_id' => $term->term_id ) );
+			}
+		}
+	}
+
+	/**
+	 * Cleanup transients from the database.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_transients() {
+		global $wpdb;
+
+		foreach ( array( '_transient_', '_transient_timeout_' ) as $prefix ) {
+			foreach ( self::$transients as $transient ) {
+				$wpdb->query(
+					$wpdb->prepare(
+						"DELETE FROM $wpdb->options WHERE option_name RLIKE %s",
+						$prefix . $transient
+					)
+				);
 			}
 		}
 	}

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -182,13 +182,13 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 
 		// Create a regular user and assign some caps.
 		$this->regular_user_id = $this->factory->user->create( array( 'role' => 'author' ) );
-		$regular_user = get_user_by( 'id', $this->regular_user_id );
+		$regular_user          = get_user_by( 'id', $this->regular_user_id );
 		$regular_user->add_cap( 'edit_others_posts' );
 		$regular_user->add_cap( 'manage_sensei' );
 
 		// Create a teacher user and assign some caps.
 		$this->teacher_user_id = $this->factory->user->create( array( 'role' => 'teacher' ) );
-		$teacher_user = get_user_by( 'id', $this->teacher_user_id );
+		$teacher_user          = get_user_by( 'id', $this->teacher_user_id );
 		$teacher_user->add_cap( 'edit_others_posts' );
 		$teacher_user->add_cap( 'manage_sensei' );
 
@@ -387,22 +387,6 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 		);
 	}
 
-	/* Helper functions. */
-
-	private function getPostIdsWithTerm( $term_id, $taxonomy ) {
-		return get_posts( array(
-			'fields'    => 'ids',
-			'post_type' => 'any',
-			'tax_query' => array(
-				array(
-					'field'    => 'term_id',
-					'terms'    => $term_id,
-					'taxonomy' => $taxonomy,
-				),
-			),
-		) );
-	}
-
 	/**
 	 * Ensure the Sensei roles and caps are deleted.
 	 *
@@ -416,12 +400,12 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 		wp_cache_flush();
 
 		$regular_user = get_user_by( 'id', $this->regular_user_id );
-		$this->assertTrue( in_array( 'author', $regular_user->roles ), 'Author role should not be removed' );
+		$this->assertTrue( in_array( 'author', $regular_user->roles, true ), 'Author role should not be removed' );
 		$this->assertTrue( $regular_user->has_cap( 'edit_others_posts' ), 'Non-Sensei cap should not be removed from user' );
 		$this->assertFalse( $regular_user->has_cap( 'manage_sensei' ), 'Sensei cap should be removed from user' );
 
 		$teacher_user = get_user_by( 'id', $this->teacher_user_id );
-		$this->assertFalse( in_array( 'teacher', $teacher_user->roles ), 'Teacher role should be removed from user' );
+		$this->assertFalse( in_array( 'teacher', $teacher_user->roles, true ), 'Teacher role should be removed from user' );
 		$this->assertFalse( array_key_exists( 'teacher', $teacher_user->caps ), 'Teacher role should be removed from user caps' );
 		$this->assertTrue( $teacher_user->has_cap( 'edit_others_posts' ), 'Non-Sensei cap should not be removed from teacher' );
 		$this->assertFalse( $teacher_user->has_cap( 'manage_sensei' ), 'Sensei cap should be removed from teacher' );
@@ -466,5 +450,21 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 		// Ensure the other transient and its timeout was not deleted.
 		$this->assertNotFalse( get_option( "{$prefix}other_transient" ), 'Non-Sensei transient' );
 		$this->assertNotFalse( get_option( "{$timeout_prefix}other_transient" ), 'Non-Sensei transient' );
+	}
+
+	/* Helper functions. */
+
+	private function getPostIdsWithTerm( $term_id, $taxonomy ) {
+		return get_posts( array(
+			'fields'    => 'ids',
+			'post_type' => 'any',
+			'tax_query' => array(
+				array(
+					'field'    => 'term_id',
+					'terms'    => $term_id,
+					'taxonomy' => $taxonomy,
+				),
+			),
+		) );
 	}
 }

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -424,11 +424,11 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Data_Cleaner::cleanup_transients
 	 */
 	public function testSenseiTransientsDeleted() {
-		set_transient( 'sensei_123_none_module_lessons', 'value', 0 );
-		set_transient( 'sensei_answers_123_456', 'value', 0 );
-		set_transient( 'sensei_answers_feedback_123_456', 'value', 0 );
-		set_transient( 'quiz_grades_123_456', 'value', 0 );
-		set_transient( 'other_transient', 'value', 0 );
+		set_transient( 'sensei_123_none_module_lessons', 'value', current_time( 'timestamp' ) + 3600 );
+		set_transient( 'sensei_answers_123_456', 'value', current_time( 'timestamp' ) + 3600 );
+		set_transient( 'sensei_answers_feedback_123_456', 'value', current_time( 'timestamp' ) + 3600 );
+		set_transient( 'quiz_grades_123_456', 'value', current_time( 'timestamp' ) + 3600 );
+		set_transient( 'other_transient', 'value', current_time( 'timestamp' ) + 3600 );
 
 		Sensei_Data_Cleaner::cleanup_all();
 

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -432,4 +432,39 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 		$role = get_role( 'teacher' );
 		$this->assertNull( $role, 'Teacher role should be removed overall' );
 	}
+
+	/**
+	 * Ensure the Sensei transients are deleted from the DB.
+	 *
+	 * @covers Sensei_Data_Cleaner::cleanup_all
+	 * @covers Sensei_Data_Cleaner::cleanup_transients
+	 */
+	public function testSenseiTransientsDeleted() {
+		set_transient( 'sensei_123_none_module_lessons', 'value', 0 );
+		set_transient( 'sensei_answers_123_456', 'value', 0 );
+		set_transient( 'sensei_answers_feedback_123_456', 'value', 0 );
+		set_transient( 'quiz_grades_123_456', 'value', 0 );
+		set_transient( 'other_transient', 'value', 0 );
+
+		Sensei_Data_Cleaner::cleanup_all();
+
+		// Flush transients from cache.
+		wp_cache_flush();
+
+		$prefix         = '_transient_';
+		$timeout_prefix = '_transient_timeout_';
+
+		// Ensure the transients and their timeouts were deleted.
+		$this->assertFalse( get_option( "{$prefix}sensei_123_none_module_lessons" ), 'Sensei none_module_lessons transient' );
+		$this->assertFalse( get_option( "{$timeout_prefix}sensei_123_none_module_lessons" ), 'Sensei none_module_lessons transient timeout' );
+		$this->assertFalse( get_option( "{$prefix}sensei_answers_123_456" ), 'Sensei sensei_answers transient' );
+		$this->assertFalse( get_option( "{$timeout_prefix}sensei_answers_123_456" ), 'Sensei sensei_answers transient timeout' );
+		$this->assertFalse( get_option( "{$prefix}sensei_answers_feedback_123_456" ), 'Sensei sensei_answers_feedback transient' );
+		$this->assertFalse( get_option( "{$timeout_prefix}sensei_answers_feedback_123_456" ), 'Sensei sensei_answers_feedback transient timeout' );
+		$this->assertFalse( get_option( "{$prefix}quiz_grades_123_456" ), 'Sensei quiz_grades transient' );
+
+		// Ensure the other transient and its timeout was not deleted.
+		$this->assertNotFalse( get_option( "{$prefix}other_transient" ), 'Non-Sensei transient' );
+		$this->assertNotFalse( get_option( "{$timeout_prefix}other_transient" ), 'Non-Sensei transient' );
+	}
 }


### PR DESCRIPTION
Contributes to #2034

This PR, on plugin deletion, deletes the transients associated with Sensei from the database. The following transients (as regular expressions) should be deleted:

- `'sensei_[0-9]+_none_module_lessons'`
- `'sensei_answers_[0-9]+_[0-9]+'`
- `'sensei_answers_feedback_[0-9]+_[0-9]+'`
- `'quiz_grades_[0-9]+_[0-9]+'`

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.

- Ensure that the tests pass.

- Add some of the above transients to the database (I just added them manually using `set_transient`).

- Delete the Sensei plugin.

- Inspect the database to ensure that those transients have been deleted. You can use this query to see all the transients in the DB: `SELECT option_id, option_name from wp_options WHERE option_name LIKE "_transient_%"`. You can also use a plugin like "Transients Manager" to check them.

- Please also test on a multisite installation. When the plugin is deleted from the Network Admin, the pages should be trashed across all sites.