### PR TITLE
Allow providers to provide debug information

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment-provider-debug-interface.php
+++ b/includes/enrolment/class-sensei-course-enrolment-provider-debug-interface.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * File containing the interface Sensei_Course_Enrolment_Provider_Debug_Interface.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Interface for course enrolment providers who wish to provide debugging information.
+ */
+interface Sensei_Course_Enrolment_Provider_Debug_Interface {
+	/**
+	 * Provide debugging information about a user's enrolment in a course.
+	 *
+	 * @param int $user_id   User ID.
+	 * @param int $course_id Course post ID.
+	 *
+	 * @return string[] Array of human readable debug messages. Allowed HTML tags: a[href]; strong; em; span[style,class]
+	 */
+	public function debug( $user_id, $course_id );
+}

--- a/includes/enrolment/class-sensei-course-manual-enrolment-provider.php
+++ b/includes/enrolment/class-sensei-course-manual-enrolment-provider.php
@@ -222,11 +222,6 @@ class Sensei_Course_Manual_Enrolment_Provider
 	 */
 	public function debug( $user_id, $course_id ) {
 		$messages = [];
-		if ( $this->is_enrolled( $user_id, $course_id ) ) {
-			$messages[] = __( 'Learner <strong>is currently</strong> manually enrolled.', 'sensei-lms' );
-		} else {
-			$messages[] = __( 'Learner <strong>is not currently</strong> manually enrolled.', 'sensei-lms' );
-		}
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 		$provider_state   = $course_enrolment->get_provider_state( $this, $user_id );

--- a/tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php
@@ -197,18 +197,15 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test debug messages are generated correctly for an enrolled student without legacy migration.
+	 * Test debug messages are generated correctly for learner without legacy migration.
 	 */
-	public function testDebugEnrolledNoLegacyEnrolled() {
+	public function testDebugEnrolledNoLegacy() {
 		$provider   = $this->getManualEnrolmentProvider();
 		$course_id  = $this->getSimpleCourseId();
 		$student_id = $this->getStandardStudentUserId();
 
-		$this->directlyEnrolStudent( $student_id, $course_id );
-
 		$debug          = $provider->debug( $student_id, $course_id );
 		$expected_debug = [
-			__( 'Learner <strong>is currently</strong> manually enrolled.', 'sensei-lms' ),
 			__( 'Learner manual enrollment <strong>was not migrated</strong> from a legacy version of Sensei LMS.', 'sensei-lms' ),
 		];
 
@@ -216,31 +213,40 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test debug messages are generated correctly for an unenrolled student without legacy migration.
+	 * Test debug messages are generated correctly for a learner with legacy migration who wasn't enrolled
+	 * from legacy and didn't have progress.
 	 */
-	public function testDebugEnrolledNoLegacyUnenrolled() {
+	public function testDebugEnrolledLegacyNoProgressNotEnrolled() {
 		$provider   = $this->getManualEnrolmentProvider();
 		$course_id  = $this->getSimpleCourseId();
 		$student_id = $this->getStandardStudentUserId();
 
+		// Set the legacy migration log.
+		$migration_log    = [
+			'had_progress' => false,
+			'is_enrolled'  => false,
+		];
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+		$provider_state   = $course_enrolment->get_provider_state( $provider, $student_id );
+		$provider_state->set_stored_value( Sensei_Course_Manual_Enrolment_Provider::DATA_KEY_LEGACY_MIGRATION, $migration_log );
+		$provider_state->save();
+
 		$debug          = $provider->debug( $student_id, $course_id );
 		$expected_debug = [
-			__( 'Learner <strong>is not currently</strong> manually enrolled.', 'sensei-lms' ),
-			__( 'Learner manual enrollment <strong>was not migrated</strong> from a legacy version of Sensei LMS.', 'sensei-lms' ),
+			__( 'Learner <strong>did not have</strong> course progress at the time of manual enrollment migration.', 'sensei-lms' ),
+			__( 'Manual enrollment <strong>was not provided</strong> to the learner on legacy migration.', 'sensei-lms' ),
 		];
 
 		$this->assertEquals( $expected_debug, $debug );
 	}
 
 	/**
-	 * Test debug messages are generated correctly for an enrolled student with legacy migration.
+	 * Test debug messages are generated correctly for a learner with legacy migration who wasn't enrolled from legacy.
 	 */
-	public function testDebugEnrolledLegacyEnrolled() {
+	public function testDebugEnrolledLegacyNotEnrolled() {
 		$provider   = $this->getManualEnrolmentProvider();
 		$course_id  = $this->getSimpleCourseId();
 		$student_id = $this->getStandardStudentUserId();
-
-		$this->directlyEnrolStudent( $student_id, $course_id );
 
 		// Set the legacy migration log.
 		$migration_log    = [
@@ -254,9 +260,35 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 
 		$debug          = $provider->debug( $student_id, $course_id );
 		$expected_debug = [
-			__( 'Learner <strong>is currently</strong> manually enrolled.', 'sensei-lms' ),
 			__( 'Learner <strong>did have</strong> course progress at the time of manual enrollment migration.', 'sensei-lms' ),
 			__( 'Manual enrollment <strong>was not provided</strong> to the learner on legacy migration.', 'sensei-lms' ),
+		];
+
+		$this->assertEquals( $expected_debug, $debug );
+	}
+
+	/**
+	 * Test debug messages are generated correctly for a learner with legacy migration who was enrolled from legacy.
+	 */
+	public function testDebugEnrolledLegacyEnrolled() {
+		$provider   = $this->getManualEnrolmentProvider();
+		$course_id  = $this->getSimpleCourseId();
+		$student_id = $this->getStandardStudentUserId();
+
+		// Set the legacy migration log.
+		$migration_log    = [
+			'had_progress' => true,
+			'is_enrolled'  => true,
+		];
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+		$provider_state   = $course_enrolment->get_provider_state( $provider, $student_id );
+		$provider_state->set_stored_value( Sensei_Course_Manual_Enrolment_Provider::DATA_KEY_LEGACY_MIGRATION, $migration_log );
+		$provider_state->save();
+
+		$debug          = $provider->debug( $student_id, $course_id );
+		$expected_debug = [
+			__( 'Learner <strong>did have</strong> course progress at the time of manual enrollment migration.', 'sensei-lms' ),
+			__( 'Manual enrollment <strong>was provided</strong> to the learner on legacy migration.', 'sensei-lms' ),
 		];
 
 		$this->assertEquals( $expected_debug, $debug );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Adds a `Sensei_Course_Enrolment_Provider_Debug_Interface` interface and sets up the manual provider to give helpful debug information about a learner/course.
* I also considered calling this `Describe` instead of `Debug`, but went with the later for now.

#### Testing instructions:

* This doesn't have any front-end changes. It will be used by the debug tool, included in a feature plugin for now.