### PR TITLE
Add redirect to setup wizard after plugin activation

### DIFF
--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -135,13 +135,13 @@ class Sensei_Onboarding {
 		}
 
 		delete_transient( 'sensei_activation_redirect' );
-		$this->redirect_to_onboarding();
+		$this->redirect_to_setup_wizard();
 	}
 
 	/**
-	 * Redirect to the onboarding.
+	 * Redirect to setup wizard.
 	 */
-	protected function redirect_to_onboarding() {
+	protected function redirect_to_setup_wizard() {
 		wp_safe_redirect( admin_url( 'admin.php?page=' . $this->page_slug ) );
 		exit;
 	}

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -135,6 +135,12 @@ class Sensei_Onboarding {
 		}
 
 		delete_transient( 'sensei_activation_redirect' );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
+		if ( isset( $_GET['activate-multi'] ) ) {
+			return;
+		}
+
 		$this->redirect_to_setup_wizard();
 	}
 

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -120,6 +120,8 @@ class Sensei_Onboarding {
 
 	/**
 	 * Redirect after first activation.
+	 *
+	 * @access private
 	 */
 	public function activation_redirect() {
 		if (

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -208,6 +208,7 @@ class Sensei_Data_Cleaner {
 		'sensei_answers_feedback_[0-9]+_[0-9]+',
 		'quiz_grades_[0-9]+_[0-9]+',
 		'sensei_comment_counts_[0-9]+',
+		'sensei_activation_redirect',
 	);
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -685,6 +685,8 @@ class Sensei_Main {
 	public function activate_sensei() {
 
 		if ( false === get_option( 'sensei_installed', false ) ) {
+			set_transient( 'sensei_activation_redirect', 1, 30 );
+
 			update_option( 'sensei_show_email_signup_form', true );
 			update_option( Sensei_Onboarding::SUGGEST_SETUP_WIZARD_OPTION, 1 );
 		}

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -207,6 +207,68 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 		$this->assertFalse( $option_value, 'Should not update option' );
 	}
 
+	/*
+	 * Testing if activation redirect works properly.
+	 */
+	public function testActivationRedirect() {
+		// Create and login as administrator.
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		set_transient( 'sensei_activation_redirect', 1, 30 );
+
+		$onboarding_mock = $this->getMockBuilder( 'Sensei_Onboarding' )
+			->setMethods( [ 'redirect_to_onboarding' ] )
+			->getMock();
+
+		$onboarding_mock->expects( $this->once() )
+			->method( 'redirect_to_onboarding' );
+
+		$onboarding_mock->activation_redirect();
+
+		$this->assertFalse( get_transient( 'sensei_activation_redirect' ), 'Transient should be removed' );
+	}
+
+	/**
+	 * Testing if activation doesn't redirect for no admin user.
+	 */
+	public function testActivationRedirectNoAdmin() {
+		// Create and login as subscriber.
+		$subscriber_id = $this->factory->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+
+		set_transient( 'sensei_activation_redirect', 1, 30 );
+
+		$onboarding_mock = $this->getMockBuilder( 'Sensei_Onboarding' )
+			->setMethods( [ 'redirect_to_onboarding' ] )
+			->getMock();
+
+		$onboarding_mock->expects( $this->never() )
+			->method( 'redirect_to_onboarding' );
+
+		$onboarding_mock->activation_redirect();
+
+		$this->assertNotFalse( get_transient( 'sensei_activation_redirect' ), 'Transient should not be removed' );
+	}
+
+	/**
+	 * Testing if activation doesn't redirect when transient is not defined.
+	 */
+	public function testActivationRedirectWithoutTransient() {
+		// Create and login as administrator.
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$onboarding_mock = $this->getMockBuilder( 'Sensei_Onboarding' )
+			->setMethods( [ 'redirect_to_onboarding' ] )
+			->getMock();
+
+		$onboarding_mock->expects( $this->never() )
+			->method( 'redirect_to_onboarding' );
+
+		$onboarding_mock->activation_redirect();
+	}
+
 	/**
 	 * Test if WooCommerce help tab is being prevented in the Sensei pages.
 	 *

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -218,11 +218,11 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 		set_transient( 'sensei_activation_redirect', 1, 30 );
 
 		$onboarding_mock = $this->getMockBuilder( 'Sensei_Onboarding' )
-			->setMethods( [ 'redirect_to_onboarding' ] )
+			->setMethods( [ 'redirect_to_setup_wizard' ] )
 			->getMock();
 
 		$onboarding_mock->expects( $this->once() )
-			->method( 'redirect_to_onboarding' );
+			->method( 'redirect_to_setup_wizard' );
 
 		$onboarding_mock->activation_redirect();
 
@@ -240,11 +240,11 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 		set_transient( 'sensei_activation_redirect', 1, 30 );
 
 		$onboarding_mock = $this->getMockBuilder( 'Sensei_Onboarding' )
-			->setMethods( [ 'redirect_to_onboarding' ] )
+			->setMethods( [ 'redirect_to_setup_wizard' ] )
 			->getMock();
 
 		$onboarding_mock->expects( $this->never() )
-			->method( 'redirect_to_onboarding' );
+			->method( 'redirect_to_setup_wizard' );
 
 		$onboarding_mock->activation_redirect();
 
@@ -260,11 +260,11 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 		wp_set_current_user( $admin_id );
 
 		$onboarding_mock = $this->getMockBuilder( 'Sensei_Onboarding' )
-			->setMethods( [ 'redirect_to_onboarding' ] )
+			->setMethods( [ 'redirect_to_setup_wizard' ] )
 			->getMock();
 
 		$onboarding_mock->expects( $this->never() )
-			->method( 'redirect_to_onboarding' );
+			->method( 'redirect_to_setup_wizard' );
 
 		$onboarding_mock->activation_redirect();
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* After Sensei LMS plugin activation, redirects the user to the setup wizard.

### Testing instructions

* Install the Sensei LMS for the first time in an environment.
* You should be redirected to the setup wizard.
* Deactivate the plugin and reactivate.
* You should not be redirected again to the setup wizard.