### PR TITLE
PHP 5.6 Check: Add notice and restrict future updates

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -252,10 +252,7 @@ class Sensei_Main {
 			add_action( 'admin_notices', array( __CLASS__, 'show_php_notice' ) );
 			add_filter( 'plugins_api', array( __CLASS__, 'plugins_api_hide_sensei_updates' ), 30, 3 );
 			add_action( 'pre_set_site_transient_update_plugins', array( __CLASS__, 'transient_update_plugins_hide_sensei_updates' ), 22, 1 );
-
-			if ( ! self::can_wordpress_hint_plugin_php_compat() ) {
-				add_action( 'plugin_row_meta', array( __CLASS__, 'add_plugin_meta_php_update_notice' ), 10, 3 );
-			}
+			add_action( 'plugin_row_meta', array( __CLASS__, 'add_plugin_meta_php_update_notice' ), 10, 3 );
 		}
 	}
 
@@ -409,12 +406,6 @@ class Sensei_Main {
 			return $response;
 		}
 
-		// If WordPress can hint when plugin requires certain PHP version and the Plugins API response included required
-		// PHP version, use that functionality.
-		if ( self::can_wordpress_hint_plugin_php_compat() && ! empty( $response->requires_php ) ) {
-			return $response;
-		}
-
 		$versions = $plugins[ $plugin_file ];
 		if ( empty( $response->version ) || version_compare( $response->version, $versions['incompatible'], '<' ) ) {
 			return $response;
@@ -443,10 +434,6 @@ class Sensei_Main {
 		foreach ( $plugins as $plugin_file => $versions ) {
 			if ( isset( $transient->response[ $plugin_file ] ) ) {
 				$item = $transient->response[ $plugin_file ];
-
-				if ( self::can_wordpress_hint_plugin_php_compat() && ! empty( $item->requires_php ) ) {
-					continue;
-				}
 
 				if ( empty( $item->new_version ) || version_compare( $item->new_version, $versions['incompatible'], '>=' ) ) {
 					// If the new version is one we know not to be compatible with installed PHP version,
@@ -507,17 +494,6 @@ class Sensei_Main {
 		}
 
 		return $plugins;
-	}
-
-	/**
-	 * Check if WordPress version can hint at which PHP versions are compatible with a plugin.
-	 *
-	 * @return bool
-	 */
-	private static function can_wordpress_hint_plugin_php_compat() {
-		global $wp_version;
-
-		return version_compare( '5.2.0', $wp_version, '<=' );
 	}
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -249,7 +249,7 @@ class Sensei_Main {
 		// Warn people with old version of PHP about upcoming changes and restrict updates.
 		if ( ! version_compare( phpversion(), '5.6.0', '>=' ) ) {
 			// Warn about upcoming Sensei 2 requirement and prevent updates.
-			add_action( 'admin_notices', array( __CLASS__, 'show_php_notice' ) );
+			add_action( 'all_admin_notices', array( __CLASS__, 'show_php_notice' ) );
 			add_filter( 'plugins_api', array( __CLASS__, 'plugins_api_hide_sensei_updates' ), 30, 3 );
 			add_action( 'pre_set_site_transient_update_plugins', array( __CLASS__, 'transient_update_plugins_hide_sensei_updates' ), 22, 1 );
 			add_action( 'plugin_row_meta', array( __CLASS__, 'add_plugin_meta_php_update_notice' ), 10, 3 );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -251,7 +251,7 @@ class Sensei_Main {
 			// Warn about upcoming Sensei 2 requirement and prevent updates.
 			add_action( 'all_admin_notices', array( __CLASS__, 'show_php_version_notice' ) );
 			add_filter( 'plugins_api', array( __CLASS__, 'plugins_api_hide_sensei_updates' ), 30, 3 );
-			add_action( 'pre_set_site_transient_update_plugins', array( __CLASS__, 'transient_update_plugins_hide_sensei_updates' ), 22, 1 );
+			add_action( 'pre_set_site_transient_update_plugins', array( __CLASS__, 'transient_update_plugins_hide_sensei_updates' ), 25, 1 );
 			add_action( 'plugin_row_meta', array( __CLASS__, 'add_plugin_meta_php_update_notice' ), 10, 3 );
 		}
 	}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -331,7 +331,7 @@ class Sensei_Main {
 		}
 		$message = sprintf(
 			// translators: %1$s is the URL to the Sensei 2 announcement; %2$s is the name of the plugin required; %3$s is the minimum version number.
-			__( '<a href="%1$s" rel="noopener noreferrer"><strong>Sensei 2.0</strong> is coming soon</a> and requires a minimum PHP version of %2$s, but you are running %3$s. <strong>Please update your version of PHP before updating Sensei.</strong>', 'woothemes-sensei' ),
+			__( '<a href="%1$s" rel="noopener noreferrer"><strong>Sensei 2.0</strong> is coming soon</a> and requires a minimum PHP version of %2$s, but you are running %3$s. <strong>To ensure that you continue to receive updates for Sensei and our official extensions, please upgrade to a newer version of PHP.</strong>', 'woothemes-sensei' ),
 			'https://senseilms.com/2019/02/27/upcoming-changes-in-sensei-2-0/',
 			'5.6.0',
 			phpversion()
@@ -374,10 +374,10 @@ class Sensei_Main {
 			return $plugin_meta;
 		}
 
-		$more_information_url = 'https://senseilms.com/documentation/';
+		$more_information_url = 'https://senseilms.com/documentation/faq/#requirements';
 
-		// translators: Placeholder is url for more info on Sensei's PHP version bump.
-		$message       = sprintf( __( 'Next version requires newer version of PHP. <a href="%s" rel="noopener noreferrer" target="_blank">More Information <span aria-hidden="true" class="dashicons dashicons-external"></span></a>', 'woothemes-sensei' ), $more_information_url );
+		// translators: %1$s is name of the Sensei product; %2$s is version not compatible with PHP 5.6; %3$s is url for more info on Sensei's PHP version bump.
+		$message       = sprintf( __( '%1$s %2$s requires a newer version of PHP. <a href="%3$s" rel="noopener noreferrer" target="_blank">More Information <span aria-hidden="true" class="dashicons dashicons-external"></span></a>', 'woothemes-sensei' ), $plugin_data['Name'], $versions['incompatible'], $more_information_url );
 		$plugin_meta[] = '<span style="color: red; font-weight: bold;">' . wp_kses_post( $message ) . '</span>';
 
 		return $plugin_meta;

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -325,7 +325,7 @@ class Sensei_Main {
 	 */
 	public static function show_php_notice() {
 		$screen        = get_current_screen();
-		$valid_screens = array( 'dashboard', 'plugins' );
+		$valid_screens = array( 'dashboard', 'plugins', 'plugins-network' );
 		if ( ! current_user_can( 'activate_plugins' ) || ! in_array( $screen->id, $valid_screens, true ) ) {
 			return;
 		}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -249,7 +249,7 @@ class Sensei_Main {
 		// Warn people with old version of PHP about upcoming changes and restrict updates.
 		if ( ! version_compare( phpversion(), '5.6.0', '>=' ) ) {
 			// Warn about upcoming Sensei 2 requirement and prevent updates.
-			add_action( 'all_admin_notices', array( __CLASS__, 'show_php_notice' ) );
+			add_action( 'all_admin_notices', array( __CLASS__, 'show_php_version_notice' ) );
 			add_filter( 'plugins_api', array( __CLASS__, 'plugins_api_hide_sensei_updates' ), 30, 3 );
 			add_action( 'pre_set_site_transient_update_plugins', array( __CLASS__, 'transient_update_plugins_hide_sensei_updates' ), 22, 1 );
 			add_action( 'plugin_row_meta', array( __CLASS__, 'add_plugin_meta_php_update_notice' ), 10, 3 );
@@ -320,7 +320,7 @@ class Sensei_Main {
 	/**
 	 * Show notice when minimum PHP version is not met.
 	 */
-	public static function show_php_notice() {
+	public static function show_php_version_notice() {
 		$screen        = get_current_screen();
 		$valid_screens = array( 'dashboard', 'plugins', 'plugins-network' );
 		if ( ! current_user_can( 'activate_plugins' ) || ! in_array( $screen->id, $valid_screens, true ) ) {


### PR DESCRIPTION
This adds a notice for installs using Sensei with older versions of PHP (less than 5.6). In addition to adding the top admin notice on plugin and dashboard page, this also adds a small notice next to Sensei and official extensions on the plugin list. Updates are blocked through WP admin (not including manual uploading) for versions of Sensei and official extensions that will require a PHP version bump. This should still allow for future security releases if necessary/possible.

### Testing
Build of PR: 
[woothemes-sensei-2cd38dc.zip](https://github.com/Automattic/sensei/files/3008381/woothemes-sensei-2cd38dc.zip)

- On instances with older versions of PHP, notice should appear at top of Plugins and Dashboard pages and next to the individual Sensei plugin + official extensions. PHP 5.6+ should not have notices.
- With the below helpers, updates should not be shown on plugins page when using older versions of PHP.
- On newer versions of PHP (5.6+), updates should still be offered when using below helpers.
- ~Using WordPress 5.2 with older PHP should show standard update warning instead of notice with plugin meta. If you're using a pre-release, you may need to manually update `$wp_version` to be 5.2.0.~

### Helpers for Testing
(Note: Actual update won't work. Update zip packages are not included.)
Simulate updates to Sensei core: 
[sensei-update-core.zip](https://github.com/Automattic/sensei/files/3008399/sensei-update-core.zip)

Simulate updates to Senesi Content Drip:
[sensei-update-content-drip.zip](https://github.com/Automattic/sensei/files/3008363/sensei-update-content-drip.zip)

### To Do
- [x] Update documentation link that shows up in plugin list.
- [x] Update notification text. (@donnapep)
- [ ] Post-merge: PR to remove this functionality for release 2.0 merge.