### PR TITLE
Add multisite support for enrolment data

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -218,7 +218,7 @@ class Sensei_Data_Cleaner {
 		'^_module_progress_[0-9]+_[0-9]+$',
 		'^%BLOG_PREFIX%sensei_learner_calculated_version$',
 		'^%BLOG_PREFIX%sensei_course_enrolment_[0-9]+$',
-		'^%BLOG_PREFIX%sensei_enrolment_providers_state_[0-9]+$',
+		'^%BLOG_PREFIX%sensei_enrolment_providers_state$',
 	);
 
 	/**

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -216,9 +216,9 @@ class Sensei_Data_Cleaner {
 	private static $user_meta_keys = array(
 		'^sensei_hide_menu_settings_notice$',
 		'^_module_progress_[0-9]+_[0-9]+$',
-		'sensei_learner_calculated_version$',
-		'sensei_course_enrolment_[0-9]+$',
-		'sensei_enrolment_providers_state_[0-9]+$',
+		'^%BLOG_PREFIX%sensei_learner_calculated_version$',
+		'^%BLOG_PREFIX%sensei_course_enrolment_[0-9]+$',
+		'^%BLOG_PREFIX%sensei_enrolment_providers_state_[0-9]+$',
 	);
 
 	/**
@@ -393,6 +393,8 @@ class Sensei_Data_Cleaner {
 		global $wpdb;
 
 		foreach ( self::$user_meta_keys as $meta_key ) {
+			$meta_key = str_replace( '%BLOG_PREFIX%', preg_quote( $wpdb->get_blog_prefix() ), $meta_key );
+
 			$wpdb->query(
 				$wpdb->prepare(
 					"DELETE FROM {$wpdb->usermeta} WHERE meta_key RLIKE %s",

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -216,9 +216,9 @@ class Sensei_Data_Cleaner {
 	private static $user_meta_keys = array(
 		'^sensei_hide_menu_settings_notice$',
 		'^_module_progress_[0-9]+_[0-9]+$',
-		'^sensei_learner_calculated_version$',
-		'^sensei_course_enrolment_[0-9]+$',
-		'^sensei_enrolment_providers_state_[0-9]+$',
+		'sensei_learner_calculated_version$',
+		'sensei_course_enrolment_[0-9]+$',
+		'sensei_enrolment_providers_state_[0-9]+$',
 	);
 
 	/**

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -393,7 +393,7 @@ class Sensei_Data_Cleaner {
 		global $wpdb;
 
 		foreach ( self::$user_meta_keys as $meta_key ) {
-			$meta_key = str_replace( '%BLOG_PREFIX%', preg_quote( $wpdb->get_blog_prefix() ), $meta_key );
+			$meta_key = str_replace( '%BLOG_PREFIX%', preg_quote( $wpdb->get_blog_prefix(), null ), $meta_key );
 
 			$wpdb->query(
 				$wpdb->prepare(

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -384,7 +384,7 @@ class Sensei_Course_Enrolment_Manager {
 	 * @see Sensei_Course_Enrolment_Manager::trigger_course_enrolment_check
 	 */
 	public function recalculate_enrolments( $user_id ) {
-		$learner_calculated_version = get_user_meta( $user_id, self::LEARNER_CALCULATION_META_NAME, true );
+		$learner_calculated_version = get_user_meta( $user_id, self::get_learner_calculated_version_meta_key(), true );
 		if ( $this->get_enrolment_calculation_version() === $learner_calculated_version ) {
 			return;
 		}
@@ -408,7 +408,7 @@ class Sensei_Course_Enrolment_Manager {
 
 		update_user_meta(
 			$user_id,
-			self::LEARNER_CALCULATION_META_NAME,
+			self::get_learner_calculated_version_meta_key(),
 			$this->get_enrolment_calculation_version()
 		);
 	}
@@ -443,7 +443,7 @@ class Sensei_Course_Enrolment_Manager {
 	 * @param int $user_id User ID.
 	 */
 	public function mark_user_as_needing_recalculation( $user_id ) {
-		delete_user_meta( $user_id, self::LEARNER_CALCULATION_META_NAME );
+		delete_user_meta( $user_id, self::get_learner_calculated_version_meta_key() );
 	}
 
 	/**
@@ -459,5 +459,22 @@ class Sensei_Course_Enrolment_Manager {
 		$current_hash = md5( implode( '-', $hash_components ) );
 
 		return $current_hash . '-' . Sensei()->version;
+	}
+
+	/**
+	 * Get the learner calculated meta key.
+	 *
+	 * @return string
+	 */
+	public static function get_learner_calculated_version_meta_key() {
+		global $wpdb;
+
+		$meta_key = self::LEARNER_CALCULATION_META_NAME;
+
+		if ( is_multisite() ) {
+			$meta_key = $wpdb->get_blog_prefix() . $meta_key;
+		}
+
+		return $meta_key;
 	}
 }

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -469,12 +469,6 @@ class Sensei_Course_Enrolment_Manager {
 	public static function get_learner_calculated_version_meta_key() {
 		global $wpdb;
 
-		$meta_key = self::LEARNER_CALCULATION_META_NAME;
-
-		if ( is_multisite() ) {
-			$meta_key = $wpdb->get_blog_prefix() . $meta_key;
-		}
-
-		return $meta_key;
+		return $wpdb->get_blog_prefix() . self::LEARNER_CALCULATION_META_NAME;
 	}
 }

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -377,7 +377,15 @@ class Sensei_Course_Enrolment {
 	 * @return string
 	 */
 	public function get_enrolment_results_meta_key() {
-		return self::META_PREFIX_ENROLMENT_RESULTS . $this->course_id;
+		global $wpdb;
+
+		$meta_key = self::META_PREFIX_ENROLMENT_RESULTS . $this->course_id;
+
+		if ( is_multisite() ) {
+			$meta_key = $wpdb->get_blog_prefix() . $meta_key;
+		}
+
+		return $meta_key;
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -379,13 +379,7 @@ class Sensei_Course_Enrolment {
 	public function get_enrolment_results_meta_key() {
 		global $wpdb;
 
-		$meta_key = self::META_PREFIX_ENROLMENT_RESULTS . $this->course_id;
-
-		if ( is_multisite() ) {
-			$meta_key = $wpdb->get_blog_prefix() . $meta_key;
-		}
-
-		return $meta_key;
+		return $wpdb->get_blog_prefix() . self::META_PREFIX_ENROLMENT_RESULTS . $this->course_id;
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
@@ -69,7 +69,7 @@ class Sensei_Enrolment_Provider_Journal_Store implements JsonSerializable {
 		if ( ! isset( self::$instances[ $user_id ] ) ) {
 			self::$instances[ $user_id ] = new self( $user_id );
 
-			$provider_journal_stores = get_user_meta( $user_id, self::META_ENROLMENT_PROVIDERS_JOURNAL, true );
+			$provider_journal_stores = get_user_meta( $user_id, self::get_provider_journal_store_meta_key(), true );
 			if ( ! empty( $provider_journal_stores ) ) {
 				self::$instances[ $user_id ]->restore_from_json( $provider_journal_stores );
 			}
@@ -131,7 +131,7 @@ class Sensei_Enrolment_Provider_Journal_Store implements JsonSerializable {
 			return true;
 		}
 
-		$result = update_user_meta( $this->user_id, self::META_ENROLMENT_PROVIDERS_JOURNAL, wp_slash( wp_json_encode( $this ) ) );
+		$result = update_user_meta( $this->user_id, self::get_provider_journal_store_meta_key(), wp_slash( wp_json_encode( $this ) ) );
 
 		if ( ! $result || is_wp_error( $result ) ) {
 			return false;
@@ -274,5 +274,22 @@ class Sensei_Enrolment_Provider_Journal_Store implements JsonSerializable {
 		return isset( $journal_store->providers_journal[ $course_id ][ $provider->get_id() ] ) ?
 			$journal_store->providers_journal[ $course_id ][ $provider->get_id() ]->get_logs() :
 			[];
+	}
+
+	/**
+	 * Get the provider journal store meta key.
+	 *
+	 * @return string
+	 */
+	public static function get_provider_journal_store_meta_key() {
+		global $wpdb;
+
+		$meta_key = self::META_ENROLMENT_PROVIDERS_JOURNAL;
+
+		if ( is_multisite() ) {
+			$meta_key = $wpdb->get_blog_prefix() . $meta_key;
+		}
+
+		return $meta_key;
 	}
 }

--- a/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal-store.php
@@ -284,12 +284,6 @@ class Sensei_Enrolment_Provider_Journal_Store implements JsonSerializable {
 	public static function get_provider_journal_store_meta_key() {
 		global $wpdb;
 
-		$meta_key = self::META_ENROLMENT_PROVIDERS_JOURNAL;
-
-		if ( is_multisite() ) {
-			$meta_key = $wpdb->get_blog_prefix() . $meta_key;
-		}
-
-		return $meta_key;
+		return $wpdb->get_blog_prefix() . self::META_ENROLMENT_PROVIDERS_JOURNAL;
 	}
 }

--- a/includes/enrolment/class-sensei-enrolment-provider-journal.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-journal.php
@@ -29,7 +29,6 @@ class Sensei_Enrolment_Provider_Journal implements JsonSerializable {
 	 */
 	private $history;
 
-
 	/**
 	 * The message log of the provider. Each element of the array has the format:
 	 *     [

--- a/includes/enrolment/class-sensei-enrolment-provider-state-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-state-store.php
@@ -227,12 +227,6 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 	public static function get_provider_state_store_meta_key() {
 		global $wpdb;
 
-		$meta_key = self::META_ENROLMENT_PROVIDERS_STATE;
-
-		if ( is_multisite() ) {
-			$meta_key = $wpdb->get_blog_prefix() . $meta_key;
-		}
-
-		return $meta_key;
+		return $wpdb->get_blog_prefix() . self::META_ENROLMENT_PROVIDERS_STATE;
 	}
 }

--- a/includes/enrolment/class-sensei-enrolment-provider-state-store.php
+++ b/includes/enrolment/class-sensei-enrolment-provider-state-store.php
@@ -63,7 +63,7 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 		if ( ! isset( self::$instances[ $user_id ] ) ) {
 			self::$instances[ $user_id ] = new self( $user_id );
 
-			$provider_state_stores = get_user_meta( $user_id, self::META_ENROLMENT_PROVIDERS_STATE, true );
+			$provider_state_stores = get_user_meta( $user_id, self::get_provider_state_store_meta_key(), true );
 			if ( ! empty( $provider_state_stores ) ) {
 				self::$instances[ $user_id ]->restore_from_json( $provider_state_stores );
 			}
@@ -196,7 +196,7 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 			return true;
 		}
 
-		$result = update_user_meta( $this->get_user_id(), self::META_ENROLMENT_PROVIDERS_STATE, wp_slash( wp_json_encode( $this ) ) );
+		$result = update_user_meta( $this->get_user_id(), self::get_provider_state_store_meta_key(), wp_slash( wp_json_encode( $this ) ) );
 
 		if ( ! $result || is_wp_error( $result ) ) {
 			return false;
@@ -216,5 +216,23 @@ class Sensei_Enrolment_Provider_State_Store implements JsonSerializable {
 		foreach ( self::$instances as $user_id => $instance ) {
 			$instance->save();
 		}
+	}
+
+
+	/**
+	 * Get the provider state store meta key.
+	 *
+	 * @return string
+	 */
+	public static function get_provider_state_store_meta_key() {
+		global $wpdb;
+
+		$meta_key = self::META_ENROLMENT_PROVIDERS_STATE;
+
+		if ( is_multisite() ) {
+			$meta_key = $wpdb->get_blog_prefix() . $meta_key;
+		}
+
+		return $meta_key;
 	}
 }

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -89,10 +89,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 
 		$course_id               = $this->getSimpleCourse();
 		$student_id              = $this->createStandardStudent();
-		$course_results_meta_key = Sensei_Course_Enrolment::META_PREFIX_ENROLMENT_RESULTS . $course_id;
-		if ( is_multisite() ) {
-			$course_results_meta_key = $wpdb->get_blog_prefix() . $course_results_meta_key;
-		}
+		$course_results_meta_key = $wpdb->get_blog_prefix() . Sensei_Course_Enrolment::META_PREFIX_ENROLMENT_RESULTS . $course_id;
 
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
 		$this->prepareEnrolmentManager();
@@ -118,11 +115,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 
 		$course_id               = $this->getSimpleCourse();
 		$student_id              = $this->createStandardStudent();
-		$course_results_meta_key = Sensei_Course_Enrolment::META_PREFIX_ENROLMENT_RESULTS . $course_id;
-
-		if ( is_multisite() ) {
-			$course_results_meta_key = $wpdb->get_blog_prefix() . $course_results_meta_key;
-		}
+		$course_results_meta_key = $wpdb->get_blog_prefix() . Sensei_Course_Enrolment::META_PREFIX_ENROLMENT_RESULTS . $course_id;
 
 		$this->addEnrolmentProvider( Sensei_Test_Enrolment_Provider_Always_Provides::class );
 		$this->prepareEnrolmentManager();

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -388,7 +388,7 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 		$course_id     = $this->getSimpleCourse();
 		$student_id    = $this->createStandardStudent();
 		$persisted_set = '{"' . $course_id . '":{"always-provides":{"test":1234}}}';
-		update_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::META_ENROLMENT_PROVIDERS_STATE, $persisted_set );
+		update_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::get_provider_state_store_meta_key(), $persisted_set );
 
 		$provider_class = Sensei_Test_Enrolment_Provider_Always_Provides::class;
 		$this->addEnrolmentProvider( $provider_class );

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
@@ -112,7 +112,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 
 		update_user_meta(
 			1,
-			Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
+			Sensei_Course_Enrolment_Manager::get_learner_calculated_version_meta_key(),
 			$enrolment_manager->get_enrolment_calculation_version()
 		);
 
@@ -120,7 +120,7 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 			$user = $this->factory->user->create();
 			update_user_meta(
 				$user,
-				Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
+				Sensei_Course_Enrolment_Manager::get_learner_calculated_version_meta_key(),
 				$enrolment_manager->get_enrolment_calculation_version()
 			);
 		}

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-learner-calculation-job.php
@@ -58,7 +58,7 @@ class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
 		$user1 = $this->factory->user->create( [ 'user_login' => 'user1' ] );
 		update_user_meta(
 			$user1,
-			Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
+			Sensei_Course_Enrolment_Manager::get_learner_calculated_version_meta_key(),
 			'random-version-string'
 		);
 		$user2 = $this->factory->user->create( [ 'user_login' => 'user2' ] );
@@ -116,12 +116,12 @@ class Sensei_Enrolment_Learner_Calculation_Job_Test extends WP_UnitTestCase {
 		// Since we mock Sensei_Course_Enrolment_Manager::recalculate_enrolments we need to manually update users.
 		update_user_meta(
 			1,
-			Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
+			Sensei_Course_Enrolment_Manager::get_learner_calculated_version_meta_key(),
 			$enrolment_manager->get_enrolment_calculation_version()
 		);
 		update_user_meta(
 			$user1,
-			Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME,
+			Sensei_Course_Enrolment_Manager::get_learner_calculated_version_meta_key(),
 			$enrolment_manager->get_enrolment_calculation_version()
 		);
 

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-journal-store.php
@@ -44,13 +44,13 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 		Sensei_Enrolment_Provider_Journal_Store::add_provider_log_message( $provider, $user, $course, 'Test message' );
 		Sensei_Enrolment_Provider_Journal_Store::persist_all();
 
-		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_ENROLMENT_PROVIDERS_JOURNAL );
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::get_provider_journal_store_meta_key() );
 		$this->assertEmpty( $user_meta, 'Nothing should be stored with the filter returning false.' );
 
 		$this->enableJournal();
 		Sensei_Enrolment_Provider_Journal_Store::persist_all();
 
-		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_ENROLMENT_PROVIDERS_JOURNAL );
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::get_provider_journal_store_meta_key() );
 		$this->assertNotEmpty( $user_meta, 'Meta should be stored with the filter returning true.' );
 	}
 
