### PR TITLE
Add Sensei pagination to Teacher Archive page for unsupported themes

### DIFF
--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
@@ -63,6 +63,7 @@ class Sensei_Unsupported_Theme_Handler_Teacher_Archive
 		add_filter( 'sensei_show_main_header', '__return_false' );
 		add_filter( 'sensei_show_main_footer', '__return_false' );
 		Sensei_Templates::get_template( 'teacher-archive.php' );
+		do_action( 'sensei_pagination' );
 		$content = ob_get_clean();
 
 		return $content;


### PR DESCRIPTION
When many courses are displayed on the teacher archive page for an unsupported theme, the pagination was not showing up.

See https://github.com/Automattic/sensei/pull/2243#issuecomment-422803116 and https://github.com/Automattic/sensei/pull/2243#issuecomment-422958692 for a similar issue on the Course Archive page.

To test, add several courses for a user with role Teacher and visit `/author/<username>`.