### PR TITLE
Remove usages of Sensei_Utils::user_started_course from Lessons code

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1034,7 +1034,7 @@ class Sensei_Frontend {
 		// make sure user is taking course.
 		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
 
-		if ( ! Sensei_Utils::user_started_course( $course_id, get_current_user_id() ) ) {
+		if ( ! Sensei_Course::is_user_enrolled( $course_id ) ) {
 			return;
 		}
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1356,7 +1356,7 @@ class Sensei_Frontend {
 	}
 
 	public function sensei_lesson_preview_title( $title = '', $id = 0 ) {
-		global $post, $current_user;
+		global $post;
 
 		// Limit to lessons and check if lesson ID matches filtered post ID.
 		// @see https://github.com/woothemes/sensei/issues/574.
@@ -1369,7 +1369,7 @@ class Sensei_Frontend {
 				$course_id = get_post_meta( $post->ID, '_lesson_course', true );
 
 				// Check if the user is taking the course.
-				if ( is_singular( 'lesson' ) && Sensei_Utils::is_preview_lesson( $post->ID ) && ! Sensei_Utils::user_started_course( $course_id, $current_user->ID ) && $post->ID == $id ) {
+				if ( is_singular( 'lesson' ) && Sensei_Utils::is_preview_lesson( $post->ID ) && ! Sensei_Course::is_user_enrolled( $course_id ) && $post->ID == $id ) {
 					$title .= ' ' . $this->sensei_lesson_preview_title_tag( $course_id );
 				}
 			}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4060,21 +4060,6 @@ class Sensei_Lesson {
 
 		_deprecated_function( __METHOD__, '3.0.0' );
 
-		$lesson_id = get_the_ID();
-
-		if ( 'lesson' != get_post_type( $lesson_id ) ) {
-			return;
-		}
-
-		$is_preview             = Sensei_Utils::is_preview_lesson( $lesson_id );
-		$pre_requisite_complete = self::is_prerequisite_complete( $lesson_id, get_current_user_id() );
-		$lesson_course_id       = get_post_meta( $lesson_id, '_lesson_course', true );
-		$user_taking_course     = Sensei_Course::is_user_enrolled( $lesson_course_id );
-
-		if ( $pre_requisite_complete && $is_preview && ! $user_taking_course ) {
-
-		}// end if
-
 	} // end user_not_taking_course_message
 
 	/**

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3999,7 +3999,7 @@ class Sensei_Lesson {
 		}
 
 		$lesson_course_id   = get_post_meta( $lesson_id, '_lesson_course', true );
-		$user_taking_course = Sensei_Utils::user_started_course( $lesson_course_id, $user_id );
+		$user_taking_course = Sensei_Course::is_user_enrolled( $lesson_course_id, $user_id );
 		if ( ! $user_taking_course || ! sensei_can_user_view_lesson( $lesson_id, $user_id ) ) {
 			return;
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4216,7 +4216,7 @@ class Sensei_Lesson {
 		$course_id  = get_post_meta( $post->ID, '_lesson_course', true );
 		$is_preview = isset( $post->ID )
 			&& Sensei_Utils::is_preview_lesson( $post->ID )
-			&& ! Sensei_Utils::user_started_course( $course_id, $current_user->ID );
+			&& ! Sensei_Course::is_user_enrolled( $course_id, $current_user->ID );
 
 		?>
 		<header class="lesson-title">

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4054,8 +4054,11 @@ class Sensei_Lesson {
 	 * Show the user not taking course message if it is the case
 	 *
 	 * @since 1.9.0
+	 * @deprecated 3.0.0
 	 */
 	public static function user_not_taking_course_message() {
+
+	  _deprecated_function( __METHOD__, '3.0.0' );
 
 		$lesson_id = get_the_ID();
 
@@ -4066,7 +4069,7 @@ class Sensei_Lesson {
 		$is_preview             = Sensei_Utils::is_preview_lesson( $lesson_id );
 		$pre_requisite_complete = self::is_prerequisite_complete( $lesson_id, get_current_user_id() );
 		$lesson_course_id       = get_post_meta( $lesson_id, '_lesson_course', true );
-		$user_taking_course     = Sensei_Utils::user_started_course( $lesson_course_id, get_current_user_id() );
+		$user_taking_course     = Sensei_Course::is_user_enrolled( $lesson_course_id );
 
 		if ( $pre_requisite_complete && $is_preview && ! $user_taking_course ) {
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3816,7 +3816,7 @@ class Sensei_Lesson {
 
 		$loop_lesson_number    = $wp_query->current_post + 1;
 		$course_id             = Sensei()->lesson->get_course_id( $lesson_id );
-		$is_user_taking_course = Sensei_Utils::user_started_course( $course_id, get_current_user_id() );
+		$is_user_taking_course = Sensei_Course::is_user_enrolled( $course_id );
 
 		// Get Lesson data
 		$complexity_array = Sensei()->lesson->lesson_complexities();

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4058,7 +4058,7 @@ class Sensei_Lesson {
 	 */
 	public static function user_not_taking_course_message() {
 
-	  _deprecated_function( __METHOD__, '3.0.0' );
+		_deprecated_function( __METHOD__, '3.0.0' );
 
 		$lesson_id = get_the_ID();
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3765,7 +3765,7 @@ class Sensei_Lesson {
 	/**
 	 * Filter the classes for lessons on the single course page.
 	 *
-	 * Adds the nesecary classes depending on the user data
+	 * Adds the necessary classes depending on the user data
 	 *
 	 * @since 1.9.0
 	 * @param array $classes

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4092,7 +4092,7 @@ class Sensei_Lesson {
 			return;
 		}
 
-		$show_course_signup_notice = sensei_is_login_required() && ! Sensei_Utils::user_started_course( $course_id, get_current_user_id() );
+		$show_course_signup_notice = sensei_is_login_required() && ! Sensei_Course::is_user_enrolled( $course_id );
 
 		/**
 		 * Filter for if we should show the course sign up notice on the lesson page.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3790,7 +3790,7 @@ class Sensei_Lesson {
 				} // End If Statement
 			} // End If Statement
 
-			$is_user_taking_course = Sensei_Utils::user_started_course( $course_id, get_current_user_id() );
+			$is_user_taking_course = Sensei_Course::is_user_enrolled( $course_id );
 			if ( Sensei_Utils::is_preview_lesson( get_the_ID() ) && ! $is_user_taking_course ) {
 
 				$lesson_classes[] = 'lesson-preview';

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4368,7 +4368,7 @@ class Sensei_Lesson {
 		$has_user_completed_lesson = Sensei_Utils::user_completed_lesson( intval( $lesson_id ), $user_id );
 
 		if ( $quiz_id && is_user_logged_in()
-			&& Sensei_Utils::user_started_course( $lesson_course_id, $user_id ) ) {
+			&& Sensei_Course::is_user_enrolled( $lesson_course_id, $user_id ) ) {
 			$has_quiz_questions = self::lesson_quiz_has_questions( $lesson_id );
 
 			// Display lesson quiz status message

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -696,7 +696,7 @@ class Sensei_Utils {
 
 			$course_id = get_post_meta( $lesson_id, '_lesson_course', true );
 			if ( $course_id ) {
-				$is_user_taking_course = self::user_started_course( $course_id, $user_id );
+				$is_user_taking_course = Sensei_Utils::has_started_course( $course_id, $user_id );
 				if ( ! $is_user_taking_course ) {
 					self::user_start_course( $user_id, $course_id );
 				}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -696,7 +696,7 @@ class Sensei_Utils {
 
 			$course_id = get_post_meta( $lesson_id, '_lesson_course', true );
 			if ( $course_id ) {
-				$is_user_taking_course = Sensei_Utils::has_started_course( $course_id, $user_id );
+				$is_user_taking_course = self::has_started_course( $course_id, $user_id );
 				if ( ! $is_user_taking_course ) {
 					self::user_start_course( $user_id, $course_id );
 				}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -674,7 +674,7 @@ class Sensei_Utils {
 	/**
 	 * Mark a lesson as started for user
 	 *
-	 * Will also start the lesson course for the user if the user hans't started taking it already.
+	 * Will also start the lesson course for the user if the user hasn't started taking it already.
 	 *
 	 * @since 1.6.0
 	 *

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -248,10 +248,6 @@ add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Templat
 add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Templates', 'deprecate_sensei_lesson_single_title' ), 15 );
 
 // @since 1.9.0
-// hook in the sensei lesson user notices
-add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'user_not_taking_course_message' ), 15 );
-
-// @since 1.9.0
 // attach the lesson title
 add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'the_title' ), 15 );
 

--- a/templates/course-results.php
+++ b/templates/course-results.php
@@ -72,7 +72,7 @@ $course = get_page_by_path( $wp_query->query_vars['course_results'], OBJECT, 'co
 
 			<section class="course-results-lessons">
 				<?php
-				if ( Sensei_Course::is_user_enrolled( $course->ID ) ) {
+				if ( Sensei_Utils::has_started_course( $course->ID ) ) {
 
 					sensei_the_course_results_lessons();
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Update `Sensei_Utils::user_started_course` to `Sensei_Course::is_user_enrolled`
* 5de21f0 sensei_lesson_preview_title: Unused filter function. Deprecate?
* Deprecate `Sensei_Lesson::user_not_taking_course_message`

#### Testing instructions:

8f7499e Lesson completed button:
* As a logged-in user, open a Preview lesson without quiz in a course not taken
* 'Complete lesson' button at the end of a lesson should not show up
* Start course, open lesson again
* 'Complete lesson' button should show up

d27df60:
* As a logged-in user, open a Preview lesson in a course not taken
* 'Preview' label at the top of the lesson should be visible
* Start course, open lesson again
* 'Preview' label should not show up

249420d maybe_start_lesson:
* Visiting a lesson with no prerequisites on a non-enrolled course
* Course and lesson progress should not be started for the user
* When enrolled in the course, lesson progress should be started when visiting it for the first time

3d304da:
* Course signup notification in a lesson should only show up when user is not already taking the course

8a7ad3f:
* Go to Learner Management > [Course] > Lessons -> [Lesson] -> Manage Learners
* Add a new Learner to the lesson who is not enrolled in the course
* Learner should be added to the course too

d355442:  
* On a single course page, `lesson-preview` class should not be added to a preview lesson when user is enrolled
* Enclosing function not currently working due to #2963

4e9e4cf8:
* On a single lesson page, 'Preview' label in title/header should only show up for users not enrolled in course

010e1f0d:
* Any quiz status message on a lesson page should only show up for enrolled users

4897d6c:
* Lesson progress on course results page should be visible if the user has started any progress on the course. 