### PR TITLE
Rename data attributes to use dash instead of underscore

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -939,8 +939,8 @@ class Sensei_Lesson {
 				array(
 					'button' => array(
 						'class'                     => array(),
-						'data-uploader_button_text' => array(),
-						'data-uploader_title'       => array(),
+						'data-uploader-button-text' => array(),
+						'data-uploader-title'       => array(),
 						'id'                        => array(),
 					),
 					'input'  => array(
@@ -1159,7 +1159,7 @@ class Sensei_Lesson {
 							// Question media
 							$html     .= '<div>';
 								$html .= '<label for="question_' . esc_attr( $question_counter ) . '_media_button">' . esc_html__( 'Question media:', 'woothemes-sensei' ) . '</label><br/>';
-								$html .= '<button id="question_' . esc_attr( $question_counter ) . '_media_button" class="upload_media_file_button button-secondary" data-uploader_title="' . esc_attr__( 'Add file to question', 'woothemes-sensei' ) . '" data-uploader_button_text="' . esc_attr__( 'Add to question', 'woothemes-sensei' ) . '">' . esc_html( $question_media_add_button ) . '</button>';
+								$html .= '<button id="question_' . esc_attr( $question_counter ) . '_media_button" class="upload_media_file_button button-secondary" data-uploader-title="' . esc_attr__( 'Add file to question', 'woothemes-sensei' ) . '" data-uploader-button-text="' . esc_attr__( 'Add to question', 'woothemes-sensei' ) . '">' . esc_html( $question_media_add_button ) . '</button>';
 								$html .= '<button id="question_' . esc_attr( $question_counter ) . '_media_button_delete" class="delete_media_file_button button-secondary ' . esc_attr( $question_media_delete_class ) . '">' . esc_html__( 'Delete file', 'woothemes-sensei' ) . '</button><br/>';
 								$html .= '<span id="question_' . esc_attr( $question_counter ) . '_media_link" class="question_media_link ' . esc_attr( $question_media_link_class ) . '">' . wp_kses_post( $question_media_link ) . '</span>';
 								$html .= '<br/><img id="question_' . esc_attr( $question_counter ) . '_media_preview" class="question_media_preview ' . esc_attr( $question_media_thumb_class ) . '" src="' . esc_url( $question_media_thumb ) . '" /><br/>';
@@ -1195,8 +1195,8 @@ class Sensei_Lesson {
 				array(
 					'button' => array(
 						'class'                     => array(),
-						'data-uploader_button_text' => array(),
-						'data-uploader_title'       => array(),
+						'data-uploader-button-text' => array(),
+						'data-uploader-title'       => array(),
 						'id'                        => array(),
 					),
 					'input'  => array(
@@ -1286,7 +1286,7 @@ class Sensei_Lesson {
 						// Question media
 						$html     .= '<p>';
 							$html .= '<label for="question_add_new_media_button">' . esc_html__( 'Question media:', 'woothemes-sensei' ) . '</label><br/>';
-							$html .= '<button id="question_add_new_media_button" class="upload_media_file_button button-secondary" data-uploader_title="' . esc_attr__( 'Add file to question', 'woothemes-sensei' ) . '" data-uploader_button_text="' . esc_attr__( 'Add to question', 'woothemes-sensei' ) . '">' . esc_html__( 'Add file', 'woothemes-sensei' ) . '</button>';
+							$html .= '<button id="question_add_new_media_button" class="upload_media_file_button button-secondary" data-uploader-title="' . esc_attr__( 'Add file to question', 'woothemes-sensei' ) . '" data-uploader-button-text="' . esc_attr__( 'Add to question', 'woothemes-sensei' ) . '">' . esc_html__( 'Add file', 'woothemes-sensei' ) . '</button>';
 							$html .= '<button id="question_add_new_media_button_delete" class="delete_media_file_button button-secondary hidden">' . esc_html__( 'Delete file', 'woothemes-sensei' ) . '</button><br/>';
 							$html .= '<span id="question_add_new_media_link" class="question_media_link hidden"></span>';
 							$html .= '<br/><img id="question_add_new_media_preview" class="question_media_preview hidden" src="" /><br/>';

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -170,8 +170,8 @@ class Sensei_Question {
 				array(
 					'button' => array(
 						'class'                     => array(),
-						'data-uploader_button_text' => array(),
-						'data-uploader_title'       => array(),
+						'data-uploader-button-text' => array(),
+						'data-uploader-title'       => array(),
 						'id'                        => array(),
 					),
 					'input'  => array(


### PR DESCRIPTION
Underscores in data attributes don't work with `wp_kses`, so we'll use dashes instead.

## Testing
- In WP admin, navigate to a lesson and add media to an existing quiz question or to a new quiz question. Confirm that the media is added.
- In DevTools, check that the `data-uploader-button-text` and `data-uploader-title` attributes appear on the "Change file" (for a question with existing media) and "Add file" (for a new question) buttons.

_Note that adding question media worked prior to this change, but the data attributes were not attached to the elements._