### PR TITLE
Fix conflict with Jetpack shortcodes and Sensei video

### DIFF
--- a/includes/3rd-party/3rd-party.php
+++ b/includes/3rd-party/3rd-party.php
@@ -6,4 +6,5 @@
  */
 
 // Require compatibility files.
+require_once dirname( __FILE__ ) . '/jetpack.php';
 require_once dirname( __FILE__ ) . '/woocommerce.php';

--- a/includes/3rd-party/jetpack.php
+++ b/includes/3rd-party/jetpack.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Adds additional compatibility with Jetpack.
+ *
+ * @package 3rd-Party
+ */
+
+/**
+ * Overrides the shortcodes that Jetpack loads.
+ *
+ * Removes Vimeo and Youtube from the Jetpack shortcodes module to avoid iframes being converted
+ * to shortcodes.
+ *
+ * @since 2.0.0
+ *
+ * @param array $shortcodes Array of shortcodes to include.
+ * @return array Revised array of shortcodes to include.
+ */
+function remove_jetpack_shortcodes( $shortcodes ) {
+	$jetpack_shortcodes_dir = WP_CONTENT_DIR . '/plugins/jetpack/modules/shortcodes/';
+	$shortcodes_to_unload   = array( 'vimeo.php', 'youtube.php' );
+
+	foreach ( $shortcodes_to_unload as $shortcode ) {
+		$key = array_search( $jetpack_shortcodes_dir . $shortcode, $shortcodes, true );
+
+		if ( $key ) {
+			unset( $shortcodes[ $key ] );
+		}
+	}
+
+	return $shortcodes;
+}
+
+add_filter( 'jetpack_shortcodes_to_include', 'remove_jetpack_shortcodes' );

--- a/includes/3rd-party/jetpack.php
+++ b/includes/3rd-party/jetpack.php
@@ -17,16 +17,8 @@
  * @return array Revised array of shortcodes to include.
  */
 function remove_jetpack_shortcodes( $shortcodes ) {
-	$jetpack_shortcodes_dir = WP_CONTENT_DIR . '/plugins/jetpack/modules/shortcodes/';
-	$shortcodes_to_unload   = array( 'vimeo.php', 'youtube.php' );
-
-	foreach ( $shortcodes_to_unload as $shortcode ) {
-		$key = array_search( $jetpack_shortcodes_dir . $shortcode, $shortcodes, true );
-
-		if ( $key ) {
-			unset( $shortcodes[ $key ] );
-		}
-	}
+	unset( $shortcodes['vimeo'] );
+	unset( $shortcodes['youtube'] );
 
 	return $shortcodes;
 }

--- a/includes/3rd-party/jetpack.php
+++ b/includes/3rd-party/jetpack.php
@@ -16,11 +16,11 @@
  * @param array $shortcodes Array of shortcodes to include.
  * @return array Revised array of shortcodes to include.
  */
