### PR TITLE
Fix permalink/rewrite rule issue on activation

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -565,7 +565,7 @@ class Sensei_Main {
 	public function install() {
 
 		register_activation_hook( $this->main_plugin_file_name, array( $this, 'activate_sensei' ) );
-		register_activation_hook( $this->main_plugin_file_name, 'flush_rewrite_rules' );
+		register_activation_hook( $this->main_plugin_file_name, array( $this, 'initiate_rewrite_rules_flush' ) );
 
 	} // End install()
 


### PR DESCRIPTION
If courses already existed in database and then we reactivate Sensei, we would need to go into Permalink settings (or save a course) before the rewrite rules would flush with the registered post type. This should fix that issue. 

### Testing Instructions
- Activate Sensei. Create a course. View that course (frontend) in another tab.
- Deactivate Sensei.
- Activate Sensei again. Refresh the frontend course and make sure it is still accessible. 