### PR TITLE
Clean up modules when course teacher is changed

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -303,7 +303,7 @@ class Sensei_Core_Modules {
 				'fields'         => 'ids',
 				'posts_per_page' => 1,
 			)
-		 );
+		);
 		if ( $post_query->found_posts > 0 ) {
 			return true;
 		}

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -268,6 +268,50 @@ class Sensei_Core_Modules {
 	}
 
 	/**
+	 * Delete a term if it is childless and not associated with a lesson or course.
+	 *
+	 * @param int $module_term_id Term ID for the module.
+	 */
+	public function remove_if_unused( $module_term_id ) {
+		if ( ! $this->is_term_used( $module_term_id ) ) {
+			wp_delete_term( $module_term_id, 'module' );
+		}
+	}
+
+	/**
+	 * Check if term either has children or is associated with a lesson or course.
+	 *
+	 * @param int $module_term_id Term ID for the module.
+	 * @return bool True if term is has children or is associated with a lesson or course.
+	 */
+	public function is_term_used( $module_term_id ) {
+		$term_children = get_term_children( $module_term_id, 'module' );
+		if ( ! is_wp_error( $term_children ) && ! empty( $term_children ) ) {
+			return true;
+		}
+
+		$post_query = new WP_Query(
+			array(
+				'post_type'      => array( 'lesson', 'course' ),
+				'tax_query'      => array(
+					array(
+						'taxonomy' => 'module',
+						'field'    => 'id',
+						'terms'    => intval( $module_term_id ),
+					),
+				),
+				'fields'         => 'ids',
+				'posts_per_page' => 1,
+			)
+		 );
+		if ( $post_query->found_posts > 0 ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Save module to lesson. This method checks for authorization, and checks
 	 * the incoming nonce.
 	 *

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -286,6 +286,7 @@ class Sensei_Core_Modules {
 	 */
 	public function is_term_used( $module_term_id ) {
 		$term_children = get_term_children( $module_term_id, 'module' );
+
 		if ( ! is_wp_error( $term_children ) && ! empty( $term_children ) ) {
 			return true;
 		}
@@ -304,6 +305,7 @@ class Sensei_Core_Modules {
 				'posts_per_page' => 1,
 			)
 		);
+
 		if ( $post_query->found_posts > 0 ) {
 			return true;
 		}

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -373,7 +373,6 @@ class Sensei_Teacher {
 	 * @return void
 	 */
 	public static function update_course_modules_author( $course_id, $new_teacher_id ) {
-
 		if ( empty( $course_id ) || empty( $new_teacher_id ) ) {
 			return;
 		}
@@ -396,6 +395,7 @@ class Sensei_Teacher {
 
 		foreach ( $terms_selected_on_course as $term ) {
 			$term_author = Sensei_Core_Modules::get_term_author( $term->slug );
+
 			if ( ! $term_author || intval( $new_teacher_id ) !== intval( $term_author->ID ) ) {
 				$new_slug       = $new_teacher_id . '-' . sanitize_title( trim( $term->name ) );
 				$search_slugs   = array();
@@ -410,8 +410,10 @@ class Sensei_Teacher {
 
 				// Search for term to recycle.
 				$new_term = false;
+
 				foreach ( $search_slugs as $search_slug ) {
 					$search_term = get_term_by( 'slug', $search_slug, 'module', ARRAY_A );
+
 					if ( $search_term && ! is_wp_error( $search_term ) ) {
 						$new_term = $search_term;
 						break;
@@ -449,14 +451,18 @@ class Sensei_Teacher {
 						// Add the new term, the false at the end says to replace all terms on this module
 						// with the new term.
 						wp_set_object_terms( $lesson->ID, $term_id, 'module', false );
+
 						$order_module     = 0;
 						$old_order_module = get_post_meta( $lesson->ID, '_order_module_' . intval( $term->term_id ), true );
+
 						if ( $old_order_module ) {
 							$order_module = $old_order_module;
+
 							if ( intval( $term->term_id ) !== intval( $term_id ) ) {
 								delete_post_meta( $lesson->ID, '_order_module_' . intval( $term->term_id ) );
 							}
 						}
+
 						update_post_meta( $lesson->ID, '_order_module_' . intval( $term_id ), $order_module );
 					}
 				}
@@ -465,7 +471,6 @@ class Sensei_Teacher {
 				Sensei()->modules->remove_if_unused( $term->term_id );
 			}
 		}
-
 	}
 
 	/**

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -403,7 +403,7 @@ class Sensei_Teacher {
 
 				// First, try to recycle an existing module.
 				if ( user_can( $new_teacher_id, 'manage_options' ) ) {
-					$admin_slug     = sanitize_title( trim( $term->name ) );
+					$admin_slug = sanitize_title( trim( $term->name ) );
 					array_unshift( $search_slugs, $admin_slug );
 					$new_slug = $admin_slug;
 				}

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -471,6 +471,9 @@ class Sensei_Teacher {
 						update_post_meta( $lesson->ID, '_order_module_' . intval( $term_id ), $order_module );
 					}
 				}
+
+				// Clean up module if no longer used.
+				Sensei()->modules->remove_if_unused( $term->term_id );
 			}
 		}
 

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -395,22 +395,17 @@ class Sensei_Teacher {
 		$lessons = Sensei()->course->course_lessons( $course_id );
 
 		foreach ( $terms_selected_on_course as $term ) {
-
 			$term_author = Sensei_Core_Modules::get_term_author( $term->slug );
 			if ( ! $term_author || intval( $new_teacher_id ) !== intval( $term_author->ID ) ) {
-
-				$search_slugs = array();
-				$new_slug     = $new_teacher_id . '-' . sanitize_title( trim( $term->name ) );
+				$new_slug       = $new_teacher_id . '-' . sanitize_title( trim( $term->name ) );
+				$search_slugs   = array();
+				$search_slugs[] = $new_slug;
 
 				// First, try to recycle an existing module.
 				if ( user_can( $new_teacher_id, 'manage_options' ) ) {
 					$admin_slug     = sanitize_title( trim( $term->name ) );
-					$search_slugs[] = $admin_slug;
-					$search_slugs[] = $new_slug;
-
+					array_unshift( $search_slugs, $admin_slug );
 					$new_slug = $admin_slug;
-				} else {
-					$search_slugs[] = $new_slug;
 				}
 
 				// Search for term to recycle.
@@ -424,7 +419,6 @@ class Sensei_Teacher {
 				}
 
 				if ( empty( $new_term ) ) {
-
 					// Create new term and set it.
 					$new_term = wp_insert_term(
 						$term->name,
@@ -433,7 +427,6 @@ class Sensei_Teacher {
 							'slug' => $new_slug,
 						)
 					);
-
 				}
 
 				if ( is_wp_error( $new_term ) ) {
@@ -453,7 +446,6 @@ class Sensei_Teacher {
 
 				foreach ( $lessons as $lesson ) {
 					if ( has_term( $term->term_id, 'module', $lesson ) ) {
-
 						// Add the new term, the false at the end says to replace all terms on this module
 						// with the new term.
 						wp_set_object_terms( $lesson->ID, $term_id, 'module', false );

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -384,76 +384,78 @@ class Sensei_Teacher {
 			Sensei()->modules->setup_modules_taxonomy();
 		}
 
+		remove_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70 );
 		$terms_selected_on_course = wp_get_object_terms( $course_id, 'module' );
+		add_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70, 3 );
 
 		if ( empty( $terms_selected_on_course ) ) {
 			return;
 		}
 
+		$lessons = Sensei()->course->course_lessons( $course_id );
+
 		foreach ( $terms_selected_on_course as $term ) {
 
+			/**
+			 * @var WP_Term $term
+			 */
 			$term_author = Sensei_Core_Modules::get_term_author( $term->slug );
-			if ( $new_teacher_id != $term_author->ID ) {
+			if ( ! $term_author || intval( $new_teacher_id ) !== intval( $term_author->ID ) ) {
 
-				$new_term = '';
+				$search_slugs = array();
+				$new_slug     = $new_teacher_id . '-' . sanitize_title( trim( $term->name ) );
 
-				// if the new teacher is admin first check to see if the term with this name already exists
+				// First, try to recycle an existing module.
 				if ( user_can( $new_teacher_id, 'manage_options' ) ) {
+					$admin_slug     = sanitize_title( trim( $term->name ) );
+					$search_slugs[] = $admin_slug;
+					$search_slugs[] = $new_slug;
 
-					$slug_without_teacher_id = str_ireplace( ' ', '-', trim( $term->name ) );
-					$term_args               = array(
-						'slug'       => $slug_without_teacher_id,
-						'hide_empty' => false,
-					);
-					$existing_admin_terms    = get_terms( 'module', $term_args );
-					if ( ! empty( $existing_admin_terms ) ) {
-						// insert it even if it exists
-						$new_term = get_term( $existing_admin_terms[0]->term_id, 'module', ARRAY_A );
+					$new_slug = $admin_slug;
+				} else {
+					$search_slugs[] = $new_slug;
+				}
+
+				// Search for term to recycle.
+				$new_term = false;
+				foreach ( $search_slugs as $search_slug ) {
+					$search_term = get_term_by( 'slug', $search_slug, 'module', ARRAY_A );
+					if ( $search_term && ! is_wp_error( $search_term ) ) {
+						$new_term = $search_term;
+						break;
 					}
 				}
 
 				if ( empty( $new_term ) ) {
-
-					// setup the new slug
-					$new_author_term_slug = $new_teacher_id . '-' . str_ireplace( ' ', '-', trim( $term->name ) );
 
 					// create new term and set it
 					$new_term = wp_insert_term(
 						$term->name,
 						'module',
 						array(
-							'slug' => $new_author_term_slug,
+							'slug' => $new_slug,
 						)
 					);
 
 				}
 
-				// if term exists
-				if ( is_wp_error( $new_term ) && isset( $new_term->errors['term_exists'] ) ) {
+				if ( is_wp_error( $new_term ) ) {
+					// Something happened. Let's leave the module alone.
+					continue;
+				}
 
-					$existing_term = get_term_by( 'slug', $new_author_term_slug, 'module' );
-					$term_id       = $existing_term->term_id;
-
-				} else {
-
-					// for a new term simply get the term from the returned value
-					$term_id = $new_term['term_id'];
-
-				} // End if().
+				$term_id = $new_term['term_id'];
 
 				// set the terms selected on the course
 				wp_set_object_terms( $course_id, $term_id, 'module', true );
 
 				// remove old term
-				if ( $term_id !== $term->term_id ) {
+				if ( intval( $term_id ) !== intval( $term->term_id ) ) {
 					wp_remove_object_terms( $course_id, $term->term_id, 'module' );
 				}
 
-				// update the lessons within the current module term
-				$lessons = Sensei()->course->course_lessons( $course_id );
 				foreach ( $lessons as $lesson ) {
-
-					if ( has_term( $term->slug, 'module', $lesson ) ) {
+					if ( has_term( $term->term_id, 'module', $lesson ) ) {
 
 						// add the new term, the false at the end says to replace all terms on this module
 						// with the new term.
@@ -462,17 +464,17 @@ class Sensei_Teacher {
 						$old_order_module = get_post_meta( $lesson->ID, '_order_module_' . intval( $term->term_id ), true );
 						if ( $old_order_module ) {
 							$order_module = $old_order_module;
-							if ( $term->term_id !== $term_id ) {
+							if ( intval( $term->term_id ) !== intval( $term_id ) ) {
 								delete_post_meta( $lesson->ID, '_order_module_' . intval( $term->term_id ) );
 							}
 						}
 						update_post_meta( $lesson->ID, '_order_module_' . intval( $term_id ), $order_module );
 					}
 				}
-			}// End if().
-		}// End foreach().
+			}
+		}
 
-	}//end update_course_modules_author()
+	}
 
 	/**
 	 * Sensei_Teacher::update_course_lessons_author

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -396,9 +396,6 @@ class Sensei_Teacher {
 
 		foreach ( $terms_selected_on_course as $term ) {
 
-			/**
-			 * @var WP_Term $term
-			 */
 			$term_author = Sensei_Core_Modules::get_term_author( $term->slug );
 			if ( ! $term_author || intval( $new_teacher_id ) !== intval( $term_author->ID ) ) {
 
@@ -428,7 +425,7 @@ class Sensei_Teacher {
 
 				if ( empty( $new_term ) ) {
 
-					// create new term and set it
+					// Create new term and set it.
 					$new_term = wp_insert_term(
 						$term->name,
 						'module',
@@ -446,10 +443,10 @@ class Sensei_Teacher {
 
 				$term_id = $new_term['term_id'];
 
-				// set the terms selected on the course
+				// Set the terms selected on the course.
 				wp_set_object_terms( $course_id, $term_id, 'module', true );
 
-				// remove old term
+				// Remove old term.
 				if ( intval( $term_id ) !== intval( $term->term_id ) ) {
 					wp_remove_object_terms( $course_id, $term->term_id, 'module' );
 				}
@@ -457,7 +454,7 @@ class Sensei_Teacher {
 				foreach ( $lessons as $lesson ) {
 					if ( has_term( $term->term_id, 'module', $lesson ) ) {
 
-						// add the new term, the false at the end says to replace all terms on this module
+						// Add the new term, the false at the end says to replace all terms on this module
 						// with the new term.
 						wp_set_object_terms( $lesson->ID, $term_id, 'module', false );
 						$order_module     = 0;


### PR DESCRIPTION
There seemed to be issues when a course with modules had its teacher changed. Especially if the old teacher was an admin and the new teacher wasn't (or visa versa). It would also leave the old, abandoned modules (which are tied to the user _if_ they aren't an admin). This tries to improve this process _and_ cleans up unused, abandoned modules from the previous teachers that would have normally been left.

The previous approach had a few problems:
- Wasn't consistent with not prepending user ID for admins.
- Didn't generate slugs consistent with how WP does (`sanitize_slugs()`). This would normally be fixed later on when creating, but might not have recycled the previous module if switching back to the old teacher.
- Didn't seem to do many checks for `WP_Error`.
- Used variables when they might not have been declared OR even worse, declared in a previous foreach loop run.

### Testing Instructions
- Create two or more teachers (TeacherA and TeacherB) as well as two or more admins (AdminA and AdminB).
- From TeacherA, create a course (CourseA) with multiple modules. Place multiple lessons in each module.
- Also from teacherA, create another course (CourseB). Give it at least one of the previous modules from CourseA. Assign lessons for that course to that module.
- From AdminA, publish both courses. (probably unnecessary?)
- From AdminA, for CourseA, change the teacher from TeacherA to TeacherB.
- Go to Courses > Modules. Verify the shared module between CourseA and CourseB was _split_. For the modules that weren't shared, those associated with TeacherA should be removed.
- Change CourseA back to TeacherA.
- Verify the old modules that were shared with CourseB are recycled.

Things to throw in the mix:
- Rename the module at various points. This will cause the module to _not_ be recycled, but that is expected/unavoidable at this point.
- Instead of just switching to TeacherB, switch back and forth from TeacherA to AdminA to AdminB to TeacherB to TeacherA. Verify it follows the modules correctly and doesn't leave any empties. 