### PR TITLE
Tested up to WordPress 5.3

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, alexsanford1, bor0, donnapep, drawmyface, dwainm, jakeom, jeffikus, lastnode, mattyza, panosktn
 Tags: elearning, lms, learning management system, teach, tutor
 Requires at least: 4.9
-Tested up to: 5.2
+Tested up to: 5.3
 Requires PHP: 5.6
 Stable tag: 2.2.1
 License: GPLv2 or later

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -8,7 +8,7 @@
  * Author URI: https://automattic.com
  * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Requires at least: 4.9
- * Tested up to: 5.2
+ * Tested up to: 5.3
  * Requires PHP: 5.6
  * Text Domain: sensei-lms
  * Domain path: /lang/


### PR DESCRIPTION
Except for #2806, I couldn't find any new major issues with WordPress 5.3.

This bumps the tested version up to 5.3. 