### PR TITLE
Build in Travis on release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ notifications:
 branches:
   only:
   - master
+  - /^release\//
 cache:
   directories:
   - vendor


### PR DESCRIPTION
Should initiate builds when base branch is `release/*`.