### PR TITLE
Add tracking for extensions page view

### DIFF
--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -178,7 +178,7 @@ final class Sensei_Extensions {
 		$extensions = $this->get_extensions( $type, $category );
 		// phpcs:enable
 
-		sensei_track_event( 'extensions_view', [
+		sensei_log_event( 'extensions_view', [
 			'view' => $category ? $category : '_all',
 		] );
 

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -177,6 +177,11 @@ final class Sensei_Extensions {
 		$resources  = $this->get_resources();
 		$extensions = $this->get_extensions( $type, $category );
 		// phpcs:enable
+
+		sensei_track_event( 'extensions_view', [
+			'view' => $category ? $category : '_all',
+		] );
+
 		include_once dirname( __FILE__ ) . '/views/html-admin-page-extensions.php';
 	}
 


### PR DESCRIPTION
Closes #2646 

Note that the `view` property values differ slightly from what the issue specified in order to match the category slugs used by the plugin and the API.

## Testing instructions

- View the Extensions page (Sensei LMS > Extensions).
- Ensure the `sensei_extensions_view` event is tracked.
- Ensure the `view` property is `_all`.
- Try clicking on the categories ("Official Extensions", "Third Party")
- Ensure the `view` property matches the category slug.