### PR TITLE
Remove enrolments on user deletion

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -933,13 +933,13 @@ class Sensei_Admin {
 	/**
 	 * Delete all user activity when user is deleted.
 	 *
-	 * @deprecated 3.0.0 Use `\Sensei_Learner::delete_all_user_activity` instead. But if you want also remove the enrolment terms, use `\Sensei_Learner::delete_user_registers`.
+	 * @deprecated 3.0.0 Use `\Sensei_Learner::delete_all_user_activity` instead.
 	 *
 	 * @param  integer $user_id User ID.
 	 * @return void
 	 */
 	public function delete_user_activity( $user_id = 0 ) {
-		_deprecated_function( __METHOD__, '3.0.0', 'To remove only activities use `\Sensei_Learner::delete_all_user_activity`. To remove also enrolment terms, use `\Sensei_Learner::delete_user_registers`' );
+		_deprecated_function( __METHOD__, '3.0.0', 'Sensei_Learner::delete_all_user_activity' );
 
 		\Sensei_Learner::instance()->delete_all_user_activity( $user_id );
 	}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -68,9 +68,6 @@ class Sensei_Admin {
 		add_action( 'trash_course', array( $this, 'delete_content' ), 10, 2 );
 		add_action( 'trash_lesson', array( $this, 'delete_content' ), 10, 2 );
 
-		// Delete user activity when user is deleted
-		add_action( 'deleted_user', array( $this, 'delete_user_activity' ), 10, 1 );
-
 		// Add notices to WP dashboard
 		add_action( 'admin_notices', array( $this, 'theme_compatibility_notices' ) );
 		// warn users in case admin_email is not a real WP_User
@@ -934,15 +931,17 @@ class Sensei_Admin {
 	}
 
 	/**
-	 * Delete all user activity when user is deleted
+	 * Delete all user activity when user is deleted.
 	 *
-	 * @param  integer $user_id User ID
+	 * @deprecated 3.0.0 Use `\Sensei_Learner::delete_user_activity` instead.
+	 *
+	 * @param  integer $user_id User ID.
 	 * @return void
 	 */
 	public function delete_user_activity( $user_id = 0 ) {
-		if ( $user_id ) {
-			Sensei_Utils::delete_all_user_activity( $user_id );
-		}
+		_deprecated_function( __METHOD__, '3.0.0', '\Sensei_Learner::delete_user_activity' );
+
+		\Sensei_Learner::instance()->delete_user_activity( $user_id );
 	}
 
 	public function render_settings( $settings = array(), $post_id = 0, $group_id = '' ) {

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -933,15 +933,15 @@ class Sensei_Admin {
 	/**
 	 * Delete all user activity when user is deleted.
 	 *
-	 * @deprecated 3.0.0 Use `\Sensei_Learner::delete_user_activity` instead.
+	 * @deprecated 3.0.0 Use `\Sensei_Learner::delete_all_user_activity` instead. But if you want also remove the enrolment terms, use `\Sensei_Learner::delete_user_registers`.
 	 *
 	 * @param  integer $user_id User ID.
 	 * @return void
 	 */
 	public function delete_user_activity( $user_id = 0 ) {
-		_deprecated_function( __METHOD__, '3.0.0', '\Sensei_Learner::delete_user_activity' );
+		_deprecated_function( __METHOD__, '3.0.0', 'To remove only activities use `\Sensei_Learner::delete_all_user_activity`. To remove also enrolment terms, use `\Sensei_Learner::delete_user_registers`' );
 
-		\Sensei_Learner::instance()->delete_user_activity( $user_id );
+		\Sensei_Learner::instance()->delete_all_user_activity( $user_id );
 	}
 
 	public function render_settings( $settings = array(), $post_id = 0, $group_id = '' ) {

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -12,6 +12,8 @@ class Sensei_Learner {
 	/**
 	 * Instance of singleton.
 	 *
+	 * @since 3.0.0
+	 *
 	 * @var self
 	 */
 	private static $instance;
@@ -25,6 +27,8 @@ class Sensei_Learner {
 
 	/**
 	 * Fetches an instance of the class.
+	 *
+	 * @since 3.0.0
 	 *
 	 * @return self
 	 */
@@ -42,6 +46,8 @@ class Sensei_Learner {
 
 	/**
 	 * Sets the actions.
+	 *
+	 * @since 3.0.0
 	 */
 	public function init() {
 		add_action( 'deleted_user', array( $this, 'delete_user_enrolments' ) );

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -10,11 +10,42 @@
  */
 class Sensei_Learner {
 	/**
+	 * Instance of singleton.
+	 *
+	 * @var self
+	 */
+	private static $instance;
+
+	/**
 	 * Cache of the learner terms.
 	 *
 	 * @var WP_Term[]
 	 */
 	private static $learner_terms = [];
+
+	/**
+	 * Fetches an instance of the class.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Sensei_Course_Enrolment_Manager constructor. Private so it can only be initialized internally.
+	 */
+	private function __construct() {}
+
+	/**
+	 * Sets the actions.
+	 */
+	public function init() {
+
+	}
 
 	/**
 	 * Get the learner term for the user.

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -84,27 +84,29 @@ class Sensei_Learner {
 	public function delete_all_user_activity( $user_id = 0 ) {
 		$dataset_changes = false;
 
-		if ( $user_id ) {
+		if ( ! $user_id ) {
+			return $dataset_changes;
+		}
 
-			$activities = Sensei_Utils::sensei_check_for_activity( array( 'user_id' => $user_id ), true );
+		$activities = Sensei_Utils::sensei_check_for_activity( array( 'user_id' => $user_id ), true );
 
-			if ( $activities ) {
+		if ( ! $activities ) {
+			return $dataset_changes;
+		}
 
-				// Need to always return an array, even with only 1 item.
-				if ( ! is_array( $activities ) ) {
-					$activities = array( $activities );
-				}
+		// Need to always return an array, even with only 1 item.
+		if ( ! is_array( $activities ) ) {
+			$activities = array( $activities );
+		}
 
-				foreach ( $activities as $activity ) {
-					if ( '' == $activity->comment_type ) { // phpcs:ignore WordPress.PHP.StrictComparisons
-						continue;
-					}
-					if ( strpos( 'sensei_', $activity->comment_type ) != 0 ) { // phpcs:ignore WordPress.PHP.StrictComparisons
-						continue;
-					}
-					$dataset_changes = wp_delete_comment( intval( $activity->comment_ID ), true );
-				}
+		foreach ( $activities as $activity ) {
+			if ( '' == $activity->comment_type ) { // phpcs:ignore WordPress.PHP.StrictComparisons
+				continue;
 			}
+			if ( strpos( 'sensei_', $activity->comment_type ) != 0 ) { // phpcs:ignore WordPress.PHP.StrictComparisons
+				continue;
+			}
+			$dataset_changes = wp_delete_comment( intval( $activity->comment_ID ), true );
 		}
 
 		return $dataset_changes;

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -100,10 +100,10 @@ class Sensei_Learner {
 		}
 
 		foreach ( $activities as $activity ) {
-			if ( '' == $activity->comment_type ) { // phpcs:ignore WordPress.PHP.StrictComparisons
+			if ( empty( $activity->comment_type ) ) {
 				continue;
 			}
-			if ( strpos( 'sensei_', $activity->comment_type ) != 0 ) { // phpcs:ignore WordPress.PHP.StrictComparisons
+			if ( strpos( $activity->comment_type, 'sensei_' ) !== 0 ) {
 				continue;
 			}
 			$dataset_changes = wp_delete_comment( intval( $activity->comment_ID ), true );

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -51,26 +51,7 @@ class Sensei_Learner {
 	 */
 	public function init() {
 		// Delete user activity and enrolment terms when user is deleted.
-		add_action( 'deleted_user', array( $this, 'delete_user_registers' ) );
-	}
-
-	/**
-	 * Delete all user activity and enrolment terms when user is deleted.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @param  integer $user_id User ID.
-	 * @return void
-	 */
-	public function delete_user_registers( $user_id = 0 ) {
-		if ( $user_id ) {
-			// Remove activities.
-			$this->delete_all_user_activity( $user_id );
-
-			// Remove enrolment terms.
-			$learner_term = self::get_learner_term( $user_id );
-			wp_delete_term( $learner_term->term_id, Sensei_PostTypes::LEARNER_TAXONOMY_NAME );
-		}
+		add_action( 'deleted_user', array( $this, 'delete_all_user_activity' ) );
 	}
 
 	/**
@@ -87,6 +68,10 @@ class Sensei_Learner {
 		if ( ! $user_id ) {
 			return $dataset_changes;
 		}
+
+		// Remove enrolment terms.
+		$learner_term = self::get_learner_term( $user_id );
+		wp_delete_term( $learner_term->term_id, Sensei_PostTypes::LEARNER_TAXONOMY_NAME );
 
 		$activities = Sensei_Utils::sensei_check_for_activity( array( 'user_id' => $user_id ), true );
 

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -149,7 +149,16 @@ class Sensei_Learner {
 
 	}//end get_full_name()
 
+	/**
+	 * Get all actice lerner ids for a course.
+	 *
+	 * @param int $course_id Course ID.
+	 *
+	 * @deprecated 3.0.0
+	 */
 	public static function get_all_active_learner_ids_for_course( $course_id ) {
+		_deprecated_function( __METHOD__, '3.0.0' );
+
 		$post_id = absint( $course_id );
 
 		if ( ! $post_id ) {
@@ -173,7 +182,16 @@ class Sensei_Learner {
 		return $learner_ids;
 	}
 
+	/**
+	 * Get all users.
+	 *
+	 * @param array $args
+	 *
+	 * @deprecated 3.0.0
+	 */
 	public static function get_all( $args ) {
+		_deprecated_function( __METHOD__, '3.0.0' );
+
 		$post_id  = 0;
 		$activity = '';
 

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -57,6 +57,8 @@ class Sensei_Learner {
 	/**
 	 * Delete all user activity and enrolment terms when user is deleted.
 	 *
+	 * @since 3.0.0
+	 *
 	 * @param  integer $user_id User ID.
 	 * @return void
 	 */

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -44,7 +44,22 @@ class Sensei_Learner {
 	 * Sets the actions.
 	 */
 	public function init() {
+		add_action( 'deleted_user', array( $this, 'delete_user_enrolments' ) );
+	}
 
+	/**
+	 * Remove user enrolments when removing user.
+	 *
+	 * Hooked into deleted_user.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @param int $user_id User ID.
+	 */
+	public function delete_user_enrolments( $user_id ) {
+		$learner_term = self::get_learner_term( $user_id );
+
+		wp_delete_term( $learner_term->term_id, Sensei_PostTypes::LEARNER_TAXONOMY_NAME );
 	}
 
 	/**

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -50,22 +50,25 @@ class Sensei_Learner {
 	 * @since 3.0.0
 	 */
 	public function init() {
-		add_action( 'deleted_user', array( $this, 'delete_user_enrolments' ) );
+		// Delete user activity and enrolment terms when user is deleted.
+		add_action( 'deleted_user', array( $this, 'delete_user_activity' ) );
 	}
 
 	/**
-	 * Remove user enrolments when removing user.
+	 * Delete all user activity and enrolment terms when user is deleted.
 	 *
-	 * Hooked into deleted_user.
-	 *
-	 * @since 3.0.0
-	 *
-	 * @param int $user_id User ID.
+	 * @param  integer $user_id User ID.
+	 * @return void
 	 */
-	public function delete_user_enrolments( $user_id ) {
-		$learner_term = self::get_learner_term( $user_id );
+	public function delete_user_activity( $user_id = 0 ) {
+		if ( $user_id ) {
+			// Remove activities.
+			Sensei_Utils::delete_all_user_activity( $user_id );
 
-		wp_delete_term( $learner_term->term_id, Sensei_PostTypes::LEARNER_TAXONOMY_NAME );
+			// Remove enrolment terms.
+			$learner_term = self::get_learner_term( $user_id );
+			wp_delete_term( $learner_term->term_id, Sensei_PostTypes::LEARNER_TAXONOMY_NAME );
+		}
 	}
 
 	/**

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -192,7 +192,7 @@ class Sensei_Learner {
 	}//end get_full_name()
 
 	/**
-	 * Get all actice lerner ids for a course.
+	 * Get all active learner ids for a course.
 	 *
 	 * @param int $course_id Course ID.
 	 *

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -96,10 +96,10 @@ class Sensei_Learner {
 				}
 
 				foreach ( $activities as $activity ) {
-					if ( '' == $activity->comment_type ) {
+					if ( '' == $activity->comment_type ) { // phpcs:ignore WordPress.PHP.StrictComparisons
 						continue;
 					}
-					if ( strpos( 'sensei_', $activity->comment_type ) != 0 ) {
+					if ( strpos( 'sensei_', $activity->comment_type ) != 0 ) { // phpcs:ignore WordPress.PHP.StrictComparisons
 						continue;
 					}
 					$dataset_changes = wp_delete_comment( intval( $activity->comment_ID ), true );

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -292,43 +292,21 @@ class Sensei_Utils {
 	} // End sensei_delete_activities()
 
 	/**
-	 * Delete all activity for specified user
+	 * Delete all activity for specified user.
 	 *
 	 * @access public
 	 * @since  1.5.0
-	 * @param  integer $user_id User ID
+	 *
+	 * @deprecated 3.0.0 Use `\Sensei_Learner::delete_all_user_activity` instead. But if you want also remove the enrolment terms, use `\Sensei_Learner::delete_user_registers`.
+	 *
+	 * @param  integer $user_id User ID.
 	 * @return boolean
 	 */
 	public static function delete_all_user_activity( $user_id = 0 ) {
+		_deprecated_function( __METHOD__, '3.0.0', 'To remove only activities use `\Sensei_Learner::delete_all_user_activity`. To remove also enrolment terms, use `\Sensei_Learner::delete_user_registers`' );
 
-		$dataset_changes = false;
-
-		if ( $user_id ) {
-
-			$activities = self::sensei_check_for_activity( array( 'user_id' => $user_id ), true );
-
-			if ( $activities ) {
-
-				// Need to always return an array, even with only 1 item
-				if ( ! is_array( $activities ) ) {
-					$activities = array( $activities );
-				}
-
-				foreach ( $activities as $activity ) {
-					if ( '' == $activity->comment_type ) {
-						continue;
-					}
-					if ( strpos( 'sensei_', $activity->comment_type ) != 0 ) {
-						continue;
-					}
-					$dataset_changes = wp_delete_comment( intval( $activity->comment_ID ), true );
-				}
-			}
-		}
-
-		return $dataset_changes;
-	} // Edn delete_all_user_activity()
-
+		return \Sensei_Learner::instance()->delete_all_user_activity( $user_id );
+	} // End delete_all_user_activity()
 
 	/**
 	 * Get value for a specified activity.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -297,13 +297,13 @@ class Sensei_Utils {
 	 * @access public
 	 * @since  1.5.0
 	 *
-	 * @deprecated 3.0.0 Use `\Sensei_Learner::delete_all_user_activity` instead. But if you want also remove the enrolment terms, use `\Sensei_Learner::delete_user_registers`.
+	 * @deprecated 3.0.0 Use `\Sensei_Learner::delete_all_user_activity` instead.
 	 *
 	 * @param  integer $user_id User ID.
 	 * @return boolean
 	 */
 	public static function delete_all_user_activity( $user_id = 0 ) {
-		_deprecated_function( __METHOD__, '3.0.0', 'To remove only activities use `\Sensei_Learner::delete_all_user_activity`. To remove also enrolment terms, use `\Sensei_Learner::delete_user_registers`' );
+		_deprecated_function( __METHOD__, '3.0.0', 'Sensei_Learner::delete_all_user_activity' );
 
 		return \Sensei_Learner::instance()->delete_all_user_activity( $user_id );
 	} // End delete_all_user_activity()

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -374,6 +374,7 @@ class Sensei_Main {
 		$this->usage_tracking->schedule_tracking_task();
 
 		Sensei_Blocks::instance()->init();
+		Sensei_Learner::instance()->init();
 		Sensei_Course_Enrolment_Manager::instance()->init();
 		$this->enrolment_scheduler = Sensei_Enrolment_Calculation_Scheduler::instance();
 

--- a/tests/unit-tests/test-class-learner.php
+++ b/tests/unit-tests/test-class-learner.php
@@ -43,8 +43,9 @@ class Sensei_Class_Student_Test extends WP_UnitTestCase {
 	} // end testClassInstance
 
 	/**
-	 * Tests that Sensei_Course_Enrolment_Manager::delete_user_enrolments delete user enrolments
-	 * when user is deleted.
+	 * Tests that user enrolments terms are deleted when user is deleted.
+	 *
+	 * @covers Sensei_Learner::delete_all_user_activity
 	 */
 	public function testDeleteUserEnrolments() {
 		$course_id  = $this->getSimpleCourse();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Add a feature to remove the enrolments on user deletion.
* There was no good class to add this feature. So I discussed with @jom and we decided to refactor the Learner class to be a singleton, because it would be a good place to add this feature and there are other features that would make sense to be on this class.
* @jom also recommended to refactor `delete_user_activity` method moving it to the Learner class because it's a "global" feature and not related only to admin.

#### Testing instructions:

* Create some courses.
* Register a new user.
* Access the course page to create the metas.
* Check the terms created for this user on the database table `wp_terms` (the term name and slug will be `user-{user_id}`).
* Subscribe to a course.
* Check the comments created about the progress (`comment_type`: `sensei_course_status`). - Because the refactory.
* Delete the user.
* Check again the database registers on `wp_terms` related to this user. It should have been removed.
* Check if the comments about the progress were removed too. - Because the refactory.

#### Deprecations
- `Sensei_Admin::delete_user_activity` is replaced by `Sensei_Learner::delete_all_user_activity`
- `Sensei_Utils:: delete_all_user_activity` is replaced by `Sensei_Learner::delete_all_user_activity`
- `Sensei_Learner::get_all_active_learner_ids_for_course` with no replacement
- `Sensei_Learner:: get_all` with no replacement