### PR TITLE
Use more consistent `learner` instead of `student` in manual methods and frontend hook

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -569,9 +569,9 @@ class Sensei_Learner_Management {
 
 		$result = false;
 		if ( 'withdraw' === $learner_action ) {
-			$result = $manual_enrolment_provider->withdraw_student( $user_id, $course_id );
+			$result = $manual_enrolment_provider->withdraw_learner( $user_id, $course_id );
 		} elseif ( 'enrol' === $learner_action ) {
-			$result = $manual_enrolment_provider->enrol_student( $user_id, $course_id );
+			$result = $manual_enrolment_provider->enrol_learner( $user_id, $course_id );
 		}
 
 		if ( ! $result ) {
@@ -689,7 +689,7 @@ class Sensei_Learner_Management {
 			$result = false;
 
 			if ( $manual_enrolment_provider instanceof Sensei_Course_Manual_Enrolment_Provider ) {
-				$result = $manual_enrolment_provider->enrol_student( $user_id, $course_id );
+				$result = $manual_enrolment_provider->enrol_learner( $user_id, $course_id );
 			}
 
 			switch ( $post_type ) {

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -269,12 +269,12 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 		switch ( $action ) {
 			case self::MANUALLY_ENROL:
 				if ( ! $manual_enrolment_provider->is_enrolled( $user_id, $course_id ) ) {
-					$manual_enrolment_provider->enrol_student( $user_id, $course_id );
+					$manual_enrolment_provider->enrol_learner( $user_id, $course_id );
 				}
 				break;
 			case self::REMOVE_MANUAL_ENROLMENT:
 				if ( $manual_enrolment_provider->is_enrolled( $user_id, $course_id ) ) {
-					$manual_enrolment_provider->withdraw_student( $user_id, $course_id );
+					$manual_enrolment_provider->withdraw_learner( $user_id, $course_id );
 				}
 				break;
 			case self::REMOVE_PROGRESS:

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1265,11 +1265,11 @@ class Sensei_Frontend {
 			 * @param int      $user_id          User ID.
 			 * @param int      $course_id        Course post ID.
 			 */
-			$student_enrollment_handler = apply_filters( 'sensei_frontend_student_enrolment_handler', [ $this, 'manually_enrol_learner' ], $current_user->ID, $post->ID );
+			$learner_enrollment_handler = apply_filters( 'sensei_frontend_learner_enrolment_handler', [ $this, 'manually_enrol_learner' ], $current_user->ID, $post->ID );
 
 			$student_enrolled = false;
-			if ( is_callable( $student_enrollment_handler ) ) {
-				$student_enrolled = call_user_func( $student_enrollment_handler, $current_user->ID, $post->ID );
+			if ( is_callable( $learner_enrollment_handler ) ) {
+				$student_enrolled = call_user_func( $learner_enrollment_handler, $current_user->ID, $post->ID );
 			}
 
 			$this->data                        = new stdClass();

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1314,7 +1314,7 @@ class Sensei_Frontend {
 		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
 		$manual_enrolment  = $enrolment_manager->get_manual_enrolment_provider();
 
-		return $manual_enrolment && $manual_enrolment->enrol_student( $user_id, $course_id );
+		return $manual_enrolment && $manual_enrolment->enrol_learner( $user_id, $course_id );
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-course-manual-enrolment-provider.php
+++ b/includes/enrolment/class-sensei-course-manual-enrolment-provider.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Course enrolment provider for manually enrolling students.
+ * Course enrolment provider for manually enrolling learners.
  *
  * @since 3.0.0
  */
@@ -74,12 +74,12 @@ class Sensei_Course_Manual_Enrolment_Provider
 	}
 
 	/**
-	 * Check if this course enrolment provider is enroling a user to a course.
+	 * Check if this course enrolment provider is enrolling a user to a course.
 	 *
 	 * @param int $user_id   User ID.
 	 * @param int $course_id Course post ID.
 	 *
-	 * @return bool  `true` if this provider enrols the student and `false` if not.
+	 * @return bool  `true` if this provider enrols the learner and `false` if not.
 	 */
 	protected function get_initial_enrolment_status( $user_id, $course_id ) {
 		if ( $this->needs_legacy_migration( $user_id, $course_id ) ) {
@@ -90,14 +90,14 @@ class Sensei_Course_Manual_Enrolment_Provider
 	}
 
 	/**
-	 * Enrols a student manually in a course.
+	 * Enrols a learner manually in a course.
 	 *
 	 * @param int $user_id   User ID.
 	 * @param int $course_id Course post ID.
 	 *
 	 * @return bool
 	 */
-	public function enrol_student( $user_id, $course_id ) {
+	public function enrol_learner( $user_id, $course_id ) {
 		// Check if they are already manually enrolled.
 		if ( $this->is_enrolled( $user_id, $course_id ) ) {
 			return true;
@@ -110,14 +110,14 @@ class Sensei_Course_Manual_Enrolment_Provider
 	}
 
 	/**
-	 * Withdraw manual enrolment for a student in a course.
+	 * Withdraw manual enrolment for a learner in a course.
 	 *
 	 * @param int $user_id   User ID.
 	 * @param int $course_id Course post ID.
 	 *
 	 * @return bool
 	 */
-	public function withdraw_student( $user_id, $course_id ) {
+	public function withdraw_learner( $user_id, $course_id ) {
 		// Check if they aren't manually enrolled.
 		if ( ! $this->is_enrolled( $user_id, $course_id ) ) {
 			return true;

--- a/tests/framework/trait-sensei-course-enrolment-manual-test-helpers.php
+++ b/tests/framework/trait-sensei-course-enrolment-manual-test-helpers.php
@@ -80,7 +80,7 @@ trait Sensei_Course_Enrolment_Manual_Test_Helpers {
 			return false;
 		}
 
-		return $manual_provider->enrol_student( $user_id, $course_id );
+		return $manual_provider->enrol_learner( $user_id, $course_id );
 	}
 
 	/**

--- a/tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php
@@ -156,7 +156,7 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( $provider->is_enrolled( $student_id, $course_id ), 'Student should not be enrolled before we enrol them.' );
 
-		$provider->enrol_student( $student_id, $course_id );
+		$provider->enrol_learner( $student_id, $course_id );
 
 		$this->assertTrue( $provider->is_enrolled( $student_id, $course_id ), 'Student should now be enrolled.' );
 	}
@@ -173,7 +173,7 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 		$this->directlyEnrolStudent( $student_id, $course_id );
 		$this->assertTrue( $provider->is_enrolled( $student_id, $course_id ), 'Student should be enrolled after directly enrolling them.' );
 
-		$provider->withdraw_student( $student_id, $course_id );
+		$provider->withdraw_learner( $student_id, $course_id );
 
 		$this->assertFalse( $provider->is_enrolled( $student_id, $course_id ), 'Student should not be enrolled after withdrawing them from the course.' );
 	}

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-course-calculation-job.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-course-calculation-job.php
@@ -125,7 +125,7 @@ class Sensei_Enrolment_Course_Calculation_Job_Test extends WP_UnitTestCase {
 
 		$manual_provider = Sensei_Course_Enrolment_Manager::instance()->get_manual_enrolment_provider();
 		foreach ( $user_ids as $user_id ) {
-			$manual_provider->enrol_student( $user_id, $course_id );
+			$manual_provider->enrol_learner( $user_id, $course_id );
 		}
 
 		return $user_ids;

--- a/tests/unit-tests/test-class-learner.php
+++ b/tests/unit-tests/test-class-learner.php
@@ -92,7 +92,7 @@ class Sensei_Class_Student_Test extends WP_UnitTestCase {
 		$manual_provider = Sensei_Course_Enrolment_Manager::instance()->get_manual_enrolment_provider();
 
 		foreach ( $enrolled_course_ids as $course_id ) {
-			$manual_provider->enrol_student( $student_id, $course_id );
+			$manual_provider->enrol_learner( $student_id, $course_id );
 		}
 
 		$base_query_args        = [
@@ -125,7 +125,7 @@ class Sensei_Class_Student_Test extends WP_UnitTestCase {
 		$manual_provider = Sensei_Course_Enrolment_Manager::instance()->get_manual_enrolment_provider();
 
 		foreach ( $enrolled_course_ids as $course_id ) {
-			$manual_provider->enrol_student( $student_id, $course_id );
+			$manual_provider->enrol_learner( $student_id, $course_id );
 		}
 
 		foreach ( $completed_course_ids as $course_id ) {
@@ -166,7 +166,7 @@ class Sensei_Class_Student_Test extends WP_UnitTestCase {
 		$manual_provider = Sensei_Course_Enrolment_Manager::instance()->get_manual_enrolment_provider();
 
 		foreach ( $enrolled_course_ids as $course_id ) {
-			$manual_provider->enrol_student( $student_id, $course_id );
+			$manual_provider->enrol_learner( $student_id, $course_id );
 		}
 
 		foreach ( $completed_course_ids as $course_id ) {

--- a/tests/unit-tests/test-class-sensei-learners-admin-bulk-actions-controller.php
+++ b/tests/unit-tests/test-class-sensei-learners-admin-bulk-actions-controller.php
@@ -83,14 +83,14 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller_Test extends WP_UnitTestCase
 
 		$mock_provider = $this->getMockBuilder( Sensei_Course_Manual_Enrolment_Provider::class )
 			->disableOriginalConstructor()
-			->setMethods( [ 'enrol_student', 'is_enrolled' ] )
+			->setMethods( [ 'enrol_learner', 'is_enrolled' ] )
 			->getMock();
 
 		$mock_provider->method( 'is_enrolled' )->willReturn( true, true, false, false );
 		$this->registerMockProvider( $mock_provider );
 
 		$mock_provider->expects( $this->exactly( 2 ) )
-			->method( 'enrol_student' )
+			->method( 'enrol_learner' )
 			->withConsecutive(
 				[ $users[1], $courses[0] ],
 				[ $users[1], $courses[1] ]
@@ -113,14 +113,14 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller_Test extends WP_UnitTestCase
 
 		$mock_provider = $this->getMockBuilder( Sensei_Course_Manual_Enrolment_Provider::class )
 			->disableOriginalConstructor()
-			->setMethods( [ 'withdraw_student', 'is_enrolled' ] )
+			->setMethods( [ 'withdraw_learner', 'is_enrolled' ] )
 			->getMock();
 
 		$mock_provider->method( 'is_enrolled' )->willReturn( true, true, false, false );
 		$this->registerMockProvider( $mock_provider );
 
 		$mock_provider->expects( $this->exactly( 2 ) )
-			->method( 'withdraw_student' )
+			->method( 'withdraw_learner' )
 			->withConsecutive(
 				[ $users[0], $courses[0] ],
 				[ $users[0], $courses[1] ]


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Minor API change to make method naming more consistent. I'll create another PR for the minor test suite change in WCPC.