### PR TITLE
Fix PHP 7.4 issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
     #    - npm install || exit 1
     #    - npm run test-js || exit 1
     - stage: test
-      php: 7.2
+      php: 7.4
       env: WP_VERSION=latest
       script:
         - ./tests/bin/run-wp-unit-tests.sh

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -967,9 +967,7 @@ class Sensei_Grading {
 
 			$right_answer = (array) get_post_meta( $question_id, '_question_right_answer', true );
 
-			if ( 0 == get_magic_quotes_gpc() ) {
-				$answer = wp_unslash( $answer );
-			}
+			$answer = wp_unslash( $answer );
 			$answer = (array) $answer;
 			if ( is_array( $right_answer ) && count( $right_answer ) == count( $answer ) ) {
 				// Loop through all answers ensure none are 'missing'
@@ -1022,9 +1020,7 @@ class Sensei_Grading {
 		$right_answer  = get_post_meta( $question_id, '_question_right_answer', true );
 		$gapfill_array = explode( '||', $right_answer );
 
-		if ( 0 == get_magic_quotes_gpc() ) { // deprecated from PHP 5.4 but we still support PHP 5.2
-			$user_answer = wp_unslash( $user_answer );
-		}
+		$user_answer = wp_unslash( $user_answer );
 
 		/**
 		 * case sensitive grading filter

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -420,10 +420,7 @@ class Sensei_Quiz {
 			// get the current questions question type
 			$question_type = Sensei()->question->get_question_type( $question_id );
 
-			// Sanitise answer
-			if ( 0 == get_magic_quotes_gpc() ) {
-				$answer = wp_unslash( $answer );
-			}
+			$answer = wp_unslash( $answer );
 
 			// compress the answer for saving
 			if ( 'multi-line' == $question_type ) {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -447,9 +447,8 @@ class Sensei_Utils {
 				$question_type = Sensei()->question->get_question_type( $question_id );
 
 				// Sanitise answer
-				if ( 0 == get_magic_quotes_gpc() ) {
-					$answer = wp_unslash( $answer );
-				}
+				$answer = wp_unslash( $answer );
+
 				switch ( $question_type ) {
 					case 'multi-line':
 						$answer = nl2br( $answer );

--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -46,10 +46,6 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function testDuplicateCourseWithLessons() {
-		$this->assertTrue(
-			method_exists( 'WooThemes_Sensei_Admin', 'duplicate_course_lessons' ),
-			'The admin class function `duplicate_course_lessons` does not exist '
-		);
 
 		$qty_lessons = 2;
 		$duplication = $this->duplicate_course_with_lessons_setup( $qty_lessons );
@@ -97,15 +93,6 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function testDuplicateCourseWithLessonsWithPrerequisite() {
-		$this->assertTrue(
-			method_exists( 'WooThemes_Sensei_Admin', 'duplicate_course_lessons' ),
-			'The admin class function `update_lesson_prerequisite_ids` does not exist '
-		);
-		$this->assertTrue(
-			method_exists( 'WooThemes_Sensei_Admin', 'duplicate_course_lessons' ),
-			'The admin class function `get_prerequisite_update_object` does not exist '
-		);
-
 		$qty_lessons = 2;
 		$duplication = $this->duplicate_course_with_lessons_setup( $qty_lessons );
 		$course_id   = $duplication['course_id'];

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -666,10 +666,8 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$old_data_user_id  = wp_create_user( 'olddata', 'olddata', 'olddata@test.com' );
 		$question_type     = Sensei()->question->get_question_type( $question_id );
 
-		// Sanitise answer
-		if ( 0 == get_magic_quotes_gpc() ) {
-			$answer = wp_unslash( $answer );
-		}
+		$answer = wp_unslash( $answer );
+
 		switch ( $question_type ) {
 			case 'multi-line':
 				$answer = nl2br( $answer );

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -1,5 +1,8 @@
 <?php
 
+/**
+ * @group usage-tracking
+ */
 class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	private $course_ids;
 	private $modules;
@@ -494,6 +497,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_learner_count
 	 */
 	public function testGetUsageDataLearners() {
+		$this->setupCoursesAndModules();
+
 		// Create some users.
 		$subscribers = $this->factory->user->create_many( 8, array( 'role' => 'subscriber' ) );
 		$editors     = $this->factory->user->create_many( 3, array( 'role' => 'editor' ) );
@@ -774,7 +779,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 */
 	public function testGetUsageDataQuestionTypesInvalidType() {
 		// Create a question.
-		$questions = $this->factory->post->create(
+		$question = $this->factory->post->create(
 			array(
 				'post_type'   => 'question',
 				'post_status' => 'publish',
@@ -782,7 +787,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		);
 
 		// Set the question to use an invalid type.
-		wp_set_post_terms( $questions[0], array( 'automattic' ), 'question-type' );
+		wp_set_post_terms( $question, array( 'automattic' ), 'question-type' );
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
 
@@ -932,6 +937,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_course_active_count
 	 */
 	public function testGetCourseActiveCount() {
+		$this->setupCoursesAndModules();
 		$this->enrollUsers();
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
@@ -947,6 +953,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_course_completed_count
 	 */
 	public function testGetCourseCompletedCount() {
+		$this->setupCoursesAndModules();
 		$this->enrollUsers();
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -1480,6 +1480,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests getting lessons with video count.
+	 *
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_lesson_with_video_count
 	 */


### PR DESCRIPTION
Fixes #2785

#### Changes proposed in this Pull Request:

* Removes usages of `get_magic_quotes_gpc()` which was deprecated in 7.4. This hasn't been useful since PHP 5.3.
* Removes new check for `method_exists` from @renatho's PR. An undocumented change in PHP 7.4 is that it no longer allows you to check existence of `private` methods with `method_exists`. @renatho It didn't seem like these were critical to the test, but let me know if I missed something.
* Fixes some usage tracking tests that were probably broken beforehand because we weren't setting up the courses/modules in tests that needed it.
* Adds the top version tested in Travis to 7.4. I Kept 7.0 and 7.1, but it seems unnecessary to check each subsequent major version. Happy to do so, though, if you think best.