### PR TITLE
Remove workaround for select2 in legacy WooCommerce

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1437,11 +1437,6 @@ class Sensei_Core_Modules {
 		wp_enqueue_script( 'sensei-chosen-ajax', Sensei()->plugin_url . 'assets/chosen/ajax-chosen.jquery' . $suffix . '.js', array( 'jquery', 'sensei-chosen' ), Sensei()->version, true );
 		wp_enqueue_script( $this->taxonomy . '-admin', esc_url( $this->assets_url ) . 'js/modules-admin' . $suffix . '.js', array( 'jquery', 'sensei-chosen', 'sensei-chosen-ajax', 'jquery-ui-sortable', 'sensei-core-select2' ), Sensei()->version, true );
 
-		// WooCommerce 2.6.x Select2 compatibility
-		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.0', '<' ) ) {
-			add_action( 'admin_enqueue_scripts', array( $this, 'admin_dequeue_scripts' ), 11 );
-		}
-
 		// localized module data
 		$localize_modulesAdmin = array(
 			'search_courses_nonce'  => wp_create_nonce( 'search-courses' ),
@@ -1450,17 +1445,6 @@ class Sensei_Core_Modules {
 		);
 
 		wp_localize_script( $this->taxonomy . '-admin', 'modulesAdmin', $localize_modulesAdmin );
-	}
-
-	/**
-	 * WooCommerce 2.6.x Select2 compatibility
-	 *
-	 * @since 1.9.17
-	 *
-	 * @return void
-	 */
-	public function admin_dequeue_scripts( $hook ) {
-		wp_dequeue_script( 'select2' );
 	}
 
 	/**


### PR DESCRIPTION
As per our Slack conversation, WooCommerce < 3.0 is only being used by 2 users who have enabled usage tracking. We probably do not need to support this version anymore.

If there are any serious concerns with this, we can always leave it in. It is not causing too much technical debt, and is probably not worth a lot of time.

A theoretical concern is removing the `admin_dequeue_scripts` without a deprecation, because technically it is public. If we have concerns here, we can leave it in with a deprecation notice. Searching the code, I cannot find any instances of it being used, other than the code that is removed in this PR, so I'm personally not very concerned.