@@ -67,7 +67,7 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 		Sensei_Enrolment_Provider_Journal_Store::add_provider_log_message( $provider, $user, $course, 'Second message' );
 		Sensei_Enrolment_Provider_Journal_Store::persist_all();
 
-		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_ENROLMENT_PROVIDERS_JOURNAL, true );
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::get_provider_journal_store_meta_key(), true );
 		$this->assertRegExp( '/.*always-provides.*Second message.*First message/', $user_meta, 'A meta with the provider id and the two messages should be stored.' );
 
 		$logs = Sensei_Enrolment_Provider_Journal_Store::get_provider_logs( $provider, $user, $course );
@@ -96,7 +96,7 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 		);
 		Sensei_Enrolment_Provider_Journal_Store::persist_all();
 
-		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_ENROLMENT_PROVIDERS_JOURNAL, true );
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::get_provider_journal_store_meta_key(), true );
 		$this->assertRegExp( '/.*manual.*s.*true/', $user_meta, 'Manual provider status should be true' );
 		$this->assertRegExp( '/.*simple.*s.*false/', $user_meta, 'Simple provider status should be true' );
 
@@ -112,7 +112,7 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 		);
 		Sensei_Enrolment_Provider_Journal_Store::persist_all();
 
-		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_ENROLMENT_PROVIDERS_JOURNAL, true );
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::get_provider_journal_store_meta_key(), true );
 		$this->assertRegExp( '/.*manual.*s.*false.*s.*true/', $user_meta, 'Manual provider status should be initially true then false' );
 		$this->assertRegExp( '/.*simple.*s.*true.*s.*false/', $user_meta, 'Simple provider status should be initially false then true' );
 	}
