### PR TITLE
Filter defer enrolment check behavior

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -317,17 +317,26 @@ class Sensei_Course_Enrolment_Manager {
 	 * @return bool
 	 */
 	private static function should_defer_enrolment_check() {
+		$should_defer_enrolment_check = true;
+
 		// If this is called during a cron job, do not defer the enrolment check.
 		if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
-			return false;
+			$should_defer_enrolment_check = false;
 		}
 
 		// If the `shutdown` action has already been fired, do not defer the enrolment check.
 		if ( did_action( 'shutdown' ) ) {
-			return false;
+			$should_defer_enrolment_check = false;
 		}
 
-		return true;
+		/**
+		 * Override deferment handling for enrolment checking.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param bool $should_defer_enrolment_check True if enrolment checks should be deferred to the end of the request.
+		 */
+		return apply_filters( 'sensei_should_defer_enrolment_check', $should_defer_enrolment_check );
 	}
 
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -33,6 +33,10 @@ class Sensei_Unit_Tests_Bootstrap {
 		tests_add_filter( 'muplugins_loaded', array( $this, 'load_sensei' ) );
 		// install Sensei
 		tests_add_filter( 'setup_theme', array( $this, 'install_sensei' ) );
+
+		// Enrolment checks should happen immediately in tests. Filter can be removed for specific tests.
+		tests_add_filter( 'sensei_should_defer_enrolment_check', '__return_false' );
+
 		// load the WP testing environment
 		require_once $this->wp_tests_dir . '/includes/bootstrap.php';
 		// load Sensei testing framework

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -90,7 +90,9 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
 		$this->prepareEnrolmentManager();
 
+		remove_filter( 'sensei_should_defer_enrolment_check', '__return_false' );
 		Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check( $student_id, $course_id );
+		add_filter( 'sensei_should_defer_enrolment_check', '__return_false' );
 
 		$this->assertTrue( '' === get_user_meta( $student_id, $course_results_meta_key, true ), 'The results meta should not be set yet after lazily triggering a course enrolment check' );
 		$this->assertEnrolmentCheckDeferred( $student_id, $course_id, 'There should be a deferred enrolment check for the student/course' );


### PR DESCRIPTION
After chatting with @alexsanford, we thought it would be better to be able to filter if this behavior should be turned on. For tests, the default will be to immediately calculate enrolment so we don't hide issues that only appear if immediately calculated.