### PR TITLE
Add historical data for provider status

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -280,6 +280,12 @@ class Sensei_Course_Enrolment {
 			$provider_results[ $enrolment_provider_id ] = $enrolment_provider->is_enrolled( $user_id, $this->course_id );
 		}
 
+		Sensei_Enrolment_Provider_State_Store::register_possible_enrolment_change(
+			$provider_results,
+			$user_id,
+			$this->course_id
+		);
+
 		$enrolment_results = new Sensei_Course_Enrolment_Provider_Results( $provider_results, $this->get_current_enrolment_result_version() );
 		update_user_meta( $user_id, $this->get_enrolment_results_meta_key(), wp_slash( wp_json_encode( $enrolment_results ) ) );
 

--- a/includes/enrolment/class-sensei-enrolment-provider-state-snapshot.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-state-snapshot.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * File containing the class Sensei_Enrolment_Provider_State_Snapshot.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * A snapshot of the state of all enrolment providers.
+ */
+class Sensei_Enrolment_Provider_State_Snapshot implements JsonSerializable {
+
+	/**
+	 * Timestamp of the snapshot.
+	 *
+	 * @var int
+	 */
+	private $timestamp;
+
+	/**
+	 * An array of the status of all enrolment providers.
+	 *
+	 * [
+	 *      'provider_id' => [ 'enrolment_status' => true|false ]
+	 * ]
+	 *
+	 * @var array
+	 */
+	private $providers_status;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array   $providers_status The providers' status.
+	 * @param integer $timestamp        The timestamp of the snapshot.
+	 */
+	private function __construct( $providers_status, $timestamp = null ) {
+		$this->timestamp        = null === $timestamp ? time() : $timestamp;
+		$this->providers_status = $providers_status;
+	}
+
+	/**
+	 * Restore a snapshot from a JSON string.
+	 *
+	 * @param array $data Serialized state of object.
+	 *
+	 * @return self|false
+	 */
+	public static function from_serialized_array( $data ) {
+
+		if ( empty( $data ) ) {
+			return false;
+		}
+
+		return new self( $data['p'], $data['t'] );
+	}
+
+	/**
+	 * Create an empty snapshot.
+	 *
+	 * @param array $providers_status The providers' status.
+	 *
+	 * @return self
+	 */
+	public static function create( $providers_status = [] ) {
+		return new self( $providers_status );
+	}
+
+	/**
+	 * Create a duplicate of a snapshot.
+	 *
+	 * @param Sensei_Enrolment_Provider_State_Snapshot $other The snapshot to copy.
+	 *
+	 * @return self
+	 */
+	public static function duplicate( Sensei_Enrolment_Provider_State_Snapshot $other ) {
+		return new self( $other->providers_status );
+	}
+
+	/**
+	 * Return object that can be serialized by `json_encode()`.
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		return [
+			't' => $this->timestamp,
+			'p' => $this->providers_status,
+		];
+	}
+
+	/**
+	 * Update the status of a provider.
+	 *
+	 * @param string $provider_id The provider to update the status for.
+	 * @param bool   $is_enrolled The enrolment status.
+	 *
+	 * @return bool True if the value was actually updated. False otherwise.
+	 */
+	public function update_status( $provider_id, $is_enrolled ) {
+
+		if ( isset( $this->providers_status[ $provider_id ]['enrolment_status'] ) && $is_enrolled === $this->providers_status[ $provider_id ]['enrolment_status'] ) {
+			return false;
+		}
+
+		$this->providers_status[ $provider_id ]['enrolment_status'] = $is_enrolled;
+
+		return true;
+	}
+}

