### PR TITLE
Bump to tested up to WordPress 5.2 for version release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, alexsanford1, bor0, donnapep, drawmyface, dwainm, jakeom, jeffikus, lastnode, mattyza, panosktn
 Tags: lms, learning management system, teach, train, tutor
 Requires at least: 4.1
-Tested up to: 5.1
+Tested up to: 5.2
 Requires PHP: 5.6
 Stable tag: 2.0.1
 License: GPLv2 or later

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -8,7 +8,7 @@
  * Author URI: https://automattic.com
  * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Requires at least: 4.1
- * Tested up to: 5.1
+ * Tested up to: 5.2
  * Requires PHP: 5.6
  * Text Domain: sensei-lms
  * Domain path: /lang/


### PR DESCRIPTION
Bumps the version of WordPress we've tested Sensei with.

This change has been made for `trunk` and `2.0.1` in WordPress.org SVN.