### PR TITLE
Add workaround for block editor issue

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1797,7 +1797,7 @@ class Sensei_Admin {
 			return;
 		}
 
-?>
+		?>
 <script type="text/javascript">
 	jQuery( document ).ready( function() {
 		if ( wp.apiFetch ) {
@@ -1813,7 +1813,7 @@ class Sensei_Admin {
 		}
 	} );
 </script>
-<?php
+		<?php
 
 	}
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/2525

This fix is a workaround. The underlying bug is in the block editor code. The full explanation, and the fix, is here: https://github.com/WordPress/gutenberg/pull/15375

Once that fix has been merged into core, this PR may be reverted.

## Testing Instructions

- Follow the instructions in #2525. Ensure the submission works properly.

- Try submissions with other post types, both core types and CPT's. Ensure that submissions still work from the block editor.

- Try submissions with core post types and CPT's (Sensei and non-Sensei) in the classic editor. Ensure that they update as expected.