### PR TITLE
Block frontend manual enrollment if there is a handling provider

### DIFF
--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -133,6 +133,24 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 	}
 
 	/**
+	 * Removes an enrolment provider.
+	 */
+	private function removeEnrolmentProvider( $class_name ) {
+		add_filter(
+			'sensei_course_enrolment_providers',
+			function( $providers ) use ( $class_name ) {
+				foreach ( $providers as $index => $provider_class ) {
+					if ( $class_name === $provider_class ) {
+						unset( $providers[ $index ] );
+					}
+				}
+
+				return $providers;
+			}
+		);
+	}
+
+	/**
 	 * Prepare the enrolment manager. Do not do this in production. This is just to simulate what is done on `init`.
 	 */
 	private function prepareEnrolmentManager() {

--- a/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
@@ -71,6 +71,46 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests to make sure manual enrolment is blocked on the frontend if someone filtered out `manual` provider.
+	 */
+	public function testMaybePreventFrontendManualEnrolNoManual() {
+		$course_id         = $this->getSimpleCourse();
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+
+		$this->removeEnrolmentProvider( Sensei_Course_Manual_Enrolment_Provider::class );
+		$this->prepareEnrolmentManager();
+
+		$this->assertFalse( $enrolment_manager->maybe_prevent_frontend_manual_enrol( null, $course_id ) );
+	}
+
+	/**
+	 * Tests to make sure manual enrolment is blocked on the frontend if there is provider that handles the course.
+	 */
+	public function testMaybePreventFrontendManualEnrolHasHandlingProvider() {
+		$course_id         = $this->getSimpleCourse();
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+
+		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
+		$this->prepareEnrolmentManager();
+
+		$this->assertFalse( $enrolment_manager->maybe_prevent_frontend_manual_enrol( null, $course_id ) );
+	}
+
+	/**
+	 * Tests to make sure manual enrolment is blocked on the frontend if there is provider that handles the course.
+	 */
+	public function testMaybeAllowFrontendManualEnrolNoHandlingProvider() {
+		$course_id         = $this->getSimpleCourse();
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+
+		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Never_Handles::class );
+		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Handles_Dog_Courses::class );
+		$this->prepareEnrolmentManager();
+
+		$this->assertEquals( null, $enrolment_manager->maybe_prevent_frontend_manual_enrol( null, $course_id ) );
+	}
+
+	/**
 	 * Simple tests for getting a site's enrolment salt.
 	 *
 	 * @covers Sensei_Course_Enrolment_Manager::get_site_salt


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Previously, WCPC would do this using the `sensei_display_start_course_form` filter. Now that providers can more easily come from anywhere, it might be better to move this up.
* @alexsanford and I decided that by default, manual enrolment should be blocked on the frontend if any other non-manual provider handles access for a course. If a provider wants to override this, they can hook into `sensei_can_user_manually_enrol` further down the filter chain.

#### Testing instructions:

* Assuming it is currently functional, switch to the `add/simple-product-provider` branch of WCPC. 
* Make sure Sensei, WCPC, and Woo are all active.
* Create two courses.
* Create a product. Assign one course to that product.
* In a private tab, sign in as a new user (subscriber).
* Open the free course. You should see the `Take This Course` button. Click that button. You should be enrolled.
* On the paid course, you should see a button to buy the course and not the `Take This Course` button. 