### PR TITLE
Bulk Learner Actions: Only query from current blog on multisite

### DIFF
--- a/includes/class-sensei-db-query-learners.php
+++ b/includes/class-sensei-db-query-learners.php
@@ -30,7 +30,7 @@ class Sensei_Db_Query_Learners {
 		$user_query = new WP_User_Query( $user_query_args );
 		$matching_user_ids = array_map( 'absint', $user_query->get_results() );
 
-        $sql = "SELECT `u`.`ID` AS 'user_id',
+        $sql = "SELECT SQL_CALC_FOUND_ROWS `u`.`ID` AS 'user_id',
               `u`.`user_nicename`,
               `u`.`user_login`,
               `u`.`user_email`,
@@ -70,7 +70,7 @@ class Sensei_Db_Query_Learners {
         $sql = $this->build_query();
 
         $results = $wpdb->get_results( $sql );
-        $this->total_items = intval( $wpdb->query( $this->build_query('count') ) );
+        $this->total_items = intval( $wpdb->get_var( 'SELECT FOUND_ROWS()' ) );
         return $results;
     }
 }


### PR DESCRIPTION
Fixes: #2143 

This PR makes the following changes:
- It uses `WP_User_Query` to get the initial list of user IDs, which has the benefit of doing the correct checks for access to a particular blog in a multisite installation. 
- In order to do this, it now runs the "search" query even if not searching (if on multisite). This is to get the correct users.
- Only runs the final query once and then uses `FOUND_ROWS()` to get the previous total.

There is quite a bit of complexity in this functionality due to the `Sensei_Db_Query_Learners` class. It seems, for now, in order to be able to query by course, we need to continue to build the raw SQL query.

## Testing Instructions
- On a multisite instance with multiple Sensei site, have multiple users register in each site (using WooCommerce) and register for courses.
- Verify for each site, under Sensei > Learner Management > Bulk Learner Actions, only the users that are associated with that particular site are displayed.
- On both the multisite instance and a standard WP instance, verify the filters and pagination continue to work as normal on that screen.