### PR TITLE
Remove WooCommerce related comments and links

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -748,7 +748,7 @@ class Sensei_Question {
 	 * This function has to be run inside the quiz question loop on the single quiz page.
 	 *
 	 * It show the correct/incorrect answer per question depending on the quiz logic explained here:
-	 * https://docs.woocommerce.com/document/sensei-quiz-settings-flowchart/
+	 * https://senseilms.com/documentation/quiz-settings-flowchart/
 	 *
 	 * Pseudo code for logic:  https://github.com/Automattic/sensei/issues/1422#issuecomment-214494263
 	 *

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -16,7 +16,7 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 
 	const SENSEI_SETTING_NAME = 'sensei_usage_tracking_enabled';
 
-	const SENSEI_TRACKING_INFO_URL = 'https://docs.woocommerce.com/document/what-data-does-sensei-track';
+	const SENSEI_TRACKING_INFO_URL = 'https://senseilms.com/documentation/what-data-does-sensei-track/';
 
 	protected function __construct() {
 		parent::__construct();

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1561,8 +1561,6 @@ class Sensei_Utils {
 		 *
 		 * @since 1.9.3
 		 *
-		 * @hooked Sensei_WC::get_subscription_user_started_course
-		 *
 		 * @param bool $user_started_course
 		 * @param integer $course_id
 		 */

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -951,8 +951,6 @@ function sensei_can_user_view_lesson( $lesson_id = '', $user_id = '' ) {
 	 *
 	 * @since 1.9.0
 	 *
-	 * @hooked Sensei_WC::alter_can_user_view_lesson
-	 *
 	 * @param bool $can_user_view_lesson
 	 * @param string $lesson_id
 	 * @param string $user_id

--- a/templates/single-course.php
+++ b/templates/single-course.php
@@ -27,7 +27,6 @@
 	 * @hooked Sensei()->frontend->sensei_course_start     -  10
 	 * @hooked Sensei_Course::the_title                    -  10
 	 * @hooked Sensei()->course->course_image              -  20
-	 * @hooked Sensei_WC::course_in_cart_message           -  20
 	 * @hooked Sensei_Course::the_course_enrolment_actions -  30
 	 * @hooked Sensei()->message->send_message_link        -  35
 	 * @hooked Sensei_Course::the_course_video             -  40


### PR DESCRIPTION
This PR removes references to WooCommerce and `Sensei_WC` from some comments and links.

Note that there are a few references left that point to Sensei's current product page (https://woocommerce.com/products/sensei/). When we get a page for Sensei on WordPress.org, we should update these links as well.