### PR TITLE
Update enrolled courses queries to use learner term

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -723,9 +723,9 @@ class Sensei_Course {
 				'3.0.0'
 			);
 
-			$learner = Sensei_Learner::instance();
+			$learner_manager = Sensei_Learner::instance();
 
-			return $learner->get_enrolled_courses_query( get_current_user_id(), $base_query )->posts;
+			return $learner_manager->get_enrolled_courses_query( get_current_user_id(), $base_query )->posts;
 		}
 
 		$results_array = array();
@@ -795,15 +795,15 @@ class Sensei_Course {
 					'3.0.0'
 				);
 
-				$learner   = Sensei_Learner::instance();
-				$post_args = array(
+				$learner_manager = Sensei_Learner::instance();
+				$post_args       = array(
 					'orderby'          => $orderby,
 					'order'            => $order,
 					'post__in'         => $includes,
 					'post__not_in'     => $excludes,
 					'suppress_filters' => 0,
 				);
-				$post_args = $learner->get_enrolled_courses_query_args( get_current_user_id(), $post_args );
+				$post_args       = $learner_manager->get_enrolled_courses_query_args( get_current_user_id(), $post_args );
 
 				break;
 
@@ -1399,7 +1399,7 @@ class Sensei_Course {
 
 			$active_count = $completed_count = 0;
 
-			$learner = Sensei_Learner::instance();
+			$learner_manager = Sensei_Learner::instance();
 
 			$base_query_args = [
 				'posts_per_page' => $per_page,
@@ -1416,7 +1416,7 @@ class Sensei_Course {
 						'post__in' => $active_ids,
 					]
 				);
-				$active_courses_query = $learner->get_enrolled_courses_query( $user->ID, $active_query_args );
+				$active_courses_query = $learner_manager->get_enrolled_courses_query( $user->ID, $active_query_args );
 				$active_courses       = $active_courses_query->posts;
 				$active_count         = $active_courses_query->found_posts;
 			} // End If Statement
@@ -1432,7 +1432,7 @@ class Sensei_Course {
 						'post__in' => $completed_ids,
 					]
 				);
