### PR TITLE
Fix/issue 2825 Append post status to pre-requisite lesson on lessons page

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2245,7 +2245,7 @@ class Sensei_Lesson {
 				} // End If Statement
 				break;
 			case 'lesson-prerequisite':
-				$lesson_prerequisite_id = get_post_meta( $id, '_lesson_prerequisite', true );
+				$lesson_prerequisite_id   = get_post_meta( $id, '_lesson_prerequisite', true );
 				$lesson_prerequisite_post = get_post( $lesson_prerequisite_id );
 				if ( 0 < absint( $lesson_prerequisite_id ) ) {
 					// translators: Placeholder is the title of the prerequisite lesson.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2246,6 +2246,7 @@ class Sensei_Lesson {
 				break;
 			case 'lesson-prerequisite':
 				$lesson_prerequisite_id = get_post_meta( $id, '_lesson_prerequisite', true );
+				$lesson_prerequisite_post = get_post( $lesson_prerequisite_id );
 				if ( 0 < absint( $lesson_prerequisite_id ) ) {
 					// translators: Placeholder is the title of the prerequisite lesson.
 					echo '<a href="' . esc_url( get_edit_post_link( absint( $lesson_prerequisite_id ) ) ) . '" title="' . esc_attr( sprintf( __( 'Edit %s', 'sensei-lms' ), get_the_title( absint( $lesson_prerequisite_id ) ) ) ) . '">' . esc_html( get_the_title( absint( $lesson_prerequisite_id ) ) ) . '</a>';

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2250,6 +2250,7 @@ class Sensei_Lesson {
 				if ( 0 < absint( $lesson_prerequisite_id ) ) {
 					// translators: Placeholder is the title of the prerequisite lesson.
 					echo '<a href="' . esc_url( get_edit_post_link( absint( $lesson_prerequisite_id ) ) ) . '" title="' . esc_attr( sprintf( __( 'Edit %s', 'sensei-lms' ), get_the_title( absint( $lesson_prerequisite_id ) ) ) ) . '">' . esc_html( get_the_title( absint( $lesson_prerequisite_id ) ) ) . '</a>';
+					_post_states( $lesson_prerequisite_post );
 				} // End If Statement
 				break;
 			default:

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2245,9 +2245,9 @@ class Sensei_Lesson {
 				} // End If Statement
 				break;
 			case 'lesson-prerequisite':
-				$lesson_prerequisite_id   = get_post_meta( $id, '_lesson_prerequisite', true );
-				$lesson_prerequisite_post = get_post( $lesson_prerequisite_id );
+				$lesson_prerequisite_id = get_post_meta( $id, '_lesson_prerequisite', true );
 				if ( 0 < absint( $lesson_prerequisite_id ) ) {
+					$lesson_prerequisite_post = get_post( $lesson_prerequisite_id );
 					// translators: Placeholder is the title of the prerequisite lesson.
 					echo '<a href="' . esc_url( get_edit_post_link( absint( $lesson_prerequisite_id ) ) ) . '" title="' . esc_attr( sprintf( __( 'Edit %s', 'sensei-lms' ), get_the_title( absint( $lesson_prerequisite_id ) ) ) ) . '">' . esc_html( get_the_title( absint( $lesson_prerequisite_id ) ) ) . '</a>';
 					_post_states( $lesson_prerequisite_post );


### PR DESCRIPTION
Fixes #2825 

#### Changes proposed in this Pull Request:

* Append the post status to the pre-requisite lesson (if the status is not "Published") on lessons page using the `_post_states()` function.

#### Testing instructions:

* Create a lesson with a pre-requisite lesson that is not "Published" (Draft, for example)
* Go to the lessons page
* You should see (on the "non published" pre-requisite lesson) the status, just like in the title column



<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Append post status to pre-requisite lesson on lessons page.
