### PR TITLE
 Uninstall: Don't delete data when another Sensei is active

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -9,10 +9,17 @@
  * @category Core
  * @author Automattic
  * @since 1.0.0
+ *
+ * @var string $plugin Plugin name being passed to `uninstall_plugin()`.
  */
 
 if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 	exit();
+}
+
+if ( class_exists( 'Sensei_Main' ) ) {
+	// Another instance of Sensei is installed and activated on the current site or network.
+	return;
 }
 
 require dirname( __FILE__ ) . '/sensei.php';
@@ -29,11 +36,44 @@ if ( ! is_multisite() ) {
 } else {
 	global $wpdb;
 
+	if ( ! function_exists( 'is_another_sensei_activated' ) ) {
+		/**
+		 * Checks if another Sensei is activated on the specific site in the network.
+		 *
+		 * @param string $current_plugin Current plugin that is being deleted.
+		 * @return bool True if another Sensei is activated.
+		 */
+		function is_another_sensei_activated( $current_plugin ) {
+			$current_plugin_basename = plugin_basename( $current_plugin );
+			$active_plugins          = (array) get_option( 'active_plugins', array() );
+			$other_sensei_basenames  = array(
+				'sensei/sensei.php',
+				'sensei/woothemes-sensei.php',
+				'woothemes-sensei/woothemes-sensei.php',
+			);
+			foreach ( $other_sensei_basenames as $basename ) {
+				if ( $basename === $current_plugin_basename ) {
+					// Plugins can be deleted on the network level even when activated on the site level.
+					// We don't want the current plugin to count in the search.
+					continue;
+				}
+				if ( in_array( $basename, $active_plugins, true ) || array_key_exists( $basename, $active_plugins ) ) {
+					return true;
+				}
+			}
+			return false;
+		}
+	}
+
 	$blog_ids         = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
 	$original_blog_id = get_current_blog_id();
 
 	foreach ( $blog_ids as $blog_id ) {
 		switch_to_blog( $blog_id );
+
+		if ( is_another_sensei_activated( $plugin ) ) {
+			continue;
+		}
 
 		// Only do deletion if the setting is true.
 		Sensei()->settings->get_settings();


### PR DESCRIPTION
For simple, non-MU sites, this will prevent data from being deleted on uninstall if `Sensei_Main` class is defined. 

It gets a bit more complicated for MU sites. Unless there is another Sensei that is network activated (which will make the class check above stop uninstall), we'll need to check `active_plugins` for each site and then only delete data if no other predictable Sensei plugin is activated. It still does the check for the individual setting.

Caveats: 
- For MU sites, this won't catch Sensei's installed in non-standard (`sensei` or `woothemes-sensei`) directories. 

### Testing Instructions
#### Non-MU Sites
Testing Not Removed:
- Set up a Sensei instance using the compat plugin or by installing into a non-standard directory like `/wp-content/plugins/sensei-test`. 
- Add courses, lessons, etc.
- Enable the Sensei setting to remove data.
- Install Sensei from this branch in `/wp-content/plugins/sensei` but don't activate.
- Delete the newly installed Sensei plugin from WP admin.
- Ensure data was _not_ removed.

Testing Removed:
- Set up a Sensei instance using this branch.
- Add courses, lessons, etc.
- Enable the Sensei setting to remove data.
- Deactivate Sensei.
- Delete Sensei.
- Ensure Sensei data _was_ removed from database.

#### MU Sites

- Test the above again by Network Activating Sensei when asked to activate.
- Test the above again, but only install and attempt deletion on the network plugins page. Activate the plugin from the individual blog's plugin page.
- _Note_: You can delete plugins from Network even if they are active on blogs. In this case, the `is_another_sensei_activated()` function should return `false` if that is the only active Sensei affecting that site and the data should be deleted.

Build of branch:
[sensei.zip](https://github.com/Automattic/sensei/files/2927129/sensei.zip)
