### PR TITLE
Log initial publish event for questions

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -38,6 +38,8 @@ class Sensei_Question {
 
 			add_action( 'save_post_question', array( $this, 'save_question' ), 10, 1 );
 		} // End If Statement
+
+		add_action( 'sensei_question_initial_publish', [ $this, 'log_initial_publish_event' ] );
 	} // End __construct()
 
 	public function question_types() {
@@ -1244,6 +1246,33 @@ class Sensei_Question {
 		return apply_filters( 'sensei_questions_get_correct_answer', $right_answer, $question_id );
 
 	} // get_correct_answer
+
+	/**
+	 * Log an event when a question is initially published.
+	 *
+	 * @since 2.1.0
+	 * @access private
+	 *
+	 * @param WP_Post $question The question object.
+	 */
+	public function log_initial_publish_event( $question ) {
+		$event_properties = [
+			'page'          => 'unknown',
+			'question_type' => $this->get_question_type( $question->ID ),
+		];
+
+		if ( function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+
+			if ( $screen && 'question' === $screen->id ) {
+				$event_properties['page'] = 'question';
+			} elseif ( isset( $_REQUEST['action'] ) && 'lesson_update_question' === $_REQUEST['action'] ) {
+				$event_properties['page'] = 'lesson';
+			}
+		}
+
+		sensei_log_event( 'question_add', $event_properties );
+	}
 
 } // End Class
 

--- a/tests/unit-tests/test-class-question.php
+++ b/tests/unit-tests/test-class-question.php
@@ -20,6 +20,7 @@ class Sensei_Class_Question_Test extends WP_UnitTestCase {
 		parent::setup();
 
 		$this->factory = new Sensei_Factory();
+		Sensei_Test_Events::reset();
 	}//end setup()
 
 	public function tearDown() {
@@ -78,4 +79,36 @@ class Sensei_Class_Question_Test extends WP_UnitTestCase {
 		);
 
 	}//end testGetQuestionType()
+
+	/**
+	 * Test initial publish logging default property values.
+	 *
+	 * @covers Sensei_Question::log_initial_publish_event
+	 */
+	public function testLogInitialPublishDefaultPropertyValues() {
+		$quiz_id     = $this->factory->quiz->create();
+		$question_id = $this->factory->question->create(
+			[
+				'post_status' => 'draft',
+				'quiz_id'     => $quiz_id,
+			]
+		);
+
+		// Publish question.
+		wp_update_post(
+			[
+				'ID'          => $question_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		Sensei()->post_types->fire_scheduled_initial_publish_actions();
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_question_add' );
+		$this->assertCount( 1, $events );
+
+		// Ensure default values are correct.
+		$event = $events[0];
+		$this->assertEquals( 'unknown', $event['url_args']['page'] );
+		$this->assertEquals( Sensei()->question->get_question_type( $question_id ), $event['url_args']['question_type'] );
+	}
 }


### PR DESCRIPTION
Fixes #2668

Adds logging for when a question is initially published from either the lesson edit screen or from the add question screen.

### Testing Instructions
- Create various types of questions in WP Admin from Questions > Add New. 
- Verify `sensei_question_add` event is fired with the `question_type` property set to the type of question selected and `page` set to `question`.

- In both classic editor and block editor, create various types of questions in WP Admin while editing a published lesson.
- Verify `sensei_question_add` event is fired with the `question_type` property set to the type of question selected and `page` set to `lesson`.
