### PR TITLE
Add revisions support to courses, lessons and questions

### DIFF
--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -127,7 +127,7 @@ class Sensei_PostTypes {
             'has_archive'         => $this->get_course_post_type_archive_slug(),
 		    'hierarchical'        => false,
 		    'menu_position'       => 51,
-		    'supports'            => array( 'title', 'editor', 'excerpt', 'thumbnail' ),
+		    'supports'            => array( 'title', 'editor', 'excerpt', 'thumbnail', 'revisions' ),
 			'show_in_rest' => true,
 			'rest_base' => 'courses',
 			'rest_controller_class' => 'WP_REST_Posts_Controller',
@@ -204,7 +204,7 @@ class Sensei_PostTypes {
 	 */
 	public function setup_lesson_post_type () {
 
-		$supports_array = array( 'title', 'editor', 'excerpt', 'thumbnail' );
+		$supports_array = array( 'title', 'editor', 'excerpt', 'thumbnail', 'revisions' );
 		$allow_comments = false;
 		if ( isset( Sensei()->settings->settings[ 'lesson_comments' ] ) ) {
 			$allow_comments = Sensei()->settings->settings[ 'lesson_comments' ];
@@ -323,7 +323,7 @@ class Sensei_PostTypes {
 		    'has_archive' => true,
 		    'hierarchical' => false,
 		    'menu_position' => 51,
-		    'supports' => array( 'title' )
+		    'supports' => array( 'title', 'revisions' )
 		);
 
         /**


### PR DESCRIPTION
Fixes #1960.

## Testing
Change the content of an existing course, lesson and question. Save the page and refresh. Check to ensure that _Revisions_ shows up in _Screen Options_, and that the _Revisions_ meta box is visible when the option is checked.