### PR TITLE
Fix lessons duplication order

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -692,14 +692,7 @@ class Sensei_Admin {
 	 * @return int Number of lessons duplicated.
 	 */
 	private function duplicate_course_lessons( $old_course_id, $new_course_id ) {
-		$lesson_args          = array(
-			'post_type'        => 'lesson',
-			'posts_per_page'   => -1,
-			'meta_key'         => '_lesson_course',
-			'meta_value'       => $old_course_id,
-			'suppress_filters' => 0,
-		);
-		$lessons              = get_posts( $lesson_args );
+		$lessons              = Sensei()->course->course_lessons( $old_course_id );
 		$new_lesson_id_lookup = array();
 		$lessons_to_update    = array();
 


### PR DESCRIPTION
Fixes #2777 

### Description

After duplicating a course with lessons, it was saving the lessons on a reversed order. It was fixed changing from `get_posts` to `course->course_lessons`, which has the correct sort logic.

### Testing Instructions

1. Create a course. Add a Lesson 1 and a Lesson 2 to the course.
2. View course edit screen. See lesson order in Course Lessons section:
![image](https://user-images.githubusercontent.com/1990037/64519419-fb7e0b80-d2eb-11e9-8a29-a6ff95173891.png)

3. Duplicate the course (with lessons).
4. Open edit screen for new course and see lesson order
Screenshot prior the fix:
![image](https://user-images.githubusercontent.com/1990037/64519518-2ff1c780-d2ec-11e9-8c48-eca0c4490600.png)

### Observation

During the work on this PR, I identified this issue: #2828
I decided to open a new issue for that to not to extend the work on this PR, considering that this only dirty the database.