### PR TITLE
Have all courses share the same provider state meta for a user

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -378,7 +378,7 @@ class Sensei_Course_Enrolment_Manager {
 	 * exist. To enforce a calculation after a possible change, use
 	 * Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check instead.
 	 *
-	 * @param int $user_id   User ID.
+	 * @param int $user_id User ID.
 	 *
 	 * @see Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check
 	 */

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -356,7 +356,7 @@ class Sensei_Course_Enrolment {
 	 * @throws Exception When learner term could not be created.
 	 */
 	public function get_provider_state( Sensei_Course_Enrolment_Provider_Interface $provider, $user_id ) {
-		return Sensei_Enrolment_Provider_State_Store::get( $user_id, $this->course_id )->get_provider_state( $provider );
+		return Sensei_Enrolment_Provider_State_Store::get( $user_id )->get_provider_state( $provider, $this->course_id );
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-enrolment-provider-state-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-state-store.php
@@ -10,10 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Stores set of all the enrolment provider state objects for a course and user.
+ * Stores set of all the enrolment provider state objects for all courses for a user.
  */
 class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
-	const META_PREFIX_ENROLMENT_PROVIDERS_STATE = 'sensei_enrolment_providers_state_';
+	const META_ENROLMENT_PROVIDERS_STATE = 'sensei_enrolment_providers_state';
 
 	/**
 	 * Flag for if a state store has changed.
@@ -25,7 +25,7 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 	/**
 	 * State objects for the providers.
 	 *
-	 * @var Sensei_Enrolment_Provider_State[]
+	 * @var Sensei_Enrolment_Provider_State[][]
 	 */
 	private $provider_states = [];
 
@@ -37,16 +37,9 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 	private $user_id;
 
 	/**
-	 * Course post ID that this store is used for.
-	 *
-	 * @var int
-	 */
-	private $course_id;
-
-	/**
 	 * Keeps track of instances of this class.
 	 *
-	 * @var self[][]
+	 * @var self[]
 	 */
 	private static $instances = [];
 
@@ -54,36 +47,29 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 	 * Class constructor.
 	 *
 	 * @param int $user_id   User ID.
-	 * @param int $course_id Course post ID.
 	 */
-	private function __construct( $user_id, $course_id ) {
-		$this->user_id   = $user_id;
-		$this->course_id = $course_id;
+	private function __construct( $user_id ) {
+		$this->user_id = $user_id;
 	}
 
 	/**
-	 * Get a state store record for a user/course.
+	 * Get a state store record for a user.
 	 *
 	 * @param int $user_id   User ID.
-	 * @param int $course_id Course post ID.
 	 *
 	 * @return self
 	 */
-	public static function get( $user_id, $course_id ) {
+	public static function get( $user_id ) {
 		if ( ! isset( self::$instances[ $user_id ] ) ) {
-			self::$instances[ $user_id ] = [];
-		}
+			self::$instances[ $user_id ] = new self( $user_id );
 
-		if ( ! isset( self::$instances[ $user_id ][ $course_id ] ) ) {
-			self::$instances[ $user_id ][ $course_id ] = new self( $user_id, $course_id );
-
-			$provider_state_stores = get_user_meta( $user_id, self::get_providers_state_meta_key( $course_id ), true );
+			$provider_state_stores = get_user_meta( $user_id, self::META_ENROLMENT_PROVIDERS_STATE, true );
 			if ( ! empty( $provider_state_stores ) ) {
-				self::$instances[ $user_id ][ $course_id ]->restore_from_json( $provider_state_stores );
+				self::$instances[ $user_id ]->restore_from_json( $provider_state_stores );
 			}
 		}
 
-		return self::$instances[ $user_id ][ $course_id ];
+		return self::$instances[ $user_id ];
 	}
 
 	/**
@@ -98,13 +84,22 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 		}
 
 		$provider_states = [];
-		foreach ( $json_arr as $provider_id => $provider_state_data ) {
-			$provider_state_data = Sensei_Enrolment_Provider_State::from_serialized_array( $this, $provider_state_data );
-			if ( ! $provider_state_data ) {
+		foreach ( $json_arr as $course_id => $providers ) {
+			if ( ! is_numeric( $course_id ) ) {
 				continue;
 			}
 
-			$provider_states[ $provider_id ] = $provider_state_data;
+			$course_id                     = (string) $course_id;
+			$provider_states[ $course_id ] = [];
+
+			foreach ( $providers as $provider_id => $provider_state_data ) {
+				$provider_state_data = Sensei_Enrolment_Provider_State::from_array( $this, $provider_state_data );
+				if ( ! $provider_state_data ) {
+					continue;
+				}
+
+				$provider_states[ $course_id ][ $provider_id ] = $provider_state_data;
+			}
 		}
 
 		$this->set_provider_states( $provider_states );
@@ -116,16 +111,21 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 	 * @return array
 	 */
 	public function jsonSerialize() {
-		return $this->provider_states;
-	}
+		$course_states = $this->provider_states;
 
-	/**
-	 * Get the course post ID.
-	 *
-	 * @return int
-	 */
-	public function get_course_id() {
-		return $this->course_id;
+		foreach ( $course_states as $course_id => $provider_states ) {
+			foreach ( $provider_states as $provider_id => $provider_state ) {
+				if ( ! $provider_state->has_data() ) {
+					unset( $course_states[ $course_id ][ $provider_id ] );
+				}
+			}
+
+			if ( empty( $course_states[ $course_id ] ) ) {
+				unset( $course_states[ $course_id ] );
+			}
+		}
+
+		return $course_states;
 	}
 
 	/**
@@ -149,18 +149,25 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 	/**
 	 * Get the state object for a provider.
 	 *
-	 * @param Sensei_Course_Enrolment_Provider_Interface $provider Provider object.
+	 * @param Sensei_Course_Enrolment_Provider_Interface $provider  Provider object.
+	 * @param int                                        $course_id Course post ID.
 	 *
 	 * @return Sensei_Enrolment_Provider_State
 	 */
-	public function get_provider_state( Sensei_Course_Enrolment_Provider_Interface $provider ) {
+	public function get_provider_state( Sensei_Course_Enrolment_Provider_Interface $provider, $course_id ) {
 		$provider_id = $provider->get_id();
 
-		if ( ! isset( $this->provider_states[ $provider_id ] ) ) {
-			$this->provider_states[ $provider_id ] = Sensei_Enrolment_Provider_State::create( $this );
+		$course_id = (string) $course_id;
+
+		if ( ! isset( $this->provider_states[ $course_id ] ) ) {
+			$this->provider_states[ $course_id ] = [];
 		}
 
-		return $this->provider_states[ $provider_id ];
+		if ( ! isset( $this->provider_states[ $course_id ][ $provider_id ] ) ) {
+			$this->provider_states[ $course_id ][ $provider_id ] = Sensei_Enrolment_Provider_State::create( $this );
+		}
+
+		return $this->provider_states[ $course_id ][ $provider_id ];
 	}
 
 	/**
@@ -189,7 +196,7 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 			return true;
 		}
 
-		$result = update_user_meta( $this->get_user_id(), self::get_providers_state_meta_key( $this->get_course_id() ), wp_slash( wp_json_encode( $this ) ) );
+		$result = update_user_meta( $this->get_user_id(), self::META_ENROLMENT_PROVIDERS_STATE, wp_slash( wp_json_encode( $this ) ) );
 
 		if ( ! $result || is_wp_error( $result ) ) {
 			return false;
@@ -206,21 +213,8 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 	 * As this isn't a singleton, Sensei_Course_Enrolment_Manager hooks this into `shutdown` in its `init` method.
 	 */
 	public static function persist_all() {
-		foreach ( self::$instances as $user_id => $course_instances ) {
-			foreach ( $course_instances as $instance ) {
-				$instance->save();
-			}
+		foreach ( self::$instances as $user_id => $instance ) {
+			$instance->save();
 		}
-	}
-
-	/**
-	 * Get the enrolment provider state meta key.
-	 *
-	 * @param int $course_id Course post ID.
-	 *
-	 * @return string
-	 */
-	private static function get_providers_state_meta_key( $course_id ) {
-		return self::META_PREFIX_ENROLMENT_PROVIDERS_STATE . $course_id;
 	}
 }

--- a/includes/enrolment/class-sensei-enrolment-provider-state-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-state-store.php
@@ -46,7 +46,7 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 	/**
 	 * Class constructor.
 	 *
-	 * @param int $user_id   User ID.
+	 * @param int $user_id User ID.
 	 */
 	private function __construct( $user_id ) {
 		$this->user_id = $user_id;
@@ -55,7 +55,7 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 	/**
 	 * Get a state store record for a user.
 	 *
-	 * @param int $user_id   User ID.
+	 * @param int $user_id User ID.
 	 *
 	 * @return self
 	 */

--- a/includes/enrolment/class-sensei-enrolment-provider-state.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-state.php
@@ -42,17 +42,12 @@ class Sensei_Enrolment_Provider_State implements JsonSerializable {
 	 * Restore a course enrolment state record from data restored from a serialized JSON string.
 	 *
 	 * @param Sensei_Enrolment_Provider_State_Store $state_store State store storing this provider state object.
-	 * @param array                                 $data        Serialized state of object.
+	 * @param array                                 $data        Data to initialize object from.
 	 *
 	 * @return self|false
 	 */
-	public static function from_serialized_array( Sensei_Enrolment_Provider_State_Store $state_store, $data ) {
-		if ( empty( $data ) ) {
-			return false;
-		}
-
-		$provider_data = isset( $data['d'] ) ? array_map( [ __CLASS__, 'sanitize_data' ], $data['d'] ) : [];
-
+	public static function from_array( Sensei_Enrolment_Provider_State_Store $state_store, $data ) {
+		$provider_data = array_map( [ __CLASS__, 'sanitize_data' ], $data );
 		$provider_data = array_filter( $provider_data, [ __CLASS__, 'filter_null_values' ] );
 
 		return new self( $state_store, $provider_data );
@@ -111,9 +106,7 @@ class Sensei_Enrolment_Provider_State implements JsonSerializable {
 	 * @return array
 	 */
 	public function jsonSerialize() {
-		return [
-			'd' => $this->provider_data,
-		];
+		return $this->provider_data;
 	}
 
 	/**
@@ -162,5 +155,14 @@ class Sensei_Enrolment_Provider_State implements JsonSerializable {
 	 */
 	public function save() {
 		return $this->state_store->save();
+	}
+
+	/**
+	 * Checks if there is any data in the state.
+	 *
+	 * @return bool
+	 */
+	public function has_data() {
+		return ! empty( $this->provider_data );
 	}
 }

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -387,8 +387,8 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 	public function testGetProviderStateSaved() {
 		$course_id     = $this->getSimpleCourse();
 		$student_id    = $this->createStandardStudent();
-		$persisted_set = '{"always-provides":{"d":{"test":1234}}}';
-		update_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::META_PREFIX_ENROLMENT_PROVIDERS_STATE . $course_id, $persisted_set );
+		$persisted_set = '{"' . $course_id . '":{"always-provides":{"test":1234}}}';
+		update_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::META_ENROLMENT_PROVIDERS_STATE, $persisted_set );
 
 		$provider_class = Sensei_Test_Enrolment_Provider_Always_Provides::class;
 		$this->addEnrolmentProvider( $provider_class );

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state.php
@@ -29,41 +29,27 @@ class Sensei_Enrolment_Provider_State_Test extends WP_UnitTestCase {
 	 * Tests to make sure arrays of serialized data return an instantiated object.
 	 */
 	public function testFromSerializedArray() {
-		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0, 0 );
+		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0 );
 		$test_array  = [
-			'd' => [
-				'test' => 'Dinosaurs!',
-			],
+			'test' => 'Dinosaurs!',
 		];
 
-		$result = Sensei_Enrolment_Provider_State::from_serialized_array( $state_store, $test_array );
+		$result = Sensei_Enrolment_Provider_State::from_array( $state_store, $test_array );
 
 		$this->assertTrue( $result instanceof Sensei_Enrolment_Provider_State, 'Serialized data should have returned a instantiated object' );
-		$this->assertEquals( $test_array['d']['test'], $result->get_stored_value( 'test' ) );
-	}
-
-	/**
-	 * Tests to make sure invalid JSON strings return false.
-	 */
-	public function testFromSerializedEmptyArrayFails() {
-		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0, 0 );
-		$result      = Sensei_Enrolment_Provider_State::from_serialized_array( $state_store, [] );
-
-		$this->assertFalse( $result, 'Invalid serialized array should have returned false' );
+		$this->assertEquals( $test_array['test'], $result->get_stored_value( 'test' ) );
 	}
 
 	/**
 	 * Tests to make sure the object is JSON serialized properly.
 	 */
 	public function testJsonSerializeValid() {
-		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0, 0 );
+		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0 );
 		$test_array  = [
-			'd' => [
-				'test' => 'Dinosaurs!',
-			],
+			'test' => 'Dinosaurs!',
 		];
 
-		$state = Sensei_Enrolment_Provider_State::from_serialized_array( $state_store, $test_array );
+		$state = Sensei_Enrolment_Provider_State::from_array( $state_store, $test_array );
 
 		$this->assertEquals( \wp_json_encode( $test_array ), \wp_json_encode( $state ) );
 	}
@@ -72,28 +58,23 @@ class Sensei_Enrolment_Provider_State_Test extends WP_UnitTestCase {
 	 * Test to make sure we can get a stored data value that has been set.
 	 */
 	public function testGetStoredValueThatHasBeenSet() {
-		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0, 0 );
+		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0 );
 		$test_array  = [
-			'd' => [
-				'test' => 'value',
-			],
+			'test' => 'value',
 		];
 
-		$state = Sensei_Enrolment_Provider_State::from_serialized_array( $state_store, $test_array );
+		$state = Sensei_Enrolment_Provider_State::from_array( $state_store, $test_array );
 
-		$this->assertEquals( $test_array['d']['test'], $state->get_stored_value( 'test' ) );
+		$this->assertEquals( $test_array['test'], $state->get_stored_value( 'test' ) );
 	}
 
 	/**
 	 * Test to make sure data values that have not been set return as null.
 	 */
 	public function testGetStoredValueThatHasNotBeenSet() {
-		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0, 0 );
-		$test_object = [
-			'd' => [],
-		];
-		$test_string = \wp_json_encode( $test_object );
-		$state       = Sensei_Enrolment_Provider_State::from_serialized_array( $state_store, $test_string );
+		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0 );
+		$test_object = [];
+		$state       = Sensei_Enrolment_Provider_State::from_array( $state_store, $test_object );
 
 		$this->assertEquals( null, $state->get_stored_value( 'test' ) );
 	}
@@ -102,7 +83,7 @@ class Sensei_Enrolment_Provider_State_Test extends WP_UnitTestCase {
 	 * Tests to ensure the enrolment status can be set.
 	 */
 	public function testSetDataValue() {
-		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0, 0 );
+		$state_store = Sensei_Enrolment_Provider_State_Store::get( 0 );
 		$state       = Sensei_Enrolment_Provider_State::create( $state_store );
 
 		$state->set_stored_value( 'test', true );
@@ -110,19 +91,17 @@ class Sensei_Enrolment_Provider_State_Test extends WP_UnitTestCase {
 		$this->assertTrue( $state->get_stored_value( 'test' ) );
 
 		$json_string = \wp_json_encode( $state );
-		$this->assertEquals( '{"d":{"test":true}}', $json_string, 'The set data value should persist when serializing the object' );
+		$this->assertEquals( '{"test":true}', $json_string, 'The set data value should persist when serializing the object' );
 	}
 
 	/**
 	 * Tests to ensure the enrolment status can be cleared.
 	 */
 	public function testClearStoredValue() {
-		$state_store   = Sensei_Enrolment_Provider_State_Store::get( 0, 0 );
-		$initial_state = [
-			'd' => [],
-		];
+		$state_store   = Sensei_Enrolment_Provider_State_Store::get( 0 );
+		$initial_state = [];
 
-		$state = Sensei_Enrolment_Provider_State::from_serialized_array( $state_store, $initial_state );
+		$state = Sensei_Enrolment_Provider_State::from_array( $state_store, $initial_state );
 		$state->set_stored_value( 'test', true );
 
 		$this->assertTrue( $state->get_stored_value( 'test' ) );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Changes provider state storage from one user meta per user per course to just one per user. All courses are stored in the same meta.
* In addition, the serialized form of the individual states dropped the `d` level. The serialized state is just the data array.

_Future task (not in 3.0.0)_: We probably should clean up the state stores (when we update it them) to remove deleted courses and maybe even providers.

#### Testing instructions:

* Ensure manual and membership providers are unaffected.
