### PR TITLE
Bump minimum supported WordPress version to 4.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ jobs:
         - ./tests/bin/run-wp-unit-tests.sh
     - stage: test
       php: 5.6
-      env: WP_VERSION=4.4
+      env: WP_VERSION=4.9
       script:
         - ./tests/bin/run-wp-unit-tests.sh
     - stage: test

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Sensei LMS ===
 Contributors: automattic, alexsanford1, bor0, donnapep, drawmyface, dwainm, jakeom, jeffikus, lastnode, mattyza, panosktn
 Tags: elearning, lms, learning management system, teach, tutor
-Requires at least: 4.1
+Requires at least: 4.9
 Tested up to: 5.2
 Requires PHP: 5.6
 Stable tag: 2.1.0

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -7,7 +7,7 @@
  * Author: Automattic
  * Author URI: https://automattic.com
  * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- * Requires at least: 4.1
+ * Requires at least: 4.9
  * Tested up to: 5.2
  * Requires PHP: 5.6
  * Text Domain: sensei-lms

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -481,14 +481,21 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		Sensei()->quiz->set_user_grades( $user_quiz_grades, $test_lesson_id, $test_user_id );
 
 		// was the lesson data reset?
-		$lesson_data_reset = Sensei()->quiz->reset_user_lesson_data( $test_lesson_id, $test_user_id );
+		ob_start();
+		$lesson_data_reset        = Sensei()->quiz->reset_user_lesson_data( $test_lesson_id, $test_user_id );
+		$lesson_data_reset_notice = ob_get_clean();
+
 		$this->assertTrue( $lesson_data_reset, 'The lesson data was not reset for a valid use case' );
+		$valid_notices = [
+			'<div class="sensei-message info">Quiz Reset Successfully.</div>',
+			'', // No notice is immediately displayed if notices haven't been printed elsewhere in another test.
+		];
+		$this->assertContains( $lesson_data_reset_notice, $valid_notices, 'Invalid notice displayed after quiz reset' );
 
 		// make sure transients are remove as well
 		$transient_key  = 'sensei_answers_' . $test_user_id . '_' . $test_lesson_id;
 		$transient_data = get_transient( $transient_key );
 		$this->assertFalse( $transient_data, 'The transient was not reset along with the users saved data. The result should be false.' );
-
 	}//end testResetUserLessonData()
 
 	/**


### PR DESCRIPTION
This fixes issues we have when running CI with events logging bypassing our suppression and firing in WordPress 4.4. I also imagine we weren't actually fully supporting 4.1 to begin with. 

In addition to the version bump, I'm also fixing a test issue that has always bugged me. I'm suppressing the output of the quiz reset notice. When running the entire test suite, notices would have fired before resetting quiz data. This caused the quiz notice to show immediately. I'm checking for either a valid notice or none at all just so we don't suppress/not catch another error or output during this process.