### PR TITLE
Show post content for paid courses on single course page

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2697,11 +2697,10 @@ class Sensei_Course {
 
 		}
 
-		if ( ( is_user_logged_in() && $is_user_taking_course )
-			|| ( $access_permission && !$has_product_attached) ) {
-
+		if ( ( is_user_logged_in() && $is_user_taking_course ) // Logged in and taking course.
+			|| ( $access_permission && ! $has_product_attached) // Not required to be logged in & no product attached.
+			|| ( ! $access_permission && $has_product_attached ) ) { // Required to be logged in and product attached.
 			// compensate for core providing and empty $content
-
 			if( empty( $content ) ){
 				remove_filter( 'the_content', array( 'Sensei_Course', 'single_course_content') );
 				$course = get_post( get_the_ID() );


### PR DESCRIPTION
Fixes #2314.

This PR shows the post content of a course on the single course page when _Access Permissions_ is selected and the course is attached to a product.

## Testing
- Check the _Access Permissions_ checkbox in _Sensei_ > _Settings_.
- Attach a product to a course.
- View the single course page as a logged out user.
- Ensure that the post content is displayed.