### PR TITLE
Move WooCommerce integration for Core into 3rd-party directory

### DIFF
--- a/includes/3rd-party/3rd-party.php
+++ b/includes/3rd-party/3rd-party.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Load 3rd party compatibility tweaks.
+ *
+ * @package 3rd-Party
+ */
+
+// Require compatibility files.
+require_once dirname( __FILE__ ) . '/woocommerce.php';

--- a/includes/3rd-party/woocommerce.php
+++ b/includes/3rd-party/woocommerce.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Adds additional compatibility with WooCommerce.
+ *
+ * @package 3rd-Party
+ */
+
+/**
+ * Allow Teachers to access the admin area when WooCommerce is installed.
+ *
+ * @param  bool $prevent_access Whether to prevent access to WP Admin.
+ * @return bool
+ */
+function sensei_woocommerce_prevent_admin_access( $prevent_access ) {
+	if ( current_user_can( 'manage_sensei_grades' ) ) {
+		return false;
+	}
+
+	return $prevent_access;
+}
+add_filter( 'woocommerce_prevent_admin_access', 'sensei_woocommerce_prevent_admin_access' );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -77,9 +77,6 @@ class Sensei_Admin {
 		// warn users in case admin_email is not a real WP_User
 		add_action( 'admin_notices', array( $this, 'notify_if_admin_email_not_real_admin_user' ) );
 
-		// Allow Teacher access the admin area
-		add_filter( 'woocommerce_prevent_admin_access', array( $this, 'admin_access' ) );
-
 		// remove a course from course order when trashed
 		add_action( 'transition_post_status', array( $this, 'remove_trashed_course_from_course_order' ) );
 
@@ -1680,21 +1677,6 @@ class Sensei_Admin {
 					break;
 			}
 		}
-	}
-
-	/**
-	 * Set Sensei users access to the admin area when WooCommerce is installed
-	 * Allow Teachers to access the admin area
-	 *
-	 * @param  bool $prevent_access
-	 * @return bool
-	 */
-	public function admin_access( $prevent_access ) {
-		if ( current_user_can( 'manage_sensei_grades' ) ) {
-			return false;
-		}
-
-		return $prevent_access;
 	}
 
 	/**

--- a/includes/class-sensei-bootstrap.php
+++ b/includes/class-sensei-bootstrap.php
@@ -54,5 +54,6 @@ class Sensei_Bootstrap {
 	private function init_must_have_includes() {
 		require_once dirname( __FILE__ ) . '/lib/woo-functions.php';
 		require_once dirname( __FILE__ ) . '/sensei-functions.php';
+		require_once dirname( __FILE__ ) . '/3rd-party/3rd-party.php';
 	}
 }


### PR DESCRIPTION
This WooCommerce integration code is not related to Course purchases, and is theoretically* still required in Sensei.

This PR moves the WooCommerce integration code into its own 3rd-party integration file. This is a pattern that is used in WPJM and Jetpack, for example, and would be a good place for us to put these sorts of integrations in the future.

*There is a caveat! This is actually dead code. Because a teacher is able to [edit posts](https://github.com/Automattic/sensei/blob/3fc3b2f35ba9cfffcce3f65f26b90dd8a89ac35b/includes/class-sensei-teacher.php#L200), the WooCommerce filter [isn't actually needed](https://github.com/woocommerce/woocommerce/blob/b70fed6868bd4fdd2d5fb0a1bad58b7200527dee/includes/admin/class-wc-admin.php#L173). However, if that cap is ever removed in the future (or in custom code) this functionality is needed in order to allow teachers to access WP Admin. However, one could make an argument for removing it entirely.

My vote is to apply this PR as-is, effectively leaving the code as-is but moving it to its own file. But I'm open to other thoughts.

## Testing

- Log in as a teacher.
- Make sure you can log into WP Admin.