### PR TITLE
Split scheduler to seperate classes for easier testing

### DIFF
--- a/includes/background-jobs/class-sensei-background-job-interface.php
+++ b/includes/background-jobs/class-sensei-background-job-interface.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the interface Sensei_Enrolment_Job_Interface.
+ * File containing the interface Sensei_Background_Job_Interface.
  *
  * @package sensei
  */
@@ -12,21 +12,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Interface for async jobs.
  */
-interface Sensei_Enrolment_Job_Interface {
+interface Sensei_Background_Job_Interface {
 	/**
 	 * Get the action name for the scheduled job.
 	 *
 	 * @return string
 	 */
-	public static function get_name();
+	public function get_name();
 
 	/**
-	 * Run the job and return `true` if the job should be immediately rescheduled (for another batch) or `false`
-	 * if the job can be considered complete.
+	 * Run the job.
+	 */
+	public function run();
+
+	/**
+	 * After the job runs, check to see if it needs to be re-queued for the next batch.
 	 *
 	 * @return bool
 	 */
-	public function run();
+	public function is_complete();
 
 	/**
 	 * Get the arguments to run with the job.

--- a/includes/background-jobs/class-sensei-scheduler-action-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler-action-scheduler.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 3.0.0
  */
 class Sensei_Scheduler_Action_Scheduler implements Sensei_Scheduler_Interface {
-	const ACTION_SCHEDULER_GROUP = 'sensei-enrolment';
+	const ACTION_SCHEDULER_GROUP = 'sensei-lms';
 
 	/**
 	 * Currently running job.

--- a/includes/background-jobs/class-sensei-scheduler-action-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler-action-scheduler.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * This file contains Sensei_Scheduler_Action_Scheduler class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Implementation of Sensei's scheduler using Action Scheduler.
+ *
+ * @since 3.0.0
+ */
+class Sensei_Scheduler_Action_Scheduler implements Sensei_Scheduler_Interface {
+	const ACTION_SCHEDULER_GROUP = 'sensei-enrolment';
+
+	/**
+	 * Schedule a job to run.
+	 *
+	 * @param Sensei_Background_Job_Interface $job  Job object.
+	 * @param int|null                        $time Time when the job should run. Defaults to now.
+	 *
+	 * @return mixed
+	 */
+	public function schedule_job( Sensei_Background_Job_Interface $job, $time = null ) {
+		if ( null === $time ) {
+			$time = time();
+		}
+
+		$next_scheduled_action = as_next_scheduled_action( $job->get_name(), [ $job->get_args() ], self::ACTION_SCHEDULER_GROUP );
+
+		if ( ! $next_scheduled_action ) {
+			as_schedule_recurring_action( $time, 0, $job->get_name(), [ $job->get_args() ], self::ACTION_SCHEDULER_GROUP );
+		}
+	}
+
+	/**
+	 * Handle running a job and handling its completion lifecycle event.
+	 *
+	 * @param Sensei_Background_Job_Interface $job                 Job object.
+	 * @param callable|null                   $completion_callback Callback to call when job is complete.
+	 */
+	public function run( Sensei_Background_Job_Interface $job, $completion_callback = null ) {
+		$job->run();
+
+		if ( $job->is_complete() ) {
+			$this->cancel_scheduled_job( $job );
+
+			if ( is_callable( $completion_callback ) ) {
+				call_user_func( $completion_callback );
+			}
+		}
+	}
+
+	/**
+	 * Cancel a scheduled job.
+	 *
+	 * @param Sensei_Background_Job_Interface $job Job to schedule.
+	 */
+	public function cancel_scheduled_job( Sensei_Background_Job_Interface $job ) {
+		as_unschedule_all_actions( $job->get_name(), [ $job->get_args() ], self::ACTION_SCHEDULER_GROUP );
+	}
+
+	/**
+	 * Cancel all jobs.
+	 */
+	public function cancel_all_jobs() {
+		as_unschedule_all_actions( null, null, self::ACTION_SCHEDULER_GROUP );
+	}
+}

--- a/includes/background-jobs/class-sensei-scheduler-action-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler-action-scheduler.php
@@ -33,6 +33,7 @@ class Sensei_Scheduler_Action_Scheduler implements Sensei_Scheduler_Interface {
 		$next_scheduled_action = as_next_scheduled_action( $job->get_name(), [ $job->get_args() ], self::ACTION_SCHEDULER_GROUP );
 
 		if ( ! $next_scheduled_action ) {
+			// Schedule a recurring task that will be cancelled when a job is marked as complete.
 			as_schedule_recurring_action( $time, 0, $job->get_name(), [ $job->get_args() ], self::ACTION_SCHEDULER_GROUP );
 		}
 	}

--- a/includes/background-jobs/class-sensei-scheduler-action-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler-action-scheduler.php
@@ -34,7 +34,7 @@ class Sensei_Scheduler_Action_Scheduler implements Sensei_Scheduler_Interface {
 
 		if ( ! $next_scheduled_action ) {
 			// Schedule a recurring task that will be cancelled when a job is marked as complete.
-			as_schedule_recurring_action( $time, 0, $job->get_name(), [ $job->get_args() ], self::ACTION_SCHEDULER_GROUP );
+			as_schedule_recurring_action( $time, 1, $job->get_name(), [ $job->get_args() ], self::ACTION_SCHEDULER_GROUP );
 		}
 	}
 

--- a/includes/background-jobs/class-sensei-scheduler-interface.php
+++ b/includes/background-jobs/class-sensei-scheduler-interface.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * This file contains Sensei_Scheduler_Interface interface.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Defines what a scheduler class should handle.
+ *
+ * @since 3.0.0
+ */
+interface Sensei_Scheduler_Interface {
+	/**
+	 * Schedule a job to run.
+	 *
+	 * @param Sensei_Background_Job_Interface $job  Job object.
+	 * @param int|null                        $time Time when the job should run. Defaults to now.
+	 *
+	 * @return mixed
+	 */
+	public function schedule_job( Sensei_Background_Job_Interface $job, $time = null );
+
+	/**
+	 * Handle running a job and handling its completion lifecycle event.
+	 *
+	 * @param Sensei_Background_Job_Interface $job                 Job object.
+	 * @param callable|null                   $completion_callback Callback to call when job is complete.
+	 */
+	public function run( Sensei_Background_Job_Interface $job, $completion_callback = null );
+
+	/**
+	 * Cancel a scheduled job.
+	 *
+	 * @param Sensei_Background_Job_Interface $job Job to schedule.
+	 */
+	public function cancel_scheduled_job( Sensei_Background_Job_Interface $job );
+
+	/**
+	 * Cancel all jobs.
+	 */
+	public function cancel_all_jobs();
+}

--- a/includes/background-jobs/class-sensei-scheduler-wp-cron.php
+++ b/includes/background-jobs/class-sensei-scheduler-wp-cron.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * This file contains Sensei_Scheduler_WP_Cron class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Implementation of Sensei's scheduler using WP Cron.
+ *
+ * @since 3.0.0
+ */
+class Sensei_Scheduler_WP_Cron implements Sensei_Scheduler_Interface {
+	/**
+	 * Schedule a job to run.
+	 *
+	 * @param Sensei_Background_Job_Interface $job  Job object.
+	 * @param int|null                        $time Time when the job should run. Defaults to now.
+	 *
+	 * @return mixed
+	 */
+	public function schedule_job( Sensei_Background_Job_Interface $job, $time = null ) {
+		if ( null === $time ) {
+			$time = time();
+		}
+
+		if ( ! wp_next_scheduled( $job->get_name(), [ $job->get_args() ] ) ) {
+			wp_schedule_single_event( $time, $job->get_name(), [ $job->get_args() ] );
+		}
+	}
+
+	/**
+	 * Handle running a job and handling its completion lifecycle event.
+	 *
+	 * @param Sensei_Background_Job_Interface $job                 Job object.
+	 * @param callable|null                   $completion_callback Callback to call when job is complete.
+	 */
+	public function run( Sensei_Background_Job_Interface $job, $completion_callback = null ) {
+		$this->schedule_job( $job );
+		$job->run();
+
+		if ( $job->is_complete() ) {
+			$this->cancel_scheduled_job( $job );
+
+			if ( is_callable( $completion_callback ) ) {
+				call_user_func( $completion_callback );
+			}
+		}
+	}
+
+	/**
+	 * Cancel a scheduled job.
+	 *
+	 * @param Sensei_Background_Job_Interface $job Job to schedule.
+	 */
+	public function cancel_scheduled_job( Sensei_Background_Job_Interface $job ) {
+		wp_clear_scheduled_hook( $job->get_name(), [ $job->get_args() ] );
+	}
+
+	/**
+	 * Cancel all jobs.
+	 */
+	public function cancel_all_jobs() {
+		$actions = apply_filters( 'sensei_background_job_actions', [] );
+		foreach ( $actions as $action_name ) {
+			wp_unschedule_hook( $action_name );
+		}
+	}
+}

--- a/includes/background-jobs/class-sensei-scheduler-wp-cron.php
+++ b/includes/background-jobs/class-sensei-scheduler-wp-cron.php
@@ -65,6 +65,13 @@ class Sensei_Scheduler_WP_Cron implements Sensei_Scheduler_Interface {
 	 * Cancel all jobs.
 	 */
 	public function cancel_all_jobs() {
+		/**
+		 * Get a list of background job actions that are handled by this class.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param array $actions Scheduled actions that are handled by this class.
+		 */
 		$actions = apply_filters( 'sensei_background_job_actions', [] );
 		foreach ( $actions as $action_name ) {
 			wp_unschedule_hook( $action_name );

--- a/includes/background-jobs/class-sensei-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler.php
@@ -69,8 +69,8 @@ class Sensei_Scheduler {
 	 */
 	private static function is_action_scheduler_available() {
 		return class_exists( 'ActionScheduler_Versions' )
-			 	&& function_exists( 'as_unschedule_all_actions' )
-			 	&& function_exists( 'as_next_scheduled_action' )
-			 	&& function_exists( 'as_schedule_single_action' );
+				&& function_exists( 'as_unschedule_all_actions' )
+				&& function_exists( 'as_next_scheduled_action' )
+				&& function_exists( 'as_schedule_single_action' );
 	}
 }

--- a/includes/background-jobs/class-sensei-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler.php
@@ -52,6 +52,13 @@ class Sensei_Scheduler {
 			$default_class_name = Sensei_Scheduler_Action_Scheduler::class;
 		}
 
+		/**
+		 * Override the default class that implements `Sensei_Scheduler_Interface`.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param string $class_name Class for the scheduler that should be used by Sensei.
+		 */
 		$class_name = apply_filters( 'sensei_scheduler_class', $default_class_name );
 		if ( ! is_subclass_of( $class_name, Sensei_Scheduler_Interface::class, true ) ) {
 			_doing_it_wrong( __METHOD__, 'The filter "sensei_scheduler_class" returned an invalid scheduler.', '3.0.0' );

--- a/includes/background-jobs/class-sensei-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler.php
@@ -78,6 +78,6 @@ class Sensei_Scheduler {
 		return class_exists( 'ActionScheduler_Versions' )
 				&& function_exists( 'as_unschedule_all_actions' )
 				&& function_exists( 'as_next_scheduled_action' )
-				&& function_exists( 'as_schedule_recurring_action' );
+				&& function_exists( 'as_schedule_single_action' );
 	}
 }

--- a/includes/background-jobs/class-sensei-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * This file contains Sensei_Scheduler class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Fetch the correct scheduler.
+ *
+ * @since 3.0.0
+ */
+class Sensei_Scheduler {
+	/**
+	 * Instance of the current handler.
+	 *
+	 * @var Sensei_Background_Job_Interface
+	 */
+	private static $instance;
+
+	/**
+	 * Get the instance of the Scheduler to use.
+	 *
+	 * @return Sensei_Scheduler_Interface
+	 */
+	public static function instance() {
+		if ( ! isset( self::$instance ) ) {
+			$class_name     = self::get_class();
+			self::$instance = new $class_name();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Get the class for the scheduler.
+	 */
+	private static function get_class() {
+		if ( 0 === did_action( 'plugins_loaded' ) ) {
+			_doing_it_wrong( __METHOD__, 'Scheduler should not be used until after the plugins are loaded.', '3.0.0' );
+		}
+
+		$default_class_name = Sensei_Scheduler_WP_Cron::class;
+
+		if ( self::is_action_scheduler_available() ) {
+			$default_class_name = Sensei_Scheduler_Action_Scheduler::class;
+		}
+
+		$class_name = apply_filters( 'sensei_scheduler_class', $default_class_name );
+		if ( ! is_subclass_of( $class_name, Sensei_Scheduler_Interface::class, true ) ) {
+			_doing_it_wrong( __METHOD__, 'The filter "sensei_scheduler_class" returned an invalid scheduler.', '3.0.0' );
+
+			$class_name = $default_class_name;
+		}
+
+		return $class_name;
+	}
+
+	/**
+	 * Check to see if Action Scheduler is available.
+	 *
+	 * @return bool
+	 */
+	private static function is_action_scheduler_available() {
+		return class_exists( 'ActionScheduler_Versions' )
+			 	&& function_exists( 'as_unschedule_all_actions' )
+			 	&& function_exists( 'as_next_scheduled_action' )
+			 	&& function_exists( 'as_schedule_single_action' );
+	}
+}

--- a/includes/background-jobs/class-sensei-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler.php
@@ -71,6 +71,6 @@ class Sensei_Scheduler {
 		return class_exists( 'ActionScheduler_Versions' )
 				&& function_exists( 'as_unschedule_all_actions' )
 				&& function_exists( 'as_next_scheduled_action' )
-				&& function_exists( 'as_schedule_single_action' );
+				&& function_exists( 'as_schedule_recurring_action' );
 	}
 }

--- a/includes/background-jobs/class-sensei-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler.php
@@ -18,7 +18,7 @@ class Sensei_Scheduler {
 	/**
 	 * Instance of the current handler.
 	 *
-	 * @var Sensei_Background_Job_Interface
+	 * @var Sensei_Scheduler_Interface
 	 */
 	private static $instance;
 
@@ -38,6 +38,8 @@ class Sensei_Scheduler {
 
 	/**
 	 * Get the class for the scheduler.
+	 *
+	 * @return string
 	 */
 	private static function get_class() {
 		if ( 0 === did_action( 'plugins_loaded' ) ) {

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -92,6 +92,7 @@ class Sensei_Autoloader {
 			new Sensei_Autoloader_Bundle( 'rest-api' ),
 			new Sensei_Autoloader_Bundle( 'domain-models' ),
 			new Sensei_Autoloader_Bundle( '' ),
+			new Sensei_Autoloader_Bundle( 'background-jobs' ),
 			new Sensei_Autoloader_Bundle( 'enrolment' ),
 		);
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -562,9 +562,8 @@ class Sensei_Main {
 	 */
 	public function deactivation() {
 		$this->usage_tracking->unschedule_tracking_task();
-		$this->enrolment_scheduler->stop_all_jobs();
+		Sensei_Scheduler::instance()->cancel_all_jobs();
 	}
-
 
 	/**
 	 * Register activation hooks.

--- a/includes/enrolment/class-sensei-enrolment-job-scheduler.php
+++ b/includes/enrolment/class-sensei-enrolment-job-scheduler.php
@@ -126,6 +126,10 @@ class Sensei_Enrolment_Job_Scheduler {
 
 	/**
 	 * Returns all the background jobs this class is responsible for. Used for cancelling in WP Cron.
+	 *
+	 * @param string[] $jobs List of job action names.
+	 *
+	 * @return string[]
 	 */
 	public function get_background_jobs( $jobs ) {
 		$jobs[] = Sensei_Enrolment_Learner_Calculation_Job::NAME;

--- a/includes/enrolment/class-sensei-enrolment-job-scheduler.php
+++ b/includes/enrolment/class-sensei-enrolment-job-scheduler.php
@@ -128,8 +128,8 @@ class Sensei_Enrolment_Job_Scheduler {
 	 * Returns all the background jobs this class is responsible for. Used for cancelling in WP Cron.
 	 */
 	public function get_background_jobs( $jobs ) {
-		$jobs[] = Sensei_Enrolment_Learner_Calculation_Job::get_name();
-		$jobs[] = Sensei_Enrolment_Course_Calculation_Job::get_name();
+		$jobs[] = Sensei_Enrolment_Learner_Calculation_Job::NAME;
+		$jobs[] = Sensei_Enrolment_Course_Calculation_Job::NAME;
 
 		return $jobs;
 	}

--- a/includes/enrolment/class-sensei-enrolment-job-scheduler.php
+++ b/includes/enrolment/class-sensei-enrolment-job-scheduler.php
@@ -155,7 +155,12 @@ class Sensei_Enrolment_Job_Scheduler {
 		$args       = [ $job->get_args() ];
 
 		if ( $this->is_action_scheduler_available() ) {
-			if ( ! as_next_scheduled_action( $name, $args, self::ACTION_SCHEDULER_GROUP ) ) {
+			$next_scheduled_action = as_next_scheduled_action( $name, $args, self::ACTION_SCHEDULER_GROUP );
+
+			if (
+				! $next_scheduled_action // Not scheduled.
+				|| true === $next_scheduled_action // Currently running.
+			) {
 				as_schedule_single_action( time(), $name, $args, self::ACTION_SCHEDULER_GROUP );
 			}
 		} else {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -54,6 +54,9 @@
 	</rule>
 	<!-- End of Temporary Rule Exclusions -->
 
+	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
+		<exclude-pattern>tests/framework/actionscheduler-mocks.php</exclude-pattern>
+	</rule>
 	<rule ref="WordPress.WP.I18n">
 		<properties>
 			<property name="text_domain" type="array" value="sensei-lms" />

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -54,13 +54,18 @@ class Sensei_Unit_Tests_Bootstrap {
 		// Testing setup for scheduler.
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/class-sensei-scheduler-shim.php';
 
-		tests_add_filter(
-			'sensei_scheduler_class',
-			function () {
-				return Sensei_Scheduler_Shim::class;
-			}
-		);
+		tests_add_filter( 'sensei_scheduler_class', [ __CLASS__, 'use_scheduler_shim' ] );
 	}
+
+	/**
+	 * Use the scheduler shim.
+	 *
+	 * @return string
+	 */
+	public static function use_scheduler_shim() {
+		return Sensei_Scheduler_Shim::class;
+	}
+
 	/**
 	 * Install Sensei after the test environment and Sensei have been loaded.
 	 *
@@ -80,6 +85,8 @@ class Sensei_Unit_Tests_Bootstrap {
 		// factories
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-manual-test-helpers.php';
+		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-scheduler-test-helpers.php';
+		require_once SENSEI_TEST_FRAMEWORK_DIR . '/class-sensei-background-job-stub.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/factories/class-sensei-factory.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/factories/class-wp-unittest-factory-for-post-sensei.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,6 +39,7 @@ class Sensei_Unit_Tests_Bootstrap {
 
 		// load the WP testing environment
 		require_once $this->wp_tests_dir . '/includes/bootstrap.php';
+
 		// load Sensei testing framework
 		$this->includes();
 	}
@@ -49,6 +50,16 @@ class Sensei_Unit_Tests_Bootstrap {
 	 */
 	public function load_sensei() {
 		require_once $this->plugin_dir . '/sensei-lms.php';
+
+		// Testing setup for scheduler.
+		require_once SENSEI_TEST_FRAMEWORK_DIR . '/class-sensei-scheduler-shim.php';
+
+		tests_add_filter(
+			'sensei_scheduler_class',
+			function () {
+				return Sensei_Scheduler_Shim::class;
+			}
+		);
 	}
 	/**
 	 * Install Sensei after the test environment and Sensei have been loaded.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -54,15 +54,15 @@ class Sensei_Unit_Tests_Bootstrap {
 		// Testing setup for scheduler.
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/class-sensei-scheduler-shim.php';
 
-		tests_add_filter( 'sensei_scheduler_class', [ __CLASS__, 'use_scheduler_shim' ] );
+		add_filter( 'sensei_scheduler_class', [ __CLASS__, 'scheduler_use_shim' ] );
 	}
 
 	/**
-	 * Use the scheduler shim.
+	 * Scheduler: Use shim.
 	 *
 	 * @return string
 	 */
-	public static function use_scheduler_shim() {
+	public static function scheduler_use_shim() {
 		return Sensei_Scheduler_Shim::class;
 	}
 

--- a/tests/framework/actionscheduler-mocks.php
+++ b/tests/framework/actionscheduler-mocks.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * File that adds mocks for action scheduler functions.
+ *
+ * @package sensei-tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$GLOBALS['scheduled_actions']       = [];
+$GLOBALS['scheduled_actions_calls'] = [];
+
+class ActionScheduler_Versions {}
+
+function _as_reset() {
+	$GLOBALS['scheduled_actions']       = [];
+	$GLOBALS['scheduled_actions_calls'] = [];
+}
+
+function _as_add_call( $function ) {
+	if ( ! isset( $GLOBALS['scheduled_actions_calls'][ $function ] ) ) {
+		$GLOBALS['scheduled_actions_calls'][ $function ] = 0;
+	}
+
+	$GLOBALS['scheduled_actions_calls'][ $function ]++;
+}
+
+function _as_call_count( $function ) {
+	if ( ! isset( $GLOBALS['scheduled_actions_calls'][ $function ] ) ) {
+		$GLOBALS['scheduled_actions_calls'][ $function ] = 0;
+	}
+
+	return $GLOBALS['scheduled_actions_calls'][ $function ];
+}
+
+function _as_match_action( $action, $query ) {
+	if ( ! empty( $query['hook'] ) && $query['hook'] !== $action['hook'] ) {
+		return false;
+	}
+
+	if ( isset( $query['args'] ) && $query['args'] !== $action['args'] ) {
+		return false;
+	}
+
+	if ( ! empty( $query['group'] ) && $query['group'] !== $action['group'] ) {
+		return false;
+	}
+
+	return true;
+}
+
+function _as_get_scheduled_actions( $hook, $args = null, $group = '' ) {
+	$matches = [];
+	$query   = compact( 'hook', 'args', 'group' );
+
+	foreach ( $GLOBALS['scheduled_actions'] as $action ) {
+		if ( _as_match_action( $action, $query ) ) {
+			$matches[] = $action;
+		}
+	}
+
+	return $matches;
+}
+
+function as_unschedule_all_actions( $hook, $args = null, $group = '' ) {
+	_as_add_call( __FUNCTION__ );
+
+	$query = compact( 'hook', 'args', 'group' );
+
+	foreach ( $GLOBALS['scheduled_actions'] as $index => $action ) {
+		if ( _as_match_action( $action, $query ) ) {
+			unset( $GLOBALS['scheduled_actions'][ $index ] );
+		}
+	}
+
+	return true;
+}
+
+function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
+	_as_add_call( __FUNCTION__ );
+
+	$query = compact( 'hook', 'args', 'group' );
+
+	foreach ( $GLOBALS['scheduled_actions'] as $action ) {
+		if ( _as_match_action( $action, $query ) ) {
+			return $action['time'];
+		}
+	}
+
+	return false;
+}
+
+function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
+	_as_add_call( __FUNCTION__ );
+
+	$GLOBALS['scheduled_actions'][] = [
+		'time'     => $timestamp,
+		'interval' => $interval_in_seconds,
+		'hook'     => $hook,
+		'args'     => $args,
+		'group'    => $group,
+	];
+
+	return true;
+}

--- a/tests/framework/actionscheduler-mocks.php
+++ b/tests/framework/actionscheduler-mocks.php
@@ -96,15 +96,14 @@ function as_next_scheduled_action( $hook, $args = null, $group = '' ) {
 	return false;
 }
 
-function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
+function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
 	_as_add_call( __FUNCTION__ );
 
 	$GLOBALS['scheduled_actions'][] = [
-		'time'     => $timestamp,
-		'interval' => $interval_in_seconds,
-		'hook'     => $hook,
-		'args'     => $args,
-		'group'    => $group,
+		'time'  => $timestamp,
+		'hook'  => $hook,
+		'args'  => $args,
+		'group' => $group,
 	];
 
 	return true;

--- a/tests/framework/actionscheduler-mocks.php
+++ b/tests/framework/actionscheduler-mocks.php
@@ -1,4 +1,8 @@
 <?php
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound
+
 /**
  * File that adds mocks for action scheduler functions.
  *
@@ -78,7 +82,7 @@ function as_unschedule_all_actions( $hook, $args = null, $group = '' ) {
 	return true;
 }
 
-function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
+function as_next_scheduled_action( $hook, $args = null, $group = '' ) {
 	_as_add_call( __FUNCTION__ );
 
 	$query = compact( 'hook', 'args', 'group' );

--- a/tests/framework/class-sensei-background-job-stub.php
+++ b/tests/framework/class-sensei-background-job-stub.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Stub implementing Sensei_Job.
+ *
+ * @package sensei-tests
+ */
+
+/**
+ * Stub to help test the background job scheduler.
+ *
+ * @since 3.0.0
+ */
+class Sensei_Background_Job_Stub implements Sensei_Background_Job_Interface {
+	/**
+	 * Name of job.
+	 *
+	 * @var string
+	 */
+	const NAME = 'test-job';
+
+	/**
+	 * Args of job.
+	 *
+	 * @var array
+	 */
+	public $args = [];
+
+	/**
+	 * Is Complete flag.
+	 *
+	 * @var bool
+	 */
+	public $is_complete = false;
+
+	/**
+	 * Turns true if it runs.
+	 *
+	 * @var bool
+	 */
+	public $did_run = false;
+
+	/**
+	 * Callable to run.
+	 *
+	 * @var callable
+	 */
+	public $run_callback;
+
+	public function get_name() {
+		return self::NAME;
+	}
+
+	public function run() {
+		$this->did_run = true;
+
+		if ( is_callable( $this->run_callback ) ) {
+			call_user_func( $this->run_callback, $this );
+		}
+	}
+
+	public function is_complete() {
+		return $this->is_complete;
+	}
+
+	public function get_args() {
+		return $this->args;
+	}
+
+}

--- a/tests/framework/class-sensei-scheduler-shim.php
+++ b/tests/framework/class-sensei-scheduler-shim.php
@@ -15,8 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 3.0.0
  */
 class Sensei_Scheduler_Shim implements Sensei_Scheduler_Interface {
-	static $scheduled_jobs = [];
-	static $action_count   = [];
+	private static $scheduled_jobs = [];
+	private static $action_count   = [];
 
 	/**
 	 * Reset the shim.
@@ -128,7 +128,7 @@ class Sensei_Scheduler_Shim implements Sensei_Scheduler_Interface {
 			wp_json_encode(
 				[
 					$job->get_name(),
-					$job->get_args()
+					$job->get_args(),
 				]
 			)
 		);

--- a/tests/framework/class-sensei-scheduler-shim.php
+++ b/tests/framework/class-sensei-scheduler-shim.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * File with class for testing scheduled background jobs.
+ *
+ * @package sensei-tests
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Used for testing scheduled jobs.
+ *
+ * @since 3.0.0
+ */
+class Sensei_Scheduler_Shim implements Sensei_Scheduler_Interface {
+	static $scheduled_jobs = [];
+	static $action_count   = [];
+
+	/**
+	 * Reset the shim.
+	 */
+	public static function reset() {
+		self::$action_count   = [];
+		self::$scheduled_jobs = [];
+	}
+
+	/**
+	 * Get the next scheduled event.
+	 *
+	 * @param Sensei_Background_Job_Interface $job Job object.
+	 *
+	 * @return int|false
+	 */
+	public static function get_next_scheduled( Sensei_Background_Job_Interface $job ) {
+		$job_hash = self::get_job_hash( $job );
+		if ( empty( self::$scheduled_jobs[ $job_hash ] ) ) {
+			return false;
+		}
+
+		return self::$scheduled_jobs[ $job_hash ];
+	}
+
+	/**
+	 * Get the number of times the event has been scheduled.
+	 *
+	 * @param string $action Action name.
+	 *
+	 * @return int
+	 */
+	public static function get_scheduled_action_count( $action ) {
+		if ( empty( self::$action_count[ $action ] ) ) {
+			return 0;
+		}
+
+		return self::$action_count[ $action ];
+	}
+
+	/**
+	 * Schedule a job to run.
+	 *
+	 * @param Sensei_Background_Job_Interface $job  Job object.
+	 * @param int|null                        $time Time when the job should run. Defaults to now.
+	 *
+	 * @return mixed
+	 */
+	public function schedule_job( Sensei_Background_Job_Interface $job, $time = null ) {
+		if ( null === $time ) {
+			$time = time();
+		}
+
+		$job_hash = self::get_job_hash( $job );
+		if ( ! isset( self::$scheduled_jobs[ $job_hash ] ) ) {
+			self::$scheduled_jobs[ $job_hash ] = $time;
+
+			if ( ! isset( self::$action_count[ $job->get_name() ] ) ) {
+				self::$action_count[ $job->get_name() ] = 0;
+			}
+			self::$action_count[ $job->get_name() ]++;
+		}
+	}
+
+	/**
+	 * Handle running a job and handling its completion lifecycle event.
+	 *
+	 * @param Sensei_Background_Job_Interface $job                 Job object.
+	 * @param callable|null                   $completion_callback Callback to call when job is complete.
+	 */
+	public function run( Sensei_Background_Job_Interface $job, $completion_callback = null ) {
+		$job->run();
+
+		if ( $job->is_complete() ) {
+			$this->cancel_scheduled_job( $job );
+
+			if ( is_callable( $completion_callback ) ) {
+				call_user_func( $completion_callback );
+			}
+		}
+	}
+
+	/**
+	 * Cancel a scheduled job.
+	 *
+	 * @param Sensei_Background_Job_Interface $job Job to schedule.
+	 */
+	public function cancel_scheduled_job( Sensei_Background_Job_Interface $job ) {
+		$job_hash = self::get_job_hash( $job );
+		unset( self::$scheduled_jobs[ $job_hash ] );
+	}
+
+	/**
+	 * Cancel all jobs.
+	 */
+	public function cancel_all_jobs() {
+		self::$scheduled_jobs = [];
+	}
+
+	/**
+	 * Get a hash representation of the job.
+	 *
+	 * @param Sensei_Background_Job_Interface $job Job object
+	 *
+	 * @return string
+	 */
+	private static function get_job_hash( Sensei_Background_Job_Interface $job ) {
+		return md5(
+			wp_json_encode(
+				[
+					$job->get_name(),
+					$job->get_args()
+				]
+			)
+		);
+	}
+}

--- a/tests/framework/trait-sensei-scheduler-test-helpers.php
+++ b/tests/framework/trait-sensei-scheduler-test-helpers.php
@@ -20,10 +20,10 @@ trait Sensei_Scheduler_Test_Helpers {
 	/**
 	 * Restore the scheduler's shim.
 	 */
-	private static function restoreScheduler() {
+	private static function restoreShimScheduler() {
 		self::resetScheduler();
 
-		tests_add_filter( 'sensei_scheduler_class', [ __CLASS__, 'use_scheduler_shim' ] );
+		add_filter( 'sensei_scheduler_class', [ 'Sensei_Unit_Tests_Bootstrap', 'scheduler_use_shim' ] );
 	}
 
 	/**
@@ -35,5 +35,23 @@ trait Sensei_Scheduler_Test_Helpers {
 		$scheduler_instance->setValue( null );
 
 		remove_all_filters( 'sensei_scheduler_class' );
+	}
+
+	/**
+	 * Scheduler: Use WP Cron.
+	 *
+	 * @return string
+	 */
+	public static function scheduler_use_wp_cron() {
+		return Sensei_Scheduler_WP_Cron::class;
+	}
+
+	/**
+	 * Scheduler: Use Action Scheduler.
+	 *
+	 * @return string
+	 */
+	public static function scheduler_use_action_scheduler() {
+		return Sensei_Scheduler_Action_Scheduler::class;
 	}
 }

--- a/tests/framework/trait-sensei-scheduler-test-helpers.php
+++ b/tests/framework/trait-sensei-scheduler-test-helpers.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * File with trait Sensei_Scheduler_Test_Helpers.
+ *
+ * @package sensei-tests
+ */
+
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Using PHPUnit conventions.
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Helpers for scheduler related tests.
+ *
+ * @since 3.0.0
+ */
+trait Sensei_Scheduler_Test_Helpers {
+	/**
+	 * Restore the scheduler's shim.
+	 */
+	private static function restoreScheduler() {
+		self::resetScheduler();
+
+		tests_add_filter( 'sensei_scheduler_class', [ __CLASS__, 'use_scheduler_shim' ] );
+	}
+
+	/**
+	 * Reset the scheduler's instance.
+	 */
+	private static function resetScheduler() {
+		$scheduler_instance = new ReflectionProperty( Sensei_Scheduler::class, 'instance' );
+		$scheduler_instance->setAccessible( true );
+		$scheduler_instance->setValue( null );
+
+		remove_all_filters( 'sensei_scheduler_class' );
+	}
+}

--- a/tests/unit-tests/background-jobs/test-class-sensei-scheduler-action-scheduler.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-scheduler-action-scheduler.php
@@ -1,0 +1,132 @@
+<?php
+/**
+ * This file contains the Sensei_Scheduler_Action_Scheduler_Test class.
+ *
+ * @package sensei
+ */
+
+/**
+ * Tests for Sensei_Scheduler_Action_Scheduler class.
+ *
+ * @group background-jobs
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class Sensei_Scheduler_Action_Scheduler_Test extends WP_UnitTestCase {
+	use Sensei_Scheduler_Test_Helpers;
+
+	/**
+	 * Tear down the test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		_as_reset();
+	}
+
+	/**
+	 * Set up before all tests.
+	 */
+	public static function setUpBeforeClass() {
+		self::createMocks();
+		self::resetScheduler();
+
+		return parent::setUpBeforeClass();
+	}
+
+	/**
+	 * Tear down after all tests.
+	 */
+	public static function tearDownAfterClass() {
+		self::restoreScheduler();
+
+		return parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Test that with the mocks we are using the Action Scheduler.
+	 */
+	public function testInstance() {
+		$this->assertTrue( Sensei_Scheduler::instance() instanceof Sensei_Scheduler_Action_Scheduler, 'With the mocks, we should be using the action scheduler handler.' );
+	}
+
+	/**
+	 * Test scheduling a job results in a single entry.
+	 */
+	public function testScheduleJob() {
+		$job       = new Sensei_Background_Job_Stub();
+		$scheduler = Sensei_Scheduler::instance();
+
+		$scheduler->schedule_job( $job );
+		$scheduler->schedule_job( $job );
+
+		$result = _as_get_scheduled_actions( $job->get_name(), [ $job->get_args() ], null );
+		$this->assertEquals( 1, count( $result ) );
+	}
+
+	/**
+	 * Tests to make sure it is queued when not complete and not queued when complete.
+	 */
+	public function testRunNotQueuedWhenComplete() {
+		$job       = new Sensei_Background_Job_Stub();
+		$scheduler = Sensei_Scheduler::instance();
+
+		$scheduler->schedule_job( $job );
+		$scheduler->run( $job );
+
+		$this->assertTrue( $job->did_run );
+
+		$result = _as_get_scheduled_actions( $job->get_name(), [ $job->get_args() ], null );
+		$this->assertEquals( 1, count( $result ), 'The job should still be queued as it is not complete' );
+
+		$job->is_complete = true;
+		$scheduler->run( $job );
+
+		$result = _as_get_scheduled_actions( $job->get_name(), [ $job->get_args() ], null );
+		$this->assertEquals( 0, count( $result ), 'The job should no longer be queued' );
+	}
+
+	/**
+	 * Tests to make sure it calls callback when complete.
+	 */
+	public function testRunCallsCallback() {
+		$job       = new Sensei_Background_Job_Stub();
+		$scheduler = Sensei_Scheduler::instance();
+
+		$did_run_callback = false;
+		$callback         = function() use ( &$did_run_callback ) {
+			$did_run_callback = true;
+		};
+
+		$scheduler->run( $job, $callback );
+
+		$this->assertFalse( $did_run_callback, 'Callback should not be called when not complete' );
+
+		$job->is_complete = true;
+		$scheduler->run( $job, $callback );
+		$this->assertTrue( $did_run_callback, 'Callback should be called when complete' );
+	}
+
+	/**
+	 * Tests jobs can be cancelled.
+	 */
+	public function testCancelScheduledJob() {
+		$job       = new Sensei_Background_Job_Stub();
+		$scheduler = Sensei_Scheduler::instance();
+
+		$scheduler->schedule_job( $job );
+
+		$result = _as_get_scheduled_actions( $job->get_name(), [ $job->get_args() ], null );
+		$this->assertEquals( 1, count( $result ) );
+
+		$result = _as_get_scheduled_actions( $job->get_name(), [ $job->get_args() ], null );
+		$this->assertEquals( 1, count( $result ) );
+	}
+
+	/**
+	 * Set up mocks.
+	 */
+	private static function createMocks() {
+		require_once SENSEI_TEST_FRAMEWORK_DIR . '/actionscheduler-mocks.php';
+	}
+}

--- a/tests/unit-tests/background-jobs/test-class-sensei-scheduler-action-scheduler.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-scheduler-action-scheduler.php
@@ -9,8 +9,6 @@
  * Tests for Sensei_Scheduler_Action_Scheduler class.
  *
  * @group background-jobs
- * @runTestsInSeparateProcesses
- * @preserveGlobalState disabled
  */
 class Sensei_Scheduler_Action_Scheduler_Test extends WP_UnitTestCase {
 	use Sensei_Scheduler_Test_Helpers;
@@ -30,6 +28,7 @@ class Sensei_Scheduler_Action_Scheduler_Test extends WP_UnitTestCase {
 	public static function setUpBeforeClass() {
 		self::createMocks();
 		self::resetScheduler();
+		add_filter( 'sensei_scheduler_class', [ __CLASS__, 'scheduler_use_action_scheduler' ] );
 
 		return parent::setUpBeforeClass();
 	}
@@ -38,7 +37,7 @@ class Sensei_Scheduler_Action_Scheduler_Test extends WP_UnitTestCase {
 	 * Tear down after all tests.
 	 */
 	public static function tearDownAfterClass() {
-		self::restoreScheduler();
+		self::restoreShimScheduler();
 
 		return parent::tearDownAfterClass();
 	}

--- a/tests/unit-tests/background-jobs/test-class-sensei-scheduler-wp-cron.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-scheduler-wp-cron.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * This file contains the Sensei_Scheduler_WP_Cron_Test class.
+ *
+ * @package sensei
+ */
+
+/**
+ * Tests for Sensei_Scheduler_WP_Cron class.
+ *
+ * @group background-jobs
+ */
+class Sensei_Scheduler_WP_Cron_Test extends WP_UnitTestCase {
+	use Sensei_Scheduler_Test_Helpers;
+
+	private static $original_cron;
+
+	/**
+	 * Set up before all tests.
+	 */
+	public static function setUpBeforeClass() {
+		self::resetScheduler();
+
+		self::$original_cron = get_option( 'cron' );
+
+		return parent::setUpBeforeClass();
+	}
+
+	/**
+	 * Tear down after all tests.
+	 */
+	public static function tearDownAfterClass() {
+		self::restoreScheduler();
+
+		update_option( 'cron', self::$original_cron );
+
+		return parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Test that by default it returns the WP Cron scheduler.
+	 */
+	public function testInstance() {
+		$this->assertTrue( Sensei_Scheduler::instance() instanceof Sensei_Scheduler_WP_Cron, 'Make sure we are on the right scheduler.' );
+	}
+
+	/**
+	 * Test scheduling a job results in a single entry.
+	 */
+	public function testScheduleJob() {
+		self::resetCron();
+
+		$job       = new Sensei_Background_Job_Stub();
+		$scheduler = Sensei_Scheduler::instance();
+
+		$cron = _get_cron_array();
+		$this->assertEquals( 0, count( $cron ) );
+
+		$scheduler->schedule_job( $job );
+		$scheduler->schedule_job( $job );
+
+		$cron = _get_cron_array();
+		$this->assertEquals( 1, count( $cron ) );
+	}
+
+	/**
+	 * Tests to make sure it is queued when not complete and not queued when complete.
+	 */
+	public function testRunNotQueuedWhenComplete() {
+		self::resetCron();
+
+		$job       = new Sensei_Background_Job_Stub();
+		$scheduler = Sensei_Scheduler::instance();
+
+		$scheduler->schedule_job( $job );
+		$scheduler->run( $job );
+
+		$this->assertTrue( $job->did_run );
+
+		$cron = _get_cron_array();
+		$this->assertEquals( 1, count( $cron ), 'The job should still be queued as it is not complete' );
+
+		$job->is_complete = true;
+		$scheduler->run( $job );
+
+		$cron = _get_cron_array();
+		$this->assertEquals( 0, count( $cron ), 'The job should no longer be queued' );
+	}
+
+	/**
+	 * Tests to make sure it calls callback when complete.
+	 */
+	public function testRunCallsCallback() {
+		$job       = new Sensei_Background_Job_Stub();
+		$scheduler = Sensei_Scheduler::instance();
+
+		$did_run_callback = false;
+		$callback         = function() use ( &$did_run_callback ) {
+			$did_run_callback = true;
+		};
+
+		$scheduler->run( $job, $callback );
+
+		$this->assertFalse( $did_run_callback, 'Callback should not be called when not complete' );
+
+		$job->is_complete = true;
+		$scheduler->run( $job, $callback );
+		$this->assertTrue( $did_run_callback, 'Callback should be called when complete' );
+	}
+
+	/**
+	 * Tests jobs can be cancelled.
+	 */
+	public function testCancelScheduledJob() {
+		self::resetCron();
+
+		$job       = new Sensei_Background_Job_Stub();
+		$scheduler = Sensei_Scheduler::instance();
+
+		$scheduler->schedule_job( $job );
+
+		$result = _get_cron_array();
+		$this->assertEquals( 1, count( $result ) );
+
+		$result = _get_cron_array();
+		$this->assertEquals( 1, count( $result ) );
+	}
+
+	/**
+	 * Reset the cron jobs.
+	 */
+	private function resetCron() {
+		update_option( 'cron', [] );
+	}
+}

--- a/tests/unit-tests/background-jobs/test-class-sensei-scheduler-wp-cron.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-scheduler-wp-cron.php
@@ -20,6 +20,7 @@ class Sensei_Scheduler_WP_Cron_Test extends WP_UnitTestCase {
 	 */
 	public static function setUpBeforeClass() {
 		self::resetScheduler();
+		add_filter( 'sensei_scheduler_class', [ __CLASS__, 'scheduler_use_wp_cron' ] );
 
 		self::$original_cron = get_option( 'cron' );
 
@@ -30,7 +31,7 @@ class Sensei_Scheduler_WP_Cron_Test extends WP_UnitTestCase {
 	 * Tear down after all tests.
 	 */
 	public static function tearDownAfterClass() {
-		self::restoreScheduler();
+		self::restoreShimScheduler();
 
 		update_option( 'cron', self::$original_cron );
 

--- a/tests/unit-tests/background-jobs/test-class-sensei-scheduler.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-scheduler.php
@@ -20,6 +20,7 @@ class Sensei_Scheduler_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		self::resetScheduler();
+		add_filter( 'sensei_scheduler_class', [ __CLASS__, 'scheduler_use_wp_cron' ] );
 	}
 
 
@@ -27,15 +28,15 @@ class Sensei_Scheduler_Test extends WP_UnitTestCase {
 	 * Clean up after all tests.
 	 */
 	public static function tearDownAfterClass() {
-		parent::tearDownAfterClass();
+		self::restoreShimScheduler();
 
-		self::restoreScheduler();
+		return parent::tearDownAfterClass();
 	}
 
 	/**
 	 * Test that by default it returns the WP Cron scheduler.
 	 */
 	public function testInstance() {
-		$this->assertTrue( Sensei_Scheduler::instance() instanceof Sensei_Scheduler_WP_Cron, 'By default, scheduler should be handled by the WP cron handler' );
+		$this->assertTrue( Sensei_Scheduler::instance() instanceof Sensei_Scheduler_WP_Cron, 'Scheduler should be handled by the WP cron handler when told to do so' );
 	}
 }

--- a/tests/unit-tests/background-jobs/test-class-sensei-scheduler.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-scheduler.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This file contains the Sensei_Scheduler_Test class.
+ *
+ * @package sensei
+ */
+
+/**
+ * Tests for Sensei_Scheduler class.
+ *
+ * @group background-jobs
+ */
+class Sensei_Scheduler_Test extends WP_UnitTestCase {
+	use Sensei_Scheduler_Test_Helpers;
+
+	/**
+	 * Setup function.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		self::resetScheduler();
+	}
+
+
+	/**
+	 * Clean up after all tests.
+	 */
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		self::restoreScheduler();
+	}
+
+	/**
+	 * Test that by default it returns the WP Cron scheduler.
+	 */
+	public function testInstance() {
+		$this->assertTrue( Sensei_Scheduler::instance() instanceof Sensei_Scheduler_WP_Cron, 'By default, scheduler should be handled by the WP cron handler' );
+	}
+}

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -18,6 +18,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$this->factory = new Sensei_Factory();
 
 		self::resetEnrolmentProviders();
+		Sensei_Scheduler_Shim::reset();
 	}
 
 	/**
@@ -27,6 +28,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		parent::tearDown();
 
 		$this->clearEnrolmentCheckDeferred();
+		Sensei_Scheduler_Shim::reset();
 	}
 
 	/**
@@ -278,7 +280,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$course->post_status = 'publish';
 		wp_update_post( $course );
 
-		$this->assertNotEmpty( wp_next_scheduled( Sensei_Enrolment_Course_Calculation_Job::get_name(), [ $job->get_args() ] ), 'Job should have been scheduled' );
+		$this->assertNotFalse( Sensei_Scheduler_Shim::get_next_scheduled( $job ), 'Job should have been scheduled' );
 	}
 
 	/**
@@ -295,7 +297,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$course->post_status = 'draft';
 		wp_update_post( $course );
 
-		$this->assertNotEmpty( wp_next_scheduled( Sensei_Enrolment_Course_Calculation_Job::get_name(), [ $job->get_args() ] ), 'Job should have been scheduled' );
+		$this->assertNotFalse( Sensei_Scheduler_Shim::get_next_scheduled( $job ), 'Job should have been scheduled' );
 	}
 
 	/**
@@ -313,7 +315,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$course->post_title  = $course->post_title . ' Updated';
 		wp_update_post( $course );
 
-		$this->assertFalse( wp_next_scheduled( Sensei_Enrolment_Course_Calculation_Job::get_name(), [ $job->get_args() ] ), 'Job should not have been scheduled' );
+		$this->assertFalse( Sensei_Scheduler_Shim::get_next_scheduled( $job ), 'Job should not have been scheduled' );
 	}
 
 	/**
@@ -330,7 +332,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$course->post_status = 'draft';
 		wp_update_post( $course );
 
-		$this->assertFalse( wp_next_scheduled( Sensei_Enrolment_Course_Calculation_Job::get_name(), [ $job->get_args() ] ), 'Job should not have been scheduled' );
+		$this->assertFalse( Sensei_Scheduler_Shim::get_next_scheduled( $job ), 'Job should not have been scheduled' );
 	}
 
 	/**

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -7,7 +7,7 @@
  */
 class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	use Sensei_Course_Enrolment_Test_Helpers;
-
+	use Sensei_Scheduler_Test_Helpers;
 
 	/**
 	 * Setup function.
@@ -18,6 +18,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$this->factory = new Sensei_Factory();
 
 		self::resetEnrolmentProviders();
+		self::restoreShimScheduler();
 		Sensei_Scheduler_Shim::reset();
 	}
 

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -7,6 +7,7 @@
  */
 class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 	use Sensei_Course_Enrolment_Test_Helpers;
+	use Sensei_Scheduler_Test_Helpers;
 
 	/**
 	 * Setup function.
@@ -17,6 +18,7 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 		$this->factory = new Sensei_Factory();
 
 		self::resetEnrolmentProviders();
+		self::restoreShimScheduler();
 	}
 
 	/**

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -439,7 +439,7 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 		$this->assertEquals( $course_enrolment->get_course_enrolment_salt(), $course_salt, 'The course salt should not have been reset' );
 
 		$this->assertTrue( $job instanceof Sensei_Enrolment_Course_Calculation_Job, 'Returned job should be an instance of Sensei_Enrolment_Course_Calculation_Job' );
-		$this->assertNotEmpty( wp_next_scheduled( Sensei_Enrolment_Course_Calculation_Job::get_name(), [ $job->get_args() ] ), 'Job should have been scheduled' );
+		$this->assertNotFalse( Sensei_Scheduler_Shim::get_next_scheduled( $job ), 'Job should have been scheduled' );
 	}
 
 	/**
@@ -475,7 +475,7 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 		$this->assertNotEquals( $course_enrolment->get_course_enrolment_salt(), $course_salt, 'The course salt should have been reset' );
 
 		$this->assertTrue( $job instanceof Sensei_Enrolment_Course_Calculation_Job, 'Returned job should be an instance of Sensei_Enrolment_Course_Calculation_Job' );
-		$this->assertNotEmpty( wp_next_scheduled( Sensei_Enrolment_Course_Calculation_Job::get_name(), [ $job->get_args() ] ), 'Job should have been scheduled' );
+		$this->assertNotFalse( Sensei_Scheduler_Shim::get_next_scheduled( $job ), 'Job should have been scheduled' );
 	}
 
 	/**

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-course-calculation-job.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-course-calculation-job.php
@@ -49,10 +49,17 @@ class Sensei_Enrolment_Course_Calculation_Job_Test extends WP_UnitTestCase {
 		$this->createAndEnrolUsers( $course_id, 5 );
 		$this->invalidateAllCourseResults( $course_enrolment );
 
-		$this->assertTrue( $job->run(), 'Job should ask to be rescheduled after first run.' );
-		$this->assertTrue( $job->run(), 'Job should ask to be rescheduled after second run.' );
-		$this->assertTrue( $job->run(), 'Job should ask to be rescheduled after third run.' );
-		$this->assertFalse( $job->run(), 'Job should ask to be completed after fourth run.' );
+		$job->run();
+		$this->assertFalse( $job->is_complete(), 'Job should not be marked complete after the first run.' );
+
+		$job->run();
+		$this->assertFalse( $job->is_complete(), 'Job should not be marked as complete after the second run.' );
+
+		$job->run();
+		$this->assertFalse( $job->is_complete(), 'Job should not be marked as complete after the third run.' );
+
+		$job->run();
+		$this->assertTrue( $job->is_complete(), 'Job should be marked as complete after fourth run.' );
 	}
 
 	/**
@@ -72,7 +79,8 @@ class Sensei_Enrolment_Course_Calculation_Job_Test extends WP_UnitTestCase {
 		$user_ids = $this->factory()->user->create_many( 3 );
 		$this->invalidateAllCourseResults( $course_enrolment );
 
-		$this->assertTrue( $job->run(), 'Job should ask to be rescheduled after first run.' );
+		$job->run();
+		$this->assertFalse( $job->is_complete(), 'Job should not be complete after first run.' );
 
 		foreach ( $user_ids as $user_id ) {
 			$results = $course_enrolment->get_enrolment_check_results( $user_id );
@@ -123,7 +131,8 @@ class Sensei_Enrolment_Course_Calculation_Job_Test extends WP_UnitTestCase {
 			$this->assertNotFalse( $results, 'Results should NOT have been cleared for users who are not enrolled' );
 		}
 
-		$this->assertTrue( $job->run(), 'Job should ask to be rescheduled after first run.' );
+		$job->run();
+		$this->assertFalse( $job->is_complete(), 'Job should not be complete after first run.' );
 
 		foreach ( $enrolled_user_ids as $user_id ) {
 			$results = $course_enrolment->get_enrolment_check_results( $user_id );

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
@@ -7,6 +7,8 @@
  * @group course-enrolment
  */
 class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
+	use Sensei_Scheduler_Test_Helpers;
+
 	/**
 	 * Setup function.
 	 */
@@ -16,6 +18,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 		$this->factory = new Sensei_Factory();
 		Sensei()->deactivation();
 
+		self::restoreShimScheduler();
 		Sensei_Scheduler_Shim::reset();
 	}
 

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
@@ -7,8 +7,6 @@
  * @group course-enrolment
  */
 class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
-	private $scheduled_events = [];
-
 	/**
 	 * Setup function.
 	 */
@@ -18,37 +16,25 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 		$this->factory = new Sensei_Factory();
 		Sensei()->deactivation();
 
-		tests_add_filter(
-			'schedule_event',
-			function ( $event ) {
-				$event_name = $event->hook;
-
-				if ( ! isset( $this->scheduled_events[ $event_name ] ) ) {
-					$this->scheduled_events[ $event_name ] = 0;
-				}
-				$this->scheduled_events[ $event_name ]++;
-
-				return $event;
-			}
-		);
+		Sensei_Scheduler_Shim::reset();
 	}
 
 	public function tearDown() {
 		parent::tearDown();
 
-		$this->scheduled_events = [];
+		Sensei_Scheduler_Shim::reset();
 	}
 
 	/**
 	 * Tests that the scheduler starts when the calculation version does not exist.
 	 */
 	public function testLearnerCalculationStartsWhenVersionIsNotSet() {
-
+		$job       = new Sensei_Enrolment_Learner_Calculation_Job( 20 );
 		$scheduler = Sensei_Enrolment_Job_Scheduler::instance();
 
 		$scheduler->maybe_start_learner_calculation();
 
-		$this->assertEventScheduledCount( 1, Sensei_Enrolment_Learner_Calculation_Job::get_name(), 'The job should have been scheduled once.' );
+		$this->assertEventScheduledCount( 1, Sensei_Enrolment_Learner_Calculation_Job::NAME, 'The job should have been scheduled once.' );
 	}
 
 	/**
@@ -65,7 +51,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 
 		$scheduler->maybe_start_learner_calculation();
 
-		$this->assertEventScheduledCount( 0, Sensei_Enrolment_Learner_Calculation_Job::get_name(), 'No job should have been scheduled.' );
+		$this->assertEventScheduledCount( 0, Sensei_Enrolment_Learner_Calculation_Job::NAME, 'No job should have been scheduled.' );
 	}
 
 	/**
@@ -78,7 +64,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 		$scheduler->maybe_start_learner_calculation();
 		$scheduler->maybe_start_learner_calculation();
 
-		$this->assertEventScheduledCount( 1, Sensei_Enrolment_Learner_Calculation_Job::get_name(), 'The job should have been scheduled once.' );
+		$this->assertEventScheduledCount( 1, Sensei_Enrolment_Learner_Calculation_Job::NAME, 'The job should have been scheduled once.' );
 	}
 
 	/**
@@ -89,11 +75,11 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 		$scheduler         = Sensei_Enrolment_Job_Scheduler::instance();
 
 		$scheduler->maybe_start_learner_calculation();
-		$scheduler->stop_all_jobs();
+		Sensei_Scheduler::instance()->cancel_all_jobs();
 		$scheduler->maybe_start_learner_calculation();
 
-		$this->assertEventScheduledCount( 2, Sensei_Enrolment_Learner_Calculation_Job::get_name(), 'The job should have been scheduled again if it prematurely stopped' );
-		$scheduler->stop_all_jobs();
+		$this->assertEventScheduledCount( 2, Sensei_Enrolment_Learner_Calculation_Job::NAME, 'The job should have been scheduled again if it prematurely stopped' );
+		Sensei_Scheduler::instance()->cancel_all_jobs();
 
 		update_option(
 			Sensei_Enrolment_Job_Scheduler::CALCULATION_VERSION_OPTION_NAME,
@@ -102,7 +88,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 
 		$scheduler->maybe_start_learner_calculation();
 
-		$this->assertEventScheduledCount( 2, Sensei_Enrolment_Learner_Calculation_Job::get_name(), 'The job should not have started again after it was completed' );
+		$this->assertEventScheduledCount( 2, Sensei_Enrolment_Learner_Calculation_Job::NAME, 'The job should not have started again after it was completed' );
 	}
 
 
@@ -138,13 +124,10 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 	 * Assert that an event was scheduled a certain number of times.
 	 *
 	 * @param int    $expected Number of times an event should have been scheduled.
-	 * @param string $event    Event name.
+	 * @param string $action   Action name.
 	 * @param string $message  Message to show for failure.
 	 */
-	public function assertEventScheduledCount( $expected, $event, $message = '' ) {
-		if ( ! isset( $this->scheduled_events[ $event ] ) ) {
-			$this->scheduled_events[ $event ] = 0;
-		}
-		$this->assertEquals( $expected, $this->scheduled_events[ $event ], $message );
+	public function assertEventScheduledCount( $expected, $action, $message = '' ) {
+		$this->assertEquals( $expected, Sensei_Scheduler_Shim::get_scheduled_action_count( $action ), $message );
 	}
 }


### PR DESCRIPTION
This PR looks big, but it is a lot of testing.

#### Changes proposed in this Pull Request:

* In testing https://github.com/Automattic/sensei-wc-paid-courses/pull/452 I discovered an issue with how I am using Action Scheduler's `as_next_scheduled_action()`. I've fixed it so it properly reschedules when there is currently an action `in-progress`.
* I took this opportunity (prior to beta) to do the separation of the different scheduling methods (WP Cron vs Action Scheduler). Most of this PR is actually tests for the new classes. 

#### Testing instructions:

With WooCommerce installed/activated...
* Ensure you have more than 20 learner users.
* Reset the site enrolment salt option (`sensei_course_enrolment_site_salt`).
* Load a WP admin page.
* Make sure the action is scheduled in Tools > Scheduled Actions. 
* Make sure it is _rescheduled_ for each batch.

#### New Filters
- `sensei_background_job_actions` - Get a list of background job actions that are handled by the class.
- `sensei_scheduler_class` - Override the default class that implements `Sensei_Scheduler_Interface`.