### PR TITLE
Add logging for settings update

### DIFF
--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -793,7 +793,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$added   = array_diff( $new_value, $old_value );
 		$removed = array_diff( $old_value, $new_value );
 
-		return array_merge( $added, $removed );
+		return array_filter( array_merge( $added, $removed ) );
 	}
 } // End Class
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -40,7 +40,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$this->get_settings();
 
 		// Log when settings are updated by the user.
-		add_action( 'update_option_sensei-settings', [ $this, 'log_settings_update' ], 10, 3 );
+		add_action( 'update_option_sensei-settings', [ $this, 'log_settings_update' ], 10, 2 );
 	} // End __construct()
 
 	/**
@@ -740,10 +740,13 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		// Log changed sections.
 		foreach ( $changed as $section => $fields ) {
-			sensei_log_event( 'settings_update', [
-				'view'     => $section,
-				'settings' => implode( ',', $fields ),
-			] );
+			sensei_log_event(
+				'settings_update',
+				[
+					'view'     => $section,
+					'settings' => implode( ',', $fields ),
+				]
+			);
 		}
 	}
 } // End Class

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -792,14 +792,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 		// We have two string arrays. Return the difference in their values.
 		$added   = array_diff( $new_value, $old_value );
 		$removed = array_diff( $old_value, $new_value );
-		$diff    = array_merge( $added, $removed );
 
-		return array_map(
-			function( $value ) use ( $field ) {
-				return $field . '[' . $value . ']';
-			},
-			$diff
-		);
+		return array_merge( $added, $removed );
 	}
 } // End Class
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -739,7 +739,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 				// Get changed setting values to be logged. In most cases, this
 				// will be an array containing only the name of the field.
-				$changed_values = $this->get_changed_setting_values(
+				$changed_values      = $this->get_changed_setting_values(
 					$field,
 					$new_field_value,
 					$old_field_value
@@ -770,8 +770,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 * @since 2.1.0
 	 *
 	 * @param string $field     The name of the setting field.
-	 * @param array  $new_array The new value.
-	 * @param array  $old_array The old value.
+	 * @param array  $new_value The new value.
+	 * @param array  $old_value The old value.
 	 *
 	 * @return array The array of strings representing the field that was
 	 *               changed, or an array containing the field name.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -62,6 +62,10 @@ class Sensei_Unit_Tests_Bootstrap {
 		// factories
 		require_once $this->tests_dir . '/framework/factories/class-sensei-factory.php';
 		require_once $this->tests_dir . '/framework/factories/class-wp-unittest-factory-for-post-sensei.php';
+
+		// Testing setup for event logging.
+		require_once $this->tests_dir . '/framework/class-sensei-test-events.php';
+		Sensei_Test_Events::init();
 	}
 	/**
 	 * Get the single class instance.

--- a/tests/framework/class-sensei-test-events.php
+++ b/tests/framework/class-sensei-test-events.php
@@ -1,0 +1,58 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Test class for event logging.
+ *
+ * @author Automattic
+ *
+ * @since 2.1.0
+ */
+class Sensei_Test_Events {
+	/**
+	 * The internal list of logged events.
+	 */
+	private static $_logged_events = [];
+
+	/**
+	 * Intialize the event logging test class.
+	 */
+	public static function init() {
+		// Set up filter to intercept event logging.
+		add_filter( 'pre_http_request', function( $preempt, $r, $url ) {
+			$host = parse_url( $url, PHP_URL_HOST );
+			$path = parse_url( $url, PHP_URL_PATH );
+			if ( 'pixel.wp.com' === $host && '/t.gif' === $path ) {
+				// Log event.
+				$args = [];
+				parse_str( parse_url( $url, PHP_URL_QUERY ), $args );
+				array_push( Sensei_Test_Events::$_logged_events, [
+					'event_name' => $args['_en'],
+					'url_args'   => $args,
+				] );
+				return new WP_Error();
+			}
+			return $preempt;
+		}, 10, 3 );
+
+		// Ensure event logging is enabled.
+		Sensei()->settings->set( Sensei_Usage_Tracking::SENSEI_SETTING_NAME, true );
+		Sensei()->settings->get_settings();
+	}
+
+	/**
+	 * Get the list of events that have been logged.
+	 */
+	public static function get_logged_events() {
+		return Sensei_Test_Events::$_logged_events;
+	}
+
+	/**
+	 * Clear the list of events that have been logged.
+	 */
+	public static function reset() {
+		Sensei_Test_Events::$_logged_events = [];
+	}
+}

