### PR TITLE
Add logging for initial publish of a course

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3339,7 +3339,7 @@ class Sensei_Course {
 
 		// If we haven't already published this course, log an event.
 		if ( $publishing && ! $already_published ) {
-			$product_id = get_post_meta( $post->ID, '_course_woocommerce_product', true );
+			$product_id       = get_post_meta( $post->ID, '_course_woocommerce_product', true );
 			$event_properties = [
 				'module_count' => count( wp_get_post_terms( $post->ID, 'module' ) ),
 				'lesson_count' => $this->course_lesson_count( $post->ID ),

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -127,6 +127,9 @@ class Sensei_Course {
 		if ( (int) get_option( 'page_on_front' ) > 0 ) {
 			add_action( 'pre_get_posts', array( $this, 'allow_course_archive_on_front_page' ), 9, 1 );
 		}
+
+		// Log event on the initial publish for a course.
+		add_action( 'transition_post_status', [ $this, 'log_initial_publish_event' ], 10, 3 );
 	}
 
 	/**
@@ -3310,6 +3313,44 @@ class Sensei_Course {
 			$filtered_message = apply_filters( 'sensei_course_complete_prerequisite_message', $complete_prerequisite_message );
 
 			Sensei()->notices->add_notice( $filtered_message, 'info' );
+		}
+	}
+
+	/**
+	 * Log an event when a course is initially published, but not on
+	 * subsequently publishes (i.e. if the course is unpublished and
+	 * re-published, do not log another event).
+	 *
+	 * @since 2.1.0
+	 * @access private
+	 *
+	 * @param string  $new_status The new post status.
+	 * @param string  $old_status The old post status.
+	 * @param WP_Post $post       The course.
+	 */
+	public function log_initial_publish_event( $new_status, $old_status, $post ) {
+		if ( 'course' !== $post->post_type ) {
+			return;
+		}
+
+		$already_published = get_post_meta( $post->ID, 'course_already_published' );
+		$publishing        = 'publish' === $new_status;
+		$unpublishing      = 'publish' === $old_status;
+
+		// If we haven't already published this course, log an event.
+		if ( $publishing && ! $already_published ) {
+			$product_id = get_post_meta( $post->ID, '_course_woocommerce_product', true );
+			$event_properties = [
+				'module_count' => count( wp_get_post_terms( $post->ID, 'module' ) ),
+				'lesson_count' => $this->course_lesson_count( $post->ID ),
+				'product_id'   => $product_id ? $product_id : -1,
+			];
+			sensei_log_event( 'course_publish', $event_properties );
+		}
+
+		// If we are publishing or unpublishing, mark as already published.
+		if ( ( $publishing || $unpublishing ) && ! $already_published ) {
+			add_post_meta( $post->ID, 'course_already_published', true, true );
 		}
 	}
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3329,7 +3329,7 @@ class Sensei_Course {
 		$event_properties = [
 			'module_count' => count( wp_get_post_terms( $course->ID, 'module' ) ),
 			'lesson_count' => $this->course_lesson_count( $course->ID ),
-			'product_id'   => $product_id ? $product_id : -1,
+			'product_id'   => intval( $product_id ) ? intval( $product_id ) : -1,
 		];
 		sensei_log_event( 'course_publish', $event_properties );
 	}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -129,7 +129,7 @@ class Sensei_Course {
 		}
 
 		// Log event on the initial publish for a course.
-		add_action( 'transition_post_status', [ $this, 'log_initial_publish_event' ], 10, 3 );
+		add_action( 'sensei_course_initial_publish', [ $this, 'log_initial_publish_event' ] );
 	}
 
 	/**
@@ -3317,41 +3317,21 @@ class Sensei_Course {
 	}
 
 	/**
-	 * Log an event when a course is initially published, but not on
-	 * subsequently publishes (i.e. if the course is unpublished and
-	 * re-published, do not log another event).
+	 * Log an event when a course is initially published.
 	 *
 	 * @since 2.1.0
 	 * @access private
 	 *
-	 * @param string  $new_status The new post status.
-	 * @param string  $old_status The old post status.
-	 * @param WP_Post $post       The course.
+	 * @param WP_Post $course The Course.
 	 */
-	public function log_initial_publish_event( $new_status, $old_status, $post ) {
-		if ( 'course' !== $post->post_type || $new_status === $old_status ) {
-			return;
-		}
-
-		$already_published = get_post_meta( $post->ID, 'course_already_published' );
-		$publishing        = 'publish' === $new_status;
-		$unpublishing      = 'publish' === $old_status;
-
-		// If we haven't already published this course, log an event.
-		if ( $publishing && ! $already_published ) {
-			$product_id       = get_post_meta( $post->ID, '_course_woocommerce_product', true );
-			$event_properties = [
-				'module_count' => count( wp_get_post_terms( $post->ID, 'module' ) ),
-				'lesson_count' => $this->course_lesson_count( $post->ID ),
-				'product_id'   => $product_id ? $product_id : -1,
-			];
-			sensei_log_event( 'course_publish', $event_properties );
-		}
-
-		// If we are publishing or unpublishing, mark as already published.
-		if ( ( $publishing || $unpublishing ) && ! $already_published ) {
-			add_post_meta( $post->ID, 'course_already_published', true, true );
-		}
+	public function log_initial_publish_event( $course ) {
+		$product_id       = get_post_meta( $course->ID, '_course_woocommerce_product', true );
+		$event_properties = [
+			'module_count' => count( wp_get_post_terms( $course->ID, 'module' ) ),
+			'lesson_count' => $this->course_lesson_count( $course->ID ),
+			'product_id'   => $product_id ? $product_id : -1,
+		];
+		sensei_log_event( 'course_publish', $event_properties );
 	}
 
 }//end class

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3329,7 +3329,7 @@ class Sensei_Course {
 	 * @param WP_Post $post       The course.
 	 */
 	public function log_initial_publish_event( $new_status, $old_status, $post ) {
-		if ( 'course' !== $post->post_type ) {
+		if ( 'course' !== $post->post_type || $new_status === $old_status ) {
 			return;
 		}
 

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -933,12 +933,18 @@ class Sensei_PostTypes {
 		add_action( 'shutdown', [ $this, 'fire_scheduled_initial_publish_actions' ] );
 
 		// Never fire actions on REST API request.
-		add_action(
-			'rest_api_init',
-			function() {
-				remove_action( 'shutdown', [ $this, 'fire_scheduled_initial_publish_actions' ] );
-			}
-		);
+		add_action( 'rest_api_init', [ $this, 'disable_fire_scheduled_initial_publish_actions' ] );
+	}
+
+	/**
+	 * Disable the scheduled "initial publish" actions from being fired. This is
+	 * called on `rest_api_init`.
+	 *
+	 * @since 2.1.0
+	 * @access private
+	 */
+	public function disable_fire_scheduled_initial_publish_actions() {
+		remove_action( 'shutdown', [ $this, 'fire_scheduled_initial_publish_actions' ] );
 	}
 
 	/**

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -922,9 +922,12 @@ class Sensei_PostTypes {
 		add_action( 'wp_insert_post', [ $this, 'fire_initial_publish_action' ], 100, 2 );
 
 		// Never fire action on REST API request.
-		add_action( 'rest_api_init', function() {
-			remove_action( 'wp_insert_post', [ $this, 'fire_initial_publish_action' ], 100, 2 );
-		} );
+		add_action(
+			'rest_api_init',
+			function() {
+				remove_action( 'wp_insert_post', [ $this, 'fire_initial_publish_action' ], 100, 2 );
+			}
+		);
 	}
 
 	/**
@@ -947,6 +950,7 @@ class Sensei_PostTypes {
 		if (
 			! $this->is_sensei_post_type_for_initial_publish_action( $post->post_type )
 			|| 'publish' !== $old_status
+			// phpcs:ignore WordPress.Security.NonceVerification
 			|| ( isset( $_REQUEST['meta-box-loader'] ) && '1' === $_REQUEST['meta-box-loader'] )
 		) {
 			return;
@@ -1008,7 +1012,7 @@ class Sensei_PostTypes {
 				'sensei_message',
 			]
 		);
-		return in_array( $post_type, $post_types );
+		return in_array( $post_type, $post_types, true );
 	}
 
 	/**

--- a/tests/framework/class-sensei-test-events.php
+++ b/tests/framework/class-sensei-test-events.php
@@ -61,9 +61,20 @@ class Sensei_Test_Events {
 
 	/**
 	 * Get the list of events that have been logged.
+	 *
+	 * @param string $event_name Optional event name to filter by.
 	 */
-	public static function get_logged_events() {
-		return self::$_logged_events;
+	public static function get_logged_events( $event_name = null ) {
+		if ( $event_name ) {
+			return array_values( array_filter(
+				Sensei_Test_Events::$_logged_events,
+				function( $element ) use ( $event_name ) {
+					return $event_name === $element['event_name'];
+				}
+			) );
+		} else {
+			return self::$_logged_events;
+		}
 	}
 
 	/**

--- a/tests/framework/class-sensei-test-events.php
+++ b/tests/framework/class-sensei-test-events.php
@@ -66,12 +66,14 @@ class Sensei_Test_Events {
 	 */
 	public static function get_logged_events( $event_name = null ) {
 		if ( $event_name ) {
-			return array_values( array_filter(
-				Sensei_Test_Events::$_logged_events,
-				function( $element ) use ( $event_name ) {
-					return $event_name === $element['event_name'];
-				}
-			) );
+			return array_values(
+				array_filter(
+					self::$_logged_events,
+					function( $element ) use ( $event_name ) {
+						return $event_name === $element['event_name'];
+					}
+				)
+			);
 		} else {
 			return self::$_logged_events;
 		}

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -148,6 +148,8 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test event logging on first publish.
+	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
 	public function testLogEventOnFirstPublish() {
@@ -158,23 +160,29 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test no event logging on second publish.
+	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
 	public function testLogNoEventOnSecondPublish() {
 		$course_id = $this->factory->course->create();
 
 		// Unpublish course.
-		wp_update_post( [
-			'ID'          => $course_id,
-			'post_status' => 'draft',
-		] );
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'draft',
+			]
+		);
 
 		// Reset test logger and republish course.
 		Sensei_Test_Events::reset();
-		wp_update_post( [
-			'ID'          => $course_id,
-			'post_status' => 'publish',
-		] );
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'publish',
+			]
+		);
 
 		// Ensure that the second publish did not log an event.
 		$events = Sensei_Test_Events::get_logged_events();
@@ -182,6 +190,8 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test no event logging on existing course second publish.
+	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
 	public function testLogNoEventOnExistingCourseSecondPublish() {
@@ -191,17 +201,21 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		delete_post_meta( $course_id, 'course_already_published' );
 
 		// Unpublish course.
-		wp_update_post( [
-			'ID'          => $course_id,
-			'post_status' => 'draft',
-		] );
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'draft',
+			]
+		);
 
 		// Reset test logger and republish course.
 		Sensei_Test_Events::reset();
-		wp_update_post( [
-			'ID'          => $course_id,
-			'post_status' => 'publish',
-		] );
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'publish',
+			]
+		);
 
 		// Ensure that the second publish did not log an event.
 		$events = Sensei_Test_Events::get_logged_events();
@@ -209,6 +223,8 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test no event logging on update.
+	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
 	public function testLogNoEventOnExistingCourseUpdate() {
@@ -219,11 +235,13 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 
 		// Reset test logger and update course without changing the status.
 		Sensei_Test_Events::reset();
-		wp_update_post( [
-			'ID'           => $course_id,
-			'post_content' => 'New content',
-			'post_status'  => 'publish',
-		] );
+		wp_update_post(
+			[
+				'ID'           => $course_id,
+				'post_content' => 'New content',
+				'post_status'  => 'publish',
+			]
+		);
 
 		// Ensure that the second publish did not log an event.
 		$events = Sensei_Test_Events::get_logged_events();
@@ -231,21 +249,27 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test event logging module count.
+	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
 	public function testLogEventModuleCount() {
-		$course_id = $this->factory->course->create( [
-			'post_status' => 'draft',
-		] );
+		$course_id = $this->factory->course->create(
+			[
+				'post_status' => 'draft',
+			]
+		);
 
 		// Add some modules.
 		wp_set_object_terms( $course_id, [ 'module-a', 'module-b' ], 'module' );
 
 		// Publish course.
-		wp_update_post( [
-			'ID'          => $course_id,
-			'post_status' => 'publish',
-		] );
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'publish',
+			]
+		);
 
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_course_publish' );
 		$this->assertCount( 1, $events );
@@ -256,12 +280,16 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test event logging lesson count.
+	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
 	public function testLogEventLessonCount() {
-		$course_id = $this->factory->course->create( [
-			'post_status' => 'draft',
-		] );
+		$course_id = $this->factory->course->create(
+			[
+				'post_status' => 'draft',
+			]
+		);
 
 		// Add some lessons to the course.
 		$lesson_ids = $this->factory->lesson->create_many( 2 );
@@ -270,10 +298,12 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		}
 
 		// Publish course.
-		wp_update_post( [
-			'ID'          => $course_id,
-			'post_status' => 'publish',
-		] );
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'publish',
+			]
+		);
 
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_course_publish' );
 		$this->assertCount( 1, $events );
