### PR TITLE
Bugfix: Comments not displaying on Lesson page

### DIFF
--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -76,22 +76,9 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		add_filter( 'template_include', array( $this, 'force_page_template' ) );
 
 		// Handle some type-specific items.
-		if ( 'lesson' === $this->post_type ) {
-			// Use theme comments UI instead of Sensei's.
-			remove_action( 'sensei_pagination', array( 'Sensei_Lesson', 'output_comments' ), 90 );
-
-			// Turn off theme comments if needed.
-			if ( ! Sensei()->settings->get( 'lesson_comments' ) ) {
-				$this->disable_comments();
-			}
-		}
-
 		if ( 'sensei_message' === $this->post_type ) {
 			// Hide the message title until `the_content` is displayed.
 			$this->add_filter_hide_the_title();
-
-			// Do not display comments through the theme.
-			$this->disable_comments();
 		}
 	}
 


### PR DESCRIPTION
On unsupported themes, Lesson comments were not being displayed at all. This was because of a change that was made in the comment handling and a failure to clean up the outdated version of the code.

## Testing

- Go to Sensei > Settings > Lesson and check the box "This will allow learners to post comments on the single Lesson page, only learner who have access to the Lesson will be allowed to comment."

- Ensure you are using an unsupported theme.

- Visit a Lesson page on the frontend. The comments should be displayed.

- Disable the setting. The comments should be hidden on the Lesson page.

- Check the other CPT pages. For Course and Quiz, the comments UI **should not** be displayed. For Messages, the comments UI **should** be displayed.