### PR TITLE
Fix course duplication prerequisites

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -532,7 +532,7 @@ class Sensei_Admin {
 	 * @param  string $redirect_url URL to redirect the user.
 	 * @return void
 	 */
-	public function safe_redirect( $redirect_url ) {
+	protected function safe_redirect( $redirect_url ) {
 		wp_safe_redirect( esc_url_raw( $redirect_url ) );
 		exit;
 	}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -517,7 +517,7 @@ class Sensei_Admin {
 	}
 
 	/**
-	 * Duplicate course with lessons
+	 * Duplicate course with lessons.
 	 *
 	 * @return void
 	 */
@@ -526,7 +526,7 @@ class Sensei_Admin {
 	}
 
 	/**
-	 * Redirect the user safely
+	 * Redirect the user safely.
 	 *
 	 * @param  string $redirect_url URL to redirect the user.
 	 * @return void
@@ -537,10 +537,10 @@ class Sensei_Admin {
 	}
 
 	/**
-	 * Duplicate content
+	 * Duplicate content.
 	 *
-	 * @param  string  $post_type    Post type being duplicated
-	 * @param  boolean $with_lessons Include lessons or not
+	 * @param  string  $post_type    Post type being duplicated.
+	 * @param  boolean $with_lessons Include lessons or not.
 	 * @return void
 	 */
 	private function duplicate_content( $post_type = 'lesson', $with_lessons = false ) {
@@ -605,14 +605,15 @@ class Sensei_Admin {
 	}
 
 	/**
-	 * Duplicate quizzes inside lessons
+	 * Duplicate quizzes inside lessons.
 	 *
-	 * @param  integer $old_lesson_id ID of original lesson
-	 * @param  integer $new_lesson_id ID of duplicate lesson
+	 * @param  integer $old_lesson_id ID of original lesson.
+	 * @param  integer $new_lesson_id ID of duplicate lesson.
 	 * @return void
 	 */
 	private function duplicate_lesson_quizzes( $old_lesson_id, $new_lesson_id ) {
 		$old_quiz_id = Sensei()->lesson->lesson_quizzes( $old_lesson_id );
+
 		if ( empty( $old_quiz_id ) ) {
 			return;
 		}
@@ -648,7 +649,7 @@ class Sensei_Admin {
 	}
 
 	/**
-	 * Update prerequisite ids after course duplication
+	 * Update prerequisite ids after course duplication.
 	 *
 	 * @param  array $lessons_to_update    List with lesson_id and old_prerequisite_id id to update.
 	 * @param  array $new_lesson_id_lookup History with the id before and after duplication.
@@ -663,7 +664,7 @@ class Sensei_Admin {
 	}
 
 	/**
-	 * Get an prerequisite update object
+	 * Get an prerequisite update object.
 	 *
 	 * @param  integer $old_lesson_id ID of the lesson before the duplication.
 	 * @param  integer $new_lesson_id New ID of the lesson.
@@ -683,7 +684,7 @@ class Sensei_Admin {
 	}
 
 	/**
-	 * Duplicate lessons inside a course
+	 * Duplicate lessons inside a course.
 	 *
 	 * @param  integer $old_course_id ID of original course.
 	 * @param  integer $new_course_id ID of duplicated course.
@@ -710,8 +711,8 @@ class Sensei_Admin {
 			if ( ! is_null( $update_prerequisite_object ) ) {
 				$lessons_to_update[] = $update_prerequisite_object;
 			}
-			$new_lesson_id_lookup[ $lesson->ID ] = $new_lesson->ID;
 
+			$new_lesson_id_lookup[ $lesson->ID ] = $new_lesson->ID;
 			$this->duplicate_lesson_quizzes( $lesson->ID, $new_lesson->ID );
 		}
 
@@ -721,12 +722,12 @@ class Sensei_Admin {
 	}
 
 	/**
-	 * Duplicate post
+	 * Duplicate post.
 	 *
-	 * @param  object  $post          Post to be duplicated
-	 * @param  string  $suffix        Suffix for duplicated post title
-	 * @param  boolean $ignore_course Ignore lesson course when dulicating
-	 * @return object                 Duplicate post object
+	 * @param  object  $post          Post to be duplicated.
+	 * @param  string  $suffix        Suffix for duplicated post title.
+	 * @param  boolean $ignore_course Ignore lesson course when dulicating.
+	 * @return object                 Duplicate post object.
 	 */
 	private function duplicate_post( $post, $suffix = null, $ignore_course = false ) {
 

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -528,6 +528,7 @@ class Sensei_Admin {
 	/**
 	 * Redirect the user safely.
 	 *
+	 * @access private
 	 * @param  string $redirect_url URL to redirect the user.
 	 * @return void
 	 */

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -637,27 +637,27 @@ class Sensei_Admin {
 	/**
 	 * Sync prerequisite ids after course duplication
 	 *
-	 * @param  array $should_update_prerequisite List with lesson_id and old_prerequisite_id id to update
-	 * @param  array $duplication_ids_history    History with the id before and after duplication
+	 * @param  array $should_update_prerequisite List with lesson_id and old_prerequisite_id id to update.
+	 * @param  array $duplication_ids_history    History with the id before and after duplication.
 	 * @return void
 	 */
 	private function prerequisite_sync_ids( $should_update_prerequisite, $duplication_ids_history ) {
 		foreach ( $should_update_prerequisite as $lesson_to_update ) {
-			$old_prerequisite_id = $lesson_to_update[ 'old_prerequisite_id' ];
+			$old_prerequisite_id = $lesson_to_update['old_prerequisite_id'];
 			$new_prerequisite_id = $duplication_ids_history[ $old_prerequisite_id ];
-			update_post_meta( $lesson_to_update[ 'lesson_id' ], '_lesson_prerequisite', $new_prerequisite_id, $old_prerequisite_id );
+			update_post_meta( $lesson_to_update['lesson_id'], '_lesson_prerequisite', $new_prerequisite_id, $old_prerequisite_id );
 		}
 	}
 
 	/**
 	 * Get an update prerequisite object
 	 *
-	 * @param  integer $new_lesson_id List with lesson_id and old_prerequisite_id id to update
-	 * @return array                  Object with the id of the lesson to update and its old prerequisite id
+	 * @param  integer $new_lesson_id List with lesson_id and old_prerequisite_id id to update.
+	 * @return array                  Object with the id of the lesson to update and its old prerequisite id.
 	 */
 	private function get_update_prerequisite_object( $new_lesson_id ) {
 		$lesson_prerequisite = get_post_meta( $new_lesson_id, '_lesson_prerequisite', true );
-		if ( $lesson_prerequisite !== '' ) {
+		if ( '' !== $lesson_prerequisite ) {
 			return array(
 				'lesson_id'           => $new_lesson_id,
 				'old_prerequisite_id' => $lesson_prerequisite,
@@ -669,12 +669,12 @@ class Sensei_Admin {
 	/**
 	 * Duplicate lessons inside a course
 	 *
-	 * @param  integer $old_course_id ID of original course
-	 * @param  integer $new_course_id ID of duplicated course
+	 * @param  integer $old_course_id ID of original course.
+	 * @param  integer $new_course_id ID of duplicated course.
 	 * @return int Number of lessons duplicated.
 	 */
 	private function duplicate_course_lessons( $old_course_id, $new_course_id ) {
-		$lesson_args = array(
+		$lesson_args                = array(
 			'post_type'        => 'lesson',
 			'posts_per_page'   => -1,
 			'meta_key'         => '_lesson_course',
@@ -693,7 +693,7 @@ class Sensei_Admin {
 			if ( ! is_null( $update_prerequisite_object ) ) {
 				$should_update_prerequisite[] = $update_prerequisite_object;
 			}
-			$duplication_ids_history[$lesson->ID] = $new_lesson->ID;
+			$duplication_ids_history[ $lesson->ID ] = $new_lesson->ID;
 
 			$this->duplicate_lesson_quizzes( $lesson->ID, $new_lesson->ID );
 		}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -645,18 +645,19 @@ class Sensei_Admin {
 		foreach ( $should_update_prerequisite as $lesson_to_update ) {
 			$old_prerequisite_id = $lesson_to_update['old_prerequisite_id'];
 			$new_prerequisite_id = $duplication_ids_history[ $old_prerequisite_id ];
-			update_post_meta( $lesson_to_update['lesson_id'], '_lesson_prerequisite', $new_prerequisite_id, $old_prerequisite_id );
+			add_post_meta( $lesson_to_update['lesson_id'], '_lesson_prerequisite', $new_prerequisite_id );
 		}
 	}
 
 	/**
 	 * Get an update prerequisite object
 	 *
-	 * @param  integer $new_lesson_id List with lesson_id and old_prerequisite_id id to update.
+	 * @param  integer $old_lesson_id ID of the lesson before the duplication.
+	 * @param  integer $new_lesson_id New ID of the lesson.
 	 * @return array                  Object with the id of the lesson to update and its old prerequisite id.
 	 */
-	private function get_update_prerequisite_object( $new_lesson_id ) {
-		$lesson_prerequisite = get_post_meta( $new_lesson_id, '_lesson_prerequisite', true );
+	private function get_update_prerequisite_object( $old_lesson_id, $new_lesson_id ) {
+		$lesson_prerequisite = get_post_meta( $old_lesson_id, '_lesson_prerequisite', true );
 		if ( '' !== $lesson_prerequisite ) {
 			return array(
 				'lesson_id'           => $new_lesson_id,
@@ -689,7 +690,7 @@ class Sensei_Admin {
 			$new_lesson = $this->duplicate_post( $lesson, '', true );
 			add_post_meta( $new_lesson->ID, '_lesson_course', $new_course_id );
 
-			$update_prerequisite_object = $this->get_update_prerequisite_object( $new_lesson->ID );
+			$update_prerequisite_object = $this->get_update_prerequisite_object( $lesson->ID, $new_lesson->ID );
 			if ( ! is_null( $update_prerequisite_object ) ) {
 				$should_update_prerequisite[] = $update_prerequisite_object;
 			}
@@ -751,7 +752,7 @@ class Sensei_Admin {
 			$post_meta = get_post_custom( $post->ID );
 			if ( $post_meta && count( $post_meta ) > 0 ) {
 
-				$ignore_meta = array( '_quiz_lesson', '_quiz_id', '_lesson_quiz' );
+				$ignore_meta = array( '_quiz_lesson', '_quiz_id', '_lesson_quiz', '_lesson_prerequisite' );
 
 				if ( $ignore_course ) {
 					$ignore_meta[] = '_lesson_course';

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -612,7 +612,11 @@ class Sensei_Admin {
 	 * @return void
 	 */
 	private function duplicate_lesson_quizzes( $old_lesson_id, $new_lesson_id ) {
-		$old_quiz_id        = Sensei()->lesson->lesson_quizzes( $old_lesson_id );
+		$old_quiz_id = Sensei()->lesson->lesson_quizzes( $old_lesson_id );
+		if ( empty( $old_quiz_id ) ) {
+			return;
+		}
+
 		$old_quiz_questions = Sensei()->lesson->lesson_quiz_questions( $old_quiz_id );
 
 		// duplicate the generic wp post information

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -671,12 +671,14 @@ class Sensei_Admin {
 	 */
 	private function get_prerequisite_update_object( $old_lesson_id, $new_lesson_id ) {
 		$lesson_prerequisite = get_post_meta( $old_lesson_id, '_lesson_prerequisite', true );
+
 		if ( ! empty( $lesson_prerequisite ) ) {
 			return array(
 				'lesson_id'           => $new_lesson_id,
 				'old_prerequisite_id' => $lesson_prerequisite,
 			);
 		}
+
 		return null;
 	}
 
@@ -704,6 +706,7 @@ class Sensei_Admin {
 			add_post_meta( $new_lesson->ID, '_lesson_course', $new_course_id );
 
 			$update_prerequisite_object = $this->get_prerequisite_update_object( $lesson->ID, $new_lesson->ID );
+
 			if ( ! is_null( $update_prerequisite_object ) ) {
 				$lessons_to_update[] = $update_prerequisite_object;
 			}
@@ -711,6 +714,7 @@ class Sensei_Admin {
 
 			$this->duplicate_lesson_quizzes( $lesson->ID, $new_lesson->ID );
 		}
+
 		$this->update_lesson_prerequisite_ids( $lessons_to_update, $new_lesson_id_lookup );
 
 		return count( $lessons );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -526,6 +526,17 @@ class Sensei_Admin {
 	}
 
 	/**
+	 * Redirect the user safely
+	 *
+	 * @param  string $redirect_url URL to redirect the user.
+	 * @return void
+	 */
+	public function safe_redirect( $redirect_url ) {
+		wp_safe_redirect( esc_url_raw( $redirect_url ) );
+		exit;
+	}
+
+	/**
 	 * Duplicate content
 	 *
 	 * @param  string  $post_type    Post type being duplicated
@@ -589,8 +600,7 @@ class Sensei_Admin {
 				sensei_log_event( $event, $event_properties );
 			}
 
-			wp_safe_redirect( esc_url_raw( $redirect_url ) );
-			exit;
+			$this->safe_redirect( $redirect_url );
 		}
 	}
 
@@ -602,7 +612,6 @@ class Sensei_Admin {
 	 * @return void
 	 */
 	private function duplicate_lesson_quizzes( $old_lesson_id, $new_lesson_id ) {
-
 		$old_quiz_id        = Sensei()->lesson->lesson_quizzes( $old_lesson_id );
 		$old_quiz_questions = Sensei()->lesson->lesson_quiz_questions( $old_quiz_id );
 

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -658,7 +658,7 @@ class Sensei_Admin {
 	 */
 	private function get_update_prerequisite_object( $old_lesson_id, $new_lesson_id ) {
 		$lesson_prerequisite = get_post_meta( $old_lesson_id, '_lesson_prerequisite', true );
-		if ( '' !== $lesson_prerequisite ) {
+		if ( ! empty( $lesson_prerequisite ) ) {
 			return array(
 				'lesson_id'           => $new_lesson_id,
 				'old_prerequisite_id' => $lesson_prerequisite,

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -285,6 +285,7 @@ class Sensei_Lesson {
 			'order'            => 'ASC',
 			'exclude'          => $post->ID,
 			'suppress_filters' => 0,
+			'post_status'      => [ 'publish', 'draft' ],
 		);
 		$posts_array = get_posts( $post_args );
 		// Build the HTML to Output

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -285,7 +285,7 @@ class Sensei_Lesson {
 			'order'            => 'ASC',
 			'exclude'          => $post->ID,
 			'suppress_filters' => 0,
-			'post_status'      => ['publish', 'draft'],
+			'post_status'      => [ 'publish', 'draft' ],
 		);
 		$posts_array = get_posts( $post_args );
 		// Build the HTML to Output
@@ -295,8 +295,8 @@ class Sensei_Lesson {
 			$html .= '<select id="lesson-prerequisite-options" name="lesson_prerequisite" class="chosen_select widefat" style="width: 100%">' . "\n";
 			$html .= '<option value="">' . esc_html__( 'None', 'sensei-lms' ) . '</option>';
 			foreach ( $posts_array as $post_item ) {
-				$draft_mark = $post_item->post_status === 'draft' ? ' — '. esc_html__( 'Draft', 'sensei-lms' ) : '';
-				$html .= '<option value="' . esc_attr( absint( $post_item->ID ) ) . '"' . selected( $post_item->ID, $select_lesson_prerequisite, false ) . '>' . esc_html( $post_item->post_title ) . $draft_mark . '</option>' . "\n";
+				$draft_mark = 'draft' === $post_item->post_status ? ' — ' . esc_html__( 'Draft', 'sensei-lms' ) : '';
+				$html      .= '<option value="' . esc_attr( absint( $post_item->ID ) ) . '"' . selected( $post_item->ID, $select_lesson_prerequisite, false ) . '>' . esc_html( $post_item->post_title ) . $draft_mark . '</option>' . "\n";
 			} // End For Loop
 			$html .= '</select>' . "\n";
 		} else {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -285,7 +285,6 @@ class Sensei_Lesson {
 			'order'            => 'ASC',
 			'exclude'          => $post->ID,
 			'suppress_filters' => 0,
-			'post_status'      => [ 'publish', 'draft' ],
 		);
 		$posts_array = get_posts( $post_args );
 		// Build the HTML to Output
@@ -295,8 +294,7 @@ class Sensei_Lesson {
 			$html .= '<select id="lesson-prerequisite-options" name="lesson_prerequisite" class="chosen_select widefat" style="width: 100%">' . "\n";
 			$html .= '<option value="">' . esc_html__( 'None', 'sensei-lms' ) . '</option>';
 			foreach ( $posts_array as $post_item ) {
-				$draft_mark = 'draft' === $post_item->post_status ? ' — ' . esc_html__( 'Draft', 'sensei-lms' ) : '';
-				$html      .= '<option value="' . esc_attr( absint( $post_item->ID ) ) . '"' . selected( $post_item->ID, $select_lesson_prerequisite, false ) . '>' . esc_html( $post_item->post_title ) . $draft_mark . '</option>' . "\n";
+				$html .= '<option value="' . esc_attr( absint( $post_item->ID ) ) . '"' . selected( $post_item->ID, $select_lesson_prerequisite, false ) . '>' . esc_html( $post_item->post_title ) . '</option>' . "\n";
 			} // End For Loop
 			$html .= '</select>' . "\n";
 		} else {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -285,6 +285,7 @@ class Sensei_Lesson {
 			'order'            => 'ASC',
 			'exclude'          => $post->ID,
 			'suppress_filters' => 0,
+			'post_status'      => ['publish', 'draft'],
 		);
 		$posts_array = get_posts( $post_args );
 		// Build the HTML to Output
@@ -294,7 +295,8 @@ class Sensei_Lesson {
 			$html .= '<select id="lesson-prerequisite-options" name="lesson_prerequisite" class="chosen_select widefat" style="width: 100%">' . "\n";
 			$html .= '<option value="">' . esc_html__( 'None', 'sensei-lms' ) . '</option>';
 			foreach ( $posts_array as $post_item ) {
-				$html .= '<option value="' . esc_attr( absint( $post_item->ID ) ) . '"' . selected( $post_item->ID, $select_lesson_prerequisite, false ) . '>' . esc_html( $post_item->post_title ) . '</option>' . "\n";
+				$draft_mark = $post_item->post_status === 'draft' ? ' — '. esc_html__( 'Draft', 'sensei-lms' ) : '';
+				$html .= '<option value="' . esc_attr( absint( $post_item->ID ) ) . '"' . selected( $post_item->ID, $select_lesson_prerequisite, false ) . '>' . esc_html( $post_item->post_title ) . $draft_mark . '</option>' . "\n";
 			} // End For Loop
 			$html .= '</select>' . "\n";
 		} else {

--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -14,6 +14,8 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 	 *
 	 * This function sets up the lessons, quizes and their questions. This function runs before
 	 * every single test in this class
+	 *
+	 * @return void
 	 */
 	public function setup() {
 		parent::setup();
@@ -28,6 +30,8 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 
 	/**
 	 * Testing the admin class to make sure it is loaded
+	 *
+	 * @return void
 	 */
 	public function testClassInstance() {
 		// test if the class exists
@@ -35,18 +39,15 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 	} // end testClassInstance
 
 	/**
-	 * Test duplicate courses with lessons.
+	 * Setup function for duplicate course
 	 *
-	 * @covers WooThemes_Sensei_Admin::duplicate_course_with_lessons_action
+	 * This function mocks the redirect method, create and set the user, create a course
+	 * with some lessons and set the needed params.
+	 *
+	 * @param $qty_lessons How many lessons to create.
+	 * @return array       Created course and list of lessons id.
 	 */
-	public function testDuplicateCourseWithLessons() {
-		$qty_lessons = 2;
-
-		$this->assertTrue(
-			method_exists( 'WooThemes_Sensei_Admin', 'duplicate_course_with_lessons_action' ),
-			'The admin class function `duplicate_course_with_lessons_action` does not exist '
-		);
-
+	private function duplicate_course_with_lessons_setup( $qty_lessons ) {
 		// Mock the safe_redirect method
 		Sensei()->admin = $this->getMockBuilder( 'WooThemes_Sensei_Admin' )
 			->setMethods( [ 'safe_redirect' ] )
@@ -65,50 +66,114 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 		);
 		wp_set_current_user( $admin_user->ID );
 
-		$course_id  = $this->factory->course->create();
-		$lesson_ids = $this->factory->lesson->create_many( $qty_lessons );
-		foreach ( $lesson_ids as $lesson_id ) {
+		// Create one course and add some lessons
+		$course_id   = $this->factory->course->create();
+		$lessons_ids = $this->factory->lesson->create_many( $qty_lessons );
+
+		foreach ( $lessons_ids as $lesson_id ) {
 			add_post_meta( $lesson_id, '_lesson_course', $course_id );
 		}
 
-		// Add the first lesson as prerequisite of the second one
-		add_post_meta( $lesson_ids[1], '_lesson_prerequisite', $lesson_ids[0] );
-
-		// Create nonce to pass in the method
+		// Create nonce
 		$duplicate_nonce = wp_create_nonce( 'duplicate_course_with_lessons_' . $course_id );
 
 		// Set request and get params
 		$_REQUEST['_wpnonce'] = $duplicate_nonce;
 		$_GET['post']         = $course_id;
 
+		return array(
+			'course_id'   => $course_id,
+			'lessons_ids' => $lessons_ids,
+		);
+	}
+
+	/**
+	 * Test duplicate courses with lessons.
+	 *
+	 * @covers WooThemes_Sensei_Admin::duplicate_course_with_lessons_action
+	 *
+	 * @return void
+	 */
+	public function testDuplicateCourseWithLessons() {
+		$this->assertTrue(
+			method_exists( 'WooThemes_Sensei_Admin', 'duplicate_course_with_lessons_action' ),
+			'The admin class function `duplicate_course_with_lessons_action` does not exist '
+		);
+
+		$qty_lessons = 2;
+		$duplication = $this->duplicate_course_with_lessons_setup( $qty_lessons );
+		$course_id   = $duplication['course_id'];
+		$lessons_ids = $duplication['lessons_ids'];
+
 		// Runs the duplication
 		Sensei()->admin->duplicate_course_with_lessons_action();
 
-		// Get duplicated course (all in draft)
-		$course_args   = array(
+		// Get the duplicated course
+		$duplicated_course_args = array(
 			'post_type'   => 'course',
+			'meta_key'    => '_duplicate', // phpcs:ignore Slow query ok.
+			'meta_value'  => $course_id, // phpcs:ignore Slow query ok.
 			'post_status' => [ 'draft' ],
 		);
-		$courses       = get_posts( $course_args );
-		$new_course_id = $courses[0]->ID;
+		$duplicated_courses     = get_posts( $duplicated_course_args );
+		$duplicated_course_id   = $duplicated_courses[0]->ID;
 
-		// Get the lessons of the duplicated post
-		$lesson_args = array(
+		// Get duplicated lessons
+		$duplicated_lesson_args = array(
 			'post_type'   => 'lesson',
 			'meta_key'    => '_lesson_course', // phpcs:ignore Slow query ok.
-			'meta_value'  => $new_course_id, // phpcs:ignore Slow query ok.
+			'meta_value'  => $duplicated_course_id, // phpcs:ignore Slow query ok.
 			'post_status' => [ 'draft' ],
 		);
-		$lessons     = get_posts( $lesson_args );
+		$duplicated_lessons     = get_posts( $duplicated_lesson_args );
 
-		// Lessons assertation
-		$this->assertCount( $qty_lessons, $lessons, 'The number of lessons duplicated should be the same that the original.' );
-
-		// Prerequisite assertation
-		$first_lesson_prerequisite  = get_post_meta( $lessons[0]->ID, '_lesson_prerequisite', true );
-		$second_lesson_prerequisite = get_post_meta( $lessons[1]->ID, '_lesson_prerequisite', true );
-		$this->assertEquals( $first_lesson_prerequisite, '', 'The first lesson prerequisite should be empty.' );
-		$this->assertEquals( $second_lesson_prerequisite, $lessons[0]->ID, 'The second lesson prerequisite should be the first duplicated lesson.' );
+		// Lessons assertion
+		$this->assertCount( $qty_lessons, $duplicated_lessons, 'The number of duplicated lessons should be the same as the original.' );
 	}
 
+	/**
+	 * Test duplicate courses with lessons with prerequisite.
+	 *
+	 * @covers WooThemes_Sensei_Admin::duplicate_course_with_lessons_action
+	 *
+	 * @return void
+	 */
+	public function testDuplicateCourseWithLessonsWithPrerequisite() {
+		$qty_lessons = 2;
+		$duplication = $this->duplicate_course_with_lessons_setup( $qty_lessons );
+		$course_id   = $duplication['course_id'];
+		$lessons_ids = $duplication['lessons_ids'];
+
+		// Add the first lesson as prerequisite of the second one
+		add_post_meta( $lessons_ids[1], '_lesson_prerequisite', $lessons_ids[0] );
+
+		// Runs the duplication
+		Sensei()->admin->duplicate_course_with_lessons_action();
+
+		// Get the duplicated prerequisite lesson
+		$duplicated_prerequisite_lesson_args = array(
+			'post_type'   => 'lesson',
+			'meta_key'    => '_duplicate', // phpcs:ignore Slow query ok.
+			'meta_value'  => $lessons_ids[0], // phpcs:ignore Slow query ok.
+			'post_status' => [ 'draft' ],
+		);
+		$duplicated_prerequisite_lesson      = get_posts( $duplicated_prerequisite_lesson_args );
+		$duplicated_prerequisite_lesson_id   = $duplicated_prerequisite_lesson[0]->ID;
+
+		// Get the duplicated dependent lesson
+		$duplicated_dependent_lesson_args = array(
+			'post_type'   => 'lesson',
+			'meta_key'    => '_duplicate', // phpcs:ignore Slow query ok.
+			'meta_value'  => $lessons_ids[1], // phpcs:ignore Slow query ok.
+			'post_status' => [ 'draft' ],
+		);
+		$duplicated_dependent_lesson      = get_posts( $duplicated_dependent_lesson_args );
+		$duplicated_dependent_lesson_id   = $duplicated_dependent_lesson[0]->ID;
+
+		// Get the prerequisite id
+		$new_prerequisite_id = get_post_meta( $duplicated_dependent_lesson_id, '_lesson_prerequisite', true );
+
+		// Prerequisite assertion
+		$this->assertEquals( $duplicated_prerequisite_lesson_id, $new_prerequisite_id, 'The duplicated dependent should have the duplicated prerequisite as its prerequisite.' );
+	}
 }//end class

--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -71,7 +71,7 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 			add_post_meta( $lesson_id, '_lesson_course', $course_id );
 		}
 
-		// Add prerequisite
+		// Add the first lesson as prerequisite of the second one
 		add_post_meta( $lesson_ids[1], '_lesson_prerequisite', $lesson_ids[0] );
 
 		// Create nonce to pass in the method
@@ -105,8 +105,10 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 		$this->assertCount( $qty_lessons, $lessons, 'The number of lessons duplicated should be the same that the original.' );
 
 		// Prerequisite assertation
-		$new_prerequisite = get_post_meta( $lessons[1]->ID, '_lesson_prerequisite', true );
-		$this->assertEquals( $lessons[0]->ID, $new_prerequisite, 'The prerequisite post meta should update after the duplication.' );
+		$first_lesson_prerequisite  = get_post_meta( $lessons[0]->ID, '_lesson_prerequisite', true );
+		$second_lesson_prerequisite = get_post_meta( $lessons[1]->ID, '_lesson_prerequisite', true );
+		$this->assertEquals( $first_lesson_prerequisite, '', 'The first lesson prerequisite should be empty.' );
+		$this->assertEquals( $second_lesson_prerequisite, $lessons[0]->ID, 'The second lesson prerequisite should be the first duplicated lesson.' );
 	}
 
 }//end class

--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -34,14 +34,21 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 	/**
 	 * Test duplicate courses with lessons.
 	 *
-	 * @covers WooThemes_Sensei_Admin::duplicate_course_with_lessons_action
+	 * @uses WooThemes_Sensei_Admin::duplicate_course_with_lessons_action
+	 * @uses WooThemes_Sensei_Admin::duplicate_content
+	 * @uses WooThemes_Sensei_Admin::duplicate_post
+	 * @uses WooThemes_Sensei_Admin::update_lesson_prerequisite_ids
+	 * @uses WooThemes_Sensei_Admin::get_prerequisite_update_object
+	 * @uses WooThemes_Sensei_Admin::duplicate_lesson_quizzes
+	 *
+	 * @covers WooThemes_Sensei_Admin::duplicate_course_lessons
 	 *
 	 * @return void
 	 */
 	public function testDuplicateCourseWithLessons() {
 		$this->assertTrue(
-			method_exists( 'WooThemes_Sensei_Admin', 'duplicate_course_with_lessons_action' ),
-			'The admin class function `duplicate_course_with_lessons_action` does not exist '
+			method_exists( 'WooThemes_Sensei_Admin', 'duplicate_course_lessons' ),
+			'The admin class function `duplicate_course_lessons` does not exist '
 		);
 
 		$qty_lessons = 2;
@@ -78,11 +85,27 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 	/**
 	 * Test duplicate courses with lessons with prerequisite.
 	 *
-	 * @covers WooThemes_Sensei_Admin::duplicate_course_with_lessons_action
+	 * @uses WooThemes_Sensei_Admin::duplicate_course_with_lessons_action
+	 * @uses WooThemes_Sensei_Admin::duplicate_content
+	 * @uses WooThemes_Sensei_Admin::duplicate_course_lessons
+	 * @uses WooThemes_Sensei_Admin::duplicate_post
+	 * @uses WooThemes_Sensei_Admin::duplicate_lesson_quizzes
+	 *
+	 * @covers WooThemes_Sensei_Admin::update_lesson_prerequisite_ids
+	 * @covers WooThemes_Sensei_Admin::get_prerequisite_update_object
 	 *
 	 * @return void
 	 */
 	public function testDuplicateCourseWithLessonsWithPrerequisite() {
+		$this->assertTrue(
+			method_exists( 'WooThemes_Sensei_Admin', 'duplicate_course_lessons' ),
+			'The admin class function `update_lesson_prerequisite_ids` does not exist '
+		);
+		$this->assertTrue(
+			method_exists( 'WooThemes_Sensei_Admin', 'duplicate_course_lessons' ),
+			'The admin class function `get_prerequisite_update_object` does not exist '
+		);
+
 		$qty_lessons = 2;
 		$duplication = $this->duplicate_course_with_lessons_setup( $qty_lessons );
 		$course_id   = $duplication['course_id'];

--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -3,17 +3,10 @@
 class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 
 	/**
-	 * Constructor function
-	 */
-	public function __construct() { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
-		parent::__construct();
-	}
-
-	/**
-	 * Setup function
+	 * Setup function.
 	 *
-	 * This function sets up the lessons, quizes and their questions. This function runs before
-	 * every single test in this class
+	 * This function sets up the lessons, quizes and their questions.
+	 * This function runs before every single test in this class.
 	 *
 	 * @return void
 	 */
@@ -29,7 +22,7 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Testing the admin class to make sure it is loaded
+	 * Testing the admin class to make sure it is loaded.
 	 *
 	 * @return void
 	 */
@@ -37,55 +30,6 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 		// test if the class exists
 		$this->assertTrue( class_exists( 'WooThemes_Sensei_Admin' ), 'Sensei Admin class does not exist' );
 	} // end testClassInstance
-
-	/**
-	 * Setup function for duplicate course
-	 *
-	 * This function mocks the redirect method, create and set the user, create a course
-	 * with some lessons and set the needed params.
-	 *
-	 * @param $qty_lessons How many lessons to create.
-	 * @return array       Created course and list of lessons id.
-	 */
-	private function duplicate_course_with_lessons_setup( $qty_lessons ) {
-		// Mock the safe_redirect method
-		Sensei()->admin = $this->getMockBuilder( 'WooThemes_Sensei_Admin' )
-			->setMethods( [ 'safe_redirect' ] )
-			->getMock();
-
-		Sensei()->admin->expects( $this->once() )
-			->method( 'safe_redirect' );
-
-		// Create and set current user as teacher
-		$admin_user = $this->factory->user->create_and_get(
-			array(
-				'user_login' => 'admin_user',
-				'user_pass'  => null,
-				'role'       => 'teacher',
-			)
-		);
-		wp_set_current_user( $admin_user->ID );
-
-		// Create one course and add some lessons
-		$course_id   = $this->factory->course->create();
-		$lessons_ids = $this->factory->lesson->create_many( $qty_lessons );
-
-		foreach ( $lessons_ids as $lesson_id ) {
-			add_post_meta( $lesson_id, '_lesson_course', $course_id );
-		}
-
-		// Create nonce
-		$duplicate_nonce = wp_create_nonce( 'duplicate_course_with_lessons_' . $course_id );
-
-		// Set request and get params
-		$_REQUEST['_wpnonce'] = $duplicate_nonce;
-		$_GET['post']         = $course_id;
-
-		return array(
-			'course_id'   => $course_id,
-			'lessons_ids' => $lessons_ids,
-		);
-	}
 
 	/**
 	 * Test duplicate courses with lessons.
@@ -175,5 +119,54 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 
 		// Prerequisite assertion
 		$this->assertEquals( $duplicated_prerequisite_lesson_id, $new_prerequisite_id, 'The duplicated dependent should have the duplicated prerequisite as its prerequisite.' );
+	}
+
+	/**
+	 * Setup function for duplicate course.
+	 *
+	 * This function mocks the redirect method, create and set the user, create a course
+	 * with some lessons and set the needed params.
+	 *
+	 * @param $qty_lessons How many lessons to create.
+	 * @return array       Created course and list of lessons id.
+	 */
+	private function duplicate_course_with_lessons_setup( $qty_lessons ) {
+		// Mock the safe_redirect method
+		Sensei()->admin = $this->getMockBuilder( 'WooThemes_Sensei_Admin' )
+			->setMethods( [ 'safe_redirect' ] )
+			->getMock();
+
+		Sensei()->admin->expects( $this->once() )
+			->method( 'safe_redirect' );
+
+		// Create and set current user as teacher
+		$admin_user = $this->factory->user->create_and_get(
+			array(
+				'user_login' => 'admin_user',
+				'user_pass'  => null,
+				'role'       => 'teacher',
+			)
+		);
+		wp_set_current_user( $admin_user->ID );
+
+		// Create one course and add some lessons
+		$course_id   = $this->factory->course->create();
+		$lessons_ids = $this->factory->lesson->create_many( $qty_lessons );
+
+		foreach ( $lessons_ids as $lesson_id ) {
+			add_post_meta( $lesson_id, '_lesson_course', $course_id );
+		}
+
+		// Create nonce
+		$duplicate_nonce = wp_create_nonce( 'duplicate_course_with_lessons_' . $course_id );
+
+		// Set request and get params
+		$_REQUEST['_wpnonce'] = $duplicate_nonce;
+		$_GET['post']         = $course_id;
+
+		return array(
+			'course_id'   => $course_id,
+			'lessons_ids' => $lessons_ids,
+		);
 	}
 }//end class

--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -81,8 +81,10 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 		$_REQUEST['_wpnonce'] = $duplicate_nonce;
 		$_GET['post']         = $course_id;
 
+		// Runs the duplication
 		Sensei()->admin->duplicate_course_with_lessons_action();
 
+		// Get duplicated course (all in draft)
 		$course_args   = array(
 			'post_type'   => 'course',
 			'post_status' => [ 'draft' ],
@@ -90,6 +92,7 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 		$courses       = get_posts( $course_args );
 		$new_course_id = $courses[0]->ID;
 
+		// Get the lessons of the duplicated post
 		$lesson_args = array(
 			'post_type'   => 'lesson',
 			'meta_key'    => '_lesson_course', // phpcs:ignore Slow query ok.
@@ -98,8 +101,10 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 		);
 		$lessons     = get_posts( $lesson_args );
 
+		// Lessons assertation
 		$this->assertCount( $qty_lessons, $lessons, 'The number of lessons duplicated should be the same that the original.' );
 
+		// Prerequisite assertation
 		$new_prerequisite = get_post_meta( $lessons[1]->ID, '_lesson_prerequisite', true );
 		$this->assertEquals( $lessons[0]->ID, $new_prerequisite, 'The prerequisite post meta should update after the duplication.' );
 	}

--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -1,0 +1,101 @@
+<?php
+
+class Sensei_Class_Admin_Test extends WP_UnitTestCase {
+
+	/**
+	 * Constructor function
+	 */
+	public function __construct() {
+		parent::__construct();
+	}
+
+	/**
+	 * Setup function
+	 *
+	 * This function sets up the lessons, quizes and their questions. This function runs before
+	 * every single test in this class
+	 */
+	public function setup() {
+		parent::setup();
+
+		$this->factory = new Sensei_Factory();
+	}//end setup()
+
+	public function tearDown() {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
+
+	/**
+	 * Testing the admin class to make sure it is loaded
+	 */
+	public function testClassInstance() {
+		// test if the class exists
+		$this->assertTrue( class_exists( 'WooThemes_Sensei_Admin' ), 'Sensei Admin class does not exist' );
+	} // end testClassInstance
+
+	/**
+	 * Test duplicate courses with lessons.
+	 *
+	 * @covers WooThemes_Sensei_Admin::duplicate_course_with_lessons_action
+	 */
+	public function testDuplicateCourseWithLessons() {
+		$qty_lessons = 2;
+
+		$this->assertTrue(
+			method_exists( 'WooThemes_Sensei_Admin', 'duplicate_course_with_lessons_action' ),
+			'The admin class function `duplicate_course_with_lessons_action` does not exist '
+		);
+
+		// Mock the safe_redirect method
+		Sensei()->admin = $this->getMockBuilder( 'WooThemes_Sensei_Admin' )
+			->setMethods( [ 'safe_redirect' ] )
+			->getMock();
+
+		Sensei()->admin->expects( $this->once() )
+			->method( 'safe_redirect' );
+
+		// Create and set current user as teacher
+		$admin_user = $this->factory->user->create_and_get( array( 'user_login' => 'admin_user', 'user_pass' => null, 'role' => 'teacher' ) );
+		wp_set_current_user( $admin_user->ID );
+
+		$course_id  = $this->factory->course->create();
+		$lesson_ids = $this->factory->lesson->create_many( $qty_lessons );
+		foreach ( $lesson_ids as $lesson_id ) {
+			add_post_meta( $lesson_id, '_lesson_course', $course_id );
+		}
+
+		// Add prerequisite
+		add_post_meta( $lesson_ids[1], '_lesson_prerequisite', $lesson_ids[0] );
+
+		// Create nonce to pass in the method
+		$duplicate_nonce = wp_create_nonce( 'duplicate_course_with_lessons_' . $course_id );
+
+		// Set request and get params
+		$_REQUEST['_wpnonce'] = $duplicate_nonce;
+		$_GET['post']         = $course_id;
+
+		Sensei()->admin->duplicate_course_with_lessons_action();
+
+		$course_args   = array(
+			'post_type'   => 'course',
+			'post_status' => [ 'draft' ],
+		);
+		$courses       = get_posts( $course_args );
+		$new_course_id = $courses[0]->ID;
+
+		$lesson_args = array(
+			'post_type'   => 'lesson',
+			'meta_key'    => '_lesson_course',
+			'meta_value'  => $new_course_id,
+			'post_status' => [ 'draft' ],
+		);
+		$lessons     = get_posts( $lesson_args );
+
+		$this->assertCount( $qty_lessons, $lessons, 'The number of lessons duplicated should be the same that the original.' );
+
+		$new_prerequisite = get_post_meta( $lessons[1]->ID, '_lesson_prerequisite', true );
+		$this->assertEquals( $lessons[0]->ID, $new_prerequisite, 'The prerequisite post meta should update after the duplication.' );
+	}
+
+}//end class

--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -5,7 +5,7 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 	/**
 	 * Constructor function
 	 */
-	public function __construct() {
+	public function __construct() { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
 		parent::__construct();
 	}
 
@@ -56,7 +56,13 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 			->method( 'safe_redirect' );
 
 		// Create and set current user as teacher
-		$admin_user = $this->factory->user->create_and_get( array( 'user_login' => 'admin_user', 'user_pass' => null, 'role' => 'teacher' ) );
+		$admin_user = $this->factory->user->create_and_get(
+			array(
+				'user_login' => 'admin_user',
+				'user_pass'  => null,
+				'role'       => 'teacher',
+			)
+		);
 		wp_set_current_user( $admin_user->ID );
 
 		$course_id  = $this->factory->course->create();
@@ -86,8 +92,8 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 
 		$lesson_args = array(
 			'post_type'   => 'lesson',
-			'meta_key'    => '_lesson_course',
-			'meta_value'  => $new_course_id,
+			'meta_key'    => '_lesson_course', // phpcs:ignore Slow query ok.
+			'meta_value'  => $new_course_id, // phpcs:ignore Slow query ok.
 			'post_status' => [ 'draft' ],
 		);
 		$lessons     = get_posts( $lesson_args );


### PR DESCRIPTION
Fixes #2819 

## Description

When a course was duplicated, the lessons' prerequisites kept pointing to the original prerequisite. Now we update the prerequisite to the new lesson (duplicated) on the duplication process.

## Testing Instructions

- Create a course with two lessons, where Lesson One is a prerequisite of Lesson Two.
- Duplicate the course, with lessons.

## Observation

This PR originated another issue for lessons as a draft: https://github.com/Automattic/sensei/issues/2822