### PR TITLE
Fix PHP warning on Course Results page

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1122,7 +1122,7 @@ class Sensei_Utils {
 					$quiz_grade = get_comment_meta( $user_lesson_status->comment_ID, 'grade', true );
 
 					// Add up total grade
-					$total_grade += $quiz_grade;
+					$total_grade += intval( $quiz_grade );
 
 					++$lesson_count;
 				}


### PR DESCRIPTION
Fixes #2254.

## Testing
1. Start a course with at least one optional quiz.
2. Complete a lesson without completing the quiz.
3. View the Course Results page (/course/<course-slug>/results).
4. Ensure the following PHP warning is not logged:
`A non-numeric value encountered in /var/www/html/wp-content/plugins/sensei/includes/class-sensei-utils.php.`

Note that https://github.com/Automattic/sensei/issues/2254#issuecomment-426968371 will be fixed in a separate PR.