### PR TITLE
Fix: Course score based on quizzes that have graded questions

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4018,6 +4018,29 @@ class Sensei_Lesson {
     }
 
 	/**
+	 * Checks if a lesson has a quiz that has at least one graded question.
+	 *
+	 * @param int $lesson_id The Lesson.
+	 * @return bool
+	 */
+	public function lesson_has_quiz_with_graded_questions( $lesson_id ) {
+		// Lesson quizzes
+		$quiz_id = $this->lesson_quizzes( $lesson_id );
+		if ( empty( $quiz_id ) ) {
+			return false;
+		}
+
+		$has_quiz_questions = self::lesson_quiz_has_questions( $lesson_id );
+		if ( false === $has_quiz_questions ) {
+			return false;
+		}
+
+		$quiz_total = Sensei_Utils::sensei_get_quiz_total( $quiz_id );
+
+		return 0 !== $quiz_total;
+	}
+
+	/**
      * Lesson Quiz Has Questions
      *
 	 * @param int $lesson_id Lesson.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1108,7 +1108,8 @@ class Sensei_Utils {
 			foreach( $lessons as $lesson ) {
 
 				// Check for lesson having questions, thus a quiz, thus having a grade
-				$has_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson->ID );
+				$has_questions = Sensei()->lesson->lesson_has_quiz_with_graded_questions( $lesson->ID );
+
 				if ( $has_questions ) {
 					$user_lesson_status = Sensei_Utils::user_lesson_status( $lesson->ID, $user_id );
 

--- a/tests/framework/factories/Sensei-Factory.php
+++ b/tests/framework/factories/Sensei-Factory.php
@@ -360,8 +360,10 @@ class Sensei_Factory extends  WP_UnitTest_Factory{
     /**
      * Generate an array of user quiz grades
      *
-     * @param int $number number of questions to generate. Default 10
-     * @trows new 'Generate questions needs a valid lesson ID.' if the ID passed in is not a valid lesson
+     * @param array $quiz_answers
+	 * @return array
+	 *
+     * @throws Exception 'Generate questions needs a valid lesson ID.' if the ID passed in is not a valid lesson
      */
     public function generate_user_quiz_grades( $quiz_answers ){
 
@@ -390,8 +392,7 @@ class Sensei_Factory extends  WP_UnitTest_Factory{
 	 * @param int   $number number of questions to generate. Default 10
 	 * @param int   $lesson_id
 	 * @param array $question_args
-	 * @throws Exception
-	 * @trows new 'Generate questions needs a valid lesson ID.' if the ID passed in is not a valid lesson
+	 * @throws Exception 'Generate questions needs a valid lesson ID.' if the ID passed in is not a valid lesson
 	 */
 	protected function attach_lessons_questions( $number = 10 , $lesson_id, $question_args = array() ){
 

--- a/tests/framework/factories/Sensei-Factory.php
+++ b/tests/framework/factories/Sensei-Factory.php
@@ -418,15 +418,16 @@ class Sensei_Factory extends  WP_UnitTest_Factory{
 		update_post_meta( $quiz_id, '_pass_required', 'on' );
 		update_post_meta( $quiz_id, '_quiz_passmark' , 50 );
 
-		update_post_meta( $lesson_id, '_quiz_has_questions', true );
-
+		if ( $number > 0 ) {
+			update_post_meta( $lesson_id, '_quiz_has_questions', true );
+		}
 
 		// if the database already contains questions don't create more but add
 		// the existing questions to the passed in lesson id's lesson
 		$question_post_query = new WP_Query( array( 'post_type' => 'question' ) );
 		$questions = $question_post_query->get_posts();
 
-		if( ! count( $questions ) > 0 ){
+		if( empty( $questions ) || ! empty( $question_args ) ){
 
 			// generate questions if none exists
 			$questions = $this->generate_questions( $number );
@@ -744,7 +745,7 @@ class Sensei_Factory extends  WP_UnitTest_Factory{
 	 */
 	public function get_lesson_graded_quiz() {
 		$lesson_id = $this->get_lesson_no_quiz();
-		$this->attach_lessons_questions( 10, $lesson_id, array( 'question_grade' => 1 ) );
+		$this->attach_lessons_questions( 10, $lesson_id, array( 'question_grade' => '1' ) );
 		return $lesson_id;
 	}
 
@@ -754,7 +755,7 @@ class Sensei_Factory extends  WP_UnitTest_Factory{
 	 */
 	public function get_lesson_no_graded_quiz() {
 		$lesson_id = $this->get_lesson_no_quiz();
-		$this->attach_lessons_questions( 10, $lesson_id, array( 'question_grade' => 0 ) );
+		$this->attach_lessons_questions( 10, $lesson_id, array( 'question_grade' => '0' ) );
 		return $lesson_id;
 	}
 

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -1,6 +1,10 @@
 <?php
 
 class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
+	/**
+	 * @var Sensei_Factory
+	 */
+	private $factory;
 
     /**
      * Constructor function
@@ -175,6 +179,38 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
       Sensei()->lesson->add_lesson_to_course_order( $a_lesson_assigned_to_an_invalid_course_id );
       $this->assertEquals( 5, count( self::get_course_lesson_order( $course_id ) ), 'do nothing on lessons where no order meta is found' );
     }
+
+	/**
+	 * @covers Sensei_Lesson::lesson_has_quiz_with_graded_questions()
+	 */
+	public function testLessonHasQuizWithGradedQuestionsLessonWithNoQuiz() {
+		$lesson_id = $this->factory->get_lesson_no_quiz();
+		$this->assertFalse( Sensei()->lesson->lesson_has_quiz_with_graded_questions( $lesson_id ) );
+	}
+
+	/**
+	 * @covers Sensei_Lesson::lesson_has_quiz_with_graded_questions()
+	 */
+	public function testLessonHasQuizWithGradedQuestionsQuizWithNoQuestions() {
+		$lesson_id = $this->factory->get_lesson_empty_quiz();
+		$this->assertFalse( Sensei()->lesson->lesson_has_quiz_with_graded_questions( $lesson_id ) );
+	}
+
+	/**
+	 * @covers Sensei_Lesson::lesson_has_quiz_with_graded_questions()
+	 */
+	public function testLessonHasQuizWithGradedQuestionsQuizWithNoGradedQuestions() {
+		$lesson_id = $this->factory->get_lesson_no_graded_quiz();
+		$this->assertFalse( Sensei()->lesson->lesson_has_quiz_with_graded_questions( $lesson_id ) );
+	}
+
+	/**
+	 * @covers Sensei_Lesson::lesson_has_quiz_with_graded_questions()
+	 */
+	public function testLessonHasQuizWithGradedQuestionsQuizWithGradedQuestions() {
+		$lesson_id = $this->factory->get_lesson_graded_quiz();
+		$this->assertTrue( Sensei()->lesson->lesson_has_quiz_with_graded_questions( $lesson_id ) );
+	}
 
     private static function get_course_lesson_order( $course_id ) {
       $order_string_array = explode( ',', get_post_meta( intval( $course_id ), '_lesson_order', true ) );


### PR DESCRIPTION
Fixes #2121

This changes the course scoring behavior to not include quiz scores when there are no graded questions.

## Testing

See issue for testing instructions.