### PR TITLE
Remove single course page displays setting in sensei's course settings

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -12,21 +12,21 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  */
 class Sensei_Course {
 
-    /**
-     * @var $token
-     */
+	/**
+	 * @var $token
+	 */
 	public $token;
 
-    /**
-     * @var array $meta_fields
-     */
+	/**
+	 * @var array $meta_fields
+	 */
 	public $meta_fields;
 
-    /**
-     * @var string|bool $my_courses_page reference to the sites
-     * my courses page, false if none was set
-     */
-    public  $my_courses_page;
+	/**
+	 * @var string|bool $my_courses_page reference to the sites
+	 * my courses page, false if none was set
+	 */
+	public  $my_courses_page;
 
 	/**
 	 * @var array The HTML allowed for message boxes.
@@ -39,14 +39,14 @@ class Sensei_Course {
 	 */
 	public function __construct () {
 
-        $this->token = 'course';
+		$this->token = 'course';
 
 		// Setup meta fields for this post type
 		$this->meta_fields = array( 'course_prerequisite', 'course_featured', 'course_video_embed', 'course_woocommerce_product' );
 		// Admin actions
 		if ( is_admin() ) {
 			// Metabox functions
-            add_action( 'add_meta_boxes', array( $this, 'meta_box_setup' ), 20 );
+			add_action( 'add_meta_boxes', array( $this, 'meta_box_setup' ), 20 );
 			add_action( 'save_post', array( $this, 'meta_box_save' ) );
 			// Custom Write Panel Columns
 			add_filter( 'manage_edit-course_columns', array( $this, 'add_column_headings' ), 10, 1 );
@@ -75,47 +75,47 @@ class Sensei_Course {
 		// Update course completion upon grading of a quiz
 		add_action( 'sensei_user_quiz_grade', array( $this, 'update_status_after_quiz_submission' ), 10, 2 );
 
-        // show the progress bar ont he single course page
-        add_action( 'sensei_single_course_content_inside_before' , array( $this, 'the_progress_statement' ), 15 );
-        add_action( 'sensei_single_course_content_inside_before' , array( $this, 'the_progress_meter' ), 16 );
+		// show the progress bar ont he single course page
+		add_action( 'sensei_single_course_content_inside_before' , array( $this, 'the_progress_statement' ), 15 );
+		add_action( 'sensei_single_course_content_inside_before' , array( $this, 'the_progress_meter' ), 16 );
 
-        // provide an option to block all emails related to a selected course
-        add_filter( 'sensei_send_emails', array( $this, 'block_notification_emails' ) );
-        add_action( 'save_post', array( $this, 'save_course_notification_meta_box' ) );
+		// provide an option to block all emails related to a selected course
+		add_filter( 'sensei_send_emails', array( $this, 'block_notification_emails' ) );
+		add_action( 'save_post', array( $this, 'save_course_notification_meta_box' ) );
 
-        // preview lessons on the course content
-        add_action( 'sensei_course_content_inside_after',array( $this, 'the_course_free_lesson_preview' ) );
+		// preview lessons on the course content
+		add_action( 'sensei_course_content_inside_after',array( $this, 'the_course_free_lesson_preview' ) );
 
-        // the course meta
-        add_action('sensei_course_content_inside_before', array( $this, 'the_course_meta' ) );
+		// the course meta
+		add_action('sensei_course_content_inside_before', array( $this, 'the_course_meta' ) );
 
-        // backwards compatible template hooks
-        add_action('sensei_course_content_inside_before', array( $this, 'content_before_backwards_compatibility_hooks' ));
-        add_action('sensei_loop_course_before', array( $this,'loop_before_backwards_compatibility_hooks' ) );
+		// backwards compatible template hooks
+		add_action('sensei_course_content_inside_before', array( $this, 'content_before_backwards_compatibility_hooks' ));
+		add_action('sensei_loop_course_before', array( $this,'loop_before_backwards_compatibility_hooks' ) );
 
-        // add the user status on the course to the markup as a class
-        add_filter('post_class', array( __CLASS__ , 'add_course_user_status_class' ), 20, 3 );
+		// add the user status on the course to the markup as a class
+		add_filter('post_class', array( __CLASS__ , 'add_course_user_status_class' ), 20, 3 );
 
-        //filter the course query in Sensei specific instances
-        add_filter( 'pre_get_posts', array( __CLASS__, 'course_query_filter' ) );
+		//filter the course query in Sensei specific instances
+		add_filter( 'pre_get_posts', array( __CLASS__, 'course_query_filter' ) );
 
-        //attache the sorting to the course archive
-        add_action ( 'sensei_archive_before_course_loop' , array( 'Sensei_Course', 'course_archive_sorting' ) );
+		//attache the sorting to the course archive
+		add_action ( 'sensei_archive_before_course_loop' , array( 'Sensei_Course', 'course_archive_sorting' ) );
 
-        //attach the filter links to the course archive
-        add_action ( 'sensei_archive_before_course_loop' , array( 'Sensei_Course', 'course_archive_filters' ) );
+		//attach the filter links to the course archive
+		add_action ( 'sensei_archive_before_course_loop' , array( 'Sensei_Course', 'course_archive_filters' ) );
 
-        //filter the course query when featured filter is applied
-        add_filter( 'pre_get_posts',  array( __CLASS__, 'course_archive_featured_filter'), 10, 1 );
+		//filter the course query when featured filter is applied
+		add_filter( 'pre_get_posts',  array( __CLASS__, 'course_archive_featured_filter'), 10, 1 );
 
-        // handle the order by title post submission
-        add_filter( 'pre_get_posts',  array( __CLASS__, 'course_archive_order_by_title'), 10, 1 );
+		// handle the order by title post submission
+		add_filter( 'pre_get_posts',  array( __CLASS__, 'course_archive_order_by_title'), 10, 1 );
 
-        // ensure the course category page respects the manual order set for courses
-        add_filter( 'pre_get_posts',  array( __CLASS__, 'alter_course_category_order'), 10, 1 );
+		// ensure the course category page respects the manual order set for courses
+		add_filter( 'pre_get_posts',  array( __CLASS__, 'alter_course_category_order'), 10, 1 );
 
-        // flush rewrite rules when saving a course
-        add_action('save_post', array( 'Sensei_Course', 'flush_rewrite_rules' ) );
+		// flush rewrite rules when saving a course
+		add_action('save_post', array( 'Sensei_Course', 'flush_rewrite_rules' ) );
 
 		// Allow course archive to be setup as the home page
 		if ( (int) get_option( 'page_on_front' ) > 0 ) {
@@ -186,13 +186,13 @@ class Sensei_Course {
 		add_meta_box( 'course-video', __( 'Course Video', 'woothemes-sensei' ), array( $this, 'course_video_meta_box_content' ), $this->token, 'normal', 'default' );
 		// Add Meta Box for Course Lessons
 		add_meta_box( 'course-lessons', __( 'Course Lessons', 'woothemes-sensei' ), array( $this, 'course_lessons_meta_box_content' ), $this->token, 'normal', 'default' );
-        // Add Meta Box to link to Manage Learners
-        add_meta_box( 'course-manage', __( 'Course Management', 'woothemes-sensei' ), array( $this, 'course_manage_meta_box_content' ), $this->token, 'side', 'default' );
-        // Remove "Custom Settings" meta box.
+		// Add Meta Box to link to Manage Learners
+		add_meta_box( 'course-manage', __( 'Course Management', 'woothemes-sensei' ), array( $this, 'course_manage_meta_box_content' ), $this->token, 'side', 'default' );
+		// Remove "Custom Settings" meta box.
 		remove_meta_box( 'woothemes-settings', $this->token, 'normal' );
 
-        // add Disable email notification box
-        add_meta_box( 'course-notifications', __( 'Course Notifications', 'woothemes-sensei' ), array( $this, 'course_notification_meta_box_content' ), 'course', 'normal', 'default' );
+		// add Disable email notification box
+		add_meta_box( 'course-notifications', __( 'Course Notifications', 'woothemes-sensei' ), array( $this, 'course_notification_meta_box_content' ), 'course', 'normal', 'default' );
 
 	} // End meta_box_setup()
 
@@ -210,10 +210,10 @@ class Sensei_Course {
 		$post_args = array(	'post_type' 		=> array( 'product', 'product_variation' ),
 							'posts_per_page' 		=> -1,
 							'orderby'         	=> 'title',
-    						'order'           	=> 'DESC',
-    						'exclude' 			=> $post->ID,
-    						'post_status'		=> array( 'publish', 'private', 'draft' ),
-    						'tax_query'			=> array(
+							'order'           	=> 'DESC',
+							'exclude' 			=> $post->ID,
+							'post_status'		=> array( 'publish', 'private', 'draft' ),
+							'tax_query'			=> array(
 								array(
 									'taxonomy'	=> 'product_type',
 									'field'		=> 'slug',
@@ -247,19 +247,19 @@ class Sensei_Course {
 
 						$parent_id = wp_get_post_parent_id( $post_item->ID );
 
-                        if( sensei_check_woocommerce_version( '2.1' ) ) {
+						if( sensei_check_woocommerce_version( '2.1' ) ) {
 							$formatted_variation = wc_get_formatted_variation( Sensei_WC_Utils::get_variation_data( $product_object ), true );
 
 						} else {
-                            // fall back to pre wc 2.1
+							// fall back to pre wc 2.1
 							$formatted_variation = woocommerce_get_formatted_variation( Sensei_WC_Utils::get_variation_data( $product_object ), true );
 
 						}
 
-                        $product_name = ucwords( $formatted_variation );
-                        if ( empty( $product_name ) ) {
-                            $product_name = __( 'Variation #', 'woothemes-sensei' ) . Sensei_WC_Utils::get_product_variation_id( $product_object );
-                        }
+						$product_name = ucwords( $formatted_variation );
+						if ( empty( $product_name ) ) {
+							$product_name = __( 'Variation #', 'woothemes-sensei' ) . Sensei_WC_Utils::get_product_variation_id( $product_object );
+						}
 					} else {
 
 						$parent_id = false;
@@ -310,7 +310,7 @@ class Sensei_Course {
 				if ( !empty( $select_course_woocommerce_product ) ) {
 					$html .= '<input type="hidden" name="course_woocommerce_product" value="'. absint( $select_course_woocommerce_product ) . '">';
 				}
-                $html .= '<p>' . "\n";
+				$html .= '<p>' . "\n";
 					$html .= esc_html( __( 'No products exist yet.', 'woothemes-sensei' ) ) . "\n";
 				$html .= '</p>'."\n";
 
@@ -336,8 +336,8 @@ class Sensei_Course {
 		$post_args = array(	'post_type' 		=> 'course',
 							'posts_per_page' 		=> -1,
 							'orderby'         	=> 'title',
-    						'order'           	=> 'DESC',
-    						'exclude' 			=> $post->ID,
+							'order'           	=> 'DESC',
+							'exclude' 			=> $post->ID,
 							'suppress_filters' 	=> 0
 							);
 		$posts_array = get_posts( $post_args );
@@ -378,10 +378,10 @@ class Sensei_Course {
 
 		$checked = '';
 		if ( isset( $course_featured ) && ( '' != $course_featured ) ) {
-	 	    $checked = checked( 'featured', $course_featured, false );
-	 	} // End If Statement
+			$checked = checked( 'featured', $course_featured, false );
+		} // End If Statement
 
-	 	$html .= '<input type="checkbox" name="course_featured" value="featured" ' . $checked . '>&nbsp;' . __( 'Feature this course', 'woothemes-sensei' ) . '<br>';
+		$html .= '<input type="checkbox" name="course_featured" value="featured" ' . $checked . '>&nbsp;' . __( 'Feature this course', 'woothemes-sensei' ) . '<br>';
 
 		echo $html;
 
@@ -478,8 +478,8 @@ class Sensei_Course {
 			$new_meta_value = ( isset( $_POST[$post_key] ) ? sanitize_html_class( $_POST[$post_key] ) : '' );
 		} // End If Statement
 
-        // update field with the new value
-        return update_post_meta( $post_id, $meta_key, $new_meta_value );
+		// update field with the new value
+		return update_post_meta( $post_id, $meta_key, $new_meta_value );
 
 	} // End save_post_meta()
 
@@ -503,8 +503,8 @@ class Sensei_Course {
 
 		$html = '';
 		$html .= '<input type="hidden" name="' . esc_attr( 'woo_' . $this->token . '_noonce' ) . '" id="'
-                 . esc_attr( 'woo_' . $this->token . '_noonce' )
-                 . '" value="' . esc_attr( wp_create_nonce( plugin_basename(__FILE__) ) ) . '" />';
+				 . esc_attr( 'woo_' . $this->token . '_noonce' )
+				 . '" value="' . esc_attr( wp_create_nonce( plugin_basename(__FILE__) ) ) . '" />';
 
 		$course_id = ( 0 < $post->ID ) ? '&course_id=' . $post->ID : '';
 		$add_lesson_admin_url = admin_url( 'post-new.php?post_type=lesson' . $course_id );
@@ -526,50 +526,50 @@ class Sensei_Course {
 		}
 		$html .= '<p>';
 		if ( 0 === count( $posts_array ) ) {
-		    $html .= esc_html__( 'No lessons exist yet for this course.', 'woothemes-sensei' ) . "\n";
+			$html .= esc_html__( 'No lessons exist yet for this course.', 'woothemes-sensei' ) . "\n";
 		} else {
 			$html .= '<hr />';
-        }
-        $html .= '<a href="' . $add_lesson_admin_url
-            . '" title="' . esc_attr__( 'Add a Lesson', 'woothemes-sensei' ) . '">';
+		}
+		$html .= '<a href="' . $add_lesson_admin_url
+			. '" title="' . esc_attr__( 'Add a Lesson', 'woothemes-sensei' ) . '">';
 		if ( count( $posts_array ) < 1 ) {
 			$html .= esc_html__( 'Please add some.', 'woothemes-sensei' );
 		} else {
 
 			$html .=  esc_html__( '+ Add Another Lesson', 'woothemes-sensei' );
-        }
+		}
 
 
-        $html .= '</a></p>';
+		$html .= '</a></p>';
 
 
 		echo $html;
 
 	} // End course_lessons_meta_box_content()
 
-    /**
-     * course_manage_meta_box_content function.
-     *
-     * @since 1.9.0
-     * @access public
-     * @return void
-     */
+	/**
+	 * course_manage_meta_box_content function.
+	 *
+	 * @since 1.9.0
+	 * @access public
+	 * @return void
+	 */
 
-    public function course_manage_meta_box_content () {
-        global $post;
+	public function course_manage_meta_box_content () {
+		global $post;
 
-        $manage_url = esc_url( add_query_arg( array( 'page' => 'sensei_learners', 'course_id' => $post->ID, 'view' => 'learners' ), admin_url( 'admin.php') ) );
+		$manage_url = esc_url( add_query_arg( array( 'page' => 'sensei_learners', 'course_id' => $post->ID, 'view' => 'learners' ), admin_url( 'admin.php') ) );
 
-        $grading_url = esc_url( add_query_arg( array( 'page' => 'sensei_grading', 'course_id' => $post->ID, 'view' => 'learners' ), admin_url( 'admin.php') ) );
-
-
-        echo "<ul><li><a href='$manage_url'>".__("Manage Learners", 'woothemes-sensei')."</a></li>";
-
-        echo "<li><a href='$grading_url'>".__("Manage Grading", 'woothemes-sensei')."</a></li></ul>";
+		$grading_url = esc_url( add_query_arg( array( 'page' => 'sensei_grading', 'course_id' => $post->ID, 'view' => 'learners' ), admin_url( 'admin.php') ) );
 
 
+		echo "<ul><li><a href='$manage_url'>".__("Manage Learners", 'woothemes-sensei')."</a></li>";
 
-    } // End course_manage_meta_box_content()
+		echo "<li><a href='$grading_url'>".__("Manage Grading", 'woothemes-sensei')."</a></li></ul>";
+
+
+
+	} // End course_manage_meta_box_content()
 
 	/**
 	 * Add column headings to the "lesson" post list screen.
@@ -710,92 +710,92 @@ class Sensei_Course {
 			} // End If Statement
 		} // End If Statement
 
-        $stored_order = get_option( 'sensei_course_order', '' );
-        $order = 'ASC';
-        $orderby = 'menu_order';
-        if( empty( $stored_order ) ){
+		$stored_order = get_option( 'sensei_course_order', '' );
+		$order = 'ASC';
+		$orderby = 'menu_order';
+		if( empty( $stored_order ) ){
 
-            $order = 'DESC';
-            $orderby = 'date';
+			$order = 'DESC';
+			$orderby = 'date';
 
-        }
+		}
 
 		switch ($type) {
 
 			case 'usercourses':
 				$post_args = array(	'post_type' 		=> 'course',
 									'orderby'         	=> $orderby,
-    								'order'           	=> $order,
-    								'post_status'      	=> 'publish',
-    								'include'			=> $includes,
-    								'exclude'			=> $excludes,
-    								'suppress_filters' 	=> 0
+									'order'           	=> $order,
+									'post_status'      	=> 'publish',
+									'include'			=> $includes,
+									'exclude'			=> $excludes,
+									'suppress_filters' 	=> 0
 									);
 				break;
 			case 'freecourses':
 
-                $post_args = array(
-                    'post_type' 		=> 'course',
-                    'orderby'         	=> $orderby,
-                    'order'           	=> $order,
-                    'post_status'      	=> 'publish',
-                    'exclude'			=> $excludes,
-                    'suppress_filters' 	=> 0
-                );
-                // Sub Query to get all WooCommerce Products that have Zero price
-                $post_args['meta_query'] = Sensei_WC::get_free_courses_meta_query_args();
+				$post_args = array(
+					'post_type' 		=> 'course',
+					'orderby'         	=> $orderby,
+					'order'           	=> $order,
+					'post_status'      	=> 'publish',
+					'exclude'			=> $excludes,
+					'suppress_filters' 	=> 0
+				);
+				// Sub Query to get all WooCommerce Products that have Zero price
+				$post_args['meta_query'] = Sensei_WC::get_free_courses_meta_query_args();
 
-                break;
+				break;
 
 			case 'paidcourses':
 
-                $post_args = array(
-                    'post_type' 		=> 'course',
-                    'orderby'         	=> $orderby,
-                    'order'           	=> $order,
-                    'post_status'      	=> 'publish',
-                    'exclude'			=> $excludes,
-                    'suppress_filters' 	=> 0
-                );
+				$post_args = array(
+					'post_type' 		=> 'course',
+					'orderby'         	=> $orderby,
+					'order'           	=> $order,
+					'post_status'      	=> 'publish',
+					'exclude'			=> $excludes,
+					'suppress_filters' 	=> 0
+				);
 
-                // Sub Query to get all WooCommerce Products that have price greater than zero
-                $post_args['meta_query'] = Sensei_WC::get_paid_courses_meta_query_args();
+				// Sub Query to get all WooCommerce Products that have price greater than zero
+				$post_args['meta_query'] = Sensei_WC::get_paid_courses_meta_query_args();
 
 				break;
 
 			case 'featuredcourses':
-                $post_args = array(	'post_type' 		=> 'course',
-                                    'orderby'         	=> $orderby,
-                                    'order'           	=> $order,
-    								'post_status'      	=> 'publish',
-    								'meta_value' 		=> 'featured',
-    								'meta_key' 			=> '_course_featured',
-    								'meta_compare' 		=> '=',
-    								'exclude'			=> $excludes,
-    								'suppress_filters' 	=> 0
+				$post_args = array(	'post_type' 		=> 'course',
+									'orderby'         	=> $orderby,
+									'order'           	=> $order,
+									'post_status'      	=> 'publish',
+									'meta_value' 		=> 'featured',
+									'meta_key' 			=> '_course_featured',
+									'meta_compare' 		=> '=',
+									'exclude'			=> $excludes,
+									'suppress_filters' 	=> 0
 									);
 				break;
 			default:
 				$post_args = array(	'post_type' 		=> 'course',
-                                    'orderby'         	=> $orderby,
-                                    'order'           	=> $order,
-    								'post_status'      	=> 'publish',
-    								'exclude'			=> $excludes,
-    								'suppress_filters' 	=> 0
+									'orderby'         	=> $orderby,
+									'order'           	=> $order,
+									'post_status'      	=> 'publish',
+									'exclude'			=> $excludes,
+									'suppress_filters' 	=> 0
 									);
 				break;
 
 		}
 
-        $post_args['posts_per_page'] = $amount;
-        $paged = $wp_query->get( 'paged' );
-        $post_args['paged'] = empty( $paged) ? 1 : $paged;
+		$post_args['posts_per_page'] = $amount;
+		$paged = $wp_query->get( 'paged' );
+		$post_args['paged'] = empty( $paged) ? 1 : $paged;
 
-        if( 'newcourses' == $type ){
+		if( 'newcourses' == $type ){
 
-            $post_args[ 'orderby' ] = 'date';
-            $post_args[ 'order' ] = 'DESC';
-        }
+			$post_args[ 'orderby' ] = 'date';
+			$post_args[ 'order' ] = 'DESC';
+		}
 
 		return $post_args;
 	}
@@ -805,24 +805,24 @@ class Sensei_Course {
 	 * course_image function.
 	 *
 	 * Outputs the courses image, or first image from a lesson within a course
-     *
-     * Will echo the image unless return true is specified.
+	 *
+	 * Will echo the image unless return true is specified.
 	 *
 	 * @access public
 	 * @param int | WP_Post $course_id (default: 0)
 	 * @param string $width (default: '100')
 	 * @param string $height (default: '100')
-     * @param bool $return default false
-     *
+	 * @param bool $return default false
+	 *
 	 * @return string | void
 	 */
 	public function course_image( $course_id = 0, $width = '100', $height = '100', $return = false ) {
 
-        if ( is_a( $course_id, 'WP_Post' ) ) {
+		if ( is_a( $course_id, 'WP_Post' ) ) {
 
-	        $course_id = $course_id->ID;
+			$course_id = $course_id->ID;
 
-        }
+		}
 
 		if ( 'course' !== get_post_type( $course_id )  ){
 
@@ -862,9 +862,9 @@ class Sensei_Course {
 
 		$img_url = '';
 		if ( has_post_thumbnail( $course_id ) ) {
-   			// Get Featured Image
-   			$img_url = get_the_post_thumbnail( $course_id, array( $width, $height ), array( 'class' => 'woo-image thumbnail alignleft') );
- 		} else {
+			// Get Featured Image
+			$img_url = get_the_post_thumbnail( $course_id, array( $width, $height ), array( 'class' => 'woo-image thumbnail alignleft') );
+		} else {
 
 			// Check for a Lesson Image
 			$course_lessons = $this->course_lessons( $course_id );
@@ -880,16 +880,16 @@ class Sensei_Course {
 				} // End If Statement
 			} // End For Loop
 
- 			if ( '' == $img_url ) {
+			if ( '' == $img_url ) {
 
- 				// Display Image Placeholder if none
+				// Display Image Placeholder if none
 				if ( Sensei()->settings->get( 'placeholder_images_enable' ) ) {
 
-                    $img_url = apply_filters( 'sensei_course_placeholder_image_url', '<img src="http://placehold.it/' . $width . 'x' . $height . '" class="woo-image thumbnail alignleft" />' );
+					$img_url = apply_filters( 'sensei_course_placeholder_image_url', '<img src="http://placehold.it/' . $width . 'x' . $height . '" class="woo-image thumbnail alignleft" />' );
 
 				} // End If Statement
 
- 			} // End If Statement
+			} // End If Statement
 
 		} // End If Statement
 
@@ -899,15 +899,15 @@ class Sensei_Course {
 
 		} // End If Statement
 
-        if( $return ){
+		if( $return ){
 
-            return $html;
+			return $html;
 
-        }else{
+		}else{
 
-            echo $html;
+			echo $html;
 
-        }
+		}
 
 	} // End course_image()
 
@@ -947,9 +947,9 @@ class Sensei_Course {
 	 */
 	public function course_lessons( $course_id = 0, $post_status = 'publish', $fields = 'all' ) {
 
-        if( is_a( $course_id, 'WP_Post' ) ){
-            $course_id = $course_id->ID;
-        }
+		if( is_a( $course_id, 'WP_Post' ) ){
+			$course_id = $course_id->ID;
+		}
 
 		$post_args = array(	'post_type'         => 'lesson',
 							'posts_per_page'       => -1,
@@ -965,67 +965,67 @@ class Sensei_Course {
 							'suppress_filters'  => 0,
 							);
 		$query_results = new WP_Query( $post_args );
-        $lessons = $query_results->posts;
+		$lessons = $query_results->posts;
 
-        // re order the lessons. This could not be done via the OR meta query as there may be lessons
-        // with the course order for a different course and this should not be included. It could also not
-        // be done via the AND meta query as it excludes lesson that does not have the _order_$course_id but
-        // that have been added to the course.
-        if( count( $lessons) > 1  ){
+		// re order the lessons. This could not be done via the OR meta query as there may be lessons
+		// with the course order for a different course and this should not be included. It could also not
+		// be done via the AND meta query as it excludes lesson that does not have the _order_$course_id but
+		// that have been added to the course.
+		if( count( $lessons) > 1  ){
 
-            foreach( $lessons as $lesson ){
+			foreach( $lessons as $lesson ){
 
-                $order = intval( get_post_meta( $lesson->ID, '_order_'. $course_id, true ) );
-                // for lessons with no order set it to be 10000 so that it show up at the end
-                $lesson->course_order = $order ? $order : 100000;
-            }
+				$order = intval( get_post_meta( $lesson->ID, '_order_'. $course_id, true ) );
+				// for lessons with no order set it to be 10000 so that it show up at the end
+				$lesson->course_order = $order ? $order : 100000;
+			}
 
-            uasort( $lessons, array( $this, '_short_course_lessons_callback' )   );
-        }
+			uasort( $lessons, array( $this, '_short_course_lessons_callback' )   );
+		}
 
-        /**
-         * Filter runs inside Sensei_Course::course_lessons function
-         *
-         * Returns all lessons for a given course
-         *
-         * @param array $lessons
-         * @param int $course_id
-         */
-        $lessons = apply_filters( 'sensei_course_get_lessons', $lessons, $course_id  );
+		/**
+		 * Filter runs inside Sensei_Course::course_lessons function
+		 *
+		 * Returns all lessons for a given course
+		 *
+		 * @param array $lessons
+		 * @param int $course_id
+		 */
+		$lessons = apply_filters( 'sensei_course_get_lessons', $lessons, $course_id  );
 
-        //return the requested fields
-        // runs after the sensei_course_get_lessons filter so the filter always give an array of lesson
-        // objects
-        if( 'ids' == $fields ) {
-            $lesson_objects = $lessons;
-            $lessons = array();
+		//return the requested fields
+		// runs after the sensei_course_get_lessons filter so the filter always give an array of lesson
+		// objects
+		if( 'ids' == $fields ) {
+			$lesson_objects = $lessons;
+			$lessons = array();
 
-            foreach ($lesson_objects as $lesson) {
-                $lessons[] = $lesson->ID;
-            }
-        }
+			foreach ($lesson_objects as $lesson) {
+				$lessons[] = $lesson->ID;
+			}
+		}
 
-        return $lessons;
+		return $lessons;
 
 	} // End course_lessons()
 
-    /**
-     * Used for the uasort in $this->course_lessons()
-     * @since 1.8.0
-     * @access protected
-     *
-     * @param array $lesson_1
-     * @param array $lesson_2
-     * @return int
-     */
-    protected function _short_course_lessons_callback( $lesson_1, $lesson_2 ){
+	/**
+	 * Used for the uasort in $this->course_lessons()
+	 * @since 1.8.0
+	 * @access protected
+	 *
+	 * @param array $lesson_1
+	 * @param array $lesson_2
+	 * @return int
+	 */
+	protected function _short_course_lessons_callback( $lesson_1, $lesson_2 ){
 
-        if ( $lesson_1->course_order == $lesson_2->course_order ) {
-            return 0;
-        }
+		if ( $lesson_1->course_order == $lesson_2->course_order ) {
+			return 0;
+		}
 
-        return ($lesson_1->course_order < $lesson_2->course_order) ? -1 : 1;
-    }
+		return ($lesson_1->course_order < $lesson_2->course_order) ? -1 : 1;
+	}
 
 	/**
 	 * Fetch all quiz ids in a course
@@ -1085,15 +1085,15 @@ class Sensei_Course {
 	 */
 	public function course_author_lesson_count( $author_id = 0, $course_id = 0 ) {
 
-        $lesson_args = array(	'post_type' 		=> 'lesson',
+		$lesson_args = array(	'post_type' 		=> 'lesson',
 								'posts_per_page' 		=> -1,
-		    					'author'         	=> $author_id,
-		    					'meta_key'        	=> '_lesson_course',
-    							'meta_value'      	=> $course_id,
-    	    					'post_status'      	=> 'publish',
-    	    					'suppress_filters' 	=> 0,
+								'author'         	=> $author_id,
+								'meta_key'        	=> '_lesson_course',
+								'meta_value'      	=> $course_id,
+								'post_status'      	=> 'publish',
+								'suppress_filters' 	=> 0,
 								'fields'            => 'ids', // less data to retrieve
-		    				);
+							);
 		$lessons_array = get_posts( $lesson_args );
 		$count = count( $lessons_array );
 		return $count;
@@ -1111,17 +1111,17 @@ class Sensei_Course {
 
 		$lesson_args = array(	'post_type' 		=> 'lesson',
 								'posts_per_page' 		=> -1,
-		    					'meta_key'        	=> '_lesson_course',
-    							'meta_value'      	=> $course_id,
-    	    					'post_status'      	=> 'publish',
-    	    					'suppress_filters' 	=> 0,
+								'meta_key'        	=> '_lesson_course',
+								'meta_value'      	=> $course_id,
+								'post_status'      	=> 'publish',
+								'suppress_filters' 	=> 0,
 								'fields'            => 'ids', // less data to retrieve
-		    				);
+							);
 		$lessons_array = get_posts( $lesson_args );
 
-        $count = count( $lessons_array );
+		$count = count( $lessons_array );
 
-        return $count;
+		return $count;
 
 	} // End course_lesson_count()
 
@@ -1136,9 +1136,9 @@ class Sensei_Course {
 
 		$lesson_args = array(	'post_type' 		=> 'lesson',
 								'posts_per_page' 		=> -1,
-    	    					'post_status'      	=> 'publish',
-    	    					'suppress_filters' 	=> 0,
-    	    					'meta_query' => array(
+								'post_status'      	=> 'publish',
+								'suppress_filters' 	=> 0,
+								'meta_query' => array(
 									array(
 										'key' => '_lesson_course',
 										'value' => $course_id
@@ -1149,12 +1149,12 @@ class Sensei_Course {
 									)
 								),
 								'fields'            => 'ids', // less data to retrieve
-		    				);
+							);
 		$lessons_array = get_posts( $lesson_args );
 
 		$count = count( $lessons_array );
 
-        return $count;
+		return $count;
 
 	} // End course_lesson_count()
 
@@ -1222,13 +1222,13 @@ class Sensei_Course {
 	public static function get_product_courses_query_args ( $product_id ) {
 
 		return array(	'post_type' 		=> 'course',
-		                 'posts_per_page' 		=> -1,
-		                 'meta_key'        	=> '_course_woocommerce_product',
-		                 'meta_value'      	=> $product_id,
-		                 'post_status'       => 'publish',
-		                 'suppress_filters' 	=> 0,
-		                 'orderby' 			=> 'menu_order date',
-		                 'order' 			=> 'ASC',
+						 'posts_per_page' 		=> -1,
+						 'meta_key'        	=> '_course_woocommerce_product',
+						 'meta_value'      	=> $product_id,
+						 'post_status'       => 'publish',
+						 'suppress_filters' 	=> 0,
+						 'orderby' 			=> 'menu_order date',
+						 'order' 			=> 'ASC',
 		);
 
 	}
@@ -1254,9 +1254,9 @@ class Sensei_Course {
 
 	/**
 	 * load_user_courses_content generates HTML for user's active & completed courses
-     *
-     * This function also ouputs the html so no need to echo the content.
-     *
+	 *
+	 * This function also ouputs the html so no need to echo the content.
+	 *
 	 * @since  1.4.0
 	 * @param  object  $user   Queried user object
 	 * @param  boolean $manage Whether the user has permission to manage the courses
@@ -1265,17 +1265,17 @@ class Sensei_Course {
 	public function load_user_courses_content( $user = false ) {
 		global $course, $my_courses_page, $my_courses_section;
 
-        if( ! isset( Sensei()->settings->settings[ 'learner_profile_show_courses' ] )
-            || ! Sensei()->settings->settings[ 'learner_profile_show_courses' ] ) {
+		if( ! isset( Sensei()->settings->settings[ 'learner_profile_show_courses' ] )
+			|| ! Sensei()->settings->settings[ 'learner_profile_show_courses' ] ) {
 
-            // do not show the content if the settings doesn't allow for it
-            return;
+			// do not show the content if the settings doesn't allow for it
+			return;
 
-        }
+		}
 
-        $manage = ( $user->ID == get_current_user_id() ) ? true : false;
+		$manage = ( $user->ID == get_current_user_id() ) ? true : false;
 
-        do_action( 'sensei_before_learner_course_content', $user );
+		do_action( 'sensei_before_learner_course_content', $user );
 
 		// Build Output HTML
 		$complete_html = $active_html = '';
@@ -1290,7 +1290,7 @@ class Sensei_Course {
 			// Logic for Active and Completed Courses
 			$per_page = 20;
 			if ( isset( Sensei()->settings->settings[ 'my_course_amount' ] )
-                && ( 0 < absint( Sensei()->settings->settings[ 'my_course_amount' ] ) ) ) {
+				&& ( 0 < absint( Sensei()->settings->settings[ 'my_course_amount' ] ) ) ) {
 
 				$per_page = absint( Sensei()->settings->settings[ 'my_course_amount' ] );
 
@@ -1336,117 +1336,117 @@ class Sensei_Course {
 					}
 				}
 
-			    // Get Course Categories
-			    $category_output = get_the_term_list( $course_item->ID, 'course-category', '', ', ', '' );
+				// Get Course Categories
+				$category_output = get_the_term_list( $course_item->ID, 'course-category', '', ', ', '' );
 
-                $active_html .= '<article class="' . esc_attr( join( ' ', get_post_class( array( 'course', 'post' ), $course_item->ID ) ) ) . '">';
+				$active_html .= '<article class="' . esc_attr( join( ' ', get_post_class( array( 'course', 'post' ), $course_item->ID ) ) ) . '">';
 
-                // Image
-                $active_html .= Sensei()->course->course_image( absint( $course_item->ID ), '100','100', true );
+				// Image
+				$active_html .= Sensei()->course->course_image( absint( $course_item->ID ), '100','100', true );
 
-                // Title
-                $active_html .= '<header>';
+				// Title
+				$active_html .= '<header>';
 
-                $active_html .= '<h2><a href="' . esc_url( get_permalink( absint( $course_item->ID ) ) ) . '" title="' . esc_attr( $course_item->post_title ) . '">' . esc_html( $course_item->post_title ) . '</a></h2>';
+				$active_html .= '<h2><a href="' . esc_url( get_permalink( absint( $course_item->ID ) ) ) . '" title="' . esc_attr( $course_item->post_title ) . '">' . esc_html( $course_item->post_title ) . '</a></h2>';
 
-                $active_html .= '</header>';
+				$active_html .= '</header>';
 
-                $active_html .= '<section class="entry">';
+				$active_html .= '<section class="entry">';
 
-                $active_html .= '<p class="sensei-course-meta">';
+				$active_html .= '<p class="sensei-course-meta">';
 
-                // Author
-                $user_info = get_userdata( absint( $course_item->post_author ) );
-                if ( isset( Sensei()->settings->settings[ 'course_author' ] )
-                    && ( Sensei()->settings->settings[ 'course_author' ] ) ) {
+				// Author
+				$user_info = get_userdata( absint( $course_item->post_author ) );
+				if ( isset( Sensei()->settings->settings[ 'course_author' ] )
+					&& ( Sensei()->settings->settings[ 'course_author' ] ) ) {
 
-                    $active_html .= '<span class="course-author">'
-                        . __( 'by', 'woothemes-sensei' )
-                        . '<a href="' . esc_url( get_author_posts_url( absint( $course_item->post_author ) ) )
-                        . '" title="' . esc_attr( $user_info->display_name ) . '">'
-                        . esc_html( $user_info->display_name )
-                        . '</a></span>';
+					$active_html .= '<span class="course-author">'
+						. __( 'by', 'woothemes-sensei' )
+						. '<a href="' . esc_url( get_author_posts_url( absint( $course_item->post_author ) ) )
+						. '" title="' . esc_attr( $user_info->display_name ) . '">'
+						. esc_html( $user_info->display_name )
+						. '</a></span>';
 
-                } // End If Statement
+				} // End If Statement
 
-                // Lesson count for this author
-                $lesson_count = Sensei()->course->course_lesson_count( absint( $course_item->ID ) );
-                // Handle Division by Zero
-                if ( 0 == $lesson_count ) {
+				// Lesson count for this author
+				$lesson_count = Sensei()->course->course_lesson_count( absint( $course_item->ID ) );
+				// Handle Division by Zero
+				if ( 0 == $lesson_count ) {
 
-                    $lesson_count = 1;
+					$lesson_count = 1;
 
-                } // End If Statement
-                $active_html .= '<span class="course-lesson-count">' . $lesson_count . '&nbsp;' .  __( 'Lessons', 'woothemes-sensei' ) . '</span>';
-                // Course Categories
-                if ( '' != $category_output ) {
+				} // End If Statement
+				$active_html .= '<span class="course-lesson-count">' . $lesson_count . '&nbsp;' .  __( 'Lessons', 'woothemes-sensei' ) . '</span>';
+				// Course Categories
+				if ( '' != $category_output ) {
 
-                    $active_html .= '<span class="course-category">' . sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ) . '</span>';
+					$active_html .= '<span class="course-category">' . sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ) . '</span>';
 
-                } // End If Statement
-                $active_html .= '<span class="course-lesson-progress">' . sprintf( __( '%1$d of %2$d lessons completed', 'woothemes-sensei' ) , $lessons_completed, $lesson_count  ) . '</span>';
+				} // End If Statement
+				$active_html .= '<span class="course-lesson-progress">' . sprintf( __( '%1$d of %2$d lessons completed', 'woothemes-sensei' ) , $lessons_completed, $lesson_count  ) . '</span>';
 
-                $active_html .= '</p>';
+				$active_html .= '</p>';
 
-                $active_html .= '<p class="course-excerpt">' . $course_item->post_excerpt . '</p>';
+				$active_html .= '<p class="course-excerpt">' . $course_item->post_excerpt . '</p>';
 
 
 
-                $progress_percentage = Sensei_Utils::quotient_as_absolute_rounded_percentage( $lessons_completed, $lesson_count, 0 );
+				$progress_percentage = Sensei_Utils::quotient_as_absolute_rounded_percentage( $lessons_completed, $lesson_count, 0 );
 
-                $active_html .= $this->get_progress_meter( $progress_percentage );
+				$active_html .= $this->get_progress_meter( $progress_percentage );
 
-                $active_html .= '</section>';
+				$active_html .= '</section>';
 
-                if( is_user_logged_in() ) {
+				if( is_user_logged_in() ) {
 
-                    $active_html .= '<section class="entry-actions">';
+					$active_html .= '<section class="entry-actions">';
 
-                    $active_html .= '<form method="POST" action="' . esc_url( remove_query_arg( array( 'active_page', 'completed_page' ) ) ) . '">';
+					$active_html .= '<form method="POST" action="' . esc_url( remove_query_arg( array( 'active_page', 'completed_page' ) ) ) . '">';
 
-                    $active_html .= '<input type="hidden" name="' . esc_attr( 'woothemes_sensei_complete_course_noonce' ) . '" id="' . esc_attr( 'woothemes_sensei_complete_course_noonce' ) . '" value="' . esc_attr( wp_create_nonce( 'woothemes_sensei_complete_course_noonce' ) ) . '" />';
+					$active_html .= '<input type="hidden" name="' . esc_attr( 'woothemes_sensei_complete_course_noonce' ) . '" id="' . esc_attr( 'woothemes_sensei_complete_course_noonce' ) . '" value="' . esc_attr( wp_create_nonce( 'woothemes_sensei_complete_course_noonce' ) ) . '" />';
 
-                    $active_html .= '<input type="hidden" name="course_complete_id" id="course-complete-id" value="' . esc_attr( absint( $course_item->ID ) ) . '" />';
+					$active_html .= '<input type="hidden" name="course_complete_id" id="course-complete-id" value="' . esc_attr( absint( $course_item->ID ) ) . '" />';
 
-                    if ( 0 < absint( count( $course_lessons ) )
-                        && Sensei()->settings->settings['course_completion'] == 'complete' ){
+					if ( 0 < absint( count( $course_lessons ) )
+						&& Sensei()->settings->settings['course_completion'] == 'complete' ){
 
-                        $active_html .= '<span><input name="course_complete" type="submit" class="course-complete" value="'
-                            .  __( 'Mark as Complete', 'woothemes-sensei' ) . '"/> </span>';
+						$active_html .= '<span><input name="course_complete" type="submit" class="course-complete" value="'
+							.  __( 'Mark as Complete', 'woothemes-sensei' ) . '"/> </span>';
 
-                    } // End If Statement
+					} // End If Statement
 
-                    $course_purchased = false;
-                    if ( Sensei_WC::is_woocommerce_active() ) {
+					$course_purchased = false;
+					if ( Sensei_WC::is_woocommerce_active() ) {
 
-                        // Get the product ID
-                        $wc_post_id = get_post_meta( absint( $course_item->ID ), '_course_woocommerce_product', true );
-                        if ( 0 < $wc_post_id ) {
+						// Get the product ID
+						$wc_post_id = get_post_meta( absint( $course_item->ID ), '_course_woocommerce_product', true );
+						if ( 0 < $wc_post_id ) {
 
-                            $course_purchased = Sensei_WC::has_customer_bought_product(  $user->ID, $wc_post_id );
+							$course_purchased = Sensei_WC::has_customer_bought_product(  $user->ID, $wc_post_id );
 
-                        } // End If Statement
+						} // End If Statement
 
-                    } // End If Statement
+					} // End If Statement
 
-	                /**
-	                 * documented in class-sensei-course.php the_course_action_buttons function
-	                 */
-	                $show_delete_course_button = apply_filters( 'sensei_show_delete_course_button', false );
+					/**
+					 * documented in class-sensei-course.php the_course_action_buttons function
+					 */
+					$show_delete_course_button = apply_filters( 'sensei_show_delete_course_button', false );
 
-                    if ( false == $course_purchased && $show_delete_course_button ) {
+					if ( false == $course_purchased && $show_delete_course_button ) {
 
-                        $active_html .= '<span><input name="course_complete" type="submit" class="course-delete" value="'
-                            .  __( 'Delete Course', 'woothemes-sensei' ) . '"/></span>';
+						$active_html .= '<span><input name="course_complete" type="submit" class="course-delete" value="'
+							.  __( 'Delete Course', 'woothemes-sensei' ) . '"/></span>';
 
-                    } // End If Statement
+					} // End If Statement
 
-                    $active_html .= '</form>';
+					$active_html .= '</form>';
 
-                    $active_html .= '</section>';
-                }
+					$active_html .= '</section>';
+				}
 
-                $active_html .= '</article>';
+				$active_html .= '</article>';
 			}
 
 			// Active pagination
@@ -1486,49 +1486,49 @@ class Sensei_Course {
 			foreach ( $completed_courses as $course_item ) {
 				$course = $course_item;
 
-			    // Get Course Categories
-			    $category_output = get_the_term_list( $course_item->ID, 'course-category', '', ', ', '' );
+				// Get Course Categories
+				$category_output = get_the_term_list( $course_item->ID, 'course-category', '', ', ', '' );
 
-		    	$complete_html .= '<article class="' . join( ' ', get_post_class( array( 'course', 'post' ), $course_item->ID ) ) . '">';
+				$complete_html .= '<article class="' . join( ' ', get_post_class( array( 'course', 'post' ), $course_item->ID ) ) . '">';
 
-		    	    // Image
-		    		$complete_html .= Sensei()->course->course_image( absint( $course_item->ID ),100, 100, true );
+					// Image
+					$complete_html .= Sensei()->course->course_image( absint( $course_item->ID ),100, 100, true );
 
-		    		// Title
-		    		$complete_html .= '<header>';
+					// Title
+					$complete_html .= '<header>';
 
-		    		    $complete_html .= '<h2><a href="' . esc_url( get_permalink( absint( $course_item->ID ) ) ) . '" title="' . esc_attr( $course_item->post_title ) . '">' . esc_html( $course_item->post_title ) . '</a></h2>';
+						$complete_html .= '<h2><a href="' . esc_url( get_permalink( absint( $course_item->ID ) ) ) . '" title="' . esc_attr( $course_item->post_title ) . '">' . esc_html( $course_item->post_title ) . '</a></h2>';
 
-		    		$complete_html .= '</header>';
+					$complete_html .= '</header>';
 
-		    		$complete_html .= '<section class="entry">';
+					$complete_html .= '<section class="entry">';
 
-		    			$complete_html .= '<p class="sensei-course-meta">';
+						$complete_html .= '<p class="sensei-course-meta">';
 
-		    		    	// Author
-		    		    	$user_info = get_userdata( absint( $course_item->post_author ) );
-		    		    	if ( isset( Sensei()->settings->settings[ 'course_author' ] ) && ( Sensei()->settings->settings[ 'course_author' ] ) ) {
-		    		    		$complete_html .= '<span class="course-author">' . __( 'by', 'woothemes-sensei' ) . '<a href="' . esc_url( get_author_posts_url( absint( $course_item->post_author ) ) ) . '" title="' . esc_attr( $user_info->display_name ) . '">' . esc_html( $user_info->display_name ) . '</a></span>';
-		    		    	} // End If Statement
+							// Author
+							$user_info = get_userdata( absint( $course_item->post_author ) );
+							if ( isset( Sensei()->settings->settings[ 'course_author' ] ) && ( Sensei()->settings->settings[ 'course_author' ] ) ) {
+								$complete_html .= '<span class="course-author">' . __( 'by', 'woothemes-sensei' ) . '<a href="' . esc_url( get_author_posts_url( absint( $course_item->post_author ) ) ) . '" title="' . esc_attr( $user_info->display_name ) . '">' . esc_html( $user_info->display_name ) . '</a></span>';
+							} // End If Statement
 
-		    		    	// Lesson count for this author
-		    		    	$complete_html .= '<span class="course-lesson-count">'
-                                . Sensei()->course->course_lesson_count( absint( $course_item->ID ) )
-                                . '&nbsp;' .  __( 'Lessons', 'woothemes-sensei' )
-                                . '</span>';
+							// Lesson count for this author
+							$complete_html .= '<span class="course-lesson-count">'
+								. Sensei()->course->course_lesson_count( absint( $course_item->ID ) )
+								. '&nbsp;' .  __( 'Lessons', 'woothemes-sensei' )
+								. '</span>';
 
-		    		    	// Course Categories
-		    		    	if ( '' != $category_output ) {
+							// Course Categories
+							if ( '' != $category_output ) {
 
-		    		    		$complete_html .= '<span class="course-category">' . sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ) . '</span>';
+								$complete_html .= '<span class="course-category">' . sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ) . '</span>';
 
-		    		    	} // End If Statement
+							} // End If Statement
 
 						$complete_html .= '</p>';
 
 						$complete_html .= '<p class="course-excerpt">' . $course_item->post_excerpt . '</p>';
 
-                        $complete_html .= $this->get_progress_meter( 100 );
+						$complete_html .= $this->get_progress_meter( 100 );
 
 						if( $manage ) {
 							$has_quizzes = Sensei()->course->course_quizzes( $course_item->ID, true );
@@ -1541,22 +1541,22 @@ class Sensei_Course {
 								if( $has_quizzes ) {
 
 									$results_link = '<a class="button view-results" href="'
-                                        . Sensei()->course_results->get_permalink( $course_item->ID )
-                                        . '">' . __( 'View results', 'woothemes-sensei' )
-                                        . '</a>';
+										. Sensei()->course_results->get_permalink( $course_item->ID )
+										. '">' . __( 'View results', 'woothemes-sensei' )
+										. '</a>';
 								}
-                                /**
-                                 * Filter documented in Sensei_Course::the_course_action_buttons
-                                 */
+								/**
+								 * Filter documented in Sensei_Course::the_course_action_buttons
+								 */
 								$complete_html .= apply_filters( 'sensei_results_links', $results_link, $course_item->ID );
 								$complete_html .= '</p>';
 
 							}
 						}
 
-		    		$complete_html .= '</section>';
+					$complete_html .= '</section>';
 
-		    	$complete_html .= '</article>';
+				$complete_html .= '</article>';
 			}
 
 			// Active pagination
@@ -1613,1157 +1613,1157 @@ class Sensei_Course {
 		if( $manage && ( ! isset( Sensei()->settings->settings['messages_disable'] ) || ! Sensei()->settings->settings['messages_disable'] ) ) {
 			?>
 			<p class="my-messages-link-container">
-                <a class="my-messages-link" href="<?php echo get_post_type_archive_link( 'sensei_message' ); ?>"
-                   title="<?php _e( 'View & reply to private messages sent to your course & lesson teachers.', 'woothemes-sensei' ); ?>">
-                    <?php _e( 'My Messages', 'woothemes-sensei' ); ?>
-                </a>
-            </p>
+				<a class="my-messages-link" href="<?php echo get_post_type_archive_link( 'sensei_message' ); ?>"
+				   title="<?php _e( 'View & reply to private messages sent to your course & lesson teachers.', 'woothemes-sensei' ); ?>">
+					<?php _e( 'My Messages', 'woothemes-sensei' ); ?>
+				</a>
+			</p>
 			<?php
 		}
 		?>
 		<div id="my-courses">
 
-		    <ul>
-		    	<li><a href="#active-courses"><?php  _e( 'Active Courses', 'woothemes-sensei' ); ?></a></li>
-		    	<li><a href="#completed-courses"><?php  _e( 'Completed Courses', 'woothemes-sensei' ); ?></a></li>
-		    </ul>
+			<ul>
+				<li><a href="#active-courses"><?php  _e( 'Active Courses', 'woothemes-sensei' ); ?></a></li>
+				<li><a href="#completed-courses"><?php  _e( 'Completed Courses', 'woothemes-sensei' ); ?></a></li>
+			</ul>
 
-		    <?php do_action( 'sensei_before_active_user_courses' ); ?>
+			<?php do_action( 'sensei_before_active_user_courses' ); ?>
 
-		    <?php
-            $course_page_url = Sensei_Course::get_courses_page_url();
-            ?>
+			<?php
+			$course_page_url = Sensei_Course::get_courses_page_url();
+			?>
 
-		    <div id="active-courses">
+			<div id="active-courses">
 
-		    	<?php if ( '' != $active_html ) {
+				<?php if ( '' != $active_html ) {
 
-		    		echo $active_html;
+					echo $active_html;
 
-		    	} else { ?>
+				} else { ?>
 
-		    		<div class="sensei-message info">
+					<div class="sensei-message info">
 
-                        <?php echo $no_active_message; ?>
+						<?php echo $no_active_message; ?>
 
-                        <a href="<?php echo $course_page_url; ?>">
+						<a href="<?php echo $course_page_url; ?>">
 
-                            <?php  _e( 'Start a Course!', 'woothemes-sensei' ); ?>
+							<?php  _e( 'Start a Course!', 'woothemes-sensei' ); ?>
 
-                        </a>
+						</a>
 
-                    </div>
+					</div>
 
-		    	<?php } // End If Statement ?>
+				<?php } // End If Statement ?>
 
-		    </div>
+			</div>
 
-		    <?php do_action( 'sensei_after_active_user_courses' ); ?>
+			<?php do_action( 'sensei_after_active_user_courses' ); ?>
 
-		    <?php do_action( 'sensei_before_completed_user_courses' ); ?>
+			<?php do_action( 'sensei_before_completed_user_courses' ); ?>
 
-		    <div id="completed-courses">
+			<div id="completed-courses">
 
-		    	<?php if ( '' != $complete_html ) {
+				<?php if ( '' != $complete_html ) {
 
-		    		echo $complete_html;
+					echo $complete_html;
 
-		    	} else { ?>
+				} else { ?>
 
-		    		<div class="sensei-message info">
+					<div class="sensei-message info">
 
-                        <?php echo $no_complete_message; ?>
+						<?php echo $no_complete_message; ?>
 
-                    </div>
+					</div>
 
-		    	<?php } // End If Statement ?>
+				<?php } // End If Statement ?>
 
-		    </div>
+			</div>
 
-		    <?php do_action( 'sensei_after_completed_user_courses' ); ?>
+			<?php do_action( 'sensei_after_completed_user_courses' ); ?>
 
 		</div>
 
 		<?php do_action( 'sensei_after_user_courses' ); ?>
 
 		<?php
-        echo ob_get_clean();
+		echo ob_get_clean();
 
-        do_action( 'sensei_after_learner_course_content', $user );
+		do_action( 'sensei_after_learner_course_content', $user );
 
 	} // end load_user_courses_content
 
-    /**
-     * Returns a list of all courses
-     *
-     * @since 1.8.0
-     * @return array $courses{
-     *  @type $course WP_Post
-     * }
-     */
-    public static function get_all_courses(){
-
-        $args = array(
-               'post_type' => 'course',
-                'posts_per_page' 		=> -1,
-                'orderby'         	=> 'title',
-                'order'           	=> 'ASC',
-                'post_status'      	=> 'any',
-                'suppress_filters' 	=> 0,
-        );
-
-        $wp_query_obj =  new WP_Query( $args );
-
-        /**
-         * sensei_get_all_courses filter
-         *
-         * This filter runs inside Sensei_Course::get_all_courses.
-         *
-         * @param array $courses{
-         *  @type WP_Post
-         * }
-         * @param array $attributes
-         */
-        return apply_filters( 'sensei_get_all_courses' , $wp_query_obj->posts );
-
-    }// end get_all_courses
-
-    /**
-     * Generate the course meter component
-     *
-     * @since 1.8.0
-     * @param int $progress_percentage 0 - 100
-     * @return string $progress_bar_html
-     */
-    public function get_progress_meter( $progress_percentage ){
-
-        if ( 50 < $progress_percentage ) {
-            $class = ' green';
-        } elseif ( 25 <= $progress_percentage && 50 >= $progress_percentage ) {
-            $class = ' orange';
-        } else {
-            $class = ' red';
-        }
-        $progress_bar_html = '<div class="meter' . esc_attr( $class ) . '"><span style="width: ' . $progress_percentage . '%">' . round( $progress_percentage ) . '%</span></div>';
-
-        return $progress_bar_html;
-
-    }// end get_progress_meter
-
-    /**
-     * Generate a statement that tells users
-     * how far they are in the course.
-     *
-     * @param int $course_id
-     * @param int $user_id
-     *
-     * @return string $statement_html
-     */
-    public function get_progress_statement( $course_id, $user_id ){
-
-        if( empty( $course_id ) || empty( $user_id )
-        || ! Sensei_Utils::user_started_course( $course_id, $user_id ) ){
-            return '';
-        }
-
-        $completed = count( $this->get_completed_lesson_ids( $course_id, $user_id ) );
-        $total_lessons = count( $this->course_lessons( $course_id ) );
-
-        $statement = sprintf( _n('Currently completed %s lesson of %s in total', 'Currently completed %s lessons of %s in total', $completed, 'woothemes-sensei'), $completed, $total_lessons );
-
-        /**
-         * Filter the course completion statement.
-         * Default Currently completed $var lesson($plural) of $var in total
-         *
-         * @param string $statement
-         */
-        return apply_filters( 'sensei_course_completion_statement', $statement );
-
-    }// end generate_progress_statement
-
-    /**
-     * Output the course progress statement
-     *
-     * @param $course_id
-     * @return void
-     */
-    public function the_progress_statement( $course_id = 0, $user_id = 0 ){
-        if( empty( $course_id ) ){
-            global $post;
-            $course_id = $post->ID;
-        }
-
-        if( empty( $user_id ) ){
-            $user_id = get_current_user_id();
-        }
-
-	    $progress_statement = $this->get_progress_statement( $course_id, $user_id  );
-	    if( ! empty( $progress_statement ) ){
-
-		    echo '<span class="progress statement  course-completion-rate">' . $progress_statement . '</span>';
-
-	    }
-
-    }
-
-    /**
-     * Output the course progress bar
-     *
-     * @param $course_id
-     * @return void
-     */
-    public function the_progress_meter( $course_id = 0, $user_id = 0 ){
-
-        if( empty( $course_id ) ){
-            global $post;
-            $course_id = $post->ID;
-        }
-
-        if( empty( $user_id ) ){
-            $user_id = get_current_user_id();
-        }
-
-        if( 'course' != get_post_type( $course_id ) || ! get_userdata( $user_id )
-            || ! Sensei_Utils::user_started_course( $course_id ,$user_id ) ){
-            return;
-        }
-        $percentage_completed = $this->get_completion_percentage( $course_id, $user_id );
+	/**
+	 * Returns a list of all courses
+	 *
+	 * @since 1.8.0
+	 * @return array $courses{
+	 *  @type $course WP_Post
+	 * }
+	 */
+	public static function get_all_courses(){
+
+		$args = array(
+			   'post_type' => 'course',
+				'posts_per_page' 		=> -1,
+				'orderby'         	=> 'title',
+				'order'           	=> 'ASC',
+				'post_status'      	=> 'any',
+				'suppress_filters' 	=> 0,
+		);
+
+		$wp_query_obj =  new WP_Query( $args );
+
+		/**
+		 * sensei_get_all_courses filter
+		 *
+		 * This filter runs inside Sensei_Course::get_all_courses.
+		 *
+		 * @param array $courses{
+		 *  @type WP_Post
+		 * }
+		 * @param array $attributes
+		 */
+		return apply_filters( 'sensei_get_all_courses' , $wp_query_obj->posts );
+
+	}// end get_all_courses
+
+	/**
+	 * Generate the course meter component
+	 *
+	 * @since 1.8.0
+	 * @param int $progress_percentage 0 - 100
+	 * @return string $progress_bar_html
+	 */
+	public function get_progress_meter( $progress_percentage ){
+
+		if ( 50 < $progress_percentage ) {
+			$class = ' green';
+		} elseif ( 25 <= $progress_percentage && 50 >= $progress_percentage ) {
+			$class = ' orange';
+		} else {
+			$class = ' red';
+		}
+		$progress_bar_html = '<div class="meter' . esc_attr( $class ) . '"><span style="width: ' . $progress_percentage . '%">' . round( $progress_percentage ) . '%</span></div>';
+
+		return $progress_bar_html;
+
+	}// end get_progress_meter
+
+	/**
+	 * Generate a statement that tells users
+	 * how far they are in the course.
+	 *
+	 * @param int $course_id
+	 * @param int $user_id
+	 *
+	 * @return string $statement_html
+	 */
+	public function get_progress_statement( $course_id, $user_id ){
+
+		if( empty( $course_id ) || empty( $user_id )
+		|| ! Sensei_Utils::user_started_course( $course_id, $user_id ) ){
+			return '';
+		}
+
+		$completed = count( $this->get_completed_lesson_ids( $course_id, $user_id ) );
+		$total_lessons = count( $this->course_lessons( $course_id ) );
+
+		$statement = sprintf( _n('Currently completed %s lesson of %s in total', 'Currently completed %s lessons of %s in total', $completed, 'woothemes-sensei'), $completed, $total_lessons );
+
+		/**
+		 * Filter the course completion statement.
+		 * Default Currently completed $var lesson($plural) of $var in total
+		 *
+		 * @param string $statement
+		 */
+		return apply_filters( 'sensei_course_completion_statement', $statement );
+
+	}// end generate_progress_statement
+
+	/**
+	 * Output the course progress statement
+	 *
+	 * @param $course_id
+	 * @return void
+	 */
+	public function the_progress_statement( $course_id = 0, $user_id = 0 ){
+		if( empty( $course_id ) ){
+			global $post;
+			$course_id = $post->ID;
+		}
+
+		if( empty( $user_id ) ){
+			$user_id = get_current_user_id();
+		}
+
+		$progress_statement = $this->get_progress_statement( $course_id, $user_id  );
+		if( ! empty( $progress_statement ) ){
+
+			echo '<span class="progress statement  course-completion-rate">' . $progress_statement . '</span>';
+
+		}
+
+	}
+
+	/**
+	 * Output the course progress bar
+	 *
+	 * @param $course_id
+	 * @return void
+	 */
+	public function the_progress_meter( $course_id = 0, $user_id = 0 ){
+
+		if( empty( $course_id ) ){
+			global $post;
+			$course_id = $post->ID;
+		}
+
+		if( empty( $user_id ) ){
+			$user_id = get_current_user_id();
+		}
+
+		if( 'course' != get_post_type( $course_id ) || ! get_userdata( $user_id )
+			|| ! Sensei_Utils::user_started_course( $course_id ,$user_id ) ){
+			return;
+		}
+		$percentage_completed = $this->get_completion_percentage( $course_id, $user_id );
 
-        echo $this->get_progress_meter( $percentage_completed );
+		echo $this->get_progress_meter( $percentage_completed );
 
-    }// end the_progress_meter
+	}// end the_progress_meter
 
-    /**
-     * Checks how many lessons are completed
-     *
-     * @since 1.8.0
-     *
-     * @param int $course_id
-     * @param int $user_id
-     * @return array $completed_lesson_ids
-     */
-    public function get_completed_lesson_ids( $course_id, $user_id = 0 ){
+	/**
+	 * Checks how many lessons are completed
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param int $course_id
+	 * @param int $user_id
+	 * @return array $completed_lesson_ids
+	 */
+	public function get_completed_lesson_ids( $course_id, $user_id = 0 ){
 
-        if( !( intval( $user_id ) ) > 0 ){
-            $user_id = get_current_user_id();
-        }
+		if( !( intval( $user_id ) ) > 0 ){
+			$user_id = get_current_user_id();
+		}
 
-        $completed_lesson_ids = array();
+		$completed_lesson_ids = array();
 
-        $course_lessons = $this->course_lessons( $course_id );
+		$course_lessons = $this->course_lessons( $course_id );
 
-        foreach( $course_lessons as $lesson ){
+		foreach( $course_lessons as $lesson ){
 
-            $is_lesson_completed = Sensei_Utils::user_completed_lesson( $lesson->ID, $user_id );
-            if( $is_lesson_completed ){
-                $completed_lesson_ids[] = $lesson->ID;
-            }
+			$is_lesson_completed = Sensei_Utils::user_completed_lesson( $lesson->ID, $user_id );
+			if( $is_lesson_completed ){
+				$completed_lesson_ids[] = $lesson->ID;
+			}
 
-        }
+		}
 
-        return $completed_lesson_ids;
+		return $completed_lesson_ids;
 
-    }// end get_completed_lesson_ids
+	}// end get_completed_lesson_ids
 
-    /**
-     * Calculate the perceantage completed in the course
-     *
-     * @since 1.8.0
-     *
-     * @param int $course_id
-     * @param int $user_id
-     * @return int $percentage
-     */
-    public function get_completion_percentage( $course_id, $user_id = 0 ){
+	/**
+	 * Calculate the perceantage completed in the course
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param int $course_id
+	 * @param int $user_id
+	 * @return int $percentage
+	 */
+	public function get_completion_percentage( $course_id, $user_id = 0 ){
 
-        if( !( intval( $user_id ) ) > 0 ){
-            $user_id = get_current_user_id();
-        }
+		if( !( intval( $user_id ) ) > 0 ){
+			$user_id = get_current_user_id();
+		}
 
-        $completed = count( $this->get_completed_lesson_ids( $course_id, $user_id ) );
+		$completed = count( $this->get_completed_lesson_ids( $course_id, $user_id ) );
 
-        if( ! (  $completed  > 0 ) ){
-            return 0;
-        }
+		if( ! (  $completed  > 0 ) ){
+			return 0;
+		}
 
-        $total_lessons = count( $this->course_lessons( $course_id ) );
-        $percentage = Sensei_Utils::quotient_as_absolute_rounded_percentage( $completed, $total_lessons, 2 );
+		$total_lessons = count( $this->course_lessons( $course_id ) );
+		$percentage = Sensei_Utils::quotient_as_absolute_rounded_percentage( $completed, $total_lessons, 2 );
 
-        /**
-         *
-         * Filter the percentage returned for a users course.
-         *
-         * @param $percentage
-         * @param $course_id
-         * @param $user_id
-         * @since 1.8.0
-         */
-        return apply_filters( 'sensei_course_completion_percentage', $percentage, $course_id, $user_id );
+		/**
+		 *
+		 * Filter the percentage returned for a users course.
+		 *
+		 * @param $percentage
+		 * @param $course_id
+		 * @param $user_id
+		 * @since 1.8.0
+		 */
+		return apply_filters( 'sensei_course_completion_percentage', $percentage, $course_id, $user_id );
 
-    }// end get_completed_lesson_ids
+	}// end get_completed_lesson_ids
 
-    /**
-     * Block email notifications for the specific courses
-     * that the user disabled the notifications.
-     *
-     * @since 1.8.0
-     * @param $should_send
-     * @return bool
-     */
-    public function block_notification_emails( $should_send ){
-        global $sensei_email_data;
-        $email = $sensei_email_data;
+	/**
+	 * Block email notifications for the specific courses
+	 * that the user disabled the notifications.
+	 *
+	 * @since 1.8.0
+	 * @param $should_send
+	 * @return bool
+	 */
+	public function block_notification_emails( $should_send ){
+		global $sensei_email_data;
+		$email = $sensei_email_data;
 
-        $course_id = '';
+		$course_id = '';
 
-        if( isset( $email['course_id'] ) ){
+		if( isset( $email['course_id'] ) ){
 
-            $course_id = $email['course_id'];
-
-        }elseif( isset( $email['lesson_id'] ) ){
+			$course_id = $email['course_id'];
+
+		}elseif( isset( $email['lesson_id'] ) ){
 
-            $course_id = Sensei()->lesson->get_course_id( $email['lesson_id'] );
-
-        }elseif( isset( $email['quiz_id'] ) ){
+			$course_id = Sensei()->lesson->get_course_id( $email['lesson_id'] );
+
+		}elseif( isset( $email['quiz_id'] ) ){
 
-            $lesson_id = Sensei()->quiz->get_lesson_id( $email['quiz_id'] );
-            $course_id = Sensei()->lesson->get_course_id( $lesson_id );
+			$lesson_id = Sensei()->quiz->get_lesson_id( $email['quiz_id'] );
+			$course_id = Sensei()->lesson->get_course_id( $lesson_id );
 
-        }
-
-        if( !empty( $course_id ) && 'course'== get_post_type( $course_id ) ) {
-
-            $course_emails_disabled = get_post_meta($course_id, 'disable_notification', true);
-
-            if ($course_emails_disabled) {
-
-                return false;
-
-            }
-
-        }// end if
-
-        return $should_send;
-    }// end block_notification_emails
-
-    /**
-     * Render the course notification setting meta box
-     *
-     * @since 1.8.0
-     * @param $course
-     */
-    public function course_notification_meta_box_content( $course ){
-
-        $checked = get_post_meta( $course->ID , 'disable_notification', true );
-
-        // generate checked html
-        $checked_html = '';
-        if( $checked ){
-            $checked_html = 'checked="checked"';
-        }
-        wp_nonce_field( 'update-course-notification-setting','_sensei_course_notification' );
-
-        echo '<input id="disable_sensei_course_notification" '.$checked_html .' type="checkbox" name="disable_sensei_course_notification" >';
-        echo '<label for="disable_sensei_course_notification">'.__('Disable notifications on this course ?', 'woothemes-sensei'). '</label>';
-
-    }// end course_notification_meta_box_content
-
-    /**
-     * Store the setting for the course notification setting.
-     *
-     * @hooked int save_post
-     * @since 1.8.0
-     *
-     * @param $course_id
-     */
-    public function save_course_notification_meta_box( $course_id ){
-
-        if( !isset( $_POST['_sensei_course_notification']  )
-            || ! wp_verify_nonce( $_POST['_sensei_course_notification'], 'update-course-notification-setting' ) ){
-            return;
-        }
-
-        if( isset( $_POST['disable_sensei_course_notification'] ) && 'on'== $_POST['disable_sensei_course_notification']  ) {
-            $new_val = true;
-        }else{
-            $new_val = false;
-        }
-
-       update_post_meta( $course_id , 'disable_notification', $new_val );
-
-    }// end save notification meta box
-
-    /**
-     * Backwards compatibility hooks added to ensure that
-     * plugins and other parts of sensei still works.
-     *
-     * This function hooks into `sensei_course_content_inside_before`
-     *
-     * @since 1.9
-     *
-     * @param WP_Post $post
-     */
-    public function content_before_backwards_compatibility_hooks( $post_id ){
+		}
+
+		if( !empty( $course_id ) && 'course'== get_post_type( $course_id ) ) {
+
+			$course_emails_disabled = get_post_meta($course_id, 'disable_notification', true);
+
+			if ($course_emails_disabled) {
+
+				return false;
+
+			}
+
+		}// end if
+
+		return $should_send;
+	}// end block_notification_emails
+
+	/**
+	 * Render the course notification setting meta box
+	 *
+	 * @since 1.8.0
+	 * @param $course
+	 */
+	public function course_notification_meta_box_content( $course ){
+
+		$checked = get_post_meta( $course->ID , 'disable_notification', true );
+
+		// generate checked html
+		$checked_html = '';
+		if( $checked ){
+			$checked_html = 'checked="checked"';
+		}
+		wp_nonce_field( 'update-course-notification-setting','_sensei_course_notification' );
+
+		echo '<input id="disable_sensei_course_notification" '.$checked_html .' type="checkbox" name="disable_sensei_course_notification" >';
+		echo '<label for="disable_sensei_course_notification">'.__('Disable notifications on this course ?', 'woothemes-sensei'). '</label>';
+
+	}// end course_notification_meta_box_content
+
+	/**
+	 * Store the setting for the course notification setting.
+	 *
+	 * @hooked int save_post
+	 * @since 1.8.0
+	 *
+	 * @param $course_id
+	 */
+	public function save_course_notification_meta_box( $course_id ){
+
+		if( !isset( $_POST['_sensei_course_notification']  )
+			|| ! wp_verify_nonce( $_POST['_sensei_course_notification'], 'update-course-notification-setting' ) ){
+			return;
+		}
+
+		if( isset( $_POST['disable_sensei_course_notification'] ) && 'on'== $_POST['disable_sensei_course_notification']  ) {
+			$new_val = true;
+		}else{
+			$new_val = false;
+		}
+
+	   update_post_meta( $course_id , 'disable_notification', $new_val );
+
+	}// end save notification meta box
+
+	/**
+	 * Backwards compatibility hooks added to ensure that
+	 * plugins and other parts of sensei still works.
+	 *
+	 * This function hooks into `sensei_course_content_inside_before`
+	 *
+	 * @since 1.9
+	 *
+	 * @param WP_Post $post
+	 */
+	public function content_before_backwards_compatibility_hooks( $post_id ){
 
-        sensei_do_deprecated_action( 'sensei_course_image','1.9.0','sensei_course_content_inside_before' );
-        sensei_do_deprecated_action( 'sensei_course_archive_course_title','1.9.0','sensei_course_content_inside_before' );
-
-    }
-
-    /**
-     * Backwards compatibility hooks that should be hooked into sensei_loop_course_before
-     *
-     * hooked into 'sensei_loop_course_before'
-     *
-     * @since 1.9
-     *
-     * @global WP_Post $post
-     */
-    public  function loop_before_backwards_compatibility_hooks( ){
+		sensei_do_deprecated_action( 'sensei_course_image','1.9.0','sensei_course_content_inside_before' );
+		sensei_do_deprecated_action( 'sensei_course_archive_course_title','1.9.0','sensei_course_content_inside_before' );
+
+	}
+
+	/**
+	 * Backwards compatibility hooks that should be hooked into sensei_loop_course_before
+	 *
+	 * hooked into 'sensei_loop_course_before'
+	 *
+	 * @since 1.9
+	 *
+	 * @global WP_Post $post
+	 */
+	public  function loop_before_backwards_compatibility_hooks( ){
 
-        global $post;
-        sensei_do_deprecated_action( 'sensei_course_archive_header','1.9.0','sensei_course_content_inside_before', $post->post_type  );
+		global $post;
+		sensei_do_deprecated_action( 'sensei_course_archive_header','1.9.0','sensei_course_content_inside_before', $post->post_type  );
 
-    }
+	}
 
-    /**
-     * Output a link to view course. The button text is different depending on the amount of preview lesson available.
-     *
-     * hooked into 'sensei_course_content_inside_after'
-     *
-     * @since 1.9.0
-     *
-     * @param integer $course_id
-     */
-    public function the_course_free_lesson_preview( $course_id ){
-        // Meta data
-        $course = get_post( $course_id );
-        $preview_lesson_count = intval( Sensei()->course->course_lesson_preview_count( $course->ID ) );
-        $is_user_taking_course = Sensei_Utils::user_started_course( $course->ID, get_current_user_id() );
+	/**
+	 * Output a link to view course. The button text is different depending on the amount of preview lesson available.
+	 *
+	 * hooked into 'sensei_course_content_inside_after'
+	 *
+	 * @since 1.9.0
+	 *
+	 * @param integer $course_id
+	 */
+	public function the_course_free_lesson_preview( $course_id ){
+		// Meta data
+		$course = get_post( $course_id );
+		$preview_lesson_count = intval( Sensei()->course->course_lesson_preview_count( $course->ID ) );
+		$is_user_taking_course = Sensei_Utils::user_started_course( $course->ID, get_current_user_id() );
 
-        if ( 0 < $preview_lesson_count && !$is_user_taking_course ) {
-            ?>
-            <p class="sensei-free-lessons">
-                <a href="<?php echo get_permalink(); ?>">
-                    <?php _e( 'Preview this course', 'woothemes-sensei' ) ?>
-                </a>
-                - <?php echo sprintf( __( '(%d preview lessons)', 'woothemes-sensei' ), $preview_lesson_count ) ; ?>
-            </p>
+		if ( 0 < $preview_lesson_count && !$is_user_taking_course ) {
+			?>
+			<p class="sensei-free-lessons">
+				<a href="<?php echo get_permalink(); ?>">
+					<?php _e( 'Preview this course', 'woothemes-sensei' ) ?>
+				</a>
+				- <?php echo sprintf( __( '(%d preview lessons)', 'woothemes-sensei' ), $preview_lesson_count ) ; ?>
+			</p>
 
-        <?php
-        }
-    }
+		<?php
+		}
+	}
 
-    /**
-     * Add course mata to the course meta hook
-     *
-     * @since 1.9.0
-     * @param integer $course_id
-     */
-    public function the_course_meta( $course_id ){
-        echo '<p class="sensei-course-meta">';
+	/**
+	 * Add course mata to the course meta hook
+	 *
+	 * @since 1.9.0
+	 * @param integer $course_id
+	 */
+	public function the_course_meta( $course_id ){
+		echo '<p class="sensei-course-meta">';
 
-        $course = get_post( $course_id );
-        $category_output = get_the_term_list( $course->ID, 'course-category', '', ', ', '' );
-        $author_display_name = get_the_author_meta( 'display_name', $course->post_author  );
+		$course = get_post( $course_id );
+		$category_output = get_the_term_list( $course->ID, 'course-category', '', ', ', '' );
+		$author_display_name = get_the_author_meta( 'display_name', $course->post_author  );
 
-        if ( isset( Sensei()->settings->settings[ 'course_author' ] ) && ( Sensei()->settings->settings[ 'course_author' ] ) ) {?>
+		if ( isset( Sensei()->settings->settings[ 'course_author' ] ) && ( Sensei()->settings->settings[ 'course_author' ] ) ) {?>
 
-            <span class="course-author"><?php _e( 'by', 'woothemes-sensei' ); ?>
+			<span class="course-author"><?php _e( 'by', 'woothemes-sensei' ); ?>
 
-                <a href="<?php echo esc_attr( get_author_posts_url( $course->post_author ) ); ?>" title="<?php echo esc_attr( $author_display_name ); ?>"><?php echo esc_attr( $author_display_name ); ?></a>
+				<a href="<?php echo esc_attr( get_author_posts_url( $course->post_author ) ); ?>" title="<?php echo esc_attr( $author_display_name ); ?>"><?php echo esc_attr( $author_display_name ); ?></a>
 
-            </span>
+			</span>
 
-        <?php } // End If Statement ?>
+		<?php } // End If Statement ?>
 
-        <span class="course-lesson-count"><?php echo Sensei()->course->course_lesson_count( $course->ID ) . '&nbsp;' .  __( 'Lessons', 'woothemes-sensei' ); ?></span>
+		<span class="course-lesson-count"><?php echo Sensei()->course->course_lesson_count( $course->ID ) . '&nbsp;' .  __( 'Lessons', 'woothemes-sensei' ); ?></span>
 
-       <?php if ( '' != $category_output ) { ?>
+	   <?php if ( '' != $category_output ) { ?>
 
-            <span class="course-category"><?php echo sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ); ?></span>
+			<span class="course-category"><?php echo sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ); ?></span>
 
-        <?php } // End If Statement
+		<?php } // End If Statement
 
-        // number of completed lessons
-        if( Sensei_Utils::user_started_course( $course->ID,  get_current_user_id() )
-            || Sensei_Utils::user_completed_course( $course->ID,  get_current_user_id() )  ){
+		// number of completed lessons
+		if( Sensei_Utils::user_started_course( $course->ID,  get_current_user_id() )
+			|| Sensei_Utils::user_completed_course( $course->ID,  get_current_user_id() )  ){
 
-            $completed = count( $this->get_completed_lesson_ids( $course->ID, get_current_user_id() ) );
-            $lesson_count = count( $this->course_lessons( $course->ID ) );
-            echo '<span class="course-lesson-progress">' . sprintf( __( '%1$d of %2$d lessons completed', 'woothemes-sensei' ) , $completed, $lesson_count  ) . '</span>';
+			$completed = count( $this->get_completed_lesson_ids( $course->ID, get_current_user_id() ) );
+			$lesson_count = count( $this->course_lessons( $course->ID ) );
+			echo '<span class="course-lesson-progress">' . sprintf( __( '%1$d of %2$d lessons completed', 'woothemes-sensei' ) , $completed, $lesson_count  ) . '</span>';
 
-        }
+		}
 
-        sensei_simple_course_price( $course->ID );
+		sensei_simple_course_price( $course->ID );
 
-        echo '</p>';
-    } // end the course meta
+		echo '</p>';
+	} // end the course meta
 
-    /**
-     * Filter the classes attached to a post types for courses
-     * and add a status class for when the user is logged in.
-     *
-     * @param $classes
-     * @param $class
-     * @param $post_id
-     *
-     * @return array $classes
-     */
-    public static function add_course_user_status_class( $classes, $class, $course_id ){
+	/**
+	 * Filter the classes attached to a post types for courses
+	 * and add a status class for when the user is logged in.
+	 *
+	 * @param $classes
+	 * @param $class
+	 * @param $post_id
+	 *
+	 * @return array $classes
+	 */
+	public static function add_course_user_status_class( $classes, $class, $course_id ){
 
-        if( 'course' == get_post_type( $course_id )  &&  is_user_logged_in() ){
+		if( 'course' == get_post_type( $course_id )  &&  is_user_logged_in() ){
 
-            if( Sensei_Utils::user_completed_course( $course_id, get_current_user_id() ) ){
+			if( Sensei_Utils::user_completed_course( $course_id, get_current_user_id() ) ){
 
-                $classes[] = 'user-status-completed';
+				$classes[] = 'user-status-completed';
 
-            }else{
+			}else{
 
-                $classes[] = 'user-status-active';
+				$classes[] = 'user-status-active';
 
-            }
+			}
 
-        }
+		}
 
-        return $classes;
+		return $classes;
 
-    }// end add_course_user_status_class
+	}// end add_course_user_status_class
 
-    /**
-     * Prints out the course action buttons links
-     *
-     * - complete course
-     * - delete course
-     *
-     * @param WP_Post $course
-     */
-    public static function the_course_action_buttons( $course ){
-
-        if( is_user_logged_in() ) { ?>
-
-            <section class="entry-actions">
-                <form method="POST" action="<?php  echo esc_url( remove_query_arg( array( 'active_page', 'completed_page' ) ) ); ?>">
-
-                    <input type="hidden"
-                           name="<?php echo esc_attr( 'woothemes_sensei_complete_course_noonce' ) ?>"
-                           id="<?php  echo esc_attr( 'woothemes_sensei_complete_course_noonce' ); ?>"
-                           value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_course_noonce' ) ); ?>"
-                        />
-
-                    <input type="hidden" name="course_complete_id" id="course-complete-id" value="<?php echo esc_attr( intval( $course->ID ) ); ?>" />
-
-                    <?php if ( 0 < absint( count( Sensei()->course->course_lessons( $course->ID ) ) )
-                        && Sensei()->settings->settings['course_completion'] == 'complete'
-                        && ! Sensei_Utils::user_completed_course( $course, get_current_user_id() )) { ?>
-
-                        <span><input name="course_complete" type="submit" class="course-complete" value="<?php  _e( 'Mark as Complete', 'woothemes-sensei' ); ?>" /></span>
-
-                   <?php  } // End If Statement
-
-                    $course_purchased = false;
-                    if ( Sensei_WC::is_woocommerce_active() ) {
-                        // Get the product ID
-                        $wc_post_id = get_post_meta( intval( $course->ID ), '_course_woocommerce_product', true );
-                        if ( 0 < $wc_post_id ) {
-
-                            $user = wp_get_current_user();
-                            $course_purchased = Sensei_Utils::sensei_customer_bought_product( $user->user_email, $user->ID, $wc_post_id );
-
-                        } // End If Statement
-                    } // End If Statement
-
-                    /**
-                     * Hide or show the delete course button.
-                     *
-                     * This button on shows in certain instances, but this filter will hide it in those
-                     * cases. For other instances the button will be hidden.
-                     *
-                     * @since 1.9.0
-                     * @param bool $show_delete_course_button defaults to false
-                     */
-                    $show_delete_course_button = apply_filters( 'sensei_show_delete_course_button', false );
-
-                    if ( ! $course_purchased
-                         && ! Sensei_Utils::user_completed_course( $course->ID, get_current_user_id() )
-                         && $show_delete_course_button ) { ?>
-
-                        <span><input name="course_complete" type="submit" class="course-delete" value="<?php echo __( 'Delete Course', 'woothemes-sensei' ); ?>"/></span>
-
-                    <?php } // End If Statement
-
-                    $has_quizzes = Sensei()->course->course_quizzes( $course->ID, true );
-                    $results_link = '';
-                    if( $has_quizzes ){
-                        $results_link = '<a class="button view-results" href="' . Sensei()->course_results->get_permalink( $course->ID ) . '">' . __( 'View results', 'woothemes-sensei' ) . '</a>';
-                    }
-
-                    // Output only if there is content to display
-                    if ( has_filter( 'sensei_results_links' ) || $has_quizzes ) { ?>
-
-                        <p class="sensei-results-links">
-                            <?php
-                            /**
-                             * Filter the results links
-                             *
-                             * @param string $results_links_html
-                             * @param integer $course_id
-                             */
-                            echo apply_filters( 'sensei_results_links', $results_link, $course->ID );
-                            ?>
-                        </p>
-
-                    <?php } // end if has filter  ?>
-                </form>
-            </section>
-
-        <?php  }// end if is user logged in
-
-    }// end the_course_action_buttons
-
-    /**
-     * This function alter the main query on the course archive page.
-     * This also gives Sensei specific filters that allows variables to be altered specifically on the course archive.
-     *
-     * This function targets only the course archives and the my courses page. Shortcodes can set their own
-     * query parameters via the arguments.
-     *
-     * This function is hooked into pre_get_posts filter
-     *
-     * @since 1.9.0
-     *
-     * @param WP_Query $query
-     * @return WP_Query $query
-     */
-    public static function course_query_filter( $query ){
-
-        // exit early for no course queries and admin queries
-        if( is_admin( ) || 'course' != $query->get( 'post_type' ) ){
-            return $query;
-        }
-
-        global $post; // used to get the current page id for my courses
-
-        // for the course archive page
-        if( $query->is_main_query() && is_post_type_archive('course') )
-        {
-            /**
-             * sensei_archive_courses_per_page
-             *
-             * Sensei courses per page on the course
-             * archive
-             *
-             * @since 1.9.0
-             * @param integer $posts_per_page defaults to the value of get_option( 'posts_per_page' )
-             */
-            $query->set( 'posts_per_page', apply_filters( 'sensei_archive_courses_per_page', get_option( 'posts_per_page' ) ) );
-            if ( isset( $query->query ) && isset( $query->query['paged'] ) && false === $query->get( 'paged', false ) ) {
+	/**
+	 * Prints out the course action buttons links
+	 *
+	 * - complete course
+	 * - delete course
+	 *
+	 * @param WP_Post $course
+	 */
+	public static function the_course_action_buttons( $course ){
+
+		if( is_user_logged_in() ) { ?>
+
+			<section class="entry-actions">
+				<form method="POST" action="<?php  echo esc_url( remove_query_arg( array( 'active_page', 'completed_page' ) ) ); ?>">
+
+					<input type="hidden"
+						   name="<?php echo esc_attr( 'woothemes_sensei_complete_course_noonce' ) ?>"
+						   id="<?php  echo esc_attr( 'woothemes_sensei_complete_course_noonce' ); ?>"
+						   value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_course_noonce' ) ); ?>"
+						/>
+
+					<input type="hidden" name="course_complete_id" id="course-complete-id" value="<?php echo esc_attr( intval( $course->ID ) ); ?>" />
+
+					<?php if ( 0 < absint( count( Sensei()->course->course_lessons( $course->ID ) ) )
+						&& Sensei()->settings->settings['course_completion'] == 'complete'
+						&& ! Sensei_Utils::user_completed_course( $course, get_current_user_id() )) { ?>
+
+						<span><input name="course_complete" type="submit" class="course-complete" value="<?php  _e( 'Mark as Complete', 'woothemes-sensei' ); ?>" /></span>
+
+				   <?php  } // End If Statement
+
+					$course_purchased = false;
+					if ( Sensei_WC::is_woocommerce_active() ) {
+						// Get the product ID
+						$wc_post_id = get_post_meta( intval( $course->ID ), '_course_woocommerce_product', true );
+						if ( 0 < $wc_post_id ) {
+
+							$user = wp_get_current_user();
+							$course_purchased = Sensei_Utils::sensei_customer_bought_product( $user->user_email, $user->ID, $wc_post_id );
+
+						} // End If Statement
+					} // End If Statement
+
+					/**
+					 * Hide or show the delete course button.
+					 *
+					 * This button on shows in certain instances, but this filter will hide it in those
+					 * cases. For other instances the button will be hidden.
+					 *
+					 * @since 1.9.0
+					 * @param bool $show_delete_course_button defaults to false
+					 */
+					$show_delete_course_button = apply_filters( 'sensei_show_delete_course_button', false );
+
+					if ( ! $course_purchased
+						 && ! Sensei_Utils::user_completed_course( $course->ID, get_current_user_id() )
+						 && $show_delete_course_button ) { ?>
+
+						<span><input name="course_complete" type="submit" class="course-delete" value="<?php echo __( 'Delete Course', 'woothemes-sensei' ); ?>"/></span>
+
+					<?php } // End If Statement
+
+					$has_quizzes = Sensei()->course->course_quizzes( $course->ID, true );
+					$results_link = '';
+					if( $has_quizzes ){
+						$results_link = '<a class="button view-results" href="' . Sensei()->course_results->get_permalink( $course->ID ) . '">' . __( 'View results', 'woothemes-sensei' ) . '</a>';
+					}
+
+					// Output only if there is content to display
+					if ( has_filter( 'sensei_results_links' ) || $has_quizzes ) { ?>
+
+						<p class="sensei-results-links">
+							<?php
+							/**
+							 * Filter the results links
+							 *
+							 * @param string $results_links_html
+							 * @param integer $course_id
+							 */
+							echo apply_filters( 'sensei_results_links', $results_link, $course->ID );
+							?>
+						</p>
+
+					<?php } // end if has filter  ?>
+				</form>
+			</section>
+
+		<?php  }// end if is user logged in
+
+	}// end the_course_action_buttons
+
+	/**
+	 * This function alter the main query on the course archive page.
+	 * This also gives Sensei specific filters that allows variables to be altered specifically on the course archive.
+	 *
+	 * This function targets only the course archives and the my courses page. Shortcodes can set their own
+	 * query parameters via the arguments.
+	 *
+	 * This function is hooked into pre_get_posts filter
+	 *
+	 * @since 1.9.0
+	 *
+	 * @param WP_Query $query
+	 * @return WP_Query $query
+	 */
+	public static function course_query_filter( $query ){
+
+		// exit early for no course queries and admin queries
+		if( is_admin( ) || 'course' != $query->get( 'post_type' ) ){
+			return $query;
+		}
+
+		global $post; // used to get the current page id for my courses
+
+		// for the course archive page
+		if( $query->is_main_query() && is_post_type_archive('course') )
+		{
+			/**
+			 * sensei_archive_courses_per_page
+			 *
+			 * Sensei courses per page on the course
+			 * archive
+			 *
+			 * @since 1.9.0
+			 * @param integer $posts_per_page defaults to the value of get_option( 'posts_per_page' )
+			 */
+			$query->set( 'posts_per_page', apply_filters( 'sensei_archive_courses_per_page', get_option( 'posts_per_page' ) ) );
+			if ( isset( $query->query ) && isset( $query->query['paged'] ) && false === $query->get( 'paged', false ) ) {
 				$query->set( 'paged', $query->query['paged'] );
-            }
-
-        }
-        // for the my courses page
-        elseif( isset( $post ) && is_page() && Sensei()->settings->get( 'my_course_page' ) == $post->ID  )
-        {
-            /**
-             * sensei_my_courses_per_page
-             *
-             * Sensei courses per page on the my courses page
-             * as set in the settings
-             *
-             * @since 1.9.0
-             * @param integer $posts_per_page default 10
-             */
-            $query->set( 'posts_per_page', apply_filters( 'sensei_my_courses_per_page', $query->get( 'posts_per_page', 10 ) ) );
-
-        }
-
-        return $query;
-
-    }// end course_query_filter
-
-    /**
-     * Determine the class of the course loop
-     *
-     * This will output .first or .last and .course-item-number-x
-     *
-     * @return array $extra_classes
-     * @since 1.9.0
-     */
-    public static function get_course_loop_content_class ()
-    {
-
-        global $sensei_course_loop;
-
-
-        if( !isset( $sensei_course_loop ) ){
-            $sensei_course_loop = array();
-        }
-
-        if (!isset($sensei_course_loop['counter'])) {
-            $sensei_course_loop['counter'] = 0;
-        }
-
-        if (!isset($sensei_course_loop['columns'])) {
-            $sensei_course_loop['columns'] = self::get_loop_number_of_columns();
-        }
-
-        // increment the counter
-        $sensei_course_loop['counter']++;
-
-        $extra_classes = array();
-        if( 0 == ( $sensei_course_loop['counter'] - 1 ) % $sensei_course_loop['columns'] || 1 == $sensei_course_loop['columns']  ){
-            $extra_classes[] = 'first';
-        }
-
-        if( 0 == $sensei_course_loop['counter'] % $sensei_course_loop['columns']  ){
-            $extra_classes[] = 'last';
-        }
-
-        // add the item number to the classes as well.
-        $extra_classes[] = 'loop-item-number-'. $sensei_course_loop['counter'];
-
-        /**
-         * Filter the course loop class the fires in the  in get_course_loop_content_class function
-         * which is called from the course loop content-course.php
-         *
-         * @since 1.9.0
-         *
-         * @param array $extra_classes
-         * @param WP_Post $loop_current_course
-         */
-        return apply_filters( 'sensei_course_loop_content_class', $extra_classes ,get_post() );
-
-    }// end get_course_loop_class
-
-    /**
-     * Get the number of columns set for Sensei courses
-     *
-     * @since 1.9.0
-     * @return mixed|void
-     */
-    public static function get_loop_number_of_columns(){
-
-        /**
-         * Filter the number of columns on the course archive page.
-         *
-         * @since 1.9.0
-         * @param int $number_of_columns default 1
-         */
-        return apply_filters('sensei_course_loop_number_of_columns', 1);
-
-    }
-
-    /**
-     * Output the course archive filter markup
-     *
-     * hooked into sensei_loop_course_before
-     *
-     * @since 1.9.0
-     * @param
-     */
-    public static function course_archive_sorting( $query ){
-
-        // don't show on category pages and other pages
-        if( ! is_archive(  'course ') || is_tax('course-category') ){
-            return;
-        }
-
-        /**
-         * Filter the sensei archive course order by values
-         *
-         * @since 1.9.0
-         * @param array $options {
-         *  @type string $option_value
-         *  @type string $option_string
-         * }
-         */
-        $course_order_by_options = apply_filters( 'sensei_archive_course_order_by_options', array(
-            "newness"     => __( "Sort by newest first", "woothemes-sensei"),
-            "title"       => __( "Sort by title A-Z", "woothemes-sensei" ),
-        ));
-
-        // setup the currently selected item
-        $selected = 'newness';
-        if( isset( $_REQUEST['course-orderby'] ) && in_array( $selected, array_keys( $course_order_by_options ), true ) ){
-
-            $selected = sanitize_text_field( $_REQUEST[ 'course-orderby' ] );
-
-        }
-
-        ?>
-
-        <form class="sensei-ordering" name="sensei-course-order" action="<?php echo esc_attr( Sensei_Utils::get_current_url() ) ; ?>" method="get">
-            <select name="course-orderby" class="orderby">
-                <?php
-                foreach( $course_order_by_options as $value => $text ){
-
-                    echo '<option value="'. $value . '"' . selected( $selected, $value, false ) . '>'. $text. '</option>';
-
-                }
-                ?>
-            </select>
-        </form>
-
-    <?php
-    }// end course archive filters
-
-    /**
-     * Output the course archive filter markup
-     *
-     * hooked into sensei_loop_course_before
-     *
-     * @since 1.9.0
-     * @param
-     */
-    public static function course_archive_filters( $query ){
-
-        // don't show on category pages
-        if( is_tax('course-category') ){
-            return;
-        }
-
-        /**
-         * filter the course archive filter buttons
-         *
-         * @since 1.9.0
-         * @param array $filters{
-         *   @type array ( $id, $url , $title )
-         * }
-         *
-         */
-        $filters = apply_filters( 'sensei_archive_course_filter_by_options', array(
-            array( 'id' => 'all', 'url' => self::get_courses_page_url(), 'title'=> __( 'All', 'woothemes-sensei' ) ),
-            array( 'id' => 'featured', 'url' => add_query_arg( array( 'course_filter'=>'featured'), self::get_courses_page_url()  ), 'title'=> __( 'Featured', 'woothemes-sensei' ) ),
-        ));
-
-
-        ?>
-        <ul class="sensei-course-filters clearfix" >
-            <?php
-
-            $active_course_filter = isset ( $_GET[ 'course_filter' ] ) ? sanitize_text_field( $_GET[ 'course_filter' ] ) :  'all';
-
-            foreach( $filters as $filter ) {
-
-                $active_class =  $active_course_filter == $filter['id'] ? ' class="active" ' : '';
-
-                echo '<li><a '. $active_class .' id="'. $filter['id'] .'" href="'. esc_url( $filter['url'] ).'" >'. $filter['title']  .'</a></li>';
-
-            }
-            ?>
-
-        </ul>
-
-        <?php
-
-    }
-
-    /**
-     * if the featured link is clicked on the course archive page
-     * filter the courses returned to only show those featured
-     *
-     * Hooked into pre_get_posts
-     *
-     * @since 1.9.0
-     * @param WP_Query $query
-     * @return WP_Query $query
-     */
-    public static function course_archive_featured_filter( $query ){
-
-        if( isset ( $_GET[ 'course_filter' ] ) && 'featured'== $_GET['course_filter'] && $query->is_main_query()  ){
-            //setup meta query for featured courses
-            $query->set( 'meta_value', 'featured'  );
-            $query->set( 'meta_key', '_course_featured'  );
-            $query->set( 'meta_compare', '='  );
-        }
-
-        return $query;
-    }
-
-    /**
-     * if the course order drop down is changed
-     *
-     * Hooked into pre_get_posts
-     *
-     * @since 1.9.0
-     * @param WP_Query $query
-     * @return WP_Query $query
-     */
-    public static function course_archive_order_by_title( $query ){
-
-        if( isset ( $_REQUEST[ 'course-orderby' ] ) && 'title' == $_REQUEST['course-orderby']
-            && 'course' === $query->get('post_type') && $query->is_main_query()  ){
-            // setup the order by title for this query
-            $query->set( 'orderby', 'title'  );
-            $query->set( 'order', 'ASC'  );
-        }
-
-        return $query;
-    }
-
-
-    /**
-     * Get the link to the courses page. This will be the course post type archive
-     * page link or the page the user set in their settings
-     *
-     * @since 1.9.0
-     * @return string $course_page_url
-     */
-    public static function get_courses_page_url(){
-
-        $course_page_id = intval( Sensei()->settings->settings[ 'course_page' ] );
-        $course_page_url = empty( $course_page_id ) ? get_post_type_archive_link('course') : get_permalink( $course_page_id );
-
-        return $course_page_url;
-
-    }// get_course_url
-
-    /**
-     * Output the headers on the course archive page
-     *
-     * Hooked into the sensei_archive_title
-     *
-     * @since 1.9.0
-     * @param string $query_type
-     * @param string $before_html
-     * @param string $after_html
-     * @return void
-     */
-    public static function archive_header( $query_type ='' , $before_html='', $after_html =''  ){
+			}
+
+		}
+		// for the my courses page
+		elseif( isset( $post ) && is_page() && Sensei()->settings->get( 'my_course_page' ) == $post->ID  )
+		{
+			/**
+			 * sensei_my_courses_per_page
+			 *
+			 * Sensei courses per page on the my courses page
+			 * as set in the settings
+			 *
+			 * @since 1.9.0
+			 * @param integer $posts_per_page default 10
+			 */
+			$query->set( 'posts_per_page', apply_filters( 'sensei_my_courses_per_page', $query->get( 'posts_per_page', 10 ) ) );
+
+		}
+
+		return $query;
+
+	}// end course_query_filter
+
+	/**
+	 * Determine the class of the course loop
+	 *
+	 * This will output .first or .last and .course-item-number-x
+	 *
+	 * @return array $extra_classes
+	 * @since 1.9.0
+	 */
+	public static function get_course_loop_content_class ()
+	{
+
+		global $sensei_course_loop;
+
+
+		if( !isset( $sensei_course_loop ) ){
+			$sensei_course_loop = array();
+		}
+
+		if (!isset($sensei_course_loop['counter'])) {
+			$sensei_course_loop['counter'] = 0;
+		}
+
+		if (!isset($sensei_course_loop['columns'])) {
+			$sensei_course_loop['columns'] = self::get_loop_number_of_columns();
+		}
+
+		// increment the counter
+		$sensei_course_loop['counter']++;
+
+		$extra_classes = array();
+		if( 0 == ( $sensei_course_loop['counter'] - 1 ) % $sensei_course_loop['columns'] || 1 == $sensei_course_loop['columns']  ){
+			$extra_classes[] = 'first';
+		}
+
+		if( 0 == $sensei_course_loop['counter'] % $sensei_course_loop['columns']  ){
+			$extra_classes[] = 'last';
+		}
+
+		// add the item number to the classes as well.
+		$extra_classes[] = 'loop-item-number-'. $sensei_course_loop['counter'];
+
+		/**
+		 * Filter the course loop class the fires in the  in get_course_loop_content_class function
+		 * which is called from the course loop content-course.php
+		 *
+		 * @since 1.9.0
+		 *
+		 * @param array $extra_classes
+		 * @param WP_Post $loop_current_course
+		 */
+		return apply_filters( 'sensei_course_loop_content_class', $extra_classes ,get_post() );
+
+	}// end get_course_loop_class
+
+	/**
+	 * Get the number of columns set for Sensei courses
+	 *
+	 * @since 1.9.0
+	 * @return mixed|void
+	 */
+	public static function get_loop_number_of_columns(){
+
+		/**
+		 * Filter the number of columns on the course archive page.
+		 *
+		 * @since 1.9.0
+		 * @param int $number_of_columns default 1
+		 */
+		return apply_filters('sensei_course_loop_number_of_columns', 1);
+
+	}
+
+	/**
+	 * Output the course archive filter markup
+	 *
+	 * hooked into sensei_loop_course_before
+	 *
+	 * @since 1.9.0
+	 * @param
+	 */
+	public static function course_archive_sorting( $query ){
+
+		// don't show on category pages and other pages
+		if( ! is_archive(  'course ') || is_tax('course-category') ){
+			return;
+		}
+
+		/**
+		 * Filter the sensei archive course order by values
+		 *
+		 * @since 1.9.0
+		 * @param array $options {
+		 *  @type string $option_value
+		 *  @type string $option_string
+		 * }
+		 */
+		$course_order_by_options = apply_filters( 'sensei_archive_course_order_by_options', array(
+			"newness"     => __( "Sort by newest first", "woothemes-sensei"),
+			"title"       => __( "Sort by title A-Z", "woothemes-sensei" ),
+		));
+
+		// setup the currently selected item
+		$selected = 'newness';
+		if( isset( $_REQUEST['course-orderby'] ) && in_array( $selected, array_keys( $course_order_by_options ), true ) ){
+
+			$selected = sanitize_text_field( $_REQUEST[ 'course-orderby' ] );
+
+		}
+
+		?>
+
+		<form class="sensei-ordering" name="sensei-course-order" action="<?php echo esc_attr( Sensei_Utils::get_current_url() ) ; ?>" method="get">
+			<select name="course-orderby" class="orderby">
+				<?php
+				foreach( $course_order_by_options as $value => $text ){
+
+					echo '<option value="'. $value . '"' . selected( $selected, $value, false ) . '>'. $text. '</option>';
+
+				}
+				?>
+			</select>
+		</form>
+
+	<?php
+	}// end course archive filters
+
+	/**
+	 * Output the course archive filter markup
+	 *
+	 * hooked into sensei_loop_course_before
+	 *
+	 * @since 1.9.0
+	 * @param
+	 */
+	public static function course_archive_filters( $query ){
+
+		// don't show on category pages
+		if( is_tax('course-category') ){
+			return;
+		}
+
+		/**
+		 * filter the course archive filter buttons
+		 *
+		 * @since 1.9.0
+		 * @param array $filters{
+		 *   @type array ( $id, $url , $title )
+		 * }
+		 *
+		 */
+		$filters = apply_filters( 'sensei_archive_course_filter_by_options', array(
+			array( 'id' => 'all', 'url' => self::get_courses_page_url(), 'title'=> __( 'All', 'woothemes-sensei' ) ),
+			array( 'id' => 'featured', 'url' => add_query_arg( array( 'course_filter'=>'featured'), self::get_courses_page_url()  ), 'title'=> __( 'Featured', 'woothemes-sensei' ) ),
+		));
+
+
+		?>
+		<ul class="sensei-course-filters clearfix" >
+			<?php
+
+			$active_course_filter = isset ( $_GET[ 'course_filter' ] ) ? sanitize_text_field( $_GET[ 'course_filter' ] ) :  'all';
+
+			foreach( $filters as $filter ) {
+
+				$active_class =  $active_course_filter == $filter['id'] ? ' class="active" ' : '';
+
+				echo '<li><a '. $active_class .' id="'. $filter['id'] .'" href="'. esc_url( $filter['url'] ).'" >'. $filter['title']  .'</a></li>';
+
+			}
+			?>
+
+		</ul>
+
+		<?php
+
+	}
+
+	/**
+	 * if the featured link is clicked on the course archive page
+	 * filter the courses returned to only show those featured
+	 *
+	 * Hooked into pre_get_posts
+	 *
+	 * @since 1.9.0
+	 * @param WP_Query $query
+	 * @return WP_Query $query
+	 */
+	public static function course_archive_featured_filter( $query ){
+
+		if( isset ( $_GET[ 'course_filter' ] ) && 'featured'== $_GET['course_filter'] && $query->is_main_query()  ){
+			//setup meta query for featured courses
+			$query->set( 'meta_value', 'featured'  );
+			$query->set( 'meta_key', '_course_featured'  );
+			$query->set( 'meta_compare', '='  );
+		}
+
+		return $query;
+	}
+
+	/**
+	 * if the course order drop down is changed
+	 *
+	 * Hooked into pre_get_posts
+	 *
+	 * @since 1.9.0
+	 * @param WP_Query $query
+	 * @return WP_Query $query
+	 */
+	public static function course_archive_order_by_title( $query ){
+
+		if( isset ( $_REQUEST[ 'course-orderby' ] ) && 'title' == $_REQUEST['course-orderby']
+			&& 'course' === $query->get('post_type') && $query->is_main_query()  ){
+			// setup the order by title for this query
+			$query->set( 'orderby', 'title'  );
+			$query->set( 'order', 'ASC'  );
+		}
+
+		return $query;
+	}
+
+
+	/**
+	 * Get the link to the courses page. This will be the course post type archive
+	 * page link or the page the user set in their settings
+	 *
+	 * @since 1.9.0
+	 * @return string $course_page_url
+	 */
+	public static function get_courses_page_url(){
+
+		$course_page_id = intval( Sensei()->settings->settings[ 'course_page' ] );
+		$course_page_url = empty( $course_page_id ) ? get_post_type_archive_link('course') : get_permalink( $course_page_id );
+
+		return $course_page_url;
+
+	}// get_course_url
+
+	/**
+	 * Output the headers on the course archive page
+	 *
+	 * Hooked into the sensei_archive_title
+	 *
+	 * @since 1.9.0
+	 * @param string $query_type
+	 * @param string $before_html
+	 * @param string $after_html
+	 * @return void
+	 */
+	public static function archive_header( $query_type ='' , $before_html='', $after_html =''  ){
 
-        if( ! is_post_type_archive('course') ){
-            return;
-        }
+		if( ! is_post_type_archive('course') ){
+			return;
+		}
 
-        // deprecated since 1.9.0
-        sensei_do_deprecated_action('sensei_archive_title','1.9.0','sensei_archive_before_course_loop');
+		// deprecated since 1.9.0
+		sensei_do_deprecated_action('sensei_archive_title','1.9.0','sensei_archive_before_course_loop');
 
-        $html = '';
+		$html = '';
 
-        if( empty( $before_html ) ){
+		if( empty( $before_html ) ){
 
-            $before_html = '<header class="archive-header"><h1>';
+			$before_html = '<header class="archive-header"><h1>';
 
-        }
+		}
 
-        if( empty( $after_html ) ){
+		if( empty( $after_html ) ){
 
-            $after_html = '</h1></header>';
+			$after_html = '</h1></header>';
 
-        }
+		}
 
-        if ( is_tax( 'course-category' ) ) {
+		if ( is_tax( 'course-category' ) ) {
 
-            global $wp_query;
+			global $wp_query;
 
-            $taxonomy_obj = $wp_query->get_queried_object();
-            $taxonomy_short_name = $taxonomy_obj->taxonomy;
-            $taxonomy_raw_obj = get_taxonomy( $taxonomy_short_name );
-            $title = sprintf( __( '%1$s Archives: %2$s', 'woothemes-sensei' ), $taxonomy_raw_obj->labels->name, $taxonomy_obj->name );
-            echo apply_filters( 'course_category_archive_title', $before_html . $title . $after_html );
-            return;
+			$taxonomy_obj = $wp_query->get_queried_object();
+			$taxonomy_short_name = $taxonomy_obj->taxonomy;
+			$taxonomy_raw_obj = get_taxonomy( $taxonomy_short_name );
+			$title = sprintf( __( '%1$s Archives: %2$s', 'woothemes-sensei' ), $taxonomy_raw_obj->labels->name, $taxonomy_obj->name );
+			echo apply_filters( 'course_category_archive_title', $before_html . $title . $after_html );
+			return;
 
-        } // End If Statement
+		} // End If Statement
 
-        switch ( $query_type ) {
-            case 'newcourses':
-                $html .= $before_html . __( 'New Courses', 'woothemes-sensei' ) . $after_html;
-                break;
-            case 'featuredcourses':
-                $html .= $before_html .  __( 'Featured Courses', 'woothemes-sensei' ) . $after_html;
-                break;
-            case 'freecourses':
-                $html .= $before_html .  __( 'Free Courses', 'woothemes-sensei' ) . $after_html;
-                break;
-            case 'paidcourses':
-                $html .= $before_html .  __( 'Paid Courses', 'woothemes-sensei' ) . $after_html;
-                break;
-            default:
-                $html .= $before_html . __( 'Courses', 'woothemes-sensei' ) . $after_html;
-                break;
-        } // End Switch Statement
+		switch ( $query_type ) {
+			case 'newcourses':
+				$html .= $before_html . __( 'New Courses', 'woothemes-sensei' ) . $after_html;
+				break;
+			case 'featuredcourses':
+				$html .= $before_html .  __( 'Featured Courses', 'woothemes-sensei' ) . $after_html;
+				break;
+			case 'freecourses':
+				$html .= $before_html .  __( 'Free Courses', 'woothemes-sensei' ) . $after_html;
+				break;
+			case 'paidcourses':
+				$html .= $before_html .  __( 'Paid Courses', 'woothemes-sensei' ) . $after_html;
+				break;
+			default:
+				$html .= $before_html . __( 'Courses', 'woothemes-sensei' ) . $after_html;
+				break;
+		} // End Switch Statement
 
-        echo apply_filters( 'course_archive_title', $html );
+		echo apply_filters( 'course_archive_title', $html );
 
-    }//course_archive_header
+	}//course_archive_header
 
 
-    /**
-     * Filter the single course content
-     * taking into account if the user has access.
-     *
-     * @1.9.0
-     *
-     * @param string $content
-     * @return string $content or $excerpt
-     */
-    public static function single_course_content( $content ){
+	/**
+	 * Filter the single course content
+	 * taking into account if the user has access.
+	 *
+	 * @1.9.0
+	 *
+	 * @param string $content
+	 * @return string $content or $excerpt
+	 */
+	public static function single_course_content( $content ){
 
-        if( ! is_singular('course') ){
+		if( ! is_singular('course') ){
 
-            return $content;
+			return $content;
 
-        }
+		}
 
-        // Content Access Permissions
-        $access_permission = false;
+		// Content Access Permissions
+		$access_permission = false;
 
-        if ( ! Sensei()->settings->get('access_permission')  || sensei_all_access() ) {
+		if ( ! Sensei()->settings->get('access_permission')  || sensei_all_access() ) {
 
-            $access_permission = true;
+			$access_permission = true;
 
-        } // End If Statement
+		} // End If Statement
 
-        // Check if the user is taking the course
-        $is_user_taking_course = Sensei_Utils::user_started_course( get_the_ID(), get_current_user_id() );
+		// Check if the user is taking the course
+		$is_user_taking_course = Sensei_Utils::user_started_course( get_the_ID(), get_current_user_id() );
 
-        if(Sensei_WC::is_woocommerce_active()) {
+		if(Sensei_WC::is_woocommerce_active()) {
 
-            $wc_post_id = get_post_meta( get_the_ID(), '_course_woocommerce_product', true );
-            $product = Sensei()->sensei_get_woocommerce_product_object( $wc_post_id );
+			$wc_post_id = get_post_meta( get_the_ID(), '_course_woocommerce_product', true );
+			$product = Sensei()->sensei_get_woocommerce_product_object( $wc_post_id );
 
-            $has_product_attached = isset ( $product ) && is_object ( $product );
+			$has_product_attached = isset ( $product ) && is_object ( $product );
 
-        } else {
+		} else {
 
-            $has_product_attached = false;
+			$has_product_attached = false;
 
-        }
+		}
 
-        if ( ( is_user_logged_in() && $is_user_taking_course )
-            || ( $access_permission && !$has_product_attached) ) {
+		if ( ( is_user_logged_in() && $is_user_taking_course )
+			|| ( $access_permission && !$has_product_attached) ) {
 
-	        // compensate for core providing and empty $content
+			// compensate for core providing and empty $content
 
-	        if( empty( $content ) ){
-		        remove_filter( 'the_content', array( 'Sensei_Course', 'single_course_content') );
-		        $course = get_post( get_the_ID() );
+			if( empty( $content ) ){
+				remove_filter( 'the_content', array( 'Sensei_Course', 'single_course_content') );
+				$course = get_post( get_the_ID() );
 
-		        $content = apply_filters( 'the_content', $course->post_content );
+				$content = apply_filters( 'the_content', $course->post_content );
 
-	        }
+			}
 
-            return $content;
+			return $content;
 
-        } else {
-            return '<p class="course-excerpt">' . get_post(  get_the_ID() )->post_excerpt . '</p>';
-        }
+		} else {
+			return '<p class="course-excerpt">' . get_post(  get_the_ID() )->post_excerpt . '</p>';
+		}
 
-    }// end single_course_content
+	}// end single_course_content
 
-    /**
-     * Output the the single course lessons title with markup.
-     *
-     * @since 1.9.0
-     */
-    public static function the_course_lessons_title(){
+	/**
+	 * Output the the single course lessons title with markup.
+	 *
+	 * @since 1.9.0
+	 */
+	public static function the_course_lessons_title(){
 
-	    if ( ! is_singular( 'course' )  ) {
-		    return;
-	    }
+		if ( ! is_singular( 'course' )  ) {
+			return;
+		}
 
-        global $post;
-        $none_module_lessons = Sensei()->modules->get_none_module_lessons( $post->ID  );
-        $course_lessons = Sensei()->course->course_lessons( $post->ID );
+		global $post;
+		$none_module_lessons = Sensei()->modules->get_none_module_lessons( $post->ID  );
+		$course_lessons = Sensei()->course->course_lessons( $post->ID );
 
-        // title should be Other Lessons if there are lessons belonging to models.
-        $title = __('Other Lessons', 'woothemes-sensei');
+		// title should be Other Lessons if there are lessons belonging to models.
+		$title = __('Other Lessons', 'woothemes-sensei');
 
-        // show header if there are lessons the number of lesson in the course is the same as those that isn't assigned to a module
-        if ( ! empty( $course_lessons ) && count( $course_lessons ) == count( $none_module_lessons ) ) {
+		// show header if there are lessons the number of lesson in the course is the same as those that isn't assigned to a module
+		if ( ! empty( $course_lessons ) && count( $course_lessons ) == count( $none_module_lessons ) ) {
 
-            $title = __('Lessons', 'woothemes-sensei');
+			$title = __('Lessons', 'woothemes-sensei');
 
-        }elseif( empty( $none_module_lessons ) ){ // if the none module lessons are simply empty the title should not be shown
+		}elseif( empty( $none_module_lessons ) ){ // if the none module lessons are simply empty the title should not be shown
 
-            $title = '';
-        }
+			$title = '';
+		}
 
-        /**
-         * hook document in class-woothemes-sensei-message.php
-         */
-        $title = apply_filters( 'sensei_single_title', $title, $post->post_type );
+		/**
+		 * hook document in class-woothemes-sensei-message.php
+		 */
+		$title = apply_filters( 'sensei_single_title', $title, $post->post_type );
 
-        ob_start(); // start capturing the following output.
+		ob_start(); // start capturing the following output.
 
-        ?>
+		?>
 
-            <header>
-                <h2> <?php echo $title; ?> </h2>
-            </header>
+			<header>
+				<h2> <?php echo $title; ?> </h2>
+			</header>
 
-        <?php
+		<?php
 
-        /**
-         * Filter the title and markup that appears above the lessons on a single course
-         * page.
-         *
-         * @since 1.9.0
-         * @param string $lessons_title_html
-         */
-        echo apply_filters('the_course_lessons_title', ob_get_clean() ); // output and filter the captured output and stop capturing.
+		/**
+		 * Filter the title and markup that appears above the lessons on a single course
+		 * page.
+		 *
+		 * @since 1.9.0
+		 * @param string $lessons_title_html
+		 */
+		echo apply_filters('the_course_lessons_title', ob_get_clean() ); // output and filter the captured output and stop capturing.
 
-    }// end the_course_lessons_title
+	}// end the_course_lessons_title
 
-    /**
-     * This function loads the global wp_query object with with lessons
-     * of the current course. It is designed to be used on the single-course template
-     * and expects the global post to be a singular course.
-     *
-     * This function excludes lessons belonging to modules as they are
-     * queried separately.
-     *
-     * @since 1.9.0
-     * @global $wp_query
-     */
-    public static function load_single_course_lessons_query(){
+	/**
+	 * This function loads the global wp_query object with with lessons
+	 * of the current course. It is designed to be used on the single-course template
+	 * and expects the global post to be a singular course.
+	 *
+	 * This function excludes lessons belonging to modules as they are
+	 * queried separately.
+	 *
+	 * @since 1.9.0
+	 * @global $wp_query
+	 */
+	public static function load_single_course_lessons_query(){
 
-        global $post, $wp_query;
+		global $post, $wp_query;
 
-        $course_id = $post->ID;
+		$course_id = $post->ID;
 
-        if( 'course' != get_post_type( $course_id ) ){
-            return;
-        }
+		if( 'course' != get_post_type( $course_id ) ){
+			return;
+		}
 
 		$course_lessons_post_status = isset( $wp_query ) && $wp_query->is_preview() ? 'all' : 'publish';
 
-        $course_lesson_query_args = array(
-	        'post_status'       => $course_lessons_post_status,
-            'post_type'         => 'lesson',
-            'posts_per_page'    => 500,
-            'orderby'           => 'date',
-            'order'             => 'ASC',
-            'meta_query'        => array(
-                array(
-                    'key' => '_lesson_course',
-                    'value' => intval( $course_id ),
-                ),
-            ),
-            'suppress_filters'  => 0,
-        );
+		$course_lesson_query_args = array(
+			'post_status'       => $course_lessons_post_status,
+			'post_type'         => 'lesson',
+			'posts_per_page'    => 500,
+			'orderby'           => 'date',
+			'order'             => 'ASC',
+			'meta_query'        => array(
+				array(
+					'key' => '_lesson_course',
+					'value' => intval( $course_id ),
+				),
+			),
+			'suppress_filters'  => 0,
+		);
 
-        // Exclude lessons belonging to modules as they are queried along with the modules.
-        $modules = Sensei()->modules->get_course_modules( $course_id );
-        if( !is_wp_error( $modules ) && ! empty( $modules ) && is_array( $modules ) ){
+		// Exclude lessons belonging to modules as they are queried along with the modules.
+		$modules = Sensei()->modules->get_course_modules( $course_id );
+		if( !is_wp_error( $modules ) && ! empty( $modules ) && is_array( $modules ) ){
 
-            $terms_ids = array();
-            foreach( $modules as $term ){
+			$terms_ids = array();
+			foreach( $modules as $term ){
 
-                $terms_ids[] = $term->term_id;
+				$terms_ids[] = $term->term_id;
 
-            }
+			}
 
-            $course_lesson_query_args[ 'tax_query'] = array(
-                array(
-                    'taxonomy' => 'module',
-                    'field'    => 'id',
-                    'terms'    => $terms_ids,
-                    'operator' => 'NOT IN',
-                ),
-            );
-        }
+			$course_lesson_query_args[ 'tax_query'] = array(
+				array(
+					'taxonomy' => 'module',
+					'field'    => 'id',
+					'terms'    => $terms_ids,
+					'operator' => 'NOT IN',
+				),
+			);
+		}
 
 		//setting lesson order
 		$course_lesson_order = get_post_meta( $course_id, '_lesson_order', true );
@@ -2774,346 +2774,346 @@ class Sensei_Course {
 			'meta_key'       => '_lesson_course',
 			'meta_value'     => intval( $course_id ),
 		) );
-        if( !empty( $course_lesson_order ) ){
+		if( !empty( $course_lesson_order ) ){
 
-            $course_lesson_query_args['post__in'] = array_merge( explode( ',', $course_lesson_order ), $all_ids );
-            $course_lesson_query_args['orderby']= 'post__in' ;
-            unset( $course_lesson_query_args['order'] );
+			$course_lesson_query_args['post__in'] = array_merge( explode( ',', $course_lesson_order ), $all_ids );
+			$course_lesson_query_args['orderby']= 'post__in' ;
+			unset( $course_lesson_query_args['order'] );
 
-        }
+		}
 
-        $wp_query = new WP_Query( $course_lesson_query_args );
+		$wp_query = new WP_Query( $course_lesson_query_args );
 
-    }// load_single_course_lessons
+	}// load_single_course_lessons
 
-    /**
-     * Flush the rewrite rules for a course post type
-     *
-     * @since 1.9.0
-     *
-     * @param $post_id
-     */
-    public static function flush_rewrite_rules( $post_id ){
+	/**
+	 * Flush the rewrite rules for a course post type
+	 *
+	 * @since 1.9.0
+	 *
+	 * @param $post_id
+	 */
+	public static function flush_rewrite_rules( $post_id ){
 
-        if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE){
+		if (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE){
 
-            return;
-
-        }
-
-
-        if( 'course' == get_post_type( $post_id )  ){
-
-            Sensei()->initiate_rewrite_rules_flush();
-
-        }
-
-    }
-
-    /**
-     * Output the course actions like start taking course, register, add to cart etc.
-     *
-     * @since 1.9.0
-     */
-    public static function the_course_enrolment_actions(){
-
-	    global $post;
-
-	    if ( 'course' != $post->post_type ) {
 			return;
-	    }
 
-        ?>
-        <section class="course-meta course-enrolment">
-        <?php
-        global  $post, $current_user;
-        $is_user_taking_course = Sensei_Utils::user_started_course( $post->ID, $current_user->ID );
+		}
+
+
+		if( 'course' == get_post_type( $post_id )  ){
+
+			Sensei()->initiate_rewrite_rules_flush();
+
+		}
+
+	}
+
+	/**
+	 * Output the course actions like start taking course, register, add to cart etc.
+	 *
+	 * @since 1.9.0
+	 */
+	public static function the_course_enrolment_actions(){
+
+		global $post;
+
+		if ( 'course' != $post->post_type ) {
+			return;
+		}
+
+		?>
+		<section class="course-meta course-enrolment">
+		<?php
+		global  $post, $current_user;
+		$is_user_taking_course = Sensei_Utils::user_started_course( $post->ID, $current_user->ID );
 		$is_course_content_restricted = (bool) apply_filters( 'sensei_is_course_content_restricted', false, $post->ID );
 
-	    if ( is_user_logged_in() && ! $is_user_taking_course ) {
+		if ( is_user_logged_in() && ! $is_user_taking_course ) {
 
-	        // Check for woocommerce
-	        if ( Sensei_WC::is_woocommerce_active() && Sensei_WC::is_course_purchasable( $post->ID ) ) {
+			// Check for woocommerce
+			if ( Sensei_WC::is_woocommerce_active() && Sensei_WC::is_course_purchasable( $post->ID ) ) {
 
-		        // Get the product ID
-                Sensei_WC::the_add_to_cart_button_html($post->ID );
+				// Get the product ID
+				Sensei_WC::the_add_to_cart_button_html($post->ID );
 
-            } else {
-                $should_display_start_course_form = (bool) apply_filters( 'sensei_display_start_course_form', true, $post->ID );
+			} else {
+				$should_display_start_course_form = (bool) apply_filters( 'sensei_display_start_course_form', true, $post->ID );
 				if ( $is_course_content_restricted && false == $should_display_start_course_form ) {
 					self::add_course_access_permission_message( '' );
 				}
-                if ( $should_display_start_course_form ) {
-                  sensei_start_course_form( $post->ID );
-                }
-            } // End If Statement
+				if ( $should_display_start_course_form ) {
+				  sensei_start_course_form( $post->ID );
+				}
+			} // End If Statement
 
-        } elseif ( is_user_logged_in() ) {
+		} elseif ( is_user_logged_in() ) {
 
-            // Check if course is completed
-            $user_course_status = Sensei_Utils::user_course_status( $post->ID, $current_user->ID );
-            $completed_course = Sensei_Utils::user_completed_course( $user_course_status );
-            // Success message
-            if ( $completed_course ) { ?>
-                <div class="status completed"><?php  _e( 'Completed', 'woothemes-sensei' ); ?></div>
-                <?php
-                $has_quizzes = Sensei()->course->course_quizzes( $post->ID, true );
-                if( has_filter( 'sensei_results_links' ) || $has_quizzes ) { ?>
-                    <p class="sensei-results-links">
-                        <?php
-                        $results_link = '';
-                        if( $has_quizzes ) {
-                            $results_link = '<a class="view-results" href="' . Sensei()->course_results->get_permalink( $post->ID ) . '">' .  __( 'View results', 'woothemes-sensei' ) . '</a>';
-                        }
-                        /**
-                         * Filter documented in Sensei_Course::the_course_action_buttons
-                         */
-                        $results_link = apply_filters( 'sensei_results_links', $results_link, $post->ID );
-                        echo $results_link;
-                        ?></p>
-                <?php } ?>
-            <?php } else { ?>
-                <div class="status in-progress"><?php echo __( 'In Progress', 'woothemes-sensei' ); ?></div>
-            <?php }
+			// Check if course is completed
+			$user_course_status = Sensei_Utils::user_course_status( $post->ID, $current_user->ID );
+			$completed_course = Sensei_Utils::user_completed_course( $user_course_status );
+			// Success message
+			if ( $completed_course ) { ?>
+				<div class="status completed"><?php  _e( 'Completed', 'woothemes-sensei' ); ?></div>
+				<?php
+				$has_quizzes = Sensei()->course->course_quizzes( $post->ID, true );
+				if( has_filter( 'sensei_results_links' ) || $has_quizzes ) { ?>
+					<p class="sensei-results-links">
+						<?php
+						$results_link = '';
+						if( $has_quizzes ) {
+							$results_link = '<a class="view-results" href="' . Sensei()->course_results->get_permalink( $post->ID ) . '">' .  __( 'View results', 'woothemes-sensei' ) . '</a>';
+						}
+						/**
+						 * Filter documented in Sensei_Course::the_course_action_buttons
+						 */
+						$results_link = apply_filters( 'sensei_results_links', $results_link, $post->ID );
+						echo $results_link;
+						?></p>
+				<?php } ?>
+			<?php } else { ?>
+				<div class="status in-progress"><?php echo __( 'In Progress', 'woothemes-sensei' ); ?></div>
+			<?php }
 
-        } else {
+		} else {
 
-            // Check for woocommerce
-		    if ( Sensei_WC::is_woocommerce_active() && Sensei_WC::is_course_purchasable( $post->ID ) ) {
+			// Check for woocommerce
+			if ( Sensei_WC::is_woocommerce_active() && Sensei_WC::is_course_purchasable( $post->ID ) ) {
 
-	            $login_link =  '<a href="' . sensei_user_login_url() . '">' . __( 'log in', 'woothemes-sensei' ) . '</a>';
-	            $message = sprintf( __( 'Or %1$s to access your purchased courses', 'woothemes-sensei' ), $login_link );
-	            Sensei()->notices->add_notice( $message, 'info' ) ;
-	            Sensei_WC::the_add_to_cart_button_html( $post->ID );
+				$login_link =  '<a href="' . sensei_user_login_url() . '">' . __( 'log in', 'woothemes-sensei' ) . '</a>';
+				$message = sprintf( __( 'Or %1$s to access your purchased courses', 'woothemes-sensei' ), $login_link );
+				Sensei()->notices->add_notice( $message, 'info' ) ;
+				Sensei_WC::the_add_to_cart_button_html( $post->ID );
 
-            } else {
+			} else {
 
-                if( get_option( 'users_can_register') ) {
+				if( get_option( 'users_can_register') ) {
 
-	                // set the permissions message
-	                $anchor_before = '<a href="' . esc_url( sensei_user_login_url() ) . '" >';
-	                $anchor_after = '</a>';
-	                $notice = sprintf(
-		                __('or %slog in%s to view this course.', 'woothemes-sensei'),
-		                $anchor_before,
-		                $anchor_after
-	                );
+					// set the permissions message
+					$anchor_before = '<a href="' . esc_url( sensei_user_login_url() ) . '" >';
+					$anchor_after = '</a>';
+					$notice = sprintf(
+						__('or %slog in%s to view this course.', 'woothemes-sensei'),
+						$anchor_before,
+						$anchor_after
+					);
 
 					self::add_course_access_permission_message( $notice );
 
-                    $my_courses_page_id = '';
+					$my_courses_page_id = '';
 
-                    /**
-                     * Filter to force Sensei to output the default WordPress user
-                     * registration link.
-                     *
-                     * @since 1.9.0
-                     * @param bool $wp_register_link default false
-                     */
+					/**
+					 * Filter to force Sensei to output the default WordPress user
+					 * registration link.
+					 *
+					 * @since 1.9.0
+					 * @param bool $wp_register_link default false
+					 */
 
-                    $wp_register_link = apply_filters('sensei_use_wp_register_link', false);
+					$wp_register_link = apply_filters('sensei_use_wp_register_link', false);
 
-                    $settings = Sensei()->settings->get_settings();
-                    if( isset( $settings[ 'my_course_page' ] )
-                        && 0 < intval( $settings[ 'my_course_page' ] ) ){
+					$settings = Sensei()->settings->get_settings();
+					if( isset( $settings[ 'my_course_page' ] )
+						&& 0 < intval( $settings[ 'my_course_page' ] ) ){
 
-                        $my_courses_page_id = $settings[ 'my_course_page' ];
+						$my_courses_page_id = $settings[ 'my_course_page' ];
 
-                    }
+					}
 
-                    // If a My Courses page was set in Settings, and 'sensei_use_wp_register_link'
-                    // is false, link to My Courses. If not, link to default WordPress registration page.
-                    if( !empty( $my_courses_page_id ) && $my_courses_page_id && !$wp_register_link){
+					// If a My Courses page was set in Settings, and 'sensei_use_wp_register_link'
+					// is false, link to My Courses. If not, link to default WordPress registration page.
+					if( !empty( $my_courses_page_id ) && $my_courses_page_id && !$wp_register_link){
 						if ( true === (bool)apply_filters( 'sensei_user_can_register_for_course', true, $post->ID ) ) {
 							$my_courses_url = get_permalink( $my_courses_page_id  );
 							$register_link = '<a href="'.$my_courses_url. '">' . __('Register', 'woothemes-sensei') .'</a>';
 							echo '<div class="status register">' . $register_link . '</div>' ;
 						}
-                    } else {
+					} else {
 
-                        wp_register( '<div class="status register">', '</div>' );
+						wp_register( '<div class="status register">', '</div>' );
 
-                    }
+					}
 
-                } // end if user can register
+				} // end if user can register
 
-            } // End If Statement
+			} // End If Statement
 
-        } // End If Statement ?>
+		} // End If Statement ?>
 
-        </section><?php
+		</section><?php
 
-    }// end the_course_enrolment_actions
+	}// end the_course_enrolment_actions
 
-    /**
-     * Output the course video inside the loop.
-     *
-     * @since 1.9.0
-     */
-    public static function the_course_video(){
+	/**
+	 * Output the course video inside the loop.
+	 *
+	 * @since 1.9.0
+	 */
+	public static function the_course_video(){
 
-        global $post;
+		global $post;
 
-	    if ( ! is_singular( 'course' )  ) {
-		    return;
-	    }
+		if ( ! is_singular( 'course' )  ) {
+			return;
+		}
 
-        // Get the meta info
-        $course_video_embed = get_post_meta( $post->ID, '_course_video_embed', true );
+		// Get the meta info
+		$course_video_embed = get_post_meta( $post->ID, '_course_video_embed', true );
 
-        if ( 'http' == substr( $course_video_embed, 0, 4) ) {
+		if ( 'http' == substr( $course_video_embed, 0, 4) ) {
 
-            $course_video_embed = wp_oembed_get( esc_url( $course_video_embed ) );
+			$course_video_embed = wp_oembed_get( esc_url( $course_video_embed ) );
 
-        } // End If Statement
+		} // End If Statement
 
 	$course_video_embed = do_shortcode( $course_video_embed );
 
 	$course_video_embed = Sensei_Wp_Kses::maybe_sanitize( $course_video_embed, self::$allowed_html );
 
-        if ( '' != $course_video_embed ) { ?>
+		if ( '' != $course_video_embed ) { ?>
 
-            <div class="course-video">
-                <?php echo $course_video_embed; ?>
-            </div>
+			<div class="course-video">
+				<?php echo $course_video_embed; ?>
+			</div>
 
-        <?php } // End If Statement
-    }
+		<?php } // End If Statement
+	}
 
-    /**
-     * Output the title for the single lesson page
-     *
-     * @global $post
-     * @since 1.9.0
-     */
-    public static function the_title(){
+	/**
+	 * Output the title for the single lesson page
+	 *
+	 * @global $post
+	 * @since 1.9.0
+	 */
+	public static function the_title(){
 
-	    if( ! is_singular( 'course' ) ){
+		if( ! is_singular( 'course' ) ){
 			return;
-	    }
-        global $post;
+		}
+		global $post;
 
-        ?>
-        <header>
+		?>
+		<header>
 
-            <h1>
+			<h1>
 
-                <?php
-                /**
-                 * Filter documented in class-sensei-messages.php the_title
-                 */
-                echo apply_filters( 'sensei_single_title', get_the_title( $post ), $post->post_type );
-                ?>
+				<?php
+				/**
+				 * Filter documented in class-sensei-messages.php the_title
+				 */
+				echo apply_filters( 'sensei_single_title', get_the_title( $post ), $post->post_type );
+				?>
 
-            </h1>
+			</h1>
 
-        </header>
+		</header>
 
-        <?php
+		<?php
 
-    }//the_title
+	}//the_title
 
-    /**
-     * Show the title on the course category pages
-     *
-     * @since 1.9.0
-     */
-    public static function course_category_title(){
+	/**
+	 * Show the title on the course category pages
+	 *
+	 * @since 1.9.0
+	 */
+	public static function course_category_title(){
 
-        if( ! is_tax( 'course-category' ) ){
-            return;
-        }
+		if( ! is_tax( 'course-category' ) ){
+			return;
+		}
 
-        $category_slug = get_query_var('course-category');
-        $term  = get_term_by('slug',$category_slug,'course-category');
+		$category_slug = get_query_var('course-category');
+		$term  = get_term_by('slug',$category_slug,'course-category');
 
-        if( ! empty($term) ){
+		if( ! empty($term) ){
 
-            $title = __( 'Category', 'woothemes-sensei' ) . ' ' . $term->name;
+			$title = __( 'Category', 'woothemes-sensei' ) . ' ' . $term->name;
 
-        }else{
+		}else{
 
-            $title = 'Course Category';
+			$title = 'Course Category';
 
-        }
+		}
 
-        $html = '<h2 class="sensei-category-title">';
-        $html .=  $title;
-        $html .= '</h2>';
+		$html = '<h2 class="sensei-category-title">';
+		$html .=  $title;
+		$html .= '</h2>';
 
-        echo apply_filters( 'course_category_title', $html , $term->term_id );
+		echo apply_filters( 'course_category_title', $html , $term->term_id );
 
-    }// course_category_title
+	}// course_category_title
 
-    /**
-     * Alter the course query to respect the order set for courses and apply
-     * this on the course-category pages.
-     *
-     * @since 1.9.0
-     *
-     * @param WP_Query $query
-     * @return WP_Query
-     */
-    public static function alter_course_category_order( $query ){
+	/**
+	 * Alter the course query to respect the order set for courses and apply
+	 * this on the course-category pages.
+	 *
+	 * @since 1.9.0
+	 *
+	 * @param WP_Query $query
+	 * @return WP_Query
+	 */
+	public static function alter_course_category_order( $query ){
 
-        if( ! $query->is_main_query() || ! is_tax( 'course-category' ) ) {
-            return $query;
-        }
+		if( ! $query->is_main_query() || ! is_tax( 'course-category' ) ) {
+			return $query;
+		}
 
-        $order = get_option( 'sensei_course_order', '' );
-        if( !empty( $order )  ){
-            $query->set('orderby', 'menu_order' );
-            $query->set('order', 'ASC' );
-        }
+		$order = get_option( 'sensei_course_order', '' );
+		if( !empty( $order )  ){
+			$query->set('orderby', 'menu_order' );
+			$query->set('order', 'ASC' );
+		}
 
-        return $query;
+		return $query;
 
-    }
+	}
 
-    /**
-     * The very basic course query arguments
-     * so we don't have to repeat this througout
-     * the code base.
-     *
-     * Usage:
-     * $args = Sensei_Course::get_default_query_args();
-     * $args['custom_arg'] ='custom value';
-     * $courses = get_posts( $args )
-     *
-     * @since 1.9.0
-     *
-     * @return array
-     */
-    public static function get_default_query_args(){
-        return array(
-            'post_type' 		=> 'course',
-            'posts_per_page' 		=> 1000,
-            'orderby'         	=> 'date',
-            'order'           	=> 'DESC',
-            'suppress_filters' 	=> 0
-        );
-    }
+	/**
+	 * The very basic course query arguments
+	 * so we don't have to repeat this througout
+	 * the code base.
+	 *
+	 * Usage:
+	 * $args = Sensei_Course::get_default_query_args();
+	 * $args['custom_arg'] ='custom value';
+	 * $courses = get_posts( $args )
+	 *
+	 * @since 1.9.0
+	 *
+	 * @return array
+	 */
+	public static function get_default_query_args(){
+		return array(
+			'post_type' 		=> 'course',
+			'posts_per_page' 		=> 1000,
+			'orderby'         	=> 'date',
+			'order'           	=> 'DESC',
+			'suppress_filters' 	=> 0
+		);
+	}
 
-    /**
-     * Check if the prerequisite course is completed
-     * Courses with no pre-requisite should always return true
-     *
-     * @since 1.9.0
-     * @param $course_id
-     * @return bool
-     */
-    public static function is_prerequisite_complete( $course_id ){
+	/**
+	 * Check if the prerequisite course is completed
+	 * Courses with no pre-requisite should always return true
+	 *
+	 * @since 1.9.0
+	 * @param $course_id
+	 * @return bool
+	 */
+	public static function is_prerequisite_complete( $course_id ){
 
-        $course_prerequisite_id = get_post_meta( $course_id, '_course_prerequisite', true );
+		$course_prerequisite_id = get_post_meta( $course_id, '_course_prerequisite', true );
 
-        // if it has a pre requisite course check it
+		// if it has a pre requisite course check it
 		$prerequisite_complete = true;
 
-        if( ! empty(  $course_prerequisite_id ) ){
+		if( ! empty(  $course_prerequisite_id ) ){
 
 			$prerequisite_complete = Sensei_Utils::user_completed_course( $course_prerequisite_id, get_current_user_id() );
 
-        }
+		}
 
 		/**
 		 * Filter course prerequisite complete
@@ -3122,9 +3122,9 @@ class Sensei_Course {
 		 * @param bool $prerequisite_complete
 		 * @param int $course_id
 		 */
-        return apply_filters( 'sensei_course_is_prerequisite_complete', $prerequisite_complete, $course_id );
+		return apply_filters( 'sensei_course_is_prerequisite_complete', $prerequisite_complete, $course_id );
 
-    }// end is_prerequisite_complete
+	}// end is_prerequisite_complete
 
 	/**
 	 * Allowing user to set course archive page as front page.
@@ -3165,7 +3165,7 @@ class Sensei_Course {
 		// as the page URI
 		$settings_course_page = get_post( Sensei()->settings->get( 'course_page' ) );
 		if( ! is_a( $settings_course_page, 'WP_Post')
-		    ||  Sensei()->post_types->has_old_shortcodes( $settings_course_page->post_content )
+			||  Sensei()->post_types->has_old_shortcodes( $settings_course_page->post_content )
 			|| $settings_course_page->ID != get_option( 'page_on_front' ) ){
 
 			return;

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2632,8 +2632,7 @@ class Sensei_Course {
         }
 
         if ( ( is_user_logged_in() && $is_user_taking_course )
-            || ( $access_permission && !$has_product_attached)
-            || 'full' == Sensei()->settings->get( 'course_single_content_display' ) ) {
+            || ( $access_permission && !$has_product_attached) ) {
 
 	        // compensate for core providing and empty $content
 
@@ -2806,29 +2805,6 @@ class Sensei_Course {
         if( 'course' == get_post_type( $post_id )  ){
 
             Sensei()->initiate_rewrite_rules_flush();
-
-        }
-
-    }
-
-    /**
-     * Optionally return the full content on the single course pages
-     * depending on the users course_single_content_display setting
-     *
-     * @since 1.9.0
-     * @param $excerpt
-     * @return string
-     */
-    public static function full_content_excerpt_override( $excerpt ){
-
-        if (   is_singular('course')  &&
-                'full' == Sensei()->settings->get( 'course_single_content_display' ) ){
-
-            return get_the_content();
-
-        } else {
-
-            return $excerpt;
 
         }
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -162,7 +162,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$pages_array = $this->pages_array();
 		$posts_per_page_array = array( '0' => '0', '1' => '1', '2' => '2', '3' => '3', '4' => '4', '5' => '5', '6' => '6', '7' => '7', '8' => '8', '9' => '9', '10' => '10', '11' => '11', '12' => '12', '13' => '13', '14' => '14', '15' => '15', '16' => '16', '17' => '17', '18' => '18', '19' => '19', '20' => '20' );
 		$complete_settings = array( 'passed' => __( 'Once all the course lessons have been completed', 'woothemes-sensei' ), 'complete' => __( 'At any time (by clicking the \'Complete Course\' button)', 'woothemes-sensei' ) );
-		$course_display_settings = array( 'excerpt' => __( 'Course Excerpt', 'woothemes-sensei' ), 'full' => __( 'Full Course Content', 'woothemes-sensei' ) );
 		$quiz_points_formats = array(
 			'none'     => __( "Don't show quiz question points", 'woothemes-sensei' ),
 			'number'   => __( "Number (e.g. 1. Default)", 'woothemes-sensei' ),
@@ -352,16 +351,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 								'type' => 'checkbox',
 								'default' => false,
 								'section' => 'course-settings'
-								);
-
-		$fields['course_single_content_display'] = array(
-								'name' => __( 'Single Course page displays:', 'woothemes-sensei' ),
-								'description' => __( 'Determines what content to display on the single course page.', 'woothemes-sensei' ),
-								'type' => 'select',
-								'default' => 'excerpt',
-								'section' => 'course-settings',
-								'required' => 0,
-								'options' => $course_display_settings
 								);
 
 		$fields['course_archive_featured_enable'] = array(

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -144,10 +144,6 @@ add_action( 'sensei_single_course_modules_before', array( 'Sensei_Core_Modules',
 // hook in the module loop destructor functionality
 add_action( 'sensei_single_course_modules_after', array( 'Sensei_Core_Modules', 'teardown_single_course_module_loop' ) );
 
-// @since 1.9.0
-// hook in the possible full content override to show instead of excerpt
-add_filter('get_the_excerpt', array( 'Sensei_Course', 'full_content_excerpt_override' ) );
-
 //@since 1.9.0
 //Course meta
 add_action( 'sensei_single_course_content_inside_before', array( 'Sensei_Course', 'the_course_enrolment_actions' ), 30 );


### PR DESCRIPTION
Hi @donnapep,

Could you use this PR to address #1939 ?

This PR removes the Single Course page displays in sensei's course settings. 
I also noticed class-sensei-course has a mix of spaces and tabs, so I made the whole file use tabs instead of spaces on another commit. Maybe it would be more suitable if I did another PR.

Happy to hear some feedback, and no worries since i know this might take a while to get reviewed. 

Thanks!