### PR TITLE
Defer triggering recalculation until the end of the request

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -31,6 +31,13 @@ class Sensei_Course_Enrolment_Manager {
 	private $enrolment_providers;
 
 	/**
+	 * Deferred enrolment checks.
+	 *
+	 * @var array
+	 */
+	private $deferred_enrolment_checks = [];
+
+	/**
 	 * Fetches an instance of the class.
 	 *
 	 * @return self
@@ -52,6 +59,7 @@ class Sensei_Course_Enrolment_Manager {
 	 */
 	public function init() {
 		add_action( 'init', [ $this, 'collect_enrolment_providers' ], 100 );
+		add_action( 'shutdown', [ $this, 'run_deferred_course_enrolment_checks' ] );
 		add_filter( 'sensei_can_user_manually_enrol', [ $this, 'maybe_prevent_frontend_manual_enrol' ], 10, 2 );
 	}
 
@@ -179,6 +187,74 @@ class Sensei_Course_Enrolment_Manager {
 	}
 
 	/**
+	 * Run the deferred enrolment checks.
+	 *
+	 * @access private
+	 */
+	public function run_deferred_course_enrolment_checks() {
+		foreach ( $this->deferred_enrolment_checks as $user_id => $course_ids ) {
+			foreach ( array_keys( $course_ids ) as $course_id ) {
+				$this->do_course_enrolment_check( $user_id, $course_id );
+			}
+		}
+	}
+
+	/**
+	 * Defer course enrolment check to the end of request.
+	 *
+	 * @param int $user_id   User ID.
+	 * @param int $course_id Course post ID.
+	 */
+	private function defer_course_enrolment_check( $user_id, $course_id ) {
+		if ( ! isset( $this->deferred_enrolment_checks[ $user_id ] ) ) {
+			$this->deferred_enrolment_checks[ $user_id ] = [];
+		}
+
+		// Check if the enrolment check is already deferred.
+		if ( isset( $this->deferred_enrolment_checks[ $user_id ][ $course_id ] ) ) {
+			return;
+		}
+
+		// Usually the user will be back calculated by the end of the request, but mark them
+		// as needing a recalculation just in case the request fails early.
+		$this->mark_user_as_needing_recalculation( $user_id );
+
+		$this->delete_enrolment_result( $user_id, $course_id );
+
+		$this->deferred_enrolment_checks[ $user_id ][ $course_id ] = true;
+	}
+
+	/**
+	 * Trigger course enrolment check when enrolment might have changed.
+	 *
+	 * @param int $user_id   User ID.
+	 * @param int $course_id Course post ID.
+	 */
+	private function do_course_enrolment_check( $user_id, $course_id ) {
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+		if ( $course_enrolment ) {
+			$course_enrolment->is_enrolled( $user_id, false );
+		}
+
+		if ( isset( $this->deferred_enrolment_checks[ $user_id ] ) ) {
+			unset( $this->deferred_enrolment_checks[ $user_id ][ $course_id ] );
+		}
+	}
+
+	/**
+	 * Delete an enrolment result so that it gets recalculated next time it is requested.
+	 *
+	 * @param int $user_id   User ID.
+	 * @param int $course_id Course post ID.
+	 */
+	private function delete_enrolment_result( $user_id, $course_id ) {
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+		if ( $course_enrolment ) {
+			$course_enrolment->delete_enrolment_result( $user_id );
+		}
+	}
+
+	/**
 	 * Gets the site course enrolment salt that can be used to invalidate all enrolments.
 	 *
 	 * @return string
@@ -213,10 +289,34 @@ class Sensei_Course_Enrolment_Manager {
 	 * @param int $course_id Course post ID.
 	 */
 	public static function trigger_course_enrolment_check( $user_id, $course_id ) {
-		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
-		if ( $course_enrolment ) {
-			$course_enrolment->is_enrolled( $user_id, false );
+		$instance = self::instance();
+
+		if ( self::should_defer_enrolment_check() ) {
+			$instance->defer_course_enrolment_check( $user_id, $course_id );
+
+			return;
 		}
+
+		$instance->do_course_enrolment_check( $user_id, $course_id );
+	}
+
+	/**
+	 * Check if we should defer enrolment checks.
+	 *
+	 * @return bool
+	 */
+	private static function should_defer_enrolment_check() {
+		// If this is called during a cron job, do not defer the enrolment check.
+		if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
+			return false;
+		}
+
+		// If the `shutdown` action has already been fired, do not defer the enrolment check.
+		if ( did_action( 'shutdown' ) ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
@@ -257,6 +357,15 @@ class Sensei_Course_Enrolment_Manager {
 			self::LEARNER_CALCULATION_META_NAME,
 			self::get_enrolment_calculation_version()
 		);
+	}
+
+	/**
+	 * Mark a user as needing recalculation.
+	 *
+	 * @param int $user_id User ID.
+	 */
+	public function mark_user_as_needing_recalculation( $user_id ) {
+		delete_user_meta( $user_id, self::LEARNER_CALCULATION_META_NAME );
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -191,6 +191,15 @@ class Sensei_Course_Enrolment {
 	}
 
 	/**
+	 * Delete the enrolment result for a particular user.
+	 *
+	 * @param int $user_id User ID.
+	 */
+	public function delete_enrolment_result( $user_id ) {
+		delete_user_meta( $user_id, $this->get_course_results_meta_key() );
+	}
+
+	/**
 	 * Get the course log meta key.
 	 *
 	 * @return string

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -91,12 +91,13 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$this->prepareEnrolmentManager();
 
 		Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check( $student_id, $course_id );
-		$this->assertTrue( false === get_user_meta( $student_id, $course_results_meta_key, true ), 'The results meta should not be set yet after lazily triggering a course enrolment check' );
+		$m = get_user_meta( $student_id, $course_results_meta_key, true );
+		$this->assertTrue( '' === get_user_meta( $student_id, $course_results_meta_key, true ), 'The results meta should not be set yet after lazily triggering a course enrolment check' );
 		$this->assertEnrolmentCheckDeferred( $student_id, $course_id, 'There should be a deferred enrolment check for the student/course' );
 
 		Sensei_Course_Enrolment_Manager::instance()->run_deferred_course_enrolment_checks();
 
-		$this->assertTrue( false !== get_user_meta( $student_id, $course_results_meta_key, true ), 'The results meta should be set after running the deferred course enrolment checks' );
+		$this->assertTrue( ! empty( get_user_meta( $student_id, $course_results_meta_key, true ) ), 'The results meta should be set after running the deferred course enrolment checks' );
 		$this->assertEnrolmentChecNotDeferred( $student_id, $course_id, 'There should no longer be a deferred enrolment check for the student/course' );
 	}
 
@@ -255,7 +256,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	 * @param int $user_id   User ID.
 	 * @param int $course_id Course post ID.
 	 */
-	private function assertEnrolmentCheckDeferred( $user_id, $course_id, $message  = null ) {
+	private function assertEnrolmentCheckDeferred( $user_id, $course_id, $message = null ) {
 		$property = new ReflectionProperty( Sensei_Course_Enrolment_Manager::class, 'deferred_enrolment_checks' );
 		$property->setAccessible( true );
 		$deferred = $property->getValue( Sensei_Course_Enrolment_Manager::instance() );
@@ -269,7 +270,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	 * @param int $user_id   User ID.
 	 * @param int $course_id Course post ID.
 	 */
-	private function assertEnrolmentChecNotDeferred( $user_id, $course_id, $message  = null ) {
+	private function assertEnrolmentChecNotDeferred( $user_id, $course_id, $message = null ) {
 		$property = new ReflectionProperty( Sensei_Course_Enrolment_Manager::class, 'deferred_enrolment_checks' );
 		$property->setAccessible( true );
 		$deferred = $property->getValue( Sensei_Course_Enrolment_Manager::instance() );

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -98,7 +98,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		Sensei_Course_Enrolment_Manager::instance()->run_deferred_course_enrolment_checks();
 
 		$this->assertTrue( ! empty( get_user_meta( $student_id, $course_results_meta_key, true ) ), 'The results meta should be set after running the deferred course enrolment checks' );
-		$this->assertEnrolmentChecNotDeferred( $student_id, $course_id, 'There should no longer be a deferred enrolment check for the student/course' );
+		$this->assertEnrolmentCheckNotDeferred( $student_id, $course_id, 'There should no longer be a deferred enrolment check for the student/course' );
 	}
 
 	/**
@@ -116,7 +116,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 
 		Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check( $student_id, $course_id );
 		$this->assertTrue( false !== get_user_meta( $student_id, $course_results_meta_key, true ), 'The results meta should be set yet after immediately running enrolment check' );
-		$this->assertEnrolmentChecNotDeferred( $student_id, $course_id, 'There should not be a deferred enrolment check for the student/course' );
+		$this->assertEnrolmentCheckNotDeferred( $student_id, $course_id, 'There should not be a deferred enrolment check for the student/course' );
 	}
 
 
@@ -270,7 +270,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	 * @param int $user_id   User ID.
 	 * @param int $course_id Course post ID.
 	 */
-	private function assertEnrolmentChecNotDeferred( $user_id, $course_id, $message = null ) {
+	private function assertEnrolmentCheckNotDeferred( $user_id, $course_id, $message = null ) {
 		$property = new ReflectionProperty( Sensei_Course_Enrolment_Manager::class, 'deferred_enrolment_checks' );
 		$property->setAccessible( true );
 		$deferred = $property->getValue( Sensei_Course_Enrolment_Manager::instance() );

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -22,6 +22,15 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tear down.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->clearEnrolmentCheckDeferred();
+	}
+
+	/**
 	 * Clean up after all tests.
 	 */
 	public static function tearDownAfterClass() {
@@ -69,6 +78,46 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$post_notify_enrolment = $course_enrolment->is_enrolled( $student_id );
 		$this->assertFalse( $post_notify_enrolment, 'Now that the crook status is known, they should no longer be enrolled in the course' );
 	}
+
+	/**
+	 * Test o make sure the recalculation happens only once when triggering course enrolment checks.
+	 */
+	public function testDeferredEnrolmentCheckCalled() {
+		$course_id               = $this->getSimpleCourse();
+		$student_id              = $this->createStandardStudent();
+		$course_results_meta_key = Sensei_Course_Enrolment::META_PREFIX_ENROLMENT_RESULTS . $course_id;
+
+		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
+		$this->prepareEnrolmentManager();
+
+		Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check( $student_id, $course_id );
+		$this->assertTrue( false === get_user_meta( $student_id, $course_results_meta_key, true ), 'The results meta should not be set yet after lazily triggering a course enrolment check' );
+		$this->assertEnrolmentCheckDeferred( $student_id, $course_id, 'There should be a deferred enrolment check for the student/course' );
+
+		Sensei_Course_Enrolment_Manager::instance()->run_deferred_course_enrolment_checks();
+
+		$this->assertTrue( false !== get_user_meta( $student_id, $course_results_meta_key, true ), 'The results meta should be set after running the deferred course enrolment checks' );
+		$this->assertEnrolmentChecNotDeferred( $student_id, $course_id, 'There should no longer be a deferred enrolment check for the student/course' );
+	}
+
+	/**
+	 * Test o make sure the recalculation happens immediately once we're inside/after shutdown action.
+	 */
+	public function testEnrolmentCheckCalledImmediatelyDuringShutdown() {
+		$course_id               = $this->getSimpleCourse();
+		$student_id              = $this->createStandardStudent();
+		$course_results_meta_key = Sensei_Course_Enrolment::META_PREFIX_ENROLMENT_RESULTS . $course_id;
+
+		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
+		$this->prepareEnrolmentManager();
+
+		do_action( 'shutdown' );
+
+		Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check( $student_id, $course_id );
+		$this->assertTrue( false !== get_user_meta( $student_id, $course_results_meta_key, true ), 'The results meta should be set yet after immediately running enrolment check' );
+		$this->assertEnrolmentChecNotDeferred( $student_id, $course_id, 'There should not be a deferred enrolment check for the student/course' );
+	}
+
 
 	/**
 	 * Tests to make sure manual enrolment is blocked on the frontend if someone filtered out `manual` provider.
@@ -200,4 +249,40 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		return $mock;
 	}
 
+	/**
+	 * Assert that an enrolment check was deferred.
+	 *
+	 * @param int $user_id   User ID.
+	 * @param int $course_id Course post ID.
+	 */
+	private function assertEnrolmentCheckDeferred( $user_id, $course_id, $message  = null ) {
+		$property = new ReflectionProperty( Sensei_Course_Enrolment_Manager::class, 'deferred_enrolment_checks' );
+		$property->setAccessible( true );
+		$deferred = $property->getValue( Sensei_Course_Enrolment_Manager::instance() );
+
+		$this->assertTrue( isset( $deferred[ $user_id ][ $course_id ] ), $message );
+	}
+
+	/**
+	 * Assert that an enrolment check was NOT deferred.
+	 *
+	 * @param int $user_id   User ID.
+	 * @param int $course_id Course post ID.
+	 */
+	private function assertEnrolmentChecNotDeferred( $user_id, $course_id, $message  = null ) {
+		$property = new ReflectionProperty( Sensei_Course_Enrolment_Manager::class, 'deferred_enrolment_checks' );
+		$property->setAccessible( true );
+		$deferred = $property->getValue( Sensei_Course_Enrolment_Manager::instance() );
+
+		$this->assertFalse( isset( $deferred[ $user_id ][ $course_id ] ), $message );
+	}
+
+	/**
+	 * Reset enrolment check deferment status.
+	 */
+	private function clearEnrolmentCheckDeferred() {
+		$property = new ReflectionProperty( Sensei_Course_Enrolment_Manager::class, 'deferred_enrolment_checks' );
+		$property->setAccessible( true );
+		$property->setValue( Sensei_Course_Enrolment_Manager::instance(), [] );
+	}
 }

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -91,7 +91,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$this->prepareEnrolmentManager();
 
 		Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check( $student_id, $course_id );
-		$m = get_user_meta( $student_id, $course_results_meta_key, true );
+
 		$this->assertTrue( '' === get_user_meta( $student_id, $course_results_meta_key, true ), 'The results meta should not be set yet after lazily triggering a course enrolment check' );
 		$this->assertEnrolmentCheckDeferred( $student_id, $course_id, 'There should be a deferred enrolment check for the student/course' );
 


### PR DESCRIPTION
This should prevent multiple/unnecessary recalculations of enrolment when the same course/user combo is triggered within the same request. It also does the critical thing quickly (invalidate the old enrolment results) so that if the request times out before `shutdown` can recalculate, it shouldn't have an effect on the user experience.

To accomplish this, it immediately marks enrolment results as stale so that if `is_enrolled` is called between `\Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check` and `\Sensei_Course_Enrolment::is_enrolled`, fresh enrolment results will be generated. Doing this should also safeguard issues around the request failing/fatalling prior to `shutdown` running.

I've set it up so that enrolment checks happen immediately if we're inside a cron request _or_ if the `shutdown` action has already occurred. 

No user-facing changes should occur in this PR.