### PR TITLE
Add filter to side-step Sensei's enrolment functionality

### DIFF
--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -185,7 +185,15 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	 * @return array
 	 */
 	public function get_known_bulk_actions() {
-		return (array) apply_filters( 'sensei_learners_admin_get_known_bulk_actions', $this->known_bulk_actions );
+		$known_bulk_actions = $this->known_bulk_actions;
+
+		$manual_provider = Sensei_Course_Enrolment_Manager::instance()->get_manual_enrolment_provider();
+		if ( ! $manual_provider ) {
+			unset( $known_bulk_actions[ self::MANUALLY_ENROL ] );
+			unset( $known_bulk_actions[ self::REMOVE_MANUAL_ENROLMENT ] );
+		}
+
+		return (array) apply_filters( 'sensei_learners_admin_get_known_bulk_actions', $known_bulk_actions );
 	}
 
 	/**

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -187,12 +187,6 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	public function get_known_bulk_actions() {
 		$known_bulk_actions = $this->known_bulk_actions;
 
-		$manual_provider = Sensei_Course_Enrolment_Manager::instance()->get_manual_enrolment_provider();
-		if ( ! $manual_provider ) {
-			unset( $known_bulk_actions[ self::MANUALLY_ENROL ] );
-			unset( $known_bulk_actions[ self::REMOVE_MANUAL_ENROLMENT ] );
-		}
-
 		return (array) apply_filters( 'sensei_learners_admin_get_known_bulk_actions', $known_bulk_actions );
 	}
 

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -308,6 +308,13 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 			'<select name="sensei_bulk_action_select" id="bulk-action-selector-top">' .
 			'<option value="">' . esc_html__( 'Bulk Learner Actions', 'sensei-lms' ) . '</option>';
 		$bulk_actions = $this->controller->get_known_bulk_actions();
+
+		$manual_provider = Sensei_Course_Enrolment_Manager::instance()->get_manual_enrolment_provider();
+		if ( ! $manual_provider ) {
+			unset( $bulk_actions[ Sensei_Learners_Admin_Bulk_Actions_Controller::MANUALLY_ENROL ] );
+			unset( $bulk_actions[ Sensei_Learners_Admin_Bulk_Actions_Controller::REMOVE_MANUAL_ENROLMENT ] );
+		}
+
 		foreach ( $bulk_actions as $value => $translation ) {
 			$rendered .= '<option value="' . esc_attr( $value ) . '">' . esc_html( $translation ) . '</option>';
 		}

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -1050,6 +1050,11 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	 * @return void
 	 */
 	public function add_learners_box() {
+		$manual_provider = Sensei_Course_Enrolment_Manager::instance()->get_manual_enrolment_provider();
+		if ( ! $manual_provider ) {
+			return;
+		}
+
 		$post_type      = '';
 		$post_title     = '';
 		$form_post_type = '';

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -93,6 +93,26 @@ class Sensei_Course_Enrolment {
 	 * @return bool
 	 */
 	public function is_enrolled( $user_id, $check_cache = true ) {
+		/**
+		 * Allow complete side-stepping of enrolment handling in Sensei.
+		 *
+		 * This will have some other side-effects. For example, if using learner queries (My Courses,
+		 * Learner Profiles, etc), you will have to save the learner term and association by using the
+		 * `\Sensei_Course_Enrolment::save_enrolment` method. Additionally, manual enrolment handling
+		 * in Learner Management will not have any effect.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param bool|null $is_enrolled If a boolean, that value will be used. Null values will keep default behavior.
+		 * @param int       $user_id     User ID.
+		 * @param int       $course_id   Course post ID.
+		 * @param bool      $check_cache Advise hooked method if cached values should be trusted.
+		 */
+		$is_enrolled = apply_filters( 'sensei_is_enrolled', null, $user_id, $this->course_id, $check_cache );
+		if ( null !== $is_enrolled ) {
+			return $is_enrolled;
+		}
+
 		// Users can only be enrolled in a published course.
 		if ( 'publish' !== get_post_status( $this->course_id ) ) {
 			return false;
@@ -225,6 +245,7 @@ class Sensei_Course_Enrolment {
 	 * Save enrolment in taxonomy.
 	 *
 	 * @param int  $user_id    User ID.
+	 * @param int  $user_id     User ID.
 	 * @param bool $is_enrolled If the user is enrolled in the course.
 	 *
 	 * @return bool

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -244,14 +244,13 @@ class Sensei_Course_Enrolment {
 	/**
 	 * Save enrolment in taxonomy.
 	 *
-	 * @param int  $user_id    User ID.
 	 * @param int  $user_id     User ID.
 	 * @param bool $is_enrolled If the user is enrolled in the course.
 	 *
 	 * @return bool
 	 * @throws Exception When learner term could not be created.
 	 */
-	private function save_enrolment( $user_id, $is_enrolled ) {
+	public function save_enrolment( $user_id, $is_enrolled ) {
 		$term = Sensei_Learner::get_learner_term( $user_id );
 		if ( ! $is_enrolled ) {
 			$result = wp_remove_object_terms( $this->course_id, [ intval( $term->term_id ) ], Sensei_PostTypes::LEARNER_TAXONOMY_NAME );


### PR DESCRIPTION
Fixes #3010

#### Changes proposed in this Pull Request:

* Adds a filter to completely side-step Sensei's enrolment functionality. See #3010 for known side-effects.
* Side-effects around learner queries can be mitigated by using `\Sensei_Course_Enrolment::save_enrolment` in the hooked method.
* Adds a bit more gracious failing when the manual provider is filtered out. The frontend doesn't change, but actions/filters already exist for folks to override that. Learner management should hide all enrolment related functionality.

#### Testing instructions:

Basic testing to make sure it is somewhat gracious.

Snippet for testing:
```php
add_filter( 
	'sensei_is_enrolled', 
	function ( $is_enrolled, $user_id, $course_id, $check_cache ) {
		return true;
	}, 
	10, 
	4 
);

add_filter(
	'sensei_course_enrolment_providers',
	function ( $enrolment_providers ) {
		return [];
	},
	100
);
```