### PR TITLE
Fix PHP warnings on Sensei Analysis page

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -295,10 +295,10 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 						'meta_key' => 'percent',
 					);
 
-				$percent_count = count( Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_percentage', $grade_args, $item ), true ) );
+				$percent_count = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_percentage', $grade_args, $item ), false );
 				$percent_total = Sensei_Grading::get_course_users_grades_sum( $item->ID );
-
                 $course_average_percent = 0;
+
                 if( $percent_count > 0 && $percent_total > 0 ){
                     $course_average_percent = Sensei_Utils::quotient_as_absolute_rounded_number( $percent_total, $percent_count, 2 );
                 }
@@ -354,10 +354,10 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 							'meta_key' => 'grade',
 						);
 
-					$grade_count = count( Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_grades', $grade_args, $item ), true ));
+					$grade_count = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_grades', $grade_args, $item ), false );
 					$grade_total = Sensei_Grading::get_lessons_users_grades_sum( $item->ID );
-
                     $lesson_average_grade = 0;
+
                     if( $grade_total > 0 && $grade_count > 0 ){
                         $lesson_average_grade = Sensei_Utils::quotient_as_absolute_rounded_number( $grade_total, $grade_count, 2 );
                     }
@@ -416,10 +416,10 @@ class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
 						'meta_key' => 'grade',
 					);
 
-				$grade_count = count( Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_lesson_grades', $grade_args, $item ), true ));
+				$grade_count = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_lesson_grades', $grade_args, $item ), false );
 				$grade_total = Sensei_Grading::get_user_graded_lessons_sum( $item->ID );
-
                 $user_average_grade = 0;
+
                 if( $grade_total > 0 && $grade_count > 0 ){
                     $user_average_grade = Sensei_Utils::quotient_as_absolute_rounded_number( $grade_total, $grade_count, 2 );
                 }


### PR DESCRIPTION
This PR fixes the `count` warnings that appear on the _Sensei_ > _Analysis_ page when:
- On the _Learners_ subpage, a learner had only ever taken 1 quiz:
![screen shot 2018-11-09 at 5 56 53 am](https://user-images.githubusercontent.com/1190420/48258895-4be2bf00-e3e4-11e8-83db-f8717fc1bdbe.jpg)
- On the _Courses_ subpage, only 1 learner had taken a quiz for a particular course:
![screen shot 2018-11-09 at 6 00 08 am](https://user-images.githubusercontent.com/1190420/48259061-d4615f80-e3e4-11e8-923b-2805e3ddd2db.jpg)
- On the _Lessons_ subpage, a particular lesson's quiz had only ever been taken once:
![screen shot 2018-11-09 at 6 05 32 am](https://user-images.githubusercontent.com/1190420/48259284-7ed98280-e3e5-11e8-93b1-bc0581cc3e18.jpg)

## Testing
- Create some data as per the above.
- On the _Sensei_ > _Analysis_ page, click on each of _Learners_, _Courses_ and _Lessons_.
- Ensure that no PHP `count` warning appears in the logs.
- Check that the _Average Grade_ or _Average Percentage_ column values remain unchanged.