### PR TITLE
Tweak Renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,11 @@
       "depTypeList": ["devDependencies"],
       "extends": ["schedule:monthly"],
       "groupName": "devDependencies"
+    },
+    {
+      "depTypeList": ["dependencies"],
+      "extends": ["schedule:monthly"],
+      "groupName": "dependencies"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "depTypeList": ["devDependencies"],
+      "extends": ["schedule:monthly"],
+      "groupName": "devDependencies"
+    }
   ]
 }


### PR DESCRIPTION
## Changes proposed in this Pull Request:

Tweaks Renovate config such that:
- Only `devDependencies` are updated
- Renovate bot runs monthly
- All dev dependencies updates will be in a single PR. This may require further discussion though. Should we perhaps group certain types (e.g. linting, JS etc.). What if we wanted to update some but not all?