### PR TITLE
Add failsafes on update version check

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -632,7 +632,7 @@ class Sensei_Main {
 		}
 
 		foreach ( (array) $course_counts as $count ) {
-			if ( $count > 0 ){
+			if ( $count > 0 ) {
 				return true;
 			}
 		}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -625,19 +625,12 @@ class Sensei_Main {
 	 * @return bool
 	 */
 	private function course_exists() {
-		$course_counts = wp_count_posts( 'course' );
+		global $wpdb;
 
-		if ( empty( $course_counts ) ) {
-			return false;
-		}
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Lightweight query run only once before post type is registered.
+		$course_sample_id = (int) $wpdb->get_var( "SELECT `ID` FROM {$wpdb->posts} WHERE `post_type`='course' LIMIT 1" );
 
-		foreach ( (array) $course_counts as $count ) {
-			if ( $count > 0 ) {
-				return true;
-			}
-		}
-
-		return false;
+		return ! empty( $course_sample_id );
 	}
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -581,7 +581,7 @@ class Sensei_Main {
 	 */
 	public function update() {
 		$current_version = get_option( 'sensei-version' );
-		$is_new_install  = ! $current_version && $this->course_exists();
+		$is_new_install  = ! $current_version && ! $this->course_exists();
 		$is_upgrade      = $current_version && version_compare( $this->version, $current_version, '>' );
 
 		// Make sure the current version is up-to-date.

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -581,7 +581,7 @@ class Sensei_Main {
 	 */
 	public function update() {
 		$current_version = get_option( 'sensei-version' );
-		$is_new_install  = ! $current_version && ! get_option( 'sensei-settings', get_option( 'woothemes-sensei-settings' ) );
+		$is_new_install  = ! $current_version && $this->course_exists();
 		$is_upgrade      = $current_version && version_compare( $this->version, $current_version, '>' );
 
 		// Make sure the current version is up-to-date.
@@ -617,6 +617,27 @@ class Sensei_Main {
 
 		// Flush rewrite cache.
 		$this->initiate_rewrite_rules_flush();
+	}
+
+	/**
+	 * Helper function to check to see if any courses exists in the database.
+	 *
+	 * @return bool
+	 */
+	private function course_exists() {
+		$course_counts = wp_count_posts( 'course' );
+
+		if ( empty( $course_counts ) ) {
+			return false;
+		}
+
+		foreach ( (array) $course_counts as $count ) {
+			if ( $count > 0 ){
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei.php
+++ b/tests/unit-tests/test-class-sensei.php
@@ -50,7 +50,6 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 	 */
 	public function testUpdateNewInstall() {
 		$this->resetUpdateOptions();
-		$this->deleteSettings();
 
 		Sensei()->update();
 
@@ -59,21 +58,20 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests to make sure the version is set on new installs but the legacy update flag option isn't set, even when
-	 * there might be a course progress artifact.
+	 * Tests to make sure the version and legacy update flag option are set when both course and progress
+	 * artifacts exist.
 	 */
-	public function testUpdateNewInstallWithProgress() {
+	public function testUpdateOldInstallWithProgress() {
 		$user_id   = $this->factory->user->create();
 		$course_id = $this->factory->course->create();
 		Sensei_Utils::user_start_course( $user_id, $course_id );
 
 		$this->resetUpdateOptions();
-		$this->deleteSettings();
 
 		Sensei()->update();
 
 		$this->assertEquals( Sensei()->version, get_option( 'sensei-version' ) );
-		$this->assertEmpty( get_option( 'sensei_enrolment_legacy' ), 'Legacy update flag option should not be set on new installs even with artifacts' );
+		$this->assertNotEmpty( get_option( 'sensei_enrolment_legacy' ), 'Legacy update flag option should be set on updates even when course and progress artifacts exist' );
 	}
 
 	/**
@@ -86,7 +84,6 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 		Sensei_Utils::user_start_course( $user_id, $course_id );
 
 		$this->resetUpdateOptions();
-		$this->deleteSettings();
 
 		update_option( 'woothemes-sensei-version', '1.9.0' );
 		update_option( 'woothemes-sensei-settings', [ 'settings' => true ] );
@@ -103,7 +100,6 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 	 */
 	public function testUpdatev1UpdateWithoutProgress() {
 		$this->resetUpdateOptions();
-		$this->deleteSettings();
 
 		update_option( 'woothemes-sensei-version', '1.9.0' );
 		update_option( 'woothemes-sensei-settings', [ 'settings' => true ] );
@@ -152,14 +148,6 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 	private function resetUpdateOptions() {
 		delete_option( 'sensei-version' );
 		delete_option( 'sensei_enrolment_legacy' );
-	}
-
-	/**
-	 * Resets the settings options.
-	 */
-	private function deleteSettings() {
-		delete_option( 'sensei-settings' );
-		delete_option( 'woothemes-sensei-settings' );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei.php
+++ b/tests/unit-tests/test-class-sensei.php
@@ -1,6 +1,14 @@
 <?php
 
 class Sensei_Globals_Test extends WP_UnitTestCase {
+	/**
+	 * Setup function.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+	}
 
 	/**
 	 * Test the global $woothemes_sensei object
@@ -35,6 +43,123 @@ class Sensei_Globals_Test extends WP_UnitTestCase {
 
 	function testSenseiFunctionReturnSameSenseiInstance() {
 		$this->assertSame( Sensei(), Sensei(), 'Sensei() should always return the same Sensei_Main instance' );
+	}
+
+	/**
+	 * Tests to make sure the version is set on new installs but the legacy update flag option isn't set.
+	 */
+	public function testUpdateNewInstall() {
+		$this->resetUpdateOptions();
+		$this->deleteSettings();
+
+		Sensei()->update();
+
+		$this->assertEquals( Sensei()->version, get_option( 'sensei-version' ) );
+		$this->assertEmpty( get_option( 'sensei_enrolment_legacy' ), 'Legacy update flag option should not be set on new installs' );
+	}
+
+	/**
+	 * Tests to make sure the version is set on new installs but the legacy update flag option isn't set, even when
+	 * there might be a course progress artifact.
+	 */
+	public function testUpdateNewInstallWithProgress() {
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		Sensei_Utils::user_start_course( $user_id, $course_id );
+
+		$this->resetUpdateOptions();
+		$this->deleteSettings();
+
+		Sensei()->update();
+
+		$this->assertEquals( Sensei()->version, get_option( 'sensei-version' ) );
+		$this->assertEmpty( get_option( 'sensei_enrolment_legacy' ), 'Legacy update flag option should not be set on new installs even with artifacts' );
+	}
+
+	/**
+	 * Tests to make sure the version is set on v1 updates and the legacy update flag option is set when there are
+	 * progress artifacts.
+	 */
+	public function testUpdatev1UpdateWithProgress() {
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		Sensei_Utils::user_start_course( $user_id, $course_id );
+
+		$this->resetUpdateOptions();
+		$this->deleteSettings();
+
+		update_option( 'woothemes-sensei-version', '1.9.0' );
+		update_option( 'woothemes-sensei-settings', [ 'settings' => true ] );
+
+		Sensei()->update();
+
+		$this->assertEquals( Sensei()->version, get_option( 'sensei-version' ) );
+		$this->assertNotEmpty( get_option( 'sensei_enrolment_legacy' ), 'Legacy update flag option should be set during v1 updates with progress artifacts' );
+	}
+
+	/**
+	 * Tests to make sure the version is set on v1 updates and the legacy update flag option is NOT set when there are
+	 * no progress artifacts.
+	 */
+	public function testUpdatev1UpdateWithoutProgress() {
+		$this->resetUpdateOptions();
+		$this->deleteSettings();
+
+		update_option( 'woothemes-sensei-version', '1.9.0' );
+		update_option( 'woothemes-sensei-settings', [ 'settings' => true ] );
+
+		Sensei()->update();
+
+		$this->assertEquals( Sensei()->version, get_option( 'sensei-version' ) );
+		$this->assertEmpty( get_option( 'sensei_enrolment_legacy' ), 'Legacy update flag option should NOT be set during v1 updates without progress artifacts' );
+	}
+
+	/**
+	 * Tests to make sure the version is set on v2 updates and the legacy update flag option is set, even without
+	 * progress artifacts.
+	 */
+	public function testUpdatev2UpdateWithoutProgress() {
+		$this->resetUpdateOptions();
+
+		update_option( 'sensei-version', '2.4.0' );
+
+		Sensei()->update();
+
+		$this->assertEquals( Sensei()->version, get_option( 'sensei-version' ) );
+		$this->assertNotEmpty( get_option( 'sensei_enrolment_legacy' ), 'Legacy update flag option should be set during v2 updates with known previous version' );
+	}
+
+	/**
+	 * Tests to make sure the version is set on v2 updates and the legacy update flag option is set when the previous
+	 * version wasn't known but there were progress artifacts.
+	 */
+	public function testUpdatev2UpdateWithProgress() {
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		Sensei_Utils::user_start_course( $user_id, $course_id );
+
+		$this->resetUpdateOptions();
+
+		Sensei()->update();
+
+		$this->assertEquals( Sensei()->version, get_option( 'sensei-version' ) );
+		$this->assertNotEmpty( get_option( 'sensei_enrolment_legacy' ), 'Legacy update flag option should be set during v2 updates with progress' );
+	}
+
+	/**
+	 * Resets the update options.
+	 */
+	private function resetUpdateOptions() {
+		delete_option( 'sensei-version' );
+		delete_option( 'sensei_enrolment_legacy' );
+	}
+
+	/**
+	 * Resets the settings options.
+	 */
+	private function deleteSettings() {
+		delete_option( 'sensei-settings' );
+		delete_option( 'woothemes-sensei-settings' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3017 

We can't rely completely on `sensei-version` getting set on previous versions of Sensei due to it being tied to the activation hook. That might not get fired if the plugin was swapped out without using WP Admin. The setting of `sensei_enrolment_legacy` is critical to migration logic in the manual provider (as well as the Subscriptions provider).

### Changes proposed in this Pull Request:

* Ensures `sensei-version` is always set if old or not set already.
* Tries to detect if this is a new install by both the version AND `sensei-settings` (with a failsafe of `woothemes-sensei-settings` for v1 installs). This will also help fix upgrades from v1 -> v3.
* If it doesn't look like a new install but the version can't be checked, it will look to see if any course progress has been set. If so, it will set `sensei_enrolment_legacy`.

### Testing instructions:

#### From a fresh install
* Activate Sensei LMS. 
* Verify that the option `sensei-version` is set to `3.0.0-beta.1` and option `sensei_enrolment_legacy` is NOT set.

#### From a Sensei v1 install with at least one enrolled learner
##### Folder Swap Method
- Swap out the `woothemes-sensei` folder with the updated v3 version. For this, you'll need to use the build package of this branch in SWCPC (I'll put it in Slack).
- Verify that the option `sensei-version` is set to `3.0.0-beta.1` and option `sensei_enrolment_legacy` is set.

##### Deactivate/Install/Activate
- Deactivate Sensei v1.
- Uninstall the plugin.
- Upload and install built version of SWCPC.
- Verify that the option `sensei-version` is set to `3.0.0-beta.1` and option `sensei_enrolment_legacy` is set.

#### From a Sensei v2 install with at least one enrolled learner
##### Folder Swap Method
- Swap out the `sensei-lms` folder with the updated v3 version (package provided below).
- Verify that the option `sensei-version` is set to `3.0.0-beta.1` and option `sensei_enrolment_legacy` is set.

##### Deactivate/Install/Activate
- Deactivate Sensei LMS v2.
- Uninstall the plugin.
- Upload and install built version of this branch (package provided below).
- Verify that the option `sensei-version` is set to `3.0.0-beta.1` and option `sensei_enrolment_legacy` is set.

#### From a Sensei v2 install with at least one enrolled learner and `sensei-version` deleted
- Swap out the `sensei-lms` folder with the updated v3 version (package provided below).
- Verify that the option `sensei-version` is set to `3.0.0-beta.1` and option `sensei_enrolment_legacy` is set.

#### From a Sensei v2 install with NO enrolled learners (clear `wp_comments`) and `sensei-version` deleted (should have `sensei-settings`).
- Swap out the `sensei-lms` folder with the updated v3 version (package provided below).
- Verify that the option `sensei-version` is set to `3.0.0-beta.1` and option `sensei_enrolment_legacy` is NOT set.

Package for testing simple Sensei LMS v2 upgrades: 
[sensei-lms-fix-version-set.zip](https://github.com/Automattic/sensei/files/4430081/sensei-lms-fix-version-set.zip)
