### PR TITLE
Include email classes in autoloader

### DIFF
--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -117,6 +117,19 @@ class Sensei_Autoloader {
 			'Sensei_Main'                                => 'class-sensei.php',
 
 			/**
+			 * Emails
+			 */
+			'Sensei_Email_Learner_Completed_Course'      => 'emails/class-sensei-email-learner-completed-course.php',
+			'Sensei_Email_Learner_Graded_Quiz'           => 'emails/class-sensei-email-learner-graded-quiz.php',
+			'Sensei_Email_New_Message_Reply'             => 'emails/class-sensei-email-new-message-reply.php',
+			'Sensei_Email_Teacher_Completed_Course'      => 'emails/class-sensei-email-teacher-completed-course.php',
+			'Sensei_Email_Teacher_Completed_Lesson'      => 'emails/class-sensei-email-teacher-completed-lesson.php',
+			'Sensei_Email_Teacher_New_Course_Assignment' => 'emails/class-sensei-email-teacher-new-course-assignment.php',
+			'Sensei_Email_Teacher_New_Message'           => 'emails/class-sensei-email-teacher-new-message.php',
+			'Sensei_Email_Teacher_Quiz_Submitted'        => 'emails/class-sensei-email-teacher-quiz-submitted.php',
+			'Sensei_Email_Teacher_Started_Course'        => 'emails/class-sensei-email-teacher-started-course.php',
+
+			/**
 			 * Admin
 			 */
 			'Sensei_Learner_Management'                  => 'admin/class-sensei-learner-management.php',

--- a/includes/class-sensei-emails.php
+++ b/includes/class-sensei-emails.php
@@ -59,14 +59,14 @@ class Sensei_Emails {
 	 */
 	function init() {
 
-		$this->emails['learner-graded-quiz']      = include dirname( __FILE__ ) . '/emails/class-sensei-email-learner-graded-quiz.php';
-		$this->emails['learner-completed-course'] = include dirname( __FILE__ ) . '/emails/class-sensei-email-learner-completed-course.php';
-		$this->emails['teacher-completed-course'] = include dirname( __FILE__ ) . '/emails/class-sensei-email-teacher-completed-course.php';
-		$this->emails['teacher-started-course']   = include dirname( __FILE__ ) . '/emails/class-sensei-email-teacher-started-course.php';
-		$this->emails['teacher-completed-lesson'] = include dirname( __FILE__ ) . '/emails/class-sensei-email-teacher-completed-lesson.php';
-		$this->emails['teacher-quiz-submitted']   = include dirname( __FILE__ ) . '/emails/class-sensei-email-teacher-quiz-submitted.php';
-		$this->emails['teacher-new-message']      = include dirname( __FILE__ ) . '/emails/class-sensei-email-teacher-new-message.php';
-		$this->emails['new-message-reply']        = include dirname( __FILE__ ) . '/emails/class-sensei-email-new-message-reply.php';
+		$this->emails['learner-graded-quiz']      = new Sensei_Email_Learner_Graded_Quiz();
+		$this->emails['learner-completed-course'] = new Sensei_Email_Learner_Completed_Course();
+		$this->emails['teacher-completed-course'] = new Sensei_Email_Teacher_Completed_Course();
+		$this->emails['teacher-started-course']   = new Sensei_Email_Teacher_Started_Course();
+		$this->emails['teacher-completed-lesson'] = new Sensei_Email_Teacher_Completed_Lesson();
+		$this->emails['teacher-quiz-submitted']   = new Sensei_Email_Teacher_Quiz_Submitted();
+		$this->emails['teacher-new-message']      = new Sensei_Email_Teacher_New_Message();
+		$this->emails['new-message-reply']        = new Sensei_Email_New_Message_Reply();
 		$this->emails                             = apply_filters( 'sensei_email_classes', $this->emails );
 	}
 

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -862,7 +862,6 @@ class Sensei_Teacher {
 		}
 
 		// load the email class
-		include dirname( __FILE__ ) . '/emails/class-sensei-email-teacher-new-course-assignment.php';
 		$email = new Sensei_Email_Teacher_New_Course_Assignment();
 		$email->trigger( $teacher_id, $course_id );
 

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -197,4 +197,17 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 			}
 		);
 	}
+
+	/**
+	 * Collect system data to track.
+	 *
+	 * @return array
+	 */
+	public function get_system_data() {
+		$system_data                 = [];
+		$system_data['version']      = Sensei()->version;
+		$system_data['wcpc_version'] = defined( 'SENSEI_WC_PAID_COURSES_VERSION' ) ? SENSEI_WC_PAID_COURSES_VERSION : null;
+
+		return array_merge( $system_data, parent::get_system_data() );
+	}
 }

