### PR TITLE
Migrate from option `woothemes-sensei-settings` to `sensei-settings`

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -282,7 +282,7 @@ class Sensei_Admin {
 
 		$allowed_post_types      = apply_filters( 'sensei_scripts_allowed_post_types', array( 'lesson', 'course', 'question' ) );
 		$allowed_post_type_pages = apply_filters( 'sensei_scripts_allowed_post_type_pages', array( 'edit.php', 'post-new.php', 'post.php', 'edit-tags.php' ) );
-		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', 'sensei_analysis', 'sensei_learners', 'sensei_updates', 'woothemes-sensei-settings', $this->lesson_order_page_slug, $this->course_order_page_slug ) );
+		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', 'sensei_analysis', 'sensei_learners', 'sensei_updates', 'sensei-settings', $this->lesson_order_page_slug, $this->course_order_page_slug ) );
 
 		// Global Styles for icons and menu items
 		wp_register_style( 'woothemes-sensei-global', Sensei()->plugin_url . 'assets/css/global.css', '', Sensei()->version, 'screen' );
@@ -349,14 +349,14 @@ class Sensei_Admin {
 
 			<p class="submit">
 
-				<a href="<?php echo esc_url( add_query_arg( 'install_sensei_pages', 'true', admin_url( 'admin.php?page=woothemes-sensei-settings' ) ) ); ?>"
+				<a href="<?php echo esc_url( add_query_arg( 'install_sensei_pages', 'true', admin_url( 'admin.php?page=sensei-settings' ) ) ); ?>"
 				   class="button-primary">
 
 					<?php esc_html_e( 'Install Sensei Pages', 'woothemes-sensei' ); ?>
 
 				</a>
 
-				<a class="skip button" href="<?php echo esc_url( add_query_arg( 'skip_install_sensei_pages', 'true', admin_url( 'admin.php?page=woothemes-sensei-settings' ) ) ); ?>">
+				<a class="skip button" href="<?php echo esc_url( add_query_arg( 'skip_install_sensei_pages', 'true', admin_url( 'admin.php?page=sensei-settings' ) ) ); ?>">
 
 					<?php esc_html_e( 'Skip setup', 'woothemes-sensei' ); ?>
 
@@ -383,7 +383,7 @@ class Sensei_Admin {
 			</p>
 
 			<p class="submit">
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=woothemes-sensei-settings' ) ); ?>" class="button-primary"><?php esc_html_e( 'Settings', 'woothemes-sensei' ); ?></a> <a class="docs button" href="http://www.woothemes.com/sensei-docs/">
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=sensei-settings' ) ); ?>" class="button-primary"><?php esc_html_e( 'Settings', 'woothemes-sensei' ); ?></a> <a class="docs button" href="http://www.woothemes.com/sensei-docs/">
 					<?php esc_html_e( 'Documentation', 'woothemes-sensei' ); ?>
 				</a>
 			</p>
@@ -447,7 +447,7 @@ class Sensei_Admin {
 
 			if ( get_option( 'skip_install_sensei_pages' ) != 1 && Sensei()->get_page_id( 'course' ) < 1 && ! isset( $_GET['install_sensei_pages'] ) && ! isset( $_GET['skip_install_sensei_pages'] ) ) {
 				add_action( 'admin_notices', array( $this, 'admin_install_notice' ) );
-			} elseif ( ! isset( $_GET['page'] ) || $_GET['page'] != 'woothemes-sensei-settings' ) {
+			} elseif ( ! isset( $_GET['page'] ) || $_GET['page'] !== 'sensei-settings' ) {
 				add_action( 'admin_notices', array( $this, 'admin_installed_notice' ) );
 			} // End If Statement
 		} // End If Statement
@@ -1154,7 +1154,7 @@ class Sensei_Admin {
 	public function course_order_screen() {
 
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-		wp_enqueue_script( 'woothemes-sensei-settings', esc_url( Sensei()->plugin_url . 'assets/js/settings' . $suffix . '.js' ), array( 'jquery', 'jquery-ui-sortable' ), Sensei()->version );
+		wp_enqueue_script( 'sensei-settings', esc_url( Sensei()->plugin_url . 'assets/js/settings' . $suffix . '.js' ), array( 'jquery', 'jquery-ui-sortable' ), Sensei()->version );
 
 		?>
 		<div id="<?php echo esc_attr( $this->course_order_page_slug ); ?>" class="wrap <?php echo esc_attr( $this->course_order_page_slug ); ?>">
@@ -1324,7 +1324,7 @@ class Sensei_Admin {
 	public function lesson_order_screen() {
 
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-		wp_enqueue_script( 'woothemes-sensei-settings', esc_url( Sensei()->plugin_url . 'assets/js/settings' . $suffix . '.js' ), array( 'jquery', 'jquery-ui-sortable' ), Sensei()->version );
+		wp_enqueue_script( 'sensei-settings', esc_url( Sensei()->plugin_url . 'assets/js/settings' . $suffix . '.js' ), array( 'jquery', 'jquery-ui-sortable' ), Sensei()->version );
 
 		?>
 		<div id="<?php echo esc_attr( $this->lesson_order_page_slug ); ?>" class="wrap <?php echo esc_attr( $this->lesson_order_page_slug ); ?>">
@@ -1691,7 +1691,7 @@ class Sensei_Admin {
 
 		// only fire on the settings page
 		if ( ! isset( $_GET['page'] )
-			|| 'woothemes-sensei-settings' != $_GET['page']
+			|| 'sensei-settings' !== $_GET['page']
 			|| 1 == get_option( 'skip_install_sensei_pages' ) ) {
 
 			return;

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -74,7 +74,7 @@ class Sensei_Analysis {
 
 		wp_enqueue_style( 'woothemes-sensei-admin' );
 
-		wp_enqueue_style( 'woothemes-sensei-settings-api', Sensei()->plugin_url . 'assets/css/settings.css', '', Sensei()->version );
+		wp_enqueue_style( 'sensei-settings-api', Sensei()->plugin_url . 'assets/css/settings.css', '', Sensei()->version );
 
 	} // End enqueue_styles()
 

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -63,6 +63,7 @@ class Sensei_Data_Cleaner {
 		'sensei_usage_tracking_opt_in_hide',
 		'woothemes-sensei-upgrades',
 		'woothemes-sensei-settings',
+		'sensei-settings',
 		'sensei_courses_page_id',
 		'woothemes-sensei_courses_page_id',
 		'woothemes-sensei_user_dashboard_page_id',

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -97,7 +97,7 @@ class Sensei_Grading {
 
 		wp_enqueue_style( Sensei()->token . '-admin' );
 
-		wp_enqueue_style( 'woothemes-sensei-settings-api', Sensei()->plugin_url . 'assets/css/settings.css', '', Sensei()->version );
+		wp_enqueue_style( 'sensei-settings-api', Sensei()->plugin_url . 'assets/css/settings.css', '', Sensei()->version );
 
 	} // End enqueue_styles()
 

--- a/includes/class-sensei-language-pack-manager.php
+++ b/includes/class-sensei-language-pack-manager.php
@@ -51,7 +51,7 @@ class Sensei_Language_Pack_Manager {
 	 * @return string
 	 */
 	protected static function get_settings_uri( $action ) {
-		return wp_nonce_url( admin_url( 'admin.php?page=woothemes-sensei-settings&action=' . $action ), 'language_pack', '_sensei_language_nonce' );
+		return wp_nonce_url( admin_url( 'admin.php?page=sensei-settings&action=' . $action ), 'language_pack', '_sensei_language_nonce' );
 	}
 
 	/**
@@ -168,7 +168,7 @@ class Sensei_Language_Pack_Manager {
 			is_admin()
 			&& current_user_can( 'update_plugins' )
 			&& isset( $_GET['page'] )
-			&& 'woothemes-sensei-settings' === $_GET['page']
+			&& 'sensei-settings' === $_GET['page']
 			&& isset( $_GET['action'] )
 		) {
 
@@ -186,8 +186,8 @@ class Sensei_Language_Pack_Manager {
 	 * Install language pack.
 	 */
 	protected function language_pack_install() {
-		$url          = wp_nonce_url( admin_url( 'admin.php?page=woothemes-sensei-settings&action=language_pack_install' ), 'language_install' );
-		$settings_url = admin_url( 'admin.php?page=woothemes-sensei-settings' );
+		$url          = wp_nonce_url( admin_url( 'admin.php?page=sensei-settings&action=language_pack_install' ), 'language_install' );
+		$settings_url = admin_url( 'admin.php?page=sensei-settings' );
 		$locale       = get_locale();
 
 		if ( ! isset( $_REQUEST['_sensei_language_nonce'] ) && wp_verify_nonce( $_REQUEST['_sensei_language_nonce'], 'language_pack' ) ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2149,7 +2149,7 @@ class Sensei_Lesson {
 
 		$allowed_post_types      = apply_filters( 'sensei_scripts_allowed_post_types', array( 'lesson', 'course', 'question' ) );
 		$allowed_post_type_pages = apply_filters( 'sensei_scripts_allowed_post_type_pages', array( 'edit.php', 'post-new.php', 'post.php', 'edit-tags.php' ) );
-		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', 'sensei_analysis', 'sensei_learners', 'sensei_updates', 'woothemes-sensei-settings', 'lesson-order' ) );
+		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', 'sensei_analysis', 'sensei_learners', 'sensei_updates', 'sensei-settings', 'lesson-order' ) );
 
 		// Test for Write Panel Pages
 		if ( ( ( isset( $post_type ) && in_array( $post_type, $allowed_post_types ) ) && ( isset( $hook ) && in_array( $hook, $allowed_post_type_pages ) ) ) || ( isset( $_GET['page'] ) && in_array( $_GET['page'], $allowed_pages ) ) ) {
@@ -2213,11 +2213,11 @@ class Sensei_Lesson {
 
 		$allowed_post_types      = apply_filters( 'sensei_scripts_allowed_post_types', array( 'lesson', 'course', 'question', 'sensei_message' ) );
 		$allowed_post_type_pages = apply_filters( 'sensei_scripts_allowed_post_type_pages', array( 'edit.php', 'post-new.php', 'post.php', 'edit-tags.php' ) );
-		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', 'sensei_analysis', 'sensei_learners', 'sensei_updates', 'woothemes-sensei-settings' ) );
+		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', 'sensei_analysis', 'sensei_learners', 'sensei_updates', 'sensei-settings' ) );
 
 		// Test for Write Panel Pages
 		if ( ( ( isset( $post_type ) && in_array( $post_type, $allowed_post_types ) ) && ( isset( $hook ) && in_array( $hook, $allowed_post_type_pages ) ) ) || ( isset( $_GET['page'] ) && in_array( $_GET['page'], $allowed_pages ) ) ) {
-			wp_enqueue_style( 'woothemes-sensei-settings-api', esc_url( Sensei()->plugin_url . 'assets/css/settings.css' ), '', Sensei()->version );
+			wp_enqueue_style( 'sensei-settings-api', esc_url( Sensei()->plugin_url . 'assets/css/settings.css' ), '', Sensei()->version );
 		}
 
 	} // End enqueue_styles()

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Settings_API {
 
 	public $token;
+	public $token_legacy;
 	public $page_slug;
 	public $name;
 	public $menu_label;
@@ -36,8 +37,9 @@ class Sensei_Settings_API {
 	 */
 	public function __construct() {
 
-		$this->token     = 'woothemes-sensei-settings';
-		$this->page_slug = 'woothemes-sensei-settings-api';
+		$this->token        = 'sensei-settings';
+		$this->token_legacy = 'woothemes-sensei-settings';
+		$this->page_slug    = 'sensei-settings-api';
 
 		$this->sections         = array();
 		$this->fields           = array();
@@ -349,7 +351,7 @@ class Sensei_Settings_API {
 		<?php
 		$this->settings_tabs();
 		settings_fields( $this->token );
-		$page = 'woothemes-sensei-settings';
+		$page = 'sensei-settings';
 		foreach ( $this->sections as $section_id => $section ) {
 
 			echo '<section id="' . esc_attr( $section_id ) . '">';
@@ -383,7 +385,7 @@ class Sensei_Settings_API {
 	 */
 	public function get_settings() {
 
-		$this->settings = get_option( $this->token, array() );
+		$this->settings = self::get_settings_raw();
 
 		foreach ( $this->fields as $k => $v ) {
 			if ( ! isset( $this->settings[ $k ] ) && isset( $v['default'] ) ) {
@@ -396,6 +398,26 @@ class Sensei_Settings_API {
 
 		return $this->settings;
 	} // End get_settings()
+
+	/**
+	 * Get the raw settings option.
+	 *
+	 * @return array
+	 */
+	protected function get_settings_raw() {
+		$settings = get_option( $this->token, false );
+		if ( false === $settings
+			 && $this->token_legacy
+			 && false !== get_option( $this->token_legacy, false )
+		) {
+			$settings = get_option( $this->token_legacy, false );
+			update_option( $this->token, $settings );
+		}
+		if ( false === $settings ) {
+			$settings = array();
+		}
+		return $settings;
+	}
 
 	/**
 	 * Register the settings fields.
@@ -986,16 +1008,16 @@ class Sensei_Settings_API {
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
 		wp_enqueue_script( 'farbtastic' );
-		wp_enqueue_script( 'woothemes-sensei-settings', esc_url( Sensei()->plugin_url . 'assets/js/settings' . $suffix . '.js' ), array( 'jquery', 'farbtastic' ), Sensei()->version );
+		wp_enqueue_script( 'sensei-settings', esc_url( Sensei()->plugin_url . 'assets/js/settings' . $suffix . '.js' ), array( 'jquery', 'farbtastic' ), Sensei()->version );
 
 		if ( $this->has_range ) {
-			wp_enqueue_script( 'woothemes-sensei-settings-ranges', esc_url( Sensei()->plugin_url . 'assets/js/ranges' . $suffix . '.js' ), array( 'jquery-ui-slider' ), Sensei()->version );
+			wp_enqueue_script( 'sensei-settings-ranges', esc_url( Sensei()->plugin_url . 'assets/js/ranges' . $suffix . '.js' ), array( 'jquery-ui-slider' ), Sensei()->version );
 		}
 
-		wp_register_script( 'woothemes-sensei-settings-imageselectors', esc_url( Sensei()->plugin_url . 'assets/js/image-selectors' . $suffix . '.js' ), array( 'jquery' ), Sensei()->version );
+		wp_register_script( 'sensei-settings-imageselectors', esc_url( Sensei()->plugin_url . 'assets/js/image-selectors' . $suffix . '.js' ), array( 'jquery' ), Sensei()->version );
 
 		if ( $this->has_imageselector ) {
-			wp_enqueue_script( 'woothemes-sensei-settings-imageselectors' );
+			wp_enqueue_script( 'sensei-settings-imageselectors' );
 		}
 
 	} // End enqueue_scripts()
@@ -1012,7 +1034,7 @@ class Sensei_Settings_API {
 		wp_enqueue_style( $this->token . '-admin' );
 
 		wp_enqueue_style( 'farbtastic' );
-		wp_enqueue_style( 'woothemes-sensei-settings-api', esc_url( Sensei()->plugin_url . 'assets/css/settings.css' ), array( 'farbtastic' ), Sensei()->version );
+		wp_enqueue_style( 'sensei-settings-api', esc_url( Sensei()->plugin_url . 'assets/css/settings.css' ), array( 'farbtastic' ), Sensei()->version );
 
 		$this->enqueue_field_styles();
 	} // End enqueue_styles()
@@ -1027,13 +1049,13 @@ class Sensei_Settings_API {
 	public function enqueue_field_styles() {
 
 		if ( $this->has_range ) {
-			wp_enqueue_style( 'woothemes-sensei-settings-ranges', esc_url( Sensei()->plugin_url . 'assets/css/ranges.css' ), '', Sensei()->version );
+			wp_enqueue_style( 'sensei-settings-ranges', esc_url( Sensei()->plugin_url . 'assets/css/ranges.css' ), '', Sensei()->version );
 		}
 
-		wp_register_style( 'woothemes-sensei-settings-imageselectors', esc_url( Sensei()->plugin_url . 'assets/css/image-selectors.css' ), '', Sensei()->version );
+		wp_register_style( 'sensei-settings-imageselectors', esc_url( Sensei()->plugin_url . 'assets/css/image-selectors.css' ), '', Sensei()->version );
 
 		if ( $this->has_imageselector ) {
-			wp_enqueue_style( 'woothemes-sensei-settings-imageselectors' );
+			wp_enqueue_style( 'sensei-settings-imageselectors' );
 		}
 	} // End enqueue_field_styles()
 } // End Class

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -406,12 +406,12 @@ class Sensei_Settings_API {
 	 */
 	protected function get_settings_raw() {
 		$settings = get_option( $this->token, false );
-		if ( false === $settings
-			 && $this->token_legacy
-			 && false !== get_option( $this->token_legacy, false )
-		) {
+		if ( false === $settings && $this->token_legacy ) {
 			$settings = get_option( $this->token_legacy, false );
-			update_option( $this->token, $settings );
+
+			if ( false !== $settings ) {
+				update_option( $this->token, $settings );
+			}
 		}
 		if ( false === $settings ) {
 			$settings = array();

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -24,9 +24,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 	public function __construct() {
 		parent::__construct(); // Required in extended classes.
 
-		$this->token        = 'sensei-settings';
-		$this->token_legacy = 'woothemes-sensei-settings';
-
 		add_action( 'init', array( __CLASS__, 'flush_rewrite_rules' ) );
 
 		// Setup Admin Settings data

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -24,7 +24,9 @@ class Sensei_Settings extends Sensei_Settings_API {
 	public function __construct() {
 		parent::__construct(); // Required in extended classes.
 
-		$this->token = 'woothemes-sensei-settings';
+		$this->token        = 'sensei-settings';
+		$this->token_legacy = 'woothemes-sensei-settings';
+
 		add_action( 'init', array( __CLASS__, 'flush_rewrite_rules' ) );
 
 		// Setup Admin Settings data
@@ -33,7 +35,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			$this->has_tabs   = true;
 			$this->name       = __( 'Sensei Settings', 'woothemes-sensei' );
 			$this->menu_label = __( 'Settings', 'woothemes-sensei' );
-			$this->page_slug  = 'woothemes-sensei-settings';
+			$this->page_slug  = 'sensei-settings';
 
 		} // End If Statement
 
@@ -68,7 +70,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 */
 	public function set( $setting, $new_value ) {
 
-		$settings             = get_option( $this->token, array() );
+		$settings             = self::get_settings_raw();
 		$settings[ $setting ] = $new_value;
 		return update_option( $this->token, $settings );
 
@@ -725,7 +727,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		 * Skipping nonce check because it is already done by WordPress for the Settings page.
 		 * phpcs:disable WordPress.Security.NonceVerification
 		 */
-		if ( isset( $_POST['option_page'] ) && 'woothemes-sensei-settings' === $_POST['option_page']
+		if ( isset( $_POST['option_page'] ) && 'sensei-settings' === $_POST['option_page']
 			&& isset( $_POST['action'] ) && 'update' === $_POST['action'] ) {
 			// phpcs:enable WordPress.Security.NonceVerification
 

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -1144,7 +1144,7 @@ class Sensei_Updates {
 
 	public function update_quiz_settings() {
 
-		$settings = get_option( 'woothemes-sensei-settings', array() );
+		$settings = get_option( 'sensei-settings', get_option( 'woothemes-sensei-settings', array() ) );
 
 		$lesson_completion = false;
 		if ( isset( $settings['lesson_completion'] ) ) {

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1397,7 +1397,7 @@ class Sensei_Main {
 	 * @return string plugin settings URL
 	 */
 	public function get_settings_url( $plugin_id = null ) {
-		return admin_url( 'admin.php?page=woothemes-sensei-settings&tab=general' );
+		return admin_url( 'admin.php?page=sensei-settings&tab=general' );
 	}
 
 		/**
@@ -1433,7 +1433,7 @@ class Sensei_Main {
 		 * @return boolean true if the current page is the admin general configuration page
 		 */
 	public function is_general_configuration_page() {
-		return isset( $_GET['page'] ) && 'woothemes-sensei-settings' === trim( $_GET['page'] ) && ( ! isset( $_GET['tab'] ) || 'general' === trim( $_GET['tab'] ) );
+		return isset( $_GET['page'] ) && 'sensei-settings' === trim( $_GET['page'] ) && ( ! isset( $_GET['tab'] ) || 'general' === trim( $_GET['tab'] ) );
 	}
 
 
@@ -1443,7 +1443,7 @@ class Sensei_Main {
 		 * @return string admin configuration url for the admin general configuration page
 		 */
 	public function get_general_configuration_url() {
-		return admin_url( 'admin.php?page=woothemes-sensei-settings&tab=general' );
+		return admin_url( 'admin.php?page=sensei-settings&tab=general' );
 	}
 
 	/**


### PR DESCRIPTION
This renames the option `woothemes-sensei-settings` to `sensei-settings`. It will migrate from the old option to the new option but (for now) won't delete the old option. This would make it more difficult to downgrade if necessary. We could delete it later on, if needed. I have include both the legacy option name and the new option name in the data cleaner. For consistency, I've also renamed the assets and page names associated with settings.

### Testing Instructions
- On `release/2.0` branch, update settings to some non-defaults and remember their values.
- Switch to this branch and load the Sensei settings page in WP admin.
- Make sure the new settings were migrated.
- Make sure you can update settings.
- Make sure `woothemes-sensei-settings` and `sensei-settings` options exist in the options table and that `sensei-settings` reflects the changes made in Sensei settings.