### PR TITLE
Rename option `woothemes-sensei-upgrades` to `sensei-upgrades`

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -61,6 +61,7 @@ class Sensei_Data_Cleaner {
 		'woothemes_sensei_language_pack_version',
 		'woothemes-sensei-version',
 		'sensei_usage_tracking_opt_in_hide',
+		'sensei-upgrades',
 		'woothemes-sensei-upgrades',
 		'woothemes-sensei-settings',
 		'sensei_courses_page_id',

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -14,7 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Updates {
 
-	public $token = 'woothemes-sensei';
+	public $token        = 'sensei';
+	public $token_legacy = 'woothemes-sensei';
 	public $version;
 	public $updates_run;
 	public $updates;
@@ -32,7 +33,7 @@ class Sensei_Updates {
 
 		// Setup object data
 		$this->parent      = $parent;
-		$this->updates_run = get_option( 'woothemes-sensei-upgrades', array() );
+		$this->updates_run = self::get_ran_upgrades_raw();
 
 		// The list of upgrades to run
 		$this->updates = array(
@@ -188,6 +189,26 @@ class Sensei_Updates {
 		add_action( 'admin_menu', array( $this, 'add_update_admin_screen' ), 50 );
 
 	} // End __construct()
+
+	/**
+	 * Get the array of upgrades that have executed.
+	 *
+	 * @return array
+	 */
+	public function get_ran_upgrades_raw() {
+		$upgrades = get_option( $this->token . '-upgrades', array() );
+
+		if ( empty( $upgrades ) && $this->token_legacy && get_option( $this->token_legacy . '-upgrades', false ) ) {
+			$upgrades = get_option( $this->token_legacy . '-upgrades', false );
+			update_option( $this->token . '-upgrades', $upgrades );
+		}
+
+		if ( empty( $upgrades ) ) {
+			$upgrades = array();
+		}
+
+		return $upgrades;
+	}
 
 	/**
 	 * add_update_admin_screen Adds admin screen to run manual udpates
@@ -578,7 +599,7 @@ class Sensei_Updates {
 								if ( method_exists( $this, $function_name ) ) {
 
 									$this->updates_run = array_unique( $this->updates_run ); // we only need one reference per update
-									update_option( Sensei()->token . '-upgrades', $this->updates_run );
+									update_option( $this->token . '-upgrades', $this->updates_run );
 									return true;
 
 								} elseif ( $this->function_in_whitelist( $function_name ) ) {
@@ -707,7 +728,7 @@ class Sensei_Updates {
 	private function set_update_run( $update ) {
 		array_push( $this->updates_run, $update );
 		$this->updates_run = array_unique( $this->updates_run ); // we only need one reference per update
-		update_option( Sensei()->token . '-upgrades', $this->updates_run );
+		update_option( $this->token . '-upgrades', $this->updates_run );
 	}
 
 	/**

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -198,9 +198,11 @@ class Sensei_Updates {
 	public function get_ran_upgrades_raw() {
 		$upgrades = get_option( $this->token . '-upgrades', array() );
 
-		if ( empty( $upgrades ) && $this->token_legacy && get_option( $this->token_legacy . '-upgrades', false ) ) {
+		if ( empty( $upgrades ) && $this->token_legacy ) {
 			$upgrades = get_option( $this->token_legacy . '-upgrades', false );
-			update_option( $this->token . '-upgrades', $upgrades );
+			if ( false !== $upgrades ) {
+				update_option( $this->token . '-upgrades', $upgrades );
+			}
 		}
 
 		if ( empty( $upgrades ) ) {


### PR DESCRIPTION
This renames the option `woothemes-sensei-upgrades` to `sensei-upgrades`. It leaves behind the old option, but like our other option renames, we could create a manual data tool to remove them. Both the legacy and the new option are removed in the data removal tool.

_Just as a note:_ Although this area of Sensei uses `Auto` to describe some data update tools, since [this commit](https://github.com/automattic/sensei/commit/070af00de11f3ed7fb4908d2f689e46bca612df2), no data update is automatic. 

### Testing Instructions
- From `master` (with WCPC deactivated first for safety), run a `Sensei > Data Update` from WP admin (for example: `Enhance the 'Teacher' role`). 
- In database, take note of the `woothemes-sensei-upgrades` value. Also, from the Data Update, the tool you ran should now say `Re-run Update`. 
- Switch to branch `rename/sensei-upgrades`.
- Refresh the `Data Update` page. Notice the tool you ran should still say `Re-run Update`.
- Check the database: `woothemes-sensei-upgrades` and `sensei-upgrades` options should match.