### PR TITLE
Start lesson when eligible user first views lesson page

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -104,6 +104,9 @@ class Sensei_Lesson {
 
 		} else {
 			// Frontend actions
+
+			// Starts lesson when the student visits for the first time and prerequisite courses have been met.
+			add_action( 'sensei_single_lesson_content_inside_before', array( __CLASS__, 'maybe_start_lesson' ) );
 		} // End If Statement
 	} // End __construct()
 
@@ -143,7 +146,6 @@ class Sensei_Lesson {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 
 	} // End meta_box_setup()
-
 
 	/**
 	 * lesson_info_meta_box_content function.
@@ -3545,6 +3547,40 @@ class Sensei_Lesson {
 
 		return apply_filters( 'sensei_lesson_prerequisite', $prerequisite_lesson_id, $current_lesson_id );
 
+	}
+
+	/**
+	 * Start the lesson the first time the student visits the page.
+	 *
+	 * @param int|string $lesson_id
+	 * @param int|string $user_id
+	 */
+	public static function maybe_start_lesson( $lesson_id = '', $user_id = '' ) {
+		if ( empty( $lesson_id ) ) {
+			$lesson_id = get_the_ID();
+		}
+
+		if ( empty( $user_id ) ) {
+			$user_id = get_current_user_id();
+		}
+
+		if ( empty( $lesson_id ) || empty( $user_id ) || 'lesson' !== get_post_type( $lesson_id ) ) {
+			return;
+		}
+
+		if ( ! sensei_can_user_view_lesson( $lesson_id, $user_id ) ) {
+			return;
+		}
+
+		if ( ! self::is_prerequisite_complete( $lesson_id, $user_id ) ) {
+			return;
+		}
+
+		if ( false !== Sensei_Utils::user_started_lesson( $lesson_id, $user_id ) ) {
+			return;
+		}
+
+		Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
 	}
 
 	/**

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3568,7 +3568,9 @@ class Sensei_Lesson {
 			return;
 		}
 
-		if ( ! sensei_can_user_view_lesson( $lesson_id, $user_id ) ) {
+		$lesson_course_id = get_post_meta( $lesson_id, '_lesson_course', true );
+		$user_taking_course = Sensei_Utils::user_started_course( $lesson_course_id, $user_id );
+		if ( ! $user_taking_course || ! sensei_can_user_view_lesson( $lesson_id, $user_id ) ) {
 			return;
 		}
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -712,6 +712,7 @@ class Sensei_Utils {
                     $comment = array();
                     $comment['comment_ID'] = $activity_logged;
                     $comment['comment_approved'] = $status;
+                    $comment['comment_date'] = current_time( 'mysql' );
                     wp_update_comment( $comment );
 
                 }

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -271,6 +271,29 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		$this->assertTrue( false !== Sensei_Utils::user_started_lesson( $lesson_id, $user_id ) );
 	}
 
+	/**
+	 * @covers Sensei_Lesson::maybe_start_lesson
+	 */
+	public function testMaybeStartLessonPreviewLesson() {
+		$user_id = wp_create_user( 'getlearnertestuser','password', 'getlearnertestuser@sensei-test.com'  );
+		wp_set_current_user( $user_id );
+
+		$course_lessons = $this->factory->get_course_with_lessons( array(
+			'lesson_count'   => 1,
+			'question_count' => 1,
+			'lesson_args'    => array(
+				'meta_input' => array(
+					'_lesson_preview' => true,
+				),
+			),
+		) );
+		$lesson_id = array_pop( $course_lessons['lesson_ids'] );
+		$this->assertEquals( '1', get_post_meta( $lesson_id, '_lesson_preview', true ) );
+
+		Sensei_Lesson::maybe_start_lesson( $lesson_id, $user_id );
+		$this->assertFalse( Sensei_Utils::user_started_lesson( $lesson_id, $user_id ) );
+	}
+
     private static function get_course_lesson_order( $course_id ) {
       $order_string_array = explode( ',', get_post_meta( intval( $course_id ), '_lesson_order', true ) );
       return array_map( 'intval', $order_string_array );

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -212,6 +212,65 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		$this->assertTrue( Sensei()->lesson->lesson_has_quiz_with_graded_questions( $lesson_id ) );
 	}
 
