### PR TITLE
Log an event when a course is created from the Edit Lesson page

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2314,7 +2314,14 @@ class Sensei_Lesson {
 					$value_to_log = $val;
 				}
 			}
-			$event_properties[ $field . '_id' ] = $value_to_log;
+
+			// Get property name.
+			$property_name = $field . '_id';
+			if ( 'course_woocommerce_product' === $field ) {
+				$property_name = 'product_id';
+			}
+
+			$event_properties[ $property_name ] = $value_to_log;
 		}
 		sensei_log_event( 'lesson_course_add', $event_properties );
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2303,6 +2303,21 @@ class Sensei_Lesson {
 		$current_user                 = wp_get_current_user();
 		$question_data['post_author'] = $current_user->ID;
 		$updated                      = $this->lesson_save_course( $course_data );
+
+		// Compute properties and log an event.
+		$event_properties = [];
+		foreach ( [ 'course_prerequisite', 'course_category', 'course_woocommerce_product' ] as $field ) {
+			$value_to_log = -1;
+			if ( isset( $course_data[ $field ] ) ) {
+				$val = intval( $course_data[ $field ] );
+				if ( $val ) {
+					$value_to_log = $val;
+				}
+			}
+			$event_properties[ $field . '_id' ] = $value_to_log;
+		}
+		sensei_log_event( 'lesson_course_add', $event_properties );
+
 		echo esc_html( $updated );
 		die(); // WordPress may print out a spurious zero without this can be particularly bad if using JSON
 	} // End lesson_add_course()


### PR DESCRIPTION
Closes #2662

Logs an event when a course is created from the "Course" metabox on an "Edit Lesson" page.

## Testing instructions

- Edit an existing lesson, or create a new one.
- In the "Course" metabox on the side, create a course without setting anything except the title.
- Ensure that the event is logged as per #2662, with `-1` for all of the relevant fields.
- Try setting some fields when creating the course, and ensure they are set properly on the event.
- Install WCPC and test setting the WooCommerce Product field as well.