### PR TITLE
Fix webpack source maps

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,8 @@
 const path = require( 'path' );
+const process = require( 'process' );
 const { fromPairs } = require( 'lodash' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
+const isDevelopment = process.env.NODE_ENV !== 'production';
 
 const files = [
 	'js/admin/course-edit.js',
@@ -68,6 +70,9 @@ function getWebpackConfig( env, argv ) {
 		output: {
 			path: path.resolve( './assets/dist' ),
 		},
+		devtool:
+			process.env.SOURCEMAP ||
+			( isDevelopment ? 'eval-source-map' : false ),
 		module: {
 			rules: [ FileLoader, ...webpackConfig.module.rules ],
 		},


### PR DESCRIPTION
This is just a small change in what kind of source maps webpack generates, as the default one was throwing warnings for `node_modules` libraries, and generally not working. 

Environmental variable checks for enabling it is the same as the base calypso config.

### Testing instructions

* Run `npm start` to start webpack in development mode
* Open `/wp-admin/admin.php?page=sensei_onboarding`
* Open browser Developer Tools, open Sources (Chrome) or Debugger (Firefox) tab
* Original `jsx` source codes should be available under `webpack/assets/onboarding`
* Breakpoints should work in these.
* Console should not be full of warnings about source maps.

