### PR TITLE
Show and log deprecation notice for legacy shortcodes

### DIFF
--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -55,6 +55,38 @@ class Sensei_Legacy_Shortcodes {
 	}
 
 	/**
+	 * Output message on frontend to warn those with the privileges on the site.
+	 *
+	 * @param string $shortcode Shortcode that was deprecated.
+	 */
+	private static function output_deprecation_notice( $shortcode ) {
+		if ( ! is_user_logged_in() || ! current_user_can( 'edit_posts' ) ) {
+			return;
+		}
+		echo '<div class="sensei"><div class="sensei-message alert">';
+		$message = sprintf(
+			// translators: %1$s is the name of the shortcode; %2$s is the link to Sensei documentation.
+			__(
+				'The Sensei shortcode <strong>[%1$s]</strong> has been deprecated and will soon be removed. Check <a href="%2$s" rel="noopener">Sensei documentation</a> for alternatives.',
+				'woothemes-sensei'
+			),
+			$shortcode,
+			self::DOCS_SHORTCODE_URL
+		);
+		echo wp_kses(
+			$message,
+			array(
+				'a'      => array(
+					'href' => array(),
+					'rel'  => array(),
+				),
+				'strong' => array(),
+			)
+		);
+		echo '</div></div>';
+	}
+
+	/**
 	 * all_courses shortcode output function.
 	 *
 	 * The function should only be called indirectly through do_shortcode()
@@ -155,6 +187,9 @@ class Sensei_Legacy_Shortcodes {
 
 		// loop and get all courses html
 		ob_start();
+
+		self::output_deprecation_notice( $shortcode_specific_override );
+
 		self::initialise_legacy_course_loop();
 		$courses = ob_get_clean();
 
@@ -193,6 +228,8 @@ class Sensei_Legacy_Shortcodes {
 		$shortcode_override = 'usercourses';
 
 		ob_start();
+
+		self::output_deprecation_notice( 'usercourses' );
 
 		if ( is_user_logged_in() ) {
 

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -40,6 +40,8 @@ class Sensei_Legacy_Shortcodes {
 	private static function throw_deprecation_warning( $shortcode ) {
 		$permalink = get_permalink();
 
+		// translators: %s is the name of the shortcode.
+		$caller  = sprintf( __( 'Shortcode `[%s]`', 'woothemes-sensei' ), $shortcode );
 		$message = sprintf(
 			// translators: %1$s is the name of the shortcode; %2$s is page URL with shortcode; %3$s is URL for shortcode documentation.
 			__(
@@ -51,7 +53,7 @@ class Sensei_Legacy_Shortcodes {
 			self::DOCS_SHORTCODE_URL
 		);
 
-		_doing_it_wrong( __METHOD__, esc_html( $message ), '2.0.0' );
+		_doing_it_wrong( esc_html( $caller ), esc_html( $message ), '2.0.0' );
 	}
 
 	/**

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -6,8 +6,6 @@
  * All functionality pertaining the the shortcodes before
  * version 1.9
  *
- * These shortcodes will soon be deprecated.
- *
  * @package Content
  * @subpackage Shortcode
  * @author Automattic
@@ -15,6 +13,8 @@
  * @since       1.6.0
  */
 class Sensei_Legacy_Shortcodes {
+
+	const DOCS_SHORTCODE_URL = 'https://senseilms.com/documentation/';
 
 	/**
 	 * Add the legacy shortcodes to WordPress
@@ -31,6 +31,29 @@ class Sensei_Legacy_Shortcodes {
 		add_shortcode( 'usercourses', array( __CLASS__, 'user_courses' ) );
 
 	}
+
+	/**
+	 * Call `_doing_it_wrong()` for a deprecated shortcode.
+	 *
+	 * @param string $shortcode Shortcode that was deprecated.
+	 */
+	private static function throw_deprecation_warning( $shortcode ) {
+		$permalink = get_permalink();
+
+		$message = sprintf(
+			// translators: %1$s is the name of the shortcode; %2$s is page URL with shortcode; %3$s is URL for shortcode documentation.
+			__(
+				'The shortcode `[%1$s]` (used on: %2$s) has been deprecated since Sensei v1.9.0. Please visit %3$s for alternatives.',
+				'woothemes-sensei'
+			),
+			$shortcode,
+			$permalink,
+			self::DOCS_SHORTCODE_URL
+		);
+
+		_doing_it_wrong( __METHOD__, esc_html( $message ), '2.0.0' );
+	}
+
 	/**
 	 * all_courses shortcode output function.
 	 *
@@ -114,6 +137,7 @@ class Sensei_Legacy_Shortcodes {
 	 * @return string
 	 */
 	public static function generate_shortcode_courses( $title, $shortcode_specific_override ) {
+		self::throw_deprecation_warning( $shortcode_specific_override, '1.9.0' );
 
 		global  $shortcode_override, $posts_array;
 
@@ -143,7 +167,7 @@ class Sensei_Legacy_Shortcodes {
 			$after = '</section>';
 
 			// assemble
-			$content = $before . $courses . $after;
+			$content .= $before . $courses . $after;
 
 		}
 
@@ -162,6 +186,8 @@ class Sensei_Legacy_Shortcodes {
 	 */
 	public static function user_courses( $atts, $content = null ) {
 		global $shortcode_override;
+		self::throw_deprecation_warning( 'usercourses', '1.9.0' );
+
 		extract( shortcode_atts( array( 'amount' => 0 ), $atts ) );
 
 		$shortcode_override = 'usercourses';

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -67,7 +67,7 @@ class Sensei_Legacy_Shortcodes {
 		$message = sprintf(
 			// translators: %1$s is the name of the shortcode; %2$s is the link to Sensei documentation.
 			__(
-				'The Sensei shortcode <strong>[%1$s]</strong> has been deprecated and will soon be removed. Check <a href="%2$s" rel="noopener">Sensei documentation</a> for alternatives.',
+				'The Sensei shortcode <strong>[%1$s]</strong> has been deprecated and will soon be removed. Check <a href="%2$s" rel="noopener">Sensei documentation</a> for alternatives. Only site editors will see this notice.',
 				'woothemes-sensei'
 			),
 			$shortcode,

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -43,7 +43,7 @@ class Sensei_Legacy_Shortcodes {
 		$message = sprintf(
 			// translators: %1$s is the name of the shortcode; %2$s is page URL with shortcode; %3$s is URL for shortcode documentation.
 			__(
-				'The shortcode `[%1$s]` (used on: %2$s) has been deprecated since Sensei v1.9.0. Please visit %3$s for alternatives.',
+				'The shortcode `[%1$s]` (used on: %2$s) has been deprecated since Sensei v1.9.0. Check %3$s for alternatives.',
 				'woothemes-sensei'
 			),
 			$shortcode,

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -202,7 +202,7 @@ class Sensei_Legacy_Shortcodes {
 			$after = '</section>';
 
 			// assemble
-			$content .= $before . $courses . $after;
+			$content = $before . $courses . $after;
 
 		}
 

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -14,7 +14,7 @@
  */
 class Sensei_Legacy_Shortcodes {
 
-	const DOCS_SHORTCODE_URL = 'https://senseilms.com/documentation/';
+	const DOCS_SHORTCODE_URL = 'https://senseilms.com/documentation/shortcodes/';
 
 	/**
 	 * Add the legacy shortcodes to WordPress


### PR DESCRIPTION
This PR does two things with legacy shortcodes:
- Calls `_doing_it_wrong` to log the deprecated usage.
- Potentially controversially, for logged in users with `edit_posts` capabilities, it displays an alert notifying them of the deprecated shortcode usage.

Please let me know if you:
- Have some suggestions on language for either message.
- Think the frontend notice is overkill. 

Shortcode deprecations feel a bit different than other types of deprecations to me because it can be non-devs that are using them. That said, they also don't "break" the site when they are no longer declared.

### Testing Instructions
- Create pages with legacy shortcodes: `[allcourses]`, `[newcourses]`, '[featuredcourses]`, '[freecourses]`, `[paidcourses]`, and `[usercourses]` (just as a note, all except for `[usercourses]` are generally handled by the same method).
- With logging enabled, verify the deprecated shortcode usage is logged.
- View on front end as user with `edit_post` [cap](https://codex.wordpress.org/Roles_and_Capabilities). Verify the notice appears above the shortcodes.
- View on front end as guest or subscriber user. Verify the notice does not appear (but the deprecation notices will still be logged). 