### PR TITLE
Add module admin scripts on course edit page

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1494,9 +1494,10 @@ class Sensei_Core_Modules {
 			array( 'course_page_module-order' )
 		);
 
-		// Only load module scripts when adding, editing or ordering modules.
-		if ( ! in_array( $hook, $script_on_pages_white_list )
-			&& ( ! $screen || 'module' !== $screen->taxonomy ) ) {
+		// Only load module scripts when adding, editing or ordering modules or editing course.
+		$screen_related = $screen && ( 'module' === $screen->taxonomy || 'course' === $screen->id );
+
+		if ( ! ( in_array( $hook, $script_on_pages_white_list ) || $screen_related ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes #2889

#### Changes proposed in this Pull Request:

* Load scripts needed for the Module meta box on the Course edit page

#### Testing instructions:

* Open a course for editing
* Click Add module in Course Modules box, add a module
* New module is created and assigned to the course
