### PR TITLE
Remove `woothemes-` prefix from asset names

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -193,8 +193,8 @@ class Sensei_Learner_Management {
 	 */
 	public function enqueue_styles() {
 
-		wp_enqueue_style( 'woothemes-sensei-admin' );
-		wp_enqueue_style( 'woothemes-sensei-jquery-ui', Sensei()->plugin_url . 'assets/css/jquery-ui.css', '', Sensei()->version );
+		wp_enqueue_style( 'sensei-admin' );
+		wp_enqueue_style( 'sensei-jquery-ui', Sensei()->plugin_url . 'assets/css/jquery-ui.css', '', Sensei()->version );
 
 	} // End enqueue_styles()
 

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -193,7 +193,6 @@ class Sensei_Learner_Management {
 	 */
 	public function enqueue_styles() {
 
-		wp_enqueue_style( 'sensei-admin' );
 		wp_enqueue_style( 'sensei-jquery-ui', Sensei()->plugin_url . 'assets/css/jquery-ui.css', '', Sensei()->version );
 
 	} // End enqueue_styles()

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -285,8 +285,8 @@ class Sensei_Admin {
 		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', 'sensei_analysis', 'sensei_learners', 'sensei_updates', 'sensei-settings', $this->lesson_order_page_slug, $this->course_order_page_slug ) );
 
 		// Global Styles for icons and menu items
-		wp_register_style( 'woothemes-sensei-global', Sensei()->plugin_url . 'assets/css/global.css', '', Sensei()->version, 'screen' );
-		wp_enqueue_style( 'woothemes-sensei-global' );
+		wp_register_style( 'sensei-global', Sensei()->plugin_url . 'assets/css/global.css', '', Sensei()->version, 'screen' );
+		wp_enqueue_style( 'sensei-global' );
 		$select_two_location = '/assets/vendor/select2/select2.min.css';
 
 		// Select 2 styles
@@ -295,8 +295,8 @@ class Sensei_Admin {
 		// Test for Write Panel Pages
 		if ( ( ( isset( $post_type ) && in_array( $post_type, $allowed_post_types ) ) && ( isset( $hook ) && in_array( $hook, $allowed_post_type_pages ) ) ) || ( isset( $_GET['page'] ) && in_array( $_GET['page'], $allowed_pages ) ) ) {
 
-			wp_register_style( 'woothemes-sensei-admin-custom', Sensei()->plugin_url . 'assets/css/admin-custom.css', '', Sensei()->version, 'screen' );
-			wp_enqueue_style( 'woothemes-sensei-admin-custom' );
+			wp_register_style( 'sensei-admin-custom', Sensei()->plugin_url . 'assets/css/admin-custom.css', '', Sensei()->version, 'screen' );
+			wp_enqueue_style( 'sensei-admin-custom' );
 
 		}
 

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -72,8 +72,6 @@ class Sensei_Analysis {
 	 */
 	public function enqueue_styles() {
 
-		wp_enqueue_style( 'sensei-admin' );
-
 		wp_enqueue_style( 'sensei-settings-api', Sensei()->plugin_url . 'assets/css/settings.css', '', Sensei()->version );
 
 	} // End enqueue_styles()

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -72,7 +72,7 @@ class Sensei_Analysis {
 	 */
 	public function enqueue_styles() {
 
-		wp_enqueue_style( 'woothemes-sensei-admin' );
+		wp_enqueue_style( 'sensei-admin' );
 
 		wp_enqueue_style( 'sensei-settings-api', Sensei()->plugin_url . 'assets/css/settings.css', '', Sensei()->version );
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -32,7 +32,7 @@ class Sensei_Main {
 	/**
 	 * Public token, referencing for the text domain.
 	 */
-	public $token = 'woothemes-sensei';
+	public $token = 'sensei';
 
 	/**
 	 * Plugin url and path for use when access resources.


### PR DESCRIPTION
_Note_: Built on #2448's branch because that had so many other asset renames. I'll rebase after that PR is merged.

This removes `woothemes-` from all remaining asset prefixes. It also renames `Sensei()->token`.

`Sensei_Main::$token` is used for a few things:
- Asset prefixes (sometimes).
- `includes/class-sensei-updates.php`: Removed in #2451
- Sensei_Main::load_class: Dead code. Places used no longer get benefit from it as the classes aren't prefixed by `woothemes`. Must be loaded by our main class loader now.
  - Sensei_Analysis::load_data_table_files
  - Sensei_Grading::load_data_table_files
  - Sensei_Learner_Management::load_data_table_files

For that last one, all those could be deprecated. They seem useless and I believe are now handled by Sensei's autoloader.

### To do after merge
- [ ] Create issues to deprecate those methods.

### Testing Instructions
- Navigate Sensei and make sure assets are loaded properly. 

