### PR TITLE
Fix comment template not displaying for messages

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4306,8 +4306,8 @@ class Sensei_Lesson {
 	 * @since 1.9.0
 	 */
 	public static function output_comments() {
-		$allow_comments       = Sensei()->settings->settings['lesson_comments'];
-		$user_can_view_lesson = sensei_can_user_view_lesson();
+		$allow_comments        = Sensei()->settings->settings['lesson_comments'];
+		$user_can_view_lesson  = sensei_can_user_view_lesson();
 		$lesson_allow_comments = $allow_comments && $user_can_view_lesson;
 
 		if ( $lesson_allow_comments || is_singular( 'sensei_message' ) ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4306,17 +4306,8 @@ class Sensei_Lesson {
 	 * @since 1.9.0
 	 */
 	public static function output_comments() {
-		global $post;
-
-		$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
-
-		if ( empty( $course_id ) ) {
-			return;
-		}
-
 		$allow_comments       = Sensei()->settings->settings['lesson_comments'];
 		$user_can_view_lesson = sensei_can_user_view_lesson();
-
 		$lesson_allow_comments = $allow_comments && $user_can_view_lesson;
 
 		if ( $lesson_allow_comments || is_singular( 'sensei_message' ) ) {


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This fixes a regression in the 3.0 beta that prevented the comment form from displaying on the single message page if `$course_id` was empty. This PR removes that variable as well as `$post`.

#### Testing instructions:

* As a logged in user, click the _Contact Course Teacher_ button on the single course page.
* Send a message to the teacher.
* Go to _My Courses_ and click on _My Messages_.
* Click on the message you just sent.
* Ensure that the comment box is displayed and that you can leave a reply.
* Also, sign in as the teacher of the course and ensure you are able to reply to the comment on the front-end.