@@ -138,7 +138,7 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 		);
 		Sensei_Enrolment_Provider_Journal_Store::persist_all();
 
-		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_ENROLMENT_PROVIDERS_JOURNAL, true );
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::get_provider_journal_store_meta_key(), true );
 		$this->assertEmpty( $user_meta, 'Meta should not be stored if the user is not enrolled to any courses.' );
 
 		// Test that after the user gets enrolled, the meta is stored.
@@ -154,7 +154,7 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 		);
 		Sensei_Enrolment_Provider_Journal_Store::persist_all();
 
-		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_ENROLMENT_PROVIDERS_JOURNAL, true );
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::get_provider_journal_store_meta_key(), true );
 		$this->assertNotEmpty( $user_meta, 'Meta should be stored after the user gets enrolled to the courses.' );
 
 		// Test that changes are stored after the user gets enrolled.
@@ -170,7 +170,7 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 		);
 		Sensei_Enrolment_Provider_Journal_Store::persist_all();
 
-		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_ENROLMENT_PROVIDERS_JOURNAL, true );
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::get_provider_journal_store_meta_key(), true );
 		$this->assertRegExp( '/.*manual.*s.*false.*s.*false/', $user_meta, 'Manual provider status should be false in both entries.' );
 		$this->assertRegExp( '/.*simple.*s.*false.*s.*true/', $user_meta, 'Simple provider status should be initially true then false.' );
 
