### PR TITLE
Learner Management: Allow manual adjustment of learner start date

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -425,10 +425,7 @@ class Sensei_Learner_Management {
 		if ( false === $date ) {
 			exit( '' );
 		}
-		$mysql_date = date( 'Y-m-d H:i:s', $date->getTimestamp() );
-		if ( false === $mysql_date ) {
-			exit( '' );
-		}
+		$mysql_date = date( 'Y-m-d', $date->getTimestamp() );
 
 		$updated = update_comment_meta( $comment_id, 'start', $mysql_date, $date_started );
 


### PR DESCRIPTION
Fixes issue #2226 

Allows you to adjust the start date of a course for a learner in the learner management page either through the calendar UI or manually adjusting the date yourself. This fixes the discrepancy between the database only accepting the date without the time stamp vs. needing the time stamp for manual adjustment. Not sure if the time stamp was there as a security measure to prevent people from adjusting the date manually, but if we wish to keep the time stamp, the database would need to be updated accordingly.

Steps to reproduce:

- Open the Learner Management page for a course.
- In the text field for editing a learner's start date, modify one of the numbers (e.g. the month) without using the calendar UI.
- Click Edit Start Date- notice that the start date is not updated.

(When using the calendar UI instead, or manually removing the time string when editing, it updates as expected.)