### PR TITLE
Test and fix lesson ordering on course duplication

### DIFF
--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -143,11 +143,6 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function testDuplicateCourseWithLessonsPreservesOrder() {
-		$this->assertTrue(
-			method_exists( 'WooThemes_Sensei_Admin', 'duplicate_course_lessons' ),
-			'The admin class function `duplicate_course_lessons` does not exist '
-		);
-
 		$qty_lessons = 2;
 		$original    = $this->duplicate_course_with_lessons_setup( $qty_lessons );
 		$course_id   = $original['course_id'];


### PR DESCRIPTION
Fixes #2828 

#### Changes proposed in this Pull Request:

Fix lesson order for courses that are duplicated with their lessons. Note that the bug only seems to have affected lessons that were not in a module.

#### Testing instructions:

- Create a course with several lessons.
- Add some of those lessons to modules, but make sure to leave at least two outside of the modules.
- On the "Order Lessons" page, select the course and reorder the lessons, both inside and outside of modules.
- On the "Courses" page, duplicate the course using the "Duplicate (with lessons)" link.
- Go to the "Order Lessons" page and select the newly created duplicate course. Ensure that the Lesson ordering is the same as it was in the original course, both inside and outside of the modules.
- For bonus points, check the `_lesson_order` meta on the course, the `_order_<course-id>` meta on the lessons without a module, and the `_order_module_<module-id>` meta on the lessons within a module. Ensure that the IDs on the duplicated posts all point to the corresponding duplicated posts. None of them should point back to the original course or lessons. Note, however, that the modules are shared and not duplicated.