### PR TITLE
Usage Tracking: Add usage tracking for quiz settings

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -106,10 +106,13 @@ class Sensei_Usage_Tracking_Data {
 			if ( empty( $course_id ) || 'publish' !== get_post_status( $lesson_id ) || 'publish' !== get_post_status( $course_id ) ) {
 				continue;
 			}
-
 			$quiz_id              = Sensei()->lesson->lesson_quizzes( $lesson_id );
 			$quiz_question_posts  = Sensei()->lesson->lesson_quiz_questions( $quiz_id );
-			$question_counts[]    = count( $quiz_question_posts );
+			$question_count = count( $quiz_question_posts );
+			if ( 0 === $question_count ) {
+				continue;
+			}
+			$question_counts[]    = $question_count;
 			$published_quiz_ids[] = $quiz_id;
 			$stats['quiz_total']++;
 		}

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -87,16 +87,16 @@ class Sensei_Usage_Tracking_Data {
 		) );
 
 		$stats = array(
-			'quiz_total'               => 0,
-			'questions_min'            => null,
-			'questions_max'            => null,
-			'category_questions'       => 0,
-			'quiz_pass_required'       => 0,
-			'quiz_passmark'            => 0,
-			'quiz_valid_num_questions' => 0,
-			'quiz_rand_questions'      => 0,
-			'quiz_auto_grade'          => 0,
-			'quiz_allow_retake'        => 0,
+			'quiz_total'          => 0,
+			'questions_min'       => null,
+			'questions_max'       => null,
+			'category_questions'  => 0,
+			'quiz_pass_required'  => 0,
+			'quiz_passmark'       => 0,
+			'quiz_num_questions'  => 0,
+			'quiz_rand_questions' => 0,
+			'quiz_auto_grade'     => 0,
+			'quiz_allow_retake'   => 0,
 		);
 		$question_counts    = array();
 		$published_quiz_ids = array();
