### PR TITLE
Fixes issue with double deferred calculation issues not getting recalculated

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -210,7 +210,9 @@ class Sensei_Course_Enrolment_Manager {
 	 * @param int                                      $user_id           User ID.
 	 */
 	public function remove_deferred_enrolment_check( Sensei_Course_Enrolment_Provider_Results $enrolment_results, $course_id, $user_id ) {
-		unset( $this->deferred_enrolment_checks[ $user_id ][ $course_id ] );
+		if ( isset( $this->deferred_enrolment_checks[ $user_id ] ) ) {
+			unset( $this->deferred_enrolment_checks[ $user_id ][ $course_id ] );
+		}
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -205,9 +205,9 @@ class Sensei_Course_Enrolment_Manager {
 	/**
 	 * When enrolment calculation happens, remove it from deferred calculation.
 	 *
-	 * @param Sensei_Course_Enrolment_Provider_Results $enrolment_results
-	 * @param int                                      $course_id
-	 * @param int                                      $user_id
+	 * @param Sensei_Course_Enrolment_Provider_Results $enrolment_results Enrolment results object.
+	 * @param int                                      $course_id         Course post ID.
+	 * @param int                                      $user_id           User ID.
 	 */
 	public function remove_deferred_enrolment_check( Sensei_Course_Enrolment_Provider_Results $enrolment_results, $course_id, $user_id ) {
 		unset( $this->deferred_enrolment_checks[ $user_id ][ $course_id ] );

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -249,10 +249,6 @@ class Sensei_Course_Enrolment_Manager {
 		if ( $course_enrolment ) {
 			$course_enrolment->is_enrolled( $user_id, false );
 		}
-
-		if ( isset( $this->deferred_enrolment_checks[ $user_id ] ) ) {
-			unset( $this->deferred_enrolment_checks[ $user_id ][ $course_id ] );
-		}
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -60,6 +60,7 @@ class Sensei_Course_Enrolment_Manager {
 	public function init() {
 		add_action( 'init', [ $this, 'collect_enrolment_providers' ], 100 );
 		add_action( 'shutdown', [ $this, 'run_deferred_course_enrolment_checks' ] );
+		add_action( 'sensei_enrolment_results_calculated', [ $this, 'remove_deferred_enrolment_check' ], 10, 3 );
 		add_filter( 'sensei_can_user_manually_enrol', [ $this, 'maybe_prevent_frontend_manual_enrol' ], 10, 2 );
 
 		add_action( 'shutdown', [ Sensei_Enrolment_Provider_State_Store::class, 'persist_all' ] );
@@ -199,6 +200,17 @@ class Sensei_Course_Enrolment_Manager {
 				$this->do_course_enrolment_check( $user_id, $course_id );
 			}
 		}
+	}
+
+	/**
+	 * When enrolment calculation happens, remove it from deferred calculation.
+	 *
+	 * @param Sensei_Course_Enrolment_Provider_Results $enrolment_results
+	 * @param int                                      $course_id
+	 * @param int                                      $user_id
+	 */
+	public function remove_deferred_enrolment_check( Sensei_Course_Enrolment_Provider_Results $enrolment_results, $course_id, $user_id ) {
+		unset( $this->deferred_enrolment_checks[ $user_id ][ $course_id ] );
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -187,6 +187,17 @@ class Sensei_Course_Enrolment {
 		$enrolment_results = new Sensei_Course_Enrolment_Provider_Results( $provider_results, $this->get_course_enrolment_providers_version() );
 		update_user_meta( $user_id, $this->get_enrolment_results_meta_key(), wp_slash( wp_json_encode( $enrolment_results ) ) );
 
+		/**
+		 * Notify upon calculation of enrolment results.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param Sensei_Course_Enrolment_Provider_Results $enrolment_results Enrolment results object.
+		 * @param int                                      $course_id         Course post ID.
+		 * @param int                                      $user_id           User ID.
+		 */
+		do_action( 'sensei_enrolment_results_calculated', $enrolment_results, $this->course_id, $user_id );
+
 		return $enrolment_results;
 	}
 

--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -126,7 +126,7 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 	}
 
 	/**
-	 * Turns a user into a crook by adding "I am a crook" to their description.
+	 * Turns a user into a non-crook by clearing their description.
 	 *
 	 * @param int $user_id
 	 * @return int
@@ -134,7 +134,7 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 	private function turnStudentIntoNormal( $user_id ) {
 		$user = get_user_by( 'ID', $user_id );
 
-		$user->description = 'I am a normal';
+		$user->description = '';
 		wp_update_user( $user );
 
 		return $user_id;

--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -126,6 +126,21 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 	}
 
 	/**
+	 * Turns a user into a crook by adding "I am a crook" to their description.
+	 *
+	 * @param int $user_id
+	 * @return int
+	 */
+	private function turnStudentIntoNormal( $user_id ) {
+		$user = get_user_by( 'ID', $user_id );
+
+		$user->description = 'I am a normal';
+		wp_update_user( $user );
+
+		return $user_id;
+	}
+
+	/**
 	 * Adds an enrolment provider.
 	 */
 	private function addEnrolmentProvider( $class_name ) {

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -1,7 +1,5 @@
 <?php
 
-use Sensei_WC_Paid_Courses\Course_Enrolment_Providers\WooCommerce_Simple;
-
 require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 
 /**


### PR DESCRIPTION
This fixes a regression from https://github.com/Automattic/sensei/pull/2905.

I noticed that a lot of tests started failing in WCPC. This is because of an issue that came up in this scenario:

All in the same request...
1) User receives enrolment.
1) User loses enrolment and triggers change.
1) Enrolment check happens.
1) User gets back enrolment and triggers change. (this is where the bug occurs because the deferred calculation from https://github.com/Automattic/sensei/pull/2905 bails early because it is still in the deferred queue).
1) Enrolment check happens.

One real-world scenario that this might happen in is with Subscription renewal. Subscriptions do  a dance from active -> on-hold -> active.