### PR TITLE
Fire event on click of Edit Course button

### DIFF
--- a/assets/js/admin/event_logging.js
+++ b/assets/js/admin/event_logging.js
@@ -12,3 +12,10 @@ window.sensei_log_event = function( event_name, properties ) {
 		jQuery.get( ajaxurl, data );
 	}
 }
+
+jQuery( document ).ready( function( $ ) {
+	$( 'body' ).on( 'click', 'a[data-sensei-log-event]', function( event ) {
+		let sensei_event_name = $( event.target ).data( 'sensei-log-event' );
+		sensei_log_event( sensei_event_name );
+	} );
+} );

--- a/assets/js/admin/event_logging.min.js
+++ b/assets/js/admin/event_logging.min.js
@@ -1,1 +1,1 @@
-"use strict";window.sensei_log_event=function(e,n){if(sensei_event_logging.enabled){var i={action:"sensei_log_event",event_name:e};n&&(i.properties=n),jQuery.get(ajaxurl,i)}};
+"use strict";window.sensei_log_event=function(e,n){if(sensei_event_logging.enabled){var t={action:"sensei_log_event",event_name:e};n&&(t.properties=n),jQuery.get(ajaxurl,t)}},jQuery(document).ready(function(t){t("body").on("click","a[data-sensei-log-event]",function(e){var n=t(e.target).data("sensei-log-event");sensei_log_event(n)})});

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -157,7 +157,7 @@ class Sensei_Lesson {
 			jQuery(function () {
 				jQuery("body.post-type-lesson .wrap a.page-title-action")
 					.last()
-					.after('<a href="<?php echo esc_attr( $url ); ?>" class="page-title-action"><?php echo esc_html__( 'Edit Course', 'sensei-lms' ); ?></a>');
+					.after('<a href="<?php echo esc_attr( $url ); ?>" class="page-title-action" data-sensei-log-event="lesson_edit_course_click"><?php echo esc_html__( 'Edit Course', 'sensei-lms' ); ?></a>');
 			});
 		</script>
 		<?php


### PR DESCRIPTION
Closes #2663 

Note that the Edit Course button (added in https://github.com/Automattic/sensei/pull/2514) seems to only appear in the classic editor. If it is added to the block editor, then as long as it has the same `data-` attribute in that case, this code should still work.

## Testing Instructions

- Install Classic Editor.
- Edit a lesson that belongs to a course.
- Click the "Edit Course" button.
- The event `sensei_lesson_edit_course_click` should be logged with no properties.