### PR TITLE
Update extension parameters passed to Google Analytics

### DIFF
--- a/includes/admin/views/html-admin-page-extensions-results.php
+++ b/includes/admin/views/html-admin-page-extensions-results.php
@@ -20,10 +20,9 @@ if ( empty( $extensions ) ) {
 	foreach ( $extensions as $extension ) {
 		$url = add_query_arg(
 			array(
-				'utm_source'   => 'product',
-				'utm_medium'   => 'extensionpage',
-				'utm_campaign' => 'sensei',
-				'utm_content'  => 'listing',
+				'utm_source'   => str_replace( ['http://', 'https://'], '', get_site_url() ),
+				'utm_medium'   => 'extensions',
+				'utm_campaign' => 'sensei-lms',
 			),
 			$extension->link
 		);

--- a/includes/admin/views/html-admin-page-extensions-results.php
+++ b/includes/admin/views/html-admin-page-extensions-results.php
@@ -20,7 +20,7 @@ if ( empty( $extensions ) ) {
 	foreach ( $extensions as $extension ) {
 		$url = add_query_arg(
 			array(
-				'utm_source'   => str_replace( ['http://', 'https://'], '', get_site_url() ),
+				'utm_source'   => str_replace( [ 'http://', 'https://' ], '', get_site_url() ),
 				'utm_medium'   => 'extensions',
 				'utm_campaign' => 'sensei-lms',
 			),


### PR DESCRIPTION
Start setting `utm_source` to the site URL and `utm_medium` to `extensions`. This will enable easier differentiation between true site referrals and users clicking from the extensions page of Sensei LMS. By logging the URL, we'll be able to see which sites are potentially interested in our extensions.

Related https://github.com/wpcomvip/a8c-senseilms-com/pull/38.

Once the above change is deployed to Sensei LMS.com, it will mean users on older versions of Sensei will start logging _Source / Medium_ as `product / extensionpage`, while users on Sensei LMS 2.2.0 will have it set to `URL / extension`.