### PR TITLE
Refactor so that providers are instantiated by their handler

### DIFF
--- a/includes/class-sensei-course-enrolment-manager.php
+++ b/includes/class-sensei-course-enrolment-manager.php
@@ -69,24 +69,24 @@ class Sensei_Course_Enrolment_Manager {
 		$this->enrolment_providers = [];
 
 		// Manual enrolment is Sensei's core enrolment provider.
-		$provider_classes = [
-			Sensei_Course_Manual_Enrolment_Provider::class,
+		$providers = [
+			Sensei_Course_Manual_Enrolment_Provider::instance(),
 		];
 
 		/**
 		 * Fetch all registered course enrolment providers.
 		 *
-		 * @param string[] $provider_classes List of enrolment providers classes.
+		 * @param Sensei_Course_Enrolment_Provider_Interface[] $providers List of enrolment providers instances.
 		 *
 		 * @since 3.0.0
 		 */
-		$provider_classes = apply_filters( 'sensei_course_enrolment_providers', $provider_classes );
-		foreach ( $provider_classes as $provider_class ) {
-			if ( ! class_exists( $provider_class ) || ! is_a( $provider_class, 'Sensei_Course_Enrolment_Provider_Interface', true ) ) {
+		$providers = apply_filters( 'sensei_course_enrolment_providers', $providers );
+		foreach ( $providers as $provider ) {
+			if ( ! ( $provider instanceof Sensei_Course_Enrolment_Provider_Interface ) ) {
 				continue;
 			}
 
-			$this->enrolment_providers[ $provider_class::get_id() ] = new $provider_class();
+			$this->enrolment_providers[ $provider->get_id() ] = $provider;
 		}
 	}
 
@@ -104,9 +104,7 @@ class Sensei_Course_Enrolment_Manager {
 			return false;
 		}
 
-		$provider_class = get_class( $provider );
-
-		return $provider_class::get_name();
+		return $provider->get_name();
 	}
 
 	/**
@@ -147,7 +145,7 @@ class Sensei_Course_Enrolment_Manager {
 	 * @throws Exception When there was an attempt to access the manual enrolment providers before providers are collected in init:100.
 	 */
 	public function get_manual_enrolment_provider() {
-		return $this->get_enrolment_provider_by_id( Sensei_Course_Manual_Enrolment_Provider::get_id() );
+		return $this->get_enrolment_provider_by_id( Sensei_Course_Manual_Enrolment_Provider::instance()->get_id() );
 	}
 
 	/**

--- a/includes/class-sensei-course-enrolment-provider-interface.php
+++ b/includes/class-sensei-course-enrolment-provider-interface.php
@@ -18,14 +18,14 @@ interface Sensei_Course_Enrolment_Provider_Interface {
 	 *
 	 * @return int
 	 */
-	public static function get_id();
+	public function get_id();
 
 	/**
 	 * Gets the descriptive name of the provider.
 	 *
 	 * @return string
 	 */
-	public static function get_name();
+	public function get_name();
 
 	/**
 	 * Check if this course enrolment provider manages enrolment for a particular course.
@@ -51,5 +51,5 @@ interface Sensei_Course_Enrolment_Provider_Interface {
 	 *
 	 * @return int
 	 */
-	public static function get_version();
+	public function get_version();
 }

--- a/includes/class-sensei-course-enrolment-provider-interface.php
+++ b/includes/class-sensei-course-enrolment-provider-interface.php
@@ -49,7 +49,7 @@ interface Sensei_Course_Enrolment_Provider_Interface {
 	/**
 	 * Gets the version of the enrolment provider logic. If this changes, enrolment will be recalculated.
 	 *
-	 * @return int
+	 * @return int|string
 	 */
 	public function get_version();
 }

--- a/includes/class-sensei-course-enrolment.php
+++ b/includes/class-sensei-course-enrolment.php
@@ -247,7 +247,7 @@ class Sensei_Course_Enrolment {
 			}
 
 			$enrolment_provider_class              = get_class( $enrolment_provider );
-			$versions[ $enrolment_provider_class ] = $enrolment_provider_class::get_version();
+			$versions[ $enrolment_provider_class ] = $enrolment_provider->get_version();
 		}
 
 		ksort( $versions );

