### PR TITLE
Remove WooThemes prefix from widgets

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -504,15 +504,7 @@ class Sensei_Main {
 		foreach ( $widget_list as $key => $value ) {
 			if ( file_exists( $this->plugin_path . 'widgets/class-sensei-' . $key . '-widget.php' ) ) {
 				require_once $this->plugin_path . 'widgets/class-sensei-' . $key . '-widget.php';
-
-				$legacy_widget_class = 'WooThemes_Sensei_' . $value . '_Widget';
-				$widget_class        = 'Sensei_' . $value . '_Widget';
-				if ( is_active_widget( false, false, $legacy_widget_class ) ) {
-					class_alias( $widget_class, $legacy_widget_class );
-					register_widget( $legacy_widget_class );
-				} else {
-					register_widget( $widget_class );
-				}
+				register_widget( 'Sensei_' . $value . '_Widget' );
 			}
 		} // End foreach().
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -502,9 +502,17 @@ class Sensei_Main {
 			)
 		);
 		foreach ( $widget_list as $key => $value ) {
-			if ( file_exists( $this->plugin_path . 'widgets/widget-woothemes-sensei-' . $key . '.php' ) ) {
-				require_once $this->plugin_path . 'widgets/widget-woothemes-sensei-' . $key . '.php';
-				register_widget( 'WooThemes_Sensei_' . $value . '_Widget' );
+			if ( file_exists( $this->plugin_path . 'widgets/class-sensei-' . $key . '-widget.php' ) ) {
+				require_once $this->plugin_path . 'widgets/class-sensei-' . $key . '-widget.php';
+
+				$legacy_widget_class = 'WooThemes_Sensei_' . $value . '_Widget';
+				$widget_class        = 'Sensei_' . $value . '_Widget';
+				if ( is_active_widget( false, false, $legacy_widget_class ) ) {
+					class_alias( $widget_class, $legacy_widget_class );
+					register_widget( $legacy_widget_class );
+				} else {
+					register_widget( $widget_class );
+				}
 			}
 		} // End foreach().
 

--- a/widgets/class-sensei-category-courses-widget.php
+++ b/widgets/class-sensei-category-courses-widget.php
@@ -13,10 +13,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.1.0
  */
 class Sensei_Category_Courses_Widget extends WP_Widget {
-	protected $woo_widget_cssclass;
-	protected $woo_widget_description;
-	protected $woo_widget_idbase;
-	protected $woo_widget_title;
+	protected $widget_cssclass;
+	protected $widget_description;
+	protected $widget_idbase;
+	protected $widget_title;
 
 	/**
 	 * Constructor function.
@@ -26,26 +26,26 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 	 */
 	public function __construct() {
 		/* Widget variable settings. */
-		$this->woo_widget_cssclass    = 'widget_sensei_category_courses';
-		$this->woo_widget_description = __( 'This widget will output a list of Courses for a specific category.', 'woothemes-sensei' );
-		$this->woo_widget_idbase      = 'sensei_category_courses';
-		$this->woo_widget_title       = __( 'Sensei - Category Courses', 'woothemes-sensei' );
+		$this->widget_cssclass    = 'widget_sensei_category_courses';
+		$this->widget_description = __( 'This widget will output a list of Courses for a specific category.', 'woothemes-sensei' );
+		$this->widget_idbase      = 'sensei_category_courses';
+		$this->widget_title       = __( 'Sensei - Category Courses', 'woothemes-sensei' );
 
 		/* Widget settings. */
 		$widget_ops = array(
-			'classname'   => $this->woo_widget_cssclass,
-			'description' => $this->woo_widget_description,
+			'classname'   => $this->widget_cssclass,
+			'description' => $this->widget_description,
 		);
 
 		/* Widget control settings. */
 		$control_ops = array(
 			'width'   => 250,
 			'height'  => 350,
-			'id_base' => $this->woo_widget_idbase,
+			'id_base' => $this->widget_idbase,
 		);
 
 		/* Create the widget. */
-		parent::__construct( $this->woo_widget_idbase, $this->woo_widget_title, $widget_ops, $control_ops );
+		parent::__construct( $this->widget_idbase, $this->widget_title, $widget_ops, $control_ops );
 
 	} // End __construct()
 
@@ -77,14 +77,14 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 		/*
 		 Widget content. */
 		// Add actions for plugins/themes to hook onto.
-		do_action( $this->woo_widget_cssclass . '_top' );
+		do_action( $this->widget_cssclass . '_top' );
 
 		if ( 0 < intval( $instance['course_category'] ) ) {
 			$this->load_component( $instance );
 		} // End If Statement
 
 		// Add actions for plugins/themes to hook onto.
-		do_action( $this->woo_widget_cssclass . '_bottom' );
+		do_action( $this->widget_cssclass . '_bottom' );
 
 		/* After widget (defined by themes). */
 		echo wp_kses_post( $after_widget );

--- a/widgets/class-sensei-category-courses-widget.php
+++ b/widgets/class-sensei-category-courses-widget.php
@@ -4,15 +4,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Sensei Lesson Component Widget
+ * Sensei Category Courses Widget
  *
  * @package Views
  * @subpackage Widgets
  * @author Automattic
  *
- * @since 1.0.0
+ * @since 1.1.0
  */
-class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
+class Sensei_Category_Courses_Widget extends WP_Widget {
 	protected $woo_widget_cssclass;
 	protected $woo_widget_description;
 	protected $woo_widget_idbase;
@@ -21,19 +21,15 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
 	/**
 	 * Constructor function.
 	 *
-	 * @since  1.0.0
+	 * @since  1.1.0
 	 * @return  void
 	 */
 	public function __construct() {
 		/* Widget variable settings. */
-		$this->woo_widget_cssclass    = 'widget_sensei_lesson_component';
-		$this->woo_widget_description = __( 'This widget will output a list of the latest Lessons.', 'woothemes-sensei' );
-		$this->woo_widget_idbase      = 'sensei_lesson_component';
-		$this->woo_widget_title       = __( 'Sensei - Lesson Component', 'woothemes-sensei' );
-
-		$this->woo_widget_componentslist = array(
-			'newlessons' => __( 'New Lessons', 'woothemes-sensei' ),
-		);
+		$this->woo_widget_cssclass    = 'widget_sensei_category_courses';
+		$this->woo_widget_description = __( 'This widget will output a list of Courses for a specific category.', 'woothemes-sensei' );
+		$this->woo_widget_idbase      = 'sensei_category_courses';
+		$this->woo_widget_title       = __( 'Sensei - Category Courses', 'woothemes-sensei' );
 
 		/* Widget settings. */
 		$widget_ops = array(
@@ -50,12 +46,13 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
 
 		/* Create the widget. */
 		parent::__construct( $this->woo_widget_idbase, $this->woo_widget_title, $widget_ops, $control_ops );
+
 	} // End __construct()
 
 	/**
 	 * Display the widget on the frontend.
 	 *
-	 * @since  1.0.0
+	 * @since  1.1.0
 	 * @param  array $args     Widget arguments.
 	 * @param  array $instance Widget settings for this instance.
 	 * @return void
@@ -67,41 +64,37 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
 		$after_title   = $args['after_title'];
 		$after_widget  = $args['after_widget'];
 
-		if ( in_array( $instance['component'], array_keys( $this->woo_widget_componentslist ) ) && ( 'activecourses' == $instance['component'] || 'completedcourses' == $instance['component'] ) && ! is_user_logged_in() ) {
-			// No Output
-		} else {
-			/* Our variables from the widget settings. */
-			$title = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
+		/* Our variables from the widget settings. */
+		$title = apply_filters( 'widget_title', $instance['title'], $instance, $this->id_base );
 
-			/* Before widget (defined by themes). */
-			echo wp_kses_post( $before_widget );
+		/* Before widget (defined by themes). */
+		echo wp_kses_post( $before_widget );
 
-			/* Display the widget title if one was input (before and after defined by themes). */
-			if ( $title ) {
-				echo wp_kses_post( $before_title . $title . $after_title ); }
+		/* Display the widget title if one was input (before and after defined by themes). */
+		if ( $title ) {
+			echo wp_kses_post( $before_title . $title . $after_title ); }
 
-			/*
-			 Widget content. */
-			// Add actions for plugins/themes to hook onto.
-			do_action( $this->woo_widget_cssclass . '_top' );
+		/*
+		 Widget content. */
+		// Add actions for plugins/themes to hook onto.
+		do_action( $this->woo_widget_cssclass . '_top' );
 
-			if ( in_array( $instance['component'], array_keys( $this->woo_widget_componentslist ) ) ) {
-				$this->load_component( $instance );
-			}
-
-			// Add actions for plugins/themes to hook onto.
-			do_action( $this->woo_widget_cssclass . '_bottom' );
-
-			/* After widget (defined by themes). */
-			echo wp_kses_post( $after_widget );
+		if ( 0 < intval( $instance['course_category'] ) ) {
+			$this->load_component( $instance );
 		} // End If Statement
+
+		// Add actions for plugins/themes to hook onto.
+		do_action( $this->woo_widget_cssclass . '_bottom' );
+
+		/* After widget (defined by themes). */
+		echo wp_kses_post( $after_widget );
 
 	} // End widget()
 
 	/**
 	 * Method to update the settings from the form() method.
 	 *
-	 * @since  1.0.0
+	 * @since  1.1.0
 	 * @param  array $new_instance New settings.
 	 * @param  array $old_instance Previous settings.
 	 * @return array               Updated settings.
@@ -113,10 +106,10 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
 		$instance['title'] = strip_tags( $new_instance['title'] );
 
 		/* The select box is returning a text value, so we escape it. */
-		$instance['component'] = esc_attr( $new_instance['component'] );
+		$instance['course_category'] = esc_attr( $new_instance['course_category'] );
 
-		/* The select box is returning a text value, so we escape it. */
-		$instance['limit'] = esc_attr( $new_instance['limit'] );
+		/* Strip tags for limit to remove HTML (important for text inputs). */
+		$instance['limit'] = strip_tags( $new_instance['limit'] );
 
 		return $instance;
 	} // End update()
@@ -125,7 +118,7 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
 	 * The form on the widget control in the widget administration area.
 	 * Make use of the get_field_id() and get_field_name() function when creating your form elements. This handles the confusing stuff.
 	 *
-	 * @since  1.0.0
+	 * @since  1.1.0
 	 * @param  array $instance The settings for this instance.
 	 * @return void
 	 */
@@ -135,9 +128,9 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
 		 Set up some default widget settings. */
 		/* Make sure all keys are added here, even with empty string values. */
 		$defaults = array(
-			'title'     => '',
-			'component' => '',
-			'limit'     => 3,
+			'title'           => '',
+			'course_category' => 0,
+			'limit'           => 3,
 		);
 
 		$instance = wp_parse_args( (array) $instance, $defaults );
@@ -147,18 +140,26 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
 			<label for="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>"><?php esc_html_e( 'Title (optional):', 'woothemes-sensei' ); ?></label>
 			<input type="text" name="<?php echo esc_attr( $this->get_field_name( 'title' ) ); ?>"  value="<?php echo esc_attr( $instance['title'] ); ?>" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'title' ) ); ?>" />
 		</p>
