### PR TITLE
Log product count when a course is published

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3335,9 +3335,9 @@ class Sensei_Course {
 		$product_ids = get_post_meta( $course->ID, '_course_woocommerce_product', false );
 
 		$event_properties = [
-			'module_count' => count( wp_get_post_terms( $course->ID, 'module' ) ),
-			'lesson_count' => $this->course_lesson_count( $course->ID ),
-			'product_count'   => empty( $product_ids ) ? 0 : count( $product_ids ),
+			'module_count'  => count( wp_get_post_terms( $course->ID, 'module' ) ),
+			'lesson_count'  => $this->course_lesson_count( $course->ID ),
+			'product_count' => empty( $product_ids ) ? 0 : count( $product_ids ),
 		];
 		sensei_log_event( 'course_publish', $event_properties );
 	}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3332,11 +3332,13 @@ class Sensei_Course {
 	 * @param WP_Post $course The Course.
 	 */
 	public function log_initial_publish_event( $course ) {
-		$product_id       = get_post_meta( $course->ID, '_course_woocommerce_product', true );
+		$product_ids = get_post_meta( $course->ID, '_course_woocommerce_product', false );
+		$product_count = empty( $product_ids ) ? 0 : count( $product_ids );
+
 		$event_properties = [
 			'module_count' => count( wp_get_post_terms( $course->ID, 'module' ) ),
 			'lesson_count' => $this->course_lesson_count( $course->ID ),
-			'product_id'   => intval( $product_id ) ? intval( $product_id ) : -1,
+			'product_count'   => $product_count,
 		];
 		sensei_log_event( 'course_publish', $event_properties );
 	}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3332,12 +3332,13 @@ class Sensei_Course {
 	 * @param WP_Post $course The Course.
 	 */
 	public function log_initial_publish_event( $course ) {
-		$product_ids = get_post_meta( $course->ID, '_course_woocommerce_product', false );
+		$product_ids   = get_post_meta( $course->ID, '_course_woocommerce_product', false );
+		$product_count = empty( $product_ids ) ? 0 : count( array_filter( $product_ids, 'is_numeric' ) );
 
 		$event_properties = [
 			'module_count'  => count( wp_get_post_terms( $course->ID, 'module' ) ),
 			'lesson_count'  => $this->course_lesson_count( $course->ID ),
-			'product_count' => empty( $product_ids ) ? 0 : count( $product_ids ),
+			'product_count' => $product_count,
 		];
 		sensei_log_event( 'course_publish', $event_properties );
 	}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3333,12 +3333,11 @@ class Sensei_Course {
 	 */
 	public function log_initial_publish_event( $course ) {
 		$product_ids = get_post_meta( $course->ID, '_course_woocommerce_product', false );
-		$product_count = empty( $product_ids ) ? 0 : count( $product_ids );
 
 		$event_properties = [
 			'module_count' => count( wp_get_post_terms( $course->ID, 'module' ) ),
 			'lesson_count' => $this->course_lesson_count( $course->ID ),
-			'product_count'   => $product_count,
+			'product_count'   => empty( $product_ids ) ? 0 : count( $product_ids ),
 		];
 		sensei_log_event( 'course_publish', $event_properties );
 	}

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -178,7 +178,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		$event = $events[0];
 		$this->assertEquals( 0, $event['url_args']['module_count'] );
 		$this->assertEquals( 0, $event['url_args']['lesson_count'] );
-		$this->assertEquals( 1, $event['url_args']['product_count'] );
+		$this->assertEquals( 0, $event['url_args']['product_count'] );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -333,10 +333,10 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 
 		Sensei()->post_types->fire_scheduled_initial_publish_actions();
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_course_publish' );
-		$this->assertCount( 1, $events );
+		$this->assertCount( 1, $events, 'One event for sensei_course_publish should be recorded' );
 
-		// Ensure product ID is correct.
+		// Ensure product count is correct.
 		$event = $events[0];
-		$this->assertEquals( 2, $event['url_args']['product_count'] );
+		$this->assertEquals( 2, $event['url_args']['product_count'], 'Event should have 2 products attached to the course' );
 	}
 }//end class

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -178,7 +178,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		$event = $events[0];
 		$this->assertEquals( 0, $event['url_args']['module_count'] );
 		$this->assertEquals( 0, $event['url_args']['lesson_count'] );
-		$this->assertEquals( -1, $event['url_args']['product_id'] );
+		$this->assertEquals( 1, $event['url_args']['product_count'] );
 	}
 
 	/**
@@ -249,11 +249,11 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test initial publish logging product ID.
+	 * Test initial publish logging product count.
 	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
-	public function testLogInitialPublishProductId() {
+	public function testLogInitialPublishProductCount() {
 		$course_id = $this->factory->course->create(
 			[
 				'post_status' => 'draft',
@@ -277,7 +277,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 
 		// Ensure product ID is correct.
 		$event = $events[0];
-		$this->assertEquals( 5, $event['url_args']['product_id'] );
+		$this->assertEquals( 1, $event['url_args']['product_count'] );
 	}
 
 	/**
@@ -285,7 +285,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	 *
 	 * @covers Sensei_Course::log_initial_publish_event
 	 */
-	public function testLogNoEventProductId() {
+	public function testLogNoEventProduct() {
 		$course_id = $this->factory->course->create(
 			[
 				'post_status' => 'draft',
@@ -306,7 +306,37 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 
 		// Ensure product ID is correct.
 		$event = $events[0];
-		$this->assertEquals( -1, $event['url_args']['product_id'] );
+		$this->assertEquals( 0, $event['url_args']['product_count'] );
 	}
 
+	/**
+	 * Test initial publish logging product count with multiple product IDs.
+	 *
+	 * @covers Sensei_Course::log_initial_publish_event
+	 */
+	public function testLogEventProductCountMultiProduct() {
+		$course_id = $this->factory->course->create(
+			[
+				'post_status' => 'draft',
+			]
+		);
+		add_post_meta( $course_id, '_course_woocommerce_product', 5 );
+		add_post_meta( $course_id, '_course_woocommerce_product', 6 );
+
+		// Publish.
+		wp_update_post(
+			[
+				'ID'          => $course_id,
+				'post_status' => 'publish',
+			]
+		);
+
+		Sensei()->post_types->fire_scheduled_initial_publish_actions();
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_course_publish' );
+		$this->assertCount( 1, $events );
+
+		// Ensure product ID is correct.
+		$event = $events[0];
+		$this->assertEquals( 2, $event['url_args']['product_count'] );
+	}
 }//end class


### PR DESCRIPTION
closes https://github.com/Automattic/sensei-wc-paid-courses/issues/109

### Testing instructions (at least how I imagined them, copied from previous prs)

* nice to have: WCPC master branch, woocommerce
* Install and activate WP Crontrol.
* Enable usage tracking.
* Create a course and save as draft.
* add two products to it (either using WCPC that
supports multiple products or manually in the db).
* publish the course.
* Run the sensei_usage_tracking_send_usage_data job.
* Check that product_count is present in the event created
* Disable usage tracking!