### PR TITLE
Add ability to prevent loading of WC Stubs

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -225,7 +225,7 @@ class Sensei_Main {
 			if ( self::activating_sensei_wc_paid_courses() ) {
 				// Do not load Sensei until after WC Paid Courses is activated.
 				return;
-			} else {
+			} elseif ( ! defined( 'LOAD_WC_STUBS' ) || LOAD_WC_STUBS ) {
 				require_once dirname( __FILE__ ) . '/sensei-wc-stubs.php';
 			}
 		}


### PR DESCRIPTION
To get tests working again in WCPC, we'll need to be able to prevent the loading of WC stubs.

I'm going to add this in the `bootstrap.php` file for WCPC:
```
define( 'LOAD_WC_STUBS', false );
```