### PR TITLE
Adds deprecation notices for WooCommerce related template functions

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -126,18 +126,23 @@ function sensei_start_course_form( $course_id ) {
 } // End sensei_start_course_form()
 
 
-	/**
-	 * sensei_wc_add_to_cart function.
-	 *
-	 * @deprecated since Sensei_WC::the_add_to_cart_button_html( $course_id );
-	 * @access public
-	 * @param mixed $course_id
-	 * @return void
-	 */
+/**
+ * sensei_wc_add_to_cart function.
+ *
+ * @deprecated since Sensei_WC::the_add_to_cart_button_html( $course_id );
+ * @access public
+ *
+ * @param mixed $course_id Course Post ID.
+ * @return void
+ */
 function sensei_wc_add_to_cart( $course_id ) {
+	_deprecated_function( __FUNCTION__, '1.9.0', 'Sensei_WC::the_add_to_cart_button_html' );
+
+	if ( ! method_exists( 'Sensei_WC', 'the_add_to_cart_button_html' ) ) {
+		return;
+	}
 
 	Sensei_WC::the_add_to_cart_button_html( $course_id );
-
 } // End sensei_wc_add_to_cart()
 
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -146,14 +146,21 @@ function sensei_wc_add_to_cart( $course_id ) {
 } // End sensei_wc_add_to_cart()
 
 
-	/**
-	 * sensei_check_if_product_is_in_cart function.
-	 *
-	 * @deprecated since 1.9.0
-	 * @param int $wc_post_id (default: 0)
-	 * @return bool
-	 */
+/**
+ * sensei_check_if_product_is_in_cart function.
+ *
+ * @deprecated since 1.9.0 use is_product_in_cart()
+ *
+ * @param int $wc_post_id Post ID for product (default: 0).
+ * @return bool
+ */
 function sensei_check_if_product_is_in_cart( $wc_product_id = 0 ) {
+	_deprecated_function( __FUNCTION__, '1.9.0', 'Sensei_WC::is_product_in_cart' );
+
+	if ( ! method_exists( 'Sensei_WC', 'is_product_in_cart' ) ) {
+		return false;
+	}
+
 	return Sensei_WC::is_product_in_cart( $wc_product_id );
 } // End sensei_check_if_product_is_in_cart()
 


### PR DESCRIPTION
Replaces #2437

This adds deprecation notices for two deprecated WC related functions.

- `sensei_wc_add_to_cart()` (since 1.9.0)
- `sensei_check_if_product_is_in_cart()` (since 1.9.0)