### PR TITLE
Remove "Free Preview" text for lessons

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1320,16 +1320,7 @@ class Sensei_Frontend {
 	} // sensei_lesson_meta()
 
 	public function sensei_lesson_preview_title_text( $course_id ) {
-
 		$preview_text = __( 'Preview', 'woothemes-sensei' );
-
-		// if this is a paid course.
-		if ( Sensei_WC::is_woocommerce_active() ) {
-			$wc_post_id = get_post_meta( $course_id, '_course_woocommerce_product', true );
-			if ( 0 < $wc_post_id ) {
-				$preview_text = __( 'Free Preview', 'woothemes-sensei' );
-			} // End If Statement
-		}
 
 		/**
 		 * The lesson preview indicator text. Defaults to "Preview" or "Free


### PR DESCRIPTION
This text will be added by WooCommerce Paid Courses when appropriate.

## Testing Instructions

- Create a course with at least one lesson that is marked as a preview.
- Visit the course page. Ensure that the text beside the lesson link is "Preview".
- Check this when the lesson is added to a module, and when it is not in a module.
- Visit the lesson page. Ensure that the text beside the title is "Preview".
- Make this course a "paid" course using WooCommerce Paid Courses, and then deactivate WooCommerce Paid Courses. All the preview indicators should still say "Preview", not "Free Preview".