### PR TITLE
Fix module associations in dummy data

### DIFF
--- a/dummy_data.xml
+++ b/dummy_data.xml
@@ -211,10 +211,6 @@ The content for this sample course is provided with permission by <a href="http:
 			<wp:meta_value><![CDATA[7710]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key>_order_module_132</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
 			<wp:meta_key>_quiz_has_questions</wp:meta_key>
 			<wp:meta_value><![CDATA[1]]></wp:meta_value>
 		</wp:postmeta>
@@ -292,10 +288,6 @@ The content for this sample course is provided with permission by <a href="http
 		<wp:postmeta>
 			<wp:meta_key>_lesson_quiz</wp:meta_key>
 			<wp:meta_value><![CDATA[7712]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_order_module_133</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
 			<wp:meta_key>_quiz_has_questions</wp:meta_key>
@@ -391,10 +383,6 @@ The content for this sample course is provided with permission by <a href="http
 			<wp:meta_value><![CDATA[on]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key>_order_module_133</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
 			<wp:meta_key>_random_question_order</wp:meta_key>
 			<wp:meta_value><![CDATA[yes]]></wp:meta_value>
 		</wp:postmeta>
@@ -454,10 +442,6 @@ The content for this sample course is provided with permission by <a href="http
 		<wp:postmeta>
 			<wp:meta_key>_lesson_quiz</wp:meta_key>
 			<wp:meta_value><![CDATA[7714]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_order_module_133</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:comment>
 			<wp:comment_id>226326</wp:comment_id>
@@ -548,10 +532,6 @@ The content for this sample course is provided with permission by <a href="http
 			<wp:meta_key>_enable_quiz_reset</wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_order_module_133</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
-		</wp:postmeta>
 	</item>
 	<item>
 				<title>Billie Jean by Michael Jackson</title>
@@ -604,10 +584,6 @@ The content for this sample course is provided with permission by <a href="http
 		<wp:postmeta>
 			<wp:meta_key>_lesson_quiz</wp:meta_key>
 			<wp:meta_value><![CDATA[7716]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_order_module_134</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:comment>
 			<wp:comment_id>226317</wp:comment_id>
@@ -694,10 +670,6 @@ The content for this sample course is provided with permission by <a href="http
 			<wp:meta_key>_enable_quiz_reset</wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_order_module_134</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
-		</wp:postmeta>
 	</item>
 	<item>
 				<title>All of Me by John Legend</title>
@@ -750,10 +722,6 @@ The content for this sample course is provided with permission by <a href="http:
 		<wp:postmeta>
 			<wp:meta_key>_lesson_quiz</wp:meta_key>
 			<wp:meta_value><![CDATA[7718]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_order_module_134</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:comment>
 			<wp:comment_id>226324</wp:comment_id>
@@ -840,10 +808,6 @@ The content for this sample course is provided with permission by <a href="http:
 			<wp:meta_key>_enable_quiz_reset</wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_order_module_134</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
-		</wp:postmeta>
 	</item>
 	<item>
 				<title>A Sky Full of Stars by Coldplay</title>
@@ -896,10 +860,6 @@ The content for this sample course is provided with permission by <a href="http
 		<wp:postmeta>
 			<wp:meta_key>_lesson_quiz</wp:meta_key>
 			<wp:meta_value><![CDATA[7720]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_order_module_134</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:comment>
 			<wp:comment_id>226325</wp:comment_id>
@@ -986,10 +946,6 @@ The content for this sample course is provided with permission by <a href="http
 			<wp:meta_key>_enable_quiz_reset</wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
 		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_order_module_134</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
-		</wp:postmeta>
 	</item>
 	<item>
 				<title>Imagine by John Lennon</title>
@@ -1042,10 +998,6 @@ The content for this sample course is provided with permission by <a title="HDp
 		<wp:postmeta>
 			<wp:meta_key>_lesson_quiz</wp:meta_key>
 			<wp:meta_value><![CDATA[7722]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_order_module_134</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:comment>
 			<wp:comment_id>226318</wp:comment_id>
@@ -1131,10 +1083,6 @@ The content for this sample course is provided with permission by <a title="HDp
 		<wp:postmeta>
 			<wp:meta_key>_enable_quiz_reset</wp:meta_key>
 			<wp:meta_value><![CDATA[]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_order_module_134</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 	</item>
 	<item>
@@ -1789,10 +1737,6 @@ The content for this sample course is provided with permission by <a href="http
 			<wp:meta_value><![CDATA[7708]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key>_order_module_132</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
 			<wp:meta_key>_quiz_has_questions</wp:meta_key>
 			<wp:meta_value><![CDATA[1]]></wp:meta_value>
 		</wp:postmeta>
@@ -2105,10 +2049,6 @@ The content for this sample course is provided with permission by <a title="HDpi
 			<wp:meta_value><![CDATA[on]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key>_order_module_132</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
 			<wp:meta_key>_random_question_order</wp:meta_key>
 			<wp:meta_value><![CDATA[yes]]></wp:meta_value>
 		</wp:postmeta>
@@ -2182,10 +2122,6 @@ The content for this sample course is provided with permission by <a title="HDpi
 		<wp:postmeta>
 			<wp:meta_key>_enable_quiz_reset</wp:meta_key>
 			<wp:meta_value><![CDATA[on]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_order_module_132</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
 			<wp:meta_key>_random_question_order</wp:meta_key>
@@ -3648,10 +3584,6 @@ Feel free to complete it.]]></content:encoded>
 			<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:postmeta>
-			<wp:meta_key>_order_module_</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
 			<wp:meta_key>_lesson_quiz</wp:meta_key>
 			<wp:meta_value><![CDATA[4865]]></wp:meta_value>
 		</wp:postmeta>
@@ -3733,10 +3665,6 @@ Feel free to complete it.]]></content:encoded>
 		<wp:postmeta>
 			<wp:meta_key>_enable_quiz_reset</wp:meta_key>
 			<wp:meta_value><![CDATA[on]]></wp:meta_value>
-		</wp:postmeta>
-		<wp:postmeta>
-			<wp:meta_key>_order_module_</wp:meta_key>
-			<wp:meta_value><![CDATA[0]]></wp:meta_value>
 		</wp:postmeta>
 		<wp:comment>
 			<wp:comment_id>151960</wp:comment_id>

--- a/dummy_data.xml
+++ b/dummy_data.xml
@@ -37,27 +37,120 @@
 
 	<wp:author><wp:author_id>1</wp:author_id><wp:author_login>sensei</wp:author_login><wp:author_email>sensei@example.com</wp:author_email><wp:author_display_name><![CDATA[Sensei]]></wp:author_display_name><wp:author_first_name><![CDATA[Sensei]]></wp:author_first_name><wp:author_last_name><![CDATA[]]></wp:author_last_name></wp:author>
 
-	<wp:term><wp:term_id>121</wp:term_id><wp:term_taxonomy>question-type</wp:term_taxonomy><wp:term_slug>boolean</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[boolean]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>132</wp:term_id><wp:term_taxonomy>module</wp:term_taxonomy><wp:term_slug>chords-101-the-building-blocks-of-music</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Chords 101 - The Building Blocks of Music]]></wp:term_name><wp:term_description><![CDATA[Chords are groups of notes that form harmony. Most songs follow the same, basic chord formulas, and we’ve broken them down here for you to learn.]]></wp:term_description></wp:term>
-	<wp:term><wp:term_id>123</wp:term_id><wp:term_taxonomy>question-type</wp:term_taxonomy><wp:term_slug>essay-paste</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[essay-paste]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>126</wp:term_id><wp:term_taxonomy>question-type</wp:term_taxonomy><wp:term_slug>file-upload</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[file-upload]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>122</wp:term_id><wp:term_taxonomy>question-type</wp:term_taxonomy><wp:term_slug>gap-fill</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[gap-fill]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>128</wp:term_id><wp:term_taxonomy>module</wp:term_taxonomy><wp:term_slug>grading</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Grading]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>115</wp:term_id><wp:term_taxonomy>course-category</wp:term_taxonomy><wp:term_slug>guitar</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Guitar]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>125</wp:term_id><wp:term_taxonomy>question-type</wp:term_taxonomy><wp:term_slug>multi-line</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[multi-line]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>112</wp:term_id><wp:term_taxonomy>question-type</wp:term_taxonomy><wp:term_slug>multiple-choice</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[multiple-choice]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>135</wp:term_id><wp:term_taxonomy>course-category</wp:term_taxonomy><wp:term_slug>music</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Music]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>136</wp:term_id><wp:term_taxonomy>course-category</wp:term_taxonomy><wp:term_slug>piano</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Piano]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>130</wp:term_id><wp:term_taxonomy>module</wp:term_taxonomy><wp:term_slug>prerequisites</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Prerequisites]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>131</wp:term_id><wp:term_taxonomy>module</wp:term_taxonomy><wp:term_slug>quiz-features</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Quiz Features]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>127</wp:term_id><wp:term_taxonomy>module</wp:term_taxonomy><wp:term_slug>quizzes-and-question-types</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Quizzes and Question Types]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>133</wp:term_id><wp:term_taxonomy>module</wp:term_taxonomy><wp:term_slug>rhythm-101-the-heartbeat-of-music</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Rhythm 101 - The Heartbeat of Music]]></wp:term_name><wp:term_description><![CDATA[In this module, we’re going to dig deeper into the beat behind the song, and we’ll learn the rhythmic structures and formulas that all songs follow.]]></wp:term_description></wp:term>
-	<wp:term><wp:term_id>120</wp:term_id><wp:term_taxonomy>course-category</wp:term_taxonomy><wp:term_slug>sensei-2</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Sensei]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>129</wp:term_id><wp:term_taxonomy>module</wp:term_taxonomy><wp:term_slug>sensei-extensions</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Sensei Extensions]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>124</wp:term_id><wp:term_taxonomy>question-type</wp:term_taxonomy><wp:term_slug>single-line</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[single-line]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>117</wp:term_id><wp:term_taxonomy>course-category</wp:term_taxonomy><wp:term_slug>theming</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Theming]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>119</wp:term_id><wp:term_taxonomy>course-category</wp:term_taxonomy><wp:term_slug>tutorials</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Tutorials]]></wp:term_name></wp:term>
-	<wp:term><wp:term_id>134</wp:term_id><wp:term_taxonomy>module</wp:term_taxonomy><wp:term_slug>your-first-songs</wp:term_slug><wp:term_parent></wp:term_parent><wp:term_name><![CDATA[Your First Songs]]></wp:term_name><wp:term_description><![CDATA[Learn to play a selection of popular songs on the piano using our game-based hybrid video lessons.]]></wp:term_description></wp:term>
+	<wp:term>
+		<wp:term_id>115</wp:term_id>
+		<wp:term_taxonomy>course-category</wp:term_taxonomy>
+		<wp:term_slug>guitar</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[Guitar]]></wp:term_name>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>117</wp:term_id>
+		<wp:term_taxonomy>course-category</wp:term_taxonomy>
+		<wp:term_slug>theming</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[Theming]]></wp:term_name>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>119</wp:term_id>
+		<wp:term_taxonomy>course-category</wp:term_taxonomy>
+		<wp:term_slug>tutorials</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[Tutorials]]></wp:term_name>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>120</wp:term_id>
+		<wp:term_taxonomy>course-category</wp:term_taxonomy>
+		<wp:term_slug>sensei-2</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[Sensei]]></wp:term_name>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>135</wp:term_id>
+		<wp:term_taxonomy>course-category</wp:term_taxonomy>
+		<wp:term_slug>music</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[Music]]></wp:term_name>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>136</wp:term_id>
+		<wp:term_taxonomy>course-category</wp:term_taxonomy>
+		<wp:term_slug>piano</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[Piano]]></wp:term_name>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>132</wp:term_id>
+		<wp:term_taxonomy>module</wp:term_taxonomy>
+		<wp:term_slug>chords-101-the-building-blocks-of-music</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[Chords 101 - The Building Blocks of Music]]></wp:term_name>
+		<wp:term_description><![CDATA[Chords are groups of notes that form harmony. Most songs follow the same, basic chord formulas, and we’ve broken them down here for you to learn.]]></wp:term_description>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>133</wp:term_id>
+		<wp:term_taxonomy>module</wp:term_taxonomy>
+		<wp:term_slug>rhythm-101-the-heartbeat-of-music</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[Rhythm 101 - The Heartbeat of Music]]></wp:term_name><wp:term_description><![CDATA[In this module, we’re going to dig deeper into the beat behind the song, and we’ll learn the rhythmic structures and formulas that all songs follow.]]></wp:term_description>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>134</wp:term_id>
+		<wp:term_taxonomy>module</wp:term_taxonomy>
+		<wp:term_slug>your-first-songs</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[Your First Songs]]></wp:term_name>
+		<wp:term_description><![CDATA[Learn to play a selection of popular songs on the piano using our game-based hybrid video lessons.]]></wp:term_description>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>112</wp:term_id>
+		<wp:term_taxonomy>question-type</wp:term_taxonomy>
+		<wp:term_slug>multiple-choice</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[multiple-choice]]></wp:term_name>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>121</wp:term_id>
+		<wp:term_taxonomy>question-type</wp:term_taxonomy>
+		<wp:term_slug>boolean</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[boolean]]></wp:term_name>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>122</wp:term_id>
+		<wp:term_taxonomy>question-type</wp:term_taxonomy>
+		<wp:term_slug>gap-fill</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[gap-fill]]></wp:term_name>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>123</wp:term_id>
+		<wp:term_taxonomy>question-type</wp:term_taxonomy>
+		<wp:term_slug>essay-paste</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[essay-paste]]></wp:term_name>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>124</wp:term_id>
+		<wp:term_taxonomy>question-type</wp:term_taxonomy>
+		<wp:term_slug>single-line</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[single-line]]></wp:term_name>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>125</wp:term_id>
+		<wp:term_taxonomy>question-type</wp:term_taxonomy>
+		<wp:term_slug>multi-line</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[multi-line]]></wp:term_name>
+	</wp:term>
+	<wp:term>
+		<wp:term_id>126</wp:term_id>
+		<wp:term_taxonomy>question-type</wp:term_taxonomy>
+		<wp:term_slug>file-upload</wp:term_slug>
+		<wp:term_parent></wp:term_parent>
+		<wp:term_name><![CDATA[file-upload]]></wp:term_name>
+	</wp:term>
 
 	<generator>http://wordpress.org/?v=4.1.2</generator>
 

