### PR TITLE
Fix label escaping on WP.com

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -474,6 +474,11 @@ class Sensei_Course {
 				wp_kses_allowed_html( 'post' ),
 				self::$allowed_html,
 				array(
+					// Explicitly allow label tag for WP.com.
+					'label'    => array(
+						'class' => array(),
+						'for'   => array(),
+					),
 					'textarea' => array(
 						'cols'     => array(),
 						'id'       => array(),

--- a/includes/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/class-sensei-learners-admin-bulk-actions-view.php
@@ -127,6 +127,11 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends WooThemes_Sensei_List_Tabl
 							'type'  => array(),
 							'value' => array(),
 						),
+						// Explicitly allow label tag for WP.com.
+						'label' => array(
+							'class' => array(),
+							'for'   => array(),
+						),
 					)
 				)
 			);

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -970,7 +970,8 @@ class Sensei_Lesson {
 					),
 					// Explicitly allow label tag for WP.com.
 					'label'  => array(
-						'for' => array(),
+						'class' => array(),
+						'for'   => array(),
 					),
 					'option' => array(
 						'value' => array(),
@@ -1235,7 +1236,8 @@ class Sensei_Lesson {
 					),
 					// Explicitly allow label tag for WP.com.
 					'label'  => array(
-						'for' => array(),
+						'class' => array(),
+						'for'   => array(),
 					),
 					// Explicitly allow textarea tag for WP.com.
 					'textarea' => array(
@@ -1243,6 +1245,7 @@ class Sensei_Lesson {
 						'id'    => array(),
 						'name'  => array(),
 						'rows'  => array(),
+					),
 				)
 			)
 		);
@@ -1866,6 +1869,11 @@ class Sensei_Lesson {
 						'type'    => array(),
 						'value'   => array(),
 					),
