### PR TITLE
Allow certain HTML tags on quiz correct answer result

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -780,7 +780,7 @@ class Sensei_Question {
 		?>
 		<div class="answer_message <?php echo esc_attr( $final_css_classes ); ?>">
 
-			<span><?php echo esc_html( $final_message ) ?></span>
+			<span><?php echo Sensei_Wp_Kses::wp_kses( $final_message ) ?></span>
 
 		</div>
 		<?php


### PR DESCRIPTION
Fixes #2071

See issue for testing the issue. I wasn't familiar with gap-fill questions, but the "answer" that is highlighted after grading is "The Gap."

<img width="1205" alt="screen shot 2018-03-23 at 3 19 36 pm" src="https://user-images.githubusercontent.com/68693/37837646-a6d94858-2ead-11e8-8bf5-e7b1d5a4b8e7.png">

<img width="840" alt="screen shot 2018-03-23 at 3 20 30 pm" src="https://user-images.githubusercontent.com/68693/37837674-bf03beb8-2ead-11e8-85ca-eb0d99168787.png">
