### PR TITLE
Carefully load plugin on activation

### DIFF
--- a/sensei.php
+++ b/sensei.php
@@ -34,17 +34,49 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
+if ( class_exists( 'Sensei_Main' ) ) {
+	if ( ! function_exists( 'is_sensei_activating' ) ) {
+		/**
+		 * Checks if Sensei is being activated.
+		 *
+		 * @since 2.0.0
+		 * @access private
+		 *
+		 * @param string|bool $activating_plugin Plugin that may be getting activated. False if none.
+		 * @param string      $plugin            This plugin basename from loading function.
+		 * @return bool
+		 */
+		function is_sensei_activating( $activating_plugin, $plugin ) {
+			return ! empty( $activating_plugin ) && $activating_plugin === $plugin;
+		}
+	}
+	if ( ! isset( $_wp_plugin_file ) ) {
+		$_wp_plugin_file = false;
+	}
+	if ( ! isset( $plugin ) ) {
+		$plugin = null;
+	}
+	if ( is_sensei_activating( $_wp_plugin_file, $plugin ) && defined( 'SENSEI_IGNORE_ACTIVATION_CONFLICT' ) && true === SENSEI_IGNORE_ACTIVATION_CONFLICT ) {
+		// Hope that this will just be a conflict that happens during activation.
+		return;
+	} else {
+		die( esc_html__( 'Deactivate other instances of Sensei before activating this plugin.', 'sensei' ) );
+	}
+}
+
 require_once dirname( __FILE__ ) . '/includes/class-sensei-bootstrap.php';
 
 Sensei_Bootstrap::get_instance()->bootstrap();
 
-/**
- * Returns the global Sensei Instance.
- *
- * @since 1.8.0
- */
-function Sensei() {
-	return Sensei_Main::instance( array( 'version' => '2.0.0-dev' ) );
+if ( ! function_exists( 'Sensei' ) ) {
+	/**
+	 * Returns the global Sensei Instance.
+	 *
+	 * @since 1.8.0
+	 */
+	function Sensei() {
+		return Sensei_Main::instance( array( 'version' => '2.0.0-dev' ) );
+	}
 }
 
 // backwards compatibility
@@ -58,13 +90,15 @@ $woothemes_sensei = Sensei();
  */
 register_activation_hook( __FILE__, 'activate_sensei' );
 
-/**
- * Activate_sensei
- *
- * All the activation checks needed to ensure Sensei is ready for use
- *
- * @since 1.8.0
- */
-function activate_sensei() {
-	Sensei()->activate();
+if ( ! function_exists( 'activate_sensei' ) ) {
+	/**
+	 * Activate_sensei
+	 *
+	 * All the activation checks needed to ensure Sensei is ready for use
+	 *
+	 * @since 1.8.0
+	 */
+	function activate_sensei() {
+		Sensei()->activate();
+	}
 }


### PR DESCRIPTION
This PR will allow those with the compatibility plugin to activate Sensei. 

Alex and I discussed this and thought this would be the best way forward. The only other way would be instructing folks to do something to either deactivate the compat plugin first or have a switch in the compat plugin to deactivate its Sensei. The downside of this approach is it could mask issues with the Sensei they are trying to activate that will cause problems once it is fully activated. Hopefully, since they for sure one instance of Sensei 2 already running in the compat plugin, this won't be a big issue.

This also puts up a friendly error when attempting to activate a second copy of Sensei (`Deactivate other instances of Sensei before activating this plugin.`). This will be shown, for example, if they have Sensei 1.x installed in `woothemes-sensei` and try to install the dotorg Sensei into `sensei` (either manually or from directory).

### Testing 
In the matching compat plugin branch, first install the compatibility plugin. Activate that plugin. Then activate another Sensei plugin on this branch. The activation should be successful and the compatibility plugin should stop reporting the `Sensei Version: ` in the plugin list in WP admin.