### PR TITLE
Update template version numbers

### DIFF
--- a/templates/archive-course.php
+++ b/templates/archive-course.php
@@ -7,7 +7,7 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     2.0.0
  */
 ?>
 

--- a/templates/archive-lesson.php
+++ b/templates/archive-lesson.php
@@ -8,22 +8,22 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     2.0.0
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+get_sensei_header();
+
+/**
+ * Action before lesson archive loop. This action runs within the archive-lesson.php.
+ *
+ * It will be executed even if there are no posts on the archive page.
+ */
+do_action( 'sensei_archive_before_lesson_loop' );
 ?>
-
-<?php get_sensei_header(); ?>
-
-	<?php
-
-		/**
-		 * Action before lesson archive loop. This action runs within the archive-lesson.php.
-		 *
-		 * It will be executed even if there are no posts on the archive page.
-		 */
-		do_action( 'sensei_archive_before_lesson_loop' );
-
-	?>
 
 	<?php if ( have_posts() ) : ?>
 

--- a/templates/archive-message.php
+++ b/templates/archive-message.php
@@ -7,13 +7,15 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     2.0.0
  */
-?>
 
-<?php get_sensei_header(); ?>
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-<?php
+get_sensei_header();
+
 /**
  * This action before course messages archive loop. This hook fires within the archive-message.php file.
  * It fires even if the current archive has no no messages.

--- a/templates/content-course.php
+++ b/templates/content-course.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * Content-course.php template file
  *
@@ -12,8 +9,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     1.12.2
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <li <?php post_class( Sensei_Course::get_course_loop_content_class() ); ?> >

--- a/templates/content-lesson.php
+++ b/templates/content-lesson.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * Content-lesson.php template file
  *
@@ -14,6 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category    Templates
  * @version     1.9.0
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <article <?php post_class( get_the_ID() ); ?> >

--- a/templates/content-message.php
+++ b/templates/content-message.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * Content-message.php template file
  *
@@ -12,8 +9,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     1.12.2
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <article <?php post_class( array( 'post', 'sensei_message' ), get_the_ID() ); ?>>

--- a/templates/course-results.php
+++ b/templates/course-results.php
@@ -7,13 +7,15 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     1.12.2
  */
-?>
 
-<?php get_sensei_header(); ?>
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-<?php
+get_sensei_header();
+
 /**
  * This hook fire inside learner-profile.php before the content
  *
@@ -105,7 +107,5 @@ $course = get_page_by_path( $wp_query->query_vars['course_results'], OBJECT, 'co
  * @since 1.9.0
  */
 do_action( 'sensei_course_results_content_after' );
-?>
 
-
-<?php get_sensei_footer(); ?>
+get_sensei_footer();

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * The Template for displaying all course lessons on the course results page.
  *
@@ -10,8 +7,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     2.0.0
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 global $course;
 ?>

--- a/templates/emails/admin-teacher-new-course-created.php
+++ b/templates/emails/admin-teacher-new-course-created.php
@@ -4,7 +4,9 @@
  *
  * @author  Automattic
  * @package Sensei/Templates/Emails/HTML
+ * @version 2.0.0
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }

--- a/templates/emails/footer.php
+++ b/templates/emails/footer.php
@@ -4,7 +4,7 @@
  *
  * @author  Automattic
  * @package Sensei/Templates/Emails
- * @version 1.6.0
+ * @version 2.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/emails/header.php
+++ b/templates/emails/header.php
@@ -4,7 +4,7 @@
  *
  * @author  Automattic
  * @package Sensei/Templates/Emails
- * @version 1.6.0
+ * @version 2.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/emails/learner-completed-course.php
+++ b/templates/emails/learner-completed-course.php
@@ -4,7 +4,7 @@
  *
  * @author  Automattic
  * @package Sensei/Templates/Emails/HTML
- * @version 1.6.0
+ * @version 2.0.0
  */
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/templates/emails/learner-graded-quiz.php
+++ b/templates/emails/learner-graded-quiz.php
@@ -4,7 +4,7 @@
  *
  * @author  Automattic
  * @package Sensei/Templates/Emails/HTML
- * @version 1.6.0
+ * @version 2.0.0
  */
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/templates/emails/new-message-reply.php
+++ b/templates/emails/new-message-reply.php
@@ -4,7 +4,7 @@
  *
  * @author  Automattic
  * @package Sensei/Templates/Emails/HTML
