### PR TITLE
Fix count warning

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1073,7 +1073,7 @@ class Sensei_Question {
 
 				// determine if the current option must be checked
 				$checked = '';
-				if ( isset( $question_data['user_answer_entry'] ) && 0 < count( $question_data['user_answer_entry'] ) ) {
+				if ( isset( $question_data['user_answer_entry'] ) ) {
 					if ( is_array( $question_data['user_answer_entry'] ) && in_array( $answer, $question_data['user_answer_entry'] ) ) {
 
 						$checked = 'checked="checked"';


### PR DESCRIPTION
Fixes issue raised in [here](https://wordpress.org/support/topic/php-error-359/)

#### Changes proposed in this Pull Request:
Removed a 0 < count() check which caused a PHP warning. The check
had no impact as count() will return a falsy value if the input is
NULL or an empty array. If $question_data value is NULL then isset
will fail while if the array is empty then no branch of the next if
will be executed.

#### Testing instructions:
1. Navigate to a multiple question quiz.
2. Answer and complete the quiz.
3. Observe that no warnings are displayed and nothing is broken.

#### Proposed changelog entry for your changes:
Remove PHP warning from multiple choice questions.
