### PR TITLE
Don't touch title in the_title hook for quizes when its not a quiz

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1140,7 +1140,7 @@ class Sensei_Quiz {
 			/**
 			 * hook document in class-woothemes-sensei-message.php
 			 */
-			return apply_filters( 'sensei_single_title', $title, get_post_type() );
+			$title = apply_filters( 'sensei_single_title', $title, get_post_type() );
 		}
 
 		return $title;

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1136,12 +1136,14 @@ class Sensei_Quiz {
 
 			// translators: Placeholder is the quiz name with any instance of the word "quiz" removed.
 			$title = sprintf( __( '%s Quiz', 'sensei-lms' ), $title_with_no_quizzes );
+
+			/**
+			 * hook document in class-woothemes-sensei-message.php
+			 */
+			return apply_filters( 'sensei_single_title', $title, get_post_type() );
 		}
 
-		/**
-		 * hook document in class-woothemes-sensei-message.php
-		 */
-		return apply_filters( 'sensei_single_title', $title, get_post_type() );
+		return $title;
 
 	}
 


### PR DESCRIPTION

Fixes #2904

#### Changes proposed in this Pull Request:

* Limit triggering of `sensei_single_title` in single quiz `the_title hook` for quiz posts.

#### Testing instructions:

* Add a filter to `sensei_single_title` and return a modified title.
* Filter only applies to Sensei titles