--- a/includes/emails/class-sensei-email-learner-completed-course.php
+++ b/includes/emails/class-sensei-email-learner-completed-course.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'Sensei_Email_Learner_Completed_Course' ) ) :
+if ( ! class_exists( 'Sensei_Email_Learner_Completed_Course', false ) ) :
 
 	/**
 	 * Learner Completed Course
@@ -90,5 +90,3 @@ if ( ! class_exists( 'Sensei_Email_Learner_Completed_Course' ) ) :
 	}
 
 endif;
-
-return new Sensei_Email_Learner_Completed_Course();

--- a/includes/emails/class-sensei-email-learner-graded-quiz.php
+++ b/includes/emails/class-sensei-email-learner-graded-quiz.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'Sensei_Email_Learner_Graded_Quiz' ) ) :
+if ( ! class_exists( 'Sensei_Email_Learner_Graded_Quiz', false ) ) :
 
 	/**
 	 * Learner Graded Quiz
@@ -106,5 +106,3 @@ if ( ! class_exists( 'Sensei_Email_Learner_Graded_Quiz' ) ) :
 	}
 
 endif;
-
-return new Sensei_Email_Learner_Graded_Quiz();

--- a/includes/emails/class-sensei-email-new-message-reply.php
+++ b/includes/emails/class-sensei-email-new-message-reply.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'Sensei_Email_New_Message_Reply' ) ) :
+if ( ! class_exists( 'Sensei_Email_New_Message_Reply', false ) ) :
 
 	/**
 	 * Teacher New Message
@@ -133,5 +133,3 @@ if ( ! class_exists( 'Sensei_Email_New_Message_Reply' ) ) :
 	}
 
 endif;
-
-return new Sensei_Email_New_Message_Reply();

--- a/includes/emails/class-sensei-email-teacher-completed-course.php
+++ b/includes/emails/class-sensei-email-teacher-completed-course.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Course' ) ) :
+if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Course', false ) ) :
 
 	/**
 	 * Teacher Completed Course
@@ -93,5 +93,3 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Course' ) ) :
 	}
 
 endif;
-
-return new Sensei_Email_Teacher_Completed_Course();

--- a/includes/emails/class-sensei-email-teacher-completed-lesson.php
+++ b/includes/emails/class-sensei-email-teacher-completed-lesson.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Lesson' ) ) :
+if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Lesson', false ) ) :
 
 	/**
 	 * Teacher Completed Lesson
@@ -81,5 +81,3 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Completed_Lesson' ) ) :
 	}
 
 endif;
-
-return new Sensei_Email_Teacher_Completed_Lesson();

--- a/includes/emails/class-sensei-email-teacher-new-course-assignment.php
+++ b/includes/emails/class-sensei-email-teacher-new-course-assignment.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( class_exists( 'Sensei_Email_Teacher_New_Course_Assignment' ) ) {
+if ( class_exists( 'Sensei_Email_Teacher_New_Course_Assignment', false ) ) {
 	return;
 }
 
@@ -85,8 +85,3 @@ class Sensei_Email_Teacher_New_Course_Assignment {
 		do_action( 'sensei_after_sending_email' );
 	}
 }
-
-/**
- * Return a new instance of this files class
- */
-return new Sensei_Email_Teacher_New_Course_Assignment();

--- a/includes/emails/class-sensei-email-teacher-new-message.php
+++ b/includes/emails/class-sensei-email-teacher-new-message.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'Sensei_Email_Teacher_New_Message' ) ) :
+if ( ! class_exists( 'Sensei_Email_Teacher_New_Message', false ) ) :
 
 	/**
 	 * Teacher New Message
@@ -99,5 +99,3 @@ if ( ! class_exists( 'Sensei_Email_Teacher_New_Message' ) ) :
 	}
 
 endif;
-
-return new Sensei_Email_Teacher_New_Message();

--- a/includes/emails/class-sensei-email-teacher-quiz-submitted.php
+++ b/includes/emails/class-sensei-email-teacher-quiz-submitted.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'Sensei_Email_Teacher_Quiz_Submitted' ) ) :
+if ( ! class_exists( 'Sensei_Email_Teacher_Quiz_Submitted', false ) ) :
 
 	/**
 	 * Teacher Quiz Submitted
@@ -89,5 +89,3 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Quiz_Submitted' ) ) :
 	}
 
 endif;
-
-return new Sensei_Email_Teacher_Quiz_Submitted();

--- a/includes/emails/class-sensei-email-teacher-started-course.php
+++ b/includes/emails/class-sensei-email-teacher-started-course.php
@@ -4,7 +4,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-if ( ! class_exists( 'Sensei_Email_Teacher_Started_Course' ) ) :
+if ( ! class_exists( 'Sensei_Email_Teacher_Started_Course', false ) ) :
 
 	/**
 	 * Teacher Started Course
@@ -81,5 +81,3 @@ if ( ! class_exists( 'Sensei_Email_Teacher_Started_Course' ) ) :
 	}
 
 endif;
-
-return new Sensei_Email_Teacher_Started_Course();


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Minor performance boost. Most comes simply by not having the `class_exists()` checks use the autoloader (before adding files to autoloader map).
* Added the files to the autoloader map.
* We might want to consider deprecating the behavior of sites being able to provide their own email classes. They can still do this via the `sensei_email_classes` filter for all emails except the `Sensei_Email_Teacher_New_Course_Assignment` email.

### Testing instructions

* Make sure email notifications are not impacted.