### PR TITLE
[Proposal] Add setting for data deletion

### DIFF
--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -64,7 +64,7 @@ class Sensei_Settings extends Sensei_Settings_API {
      * @param $new_value
      */
     public function set( $setting, $new_value ){
-    	
+
         $settings = get_option( $this->token, array() );
 		$settings[ $setting ] = $new_value;
 		return update_option( $this->token,$settings );
@@ -243,6 +243,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$fields['sensei_video_embed_html_sanitization_disable'] = array(
 								'name' => __( 'Disable HTML security', 'woothemes-sensei' ),
 								'description' => __( 'Allow any HTML tags in the Video Embed field. Warning: Enabling this may leave your site more vulnerable to XSS attacks', 'woothemes-sensei' ),
+								'type' => 'checkbox',
+								'default' => false,
+								'section' => 'default-settings'
+								);
+
+		$fields['sensei_delete_data_on_uninstall'] = array(
+								'name' => __( 'Delete all data on uninstall', 'woothemes-sensei' ),
+								'description' => __( 'Delete all saved data for Sensei when the plugin is deleted. IMPORTANT NOTE: once the data is deleted, it cannot be restored!', 'woothemes-sensei' ),
 								'type' => 'checkbox',
 								'default' => false,
 								'section' => 'default-settings'

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -249,8 +249,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 								);
 
 		$fields['sensei_delete_data_on_uninstall'] = array(
-								'name' => __( 'Delete all data on uninstall', 'woothemes-sensei' ),
-								'description' => __( 'Delete all saved data for Sensei when the plugin is deleted. IMPORTANT NOTE: once the data is deleted, it cannot be restored!', 'woothemes-sensei' ),
+								'name' => __( 'Delete data on uninstall', 'woothemes-sensei' ),
+								'description' => __( 'Delete Sensei data when the plugin is deleted. Once removed, this data cannot be restored.', 'woothemes-sensei' ),
 								'type' => 'checkbox',
 								'default' => false,
 								'section' => 'default-settings'

--- a/uninstall.php
+++ b/uninstall.php
@@ -15,16 +15,17 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit();
 }
 
-$token = 'woothemes-sensei';
-delete_option( 'skip_install_sensei_pages' );
-delete_option( 'sensei_installed' );
-
-// Cleanup all data.
 require 'woothemes-sensei.php';
 require 'includes/class-sensei-data-cleaner.php';
 
+// Cleanup all data.
 if ( ! is_multisite() ) {
-	Sensei_Data_Cleaner::cleanup_all();
+
+	// Only do deletion if the setting is true.
+	$do_deletion = Sensei()->settings->get( 'sensei_delete_data_on_uninstall' );
+	if ( $do_deletion ) {
+		Sensei_Data_Cleaner::cleanup_all();
+	}
 } else {
 	global $wpdb;
 
@@ -33,7 +34,13 @@ if ( ! is_multisite() ) {
 
 	foreach ( $blog_ids as $blog_id ) {
 		switch_to_blog( $blog_id );
-		Sensei_Data_Cleaner::cleanup_all();
+
+		// Only do deletion if the setting is true.
+		Sensei()->settings->get_settings();
+		$do_deletion = Sensei()->settings->get( 'sensei_delete_data_on_uninstall' );
+		if ( $do_deletion ) {
+			Sensei_Data_Cleaner::cleanup_all();
+		}
 	}
 
 	switch_to_blog( $original_blog_id );


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/2116

(In particular, this PR uses [this proposed solution](https://github.com/Automattic/sensei/issues/2116#issuecomment-378944319)).

This PR adds a setting to determine whether Sensei's data should be deleted when the plugin is deleted.

## Notes:

- The Setting is currently *off* by default.

- For multisite, the Setting has to be enabled for each site individually.

## Testing

- First, you may want to back up your data, or copy it to a fresh WordPress installation.

- Add some Sensei data to the database.

- On the settings page, leave the option **unchecked** for "Delete all data on uninstall".

- Delete the Sensei plugin.

- Reinstall the Sensei plugin and ensure all of your data from before is still there.

- On the settings page, **check** the option for "Delete all data on uninstall".

- Delete the Sensei plugin.

- Reinstall the Sensei plugin and ensure that your data from before has been deleted.

- Please also test on a multisite installation. Set the option in the Settings page to `true` on some sites and `false` on others. When the plugin is deleted from the Network Admin, the data should be deleted only for the sites that have the Setting checked.