### PR TITLE
Log importing of dummy data

### DIFF
--- a/includes/3rd-party/wordpress-importer.php
+++ b/includes/3rd-party/wordpress-importer.php
@@ -7,8 +7,6 @@
 
 /**
  * Track when dummy data is imported but don't track any events that could fire during import.
- *
- * @return bool
  */
 function sensei_wordpress_importer_usage_tracking_dummy_data() {
 	// Log the import event if we're importing the dummy data.

--- a/includes/3rd-party/wordpress-importer.php
+++ b/includes/3rd-party/wordpress-importer.php
@@ -32,6 +32,16 @@ function sensei_wordpress_importer_add_modules_to_imported_lessons() {
 			$order++;
 		}
 	}
+
+	// Log the import event if we're importing the dummy data.
+	$global_importer = isset( $GLOBALS['wp_import'] ) ? $GLOBALS['wp_import'] : false;
+	if (
+		$global_importer
+		&& 'WP_Import' === get_class( $global_importer )
+		&& 'http://demo.sensei.com/' === $global_importer->base_url
+	) {
+		sensei_log_event( 'data_import', [ 'dummy_data' => 1 ] );
+	}
 }
 
 add_action( 'import_end', 'sensei_wordpress_importer_add_modules_to_imported_lessons' );

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -304,5 +304,18 @@ function sensei_log_event( $event_name, $properties = [] ) {
 		$properties
 	);
 
+	/**
+	 * Explicitly disable usage tracking from being sent.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @param bool   $log_event    Whether we should log the event.
+	 * @param string $event_name   The name of the event, without the `sensei_` prefix.
+	 * @param array  $properties   The event properties to be sent.
+	 */
+	if ( false === apply_filters( 'sensei_log_event', true, $event_name, $properties ) ) {
+		return;
+	}
+
 	Sensei_Usage_Tracking::get_instance()->send_event( $event_name, $properties );
 }


### PR DESCRIPTION
Fixes #2671 

This adds a new event `sensei_data_import` (always has property `'dummy_data'=1`) when users import Sensei's dummy data. It also prevents imported dummy data from firing additional events. In order to do this, it introduces a new filter: `sensei_log_event` in `sensei_log_event()`. 

### Testing Instructions
1. Using the WordPress Importer, go through the process to import the `dummy_data.xml` from this repository. Make sure it is in an instance where you haven't already imported dummy data.
1. Verify the `sensei_data_import` event is triggered with the property `'dummy_data'=1`. Verify no `sensei_module_add` events are fired.
1. Using the WordPress Importer, go through the process to import a completely different (not based on) WXR file. 
1. Verify no `sensei_data_import` event is triggered. If the import file contained modules that weren't already in your database, verify `sensei_module_add` was fired.