### PR TITLE
Migrate `woothemes-sensei-version` option to `sensei-version`

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -59,6 +59,7 @@ class Sensei_Data_Cleaner {
 		'sensei_flush_rewrite_rules',
 		'sensei_needs_language_pack_install',
 		'woothemes_sensei_language_pack_version',
+		'sensei-version',
 		'woothemes-sensei-version',
 		'sensei_usage_tracking_opt_in_hide',
 		'woothemes-sensei-upgrades',

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -182,7 +182,7 @@ class Sensei_Updates {
 		);
 
 		$this->updates = apply_filters( 'sensei_upgrade_functions', $this->updates, $this->updates );
-		$this->version = get_option( 'woothemes-sensei-version' );
+		$this->version = get_option( 'sensei-version' );
 
 		// Manual Update Screen
 		add_action( 'admin_menu', array( $this, 'add_update_admin_screen' ), 50 );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -611,9 +611,9 @@ class Sensei_Main {
 	 * @return void
 	 */
 	private function register_plugin_version() {
-		if ( $this->version != '' ) {
+		if ( $this->version !== '' ) {
 
-			update_option( 'woothemes-sensei-version', $this->version );
+			update_option( 'sensei-version', $this->version );
 
 		}
 	} // End register_plugin_version()

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -611,7 +611,7 @@ class Sensei_Main {
 	 * @return void
 	 */
 	private function register_plugin_version() {
-		if ( $this->version !== '' ) {
+		if ( isset( $this->version ) ) {
 
 			update_option( 'sensei-version', $this->version );
 

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -278,7 +278,7 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 	public function testSenseiOptionsDeleted() {
 		// Set a couple Sensei options.
 		update_option( 'sensei_usage_tracking_opt_in_hide', '1' );
-		update_option( 'woothemes-sensei-version', '1.10.0' );
+		update_option( 'sensei-version', '1.10.0' );
 
 		// Set a couple other options.
 		update_option( 'my_option_1', 'Value 1' );
@@ -288,7 +288,7 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 
 		// Ensure the Sensei options are deleted.
 		$this->assertFalse( get_option( 'sensei_usage_tracking_opt_in_hide' ) );
-		$this->assertFalse( get_option( 'woothemes-sensei-version' ) );
+		$this->assertFalse( get_option( 'sensei-version' ) );
 
 		// Ensure the non-Sensei options are intact.
 		$this->assertEquals( 'Value 1', get_option( 'my_option_1' ) );


### PR DESCRIPTION
This is a very simple option rename. We aren't referencing the legacy option anywhere (except the data cleaner) because it will be updated on activation. I'm leaving the legacy option around for now, but we could create a manual data cleaner for people to remove it manually (along with other migrated options).

### Testing Instructions
- From `master`, deactivate and activate Sensei, make sure `woothemes-sensei-version` is current stable release. 
- From this branch, deactivate and activate Sensei, make sure `sensei-version` is `2.0.0-dev`.