@@ -188,7 +188,7 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 		);
 		Sensei_Enrolment_Provider_Journal_Store::persist_all();
 
-		$user_meta     = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_ENROLMENT_PROVIDERS_JOURNAL, true );
+		$user_meta     = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::get_provider_journal_store_meta_key(), true );
 		$journal_array = json_decode( $user_meta, true );
 		$this->assertArrayHasKey( $course, $journal_array );
 		$this->assertArrayNotHasKey( $second_course, $journal_array );
@@ -217,7 +217,7 @@ class Sensei_Enrolment_Provider_Journal_Store_Test extends WP_UnitTestCase {
 		);
 		Sensei_Enrolment_Provider_Journal_Store::persist_all();
 
-		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::META_ENROLMENT_PROVIDERS_JOURNAL, true );
+		$user_meta = get_user_meta( $user, Sensei_Enrolment_Provider_Journal_Store::get_provider_journal_store_meta_key(), true );
 		$this->assertRegExp( '/.*manual.*s.*false/', $user_meta, 'Manual provider status should be stored.' );
 		$this->assertRegExp( '/.*simple.*s.*false/', $user_meta, 'Simple provider status should be stored.' );
 	}

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-provider-state-store.php
@@ -151,7 +151,7 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 		$course_id     = $this->getSimpleCourse();
 		$student_id    = $this->createStandardStudent();
 		$persisted_set = '{"' . $course_id . '":{"always-provides":{"test":1234}}}';
