### PR TITLE
[WIP] WPML support to course subscription and lesson progress

### DIFF
--- a/includes/class-sensei-emails.php
+++ b/includes/class-sensei-emails.php
@@ -42,10 +42,10 @@ class Sensei_Emails {
 
 		// Hooks for sending emails during Sensei events
 		add_action( 'sensei_user_quiz_grade', array( $this, 'learner_graded_quiz' ), 10, 4 );
-		add_action( 'sensei_course_status_updated', array( $this, 'learner_completed_course' ), 10, 4 );
-		add_action( 'sensei_course_status_updated', array( $this, 'teacher_completed_course' ), 10, 4 );
+		add_action( 'sensei_course_status_updated', array( $this, 'learner_completed_course' ), 10, 6 );
+		add_action( 'sensei_course_status_updated', array( $this, 'teacher_completed_course' ), 10, 6 );
 		add_action( 'sensei_user_course_start', array( $this, 'teacher_started_course' ), 10, 2 );
-		add_action( 'sensei_user_lesson_end', array( $this, 'teacher_completed_lesson' ), 10, 2 );
+		add_action( 'sensei_user_lesson_end', array( $this, 'teacher_completed_lesson' ), 10, 3 );
 		add_action( 'sensei_user_quiz_submitted', array( $this, 'teacher_quiz_submitted' ), 10, 5 );
 		add_action( 'sensei_new_private_message', array( $this, 'teacher_new_message' ), 10, 1 );
 		add_action( 'sensei_private_message_reply', array( $this, 'new_message_reply' ), 10, 2 );

--- a/includes/class-sensei-emails.php
+++ b/includes/class-sensei-emails.php
@@ -242,14 +242,20 @@ class Sensei_Emails {
 	}
 
 	/**
-	 * Send email to learner on course completion
+	 * Send email to learner on course completion.
 	 *
 	 * @access public
+	 * @param  string $status
+	 * @param  int    $user_id
+	 * @param  int    $course_id
+	 * @param  int    $comment_id
+	 * @param  array  $metadata
+	 * @param  bool   $replicating_lang Flag if the status is being replicated for another language.
 	 * @return void
 	 */
-	function learner_completed_course( $status = 'in-progress', $user_id = 0, $course_id = 0, $comment_id = 0 ) {
+	public function learner_completed_course( $status = 'in-progress', $user_id = 0, $course_id = 0, $comment_id = 0, $metadata = array(), $replicating_lang = false ) {
 
-		if ( 'complete' != $status ) {
+		if ( 'complete' != $status || $replicating_lang ) {
 			return;
 		}
 
@@ -270,14 +276,20 @@ class Sensei_Emails {
 	}
 
 	/**
-	 * Send email to teacher on course completion
+	 * Send email to teacher on course completion.
 	 *
 	 * @access public
+	 * @param  string $status
+	 * @param  int    $learner_id
+	 * @param  int    $course_id
+	 * @param  int    $comment_id
+	 * @param  array  $metadata
+	 * @param  bool   $replicating_lang Flag if the status is being replicated for another language.
 	 * @return void
 	 */
-	function teacher_completed_course( $status = 'in-progress', $learner_id = 0, $course_id = 0, $comment_id = 0 ) {
+	public function teacher_completed_course( $status = 'in-progress', $learner_id = 0, $course_id = 0, $comment_id = 0, $metadata = array(), $replicating_lang = false ) {
 
-		if ( 'complete' != $status ) {
+		if ( 'complete' != $status || $replicating_lang ) {
 			return;
 		}
 
@@ -322,15 +334,20 @@ class Sensei_Emails {
 	}
 
 	/**
-	 * teacher_completed_lesson()
-	 *
-	 * Send email to teacher on student completing lesson
+	 * Send email to teacher on student completing lesson.
 	 *
 	 * @access public
+	 * @param  int  $learner_id
+	 * @param  int  $lesson_id
+	 * @param  bool $replicating_lang Flag if the status is being replicated for another language.
 	 * @return void
-	 * @since 1.9.0
+	 * @since  1.9.0
 	 */
-	function teacher_completed_lesson( $learner_id = 0, $lesson_id = 0 ) {
+	public function teacher_completed_lesson( $learner_id = 0, $lesson_id = 0, $replicating_lang = false ) {
+
+		if ( $replicating_lang ) {
+			return;
+		}
 
 		$send = false;
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -728,7 +728,7 @@ class Sensei_Utils {
 			$status   = 'in-progress';
 
 			// Note: When this action runs the lesson status may not yet exist.
-			do_action( 'sensei_user_lesson_start', $user_id, $lesson_id, $complete );
+			do_action( 'sensei_user_lesson_start', $user_id, $lesson_id );
 
 			if ( $complete ) {
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -767,7 +767,7 @@ class Sensei_Utils {
 
 			if ( $complete ) {
 				// Run this *after* the lesson status has been created/updated
-				do_action( 'sensei_user_lesson_end', $user_id, $lesson_id );
+				do_action( 'sensei_user_lesson_end', $user_id, $lesson_id, $replicating_lang );
 			}
 		}
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1972,13 +1972,14 @@ class Sensei_Utils {
 	 *
 	 * @access public
 	 * @since  1.7.0
-	 * @param int    $user_id
-	 * @param int    $course_id
-	 * @param string $status
-	 * @param array  $metadata
-	 * @return mixed false or comment_ID
+	 * @param  int    $user_id
+	 * @param  int    $course_id
+	 * @param  string $status
+	 * @param  array  $metadata
+	 * @param  bool   $replicating_lang Flag if the status is being replicated for another language.
+	 * @return mixed                    false or comment_ID.
 	 */
-	public static function update_course_status( $user_id, $course_id, $status = 'in-progress', $metadata = array() ) {
+	public static function update_course_status( $user_id, $course_id, $status = 'in-progress', $metadata = array(), $replicating_lang = false ) {
 		$comment_id = false;
 		if ( ! empty( $status ) ) {
 			$args = array(
@@ -1999,7 +2000,8 @@ class Sensei_Utils {
 					update_comment_meta( $comment_id, $key, $value );
 				}
 			}
-			do_action( 'sensei_course_status_updated', $status, $user_id, $course_id, $comment_id );
+
+			do_action( 'sensei_course_status_updated', $status, $user_id, $course_id, $comment_id, $metadata, $replicating_lang );
 		}
 		return $comment_id;
 	}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1938,10 +1938,10 @@ class Sensei_Utils {
 	 * @param int|string $lesson_id
 	 * @param string     $status
 	 * @param array      $metadata
-	 *
-	 * @return mixed false or comment_ID
+	 * @param bool       $replicating_lang Flag if the status is being replicated for another language.
+	 * @return mixed                       false or comment_ID.
 	 */
-	public static function update_lesson_status( $user_id, $lesson_id, $status = 'in-progress', $metadata = array() ) {
+	public static function update_lesson_status( $user_id, $lesson_id, $status = 'in-progress', $metadata = array(), $replicating_lang = false ) {
 		$comment_id = false;
 		if ( ! empty( $status ) ) {
 			$args = array(
@@ -1963,7 +1963,7 @@ class Sensei_Utils {
 				}
 			}
 
-			do_action( 'sensei_lesson_status_updated', $status, $user_id, $lesson_id, $comment_id );
+			do_action( 'sensei_lesson_status_updated', $status, $user_id, $lesson_id, $comment_id, $metadata, $replicating_lang );
 		}
 		return $comment_id;
 	}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -700,13 +700,14 @@ class Sensei_Utils {
 	 *
 	 * @since 1.6.0
 	 *
-	 * @param  integer     $lesson_id ID of lesson
-	 * @param int| string $user_id default 0
-	 * @param bool        $complete default false
+	 * @param integer    $lesson_id        ID of lesson.
+	 * @param int|string $user_id          default 0.
+	 * @param bool       $complete         default false.
+	 * @param bool       $replicating_lang default false. Flag if the status is being replicated for another language.
 	 *
 	 * @return mixed boolean or comment_ID
 	 */
-	public static function sensei_start_lesson( $lesson_id = 0, $user_id = 0, $complete = false ) {
+	public static function sensei_start_lesson( $lesson_id = 0, $user_id = 0, $complete = false, $replicating_lang = false ) {
 
 		if ( intval( $user_id ) == 0 ) {
 			$user_id = get_current_user_id();
@@ -727,8 +728,8 @@ class Sensei_Utils {
 			$metadata = array();
 			$status   = 'in-progress';
 
-			// Note: When this action runs the lesson status may not yet exist
-			do_action( 'sensei_user_lesson_start', $user_id, $lesson_id );
+			// Note: When this action runs the lesson status may not yet exist.
+			do_action( 'sensei_user_lesson_start', $user_id, $lesson_id, $complete, $replicating_lang );
 
 			if ( $complete ) {
 

--- a/includes/wpml/class-sensei-wpml.php
+++ b/includes/wpml/class-sensei-wpml.php
@@ -4,6 +4,7 @@ class Sensei_WPML {
 		add_action( 'sensei_before_mail', array( $this, 'sensei_before_mail' ) );
 		add_action( 'sensei_after_sending_email', array( $this, 'sensei_after_sending_email' ) );
 		add_action( 'sensei_course_status_updated', array( $this, 'sensei_course_status_updated' ), 10, 6 );
+		add_action( 'sensei_lesson_status_updated', array( $this, 'sensei_lesson_status_updated' ), 10, 6 );
 		add_action( 'sensei_user_lesson_start', array( $this, 'sensei_user_lesson_start' ), 10, 4 );
 	}
 
@@ -66,6 +67,37 @@ class Sensei_WPML {
 			}
 
 			Sensei_Utils::update_course_status( $user_id, $item->element_id, $status, $metadata, true );
+		}
+	}
+
+	/**
+	 * Start the lesson for the user on all languages.
+	 *
+	 * @param string $status
+	 * @param int    $user_id
+	 * @param int    $lesson_id
+	 * @param array  $comment_id
+	 * @param array  $metadata
+	 * @param bool   $replicating_lang Flag if the content is being replicated for another language.
+	 * @return void
+	 */
+	public function sensei_lesson_status_updated( $status, $user_id, $lesson_id, $comment_id, $metadata, $replicating_lang ) {
+		if ( $replicating_lang ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$trid                 = apply_filters( 'wpml_element_trid', null, $lesson_id );
+		$element_translations = apply_filters( 'wpml_get_element_translations', [], $trid );
+		// phpcs:enable
+
+		foreach ( $element_translations as $item ) {
+			// Skip the original update.
+			if ( (int) $item->element_id === (int) $lesson_id ) {
+				continue;
+			}
+
+			Sensei_Utils::update_lesson_status( $user_id, $item->element_id, $status, $metadata, true );
 		}
 	}
 

--- a/includes/wpml/class-sensei-wpml.php
+++ b/includes/wpml/class-sensei-wpml.php
@@ -56,7 +56,7 @@ class Sensei_WPML {
 
 		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$trid                 = apply_filters( 'wpml_element_trid', null, $course_id );
-		$element_translations = apply_filters( 'wpml_get_element_translations', null, $trid );
+		$element_translations = apply_filters( 'wpml_get_element_translations', [], $trid );
 		// phpcs:enable
 
 		foreach ( $element_translations as $item ) {
@@ -86,7 +86,7 @@ class Sensei_WPML {
 
 		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 		$trid                 = apply_filters( 'wpml_element_trid', null, $lesson_id );
-		$element_translations = apply_filters( 'wpml_get_element_translations', null, $trid );
+		$element_translations = apply_filters( 'wpml_get_element_translations', [], $trid );
 		// phpcs:enable
 
 		foreach ( $element_translations as $item ) {

--- a/includes/wpml/class-sensei-wpml.php
+++ b/includes/wpml/class-sensei-wpml.php
@@ -4,6 +4,7 @@ class Sensei_WPML {
 		add_action( 'sensei_before_mail', array( $this, 'sensei_before_mail' ) );
 		add_action( 'sensei_after_sending_email', array( $this, 'sensei_after_sending_email' ) );
 		add_action( 'sensei_course_status_updated', array( $this, 'sensei_course_status_updated' ), 10, 6 );
+		add_action( 'sensei_user_lesson_start', array( $this, 'sensei_user_lesson_start' ), 10, 4 );
 	}
 
 	public function sensei_before_mail( $email_address ) {
@@ -65,6 +66,36 @@ class Sensei_WPML {
 			}
 
 			Sensei_Utils::update_course_status( $user_id, $item->element_id, $status, $metadata, true );
+		}
+	}
+
+	/**
+	 * Replicate lesson status for all languages.
+	 *
+	 * @param int  $user_id
+	 * @param int  $lesson_id
+	 * @param bool $complete
+	 * @param bool $replicating_lang Flag if the status is being replicated for another language.
+	 * @return void
+	 */
+	public function sensei_user_lesson_start( $user_id, $lesson_id, $complete, $replicating_lang ) {
+		// Prevent to replicate the replication.
+		if ( $replicating_lang ) {
+			return;
+		}
+
+		// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
+		$trid                 = apply_filters( 'wpml_element_trid', null, $lesson_id );
+		$element_translations = apply_filters( 'wpml_get_element_translations', null, $trid );
+		// phpcs:enable
+
+		foreach ( $element_translations as $item ) {
+			// Skip the original update.
+			if ( (int) $item->element_id === (int) $lesson_id ) {
+				continue;
+			}
+
+			Sensei_Utils::sensei_start_lesson( $item->element_id, $user_id, $complete, true );
 		}
 	}
 }

--- a/includes/wpml/class-sensei-wpml.php
+++ b/includes/wpml/class-sensei-wpml.php
@@ -5,7 +5,7 @@ class Sensei_WPML {
 		add_action( 'sensei_after_sending_email', array( $this, 'sensei_after_sending_email' ) );
 		add_action( 'sensei_course_status_updated', array( $this, 'sensei_course_status_updated' ), 10, 6 );
 		add_action( 'sensei_lesson_status_updated', array( $this, 'sensei_lesson_status_updated' ), 10, 6 );
-		add_action( 'sensei_user_lesson_start', array( $this, 'sensei_user_lesson_start' ), 10, 4 );
+		add_action( 'sensei_started_lesson_completed', array( $this, 'sensei_started_lesson_completed' ), 10, 5 );
 	}
 
 	public function sensei_before_mail( $email_address ) {
@@ -104,13 +104,14 @@ class Sensei_WPML {
 	/**
 	 * Replicate lesson status for all languages.
 	 *
-	 * @param int  $user_id
-	 * @param int  $lesson_id
-	 * @param bool $complete
-	 * @param bool $replicating_lang Flag if the status is being replicated for another language.
+	 * @param int    $lesson_id
+	 * @param int    $user_id
+	 * @param string $status
+	 * @param bool   $complete
+	 * @param bool   $replicating_lang Flag if the status is being replicated for another language.
 	 * @return void
 	 */
-	public function sensei_user_lesson_start( $user_id, $lesson_id, $complete, $replicating_lang ) {
+	public function sensei_started_lesson_completed( $lesson_id, $user_id, $status, $complete, $replicating_lang ) {
 		// Prevent to replicate the replication.
 		if ( $replicating_lang ) {
 			return;
@@ -127,7 +128,7 @@ class Sensei_WPML {
 				continue;
 			}
 
-			Sensei_Utils::sensei_start_lesson( $item->element_id, $user_id, $complete, true );
+			Sensei_Utils::complete_lesson( $item->element_id, $user_id, $status, $complete, true );
 		}
 	}
 }

--- a/includes/wpml/class-sensei-wpml.php
+++ b/includes/wpml/class-sensei-wpml.php
@@ -3,9 +3,33 @@ class Sensei_WPML {
 	public function __construct() {
 		add_action( 'sensei_before_mail', array( $this, 'sensei_before_mail' ) );
 		add_action( 'sensei_after_sending_email', array( $this, 'sensei_after_sending_email' ) );
-		add_action( 'sensei_course_status_updated', array( $this, 'sensei_course_status_updated' ), 10, 6 );
-		add_action( 'sensei_lesson_status_updated', array( $this, 'sensei_lesson_status_updated' ), 10, 6 );
-		add_action( 'sensei_started_lesson_completed', array( $this, 'sensei_started_lesson_completed' ), 10, 5 );
+
+		add_action( 'init', array( $this, 'init_hook' ), 13 );
+	}
+
+	/**
+	 * Method to run on the init action.
+	 *
+	 * @return void
+	 */
+	public function init_hook() {
+		/**
+		 * Replicate user progress for all languages hook.
+		 *
+		 * This can affect other hooks behavior. The following actions will run for
+		 * all translation content throught WPML:
+		 * sensei_course_status_updated, sensei_lesson_status_updated,
+		 * sensei_user_lesson_end and sensei_started_lesson_completed.
+		 *
+		 * @since 2.3.0
+		 *
+		 * @param bool $replicate_progress If progress should be replicated for all languages.
+		 */
+		if ( apply_filters( 'sensei_wpml_replicate_user_progress_for_all_languages', false ) ) {
+			add_action( 'sensei_course_status_updated', array( $this, 'sensei_course_status_updated' ), 10, 6 );
+			add_action( 'sensei_lesson_status_updated', array( $this, 'sensei_lesson_status_updated' ), 10, 6 );
+			add_action( 'sensei_started_lesson_completed', array( $this, 'sensei_started_lesson_completed' ), 10, 5 );
+		}
 	}
 
 	public function sensei_before_mail( $email_address ) {

--- a/includes/wpml/class-sensei-wpml.php
+++ b/includes/wpml/class-sensei-wpml.php
@@ -146,6 +146,9 @@ class Sensei_WPML {
 		$element_translations = apply_filters( 'wpml_get_element_translations', [], $trid );
 		// phpcs:enable
 
+		global $sitepress;
+		// Fix for the Sensei_Utils::sensei_check_for_activity receive the comments from all languages.
+		remove_filter( 'comments_clauses', array( $sitepress, 'comments_clauses' ) );
 		foreach ( $element_translations as $item ) {
 			// Skip the original update.
 			if ( (int) $item->element_id === (int) $lesson_id ) {
@@ -154,5 +157,7 @@ class Sensei_WPML {
 
 			Sensei_Utils::complete_lesson( $item->element_id, $user_id, $status, $complete, true );
 		}
+		// Re-enable the filter.
+		add_filter( 'comments_clauses', array( $sitepress, 'comments_clauses' ), 10, 2 );
 	}
 }


### PR DESCRIPTION
Fixes #2788

#### Changes proposed in this Pull Request:

* If the user subscribe on a course that has other languages, he subscribes for all languages.
* If the user progresses on lessons that has other languages, the status will be replicated for all languages.
* Add a new filter: `sensei_wpml_replicate_user_progress_for_all_languages` to active this behavior. This filter was added because it can cause some hooks side effects (mentioned below)

#### Site effects:

* Now some events will happen multiple times (one for each language). For our use of the actions, on some cases it's expected (e.g. update status after lesson change), for others not (e.g. send an email on completing a course). To solve this, we added the flag `$replicating_lang` to the `sensei_course_status_updated`, `sensei_lesson_status_updated`, `sensei_user_lesson_end`, and `sensei_started_lesson_completed` actions.

#### Other considered alternatives:

* It was considered instead of replicate all the status, always fetch the status from the main language. But it would be much more intrusive on the code and complex.
* It was considered to prevent all the `do_action` when replicating the progress, but in some cases, it is expected. So we transferred this responsibility to the actions itself.

#### Testing instructions:

* Install / activate the WPML plugin
* Add the filter to activate the replication progress for other languages (It can be added in the `function.php` of the theme)
```php
function sensei_wpml_replicate_user_progress_for_all_languages() {
	return true;
}
add_filter( 'sensei_wpml_replicate_user_progress_for_all_languages', 'sensei_wpml_replicate_user_progress_for_all_languages' );
```
* Create a course with a lesson
* Translate the course and the lesson for other languages
  * Some instructions about how to translate: https://wpml.org/announcements/2018/10/sensei/ (it's out of date, but gives the basic idea)
* Subscribe to the course and check if you're subscribed on all languages
* Complete the lesson and check if it's completed for all languages

<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:

* Add WPML support to course subscription and lesson progress. It can be activated through the filter `sensei_wpml_replicate_user_progress_for_all_languages` with a `true` as parameter.
  * **Warning:** Now some progress events will happen multiple times (one for each language), so maybe some actions should not work as expected, like to send an email while completing a course - It would send one email for each language. For these cases, we updated the `sensei_course_status_updated`, `sensei_lesson_status_updated`, `sensei_user_lesson_end`, and `sensei_started_lesson_completed` actions, adding a last argument which is the flag `$replicating_lang`. This flag means that the action is being called from a replication.