### PR TITLE
Add phpcodesniffer to the composer.json file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,9 @@
 {
+	"name": "Sensei",
+	"description": "A learning management plugin for WordPress, which provides the smoothest platform for helping you teach anything.",
 	"require-dev": {
 		"apigen/apigen": "*",
+		"squizlabs/php_codesniffer": "3.*",
 		"wp-coding-standards/wpcs": "^0.14.0",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
 	}

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-	"name": "Sensei",
+	"name": "woothemes-sensei",
 	"description": "A learning management plugin for WordPress, which provides the smoothest platform for helping you teach anything.",
 	"require-dev": {
 		"apigen/apigen": "*",


### PR DESCRIPTION
This PR adds PHPCodeSniffer to the composer.json file, to avoid errors in environments that expect it be available locally in order to run. This change will also help us better write automation scripts that do not rely on global installs.

As a consequence, I also added the `name` and `description` field to the composer.json file which will help if someone is using [wppackagist](https://wpackagist.org/) to manage plugins.

