### PR TITLE
Pass the comment ID to the `sensei_is_legacy_enrolled` filter

### DIFF
--- a/includes/class-sensei-course-manual-enrolment-provider.php
+++ b/includes/class-sensei-course-manual-enrolment-provider.php
@@ -161,11 +161,12 @@ class Sensei_Course_Manual_Enrolment_Provider implements Sensei_Course_Enrolment
 		 *
 		 * @since 3.0.0
 		 *
-		 * @param bool $is_legacy_enrolled If the user was actually enrolled before 3.0.0 migration.
-		 * @param int  $user_id            User ID.
-		 * @param int  $course_id          Course post ID.
+		 * @param bool      $is_legacy_enrolled          If the user was actually enrolled before 3.0.0 migration.
+		 * @param int       $user_id                     User ID.
+		 * @param int       $course_id                   Course post ID.
+		 * @param int|false $course_progress_comment_id  Comment ID for the course progress record (if it exists).
 		 */
-		$is_legacy_enrolled = apply_filters( 'sensei_is_legacy_enrolled', $is_legacy_enrolled, $user_id, $course_id );
+		$is_legacy_enrolled = apply_filters( 'sensei_is_legacy_enrolled', $is_legacy_enrolled, $user_id, $course_id, $course_progress_comment_id );
 
 		$migration_log['is_enrolled'] = $is_legacy_enrolled;
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1528,7 +1528,7 @@ class Sensei_Utils {
 	 *
 	 * @param int $course_id Course ID.
 	 * @param int $user_id   User ID.
-	 * @return int|bool false or comment_ID
+	 * @return int|false false or comment_ID
 	 */
 	public static function get_course_progress_comment_id( $course_id, $user_id = null ) {
 		if ( empty( $course_id ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* When we're working on implementing this filter in WCPC, it would be helpful to pass the comment ID to get the start date (and maybe even progress status). 
* They could technically get this, but since we already fetch it we might as well pass it.