### PR TITLE
Run plugin update checker and tasks on every request

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -442,7 +442,7 @@ class Sensei_Main {
 
 		// check flush the rewrite rules if the option sensei_flush_rewrite_rules option is 1
 		add_action( 'admin_init', array( $this, 'flush_rewrite_rules' ), 101 );
-		add_action( 'admin_init', array( $this, 'update' ) );
+		add_action( 'init', array( $this, 'update' ) );
 
 		// Add plugin action links filter
 		add_filter( 'plugin_action_links_' . plugin_basename( $this->main_plugin_file_name ), array( $this, 'plugin_action_links' ) );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -591,7 +591,7 @@ class Sensei_Main {
 		}
 
 		// Mark site as having enrolment data from pre-3.0.0.
-		if ( version_compare( '3.0.0-dev', get_option( 'sensei-version' ), '>' ) ) {
+		if ( get_option( 'sensei-version' ) && version_compare( '3.0.0-dev', get_option( 'sensei-version' ), '>' ) ) {
 			update_option( 'sensei_enrolment_legacy', time() );
 		}
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -456,13 +456,16 @@ class Sensei_Main {
 	}
 
 	/**
-	 * Run Sensei updates.
+	 * Run Sensei automatic data updates. This has been unused for many versions and should be considered destructive.
 	 *
-	 * @access  public
+	 * @deprecated 3.0.0
 	 * @since   1.1.0
+	 *
 	 * @return  void
 	 */
 	public function run_updates() {
+		_deprecated_function( __METHOD__, '3.0.0' );
+
 		// Run updates if administrator
 		if ( current_user_can( 'manage_options' ) || current_user_can( 'manage_sensei' ) ) {
 


### PR DESCRIPTION
This fixes an issue with legacy enrolment migration if an admin page doesn't load before a user visits My Courses. In theory, this shouldn't happen, but this makes it a bit safer. The check itself is really lightweight because the option `sensei-version` is autoloaded.

Just a note: we should never do any destructive or slow tasks in this method. All database table updates or larger migration tasks should always take place with an async task. 

Just so we're never tempted, I took this opportunity to deprecate `Sensei_Main::run_updates`. It has been unused for a long time. The automatic data updates it could run could also be destructive. This would be an example of a task we would never want to run in `Sensei_Main::update` :).

For precedence on doing this in another plugin, I present some lovely code from our friends at Woo 😃 
https://github.com/woocommerce/woocommerce/blob/22392546f6c4601da7b76327d0556b3f808fcea7/includes/class-wc-install.php#L152-L176
### Deprecated Methods
- `Sensei_Main::run_updates`