### PR TITLE
Add deprecation notice

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1480,6 +1480,7 @@ class Sensei_Frontend {
 	/**
 	 * Activate all purchased courses for user.
 	 *
+	 * @deprecated 2.0.0 Use `\Sensei_WC_Paid_Courses\Courses::activate_purchased_courses()` if it exists.
 	 * @since  1.4.8
 	 * @param  integer $user_id User ID.
 	 * @return void
@@ -1497,6 +1498,7 @@ class Sensei_Frontend {
 	/**
 	 * Activate single course if already purchases.
 	 *
+	 * @deprecated 2.0.0 Use `\Sensei_WC_Paid_Courses\Courses::activate_purchased_single_course()` if it exists.
 	 * @return void
 	 */
 	public function activate_purchased_single_course() {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1812,7 +1812,6 @@ class Sensei_Utils {
 					case 'graded':
 					case 'passed':
 						return true;
-						break;
 
 					case 'failed':
 						// This may be 'completed' depending on...
@@ -1829,7 +1828,6 @@ class Sensei_Utils {
 							}
 						}
 						return false;
-						break;
 				}
 			} // End If Statement
 		}


### PR DESCRIPTION
Addressing comments from @donnapep  in https://github.com/Automattic/sensei/pull/2416

Adds `@deprecated` tag to deprecated methods.

## Discussion

> We seem to be taking 2 different approaches to deprecating functions. Always showing a deprecation notice as we're doing here, or only showing a deprecation notice if the corresponding function is not available in WCPC as per [this code](https://github.com/Automattic/sensei/pull/2413/commits/66a916214ebeb3937584e3c128ae690c07dfe795#diff-978209e01c6c9e4491c170874c427461R163).
>
> It would be good to standardize and choose an approach. I don't have a preference as to which to use, only that we're consistent.

Good catch. @jom maybe we should make a decision on which way we want to do this? My logic is that since the method is deprecated, we should unconditionally log the notice, because we don't want people calling it anymore. But I'm open to discussion 🙂 