### PR TITLE
Refactor removal of Sensei comments from total counts

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -205,6 +205,7 @@ class Sensei_Data_Cleaner {
 		'sensei_answers_[0-9]+_[0-9]+',
 		'sensei_answers_feedback_[0-9]+_[0-9]+',
 		'quiz_grades_[0-9]+_[0-9]+',
+		'sensei_comment_counts_[0-9]+',
 	);
 
 	/**

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -86,6 +86,7 @@ class Sensei_Learner {
 			$activities = array( $activities );
 		}
 
+		$post_ids = [];
 		foreach ( $activities as $activity ) {
 			if ( empty( $activity->comment_type ) ) {
 				continue;
@@ -93,7 +94,13 @@ class Sensei_Learner {
 			if ( strpos( $activity->comment_type, 'sensei_' ) !== 0 ) {
 				continue;
 			}
+
+			$post_ids[]      = $activity->comment_post_ID;
 			$dataset_changes = wp_delete_comment( intval( $activity->comment_ID ), true );
+		}
+
+		foreach ( array_unique( $post_ids ) as $post_id ) {
+			Sensei()->flush_comment_counts_cache( $post_id );
 		}
 
 		return $dataset_changes;

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -1097,6 +1097,7 @@ class Sensei_Updates {
 			'status' => 'approve',
 		);
 
+		$post_ids   = [];
 		$activities = get_comments( $args );
 
 		foreach ( $activities as $activity ) {
@@ -1114,7 +1115,13 @@ class Sensei_Updates {
 
 			if ( ! $user_exists ) {
 				wp_delete_comment( intval( $activity->comment_ID ), true );
+
+				$post_ids[] = $activity->comment_post_ID;
 			}
+		}
+
+		foreach ( array_unique( $post_ids ) as $post_id ) {
+			Sensei()->flush_comment_counts_cache( $post_id );
 		}
 
 		$total_activities = count( $activity_count );

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -670,6 +670,7 @@ class Sensei_Utils {
 					$comment['comment_date']     = current_time( 'mysql' );
 					wp_update_comment( $comment );
 
+					Sensei()->flush_comment_counts_cache( $lesson_id );
 				}
 			}
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -88,6 +88,8 @@ class Sensei_Utils {
 
 		do_action( 'sensei_log_activity_after', $args, $data, $comment_id );
 
+		Sensei()->flush_comment_counts_cache( $args['post_id'] );
+
 		if ( 0 < $comment_id ) {
 			// Return the ID so that it can be used for meta data storage
 			return $comment_id;
@@ -242,6 +244,9 @@ class Sensei_Utils {
 				} // End If Statement
 			} // End For Loop
 		} // End If Statement
+
+		Sensei()->flush_comment_counts_cache( $args['post_id'] );
+
 		return $dataset_changes;
 	} // End sensei_delete_activities()
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -987,6 +987,10 @@ class Sensei_Main {
 			return $comment_counts;
 		}
 
+		if ( ! $this->comment_counts_include_sensei_comments( $post_id ) ) {
+			return $comment_counts;
+		}
+
 		// If there are no Sensei comments to deduct, return early.
 		$sensei_counts = $this->get_sensei_comment_counts( $post_id );
 		if ( empty( $sensei_counts ) ) {
@@ -1010,6 +1014,36 @@ class Sensei_Main {
 		}
 
 		return $comment_counts;
+	}
+
+	/**
+	 * Get if the comment counts include Sensei comments.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return bool
+	 */
+	private function comment_counts_include_sensei_comments( $post_id ) {
+		// On a clean install, WordPress does not include Sensei's comments in its count.
+		$includes_sensei_comments = false;
+
+		// WooCommerce includes Sensei's comments in its counts.
+		if (
+			empty( $post_id )
+			&& has_filter( 'wp_count_comments', [ 'WC_Comments', 'wp_count_comments' ] )
+		) {
+			$includes_sensei_comments = true;
+		}
+
+		/**
+		 * Available to override if `wp_count_comments()` includes Sensei's comments in the count.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param bool $includes_sensei_comments Whether the count already includes Sensei's comments.
+		 * @param int  $post_id                  Post ID.
+		 */
+		return apply_filters( 'sensei_comment_counts_include_sensei_comments', $includes_sensei_comments, $post_id );
 	}
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1144,23 +1144,6 @@ class Sensei_Main {
 	}
 
 	/**
-	 * Get the comment counts without Sensei modifications.
-	 *
-	 * @param  int $post_id Post ID.
-	 *
-	 * @return stdClass
-	 */
-	private function get_comment_counts_raw( $post_id ) {
-		remove_filter( 'wp_count_comments', [ $this, 'sensei_count_comments' ], 999 );
-
-		$raw_comment_count = wp_count_comments( $post_id );
-
-		add_filter( 'wp_count_comments', [ $this, 'sensei_count_comments' ], 999, 2 );
-
-		return $raw_comment_count;
-	}
-
-	/**
 	 * Init images.
 	 *
 	 * @since 1.4.5

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -980,8 +980,11 @@ class Sensei_Main {
 	 */
 	public function sensei_count_comments( $comment_counts, $post_id ) {
 		if (
+			// If comment counts are empty, so far nothing has touched core's counts and we can return early.
+			empty( $comment_counts )
+
 			// If we are getting counts for a specific, non-Sensei post, return early.
-			(
+			|| (
 				! empty( $post_id )
 				&& ! in_array( get_post_type( $post_id ), [ 'course', 'lesson', 'quiz' ], true )
 			)
@@ -996,15 +999,6 @@ class Sensei_Main {
 		$sensei_counts = $this->get_sensei_comment_counts( $post_id );
 		if ( empty( $sensei_counts ) ) {
 			return $comment_counts;
-		}
-
-		// If nothing else has provided a filter value, get the raw value and side-step this filter.
-		if ( empty( $comment_counts ) ) {
-			$comment_counts = $this->get_comment_counts_raw( $post_id );
-
-			if ( empty( $comment_counts ) ) {
-				return $comment_counts;
-			}
 		}
 
 		// Subtract Sensei's comment counts from all the comment counts.

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -979,15 +979,16 @@ class Sensei_Main {
 	 * @return stdClass
 	 */
 	public function sensei_count_comments( $comment_counts, $post_id ) {
-		// If we are getting counts for a specific, non-Sensei post, return early.
 		if (
-			! empty( $post_id )
-			&& ! in_array( get_post_type( $post_id ), [ 'course', 'lesson', 'quiz' ], true )
-		) {
-			return $comment_counts;
-		}
+			// If we are getting counts for a specific, non-Sensei post, return early.
+			(
+				! empty( $post_id )
+				&& ! in_array( get_post_type( $post_id ), [ 'course', 'lesson', 'quiz' ], true )
+			)
 
-		if ( ! $this->comment_counts_include_sensei_comments( $post_id ) ) {
+			// If Sensei's comment counts aren't included, we don't need to adjust.
+			|| ! $this->comment_counts_include_sensei_comments( $post_id )
+		) {
 			return $comment_counts;
 		}
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1124,11 +1124,12 @@ class Sensei_Main {
 			$row['num_comments'] = (int) $row['num_comments'];
 
 			// Don't count post-trashed toward totals.
-			if ( ! in_array( $row['comment_approved'], array( 'post-trashed', 'trash', 'spam' ), true ) ) {
-				$stats['all']            += $row['num_comments'];
+			if ( ! in_array( $row['comment_approved'], [ 'post-trashed', 'trash' ], true ) ) {
 				$stats['total_comments'] += $row['num_comments'];
-			} elseif ( ! in_array( $row['comment_approved'], array( 'post-trashed', 'trash' ), true ) ) {
-				$stats['total_comments'] += $row['num_comments'];
+
+				if ( 'spam' !== $row['comment_approved'] ) {
+					$stats['all'] += $row['num_comments'];
+				}
 			}
 
 			if ( ! isset( $stats[ $row['comment_approved'] ] ) ) {

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1101,7 +1101,7 @@ class Sensei_Main {
 					SELECT comment_approved, COUNT(*) AS num_comments
 					FROM {$wpdb->comments}
 					WHERE
-						comment_type IN ( 'sensei_course_status', 'sensei_lesson_status', 'sensei_user_answer' )
+						comment_type LIKE 'sensei_%'
 						{$post_where}
 					GROUP BY comment_approved
 			",

--- a/tests/unit-tests/test-class-sensei.php
+++ b/tests/unit-tests/test-class-sensei.php
@@ -290,9 +290,8 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 				shuffle( $types );
 
 				return $types[0];
-			}
+			},
 		];
-
 
 		$post_ids    = $this->factory->course->create_many( $course_count );
 		$comment_ids = $this->createCommentsForPosts( $post_ids, $comment_approved_map, $comment_args );
@@ -317,10 +316,10 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 		};
 
 		$comment_ids = [];
-		foreach( $comment_approved_map as $status => $n ) {
+		foreach ( $comment_approved_map as $status => $n ) {
 			$comment_args['comment_approved'] = $status;
 
-			for( $i=0; $i < $n; $i++ ) {
+			for ( $i = 0; $i < $n; $i++ ) {
 				$comment_ids[] = $this->createComment( $comment_args );
 			}
 		}


### PR DESCRIPTION
Fixes #3007
Fixes #1925
Fixes #2319

### Changes proposed in this Pull Request:

* Refactors how we remove Sensei's comment counts from the total counts. Inspired somewhat from how WooCommerce and WooCommerce Memberships approaches it, even though I think WooCommerce is doing it incorrectly.
* For now, it only removes Sensei's comments from the counts when WooCommerce is active. WordPress core actually already removes the counts (only handles approval statuses that it knows about, which Sensei doesn't use). Unfortunately, WooCommerce includes them. This is really a fix Sensei compatibility issue with WooCommerce, but it is behind a filter so folks can include it if other plugins are also misbehaving.
* Should make this compatible with WooCommerce Memberships (and other implementations that expect `all` count).
* We still have slow queries, but we are now caching counts for all posts (`_transient_sensei_comment_counts_0`) and individual Sensei related posts (`_transient_sensei_comment_counts_{$post_id}`). These get cleared when activity changes. This should improve the subsequent load times quite a bit.
* Should improve the speed on large sites in WP Admin by caching the counts used for the top menu bar's pending moderation count.

### Testing instructions:

#### Without WooCommerce Enabled
* Have several courses with progress from several users.
* On normal posts, add some comments. Mark some as spam.
* Go to WP Admin > Comments.
* Make sure the numbers next to the comment statuses are accurate. Note: All doesn't include Spam.

#### Activate WooCommerce
- Place some orders.
- Go back to WP Admin > Comments and make sure the numbers next to the comment statuses are accurate.
