### PR TITLE
Fix 2858: Apply filter when my-courses page not set

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3095,9 +3095,9 @@ class Sensei_Course {
 							esc_html__( 'Register', 'sensei-lms' ) . '</a></div>';
 					}
 				} else {
-
-					wp_register( '<div class="status register">', '</div>' );
-
+					if ( true === (bool) apply_filters( 'sensei_user_can_register_for_course', true, $post->ID ) ) {
+						wp_register( '<div class="status register">', '</div>' );
+					}
 				}
 			}
 		}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3086,18 +3086,17 @@ class Sensei_Course {
 
 				}
 
+				if ( ! (bool) apply_filters( 'sensei_user_can_register_for_course', true, $post->ID ) ) {
+					return;
+				}
 				// If a My Courses page was set in Settings, and 'sensei_use_wp_register_link'
 				// is false, link to My Courses. If not, link to default WordPress registration page.
 				if ( ! empty( $my_courses_page_id ) && $my_courses_page_id && ! $wp_register_link ) {
-					if ( true === (bool) apply_filters( 'sensei_user_can_register_for_course', true, $post->ID ) ) {
 						$my_courses_url = get_permalink( $my_courses_page_id );
 						echo '<div class="status register"><a href="' . esc_url( $my_courses_url ) . '">' .
 							esc_html__( 'Register', 'sensei-lms' ) . '</a></div>';
-					}
 				} else {
-					if ( true === (bool) apply_filters( 'sensei_user_can_register_for_course', true, $post->ID ) ) {
 						wp_register( '<div class="status register">', '</div>' );
-					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #2858 

#### Changes proposed in this Pull Request:

* Apply `sensei_user_can_register_for_course` filter when the "My courses page" is not set

The conditional statement in line 3091 is responsible for checking whether to show the "My courses" page as the registration form, or to show the default WordPress register form (the `wp_register()` inside the `else` on line 3097). The issue here is, that when entering that `else` on line 3097, the filter in discussion is not applied; causing the register button to appear.

#### Testing instructions:

1. Go to Settings > General and ensure the setting "Anyone can register" is set.
2. Go to Sensei LMS > Settings and ensure the "My Courses Page" setting is set to a page.
3. Add the code snippet: add_filter( 'sensei_user_can_register_for_course', '__return_false' );
4. In a logged-out window, visit the course. You should not see the Register button. This is the correct behaviour.
5. Now, go to Sensei LMS > Settings and unset the "My Courses Page" setting (i.e. set it to "Select a Page:").
6. In a logged-out window, visit the course. You should not see the Register button. This is the correct behaviour.


<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Apply `sensei_user_can_register_for_course` filter when the "My courses page" is not set.
