### PR TITLE
Move array initialization outside loop

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2177,6 +2177,8 @@ class Sensei_Core_Modules {
 
 		}
 
+		$users_terms = [];
+
 		// loop through and update all terms adding the author name
 		foreach ( $terms as $index => $term ) {
 
@@ -2192,7 +2194,6 @@ class Sensei_Core_Modules {
 			}
 
 			// add the term to the teachers terms
-			$users_terms   = [];
 			$users_terms[] = $term;
 
 		}


### PR DESCRIPTION
Fixes #2741.

This PR moves the array initialization outside of the `foreach` loop so that it's not reset with each iteration of the loop.