### PR TITLE
Make course categories available via the REST API

### DIFF
--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -437,6 +437,7 @@ class Sensei_PostTypes {
 		$args = array(
 			'hierarchical' => true,
 			'labels' => $labels,
+			'show_in_rest' => true,
 			'show_ui' => true,
 			'query_var' => true,
 			'show_in_nav_menus' => true,


### PR DESCRIPTION
Adjust the `course-categories` taxonomy configuration so that it will be included in the WP REST API and picked up in WordPress 5.0 automatically.

## Testing

With the Gutenberg plugin or WordPress 5.0 installed, browse to a course. You should see _Course Categories_ in the sidebar.