### PR TITLE
Add data port base class

### DIFF
--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -94,6 +94,7 @@ class Sensei_Autoloader {
 			new Sensei_Autoloader_Bundle( '' ),
 			new Sensei_Autoloader_Bundle( 'background-jobs' ),
 			new Sensei_Autoloader_Bundle( 'enrolment' ),
+			new Sensei_Autoloader_Bundle( 'data-port' ),
 		);
 
 		// add Sensei custom auto loader

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -1,0 +1,332 @@
+<?php
+/**
+ * File containing the Sensei_Data_Port_Job class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Superclass of data import/export jobs. It provides basic functionality like logging, maintaining state, cleanup and
+ * running data port tasks which are registered by subclasses.
+ */
+abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface {
+	const OPTION_PREFIX = 'sensei-tools-';
+
+	/**
+	 * An array which holds the results of the data port job and populated in subclasses.
+	 *
+	 * @var array
+	 */
+	protected $results;
+
+	/**
+	 * An array which contains the state for each task.
+	 *
+	 * @var array
+	 */
+	protected $task_state;
+
+	/**
+	 * Unique id for the job.
+	 *
+	 * @var string
+	 */
+	private $job_id;
+
+	/**
+	 * An array containing log entries (e.g. errors). It has the following format:
+	 * {
+	 *
+	 *     @type array $type {
+	 *         @type string $title The post title of the entity this entry applies to.
+	 *         @type string $id    The id of the entity this entry applies to.
+	 *         @type string $msg   The log message.
+	 *     }
+	 * }
+	 *
+	 * @var array
+	 */
+	private $logs;
+
+	/**
+	 * True if the job is completed.
+	 *
+	 * @var bool
+	 */
+	private $is_completed;
+
+	/**
+	 * True if the internal state has changed and needs to be stored.
+	 *
+	 * @var bool
+	 */
+	private $has_changed;
+
+	/**
+	 * Estimate of completion percentage.
+	 *
+	 * @var float
+	 */
+	private $percentage;
+
+	/**
+	 * The tasks that consist this data port job.
+	 *
+	 * @var Sensei_Data_Port_Task_Interface[]
+	 */
+	private $tasks;
+
+	/**
+	 * Sensei_Data_Port_Job constructor.
+	 *
+	 * @param string $job_id   Unique job id.
+	 * @param string $json     A json string to restore internal state from.
+	 */
+	protected function __construct( $job_id, $json = '' ) {
+		$this->job_id      = $job_id;
+		$this->has_changed = false;
+
+		if ( '' !== $json ) {
+			$this->restore_from_json( $json );
+		} else {
+			$this->logs         = [];
+			$this->results      = [];
+			$this->is_completed = false;
+			$this->has_changed  = true;
+			$this->task_state   = [];
+			$this->percentage   = 0;
+		}
+
+		$this->tasks = $this->get_tasks();
+
+		add_action( 'shutdown', [ $this, 'persist' ] );
+	}
+
+	/**
+	 * Restore a stored job. Returns null if the job does not exist.
+	 *
+	 * @param string $job_id  The job id.
+	 *
+	 * @return Sensei_Data_Port_Job|null instance.
+	 */
+	public static function get( $job_id ) {
+		$json = get_option( self::get_option_name(), '' );
+
+		if ( empty( $json ) ) {
+			return null;
+		}
+
+		return new static( $job_id, $json );
+	}
+
+	/**
+	 * Get the results of the job.
+	 *
+	 * @return array The results.
+	 */
+	public function get_results() {
+		return $this->results;
+	}
+
+	/**
+	 * Get the logs of the job. The logs are grouped by type. The pagination works on the total number of logs which
+	 * means that depending on the arguments, multiple type of logs can be returned.
+	 *
+	 * @param int $offset  Offset for pagination.
+	 * @param int $limit   Limit for pagination.
+	 *
+	 * @return array The logs.
+	 */
+	public function get_logs( $offset = 0, $limit = 20 ) {
+
+		$result_logs = [];
+
+		foreach ( $this->logs as $type => $messages ) {
+
+			// Check if the logs should start from this group.
+			if ( $offset < count( $messages ) ) {
+				$added_logs           = array_slice( $messages, $offset, $limit );
+				$offset               = 0;
+				$result_logs[ $type ] = $added_logs;
+
+				if ( count( $added_logs ) >= $limit ) {
+					return $result_logs;
+				} else {
+					// Adjust the limit to take into account added logs.
+					$limit -= count( $added_logs );
+				}
+			} else {
+				// Adjust the offset for the skipped log entries.
+				$offset -= count( $messages );
+			}
+		}
+
+		return $result_logs;
+	}
+
+	/**
+	 * Delete any stored state for this job.
+	 */
+	public function clean_up() {
+		foreach ( $this->tasks as $task ) {
+			$task->cleanup();
+		}
+
+		delete_option( self::get_option_name( $this->job_id ) );
+	}
+
+	/**
+	 * Get the completion status of the job.
+	 *
+	 * @return array
+	 */
+	public function get_status() {
+		return [
+			'status'     => $this->is_completed ? 'completed' : 'pending',
+			'percentage' => $this->percentage,
+		];
+	}
+
+	/**
+	 * Creates the tasks that consist the data port job.
+	 *
+	 * @return Sensei_Data_Port_Task_Interface[]
+	 */
+	abstract public function get_tasks();
+
+	/**
+	 * Serialize state to JSON.
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		return [
+			's' => $this->task_state,
+			'l' => $this->logs,
+			'r' => $this->results,
+			'c' => $this->is_completed,
+			'p' => $this->percentage,
+		];
+	}
+
+	/**
+	 * Restore state from JSON.
+	 *
+	 * @param string $json_string The JSON string.
+	 */
+	private function restore_from_json( $json_string ) {
+		$json_arr = json_decode( $json_string, true );
+
+		if ( ! $json_arr ) {
+			return;
+		}
+
+		$this->task_state   = $json_arr['s'];
+		$this->logs         = $json_arr['l'];
+		$this->results      = $json_arr['r'];
+		$this->is_completed = $json_arr['c'];
+		$this->percentage   = $json_arr['p'];
+	}
+
+	/**
+	 * Add an entry to the logs.
+	 *
+	 * @param string $post_tile Post title of the entity this log applies to.
+	 * @param string $message   Log message.
+	 * @param string $type      Post type this message.
+	 * @param string $id        Id of the entity this log applies to.
+	 */
+	protected function add_log_entry( $post_tile, $message, $type, $id = '' ) {
+		$this->has_changed = true;
+
+		$entry = [
+			'title' => sanitize_text_field( $post_tile ),
+			'msg'   => sanitize_text_field( $message ),
+		];
+
+		if ( ! empty( $id ) ) {
+			$entry['id'] = sanitize_text_field( $id );
+		}
+
+		$this->logs[ sanitize_text_field( $type ) ][] = $entry;
+	}
+
+	/**
+	 * Persist state to the db.
+	 *
+	 * @access private
+	 */
+	public function persist() {
+		if ( $this->has_changed ) {
+			update_option( self::get_option_name( $this->job_id ), wp_slash( wp_json_encode( $this ) ) );
+		}
+
+		$this->has_changed = false;
+	}
+
+	/**
+	 * Run the job.
+	 */
+	public function run() {
+		if ( $this->is_completed ) {
+			return;
+		}
+
+		$completed_cycles   = 0;
+		$total_cycles       = 0;
+		$has_processed_task = false;
+
+		foreach ( $this->tasks as $task ) {
+
+			if ( ! $has_processed_task && ! $task->is_completed() ) {
+				$task->run();
+				$has_processed_task = true;
+			}
+
+			$ratio = $task->get_completion_ratio();
+
+			$completed_cycles += $ratio['completed'];
+			$total_cycles     += $ratio['total'];
+		}
+
+		if ( ! $has_processed_task ) {
+			$this->is_completed = true;
+			$this->percentage   = 100;
+		} else {
+			$this->percentage = 100 * $completed_cycles / $total_cycles;
+		}
+	}
+
+	/**
+	 * Returns true if job is completed.
+	 *
+	 * @return bool True if job is completed.
+	 */
+	public function is_complete() {
+		return $this->is_completed;
+	}
+
+	/**
+	 * No a arguments are needed for data port jobs.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		return [];
+	}
+
+	/**
+	 * Retrieve the option name for a job.
+	 *
+	 * @param string $job_id Unique job id.
+	 *
+	 * @return string The option name.
+	 */
+	private static function get_option_name( $job_id ) {
+		return self::OPTION_PREFIX . $job_id;
+	}
+}

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * running data port tasks which are registered by subclasses.
  */
 abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, JsonSerializable {
-	const OPTION_PREFIX = 'sensei-tools-';
+	const OPTION_PREFIX = 'sensei-data-port-';
 
 	/**
 	 * An array which holds the results of the data port job and populated in subclasses.

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -173,9 +173,10 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface {
 	 */
 	public function clean_up() {
 		foreach ( $this->tasks as $task ) {
-			$task->cleanup();
+			$task->clean_up();
 		}
 
+		$this->has_changed = false;
 		delete_option( self::get_option_name( $this->job_id ) );
 	}
 

--- a/includes/data-port/class-sensei-data-port-task-interface.php
+++ b/includes/data-port/class-sensei-data-port-task-interface.php
@@ -43,6 +43,6 @@ interface Sensei_Data_Port_Task_Interface {
 	/**
 	 * Performs any required cleanup of the task.
 	 */
-	public function cleanup();
+	public function clean_up();
 
 }

--- a/includes/data-port/class-sensei-data-port-task-interface.php
+++ b/includes/data-port/class-sensei-data-port-task-interface.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * File containing the interface Sensei_Data_Port_Task_Interface.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * A data port task is a task that is executed as part of a data port job. Each job can define each own set of tasks
+ * which will be executed sequentially by the job. A task will not be executed until the previous task is completed.
+ */
+interface Sensei_Data_Port_Task_Interface {
+
+	/**
+	 * Run this task.
+	 */
+	public function run();
+
+	/**
+	 * Returns true if the task is completed.
+	 *
+	 * @return boolean
+	 */
+	public function is_completed();
+
+	/**
+	 * Returns the completion ratio of this task. The ration has the following format:
+	 *
+	 * {
+	 *
+	 *     @type integer $completed  Number of completed actions.
+	 *     @type integer $total      Number of total actions.
+	 * }
+	 *
+	 * @return array
+	 */
+	public function get_completion_ratio();
+
+	/**
+	 * Performs any required cleanup of the task.
+	 */
+	public function cleanup();
+
+}

--- a/tests/framework/data-port/class-sensei-data-port-job-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-job-mock.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file contains the Sensei_Data_Port_Task_Mock class.
+ *
+ * @package sensei
+ */
+
+
+class Sensei_Data_Port_Job_Mock extends Sensei_Data_Port_Job {
+
+	private static $tasks;
+
+	public static function create( $tasks ) {
+		self::$tasks = $tasks;
+
+		return new self( 'test-job' );
+	}
+
+	public function get_name() {
+		return 'test-job';
+	}
+
+	public function get_tasks() {
+		return self::$tasks;
+	}
+
+	public function log( $title, $message, $type, $id ) {
+		$this->add_log_entry( $title, $message, $type, $id );
+	}
+
+}

--- a/tests/framework/data-port/class-sensei-data-port-task-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-task-mock.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * This file contains the Sensei_Data_Port_Task_Mock class.
+ *
+ * @package sensei
+ */
+
+
+class Sensei_Data_Port_Task_Mock implements Sensei_Data_Port_Task_Interface {
+
+	private $is_complete;
+
+	private $completed_cycles;
+
+	private $total_cycles;
+
+	public function __construct( $is_complete, $completed_cycles, $total_cycles ) {
+		$this->is_complete      = $is_complete;
+		$this->completed_cycles = $completed_cycles;
+		$this->total_cycles     = $total_cycles;
+	}
+
+	public function run() {}
+
+	public function is_completed() {
+		return $this->is_complete;
+	}
+
+	public function get_completion_ratio() {
+		return [
+			'completed' => $this->completed_cycles,
+			'total'     => $this->total_cycles,
+		];
+	}
+
+	public function cleanup() {}
+
+}

--- a/tests/framework/data-port/class-sensei-data-port-task-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-task-mock.php
@@ -33,6 +33,6 @@ class Sensei_Data_Port_Task_Mock implements Sensei_Data_Port_Task_Interface {
 		];
 	}
 
