### PR TITLE
Only apply logic for paid and free courses when WCPC is active

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -698,7 +698,8 @@ class Sensei_Course {
 			case 'freecourses':
 				_doing_it_wrong(
 					__FUNCTION__,
-					sprintf( __( 'Queries for course type of %s is deprecated.', 'woothemes-sensei' ), 'freecourses' ),
+					// translators: string argument is "freecourses" (the query type).
+					sprintf( esc_html__( 'Queries for course type of %s is deprecated.', 'woothemes-sensei' ), 'freecourses' ),
 					'2.0.0'
 				);
 
@@ -722,7 +723,8 @@ class Sensei_Course {
 			case 'paidcourses':
 				_doing_it_wrong(
 					__FUNCTION__,
-					sprintf( __( 'Queries for course type of %s is deprecated.', 'woothemes-sensei' ), 'paidcourses' ),
+					// translators: string argument is "paidcourses" (the query type).
+					sprintf( esc_html__( 'Queries for course type of %s is deprecated.', 'woothemes-sensei' ), 'paidcourses' ),
 					'2.0.0'
 				);
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -696,6 +696,12 @@ class Sensei_Course {
 				break;
 
 			case 'freecourses':
+				_doing_it_wrong(
+					__FUNCTION__,
+					sprintf( __( 'Queries for course type of %s is deprecated.', 'woothemes-sensei' ), 'freecourses' ),
+					'2.0.0'
+				);
+
 				$post_args = array(
 					'post_type'        => 'course',
 					'orderby'          => $orderby,
@@ -714,6 +720,12 @@ class Sensei_Course {
 				break;
 
 			case 'paidcourses':
+				_doing_it_wrong(
+					__FUNCTION__,
+					sprintf( __( 'Queries for course type of %s is deprecated.', 'woothemes-sensei' ), 'paidcourses' ),
+					'2.0.0'
+				);
+
 				$post_args = array(
 					'post_type'        => 'course',
 					'orderby'          => $orderby,

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -692,7 +692,9 @@ class Sensei_Course {
 					'exclude'          => $excludes,
 					'suppress_filters' => 0,
 				);
+
 				break;
+
 			case 'freecourses':
 				$post_args = array(
 					'post_type'        => 'course',
@@ -702,8 +704,12 @@ class Sensei_Course {
 					'exclude'          => $excludes,
 					'suppress_filters' => 0,
 				);
-				// Sub Query to get all WooCommerce Products that have Zero price
-				$post_args['meta_query'] = Sensei_WC::get_free_courses_meta_query_args();
+
+				// If WooCommerce Paid Courses is not active, we will display all courses.
+				if ( class_exists( 'Sensei_WC_Paid_Courses\Sensei_WC_Paid_Courses' ) ) {
+					// Sub Query to get all WooCommerce Products that have Zero price
+					$post_args['meta_query'] = Sensei_WC::get_free_courses_meta_query_args();
+				}
 
 				break;
 
@@ -717,8 +723,13 @@ class Sensei_Course {
 					'suppress_filters' => 0,
 				);
 
-				// Sub Query to get all WooCommerce Products that have price greater than zero
-				$post_args['meta_query'] = Sensei_WC::get_paid_courses_meta_query_args();
+				// If WooCommerce Paid Courses is not active, we will display no courses.
+				if ( class_exists( 'Sensei_WC_Paid_Courses\Sensei_WC_Paid_Courses' ) ) {
+					// Sub Query to get all WooCommerce Products that have price greater than zero
+					$post_args['meta_query'] = Sensei_WC::get_paid_courses_meta_query_args();
+				} else {
+					$post_args['post__in'] = array( -1 );
+				}
 
 				break;
 


### PR DESCRIPTION
This one is tricky.

The logic specifically related to paid and free courses seems to only be used for legacy purposes. But this is complicated by the fact that it is in a function with other course query logic that is _not_ related to paid or free courses. Plus the function itself is public, and may be used by third-party code (it is used by Sensei Certificated, for example).

I don't want to make the 2.0 work more complex than it needs to be. Given that, and the fact that this seems to be solely used by legacy code, I'm thinking that a relatively simple solution might be warranted in this case. That said, I'll be explicit here about why I made the choices I did, for posterity, and we can discuss and change our strategy if we want to.

_Note: the linter issues in CI will be fixed by https://github.com/Automattic/sensei/pull/2390_

## Notes

- The reference to "paid" and "free" courses comes from `Sensei_Course::get_archive_query_args`. This method is used by `Sensei_Courses::course_query`.
- The `course_query` method is only used in a few places:
  - In `Sensei_Course`, it is used to load the user's courses. [#](https://github.com/Automattic/sensei/blob/5f9c14ebf1e1210802b2c75ce4a7b86014df5030/includes/class-sensei-course.php#L1285-L1292)
  - It is used by the `Sensei_Legacy_Shortcodes` class for the various shortcodes supported by that class. [#](https://github.com/Automattic/sensei/blob/5f9c14ebf1e1210802b2c75ce4a7b86014df5030/includes/shortcodes/class-sensei-legacy-shortcodes.php#L270)
  - It is used by Sensei Certificates to load the user's courses. [#](https://github.com/woocommerce/sensei-certificates/blob/0eaf685cbe7ab6dc0333be614bd6c750a8233aa9/classes/class-woothemes-sensei-certificates.php#L516)
- Similarly, the `get_archive_query_args` method is only used in a couple places:
  - It is used from within `course_query`. [#](https://github.com/Automattic/sensei/blob/5f9c14ebf1e1210802b2c75ce4a7b86014df5030/includes/class-sensei-course.php#L629)
  - It is used by `Sensei_Legacy_Shortcodes`. [#](https://github.com/Automattic/sensei/blob/5f9c14ebf1e1210802b2c75ce4a7b86014df5030/includes/shortcodes/class-sensei-legacy-shortcodes.php#L230)
- There are two more references to `paidcourses`, which both appear to be related to the legacy shortcodes:
  - We check for an `action` of `paidcourses` [here](https://github.com/Automattic/sensei/blob/5f9c14ebf1e1210802b2c75ce4a7b86014df5030/includes/class-sensei-frontend.php#L591), which seems to be related to [this functionality](https://github.com/Automattic/sensei/blob/5f9c14ebf1e1210802b2c75ce4a7b86014df5030/includes/shortcodes/class-sensei-legacy-shortcodes.php#L124) in legacy shortcodes (which doesn't seem to work anymore).
  - We check for legacy shortcodes [here](https://github.com/Automattic/sensei/blob/5f9c14ebf1e1210802b2c75ce4a7b86014df5030/includes/class-sensei-posttypes.php#L198) for some backwards compatibility code.

## Proposed solution

I originally considered moving the query logic into a filter. This way WCPC could add the functionality for Free and Paid courses.

I decided against that because of the fact that this seems to only be used by legacy code, and I'm thinking that it should all eventually be deprecated and removed anyway.

The solution I opted for then, is as follows:

- When the method is called for `paidcourses` or `freecourses`, first check to see whether WCPC is active.
- If it is, call the function from `Sensei_WC` as before.
- If not, then return _all_ courses for `freecourses`, and _no_ courses for `paidcourses`.
- In any case, print a warning stating that using this method with `freecourses` or `paidcourses` is deprecated.

## Testing instructions

- Ensure that both Sensei and WooCommerce Paid Courses are active.
- Create at least one free course, and at least one paid course.
- Create a page or post with the legacy shortcode `[freecourses]`.
- Ensure that page shows only the free courses.
- Disable WCPC. Ensure the page shows all courses.
- Enable WCPC.
- Create a page or post with the legacy shortcode `[paidcourses]`.
- Ensure that page shows only the paid courses.
- Disable WCPC. Ensure the page shows no courses.