### PR TITLE
Run plugin updates when needed

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -436,6 +436,7 @@ class Sensei_Main {
 
 		// check flush the rewrite rules if the option sensei_flush_rewrite_rules option is 1
 		add_action( 'init', array( $this, 'flush_rewrite_rules' ), 101 );
+		add_action( 'admin_init', array( $this, 'update' ) );
 
 		// Add plugin action links filter
 		add_filter( 'plugin_action_links_' . plugin_basename( $this->main_plugin_file_name ), array( $this, 'plugin_action_links' ) );
@@ -569,6 +570,19 @@ class Sensei_Main {
 
 	} // End install()
 
+	/**
+	 * Check for plugin updates.
+	 *
+	 * @since 2.0.0
+	 */
+	public function update() {
+		if ( ! version_compare( $this->version, get_option( 'sensei-version' ), '>' ) ) {
+			return;
+		}
+
+		// Run updates.
+		$this->register_plugin_version();
+	}
 
 	/**
 	 * Run on activation of the plugin.


### PR DESCRIPTION
This runs updates when the recorded version in the database doesn't match the current plugin version.

Currently it just updates `sensei-version` (so the compatibility plugin loads WCPC), but we could add additional steps from one of Sensei's three activation methods:
`Sensei_Main::activate()`
`Sensei_Main::activate_sensei()`
`Sensei_Main::activation()`

Outside of this PR, I think we should consolidate these activation methods