### PR TITLE
Allow HTML in question titles

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -533,7 +533,7 @@ class Sensei_Question {
 		$question_grade = Sensei()->question->get_question_grade( $question_id );
 
 		$title_html  = '<span class="question question-title">';
-		$title_html .= esc_html( $title );
+		$title_html .= wp_kses_post( $title );
 		$title_html .= Sensei()->view_helper->format_question_points( $question_grade );
 		$title_html .= '</span>';
 


### PR DESCRIPTION
Fixes #2779

While investigating this issue it seemed easier to fix it. We started stripping HTML from question titles last year, including HTML that comes from `the_content` filters (such as this LaTeX image). 

One note: Most of the quiz bits are being double `wp_kses`'d right now. We have sanitizers in both methods that get fields and the methods that output fields. I just kept that for now and switched to `wp_kses_post`.

See issue for testing instruction.