### PR TITLE
Change lessons secondary query to don't override the global WP_Query

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2947,7 +2947,7 @@ class Sensei_Course {
 	 * This function excludes lessons belonging to modules as they are
 	 * queried separately.
 	 *
-	 * @since 3.0.0
+	 * @since 3.1.0
 	 *
 	 * @return WP_Query $wp_query
 	 */

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2931,6 +2931,8 @@ class Sensei_Course {
 	public static function load_single_course_lessons_query() {
 		_deprecated_function( __METHOD__, '3.1.0', 'Sensei_Course::get_single_course_lessons_query' );
 
+		global $wp_query;
+
 		$args = self::get_single_course_lessons_args();
 
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Used for lesson loop on single course page. Reset in hook to `sensei_single_course_lessons_after`.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1869,7 +1869,7 @@ class Sensei_Course {
 		 */
 		return apply_filters( 'sensei_get_all_courses', $wp_query_obj->posts );
 
-	}//end get_all_courses()
+	}
 
 	/**
 	 * Generate the course meter component
@@ -1892,7 +1892,7 @@ class Sensei_Course {
 
 		return $progress_bar_html;
 
-	}//end get_progress_meter()
+	}
 
 	/**
 	 * Generate a statement that tells users
@@ -1927,7 +1927,7 @@ class Sensei_Course {
 		 */
 		return apply_filters( 'sensei_course_completion_statement', $statement );
 
-	}//end get_progress_statement()
+	}
 
 	/**
 	 * Output the course progress statement
@@ -1982,7 +1982,7 @@ class Sensei_Course {
 
 		echo wp_kses_post( $this->get_progress_meter( $percentage_completed ) );
 
-	}//end the_progress_meter()
+	}
 
 	/**
 	 * Checks how many lessons are completed
@@ -2013,7 +2013,7 @@ class Sensei_Course {
 
 		return $completed_lesson_ids;
 
-	}//end get_completed_lesson_ids()
+	}
 
 	/**
 	 * Calculate the perceantage completed in the course
@@ -2050,7 +2050,7 @@ class Sensei_Course {
 		 */
 		return apply_filters( 'sensei_course_completion_percentage', $percentage, $course_id, $user_id );
 
-	}//end get_completion_percentage()
+	}
 
 	/**
 	 * Block email notifications for the specific courses
@@ -2093,7 +2093,7 @@ class Sensei_Course {
 		}// end if
 
 		return $should_send;
-	}//end block_notification_emails()
+	}
 
 	/**
 	 * Render the course notification setting meta box
@@ -2110,7 +2110,7 @@ class Sensei_Course {
 		echo '<input id="disable_sensei_course_notification" ' . checked( $checked, true, false ) . ' type="checkbox" name="disable_sensei_course_notification" >';
 		echo '<label for="disable_sensei_course_notification">' . esc_html__( 'Disable notifications on this course?', 'sensei-lms' ) . '</label>';
 
-	}//end course_notification_meta_box_content()
+	}
 
 	/**
 	 * Store the setting for the course notification setting.
@@ -2135,7 +2135,7 @@ class Sensei_Course {
 
 		update_post_meta( $course_id, 'disable_notification', $new_val );
 
-	}//end save_course_notification_meta_box()
+	}
 
 	/**
 	 * Output a link to view course. The button text is different depending on the amount of preview lesson available.
@@ -2261,7 +2261,7 @@ class Sensei_Course {
 
 		return $classes;
 
-	}//end add_course_user_status_class()
+	}
 
 	/**
 	 * Prints out the course action buttons links
@@ -2372,7 +2372,7 @@ class Sensei_Course {
 			<?php
 		}// end if is user logged in
 
-	}//end the_course_action_buttons()
+	}
 
 	/**
 	 * This function alter the main query on the course archive page.
@@ -2430,7 +2430,7 @@ class Sensei_Course {
 
 		return $query;
 
-	}//end course_query_filter()
+	}
 
 	/**
 	 * Determine the class of the course loop
@@ -2481,7 +2481,7 @@ class Sensei_Course {
 		 */
 		return apply_filters( 'sensei_course_loop_content_class', $extra_classes, get_post() );
 
