### PR TITLE
Set a default parent_id property when logging module creation

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -468,7 +468,7 @@ class Sensei_Core_Modules {
 		$module           = get_term( $module_id );
 		$event_properties = [
 			// phpcs:ignore WordPress.Security.NonceVerification
-			'page' => isset( $_REQUEST['from_page'] ) ? $_REQUEST['from_page'] : '',
+			'page'      => isset( $_REQUEST['from_page'] ) ? $_REQUEST['from_page'] : '',
 			'parent_id' => -1,
 		];
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -469,6 +469,7 @@ class Sensei_Core_Modules {
 		$event_properties = [
 			// phpcs:ignore WordPress.Security.NonceVerification
 			'page' => isset( $_REQUEST['from_page'] ) ? $_REQUEST['from_page'] : '',
+			'parent_id' => -1,
 		];
 
 		if ( $module->parent ) {


### PR DESCRIPTION
Small tweak to module logging to set `parent_id` to -1 if there is no parent, in order to be consistent with how other events with missing parameters are logged.

## Testing
- Go to the Courses > Modules page.
- Create two modules - one with a parent and one without.
- Ensure a `sensei_module_add` event was logged and that `parent_id` is set appropriately.
- Add a new module from the course page.
- Ensure a `sensei_module_add` event was logged and that `parent_id` is `-1`.