### PR TITLE
Return early when checking enrolment for guests

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -93,6 +93,10 @@ class Sensei_Course_Enrolment {
 	 * @return bool
 	 */
 	public function is_enrolled( $user_id, $check_cache = true ) {
+		if ( empty( $user_id ) ) {
+			return false;
+		}
+
 		/**
 		 * Allow complete side-stepping of enrolment handling in Sensei.
 		 *

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -93,7 +93,7 @@ class Sensei_Course_Enrolment {
 	 * @return bool
 	 */
 	public function is_enrolled( $user_id, $check_cache = true ) {
-		if ( empty( $user_id ) ) {
+		if ( ! $user_id ) {
 			return false;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Return `false` early on enrolment checks. Should prevent strange issues from occurring.

No testing instructions, but it seems like this should definitely be in place. I think for most places, enrolment isn't even checked for guests. However, there does seem to be some cases where it does.