### PR TITLE
Update lesson preview checkbox text

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -350,7 +350,7 @@ class Sensei_Lesson {
 		} // End If Statement
 
 		$html .= '<label for="lesson_preview">';
-		$html .= '<input type="checkbox" id="lesson_preview" name="lesson_preview" value="preview" ' . $checked . '>&nbsp;' . esc_html__( 'Allow this lesson to be viewed without purchase/login', 'sensei-lms' ) . '<br>';
+		$html .= '<input type="checkbox" id="lesson_preview" name="lesson_preview" value="preview" ' . $checked . '>&nbsp;' . esc_html__( 'Allow this lesson to be viewed without login', 'sensei-lms' ) . '<br>';
 
 		echo wp_kses(
 			$html,


### PR DESCRIPTION
Fixes #2496.

## Testing
Navigation to a lesson in WP Admin and ensure the text in the Preview metabox looks like the following:
![Screen Shot 2019-06-05 at 11 50 36 AM](https://user-images.githubusercontent.com/1190420/58970860-4128b680-8788-11e9-8139-ec1a8be801f7.jpg)
