### PR TITLE
Courses must be published to have enrolment

### DIFF
--- a/includes/class-sensei-course-enrolment.php
+++ b/includes/class-sensei-course-enrolment.php
@@ -85,6 +85,11 @@ class Sensei_Course_Enrolment {
 	 * @return bool
 	 */
 	public function is_enrolled( $user_id, $check_cache = true ) {
+		// Users can only be enrolled in a published course.
+		if ( 'publish' !== get_post_status( $this->course_id ) ) {
+			return false;
+		}
+
 		try {
 			if ( $check_cache ) {
 				$enrolment_check_results = $this->get_enrolment_check_results( $user_id );

--- a/tests/unit-tests/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/test-class-sensei-course-enrolment.php
@@ -121,6 +121,24 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Check that unpublished courses return `false` for `is_enrolled`.
+	 */
+	public function testEnrolmentCheckUnpublishedCourse() {
+		$course_id  = $this->factory->course->create(
+			[
+				'post_status' => 'draft',
+			]
+		);
+		$student_id = $this->createStandardStudent();
+		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
+		$this->prepareEnrolmentManager();
+
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+
+		$this->assertFalse( $course_enrolment->is_enrolled( $student_id ), 'Students cannot be enrolled in unpublished courses.' );
+	}
+
+	/**
 	 * Check for positive result when positive and negative provider exist. Checks for case when positive is registered second.
 	 */
 	public function testEnrolmentCheckPositivePrevailsSecond() {


### PR DESCRIPTION
While working with @renatho on a WCPC task to add the actions that are fired when products are changed, I found we probably want to not allow enrolment when a course is unpublished. 

The case we're protecting here is:
We have a published course attached to product A.
We unpublish the course. Remove product A and add product B.
On publish, enrolment is recalculated for purchasers of product B but not product A.

To fix this, we're going to have WCPC recalculate for purchasers of product on unpublishing. Unless this returns false, product B customers will continue to have enrolment until it is manually recalculated.

An alternative approach would be to store the state of `_woocommerce_course_products` when we move from a published to a non-published state and then compare when we go again to publish.