### PR TITLE
Fix i18n violations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
 		"phpcompatibility/phpcompatibility-wp": "^2",
 		"phpunit/phpunit": "^6.5",
-		"squizlabs/php_codesniffer": "^3.3",
+		"squizlabs/php_codesniffer": "^3.3.2",
 		"wp-coding-standards/wpcs": "^1.1.0"
 	},
 	"prefer-stable": true

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -535,7 +535,7 @@ class Sensei_Learner_Management {
 			die();
 		}
 
-		$default = isset( $_GET['default'] ) ? $_GET['default'] : __( 'None', 'woocommerce' );
+		$default = isset( $_GET['default'] ) ? $_GET['default'] : __( 'None', 'woothemes-sensei' );
 
 		$found_users = array( '' => $default );
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1894,11 +1894,11 @@ class Sensei_Frontend {
 		// Check the username.
 		$username_error_notice = '';
 		if ( $new_user_name == '' ) {
-			$username_error_notice = __( '<strong>ERROR</strong>: Please enter a username.' );
+			$username_error_notice = __( '<strong>ERROR</strong>: Please enter a username.', 'woothemes-sensei' );
 		} elseif ( ! validate_username( $new_user_name ) ) {
-			$username_error_notice = __( '<strong>ERROR</strong>: This username is invalid because it uses illegal characters. Please enter a valid username.' );
+			$username_error_notice = __( '<strong>ERROR</strong>: This username is invalid because it uses illegal characters. Please enter a valid username.', 'woothemes-sensei' );
 		} elseif ( username_exists( $new_user_name ) ) {
-			$username_error_notice = __( '<strong>ERROR</strong>: This username is already registered. Please choose another one.' );
+			$username_error_notice = __( '<strong>ERROR</strong>: This username is already registered. Please choose another one.', 'woothemes-sensei' );
 		}
 
 		// exit on username error.
@@ -1910,11 +1910,11 @@ class Sensei_Frontend {
 		// Check the e-mail address.
 		$email_error_notice = '';
 		if ( $new_user_email == '' ) {
-			$email_error_notice = __( '<strong>ERROR</strong>: Please enter an email address.' );
+			$email_error_notice = __( '<strong>ERROR</strong>: Please enter an email address.', 'woothemes-sensei' );
 		} elseif ( ! is_email( $new_user_email ) ) {
-			$email_error_notice = __( '<strong>ERROR</strong>: The email address isn&#8217;t correct.' );
+			$email_error_notice = __( '<strong>ERROR</strong>: The email address isn&#8217;t correct.', 'woothemes-sensei' );
 		} elseif ( email_exists( $new_user_email ) ) {
-			$email_error_notice = __( '<strong>ERROR</strong>: This email is already registered, please choose another one.' );
+			$email_error_notice = __( '<strong>ERROR</strong>: This email is already registered, please choose another one.', 'woothemes-sensei' );
 		}
 
 		// exit on email address error.
@@ -1926,7 +1926,7 @@ class Sensei_Frontend {
 		// check user password
 		// exit on email address error.
 		if ( empty( $new_user_password ) ) {
-			Sensei()->notices->add_notice( __( '<strong>ERROR</strong>: The password field is empty.' ), 'alert' );
+			Sensei()->notices->add_notice( __( '<strong>ERROR</strong>: The password field is empty.', 'woothemes-sensei' ), 'alert' );
 			return;
 		}
 
@@ -1934,7 +1934,7 @@ class Sensei_Frontend {
 		$user_id = wp_create_user( $new_user_name, $new_user_password, $new_user_email );
 		if ( ! $user_id || is_wp_error( $user_id ) ) {
 			// translators: Placeholder is the admin email address.
-			Sensei()->notices->add_notice( sprintf( __( '<strong>ERROR</strong>: Couldn&#8217;t register you&hellip; please contact the <a href="mailto:%s">webmaster</a> !' ), get_option( 'admin_email' ) ), 'alert' );
+			Sensei()->notices->add_notice( sprintf( __( '<strong>ERROR</strong>: Couldn&#8217;t register you&hellip; please contact the <a href="mailto:%s">webmaster</a> !', 'woothemes-sensei' ), get_option( 'admin_email' ) ), 'alert' );
 		}
 
 		// Notify the Admin and not the user. See https://github.com/Automattic/sensei/issues/1761.

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -257,7 +257,7 @@ class Sensei_Grading_User_Quiz {
 				<span class="total_grade_total"><?php echo $user_quiz_grade_total; ?></span> / <span class="quiz_grade_total"><?php echo $quiz_grade_total; ?></span> (<span class="total_grade_percent"><?php echo $quiz_grade; ?></span>%)
 			</div>
 			<div class="buttons">
-				<input type="submit" value="<?php esc_attr_e( 'Save' ); ?>" class="grade-button button-primary" title="Saves grades as currently marked on this page" />
+				<input type="submit" value="<?php esc_attr_e( 'Save', 'woothemes-sensei' ); ?>" class="grade-button button-primary" title="Saves grades as currently marked on this page" />
 				<input type="button" value="<?php esc_attr_e( 'Auto grade', 'woothemes-sensei' ); ?>" class="autograde-button button-secondary" title="Where possible, automatically grades questions that have not yet been graded" />
 				<input type="reset" value="<?php esc_attr_e( 'Reset', 'woothemes-sensei' ); ?>" class="reset-button button-secondary" title="Resets all questions to ungraded and total grade to 0" />
 			</div>

--- a/includes/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/class-sensei-learners-admin-bulk-actions-view.php
@@ -108,7 +108,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends WooThemes_Sensei_List_Tabl
         $login = esc_html( $learner->user_login );
         $title = esc_html( Sensei_Learner::get_full_name( $learner->user_id ) );
 		// translators: Placeholder %s is the learner's full name.
-        $a_title = sprintf( __( 'Edit &#8220;%s&#8221;' ), $title );
+        $a_title = sprintf( __( 'Edit &#8220;%s&#8221;', 'woothemes-sensei' ), $title );
         $html = '<strong><a class="row-title" href="' . admin_url( 'user-edit.php?user_id=' . $learner->user_id ) . '" title="' . esc_attr( $a_title ) . '">' . esc_html( $login ) . '</a></strong>';
         $html .= ' <span>(<em>' . $title . '</em>, ' . esc_html( $learner->user_email ) . ')</span>';
         return $html;

--- a/includes/class-sensei-learners-main.php
+++ b/includes/class-sensei-learners-main.php
@@ -265,7 +265,7 @@ class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 
                 $title = Sensei_Learner::get_full_name( $user_activity->user_id );
 				// translators: Placeholder is the full name of the learner.
-				$a_title = sprintf( __( 'Edit &#8220;%s&#8221;' ), $title );
+				$a_title = sprintf( __( 'Edit &#8220;%s&#8221;', 'woothemes-sensei' ), $title );
 				$edit_start_date_form = $this->get_edit_start_date_form( $user_activity, $post_id, $post_type, $object_type );
 
                 /**
@@ -297,7 +297,7 @@ class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 				$lesson_learners = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_learners_lesson_learners', array( 'post_id' => $item->ID, 'type' => 'sensei_lesson_status', 'status' => 'any' ) ) );
 				$title = get_the_title( $item );
 				// translators: Placeholder is the item title.
-				$a_title = sprintf( __( 'Edit &#8220;%s&#8221;' ), $title );
+				$a_title = sprintf( __( 'Edit &#8220;%s&#8221;', 'woothemes-sensei' ), $title );
 
 				$grading_action = '';
 				if ( Sensei_Lesson::lesson_quiz_has_questions( $item->ID ) ) {
@@ -317,7 +317,7 @@ class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
                 $course_learners = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_learners_course_learners', array( 'post_id' => $item->ID, 'type' => 'sensei_course_status', 'status' => 'any' ) ) );
 				$title = get_the_title( $item );
 				// translators: Placeholder is the item title.
-				$a_title = sprintf( __( 'Edit &#8220;%s&#8221;' ), $title );
+				$a_title = sprintf( __( 'Edit &#8220;%s&#8221;', 'woothemes-sensei' ), $title );
 
 				$grading_action = '';
 				if ( version_compare($wp_version, '4.1', '>=') ) {

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1816,7 +1816,7 @@ class Sensei_Core_Modules
 		<div id="taxonomy-<?php echo $tax_name; ?>" class="categorydiv">
 			<ul id="<?php echo $tax_name; ?>-tabs" class="category-tabs">
 				<li class="tabs"><a href="#<?php echo $tax_name; ?>-all"><?php echo $taxonomy->labels->all_items; ?></a></li>
-				<li class="hide-if-no-js"><a href="#<?php echo $tax_name; ?>-pop"><?php _e( 'Most Used' ); ?></a></li>
+				<li class="hide-if-no-js"><a href="#<?php echo $tax_name; ?>-pop"><?php _e( 'Most Used','woothemes-sensei' ); ?></a></li>
 			</ul>
 
 			<div id="<?php echo $tax_name; ?>-pop" class="tabs-panel" style="display: none;">
@@ -1840,7 +1840,7 @@ class Sensei_Core_Modules
 						<a id="sensei-<?php echo $tax_name; ?>-add-toggle" href="#<?php echo $tax_name; ?>-add" class="hide-if-no-js">
 							<?php
 							/* translators: %s: add new taxonomy label */
-							printf( __( '+ %s' ), $taxonomy->labels->add_new_item );
+							printf( __( '+ %s', 'woothemes-sensei' ), $taxonomy->labels->add_new_item );
 							?>
 						</a>
 					</h4>

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -138,7 +138,7 @@ class Sensei_Updates
                         || ! wp_verify_nonce( $_POST[ $function_name.'_nonce_field' ] , 'run_'.$function_name ) ){
 
                         wp_die(
-                            '<h1>' . __( 'Cheatin&#8217; uh?' ) . '</h1>' .
+                            '<h1>' . __( 'Cheatin&#8217; uh?', 'woothemes-sensei' ) . '</h1>' .
                             '<p>' . __( 'The nonce supplied in order to run this update function is invalid', 'woothemes-sensei' ) . '</p>',
                             403
                         );
@@ -187,7 +187,7 @@ class Sensei_Updates
                     || ! wp_verify_nonce( $_GET[ $function_name.'_nonce' ] , 'run_'.$function_name ) ){
 
                     wp_die(
-                        '<h1>' . __( 'Cheatin&#8217; uh?' ) . '</h1>' .
+                        '<h1>' . __( 'Cheatin&#8217; uh?', 'woothemes-sensei' ) . '</h1>' .
                         '<p>' . __( 'The nonce supplied in order to run this update function is invalid', 'woothemes-sensei' ) . '</p>',
                         403
                     );

--- a/includes/class-sensei-wc.php
+++ b/includes/class-sensei-wc.php
@@ -962,7 +962,7 @@ class Sensei_WC {
 
 		if ( self::is_product_in_cart( $wc_product_id ) ) {
 
-			$cart_link = '<a href="' . wc_get_checkout_url() . '" title="' . __( 'Checkout', 'woocommerce' ) . '">' . __( 'checkout', 'woocommerce' ) . '</a>';
+			$cart_link = '<a href="' . wc_get_checkout_url() . '" title="' . __( 'Checkout', 'woothemes-sensei' ) . '">' . __( 'checkout', 'woothemes-sensei' ) . '</a>';
 
 			// translators: Placeholder is a link to the cart.
 			$message = sprintf( __( 'This course is already in your cart, please proceed to %1$s, to gain access.', 'woothemes-sensei' ), $cart_link );

--- a/includes/rest-api/class-sensei-rest-api-endpoint-courses.php
+++ b/includes/rest-api/class-sensei-rest-api-endpoint-courses.php
@@ -65,7 +65,7 @@ class Sensei_REST_API_Endpoint_Courses extends Sensei_REST_API_Controller {
 
         $course = $this->factory->find_one_by_id($item_id);
         if ( empty( $course ) ) {
-            return $this->not_found( __( 'Course not found' ) );
+            return $this->not_found( __( 'Course not found', 'woothemes-sensei' ) );
         }
 
         return $this->succeed( $this->prepare_data_transfer_object( $course ) );

--- a/includes/rest-api/class-sensei-rest-api-endpoint-modules.php
+++ b/includes/rest-api/class-sensei-rest-api-endpoint-modules.php
@@ -38,7 +38,7 @@ class Sensei_REST_API_Endpoint_Modules extends Sensei_REST_API_Controller {
 
         $course = $this->factory->find_one_by_id($item_id);
         if ( empty( $course ) ) {
-            return $this->not_found( __( 'Module not found' ) );
+            return $this->not_found( __( 'Module not found', 'woothemes-sensei' ) );
         }
 
         return $this->succeed( $this->prepare_data_transfer_object( $course ) );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
-<ruleset name="Sensei">
+<ruleset name="Sensei"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
 	<description>A custom set of code standard rules to check for Sensei plugin.</description>
 
 	<!-- For help in understanding this file: https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -37,8 +37,8 @@
 	<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
 		<properties>
 			<property name="prefixes" type="array">
-				<element name="sensei"/>
-				<element name="woothemes"/>
+				<element value="sensei"/>
+				<element value="woothemes"/>
 			</property>
 		</properties>
 	</rule>
@@ -46,7 +46,7 @@
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array">
-				<element name="woothemes-sensei"/>
+				<element value="woothemes-sensei"/>
 			</property>
 		</properties>
 	</rule>


### PR DESCRIPTION
Fixes a small mistake I introduced in 64e86d72b87dc08e4e9da40f1e2fb399469bb884 for the PHPS config file - should be `<element value="..."/>` and not `<element name="..."/>`.

Also, adds an XSD reference to the `phpcs.xml.dist` so that issues like this are more easily spotted via IDEs and any other XML validation tools.

Requires PHPCS 3.3.2, which is when the new array element attribute was added to the XSD file.

Note, that this now _does_ enable the prefix and i18n checks that the previous effort was meant to!