### PR TITLE
Ensure we are performing updates on the Lesson, not a revision

### DIFF
--- a/includes/class-sensei-core-lesson-modules.php
+++ b/includes/class-sensei-core-lesson-modules.php
@@ -18,7 +18,14 @@ class Sensei_Core_Lesson_Modules {
 	private $lesson_id;
 
 	public function __construct( $lesson_id ) {
-		$this->lesson_id = $lesson_id;
+		$parent_id = wp_is_post_revision( $lesson_id );
+
+		// Ensure we are working with the Lesson post, not a revision.
+		if ( $parent_id ) {
+			$this->lesson_id = $parent_id;
+		} else {
+			$this->lesson_id = $lesson_id;
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/2201

More technical details on the cause of the bug are in the [commit message](https://github.com/Automattic/sensei/commit/bcd5e617c6aa7073a7857a09566a9b61bd36b25f).

Ensuring that all checks and updates occur on the parent post fixes the bug.

For testing instructions, see the linked issue. On this branch, editing and saving the lesson should not change its ordering within the module.