### PR TITLE
Deprecate Sensei_Utils::user_started_course

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1417,8 +1417,7 @@ class Sensei_Utils {
 	 * @return bool
 	 */
 	public static function user_started_course( $course_id = 0, $user_id = 0 ) {
-		// @todo Uncomment next line when we're ready to remove usage in the plugin itself.
-		// _deprecated_function( __METHOD__, '3.0.0', 'To check if a user is enrolled use `Sensei_Course::is_user_enrolled()`. For course progress check, use `Sensei_Utils::has_started_course()`' );
+		_deprecated_function( __METHOD__, '3.0.0', 'To check if a user is enrolled use `Sensei_Course::is_user_enrolled()`. For course progress check, use `Sensei_Utils::has_started_course()`' );
 
 		if ( empty( $course_id ) ) {
 			return false;


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Uncomments the deprecation of `Sensei_Utils::user_started_course`

After updating plugins and all usages of this method, it is safe to deprecate it.