### PR TITLE
Replace Twitter button with Create Course

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -217,7 +217,7 @@ class Sensei_Admin {
 				<p><?php echo wp_kses_post( __( '<strong>Congratulations!</strong> &#8211; Sensei LMS has been installed and set up.', 'sensei-lms' ) ); ?></p>
 				<p>
 					<a href="<?php echo esc_url( admin_url( 'post-new.php?post_type=course' ) ); ?>" class="button-primary">
-						<?php esc_html_e( 'Create Course', 'sensei-lms' ); ?>
+						<?php esc_html_e( 'Create a Course', 'sensei-lms' ); ?>
 					</a>
 				</p>
 			</div>
@@ -415,7 +415,7 @@ class Sensei_Admin {
 
 			<p>
 				<a href="<?php echo esc_url( admin_url( 'post-new.php?post_type=course' ) ); ?>" class="button-primary">
-					<?php esc_html_e( 'Create Course', 'sensei-lms' ); ?>
+					<?php esc_html_e( 'Create a Course', 'sensei-lms' ); ?>
 				</a>
 			</p>
 

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -215,8 +215,11 @@ class Sensei_Admin {
 			?>
 			<div id="message" class="updated sensei-message sensei-connect">
 				<p><?php echo wp_kses_post( __( '<strong>Congratulations!</strong> &#8211; Sensei LMS has been installed and set up.', 'sensei-lms' ) ); ?></p>
-				<p><a href="https://twitter.com/share" class="twitter-share-button" data-url="https://woocommerce.com/products/sensei/" data-text="A premium Learning Management plugin for #WordPress that helps you create courses. Beautifully." data-via="senseilms" data-size="large" data-hashtags="Sensei">Tweet</a>
-				<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");</script></p>
+				<p>
+					<a href="<?php echo esc_url( admin_url( 'post-new.php?post_type=course' ) ); ?>" class="button-primary">
+						<?php esc_html_e( 'Create Course', 'sensei-lms' ); ?>
+					</a>
+				</p>
 			</div>
 			<?php
 
@@ -411,15 +414,9 @@ class Sensei_Admin {
 			</p>
 
 			<p>
-
-				<a href="https://twitter.com/share" class="twitter-share-button" data-url="http://www.woothemes.com/sensei/" data-text="A premium Learning Management plugin for #WordPress that helps you teach courses online. Beautifully." data-via="WooThemes" data-size="large" data-hashtags="Sensei">
-					<?php esc_html_e( 'Tweet', 'sensei-lms' ); ?>
+				<a href="<?php echo esc_url( admin_url( 'post-new.php?post_type=course' ) ); ?>" class="button-primary">
+					<?php esc_html_e( 'Create Course', 'sensei-lms' ); ?>
 				</a>
-
-				<script>
-					!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0];if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src="//platform.twitter.com/widgets.js";fjs.parentNode.insertBefore(js,fjs);}}(document,"script","twitter-wjs");
-				</script>
-
 			</p>
 
 		</div>


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Removes Tweet links when you either install or skip installing Sensei pages. Replaces with button to create a course.

#### Testing instructions:

* Install fresh install of Sensei. 
* Click **Install Sensei LMS Pages**.
<img width="573" alt="Screen Shot 2020-01-17 at 8 58 38 PM" src="https://user-images.githubusercontent.com/68693/72645704-25b39a00-396c-11ea-9028-8e91345cc418.png">

* Check link that is shown on success message.
* On another fresh install.
* Instead of clicking **Install Sensei LMS Pages**, click on **Skip Setup**.
* Check link.

<img width="479" alt="Screen Shot 2020-01-17 at 9 00 08 PM" src="https://user-images.githubusercontent.com/68693/72645796-5b588300-396c-11ea-8f14-2539682a2fed.png">

