### PR TITLE
Allow filtering learner job batch size and fix bug in course calculation job

### DIFF
--- a/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
@@ -112,13 +112,13 @@ class Sensei_Enrolment_Course_Calculation_Job implements Sensei_Background_Job_I
 
 		$user_ids = $user_query->get_results();
 
-		Sensei_Course_Enrolment::set_store_negative_enrolment_results( false );
+		add_filter( 'sensei_course_enrolment_store_results', [ Sensei_Course_Enrolment::class, 'do_not_store_negative_enrolment_results' ], 10, 5 );
 		foreach ( $user_ids as $user_id ) {
 			$course_enrolment->is_enrolled( $user_id, false );
 
 			$this->set_last_user_id( $user_id );
 		}
-		Sensei_Course_Enrolment::set_store_negative_enrolment_results( true );
+		remove_filter( 'sensei_course_enrolment_store_results', [ Sensei_Course_Enrolment::class, 'do_not_store_negative_enrolment_results' ], 10 );
 
 		if (
 			empty( $user_ids )

--- a/includes/enrolment/class-sensei-enrolment-job-scheduler.php
+++ b/includes/enrolment/class-sensei-enrolment-job-scheduler.php
@@ -108,7 +108,7 @@ class Sensei_Enrolment_Job_Scheduler {
 			return;
 		}
 
-		$job = new Sensei_Enrolment_Learner_Calculation_Job( 20 );
+		$job = new Sensei_Enrolment_Learner_Calculation_Job();
 		Sensei_Scheduler::instance()->schedule_job( $job );
 	}
 
@@ -118,7 +118,7 @@ class Sensei_Enrolment_Job_Scheduler {
 	 * @access private
 	 */
 	public function run_learner_calculation() {
-		$job                 = new Sensei_Enrolment_Learner_Calculation_Job( 20 );
+		$job                 = new Sensei_Enrolment_Learner_Calculation_Job();
 		$completion_callback = function() {
 			$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
 

--- a/includes/enrolment/class-sensei-enrolment-learner-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-learner-calculation-job.php
@@ -14,7 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * up to run once after a Sensei version upgrade or when Sensei_Course_Enrolment_Manager::get_site_salt() is updated.
  */
 class Sensei_Enrolment_Learner_Calculation_Job implements Sensei_Background_Job_Interface {
-	const NAME = 'sensei_calculate_learner_enrolments';
+	const NAME               = 'sensei_calculate_learner_enrolments';
+	const DEFAULT_BATCH_SIZE = 10;
 
 	/**
 	 * Number of users for each job run.
@@ -32,11 +33,16 @@ class Sensei_Enrolment_Learner_Calculation_Job implements Sensei_Background_Job_
 
 	/**
 	 * Sensei_Enrolment_Learner_Calculation_Job constructor.
-	 *
-	 * @param integer $batch_size The scheduler's batch size.
 	 */
-	public function __construct( $batch_size ) {
-		$this->batch_size = $batch_size;
+	public function __construct() {
+		/**
+		 * Filter the batch size for the number of users to query per run in the learner calculation job.
+		 *
+		 * @since 3.0.0
+		 *
+		 * @param int $batch_size Batch size to filter.
+		 */
+		$this->batch_size = apply_filters( 'sensei_enrolment_learner_calculation_job_batch_size', self::DEFAULT_BATCH_SIZE );
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-enrolment-learner-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-learner-calculation-job.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Enrolment_Learner_Calculation_Job implements Sensei_Background_Job_Interface {
 	const NAME               = 'sensei_calculate_learner_enrolments';
-	const DEFAULT_BATCH_SIZE = 10;
+	const DEFAULT_BATCH_SIZE = 20;
 
 	/**
 	 * Number of users for each job run.

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
@@ -32,7 +32,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 	 * Tests that the scheduler starts when the calculation version does not exist.
 	 */
 	public function testLearnerCalculationStartsWhenVersionIsNotSet() {
-		$job       = new Sensei_Enrolment_Learner_Calculation_Job( 20 );
+		$job       = new Sensei_Enrolment_Learner_Calculation_Job();
 		$scheduler = Sensei_Enrolment_Job_Scheduler::instance();
 
 		$scheduler->maybe_start_learner_calculation();

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
@@ -20,11 +20,27 @@ class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Clean up after test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		remove_all_filters( 'sensei_enrolment_learner_calculation_job_batch_size' );
+	}
+
+	/**
 	 * Tests that a call to Sensei_Enrolment_Calculation_Scheduler::calculate_enrolments, calculates the enrolments for
 	 * a number of users equal to the batch size.
 	 */
 	public function testSchedulerCalculatesEnrolmentsForOneBatch() {
-		$job = new Sensei_Enrolment_Learner_Calculation_Job( 2 );
+		add_filter(
+			'sensei_enrolment_learner_calculation_job_batch_size',
+			function() {
+				return 2;
+			}
+		);
+
+		$job = new Sensei_Enrolment_Learner_Calculation_Job();
 
 		$mock = $this->getMockBuilder( Sensei_Course_Enrolment_Manager::class )
 			->disableOriginalConstructor()
@@ -60,8 +76,15 @@ class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
 	 * calculates the enrolments for all users.
 	 */
 	public function testSchedulerCalculatesEnrolmentsForAllBatches() {
+		add_filter(
+			'sensei_enrolment_learner_calculation_job_batch_size',
+			function() {
+				return 2;
+			}
+		);
+
 		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
-		$job               = new Sensei_Enrolment_Learner_Calculation_Job( 2 );
+		$job               = new Sensei_Enrolment_Learner_Calculation_Job();
 
 		$mock = $this->getMockBuilder( Sensei_Course_Enrolment_Manager::class )
 			->disableOriginalConstructor()


### PR DESCRIPTION
A site I'm testing has over 200 courses. We could eventually do something similar to @renatho's approach and determine the batch size in "number of calculations." For now, I think a filter will help us with similar sites.

#### Changes proposed in this Pull Request:

* Adds a filter to change the default batch size for the learner job.
* Fixes bug in `\Sensei_Enrolment_Course_Calculation_Job` from #3031