### PR TITLE
Add Sensei pagination to Lesson Archive page for unsupported themes

### DIFF
--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php
@@ -68,6 +68,7 @@ class Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive
 		} else {
 			Sensei_Templates::get_template( 'archive-lesson.php' );
 		}
+		remove_action( 'sensei_pagination', array( 'Sensei_Lesson', 'output_comments' ), 90 );
 		do_action( 'sensei_pagination' );
 		$content = ob_get_clean();
 

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php
@@ -68,6 +68,7 @@ class Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive
 		} else {
 			Sensei_Templates::get_template( 'archive-lesson.php' );
 		}
+		do_action( 'sensei_pagination' );
 		$content = ob_get_clean();
 
 		return $content;


### PR DESCRIPTION
When many lessons are displayed on the archive page for an unsupported theme, the pagination was not showing up.

See https://github.com/Automattic/sensei/pull/2243#issuecomment-422803116 and https://github.com/Automattic/sensei/pull/2243#issuecomment-422958692 for a similar issue on the Course Archive page.

To test, add a tag to several lessons and visit `/lesson-tag/<tag-name>`.