### PR TITLE
Fire actions on enrolment status change and manual enrolment status change

### DIFF
--- a/includes/enrolment/class-sensei-course-manual-enrolment-provider.php
+++ b/includes/enrolment/class-sensei-course-manual-enrolment-provider.php
@@ -106,7 +106,21 @@ class Sensei_Course_Manual_Enrolment_Provider
 		$this->set_enrolment_status( $user_id, $course_id, true );
 		Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check( $user_id, $course_id );
 
-		return $this->is_enrolled( $user_id, $course_id );
+		if ( ! $this->is_enrolled( $user_id, $course_id ) ) {
+			return false;
+		}
+
+		/**
+		 * Fire action when a learner is provided with manual enrolment.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param int $user_id   User ID.
+		 * @param int $course_id Course post ID.
+		 */
+		do_action( 'sensei_manual_enrolment_learner_enrolled', $user_id, $course_id );
+
+		return true;
 	}
 
 	/**
@@ -126,7 +140,21 @@ class Sensei_Course_Manual_Enrolment_Provider
 		$this->set_enrolment_status( $user_id, $course_id, false );
 		Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check( $user_id, $course_id );
 
-		return ! $this->is_enrolled( $user_id, $course_id );
+		if ( $this->is_enrolled( $user_id, $course_id ) ) {
+			return false;
+		}
+
+		/**
+		 * Fire action when a learner's manual enrolment is withdrawn.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param int $user_id   User ID.
+		 * @param int $course_id Course post ID.
+		 */
+		do_action( 'sensei_manual_enrolment_learner_withdrawn', $user_id, $course_id );
+
+		return true;
 	}
 
 	/**


### PR DESCRIPTION
I realized we have a lack of actions being fired. I think these will be useful (especially `sensei_course_enrolment_status_changed`).

#### Changes proposed in this Pull Request:

* Add hook for when a learner's manual enrolment is provided.
* Add hook for when a learner's manual enrolment is withdrawn.
* Add hook for when a learner's overall course enrolment status changes.

#### Testing instructions:

Snippet for testing:
```
add_action( 
	'sensei_course_enrolment_status_changed', 
	function( $user_id, $course_id, $is_enrolled ) {
		$is_enrolled = (int) $is_enrolled;
		error_log( "Enrolment Status Change: user({$user_id}); course({$course_id}); is_enrolled({$is_enrolled})" );
	},
	10,
	3
);

add_action( 
	'sensei_manual_enrolment_learner_enrolled', 
	function( $user_id, $course_id ) {
		error_log( "Manual Enrolment Provided: user({$user_id}); course({$course_id})" );
	},
	10,
	2
);

add_action( 
	'sensei_manual_enrolment_learner_withdrawn', 
	function( $user_id, $course_id ) {
		error_log( "Manual Enrolment Withdrawn: user({$user_id}); course({$course_id})" );
	},
	10,
	2
);
```

* Manually enroll and make sure action is fired.
* Remove manual enrolment and make sure action is fired.
* Both actions should correspond with a `sensei_course_enrolment_status_changed` firing.

### New Hooks
- `sensei_course_enrolment_status_changed`
- `sensei_manual_enrolment_learner_enrolled`
- `sensei_manual_enrolment_learner_withdrawn`