--- a/includes/class-sensei-course-manual-enrolment-provider.php
+++ b/includes/class-sensei-course-manual-enrolment-provider.php
@@ -19,11 +19,36 @@ class Sensei_Course_Manual_Enrolment_Provider implements Sensei_Course_Enrolment
 	const META_PREFIX_MANUAL_STATUS    = 'course-enrolment-manual-';
 
 	/**
+	 * Singleton instance.
+	 *
+	 * @var self
+	 */
+	private static $instance;
+
+	/**
+	 * Provides singleton instance of manual provider.
+	 *
+	 * @return Sensei_Course_Manual_Enrolment_Provider
+	 */
+	public static function instance() {
+		if ( ! isset( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Sensei_Course_Manual_Enrolment_Provider constructor. Private so it can only be initialized internally.
+	 */
+	private function __construct() {}
+
+	/**
 	 * Gets the unique identifier of this enrolment provider.
 	 *
 	 * @return int
 	 */
-	public static function get_id() {
+	public function get_id() {
 		return 'manual';
 	}
 
@@ -32,7 +57,7 @@ class Sensei_Course_Manual_Enrolment_Provider implements Sensei_Course_Enrolment
 	 *
 	 * @return string
 	 */
-	public static function get_name() {
+	public function get_name() {
 		return esc_html__( 'Manual', 'sensei-lms' );
 	}
 
@@ -236,7 +261,7 @@ class Sensei_Course_Manual_Enrolment_Provider implements Sensei_Course_Enrolment
 	 *
 	 * @return int
 	 */
-	public static function get_version() {
+	public function get_version() {
 		// @todo change this to just increment an integer.
 		return filemtime( __FILE__ );
 	}

--- a/includes/class-sensei-course-manual-enrolment-provider.php
+++ b/includes/class-sensei-course-manual-enrolment-provider.php
@@ -259,7 +259,7 @@ class Sensei_Course_Manual_Enrolment_Provider implements Sensei_Course_Enrolment
 	/**
 	 * Gets the version of the enrolment provider logic. If this changes, enrolment will be recalculated.
 	 *
-	 * @return int
+	 * @return int|string
 	 */
 	public function get_version() {
 		// @todo change this to just increment an integer.

--- a/includes/class-sensei-learners-main.php
+++ b/includes/class-sensei-learners-main.php
@@ -322,7 +322,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$actions = [];
 
 				$enrolment_manager         = Sensei_Course_Enrolment_Manager::instance();
-				$manual_enrolment_provider = $enrolment_manager->get_enrolment_provider_by_id( Sensei_Course_Manual_Enrolment_Provider::get_id() );
+				$manual_enrolment_provider = $enrolment_manager->get_manual_enrolment_provider();
 
 				if ( 'course' === $post_type && $manual_enrolment_provider instanceof Sensei_Course_Manual_Enrolment_Provider ) {
 					if ( $manual_enrolment_provider->is_enrolled( $user_activity->user_id, $post_id ) ) {

--- a/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-always-provides.php
+++ b/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-always-provides.php
@@ -11,11 +11,13 @@
  * Used in testing. Always provides enrolment.
  */
 class Sensei_Test_Enrolment_Provider_Always_Provides implements Sensei_Course_Enrolment_Provider_Interface {
-	public static function get_id() {
-		return 'always-provides';
+	const ID = 'always-provides';
+
+	public function get_id() {
+		return self::ID;
 	}
 
-	public static function get_name() {
+	public function get_name() {
 		return 'Always Provides';
 	}
 
@@ -27,7 +29,7 @@ class Sensei_Test_Enrolment_Provider_Always_Provides implements Sensei_Course_En
 		return true;
 	}
 
-	public static function get_version() {
+	public function get_version() {
 		return 1;
 	}
 

--- a/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-denies-crooks.php
+++ b/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-denies-crooks.php
@@ -11,11 +11,13 @@
  * Used in testing. Denies enrolment for crooks.
  */
 class Sensei_Test_Enrolment_Provider_Denies_Crooks implements Sensei_Course_Enrolment_Provider_Interface {
-	public static function get_id() {
-		return 'denies-crooks';
+	const ID = 'denies-crooks';
+
+	public function get_id() {
+		return self::ID;
 	}
 
-	public static function get_name() {
+	public function get_name() {
 		return 'Denies Crooks';
 	}
 
@@ -32,7 +34,7 @@ class Sensei_Test_Enrolment_Provider_Denies_Crooks implements Sensei_Course_Enro
 		return true;
 	}
 
-	public static function get_version() {
+	public function get_version() {
 		return 1;
 	}
 

--- a/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-handles-dog-courses.php
+++ b/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-handles-dog-courses.php
@@ -11,11 +11,13 @@
  * Used in testing. Handles enrolment for courses with "dog" in their title.
  */
 class Sensei_Test_Enrolment_Provider_Handles_Dog_Courses implements Sensei_Course_Enrolment_Provider_Interface {
-	public static function get_id() {
-		return 'handles-dog-courses';
+	const ID = 'handles-dog-courses';
+
+	public function get_id() {
+		return self::ID;
 	}
 
-	public static function get_name() {
+	public function get_name() {
 		return 'Handles Dog Courses';
 	}
 
@@ -31,7 +33,7 @@ class Sensei_Test_Enrolment_Provider_Handles_Dog_Courses implements Sensei_Cours
 		return true;
 	}
 
-	public static function get_version() {
+	public function get_version() {
 		return 1;
 	}
 

--- a/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-never-handles.php
+++ b/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-never-handles.php
@@ -11,11 +11,13 @@
  * Used in testing. Never handles a particular course's enrolment.
  */
 class Sensei_Test_Enrolment_Provider_Never_Handles implements Sensei_Course_Enrolment_Provider_Interface {
-	public static function get_id() {
-		return 'never-handles';
+	const ID = 'never-handles';
+
+	public function get_id() {
+		return self::ID;
 	}
 
-	public static function get_name() {
+	public function get_name() {
 		return 'Never Handles';
 	}
 
@@ -27,7 +29,7 @@ class Sensei_Test_Enrolment_Provider_Never_Handles implements Sensei_Course_Enro
 		return true;
 	}
 
-	public static function get_version() {
+	public function get_version() {
 		return 1;
 	}
 

--- a/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-never-provides.php
+++ b/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-never-provides.php
@@ -11,11 +11,13 @@
  * Used in testing. Never provides enrolment.
  */
 class Sensei_Test_Enrolment_Provider_Never_Provides implements Sensei_Course_Enrolment_Provider_Interface {
-	public static function get_id() {
-		return 'never-provides';
+	const ID = 'never-provides';
+
+	public function get_id() {
+		return self::ID;
 	}
 
-	public static function get_name() {
+	public function get_name() {
 		return 'Never Provides';
 	}
 
@@ -27,7 +29,7 @@ class Sensei_Test_Enrolment_Provider_Never_Provides implements Sensei_Course_Enr
 		return false;
 	}
 
-	public static function get_version() {
+	public function get_version() {
 		return 1;
 	}
 

--- a/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-provides-for-dinosaurs.php
+++ b/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-provides-for-dinosaurs.php
@@ -11,11 +11,13 @@
  * Used in testing. Provides enrolment for dinosaurs only.
  */
 class Sensei_Test_Enrolment_Provider_Provides_For_Dinosaurs implements Sensei_Course_Enrolment_Provider_Interface {
-	public static function get_id() {
-		return 'provides-for-dinosaurs';
+	const ID = 'provides-for-dinosaurs';
+
+	public function get_id() {
+		return self::ID;
 	}
 
-	public static function get_name() {
+	public function get_name() {
 		return 'Provides for Dinosaurs';
 	}
 
@@ -32,7 +34,7 @@ class Sensei_Test_Enrolment_Provider_Provides_For_Dinosaurs implements Sensei_Co
 		return false;
 	}
 
-	public static function get_version() {
+	public function get_version() {
 		return 1;
 	}
 

--- a/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-version-morph.php
+++ b/tests/framework/enrolment-providers/class-sensei-test-enrolment-provider-version-morph.php
@@ -11,13 +11,15 @@
  * Used in testing. Version can be increased. Provides enrolment when version is even.
  */
 class Sensei_Test_Enrolment_Provider_Version_Morph implements Sensei_Course_Enrolment_Provider_Interface {
+	const ID = 'version-morph';
+
 	public static $version = 1;
 
-	public static function get_id() {
-		return 'version-morph';
+	public function get_id() {
+		return self::ID;
 	}
 
-	public static function get_name() {
+	public function get_name() {
 		return 'Version Morph';
 	}
 
@@ -29,7 +31,7 @@ class Sensei_Test_Enrolment_Provider_Version_Morph implements Sensei_Course_Enro
 		return 0 === self::$version % 2;
 	}
 
-	public static function get_version() {
+	public function get_version() {
 		return self::$version;
 	}
 

--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -121,11 +121,7 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 		add_filter(
 			'sensei_course_enrolment_providers',
 			function( $providers ) use ( $class_name ) {
-				if ( in_array( $class_name, $providers, true ) ) {
-					return $providers;
-				}
-
-				$providers[] = $class_name;
+				$providers[] = new $class_name();
 
 				return $providers;
 			}

--- a/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment-manager.php
@@ -37,8 +37,8 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$this->prepareEnrolmentManager();
 
 		$enrolment_manager        = Sensei_Course_Enrolment_Manager::instance();
-		$provider_always_provides = $enrolment_manager->get_enrolment_provider_by_id( Sensei_Test_Enrolment_Provider_Always_Provides::get_id() );
-		$provider_never_provides  = $enrolment_manager->get_enrolment_provider_by_id( Sensei_Test_Enrolment_Provider_Never_Provides::get_id() );
+		$provider_always_provides = $enrolment_manager->get_enrolment_provider_by_id( Sensei_Test_Enrolment_Provider_Always_Provides::ID );
+		$provider_never_provides  = $enrolment_manager->get_enrolment_provider_by_id( Sensei_Test_Enrolment_Provider_Never_Provides::ID );
 
 		$this->assertFalse( $provider_never_provides, 'This provider was never registered and should not be returned.' );
 		$this->assertNotFalse( $provider_always_provides, 'This provider was registered and its singleton instance should be returned' );

--- a/tests/unit-tests/test-class-sensei-course-manual-enrolment-provider.php
+++ b/tests/unit-tests/test-class-sensei-course-manual-enrolment-provider.php
@@ -38,8 +38,8 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 	public function testProviderIsRegistered() {
 		$providers = Sensei_Course_Enrolment_Manager::instance()->get_all_enrolment_providers();
 
-		$this->assertTrue( isset( $providers[ Sensei_Course_Manual_Enrolment_Provider::get_id() ] ), '`manual` provider key should be set' );
-		$this->assertTrue( $providers[ Sensei_Course_Manual_Enrolment_Provider::get_id() ] instanceof Sensei_Course_Manual_Enrolment_Provider, '`manual` provider should be of class Sensei_Course_Manual_Enrolment_Provider' );
+		$this->assertTrue( isset( $providers[ Sensei_Course_Manual_Enrolment_Provider::instance()->get_id() ] ), '`manual` provider key should be set' );
+		$this->assertTrue( $providers[ Sensei_Course_Manual_Enrolment_Provider::instance()->get_id() ] instanceof Sensei_Course_Manual_Enrolment_Provider, '`manual` provider should be of class Sensei_Course_Manual_Enrolment_Provider' );
 	}
 
 	/**


### PR DESCRIPTION
Based on feedback from https://github.com/Automattic/sensei-wc-paid-courses/pull/324#discussion_r372326436, this refactors it so that providers are instantiated before being passed to `Sensei_Course_Enrolment_Manager`. No user-side changes should be in place for this PR.

I think we should keep our own providers as singletons, but this design does not mean other folks could do as @gkaragia suggested and pass settings that change behavior into multiple instances of the same provider class.