### PR TITLE
Remove deprecated `sensei_woocommerce_in_cart_message` action

### DIFF
--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -502,7 +502,6 @@ class Sensei_Templates {
 
 		// deprecate all these hooks
 		sensei_do_deprecated_action( 'sensei_course_start', '1.9.0', 'sensei_single_course_content_inside_before' );
-		sensei_do_deprecated_action( 'sensei_woocommerce_in_cart_message', '1.9.0', 'sensei_single_course_content_inside_before' );
 		sensei_do_deprecated_action( 'sensei_course_meta', '1.9.0', 'sensei_single_course_content_inside_before' );
 		sensei_do_deprecated_action( 'sensei_course_meta_video', '1.9.0', 'sensei_single_course_content_inside_before' );
 


### PR DESCRIPTION
This is a wee PR to remove reference to a very old/deprecated action, `sensei_woocommerce_in_cart_message`. It has been deprecated with warning since 1.9.0 and feels safe to remove.