### PR TITLE
Tweaks to question media escaping to fix media output

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -660,10 +660,10 @@ class Sensei_Question {
 	 * @return string with allowed html elements
 	 */
 	private static function question_media_kses_post( $source_string ) {
-		$source_tag = array(
+		$source_tag   = array(
 			'source' => array(
 				'type' => true,
-				'src' => true,
+				'src'  => true,
 			),
 		);
 		$allowed_html = array_merge( $source_tag, wp_kses_allowed_html( 'post' ) );

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -617,7 +617,7 @@ class Sensei_Question {
 		if ( $question_media_link ) {
 
 				$output .= '<div class="question_media_display">';
-				$output .= $question_media_link;
+				$output .= self::question_media_kses_post( $question_media_link );
 				$output .= '<dl>';
 
 			if ( $question_media_title ) {
@@ -641,7 +641,6 @@ class Sensei_Question {
 
 	} // end get_the_question_media
 
-
 	/**
 	 * Output the question media
 	 *
@@ -649,9 +648,26 @@ class Sensei_Question {
 	 * @param string $question_id
 	 */
 	public static function the_question_media( $question_id ) {
-		// Note: get_the_question_media() handles escaping output.
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo self::get_the_question_media( $question_id );
+		echo self::question_media_kses_post( self::get_the_question_media( $question_id ) );
+	}
+
+	/**
+	 * Special kses processing for media output to allow 'source' video tag.
+	 *
+	 * @since 2.5.0
+	 * @param string $source_string
+	 * @return string with allowed html elements
+	 */
+	private static function question_media_kses_post( $source_string ) {
+		$source_tag = array(
+			'source' => array(
+				'type' => true,
+				'src' => true,
+			),
+		);
+		$allowed_html = array_merge( $source_tag, wp_kses_allowed_html( 'post' ) );
+
+		return wp_kses( $source_string, $allowed_html );
 	}
 
 	/**

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -617,7 +617,7 @@ class Sensei_Question {
 		if ( $question_media_link ) {
 
 				$output .= '<div class="question_media_display">';
-				$output .= self::question_media_kses_post( $question_media_link );
+				$output .= self::question_media_kses( $question_media_link );
 				$output .= '<dl>';
 
 			if ( $question_media_title ) {
@@ -649,7 +649,7 @@ class Sensei_Question {
 	 */
 	public static function the_question_media( $question_id ) {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo self::question_media_kses_post( self::get_the_question_media( $question_id ) );
+		echo self::question_media_kses( self::get_the_question_media( $question_id ) );
 	}
 
 	/**
@@ -659,7 +659,7 @@ class Sensei_Question {
 	 * @param string $source_string
 	 * @return string with allowed html elements
 	 */
-	private static function question_media_kses_post( $source_string ) {
+	private static function question_media_kses( $source_string ) {
 		$source_tag   = array(
 			'source' => array(
 				'type' => true,

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -649,9 +649,9 @@ class Sensei_Question {
 	 * @param string $question_id
 	 */
 	public static function the_question_media( $question_id ) {
-
+		// Note: get_the_question_media() handles escaping output.
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo self::get_the_question_media( $question_id );
-
 	}
 
 	/**

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -648,6 +648,7 @@ class Sensei_Question {
 	 * @param string $question_id
 	 */
 	public static function the_question_media( $question_id ) {
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		echo self::question_media_kses_post( self::get_the_question_media( $question_id ) );
 	}
 

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -617,7 +617,7 @@ class Sensei_Question {
 		if ( $question_media_link ) {
 
 				$output .= '<div class="question_media_display">';
-				$output .= wp_kses_post( $question_media_link );
+				$output .= $question_media_link;
 				$output .= '<dl>';
 
 			if ( $question_media_title ) {
@@ -650,7 +650,7 @@ class Sensei_Question {
 	 */
 	public static function the_question_media( $question_id ) {
 
-		echo wp_kses_post( self::get_the_question_media( $question_id ) );
+		echo self::get_the_question_media( $question_id );
 
 	}
 

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -654,7 +654,7 @@ class Sensei_Question {
 	/**
 	 * Special kses processing for media output to allow 'source' video tag.
 	 *
-	 * @since 2.5.0
+	 * @since 3.0.0
 	 * @param string $source_string
 	 * @return string with allowed html elements
 	 */


### PR DESCRIPTION
Fixes #2443

#### Changes proposed in this Pull Request:

#2443 was caused by using `wp_kses_post` on the output from `wp_video_shortcode`, which was stripping out the `<source>` tag that is necessary for a browser to load a video.

I've also removed another usage of `wp_kses_post` in `the_question_media()` which seemed redundant because the output was already being escaped in `get_the_question_media()`. This required a `phpcs` ignore though.

I started to write a test but wasn't sure how I could add an actual media attachment for testing the output 🤔 Suggestions welcome!

#### Testing instructions:

* Create some quiz questions and an image, audio and video file to each.
* Verify that the content appears properly in the question on the front-end of the site.

#### Proposed changelog entry for your changes:
Fixes video playback for question media attachments.