### PR TITLE
enhance performance to admin list courses page issue (#2215)

### DIFF
--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -1261,24 +1261,21 @@ class Sensei_Teacher {
 
 		// get roles with the course edit capability
 		// and then get the users with those roles
-		$users_who_can_edit_courses = array();
+		$role_users_who_can_edit_courses = array();
 		foreach ( $roles as $role_item ) {
 
 			$role = get_role( strtolower( $role_item['name'] ) );
 
 			if ( is_a( $role, 'WP_Role' ) && $role->has_cap( 'edit_courses' ) ) {
-
-				$user_query_args                 = array(
-					'role'   => $role->name,
-					'fields' => array( 'ID', 'display_name' ),
-				);
-				$role_users_who_can_edit_courses = get_users( $user_query_args );
-
-				// add user from the current $user_role to all users
-				$users_who_can_edit_courses = array_merge( $users_who_can_edit_courses, $role_users_who_can_edit_courses );
-
+				$role_users_who_can_edit_courses[] = $role->name;
 			}
 		}
+
+		$user_query_args  = array(
+			'role__in' => $role_users_who_can_edit_courses,
+			'fields'   => array( 'ID', 'display_name' ),
+		);
+		$users_who_can_edit_courses = get_users( $user_query_args );
 
 		// Create the select element with the given users who can edit course
 		$selected       = isset( $_GET['course_teacher'] ) ? $_GET['course_teacher'] : '';

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -1271,10 +1271,11 @@ class Sensei_Teacher {
 			}
 		}
 
-		$user_query_args  = array(
+		$user_query_args = array(
 			'role__in' => $role_users_who_can_edit_courses,
 			'fields'   => array( 'ID', 'display_name' ),
 		);
+
 		$users_who_can_edit_courses = get_users( $user_query_args );
 
 		// Create the select element with the given users who can edit course


### PR DESCRIPTION
What I do to Reproduce the issue (#2215):

1- Add 44717 customers.
2- Add 2,969 teachers.
3- I used the Query Monitor plugin

What Happened 
Sensei plugin calls function WP_User_Query->query() several times, when we can use it once.
I hope this PR fix this issue @sophosscott @LukeAbel

![themaster](https://user-images.githubusercontent.com/4804842/60686320-50df0c00-9ea8-11e9-92a0-f4ca5d602949.jpg)

![themaster-after](https://user-images.githubusercontent.com/4804842/60686326-5b010a80-9ea8-11e9-889d-e0b3fa51887e.jpg)
