### PR TITLE
Add course enrolment recalculation scheduler

### DIFF
--- a/includes/class-sensei-course-enrolment-manager.php
+++ b/includes/class-sensei-course-enrolment-manager.php
@@ -14,6 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Course_Enrolment_Manager {
 	const COURSE_ENROLMENT_SITE_SALT_OPTION = 'sensei_course_enrolment_site_salt';
+	const LEARNER_CALCULATION_META_NAME     = 'learner_calculated_version';
 
 	/**
 	 * Instance of singleton.
@@ -216,5 +217,54 @@ class Sensei_Course_Enrolment_Manager {
 		if ( $course_enrolment ) {
 			$course_enrolment->is_enrolled( $user_id, false );
 		}
+	}
+
+	/**
+	 * Recalculate all enrolments for a specific user. This method will return the cached enrolments if they already
+	 * exist. To enforce a calculation after a possible change, use
+	 * Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check instead.
+	 *
+	 * @param int $user_id   User ID.
+	 *
+	 * @see Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check
+	 */
+	public function recalculate_enrolments( $user_id ) {
+
+		$learner_calculated_version = get_user_meta( $user_id, self::LEARNER_CALCULATION_META_NAME, true );
+		if ( self::get_enrolment_calculation_version() === $learner_calculated_version ) {
+			return;
+		}
+
+		$course_args = [
+			'post_type'      => 'course',
+			'post_status'    => 'publish',
+			'posts_per_page' => - 1,
+			'fields'         => 'ids',
+		];
+
+		$courses = get_posts( $course_args );
+
+		if ( empty( $courses ) ) {
+			return;
+		}
+
+		foreach ( $courses as $course ) {
+			Sensei_Course_Enrolment::get_course_instance( $course )->is_enrolled( $user_id );
+		}
+
+		update_user_meta(
+			$user_id,
+			self::LEARNER_CALCULATION_META_NAME,
+			self::get_enrolment_calculation_version()
+		);
+	}
+
+	/**
+	 * Returns the enrolment calculation version string.
+	 *
+	 * @return string The calculation version.
+	 */
+	public static function get_enrolment_calculation_version() {
+		return self::get_site_salt() . '-' . Sensei()->version;
 	}
 }

