### PR TITLE
Add clear background to TinyMCE buttons

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -411,7 +411,7 @@ class Sensei_Utils {
 			'editor_class'  => 'sensei_text_editor',
 			'teeny'         => false,
 			'dfw'           => false,
-			'editor_css'    => '<style> .mce-top-part button { background-color: rgba(0,0,0,0.0) !important; } </style>',
+			'editor_css'    => '<style> .mce-top-part button { background-color: rgba(0,0,0,0); } </style>',
 			'tinymce'       => array(
 				'theme_advanced_buttons1' => $buttons,
 				'theme_advanced_buttons2' => '',

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -411,6 +411,7 @@ class Sensei_Utils {
 			'editor_class'  => 'sensei_text_editor',
 			'teeny'         => false,
 			'dfw'           => false,
+			'editor_css'    => '<style> .mce-top-part button { background-color: rgba(0,0,0,0.0) !important; } </style>',
 			'tinymce'       => array(
 				'theme_advanced_buttons1' => $buttons,
 				'theme_advanced_buttons2' => '',


### PR DESCRIPTION
This PR adds a clear background to the TinyMCE buttons.

Testing instructions:
1. Go to a quiz that has a multi line question.
2. The buttons in the TinyMCE editor should not have the TwentyTwenty colors; they should have a clear background.