### PR TITLE
Fix/issue 2768

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1768,8 +1768,8 @@ class Sensei_Frontend {
 
 		// Redirect.
 		global $wp;
-		if ( wp_get_referer() ) {
-			$redirect = esc_url( wp_get_referer() );
+		if ( ! empty( $new_user_http_referer ) ) {
+			$redirect = esc_url( $new_user_http_referer );
 		} else {
 			$redirect = esc_url( home_url( $wp->request ) );
 		}

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1706,6 +1706,7 @@ class Sensei_Frontend {
 		$new_user_name     = sanitize_user( $_POST['sensei_reg_username'] );
 		$new_user_email    = $_POST['sensei_reg_email'];
 		$new_user_password = $_POST['sensei_reg_password'];
+		$new_user_http_referer = $_POST['sensei_reg_http_referer'];
 
 		// Check the username.
 		$username_error_notice = '';

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1284,6 +1284,8 @@ class Sensei_Frontend {
 						<!-- Spam Trap -->
 						<div style="left:-999em; position:absolute;"><label for="trap"><?php esc_html_e( 'Anti-spam', 'sensei-lms' ); ?></label><input type="text" name="email_2" id="trap" tabindex="-1" /></div>
 
+						<input type="hidden" id="sensei_reg_http_referer" name="sensei_reg_http_referer" value="<?php echo wp_get_referer() ? esc_attr( wp_get_referer() ) : ''; ?>">
+
 						<?php do_action( 'sensei_register_form_fields' ); ?>
 						<?php do_action( 'register_form' ); ?>
 


### PR DESCRIPTION
Fixes #2768 

#### Changes proposed in this Pull Request:

* This PR sends the http referer in the register form in a hidden value, and then creates the redirect link from that value.

#### Testing instructions:

1. Enable 'Anyone can register' in Settings > General, and 'Access Permissions' in Sensei LMS > Settings.
2. View a course page as a logged out user.
3. Click the Register button and complete the registration form
4. You should be redirected to the course you were viewing