- * @version 1.6.0
+ * @version 2.0.0
  */
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/templates/emails/teacher-completed-course.php
+++ b/templates/emails/teacher-completed-course.php
@@ -4,7 +4,7 @@
  *
  * @author  Automattic
  * @package Sensei/Templates/Emails/HTML
- * @version 1.6.0
+ * @version 2.0.0
  */
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/templates/emails/teacher-completed-lesson.php
+++ b/templates/emails/teacher-completed-lesson.php
@@ -4,7 +4,7 @@
  *
  * @author  Automattic
  * @package Sensei/Templates/Emails/HTML
- * @version 1.6.0
+ * @version 2.0.0
  */
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/templates/emails/teacher-new-course-assignment.php
+++ b/templates/emails/teacher-new-course-assignment.php
@@ -4,7 +4,9 @@
  *
  * @author  Automattic
  * @package Sensei/Templates/Emails/HTML
+ * @version 2.0.0
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }

--- a/templates/emails/teacher-new-message.php
+++ b/templates/emails/teacher-new-message.php
@@ -4,7 +4,7 @@
  *
  * @author  Automattic
  * @package Sensei/Templates/Emails/HTML
- * @version 1.6.0
+ * @version 2.0.0
  */
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable

--- a/templates/emails/teacher-quiz-submitted.php
+++ b/templates/emails/teacher-quiz-submitted.php
@@ -4,8 +4,9 @@
  *
  * @author  Automattic
  * @package Sensei/Templates/Emails/HTML
- * @version 1.6.0
+ * @version 2.0.0
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 } // Exit if accessed directly ?>

--- a/templates/emails/teacher-started-course.php
+++ b/templates/emails/teacher-started-course.php
@@ -4,16 +4,14 @@
  *
  * @author  Automattic
  * @package Sensei/Templates/Emails/HTML
- * @version 1.6.0
+ * @version 2.0.0
  */
 
 // phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
-} // Exit if accessed directly ?>
-
-<?php
+} // Exit if accessed directly
 
 // Get data for email content
 global $sensei_email_data;

--- a/templates/globals/pagination-lesson.php
+++ b/templates/globals/pagination-lesson.php
@@ -1,15 +1,16 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * Pagination - Lesson
  *
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     1.9.20
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 global $post;
 

--- a/templates/globals/pagination-quiz.php
+++ b/templates/globals/pagination-quiz.php
@@ -1,14 +1,15 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * Pagination - Lesson
  *
  * @author  Automattic
  * @package Sensei/Templates
- * @version 1.1.0
+ * @version 1.9.20
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 global $post;
 

--- a/templates/globals/pagination.php
+++ b/templates/globals/pagination.php
@@ -1,15 +1,17 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * Pagination - Show numbered pagination for sensei archives
  *
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     1.12.2
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 // Exit if accessed directly
 global $wp_query;
 

--- a/templates/globals/wrapper-end.php
+++ b/templates/globals/wrapper-end.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * Content wrappers
  *
@@ -12,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category    Templates
  * @version     1.9.0
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 		</div>
 		<?php get_sidebar(); ?>

--- a/templates/globals/wrapper-start.php
+++ b/templates/globals/wrapper-start.php
@@ -8,6 +8,10 @@
  * @package Sensei/Templates
  * @version 1.6.4
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <div id="content" class="page col-full">

--- a/templates/learner-profile.php
+++ b/templates/learner-profile.php
@@ -7,13 +7,15 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     2.0.0
  */
-?>
 
-<?php get_sensei_header(); ?>
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-<?php
+get_sensei_header();
+
 /**
  * This hook fire inside learner-profile.php before the content
  *

--- a/templates/loop-course.php
+++ b/templates/loop-course.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * The Template for outputting Lists of any Sensei content type.
  *
@@ -12,9 +9,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category    Templates
  * @version     1.9.0
  */
-?>
 
-<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * This runs before the the course loop items in the loop.php template. It runs
  * only only for the course post type. This loop will not run if the current wp_query

--- a/templates/loop-lesson.php
+++ b/templates/loop-lesson.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * The Template for outputting Lesson Archive items
  *
@@ -12,9 +9,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category    Templates
  * @version     1.9.0
  */
-?>
 
-<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * This runs before the post type items in the loop-lesson.php template.
  *

--- a/templates/loop-message.php
+++ b/templates/loop-message.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * The Template for outputting Message Archive items
  *
@@ -12,9 +9,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category    Templates
  * @version     1.9.0
  */
-?>
 
-<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * This runs before the the message loop items in the loop-message.php template. It runs
  * only only for the message post type. This loop will not run if the current wp_query

