### PR TITLE
Remove usages of Sensei_Utils::user_started_course in templates

### DIFF
--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -523,7 +523,7 @@ class Sensei_Templates {
 		}
 
 	}//end deprecate_single_lesson_breadcrumbs_and_comments_hooks()
-	
+
 	/**
 	 * Running the deprecated hook: sensei_lesson_single_meta
 	 *

--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -523,27 +523,7 @@ class Sensei_Templates {
 		}
 
 	}//end deprecate_single_lesson_breadcrumbs_and_comments_hooks()
-
-	/**
-	 * Deprecate the hook sensei_lesson_course_signup.
-	 *
-	 * The hook content will be linked directly on the recommended
-	 * sensei_single_lesson_content_inside_after
-	 *
-	 * @deprecated since 1.9.0
-	 */
-	public static function deprecate_sensei_lesson_course_signup_hook() {
-
-		$lesson_course_id   = get_post_meta( get_the_ID(), '_lesson_course', true );
-		$user_taking_course = Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id() );
-
-		if ( ! $user_taking_course ) {
-
-			sensei_do_deprecated_action( 'sensei_lesson_course_signup', '1.9.0', 'sensei_single_lesson_content_inside_after', $lesson_course_id );
-
-		}
-	}//end deprecate_sensei_lesson_course_signup_hook()
-
+	
 	/**
 	 * Running the deprecated hook: sensei_lesson_single_meta
 	 *

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -740,13 +740,13 @@ class Sensei_Main {
 					// translators: The placeholder %s is a link to the course.
 					$this->notices->add_notice( sprintf( __( 'Please complete the previous %1$s before taking this course.', 'sensei-lms' ), $course_link ), 'info' );
 
-				} elseif ( class_exists( 'Sensei_WC' ) && Sensei_WC::is_woocommerce_active() && Sensei_WC::is_course_purchasable( $post->ID ) && ! Sensei_Utils::user_started_course( $post->ID, $current_user->ID ) ) {
+				} elseif ( class_exists( 'Sensei_WC' ) && Sensei_WC::is_woocommerce_active() && Sensei_WC::is_course_purchasable( $post->ID ) && ! Sensei_Course::is_user_enrolled( $post->ID, $current_user->ID ) ) {
 
 					// translators: The placeholders are the opening and closing tags for a link to log in.
 					$message = sprintf( __( 'Or %1$s login %2$s to access your purchased courses', 'sensei-lms' ), '<a href="' . sensei_user_login_url() . '">', '</a>' );
 					$this->notices->add_notice( $message, 'info' );
 
-				} elseif ( ! Sensei_Utils::user_started_course( $post->ID, $current_user->ID ) ) {
+				} elseif ( ! Sensei_Course::is_user_enrolled( $post->ID, $current_user->ID ) ) {
 
 					// users who haven't started the course are allowed to view it
 					$user_allowed = true;

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -268,10 +268,6 @@ add_action( 'sensei_single_lesson_content_inside_after', 'sensei_the_single_less
 add_action( 'sensei_single_lesson_content_inside_after', array( 'Sensei_Templates', 'deprecate_sensei_lesson_single_meta_hook' ), 15 );
 
 // @since 1.9.0
-// deprecate the sensei_lesson_course_signup hook
-add_action( 'sensei_single_lesson_content_inside_after', array( 'Sensei_Templates', 'deprecate_sensei_lesson_course_signup_hook' ), 20 );
-
-// @since 1.9.0
 // hook in the lesson prerequisite completion message
 add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'prerequisite_complete_message' ), 20 );
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -991,7 +991,7 @@ function sensei_the_single_lesson_meta() {
 	// Complete Lesson Logic
 	do_action( 'sensei_complete_lesson' );
 	// Check that the course has been started
-	if ( Sensei()->access_settings()
+	if ( ! Sensei()->access_settings()
 		|| Sensei_Course::is_user_enrolled( $lesson_course_id )
 		|| $is_preview ) {
 		?>

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -992,7 +992,7 @@ function sensei_the_single_lesson_meta() {
 	do_action( 'sensei_complete_lesson' );
 	// Check that the course has been started
 	if ( Sensei()->access_settings()
-		|| Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id() )
+		|| Sensei_Course::is_user_enrolled( $lesson_course_id )
 		|| $is_preview ) {
 		?>
 		<section class="lesson-meta">
@@ -1006,8 +1006,7 @@ function sensei_the_single_lesson_meta() {
 			<?php do_action( 'sensei_frontend_messages' ); ?>
 
 			<?php
-			if ( ! $is_preview
-				|| Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id() ) ) {
+			if ( ! $is_preview || Sensei_Course::is_user_enrolled( $lesson_course_id ) ) {
 
 				sensei_do_deprecated_action( 'sensei_lesson_quiz_meta', '1.9.0', 'sensei_single_lesson_content_inside_before', array( get_the_ID(), get_current_user_id() ) );
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -991,7 +991,7 @@ function sensei_the_single_lesson_meta() {
 	// Complete Lesson Logic
 	do_action( 'sensei_complete_lesson' );
 	// Check that the course has been started
-	if ( ! Sensei()->access_settings()
+	if ( Sensei()->access_settings()
 		|| Sensei_Course::is_user_enrolled( $lesson_course_id )
 		|| $is_preview ) {
 		?>

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -927,7 +927,7 @@ function sensei_can_user_view_lesson( $lesson_id = '', $user_id = '' ) {
 	// Check for prerequisite lesson completions
 	$pre_requisite_complete = Sensei_Lesson::is_prerequisite_complete( $lesson_id, $user_id );
 	$lesson_course_id       = get_post_meta( $lesson_id, '_lesson_course', true );
-	$user_taking_course     = Sensei_Utils::user_started_course( $lesson_course_id, $user_id );
+	$user_taking_course     = Sensei_Course::is_user_enrolled( $lesson_course_id, $user_id );
 
 	$is_preview = false;
 	if ( Sensei_Utils::is_preview_lesson( $lesson_id ) ) {

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -437,11 +437,6 @@ function sensei_get_excerpt( $post_id = '' ) {
 	return get_the_excerpt();
 }
 
-function sensei_has_user_started_course( $post_id = 0, $user_id = 0 ) {
-	_deprecated_function( __FUNCTION__, '1.7', 'Sensei_Utils::user_started_course()' );
-	return Sensei_Utils::user_started_course( $post_id, $user_id );
-} // End sensei_has_user_started_course()
-
 function sensei_has_user_completed_lesson( $post_id = 0, $user_id = 0 ) {
 	_deprecated_function( __FUNCTION__, '1.7', 'Sensei_Utils::user_completed_lesson()' );
 	return Sensei_Utils::user_completed_lesson( $post_id, $user_id );

--- a/templates/course-results.php
+++ b/templates/course-results.php
@@ -72,8 +72,7 @@ $course = get_page_by_path( $wp_query->query_vars['course_results'], OBJECT, 'co
 
 			<section class="course-results-lessons">
 				<?php
-				$started_course = Sensei_Utils::user_started_course( $course->ID, get_current_user_id() );
-				if ( $started_course ) {
+				if ( Sensei_Course::is_user_enrolled( $course->ID ) ) {
 
 					sensei_the_course_results_lessons();
 

--- a/templates/single-course/modules.php
+++ b/templates/single-course/modules.php
@@ -113,7 +113,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 										<?php
 										$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
-										if ( Sensei_Utils::is_preview_lesson( get_the_ID() ) && ! Sensei_Utils::user_started_course( $course_id, get_current_user_id() ) ) {
+										if ( Sensei_Utils::is_preview_lesson( get_the_ID() ) && ! Sensei_Course::is_user_enrolled( $course_id ) ) {
 
 											echo wp_kses_post( Sensei()->frontend->sensei_lesson_preview_title_tag( $course_id ) );
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Remove usages of `Sensei_Utils::user_started_course` in templates
* Remove deprecated sensei_lesson_course_signup hook
* Remove unused deprecated function sensei_has_user_started_course

#### Testing instructions:

8afd87d modules.php:
* Have course with modules
* Enable Preview for a lesson
* Single course frontend should display a Preview button next to the lesson in a module's lesson list when user is not enrolled
* Preview button should not be displayed when user is enrolled

6481e72 sensei_can_user_view_lesson:
* Make sure Access Permissions is enabled in Sensei settings
* Log in with a non-admin user
* Try to view a lesson with no prerequisites in a non-enrolled course
* Should display a *Please sign up for the course notification*
* Take course
* Lesson is now viewable

642690e sensei_the_single_lesson_meta:
* "Lesson meta" below lesson content is only displayed for enrolled users on single lesson page. (This is pretty much an empty wrapper `section` now)
* Deprecated, to be removed

9b12574 course-results.php:
* Go to a Course results page with a direct link (e.g. `/course/sensei-theming-101/results/`) as a logged in user, on a non-enrolled course
* Lesson result list should not be displayed 

a96efbf check_user_permissions:
* Containing function is unused in Sensei codebase. 

#### Proposed changelog entry for your changes:

* Remove deprecated hook sensei_lesson_course_signup
* Remove deprecated function sensei_has_user_started_course
