### PR TITLE
Fix: PHPCS improvements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"require-dev": {
 		"apigen/apigen": "*",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
-		"phpcompatibility/php-compatibility": "*",
+		"phpcompatibility/phpcompatibility-wp": "^1",
 		"phpunit/phpunit": "^6.5",
 		"squizlabs/php_codesniffer": "3.*",
 		"wp-coding-standards/wpcs": "^0.14.0"

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
 		"phpcompatibility/phpcompatibility-wp": "^1",
 		"phpunit/phpunit": "^6.5",
 		"squizlabs/php_codesniffer": "^3.3",
-		"wp-coding-standards/wpcs": "^0.14.0"
+		"wp-coding-standards/wpcs": "^1.1.0"
 	},
 	"prefer-stable": true
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
 		"phpcompatibility/phpcompatibility-wp": "^1",
 		"phpunit/phpunit": "^6.5",
-		"squizlabs/php_codesniffer": "3.*",
+		"squizlabs/php_codesniffer": "^3.3",
 		"wp-coding-standards/wpcs": "^0.14.0"
 	},
 	"prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
 	"name": "woothemes-sensei",
 	"description": "A learning management plugin for WordPress, which provides the smoothest platform for helping you teach anything.",
 	"require-dev": {
+		"php": "^5.4 || ^7",
 		"apigen/apigen": "*",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
 		"phpcompatibility/phpcompatibility-wp": "^1",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -28,4 +28,12 @@
 		</properties>
 	</rule>
 
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element name="woothemes-sensei"/>
+			</property>
+		</properties>
+	</rule>
+
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -19,4 +19,13 @@
 	<rule ref="WordPress-Extra"/>
 	<rule ref="WordPress-Docs"/>
 
+	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+		<properties>
+			<property name="prefixes" type="array">
+				<element name="sensei"/>
+				<element name="woothemes"/>
+			</property>
+		</properties>
+	</rule>
+
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -16,7 +16,7 @@
 
 	<!-- Rules -->
 	<rule ref="PHPCompatibilityWP"/>
-	<rule ref="WordPress">
-		<exclude name="WordPress.VIP" />
-	</rule>
+	<rule ref="WordPress-Extra"/>
+	<rule ref="WordPress-Docs"/>
+
 </ruleset>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,7 +15,7 @@
 	<config name="testVersion" value="5.2-"/>
 
 	<!-- Rules -->
-	<rule ref="PHPCompatibility" />
+	<rule ref="PHPCompatibilityWP"/>
 	<rule ref="WordPress">
 		<exclude name="WordPress.VIP" />
 	</rule>

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,23 +1,38 @@
 <?xml version="1.0"?>
 <ruleset name="Sensei">
-	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
-	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
+	<description>A custom set of code standard rules to check for Sensei plugin.</description>
 
-	<!-- Set a description for this ruleset. -->
-	<description>A custom set of code standard rules to check for WordPress themes and plugins.</description>
+	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- For help in using PHPCS: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Usage -->
 
-	<exclude-pattern>apigen/</exclude-pattern>
-	<exclude-pattern>*/node_modules/*</exclude-pattern>
-	<exclude-pattern>*/vendor/*</exclude-pattern>
+	<!-- What to scan -->
+	<file>.</file>
+	<!-- Ignoring Files and Folders:
+		https://github.com/squizlabs/PHP_CodeSniffer/wiki/Advanced-Usage#ignoring-files-and-folders -->
+	<exclude-pattern>./apigen/</exclude-pattern>
+	<exclude-pattern>./node_modules/</exclude-pattern>
+	<exclude-pattern>./vendor/</exclude-pattern>
 
-	<config name="minimum_supported_wp_version" value="4.7" />
-	<!-- Check for cross-version support for PHP 5.2 and higher. -->
+	<!-- How to scan -->
+	<arg value="sp"/> <!-- Show sniff and progress -->
+	<arg name="basepath" value="."/> <!-- Strip the file paths down to the relevant bit -->
+	<arg name="parallel" value="50"/> <!-- Enables parallel processing when available for faster results. -->
+	<arg name="extensions" value="php"/> <!-- Limit to PHP files -->
+
+	<!-- Rules: Check PHP version compatibility - see
+		https://github.com/PHPCompatibility/PHPCompatibilityWP -->
+	<rule ref="PHPCompatibilityWP"/>
+	<!-- For help in understanding this testVersion:
+		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
 	<config name="testVersion" value="5.2-"/>
 
-	<!-- Rules -->
-	<rule ref="PHPCompatibilityWP"/>
-	<rule ref="WordPress-Extra"/>
+	<!-- Rules: WordPress Coding Standards - see
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->
+	<rule ref="WordPress-Extra"/><!-- Includes WordPress-Core -->
 	<rule ref="WordPress-Docs"/>
+	<!-- For help in understanding these custom sniff properties:
+		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/wiki/Customizable-sniff-properties -->
+	<config name="minimum_supported_wp_version" value="4.7"/>
 
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>


### PR DESCRIPTION
Fixes #2262.

Note that this improves the PHPCS setup, not the actual violations. Due to the change to WPCS 1.1, and the addition of text domain and prefix checks, it's likely that the number of violations will actually have gone up - best to consider that the violations were being under-reported before.

See individual commits for more information.