### PR TITLE
Block enrolment checking and display notice with WCPC v1

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -479,7 +479,7 @@ class Sensei_Course_Enrolment_Manager {
 		add_filter( 'sensei_is_enrolled', '__return_false' );
 
 		// Show admin notice.
-		add_action( 'admin_notices',  [ $this, 'add_wcpc_1_notice' ] );
+		add_action( 'admin_notices', [ $this, 'add_wcpc_1_notice' ] );
 	}
 
 	/**
@@ -487,7 +487,7 @@ class Sensei_Course_Enrolment_Manager {
 	 *
 	 * @access private
 	 */
-	public static function add_wcpc_1_notice() {
+	public function add_wcpc_1_notice() {
 		$screen        = get_current_screen();
 		$valid_screens = [ 'dashboard', 'plugins', 'plugins-network', 'sensei-lms_page_sensei_learners' ];
 

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -495,7 +495,7 @@ class Sensei_Course_Enrolment_Manager {
 			return;
 		}
 
-		$message = __( '<strong>Sensei LMS</strong> has detected an incompatible version of WooCommerce Paid Courses. Learners will not be able to access their courses until it is deactivated or upgraded to version 2.0.0 or greater.', 'sensei-lms' );
+		$message = __( '<strong>Sensei LMS</strong> has detected an incompatible version of WooCommerce Paid Courses. Learners will not be able to access their courses until it is upgraded to version 2.0.0 or greater.', 'sensei-lms' );
 
 		echo '<div class="error"><p>';
 		echo wp_kses( $message, [ 'strong' => [] ] );

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -65,6 +65,7 @@ class Sensei_Course_Enrolment_Manager {
 	 * Sets the actions.
 	 */
 	public function init() {
+		add_action( 'plugins_loaded', [ $this, 'detect_wcpc_1' ], 100 );
 		add_action( 'init', [ $this, 'collect_enrolment_providers' ], 100 );
 		add_action( 'shutdown', [ $this, 'run_deferred_course_enrolment_checks' ] );
 		add_action( 'sensei_enrolment_results_calculated', [ $this, 'remove_deferred_enrolment_check' ], 10, 3 );
@@ -459,5 +460,45 @@ class Sensei_Course_Enrolment_Manager {
 		$current_hash = md5( implode( '-', $hash_components ) );
 
 		return $current_hash . '-' . Sensei()->version;
+	}
+
+	/**
+	 * Detect WooCommerce Paid Courses v1 and disable the enrolment functionality while it is installed.
+	 *
+	 * @access private
+	 */
+	public function detect_wcpc_1() {
+		if (
+			! defined( 'SENSEI_WC_PAID_COURSES_VERSION' )
+			|| '1.' !== substr( SENSEI_WC_PAID_COURSES_VERSION, 0, 2 )
+		) {
+			return;
+		}
+
+		// Disable enrolment system until WCPC is deactivated or upgraded.
+		add_filter( 'sensei_is_enrolled', '__return_false' );
+
+		// Show admin notice.
+		add_action( 'admin_notices',  [ $this, 'add_wcpc_1_notice' ] );
+	}
+
+	/**
+	 * Adds notice in WP Admin when we detect WooCommerce Paid Courses v1 is installed.
+	 *
+	 * @access private
+	 */
+	public static function add_wcpc_1_notice() {
+		$screen        = get_current_screen();
+		$valid_screens = [ 'dashboard', 'plugins', 'plugins-network', 'sensei-lms_page_sensei_learners' ];
+
+		if ( ! current_user_can( 'activate_plugins' ) || ! in_array( $screen->id, $valid_screens, true ) ) {
+			return;
+		}
+
+		$message = __( '<strong>Sensei LMS</strong> has detected an incompatible version of WooCommerce Paid Courses. Learners will not be able to access their courses until it is deactivated or upgraded to version 2.0.0 or greater.', 'sensei-lms' );
+
+		echo '<div class="error"><p>';
+		echo wp_kses( $message, [ 'strong' => [] ] );
+		echo '</p></div>';
 	}
 }

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -477,6 +477,7 @@ class Sensei_Course_Enrolment_Manager {
 
 		// Disable enrolment system until WCPC is deactivated or upgraded.
 		add_filter( 'sensei_is_enrolled', '__return_false' );
+		add_filter( 'sensei_course_enrolment_providers', '__return_empty_array', 100 );
 
 		// Show admin notice.
 		add_action( 'admin_notices', [ $this, 'add_wcpc_1_notice' ] );


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* Detects WCPC v1. If it is activated, this will display a notice and block enrolment until WCPC is upgraded or deactivated.

#### Testing instructions:

* In a WCPC v1 + Sensei v2 environment, switch to this branch in Sensei. 
* You should see a notice appear on the Dashboard, Plugins, and Learner Management pages.
* Course access should be blocked for all learners.
* My Courses page should be empty for all learners.
* `sensei_learner_calculated_version` user meta will get calculated with the learner job, but that is okay. No other `sensei_` user meta should exist.
* Switch to WCPC `master`.
* Reload My Courses for a learner who should be enrolled in some courses. Courses should  appear even before the learner job finishes.
* Learners should regain access.
* Admin notice should no longer appear.