### PR TITLE
Delete post meta from database on plugin deletion

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -212,12 +212,23 @@ class Sensei_Data_Cleaner {
 	);
 
 	/**
+	 * Post meta to be deleted.
+	 *
+	 * @var $post_meta
+	 */
+	private static $post_meta = array(
+		'sensei_payment_complete',
+		'sensei_products_processed',
+	);
+
+	/**
 	 * Cleanup all data.
 	 *
 	 * @access public
 	 */
 	public static function cleanup_all() {
 		self::cleanup_custom_post_types();
+		self::cleanup_post_meta();
 		self::cleanup_pages();
 		self::cleanup_taxonomies();
 		self::cleanup_roles_and_caps();
@@ -379,4 +390,16 @@ class Sensei_Data_Cleaner {
 		}
 	}
 
+	/**
+	 * Cleanup post meta that doesn't get deleted automatically.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_post_meta() {
+		global $wpdb;
+
+		foreach ( self::$post_meta as $post_meta ) {
+			$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => $post_meta ) );
+		}
+	}
 }

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -424,11 +424,11 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Data_Cleaner::cleanup_transients
 	 */
 	public function testSenseiTransientsDeleted() {
-		set_transient( 'sensei_123_none_module_lessons', 'value', current_time( 'timestamp' ) + 3600 );
-		set_transient( 'sensei_answers_123_456', 'value', current_time( 'timestamp' ) + 3600 );
-		set_transient( 'sensei_answers_feedback_123_456', 'value', current_time( 'timestamp' ) + 3600 );
-		set_transient( 'quiz_grades_123_456', 'value', current_time( 'timestamp' ) + 3600 );
-		set_transient( 'other_transient', 'value', current_time( 'timestamp' ) + 3600 );
+		set_transient( 'sensei_123_none_module_lessons', 'value', 3600 );
+		set_transient( 'sensei_answers_123_456', 'value', 3600 );
+		set_transient( 'sensei_answers_feedback_123_456', 'value', 3600 );
+		set_transient( 'quiz_grades_123_456', 'value', 3600 );
+		set_transient( 'other_transient', 'value', 3600 );
 
 		Sensei_Data_Cleaner::cleanup_all();
 

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -494,6 +494,42 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Ensure the Sensei roles and caps are deleted.
+	 *
+	 * @covers Sensei_Data_Cleaner::cleanup_all
+	 * @covers Sensei_Data_Cleaner::cleanup_roles_and_caps
+	 */
+	public function testSenseiPostMetaDeleted() {
+		// Sensei post meta.
+		update_post_meta( $this->course_ids[0], '_course_prerequisite', $this->course_ids[1] );
+		update_post_meta( $this->lesson_ids[0], '_lesson_course', $this->course_ids[0] );
+
+		// Non-Sensei post meta.
+		update_post_meta( $this->post_ids[0], 'meta1', 'value1' );
+		update_post_meta( $this->post_ids[1], 'meta2', 'value2' );
+
+		// Sensei meta that needs to be deleted directly.
+		update_post_meta( $this->post_ids[0], 'sensei_payment_complete', true );
+		update_post_meta( $this->post_ids[1], 'sensei_products_processed', 3 );
+
+		Sensei_Data_Cleaner::cleanup_all();
+
+		$this->emptyTrash();
+
+		// Ensure Sensei post meta is deleted.
+		$this->assertEmpty( get_post_meta( $this->course_ids[0], '_course_prerequisite', true ), '_course_prerequisite should be deleted' );
+		$this->assertEmpty( get_post_meta( $this->lesson_ids[0], '_lesson_course', true ), '_lesson_course should be deleted' );
+
+		// Ensure non-Sensei post meta is not deleted.
+		$this->assertEquals( 'value1', get_post_meta( $this->post_ids[0], 'meta1', true ), 'meta1 should not be deleted' );
+		$this->assertEquals( 'value2', get_post_meta( $this->post_ids[1], 'meta2', true ), 'meta2 should not be deleted' );
+
+		// Ensure other Sensei meta is deleted.
+		$this->assertEmpty( get_post_meta( $this->post_ids[0], 'sensei_payment_complete', true ), 'sensei_payment_complete should be deleted' );
+		$this->assertEmpty( get_post_meta( $this->post_ids[1], 'sensei_products_processed', true ), 'sensei_products_processed should not be deleted' );
+	}
+
 	/* Helper functions. */
 
 	private function getPostIdsWithTerm( $term_id, $taxonomy ) {
@@ -508,5 +544,23 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 				),
 			),
 		) );
+	}
+
+	private function emptyTrash() {
+		$trashed_posts = get_posts(
+			array(
+				'post_type'   => 'any',
+				'post_status' => 'trash',
+				'numberposts' => -1,
+			)
+		);
+
+		// Set the trash time to be a very long time ago.
+		foreach ( $trashed_posts as $post ) {
+			update_post_meta( $post->ID, '_wp_trash_meta_time', 0 );
+		}
+
+		// Run a scheduled trash cleanup.
+		wp_scheduled_delete();
 	}
 }


### PR DESCRIPTION
Contributes to #2034

This PR, on plugin deletion, deletes Sensei's post meta from the database. Most of the meta is removed when the CPT's are deleted. The meta `sensei_payment_complete` and `sensei_products_processed`, which are not stored on Sensei CPT's, are deleted manually.

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.

- Ensure that the tests pass.

- Add some Sensei meta to the database. You can do this by setting up course and lesson prerequisites and filling out other metaboxes.

- Delete the Sensei plugin.

- Ensure that the trash is emptied. You can do this by running the following code snippet:

```
global $wpdb;
$wpdb->update( $wpdb->postmeta, array( 'meta_value' => 0 ), array( 'meta_key' => '_wp_trash_meta_time' ) );
wp_scheduled_delete();
```

- Inspect the database to ensure that the Sensei post meta has been deleted.

- Please also test on a multisite installation. When the plugin is deleted from the Network Admin, the pages should be trashed across all sites.