### PR TITLE
Remove usages of Sensei_Utils::user_started_course in course methods

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1858,8 +1858,11 @@ class Sensei_Course {
 	 */
 	public function get_progress_statement( $course_id, $user_id ) {
 
-		if ( empty( $course_id ) || empty( $user_id )
-		|| ! Sensei_Utils::user_started_course( $course_id, $user_id ) ) {
+		if (
+			empty( $course_id )
+			|| empty( $user_id )
+			|| ! self::is_user_enrolled( $course_id, $user_id )
+		) {
 			return '';
 		}
 
@@ -1921,8 +1924,11 @@ class Sensei_Course {
 			$user_id = get_current_user_id();
 		}
 
-		if ( 'course' != get_post_type( $course_id ) || ! get_userdata( $user_id )
-			|| ! Sensei_Utils::user_started_course( $course_id, $user_id ) ) {
+		if (
+			'course' !== get_post_type( $course_id )
+			|| ! get_userdata( $user_id )
+			|| ! self::is_user_enrolled( $course_id, $user_id )
+		) {
 			return;
 		}
 		$percentage_completed = $this->get_completion_percentage( $course_id, $user_id );
@@ -2135,7 +2141,7 @@ class Sensei_Course {
 		// Meta data
 		$course                = get_post( $course_id );
 		$preview_lesson_count  = intval( Sensei()->course->course_lesson_preview_count( $course->ID ) );
-		$is_user_taking_course = Sensei_Utils::user_started_course( $course->ID, get_current_user_id() );
+		$is_user_taking_course = self::is_user_enrolled( $course->ID, get_current_user_id() );
 
 		if ( 0 < $preview_lesson_count && ! $is_user_taking_course ) {
 			?>
@@ -2942,7 +2948,7 @@ class Sensei_Course {
 		?>
 		<section class="course-meta course-enrolment">
 		<?php
-		$is_user_taking_course = Sensei_Utils::user_started_course( $post->ID, $current_user->ID );
+		$is_user_taking_course = self::is_user_enrolled( $post->ID, $current_user->ID );
 
 		// If user is taking course, display progress.
 		if ( $is_user_taking_course ) {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1240,7 +1240,7 @@ class Sensei_Utils {
 
 		if ( $course_id > 0 && $user_id > 0 ) {
 
-			$started_course = self::user_started_course( $course_id, $user_id );
+			$started_course = self::has_started_course( $course_id, $user_id );
 
 			if ( $started_course ) {
 				$passmark   = self::sensei_course_pass_grade( $course_id ); // This happens inside sensei_user_passed_course()!


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Updates deprecated usage of `Sensei_Utils::user_started_course` in courses related code.
* For all usages in `Sensei_Course`, it was pretty clearly checking for enrolment.
* For the results page status, I used `has_started_course`. The reason being, if someone has progress and goes to `/courses/{slug}/results`, they should be able see their actual progress.

#### Testing instructions:

* Course results page should show proper message if user has ever started course (and hasn't had progress reset when not enrolled).
* When viewing a course you're enrolled in, the course progress meter and message at the top should show up correctly. If you aren't enrolled and there aren't products associated with it, you should see action button to start taking course.
* If your course has preview lessons, when you aren't enrolled you should see button `Preview this course`.