### PR TITLE
Only load parent courses if the child variation has none

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1184,8 +1184,11 @@ class Sensei_Course {
 		switch( $product->get_type() ) {
 			case 'subscription_variation':
 			case 'variation':
-				$parent_product_courses = get_posts( self::get_product_courses_query_args( $product->get_parent_id() ) );
-				$courses                = array_merge( $courses, $parent_product_courses);
+				if ( empty( $courses ) ) {
+
+					$courses = get_posts( self::get_product_courses_query_args( $product->get_parent_id() ) );
+
+				}
 				break;
 
 			case 'variable-subscription':


### PR DESCRIPTION
Change the behavior of #2101 to only load courses from the parent product if the subscription/product variation doesn't have a course associated with it. 

For testing instructions, see #2101.