### PR TITLE
Usage Tracking: Add stats for number of quizzes and quiz questions

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -109,19 +109,6 @@ class Sensei_Usage_Tracking_Data {
 		}
 
 		if ( ! empty( $published_quiz_ids ) ) {
-			$multiple_question_query     = new WP_Query( array(
-				'post_type'        => 'multiple_question',
-				'posts_per_page'   => -1,
-				'fields'           => 'ids',
-				'no_found_rows'    => true,
-				'suppress_filters' => 1,
-				'meta_query'       => array(
-					array(
-						'key'   => '_quiz_id',
-						'value' => $published_quiz_ids,
-					),
-				),
-			) );
 			$stats['category_questions'] = self::get_category_question_count( $published_quiz_ids );
 		}
 
@@ -137,7 +124,7 @@ class Sensei_Usage_Tracking_Data {
 	 * Get the number of category/multiple questions assigned to published quizzes.
 	 *
 	 * @since 1.11.0
-	 * 
+	 *
 	 * @param int[] $published_quiz_ids
 	 * @return int
 	 */

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -122,7 +122,7 @@ class Sensei_Usage_Tracking_Data {
 					),
 				),
 			) );
-			$stats['category_questions'] = count( $multiple_question_query->posts );
+			$stats['category_questions'] = self::get_category_question_count( $published_quiz_ids );
 		}
 
 		if ( ! empty( $question_counts ) ) {
@@ -131,6 +131,32 @@ class Sensei_Usage_Tracking_Data {
 		}
 
 		return $stats;
+	}
+
+	/**
+	 * Get the number of category/multiple questions assigned to published quizzes.
+	 *
+	 * @since 1.11.0
+	 * 
+	 * @param int[] $published_quiz_ids
+	 * @return int
+	 */
+	private static function get_category_question_count( $published_quiz_ids ) {
+		$multiple_question_query     = new WP_Query( array(
+			'post_type'        => 'multiple_question',
+			'posts_per_page'   => -1,
+			'fields'           => 'ids',
+			'no_found_rows'    => true,
+			'suppress_filters' => 1,
+			'meta_query'       => array(
+				array(
+					'key'   => '_quiz_id',
+					'value' => $published_quiz_ids,
+				),
+			),
+		) );
+
+		return count( $multiple_question_query->posts );
 	}
 
 	/**

--- a/tests/framework/factories/class-wp-unittest-factory-for-multiple-question.php
+++ b/tests/framework/factories/class-wp-unittest-factory-for-multiple-question.php
@@ -1,0 +1,46 @@
+<?php
+
+class WP_UnitTest_Factory_For_Multiple_Question extends WP_UnitTest_Factory_For_Post_Sensei {
+	function __construct( $factory = null ) {
+		parent::__construct( $factory );
+		$this->default_generation_definitions = array(
+			'post_status'  => 'publish',
+			'post_title'   => new WP_UnitTest_Generator_Sequence( 'Multiple question title %s' ),
+			'post_content' => new WP_UnitTest_Generator_Sequence( 'Multiple question content %s' ),
+			'post_excerpt' => new WP_UnitTest_Generator_Sequence( 'Multiple question excerpt %s' ),
+			'post_type'    => 'multiple_question',
+		);
+	}
+
+	/**
+	 * @param array $args
+	 *
+	 * @return int|WP_Error
+	 * @throws Exception
+	 */
+	public function create_object( $args ) {
+		if ( ! isset( $args['meta_input'] ) ) {
+			$args['meta_input'] = array();
+		}
+		$args['meta_input']['number'] = isset( $args['question_number'] ) ? $args['question_number'] : 3;
+		if ( ! isset( $args['question_category_id'] ) ) {
+			$question_category            = $this->factory->question_category->create_and_get();
+			$args['question_category_id'] = $question_category->term_id;
+			$this->factory->question->create_many( $args['meta_input']['number'] + 1, array(
+				'quiz_id'           => $this->factory->quiz->create(),
+				'question_category' => $args['question_category_id'],
+			) );
+		}
+		$args['meta_input']['category'] = $args['question_category_id'];
+
+		if ( ! empty( $args['quiz_id'] ) ) {
+			$args['meta_input']['_quiz_id']             = $args['quiz_id'];
+			$args['meta_input']['_quiz_question_order'] = $args['quiz_id'] . '000' . $args['meta_input']['number'];
+			$lesson_id                                  = get_post_meta( $args['quiz_id'], '_quiz_lesson', true );
+			update_post_meta( $lesson_id, '_quiz_has_questions', '1' );
+		}
+
+		return parent::create_object( $args );
+	}
+
+}

