### PR TITLE
Ignore and fix PHPCS issues with global variable overrides

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -108,6 +108,7 @@ class Sensei_Admin {
 		}
 
 		if ( $menu_cap ) {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Only way to add separator above our menu group.
 			$menu[] = array( '', 'read', 'separator-sensei', '', 'wp-menu-separator sensei' );
 			add_menu_page( 'Sensei LMS', 'Sensei LMS', $menu_cap, 'sensei', array( Sensei()->analysis, 'analysis_page' ), '', '50' );
 		}
@@ -163,6 +164,7 @@ class Sensei_Admin {
 			return;
 		}
 
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Only way to highlight our special pages in menu.
 		if ( $screen->base == 'post' && $post_type == 'course' ) {
 
 			$parent_file = 'edit.php?post_type=course';
@@ -183,6 +185,7 @@ class Sensei_Admin {
 			$parent_file  = 'sensei';
 
 		}
+		// phpcs:enable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 	}
 
 	/**

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -154,8 +154,6 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	 * @return void
 	 */
 	public function prepare_items() {
-		global $per_page;
-
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -78,8 +78,6 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 	 * @return void
 	 */
 	public function prepare_items() {
-		global $per_page;
-
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -135,8 +135,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @return void
 	 */
 	public function prepare_items() {
-		global $per_page;
-
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {

--- a/includes/class-sensei-analysis-user-profile-list-table.php
+++ b/includes/class-sensei-analysis-user-profile-list-table.php
@@ -77,8 +77,6 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 	 * @return void
 	 */
 	public function prepare_items() {
-		global $per_page;
-
 		// Handle orderby (needs work)
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2856,6 +2856,7 @@ class Sensei_Course {
 
 		}
 
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Used for lesson loop on single course page. Reset in hook to `sensei_single_course_lessons_after`.
 		$wp_query = new WP_Query( $course_lesson_query_args );
 
 	}//end load_single_course_lessons_query()

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1766,7 +1766,7 @@ class Sensei_Frontend {
 			wp_new_user_notification( $user_id, $new_user_password );
 		}
 
-		// set global current user aka log the user in.
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Log in recently registered user.
 		$current_user = get_user_by( 'id', $user_id );
 		wp_set_auth_cookie( $user_id, true );
 

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -99,7 +99,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 	 * @return void
 	 */
 	public function prepare_items() {
-		global  $per_page, $wp_version;
+		global $wp_version;
 
 		// Handle orderby
 		$orderby = '';

--- a/includes/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/class-sensei-learners-admin-bulk-actions-view.php
@@ -304,7 +304,6 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	}
 
 	public function parse_query_args() {
-		global $per_page;
 		// Handle orderby
 		$course_id = 0;
 		$lesson_id = 0;

--- a/includes/class-sensei-learners-main.php
+++ b/includes/class-sensei-learners-main.php
@@ -144,7 +144,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	 * @return void
 	 */
 	public function prepare_items() {
-		global $avail_stati, $wpdb, $per_page;
+		global $avail_stati, $wpdb;
 
 		// Handle orderby
 		$orderby = '';

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2335,7 +2335,6 @@ class Sensei_Lesson {
 	 * @return void
 	 */
 	public function lesson_add_course() {
-		global $current_user;
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_add_course_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
@@ -2387,7 +2386,6 @@ class Sensei_Lesson {
 	 * @return void
 	 */
 	public function lesson_update_question() {
-		global $current_user;
 		// Add nonce security to the request
 		if ( isset( $_POST['lesson_update_question_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
@@ -2717,7 +2715,6 @@ class Sensei_Lesson {
 	 * @return integer|boolean $course_id or false
 	 */
 	private function lesson_save_course( $data = array() ) {
-		global $current_user;
 		$return = false;
 		// Setup the course data
 		$course_id           = 0;

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2297,7 +2297,7 @@ class Sensei_Core_Modules {
 	 */
 	public static function teardown_single_course_module_loop() {
 
-		global $sensei_modules_loop, $wp_query, $post;
+		global $sensei_modules_loop;
 
 		// reset all of the modules loop variables
 		$sensei_modules_loop['total']   = 0;
@@ -2306,7 +2306,6 @@ class Sensei_Core_Modules {
 
 		// set the current course to be the global post again
 		wp_reset_query();
-		$post = $wp_query->post;
 	}//end teardown_single_course_module_loop()
 
 } // end modules class

--- a/includes/renderers/class-sensei-renderer-single-post.php
+++ b/includes/renderers/class-sensei-renderer-single-post.php
@@ -150,10 +150,12 @@ class Sensei_Renderer_Single_Post implements Sensei_Renderer_Interface {
 	public function set_global_vars() {
 		global $wp_query, $wp_the_query, $post, $pages;
 
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Used to render single post.
 		$post         = get_post( $this->post_id );
 		$pages        = array( $post->post_content );
 		$wp_query     = $this->post_query;
 		$wp_the_query = $wp_query;
+		// phpcs:enable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 	}
 
 	/**
@@ -163,10 +165,12 @@ class Sensei_Renderer_Single_Post implements Sensei_Renderer_Interface {
 	private function reset_global_vars() {
 		global $wp_query, $wp_the_query, $post, $pages;
 
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Restoring preexisting state.
 		$wp_query     = $this->global_wp_query_ref;
 		$wp_the_query = $this->global_wp_the_query_ref;
 		$post         = $this->global_post_ref;
 		$pages        = $this->global_pages_ref;
+		// phpcs:enable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 	}
 
 	/**

--- a/includes/shortcodes/class-sensei-shortcode-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-courses.php
@@ -209,6 +209,7 @@ class Sensei_Shortcode_Courses implements Sensei_Shortcode_Interface {
 		Sensei_Templates::get_template( 'loop-course.php' );
 		$shortcode_output = ob_get_clean();
 
+		// phpcs:ignore WordPress.WP.DiscouragedFunctions.wp_reset_query_wp_reset_query -- wp_reset_postdata() is not a good alternative.
 		wp_reset_query();
 
 		return $shortcode_output;

--- a/includes/shortcodes/class-sensei-shortcode-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-courses.php
@@ -202,12 +202,14 @@ class Sensei_Shortcode_Courses implements Sensei_Shortcode_Interface {
 		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		global $wp_query;
 
-		// assign the query setup in $this-> setup_course_query
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Used to produce loop in shortcode. Reset below.
 		$wp_query = $this->query;
 
 		ob_start();
 		Sensei_Templates::get_template( 'loop-course.php' );
 		$shortcode_output = ob_get_clean();
+
+		wp_reset_query();
 
 		return $shortcode_output;
 

--- a/includes/shortcodes/class-sensei-shortcode-featured-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-featured-courses.php
@@ -118,6 +118,7 @@ class Sensei_Shortcode_Featured_Courses implements Sensei_Shortcode_Interface {
 		Sensei_Templates::get_template( 'loop-course.php' );
 		$shortcode_output = ob_get_clean();
 
+		// phpcs:ignore WordPress.WP.DiscouragedFunctions.wp_reset_query_wp_reset_query -- wp_reset_postdata() is not a good alternative.
 		wp_reset_query();
 
 		return $shortcode_output;

--- a/includes/shortcodes/class-sensei-shortcode-featured-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-featured-courses.php
@@ -111,12 +111,14 @@ class Sensei_Shortcode_Featured_Courses implements Sensei_Shortcode_Interface {
 		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		global $wp_query;
 
-		// assign the query setup in $this-> setup_course_query
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Used to produce loop in shortcode. Reset below.
 		$wp_query = $this->query;
 
 		ob_start();
 		Sensei_Templates::get_template( 'loop-course.php' );
 		$shortcode_output = ob_get_clean();
+
+		wp_reset_query();
 
 		return $shortcode_output;
 

--- a/includes/shortcodes/class-sensei-shortcode-lesson-page.php
+++ b/includes/shortcodes/class-sensei-shortcode-lesson-page.php
@@ -96,6 +96,7 @@ class Sensei_Shortcode_Lesson_Page implements Sensei_Shortcode_Interface {
 		Sensei_Templates::get_template( 'content-single-lesson.php' );
 		$shortcode_output = ob_get_clean();
 
+		// phpcs:ignore WordPress.WP.DiscouragedFunctions.wp_reset_query_wp_reset_query -- wp_reset_postdata() is not a good alternative.
 		wp_reset_query();
 
 		return $shortcode_output;

--- a/includes/shortcodes/class-sensei-shortcode-lesson-page.php
+++ b/includes/shortcodes/class-sensei-shortcode-lesson-page.php
@@ -78,6 +78,8 @@ class Sensei_Shortcode_Lesson_Page implements Sensei_Shortcode_Interface {
 
 		// set the wp_query to the current lessons query
 		global $wp_query;
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Using it for loop below. Reset afterwards.
 		$wp_query = $this->lesson_page_query;
 
 		if ( have_posts() ) {
@@ -93,6 +95,8 @@ class Sensei_Shortcode_Lesson_Page implements Sensei_Shortcode_Interface {
 		ob_start();
 		Sensei_Templates::get_template( 'content-single-lesson.php' );
 		$shortcode_output = ob_get_clean();
+
+		wp_reset_query();
 
 		return $shortcode_output;
 

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -315,6 +315,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 		$shortcode_output = ob_get_clean();
 
+		// phpcs:ignore WordPress.WP.DiscouragedFunctions.wp_reset_query_wp_reset_query -- wp_reset_postdata() is not a good alternative.
 		wp_reset_query();
 
 		$this->detach_shortcode_hooks();

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -297,7 +297,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 		// mostly hooks added for legacy and backwards compatiblity sake
 		do_action( 'sensei_my_courses_before' );
-		do_action( 'sensei_before_user_course_content', get_current_user() );
+		do_action( 'sensei_before_user_course_content', wp_get_current_user() );
 
 		ob_start();
 		echo '<section id="sensei-user-courses">';
@@ -310,7 +310,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		echo '</section>';
 
 		// mostly hooks added for legacy and backwards compatiblity sake
-		do_action( 'sensei_after_user_course_content', get_current_user() );
+		do_action( 'sensei_after_user_course_content', wp_get_current_user() );
 		do_action( 'sensei_my_courses_after' );
 
 		$shortcode_output = ob_get_clean();

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -290,7 +290,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		// setup the course query that will be used when rendering
 		$this->setup_course_query();
 
-		// assign the query setup in $this-> setup_course_query
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Mocking loop for shortcode. Reset below.
 		$wp_query = $this->query;
 
 		$this->attach_shortcode_hooks();
@@ -314,6 +314,8 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		do_action( 'sensei_my_courses_after' );
 
 		$shortcode_output = ob_get_clean();
+
+		wp_reset_query();
 
 		$this->detach_shortcode_hooks();
 

--- a/includes/shortcodes/class-sensei-shortcode-user-messages.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-messages.php
@@ -92,12 +92,16 @@ class Sensei_Shortcode_User_Messages implements Sensei_Shortcode_Interface {
 
 		// set the wp_query to the current messages query
 		global $wp_query;
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Mock loop for template part below. Reset afterwards.
 		$wp_query = $this->messages_query;
 
 		ob_start();
 		Sensei()->notices->maybe_print_notices();
 		Sensei_Templates::get_part( 'loop', 'message' );
 		$messages_html = ob_get_clean();
+
+		wp_reset_query();
 
 		return $messages_html;
 

--- a/includes/shortcodes/class-sensei-shortcode-user-messages.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-messages.php
@@ -101,6 +101,7 @@ class Sensei_Shortcode_User_Messages implements Sensei_Shortcode_Interface {
 		Sensei_Templates::get_part( 'loop', 'message' );
 		$messages_html = ob_get_clean();
 
+		// phpcs:ignore WordPress.WP.DiscouragedFunctions.wp_reset_query_wp_reset_query -- wp_reset_postdata() is not a good alternative.
 		wp_reset_query();
 
 		return $messages_html;

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -519,6 +519,7 @@ function sensei_setup_module() {
 		// setup the global wp-query only if the lessons
 		if ( $modules_query->have_posts() ) {
 
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Use modules query for modules loop. Reset in `Sensei_Core_Modules::teardown_single_course_module_loop()`
 			$wp_query = $modules_query;
 
 		} else {

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -66,11 +66,13 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 		 * Set up new global $post and set it on $wp_query. Set $wp_the_query
 		 * as well so we can reset it back to this later.
 		 */
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Used to mock our own page within a custom loop. Reset afterwards.
 		$post            = new WP_Post( (object) $dummy_post_properties );
 		$wp_query        = clone $wp_query;
 		$wp_query->post  = $post;
 		$wp_query->posts = array( $post );
 		$wp_the_query    = $wp_query;
+		// phpcs:enable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 
 		// Prevent comments form from appearing.
 		$wp_query->post_count    = 1;
@@ -275,8 +277,10 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 			throw new Exception( 'setup_original_query cannot be called before output_content_as_page' );
 		}
 
+		// phpcs:disable WordPress.WP.GlobalVariablesOverride.OverrideProhibited -- Resetting to the original query from self::output_content_as_page().
 		$wp_query = $this->original_query;
 		$post     = $this->original_post;
+		// phpcs:enable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 	}
 
 }

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -24,7 +24,7 @@ $question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(
 
 <?php
 $count = 0;
-foreach ( $question_data['answer_options'] as $id => $option ) {
+foreach ( $question_data['answer_options'] as $option ) {
 
 	$count++;
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -77,8 +77,8 @@ if ( ! is_multisite() ) {
 	$blog_ids         = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
 	$original_blog_id = get_current_blog_id();
 
-	foreach ( $blog_ids as $blog_id ) {
-		switch_to_blog( $blog_id );
+	foreach ( $blog_ids as $current_blog_id ) {
+		switch_to_blog( $current_blog_id );
 
 		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- $plugin is passed to `uninstall_plugin`
 		if ( is_another_sensei_activated( $plugin ) ) {

--- a/uninstall.php
+++ b/uninstall.php
@@ -77,8 +77,8 @@ if ( ! is_multisite() ) {
 	$blog_ids         = $wpdb->get_col( "SELECT blog_id FROM $wpdb->blogs" );
 	$original_blog_id = get_current_blog_id();
 
-	foreach ( $blog_ids as $current_blog_id ) {
-		switch_to_blog( $current_blog_id );
+	foreach ( $blog_ids as $sensei_lms_current_blog_id ) {
+		switch_to_blog( $sensei_lms_current_blog_id );
 
 		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- $plugin is passed to `uninstall_plugin`
 		if ( is_another_sensei_activated( $plugin ) ) {


### PR DESCRIPTION
This PR:
- Ignores safe global variable overrides.
- On shortcodes, ignores override of `$wp_query` and then runs `wp_reset_query()` after.
- Fixes a couple of legit calls to `get_current_user()` and switched them to `wp_get_current_user()`. These were in legacy actions that I doubt had much effect.
- In admin pages with loops, we were overriding the global `$per_page`. This doesn't seem to have an effect. This change is on pages+tabs on grading, learners, and analysis pages. See https://github.com/Automattic/sensei/pull/2733/commits/cb12744c18a92b2e6d4ce45b20d48db402094d93 for more. I tested with this snippet on my not-massive dev site:
```
add_filter( 'sensei_comments_per_page', function() { 
  return 4; 
} );
```
