### PR TITLE
Update URL and Twitter account in tweet

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -183,7 +183,7 @@ class Sensei_Admin {
             ?>
             <div id="message" class="updated sensei-message sensei-connect">
                 <p><?php _e( '<strong>Congratulations!</strong> &#8211; Sensei has been installed and set up.', 'woothemes-sensei' ); ?></p>
-                <p><a href="https://twitter.com/share" class="twitter-share-button" data-url="http://www.woothemes.com/sensei/" data-text="A premium Learning Management plugin for #WordPress that helps you create courses. Beautifully." data-via="WooThemes" data-size="large" data-hashtags="Sensei">Tweet</a>
+                <p><a href="https://twitter.com/share" class="twitter-share-button" data-url="https://woocommerce.com/products/sensei/" data-text="A premium Learning Management plugin for #WordPress that helps you create courses. Beautifully." data-via="senseilms" data-size="large" data-hashtags="Sensei">Tweet</a>
                 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script></p>
             </div>
             <?php


### PR DESCRIPTION
This PR updates the Twitter account info in the tweet text that is available after Sensei is first installed.

## Testing
1. Deactivate and re-activate Sensei.
2. Click _Skip setup_.
3. Click the _Tweet_ button. Ensure the tweet is "A premium Learning Management plugin for #WordPress that helps you create courses. Beautifully. https://woocommerce.com/products/sensei/ #Sensei via @senseilms"