### PR TITLE
Remove WooCommerce $product handling in shortcode

### DIFF
--- a/includes/shortcodes/class-sensei-shortcode-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-courses.php
@@ -201,7 +201,6 @@ class Sensei_Shortcode_Courses implements Sensei_Shortcode_Interface {
 	public function render() {
 
 		global $wp_query;
-		$this->maybe_store_global_product();
 
 		// keep a reference to old query
 		$current_global_query = $wp_query;
@@ -216,32 +215,8 @@ class Sensei_Shortcode_Courses implements Sensei_Shortcode_Interface {
 		// restore old query
 		$wp_query = $current_global_query;
 
-		$this->restore_global_product();
-
 		return $shortcode_output;
 
 	}//end render()
-
-	private function maybe_store_global_product() {
-		global $product;
-		if ( ! Sensei_WC::is_woocommerce_active() ) {
-			return;
-		}
-		if ( isset( $product ) && $product ) {
-			$this->global_product = $product;
-		} else {
-			$this->global_product = null;
-		}
-	}
-
-	private function restore_global_product() {
-		global $product;
-		if ( ! Sensei_WC::is_woocommerce_active() ) {
-			return;
-		}
-		if ( isset( $this->global_product ) && $this->global_product ) {
-			$product = $this->global_product;
-		}
-	}
 
 }

--- a/includes/shortcodes/class-sensei-shortcode-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-courses.php
@@ -202,18 +202,12 @@ class Sensei_Shortcode_Courses implements Sensei_Shortcode_Interface {
 
 		global $wp_query;
 
-		// keep a reference to old query
-		$current_global_query = $wp_query;
-
 		// assign the query setup in $this-> setup_course_query
 		$wp_query = $this->query;
 
 		ob_start();
 		Sensei_Templates::get_template( 'loop-course.php' );
 		$shortcode_output = ob_get_clean();
-
-		// restore old query
-		$wp_query = $current_global_query;
 
 		return $shortcode_output;
 

--- a/includes/shortcodes/class-sensei-shortcode-featured-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-featured-courses.php
@@ -111,18 +111,12 @@ class Sensei_Shortcode_Featured_Courses implements Sensei_Shortcode_Interface {
 
 		global $wp_query;
 
-		// keep a reference to old query
-		$current_global_query = $wp_query;
-
 		// assign the query setup in $this-> setup_course_query
 		$wp_query = $this->query;
 
 		ob_start();
 		Sensei_Templates::get_template( 'loop-course.php' );
 		$shortcode_output = ob_get_clean();
-
-		// restore old query
-		$wp_query = $current_global_query;
 
 		return $shortcode_output;
 

--- a/includes/shortcodes/class-sensei-shortcode-lesson-page.php
+++ b/includes/shortcodes/class-sensei-shortcode-lesson-page.php
@@ -94,9 +94,6 @@ class Sensei_Shortcode_Lesson_Page implements Sensei_Shortcode_Interface {
 		Sensei_Templates::get_template( 'content-single-lesson.php' );
 		$shortcode_output = ob_get_clean();
 
-		// set back the global query
-		wp_reset_query();
-
 		return $shortcode_output;
 
 	}//end render()

--- a/includes/shortcodes/class-sensei-shortcode-loader.php
+++ b/includes/shortcodes/class-sensei-shortcode-loader.php
@@ -164,6 +164,7 @@ class Sensei_Shortcode_Loader {
 		$output = $shortcode->render();
 
 		// Restore query and other globals.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride
 		$wp_query = $current_global_query;
 		wp_reset_postdata();
 

--- a/includes/shortcodes/class-sensei-shortcode-loader.php
+++ b/includes/shortcodes/class-sensei-shortcode-loader.php
@@ -135,6 +135,7 @@ class Sensei_Shortcode_Loader {
 	 * @return string
 	 */
 	public function render_shortcode( $attributes = '', $content = '', $code ) {
+		global $wp_query;
 
 		// only respond if the shortcode that we've added shortcode
 		// classes for.
@@ -157,7 +158,16 @@ class Sensei_Shortcode_Loader {
 
 		}
 
-		return $shortcode->render();
+		// Save current query.
+		$current_global_query = $wp_query;
+
+		$output = $shortcode->render();
+
+		// Restore query and other globals.
+		$wp_query = $current_global_query;
+		wp_reset_postdata();
+
+		return $output;
 
 	}
 

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -290,9 +290,6 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		// setup the course query that will be used when rendering
 		$this->setup_course_query();
 
-		// keep a reference to old query
-		$current_global_query = $wp_query;
-
 		// assign the query setup in $this-> setup_course_query
 		$wp_query = $this->query;
 
@@ -319,11 +316,6 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		$shortcode_output = ob_get_clean();
 
 		$this->detach_shortcode_hooks();
-
-		// restore old query
-		$wp_query = $current_global_query;
-
-		wp_reset_postdata();
 
 		return $shortcode_output;
 

--- a/includes/shortcodes/class-sensei-shortcode-user-messages.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-messages.php
@@ -99,9 +99,6 @@ class Sensei_Shortcode_User_Messages implements Sensei_Shortcode_Interface {
 		Sensei_Templates::get_part( 'loop', 'message' );
 		$messages_html = ob_get_clean();
 
-		// set back the global query
-		wp_reset_query();
-
 		return $messages_html;
 
 	}//end render()


### PR DESCRIPTION
For background, the product handling functionality was added in [this PR](https://github.com/Automattic/sensei/pull/1826) to solve [this issue](https://github.com/Automattic/sensei/issues/1800).

After some testing, it seemed that the shortcode was only changing the `$product` global when it changed the global post data. This happened even when WCPC was not enabled, and so it did not appear to be related to Sensei's WooCommerce functionality. Ensuring that the global post data is reset properly after the shortcode is rendered fixes the issue (and other related issues that I found along the way).

Code to save and restore the global `$wp_query` was already present in many of Sensei's shortcodes. However, they were inconsistent in how they restore the query. Some would reset the post data, others didn't. This PR removes the handling within the individual shortcodes in favor of doing it globally within the [shortcode loader](https://github.com/Automattic/sensei/compare/release/2.0...remove/wc-product-handling-in-shortcode?expand=1#diff-2209d4b2a462f41a37d8c0620566f8c0).

## Testing instructions

- See #1800 and follow the testing instructions there. Make sure the upsell products appear underneath the shortcode content.
- Repeat with the following shortcodes (which were modified in this PR). Ensure that they output correctly, and the upsell products appear as expected.
  - `[sensei_featured_courses]`
  - `[sensei_lesson_page]` (Note that this shortcode doesn't seem to output anything when you give it a Lesson ID, but it didn't seem to work before the PR, and I'm not sure it ever has).
  - `[sensei_user_courses]`
  - `[sensei_user_messages]`