--- a/includes/class-sensei-course-enrolment-manager.php
+++ b/includes/class-sensei-course-enrolment-manager.php
@@ -162,11 +162,11 @@ class Sensei_Course_Enrolment_Manager {
 		$all_providers = $this->get_all_enrolment_providers();
 
 		// If the manual provider has been filtered out, do not allow frontend enrolment.
-		if ( ! isset( $all_providers[ Sensei_Course_Manual_Enrolment_Provider::get_id() ] ) ) {
+		if ( ! isset( $all_providers[ Sensei_Course_Manual_Enrolment_Provider::instance()->get_id() ] ) ) {
 			return false;
 		}
 
-		unset( $all_providers[ Sensei_Course_Manual_Enrolment_Provider::get_id() ] );
+		unset( $all_providers[ Sensei_Course_Manual_Enrolment_Provider::instance()->get_id() ] );
 
 		foreach ( $all_providers as $provider ) {
 			if ( $provider->handles_enrolment( $course_id ) ) {

--- a/includes/class-sensei-enrolment-calculation-scheduler.php
+++ b/includes/class-sensei-enrolment-calculation-scheduler.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * File containing the class Sensei_Enrolment_Calculation_Scheduler.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * The Sensei_Enrolment_Calculation_Scheduler is responsible for running jobs of user enrolment calculations. It is set
+ * up to run once after a Sensei version upgrade or when Sensei_Course_Enrolment_Manager::get_site_salt() is updated.
+ */
+class Sensei_Enrolment_Calculation_Scheduler {
+	const CALCULATION_VERSION_OPTION_NAME = 'sensei-scheduler-calculation-version';
+
+	/**
+	 * Number of users for each job run.
+	 *
+	 * @var integer
+	 */
+	private $batch_size;
+
+	/**
+	 * Instance of singleton.
+	 *
+	 * @var self
+	 */
+	private static $instance;
+
+
+	/**
+	 * Sensei_Enrolment_Calculation_Scheduler constructor.
+	 *
+	 * @param integer $batch_size The scheduler's batch size.
+	 */
+	private function __construct( $batch_size ) {
+		$this->batch_size = $batch_size;
+
+		add_action( 'sensei_calculate_enrolments', [ $this, 'calculate_enrolments' ], 10, 0 );
+		add_action( 'init', [ $this, 'start' ], 101 );
+	}
+
+	/**
+	 * Fetches the instance of the class.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self( 20 );
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * This method starts the scheduler if the run is not completed for the current Sensei version.
+	 */
+	public function start() {
+		if ( get_option( self::CALCULATION_VERSION_OPTION_NAME ) === Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version() ) {
+			return;
+		}
+
+		if ( ! wp_next_scheduled( 'sensei_calculate_enrolments' ) ) {
+			wp_schedule_single_event( time(), 'sensei_calculate_enrolments' );
+		}
+	}
+
+	/**
+	 * Stops the scheduler.
+	 */
+	public function stop() {
+		wp_clear_scheduled_hook( 'sensei_calculate_enrolments' );
+	}
+
+
+	/**
+	 * Marks the run as completed and stops the scheduler.
+	 */
+	public function complete() {
+		update_option(
+			self::CALCULATION_VERSION_OPTION_NAME,
+			Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+		);
+		$this->stop();
+	}
+
+	/**
+	 * This method will be called at each scheduled job. It calculates the enrolments for a batch of users.
+	 *
+	 * @access private
+	 */
+	public function calculate_enrolments() {
+
+		$meta_query = [
+			'relation' => 'OR',
+			[
+				'key'     => Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
+				'value'   => Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version(),
+				'compare' => '!=',
+			],
+			[
+				'key'     => Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
+				'compare' => 'NOT EXISTS',
+			],
+		];
+
+		$user_args = [
+			'fields'     => 'ID',
+			'number'     => $this->batch_size,
+			'meta_query' => $meta_query, // phpcs:ignore  WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- The results are limited by the batch size.
+		];
+
+		$users = get_users( $user_args );
+
+		if ( empty( $users ) ) {
+			$this->complete();
+			return;
+		}
+
+		foreach ( $users as $user ) {
+			Sensei_Course_Enrolment_Manager::instance()->recalculate_enrolments( $user );
+		}
+
+		$this->start();
+	}
+}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -178,6 +178,13 @@ class Sensei_Main {
 	public $feature_flags;
 
 	/**
+	 * The scheduler which is responsible to recalculate user enrolments.
+	 *
+	 * @var Sensei_Enrolment_Calculation_Scheduler
+	 */
+	private $enrolment_scheduler;
+
+	/**
 	 * Constructor method.
 	 *
 	 * @param  string $file The base file of the plugin.
@@ -368,6 +375,7 @@ class Sensei_Main {
 
 		Sensei_Blocks::instance()->init();
 		Sensei_Course_Enrolment_Manager::instance()->init();
+		$this->enrolment_scheduler = Sensei_Enrolment_Calculation_Scheduler::instance();
 
 		// Differentiate between administration and frontend logic.
 		if ( is_admin() ) {
@@ -549,6 +557,7 @@ class Sensei_Main {
 	 */
 	public function deactivation() {
 		$this->usage_tracking->unschedule_tracking_task();
+		$this->enrolment_scheduler->stop();
 	}
 
 

--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -135,8 +135,8 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 		add_filter(
 			'sensei_course_enrolment_providers',
 			function( $providers ) use ( $class_name ) {
-				foreach ( $providers as $index => $provider_class ) {
-					if ( $class_name === $provider_class ) {
+				foreach ( $providers as $index => $provider ) {
+					if ( get_class( $provider ) === $class_name ) {
 						unset( $providers[ $index ] );
 					}
 				}

--- a/tests/unit-tests/test-class-sensei-enrolment-calculation-scheduler.php
+++ b/tests/unit-tests/test-class-sensei-enrolment-calculation-scheduler.php
@@ -1,0 +1,231 @@
+<?php
+
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
+
+/**
+ * Tests for Sensei_Enrolment_Calculation_Scheduler class.
+ *
+ * @covers Sensei_Enrolment_Calculation_Scheduler
+ */
+class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
+	/**
+	 * Setup function.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+		Sensei()->deactivation();
+	}
+
+	/**
+	 * Tests that the scheduler starts when the calculation version does not exist.
+	 */
+	public function testSchedulerStartsWhenVersionIsNotSet() {
+		$scheduler = Sensei_Enrolment_Calculation_Scheduler::instance();
+
+		$schedule_called = false;
+
+		tests_add_filter(
+			'schedule_event',
+			function ( $event ) use ( &$schedule_called ) {
+				$schedule_called = true;
+				return $event;
+			}
+		);
+
+		$scheduler->start();
+
+		$this->assertTrue( $schedule_called );
+	}
+
+	/**
+	 * Tests that the scheduler doesn't starts when the calculation version is the current one.
+	 */
+	public function testSchedulerDoesntStartWhenVersionIsSet() {
+		$scheduler = Sensei_Enrolment_Calculation_Scheduler::instance();
+
+		update_option(
+			Sensei_Enrolment_Calculation_Scheduler::CALCULATION_VERSION_OPTION_NAME,
+			Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+		);
+
+		$schedule_called = false;
+
+		tests_add_filter(
+			'schedule_event',
+			function ( $event ) use ( &$schedule_called ) {
+				$schedule_called = true;
+				return $event;
+			}
+		);
+
+		$scheduler->start();
+
+		$this->assertFalse( $schedule_called );
+	}
+
+	/**
+	 * Tests that once the scheduler has started, subsequent starts have no effect.
+	 */
+	public function testSchedulerDoesntRescheduleWhenStartedManyTimes() {
+		$scheduler = Sensei_Enrolment_Calculation_Scheduler::instance();
+
+		$schedule_count = 0;
+
+		tests_add_filter(
+			'schedule_event',
+			function ( $event ) use ( &$schedule_count ) {
+				$schedule_count ++;
+				return $event;
+			}
+		);
+
+		$scheduler->start();
+		$scheduler->start();
+		$scheduler->start();
+
+		$this->assertEquals( 1, $schedule_count );
+	}
+
+	/**
+	 * Tests that once the scheduler run is completed, subsequent starts have no effect.
+	 */
+	public function testSchedulerDoesntStartAfterCompletion() {
+		$scheduler = Sensei_Enrolment_Calculation_Scheduler::instance();
+
+		$schedule_count = 0;
+
+		tests_add_filter(
+			'schedule_event',
+			function ( $event ) use ( &$schedule_count ) {
+				$schedule_count ++;
+				return $event;
+			}
+		);
+
+		$scheduler->start();
+		$scheduler->stop();
+		$scheduler->start();
+
+		$this->assertEquals( 2, $schedule_count );
+
+		$scheduler->complete();
+		$scheduler->start();
+
+		$this->assertEquals( 2, $schedule_count );
+	}
+
+	/**
+	 * Tests that when there are no users to calculate, the schedule run is completed.
+	 */
+	public function testSchedulerCompletesWhenUsersAreCalculated() {
+		$scheduler = Sensei_Enrolment_Calculation_Scheduler::instance();
+
+		update_user_meta(
+			1,
+			Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
+			Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+		);
+
+		for ( $i = 0; $i < 3; $i ++ ) {
+			$user = $this->factory->user->create();
+			update_user_meta(
+				$user,
+				Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
+				Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+			);
+		}
+
+		$scheduler->calculate_enrolments();
+
+		$option = get_option( Sensei_Enrolment_Calculation_Scheduler::CALCULATION_VERSION_OPTION_NAME );
+		$this->assertEquals( Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version(), $option );
+	}
+
+	/**
+	 * Tests that a call to Sensei_Enrolment_Calculation_Scheduler::calculate_enrolments, calculates the enrolments for
+	 * a number of users equal to the batch size.
+	 */
+	public function testSchedulerCalculatesEnrolmentsForOneBatch() {
+		$scheduler = Sensei_Enrolment_Calculation_Scheduler::instance();
+
+		$property = new ReflectionProperty( 'Sensei_Enrolment_Calculation_Scheduler', 'batch_size' );
+		$property->setAccessible( true );
+		$property->setValue( $scheduler, 2 );
+
+		$mock = $this->getMockBuilder( Sensei_Course_Enrolment_Manager::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'recalculate_enrolments' ] )
+			->getMock();
+
+		$property = new ReflectionProperty( 'Sensei_Course_Enrolment_Manager', 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( $mock );
+
+		$user1 = $this->factory->user->create( [ 'user_login' => 'user1' ] );
+		update_user_meta(
+			$user1,
+			Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
+			'random-version-string'
+		);
+		$user2 = $this->factory->user->create( [ 'user_login' => 'user2' ] );
+
+		$mock->expects( $this->exactly( 2 ) )
+			->method( 'recalculate_enrolments' )
+			->withConsecutive(
+				[ $this->equalTo( 1 ) ],
+				[ $this->equalTo( $user1 ) ]
+			);
+
+		$scheduler->calculate_enrolments();
+	}
+
+	/**
+	 * Tests that calling Sensei_Enrolment_Calculation_Scheduler::calculate_enrolments multiple times, eventually
+	 * calculates the enrolments for all users.
+	 */
+	public function testSchedulerCalculatesEnrolmentsForAllBatches() {
+		$scheduler = Sensei_Enrolment_Calculation_Scheduler::instance();
+
+		$property = new ReflectionProperty( 'Sensei_Enrolment_Calculation_Scheduler', 'batch_size' );
+		$property->setAccessible( true );
+		$property->setValue( $scheduler, 2 );
+
+		$mock = $this->getMockBuilder( Sensei_Course_Enrolment_Manager::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'recalculate_enrolments' ] )
+			->getMock();
+
+		$property = new ReflectionProperty( 'Sensei_Course_Enrolment_Manager', 'instance' );
+		$property->setAccessible( true );
+		$property->setValue( $mock );
+
+		$user1 = $this->factory->user->create( [ 'user_login' => 'user1' ] );
+		$user2 = $this->factory->user->create( [ 'user_login' => 'user2' ] );
+
+		$mock->expects( $this->exactly( 3 ) )
+			->method( 'recalculate_enrolments' )
+			->withConsecutive(
+				[ $this->equalTo( 1 ) ],
+				[ $this->equalTo( $user1 ) ],
+				[ $this->equalTo( $user2 ) ]
+			);
+
+		$scheduler->calculate_enrolments();
+
+		// Since we mock Sensei_Course_Enrolment_Manager::recalculate_enrolments we need to manually update users.
+		update_user_meta(
+			1,
+			Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
+			Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+		);
+		update_user_meta(
+			$user1,
+			Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
+			Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+		);
+
+		$scheduler->calculate_enrolments();
+	}
+}


### PR DESCRIPTION
#### Overview
A learner's enrolment to a course is precalculated and stored in the
database in order to have fewer calculations to do when browsing the
site. After version upgrade, lot of these enrolments might change
and need to be recalculated.

The scheduler is responsible for recalculating the enrolment in a
scalable way. It executes a job periodically which calculates the
enrolments for all courses and a small subset of users.

#### Testing instructions:
To test this, you should probably modify the scheduler's interval and batch size which by default are 60 seconds and 20 users respectively. You can trigger the WP cronjobs to run by requesting the `wp-cron.php` file i.e. `http://<your_site>/wp-cron.php`.

To verify that the scheduler does what is supposed to do I queried the database. I am including the queries I used in case someone wants to follow the same approach:

Check enrolment data for all users:
```
SELECT
	t.term_id,
	t.name,
	m.meta_key,
	m.meta_value
FROM
	wp_terms t
	INNER JOIN wp_termmeta m
		ON t.term_id = m.term_id
WHERE 
		t.name LIKE 'user%'
	AND m.meta_key LIKE 'course-enrolment%'
ORDER BY 1;
```

Check the users for which the calculation is completed:
`SELECT * FROM wp_usermeta WHERE meta_key LIKE 'learner%';`

Check if the scheduler work is completed:
`SELECT * FROM wp_options WHERE option_name = 'sensei-scheduler-calculation-version';`