### PR TITLE
Stub out Sensei_WC classes if needed

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -205,10 +205,9 @@ class Sensei_Main {
 	 */
 	private function __construct( $main_plugin_file_name, $args ) {
 
-		// Disable Sensei if WC Paid Courses is not installed and activated.
+		// Stub Sensei_WC classes if WC Paid Courses is not installed and activated.
 		if ( ! self::is_sensei_wc_paid_courses_activated() ) {
-			error_log( 'Sensei WC Paid Courses not activated! Please activate before using Sensei 2.0-dev' );
-			return;
+			require_once dirname( __FILE__) . '/sensei-wc-stubs.php';
 		}
 
 		// Setup object data

--- a/includes/sensei-wc-stubs.php
+++ b/includes/sensei-wc-stubs.php
@@ -1,0 +1,17 @@
+<?php
+/*
+ * TODO: These are stub classes to make the tests pass while developing 2.0.
+ * Before 2.0 is released, these should be removed.
+ */
+class Sensei_WC {
+	public static function is_woocommerce_active() { return false; }
+	public static function is_woocommerce_present() { return false; }
+	public static function load_woocommerce_integration_hooks() {}
+}
+class Sensei_WC_Memberships {
+	public static function is_wc_memberships_active() { return false; }
+	public static function load_wc_memberships_integration_hooks() {}
+}
+class Sensei_WC_Subscriptions {
+	public static function load_wc_subscriptions_integration_hooks() {}
+}


### PR DESCRIPTION
This replaces the previous solution of disabling Sensei when WooCommerce Paid Courses is not active. This way we can test Sensei without WCPC, and the PHPUnit tests will pass as well.

## Testing instructions

- Run all of the PHPUnit tests and ensure that they run and pass.
- Try using Sensei without WooCommerce Paid Courses enabled, and ensure that it loads and works.