### PR TITLE
Fix theme compatibility issues for Message comments

### DIFF
--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -156,6 +156,7 @@ class Sensei_Autoloader {
 			 */
 			'Sensei_Unsupported_Theme_Handler_Interface'          => 'unsupported-theme-handlers/interface-sensei-unsupported-theme-handler.php',
 			'Sensei_Unsupported_Theme_Handler_Page_Imitator'      => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php',
+			'Sensei_Unsupported_Theme_Handler_Utils'              => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-utils.php',
 			'Sensei_Unsupported_Theme_Handler_CPT'                => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php',
 			'Sensei_Unsupported_Theme_Handler_Module'             => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-module.php',
 			'Sensei_Unsupported_Theme_Handler_Course_Results'     => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-results.php',

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4008,7 +4008,7 @@ class Sensei_Lesson {
 		$lesson_allow_comments = $allow_comments && ( $user_taking_course || $has_access || $is_preview );
 
 		if ( $lesson_allow_comments || is_singular( 'sensei_message' ) ) {
-			comments_template();
+			comments_template( '', true );
 		}
 	}
 

--- a/includes/class-sensei-unsupported-themes.php
+++ b/includes/class-sensei-unsupported-themes.php
@@ -78,7 +78,7 @@ class Sensei_Unsupported_Themes {
 			new Sensei_Unsupported_Theme_Handler_CPT( 'course' ),
 			new Sensei_Unsupported_Theme_Handler_CPT( 'lesson' ),
 			new Sensei_Unsupported_Theme_Handler_CPT( 'sensei_message', array(
-				'show_pagination'   => false,
+				'show_pagination'   => true,
 				'template_filename' => 'single-message.php',
 			) ),
 			new Sensei_Unsupported_Theme_Handler_CPT( 'quiz' ),

--- a/includes/renderers/class-sensei-renderer-single-post.php
+++ b/includes/renderers/class-sensei-renderer-single-post.php
@@ -93,19 +93,21 @@ class Sensei_Renderer_Single_Post implements Sensei_Renderer_Interface {
 		// Capture output.
 		ob_start();
 
-		// Render the template, and pagination if needed.
+		// Render the template.
 		Sensei_Templates::get_template( $this->template );
+
+		// Reset all filters.
+		remove_filter( 'sensei_show_main_footer', '__return_false' );
+		remove_filter( 'sensei_show_main_header', '__return_false' );
+		remove_filter( 'the_title', array( $this, 'hide_the_title' ), 100 );
+
+		// Render pagination if needed.
 		if ( $this->show_pagination ) {
 			do_action( 'sensei_pagination' );
 		}
 		$output = ob_get_clean();
 
 		$this->reset_global_vars();
-
-		// Reset all filters.
-		remove_filter( 'sensei_show_main_footer', '__return_false' );
-		remove_filter( 'sensei_show_main_header', '__return_false' );
-		remove_filter( 'the_title', array( $this, 'hide_the_title' ), 100 );
 
 		return $output;
 	}

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php
@@ -52,6 +52,9 @@ class Sensei_Unsupported_Theme_Handler_Course_Archive
 				'post_title' => __( 'Courses', 'woothemes-sensei' ),
 			) );
 		}
+
+		// Disable pagination.
+		Sensei_Unsupported_Theme_Handler_Utils::disable_theme_pagination();
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-results.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-results.php
@@ -51,6 +51,9 @@ class Sensei_Unsupported_Theme_Handler_Course_Results
 		$this->output_content_as_page( $content, $course, array(
 			'post_title' => sanitize_text_field( $course->post_title ),
 		) );
+
+		// Disable pagination.
+		Sensei_Unsupported_Theme_Handler_Utils::disable_theme_pagination();
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -92,10 +92,6 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 
 			// Do not display comments through the theme.
 			$this->disable_comments();
-
-			// Do not display any pagination.
-			add_filter( 'previous_post_link', '__return_false' );
-			add_filter( 'next_post_link', '__return_false' );
 		}
 	}
 
@@ -143,6 +139,9 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 
 		// Disable comments again.
 		$this->disable_comments();
