### PR TITLE
Ensure comments are not displayed on archive pages

### DIFF
--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -75,27 +75,14 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		add_filter( 'the_content', array( $this, 'cpt_page_content_filter' ) );
 		add_filter( 'template_include', array( $this, 'force_page_template' ) );
 
+		// Disable comments.
+		Sensei_Unsupported_Theme_Handler_Utils::disable_comments();
+
 		// Handle some type-specific items.
 		if ( 'sensei_message' === $this->post_type ) {
 			// Hide the message title until `the_content` is displayed.
 			$this->add_filter_hide_the_title();
 		}
-	}
-
-	/**
-	 * Disable rendering of comments.
-	 */
-	public function disable_comments() {
-		add_filter( 'comments_open', '__return_false', 100 );
-		add_filter( 'get_comments_number', '__return_false', 100 );
-	}
-
-	/**
-	 * If we have previously disabled comments, re-enable them.
-	 */
-	public function reenable_comments() {
-		remove_filter( 'comments_open', '__return_false', 100 );
-		remove_filter( 'get_comments_number', '__return_false', 100 );
 	}
 
 	/**
@@ -119,13 +106,13 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 		$this->remove_filter_hide_the_title();
 
 		// Temporarily re-enable comments.
-		$this->reenable_comments();
+		Sensei_Unsupported_Theme_Handler_Utils::reenable_comments();
 
 		$renderer = $this->get_renderer();
 		$content  = $renderer->render();
 
-		// Disable comments again.
-		$this->disable_comments();
+		// Disable theme comments.
+		Sensei_Unsupported_Theme_Handler_Utils::disable_comments();
 
 		// Disable pagination.
 		Sensei_Unsupported_Theme_Handler_Utils::disable_theme_pagination();

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -53,7 +53,7 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 	 *                               creating the Page.
 	 */
 	protected function output_content_as_page( $content, $object_to_copy = null, $post_params = array() ) {
-		global $post, $wp_query;
+		global $post, $wp_query, $wp_the_query;
 
 		// Set up dummy post for rendering.
 		$dummy_post_properties = array_merge( $this->generate_dummy_post_args( $object_to_copy ), $post_params, array( 'post_content' => $content ) );
@@ -79,6 +79,10 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 		$wp_query->is_single     = true;
 		$wp_query->is_archive    = false;
 		$wp_query->max_num_pages = 0;
+
+		add_filter( 'comments_template_query_args', array( $this, 'filter_comment_args_load_none' ), 100 );
+		add_filter( 'comments_open', '__return_false', 100 );
+		add_filter( 'get_comments_number', '__return_false', 100 );
 
 		$this->prepare_wp_query( $wp_query, $object_to_copy, $post_params );
 
@@ -231,6 +235,19 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 			return '';
 		}
 		return $title;
+	}
+
+	/**
+	 * Filter on `comments_template_query_args` to ensure that no comments are
+	 * loaded.
+	 *
+	 * @param array $comment_args
+	 *
+	 * @return array
+	 */
+	public function filter_comment_args_load_none( $comment_args ) {
+		$comment_args['comment__in'] = array( 0 );
+		return $comment_args;
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -80,9 +80,7 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 		$wp_query->is_archive    = false;
 		$wp_query->max_num_pages = 0;
 
-		add_filter( 'comments_template_query_args', array( $this, 'filter_comment_args_load_none' ), 100 );
-		add_filter( 'comments_open', '__return_false', 100 );
-		add_filter( 'get_comments_number', '__return_false', 100 );
+		Sensei_Unsupported_Theme_Handler_Utils::disable_comments();
 
 		$this->prepare_wp_query( $wp_query, $object_to_copy, $post_params );
 
@@ -235,19 +233,6 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 			return '';
 		}
 		return $title;
-	}
-
-	/**
-	 * Filter on `comments_template_query_args` to ensure that no comments are
-	 * loaded.
-	 *
-	 * @param array $comment_args
-	 *
-	 * @return array
-	 */
-	public function filter_comment_args_load_none( $comment_args ) {
-		$comment_args['comment__in'] = array( 0 );
-		return $comment_args;
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-utils.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-utils.php
@@ -22,4 +22,36 @@ class Sensei_Unsupported_Theme_Handler_Utils {
 		add_filter( 'next_post_link', '__return_false' );
 	}
 
+	/**
+	 * Disable rendering of comments.
+	 */
+	public static function disable_comments() {
+		add_filter( 'comments_template_query_args', array( 'Sensei_Unsupported_Theme_Handler_Utils', 'filter_comment_args_load_none' ), 100 );
+		add_filter( 'comments_open', '__return_false', 100 );
+		add_filter( 'get_comments_number', '__return_false', 100 );
+	}
+
+	/**
+	 * If we have previously disabled comments, re-enable them.
+	 */
+	public static function reenable_comments() {
+		remove_filter( 'comments_template_query_args', array( 'Sensei_Unsupported_Theme_Handler_Utils', 'filter_comment_args_load_none' ), 100 );
+		remove_filter( 'comments_open', '__return_false', 100 );
+		remove_filter( 'get_comments_number', '__return_false', 100 );
+	}
+
+	/**
+	 * Filter on `comments_template_query_args` to ensure that no comments are
+	 * loaded.
+	 *
+	 * @param array $comment_args
+	 *
+	 * @return array
+	 */
+	public static function filter_comment_args_load_none( $comment_args ) {
+		$comment_args['comment__in'] = array( 0 );
+		return $comment_args;
+	}
+
+
 }


### PR DESCRIPTION
In some themes, the `comments_template()` WP function is called unconditionally in some templates. We found a bug in theme compatibility on archive pages when this happens:

- WordPress tries, at that point, to load all comments.
- Since archive pages use a dummy page object for rendering, the `post_id` is `0`.
- When `WP_Comment_Query` sees a `post_id` of `0`, it loads all comments for all posts.

This was causing all of the comments across the site to be loaded and displayed on all Sensei archive pages on this themes. Any theme that used a condition (such as `have_comments()` or `comments_open()`) when calling `comments_template()` would not have this problem, since both would be false until _after_ `comments_template()` is called.

## Testing

- Visit an archive page using an unsupported theme (e.g. `/lesson-tag/<tag>`.

- In the theme's `page.php` template, find the call to `comments_template()`. If it within an `if` statement, modify the file so that it is not in an `if` statement. (If available, you may also use the Jannah theme, on which this bug was found).

- Load the archive page, and ensure that no comments appear when using this branch.