### PR TITLE
Delete user's messages when the user is deleted

### DIFF
--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -399,6 +399,7 @@ class Sensei_PostTypes {
 			    'hierarchical' => false,
 			    'menu_position' => 50,
 			    'supports' => array( 'title', 'editor', 'comments' ),
+			    'delete_with_user' => true,
 			);
 
             /**


### PR DESCRIPTION
When deleting a user with `Delete all content` selected, that user's messages should be deleted as well.

## Testing Instructions
- Select a course and send a message by clicking the _Contact Course Teacher_ button. Repeat as many times as you like.
- In _Sensei_ > _Messages_, confirm that the message(s) appears.
- Delete the user that sent the message(s) and choose `Delete all content`.
- Verify the user's message(s) no longer appear in _Sensei_ > _Messages_.