### PR TITLE
Remove course filter based on subscription

### DIFF
--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -137,6 +137,15 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	}
 
 	private function should_filter_course_by_status( $course_status, $user_id ) {
+		/**
+		 * Filters courses processed by the course query in the
+		 * [sensei_user_courses] shortcode.
+		 *
+		 * @param bool       $should_filter Whether the course should be filtered out.
+		 * @param WP_Comment $course_status The current course statue record.
+		 * @param int        $user_id       The user ID.
+		 * @return bool
+		 */
 		return (bool) apply_filters(
 			'sensei_setup_course_query_should_filter_course_by_status',
 			false,

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -137,14 +137,9 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	}
 
 	private function should_filter_course_by_status( $course_status, $user_id ) {
-		$should_filter = Sensei_WC_Subscriptions::has_user_bought_subscription_but_cancelled(
-			$course_status->comment_post_ID,
-			$user_id
-		);
-
 		return (bool) apply_filters(
 			'sensei_setup_course_query_should_filter_course_by_status',
-			$should_filter,
+			false,
 			$course_status,
 			$user_id
 		);

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -142,7 +142,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		 * [sensei_user_courses] shortcode.
 		 *
 		 * @param bool       $should_filter Whether the course should be filtered out.
-		 * @param WP_Comment $course_status The current course statue record.
+		 * @param WP_Comment $course_status The current course status record.
 		 * @param int        $user_id       The user ID.
 		 * @return bool
 		 */


### PR DESCRIPTION
Removes logic for filtering courses in the `sensei_user_courses` shortcode. This logic checks whether the course is attached to a subscription that the user has since cancelled. This logic is moved to WooCommerce Paid Courses and attached to the filter from there.

To test, see the corresponding PR in WooCommerce Paid Courses.