-	public function cleanup() {}
+	public function clean_up() {}
 
 }

--- a/tests/unit-tests/data-port/test-class-sensei-data-port.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * This file contains the Sensei_Data_Port_Job_Test class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/data-port/class-sensei-data-port-job-mock.php';
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/data-port/class-sensei-data-port-task-mock.php';
+
+/**
+ * Tests for Sensei_Data_Port_Job class.
+ *
+ * @group data-port
+ */
+class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
+
+	public function testJobWithCompletedTasksIsCompleted() {
+		$first_completed  = $this->mock_task_method( true, 100, 100, 'run' );
+		$second_completed = $this->mock_task_method( true, 100, 100, 'run' );
+
+		$job = Sensei_Data_Port_Job_Mock::create( [ $first_completed, $second_completed ] );
+
+		$first_completed->expects( $this->never() )->method( 'run' );
+		$second_completed->expects( $this->never() )->method( 'run' );
+
+		$this->assertFalse( $job->is_complete(), 'Job should not be completed until all tasks are completed.' );
+		$job->run();
+		$this->assertTrue( $job->is_complete(), 'Job should be completed until all tasks are completed.' );
+
+		$this->assertEquals(
+			[
+				'status'     => 'completed',
+				'percentage' => 100,
+			],
+			$job->get_status()
+		);
+	}
+
+	public function testJobWithNotCompletedTasksIsNotCompleted() {
+		$completed = $this->mock_task_method( true, 100, 100, 'run' );
+		$pending   = $this->mock_task_method( false, 25, 100, 'run' );
+
+		$job = Sensei_Data_Port_Job_Mock::create( [ $completed, $pending ] );
+
+		$completed->expects( $this->never() )->method( 'run' );
+		$pending->expects( $this->once() )->method( 'run' );
+
+		$this->assertFalse( $job->is_complete(), 'Job should not be completed until all tasks are completed.' );
+		$job->run();
+		$this->assertFalse( $job->is_complete(), 'Job should not be completed until all tasks are completed.' );
+
+		$this->assertEquals(
+			[
+				'status'     => 'pending',
+				'percentage' => 62.5,
+			],
+			$job->get_status()
+		);
+	}
+
+	public function testOnlyOnePendingTaskIsExecuted() {
+		$first_pending  = $this->mock_task_method( false, 50, 100, 'run' );
+		$second_pending = $this->mock_task_method( false, 0, 100, 'run' );
+
+		$job = Sensei_Data_Port_Job_Mock::create( [ $first_pending, $second_pending ] );
+
+		$first_pending->expects( $this->once() )->method( 'run' );
+		$second_pending->expects( $this->never() )->method( 'run' );
+
+		$this->assertFalse( $job->is_complete(), 'Job should not be completed until all tasks are completed.' );
+		$job->run();
+		$this->assertFalse( $job->is_complete(), 'Job should not be completed until all tasks are completed.' );
+
+		$this->assertEquals(
+			[
+				'status'     => 'pending',
+				'percentage' => 25,
+			],
+			$job->get_status()
+		);
+	}
+
+
+	public function testCleanupCallsAllTaskCleanup() {
+		$first_completed  = $this->mock_task_method( true, 100, 100, 'cleanup' );
+		$second_completed = $this->mock_task_method( true, 100, 100, 'cleanup' );
+
+		$job = Sensei_Data_Port_Job_Mock::create( [ $first_completed, $second_completed ] );
+
+		$first_completed->expects( $this->once() )->method( 'cleanup' );
+		$second_completed->expects( $this->once() )->method( 'cleanup' );
+
+		$job->clean_up();
+	}
+
+	public function testLogMessagePagination() {
+		$job = Sensei_Data_Port_Job_Mock::create( [ new Sensei_Data_Port_Task_Mock( true, 100, 100 ) ] );
+
+		$job->log( 'First course', 'First failed', 'course', '1' );
+		$job->log( 'First lesson', 'First failed', 'lesson', '1' );
+		$job->log( 'Third course', 'Third failed', 'course', '3' );
+		$job->log( 'Second lesson', 'Second failed', 'lesson', '2' );
+
+		$expected = [
+			'course' => [
+				[
+					'title' => 'First course',
+					'msg'   => 'First failed',
+					'id'    => '1',
+				],
+				[
+					'title' => 'Third course',
+					'msg'   => 'Third failed',
+					'id'    => '3',
+				],
+			],
+			'lesson' => [
+				[
+					'title' => 'First lesson',
+					'msg'   => 'First failed',
+					'id'    => '1',
+				],
+				[
+					'title' => 'Second lesson',
+					'msg'   => 'Second failed',
+					'id'    => '2',
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $job->get_logs() );
+
+		$expected = [
+			'course' => [
+				[
+					'title' => 'First course',
+					'msg'   => 'First failed',
+					'id'    => '1',
+				],
+				[
+					'title' => 'Third course',
+					'msg'   => 'Third failed',
+					'id'    => '3',
+				],
+			],
+			'lesson' => [
+				[
+					'title' => 'First lesson',
+					'msg'   => 'First failed',
+					'id'    => '1',
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $job->get_logs( 0, 3 ) );
+
+		$expected = [
+			'course' => [
+				[
+					'title' => 'Third course',
+					'msg'   => 'Third failed',
+					'id'    => '3',
+				],
+			],
+			'lesson' => [
+				[
+					'title' => 'First lesson',
+					'msg'   => 'First failed',
+					'id'    => '1',
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $job->get_logs( 1, 2 ) );
+
+		$expected = [
+			'lesson' => [
+				[
+					'title' => 'First lesson',
+					'msg'   => 'First failed',
+					'id'    => '1',
+				],
+				[
+					'title' => 'Second lesson',
+					'msg'   => 'Second failed',
+					'id'    => '2',
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $job->get_logs( 2, 10 ) );
+
+		$expected = [
+			'lesson' => [
+				[
+					'title' => 'Second lesson',
+					'msg'   => 'Second failed',
+					'id'    => '2',
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $job->get_logs( 3, 10 ) );
+	}
+
+
+	private function mock_task_method( $is_complete, $completed_cycles, $total_cycles, $method ) {
+		return $this->getMockBuilder( Sensei_Data_Port_Task_Mock::class )
+			->setConstructorArgs( [ $is_complete, $completed_cycles, $total_cycles ] )
+			->setMethods( [ $method ] )
+			->getMock();
+	}
+}

--- a/tests/unit-tests/data-port/test-class-sensei-data-port.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port.php
@@ -208,6 +208,20 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $job->get_logs( 3, 10 ) );
 	}
 
+	public function testStateIsPersisted() {
+		$job = Sensei_Data_Port_Job_Mock::create( [ new Sensei_Data_Port_Task_Mock( true, 100, 100 ) ] );
+
+		$this->assertFalse( get_option( Sensei_Data_Port_Job::OPTION_PREFIX . 'test-job' ), 'Option should not be stored if persist is not called.' );
+
+		$job->persist();
+
+		$this->assertNotFalse( get_option( Sensei_Data_Port_Job::OPTION_PREFIX . 'test-job' ), 'Option should be stored if persist is called.' );
+
+		$job->clean_up();
+		$job->persist();
+
+		$this->assertFalse( get_option( Sensei_Data_Port_Job::OPTION_PREFIX . 'test-job' ), 'Option should not be stored if persist is not called.' );
+	}
 
 	private function mock_task_method( $is_complete, $completed_cycles, $total_cycles, $method ) {
 		return $this->getMockBuilder( Sensei_Data_Port_Task_Mock::class )

--- a/tests/unit-tests/data-port/test-class-sensei-data-port.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port.php
@@ -87,13 +87,13 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 
 
 	public function testCleanupCallsAllTaskCleanup() {
-		$first_completed  = $this->mock_task_method( true, 100, 100, 'cleanup' );
-		$second_completed = $this->mock_task_method( true, 100, 100, 'cleanup' );
+		$first_completed  = $this->mock_task_method( true, 100, 100, 'clean_up' );
+		$second_completed = $this->mock_task_method( true, 100, 100, 'clean_up' );
 
 		$job = Sensei_Data_Port_Job_Mock::create( [ $first_completed, $second_completed ] );
 
-		$first_completed->expects( $this->once() )->method( 'cleanup' );
-		$second_completed->expects( $this->once() )->method( 'cleanup' );
+		$first_completed->expects( $this->once() )->method( 'clean_up' );
+		$second_completed->expects( $this->once() )->method( 'clean_up' );
 
 		$job->clean_up();
 	}


### PR DESCRIPTION
#### Overview
These classes implement the common functionality of import and export jobs. This includes storing job state, logging and cleanup. A job is consisted from a number of tasks which can be different for each type of job and are executed sequentially one after the other.

Main points of the new approach:
- A new interface has been introduced which defines a data port task
- Instantiation of the tasks has been moved entirely to subclasses. Same with the job creation.
- Logs are now grouped by type. Pagination is independent of grouping.
- The task state and the results are handled entirely by subclasses. The base class handles storage in the db only.

@jom @alexsanford I am thinking that the reviews of data port tasks will not be handled by the whole team. Let me know if you don't agree.