### PR TITLE
Fix issue with teachers not being able to enrol students

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -406,7 +406,7 @@ class Sensei_Learner_Management {
 		// validate we can edit date.
 		$may_edit_date = false;
 
-		if ( current_user_can( 'manage_sensei' ) || get_current_user_id() === $post->post_author ) {
+		if ( current_user_can( 'manage_sensei' ) || get_current_user_id() === intval( $post->post_author ) ) {
 			$may_edit_date = true;
 		}
 
@@ -467,7 +467,7 @@ class Sensei_Learner_Management {
 		$may_remove_user = false;
 
 		// Only teachers and admins can remove users.
-		if ( current_user_can( 'manage_sensei' ) || get_current_user_id() === $post->post_author ) {
+		if ( current_user_can( 'manage_sensei' ) || get_current_user_id() === intval( $post->post_author ) ) {
 			$may_remove_user = true;
 		}
 
@@ -548,8 +548,10 @@ class Sensei_Learner_Management {
 		$course_id = intval( $_GET['course_id'] );
 		$post      = get_post( $course_id );
 
+		$may_manage_enrolment = false;
+
 		// Only teachers and admins can enrol and withdraw users.
-		if ( current_user_can( 'manage_sensei' ) || get_current_user_id() === $post->post_author ) {
+		if ( current_user_can( 'manage_sensei' ) || get_current_user_id() === intval( $post->post_author ) ) {
 			$may_manage_enrolment = true;
 		}
 

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -671,6 +671,17 @@ class Sensei_Learner_Management {
 		$lesson_id = isset( $_POST['add_lesson_id'] ) ? $_POST['add_lesson_id'] : '';
 		$results   = [];
 
+		$course = get_post( $course_id );
+		if (
+			! $course
+			|| (
+				! current_user_can( 'manage_sensei' )
+				&& get_current_user_id() !== intval( $course->post_author )
+			)
+		) {
+			return $result;
+		}
+
 		$enrolment_manager         = Sensei_Course_Enrolment_Manager::instance();
 		$manual_enrolment_provider = $enrolment_manager->get_manual_enrolment_provider();
 


### PR DESCRIPTION
Fixes #2921 and #2913. 

#### Changes proposed in this Pull Request:

* Fixes issue with teachers not being able to manually enrol students.
* Adds auth check for adding learners via form.

#### Testing instructions:

* See issue.
* While on learner management for teachers and admins, verify enrolling new students via form still works.