### PR TITLE
Update version number on plugin update

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -567,7 +567,8 @@ class Sensei_Main {
 	/**
 	 * Check for plugin updates.
 	 *
-	 * @since 1.12.3
+	 * @access private
+	 * @since  1.12.3
 	 */
 	public function update() {
 		if ( ! version_compare( $this->version, get_option( 'woothemes-sensei-version' ), '>' ) ) {

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -430,6 +430,7 @@ class Sensei_Main {
 
 		// check flush the rewrite rules if the option sensei_flush_rewrite_rules option is 1
 		add_action( 'init', array( $this, 'flush_rewrite_rules' ), 101 );
+		add_action( 'admin_init', array( $this, 'update' ) );
 
 		// Add plugin action links filter
 		add_filter( 'plugin_action_links_' . plugin_basename( $this->main_plugin_file_name ), array( $this, 'plugin_action_links' ) );
@@ -563,6 +564,19 @@ class Sensei_Main {
 
 	} // End install()
 
+	/**
+	 * Check for plugin updates.
+	 *
+	 * @since 1.12.3
+	 */
+	public function update() {
+		if ( ! version_compare( $this->version, get_option( 'woothemes-sensei-version' ), '>' ) ) {
+			return;
+		}
+
+		// Run updates.
+		$this->register_plugin_version();
+	}
 
 	/**
 	 * Run on activation of the plugin.


### PR DESCRIPTION
Brings a similar fix from #2497 over to the 1.x branch.

### Testing
- Change the `woothemes-sensei-version` option in the database to an older version (`1.11.2`). 
- Refresh any page in WordPress admin.
- Verify the option was updated to 1.12.2 (current version in branch).