### PR TITLE
Fixes associating courses after purchase of a variable subscription product

### DIFF
--- a/includes/class-sensei-wc-subscriptions.php
+++ b/includes/class-sensei-wc-subscriptions.php
@@ -85,17 +85,18 @@ class Sensei_WC_Subscriptions {
 
         foreach($order->get_items() as $item) {
 
-            $product_type = '';
-            if (Sensei_WC_Utils::is_wc_item_variation($item)) {
+            $item_id = Sensei_WC_Utils::get_item_id_from_item( $item );
+
+            $product_type = WC_Product_Factory::get_product_type( $item_id );
+
+            if ( Sensei_WC_Utils::is_wc_item_variation( $item ) ) {
                 $product_type = 'subscription_variation';
             }
-
-            $item_id = Sensei_WC_Utils::get_item_id_from_item($item);
 
             // Get courses that use the WC product
             $courses = array();
 
-            if ( ! in_array( $product_type, self::get_subscription_types() ) ) {
+            if ( in_array( $product_type, self::get_subscription_types() ) ) {
 
                 $courses = Sensei()->course->get_product_courses( $item_id );
 

--- a/includes/class-sensei-wc-subscriptions.php
+++ b/includes/class-sensei-wc-subscriptions.php
@@ -57,61 +57,63 @@ class Sensei_WC_Subscriptions {
         return true;
     }
 
-    /**
-     * Responds to when a subscription product is purchased
-     *
-     * @since  1.2.0
-     * @since  1.9.0 move to class Sensei_WC
-     * @since  1.9.12 move to class Sensei_WC_Subscriptions
-     *
-     * @param   WC_Order $order
-     *
-     * @return  void
-     */
-    public static function activate_subscription(  $order ) {
+	/**
+	 * Responds to when a subscription product is purchased
+	 *
+	 * @since  1.2.0
+	 * @since  1.9.0 move to class Sensei_WC
+	 * @since  1.9.12 move to class Sensei_WC_Subscriptions
+	 *
+	 * @param   WC_Order $order
+	 *
+	 * @return  void
+	 */
+	public static function activate_subscription(  $order ) {
 
-        $order_user = get_user_by('id', $order->user_id);
-        $user['ID'] = $order_user->ID;
-        $user['user_login'] = $order_user->user_login;
-        $user['user_email'] = $order_user->user_email;
-        $user['user_url'] = $order_user->user_url;
+		$order_user = get_user_by('id', $order->user_id);
+		$user['ID'] = $order_user->ID;
+		$user['user_login'] = $order_user->user_login;
+		$user['user_email'] = $order_user->user_email;
+		$user['user_url'] = $order_user->user_url;
 
-        // Run through each product ordered
-        if ( ! sizeof($order->get_items() )>0 ) {
+		// Run through each product ordered
+		if ( ! sizeof($order->get_items() )>0 ) {
 
-            return;
+			return;
 
-        }
+		}
 
-        foreach($order->get_items() as $item) {
+		foreach($order->get_items() as $item) {
 
-            $item_id = Sensei_WC_Utils::get_item_id_from_item( $item );
+			$item_id = Sensei_WC_Utils::get_item_id_from_item( $item );
 
-            $product_type = WC_Product_Factory::get_product_type( $item_id );
+			$product_type = WC_Product_Factory::get_product_type( $item_id );
 
-            if ( Sensei_WC_Utils::is_wc_item_variation( $item ) ) {
-                $product_type = 'subscription_variation';
-            }
+			if ( Sensei_WC_Utils::is_wc_item_variation( $item ) ) {
 
-            // Get courses that use the WC product
-            $courses = array();
+				$product_type = 'subscription_variation';
 
-            if ( in_array( $product_type, self::get_subscription_types() ) ) {
+			}
 
-                $courses = Sensei()->course->get_product_courses( $item_id );
+			// Get courses that use the WC product
+			$courses = array();
 
-            } // End If Statement
+			if ( in_array( $product_type, self::get_subscription_types() ) ) {
 
-            // Loop and add the user to the course.
-            foreach ( $courses as $course_item ){
+				$courses = Sensei()->course->get_product_courses( $item_id );
 
-                Sensei_Utils::user_start_course( intval( $user['ID'] ), $course_item->ID  );
+			} // End If Statement
 
-            } // End For Loop
+			// Loop and add the user to the course.
+			foreach ( $courses as $course_item ){
 
-        } // End For Loop
+				Sensei_Utils::user_start_course( intval( $user['ID'] ), $course_item->ID  );
 
-    }
+			} // End For Loop
+
+		} // End For Loop
+
+	}
 
     /**
      * Determine if the user has and active subscription to give them access

--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -425,17 +425,7 @@ class Sensei_WC {
 			if ( $user_id ) {
 
 				// Get all courses for product
-				$args = Sensei_Course::get_default_query_args();
-				$args['meta_query'] = array( array(
-							'key' => '_course_woocommerce_product',
-							'value' => $item_id,
-						),
-				);
-				$args['orderby'] = 'menu_order date';
-				$args['order'] = 'ASC';
-
-				// loop through courses
-				$courses = get_posts( $args );
+				$courses = Sensei()->course->get_product_courses( $item_id );
 				if ( $courses && count( $courses ) > 0 ) {
 
 					foreach ( $courses as $course ) {


### PR DESCRIPTION
Fixes #2069

This PR fixes the issue where courses associated with the _parent_ product of a subscription variation weren't being properly signing students up for the course after subscription.

This includes a refactor to `Sensei_Course::get_product_courses()` to reduce complexity when adding the logic needed for parent products (when buying a variation).

Before merge, I'll also be doing a whitespace fix on these methods.

## Testing Instructions
- For simplicity, set up/duplicate different courses and associate them with different product types: basic product, variable product (associated with parent product), variable product (associated with product variation), simple subscription, variable subscription (associated with parent product), and variable subscription (associated with product variation). 
- For each of these:
  - Verify the student is not enrolled in the course.
  - Purchase the product.
  - Verify the student is properly enrolled in the course.