### PR TITLE
Prevent unnecessary querying on non-Sensei pages

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -69,6 +69,7 @@ class Sensei_Data_Cleaner {
 		'woothemes-sensei-upgrades',
 		'woothemes-sensei-settings',
 		'sensei-settings',
+		'sensei_show_email_signup_form',
 		'sensei_courses_page_id',
 		'woothemes-sensei_courses_page_id',
 		'woothemes-sensei_user_dashboard_page_id',

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -41,6 +41,9 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		// Log when settings are updated by the user.
 		add_action( 'update_option_sensei-settings', [ $this, 'log_settings_update' ], 10, 2 );
+
+		// Make sure we don't trigger queries if legacy options aren't loaded in pre-loaded options.
+		add_filter( 'alloptions', [ $this, 'no_special_query_for_legacy_options' ] );
 	} // End __construct()
 
 	/**
@@ -98,6 +101,27 @@ class Sensei_Settings extends Sensei_Settings_API {
 			add_action( 'admin_print_styles', array( $this, 'enqueue_styles' ) );
 		}
 	} // End register_settings_screen()
+
+	/**
+	 * Add legacy options to alloptions if they don't exist.
+	 *
+	 * @since 3.0.1
+	 *
+	 * @param array $alloptions All options that are preloaded by WordPress.
+	 *
+	 * @return array
+	 */
+	public function no_special_query_for_legacy_options( $alloptions ) {
+		if ( ! isset( $alloptions['woothemes-sensei_user_dashboard_page_id'] ) ) {
+			$alloptions['woothemes-sensei_user_dashboard_page_id'] = 0;
+		}
+
+		if ( ! isset( $alloptions['woothemes-sensei_courses_page_id'] ) ) {
+			$alloptions['woothemes-sensei_courses_page_id'] = 0;
+		}
+
+		return $alloptions;
+	}
 
 	/**
 	 * Add settings sections.
@@ -653,6 +677,10 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 * @return array
 	 */
 	private function pages_array() {
+		if ( ! is_admin() ) {
+			return [];
+		}
+
 		// REFACTOR - Transform this into a field type instead.
 		// Setup an array of portfolio gallery terms for a dropdown.
 		$pages_dropdown = wp_dropdown_pages(

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -33,7 +33,8 @@ class Sensei_Updates {
 
 		// Setup object data
 		$this->parent      = $parent;
-		$this->updates_run = self::get_ran_upgrades_raw();
+
+		add_action( 'admin_init', array( $this, 'init_updates_run' ) );
 
 		// The list of upgrades to run
 		$this->updates = array(
@@ -197,6 +198,13 @@ class Sensei_Updates {
 		add_action( 'admin_menu', array( $this, 'add_update_admin_screen' ), 50 );
 
 	} // End __construct()
+
+	/**
+	 * Initializes the updates that have been executed.
+	 */
+	public function init_updates_run() {
+		$this->updates_run = self::get_ran_upgrades_raw();
+	}
 
 	/**
 	 * Get all the possible updates.

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -32,7 +32,7 @@ class Sensei_Updates {
 	public function __construct( $parent ) {
 
 		// Setup object data
-		$this->parent      = $parent;
+		$this->parent = $parent;
 
 		add_action( 'admin_init', array( $this, 'init_updates_run' ) );
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -238,9 +238,7 @@ class Sensei_Main {
 	 * Load the email signup modal if we haven't already.
 	 */
 	private function maybe_init_email_signup_modal() {
-		if ( get_option( 'sensei_show_email_signup_form', false ) ) {
-			add_action( 'admin_init', array( $this, 'load_email_signup_modal' ) );
-		}
+		add_action( 'admin_init', array( $this, 'load_email_signup_modal' ) );
 	}
 
 	/**
@@ -249,8 +247,12 @@ class Sensei_Main {
 	 * @access private
 	 */
 	public function load_email_signup_modal() {
+		if ( ! get_option( 'sensei_show_email_signup_form', false ) ) {
+			return;
+		}
+
 		Sensei_Email_Signup_Form::instance()->init();
-		delete_option( 'sensei_show_email_signup_form' );
+		update_option( 'sensei_show_email_signup_form', false );
 	}
 
 	/**


### PR DESCRIPTION
This PR fixes a few of Sensei's unnecessary queries that it does on every request, including non-Sensei and non-admin related requests.

### Changes proposed in this Pull Request:

* https://github.com/Automattic/sensei/commit/68d0b071f525b76bfa86eb361ad24597a8506dd2 Data updates were pulling its ran updates array when not needed. It did this even on the frontend.
* https://github.com/Automattic/sensei/commit/3147d510c7d00a4f61023b2ba084b7d904f84cef The email signup option was deleted, which meant it wasn't preloaded. Right now I've set it to `false`, but we could delete it and make it query for the option admin request. It was doing this query on non-admin pages. 
* https://github.com/Automattic/sensei/commit/6b9e334d6cbe3808b3e16fe238cf496e67bfca05 Legacy options (that seem like they might be even pre-1.0.0) were queried on every request. We could probably just stop failing back to these as it does seem pre-1.0.0. It would just catch people who had a pre-1.0.0 install and haven't changed their Sensei settings since.

### Future Changes
- `\Sensei_PostTypes::get_course_post_type_archive_slug` needs a refactor. It queries the content of the course page on _every_ single request. #2023 filed.

#### Testing instructions:

* On settings page, make sure select options with page dropdown load properly. 
* On data updates, run an update (except for the enrollment one). Make sure the update is marked as ran (button label).
* Install on a new instance. Make sure you get the dialog to sign up for the mailing list when first activated.