### PR TITLE
Fix items not showing up on plugin activation via WP CLI

### DIFF
--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -82,7 +82,7 @@ class Sensei_PostTypes {
 		$this->load_posttype_objects( $default_post_types );
 
 		// Admin functions
-		if ( is_admin() ) {
+		if ( is_admin() || defined( 'WP_CLI' ) && WP_CLI ) {
 			$this->set_role_cap_defaults( $default_post_types );
 			global $pagenow;
 			if ( ( $pagenow == 'post.php' || $pagenow == 'post-new.php' ) ) {


### PR DESCRIPTION
On activating the plugin via WP CLI, a lot of functionality wasn't showing up. The root cause was that the role caps were not being set. There's an open issue for this here from a while back https://github.com/Automattic/sensei/issues/1797