### PR TITLE
Move `woocommerce_disable_admin_bar` code to 3rd-party file

### DIFF
--- a/includes/3rd-party/woocommerce.php
+++ b/includes/3rd-party/woocommerce.php
@@ -19,3 +19,15 @@ function sensei_woocommerce_prevent_admin_access( $prevent_access ) {
 	return $prevent_access;
 }
 add_filter( 'woocommerce_prevent_admin_access', 'sensei_woocommerce_prevent_admin_access' );
+
+/**
+ * Show admin bar to users who can 'edit_courses'.
+ */
+function sensei_woocommerce_show_admin_bar() {
+	if ( current_user_can( 'edit_courses' ) ) {
+		add_filter( 'woocommerce_disable_admin_bar', '__return_false', 10, 1 );
+	}
+}
+
+// Use WooCommerce filter to show admin bar to Teachers.
+add_action( 'init', 'sensei_woocommerce_show_admin_bar' );

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -97,9 +97,6 @@ class Sensei_Frontend {
 		// Only show course & lesson excerpts in search results.
 		add_filter( 'the_content', array( $this, 'sensei_search_results_excerpt' ) );
 
-		// Use WooCommerce filter to show admin bar to Teachers.
-		add_action( 'init', array( $this, 'sensei_show_admin_bar' ) );
-
 		// Lesson tags.
 		add_action( 'sensei_lesson_meta_extra', array( $this, 'lesson_tags_display' ), 10, 1 );
 		add_action( 'pre_get_posts', array( $this, 'lesson_tag_archive_filter' ), 10, 1 );
@@ -1816,22 +1813,6 @@ class Sensei_Frontend {
 			Sensei()->notices->add_notice( $message, 'alert' );
 
 	}//end login_message_process()
-
-
-	/**
-	 * Show admin bar to users who can 'edit_courses'.
-	 *
-	 * @return void redirect
-	 */
-	public function sensei_show_admin_bar() {
-
-		if ( current_user_can( 'edit_courses' ) ) {
-
-			add_filter( 'woocommerce_disable_admin_bar', '__return_false', 10, 1 );
-
-		}
-
-	}
 
 } // End Class
 


### PR DESCRIPTION
Similar to #2380 (the other code in the 3rd-party file), this is actually dead code for the same reason: teachers [now have](https://github.com/Automattic/sensei/commit/2b1a1adc6a93d216c0b592bec3862ca5a1f8973f) the `edit_posts` capability.

## Testing
- Log in as a teacher.
- Make sure you can see the WP admin toolbar at the top while you're on a frontend page.