### PR TITLE
Add usage tracking for course enrolments

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -35,6 +35,7 @@ class Sensei_Usage_Tracking_Data {
 			'course_prereqs'          => self::get_course_prereqs_count(),
 			'course_featured'         => self::get_course_featured_count(),
 			'enrolments'              => self::get_course_enrolments(),
+			'enrolment_last'          => self::get_last_course_enrolment(),
 			'learners'                => self::get_learner_count(),
 			'lessons'                 => wp_count_posts( 'lesson' )->publish,
 			'lesson_modules'          => self::get_lesson_module_count(),
@@ -353,6 +354,28 @@ class Sensei_Usage_Tracking_Data {
 			INNER JOIN {$wpdb->posts} p ON p.ID = c.comment_post_ID
 			WHERE comment_type = 'sensei_course_status'
 				AND meta_key = '{$wpdb->prefix}capabilities' AND meta_value NOT LIKE '%administrator%'
+				AND post_status = 'publish' AND c.user_id <> 0"
+		);
+	}
+
+	/**
+	 * Gets the date of the most recent enrolment by any non-admin learner in any published course.
+	 *
+	 * @since 1.12.2
+	 *
+	 * @return int Date of the most recent course enrolment.
+	 **/
+	private static function get_last_course_enrolment() {
+		global $wpdb;
+
+		return $wpdb->get_var(
+			"SELECT IFNULL(MAX(cm.meta_value), 'N/A')
+			FROM {$wpdb->comments} c
+			INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_ID
+			INNER JOIN {$wpdb->usermeta} um ON c.user_id = um.user_id
+			INNER JOIN {$wpdb->posts} p ON p.ID = c.comment_post_ID
+			WHERE comment_type = 'sensei_course_status' AND cm.meta_key = 'start'
+				AND um.meta_key = '{$wpdb->prefix}capabilities' AND um.meta_value NOT LIKE '%administrator%'
 				AND post_status = 'publish' AND c.user_id <> 0"
 		);
 	}

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -34,6 +34,7 @@ class Sensei_Usage_Tracking_Data {
 			'course_no_notifications' => self::get_course_no_notifications_count(),
 			'course_prereqs'          => self::get_course_prereqs_count(),
 			'course_featured'         => self::get_course_featured_count(),
+			'course_enrolments'       => self::get_course_enrolments(),
 			'learners'                => self::get_learner_count(),
 			'lessons'                 => wp_count_posts( 'lesson' )->publish,
 			'lesson_modules'          => self::get_lesson_module_count(),
@@ -329,6 +330,27 @@ class Sensei_Usage_Tracking_Data {
 		);
 
 		return $query->found_posts;
+	}
+
+	/**
+	 * Gets the total number of non-admin learners enrolled in at least one published course.
+	 *
+	 * @since 1.12.2
+	 *
+	 * @return int Number of course enrolments.
+	 **/
+	private static function get_course_enrolments() {
+		global $wpdb;
+
+		return $wpdb->get_var(
+			"SELECT COUNT(DISTINCT c.user_id)
+			FROM {$wpdb->comments} c
+			INNER JOIN {$wpdb->usermeta} um ON c.user_id = um.user_id
+			INNER JOIN {$wpdb->posts} p ON p.ID = c.comment_post_ID
+			WHERE comment_type = 'sensei_course_status'
+				AND meta_key = '{$wpdb->prefix}capabilities' AND meta_value NOT LIKE '%administrator%'
+				AND post_status = 'publish' AND c.user_id <> 0"
+		);
 	}
 
 	/**

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -35,6 +35,7 @@ class Sensei_Usage_Tracking_Data {
 			'course_prereqs'          => self::get_course_prereqs_count(),
 			'course_featured'         => self::get_course_featured_count(),
 			'enrolments'              => self::get_course_enrolments(),
+			'enrolment_first'         => self::get_first_course_enrolment(),
 			'enrolment_last'          => self::get_last_course_enrolment(),
 			'learners'                => self::get_learner_count(),
 			'lessons'                 => wp_count_posts( 'lesson' )->publish,
@@ -370,6 +371,28 @@ class Sensei_Usage_Tracking_Data {
 
 		return $wpdb->get_var(
 			"SELECT IFNULL(MAX(cm.meta_value), 'N/A')
+			FROM {$wpdb->comments} c
+			INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_ID
+			INNER JOIN {$wpdb->usermeta} um ON c.user_id = um.user_id
+			INNER JOIN {$wpdb->posts} p ON p.ID = c.comment_post_ID
+			WHERE comment_type = 'sensei_course_status' AND cm.meta_key = 'start'
+				AND um.meta_key = '{$wpdb->prefix}capabilities' AND um.meta_value NOT LIKE '%administrator%'
+				AND post_status = 'publish' AND c.user_id <> 0"
+		);
+	}
+
+	/**
+	 * Gets the date of the first enrolment by any non-admin learner in any published course.
+	 *
+	 * @since 1.12.2
+	 *
+	 * @return int Date of the first course enrolment.
+	 **/
+	private static function get_first_course_enrolment() {
+		global $wpdb;
+
+		return $wpdb->get_var(
+			"SELECT IFNULL(MIN(cm.meta_value), 'N/A')
 			FROM {$wpdb->comments} c
 			INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_ID
 			INNER JOIN {$wpdb->usermeta} um ON c.user_id = um.user_id

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -34,7 +34,7 @@ class Sensei_Usage_Tracking_Data {
 			'course_no_notifications' => self::get_course_no_notifications_count(),
 			'course_prereqs'          => self::get_course_prereqs_count(),
 			'course_featured'         => self::get_course_featured_count(),
-			'course_enrolments'       => self::get_course_enrolments(),
+			'enrolments'              => self::get_course_enrolments(),
 			'learners'                => self::get_learner_count(),
 			'lessons'                 => wp_count_posts( 'lesson' )->publish,
 			'lesson_modules'          => self::get_lesson_module_count(),
@@ -64,28 +64,30 @@ class Sensei_Usage_Tracking_Data {
 	 * @return array
 	 */
 	private static function get_quiz_stats() {
-		$query = new WP_Query( array(
-			'post_type'      => 'lesson',
-			'fields'         => 'ids',
-			'posts_per_page' => -1,
-			'no_found_rows'  => true,
-			'meta_query'     => array(
-				array(
-					'key'   => '_quiz_has_questions',
-					'value' => true,
+		$query = new WP_Query(
+			array(
+				'post_type'      => 'lesson',
+				'fields'         => 'ids',
+				'posts_per_page' => -1,
+				'no_found_rows'  => true,
+				'meta_query'     => array(
+					array(
+						'key'   => '_quiz_has_questions',
+						'value' => true,
+					),
+					array(
+						'key'     => '_lesson_course',
+						'value'   => '',
+						'compare' => '!=',
+					),
+					array(
+						'key'     => '_lesson_course',
+						'value'   => '0',
+						'compare' => '!=',
+					),
 				),
-				array(
-					'key'     => '_lesson_course',
-					'value'   => '',
-					'compare' => '!=',
-				),
-				array(
-					'key'     => '_lesson_course',
-					'value'   => '0',
-					'compare' => '!=',
-				),
-			),
-		) );
+			)
+		);
 
 		$stats = array(
 			'quiz_total'          => 0,
@@ -166,7 +168,7 @@ class Sensei_Usage_Tracking_Data {
 		global $wpdb;
 
 		$published_quiz_ids = array_map( 'intval', $published_quiz_ids );
-		return (int) $wpdb->get_var( $wpdb->prepare( "SELECT count(DISTINCT `post_id`) FROM {$wpdb->postmeta} WHERE `post_id` IN (" . implode( ',', $published_quiz_ids ) . ") AND `meta_key`=%s AND `meta_value`=%s", $meta_key, $meta_value ) );
+		return (int) $wpdb->get_var( $wpdb->prepare( "SELECT count(DISTINCT `post_id`) FROM {$wpdb->postmeta} WHERE `post_id` IN (" . implode( ',', $published_quiz_ids ) . ') AND `meta_key`=%s AND `meta_value`=%s', $meta_key, $meta_value ) );
 	}
 
 	/**
@@ -178,19 +180,21 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int
 	 */
 	private static function get_category_question_count( $published_quiz_ids ) {
-		$multiple_question_query     = new WP_Query( array(
-			'post_type'        => 'multiple_question',
-			'posts_per_page'   => -1,
-			'fields'           => 'ids',
-			'no_found_rows'    => true,
-			'suppress_filters' => 1,
-			'meta_query'       => array(
-				array(
-					'key'   => '_quiz_id',
-					'value' => $published_quiz_ids,
+		$multiple_question_query     = new WP_Query(
+			array(
+				'post_type'        => 'multiple_question',
+				'posts_per_page'   => -1,
+				'fields'           => 'ids',
+				'no_found_rows'    => true,
+				'suppress_filters' => 1,
+				'meta_query'       => array(
+					array(
+						'key'   => '_quiz_id',
+						'value' => $published_quiz_ids,
+					),
 				),
-			),
-		) );
+			)
+		);
 
 		return count( $multiple_question_query->posts );
 	}
@@ -561,7 +565,8 @@ class Sensei_Usage_Tracking_Data {
 		foreach ( $courses as $course ) {
 			// Get modules for this course.
 			$module_count = wp_count_terms(
-				'module', array(
+				'module',
+				array(
 					'object_ids' => $course,
 				)
 			);
@@ -594,10 +599,11 @@ class Sensei_Usage_Tracking_Data {
 		$courses       = $query->posts;
 		$total_courses = is_array( $courses ) ? count( $courses ) : 0;
 
-		for( $i = 0; $i < $total_courses; $i++ ) {
+		for ( $i = 0; $i < $total_courses; $i++ ) {
 			// Get modules for this course.
 			$module_count = wp_count_terms(
-				'module', array(
+				'module',
+				array(
 					'object_ids' => $courses[ $i ],
 				)
 			);

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -1297,6 +1297,117 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_first_course_enrolment
+	 */
+	public function testGetFirstCourseEnrolment() {
+		$first_enrolment_date = '2017-04-13 19:07:43';
+
+		// Create course and users.
+		$course_id = $this->factory->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_type'   => 'course',
+			)
+		);
+		$subscribers = $this->factory->user->create_many( 3, array( 'role' => 'subscriber' ) );
+		$comment_ids = array();
+
+		// Enroll users in course.
+		foreach ( $subscribers as $subscriber ) {
+			$comment_ids[] = $this->factory->comment->create(
+				array(
+					'user_id'          => $subscriber,
+					'comment_post_ID'  => $course_id,
+					'comment_type'     => 'sensei_course_status',
+				)
+			);
+		}
+
+		update_comment_meta( $comment_ids[0], 'start', '2017-05-23 10:59:00' );
+		update_comment_meta( $comment_ids[1], 'start', $first_enrolment_date );
+		update_comment_meta( $comment_ids[2], 'start', '2018-10-01 13:25:25' );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'enrolment_first', $usage_data, 'Key' );
+		$this->assertEquals( $first_enrolment_date, $usage_data['enrolment_first'], 'Count' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_first_course_enrolment
+	 */
+	public function testGetFirstCourseEnrolmentNoAdminUsers() {
+		$first_enrolment_date = '2018-11-09 09:48:05';
+
+		// Create course and users.
+		$course_id = $this->factory->post->create(
+			array(
+				'post_status' => 'publish',
+				'post_type'   => 'course',
+			)
+		);
+		$administrators = $this->factory->user->create_many( 2, array( 'role' => 'administrator' ) );
+		$subscribers = $this->factory->user->create_many( 1, array( 'role' => 'subscriber' ) );
+		$comment_ids = array();
+
+		// Enroll users in course.
+		foreach ( array_merge( $administrators, $subscribers ) as $user ) {
+			$comment_ids[] = $this->factory->comment->create(
+				array(
+					'user_id'          => $user,
+					'comment_post_ID'  => $course_id,
+					'comment_type'     => 'sensei_course_status',
+				)
+			);
+		}
+
+		update_comment_meta( $comment_ids[0], 'start', '2017-05-23 10:59:00' ); // Admin.
+		update_comment_meta( $comment_ids[1], 'start', '2018-10-01 13:25:25' ); // Admin.
+		update_comment_meta( $comment_ids[2], 'start', $first_enrolment_date ); // Subscriber.
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( $first_enrolment_date, $usage_data['enrolment_first'] );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_first_course_enrolment
+	 */
+	public function testGetFirstCourseEnrolmentPublishedCourses() {
+		// Create course and users.
+		$course_id = $this->factory->post->create(
+			array(
+				'post_status' => 'draft',
+				'post_type' => 'course',
+			)
+		);
+		$subscribers = $this->factory->user->create_many( 3, array( 'role' => 'subscriber' ) );
+		$comment_ids = array();
+
+		// Enroll users in course.
+		foreach ( $subscribers as $subscriber ) {
+			$comment_ids[] = $this->factory->comment->create(
+				array(
+					'user_id'          => $subscriber,
+					'comment_post_ID'  => $course_id,
+					'comment_type'     => 'sensei_course_status',
+				)
+			);
+		}
+
+		update_comment_meta( $comment_ids[0], 'start', '2017-05-23 10:59:00' );
+		update_comment_meta( $comment_ids[1], 'start', '2018-11-09 09:48:05' );
+		update_comment_meta( $comment_ids[2], 'start', '2018-10-01 13:25:25' );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertEquals( 'N/A', $usage_data['enrolment_first'] );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_lesson_has_length_count
 	 */
 	public function testGetLessonHasLengthCount() {

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -7,20 +7,21 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	/**
 	 * Sets up the factory.
 	 */
-	public function setUp(){
+	public function setUp() {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
-	}// end function setUp()
+	}//end setUp()
 
-	public function tearDown(){
+	public function tearDown() {
 		parent::tearDown();
 		$this->factory->tearDown();
 	} // end tearDown
 
 	private function setupCoursesAndModules() {
 		$this->course_ids = $this->factory->post->create_many(
-			3, array(
+			3,
+			array(
 				'post_status' => 'publish',
 				'post_type'   => 'course',
 			)
@@ -63,13 +64,15 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	// Create some published and unpublished lessons.
 	private function createLessons() {
 		$drafts    = $this->factory->post->create_many(
-			2, array(
+			2,
+			array(
 				'post_status' => 'draft',
 				'post_type'   => 'lesson',
 			)
 		);
 		$published = $this->factory->post->create_many(
-			3, array(
+			3,
+			array(
 				'post_status' => 'publish',
 				'post_type'   => 'lesson',
 			)
@@ -147,10 +150,12 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_quiz_stats
 	 */
 	public function testGetMinMaxQuestionsMinMaxSame() {
-		$this->factory->get_course_with_lessons( array(
-			'lesson_count' => 1,
-			'question_count' => 2,
-		) );
+		$this->factory->get_course_with_lessons(
+			array(
+				'lesson_count' => 1,
+				'question_count' => 2,
+			)
+		);
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( 1, $usage_data['quiz_total'] );
@@ -166,18 +171,24 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->factory->course->create();
 		$this->factory->lesson->create();
 
-		$this->factory->get_course_with_lessons( array(
-			'lesson_count' => 1,
-			'question_count' => 0,
-		) );
-		$this->factory->get_course_with_lessons( array(
-			'question_count' => array( 1, 2 ),
-			'lesson_count' => 2,
-		) );
-		$this->factory->get_course_with_lessons( array(
-			'question_count' => array( 0, 1, 6 ),
-			'lesson_count'   => 4, // Missing one should be 5 questions.
-		) );
+		$this->factory->get_course_with_lessons(
+			array(
+				'lesson_count' => 1,
+				'question_count' => 0,
+			)
+		);
+		$this->factory->get_course_with_lessons(
+			array(
+				'question_count' => array( 1, 2 ),
+				'lesson_count' => 2,
+			)
+		);
+		$this->factory->get_course_with_lessons(
+			array(
+				'question_count' => array( 0, 1, 6 ),
+				'lesson_count'   => 4, // Missing one should be 5 questions.
+			)
+		);
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( 5, $usage_data['quiz_total'] );
@@ -190,24 +201,30 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_quiz_stats
 	 */
 	public function testGetMinMaxQuestionsDrafts() {
-		$this->factory->get_course_with_lessons( array(
-			'lesson_count'   => 1,
-			'question_count' => 4,
-			'lesson_args'    => array(
-				'post_status' => 'draft',
-			),
-		) );
-		$this->factory->get_course_with_lessons( array(
-			'lesson_count'   => 1,
-			'question_count' => 4,
-			'course_args'    => array(
-				'post_status' => 'draft',
-			),
-		) );
-		$this->factory->get_course_with_lessons( array(
-			'question_count' => array( 2, 3 ),
-			'lesson_count'   => 2,
-		) );
+		$this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'   => 1,
+				'question_count' => 4,
+				'lesson_args'    => array(
+					'post_status' => 'draft',
+				),
+			)
+		);
+		$this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'   => 1,
+				'question_count' => 4,
+				'course_args'    => array(
+					'post_status' => 'draft',
+				),
+			)
+		);
+		$this->factory->get_course_with_lessons(
+			array(
+				'question_count' => array( 2, 3 ),
+				'lesson_count'   => 2,
+			)
+		);
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( 2, $usage_data['quiz_total'] );
@@ -221,11 +238,13 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_category_question_count
 	 */
 	public function testCategoryQuestionsNone() {
-		$this->factory->get_course_with_lessons( array(
-			'lesson_count'            => 1,
-			'question_count'          => 2,
-			'multiple_question_count' => 0,
-		) );
+		$this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'            => 1,
+				'question_count'          => 2,
+				'multiple_question_count' => 0,
+			)
+		);
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( 0, $usage_data['category_questions'] );
@@ -237,11 +256,13 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_category_question_count
 	 */
 	public function testCategoryQuestionsSimple() {
-		$this->factory->get_course_with_lessons( array(
-			'lesson_count'            => 1,
-			'question_count'          => 2,
-			'multiple_question_count' => 1,
-		) );
+		$this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'            => 1,
+				'question_count'          => 2,
+				'multiple_question_count' => 1,
+			)
+		);
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( 1, $usage_data['category_questions'] );
@@ -253,20 +274,24 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_category_question_count
 	 */
 	public function testCategoryQuestionsWithDraft() {
-		$this->factory->get_course_with_lessons( array(
-			'lesson_count'            => 2,
-			'question_count'          => array( 0, 1 ),
-			'multiple_question_count' => array( 1, 2 ),
-		) );
+		$this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'            => 2,
+				'question_count'          => array( 0, 1 ),
+				'multiple_question_count' => array( 1, 2 ),
+			)
+		);
 
-		$this->factory->get_course_with_lessons( array(
-			'lesson_count'            => 1,
-			'question_count'          => 2,
-			'multiple_question_count' => 1,
-			'lesson_args'             => array(
-				'post_status' => 'draft',
-			),
-		) );
+		$this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'            => 1,
+				'question_count'          => 2,
+				'multiple_question_count' => 1,
+				'lesson_args'             => array(
+					'post_status' => 'draft',
+				),
+			)
+		);
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
 		$this->assertEquals( 3, $usage_data['category_questions'] );
@@ -341,39 +366,54 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		);
 
 		foreach ( $invalid_values as $value ) {
-			$this->factory->get_course_with_lessons( array(
-				'lesson_count'   => 1,
-				'question_count' => 3,
-				'quiz_args'      => array(
-					'meta_input' => array_merge( $default_values, array(
-						$meta_key => $value,
-					) ),
-				),
-			) );
+			$this->factory->get_course_with_lessons(
+				array(
+					'lesson_count'   => 1,
+					'question_count' => 3,
+					'quiz_args'      => array(
+						'meta_input' => array_merge(
+							$default_values,
+							array(
+								$meta_key => $value,
+							)
+						),
+					),
+				)
+			);
 		}
 
 		foreach ( $valid_values as $value ) {
-			$this->factory->get_course_with_lessons( array(
-				'lesson_count'   => 1,
-				'question_count' => 3,
-				'quiz_args'      => array(
-					'meta_input' => array_merge( $default_values, array(
-						$meta_key => $value,
-					) ),
-				),
-			) );
-			$this->factory->get_course_with_lessons( array(
-				'lesson_count'   => 1,
-				'question_count' => 3,
-				'lesson_args'    => array(
-					'post_status' => 'draft',
-				),
-				'quiz_args'      => array(
-					'meta_input' => array_merge( $default_values, array(
-						$meta_key => $value,
-					) ),
-				),
-			) );
+			$this->factory->get_course_with_lessons(
+				array(
+					'lesson_count'   => 1,
+					'question_count' => 3,
+					'quiz_args'      => array(
+						'meta_input' => array_merge(
+							$default_values,
+							array(
+								$meta_key => $value,
+							)
+						),
+					),
+				)
+			);
+			$this->factory->get_course_with_lessons(
+				array(
+					'lesson_count'   => 1,
+					'question_count' => 3,
+					'lesson_args'    => array(
+						'post_status' => 'draft',
+					),
+					'quiz_args'      => array(
+						'meta_input' => array_merge(
+							$default_values,
+							array(
+								$meta_key => $value,
+							)
+						),
+					),
+				)
+			);
 		}
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
@@ -395,20 +435,24 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			'_quiz_grade_type'       => 'auto',
 			'_enable_quiz_reset'     => 'on',
 		);
-		$course_lessons_a = $this->factory->get_course_with_lessons( array(
-			'lesson_count'   => 1,
-			'question_count' => 3,
-			'quiz_args'      => array(
-				'meta_input' => $values,
-			),
-		) );
-		$course_lessons_b = $this->factory->get_course_with_lessons( array(
-			'lesson_count'   => 1,
-			'question_count' => 0,
-			'quiz_args'      => array(
-				'meta_input' => $values,
-			),
-		) );
+		$course_lessons_a = $this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'   => 1,
+				'question_count' => 3,
+				'quiz_args'      => array(
+					'meta_input' => $values,
+				),
+			)
+		);
+		$course_lessons_b = $this->factory->get_course_with_lessons(
+			array(
+				'lesson_count'   => 1,
+				'question_count' => 0,
+				'quiz_args'      => array(
+					'meta_input' => $values,
+				),
+			)
+		);
 
 		// Fake out! Replicate a data integrity issue that exists in Sensei.
 		update_post_meta( $course_lessons_b['lesson_ids'][0], '_quiz_has_questions', '1' );
@@ -425,13 +469,15 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Create some published and unpublished courses.
 		$this->factory->post->create_many(
-			2, array(
+			2,
+			array(
 				'post_status' => 'draft',
 				'post_type'   => 'course',
 			)
 		);
 		$this->factory->post->create_many(
-			$published, array(
+			$published,
+			array(
 				'post_status' => 'publish',
 				'post_type'   => 'course',
 			)
@@ -594,13 +640,15 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Create some published and unpublished messages.
 		$this->factory->post->create_many(
-			5, array(
+			5,
+			array(
 				'post_status' => 'pending',
 				'post_type'   => 'sensei_message',
 			)
 		);
 		$this->factory->post->create_many(
-			$published, array(
+			$published,
+			array(
 				'post_status' => 'publish',
 				'post_type'   => 'sensei_message',
 			)
@@ -656,13 +704,15 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Create some published and unpublished questions.
 		$this->factory->post->create_many(
-			12, array(
+			12,
+			array(
 				'post_status' => 'private',
 				'post_type'   => 'question',
 			)
 		);
 		$this->factory->post->create_many(
-			$published, array(
+			$published,
+			array(
 				'post_status' => 'publish',
 				'post_type'   => 'question',
 			)
@@ -682,7 +732,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetUsageDataQuestionTypes() {
 		// Create some questions.
 		$questions = $this->factory->post->create_many(
-			10, array(
+			10,
+			array(
 				'post_type'   => 'question',
 				'post_status' => 'publish',
 			)
@@ -745,14 +796,16 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetUsageDataQuestionMediaCount() {
 		// Create some questions.
 		$questions = $this->factory->post->create_many(
-			5, array(
+			5,
+			array(
 				'post_type'   => 'question',
 				'post_status' => 'publish',
 			)
 		);
 		// Create some media.
 		$media = $this->factory->attachment->create_many(
-			3, array(
+			3,
+			array(
 				'post_type'   => 'question',
 				'post_status' => 'publish',
 			)
@@ -776,7 +829,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetUsageDataQuestionMediaCountNoMedia() {
 		// Create some questions, but don't attach any media.
 		$questions = $this->factory->post->create_many(
-			5, array(
+			5,
+			array(
 				'post_type'   => 'question',
 				'post_status' => 'publish',
 			)
@@ -795,7 +849,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetRandomOrderCount() {
 		// Create some questions.
 		$questions = $this->factory->post->create_many(
-			3, array(
+			3,
+			array(
 				'post_type'   => 'question',
 				'post_status' => 'publish',
 			)
@@ -824,7 +879,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetRandomOrderCountMultipleChoiceOnly() {
 		// Create some questions.
 		$questions = $this->factory->post->create_many(
-			6, array(
+			6,
+			array(
 				'post_type'   => 'question',
 				'post_status' => 'publish',
 			)
@@ -907,12 +963,14 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$with_video = 4;
 
 		$course_ids_without_video = $this->factory->post->create_many(
-			3, array(
+			3,
+			array(
 				'post_type' => 'course',
 			)
 		);
 		$course_ids_with_video    = $this->factory->post->create_many(
-			$with_video, array(
+			$with_video,
+			array(
 				'post_type' => 'course',
 			)
 		);
@@ -942,12 +1000,14 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$with_disabled_notification = 2;
 
 		$course_ids_without_disabled = $this->factory->post->create_many(
-			3, array(
+			3,
+			array(
 				'post_type' => 'course',
 			)
 		);
 		$course_ids_with_disabled    = $this->factory->post->create_many(
-			$with_disabled_notification, array(
+			$with_disabled_notification,
+			array(
 				'post_type' => 'course',
 			)
 		);
@@ -971,12 +1031,14 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$with_prereq = 2;
 
 		$course_ids_without_prereq = $this->factory->post->create_many(
-			3, array(
+			3,
+			array(
 				'post_type' => 'course',
 			)
 		);
 		$course_ids_with_prereq    = $this->factory->post->create_many(
-			$with_prereq, array(
+			$with_prereq,
+			array(
 				'post_type' => 'course',
 			)
 		);
@@ -1003,12 +1065,14 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$featured = 2;
 
 		$non_featured_course_ids = $this->factory->post->create_many(
-			3, array(
+			3,
+			array(
 				'post_type' => 'course',
 			)
 		);
 		$featured_course_ids     = $this->factory->post->create_many(
-			$featured, array(
+			$featured,
+			array(
 				'post_type' => 'course',
 			)
 		);
@@ -1053,8 +1117,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertArrayHasKey( 'course_enrolments', $usage_data, 'Key' );
-		$this->assertEquals( $enrolments, $usage_data['course_enrolments'], 'Count' );
+		$this->assertArrayHasKey( 'enrolments', $usage_data, 'Key' );
+		$this->assertEquals( $enrolments, $usage_data['enrolments'], 'Count' );
 	}
 
 	/**
@@ -1087,7 +1151,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( $enrolments, $usage_data['course_enrolments'] );
+		$this->assertEquals( $enrolments, $usage_data['enrolments'] );
 	}
 
 	/**
@@ -1117,7 +1181,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
-		$this->assertEquals( 0, $usage_data['course_enrolments'] );
+		$this->assertEquals( 0, $usage_data['enrolments'] );
 	}
 
 	/**
@@ -1129,12 +1193,14 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Create some lessons
 		$lesson_without_length_ids = $this->factory->post->create_many(
-			2, array(
+			2,
+			array(
 				'post_type' => 'lesson',
 			)
 		);
 		$lesson_with_length_ids    = $this->factory->post->create_many(
-			$lessons_with_length, array(
+			$lessons_with_length,
+			array(
 				'post_type' => 'lesson',
 			)
 		);
@@ -1160,12 +1226,14 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Create some lessons
 		$lesson_without_complexity_ids = $this->factory->post->create_many(
-			2, array(
+			2,
+			array(
 				'post_type' => 'lesson',
 			)
 		);
 		$lesson_with_complexity_ids    = $this->factory->post->create_many(
-			$lessons_with_complexity, array(
+			$lessons_with_complexity,
+			array(
 				'post_type' => 'lesson',
 			)
 		);
@@ -1191,12 +1259,14 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Create some lessons
 		$lesson_without_video_ids = $this->factory->post->create_many(
-			4, array(
+			4,
+			array(
 				'post_type' => 'lesson',
 			)
 		);
 		$lesson_with_video_ids    = $this->factory->post->create_many(
-			$lessons_with_video, array(
+			$lessons_with_video,
+			array(
 				'post_type' => 'lesson',
 			)
 		);


### PR DESCRIPTION
Addresses #2299.

This PR logs the following usage tracking data:

- Total number of non-admin users enrolled in at least 1 published course.
- Date of the last enrolment by any _non-admin_ user in any _published_ course.
- Date of the first enrolment by any _non-admin_ user in any _published_ course.

## Testing
1. Check that the tests run.
2. Check that `enrolments`, `enrolment_first` and `enrolment_last` are correctly logged in Tracks. The dates come from the _Date Started_ column in _Sensei_ > _Analysis_ when you click on a learner.
3. Try changing published courses to draft courses, and the role of non-admin users to "Administrator", and verify that the count is correctly adjusted.
4. Remove all non-admin users from all courses. Ensure that `enrolments` is 0 and that both `enrolment_first` and `enrolment_last` are N/A.