### PR TITLE
Change user_started_course in quiz and email code

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -781,7 +781,7 @@ class Sensei_Question {
 		$user_lesson_status = Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
 		$quiz_graded        = isset( $user_lesson_status->comment_approved ) && ! in_array( $user_lesson_status->comment_approved, array( 'in-progress', 'ungraded' ) );
 
-		if ( ! Sensei_Utils::has_started_course( Sensei()->lesson->get_course_id( $lesson_id ) ) ) {
+		if ( ! Sensei_Utils::has_started_course( Sensei()->lesson->get_course_id( $lesson_id ), get_current_user_id() ) ) {
 			return;
 		}
 

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -781,7 +781,7 @@ class Sensei_Question {
 		$user_lesson_status = Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
 		$quiz_graded        = isset( $user_lesson_status->comment_approved ) && ! in_array( $user_lesson_status->comment_approved, array( 'in-progress', 'ungraded' ) );
 
-		if ( ! Sensei_Utils::user_started_course( Sensei()->lesson->get_course_id( $lesson_id ), get_current_user_id() ) ) {
+		if ( ! Sensei_Utils::has_started_course( Sensei()->lesson->get_course_id( $lesson_id ) ) ) {
 			return;
 		}
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1251,7 +1251,7 @@ class Sensei_Quiz {
 	}
 
 	/**
-	 * The quiz action buttons needed to ouput quiz
+	 * The quiz action buttons needed to output quiz
 	 * action such as reset complete and save.
 	 *
 	 * @since 1.3.0

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1287,7 +1287,7 @@ class Sensei_Quiz {
 			$show_actions = Sensei_Utils::user_completed_lesson( $lesson_prerequisite, $current_user->ID );
 
 		}
-		if ( $show_actions && is_user_logged_in() && Sensei_Utils::user_started_course( $lesson_course_id, $current_user->ID ) ) {
+		if ( $show_actions && is_user_logged_in() && Sensei_Course::is_user_enrolled( $lesson_course_id, $current_user->ID ) ) {
 
 			// Get Reset Settings
 			$reset_quiz_allowed = get_post_meta( $post->ID, '_enable_quiz_reset', true );

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1287,7 +1287,7 @@ class Sensei_Utils {
 			$course_id = absint( get_post_meta( $lesson_id, '_lesson_course', true ) );
 
 			// Has user started course
-			$started_course = self::user_started_course( $course_id, $user_id );
+			$started_course = Sensei_Course::is_user_enrolled( $course_id, $user_id );
 
 			// Has user completed lesson
 			$user_lesson_status = self::user_lesson_status( $lesson_id, $user_id );

--- a/includes/emails/class-sensei-email-learner-completed-course.php
+++ b/includes/emails/class-sensei-email-learner-completed-course.php
@@ -47,7 +47,7 @@ if ( ! class_exists( 'Sensei_Email_Learner_Completed_Course' ) ) :
 		function trigger( $user_id = 0, $course_id = 0 ) {
 			global  $sensei_email_data;
 
-			if ( ! Sensei_Utils::user_started_course( $course_id, $user_id ) ) {
+			if ( ! Sensei_Course::is_user_enrolled( $course_id, $user_id ) ) {
 				return;
 			}
 

--- a/includes/emails/class-sensei-email-teacher-completed-course.php
+++ b/includes/emails/class-sensei-email-teacher-completed-course.php
@@ -45,7 +45,7 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Course' ) ) :
 		function trigger( $learner_id = 0, $course_id = 0 ) {
 			global  $sensei_email_data;
 
-			if ( ! Sensei_Utils::user_started_course( $course_id, $learner_id ) ) {
+			if ( ! Sensei_Course::is_user_enrolled( $course_id, $learner_id ) ) {
 				return;
 			}
 			// Get learner user object

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -376,7 +376,7 @@ class Sensei_Legacy_Shortcodes {
 		$author_display_name   = $user_info->display_name;
 		$category_output       = get_the_term_list( $course_id, 'course-category', '', ', ', '' );
 		$preview_lesson_count  = intval( Sensei()->course->course_lesson_preview_count( $course_id ) );
-		$is_user_taking_course = Sensei_Course::is_user_enrolled(ourse_id, get_current_user_id() );
+		$is_user_taking_course = Sensei_Course::is_user_enrolled( $course_id, get_current_user_id() );
 		?>
 
 		<article class="<?php echo esc_attr( join( ' ', get_post_class( array( 'course', 'post' ), $course_id ) ) ); ?>">

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -376,7 +376,7 @@ class Sensei_Legacy_Shortcodes {
 		$author_display_name   = $user_info->display_name;
 		$category_output       = get_the_term_list( $course_id, 'course-category', '', ', ', '' );
 		$preview_lesson_count  = intval( Sensei()->course->course_lesson_preview_count( $course_id ) );
-		$is_user_taking_course = Sensei_Utils::user_started_course( $course_id, get_current_user_id() );
+		$is_user_taking_course = Sensei_Course::is_user_enrolled(ourse_id, get_current_user_id() );
 		?>
 
 		<article class="<?php echo esc_attr( join( ' ', get_post_class( array( 'course', 'post' ), $course_id ) ) ); ?>">


### PR DESCRIPTION

#### Changes proposed in this Pull Request:

* Change `Sensei_Utils::user_started_course` to `Sensei_Course::is_user_enrolled` in Quiz and Email related bits

#### Testing instructions:

* Quiz action buttons (eg. Complete quiz, Save quiz) only shop up for enrolled users
* Quiz status message displays *Please sign up for this course..* if user is not enrolled
* Quiz answer grade only shows up on a quiz page when the user has started the course (and the quiz is graded).
  (Currently the entire quiz page is only accessible when they are enrolled)
* Course completed email is only sent out to learner and teacher when learner is enrolled.
* Reset progress on course in Learner Management should work properly both when the user is enrolled and when not.

