### PR TITLE
Remove user meta on uninstall

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -215,8 +215,8 @@ class Sensei_Data_Cleaner {
 	private static $user_meta_keys = array(
 		'^sensei_hide_menu_settings_notice$',
 		'^_module_progress_[0-9]+_[0-9]+$',
-		'^learner_calculated_version$',
-		'^sensei\-course\-enrolment\-[0-9]+$',
+		'^sensei_learner_calculated_version$',
+		'^sensei_course_enrolment_[0-9]+$',
 	);
 
 	/**

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -216,6 +216,7 @@ class Sensei_Data_Cleaner {
 		'^sensei_hide_menu_settings_notice$',
 		'^_module_progress_[0-9]+_[0-9]+$',
 		'^learner_calculated_version$',
+		'^sensei\-course\-enrolment\-[0-9]+$',
 	);
 
 	/**

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Course_Enrolment_Manager {
 	const COURSE_ENROLMENT_SITE_SALT_OPTION = 'sensei_course_enrolment_site_salt';
-	const LEARNER_CALCULATION_META_NAME     = 'learner_calculated_version';
+	const LEARNER_CALCULATION_META_NAME     = 'sensei_learner_calculated_version';
 
 	/**
 	 * Instance of singleton.

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Handles course enrolment logic for a particular course.
  */
 class Sensei_Course_Enrolment {
-	const META_PREFIX_ENROLMENT_RESULTS = 'course-enrolment-';
+	const META_PREFIX_ENROLMENT_RESULTS = 'sensei-course-enrolment-';
 
 	/**
 	 * Courses instances.

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Handles course enrolment logic for a particular course.
  */
 class Sensei_Course_Enrolment {
-	const META_PREFIX_ENROLMENT_RESULTS = 'sensei-course-enrolment-';
+	const META_PREFIX_ENROLMENT_RESULTS = 'sensei_course_enrolment_';
 
 	/**
 	 * Courses instances.


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* I should have done this in the PR switching to user meta, but I've prefixed our user meta key with `sensei_`. User meta is more of a shared namespace than the learner term meta.
* Similarly, I prefixed `learner_calculated_version` with `sensei_`. (cc: @gkaragia)
* Set it so those user meta entries are removed on plugin uninstall.

#### Testing instructions:

* Enable setting to delete data on uninstall.
* Make sure you have some enrolments calculated and you see `sensei_course_enrolment_*` entries in your user meta table.
* Deactivate and then uninstall the plugin. Verify those entries are removed.
