### PR TITLE
Fix visibility of courses on Bulk Learner Actions screen

### DIFF
--- a/includes/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/class-sensei-learners-admin-bulk-actions-view.php
@@ -107,6 +107,8 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends WooThemes_Sensei_List_Tabl
 		$row_data         = apply_filters( 'sensei_learner_admin_get_row_data', $row_data, $item, $this );
 		$escaped_row_data = array();
 
+		add_filter( 'safe_style_css', array( $this, 'get_allowed_css' ) );
+
 		foreach ( $row_data as $key => $data ) {
 			$escaped_row_data[ $key ] = wp_kses(
 				$data,
@@ -129,6 +131,8 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends WooThemes_Sensei_List_Tabl
 				)
 			);
 		}
+
+		remove_filter( 'safe_style_css', array( $this, 'get_allowed_css' ) );
 
 		return $escaped_row_data;
 	}
@@ -286,6 +290,12 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends WooThemes_Sensei_List_Tabl
 
 			return $html . '<div class="learner-course-overview-detail" style="display:none">' . $courses . '</div>';
 		}
+	}
+
+	private function get_allowed_css( $style ) {
+		$styles[] = 'display';
+
+		return $styles;
 	}
 
 	public function parse_query_args() {


### PR DESCRIPTION
WordPress only allows certain `style` attributes as per [this forum post](https://wordpress.stackexchange.com/questions/173526/why-is-wp-kses-not-keeping-style-attributes-as-expected/195433#195433). This PR uses the `safe_style_css` filter to temporarily add `display` to the whitelist.

## Testing
1. Navigate to _Sensei_ > _Learner Management_ > _Bulk Learner Actions_.
2. Ensure the courses that a student is enrolled in are not visible until _...more_ is clicked.