### PR TITLE
Improve performance of fetching the learner count for usage tracking

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -357,25 +357,15 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Number of learners.
 	 **/
 	private static function get_learner_count() {
-		$learner_count = 0;
-		$user_query    = new WP_User_Query( array( 'fields' => 'ID' ) );
-		$learners      = $user_query->get_results();
+		global $wpdb;
 
-		foreach ( $learners as $learner ) {
-			$course_args = array(
-				'user_id' => $learner,
-				'type'    => 'sensei_course_status',
-				'status'  => 'any',
-			);
-
-			$course_count = Sensei_Utils::sensei_check_for_activity( $course_args );
-
-			if ( $course_count > 0 ) {
-				$learner_count++;
-			}
-		}
-
-		return $learner_count;
+		return $wpdb->get_var(
+			"SELECT COUNT(DISTINCT user_id)
+			FROM {$wpdb->comments}
+			WHERE comment_type = 'sensei_course_status'
+				AND comment_approved IN ('in-progress', 'complete')
+				AND user_id <> 0"
+		);
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -456,17 +456,19 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		foreach ( $subscribers as $subscriber ) {
 			$this->factory->comment->create(
 				array(
-					'user_id'         => $subscriber,
-					'comment_post_ID' => $this->course_ids[0],
-					'comment_type'    => 'sensei_course_status',
+					'user_id'          => $subscriber,
+					'comment_post_ID'  => $this->course_ids[0],
+					'comment_type'     => 'sensei_course_status',
+					'comment_approved' => 'in-progress',
 				)
 			);
 
 			$this->factory->comment->create(
 				array(
-					'user_id'         => $subscriber,
-					'comment_post_ID' => $this->course_ids[1],
-					'comment_type'    => 'sensei_course_status',
+					'user_id'          => $subscriber,
+					'comment_post_ID'  => $this->course_ids[1],
+					'comment_type'     => 'sensei_course_status',
+					'comment_approved' => 'complete',
 				)
 			);
 		}


### PR DESCRIPTION
`get_learner_count` was running slow for a site with several thousand users. This PR improves the performance of the function to speed up the cron job and prevent timeout errors.

Note that the query used further refines the learner count. I was seeing some `sensei_course_status` rows where `comment_approved` was set to `post-trashed`. Now the count will only include valid course statuses of `in-progress` or `complete`.

Additionally, there were some records where the user ID was 0. This manifests in the _Learner Management_ dashboard as learners with no user names. There's likely some sort of data integrity issue here, so it's best if we exclude these IDs from the count.

## Benchmarks
### Before
![screen shot 2018-05-31 at 1 37 45 pm](https://user-images.githubusercontent.com/1190420/40797964-d44e11fa-64d7-11e8-9d9c-5b3a7da279d4.jpg)

### After
![screen shot 2018-05-31 at 1 38 42 pm](https://user-images.githubusercontent.com/1190420/40798011-fbf01d20-64d7-11e8-8964-cdd1072bb47d.jpg)

## Testing
- Run some benchmark tests as per the above (hat tip @jom).
- Ensure usage tracking data is logged in Tracks and that the value of _learners_ is correct.