### PR TITLE
Allow for not storing enrolment results when they don't provide enrolment

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -326,7 +326,7 @@ class Sensei_Course_Enrolment {
 	}
 
 	/**
-	 * Store the enrolment results.
+	 * Store the enrolment results in user meta.
 	 *
 	 * @param int                                      $user_id           User ID.
 	 * @param Sensei_Course_Enrolment_Provider_Results $enrolment_results Enrolment results object.

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -328,8 +328,8 @@ class Sensei_Course_Enrolment {
 	/**
 	 * Store the enrolment results.
 	 *
-	 * @param int                                      $user_id
-	 * @param Sensei_Course_Enrolment_Provider_Results $enrolment_results
+	 * @param int                                      $user_id           User ID.
+	 * @param Sensei_Course_Enrolment_Provider_Results $enrolment_results Enrolment results object.
 	 */
 	private function store_enrolment_results( $user_id, Sensei_Course_Enrolment_Provider_Results $enrolment_results ) {
 		$results_meta_key =  $this->get_enrolment_results_meta_key();

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -38,6 +38,13 @@ class Sensei_Course_Enrolment {
 	private static $instances = [];
 
 	/**
+	 * Option for whether negative enrolment results should be stored.
+	 *
+	 * @var bool
+	 */
+	private static $store_negative_enrolment_results = true;
+
+	/**
 	 * Enrolment providers handling this particular course.
 	 *
 	 * @var Sensei_Course_Enrolment_Provider_Interface[]
@@ -301,7 +308,8 @@ class Sensei_Course_Enrolment {
 		}
 
 		$enrolment_results = new Sensei_Course_Enrolment_Provider_Results( $provider_results, $this->get_current_enrolment_result_version() );
-		update_user_meta( $user_id, $this->get_enrolment_results_meta_key(), wp_slash( wp_json_encode( $enrolment_results ) ) );
+
+		$this->store_enrolment_results( $user_id, $enrolment_results );
 
 		/**
 		 * Notify upon calculation of enrolment results.
@@ -315,6 +323,47 @@ class Sensei_Course_Enrolment {
 		do_action( 'sensei_enrolment_results_calculated', $enrolment_results, $this->course_id, $user_id );
 
 		return $enrolment_results;
+	}
+
+	/**
+	 * Store the enrolment results.
+	 *
+	 * @param int                                      $user_id
+	 * @param Sensei_Course_Enrolment_Provider_Results $enrolment_results
+	 */
+	private function store_enrolment_results( $user_id, Sensei_Course_Enrolment_Provider_Results $enrolment_results ) {
+		$results_meta_key =  $this->get_enrolment_results_meta_key();
+
+		$store_results      = true;
+		$had_existing_value = ! empty( get_user_meta( $user_id, $results_meta_key, true ) );
+
+		if (
+			! self::$store_negative_enrolment_results
+			&& ! $had_existing_value
+			&& ! $enrolment_results->is_enrolment_provided()
+		) {
+			// We're probably in a background request and we haven't already stored results.
+			$store_results = false;
+		}
+
+		/**
+		 * Filter on whether course enrolment results should be stored.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param bool                                     $store_results     Whether to store the results.
+		 * @param int                                      $course_id         Course post ID.
+		 * @param int                                      $user_id           User ID.
+		 * @param Sensei_Course_Enrolment_Provider_Results $enrolment_results Enrolment results object.
+		 */
+		$store_results = apply_filters( 'sensei_course_enrolment_store_results', $store_results, $user_id, $this->course_id, $enrolment_results );
+
+		if ( $store_results ) {
+			update_user_meta( $user_id, $results_meta_key, wp_slash( wp_json_encode( $enrolment_results ) ) );
+		} elseif ( $had_existing_value ) {
+			// This will only occur if the filter returns something other than the default.
+			delete_user_meta( $user_id, $results_meta_key );
+		}
 	}
 
 	/**
@@ -403,5 +452,14 @@ class Sensei_Course_Enrolment {
 		update_post_meta( $this->course_id, self::META_COURSE_ENROLMENT_VERSION, $new_salt );
 
 		return $new_salt;
+	}
+
+	/**
+	 * Set whether enrolment results user meta should be stored when enrolment is not provided.
+	 *
+	 * @param bool $store_negative_enrolment_results True if we should store negative enrolment results.
+	 */
+	public static function set_store_negative_enrolment_results( $store_negative_enrolment_results ) {
+		self::$store_negative_enrolment_results = $store_negative_enrolment_results;
 	}
 }

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -333,17 +333,10 @@ class Sensei_Course_Enrolment {
 	 */
 	private function store_enrolment_results( $user_id, Sensei_Course_Enrolment_Provider_Results $enrolment_results ) {
 		$results_meta_key   = $this->get_enrolment_results_meta_key();
-		$store_results      = true;
 		$had_existing_value = ! empty( get_user_meta( $user_id, $results_meta_key, true ) );
 
-		if (
-			! self::$store_negative_enrolment_results
-			&& ! $had_existing_value
-			&& ! $enrolment_results->is_enrolment_provided()
-		) {
-			// We're probably in a background request and we haven't already stored results.
-			$store_results = false;
-		}
+		// We're probably in a background request and we haven't already stored results.
+		$store_results = self::$store_negative_enrolment_results || $had_existing_value || $enrolment_results->is_enrolment_provided();
 
 		/**
 		 * Filter on whether course enrolment results should be stored.

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -332,8 +332,7 @@ class Sensei_Course_Enrolment {
 	 * @param Sensei_Course_Enrolment_Provider_Results $enrolment_results Enrolment results object.
 	 */
 	private function store_enrolment_results( $user_id, Sensei_Course_Enrolment_Provider_Results $enrolment_results ) {
-		$results_meta_key =  $this->get_enrolment_results_meta_key();
-
+		$results_meta_key   = $this->get_enrolment_results_meta_key();
 		$store_results      = true;
 		$had_existing_value = ! empty( get_user_meta( $user_id, $results_meta_key, true ) );
 

--- a/includes/enrolment/class-sensei-enrolment-learner-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-learner-calculation-job.php
@@ -90,9 +90,11 @@ class Sensei_Enrolment_Learner_Calculation_Job implements Sensei_Background_Job_
 			return;
 		}
 
+		Sensei_Course_Enrolment::set_store_negative_enrolment_results( false );
 		foreach ( $users as $user ) {
 			Sensei_Course_Enrolment_Manager::instance()->recalculate_enrolments( $user );
 		}
+		Sensei_Course_Enrolment::set_store_negative_enrolment_results( true );
 	}
 
 	/**

--- a/tests/framework/trait-sensei-course-enrolment-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-test-helpers.php
@@ -45,6 +45,8 @@ trait Sensei_Course_Enrolment_Test_Helpers {
 		$course_enrolment_instances = new ReflectionProperty( Sensei_Course_Enrolment::class, 'instances' );
 		$course_enrolment_instances->setAccessible( true );
 		$course_enrolment_instances->setValue( [] );
+
+		Sensei_Course_Enrolment::set_store_negative_enrolment_results( true );
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* This is the first step in allowing us to only store positive enrolment results when running background jobs that loop over all courses and users. This should help us limit the number of `false` enrolments are cached for users who don't have any connection to a course.
* This currently just blocks the enrolment results from being stored when running the `Sensei_Enrolment_Learner_Calculation_Job`. #3029 will fix the issues this presents in the course calculation job.
* The main side-effect this will have (which I think is well worth it) is it will slightly slow down the pagination in learner management, especially for courses with many unenrolled learners with progress.

### Testing Instructions

#### In your pre-3.0.0 environment
- Create a course and many users.
- Enrol some of the users.

#### Switch to this branch.
- After loading WP page, make sure the background job `sensei_calculate_learner_enrolments` is queued and runs.
- Without going to learner management or visiting the course as a user, ensure `sensei_course_enrolment_{course_id}` user meta isn't set for users who aren't enrolled in the course.