### PR TITLE
Re-add the environment to the Travis build that was failing on WP trunk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
     env: WP_VERSION=4.4
   - php: "5.6"
     env: WP_VERSION=latest
+  - php: "5.6"
+    env: WP_VERSION=trunk
   - php: "5.3"
     env: WP_VERSION=latest
     dist: precise


### PR DESCRIPTION
This reverts commit b66685e27827c9ed2bd17bb59b242521bb78cf63.

See #2149 

We can use this PR to test when the upstream issue has been fixed.

