### PR TITLE
Introduce enrolment manager

### DIFF
--- a/includes/class-sensei-course-enrolment-manager.php
+++ b/includes/class-sensei-course-enrolment-manager.php
@@ -128,7 +128,7 @@ class Sensei_Course_Enrolment_Manager {
 	public static function reset_site_salt() {
 		$new_salt = md5( uniqid() );
 
-		\update_option( self::COURSE_ENROLMENT_SITE_SALT_OPTION, $new_salt, true );
+		update_option( self::COURSE_ENROLMENT_SITE_SALT_OPTION, $new_salt, true );
 
 		return $new_salt;
 	}

--- a/includes/class-sensei-course-enrolment-manager.php
+++ b/includes/class-sensei-course-enrolment-manager.php
@@ -91,7 +91,7 @@ class Sensei_Course_Enrolment_Manager {
 	 * @param string $provider_id Unique identifier of the enrolment provider.
 	 *
 	 * @return string|false
-	 * @throws Exception When there was an attempt to access enrolment providers before collected in init:100.
+	 * @throws Exception When there was an attempt to access enrolment providers before they are collected in init:100.
 	 */
 	public function get_enrolment_provider_name_by_id( $provider_id ) {
 		$provider = $this->get_enrolment_provider_by_id( $provider_id );
@@ -110,7 +110,7 @@ class Sensei_Course_Enrolment_Manager {
 	 * @param string $provider_id Unique identifier of the enrolment provider.
 	 *
 	 * @return Sensei_Course_Enrolment_Provider_Interface|false
-	 * @throws Exception When there was an attempt to access enrolment providers before collected in init:100.
+	 * @throws Exception When there was an attempt to access enrolment providers before they are collected in init:100.
 	 */
 	public function get_enrolment_provider_by_id( $provider_id ) {
 		$all_providers = $this->get_all_enrolment_providers();
@@ -145,7 +145,7 @@ class Sensei_Course_Enrolment_Manager {
 	 * Get an array of all the instantiated course enrolment providers.
 	 *
 	 * @return Sensei_Course_Enrolment_Provider_Interface[]
-	 * @throws Exception When there was an attempt to access enrolment providers before collected in init:100.
+	 * @throws Exception When there was an attempt to access enrolment providers before they are collected in init:100.
 	 */
 	public function get_all_enrolment_providers() {
 		if ( ! isset( $this->enrolment_providers ) ) {

--- a/includes/class-sensei-course-enrolment-manager.php
+++ b/includes/class-sensei-course-enrolment-manager.php
@@ -136,10 +136,10 @@ class Sensei_Course_Enrolment_Manager {
 	/**
 	 * Trigger course enrolment check when enrolment might have changed.
 	 *
+	 * @param int $user_id User ID.
 	 * @param int $course_id Course post ID.
-	 * @param int $user_id   User ID.
 	 */
-	public static function trigger_course_enrolment_check( $course_id, $user_id ) {
+	public static function trigger_course_enrolment_check( $user_id, $course_id ) {
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 		if ( $course_enrolment ) {
 			$course_enrolment->is_enrolled( $user_id, false );

--- a/includes/class-sensei-course-enrolment-manager.php
+++ b/includes/class-sensei-course-enrolment-manager.php
@@ -111,7 +111,7 @@ class Sensei_Course_Enrolment_Manager {
 	 * @return string
 	 */
 	public static function get_site_salt() {
-		$enrolment_salt = \get_option( self::COURSE_ENROLMENT_SITE_SALT_OPTION );
+		$enrolment_salt = get_option( self::COURSE_ENROLMENT_SITE_SALT_OPTION );
 
 		if ( ! $enrolment_salt ) {
 			return self::reset_site_salt();

--- a/includes/class-sensei-course-enrolment-manager.php
+++ b/includes/class-sensei-course-enrolment-manager.php
@@ -13,6 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Handles the management of course enrolment.
  */
 class Sensei_Course_Enrolment_Manager {
+	const COURSE_ENROLMENT_SITE_SALT_OPTION = 'sensei_course_enrolment_site_salt';
+
 	/**
 	 * All course enrolment providers.
 	 *
@@ -102,6 +104,34 @@ class Sensei_Course_Enrolment_Manager {
 		}
 
 		return self::$enrolment_providers;
+	}
+
+	/**
+	 * Gets the site course enrolment salt that can be used to invalidate all enrolments.
+	 *
+	 * @return string
+	 */
+	public static function get_site_salt() {
+		$enrolment_salt = \get_option( self::COURSE_ENROLMENT_SITE_SALT_OPTION );
+
+		if ( ! $enrolment_salt ) {
+			return self::reset_site_salt();
+		}
+
+		return $enrolment_salt;
+	}
+
+	/**
+	 * Resets the site course enrolment salt. If already set, this will invalidate all current course enrolment results.
+	 *
+	 * @return string
+	 */
+	public static function reset_site_salt() {
+		$new_salt = md5( uniqid() );
+
+		\update_option( self::COURSE_ENROLMENT_SITE_SALT_OPTION, $new_salt, true );
+
+		return $new_salt;
 	}
 
 	/**

--- a/includes/class-sensei-course-enrolment-manager.php
+++ b/includes/class-sensei-course-enrolment-manager.php
@@ -91,6 +91,7 @@ class Sensei_Course_Enrolment_Manager {
 	 * @param string $provider_id Unique identifier of the enrolment provider.
 	 *
 	 * @return string|false
+	 * @throws Exception When there was an attempt to access enrolment providers before collected in init:100.
 	 */
 	public function get_enrolment_provider_name_by_id( $provider_id ) {
 		$provider = $this->get_enrolment_provider_by_id( $provider_id );
@@ -109,6 +110,7 @@ class Sensei_Course_Enrolment_Manager {
 	 * @param string $provider_id Unique identifier of the enrolment provider.
 	 *
 	 * @return Sensei_Course_Enrolment_Provider_Interface|false
+	 * @throws Exception When there was an attempt to access enrolment providers before collected in init:100.
 	 */
 	public function get_enrolment_provider_by_id( $provider_id ) {
 		$all_providers = $this->get_all_enrolment_providers();

--- a/includes/class-sensei-course-enrolment-manager.php
+++ b/includes/class-sensei-course-enrolment-manager.php
@@ -91,7 +91,6 @@ class Sensei_Course_Enrolment_Manager {
 			 * @param string[] $provider_classes List of enrolment providers classes.
 			 *
 			 * @since 3.0.0
-			 *
 			 */
 			$provider_classes = apply_filters( 'sensei_course_enrolment_providers', [] );
 			foreach ( $provider_classes as $provider_class ) {

--- a/includes/class-sensei-course-enrolment-manager.php
+++ b/includes/class-sensei-course-enrolment-manager.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * File containing the class Sensei_Course_Enrolment_Manager.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Handles the management of course enrolment.
+ */
+class Sensei_Course_Enrolment_Manager {
+	/**
+	 * All course enrolment providers.
+	 *
+	 * @var Sensei_Course_Enrolment_Provider_Interface[]
+	 */
+	private static $enrolment_providers;
+
+	/**
+	 * Gets the descriptive name of the provider by ID.
+	 *
+	 * @param string $provider_id Unique identifier of the enrolment provider.
+	 *
+	 * @return string|false
+	 */
+	public static function get_enrolment_provider_name_by_id( $provider_id ) {
+		$provider = self::get_enrolment_provider_by_id( $provider_id );
+		if ( ! $provider ) {
+			return false;
+		}
+
+		$provider_class = get_class( $provider );
+
+		return $provider_class::get_name();
+	}
+
+	/**
+	 * Gets the enrolment provider object by its ID.
+	 *
+	 * @param string $provider_id Unique identifier of the enrolment provider.
+	 *
+	 * @return Sensei_Course_Enrolment_Provider_Interface|false
+	 */
+	public static function get_enrolment_provider_by_id( $provider_id ) {
+		$all_providers = self::get_all_enrolment_providers();
+		if ( ! isset( $all_providers[ $provider_id ] ) ) {
+			return false;
+		}
+
+		return $all_providers[ $provider_id ];
+	}
+
+	/**
+	 * Check if we should use the legacy enrolment check. Legacy check uses course
+	 * progress to determine enrolment.
+	 *
+	 * @return bool
+	 */
+	public static function use_legacy_enrolment_check() {
+		$use_legacy_enrolment_check = false;
+
+		// Check if WCPC is around but not offering enrolment providers (an old version).
+		if (
+			class_exists( '\Sensei_WC_Paid_Courses\Sensei_WC_Paid_Courses' ) &&
+			! class_exists( '\Sensei_WC_Paid_Courses\Course_Enrolment_Providers' )
+		) {
+			$use_legacy_enrolment_check = true;
+		}
+
+		return apply_filters( 'sensei_legacy_enrolment_check', $use_legacy_enrolment_check );
+	}
+
+	/**
+	 * Get an array of all the instantiated course enrolment providers.
+	 *
+	 * @return Sensei_Course_Enrolment_Provider_Interface[]
+	 */
+	public static function get_all_enrolment_providers() {
+		if ( ! isset( self::$enrolment_providers ) ) {
+			self::$enrolment_providers = [];
+
+			/**
+			 * Fetch all registered course enrolment providers.
+			 *
+			 * @param string[] $provider_classes List of enrolment providers classes.
+			 *
+			 * @since 3.0.0
+			 *
+			 */
+			$provider_classes = apply_filters( 'sensei_course_enrolment_providers', [] );
+			foreach ( $provider_classes as $provider_class ) {
+				if ( ! class_exists( $provider_class ) || ! is_a( $provider_class, 'Sensei_Course_Enrolment_Provider_Interface', true ) ) {
+					continue;
+				}
+
+				self::$enrolment_providers[ $provider_class::get_id() ] = new $provider_class();
+			}
+		}
+
+		return self::$enrolment_providers;
+	}
+
+	/**
+	 * Trigger course enrolment check when enrolment might have changed.
+	 *
+	 * @param int $course_id Course post ID.
+	 * @param int $user_id   User ID.
+	 */
+	public static function trigger_course_enrolment_check( $course_id, $user_id ) {
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+		if ( $course_enrolment ) {
+			$course_enrolment->is_enrolled( $user_id, false );
+		}
+	}
+}

--- a/includes/class-sensei-course-enrolment.php
+++ b/includes/class-sensei-course-enrolment.php
@@ -224,7 +224,10 @@ class Sensei_Course_Enrolment {
 		if ( ! isset( $this->course_enrolment_providers ) ) {
 			$this->course_enrolment_providers = [];
 
-			foreach ( Sensei_Course_Enrolment_Manager::get_all_enrolment_providers() as $id => $enrolment_provider ) {
+			$enrolment_manager   = Sensei_Course_Enrolment_Manager::instance();
+			$enrolment_providers = $enrolment_manager->get_all_enrolment_providers();
+
+			foreach ( $enrolment_providers as $id => $enrolment_provider ) {
 				if ( $enrolment_provider->handles_enrolment( $this->course_id ) ) {
 					$this->course_enrolment_providers[ $id ] = $enrolment_provider;
 				}

--- a/includes/class-sensei-course-enrolment.php
+++ b/includes/class-sensei-course-enrolment.php
@@ -255,7 +255,7 @@ class Sensei_Course_Enrolment {
 	 *
 	 * @return string
 	 */
-	public static function hash_course_enrolment_provider_versions( $enrolment_providers ) {
+	private static function hash_course_enrolment_provider_versions( $enrolment_providers ) {
 		$versions = [];
 		foreach ( $enrolment_providers as $enrolment_provider ) {
 			if ( ! ( $enrolment_provider instanceof Sensei_Course_Enrolment_Provider_Interface ) ) {

--- a/includes/class-sensei-course-enrolment.php
+++ b/includes/class-sensei-course-enrolment.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Handles course enrolment logic.
+ * Handles course enrolment logic for a particular course.
  */
 class Sensei_Course_Enrolment {
 	const META_PREFIX_ENROLMENT_RESULTS = 'course-enrolment-';
@@ -21,13 +21,6 @@ class Sensei_Course_Enrolment {
 	 * @var static[]
 	 */
 	private static $instances = [];
-
-	/**
-	 * All course enrolment providers.
-	 *
-	 * @var Sensei_Course_Enrolment_Provider_Interface[]
-	 */
-	private static $enrolment_providers;
 
 	/**
 	 * Enrolment providers handling this particular course.
@@ -117,15 +110,6 @@ class Sensei_Course_Enrolment {
 		}
 
 		return $is_enrolled;
-	}
-
-	/**
-	 * Trigger course enrolment check when enrolment might have changed.
-	 *
-	 * @param int $user_id User ID.
-	 */
-	public function trigger_course_enrolment_check( $user_id ) {
-		$this->is_enrolled( $user_id, false );
 	}
 
 	/**
@@ -240,7 +224,7 @@ class Sensei_Course_Enrolment {
 		if ( ! isset( $this->course_enrolment_providers ) ) {
 			$this->course_enrolment_providers = [];
 
-			foreach ( self::get_all_enrolment_providers() as $id => $enrolment_provider ) {
+			foreach ( Sensei_Course_Enrolment_Manager::get_all_enrolment_providers() as $id => $enrolment_provider ) {
 				if ( $enrolment_provider->handles_enrolment( $this->course_id ) ) {
 					$this->course_enrolment_providers[ $id ] = $enrolment_provider;
 				}
@@ -248,69 +232,6 @@ class Sensei_Course_Enrolment {
 		}
 
 		return $this->course_enrolment_providers;
-	}
-
-	/**
-	 * Gets the enrolment provider object by its ID.
-	 *
-	 * @param string $provider_id Unique identifier of the enrolment provider.
-	 *
-	 * @return Sensei_Course_Enrolment_Provider_Interface|false
-	 */
-	public static function get_enrolment_provider_by_id( $provider_id ) {
-		$all_providers = self::get_all_enrolment_providers();
-		if ( ! isset( $all_providers[ $provider_id ] ) ) {
-			return false;
-		}
-
-		return $all_providers[ $provider_id ];
-	}
-
-	/**
-	 * Gets the descriptive name of the provider by ID.
-	 *
-	 * @param string $provider_id Unique identifier of the enrolment provider.
-	 *
-	 * @return string|false
-	 */
-	public static function get_enrolment_provider_name_by_id( $provider_id ) {
-		$provider = self::get_enrolment_provider_by_id( $provider_id );
-		if ( ! $provider ) {
-			return false;
-		}
-
-		$provider_class = get_class( $provider );
-
-		return $provider_class::get_name();
-	}
-
-	/**
-	 * Get an array of all the instantiated course enrolment providers.
-	 *
-	 * @return Sensei_Course_Enrolment_Provider_Interface[]
-	 */
-	private static function get_all_enrolment_providers() {
-		if ( ! isset( self::$enrolment_providers ) ) {
-			self::$enrolment_providers = [];
-
-			/**
-			 * Fetch all registered course enrolment providers.
-			 *
-			 * @since 3.0.0
-			 *
-			 * @param string[] $provider_classes List of enrolment providers classes.
-			 */
-			$provider_classes = apply_filters( 'sensei_course_enrolment_providers', [] );
-			foreach ( $provider_classes as $provider_class ) {
-				if ( ! class_exists( $provider_class ) || ! is_a( $provider_class, 'Sensei_Course_Enrolment_Provider_Interface', true ) ) {
-					continue;
-				}
-
-				self::$enrolment_providers[ $provider_class::get_id() ] = new $provider_class();
-			}
-		}
-
-		return self::$enrolment_providers;
 	}
 
 	/**
@@ -334,7 +255,7 @@ class Sensei_Course_Enrolment {
 	 *
 	 * @return string
 	 */
-	private static function hash_course_enrolment_provider_versions( $enrolment_providers ) {
+	public static function hash_course_enrolment_provider_versions( $enrolment_providers ) {
 		$versions = [];
 		foreach ( $enrolment_providers as $enrolment_provider ) {
 			if ( ! ( $enrolment_provider instanceof Sensei_Course_Enrolment_Provider_Interface ) ) {
@@ -348,25 +269,5 @@ class Sensei_Course_Enrolment {
 		ksort( $versions );
 
 		return md5( wp_json_encode( $versions ) );
-	}
-
-	/**
-	 * Check if we should use the legacy enrolment check. Legacy check uses course
-	 * progress to determine enrolment.
-	 *
-	 * @return bool
-	 */
-	public static function use_legacy_enrolment_check() {
-		$use_legacy_enrolment_check = false;
-
-		// Check if WCPC is around but not offering enrolment providers (an old version).
-		if (
-			class_exists( '\Sensei_WC_Paid_Courses\Sensei_WC_Paid_Courses' ) &&
-			! class_exists( '\Sensei_WC_Paid_Courses\Course_Enrolment_Providers' )
-		) {
-			$use_legacy_enrolment_check = true;
-		}
-
-		return apply_filters( 'sensei_legacy_enrolment_check', $use_legacy_enrolment_check );
 	}
 }

--- a/includes/class-sensei-course-enrolment.php
+++ b/includes/class-sensei-course-enrolment.php
@@ -268,6 +268,6 @@ class Sensei_Course_Enrolment {
 
 		ksort( $versions );
 
-		return md5( wp_json_encode( $versions ) );
+		return md5( Sensei_Course_Enrolment_Manager::get_site_salt() . wp_json_encode( $versions ) );
 	}
 }

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -173,7 +173,7 @@ class Sensei_Course {
 		}
 
 		// @todo This should be replaced by the manual course enrolment provider.
-		if ( \Sensei_Course_Enrolment::use_legacy_enrolment_check() ) {
+		if ( Sensei_Course_Enrolment_Manager::use_legacy_enrolment_check() ) {
 			return false !== Sensei_Utils::has_started_course( $course_id, $user_id );
 		}
 

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -54,6 +54,7 @@ class Sensei_Data_Cleaner {
 	 */
 	private static $options = array(
 		'sensei_installed',
+		'sensei_course_enrolment_site_salt',
 		'sensei_course_order',
 		'skip_install_sensei_pages',
 		'sensei_flush_rewrite_rules',

--- a/includes/class-sensei-learners-main.php
+++ b/includes/class-sensei-learners-main.php
@@ -284,7 +284,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 						$enrolment_tooltip_html[] = '<ul class="enrolment-helper">';
 
 						foreach ( $enrolment_results->get_provider_results() as $id => $result ) {
-							$name = Sensei_Course_Enrolment::get_enrolment_provider_name_by_id( $id );
+							$name = Sensei_Course_Enrolment_Manager::get_enrolment_provider_name_by_id( $id );
 							if ( ! $name ) {
 								$name = $id;
 							}

--- a/includes/class-sensei-learners-main.php
+++ b/includes/class-sensei-learners-main.php
@@ -284,7 +284,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 						$enrolment_tooltip_html[] = '<ul class="enrolment-helper">';
 
 						foreach ( $enrolment_results->get_provider_results() as $id => $result ) {
-							$name = Sensei_Course_Enrolment_Manager::get_enrolment_provider_name_by_id( $id );
+							$name = Sensei_Course_Enrolment_Manager::instance()->get_enrolment_provider_name_by_id( $id );
 							if ( ! $name ) {
 								$name = $id;
 							}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -367,6 +367,7 @@ class Sensei_Main {
 		$this->usage_tracking->schedule_tracking_task();
 
 		Sensei_Blocks::instance()->init();
+		Sensei_Course_Enrolment_Manager::instance()->init();
 
 		// Differentiate between administration and frontend logic.
 		if ( is_admin() ) {

--- a/tests/framework/trait-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-course-enrolment-test-helpers.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * File with trait Course_Enrolment_Test_Helpers.
+ *
+ * @package sensei-tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-always-provides.php';
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-denies-crooks.php';
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-handles-dog-courses.php';
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-never-handles.php';
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-never-provides.php';
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-provides-for-dinosaurs.php';
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-version-morph.php';
+
+/**
+ * Helpers for course enrolment related tests.
+ *
+ * @since 3.0.0
+ */
+trait Course_Enrolment_Test_Helpers {
+
+	/**
+	 * Resets the enrolment providers.
+	 */
+	private function resetEnrolmentProviders() {
+		remove_all_filters( 'sensei_course_enrolment_providers' );
+
+		$enrolment_providers = new ReflectionProperty( Sensei_Course_Enrolment_Manager::class, 'enrolment_providers' );
+		$enrolment_providers->setAccessible( true );
+		$enrolment_providers->setValue( null );
+
+		$course_enrolment_instances = new ReflectionProperty( Sensei_Course_Enrolment::class, 'instances' );
+		$course_enrolment_instances->setAccessible( true );
+		$course_enrolment_instances->setValue( [] );
+	}
+
+	/**
+	 * Gets a simple course ID.
+	 *
+	 * @return int
+	 */
+	private function getSimpleCourse() {
+		return $this->factory->course->create();
+	}
+
+	/**
+	 * Gets a course ID for a course with "dog" in the title.
+	 *
+	 * @return int
+	 */
+	private function getDogCourse() {
+		return $this->factory->course->create(
+			[
+				'post_title' => 'Dog Whispering',
+			]
+		);
+	}
+
+	/**
+	 * Creates a standard student user account.
+	 *
+	 * @return int
+	 */
+	private function createStandardStudent() {
+		return $this->factory->user->create();
+	}
+
+	/**
+	 * Create a user with "Dinosaur" in its display name.
+	 *
+	 * @return int
+	 */
+	private function createDinosaurStudent() {
+		$user_id = $this->createStandardStudent();
+
+		$dinosaur_names = [
+			'Pat',
+			'Tony',
+			'Jan',
+			'Meg',
+		];
+
+		shuffle( $dinosaur_names );
+
+		wp_update_user(
+			[
+				'ID'           => $user_id,
+				'display_name' => 'Dinosaur ' . $dinosaur_names[0],
+			]
+		);
+
+		return $user_id;
+	}
+
+	/**
+	 * Turns a user into a crook by adding "I am a crook" to their description.
+	 *
+	 * @param int $user_id
+	 * @return int
+	 */
+	private function turnStudentIntoCrook( $user_id ) {
+		$user = get_user_by( 'ID', $user_id );
+
+		$user->description = 'I am a crook';
+		wp_update_user( $user );
+
+		return $user_id;
+	}
+
+	/**
+	 * Adds an enrolment provider.
+	 */
+	private function addEnrolmentProvider( $class_name ) {
+		add_filter(
+			'sensei_course_enrolment_providers',
+			function( $providers ) use ( $class_name ) {
+				if ( in_array( $class_name, $providers, true ) ) {
+					return $providers;
+				}
+
+				$providers[] = $class_name;
+
+				return $providers;
+			}
+		);
+	}
+
+}

--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -27,7 +27,7 @@ require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test
 trait Sensei_Course_Enrolment_Test_Helpers {
 
 	/**
-	 * Resets the enrolment providers.
+	 * Resets the enrolment providers. Do not do this in production. This is just to reset state in tests.
 	 */
 	private static function resetEnrolmentProviders() {
 		remove_all_filters( 'sensei_course_enrolment_providers' );
@@ -133,7 +133,7 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 	}
 
 	/**
-	 * Prepare the enrolment manager.
+	 * Prepare the enrolment manager. Do not do this in production. This is just to simulate what is done on `init`.
 	 */
 	private function prepareEnrolmentManager() {
 		Sensei_Course_Enrolment_Manager::instance()->collect_enrolment_providers();

--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -29,7 +29,7 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 	/**
 	 * Resets the enrolment providers.
 	 */
-	private function resetEnrolmentProviders() {
+	private static function resetEnrolmentProviders() {
 		remove_all_filters( 'sensei_course_enrolment_providers' );
 
 		$enrolment_providers = new ReflectionProperty( Sensei_Course_Enrolment_Manager::class, 'enrolment_providers' );

--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -34,7 +34,7 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 
 		$enrolment_providers = new ReflectionProperty( Sensei_Course_Enrolment_Manager::class, 'enrolment_providers' );
 		$enrolment_providers->setAccessible( true );
-		$enrolment_providers->setValue( null );
+		$enrolment_providers->setValue( Sensei_Course_Enrolment_Manager::instance(), null );
 
 		$course_enrolment_instances = new ReflectionProperty( Sensei_Course_Enrolment::class, 'instances' );
 		$course_enrolment_instances->setAccessible( true );
@@ -132,4 +132,10 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 		);
 	}
 
+	/**
+	 * Prepare the enrolment manager.
+	 */
+	private function prepareEnrolmentManager() {
+		Sensei_Course_Enrolment_Manager::instance()->collect_enrolment_providers();
+	}
 }

--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -5,6 +5,8 @@
  * @package sensei-tests
  */
 
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Using PHPUnit conventions.
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -22,7 +22,7 @@ require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test
  *
  * @since 3.0.0
  */
-trait Course_Enrolment_Test_Helpers {
+trait Sensei_Course_Enrolment_Test_Helpers {
 
 	/**
 	 * Resets the enrolment providers.

--- a/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
@@ -2,7 +2,12 @@
 
 require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 
-class Sensei_Class_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
+/**
+ * Tests for Sensei_Course_Enrolment_Manager class.
+ *
+ * @group course-enrolment
+ */
+class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	use Sensei_Course_Enrolment_Test_Helpers;
 
 	/**
@@ -29,9 +34,11 @@ class Sensei_Class_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	 */
 	public function testGetEnrolmentProviderById() {
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
+		$this->prepareEnrolmentManager();
 
-		$provider_always_provides = Sensei_Course_Enrolment_Manager::get_enrolment_provider_by_id( Sensei_Test_Enrolment_Provider_Always_Provides::get_id() );
-		$provider_never_provides  = Sensei_Course_Enrolment_Manager::get_enrolment_provider_by_id( Sensei_Test_Enrolment_Provider_Never_Provides::get_id() );
+		$enrolment_manager        = Sensei_Course_Enrolment_Manager::instance();
+		$provider_always_provides = $enrolment_manager->get_enrolment_provider_by_id( Sensei_Test_Enrolment_Provider_Always_Provides::get_id() );
+		$provider_never_provides  = $enrolment_manager->get_enrolment_provider_by_id( Sensei_Test_Enrolment_Provider_Never_Provides::get_id() );
 
 		$this->assertFalse( $provider_never_provides, 'This provider was never registered and should not be returned.' );
 		$this->assertNotFalse( $provider_always_provides, 'This provider was registered and its singleton instance should be returned' );
@@ -47,6 +54,7 @@ class Sensei_Class_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$student_id = $this->createStandardStudent();
 
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Denies_Crooks::class );
+		$this->prepareEnrolmentManager();
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 

--- a/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
@@ -2,7 +2,7 @@
 
 require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 
-class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
+class Sensei_Class_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 
 	use Sensei_Course_Enrolment_Test_Helpers;
 

--- a/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
@@ -1,10 +1,10 @@
 <?php
 
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-course-enrolment-test-helpers.php';
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 
 class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 
-	use Course_Enrolment_Test_Helpers;
+	use Sensei_Course_Enrolment_Test_Helpers;
 
 	/**
 	 * Setup function.

--- a/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
@@ -61,4 +61,28 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 		$post_notify_enrolment = $course_enrolment->is_enrolled( $student_id );
 		$this->assertFalse( $post_notify_enrolment, 'Now that the crook status is known, they should no longer be enrolled in the course' );
 	}
+
+	/**
+	 * Simple tests for getting a site's enrolment salt.
+	 *
+	 * @covers \Sensei_Course_Enrolment_Manager::get_site_salt
+	 */
+	public function testGetSiteEnrolmentSalt() {
+		$enrolment_salt = Sensei_Course_Enrolment_Manager::get_site_salt();
+		$this->assertTrue( ! empty( $enrolment_salt ), 'Enrolment salt should not be empty' );
+		$this->assertEquals( Sensei_Course_Enrolment_Manager::get_site_salt(), $enrolment_salt, 'Getting enrolment salt twice without resetting should product the same result' );
+	}
+
+	/**
+	 * Tests to make sure resetting the site enrolment salt produces a new salt.
+	 *
+	 * @covers \Sensei_Course_Enrolment_Manager::get_site_salt
+	 */
+	public function testResetSiteEnrolmentSalt() {
+		$enrolment_salt = Sensei_Course_Enrolment_Manager::get_site_salt();
+		$this->assertTrue( ! empty( $enrolment_salt ), 'Enrolment salt should not be empty' );
+		$new_enrolment_salt = Sensei_Course_Enrolment_Manager::reset_site_salt();
+		$this->assertNotEquals( Sensei_Course_Enrolment_Manager::get_site_salt(), $enrolment_salt, 'Getting enrolment salt after resetting it should produce a different result.' );
+		$this->assertEquals( Sensei_Course_Enrolment_Manager::get_site_salt(), $new_enrolment_salt, 'Getting enrolment salt after resetting return the same salt as the reset method returns.' );
+	}
 }

--- a/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
@@ -57,7 +57,7 @@ class Sensei_Class_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$pre_notify_enrolment = $course_enrolment->is_enrolled( $student_id );
 		$this->assertTrue( $pre_notify_enrolment, 'Even as a crook, the cached value should be used until we notify the course enrolment handler' );
 
-		Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check( $course_id, $student_id );
+		Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check( $student_id, $course_id );
 		$post_notify_enrolment = $course_enrolment->is_enrolled( $student_id );
 		$this->assertFalse( $post_notify_enrolment, 'Now that the crook status is known, they should no longer be enrolled in the course' );
 	}

--- a/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
@@ -1,0 +1,64 @@
+<?php
+
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-course-enrolment-test-helpers.php';
+
+class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
+
+	use Course_Enrolment_Test_Helpers;
+
+	/**
+	 * Setup function.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+	}
+
+	/**
+	 * Clean up after test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->resetEnrolmentProviders();
+	}
+
+	/**
+	 * Tests getting an enrolment provider by ID.
+	 */
+	public function testGetEnrolmentProviderById() {
+		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
+
+		$provider_always_provides = Sensei_Course_Enrolment_Manager::get_enrolment_provider_by_id( Sensei_Test_Enrolment_Provider_Always_Provides::get_id() );
+		$provider_never_provides  = Sensei_Course_Enrolment_Manager::get_enrolment_provider_by_id( Sensei_Test_Enrolment_Provider_Never_Provides::get_id() );
+
+		$this->assertFalse( $provider_never_provides, 'This provider was never registered and should not be returned.' );
+		$this->assertNotFalse( $provider_always_provides, 'This provider was registered and its singleton instance should be returned' );
+
+		$this->assertTrue( $provider_always_provides instanceof Sensei_Test_Enrolment_Provider_Always_Provides, 'Singleton instance of the provider should be returned.' );
+	}
+
+	/**
+	 * Tests re-checking enrolment when something might have changed.
+	 */
+	public function testTriggerCourseEnrolmentCheckSimple() {
+		$course_id  = $this->getSimpleCourse();
+		$student_id = $this->createStandardStudent();
+
+		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Denies_Crooks::class );
+
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+
+		$pre_crook_enrolment = $course_enrolment->is_enrolled( $student_id );
+		$this->assertTrue( $pre_crook_enrolment, 'As a non-crook, this student should be enrolled' );
+
+		$this->turnStudentIntoCrook( $student_id );
+		$pre_notify_enrolment = $course_enrolment->is_enrolled( $student_id );
+		$this->assertTrue( $pre_notify_enrolment, 'Even as a crook, the cached value should be used until we notify the course enrolment handler' );
+
+		Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check( $course_id, $student_id );
+		$post_notify_enrolment = $course_enrolment->is_enrolled( $student_id );
+		$this->assertFalse( $post_notify_enrolment, 'Now that the crook status is known, they should no longer be enrolled in the course' );
+	}
+}

--- a/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
@@ -3,7 +3,6 @@
 require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 
 class Sensei_Class_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
-
 	use Sensei_Course_Enrolment_Test_Helpers;
 
 	/**
@@ -13,15 +12,16 @@ class Sensei_Class_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
+
+		self::resetEnrolmentProviders();
 	}
 
 	/**
-	 * Clean up after test.
+	 * Clean up after all tests.
 	 */
-	public function tearDown() {
-		parent::tearDown();
-
-		$this->resetEnrolmentProviders();
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+		self::resetEnrolmentProviders();
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-course-enrolment-provider-results.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment-provider-results.php
@@ -1,6 +1,10 @@
 <?php
-
-class Sensei_Class_Course_Enrolment_Provider_Results_Test extends WP_UnitTestCase {
+/**
+ * Tests for Sensei_Course_Enrolment_Provider_Results class.
+ *
+ * @group course-enrolment
+ */
+class Sensei_Course_Enrolment_Provider_Results_Test extends WP_UnitTestCase {
 
 	/**
 	 * Setup function.

--- a/tests/unit-tests/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment.php
@@ -1,13 +1,10 @@
 <?php
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-always-provides.php';
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-denies-crooks.php';
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-handles-dog-courses.php';
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-never-handles.php';
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-never-provides.php';
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-provides-for-dinosaurs.php';
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/enrolment-providers/class-sensei-test-enrolment-provider-version-morph.php';
+
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-course-enrolment-test-helpers.php';
 
 class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
+
+	use Course_Enrolment_Test_Helpers;
 
 	/**
 	 * Setup function.
@@ -42,21 +39,6 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( $instance instanceof Sensei_Course_Enrolment );
 		$this->assertEquals( 1000, $instance->get_course_id(), 'Course ID for provided instance did not match the created instance' );
-	}
-
-	/**
-	 * Tests getting an enrolment provider by ID.
-	 */
-	public function testGetEnrolmentProviderById() {
-		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
-
-		$provider_always_provides = Sensei_Course_Enrolment::get_enrolment_provider_by_id( Sensei_Test_Enrolment_Provider_Always_Provides::get_id() );
-		$provider_never_provides  = Sensei_Course_Enrolment::get_enrolment_provider_by_id( Sensei_Test_Enrolment_Provider_Never_Provides::get_id() );
-
-		$this->assertFalse( $provider_never_provides, 'This provider was never registered and should not be returned.' );
-		$this->assertNotFalse( $provider_always_provides, 'This provider was registered and its singleton instance should be returned' );
-
-		$this->assertTrue( $provider_always_provides instanceof Sensei_Test_Enrolment_Provider_Always_Provides, 'Singleton instance of the provider should be returned.' );
 	}
 
 	/**
@@ -226,29 +208,6 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests re-checking enrolment when something might have changed.
-	 */
-	public function testTriggerCourseEnrolmentCheckSimple() {
-		$course_id  = $this->getSimpleCourse();
-		$student_id = $this->createStandardStudent();
-
-		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Denies_Crooks::class );
-
-		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
-
-		$pre_crook_enrolment = $course_enrolment->is_enrolled( $student_id );
-		$this->assertTrue( $pre_crook_enrolment, 'As a non-crook, this student should be enrolled' );
-
-		$this->turnStudentIntoCrook( $student_id );
-		$pre_notify_enrolment = $course_enrolment->is_enrolled( $student_id );
-		$this->assertTrue( $pre_notify_enrolment, 'Even as a crook, the cached value should be used until we notify the course enrolment handler' );
-
-		$course_enrolment->trigger_course_enrolment_check( $student_id );
-		$post_notify_enrolment = $course_enrolment->is_enrolled( $student_id );
-		$this->assertFalse( $post_notify_enrolment, 'Now that the crook status is known, they should no longer be enrolled in the course' );
-	}
-
-	/**
 	 * Tests re-checking enrolment when we have it ignore cached result.
 	 */
 	public function testCourseEnrolmentCheckDoNotUseCache() {
@@ -308,115 +267,9 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 
 		// Turns the student into someone who won't be enrolled by provider.
 		$this->turnStudentIntoCrook( $student_id );
-		$course_enrolment->trigger_course_enrolment_check( $student_id );
+		$course_enrolment->is_enrolled( $student_id, false );
 
 		$this->assertFalse( has_term( $student_term->term_id, Sensei_PostTypes::LEARNER_TAXONOMY_NAME, $course_id ), 'Student term associated should be removed when enrolment was removed' );
-	}
-
-	/**
-	 * Gets a simple course ID.
-	 *
-	 * @return int
-	 */
-	private function getSimpleCourse() {
-		return $this->factory->course->create();
-	}
-
-	/**
-	 * Gets a course ID for a course with "dog" in the title.
-	 *
-	 * @return int
-	 */
-	private function getDogCourse() {
-		return $this->factory->course->create(
-			[
-				'post_title' => 'Dog Whispering',
-			]
-		);
-	}
-
-	/**
-	 * Creates a standard student user account.
-	 *
-	 * @return int
-	 */
-	private function createStandardStudent() {
-		return $this->factory->user->create();
-	}
-
-	/**
-	 * Create a user with "Dinosaur" in its display name.
-	 *
-	 * @return int
-	 */
-	private function createDinosaurStudent() {
-		$user_id = $this->createStandardStudent();
-
-		$dinosaur_names = [
-			'Pat',
-			'Tony',
-			'Jan',
-			'Meg',
-		];
-
-		shuffle( $dinosaur_names );
-
-		wp_update_user(
-			[
-				'ID'           => $user_id,
-				'display_name' => 'Dinosaur ' . $dinosaur_names[0],
-			]
-		);
-
-		return $user_id;
-	}
-
-	/**
-	 * Turns a user into a crook by adding "I am a crook" to their description.
-	 *
-	 * @param int $user_id
-	 * @return int
-	 */
-	private function turnStudentIntoCrook( $user_id ) {
-		$user = get_user_by( 'ID', $user_id );
-
-		$user->description = 'I am a crook';
-		wp_update_user( $user );
-
-		return $user_id;
-	}
-
-	/**
-	 * Adds an enrolment provider.
-	 */
-	private function addEnrolmentProvider( $class_name ) {
-		add_filter(
-			'sensei_course_enrolment_providers',
-			function( $providers ) use ( $class_name ) {
-				if ( in_array( $class_name, $providers, true ) ) {
-					return $providers;
-				}
-
-				$providers[] = $class_name;
-
-				return $providers;
-			}
-		);
-	}
-
-	/**
-	 * Resets the enrolment providers.
-	 */
-	private function resetEnrolmentProviders() {
-		remove_all_filters( 'sensei_course_enrolment_providers' );
-
-		$enrolment_providers = new ReflectionProperty( Sensei_Course_Enrolment::class, 'enrolment_providers' );
-		$enrolment_providers->setAccessible( true );
-		$enrolment_providers->setValue( null );
-
-		$course_enrolment_instances = new ReflectionProperty( Sensei_Course_Enrolment::class, 'instances' );
-		$course_enrolment_instances->setAccessible( true );
-		$course_enrolment_instances->setValue( [] );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment.php
@@ -1,10 +1,10 @@
 <?php
 
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-course-enrolment-test-helpers.php';
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 
 class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 
-	use Course_Enrolment_Test_Helpers;
+	use Sensei_Course_Enrolment_Test_Helpers;
 
 	/**
 	 * Setup function.

--- a/tests/unit-tests/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment.php
@@ -2,7 +2,12 @@
 
 require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 
-class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
+/**
+ * Tests for Sensei_Course_Enrolment class.
+ *
+ * @group course-enrolment
+ */
+class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 	use Sensei_Course_Enrolment_Test_Helpers;
 
 	/**
@@ -48,6 +53,7 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 		$course_id  = $this->getSimpleCourse();
 		$student_id = $this->createStandardStudent();
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
+		$this->prepareEnrolmentManager();
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
@@ -61,6 +67,7 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 		$course_id  = $this->getSimpleCourse();
 		$student_id = $this->createStandardStudent();
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Never_Provides::class );
+		$this->prepareEnrolmentManager();
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
@@ -89,6 +96,8 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 
 		// This provider provides enrolment for any student when a course with "dog" in the title is checked.
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Handles_Dog_Courses::class );
+		$this->prepareEnrolmentManager();
+
 		$course_enrolment_simple = Sensei_Course_Enrolment::get_course_instance( $course_id_simple );
 		$course_enrolment_dog    = Sensei_Course_Enrolment::get_course_instance( $course_id_dog );
 
@@ -104,6 +113,7 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 		$student_id = $this->createStandardStudent();
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Never_Provides::class );
+		$this->prepareEnrolmentManager();
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
@@ -116,8 +126,10 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 	public function testEnrolmentCheckPositivePrevailsSecond() {
 		$course_id  = $this->getSimpleCourse();
 		$student_id = $this->createStandardStudent();
+
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Never_Provides::class );
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
+		$this->prepareEnrolmentManager();
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
@@ -130,7 +142,9 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 	public function testEnrolmentCheckNoHandlingProviders() {
 		$course_id  = $this->getSimpleCourse();
 		$student_id = $this->createStandardStudent();
+
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Never_Handles::class );
+		$this->prepareEnrolmentManager();
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
@@ -143,8 +157,10 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 	public function testEnrolmentCheckNonHandlingProvidersIgnored() {
 		$course_id  = $this->getSimpleCourse();
 		$student_id = $this->createStandardStudent();
+
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Never_Handles::class );
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Never_Provides::class );
+		$this->prepareEnrolmentManager();
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
@@ -184,6 +200,7 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 		$student_id_dino     = $this->createDinosaurStudent();
 
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Provides_For_Dinosaurs::class );
+		$this->prepareEnrolmentManager();
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
@@ -200,6 +217,7 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 		$student_id_okay  = $this->createStandardStudent();
 
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Denies_Crooks::class );
+		$this->prepareEnrolmentManager();
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
@@ -215,6 +233,7 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 		$student_id = $this->createStandardStudent();
 
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Denies_Crooks::class );
+		$this->prepareEnrolmentManager();
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
@@ -240,6 +259,7 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 		$student_id = $this->createStandardStudent();
 
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
+		$this->prepareEnrolmentManager();
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 		$this->assertTrue( $course_enrolment->is_enrolled( $student_id ) );
@@ -258,6 +278,7 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 		$student_id = $this->createStandardStudent();
 
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Denies_Crooks::class );
+		$this->prepareEnrolmentManager();
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 		$this->assertTrue( $course_enrolment->is_enrolled( $student_id ) );
@@ -278,6 +299,7 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 	private function resetAndSetUpVersionedProvider( $bump_version ) {
 		self::resetEnrolmentProviders();
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Version_Morph::class );
+		$this->prepareEnrolmentManager();
 
 		if ( $bump_version ) {
 			Sensei_Test_Enrolment_Provider_Version_Morph::$version++;

--- a/tests/unit-tests/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment.php
@@ -3,7 +3,6 @@
 require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 
 class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
-
 	use Sensei_Course_Enrolment_Test_Helpers;
 
 	/**
@@ -13,15 +12,16 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
+
+		self::resetEnrolmentProviders();
 	}
 
 	/**
-	 * Clean up after test.
+	 * Clean up after all tests.
 	 */
-	public function tearDown() {
-		parent::tearDown();
-
-		$this->resetEnrolmentProviders();
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+		self::resetEnrolmentProviders();
 	}
 
 	public function testGetCourseInstanceMultiple() {
@@ -276,7 +276,7 @@ class Sensei_Class_Course_Enrolment_Test extends WP_UnitTestCase {
 	 * Helper for `\Sensei_Class_Course_Enrolment_Test::testEnrolmentCheckVersionCachingWorks`.
 	 */
 	private function resetAndSetUpVersionedProvider( $bump_version ) {
-		$this->resetEnrolmentProviders();
+		self::resetEnrolmentProviders();
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Version_Morph::class );
 
 		if ( $bump_version ) {


### PR DESCRIPTION
In chatting with @alexsanford, we agreed it seemed necessary to have a new class that handled some of the enrolment related logic outside of a specific course. We'll eventually use this to do better invalidation at a user level and user-course level.

This also moves some of the methods that were in the class `Sensei_Course_Enrolment` that should have been in a handler class, such as collecting all the available course enrollment providers. 

I didn't move `\Sensei_Course_Enrolment::hash_course_enrolment_provider_versions`, but could be persuaded. I didn't for now because it seemed like it will only be used in this class.

This also introduces the concept of a course enrolment site salt. We'll be able to reset this to invalidate all enrolment results (causing them to be recalculated).