### PR TITLE
Remove `Sensei_Main` deprecated methods without replacement

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1206,24 +1206,6 @@ class Sensei_Main {
 	} // end func email course details
 
 	/**
-	 * Sensei_woocommerce_reactivate_subscription
-	 *
-	 * @deprecated since 1.9.0, moved to Sensei_WC class
-	 *
-	 * @param int   $user_id          User ID.
-	 * @param mixed $subscription_key Subscription Key.
-	 */
-	public function sensei_woocommerce_reactivate_subscription( $user_id, $subscription_key ) {
-		_deprecated_function( __METHOD__, '1.9.0', 'Sensei_WC::reactivate_subscription' );
-
-		if ( ! method_exists( 'Sensei_WC', 'reactivate_subscription' ) ) {
-			return;
-		}
-
-		Sensei_WC::reactivate_subscription( $user_id, $subscription_key );
-	}
-
-	/**
 	 * WooCommerce Subscription Ended
 	 *
 	 * @deprecated since 1.9.0, moved to Sensei_WC class

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1206,24 +1206,6 @@ class Sensei_Main {
 	} // end func email course details
 
 	/**
-	 * WooCommerce Subscription Ended
-	 *
-	 * @deprecated since 1.9.0, moved to Sensei_WC class
-	 *
-	 * @param int   $user_id          The user id.
-	 * @param mixed $subscription_key The sub key.
-	 */
-	public function sensei_woocommerce_subscription_ended( $user_id, $subscription_key ) {
-		_deprecated_function( __METHOD__, '1.9.0', 'Sensei_WC::end_subscription' );
-
-		if ( ! method_exists( 'Sensei_WC', 'end_subscription' ) ) {
-			return;
-		}
-
-		Sensei_WC::end_subscription( $user_id, $subscription_key );
-	}
-
-	/**
 	 * Sensei_woocommerce_complete_order description
 	 *
 	 * @deprecated since 1.9.0 use Sensei_WC::complete_order( $order_id );


### PR DESCRIPTION
These methods would have been causing fatal errors for some time. I feel like it is safe to remove them.

From https://github.com/Automattic/sensei/pull/2446#issuecomment-464044934