### PR TITLE
Fix issues in packaging task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,11 +44,11 @@ var paths = {
 		'templates/**/*',
 		'uninstall.php',
 		'widgets/**/*',
-		'woothemes-sensei.php',
+		'sensei.php',
 		'wpml-config.xml',
 	],
-	packageDir: 'build/woothemes-sensei',
-	packageZip: 'build/woothemes-sensei.zip'
+	packageDir: 'build/sensei',
+	packageZip: 'build/sensei.zip'
 };
 
 gulp.task( 'clean', gulp.series( function( cb ) {


### PR DESCRIPTION
This PR fixes the `gulp package` task after the change of `woothemes-sensei.php` to `sensei.php`.

## Testing instructions

- Run ` gulp package` (or `gulp package-unsafe`).
- Ensure the package is created in `build/`
- Ensure that the package is named `sensei` instead of `woothemes-sensei`.
- Installed the zip file into a fresh installation and ensure that it works.