### PR TITLE
Introduce a provider journal store

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -73,6 +73,7 @@ class Sensei_Course_Enrolment_Manager {
 		add_action( 'transition_post_status', [ $this, 'recalculate_on_course_post_status_change' ], 10, 3 );
 
 		add_action( 'shutdown', [ Sensei_Enrolment_Provider_State_Store::class, 'persist_all' ] );
+		add_action( 'shutdown', [ Sensei_Enrolment_Provider_Journal_Store::class, 'persist_all' ] );
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -300,6 +300,12 @@ class Sensei_Course_Enrolment {
 			$provider_results[ $enrolment_provider_id ] = $enrolment_provider->is_enrolled( $user_id, $this->course_id );
 		}
 
+		Sensei_Enrolment_Provider_Journal_Store::register_possible_enrolment_change(
+			$provider_results,
+			$user_id,
+			$this->course_id
+		);
+
 		$enrolment_results = new Sensei_Course_Enrolment_Provider_Results( $provider_results, $this->get_current_enrolment_result_version() );
 		update_user_meta( $user_id, $this->get_enrolment_results_meta_key(), wp_slash( wp_json_encode( $enrolment_results ) ) );
 

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -300,14 +300,14 @@ class Sensei_Course_Enrolment {
 			$provider_results[ $enrolment_provider_id ] = $enrolment_provider->is_enrolled( $user_id, $this->course_id );
 		}
 
+		$enrolment_results = new Sensei_Course_Enrolment_Provider_Results( $provider_results, $this->get_current_enrolment_result_version() );
+		update_user_meta( $user_id, $this->get_enrolment_results_meta_key(), wp_slash( wp_json_encode( $enrolment_results ) ) );
+
 		Sensei_Enrolment_Provider_Journal_Store::register_possible_enrolment_change(
-			$provider_results,
+			$enrolment_results,
 			$user_id,
 			$this->course_id
 		);
-
-		$enrolment_results = new Sensei_Course_Enrolment_Provider_Results( $provider_results, $this->get_current_enrolment_result_version() );
-		update_user_meta( $user_id, $this->get_enrolment_results_meta_key(), wp_slash( wp_json_encode( $enrolment_results ) ) );
 
 		/**
 		 * Notify upon calculation of enrolment results.

--- a/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
@@ -233,17 +233,17 @@ class Sensei_Enrolment_Provider_Journal_Store implements JsonSerializable {
 	/**
 	 * Get the enrolment status history of a provider for a specified user and course.
 	 *
-	 * @param int $user_id     The user id.
-	 * @param int $course_id   The course id.
-	 * @param int $provider_id The provider id.
+	 * @param Sensei_Course_Enrolment_Provider_Interface $provider  The provider.
+	 * @param int                                        $user_id   The user id.
+	 * @param int                                        $course_id The course id.
 	 *
 	 * @return array The history of the provider. Each element of the array has the format:
 	 *               [ 'timestamp' => Timestamp of the status change, 'enrolment_status' => true|false|null ]
 	 */
-	public static function get_provider_history( $user_id, $course_id, $provider_id ) {
+	public static function get_provider_history( Sensei_Course_Enrolment_Provider_Interface $provider, $user_id, $course_id ) {
 		$journal_store = self::get( $user_id, $course_id );
 
-		return isset( $journal_store->providers_journal[ $provider_id ] ) ? $journal_store->providers_journal[ $provider_id ]->get_history() : [];
+		return isset( $journal_store->providers_journal[ $provider->get_id() ] ) ? $journal_store->providers_journal[ $provider->get_id() ]->get_history() : [];
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
@@ -208,14 +208,14 @@ class Sensei_Enrolment_Provider_Journal_Store implements JsonSerializable {
 	 * Get a snapshot of the providers' enrolment status for a user and course at a specific timestamp. If no timestamp
 	 * is provided the current snapshot is returned.
 	 *
-	 * @param int $user_id     The user to return the snapshot for.
-	 * @param int $course_id   The course to return the snapshot for.
-	 * @param int $timestamp   The timestamp of the snapshot in microseconds. If omitted the current snapshot is returned.
+	 * @param int       $user_id     The user to return the snapshot for.
+	 * @param int       $course_id   The course to return the snapshot for.
+	 * @param int|float $timestamp   The timestamp of the snapshot. If omitted the current snapshot is returned.
 	 *
 	 * @return array
 	 */
 	public static function get_enrolment_snanpshot( $user_id, $course_id, $timestamp = null ) {
-		$timestamp     = null === $timestamp ? microtime( true ) : $timestamp;
+		$timestamp     = null === $timestamp ? microtime( true ) : (float) $timestamp;
 		$journal_store = self::get( $user_id, $course_id );
 
 		$snapshot = [];

--- a/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
@@ -123,6 +123,17 @@ class Sensei_Enrolment_Provider_Journal_Store implements JsonSerializable {
 	 * @return bool
 	 */
 	public function save() {
+		/**
+		 * Enables journal storage for sensei.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param bool $enable_journal True to enable.
+		 */
+		if ( ! apply_filters( 'sensei_enable_journal', false ) ) {
+			return false;
+		}
+
 		if ( ! $this->has_changed ) {
 			return true;
 		}
@@ -199,12 +210,12 @@ class Sensei_Enrolment_Provider_Journal_Store implements JsonSerializable {
 	 *
 	 * @param int $user_id     The user to return the snapshot for.
 	 * @param int $course_id   The course to return the snapshot for.
-	 * @param int $timestamp   The timestamp of the snapshot. If omitted the current snapshot is returned.
+	 * @param int $timestamp   The timestamp of the snapshot in microseconds. If omitted the current snapshot is returned.
 	 *
 	 * @return array
 	 */
 	public static function get_enrolment_snanpshot( $user_id, $course_id, $timestamp = null ) {
-		$timestamp     = null === $timestamp ? time() : $timestamp;
+		$timestamp     = null === $timestamp ? microtime( true ) : $timestamp;
 		$journal_store = self::get( $user_id, $course_id );
 
 		$snapshot = [];
@@ -251,6 +262,7 @@ class Sensei_Enrolment_Provider_Journal_Store implements JsonSerializable {
 		}
 
 		$journal_store->providers_journal[ $provider_id ]->add_log_message( $message );
+		$journal_store->has_changed = true;
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
@@ -124,13 +124,13 @@ class Sensei_Enrolment_Provider_Journal_Store implements JsonSerializable {
 	 */
 	public function save() {
 		/**
-		 * Enables journal storage for sensei.
+		 * Enables journal storage for Sensei.
 		 *
 		 * @since 3.0.0
 		 *
 		 * @param bool $enable_journal True to enable.
 		 */
-		if ( ! apply_filters( 'sensei_enable_journal', false ) ) {
+		if ( ! apply_filters( 'sensei_enable_enrolment_provider_journal', false ) ) {
 			return false;
 		}
 

--- a/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
@@ -249,35 +249,35 @@ class Sensei_Enrolment_Provider_Journal_Store implements JsonSerializable {
 	/**
 	 * Add a log message to a provider.
 	 *
-	 * @param int    $user_id     The user id.
-	 * @param int    $course_id   The course id.
-	 * @param int    $provider_id The provider id.
-	 * @param string $message     The message to be added.
+	 * @param Sensei_Course_Enrolment_Provider_Interface $provider  The provider.
+	 * @param int                                        $user_id   The user id.
+	 * @param int                                        $course_id The course id.
+	 * @param string                                     $message   The message to be added.
 	 */
-	public static function add_provider_log_message( $user_id, $course_id, $provider_id, $message ) {
+	public static function add_provider_log_message( Sensei_Course_Enrolment_Provider_Interface $provider, $user_id, $course_id, $message ) {
 		$journal_store = self::get( $user_id, $course_id );
 
-		if ( ! isset( $journal_store->providers_journal[ $provider_id ] ) ) {
-			$journal_store->providers_journal[ $provider_id ] = Sensei_Enrolment_Provider_Journal::create();
+		if ( ! isset( $journal_store->providers_journal[ $provider->get_id() ] ) ) {
+			$journal_store->providers_journal[ $provider->get_id() ] = Sensei_Enrolment_Provider_Journal::create();
 		}
 
-		$journal_store->providers_journal[ $provider_id ]->add_log_message( $message );
+		$journal_store->providers_journal[ $provider->get_id() ]->add_log_message( $message );
 		$journal_store->has_changed = true;
 	}
 
 	/**
 	 * Get the log messages of a provider.
 	 *
-	 * @param int $user_id     The user id.
-	 * @param int $course_id   The course id.
-	 * @param int $provider_id The provider id.
+	 * @param Sensei_Course_Enrolment_Provider_Interface $provider  The provider.
+	 * @param int                                        $user_id   The user id.
+	 * @param int                                        $course_id The course id.
 	 *
 	 * @return array The message log of the provider. Each element of the array has the format:
 	 *               [ 'timestamp' => Timestamp of the message, 'message' => The actual message ]
 	 */
-	public static function get_provider_logs( $user_id, $course_id, $provider_id ) {
+	public static function get_provider_logs( Sensei_Course_Enrolment_Provider_Interface $provider, $user_id, $course_id ) {
 		$journal_store = self::get( $user_id, $course_id );
 
-		return isset( $journal_store->providers_journal[ $provider_id ] ) ? $journal_store->providers_journal[ $provider_id ]->get_logs() : [];
+		return isset( $journal_store->providers_journal[ $provider->get_id() ] ) ? $journal_store->providers_journal[ $provider->get_id() ]->get_logs() : [];
 	}
 }

--- a/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
@@ -1,0 +1,271 @@
+<?php
+/**
+ * File containing the class Sensei_Enrolment_Provider_Journal_Store.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * This class is responsible for storing provider metadata like logs and status history.
+ */
+class Sensei_Enrolment_Provider_Journal_Store implements JsonSerializable {
+	const META_PREFIX_ENROLMENT_PROVIDERS_JOURNAL = 'sensei_enrolment_providers_journal_';
+
+	/**
+	 * Flag for if a state the store has changed.
+	 *
+	 * @var bool
+	 */
+	private $has_changed = false;
+
+	/**
+	 * Journal objects for the providers.
+	 *
+	 * @var Sensei_Enrolment_Provider_Journal[]
+	 */
+	private $providers_journal;
+
+	/**
+	 * User ID that this store is used for.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * Course post ID that this store is used for.
+	 *
+	 * @var int
+	 */
+	private $course_id;
+
+	/**
+	 * Keeps track of instances of this class.
+	 *
+	 * @var self[][]
+	 */
+	private static $instances = [];
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param int $user_id   User ID.
+	 * @param int $course_id Course post ID.
+	 */
+	private function __construct( $user_id, $course_id ) {
+		$this->user_id           = $user_id;
+		$this->course_id         = $course_id;
+		$this->providers_journal = [];
+	}
+
+	/**
+	 * Get a journal store record for a user/course.
+	 *
+	 * @param int $user_id   User ID.
+	 * @param int $course_id Course post ID.
+	 *
+	 * @return self
+	 */
+	private static function get( $user_id, $course_id ) {
+		if ( ! isset( self::$instances[ $user_id ] ) ) {
+			self::$instances[ $user_id ] = [];
+		}
+
+		if ( ! isset( self::$instances[ $user_id ][ $course_id ] ) ) {
+			self::$instances[ $user_id ][ $course_id ] = new self( $user_id, $course_id );
+
+			$provider_journal_stores = get_user_meta( $user_id, self::get_providers_meta_key( $course_id ), true );
+			if ( ! empty( $provider_journal_stores ) ) {
+				self::$instances[ $user_id ][ $course_id ]->restore_from_json( $provider_journal_stores );
+			}
+		}
+
+		return self::$instances[ $user_id ][ $course_id ];
+	}
+
+	/**
+	 * Restore a provider journal store from a serialized JSON string.
+	 *
+	 * @param string $json_string JSON representation of enrolment state.
+	 */
+	private function restore_from_json( $json_string ) {
+		$json_arr = json_decode( $json_string, true );
+
+		if ( ! $json_arr ) {
+			return;
+		}
+
+		foreach ( $json_arr as $provider_id => $provider_journal_data ) {
+			$provider_journal = Sensei_Enrolment_Provider_Journal::from_serialized_array( $provider_journal_data );
+
+			if ( $provider_journal ) {
+				$this->providers_journal[ $provider_id ] = $provider_journal;
+			}
+		}
+	}
+
+	/**
+	 * Return object that can be serialized by `json_encode()`.
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		return $this->providers_journal;
+	}
+
+	/**
+	 * Persist this store.
+	 *
+	 * @return bool
+	 */
+	public function save() {
+		if ( ! $this->has_changed ) {
+			return true;
+		}
+
+		$result = update_user_meta( $this->user_id, self::get_providers_meta_key( $this->course_id ), wp_slash( wp_json_encode( $this ) ) );
+
+		if ( ! $result || is_wp_error( $result ) ) {
+			return false;
+		}
+
+		$this->has_changed = false;
+
+		return true;
+	}
+
+	/**
+	 * Save all stores that need it.
+	 *
+	 * As this isn't a singleton, Sensei_Course_Enrolment_Manager hooks this into `shutdown` in its `init` method.
+	 */
+	public static function persist_all() {
+		foreach ( self::$instances as $user_id => $course_instances ) {
+			foreach ( $course_instances as $instance ) {
+				$instance->save();
+			}
+		}
+	}
+
+	/**
+	 * Get the journal store user meta key.
+	 *
+	 * @param int $course_id Course post ID.
+	 *
+	 * @return string
+	 */
+	private static function get_providers_meta_key( $course_id ) {
+		return self::META_PREFIX_ENROLMENT_PROVIDERS_JOURNAL . $course_id;
+	}
+
+	/**
+	 * Register a possible update in the status of a provider for a user and a course. If there was no actual change on
+	 * the status, this method has no effect.
+	 *
+	 * @param array $provider_results An array with the format 'provider_id' => enrollment result.
+	 * @param int   $user_id          The user which the change applies to.
+	 * @param int   $course_id        The course which the change applies to.
+	 */
+	public static function register_possible_enrolment_change( $provider_results, $user_id, $course_id ) {
+		$journal_store = self::get( $user_id, $course_id );
+
+		$has_changed = false;
+
+		foreach ( $provider_results as $provider_id => $is_enrolled ) {
+			if ( ! isset( $journal_store->providers_journal[ $provider_id ] ) ) {
+				$journal_store->providers_journal[ $provider_id ] = Sensei_Enrolment_Provider_Journal::create();
+			}
+
+			$has_changed = $journal_store->providers_journal[ $provider_id ]->update_enrolment_status( $is_enrolled ) || $has_changed;
+		}
+
+		$current_snapshot = self::get_enrolment_snanpshot( $user_id, $course_id );
+
+		$removed_providers = array_diff( array_keys( $current_snapshot ), array_keys( $provider_results ) );
+		foreach ( $removed_providers as $removed_provider ) {
+			$has_changed = $journal_store->providers_journal[ $removed_provider ]->delete_enrolment_status() || $has_changed;
+		}
+
+		$journal_store->has_changed = $has_changed;
+	}
+
+	/**
+	 * Get a snapshot of the providers' enrolment status for a user and course at a specific timestamp. If no timestamp
+	 * is provided the current snapshot is returned.
+	 *
+	 * @param int $user_id     The user to return the snapshot for.
+	 * @param int $course_id   The course to return the snapshot for.
+	 * @param int $timestamp   The timestamp of the snapshot. If omitted the current snapshot is returned.
+	 *
+	 * @return array
+	 */
+	public static function get_enrolment_snanpshot( $user_id, $course_id, $timestamp = null ) {
+		$timestamp     = null === $timestamp ? time() : $timestamp;
+		$journal_store = self::get( $user_id, $course_id );
+
+		$snapshot = [];
+		foreach ( $journal_store->providers_journal as $provider_id => $journal ) {
+			$status = $journal->get_status_at( $timestamp );
+
+			if ( null !== $status['enrolment_status'] ) {
+				$snapshot[ $provider_id ] = $status['enrolment_status'];
+			}
+		}
+
+		return $snapshot;
+	}
+
+	/**
+	 * Get the enrolment status history of a provider for a specified user and course.
+	 *
+	 * @param int $user_id     The user id.
+	 * @param int $course_id   The course id.
+	 * @param int $provider_id The provider id.
+	 *
+	 * @return array The history of the provider. Each element of the array has the format:
+	 *               [ 'timestamp' => Timestamp of the status change, 'enrolment_status' => true|false|null ]
+	 */
+	public static function get_provider_history( $user_id, $course_id, $provider_id ) {
+		$journal_store = self::get( $user_id, $course_id );
+
+		return isset( $journal_store->providers_journal[ $provider_id ] ) ? $journal_store->providers_journal[ $provider_id ]->get_history() : [];
+	}
+
+	/**
+	 * Add a log message to a provider.
+	 *
+	 * @param int    $user_id     The user id.
+	 * @param int    $course_id   The course id.
+	 * @param int    $provider_id The provider id.
+	 * @param string $message     The message to be added.
+	 */
+	public static function add_provider_log_message( $user_id, $course_id, $provider_id, $message ) {
+		$journal_store = self::get( $user_id, $course_id );
+
+		if ( ! isset( $journal_store->providers_journal[ $provider_id ] ) ) {
+			$journal_store->providers_journal[ $provider_id ] = Sensei_Enrolment_Provider_Journal::create();
+		}
+
+		$journal_store->providers_journal[ $provider_id ]->add_log_message( $message );
+	}
+
+	/**
+	 * Get the log messages of a provider.
+	 *
+	 * @param int $user_id     The user id.
+	 * @param int $course_id   The course id.
+	 * @param int $provider_id The provider id.
+	 *
+	 * @return array The message log of the provider. Each element of the array has the format:
+	 *               [ 'timestamp' => Timestamp of the message, 'message' => The actual message ]
+	 */
+	public static function get_provider_logs( $user_id, $course_id, $provider_id ) {
+		$journal_store = self::get( $user_id, $course_id );
+
+		return isset( $journal_store->providers_journal[ $provider_id ] ) ? $journal_store->providers_journal[ $provider_id ]->get_logs() : [];
+	}
+}

--- a/includes/enrolment/class-sensei-enrolment-provider-journal.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal.php
@@ -95,6 +95,10 @@ class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
 			return false;
 		}
 
+		if ( ! isset( $log_entry['t'], $log_entry['m'] ) ) {
+			return false;
+		}
+
 		return [
 			'timestamp' => (int) $log_entry['t'],
 			'message'   => sanitize_text_field( $log_entry['m'] ),
@@ -178,7 +182,7 @@ class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
 		$message_log_size = apply_filters( 'sensei_enrolment_message_log_size', self::DEFAULT_MESSAGE_LOG_SIZE );
 
 		$message_entry = [
-			'timestamp' => time(),
+			'timestamp' => microtime( true ),
 			'message'   => sanitize_text_field( $message ),
 		];
 		array_unshift( $this->message_log, $message_entry );
@@ -197,7 +201,7 @@ class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
 		if ( empty( $this->history ) || $this->history[0]['enrolment_status'] !== $enrolment_status ) {
 			$this->add_status(
 				[
-					'timestamp'        => time(),
+					'timestamp'        => microtime( true ),
 					'enrolment_status' => $enrolment_status,
 				]
 			);
@@ -214,10 +218,10 @@ class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
 	 * @return bool True if there was a deletion, false otherwise.
 	 */
 	public function delete_enrolment_status() {
-		if ( ! empty( $this->history ) ) {
+		if ( ! empty( $this->history ) && null !== $this->history[0]['enrolment_status'] ) {
 			$this->add_status(
 				[
-					'timestamp'        => time(),
+					'timestamp'        => microtime( true ),
 					'enrolment_status' => null,
 				]
 			);

--- a/includes/enrolment/class-sensei-enrolment-provider-journal.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal.php
@@ -133,10 +133,17 @@ class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
 		$history     = array_map( [ __CLASS__, 'serialize_history_entry' ], $this->history );
 		$message_log = array_map( [ __CLASS__, 'serialize_log_entry' ], $this->message_log );
 
-		return [
-			'h' => $history,
-			'l' => $message_log,
-		];
+		$result = [];
+
+		if ( ! empty( $history ) ) {
+			$result['h'] = $history;
+		}
+
+		if ( ! empty( $message_log ) ) {
+			$result['l'] = $message_log;
+		}
+
+		return $result;
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-enrolment-provider-journal.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal.php
@@ -1,0 +1,288 @@
+<?php
+/**
+ * File containing the class Sensei_Enrolment_Provider_Journal.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * This class represents a journal for a single provider.
+ */
+class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
+	const DEFAULT_HISTORY_SIZE     = 30;
+	const DEFAULT_MESSAGE_LOG_SIZE = 30;
+
+	/**
+	 * The history of the provider's status. A null enrolment status marks a deletion of a provider. Each element of
+	 * the array has the format:
+	 *     [
+	 *         'timestamp' => Timestamp of the status change,
+	 *          'enrolment_status' => true|false|null
+	 *     ]
+	 *
+	 * @var array
+	 */
+	private $history;
+
+
+	/**
+	 * The message log of the provider. Each element of the array has the format:
+	 *     [
+	 *         'timestamp' => Timestamp of the message,
+	 *          'message' => The actual message
+	 *     ]
+	 *
+	 * @var array
+	 */
+	private $message_log;
+
+	/**
+	 * Class constructor.
+	 *
+	 * @param array $history     The status history.
+	 * @param array $message_log The message log.
+	 */
+	private function __construct( $history, $message_log ) {
+		$this->history     = $history;
+		$this->message_log = $message_log;
+	}
+
+	/**
+	 * Restore a journal from a JSON string.
+	 *
+	 * @param array $data Serialized state of object.
+	 *
+	 * @return self|false
+	 */
+	public static function from_serialized_array( $data ) {
+
+		if ( empty( $data ) ) {
+			return false;
+		}
+
+		$history     = isset( $data['h'] ) ? array_filter( array_map( [ __CLASS__, 'deserialize_history_entry' ], $data['h'] ) ) : [];
+		$message_log = isset( $data['l'] ) ? array_filter( array_map( [ __CLASS__, 'deserialize_log_entry' ], $data['l'] ) ) : [];
+
+		return new self( $history, $message_log );
+	}
+
+	/**
+	 * Create an empty journal.
+	 *
+	 * @return self
+	 */
+	public static function create() {
+		return new self( [], [] );
+	}
+
+	/**
+	 * Sanitize a log entry.
+	 *
+	 * @param  array $log_entry Non-sanitized log entry.
+	 *
+	 * @return array
+	 */
+	private static function deserialize_log_entry( $log_entry ) {
+		if ( ! is_array( $log_entry ) ) {
+			return false;
+		}
+
+		if ( 2 !== count( $log_entry ) ) {
+			return false;
+		}
+
+		return [
+			'timestamp' => (int) $log_entry['t'],
+			'message'   => sanitize_text_field( $log_entry['m'] ),
+		];
+	}
+
+	/**
+	 * Helper method to deserialize a history entry.
+	 *
+	 * @param array $entry The serialized history entry.
+	 *
+	 * @return array|bool
+	 */
+	private static function deserialize_history_entry( $entry ) {
+		if ( ! isset( $entry['t'], $entry['s'] ) ) {
+			return false;
+		}
+
+		return [
+			'timestamp'        => (int) $entry['t'],
+			'enrolment_status' => (bool) $entry['s'],
+		];
+	}
+
+	/**
+	 * Return object that can be serialized by `json_encode()`.
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		$history     = array_map( [ __CLASS__, 'serialize_history_entry' ], $this->history );
+		$message_log = array_map( [ __CLASS__, 'serialize_log_entry' ], $this->message_log );
+
+		return [
+			'h' => $history,
+			'l' => $message_log,
+		];
+	}
+
+	/**
+	 * Helper method to serialize a history entry.
+	 *
+	 * @param array $entry The deserialized history entry.
+	 *
+	 * @return array
+	 */
+	private function serialize_history_entry( $entry ) {
+		return [
+			't' => $entry['timestamp'],
+			's' => $entry['enrolment_status'],
+		];
+	}
+
+	/**
+	 * Helper method to serialize a message log entry.
+	 *
+	 * @param array $entry The serialized log entry.
+	 *
+	 * @return array
+	 */
+	private function serialize_log_entry( $entry ) {
+		return [
+			't' => $entry['timestamp'],
+			'm' => $entry['message'],
+		];
+	}
+
+	/**
+	 * Adds a message to the log.
+	 *
+	 * @param string $message The message.
+	 */
+	public function add_log_message( $message ) {
+		/**
+		 * Filter the maximum amount of log messages that are going to be stored for each user, course and provider.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param int  $message_log_size Default message log size.
+		 */
+		$message_log_size = apply_filters( 'sensei_enrolment_message_log_size', self::DEFAULT_MESSAGE_LOG_SIZE );
+
+		$message_entry = [
+			'timestamp' => time(),
+			'message'   => sanitize_text_field( $message ),
+		];
+		array_unshift( $this->message_log, $message_entry );
+		array_splice( $this->message_log, $message_log_size );
+	}
+
+	/**
+	 * Update the current enrolment status. If the status is not changed, this method has no effect.
+	 *
+	 * @param bool $enrolment_status The enrolment status.
+	 *
+	 * @return bool True if there was an update, false otherwise.
+	 */
+	public function update_enrolment_status( $enrolment_status ) {
+
+		if ( empty( $this->history ) || $this->history[0]['enrolment_status'] !== $enrolment_status ) {
+			$this->add_status(
+				[
+					'timestamp'        => time(),
+					'enrolment_status' => $enrolment_status,
+				]
+			);
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Delete the enrolment status. A deleted enrolment status is marked by null.
+	 *
+	 * @return bool True if there was a deletion, false otherwise.
+	 */
+	public function delete_enrolment_status() {
+		if ( ! empty( $this->history ) ) {
+			$this->add_status(
+				[
+					'timestamp'        => time(),
+					'enrolment_status' => null,
+				]
+			);
+
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the enrolment status at a specified timestamp.
+	 *
+	 * @param int $timestamp The timestamp to retrieve the status for.
+	 *
+	 * @return array The historical status entry.
+	 */
+	public function get_status_at( $timestamp ) {
+
+		foreach ( $this->history as $status ) {
+			if ( $status['timestamp'] <= $timestamp ) {
+				return $status;
+			}
+		}
+
+		return [
+			'timestamp'        => $timestamp,
+			'enrolment_status' => null,
+		];
+	}
+
+	/**
+	 * Get the status history.
+	 *
+	 * @return array
+	 */
+	public function get_history() {
+		return $this->history;
+	}
+
+	/**
+	 * Get the message log.
+	 *
+	 * @return array
+	 */
+	public function get_logs() {
+		return $this->message_log;
+	}
+
+	/**
+	 * Helper method to add a status entry to the history.
+	 *
+	 * @param array $status The history entry.
+	 */
+	private function add_status( $status ) {
+		/**
+		 * Filter the maximum amount of historical entries that are going to be stored for each user, course and provider.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param int  $history_size Default history size.
+		 */
+		$history_size = apply_filters( 'sensei_enrolment_history_size', self::DEFAULT_HISTORY_SIZE );
+
+		array_unshift( $this->history, $status );
+		array_splice( $this->history, $history_size );
+	}
+}

--- a/includes/enrolment/class-sensei-enrolment-provider-journal.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal.php
@@ -113,13 +113,13 @@ class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
 	 * @return array|bool
 	 */
 	private static function deserialize_history_entry( $entry ) {
-		if ( ! isset( $entry['t'], $entry['s'] ) ) {
+		if ( ! isset( $entry['t'] ) || ! array_key_exists( 's', $entry ) ) {
 			return false;
 		}
 
 		return [
-			'timestamp'        => (int) $entry['t'],
-			'enrolment_status' => (bool) $entry['s'],
+			'timestamp'        => (float) $entry['t'],
+			'enrolment_status' => null === $entry['s'] ? null : (bool) $entry['s'],
 		];
 	}
 
@@ -182,7 +182,7 @@ class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
 		$message_log_size = apply_filters( 'sensei_enrolment_message_log_size', self::DEFAULT_MESSAGE_LOG_SIZE );
 
 		$message_entry = [
-			'timestamp' => microtime( true ),
+			'timestamp' => time(),
 			'message'   => sanitize_text_field( $message ),
 		];
 		array_unshift( $this->message_log, $message_entry );
@@ -242,7 +242,7 @@ class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
 	public function get_status_at( $timestamp ) {
 
 		foreach ( $this->history as $status ) {
-			if ( $status['timestamp'] <= $timestamp ) {
+			if ( $status['timestamp'] < $timestamp || abs( $status['timestamp'] - $timestamp ) < 0.001 ) {
 				return $status;
 			}
 		}

--- a/includes/enrolment/class-sensei-enrolment-provider-journal.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal.php
@@ -13,8 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This class represents a journal for a single provider.
  */
 class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
-	const DEFAULT_HISTORY_SIZE     = 30;
-	const DEFAULT_MESSAGE_LOG_SIZE = 30;
+	const DEFAULT_HISTORY_SIZE        = 30;
+	const DEFAULT_MESSAGE_LOG_SIZE    = 30;
+	const HISTORY_TIMESTAMP_PRECISION = 0.001;
 
 	/**
 	 * The history of the provider's status. A null enrolment status marks a deletion of a provider. Each element of
@@ -242,7 +243,7 @@ class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
 	public function get_status_at( $timestamp ) {
 
 		foreach ( $this->history as $status ) {
-			if ( $status['timestamp'] < $timestamp || abs( $status['timestamp'] - $timestamp ) < 0.001 ) {
+			if ( $status['timestamp'] < $timestamp || abs( $status['timestamp'] - $timestamp ) < self::HISTORY_TIMESTAMP_PRECISION ) {
 				return $status;
 			}
 		}

--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -57,6 +57,15 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 	}
 
 	/**
+	 * Resets the journal stores.
+	 */
+	private static function resetEnrolmentJournalStores() {
+		$state_store_instances = new ReflectionProperty( Sensei_Enrolment_Provider_Journal_Store::class, 'instances' );
+		$state_store_instances->setAccessible( true );
+		$state_store_instances->setValue( [] );
+	}
+
+	/**
 	 * Gets a simple course ID.
 	 *
 	 * @return int

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
@@ -238,7 +238,6 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 				}
 			}';
 
-
 		$method = new ReflectionMethod( $journal_store, 'restore_from_json' );
 		$method->setAccessible( true );
 		$method->invoke( $journal_store, $journal_json );

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
@@ -116,33 +116,36 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 		$course = $this->factory->course->create();
 		$user   = $this->factory->user->create();
 		$this->enableJournal();
+		$manual_provider = Sensei_Course_Manual_Enrolment_Provider::instance();
+		$never_provides  = new Sensei_Test_Enrolment_Provider_Never_Provides();
+		$denies_crooks   = new Sensei_Test_Enrolment_Provider_Denies_Crooks();
 
 		$provider_results = [
-			'manual'      => true,
-			'simple'      => false,
-			'memberships' => false,
+			'manual'         => true,
+			'never-provides' => false,
+			'denies-crooks'  => false,
 		];
 
 		Sensei_Enrolment_Provider_Journal_Store::register_possible_enrolment_change( $provider_results, $user, $course );
 		Sensei_Enrolment_Provider_Journal_Store::register_possible_enrolment_change( $provider_results, $user, $course );
 
 		$provider_results = [
-			'manual' => false,
-			'simple' => false,
+			'manual'         => false,
+			'never-provides' => false,
 		];
 
 		Sensei_Enrolment_Provider_Journal_Store::register_possible_enrolment_change( $provider_results, $user, $course );
 
-		$manual_history = Sensei_Enrolment_Provider_Journal_Store::get_provider_history( $user, $course, 'manual' );
+		$manual_history = Sensei_Enrolment_Provider_Journal_Store::get_provider_history( $manual_provider, $user, $course );
 		$this->assertCount( 2, $manual_history, 'There should be 2 changes in manual provider status.' );
 		$this->assertFalse( $manual_history[0]['enrolment_status'], 'The current status should be false.' );
 		$this->assertTrue( $manual_history[1]['enrolment_status'], 'The previous status should be true.' );
 
-		$simple_history = Sensei_Enrolment_Provider_Journal_Store::get_provider_history( $user, $course, 'simple' );
+		$simple_history = Sensei_Enrolment_Provider_Journal_Store::get_provider_history( $never_provides, $user, $course );
 		$this->assertCount( 1, $simple_history, 'There should be 1 change in simple provider status.' );
 		$this->assertFalse( $simple_history[0]['enrolment_status'], 'The current status should be false.' );
 
-		$memberships_history = Sensei_Enrolment_Provider_Journal_Store::get_provider_history( $user, $course, 'memberships' );
+		$memberships_history = Sensei_Enrolment_Provider_Journal_Store::get_provider_history( $denies_crooks, $user, $course );
 		$this->assertCount( 2, $memberships_history, 'There should be 2 changes in memberships provider status.' );
 		$this->assertNull( $memberships_history[0]['enrolment_status'], 'The current status should be deleted.' );
 		$this->assertFalse( $memberships_history[1]['enrolment_status'], 'The previous status should be false.' );

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
@@ -197,7 +197,7 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 
 	private function enableJournal() {
 		tests_add_filter(
-			'sensei_enable_journal',
+			'sensei_enable_enrolment_provider_journal',
 			function () {
 				return true;
 			}

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
@@ -1,0 +1,206 @@
+<?php
+
+/**
+ * Tests for Sensei_Enrolment_Provider_Journal_Store class.
+ *
+ * @group course-enrolment
+ *
+ * @property Sensei_Factory $factory
+ */
+class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
+	use Sensei_Course_Enrolment_Test_Helpers;
+
+
+	/**
+	 * Setup function.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+
+		self::resetEnrolmentJournalStores();
+		self::resetEnrolmentProviders();
+	}
+
+	/**
+	 * Clean up after all tests.
+	 */
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+
+		self::resetEnrolmentJournalStores();
+		self::resetEnrolmentProviders();
+	}
+
+	/**
+	 * Tests that nothing is stored when the journal is disabled.
+	 */
+	public function testEnableJournalFilter() {
+		$course   = $this->factory->course->create();
+		$user     = $this->factory->user->create();
+		$provider = new Sensei_Test_Enrolment_Provider_Always_Provides();
+
+		Sensei_Enrolment_Provider_Journal_Store::add_provider_log_message( $user, $course, $provider->get_id(), 'Test message' );
+		Sensei_Enrolment_Provider_Journal_Store::persist_all();
+
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_PREFIX_ENROLMENT_PROVIDERS_JOURNAL . $course );
+		$this->assertEmpty( $user_meta, 'Nothing should be stored with the filter returning false.' );
+
+		$this->enableJournal();
+		Sensei_Enrolment_Provider_Journal_Store::persist_all();
+
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_PREFIX_ENROLMENT_PROVIDERS_JOURNAL . $course );
+		$this->assertNotEmpty( $user_meta, 'Meta should be stored with the filter returning true.' );
+	}
+
+	/**
+	 * Tests to make sure that messages are stored in the db correctly.
+	 */
+	public function testMessagesAreStored() {
+		$course   = $this->factory->course->create();
+		$user     = $this->factory->user->create();
+		$provider = new Sensei_Test_Enrolment_Provider_Always_Provides();
+		$this->enableJournal();
+
+		Sensei_Enrolment_Provider_Journal_Store::add_provider_log_message( $user, $course, $provider->get_id(), 'First message' );
+		Sensei_Enrolment_Provider_Journal_Store::add_provider_log_message( $user, $course, $provider->get_id(), 'Second message' );
+		Sensei_Enrolment_Provider_Journal_Store::persist_all();
+
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_PREFIX_ENROLMENT_PROVIDERS_JOURNAL . $course, true );
+		$this->assertRegExp( '/.*always-provides.*Second message.*First message/', $user_meta, 'A meta with the provider id and the two messages should be stored.' );
+
+		$logs = Sensei_Enrolment_Provider_Journal_Store::get_provider_logs( $user, $course, $provider->get_id() );
+		$this->assertCount( 2, $logs, 'There should be exactly 2 messages in the logs' );
+		$this->assertEquals( 'Second message', $logs[0]['message'], 'The second message should be in the beginning of the log.' );
+		$this->assertEquals( 'First message', $logs[1]['message'], 'The first message should be in the end of the log.' );
+	}
+
+	/**
+	 * Tests that the provider enrolment status is stored correctly.
+	 */
+	public function testEnrolmentHistoryIsStored() {
+		$course = $this->factory->course->create();
+		$user   = $this->factory->user->create();
+		$this->enableJournal();
+
+		$provider_results = [
+			'manual' => true,
+			'simple' => false,
+		];
+
+		Sensei_Enrolment_Provider_Journal_Store::register_possible_enrolment_change( $provider_results, $user, $course );
+		Sensei_Enrolment_Provider_Journal_Store::persist_all();
+
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_PREFIX_ENROLMENT_PROVIDERS_JOURNAL . $course, true );
+		$this->assertRegExp( '/.*manual.*s.*true/', $user_meta, 'Manual provider status should be true' );
+		$this->assertRegExp( '/.*simple.*s.*false/', $user_meta, 'Simple provider status should be true' );
+
+		$provider_results = [
+			'manual' => false,
+			'simple' => true,
+		];
+
+		Sensei_Enrolment_Provider_Journal_Store::register_possible_enrolment_change( $provider_results, $user, $course );
+		Sensei_Enrolment_Provider_Journal_Store::persist_all();
+
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_PREFIX_ENROLMENT_PROVIDERS_JOURNAL . $course, true );
+		$this->assertRegExp( '/.*manual.*s.*false.*s.*true/', $user_meta, 'Manual provider status should be initially true then false' );
+		$this->assertRegExp( '/.*simple.*s.*true.*s.*false/', $user_meta, 'Simple provider status should be initially false then true' );
+	}
+
+	/**
+	 * Tests that only the changes are stored in enrolment history.
+	 */
+	public function testOnlyChangesAreStoredInHistory() {
+		$course = $this->factory->course->create();
+		$user   = $this->factory->user->create();
+		$this->enableJournal();
+
+		$provider_results = [
+			'manual'      => true,
+			'simple'      => false,
+			'memberships' => false,
+		];
+
+		Sensei_Enrolment_Provider_Journal_Store::register_possible_enrolment_change( $provider_results, $user, $course );
+		Sensei_Enrolment_Provider_Journal_Store::register_possible_enrolment_change( $provider_results, $user, $course );
+
+		$provider_results = [
+			'manual' => false,
+			'simple' => false,
+		];
+
+		Sensei_Enrolment_Provider_Journal_Store::register_possible_enrolment_change( $provider_results, $user, $course );
+
+		$manual_history = Sensei_Enrolment_Provider_Journal_Store::get_provider_history( $user, $course, 'manual' );
+		$this->assertCount( 2, $manual_history, 'There should be 2 changes in manual provider status.' );
+		$this->assertFalse( $manual_history[0]['enrolment_status'], 'The current status should be false.' );
+		$this->assertTrue( $manual_history[1]['enrolment_status'], 'The previous status should be true.' );
+
+		$simple_history = Sensei_Enrolment_Provider_Journal_Store::get_provider_history( $user, $course, 'simple' );
+		$this->assertCount( 1, $simple_history, 'There should be 1 change in simple provider status.' );
+		$this->assertFalse( $simple_history[0]['enrolment_status'], 'The current status should be false.' );
+
+		$memberships_history = Sensei_Enrolment_Provider_Journal_Store::get_provider_history( $user, $course, 'memberships' );
+		$this->assertCount( 2, $memberships_history, 'There should be 2 changes in memberships provider status.' );
+		$this->assertNull( $memberships_history[0]['enrolment_status'], 'The current status should be deleted.' );
+		$this->assertFalse( $memberships_history[1]['enrolment_status'], 'The previous status should be false.' );
+	}
+
+	/**
+	 * Tests that Sensei_Enrolment_Provider_Journal_Store::get_enrolment_snanpshot returns correct snapshots.
+	 */
+	public function testHistorySnapshotsWithDeletions() {
+		$course = $this->factory->course->create();
+		$user   = $this->factory->user->create();
+		$this->enableJournal();
+
+		$provider_results = [
+			'manual' => true,
+			'simple' => false,
+		];
+
+		Sensei_Enrolment_Provider_Journal_Store::register_possible_enrolment_change( $provider_results, $user, $course );
+		$after_first_change = microtime( true );
+		usleep( 1000 );
+
+		$provider_results = [
+			'memberships' => false,
+		];
+
+		Sensei_Enrolment_Provider_Journal_Store::register_possible_enrolment_change( $provider_results, $user, $course );
+		$after_second_change = microtime( true );
+		usleep( 1000 );
+
+		$provider_results = [
+			'manual'      => false,
+			'memberships' => true,
+		];
+
+		Sensei_Enrolment_Provider_Journal_Store::register_possible_enrolment_change( $provider_results, $user, $course );
+
+		$first_change_snapshot = Sensei_Enrolment_Provider_Journal_Store::get_enrolment_snanpshot( $user, $course, $after_first_change );
+		$this->assertCount( 2, $first_change_snapshot, 'There should be 2 providers in the snapshot.' );
+		$this->assertTrue( $first_change_snapshot['manual'], 'The manual provider status should be true.' );
+		$this->assertFalse( $first_change_snapshot['simple'], 'The simple provider status should be false.' );
+
+		$second_change_snapshot = Sensei_Enrolment_Provider_Journal_Store::get_enrolment_snanpshot( $user, $course, $after_second_change );
+		$this->assertCount( 1, $second_change_snapshot, 'There should be 1 provider in the snapshot.' );
+		$this->assertFalse( $second_change_snapshot['memberships'], 'The memberships provider status should be false.' );
+
+		$current_snapshot = Sensei_Enrolment_Provider_Journal_Store::get_enrolment_snanpshot( $user, $course );
+		$this->assertCount( 2, $current_snapshot, 'There should be 2 providers in the snapshot.' );
+		$this->assertTrue( $current_snapshot['memberships'], 'The memberships provider status should be true.' );
+		$this->assertFalse( $current_snapshot['manual'], 'The manual provider status should be false.' );
+	}
+
+	private function enableJournal() {
+		tests_add_filter(
+			'sensei_enable_journal',
+			function () {
+				return true;
+			}
+		);
+	}
+}

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
@@ -41,7 +41,7 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 		$user     = $this->factory->user->create();
 		$provider = new Sensei_Test_Enrolment_Provider_Always_Provides();
 
-		Sensei_Enrolment_Provider_Journal_Store::add_provider_log_message( $user, $course, $provider->get_id(), 'Test message' );
+		Sensei_Enrolment_Provider_Journal_Store::add_provider_log_message( $provider, $user, $course, 'Test message' );
 		Sensei_Enrolment_Provider_Journal_Store::persist_all();
 
 		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_PREFIX_ENROLMENT_PROVIDERS_JOURNAL . $course );
@@ -63,14 +63,14 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 		$provider = new Sensei_Test_Enrolment_Provider_Always_Provides();
 		$this->enableJournal();
 
-		Sensei_Enrolment_Provider_Journal_Store::add_provider_log_message( $user, $course, $provider->get_id(), 'First message' );
-		Sensei_Enrolment_Provider_Journal_Store::add_provider_log_message( $user, $course, $provider->get_id(), 'Second message' );
+		Sensei_Enrolment_Provider_Journal_Store::add_provider_log_message( $provider, $user, $course, 'First message' );
+		Sensei_Enrolment_Provider_Journal_Store::add_provider_log_message( $provider, $user, $course, 'Second message' );
 		Sensei_Enrolment_Provider_Journal_Store::persist_all();
 
 		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_PREFIX_ENROLMENT_PROVIDERS_JOURNAL . $course, true );
 		$this->assertRegExp( '/.*always-provides.*Second message.*First message/', $user_meta, 'A meta with the provider id and the two messages should be stored.' );
 
-		$logs = Sensei_Enrolment_Provider_Journal_Store::get_provider_logs( $user, $course, $provider->get_id() );
+		$logs = Sensei_Enrolment_Provider_Journal_Store::get_provider_logs( $provider, $user, $course );
 		$this->assertCount( 2, $logs, 'There should be exactly 2 messages in the logs' );
 		$this->assertEquals( 'Second message', $logs[0]['message'], 'The second message should be in the beginning of the log.' );
 		$this->assertEquals( 'First message', $logs[1]['message'], 'The first message should be in the end of the log.' );

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal.php
@@ -1,0 +1,186 @@
+<?php
+
+/**
+ * Tests for Sensei_Enrolment_Provider_Journal class.
+ *
+ * @group course-enrolment
+ */
+class Sensei_Enrolment_Provider_Journal_Test extends WP_UnitTestCase {
+
+
+	/**
+	 * Tests to make sure arrays of serialized data return an instantiated object.
+	 *
+	 * @dataProvider  serializedArrayProvider
+	 */
+	public function testFromSerializedArray( $input, $expected_history, $expected_log ) {
+
+		$result = Sensei_Enrolment_Provider_Journal::from_serialized_array( $input );
+
+		$this->assertInstanceOf( 'Sensei_Enrolment_Provider_Journal', $result, 'Serialized data should have returned a instantiated object' );
+		$this->assertCount( $expected_history, $result->get_history() );
+		$this->assertCount( $expected_log, $result->get_logs() );
+	}
+
+	public function serializedArrayProvider() {
+		return [
+			'history 2 elements, log empty' => [
+				[
+					'h' => [
+						[
+							't' => 1586350840,
+							's' => false,
+						],
+						[
+							't' => 1586350640,
+							's' => true,
+						],
+					],
+					'l' => [],
+				],
+				2,
+				0,
+			],
+			'history empty, log 2 elements' => [
+				[
+					'h' => [],
+					'l' => [
+						[
+							't' => 1586350840,
+							'm' => 'A log message',
+						],
+						[
+							't' => 1586350640,
+							'm' => 'Another message',
+						],
+					],
+				],
+				0,
+				2,
+			],
+			'history empty, log empty'      => [
+				[
+					'h' => [],
+					'l' => [],
+				],
+				0,
+				0,
+			],
+		];
+	}
+
+	/**
+	 * Tests to make sure invalid JSON strings return false.
+	 */
+	public function testFromSerializedEmptyArrayFails() {
+		$result = Sensei_Enrolment_Provider_Journal::from_serialized_array( [] );
+
+		$this->assertFalse( $result, 'Invalid serialized array should have returned false' );
+	}
+
+	/**
+	 * Tests to make sure a log message is added and the object is JSON serialized properly.
+	 */
+	public function testMessageAddedAndSerialized() {
+		$journal = Sensei_Enrolment_Provider_Journal::create();
+
+		$journal->add_log_message( 'Test message 1' );
+		$journal->add_log_message( 'Test message 2' );
+
+		$journal_array = json_decode( wp_json_encode( $journal ), true );
+
+		$this->assertEquals( 'Test message 2', $journal_array['l'][0]['m'], 'Second message should be the first in the log' );
+		$this->assertEquals( 'Test message 1', $journal_array['l'][1]['m'], 'First message should be the second in the log' );
+	}
+
+	/**
+	 * Tests to make sure that status is updated and the object is JSON serialized properly.
+	 */
+	public function testStatusUpdatedAndSerialized() {
+		$journal = Sensei_Enrolment_Provider_Journal::create();
+
+		$journal->update_enrolment_status( false );
+		$journal->update_enrolment_status( false );
+		$journal->update_enrolment_status( true );
+
+		$journal_array = json_decode( wp_json_encode( $journal ), true );
+
+		$this->assertCount( 2, $journal_array['h'], 'There should be 2 status updates in history.' );
+		$this->assertTrue( $journal_array['h'][0]['s'], 'The current status should be true.' );
+		$this->assertFalse( $journal_array['h'][1]['s'], 'The previous status should be false.' );
+	}
+
+	/**
+	 * Tests to make sure that status is deleted and the object is JSON serialized properly.
+	 */
+	public function testStatusDeletedAndSerialized() {
+		$journal = Sensei_Enrolment_Provider_Journal::create();
+
+		$journal->delete_enrolment_status();
+
+		$journal_array = json_decode( wp_json_encode( $journal ), true );
+
+		$this->assertCount( 0, $journal_array['h'], 'Deletion on an empty history should have no effect.' );
+
+		$journal->update_enrolment_status( false );
+		$journal->delete_enrolment_status();
+		$journal->delete_enrolment_status();
+
+		$journal_array = json_decode( wp_json_encode( $journal ), true );
+
+		$this->assertCount( 2, $journal_array['h'], 'Deleting an already deleted status should have no effect.' );
+		$this->assertNull( $journal_array['h'][0]['s'], 'The current status should be deleted.' );
+		$this->assertFalse( $journal_array['h'][1]['s'], 'The previous status should be false.' );
+	}
+
+	/**
+	 * Tests to make sure that status is returned when requested by timestamp.
+	 */
+	public function testGetStatusWithTimestamp() {
+		$journal = Sensei_Enrolment_Provider_Journal::create();
+
+		$journal->update_enrolment_status( false );
+		$journal->update_enrolment_status( true );
+
+		$status = $journal->get_status_at( 1586361098 );
+
+		$this->assertNull( $status['enrolment_status'], 'Status with a very old timestamp should be null.' );
+
+		$status = $journal->get_status_at( microtime( true ) );
+
+		$this->assertTrue( $status['enrolment_status'], 'Current status should be true.' );
+	}
+
+	/**
+	 * Tests to make sure that a maximum number of entries are kept in history and message log.
+	 */
+	public function testHistoryAndLogIsLimited() {
+		$journal = Sensei_Enrolment_Provider_Journal::create();
+
+		tests_add_filter(
+			'sensei_enrolment_history_size',
+			function () {
+				return 3;
+			}
+		);
+
+		tests_add_filter(
+			'sensei_enrolment_message_log_size',
+			function () {
+				return 2;
+			}
+		);
+
+		$journal->update_enrolment_status( false );
+		$journal->update_enrolment_status( true );
+		$journal->update_enrolment_status( false );
+		$journal->update_enrolment_status( true );
+
+		$journal->add_log_message( 'Test message' );
+		$journal->add_log_message( 'Test message' );
+		$journal->add_log_message( 'Test message' );
+
+		$this->assertCount( 3, $journal->get_history(), 'The history size should have a maximum size of 3.' );
+		$this->assertCount( 2, $journal->get_logs(), 'The message log size should have a maximum size of 2.' );
+	}
+}

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal.php
@@ -120,7 +120,7 @@ class Sensei_Enrolment_Provider_Journal_Test extends WP_UnitTestCase {
 
 		$journal_array = json_decode( wp_json_encode( $journal ), true );
 
-		$this->assertCount( 0, $journal_array['h'], 'Deletion on an empty history should have no effect.' );
+		$this->assertArrayNotHasKey( 'h', $journal_array, 'Deletion on an empty history should have no effect.' );
 
 		$journal->update_enrolment_status( false );
 		$journal->delete_enrolment_status();


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

This PR introduces a separate user meta that is going to store a journal for each provider. It includes the functionality that was removed in #3021 and the changes proposed in #2997. 

Initially nothing will be stored in the database. The reason for the PR is to introduce the API and to be available during testing. To enable the functionality the `sensei_enable_journal` filter shoud return true.

The structure of the entry in the database is the following:
```
{
  "course_id: {
    "provider_id": {
      "history": [{
        "timestamp": <timestamp of the change in enrolment>,
        "enrolment_status": true|false|null
      }],
      "log": [{
        "timestamp": <timestamp of the message>,
        "log": "Log message"
      }]
    },
    "another_provider_id": {
      ....
    }
  }
}
```
* A null enrolment status is stored when a provider stops being responsible for the enrolment.
* The actual keys stored are one letter only to save space.

#### Testing instructions
There are no observable changes on the site. The only method that is used at the moment is `register_possible_enrolment_change` and nothing is stored in the database. To enable storing you should return true in `sensei_enable_journal` filter. The rest of the methods can be only verified through the automated tests.

Once the filter is enabled, perform changes to the enrolment of the user and observe that the `sensei_enrolment_providers_journal` entry is updated.