### PR TITLE
Add Recalculate Enrolment data update

### DIFF
--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -184,7 +184,7 @@ class Sensei_Updates {
 				'manual' => array(
 					'recalculate_enrolment' => array(
 						'title'    => __( 'Recalculate enrollment', 'sensei-lms' ),
-						'desc'     => __( 'Invalidate the cached enrolment and have Sensei LMS recalculate for all users and courses.', 'sensei-lms' ),
+						'desc'     => __( 'Invalidate the cached enrollment and trigger recalculation for all users and courses.', 'sensei-lms' ),
 						'multiple' => true,
 					),
 				),

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -180,6 +180,14 @@ class Sensei_Updates {
 				),
 				'manual' => array(),
 			),
+			'3.0.0' => array(
+				'manual' => array(
+					'recalculate_enrolment' => array(
+						'title'    => __( 'Recalculate enrollment', 'sensei-lms' ),
+						'desc'     => __( 'Invalidate the cached enrolment and have Sensei LMS recalculate for all users and courses.', 'sensei-lms' ),
+					),
+				),
+			),
 		);
 
 		$this->version = get_option( 'sensei-version' );
@@ -2108,6 +2116,19 @@ class Sensei_Updates {
 
 	}//end enhance_teacher_role()
 
+	/**
+	 * Invalidates the calculated/cached enrolment to trigger Sensei to recalculate enrolment
+	 * for all learners and classes.
+	 *
+	 * @access private
+	 * @since 3.0.0
+	 */
+	public function recalculate_enrolment() {
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+		$enrolment_manager->reset_site_salt();
+
+		return true;
+	}
 } // End Class
 
 /**

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -185,6 +185,7 @@ class Sensei_Updates {
 					'recalculate_enrolment' => array(
 						'title'    => __( 'Recalculate enrollment', 'sensei-lms' ),
 						'desc'     => __( 'Invalidate the cached enrolment and have Sensei LMS recalculate for all users and courses.', 'sensei-lms' ),
+						'multiple' => true,
 					),
 				),
 			),
@@ -498,14 +499,14 @@ class Sensei_Updates {
 												   id="update-sensei"
 												   class="button
 												   <?php
-													if ( ! $update_run ) {
+													if ( ! $update_run || ! empty( $data['multiple'] ) ) {
 														echo ' button-primary'; }
 													?>
 													"
 												   type="submit"
 												   value="
 												   <?php
-													if ( $update_run ) {
+													if ( $update_run && empty( $data['multiple'] ) ) {
 														esc_html_e( 'Re-run Update', 'sensei-lms' );
 													} else {
 														esc_html_e( 'Run Update', 'sensei-lms' ); }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds Recalculate Enrolment data update task. This resets the site enrolment salt (`sensei_course_enrolment_site_salt`) which forces a recalculation of all enrolments.  

I wanted to do more to retire this screen and shift it to `Tools`, but didn't have time.

#### Testing instructions:

* Run the `Recalculate enrollment` data update in Sensei LMS > Data Updates.
* Ensure the `sensei_course_enrolment_site_salt` option is changed.
* Ensure the `sensei_calculate_learner_enrolments` action is scheduled (might need a page refresh).
