### PR TITLE
Deprecate "Delete Course" buttons

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1423,7 +1423,7 @@ class Sensei_Course {
 						[ false ],
 						'2.0.0',
 						null,
-						'Sensei "Delete Course" button will be removed in version 2.1.0.'
+						'Sensei "Delete Course" button will be removed on or after 2019-11-01.'
 					);
 
 					if ( false == $course_purchased && $show_delete_course_button ) {
@@ -2224,7 +2224,7 @@ if ( Sensei_Utils::user_started_course( $course->ID, get_current_user_id() )
 						[ false ],
 						'2.0.0',
 						null,
-						'Sensei "Delete Course" button will be removed in version 2.1.0.'
+						'Sensei "Delete Course" button will be removed on or after 2019-11-01.'
 					);
 
 					if ( ! $course_purchased

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1404,7 +1404,7 @@ class Sensei_Course {
 					} // End If Statement
 
 					$course_purchased = false;
-					if ( Sensei_WC::is_woocommerce_active() ) {
+					if ( class_exists( 'Sensei_WC' ) && Sensei_WC::is_woocommerce_active() ) {
 
 						// Get the product ID
 						$wc_post_id = get_post_meta( absint( $course_item->ID ), '_course_woocommerce_product', true );
@@ -1418,7 +1418,13 @@ class Sensei_Course {
 					/**
 					 * documented in class-sensei-course.php the_course_action_buttons function
 					 */
-					$show_delete_course_button = apply_filters( 'sensei_show_delete_course_button', false );
+					$show_delete_course_button = apply_filters_deprecated(
+						'sensei_show_delete_course_button',
+						[ false ],
+						'2.0.0',
+						null,
+						'Sensei "Delete Course" button will be removed in version 2.1.0.'
+					);
 
 					if ( false == $course_purchased && $show_delete_course_button ) {
 
@@ -2193,7 +2199,7 @@ if ( Sensei_Utils::user_started_course( $course->ID, get_current_user_id() )
 					} // End If Statement
 
 					$course_purchased = false;
-					if ( Sensei_WC::is_woocommerce_active() ) {
+					if ( class_exists( 'Sensei_WC' ) && Sensei_WC::is_woocommerce_active() ) {
 						// Get the product ID
 						$wc_post_id = get_post_meta( intval( $course->ID ), '_course_woocommerce_product', true );
 						if ( 0 < $wc_post_id ) {
@@ -2213,7 +2219,13 @@ if ( Sensei_Utils::user_started_course( $course->ID, get_current_user_id() )
 					 * @since 1.9.0
 					 * @param bool $show_delete_course_button defaults to false
 					 */
-					$show_delete_course_button = apply_filters( 'sensei_show_delete_course_button', false );
+					$show_delete_course_button = apply_filters_deprecated(
+						'sensei_show_delete_course_button',
+						[ false ],
+						'2.0.0',
+						null,
+						'Sensei "Delete Course" button will be removed in version 2.1.0.'
+					);
 
 					if ( ! $course_purchased
 						 && ! Sensei_Utils::user_completed_course( $course->ID, get_current_user_id() )

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1425,7 +1425,7 @@ class Sensei_Course {
 						[ false ],
 						'2.0.0',
 						null,
-						'Sensei "Delete Course" button will be removed on or after 2019-11-01.'
+						'Sensei "Delete Course" button will be removed in version 4.0.'
 					);
 
 					if ( false == $course_purchased && $show_delete_course_button ) {
@@ -2229,7 +2229,7 @@ if ( Sensei_Utils::user_started_course( $course->ID, get_current_user_id() )
 				[ false ],
 				'2.0.0',
 				null,
-				'Sensei "Delete Course" button will be removed on or after 2019-11-01.'
+				'Sensei "Delete Course" button will be removed in version 4.0.'
 			);
 
 			if ( ! $course_purchased

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1417,6 +1417,8 @@ class Sensei_Course {
 
 					/**
 					 * documented in class-sensei-course.php the_course_action_buttons function
+					 *
+					 * @deprecated 2.0.0
 					 */
 					$show_delete_course_button = apply_filters_deprecated(
 						'sensei_show_delete_course_button',
@@ -2217,6 +2219,9 @@ if ( Sensei_Utils::user_started_course( $course->ID, get_current_user_id() )
 					 * cases. For other instances the button will be hidden.
 					 *
 					 * @since 1.9.0
+					 *
+					 * @deprecated 2.0.0
+					 *
 					 * @param bool $show_delete_course_button defaults to false
 					 */
 					$show_delete_course_button = apply_filters_deprecated(

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2205,7 +2205,7 @@ if ( Sensei_Utils::user_started_course( $course->ID, get_current_user_id() )
 						if ( 0 < $wc_post_id ) {
 
 							$user             = wp_get_current_user();
-							$course_purchased = Sensei_Utils::sensei_customer_bought_product( $user->user_email, $user->ID, $wc_post_id );
+							$course_purchased = Sensei_WC::has_customer_bought_product( $user->ID, $wc_post_id );
 
 						} // End If Statement
 					} // End If Statement

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2182,90 +2182,92 @@ if ( Sensei_Utils::user_started_course( $course->ID, get_current_user_id() )
 				<form method="POST" action="<?php echo esc_url( remove_query_arg( array( 'active_page', 'completed_page' ) ) ); ?>">
 
 					<input type="hidden"
-						   name="<?php echo esc_attr( 'woothemes_sensei_complete_course_noonce' ); ?>"
-						   id="<?php echo esc_attr( 'woothemes_sensei_complete_course_noonce' ); ?>"
-						   value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_course_noonce' ) ); ?>"
+							name="<?php echo esc_attr( 'woothemes_sensei_complete_course_noonce' ); ?>"
+							id="<?php echo esc_attr( 'woothemes_sensei_complete_course_noonce' ); ?>"
+							value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_course_noonce' ) ); ?>"
 						/>
 
 					<input type="hidden" name="course_complete_id" id="course-complete-id" value="<?php echo esc_attr( intval( $course->ID ) ); ?>" />
 
-					<?php
-					if ( 0 < absint( count( Sensei()->course->course_lessons( $course->ID ) ) )
-						&& Sensei()->settings->settings['course_completion'] == 'complete'
-						&& ! Sensei_Utils::user_completed_course( $course, get_current_user_id() ) ) {
-						?>
-
-						<span><input name="course_complete" type="submit" class="course-complete" value="<?php esc_attr_e( 'Mark as Complete', 'woothemes-sensei' ); ?>" /></span>
-
-						<?php
-					} // End If Statement
-
-					$course_purchased = false;
-					if ( class_exists( 'Sensei_WC' ) && Sensei_WC::is_woocommerce_active() ) {
-						// Get the product ID
-						$wc_post_id = get_post_meta( intval( $course->ID ), '_course_woocommerce_product', true );
-						if ( 0 < $wc_post_id ) {
-
-							$user             = wp_get_current_user();
-							$course_purchased = Sensei_WC::has_customer_bought_product( $user->ID, $wc_post_id );
-
-						} // End If Statement
-					} // End If Statement
-
-					/**
-					 * Hide or show the delete course button.
-					 *
-					 * This button on shows in certain instances, but this filter will hide it in those
-					 * cases. For other instances the button will be hidden.
-					 *
-					 * @since 1.9.0
-					 *
-					 * @deprecated 2.0.0
-					 *
-					 * @param bool $show_delete_course_button defaults to false
-					 */
-					$show_delete_course_button = apply_filters_deprecated(
-						'sensei_show_delete_course_button',
-						[ false ],
-						'2.0.0',
-						null,
-						'Sensei "Delete Course" button will be removed on or after 2019-11-01.'
-					);
-
-					if ( ! $course_purchased
-						 && ! Sensei_Utils::user_completed_course( $course->ID, get_current_user_id() )
-						 && $show_delete_course_button ) {
+			<?php
+			if ( 0 < absint( count( Sensei()->course->course_lessons( $course->ID ) ) )
+				&& Sensei()->settings->settings['course_completion'] == 'complete'
+				&& ! Sensei_Utils::user_completed_course( $course, get_current_user_id() ) ) {
 				?>
 
-						<span><input name="course_complete" type="submit" class="course-delete" value="<?php echo esc_attr__( 'Delete Course', 'woothemes-sensei' ); ?>"/></span>
+					<span><input name="course_complete" type="submit" class="course-complete" value="<?php esc_attr_e( 'Mark as Complete', 'woothemes-sensei' ); ?>" /></span>
 
-										<?php
-					} // End If Statement
+				<?php
+			} // End If Statement
 
-					$has_quizzes  = Sensei()->course->course_quizzes( $course->ID, true );
-					$results_link = '';
-					if ( $has_quizzes ) {
-						$results_link = '<a class="button view-results" href="' . esc_url( Sensei()->course_results->get_permalink( $course->ID ) ) . '">' .
-							esc_html__( 'View results', 'woothemes-sensei' ) . '</a>';
-					}
+			$course_purchased = false;
+			if ( class_exists( 'Sensei_WC' ) && Sensei_WC::is_woocommerce_active() ) {
+				// Get the product ID
+				$wc_post_id = get_post_meta( intval( $course->ID ), '_course_woocommerce_product', true );
+				if ( 0 < $wc_post_id ) {
 
-					// Output only if there is content to display.
-					if ( has_filter( 'sensei_results_links' ) || $has_quizzes ) {
-						?>
+					$user             = wp_get_current_user();
+					$course_purchased = Sensei_WC::has_customer_bought_product( $user->ID, $wc_post_id );
 
-						<p class="sensei-results-links">
-							<?php
-							/**
-							 * Filter the results links
-							 *
-							 * @param string $results_links_html
-							 * @param integer $course_id
-							 */
-							echo wp_kses_post( apply_filters( 'sensei_results_links', $results_link, $course->ID ) );
-							?>
-						</p>
+				} // End If Statement
+			} // End If Statement
 
-										<?php } // end if has filter ?>
+			/**
+			 * Hide or show the delete course button.
+			 *
+			 * This button on shows in certain instances, but this filter will hide it in those
+			 * cases. For other instances the button will be hidden.
+			 *
+			 * @since 1.9.0
+			 *
+			 * @deprecated 2.0.0
+			 *
+			 * @param bool $show_delete_course_button defaults to false
+			 */
+			$show_delete_course_button = apply_filters_deprecated(
+				'sensei_show_delete_course_button',
+				[ false ],
+				'2.0.0',
+				null,
+				'Sensei "Delete Course" button will be removed on or after 2019-11-01.'
+			);
+
+			if ( ! $course_purchased
+					&& ! Sensei_Utils::user_completed_course( $course->ID, get_current_user_id() )
+					&& $show_delete_course_button ) {
+				?>
+
+					<span><input name="course_complete" type="submit" class="course-delete" value="<?php echo esc_attr__( 'Delete Course', 'woothemes-sensei' ); ?>"/></span>
+
+				<?php
+			} // End If Statement
+
+			$has_quizzes  = Sensei()->course->course_quizzes( $course->ID, true );
+			$results_link = '';
+			if ( $has_quizzes ) {
+				$results_link = '<a class="button view-results" href="' . esc_url( Sensei()->course_results->get_permalink( $course->ID ) ) . '">' .
+					esc_html__( 'View results', 'woothemes-sensei' ) . '</a>';
+			}
+
+			// Output only if there is content to display.
+			if ( has_filter( 'sensei_results_links' ) || $has_quizzes ) {
+				?>
+
+					<p class="sensei-results-links">
+				<?php
+				/**
+				 * Filter the results links
+				 *
+				 * @param string $results_links_html
+				 * @param integer $course_id
+				 */
+				echo wp_kses_post( apply_filters( 'sensei_results_links', $results_link, $course->ID ) );
+				?>
+					</p>
+
+				<?php
+			} // end if has filter
+			?>
 				</form>
 			</section>
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2249,7 +2249,7 @@ if ( Sensei_Utils::user_started_course( $course->ID, get_current_user_id() )
 							esc_html__( 'View results', 'woothemes-sensei' ) . '</a>';
 					}
 
-					// Output only if there is content to display
+					// Output only if there is content to display.
 					if ( has_filter( 'sensei_results_links' ) || $has_quizzes ) {
 						?>
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -935,7 +935,7 @@ class Sensei_Frontend {
 				case __( 'Delete Course', 'woothemes-sensei' ):
 					_doing_it_wrong(
 						'Sensei_Frontend::sensei_complete_course',
-						'Handling for "Delete Course" button will be removed on or after 2019-11-01.',
+						'Handling for "Delete Course" button will be removed in version 4.0.',
 						'2.0.0'
 					);
 					Sensei_Utils::sensei_remove_user_from_course( $sanitized_course_id, $current_user->ID );

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -927,6 +927,9 @@ class Sensei_Frontend {
 					break;
 
 				/**
+				 * Handle the Delete Course button. This is deprecated and will
+				 * be removed.
+				 *
 				 * @deprecated 2.0.0
 				 */
 				case __( 'Delete Course', 'woothemes-sensei' ):

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -926,7 +926,15 @@ class Sensei_Frontend {
 
 					break;
 
+				/**
+				 * @deprecated 2.0.0
+				 */
 				case __( 'Delete Course', 'woothemes-sensei' ):
+					_doing_it_wrong(
+						'Sensei_Frontend::sensei_complete_course',
+						'Handling for "Delete Course" button will be removed on or after 2019-11-01.',
+						'2.0.0'
+					);
 					Sensei_Utils::sensei_remove_user_from_course( $sanitized_course_id, $current_user->ID );
 
 					// Success message.

--- a/includes/sensei-wc-stubs.php
+++ b/includes/sensei-wc-stubs.php
@@ -18,4 +18,5 @@ class Sensei_WC_Memberships {
 }
 class Sensei_WC_Subscriptions {
 	public static function load_wc_subscriptions_integration_hooks() {}
+	public static function has_user_bought_subscription_but_cancelled() {}
 }


### PR DESCRIPTION
The "Delete Course" button is an opt-in feature on the My Courses page for users to remove themselves from courses in which they have enrolled. It is rendered by the `sensei_user_courses` shortcode, and the legacy `usercourses` shortcode. In both cases, it is not rendered for paid courses, because then the user would not have a way to re-add themselves to the course without paying again.

Some history: [#](https://github.com/Automattic/sensei/issues/688), [#](https://github.com/Automattic/sensei/issues/1324), [#](https://github.com/Automattic/sensei/issues/1652)

Because this is turned off by default, I would argue that it's time to deprecate the functionality and provide a workaround for users who still want it. Otherwise, we would have to move the paid courses logic to WCPC, which seems like overkill for this sort of feature. This PR provides the deprecation.

## Workaround

After this functionality is removed, users may re-add it with the following code snippet:

```php
function sensei_the_delete_course_button( $course ) {
	$course = get_post( $course );

	$course_purchased = false;
	if ( class_exists( 'Sensei_WC' ) && Sensei_WC::is_woocommerce_active() ) {
		// Get the product ID
		$wc_post_id = get_post_meta( intval( $course->ID ), '_course_woocommerce_product', true );
		if ( 0 < $wc_post_id ) {
			$user             = wp_get_current_user();
			$course_purchased = Sensei_Utils::sensei_customer_bought_product( $user->user_email, $user->ID, $wc_post_id );
		} // End If Statement
	} // End If Statement

	if ( ! $course_purchased && ! Sensei_Utils::user_completed_course( $course->ID, get_current_user_id() ) ) {
		?>
		<section class="entry-actions">
			<form method="POST" action="<?php echo esc_url( remove_query_arg( array( 'active_page', 'completed_page' ) ) ); ?>">

				<input type="hidden"
					name="<?php echo esc_attr( 'woothemes_sensei_complete_course_noonce' ); ?>"
					id="<?php echo esc_attr( 'woothemes_sensei_complete_course_noonce' ); ?>"
					value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_course_noonce' ) ); ?>"
				/>

				<input type="hidden" name="course_complete_id" id="course-complete-id" value="<?php echo esc_attr( intval( $course->ID ) ); ?>" />
				<span><input name="course_complete" type="submit" class="course-delete" value="<?php echo esc_attr__( 'Delete Course', 'woothemes-sensei' ); ?>"/></span>
			</form>
		</section>
		<?php
	} // End If Statement
}
add_action( 'sensei_course_content_inside_after', 'sensei_the_delete_course_button', 11 );
```

## Testing Instructions

### Test the deprecated functionality

- Sign in as user and start taking a few courses. Make sure at least one of them is a paid course using WooCommerce Paid Courses.
- Create two "My Courses" pages using the `sensei_user_courses` and `usercourses` shortcodes.
- Add the snippet `add_filter( 'sensei_show_delete_course_button', '__return_true' );` to enable the "Delete Course" buttons.
- On each "My Courses" page, ensure that the "Delete Course" button appears and works for the free courses.
- Ensure that the "Delete Course" button does not appear for paid courses.
- Deactivate WooCommerce Paid Courses. Ensure the delete button appears for all courses.

### Test the workaround

- Sign in as user and start taking a few courses. Make sure at least one of them is a paid course using WooCommerce Paid Courses.
- Create two "My Courses" pages using the `sensei_user_courses` and `usercourses` shortcodes.
- Add the snippet above to enable the workaround for the "Delete Course" buttons.
- On each "My Courses" page, ensure that the "Delete Course" button appears and works for the free courses.
- Ensure that the "Delete Course" button does not appear for paid courses.
- Deactivate WooCommerce Paid Courses. Ensure the delete button appears for all courses.