-		update_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::META_ENROLMENT_PROVIDERS_STATE, $persisted_set );
+		update_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::get_provider_state_store_meta_key(), $persisted_set );
 
 		$provider_class = Sensei_Test_Enrolment_Provider_Always_Provides::class;
 		$this->addEnrolmentProvider( $provider_class );
@@ -167,7 +167,7 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 		$provider_state->save();
 
 		$expected_persisted_set = '{"' . $course_id . '":{"always-provides":{"test":54321}}}';
-		$persisted_set          = get_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::META_ENROLMENT_PROVIDERS_STATE, true );
+		$persisted_set          = get_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::get_provider_state_store_meta_key(), true );
 		$this->assertEquals( $expected_persisted_set, $persisted_set, 'The changed stored value should have been persisted' );
 	}
 
@@ -178,7 +178,7 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 		$course_id     = $this->getSimpleCourse();
 		$student_id    = $this->createStandardStudent();
 		$persisted_set = '{"' . $course_id . '":{"always-provides":{"test":1234}}}';
-		update_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::META_ENROLMENT_PROVIDERS_STATE, $persisted_set );
+		update_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::get_provider_state_store_meta_key(), $persisted_set );
 
 		$provider_class = Sensei_Test_Enrolment_Provider_Always_Provides::class;
 		$this->addEnrolmentProvider( $provider_class );