--- a/tests/framework/class-sensei-test-events.php
+++ b/tests/framework/class-sensei-test-events.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * File with class for testing events.
+ *
+ * @package sensei-tests
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -11,8 +17,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 2.1.0
  */
 class Sensei_Test_Events {
+
 	/**
 	 * The internal list of logged events.
+	 *
+	 * @var array
 	 */
 	private static $_logged_events = [];
 
@@ -21,21 +30,29 @@ class Sensei_Test_Events {
 	 */
 	public static function init() {
 		// Set up filter to intercept event logging.
-		add_filter( 'pre_http_request', function( $preempt, $r, $url ) {
-			$host = parse_url( $url, PHP_URL_HOST );
-			$path = parse_url( $url, PHP_URL_PATH );
-			if ( 'pixel.wp.com' === $host && '/t.gif' === $path ) {
-				// Log event.
-				$args = [];
-				parse_str( parse_url( $url, PHP_URL_QUERY ), $args );
-				array_push( Sensei_Test_Events::$_logged_events, [
-					'event_name' => $args['_en'],
-					'url_args'   => $args,
-				] );
-				return new WP_Error();
-			}
-			return $preempt;
-		}, 10, 3 );
+		add_filter(
+			'pre_http_request',
+			function( $preempt, $r, $url ) {
+				$host = wp_parse_url( $url, PHP_URL_HOST );
+				$path = wp_parse_url( $url, PHP_URL_PATH );
+				if ( 'pixel.wp.com' === $host && '/t.gif' === $path ) {
+					// Log event.
+					$args = [];
+					parse_str( wp_parse_url( $url, PHP_URL_QUERY ), $args );
+					array_push(
+						self::$_logged_events,
+						[
+							'event_name' => $args['_en'],
+							'url_args'   => $args,
+						]
+					);
+					return new WP_Error();
+				}
+				return $preempt;
+			},
+			10,
+			3
+		);
 
 		// Ensure event logging is enabled.
 		Sensei()->settings->set( Sensei_Usage_Tracking::SENSEI_SETTING_NAME, true );
@@ -46,13 +63,13 @@ class Sensei_Test_Events {
 	 * Get the list of events that have been logged.
 	 */
 	public static function get_logged_events() {
-		return Sensei_Test_Events::$_logged_events;
+		return self::$_logged_events;
 	}
 
 	/**
 	 * Clear the list of events that have been logged.
 	 */
 	public static function reset() {
-		Sensei_Test_Events::$_logged_events = [];
+		self::$_logged_events = [];
 	}
 }

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -1,0 +1,107 @@
+<?php
+
+class Sensei_Settings_Test extends WP_UnitTestCase {
+	/**
+	 * Set up for tests.
+	 */
+	public function setUp() {
+		Sensei_Test_Events::reset();
+		$this->resetSimulateSettingsRequest();
+
+		parent::setUp();
+	}
+
+	/**
+	 * @covers Sensei_Settings::log_settings_update
+	 */
+	public function testLogChangedSettings() {
+		$settings = Sensei()->settings;
+		$new      = $settings->get_settings();
+
+		// Change some settings in General.
+		$new['sensei_delete_data_on_uninstall']              = ! $new['sensei_delete_data_on_uninstall'];
+		$new['sensei_video_embed_html_sanitization_disable'] = ! $new['sensei_video_embed_html_sanitization_disable'];
+
+		// Change some settings in Courses section.
+		$new['course_archive_featured_enable'] = ! $new['course_archive_featured_enable'];
+		$new['course_archive_more_link_text']  = $new['course_archive_more_link_text'] . '...';
+
+		// Trigger update with new setting values. Ensure that we are simulating an update from the wp-admin UI.
+		$this->simulateSettingsRequest();
+		$old = $settings->get_settings();
+		$settings->log_settings_update( $old, $new );
+
+		// Ensure events were logged.
+		$events = Sensei_Test_Events::get_logged_events();
+		$this->assertCount( 2, $events );
+
+		// Ensure General settings were logged.
+		$this->assertEquals( 'sensei_settings_update', $events[0]['event_name'] );
+		$this->assertEquals( 'default-settings', $events[0]['url_args']['view'] );
+		$changed = explode( ',', $events[0]['url_args']['settings'] );
+		sort( $changed );
+		$this->assertEquals( [ 'sensei_delete_data_on_uninstall', 'sensei_video_embed_html_sanitization_disable' ], $changed );
+
+		// Ensure Course settings were logged.
+		$this->assertEquals( 'sensei_settings_update', $events[1]['event_name'] );
+		$this->assertEquals( 'course-settings', $events[1]['url_args']['view'] );
+		$changed = explode( ',', $events[1]['url_args']['settings'] );
+		sort( $changed );
+		$this->assertEquals( [ 'course_archive_featured_enable', 'course_archive_more_link_text' ], $changed );
+	}
+
+	/**
+	 * @covers Sensei_Settings::log_settings_update
+	 */
+	public function testOnlyLogSettingsOnUserUpdate() {
+		$settings = Sensei()->settings;
+		$new      = $settings->get_settings();
+
+		// Change a setting.
+		$new['sensei_delete_data_on_uninstall'] = ! $new['sensei_delete_data_on_uninstall'];
+
+		// Trigger update with new setting values.
+		$old = $settings->get_settings();
+		$settings->log_settings_update( $old, $new );
+
+		// Ensure no events were logged.
+		$events = Sensei_Test_Events::get_logged_events();
+		$this->assertCount( 0, $events );
+	}
+
+	/**
+	 * Simulate Sensei settings update request.
+	 */
+	private function simulateSettingsRequest() {
+		global $current_screen;
+
+		$this->original_request_method = $_SERVER['REQUEST_METHOD'];
+		$this->original_screen         = $current_screen;
+
+		// Simulate the request.
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		set_current_screen( 'options' );
+	}
+
+	/**
+	 * Reset values from simulating Sensei settings update request.
+	 */
+	private function resetSimulateSettingsRequest() {
+		global $current_screen;
+
+		if ( $this->original_request_method ) {
+			$_SERVER['REQUEST_METHOD'] = $this->original_request_method;
+		} else {
+			$_SERVER['REQUEST_METHOD'] = 'GET';
+		}
+
+		if ( $this->original_screen ) {
+			$current_screen = $this->original_screen;
+		} else {
+			$current_screen = null;
+		}
+
+		$this->original_request_method = null;
+		$this->original_screen = null;
+	}
+}

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -1,5 +1,13 @@
 <?php
+/**
+ * File with class for testing Sensei Settings.
+ *
+ * @package sensei-tests
+ */
 
+/**
+ * Class for testing Sensei Settings.
+ */
 class Sensei_Settings_Test extends WP_UnitTestCase {
 	/**
 	 * Set up for tests.
@@ -12,6 +20,8 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test logging of changed settings.
+	 *
 	 * @covers Sensei_Settings::log_settings_update
 	 */
 	public function testLogChangedSettings() {
@@ -51,6 +61,8 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test logging of settings only on user update.
+	 *
 	 * @covers Sensei_Settings::log_settings_update
 	 */
 	public function testOnlyLogSettingsOnUserUpdate() {
@@ -102,6 +114,6 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 		}
 
 		$this->original_request_method = null;
-		$this->original_screen = null;
+		$this->original_screen         = null;
 	}
 }

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -121,8 +121,8 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 		sort( $changed );
 		$this->assertEquals(
 			[
-				'email_teachers[teacher-completed-course]',
-				'email_teachers[teacher-completed-lesson]',
+				'teacher-completed-course',
+				'teacher-completed-lesson',
 			],
 			$changed
 		);

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -106,7 +106,7 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 		$new = $settings->get_settings();
 
 		// Change the "email_teachers" setting.
-		$new['email_teachers'] = [ 'teacher-started-course', 'teacher-completed-lesson' ];
+		$new['email_teachers'] = [ '', 'teacher-started-course', 'teacher-completed-lesson' ];
 
 		// Trigger update with new setting values.
 		$this->simulateSettingsRequest();

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -20,6 +20,16 @@ class Sensei_Settings_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tear down after tests.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		Sensei_Test_Events::reset();
+		$this->resetSimulateSettingsRequest();
+	}
+
+	/**
 	 * Test logging of changed settings.
 	 *
 	 * @covers Sensei_Settings::log_settings_update


### PR DESCRIPTION
Closes #2645 

See the issue for the event description. Note that the `view` property names have been changed to match the section slugs, and the values in `settings` are comma-separated.

This PR also adds a helper class for testing logged events.

## Testing Instructions

- Change some Sensei settings in a few different sections and save.
- Ensure that one event is logged for each section with changed settings.
- Ensure that the `view` and `settings` properties have the correct values based on the settings that were changed.