### PR TITLE
Add theme compatibility for the Message page

### DIFF
--- a/includes/class-sensei-unsupported-themes.php
+++ b/includes/class-sensei-unsupported-themes.php
@@ -77,6 +77,10 @@ class Sensei_Unsupported_Themes {
 		$this->_handlers = array(
 			new Sensei_Unsupported_Theme_Handler_CPT( 'course' ),
 			new Sensei_Unsupported_Theme_Handler_CPT( 'lesson' ),
+			new Sensei_Unsupported_Theme_Handler_CPT( 'sensei_message', array(
+				'show_pagination'   => false,
+				'template_filename' => 'single-message.php',
+			) ),
 			new Sensei_Unsupported_Theme_Handler_Module(),
 			new Sensei_Unsupported_Theme_Handler_Course_Results(),
 			new Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive(),

--- a/includes/renderers/class-sensei-renderer-single-post.php
+++ b/includes/renderers/class-sensei-renderer-single-post.php
@@ -118,7 +118,10 @@ class Sensei_Renderer_Single_Post implements Sensei_Renderer_Interface {
 			return;
 		}
 
-		$args = array( 'p' => $this->post_id );
+		$args = array(
+			'p'         => $this->post_id,
+			'post_type' => get_post_type( $this->post_id ),
+		);
 
 		$this->post_query = new WP_Query( $args );
 	}
@@ -145,11 +148,10 @@ class Sensei_Renderer_Single_Post implements Sensei_Renderer_Interface {
 	public function set_global_vars() {
 		global $wp_query, $wp_the_query, $post, $pages;
 
-		$post           = get_post( $this->post_id );
-		$pages          = array( $post->post_content );
-		$wp_query       = $this->post_query;
-		$wp_the_query   = $wp_query;
-		$wp_query->post = get_post( $this->post_id );
+		$post         = get_post( $this->post_id );
+		$pages        = array( $post->post_content );
+		$wp_query     = $this->post_query;
+		$wp_the_query = $wp_query;
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -21,12 +21,21 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 	protected $post_type;
 
 	/**
+	 * @var array Additional options.
+	 */
+	protected $options;
+
+	/**
 	 * Construct the handler.
 	 *
 	 * @param string $post_type The post type to render.
+	 * @param array  $options   An array of options. Currently supports:
+	 *                            bool   show_pagination
+	 *                            string template_filename
 	 */
-	public function __construct( $post_type ) {
+	public function __construct( $post_type, $options = array() ) {
 		$this->post_type = $post_type;
+		$this->options   = $options;
 	}
 
 	/**
@@ -82,6 +91,10 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		return $content;
 	}
 
+	protected function get_option( $name, $default = null ) {
+		return isset( $this->options[ $name ] ) ? $this->options[ $name ] : $default;
+	}
+
 	/**
 	 * Get the renderer for this handler. Subclasses may override this to
 	 * provide a custom object that implements Sensei_Renderer_Interface.
@@ -89,7 +102,8 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 	 * @return Sensei_Renderer_Interface The renderer object to use.
 	 */
 	protected function get_renderer() {
-		$post_id = get_the_ID();
+		$post_id         = get_the_ID();
+		$show_pagination = $this->get_option( 'show_pagination', true );
 
 		/**
 		 * Whether to show pagination on the CPT page when displaying on a
@@ -102,7 +116,7 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		 */
 		$show_pagination = apply_filters(
 			'sensei_cpt_page_show_pagination',
-			true,
+			$show_pagination,
 			$this->post_type,
 			$post_id
 		);
@@ -113,7 +127,7 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 	}
 
 	protected function get_template_filename() {
-		return "single-{$this->post_type}.php";
+		return $this->get_option( 'template_filename', "single-{$this->post_type}.php" );
 	}
 
 }

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -61,6 +61,7 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		$this->post_id = get_the_ID();
 
 		add_filter( 'the_content', array( $this, 'cpt_page_content_filter' ) );
+		add_filter( 'template_include', array( $this, 'force_page_template' ) );
 
 		// Handle some type-specific items.
 		if ( 'lesson' === $this->post_type ) {
@@ -161,6 +162,16 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 			return '';
 		}
 		return $title;
+	}
+
+	public function force_page_template( $template ) {
+		$path = get_query_template( 'page' );
+
+		if ( $path ) {
+			return $path;
+		}
+
+		return $template;
 	}
 
 }

--- a/templates/single-message.php
+++ b/templates/single-message.php
@@ -11,7 +11,10 @@
  */
 ?>
 
-<?php  get_sensei_header();  ?>
+<?php
+get_sensei_header();
+the_post();
+?>
 
 <article <?php post_class(); ?> >
 

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-cpt.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-cpt.php
@@ -99,6 +99,7 @@ class Sensei_Unsupported_Theme_Handler_CPT_Test extends WP_UnitTestCase {
 	 * @since 1.12.0
 	 */
 	public function testShouldRemoveContentFilter() {
+		$this->handler->handle_request();
 		$this->handler->cpt_page_content_filter( '' );
 
 		$this->assertFalse( has_filter( 'the_content', array( $this->handler, 'cpt_page_content_filter' ) ) );
@@ -110,6 +111,8 @@ class Sensei_Unsupported_Theme_Handler_CPT_Test extends WP_UnitTestCase {
 	 * @since 1.12.0
 	 */
 	public function testShouldUseSinglePostRenderer() {
+		$this->handler->handle_request();
+
 		$handler_content = $this->handler->cpt_page_content_filter( '' );
 		$renderer        = new Sensei_Renderer_Single_Post(
 			$this->course->ID,
@@ -133,6 +136,7 @@ class Sensei_Unsupported_Theme_Handler_CPT_Test extends WP_UnitTestCase {
 	 * @since 1.12.0
 	 */
 	public function testShouldShowPaginationByDefault() {
+		$this->handler->handle_request();
 		$this->handler->cpt_page_content_filter( '' );
 		$this->assertEquals( 1, did_action( 'sensei_pagination' ) );
 	}
@@ -144,6 +148,7 @@ class Sensei_Unsupported_Theme_Handler_CPT_Test extends WP_UnitTestCase {
 	 */
 	public function testShouldHidePaginationWhenFiltered() {
 		add_filter( 'sensei_cpt_page_show_pagination', '__return_false' );
+		$this->handler->handle_request();
 		$this->handler->cpt_page_content_filter( '' );
 		$this->assertEquals( 0, did_action( 'sensei_pagination' ) );
 	}


### PR DESCRIPTION
Partial solution to #2154

Adds theme compatibility for the Message page.

This PR changes some of the CPT handling code. The changes should be backwards compatible, but we may want to test the Lesson and Course pages to be sure that nothing broke.

## Testing

To test, simply load a Message page on several different themes. Make sure to try themes that support Sensei, and themes that do not. Also try with themes that Sensei provides integration for. Also, please double-check Course and Lesson pages.