### PR TITLE
Remove default wrapper around single post renderer on unsupported theme

### DIFF
--- a/includes/renderers/class-sensei-renderer-single-post.php
+++ b/includes/renderers/class-sensei-renderer-single-post.php
@@ -87,14 +87,15 @@ class Sensei_Renderer_Single_Post implements Sensei_Renderer_Interface {
 		add_filter( 'sensei_show_main_footer', '__return_false' );
 		add_filter( 'sensei_show_main_header', '__return_false' );
 
-		// Even though the header is not being displayed, the action hooked to it still needs to fire.
-		do_action( 'sensei_before_main_content' );
-
 		// We'll make the assumption that the theme will display the title.
 		add_filter( 'the_title', array( $this, 'hide_the_title' ), 100, 2 );
 
 		// Capture output.
 		ob_start();
+
+		// Even though the header is not being displayed, the action hooked to it still needs to fire. Remove default wrapper.
+		remove_action( 'sensei_before_main_content', array( Sensei()->frontend, 'sensei_output_content_wrapper' ) );
+		do_action( 'sensei_before_main_content' );
 
 		// Render the template.
 		Sensei_Templates::get_template( $this->template );


### PR DESCRIPTION
This fixes an issue related to unsupported themes outputting `wrapper-start.php` on pages that use the single post renderer. This removes the `sensei_output_content_wrapper` method on the `sensei_before_main_content` action to prevent conflict with unsupported themes. 

In addition, I moved this block of code below `ob_start()` to prevent any future hook output from displaying during the tests.

### Testing Instructions
- Activate an unsupported theme.
- View the course and lesson pages and make sure tags are correctly nested and the contents of `wrapper-start.php` are not output.
- Run tests and make sure no HTML output is displayed.
- Make sure issue fixed in #2756 is still fixed.