### PR TITLE
Add filter for conditionally hiding lessons on single course page

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2712,12 +2712,24 @@ class Sensei_Course {
 	 * @since 1.9.0
 	 */
 	public static function the_course_lessons_title() {
-
 		if ( ! is_singular( 'course' ) ) {
 			return;
 		}
 
+		/**
+		 * Access check for the course lessons.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param bool $show_lessons Whether or not the lessons should be shown. Default true.
+		 * @param int  $course_id    Course ID.
+		 */
+		if ( ! apply_filters( 'sensei_course_lessons_has_access', true, get_the_ID() ) ) {
+			return;
+		}
+
 		global $post;
+
 		$none_module_lessons = Sensei()->modules->get_none_module_lessons( $post->ID );
 		$course_lessons      = Sensei()->course->course_lessons( $post->ID );
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2712,19 +2712,7 @@ class Sensei_Course {
 	 * @since 1.9.0
 	 */
 	public static function the_course_lessons_title() {
-		if ( ! is_singular( 'course' ) ) {
-			return;
-		}
-
-		/**
-		 * Access check for the course lessons.
-		 *
-		 * @since 2.2.0
-		 *
-		 * @param bool $show_lessons Whether or not the lessons should be shown. Default true.
-		 * @param int  $course_id    Course ID.
-		 */
-		if ( ! apply_filters( 'sensei_course_lessons_has_access', true, get_the_ID() ) ) {
+		if ( ! is_singular( 'course' ) || ! Sensei_Utils::show_course_lessons( get_the_ID() ) ) {
 			return;
 		}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1580,6 +1580,17 @@ class Sensei_Core_Modules {
 	 * @return void
 	 */
 	public function load_course_module_content_template() {
+		/**
+		 * Access check for the course lessons.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param bool $show_lessons Whether or not the lessons should be shown. Default true.
+		 * @param int  $course_id    Course ID.
+		 */
+		if ( ! apply_filters( 'sensei_course_lessons_has_access', true, get_the_ID() ) ) {
+			return;
+		}
 
 		// load backwards compatible template name if it exists in the users theme
 		$located_template = locate_template( Sensei()->template_url . 'single-course/course-modules.php' );

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1543,19 +1543,7 @@ class Sensei_Core_Modules {
 	 * @return void
 	 */
 	public function course_modules_title() {
-		if ( ! sensei_module_has_lessons() ) {
-			return;
-		}
-
-		/**
-		 * Access check for the course lessons.
-		 *
-		 * @since 2.2.0
-		 *
-		 * @param bool $show_lessons Whether or not the lessons should be shown. Default true.
-		 * @param int  $course_id    Course ID.
-		 */
-		if ( ! apply_filters( 'sensei_course_lessons_has_access', true, get_the_ID() ) ) {
+		if ( ! sensei_module_has_lessons() || ! Sensei_Utils::show_course_lessons( get_the_ID() ) ) {
 			return;
 		}
 
@@ -1580,15 +1568,7 @@ class Sensei_Core_Modules {
 	 * @return void
 	 */
 	public function load_course_module_content_template() {
-		/**
-		 * Access check for the course lessons.
-		 *
-		 * @since 2.2.0
-		 *
-		 * @param bool $show_lessons Whether or not the lessons should be shown. Default true.
-		 * @param int  $course_id    Course ID.
-		 */
-		if ( ! apply_filters( 'sensei_course_lessons_has_access', true, get_the_ID() ) ) {
+		if ( ! Sensei_Utils::show_course_lessons( get_the_ID() ) ) {
 			return;
 		}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1543,19 +1543,33 @@ class Sensei_Core_Modules {
 	 * @return void
 	 */
 	public function course_modules_title() {
-		if ( sensei_module_has_lessons() ) {
-			global $post;
-
-			/**
-			 * Filters the module title on the single course page.
-			 *
-			 * @since 2.2.0
-			 *
-			 * @param string $html   The HTML to be displayed.
-			 * @param int $course_id Course ID.
-			 */
-			echo wp_kses_post( apply_filters( 'sensei_modules_title', '<header class="modules-title"><h2>' . __( 'Modules', 'sensei-lms' ) . '</h2></header>', $post->ID ) );
+		if ( ! sensei_module_has_lessons() ) {
+			return;
 		}
+
+		/**
+		 * Access check for the course lessons.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param bool $show_lessons Whether or not the lessons should be shown. Default true.
+		 * @param int  $course_id    Course ID.
+		 */
+		if ( ! apply_filters( 'sensei_course_lessons_has_access', true, get_the_ID() ) ) {
+			return;
+		}
+
+		global $post;
+
+		/**
+		 * Filters the module title on the single course page.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param string $html   The HTML to be displayed.
+		 * @param int $course_id Course ID.
+		 */
+		echo wp_kses_post( apply_filters( 'sensei_modules_title', '<header class="modules-title"><h2>' . __( 'Modules', 'sensei-lms' ) . '</h2></header>', $post->ID ) );
 	}
 
 	/**

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2544,6 +2544,27 @@ class Sensei_Utils {
 
 		return ( null !== $filter_to_apply ) ? (bool) apply_filters( $filter_to_apply, $setting_on ) : $setting_on;
 	}
+
+
+	/**
+	 * Determine whether to show the lessons on the single course page.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param int|false $course_id Course ID.
+	 * @return bool Whether to show the lessons. Default true.
+	 */
+	public static function show_course_lessons( $course_id ) {
+		/**
+		 * Set the visibility of lessons on the single course page.
+		 *
+		 * @since 2.2.0
+		 *
+		 * @param bool $show_lessons   Whether the lessons should be shown. Default true.
+		 * @param int|false $course_id Course ID.
+		 */
+		return apply_filters( 'sensei_course_show_lessons', true, $course_id );
+}
 } // End Class
 
 /**

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2564,7 +2564,7 @@ class Sensei_Utils {
 		 * @param int|false $course_id Course ID.
 		 */
 		return apply_filters( 'sensei_course_show_lessons', true, $course_id );
-}
+	}
 } // End Class
 
 /**

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -26,6 +26,17 @@ function sensei_course_archive_next_link( $type = 'newcourses' ) {
 	  * @return void
 	  */
 function course_single_lessons() {
+	/**
+	 * Access check for the course lessons.
+	 *
+	 * @since 2.2.0
+	 *
+	 * @param bool $show_lessons Whether or not the lessons should be shown. Default true.
+	 * @param int  $course_id    Course ID.
+	 */
+	if ( ! apply_filters( 'sensei_course_lessons_has_access', true, get_the_ID() ) ) {
+		return;
+	}
 
 	// load backwards compatible template name if it exists in the users theme
 	$located_template = locate_template( Sensei()->template_url . 'single-course/course-lessons.php' );

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -26,15 +26,7 @@ function sensei_course_archive_next_link( $type = 'newcourses' ) {
 	  * @return void
 	  */
 function course_single_lessons() {
-	/**
-	 * Access check for the course lessons.
-	 *
-	 * @since 2.2.0
-	 *
-	 * @param bool $show_lessons Whether or not the lessons should be shown. Default true.
-	 * @param int  $course_id    Course ID.
-	 */
-	if ( ! apply_filters( 'sensei_course_lessons_has_access', true, get_the_ID() ) ) {
+	if ( ! Sensei_Utils::show_course_lessons( get_the_ID() ) ) {
 		return;
 	}
 


### PR DESCRIPTION
Partial fix for https://github.com/Automattic/sensei-wc-paid-courses/issues/116.

Adds a filter to control the visibility of the lessons on the single course page.

## Testing
- Create a new course and add a module to it.
- Create 2 lessons and add them to the new course. Attach one of the lessons to the module and leave the other lesson unattached to a module.
- Create another new course but don't attach it to any modules. Create 2 lessons for this new course.
- Add the following line to the `functions.php` file of your theme - `add_filter( 'sensei_course_show_lessons', '__return_false' );`
- On the front-end ,browse to the single course page of both courses. Ensure that the modules (if applicable) and lessons **are not** visible.
- Change the line in `functions.php` to - `add_filter( 'sensei_course_show_lessons', '__return_true' );`
- Browse to the single course page of both courses. Ensure that the modules (if applicable) and lessons **are** visible.

## New Filter
`sensei_course_show_lessons `