### PR TITLE
Remove unused variables from codebase

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -101,8 +101,6 @@ class Sensei_Learner_Management {
 	 * @access public
 	 */
 	public function learners_admin_menu() {
-		global $menu;
-
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
 			$learners_page = add_submenu_page( 'sensei', $this->name, $this->name, 'manage_sensei_grades', $this->page_slug, array( $this, 'learners_page' ) );
 			add_action( "load-$learners_page", array( $this, 'load_screen_options_when_on_bulk_actions' ) );

--- a/includes/class-sensei-admin-rest-api-testharness.php
+++ b/includes/class-sensei-admin-rest-api-testharness.php
@@ -57,12 +57,8 @@ class Sensei_Admin_Rest_Api_Testharness {
 	}
 
 	function testharness_admin_menu() {
-		global $menu, $woocommerce;
-
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
-
 			add_submenu_page( 'sensei', $this->name, $this->name, 'manage_sensei_grades', $this->page_slug, array( $this, 'render_page' ) );
-
 		}
 	}
 

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -155,7 +155,7 @@ class Sensei_Admin {
 	 * @return void
 	 */
 	public function admin_menu_highlight() {
-		global $menu, $submenu, $parent_file, $submenu_file, $self, $post_type, $taxonomy;
+		global $parent_file, $submenu_file, $post_type, $taxonomy;
 
 		$screen = get_current_screen();
 

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -203,19 +203,19 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		$user_end_date   = $item->comment_date;
 
 		if ( 'complete' == $item->comment_approved ) {
-			$status       = __( 'Completed', 'sensei-lms' );
-			$grade = __( 'No Grade', 'sensei-lms' );
+			$status = __( 'Completed', 'sensei-lms' );
+			$grade  = __( 'No Grade', 'sensei-lms' );
 		} elseif ( 'graded' == $item->comment_approved ) {
-			$status       = __( 'Graded', 'sensei-lms' );
-			$grade = get_comment_meta( $item->comment_ID, 'grade', true );
+			$status = __( 'Graded', 'sensei-lms' );
+			$grade  = get_comment_meta( $item->comment_ID, 'grade', true );
 		} elseif ( 'passed' == $item->comment_approved ) {
-			$status       = __( 'Passed', 'sensei-lms' );
-			$grade = get_comment_meta( $item->comment_ID, 'grade', true );
+			$status = __( 'Passed', 'sensei-lms' );
+			$grade  = get_comment_meta( $item->comment_ID, 'grade', true );
 		} elseif ( 'failed' == $item->comment_approved ) {
-			$status       = __( 'Failed', 'sensei-lms' );
-			$grade = get_comment_meta( $item->comment_ID, 'grade', true );
+			$status = __( 'Failed', 'sensei-lms' );
+			$grade  = get_comment_meta( $item->comment_ID, 'grade', true );
 		} elseif ( 'ungraded' == $item->comment_approved ) {
-			$status       = __( 'Ungraded', 'sensei-lms' );
+			$status = __( 'Ungraded', 'sensei-lms' );
 		} else {
 			$status        = __( 'In Progress', 'sensei-lms' );
 			$user_end_date = '';

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -201,32 +201,21 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 	protected function get_row_data( $item ) {
 		$user_start_date = get_comment_meta( $item->comment_ID, 'start', true );
 		$user_end_date   = $item->comment_date;
-		$status_class    = $grade = '';
 
 		if ( 'complete' == $item->comment_approved ) {
 			$status       = __( 'Completed', 'sensei-lms' );
-			$status_class = 'graded';
-
 			$grade = __( 'No Grade', 'sensei-lms' );
 		} elseif ( 'graded' == $item->comment_approved ) {
 			$status       = __( 'Graded', 'sensei-lms' );
-			$status_class = 'graded';
-
 			$grade = get_comment_meta( $item->comment_ID, 'grade', true );
 		} elseif ( 'passed' == $item->comment_approved ) {
 			$status       = __( 'Passed', 'sensei-lms' );
-			$status_class = 'graded';
-
 			$grade = get_comment_meta( $item->comment_ID, 'grade', true );
 		} elseif ( 'failed' == $item->comment_approved ) {
 			$status       = __( 'Failed', 'sensei-lms' );
-			$status_class = 'failed';
-
 			$grade = get_comment_meta( $item->comment_ID, 'grade', true );
 		} elseif ( 'ungraded' == $item->comment_approved ) {
 			$status       = __( 'Ungraded', 'sensei-lms' );
-			$status_class = 'ungraded';
-
 		} else {
 			$status        = __( 'In Progress', 'sensei-lms' );
 			$user_end_date = '';

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -603,13 +603,14 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	public function stats_boxes() {
 
 		// Get the data required
-		$user_count    = count_users();
-		$user_count    = apply_filters( 'sensei_analysis_total_users', $user_count['total_users'], $user_count );
-		$total_courses = Sensei()->course->course_count( array( 'publish', 'private' ) );
-		$total_lessons = Sensei()->lesson->lesson_count( array( 'publish', 'private' ) );
+		$user_count          = count_users();
+		$user_count          = apply_filters( 'sensei_analysis_total_users', $user_count['total_users'], $user_count );
+		$total_courses       = Sensei()->course->course_count( array( 'publish', 'private' ) );
+		$total_lessons       = Sensei()->lesson->lesson_count( array( 'publish', 'private' ) );
 		$total_grade_count   = Sensei_Grading::get_graded_lessons_count();
 		$total_grade_total   = Sensei_Grading::get_graded_lessons_sum();
 		$total_average_grade = 0;
+
 		if ( $total_grade_total > 0 && $total_grade_count > 0 ) {
 			$total_average_grade = Sensei_Utils::quotient_as_absolute_rounded_number( $total_grade_total, $total_grade_count, 2 );
 		}

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -607,20 +607,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$user_count    = apply_filters( 'sensei_analysis_total_users', $user_count['total_users'], $user_count );
 		$total_courses = Sensei()->course->course_count( array( 'publish', 'private' ) );
 		$total_lessons = Sensei()->lesson->lesson_count( array( 'publish', 'private' ) );
-
-		/**
-		 * filter the analysis tot grades query args
-		 */
-		$grade_args = apply_filters(
-			'sensei_analysis_total_quiz_grades',
-			array(
-				'type'     => 'sensei_lesson_status',
-				'status'   => 'any',
-
-				'meta_key' => 'grade',
-			)
-		);
-
 		$total_grade_count   = Sensei_Grading::get_graded_lessons_count();
 		$total_grade_total   = Sensei_Grading::get_graded_lessons_sum();
 		$total_average_grade = 0;

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -52,12 +52,8 @@ class Sensei_Analysis {
 	 * @return void
 	 */
 	public function analysis_admin_menu() {
-		global $menu, $woocommerce;
-
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
-
 			add_submenu_page( 'sensei', __( 'Analysis', 'sensei-lms' ), __( 'Analysis', 'sensei-lms' ), 'manage_sensei_grades', 'sensei_analysis', array( $this, 'analysis_page' ) );
-
 		}
 
 	} // End analysis_admin_menu()

--- a/includes/class-sensei-course-results.php
+++ b/includes/class-sensei-course-results.php
@@ -103,21 +103,6 @@ class Sensei_Course_Results {
 	}
 
 	/**
-	 * Load content for course results
-	 *
-	 * @since  1.4.0
-	 * @return void
-	 */
-	public function content() {
-		global $wp_query,  $current_user;
-
-		if ( isset( $wp_query->query_vars['course_results'] ) ) {
-			Sensei_Templates::get_template( 'course-results/course-info.php' );
-		}
-
-	}
-
-	/**
 	 * Load course results info
 	 *
 	 * @since  1.4.0

--- a/includes/class-sensei-course-results.php
+++ b/includes/class-sensei-course-results.php
@@ -103,6 +103,22 @@ class Sensei_Course_Results {
 	}
 
 	/**
+	 * Load content for course results
+	 *
+	 * @since  1.4.0
+	 * @return void
+	 */
+	public function content() {
+		global $wp_query;
+
+		_deprecated_function( __METHOD__, '2.2.0' );
+
+		if ( isset( $wp_query->query_vars['course_results'] ) ) {
+			Sensei_Templates::get_template( 'course-results/course-info.php' );
+		}
+	}
+
+	/**
 	 * Load course results info
 	 *
 	 * @since  1.4.0

--- a/includes/class-sensei-course-results.php
+++ b/includes/class-sensei-course-results.php
@@ -127,10 +127,7 @@ class Sensei_Course_Results {
 	 * @return void
 	 */
 	public function course_lessons() {
-
-		global $course;
 		_deprecated_function( 'Sensei_modules course_lessons ', '1.9.0' );
-
 	}
 
 	/**
@@ -198,10 +195,7 @@ class Sensei_Course_Results {
 	 * @since 1.8.0
 	 */
 	public static function fire_course_image_hook() {
-
-		global $course;
 		sensei_do_deprecated_action( 'sensei_course_image', '1.9.0', 'sensei_single_course_content_inside_before', array( get_the_ID() ) );
-
 	}
 
 } // End Class

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -600,8 +600,6 @@ class Sensei_Course {
 	 * @return void
 	 */
 	public function add_column_data( $column_name, $id ) {
-		global $wpdb, $post;
-
 		switch ( $column_name ) {
 			case 'id':
 				echo esc_html( $id );

--- a/includes/class-sensei-emails.php
+++ b/includes/class-sensei-emails.php
@@ -159,8 +159,6 @@ class Sensei_Emails {
 	 * @return void
 	 */
 	function send( $to, $subject, $message, $headers = "Content-Type: text/html\r\n", $attachments = '', $content_type = 'text/html' ) {
-		global $email_template;
-
 		// Set content type
 		$this->_content_type = $content_type;
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -372,11 +372,8 @@ class Sensei_Frontend {
 		global $pagenow, $wp_rewrite;
 
 		if ( 'nav-menus.php' != $pagenow && ! defined( 'DOING_AJAX' ) && isset( $item->url ) && 'custom' == $item->type ) {
-
 			// Set up Sensei menu links.
-			$course_page_id     = intval( Sensei()->settings->settings['course_page'] );
 			$my_account_page_id = intval( Sensei()->settings->settings['my_course_page'] );
-
 			$course_page_url    = Sensei_Course::get_courses_page_url();
 			$lesson_archive_url = get_post_type_archive_link( 'lesson' );
 			$my_courses_url     = get_permalink( $my_account_page_id );
@@ -818,7 +815,7 @@ class Sensei_Frontend {
 
 		switch ( $sanitized_submit ) {
 			case 'lesson-complete':
-				Sensei_Utils::sensei_start_lesson( $lesson_id, $current_user->ID, $complete = true );
+				Sensei_Utils::sensei_start_lesson( $lesson_id, $current_user->ID, true );
 				$this->maybe_redirect_to_next_lesson( $lesson_id );
 
 				break;
@@ -877,7 +874,8 @@ class Sensei_Frontend {
 	 * Marks a course as complete.
 	 */
 	public function sensei_complete_course() {
-		global $post,  $current_user, $wp_query;
+		global $current_user;
+
 		if ( isset( $_POST['course_complete'] ) && wp_verify_nonce( $_POST['woothemes_sensei_complete_course_noonce'], 'woothemes_sensei_complete_course_noonce' ) ) {
 
 			$sanitized_submit    = esc_html( $_POST['course_complete'] );
@@ -899,7 +897,7 @@ class Sensei_Frontend {
 						// Mark all quiz user meta lessons as complete.
 						foreach ( $course_lesson_ids as $lesson_item_id ) {
 							// Mark lesson as complete.
-							$activity_logged = Sensei_Utils::sensei_start_lesson( $lesson_item_id, $current_user->ID, $complete = true );
+							$activity_logged = Sensei_Utils::sensei_start_lesson( $lesson_item_id, $current_user->ID, true );
 						} // End For Loop
 
 						// Update with final stats.
@@ -1031,11 +1029,11 @@ class Sensei_Frontend {
 	public function sensei_complete_lesson_button() {
 		global  $post;
 
-		$quiz_id   = 0;
 		$lesson_id = $post->ID;
 
 		// make sure user is taking course.
 		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
+
 		if ( ! Sensei_Utils::user_started_course( $course_id, get_current_user_id() ) ) {
 			return;
 		}
@@ -1107,12 +1105,8 @@ class Sensei_Frontend {
 	} // End sensei_lesson_quiz_meta()
 
 	public function sensei_course_archive_meta() {
-		global  $post;
 		// Meta data.
 		$post_id             = get_the_ID();
-		$post_title          = get_the_title();
-		$author_display_name = get_the_author();
-		$author_id           = get_the_author_meta( 'ID' );
 		$category_output     = get_the_term_list( $post_id, 'course-category', '', ', ', '' );
 		$free_lesson_count   = intval( Sensei()->course->course_lesson_preview_count( $post_id ) );
 		?>
@@ -1313,7 +1307,6 @@ class Sensei_Frontend {
 	} // End sensei_login_form()
 
 	public function sensei_lesson_meta( $post_id = 0 ) {
-		global $post;
 		if ( 0 < intval( $post_id ) ) {
 			$lesson_course_id = absint( get_post_meta( $post_id, '_lesson_course', true ) );
 			?>

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1106,9 +1106,9 @@ class Sensei_Frontend {
 
 	public function sensei_course_archive_meta() {
 		// Meta data.
-		$post_id             = get_the_ID();
-		$category_output     = get_the_term_list( $post_id, 'course-category', '', ', ', '' );
-		$free_lesson_count   = intval( Sensei()->course->course_lesson_preview_count( $post_id ) );
+		$post_id           = get_the_ID();
+		$category_output   = get_the_term_list( $post_id, 'course-category', '', ', ', '' );
+		$free_lesson_count = intval( Sensei()->course->course_lesson_preview_count( $post_id ) );
 		?>
 		<section class="entry">
 			<p class="sensei-course-meta">

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -60,8 +60,6 @@ class Sensei_Grading {
 	 * @return void
 	 */
 	public function grading_admin_menu() {
-		global $menu;
-
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
 			add_submenu_page( 'sensei', __( 'Grading', 'sensei-lms' ), __( 'Grading', 'sensei-lms' ), 'manage_sensei_grades', $this->page_slug, array( $this, 'grading_page' ) );
 		}
@@ -541,8 +539,6 @@ class Sensei_Grading {
 	 * fallback.
 	 */
 	private function deprecated_get_lessons_dropdown() {
-		$posts_array = array();
-
 		// Parse POST data
 		// phpcs:ignore WordPress.Security.NonceVerification -- No modifications are made here.
 		$data        = $_POST['data'];

--- a/includes/class-sensei-learner-profiles.php
+++ b/includes/class-sensei-learner-profiles.php
@@ -115,25 +115,6 @@ class Sensei_Learner_Profiles {
 	}
 
 	/**
-	 * Load content for learner profiles
-	 *
-	 * @since  1.4.0
-	 * @return void
-	 */
-	public function content() {
-		global $wp_query,  $learner_user, $current_user;
-
-		if ( isset( Sensei()->settings->settings['learner_profile_enable'] ) && Sensei()->settings->settings['learner_profile_enable'] ) {
-
-			if ( isset( $wp_query->query_vars['learner_profile'] ) ) {
-
-				Sensei_Templates::get_template( 'learner-profile/learner-info.php' );
-
-			}
-		}
-	}
-
-	/**
 	 * Set heading for courses section of learner profiles
 	 *
 	 * @since  1.4.0

--- a/includes/class-sensei-learner-profiles.php
+++ b/includes/class-sensei-learner-profiles.php
@@ -115,6 +115,27 @@ class Sensei_Learner_Profiles {
 	}
 
 	/**
+	 * Load content for learner profiles
+	 *
+	 * @since  1.4.0
+	 * @return void
+	 */
+	public function content() {
+		global $wp_query;
+
+		_deprecated_function( __METHOD__, '2.2.0' );
+
+		if ( isset( Sensei()->settings->settings['learner_profile_enable'] ) && Sensei()->settings->settings['learner_profile_enable'] ) {
+
+			if ( isset( $wp_query->query_vars['learner_profile'] ) ) {
+
+				Sensei_Templates::get_template( 'learner-profile/learner-info.php' );
+
+			}
+		}
+	}
+
+	/**
 	 * Set heading for courses section of learner profiles
 	 *
 	 * @since  1.4.0

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -78,8 +78,6 @@ class Sensei_Learner {
 	}
 
 	public static function get_all( $args ) {
-
-		$user_ids = false;
 		$post_id  = 0;
 		$activity = '';
 

--- a/includes/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/class-sensei-learners-admin-bulk-actions-controller.php
@@ -262,9 +262,8 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	}
 
 	public function learners_admin_menu() {
-		global $menu;
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
-			$learners_page = add_submenu_page( 'sensei', __( 'Learner Admin', 'sensei-lms' ), __( 'Learner Admin', 'sensei-lms' ), 'manage_sensei_grades', 'sensei_learner_admin', array( $this, 'learner_admin_page' ) );
+			add_submenu_page( 'sensei', __( 'Learner Admin', 'sensei-lms' ), __( 'Learner Admin', 'sensei-lms' ), 'manage_sensei_grades', 'sensei_learner_admin', array( $this, 'learner_admin_page' ) );
 		}
 	}
 

--- a/includes/class-sensei-learners-main.php
+++ b/includes/class-sensei-learners-main.php
@@ -144,7 +144,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	 * @return void
 	 */
 	public function prepare_items() {
-		global $avail_stati, $wpdb, $per_page;
+		global $per_page;
 
 		// Handle orderby
 		$orderby = '';
@@ -537,8 +537,6 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	 * @return array learners
 	 */
 	private function get_learners( $args ) {
-
-		$user_ids = false;
 		$post_id  = 0;
 		$activity = '';
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -1020,8 +1020,6 @@ class Sensei_Lesson {
 		$html = '';
 
 		if ( count( $questions ) > 0 ) {
-
-			$question_class   = '';
 			$question_counter = 1;
 
 			foreach ( $questions as $question ) {
@@ -1063,7 +1061,7 @@ class Sensei_Lesson {
 	}
 
 	public function quiz_panel_question( $question_type = '', $question_counter = 0, $question_id = 0, $context = 'quiz', $multiple_data = array() ) {
-		global $row_counter,  $quiz_questions;
+		global $row_counter;
 
 		$html = '';
 
@@ -2010,9 +2008,8 @@ class Sensei_Lesson {
 	public function lesson_quiz_meta_box_content() {
 		global $post;
 
-		// Get quiz panel
 		$quiz_id = 0;
-		$quizzes = array();
+
 		if ( 0 < $post->ID ) {
 			$quiz_id = $this->lesson_quizzes( $post->ID, 'any' );
 		}
@@ -2034,7 +2031,7 @@ class Sensei_Lesson {
 		// Get quiz panel
 		$quiz_id   = 0;
 		$lesson_id = $post->ID;
-		$quizzes   = array();
+
 		if ( 0 < $lesson_id ) {
 			$quiz_id = $this->lesson_quizzes( $lesson_id, 'any' );
 		}
@@ -2303,8 +2300,6 @@ class Sensei_Lesson {
 	 * @return void
 	 */
 	public function add_column_data( $column_name, $id ) {
-		global $wpdb, $post;
-
 		switch ( $column_name ) {
 			case 'id':
 				echo esc_html( $id );
@@ -2717,29 +2712,23 @@ class Sensei_Lesson {
 	 * @return integer|boolean $course_id or false
 	 */
 	private function lesson_save_course( $data = array() ) {
-		global $current_user;
 		$return = false;
 		// Setup the course data
 		$course_id           = 0;
 		$course_content      = '';
 		$course_title        = '';
-		$course_prerequisite = 0;
-		$course_category     = 0;
+
 		if ( isset( $data['course_id'] ) && ( 0 < absint( $data['course_id'] ) ) ) {
 			$course_id = absint( $data['course_id'] );
 		} // End If Statement
 		if ( isset( $data['course_title'] ) && ( '' != $data['course_title'] ) ) {
 			$course_title = $data['course_title'];
 		} // End If Statement
-		$post_title = $course_title;
-		if ( isset( $data['post_author'] ) ) {
-			$post_author = $data['post_author'];
-		} else {
-			$current_user = wp_get_current_user();
-			$post_author  = $current_user->ID;
-		} // End If Statement
+
+		$post_title  = $course_title;
 		$post_status = 'publish';
 		$post_type   = 'course';
+
 		if ( isset( $data['course_content'] ) && ( '' != $data['course_content'] ) ) {
 			$course_content = $data['course_content'];
 		} // End If Statement
@@ -3228,9 +3217,7 @@ class Sensei_Lesson {
 					$questions[] = $question;
 				}
 			} else {
-
 				// Otherwise, make sure that we convert all multiple questions into single questions
-				$multiple_array     = array();
 				$existing_questions = array();
 
 				// Set array of questions that already exist so we can prevent duplicates from appearing
@@ -3428,8 +3415,6 @@ class Sensei_Lesson {
 				$dimensions       = Sensei()->get_image_size( $image_thumb_size );
 				$width            = $dimensions['width'];
 				$height           = $dimensions['height'];
-				$crop             = $dimensions['crop'];
-
 			} else {
 
 				if ( ! $widget && ! Sensei()->settings->settings['course_lesson_image_enable'] ) {
@@ -3441,8 +3426,6 @@ class Sensei_Lesson {
 				$dimensions       = Sensei()->get_image_size( $image_thumb_size );
 				$width            = $dimensions['width'];
 				$height           = $dimensions['height'];
-				$crop             = $dimensions['crop'];
-
 			} // End If Statement
 		} // End If Statement
 
@@ -3878,7 +3861,6 @@ class Sensei_Lesson {
 		$loop_lesson_number = $wp_query->current_post + 1;
 
 		$course_id              = Sensei()->lesson->get_course_id( $lesson_id );
-		$single_lesson_complete = false;
 		$is_user_taking_course  = Sensei_Utils::user_started_course( $course_id, get_current_user_id() );
 
 		// Get Lesson data
@@ -4345,7 +4327,6 @@ class Sensei_Lesson {
 		}
 
 		$lesson_prerequisite       = (int) get_post_meta( $lesson_id, '_lesson_prerequisite', true );
-		$lesson_course_id          = (int) get_post_meta( $lesson_id, '_lesson_course', true );
 		$quiz_id                   = Sensei()->lesson->lesson_quizzes( $lesson_id );
 		$has_user_completed_lesson = Sensei_Utils::user_completed_lesson( intval( $lesson_id ), $user_id );
 		$show_actions              = is_user_logged_in() ? true : false;
@@ -4467,7 +4448,7 @@ class Sensei_Lesson {
 	public static function limit_archive_content( $content ) {
 
 		if ( is_post_type_archive( 'lesson' ) && Sensei()->settings->get( 'access_permission' ) ) {
-			return wp_trim_words( $content, $num_words = 30, $more = '…' );
+			return wp_trim_words( $content, 30, '…' );
 		}
 
 		return $content;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2714,9 +2714,9 @@ class Sensei_Lesson {
 	private function lesson_save_course( $data = array() ) {
 		$return = false;
 		// Setup the course data
-		$course_id           = 0;
-		$course_content      = '';
-		$course_title        = '';
+		$course_id      = 0;
+		$course_content = '';
+		$course_title   = '';
 
 		if ( isset( $data['course_id'] ) && ( 0 < absint( $data['course_id'] ) ) ) {
 			$course_id = absint( $data['course_id'] );
@@ -3856,12 +3856,11 @@ class Sensei_Lesson {
 	 * @param $lesson_id
 	 */
 	public static function the_lesson_meta( $lesson_id ) {
-
 		global $wp_query;
-		$loop_lesson_number = $wp_query->current_post + 1;
 
-		$course_id              = Sensei()->lesson->get_course_id( $lesson_id );
-		$is_user_taking_course  = Sensei_Utils::user_started_course( $course_id, get_current_user_id() );
+		$loop_lesson_number    = $wp_query->current_post + 1;
+		$course_id             = Sensei()->lesson->get_course_id( $lesson_id );
+		$is_user_taking_course = Sensei_Utils::user_started_course( $course_id, get_current_user_id() );
 
 		// Get Lesson data
 		$complexity_array = Sensei()->lesson->lesson_complexities();

--- a/includes/class-sensei-list-table.php
+++ b/includes/class-sensei-list-table.php
@@ -147,7 +147,7 @@ class Sensei_List_Table extends WP_List_Table {
 	 * @return array $columns, the array of columns to use with the table
 	 */
 	public function get_columns() {
-		return $columns = $this->columns;
+		return $this->columns;
 	} // End get_columns()
 
 	/**
@@ -157,7 +157,7 @@ class Sensei_List_Table extends WP_List_Table {
 	 * @return array $sortable, the array of columns that can be sorted by the user
 	 */
 	public function get_sortable_columns() {
-		return $sortable = $this->sortable_columns;
+		return $this->sortable_columns;
 	} // End get_sortable_columns()
 
 	/**

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -302,12 +302,10 @@ class Sensei_Messages {
 	}
 
 	public function teacher_contact_form( $post ) {
-
 		if ( ! is_user_logged_in() ) {
 			return;
 		}
 
-		global $current_user;
 		wp_get_current_user();
 
 		$html = '';
@@ -361,7 +359,7 @@ class Sensei_Messages {
 			return false;
 		}
 
-		$message_id = $this->save_new_message_post( $current_user->ID, $post->post_author, sanitize_text_field( $_POST['contact_message'] ), $post->ID );
+		$this->save_new_message_post( $current_user->ID, $post->post_author, sanitize_text_field( $_POST['contact_message'] ), $post->ID );
 	}
 
 	public function message_reply_received( $comment_id = 0 ) {

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -731,8 +731,6 @@ class Sensei_PostTypes {
 	 * @return array           The modified array of messages for post types.
 	 */
 	public function setup_post_type_messages( $messages ) {
-		global $post, $post_ID;
-
 		$messages['course']            = $this->create_post_type_messages( 'course' );
 		$messages['lesson']            = $this->create_post_type_messages( 'lesson' );
 		$messages['quiz']              = $this->create_post_type_messages( 'quiz' );

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -86,8 +86,6 @@ class Sensei_Question {
 	 * @return void
 	 */
 	public function add_column_data( $column_name, $id ) {
-		global $wpdb, $post;
-
 		switch ( $column_name ) {
 
 			case 'id':
@@ -313,7 +311,7 @@ class Sensei_Question {
 			remove_action( 'save_post_question', array( $this, 'save_question' ) );
 
 			// Update question data
-			$question_id = Sensei()->lesson->lesson_save_question( $data, 'question' );
+			Sensei()->lesson->lesson_save_question( $data, 'question' );
 
 			// Re-hook same function
 			add_action( 'save_post_question', array( $this, 'save_question' ) );
@@ -693,7 +691,6 @@ class Sensei_Question {
 		$user_lesson_status = Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
 		$user_quiz_grade    = Sensei_Quiz::get_user_quiz_grade( $lesson_id, get_current_user_id() );
 		$reset_quiz_allowed = Sensei_Quiz::is_reset_allowed( $lesson_id );
-		$quiz_grade_type    = get_post_meta( $quiz_id, '_quiz_grade_type', true );
 		$quiz_graded        = isset( $user_lesson_status->comment_approved ) && ! in_array( $user_lesson_status->comment_approved, array( 'ungraded', 'in-progress' ) );
 
 		$quiz_required_pass_grade     = intval( get_post_meta( $quiz_id, '_quiz_passmark', true ) );
@@ -758,11 +755,8 @@ class Sensei_Question {
 	 * @since 1.9.0
 	 */
 	public static function the_answer_result_indication() {
+		global $sensei_question_loop;
 
-		global $post,  $current_user, $sensei_question_loop;
-
-		$answer_message       = '';
-		$answer_message_class = '';
 		$quiz_id              = $sensei_question_loop['quiz_id'];
 		$question_item        = $sensei_question_loop['current_question'];
 		$lesson_id            = Sensei()->quiz->get_lesson_id( $quiz_id );
@@ -1192,10 +1186,8 @@ class Sensei_Question {
 	 * @return string $correct_answer or empty
 	 */
 	public static function get_correct_answer( $question_id ) {
-
 		$right_answer = get_post_meta( $question_id, '_question_right_answer', true );
 		$type         = Sensei()->question->get_question_type( $question_id );
-		$grade_type   = 'manual-grade';
 
 		if ( 'boolean' == $type ) {
 			if ( 'true' === $right_answer ) {

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -757,11 +757,11 @@ class Sensei_Question {
 	public static function the_answer_result_indication() {
 		global $sensei_question_loop;
 
-		$quiz_id              = $sensei_question_loop['quiz_id'];
-		$question_item        = $sensei_question_loop['current_question'];
-		$lesson_id            = Sensei()->quiz->get_lesson_id( $quiz_id );
-		$user_lesson_status   = Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
-		$quiz_graded          = isset( $user_lesson_status->comment_approved ) && ! in_array( $user_lesson_status->comment_approved, array( 'in-progress', 'ungraded' ) );
+		$quiz_id            = $sensei_question_loop['quiz_id'];
+		$question_item      = $sensei_question_loop['current_question'];
+		$lesson_id          = Sensei()->quiz->get_lesson_id( $quiz_id );
+		$user_lesson_status = Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
+		$quiz_graded        = isset( $user_lesson_status->comment_approved ) && ! in_array( $user_lesson_status->comment_approved, array( 'in-progress', 'ungraded' ) );
 
 		if ( ! Sensei_Utils::user_started_course( Sensei()->lesson->get_course_id( $lesson_id ), get_current_user_id() ) ) {
 			return;

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -342,9 +342,6 @@ class Sensei_Quiz {
 		global  $post, $current_user;
 		$this->data = new stdClass();
 
-		// Default grade
-		$grade = 0;
-
 		// Get Quiz Questions
 		$lesson_quiz_questions = Sensei()->lesson->lesson_quiz_questions( $post->ID );
 
@@ -352,9 +349,6 @@ class Sensei_Quiz {
 
 		// Get quiz grade type
 		$quiz_grade_type = get_post_meta( $post->ID, '_quiz_grade_type', true );
-
-		// Get quiz pass setting
-		$pass_required = get_post_meta( $post->ID, '_pass_required', true );
 
 		// Get quiz pass mark
 		$quiz_passmark = Sensei_Utils::as_absolute_rounded_number( get_post_meta( $post->ID, '_quiz_passmark', true ), 2 );
@@ -493,9 +487,9 @@ class Sensei_Quiz {
 		delete_transient( $answers_feedback_transient_key );
 
 		// reset the quiz answers and feedback notes
-		$deleted_answers       = Sensei_Utils::delete_user_data( 'quiz_answers', $lesson_id, $user_id );
-		$deleted_grades        = Sensei_Utils::delete_user_data( 'quiz_grades', $lesson_id, $user_id );
-		$deleted_user_feedback = Sensei_Utils::delete_user_data( 'quiz_answers_feedback', $lesson_id, $user_id );
+		Sensei_Utils::delete_user_data( 'quiz_answers', $lesson_id, $user_id );
+		Sensei_Utils::delete_user_data( 'quiz_grades', $lesson_id, $user_id );
+		Sensei_Utils::delete_user_data( 'quiz_answers_feedback', $lesson_id, $user_id );
 
 		// Delete quiz answers, this auto deletes the corresponding meta data, such as the question/answer grade
 		Sensei_Utils::sensei_delete_quiz_answers( $quiz_id, $user_id );

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -784,8 +784,6 @@ class Sensei_Settings_API {
 	 * @param  array $args
 	 */
 	public function form_field_button( $args ) {
-		$options = $this->get_settings();
-
 		if ( isset( $args['data']['target'] ) && isset( $args['data']['label'] ) ) {
 			printf( '<a href="%s" class="button button-secondary">%s</a> ', esc_url( $args['data']['target'] ), esc_html( $args['data']['label'] ) );
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -142,8 +142,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 * @return void
 	 */
 	public function init_fields() {
-		global $pagenow;
-
 		$pages_array          = $this->pages_array();
 		$posts_per_page_array = array(
 			'0'  => '0',

--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -697,8 +697,7 @@ class Sensei_Templates {
 
 
 	public static function the_register_button( $post_id = '' ) {
-
-		global $current_user, $post;
+		global $current_user;
 
 		if ( ! get_option( 'users_can_register' )
 			 || 'course' != get_post_type( $post_id )
@@ -706,7 +705,6 @@ class Sensei_Templates {
 			 || ! Sensei()->settings->get( 'access_permission' ) ) {
 
 			return;
-
 		}
 
 		// if user is not logged in skipped for single lesson

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -850,7 +850,6 @@ class Sensei_Updates {
 		);
 		$quizzes = get_posts( $args );
 
-		$old_answers      = array();
 		$right_answers    = array();
 		$old_user_answers = array();
 
@@ -1607,7 +1606,8 @@ class Sensei_Updates {
 							) ) {
 									continue; // Found the meta data already
 							}
-							$result = $wpdb->insert(
+
+							$wpdb->insert(
 								$wpdb->commentmeta,
 								array(
 									'comment_id' => $comment_ID,
@@ -1752,7 +1752,8 @@ class Sensei_Updates {
 							) ) {
 									continue; // Found the meta data already
 							}
-							$result = $wpdb->insert(
+
+							$wpdb->insert(
 								$wpdb->commentmeta,
 								array(
 									'comment_id' => $comment_ID,
@@ -1986,7 +1987,8 @@ class Sensei_Updates {
 							) ) {
 									continue; // Found the meta data already
 							}
-							$result = $wpdb->insert(
+
+							$wpdb->insert(
 								$wpdb->commentmeta,
 								array(
 									'comment_id' => $comment_ID,
@@ -2072,7 +2074,7 @@ class Sensei_Updates {
 	public function remove_legacy_comments() {
 		global $wpdb;
 
-		$result = $wpdb->delete( $wpdb->comments, array( 'comment_approved' => 'legacy' ) );
+		$wpdb->delete( $wpdb->comments, array( 'comment_approved' => 'legacy' ) );
 
 		return true;
 	}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1317,10 +1317,6 @@ class Sensei_Utils {
 		$extra     = '';
 
 		if ( $lesson_id > 0 && $user_id > 0 ) {
-
-			// Prerequisite lesson
-			$prerequisite = get_post_meta( $lesson_id, '_lesson_prerequisite', true );
-
 			// Course ID
 			$course_id = absint( get_post_meta( $lesson_id, '_lesson_course', true ) );
 
@@ -1350,7 +1346,6 @@ class Sensei_Utils {
 
 			// Quiz passmark
 			$quiz_passmark       = absint( get_post_meta( $quiz_id, '_quiz_passmark', true ) );
-			$quiz_passmark_float = (float) $quiz_passmark;
 
 			// Pass required
 			$pass_required = get_post_meta( $quiz_id, '_pass_required', true );
@@ -2508,7 +2503,7 @@ class Sensei_Utils {
 			'complete' => 0,
 		);
 
-		$activity_logged = self::update_course_status( $user_id, $course_id, $course_status = 'in-progress', $course_metadata );
+		$activity_logged = self::update_course_status( $user_id, $course_id, 'in-progress', $course_metadata );
 
 		// Allow further actions
 		if ( $activity_logged ) {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1345,7 +1345,7 @@ class Sensei_Utils {
 			}
 
 			// Quiz passmark
-			$quiz_passmark       = absint( get_post_meta( $quiz_id, '_quiz_passmark', true ) );
+			$quiz_passmark = absint( get_post_meta( $quiz_id, '_quiz_passmark', true ) );
 
 			// Pass required
 			$pass_required = get_post_meta( $quiz_id, '_pass_required', true );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -192,7 +192,7 @@ class Sensei_Main {
 
 		// Setup object data
 		$this->main_plugin_file_name = $main_plugin_file_name;
-		$this->plugin_url            = trailingslashit( plugins_url( '', $plugin = $this->main_plugin_file_name ) );
+		$this->plugin_url            = trailingslashit( plugins_url( '', $this->main_plugin_file_name ) );
 		$this->plugin_path           = trailingslashit( dirname( $this->main_plugin_file_name ) );
 		$this->template_url          = apply_filters( 'sensei_template_url', 'sensei/' );
 		$this->version               = isset( $args['version'] ) ? $args['version'] : null;

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -255,19 +255,7 @@ class Sensei_Legacy_Shortcodes {
 	 * @since 1.9.0
 	 */
 	public static function initialise_legacy_course_loop() {
-
-		global  $post, $wp_query, $shortcode_override, $course_excludes;
-
-		// Handle Query Type
-		$query_type = '';
-
-		if ( isset( $_GET['action'] ) && ( '' != esc_html( $_GET['action'] ) ) ) {
-			$query_type = esc_html( $_GET['action'] );
-		} // End If Statement
-
-		if ( '' != $shortcode_override ) {
-			$query_type = $shortcode_override;
-		} // End If Statement
+		global $wp_query, $shortcode_override, $course_excludes;
 
 		if ( ! is_array( $course_excludes ) ) {
 			$course_excludes = array(); }
@@ -314,8 +302,7 @@ class Sensei_Legacy_Shortcodes {
 	 * @param WP_Query $course_query
 	 */
 	public static function loop_courses( $course_query, $amount ) {
-
-		global $shortcode_override, $posts_array, $post, $wp_query, $shortcode_override, $course_excludes, $course_includes;
+		global $shortcode_override, $posts_array, $course_excludes, $course_includes;
 
 		if ( count( $course_query->get_posts() ) > 0 ) {
 
@@ -387,7 +374,6 @@ class Sensei_Legacy_Shortcodes {
 		$user_info             = get_userdata( absint( $course->post_author ) );
 		$author_link           = get_author_posts_url( absint( $course->post_author ) );
 		$author_display_name   = $user_info->display_name;
-		$author_id             = $course->post_author;
 		$category_output       = get_the_term_list( $course_id, 'course-category', '', ', ', '' );
 		$preview_lesson_count  = intval( Sensei()->course->course_lesson_preview_count( $course_id ) );
 		$is_user_taking_course = Sensei_Utils::user_started_course( $course_id, get_current_user_id() );

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -429,11 +429,9 @@ function sensei_get_prev_next_lessons( $lesson_id = 0 ) {
    * @return string $excerpt
    */
 function sensei_get_excerpt( $post_id = '' ) {
-
-	global $post;
 	_deprecated_function( 'sensei_get_excerpt', 'use the WordPress excerpt functionality.' );
-	return get_the_excerpt();
 
+	return get_the_excerpt();
 }
 
 function sensei_has_user_started_course( $post_id = 0, $user_id = 0 ) {
@@ -683,7 +681,7 @@ function sensei_get_the_module_status() {
 	}
 
 	global $sensei_modules_loop;
-	$module_title    = $sensei_modules_loop['current_module']->name;
+
 	$module_term_id  = $sensei_modules_loop['current_module']->term_id;
 	$course_id       = $sensei_modules_loop['course_id'];
 	$module_progress = Sensei()->modules->get_user_module_progress( $module_term_id, $course_id, get_current_user_id() );


### PR DESCRIPTION
This removes unused variables as per the linter warnings, but does not touch unused function parameters.

Not sure about removing those public functions outright that load non-existent templates. Should they be deprecated instead?