### PR TITLE
 Deprecate sensei_simple_course_price() and introduce new hooks

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2103,14 +2103,16 @@ class Sensei_Course {
 			<?php echo esc_html( Sensei()->course->course_lesson_count( $course->ID ) ) . '&nbsp;' . esc_html__( 'Lessons', 'woothemes-sensei' ); ?>
 		</span>
 
-		<?php if ( ! empty( $category_output ) ) { ?>
+		<?php
+		if ( ! empty( $category_output ) ) {
+			?>
 
 			<span class="course-category">
 				<?php
 				// translators: Placeholder is a comma-separated list of the course categories.
 				echo wp_kses_post( sprintf( __( 'in %s', 'woothemes-sensei' ), $category_output ) );
 				?>
-</span>
+			</span>
 
 			<?php
 		} // End If Statement

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2085,6 +2085,9 @@ class Sensei_Course {
 		$category_output     = get_the_term_list( $course->ID, 'course-category', '', ', ', '' );
 		$author_display_name = get_the_author_meta( 'display_name', $course->post_author );
 
+		/** This action is documented in includes/class-sensei-frontend.php */
+		do_action( 'sensei_course_meta_inside_before', $course->ID );
+
 		if ( isset( Sensei()->settings->settings['course_author'] ) && ( Sensei()->settings->settings['course_author'] ) ) {
 			?>
 
@@ -2100,7 +2103,7 @@ class Sensei_Course {
 			<?php echo esc_html( Sensei()->course->course_lesson_count( $course->ID ) ) . '&nbsp;' . esc_html__( 'Lessons', 'woothemes-sensei' ); ?>
 		</span>
 
-		<?php if ( '' != $category_output ) { ?>
+		<?php if ( '' !== $category_output ) { ?>
 
 			<span class="course-category">
 				<?php
@@ -2110,20 +2113,20 @@ class Sensei_Course {
 </span>
 
 			<?php
-} // End If Statement
+		} // End If Statement
 
 		// number of completed lessons
-if ( Sensei_Utils::user_started_course( $course->ID, get_current_user_id() )
+		if ( Sensei_Utils::user_started_course( $course->ID, get_current_user_id() )
 			|| Sensei_Utils::user_completed_course( $course->ID, get_current_user_id() ) ) {
 
 			$completed    = count( $this->get_completed_lesson_ids( $course->ID, get_current_user_id() ) );
 			$lesson_count = count( $this->course_lessons( $course->ID ) );
 			// translators: Placeholders are the number of lessons completed and the total number of lessons, respectively.
 			echo '<span class="course-lesson-progress">' . esc_html( sprintf( __( '%1$d of %2$d lessons completed', 'woothemes-sensei' ), $completed, $lesson_count ) ) . '</span>';
+		}
 
-}
-
-		sensei_simple_course_price( $course->ID );
+		/** This action is documented in includes/class-sensei-frontend.php */
+		do_action( 'sensei_course_meta_inside_after', $course->ID );
 
 		echo '</p>';
 	} // end the course meta

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2103,7 +2103,7 @@ class Sensei_Course {
 			<?php echo esc_html( Sensei()->course->course_lesson_count( $course->ID ) ) . '&nbsp;' . esc_html__( 'Lessons', 'woothemes-sensei' ); ?>
 		</span>
 
-		<?php if ( '' !== $category_output ) { ?>
+		<?php if ( ! empty( $category_output ) ) { ?>
 
 			<span class="course-category">
 				<?php

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1123,7 +1123,7 @@ class Sensei_Frontend {
 				?>
 			   <span class="course-lesson-count"><?php echo esc_html( Sensei()->course->course_lesson_count( $post_id ) ) . '&nbsp;' . esc_html__( 'Lessons', 'woothemes-sensei' ); ?></span>
 			<?php
-			if ( '' !== $category_output ) {
+			if ( ! empty( $category_output ) ) {
 				?>
 				<span class="course-category">
 					<?php

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1105,19 +1105,44 @@ class Sensei_Frontend {
 		?>
 		<section class="entry">
 			<p class="sensei-course-meta">
-			<?php if ( isset( Sensei()->settings->settings['course_author'] ) && ( Sensei()->settings->settings['course_author'] ) ) { ?>
+				<?php
+				/**
+				 * Fires before course meta is displayed.
+				 *
+				 * @since 2.0.0
+				 *
+				 * @params int $course_id Course post ID.
+				 */
+				do_action( 'sensei_course_meta_inside_before', $post_id );
+
+				if ( isset( Sensei()->settings->settings['course_author'] ) && ( Sensei()->settings->settings['course_author'] ) ) {
+					?>
 			   <span class="course-author"><?php esc_html_e( 'by', 'woothemes-sensei' ); ?><?php the_author_link(); ?></span>
-			<?php } // End If Statement ?>
+					<?php
+				} // End If Statement
+				?>
 			   <span class="course-lesson-count"><?php echo esc_html( Sensei()->course->course_lesson_count( $post_id ) ) . '&nbsp;' . esc_html__( 'Lessons', 'woothemes-sensei' ); ?></span>
-			<?php if ( '' != $category_output ) { ?>
+			<?php
+			if ( '' !== $category_output ) {
+				?>
 				<span class="course-category">
 					<?php
 					// translators: Placeholder is a comma-separated list of course categories.
 					echo sprintf( esc_html__( 'in %s', 'woothemes-sensei' ), wp_kses_post( $category_output ) );
 					?>
 				</span>
-			<?php } // End If Statement ?>
-			<?php sensei_simple_course_price( $post_id ); ?>
+				<?php
+			} // End If Statement
+
+			/**
+			 * Fires after course meta is displayed.
+			 *
+			 * @since 2.0.0
+			 *
+			 * @params int $course_id Course post ID.
+			 */
+			do_action( 'sensei_course_meta_inside_after', $post_id );
+			?>
 			</p>
 			<p class="course-excerpt"><?php the_excerpt(); ?></p>
 			<?php

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -347,6 +347,11 @@ class Sensei_Legacy_Shortcodes {
 
 					<p class="sensei-course-meta">
 
+						<?php
+						/** This action is documented in includes/class-sensei-frontend.php */
+						do_action( 'sensei_course_meta_inside_before', $course_id );
+						?>
+
 						<?php if ( isset( Sensei()->settings->settings['course_author'] ) && ( Sensei()->settings->settings['course_author'] ) ) { ?>
 							<span class="course-author">
 								<?php esc_html_e( 'by', 'woothemes-sensei' ); ?>
@@ -360,7 +365,7 @@ class Sensei_Legacy_Shortcodes {
 									<?php echo esc_html( Sensei()->course->course_lesson_count( $course_id ) ) . '&nbsp;' . esc_html__( 'Lessons', 'woothemes-sensei' ); ?>
 								</span>
 
-						<?php if ( '' != $category_output ) { ?>
+						<?php if ( '' !== $category_output ) { ?>
 							<span class="course-category">
 								<?php
 								// translators: Placeholder is a comma-separated list of categories.
@@ -369,7 +374,10 @@ class Sensei_Legacy_Shortcodes {
 							</span>
 						<?php } // End If Statement ?>
 
-						<?php sensei_simple_course_price( $course_id ); ?>
+						<?php
+						/** This action is documented in includes/class-sensei-frontend.php */
+						do_action( 'sensei_course_meta_inside_after', $course_id );
+						?>
 
 					</p>
 

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -365,7 +365,7 @@ class Sensei_Legacy_Shortcodes {
 									<?php echo esc_html( Sensei()->course->course_lesson_count( $course_id ) ) . '&nbsp;' . esc_html__( 'Lessons', 'woothemes-sensei' ); ?>
 								</span>
 
-						<?php if ( '' !== $category_output ) { ?>
+						<?php if ( ! empty( $category_output ) ) { ?>
 							<span class="course-category">
 								<?php
 								// translators: Placeholder is a comma-separated list of categories.

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -155,38 +155,16 @@ function sensei_check_if_product_is_in_cart( $wc_product_id = 0 ) {
 	/**
 	 * sensei_simple_course_price function.
 	 *
-	 * @access public
+	 * @deprecated 2.0.0 Use `\Sensei_WC_Paid_Courses\Frontend\Courses::output_course_price()` if it exists.
 	 * @param mixed $post_id
 	 * @return void
 	 */
 function sensei_simple_course_price( $post_id ) {
-
-	global $wp_the_query;
-
-	// check for the my courses shortcode
-	if ( strpos( $wp_the_query->post->post_content, 'sensei_user_courses' ) || strpos( $wp_the_query->post->post_content, 'usercourses' ) ) {
+	if ( ! method_exists( 'Sensei_WC_Paid_Courses\Frontend\Courses', 'output_course_price' ) ) {
+		_deprecated_function( __FUNCTION__, '2.0.0', 'Sensei_WC_Paid_Courses\Frontend\Courses::output_course_price()' );
 		return;
 	}
-
-	$wc_post_id = get_post_meta( $post_id, '_course_woocommerce_product', true );
-	if ( ! Sensei_WC::is_woocommerce_active() || empty( $wc_post_id ) || false ) {
-		return;
-	}
-
-	// Get the product
-	$product = Sensei_WC::get_product_object( $wc_post_id );
-
-	if ( isset( $product ) && ! empty( $product ) && $product->is_purchasable()
-		 && $product->is_in_stock() && ! sensei_check_if_product_is_in_cart( $wc_post_id ) ) {
-		?>
-
-			<span class="course-price">
-				<?php echo wp_kses_post( $product->get_price_html() ); ?>
-			</span>
-
-		<?php
-	} // End If Statement
-
+	\Sensei_WC_Paid_Courses\Frontend\Courses::output_course_price( $post_id );
 } // End sensei_simple_course_price()
 
 	/**

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -160,10 +160,12 @@ function sensei_check_if_product_is_in_cart( $wc_product_id = 0 ) {
 	 * @return void
 	 */
 function sensei_simple_course_price( $post_id ) {
+	_deprecated_function( __FUNCTION__, '2.0.0', 'Sensei_WC_Paid_Courses\Frontend\Courses::output_course_price()' );
+
 	if ( ! method_exists( 'Sensei_WC_Paid_Courses\Frontend\Courses', 'output_course_price' ) ) {
-		_deprecated_function( __FUNCTION__, '2.0.0', 'Sensei_WC_Paid_Courses\Frontend\Courses::output_course_price()' );
 		return;
 	}
+
 	\Sensei_WC_Paid_Courses\Frontend\Courses::output_course_price( $post_id );
 } // End sensei_simple_course_price()
 

--- a/widgets/widget-woothemes-sensei-category-courses.php
+++ b/widgets/widget-woothemes-sensei-category-courses.php
@@ -211,7 +211,12 @@ class WooThemes_Sensei_Category_Courses_Widget extends WP_Widget {
 					<?php do_action( 'sensei_course_image', $post_id ); ?>
 					<a href="<?php echo esc_url( get_permalink( $post_id ) ); ?>" title="<?php echo esc_attr( $post_title ); ?>"><?php echo esc_html( $post_title ); ?></a>
 					<br />
-					<?php if ( isset( Sensei()->settings->settings['course_author'] ) && ( Sensei()->settings->settings['course_author'] ) ) { ?>
+					<?php
+					/** This action is documented in includes/class-sensei-frontend.php */
+					do_action( 'sensei_course_meta_inside_before', $post_id );
+
+					if ( isset( Sensei()->settings->settings['course_author'] ) && ( Sensei()->settings->settings['course_author'] ) ) {
+						?>
 						<span class="course-author">
 							<?php esc_html_e( 'by', 'woothemes-sensei' ); ?>
 							<a href="<?php echo esc_url( $author_link ); ?>" title="<?php echo esc_attr( $author_display_name ); ?>">
@@ -222,7 +227,10 @@ class WooThemes_Sensei_Category_Courses_Widget extends WP_Widget {
 					<?php } // End If Statement ?>
 					<span class="course-lesson-count"><?php echo esc_html( Sensei()->course->course_lesson_count( $post_id ) ) . '&nbsp;' . esc_html__( 'Lessons', 'woothemes-sensei' ); ?></span>
 					<br />
-					<?php sensei_simple_course_price( $post_id ); ?>
+					<?php
+					/** This action is documented in includes/class-sensei-frontend.php */
+					do_action( 'sensei_course_meta_inside_after', $post_id );
+					?>
 				</li>
 			<?php } // End For Loop ?>
 			</ul>

--- a/widgets/widget-woothemes-sensei-course-component.php
+++ b/widgets/widget-woothemes-sensei-course-component.php
@@ -302,6 +302,10 @@ class WooThemes_Sensei_Course_Component_Widget extends WP_Widget {
 					</a>
 					<br />
 
+					<?php
+					/** This action is documented in includes/class-sensei-frontend.php */
+					do_action( 'sensei_course_meta_inside_before', $post_id );
+					?>
 					<?php if ( isset( Sensei()->settings->settings['course_author'] ) && ( Sensei()->settings->settings['course_author'] ) ) { ?>
 						<span class="course-author">
 							<?php esc_html_e( 'by', 'woothemes-sensei' ); ?>
@@ -318,7 +322,10 @@ class WooThemes_Sensei_Course_Component_Widget extends WP_Widget {
 
 					<br />
 
-					<?php sensei_simple_course_price( $post_id ); ?>
+					<?php
+					/** This action is documented in includes/class-sensei-frontend.php */
+					do_action( 'sensei_course_meta_inside_after', $post_id );
+					?>
 
 				</li>
 


### PR DESCRIPTION
This deprecates `sensei_simple_course_price()` and moves its functionality to WCPC. In the process, it also introduces two filters to be used in multiple files. The repeated use of the same filters highlighted some parts where we have code duplication (the display of course meta). @alexsanford and I discussed it for a bit and thought refactoring would add too much scope creep to this PR and overall project.

Note: Previously the cost was hidden on the `[usercourses]` shortcode, but that shortcode doesn't seem to output the course price even with the explicit exclusion removed.

### Testing Instructions
By itself, just make sure no deprecation notices are thrown around Sensei. 

### New Hooks
- `includes/class-sensei-frontend.php`: `sensei_course_meta_inside_before`
- `includes/class-sensei-frontend.php`: `sensei_course_meta_inside_after` (hooked into new method in WCPC).

These new hooks are also used here:
- `widgets/widget-woothemes-sensei-category-courses.php`
- `widgets/widget-woothemes-sensei-course-component.php`
- `includes/class-sensei-course.php`
- `includes/shortcodes/class-sensei-legacy-shortcodes.php`