### PR TITLE
Add the Sensei messages REST endpoint

### DIFF
--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -802,7 +802,26 @@ class Sensei_Messages {
 	 * @param $post_id
 	 */
 	public static function the_message_title( $message_post_id ) {
+		?>
+		<h2>
+			<a href="<?php echo esc_url_raw( get_the_permalink( $message_post_id ) ); ?>">
+				<?php echo esc_html( self::get_the_message_title( $message_post_id ) ); ?>
+			</a>
 
+		</h2>
+
+		<?php
+	} //end the_message_header
+
+	/**
+	 * Get the message title that is going to be displayed.
+	 *
+	 * @since 2.3.0
+	 * @param integer $message_post_id The message id.
+	 *
+	 * @return string the message title
+	 */
+	public static function get_the_message_title( $message_post_id ) {
 		$content_post_id = get_post_meta( $message_post_id, '_post', true );
 
 		if ( $content_post_id ) {
@@ -816,16 +835,8 @@ class Sensei_Messages {
 
 		}
 
-		?>
-		<h2>
-			<a href="<?php echo esc_url_raw( get_the_permalink( $message_post_id ) ); ?>">
-				<?php echo esc_html( $title ); ?>
-			</a>
-
-		</h2>
-
-		<?php
-	} //end the_message_header
+		return $title;
+	}
 
 	/**
 	 * Output the message sender given the post id.

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -417,27 +417,30 @@ class Sensei_PostTypes {
 		if ( ! isset( Sensei()->settings->settings['messages_disable'] ) || ! Sensei()->settings->settings['messages_disable'] ) {
 
 			$args = array(
-				'labels'              => $this->create_post_type_labels( $this->labels['sensei_message']['singular'], $this->labels['sensei_message']['plural'], $this->labels['sensei_message']['menu'] ),
-				'public'              => true,
-				'publicly_queryable'  => true,
-				'show_ui'             => true,
-				'show_in_menu'        => 'admin.php?page=sensei',
-				'show_in_nav_menus'   => true,
-				'query_var'           => true,
-				'exclude_from_search' => true,
-				'rewrite'             => array(
+				'labels'                => $this->create_post_type_labels( $this->labels['sensei_message']['singular'], $this->labels['sensei_message']['plural'], $this->labels['sensei_message']['menu'] ),
+				'public'                => true,
+				'publicly_queryable'    => true,
+				'show_ui'               => true,
+				'show_in_menu'          => 'admin.php?page=sensei',
+				'show_in_nav_menus'     => true,
+				'query_var'             => true,
+				'exclude_from_search'   => true,
+				'rewrite'               => array(
 					'slug'       => esc_attr( apply_filters( 'sensei_messages_slug', _x( 'messages', 'post type single slug', 'sensei-lms' ) ) ),
 					'with_front' => false,
 					'feeds'      => false,
 					'pages'      => true,
 				),
-				'map_meta_cap'        => true,
-				'capability_type'     => 'question',
-				'has_archive'         => true,
-				'hierarchical'        => false,
-				'menu_position'       => 50,
-				'supports'            => array( 'title', 'editor', 'comments' ),
-				'delete_with_user'    => true,
+				'map_meta_cap'          => true,
+				'capability_type'       => 'question',
+				'has_archive'           => true,
+				'hierarchical'          => false,
+				'menu_position'         => 50,
+				'show_in_rest'          => true,
+				'rest_base'             => 'sensei-messages',
+				'rest_controller_class' => 'Sensei_REST_API_Messages_Controller',
+				'supports'              => array( 'title', 'editor', 'comments' ),
+				'delete_with_user'      => true,
 			);
 
 			/**

--- a/includes/rest-api/class-sensei-rest-api-messages-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-messages-controller.php
@@ -1,0 +1,170 @@
+<?php
+/**
+ * Sensei REST API: Sensei_REST_API_Messages_Controller class
+ *
+ * @package sensei-lms
+ * @since 2.3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+} // Exit if accessed directly
+
+/**
+ * A REST controller for the Sensei messages.
+ *
+ * @since 2.3.0
+ *
+ * @see WP_REST_Posts_Controller
+ */
+class Sensei_REST_API_Messages_Controller extends WP_REST_Posts_Controller {
+
+	/**
+	 * Constructor.
+	 *
+	 * @param string $post_type Post type.
+	 */
+	public function __construct( $post_type ) {
+		parent::__construct( $post_type );
+
+		// This filter is needed in order for students to be able to see their own messages only.
+		add_filter( 'rest_sensei_message_query', array( $this, 'exclude_others_comments' ), 10, 2 );
+
+		register_rest_field(
+			'sensei_message',
+			'sender',
+			array(
+				'get_callback' => function( $object ) {
+					return get_post_meta( $object['id'], '_sender', true );
+				},
+				'context'      => array( 'view' ),
+				'schema'       => array(
+					'description' => __( 'The username of the message\'s sender.', 'sensei-lms' ),
+					'type'        => 'string',
+				),
+			)
+		);
+
+		register_rest_field(
+			'sensei_message',
+			'displayed_title',
+			array(
+				'get_callback' => function( $object ) {
+					return Sensei_Messages::get_the_message_title( $object['id'] );
+				},
+				'context'      => array( 'view' ),
+				'schema'       => array(
+					'description' => __( 'The message\'s title.', 'sensei-lms' ),
+					'type'        => 'string',
+				),
+			)
+		);
+
+		register_rest_field(
+			'sensei_message',
+			'displayed_date',
+			array(
+				'get_callback' => function( $object ) {
+					return get_the_date( '', $object['id'] );
+				},
+				'context'      => array( 'view' ),
+				'schema'       => array(
+					'description' => __( 'The formatted date that the message was created.', 'sensei-lms' ),
+					'type'        => 'string',
+				),
+			)
+		);
+	}
+
+	/**
+	 * Overrides get_item_schema to add the 'excerpt'. The 'exceprt' is also returned in WP_REST_Posts_Controller but
+	 * only when the post type supports the 'excerpt' feature which we cannot add since it is going to have side effects.
+	 *
+	 * @since 2.3.0
+	 *
+	 * @return array The schema.
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+
+		$schema['properties']['excerpt'] = array(
+			'description' => __( 'The excerpt for the object.', 'sensei-lms' ),
+			'type'        => 'object',
+			'context'     => array( 'view' ),
+			'properties'  => array(
+				'raw'       => array(
+					'description' => __( 'Excerpt for the object, as it exists in the database.', 'sensei-lms' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+				),
+				'rendered'  => array(
+					'description' => __( 'HTML excerpt for the object, transformed for display.', 'sensei-lms' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'protected' => array(
+					'description' => __( 'Whether the excerpt is protected with a password.', 'sensei-lms' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $schema;
+	}
+
+	/**
+	 * Overrides get_collection_params to add the 'sender' argument.
+	 *
+	 * @since 2.3.0
+	 */
+	public function get_collection_params() {
+
+		$query_params = parent::get_collection_params();
+
+		$query_params['sender'] = array(
+			'description'       => __( 'Returns the messages from either all or the current user.', 'sensei-lms' ),
+			'type'              => 'string',
+			'default'           => 'current',
+			'validate_callback' => function ( $value ) {
+
+				if ( in_array( $value, array( 'all', 'current' ), true ) ) {
+					return true;
+				}
+
+				return new WP_Error( 'rest_invalid_param', __( 'Parameter sender can be either current or all', 'sensei-lms' ) );
+			},
+		);
+
+		return $query_params;
+	}
+
+	/**
+	 * This method adds filters to the sensei message query to restrict students to see their own messages only.
+	 *
+	 * @since 2.3.0
+	 * @access private
+	 *
+	 * @param array           $args The query args.
+	 * @param WP_REST_Request $request The current REST request.
+	 * @return array The modified query args.
+	 */
+	public function exclude_others_comments( $args, $request ) {
+
+		if (
+			'all' === $request->get_param( 'sender' ) &&
+			( current_user_can( 'moderate_comments' ) || current_user_can( 'read_private_sensei_messages' ) )
+		) {
+			return $args;
+		}
+
+		$current_user = wp_get_current_user();
+
+		$args['meta_key']   = '_sender'; // phpcs:ignore  Slow query ok.
+		$args['meta_value'] = $current_user->user_login; // phpcs:ignore Slow query ok.
+
+		return $args;
+	}
+}

--- a/tests/unit-tests/rest-api/class-sensei-rest-api-messages-controller.php
+++ b/tests/unit-tests/rest-api/class-sensei-rest-api-messages-controller.php
@@ -1,0 +1,273 @@
+<?php
+/**
+ * Sensei REST API: Sensei_REST_API_Messages_Controller tests
+ *
+ * @package sensei-lms
+ * @since 2.3.0
+ */
+
+/**
+ * Class Sensei_REST_API_Messages_Controller tests.
+ */
+class Sensei_REST_API_Messages_Controller_Tests extends WP_Test_REST_TestCase {
+
+	/**
+	 * A server instance that we use in tests to dispatch requests.
+	 *
+	 * @var WP_REST_Server $server
+	 */
+	protected $server;
+
+	/**
+	 * Test specific setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		do_action( 'rest_api_init' );
+
+		// We need to re-instansiate the controller on each tests to register any hooks.
+		new Sensei_REST_API_Messages_Controller( 'sensei_message' );
+	}
+
+	/**
+	 * Test specific teardown.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+	}
+
+	/**
+	 * Class wide setup.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper factory to create WP objects.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		$teacher_role = new Sensei_Teacher();
+		$teacher_role->create_role();
+	}
+
+
+	/**
+	 * Tests if privileged users can access all messages.
+	 *
+	 * @since 2.3.0
+	 * @covers Sensei_REST_API_Messages_Controller::exclude_others_comments
+	 * @group wip
+	 */
+	public function testPrivilegedUsersCanAccessMessages() {
+
+		$this->factory->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'login',
+			)
+		);
+
+		$this->create_sensei_message( 'Message title', 'login' );
+
+		// Test that a teacher can see all messages when sender=all.
+		$teacher_id = $this->factory->user->create( array( 'role' => 'teacher' ) );
+		wp_set_current_user( $teacher_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/sensei-messages' );
+		$request->set_param( 'sender', 'all' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertCount( 1, $response->get_data(), 'A teacher does not see exactly one message.' );
+		$this->assertEquals( 'Message title', $response->get_data()[0]['displayed_title'] );
+
+		// Test that an administrator can see all messages when sender=all.
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/sensei-messages' );
+		$request->set_param( 'sender', 'all' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertCount( 1, $response->get_data(), 'An administrator does not see exactly one message.' );
+		$this->assertEquals( 'Message title', $response->get_data()[0]['displayed_title'] );
+
+		// Test that an administrator does not see all messages when no sender argument is supplied.
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sensei-messages' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertCount( 0, $response->get_data(), 'Messages are returned for an administrator which didn\'t create any. ' );
+	}
+
+	/**
+	 * Tests if normal users can access only their own messages.
+	 *
+	 * @since 2.3.0
+	 * @covers Sensei_REST_API_Messages_Controller::exclude_others_comments
+	 * @group wip
+	 */
+	public function testUsersCanAccessOwnMessagesOnly() {
+
+		$first_user = $this->factory->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'first',
+			)
+		);
+
+		$this->create_sensei_message( 'First message', 'first' );
+
+		$second_user = $this->factory->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'second',
+			)
+		);
+
+		$this->create_sensei_message( 'Second message', 'second' );
+
+		// Test that the first user can see his own message only.
+		wp_set_current_user( $first_user );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sensei-messages' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertCount( 1, $response->get_data(), 'The first user does not see exactly one message.' );
+		$this->assertEquals( 'First message', $response->get_data()[0]['displayed_title'], 'A user can see other than his own messages.' );
+
+		// Test that the second user can see his own message only.
+		wp_set_current_user( $second_user );
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/sensei-messages' );
+		$request->set_param( 'sender', 'current' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertCount( 1, $response->get_data(), 'The second user does not see exactly one message.' );
+		$this->assertEquals( 'Second message', $response->get_data()[0]['displayed_title'], 'A user can see other than his own messages.' );
+
+		// Test that the sender=all arguments makes no difference.
+		$request->set_param( 'sender', 'all' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertCount( 1, $response->get_data(), 'Sender argument affects output for an unprivileged user.' );
+	}
+
+	/**
+	 * Tests sender and displayed_date elements.
+	 *
+	 * @since 2.3.0
+	 * @covers Sensei_REST_API_Messages_Controller::exclude_others_comments
+	 * @group wip
+	 */
+	public function testSenderAndDateAreCorrect() {
+
+		$first_user = $this->factory->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'first',
+			)
+		);
+
+		$message_id = $this->create_sensei_message( 'Without course', 'first' );
+
+		wp_set_current_user( $first_user );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sensei-messages/' . $message_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 'first', $response->get_data()['sender'] );
+		$this->assertEquals( get_the_date( '', $message_id ), $response->get_data()['displayed_date'] );
+	}
+
+	/**
+	 * Tests the displayed_title element when there is no course linked.
+	 *
+	 * @since 2.3.0
+	 * @covers Sensei_REST_API_Messages_Controller::exclude_others_comments
+	 * @group wip
+	 */
+	public function testDisplayedTitleNoCourse() {
+
+		$first_user = $this->factory->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'first',
+			)
+		);
+
+		$message_without_course = $this->create_sensei_message( 'Without course', 'first' );
+
+		wp_set_current_user( $first_user );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sensei-messages/' . $message_without_course );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 'Without course', $response->get_data()['displayed_title'] );
+	}
+
+	/**
+	 * Tests the displayed_title element when there is a course linked to the message.
+	 *
+	 * @since 2.3.0
+	 * @covers Sensei_REST_API_Messages_Controller::exclude_others_comments
+	 * @group wip
+	 */
+	public function testDisplayedTitleWithCourse() {
+
+		$first_user = $this->factory->user->create(
+			array(
+				'role'       => 'subscriber',
+				'user_login' => 'first',
+			)
+		);
+
+		$message_args = array(
+			'post_type'   => 'course',
+			'post_status' => 'publish',
+			'post_title'  => 'Course title',
+		);
+
+		$course = $this->factory->post->create( $message_args );
+
+		$message_with_course = $this->create_sensei_message( 'Message title', 'first', $course );
+
+		wp_set_current_user( $first_user );
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/sensei-messages/' . $message_with_course );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 'Re: Course title', $response->get_data()['displayed_title'] );
+	}
+
+	/**
+	 * Helper method to create a sensei message.
+	 *
+	 * @param string  $title The messager title.
+	 * @param string  $sender The username of the sender.
+	 * @param integer $course The course id.
+	 *
+	 * @return int The message id
+	 */
+	private function create_sensei_message( $title, $sender, $course = null ) {
+		$message_args = array(
+			'post_type'   => 'sensei_message',
+			'post_status' => 'publish',
+			'post_title'  => $title,
+			'meta_input'  => array(
+				'_sender' => $sender,
+			),
+		);
+
+		if ( null !== $course ) {
+			$message_args['meta_input']['_posttype'] = 'course';
+			$message_args['meta_input']['_post']     = $course;
+		}
+
+		$message_id = $this->factory->post->create( $message_args );
+
+		return $message_id;
+	}
+}


