### PR TITLE
Add tracking for link to "Add Lesson" from course

### DIFF
--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -1,0 +1,15 @@
+jQuery( document ).ready( function( $ ) {
+	// Log when the "Add Lesson" link is clicked.
+	$( 'a.add-course-lesson' ).click( function() {
+		var properties = {
+			course_status: $( this ).data( 'course-status' ),
+		};
+
+		// Get course status from post state if it's available.
+		if ( wp.data && wp.data.select( 'core/editor' ) ) {
+			properties.course_status = wp.data.select( 'core/editor' ).getCurrentPostAttribute( 'status' );
+		}
+
+		sensei_log_event( 'course_add_lesson_click', properties );
+	} );
+} );

--- a/assets/js/admin/course-edit.min.js
+++ b/assets/js/admin/course-edit.min.js
@@ -1,0 +1,1 @@
+"use strict";jQuery(document).ready(function(e){e("a.add-course-lesson").click(function(){var t={course_status:e(this).data("course-status")};wp.data&&wp.data.select("core/editor")&&(t.course_status=wp.data.select("core/editor").getCurrentPostAttribute("status")),sensei_log_event("course_add_lesson_click",t)})});

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -54,6 +54,9 @@ class Sensei_Course {
 			// Custom Write Panel Columns
 			add_filter( 'manage_edit-course_columns', array( $this, 'add_column_headings' ), 10, 1 );
 			add_action( 'manage_posts_custom_column', array( $this, 'add_column_data' ), 10, 2 );
+
+			// Enqueue scripts.
+			add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_scripts' ) );
 		} else {
 			$this->my_courses_page = false;
 		} // End If Statement
@@ -126,6 +129,23 @@ class Sensei_Course {
 		// Allow course archive to be setup as the home page
 		if ( (int) get_option( 'page_on_front' ) > 0 ) {
 			add_action( 'pre_get_posts', array( $this, 'allow_course_archive_on_front_page' ), 9, 1 );
+		}
+	}
+
+	/**
+	 * Register and enqueue scripts that are needed in the backend.
+	 *
+	 * @access private
+	 * @since 2.1.0
+	 */
+	public function register_admin_scripts() {
+		$screen = get_current_screen();
+
+		// Allow developers to load non-minified versions of scripts
+		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+
+		if ( 'course' == $screen->id ) {
+			wp_enqueue_script( 'sensei-admin-course-edit', Sensei()->plugin_url . 'assets/js/admin/course-edit' . $suffix . '.js', array( 'jquery' ), Sensei()->version, true );
 		}
 	}
 
@@ -485,7 +505,8 @@ class Sensei_Course {
 		} else {
 			$html .= '<hr />';
 		}
-		$html .= '<a href="' . esc_url( $add_lesson_admin_url )
+		$html .= '<a class="add-course-lesson" href="' . esc_url( $add_lesson_admin_url )
+			. '" data-course-status="' . esc_attr( $post->post_status )
 			. '" title="' . esc_attr__( 'Add a Lesson', 'sensei-lms' ) . '">';
 		if ( count( $posts_array ) < 1 ) {
 			$html .= esc_html__( 'Please add some.', 'sensei-lms' );

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -141,10 +141,10 @@ class Sensei_Course {
 	public function register_admin_scripts() {
 		$screen = get_current_screen();
 
-		// Allow developers to load non-minified versions of scripts
+		// Allow developers to load non-minified versions of scripts.
 		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
-		if ( 'course' == $screen->id ) {
+		if ( 'course' === $screen->id ) {
 			wp_enqueue_script( 'sensei-admin-course-edit', Sensei()->plugin_url . 'assets/js/admin/course-edit' . $suffix . '.js', array( 'jquery' ), Sensei()->version, true );
 		}
 	}


### PR DESCRIPTION
Closes #2660 

Tracks clicking the link to add a lesson from the course page. This link is in the "Course Lessons" metabox, and has different text based on whether the course already has lessons or not.

## Implementation notes

The current implementation does the tracking from JS. There are two implications to be considered:

- The block editor requires special treatment. This is because, although we specify the course status in a `data` attribute, that status may have changed since the page was rendered. We handle this by checking for `wp.data` and loading the current post status from there if we can.
- This is triggered using the `click` event which does not pick up on all cases. For example, if a user middle-clicks to open in a new tab, or right clicks and chooses "Open Link in New Tab", this event is not logged.

An alternative implementation would be to log this from PHP when the "Add Lesson" page is visited. We could add a URL parameter to indicate that the visit is coming from this specific link. The trade-off would be that if a user refreshes the page, the event may fire again. Also I'm not sure we want to add URL parameters for the sole purpose of tracking data? Maybe it's fine though? In any case, this option would solve the problems above.

## Testing Instructions

- Open the Edit page for a course, and click the "Add Lesson" link in the Course Lessons metabox. The event should be logged.
- Try this in both the Classic and Block editors.
- Try changing the course's status and clicking the link again. Ensure that the `course_status` attribute is logged correctly.
- Try adding a new course, and clicking this link before the course is published. An event should still be logged.