### PR TITLE
Add transparent background to TinyMCE editor buttons for multi line questions

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -411,6 +411,7 @@ class Sensei_Utils {
 			'editor_class'  => 'sensei_text_editor',
 			'teeny'         => false,
 			'dfw'           => false,
+			'editor_css'    => '<style> .mce-top-part button { background-color: rgba(0,0,0,0); } </style>',
 			'tinymce'       => array(
 				'theme_advanced_buttons1' => $buttons,
 				'theme_advanced_buttons2' => '',


### PR DESCRIPTION
#### Changes proposed in this Pull Request:
This PR adds a clear background to the TinyMCE buttons and is a partial fix for #2806. It's a duplicate of #2833 in order to ship it in the 2.4 release.

#### Testing instructions:
1. Switch to the Twenty Twenty theme.
2. Add a multi line question to a lesson quiz.
3. Browse to that quiz on the front-end.
4. Ensure that the buttons in the TinyMCE editor have a transparent background.

#### Proposed changelog entry for your changes:
Add transparent background to TinyMCE editor buttons for multi line questions