### PR TITLE
Manually enrol student on frontend when they sign up for course

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2996,6 +2996,41 @@ class Sensei_Course {
 	}
 
 	/**
+	 * Check if a user can manually enrol themselves.
+	 *
+	 * @param int $course_id Course post ID.
+	 *
+	 * @return bool
+	 */
+	public static function can_current_user_manually_enrol( $course_id ) {
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		// Check if the user is already enrolled through any provider.
+		$is_user_enrolled = self::is_user_enrolled( $course_id, get_current_user_id() );
+
+		$default_can_user_manually_enrol = ! $is_user_enrolled;
+
+		$can_user_manually_enrol = apply_filters_deprecated(
+			'sensei_display_start_course_form',
+			[ $default_can_user_manually_enrol, $course_id ],
+			'3.0.0',
+			'sensei_can_user_manually_enrol'
+		);
+
+		/**
+		 * Check if currently logged in user can manually enrol themselves. Defaults to `true`.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param bool $can_user_manually_enrol True if they can manually enrol themselves, false if not.
+		 * @param int  $course_id               Course post ID.
+		 */
+		return (bool) apply_filters( 'sensei_can_user_manually_enrol', $can_user_manually_enrol, $course_id );
+	}
+
+	/**
 	 * Output the course actions like start taking course, register, etc. Note
 	 * that this expects that the user is not already taking the course; that
 	 * check is done in `the_course_enrolment_actions`.
@@ -3010,7 +3045,7 @@ class Sensei_Course {
 		$is_course_content_restricted = (bool) apply_filters( 'sensei_is_course_content_restricted', false, $post->ID );
 
 		if ( is_user_logged_in() ) {
-			$should_display_start_course_form = (bool) apply_filters( 'sensei_display_start_course_form', true, $post->ID );
+			$should_display_start_course_form = self::can_current_user_manually_enrol( $post->ID );
 			if ( $is_course_content_restricted && false == $should_display_start_course_form ) {
 				self::add_course_access_permission_message( '' );
 			}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3020,7 +3020,7 @@ class Sensei_Course {
 		);
 
 		/**
-		 * Check if currently logged in user can manually enrol themselves. Defaults to `true`.
+		 * Check if currently logged in user can manually enrol themselves. Defaults to `true` when not already enrolled.
 		 *
 		 * @since 3.0.0
 		 *

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1380,12 +1380,12 @@ class Sensei_Frontend {
 	public function sensei_course_start() {
 		global $post, $current_user;
 
-		// Check if the user is taking the course.
-		$is_user_taking_course = Sensei_Utils::user_started_course( $post->ID, $current_user->ID );
 		// Handle user starting the course.
-		if ( isset( $_POST['course_start'] )
+		if (
+			isset( $_POST['course_start'] )
 			&& wp_verify_nonce( $_POST['woothemes_sensei_start_course_noonce'], 'woothemes_sensei_start_course_noonce' )
-			&& ! $is_user_taking_course ) {
+			&& Sensei_Course::can_current_user_manually_enrol( $post->ID )
+		) {
 
 			// Manually enrol a student.
 			$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1387,11 +1387,14 @@ class Sensei_Frontend {
 			&& wp_verify_nonce( $_POST['woothemes_sensei_start_course_noonce'], 'woothemes_sensei_start_course_noonce' )
 			&& ! $is_user_taking_course ) {
 
-			// Start the course.
-			$activity_logged                   = Sensei_Utils::user_start_course( $current_user->ID, $post->ID );
+			// Manually enrol a student.
+			$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+			$manual_enrolment  = $enrolment_manager->get_manual_enrolment_provider();
+			$student_enrolled  = $manual_enrolment && $manual_enrolment->enrol_student( $current_user->ID, $post->ID );
+
 			$this->data                        = new stdClass();
 			$this->data->is_user_taking_course = false;
-			if ( $activity_logged ) {
+			if ( $student_enrolled ) {
 				$this->data->is_user_taking_course = true;
 
 				// Refresh page to avoid re-posting.

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -121,7 +121,7 @@ function sensei_start_course_form( $course_id ) {
 
 				<input type="hidden" name="<?php echo esc_attr( 'woothemes_sensei_start_course_noonce' ); ?>" id="<?php echo esc_attr( 'woothemes_sensei_start_course_noonce' ); ?>" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_start_course_noonce' ) ); ?>" />
 
-				<span><input name="course_start" type="submit" class="course-start" value="<?php esc_html_e( 'Start taking this Course', 'sensei-lms' ); ?>"/></span>
+				<span><input name="course_start" type="submit" class="course-start" value="<?php esc_html_e( 'Take This Course', 'sensei-lms' ); ?>"/></span>
 
 			</form>
 			<?php


### PR DESCRIPTION
_Based on #2848 until merged_

#### Changes proposed in this Pull Request:

* Hey look! A small PR. This just hooks up the frontend form to the manual enrolment provider.

#### Testing instructions:

* Reset database to snapshot created in #2848 testing instructions on `version/2.3.0` tag.
* Switch to this branch.
* Using one of the users that were not enrolled in the course, log in as that user and visit the course page.
* Click `Take This Course` button.
* User should see course progress at the top and in Learner Management they should show up as enrolled.