### PR TITLE
Only run tests in multisite for one version of PHP (5.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,12 @@ jobs:
       script:
         - ./tests/bin/run-wp-unit-tests.sh
     - stage: test
+      php: 5.3
+      env: WP_VERSION=latest WP_MULTISITE=1
+      dist: precise
+      script:
+      - ./tests/bin/run-wp-unit-tests.sh
+    - stage: test
       script:
         - npm install
         - npx eslint --config .eslintrc.wpcom.json --ignore-path .eslintignore-wpcom .

--- a/tests/bin/run-wp-unit-tests.sh
+++ b/tests/bin/run-wp-unit-tests.sh
@@ -2,5 +2,4 @@
 
 if [[ ! -z "$WP_VERSION" ]]; then
 	phpunit
-	WP_MULTISITE=1 phpunit
 fi


### PR DESCRIPTION
This should speed up our tests until we add specific checks for multisite installs.