### PR TITLE
Add missing deprecation notices

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -817,6 +817,7 @@ class Sensei_Learner_Management {
 	 */
 	public function get_learner_full_name( $user_id ) {
 
+		// To be removed in 5.0.0.
 		_deprecated_function( __METHOD__, '1.9.0', 'Sensei_Learner::get_full_name' );
 		return Sensei_Learner::get_full_name( $user_id );
 

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -808,7 +808,7 @@ class Sensei_Learner_Management {
 	 *
 	 * The user must have both name and surname otherwise display name will be returned.
 	 *
-	 * @deprecated since 1.9.0 use Se
+	 * @deprecated since 1.9.0 use Sensei_Learner::get_full_name
 	 * @since 1.8.0
 	 *
 	 * @param int $user_id | bool false for an invalid $user_id.
@@ -817,6 +817,7 @@ class Sensei_Learner_Management {
 	 */
 	public function get_learner_full_name( $user_id ) {
 
+		_deprecated_function( __METHOD__, '1.9.0', 'Sensei_Learner::get_full_name' );
 		return Sensei_Learner::get_full_name( $user_id );
 
 	}

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -192,6 +192,8 @@ class Sensei_Frontend {
 	 */
 	function sensei_get_template_part( $slug, $name = '' ) {
 
+		_deprecated_function( 'sensei_locate_template', '1.9.0', 'Sensei_Templates::get_part' );
+
 		Sensei_Templates::get_part( $slug, $name );
 
 	} // End sensei_get_template_part()

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -184,7 +184,7 @@ class Sensei_Frontend {
 	/**
 	 * Get template part.
 	 *
-	 * @deprecated since 1.9.0
+	 * @deprecated since 1.9.0 use Sensei_Templates::get_part
 	 * @access public
 	 * @param mixed  $slug Template slug.
 	 * @param string $name Optional. Template name. Default ''.
@@ -192,7 +192,7 @@ class Sensei_Frontend {
 	 */
 	function sensei_get_template_part( $slug, $name = '' ) {
 
-		_deprecated_function( 'sensei_locate_template', '1.9.0', 'Sensei_Templates::get_part' );
+		_deprecated_function( __METHOD__, '1.9.0', 'Sensei_Templates::get_part' );
 
 		Sensei_Templates::get_part( $slug, $name );
 
@@ -518,7 +518,7 @@ class Sensei_Frontend {
 	/**
 	 * Outputs the course image.
 	 *
-	 * @deprecated since 1.9.0
+	 * @deprecated since 1.9.0 use Sensei()->course->course_image
 	 * @param int    $course_id Course ID.
 	 * @param string $width Optional. Image width. Default '100'.
 	 * @param string $height Optional. Image height. Default '100'.
@@ -528,6 +528,7 @@ class Sensei_Frontend {
 	 */
 	function sensei_course_image( $course_id, $width = '100', $height = '100', $return = false ) {
 
+		_deprecated_function( __METHOD__, '1.9.0', 'Sensei()->course->course_image' );
 		if ( ! $return ) {
 
 			echo wp_kses_post( Sensei()->course->course_image( $course_id, $width, $height ) );
@@ -543,7 +544,7 @@ class Sensei_Frontend {
 	 * Outputs the lesson image.
 	 *
 	 * @since  1.2.0
-	 * @deprecated since 1.9.0
+	 * @deprecated since 1.9.0 use Sensei()->lesson->lesson_image
 	 * @param int        $lesson_id Lesson ID.
 	 * @param string     $width Optional. Image width. Default '100'.
 	 * @param string     $height Optional. Image height. Default '100'.
@@ -553,6 +554,8 @@ class Sensei_Frontend {
 	 * @return string Lesson image or empty string if the image was echoed.
 	 */
 	function sensei_lesson_image( $lesson_id, $width = '100', $height = '100', $return = false, $widget = false ) {
+
+		_deprecated_function( __METHOD__, '1.9.0', 'Sensei()->lesson->lesson_image' );
 
 		if ( ! $return ) {
 
@@ -1098,9 +1101,11 @@ class Sensei_Frontend {
 	/**
 	 * Outputs the quiz buttons and messages.
 	 *
-	 * @deprecated since 1.9.0
+	 * @deprecated since 1.9.0 use Sensei_Lesson::footer_quiz_call_to_action()
 	 */
 	public function sensei_lesson_quiz_meta() {
+
+		_deprecated_function( __METHOD__, '1.9.0', 'Sensei_Lesson::footer_quiz_call_to_action' );
 
 		Sensei_Lesson::footer_quiz_call_to_action();
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -192,6 +192,7 @@ class Sensei_Frontend {
 	 */
 	function sensei_get_template_part( $slug, $name = '' ) {
 
+		// To be removed in 5.0.0.
 		_deprecated_function( __METHOD__, '1.9.0', 'Sensei_Templates::get_part' );
 
 		Sensei_Templates::get_part( $slug, $name );
@@ -528,6 +529,7 @@ class Sensei_Frontend {
 	 */
 	function sensei_course_image( $course_id, $width = '100', $height = '100', $return = false ) {
 
+		// To be removed in 5.0.0.
 		_deprecated_function( __METHOD__, '1.9.0', 'Sensei()->course->course_image' );
 		if ( ! $return ) {
 
@@ -555,6 +557,7 @@ class Sensei_Frontend {
 	 */
 	function sensei_lesson_image( $lesson_id, $width = '100', $height = '100', $return = false, $widget = false ) {
 
+		// To be removed in 5.0.0.
 		_deprecated_function( __METHOD__, '1.9.0', 'Sensei()->lesson->lesson_image' );
 
 		if ( ! $return ) {
@@ -1105,6 +1108,7 @@ class Sensei_Frontend {
 	 */
 	public function sensei_lesson_quiz_meta() {
 
+		// To be removed in 5.0.0.
 		_deprecated_function( __METHOD__, '1.9.0', 'Sensei_Lesson::footer_quiz_call_to_action' );
 
 		Sensei_Lesson::footer_quiz_call_to_action();

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -411,6 +411,7 @@ class Sensei_Utils {
 	 */
 	public static function sensei_save_quiz_answers( $submitted = array(), $user_id = 0 ) {
 
+		// To be removed in 5.0.0.
 		_deprecated_function( __METHOD__, '1.9.4', 'Sensei_Quiz::save_user_answers' );
 
 		if ( intval( $user_id ) == 0 ) {
@@ -547,6 +548,7 @@ class Sensei_Utils {
 	 */
 	public static function sensei_grade_quiz_auto( $quiz_id = 0, $submitted = array(), $total_questions = 0, $quiz_grade_type = 'auto' ) {
 
+		// To be removed in 5.0.0.
 		_deprecated_function( __METHOD__, '1.7.4', 'Sensei_Grading::grade_quiz_auto' );
 
 		return Sensei_Grading::grade_quiz_auto( $quiz_id, $submitted, $total_questions, $quiz_grade_type );
@@ -597,6 +599,7 @@ class Sensei_Utils {
 	 */
 	public static function sensei_grade_question_auto( $question_id = 0, $question_type = '', $answer = '', $user_id = 0 ) {
 
+		// To be removed in 5.0.0.
 		_deprecated_function( __METHOD__, '1.7.4', 'Sensei_Grading::grade_question_auto' );
 
 		return Sensei_Grading::grade_question_auto( $question_id, $question_type, $answer, $user_id );
@@ -907,6 +910,7 @@ class Sensei_Utils {
 	 */
 	public static function sensei_get_user_question_answer_notes( $question = 0, $user_id = 0 ) {
 
+		// To be removed in 5.0.0.
 		_deprecated_function( __METHOD__, '1.7.5', 'Sensei()->quiz->get_user_question_feedback' );
 
 		$answer_notes = false;

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -411,6 +411,8 @@ class Sensei_Utils {
 	 */
 	public static function sensei_save_quiz_answers( $submitted = array(), $user_id = 0 ) {
 
+		_deprecated_function( __METHOD__, '1.9.4', 'Sensei_Quiz::save_user_answers' );
+
 		if ( intval( $user_id ) == 0 ) {
 			$user_id = get_current_user_id();
 		}
@@ -545,6 +547,8 @@ class Sensei_Utils {
 	 */
 	public static function sensei_grade_quiz_auto( $quiz_id = 0, $submitted = array(), $total_questions = 0, $quiz_grade_type = 'auto' ) {
 
+		_deprecated_function( __METHOD__, '1.7.4', 'Sensei_Grading::grade_quiz_auto' );
+
 		return Sensei_Grading::grade_quiz_auto( $quiz_id, $submitted, $total_questions, $quiz_grade_type );
 
 	} // End sensei_grade_quiz_auto()
@@ -592,6 +596,8 @@ class Sensei_Utils {
 	 * @return int $question_grade
 	 */
 	public static function sensei_grade_question_auto( $question_id = 0, $question_type = '', $answer = '', $user_id = 0 ) {
+
+		_deprecated_function( __METHOD__, '1.7.4', 'Sensei_Grading::grade_question_auto' );
 
 		return Sensei_Grading::grade_question_auto( $question_id, $question_type, $answer, $user_id );
 
@@ -900,6 +906,9 @@ class Sensei_Utils {
 	 * @return string
 	 */
 	public static function sensei_get_user_question_answer_notes( $question = 0, $user_id = 0 ) {
+
+		_deprecated_function( __METHOD__, '1.7.5', 'Sensei()->quiz->get_user_question_feedback' );
+
 		$answer_notes = false;
 		if ( $question ) {
 			if ( is_object( $question ) ) {

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -68,6 +68,7 @@ function lesson_single_meta() {
 	  */
 function quiz_questions( $return = false ) {
 
+	// To be removed in 5.0.0.
 	_deprecated_function( __FUNCTION__, '1.9.0', 'Sensei_Templates::get_template' );
 	Sensei_Templates::get_template( 'single-quiz/quiz-questions.php' );
 
@@ -101,6 +102,7 @@ function quiz_question_type( $question_type = 'multiple-choice' ) {
 	 */
 function sensei_check_prerequisite_course( $course_id ) {
 
+	// To be removed in 5.0.0.
 	_deprecated_function( __FUNCTION__, '1.9.0', 'Sensei_Course::is_prerequisite_complete' );
 	return Sensei_Course::is_prerequisite_complete( $course_id );
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -64,10 +64,11 @@ function lesson_single_meta() {
 	  * @access public
 	  * @param bool $return (default: false)
 	  * @return void
-	  * @deprecated since 1.9.0
+	  * @deprecated since 1.9.0 use Sensei_Templates::get_template
 	  */
 function quiz_questions( $return = false ) {
 
+	_deprecated_function( __FUNCTION__, '1.9.0', 'Sensei_Templates::get_template' );
 	Sensei_Templates::get_template( 'single-quiz/quiz-questions.php' );
 
 } // End quiz_questions()
@@ -100,6 +101,7 @@ function quiz_question_type( $question_type = 'multiple-choice' ) {
 	 */
 function sensei_check_prerequisite_course( $course_id ) {
 
+	_deprecated_function( __FUNCTION__, '1.9.0', 'Sensei_Course::is_prerequisite_complete' );
 	return Sensei_Course::is_prerequisite_complete( $course_id );
 
 } // End sensei_check_prerequisite_course()


### PR DESCRIPTION
Some methods only had a `@deprecated` tag with no user-facing warning. This adds the appropriate `_deprecated_function` calls. 

* `Sensei_Learner_Management::get_learner_full_name`
* `Sensei_Frontend::sensei_get_template_part`
* `Sensei_Frontend::sensei_course_image`
* `Sensei_Frontend::sensei_lesson_image`
* `Sensei_Frontend::sensei_lesson_quiz_meta`
* `Sensei_Utils::sensei_save_quiz_answers`
* `Sensei_Utils::sensei_grade_quiz_auto`
* `Sensei_Utils::sensei_grade_question_auto`
* `Sensei_Utils::sensei_get_user_question_answer_notes`
* `quiz_questions`
* `sensei_check_prerequisite_course`

#### Testing instructions:

* Using these methods should show a user error when `WP_DEBUG` is on.

