### PR TITLE
Allow frontend enrolment form to be handled elsewhere

### DIFF
--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -444,34 +444,10 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 				$reset_action = 'reset_progress';
 				$reset_label  = esc_html__( 'Reset progress', 'sensei-lms' );
-
-				$is_course_progress_reset_removal = ! $is_user_enrolled;
-
-				/**
-				 * Determine if resetting the course progress will actually just remove it.
-				 *
-				 * @param bool $is_course_progress_reset_removal True if this course progress reset will just remove the progress.
-				 * @param bool $is_user_enrolled                 True if the user is enrolled.
-				 * @param int  $user_id                          User ID.
-				 * @param int  $course_id                        Course post ID.
-				 */
-				$is_course_progress_reset_removal = apply_filters( 'sensei_user_course_progress_reset_is_removal', $is_course_progress_reset_removal, $is_user_enrolled, $user_activity->user_id, $this->course_id );
-
-				if ( 'course' === $post_type && $is_course_progress_reset_removal ) {
+				if ( 'course' === $post_type && ! $is_user_enrolled ) {
 					$reset_action = 'remove_progress';
 					$reset_label  = esc_html__( 'Remove progress', 'sensei-lms' );
 				}
-
-				/**
-				 * Allow customization of the course progress reset label.
-				 *
-				 * @param string $reset_label                      Label for the reset button.
-				 * @param bool   $is_course_progress_reset_removal True if this course progress reset will just remove the progress.
-				 * @param bool   $is_user_enrolled                 True if the user is enrolled.
-				 * @param int    $user_id                          User ID.
-				 * @param int    $course_id                        Course post ID.
-				 */
-				$reset_label = apply_filters( 'sensei_user_course_progress_reset_action_label', $reset_label, $is_course_progress_reset_removal, $is_user_enrolled, $user_activity->user_id, $this->course_id );
 
 				$actions[] = '<a class="learner-async-action button" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="' . esc_attr( $reset_action ) . '" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' . $reset_label . '</a>';
 

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -444,10 +444,34 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 				$reset_action = 'reset_progress';
 				$reset_label  = esc_html__( 'Reset progress', 'sensei-lms' );
-				if ( 'course' === $post_type && ! $is_user_enrolled ) {
+
+				$is_course_progress_reset_removal = ! $is_user_enrolled;
+
+				/**
+				 * Determine if resetting the course progress will actually just remove it.
+				 *
+				 * @param bool $is_course_progress_reset_removal True if this course progress reset will just remove the progress.
+				 * @param bool $is_user_enrolled                 True if the user is enrolled.
+				 * @param int  $user_id                          User ID.
+				 * @param int  $course_id                        Course post ID.
+				 */
+				$is_course_progress_reset_removal = apply_filters( 'sensei_user_course_progress_reset_is_removal', $is_course_progress_reset_removal, $is_user_enrolled, $user_activity->user_id, $this->course_id );
+
+				if ( 'course' === $post_type && $is_course_progress_reset_removal ) {
 					$reset_action = 'remove_progress';
 					$reset_label  = esc_html__( 'Remove progress', 'sensei-lms' );
 				}
+
+				/**
+				 * Allow customization of the course progress reset label.
+				 *
+				 * @param string $reset_label                      Label for the reset button.
+				 * @param bool   $is_course_progress_reset_removal True if this course progress reset will just remove the progress.
+				 * @param bool   $is_user_enrolled                 True if the user is enrolled.
+				 * @param int    $user_id                          User ID.
+				 * @param int    $course_id                        Course post ID.
+				 */
+				$reset_label = apply_filters( 'sensei_user_course_progress_reset_action_label', $reset_label, $is_course_progress_reset_removal, $is_user_enrolled, $user_activity->user_id, $this->course_id );
 
 				$actions[] = '<a class="learner-async-action button" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="' . esc_attr( $reset_action ) . '" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' . $reset_label . '</a>';
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1261,7 +1261,6 @@ class Sensei_Frontend {
 			 * @param bool|null $student_enrolled True if the student enrolled; False if there was a problem.
 			 * @param int       $user_id          User ID.
 			 * @param int       $course_id        Course post ID.
-			 *
 			 */
 			$student_enrolled = apply_filters( 'sensei_handle_frontend_student_enrolment', null, $current_user->ID, $post->ID );
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1253,10 +1253,24 @@ class Sensei_Frontend {
 			&& Sensei_Course::can_current_user_manually_enrol( $post->ID )
 		) {
 
-			// Manually enrol a student.
-			$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
-			$manual_enrolment  = $enrolment_manager->get_manual_enrolment_provider();
-			$student_enrolled  = $manual_enrolment && $manual_enrolment->enrol_student( $current_user->ID, $post->ID );
+			/**
+			 * Lets providers handle their own course sign-up. If they return a boolean, it will be treated as a result.
+			 *
+			 * @since 3.0.0
+			 *
+			 * @param bool|null $student_enrolled True if the student enrolled; False if there was a problem.
+			 * @param int       $user_id          User ID.
+			 * @param int       $course_id        Course post ID.
+			 *
+			 */
+			$student_enrolled = apply_filters( 'sensei_handle_frontend_student_enrolment', null, $current_user->ID, $post->ID );
+
+			// If no other handler took care of enrolling the student, sign the student up with the manual enrolment provider.
+			if ( null === $student_enrolled ) {
+				$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+				$manual_enrolment  = $enrolment_manager->get_manual_enrolment_provider();
+				$student_enrolled  = $manual_enrolment && $manual_enrolment->enrol_student( $current_user->ID, $post->ID );
+			}
 
 			$this->data                        = new stdClass();
 			$this->data->is_user_taking_course = false;

--- a/includes/enrolment/class-sensei-enrolment-provider-state.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-state.php
@@ -62,10 +62,24 @@ class Sensei_Enrolment_Provider_State implements JsonSerializable {
 			return false;
 		}
 
-		$provider_data = isset( $data['d'] ) ? array_filter( array_map( [ __CLASS__, 'sanitize_data' ], $data['d'] ) ) : [];
-		$logs          = isset( $data['l'] ) ? array_filter( array_map( [ __CLASS__, 'sanitize_logs' ], $data['l'] ) ) : [];
+		$provider_data = isset( $data['d'] ) ? array_map( [ __CLASS__, 'sanitize_data' ], $data['d'] ) : [];
+		$logs          = isset( $data['l'] ) ? array_map( [ __CLASS__, 'sanitize_logs' ], $data['l'] ) : [];
+
+		$provider_data = array_filter( $provider_data, [ __CLASS__, 'filter_null_values' ] );
+		$logs          = array_filter( $logs, [ __CLASS__, 'filter_null_values' ] );
 
 		return new self( $state_store, $provider_data, $logs );
+	}
+
+	/**
+	 * Helper method to filter out null values.
+	 *
+	 * @param mixed $value Value to filter.
+	 *
+	 * @return bool
+	 */
+	private static function filter_null_values( $value ) {
+		return null !== $value;
 	}
 
 	/**

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -90,7 +90,7 @@ function sensei_check_prerequisite_course( $course_id ) {
 	 */
 function sensei_start_course_form( $course_id ) {
 
-	$prerequisite_complete = sensei_check_prerequisite_course( $course_id );
+	$prerequisite_complete = Sensei_Course::is_prerequisite_complete( $course_id );
 
 	if ( $prerequisite_complete ) {
 		?><form method="POST" action="<?php echo esc_url( get_permalink( $course_id ) ); ?>">


### PR DESCRIPTION
Paired with WCPC Proposal. This just allows for the functionality added in that WCPC PR.

### Changes Proposed
- Allows alternative handlers for course sign-up and allows learner management actions to be relabeled. 
- Fix bug in state storage around stored `false` values.

#### New Filter
- `sensei_handle_frontend_student_enrolment` - Allow providers to handle their own course sign-up.