### PR TITLE
Fix/issue 2832 Prevent comments from being displayed if user isn't allowed to view lesson

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4325,9 +4325,9 @@ class Sensei_Lesson {
 			return;
 		}
 
-		$allow_comments     = Sensei()->settings->settings['lesson_comments'];
-		$has_access         = ! Sensei()->settings->get( 'access_permission' );
-		$is_preview         = Sensei_Utils::is_preview_lesson( $post->ID );
+		$allow_comments       = Sensei()->settings->settings['lesson_comments'];
+		$has_access           = ! Sensei()->settings->get( 'access_permission' );
+		$is_preview           = Sensei_Utils::is_preview_lesson( $post->ID );
 		$user_can_view_lesson = sensei_can_user_view_lesson();
 
 		$lesson_allow_comments = $allow_comments && ( $user_can_view_lesson || $has_access || $is_preview );

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4329,6 +4329,7 @@ class Sensei_Lesson {
 		$user_taking_course = Sensei_Utils::user_started_course( $course_id );
 		$has_access         = ! Sensei()->settings->get( 'access_permission' );
 		$is_preview         = Sensei_Utils::is_preview_lesson( $post->ID );
+		$user_can_view_lesson = sensei_can_user_view_lesson();
 
 		$lesson_allow_comments = $allow_comments && ( $user_taking_course || $has_access || $is_preview );
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4326,11 +4326,9 @@ class Sensei_Lesson {
 		}
 
 		$allow_comments       = Sensei()->settings->settings['lesson_comments'];
-		$has_access           = ! Sensei()->settings->get( 'access_permission' );
-		$is_preview           = Sensei_Utils::is_preview_lesson( $post->ID );
 		$user_can_view_lesson = sensei_can_user_view_lesson();
 
-		$lesson_allow_comments = $allow_comments && ( $user_can_view_lesson || $has_access || $is_preview );
+		$lesson_allow_comments = $allow_comments && $user_can_view_lesson;
 
 		if ( $lesson_allow_comments || is_singular( 'sensei_message' ) ) {
 			comments_template( '', true );

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4326,12 +4326,11 @@ class Sensei_Lesson {
 		}
 
 		$allow_comments     = Sensei()->settings->settings['lesson_comments'];
-		$user_taking_course = Sensei_Utils::user_started_course( $course_id );
 		$has_access         = ! Sensei()->settings->get( 'access_permission' );
 		$is_preview         = Sensei_Utils::is_preview_lesson( $post->ID );
 		$user_can_view_lesson = sensei_can_user_view_lesson();
 
-		$lesson_allow_comments = $allow_comments && ( $user_taking_course || $has_access || $is_preview );
+		$lesson_allow_comments = $allow_comments && ( $user_can_view_lesson || $has_access || $is_preview );
 
 		if ( $lesson_allow_comments || is_singular( 'sensei_message' ) ) {
 			comments_template( '', true );


### PR DESCRIPTION
Fixes #2832 

On line 4333 of the `class-sensei-lesson.php` file we can see that the conditions used for displaying comments are the following: 
`$lesson_allow_comments = $allow_comments && ( $user_taking_course || $has_access || $is_preview );`

This means that if the user is taking the course (`$user_taking_course`) comments will be displayed. What this PR does is change this "user_is_taking_course" logic to a "user_can_view_lesson" logic. 
This should prevent comments from being displayed if user can't view that lesson. 
For the "user_can_view_lesson" logic, this PR uses the Sensei `sensei_can_user_view_lesson()` function.


### Testing instructions:
1. Create a course with 2 lessons.
2. Make Lesson 1 a prerequisite of Lesson 2.
3. Start taking the course.
4. Complete Lesson 1.
5. Add a comment to Lesson 2.
6. Log in as a different user.
7. Start taking the course, but don't complete Lesson 1.
8. View lesson 2. You'll see "You must first complete Lesson 1 before viewing this Lesson"
9. You should not be able to see any comments nor create a new one
