### PR TITLE
Set dummy post ID to the next available post ID

### DIFF
--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -110,8 +110,10 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 	 * @return array
 	 */
 	private function generate_dummy_post_args( $object_to_copy ) {
+		global $wpdb;
+
 		$default_args = array(
-			'ID'                    => 0,
+			'ID'                    => absint( $wpdb->get_var( "SELECT MAX( ID ) from {$wpdb->prefix}posts" ) ) + 1,
 			'post_status'           => 'publish',
 			'post_author'           => 0,
 			'post_parent'           => 0,


### PR DESCRIPTION
Fixes #2771 

## The Problem

The Academia theme, as per the issue linked above, seemed to have problems with our theme compatibility code. This stemmed from the fact that when we use a "dummy post" for rendering, we give it an ID of `0`. Something about this made the theme behave unexpectedly.

I traced it through to the fetching of metadata, and I'm thinking it is related to [this code](https://core.trac.wordpress.org/browser/tags/5.2/src/wp-includes/meta.php#L494), which returns `false` instead of an empty string when the object ID is `0`. Also, the theme itself has some conditional logic that checks specifically for an empty string, so when `get_metadata` returns false, it will behave differently than when the meta does not exist (see [#](https://core.trac.wordpress.org/browser/tags/5.2/src/wp-includes/meta.php#L541)).

## The Solution

The solution I'm attempting here is to set the "dummy post" ID to a valid, non-zero number. That said, I do not want to set it to a number that is being used as a valid ID in the database, because I feel like that could cause other problems. Instead, I fetch the largest post ID currently in the database and add 1. This query should only be run once per request (I think?) so the performance penalty should be negligible.

## Testing Instructions

- See #2771 to test on Academia.
- We should test archive pages on several themes to make sure that the ID change doesn't cause some other unexpected behaviour.