### PR TITLE
Remove Sensei_WC* initializes hooks

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -270,21 +270,6 @@ class Sensei_Main {
 		add_action( 'init', array( $this, 'load_localisation' ), 0 );
 
 		$this->initialize_global_objects();
-
-		/**
-		 * Hook in WooCommerce functionality
-		 */
-		add_action( 'init', array( 'Sensei_WC', 'load_woocommerce_integration_hooks' ) );
-
-		/**
-		 * Hook in WooCommerce Memberships functionality
-		 */
-		add_action( 'init', array( 'Sensei_WC_Memberships', 'load_wc_memberships_integration_hooks' ) );
-
-		/**
-		 * Hook in WooCommerce Subscriptions functionality
-		 */
-		add_action( 'init', array( 'Sensei_WC_Subscriptions', 'load_wc_subscriptions_integration_hooks' ) );
 	}
 
 	/**


### PR DESCRIPTION
This is a pretty simple one. Just removes the initialization hooks for `Sensei_WC`, `Sensei_WC_Memberships`, and `Sensei_WC_Subscriptions`.