### PR TITLE
[WIP] Add proof-of-concept for event tracking

### DIFF
--- a/includes/class-sensei-event-tracking.php
+++ b/includes/class-sensei-event-tracking.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Usage Tracking subclass for Sensei.
+ **/
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sensei Event Tracking class.
+ **/
+class Sensei_Event_Tracking {
+
+	/**
+	 * Initialize event tracking hooks.
+	 *
+	 * @since 2.1.0
+	 */
+	public static function init() {
+		add_action( 'transition_post_status', [ __CLASS__, 'track_course_published' ], 10, 3 );
+	}
+
+	/**
+	 * Track an event when a course is published.
+	 *
+	 * @access private
+	 * @since 2.1.0
+	 *
+	 * @param string  $new_status New post status.
+	 * @param string  $old_status Old post status.
+	 * @param WP_Post $course     The Post.
+	 */
+	public static function track_course_published( $new_status, $old_status, $course ) {
+		// Only track for courses being published.
+		$publishing = ( $old_status !== $new_status && 'publish' === $new_status );
+		if ( ! $publishing || 'course' !== $course->post_type ) {
+			return;
+		}
+
+		Sensei_Usage_Tracking::get_instance()->send_event(
+			'course_publish',
+			[
+				'course_id'   => $course->ID,
+				'course_name' => $course->post_title,
+			]
+		);
+	}
+
+}

--- a/includes/class-sensei-event-tracking.php
+++ b/includes/class-sensei-event-tracking.php
@@ -1,6 +1,10 @@
 <?php
 /**
  * Usage Tracking subclass for Sensei.
+ *
+ * @package Core
+ * @author Automattic
+ * @since 2.1.0
  **/
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -371,6 +371,9 @@ class Sensei_Main {
 		// data will be sent.
 		$this->usage_tracking->schedule_tracking_task();
 
+		// Initialize Event Tracking
+		Sensei_Event_Tracking::init();
+
 		// Differentiate between administration and frontend logic.
 		if ( is_admin() ) {
 			// Load Admin Class

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -371,7 +371,7 @@ class Sensei_Main {
 		// data will be sent.
 		$this->usage_tracking->schedule_tracking_task();
 
-		// Initialize Event Tracking
+		// Initialize Event Tracking.
 		Sensei_Event_Tracking::init();
 
 		// Differentiate between administration and frontend logic.


### PR DESCRIPTION
I decided to do a small spike on event tracking for Sensei. Turns out our usage tracking functionality already has a nice method for tracking arbitrary events from PHP, while respecting the opt-in usage tracking option. This PR shows a simple way to use that method to track course publishing.

It might be nice to have a wrapper function that can be called from anywhere as well, maybe `sensei_track_event( $event_name, $properties = [] )`. This might be better, in general, than having a dedicated "Event Tracking" class, as per this PR.

I think we could use this for all of our event tracking needs. Eventually we may need JS tracking as well, but for now I think we can do everything from PHP. This way we have full control over the data, and aren't receiving extra stuff that JS would send our way.

cc @donnapep @jom 