### PR TITLE
Correct version of modules-frontend.css file

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1313,8 +1313,8 @@ class Sensei_Core_Modules
 		$disable_styles = apply_filters( 'sensei_disable_styles', $disable_styles );
 
 		if ( ! $disable_styles ) {
-			wp_register_style($this->taxonomy . '-frontend', esc_url($this->assets_url) . 'css/modules-frontend.css', Sensei()->version );
-			wp_enqueue_style($this->taxonomy . '-frontend');
+			wp_register_style( $this->taxonomy . '-frontend', esc_url( $this->assets_url ) . 'css/modules-frontend.css', array(), Sensei()->version );
+			wp_enqueue_style( $this->taxonomy . '-frontend' );
 		}
 
 	}


### PR DESCRIPTION
This PR fixes the call to `wp_register_style` for `modules-frontend.css` to pass the correct number of arguments so that the Sensei version number is appended to the CSS file name.