### PR TITLE
Added a new capability to solve #2351

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1700,7 +1700,7 @@ class Sensei_Core_Modules {
 			'show_in_nav_menus'  => false,
 			'show_in_quick_edit' => false,
 			'show_ui'            => true,
-			'show_in_menu'       =>false,
+			'show_in_menu'       => false,
 			'rewrite'            => array( 'slug' => $modules_rewrite_slug ),
 			'labels'             => $labels,
 		);

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -888,7 +888,7 @@ class Sensei_Core_Modules {
 	 */
 	public function register_modules_admin_menu_items() {
 		// add the modules link under the Course main menu
-		add_submenu_page( 'edit.php?post_type=course', __( 'Modules', 'sensei' ), __( 'Modules', 'sensei' ), 'manage_modules', 'edit-tags.php?taxonomy=module', '' );
+		add_submenu_page( 'edit.php?post_type=course', __( 'Modules', 'sensei' ), __( 'Modules', 'sensei' ), 'manage_sensei_categories', 'edit-tags.php?taxonomy=module', '' );
 
 		// Register new admin page for module ordering.
 		add_submenu_page( 'edit.php?post_type=course', __( 'Order Modules', 'sensei' ), __( 'Order Modules', 'sensei' ), 'edit_lessons', $this->order_page_slug, array( $this, 'module_order_screen' ) );
@@ -1692,15 +1692,14 @@ class Sensei_Core_Modules {
 			'hierarchical'       => true,
 			'show_admin_column'  => true,
 			'capabilities'       => array(
-				'manage_terms' => 'manage_categories',
+				'manage_terms' => 'manage_sensei_categories',
 				'edit_terms'   => 'edit_courses',
-				'delete_terms' => 'manage_categories',
+				'delete_terms' => 'manage_sensei_categories',
 				'assign_terms' => 'edit_courses',
 			),
 			'show_in_nav_menus'  => false,
 			'show_in_quick_edit' => false,
 			'show_ui'            => true,
-			'show_in_menu'       => false,
 			'rewrite'            => array( 'slug' => $modules_rewrite_slug ),
 			'labels'             => $labels,
 		);

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -888,7 +888,7 @@ class Sensei_Core_Modules {
 	 */
 	public function register_modules_admin_menu_items() {
 		// add the modules link under the Course main menu
-		add_submenu_page( 'edit.php?post_type=course', __( 'Modules', 'sensei' ), __( 'Modules', 'sensei' ), 'manage_categories', 'edit-tags.php?taxonomy=module', '' );
+		add_submenu_page( 'edit.php?post_type=course', __( 'Modules', 'sensei' ), __( 'Modules', 'sensei' ), 'manage_modules', 'edit-tags.php?taxonomy=module', '' );
 
 		// Register new admin page for module ordering.
 		add_submenu_page( 'edit.php?post_type=course', __( 'Order Modules', 'sensei' ), __( 'Order Modules', 'sensei' ), 'edit_lessons', $this->order_page_slug, array( $this, 'module_order_screen' ) );
@@ -1700,6 +1700,7 @@ class Sensei_Core_Modules {
 			'show_in_nav_menus'  => false,
 			'show_in_quick_edit' => false,
 			'show_ui'            => true,
+			'show_in_menu'       =>false,
 			'rewrite'            => array( 'slug' => $modules_rewrite_slug ),
 			'labels'             => $labels,
 		);

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -457,9 +457,9 @@ class Sensei_PostTypes {
 			'query_var'         => true,
 			'show_in_nav_menus' => true,
 			'capabilities'      => array(
-				'manage_terms' => 'manage_categories',
+				'manage_terms' => 'manage_sensei_categories',
 				'edit_terms'   => 'edit_courses',
-				'delete_terms' => 'manage_categories',
+				'delete_terms' => 'manage_sensei_categories',
 				'assign_terms' => 'edit_courses',
 			),
 			'rewrite'           => array( 'slug' => esc_attr( apply_filters( 'sensei_course_category_slug', _x( 'course-category', 'taxonomy archive slug', 'sensei' ) ) ) ),
@@ -616,9 +616,9 @@ class Sensei_PostTypes {
 			'query_var'         => true,
 			'show_in_nav_menus' => true,
 			'capabilities'      => array(
-				'manage_terms' => 'manage_categories',
+				'manage_terms' => 'manage_sensei_categories',
 				'edit_terms'   => 'edit_lessons',
-				'delete_terms' => 'manage_categories',
+				'delete_terms' => 'manage_sensei_categories',
 				'assign_terms' => 'edit_lessons',
 			),
 			'rewrite'           => array( 'slug' => esc_attr( apply_filters( 'sensei_lesson_tag_slug', _x( 'lesson-tag', 'taxonomy archive slug', 'sensei' ) ) ) ),

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -1145,7 +1145,7 @@ class Sensei_Updates {
 		if ( ! is_null( $role ) ) {
 			$role->add_cap( 'manage_sensei' );
 			$role->add_cap( 'manage_sensei_grades' );
-			$role->add_cap( 'manage_modules' );
+			$role->add_cap( 'manage_sensei_categories' );
 		}
 
 		return true;
@@ -1257,7 +1257,7 @@ class Sensei_Updates {
 
 		if ( ! is_null( $role ) ) {
 			$role->add_cap( 'manage_sensei_grades' );
-			$role->add_cap( 'manage_modules' );
+			$role->add_cap( 'manage_sensei_categories' );
 		}
 
 		return true;

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -1145,6 +1145,7 @@ class Sensei_Updates {
 		if ( ! is_null( $role ) ) {
 			$role->add_cap( 'manage_sensei' );
 			$role->add_cap( 'manage_sensei_grades' );
+			$role->add_cap( 'manage_modules' );
 		}
 
 		return true;
@@ -1256,6 +1257,7 @@ class Sensei_Updates {
 
 		if ( ! is_null( $role ) ) {
 			$role->add_cap( 'manage_sensei_grades' );
+			$role->add_cap( 'manage_modules' );
 		}
 
 		return true;


### PR DESCRIPTION
Hello!

Addressing: #2351 

Shop manager could see some Sensei menu items because it has the capability  `manage_categories`.
This means any theme or plugin that creates a role with that capability would be able to view/delete `modules`, `course categories` and `lesson tags`.

I created a new capability called `manage_sensei_categories` and gave it to Administrators and Editors (which are the only default roles to have `manage_categories`). 

Teacher's do not have this capability, nor did they have `manage_categories` so nothing has changed in terms of Sensei/Default roles' capabilities. 

This patch only aims to exclude non-Sensei/Default roles from managing Sensei categories. 