### PR TITLE
Use domain as value of Tracks userid parameter

### DIFF
--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -218,10 +218,10 @@ abstract class Sensei_Usage_Tracking_Base {
 
 		$properties['admin_email'] = get_option( 'admin_email' );
 		$properties['_ut']         = $this->get_event_prefix() . ':site_url';
-		// Use site URL as the userid to enable usage tracking at the site level.
-		// Note that we would likely want to use site URL + user ID for userid if we were
+		// Use site domain as the userid to enable usage tracking at the site level.
+		// Note that we would likely want to use site domain + user ID for userid if we were
 		// to ever add event tracking at the user level.
-		$properties['_ui'] = site_url();
+		$properties['_ui'] = str_replace( 'www.', '', parse_url( site_url(), PHP_URL_HOST ) );
 		$properties['_ul'] = $user->user_login;
 		$properties['_en'] = $event_name;
 		$properties['_ts'] = $event_timestamp . '000';

--- a/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -225,7 +225,7 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 					'button_clicked' => 'my_button',
 					'admin_email'    => 'admin@example.org',
 					'_ut'            => $this->usage_tracking->get_prefix() . ':site_url',
-					'_ui'            => 'http://example.org',
+					'_ui'            => 'example.org',
 					'_ul'            => '',
 					'_en'            => $this->usage_tracking->get_prefix() . '_my_event',
 					'_ts'            => '1234000',


### PR DESCRIPTION
Currently, there are some sites logging multiple values in the Tracks `userid` parameter field that differ only by the protocol (i.e. `http` or `https`) or server name (i.e. `www.` or no `www.`). This makes querying and analyzing data more difficult, as some sites could be included multiple times in query results unless explicitly filtered out.

This PR changes the value stored in the `userid` parameter so that only the site domain is passed. For example, _http://www.example.com_ would be logged as _example.com_, and _https://example.com_ would also be logged as _example.com_.

## Testing
Run usage tracking and ensure the value of the `userid` parameter in Tracks contains only the domain.