### PR TITLE
Fix email template rendering issue

### DIFF
--- a/includes/class-sensei-emails.php
+++ b/includes/class-sensei-emails.php
@@ -215,6 +215,7 @@ class Sensei_Emails {
 		include( $template );
 		do_action( 'sensei_after_email_template', $email_template );
 
+		$email_template = '';
 		return ob_get_clean();
 	}
 

--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -140,12 +140,6 @@ class Sensei_Templates {
 
         global $wp_query, $email_template;
 
-		// If our unsupported theme renderer is handling the request, we do not
-		// need to find a custom template.
-		if ( Sensei_Unsupported_Themes::get_instance()->is_handling_request() ) {
-			return $template;
-		}
-
         $find = array( 'woothemes-sensei.php' );
         $file = '';
 
@@ -154,6 +148,14 @@ class Sensei_Templates {
             $file 	= 'emails/' . $email_template;
             $find[] = $file;
             $find[] = Sensei()->template_url . $file;
+
+		} elseif ( Sensei_Unsupported_Themes::get_instance()->is_handling_request() ) {
+
+			/*
+			* If our unsupported theme renderer is handling the request, we do
+			* not need to find a custom template.
+			*/
+			$file = null;
 
         } elseif ( is_single() && get_post_type() == 'course' ) {
 

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-page-imitator.php
@@ -156,9 +156,8 @@ class Sensei_Unsupported_Theme_Handler_Page_Imitator_Test extends WP_UnitTestCas
 		$this->course = $this->factory->course->create_and_get();
 		$this->factory->post->create_many( 2 );
 
-		// Setup $wp_query to be for the lessons in Module 2.
 		$args         = array(
-			'post_type' => 'post',
+			'post_type' => 'course',
 		);
 		$wp_query     = new WP_Query( $args );
 		$wp_the_query = $wp_query;


### PR DESCRIPTION
Fixes #2255 

The problem was that when [this action](https://github.com/Automattic/sensei/pull/2217/files#diff-40321a87591949b1299da640ddd3f211R68) was set to fire earlier in #2217, the global `$email_template` variable was set earlier (in [this code](https://github.com/Automattic/sensei/blob/e89536cb3a4dc451ac347add0eb2992c018b1350/includes/class-sensei-emails.php#L209)) but was never reset. This caused the handling [here](https://github.com/Automattic/sensei/blob/e89536cb3a4dc451ac347add0eb2992c018b1350/includes/class-sensei-templates.php#L152) to always use an email template for subsequent calls, causing the template to be rendered on the front-end.

This PR resets the `$email_template` variable, and also future-proofs the template handler in case the email is ever rendered later (there was a separate issue here that would have caused late-rendered emails to render incorrectly on unsupported themes).

Kudos to @jom for his help in getting to the root of this one! 👏 