-		<!-- Widget Component: Select Input -->
+		<!-- Widget Course Category: Select Input -->
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'component' ) ); ?>"><?php esc_html_e( 'Component:', 'woothemes-sensei' ); ?></label>
-			<select name="<?php echo esc_attr( $this->get_field_name( 'component' ) ); ?>" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'component' ) ); ?>">
-			<?php foreach ( $this->woo_widget_componentslist as $k => $v ) { ?>
-				<option value="<?php echo esc_attr( $k ); ?>"<?php selected( $instance['component'], $k ); ?>><?php echo esc_html( $v ); ?></option>
-			<?php } ?>
-			</select>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'course_category' ) ); ?>"><?php esc_html_e( 'Course Category:', 'woothemes-sensei' ); ?></label>
+			<?php
+			$cat_args = array(
+				'hierarchical'     => true,
+				'show_option_none' => __( 'Select Category:', 'woothemes-sensei' ),
+				'taxonomy'         => 'course-category',
+				'orderby'          => 'name',
+				'selected'         => intval( $instance['course_category'] ),
+				'id'               => $this->get_field_id( 'course_category' ),
+				'name'             => $this->get_field_name( 'course_category' ),
+				'class'            => 'widefat',
+			);
+			wp_dropdown_categories( apply_filters( 'widget_course_categories_dropdown_args', $cat_args ) );
+			?>
 		</p>
 		<!-- Widget Limit: Text Input -->
 		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>"><?php esc_html_e( 'Number of Lessons (optional):', 'woothemes-sensei' ); ?></label>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>"><?php esc_html_e( 'Number of Courses (optional):', 'woothemes-sensei' ); ?></label>
 			<input type="text" name="<?php echo esc_attr( $this->get_field_name( 'limit' ) ); ?>"  value="<?php echo esc_attr( $instance['limit'] ); ?>" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'limit' ) ); ?>" />
 		</p>
 
