### PR TITLE
Fix/issue 2859 - Add setting for enabling/disabling the email sent to a teacher when a course is assigned to them

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -71,6 +71,7 @@ class Sensei_Data_Cleaner {
 		'sensei_courses_page_id',
 		'woothemes-sensei_courses_page_id',
 		'woothemes-sensei_user_dashboard_page_id',
+		'enable_assigned_teacher_course_setting_by_default',
 	);
 
 	/**

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -487,7 +487,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'section'     => 'learner-profile-settings',
 		);
 
-		// Email notifications
+		// Email notifications.
 		$learner_email_options = array(
 			'learner-graded-quiz'      => __( 'Their quiz is graded (auto and manual grading)', 'sensei-lms' ),
 			'learner-completed-course' => __( 'They complete a course', 'sensei-lms' ),
@@ -499,6 +499,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'teacher-completed-lesson' => __( 'A learner completes a lesson', 'sensei-lms' ),
 			'teacher-quiz-submitted'   => __( 'A learner submits a quiz for grading', 'sensei-lms' ),
 			'teacher-new-message'      => __( 'A learner sends a private message to a teacher', 'sensei-lms' ),
+			'teacher-assigned-course'  => __( 'A course is assigned to a teacher', 'sensei-lms' ),
 		);
 
 		$global_email_options = array(
@@ -519,7 +520,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'description' => __( 'Select the notifications that will be sent to teachers.', 'sensei-lms' ),
 			'type'        => 'multicheck',
 			'options'     => $teacher_email_options,
-			'defaults'    => array( 'teacher-completed-course', 'teacher-started-course', 'teacher-quiz-submitted', 'teacher-new-message' ),
+			'defaults'    => array( 'teacher-completed-course', 'teacher-started-course', 'teacher-quiz-submitted', 'teacher-new-message', 'teacher-assigned-course' ),
 			'section'     => 'email-notification-settings',
 		);
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -38,6 +38,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$this->register_hook_listener();
 		$this->get_settings();
+		$this->enable_assigned_teacher_course_setting_by_default();
 
 		// Log when settings are updated by the user.
 		add_action( 'update_option_sensei-settings', [ $this, 'log_settings_update' ], 10, 2 );
@@ -794,6 +795,27 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		return array_filter( array_merge( $added, $removed ) );
 	}
+
+	/**
+	 * Enables the "teacher is assigned course" (notification) setting by default.
+	 *
+	 * Before introducing this setting, the behavior of Sensei was to "send emails
+	 * when a course is assigned to a teacher automatically". The default behavior
+	 * of the newly introduced setting should match that, so that the expeceted
+	 * behavior is not changed automatically.
+	 *
+	 * @return void
+	 */
+	public function enable_assigned_teacher_course_setting_by_default() {
+
+		if ( ! get_option( 'enable_assigned_teacher_course_setting_by_default', false ) && isset( $this->settings['email_teachers'] ) ) {
+			array_push( $this->settings['email_teachers'], 'teacher-assigned-course' );
+			update_option( $this->token, $this->settings );
+			update_option( 'enable_assigned_teacher_course_setting_by_default', 1 );
+		}
+
+	} // End enable assigned teacher course setting by default function.
+
 } // End Class
 
 /**

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -852,16 +852,21 @@ class Sensei_Teacher {
 	 */
 	public function teacher_course_assigned_notification( $teacher_id, $course_id ) {
 
+		// If setting is disabled, exit.
+		if ( ! in_array( 'teacher-assigned-course', (array) Sensei()->settings->settings['email_teacher'], true ) ) {
+			return false;
+		}
+
 		if ( 'course' != get_post_type( $course_id ) || ! get_userdata( $teacher_id ) ) {
 			return false;
 		}
 
-		// if new user is the same as the current logged user, they don't need an email
+		// If new user is the same as the current logged user, they don't need an email.
 		if ( $teacher_id == get_current_user_id() ) {
 			return true;
 		}
 
-		// load the email class
+		// Load the email class.
 		include dirname( __FILE__ ) . '/emails/class-sensei-email-teacher-new-course-assignment.php';
 		$email = new Sensei_Email_Teacher_New_Course_Assignment();
 		$email->trigger( $teacher_id, $course_id );

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -853,7 +853,7 @@ class Sensei_Teacher {
 	public function teacher_course_assigned_notification( $teacher_id, $course_id ) {
 
 		// If setting is disabled, exit.
-		if ( ! in_array( 'teacher-assigned-course', (array) Sensei()->settings->settings['email_teachers'], true ) ) {
+		if ( ! isset( Sensei()->settings->settings['email_teachers'] ) || ! in_array( 'teacher-assigned-course', (array) Sensei()->settings->settings['email_teachers'], true ) ) {
 			return false;
 		}
 

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -853,7 +853,7 @@ class Sensei_Teacher {
 	public function teacher_course_assigned_notification( $teacher_id, $course_id ) {
 
 		// If setting is disabled, exit.
-		if ( ! in_array( 'teacher-assigned-course', (array) Sensei()->settings->settings['email_teacher'], true ) ) {
+		if ( ! in_array( 'teacher-assigned-course', (array) Sensei()->settings->settings['email_teachers'], true ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #2859 

#### Changes proposed in this Pull Request:

* This PR creates a new setting to enable/disable the email sent to a teacher when a course is assigned to them.

#### Testing instructions:
* Go to Sensei Settings-> Email Notifications
* Under "Emails sent to teachers" block, you should see the newly created setting "A course is assigned to a teacher"
* If disabled, when assigning a course to a teacher, the notification email should not be sent to the teacher.
* If enabled, when assigning a course to a teacher, the notification email should be sent to the teacher.



<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
* Add setting for enabling/disabling the email sent to a teacher when a course is assigned to them.
