### PR TITLE
Add help tab on Courses page to re-launch setup wizard

### DIFF
--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -36,6 +36,7 @@ class Sensei_Onboarding {
 
 		if ( is_admin() ) {
 			add_action( 'admin_menu', [ $this, 'admin_menu' ], 20 );
+			add_action( 'current_screen', [ $this, 'add_onboarding_help_tab' ] );
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 			if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
@@ -95,6 +96,42 @@ class Sensei_Onboarding {
 
 		</div>
 		<?php
+	}
+
+	/**
+	 * Check if should show help tab or not.
+	 *
+	 * @param string $screen_id Screen ID to check if should show the help tab.
+	 *
+	 * @return boolean
+	 */
+	private function should_show_help_screen( $screen_id ) {
+		return 'edit-course' === $screen_id;
+	}
+
+	/**
+	 * Add onboarding help tab.
+	 *
+	 * @access private
+	 */
+	public function add_onboarding_help_tab() {
+		$screen = get_current_screen();
+
+		if ( ! $screen || ! $this->should_show_help_screen( $screen->id ) ) {
+			return;
+		}
+
+		$screen->add_help_tab(
+			[
+				'id'      => 'sensei_lms_onboarding_tab',
+				'title'   => __( 'Setup wizard', 'sensei-lms' ),
+				'content' =>
+					'<h2>' . __( 'Sensei LMS Onboarding', 'sensei-lms' ) . '</h2>' .
+					'<h3>' . __( 'Setup Wizard', 'sensei-lms' ) . '</h3>' .
+					'<p>' . __( 'If you need to access the setup wizard again, please click on the button bellow.', 'sensei-lms' ) . '</p>' .
+					'<p><a href="' . admin_url( 'admin.php?page=' . $this->page_slug ) . '" class="button button-primary">' . __( 'Setup wizard', 'sensei-lms' ) . '</a></p>',
+			]
+		);
 	}
 
 }

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -38,8 +38,7 @@ class Sensei_Onboarding {
 			add_action( 'admin_menu', [ $this, 'admin_menu' ], 20 );
 			add_action( 'current_screen', [ $this, 'add_onboarding_help_tab' ] );
 
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
-			if ( isset( $_GET['post_type'] ) && 'course' === $_GET['post_type'] ) {
+			if ( $this->should_prevent_woocommerce_help_tab() ) {
 				// Prevent WooCommerce help tab.
 				add_filter( 'woocommerce_enable_admin_help_tab', '__return_false' );
 			}
@@ -72,6 +71,21 @@ class Sensei_Onboarding {
 			}
 		}
 
+	}
+
+	/**
+	 * Check if should prevent woocommerce help tab or not.
+	 *
+	 * @return boolean
+	 */
+	private function should_prevent_woocommerce_help_tab() {
+		$post_types_to_prevent = [ 'course', 'lesson', 'sensei_message' ];
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
+		return isset( $_GET['post_type'] ) && (
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
+			in_array( $_GET['post_type'], $post_types_to_prevent, true )
+		);
 	}
 
 	/**

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -116,7 +116,8 @@ class Sensei_Onboarding {
 	 * @access private
 	 */
 	public function add_onboarding_help_tab() {
-		$screen = get_current_screen();
+		$screen           = get_current_screen();
+		$link_track_event = 'sensei_setup_wizard_click';
 
 		if ( ! $screen || ! $this->should_show_help_screen( $screen->id ) ) {
 			return;
@@ -130,7 +131,7 @@ class Sensei_Onboarding {
 					'<h2>' . __( 'Sensei LMS Onboarding', 'sensei-lms' ) . '</h2>' .
 					'<h3>' . __( 'Setup Wizard', 'sensei-lms' ) . '</h3>' .
 					'<p>' . __( 'If you need to access the setup wizard again, please click on the button bellow.', 'sensei-lms' ) . '</p>' .
-					'<p><a href="' . admin_url( 'admin.php?page=' . $this->page_slug ) . '" class="button button-primary">' . __( 'Setup wizard', 'sensei-lms' ) . '</a></p>',
+					'<p><a href="' . admin_url( 'admin.php?page=' . $this->page_slug ) . '" class="button button-primary" data-sensei-log-event="' . $link_track_event . '">' . __( 'Setup wizard', 'sensei-lms' ) . '</a></p>',
 			]
 		);
 	}

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -37,6 +37,7 @@ class Sensei_Onboarding {
 		if ( is_admin() ) {
 			add_action( 'admin_menu', [ $this, 'admin_menu' ], 20 );
 			add_action( 'current_screen', [ $this, 'add_onboarding_help_tab' ] );
+			add_filter( 'woocommerce_screen_ids', [ $this, 'filter_woocommerce_screen_ids' ], 11 );
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 			if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
@@ -134,4 +135,22 @@ class Sensei_Onboarding {
 		);
 	}
 
+	/**
+	 * Filter the woocommerce screens to prevent show the WooCommerce
+	 * help tab together with the onboarding tab.
+	 *
+	 * @access private
+	 *
+	 * @param string[] $screen_ids List of screen IDs considered as WooCommerce screen.
+	 *
+	 * @return $screen_ids Filtered screens.
+	 */
+	public function filter_woocommerce_screen_ids( $screen_ids ) {
+		return array_filter(
+			$screen_ids,
+			function( $screen_id ) {
+				return ! $this->should_show_help_screen( $screen_id );
+			}
+		);
+	}
 }

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -116,10 +116,11 @@ class Sensei_Onboarding {
 	 * @access private
 	 */
 	public function add_onboarding_help_tab() {
-		$screen           = get_current_screen();
-		$link_track_event = 'sensei_setup_wizard_click';
+		$screen                 = get_current_screen();
+		$setup_wizard_completed = get_option( 'sensei_setup_wizard_completed' );
+		$link_track_event       = 'sensei_setup_wizard_click';
 
-		if ( ! $screen || ! $this->should_show_help_screen( $screen->id ) ) {
+		if ( ! $screen || ! $this->should_show_help_screen( $screen->id ) || $setup_wizard_completed ) {
 			return;
 		}
 

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -130,7 +130,7 @@ class Sensei_Onboarding {
 				'content' =>
 					'<h2>' . __( 'Sensei LMS Onboarding', 'sensei-lms' ) . '</h2>' .
 					'<h3>' . __( 'Setup Wizard', 'sensei-lms' ) . '</h3>' .
-					'<p>' . __( 'If you need to access the setup wizard again, please click on the button bellow.', 'sensei-lms' ) . '</p>' .
+					'<p>' . __( 'If you need to access the setup wizard again, please click on the button below.', 'sensei-lms' ) . '</p>' .
 					'<p><a href="' . admin_url( 'admin.php?page=' . $this->page_slug ) . '" class="button button-primary" data-sensei-log-event="' . $link_track_event . '">' . __( 'Setup wizard', 'sensei-lms' ) . '</a></p>',
 			]
 		);

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -37,7 +37,7 @@ class Sensei_Onboarding {
 		if ( is_admin() ) {
 			add_action( 'admin_menu', [ $this, 'admin_menu' ], 20 );
 			add_action( 'current_screen', [ $this, 'add_onboarding_help_tab' ] );
-			add_filter( 'woocommerce_screen_ids', [ $this, 'filter_woocommerce_screen_ids' ], 11 );
+			add_filter( 'woocommerce_screen_ids', [ $this, 'remove_some_sensei_screens_from_woocommerce_screens' ], 11 );
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 			if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
@@ -146,7 +146,7 @@ class Sensei_Onboarding {
 	 *
 	 * @return $screen_ids Filtered screens.
 	 */
-	public function filter_woocommerce_screen_ids( $screen_ids ) {
+	public function remove_some_sensei_screens_from_woocommerce_screens( $screen_ids ) {
 		return array_filter(
 			$screen_ids,
 			function( $screen_id ) {

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -116,11 +116,10 @@ class Sensei_Onboarding {
 	 * @access private
 	 */
 	public function add_onboarding_help_tab() {
-		$screen                 = get_current_screen();
-		$setup_wizard_completed = get_option( 'sensei_setup_wizard_completed' );
-		$link_track_event       = 'sensei_setup_wizard_click';
+		$screen           = get_current_screen();
+		$link_track_event = 'sensei_setup_wizard_click';
 
-		if ( ! $screen || ! $this->should_show_help_screen( $screen->id ) || $setup_wizard_completed ) {
+		if ( ! $screen || ! $this->should_show_help_screen( $screen->id ) ) {
 			return;
 		}
 

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -80,7 +80,7 @@ class Sensei_Onboarding {
 	public function admin_menu() {
 		if ( current_user_can( 'manage_sensei' ) ) {
 			add_submenu_page(
-				'sensei',
+				null,
 				__( 'Onboarding', 'sensei-lms' ),
 				__( 'Onboarding', 'sensei-lms' ),
 				'manage_sensei',

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -118,10 +118,11 @@ class Sensei_Onboarding {
 	/**
 	 * Add onboarding help tab.
 	 *
+	 * @param WP_Screen $screen Current screen.
+	 *
 	 * @access private
 	 */
-	public function add_onboarding_help_tab() {
-		$screen           = get_current_screen();
+	public function add_onboarding_help_tab( $screen ) {
 		$link_track_event = 'sensei_setup_wizard_click';
 
 		if ( ! $screen || ! $this->should_show_help_screen( $screen->id ) ) {

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -123,7 +123,7 @@ class Sensei_Onboarding {
 	 * @access private
 	 */
 	public function add_onboarding_help_tab( $screen ) {
-		$link_track_event = 'sensei_setup_wizard_click';
+		$link_track_event = 'setup_wizard_click';
 
 		if ( ! $screen || ! $this->should_show_help_screen( $screen->id ) ) {
 			return;

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -41,7 +41,7 @@ class Sensei_Onboarding {
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 			if ( isset( $_GET['post_type'] ) && 'course' === $_GET['post_type'] ) {
 				// Prevent WooCommerce help tab.
-				add_filter( 'woocommerce_enable_admin_help_tab', __return_false );
+				add_filter( 'woocommerce_enable_admin_help_tab', '__return_false' );
 			}
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -37,7 +37,12 @@ class Sensei_Onboarding {
 		if ( is_admin() ) {
 			add_action( 'admin_menu', [ $this, 'admin_menu' ], 20 );
 			add_action( 'current_screen', [ $this, 'add_onboarding_help_tab' ] );
-			add_filter( 'woocommerce_screen_ids', [ $this, 'remove_some_sensei_screens_from_woocommerce_screens' ], 11 );
+
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
+			if ( isset( $_GET['post_type'] ) && 'course' === $_GET['post_type'] ) {
+				// Prevent WooCommerce help tab.
+				add_filter( 'woocommerce_enable_admin_help_tab', __return_false );
+			}
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 			if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
@@ -133,25 +138,6 @@ class Sensei_Onboarding {
 					'<p>' . __( 'If you need to access the setup wizard again, please click on the button below.', 'sensei-lms' ) . '</p>' .
 					'<p><a href="' . admin_url( 'admin.php?page=' . $this->page_slug ) . '" class="button button-primary" data-sensei-log-event="' . $link_track_event . '">' . __( 'Setup wizard', 'sensei-lms' ) . '</a></p>',
 			]
-		);
-	}
-
-	/**
-	 * Filter the woocommerce screens to prevent show the WooCommerce
-	 * help tab together with the onboarding tab.
-	 *
-	 * @access private
-	 *
-	 * @param string[] $screen_ids List of screen IDs considered as WooCommerce screen.
-	 *
-	 * @return $screen_ids Filtered screens.
-	 */
-	public function remove_some_sensei_screens_from_woocommerce_screens( $screen_ids ) {
-		return array_filter(
-			$screen_ids,
-			function( $screen_id ) {
-				return ! $this->should_show_help_screen( $screen_id );
-			}
 		);
 	}
 }

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -199,7 +199,7 @@ class Sensei_Main {
 	 *
 	 * @var Sensei_Onboarding
 	 */
-	private $onboarding;
+	public $onboarding;
 
 	/**
 	 * Constructor method.

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -397,6 +397,9 @@ class Sensei_Main {
 		$this->enrolment_scheduler = Sensei_Enrolment_Job_Scheduler::instance();
 		$this->enrolment_scheduler->init();
 
+		// Onboarding Wizard.
+		$this->onboarding = new Sensei_Onboarding();
+
 		// Differentiate between administration and frontend logic.
 		if ( is_admin() ) {
 			// Load Admin Class
@@ -404,9 +407,6 @@ class Sensei_Main {
 
 			// Load Analysis Reports
 			$this->analysis = new Sensei_Analysis( $this->main_plugin_file_name );
-
-			// Loading onboarding page
-			$this->onboarding = new Sensei_Onboarding();
 
 			if ( $this->feature_flags->is_enabled( 'rest_api_testharness' ) ) {
 				$this->test_harness = new Sensei_Admin_Rest_Api_Testharness( $this->main_plugin_file_name );

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -39,7 +39,7 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	 * Testing the onboarding class to make sure it is loaded.
 	 */
 	public function testClassInstance() {
-		$this->assertTrue( class_exists( 'Sensei_Onboarding' ), 'Sensei Admin class does not exist' );
+		$this->assertTrue( class_exists( 'Sensei_Onboarding' ), 'Sensei Onboarding class does not exist' );
 	}
 
 	/**

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -43,24 +43,6 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test remove some Sensei screens from WooCommerce screens.
-	 *
-	 * @covers Sensei_Onboarding::should_show_help_screen
-	 * @covers Sensei_Onboarding::remove_some_sensei_screens_from_woocommerce_screens
-	 */
-	public function testRemoveSomeSenseiScreensFromWoocommerceScreens() {
-		$previous_screen_ids          = [
-			'a',
-			'b',
-			'edit-course',
-		];
-		$expected_filtered_screen_ids = [ 'a', 'b' ];
-		$filtered_screen_ids          = $this->onboarding_instance->remove_some_sensei_screens_from_woocommerce_screens( $previous_screen_ids );
-
-		$this->assertEquals( $expected_filtered_screen_ids, $filtered_screen_ids, 'Should filter removing edit course screens.' );
-	}
-
-	/**
 	 * Test add onboarding help tab to edit course screen.
 	 *
 	 * @covers Sensei_Onboarding::add_onboarding_help_tab

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -49,10 +49,9 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	 */
 	public function testAddOnboardingHelpTab() {
 		set_current_screen( 'edit-course' );
+		$screen = get_current_screen();
 
-		$this->onboarding_instance->add_onboarding_help_tab();
-
-		$screen      = get_current_screen();
+		$this->onboarding_instance->add_onboarding_help_tab( $screen );
 		$created_tab = $screen->get_help_tab( 'sensei_lms_onboarding_tab' );
 
 		$this->assertNotNull( $created_tab, 'Should create the onboarding tab to edit course screens.' );
@@ -65,10 +64,9 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	 */
 	public function testAddOnboardingHelpTabNonEditCourseScreen() {
 		set_current_screen( 'edit-lesson' );
+		$screen = get_current_screen();
 
-		$this->onboarding_instance->add_onboarding_help_tab();
-
-		$screen      = get_current_screen();
+		$this->onboarding_instance->add_onboarding_help_tab( $screen );
 		$created_tab = $screen->get_help_tab( 'sensei_lms_onboarding_tab' );
 
 		$this->assertNull( $created_tab, 'Should not create the onboarding tab to non edit course screens.' );

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * This file contains the Sensei_Onboarding_Test class.
+ *
+ * @package sensei
+ */
+
+/**
+ * Tests for Sensei_Onboarding_Test class.
+ *
+ * @group onboarding
+ */
+class Sensei_Onboarding_Test extends WP_UnitTestCase {
+	/**
+	 * Set up before each test.
+	 */
+	public function setup() {
+		parent::setup();
+
+		$this->onboarding_instance = new Sensei_Onboarding();
+	}
+
+	/**
+	 * Testing the onboarding class to make sure it is loaded.
+	 */
+	public function testClassInstance() {
+		$this->assertTrue( class_exists( 'Sensei_Onboarding' ), 'Sensei Admin class does not exist' );
+	}
+
+	/**
+	 * Test filter WooCommerce screen IDs.
+	 *
+	 * @covers Sensei_Onboarding::should_show_help_screen
+	 * @covers Sensei_Onboarding::filter_woocommerce_screen_ids
+	 */
+	public function testFilterWooCommerceScreenIds() {
+		$previous_screen_ids          = [
+			'a',
+			'b',
+			'edit-course',
+		];
+		$expected_filtered_screen_ids = [ 'a', 'b' ];
+		$filtered_screen_ids          = $this->onboarding_instance->filter_woocommerce_screen_ids( $previous_screen_ids );
+
+		$this->assertEquals( $expected_filtered_screen_ids, $filtered_screen_ids, 'Should filter removing edit course screens.' );
+	}
+
+	/**
+	 * Test add onboarding help tab to edit course screen.
+	 *
+	 * @covers Sensei_Onboarding::add_onboarding_help_tab
+	 */
+	public function testAddOnboardingHelpTab() {
+		set_current_screen( 'edit-course' );
+
+		$this->onboarding_instance->add_onboarding_help_tab();
+
+		$screen      = get_current_screen();
+		$created_tab = $screen->get_help_tab( 'sensei_lms_onboarding_tab' );
+
+		$this->assertNotNull( $created_tab, 'Should create the onboarding tab to edit course screens.' );
+	}
+
+	/**
+	 * Test add onboarding help tab in non edit course screens.
+	 *
+	 * @covers Sensei_Onboarding::add_onboarding_help_tab
+	 */
+	public function testAddOnboardingHelpTabNonEditCourseScreen() {
+		set_current_screen( 'edit-lesson' );
+
+		$this->onboarding_instance->add_onboarding_help_tab();
+
+		$screen      = get_current_screen();
+		$created_tab = $screen->get_help_tab( 'sensei_lms_onboarding_tab' );
+
+		$this->assertNull( $created_tab, 'Should not create the onboarding tab to non edit course screens.' );
+	}
+}

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -43,19 +43,19 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test filter WooCommerce screen IDs.
+	 * Test remove some Sensei screens from WooCommerce screens.
 	 *
 	 * @covers Sensei_Onboarding::should_show_help_screen
-	 * @covers Sensei_Onboarding::filter_woocommerce_screen_ids
+	 * @covers Sensei_Onboarding::remove_some_sensei_screens_from_woocommerce_screens
 	 */
-	public function testFilterWooCommerceScreenIds() {
+	public function testRemoveSomeSenseiScreensFromWoocommerceScreens() {
 		$previous_screen_ids          = [
 			'a',
 			'b',
 			'edit-course',
 		];
 		$expected_filtered_screen_ids = [ 'a', 'b' ];
-		$filtered_screen_ids          = $this->onboarding_instance->filter_woocommerce_screen_ids( $previous_screen_ids );
+		$filtered_screen_ids          = $this->onboarding_instance->remove_some_sensei_screens_from_woocommerce_screens( $previous_screen_ids );
 
 		$this->assertEquals( $expected_filtered_screen_ids, $filtered_screen_ids, 'Should filter removing edit course screens.' );
 	}

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -17,7 +17,7 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	public function setup() {
 		parent::setup();
 
-		$this->onboarding_instance = new Sensei_Onboarding();
+		Sensei()->onboarding = new Sensei_Onboarding();
 
 		// Save original current screen.
 		global $current_screen;
@@ -51,7 +51,7 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 		set_current_screen( 'edit-course' );
 		$screen = get_current_screen();
 
-		$this->onboarding_instance->add_onboarding_help_tab( $screen );
+		Sensei()->onboarding->add_onboarding_help_tab( $screen );
 		$created_tab = $screen->get_help_tab( 'sensei_lms_onboarding_tab' );
 
 		$this->assertNotNull( $created_tab, 'Should create the onboarding tab to edit course screens.' );
@@ -66,7 +66,7 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 		set_current_screen( 'edit-lesson' );
 		$screen = get_current_screen();
 
-		$this->onboarding_instance->add_onboarding_help_tab( $screen );
+		Sensei()->onboarding->add_onboarding_help_tab( $screen );
 		$created_tab = $screen->get_help_tab( 'sensei_lms_onboarding_tab' );
 
 		$this->assertNull( $created_tab, 'Should not create the onboarding tab to non edit course screens.' );

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -18,6 +18,21 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 		parent::setup();
 
 		$this->onboarding_instance = new Sensei_Onboarding();
+
+		// Save original current screen.
+		global $current_screen;
+		$this->original_screen = $current_screen;
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		// Restore current screen.
+		global $current_screen;
+		$current_screen = $this->original_screen;
 	}
 
 	/**

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -17,8 +17,6 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	public function setup() {
 		parent::setup();
 
-		Sensei()->onboarding = new Sensei_Onboarding();
-
 		// Save original current screen.
 		global $current_screen;
 		$this->original_screen = $current_screen;


### PR DESCRIPTION
Fixes #3076 

### Changes proposed in this Pull Request

* Add a help tab with Onboarding Wizard call to action.
* Prevent WooCommerce showing the help tab in the `course`, `lesson` and `sensei_message` post-type pages.
* Once now it's accessible through the help tab, we're hiding the onboarding submenu item.

### Testing instructions

* Activate WooCommerce, WooCommerce Memberships and Sensei LMS plugins.
* Go to `wp-admin`
* Go to the course menu `Courses`.
* Click on the "Help ▼" button located in the top right.
* Make sure appears only the Onboarding help tab (`Setup wizard`) and WooCommerce help tabs and links don't appear.
* Click on the `Setup wizard` button.
* Make sure you're in the onboarding area and the `sensei_setup_wizard_click` event was logged (you can use https://github.com/Automattic/event-monitor updating the URL in `sensei/includes/lib/usage-tracking/class-usage-tracking-base.php`).
* Go to `wp-admin`.
* Go to the non-course screens.
* Make sure that the Onboarding help tab doesn't appear.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot

<img width="1096" alt="Screen Shot 2020-04-29 at 17 06 49" src="https://user-images.githubusercontent.com/876340/80641829-d6d1d200-8a3b-11ea-8c6c-d46541f259df.png">
