### PR TITLE
Add a filter for modifying the module title HTML

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1497,13 +1497,16 @@ class Sensei_Core_Modules {
 	 * @return void
 	 */
 	public function course_modules_title() {
-
 		if ( sensei_module_has_lessons() ) {
-
-			echo '<header class="modules-title"><h2>' . esc_html__( 'Modules', 'sensei-lms' ) . '</h2></header>';
-
+			/**
+			 * Filters the module title on the single course page.
+			 *
+			 * @since 2.2.0
+			 *
+			 * @param string $html The HTML to be displayed.
+			 */
+			echo apply_filters( 'sensei_modules_title', '<header class="modules-title"><h2>' . esc_html__( 'Modules', 'sensei-lms' ) . '</h2></header>' );
 		}
-
 	}
 
 	/**

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1498,14 +1498,17 @@ class Sensei_Core_Modules {
 	 */
 	public function course_modules_title() {
 		if ( sensei_module_has_lessons() ) {
+			global $post;
+
 			/**
 			 * Filters the module title on the single course page.
 			 *
 			 * @since 2.2.0
 			 *
-			 * @param string $html The HTML to be displayed.
+			 * @param string $html   The HTML to be displayed.
+			 * @param int $course_id Course ID.
 			 */
-			echo wp_kses_post( apply_filters( 'sensei_modules_title', '<header class="modules-title"><h2>' . __( 'Modules', 'sensei-lms' ) . '</h2></header>' ) );
+			echo wp_kses_post( apply_filters( 'sensei_modules_title', '<header class="modules-title"><h2>' . __( 'Modules', 'sensei-lms' ) . '</h2></header>', $post->ID ) );
 		}
 	}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1505,7 +1505,7 @@ class Sensei_Core_Modules {
 			 *
 			 * @param string $html The HTML to be displayed.
 			 */
-			echo apply_filters( 'sensei_modules_title', '<header class="modules-title"><h2>' . esc_html__( 'Modules', 'sensei-lms' ) . '</h2></header>' );
+			echo wp_kses_post( apply_filters( 'sensei_modules_title', '<header class="modules-title"><h2>' . __( 'Modules', 'sensei-lms' ) . '</h2></header>' ) );
 		}
 	}
 


### PR DESCRIPTION
This PR adds a filter to enable altering the HTML and/or text of the "Modules" title that appears on the single course page.

## Testing
Add the following code to your theme's `functions.php`:
```
function modules_title( $html ) {
    return 'My New Title';
}

add_filter( 'sensei_modules_title', 'modules_title' );
```

On the single course page of a course with modules, ensure that "My New Title" appears instead of "Modules".