### PR TITLE
Allow for non-master base branches on PHPCS checks

### DIFF
--- a/scripts/linter-ci
+++ b/scripts/linter-ci
@@ -46,8 +46,18 @@ rm -rf diffs/
 mkdir -p diffs/branch
 mkdir -p diffs/master
 
+base_branch=${TRAVIS_BRANCH:-master}
+
+echo "Getting merge base for ${base_branch}"
+
 # Get merge-base with master
-merge_base=`git merge-base HEAD master`
+
+if [[ "master" != "${base_branch}" ]]; then
+	git fetch origin ${base_branch}
+	git branch ${base_branch} FETCH_HEAD
+fi
+
+merge_base=`git merge-base HEAD ${base_branch}`
 
 if ! git diff $merge_base.. --name-only | grep '\.php$' > diffs/changed-files
 then


### PR DESCRIPTION
Fixes issue when running PHPCS comparisons on non-`master` base branches.