### PR TITLE
Fix issue with how we filter allowed CSS attributes on bulk learner

### DIFF
--- a/includes/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/class-sensei-learners-admin-bulk-actions-view.php
@@ -297,8 +297,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		}
 	}
 
-	private function get_allowed_css( $style ) {
-		$styles   = [];
+	public function get_allowed_css( $styles ) {
 		$styles[] = 'display';
 
 		return $styles;

--- a/includes/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/class-sensei-learners-admin-bulk-actions-view.php
@@ -297,6 +297,14 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		}
 	}
 
+	/**
+	 * Allows us to add `display: none` to course list.
+	 *
+	 * @access private
+	 *
+	 * @param array $styles List of styles that are allowe and considered safe.
+	 * @return array
+	 */
 	public function get_allowed_css( $styles ) {
 		$styles[] = 'display';
 

--- a/includes/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/class-sensei-learners-admin-bulk-actions-view.php
@@ -302,7 +302,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	 *
 	 * @access private
 	 *
-	 * @param array $styles List of styles that are allowe and considered safe.
+	 * @param array $styles List of styles that are allowed and considered safe.
 	 * @return array
 	 */
 	public function get_allowed_css( $styles ) {


### PR DESCRIPTION
This fixes a minor issue with bulk learner actions from #2331. This technically worked before because the filter would go bust when it tried to access the private method. WP's `safecss_filter_attr()` does a funny thing when the allowed attributes list is `null` (which is what happened) in that it allows all attributes. While not a serious issue at all, we might as well fix it.

## Testing
1. Navigate to _Sensei_ > _Learner Management_ > _Bulk Learner Actions_.
2. Ensure the courses that a student is enrolled in are not visible until _...more_ is clicked.