### PR TITLE
Add Sensei and WCPC version directly in usage stats

### DIFF
--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -197,4 +197,17 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 			}
 		);
 	}
+
+	/**
+	 * Collect system data to track.
+	 *
+	 * @return array
+	 */
+	public function get_system_data() {
+		$system_data                 = [];
+		$system_data['version']      = Sensei()->version;
+		$system_data['wcpc_version'] = defined( 'SENSEI_WC_PAID_COURSES_VERSION' ) ? SENSEI_WC_PAID_COURSES_VERSION : null;
+
+		return array_merge( $system_data, parent::get_system_data() );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds Sensei version and, if it exists, WCPC version to the system data for more easy querying.
* I'm not taking them out of the plugin list. We could filter them out, but I thought I wouldn't in case we had queries that depended on them.

### Testing instructions

* See p6rkRX-10C-p2
* Initiate tracks event by running cron event manually.
