### PR TITLE
Block access to module when not signed up

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -178,6 +178,46 @@ class Sensei_Course {
 	}
 
 	/**
+	 * Check if a visitor can access course content.
+	 *
+	 * This is just part of the check for lessons and quizzes. To include checks for prerequisites and preview lessons,
+	 * use the global template function `sensei_can_user_view_lesson()`.
+	 *
+	 * @param int    $course_id Course post ID.
+	 * @param int    $user_id   User ID.
+	 * @param string $context   Context that we're checking for course content access (`lesson`, `quiz`, or `module`).
+	 */
+	public function can_access_course_content( $course_id, $user_id = null, $context = 'lesson' ) {
+		if ( null === $user_id ) {
+			$user_id = get_current_user_id();
+		}
+
+		$is_user_enrolled        = is_user_logged_in() && self::is_user_enrolled( $course_id, $user_id );
+		$can_view_course_content = false;
+
+		if (
+			! Sensei()->settings->get( 'access_permission' )
+			|| sensei_all_access()
+			|| $is_user_enrolled
+		) {
+			$can_view_course_content = true;
+		}
+
+		/**
+		 * Filters if a visitor can view course content.
+		 *
+		 * @since 3.0.0.
+		 *
+		 * @param bool   $can_view_course_content True if they can view the course content.
+		 * @param int    $course_id               Course post ID.
+		 * @param int    $user_id                 User ID if user is logged in.
+		 * @param string $context                 Context that we're checking for course content
+		 *                                        access (`lesson`, `quiz`, or `module`).
+		 */
+		return apply_filters( 'sensei_can_access_course_content', $can_view_course_content, $course_id, $user_id, $context );
+	}
+
+	/**
 	 * @param $message
 	 */
 	private static function add_course_access_permission_message( $message ) {

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -192,12 +192,15 @@ class Sensei_Course {
 			$user_id = get_current_user_id();
 		}
 
-		$is_user_enrolled        = is_user_logged_in() && self::is_user_enrolled( $course_id, $user_id );
 		$can_view_course_content = false;
+		$is_user_enrolled        = false;
+		if ( ! empty( $user_id ) ) {
+			$is_user_enrolled = self::is_user_enrolled( $course_id, $user_id );
+		}
 
 		if (
 			! sensei_is_login_required()
-			|| sensei_all_access()
+			|| sensei_all_access( $user_id )
 			|| $is_user_enrolled
 		) {
 			$can_view_course_content = true;

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -196,7 +196,7 @@ class Sensei_Course {
 		$can_view_course_content = false;
 
 		if (
-			! Sensei()->settings->get( 'access_permission' )
+			! sensei_is_login_required()
 			|| sensei_all_access()
 			|| $is_user_enrolled
 		) {

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -870,7 +870,7 @@ class Sensei_Core_Modules {
 			return;
 		}
 
-		$show_course_signup_notice = ! $this->can_view_module_content();
+		$show_course_signup_notice = ! $this->can_view_module_content( null, $course_id );
 
 		/**
 		 * Filter for if we should show the course sign up notice on the module page.

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -838,9 +838,10 @@ class Sensei_Core_Modules {
 			$user_id = get_current_user_id();
 		}
 
-		if ( ! sensei_is_login_required() ) {
-			$can_view_module_content = true;
-		} elseif ( $course_id && Sensei()->course->can_access_course_content( $course_id, $user_id, 'module' ) ) {
+		if (
+			! sensei_is_login_required()
+			|| ( $course_id && Sensei()->course->can_access_course_content( $course_id, $user_id, 'module' ) )
+		) {
 			$can_view_module_content = true;
 		}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -789,12 +789,13 @@ class Sensei_Core_Modules {
 
 			$module = get_queried_object();
 
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Safe handling of course ID query var.
 			$course_id = isset( $_GET['course_id'] ) ? intval( $_GET['course_id'] ) : null;
 			$user_id   = get_current_user_id();
 
 			$module_progress = false;
-			if ( $user_id && isset( $_GET['course_id'] ) && intval( $_GET['course_id'] ) > 0 ) {
-				$module_progress = $this->get_user_module_progress( $module->term_id, $_GET['course_id'], $user_id );
+			if ( $user_id && ! empty( $course_id ) ) {
+				$module_progress = $this->get_user_module_progress( $module->term_id, $course_id, $user_id );
 			}
 
 			if ( $module_progress && $module_progress > 0 ) {

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -83,10 +83,10 @@ class Sensei_PostTypes {
 			'messages' => 'Messages',
 		);
 		$this->load_posttype_objects( $default_post_types );
+		$this->set_role_cap_defaults( $default_post_types );
 
 		// Admin functions
-		if ( is_admin() || defined( 'WP_CLI' ) && WP_CLI ) {
-			$this->set_role_cap_defaults( $default_post_types );
+		if ( is_admin() ) {
 			global $pagenow;
 			if ( ( $pagenow == 'post.php' || $pagenow == 'post-new.php' ) ) {
 				add_filter( 'enter_title_here', array( $this, 'enter_title_here' ), 10 );

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -71,6 +71,10 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$settings             = $this->get_settings();
 		$settings[ $setting ] = $new_value;
+
+		// Update the cached setting.
+		$this->settings[ $setting ] = $new_value;
+
 		return update_option( $this->token, $settings );
 
 	}

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -453,4 +453,5 @@ add_action( 'sensei_course_results_content_inside_before', array( $sensei->notic
 add_action( 'sensei_no_permissions_inside_before_content', array( $sensei->notices, 'maybe_print_notices' ), 90 );
 add_action( 'sensei_single_course_content_inside_before', array( $sensei->notices, 'maybe_print_notices' ), 40 );
 add_action( 'sensei_single_lesson_content_inside_before', array( $sensei->notices, 'maybe_print_notices' ), 40 );
+add_action( 'sensei_taxonomy_module_content_inside_before', array( $sensei->notices, 'maybe_print_notices' ), 40 );
 

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -58,27 +58,35 @@ function sensei_all_access( $user_id = null ) {
 
 	$access = user_can( $user_id, 'manage_sensei' ) || user_can( $user_id, 'manage_sensei_grades' );
 
-	// For backwards compatibility with filter, we temporarily need to change the current user.
-	$previous_current_user_id = get_current_user_id();
-	wp_set_current_user( $user_id );
+	if ( has_filter( 'sensei_all_access' ) ) {
+		// For backwards compatibility with filter, we temporarily need to change the current user.
+		$previous_current_user_id = get_current_user_id();
+		wp_set_current_user( $user_id );
+
+		/**
+		 * Filter sensei_all_access function result which determines if the current user
+		 * can access all of Sensei without restrictions.
+		 *
+		 * @since 1.4.0
+		 * @deprecated 3.0.0
+		 *
+		 * @param bool $access True if user has all access.
+		 */
+		$access = apply_filters_deprecated( 'sensei_all_access', [ $access ], '3.0.0', 'sensei_user_all_access' );
+
+		wp_set_current_user( $previous_current_user_id );
+	}
 
 	/**
-	 * Filter sensei_all_access function result which determines if the current user
-	 * can access all of Sensei without restrictions.
+	 * Filter if a particular user has access to all of Sensei without restrictions.
 	 *
-	 * @since 1.4.0
-	 * @since 3.0.0 Added $user_id parameter.
+	 * @since 3.0.0
 	 *
 	 * @param bool $access  True if user has all access.
 	 * @param int  $user_id User ID to check.
 	 */
-	$access = apply_filters( 'sensei_all_access', $access, $user_id );
-
-	wp_set_current_user( $previous_current_user_id );
-
-	return $access;
-
-} // End sensei_all_access()
+	return apply_filters( 'sensei_user_all_access', $access, $user_id );
+}
 
 if ( ! function_exists( 'sensei_light_or_dark' ) ) {
 

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -38,25 +38,45 @@ function is_sensei() {
 }
 
 /**
- * Determine if the current user is and admin that
- * can acess all of Sensei without restrictions
+ * Determine if a user is an admin that can access all of Sensei without restrictions.
  *
  * @since 1.4.0
+ * @since 3.0.0 Added `$user_id` argument. Preserves backward compatibility.
+ *
+ * @param int $user_id User ID. Defaults to current user.
+ *
  * @return boolean
  */
-function sensei_all_access() {
+function sensei_all_access( $user_id = null ) {
+	if ( null === $user_id ) {
+		$user_id = get_current_user_id();
+	}
 
-	$access = current_user_can( 'manage_sensei' ) || current_user_can( 'manage_sensei_grades' );
+	if ( empty( $user_id ) ) {
+		return false;
+	}
+
+	$access = user_can( $user_id, 'manage_sensei' ) || user_can( $user_id, 'manage_sensei_grades' );
+
+	// For backwards compatibility with filter, we temporarily need to change the current user.
+	$previous_current_user_id = get_current_user_id();
+	wp_set_current_user( $user_id );
 
 	/**
-	 * Filter sensei_all_access function result
-	 * which determinse if the current user
-	 * can access all of Sensei without restrictions
+	 * Filter sensei_all_access function result which determines if the current user
+	 * can access all of Sensei without restrictions.
 	 *
 	 * @since 1.4.0
-	 * @param bool $access
+	 * @since 3.0.0 Added $user_id parameter.
+	 *
+	 * @param bool $access  True if user has all access.
+	 * @param int  $user_id User ID to check.
 	 */
-	return apply_filters( 'sensei_all_access', $access );
+	$access = apply_filters( 'sensei_all_access', $access, $user_id );
+
+	wp_set_current_user( $previous_current_user_id );
+
+	return $access;
 
 } // End sensei_all_access()
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -927,20 +927,16 @@ function sensei_can_user_view_lesson( $lesson_id = null, $user_id = null ) {
 	}
 
 	// Check for prerequisite lesson completions.
-	$pre_requisite_complete   = Sensei_Lesson::is_prerequisite_complete( $lesson_id, $user_id );
-	$is_preview_lesson        = false;
-	$global_access_permission = false;
+	$pre_requisite_complete = Sensei_Lesson::is_prerequisite_complete( $lesson_id, $user_id );
+	$is_preview_lesson      = false;
 
 	if ( Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
 		$is_preview_lesson      = true;
 		$pre_requisite_complete = true;
 	};
 
-	if ( ! Sensei()->settings->get( 'access_permission' ) || sensei_all_access() ) {
-		$global_access_permission = true;
-	}
-
-	$can_user_view_lesson = $global_access_permission
+	$can_user_view_lesson = ! sensei_is_login_required()
+							|| sensei_all_access()
 							|| ( $user_can_view_course_content && $pre_requisite_complete )
 							|| $is_preview_lesson;
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -893,80 +893,68 @@ function sensei_get_the_question_id() {
  * Template function to determine if the current user can
  * access the current lesson content being viewed.
  *
- * This function checks in the folowing order
+ * This function checks in the following order
  * - if the current user has all access based on their permissions
- * - If the access permission setting is enabled for this site, if not the user has accces
+ * - If the access permission setting is enabled for this site, if not the user has access
  * - if the lesson has a pre-requisite and if the user has completed that
  * - If it is a preview the user has access as well
  *
  * @since 1.9.0
  *
- * @param string $lesson_id
+ * @param int $lesson_id Lesson post ID. Default: Use global post in loop.
+ * @param int $user_id   User ID. Default: Use currently logged in user ID.
  * @return bool
  */
-function sensei_can_user_view_lesson( $lesson_id = '', $user_id = '' ) {
-
+function sensei_can_user_view_lesson( $lesson_id = null, $user_id = null ) {
 	if ( empty( $lesson_id ) ) {
-
 		$lesson_id = get_the_ID();
-
 	}
 
-	if ( 'quiz' == get_post_type( get_the_ID() ) ) {
-
+	$context = 'lesson';
+	if ( 'quiz' === get_post_type( get_the_ID() ) ) {
+		$context   = 'quiz';
 		$lesson_id = Sensei()->quiz->get_lesson_id( get_the_ID() );
-
 	}
 
 	if ( empty( $user_id ) ) {
-
 		$user_id = get_current_user_id();
-
 	}
 
-	// Check for prerequisite lesson completions
-	$pre_requisite_complete = Sensei_Lesson::is_prerequisite_complete( $lesson_id, $user_id );
-	$lesson_course_id       = get_post_meta( $lesson_id, '_lesson_course', true );
-	$user_taking_course     = Sensei_Course::is_user_enrolled( $lesson_course_id, $user_id );
+	$user_can_view_course_content = false;
+	$course_id                    = Sensei()->lesson->get_course_id( $lesson_id );
+	if ( $course_id ) {
+		$user_can_view_course_content = Sensei()->course->can_access_course_content( $course_id, $user_id, $context );
+	}
 
-	$is_preview = false;
+	// Check for prerequisite lesson completions.
+	$pre_requisite_complete   = Sensei_Lesson::is_prerequisite_complete( $lesson_id, $user_id );
+	$is_preview_lesson        = false;
+	$global_access_permission = false;
+
 	if ( Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
-
-		$is_preview             = true;
+		$is_preview_lesson      = true;
 		$pre_requisite_complete = true;
-
 	};
 
-	$user_can_access_lesson = false;
-
-	if ( is_user_logged_in() && $user_taking_course ) {
-
-		$user_can_access_lesson = true;
-
-	}
-
-	$access_permission = false;
-
 	if ( ! Sensei()->settings->get( 'access_permission' ) || sensei_all_access() ) {
-
-		$access_permission = true;
-
+		$global_access_permission = true;
 	}
 
-	$can_user_view_lesson = $access_permission || ( $user_can_access_lesson && $pre_requisite_complete ) || $is_preview;
+	$can_user_view_lesson = $global_access_permission
+							|| ( $user_can_view_course_content && $pre_requisite_complete )
+							|| $is_preview_lesson;
 
 	/**
-	 * Filter the can user view lesson function
+	 * Filter if the can user view lesson content, including quizzes.
 	 *
 	 * @since 1.9.0
 	 *
-	 * @param bool $can_user_view_lesson
-	 * @param string $lesson_id
-	 * @param string $user_id
+	 * @param bool   $can_user_view_lesson True if they can view lesson/quiz content.
+	 * @param string $lesson_id            Lesson post ID.
+	 * @param string $user_id              User ID.
 	 */
 	return apply_filters( 'sensei_can_user_view_lesson', $can_user_view_lesson, $lesson_id, $user_id );
-
-} // end sensei_can_current_user_view_lesson
+}
 
 /**
  * Ouput the single lesson meta

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -945,13 +945,13 @@ function sensei_can_user_view_lesson( $lesson_id = null, $user_id = null ) {
 							|| $is_preview_lesson;
 
 	/**
-	 * Filter if the can user view lesson content, including quizzes.
+	 * Filter if the user can view lesson and quiz content.
 	 *
 	 * @since 1.9.0
 	 *
-	 * @param bool   $can_user_view_lesson True if they can view lesson/quiz content.
-	 * @param string $lesson_id            Lesson post ID.
-	 * @param string $user_id              User ID.
+	 * @param bool $can_user_view_lesson True if they can view lesson/quiz content.
+	 * @param int  $lesson_id            Lesson post ID.
+	 * @param int  $user_id              User ID.
 	 */
 	return apply_filters( 'sensei_can_user_view_lesson', $can_user_view_lesson, $lesson_id, $user_id );
 }

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -936,7 +936,7 @@ function sensei_can_user_view_lesson( $lesson_id = null, $user_id = null ) {
 	};
 
 	$can_user_view_lesson = ! sensei_is_login_required()
-							|| sensei_all_access()
+							|| sensei_all_access( $user_id )
 							|| ( $user_can_view_course_content && $pre_requisite_complete )
 							|| $is_preview_lesson;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -67,6 +67,7 @@ class Sensei_Unit_Tests_Bootstrap {
 	 */
 	public function includes() {
 		// factories
+		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-manual-test-helpers.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/factories/class-sensei-factory.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/factories/class-wp-unittest-factory-for-post-sensei.php';

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
-
 /**
  * Tests for Sensei_Course_Enrolment_Manager class.
  *

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-stored-status-provider.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-stored-status-provider.php
@@ -1,5 +1,4 @@
 <?php
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 
 /**
  * Tests for Sensei_Course_Enrolment_Stored_Status_Provider abstract class.

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
-
 /**
  * Tests for Sensei_Course_Enrolment class.
  *

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
@@ -1,5 +1,4 @@
 <?php
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 
 /**
  * Tests for Sensei_Enrolment_Learner_Calculation_Job class.

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
@@ -1,5 +1,4 @@
 <?php
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 
 /**
  * Tests for Sensei_Enrolment_Provider_State_Store class.

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state.php
@@ -1,5 +1,4 @@
 <?php
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 
 /**
  * Tests for Sensei_Enrolment_Provider_State class.

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -1,6 +1,7 @@
 <?php
 
 class Sensei_Class_Course_Test extends WP_UnitTestCase {
+	use Sensei_Course_Enrolment_Test_Helpers;
 	use Sensei_Course_Enrolment_Manual_Test_Helpers;
 
 	/**

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -367,11 +367,9 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		$user_id         = $this->factory->user->create( [ 'role' => 'administrator' ] );
 		$course_id       = $this->factory->course->create();
 
-		global $wp_roles;
-		$user = get_user_by('ID',$user_id);
-		var_dump($wp_roles);
-		var_dump($user);
-		var_dump($user->get_role_caps());
+		$user = get_user_by( 'id', $user_id );
+		$user->add_cap( 'manage_sensei' );
+
 		$this->assertTrue( $course_instance->can_access_course_content( $course_id, $user_id ), 'Admins should have access to course content' );
 	}
 

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -385,6 +385,8 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	 * Checks to make sure standard users who are enrolled can view course content.
 	 */
 	public function testCanAccessCourseContentEnrolledStandardCan() {
+		$this->prepareEnrolmentManager();
+
 		$course_instance = Sensei()->course;
 		$user_id         = $this->factory->user->create();
 		$course_id       = $this->factory->course->create();

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -367,6 +367,11 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		$user_id         = $this->factory->user->create( [ 'role' => 'administrator' ] );
 		$course_id       = $this->factory->course->create();
 
+		global $wp_roles;
+		$user = get_user_by('ID',$user_id);
+		var_dump($wp_roles);
+		var_dump($user);
+		var_dump($user->get_role_caps());
 		$this->assertTrue( $course_instance->can_access_course_content( $course_id, $user_id ), 'Admins should have access to course content' );
 	}
 

--- a/tests/unit-tests/test-class-learner.php
+++ b/tests/unit-tests/test-class-learner.php
@@ -1,7 +1,5 @@
 <?php
 
-require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
-
 class Sensei_Class_Student_Test extends WP_UnitTestCase {
 	use Sensei_Course_Enrolment_Test_Helpers;
 	use Sensei_Course_Enrolment_Manual_Test_Helpers;


### PR DESCRIPTION
Fixes #2964

#### Changes proposed in this Pull Request:

* Introduces `Sensei_Course::can_access_course_content` for shared content access checking logic.
* Modifies and updates `sensei_can_user_view_lesson()` to use that logic.
* Introduces `\Sensei_Core_Modules::can_view_module_content` and hides the module description if enabled.
* If viewing module from a course context (`?course_id={id}` in URL), it will also show a message to sign up for course before starting module (using slightly modified lesson code).

#### Testing instructions:

* See https://github.com/Automattic/sensei/issues/2964
* Make sure Access Permissions is enabled.
* Visit module from a course page as a user who isn't enrolled. Verify message is displayed.

#### New Filters
- `sensei_can_access_course_content` - Whether or not the user can view course content.
- `sensei_can_user_view_module` - Whether or not the user can view module content.
- `sensei_module_show_course_signup_notice` -  Whether or not to show the course sign-up notice on the module page.
- `sensei_module_course_signup_notice_message` - Customize the course sign-up notice message on the module page.
- `sensei_module_course_signup_notice_level` - Customize the alert level for the course sign-up notice message on the module page.