### PR TITLE
Use new strategy for looping through last user ID

### DIFF
--- a/includes/enrolment/class-sensei-enrolment-learner-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-learner-calculation-job.php
@@ -14,8 +14,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * up to run once after a Sensei version upgrade or when Sensei_Course_Enrolment_Manager::get_site_salt() is updated.
  */
 class Sensei_Enrolment_Learner_Calculation_Job implements Sensei_Background_Job_Interface {
-	const NAME               = 'sensei_calculate_learner_enrolments';
-	const DEFAULT_BATCH_SIZE = 20;
+	const NAME                      = 'sensei_calculate_learner_enrolments';
+	const DEFAULT_BATCH_SIZE        = 20;
+	const OPTION_TRACK_LAST_USER_ID = 'sensei_calculate_learner_enrolments_job_last_user_id';
+	const OPTION_TRACK_VERSION_CALC = 'sensei_calculate_learner_enrolments_job_calculating_version';
 
 	/**
 	 * Number of users for each job run.
@@ -67,40 +69,56 @@ class Sensei_Enrolment_Learner_Calculation_Job implements Sensei_Background_Job_
 	 * Run the job.
 	 */
 	public function run() {
-		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
-
-		$meta_query = [
-			'relation' => 'OR',
-			[
-				'key'     => Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
-				'value'   => $enrolment_manager->get_enrolment_calculation_version(),
-				'compare' => '!=',
-			],
-			[
-				'key'     => Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
-				'compare' => 'NOT EXISTS',
-			],
-		];
-
 		$user_args = [
-			'fields'     => 'ID',
-			'number'     => $this->batch_size,
-			'meta_query' => $meta_query, // phpcs:ignore  WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- The results are limited by the batch size.
+			'fields'  => 'ID',
+			'number'  => $this->batch_size,
+			'order'   => 'ASC',
+			'orderby' => 'ID',
 		];
 
-		$users = get_users( $user_args );
+		add_action( 'pre_user_query', [ $this, 'modify_user_query_add_user_id' ] );
+		$user_query = new WP_User_Query( $user_args );
+		remove_action( 'pre_user_query', [ $this, 'modify_user_query_add_user_id' ] );
 
-		if ( empty( $users ) ) {
-			$this->is_complete = true;
-
-			return;
-		}
+		$user_ids = $user_query->get_results();
 
 		add_filter( 'sensei_course_enrolment_store_results', [ Sensei_Course_Enrolment::class, 'do_not_store_negative_enrolment_results' ], 10, 5 );
-		foreach ( $users as $user ) {
-			Sensei_Course_Enrolment_Manager::instance()->recalculate_enrolments( $user );
+		foreach ( $user_ids as $user_id ) {
+			Sensei_Course_Enrolment_Manager::instance()->recalculate_enrolments( $user_id );
+			$this->set_last_user_id( $user_id );
 		}
 		remove_filter( 'sensei_course_enrolment_store_results', [ Sensei_Course_Enrolment::class, 'do_not_store_negative_enrolment_results' ], 10 );
+
+		if (
+			empty( $user_ids )
+			|| (int) $user_query->get_total() <= (int) $this->batch_size
+		) {
+			$this->end();
+		}
+	}
+
+	/**
+	 * Set up job before it is scheduled for the first time.
+	 *
+	 * @param string $current_version Setting up current version.
+	 */
+	public function setup( $current_version ) {
+		update_option( self::OPTION_TRACK_VERSION_CALC, $current_version, false );
+
+		$this->set_last_user_id( 0 );
+	}
+
+	/**
+	 * Check if version that is running is for the current version.
+	 *
+	 * @param string $version_check Version to check.
+	 *
+	 * @return bool
+	 */
+	public function is_calculating_version( $version_check ) {
+		$version = get_option( self::OPTION_TRACK_VERSION_CALC, false );
+
+		return $version === $version_check;
 	}
 
 	/**
@@ -110,5 +128,46 @@ class Sensei_Enrolment_Learner_Calculation_Job implements Sensei_Background_Job_
 	 */
 	public function is_complete() {
 		return $this->is_complete;
+	}
+
+	/**
+	 * Modify user query to add the user ID check.
+	 *
+	 * @access private
+	 *
+	 * @param WP_User_Query $user_query User query to modify.
+	 */
+	public function modify_user_query_add_user_id( WP_User_Query $user_query ) {
+		global $wpdb;
+
+		$user_query->query_where .= $wpdb->prepare( ' AND ID>%d', $this->get_last_user_id() );
+	}
+
+	/**
+	 * Set the last calculated user ID.
+	 *
+	 * @param int $user_id User ID.
+	 */
+	private function set_last_user_id( $user_id ) {
+		update_option( self::OPTION_TRACK_LAST_USER_ID, (int) $user_id, false );
+	}
+
+	/**
+	 * Get the last user ID that was calculated.
+	 *
+	 * @return int
+	 */
+	public function get_last_user_id() {
+		return (int) get_option( self::OPTION_TRACK_LAST_USER_ID, 0 );
+	}
+
+	/**
+	 * Clean up after the job ends.
+	 */
+	public function end() {
+		$this->is_complete = true;
+
+		delete_option( self::OPTION_TRACK_LAST_USER_ID );
+		delete_option( self::OPTION_TRACK_VERSION_CALC );
 	}
 }

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
@@ -26,6 +26,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 		parent::tearDown();
 
 		Sensei_Scheduler_Shim::reset();
+		( new Sensei_Enrolment_Learner_Calculation_Job() )->end();
 	}
 
 	/**
@@ -36,6 +37,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 		$scheduler = Sensei_Enrolment_Job_Scheduler::instance();
 
 		$scheduler->maybe_start_learner_calculation();
+		$job->end();
 
 		$this->assertEventScheduledCount( 1, Sensei_Enrolment_Learner_Calculation_Job::NAME, 'The job should have been scheduled once.' );
 	}
@@ -61,11 +63,14 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 	 * Tests that once the scheduler has started, subsequent starts have no effect.
 	 */
 	public function testLearnerCalculationDoesntRescheduleWhenStartedManyTimes() {
+		$job       = new Sensei_Enrolment_Learner_Calculation_Job();
 		$scheduler = Sensei_Enrolment_Job_Scheduler::instance();
 
 		$scheduler->maybe_start_learner_calculation();
 		$scheduler->maybe_start_learner_calculation();
 		$scheduler->maybe_start_learner_calculation();
+
+		$job->end();
 
 		$this->assertEventScheduledCount( 1, Sensei_Enrolment_Learner_Calculation_Job::NAME, 'The job should have been scheduled once.' );
 	}
