### PR TITLE
lesson video allow html tag change with defualt wp kses

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -49,17 +49,7 @@ class Sensei_Frontend {
 	 */
 	public function __construct() {
 
-		$this->allowed_html = array(
-			'embed'  => array(),
-			'iframe' => array(
-				'width'           => array(),
-				'height'          => array(),
-				'src'             => array(),
-				'frameborder'     => array(),
-				'allowfullscreen' => array(),
-			),
-			'video'  => Sensei_Wp_Kses::get_video_html_tag_allowed_attributes(),
-		);
+		$this->allowed_html = Sensei_Wp_Kses::get_default_wp_kses_allowed_html();
 
 		// Template output actions.
 		add_action( 'sensei_before_main_content', array( $this, 'sensei_output_content_wrapper' ), 10 );


### PR DESCRIPTION
Fixes #

#### Changes proposed in this Pull Request:

* i am getting  issue with video allow html tags 
I have replaced allowed_html tag with default kses_allowed_html with the same structure 

#### Testing instructions:

* please check in allowed_html in file class-sensi-lesson.php and class-sensi fronted.php both are different so i make same like class-sensi-lesson.php in class-sensi fronted.php

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
#### Screenshot / Video



<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