+
+		// Disable pagination.
+		Sensei_Unsupported_Theme_Handler_Utils::disable_theme_pagination();
 
 		return $content;
 	}

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Unsupported Theme Handler for CPT's.
+ *
+ * @package Core
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -16,17 +22,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_Handler_Interface {
 
 	/**
-	 * @var int The post ID.
+	 * The post ID.
+	 *
+	 * @var int $post_id
 	 */
 	protected $post_id;
 
 	/**
-	 * @var string The post type to render.
+	 * The post type to render.
+	 *
+	 * @var string $post_type
 	 */
 	protected $post_type;
 
 	/**
-	 * @var array Additional options.
+	 * Additional options.
+	 *
+	 * @var array $options
 	 */
 	protected $options;
 
@@ -35,8 +47,8 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 	 *
 	 * @param string $post_type The post type to render.
 	 * @param array  $options   An array of options. Currently supports:
-	 *                            bool   show_pagination
-	 *                            string template_filename
+	 *                            bool   show_pagination   Whether to show pagination.
+	 *                            string template_filename The template file to use for rendering.
 	 */
 	public function __construct( $post_type, $options = array() ) {
 		$this->post_type = $post_type;
@@ -65,7 +77,7 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 
 		// Handle some type-specific items.
 		if ( 'lesson' === $this->post_type ) {
-			// Use theme comments UI instead of Sensei's
+			// Use theme comments UI instead of Sensei's.
 			remove_action( 'sensei_pagination', array( 'Sensei_Lesson', 'output_comments' ), 90 );
 
 			// Turn off theme comments if needed.
@@ -131,6 +143,14 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		return $content;
 	}
 
+	/**
+	 * Get an option from the $options array, or the default value if that
+	 * option was not set.
+	 *
+	 * @param string $name    The option name.
+	 * @param string $default The default option value. If not specified, this
+	 *                        will be null.
+	 */
 	protected function get_option( $name, $default = null ) {
 		return isset( $this->options[ $name ] ) ? $this->options[ $name ] : $default;
 	}
@@ -205,6 +225,12 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		return $title;
 	}
 
+	/**
+	 * Filter to return the page.php template of the theme if possible.
+	 *
+	 * @param  string $template The original template to be used.
+	 * @return string The page.php template if possible, the original template * otherwise.
+	 */
 	public function force_page_template( $template ) {
 		$path = get_query_template( 'page' );
 

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -70,15 +70,33 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 
 			// Turn off theme comments if needed.
 			if ( ! Sensei()->settings->get( 'lesson_comments' ) ) {
-				add_filter( 'comments_open', '__return_false', 100 );
-				add_filter( 'get_comments_number', '__return_false', 100 );
+				$this->disable_comments();
 			}
 		}
 
 		if ( 'sensei_message' === $this->post_type ) {
 			// Do not display the Message title.
 			add_filter( 'the_title', array( $this, 'hide_the_title' ), 20, 2 );
+
+			// Do not display comments through the theme.
+			$this->disable_comments();
 		}
+	}
+
+	/**
+	 * Disable rendering of comments.
+	 */
+	public function disable_comments() {
+		add_filter( 'comments_open', '__return_false', 100 );
+		add_filter( 'get_comments_number', '__return_false', 100 );
+	}
+
+	/**
+	 * If we have previously disabled comments, re-enable them.
+	 */
+	public function reenable_comments() {
+		remove_filter( 'comments_open', '__return_false', 100 );
+		remove_filter( 'get_comments_number', '__return_false', 100 );
 	}
 
 	/**
@@ -98,8 +116,14 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		// Remove the filter we're in to avoid nested calls.
 		remove_filter( 'the_content', array( $this, 'cpt_page_content_filter' ) );
 
+		// Temporarily re-enable comments.
+		$this->reenable_comments();
+
 		$renderer = $this->get_renderer();
 		$content  = $renderer->render();
+
+		// Disable comments again.
+		$this->disable_comments();
 
 		return $content;
 	}

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -92,6 +92,10 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 
 			// Do not display comments through the theme.
 			$this->disable_comments();
+
+			// Do not display any pagination.
+			add_filter( 'previous_post_link', '__return_false' );
+			add_filter( 'next_post_link', '__return_false' );
 		}
 	}
 

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -75,8 +75,8 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		}
 
 		if ( 'sensei_message' === $this->post_type ) {
-			// Do not display the Message title.
-			add_filter( 'the_title', array( $this, 'hide_the_title' ), 20, 2 );
+			// Hide the message title until `the_content` is displayed.
+			$this->add_filter_hide_the_title();
 
 			// Do not display comments through the theme.
 			$this->disable_comments();
@@ -115,6 +115,9 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 
 		// Remove the filter we're in to avoid nested calls.
 		remove_filter( 'the_content', array( $this, 'cpt_page_content_filter' ) );
+
+		// Remove the filter to hide the title (if needed).
+		$this->remove_filter_hide_the_title();
 
 		// Temporarily re-enable comments.
 		$this->reenable_comments();
@@ -171,6 +174,20 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 	 */
 	protected function get_template_filename() {
 		return $this->get_option( 'template_filename', "single-{$this->post_type}.php" );
+	}
+
+	/**
+	 * Add a filter to hide the post title.
+	 */
+	public function add_filter_hide_the_title() {
+		add_filter( 'the_title', array( $this, 'hide_the_title' ), 20, 2 );
+	}
+
+	/**
+	 * Remove the filter to hide the post title.
+	 */
+	public function remove_filter_hide_the_title() {
+		remove_filter( 'the_title', array( $this, 'hide_the_title' ), 20, 2 );
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-learner-profile.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-learner-profile.php
@@ -51,6 +51,9 @@ class Sensei_Unsupported_Theme_Handler_Learner_Profile
 		// Render the learner profile page and output it as a Page.
 		$content = $this->render_page();
 		$this->output_content_as_page( $content, $learner_user );
+
+		// Disable pagination.
+		Sensei_Unsupported_Theme_Handler_Utils::disable_theme_pagination();
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php
@@ -47,6 +47,9 @@ class Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive
 		// Render the lesson tag archive page and output it as a Page.
 		$content = $this->render_page();
 		$this->output_content_as_page( $content, $term );
+
+		// Disable pagination.
+		Sensei_Unsupported_Theme_Handler_Utils::disable_theme_pagination();
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-message-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-message-archive.php
@@ -47,6 +47,10 @@ class Sensei_Unsupported_Theme_Handler_Message_Archive
 		// Render the message archive page and output it as a Page.
 		$content = $this->render_page();
 		$this->output_content_as_page( $content, $post_type );
+
+		// Do not display any pagination from the theme.
+		add_filter( 'previous_post_link', '__return_false' );
+		add_filter( 'next_post_link', '__return_false' );
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-message-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-message-archive.php
@@ -48,9 +48,8 @@ class Sensei_Unsupported_Theme_Handler_Message_Archive
 		$content = $this->render_page();
 		$this->output_content_as_page( $content, $post_type );
 
-		// Do not display any pagination from the theme.
-		add_filter( 'previous_post_link', '__return_false' );
-		add_filter( 'next_post_link', '__return_false' );
+		// Disable pagination.
+		Sensei_Unsupported_Theme_Handler_Utils::disable_theme_pagination();
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-module.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-module.php
@@ -51,6 +51,9 @@ class Sensei_Unsupported_Theme_Handler_Module
 			'post_title' => sanitize_text_field( $module->name ),
 			'post_name'  => $module->slug,
 		) );