-	}//end get_course_loop_content_class()
+	}
 
 	/**
 	 * Get the number of columns set for Sensei courses
@@ -2556,7 +2556,7 @@ class Sensei_Course {
 		</form>
 
 		<?php
-	}//end course_archive_sorting()
+	}
 
 	/**
 	 * Output the course archive filter markup
@@ -2746,7 +2746,7 @@ class Sensei_Course {
 
 		echo wp_kses_post( apply_filters( 'course_archive_title', $html ) );
 
-	}//end archive_header()
+	}
 
 
 	/**
@@ -2783,7 +2783,7 @@ class Sensei_Course {
 			return '<p class="course-excerpt">' . get_post( get_the_ID() )->post_excerpt . '</p>';
 		}
 
-	}//end single_course_content()
+	}
 
 	/**
 	 * Output the the single course lessons title with markup.
@@ -2839,7 +2839,7 @@ class Sensei_Course {
 		 */
 		echo wp_kses_post( apply_filters( 'the_course_lessons_title', ob_get_clean() ) ); // output and filter the captured output and stop capturing.
 
-	}//end the_course_lessons_title()
+	}
 
 	/**
 	 * Get a wp_query object with with lessons of the current course.
@@ -2922,7 +2922,7 @@ class Sensei_Course {
 		}
 
 		return new WP_Query( $course_lesson_query_args );
-	}//end get_single_course_lessons_query()
+	}
 
 	/**
 	 * Flush the rewrite rules.
@@ -3191,7 +3191,7 @@ class Sensei_Course {
 
 		<?php
 
-	}//end the_title()
+	}
 
 	/**
 	 * Show the title on the course category pages
@@ -3223,7 +3223,7 @@ class Sensei_Course {
 
 		echo wp_kses_post( apply_filters( 'course_category_title', $html, $term->term_id ) );
 
-	}//end course_category_title()
+	}
 
 	/**
 	 * Alter the course query to respect the order set for courses and apply
@@ -3304,7 +3304,7 @@ class Sensei_Course {
 		 */
 		return apply_filters( 'sensei_course_is_prerequisite_complete', $prerequisite_complete, $course_id );
 
-	}//end is_prerequisite_complete()
+	}
 
 	/**
 	 * Allowing user to set course archive page as front page.
@@ -3443,7 +3443,7 @@ class Sensei_Course {
 		sensei_log_event( 'course_publish', $event_properties );
 	}
 
-}//end class
+}
 
 /**
  * Class WooThemes_Sensei_Course

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2842,20 +2842,11 @@ class Sensei_Course {
 	}
 
 	/**
-	 * Get a wp_query object with with lessons of the current course.
-	 * It is designed to be used on the single-course template
-	 * and expects the global post to be a singular course.
+	 * Get single course lessons args.
 	 *
-	 * This function excludes lessons belonging to modules as they are
-	 * queried separately.
-	 *
-	 * @since 1.9.0
-	 * @since 3.0.0 Returns the WP_Query object.
-	 *
-	 * @return $wp_query
+	 * @return array $course_lesson_query_args
 	 */
