### PR TITLE
Add learner management filter for manually enrolled users

### DIFF
--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -987,7 +987,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$link_title = esc_html__( 'Unenrolled Learners', 'sensei-lms' );
 				break;
 			case 'manual':
-				$link_title = esc_html__( 'Manually enrolled Learners', 'sensei-lms' );
+				$link_title = esc_html__( 'Manually Enrolled Learners', 'sensei-lms' );
 				break;
 			case 'all':
 				$link_title = esc_html__( 'All Learners', 'sensei-lms' );

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -847,7 +847,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	/**
 	 * Check if the user's enrollment is provided by the manual provider.
 	 *
-	 * @param $user_id integer The user id.
+	 * @param integer $user_id The user id.
 	 * @return bool The manual enrollment status.
 	 */
 	private function is_manually_enrolled( $user_id ) {

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -928,6 +928,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			$menu['learners']            = $this->learners_link( 'all' );
 			$menu['enrolled-learners']   = $this->learners_link( 'enrolled' );
 			$menu['unenrolled-learners'] = $this->learners_link( 'unenrolled' );
+			$menu['manually-enrolled-learners'] = $this->learners_link( 'manual' );
 			$menu['lessons']             = $this->lessons_link();
 
 		} elseif ( $this->course_id && $this->lesson_id ) {
@@ -984,6 +985,9 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				break;
 			case 'unenrolled':
 				$link_title = esc_html__( 'Unenrolled Learners', 'sensei-lms' );
+				break;
+			case 'manual':
+				$link_title = esc_html__( 'Manually enrolled Learners', 'sensei-lms' );
 				break;
 			case 'all':
 				$link_title = esc_html__( 'All Learners', 'sensei-lms' );

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -824,7 +824,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		if ( in_array( $this->enrolment_status, [ 'enrolled', 'unenrolled', 'manual' ], true ) ) {
 			$enroled_users = Sensei_Course_Enrolment::get_course_instance( $this->course_id )->get_enrolled_user_ids();
 
-			if ( 'manual' == $this->enrolment_status ) {
+			if ( 'manual' === $this->enrolment_status ) {
 				$enroled_users = array_filter( $enroled_users, [ $this, 'is_manually_enrolled' ] );
 			}
 
@@ -845,10 +845,10 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	}
 
 	/**
-	 * Check if the user's enrollment is provided by the manual provider
+	 * Check if the user's enrollment is provided by the manual provider.
 	 *
-	 * @param $user_id
-	 * @return bool
+	 * @param $user_id integer The user id.
+	 * @return bool The manual enrollment status.
 	 */
 	private function is_manually_enrolled( $user_id ) {
 		$enrolment_manager         = Sensei_Course_Enrolment_Manager::instance();
@@ -925,11 +925,11 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 		if ( $this->course_id && ! $this->lesson_id ) {
 
-			$menu['learners']            = $this->learners_link( 'all' );
-			$menu['enrolled-learners']   = $this->learners_link( 'enrolled' );
-			$menu['unenrolled-learners'] = $this->learners_link( 'unenrolled' );
+			$menu['learners']                   = $this->learners_link( 'all' );
+			$menu['enrolled-learners']          = $this->learners_link( 'enrolled' );
+			$menu['unenrolled-learners']        = $this->learners_link( 'unenrolled' );
 			$menu['manually-enrolled-learners'] = $this->learners_link( 'manual' );
-			$menu['lessons']             = $this->lessons_link();
+			$menu['lessons']                    = $this->lessons_link();
 
 		} elseif ( $this->course_id && $this->lesson_id ) {
 


### PR DESCRIPTION
Depends and built on #2981

#### Changes proposed in this Pull Request:

* Add 'Manually enrolled' filter for a course's learner list in Learner Management. 

This is the brute force approach, going through enrolled users and checking if enrollment is provided by `Sensei_Course_Manual_Enrolment_Provider`. It's an extra user_meta query per enrolled user on the course.  

In local manual testing, speed is reasonable with 1000 users, about 20% slower than the unfiltered page. (Which itself slows down by about 150% at this point.)
Might not scale well with a much larger number of users. 

Other solutions that came up were adding an extra meta tag that would be query-able, or trying to get the data from the current one via some regexp or text-based query. 

Since this is a pretty situational feature, this might be good enough? There is not much to reasonably do with the results with a huge number of learners listed anyway. 

#### Testing instructions:

* Have a course with learners from multiple providers.
* Open Learner Management > [Course]
* Select *Manually Enrolled Learners*
* List should be filtered
* Pagination and total number should be accurate
