### PR TITLE
Update PHP version for CI to 5.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,11 @@ jobs:
       script:
         - ./tests/bin/run-wp-unit-tests.sh
     - stage: test
+      php: 5.6
+      env: WP_VERSION=latest WP_MULTISITE=1
+      script:
+      - ./tests/bin/run-wp-unit-tests.sh
+    - stage: test
       script:
         - npm install
         - npx eslint --config .eslintrc.wpcom.json --ignore-path .eslintignore-wpcom .

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,18 +70,6 @@ jobs:
       script:
         - ./tests/bin/run-wp-unit-tests.sh
     - stage: test
-      php: 5.3
-      env: WP_VERSION=latest
-      dist: precise
-      script:
-        - ./tests/bin/run-wp-unit-tests.sh
-    - stage: test
-      php: 5.3
-      env: WP_VERSION=latest WP_MULTISITE=1
-      dist: precise
-      script:
-      - ./tests/bin/run-wp-unit-tests.sh
-    - stage: test
       script:
         - npm install
         - npx eslint --config .eslintrc.wpcom.json --ignore-path .eslintignore-wpcom .

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -28,7 +28,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 	<!-- For help in understanding this testVersion:
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.2-"/>
+	<config name="testVersion" value="5.6-"/>
 
 	<!-- Rules: WordPress Coding Standards - see
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->


### PR DESCRIPTION
Since WP will be updating its minimum PHP version to 5.6, we are starting to use language features from that version, and should not check for incompatibilities with lower versions.

This PR removes the phpcs check for 5.2 language compatibility, and removes the CI test runs on the 5.3 environment.