### PR TITLE
Remove logging functionality from provider state

### DIFF
--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -387,7 +387,7 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 	public function testGetProviderStateSaved() {
 		$course_id     = $this->getSimpleCourse();
 		$student_id    = $this->createStandardStudent();
-		$persisted_set = '{"always-provides":{"d":{"test":1234},"l":[[1581098440,"This is a log message"]]}}';
+		$persisted_set = '{"always-provides":{"d":{"test":1234}}}';
 		update_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::META_PREFIX_ENROLMENT_PROVIDERS_STATE . $course_id, $persisted_set );
 
 		$provider_class = Sensei_Test_Enrolment_Provider_Always_Provides::class;
@@ -401,9 +401,6 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( $provider_state instanceof Sensei_Enrolment_Provider_State );
 		$this->assertEquals( 1234, $provider_state->get_stored_value( 'test' ), 'Persisted stored value should be retrieved' );
-
-		$logs = $provider_state->get_logs();
-		$this->assertEquals( 'This is a log message', $logs[0][1], 'Persisted log entry should be retrieved' );
 	}
 
 	/**

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
@@ -60,16 +60,9 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 				'd' => [
 					'test' => true,
 				],
-				'l' => [],
 			],
 			$never_provides_provider->get_id()  => [
 				'd' => [],
-				'l' => [
-					[
-						time(),
-						'Such a great log message.',
-					],
-				],
 			],
 		];
 
@@ -80,10 +73,6 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 
 		$always_provides_state = $state_store->get_provider_state( $always_provides_provider );
 		$this->assertTrue( $always_provides_state->get_stored_value( 'test' ), 'Provider state should have been initialized with a stored value test as true' );
-
-		$never_provides_state = $state_store->get_provider_state( $never_provides_provider );
-		$logs                 = $never_provides_state->get_logs();
-		$this->assertEquals( $data['never-provides']['l'][0][1], $logs[0][1], 'Never provides provider should have a log entry' );
 	}
 
 	/**
@@ -101,16 +90,9 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 				'd' => [
 					'test' => true,
 				],
-				'l' => [],
 			],
 			$never_provides_provider->get_id()  => [
 				'd' => [],
-				'l' => [
-					[
-						time(),
-						'Such a great log message.',
-					],
-				],
 			],
 		];
 
@@ -127,7 +109,6 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 	 * @covers \Sensei_Enrolment_Provider_State_Store::set_has_changed
 	 * @covers \Sensei_Enrolment_Provider_State_Store::get_has_changed
 	 * @covers \Sensei_Enrolment_Provider_State::set_stored_value
-	 * @covers \Sensei_Enrolment_Provider_State::add_log_message
 	 */
 	public function testHasChangedStates() {
 		$always_provides_provider = new Sensei_Test_Enrolment_Provider_Always_Provides();
@@ -140,10 +121,6 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 		$provider_state->set_stored_value( 'test', true );
 		$this->assertTrue( $state_store->get_has_changed(), 'State store should be marked as having had changed after setting data value' );
 		$state_store->set_has_changed( false );
-
-		$this->assertFalse( $state_store->get_has_changed(), 'Has Changed status should have been set to false.' );
-		$provider_state->add_log_message( 'Test log message' );
-		$this->assertTrue( $state_store->get_has_changed(), 'State store should be marked as having had changed after adding log entry' );
 	}
 
 	/**
@@ -170,7 +147,7 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 	public function testPersistStateSetsWhenChange() {
 		$course_id     = $this->getSimpleCourse();
 		$student_id    = $this->createStandardStudent();
-		$persisted_set = '{"always-provides":{"d":{"test":1234},"l":[[1581098440,"This is a log message"]]}}';
+		$persisted_set = '{"always-provides":{"d":{"test":1234}}}';
 		update_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::META_PREFIX_ENROLMENT_PROVIDERS_STATE . $course_id, $persisted_set );
 
 		$provider_class = Sensei_Test_Enrolment_Provider_Always_Provides::class;
@@ -184,7 +161,7 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 		$provider_state->set_stored_value( 'test', 54321 );
 		$provider_state->save();
 
-		$expected_persisted_set = '{"always-provides":{"d":{"test":54321},"l":[[1581098440,"This is a log message"]]}}';
+		$expected_persisted_set = '{"always-provides":{"d":{"test":54321}}}';
 		$persisted_set          = get_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::META_PREFIX_ENROLMENT_PROVIDERS_STATE . $course_id, true );
 		$this->assertEquals( $expected_persisted_set, $persisted_set, 'The changed stored value should have been persisted' );
 	}
@@ -195,7 +172,7 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 	public function testMpPersistStateSetsWhenMpChange() {
 		$course_id     = $this->getSimpleCourse();
 		$student_id    = $this->createStandardStudent();
-		$persisted_set = '{"always-provides":{"d":{"test":1234},"l":[[1581098440,"This is a log message"]]}}';
+		$persisted_set = '{"always-provides":{"d":{"test":1234}}}';
 		update_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::META_PREFIX_ENROLMENT_PROVIDERS_STATE . $course_id, $persisted_set );
 
 		$provider_class = Sensei_Test_Enrolment_Provider_Always_Provides::class;
@@ -212,7 +189,6 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 
 		// This isn't a change in the stored value.
 		$provider_state->set_stored_value( 'test', 1234 );
-		$provider_state->get_logs();
 		$provider_state->get_stored_value( 'new-key' );
 		$provider_state->save();
 

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state.php
@@ -34,18 +34,11 @@ class Sensei_Enrolment_Provider_State_Test extends WP_UnitTestCase {
 			'd' => [
 				'test' => 'Dinosaurs!',
 			],
-			'l' => [
-				[
-					time(),
-					'This is a test.',
-				],
-			],
 		];
 
 		$result = Sensei_Enrolment_Provider_State::from_serialized_array( $state_store, $test_array );
 
 		$this->assertTrue( $result instanceof Sensei_Enrolment_Provider_State, 'Serialized data should have returned a instantiated object' );
-		$this->assertEquals( $test_array['l'], $result->get_logs() );
 		$this->assertEquals( $test_array['d']['test'], $result->get_stored_value( 'test' ) );
 	}
 
@@ -67,12 +60,6 @@ class Sensei_Enrolment_Provider_State_Test extends WP_UnitTestCase {
 		$test_array  = [
 			'd' => [
 				'test' => 'Dinosaurs!',
-			],
-			'l' => [
-				[
-					time(),
-					'This is a test.',
-				],
 			],
 		];
 
@@ -123,7 +110,7 @@ class Sensei_Enrolment_Provider_State_Test extends WP_UnitTestCase {
 		$this->assertTrue( $state->get_stored_value( 'test' ) );
 
 		$json_string = \wp_json_encode( $state );
-		$this->assertEquals( '{"d":{"test":true},"l":[]}', $json_string, 'The set data value should persist when serializing the object' );
+		$this->assertEquals( '{"d":{"test":true}}', $json_string, 'The set data value should persist when serializing the object' );
 	}
 
 	/**
@@ -133,7 +120,6 @@ class Sensei_Enrolment_Provider_State_Test extends WP_UnitTestCase {
 		$state_store   = Sensei_Enrolment_Provider_State_Store::get( 0, 0 );
 		$initial_state = [
 			'd' => [],
-			'l' => [],
 		];
 
 		$state = Sensei_Enrolment_Provider_State::from_serialized_array( $state_store, $initial_state );
@@ -148,70 +134,5 @@ class Sensei_Enrolment_Provider_State_Test extends WP_UnitTestCase {
 		$expected_string = \wp_json_encode( $initial_state );
 
 		$this->assertEquals( $expected_string, $json_string, 'Setting the value to null should persist with data not set when serializing the object' );
-	}
-
-	/**
-	 * Tests logging a simple message.
-	 */
-	public function testAddLogMessage() {
-		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0, 0 );
-		$state       = Sensei_Enrolment_Provider_State::create( $state_store );
-
-		$test_message = 'I really hope this works';
-		$state->add_log_message( $test_message );
-		$logs = $state->get_logs();
-
-		$this->assertEquals( $logs[0][1], $test_message, 'The message should match what was added' );
-	}
-
-	/**
-	 * Tests pruning the most recent 30 messages on log add.
-	 */
-	public function testPruneOnAddLog() {
-		$time         = time();
-		$initial_data = [
-			'l' => [],
-		];
-		for ( $i = 0; $i < 31; $i++ ) {
-			$initial_data['l'][] = [
-				$time + $i,
-				'Log entry ' . $i,
-			];
-		}
-
-		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0, 0 );
-		$state       = Sensei_Enrolment_Provider_State::from_serialized_array( $state_store, $initial_data );
-
-		$state->add_log_message( 'This should cause a pruning' );
-		$logs = $state->get_logs();
-
-		$this->assertEquals( 30, count( $logs ), 'The log should have been pruned to just 30 entries.' );
-		$this->assertEquals( $initial_data['l'][2], $logs[0], 'The first log entry should be the original second oldest' );
-		$this->assertEquals( 'This should cause a pruning', $logs[29][1], 'The last log entry should be the entry we just added' );
-	}
-
-	/**
-	 * Tests getting log message with oldest at the top.
-	 */
-	public function testGetLogs() {
-		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0, 0 );
-		$state       = Sensei_Enrolment_Provider_State::create( $state_store );
-
-		$initial_data = [
-			'First log entry',
-			'Second log entry',
-			'Third log entry',
-			'Fourth log entry',
-		];
-		foreach ( $initial_data as $entry ) {
-			$state->add_log_message( $entry );
-		}
-
-		$logs = $state->get_logs();
-
-		$this->assertEquals( $initial_data[0], $logs[0][1], 'The first log entry should be the oldest' );
-		$this->assertEquals( $initial_data[1], $logs[1][1], 'The second log entry should be the second oldest' );
-		$this->assertEquals( $initial_data[2], $logs[2][1], 'The third log entry should be the third oldest' );
-		$this->assertEquals( $initial_data[3], $logs[3][1], 'The last log entry should be the newest' );
 	}
 }


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Removes the logging functionality from provider state. It didn't make sense to be stored with the state.
* This will probably soon be replaced with another storage for logs + historical data (#2997) that will be disabled by default (for now; with a filter).