### PR TITLE
Fix i18n linter issues and add checks to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,3 +78,8 @@ jobs:
       script:
         - npm install
         - npx eslint --config .eslintrc.wpcom.json --ignore-path .eslintignore-wpcom .
+    - stage: test
+      php: 7.2
+      script:
+        - composer install
+        - ./vendor/bin/phpcs -s --sniffs=WordPress.WP.I18n,Generic.PHP.Syntax .

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -394,7 +394,12 @@ class Sensei_Admin {
 	public function language_pack_install_notice() {
 		?>
 		<div id="message" class="updated sensei-message sensei-connect">
-				<p><?php echo sprintf( __( '%1$sSensei in your language %2$s. There is a translation available for your language.', 'woothemes-sensei' ),'<strong>','</strong>' ); ?><p>
+			<p>
+				<?php
+				// translators: Placeholders are opening and closing <strong> tags.
+				echo sprintf( __( '%1$sSensei in your language %2$s. There is a translation available for your language.', 'woothemes-sensei' ),'<strong>','</strong>' );
+				?>
+			</p>
 
 				<p class="submit">
 					<a href="<?php echo esc_url( Sensei_Language_Pack_Manager::get_install_uri() ); ?>" class="button-primary"><?php _e( 'Install', 'woothemes-sensei' ); ?></a>
@@ -509,6 +514,7 @@ class Sensei_Admin {
 	 */
 	private function duplicate_content( $post_type = 'lesson', $with_lessons = false ) {
 		if ( ! isset( $_GET['post'] ) ) {
+			// translators: Placeholder is the post type string.
 			wp_die( sprintf( __( 'Please supply a %1$s ID.', 'woothemes-sensei' ) ), $post_type );
 		}
 

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -394,7 +394,7 @@ class Sensei_Admin {
 	public function language_pack_install_notice() {
 		?>
 		<div id="message" class="updated sensei-message sensei-connect">
-				<p><?php echo sprintf( __( '%sSensei in your language %s. There is a translation available for your language.', 'woothemes-sensei' ),'<strong>','</strong>' ); ?><p>
+				<p><?php echo sprintf( __( '%1$sSensei in your language %2$s. There is a translation available for your language.', 'woothemes-sensei' ),'<strong>','</strong>' ); ?><p>
 
 				<p class="submit">
 					<a href="<?php echo esc_url( Sensei_Language_Pack_Manager::get_install_uri() ); ?>" class="button-primary"><?php _e( 'Install', 'woothemes-sensei' ); ?></a>
@@ -1599,7 +1599,7 @@ class Sensei_Admin {
 			 * - The current admin email address from the Settings.
 			 * - A link to view the existing admin users, with the translated text "existing Administrator".
 			 */
-			$warning = __( 'To prevent issues with Sensei module names, your Email Address in %s should also belong to an Administrator user. You can either %s with the email address %s, or change that email address to match the email of an %s.', 'woothemes-sensei' );
+			$warning = __( 'To prevent issues with Sensei module names, your Email Address in %1$s should also belong to an Administrator user. You can either %2$s with the email address %3$s, or change that email address to match the email of an %4$s.', 'woothemes-sensei' );
 
 			?><div id="message" class="error sensei-message sensei-connect">
 				<p>

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -269,7 +269,7 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 		switch( $this->type ) {
 			case 'courses' :
 				// Get Learners (i.e. those who have started)
-				$course_args = array( 
+				$course_args = array(
 						'post_id' => $item->ID,
 						'type' => 'sensei_course_status',
 						'status' => 'any',
@@ -277,7 +277,7 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 				$course_students = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_learners', $course_args, $item ) );
 
 				// Get Course Completions
-				$course_args = array( 
+				$course_args = array(
 						'post_id' => $item->ID,
 						'type' => 'sensei_course_status',
 						'status' => 'complete',
@@ -288,7 +288,7 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 				$course_lessons = Sensei()->lesson->lesson_count( array('publish', 'private'), $item->ID );
 
 				// Get Percent Complete
-				$grade_args = array( 
+				$grade_args = array(
 						'post_id' => $item->ID,
 						'type' => 'sensei_course_status',
 						'status' => 'any',
@@ -324,7 +324,7 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 
 			case 'lessons' :
 				// Get Learners (i.e. those who have started)
-				$lesson_args = array( 
+				$lesson_args = array(
 						'post_id' => $item->ID,
 						'type' => 'sensei_lesson_status',
 						'status' => 'any',
@@ -332,7 +332,7 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 				$lesson_students = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_learners', $lesson_args, $item ) );
 
 				// Get Course Completions
-				$lesson_args = array( 
+				$lesson_args = array(
 						'post_id' => $item->ID,
 						'type' => 'sensei_lesson_status',
 						'status' => array( 'complete', 'graded', 'passed', 'failed' ),
@@ -340,14 +340,14 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 					);
 				$lesson_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_completions', $lesson_args, $item ) );
 
-				// Course 
+				// Course
 				$course_id = get_post_meta( $item->ID, '_lesson_course', true );
 				$course_title = $course_id ? get_the_title( $course_id ) : '';
 
 				$lesson_average_grade = __('n/a', 'woothemes-sensei');
 				if ( false != Sensei_Lesson::lesson_quiz_has_questions( $item->ID ) ) {
 					// Get Percent Complete
-					$grade_args = array( 
+					$grade_args = array(
 							'post_id' => $item->ID,
 							'type' => 'sensei_lesson_status',
 							'status' => array( 'graded', 'passed', 'failed' ),
@@ -393,7 +393,7 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 			case 'users' :
 			default:
 				// Get Started Courses
-				$course_args = array( 
+				$course_args = array(
 						'user_id' => $item->ID,
 						'type' => 'sensei_course_status',
 						'status' => 'any',
@@ -401,7 +401,7 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 				$user_courses_started = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_courses_started', $course_args, $item ) );
 
 				// Get Completed Courses
-				$course_args = array( 
+				$course_args = array(
 						'user_id' => $item->ID,
 						'type' => 'sensei_course_status',
 						'status' => 'complete',
@@ -409,7 +409,7 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 				$user_courses_ended = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_courses_ended', $course_args, $item ) );
 
 				// Get Quiz Grades
-				$grade_args = array( 
+				$grade_args = array(
 						'user_id' => $item->ID,
 						'type' => 'sensei_lesson_status',
 						'status' => 'any',
@@ -569,12 +569,12 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 		}
 
 
-		$course_args = array( 
+		$course_args = array(
 				'type' => 'sensei_course_status',
 				'status' => 'any',
 			);
 		$total_courses_started = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_total_courses_started', $course_args ) );
-		$course_args = array( 
+		$course_args = array(
 				'type' => 'sensei_course_status',
 				'status' => 'complete',
 			);
@@ -582,7 +582,7 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 		$average_courses_per_learner = Sensei_Utils::quotient_as_absolute_rounded_number( $total_courses_started, $user_count, 2 );
 
 		// Setup the boxes to render
-		$stats_to_render = array( 
+		$stats_to_render = array(
 								__( 'Total Courses', 'woothemes-sensei' ) => $total_courses,
 								__( 'Total Lessons', 'woothemes-sensei' ) => $total_lessons,
 								__( 'Total Learners', 'woothemes-sensei' ) => $user_count,
@@ -605,6 +605,7 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 		} else {
 			$type = $this->view;
 		}
+		// translators: Placeholders %1$s and %3$s are opening and closing <em> tages, %2$s is the view type.
 		echo  sprintf( __( '%1$sNo %2$s found%3$s', 'woothemes-sensei' ), '<em>', $type, '</em>' );
 	} // End no_items()
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -516,7 +516,14 @@ class Sensei_Course {
 				$html .= '<p>'."\n";
 
 					$html .= $post_item->post_title."\n";
-					$html .= '<a href="' . esc_url( get_edit_post_link( $post_item->ID ) ) . '" title="' . esc_attr( sprintf( __( 'Edit %s', 'woothemes-sensei' ), $post_item->post_title ) ) . '" class="edit-lesson-action">' . __( 'Edit this lesson', 'woothemes-sensei' ) . '</a>';
+				$html .= '<a href="'
+					. esc_url( get_edit_post_link( $post_item->ID ) )
+					. '" title="'
+					// translators: Placeholder is the Lesson title.
+					. esc_attr( sprintf( __( 'Edit %s', 'woothemes-sensei' ), $post_item->post_title ) )
+					. '" class="edit-lesson-action">'
+					. __( 'Edit this lesson', 'woothemes-sensei' )
+					. '</a>';
 
 				$html .= '</p>'."\n";
 
@@ -611,7 +618,16 @@ class Sensei_Course {
 
 			case 'course-prerequisite':
 				$course_prerequisite_id = get_post_meta( $id, '_course_prerequisite', true);
-				if ( 0 < absint( $course_prerequisite_id ) ) { echo '<a href="' . esc_url( get_edit_post_link( absint( $course_prerequisite_id ) ) ) . '" title="' . esc_attr( sprintf( __( 'Edit %s', 'woothemes-sensei' ), get_the_title( absint( $course_prerequisite_id ) ) ) ) . '">' . get_the_title( absint( $course_prerequisite_id ) ) . '</a>'; }
+				if ( 0 < absint( $course_prerequisite_id ) ) {
+					echo '<a href="'
+						. esc_url( get_edit_post_link( absint( $course_prerequisite_id ) ) )
+						. '" title="'
+						// translators: Placeholder is the title of the course prerequisite.
+						. esc_attr( sprintf( __( 'Edit %s', 'woothemes-sensei' ), get_the_title( absint( $course_prerequisite_id ) ) ) )
+						. '">'
+						. get_the_title( absint( $course_prerequisite_id ) )
+						. '</a>';
+				}
 
 			break;
 
@@ -632,7 +648,14 @@ class Sensei_Course {
 						} else {
 							$product_name = get_the_title( absint( $course_woocommerce_product_id ) );
 						} // End If Statement
-						echo '<a href="' . esc_url( get_edit_post_link( absint( $course_woocommerce_product_id ) ) ) . '" title="' . esc_attr( sprintf( __( 'Edit %s', 'woothemes-sensei' ), $product_name ) ) . '">' . $product_name . '</a>';
+						echo '<a href="'
+							. esc_url( get_edit_post_link( absint( $course_woocommerce_product_id ) ) )
+							. '" title="'
+							// translators: Placeholder is the product name.
+							. esc_attr( sprintf( __( 'Edit %s', 'woothemes-sensei' ), $product_name ) )
+							. '">'
+							. $product_name
+							. '</a>';
 					} // End If Statement
 				} // End If Statement
 			break;
@@ -1381,9 +1404,14 @@ class Sensei_Course {
 				// Course Categories
 				if ( '' != $category_output ) {
 
-					$active_html .= '<span class="course-category">' . sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ) . '</span>';
+					$active_html .= '<span class="course-category">'
+						// translators: Placeholder is a comma-separated list of the Course categories.
+						. sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output )
+						. '</span>';
 
 				} // End If Statement
+
+				// translators: Placeholders are the counts for lessons completed and total lessons, respectively.
 				$active_html .= '<span class="course-lesson-progress">' . sprintf( __( '%1$d of %2$d lessons completed', 'woothemes-sensei' ) , $lessons_completed, $lesson_count  ) . '</span>';
 
 				$active_html .= '</p>';
@@ -1520,6 +1548,7 @@ class Sensei_Course {
 							// Course Categories
 							if ( '' != $category_output ) {
 
+								// translators: Placeholder is comma-separated list of course categories.
 								$complete_html .= '<span class="course-category">' . sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ) . '</span>';
 
 							} // End If Statement
@@ -1769,6 +1798,7 @@ class Sensei_Course {
 		$completed = count( $this->get_completed_lesson_ids( $course_id, $user_id ) );
 		$total_lessons = count( $this->course_lessons( $course_id ) );
 
+		// translators: Placeholders are the counts for lessons completed and total lessons, respectively.
 		$statement = sprintf( _n('Currently completed %1$s lesson of %2$s in total', 'Currently completed %1$s lessons of %2$s in total', $completed, 'woothemes-sensei'), $completed, $total_lessons );
 
 		/**
@@ -2047,7 +2077,10 @@ class Sensei_Course {
 				<a href="<?php echo get_permalink(); ?>">
 					<?php _e( 'Preview this course', 'woothemes-sensei' ) ?>
 				</a>
-				- <?php echo sprintf( __( '(%d preview lessons)', 'woothemes-sensei' ), $preview_lesson_count ) ; ?>
+				- <?php
+					// translators: Placeholder is the number of preview lessons.
+					echo sprintf( __( '(%d preview lessons)', 'woothemes-sensei' ), $preview_lesson_count ) ;
+				?>
 			</p>
 
 		<?php
@@ -2081,7 +2114,12 @@ class Sensei_Course {
 
 	   <?php if ( '' != $category_output ) { ?>
 
-			<span class="course-category"><?php echo sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ); ?></span>
+			<span class="course-category">
+				<?php
+				// translators: Placeholder is a comma-separated list of the course categories.
+				echo sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output );
+				?>
+</span>
 
 		<?php } // End If Statement
 
@@ -2091,6 +2129,7 @@ class Sensei_Course {
 
 			$completed = count( $this->get_completed_lesson_ids( $course->ID, get_current_user_id() ) );
 			$lesson_count = count( $this->course_lessons( $course->ID ) );
+			// translators: Placeholders are the number of lessons completed and the total number of lessons, respectively.
 			echo '<span class="course-lesson-progress">' . sprintf( __( '%1$d of %2$d lessons completed', 'woothemes-sensei' ) , $completed, $lesson_count  ) . '</span>';
 
 		}
@@ -2560,6 +2599,7 @@ class Sensei_Course {
 			$taxonomy_obj = $wp_query->get_queried_object();
 			$taxonomy_short_name = $taxonomy_obj->taxonomy;
 			$taxonomy_raw_obj = get_taxonomy( $taxonomy_short_name );
+			// translators: Placeholders are the taxonomy name and the term name, respectively.
 			$title = sprintf( __( '%1$s Archives: %2$s', 'woothemes-sensei' ), $taxonomy_raw_obj->labels->name, $taxonomy_obj->name );
 			echo apply_filters( 'course_category_archive_title', $before_html . $title . $after_html );
 			return;
@@ -2896,6 +2936,7 @@ class Sensei_Course {
 			if ( Sensei_WC::is_woocommerce_active() && Sensei_WC::is_course_purchasable( $post->ID ) ) {
 
 				$login_link =  '<a href="' . sensei_user_login_url() . '">' . __( 'log in', 'woothemes-sensei' ) . '</a>';
+				// translators: Placeholder is a link to log in.
 				$message = sprintf( __( 'Or %1$s to access your purchased courses', 'woothemes-sensei' ), $login_link );
 				Sensei()->notices->add_notice( $message, 'info' ) ;
 				Sensei_WC::the_add_to_cart_button_html( $post->ID );
@@ -2908,6 +2949,7 @@ class Sensei_Course {
 					$anchor_before = '<a href="' . esc_url( sensei_user_login_url() ) . '" >';
 					$anchor_after = '</a>';
 					$notice = sprintf(
+						// translators: Placeholders are an opening and closing <a> tag linking to the login URL.
 						__('or %1$slog in%2$s to view this course.', 'woothemes-sensei'),
 						$anchor_before,
 						$anchor_after

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1769,7 +1769,7 @@ class Sensei_Course {
 		$completed = count( $this->get_completed_lesson_ids( $course_id, $user_id ) );
 		$total_lessons = count( $this->course_lessons( $course_id ) );
 
-		$statement = sprintf( _n('Currently completed %s lesson of %s in total', 'Currently completed %s lessons of %s in total', $completed, 'woothemes-sensei'), $completed, $total_lessons );
+		$statement = sprintf( _n('Currently completed %1$s lesson of %2$s in total', 'Currently completed %1$s lessons of %2$s in total', $completed, 'woothemes-sensei'), $completed, $total_lessons );
 
 		/**
 		 * Filter the course completion statement.
@@ -2908,7 +2908,7 @@ class Sensei_Course {
 					$anchor_before = '<a href="' . esc_url( sensei_user_login_url() ) . '" >';
 					$anchor_after = '</a>';
 					$notice = sprintf(
-						__('or %slog in%s to view this course.', 'woothemes-sensei'),
+						__('or %1$slog in%2$s to view this course.', 'woothemes-sensei'),
 						$anchor_before,
 						$anchor_after
 					);

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1439,8 +1439,11 @@ class Sensei_Frontend {
 		if ( 0 < intval( $wc_post_id ) && ! $user_course_status_id ) {
 
 			if ( Sensei_WC::is_product_in_cart( $wc_post_id ) ) {
-				// translators: Placeholder is a link to complete the purchase.
-				echo '<div class="sensei-message info">' . sprintf( __( 'You have already added this Course to your cart. Please %1$s to access the course.', 'woothemes-sensei' ) . '</div>', '<a class="cart-complete" href="' . $woocommerce->cart->get_checkout_url() . '" title="' . __( 'complete the purchase', 'woothemes-sensei' ) . '">' . __( 'complete the purchase', 'woothemes-sensei' ) . '</a>' );
+				echo '<div class="sensei-message info">' . sprintf(
+					// translators: Placeholder is a link to complete the purchase.
+					__( 'You have already added this Course to your cart. Please %1$s to access the course.', 'woothemes-sensei' ) . '</div>',
+					'<a class="cart-complete" href="' . $woocommerce->cart->get_checkout_url() . '" title="' . __( 'complete the purchase', 'woothemes-sensei' ) . '">' . __( 'complete the purchase', 'woothemes-sensei' ) . '</a>'
+				);
 			} // End If Statement
 		} // End If Statement
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1130,6 +1130,7 @@ class Sensei_Frontend {
 			<p class="course-excerpt"><?php the_excerpt(); ?></p>
 			<?php
 			if ( 0 < $free_lesson_count ) {
+				// translators: Placeholder is the number of free lessons in the course.
 				$free_lessons = sprintf( __( 'You can access %d of this course\'s lessons for free', 'woothemes-sensei' ), $free_lesson_count );
 				?>
 				<p class="sensei-free-lessons"><a href="<?php echo get_permalink( $post_id ); ?>"><?php _e( 'Preview this course', 'woothemes-sensei' ); ?></a> - <?php echo $free_lessons; ?></p>

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -756,7 +756,10 @@ class Sensei_Frontend {
 				if ( $tag_list ) {
 					?>
 					<section class="lesson-tags">
-						<?php printf( __( 'Lesson tags: %1$s', 'woothemes-sensei' ), $tag_list ); ?>
+						<?php
+							// translators: Placeholder is a comma-separated list of links to the tags.
+							printf( __( 'Lesson tags: %1$s', 'woothemes-sensei' ), $tag_list );
+						?>
 					</section>
 					<?php
 				}
@@ -789,6 +792,7 @@ class Sensei_Frontend {
 	 */
 	public function lesson_tag_archive_header( $title ) {
 		if ( is_tax( 'lesson-tag' ) ) {
+			// translators: Placeholder is the filtered tag name.
 			$title = sprintf( __( 'Lesson tag: %1$s', 'woothemes-sensei' ), apply_filters( 'sensei_lesson_tag_archive_title', get_queried_object()->name ) );
 		}
 		return $title;
@@ -914,7 +918,10 @@ class Sensei_Frontend {
 						do_action( 'sensei_user_course_end', $current_user->ID, $sanitized_course_id );
 
 						// Success message.
-						$this->messages = '<header class="archive-header"><div class="sensei-message tick">' . sprintf( __( '%1$s marked as complete.', 'woothemes-sensei' ), get_the_title( $sanitized_course_id ) ) . '</div></header>';
+						$this->messages = '<header class="archive-header"><div class="sensei-message tick">'
+							// translators: Placeholder is the Course title.
+							. sprintf( __( '%1$s marked as complete.', 'woothemes-sensei' ), get_the_title( $sanitized_course_id ) )
+							. '</div></header>';
 					} // End If Statement
 
 					break;
@@ -923,7 +930,10 @@ class Sensei_Frontend {
 					Sensei_Utils::sensei_remove_user_from_course( $sanitized_course_id, $current_user->ID );
 
 					// Success message.
-					$this->messages = '<header class="archive-header"><div class="sensei-message tick">' . sprintf( __( '%1$s deleted.', 'woothemes-sensei' ), get_the_title( $sanitized_course_id ) ) . '</div></header>';
+					$this->messages = '<header class="archive-header"><div class="sensei-message tick">'
+						// translators: Placeholder is the Course title.
+						. sprintf( __( '%1$s deleted.', 'woothemes-sensei' ), get_the_title( $sanitized_course_id ) )
+						. '</div></header>';
 					break;
 
 				default:
@@ -1108,7 +1118,12 @@ class Sensei_Frontend {
 			<?php } // End If Statement ?>
 			   <span class="course-lesson-count"><?php echo Sensei()->course->course_lesson_count( $post_id ) . '&nbsp;' . __( 'Lessons', 'woothemes-sensei' ); ?></span>
 			<?php if ( '' != $category_output ) { ?>
-			   <span class="course-category"><?php echo sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ); ?></span>
+				<span class="course-category">
+					<?php
+					// translators: Placeholder is a comma-separated list of course categories.
+					echo sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output );
+					?>
+				</span>
 			<?php } // End If Statement ?>
 			<?php sensei_simple_course_price( $post_id ); ?>
 			</p>
@@ -1284,7 +1299,15 @@ class Sensei_Frontend {
 				<span class="course-author"><?php _e( 'by', 'woothemes-sensei' ); ?><?php the_author_link(); ?></span>
 				<?php } ?>
 				<?php if ( 0 < intval( $lesson_course_id ) ) { ?>
-				<span class="lesson-course"><?php echo '&nbsp;' . sprintf( __( 'Part of: %s', 'woothemes-sensei' ), '<a href="' . esc_url( get_permalink( $lesson_course_id ) ) . '" title="' . __( 'View course', 'woothemes-sensei' ) . '"><em>' . get_the_title( $lesson_course_id ) . '</em></a>' ); ?></span>
+				<span class="lesson-course">
+					<?php
+					echo '&nbsp;' . sprintf(
+						// translators: Placeholder is a link to view the course.
+						__( 'Part of: %s', 'woothemes-sensei' ),
+						'<a href="' . esc_url( get_permalink( $lesson_course_id ) ) . '" title="' . __( 'View course', 'woothemes-sensei' ) . '"><em>' . get_the_title( $lesson_course_id ) . '</em></a>'
+					);
+					?>
+				</span>
 				<?php } ?>
 			</p>
 			<p class="lesson-excerpt"><?php the_excerpt(); ?></p>
@@ -1416,6 +1439,7 @@ class Sensei_Frontend {
 		if ( 0 < intval( $wc_post_id ) && ! $user_course_status_id ) {
 
 			if ( Sensei_WC::is_product_in_cart( $wc_post_id ) ) {
+				// translators: Placeholder is a link to complete the purchase.
 				echo '<div class="sensei-message info">' . sprintf( __( 'You have already added this Course to your cart. Please %1$s to access the course.', 'woothemes-sensei' ) . '</div>', '<a class="cart-complete" href="' . $woocommerce->cart->get_checkout_url() . '" title="' . __( 'complete the purchase', 'woothemes-sensei' ) . '">' . __( 'complete the purchase', 'woothemes-sensei' ) . '</a>' );
 			} // End If Statement
 		} // End If Statement
@@ -1905,6 +1929,7 @@ class Sensei_Frontend {
 		// register user.
 		$user_id = wp_create_user( $new_user_name, $new_user_password, $new_user_email );
 		if ( ! $user_id || is_wp_error( $user_id ) ) {
+			// translators: Placeholder is the admin email address.
 			Sensei()->notices->add_notice( sprintf( __( '<strong>ERROR</strong>: Couldn&#8217;t register you&hellip; please contact the <a href="mailto:%s">webmaster</a> !' ), get_option( 'admin_email' ) ), 'alert' );
 		}
 

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -61,13 +61,13 @@ class Sensei_Grading_User_Quiz {
 			<input type="hidden" name="sensei_manual_grade" value="<?php echo esc_attr( $this->quiz_id ); ?>" />
 			<input type="hidden" name="sensei_grade_next_learner" value="<?php echo esc_attr( $this->user_id ); ?>" />
 			<div class="total_grade_display">
-				<span><?php esc_attr_e( __( 'Grade:', 'woothemes-sensei' ) ); ?></span>
+				<span><?php esc_attr_e( 'Grade:', 'woothemes-sensei' ); ?></span>
 				<span class="total_grade_total"><?php echo $user_quiz_grade_total; ?></span> / <span class="quiz_grade_total"><?php echo $quiz_grade_total; ?></span> (<span class="total_grade_percent"><?php echo $quiz_grade; ?></span>%)
 			</div>
 			<div class="buttons">
-				<input type="submit" value="<?php esc_attr_e( __( 'Save', 'woothemes-sensei' ) ); ?>" class="grade-button button-primary" title="Saves grades as currently marked on this page" />
-				<input type="button" value="<?php esc_attr_e( __( 'Auto grade', 'woothemes-sensei' ) ); ?>" class="autograde-button button-secondary" title="Where possible, automatically grades questions that have not yet been graded" />
-				<input type="reset" value="<?php esc_attr_e( __( 'Reset', 'woothemes-sensei' ) ); ?>" class="reset-button button-secondary" title="Resets all questions to ungraded and total grade to 0" />
+				<input type="submit" value="<?php esc_attr_e( 'Save', 'woothemes-sensei' ); ?>" class="grade-button button-primary" title="Saves grades as currently marked on this page" />
+				<input type="button" value="<?php esc_attr_e( 'Auto grade', 'woothemes-sensei' ); ?>" class="autograde-button button-secondary" title="Where possible, automatically grades questions that have not yet been graded" />
+				<input type="reset" value="<?php esc_attr_e( 'Reset', 'woothemes-sensei' ); ?>" class="reset-button button-secondary" title="Resets all questions to ungraded and total grade to 0" />
 			</div>
 			<div class="clear"></div><br/><?php
 
@@ -143,6 +143,7 @@ class Sensei_Grading_User_Quiz {
 							$answer_media_url = wp_get_attachment_url( $attachment_id );
 							$answer_media_filename = basename( $answer_media_url );
 							if( $answer_media_url && $answer_media_filename ) {
+								// translators: Placeholder is a link to the submitted file.
 								$user_answer_content = sprintf( __( 'Submitted file: %1$s', 'woothemes-sensei' ), '<a href="' . esc_url( $answer_media_url ) . '" target="_blank">' . esc_html( $answer_media_filename ) . '</a>' );
 							}
 						}
@@ -156,6 +157,7 @@ class Sensei_Grading_User_Quiz {
 			}
 			$user_answer_content = (array) $user_answer_content;
 			$right_answer = (array) $right_answer;
+			// translators: Placeholder is the question number.
 			$question_title = sprintf( __( 'Question %d: ', 'woothemes-sensei' ), $count ) . $type_name;
 
 			$graded_class = '';
@@ -251,13 +253,13 @@ class Sensei_Grading_User_Quiz {
 			<input type="hidden" name="total_graded_questions" id="total_graded_questions" value="<?php echo esc_attr( $graded_count ); ?>" />
 			<input type="hidden" name="all_questions_graded" id="all_questions_graded" value="<?php echo esc_attr( $all_graded ); ?>" />
 			<div class="total_grade_display">
-				<span><?php esc_attr_e( __( 'Grade:', 'woothemes-sensei' ) ); ?></span>
+				<span><?php esc_attr_e( 'Grade:', 'woothemes-sensei' ); ?></span>
 				<span class="total_grade_total"><?php echo $user_quiz_grade_total; ?></span> / <span class="quiz_grade_total"><?php echo $quiz_grade_total; ?></span> (<span class="total_grade_percent"><?php echo $quiz_grade; ?></span>%)
 			</div>
 			<div class="buttons">
 				<input type="submit" value="<?php esc_attr_e( 'Save' ); ?>" class="grade-button button-primary" title="Saves grades as currently marked on this page" />
-				<input type="button" value="<?php esc_attr_e( __( 'Auto grade', 'woothemes-sensei' ) ); ?>" class="autograde-button button-secondary" title="Where possible, automatically grades questions that have not yet been graded" />
-				<input type="reset" value="<?php esc_attr_e( __( 'Reset', 'woothemes-sensei' ) ); ?>" class="reset-button button-secondary" title="Resets all questions to ungraded and total grade to 0" />
+				<input type="button" value="<?php esc_attr_e( 'Auto grade', 'woothemes-sensei' ); ?>" class="autograde-button button-secondary" title="Where possible, automatically grades questions that have not yet been graded" />
+				<input type="reset" value="<?php esc_attr_e( 'Reset', 'woothemes-sensei' ); ?>" class="reset-button button-secondary" title="Resets all questions to ungraded and total grade to 0" />
 			</div>
 			<div class="clear"></div>
 			<script type="text/javascript">

--- a/includes/class-sensei-language-pack-manager.php
+++ b/includes/class-sensei-language-pack-manager.php
@@ -278,8 +278,12 @@ class Sensei_Language_Pack_Manager {
 				echo '<div class="error"><p>' . __( 'Failed to install/update the translation:', 'woothemes-sensei' ) . ' ' . __( 'There is no translation available for your language!', 'woothemes-sensei' ) . '</p></div>';
 				break;
 			case 4 :
-				// translators: Placeholders are an opening and closing <a> tag for the WordPress Codex page.
-				echo '<div class="error"><p>' . __( 'Failed to install/update the translation:', 'woothemes-sensei' ) . ' ' . sprintf( __( 'An authentication error occurred while updating the translation. Please try again or configure your %1$sUpgrade Constants%2$s.', 'woothemes-sensei' ), '<a href="http://codex.wordpress.org/Editing_wp-config.php#WordPress_Upgrade_Constants">', '</a>' ) . '</p></div>';
+				echo '<div class="error"><p>'
+					. __( 'Failed to install/update the translation:', 'woothemes-sensei' )
+					. ' '
+					// translators: Placeholders are an opening and closing <a> tag for the WordPress Codex page.
+					. sprintf( __( 'An authentication error occurred while updating the translation. Please try again or configure your %1$sUpgrade Constants%2$s.', 'woothemes-sensei' ), '<a href="http://codex.wordpress.org/Editing_wp-config.php#WordPress_Upgrade_Constants">', '</a>' )
+					. '</p></div>';
 				break;
 			case 5 :
 				echo '<div class="error"><p>' . __( 'Failed to install/update the translation:', 'woothemes-sensei' ) . ' ' . __( 'Sorry but there is no translation available for your language =/', 'woothemes-sensei' ) . '</p></div>';

--- a/includes/class-sensei-language-pack-manager.php
+++ b/includes/class-sensei-language-pack-manager.php
@@ -278,7 +278,7 @@ class Sensei_Language_Pack_Manager {
 				echo '<div class="error"><p>' . __( 'Failed to install/update the translation:', 'woothemes-sensei' ) . ' ' . __( 'There is no translation available for your language!', 'woothemes-sensei' ) . '</p></div>';
 				break;
 			case 4 :
-				echo '<div class="error"><p>' . __( 'Failed to install/update the translation:', 'woothemes-sensei' ) . ' ' . sprintf( __( 'An authentication error occurred while updating the translation. Please try again or configure your %sUpgrade Constants%s.', 'woothemes-sensei' ), '<a href="http://codex.wordpress.org/Editing_wp-config.php#WordPress_Upgrade_Constants">', '</a>' ) . '</p></div>';
+				echo '<div class="error"><p>' . __( 'Failed to install/update the translation:', 'woothemes-sensei' ) . ' ' . sprintf( __( 'An authentication error occurred while updating the translation. Please try again or configure your %1$sUpgrade Constants%2$s.', 'woothemes-sensei' ), '<a href="http://codex.wordpress.org/Editing_wp-config.php#WordPress_Upgrade_Constants">', '</a>' ) . '</p></div>';
 				break;
 			case 5 :
 				echo '<div class="error"><p>' . __( 'Failed to install/update the translation:', 'woothemes-sensei' ) . ' ' . __( 'Sorry but there is no translation available for your language =/', 'woothemes-sensei' ) . '</p></div>';

--- a/includes/class-sensei-language-pack-manager.php
+++ b/includes/class-sensei-language-pack-manager.php
@@ -278,6 +278,7 @@ class Sensei_Language_Pack_Manager {
 				echo '<div class="error"><p>' . __( 'Failed to install/update the translation:', 'woothemes-sensei' ) . ' ' . __( 'There is no translation available for your language!', 'woothemes-sensei' ) . '</p></div>';
 				break;
 			case 4 :
+				// translators: Placeholders are an opening and closing <a> tag for the WordPress Codex page.
 				echo '<div class="error"><p>' . __( 'Failed to install/update the translation:', 'woothemes-sensei' ) . ' ' . sprintf( __( 'An authentication error occurred while updating the translation. Please try again or configure your %1$sUpgrade Constants%2$s.', 'woothemes-sensei' ), '<a href="http://codex.wordpress.org/Editing_wp-config.php#WordPress_Upgrade_Constants">', '</a>' ) . '</p></div>';
 				break;
 			case 5 :

--- a/includes/class-sensei-learner-profiles.php
+++ b/includes/class-sensei-learner-profiles.php
@@ -68,6 +68,7 @@ class Sensei_Learner_Profiles {
 
             $name = Sensei_Learner::get_full_name( $learner_user->ID );
 
+			// translators: Placeholder is the full name of the learner.
 			$title = apply_filters( 'sensei_learner_profile_courses_heading', sprintf( __( 'Courses %s is taking', 'woothemes-sensei' ), $name ) ) . ' ' . $sep . ' ';
 		}
 		return $title;
@@ -98,7 +99,7 @@ class Sensei_Learner_Profiles {
 				$permalink = trailingslashit( get_home_url() ) . '?learner_profile=' . $user->user_nicename;
 			}
 		}
-		
+
         /**
          * This allows filtering of the Learner Profile permalinks.
          * @since 1.9.13
@@ -137,6 +138,7 @@ class Sensei_Learner_Profiles {
 			$name = $user->display_name;
 		}
 		$name = apply_filters( 'sensei_learner_profile_courses_heading_name', $name );
+		// translators: Placeholder is the first name or the display name of the user.
 		echo '<h2>' . apply_filters( 'sensei_learner_profile_courses_heading', sprintf( __( 'Courses %s is taking', 'woothemes-sensei' ), $name ) ) . '</h2>';
 	}
 

--- a/includes/class-sensei-learners-main.php
+++ b/includes/class-sensei-learners-main.php
@@ -264,6 +264,7 @@ class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 				}
 
                 $title = Sensei_Learner::get_full_name( $user_activity->user_id );
+				// translators: Placeholder is the full name of the learner.
 				$a_title = sprintf( __( 'Edit &#8220;%s&#8221;' ), $title );
 				$edit_start_date_form = $this->get_edit_start_date_form( $user_activity, $post_id, $post_type, $object_type );
 
@@ -284,6 +285,7 @@ class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 						'title' => '<strong><a class="row-title" href="' . admin_url( 'user-edit.php?user_id=' . $user_activity->user_id ) . '" title="' . esc_attr( $a_title ) . '">' . $title . '</a></strong>',
 						'date_started' => get_comment_meta( $user_activity->comment_ID, 'start', true),
 						'user_status' => $status_html,
+						// translators: Placeholder is the "object type"; lesson or course.
 						'actions' => '<a class="remove-learner button" data-user_id="' . $user_activity->user_id . '" data-post_id="' . $post_id . '" data-post_type="' . $post_type . '">' . sprintf( __( 'Remove from %1$s', 'woothemes-sensei' ), $object_type ) . '</a>'
 							. '<a class="reset-learner button" data-user_id="' . $user_activity->user_id . '" data-post_id="' . $post_id . '" data-post_type="' . $post_type . '">' . sprintf( __( 'Reset progress', 'woothemes-sensei' ), $object_type ) . '</a>'
 					. $edit_start_date_form,
@@ -294,6 +296,7 @@ class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 			case 'lessons' :
 				$lesson_learners = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_learners_lesson_learners', array( 'post_id' => $item->ID, 'type' => 'sensei_lesson_status', 'status' => 'any' ) ) );
 				$title = get_the_title( $item );
+				// translators: Placeholder is the item title.
 				$a_title = sprintf( __( 'Edit &#8220;%s&#8221;' ), $title );
 
 				$grading_action = '';
@@ -313,6 +316,7 @@ class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 			default:
                 $course_learners = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_learners_course_learners', array( 'post_id' => $item->ID, 'type' => 'sensei_course_status', 'status' => 'any' ) ) );
 				$title = get_the_title( $item );
+				// translators: Placeholder is the item title.
 				$a_title = sprintf( __( 'Edit &#8220;%s&#8221;' ), $title );
 
 				$grading_action = '';
@@ -563,7 +567,7 @@ class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 			$menu['learners'] = '<a class="' . $learners_class . '" href="' . esc_url( add_query_arg( $learner_args, admin_url( 'admin.php' ) ) ) . '">' . __( 'Learners', 'woothemes-sensei' ) . '</a>';
 			$menu['lessons'] = '<a class="' . $lessons_class . '" href="' . esc_url( add_query_arg( $lesson_args, admin_url( 'admin.php' ) ) ) . '">' . __( 'Lessons', 'woothemes-sensei' ) . '</a>';
 
-		} 
+		}
 		// Have Course and Lesson
 		elseif( $this->course_id && $this->lesson_id ) {
 
@@ -575,7 +579,12 @@ class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 
 			$course = get_the_title( $this->course_id );
 
-			$menu['back'] = '<a href="' . esc_url( add_query_arg( $query_args, admin_url( 'admin.php' ) ) ) . '">' . sprintf( __( '%1$sBack to %2$s%3$s', 'woothemes-sensei' ), '<em>&larr; ', $course, '</em>' ) . '</a>';
+			$menu['back'] = '<a href="'
+				. esc_url( add_query_arg( $query_args, admin_url( 'admin.php' ) ) )
+				. '">'
+				// translators: Placeholders %1$s and %3$s are the opening and closing <em> tags, %2$s is the Course title.
+				. sprintf( __( '%1$sBack to %2$s%3$s', 'woothemes-sensei' ), '<em>&larr; ', $course, '</em>' )
+				. '</a>';
 		}
 		$menu = apply_filters( 'sensei_learners_sub_menu', $menu );
 		if ( !empty($menu) ) {
@@ -628,11 +637,16 @@ class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 		}
 		?>
 		<div class="postbox">
-			<h3><span><?php printf( __( 'Add Learner to %1$s', 'woothemes-sensei' ), $post_type ); ?></span></h3>
+			<h3><span>
+				<?php
+				// translators: Placeholder is the post type.
+				printf( __( 'Add Learner to %1$s', 'woothemes-sensei' ), $post_type );
+				?>
+			</span></h3>
 			<div class="inside">
 				<form name="add_learner" action="" method="post">
 					<p>
-						<select name="add_user_id" id="add_learner_search" multiple="multiple" style="min-width:300px;>
+						<select name="add_user_id" id="add_learner_search" multiple="multiple" style="min-width:300px;">
 							<option value="0" selected="selected"><?php _e( 'Find learner', 'woothemes-sensei' ) ;?></option>
 						</select>
 						<?php if( 'lesson' == $form_post_type ) { ?>
@@ -643,9 +657,19 @@ class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 						<br/>
 						<span class="description"><?php _e( 'Search for a user by typing their name or username.', 'woothemes-sensei' ); ?></span>
 					</p>
-					<p><?php submit_button( sprintf( __( 'Add to \'%1$s\'', 'woothemes-sensei' ), $post_title ), 'primary', 'add_learner_submit', false, array() ); ?></p>
+					<p>
+						<?php
+						// translators: Placeholder is the post title.
+						submit_button( sprintf( __( 'Add to \'%1$s\'', 'woothemes-sensei' ), $post_title ), 'primary', 'add_learner_submit', false, array() );
+						?>
+					</p>
 					<?php if( 'lesson' == $form_post_type ) { ?>
-						<p><span class="description"><?php printf( __( 'Learner will also be added to the course \'%1$s\' if they are not already taking it.', 'woothemes-sensei' ), $course_title ); ?></span></p>
+						<p><span class="description">
+							<?php
+							// translators: Placeholder is the course title.
+							printf( __( 'Learner will also be added to the course \'%1$s\' if they are not already taking it.', 'woothemes-sensei' ), $course_title );
+							?>
+						</span></p>
 					<?php } ?>
 
 					<input type="hidden" name="add_post_type" value="<?php echo $form_post_type; ?>" />

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -957,6 +957,7 @@ class Sensei_Lesson {
 					} else {
 						$row_numbers = $question_counter . ' - ' . $end_number;
 					}
+					// translators: Placeholder is the question category name.
 					$row_title = sprintf( esc_html__( 'Selected from \'%1$s\' ', 'woothemes-sensei' ), $multiple_data[0] );
 
 					$html .= '<td class="table-count question-number question-count-column"><span class="number hidden">' . esc_html( $question_counter ) . '</span><span class="hidden total-number">' . esc_html( $multiple_data[1] ) . '</span><span class="row-numbers">' . esc_html( $row_numbers ) . '</span></td>';
@@ -1063,6 +1064,7 @@ class Sensei_Lesson {
 			$html .= '<div class="tab-content" id="tab-new-content">';
 
 		if ( 'quiz' == $context ) {
+			// translators: Placeholders are an opening and closing <a> tag linking to the question bank.
 			$html .= '<p><em>' . sprintf( esc_html__( 'Add a new question to this quiz - your question will also be added to the %1$squestion bank%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'edit.php?post_type=question' ) . '">', '</a>' ) . '</em></p>';
 		}
 
@@ -1138,6 +1140,7 @@ class Sensei_Lesson {
 
 			$html .= '<div class="tab-content hidden" id="tab-existing-content">';
 
+				// translators: Placeholders are an opening and closing <a> tag linking to the question bank.
 				$html .= '<p><em>' . sprintf( esc_html__( 'Add an existing question to this quiz from the %1$squestion bank%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'edit.php?post_type=question' ) . '">', '</a>' ) . '</em></p>';
 
 				$html .= '<div id="existing-filters" class="alignleft actions">
@@ -1213,6 +1216,7 @@ class Sensei_Lesson {
 			if ( ! empty( $question_cats ) && ! is_wp_error( $question_cats ) ) {
 				$html .= '<div class="tab-content hidden" id="tab-multiple-content">';
 
+					// translators: Placeholders are an opening and closing <a> tag linking to the question categories page.
 					$html .= '<p><em>' . sprintf( esc_html__( 'Add any number of questions from a specified category. Edit your question categories %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'edit-tags.php?taxonomy=question-category&post_type=question' ) . '">', '</a>' ) . '</em></p>';
 
 					$html .= '<p><select id="add-multiple-question-category-options" name="multiple_category" class="chosen_select widefat question-category-select">' . "\n";
@@ -1955,12 +1959,14 @@ class Sensei_Lesson {
 			case 'lesson-course':
 				$lesson_course_id = get_post_meta( $id, '_lesson_course', true );
 				if ( 0 < absint( $lesson_course_id ) ) {
+					// translators: Placeholder is the course title.
 					echo '<a href="' . esc_url( get_edit_post_link( absint( $lesson_course_id ) ) ) . '" title="' . sprintf( esc_attr__( 'Edit %s', 'woothemes-sensei' ), get_the_title( absint( $lesson_course_id ) ) ) . '">' . get_the_title( absint( $lesson_course_id ) ) . '</a>';
 				} // End If Statement
 				break;
 			case 'lesson-prerequisite':
 				$lesson_prerequisite_id = get_post_meta( $id, '_lesson_prerequisite', true );
 				if ( 0 < absint( $lesson_prerequisite_id ) ) {
+					// translators: Placeholder is the title of the prerequisite lesson.
 					echo '<a href="' . esc_url( get_edit_post_link( absint( $lesson_prerequisite_id ) ) ) . '" title="' . sprintf( esc_attr__( 'Edit %s', 'woothemes-sensei' ), get_the_title( absint( $lesson_prerequisite_id ) ) ) . '">' . get_the_title( absint( $lesson_prerequisite_id ) ) . '</a>';
 				} // End If Statement
 				break;
@@ -2088,6 +2094,7 @@ class Sensei_Lesson {
 				$post_data = array(
 					'post_content' => '',
 					'post_status' => 'publish',
+					// translators: Placeholders are the question number and the question category name.
 					'post_title' => sprintf( esc_html__( '%1$s Question(s) from %2$s', 'woothemes-sensei' ), $question_number, $cat->name ),
 					'post_type' => 'multiple_question',
 				);
@@ -3472,6 +3479,7 @@ class Sensei_Lesson {
 
 		}
 
+		// translators: Placeholder is the lesson title.
 		$heading_link_title = sprintf( esc_html__( 'Start %s', 'woothemes-sensei' ), get_the_title( $lesson_id ) );
 
 		?>
@@ -3694,6 +3702,7 @@ class Sensei_Lesson {
 						$a_element .= esc_html__( 'course', 'woothemes-sensei' );
 						$a_element .= '</a>';
 
+						// translators: Placeholder is a link to the Course.
 						$message = sprintf( esc_html__( 'Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $a_element );
 
 						Sensei()->notices->add_notice( $message, 'info' );
@@ -3706,6 +3715,7 @@ class Sensei_Lesson {
 					$a_element .= esc_html__( 'course', 'woothemes-sensei' );
 					$a_element .= '</a>';
 
+					// translators: Placeholder is a link to the Course.
 					$message = sprintf( esc_html__( 'Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $a_element );
 
 					Sensei()->notices->add_notice( $message, 'alert' );
@@ -3724,6 +3734,7 @@ class Sensei_Lesson {
 											. '">' . esc_html__( 'course', 'woothemes-sensei' )
 										. '</a>';
 
+						// translators: Placeholder is a link to the Course.
 						echo sprintf( esc_html__( 'Please sign up for the %1$s before starting the lesson.', 'woothemes-sensei' ), $course_link );
 
 						?>
@@ -3749,8 +3760,16 @@ class Sensei_Lesson {
 		$lesson_has_pre_requisite = $lesson_prerequisite > 0;
 		if ( ! WooThemes_Sensei_Lesson::is_prerequisite_complete( get_the_ID(), get_current_user_id() ) && $lesson_has_pre_requisite ) {
 
-			$prerequisite_lesson_link  = '<a href="' . esc_url( get_permalink( $lesson_prerequisite ) ) . '" title="' . sprintf( esc_attr__( 'You must first complete: %1$s', 'woothemes-sensei' ), get_the_title( $lesson_prerequisite ) ) . '">' . get_the_title( $lesson_prerequisite ) . '</a>';
-			Sensei()->notices->add_notice( sprintf( esc_html__( 'You must first complete %1$s before viewing this Lesson', 'woothemes-sensei' ), $prerequisite_lesson_link ), 'info' );
+			$prerequisite_lesson_link  = '<a href="'
+				. esc_url( get_permalink( $lesson_prerequisite ) )
+				. '" title="'
+				// translators: Placeholder is the lesson prerequisite title.
+				. sprintf( esc_attr__( 'You must first complete: %1$s', 'woothemes-sensei' ), get_the_title( $lesson_prerequisite ) )
+				. '">'
+				. get_the_title( $lesson_prerequisite )
+				. '</a>';
+			// translators: Placeholder is the link to the prerequisite lesson.
+			Sensei()->notices->add_notice( sprintf( esc_html__( 'You must first complete %1$s before viewing this Lesson', 'woothemes-sensei' ), $prerequisite_lesson_link ), 'info');
 
 		}
 

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -150,7 +150,9 @@ class Sensei_Messages {
 
 			$settings[] = array(
 				'id'          => 'post',
+				// translators: Placeholder the post type (e.g. lesson or course) to which this message relates.
 				'label'       => sprintf( __( 'Message from %1$s:', 'woothemes-sensei' ), $message_posttype ),
+				// translators: Placeholder the post type (e.g. lesson or course) to which this message relates.
 				'description' => sprintf( __( 'The %1$s to which this message relates.', 'woothemes-sensei' ), $message_posttype ),
 				'type'        => 'plain-text',
 				'default'     => $course_name,
@@ -595,7 +597,10 @@ class Sensei_Messages {
             <p class="message-meta">
                 <small>
                     <em>
-                        <?php printf( __( 'Sent by %1$s on %2$s.', 'woothemes-sensei' ), $sender->display_name, get_the_date() ); ?>
+						<?php
+						// translators: Placeholders are the sender's display name and the date, respectively.
+						printf( __( 'Sent by %1$s on %2$s.', 'woothemes-sensei' ), $sender->display_name, get_the_date() );
+						?>
                     </em>
                 </small>
             </p>
@@ -616,6 +621,7 @@ class Sensei_Messages {
 
         $content_post_id = get_post_meta( $post->ID, '_post', true );
         if( $content_post_id ) {
+			// translators: Placeholder is a link to post, with the post's title as the link text.
             $title = sprintf( __( 'Re: %1$s', 'woothemes-sensei' ), '<a href="' . get_permalink( $content_post_id ) . '">' . get_the_title( $content_post_id ) . '</a>' );
         } else {
             $title = get_the_title( $post->ID );
@@ -681,6 +687,7 @@ class Sensei_Messages {
 
         if( $content_post_id ) {
 
+			// translators: Placeholder is the post title.
             $title = sprintf( __( 'Re: %1$s', 'woothemes-sensei' ), get_the_title( $content_post_id ) );
 
         } else {
@@ -711,6 +718,7 @@ class Sensei_Messages {
         $sender = get_user_by( 'login', $sender_username );
 
         if( $sender_username && $sender instanceof WP_User ) {
+			// translators: Placeholders are the sender's display name and the date.
             $sender_display_name = sprintf( __( 'Sent by %1$s on %2$s.', 'woothemes-sensei' ), $sender->display_name, get_the_date() );
             ?>
             <p class="message-meta">

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -634,19 +634,27 @@ class Sensei_PostTypes {
 		$lower_case_plural =  function_exists( 'mb_strtolower' ) ? mb_strtolower( $plural, 'UTF-8') :  strtolower( $plural );
 
 		$labels = array(
-		    'name' => sprintf( _x( '%s', 'post type general name', 'woothemes-sensei' ), $plural ),
-		    'singular_name' => sprintf( _x( '%s', 'post type singular name', 'woothemes-sensei' ), $singular ),
+		    'name' => $plural,
+		    'singular_name' => $singular,
 		    'add_new' => __( 'Add New', 'woothemes-sensei' ),
+			// translators: Placeholder is the singular post type label.
 		    'add_new_item' => sprintf( __( 'Add New %s', 'woothemes-sensei' ), $singular ),
+			// translators: Placeholder is the singular post type label.
 		    'edit_item' => sprintf( __( 'Edit %s', 'woothemes-sensei' ), $singular ),
+			// translators: Placeholder is the singular post type label.
 		    'new_item' => sprintf( __( 'New %s', 'woothemes-sensei' ), $singular ),
+			// translators: Placeholder is the plural post type label.
 		    'all_items' => sprintf( __( 'All %s', 'woothemes-sensei' ), $plural ),
+			// translators: Placeholder is the singular post type label.
 		    'view_item' => sprintf( __( 'View %s', 'woothemes-sensei' ), $singular ),
+			// translators: Placeholder is the plural post type label.
 		    'search_items' => sprintf( __( 'Search %s', 'woothemes-sensei' ), $plural ),
+			// translators: Placeholder is the lower-case plural post type label.
 		    'not_found' =>  sprintf( __( 'No %s found', 'woothemes-sensei' ), $lower_case_plural ) ,
+			// translators: Placeholder is the lower-case plural post type label.
 		    'not_found_in_trash' => sprintf( __( 'No %s found in Trash', 'woothemes-sensei' ),  $lower_case_plural ),
 		    'parent_item_colon' => '',
-		    'menu_name' => sprintf( __( '%s', 'woothemes-sensei' ), $menu )
+		    'menu_name' => $menu,
 		  );
 
 		return $labels;
@@ -683,15 +691,30 @@ class Sensei_PostTypes {
 
 		$messages = array(
 			0 => '',
+			// translators: Placeholders are the singular label for the post type and the post's permalink, respectively.
 			1 => sprintf( __( '%1$s updated. %2$sView %1$s%3$s.' , 'woothemes-sensei' ), $this->labels[$post_type]['singular'], '<a href="' . esc_url( get_permalink( $post_ID ) ) . '">', '</a>' ),
 			2 => __( 'Custom field updated.' , 'woothemes-sensei' ),
 			3 => __( 'Custom field deleted.' , 'woothemes-sensei' ),
+			// translators: Placeholder is the singular label for the post type.
 			4 => sprintf( __( '%1$s updated.' , 'woothemes-sensei' ), $this->labels[$post_type]['singular'] ),
+			// translators: Placeholders are the singular label for the post type and the post's revision, respectively.
 			5 => isset( $_GET['revision'] ) ? sprintf( __( '%1$s restored to revision from %2$s.' , 'woothemes-sensei' ), $this->labels[$post_type]['singular'], wp_post_revision_title( (int) $_GET['revision'], false ) ) : false,
+			// translators: Placeholders are the singular label for the post type and the post's permalink, respectively.
 			6 => sprintf( __( '%1$s published. %2$sView %1$s%3$s.' , 'woothemes-sensei' ), $this->labels[$post_type]['singular'], '<a href="' . esc_url( get_permalink( $post_ID ) ) . '">', '</a>' ),
+			// translators: Placeholder is the singular label for the post type.
 			7 => sprintf( __( '%1$s saved.' , 'woothemes-sensei' ), $this->labels[$post_type]['singular'] ),
+			// translators: Placeholders are the singular label for the post type and the post's preview link, respectively.
 			8 => sprintf( __( '%1$s submitted. %2$sPreview %1$s%3$s.' , 'woothemes-sensei' ), $this->labels[$post_type]['singular'], '<a target="_blank" href="' . esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) . '">', '</a>' ),
+			/*
+ 			 * translators: Placeholders are as follows (in order):
+ 			 *
+ 			 * - The singular label for the post type.
+ 			 * - The formatted post date.
+ 			 * - The opening tag for the post's permalink.
+ 			 * - The closing tag for the post's permalink.
+ 			 */
 			9 => sprintf( __( '%1$s scheduled for: %2$s. %3$sPreview %4$s%5$s.' , 'woothemes-sensei' ), $this->labels[$post_type]['singular'], '<strong>' . date_i18n( __( 'M j, Y @ G:i' , 'woothemes-sensei' ), strtotime( $post->post_date ) ) . '</strong>', '<a target="_blank" href="' . esc_url( get_permalink( $post_ID ) ) . '">', $this->labels[$post_type]['singular'], '</a>' ),
+ 			// translators: Placeholders are the singular label for the post type and the post's preview link, respectively.
 			10 => sprintf( __( '%1$s draft updated. %2$sPreview %3$s%4$s.' , 'woothemes-sensei' ), $this->labels[$post_type]['singular'], '<a target="_blank" href="' . esc_url( add_query_arg( 'preview', 'true', get_permalink( $post_ID ) ) ) . '">', $this->labels[$post_type]['singular'], '</a>' ),
 		);
 

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -900,7 +900,7 @@ class Sensei_Question {
                 $upload_size_unit = (int) $upload_size_unit;
 
             }
-            $max_upload_size = sprintf( __( 'Maximum upload file size: %d%s', 'woothemes-sensei' ), esc_html( $upload_size_unit ), esc_html( $sizes[ $u ] ) );
+            $max_upload_size = sprintf( __( 'Maximum upload file size: %1$d%2$s', 'woothemes-sensei' ), esc_html( $upload_size_unit ), esc_html( $sizes[ $u ] ) );
 
             // Assemble all the data needed by the file upload template
             $question_data[ 'answer_media_url' ]      = $answer_media_url;

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -164,6 +164,7 @@ class Sensei_Question {
 	public function question_lessons_panel() {
 		global $post;
 
+		// translators: Placeholders are an opening and closing <em> tag.
 		$no_lessons = sprintf( __( '%1$sThis question does not appear in any quizzes yet.%2$s', 'woothemes-sensei' ), '<em>', '</em>' );
 
 		if( ! isset( $post->ID ) ) {
@@ -740,6 +741,7 @@ class Sensei_Question {
 		} elseif( $user_question_grade > 0 ) {
 			$user_correct         = true;
 			$answer_message_class = 'user_right';
+			// translators: Placeholder is the question grade.
 			$answer_message       = sprintf( __( 'Grade: %d', 'woothemes-sensei' ), $user_question_grade );
 		} else {
             $user_correct          = false;
@@ -900,6 +902,7 @@ class Sensei_Question {
                 $upload_size_unit = (int) $upload_size_unit;
 
             }
+			// translators: Placeholders are the upload size and the measurement (e.g. 5 MB)
             $max_upload_size = sprintf( __( 'Maximum upload file size: %1$d%2$s', 'woothemes-sensei' ), esc_html( $upload_size_unit ), esc_html( $sizes[ $u ] ) );
 
             // Assemble all the data needed by the file upload template

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1132,6 +1132,7 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
              }
 
+			 // translators: Placeholder is the quiz name with any instance of the word "quiz" removed.
              $title = sprintf( __( '%s Quiz', 'woothemes-sensei' ), $title_with_no_quizzes );
          }
 

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -794,6 +794,7 @@ class Sensei_Settings_API {
 		if ( isset( $data['error_message'] ) ) {
 			$message = $data['error_message'];
 		} else {
+			// translators: Placeholder is the field name.
 			$message = sprintf( __( '%s is a required field', 'woothemes-sensei' ), $data['name'] );
 		}
 		$this->errors[$key] = $message;
@@ -811,6 +812,7 @@ class Sensei_Settings_API {
 				add_settings_error( $this->token . '-errors', $k, $v, 'error' );
 			}
 		} else {
+			// translators: Placeholder is the name of the settings page.
 			$message = sprintf( __( '%s updated', 'woothemes-sensei' ), $this->name );
 			add_settings_error( $this->token . '-errors', $this->token, $message, 'updated' );
 		}

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -173,7 +173,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['access_permission'] = array(
 								'name' => __( 'Access Permissions', 'woothemes-sensei' ),
-								'description' => __( 'Users must be logged in to view Course and Lesson content.', 'woothemes-sensei', 'woothemes-sensei' ),
+								'description' => __( 'Users must be logged in to view Course and Lesson content.', 'woothemes-sensei' ),
 								'type' => 'checkbox',
 								'default' => true,
 								'section' => 'default-settings'
@@ -313,6 +313,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['course_archive_image_hard_crop'] = array(
 								'name' => __( 'Image Hard Crop - Archive', 'woothemes-sensei' ),
+								// translators: Placeholders are an opening and closing <a> tag linking to the documentation page.
 								'description' => sprintf( __( 'After changing this setting, you may need to %1$sregenerate your thumbnails%2$s.', 'woothemes-sensei' ), '<a href="' . esc_url( 'http://wordpress.org/extend/plugins/regenerate-thumbnails/' ) . '">', '</a>' ),
 								'type' => 'checkbox',
 								'default' => false,
@@ -347,6 +348,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['course_single_image_hard_crop'] = array(
 								'name' => __( 'Image Hard Crop - Single', 'woothemes-sensei' ),
+								// translators: Placeholders are an opening and closing <a> tag linking to the documentation page.
 								'description' => sprintf( __( 'After changing this setting, you may need to %1$sregenerate your thumbnails%2$s.', 'woothemes-sensei' ), '<a href="' . esc_url( 'http://wordpress.org/extend/plugins/regenerate-thumbnails/' ) . '">', '</a>' ),
 								'type' => 'checkbox',
 								'default' => false,
@@ -416,6 +418,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['lesson_archive_image_hard_crop'] = array(
 								'name' => __( 'Image Hard Crop - Course Lessons', 'woothemes-sensei' ),
+								// translators: Placeholders are an opening and closing <a> tag linking to the documentation page.
 								'description' => sprintf( __( 'After changing this setting, you may need to %1$sregenerate your thumbnails%2$s.', 'woothemes-sensei' ), '<a href="' . esc_url( 'http://wordpress.org/extend/plugins/regenerate-thumbnails/' ) . '">', '</a>' ),
 								'type' => 'checkbox',
 								'default' => false,
@@ -450,6 +453,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['lesson_single_image_hard_crop'] = array(
 								'name' => __( 'Image Hard Crop - Single', 'woothemes-sensei' ),
+								// translators: Placeholders are an opening and closing <a> tag linking to the documentation page.
 								'description' => sprintf( __( 'After changing this setting, you may need to %1$sregenerate your thumbnails%2$s.', 'woothemes-sensei' ), '<a href="' . esc_url( 'http://wordpress.org/extend/plugins/regenerate-thumbnails/' ) . '">', '</a>' ),
 								'type' => 'checkbox',
 								'default' => false,
@@ -463,6 +467,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['learner_profile_enable'] = array(
 							'name' => __( 'Public learner profiles', 'woothemes-sensei' ),
+							// translators: Placeholder is a profile URL example.
 							'description' => sprintf( __( 'Enable public learner profiles that will be accessible to everyone. Profile URL format: %s', 'woothemes-sensei' ), $profile_url_example ),
 							'type' => 'checkbox',
 							'default' => true,
@@ -543,6 +548,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['email_header_image'] = array(
 								'name' => __( 'Header Image', 'woothemes-sensei' ),
+								// translators: Placeholders are opening and closing <a> tags linking to the media uploader.
 								'description' => sprintf( __( 'Enter a URL to an image you want to show in the email\'s header. Upload your image using the %1$smedia uploader%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'media-new.php' ) . '">', '</a>' ),
 								'type' => 'text',
 								'default' => '',
@@ -554,6 +560,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 								'name' => __( 'Email Footer Text', 'woothemes-sensei' ),
 								'description' => __( 'The text to appear in the footer of Sensei emails.', 'woothemes-sensei' ),
 								'type' => 'textarea',
+								// translators: Placeholder is the blog name.
 								'default' => sprintf( __( '%1$s - Powered by Sensei', 'woothemes-sensei' ), get_bloginfo( 'name' ) ),
 								'section' => 'email-notification-settings',
 								'required' => 0
@@ -561,6 +568,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['email_base_color'] = array(
 								'name' => __( 'Base Colour', 'woothemes-sensei' ),
+								// translators: Placeholders are opening and closing <code> tags.
 								'description' => sprintf( __( 'The base colour for Sensei email templates. Default %1$s#557da1%2$s.', 'woothemes-sensei' ), '<code>', '</code>' ),
 								'type' => 'color',
 								'default' => '#557da1',
@@ -570,6 +578,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['email_background_color'] = array(
 								'name' => __( 'Background Colour', 'woothemes-sensei' ),
+								// translators: Placeholders are opening and closing <code> tags.
 								'description' => sprintf( __( 'The background colour for Sensei email templates. Default %1$s#f5f5f5%2$s.', 'woothemes-sensei' ), '<code>', '</code>' ),
 								'type' => 'color',
 								'default' => '#f5f5f5',
@@ -579,6 +588,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['email_body_background_color'] = array(
 								'name' => __( 'Body Background Colour', 'woothemes-sensei' ),
+								// translators: Placeholders are opening and closing <code> tags.
 								'description' => sprintf( __( 'The main body background colour for Sensei email templates. Default %1$s#fdfdfd%2$s.', 'woothemes-sensei' ), '<code>', '</code>' ),
 								'type' => 'color',
 								'default' => '#fdfdfd',
@@ -588,6 +598,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['email_text_color'] = array(
 								'name' => __( 'Body Text Colour', 'woothemes-sensei' ),
+								// translators: Placeholders are opening and closing <code> tags.
 								'description' => sprintf( __( 'The main body text colour for Sensei email templates. Default %1$s#505050%2$s.', 'woothemes-sensei' ), '<code>', '</code>' ),
 								'type' => 'color',
 								'default' => '#505050',

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -1571,7 +1571,10 @@ class Sensei_Teacher {
 		?>
 			<h2 class="teacher-archive-title">
 
-				<?php echo sprintf( __( 'All courses by %s', 'woothemes-sensei' ) , $author_name ); ?>
+				<?php
+				// translators: Placeholder is the author name.
+				echo sprintf( __( 'All courses by %s', 'woothemes-sensei' ) , $author_name );
+				?>
 
 			</h2>
 		<?php

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -271,7 +271,12 @@ class Sensei_Updates
         } else { ?>
 
             <h2><?php _e('Updates', 'woothemes-sensei'); ?></h2>
-            <p><?php printf(__('These are updates that have been made available as new Sensei versions have been released. Updates of type %1$sAuto%2$s will run as you update Sensei to the relevant version - other updates need to be run manually and you can do that here.', 'woothemes-sensei'), '<code>', '</code>'); ?></p>
+            <p>
+				<?php
+				// translators: Placeholders are opening and closing <code> tags.
+				printf(__('These are updates that have been made available as new Sensei versions have been released. Updates of type %1$sAuto%2$s will run as you update Sensei to the relevant version - other updates need to be run manually and you can do that here.', 'woothemes-sensei'), '<code>', '</code>');
+				?>
+			</p>
 
             <div class="updated"><p>
                     <strong><?php _e('Only run these updates if you have been instructed to do so by Support staff.', 'woothemes-sensei'); ?></strong>
@@ -318,7 +323,12 @@ class Sensei_Updates
                                             <input type="hidden" name="checked[]" value="<?php echo $update; ?>">
                                             <strong><?php echo $data['title']; ?></strong><br><?php echo $data['desc']; ?>
                                             <br>
-                                            <em><?php printf(__('Originally included in %1$s v%2$s', 'woothemes-sensei'), $product, $version); ?></em>
+                                            <em>
+												<?php
+												// translators: Placeholders are the product name and the version number, respectively.
+												printf(__('Originally included in %1$s v%2$s', 'woothemes-sensei'), $product, $version);
+												?>
+											</em>
                                         </p>
                                     </td>
                                     <?php
@@ -330,7 +340,10 @@ class Sensei_Updates
                                     <td><p><?php echo $type_label; ?></p></td>
                                     <td>
                                         <p>
-                                            <input onclick="javascript:return confirm('<?php echo addslashes( sprintf( __( 'Are you sure you want to run the \'%s\' update?', 'woothemes-sensei' ), $data['title'] ) ); ?>');"
+                                            <input onclick="javascript:return confirm('<?php
+												// translators: Placeholder is the title of the update.
+												echo addslashes( sprintf( __( 'Are you sure you want to run the \'%s\' update?', 'woothemes-sensei' ), $data['title'] ) );
+												?>');"
                                                    id="update-sensei"
                                                    class="button<?php if( ! $update_run ) { echo ' button-primary'; } ?>"
                                                    type="submit"
@@ -534,6 +547,7 @@ class Sensei_Updates
 				switch( $version ) {
 
 					case '1.7.0':
+						// translators: Placeholders are an opening and closing <a> tag linking to an informational post.
 						$update_message .= '<p><em>' . sprintf( __( 'Want to know what these upgrades are all about? %1$sFind out more here%2$s.', 'woothemes-sensei' ), '<a href="http://develop.woothemes.com/sensei/2014/12/03/important-information-about-sensei-1-7" target="_blank">', '</a>' ) . '</em></p>' . "\n";
 					break;
 

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -318,7 +318,7 @@ class Sensei_Updates
                                             <input type="hidden" name="checked[]" value="<?php echo $update; ?>">
                                             <strong><?php echo $data['title']; ?></strong><br><?php echo $data['desc']; ?>
                                             <br>
-                                            <em><?php printf(__('Originally included in %s v%s', 'woothemes-sensei'), $product, $version); ?></em>
+                                            <em><?php printf(__('Originally included in %1$s v%2$s', 'woothemes-sensei'), $product, $version); ?></em>
                                         </p>
                                     </td>
                                     <?php

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1273,7 +1273,7 @@ class Sensei_Utils {
 			$has_quiz_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
 
 			if ( ! $started_course ) {
-$status = 'not_started_course';
+				$status = 'not_started_course';
 				$box_class = 'info';
 				// translators: Placeholders are an opening and closing <a> tag linking to the course permalink.
 				$message = sprintf( __( 'Please sign up for %1$sthe course%2$s before taking this quiz', 'woothemes-sensei' ), '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr( __( 'Sign Up', 'woothemes-sensei' ) ) . '">', '</a>' );

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -164,6 +164,7 @@ class Sensei_Utils {
 		}
 		// Check for legacy code
 		if ( isset($args['type']) && in_array($args['type'], array('sensei_course_start', 'sensei_course_end', 'sensei_lesson_start', 'sensei_lesson_end', 'sensei_quiz_asked', 'sensei_user_grade', 'sensei_quiz_grade', 'sense_answer_notes') ) ) {
+			// translators: Placeholder is the name of a deprecated Sensei activity type.
 			_deprecated_argument( __FUNCTION__, '1.7', sprintf( __('Sensei activity type %s is no longer used.', 'woothemes-sensei'), $args['type'] ) );
 			return false;
 		}
@@ -1195,10 +1196,12 @@ class Sensei_Utils {
 				if( $user_grade >= $passmark ) {
 					$status = 'passed';
 					$box_class = 'tick';
+					// translators: Placeholder is the user's grade.
 					$message = sprintf( __( 'You have passed this course with a grade of %1$d%%.', 'woothemes-sensei' ), $user_grade );
 				} else {
 					$status = 'failed';
 					$box_class = 'alert';
+					// translators: Placeholders are the required grade and the actual grade, respectively.
 					$message = sprintf( __( 'You require %1$d%% to pass this course. Your grade is %2$s%%.', 'woothemes-sensei' ), $passmark, $user_grade );
 				}
 			}
@@ -1270,9 +1273,9 @@ class Sensei_Utils {
 			$has_quiz_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
 
 			if ( ! $started_course ) {
-
-				$status = 'not_started_course';
+$status = 'not_started_course';
 				$box_class = 'info';
+				// translators: Placeholders are an opening and closing <a> tag linking to the course permalink.
 				$message = sprintf( __( 'Please sign up for %1$sthe course%2$s before taking this quiz', 'woothemes-sensei' ), '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr( __( 'Sign Up', 'woothemes-sensei' ) ) . '">', '</a>' );
 
 			} elseif ( ! is_user_logged_in() ) {
@@ -1298,8 +1301,10 @@ class Sensei_Utils {
 				// Lesson status will be "passed" (passmark reached)
 				elseif ( ! empty( $quiz_grade ) && abs( $quiz_grade ) >= 0 ) {
 					if( $is_lesson ) {
+						// translators: Placeholder is the quiz grade.
 						$message = sprintf( __( 'Congratulations! You have passed this lesson\'s quiz achieving %s%%', 'woothemes-sensei' ), Sensei_Utils::round( $quiz_grade ) );
 					} else {
+						// translators: Placeholder is the quiz grade.
 						$message = sprintf( __( 'Congratulations! You have passed this quiz achieving %s%%', 'woothemes-sensei' ),  Sensei_Utils::round( $quiz_grade ) );
 					}
 				}
@@ -1322,8 +1327,10 @@ class Sensei_Utils {
 					$status = 'complete';
 					$box_class = 'info';
 					if( $is_lesson ) {
+						// translators: Placeholders are an opening and closing <a> tag linking to the quiz permalink.
 						$message = sprintf( __( 'You have completed this lesson\'s quiz and it will be graded soon. %1$sView the lesson quiz%2$s', 'woothemes-sensei' ), '<a href="' . esc_url( get_permalink( $quiz_id ) ) . '" title="' . esc_attr( get_the_title( $quiz_id ) ) . '">', '</a>' );
 					} else {
+						// translators: Placeholder is the quiz passmark.
 						$message = sprintf( __( 'You have completed this quiz and it will be graded soon. You require %1$s%% to pass.', 'woothemes-sensei' ),  Sensei_Utils::round( $quiz_passmark ) );
 					}
 				}
@@ -1332,8 +1339,10 @@ class Sensei_Utils {
 					$status = 'failed';
 					$box_class = 'alert';
 					if( $is_lesson ) {
+						// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
 						$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz. Your grade is %2$s%%', 'woothemes-sensei' ),  Sensei_Utils::round( $quiz_passmark ),  Sensei_Utils::round( $quiz_grade ) );
 					} else {
+						// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
 						$message = sprintf( __( 'You require %1$d%% to pass this quiz. Your grade is %2$s%%', 'woothemes-sensei' ),  Sensei_Utils::round( $quiz_passmark ),  Sensei_Utils::round( $quiz_grade ) );
 					}
 				}
@@ -1345,8 +1354,10 @@ class Sensei_Utils {
 					if( ! Sensei_Lesson::is_prerequisite_complete( $lesson_id, get_current_user_id() ) ) {
 						$message = '';
 					}  else if( $is_lesson ) {
+						// translators: Placeholder is the quiz passmark.
 						$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz.', 'woothemes-sensei' ),  Sensei_Utils::round( $quiz_passmark ) );
 					} else {
+						// translators: Placeholder is the quiz passmark.
 						$message = sprintf( __( 'You require %1$d%% to pass this quiz.', 'woothemes-sensei' ),  Sensei_Utils::round( $quiz_passmark ) );
 					}
 				}
@@ -1361,10 +1372,12 @@ class Sensei_Utils {
 
 			if ( Sensei_WC::is_course_purchasable( $course_id ) ){
 
+				// translators: Placeholder is a link to the course permalink.
 				$message = sprintf( __( 'Please purchase the %1$s before taking this quiz.', 'woothemes-sensei' ), $a_element );
 
 			} else {
 
+				// translators: Placeholder is a link to the course permalink.
 				$message = sprintf( __( 'Please sign up for the %1$s before taking this quiz.', 'woothemes-sensei' ), $a_element );
 
 			}

--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -483,6 +483,7 @@ class Sensei_WC {
 							  . '" title="' . __( 'complete purchase', 'woothemes-sensei' ) . '">'
 							  . __( 'complete the purchase', 'woothemes-sensei' ) . '</a>';
 
+				// translators: Placeholder is a link to the cart.
 				echo sprintf( __( 'You have already added this Course to your cart. Please %1$s to access the course.', 'woothemes-sensei' ), $cart_link );
 
 				?>
@@ -963,6 +964,7 @@ class Sensei_WC {
 
 			$cart_link = '<a href="' . wc_get_checkout_url() . '" title="' . __( 'Checkout', 'woocommerce' ) . '">' . __( 'checkout', 'woocommerce' ) . '</a>';
 
+			// translators: Placeholder is a link to the cart.
 			$message = sprintf( __( 'This course is already in your cart, please proceed to %1$s, to gain access.', 'woothemes-sensei' ), $cart_link );
 			?>
 			<span class="add-to-cart-login">
@@ -983,6 +985,7 @@ class Sensei_WC {
 			<?php
 
 		} else {
+			// translators: Placeholder is a link to log in.
 			$message = sprintf( __( 'Or %1$s to access your purchased courses', 'woothemes-sensei' ), $login_link );
 			?>
 				<span class="add-to-cart-login">
@@ -1194,6 +1197,7 @@ class Sensei_WC {
 							$title = $course->post_title;
 							$permalink = get_permalink( $course->ID );
 							$order_contains_courses = true;
+							// translators: Placeholder is a link to the course.
 							$course_details_html .= '<p><strong>' . sprintf( __( 'View course: %1$s', 'woothemes-sensei' ), '</strong><a href="' . esc_url( $permalink ) . '">' . $title . '</a>' ) . '</p>';
 						}
 					}

--- a/includes/emails/class-woothemes-sensei-email-learner-completed-course.php
+++ b/includes/emails/class-woothemes-sensei-email-learner-completed-course.php
@@ -54,12 +54,13 @@ class WooThemes_Sensei_Email_Learner_Completed_Course {
 
 		// Set recipient (learner)
 		$this->recipient = stripslashes( $this->user->user_email );
-		
+
 		do_action('sensei_before_mail', $this->recipient);
-		
+
+		// translators: Placeholder is the blog name.
 		$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] You have completed a course', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
 		$this->heading = apply_filters( 'sensei_email_heading', __( 'You have completed a course', 'woothemes-sensei' ), $this->template );
- 
+
 
 		// Get passed status
 		$passed = __( 'passed', 'woothemes-sensei' );

--- a/includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php
+++ b/includes/emails/class-woothemes-sensei-email-learner-graded-quiz.php
@@ -56,12 +56,13 @@ class WooThemes_Sensei_Email_Learner_Graded_Quiz {
 
 		// Set recipient (learner)
 		$this->recipient = stripslashes( $this->user->user_email );
- 
+
 		do_action('sensei_before_mail', $this->recipient);
-		
+
+		// translators: Placeholder is the blog name.
 		$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your quiz has been graded', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
 		$this->heading = apply_filters( 'sensei_email_heading', __( 'Your quiz has been graded', 'woothemes-sensei' ), $this->template );
-		
+
 
 		// Get passed flag
 		$passed = __( 'failed', 'woothemes-sensei' );
@@ -73,6 +74,7 @@ class WooThemes_Sensei_Email_Learner_Graded_Quiz {
 		$grade_type = get_post_meta( $quiz_id, '_quiz_grade_type', true );
 
 		if( 'auto' == $grade_type ) {
+			// translators: Placeholder is the blog name.
 			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] You have completed a quiz', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
 			$this->heading = apply_filters( 'sensei_email_heading', __( 'You have completed a quiz', 'woothemes-sensei' ), $this->template );
 		}

--- a/includes/emails/class-woothemes-sensei-email-new-message-reply.php
+++ b/includes/emails/class-woothemes-sensei-email-new-message-reply.php
@@ -88,12 +88,13 @@ class WooThemes_Sensei_Email_New_Message_Reply {
 		} else {
 			$this->recipient = stripslashes( $this->original_sender->user_email );
 		}
-		
+
 		do_action('sensei_before_mail', $this->recipient);
-		
+
+		// translators: Placeholder is the blog name.
 		$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] You have a new message', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
 		$this->heading = apply_filters( 'sensei_email_heading', __( 'You have received a reply to your private message', 'woothemes-sensei' ), $this->template );
- 
+
 
 		$content_type = get_post_meta( $this->message->ID, '_posttype', true );
 		$content_id = get_post_meta( $this->message->ID, '_post', true );

--- a/includes/emails/class-woothemes-sensei-email-teacher-completed-course.php
+++ b/includes/emails/class-woothemes-sensei-email-teacher-completed-course.php
@@ -55,9 +55,10 @@ class WooThemes_Sensei_Email_Teacher_Completed_Course {
 
 		// Set recipient (learner)
 		$this->recipient = stripslashes( $this->teacher->user_email );
-		
+
 		do_action('sensei_before_mail', $this->recipient);
-		
+
+		// translators: Placeholder is the blog name.
 		$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has completed a course', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
 		$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has completed a course', 'woothemes-sensei' ), $this->template );
 

--- a/includes/emails/class-woothemes-sensei-email-teacher-completed-lesson.php
+++ b/includes/emails/class-woothemes-sensei-email-teacher-completed-lesson.php
@@ -28,6 +28,7 @@ class WooThemes_Sensei_Email_Teacher_Completed_Lesson {
 	 */
 	function __construct() {
 		$this->template = 'teacher-completed-lesson';
+		// translators: Placeholder is the blog name.
 		$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has completed a lesson', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
 		$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has completed a lesson', 'woothemes-sensei' ), $this->template );
 	}

--- a/includes/emails/class-woothemes-sensei-email-teacher-new-message.php
+++ b/includes/emails/class-woothemes-sensei-email-teacher-new-message.php
@@ -51,12 +51,13 @@ class WooThemes_Sensei_Email_Teacher_New_Message {
 
 		// Set recipient (teacher)
 		$this->recipient = stripslashes( $this->teacher->user_email );
-		
+
 		do_action('sensei_before_mail', $this->recipient);
-		
+
+		// translators: Placeholder is the blog name.
 		$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] You have received a new private message', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
 		$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has sent you a private message', 'woothemes-sensei' ), $this->template );
- 
+
 
 		$content_type = get_post_meta( $message_id, '_posttype', true );
 		$content_id = get_post_meta( $message_id, '_post', true );

--- a/includes/emails/class-woothemes-sensei-email-teacher-quiz-submitted.php
+++ b/includes/emails/class-woothemes-sensei-email-teacher-quiz-submitted.php
@@ -57,12 +57,13 @@ class WooThemes_Sensei_Email_Teacher_Quiz_Submitted {
 
 		// Set recipient (teacher)
 		$this->recipient = stripslashes( $this->teacher->user_email );
-		
+
 		do_action('sensei_before_mail', $this->recipient);
-		
+
+		// translators: Placeholder is the blog name.
 		$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has submitted a quiz for grading', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
 		$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has submitted a quiz for grading', 'woothemes-sensei' ), $this->template );
- 
+
 
 		// Construct data array
 		$sensei_email_data = apply_filters( 'sensei_email_data', array(

--- a/includes/emails/class-woothemes-sensei-email-teacher-started-course.php
+++ b/includes/emails/class-woothemes-sensei-email-teacher-started-course.php
@@ -50,12 +50,13 @@ class WooThemes_Sensei_Email_Teacher_Started_Course {
 
 		// Set recipient (learner)
 		$this->recipient = stripslashes( $this->teacher->user_email );
-		
+
 		do_action('sensei_before_mail', $this->recipient);
-		
+
+		// translators: Placeholder is the blog name.
 		$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has started a course', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
 		$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has started a course', 'woothemes-sensei' ), $this->template );
- 
+
 
 		// Construct data array
 		$sensei_email_data = apply_filters( 'sensei_email_data', array(

--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -8,6 +8,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+// phpcs:disable WordPress.WP.I18n.NonSingularStringLiteralDomain
+
 /**
  * Usage Tracking class. Please update the prefix to something unique to your
  * plugin.
@@ -576,3 +578,4 @@ abstract class Sensei_Usage_Tracking_Base {
 <?php
 	}
 }
+// phpcs: enable

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -197,7 +197,7 @@ function sensei_do_deprecated_action( $hook_tag, $version, $alternative="" , $ar
 
     if( has_action( $hook_tag ) ){
 
-        $error_message = sprintf( __( "SENSEI: The hook '%s', has been deprecated since '%s'." , 'woothemes-sensei'), $hook_tag ,$version );
+        $error_message = sprintf( __( "SENSEI: The hook '%1\$s', has been deprecated since '%2\$s'." , 'woothemes-sensei'), $hook_tag ,$version );
 
         if( !empty( $alternative ) ){
 

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -201,6 +201,7 @@ function sensei_do_deprecated_action( $hook_tag, $version, $alternative="" , $ar
 
         if( !empty( $alternative ) ){
 
+			// translators: Placeholder is the alternative action name.
             $error_message .= sprintf( __("Please use '%s' instead.", 'woothemes-sensei'), $alternative ) ;
 
         }

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -363,7 +363,12 @@ class Sensei_Legacy_Shortcodes {
                                 </span>
 
                         <?php if ( '' != $category_output ) { ?>
-                            <span class="course-category"><?php echo sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ); ?></span>
+                            <span class="course-category">
+								<?php
+								// translators: Placeholder is a comma-separated list of categories.
+								echo sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output );
+								?>
+							</span>
                         <?php } // End If Statement ?>
 
                         <?php sensei_simple_course_price( $course_id ); ?>
@@ -375,6 +380,7 @@ class Sensei_Legacy_Shortcodes {
                     </p>
 
                     <?php if ( 0 < $preview_lesson_count && !$is_user_taking_course ) {
+						// translators: Placeholder is the number of preview lessons.
                         $preview_lessons = sprintf( __( '(%d preview lessons)', 'woothemes-sensei' ), $preview_lesson_count ); ?>
                         <p class="sensei-free-lessons">
                             <a href="<?php echo get_permalink( $course_id ); ?>"><?php _e( 'Preview this course', 'woothemes-sensei' ) ?>

--- a/includes/shortcodes/class-sensei-shortcode-course-page.php
+++ b/includes/shortcodes/class-sensei-shortcode-course-page.php
@@ -51,6 +51,7 @@ class Sensei_Shortcode_Course_Page implements Sensei_Shortcode_Interface {
 	public function render() {
 		if ( empty( $this->id ) ) {
 			return sprintf(
+				// translators: Placeholder is the example shortcode text.
 				__( 'Please supply a course ID for the shortcode: %s', 'woothemes-sensei' ),
 				'[sensei_course_page id=""]'
 			);
@@ -59,6 +60,7 @@ class Sensei_Shortcode_Course_Page implements Sensei_Shortcode_Interface {
 		try {
 			return $this->renderer->render();
 		} catch ( Sensei_Renderer_Missing_Fields_Exception $e ) {
+			// translators: Placeholders are the shortcode name and the error message.
 			return sprintf( __( 'Error rendering %1$s shortcode - %2$s', 'woothemes-sensei' ), '[sensei_course_page]', $e->getMessage() );
 		}
 	}

--- a/includes/shortcodes/class-sensei-shortcode-course-page.php
+++ b/includes/shortcodes/class-sensei-shortcode-course-page.php
@@ -59,7 +59,7 @@ class Sensei_Shortcode_Course_Page implements Sensei_Shortcode_Interface {
 		try {
 			return $this->renderer->render();
 		} catch ( Sensei_Renderer_Missing_Fields_Exception $e ) {
-			return sprintf( __( 'Error rendering %s shortcode - %s', 'woothemes-sensei' ), '[sensei_course_page]', $e->getMessage() );
+			return sprintf( __( 'Error rendering %1$s shortcode - %2$s', 'woothemes-sensei' ), '[sensei_course_page]', $e->getMessage() );
 		}
 	}
 

--- a/includes/shortcodes/class-sensei-shortcode-unpurchased-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-unpurchased-courses.php
@@ -131,7 +131,7 @@ class Sensei_Shortcode_Unpurchased_Courses implements Sensei_Shortcode_Interface
             $anchor_before = '<a href="' . esc_url( sensei_user_login_url() ) . '" >';
             $anchor_after = '</a>';
             $notice = sprintf(
-                __('You must be logged in to view the non-purchased courses. Click here to %slogin%s.', 'woothemes-sensei' ),
+                __('You must be logged in to view the non-purchased courses. Click here to %1$slogin%2$s.', 'woothemes-sensei' ),
                 $anchor_before,
                 $anchor_after
             );

--- a/includes/shortcodes/class-sensei-shortcode-unpurchased-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-unpurchased-courses.php
@@ -131,6 +131,7 @@ class Sensei_Shortcode_Unpurchased_Courses implements Sensei_Shortcode_Interface
             $anchor_before = '<a href="' . esc_url( sensei_user_login_url() ) . '" >';
             $anchor_after = '</a>';
             $notice = sprintf(
+				// translators: Placeholders are an opening and closing <a> tag linking to the login URL.
                 __('You must be logged in to view the non-purchased courses. Click here to %1$slogin%2$s.', 'woothemes-sensei' ),
                 $anchor_before,
                 $anchor_after

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -71,7 +71,10 @@ global $course;
                     <h2>
 
                         <a href="<?php echo esc_url_raw( get_permalink( $lesson->ID ) ); ?>"
-                           title="<?php echo esc_attr_e( sprintf( __( 'Start %s', 'woothemes-sensei' ), $lesson->post_title ) ); ?>">
+                           title="<?php
+							// translators: Placeholder is the lesson title.
+							echo esc_attr( sprintf( __( 'Start %s', 'woothemes-sensei' ), $lesson->post_title ) );
+						?> ">
 
                             <?php echo esc_html( $lesson->post_title ); ?>
 
@@ -128,9 +131,15 @@ global $course;
 
                 <h2>
 
-                    <a href="<?php echo esc_url_raw( get_permalink( $lesson->ID ) ) ?>" title="<?php esc_attr_e( sprintf( __( 'Start %s', 'woothemes-sensei' ), $lesson->post_title ) ) ?>" >
+                    <a href="<?php echo esc_url_raw( get_permalink( $lesson->ID ) ) ?>" title="<?php
+						// translators: Placeholder it the lesson title.
+						esc_attr( sprintf( __( 'Start %s', 'woothemes-sensei' ), $lesson->post_title ) )
+					?>" >
 
-                        <?php esc_html_e( sprintf( __( '%s', 'woothemes-sensei' ), $lesson->post_title ) ); ?>
+						<?php
+						// translators: Placeholder is the lesson title.
+						esc_html( $lesson->post_title );
+						?>
 
                     </a>
 

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -136,10 +136,7 @@ global $course;
 						esc_attr( sprintf( __( 'Start %s', 'woothemes-sensei' ), $lesson->post_title ) )
 					?>" >
 
-						<?php
-						// translators: Placeholder is the lesson title.
-						esc_html( $lesson->post_title );
-						?>
+						<?php echo esc_html( $lesson->post_title ); ?>
 
                     </a>
 

--- a/templates/emails/footer.php
+++ b/templates/emails/footer.php
@@ -20,6 +20,7 @@ if( isset( Sensei()->settings->settings['email_base_color'] ) && '' != Sensei()-
 
 $base_lighter_40 = sensei_hex_lighter( $base, 40 );
 
+// translators: Placeholder is the blog name.
 $footer_text = sprintf( __( '%1$s - Powered by Sensei', 'woothemes-sensei' ), get_bloginfo( 'name' ) );
 if( isset( Sensei()->settings->settings['email_footer_text'] ) ) {
     $footer_text = Sensei()->settings->settings['email_footer_text'];

--- a/templates/emails/learner-completed-course.php
+++ b/templates/emails/learner-completed-course.php
@@ -23,7 +23,12 @@ $large = "text-align: center !important;font-size: 350% !important;line-height: 
 
 <?php do_action( 'sensei_before_email_content', $template ); ?>
 
-<p style="<?php echo esc_attr( $small ); ?>"><?php printf( __( 'You have completed and %1$s the course', 'woothemes-sensei' ), $passed ); ?></p>
+<p style="<?php echo esc_attr( $small ); ?>">
+<?php
+// translators: Placeholder is the translated text for "passed" or "failed".
+printf( __( 'You have completed and %1$s the course', 'woothemes-sensei' ), $passed );
+?>
+</p>
 
 <h2 style="<?php echo esc_attr( $large ); ?>"><?php echo get_the_title( $course_id ); ?></h2>
 

--- a/templates/emails/learner-graded-quiz.php
+++ b/templates/emails/learner-graded-quiz.php
@@ -23,7 +23,12 @@ $large = "text-align: center !important;font-size: 350% !important;line-height: 
 
 <?php do_action( 'sensei_before_email_content', $template ); ?>
 
-<p style="<?php echo esc_attr( $small ); ?>"><?php printf( __( 'You %1$s the lesson', 'woothemes-sensei' ), $passed ); ?></p>
+<p style="<?php echo esc_attr( $small ); ?>">
+<?php
+// translators: Placeholder is the translated text for "passed" or "failed".
+printf( __( 'You %1$s the lesson', 'woothemes-sensei' ), $passed );
+?>
+</p>
 
 <h2 style="<?php echo esc_attr( $large ); ?>"><?php echo get_the_title( $lesson_id ); ?></h2>
 
@@ -31,10 +36,20 @@ $large = "text-align: center !important;font-size: 350% !important;line-height: 
 
 <h2 style="<?php echo esc_attr( $large ); ?>"><?php echo $grade . '%'; ?></h2>
 
-<p style="<?php echo esc_attr( $small ); ?>"><?php printf( __( 'The pass mark is %1$s', 'woothemes-sensei' ), $passmark . '%' ); ?></p>
+<p style="<?php echo esc_attr( $small ); ?>">
+<?php
+// translators: Placeholder is the passmark as a percentage.
+printf( __( 'The pass mark is %1$s', 'woothemes-sensei' ), $passmark . '%' );
+?>
+</p>
 
 <hr/>
 
-<p style="<?php echo esc_attr( $small ); ?>"><?php printf( __( 'You can review your grade and your answers %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . get_permalink( $quiz_id ) . '">', '</a>' ); ?></p>
+<p style="<?php echo esc_attr( $small ); ?>">
+<?php
+// translators: Placeholders are an opening and closing <a> tag linking to the quiz permalink.
+printf( __( 'You can review your grade and your answers %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . get_permalink( $quiz_id ) . '">', '</a>' );
+?>
+</p>
 
 <?php do_action( 'sensei_after_email_content', $template ); ?>

--- a/templates/emails/new-message-reply.php
+++ b/templates/emails/new-message-reply.php
@@ -25,7 +25,12 @@ $large = "text-align: center !important;font-size: 350% !important;line-height: 
 
 <h2 style="<?php echo esc_attr( $large ); ?>"><?php echo $commenter_name; ?></h2>
 
-<p style="<?php echo esc_attr( $small ); ?>"><?php printf( __( 'has replied to your private message regarding the %1$s', 'woothemes-sensei' ), $content_type ); ?></p>
+<p style="<?php echo esc_attr( $small ); ?>">
+<?php
+// translators: Placeholder is the post type (e.g. course or lesson)
+printf( __( 'has replied to your private message regarding the %1$s', 'woothemes-sensei' ), $content_type );
+?>
+</p>
 
 <h2 style="<?php echo esc_attr( $large ); ?>"><?php echo $content_title; ?></h2>
 
@@ -35,6 +40,11 @@ $large = "text-align: center !important;font-size: 350% !important;line-height: 
 
 <hr/>
 
-<p style="<?php echo esc_attr( $small ); ?>"><?php printf( __( 'You can view the message and reply %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . $comment_link . '">', '</a>' ); ?></p>
+<p style="<?php echo esc_attr( $small ); ?>">
+<?php
+// translators: Placeholder is an opening an closing <a> tag linking to the comment.
+printf( __( 'You can view the message and reply %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . $comment_link . '">', '</a>' );
+?>
+</p>
 
 <?php do_action( 'sensei_after_email_content', $template ); ?>

--- a/templates/emails/teacher-completed-course.php
+++ b/templates/emails/teacher-completed-course.php
@@ -27,12 +27,22 @@ $large = "text-align: center !important;font-size: 350% !important;line-height: 
 
 <h2 style="<?php echo esc_attr( $large ); ?>"><?php echo $learner_name; ?></h2>
 
-<p style="<?php echo esc_attr( $small ); ?>"><?php printf( __( 'has completed and %1$s the course', 'woothemes-sensei' ), $passed ); ?></p>
+<p style="<?php echo esc_attr( $small ); ?>">
+<?php
+// translators: Placeholder is the translated text for "passed" or "failed".
+printf( __( 'has completed and %1$s the course', 'woothemes-sensei' ), $passed );
+?>
+</p>
 
 <h2 style="<?php echo esc_attr( $large ); ?>"><?php echo get_the_title( $course_id ); ?></h2>
 
 <hr/>
 
-<p style="<?php echo esc_attr( $small ); ?>"><?php printf( __( 'Manage this course\'s learners %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'admin.php?page=sensei_learners&view=learners&course_id=' . $course_id ) . '">', '</a>' ); ?></p>
+<p style="<?php echo esc_attr( $small ); ?>">
+<?php
+// translators: Placeholders are an opening an closing <a> tag linking to the course learners admin page.
+printf( __( 'Manage this course\'s learners %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'admin.php?page=sensei_learners&view=learners&course_id=' . $course_id ) . '">', '</a>' );
+?>
+</p>
 
 <?php do_action( 'sensei_after_email_content', $template ); ?>

--- a/templates/emails/teacher-completed-lesson.php
+++ b/templates/emails/teacher-completed-lesson.php
@@ -33,6 +33,11 @@ $large = "text-align: center !important;font-size: 350% !important;line-height: 
 
 <hr/>
 
-<p style="<?php echo esc_attr( $small ); ?>"><?php printf( __( 'Manage this lesson\'s learners %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'admin.php?page=sensei_learners&view=learners&lesson_id=' . $lesson_id ) . '">', '</a>' ); ?></p>
+<p style="<?php echo esc_attr( $small ); ?>">
+<?php
+// translators: Placeholders are an opening and closing <a> tag linking to the lesson's learners page.
+printf( __( 'Manage this lesson\'s learners %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'admin.php?page=sensei_learners&view=learners&lesson_id=' . $lesson_id ) . '">', '</a>' );
+?>
+</p>
 
 <?php do_action( 'sensei_after_email_content', $template ); ?>

--- a/templates/emails/teacher-new-message.php
+++ b/templates/emails/teacher-new-message.php
@@ -27,7 +27,12 @@ $large = "text-align: center !important;font-size: 350% !important;line-height: 
 
 <h2 style="<?php echo esc_attr( $large ); ?>"><?php echo $learner_name; ?></h2>
 
-<p style="<?php echo esc_attr( $small ); ?>"><?php printf( __( 'has sent you a private message regarding the %1$s', 'woothemes-sensei' ), $content_type ); ?></p>
+<p style="<?php echo esc_attr( $small ); ?>">
+<?php
+// translators: Placeholder is the post type (e.g. course or lesson).
+printf( __( 'has sent you a private message regarding the %1$s', 'woothemes-sensei' ), $content_type );
+?>
+</p>
 
 <h2 style="<?php echo esc_attr( $large ); ?>"><?php echo $content_title; ?></h2>
 
@@ -37,6 +42,11 @@ $large = "text-align: center !important;font-size: 350% !important;line-height: 
 
 <hr/>
 
-<p style="<?php echo esc_attr( $small ); ?>"><?php printf( __( 'You can reply to this message %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . get_permalink( $message_id ) . '">', '</a>' ); ?></p>
+<p style="<?php echo esc_attr( $small ); ?>">
+<?php
+// translators: Placeholders are an opening and closing <a> tag linking to the Message permalink.
+printf( __( 'You can reply to this message %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . get_permalink( $message_id ) . '">', '</a>' );
+?>
+</p>
 
 <?php do_action( 'sensei_after_email_content', $template ); ?>

--- a/templates/emails/teacher-quiz-submitted.php
+++ b/templates/emails/teacher-quiz-submitted.php
@@ -35,6 +35,11 @@ $large = "text-align: center !important;font-size: 350% !important;line-height: 
 
 <hr/>
 
-<p style="<?php echo esc_attr( $small ); ?>"><?php printf( __( 'You can grade this quiz %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'admin.php?page=sensei_grading&user=' . $learner_id . '&quiz_id=' . $quiz_id ) . '">', '</a>' ); ?></p>
+<p style="<?php echo esc_attr( $small ); ?>">
+<?php
+// translators: Placeholders are an opening and closing <a> tag linking to the grading page for the quiz.
+printf( __( 'You can grade this quiz %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'admin.php?page=sensei_grading&user=' . $learner_id . '&quiz_id=' . $quiz_id ) . '">', '</a>' );
+?>
+</p>
 
 <?php do_action( 'sensei_after_email_content', $template ); ?>

--- a/templates/emails/teacher-started-course.php
+++ b/templates/emails/teacher-started-course.php
@@ -33,6 +33,11 @@ $large = "text-align: center !important;font-size: 350% !important;line-height: 
 
 <hr/>
 
-<p style="<?php echo esc_attr( $small ); ?>"><?php printf( __( 'Manage this course\'s learners %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'admin.php?page=sensei_learners&view=learners&course_id=' . $course_id ) . '">', '</a>' ); ?></p>
+<p style="<?php echo esc_attr( $small ); ?>">
+<?php
+// translators: Placeholders are an opening and closing <a> tag linking to the course's learners page in wp-admin.
+printf( __( 'Manage this course\'s learners %1$shere%2$s.', 'woothemes-sensei' ), '<a href="' . admin_url( 'admin.php?page=sensei_learners&view=learners&course_id=' . $course_id ) . '">', '</a>' );
+?>
+</p>
 
 <?php do_action( 'sensei_after_email_content', $template ); ?>

--- a/widgets/widget-woothemes-sensei-lesson-component.php
+++ b/widgets/widget-woothemes-sensei-lesson-component.php
@@ -199,7 +199,12 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
     					<br />
     				<?php } // End If Statement ?>
     				<?php if ( 0 < $lesson_course_id ) { ?>
-                        <span class="lesson-course"><?php echo ' ' . sprintf( __( 'Part of: %s', 'woothemes-sensei' ), '<a href="' . esc_url( get_permalink( $lesson_course_id ) ) . '" title="' . esc_attr( __( 'View course', 'woothemes-sensei' ) ) . '"><em>' . get_the_title( $lesson_course_id ) . '</em></a>' ); ?></span>
+                        <span class="lesson-course">
+							<?php
+							// translators: Placeholder is a link to the Course permalink.
+							echo ' ' . sprintf( __( 'Part of: %s', 'woothemes-sensei' ), '<a href="' . esc_url( get_permalink( $lesson_course_id ) ) . '" title="' . esc_attr( __( 'View course', 'woothemes-sensei' ) ) . '"><em>' . get_the_title( $lesson_course_id ) . '</em></a>' );
+							?>
+						</span>
                     <?php } ?>
     				<br />
 		    	</li>

--- a/widgets/widget-woothemes-sensei-lesson-component.php
+++ b/widgets/widget-woothemes-sensei-lesson-component.php
@@ -201,8 +201,11 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
     				<?php if ( 0 < $lesson_course_id ) { ?>
                         <span class="lesson-course">
 							<?php
-							// translators: Placeholder is a link to the Course permalink.
-							echo ' ' . sprintf( __( 'Part of: %s', 'woothemes-sensei' ), '<a href="' . esc_url( get_permalink( $lesson_course_id ) ) . '" title="' . esc_attr( __( 'View course', 'woothemes-sensei' ) ) . '"><em>' . get_the_title( $lesson_course_id ) . '</em></a>' );
+							echo ' ' . sprintf(
+								// translators: Placeholder is a link to the Course permalink.
+								__( 'Part of: %s', 'woothemes-sensei' ),
+								'<a href="' . esc_url( get_permalink( $lesson_course_id ) ) . '" title="' . esc_attr( __( 'View course', 'woothemes-sensei' ) ) . '"><em>' . get_the_title( $lesson_course_id ) . '</em></a>'
+							);
 							?>
 						</span>
                     <?php } ?>


### PR DESCRIPTION
Adds phpcs checks for i18n and syntax issues. This is a similar check to what is run on WordPress.com, and will allow us to more seamlessly deploy new code to that platform.

Note that a lot of i18n linter issues needed to be fixed for this to pass. Most of the changes are the addition of `translators:` comments.

# Testing

- See the CI run for this PR and ensure the phpcs job is passing.

- See the CI run for https://github.com/Automattic/sensei/pull/2232 and ensure the phpcs job is failing.