### PR TITLE
Extract purchase logic for Course Signup Link on a Lesson

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4116,7 +4116,7 @@ class Sensei_Lesson {
 			 * @param string $notice_level Notice level to use for the shown alert (alert, tick, download, info).
 			 * @param int    $course_id    Post ID for the course.
 			 */
-			$notice_level = apply_filters( 'sensei_lesson_show_course_signup_notice_level', 'alert', $course_id );
+			$notice_level = apply_filters( 'sensei_lesson_course_signup_notice_level', 'alert', $course_id );
 			Sensei()->notices->add_notice( $message, $notice_level );
 			echo '</section>';
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4115,7 +4115,7 @@ class Sensei_Lesson {
 			 * @param string $notice_level Notice level to use for the shown alert (alert, tick, download, info).
 			 * @param int    $course_id    Post ID for the course.
 			 */
-			$notice_level = apply_filters( 'sensei_lesson_course_signup_notice_level', 'alert', $course_id );
+			$notice_level = apply_filters( 'sensei_lesson_course_signup_notice_level', 'info', $course_id );
 			Sensei()->notices->add_notice( $message, $notice_level );
 		}
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4074,74 +4074,53 @@ class Sensei_Lesson {
 
 		$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
 
-		if ( empty( $course_id ) || 'course' != get_post_type( $course_id ) || sensei_all_access() || Sensei_Utils::is_preview_lesson( get_the_ID() ) ) {
-
+		if ( empty( $course_id ) || 'course' !== get_post_type( $course_id ) || sensei_all_access() || Sensei_Utils::is_preview_lesson( get_the_ID() ) ) {
 			return;
-
 		}
 
-		?>
+		$show_course_signup_notice = sensei_is_login_required() && ! Sensei_Utils::user_started_course( $course_id, get_current_user_id() );
 
-		<section class="course-signup lesson-meta">
+		/**
+		 * Filter for if we should show the course sign up notice on the lesson page.
+		 *
+		 * @since 2.0.0
+		 *
+		 * @param bool $show_course_signup_notice Should we show course sign up notice?
+		 * @param int  $course_id                 Post ID for the course.
+		 */
+		if ( apply_filters( 'sensei_lesson_show_course_signup_notice', $show_course_signup_notice, $course_id ) ) {
+			echo '<section class="course-signup lesson-meta">';
+			$course_link  = '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr__( 'Sign Up', 'woothemes-sensei' ) . '">';
+			$course_link .= esc_html__( 'course', 'woothemes-sensei' );
+			$course_link .= '</a>';
 
-			<?php
+			// translators: Placeholder is a link to the Course.
+			$message_default = sprintf( esc_html__( 'Please sign up for the %1$s before starting the lesson.', 'woothemes-sensei' ), $course_link );
 
-			global $current_user;
-			$wc_post_id = (int) get_post_meta( $course_id, '_course_woocommerce_product', true );
+			/**
+			 * Filter the course sign up notice message on the lesson page.
+			 *
+			 * @since 2.0.0
+			 *
+			 * @param string $message     Should we show course sign up notice?
+			 * @param int    $course_id   Post ID for the course.
+			 * @param string $course_link Generated HTML link to the course.
+			 */
+			$message = apply_filters( 'sensei_lesson_course_signup_notice_message', $message_default, $course_id, $course_link );
 
-			if ( Sensei_WC::is_woocommerce_active() && Sensei_WC::is_course_purchasable( $course_id ) ) {
+			/**
+			 * Filter the course sign up notice message alert level on the lesson page.
+			 *
+			 * @since 2.0.0
+			 *
+			 * @param string $notice_level Notice level to use for the shown alert (alert, tick, download, info).
+			 * @param int    $course_id    Post ID for the course.
+			 */
+			$notice_level = apply_filters( 'sensei_lesson_show_course_signup_notice_level', 'alert', $course_id );
+			Sensei()->notices->add_notice( $message, $notice_level );
+			echo '</section>';
+		}
 
-				if ( is_user_logged_in() && ! Sensei_Utils::user_started_course( $course_id, $current_user->ID ) ) {
-
-						$a_element  = '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr__( 'Sign Up', 'woothemes-sensei' ) . '">';
-						$a_element .= esc_html__( 'course', 'woothemes-sensei' );
-						$a_element .= '</a>';
-
-						// translators: Placeholder is a link to the Course.
-						$message = sprintf( esc_html__( 'Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $a_element );
-
-						Sensei()->notices->add_notice( $message, 'info' );
-
-				}
-
-				if ( ! is_user_logged_in() ) {
-
-					$a_element  = '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr__( 'Sign Up', 'woothemes-sensei' ) . '">';
-					$a_element .= esc_html__( 'course', 'woothemes-sensei' );
-					$a_element .= '</a>';
-
-					// translators: Placeholder is a link to the Course.
-					$message = sprintf( esc_html__( 'Please purchase the %1$s before starting the lesson.', 'woothemes-sensei' ), $a_element );
-
-					Sensei()->notices->add_notice( $message, 'alert' );
-
-				}
-			} else {
-				?>
-
-							<?php if ( ! Sensei_Utils::user_started_course( $course_id, get_current_user_id() ) && sensei_is_login_required() ) : ?>
-
-					<div class="sensei-message alert">
-								<?php
-								$course_link = '<a href="'
-											. esc_url( get_permalink( $course_id ) )
-											. '" title="' . esc_attr__( 'Sign Up', 'woothemes-sensei' )
-											. '">' . esc_html__( 'course', 'woothemes-sensei' )
-										. '</a>';
-
-								// translators: Placeholder is a link to the Course.
-								echo wp_kses_post( sprintf( __( 'Please sign up for the %1$s before starting the lesson.', 'woothemes-sensei' ), $course_link ) );
-
-								?>
-					</div>
-
-				<?php endif; ?>
-
-						<?php } // End If Statement ?>
-
-		</section>
-
-		<?php
 	}//end course_signup_link()
 
 	/**

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4085,7 +4085,7 @@ class Sensei_Lesson {
 		 *
 		 * @since 2.0.0
 		 *
-		 * @param bool $show_course_signup_notice Should we show course sign up notice?
+		 * @param bool $show_course_signup_notice True if we should show the signup notice to the user.
 		 * @param int  $course_id                 Post ID for the course.
 		 */
 		if ( apply_filters( 'sensei_lesson_show_course_signup_notice', $show_course_signup_notice, $course_id ) ) {
@@ -4102,7 +4102,7 @@ class Sensei_Lesson {
 			 *
 			 * @since 2.0.0
 			 *
-			 * @param string $message     Should we show course sign up notice?
+			 * @param string $message     Message to show user.
 			 * @param int    $course_id   Post ID for the course.
 			 * @param string $course_link Generated HTML link to the course.
 			 */

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4089,7 +4089,6 @@ class Sensei_Lesson {
 		 * @param int  $course_id                 Post ID for the course.
 		 */
 		if ( apply_filters( 'sensei_lesson_show_course_signup_notice', $show_course_signup_notice, $course_id ) ) {
-			echo '<section class="course-signup lesson-meta">';
 			$course_link  = '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr__( 'Sign Up', 'woothemes-sensei' ) . '">';
 			$course_link .= esc_html__( 'course', 'woothemes-sensei' );
 			$course_link .= '</a>';
@@ -4118,7 +4117,6 @@ class Sensei_Lesson {
 			 */
 			$notice_level = apply_filters( 'sensei_lesson_course_signup_notice_level', 'alert', $course_id );
 			Sensei()->notices->add_notice( $message, $notice_level );
-			echo '</section>';
 		}
 
 	}//end course_signup_link()


### PR DESCRIPTION
This refactors `Sensei_Lesson::course_signup_link()` to use filters when generating the alert that appears above lessons for courses that haven't been started. WooCommerce related functionality has been moved to WCPC.

One change is before the parent element `<section class="course-signup lesson-meta">...</section>` was shown even if no notice was displayed. I've changed that so it just echos that if a notice is to be displayed.

### Testing Instructions
View the lesson page without WCPC and make sure the following conditions are met:
- Logged out user: Shown info notice (gray) for _signing up_ for the course.
- Logged in user, in course: No alert is shown.
- Logged in user, not in course: Shown info notice (gray) for _signing up_ for the course. 

### New Filters
- `includes/class-sensei-lesson.php`: `sensei_lesson_show_course_signup_notice`
- `includes/class-sensei-lesson.php`: `sensei_lesson_course_signup_notice_message`
- `includes/class-sensei-lesson.php`: `sensei_lesson_course_signup_notice_level`