@@ -284,21 +314,27 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test event logging product ID.
+	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
 	public function testLogEventProductId() {
-		$course_id = $this->factory->course->create( [
-			'post_status' => 'draft',
-		] );
+		$course_id = $this->factory->course->create(
+			[
+				'post_status' => 'draft',
+			]
+		);
 
 		// Add product ID.
 		add_post_meta( $course_id, '_course_woocommerce_product', 5 );
 
 		// Publish without product ID.
-		wp_update_post( [
-			'ID'          => $course_id,
-			'post_status' => 'publish',
-		] );
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'publish',
+			]
+		);
 
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_course_publish' );
 		$this->assertCount( 1, $events );
@@ -309,18 +345,24 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test event logging without product ID.
+	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
 	public function testLogNoEventProductId() {
-		$course_id = $this->factory->course->create( [
-			'post_status' => 'draft',
-		] );
+		$course_id = $this->factory->course->create(
+			[
+				'post_status' => 'draft',
+			]
+		);
 
 		// Publish without product ID.
-		wp_update_post( [
-			'ID'          => $course_id,
-			'post_status' => 'publish',
-		] );
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'publish',
+			]
+		);
 
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_course_publish' );
 		$this->assertCount( 1, $events );

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -184,6 +184,33 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	/**
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
+	public function testLogNoEventOnExistingCourseSecondPublish() {
+		$course_id = $this->factory->course->create();
+
+		// Remove the meta to simulate an existing course.
+		delete_post_meta( $course_id, 'course_already_published' );
+
+		// Unpublish course.
+		wp_update_post( [
+			'ID'          => $course_id,
+			'post_status' => 'draft',
+		] );
+
+		// Reset test logger and republish course.
+		Sensei_Test_Events::reset();
+		wp_update_post( [
+			'ID'          => $course_id,
+			'post_status' => 'publish',
+		] );
+
+		// Ensure that the second publish did not log an event.
+		$events = Sensei_Test_Events::get_logged_events();
+		$this->assertCount( 0, $events );
+	}
+
+	/**
+	 * @covers Sensei_Course::log_initial_publish_event
+	 */
 	public function testLogEventModuleCount() {
 		$course_id = $this->factory->course->create( [
 			'post_status' => 'draft',

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -148,112 +148,11 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test event logging on first publish.
+	 * Test initial publish logging module count.
 	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
-	public function testLogEventOnFirstPublish() {
-		$this->factory->course->create();
-
-		$events = Sensei_Test_Events::get_logged_events( 'sensei_course_publish' );
-		$this->assertCount( 1, $events );
-	}
-
-	/**
-	 * Test no event logging on second publish.
-	 *
-	 * @covers Sensei_Course::log_initial_publish_event
-	 */
-	public function testLogNoEventOnSecondPublish() {
-		$course_id = $this->factory->course->create();
-
-		// Unpublish course.
-		wp_update_post(
-			[
-				'ID'          => $course_id,
-				'post_status' => 'draft',
-			]
-		);
-
-		// Reset test logger and republish course.
-		Sensei_Test_Events::reset();
-		wp_update_post(
-			[
-				'ID'          => $course_id,
-				'post_status' => 'publish',
-			]
-		);
-
-		// Ensure that the second publish did not log an event.
-		$events = Sensei_Test_Events::get_logged_events();
-		$this->assertCount( 0, $events );
-	}
-
-	/**
-	 * Test no event logging on existing course second publish.
-	 *
-	 * @covers Sensei_Course::log_initial_publish_event
-	 */
-	public function testLogNoEventOnExistingCourseSecondPublish() {
-		$course_id = $this->factory->course->create();
-
-		// Remove the meta to simulate an existing course.
-		delete_post_meta( $course_id, 'course_already_published' );
-
-		// Unpublish course.
-		wp_update_post(
-			[
-				'ID'          => $course_id,
-				'post_status' => 'draft',
-			]
-		);
-
-		// Reset test logger and republish course.
-		Sensei_Test_Events::reset();
-		wp_update_post(
-			[
-				'ID'          => $course_id,
-				'post_status' => 'publish',
-			]
-		);
-
-		// Ensure that the second publish did not log an event.
-		$events = Sensei_Test_Events::get_logged_events();
-		$this->assertCount( 0, $events );
-	}
-
-	/**
-	 * Test no event logging on update.
-	 *
-	 * @covers Sensei_Course::log_initial_publish_event
-	 */
-	public function testLogNoEventOnExistingCourseUpdate() {
-		$course_id = $this->factory->course->create();
-
-		// Remove the meta to simulate an existing published course.
-		delete_post_meta( $course_id, 'course_already_published' );
-
-		// Reset test logger and update course without changing the status.
-		Sensei_Test_Events::reset();
-		wp_update_post(
-			[
-				'ID'           => $course_id,
-				'post_content' => 'New content',
-				'post_status'  => 'publish',
-			]
-		);
-
-		// Ensure that the second publish did not log an event.
-		$events = Sensei_Test_Events::get_logged_events();
-		$this->assertCount( 0, $events );
-	}
-
-	/**
-	 * Test event logging module count.
-	 *
-	 * @covers Sensei_Course::log_initial_publish_event
-	 */
-	public function testLogEventModuleCount() {
+	public function testLogInitialPublishModuleCount() {
 		$course_id = $this->factory->course->create(
 			[
 				'post_status' => 'draft',
@@ -280,11 +179,11 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test event logging lesson count.
+	 * Test initial publish logging lesson count.
 	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
-	public function testLogEventLessonCount() {
+	public function testLogInitialPublishLessonCount() {
 		$course_id = $this->factory->course->create(
 			[
 				'post_status' => 'draft',
@@ -314,11 +213,11 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test event logging product ID.
+	 * Test initial publish logging product ID.
 	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
-	public function testLogEventProductId() {
+	public function testLogInitialPublishProductId() {
 		$course_id = $this->factory->course->create(
 			[
 				'post_status' => 'draft',
@@ -345,7 +244,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test event logging without product ID.
+	 * Test initial publish logging without product ID.
 	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -170,6 +170,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 			]
 		);
 
+		Sensei()->post_types->fire_scheduled_initial_publish_actions();
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_course_publish' );
 		$this->assertCount( 1, $events );
 
@@ -203,6 +204,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 			]
 		);
 
+		Sensei()->post_types->fire_scheduled_initial_publish_actions();
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_course_publish' );
 		$this->assertCount( 1, $events );
 
@@ -237,6 +239,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 			]
 		);
 
+		Sensei()->post_types->fire_scheduled_initial_publish_actions();
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_course_publish' );
 		$this->assertCount( 1, $events );
 
@@ -268,6 +271,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 			]
 		);
 
+		Sensei()->post_types->fire_scheduled_initial_publish_actions();
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_course_publish' );
 		$this->assertCount( 1, $events );
 
@@ -296,6 +300,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 			]
 		);
 
+		Sensei()->post_types->fire_scheduled_initial_publish_actions();
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_course_publish' );
 		$this->assertCount( 1, $events );
 

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -211,6 +211,28 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	/**
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
+	public function testLogNoEventOnExistingCourseUpdate() {
+		$course_id = $this->factory->course->create();
+
+		// Remove the meta to simulate an existing published course.
+		delete_post_meta( $course_id, 'course_already_published' );
+
+		// Reset test logger and update course without changing the status.
+		Sensei_Test_Events::reset();
+		wp_update_post( [
+			'ID'           => $course_id,
+			'post_content' => 'New content',
+			'post_status'  => 'publish',
+		] );
+
+		// Ensure that the second publish did not log an event.
+		$events = Sensei_Test_Events::get_logged_events();
+		$this->assertCount( 0, $events );
+	}
+
+	/**
+	 * @covers Sensei_Course::log_initial_publish_event
+	 */
 	public function testLogEventModuleCount() {
 		$course_id = $this->factory->course->create( [
 			'post_status' => 'draft',

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -148,6 +148,39 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test initial publish logging default property values.
+	 *
+	 * @covers Sensei_Course::log_initial_publish_event
+	 */
+	public function testLogInitialPublishDefaultPropertyValues() {
+		$course_id = $this->factory->course->create(
+			[
+				'post_status' => 'draft',
+			]
+		);
+
+		// Set product meta to "-", which simulates actual behaviour.
+		add_post_meta( $course_id, '_course_woocommerce_product', '-', true );
+
+		// Publish course.
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_course_publish' );
+		$this->assertCount( 1, $events );
+
+		// Ensure default values are correct.
+		$event = $events[0];
+		$this->assertEquals( 0, $event['url_args']['module_count'] );
+		$this->assertEquals( 0, $event['url_args']['lesson_count'] );
+		$this->assertEquals( -1, $event['url_args']['product_id'] );
+	}
+
+	/**
 	 * Test initial publish logging module count.
 	 *
 	 * @covers Sensei_Course::log_initial_publish_event

--- a/tests/unit-tests/test-class-posttypes.php
+++ b/tests/unit-tests/test-class-posttypes.php
@@ -50,6 +50,36 @@ class Sensei_Class_PostTypes extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure intitial publish action is fired after other hooks.
+	 *
+	 * @covers Sensei_PostType::setup_initial_publish_action
+	 */
+	public function testFireActionAfterHooks() {
+		add_action(
+			'save_post',
+			function( $post_id ) {
+				if ( 'course' === get_post_type( $post_id ) ) {
+					add_post_meta( $post_id, 'test_meta', 'test_value', true );
+				}
+			}
+		);
+
+		// Ensure that meta exists on `sensei_course_initial_publish`.
+		$test_suite = $this;
+		add_action(
+			'sensei_course_initial_publish',
+			function( $post ) use ( $test_suite ) {
+				$meta_value = get_post_meta( $post->ID, 'test_meta', true );
+				$test_suite->assertEquals( 'test_value', $meta_value );
+			}
+		);
+
+		// Ensure the action was called.
+		$course_id = $this->factory->course->create();
+		$this->assertEquals( 1, did_action( 'sensei_course_initial_publish' ) );
+	}
+
+	/**
 	 * Test action fires for no non-Sensei post types.
 	 *
 	 * @covers Sensei_PostType::setup_initial_publish_action

--- a/tests/unit-tests/test-class-posttypes.php
+++ b/tests/unit-tests/test-class-posttypes.php
@@ -110,7 +110,17 @@ class Sensei_Class_PostTypes extends WP_UnitTestCase {
 	 * @covers Sensei_PostType::setup_initial_publish_action
 	 */
 	public function testFireNoActionOnRestApiRequest() {
-		do_action( 'rest_api_init' );
+		$this->assertNotFalse(
+			has_action(
+				'rest_api_init',
+				[ Sensei()->post_types, 'disable_fire_scheduled_initial_publish_actions' ]
+			)
+		);
+
+		// Simulate `rest_api_init`.
+		Sensei()->post_types->disable_fire_scheduled_initial_publish_actions();
+
+		// Ensure the firing action was removed.
 		$this->assertFalse(
 			has_action(
 				'shutdown',

--- a/tests/unit-tests/test-class-posttypes.php
+++ b/tests/unit-tests/test-class-posttypes.php
@@ -1,5 +1,13 @@
 <?php
+/**
+ * File containing tests for Sensei_PostTypes class.
+ *
+ * @package sensei-tests
+ */
 
+/**
+ * Class for testing Sensei_PostTypes.
+ */
 class Sensei_Class_PostTypes extends WP_UnitTestCase {
 	/**
 	 * Setup function.

--- a/tests/unit-tests/test-class-posttypes.php
+++ b/tests/unit-tests/test-class-posttypes.php
@@ -1,0 +1,147 @@
+<?php
+
+class Sensei_Class_PostTypes extends WP_UnitTestCase {
+	/**
+	 * Setup function.
+	 */
+	public function setup() {
+		parent::setup();
+		$this->factory = new Sensei_Factory();
+	}
+
+	/**
+	 * Tear down function.
+	 */
+	public function tearDown() {
+		$this->factory->tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test action firing on first publish.
+	 *
+	 * @covers Sensei_PostType::setup_initial_publish_action
+	 */
+	public function testFireActionOnFirstPublish() {
+		$this->factory->course->create();
+		$this->assertEquals( 1, did_action( 'sensei_course_initial_publish' ) );
+	}
+
+	/**
+	 * Test action fires for all Sensei post types.
+	 *
+	 * @covers Sensei_PostType::setup_initial_publish_action
+	 */
+	public function testFireActionForSenseiPostTypes() {
+		$this->factory->course->create();
+		$this->assertEquals( 1, did_action( 'sensei_course_initial_publish' ) );
+
+		$this->factory->lesson->create();
+		$this->assertEquals( 1, did_action( 'sensei_lesson_initial_publish' ) );
+
+		$quiz = $this->factory->quiz->create();
+		$this->assertEquals( 1, did_action( 'sensei_quiz_initial_publish' ) );
+
+		$this->factory->question->create( [ 'quiz_id' => $quiz ] );
+		$this->assertEquals( 1, did_action( 'sensei_question_initial_publish' ) );
+
+		$this->factory->message->create();
+		$this->assertEquals( 1, did_action( 'sensei_sensei_message_initial_publish' ) );
+	}
+
+	/**
+	 * Test action fires for no non-Sensei post types.
+	 *
+	 * @covers Sensei_PostType::setup_initial_publish_action
+	 */
+	public function testFireNoActionForNonSenseiPostType() {
+		$this->factory->post->create();
+		$this->assertEquals( 0, did_action( 'sensei_post_initial_publish' ) );
+	}
+
+	/**
+	 * Test no action firing on second publish.
+	 *
+	 * @covers Sensei_PostType::setup_initial_publish_action
+	 */
+	public function testFireNoActionOnSecondPublish() {
+		$course_id = $this->factory->course->create();
+		$this->assertEquals( 1, did_action( 'sensei_course_initial_publish' ) );
+
+		// Unpublish course.
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'draft',
+			]
+		);
+
+		// Republish course.
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		// Ensure that the second publish did not fire a second action.
+		$this->assertEquals( 1, did_action( 'sensei_course_initial_publish' ) );
+	}
+
+	/**
+	 * Test no action firing on existing post second publish.
+	 *
+	 * @covers Sensei_PostType::setup_initial_publish_action
+	 */
+	public function testFireNoActionOnExistingPostSecondPublish() {
+		$course_id = $this->factory->course->create();
+		$this->assertEquals( 1, did_action( 'sensei_course_initial_publish' ) );
+
+		// Remove the meta to simulate an existing course.
+		delete_post_meta( $course_id, '_sensei_already_published' );
+
+		// Unpublish course.
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'draft',
+			]
+		);
+
+		// Republish course.
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		// Ensure that the second publish did not fire a second action.
+		$this->assertEquals( 1, did_action( 'sensei_course_initial_publish' ) );
+	}
+
+	/**
+	 * Test no action firing on update.
+	 *
+	 * @covers Sensei_PostType::setup_initial_publish_action
+	 */
+	public function testFireNoActionOnExistingCourseUpdate() {
+		$course_id = $this->factory->course->create();
+		$this->assertEquals( 1, did_action( 'sensei_course_initial_publish' ) );
+
+		// Remove the meta to simulate an existing published course.
+		delete_post_meta( $course_id, '_sensei_already_published' );
+
+		// Update course without changing the status.
+		wp_update_post(
+			[
+				'ID'           => $course_id,
+				'post_content' => 'New content',
+				'post_status'  => 'publish',
+			]
+		);
+
+		// Ensure that the second publish did not fire an action.
+		$this->assertEquals( 1, did_action( 'sensei_course_initial_publish' ) );
+	}
+}


### PR DESCRIPTION
Closes #2650 

Adds logging for when a course is initially published but does not log if the course is unpublished and published again later.

## Implementation note

There is a check here for meta that is added by WCPC. I don't really like it being in this codebase since it seems like it should be in WCPC itself. However, since it is just meta, there isn't any strong technical reason why this plugin couldn't simply check for it. This keeps it much simpler but introduces a funny dependency.

Open to thoughts on this.

## Testing instructions

_Note: please test this in both the classic editor **and** the block editor._

- Create a course and save it as a draft.
- Add modules to the course.
- Add lessons to the course.
- Publish the course. Ensure that the logged event has the correct attributes (including `-1` for the `product_id`).
- Unpublish the course and publish it again. Ensure that another event is not logged.
- Follow steps 1-3 and then install WCPC and link a product to the course.
- Publish the course, and ensure the `product_id` attribute on the event is correct.
- Create another draft course, but do not include any modules or lessons.
- Publish the course and ensure that the `module_count` and `lesson_count` attributes are `0`.
- Create a course and add modules, lessons, and a product without saving as a draft (set all of these things while on the initial "Add Course" screen). On publishing, ensure that the event is logged, and the properties are set correctly.

### Additional test for existing installations

- On a site with courses that have already been published, switch to this branch.
- Unpublish and publish an existing course.
- Ensure that no event is logged.