### PR TITLE
Use a less filtered method for checking if user has started course

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1399,17 +1399,17 @@ class Sensei_Utils {
 	 */
 	public static function user_start_course( $user_id = 0, $course_id = 0 ) {
 
-		$activity_logged = false;
+		$activity_comment_id = false;
 
 		if ( $user_id && $course_id ) {
-			// Check if user is already on the Course
-			$activity_logged = self::has_started_course( $course_id, $user_id );
-			if ( ! $activity_logged ) {
-				$activity_logged = self::start_user_on_course( $user_id, $course_id );
+			// Check if user is already on the Course.
+			$activity_comment_id = self::get_course_progress_comment_id( $course_id, $user_id );
+			if ( false === $activity_comment_id ) {
+				$activity_comment_id = self::start_user_on_course( $user_id, $course_id );
 			}
 		}
 
-		return $activity_logged;
+		return $activity_comment_id;
 	}
 
 	/**


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* I'm worried our previous check would restart courses on legacy instances that override the `sensei_user_started_course` filter.
* This method doesn't have the filter on it so should give a more raw result.

#### Testing instructions:

* On 2.0.0 instance, add snippet:
```php
if ( interface_exists( 'Sensei_Course_Enrolment_Provider_Interface' ) ) {
	add_filter( 'sensei_user_started_course', '__return_false' );
}
```
* Migrate to this branch. Ensure enrolment is calculated.
* Ensure course progress isn't reset.
