### PR TITLE
Fix to show help tab only for sensei manager users

### DIFF
--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -147,7 +147,7 @@ class Sensei_Onboarding {
 	public function add_onboarding_help_tab( $screen ) {
 		$link_track_event = 'setup_wizard_click';
 
-		if ( ! $screen || ! $this->should_show_help_screen( $screen->id ) ) {
+		if ( ! $screen || ! $this->should_show_help_screen( $screen->id ) || ! current_user_can( 'manage_sensei' ) ) {
 			return;
 		}
 

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -46,9 +46,14 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Onboarding::add_onboarding_help_tab
 	 */
 	public function testAddOnboardingHelpTab() {
+		// Create and login as administrator.
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
 		set_current_screen( 'edit-course' );
 		$screen = get_current_screen();
 
+		$screen->remove_help_tab( 'sensei_lms_onboarding_tab' );
 		Sensei()->onboarding->add_onboarding_help_tab( $screen );
 		$created_tab = $screen->get_help_tab( 'sensei_lms_onboarding_tab' );
 
@@ -61,12 +66,37 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Onboarding::add_onboarding_help_tab
 	 */
 	public function testAddOnboardingHelpTabNonEditCourseScreen() {
+		// Create and login as administrator.
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
 		set_current_screen( 'edit-lesson' );
 		$screen = get_current_screen();
 
+		$screen->remove_help_tab( 'sensei_lms_onboarding_tab' );
 		Sensei()->onboarding->add_onboarding_help_tab( $screen );
 		$created_tab = $screen->get_help_tab( 'sensei_lms_onboarding_tab' );
 
 		$this->assertNull( $created_tab, 'Should not create the onboarding tab to non edit course screens.' );
+	}
+
+	/**
+	 * Test add onboarding help tab for no admin user.
+	 *
+	 * @covers Sensei_Onboarding::add_onboarding_help_tab
+	 */
+	public function testAddOnboardingHelpTabNoAdmin() {
+		// Create and login as teacher.
+		$teacher_id = $this->factory->user->create( array( 'role' => 'teacher' ) );
+		wp_set_current_user( $teacher_id );
+
+		set_current_screen( 'edit-course' );
+		$screen = get_current_screen();
+
+		$screen->remove_help_tab( 'sensei_lms_onboarding_tab' );
+		Sensei()->onboarding->add_onboarding_help_tab( $screen );
+		$created_tab = $screen->get_help_tab( 'sensei_lms_onboarding_tab' );
+
+		$this->assertNull( $created_tab, 'Should not create the onboarding tab to no admin user.' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* The help tab for the setup wizard should be added only for sensei manager users.

Feature introduced here: https://github.com/Automattic/sensei/pull/3093

### Testing instructions

* Go to wp-admin.
* Login as a teacher.
* Go to the course menu Courses and make sure that the help tab doesn't appear.
* Login as admin.
* Go to the course menu Courses and make sure that the help tab appears.

Related - #3093