### PR TITLE
Add theme compatibility for the Message archive page

### DIFF
--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -161,6 +161,7 @@ class Sensei_Autoloader {
 			'Sensei_Unsupported_Theme_Handler_Course_Results'     => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-results.php',
 			'Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive' => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php',
 			'Sensei_Unsupported_Theme_Handler_Teacher_Archive'    => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php',
+			'Sensei_Unsupported_Theme_Handler_Message_Archive'    => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-message-archive.php',
 			'Sensei_Unsupported_Theme_Handler_Learner_Profile'    => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-learner-profile.php',
 			'Sensei_Unsupported_Theme_Handler_Course_Archive'     => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php',
 

--- a/includes/class-sensei-unsupported-themes.php
+++ b/includes/class-sensei-unsupported-themes.php
@@ -82,6 +82,7 @@ class Sensei_Unsupported_Themes {
 			new Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive(),
 			new Sensei_Unsupported_Theme_Handler_Teacher_Archive(),
 			new Sensei_Unsupported_Theme_Handler_Learner_Profile(),
+			new Sensei_Unsupported_Theme_Handler_Message_Archive(),
 			new Sensei_Unsupported_Theme_Handler_Course_Archive(),
 		);
 	}

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-message-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-message-archive.php
@@ -62,6 +62,8 @@ class Sensei_Unsupported_Theme_Handler_Message_Archive
 		add_filter( 'sensei_show_main_footer', '__return_false' );
 
 		Sensei_Templates::get_template( 'archive-message.php' );
+		do_action( 'sensei_pagination' );
+
 		$content = ob_get_clean();
 
 		return $content;

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-message-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-message-archive.php
@@ -68,15 +68,13 @@ class Sensei_Unsupported_Theme_Handler_Message_Archive
 	}
 
 	/**
-	 * Prepare the WP query object for the imitated request. The `queried_object` property should
-	 * be the queried author in order for it to show up in the page's `<title>` tag for this author
-	 * query.
+	 * Prepare the WP query object for the imitated request.
 	 *
 	 * @param WP_Query $wp_query
-	 * @param WP_Post  $post_to_copy
+	 * @param object   $object_to_copy
 	 * @param array    $post_params
 	 */
-	protected function prepare_wp_query( $wp_query, $post_to_copy, $post_params ) {
+	protected function prepare_wp_query( $wp_query, $object_to_copy, $post_params ) {
 		global $post;
 		$wp_query->queried_object = $post;
 	}

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-message-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-message-archive.php
@@ -1,0 +1,83 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sensei Unsupported Theme Handler for the Message Archive Page.
+ *
+ * Handles rendering the message archive page for themes that do not declare support for
+ * Sensei.
+ *
+ * @author Automattic
+ *
+ * @since 1.12.0
+ */
+class Sensei_Unsupported_Theme_Handler_Message_Archive
+	extends Sensei_Unsupported_Theme_Handler_Page_Imitator
+	implements Sensei_Unsupported_Theme_Handler_Interface {
+
+	/**
+	 * We can handle this request if it is for a message archive page.
+	 *
+	 * @return bool
+	 */
+	public function can_handle_request() {
+		return is_post_type_archive( 'sensei_message' );
+	}
+
+	/**
+	 * Set up handling for a message archive page.
+	 *
+	 * This is done by manually rendering the content for the page, creating a
+	 * dummy post object, setting its content to the rendered content we generated,
+	 * and then forcing WordPress to render that post.
+	 * Adapted from WooCommerce and bbPress.
+	 *
+	 * @since 1.12.0
+	 */
+	public function handle_request() {
+		global $wp_query;
+
+		/**
+		 * @var WP_Post_Type $post_type Post type object.
+		 */
+		$post_type = $wp_query->get_queried_object();
+
+		// Render the message archive page and output it as a Page.
+		$content = $this->render_page();
+		$this->output_content_as_page( $content, $post_type );
+	}
+
+	/**
+	 * Return the content for the message archive page.
+	 *
+	 * @since 1.12.0
+	 *
+	 * @return string
+	 */
+	private function render_page() {
+		ob_start();
+		add_filter( 'sensei_show_main_header', '__return_false' );
+		add_filter( 'sensei_show_main_footer', '__return_false' );
+
+		Sensei_Templates::get_template( 'archive-message.php' );
+		$content = ob_get_clean();
+
+		return $content;
+	}
+
+	/**
+	 * Prepare the WP query object for the imitated request. The `queried_object` property should
+	 * be the queried author in order for it to show up in the page's `<title>` tag for this author
+	 * query.
+	 *
+	 * @param WP_Query $wp_query
+	 * @param WP_Post  $post_to_copy
+	 * @param array    $post_params
+	 */
+	protected function prepare_wp_query( $wp_query, $post_to_copy, $post_params ) {
+		global $post;
+		$wp_query->queried_object = $post;
+	}
+}

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -141,6 +141,9 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 		if ( $object_to_copy instanceof WP_Post ) {
 			return array_merge( $default_args, $this->generate_post_args_from_post( $object_to_copy ) );
 		}
+		if ( $object_to_copy instanceof WP_Post_Type ) {
+			return array_merge( $default_args, $this->generate_post_args_from_post_type( $object_to_copy ) );
+		}
 
 		return $default_args;
 	}