--- a/templates/single-course.php
+++ b/templates/single-course.php
@@ -9,9 +9,13 @@
  * @category    Templates
  * @version     1.9.0
  */
-?>
 
-<?php get_sensei_header(); ?>
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+get_sensei_header();
+?>
 
 <article <?php post_class( array( 'course', 'post' ) ); ?>>
 

--- a/templates/single-course/lessons.php
+++ b/templates/single-course/lessons.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * The Template for displaying all single course meta information.
  *
@@ -12,6 +9,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category    Templates
  * @version     1.9.0
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <section class="course-lessons">

--- a/templates/single-course/modules.php
+++ b/templates/single-course/modules.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * List the Course Modules and Lesson in these modules
  *
@@ -13,8 +10,12 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.10.0
+ * @version     2.0.0
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 ?>
 
 <?php

--- a/templates/single-lesson.php
+++ b/templates/single-lesson.php
@@ -7,8 +7,12 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     1.12.2
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 global $post;
 

--- a/templates/single-message.php
+++ b/templates/single-message.php
@@ -7,11 +7,13 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     1.12.0
  */
-?>
 
-<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 get_sensei_header();
 the_post();
 ?>

--- a/templates/single-quiz.php
+++ b/templates/single-quiz.php
@@ -7,11 +7,15 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     2.0.0
  */
-?>
 
-<?php get_sensei_header(); ?>
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+get_sensei_header();
+?>
 
 <article <?php post_class(); ?>>
 

--- a/templates/single-quiz/question-type-boolean.php
+++ b/templates/single-quiz/question-type-boolean.php
@@ -1,25 +1,23 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * The Template for displaying True/False ( Boolean ) Question type.
  *
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     2.0.0
  */
-?>
 
-<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-	/**
-	 * Get the question data with the current quiz id
-	 * All data is loaded in this array to keep the template clean.
-	 */
-	$question_data   = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
-	$boolean_options = array( 'true', 'false' );
+/**
+ * Get the question data with the current quiz id
+ * All data is loaded in this array to keep the template clean.
+ */
+$question_data   = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
+$boolean_options = array( 'true', 'false' );
 
 ?>
 

--- a/templates/single-quiz/question-type-file-upload.php
+++ b/templates/single-quiz/question-type-file-upload.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * The Template for displaying File Upload Questions.
  *
@@ -10,17 +7,18 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     2.0.0
  */
-?>
 
-<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-	/**
-	 * Get the question data with the current quiz id
-	 * All data is loaded in this array to keep the template clean.
-	 */
-	$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
+/**
+ * Get the question data with the current quiz id
+ * All data is loaded in this array to keep the template clean.
+ */
+$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
 
 ?>
 

--- a/templates/single-quiz/question-type-gap-fill.php
+++ b/templates/single-quiz/question-type-gap-fill.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * The Template for displaying Gap Fill Line Questions.
  *
@@ -10,17 +7,18 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     1.12.2
  */
-?>
 
-<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-	/**
-	 * Get the question data with the current quiz id
-	 * All data is loaded in this array to keep the template clean.
-	 */
-	$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
+/**
+ * Get the question data with the current quiz id
+ * All data is loaded in this array to keep the template clean.
+ */
+$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
 
 ?>
 

--- a/templates/single-quiz/question-type-multi-line.php
+++ b/templates/single-quiz/question-type-multi-line.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * The Template for displaying Multi Line Questions.
  *
@@ -10,25 +7,22 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     2.0.0
  */
-?>
 
-<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-	/**
-	 * Get the question data with the current quiz id
-	 * All data is loaded in this array to keep the template clean.
-	 */
-	$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
+/**
+ * Get the question data with the current quiz id
+ * All data is loaded in this array to keep the template clean.
+ */
+$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
 
-?>
-
-<?php
-
-	Sensei_Utils::sensei_text_editor(
-		$question_data['user_answer_entry'],
-		'textquestion' . $question_data['ID'],
-		'sensei_question[' . $question_data['ID'] . ']'
-	);
+Sensei_Utils::sensei_text_editor(
+	$question_data['user_answer_entry'],
+	'textquestion' . $question_data['ID'],
+	'sensei_question[' . $question_data['ID'] . ']'
+);
 

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -1,24 +1,22 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * The Template for displaying Multiple Choice Questions.
  *
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     1.12.2
  */
-?>
 
