### PR TITLE
Only migrate manual enrolment when they had progress

### DIFF
--- a/includes/enrolment/class-sensei-course-manual-enrolment-provider.php
+++ b/includes/enrolment/class-sensei-course-manual-enrolment-provider.php
@@ -144,7 +144,7 @@ class Sensei_Course_Manual_Enrolment_Provider
 		 * Allows other providers to have an opinion about whether or not a user was enrolled pre-3.0.0.
 		 * This should only be called once per user/course just after upgrading from a pre-3.0.0 version of Sensei.
 		 *
-		 * Note: This will only allow manual enrolment to not be given. It won't be called for learners with course
+		 * Note: This will only allow manual enrolment to not be given. It won't be called for learners without course
 		 * progress.
 		 *
 		 * @since 3.0.0

--- a/tests/framework/trait-sensei-course-enrolment-manual-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-manual-test-helpers.php
@@ -27,11 +27,11 @@ trait Sensei_Course_Enrolment_Manual_Test_Helpers {
 	 * @return bool
 	 */
 	private function wasLegacyEnrolmentChecked( $user_id, $course_id ) {
-		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
-		$provider_state   = $course_enrolment->get_provider_state( Sensei_Course_Manual_Enrolment_Provider::instance(), $user_id );
-		$migration_log    = $provider_state->get_stored_value( Sensei_Course_Manual_Enrolment_Provider::DATA_KEY_LEGACY_MIGRATION );
+		$course_enrolment        = Sensei_Course_Enrolment::get_course_instance( $course_id );
+		$provider_state          = $course_enrolment->get_provider_state( Sensei_Course_Manual_Enrolment_Provider::instance(), $user_id );
+		$legacy_migration_status = $provider_state->get_stored_value( Sensei_Course_Manual_Enrolment_Provider::DATA_KEY_LEGACY_MIGRATION );
 
-		return ! empty( $migration_log );
+		return null !== $legacy_migration_status;
 	}
 
 	/**

--- a/tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php
@@ -103,26 +103,8 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 		$this->assertNotEmpty( get_option( 'sensei_enrolment_legacy' ), 'The site-wide legacy enrolment flag should have been set.' );
 
 		$is_enrolled = $provider->is_enrolled( $student_id, $course_id );
-		$this->assertTrue( $this->wasLegacyEnrolmentChecked( $student_id, $course_id ), 'Legacy enrolment status for user should have been checked.' );
+		$this->assertFalse( $this->wasLegacyEnrolmentChecked( $student_id, $course_id ), 'Legacy enrolment status for user should not have been checked.' );
 		$this->assertFalse( $is_enrolled, 'The user should not have been enrolled because they were not enrolled previously.' );
-	}
-
-	/**
-	 * Tests to make sure enrolment is provided when the `sensei_is_legacy_enrolled` filter returns true.
-	 */
-	public function testIsEnrolledLegacyMigrateWithFilter() {
-		$provider   = $this->getManualEnrolmentProvider();
-		$course_id  = $this->getSimpleCourseId();
-		$student_id = $this->getStandardStudentUserId();
-
-		$this->simulateUpgradingFromSensei2ToSensei3();
-		add_filter( 'sensei_is_legacy_enrolled', '__return_true' );
-
-		$this->assertNotEmpty( get_option( 'sensei_enrolment_legacy' ), 'The site-wide legacy enrolment flag should have been set.' );
-
-		$is_enrolled = $provider->is_enrolled( $student_id, $course_id );
-		$this->assertTrue( $this->wasLegacyEnrolmentChecked( $student_id, $course_id ), 'Legacy enrolment status for user should have been checked.' );
-		$this->assertTrue( $is_enrolled, 'The user should have been enrolled due to legacy enrolment migration filter.' );
 	}
 
 	/**
@@ -213,34 +195,6 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test debug messages are generated correctly for a learner with legacy migration who wasn't enrolled
-	 * from legacy and didn't have progress.
-	 */
-	public function testDebugEnrolledLegacyNoProgressNotEnrolled() {
-		$provider   = $this->getManualEnrolmentProvider();
-		$course_id  = $this->getSimpleCourseId();
-		$student_id = $this->getStandardStudentUserId();
-
-		// Set the legacy migration log.
-		$migration_log    = [
-			'had_progress' => false,
-			'is_enrolled'  => false,
-		];
-		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
-		$provider_state   = $course_enrolment->get_provider_state( $provider, $student_id );
-		$provider_state->set_stored_value( Sensei_Course_Manual_Enrolment_Provider::DATA_KEY_LEGACY_MIGRATION, $migration_log );
-		$provider_state->save();
-
-		$debug          = $provider->debug( $student_id, $course_id );
-		$expected_debug = [
-			__( 'Learner <strong>did not have</strong> course progress at the time of manual enrollment migration.', 'sensei-lms' ),
-			__( 'Manual enrollment <strong>was not provided</strong> to the learner on legacy migration.', 'sensei-lms' ),
-		];
-
-		$this->assertEquals( $expected_debug, $debug );
-	}
-
-	/**
 	 * Test debug messages are generated correctly for a learner with legacy migration who wasn't enrolled from legacy.
 	 */
 	public function testDebugEnrolledLegacyNotEnrolled() {
@@ -248,14 +202,10 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 		$course_id  = $this->getSimpleCourseId();
 		$student_id = $this->getStandardStudentUserId();
 
-		// Set the legacy migration log.
-		$migration_log    = [
-			'had_progress' => true,
-			'is_enrolled'  => false,
-		];
+		// Set the legacy enrolment status.
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 		$provider_state   = $course_enrolment->get_provider_state( $provider, $student_id );
-		$provider_state->set_stored_value( Sensei_Course_Manual_Enrolment_Provider::DATA_KEY_LEGACY_MIGRATION, $migration_log );
+		$provider_state->set_stored_value( Sensei_Course_Manual_Enrolment_Provider::DATA_KEY_LEGACY_MIGRATION, false );
 		$provider_state->save();
 
 		$debug          = $provider->debug( $student_id, $course_id );
@@ -275,14 +225,10 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 		$course_id  = $this->getSimpleCourseId();
 		$student_id = $this->getStandardStudentUserId();
 
-		// Set the legacy migration log.
-		$migration_log    = [
-			'had_progress' => true,
-			'is_enrolled'  => true,
-		];
+		// Set the legacy migration status.
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 		$provider_state   = $course_enrolment->get_provider_state( $provider, $student_id );
-		$provider_state->set_stored_value( Sensei_Course_Manual_Enrolment_Provider::DATA_KEY_LEGACY_MIGRATION, $migration_log );
+		$provider_state->set_stored_value( Sensei_Course_Manual_Enrolment_Provider::DATA_KEY_LEGACY_MIGRATION, true );
 		$provider_state->save();
 
 		$debug          = $provider->debug( $student_id, $course_id );


### PR DESCRIPTION
This is a precursor to more consolidation of provider state.

#### Changes proposed in this Pull Request:

* This simplifies storage drastically of legacy enrolment migration information. It does this by:
  * Only migrating when user had progress. Previously, it would still ask the providers/filtered hooks if they should be granted manual enrolment even when they didn't have course progress. None of our current implementations ever handled the `false` -> `true` case, so this should be safe.
  * Because we're doing the above, we can greatly reduce what we log. We can assume if they have the `legacy_manual` value, they had progress. We can then just store the initial migrated value.

#### Testing instructions:

* See testing instructions from #2848 