### PR TITLE
No longer flush rewrite rules on course and lesson save

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -123,9 +123,6 @@ class Sensei_Course {
 		// ensure the course category page respects the manual order set for courses
 		add_filter( 'pre_get_posts', array( __CLASS__, 'alter_course_category_order' ), 10, 1 );
 
-		// flush rewrite rules when saving a course
-		add_action( 'save_post', array( 'Sensei_Course', 'flush_rewrite_rules' ) );
-
 		// Allow course archive to be setup as the home page
 		if ( (int) get_option( 'page_on_front' ) > 0 ) {
 			add_action( 'pre_get_posts', array( $this, 'allow_course_archive_on_front_page' ), 9, 1 );
@@ -2859,29 +2856,6 @@ class Sensei_Course {
 		$wp_query = new WP_Query( $course_lesson_query_args );
 
 	}//end load_single_course_lessons_query()
-
-	/**
-	 * Flush the rewrite rules for a course post type
-	 *
-	 * @since 1.9.0
-	 *
-	 * @param $post_id
-	 */
-	public static function flush_rewrite_rules( $post_id ) {
-
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-
-			return;
-
-		}
-
-		if ( 'course' == get_post_type( $post_id ) ) {
-
-			Sensei()->initiate_rewrite_rules_flush();
-
-		}
-
-	}
 
 	/**
 	 * Optionally return the full content on the single course pages

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2858,6 +2858,18 @@ class Sensei_Course {
 	}//end load_single_course_lessons_query()
 
 	/**
+	 * Flush the rewrite rules.
+	 *
+	 * @since 1.9.0
+	 * @deprecated 2.2.1
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function flush_rewrite_rules( $post_id ) {
+		_deprecated_function( __METHOD__, '2.2.1' );
+	}
+
+	/**
 	 * Optionally return the full content on the single course pages
 	 * depending on the users course_single_content_display setting
 	 *

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4302,6 +4302,18 @@ class Sensei_Lesson {
 	}//end the_title()
 
 	/**
+	 * Flush the rewrite rules.
+	 *
+	 * @since 1.9.0
+	 * @deprecated 2.2.1
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public static function flush_rewrite_rules( $post_id ) {
+		_deprecated_function( __METHOD__, '2.2.1' );
+	}
+
+	/**
 	 * Output the quiz specific buttons and messaging on the single lesson page
 	 *
 	 * @since 1.0.0 moved here from frontend class

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -102,9 +102,6 @@ class Sensei_Lesson {
 			// save bulk edit fields
 			add_action( 'wp_ajax_save_bulk_edit_book', array( $this, 'save_all_lessons_edit_fields' ) );
 
-			// flush rewrite rules when saving a lesson
-			add_action( 'save_post', array( __CLASS__, 'flush_rewrite_rules' ) );
-
 			add_action( 'admin_head', array( $this, 'add_custom_link_to_course' ) );
 
 		} else {
@@ -4303,29 +4300,6 @@ class Sensei_Lesson {
 		<?php
 
 	}//end the_title()
-
-	/**
-	 * Flush the rewrite rules for a lesson post type
-	 *
-	 * @since 1.9.0
-	 *
-	 * @param $post_id
-	 */
-	public static function flush_rewrite_rules( $post_id ) {
-
-		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
-
-			return;
-
-		}
-
-		if ( 'lesson' == get_post_type( $post_id ) ) {
-
-			Sensei()->initiate_rewrite_rules_flush();
-
-		}
-
-	}
 
 	/**
 	 * Output the quiz specific buttons and messaging on the single lesson page

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -688,7 +688,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 	/**
 	 * Flush the rewrite rules after the settings have been updated.
-	 * This is to ensure that the
+	 * This is to ensure that the proper permalinks are set up for archive pages.
 	 *
 	 * @since 1.9.0
 	 */

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -435,7 +435,7 @@ class Sensei_Main {
 		add_action( 'plugins_loaded', array( $this, 'wp_quicklatex_support' ), 200 ); // Runs after Plugins have loaded
 
 		// check flush the rewrite rules if the option sensei_flush_rewrite_rules option is 1
-		add_action( 'init', array( $this, 'flush_rewrite_rules' ), 101 );
+		add_action( 'admin_init', array( $this, 'flush_rewrite_rules' ), 101 );
 		add_action( 'admin_init', array( $this, 'update' ) );
 
 		// Add plugin action links filter

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -582,6 +582,9 @@ class Sensei_Main {
 
 		// Run updates.
 		$this->register_plugin_version();
+
+		// Flush rewrite cache.
+		$this->initiate_rewrite_rules_flush();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2142 

### Changes Proposed in PR
- Instead of checking for a pending rewrite flush on `init`, 26cac4969c660aa16a344afc698c7447d8da0c3a changes it to `admin_init` only. It is an expensive operation to do (when triggered) and everything that triggers Sensei's rewrite rule flush happens from the admin.
- Removes triggering Sensei's rewrite rule flush on lesson (7366d2ba59674c4aed46ba03c8a8646f83391456) and course save (9980bef8db7893e305934086f5257b75e712d18f). This was unnecessary as none of the rules care are for specific courses and lessons.
- Triggers Sensei's rewrite rule flush on update. This seems like a safe time to initiate this process in case anything changed on plugin update.

### Testing Instructions
- Under WP Admin > Settings > Permalinks, set to an option other than `Plain`. 
- On a brand new instance, install and activate Sensei. 
- Create a course and lessons for that course.
- View the course. Make sure the permalink works for the course.
- Complete the course.
- When viewing the course, append `/results` on the end. For example:
`http://sensei.docker/course/jakes-great-course/results/`
- Make sure that goes to an expected page. 