### PR TITLE
Add theme compatibility to the teacher archive page

### DIFF
--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -159,6 +159,7 @@ class Sensei_Autoloader {
 			'Sensei_Unsupported_Theme_Handler_Module'             => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-module.php',
 			'Sensei_Unsupported_Theme_Handler_Course_Results'     => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-results.php',
 			'Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive' => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php',
+			'Sensei_Unsupported_Theme_Handler_Teacher_Archive'    => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php',
 
             /**
              * Built in theme integration support

--- a/includes/class-sensei-unsupported-themes.php
+++ b/includes/class-sensei-unsupported-themes.php
@@ -79,6 +79,7 @@ class Sensei_Unsupported_Themes {
 			new Sensei_Unsupported_Theme_Handler_Module(),
 			new Sensei_Unsupported_Theme_Handler_Course_Results(),
 			new Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive(),
+			new Sensei_Unsupported_Theme_Handler_Teacher_Archive(),
 		);
 	}
 

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
@@ -67,7 +67,6 @@ class Sensei_Unsupported_Theme_Handler_Teacher_Archive
 		$content = $this->render_page();
 		$this->output_content_as_page( $content, $teacher_post, array(
 			'post_title' => sanitize_text_field( $teacher_post->post_title ),
-			'post_name'  => $teacher_post->post_name,
 		) );
 	}
 
@@ -95,7 +94,7 @@ class Sensei_Unsupported_Theme_Handler_Teacher_Archive
 	 *
 	 * @param WP_Query $wp_query
 	 * @param WP_Post  $post_to_copy
-	 * @param array $post_params
+	 * @param array    $post_params
 	 */
 	protected function prepare_wp_query( $wp_query, $post_to_copy, $post_params ) {
 		$wp_query->queried_object    = $this->author;

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
@@ -48,9 +48,7 @@ class Sensei_Unsupported_Theme_Handler_Teacher_Archive
 
 		// Render the teacher archive page and output it as a Page.
 		$content = $this->render_page();
-		$this->output_content_as_page( $content, $this->author, array(
-			'post_title' => sanitize_text_field( $this->author->display_name ),
-		) );
+		$this->output_content_as_page( $content, $this->author );
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
@@ -1,0 +1,105 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sensei Unsupported Theme Handler for the Teacher Archive Page.
+ *
+ * Handles rendering the teacher archive page for themes that do not declare support for
+ * Sensei.
+ *
+ * @author Automattic
+ *
+ * @since 1.12.0
+ */
+class Sensei_Unsupported_Theme_Handler_Teacher_Archive
+	extends Sensei_Unsupported_Theme_Handler_Page_Imitator
+	implements Sensei_Unsupported_Theme_Handler_Interface {
+
+	/**
+	 * @var WP_User $author
+	 */
+	private $author;
+
+	/**
+	 * We can handle this request if it is for a teacher archive page.
+	 *
+	 * @return bool
+	 */
+	public function can_handle_request() {
+		return is_author()
+				&& Sensei_Teacher::is_a_teacher( get_query_var('author') )
+				&& ! user_can( get_query_var('author'), 'manage_options' );
+	}
+
+	/**
+	 * Set up handling for a teacher archive page.
+	 *
+	 * This is done by manually rendering the content for the page, creating a
+	 * dummy post object, setting its content to the rendered content we generated,
+	 * and then forcing WordPress to render that post.
+	 * Adapted from WooCommerce and bbPress.
+	 *
+	 * @since 1.12.0
+	 */
+	public function handle_request() {
+		$this->author = get_user_by( 'id', get_query_var('author') );
+
+		if ( ! $this->author ) {
+			return;
+		}
+
+		$teacher_post = new WP_Post( (object) array(
+			'post_author'       => $this->author->ID,
+			'post_date'         => $this->author->user_registered,
+			'post_date_gmt'     => $this->author->user_registered,
+			'post_modified'     => $this->author->user_registered,
+			'post_modified_gmt' => $this->author->user_registered,
+			'post_title'        => $this->author->display_name,
+			'post_name'         => $this->author->user_nicename,
+			'post_excerpt'      => '',
+			'post_content'      => '',
+			'post_type'         => 'page',
+		) );
+
+		// Render the teacher archive page and output it as a Page.
+		$content = $this->render_page();
+		$this->output_content_as_page( $content, $teacher_post, array(
+			'post_title' => sanitize_text_field( $teacher_post->post_title ),
+			'post_name'  => $teacher_post->post_name,
+		) );
+	}
+
+	/**
+	 * Return the content for the teacher archive page.
+	 *
+	 * @since 1.12.0
+	 *
+	 * @return string
+	 */
+	private function render_page() {
+		ob_start();
+		add_filter( 'sensei_show_main_header', '__return_false' );
+		add_filter( 'sensei_show_main_footer', '__return_false' );
+		Sensei_Templates::get_template( 'teacher-archive.php' );
+		$content = ob_get_clean();
+
+		return $content;
+	}
+
+	/**
+	 * Prepare the WP query object for the imitated request. The `queried_object` property should
+	 * be the queried author in order for it to show up in the page's `<title>` tag for this author
+	 * query.
+	 *
+	 * @param WP_Query $wp_query
+	 * @param WP_Post  $post_to_copy
+	 * @param array $post_params
+	 */
+	protected function prepare_wp_query( $wp_query, $post_to_copy, $post_params ) {
+		$wp_query->queried_object    = $this->author;
+		$wp_query->queried_object_id = $this->author->ID;
+	}
+
+}

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
@@ -46,27 +46,10 @@ class Sensei_Unsupported_Theme_Handler_Teacher_Archive
 	public function handle_request() {
 		$this->author = get_user_by( 'id', get_query_var('author') );
 
-		if ( ! $this->author ) {
-			return;
-		}
-
-		$teacher_post = new WP_Post( (object) array(
-			'post_author'       => $this->author->ID,
-			'post_date'         => $this->author->user_registered,
-			'post_date_gmt'     => $this->author->user_registered,
-			'post_modified'     => $this->author->user_registered,
-			'post_modified_gmt' => $this->author->user_registered,
-			'post_title'        => $this->author->display_name,
-			'post_name'         => $this->author->user_nicename,
-			'post_excerpt'      => '',
-			'post_content'      => '',
-			'post_type'         => 'page',
-		) );
-
 		// Render the teacher archive page and output it as a Page.
 		$content = $this->render_page();
-		$this->output_content_as_page( $content, $teacher_post, array(
-			'post_title' => sanitize_text_field( $teacher_post->post_title ),
+		$this->output_content_as_page( $content, $this->author, array(
+			'post_title' => sanitize_text_field( $this->author->display_name ),
 		) );
 	}
 

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
@@ -29,8 +29,8 @@ class Sensei_Unsupported_Theme_Handler_Teacher_Archive
 	 */
 	public function can_handle_request() {
 		return is_author()
-				&& Sensei_Teacher::is_a_teacher( get_query_var('author') )
-				&& ! user_can( get_query_var('author'), 'manage_options' );
+				&& Sensei_Teacher::is_a_teacher( get_query_var( 'author' ) )
+				&& ! user_can( get_query_var( 'author' ), 'manage_options' );
 	}
 
 	/**
@@ -44,7 +44,7 @@ class Sensei_Unsupported_Theme_Handler_Teacher_Archive
 	 * @since 1.12.0
 	 */
 	public function handle_request() {
-		$this->author = get_user_by( 'id', get_query_var('author') );
+		$this->author = get_user_by( 'id', get_query_var( 'author' ) );
 
 		// Render the teacher archive page and output it as a Page.
 		$content = $this->render_page();

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-teacher-archive.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-teacher-archive.php
@@ -1,0 +1,165 @@
+<?php
+
+include_once 'test-class-sensei-unsupported-theme-handler-page-imitator.php';
+
+class Sensei_Unsupported_Theme_Handler_Teacher_Archive_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Sensei_Unsupported_Theme_Handler_Teacher_Archive_Test The request handler to test.
+	 */
+	private $handler;
+
+	/**
+	 * @var WP_User
+	 */
+	private $teacher_user;
+
+	public function setUp() {
+		parent::setUp();
+		Sensei()->teacher->create_role();
+
+		$this->factory = new Sensei_Factory();
+		$this->setupTeacherArchivePage();
+
+		Sensei_Unsupported_Theme_Handler_Page_Imitator_Test::create_page_template();
+
+		$this->handler = new Sensei_Unsupported_Theme_Handler_Teacher_Archive();
+	}
+
+	public function tearDown() {
+		$this->handler = null;
+
+		Sensei_Unsupported_Theme_Handler_Page_Imitator_Test::delete_page_template();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Teacher_Archive handles the teacher archive page.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldHandleTeacherArchivePage() {
+		$this->assertTrue( $this->handler->can_handle_request() );
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Teacher_Archive does not handle a
+	 * non-teacher archive page.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldNotHandleNonTeacherArchivePage() {
+		// Set up the query to be for the Courses page.
+		global $wp_query;
+		$wp_query = new WP_Query( array(
+			'post_type' => 'teacher_user',
+		) );
+
+		$this->assertFalse( $this->handler->can_handle_request() );
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Teacher_Archive disables the header and
+	 * footer when rendering the teacher archive page.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldDisableHeaderAndFooter() {
+		$this->assertFalse( has_filter( 'sensei_show_main_header', '__return_false' ), 'Header should initially be enabled' );
+		$this->assertFalse( has_filter( 'sensei_show_main_footer', '__return_false' ), 'Footer should initially be enabled' );
+
+		$this->handler->handle_request();
+
+		$this->assertNotFalse( has_filter( 'sensei_show_main_header', '__return_false' ), 'Header should be disabled by handler' );
+		$this->assertNotFalse( has_filter( 'sensei_show_main_footer', '__return_false' ), 'Footer should be disabled by handler' );
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Teacher_Archive renders the teacher archive page using
+	 * the teacher-archive.php template.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldUseTeacherArchiveTemplate() {
+		// We'll test to ensure it uses the template by checking if the
+		// sensei_teacher_archive_course_loop_before action was run.
+		$this->assertEquals(
+			0,
+			did_action( 'sensei_teacher_archive_course_loop_before' ),
+			'Should not have already done action sensei_teacher_archive_course_loop_before'
+		);
+
+		$this->handler->handle_request();
+
+		$this->assertEquals(
+			1,
+			did_action( 'sensei_teacher_archive_course_loop_before' ),
+			'Should have done action sensei_teacher_archive_course_loop_before'
+		);
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Teacher_Archive sets up a dummy post for
+	 * the final render of the teacher archive content.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldSetupDummyPost() {
+		global $post;
+
+		$this->handler->handle_request();
+
+		$this->assertEquals( 0, $post->ID, 'The dummy post ID should be 0' );
+		$this->assertEquals( 'page', $post->post_type, 'The dummy post type should be "page"' );
+
+		$copied_from_teacher_user = array(
+			'post_author'       => 'ID',
+			'post_date'         => 'user_registered',
+			'post_date_gmt'     => 'user_registered',
+			'post_modified'     => 'user_registered',
+			'post_modified_gmt' => 'user_registered',
+		);
+		foreach ( $copied_from_teacher_user as $post_field => $user_field ) {
+			$this->assertEquals(
+				$this->teacher_user->{$user_field},
+				$post->{$post_field},
+				"Dummy post field $post_field should be copied from the Course"
+			);
+		}
+	}
+
+	/**
+	 * Helper to set up the current request to be a teacher archive page. This request
+	 * will be handled by the unsupported theme handler if the theme is not
+	 * supported.
+	 *
+	 * @since 1.12.0
+	 */
+	private function setupTeacherArchivePage() {
+		global $post, $wp_query, $wp_the_query;
+
+		$this->teacher_user = $this->factory->user->create_and_get( array( 'role' => 'teacher' ) );
+
+		$posts = $this->factory->post->create_many( 2 );
+
+		// Setup $wp_query to be simple post list with the teacher_archive query arg.
+		$args         = array(
+			'post_type' => 'post',
+			'teacher_archive' => $this->teacher_user->user_nicename,
+		);
+		$wp_query = new WP_Query( $args );
+		$wp_the_query = $wp_query;
+
+		$wp_query->is_author            = true;
+		$wp_query->query_vars['author'] = $this->teacher_user->ID;
+		$wp_query->queried_object       = $this->teacher_user;
+		$wp_query->queried_object_id    = $this->teacher_user->ID;
+
+		// Setup $post to be the first lesson.
+		$posts = get_posts( array_merge( $args, array(
+			'posts_per_page' => 1,
+		) ) );
+		$post  = $posts[0];
+	}
+}


### PR DESCRIPTION
Partial solution to #2154

Using the same abstract from #2235, this adds the support for the teacher course archive page in unsupported themes. 

_Note_: Teacher archive pages are just supported for people with the teacher role.

## Testing
- Create multiple courses for a teacher.
- Visit the teacher archive page for the teacher (`/author/{user_nicename}`). 
- Ensure that the page looks right on themes that support Sensei and themes that do not support Sensei.
- For themes that do not support Sensei, ensure that:
  - The title is not duplicated.
  - The pagination does NOT show up at the bottom.