### PR TITLE
Fix error in data updates when there are no quizzes

### DIFF
--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -1151,24 +1151,32 @@ class Sensei_Updates
 
 		// ...get all Quiz IDs for the above Lessons
 		$id_list = join( ',', $lesson_ids );
-		$meta_list = $wpdb->get_results( "SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = '_quiz_lesson' AND meta_value IN ($id_list)", ARRAY_A );
 		$lesson_quiz_ids = array();
-		if ( !empty($meta_list) ) {
-			foreach ( $meta_list as $metarow ) {
-				$lesson_id = $metarow['meta_value'];
-				$quiz_id = $metarow['post_id'];
-				$lesson_quiz_ids[ $lesson_id ] = $quiz_id;
-			}
-		}
-
-		// ...check all Quiz IDs for questions
-		$id_list = join( ',', array_values($lesson_quiz_ids) );
-		$meta_list = $wpdb->get_results( "SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = '_quiz_id' AND meta_value IN ($id_list)", ARRAY_A );
 		$lesson_quiz_ids_with_questions = array();
-		if ( !empty($meta_list) ) {
-			foreach ( $meta_list as $metarow ) {
-				$quiz_id = $metarow['meta_value'];
-				$lesson_quiz_ids_with_questions[] = $quiz_id;
+
+		if ( ! empty( $id_list ) ) {
+			$meta_list = $wpdb->get_results( "SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = '_quiz_lesson' AND meta_value IN ($id_list)", ARRAY_A );
+
+			if ( ! empty( $meta_list ) ) {
+				foreach ( $meta_list as $metarow ) {
+					$lesson_id = $metarow['meta_value'];
+					$quiz_id = $metarow['post_id'];
+					$lesson_quiz_ids[ $lesson_id ] = $quiz_id;
+				}
+			}
+
+			// ...check all Quiz IDs for questions
+			$id_list = join( ',', array_values( $lesson_quiz_ids ) );
+
+			if ( ! empty( $id_list ) ) {
+				$meta_list = $wpdb->get_results( "SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = '_quiz_id' AND meta_value IN ($id_list)", ARRAY_A );
+
+				if ( ! empty( $meta_list ) ) {
+					foreach ( $meta_list as $metarow ) {
+						$quiz_id = $metarow['meta_value'];
+						$lesson_quiz_ids_with_questions[] = $quiz_id;
+					}
+				}
 			}
 		}
 
@@ -1234,31 +1242,39 @@ class Sensei_Updates
 		$lesson_ids_with_quizzes = get_posts( $args );
 		// ...get all Quiz IDs for the above Lessons
 		$id_list = join( ',', $lesson_ids_with_quizzes );
-		$meta_list = $wpdb->get_results( "SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = '_quiz_lesson' AND meta_value IN ($id_list)", ARRAY_A );
 		$lesson_quiz_ids = array();
-		if ( !empty($meta_list) ) {
-			foreach ( $meta_list as $metarow ) {
-				$lesson_id = $metarow['meta_value'];
-				$quiz_id = $metarow['post_id'];
-				$lesson_quiz_ids[ $lesson_id ] = $quiz_id;
-			}
-		}
-
-		// ...get all Pass Required & Passmarks for the above Lesson/Quizzes
-		$id_list = join( ',', array_values($lesson_quiz_ids) );
-		$meta_list = $wpdb->get_results( "SELECT post_id, meta_key, meta_value FROM $wpdb->postmeta WHERE ( meta_key = '_pass_required' OR meta_key = '_quiz_passmark' ) AND post_id IN ($id_list)", ARRAY_A );
 		$quizzes_pass_required = $quizzes_passmarks = array();
-		if ( !empty($meta_list) ) {
-			foreach ( $meta_list as $metarow ) {
-				if ( !empty($metarow['meta_value']) ) {
+
+		if ( ! empty( $id_list ) ) {
+			$meta_list = $wpdb->get_results( "SELECT post_id, meta_value FROM $wpdb->postmeta WHERE meta_key = '_quiz_lesson' AND meta_value IN ($id_list)", ARRAY_A );
+
+			if ( !empty($meta_list) ) {
+				foreach ( $meta_list as $metarow ) {
+					$lesson_id = $metarow['meta_value'];
 					$quiz_id = $metarow['post_id'];
-					$key = $metarow['meta_key'];
-					$value = $metarow['meta_value'];
-					if ( '_pass_required' == $key ) {
-						$quizzes_pass_required[ $quiz_id ] = $value;
-					}
-					if ( '_quiz_passmark' == $key ) {
-						$quizzes_passmarks[ $quiz_id ] = $value;
+					$lesson_quiz_ids[ $lesson_id ] = $quiz_id;
+				}
+			}
+
+			// ...get all Pass Required & Passmarks for the above Lesson/Quizzes
+			$id_list = join( ',', array_values($lesson_quiz_ids) );
+
+			if ( ! empty( $id_list ) ) {
+				$meta_list = $wpdb->get_results( "SELECT post_id, meta_key, meta_value FROM $wpdb->postmeta WHERE ( meta_key = '_pass_required' OR meta_key = '_quiz_passmark' ) AND post_id IN ($id_list)", ARRAY_A );
+
+				if ( !empty($meta_list) ) {
+					foreach ( $meta_list as $metarow ) {
+						if ( !empty($metarow['meta_value']) ) {
+							$quiz_id = $metarow['post_id'];
+							$key = $metarow['meta_key'];
+							$value = $metarow['meta_value'];
+							if ( '_pass_required' == $key ) {
+								$quizzes_pass_required[ $quiz_id ] = $value;
+							}
+							if ( '_quiz_passmark' == $key ) {
+								$quizzes_passmarks[ $quiz_id ] = $value;
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
When a lesson has no quizzes, running the _Convert lesson statuses_ and _Update lesson statuses_ data updates result in the following errors:

## Convert lesson statuses
```
WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1 for query SELECT post_id, meta_value FROM wp_postmeta WHERE meta_key = '_quiz_lesson' AND meta_value IN () made by do_action('sensei_page_sensei_updates'), WP_Hook->do_action, WP_Hook->apply_filters, Sensei_Updates->sensei_updates_page, Sensei_Updates->status_changes_convert_lessons
```

## Update lesson statuses
```
WordPress database error You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ')' at line 1 for query SELECT post_id, meta_value FROM wp_postmeta WHERE meta_key = '_quiz_lesson' AND meta_value IN () made by do_action('sensei_page_sensei_updates'), WP_Hook->do_action, WP_Hook->apply_filters, Sensei_Updates->sensei_updates_page, Sensei_Updates->status_changes_fix_lessons
```

As a result, the data updates don't run properly.

## Testing
1. Run the SQL query I sent in Slack to update the database with test data. May want to spin up a new site for this.
2. Run the following queries and make note of the row counts:
```
select * from wp_comments where comment_type = 'sensei_lesson_status' 

select * from wp_commentmeta
where meta_key in ('start', 'questions_asked', 'grade') 

select * from wp_postmeta
where meta_key = '_quiz_has_questions'
```
3. Change `siteurl` and `home` values in `wp_options` to the URL of your local site.
4. Enable debugging in `wp-config.php`.
5. Use the Production credentials in 916507-zen to log in. **Confirm that you've logged in to your local site and not the client's site!**
6. Install & activate this branch of Sensei.
7. Go to _Adjustments_ > _General_ and change the language to English. (Alternatively, [turn off Google Translate](https://support.google.com/chrome/answer/173424?visit_id=0-636589009227931268-4200837465&p=ib_translation_bar&rd=1) as data updates won't run if it's enabled.)
8. Go to _Sensei_ > _Data Updates_ and run _Convert lesson statuses_. Ensure the above error does not appear in the logs and that the update finishes (this may take a few minutes).
9. Go to _Sensei_ > _Data Updates_ and run _Update lesson statuses_. Ensure the above error does not appear in the logs and that the update finishes.
10. Run the queries from step 2 again. The row counts from the first two queries should be different. For the last query, the row count should still be 0 since there is no quiz data.
11. The queries should also be tested to ensure they still work when there is quiz data. To do that, repeat steps 1 - 5. Then, install **Sensei 1.6.9** and add some quizzes to a few lessons. Switch back to this branch, update the language, and run the data updates. Ensure that the following query returns results:
```
select * from wp_postmeta
where meta_key = '_quiz_has_questions'
```