### PR TITLE
Add check for PHP version

### DIFF
--- a/includes/class-sensei-dependency-checker.php
+++ b/includes/class-sensei-dependency-checker.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Defines a class with methods for checking if Sensei's dependencies are met.
+ *
+ * NOTICE: This class should be PHP 5.2 compatible.
+ *
+ * @package Core
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sensei Dependencies Check
+ *
+ * @since 2.0.0
+ */
+class Sensei_Dependency_Checker {
+	const MINIMUM_PHP_VERSION = '5.6';
+
+	/**
+	 * Checks if all dependencies are met.
+	 *
+	 * @return bool
+	 */
+	public static function are_dependencies_met() {
+		$are_met = true;
+		if ( ! self::check_php() ) {
+			add_action( 'admin_notices', array( __CLASS__, 'add_php_notice' ) );
+			$are_met = false;
+		}
+		return $are_met;
+	}
+
+	/**
+	 * Checks for our PHP version requirement.
+	 *
+	 * @return bool
+	 */
+	private static function check_php() {
+		return version_compare( phpversion(), self::MINIMUM_PHP_VERSION, '>=' );
+	}
+
+	/**
+	 * Adds notice in WP Admin that minimum version of PHP is not met.
+	 *
+	 * @access private
+	 */
+	public static function add_php_notice() {
+		$screen        = get_current_screen();
+		$valid_screens = array( 'dashboard', 'plugins' );
+
+		if ( ! current_user_can( 'activate_plugins' ) || ! in_array( $screen->id, $valid_screens, true ) ) {
+			return;
+		}
+
+		// translators: %1$s is version of PHP that Sensei requires; %2$s is the version of PHP WordPress is running on.
+		$message = sprintf( __( '<strong>Sensei</strong> requires PHP version %1$s but you are running %2$s.', 'sensei' ), self::MINIMUM_PHP_VERSION, phpversion() );
+		echo '<div class="error"><p>';
+		echo wp_kses( $message, array( 'strong' => array() ) );
+		echo '</p></div>';
+	}
+}

--- a/includes/class-sensei-dependency-checker.php
+++ b/includes/class-sensei-dependency-checker.php
@@ -59,6 +59,7 @@ class Sensei_Dependency_Checker {
 		$message = sprintf( __( '<strong>Sensei</strong> requires PHP version %1$s but you are running %2$s.', 'sensei' ), self::MINIMUM_PHP_VERSION, phpversion() );
 		echo '<div class="error"><p>';
 		echo wp_kses( $message, array( 'strong' => array() ) );
+		echo '<p><a class="button button-primary" href="https://wordpress.org/support/update-php/" rel="noopener">' . esc_html__( 'Learn more about updating PHP', 'sensei' ) . '</a></p>';
 		echo '</p></div>';
 	}
 }

--- a/includes/class-sensei-dependency-checker.php
+++ b/includes/class-sensei-dependency-checker.php
@@ -45,7 +45,17 @@ class Sensei_Dependency_Checker {
 		$message = sprintf( __( '<strong>Sensei</strong> requires PHP version %1$s but you are running %2$s.', 'sensei' ), self::MINIMUM_PHP_VERSION, phpversion() );
 		echo '<div class="error"><p>';
 		echo wp_kses( $message, array( 'strong' => array() ) );
-		echo '<p><a class="button button-primary" href="https://wordpress.org/support/update-php/" rel="noopener">' . esc_html__( 'Learn more about updating PHP', 'sensei' ) . '</a></p>';
+		$php_update_url = 'https://wordpress.org/support/update-php/';
+		if ( function_exists( 'wp_get_update_php_url' ) ) {
+			$php_update_url = wp_get_update_php_url();
+		}
+		printf(
+			'<p><a class="button button-primary" href="%1$s" target="_blank" rel="noopener noreferrer">%2$s <span class="screen-reader-text">%3$s</span><span aria-hidden="true" class="dashicons dashicons-external"></span></a></p>',
+			esc_url( $php_update_url ),
+			esc_html__( 'Learn more about updating PHP', 'sensei' ),
+			/* translators: accessibility text */
+			esc_html__( '(opens in a new tab)', 'sensei' )
+		);
 		echo '</p></div>';
 	}
 }

--- a/includes/class-sensei-dependency-checker.php
+++ b/includes/class-sensei-dependency-checker.php
@@ -20,25 +20,11 @@ class Sensei_Dependency_Checker {
 	const MINIMUM_PHP_VERSION = '5.6';
 
 	/**
-	 * Checks if all dependencies are met.
-	 *
-	 * @return bool
-	 */
-	public static function are_dependencies_met() {
-		$are_met = true;
-		if ( ! self::check_php() ) {
-			add_action( 'admin_notices', array( __CLASS__, 'add_php_notice' ) );
-			$are_met = false;
-		}
-		return $are_met;
-	}
-
-	/**
 	 * Checks for our PHP version requirement.
 	 *
 	 * @return bool
 	 */
-	private static function check_php() {
+	public static function check_php() {
 		return version_compare( phpversion(), self::MINIMUM_PHP_VERSION, '>=' );
 	}
 

--- a/sensei.php
+++ b/sensei.php
@@ -8,13 +8,14 @@
  * Author URI: https://automattic.com
  * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Requires at least: 4.1
- * Tested up to: 4.9
+ * Tested up to: 5.1
+ * Requires PHP: 5.6
  * Text Domain: sensei
  * Domain path: /lang/
  */
 
 /*
-  Copyright 2013-2018 Automattic
+  Copyright 2013-2019 Automattic
 
 	This program is free software; you can redistribute it and/or modify
 	it under the terms of the GNU General Public License, version 2, as
@@ -32,6 +33,11 @@
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
+}
+
+require_once dirname( __FILE__ ) . '/includes/class-sensei-dependency-checker.php';
+if ( ! Sensei_Dependency_Checker::are_dependencies_met() ) {
+	return;
 }
 
 if ( class_exists( 'Sensei_Main' ) ) {

--- a/sensei.php
+++ b/sensei.php
@@ -36,7 +36,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once dirname( __FILE__ ) . '/includes/class-sensei-dependency-checker.php';
-if ( ! Sensei_Dependency_Checker::are_dependencies_met() ) {
+if ( ! Sensei_Dependency_Checker::check_php() ) {
+	add_action( 'admin_notices', array( 'Sensei_Dependency_Checker', 'add_php_notice' ) );
 	return;
 }
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -16,6 +16,12 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 }
 
 require dirname( __FILE__ ) . '/sensei.php';
+
+if ( ! function_exists( 'Sensei' ) ) {
+	// We still want people to be able to delete Sensei if they don't meet dependencies.
+	return;
+}
+
 require dirname( __FILE__ ) . '/includes/class-sensei-data-cleaner.php';
 
 // Cleanup all data.


### PR DESCRIPTION
This adds a simple check for PHP 5.6 into Sensei. It will also prevent data deletion if 5.6 dependency isn't met. There isn't really a way around this, but we could throw an exception in `uninstall.php` _if_ they've enabled their setting and instruct them to downgrade Sensei before deleting. We would have to do this without loading `sensei.php` and `class-sensei-data-cleaner.php`.

### Testing
Use a built package and test on versions PHP 5.2+ and before PHP 5.6.