@@ -191,6 +194,20 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 			'post_modified_gmt' => $post_to_copy->post_modified_gmt,
 			'post_title'        => $post_to_copy->post_title,
 			'post_name'         => $post_to_copy->post_name,
+		);
+	}
+
+
+	/**
+	 * Generate dummy post args from a post type object.
+	 *
+	 * @param WP_Post_Type $post_type_to_copy
+	 * @return array
+	 */
+	private function generate_post_args_from_post_type( $post_type_to_copy ) {
+		return array(
+			'post_title' => $post_type_to_copy->label,
+			'post_name'  => $post_type_to_copy->name,
 		);
 	}
 

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -27,10 +27,10 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 	 * Prepare the WP query object for the imitated request.
 	 *
 	 * @param WP_Query $wp_query
-	 * @param WP_Post  $post_to_copy
-	 * @param array    prepare_wp_query$post_params
+	 * @param object   $object_to_copy
+	 * @param array    $post_params
 	 */
-	protected function prepare_wp_query( $wp_query, $post_to_copy, $post_params ) {
+	protected function prepare_wp_query( $wp_query, $object_to_copy, $post_params ) {
 		// For use in sub-classes.
 	}
 

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
@@ -74,10 +74,10 @@ class Sensei_Unsupported_Theme_Handler_Teacher_Archive
 	 * query.
 	 *
 	 * @param WP_Query $wp_query
-	 * @param WP_Post  $post_to_copy
+	 * @param object   $object_to_copy
 	 * @param array    $post_params
 	 */
-	protected function prepare_wp_query( $wp_query, $post_to_copy, $post_params ) {
+	protected function prepare_wp_query( $wp_query, $object_to_copy, $post_params ) {
 		$wp_query->queried_object    = $this->author;
 		$wp_query->queried_object_id = $this->author->ID;
 	}

--- a/tests/framework/factories/class-sensei-factory.php
+++ b/tests/framework/factories/class-sensei-factory.php
@@ -75,6 +75,11 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 	public $question_category;
 
 	/**
+	 * @var WP_UnitTest_Factory_For_Message
+	 */
+	public $message;
+
+	/**
 	 * constructor function
 	 *
 	 * This sets up some basic demo data
@@ -87,6 +92,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-multiple-question.php';
 		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-lesson.php';
 		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-module.php';
+		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-message.php';
 		require_once dirname( __FILE__ ) . '/class-wp-unittest-factory-for-question-category.php';
 
 		$this->course            = new WP_UnitTest_Factory_For_Course( $this );
@@ -95,6 +101,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 		$this->question          = new WP_UnitTest_Factory_For_Question( $this );
 		$this->multiple_question = new WP_UnitTest_Factory_For_Multiple_Question( $this );
 		$this->module            = new WP_UnitTest_Factory_For_Module( $this );
+		$this->message           = new WP_UnitTest_Factory_For_Message( $this );
 		$this->question_category = new WP_UnitTest_Factory_For_Question_Category( $this );
 	}// end construct
 

--- a/tests/framework/factories/class-wp-unittest-factory-for-message.php
+++ b/tests/framework/factories/class-wp-unittest-factory-for-message.php
@@ -1,0 +1,13 @@
+<?php
+
+class WP_UnitTest_Factory_For_Message extends WP_UnitTest_Factory_For_Post_Sensei {
+	function __construct( $factory = null ) {
+		parent::__construct( $factory );
+		$this->default_generation_definitions = array(
+			'post_status'  => 'publish',
+			'post_title'   => new WP_UnitTest_Generator_Sequence( 'Message title %s' ),
+			'post_content' => new WP_UnitTest_Generator_Sequence( 'Message content %s' ),
+			'post_type'    => 'sensei_message',
+		);
+	}
+}

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-message-archive.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-message-archive.php
@@ -1,0 +1,150 @@
+<?php
+
+include_once 'test-class-sensei-unsupported-theme-handler-page-imitator.php';
+
+class Sensei_Unsupported_Theme_Handler_Message_Archive_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var Sensei_Unsupported_Theme_Handler_Message_Archive_Test The request handler to test.
+	 */
+	private $handler;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+		$this->setupMessageArchiveRequest();
+
+		Sensei_Unsupported_Theme_Handler_Page_Imitator_Test::create_page_template();
+
+		$this->handler = new Sensei_Unsupported_Theme_Handler_Message_Archive();
+	}
+
+	public function tearDown() {
+		$this->handler = null;
+
+		Sensei_Unsupported_Theme_Handler_Page_Imitator_Test::delete_page_template();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Message_Archive handles the message archive page.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldHandleMessageArchivePage() {
+		$this->assertTrue( $this->handler->can_handle_request() );
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Message_Archive does not handle a
+	 * non-message archive page.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldNotHandleNonMessageArchivePage() {
+		// Set up the query to be for the Courses page.
+		global $wp_query;
+		$wp_query = new WP_Query( array(
+			'post_type' => 'post',
+		) );
+
+		$this->assertFalse( $this->handler->can_handle_request() );
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Message_Archive disables the header and
+	 * footer when rendering the message archive page.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldDisableHeaderAndFooter() {
+		$this->assertFalse( has_filter( 'sensei_show_main_header', '__return_false' ), 'Header should initially be enabled' );
+		$this->assertFalse( has_filter( 'sensei_show_main_footer', '__return_false' ), 'Footer should initially be enabled' );
+
+		$this->handler->handle_request();
+
+		$this->assertNotFalse( has_filter( 'sensei_show_main_header', '__return_false' ), 'Header should be disabled by handler' );
+		$this->assertNotFalse( has_filter( 'sensei_show_main_footer', '__return_false' ), 'Footer should be disabled by handler' );
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Message_Archive renders the message archive page using
+	 * the archive-message.php template.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldUseMessageArchiveTemplate() {
+		// We'll test to ensure it uses the template by checking if the
+		// sensei_archive_before_message_loop action was run.
+		$this->assertEquals(
+			0,
+			did_action( 'sensei_archive_before_message_loop' ),
+			'Should not have already done action sensei_archive_before_message_loop'
+		);
+
+		$this->handler->handle_request();
+
+		$this->assertEquals(
+			1,
+			did_action( 'sensei_archive_before_message_loop' ),
+			'Should have done action sensei_archive_before_message_loop'
+		);
+	}
+
+	/**
+	 * Ensure Sensei_Unsupported_Theme_Handler_Message_Archive sets up a dummy post for
+	 * the final render of the message archive content.
+	 *
+	 * @since 1.12.0
+	 */
+	public function testShouldSetupDummyPost() {
+		global $post;
+
+		$this->handler->handle_request();
+
+		$this->assertEquals( 0, $post->ID, 'The dummy post ID should be 0' );
+		$this->assertEquals( 'page', $post->post_type, 'The dummy post type should be "page"' );
+
+		$post_type = get_post_type_object( 'sensei_message' );
+
+		$copied_from_post_type = array(
+			'post_title' => 'label',
+		);
+
+		foreach ( $copied_from_post_type as $post_field => $post_type_field ) {
+			$this->assertEquals(
+				$post_type->{$post_type_field},
+				$post->{$post_field},
+				"Dummy post field $post_field should be copied from the term"
+			);
+		}
+	}
+
+	/**
+	 * Helper to set up the current request to be a message archive page. This request
+	 * will be handled by the unsupported theme handler if the theme is not
+	 * supported.
+	 *
+	 * @since 1.12.0
+	 */
+	private function setupMessageArchiveRequest() {
+		global $wp_query, $wp_the_query;
+
+		$this->factory->message->create_many( 2 );
+
+		// Setup $wp_query to be simple post list.
+		$args = array(
+			'post_type' => 'sensei_message',
+		);
+
+		$wp_query     = new WP_Query( $args );
+		$wp_the_query = $wp_query;
+
+		$wp_query->is_post_type_archive    = 'sensei_message';
+		$wp_query->queried_object          = get_post_type_object( 'sensei_message' );
+		$wp_query->queried_object_id       = '';
+		$wp_query->query_vars['post_type'] = 'sensei_message';
+	}
+}


### PR DESCRIPTION
Partial solution to #2154

Adds theme compatibility for the Message archive page.

In addition to that, it also:
- Adds a test factory for messages.
- In line with #2239, I've updated the signature for the `prepare_wp_query` for the parent class and where appropriate on child classes.

## Testing

- Send multiple messages from a learner to a teacher from a course page.
- View the message archive page (`/messages`) and make sure it looks fine on unsupported themes.