@@ -166,29 +167,32 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
 	} // End form()
 
 	/**
-	 * Load the desired component, if a method is available for it.
+	 * Load the output.
 	 *
-	 * @param  string $instance The component to potentially be loaded.
-	 * @since  5.0.8
+	 * @param  array $instance.
+	 * @since  1.1.0
 	 * @return void
 	 */
 	protected function load_component( $instance ) {
 
-		global  $current_user;
-
-		/*
-		newlessons
-		*/
 		$posts_array = array();
-
 		$post_args   = array(
-			'post_type'        => 'lesson',
+			'post_type'        => 'course',
 			'posts_per_page'   => intval( $instance['limit'] ),
 			'orderby'          => 'menu_order date',
-			'order'            => 'DESC',
+			'order'            => 'ASC',
 			'post_status'      => 'publish',
 			'suppress_filters' => 0,
 		);
+
+		$post_args['tax_query'] = array(
+			array(
+				'taxonomy' => 'course-category',
+				'field'    => 'id',
+				'terms'    => intval( $instance['course_category'] ),
+			),
+		);
+
 		$posts_array = get_posts( $post_args );
 
 		if ( count( $posts_array ) > 0 ) {
@@ -202,13 +206,17 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
 				$author_link         = get_author_posts_url( absint( $post_item->post_author ) );
 				$author_display_name = $user_info->display_name;
 				$author_id           = $post_item->post_author;
-				$lesson_course_id    = get_post_meta( $post_id, '_lesson_course', true );
 				?>
 				<li class="fix">
-					<?php do_action( 'sensei_lesson_image', $post_id, '100', '100', false, true ); ?>
+					<?php do_action( 'sensei_course_image', $post_id ); ?>
 					<a href="<?php echo esc_url( get_permalink( $post_id ) ); ?>" title="<?php echo esc_attr( $post_title ); ?>"><?php echo esc_html( $post_title ); ?></a>
 					<br />
-					<?php if ( isset( Sensei()->settings->settings['lesson_author'] ) && ( Sensei()->settings->settings['lesson_author'] ) ) { ?>
+					<?php
+					/** This action is documented in includes/class-sensei-frontend.php */
+					do_action( 'sensei_course_meta_inside_before', $post_id );
+
+					if ( isset( Sensei()->settings->settings['course_author'] ) && ( Sensei()->settings->settings['course_author'] ) ) {
+						?>
 						<span class="course-author">
 							<?php esc_html_e( 'by', 'woothemes-sensei' ); ?>
 							<a href="<?php echo esc_url( $author_link ); ?>" title="<?php echo esc_attr( $author_display_name ); ?>">
@@ -217,24 +225,15 @@ class WooThemes_Sensei_Lesson_Component_Widget extends WP_Widget {
 						</span>
 						<br />
 					<?php } // End If Statement ?>
-					<?php if ( 0 < $lesson_course_id ) { ?>
-						<span class="lesson-course">
-							<?php
-							echo ' ' . wp_kses_post(
-								sprintf(
-									// translators: Placeholder is a link to the Course permalink.
-									__( 'Part of: %s', 'woothemes-sensei' ),
-									'<a href="' . esc_url( get_permalink( $lesson_course_id ) ) . '" title="' . esc_attr( __( 'View course', 'woothemes-sensei' ) ) . '"><em>' . esc_html( get_the_title( $lesson_course_id ) ) . '</em></a>'
-								)
-							);
-							?>
-						</span>
-					<?php } ?>
+					<span class="course-lesson-count"><?php echo esc_html( Sensei()->course->course_lesson_count( $post_id ) ) . '&nbsp;' . esc_html__( 'Lessons', 'woothemes-sensei' ); ?></span>
 					<br />
+					<?php
+					/** This action is documented in includes/class-sensei-frontend.php */
+					do_action( 'sensei_course_meta_inside_after', $post_id );
+					?>
 				</li>
 			<?php } // End For Loop ?>
-			<?php echo '<li class="my-account fix"><a class="button" href="' . esc_url( get_post_type_archive_link( 'lesson' ) ) . '">' . esc_html__( 'More Lessons', 'woothemes-sensei' ) . '</a></li>'; ?>
-		</ul>
+			</ul>
 			<?php
 		} // End If Statement
 	} // End load_component()

--- a/widgets/class-sensei-course-categories-widget.php
+++ b/widgets/class-sensei-course-categories-widget.php
@@ -13,10 +13,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.1.0
  */
 class Sensei_Course_Categories_Widget extends WP_Widget {
-	protected $woo_widget_cssclass;
-	protected $woo_widget_description;
-	protected $woo_widget_idbase;
-	protected $woo_widget_title;
+	protected $widget_cssclass;
+	protected $widget_description;
+	protected $widget_idbase;
+	protected $widget_title;
 
 	/**
 	 * Constructor function.
@@ -26,26 +26,26 @@ class Sensei_Course_Categories_Widget extends WP_Widget {
 	 */
 	public function __construct() {
 		/* Widget variable settings. */
-		$this->woo_widget_cssclass    = 'widget_sensei_course_categories';
-		$this->woo_widget_description = __( 'This widget will output a list of Course Categories.', 'woothemes-sensei' );
-		$this->woo_widget_idbase      = 'sensei_course_categories';
-		$this->woo_widget_title       = __( 'Sensei - Course Categories', 'woothemes-sensei' );
+		$this->widget_cssclass    = 'widget_sensei_course_categories';
+		$this->widget_description = __( 'This widget will output a list of Course Categories.', 'woothemes-sensei' );
+		$this->widget_idbase      = 'sensei_course_categories';
+		$this->widget_title       = __( 'Sensei - Course Categories', 'woothemes-sensei' );
 
 		/* Widget settings. */
 		$widget_ops = array(
-			'classname'   => $this->woo_widget_cssclass,
-			'description' => $this->woo_widget_description,
+			'classname'   => $this->widget_cssclass,
+			'description' => $this->widget_description,
 		);
 
 		/* Widget control settings. */
 		$control_ops = array(
 			'width'   => 250,
 			'height'  => 350,
-			'id_base' => $this->woo_widget_idbase,
+			'id_base' => $this->widget_idbase,
 		);
 
 		/* Create the widget. */
-		parent::__construct( $this->woo_widget_idbase, $this->woo_widget_title, $widget_ops, $control_ops );
+		parent::__construct( $this->widget_idbase, $this->widget_title, $widget_ops, $control_ops );
 	} // End __construct()
 
 	/**
@@ -76,12 +76,12 @@ class Sensei_Course_Categories_Widget extends WP_Widget {
 		/*
 		 Widget content. */
 		// Add actions for plugins/themes to hook onto.
-		do_action( $this->woo_widget_cssclass . '_top' );
+		do_action( $this->widget_cssclass . '_top' );
 
 		$this->load_component( $instance );
 
 		// Add actions for plugins/themes to hook onto.
-		do_action( $this->woo_widget_cssclass . '_bottom' );
+		do_action( $this->widget_cssclass . '_bottom' );
 
 		/* After widget (defined by themes). */
 		echo wp_kses_post( $after_widget );

--- a/widgets/class-sensei-course-categories-widget.php
+++ b/widgets/class-sensei-course-categories-widget.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 1.1.0
  */
-class WooThemes_Sensei_Course_Categories_Widget extends WP_Widget {
+class Sensei_Course_Categories_Widget extends WP_Widget {
 	protected $woo_widget_cssclass;
 	protected $woo_widget_description;
 	protected $woo_widget_idbase;

--- a/widgets/class-sensei-course-component-widget.php
+++ b/widgets/class-sensei-course-component-widget.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 1.1.0
  */
-class WooThemes_Sensei_Course_Component_Widget extends WP_Widget {
+class Sensei_Course_Component_Widget extends WP_Widget {
 	protected $woo_widget_cssclass;
 	protected $woo_widget_description;
 	protected $woo_widget_idbase;

--- a/widgets/class-sensei-course-component-widget.php
+++ b/widgets/class-sensei-course-component-widget.php
@@ -13,10 +13,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.1.0
  */
 class Sensei_Course_Component_Widget extends WP_Widget {
-	protected $woo_widget_cssclass;
-	protected $woo_widget_description;
-	protected $woo_widget_idbase;
-	protected $woo_widget_title;
+	protected $widget_cssclass;
+	protected $widget_description;
+	protected $widget_idbase;
+	protected $widget_title;
 	protected $instance;
 
 	/**
@@ -26,10 +26,10 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 	 */
 	public function __construct() {
 		/* Widget variable settings. */
-		$this->woo_widget_cssclass    = 'widget_sensei_course_component';
-		$this->woo_widget_description = __( 'This widget will output a list of Courses - New, Featured, Free, Paid, Active, Completed.', 'woothemes-sensei' );
-		$this->woo_widget_idbase      = 'sensei_course_component';
-		$this->woo_widget_title       = __( 'Sensei - Course Component', 'woothemes-sensei' );
+		$this->widget_cssclass    = 'widget_sensei_course_component';
+		$this->widget_description = __( 'This widget will output a list of Courses - New, Featured, Free, Paid, Active, Completed.', 'woothemes-sensei' );
+		$this->widget_idbase      = 'sensei_course_component';
+		$this->widget_title       = __( 'Sensei - Course Component', 'woothemes-sensei' );
 
 		/**
 		 * Allows filtering of the widget's component list.
@@ -42,7 +42,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 		 *     @type string ${$component_name} Label for the component.
 		 * }
 		 */
-		$this->woo_widget_componentslist = apply_filters(
+		$this->widget_componentslist = apply_filters(
 			'sensei_widget_course_component_components_list',
 			array(
 				'usercourses'      => __( 'New Courses', 'woothemes-sensei' ),
@@ -54,19 +54,19 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 
 		/* Widget settings. */
 		$widget_ops = array(
-			'classname'   => $this->woo_widget_cssclass,
-			'description' => $this->woo_widget_description,
+			'classname'   => $this->widget_cssclass,
+			'description' => $this->widget_description,
 		);
 
 		/* Widget control settings. */
 		$control_ops = array(
 			'width'   => 250,
 			'height'  => 350,
-			'id_base' => $this->woo_widget_idbase,
+			'id_base' => $this->widget_idbase,
 		);
 
 		/* Create the widget. */
-		parent::__construct( $this->woo_widget_idbase, $this->woo_widget_title, $widget_ops, $control_ops );
+		parent::__construct( $this->widget_idbase, $this->widget_title, $widget_ops, $control_ops );
 	} // End __construct()
 
 	/**
@@ -82,7 +82,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 		remove_filter( 'pre_get_posts', 'sensei_course_archive_filter', 10, 1 );
 
 		// don't show active or completed course if a user is not logged in
-		if ( ! in_array( $instance['component'], array_keys( $this->woo_widget_componentslist ) )
+		if ( ! in_array( $instance['component'], array_keys( $this->widget_componentslist ) )
 			 || ( ! is_user_logged_in() && ( 'activecourses' == $instance['component'] || 'completedcourses' == $instance['component'] ) ) ) {
 			// No Output
 			return;
@@ -104,14 +104,14 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 		/*
 		 Widget content. */
 		// Add actions for plugins/themes to hook onto.
-		do_action( $this->woo_widget_cssclass . '_top' );
+		do_action( $this->widget_cssclass . '_top' );
 
-		if ( in_array( $instance['component'], array_keys( $this->woo_widget_componentslist ) ) ) {
+		if ( in_array( $instance['component'], array_keys( $this->widget_componentslist ) ) ) {
 			$this->load_component( $instance );
 		}
 
 		// Add actions for plugins/themes to hook onto.
-		do_action( $this->woo_widget_cssclass . '_bottom' );
+		do_action( $this->widget_cssclass . '_bottom' );
 
 		/* After widget (defined by themes). */
 		echo wp_kses_post( $args['after_widget'] );
@@ -173,7 +173,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'component' ) ); ?>"><?php esc_html_e( 'Component:', 'woothemes-sensei' ); ?></label>
 			<select name="<?php echo esc_attr( $this->get_field_name( 'component' ) ); ?>" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'component' ) ); ?>">
-			<?php foreach ( $this->woo_widget_componentslist as $k => $v ) { ?>
+			<?php foreach ( $this->widget_componentslist as $k => $v ) { ?>
 				<option value="<?php echo esc_attr( $k ); ?>"<?php selected( $instance['component'], $k ); ?>><?php echo esc_html( $v ); ?></option>
 			<?php } ?>
 			</select>

--- a/widgets/class-sensei-lesson-component-widget.php
+++ b/widgets/class-sensei-lesson-component-widget.php
@@ -13,10 +13,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 class Sensei_Lesson_Component_Widget extends WP_Widget {
-	protected $woo_widget_cssclass;
-	protected $woo_widget_description;
-	protected $woo_widget_idbase;
-	protected $woo_widget_title;
+	protected $widget_cssclass;
+	protected $widget_description;
+	protected $widget_idbase;
+	protected $widget_title;
 
 	/**
 	 * Constructor function.
@@ -26,30 +26,30 @@ class Sensei_Lesson_Component_Widget extends WP_Widget {
 	 */
 	public function __construct() {
 		/* Widget variable settings. */
-		$this->woo_widget_cssclass    = 'widget_sensei_lesson_component';
-		$this->woo_widget_description = __( 'This widget will output a list of the latest Lessons.', 'woothemes-sensei' );
-		$this->woo_widget_idbase      = 'sensei_lesson_component';
-		$this->woo_widget_title       = __( 'Sensei - Lesson Component', 'woothemes-sensei' );
+		$this->widget_cssclass    = 'widget_sensei_lesson_component';
+		$this->widget_description = __( 'This widget will output a list of the latest Lessons.', 'woothemes-sensei' );
+		$this->widget_idbase      = 'sensei_lesson_component';
+		$this->widget_title       = __( 'Sensei - Lesson Component', 'woothemes-sensei' );
 
-		$this->woo_widget_componentslist = array(
+		$this->widget_componentslist = array(
 			'newlessons' => __( 'New Lessons', 'woothemes-sensei' ),
 		);
 
 		/* Widget settings. */
 		$widget_ops = array(
-			'classname'   => $this->woo_widget_cssclass,
-			'description' => $this->woo_widget_description,
+			'classname'   => $this->widget_cssclass,
+			'description' => $this->widget_description,
 		);
 
 		/* Widget control settings. */
 		$control_ops = array(
 			'width'   => 250,
 			'height'  => 350,
-			'id_base' => $this->woo_widget_idbase,
+			'id_base' => $this->widget_idbase,
 		);
 
 		/* Create the widget. */
-		parent::__construct( $this->woo_widget_idbase, $this->woo_widget_title, $widget_ops, $control_ops );
+		parent::__construct( $this->widget_idbase, $this->widget_title, $widget_ops, $control_ops );
 	} // End __construct()
 
 	/**
@@ -67,7 +67,7 @@ class Sensei_Lesson_Component_Widget extends WP_Widget {
 		$after_title   = $args['after_title'];
 		$after_widget  = $args['after_widget'];
 
-		if ( in_array( $instance['component'], array_keys( $this->woo_widget_componentslist ) ) && ( 'activecourses' == $instance['component'] || 'completedcourses' == $instance['component'] ) && ! is_user_logged_in() ) {
+		if ( in_array( $instance['component'], array_keys( $this->widget_componentslist ) ) && ( 'activecourses' == $instance['component'] || 'completedcourses' == $instance['component'] ) && ! is_user_logged_in() ) {
 			// No Output
 		} else {
 			/* Our variables from the widget settings. */
@@ -83,14 +83,14 @@ class Sensei_Lesson_Component_Widget extends WP_Widget {
 			/*
 			 Widget content. */
 			// Add actions for plugins/themes to hook onto.
-			do_action( $this->woo_widget_cssclass . '_top' );
+			do_action( $this->widget_cssclass . '_top' );
 
-			if ( in_array( $instance['component'], array_keys( $this->woo_widget_componentslist ) ) ) {
+			if ( in_array( $instance['component'], array_keys( $this->widget_componentslist ) ) ) {
 				$this->load_component( $instance );
 			}
 
 			// Add actions for plugins/themes to hook onto.
-			do_action( $this->woo_widget_cssclass . '_bottom' );
+			do_action( $this->widget_cssclass . '_bottom' );
 
 			/* After widget (defined by themes). */
 			echo wp_kses_post( $after_widget );
@@ -151,7 +151,7 @@ class Sensei_Lesson_Component_Widget extends WP_Widget {
 		<p>
 			<label for="<?php echo esc_attr( $this->get_field_id( 'component' ) ); ?>"><?php esc_html_e( 'Component:', 'woothemes-sensei' ); ?></label>
 			<select name="<?php echo esc_attr( $this->get_field_name( 'component' ) ); ?>" class="widefat" id="<?php echo esc_attr( $this->get_field_id( 'component' ) ); ?>">
-			<?php foreach ( $this->woo_widget_componentslist as $k => $v ) { ?>
+			<?php foreach ( $this->widget_componentslist as $k => $v ) { ?>
 				<option value="<?php echo esc_attr( $k ); ?>"<?php selected( $instance['component'], $k ); ?>><?php echo esc_html( $v ); ?></option>
 			<?php } ?>
 			</select>


### PR DESCRIPTION
I thought this was going to be harder because widgets are registered with their class names. Turns out, widgets that extend `WP_Widget` use the ID passed to the parent constructor for all unique naming. This means that previous installs shouldn't lost their Sensei placed widgets. Additionally, the hooks used in our widgets use a predefined prefix that doesn't contain `woothemes`. 🎉 

### Testing Instructions
- From `master`, add all of Sensei core's widgets to sidebar areas.
- Switch to this branch. Load the front end and make sure they are all still there.
- Make sure no errors are logged/thrown.