### PR TITLE
Remove the taxonomy sensei_learner terms and new user meta on uninstall

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -215,6 +215,7 @@ class Sensei_Data_Cleaner {
 	private static $user_meta_keys = array(
 		'^sensei_hide_menu_settings_notice$',
 		'^_module_progress_[0-9]+_[0-9]+$',
+		'^learner_calculated_version$',
 	);
 
 	/**

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -45,6 +45,7 @@ class Sensei_Data_Cleaner {
 		'question-type',
 		'question-category',
 		'lesson-tag',
+		'sensei_learner',
 	);
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* I didn't add the taxonomy to the data remover class. This just deletes it on uninstall (when the setting is enabled.
* This also deletes the `learner_calculated_version` user meta.

#### Testing instructions:

* Add learners who have enrolment in a course. 
* Enable the setting `Delete data on uninstall` in Sensei settings.
* Deactivate the plugin.
* Uninstall the plugin.
* Verify the learner terms and their corresponding meta are deleted from `{prefix}terms` and `{prefix}term_meta` tables.