-				$completed_courses_query = $learner->get_enrolled_courses_query( $user->ID, $completed_query_args );
+				$completed_courses_query = $learner_manager->get_enrolled_courses_query( $user->ID, $completed_query_args );
 				$completed_courses       = $completed_courses_query->posts;
 				$completed_count         = $completed_courses_query->found_posts;
 			} // End If Statement

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -693,9 +693,8 @@ class Sensei_Course {
 	 * @since 1.0.0
 	 * @since 2.0.0 For `$type` argument, `paidcourses` is no longer supported.
 	 * @since 2.0.0 For `$type` argument, `freecourses` is no longer supported.
-	 * @since 3.0.0 For `$type` argument, `usercourses` is no longer supported. Use `Sensei_Learner::get_enrolled_courses_query`.
 	 *
-	 * @access public
+	 * @deprecated 3.0.0
 	 *
 	 * @param int    $amount (default: 0)
 	 * @param string $type (default: 'default')
@@ -703,6 +702,8 @@ class Sensei_Course {
 	 * @return array
 	 */
 	public function course_query( $amount = 0, $type = 'default', $includes = array(), $excludes = array() ) {
+		_deprecated_function( __METHOD__, '3.0.0' );
+
 		if ( 'usercourses' === $type ) {
 			$base_query = [
 				'posts_per_page' => $amount,
@@ -713,13 +714,6 @@ class Sensei_Course {
 			if ( ! empty( $excludes ) ) {
 				$base_query['post__not_in'] = $excludes;
 			}
-
-			// Note: This may break deprecated behavior for users calling this for a non-current user ID.
-			_doing_it_wrong(
-				__METHOD__,
-				esc_html__( 'Querying for argument `$type` of `usercourses` is deprecated. Use `Sensei_Learner::get_enrolled_courses_query`.', 'sensei-lms' ),
-				'3.0.0'
-			);
 
 			$learner_manager = Sensei_Learner::instance();
 
@@ -754,15 +748,16 @@ class Sensei_Course {
 	 * @since 1.0.0
 	 * @since 2.0.0 For `$type` argument, `paidcourses` is no longer supported.
 	 * @since 2.0.0 For `$type` argument, `freecourses` is no longer supported.
-	 * @since 3.0.0 For `$type` argument, `usercourses` is no longer supported. Use `Sensei_Learner::get_enrolled_courses_query`.
 	 *
-	 * @access public
+	 * @deprecated 3.0.0
+	 *
 	 * @param string $type (default: '')
 	 * @param int    $amount (default: 0)
 	 * @param array  $includes (default: array())
 	 * @return array
 	 */
 	public function get_archive_query_args( $type = '', $amount = 0, $includes = array(), $excludes = array() ) {
+		_deprecated_function( __METHOD__, '3.0.0' );
 
 		global $wp_query;
 
@@ -787,12 +782,6 @@ class Sensei_Course {
 		switch ( $type ) {
 
 			case 'usercourses':
-				_doing_it_wrong(
-					__METHOD__,
-					esc_html__( 'Querying with argument `$type` having a value of `usercourses` is deprecated. Use `Sensei_Learner::get_enrolled_courses_query`.', 'sensei-lms' ),
-					'3.0.0'
-				);
-
 				$learner_manager = Sensei_Learner::instance();
 				$post_args       = array(
 					'orderby'          => $orderby,

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1386,7 +1386,7 @@ class Sensei_Course {
 
 			$completed_query_args    = [
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Safe use of pagination var.
-				'paged'          => isset( $_GET['active_page'] ) ? absint( $_GET['active_page'] ) : 1,
+				'paged'          => isset( $_GET['completed_page'] ) ? absint( $_GET['completed_page'] ) : 1,
 				'posts_per_page' => $per_page,
 			];
 			$completed_courses_query = $learner_manager->get_enrolled_completed_courses_query( $user->ID, $completed_query_args );

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -154,9 +154,9 @@ class Sensei_Learner {
 		$query_args = $this->get_enrolled_courses_query_args( $user_id, $base_query_args );
 
 		if ( 'active' === $type ) {
-			$course_ids = $this->get_active_course_ids( $user_id );
+			$course_ids = $this->get_course_ids_by_progress_status( $user_id, 'in-progress' );
 		} else {
-			$course_ids = $this->get_completed_course_ids( $user_id );
+			$course_ids = $this->get_course_ids_by_progress_status( $user_id, 'complete' );
 		}
 
 		if ( ! empty( $query_args['post__in'] ) ) {
@@ -228,28 +228,6 @@ class Sensei_Learner {
 		 * @param int $user_id User ID.
 		 */
 		do_action( 'sensei_before_learners_enrolled_courses_query', $user_id );
-	}
-
-	/**
-	 * Get the course IDs for a learner's completed courses.
-	 *
-	 * @param int $user_id User ID.
-	 *
-	 * @return int[]
-	 */
-	private function get_completed_course_ids( $user_id ) {
-		return $this->get_course_ids_by_progress_status( $user_id, 'complete' );
-	}
-
-	/**
-	 * Get the course IDs for a learner's active courses.
-	 *
-	 * @param int $user_id User ID.
-	 *
-	 * @return int[]
-	 */
-	private function get_active_course_ids( $user_id ) {
-		return $this->get_course_ids_by_progress_status( $user_id, 'in-progress' );
 	}
 
 	/**

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -144,7 +144,7 @@ class Sensei_Learner {
 	 *
 	 * @param int    $user_id         User ID.
 	 * @param array  $base_query_args Base query arguments.
-	 * @param string $type            Type of query to run.
+	 * @param string $type            Type of query to run (`active` or `completed`).
 	 *
 	 * @return WP_Query
 	 */

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -198,7 +198,10 @@ class Sensei_Learner {
 			}
 
 			if ( ! empty( $query_args['post__in'] ) ) {
-				$course_ids = array_intersect( $course_ids, (array) $query_args['post__in'] );
+				$existing_course_ids = (array) $query_args['post__in'];
+				$existing_course_ids = array_map( 'intval', $existing_course_ids );
+
+				$course_ids = array_intersect( $course_ids, $existing_course_ids );
 			}
 
 			if ( empty( $course_ids ) ) {
@@ -260,7 +263,7 @@ class Sensei_Learner {
 		}
 
 		foreach ( $course_statuses as $status ) {
-			$course_ids[] = $status->comment_post_ID;
+			$course_ids[] = intval( $status->comment_post_ID );
 		}
 
 		return $course_ids;

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -9,7 +9,7 @@
  * @since 1.9.0
  */
 class Sensei_Learner {
-	const LEARNER_TERM_PREFIX              = 'user-';
+	const LEARNER_TERM_PREFIX = 'user-';
 
 	/**
 	 * Instance of singleton.

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -9,10 +9,10 @@
  * @since 1.9.0
  */
 class Sensei_Learner {
-	const LEARNER_TERM_PREFIX            = 'user-';
-	const COURSE_STATUS_FILTER           = 'sensei_course_status';
-	const COURSE_STATUS_FILTER_COMPLETED = 'completed';
-	const COURSE_STATUS_FILTER_ACTIVE    = 'active';
+	const LEARNER_TERM_PREFIX              = 'user-';
+	const COURSE_PROGRESS_FILTER           = 'sensei_course_progress';
+	const COURSE_PROGRESS_FILTER_COMPLETED = 'completed';
+	const COURSE_PROGRESS_FILTER_ACTIVE    = 'active';
 
 	/**
 	 * Instance of singleton.
@@ -134,7 +134,7 @@ class Sensei_Learner {
 	 * @return WP_Query
 	 */
 	public function get_enrolled_active_courses_query( $user_id, $base_query_args = [] ) {
-		$base_query_args[ self::COURSE_STATUS_FILTER ] = self::COURSE_STATUS_FILTER_ACTIVE;
+		$base_query_args[ self::COURSE_PROGRESS_FILTER ] = self::COURSE_PROGRESS_FILTER_ACTIVE;
 
 		return $this->get_enrolled_courses_query( $user_id, $base_query_args );
 	}
@@ -147,7 +147,7 @@ class Sensei_Learner {
 	 * @return WP_Query
 	 */
 	public function get_enrolled_completed_courses_query( $user_id, $base_query_args = [] ) {
-		$base_query_args[ self::COURSE_STATUS_FILTER ] = self::COURSE_STATUS_FILTER_COMPLETED;
+		$base_query_args[ self::COURSE_PROGRESS_FILTER ] = self::COURSE_PROGRESS_FILTER_COMPLETED;
 
 		return $this->get_enrolled_courses_query( $user_id, $base_query_args );
 	}
@@ -188,12 +188,12 @@ class Sensei_Learner {
 			'include_children' => false,
 		];
 
-		if ( isset( $query_args[ self::COURSE_STATUS_FILTER ] ) ) {
+		if ( isset( $query_args[ self::COURSE_PROGRESS_FILTER ] ) ) {
 			$course_ids = [];
-			if ( self::COURSE_STATUS_FILTER_COMPLETED === $query_args[ self::COURSE_STATUS_FILTER ] ) {
+			if ( self::COURSE_PROGRESS_FILTER_COMPLETED === $query_args[ self::COURSE_PROGRESS_FILTER ] ) {
 				$course_ids = $this->get_completed_course_ids( $user_id );
 			}
-			if ( self::COURSE_STATUS_FILTER_ACTIVE === $query_args[ self::COURSE_STATUS_FILTER ] ) {
+			if ( self::COURSE_PROGRESS_FILTER_ACTIVE === $query_args[ self::COURSE_PROGRESS_FILTER ] ) {
 				$course_ids = $this->get_active_course_ids( $user_id );
 			}
 
@@ -210,7 +210,7 @@ class Sensei_Learner {
 
 			$query_args['post__in'] = $course_ids;
 
-			unset( $query_args[ self::COURSE_STATUS_FILTER ] );
+			unset( $query_args[ self::COURSE_PROGRESS_FILTER ] );
 		}
 
 		return $query_args;

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -132,8 +132,20 @@ class Sensei_Learner {
 	 * @return array
 	 */
 	public function get_enrolled_courses_query_args( $user_id, $base_query_args = [] ) {
+		$order                = 'DESC';
+		$orderby              = 'date';
+		$has_set_course_order = '' !== get_option( 'sensei_course_order', '' );
+
+		// If a fixed course order has been set, trust menu_order.
+		if ( $has_set_course_order ) {
+			$order   = 'ASC';
+			$orderby = 'menu_order';
+		}
+
 		$default_args = [
 			'post_status' => 'publish',
+			'order'       => $order,
+			'orderby'     => $orderby,
 			'tax_query'   => [], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Just empty to set array.
 		];
 

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -108,7 +108,7 @@ class Sensei_Learner {
 	 * @return WP_Query
 	 */
 	public function get_enrolled_courses_query( $user_id, $base_query_args = [] ) {
-		$this->before_enrolled_courses_query($user_id);
+		$this->before_enrolled_courses_query( $user_id );
 
 		$query_args = $this->get_enrolled_courses_query_args( $user_id, $base_query_args );
 
@@ -124,11 +124,11 @@ class Sensei_Learner {
 	 * @return WP_Query
 	 */
 	public function get_enrolled_active_courses_query( $user_id, $base_query_args = [] ) {
-		$this->before_enrolled_courses_query($user_id);
+		$this->before_enrolled_courses_query( $user_id );
 
 		$query_args = $this->get_enrolled_courses_query_args( $user_id, $base_query_args );
 		$course_ids = $this->get_active_course_ids( $user_id );
-		$query_args = $this->post_inclusion_query_args_helper( $query_args, $course_ids );
+		$query_args = $this->query_args_helper_course_id_inclusion( $query_args, $course_ids );
 
 		return new WP_Query( $query_args );
 	}
@@ -142,11 +142,11 @@ class Sensei_Learner {
 	 * @return WP_Query
 	 */
 	public function get_enrolled_completed_courses_query( $user_id, $base_query_args = [] ) {
-		$this->before_enrolled_courses_query($user_id);
+		$this->before_enrolled_courses_query( $user_id );
 
 		$query_args = $this->get_enrolled_courses_query_args( $user_id, $base_query_args );
 		$course_ids = $this->get_completed_course_ids( $user_id );
-		$query_args = $this->post_inclusion_query_args_helper( $query_args, $course_ids );
+		$query_args = $this->query_args_helper_course_id_inclusion( $query_args, $course_ids );
 
 		return new WP_Query( $query_args );
 	}
@@ -194,11 +194,11 @@ class Sensei_Learner {
 	 * Modify query to only include a certain set of course IDs.
 	 *
 	 * @param array $query_args Query arguments.
-	 * @param int[] $course_ids Course IDs
+	 * @param int[] $course_ids Course IDs.
 	 *
 	 * @return array
 	 */
-	private function post_inclusion_query_args_helper( $query_args, $course_ids ) {
+	private function query_args_helper_course_id_inclusion( $query_args, $course_ids ) {
 		if ( ! empty( $query_args['post__in'] ) ) {
 			$existing_course_ids = (array) $query_args['post__in'];
 			$existing_course_ids = array_map( 'intval', $existing_course_ids );
@@ -217,14 +217,8 @@ class Sensei_Learner {
 
 	/**
 	 * Notify that a user's enrolled courses are about to be queried.
-	 *
-	 * @param int   $user_id         User ID.
-	 * @param array $base_query_args Base query arguments.
-	 *
-	 * @return WP_Query
 	 */
 	private function before_enrolled_courses_query( $user_id ) {
-
 		/**
 		 * Fire before we query a user's enrolled courses. This needs to be called before
 		 * building the query arguments because `active` courses might be incomplete if we

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -112,7 +112,9 @@ class Sensei_Learner {
 	 */
 	public function get_enrolled_courses_query( $user_id, $base_query_args = [] ) {
 		/**
-		 * Fire before we query a user's enrolled courses.
+		 * Fire before we query a user's enrolled courses. This needs to be called before
+		 * building the query arguments because `active` courses might be incomplete if we
+		 * haven't verified a user's enrolment is up-to-date.
 		 *
 		 * @since 3.0.0
 		 *

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -200,10 +200,10 @@ class Sensei_Learner {
 	 */
 	private function query_args_helper_course_id_inclusion( $query_args, $course_ids ) {
 		if ( ! empty( $query_args['post__in'] ) ) {
-			$existing_course_ids = (array) $query_args['post__in'];
-			$existing_course_ids = array_map( 'intval', $existing_course_ids );
+			$existing_post_ids = (array) $query_args['post__in'];
+			$existing_post_ids = array_map( 'intval', $existing_post_ids );
 
-			$course_ids = array_intersect( $course_ids, $existing_course_ids );
+			$course_ids = array_intersect( $course_ids, $existing_post_ids );
 		}
 
 		if ( empty( $course_ids ) ) {

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -138,6 +138,7 @@ class Sensei_Learner {
 
 		return $this->get_enrolled_courses_query( $user_id, $base_query_args );
 	}
+
 	/**
 	 * Query the courses a user is enrolled in and has completed.
 	 *

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -62,6 +62,7 @@ class Sensei_Course_Enrolment_Manager {
 		add_action( 'shutdown', [ $this, 'run_deferred_course_enrolment_checks' ] );
 		add_action( 'sensei_enrolment_results_calculated', [ $this, 'remove_deferred_enrolment_check' ], 10, 3 );
 		add_filter( 'sensei_can_user_manually_enrol', [ $this, 'maybe_prevent_frontend_manual_enrol' ], 10, 2 );
+		add_action( 'sensei_before_learners_enrolled_courses_query', [ $this, 'recalculate_enrolments' ] );
 
 		add_action( 'shutdown', [ Sensei_Enrolment_Provider_State_Store::class, 'persist_all' ] );
 	}

--- a/includes/shortcodes/class-sensei-shortcode-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-courses.php
@@ -191,7 +191,7 @@ class Sensei_Shortcode_Courses implements Sensei_Shortcode_Interface {
 
 		$this->query = new WP_Query( $query_args );
 
-	}//end setup_course_query()
+	}
 
 	/**
 	 * Rendering the shortcode this class is responsible for.

--- a/includes/shortcodes/class-sensei-shortcode-featured-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-featured-courses.php
@@ -102,7 +102,7 @@ class Sensei_Shortcode_Featured_Courses implements Sensei_Shortcode_Interface {
 
 		$this->query = new WP_Query( $query_args );
 
-	}//end setup_course_query()
+	}
 
 	/**
 	 * Rendering the shortcode this class is responsible for.

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -195,7 +195,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 			add_action( 'sensei_loop_course_inside_before', $empty_callback );
 		}
 
-	}//end setup_course_query()
+	}
 
 	/**
 	 * Output the message that tells the user they have

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -40,7 +40,6 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 	/**
 	 * @var string number of items to show on the current page
-	 * Default: -1.
 	 */
 	protected $number;
 
@@ -89,7 +88,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 		$attributes = shortcode_atts(
 			array(
-				'number'  => '10',
+				'number'  => null,
 				'status'  => 'all',
 				'orderby' => 'title',
 				'order'   => 'ASC',
@@ -111,13 +110,21 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 		$this->page_id = $wp_query->get_queried_object_id();
 
+		$per_page = 10;
+		if (
+			isset( Sensei()->settings->settings['my_course_amount'] )
+			&& 0 < absint( Sensei()->settings->settings['my_course_amount'] )
+		) {
+			$per_page = absint( Sensei()->settings->settings['my_course_amount'] );
+		}
+
 		// set up all argument need for constructing the course query
-		$this->number  = isset( $attributes['number'] ) ? $attributes['number'] : '10';
+		$this->number  = isset( $attributes['number'] ) ? absint( $attributes['number'] ) : $per_page;
 		$this->orderby = isset( $attributes['orderby'] ) ? $attributes['orderby'] : 'title';
 		$this->status  = isset( $attributes['status'] ) ? $attributes['status'] : 'all';
 
 		// set the default for menu_order to be ASC
-		if ( 'menu_order' == $this->orderby && ! isset( $attributes['order'] ) ) {
+		if ( 'menu_order' === $this->orderby && ! isset( $attributes['order'] ) ) {
 
 			$this->order = 'ASC';
 
@@ -216,7 +223,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 			'posts_per_page' => $number_of_posts,
 		);
 
-		if ( null !== $included_courses )  {
+		if ( null !== $included_courses ) {
 			$base_query_args['post__in'] = $included_courses;
 		}
 

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -182,11 +182,11 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		);
 
 		if ( 'complete' === $this->status ) {
-			$this->query = $learner_manager->get_enrolled_completed_courses_query( $user_id, $base_query_args );
-			$empty_callback   = [ $this, 'completed_no_course_message_output' ];
+			$this->query    = $learner_manager->get_enrolled_completed_courses_query( $user_id, $base_query_args );
+			$empty_callback = [ $this, 'completed_no_course_message_output' ];
 		} elseif ( 'active' === $this->status ) {
-			$this->query = $learner_manager->get_enrolled_active_courses_query( $user_id, $base_query_args );
-			$empty_callback   = [ $this, 'active_no_course_message_output' ];
+			$this->query    = $learner_manager->get_enrolled_active_courses_query( $user_id, $base_query_args );
+			$empty_callback = [ $this, 'active_no_course_message_output' ];
 		} else {
 			$this->query = $learner_manager->get_enrolled_courses_query( $user_id, $base_query_args );
 		}

--- a/tests/unit-tests/test-class-learner.php
+++ b/tests/unit-tests/test-class-learner.php
@@ -71,13 +71,13 @@ class Sensei_Class_Student_Test extends WP_UnitTestCase {
 		$learner_manager = Sensei_Learner::instance();
 
 		$args_without_order = $learner_manager->get_enrolled_courses_query_args( 0 );
-		$this->assertEqual( 'date', $args_without_order['orderby'], 'Initially we should order by date' );
+		$this->assertEquals( 'date', $args_without_order['orderby'], 'Initially we should order by date' );
 
 		// Simulate us setting the course order. Normally this would also set the menu_order for all courses.
 		update_option( 'sensei_course_order', '1,2,3' );
 
 		$args_with_order = $learner_manager->get_enrolled_courses_query_args( 0 );
-		$this->assertEqual( 'menu_order', $args_with_order['orderby'], 'Initially we should order by date' );
+		$this->assertEquals( 'menu_order', $args_with_order['orderby'], 'Initially we should order by date' );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-learner.php
+++ b/tests/unit-tests/test-class-learner.php
@@ -217,7 +217,7 @@ class Sensei_Class_Student_Test extends WP_UnitTestCase {
 		$query_enrolled_courses = $learner_manager->get_enrolled_courses_query( $student_id, $base_query_args );
 
 		$user_meta = get_user_meta( $student_id, Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME, true );
-		$this->assertEquals( Sensei_Course_Enrolment_Manager::get_enrolment_calculation_version(), $user_meta, 'Learner should have been calculated prior to querying courses' );
+		$this->assertEquals( Sensei_Course_Enrolment_Manager::instance()->get_enrolment_calculation_version(), $user_meta, 'Learner should have been calculated prior to querying courses' );
 
 		$this->assertTrue( $query_enrolled_courses instanceof WP_Query, 'Returned value should be instance of WP_Query' );
 		$this->assertEquals( count( $enrolled_course_ids ), $query_enrolled_courses->found_posts, 'Number of found posts should match number of enrolled courses' );

--- a/widgets/class-sensei-course-component-widget.php
+++ b/widgets/class-sensei-course-component-widget.php
@@ -358,7 +358,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Get all new course IDS
+	 * Get all new courses.
 	 *
 	 * @since 1.9.2
 	 *
@@ -371,75 +371,53 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 	}
 
 	/**
-	 * Get all active course IDS for the current user
+	 * Get all active courses for the current user
 	 *
 	 * @since 1.9.2
 	 *
-	 * @return array $courses
+	 * @return WP_Post[]
 	 */
 	public function get_active_courses() {
-
-		$courses               = array();
-		$activity_args         = array(
-			'user_id' => get_current_user_id(),
-			'type'    => 'sensei_course_status',
-			'status'  => 'in-progress',
-		);
-		$user_courses_activity = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
-
-		if ( ! is_array( $user_courses_activity ) ) {
-			$user_courses_activity_arr   = array();
-			$user_courses_activity_arr[] = $user_courses_activity;
-			$user_courses_activity       = $user_courses_activity_arr;
-
+		$user_id = get_current_user_id();
+		if ( empty( $user_id ) ) {
+			return [];
 		}
 
-		foreach ( $user_courses_activity as $activity ) {
-			$courses[] = get_post( $activity->comment_post_ID );
-		}
+		$query_args = [
+			'posts_per_page' => $this->instance['limit'],
+		];
 
-		return $courses;
+		$learner_manager = Sensei_Learner::instance();
+		$courses_query   = $learner_manager->get_enrolled_active_courses_query( $user_id, $query_args );
 
+		return $courses_query->posts;
 	}
 
 	/**
-	 * Get all active course IDS for the current user
+	 * Get all courses for the current user.
 	 *
 	 * @since 1.9.2
 	 *
 	 * @return array $courses
 	 */
 	public function get_completed_courses() {
-
-		$courses       = array();
-		$activity_args = array(
-			'user_id' => get_current_user_id(),
-			'type'    => 'sensei_course_status',
-			'status'  => 'complete',
-		);
-
-		$user_courses_activity = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
-
-		if ( ! is_array( $user_courses_activity ) ) {
-			$user_courses_activity_arr   = array();
-			$user_courses_activity_arr[] = $user_courses_activity;
-			$user_courses_activity       = $user_courses_activity_arr;
-
+		$user_id = get_current_user_id();
+		if ( empty( $user_id ) ) {
+			return [];
 		}
 
-		foreach ( $user_courses_activity as $activity ) {
+		$query_args = [
+			'posts_per_page' => $this->instance['limit'],
+		];
 
-			if ( isset( $activity->comment_post_ID ) ) {
+		$learner_manager = Sensei_Learner::instance();
+		$courses_query   = $learner_manager->get_enrolled_completed_courses_query( $user_id, $query_args );
 
-				$courses[] = get_post( $activity->comment_post_ID );
-
-			}
-		}
-		return $courses;
+		return $courses_query->posts;
 	}
 
 	/**
-	 * Get all active course IDS for the current user
+	 * Get the featured courses.
 	 *
 	 * @since 1.9.2
 	 *


### PR DESCRIPTION
Fixes #2863

#### Changes proposed in this Pull Request:

* Centralizes enrolled course querying in `Sensei_Learner`. This could live in `Sensei_Course` or `Sensei_Course_Enrolment_Manager`, but both seemed a bit bloated and I thought this seemed okay.
* Updated query on _Course Component_ widget for `My Active Courses` and `My Completed Courses`.
* Updated query on _My Courses_ page (`[sensei_user_courses]`).
* Updated query on _Learner Profile_ pages (`https://example.com/learner/{username}`). 
* Deprecated using `usercourses` for `$type` in `Sensei_Course::course_query` and `Sensei_Course::get_archive_query_args`.
* Added a notice on _My Courses_ on the _All Courses_ tab when no courses are found. We could consolidate these methods (or have one call the other with a argument).
* Ensures user enrolment is calculated before querying.

In this PR, I _might_ have fixed the legacy shortcodes, but I didn't test them.

Additional notes:
- _My Courses_ ignores course order and instead sorts by title. _Learner Profiles_ uses course order if set and `date` if not. Should we standardize this? If so, to what?
- The `My Courses Pagination` setting has had an effect on Learner Profile pages. Should we rename this to be more general?
- I think `Sensei_Course::course_query` and `Sensei_Course::get_archive_query_args` are just used in the legacy shortcodes class. We could deprecate them completely. **Edit: I've deprecated them now**
- "Calculating enrolment" is much more lightweight than Sensei 2/WCPC 1. @gkaragia's `\Sensei_Course_Enrolment_Manager::recalculate_enrolments` method, which is called before any of the above queries, only actually calculates enrolment if necessary. Before, we were doing all those heavy queries every time we loaded _My Courses_. The benefit of this is we can also ensure course enrolment is up to date in these other places.

#### Testing instructions:

- Enroll a student in several courses. Complete some of them.
- Make sure there are some courses a student isn't enrolled in.
- Enable Learner Profiles if not already enabled.
- In settings under _Courses_, set the `My Courses Pagination` to a small number (less than the number of courses a student is enrolled in).
- Visit _Learner Profile_ page. Make sure listings show up correctly. Check pagination.
- Visit _My Courses_ page. Make sure listings show up correctly. Check pagination.
- Bonus: Start from pre-3.0.0 database with the above conditions set (disable WCPC for now as its enrolment is incomplete). Move to this branch with all WordPress pages closed in browser and immediately load the _My Courses_ page. It should calculate enrolment and show the correct courses.

#### Deprecations
- `Sensei_Course::filter_my_courses` 
- `Sensei_Course::course_query`
- `Sensei_Course::get_archive_query_args`