### PR TITLE
Fix PHP notices when viewing or adding a lesson and there are no courses

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -616,9 +616,6 @@ class Sensei_Lesson {
 						$html .= '</select>' . "\n";
 						// Course Product
 						if ( Sensei_WC::is_woocommerce_active() ) {
-							// Get the Products
-							$select_course_woocommerce_product = get_post_meta( $post_item->ID, '_course_woocommerce_product', true );
-
 							$product_args = array(	'post_type' 		=> array( 'product', 'product_variation' ),
 													'posts_per_page' 		=> -1,
 													'orderby'         	=> 'title',


### PR DESCRIPTION
This PR fixes the PHP notices that were being logged when there were no courses, as reported in #2033:
```
PHP Notice:  Undefined variable: post_item in /app/public/wp-content/plugins/sensei/includes/class-sensei-lesson.php on line 620
PHP Notice:  Trying to get property of non-object in /app/public/wp-content/plugins/sensei/includes/class-sensei-lesson.php on line 620
```

## Testing
1. Trash all existing courses.
2. Add a new lesson or view an existing lesson.
3. Check the logs to ensure the above notices do not appear.