### PR TITLE
Use updated lesson data when updating quiz

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -455,11 +455,15 @@ class Sensei_Lesson {
 
 		 // Sanitize and setup the post data
 		$_POST = stripslashes_deep( $_POST );
+
+		// Retrieve the update lesson.
+		$lesson = get_post( $post_id );
+
 		if ( isset( $_POST['quiz_id'] ) && ( 0 < absint( $_POST['quiz_id'] ) ) ) {
 			$quiz_id = absint( $_POST['quiz_id'] );
 		} // End If Statement
-		$post_title   = esc_html( $_POST['post_title'] );
-		$post_status  = esc_html( $_POST['post_status'] );
+		$post_title   = esc_html( $lesson->post_title );
+		$post_status  = esc_html( $lesson->post_status );
 		$post_content = '';
 
 		// Setup Query Arguments

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2769,7 +2769,6 @@ class Sensei_Lesson {
 		} // End If Statement
 
 		$post_title  = $question_text;
-		$post_author = $data['post_author'];
 		$post_status = 'publish';
 		$post_type   = 'question';
 		// Handle the extended question text


### PR DESCRIPTION
Using the `$_POST` data led to inconsistent results after updating to 5.0. This method is tied to `save_post` so the lesson data will be updated by the time it fires.

## Testing
1) Enable `WP_DEBUG` and error logging.
1) Using WordPress 5.0 or the Gutenberg plugin, edit a lesson with a quiz. 
1) Give the lesson a new title.
1) Verify the quiz `post_title` was updated on the quiz and no PHP errors are output or shown in log.

Before, this error would be given:
```
[21-Nov-2018 16:24:26 UTC] PHP Notice:  Undefined index: post_title in /var/www/html/wp-content/plugins/woothemes-sensei/includes/class-sensei-lesson.php on line 461
[21-Nov-2018 16:24:26 UTC] PHP Stack trace:
[21-Nov-2018 16:24:26 UTC] PHP   1. {main}() /var/www/html/wp-admin/post.php:0
[21-Nov-2018 16:24:26 UTC] PHP   2. edit_post() /var/www/html/wp-admin/post.php:199
[21-Nov-2018 16:24:26 UTC] PHP   3. wp_update_post() /var/www/html/wp-admin/includes/post.php:377
[21-Nov-2018 16:24:26 UTC] PHP   4. wp_insert_post() /var/www/html/wp-includes/post.php:3820
[21-Nov-2018 16:24:26 UTC] PHP   5. do_action() /var/www/html/wp-includes/post.php:3747
[21-Nov-2018 16:24:26 UTC] PHP   6. WP_Hook->do_action() /var/www/html/wp-includes/plugin.php:453
[21-Nov-2018 16:24:26 UTC] PHP   7. WP_Hook->apply_filters() /var/www/html/wp-includes/class-wp-hook.php:310
[21-Nov-2018 16:24:26 UTC] PHP   8. WooThemes_Sensei_Lesson->quiz_update() /var/www/html/wp-includes/class-wp-hook.php:288
```