### PR TITLE
Don't call non-static method statically

### DIFF
--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -178,7 +178,7 @@ function sensei_simple_course_price( $post_id ) {
 		return;
 	}
 
-	\Sensei_WC_Paid_Courses\Frontend\Courses::output_course_price( $post_id );
+	\Sensei_WC_Paid_Courses\Frontend\Courses::instance()->output_course_price( $post_id );
 } // End sensei_simple_course_price()
 
 	/**


### PR DESCRIPTION
## Steps to Reproduce
1. Add `add_action( 'sensei_course_meta_inside_after', 'sensei_simple_course_price' );` to your theme's `functions.php` file.
2. Browse to the _My Courses_ page on the front-end.
3. The following shows up in the logs:
```
PHP Deprecated:  Non-static method Sensei_WC_Paid_Courses\Frontend\Courses::output_course_price() should not be called statically in /app/public/wp-content/plugins/woothemes-sensei/plugins/sensei-lms/includes/template-functions.php on line 181
```

## Testing
After following the above steps, the deprecated notice should no longer appear in the logs.