### PR TITLE
Log event on analysis page CSV export

### DIFF
--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -597,21 +597,47 @@ class Sensei_Analysis {
 			}
 			$type = isset( $_GET['view'] ) ? esc_html( $_GET['view'] ) : false;
 
+			// Set up default properties for logging an event.
+			$event_properties = [
+				'view'      => '',
+				'course_id' => '',
+				'lesson_id' => '',
+				'user_id'   => '',
+			];
+
 			if ( 0 < $lesson_id ) {
 				// Viewing a specific Lesson and all its Learners
 				$sensei_analysis_report_object = $this->load_report_object( 'Lesson', $lesson_id );
+				$event_properties['view']      = 'lesson_learners';
+				$event_properties['lesson_id'] = $lesson_id;
 			} elseif ( 0 < $course_id && 0 < $user_id ) {
 				// Viewing a specific User on a specific Course
 				$sensei_analysis_report_object = $this->load_report_object( 'Course', $course_id, $user_id );
+				$event_properties['view']      = 'learner_course_lessons';
+				$event_properties['course_id'] = $course_id;
+				$event_properties['user_id']   = $user_id;
 			} elseif ( 0 < $course_id ) {
 				// Viewing a specific Course and all it's Lessons, or it's Learners
 				$sensei_analysis_report_object = $this->load_report_object( 'Course', $course_id );
+				$event_properties['course_id'] = $course_id;
+
+				// Set view property for event logging.
+				if ( isset( $_GET['view'] ) ) {
+					if ( 'lesson' === $_GET['view'] ) {
+						$event_properties['view'] = 'course_lessons';
+					} else if ( 'user' === $_GET['view'] ) {
+						$event_properties['view'] = 'course_learners';
+					}
+				}
 			} elseif ( 0 < $user_id ) {
 				// Viewing a specific Learner, and their Courses
 				$sensei_analysis_report_object = $this->load_report_object( 'User_Profile', $user_id );
+				$event_properties['view']      = 'learner_courses';
+				$event_properties['user_id']   = $user_id;
 			} else {
 				// Overview of all Learners, all Courses, or all Lessons
 				$sensei_analysis_report_object = $this->load_report_object( 'Overview', $type );
+				$event_properties['view']      = isset( $_GET['view'] ) ? $_GET['view'] : '';
 			} // End If Statement
 
 			// Handle the headers
@@ -622,6 +648,9 @@ class Sensei_Analysis {
 
 			// Output the data
 			$this->report_write_download( $report_data_array );
+
+			// Log event.
+			sensei_log_event( 'analysis_export', $event_properties );
 
 			// Cleanly exit
 			exit;

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -598,42 +598,32 @@ class Sensei_Analysis {
 			$type = isset( $_GET['view'] ) ? esc_html( $_GET['view'] ) : false;
 
 			// Set up default properties for logging an event.
-			$event_properties = [
-				'view'      => '',
-				'course_id' => '',
-				'lesson_id' => '',
-				'user_id'   => '',
-			];
+			$event_properties = [ 'view' => '' ];
 
 			if ( 0 < $lesson_id ) {
 				// Viewing a specific Lesson and all its Learners
 				$sensei_analysis_report_object = $this->load_report_object( 'Lesson', $lesson_id );
-				$event_properties['view']      = 'lesson_learners';
-				$event_properties['lesson_id'] = $lesson_id;
+				$event_properties['view']      = 'course-lesson-users';
 			} elseif ( 0 < $course_id && 0 < $user_id ) {
 				// Viewing a specific User on a specific Course
 				$sensei_analysis_report_object = $this->load_report_object( 'Course', $course_id, $user_id );
-				$event_properties['view']      = 'learner_course_lessons';
-				$event_properties['course_id'] = $course_id;
-				$event_properties['user_id']   = $user_id;
+				$event_properties['view']      = 'user-course-lessons';
 			} elseif ( 0 < $course_id ) {
 				// Viewing a specific Course and all it's Lessons, or it's Learners
 				$sensei_analysis_report_object = $this->load_report_object( 'Course', $course_id );
-				$event_properties['course_id'] = $course_id;
 
 				// Set view property for event logging.
 				if ( isset( $_GET['view'] ) ) {
 					if ( 'lesson' === $_GET['view'] ) {
-						$event_properties['view'] = 'course_lessons';
+						$event_properties['view'] = 'course-lessons';
 					} else if ( 'user' === $_GET['view'] ) {
-						$event_properties['view'] = 'course_learners';
+						$event_properties['view'] = 'course-users';
 					}
 				}
 			} elseif ( 0 < $user_id ) {
 				// Viewing a specific Learner, and their Courses
 				$sensei_analysis_report_object = $this->load_report_object( 'User_Profile', $user_id );
-				$event_properties['view']      = 'learner_courses';
-				$event_properties['user_id']   = $user_id;
+				$event_properties['view']      = 'user-courses';
 			} else {
 				// Overview of all Learners, all Courses, or all Lessons
 				$sensei_analysis_report_object = $this->load_report_object( 'Overview', $type );

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -616,7 +616,7 @@ class Sensei_Analysis {
 				if ( isset( $_GET['view'] ) ) {
 					if ( 'lesson' === $_GET['view'] ) {
 						$event_properties['view'] = 'course-lessons';
-					} else if ( 'user' === $_GET['view'] ) {
+					} elseif ( 'user' === $_GET['view'] ) {
 						$event_properties['view'] = 'course-users';
 					}
 				}


### PR DESCRIPTION
Closes #2627 

This PR logs a `sensei_analysis_export` event whenever the "Export CSV" functionality is used. However, I've added a custom `view` property for several of the cases, in an attempt to make the source of the event very explicit. My thought is that this will ultimately help with querying.

## Testing instructions

- Go to Sensei > Analysis.
- Try each case below, and ensure that an event is logged with the correct properties. Properties without a value should be present and empty.

## Properties for each case

There are 8 cases, which are reflected in #2627 as well. Below is a list of the cases, and what properties should be set in the logged event.

- Analysis (Learners)
  - `view`: `users`
- Analysis (Courses):
  - `view`: `courses`
- Analysis (Lessons):
  - `view`: `lessons`
- Analysis > Username:
  - `view`: `learner_courses`
  - `user_id`
- Analysis > Username > Username > Course Name:
  - `view`: `learner_course_lessons`
  - `course_id`
  - `user_id`
- Analysis > Course Name (Lessons):
  - `view`: `course_lessons`
  - `course_id`
- Analysis > Course Name (Learners):
  - `view`: `course_learners`
  - `course_id`
- Analysis > Course Name > Lesson Name:
  - `view`: `lesson_learners`
  - `lesson_id`