+	/**
+	 * @covers Sensei_Lesson::maybe_start_lesson
+	 */
+	public function testMaybeStartLessonNotInLoop() {
+		$user_id = wp_create_user( 'getlearnertestuser','password', 'getlearnertestuser@sensei-test.com'  );
+		wp_set_current_user( $user_id );
+
+		$lesson_id = '';
+		Sensei_Lesson::maybe_start_lesson( $lesson_id, $user_id );
+		$this->assertFalse( Sensei_Utils::user_started_lesson( $lesson_id, $user_id ) );
+	}
+
+	/**
+	 * @covers Sensei_Lesson::maybe_start_lesson
+	 */
+	public function testMaybeStartLessonNotActuallyLesson() {
+		$user_id = wp_create_user( 'getlearnertestuser','password', 'getlearnertestuser@sensei-test.com'  );
+		wp_set_current_user( $user_id );
+
+		$lesson_id = $this->factory->quiz->create();
+		Sensei_Lesson::maybe_start_lesson( $lesson_id, $user_id );
+		$this->assertFalse( Sensei_Utils::user_started_lesson( $lesson_id, $user_id ) );
+	}
+
+	/**
+	 * @covers Sensei_Lesson::maybe_start_lesson
+	 */
+	public function testMaybeStartLessonNotEnrolled() {
+		$user_id = wp_create_user( 'getlearnertestuser','password', 'getlearnertestuser@sensei-test.com'  );
+		wp_set_current_user( $user_id );
+
+		$course_lessons = $this->factory->get_course_with_lessons( array(
+			'lesson_count'            => 1,
+			'question_count'          => 1,
+		) );
+		$lesson_id = array_pop( $course_lessons['lesson_ids'] );
+
+		Sensei_Lesson::maybe_start_lesson( $lesson_id, $user_id );
+		$this->assertFalse( Sensei_Utils::user_started_lesson( $lesson_id, $user_id ) );
+	}
+
+	/**
+	 * @covers Sensei_Lesson::maybe_start_lesson
+	 */
+	public function testMaybeStartLessonEnrolled() {
+		$user_id = wp_create_user( 'getlearnertestuser','password', 'getlearnertestuser@sensei-test.com'  );
+		wp_set_current_user( $user_id );
+
+		$course_lessons = $this->factory->get_course_with_lessons( array(
+			'lesson_count'            => 1,
+			'question_count'          => 1,
+		) );
+		$lesson_id = array_pop( $course_lessons['lesson_ids'] );
+		Sensei_Utils::start_user_on_course( $user_id, $course_lessons['course_id'] );
+
+		Sensei_Lesson::maybe_start_lesson( $lesson_id, $user_id );
+		$this->assertTrue( false !== Sensei_Utils::user_started_lesson( $lesson_id, $user_id ) );
+	}
+
     private static function get_course_lesson_order( $course_id ) {
       $order_string_array = explode( ',', get_post_meta( intval( $course_id ), '_lesson_order', true ) );
       return array_map( 'intval', $order_string_array );


### PR DESCRIPTION
Fixes #1430

This will start the lesson the first time a user views the lesson page if all the following conditions are met:
- User is logged in.
- User is enrolled in course.
- User has completed lesson prerequisites.

## Testing Instructions
- Try visiting lesson for all varieties of situations (not enrolled; incomplete prerequisites) and verify the student does _not_ start the lesson (in Analysis > Lessons).
- Try visiting lesson for all necessary conditions are met and verify the student does start the lesson (in Analysis > Lessons).
- All unit tests should pass.