### PR TITLE
Ensure WooCommerce notices are displayed for unsupported themes

### DIFF
--- a/includes/renderers/class-sensei-renderer-single-post.php
+++ b/includes/renderers/class-sensei-renderer-single-post.php
@@ -87,6 +87,9 @@ class Sensei_Renderer_Single_Post implements Sensei_Renderer_Interface {
 		add_filter( 'sensei_show_main_footer', '__return_false' );
 		add_filter( 'sensei_show_main_header', '__return_false' );
 
+		// Even though the header is not being displayed, the action hooked to it still needs to fire.
+		do_action( 'sensei_before_main_content' );
+
 		// We'll make the assumption that the theme will display the title.
 		add_filter( 'the_title', array( $this, 'hide_the_title' ), 100, 2 );
 

--- a/tests/unit-tests/renderers/test-class-sensei-renderer-single-post.php
+++ b/tests/unit-tests/renderers/test-class-sensei-renderer-single-post.php
@@ -53,25 +53,18 @@ class Sensei_Renderer_Single_Post_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure renderer disables Sensei's header and footer.
+	 * Ensure renderer disables Sensei's footer.
 	 *
 	 * @since 1.12.0
 	 */
-	public function testShouldTemporarilyDisableHeaderAndFooter() {
+	public function testShouldTemporarilyDisableFooter() {
 		$renderer = new Sensei_Renderer_Single_Post( $this->post_id, 'single.php' );
 		$renderer->render();
 
 		/*
-		 * sensei_get_header and sensei_get_footer fire the actions
-		 * 'sensei_before_main_content' and 'sensei_after_main_content',
-		 * respectively. If these actions were not called, we know that the
-		 * header and footer were skipped.
+		 * sensei_get_footer fires the 'sensei_after_main_content' action.
+		 * If this action was not called, we know that the footer was skipped.
 		 */
-		$this->assertEquals(
-			0,
-			did_action( 'sensei_before_main_content' ),
-			'Should not have called sensei_before_main_content'
-		);
 		$this->assertEquals(
 			0,
 			did_action( 'sensei_after_main_content' ),


### PR DESCRIPTION
This PR fixes WooCommerce notices not being displayed for unsupported themes on the single course page. This was discovered while working on https://github.com/Automattic/sensei-wc-paid-courses/issues/102.

I didn't see an easy way to update the unit test to check that the header is disabled, so I updated it so that it only checks the footer.

## Testing
- Switch to an unsupported theme like GeneratePress.
- Create a paid product and give it a price.
- Attach the product to a course.
- Browse to that course and click the "Purchase this Course" button.
- Ensure that you see a WooCommerce notice similar to the following:
![Screen Shot 2019-07-19 at 10 05 10 AM](https://user-images.githubusercontent.com/1190420/61540981-b8e73380-aa0c-11e9-894a-fa166b8bf0ad.jpg)

_Note that for some themes the notice may not be styled appropriately. This will be fixed in https://github.com/Automattic/sensei-wc-paid-courses/pull/148._