-function remove_jetpack_shortcodes( $shortcodes ) {
+function sensei_jetpack_remove_shortcodes( $shortcodes ) {
 	unset( $shortcodes['vimeo'] );
 	unset( $shortcodes['youtube'] );
 
 	return $shortcodes;
 }
 
-add_filter( 'jetpack_shortcodes_to_include', 'remove_jetpack_shortcodes' );
+add_filter( 'jetpack_shortcodes_to_include', 'sensei_jetpack_remove_shortcodes' );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -459,8 +459,6 @@ class Sensei_Main {
 		// Add plugin action links filter
 		add_filter( 'plugin_action_links_' . plugin_basename( $this->main_plugin_file_name ), array( $this, 'plugin_action_links' ) );
 
-		add_filter( 'jetpack_shortcodes_to_include', array( $this, 'remove_jetpack_shortcodes' ) );
-
 		/**
 		 * Load all Template hooks
 		 */
@@ -1096,32 +1094,6 @@ class Sensei_Main {
 	 */
 	public function wp_quicklatex_support() {
 		$this->maybe_add_latex_support_via( 'quicklatex_parser' );
-	}
-
-	/**
-	 * Overrides the shortcodes that Jetpack loads.
-	 *
-	 * Removes Vimeo and Youtube from the Jetpack shortcodes module to avoid iframes being converted
-	 * to shortcodes.
-	 *
-	 * @since 2.0.0
-	 *
-	 * @param array $shortcodes Array of shortcodes to include.
-	 * @return array Revised array of shortcodes to include.
-	 */
-	public function remove_jetpack_shortcodes( $shortcodes ) {
-		$jetpack_shortcodes_dir = WP_CONTENT_DIR . '/plugins/jetpack/modules/shortcodes/';
-		$shortcodes_to_unload   = array( 'vimeo.php', 'youtube.php' );
-
-		foreach ( $shortcodes_to_unload as $shortcode ) {
-			$key = array_search( $jetpack_shortcodes_dir . $shortcode, $shortcodes, true );
-
-			if ( $key ) {
-				unset( $shortcodes[ $key ] );
-			}
-		}
-
-		return $shortcodes;
 	}
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -459,6 +459,8 @@ class Sensei_Main {
 		// Add plugin action links filter
 		add_filter( 'plugin_action_links_' . plugin_basename( $this->main_plugin_file_name ), array( $this, 'plugin_action_links' ) );
 
+		add_filter( 'jetpack_shortcodes_to_include', array( $this, 'remove_jetpack_shortcodes' ) );
+
 		/**
 		 * Load all Template hooks
 		 */
@@ -1094,6 +1096,30 @@ class Sensei_Main {
 	 */
 	public function wp_quicklatex_support() {
 		$this->maybe_add_latex_support_via( 'quicklatex_parser' );
+	}
+
+	/**
+	 * Overrides the shortcodes that Jetpack loads.
+	 *
+	 * Removes Vimeo and Youtube from the Jetpack shortcodes module to avoid iframes being converted
+	 * to shortcodes.
+	 *
+	 * @since 2.0.0
+	 *
+	 * @param array $shortcodes Array of shortcodes to include.
+	 * @return array Revised array of shortcodes to include.
+	 */
+	public function remove_jetpack_shortcodes( $shortcodes ) {
+		$jetpack_shortcodes_dir = WP_CONTENT_DIR . '/plugins/jetpack/modules/shortcodes/';
+		$shortcodes_to_unload = array( 'vimeo.php', 'youtube.php' );
+
+		foreach ( $shortcodes_to_unload as $shortcode ) {
+			if ( $key = array_search( $jetpack_shortcodes_dir . $shortcode, $shortcodes ) ) {
+				unset( $shortcodes[$key] );
+			}
+		}
+
+		return $shortcodes;
 	}
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1111,11 +1111,13 @@ class Sensei_Main {
 	 */
 	public function remove_jetpack_shortcodes( $shortcodes ) {
 		$jetpack_shortcodes_dir = WP_CONTENT_DIR . '/plugins/jetpack/modules/shortcodes/';
-		$shortcodes_to_unload = array( 'vimeo.php', 'youtube.php' );
+		$shortcodes_to_unload   = array( 'vimeo.php', 'youtube.php' );
 
 		foreach ( $shortcodes_to_unload as $shortcode ) {
-			if ( $key = array_search( $jetpack_shortcodes_dir . $shortcode, $shortcodes ) ) {
-				unset( $shortcodes[$key] );
+			$key = array_search( $jetpack_shortcodes_dir . $shortcode, $shortcodes, true );
+
+			if ( $key ) {
+				unset( $shortcodes[ $key ] );
 			}
 		}
 


### PR DESCRIPTION
Fixes #2420.

The solution here was discussed with the Jetpack team. They recommended using the [`jetpack_shortcodes_to_include` filter](https://developer.jetpack.com/hooks/jetpack_shortcodes_to_include/) to turn off the Jetpack shortcodes for Vimeo and Youtube, which are video types both Sensei and Jetpack support.

Ideally, this code would only run for courses and lessons, but the `plugins_loaded` hook from which the filter fires seems too early to be able to determine the post type. Let me know if you've other ideas.

## Testing
1. Install Jetpack and connect to your WordPress.com account (you will not be able to do this locally).
2. Add Vimeo embed code to the _Video Embed Code_ field of a lesson and save.
3. Refresh the page and ensure that the field has not changed to a shortcode.
4. Browse to the lesson on the front-end and ensure the video is visible.
5. Add Youtube embed code to the _Course Video_ field of a course and save.
6. Refresh the page and ensure that the field has not changed to a shortcode.
7. Browse to the course on the front-end and ensure the video is visible.