+					// Explicitly allow label tag for WP.com.
+					'label' => array(
+						'class' => array(),
+						'for'   => array(),
+					),
 					// Explicitly allow textarea tag for WP.com.
 					'textarea' => array(
 						'class' => array(),
@@ -1912,6 +1920,10 @@ class Sensei_Lesson {
 			array_merge(
 				wp_kses_allowed_html( 'post' ),
 				array(
+					// Explicitly allow label tag for WP.com.
+					'label' => array(
+						'for' => array(),
+					),
 					// Explicitly allow textarea tag for WP.com.
 					'textarea' => array(
 						'class' => array(),

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2012,6 +2012,10 @@ class Sensei_Lesson {
 						'type'        => array(),
 						'value'       => array(),
 					),
+					// Explicitly allow label tag for WP.com.
+					'label'    => array(
+						'for' => array(),
+					),
 					'option'   => array(
 						'selected' => array(),
 						'value'    => array(),

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3645,7 +3645,7 @@ class Sensei_Lesson {
 		$html .= '<span class="input-text-wrap">';
 		$html .= $field;
 		$html .= '</span>';
-		$html .= '</label></div>';
+		$html .= '</div>';
 
 		return wp_kses(
 			$html,

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -198,6 +198,10 @@ class Sensei_Lesson {
 						'type'  => array(),
 						'value' => array(),
 					),
+					// Explicitly allow label tag for WP.com.
+					'label'    => array(
+						'for' => array(),
+					),
 					'option'   => array(
 						'selected' => array(),
 						'value'    => array(),
@@ -311,6 +315,10 @@ class Sensei_Lesson {
 						'name'    => array(),
 						'type'    => array(),
 						'value'   => array(),
+					),
+					// Explicitly allow label tag for WP.com.
+					'label' => array(
+						'for' => array(),
 					),
 				)
 			)
@@ -790,6 +798,10 @@ class Sensei_Lesson {
 						'type'  => array(),
 						'value' => array(),
 					),
+					// Explicitly allow label tag for WP.com.
+					'label'    => array(
+						'for' => array(),
+					),
 					'optgroup' => array(
 						'label' => array(),
 					),
@@ -956,7 +968,11 @@ class Sensei_Lesson {
 						'type'        => array(),
 						'value'       => array(),
 					),
-					'option'   => array(
+					// Explicitly allow label tag for WP.com.
+					'label'  => array(
+						'for' => array(),
+					),
+					'option' => array(
 						'value' => array(),
 					),
 					'select'   => array(
@@ -1217,13 +1233,16 @@ class Sensei_Lesson {
 						'type'    => array(),
 						'value'   => array(),
 					),
+					// Explicitly allow label tag for WP.com.
+					'label'  => array(
+						'for' => array(),
+					),
 					// Explicitly allow textarea tag for WP.com.
 					'textarea' => array(
 						'class' => array(),
 						'id'    => array(),
 						'name'  => array(),
 						'rows'  => array(),
-					),
 				)
 			)
 		);

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -190,6 +190,10 @@ class Sensei_Messages {
 						'type'        => array(),
 						'value'       => array(),
 					),
+					// Explicitly allow label tag for WP.com.
+					'label'    => array(
+						'for' => array(),
+					),
 					'option'   => array(
 						'selected' => array(),
 						'value'    => array(),

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -189,7 +189,8 @@ class Sensei_Question {
 					),
 					// Explicitly allow label tag for WP.com.
 					'label'  => array(
-						'for' => array(),
+						'class' => array(),
+						'for'   => array(),
 					),
 					'option' => array(
 						'value' => array(),

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -187,7 +187,11 @@ class Sensei_Question {
 						'type'        => array(),
 						'value'       => array(),
 					),
-					'option'   => array(
+					// Explicitly allow label tag for WP.com.
+					'label'  => array(
+						'for' => array(),
+					),
+					'option' => array(
 						'value' => array(),
 					),
 					'select'   => array(

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -626,6 +626,10 @@ class Sensei_Settings_API {
 				array_merge(
 					wp_kses_allowed_html( 'post' ),
 					array(
+						// Explicitly allow label tag for WP.com.
+						'label' => array(
+							'for' => array(),
+						),
 						'input' => array(
 							'checked' => array(),
 							'class'   => array(),


### PR DESCRIPTION
## Testing
- Browse to a course and check that the _Video Embed Code_ label in the _Course Video_ meta box is not visible. (The meta box heading serves as the label.)
- In _Learner Management_, click on _Bulk Learner Actions_. Ensure the first column in each row is a checkbox.
- In _Settings_ > _Email Notifications_, ensure the checkbox elements are wrapped inside `label`s (or just click the checkbox text and ensure the checkbox is toggled).
- In the _Message Information_ meta box of a message, check that each field value is wrapped in a `label` tag.

### Lessons
- In the _Quiz Settings_, ensure that each setting is wrapped inside a `label` tag.
- In the _Lesson Information_ meta box, check that each field label is actually a `label` element.
- In the _Preview_ meta box, ensure that the checkbox is wrapped inside a `label` tag.
- In the _Course_ meta box, click _Add New Course_. Ensure that each field label is actually a `label` element.

### Questions
- When adding a new question to a quiz, or editing an existing question, ensure that _Question_, _Question Description_, _Question Type_, _Question Category_, _Question Grade_, _Randomise answer order_ and _Question Media_ are wrapped in a `label` tag.
- On the _Add New Question_ screen, ensure that _Question_, _Question Description_, _Question Type_, _Question Grade_, _Randomise answer order_ and _Question Media_ are wrapped in a `label` tag.

### Question Types
When adding/editing questions to a quiz or in the _Questions_ CPT, ensure that the following fields are wrapped in a `label` element:
- Multiple Choice: Right, Wrong, Answer Feedback
- True/ False: Right, Wrong, Answer Feedback
- Gap Fill: Text before the Gap, The Gap, Text after the Gap, and Preview
- Multi Line: Guide/Teacher Notes
- Single Line: Recommended Answer
- File Upload: Description and Guide/Teacher Notes