### PR DESCRIPTION
### Overview
With this change we expose a new REST endpoint which returns Sensei messages. The endpoint requires the user to be logged i, and it is going to return his own messages only. Privileged users (capabilities 'moderate_comments' and 'read_private_sensei_messages') can access all messages.

### Example request
(The endpoint should probable be updated)
curl -X OPTIONS -i https://example.com/wp-json/wp/v2/messages 

### Shema
The new endpoint expands the posts endpoint which can be found [here](https://developer.wordpress.org/rest-api/reference/posts). The following elements were added:

| Element  | Description |
| ------------- | ------------- |
| sender | Type: String. The username of the user which sent the message  |
| displayed_title  | Type: String. The message's title.  |
| displayed_date  | Type: Date string. The message creation date. It is formatted according to WP settings. |

### Arguments
Any arguments that exist for the posts endpoint, exist for the messages endpoint too. Additionally, the following arguments are supported:

| Element  | Description |
| ------------- | ------------- |
| sender |  The sender of the returned messages. The value 'current' returns the messages of the logged in user. <br><br>Default: current<br>One of: all, current  |

### Testing
To test the new endpoint you will need to use a tool to send HTTP requests. To imitate a logged in user, you can use a plugin like [this one](https://github.com/WP-API/Basic-Auth). You should then add an 'Authorization' header with a value of 'Basic ' + the Base64 encoded string of username:password.
