### PR TITLE
Add Onboarding Wiz. Purpose step

### DIFF
--- a/assets/onboarding/_variables.scss
+++ b/assets/onboarding/_variables.scss
@@ -1,3 +1,20 @@
 $primary: #32af7d;
 $secondary: #674399;
 $link: #50575e;
+
+$gray-0: #f6f7f7;
+$gray-5: #dcdcde;
+$gray-10: #c3c4c7;
+$gray-20: #a7aaad;
+$gray-30: #8e9196;
+$gray-40: #787c82;
+$gray-50: #646970;
+$gray-60: #50575e;
+$gray-70: #3c434a;
+$gray-80: #2c3338;
+$gray-90: #1d2327;
+$gray-100: #101517;
+$gray: #646970;
+
+$text_primary: $gray-80;
+$text_secondary: $gray-60;

--- a/assets/onboarding/purpose/index.jsx
+++ b/assets/onboarding/purpose/index.jsx
@@ -49,7 +49,7 @@ export const Purpose = () => {
 
 	const isEmpty = ! selected.length;
 
-	const selectItem = ( id ) => {
+	const toggleItem = ( id ) => {
 		setFormState( ( formState ) => ( {
 			...formState,
 			selected: selected.includes( id )
@@ -80,7 +80,7 @@ export const Purpose = () => {
 							key={ id }
 							label={ title }
 							help={ description }
-							onChange={ () => selectItem( id ) }
+							onChange={ () => toggleItem( id ) }
 							checked={ selected.includes( id ) }
 							className="sensei-onboarding__checkbox"
 						/>

--- a/assets/onboarding/purpose/index.jsx
+++ b/assets/onboarding/purpose/index.jsx
@@ -34,6 +34,10 @@ const purposes = [
 		description:
 			'You work at a company that regularly trains new or existing employees.',
 	},
+	{
+		id: 'other',
+		title: 'Other',
+	},
 ];
 
 /**
@@ -85,13 +89,6 @@ export const Purpose = () => {
 							className="sensei-onboarding__checkbox"
 						/>
 					) ) }
-					<CheckboxControl
-						key="other"
-						label="Other"
-						onChange={ () => selectItem( 'other' ) }
-						checked={ selected.includes( 'other' ) }
-						className="sensei-onboarding__checkbox"
-					/>
 					{ selected.includes( 'other' ) && (
 						<TextControl
 							className="sensei-onboarding__textcontrol-other"

--- a/assets/onboarding/purpose/index.jsx
+++ b/assets/onboarding/purpose/index.jsx
@@ -1,9 +1,8 @@
 import { Card, H } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { Button, CheckboxControl, TextControl } from '@wordpress/components';
-import { useState, useEffect } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { useQueryStringRouter } from '../query-string-router';
-import { isEqual } from 'lodash';
 
 const purposes = [
 	{

--- a/assets/onboarding/purpose/index.jsx
+++ b/assets/onboarding/purpose/index.jsx
@@ -99,6 +99,7 @@ export const Purpose = () => {
 						<TextControl
 							className="sensei-onboarding__textcontrol-other"
 							value={ other }
+							placeholder={ __( 'Description', 'sensei-lms' ) }
 							onChange={ ( value ) =>
 								setState( { selected, other: value } )
 							}

--- a/assets/onboarding/purpose/index.jsx
+++ b/assets/onboarding/purpose/index.jsx
@@ -36,7 +36,6 @@ const purposes = [
 	},
 ];
 
-
 /**
  * Purpose step for Onboarding Wizard.
  */
@@ -50,18 +49,18 @@ export const Purpose = () => {
 
 	const isEmpty = ! selected.length;
 
-	function selectItem( id ) {
+	const selectItem = ( id ) => {
 		setState( {
 			other,
 			selected: selected.includes( id )
 				? selected.filter( ( item ) => item !== id )
 				: [ id, ...selected ],
 		} );
-	}
+	};
 
-	async function submitPage() {
+	const submitPage = () => {
 		goTo( 'features' );
-	}
+	};
 
 	return (
 		<>

--- a/assets/onboarding/purpose/index.jsx
+++ b/assets/onboarding/purpose/index.jsx
@@ -42,7 +42,7 @@ const purposes = [
 export const Purpose = () => {
 	const { goTo } = useQueryStringRouter();
 
-	const [ { selected, other }, setState ] = useState( {
+	const [ { selected, other }, setFormState ] = useState( {
 		selected: [],
 		other: '',
 	} );
@@ -50,12 +50,12 @@ export const Purpose = () => {
 	const isEmpty = ! selected.length;
 
 	const selectItem = ( id ) => {
-		setState( {
-			other,
+		setFormState( ( formState ) => ( {
+			...formState,
 			selected: selected.includes( id )
 				? selected.filter( ( item ) => item !== id )
 				: [ id, ...selected ],
-		} );
+		} ) );
 	};
 
 	const submitPage = () => {
@@ -98,7 +98,10 @@ export const Purpose = () => {
 							value={ other }
 							placeholder={ __( 'Description', 'sensei-lms' ) }
 							onChange={ ( value ) =>
-								setState( { selected, other: value } )
+								setFormState( ( formState ) => ( {
+									...formState,
+									other: value,
+								} ) )
 							}
 						/>
 					) }

--- a/assets/onboarding/purpose/index.jsx
+++ b/assets/onboarding/purpose/index.jsx
@@ -48,9 +48,7 @@ export const Purpose = () => {
 		other: '',
 	} );
 
-	const isEmpty =
-		! selected.length ||
-		( isEqual( [ 'other' ], selected ) && ! other.length );
+	const isEmpty = ! selected.length;
 
 	function selectItem( id ) {
 		setState( {

--- a/assets/onboarding/purpose/index.jsx
+++ b/assets/onboarding/purpose/index.jsx
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { Button, CheckboxControl, TextControl } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { useQueryStringRouter } from '../query-string-router';
+import { isEqual } from 'lodash';
 
 const purposes = [
 	{
@@ -46,6 +47,10 @@ export const Purpose = () => {
 		selected: [],
 		other: '',
 	} );
+
+	const isEmpty =
+		! selected.length ||
+		( isEqual( [ 'other' ], selected ) && ! other.length );
 
 	function selectItem( id ) {
 		setState( {
@@ -103,6 +108,7 @@ export const Purpose = () => {
 
 				<Button
 					isPrimary
+					disabled={ isEmpty }
 					className="sensei-onboarding__button sensei-onboarding__button-card"
 					onClick={ submitPage }
 				>

--- a/assets/onboarding/purpose/index.jsx
+++ b/assets/onboarding/purpose/index.jsx
@@ -1,0 +1,114 @@
+import { Card, H } from '@woocommerce/components';
+import { __ } from '@wordpress/i18n';
+import { Button, CheckboxControl, TextControl } from '@wordpress/components';
+import { useState, useEffect } from '@wordpress/element';
+import { useQueryStringRouter } from '../query-string-router';
+
+const purposes = [
+	{
+		id: 'share_knowledge',
+		title: 'Share your knowledge',
+		description: 'You are a hobbyist interested in sharing your knowledge.',
+	},
+	{
+		id: 'generate_income',
+		title: 'Generate income',
+		description:
+			'You would like to generate additional income for yourself or your business.',
+	},
+	{
+		id: 'promote_business',
+		title: 'Promote your business',
+		description:
+			'You own a business and would like to use online courses to promote it.',
+	},
+	{
+		id: 'provide_certification',
+		title: 'Provide certification training',
+		description: 'You want to help people become certified professionals.',
+	},
+	{
+		id: 'train_employees',
+		title: 'Train employees',
+		description:
+			'You work at a company that regularly trains new or existing employees.',
+	},
+];
+
+
+/**
+ * Purpose step for Onboarding Wizard.
+ */
+export const Purpose = () => {
+	const { goTo } = useQueryStringRouter();
+
+	const [ { selected, other }, setState ] = useState( {
+		selected: [],
+		other: '',
+	} );
+
+	function selectItem( id ) {
+		setState( {
+			other,
+			selected: selected.includes( id )
+				? selected.filter( ( item ) => item !== id )
+				: [ id, ...selected ],
+		} );
+	}
+
+	async function submitPage() {
+		goTo( 'features' );
+	}
+
+	return (
+		<>
+			<div className="sensei-onboarding__title">
+				<H>
+					{ __(
+						'What is your primary purpose for offering online courses?',
+						'sensei-lms'
+					) }
+				</H>
+				<p> { __( 'Choose any that apply', 'sensei-lms' ) } </p>
+			</div>
+			<Card className="sensei-onboarding__card">
+				<div className="sensei-onboarding__checkbox-list">
+					{ purposes.map( ( { id, title, description } ) => (
+						<CheckboxControl
+							key={ id }
+							label={ title }
+							help={ description }
+							onChange={ () => selectItem( id ) }
+							checked={ selected.includes( id ) }
+							className="sensei-onboarding__checkbox"
+						/>
+					) ) }
+					<CheckboxControl
+						key="other"
+						label="Other"
+						onChange={ () => selectItem( 'other' ) }
+						checked={ selected.includes( 'other' ) }
+						className="sensei-onboarding__checkbox"
+					/>
+					{ selected.includes( 'other' ) && (
+						<TextControl
+							className="sensei-onboarding__textcontrol-other"
+							value={ other }
+							onChange={ ( value ) =>
+								setState( { selected, other: value } )
+							}
+						/>
+					) }
+				</div>
+
+				<Button
+					isPrimary
+					className="sensei-onboarding__button sensei-onboarding__button-card"
+					onClick={ submitPage }
+				>
+					{ __( 'Continue', 'sensei-lms' ) }
+				</Button>
+			</Card>
+		</>
+	);
+};

--- a/assets/onboarding/steps.jsx
+++ b/assets/onboarding/steps.jsx
@@ -1,5 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { Welcome } from './welcome';
+import { Purpose } from './purpose';
+
 
 export const steps = [
 	{
@@ -10,7 +12,7 @@ export const steps = [
 	},
 	{
 		key: 'purpose',
-		container: <div>Purpose</div>,
+		container: <Purpose />,
 		label: __( 'Purpose', 'sensei-lms' ),
 		isComplete: false,
 	},

--- a/assets/onboarding/steps.jsx
+++ b/assets/onboarding/steps.jsx
@@ -2,7 +2,6 @@ import { __ } from '@wordpress/i18n';
 import { Welcome } from './welcome';
 import { Purpose } from './purpose';
 
-
 export const steps = [
 	{
 		key: 'welcome',

--- a/assets/onboarding/style.scss
+++ b/assets/onboarding/style.scss
@@ -67,15 +67,17 @@
     text-align: center;
   }
 
-  &__title {
-    text-align: center;
-    margin: 40px 0;
+	&__title {
 
-    h2 {
-      font-weight: normal;
-      font-size: 24px;
-    }
-  }
+		text-align: center;
+		margin: 40px 0 20px 0;
+
+		h2 {
+			color: $text_primary;
+			font-weight: normal;
+			font-size: 24px;
+		}
+	}
 
   &__card {
     p {

--- a/assets/onboarding/style.scss
+++ b/assets/onboarding/style.scss
@@ -1,7 +1,5 @@
 @import '~@woocommerce/components/build-style/style.css';
 @import 'fullscreen';
-@import 'variables';
-@import 'wp-colors';
 
 .sensei-onboarding {
 
@@ -35,37 +33,37 @@
 		max-width: 476px;
 		margin-left: auto;
 		margin-right: auto;
+		font-size: 16px;
 	}
 
-  &__button.components-button {
-    display: flex;
-    margin: 8px auto 0;
+	&__button.components-button {
+		display: flex;
+		margin: 8px auto 0;
 
-    max-width: 100%;
-    justify-content: center;
+		max-width: 100%;
+		justify-content: center;
 
-    height: 48px;
-    padding-left: 25px;
-    padding-right: 25px;
-    text-align: center;
-    font-size: 14px;
-    line-height: 36px;
-    font-weight: 500;
-    align-items: center;
-  }
+		height: 48px;
+		padding-left: 25px;
+		padding-right: 25px;
+		text-align: center;
+		font-size: 14px;
+		line-height: 36px;
+		font-weight: 500;
+		align-items: center;
+	}
 
-  &__button-card.components-button {
-    width: 310px;
-  }
+	&__button-card.components-button {
+		width: 310px;
+	}
 
-  &__button-modal.components-button {
-    margin-right: 0;
-  }
+	&__button-modal.components-button {
+		margin-right: 0;
+	}
 
-
-  &__skip {
-    text-align: center;
-  }
+	&__skip {
+		text-align: center;
+	}
 
 	&__title {
 
@@ -86,24 +84,64 @@
 		}
 	}
 
-  &__card {
-    p {
-      font-size: 14px;
-      line-height: 1.65;
-    }
-  }
+	&__card {
+		p {
+			font-size: 14px;
+			line-height: 1.65;
+		}
+	}
 
-  &__usage-modal {
-    width: 600px;
-    max-width: 100%;
+	&__usage-modal {
+		width: 600px;
+		max-width: 100%;
 
-    .components-modal__header {
-      border-bottom: none;
-      margin-bottom: 0;
-    }
-  }
+		.components-modal__header {
+			border-bottom: none;
+			margin-bottom: 0;
+		}
+	}
 
-  &__tracking {
-    margin: 1rem 0;
-  }
+	&__tracking {
+		margin: 1rem 0;
+	}
+
+	&__checkbox-list {
+
+		margin-bottom: 26px;
+
+		.sensei-onboarding__checkbox {
+
+			position: relative;
+
+
+			.components-checkbox-control__input-container {
+				position: absolute;
+			}
+
+			.components-checkbox-control__label {
+				color: $text_primary;
+				font-size: 16px;
+				margin-left: 40px;
+				padding-right: 20px;
+			}
+
+			.components-base-control__help {
+				font-style: normal;
+				margin-left: 40px;
+				padding-top: 4px;
+				padding-right: 20px;
+				padding-bottom: 14px;
+				border-bottom: 1px solid $gray-5;
+			}
+
+		}
+		.sensei-onboarding__textcontrol-other {
+			margin-left: 40px;
+			margin-right: 20px;
+
+			.components-text-control__input {
+				padding: 8px 12px;
+			}
+		}
+	}
 }

--- a/assets/onboarding/style.scss
+++ b/assets/onboarding/style.scss
@@ -7,7 +7,7 @@
 
 	&__page {
 		background: #f6f7f7;
-		color: #50575e;
+		color: $text_secondary;
 
 		* {
 			box-sizing: border-box;
@@ -76,6 +76,13 @@
 			color: $text_primary;
 			font-weight: normal;
 			font-size: 24px;
+			line-height: 32px;
+			margin: 0;
+			margin-bottom: 8px;
+		}
+
+		p {
+			font-size: 16px;
 		}
 	}
 

--- a/assets/onboarding/style.scss
+++ b/assets/onboarding/style.scss
@@ -115,15 +115,10 @@
 
 			position: relative;
 
-
-			.components-checkbox-control__input-container {
-				position: absolute;
-			}
-
 			.components-checkbox-control__label {
 				color: $text_primary;
 				font-size: 16px;
-				margin-left: 40px;
+				margin-left: 8px;
 				padding-right: 20px;
 			}
 

--- a/assets/onboarding/style.scss
+++ b/assets/onboarding/style.scss
@@ -1,4 +1,6 @@
 @import '~@woocommerce/components/build-style/style.css';
+@import 'variables';
+@import 'wp-colors';
 @import 'fullscreen';
 
 .sensei-onboarding {

--- a/assets/onboarding/wp-colors.scss
+++ b/assets/onboarding/wp-colors.scss
@@ -82,6 +82,8 @@ body.sensei-color {
 
   .components-checkbox-control__input[type='checkbox'] {
 
+    border: 2px solid $gray-50;
+
     &:checked {
       background-color: $primary;
       border-color: $primary;
@@ -94,11 +96,22 @@ body.sensei-color {
 
   }
 
+  .components-checkbox-control__checked {
+    transform: scale(0.75);
+  }
+
+  input[type='text'] {
+    &:focus {
+      border-color: $primary;
+      box-shadow: 0 0 0 1px $primary;
+    }
+  }
+
   .woocommerce-stepper {
 
     &__step.is-complete, &__step.is-active {
       .woocommerce-stepper__step-icon {
-        background: $secondary;
+        background: $primary;
       }
     }
   }

--- a/assets/onboarding/wp-colors.scss
+++ b/assets/onboarding/wp-colors.scss
@@ -2,118 +2,118 @@
 
 body.sensei-color {
 
-  $button: $primary;
-  $button-shade-10: darken($button, 10%);
-  $button-shade-20: darken($button, 20%);
+	$button: $primary;
+	$button-shade-10: darken($button, 10%);
+	$button-shade-20: darken($button, 20%);
 
-  .components-button {
+	.components-button {
 
-    &.is-primary {
-      background: $button;
-      border-color: transparent;
-    }
+		&.is-primary {
+			background: $button;
+			border-color: transparent;
+		}
 
-    &.is-primary:hover:not(:disabled) {
-      background: $button-shade-10;
-    }
+		&.is-primary:hover:not(:disabled) {
+			background: $button-shade-10;
+		}
 
-    &.is-primary:focus:not(:disabled) {
-      background: $button-shade-10;
-      border-color: $button-shade-20;
-    }
+		&.is-primary:focus:not(:disabled) {
+			background: $button-shade-10;
+			border-color: $button-shade-20;
+		}
 
-    &.is-primary:active:not(:disabled) {
-      background: $button-shade-20;
-      border-color: $button-shade-20;
-    }
+		&.is-primary:active:not(:disabled) {
+			background: $button-shade-20;
+			border-color: $button-shade-20;
+		}
 
-    &.is-primary:focus:not(:disabled) {
-      box-shadow: inset 0 0 0 1px #fff, 0 0 0 1.5px $button;
-    }
+		&.is-primary:focus:not(:disabled) {
+			box-shadow: inset 0 0 0 1px #fff, 0 0 0 1.5px $button;
+		}
 
-    &.is-primary:disabled, &.is-primary:disabled:active:enabled, &.is-primary[aria-disabled='true'], &.is-primary[aria-disabled='true']:enabled, &.is-primary[aria-disabled='true']:active:enabled {
-      color: lighten($button, 40%);
-      background: lighten($button, 10%);
-      border-color: lighten($button, 10%);
-    }
+		&.is-primary:disabled, &.is-primary:disabled:active:enabled, &.is-primary[aria-disabled='true'], &.is-primary[aria-disabled='true']:enabled, &.is-primary[aria-disabled='true']:active:enabled {
+			color: lighten($button, 40%);
+			background: lighten($button, 10%);
+			border-color: lighten($button, 10%);
+		}
 
-    &.is-primary:disabled:focus:enabled, &.is-primary:disabled:active:enabled:focus:enabled, &.is-primary[aria-disabled='true']:focus:enabled, &.is-primary[aria-disabled='true']:enabled:focus:enabled, &.is-primary[aria-disabled='true']:active:enabled:focus:enabled {
-      box-shadow: 0 0 0 1px #fff, 0 0 0 3px $button;
-    }
+		&.is-primary:disabled:focus:enabled, &.is-primary:disabled:active:enabled:focus:enabled, &.is-primary[aria-disabled='true']:focus:enabled, &.is-primary[aria-disabled='true']:enabled:focus:enabled, &.is-primary[aria-disabled='true']:active:enabled:focus:enabled {
+			box-shadow: 0 0 0 1px #fff, 0 0 0 3px $button;
+		}
 
-    &.is-primary.is-busy, &.is-primary.is-busy:disabled, &.is-primary.is-busy[aria-disabled='true'] {
-      background-image: linear-gradient(-45deg, $button 28%, $button-shade-20 28%, $button-shade-20 72%, $button 72%);
-      border-color: $button;
-    }
+		&.is-primary.is-busy, &.is-primary.is-busy:disabled, &.is-primary.is-busy[aria-disabled='true'] {
+			background-image: linear-gradient(-45deg, $button 28%, $button-shade-20 28%, $button-shade-20 72%, $button 72%);
+			border-color: $button;
+		}
 
-    &.is-secondary:active:not(:disabled), &.is-tertiary:active:not(:disabled) {
-      color: $button-shade-20;
-      box-shadow: none;
-    }
+		&.is-secondary:active:not(:disabled), &.is-tertiary:active:not(:disabled) {
+			color: $button-shade-20;
+			box-shadow: none;
+		}
 
-    &.is-secondary:hover:not(:disabled), &.is-tertiary:hover:not(:disabled) {
-      color: $button-shade-10;
-      box-shadow: inset 0 0 0 1px $button-shade-10;
-    }
+		&.is-secondary:hover:not(:disabled), &.is-tertiary:hover:not(:disabled) {
+			color: $button-shade-10;
+			box-shadow: inset 0 0 0 1px $button-shade-10;
+		}
 
-    &.is-secondary {
-      box-shadow: inset 0 0 0 1px $button;
-      color: $button;
-    }
+		&.is-secondary {
+			box-shadow: inset 0 0 0 1px $button;
+			color: $button;
+		}
 
-    &.is-tertiary {
-      color: $button;
-    }
-  }
+		&.is-tertiary {
+			color: $button;
+		}
+	}
 
-  a, .button-link, .components-button.is-link {
-    color: $link;
+	a, .button-link, .components-button.is-link {
+		color: $link;
 
-    &:hover,
-    &:active {
-      color: lighten($link, 20%);
-    }
+		&:hover,
+		&:active {
+			color: lighten($link, 20%);
+		}
 
-    &:focus {
-      color: darken($link, 20%);
-    }
+		&:focus {
+			color: darken($link, 20%);
+		}
 
-  }
+	}
 
-  .components-checkbox-control__input[type='checkbox'] {
+	.components-checkbox-control__input[type='checkbox'] {
 
-    border: 2px solid $gray-50;
+		border: 2px solid $gray-50;
 
-    &:checked {
-      background-color: $primary;
-      border-color: $primary;
-    }
+		&:checked {
+			background-color: $primary;
+			border-color: $primary;
+		}
 
-    &:focus {
-      box-shadow: 0 0 2px rgba($link, .5);
-      border-color: $primary;
-    }
+		&:focus {
+			box-shadow: 0 0 2px rgba($primary, .5);
+			border-color: $primary;
+		}
 
-  }
+	}
 
-  .components-checkbox-control__checked {
-    transform: scale(0.75);
-  }
+	.components-checkbox-control__checked {
+		transform: scale(0.75);
+	}
 
-  input[type='text'] {
-    &:focus {
-      border-color: $primary;
-      box-shadow: 0 0 0 1px $primary;
-    }
-  }
+	input[type='text'] {
+		&:focus {
+			border-color: $primary;
+			box-shadow: 0 0 0 1px $primary;
+		}
+	}
 
-  .woocommerce-stepper {
+	.woocommerce-stepper {
 
-    &__step.is-complete, &__step.is-active {
-      .woocommerce-stepper__step-icon {
-        background: $primary;
-      }
-    }
-  }
+		&__step.is-complete, &__step.is-active {
+			.woocommerce-stepper__step-icon {
+				background: $primary;
+			}
+		}
+	}
 
 }


### PR DESCRIPTION
Fixes #3039 

### Changes proposed in this Pull Request

* Add Purpose step with fixed options checkbox list
* Also contains some CSS improvements, and greener controls
* REST API (saving things) is not yet hooked up

### Testing instructions

* Navigate to `/wp-admin/admin.php?page=sensei_onboarding&step=purpose`
* Items should be selectable
* Text field appears when 'Other' is selected
* Continue navigates to next page

### Screenshot

<img width="1092" alt="Sensei Onboarding Purpose step" src="https://user-images.githubusercontent.com/176949/81015443-03805200-8e5f-11ea-8a2b-5e8177609bd3.png">
