### PR TITLE
Fix npm test scripts and CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,12 @@ before_script:
   fi
 jobs:
   include:
-    - stage: test
-      script:
-        - npm install || exit 1
-        - npm run test || exit 1
+    # There are no JS blocks to test yet. Uncomment below when we start adding
+    # blocks.
+    #- stage: test
+    #  script:
+    #    - npm install || exit 1
+    #    - npm run test-js || exit 1
     - stage: test
       php: 7.2
       env: WP_VERSION=latest

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
   "scripts": {
     "build": "gulp && cross-env BABEL_ENV=default webpack --mode=production",
     "dev": "gulp && cross-env BABEL_ENV=default webpack --mode=development --watch",
-    "test": "gulp test && jest"
+    "test": "npm run test-php && npm run test-js",
+    "test-php": "gulp test",
+    "test-js": "jest"
   }
 }


### PR DESCRIPTION
The CI is failing on the JS testing environment. This is for two reasons:

1. It was trying to execute PHP tests *and* JS tests without the environment set up. This PR sets it up to only run the JS tests.

2. The JS tests are set up for testing Gutenberg blocks, but we don't have any yet! So `jest` fails because it can't find any test files to run. For now, I've commented out the relevant lines in `.travis.yml`. When we start developing blocks, these lines can be uncommented. Alternatively, we could remove them now and add them back in later if that seems cleaner.