@@ -190,7 +190,7 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 		$provider_state    = $course_enrolment->get_provider_state( $provider, $student_id );
 
 		// Background remove user meta.
-		delete_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::META_ENROLMENT_PROVIDERS_STATE );
+		delete_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::get_provider_state_store_meta_key() );
 
 		// This isn't a change in the stored value.
 		$provider_state->set_stored_value( 'test', 1234 );
@@ -198,7 +198,7 @@ class Sensei_Enrolment_Provider_State_Store_Test extends WP_UnitTestCase {
 		$provider_state->save();
 
 		$expected_persisted_set = null;
-		$persisted_set          = get_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::META_ENROLMENT_PROVIDERS_STATE, true );
+		$persisted_set          = get_user_meta( $student_id, Sensei_Enrolment_Provider_State_Store::get_provider_state_store_meta_key(), true );
 		$this->assertEquals( $expected_persisted_set, $persisted_set, 'The state stores should NOT have been persisted without a change' );
 	}
 

--- a/tests/unit-tests/test-class-learner.php
+++ b/tests/unit-tests/test-class-learner.php
@@ -205,7 +205,7 @@ class Sensei_Class_Student_Test extends WP_UnitTestCase {
 			$this->directlyEnrolStudent( $student_id, $course_id );
 		}
 
-		$user_meta = get_user_meta( $student_id, Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME, true );
+		$user_meta = get_user_meta( $student_id, Sensei_Course_Enrolment_Manager::get_learner_calculated_version_meta_key(), true );
 		$this->assertEmpty( $user_meta, 'Learner should not be calculated prior to querying courses' );
 
 		// This should run
@@ -214,7 +214,7 @@ class Sensei_Class_Student_Test extends WP_UnitTestCase {
 		];
 		$query_enrolled_courses = $learner_manager->get_enrolled_courses_query( $student_id, $base_query_args );
 
-		$user_meta = get_user_meta( $student_id, Sensei_Course_Enrolment_Manager::LEARNER_CALCULATION_META_NAME, true );
+		$user_meta = get_user_meta( $student_id, Sensei_Course_Enrolment_Manager::get_learner_calculated_version_meta_key(), true );
 		$this->assertEquals( Sensei_Course_Enrolment_Manager::instance()->get_enrolment_calculation_version(), $user_meta, 'Learner should have been calculated prior to querying courses' );
 
 		$this->assertTrue( $query_enrolled_courses instanceof WP_Query, 'Returned value should be instance of WP_Query' );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Prefixes user meta for enrolment data to support multisite installations.

### Testing Notes
- Test everything on normal sites 😆 .

#### Multisite Install on Sensei v2.
- Create two sites. Activate Sensei on both sites. Note: Network activate doesn't set up the prompt for creating Sensei pages, so I'd recommend that you activate on the site level.
- Create multiple users. Have some users be on both sites while others are just on individual sites.
- Create multiple courses on each site. For some courses, create lessons.
- Enrol users in courses. 
- For one user, progress and complete the lessons for a course with lessons.
- Create a database snapshot.

#### This branch.
- Switch to this branch on Sensei.
- Log in and ensure calculation job starts and runs.
- Check usermeta table. All `%sensei%` user meta should be prefixed with the blog table prefix.
- Only users who have been added to a site should have state and cached enrolment results for the courses on the site.
- Test manual enrolment flows.

Note: I continued to use `*_user_meta` instead of `*_user_option` methods because it was less change at this point in time _and_ `get_user_option` seemed to not update its memory values when `update_user_option` is called. This is probably a solvable problem, but seemed like a larger change at this point in time.