### PR TITLE
Fix settings deletion on page setup

### DIFF
--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -388,9 +388,16 @@ class Sensei_Settings_API {
 		$this->settings = self::get_settings_raw();
 
 		foreach ( $this->fields as $k => $v ) {
-			if ( ! isset( $this->settings[ $k ] ) && isset( $v['default'] ) ) {
-				$this->settings[ $k ] = $v['default'];
+
+			if ( ! isset( $this->settings[ $k ] ) ) {
+
+				if ( isset( $v['default'] ) ) {
+					$this->settings[ $k ] = $v['default'];
+				} elseif ( isset( $v['defaults'] ) ) {
+					$this->settings[ $k ] = $v['defaults'];
+				}
 			}
+
 			if ( $v['type'] == 'checkbox' && $this->settings[ $k ] != true ) {
 				$this->settings[ $k ] = 0;
 			}

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -69,7 +69,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 */
 	public function set( $setting, $new_value ) {
 
-		$settings             = self::get_settings_raw();
+		$settings             = $this->get_settings();
 		$settings[ $setting ] = $new_value;
 		return update_option( $this->token, $settings );
 


### PR DESCRIPTION
Fixes #2846

#### Changes proposed in this Pull Request:
As @jom proposed, I switched the `get_settings_raw()` method call with `get_settings` method. Method `get_settings` takes into account default values so the settings now will be correct.

#### Testing instructions:
For the steps have a look at #2846