### PR TITLE
Migrate references from legacy class names to new class names

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -227,7 +227,7 @@ class Sensei_Learner_Management {
 	 */
 	public function load_data_object( $name = '', $data = 0, $optional_data = null ) {
 		// Load Analysis data.
-		$object_name = 'WooThemes_Sensei_Learners_' . $name;
+		$object_name = 'Sensei_Learners_' . $name;
 		if ( is_null( $optional_data ) ) {
 			$sensei_learners_object = new $object_name( $data );
 		} else {

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author Automattic
  * @since 1.2.0
  */
-class Sensei_Analysis_Course_List_Table extends WooThemes_Sensei_List_Table {
+class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	public $user_id;
 	public $course_id;
 	public $total_lessons;
@@ -459,9 +459,9 @@ class Sensei_Analysis_Course_List_Table extends WooThemes_Sensei_List_Table {
 							'status'   => array( 'graded', 'passed', 'failed' ),
 							'meta_key' => 'grade',
 						);
-						add_filter( 'comments_clauses', array( 'WooThemes_Sensei_Utils', 'comment_total_sum_meta_value_filter' ) );
+						add_filter( 'comments_clauses', array( 'Sensei_Utils', 'comment_total_sum_meta_value_filter' ) );
 						$lesson_grades = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_grades', $grade_args, $item ), true );
-						remove_filter( 'comments_clauses', array( 'WooThemes_Sensei_Utils', 'comment_total_sum_meta_value_filter' ) );
+						remove_filter( 'comments_clauses', array( 'Sensei_Utils', 'comment_total_sum_meta_value_filter' ) );
 
 						$grade_count          = ! empty( $lesson_grades->total ) ? $lesson_grades->total : 1;
 						$grade_total          = ! empty( $lesson_grades->meta_sum ) ? doubleval( $lesson_grades->meta_sum ) : 0;

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 1.2.0
  */
-class Sensei_Analysis_Lesson_List_Table extends WooThemes_Sensei_List_Table {
+class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 	public $lesson_id;
 	public $course_id;
 	public $page_slug = 'sensei_analysis';

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 1.2.0
  */
-class Sensei_Analysis_Overview_List_Table extends WooThemes_Sensei_List_Table {
+class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	public $type;
 	public $page_slug = 'sensei_analysis';
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -512,7 +512,7 @@ class Sensei_Frontend {
 	 */
 	function the_single_title() {
 
-		_deprecated_function( ' WooThemes_Sensei_Frontend::the_single_title', '1.9.0' );
+		_deprecated_function( 'Sensei_Frontend::the_single_title', '1.9.0' );
 
 	} // End sensei_single_title()
 
@@ -594,13 +594,13 @@ class Sensei_Frontend {
 	 *
 	 * @access public
 	 * @since  1.2.0
-	 * @deprecated since 1.9.0 use WooThemes_Sensei_Course::archive_header
+	 * @deprecated since 1.9.0 use Sensei_Course::archive_header
 	 * @return void
 	 */
 	function sensei_course_archive_header() {
 
-		trigger_error( 'This function sensei_course_archive_header has been depricated. Please use: WooThemes_Sensei_Course::course_archive_header ' );
-		WooThemes_Sensei_Course::archive_header( '', '<header class="archive-header"><h1>', '</h1></header>' );
+		trigger_error( 'This function sensei_course_archive_header has been depricated. Please use: Sensei_Course::course_archive_header ' );
+		Sensei_Course::archive_header( '', '<header class="archive-header"><h1>', '</h1></header>' );
 
 	} // sensei_course_archive_header()
 
@@ -613,7 +613,7 @@ class Sensei_Frontend {
 	 * @return void
 	 */
 	public function sensei_lesson_archive_header() {
-		_deprecated_function( 'WooThemes_Sensei_Frontend::sensei_lesson_archive_header', '1.9.0', 'WooThemes_Sensei_Lesson::the_archive_header' );
+		_deprecated_function( 'Sensei_Frontend::sensei_lesson_archive_header', '1.9.0', 'Sensei_Lesson::the_archive_header' );
 		Sensei()->lesson->the_archive_header();
 	} // sensei_course_archive_header()
 
@@ -712,12 +712,12 @@ class Sensei_Frontend {
 	/**
 	 * Outputs the course signup link.
 	 *
-	 * @deprecated since 1.9.0 use WooThemes_Sensei_Lesson::course_signup_link instead
+	 * @deprecated since 1.9.0 use Sensei_Lesson::course_signup_link instead
 	 */
 	public function sensei_lesson_course_signup_link() {
 
-		_deprecated_function( 'sensei_lesson_course_signup_link', '1.9.0', 'WooThemes_Sensei_Lesson::course_signup_link' );
-		WooThemes_Sensei_Lesson::course_signup_link();
+		_deprecated_function( 'sensei_lesson_course_signup_link', '1.9.0', 'Sensei_Lesson::course_signup_link' );
+		Sensei_Lesson::course_signup_link();
 	}
 
 	/**
@@ -942,7 +942,7 @@ class Sensei_Frontend {
 	/**
 	 * Gets the quiz answers for the current user.
 	 *
-	 * @deprecated use WooThemes_Sensei_Quiz::get_user_answers
+	 * @deprecated use Sensei_Quiz::get_user_answers
 	 * @param int $lesson_id Lesson ID.
 	 * @return array Quiz answers for the current user.
 	 */
@@ -981,7 +981,7 @@ class Sensei_Frontend {
 	 * @return bool true if the user has completed the lesson, false otherwise.
 	 */
 	public function sensei_has_user_completed_lesson( $post_id = 0, $user_id = 0 ) {
-		_deprecated_function( __FUNCTION__, '1.7', 'WooThemes_Sensei_Utils::user_completed_lesson()' );
+		_deprecated_function( __FUNCTION__, '1.7', 'Sensei_Utils::user_completed_lesson()' );
 		return Sensei_Utils::user_completed_lesson( $post_id, $user_id );
 	} // End sensei_has_user_completed_lesson()
 

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author Automattic
  * @since 1.3.0
  */
-class Sensei_Grading_Main extends WooThemes_Sensei_List_Table {
+class Sensei_Grading_Main extends Sensei_List_Table {
 
 	public $user_id;
 	public $course_id;

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -131,7 +131,7 @@ class Sensei_Grading {
 	 */
 	public function load_data_object( $name = '', $data = 0, $optional_data = null ) {
 		// Load Analysis data
-		$object_name = 'WooThemes_Sensei_Grading_' . $name;
+		$object_name = 'Sensei_Grading_' . $name;
 		if ( is_null( $optional_data ) ) {
 			$sensei_grading_object = new $object_name( $data );
 		} else {
@@ -683,7 +683,7 @@ class Sensei_Grading {
 			else {
 				$lesson_status = 'graded';
 			}
-			$lesson_metadata['grade'] = $grade; // Technically already set as part of "WooThemes_Sensei_Utils::sensei_grade_quiz()" above
+			$lesson_metadata['grade'] = $grade; // Technically already set as part of "Sensei_Utils::sensei_grade_quiz()" above
 
 			Sensei_Utils::update_lesson_status( $user_id, $quiz_lesson_id, $lesson_status, $lesson_metadata );
 

--- a/includes/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/class-sensei-learners-admin-bulk-actions-view.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 } // Exit if accessed directly
 
-class Sensei_Learners_Admin_Bulk_Actions_View extends WooThemes_Sensei_List_Table {
+class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 
 
 	public $view      = '';

--- a/includes/class-sensei-learners-main.php
+++ b/includes/class-sensei-learners-main.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 1.3.0
  */
-class Sensei_Learners_Main extends WooThemes_Sensei_List_Table {
+class Sensei_Learners_Main extends Sensei_List_Table {
 
 	public $course_id = 0;
 	public $lesson_id = 0;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -678,7 +678,7 @@ class Sensei_Lesson {
 			'style' => 'width: 100%',
 		);
 
-		$courses         = WooThemes_Sensei_Course::get_all_courses();
+		$courses         = Sensei_Course::get_all_courses();
 		$courses_options = array();
 		foreach ( $courses as $course ) {
 			$courses_options[ $course->ID ] = get_the_title( $course );
@@ -3509,7 +3509,7 @@ class Sensei_Lesson {
 					//
 					// course selection
 					//
-					$courses        = WooThemes_Sensei_Course::get_all_courses();
+					$courses        = Sensei_Course::get_all_courses();
 					$course_options = array();
 					if ( count( $courses ) > 0 ) {
 						foreach ( $courses as $course ) {
@@ -3934,9 +3934,9 @@ class Sensei_Lesson {
 		if ( 'lesson' == get_post_type( get_the_ID() ) ) {
 
 			// remove this hooks to avoid an infinite loop.
-			remove_filter( 'get_the_excerpt', array( 'WooThemes_Sensei_Lesson', 'alter_the_lesson_excerpt' ) );
+			remove_filter( 'get_the_excerpt', array( 'Sensei_Lesson', 'alter_the_lesson_excerpt' ) );
 
-			return WooThemes_Sensei_Lesson::lesson_excerpt( get_post( get_the_ID() ) );
+			return Sensei_Lesson::lesson_excerpt( get_post( get_the_ID() ) );
 		}
 
 		return $excerpt;
@@ -4128,9 +4128,9 @@ class Sensei_Lesson {
 	 */
 	public static function prerequisite_complete_message() {
 
-		$lesson_prerequisite      = WooThemes_Sensei_Lesson::get_lesson_prerequisite_id( get_the_ID() );
+		$lesson_prerequisite      = Sensei_Lesson::get_lesson_prerequisite_id( get_the_ID() );
 		$lesson_has_pre_requisite = $lesson_prerequisite > 0;
-		if ( ! WooThemes_Sensei_Lesson::is_prerequisite_complete( get_the_ID(), get_current_user_id() ) && $lesson_has_pre_requisite ) {
+		if ( ! Sensei_Lesson::is_prerequisite_complete( get_the_ID(), get_current_user_id() ) && $lesson_has_pre_requisite ) {
 
 			$prerequisite_lesson_link = '<a href="'
 				. esc_url( get_permalink( $lesson_prerequisite ) )

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3936,7 +3936,7 @@ class Sensei_Lesson {
 			// remove this hooks to avoid an infinite loop.
 			remove_filter( 'get_the_excerpt', array( 'Sensei_Lesson', 'alter_the_lesson_excerpt' ) );
 
-			return Sensei_Lesson::lesson_excerpt( get_post( get_the_ID() ) );
+			return self::lesson_excerpt( get_post( get_the_ID() ) );
 		}
 
 		return $excerpt;
@@ -4128,9 +4128,9 @@ class Sensei_Lesson {
 	 */
 	public static function prerequisite_complete_message() {
 
-		$lesson_prerequisite      = Sensei_Lesson::get_lesson_prerequisite_id( get_the_ID() );
+		$lesson_prerequisite      = self::get_lesson_prerequisite_id( get_the_ID() );
 		$lesson_has_pre_requisite = $lesson_prerequisite > 0;
-		if ( ! Sensei_Lesson::is_prerequisite_complete( get_the_ID(), get_current_user_id() ) && $lesson_has_pre_requisite ) {
+		if ( ! self::is_prerequisite_complete( get_the_ID(), get_current_user_id() ) && $lesson_has_pre_requisite ) {
 
 			$prerequisite_lesson_link = '<a href="'
 				. esc_url( get_permalink( $lesson_prerequisite ) )

--- a/includes/class-sensei-list-table.php
+++ b/includes/class-sensei-list-table.php
@@ -247,7 +247,7 @@ class Sensei_List_Table extends WP_List_Table {
 	 * @abstract
 	 */
 	protected function get_row_data( $item ) {
-		die( 'either function WooThemes_Sensei_List_Table::get_row_data() must be over-ridden in a sub-class or WooThemes_Sensei_List_Table::single_row() should be.' );
+		die( 'either function Sensei_List_Table::get_row_data() must be over-ridden in a sub-class or Sensei_List_Table::single_row() should be.' );
 	}
 
 	/**

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -536,7 +536,7 @@ class Sensei_Core_Modules {
 				)
 			);
 			if ( ! $is_user_taking_course ) {
-				if ( method_exists( 'WooThemes_Sensei_Frontend', 'sensei_lesson_preview_title_text' ) ) {
+				if ( method_exists( 'Sensei_Frontend', 'sensei_lesson_preview_title_text' ) ) {
 					$title_text = Sensei()->frontend->sensei_lesson_preview_title_text( $course_id );
 					// Remove brackets for display here
 					$title_text = str_replace( '(', '', $title_text );

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -102,7 +102,7 @@ class Sensei_PostTypes {
 		foreach ( $posttypes as $posttype_token => $posttype_name ) {
 
 			// Load the files
-			$class_name                   = 'WooThemes_Sensei_' . $posttype_name;
+			$class_name                   = 'Sensei_' . $posttype_name;
 			$this->$posttype_token        = new $class_name();
 			$this->$posttype_token->token = $posttype_token;
 

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -497,7 +497,7 @@ class Sensei_Question {
 	/**
 	 * Echo the sensei question title.
 	 *
-	 * @uses WooThemes_Sensei_Question::get_the_question_title
+	 * @uses Sensei_Question::get_the_question_title
 	 *
 	 * @since 1.9.0
 	 * @param $question_id

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -629,7 +629,7 @@ class Sensei_Quiz {
 
 			}
 
-			$lesson_metadata['grade'] = $grade; // Technically already set as part of "WooThemes_Sensei_Utils::sensei_grade_quiz_auto()" above
+			$lesson_metadata['grade'] = $grade; // Technically already set as part of "Sensei_Utils::sensei_grade_quiz_auto()" above
 
 		} // end if ! is_wp_error( $grade ...
 
@@ -1431,7 +1431,7 @@ class Sensei_Quiz {
 		return $merged;
 	}
 
-} // End Class WooThemes_Sensei_Quiz
+} // End Class Sensei_Quiz
 
 
 

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -2054,7 +2054,7 @@ class Sensei_Updates {
 	}
 
 	 /**
-	  * WooThemes_Sensei_Updates::enhance_teacher_role
+	  * Sensei_Updates::enhance_teacher_role
 	  *
 	  * This runs the update to create the teacher role
 	  *

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -565,7 +565,7 @@ class Sensei_Utils {
 	 * This function grades each question automatically if the are auto gradable.
 	 * It store all question grades.
 	 *
-	 * @deprecated since 1.7.4 use WooThemes_Sensei_Grading::grade_quiz_auto instead
+	 * @deprecated since 1.7.4 use Sensei_Grading::grade_quiz_auto instead
 	 *
 	 * @param  integer $quiz_id         ID of quiz
 	 * @param  array   $submitted questions id ans answers {
@@ -616,7 +616,7 @@ class Sensei_Utils {
 	 *
 	 * This function checks the question type and then grades it accordingly.
 	 *
-	 * @deprecated since 1.7.4 use WooThemes_Sensei_Grading::grade_question_auto instead
+	 * @deprecated since 1.7.4 use Sensei_Grading::grade_question_auto instead
 	 *
 	 * @param integer $question_id
 	 * @param string  $question_type of the standard Sensei question types
@@ -627,7 +627,7 @@ class Sensei_Utils {
 	 */
 	public static function sensei_grade_question_auto( $question_id = 0, $question_type = '', $answer = '', $user_id = 0 ) {
 
-		return WooThemes_Sensei_Grading::grade_question_auto( $question_id, $question_type, $answer, $user_id );
+		return Sensei_Grading::grade_question_auto( $question_id, $question_type, $answer, $user_id );
 
 	} // end sensei_grade_question_auto
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -49,12 +49,12 @@ class Sensei_Main {
 	public $post_types;
 
 	/**
-	 * @var WooThemes_Sensei_Settings
+	 * @var Sensei_Settings
 	 */
 	public $settings;
 
 	/**
-	 * @var WooThemes_Sensei_Course_Results
+	 * @var Sensei_Course_Results
 	 */
 	public $course_results;
 
@@ -64,32 +64,32 @@ class Sensei_Main {
 	public $updates;
 
 	/**
-	 * @var WooThemes_Sensei_Course
+	 * @var Sensei_Course
 	 */
 	public $course;
 
 	/**
-	 * @var WooThemes_Sensei_Lesson
+	 * @var Sensei_Lesson
 	 */
 	public $lesson;
 
 	/**
-	 * @var WooThemes_Sensei_Quiz
+	 * @var Sensei_Quiz
 	 */
 	public $quiz;
 
 	/**
-	 * @var WooThemes_Sensei_Question
+	 * @var Sensei_Question
 	 */
 	public $question;
 
 	/**
-	 * @var WooThemes_Sensei_Admin
+	 * @var Sensei_Admin
 	 */
 	public $admin;
 
 	/**
-	 * @var WooThemes_Sensei_Frontend
+	 * @var Sensei_Frontend
 	 */
 	public $frontend;
 
@@ -104,17 +104,17 @@ class Sensei_Main {
 	public $theme_integration_loader;
 
 	/**
-	 * @var WooThemes_Sensei_Grading
+	 * @var Sensei_Grading
 	 */
 	public $grading;
 
 	/**
-	 * @var WooThemes_Sensei_Emails
+	 * @var Sensei_Emails
 	 */
 	public $emails;
 
 	/**
-	 * @var WooThemes_Sensei_Learner_Profiles
+	 * @var Sensei_Learner_Profiles
 	 */
 	public $learner_profiles;
 
@@ -124,7 +124,7 @@ class Sensei_Main {
 	public $teacher;
 
 	/**
-	 * @var WooThemes_Sensei_Learners
+	 * @var Sensei_Learners
 	 */
 	public $learners;
 
@@ -280,7 +280,7 @@ class Sensei_Main {
 	 * @since 1.8.0
 	 * @static
 	 * @see WC()
-	 * @return WooThemes_Sensei Instance.
+	 * @return self
 	 */
 	public static function instance( $args ) {
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -49,7 +49,7 @@ function course_single_lessons() {
 	  */
 function lesson_single_meta() {
 
-	_deprecated_function( 'lesson_single_meta', '1.9;0', 'WooThemes_Sensei_Lesson::the_lesson_meta' );
+	_deprecated_function( 'lesson_single_meta', '1.9;0', 'Sensei_Lesson::the_lesson_meta' );
 	sensei_the_single_lesson_meta();
 
 } // End lesson_single_meta()
@@ -437,12 +437,12 @@ function sensei_get_excerpt( $post_id = '' ) {
 }
 
 function sensei_has_user_started_course( $post_id = 0, $user_id = 0 ) {
-	_deprecated_function( __FUNCTION__, '1.7', 'WooThemes_Sensei_Utils::user_started_course()' );
+	_deprecated_function( __FUNCTION__, '1.7', 'Sensei_Utils::user_started_course()' );
 	return Sensei_Utils::user_started_course( $post_id, $user_id );
 } // End sensei_has_user_started_course()
 
 function sensei_has_user_completed_lesson( $post_id = 0, $user_id = 0 ) {
-	_deprecated_function( __FUNCTION__, '1.7', 'WooThemes_Sensei_Utils::user_completed_lesson()' );
+	_deprecated_function( __FUNCTION__, '1.7', 'Sensei_Utils::user_completed_lesson()' );
 	return Sensei_Utils::user_completed_lesson( $post_id, $user_id );
 } // End sensei_has_user_completed_lesson()
 
@@ -457,7 +457,7 @@ function sensei_has_user_completed_lesson( $post_id = 0, $user_id = 0 ) {
  */
 function sensei_has_user_completed_prerequisite_lesson( $current_lesson_id, $user_id ) {
 
-	return WooThemes_Sensei_Lesson::is_prerequisite_complete( $current_lesson_id, $user_id );
+	return Sensei_Lesson::is_prerequisite_complete( $current_lesson_id, $user_id );
 
 } // End sensei_has_user_completed_prerequisite_lesson()
 
@@ -837,7 +837,7 @@ function sensei_the_question_content() {
 	$question_type = Sensei()->question->get_question_type( $sensei_question_loop['current_question']->ID );
 
 	// load the template that displays the question information.
-	WooThemes_Sensei_Question::load_question_template( $question_type );
+	Sensei_Question::load_question_template( $question_type );
 
 }//end sensei_the_question_content()
 
@@ -928,7 +928,7 @@ function sensei_can_user_view_lesson( $lesson_id = '', $user_id = '' ) {
 	}
 
 	// Check for prerequisite lesson completions
-	$pre_requisite_complete = WooThemes_Sensei_Lesson::is_prerequisite_complete( $lesson_id, $user_id );
+	$pre_requisite_complete = Sensei_Lesson::is_prerequisite_complete( $lesson_id, $user_id );
 	$lesson_course_id       = get_post_meta( $lesson_id, '_lesson_course', true );
 	$user_taking_course     = Sensei_Utils::user_started_course( $lesson_course_id, $user_id );
 

--- a/templates/content-course.php
+++ b/templates/content-course.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 ?>
 
-<li <?php post_class( WooThemes_Sensei_Course::get_course_loop_content_class() ); ?> >
+<li <?php post_class( Sensei_Course::get_course_loop_content_class() ); ?> >
 
 	<?php
 	/**

--- a/templates/single-course/lessons.php
+++ b/templates/single-course/lessons.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		/**
 		 * Actions just before the sensei single course lessons loop begins
 		 *
-		 * @hooked WooThemes_Sensei_Course::load_single_course_lessons_query
+		 * @hooked Sensei_Course::load_single_course_lessons_query
 		 * @since 1.9.0
 		 */
 		do_action( 'sensei_single_course_lessons_before' );
@@ -50,8 +50,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 					 *
 					 * @param $lessons_id
 					 *
-					 * @hooked WooThemes_Sensei_Lesson::the_lesson_meta -  5
-					 * @hooked WooThemes_Sensei_Lesson::the_lesson_thumbnail - 8
+					 * @hooked Sensei_Lesson::the_lesson_meta -  5
+					 * @hooked Sensei_Lesson::the_lesson_thumbnail - 8
 					 */
 					do_action( 'sensei_single_course_inside_before_lesson', get_the_ID() );
 
@@ -91,7 +91,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		/**
 		 * Actions just before the sensei single course lessons loop begins
 		 *
-		 * @hooked WooThemes_Sensei_Course::reset_single_course_query
+		 * @hooked Sensei_Course::reset_single_course_query
 		 *
 		 * @since 1.9.0
 		 */

--- a/templates/single-message.php
+++ b/templates/single-message.php
@@ -26,8 +26,8 @@ the_post();
 	 *
 	 * @param integer $message_id
 	 *
-	 * @hooked WooThemes_Sensei_Messages::the_title                 - 20
-	 * @hooked WooThemes_Sensei_Messages::the_message_sent_by_title - 40
+	 * @hooked Sensei_Messages::the_title                 - 20
+	 * @hooked Sensei_Messages::the_message_sent_by_title - 40
 	 */
 	do_action( 'sensei_single_message_content_inside_before', get_the_ID() );
 	?>

--- a/templates/single-quiz.php
+++ b/templates/single-quiz.php
@@ -43,7 +43,7 @@
 						/**
 						 * Action inside before the question content on single-quiz page
 						 *
-						 * @hooked WooThemes_Sensei_Quiz::the_user_status_message  - 10
+						 * @hooked Sensei_Quiz::the_user_status_message  - 10
 						 *
 						 * @param string $the_quiz_id
 						 */
@@ -67,10 +67,10 @@
 								/**
 								 * Action inside before the question content on single-quiz page
 								 *
-								 * @hooked WooThemes_Sensei_Question::the_question_title        - 10
-								 * @hooked WooThemes_Sensei_Question::the_question_description  - 20
-								 * @hooked WooThemes_Sensei_Question::the_question_media        - 30
-								 * @hooked WooThemes_Sensei_Question::the_question_hidden_field - 40
+								 * @hooked Sensei_Question::the_question_title        - 10
+								 * @hooked Sensei_Question::the_question_description  - 20
+								 * @hooked Sensei_Question::the_question_media        - 30
+								 * @hooked Sensei_Question::the_question_hidden_field - 40
 								 *
 								 * @since 1.9.0
 								 * @param string $the_question_id
@@ -86,7 +86,7 @@
 								/**
 								 * Action inside before the question content on single-quiz page
 								 *
-								 * @hooked WooThemes_Sensei_Question::answer_feedback_notes
+								 * @hooked Sensei_Question::answer_feedback_notes
 								 *
 								 * @param string $the_question_id
 								 */

--- a/templates/single-quiz/question-type-boolean.php
+++ b/templates/single-quiz/question-type-boolean.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * Get the question data with the current quiz id
 	 * All data is loaded in this array to keep the template clean.
 	 */
-	$question_data   = WooThemes_Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
+	$question_data   = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
 	$boolean_options = array( 'true', 'false' );
 
 ?>

--- a/templates/single-quiz/question-type-file-upload.php
+++ b/templates/single-quiz/question-type-file-upload.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * Get the question data with the current quiz id
 	 * All data is loaded in this array to keep the template clean.
 	 */
-	$question_data = WooThemes_Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
+	$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
 
 ?>
 

--- a/templates/single-quiz/question-type-gap-fill.php
+++ b/templates/single-quiz/question-type-gap-fill.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * Get the question data with the current quiz id
 	 * All data is loaded in this array to keep the template clean.
 	 */
-	$question_data = WooThemes_Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
+	$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
 
 ?>
 

--- a/templates/single-quiz/question-type-multi-line.php
+++ b/templates/single-quiz/question-type-multi-line.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * Get the question data with the current quiz id
 	 * All data is loaded in this array to keep the template clean.
 	 */
-	$question_data = WooThemes_Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
+	$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
 
 ?>
 

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * Get the question data with the current quiz id
 	 * All data is loaded in this array to keep the template clean.
 	 */
-	$question_data = WooThemes_Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
+	$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
 
 ?>
 

--- a/templates/single-quiz/question-type-single-line.php
+++ b/templates/single-quiz/question-type-single-line.php
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	 * Get the question data with the current quiz id
 	 * All data is loaded in this array to keep the template clean.
 	 */
-	$question_data = WooThemes_Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
+	$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
 
 ?>
 


### PR DESCRIPTION
When we renamed classes from having the `WooThemes_Sensei` prefix to just `Sensei_` artifacts were left behind. We were extending renamed classes with the old class name. These old class names exist because they're usually created at the bottom of the class files. A lot of changes were in comments and deprecation warnings.

Testing for this will probably be best done in our final bit, but the **danger zones** are:
- admin grading
- admin learner management
- quizzes

One change/bug is that before, this line had no effect because it was added with the _new class name_ but removed here with the old class name. I've changed it so now it will indeed remove the filter. Seems safe.
https://github.com/Automattic/sensei/blob/ab2092f92eae1252ab882fb335827fdca3b7d93a/includes/class-sensei-lesson.php#L3937