### PR TITLE
[WIP] Proof of concept for adding React component

### DIFF
--- a/assets/components/course-lessons/greeting.jsx
+++ b/assets/components/course-lessons/greeting.jsx
@@ -1,0 +1,7 @@
+class Greeting extends React.Component {
+	render() {
+		return <p>Hello, World! These are the Course Lessons.</p>;
+	}
+}
+
+export default Greeting;

--- a/assets/components/course-lessons/index.jsx
+++ b/assets/components/course-lessons/index.jsx
@@ -1,0 +1,4 @@
+import Greeting from './greeting.jsx';
+import './style.scss';
+
+ReactDOM.render( <Greeting />, document.getElementById( 'sensei-component-course-lesson-container' ) );

--- a/assets/components/course-lessons/style.scss
+++ b/assets/components/course-lessons/style.scss
@@ -1,0 +1,5 @@
+#sensei-component-course-lesson-container {
+	p {
+		color: blue;
+	}
+}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -331,6 +331,10 @@ class Sensei_Admin {
 
 		}
 
+		if ( 'course' === $screen->id ) {
+			wp_enqueue_script( 'sensei-component-course-lessons', Sensei()->plugin_url . 'build/components/course-lessons/index.js', array(), Sensei()->version, true );
+		}
+
 		wp_enqueue_script( 'sensei-message-menu-fix', Sensei()->plugin_url . 'assets/js/admin/message-menu-fix.js', array( 'jquery' ), Sensei()->version, true );
 	}
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -452,6 +452,7 @@ class Sensei_Course {
 		} // End If Statement
 
 		$html  = '';
+		$html .= '<div id="sensei-component-course-lesson-container">Component should go here</div>';
 		$html .= '<input type="hidden" name="' . esc_attr( 'woo_' . $this->token . '_noonce' ) . '" id="'
 				 . esc_attr( 'woo_' . $this->token . '_noonce' )
 				 . '" value="' . esc_attr( wp_create_nonce( plugin_basename( __FILE__ ) ) ) . '" />';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,9 +1,9 @@
 const webpack = require( 'webpack' );
 const glob = require( 'glob' );
 const miniCssExtractPlugin = require( 'mini-css-extract-plugin' );
-const entryArray = glob.sync( './assets/blocks/**/index.jsx' );
+const entryArray = glob.sync( './assets/components/**/index.jsx' );
 const entryObject = entryArray.reduce( ( acc, item ) => {
-	let name = item.replace( './assets/blocks/', '' ).replace( '/index.jsx', '' );
+	let name = item.replace( './assets/components/', '' ).replace( '/index.jsx', '' );
 	acc[name] = item;
 
 	return acc;
@@ -11,9 +11,10 @@ const entryObject = entryArray.reduce( ( acc, item ) => {
 
 const webpackConfig = ( env, argv ) => {
 	return {
+		mode: argv.mode ? argv.mode : 'development',
 		entry: entryObject,
 		output: {
-			filename: 'build/blocks/[name]/index.js',
+			filename: 'build/components/[name]/index.js',
 			path: __dirname
 		},
 		module: {
@@ -26,7 +27,7 @@ const webpackConfig = ( env, argv ) => {
 				{
 					test: /style\.s?css$/,
 					include: [
-						/assets\/blocks/
+						/assets\/components/
 					],
 					use: [
 						argv.mode !== 'production' ? 'style-loader' : miniCssExtractPlugin.loader,
@@ -38,7 +39,7 @@ const webpackConfig = ( env, argv ) => {
 		},
 		plugins: [
 			new miniCssExtractPlugin( {
-				filename: 'build/blocks/[name]/style.css'
+				filename: 'build/components/[name]/style.css'
 			} )
 		]
 	};


### PR DESCRIPTION
This is a proof-of-concept for building a JS component and adding it to a metabox. Note that other than the build configuration changes, none of this code should actually be merged into `master`.

### Issues

- It currently only works on the Gutenberg editor. Within the classic editor, it seems that React and ReactDOM are not available. There may be a JS dependency built into WP that we can pull in here, but I couldn't find it.

- If the JS code hasn't been built, this will silently fail. We should check for the build, and show a notice if needed (the Gutenberg plugin does this).

- We will have to have a fallback for WP <5.0 (this may be the same fallback as for the Classic Editor page).

- We should add `gulp` tasks for building, watching, etc. Currently we just use `npx webpack`.