### PR TITLE
Fix when force completing lessons with quizzes with questions

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3578,7 +3578,7 @@ class Sensei_Lesson {
 
 		}
 
-		return  Sensei_Utils::user_completed_lesson( $pre_requisite_id, $user_id );
+		return Sensei_Utils::user_completed_lesson( $pre_requisite_id, $user_id );
 
 	}// end is_prerequisite_complete
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -706,7 +706,7 @@ class Sensei_Utils {
 
                 // if users is already taking the lesson  and the status changes to complete update it
                 $current_user_activity = get_comment($activity_logged);
-                if( $status=='complete' &&
+                if( in_array( $status, array( 'complete', 'passed' ), true ) &&
                     $status != $current_user_activity->comment_approved  ){
 
                     $comment = array();

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -47,7 +47,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 
     /**
      * Testing the is lesson pre-requisite completed function.
-     *
+     * @group jake-wip
      * @since 1.9.0
      */
     public function testIsPreRequisiteComplete() {
@@ -63,6 +63,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
             'None existing lesson or user should return false');
 
         $test_user_id = wp_create_user( 'studentPrerequisite', 'studentPrerequisite', 'studentPrerequisite@test.com' );
+
         $test_lesson = $this->factory->get_lessons();
         $test_lesson_id = $test_lesson[0];
 
@@ -80,11 +81,11 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 
         Sensei_Utils::user_start_lesson( $test_user_id ,$test_lesson_prerequisite_id );
         $this->assertFalse( WooThemes_Sensei_Lesson::is_prerequisite_complete( $test_lesson_id, $test_user_id ),
-            'Users that has NOT completeded prerequisite should return false.');
+            'Users that has NOT completed prerequisite should return false.');
 
         Sensei_Utils::user_start_lesson( $test_user_id, $test_lesson_prerequisite_id, true );
-        $this->assertTrue( Sensei_Lesson::is_prerequisite_complete( $test_lesson_id, $test_user_id ),
-            'Users that has completeded prerequisite should return true.');
+        $this->assertTrue( Sensei_Lesson::is_prerequisite_complete( $test_lesson_id, $test_user_id, true ),
+            'Users that has completed prerequisite should return true.');
 
     } // end testIsPreRequisiteComplete
 

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -47,7 +47,6 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 
     /**
      * Testing the is lesson pre-requisite completed function.
-     * @group jake-wip
      * @since 1.9.0
      */
     public function testIsPreRequisiteComplete() {


### PR DESCRIPTION
There was a bug exposed in the testing of #2145 where we weren't sometimes completing lessons when they had quizzes with questions. This only happened when we were forcing completion of a lesson in `Sensei_Utils::sensei_start_lesson()`. 