### PR TITLE
Remove WooThemes prefix from email classes

### DIFF
--- a/includes/class-sensei-emails.php
+++ b/includes/class-sensei-emails.php
@@ -59,14 +59,14 @@ class Sensei_Emails {
 	 */
 	function init() {
 
-		$this->emails['learner-graded-quiz']      = include dirname( __FILE__ ) . '/emails/class-woothemes-sensei-email-learner-graded-quiz.php';
-		$this->emails['learner-completed-course'] = include dirname( __FILE__ ) . '/emails/class-woothemes-sensei-email-learner-completed-course.php';
-		$this->emails['teacher-completed-course'] = include dirname( __FILE__ ) . '/emails/class-woothemes-sensei-email-teacher-completed-course.php';
-		$this->emails['teacher-started-course']   = include dirname( __FILE__ ) . '/emails/class-woothemes-sensei-email-teacher-started-course.php';
-		$this->emails['teacher-completed-lesson'] = include dirname( __FILE__ ) . '/emails/class-woothemes-sensei-email-teacher-completed-lesson.php';
-		$this->emails['teacher-quiz-submitted']   = include dirname( __FILE__ ) . '/emails/class-woothemes-sensei-email-teacher-quiz-submitted.php';
-		$this->emails['teacher-new-message']      = include dirname( __FILE__ ) . '/emails/class-woothemes-sensei-email-teacher-new-message.php';
-		$this->emails['new-message-reply']        = include dirname( __FILE__ ) . '/emails/class-woothemes-sensei-email-new-message-reply.php';
+		$this->emails['learner-graded-quiz']      = include dirname( __FILE__ ) . '/emails/class-sensei-email-learner-graded-quiz.php';
+		$this->emails['learner-completed-course'] = include dirname( __FILE__ ) . '/emails/class-sensei-email-learner-completed-course.php';
+		$this->emails['teacher-completed-course'] = include dirname( __FILE__ ) . '/emails/class-sensei-email-teacher-completed-course.php';
+		$this->emails['teacher-started-course']   = include dirname( __FILE__ ) . '/emails/class-sensei-email-teacher-started-course.php';
+		$this->emails['teacher-completed-lesson'] = include dirname( __FILE__ ) . '/emails/class-sensei-email-teacher-completed-lesson.php';
+		$this->emails['teacher-quiz-submitted']   = include dirname( __FILE__ ) . '/emails/class-sensei-email-teacher-quiz-submitted.php';
+		$this->emails['teacher-new-message']      = include dirname( __FILE__ ) . '/emails/class-sensei-email-teacher-new-message.php';
+		$this->emails['new-message-reply']        = include dirname( __FILE__ ) . '/emails/class-sensei-email-new-message-reply.php';
 		$this->emails                             = apply_filters( 'sensei_email_classes', $this->emails );
 	}
 

--- a/includes/emails/class-sensei-email-learner-completed-course.php
+++ b/includes/emails/class-sensei-email-learner-completed-course.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'WooThemes_Sensei_Email_Learner_Completed_Course' ) ) :
+if ( ! class_exists( 'Sensei_Email_Learner_Completed_Course' ) ) :
 
 	/**
 	 * Learner Completed Course
@@ -16,7 +16,7 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Learner_Completed_Course' ) ) :
 	 *
 	 * @since       1.6.0
 	 */
-	class WooThemes_Sensei_Email_Learner_Completed_Course {
+	class Sensei_Email_Learner_Completed_Course {
 
 		var $template;
 		var $subject;
@@ -91,4 +91,4 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Learner_Completed_Course' ) ) :
 
 endif;
 
-return new WooThemes_Sensei_Email_Learner_Completed_Course();
+return new Sensei_Email_Learner_Completed_Course();

--- a/includes/emails/class-sensei-email-learner-graded-quiz.php
+++ b/includes/emails/class-sensei-email-learner-graded-quiz.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'WooThemes_Sensei_Email_Learner_Graded_Quiz' ) ) :
+if ( ! class_exists( 'Sensei_Email_Learner_Graded_Quiz' ) ) :
 
 	/**
 	 * Learner Graded Quiz
@@ -16,7 +16,7 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Learner_Graded_Quiz' ) ) :
 	 *
 	 * @since       1.6.0
 	 */
