### PR TITLE
Fix escaping of excerpts

### DIFF
--- a/templates/content-course.php
+++ b/templates/content-course.php
@@ -51,7 +51,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			<p class="course-excerpt">
 
-				<?php echo esc_html( get_the_excerpt() ); ?>
+				<?php echo wp_kses_post( get_the_excerpt() ); ?>
 
 			</p>
 

--- a/templates/single-lesson.php
+++ b/templates/single-lesson.php
@@ -58,7 +58,7 @@ if ( have_posts() ) {
 
 				<p>
 
-					<?php echo esc_html( get_the_excerpt() ); ?>
+					<?php echo wp_kses_post( get_the_excerpt() ); ?>
 
 				</p>
 


### PR DESCRIPTION
This fixes some escaping issues with excerpt, which may contain HTML.

## Testing
1. Switch to the Twenty Seventeen theme.
2. Add enough content to a course that it will be truncated wherever an excerpt is shown. Ensure the course does not have an excerpt.
3. Browse to the course archive or course category page and ensure the course description shows a "Continue Reading" link.
4. In _Sensei_ > _Settings_ > _General_, check the _Access Permissions_ checkbox.
5. Add an excerpt to a non-preview lesson.
5. As a logged out user, browse to that lesson.
6. Ensure the excerpt appears as expected.
7. Add a long message, or edit an existing message, so that it will be truncated wherever an excerpt is shown.
8. Browse to the message archive page and ensure the truncated message shows a "Continue Reading" link.