### PR TITLE
Add source parameter to event logging

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1839,9 +1839,12 @@ class Sensei_Admin {
 		$properties = isset( $_REQUEST['properties'] ) ? $_REQUEST['properties'] : [];
 
 		// Set the source to js-event.
-		add_filter( 'sensei_event_logging_source', function() {
-			return 'js-event';
-		} );
+		add_filter(
+			'sensei_event_logging_source',
+			function() {
+				return 'js-event';
+			}
+		);
 
 		sensei_log_event( $event_name, $properties );
 		// phpcs:enable WordPress.Security.NonceVerification

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1838,6 +1838,11 @@ class Sensei_Admin {
 		$event_name = $_REQUEST['event_name'];
 		$properties = isset( $_REQUEST['properties'] ) ? $_REQUEST['properties'] : [];
 
+		// Set the source to js-event.
+		add_filter( 'sensei_event_logging_source', function() {
+			return 'js-event';
+		} );
+
 		sensei_log_event( $event_name, $properties );
 		// phpcs:enable WordPress.Security.NonceVerification
 	}

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -73,6 +73,13 @@ class Sensei_Usage_Tracking_Data {
 		];
 
 		/**
+		 * Filter the event logging source.
+		 *
+		 * @param string The source (defaults to "unknown").
+		 */
+		$base_fields['source'] = apply_filters( 'sensei_event_logging_source', 'unknown' );
+
+		/**
 		 * Filter the fields that should be sent with every event that is logged.
 		 *
 		 * @param array $base_fields The default base fields.

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -176,9 +176,12 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	 * @access private
 	 */
 	public function set_event_logging_source_frontend() {
-		add_filter( 'sensei_event_logging_source', function( $fields ) {
-			return 'frontend';
-		} );
+		add_filter(
+			'sensei_event_logging_source',
+			function( $fields ) {
+				return 'frontend';
+			}
+		);
 	}
 
 	/**
@@ -189,8 +192,11 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	 * @access private
 	 */
 	public function set_event_logging_source_data_import() {
-		add_filter( 'sensei_event_logging_source', function( $fields ) {
-			return 'data-import';
-		} );
+		add_filter(
+			'sensei_event_logging_source',
+			function( $fields ) {
+				return 'data-import';
+			}
+		);
 	}
 }

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -23,8 +23,27 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 
 		// Add filter for settings.
 		add_filter( 'sensei_settings_fields', array( $this, 'add_setting_field' ) );
+
+		// Init event logging source filters.
+		add_action( 'init', [ $this, 'init_event_logging_sources' ] );
 	}
 
+	/*
+	 * Initalization.
+	 */
+
+	/**
+	 * Initialize filters for event logging sources.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @access private
+	 */
+	public function init_event_logging_sources() {
+		add_filter( 'sensei_event_logging_source', [ $this, 'detect_event_logging_source' ], 1 );
+		add_filter( 'template_redirect', [ $this, 'set_event_logging_source_frontend' ] );
+		add_filter( 'import_start', [ $this, 'set_event_logging_source_data_import' ] );
+	}
 
 	/*
 	 * Implementation for abstract functions.
@@ -124,5 +143,54 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 		);
 
 		return $fields;
+	}
+
+	/**
+	 * Attempt to detect the source of the event logging request.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @access private
+	 *
+	 * @param  string $source The initial source.
+	 * @return string         The detected source.
+	 */
+	public static function detect_event_logging_source( $source ) {
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return 'rest-api';
+		}
+
+		if ( is_admin() ) {
+			return 'wp-admin';
+		}
+
+		return $source;
+	}
+
+
+	/**
+	 * Set the event logging source to `frontend`.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @access private
+	 */
+	public function set_event_logging_source_frontend() {
+		add_filter( 'sensei_event_logging_source', function( $fields ) {
+			return 'frontend';
+		} );
+	}
+
+	/**
+	 * Set the event logging source to `data-import`.
+	 *
+	 * @since 2.1.0
+	 *
+	 * @access private
+	 */
+	public function set_event_logging_source_data_import() {
+		add_filter( 'sensei_event_logging_source', function( $fields ) {
+			return 'data-import';
+		} );
 	}
 }


### PR DESCRIPTION
As per our Slack conversation, this PR aims to provide a `source` parameter to all logged events that we can later use for querying.

Currently, these sources are logged:

- `wp-admin` (includes all AJAX requests)
- `rest-api` (note that events fired through direct interaction with the block editor may have this source)
- `frontend`
- `data-import`
- `js-event` (for JS calls to `sensei_log_event`)

## Testing instructions

### wp-admin

Create a module from WP Admin. Use both the Module page, and the Course page metabox. Ensure the `source` for the events is `wp-admin`.

### rest-api

Add the following code snippet:

```php
add_action( 'rest_api_init', function() {
	sensei_log_event( 'rest_api_request' );
} );
```

Perform a REST API request (e.g. `http://my.site.com/wp-json/wp/v2/courses`). Ensure the source for the `sensei_rest_api_request` event is `rest-api`.

### frontend

Add a call to `sensei_log_event` to a template and then load that template (e.g. add `sensei_log_event( 'rendering_course' );` to `single-course.php` and then view a course). Ensure the source is `frontend`.

### data-import

Import data with modules (here is a data file you can use [#](https://cld.wthms.co/72ijyr)). Ensure the `sensei_module_add` event is tracked twice (once for each module) and that the source is `data-import`.

### js-event

View the Sensei settings page. Ensure that the event logged has source `js-event`.