### PR TITLE
Colors and text field setting descriptions can contain HTML

### DIFF
--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -447,7 +447,7 @@ class Sensei_Settings_API {
 
 		echo '<input id="' . esc_attr( $args['key'] ) . '" name="' . esc_attr( $this->token ) . '[' . esc_attr( $args['key'] ) . ']" size="40" type="text" value="' . esc_attr( $options[ $args['key'] ] ) . '" />' . "\n";
 		if ( isset( $args['data']['description'] ) ) {
-			echo '<span class="description">' . esc_html( $args['data']['description'] ) . '</span>' . "\n";
+			echo '<span class="description">' . wp_kses_post( $args['data']['description'] ) . '</span>' . "\n";
 		}
 	} // End form_field_text()
 
@@ -465,7 +465,7 @@ class Sensei_Settings_API {
 		echo '<input id="' . esc_attr( $args['key'] ) . '" name="' . esc_attr( $this->token ) . '[' . esc_attr( $args['key'] ) . ']" size="40" type="text" class="color" value="' . esc_attr( $options[ $args['key'] ] ) . '" />' . "\n";
 		echo '<div style="position:absolute;background:#FFF;z-index:99;border-radius:100%;" class="colorpicker"></div>';
 		if ( isset( $args['data']['description'] ) ) {
-			echo '<span class="description">' . esc_html( $args['data']['description'] ) . '</span>' . "\n";
+			echo '<span class="description">' . wp_kses_post( $args['data']['description'] ) . '</span>' . "\n";
 		}
 	} // End form_field_text()
 


### PR DESCRIPTION
## Testing
Browse to _Sensei_ > _Settings_ > _Email Notifications_ and ensure the setting descriptions appear as in the _After_ screenshot.

## Before
![screen shot 2018-11-27 at 8 57 02 am](https://user-images.githubusercontent.com/1190420/49086419-76c17580-f222-11e8-87bb-ae1ae63f93ae.jpg)

## After
![screen shot 2018-11-27 at 8 58 10 am](https://user-images.githubusercontent.com/1190420/49086471-948eda80-f222-11e8-9e2f-8ad3f835cddb.jpg)
