### PR TITLE
Remove use of WooCommerce magic method

### DIFF
--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -1333,7 +1333,7 @@ class Sensei_WC {
 		if ( 0 < sizeof( $order->get_items() ) ) {
 
 			// Get order user
-			$user_id = $order->__get( 'user_id' );
+			$user_id = $order->get_customer_id();
 
 			foreach ( $order->get_items() as $item ) {
 


### PR DESCRIPTION
Fixes #1830 

Used `get_customer_id()` instead of the magic function `__get()` 