@@ -74,6 +79,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 	 * Tests that once the scheduler run is completed, subsequent starts have no effect.
 	 */
 	public function testLearnerCalculationDoesntStartAfterCompletion() {
+		$job               = new Sensei_Enrolment_Learner_Calculation_Job();
 		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
 		$scheduler         = Sensei_Enrolment_Job_Scheduler::instance();
 
@@ -90,6 +96,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 		);
 
 		$scheduler->maybe_start_learner_calculation();
+		$job->end();
 
 		$this->assertEventScheduledCount( 2, Sensei_Enrolment_Learner_Calculation_Job::NAME, 'The job should not have started again after it was completed' );
 	}
@@ -99,6 +106,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 	 * Tests that when there are no users to calculate, the schedule run is completed.
 	 */
 	public function testLearnerCalculationCompletesWhenUsersAreCalculated() {
+		$job               = new Sensei_Enrolment_Learner_Calculation_Job();
 		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
 		$scheduler         = Sensei_Enrolment_Job_Scheduler::instance();
 
@@ -118,6 +126,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 		}
 
 		$scheduler->run_learner_calculation();
+		$job->end();
 
 		$option = get_option( Sensei_Enrolment_Job_Scheduler::CALCULATION_VERSION_OPTION_NAME );
 		$this->assertEquals( $enrolment_manager->get_enrolment_calculation_version(), $option );

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
@@ -26,6 +26,7 @@ class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
 		parent::tearDown();
 
 		remove_all_filters( 'sensei_enrolment_learner_calculation_job_batch_size' );
+		( new Sensei_Enrolment_Learner_Calculation_Job() )->end();
 	}
 
 	/**
@@ -41,6 +42,7 @@ class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
 		);
 
 		$job = new Sensei_Enrolment_Learner_Calculation_Job();
+		$job->setup( 'version' );
 
 		$mock = $this->getMockBuilder( Sensei_Course_Enrolment_Manager::class )
 			->disableOriginalConstructor()
@@ -85,6 +87,7 @@ class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
 
 		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
 		$job               = new Sensei_Enrolment_Learner_Calculation_Job();
+		$job->setup( 'version' );
 
 		$mock = $this->getMockBuilder( Sensei_Course_Enrolment_Manager::class )
 			->disableOriginalConstructor()


### PR DESCRIPTION
I'm working on a site that already has a quite large usermeta table. Sensei is not the primary user of the usermeta table in this case. Queries that use `LEFT JOIN` that include a meta value seem to take too long after a certain point. 

#### Changes proposed in this Pull Request:

* Uses a similar strategy from #3029 (but in a more simple way) for the learner calculation job.

#### Testing instructions:

* Migrate to this branch from a pre-3.0 instance of Sensei. 
* Ensure all the calculations are performed.
