### PR TITLE
Fixing "course name" missing from "Your student has started a course" email

### DIFF
--- a/includes/emails/class-sensei-email-teacher-started-course.php
+++ b/includes/emails/class-sensei-email-teacher-started-course.php
@@ -55,13 +55,13 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Started_Course' ) ) :
 
 			do_action( 'sensei_before_mail', $this->recipient );
 
-			// Get course name
+			// Get course name.
 			$course_post = get_post( $course_id );
 			$course_name = esc_html( $course_post->post_title );
 
-			// translators: Placeholders are the blog name and Course Name
+			// translators: Placeholders are the blog name and Course Name.
 			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has started a new course: %2$s ', 'sensei-lms' ), get_bloginfo( 'name' ), $course_name ), $this->template );
-			// translators: Placeholder is the Course Name
+			// translators: Placeholder is the Course Name.
 			$this->heading = apply_filters( 'sensei_email_heading', sprintf( __( 'Your student has started the course: %1$s', 'sensei-lms' ), $course_name ), $this->template );
 
 			// Construct data array

--- a/includes/emails/class-sensei-email-teacher-started-course.php
+++ b/includes/emails/class-sensei-email-teacher-started-course.php
@@ -55,13 +55,13 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Started_Course' ) ) :
 
 			do_action( 'sensei_before_mail', $this->recipient );
 
-			//Get course name
+			// Get course name
 			$course_post = get_post( $course_id );
 			$course_name = esc_html( $course_post->post_title );
 
-			// translators: Placeholders are the blog name and Course Name.
+			// translators: Placeholders are the blog name and Course Name
 			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has started a new course: %2$s ', 'sensei-lms' ), get_bloginfo( 'name' ), $course_name ), $this->template );
-			// translators: Placeholder is the Course Name.
+			// translators: Placeholder is the Course Name
 			$this->heading = apply_filters( 'sensei_email_heading', sprintf( __( 'Your student has started the course: %1$s', 'sensei-lms' ), $course_name ), $this->template );
 
 			// Construct data array

--- a/includes/emails/class-sensei-email-teacher-started-course.php
+++ b/includes/emails/class-sensei-email-teacher-started-course.php
@@ -60,7 +60,7 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Started_Course' ) ) :
 			$course_name = esc_html( $course_post->post_title );
 
 			// translators: Placeholders are the blog name and Course Name.
-			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has started a new course: %2$s ', 'sensei-lms' ), get_bloginfo( 'name' ), $course_title ), $this->template );
+			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has started a new course: %2$s ', 'sensei-lms' ), get_bloginfo( 'name' ), $course_name ), $this->template );
 			// translators: Placeholder is the Course Name.
 			$this->heading = apply_filters( 'sensei_email_heading', sprintf( __( 'Your student has started the course: %1$s', 'sensei-lms' ), $course_name ), $this->template );
 

--- a/includes/emails/class-sensei-email-teacher-started-course.php
+++ b/includes/emails/class-sensei-email-teacher-started-course.php
@@ -55,9 +55,14 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Started_Course' ) ) :
 
 			do_action( 'sensei_before_mail', $this->recipient );
 
-			// translators: Placeholder is the blog name.
-			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has started a course', 'sensei-lms' ), get_bloginfo( 'name' ) ), $this->template );
-			$this->heading = apply_filters( 'sensei_email_heading', __( 'Your student has started a course', 'sensei-lms' ), $this->template );
+			//Get course name
+			$course_post = get_post( $course_id );
+			$course_name = esc_html( $course_post->post_title );
+
+			// translators: Placeholders are the blog name and Course Name.
+			$this->subject = apply_filters( 'sensei_email_subject', sprintf( __( '[%1$s] Your student has started a new course: %2$s ', 'sensei-lms' ), get_bloginfo( 'name' ), $course_title ), $this->template );
+			// translators: Placeholder is the Course Name.
+			$this->heading = apply_filters( 'sensei_email_heading', sprintf( __( 'Your student has started the course: %1$s', 'sensei-lms' ), $course_name ), $this->template );
 
 			// Construct data array
 			$sensei_email_data = apply_filters(
@@ -69,6 +74,7 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Started_Course' ) ) :
 					'learner_id'   => $learner_id,
 					'learner_name' => $this->learner->display_name,
 					'course_id'    => $course_id,
+					'course_name'  => $course_name,
 				),
 				$this->template
 			);

--- a/templates/emails/teacher-started-course.php
+++ b/templates/emails/teacher-started-course.php
@@ -32,7 +32,7 @@ $large = 'text-align: center !important;font-size: 350% !important;line-height: 
 
 <p style="<?php echo esc_attr( $small ); ?>"><?php esc_html_e( 'has started the course', 'sensei-lms' ); ?></p>
 
-<h2 style="<?php echo esc_attr( $large ); ?>"><?php echo esc_html( get_the_title( $course_id ) ); ?></h2>
+<h2 style="<?php echo esc_attr( $large ); ?>"><?php echo esc_html( $course_name ); ?></h2>
 
 <hr/>
 


### PR DESCRIPTION
Fixes #2757

#### Changes proposed in this Pull Request:

* Adding course name to teacher email - get_post_title is not working so need to grab title from get_post() instead.

#### Testing instructions:

* Sign up for a course and the emailed template sent to teacher will populate the course names as it should