--- a/includes/3rd-party/3rd-party.php
+++ b/includes/3rd-party/3rd-party.php
@@ -7,3 +7,4 @@
 
 // Require compatibility files.
 require_once dirname( __FILE__ ) . '/woocommerce.php';
+require_once dirname( __FILE__ ) . '/wordpress-importer.php';

--- a/includes/3rd-party/wordpress-importer.php
+++ b/includes/3rd-party/wordpress-importer.php
@@ -8,7 +8,7 @@
 /**
  * Attaches modules to lessons for dummy data.
  */
-function sensei_add_modules_to_imported_lessons() {
+function sensei_wordpress_importer_add_modules_to_imported_lessons() {
 	$modules_with_lessons = array(
 		'chords-101-the-building-blocks-of-music' => array( 7706, 7709 ),
 		'rhythm-101-the-heartbeat-of-music'       => array( 7711, 7713 ),
@@ -34,4 +34,4 @@ function sensei_add_modules_to_imported_lessons() {
 	}
 }
 
-add_action( 'import_end', 'sensei_add_modules_to_imported_lessons' );
+add_action( 'import_end', 'sensei_wordpress_importer_add_modules_to_imported_lessons' );

--- a/includes/3rd-party/wordpress-importer.php
+++ b/includes/3rd-party/wordpress-importer.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Adds additional compatibility with WordPress Importer.
+ *
+ * @package 3rd-Party
+ */
+
+/**
+ * Attaches modules to lessons for dummy data.
+ */
+function sensei_add_modules_to_imported_lessons() {
+	$modules_with_lessons = array(
+		'chords-101-the-building-blocks-of-music' => array( 7706, 7709 ),
+		'rhythm-101-the-heartbeat-of-music'       => array( 7711, 7713 ),
+		'your-first-songs'                        => array( 7715, 7717, 7719, 7721 ),
+	);
+
+	foreach ( $modules_with_lessons as $module_slug => $lesson_ids ) {
+
+		$order = 1;
+		$term  = get_term_by( 'slug', $module_slug, 'module' );
+
+		if ( ! $term ) {
+			return;
+		}
+
+		$module_id = $term->term_id;
+
+		// Attach the module to each lesson.
+		foreach ( $lesson_ids as $lesson_id ) {
+			update_post_meta( $lesson_id, '_order_module_' . $module_id, $order );
+			$order++;
+		}
+	}
+}
+
+add_action( 'import_end', 'sensei_add_modules_to_imported_lessons' );


### PR DESCRIPTION
Fixes #2431.

The term ID for the module is generated dynamically, but the dummy data was associating modules to lessons using a static ID. This PR hooks into WordPress Importer's `import_end` action and programmatically attaches lessons to modules once the import is complete and the module IDs are known. Since there is no way to know if the import was for Sensei dummy data or not, the hooked function will run with every import but will return early if the dummy data module does not exist.

Note that the lesson IDs are hard-coded to be the same as what's used in the dummy data file. I would expect that may cause problems if those post IDs already exist when the dummy data is imported, but I won't be addressing that in this PR.

## Testing
1. On a fresh WordPress install, import WordPress content from a previous export. Don't import the dummy data yet.
2. Ensure there are no errors.
3. Import `dummy_data.xml` using the WordPress Importer.
4. Browse to the _How to Play the Piano_ course on the front-end. Ensure that lessons show below their module.