--- a/tests/framework/factories/class-wp-unittest-factory-for-question-category.php
+++ b/tests/framework/factories/class-wp-unittest-factory-for-question-category.php
@@ -1,0 +1,12 @@
+<?php
+
+class WP_UnitTest_Factory_For_Question_Category extends WP_UnitTest_Factory_For_Term {
+	function __construct( $factory = null ) {
+		parent::__construct( $factory, 'question-category' );
+		$this->default_generation_definitions = array(
+			'name'        => new WP_UnitTest_Generator_Sequence( 'Question Category %s' ),
+			'taxonomy'    => 'question-category',
+			'description' => new WP_UnitTest_Generator_Sequence( 'Question Category description %s' ),
+		);
+	}
+}

--- a/tests/framework/factories/class-wp-unittest-factory-for-question.php
+++ b/tests/framework/factories/class-wp-unittest-factory-for-question.php
@@ -22,6 +22,9 @@ class WP_UnitTest_Factory_For_Question extends WP_UnitTest_Factory_For_Post_Sens
 			$this->generated_types[] = $type;
 		}
 		$this->question_count++;
+		if ( isset( $args['quiz_id'] ) && ! isset( $args['post_author']  ) ) {
+			$args['post_author']  = get_post( $args['quiz_id'] )->post_author;
+		}
 		$args = array_merge( $this->get_sample_question_data( $type ), $args );
 		return Sensei()->lesson->lesson_save_question( $args );
 	}

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -218,6 +218,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_quiz_stats
+	 * @covers Sensei_Usage_Tracking_Data::get_category_question_count
 	 */
 	public function testCategoryQuestionsNone() {
 		$this->factory->get_course_with_lessons( array(
@@ -233,6 +234,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_quiz_stats
+	 * @covers Sensei_Usage_Tracking_Data::get_category_question_count
 	 */
 	public function testCategoryQuestionsSimple() {
 		$this->factory->get_course_with_lessons( array(
@@ -248,6 +250,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_quiz_stats
+	 * @covers Sensei_Usage_Tracking_Data::get_category_question_count
 	 */
 	public function testCategoryQuestionsWithDraft() {
 		$this->factory->get_course_with_lessons( array(

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -175,14 +175,14 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			'lesson_count' => 2,
 		) );
 		$this->factory->get_course_with_lessons( array(
-			'question_count' => array( 0, 1, 11 ),
+			'question_count' => array( 0, 1, 6 ),
 			'lesson_count'   => 4, // Missing one should be 5 questions.
 		) );
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( 5, $usage_data['quiz_total'] );
 		$this->assertEquals( 1, $usage_data['questions_min'] );
-		$this->assertEquals( 11, $usage_data['questions_max'] );
+		$this->assertEquals( 6, $usage_data['questions_max'] );
 	}
 
 	/**
@@ -204,7 +204,6 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 				'post_status' => 'draft',
 			),
 		) );
-
 		$this->factory->get_course_with_lessons( array(
 			'question_count' => array( 2, 3 ),
 			'lesson_count'   => 2,
@@ -214,6 +213,60 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->assertEquals( 2, $usage_data['quiz_total'] );
 		$this->assertEquals( 2, $usage_data['questions_min'] );
 		$this->assertEquals( 3, $usage_data['questions_max'] );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_quiz_stats
+	 */
+	public function testCategoryQuestionsNone() {
+		$this->factory->get_course_with_lessons( array(
+			'lesson_count'            => 1,
+			'question_count'          => 2,
+			'multiple_question_count' => 0,
+		) );
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 0, $usage_data['category_questions'] );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_quiz_stats
+	 */
+	public function testCategoryQuestionsSimple() {
+		$this->factory->get_course_with_lessons( array(
+			'lesson_count'            => 1,
+			'question_count'          => 2,
+			'multiple_question_count' => 1,
+		) );
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 1, $usage_data['category_questions'] );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_quiz_stats
+	 */
+	public function testCategoryQuestionsWithDraft() {
+		$this->factory->get_course_with_lessons( array(
+			'lesson_count'            => 2,
+			'question_count'          => array( 0, 1 ),
+			'multiple_question_count' => array( 1, 2 ),
+		) );
+
+		$this->factory->get_course_with_lessons( array(
+			'lesson_count'            => 1,
+			'question_count'          => 2,
+			'multiple_question_count' => 1,
+			'lesson_args'             => array(
+				'post_status' => 'draft',
+			),
+		) );
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 3, $usage_data['category_questions'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2088

This adds usage stats for:
- [x] `quiz_total`: Total number of quizzes for published lessons/courses that have at least one question.
- [x] `questions_min`: Minimum number of questions any published quiz has.
- [x] `questions_max`: Maximum number of questions any published quiz has.
- [x] `category_questions`: Number of category questions added to all published quizzes.

## Testing
1. Check that `quiz_total` is correctly logged in Tracks.
2. Check that `questions_min` is correctly logged in Tracks.
3. Check that `questions_max` is correctly logged in Tracks.
4. Check that `category_questions` is correctly logged in Tracks.