### PR TITLE
Remove invalid course video from piano course

### DIFF
--- a/dummy_data.xml
+++ b/dummy_data.xml
@@ -1794,10 +1794,6 @@ The content for this sample course is provided with permission by <a title="HDpi
 			<wp:meta_key>_course_featured</wp:meta_key>
 			<wp:meta_value><![CDATA[featured]]></wp:meta_value>
 		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_course_video_embed</wp:meta_key>
-			<wp:meta_value><![CDATA[&lt;iframe width=&quot;853&quot; height=&quot;480&quot; src=&quot;//www.youtube.com/embed/qR0l_tyJ9O8?rel=0&quot; frameborder=&quot;0&quot; allowfullscreen&gt;&lt;/iframe&gt;]]></wp:meta_value>
-		</wp:postmeta>
 		<wp:comment>
 			<wp:comment_id>218692</wp:comment_id>
 			<wp:comment_author><![CDATA[]]></wp:comment_author>


### PR DESCRIPTION
Fixes #2267.

The embed code linked to a dead video, so I've removed it entirely.

## Testing
1. Import `dummy_data.xml`.
2. Browse to the _How to Play the Piano_ course.
3. Ensure there is no video embed code displayed.