### PR TITLE
Override queried_object in $wp_query when rendering a dummy post

### DIFF
--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -85,6 +85,8 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 		$wp_query        = clone $wp_query;
 		$wp_query->post  = $post;
 		$wp_query->posts = array( $post );
+		$wp_query->queried_object = $post;
+		$wp_query->queried_object_id = $post->ID;
 		$wp_the_query    = $wp_query;
 		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -81,13 +81,13 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 		 * as well so we can reset it back to this later.
 		 */
 		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited -- Used to mock our own page within a custom loop. Reset afterwards.
-		$post            = $this->dummy_post;
-		$wp_query        = clone $wp_query;
-		$wp_query->post  = $post;
-		$wp_query->posts = array( $post );
-		$wp_query->queried_object = $post;
+		$post                        = $this->dummy_post;
+		$wp_query                    = clone $wp_query;
+		$wp_query->post              = $post;
+		$wp_query->posts             = array( $post );
+		$wp_query->queried_object    = $post;
 		$wp_query->queried_object_id = $post->ID;
-		$wp_the_query    = $wp_query;
+		$wp_the_query                = $wp_query;
 		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		// Prevent comments form from appearing.


### PR DESCRIPTION
Fixes #2754

#### Changes proposed in this Pull Request:

* Override queried_object in $wp_query when creating a dummy post for rendering archive page content in unsupported themes. 

#### Testing instructions:

* PHP notices gone on Courses page on Divi/GeneratePress/Hello Elementor themes.
* Courses page renders and works
