### PR TITLE
Fix pot file generation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -108,7 +108,7 @@ gulp.task( 'block-editor-assets', gulp.series( function( cb ) {
 } ) );
 
 gulp.task( 'pot', gulp.series( function() {
-	return gulp.src( [ '**/**.php', '!node_modules/**', '!build/**' ] )
+	return gulp.src( [ '**/**.php', '!node_modules/**', '!vendor/**', '!build/**' ] )
 		.pipe( sort() )
 		.pipe( wpPot( {
 			domain: 'sensei-lms',

--- a/package-lock.json
+++ b/package-lock.json
@@ -15896,9 +15896,9 @@
       },
       "dependencies": {
         "acorn": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-          "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+          "version": "6.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+          "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==",
           "dev": true
         },
         "ansi-escapes": {
@@ -18348,15 +18348,15 @@
       }
     },
     "gulp-wp-pot": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/gulp-wp-pot/-/gulp-wp-pot-2.3.6.tgz",
-      "integrity": "sha512-RaS7MiT8w9HdfmH8c6l7QKeeZeWDMDoyWUb//vFXGH05XY1t2w4iv22k0AIWyZ9w2ceX6W2ia3jC5hH+5wn2rA==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/gulp-wp-pot/-/gulp-wp-pot-2.4.0.tgz",
+      "integrity": "sha512-jOcIBVkp5uh1CotgTOmvA7QEOgITCLtd9gqAIrFvzRjbs1nLhoirTnj+WBoCB/eGQQ1CzS4Ho2THs1TJfKujcA==",
       "dev": true,
       "requires": {
         "plugin-error": "^1.0.1",
         "through2": "^3.0.1",
         "vinyl": "^2.2.0",
-        "wp-pot": "^1.7.1"
+        "wp-pot": "^1.9.0"
       },
       "dependencies": {
         "through2": {
@@ -25380,13 +25380,13 @@
       }
     },
     "matched": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/matched/-/matched-4.0.0.tgz",
-      "integrity": "sha512-mD08ireECeLL/CCgum8EeLx/SZiAmhbbt4FPlCZ4GG2xKBJ/yB8qn0uvuvouQzCORknElll2jSNVdtCWNQdR2g==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/matched/-/matched-5.0.0.tgz",
+      "integrity": "sha512-O0LCuxYYBNBjP2dmAg0i6PME0Mb0dvjulpMC0tTIeMRh6kXYsugOT5GOWpFkSzqjQjgOUs/eiyvpVhXdN2La4g==",
       "dev": true,
       "requires": {
-        "glob": "^7.1.3",
-        "picomatch": "^2.0.5"
+        "glob": "^7.1.6",
+        "picomatch": "^2.2.1"
       },
       "dependencies": {
         "glob": {
@@ -25402,6 +25402,12 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
+        },
+        "picomatch": {
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+          "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+          "dev": true
         }
       }
     },
@@ -27416,9 +27422,9 @@
       "dev": true
     },
     "php-parser": {
-      "version": "3.0.0-prerelease.9",
-      "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.0.0-prerelease.9.tgz",
-      "integrity": "sha512-QTVGKeiGZyRq7NpXMx15Dkiq9+B2KLGStck1Wrik+Hui+vb70rDBF+dY1RD6/IC8Wy/tUAhcKiCfKWVJUjymDA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/php-parser/-/php-parser-3.0.0.tgz",
+      "integrity": "sha512-WqGNf8Y5LBOXKJz9eKMwxjqfJ7KnwVU7DH3ebPTaOLlPtVrig++zG8KoOXywY9V9jQxY+wOY0EtC/e+wamaxsQ==",
       "dev": true
     },
     "picomatch": {
@@ -35395,14 +35401,14 @@
       "dev": true
     },
     "wp-pot": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/wp-pot/-/wp-pot-1.8.0.tgz",
-      "integrity": "sha512-/mAX/emTaZ8IByXLVWHILzP6Epm22kk09S5vaUD20xpirqV6EzTF4Cn5JPivcbanczo6Bb98JR6B/mL8EHHQMA==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/wp-pot/-/wp-pot-1.9.0.tgz",
+      "integrity": "sha512-zDuGOeVuo7W5234TA5tNUA+7BDmVk14IcpwfCa9LLis2KFmN1b3BCq/0tNftCS5XtjffSo8dByAWHHkWwAZMBw==",
       "dev": true,
       "requires": {
-        "matched": "^4.0.0",
+        "matched": "^5.0.0",
         "path-sort": "^0.1.0",
-        "php-parser": "^3.0.0-prerelease.9"
+        "php-parser": "^3.0.0"
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "gulp-sass": "4.0.2",
     "gulp-sort": "2.0.0",
     "gulp-uglify": "3.0.2",
-    "gulp-wp-pot": "2.3.6",
+    "gulp-wp-pot": "2.4.0",
     "gulp-zip": "4.2.0",
     "jest": "25.0.0",
     "mini-css-extract-plugin": "0.4.5",


### PR DESCRIPTION
### Changes Proposed
- Updates `gulp-wp-pot` to version that works.
- Ignore the `vendor/` folder. There was a file that the diff program couldn't parse.