### PR TITLE
Remove deprecated WC methods from `Sensei_Main` class

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1185,17 +1185,6 @@ class Sensei_Main {
 	}
 
 	/**
-	 * Sensei_woocommerce_reactivate_subscription
-	 *
-	 * @deprecated since 1.9.0, moved to Sensei_WC class
-	 * @param int   $user_id User ID.
-	 * @param mixed $subscription_key Subscription Key.
-	 */
-	public function sensei_woocommerce_reactivate_subscription( $user_id, $subscription_key ) {
-		Sensei_WC::reactivate_subscription( $user_id, $subscription_key );
-	}
-
-	/**
 	 * WooCommerce Subscription Ended
 	 *
 	 * @deprecated since 1.9.0, moved to Sensei_WC class

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1185,17 +1185,6 @@ class Sensei_Main {
 	}
 
 	/**
-	 * WooCommerce Subscription Ended
-	 *
-	 * @deprecated since 1.9.0, moved to Sensei_WC class
-	 * @param int   $user_id The user id.
-	 * @param mixed $subscription_key The sub key.
-	 */
-	public function sensei_woocommerce_subscription_ended( $user_id, $subscription_key ) {
-		Sensei_WC::end_subscription( $user_id, $subscription_key );
-	}
-
-	/**
 	 * Sensei_woocommerce_complete_order description
 	 *
 	 * @deprecated since 1.9.0 use Sensei_WC::complete_order( $order_id );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1185,20 +1185,6 @@ class Sensei_Main {
 	}
 
 	/**
-	 * Sensei_woocommerce_complete_order description
-	 *
-	 * @deprecated since 1.9.0 use Sensei_WC::complete_order( $order_id );
-	 * @since   1.0.3
-	 * @access  public
-	 * @param   int $order_id WC order ID.
-	 *
-	 * @return  void
-	 */
-	public function sensei_woocommerce_complete_order( $order_id = 0 ) {
-		Sensei_WC::complete_order( $order_id );
-	}
-
-	/**
 	 * Runs when an order is cancelled.
 	 *
 	 * @deprecated since 1.9.0

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1185,20 +1185,6 @@ class Sensei_Main {
 	}
 
 	/**
-	 * Change order status with virtual products to completed
-	 *
-	 * @deprecated since 1.9.0 use Sensei_WC::virtual_order_payment_complete( $order_status, $order_id )
-	 *
-	 * @since  1.1.0
-	 * @param string $order_status Order Status.
-	 * @param int    $order_id Order ID.
-	 * @return string
-	 **/
-	public function virtual_order_payment_complete( $order_status, $order_id ) {
-		return Sensei_WC::virtual_order_payment_complete( $order_status, $order_id );
-	}
-
-	/**
 	 * Add custom action links on the plugin screen.
 	 *
 	 * @param   mixed $actions Plugin Actions Links.

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1185,19 +1185,6 @@ class Sensei_Main {
 	}
 
 	/**
-	 * Disable guest checkout if a course product is in the cart
-	 *
-	 * @deprecated since 1.9.0
-	 * @param  boolean $guest_checkout Current guest checkout setting.
-	 * @return boolean                 Modified guest checkout setting.
-	 */
-	public function disable_guest_checkout( $guest_checkout ) {
-
-		return Sensei_WC::disable_guest_checkout( $guest_checkout );
-
-	}//end disable_guest_checkout()
-
-	/**
 	 * Change order status with virtual products to completed
 	 *
 	 * @deprecated since 1.9.0 use Sensei_WC::virtual_order_payment_complete( $order_status, $order_id )

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1185,21 +1185,6 @@ class Sensei_Main {
 	}
 
 	/**
-	 * Sensei_woocommerce_email_course_details adds detail to email
-	 *
-	 * @deprecated since 1.9.0 use Sensei_WC::email_course_details
-	 *
-	 * @since   1.4.5
-	 * @access  public
-	 * @param   WC_Order $order Order.
-	 *
-	 * @return  void
-	 */
-	public function sensei_woocommerce_email_course_details( $order ) {
-		Sensei_WC::email_course_details( $order );
-	} // end func email course details
-
-	/**
 	 * Sensei_woocommerce_reactivate_subscription
 	 *
 	 * @deprecated since 1.9.0, moved to Sensei_WC class

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1185,19 +1185,6 @@ class Sensei_Main {
 	}
 
 	/**
-	 * Setup required WooCommerce settings.
-	 *
-	 * @access  public
-	 * @since   1.1.0
-	 * @return  void
-	 */
-	public function set_woocommerce_functionality() {
-
-		_deprecated_function( 'Sensei()->set_woocommerce_functionality', 'Sensei 1.9.0' );
-
-	} // End set_woocommerce_functionality()
-
-	/**
 	 * Disable guest checkout if a course product is in the cart
 	 *
 	 * @deprecated since 1.9.0

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1185,25 +1185,6 @@ class Sensei_Main {
 	}
 
 	/**
-	 * Returns the WooCommerce Product Object
-	 *
-	 * The code caters for pre and post WooCommerce 2.2 installations.
-	 *
-	 * @deprecated since 1.9.0
-	 * @since   1.1.1
-	 *
-	 * @param   integer $wc_product_id Product ID or Variation ID.
-	 * @param   string  $product_type  '' or 'variation'.
-	 *
-	 * @return   WC_Product $wc_product_object
-	 */
-	public function sensei_get_woocommerce_product_object( $wc_product_id = 0, $product_type = '' ) {
-
-		return Sensei_WC::get_product_object( $wc_product_id, $product_type );
-
-	} // End sensei_get_woocommerce_product_object()
-
-	/**
 	 * Setup required WooCommerce settings.
 	 *
 	 * @access  public

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1185,21 +1185,6 @@ class Sensei_Main {
 	}
 
 	/**
-	 * Runs when an order is cancelled.
-	 *
-	 * @deprecated since 1.9.0
-	 *
-	 * @since   1.2.0
-	 * @param   integer $order_id order ID.
-	 * @return  void
-	 */
-	public function sensei_woocommerce_cancel_order( $order_id ) {
-
-		Sensei_WC::cancel_order( $order_id );
-
-	} // End sensei_woocommerce_cancel_order()
-
-	/**
 	 * Sensei_activate_subscription runs when a subscription product is purchased
 	 *
 	 * @deprecated since 1.9.0

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1185,23 +1185,6 @@ class Sensei_Main {
 	}
 
 	/**
-	 * Sensei_activate_subscription runs when a subscription product is purchased
-	 *
-	 * @deprecated since 1.9.0
-	 * @since   1.2.0
-	 * @access  public
-	 *
-	 * @param   integer $order_id order ID.
-	 *
-	 * @return  void
-	 */
-	public function sensei_activate_subscription( $order_id = 0 ) {
-
-		Sensei_WC::activate_subscription( $order_id );
-
-	} // End sensei_activate_subscription()
-
-	/**
 	 * If WooCommerce is activated and the customer has purchased the course, update Sensei to indicate that they are taking the course.
 	 *
 	 * @deprecated since 1.9.0

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1185,21 +1185,6 @@ class Sensei_Main {
 	}
 
 	/**
-	 * If WooCommerce is activated and the customer has purchased the course, update Sensei to indicate that they are taking the course.
-	 *
-	 * @deprecated since 1.9.0
-	 * @since  1.0.0
-	 * @param  int          $course_id  (default: 0).
-	 * @param  array/Object $order_user (default: array()) Specific user's data.
-	 * @return bool|int
-	 */
-	public function woocommerce_course_update( $course_id = 0, $order_user = array() ) {
-
-		return Sensei_WC::course_update( $course_id, $order_user );
-
-	} // End woocommerce_course_update()
-
-	/**
 	 * Returns the WooCommerce Product Object
 	 *
 	 * The code caters for pre and post WooCommerce 2.2 installations.


### PR DESCRIPTION
This removes the following methods:
  - `Sensei_Main::sensei_woocommerce_email_course_details`
  - `Sensei_Main::sensei_woocommerce_reactivate_subscription`
  - `Sensei_Main::sensei_woocommerce_subscription_ended`
  - `Sensei_Main::sensei_woocommerce_complete_order`
  - `Sensei_Main::sensei_woocommerce_cancel_order`
  - `Sensei_Main::sensei_activate_subscription`
  - `Sensei_Main::woocommerce_course_update`
  - `Sensei_Main::sensei_get_woocommerce_product_object`
  - `Sensei_Main::set_woocommerce_functionality`
  - `Sensei_Main::disable_guest_checkout`
  - `Sensei_Main::virtual_order_payment_complete`