### PR TITLE
Fix PHP notices when purchasing non-course product as a guest

### DIFF
--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -1557,8 +1557,10 @@ class Sensei_WC {
 			return '';
 		}
 
-		if (  in_array( $order_status, array( 'wc-processing', 'processing' ), true )  && in_array( $order->post_status, array( 'wc-on-hold', 'wc-pending', 'wc-failed' ), true ) ) {
+		$status = Sensei_WC_Utils::get_order_status( $order );
 
+		if ( in_array( $order_status, array( 'wc-processing', 'processing' ), true ) &&
+			in_array( $status, array( 'wc-on-hold', 'wc-pending', 'wc-failed' ), true ) ) {
 			$virtual_order = true;
 
 			if ( count( $order->get_items() ) > 0 ) {

--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -1247,12 +1247,14 @@ class Sensei_WC {
 		if ( ! in_array( $order_status, array( 'wc-completed', 'wc-processing' ) ) ) {
 			return;
 		}
-
 		$user = get_user_by( 'id', $order->get_user_id() );
-		$order_user['ID'] = $user->ID;
-		$order_user['user_login'] = $user->user_login;
-		$order_user['user_email'] = $user->user_email;
-		$order_user['user_url'] = $user->user_url;
+
+		if ( $user ) {
+			$order_user['ID'] = $user->ID;
+			$order_user['user_login'] = $user->user_login;
+			$order_user['user_email'] = $user->user_email;
+			$order_user['user_url'] = $user->user_url;
+		}
 
 		if ( 0 == sizeof( $order->get_items() ) ) {
 			return;
@@ -1285,14 +1287,17 @@ class Sensei_WC {
 			$courses = Sensei()->course->get_product_courses( $_product_id );
 			Sensei_WC_Utils::log( 'Sensei_WC::complete_order: Got (' . count( $courses ) . ') course(s), order_id ' . $order_id . ', product_id ' . $_product_id );
 
-			// Loop and update those courses
-			foreach ( $courses as $course_item ) {
-				Sensei_WC_Utils::log( 'Sensei_WC::complete_order: Update course_id ' . $course_item->ID . ' for user_id ' . $order_user['ID'] );
-				$update_course = self::course_update( $course_item->ID, $order_user, $order );
-				if ( false === $update_course ) {
-					Sensei_WC_Utils::log( 'Sensei_WC::complete_order: FAILED course_update course_id ' . $course_item->ID . ' for user_id ' . $order_user['ID'] );
+			if ( count( $order_user ) > 0 ) {
+				// Loop and update those courses.
+				foreach ( $courses as $course_item ) {
+					Sensei_WC_Utils::log( 'Sensei_WC::complete_order: Update course_id ' . $course_item->ID . ' for user_id ' . $order_user['ID'] );
+					$update_course = self::course_update( $course_item->ID, $order_user, $order );
+					if ( false === $update_course ) {
+						Sensei_WC_Utils::log( 'Sensei_WC::complete_order: FAILED course_update course_id ' . $course_item->ID . ' for user_id ' . $order_user['ID'] );
+					}
 				}
 			}
+
 			if ( count( $courses ) > 0 ) {
 				$order_contains_courses = true;
             }


### PR DESCRIPTION
Fixes #2031 to remove the following PHP notices:
```
[23-Mar-2018 11:34:05 UTC] post_status was called incorrectly. Order properties should not be accessed directly. Backtrace: require('wp-blog-header.php'), require_once('wp-includes/template-loader.php'), do_action('template_redirect'), WP_Hook->do_action, WP_Hook->apply_filters, WC_AJAX::do_wc_ajax, do_action('wc_ajax_checkout'), WP_Hook->do_action, WP_Hook->apply_filters, WC_AJAX::checkout, WC_Checkout->process_checkout, WC_Checkout->process_order_without_payment, WC_Order->payment_complete, apply_filters('woocommerce_payment_complete_order_status'), WP_Hook->apply_filters, Sensei_WC::virtual_order_payment_complete, WC_Abstract_Legacy_Order->__get, wc_doing_it_wrong. This message was added in version 3.0.
[23-Mar-2018 11:34:05 UTC] PHP Notice:  Trying to get property of non-object in /app/public/wp-content/plugins/sensei/includes/class-sensei-wc.php on line 1252
[23-Mar-2018 11:34:05 UTC] PHP Notice:  Trying to get property of non-object in /app/public/wp-content/plugins/sensei/includes/class-sensei-wc.php on line 1253
[23-Mar-2018 11:34:05 UTC] PHP Notice:  Trying to get property of non-object in /app/public/wp-content/plugins/sensei/includes/class-sensei-wc.php on line 1254
[23-Mar-2018 11:34:05 UTC] PHP Notice:  Trying to get property of non-object in /app/public/wp-content/plugins/sensei/includes/class-sensei-wc.php on line 1255
```

## Testing
1. In _WooCommerce_ > _Settings_ > _Checkout_, ensure _Enable guest checkout_ is checked.
2. As a logged out user, add some products that are _not_ tied to a Sensei course to your cart.
3. Proceed through the checkout flow and place the order.
4. Check the logs to ensure the above notices do not appear and that your order was successful.