### PR TITLE
Add filter for course signup on quiz page for logged out users

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1435,21 +1435,23 @@ class Sensei_Utils {
 		} else {
 
 			$course_id  = Sensei()->lesson->get_course_id( $lesson_id );
-			$a_element  = '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr__( 'Sign Up', 'woothemes-sensei' ) . '">';
-			$a_element .= esc_html__( 'course', 'woothemes-sensei' );
-			$a_element .= '</a>';
+			$course_link  = '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr__( 'Sign Up', 'woothemes-sensei' ) . '">';
+			$course_link .= esc_html__( 'course', 'woothemes-sensei' );
+			$course_link .= '</a>';
 
-			if ( Sensei_WC::is_course_purchasable( $course_id ) ) {
+			// translators: Placeholder is a link to the course permalink.
+			$message_default = sprintf( __( 'Please sign up for the %1$s before taking this quiz.', 'woothemes-sensei' ), $course_link );
 
-				// translators: Placeholder is a link to the course permalink.
-				$message = sprintf( __( 'Please purchase the %1$s before taking this quiz.', 'woothemes-sensei' ), $a_element );
-
-			} else {
-
-				// translators: Placeholder is a link to the course permalink.
-				$message = sprintf( __( 'Please sign up for the %1$s before taking this quiz.', 'woothemes-sensei' ), $a_element );
-
-			}
+			/**
+			 * Filter the course sign up notice message on the quiz page.
+			 *
+			 * @since 2.0.0
+			 *
+			 * @param string $message     Message to show user.
+			 * @param int    $course_id   Post ID for the course.
+			 * @param string $course_link Generated HTML link to the course.
+			 */
+			$message = apply_filters( 'sensei_quiz_course_signup_notice_message', $message_default, $course_id, $course_link );
 		}
 
 		// Legacy filter

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1434,7 +1434,7 @@ class Sensei_Utils {
 			}
 		} else {
 
-			$course_id  = Sensei()->lesson->get_course_id( $lesson_id );
+			$course_id    = Sensei()->lesson->get_course_id( $lesson_id );
 			$course_link  = '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr__( 'Sign Up', 'woothemes-sensei' ) . '">';
 			$course_link .= esc_html__( 'course', 'woothemes-sensei' );
 			$course_link .= '</a>';


### PR DESCRIPTION
This adds a filter for the message shown to logged out users visiting quiz pages. This will allow WCPC to hook in and change the message to _purchase_ instead of _sign up_. 

Current behavior only customizes the behavior of logged _out_ users, not logged in users.

### Testing Instructions
With WCPC disabled.
- Logged in or out, visit quiz associated with course not enrolled in: Should see prompt to _sign up_ for course.

### New Fitlers
- `includes/class-sensei-utils.php`: `sensei_quiz_course_signup_notice_message`