-<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-	/**
-	 * Get the question data with the current quiz id
-	 * All data is loaded in this array to keep the template clean.
-	 */
-	$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
+/**
+ * Get the question data with the current quiz id
+ * All data is loaded in this array to keep the template clean.
+ */
+$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
 
 ?>
 

--- a/templates/single-quiz/question-type-single-line.php
+++ b/templates/single-quiz/question-type-single-line.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * The Template for displaying Single Line Questions.
  *
@@ -10,17 +7,18 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     2.0.0
  */
-?>
 
-<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
-	/**
-	 * Get the question data with the current quiz id
-	 * All data is loaded in this array to keep the template clean.
-	 */
-	$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
+/**
+ * Get the question data with the current quiz id
+ * All data is loaded in this array to keep the template clean.
+ */
+$question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
 
 ?>
 

--- a/templates/taxonomy-module.php
+++ b/templates/taxonomy-module.php
@@ -9,9 +9,13 @@
  * @category  Templates
  * @version   1.9.20
  */
-?>
 
-<?php get_sensei_header(); ?>
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+get_sensei_header();
+?>
 
 	<?php
 		/**

--- a/templates/teacher-archive.php
+++ b/templates/teacher-archive.php
@@ -8,44 +8,42 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     2.0.0
  */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+get_sensei_header();
+
+/**
+ * This action before teacher courses loop. This hook fires within the archive-course.php
+ * It fires even if the current archive has no posts.
+ *
+ * @since 1.9.0
+ */
+do_action( 'sensei_teacher_archive_course_loop_before' );
 ?>
 
-<?php get_sensei_header(); ?>
+<?php if ( have_posts() ) : ?>
 
-	<?php
+	<?php sensei_load_template( 'loop-course.php' ); ?>
 
-		/**
-		 * This action before teacher courses loop. This hook fires within the archive-course.php
-		 * It fires even if the current archive has no posts.
-		 *
-		 * @since 1.9.0
-		 */
-		do_action( 'sensei_teacher_archive_course_loop_before' );
+<?php else : ?>
 
-	?>
+	<p><?php esc_html_e( 'There are no courses for this teacher.', 'sensei' ); ?></p>
 
-	<?php if ( have_posts() ) : ?>
+<?php endif; // End If Statement ?>
 
-		<?php sensei_load_template( 'loop-course.php' ); ?>
+<?php
 
-	<?php else : ?>
+/**
+ * This action runs after including the teacher archive loop. This hook fires within the teacher-archive.php
+ * It fires even if the current archive has no posts.
+ *
+ * @since 1.9.0
+ */
+do_action( 'sensei_teacher_archive_course_loop_after' );
 
-		<p><?php esc_html_e( 'There are no courses for this teacher.', 'sensei' ); ?></p>
-
-	<?php endif; // End If Statement ?>
-
-	<?php
-
-		/**
-		 * This action runs after including the teacher archive loop. This hook fires within the teacher-archive.php
-		 * It fires even if the current archive has no posts.
-		 *
-		 * @since 1.9.0
-		 */
-		do_action( 'sensei_teacher_archive_course_loop_after' );
-
-	?>
-
-<?php get_sensei_footer(); ?>
+get_sensei_footer();

--- a/templates/user/login-form.php
+++ b/templates/user/login-form.php
@@ -1,8 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
-
 /**
  * The Template for displaying the sensei login form
  *
@@ -11,11 +7,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     2.0.0
  */
-?>
 
-<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
 /**
  *  Executes before the Sensei Login form markup begins.
  *

--- a/templates/user/my-courses.php
+++ b/templates/user/my-courses.php
@@ -1,7 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
 /**
  * The Template for displaying the my course page data.
  *
@@ -12,9 +9,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @category    Templates
  * @version     1.9.0
  */
-?>
 
-<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /**
  * Executes before the Sensei my courses markup begins. This hook
  * only fires whe a user is logged in. If you need to add


### PR DESCRIPTION
This PR updates the version numbers on templates and does some minor clean up.

Any file that has translated strings gets bumped to `2.0.0`. Other files needed a version bump as well. I only bumped the version if the changes since marked version were substantial. Most were from our PHPCS cleanup when we added escaping. I didn't, for example, bump the versions for changes just made to whitespace/code formatting or adding/modifying the `ABSPATH` check.

In terms of cleanup:
- Moved `ABSPATH` checks below docblock for PHPCS.
- Added a few `ABSPATH` checks.
- Merged neighboring php blocks in the header (sometimes footer).
- Did some minor fixes with indenting (might be easier to review without whitespace changes), but nothing too extreme.