### PR TITLE
Show comments for preview lessons

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3888,25 +3888,25 @@ class Sensei_Lesson {
 	} // End sensei_lesson_quiz_meta()
 
 	/**
-	 * Show the lesson comments. This should be used in the loop.
+	 * Shows the lesson comments. This should be used in the loop.
 	 *
 	 * @since 1.9.0
 	 */
-	public static function output_comments(){
+	public static function output_comments() {
+		global $post;
 
 		$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
-		$allow_comments = Sensei()->settings->settings[ 'lesson_comments' ];
-		$user_taking_course = Sensei_Utils::user_started_course($course_id );
+		$allow_comments = Sensei()->settings->settings['lesson_comments'];
+		$user_taking_course = Sensei_Utils::user_started_course( $course_id );
+		$has_access = ! Sensei()->settings->get( 'access_permission' );
+		$is_preview = Sensei_Utils::is_preview_lesson( $post->ID );
 
-		$lesson_allow_comments = $allow_comments  && $user_taking_course;
+		$lesson_allow_comments = $allow_comments && ( $user_taking_course || $has_access || $is_preview );
 
-		if (  $lesson_allow_comments || is_singular( 'sensei_message' ) ) {
-
+		if ( $lesson_allow_comments || is_singular( 'sensei_message' ) ) {
 			comments_template();
-
-		} // End If Statement
-
-	} //output_comments
+		}
+	}
 
 	/**
 	 * Display the leeson quiz status if it should be shown


### PR DESCRIPTION
Fixes #2192.

## Setup
1. In _Sensei_ > _Settings_ > _Lessons_, select the _Allow Comments For Lessons_ checkbox.
2. Open an existing lesson. In the _Discussion_ meta box, select the _Allow comments_ checkbox.

## Testing
Ensure that lesson comments are visible to a logged out user when:
- _Access Permissions_ and _Allow this lesson to be viewed without purchase/login_ are both selected.
- _Access Permissions_ is **not** selected and _Allow this lesson to be viewed without purchase/login_ is selected.
- _Access Permissions_ is **not** selected and _Allow this lesson to be viewed without purchase/login_ is **not** selected.

Ensure lesson comments are **not** visible to a logged out user when:
- _Access Permissions_ is selected and _Allow this lesson to be viewed without purchase/login_ is **not** selected.