### PR TITLE
Rename "Remove progress" bulk learner action

### DIFF
--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -117,7 +117,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 		$this->known_bulk_actions = [
 			self::MANUALLY_ENROL                => __( 'Add manual enrollment', 'sensei-lms' ),
 			self::REMOVE_MANUAL_ENROLMENT       => __( 'Remove manual enrollment', 'sensei-lms' ),
-			self::REMOVE_PROGRESS               => __( 'Remove progress', 'sensei-lms' ),
+			self::REMOVE_PROGRESS               => __( 'Reset or remove progress', 'sensei-lms' ),
 			self::COMPLETE_COURSE               => __( 'Recalculate Course(s) Completion (notify on complete)', 'sensei-lms' ),
 			self::RECALCULATE_COURSE_COMPLETION => __( 'Recalculate Course(s) Completion (do not notify on complete)', 'sensei-lms' ),
 		];
@@ -419,4 +419,3 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	}
 
 }
-


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

Rename "Remove progress" in Bulk Learner Management dropdown to "Reset or remove progress". If a user is enrolled, their progress is reset, but if they are not enrolled, their progress is removed.

#### Testing instructions:

* Go to _Sensei LMS_ > _Learner Management_.
* Click on the _Bulk Learner Actions_ link.
* Open the _Bulk Learner Actions_ dropdown.
* "Reset or remove progress" should be an option.