### PR TITLE
Only produce install sensei pages notice on install (#2493)

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -597,7 +597,6 @@ class Sensei_Main {
 			update_option( 'sensei_show_email_signup_form', true );
 		}
 
-		update_option( 'skip_install_sensei_pages', 0 );
 		update_option( 'sensei_installed', 1 );
 
 	} // End activate_sensei()


### PR DESCRIPTION
Hello!

Addressing: #2493 

The reason the Install Sensei Pages notice would appear on every activation is because the `skip_install_sensei_pages` option was set to false on activation.

Removing this line of code should produce the desired results without any unintended consequences. 

> The only time this notice should be displayed is on a site which has never had Sensei installed, or where Sensei was uninstalled with the Delete data on uninstall setting checked.
