### PR TITLE
Remove Sensei user meta on uninstall

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -202,6 +202,16 @@ class Sensei_Data_Cleaner {
 	);
 
 	/**
+	 * User meta key names (as MySQL regexes) to be deleted.
+	 *
+	 * @var array $user_meta_keys
+	 */
+	private static $user_meta_keys = array(
+		'^sensei_hide_menu_settings_notice$',
+		'^_module_progress_[0-9]+_[0-9]+$',
+	);
+
+	/**
 	 * Cleanup all data.
 	 *
 	 * @access public
@@ -213,6 +223,7 @@ class Sensei_Data_Cleaner {
 		self::cleanup_roles_and_caps();
 		self::cleanup_transients();
 		self::cleanup_options();
+		self::cleanup_user_meta();
 	}
 
 	/**
@@ -349,4 +360,23 @@ class Sensei_Data_Cleaner {
 			}
 		}
 	}
+
+	/**
+	 * Cleanup Sensei user meta from the database.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_user_meta() {
+		global $wpdb;
+
+		foreach ( self::$user_meta_keys as $meta_key ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					"DELETE FROM {$wpdb->usermeta} WHERE meta_key RLIKE %s",
+					$meta_key
+				)
+			);
+		}
+	}
+
 }


### PR DESCRIPTION
Advancing #2034, this removes the user meta on uninstall. Specifically, user meta keys:
- `_module_progress_#_#`
- `sensei_hide_menu_settings_notice`

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.
- Ensure that the tests pass.
- Set up at least one admin user and have that user progress partially through one course with modules.
- While logged in, visit `http://sensei.localhost/wp-admin/?sensei_hide_notice=menu_settings` (replacing the hostname).
- Verify this student has `sensei_hide_menu_settings_notice` and some `_module_progress_#_#` user meta. 
- Delete the Sensei plugin.
- Verify the Sensei user meta is removed from the database.
- Please also test on a multisite installation. When the plugin is deleted from the Network Admin, the Sensei user meta should be trashed across the network.

