### PR TITLE
Fix: Learner management tool to add multiple users

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -605,19 +605,22 @@ class Sensei_Learner_Management {
 		}
 
 		$post_type = $_POST['add_post_type'];
-		$user_id   = absint( $_POST['add_user_id'] );
+		$user_id   =  $_REQUEST['add_user_id'] ;
 		$course_id = absint( $_POST['add_course_id'] );
 		$lesson_id = isset( $_POST['add_lesson_id'] ) ? $_POST['add_lesson_id'] : '';
 
 		switch ( $post_type ) {
 			case 'course':
-				$result = Sensei_Utils::user_start_course( $user_id, $course_id );
+				for ( $i = 0; $i < count($user_id); $i++ ) {
+					if ( $user_id[$i] !== 0 ) { //
+						$result = Sensei_Utils::user_start_course( $user_id[$i], $course_id );
 
 				// Complete each lesson if course is set to be completed.
-				if ( isset( $_POST['add_complete_course'] ) && 'yes' === $_POST['add_complete_course'] ) {
-					Sensei_Utils::force_complete_user_course( $user_id, $course_id );
-				}
-
+					if ( isset( $_POST['add_complete_course'] ) && 'yes' === $_POST['add_complete_course'] ) {
+						Sensei_Utils::force_complete_user_course( $user_id[$i], $course_id );
+					}
+					}
+				};
 				break;
 
 			case 'lesson':
@@ -626,8 +629,11 @@ class Sensei_Learner_Management {
 					$complete = true;
 				}
 
-				$result = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id, $complete );
-
+				for ( $i = 0; $i < count($user_id); $i++ ) {
+					if ( $user_id[$i] !== 0 ) {
+						$result = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id[$i], $complete ); //add user to lesson
+					}
+				};
 				break;
 		}
 

--- a/includes/class-sensei-learners-main.php
+++ b/includes/class-sensei-learners-main.php
@@ -776,7 +776,7 @@ class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
 			<div class="inside">
 				<form name="add_learner" action="" method="post">
 					<p>
-						<select name="add_user_id" id="add_learner_search" multiple="multiple" style="min-width:300px;">
+						<select name="add_user_id[]" id="add_learner_search" multiple="multiple" style="min-width:300px;">
 							<option value="0" selected="selected"><?php esc_html_e( 'Find learner', 'woothemes-sensei' ); ?></option>
 						</select>
 						<?php if ( 'lesson' == $form_post_type ) { ?>


### PR DESCRIPTION
*Fixes issue #2288 

Issue:
In Learner Management -> Add Learner, the text area allows you to enter more than learner, but actually only adds one learner (the last learner on the list)

Fixes the issue by returning user ids in an array, then looping through the users to add them to the list.

Testing:
1. Go to Learner Management
2. Click on a course
3. Add multiple learners to course
4. Multiple learners should all be added

Fixed example here:
[https://streamable.com/3kibh](url)