### PR TITLE
Add hooks around saving course meta

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -461,7 +461,7 @@ class Sensei_Course {
 		 * @param string $meta_key       The meta to be saved.
 		 * @param mixed  $new_meta_value The meta value to be saved.
 		 */
-		do_action( "sensei_course_meta_before_save", $post_id, $meta_key, $new_meta_value );
+		do_action( 'sensei_course_meta_before_save', $post_id, $meta_key, $new_meta_value );
 
 		/**
 		 * Filter whether or not to run the default save functionality for the
@@ -477,7 +477,7 @@ class Sensei_Course {
 		 * @param mixed  $new_meta_value The meta value to be saved.
 		 * @return bool
 		 */
-		if ( apply_filters( "sensei_course_meta_do_default_save", true, $post_id, $meta_key, $new_meta_value ) ) {
+		if ( apply_filters( 'sensei_course_meta_do_default_save', true, $post_id, $meta_key, $new_meta_value ) ) {
 			// Update meta field with the new value
 			return update_post_meta( $post_id, $meta_key, $new_meta_value );
 		}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -476,7 +476,7 @@ class Sensei_Course {
 		 * @param string $meta_key       The meta to be saved.
 		 * @param mixed  $new_meta_value The meta value to be saved.
 		 */
-		if ( apply_filters( 'sensei_course_meta_do_default_save', true, $post_id, $meta_key, $new_meta_value ) ) {
+		if ( apply_filters( 'sensei_course_meta_default_save', true, $post_id, $meta_key, $new_meta_value ) ) {
 			// Update meta field with the new value
 			return update_post_meta( $post_id, $meta_key, $new_meta_value );
 		}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -475,7 +475,6 @@ class Sensei_Course {
 		 * @param int    $post_id        The course ID.
 		 * @param string $meta_key       The meta to be saved.
 		 * @param mixed  $new_meta_value The meta value to be saved.
-		 * @return bool
 		 */
 		if ( apply_filters( 'sensei_course_meta_do_default_save', true, $post_id, $meta_key, $new_meta_value ) ) {
 			// Update meta field with the new value

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -452,8 +452,35 @@ class Sensei_Course {
 			$new_meta_value = ( isset( $_POST[ $post_key ] ) ? sanitize_html_class( $_POST[ $post_key ] ) : '' );
 		} // End If Statement
 
-		// update field with the new value
-		return update_post_meta( $post_id, $meta_key, $new_meta_value );
+		/**
+		 * Action before saving the meta value.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param int    $post_id        The course ID.
+		 * @param string $meta_key       The meta to be saved.
+		 * @param mixed  $new_meta_value The meta value to be saved.
+		 */
+		do_action( "sensei_course_meta_before_save", $post_id, $meta_key, $new_meta_value );
+
+		/**
+		 * Filter whether or not to run the default save functionality for the
+		 * meta. This may be used with the
+		 * "sensei_course_meta_before_save" action to create custom
+		 * save functionality for specific meta.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param bool   $do_save        Whether or not to do the default save.
+		 * @param int    $post_id        The course ID.
+		 * @param string $meta_key       The meta to be saved.
+		 * @param mixed  $new_meta_value The meta value to be saved.
+		 * @return bool
+		 */
+		if ( apply_filters( "sensei_course_meta_do_default_save", true, $post_id, $meta_key, $new_meta_value ) ) {
+			// Update meta field with the new value
+			return update_post_meta( $post_id, $meta_key, $new_meta_value );
+		}
 
 	} // End save_post_meta()
 


### PR DESCRIPTION
This allows 3rd party code to add custom save functionality for meta being saved through a metabox.

## New Action
- `sensei_course_meta_before_save` - Action before saving the meta value.

## New Filter
- `sensei_course_meta_default_save` - Whether or not to run the default save functionality for the meta.