### PR TITLE
Update VVV test install script and ReadMe

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -6,24 +6,24 @@
 
 1) `$ vagrant SSH` into the machine running your Sensei setup.
 
-2) `$ cd /srv/www/wp-trunk ` or `$ cd /srv/www/wp-trunk wp-develop` depending on where you run Sensei from.
+2) `$ cd /srv/www/wordpress-default/public_html` or `$ cd /srv/www/wordpress-develop/public_html/src` depending on where you run Sensei from.
 
-3) Proceed to `cd wp-content/plugins/sensei/` or to directory where you've installed Sensei
+3) Proceed to `cd wp-content/plugins/sensei` or to directory where you've installed Sensei
 
 4) Install the tests:
 
-    $ tests/bin/install_vvv.sh
+    `$ tests/bin/install_vvv.sh`
 
 ### In your local machine
 
 1) Install [PHPUnit](http://phpunit.de/) by following their [installation guide](https://phpunit.de/getting-started.html). If you've installed it correctly, this should display the version:
 
-    $ phpunit --version
+    `$ phpunit --version`
 
 
 2) Install WordPress and the WP Unit Test lib using the `install.sh` script. Change to the plugin root directory and type:
 
-    $ tests/bin/install.sh
+    `$ tests/bin/install.sh`
 
 **Important**: You might need to change the DB parameters accordingly within the `install.sh` file.
 
@@ -31,7 +31,7 @@
 
 Simply change to the plugin root directory and type:
 
-    $ phpunit
+    $ gulp test
 
 The tests will execute and you'll be presented with a summary. Code coverage documentation is automatically generated as HTML in the `tmp/coverage` directory.
 
@@ -45,9 +45,9 @@ A text code coverage summary can be displayed using the `--coverage-text` option
 
 ## Writing Tests
 
-* Each test file should roughly correspond to an associated source file, e.g. the `test-class-woothemes-sensei.php` test file covers code in `class-woothemes-sensei.php`
-* Each test method should cover a single method or function with one or more assertions
-* A single method or function can have multiple associated test methods if it's a large or complex method
-* Prefer `assertsEquals()` where possible as it tests both type & equality
+* Each test file should roughly correspond to an associated source file, e.g. the `test-class-woothemes-sensei.php` test file covers code in `class-woothemes-sensei.php`.
+* Each test method should cover a single method or function with one or more assertions.
+* A single method or function can have multiple associated test methods if it's a large or complex method.
+* Prefer `assertsEquals()` where possible as it tests both type & equality.
 * Remember that only methods prefixed with `test` will be run.
 * Filters persist between test cases so be sure to remove them in your test method or in the `tearDown()` method.

--- a/tests/bin/install_vvv.sh
+++ b/tests/bin/install_vvv.sh
@@ -23,7 +23,7 @@ install_test_suite() {
 	# set up testing suite
 	cd $WP_TESTS_DIR
 	rm -rf wp-tests-config.php
-	cp ../../wp-tests-config.php wp-tests-config.php
+	cp ../../wp-tests-config-sample.php wp-tests-config.php
 
 	sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" wp-tests-config.php
 	sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" wp-tests-config.php


### PR DESCRIPTION
In setting up VVV, I realized there was an error in the VVV test install script, and that the instructions were outdated. This PR updates the script and instructions to work with Vagrant 2.1.2 and VVV 2.2.1.

## Testing
You'll need to be using [VVV](https://varyingvagrantvagrants.org/docs/en-US/installation/) in order to test. Just follow the _Using Varying Vagrant Vagrants_ instructions in the _Sensei Unit Tests_ [ReadMe](https://github.com/Automattic/sensei/blob/5171de03cfd1ad35e8184bdba437221ef5e3e8e0/tests/README.md) and ensure that everything works.