### PR TITLE
Do not limit message comments on single post comment feeds

### DIFF
--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -561,6 +561,10 @@ class Sensei_Messages {
 	 * @return string
 	 */
 	public function exclude_message_comments_from_feed_where( $where ) {
+		if ( is_singular() ) {
+			return $where;
+		}
+
 		return $where . ( $where ? ' AND ' : '' ) . " post_type != 'sensei_message' ";
 	}
 


### PR DESCRIPTION
Fixes #2759 

Fixes issue with MySQL error when posts table isn't being joined. When WordPress queries comments for a single post in the feed, it doesn't join with the posts table. Messages themselves shouldn't have comment feeds.

### Testing Instructions
- See issue #2759 for testing instructions. I might have had to add a lesson to the course, but might have just been me.
- Verify private message responses are still hidden in `/comments/feed` (#2726)
- Note: I disabled browser caching while testing this. I also disabled feed caching using this snippet, but not sure if necessary:
```php
add_action( 'wp_feed_options', function ( $feed ) {
	$feed->enable_cache( false );
} );
```