### PR TITLE
Recalculate when any provider version changes

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -31,6 +31,13 @@ class Sensei_Course_Enrolment_Manager {
 	private $enrolment_providers;
 
 	/**
+	 * Hash of all the enrolment provider versions.
+	 *
+	 * @var string
+	 */
+	private $enrolment_providers_versions_hash;
+
+	/**
 	 * Deferred enrolment checks.
 	 *
 	 * @var array
@@ -100,6 +107,31 @@ class Sensei_Course_Enrolment_Manager {
 
 			$this->enrolment_providers[ $provider->get_id() ] = $provider;
 		}
+	}
+
+	/**
+	 * Generates a hash of all the enrolment provider versions.
+	 *
+	 * @return string
+	 */
+	public function get_enrolment_provider_versions_hash() {
+		if ( ! isset( $this->enrolment_providers_versions_hash ) ) {
+			$versions = [];
+			foreach ( $this->get_all_enrolment_providers() as $enrolment_provider ) {
+				if ( ! ( $enrolment_provider instanceof Sensei_Course_Enrolment_Provider_Interface ) ) {
+					continue;
+				}
+
+				$enrolment_provider_class              = get_class( $enrolment_provider );
+				$versions[ $enrolment_provider_class ] = $enrolment_provider->get_version();
+			}
+
+			ksort( $versions );
+
+			$this->enrolment_providers_versions_hash = md5( wp_json_encode( $versions ) );
+		}
+
+		return $this->enrolment_providers_versions_hash;
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -417,6 +417,12 @@ class Sensei_Course_Enrolment_Manager {
 	 * @return string The calculation version.
 	 */
 	public function get_enrolment_calculation_version() {
-		return $this->get_site_salt() . '-' . Sensei()->version;
+		$hash_components   = [];
+		$hash_components[] = $this->get_site_salt();
+		$hash_components[] = $this->get_enrolment_provider_versions_hash();
+
+		$current_hash = md5( implode( '-', $hash_components ) );
+
+		return $current_hash . '-' . Sensei()->version;
 	}
 }

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -270,11 +270,11 @@ class Sensei_Course_Enrolment_Manager {
 	 *
 	 * @return string
 	 */
-	public static function get_site_salt() {
+	public function get_site_salt() {
 		$enrolment_salt = get_option( self::COURSE_ENROLMENT_SITE_SALT_OPTION );
 
 		if ( ! $enrolment_salt ) {
-			return self::reset_site_salt();
+			return $this->reset_site_salt();
 		}
 
 		return $enrolment_salt;
@@ -285,7 +285,7 @@ class Sensei_Course_Enrolment_Manager {
 	 *
 	 * @return string
 	 */
-	public static function reset_site_salt() {
+	public function reset_site_salt() {
 		$new_salt = md5( uniqid() );
 
 		update_option( self::COURSE_ENROLMENT_SITE_SALT_OPTION, $new_salt, true );
@@ -342,7 +342,7 @@ class Sensei_Course_Enrolment_Manager {
 	public function recalculate_enrolments( $user_id ) {
 
 		$learner_calculated_version = get_user_meta( $user_id, self::LEARNER_CALCULATION_META_NAME, true );
-		if ( self::get_enrolment_calculation_version() === $learner_calculated_version ) {
+		if ( $this->get_enrolment_calculation_version() === $learner_calculated_version ) {
 			return;
 		}
 
@@ -366,7 +366,7 @@ class Sensei_Course_Enrolment_Manager {
 		update_user_meta(
 			$user_id,
 			self::LEARNER_CALCULATION_META_NAME,
-			self::get_enrolment_calculation_version()
+			$this->get_enrolment_calculation_version()
 		);
 	}
 
@@ -384,7 +384,7 @@ class Sensei_Course_Enrolment_Manager {
 	 *
 	 * @return string The calculation version.
 	 */
-	public static function get_enrolment_calculation_version() {
-		return self::get_site_salt() . '-' . Sensei()->version;
+	public function get_enrolment_calculation_version() {
+		return $this->get_site_salt() . '-' . Sensei()->version;
 	}
 }

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -370,6 +370,8 @@ class Sensei_Course_Enrolment {
 	 * @return string
 	 */
 	private function hash_course_enrolment_provider_versions( $enrolment_providers ) {
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+
 		$versions = [];
 		foreach ( $enrolment_providers as $enrolment_provider ) {
 			if ( ! ( $enrolment_provider instanceof Sensei_Course_Enrolment_Provider_Interface ) ) {
@@ -382,7 +384,7 @@ class Sensei_Course_Enrolment {
 
 		ksort( $versions );
 
-		return md5( Sensei_Course_Enrolment_Manager::get_site_salt() . $this->get_course_enrolment_salt() . wp_json_encode( $versions ) );
+		return md5( $enrolment_manager->get_site_salt() . $this->get_course_enrolment_salt() . wp_json_encode( $versions ) );
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -349,23 +349,12 @@ class Sensei_Course_Enrolment {
 	public function get_current_enrolment_result_version() {
 		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
 
-		$components   = [];
-		$components[] = Sensei_Course_Enrolment_Manager::get_site_salt();
-		$components[] = $this->get_course_enrolment_salt();
-		$components[] = $enrolment_manager->get_enrolment_provider_versions_hash();
+		$salt_components   = [];
+		$salt_components[] = $enrolment_manager->get_site_salt();
+		$salt_components[] = $enrolment_manager->get_enrolment_provider_versions_hash();
+		$salt_components[] = $this->get_course_enrolment_salt();
 
-		return md5( implode( '-', $components ) );
-	}
-
-	/**
-	 * Generates a hash of all the enrolment provider versions.
-	 *
-	 * @return string
-	 */
-	private function hash_course_enrolment_provider_versions() {
-		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
-
-		return md5( $enrolment_manager->get_site_salt() . $this->get_course_enrolment_salt() . wp_json_encode( $versions ) );
+		return md5( implode( '-', $salt_components ) );
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -349,12 +349,12 @@ class Sensei_Course_Enrolment {
 	public function get_current_enrolment_result_version() {
 		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
 
-		$salt_components   = [];
-		$salt_components[] = $enrolment_manager->get_site_salt();
-		$salt_components[] = $enrolment_manager->get_enrolment_provider_versions_hash();
-		$salt_components[] = $this->get_course_enrolment_salt();
+		$hash_components   = [];
+		$hash_components[] = $enrolment_manager->get_site_salt();
+		$hash_components[] = $enrolment_manager->get_enrolment_provider_versions_hash();
+		$hash_components[] = $this->get_course_enrolment_salt();
 
-		return md5( implode( '-', $salt_components ) );
+		return md5( implode( '-', $hash_components ) );
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-enrolment-job-scheduler.php
+++ b/includes/enrolment/class-sensei-enrolment-job-scheduler.php
@@ -89,7 +89,9 @@ class Sensei_Enrolment_Job_Scheduler {
 	 * @access private
 	 */
 	public function maybe_start_learner_calculation() {
-		if ( get_option( self::CALCULATION_VERSION_OPTION_NAME ) === Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version() ) {
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+
+		if ( get_option( self::CALCULATION_VERSION_OPTION_NAME ) === $enrolment_manager->get_enrolment_calculation_version() ) {
 			return;
 		}
 
@@ -105,9 +107,11 @@ class Sensei_Enrolment_Job_Scheduler {
 	public function run_learner_calculation() {
 		$job                 = new Sensei_Enrolment_Learner_Calculation_Job( 20 );
 		$completion_callback = function() {
+			$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+
 			update_option(
 				self::CALCULATION_VERSION_OPTION_NAME,
-				Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+				$enrolment_manager->get_enrolment_calculation_version()
 			);
 		};
 

--- a/includes/enrolment/class-sensei-enrolment-learner-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-learner-calculation-job.php
@@ -55,12 +55,13 @@ class Sensei_Enrolment_Learner_Calculation_Job implements Sensei_Enrolment_Job_I
 	 * @return bool
 	 */
 	public function run() {
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
 
 		$meta_query = [
 			'relation' => 'OR',
 			[
 				'key'     => Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
-				'value'   => Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version(),
+				'value'   => $enrolment_manager->get_enrolment_calculation_version(),
 				'compare' => '!=',
 			],
 			[

--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -38,6 +38,10 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 		$enrolment_providers->setAccessible( true );
 		$enrolment_providers->setValue( Sensei_Course_Enrolment_Manager::instance(), null );
 
+		$enrolment_providers = new ReflectionProperty( Sensei_Course_Enrolment_Manager::class, 'enrolment_providers_versions_hash' );
+		$enrolment_providers->setAccessible( true );
+		$enrolment_providers->setValue( Sensei_Course_Enrolment_Manager::instance(), null );
+
 		$course_enrolment_instances = new ReflectionProperty( Sensei_Course_Enrolment::class, 'instances' );
 		$course_enrolment_instances->setAccessible( true );
 		$course_enrolment_instances->setValue( [] );

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -256,7 +256,6 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 			$enrolment_manager->get_enrolment_calculation_version()
 		);
 
-
 		$simple_mock = $this->create_course_enrolment_mock( $simple_course );
 
 		$simple_mock->expects( $this->never() )->method( 'is_enrolled' );

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -245,6 +245,8 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	 * have been already calculated.
 	 */
 	public function testNoCalculationIsPerformedWhenAlreadyCalculated() {
+		$this->prepareEnrolmentManager();
+
 		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
 		$simple_course     = $this->getSimpleCourse();
 		$student_id        = $this->createStandardStudent();
@@ -254,7 +256,6 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 			$enrolment_manager->get_enrolment_calculation_version()
 		);
 
-		$this->prepareEnrolmentManager();
 
 		$simple_mock = $this->create_course_enrolment_mock( $simple_course );
 

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -191,9 +191,11 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Course_Enrolment_Manager::get_site_salt
 	 */
 	public function testGetSiteEnrolmentSalt() {
-		$enrolment_salt = Sensei_Course_Enrolment_Manager::get_site_salt();
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+		$enrolment_salt    = $enrolment_manager->get_site_salt();
+
 		$this->assertTrue( ! empty( $enrolment_salt ), 'Enrolment salt should not be empty' );
-		$this->assertEquals( Sensei_Course_Enrolment_Manager::get_site_salt(), $enrolment_salt, 'Getting enrolment salt twice without resetting should product the same result' );
+		$this->assertEquals( $enrolment_manager->get_site_salt(), $enrolment_salt, 'Getting enrolment salt twice without resetting should product the same result' );
 	}
 
 	/**
@@ -202,11 +204,13 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Course_Enrolment_Manager::get_site_salt
 	 */
 	public function testResetSiteEnrolmentSalt() {
-		$enrolment_salt = Sensei_Course_Enrolment_Manager::get_site_salt();
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+		$enrolment_salt    = $enrolment_manager->get_site_salt();
+
 		$this->assertTrue( ! empty( $enrolment_salt ), 'Enrolment salt should not be empty' );
-		$new_enrolment_salt = Sensei_Course_Enrolment_Manager::reset_site_salt();
-		$this->assertNotEquals( Sensei_Course_Enrolment_Manager::get_site_salt(), $enrolment_salt, 'Getting enrolment salt after resetting it should produce a different result.' );
-		$this->assertEquals( Sensei_Course_Enrolment_Manager::get_site_salt(), $new_enrolment_salt, 'Getting enrolment salt after resetting return the same salt as the reset method returns.' );
+		$new_enrolment_salt = $enrolment_manager->reset_site_salt();
+		$this->assertNotEquals( $enrolment_manager->get_site_salt(), $enrolment_salt, 'Getting enrolment salt after resetting it should produce a different result.' );
+		$this->assertEquals( $enrolment_manager->get_site_salt(), $new_enrolment_salt, 'Getting enrolment salt after resetting return the same salt as the reset method returns.' );
 	}
 
 	/**
@@ -214,9 +218,10 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
  * all courses.
  */
 	public function testEnrolmentsForAllCoursesAreCalculated() {
-		$simple_course = $this->getSimpleCourse();
-		$dog_course    = $this->getDogCourse();
-		$student_id    = $this->createStandardStudent();
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+		$simple_course     = $this->getSimpleCourse();
+		$dog_course        = $this->getDogCourse();
+		$student_id        = $this->createStandardStudent();
 
 		$this->prepareEnrolmentManager();
 
@@ -232,7 +237,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		Sensei_Course_Enrolment_Manager::instance()->recalculate_enrolments( $student_id );
 
 		$user_meta = get_user_meta( $student_id, Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME, true );
-		$this->assertEquals( Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version(), $user_meta );
+		$this->assertEquals( $enrolment_manager->get_enrolment_calculation_version(), $user_meta );
 	}
 
 	/**
@@ -240,12 +245,13 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	 * have been already calculated.
 	 */
 	public function testNoCalculationIsPerformedWhenAlreadyCalculated() {
-		$simple_course = $this->getSimpleCourse();
-		$student_id    = $this->createStandardStudent();
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+		$simple_course     = $this->getSimpleCourse();
+		$student_id        = $this->createStandardStudent();
 		update_user_meta(
 			$student_id,
 			Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
-			Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+			$enrolment_manager->get_enrolment_calculation_version()
 		);
 
 		$this->prepareEnrolmentManager();

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -210,6 +210,57 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests to make sure a provider version bump produces a new result version hash.
+	 */
+	public function testHashChangesOnProviderVersionChange() {
+		Sensei_Test_Enrolment_Provider_Version_Morph::$version = 1;
+
+		$course_id        = $this->getSimpleCourse();
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+
+		$this->resetAndSetUpVersionedProvider( false );
+
+		$initial_version_hash = $course_enrolment->get_current_enrolment_result_version();
+
+		$this->resetAndSetUpVersionedProvider( true ); // Bump version.
+
+		$this->assertNotEquals( $initial_version_hash, $course_enrolment->get_current_enrolment_result_version(), 'Provider version bump should produce a new result version' );
+	}
+
+	/**
+	 * Tests to make sure a course salt reset produces a new result version hash.
+	 */
+	public function testHashChangesOnCourseSaltReset() {
+		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
+		$this->prepareEnrolmentManager();
+
+		$course_id        = $this->getSimpleCourse();
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+
+		$initial_version_hash = $course_enrolment->get_current_enrolment_result_version();
+
+		$course_enrolment->reset_course_enrolment_salt();
+
+		$this->assertNotEquals( $initial_version_hash, $course_enrolment->get_current_enrolment_result_version(), 'Course salt reset should produce a new result version' );
+	}
+
+	/**
+	 * Tests to make sure a site salt reset produces a new result version hash.
+	 */
+	public function testHashChangesOnSiteSaltReset() {
+		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
+		$this->prepareEnrolmentManager();
+
+		$course_id        = $this->getSimpleCourse();
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+
+		$initial_version_hash = $course_enrolment->get_current_enrolment_result_version();
+		Sensei_Course_Enrolment_Manager::reset_site_salt();
+
+		$this->assertNotEquals( $initial_version_hash, $course_enrolment->get_current_enrolment_result_version(), 'Site salt reset should produce a new result version' );
+	}
+
+	/**
 	 * Tests a provider that actually has an opinion about which students are enrolled. Only enrols users with "Dinosaur" in their name.
 	 */
 	public function testEnrolmentCheckConditionalUserPositive() {

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -255,7 +255,7 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
 		$initial_version_hash = $course_enrolment->get_current_enrolment_result_version();
-		Sensei_Course_Enrolment_Manager::reset_site_salt();
+		Sensei_Course_Enrolment_Manager::instance()->reset_site_salt();
 
 		$this->assertNotEquals( $initial_version_hash, $course_enrolment->get_current_enrolment_result_version(), 'Site salt reset should produce a new result version' );
 	}

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
@@ -55,11 +55,12 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 	 * Tests that the scheduler doesn't starts when the calculation version is the current one.
 	 */
 	public function testLearnerCalculationDoesntStartWhenVersionIsSet() {
-		$scheduler = Sensei_Enrolment_Job_Scheduler::instance();
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+		$scheduler         = Sensei_Enrolment_Job_Scheduler::instance();
 
 		update_option(
 			Sensei_Enrolment_Job_Scheduler::CALCULATION_VERSION_OPTION_NAME,
-			Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+			$enrolment_manager->get_enrolment_calculation_version()
 		);
 
 		$scheduler->maybe_start_learner_calculation();
@@ -84,7 +85,8 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 	 * Tests that once the scheduler run is completed, subsequent starts have no effect.
 	 */
 	public function testLearnerCalculationDoesntStartAfterCompletion() {
-		$scheduler = Sensei_Enrolment_Job_Scheduler::instance();
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+		$scheduler         = Sensei_Enrolment_Job_Scheduler::instance();
 
 		$scheduler->maybe_start_learner_calculation();
 		$scheduler->stop_all_jobs();
@@ -95,7 +97,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 
 		update_option(
 			Sensei_Enrolment_Job_Scheduler::CALCULATION_VERSION_OPTION_NAME,
-			Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+			$enrolment_manager->get_enrolment_calculation_version()
 		);
 
 		$scheduler->maybe_start_learner_calculation();
@@ -108,12 +110,13 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 	 * Tests that when there are no users to calculate, the schedule run is completed.
 	 */
 	public function testLearnerCalculationCompletesWhenUsersAreCalculated() {
-		$scheduler = Sensei_Enrolment_Job_Scheduler::instance();
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+		$scheduler         = Sensei_Enrolment_Job_Scheduler::instance();
 
 		update_user_meta(
 			1,
 			Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
-			Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+			$enrolment_manager->get_enrolment_calculation_version()
 		);
 
 		for ( $i = 0; $i < 3; $i ++ ) {
@@ -121,14 +124,14 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 			update_user_meta(
 				$user,
 				Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
-				Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+				$enrolment_manager->get_enrolment_calculation_version()
 			);
 		}
 
 		$scheduler->run_learner_calculation();
 
 		$option = get_option( Sensei_Enrolment_Job_Scheduler::CALCULATION_VERSION_OPTION_NAME );
-		$this->assertEquals( Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version(), $option );
+		$this->assertEquals( $enrolment_manager->get_enrolment_calculation_version(), $option );
 	}
 
 	/**

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
@@ -56,7 +56,8 @@ class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
 	 * calculates the enrolments for all users.
 	 */
 	public function testSchedulerCalculatesEnrolmentsForAllBatches() {
-		$job = new Sensei_Enrolment_Learner_Calculation_Job( 2 );
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+		$job               = new Sensei_Enrolment_Learner_Calculation_Job( 2 );
 
 		$mock = $this->getMockBuilder( Sensei_Course_Enrolment_Manager::class )
 			->disableOriginalConstructor()
@@ -84,12 +85,12 @@ class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
 		update_user_meta(
 			1,
 			Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
-			Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+			$enrolment_manager->get_enrolment_calculation_version()
 		);
 		update_user_meta(
 			$user1,
 			Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
-			Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version()
+			$enrolment_manager->get_enrolment_calculation_version()
 		);
 
 		$job->run();

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
@@ -1,4 +1,5 @@
 <?php
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 
 /**
  * Tests for Sensei_Enrolment_Learner_Calculation_Job class.
@@ -7,6 +8,8 @@
  * @group course-enrolment
  */
 class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
+	use Sensei_Course_Enrolment_Test_Helpers;
+
 	/**
 	 * Setup function.
 	 */
@@ -32,6 +35,8 @@ class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
 		$property = new ReflectionProperty( 'Sensei_Course_Enrolment_Manager', 'instance' );
 		$property->setAccessible( true );
 		$property->setValue( $mock );
+
+		$this->prepareEnrolmentManager();
 
 		$user1 = $this->factory->user->create( [ 'user_login' => 'user1' ] );
 		update_user_meta(
@@ -67,6 +72,8 @@ class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
 		$property = new ReflectionProperty( 'Sensei_Course_Enrolment_Manager', 'instance' );
 		$property->setAccessible( true );
 		$property->setValue( $mock );
+
+		$this->prepareEnrolmentManager();
 
 		$user1 = $this->factory->user->create( [ 'user_login' => 'user1' ] );
 		$user2 = $this->factory->user->create( [ 'user_login' => 'user2' ] );


### PR DESCRIPTION
While working on #2909 I realized that we want an enrolment result to be invalidated if _any_ provider version is bumped.

Before this PR, the version hash was produced with just the providers that handled the course. However, part of the version bump could be due to a change to how a provider determines which courses it provides enrolment for.

This also changes the async job to use both the site salt _and_ the provider versions hash when decided whether or not to run. In doing so, I made the site salt methods non-static (🎁 for @gkaragia). I should have when I made the rest of the class a singleton, but missed them.

This shouldn't result in any easily testable user-facing changes.