+
+		// Disable pagination.
+		Sensei_Unsupported_Theme_Handler_Utils::disable_theme_pagination();
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php
@@ -49,6 +49,9 @@ class Sensei_Unsupported_Theme_Handler_Teacher_Archive
 		// Render the teacher archive page and output it as a Page.
 		$content = $this->render_page();
 		$this->output_content_as_page( $content, $this->author );
+
+		// Disable pagination.
+		Sensei_Unsupported_Theme_Handler_Utils::disable_theme_pagination();
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-utils.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-utils.php
@@ -1,0 +1,25 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sensei utility class for unsupported theme handling.
+ *
+ * Provides common functions needed for unsupported theme handlers.
+ *
+ * @author Automattic
+ *
+ * @since 1.12.0
+ */
+class Sensei_Unsupported_Theme_Handler_Utils {
+
+	/**
+	 * Turn off pagination in the theme.
+	 */
+	public static function disable_theme_pagination() {
+		add_filter( 'previous_post_link', '__return_false' );
+		add_filter( 'next_post_link', '__return_false' );
+	}
+
+}


### PR DESCRIPTION
This PR fixes two issues that were found on the Message page on unsupported themes:

- The Message comments UI was not being displayed for some themes (e.g. Divi). This prevented commenting on Message threads.

- In some themes (Sydney, Astra) the comments section header included the title of the message. The issue was that the title was blank (`Two Comments on ""`).

## Testing

- Visit the Message page on several themes (`/messages/<message_slug>`). Ensure that you can see the message comments and add a new comment.

- If the theme displays the title in the comment section header, ensure that it displays properly.

- In https://github.com/Automattic/sensei/commit/5fbfc0b4ddb88e809f11ee3e904beb03558ea4f3 there is a change that potentially touches comments across all of Sensei. It should not have any effect on rendering, but we should test comments on some supported themes and ensure that nothing bad has happened.