### PR TITLE
Only merge with parent product courses if no variation courses

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1184,8 +1184,17 @@ class Sensei_Course {
 		switch( $product->get_type() ) {
 			case 'subscription_variation':
 			case 'variation':
-				$parent_product_courses = get_posts( self::get_product_courses_query_args( $product->get_parent_id() ) );
-				$courses                = array_merge( $courses, $parent_product_courses);
+				/**
+				 * Merge a product variation's courses with the parent's courses. Defaults to false.
+				 *
+				 * @since 1.10.0
+				 *
+				 * @param bool $merge_courses_with_parent_product True to merge with parent product's courses.
+				 */
+				if ( empty( $courses ) || apply_filters( 'sensei_merge_courses_with_parent_product', false ) ) {
+					$parent_product_courses = get_posts( self::get_product_courses_query_args( $product->get_parent_id() ) );
+					$courses                = array_merge( $courses, $parent_product_courses );
+				}
 				break;
 
 			case 'variable-subscription':


### PR DESCRIPTION
Replaces #2110

Change the behavior of #2101 to only load courses from the parent product if the subscription/product variation doesn't have a course associated with it _or_ if `sensei_merge_courses_with_parent_product` filters to a value that evaluates to `true`. 

For testing instructions, see #2101.