### PR TITLE
Update course calculation job to paginate using last calculated user ID

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -383,7 +383,6 @@ class Sensei_Course_Enrolment_Manager {
 	 * @see Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check
 	 */
 	public function recalculate_enrolments( $user_id ) {
-
 		$learner_calculated_version = get_user_meta( $user_id, self::LEARNER_CALCULATION_META_NAME, true );
 		if ( $this->get_enrolment_calculation_version() === $learner_calculated_version ) {
 			return;
@@ -434,7 +433,7 @@ class Sensei_Course_Enrolment_Manager {
 		}
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $post->ID );
-		$course_enrolment->recalculate_enrolment( false );
+		$course_enrolment->recalculate_enrolment();
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -150,24 +150,13 @@ class Sensei_Course_Enrolment {
 	/**
 	 * Marks all enrolment results as invalid for a course and enqueues an async job to recalculate.
 	 *
-	 * @param bool $enrolled_learners_only
-	 *
 	 * @return Sensei_Enrolment_Course_Calculation_Job
 	 */
-	public function recalculate_enrolment( $enrolled_learners_only ) {
-		$invalidated_only = false;
-
-		// If we just invalidated current learners, we only have to recalculate for those invalidated results.
-		if ( $enrolled_learners_only ) {
-			$invalidated_only = true;
-			$this->invalidate_enrolled_learner_results();
-		} else {
-			$this->invalidate_all_learner_results();
-		}
-
+	public function recalculate_enrolment() {
+		$this->invalidate_all_learner_results();
 		$job_scheduler = Sensei_Enrolment_Job_Scheduler::instance();
 
-		return $job_scheduler->start_course_calculation_job( $this->course_id, $invalidated_only );
+		return $job_scheduler->start_course_calculation_job( $this->course_id );
 	}
 
 	/**
@@ -180,16 +169,6 @@ class Sensei_Course_Enrolment {
 	 */
 	public function invalidate_learner_result( $user_id ) {
 		update_user_meta( $user_id, $this->get_enrolment_results_meta_key(), '' );
-	}
-
-	/**
-	 * Bulk invalidate all learner results for enrolled users in a course.
-	 */
-	private function invalidate_enrolled_learner_results() {
-		$enrolled_user_ids = $this->get_enrolled_user_ids();
-		foreach ( $enrolled_user_ids as $user_id ) {
-			$this->invalidate_learner_result( $user_id );
-		}
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
@@ -219,7 +219,7 @@ class Sensei_Enrolment_Course_Calculation_Job implements Sensei_Background_Job_I
 	private function get_last_user_id_option_name() {
 		$job_id = $this->get_job_id();
 
-		if ( false === $job_id ) {
+		if ( ! $job_id ) {
 			return false;
 		}
 

--- a/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
@@ -290,7 +290,7 @@ class Sensei_Enrolment_Course_Calculation_Job implements Sensei_Background_Job_I
 	/**
 	 * Set up job before it is scheduled for the first time.
 	 */
-	public function start() {
+	public function setup() {
 		$this->job_id = md5( uniqid() );
 
 		update_option( $this->get_current_job_option_name(), $this->job_id, false );

--- a/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
@@ -208,7 +208,9 @@ class Sensei_Enrolment_Course_Calculation_Job implements Sensei_Background_Job_I
 	 * @return string
 	 */
 	private function get_current_job_option_name() {
-		return self::OPTION_TRACK_CURRENT_JOB_PREFIX . $this->course_id . '_' . $this->invalidated_only ? 1 : 0;
+		$invalidated_suffix = $this->invalidated_only ? 1 : 0;
+
+		return self::OPTION_TRACK_CURRENT_JOB_PREFIX . $this->course_id . '_' . $invalidated_suffix;
 	}
 
 	/**
@@ -289,7 +291,7 @@ class Sensei_Enrolment_Course_Calculation_Job implements Sensei_Background_Job_I
 	public function start() {
 		$this->job_id = md5( uniqid() );
 
-		update_option( $this->get_current_job_option_name(), $this->job_id );
+		update_option( $this->get_current_job_option_name(), $this->job_id, false );
 
 		$this->set_last_user_id( 0 );
 	}

--- a/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
@@ -124,11 +124,13 @@ class Sensei_Enrolment_Course_Calculation_Job implements Sensei_Background_Job_I
 
 		$user_ids = $user_query->get_results();
 
+		Sensei_Course_Enrolment::set_store_negative_enrolment_results( false );
 		foreach ( $user_ids as $user_id ) {
 			$course_enrolment->is_enrolled( $user_id, false );
 
 			$this->set_last_user_id( $user_id );
 		}
+		Sensei_Course_Enrolment::set_store_negative_enrolment_results( true );
 
 		if (
 			empty( $user_ids )

--- a/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
@@ -65,8 +65,6 @@ class Sensei_Enrolment_Course_Calculation_Job implements Sensei_Background_Job_I
 		$this->course_id        = isset( $args['course_id'] ) ? intval( $args['course_id'] ) : null;
 		$this->invalidated_only = isset( $args['invalidated_only'] ) ? boolval( $args['invalidated_only'] ) : false;
 
-		$batch_size = isset( $args['batch_size'] ) ? intval( $args['batch_size'] ) : self::DEFAULT_BATCH_SIZE;
-
 		/**
 		 * Filter the batch size for the number of users to query per run in the course calculation job.
 		 *
@@ -76,7 +74,7 @@ class Sensei_Enrolment_Course_Calculation_Job implements Sensei_Background_Job_I
 		 * @param int  $course_id        Course ID we're running.
 		 * @param bool $invalidated_only Whether this is just a job for invalidated course results only.
 		 */
-		$this->batch_size = apply_filters( 'sensei_enrolment_course_calculation_job_batch_size', $batch_size, $this->course_id, $this->invalidated_only );
+		$this->batch_size = apply_filters( 'sensei_enrolment_course_calculation_job_batch_size', self::DEFAULT_BATCH_SIZE, $this->course_id, $this->invalidated_only );
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
@@ -156,8 +156,10 @@ class Sensei_Enrolment_Course_Calculation_Job implements Sensei_Background_Job_I
 	 */
 	private function get_query_args( $course_enrolment ) {
 		$user_args = [
-			'fields' => 'ID',
-			'number' => $this->batch_size,
+			'fields'  => 'ID',
+			'number'  => $this->batch_size,
+			'orderby' => 'ID',
+			'order'   => 'ASC',
 		];
 
 		$meta_key = $course_enrolment->get_enrolment_results_meta_key();

--- a/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
@@ -264,6 +264,7 @@ class Sensei_Enrolment_Course_Calculation_Job implements Sensei_Background_Job_I
 	public function get_current_job_id() {
 		global $wpdb;
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Avoiding cache issues with multiple jobs running.
 		$row = $wpdb->get_row( $wpdb->prepare( "SELECT option_value FROM {$wpdb->options} WHERE option_name = %s LIMIT 1", $this->get_current_job_option_name() ) );
 
 		if ( is_object( $row ) && ! empty( $row->option_value ) ) {

--- a/includes/enrolment/class-sensei-enrolment-job-scheduler.php
+++ b/includes/enrolment/class-sensei-enrolment-job-scheduler.php
@@ -58,18 +58,16 @@ class Sensei_Enrolment_Job_Scheduler {
 	/**
 	 * Start a job to recalculate enrolments for a course.
 	 *
-	 * @param int  $course_id        Course post ID.
-	 * @param bool $invalidated_only Recalculate just the results that have been invalidated (set to an empty string).
+	 * @param int $course_id Course post ID.
 	 *
 	 * @return Sensei_Enrolment_Course_Calculation_Job Job object.
 	 */
-	public function start_course_calculation_job( $course_id, $invalidated_only ) {
+	public function start_course_calculation_job( $course_id ) {
 		$args = [
-			'course_id'        => $course_id,
-			'invalidated_only' => $invalidated_only,
+			'course_id' => $course_id,
 		];
 
-		// Make sure all previous jobs for this course are stopped.
+		// Make sure any previous job for this course is stopped.
 		$this->cancel_course_calculation_job( $course_id );
 
 		$job = new Sensei_Enrolment_Course_Calculation_Job( $args );
@@ -81,25 +79,20 @@ class Sensei_Enrolment_Job_Scheduler {
 	}
 
 	/**
-	 * Cancel all variations of a course calculation job.
+	 * Cancel any current course calculation job.
 	 *
 	 * @param int $course_id Course post ID.
 	 */
 	private function cancel_course_calculation_job( $course_id ) {
-		$invalidated_only_variations = [ true, false ];
+		$args = [
+			'course_id' => $course_id,
+		];
+		$job  = new Sensei_Enrolment_Course_Calculation_Job( $args );
 
-		foreach ( $invalidated_only_variations as $invalidated_only ) {
-			$args = [
-				'course_id'        => $course_id,
-				'invalidated_only' => $invalidated_only,
-			];
-			$job  = new Sensei_Enrolment_Course_Calculation_Job( $args );
-
-			// If we are able to resume a current job, cancel it.
-			if ( $job->resume() ) {
-				$job->end();
-				Sensei_Scheduler::instance()->cancel_scheduled_job( $job );
-			}
+		// If we are able to resume a current job, cancel it.
+		if ( $job->resume() ) {
+			$job->end();
+			Sensei_Scheduler::instance()->cancel_scheduled_job( $job );
 		}
 	}
 

--- a/includes/enrolment/class-sensei-enrolment-job-scheduler.php
+++ b/includes/enrolment/class-sensei-enrolment-job-scheduler.php
@@ -73,7 +73,7 @@ class Sensei_Enrolment_Job_Scheduler {
 		$this->cancel_course_calculation_job( $course_id );
 
 		$job = new Sensei_Enrolment_Course_Calculation_Job( $args );
-		$job->start();
+		$job->setup();
 
 		Sensei_Scheduler::instance()->schedule_job( $job );
 

--- a/includes/enrolment/class-sensei-enrolment-job-scheduler.php
+++ b/includes/enrolment/class-sensei-enrolment-job-scheduler.php
@@ -70,7 +70,7 @@ class Sensei_Enrolment_Job_Scheduler {
 		];
 
 		// Make sure all previous jobs for this course are stopped.
-		$this->cancel_course_calculation_job();
+		$this->cancel_course_calculation_job( $course_id );
 
 		$job = new Sensei_Enrolment_Course_Calculation_Job( $args );
 		$job->start();

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -273,8 +273,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	public function testRecalculateOnCoursePostScheduleChangeTrueDraftToPublish() {
 		$course   = $this->factory->course->create_and_get( [ 'post_status' => 'draft' ] );
 		$job_args = [
-			'course_id'        => $course->ID,
-			'invalidated_only' => false,
+			'course_id' => $course->ID,
 		];
 		$job      = new Sensei_Enrolment_Course_Calculation_Job( $job_args );
 
@@ -292,8 +291,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	public function testRecalculateOnCoursePostScheduleChangeTruePublishToDraft() {
 		$course   = $this->factory->course->create_and_get( [ 'post_status' => 'publish' ] );
 		$job_args = [
-			'course_id'        => $course->ID,
-			'invalidated_only' => false,
+			'course_id' => $course->ID,
 		];
 		$job      = new Sensei_Enrolment_Course_Calculation_Job( $job_args );
 
@@ -311,8 +309,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	public function testRecalculateOnCoursePostScheduleChangeFalsePublishToPublish() {
 		$course   = $this->factory->course->create_and_get( [ 'post_status' => 'publish' ] );
 		$job_args = [
-			'course_id'        => $course->ID,
-			'invalidated_only' => false,
+			'course_id' => $course->ID,
 		];
 		$job      = new Sensei_Enrolment_Course_Calculation_Job( $job_args );
 
@@ -329,8 +326,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	public function testRecalculateOnCoursePostScheduleChangeFalseScheduledToDraft() {
 		$course   = $this->factory->course->create_and_get( [ 'post_status' => 'scheduled' ] );
 		$job_args = [
-			'course_id'        => $course->ID,
-			'invalidated_only' => false,
+			'course_id' => $course->ID,
 		];
 		$job      = new Sensei_Enrolment_Course_Calculation_Job( $job_args );
 

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -281,6 +281,8 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 		$course->post_status = 'publish';
 		wp_update_post( $course );
 
+		$job->resume();
+
 		$this->assertNotFalse( Sensei_Scheduler_Shim::get_next_scheduled( $job ), 'Job should have been scheduled' );
 	}
 
@@ -297,6 +299,8 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 
 		$course->post_status = 'draft';
 		wp_update_post( $course );
+
+		$job->resume();
 
 		$this->assertNotFalse( Sensei_Scheduler_Shim::get_next_scheduled( $job ), 'Job should have been scheduled' );
 	}

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-course-calculation-job.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-course-calculation-job.php
@@ -60,7 +60,7 @@ class Sensei_Enrolment_Course_Calculation_Job_Test extends WP_UnitTestCase {
 				'invalidated_only' => false,
 			]
 		);
-		$job->start();
+		$job->setup();
 
 		$this->createAndEnrolUsers( $course_id, 5 );
 		$this->invalidateAllCourseResults( $course_enrolment );
@@ -94,7 +94,7 @@ class Sensei_Enrolment_Course_Calculation_Job_Test extends WP_UnitTestCase {
 				'invalidated_only' => false,
 			]
 		);
-		$job->start();
+		$job->setup();
 
 		$enrolled_user_ids = $this->createAndEnrolUsers( $course_id, 3 );
 		$other_user_ids    = $this->factory()->user->create_many( 1 );
@@ -134,7 +134,7 @@ class Sensei_Enrolment_Course_Calculation_Job_Test extends WP_UnitTestCase {
 				'invalidated_only' => true,
 			]
 		);
-		$job->start();
+		$job->setup();
 
 		$enrolled_user_ids = $this->createAndEnrolUsers( $course_id, 2 );
 		$other_user_ids    = $this->factory()->user->create_many( 2 );

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-course-calculation-job.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-course-calculation-job.php
@@ -96,15 +96,22 @@ class Sensei_Enrolment_Course_Calculation_Job_Test extends WP_UnitTestCase {
 		);
 		$job->start();
 
-		$user_ids = $this->factory()->user->create_many( 3 );
+		$enrolled_user_ids = $this->createAndEnrolUsers( $course_id, 3 );
+		$other_user_ids    = $this->factory()->user->create_many( 1 );
+
 		$this->invalidateAllCourseResults( $course_enrolment );
 
 		$job->run();
 		$this->assertTrue( $job->is_complete(), 'Job should be complete after first run.' );
 
-		foreach ( $user_ids as $user_id ) {
+		foreach ( $enrolled_user_ids as $user_id ) {
 			$results = $course_enrolment->get_enrolment_check_results( $user_id );
-			$this->assertNotFalse( $results, 'Results should have been calculated' );
+			$this->assertNotFalse( $results, 'Results should have been calculated and stored' );
+		}
+
+		foreach ( $other_user_ids as $user_id ) {
+			$results = $course_enrolment->get_enrolment_check_results( $user_id );
+			$this->assertFalse( $results, 'Results should have not been stored' );
 		}
 	}
 


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Only stores course enrolment results when they do indicate enrolment is provided. This will help with a lot of unnecessary storage.
* Adds additional protection for this job so that multiple instances can't be initiated on the same course.
* Prevents one unnecessary run by ending the job early if there are going to be no more users to calculate.
* In order to simplify job cancellation and management, I remove the batch size as a job argument. Instead I've added a hook to modify the batch size.

#### Testing instructions:

* Create and publish a NEW course.
* Create a lot of users (more than 40).
* Enrol some users in the new course. Make sure you enrol the most recent user added as a test case.
* Ensure there is just user meta stored (`sensei_course_enrolment_{course_id}`) for that course for the enrolled users 
* Unpublish the job.
* Monitor the job (WP Cron / Action Scheduler) and make sure it runs `floor( num_users / 40 )` times. 
* Ensure there is STILL just user meta stored (`sensei_course_enrolment_{course_id}`) for that course for the enrolled users 
* For the last user added that you enrolled early. Make sure their corresponding term ID is not associated with the course post ID (`object_id`) in `{prefix}term_relationships`.
