### PR TITLE
lesson video tags allow post too

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -32,7 +32,7 @@ class Sensei_Lesson {
 
 		$this->question_order = '';
 
-		$this->allowed_html = Sensei_Wp_Kses::get_default_wp_kses_allowed_html();
+		$this->allowed_html = array_merge( Sensei_Wp_Kses::get_default_wp_kses_allowed_html(), wp_kses_allowed_html( 'post' ) );
 
 		// Admin actions
 		if ( is_admin() ) {


### PR DESCRIPTION
lesson allow video tags allowing any tags here that wp_kses_post allows

Fixes #

#### Changes proposed in this Pull Request:

*

#### Testing instructions:

*

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
#### Screenshot / Video



<!-- Add the following only if this is meant to be in changelog -->
#### Proposed changelog entry for your changes:
