### PR TITLE
Only show the email signup modal if option sensei_installed does not exist

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -619,7 +619,7 @@ class Sensei_Main {
 	 */
 	public function activate_sensei() {
 
-		if ( ! get_option( 'sensei_installed', false ) ) {
+		if ( false === get_option( 'sensei_installed', false ) ) {
 			update_option( 'sensei_show_email_signup_form', true );
 		}
 


### PR DESCRIPTION
This fixes an issue which caused the modal to show up multiple times in some cases.

## Testing instructions

- Install and activate Sensei on a fresh WP installation.
- Ensure the email signup modal appears. Dismiss it.
- On the "Welcome to Sensei" notice, click "Skip Setup".
- Deactivate and Reactivate Sensei.
- Ensure the email signup modal does not appear on reactivation.
- Follow the above step, but click "Install Sensei Pages" instead of "Skip Setup". Ensure the modal does not appear on activate.