### PR TITLE
Fix bug on WP <5.0

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1822,7 +1822,7 @@ class Sensei_Admin {
 	public function output_cpt_block_editor_workaround() {
 		$screen = get_current_screen();
 
-		if ( ! $screen->is_block_editor() ) {
+		if ( ! ( method_exists( $screen, 'is_block_editor' ) && $screen->is_block_editor() ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #2735 

This bug was introduced in https://github.com/Automattic/sensei/pull/2658, which was created to solve the problem outlined by https://github.com/Automattic/sensei/issues/2525. Calling `is_block_editor` on WP <5.0 caused a fatal. In this PR, we check if the method exists. If not, we assume that we are not on a block editor page.

## Testing Instructions

- On WordPress <5.0, follow the instructions in #2735. Ensure that the fatal does not appear.
- On WordPress >=5.0, follow the instructions in #2525. Ensure that the bug does not reappear.