-	class WooThemes_Sensei_Email_Learner_Graded_Quiz {
+	class Sensei_Email_Learner_Graded_Quiz {
 
 		var $template;
 		var $subject;
@@ -107,4 +107,4 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Learner_Graded_Quiz' ) ) :
 
 endif;
 
-return new WooThemes_Sensei_Email_Learner_Graded_Quiz();
+return new Sensei_Email_Learner_Graded_Quiz();

--- a/includes/emails/class-sensei-email-new-message-reply.php
+++ b/includes/emails/class-sensei-email-new-message-reply.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'WooThemes_Sensei_Email_New_Message_Reply' ) ) :
+if ( ! class_exists( 'Sensei_Email_New_Message_Reply' ) ) :
 
 	/**
 	 * Teacher New Message
@@ -16,7 +16,7 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_New_Message_Reply' ) ) :
 	 *
 	 * @since       1.6.0
 	 */
-	class WooThemes_Sensei_Email_New_Message_Reply {
+	class Sensei_Email_New_Message_Reply {
 
 		/**
 		 * @var string
@@ -134,4 +134,4 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_New_Message_Reply' ) ) :
 
 endif;
 
-return new WooThemes_Sensei_Email_New_Message_Reply();
+return new Sensei_Email_New_Message_Reply();

--- a/includes/emails/class-sensei-email-teacher-completed-course.php
+++ b/includes/emails/class-sensei-email-teacher-completed-course.php
@@ -4,19 +4,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Quiz_Submitted' ) ) :
+if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Course' ) ) :
 
 	/**
-	 * Teacher Quiz Submitted
+	 * Teacher Completed Course
 	 *
-	 * An email sent to the teacher when one of their students submits a quiz for manual grading.
+	 * An email sent to the teacher when one of their students completes a course.
 	 *
 	 * @package Users
 	 * @author Automattic
 	 *
 	 * @since       1.6.0
 	 */
-	class WooThemes_Sensei_Email_Teacher_Quiz_Submitted {
+	class Sensei_Email_Teacher_Completed_Course {
 
 		var $template;
 		var $subject;
@@ -27,44 +27,48 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Quiz_Submitted' ) ) :
 
 		/**
 		 * Constructor
+		 *
+		 * @access public
 		 */
 		function __construct() {
-			$this->template = 'teacher-quiz-submitted';
+			$this->template = 'teacher-completed-course';
 		}
 
 		/**
 		 * trigger function.
 		 *
-		 * @param integer $learner_id
-		 * @param integer $quiz_id
+		 * @param int $learner_id
+		 * @param int $course_id
 		 *
 		 * @return void
 		 */
-		function trigger( $learner_id = 0, $quiz_id = 0 ) {
+		function trigger( $learner_id = 0, $course_id = 0 ) {
 			global  $sensei_email_data;
 
+			if ( ! Sensei_Utils::user_started_course( $course_id, $learner_id ) ) {
+				return;
+			}
 			// Get learner user object
 			$this->learner = new WP_User( $learner_id );
 
 			// Get teacher ID and user object
-			$lesson_id = get_post_meta( $quiz_id, '_quiz_lesson', true );
-
-			if ( ! Sensei_Utils::user_started_lesson( $lesson_id, $learner_id ) ) {
-				return;
-			}
-
-			$course_id     = get_post_meta( $lesson_id, '_lesson_course', true );
 			$teacher_id    = get_post_field( 'post_author', $course_id, 'raw' );
 			$this->teacher = new WP_User( $teacher_id );
 
-			// Set recipient (teacher)
+			// Set recipient (learner)
 			$this->recipient = stripslashes( $this->teacher->user_email );
 
 			do_action( 'sensei_before_mail', $this->recipient );
 
 			// translators: Placeholder is the blog name.
-			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has submitted a quiz for grading', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
-			$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has submitted a quiz for grading', 'woothemes-sensei' ), $this->template );
+			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has completed a course', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
+			$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has completed a course', 'woothemes-sensei' ), $this->template );
+
+			// Get passed status
+			$passed = __( 'passed', 'woothemes-sensei' );
+			if ( ! Sensei_Utils::sensei_user_passed_course( $course_id, $learner_id ) ) {
+				$passed = __( 'failed', 'woothemes-sensei' );
+			}
 
 			// Construct data array
 			$sensei_email_data = apply_filters(
@@ -75,8 +79,8 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Quiz_Submitted' ) ) :
 					'teacher_id'   => $teacher_id,
 					'learner_id'   => $learner_id,
 					'learner_name' => $this->learner->display_name,
-					'quiz_id'      => $quiz_id,
-					'lesson_id'    => $lesson_id,
+					'course_id'    => $course_id,
+					'passed'       => $passed,
 				),
 				$this->template
 			);
@@ -90,4 +94,4 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Quiz_Submitted' ) ) :
 
 endif;
 
-return new WooThemes_Sensei_Email_Teacher_Quiz_Submitted();
+return new Sensei_Email_Teacher_Completed_Course();

--- a/includes/emails/class-sensei-email-teacher-completed-lesson.php
+++ b/includes/emails/class-sensei-email-teacher-completed-lesson.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Completed_Lesson' ) ) :
+if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Lesson' ) ) :
 
 	/**
 	 * Teacher Completed Lesson
@@ -16,7 +16,7 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Completed_Lesson' ) ) :
 	 *
 	 * @since       1.6.0
 	 */
-	class WooThemes_Sensei_Email_Teacher_Completed_Lesson {
+	class Sensei_Email_Teacher_Completed_Lesson {
 
 		var $template;
 		var $subject;
@@ -82,4 +82,4 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Completed_Lesson' ) ) :
 
 endif;
 
-return new WooThemes_Sensei_Email_Teacher_Completed_Lesson();
+return new Sensei_Email_Teacher_Completed_Lesson();

--- a/includes/emails/class-sensei-email-teacher-new-message.php
+++ b/includes/emails/class-sensei-email-teacher-new-message.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_New_Message' ) ) :
+if ( ! class_exists( 'Sensei_Email_Teacher_New_Message' ) ) :
 
 	/**
 	 * Teacher New Message
@@ -16,7 +16,7 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_New_Message' ) ) :
 	 *
 	 * @since       1.6.0
 	 */
-	class WooThemes_Sensei_Email_Teacher_New_Message {
+	class Sensei_Email_Teacher_New_Message {
 
 		var $template;
 		var $subject;
@@ -100,4 +100,4 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_New_Message' ) ) :
 
 endif;
 
-return new WooThemes_Sensei_Email_Teacher_New_Message();
+return new Sensei_Email_Teacher_New_Message();

--- a/includes/emails/class-sensei-email-teacher-quiz-submitted.php
+++ b/includes/emails/class-sensei-email-teacher-quiz-submitted.php
@@ -4,19 +4,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Started_Course' ) ) :
+if ( ! class_exists( 'Sensei_Email_Teacher_Quiz_Submitted' ) ) :
 
 	/**
-	 * Teacher Started Course
+	 * Teacher Quiz Submitted
 	 *
-	 * An email sent to the teacher when one of their students starts a course.
+	 * An email sent to the teacher when one of their students submits a quiz for manual grading.
 	 *
 	 * @package Users
 	 * @author Automattic
 	 *
 	 * @since       1.6.0
 	 */
-	class WooThemes_Sensei_Email_Teacher_Started_Course {
+	class Sensei_Email_Teacher_Quiz_Submitted {
 
 		var $template;
 		var $subject;
@@ -29,35 +29,42 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Started_Course' ) ) :
 		 * Constructor
 		 */
 		function __construct() {
-			$this->template = 'teacher-started-course';
+			$this->template = 'teacher-quiz-submitted';
 		}
 
 		/**
 		 * trigger function.
 		 *
-		 * @param int $learner_id
-		 * @param int $course_id
+		 * @param integer $learner_id
+		 * @param integer $quiz_id
 		 *
 		 * @return void
 		 */
-		function trigger( $learner_id = 0, $course_id = 0 ) {
+		function trigger( $learner_id = 0, $quiz_id = 0 ) {
 			global  $sensei_email_data;
 
 			// Get learner user object
 			$this->learner = new WP_User( $learner_id );
 
 			// Get teacher ID and user object
+			$lesson_id = get_post_meta( $quiz_id, '_quiz_lesson', true );
+
+			if ( ! Sensei_Utils::user_started_lesson( $lesson_id, $learner_id ) ) {
+				return;
+			}
+
+			$course_id     = get_post_meta( $lesson_id, '_lesson_course', true );
 			$teacher_id    = get_post_field( 'post_author', $course_id, 'raw' );
 			$this->teacher = new WP_User( $teacher_id );
 
-			// Set recipient (learner)
+			// Set recipient (teacher)
 			$this->recipient = stripslashes( $this->teacher->user_email );
 
 			do_action( 'sensei_before_mail', $this->recipient );
 
 			// translators: Placeholder is the blog name.
-			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has started a course', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
-			$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has started a course', 'woothemes-sensei' ), $this->template );
+			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has submitted a quiz for grading', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
+			$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has submitted a quiz for grading', 'woothemes-sensei' ), $this->template );
 
 			// Construct data array
 			$sensei_email_data = apply_filters(
@@ -68,7 +75,8 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Started_Course' ) ) :
 					'teacher_id'   => $teacher_id,
 					'learner_id'   => $learner_id,
 					'learner_name' => $this->learner->display_name,
-					'course_id'    => $course_id,
+					'quiz_id'      => $quiz_id,
+					'lesson_id'    => $lesson_id,
 				),
 				$this->template
 			);
@@ -82,4 +90,4 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Started_Course' ) ) :
 
 endif;
 
-return new WooThemes_Sensei_Email_Teacher_Started_Course();
+return new Sensei_Email_Teacher_Quiz_Submitted();

--- a/includes/emails/class-sensei-email-teacher-started-course.php
+++ b/includes/emails/class-sensei-email-teacher-started-course.php
@@ -4,19 +4,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Completed_Course' ) ) :
+if ( ! class_exists( 'Sensei_Email_Teacher_Started_Course' ) ) :
 
 	/**
-	 * Teacher Completed Course
+	 * Teacher Started Course
 	 *
-	 * An email sent to the teacher when one of their students completes a course.
+	 * An email sent to the teacher when one of their students starts a course.
 	 *
 	 * @package Users
 	 * @author Automattic
 	 *
 	 * @since       1.6.0
 	 */
-	class WooThemes_Sensei_Email_Teacher_Completed_Course {
+	class Sensei_Email_Teacher_Started_Course {
 
 		var $template;
 		var $subject;
@@ -27,11 +27,9 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Completed_Course' ) ) :
 
 		/**
 		 * Constructor
-		 *
-		 * @access public
 		 */
 		function __construct() {
-			$this->template = 'teacher-completed-course';
+			$this->template = 'teacher-started-course';
 		}
 
 		/**
@@ -45,9 +43,6 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Completed_Course' ) ) :
 		function trigger( $learner_id = 0, $course_id = 0 ) {
 			global  $sensei_email_data;
 
-			if ( ! Sensei_Utils::user_started_course( $course_id, $learner_id ) ) {
-				return;
-			}
 			// Get learner user object
 			$this->learner = new WP_User( $learner_id );
 
@@ -61,14 +56,8 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Completed_Course' ) ) :
 			do_action( 'sensei_before_mail', $this->recipient );
 
 			// translators: Placeholder is the blog name.
-			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has completed a course', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
-			$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has completed a course', 'woothemes-sensei' ), $this->template );
-
-			// Get passed status
-			$passed = __( 'passed', 'woothemes-sensei' );
-			if ( ! Sensei_Utils::sensei_user_passed_course( $course_id, $learner_id ) ) {
-				$passed = __( 'failed', 'woothemes-sensei' );
-			}
+			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has started a course', 'woothemes-sensei' ), get_bloginfo( 'name' ) ), $this->template );
+			$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has started a course', 'woothemes-sensei' ), $this->template );
 
 			// Construct data array
 			$sensei_email_data = apply_filters(
@@ -80,7 +69,6 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Completed_Course' ) ) :
 					'learner_id'   => $learner_id,
 					'learner_name' => $this->learner->display_name,
 					'course_id'    => $course_id,
-					'passed'       => $passed,
 				),
 				$this->template
 			);
@@ -94,4 +82,4 @@ if ( ! class_exists( 'WooThemes_Sensei_Email_Teacher_Completed_Course' ) ) :
 
 endif;
 
-return new WooThemes_Sensei_Email_Teacher_Completed_Course();
+return new Sensei_Email_Teacher_Started_Course();


### PR DESCRIPTION
This simply removes the WooThemes prefix from email classes. 

### Testing Instructions
- Enable all email notifications.
- Make sure they are getting triggered appropriately.