### PR TITLE
Fix bug: Change progress status to Completed in Modules

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -819,6 +819,7 @@ class Sensei_Core_Modules {
 	 * @return mixed              Module progress percentage on success, false on failure
 	 */
 	public function get_user_module_progress( $module_id = 0, $course_id = 0, $user_id = 0 ) {
+		$this->save_user_module_progress ( $module_id, $course_id, $user_id);
 		$module_progress = get_user_meta( intval( $user_id ), '_module_progress_' . intval( $course_id ) . '_' . intval( $module_id ), true );
 		if ( $module_progress ) {
 			return (float) $module_progress;


### PR DESCRIPTION
### Issue

As stated in issue #2313 the status doesn't change from "In Progress" to "Completed" even if all modules are marked completed.

### Problem description
The template-function.php file calls the get_user_module_progress() function from the class-sensei-modules.php.  The resulting progress number is determining the output for the progress tab on the page. The problem is that when the get_user_module_progress() runs it doesn't get the correct input.

### Solution
To solve this I have added one line of code, calling a function to make sure that the progress data is up to date and saved to the metadata, so the input is correct before it's processed and sent back to determine the status of the module.

<img width="482" alt="sens1" src="https://user-images.githubusercontent.com/31791243/48970640-bb45e900-f049-11e8-95e4-722057f37c87.png">
<img width="457" alt="sens2" src="https://user-images.githubusercontent.com/31791243/48970644-c6991480-f049-11e8-86a4-94ece6978042.png">

### Test
To test load a page with all completed lessons  and also add new lessons and mark them as completed to check correct functionaity.
