### PR TITLE
For enrolment results, use time not microtime for logging

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment-provider-results.php
+++ b/includes/enrolment/class-sensei-course-enrolment-provider-results.php
@@ -23,7 +23,7 @@ final class Sensei_Course_Enrolment_Provider_Results implements JsonSerializable
 	/**
 	 * Time the results were generated.
 	 *
-	 * @var float
+	 * @var int
 	 */
 	private $time;
 
@@ -45,7 +45,7 @@ final class Sensei_Course_Enrolment_Provider_Results implements JsonSerializable
 	public function __construct( $provider_results, $version_hash, $time = null ) {
 		$this->provider_results = $provider_results;
 		$this->version_hash     = $version_hash;
-		$this->time             = isset( $time ) ? $time : microtime( true );
+		$this->time             = isset( $time ) ? $time : time();
 	}
 
 	/**
@@ -63,7 +63,7 @@ final class Sensei_Course_Enrolment_Provider_Results implements JsonSerializable
 
 		$provider_results = isset( $json_arr['r'] ) ? array_map( 'boolval', $json_arr['r'] ) : [];
 		$version          = isset( $json_arr['v'] ) ? sanitize_text_field( $json_arr['v'] ) : -1;
-		$time             = isset( $json_arr['t'] ) ? floatval( $json_arr['t'] ) : null;
+		$time             = isset( $json_arr['t'] ) ? intval( $json_arr['t'] ) : null;
 
 		return new self( $provider_results, $version, $time );
 	}
@@ -121,7 +121,7 @@ final class Sensei_Course_Enrolment_Provider_Results implements JsonSerializable
 	/**
 	 * Get the time these results were generated.
 	 *
-	 * @return string
+	 * @return int
 	 */
 	public function get_time() {
 		return $this->time;

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-provider-results.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-provider-results.php
@@ -20,7 +20,7 @@ class Sensei_Course_Enrolment_Provider_Results_Test extends WP_UnitTestCase {
 	 */
 	public function testFromJson() {
 		$base = [
-			't' => microtime( true ) - 4,
+			't' => time() - 4,
 			'v' => '###',
 			'r' => [
 				'testA' => true,


### PR DESCRIPTION
A very wee PR 🥳 

#### Changes proposed in this Pull Request:

* Similar to my feedback in #3027, this switches the enrolment results to use `time()` instead of `microtime( true )`. This will keep it from dealing with JSON/PHP's float handling in storage.