--- a/includes/enrolment/class-sensei-enrolment-provider-state-snapshot.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-state-snapshot.php
@@ -25,7 +25,7 @@ class Sensei_Enrolment_Provider_State_Snapshot implements JsonSerializable {
 	 * An array of the status of all enrolment providers.
 	 *
 	 * [
-	 *      'provider_id' => [ 'enrolment_status' => true|false ]
+	 *      'provider_id' => [ 'es' => true|false ]
 	 * ]
 	 *
 	 * @var array
@@ -103,11 +103,33 @@ class Sensei_Enrolment_Provider_State_Snapshot implements JsonSerializable {
 	 */
 	public function update_status( $provider_id, $is_enrolled ) {
 
-		if ( isset( $this->providers_status[ $provider_id ]['enrolment_status'] ) && $is_enrolled === $this->providers_status[ $provider_id ]['enrolment_status'] ) {
+		if ( isset( $this->providers_status[ $provider_id ]['es'] ) && $is_enrolled === $this->providers_status[ $provider_id ]['es'] ) {
 			return false;
 		}
 
-		$this->providers_status[ $provider_id ]['enrolment_status'] = $is_enrolled;
+		$this->providers_status[ $provider_id ]['es'] = $is_enrolled;
+
+		return true;
+	}
+
+	/**
+	 * Set the active providers of the snapshot
+	 *
+	 * @param array $active_provider_ids The active providers id.
+	 *
+	 * @return bool True if the providers were actually updated. False otherwise.
+	 */
+	public function set_active_providers( $active_provider_ids ) {
+
+		$removed_providers = array_diff( array_keys( $this->providers_status ), $active_provider_ids );
+
+		if ( empty( $removed_providers ) ) {
+			return false;
+		}
+
+		foreach ( $removed_providers as $index => $provider_id ) {
+			unset( $this->providers_status[ $provider_id ] );
+		}
 
 		return true;
 	}

--- a/includes/enrolment/class-sensei-enrolment-provider-state-snapshot.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-state-snapshot.php
@@ -107,6 +107,10 @@ class Sensei_Enrolment_Provider_State_Snapshot implements JsonSerializable {
 			return false;
 		}
 
+		if ( ! isset( $this->providers_status[ $provider_id ] ) ) {
+			$this->providers_status[ $provider_id ] = [];
+		}
+
 		$this->providers_status[ $provider_id ]['es'] = $is_enrolled;
 
 		return true;

--- a/includes/enrolment/class-sensei-enrolment-provider-state-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-state-store.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Stores set of all the enrolment provider state objects for a course and user.
  */
 class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
-	const HISTORY_SIZE = 30;
+	const DEFAULT_HISTORY_SIZE = 30;
 
 	const META_PREFIX_ENROLMENT_PROVIDERS_STATE = 'sensei_enrolment_providers_state_';
 
@@ -273,7 +273,7 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 		 *
 		 * @param int  $history_size Default history size.
 		 */
-		$history_size = apply_filters( 'sensei_enrolment_history_size', self::HISTORY_SIZE );
+		$history_size = apply_filters( 'sensei_enrolment_history_size', self::DEFAULT_HISTORY_SIZE );
 
 		$this->has_changed = true;
 		array_unshift( $this->history, $snapshot );

--- a/includes/enrolment/class-sensei-enrolment-provider-state-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-state-store.php
@@ -239,6 +239,8 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 			$has_changed = $new_snapshot->update_status( $provider_id, $is_enrolled ) || $has_changed;
 		}
 
+		$has_changed = $new_snapshot->set_active_providers( array_keys( $provider_results ) ) || $has_changed;
+
 		if ( $has_changed ) {
 			$state_store->add_snapshot( $new_snapshot );
 		}

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -385,7 +385,7 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 	public function testGetProviderStateSaved() {
 		$course_id     = $this->getSimpleCourse();
 		$student_id    = $this->createStandardStudent();
-		$persisted_set = '{"always-provides":{"d":{"test":1234},"l":[[1581098440,"This is a log message"]]}}';
+		$persisted_set = '{"s":{"always-provides":{"d":{"test":1234},"l":[[1581098440,"This is a log message"]]}},"h":[]}';
 		update_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::META_PREFIX_ENROLMENT_PROVIDERS_STATE . $course_id, $persisted_set );
 
 		$provider_class = Sensei_Test_Enrolment_Provider_Always_Provides::class;

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
@@ -169,7 +169,7 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 		$data_json   = \wp_json_encode( $data );
 		$state_store = $this->getStateStoreFromJSON( $data_json, 1, 1 );
 
-		for ( $i = 0; $i < Sensei_Enrolment_Provider_State_Store::HISTORY_SIZE; $i++ ) {
+		for ( $i = 0; $i < Sensei_Enrolment_Provider_State_Store::DEFAULT_HISTORY_SIZE; $i++ ) {
 			$results = [
 				'simple' . $i => true,
 			];
@@ -178,7 +178,7 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 		}
 
 		$history = json_decode( wp_json_encode( $state_store ), true )['h'];
-		$this->assertCount( Sensei_Enrolment_Provider_State_Store::HISTORY_SIZE, $history );
+		$this->assertCount( Sensei_Enrolment_Provider_State_Store::DEFAULT_HISTORY_SIZE, $history );
 	}
 
 	/**

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
@@ -112,8 +112,8 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 		$history = json_decode( wp_json_encode( $state_store ), true )['h'];
 
 		$this->assertCount( 1, $history );
-		$this->assertTrue( $history[0]['p']['manual']['enrolment_status'] );
-		$this->assertFalse( $history[0]['p']['simple']['enrolment_status'] );
+		$this->assertTrue( $history[0]['p']['manual']['es'] );
+		$this->assertFalse( $history[0]['p']['simple']['es'] );
 
 		// Test that adding the same result has no effect.
 		Sensei_Enrolment_Provider_State_Store::register_possible_enrolment_change( $results, 1, 1 );
@@ -131,8 +131,20 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 		$history = json_decode( wp_json_encode( $state_store ), true )['h'];
 
 		$this->assertCount( 2, $history );
-		$this->assertTrue( $history[1]['p']['manual']['enrolment_status'] );
-		$this->assertFalse( $history[0]['p']['manual']['enrolment_status'] );
+		$this->assertTrue( $history[1]['p']['manual']['es'] );
+		$this->assertFalse( $history[0]['p']['manual']['es'] );
+
+		// Test that removing a provider adds a new entry to history.
+		$results = [
+			'manual' => false,
+		];
+
+		Sensei_Enrolment_Provider_State_Store::register_possible_enrolment_change( $results, 1, 1 );
+		$history = json_decode( wp_json_encode( $state_store ), true )['h'];
+
+		$this->assertCount( 3, $history );
+		$this->assertFalse( $history[0]['p']['manual']['es'] );
+		$this->assertArrayNotHasKey( 'simple', $history[0]['p'] );
 	}
 
 	/**


### PR DESCRIPTION
#### Overview
The idea behind this PR is to keep historical data of the status of the enrolment providers for every user and course. Whenever the status of an enrolment provider is updated, a new snaphot will be stored in user meta. The number of snaspshots are going to be limited per user to avoid taking too much space.  This will hopefully help us in the future to debug possible issues with user enrolment or display this information on admin screens. 

#### Proposed changes
* Update `sensei_enrolment_providers_state_<course_id>` user meta to have the following format:
```
{
	s: {
		// The store as it was before
		{
			<provider id>: {
				// Provider data
			}
		}
	}
	h: [
		{
			t: <timestamp>
			p: {
				<provider id>: {
					es: true|false
				}
			}
		},
		....
	]
}
```
* Update `Sensei_Enrolment_Provider_State_Store` to handle the snapshots. This is achieved by calling `register_possible_enrolment_change` during enrolment recalculation. The result of all providers is compared with the most recent snapshot and if there are differences a new snapshot is created.

#### Possible issues
* If there are scenarios where the enrolment status is updated many times, there will be many snapshots for the same scenario which offer low value.
* This will create extra data for every user and course. Since for big sites this might create a lot of data I have also added a filter to be able to customize the number of entries.

#### Testing instructions
* Since this modified the content of `sensei_enrolment_providers_state_*` user meta in a non backwards compatible way, you should delete the meta for all users (e.g. `DELETE FROM wp_usermeta WHERE meta_key LIKE 'sensei%'`) or use a pre-3v database.
* There is no observable change in the frontend. To test, modify the enrolments for a user and observe that the appropriate entries are created in `wp_usermeta` table.

_Note:_ I opened a new PR since I couldn't reopoen the old one #2993