### PR TITLE
Add a filter for the course archive page URL

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2651,7 +2651,7 @@ class Sensei_Course {
 		$course_page_id  = intval( Sensei()->settings->settings['course_page'] );
 		$course_page_url = empty( $course_page_id ) ? get_post_type_archive_link( 'course' ) : get_permalink( $course_page_id );
 
-		return $course_page_url;
+		return apply_filters('sensei_course_page_url', $course_page_url);
 
 	}//end get_courses_page_url()
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2657,7 +2657,7 @@ class Sensei_Course {
 		 *
 		 * @param string $course_page_url Course archive page URL.
 		 */
-		return apply_filters( 'sensei_course_page_url', $course_page_url );
+		return apply_filters( 'sensei_course_archive_page_url', $course_page_url );
 	}
 
 	/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2651,7 +2651,7 @@ class Sensei_Course {
 		$course_page_id  = intval( Sensei()->settings->settings['course_page'] );
 		$course_page_url = empty( $course_page_id ) ? get_post_type_archive_link( 'course' ) : get_permalink( $course_page_id );
 
-		return apply_filters('sensei_course_page_url', $course_page_url);
+		return apply_filters( 'sensei_course_page_url', $course_page_url );
 
 	}//end get_courses_page_url()
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2647,13 +2647,18 @@ class Sensei_Course {
 	 * @return string $course_page_url
 	 */
 	public static function get_courses_page_url() {
-
 		$course_page_id  = intval( Sensei()->settings->settings['course_page'] );
 		$course_page_url = empty( $course_page_id ) ? get_post_type_archive_link( 'course' ) : get_permalink( $course_page_id );
 
+		/**
+		 * Filter the course archive page URL.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param string $course_page_url Course archive page URL.
+		 */
 		return apply_filters( 'sensei_course_page_url', $course_page_url );
-
-	}//end get_courses_page_url()
+	}
 
 	/**
 	 * Output the headers on the course archive page


### PR DESCRIPTION
Fixes #2866.

#### Changes proposed in this Pull Request:

* This PR adds a `sensei_course_archive_page_url` filter so that the course archive page URL can be altered by 3PDs.

#### Testing instructions:

* Add the following code to the `functions.php` file of the theme:
```
add_filter( 'sensei_course_archive_page_url', function( $url ) {
	return 'https://google.com';
} );
```
* Log in as a user who has not started any courses.
* Browse to the My Courses page and select the Active Courses tab.
* Click on "Start a Course!" and ensure you're taken to Google's home page.

#### New Filter
- `sensei_course_archive_page_url` - Filter the course archive page URL.