### PR TITLE
Fix display of all other lessons after module is removed

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2766,11 +2766,18 @@ class Sensei_Course {
             );
         }
 
-        //setting lesson order
-        $course_lesson_order = get_post_meta( $course_id, '_lesson_order', true);
+		//setting lesson order
+		$course_lesson_order = get_post_meta( $course_id, '_lesson_order', true );
+		$all_ids             = get_posts( array(
+			'post_type'      => 'lesson',
+			'posts_per_page' => -1,
+			'fields'         => 'ids',
+			'meta_key'       => '_lesson_course',
+			'meta_value'     => intval( $course_id ),
+		) );
         if( !empty( $course_lesson_order ) ){
 
-            $course_lesson_query_args['post__in'] = explode( ',', $course_lesson_order );
+            $course_lesson_query_args['post__in'] = array_merge( explode( ',', $course_lesson_order ), $all_ids );
             $course_lesson_query_args['orderby']= 'post__in' ;
             unset( $course_lesson_query_args['order'] );
 


### PR DESCRIPTION
Fixes #2130

When a module is removed from a course, lessons that were in that module now show up in "Other Lessons" when viewing the course on the frontend.

## Testing

- Create a course and add several lessons. Ensure that some lessons are in a module, and others are not.

- Go to the "Order Lessons" page for that course. Reorder the "Other Lessons" section. This ensures that the DB is set up in such a way that would have reproduced the bug. Specifically, it means that only the lessons in "Other Lessons" will have ordering information in the Course's meta. Other lessons will not.

- Now remove a module from the course on the course edit page.

- View that course on the frontend. The lessons from the module that was removed should appear in the "Other Lessons" section. Note that their order is undefined.

- Reorder the lessons again in the Order Lessons page. On the frontend, the "Other Lessons" section should respect the new ordering.

- Add the module back into the course. On the frontend, the courses should appear in the module section again, and _not_ in "Other Lessons".

## Weird note

When the module is first removed, as mentioned above, the order of the lessons within the "Other Lessons" section is undefined. It also may differ from the initial ordering of those same lessons on the "Order Lessons" page. This is an issue involving the two different pieces of information Sensei sets for tracking the order of the lessons (see the code here and notice that the `_lesson_order` meta is set on the Course _and_ the `_order_{$course_id}` meta is set on the Lesson). On my installation, I saw instances of these two getting out of sync.

This is strange, but I would argue that it is not a problem. If the user explicitly sets an order for the lessons, then that will be respected.