-	public static function get_single_course_lessons_query() {
-
+	private static function get_single_course_lessons_args() {
 		global $post, $wp_query;
 
 		$course_id = $post->ID;
@@ -2921,7 +2912,47 @@ class Sensei_Course {
 
 		}
 
-		return new WP_Query( $course_lesson_query_args );
+		return $course_lesson_query_args;
+	}
+
+	/**
+	 * This function loads the global wp_query object with with lessons
+	 * of the current course. It is designed to be used on the single-course template
+	 * and expects the global post to be a singular course.
+	 *
+	 * This function excludes lessons belonging to modules as they are
+	 * queried separately.
+	 *
+	 * @since 1.9.0
+	 * @global $wp_query
+	 *
+	 * @deprecated 3.0.0 Use `Sensei_Course::get_single_course_lessons_query` instead.
+	 */
+	public static function load_single_course_lessons_query() {
+		_deprecated_function( __METHOD__, '3.0.0', 'Sensei_Course::get_single_course_lessons_query' );
+
+		$args = self::get_single_course_lessons_args();
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Used for lesson loop on single course page. Reset in hook to `sensei_single_course_lessons_after`.
+		$wp_query = new WP_Query( $args );
+	}
+
+	/**
+	 * Get a wp_query object with with lessons of the current course.
+	 * It is designed to be used on the single-course template
+	 * and expects the global post to be a singular course.
+	 *
+	 * This function excludes lessons belonging to modules as they are
+	 * queried separately.
+	 *
+	 * @since 3.0.0
+	 *
+	 * @return WP_Query $wp_query
+	 */
+	public static function get_single_course_lessons_query() {
+		$args = self::get_single_course_lessons_args();
+
+		return new WP_Query( $args );
 	}
 
 	/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2926,10 +2926,10 @@ class Sensei_Course {
 	 * @since 1.9.0
 	 * @global $wp_query
 	 *
-	 * @deprecated 3.1.0 Use `Sensei_Course::get_single_course_lessons_query` instead.
+	 * @deprecated 3.2.0 Use `Sensei_Course::get_single_course_lessons_query` instead.
 	 */
 	public static function load_single_course_lessons_query() {
-		_deprecated_function( __METHOD__, '3.1.0', 'Sensei_Course::get_single_course_lessons_query' );
+		_deprecated_function( __METHOD__, '3.2.0', 'Sensei_Course::get_single_course_lessons_query' );
 
 		global $wp_query;
 
@@ -2947,7 +2947,7 @@ class Sensei_Course {
 	 * This function excludes lessons belonging to modules as they are
 	 * queried separately.
 	 *
-	 * @since 3.1.0
+	 * @since 3.2.0
 	 *
 	 * @return WP_Query $wp_query
 	 */

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2926,10 +2926,10 @@ class Sensei_Course {
 	 * @since 1.9.0
 	 * @global $wp_query
 	 *
-	 * @deprecated 3.0.0 Use `Sensei_Course::get_single_course_lessons_query` instead.
+	 * @deprecated 3.1.0 Use `Sensei_Course::get_single_course_lessons_query` instead.
 	 */
 	public static function load_single_course_lessons_query() {
-		_deprecated_function( __METHOD__, '3.0.0', 'Sensei_Course::get_single_course_lessons_query' );
+		_deprecated_function( __METHOD__, '3.1.0', 'Sensei_Course::get_single_course_lessons_query' );
 
 		$args = self::get_single_course_lessons_args();
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2842,17 +2842,19 @@ class Sensei_Course {
 	}//end the_course_lessons_title()
 
 	/**
-	 * This function loads the global wp_query object with with lessons
-	 * of the current course. It is designed to be used on the single-course template
+	 * Get a wp_query object with with lessons of the current course.
+	 * It is designed to be used on the single-course template
 	 * and expects the global post to be a singular course.
 	 *
 	 * This function excludes lessons belonging to modules as they are
 	 * queried separately.
 	 *
 	 * @since 1.9.0
-	 * @global $wp_query
+	 * @since 3.0.0 Returns the WP_Query object.
+	 *
+	 * @return $wp_query
 	 */
-	public static function load_single_course_lessons_query() {
+	public static function get_single_course_lessons_query() {
 
 		global $post, $wp_query;
 
@@ -2919,10 +2921,8 @@ class Sensei_Course {
 
 		}
 
-		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Used for lesson loop on single course page. Reset in hook to `sensei_single_course_lessons_after`.
-		$wp_query = new WP_Query( $course_lesson_query_args );
-
-	}//end load_single_course_lessons_query()
+		return new WP_Query( $course_lesson_query_args );
+	}//end get_single_course_lessons_query()
 
 	/**
 	 * Flush the rewrite rules.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3862,7 +3862,7 @@ class Sensei_Lesson {
 				<?php
 
 				$meta_html          = '';
-				$user_lesson_status = Sensei_Utils::user_lesson_status( get_the_ID(), get_current_user_id() );
+				$user_lesson_status = Sensei_Utils::user_lesson_status( $lesson_id, get_current_user_id() );
 
 				$lesson_length = get_post_meta( $lesson_id, '_lesson_length', true );
 				if ( '' != $lesson_length ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3779,7 +3779,7 @@ class Sensei_Lesson {
 				$single_lesson_complete = Sensei_Utils::user_completed_lesson( get_the_ID(), get_current_user_id() );
 				if ( $single_lesson_complete ) {
 
-					$lesson_classes[] = 'lesson-completed';
+					$lesson_classes[] = 'completed';
 
 				} // End If Statement
 			} // End If Statement
@@ -3787,7 +3787,7 @@ class Sensei_Lesson {
 			$is_user_taking_course = Sensei_Course::is_user_enrolled( $course_id );
 			if ( Sensei_Utils::is_preview_lesson( get_the_ID() ) && ! $is_user_taking_course ) {
 
-				$lesson_classes[] = 'lesson-preview';
+				$lesson_classes[] = 'preview';
 
 			}
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2361,10 +2361,10 @@ class Sensei_Utils {
 	 *
 	 * @since 1.9.0
 	 *
-	 * @deprecated 3.1.0 Use the `wp_reset_query` instead.
+	 * @deprecated 3.2.0 Use the `wp_reset_query` instead.
 	 */
 	public static function restore_wp_query() {
-		_deprecated_function( __METHOD__, '3.1.0', 'wp_reset_query' );
+		_deprecated_function( __METHOD__, '3.2.0', 'wp_reset_query' );
 
 		wp_reset_query();
 	}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2361,10 +2361,10 @@ class Sensei_Utils {
 	 *
 	 * @since 1.9.0
 	 *
-	 * @deprecated 3.0.0 Use the `wp_reset_query` instead.
+	 * @deprecated 3.1.0 Use the `wp_reset_query` instead.
 	 */
 	public static function restore_wp_query() {
-		_deprecated_function( __METHOD__, '3.0.0', 'wp_reset_query' );
+		_deprecated_function( __METHOD__, '3.1.0', 'wp_reset_query' );
 
 		wp_reset_query();
 	}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2360,11 +2360,13 @@ class Sensei_Utils {
 	 * Restore the global WP_Query
 	 *
 	 * @since 1.9.0
+	 *
+	 * @deprecated 3.0.0 Use the `wp_reset_query` instead.
 	 */
 	public static function restore_wp_query() {
+		_deprecated_function( __METHOD__, '3.0.0', 'wp_reset_query' );
 
 		wp_reset_query();
-
 	}
 
 	/**

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -82,7 +82,7 @@ add_filter( 'the_content', array( 'Sensei_Course', 'single_course_content' ) );
 add_action( 'sensei_single_course_content_inside_after', array( 'Sensei_Course', 'the_course_lessons_title' ), 9 );
 
 // @since 1.9.0
-// @since 3.0.0 Use secondary query to loop the lessons.
+// @since 3.2.0 Use secondary query to loop the lessons.
 // Load the course lessons template
 add_action( 'sensei_single_course_content_inside_after', 'course_single_lessons', 10 );
 

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -82,11 +82,9 @@ add_filter( 'the_content', array( 'Sensei_Course', 'single_course_content' ) );
 add_action( 'sensei_single_course_content_inside_after', array( 'Sensei_Course', 'the_course_lessons_title' ), 9 );
 
 // @since 1.9.0
-// hooks in the course lessons query and remove it at the end
-// also loading the course lessons template in the middle
-add_action( 'sensei_single_course_lessons_before', array( 'Sensei_Course', 'load_single_course_lessons_query' ) );
+// @since 3.0.0 Use secondary query to loop the lessons.
+// Load the course lessons template
 add_action( 'sensei_single_course_content_inside_after', 'course_single_lessons', 10 );
-add_action( 'sensei_single_course_lessons_after', array( 'Sensei_Utils', 'restore_wp_query' ) );
 
 // @since 1.9.0
 // add post classes to the lessons on the single course page

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -26,7 +26,9 @@ function course_single_lessons() {
 
 	}
 
-	Sensei_Templates::get_template( 'single-course/lessons.php' );
+	$lessons_query = Sensei_Course::get_single_course_lessons_query();
+	Sensei_Templates::get_template( 'single-course/lessons.php', [ 'query' => $lessons_query ] );
+	wp_reset_postdata();
 
 } // End course_single_lessons()
 

--- a/templates/single-course/lessons.php
+++ b/templates/single-course/lessons.php
@@ -22,7 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 		/**
 		 * Actions just before the sensei single course lessons loop begins
 		 *
-		 * @hooked Sensei_Course::load_single_course_lessons_query
 		 * @since 1.9.0
 		 */
 		do_action( 'sensei_single_course_lessons_before' );
@@ -32,11 +31,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php
 
 	// lessons loaded into loop in the sensei_single_course_lessons_before hook
-	if ( have_posts() ) :
+	if ( $query->have_posts() ) :
 
 		// start course lessons loop
-		while ( have_posts() ) :
-			the_post();
+		while ( $query->have_posts() ) :
+			$query->the_post();
 			?>
 
 			<article <?php post_class(); ?> >
@@ -91,8 +90,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		/**
 		 * Actions just before the sensei single course lessons loop begins
-		 *
-		 * @hooked Sensei_Course::reset_single_course_query
 		 *
 		 * @since 1.9.0
 		 */

--- a/templates/single-course/lessons.php
+++ b/templates/single-course/lessons.php
@@ -7,7 +7,7 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     3.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/single-course/lessons.php
+++ b/templates/single-course/lessons.php
@@ -30,12 +30,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 	<?php
 
+	// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable -- The template receives the $query variable from args.
+
 	// lessons loaded into loop in the sensei_single_course_lessons_before hook
 	if ( $query->have_posts() ) :
 
 		// start course lessons loop
 		while ( $query->have_posts() ) :
 			$query->the_post();
+			// phpcs:enable
 			?>
 
 			<article <?php post_class(); ?> >


### PR DESCRIPTION
Fixes #2963

### Changes proposed in this Pull Request:

* This PR changes how to handle the lessons' secondary query. Instead of overriding the global `wp_query`, it's returning a new instance to use in the template.
* This also fixes a class that puts a border after each lesson in the list.

### Testing instructions:

* Create a new course.
* Add 3 lessons (one of them allowing preview).
* Complete one of the lessons that is not allowed to preview.
* Access the single course page.
* Make sure that the `lesson-completed` class is added to the completed lesson.
* Make sure that the `lesson-preview` class is added to the lessons allowed to preview.
* Make sure the other lesson doesn't have any of these two classes.
* Make sure all of them have the class `course` (putting a border separating the lessons).

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* `Sensei_Utils::restore_wp_query` Use `wp_reset_query` instead.
* `Sensei_Course::load_single_course_lessons_query` Use `Sensei_Course::get_single_course_lessons_query`instead

### Templates
- `templates/single-course/lessons.php` - **Breaking change** as data is now fetched via a secondary query instead of using the loop.