@@ -115,13 +115,13 @@ class Sensei_Usage_Tracking_Data {
 		}
 
 		if ( ! empty( $published_quiz_ids ) ) {
-			$stats['category_questions']       = self::get_category_question_count( $published_quiz_ids );
-			$stats['quiz_valid_num_questions'] = self::get_quiz_setting_non_empty_count( $published_quiz_ids, '_show_questions' );
-			$stats['quiz_passmark']            = self::get_quiz_setting_non_empty_count( $published_quiz_ids, '_quiz_passmark' );
-			$stats['quiz_pass_required']       = self::get_quiz_setting_value_count( $published_quiz_ids, '_pass_required', 'on' );
-			$stats['quiz_rand_questions']      = self::get_quiz_setting_value_count( $published_quiz_ids, '_random_question_order', 'yes' );
-			$stats['quiz_auto_grade']          = self::get_quiz_setting_value_count( $published_quiz_ids, '_quiz_grade_type', 'auto' );
-			$stats['quiz_allow_retake']        = self::get_quiz_setting_value_count( $published_quiz_ids, '_enable_quiz_reset', 'on' );
+			$stats['category_questions']  = self::get_category_question_count( $published_quiz_ids );
+			$stats['quiz_num_questions']  = self::get_quiz_setting_non_empty_count( $published_quiz_ids, '_show_questions' );
+			$stats['quiz_passmark']       = self::get_quiz_setting_non_empty_count( $published_quiz_ids, '_quiz_passmark' );
+			$stats['quiz_pass_required']  = self::get_quiz_setting_value_count( $published_quiz_ids, '_pass_required', 'on' );
+			$stats['quiz_rand_questions'] = self::get_quiz_setting_value_count( $published_quiz_ids, '_random_question_order', 'yes' );
+			$stats['quiz_auto_grade']     = self::get_quiz_setting_value_count( $published_quiz_ids, '_quiz_grade_type', 'auto' );
+			$stats['quiz_allow_retake']   = self::get_quiz_setting_value_count( $published_quiz_ids, '_enable_quiz_reset', 'on' );
 		}
 
 		if ( ! empty( $question_counts ) ) {

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -92,6 +92,7 @@ class Sensei_Usage_Tracking_Data {
 			'questions_max'            => null,
 			'category_questions'       => 0,
 			'quiz_pass_required'       => 0,
+			'quiz_passmark'            => 0,
 			'quiz_valid_num_questions' => 0,
 			'quiz_rand_questions'      => 0,
 			'quiz_auto_grade'          => 0,
@@ -116,6 +117,7 @@ class Sensei_Usage_Tracking_Data {
 		if ( ! empty( $published_quiz_ids ) ) {
 			$stats['category_questions']       = self::get_category_question_count( $published_quiz_ids );
 			$stats['quiz_valid_num_questions'] = self::get_quiz_setting_non_empty_count( $published_quiz_ids, '_show_questions' );
+			$stats['quiz_passmark']            = self::get_quiz_setting_non_empty_count( $published_quiz_ids, '_quiz_passmark' );
 			$stats['quiz_pass_required']       = self::get_quiz_setting_value_count( $published_quiz_ids, '_pass_required', 'on' );
 			$stats['quiz_rand_questions']      = self::get_quiz_setting_value_count( $published_quiz_ids, '_random_question_order', 'yes' );
 			$stats['quiz_auto_grade']          = self::get_quiz_setting_value_count( $published_quiz_ids, '_quiz_grade_type', 'auto' );

--- a/tests/framework/factories/class-wp-unittest-factory-for-multiple-question.php
+++ b/tests/framework/factories/class-wp-unittest-factory-for-multiple-question.php
@@ -35,7 +35,7 @@ class WP_UnitTest_Factory_For_Multiple_Question extends WP_UnitTest_Factory_For_
 
 		if ( ! empty( $args['quiz_id'] ) ) {
 			$args['meta_input']['_quiz_id']             = $args['quiz_id'];
-			$args['meta_input']['_quiz_question_order'] = $args['quiz_id'] . '000' . $args['meta_input']['number'];
+			$args['meta_input']['_quiz_question_order' . $args['quiz_id']] = $args['quiz_id'] . '000' . $args['meta_input']['number'];
 			$lesson_id                                  = get_post_meta( $args['quiz_id'], '_quiz_lesson', true );
 			update_post_meta( $lesson_id, '_quiz_has_questions', '1' );
 		}

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -273,6 +273,108 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Used as a data provider for quiz settings test.
+	 *
+	 * @return array
+	 */
+	public function quizSettingData() {
+		return array(
+			array(
+				'quiz_valid_num_questions',
+				'_show_questions',
+				array( '' ),
+				array( 1, 2, 3 ),
+			),
+			array(
+				'quiz_pass_required',
+				'_pass_required',
+				array( 'off', '' ),
+				array( 'on' ),
+			),
+			array(
+				'quiz_rand_questions',
+				'_random_question_order',
+				array( 'no', '' ),
+				array( 'yes' ),
+			),
+			array(
+				'quiz_auto_grade',
+				'_quiz_grade_type',
+				array( 'manual', '' ),
+				array( 'auto' ),
+			),
+			array(
+				'quiz_allow_retake',
+				'_enable_quiz_reset',
+				array( 'off', '' ),
+				array( 'on' ),
+			),
+		);
+	}
+
+	/**
+	 * @param string $stat_key
+	 * @param string $meta_key
+	 * @param array  $invalid_values
+	 * @param array  $valid_values
+	 *
+	 * @dataProvider quizSettingData
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_quiz_stats
+	 * @covers Sensei_Usage_Tracking_Data::get_quiz_setting_value_count
+	 * @covers Sensei_Usage_Tracking_Data::get_quiz_setting_non_empty_count
+	 */
+	public function testQuizSettingCounts( $stat_key, $meta_key, $invalid_values, $valid_values ) {
+		$default_values = array(
+			'_pass_required'         => '',
+			'_quiz_passmark'         => 70,
+			'_show_questions'        => '',
+			'_random_question_order' => 'no',
+			'_quiz_grade_type'       => 'auto',
+			'_enable_quiz_reset'     => '',
+		);
+
+		foreach ( $invalid_values as $value ) {
+			$this->factory->get_course_with_lessons( array(
+				'lesson_count'   => 1,
+				'question_count' => 3,
+				'quiz_args'      => array(
+					'meta_input' => array_merge( $default_values, array(
+						$meta_key => $value,
+					) ),
+				),
+			) );
+		}
+
+		foreach ( $valid_values as $value ) {
+			$this->factory->get_course_with_lessons( array(
+				'lesson_count'   => 1,
+				'question_count' => 3,
+				'quiz_args'      => array(
+					'meta_input' => array_merge( $default_values, array(
+						$meta_key => $value,
+					) ),
+				),
+			) );
+			$this->factory->get_course_with_lessons( array(
+				'lesson_count'   => 1,
+				'question_count' => 3,
+				'lesson_args'    => array(
+					'post_status' => 'draft',
+				),
+				'quiz_args'      => array(
+					'meta_input' => array_merge( $default_values, array(
+						$meta_key => $value,
+					) ),
+				),
+			) );
+		}
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( count( $valid_values ), $usage_data[ $stat_key ] );
+	}
+
+	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 */
 	public function testGetUsageDataCourses() {

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -286,6 +286,12 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 				array( 1, 2, 3 ),
 			),
 			array(
+				'quiz_passmark',
+				'_quiz_passmark',
+				array( '', 0 ),
+				array( 1, 20, 100 ),
+			),
+			array(
 				'quiz_pass_required',
 				'_pass_required',
 				array( 'off', '' ),

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -382,6 +382,43 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_quiz_stats
+	 * @covers Sensei_Usage_Tracking_Data::get_quiz_setting_value_count
+	 * @covers Sensei_Usage_Tracking_Data::get_quiz_setting_non_empty_count
+	 */
+	public function testQuizSettingCountsWithBadLesson() {
+		$values = array(
+			'_pass_required'         => '',
+			'_quiz_passmark'         => 70,
+			'_show_questions'        => '',
+			'_random_question_order' => 'no',
+			'_quiz_grade_type'       => 'auto',
+			'_enable_quiz_reset'     => 'on',
+		);
+		$course_lessons_a = $this->factory->get_course_with_lessons( array(
+			'lesson_count'   => 1,
+			'question_count' => 3,
+			'quiz_args'      => array(
+				'meta_input' => $values,
+			),
+		) );
+		$course_lessons_b = $this->factory->get_course_with_lessons( array(
+			'lesson_count'   => 1,
+			'question_count' => 0,
+			'quiz_args'      => array(
+				'meta_input' => $values,
+			),
+		) );
+
+		// Fake out! Replicate a data integrity issue that exists in Sensei.
+		update_post_meta( $course_lessons_b['lesson_ids'][0], '_quiz_has_questions', '1' );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$this->assertEquals( 1, $usage_data['quiz_allow_retake'] );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 */
 	public function testGetUsageDataCourses() {
 		$published = 4;

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -280,7 +280,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function quizSettingData() {
 		return array(
 			array(
-				'quiz_valid_num_questions',
+				'quiz_num_questions',
 				'_show_questions',
 				array( '' ),
 				array( 1, 2, 3 ),


### PR DESCRIPTION
Fixes #2087

This adds usage stats for the following settings:
- `quiz_pass_required` is count of published quizzes with `_pass_required` => `on`
- `quiz_rand_questions` is count of published quizzes with `_random_question_order` => `yes`
- `quiz_auto_grade` is count of published quizzes with `_quiz_grade_type` => `auto`
- `quiz_allow_retake` is count of published quizzes with `_enable_quiz_reset` => `on`
- `quiz_num_questions` is count of published quizzes with a valid value for `_show_questions` (not empty and `> 1`)
- `quiz_passmark` is count of published quizzes with a valid value for `_quiz_passmark` (not empty and `> 1`)

## Testing
1. Check that `quiz_pass_required` is correctly logged in Tracks.
2. Check that `quiz_rand_questions` is correctly logged in Tracks.
3. Check that `quiz_auto_grade` is correctly logged in Tracks.
4. Check that `quiz_allow_retake` is correctly logged in Tracks.
5. Check that `quiz_num_questions` is correctly logged in Tracks.
6. Check that `quiz_passmark` is correctly logged in Tracks.