### PR TITLE
Package readme.txt instead of README.md

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ var paths = {
 		'dummy_data.xml',
 		'includes/**/*',
 		'lang/**/*',
-		'README.md',
+		'readme.txt',
 		'templates/**/*',
 		'uninstall.php',
 		'widgets/**/*',

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, alexsanford1, bor0, donnapep, drawmyface, dwainm, jakeom, jeffikus, lastnode, mattyza, panosktn
 Tags: lms, learning management system, teach, train, tutor
 Requires at least: 4.1
-Tested up to: 5.0.3
+Tested up to: 5.1
 Requires PHP: 5.6
 Stable tag: 2.0.0
 License: GPLv2 or later


### PR DESCRIPTION
The build was packaging the Github version of the ReadMe instead of the WordPress.org version.