### PR TITLE
Add theme compatibility to the lesson tag archive page

### DIFF
--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -153,11 +153,12 @@ class Sensei_Autoloader {
 			/**
 			 * Unsupported theme handlers.
 			 */
-			'Sensei_Unsupported_Theme_Handler_Interface'      => 'unsupported-theme-handlers/interface-sensei-unsupported-theme-handler.php',
-			'Sensei_Unsupported_Theme_Handler_Page_Imitator'  => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php',
-			'Sensei_Unsupported_Theme_Handler_Course'         => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course.php',
-			'Sensei_Unsupported_Theme_Handler_Module'         => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-module.php',
-			'Sensei_Unsupported_Theme_Handler_Course_Results' => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-results.php',
+			'Sensei_Unsupported_Theme_Handler_Interface'          => 'unsupported-theme-handlers/interface-sensei-unsupported-theme-handler.php',
+			'Sensei_Unsupported_Theme_Handler_Page_Imitator'      => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php',
+			'Sensei_Unsupported_Theme_Handler_Course'             => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course.php',
+			'Sensei_Unsupported_Theme_Handler_Module'             => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-module.php',
+			'Sensei_Unsupported_Theme_Handler_Course_Results'     => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-results.php',
+			'Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive' => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php',
 
             /**
              * Built in theme integration support

--- a/includes/class-sensei-unsupported-themes.php
+++ b/includes/class-sensei-unsupported-themes.php
@@ -78,6 +78,7 @@ class Sensei_Unsupported_Themes {
 			new Sensei_Unsupported_Theme_Handler_Course(),
 			new Sensei_Unsupported_Theme_Handler_Module(),
 			new Sensei_Unsupported_Theme_Handler_Course_Results(),
+			new Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive(),
 		);
 	}
 

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php
@@ -1,0 +1,76 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sensei Unsupported Theme Handler for the Lesson Tag Archive Page.
+ *
+ * Handles rendering the lesson tag archive page for themes that do not declare support for
+ * Sensei.
+ *
+ * @author Automattic
+ *
+ * @since 1.12.0
+ */
+class Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive
+	extends Sensei_Unsupported_Theme_Handler_Page_Imitator
+	implements Sensei_Unsupported_Theme_Handler_Interface {
+
+	/**
+	 * We can handle this request if it is for a lesson tag archive page.
+	 *
+	 * @return bool
+	 */
+	public function can_handle_request() {
+		return is_tax( 'lesson-tag' );
+	}
+
+	/**
+	 * Set up handling for a lesson tag archive page.
+	 *
+	 * This is done by manually rendering the content for the page, creating a
+	 * dummy post object, setting its content to the rendered content we generated,
+	 * and then forcing WordPress to render that post.
+	 * Adapted from WooCommerce and bbPress.
+	 *
+	 * @since 1.12.0
+	 */
+	public function handle_request() {
+		global $wp_query;
+
+		/**
+		 * @var WP_Term $term Term object. `is_tax` should ensure that is what is queried here.
+		 */
+		$term = $wp_query->get_queried_object();
+
+		// Render the lesson tag archive page and output it as a Page.
+		$content = $this->render_page();
+		$this->output_content_as_page( $content, $term );
+	}
+
+	/**
+	 * Return the content for the lesson tag archive page.
+	 *
+	 * @since 1.12.0
+	 *
+	 * @return string
+	 */
+	private function render_page() {
+		ob_start();
+		add_filter( 'sensei_show_main_header', '__return_false' );
+		add_filter( 'sensei_show_main_footer', '__return_false' );
+
+		$legacy_template = Sensei()->template_url . 'taxonomy-lesson-tag.php';
+		$found_legacy_template = locate_template( array( $legacy_template ) );
+		if ( $found_legacy_template ) {
+			Sensei_Templates::get_template( 'taxonomy-lesson-tag.php' );
+		} else {
+			Sensei_Templates::get_template( 'archive-lesson.php' );
+		}
+		$content = ob_get_clean();
+
+		return $content;
+	}
+
+}

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-lesson-tag-archive.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-lesson-tag-archive.php
@@ -1,0 +1,155 @@
+<?php
+
+include_once 'test-class-sensei-unsupported-theme-handler-page-imitator.php';
+
+class Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive_Test The request handler to test.
+	 */
+	private $handler;
+
+	/**
+	 * @var WP_Term $term
+	 */
+	private $term;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+		$this->setupLessonTagArchiveRequest();
+
+		Sensei_Unsupported_Theme_Handler_Page_Imitator_Test::create_page_template();
+
+		$this->handler = new Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive();
+	}
+
+	public function tearDown() {
+		$this->handler = null;
+
+		Sensei_Unsupported_Theme_Handler_Page_Imitator_Test::delete_page_template();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive handles the lesson tag archive page.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldHandleTeacherArchivePage() {
+		$this->assertTrue( $this->handler->can_handle_request() );
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive does not handle a
+	 * non-lesson tag archive page.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldNotHandleNonTeacherArchivePage() {
+		// Set up the query to be for the Courses page.
+		global $wp_query;
+		$wp_query = new WP_Query( array(
+			'post_type' => 'post',
+		) );
+
+		$this->assertFalse( $this->handler->can_handle_request() );
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive disables the header and
+	 * footer when rendering the lesson tag archive page.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldDisableHeaderAndFooter() {
+		$this->assertFalse( has_filter( 'sensei_show_main_header', '__return_false' ), 'Header should initially be enabled' );
+		$this->assertFalse( has_filter( 'sensei_show_main_footer', '__return_false' ), 'Footer should initially be enabled' );
+
+		$this->handler->handle_request();
+
+		$this->assertNotFalse( has_filter( 'sensei_show_main_header', '__return_false' ), 'Header should be disabled by handler' );
+		$this->assertNotFalse( has_filter( 'sensei_show_main_footer', '__return_false' ), 'Footer should be disabled by handler' );
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive renders the lesson tag archive page using
+	 * the lesson-archive.php template.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldUseLessonArchiveTemplate() {
+		// We'll test to ensure it uses the template by checking if the
+		// sensei_archive_before_lesson_loop action was run.
+		$this->assertEquals(
+			0,
+			did_action( 'sensei_archive_before_lesson_loop' ),
+			'Should not have already done action sensei_archive_before_lesson_loop'
+		);
+
+		$this->handler->handle_request();
+
+		$this->assertEquals(
+			1,
+			did_action( 'sensei_archive_before_lesson_loop' ),
+			'Should have done action sensei_archive_before_lesson_loop'
+		);
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive sets up a dummy post for
+	 * the final render of the lesson tag archive content.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldSetupDummyPost() {
+		global $post;
+
+		$this->handler->handle_request();
+
+		$this->assertEquals( 0, $post->ID, 'The dummy post ID should be 0' );
+		$this->assertEquals( 'page', $post->post_type, 'The dummy post type should be "page"' );
+
+		$copied_from_term = array(
+			'post_title'        => 'name',
+		);
+		foreach ( $copied_from_term as $post_field => $term_field ) {
+			$this->assertEquals(
+				$this->term->{$term_field},
+				$post->{$post_field},
+				"Dummy post field $post_field should be copied from the term"
+			);
+		}
+	}
+
+	/**
+	 * Helper to set up the current request to be a lesson tag archive page. This request
+	 * will be handled by the unsupported theme handler if the theme is not
+	 * supported.
+	 *
+	 * @since 1.12.0
+	 */
+	private function setupLessonTagArchiveRequest() {
+		global $wp_query, $wp_the_query;
+
+		wp_insert_term( 'test1', 'lesson-tag' );
+		$this->term = get_term_by( 'slug', 'test1', 'lesson-tag' );
+
+		$course_lessons = $this->factory->get_course_with_lessons();
+		wp_set_object_terms( $course_lessons['lesson_ids'][0], $this->term->term_id, 'lesson-tag' );
+
+		// Setup $wp_query to be simple post list.
+		$args         = array(
+			'post_type' => 'post',
+		);
+
+		$wp_query = new WP_Query( $args );
+		$wp_the_query = $wp_query;
+
+		$wp_query->is_tax               = 'lesson-tag';
+		$wp_query->queried_object       = $this->term;
+		$wp_query->queried_object_id    = $this->term->term_id;
+	}
+}

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-lesson-tag-archive.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-lesson-tag-archive.php
@@ -38,7 +38,7 @@ class Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive_Test extends WP_UnitTe
 	 *
 	 * @since 1.12.0
 	 */
-	public function testShouldHandleTeacherArchivePage() {
+	public function testShouldHandleLessonTagArchivePage() {
 		$this->assertTrue( $this->handler->can_handle_request() );
 	}
 
@@ -48,7 +48,7 @@ class Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive_Test extends WP_UnitTe
 	 *
 	 * @since 1.12.0
 	 */
-	public function testShouldNotHandleNonTeacherArchivePage() {
+	public function testShouldNotHandleNonLessonTagArchivePage() {
 		// Set up the query to be for the Courses page.
 		global $wp_query;
 		$wp_query = new WP_Query( array(


### PR DESCRIPTION
Partial solution to #2154

Using the same abstract from #2235, this adds the support for the lesson tag archive page in unsupported themes. 

## Testing
- Create course with various lessons associated with various lesson tags.
- Visit the tag archive page for a particular lesson tag (`/lesson-tag/{term-slug}`). 
- Ensure that the page looks right on themes that support Sensei and themes that do not support Sensei.
- For themes that do not support Sensei, ensure that:
  - The title is not duplicated.
  - The pagination does NOT show up at the bottom.