### PR TITLE
Add Classic Editor plugin to usage tracking

### DIFF
--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -79,14 +79,15 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 			return true;
 		}
 		$third_party_plugins = array(
+			'classic-editor',
+			'jetpack',
+			'polylang',
+			'sitepress-multilingual-cms',
 			'woocommerce',
-			'woothemes-updater',
-			'woocommerce-subscriptions',
 			'woocommerce-memberships',
 			'woocommerce-product-vendors',
-			'polylang',
-			'jetpack',
-			'sitepress-multilingual-cms',
+			'woocommerce-subscriptions',
+			'woothemes-updater',
 			'wp-quicklatex',
 		);
 		if ( in_array( $plugin_slug, $third_party_plugins, true ) ) {


### PR DESCRIPTION
Between tracking the WordPress version and activation of the Classic Editor plugin, we can get a sense of how many users are using the new editor. This will help us determine how blocks work should be prioritized.

## Testing
- Enable usage tracking.
- Install and activate the Classic Editor plugin and WP Crontrol plugins.
- Run the `sensei_usage_tracking_send_usage_data` job.
- Check that `plugin_classic_editor` is logged [in Tracks](https://mc.a8c.com/tracks/live/?eventname=sensei_system_log&user=&useragent=) with the correct version number.
- Disable usage tracking!