### PR TITLE
Use Action Scheduler for enrolment async jobs when available

### DIFF
--- a/includes/enrolment/class-sensei-enrolment-job-scheduler.php
+++ b/includes/enrolment/class-sensei-enrolment-job-scheduler.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Sensei_Enrolment_Job_Scheduler is a class that handles the async jobs for calculating enrolment.
  */
 class Sensei_Enrolment_Job_Scheduler {
+	const ACTION_SCHEDULER_GROUP          = 'sensei-enrolment';
 	const CALCULATION_VERSION_OPTION_NAME = 'sensei-scheduler-calculation-version';
 
 	/**
@@ -73,14 +74,6 @@ class Sensei_Enrolment_Job_Scheduler {
 		$this->schedule_single_job( $job );
 
 		return $job;
-	}
-
-	/**
-	 * Stops all jobs that this class is responsible for.
-	 */
-	public function stop_all_jobs() {
-		wp_unschedule_hook( Sensei_Enrolment_Learner_Calculation_Job::get_name() );
-		wp_unschedule_hook( Sensei_Enrolment_Course_Calculation_Job::get_name() );
 	}
 
 	/**
@@ -157,8 +150,14 @@ class Sensei_Enrolment_Job_Scheduler {
 		$name       = $class_name::get_name();
 		$args       = [ $job->get_args() ];
 
-		if ( ! wp_next_scheduled( $name, $args ) ) {
-			wp_schedule_single_event( time(), $name, $args );
+		if ( $this->is_action_scheduler_available() ) {
+			if ( ! as_next_scheduled_action( $name, $args, self::ACTION_SCHEDULER_GROUP ) ) {
+				as_schedule_single_action( time(), $name, $args, self::ACTION_SCHEDULER_GROUP );
+			}
+		} else {
+			if ( ! wp_next_scheduled( $name, $args ) ) {
+				wp_schedule_single_event( time(), $name, $args );
+			}
 		}
 	}
 
@@ -173,5 +172,33 @@ class Sensei_Enrolment_Job_Scheduler {
 		$args       = [ $job->get_args() ];
 
 		wp_clear_scheduled_hook( $name, $args );
+
+		if ( $this->is_action_scheduler_available() ) {
+			as_unschedule_all_actions( $name, $args, self::ACTION_SCHEDULER_GROUP );
+		}
+	}
+
+	/**
+	 * Stops all jobs that this class is responsible for.
+	 */
+	public function stop_all_jobs() {
+		wp_unschedule_hook( Sensei_Enrolment_Learner_Calculation_Job::get_name() );
+		wp_unschedule_hook( Sensei_Enrolment_Course_Calculation_Job::get_name() );
+
+		if ( $this->is_action_scheduler_available() ) {
+			as_unschedule_all_actions( null, null, self::ACTION_SCHEDULER_GROUP );
+		}
+	}
+
+	/**
+	 * Check to see if Action Scheduler is available.
+	 *
+	 * @return bool
+	 */
+	private function is_action_scheduler_available() {
+		return class_exists( 'ActionScheduler_Versions' )
+				&& function_exists( 'as_unschedule_all_actions' )
+				&& function_exists( 'as_next_scheduled_action' )
+				&& function_exists( 'as_schedule_single_action' );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This changes the async job running for course enrolment to use [Action Scheduler](https://actionscheduler.org) when available. For sites with WooCommerce this will (a) help speed up batch processing jobs; (b) add job tracking and reliability. 

Action Scheduler maximizes the time it can spend on jobs using various techniques. For sites that use WCPC (and then also Woo), these batch jobs will be heavier and could benefit from AS. 

Alternatively, we could package Action Scheduler inside of Sensei.

#### Testing instructions:

* With WooCommerce activated (or the stand-alone Action Scheduler plugin), initiate an async job by either removing the `sensei-scheduler-calculation-version` option or see #2909 to initiate another job manually.
* Monitor actions from the _Scheduled Actions_ tool under _Tools_. (Example: http://sensei.docker/wp-admin/tools.php?page=action-scheduler&s=sensei&action=-1&paged=1&action2=-1)