### PR TITLE
Update usage tracking for enrolment count

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -37,6 +37,7 @@ class Sensei_Usage_Tracking_Data {
 			'enrolments'              => self::get_course_enrolments(),
 			'enrolment_first'         => self::get_first_course_enrolment(),
 			'enrolment_last'          => self::get_last_course_enrolment(),
+			'enrolment_calculated'    => self::get_is_enrolment_calculated() ? 1 : 0,
 			'learners'                => self::get_learner_count(),
 			'lessons'                 => wp_count_posts( 'lesson' )->publish,
 			'lesson_modules'          => self::get_lesson_module_count(),
@@ -386,9 +387,22 @@ class Sensei_Usage_Tracking_Data {
 	}
 
 	/**
+	 * Checks if enrolment has been calculated for the current Sensei version.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return bool
+	 */
+	private static function get_is_enrolment_calculated() {
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+
+		return get_option( Sensei_Enrolment_Job_Scheduler::CALCULATION_VERSION_OPTION_NAME ) === $enrolment_manager->get_enrolment_calculation_version();
+	}
+
+	/**
 	 * Get the learner term IDs for all admin users.
 	 *
-	 * @return string[]
+	 * @return int[]
 	 */
 	private static function get_admin_learner_term_ids() {
 		$admins         = get_users( [ 'role' => 'administrator' ] );

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -375,17 +375,30 @@ class Sensei_Usage_Tracking_Data {
 	 * @return int Number of course enrolments.
 	 **/
 	private static function get_course_enrolments() {
-		global $wpdb;
-
-		return $wpdb->get_var(
-			"SELECT COUNT(DISTINCT c.user_id)
-			FROM {$wpdb->comments} c
-			INNER JOIN {$wpdb->usermeta} um ON c.user_id = um.user_id
-			INNER JOIN {$wpdb->posts} p ON p.ID = c.comment_post_ID
-			WHERE comment_type = 'sensei_course_status'
-				AND meta_key = '{$wpdb->prefix}capabilities' AND meta_value NOT LIKE '%administrator%'
-				AND post_status = 'publish' AND c.user_id <> 0"
+		return (int) get_terms(
+			[
+				'hide_empty' => true,
+				'fields'     => 'count',
+				'exclude'    => self::get_admin_learner_term_ids(),
+				'taxonomy'   => Sensei_PostTypes::LEARNER_TAXONOMY_NAME,
+			]
 		);
+	}
+
+	/**
+	 * Get the learner term IDs for all admin users.
+	 *
+	 * @return string[]
+	 */
+	private static function get_admin_learner_term_ids() {
+		$admins         = get_users( [ 'role' => 'administrator' ] );
+		$admin_term_ids = [];
+		foreach ( $admins as $admin ) {
+			$learner_term     = Sensei_Learner::get_learner_term( $admin->ID );
+			$admin_term_ids[] = $learner_term->term_id;
+		}
+
+		return $admin_term_ids;
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -1425,6 +1425,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test getting count of lessons with `_lesson_length` set.
+	 *
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_lesson_has_length_count
 	 */
@@ -1458,6 +1460,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test getting count of lessons with `_lesson_complexity` set.
+	 *
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_lesson_with_complexity_count
 	 */

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -4,6 +4,8 @@
  * @group usage-tracking
  */
 class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
+	use Sensei_Course_Enrolment_Manual_Test_Helpers;
+
 	private $course_ids;
 	private $modules;
 
@@ -1113,13 +1115,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Enroll users in course.
 		foreach ( $subscribers as $subscriber ) {
-			$this->factory->comment->create(
-				array(
-					'user_id'         => $subscriber,
-					'comment_post_ID' => $course_id,
-					'comment_type'    => 'sensei_course_status',
-				)
-			);
+			$this->manuallyEnrolStudentInCourse( $subscriber, $course_id );
 		}
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
@@ -1147,13 +1143,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Enroll users in course.
 		foreach ( array_merge( $administrators, $subscribers ) as $user ) {
-			$this->factory->comment->create(
-				array(
-					'user_id'         => $user,
-					'comment_post_ID' => $course_id,
-					'comment_type'    => 'sensei_course_status',
-				)
-			);
+			$this->manuallyEnrolStudentInCourse( $user, $course_id );
 		}
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
@@ -1177,13 +1167,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Enroll users in course.
 		foreach ( $subscribers as $subscriber ) {
-			$this->factory->comment->create(
-				array(
-					'user_id'         => $subscriber,
-					'comment_post_ID' => $course_id,
-					'comment_type'    => 'sensei_course_status',
-				)
-			);
+			$this->manuallyEnrolStudentInCourse( $subscriber, $course_id );
 		}
 
 		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
@@ -1210,13 +1194,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Enroll users in course.
 		foreach ( $subscribers as $subscriber ) {
-			$comment_ids[] = $this->factory->comment->create(
-				array(
-					'user_id'         => $subscriber,
-					'comment_post_ID' => $course_id,
-					'comment_type'    => 'sensei_course_status',
-				)
-			);
+			$this->manuallyEnrolStudentInCourse( $subscriber, $course_id );
 		}
 
 		update_comment_meta( $comment_ids[0], 'start', '2017-05-23 10:59:00' );

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -1126,6 +1126,33 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 	/**
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_is_enrolment_calculated
+	 */
+	public function testGetIsEnrolmentCalculatedTrue() {
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+		update_option( Sensei_Enrolment_Job_Scheduler::CALCULATION_VERSION_OPTION_NAME, $enrolment_manager->get_enrolment_calculation_version() );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'enrolments', $usage_data, 'Key' );
+		$this->assertEquals( 1, $usage_data['enrolment_calculated'], 'Boolean int' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
+	 * @covers Sensei_Usage_Tracking_Data::get_is_enrolment_calculated
+	 */
+	public function testGetIsEnrolmentCalculatedFalse() {
+		delete_option( Sensei_Enrolment_Job_Scheduler::CALCULATION_VERSION_OPTION_NAME );
+
+		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+
+		$this->assertArrayHasKey( 'enrolments', $usage_data, 'Key' );
+		$this->assertEquals( 0, $usage_data['enrolment_calculated'], 'Boolean int' );
+	}
+
+	/**
+	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_course_enrolments
 	 */
 	public function testGetCourseEnrolmentsNoAdminUsers() {

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -1221,7 +1221,13 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 
 		// Enroll users in course.
 		foreach ( $subscribers as $subscriber ) {
-			$this->manuallyEnrolStudentInCourse( $subscriber, $course_id );
+			$comment_ids[] = $this->factory->comment->create(
+				array(
+					'user_id'         => $subscriber,
+					'comment_post_ID' => $course_id,
+					'comment_type'    => 'sensei_course_status',
+				)
+			);
 		}
 
 		update_comment_meta( $comment_ids[0], 'start', '2017-05-23 10:59:00' );


### PR DESCRIPTION
Fixes #2836

#### Changes proposed in this Pull Request:

* Updates learner count to use terms.
* Includes new binary flag `enrolment_calculated` for whether enrolment has been calculated site wide for that version of Sensei. This may be useful when looking at `enrolments` and possibly filtering out usage stats that haven't yet had a chance to be initially calculated.
* We're using term counts. These count the number of _published_ courses a [learner] term is associated with, which means we should be able to use it for this.
* As discussed on Slack, we're leaving the `enrolment_first` and `enrolment_last` as-is. Joining enrolment tables and progress tables isn't worth it for this case.

#### Testing instructions:

* See the initial PR (#2309) for testing instructions.