### PR TITLE
Ensure answers to true / false questions are translated for students

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1135,11 +1135,13 @@ class Sensei_Question {
         $type_name = __( 'Multiple Choice', 'woothemes-sensei' );
         $grade_type = 'manual-grade';
 
-        if ('boolean'== $type ) {
-
-            $right_answer = ucfirst($right_answer);
-
-        }elseif( 'multiple-choice' == $type ) {
+        if ( 'boolean' == $type ) {
+			if( 'true' === $right_answer ) {
+				$right_answer = __( 'True', 'woothemes-sensei' );
+			} else {
+				$right_answer = __( 'False', 'woothemes-sensei' );
+			}
+        } elseif( 'multiple-choice' == $type ) {
 
             $right_answer = (array) $right_answer;
             $right_answer = implode( ', ', $right_answer );


### PR DESCRIPTION
Fixes #1992.

## Testing
1. Add a true/false question to a lesson.
2. On the front-end, take the quiz and submit it.
3. In _Settings_ > _General_, change _Site Language_ to another language. I used Russian since I know Sensei has translations for it. (You may be prompted to install a language pack. If so, install it):
![screen shot 2018-03-23 at 11 27 57 am](https://user-images.githubusercontent.com/1190420/37838050-449faea4-2e8d-11e8-8122-2ed1f554b0e4.jpg)
4. Back on the front-end, refresh the quiz results and ensure the right answer is translated.

### Before
![screen shot 2018-03-23 at 11 31 25 am](https://user-images.githubusercontent.com/1190420/37838240-c6973724-2e8d-11e8-86e1-6b84fde492cb.jpg)

### After
![screen shot 2018-03-23 at 11 32 37 am](https://user-images.githubusercontent.com/1190420/37838291-ea3256be-2e8d-11e8-9e51-5097bd0a9d03.jpg)