### PR TITLE
Add a class which manages data port jobs

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -59,7 +59,7 @@ class Sensei_Data_Cleaner {
 		'sensei_course_order',
 		'skip_install_sensei_pages', // @deprecated since 3.1.0.
 		'sensei_suggest_setup_wizard',
-		'sensei-tools-jobs',
+		'sensei-data-port-jobs',
 		'sensei_flush_rewrite_rules',
 		'sensei_needs_language_pack_install',
 		'woothemes_sensei_language_pack_version',

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -59,6 +59,7 @@ class Sensei_Data_Cleaner {
 		'sensei_course_order',
 		'skip_install_sensei_pages', // @deprecated since 3.1.0.
 		'sensei_suggest_setup_wizard',
+		'sensei-tools-jobs',
 		'sensei_flush_rewrite_rules',
 		'sensei_needs_language_pack_install',
 		'woothemes_sensei_language_pack_version',

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -393,6 +393,7 @@ class Sensei_Main {
 		Sensei_Course_Enrolment_Manager::instance()->init();
 		$this->enrolment_scheduler = Sensei_Enrolment_Job_Scheduler::instance();
 		$this->enrolment_scheduler->init();
+		Sensei_Data_Port_Manager::instance()->init();
 
 		// Onboarding Wizard.
 		$this->onboarding = Sensei_Onboarding::instance();
@@ -580,6 +581,7 @@ class Sensei_Main {
 	public function deactivation() {
 		$this->usage_tracking->unschedule_tracking_task();
 		Sensei_Scheduler::instance()->cancel_all_jobs();
+		Sensei_Data_Port_Manager::instance()->cancel_all_jobs();
 	}
 
 	/**

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * running data port tasks which are registered by subclasses.
  */
 abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, JsonSerializable {
-	const OPTION_PREFIX         = 'sensei-tools-job-';
+	const OPTION_PREFIX         = 'sensei-data-port-job-';
 	const SCHEDULED_ACTION_NAME = 'sensei-data-port-job';
 
 	/**

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -14,7 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * running data port tasks which are registered by subclasses.
  */
 abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, JsonSerializable {
-	const OPTION_PREFIX = 'sensei-tools-job-';
+	const OPTION_PREFIX         = 'sensei-tools-job-';
+	const SCHEDULED_ACTION_NAME = 'sensei-data-port-job';
 
 	/**
 	 * An array which holds the results of the data port job and populated in subclasses.
@@ -327,7 +328,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	 * @return string
 	 */
 	public function get_name() {
-		return self::get_option_name( $this->job_id );
+		return self::SCHEDULED_ACTION_NAME;
 	}
 
 	/**
@@ -337,7 +338,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	 *
 	 * @return string The option name.
 	 */
-	public static function get_option_name( $job_id ) {
+	private static function get_option_name( $job_id ) {
 		return self::OPTION_PREFIX . $job_id;
 	}
 }

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * running data port tasks which are registered by subclasses.
  */
 abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, JsonSerializable {
-	const OPTION_PREFIX = 'sensei-data-port-';
+	const OPTION_PREFIX = 'sensei-tools-job-';
 
 	/**
 	 * An array which holds the results of the data port job and populated in subclasses.
@@ -81,19 +81,14 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	private $percentage;
 
 	/**
-	 * The tasks that consist this data port job.
-	 *
-	 * @var Sensei_Data_Port_Task_Interface[]
-	 */
-	private $tasks;
-
-	/**
-	 * Sensei_Data_Port_Job constructor.
+	 * Sensei_Data_Port_Job constructor. A data port instance can be created either when a new data port job is
+	 * registered or when an existing one is restored from a JSON string.
 	 *
 	 * @param string $job_id   Unique job id.
+	 * @param array  $args     Arguments to be used by subclasses.
 	 * @param string $json     A json string to restore internal state from.
 	 */
-	protected function __construct( $job_id, $json = '' ) {
+	protected function __construct( $job_id, $args = [], $json = '' ) {
 		$this->job_id      = $job_id;
 		$this->has_changed = false;
 		$this->is_deleted  = false;
@@ -109,8 +104,6 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 			$this->percentage   = 0;
 		}
 
-		$this->tasks = $this->get_tasks();
-
 		add_action( 'shutdown', [ $this, 'persist' ] );
 	}
 
@@ -122,13 +115,13 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	 * @return Sensei_Data_Port_Job|null instance.
 	 */
 	public static function get( $job_id ) {
-		$json = get_option( self::get_option_name(), '' );
+		$json = get_option( self::get_option_name( $job_id ), '' );
 
 		if ( empty( $json ) ) {
 			return null;
 		}
 
-		return new static( $job_id, $json );
+		return new static( $job_id, [], $json );
 	}
 
 	/**
@@ -180,7 +173,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	 * Delete any stored state for this job.
 	 */
 	public function clean_up() {
-		foreach ( $this->tasks as $task ) {
+		foreach ( $this->get_tasks() as $task ) {
 			$task->clean_up();
 		}
 
@@ -271,7 +264,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	 */
 	public function persist() {
 		if ( ! $this->is_deleted && $this->has_changed ) {
-			update_option( self::get_option_name( $this->job_id ), wp_slash( wp_json_encode( $this ) ) );
+			update_option( self::get_option_name( $this->job_id ), wp_json_encode( $this ) );
 		}
 
 		$this->has_changed = false;
@@ -289,7 +282,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 		$total_cycles       = 0;
 		$has_processed_task = false;
 
-		foreach ( $this->tasks as $task ) {
+		foreach ( $this->get_tasks() as $task ) {
 
 			if ( ! $has_processed_task && ! $task->is_completed() ) {
 				$task->run();
@@ -320,12 +313,21 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	}
 
 	/**
-	 * No a arguments are needed for data port jobs.
+	 * Returns the arguments for data port jobs.
 	 *
 	 * @return array
 	 */
 	public function get_args() {
-		return [];
+		return [ 'job_id' => $this->job_id ];
+	}
+
+	/**
+	 * Get the action name for the scheduled job.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return self::get_option_name( $this->job_id );
 	}
 
 	/**
@@ -335,7 +337,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	 *
 	 * @return string The option name.
 	 */
-	private static function get_option_name( $job_id ) {
+	public static function get_option_name( $job_id ) {
 		return self::OPTION_PREFIX . $job_id;
 	}
 }

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -76,7 +76,7 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 	 */
 	public function init() {
 		foreach ( $this->data_port_jobs as $job ) {
-			add_action( Sensei_Data_Port_Job::get_option_name( $job['id'] ), [ $this, 'run_data_port_job' ] );
+			add_action( Sensei_Data_Port_Job::SCHEDULED_ACTION_NAME, [ $this, 'run_data_port_job' ] );
 		}
 
 		add_action( 'shutdown', [ $this, 'persist' ] );

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This class is responsible creating, deleting and keeping track of data port jobs.
  */
 class Sensei_Data_Port_Manager implements JsonSerializable {
-	const OPTION_NAME = 'sensei-tools-jobs';
+	const OPTION_NAME = 'sensei-data-port-jobs';
 
 	/**
 	 * An array of all in progress data port jobs. It has the following format:

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * File containing the Sensei_Data_Port_Manager class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * This class is responsible creating, deleting and keeping track of data port jobs.
+ */
+class Sensei_Data_Port_Manager implements JsonSerializable {
+	const OPTION_NAME = 'sensei-tools-jobs';
+
+	/**
+	 * An array of all in progress data port jobs. It has the following format:
+	 * {
+	 *
+	 *     @type string $id        Unique id for this job.
+	 *     @type int    $user_id   The user which initiatied this job.
+	 *     @type int    $time      When the job started.
+	 *     @type string $handler   The class which handles this job.
+	 * }
+	 *
+	 * @var array
+	 */
+	private $data_port_jobs;
+
+	/**
+	 * Tracks if the data port jobs have been updated.
+	 *
+	 * @var boolean
+	 */
+	private $has_changed;
+
+	/**
+	 * Instance of singleton.
+	 *
+	 * @var self
+	 */
+	private static $instance;
+
+	/**
+	 * Fetches an instance of the class.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Sensei_Data_Port_Manager constructor.
+	 */
+	private function __construct() {
+		$json_string       = get_option( self::OPTION_NAME );
+		$this->has_changed = false;
+
+		if ( $json_string ) {
+			$this->data_port_jobs = json_decode( $json_string, true );
+		} else {
+			$this->data_port_jobs = [];
+		}
+	}
+
+	/**
+	 * Initializes the data port manager.
+	 */
+	public function init() {
+		foreach ( $this->data_port_jobs as $job ) {
+			add_action( Sensei_Data_Port_Job::get_option_name( $job['id'] ), [ $this, 'run_data_port_job' ] );
+		}
+
+		add_action( 'shutdown', [ $this, 'persist' ] );
+	}
+
+	/**
+	 * Runs a data port job.
+	 *
+	 * @param array $args  The arguments of the background job. Only the job_id is included.
+	 */
+	public function run_data_port_job( $args ) {
+
+		if ( empty( $args['job_id'] ) ) {
+			return;
+		}
+
+		$job = $this->get_job( $args['job_id'] );
+
+		if ( null !== $job ) {
+			Sensei_Scheduler::instance()->run( $job );
+		}
+	}
+
+	/**
+	 * Starts a data import job.
+	 *
+	 * @param int $user_id  The user which started the job.
+	 */
+	public function start_import_job( $user_id ) {
+		$job_id = md5( uniqid( '', true ) );
+
+		$this->has_changed      = true;
+		$this->data_port_jobs[] = [
+			'user_id' => $user_id,
+			'time'    => time(),
+			'handler' => 'Sensei_Import_Job',
+			'id'      => $job_id,
+		];
+
+		$job = new Sensei_Import_Job( $job_id );
+		Sensei_Scheduler::instance()->schedule_job( $job );
+	}
+
+	/**
+	 * Cancel a job.
+	 *
+	 * @param string $job_id  The job id.
+	 */
+	public function cancel_job( $job_id ) {
+		$job = $this->get_job( $job_id );
+
+		if ( null !== $job ) {
+			$job->clean_up();
+		}
+
+		$this->has_changed    = true;
+		$this->data_port_jobs = array_filter(
+			$this->data_port_jobs,
+			function ( $job ) use ( $job_id ) {
+				return $job['id'] !== $job_id;
+			}
+		);
+	}
+
+	/**
+	 * Cancel all pending jobs.
+	 */
+	public function cancel_all_jobs() {
+		foreach ( $this->data_port_jobs as $job ) {
+			if ( $job['handler'] instanceof \Sensei_Data_Port_Job ) {
+				$job_instance = $job['handler']::get( $job['id'] );
+
+				if ( null !== $job_instance ) {
+					$job_instance->clean_up();
+				}
+			}
+		}
+
+		$this->has_changed    = true;
+		$this->data_port_jobs = [];
+	}
+
+	/**
+	 * Serialize the port jobs to JSON.
+	 *
+	 * @return array
+	 */
+	public function jsonSerialize() {
+		return $this->data_port_jobs;
+	}
+
+	/**
+	 * Persist state to the db.
+	 *
+	 * @access private
+	 */
+	public function persist() {
+		if ( $this->has_changed ) {
+			update_option( self::OPTION_NAME, wp_json_encode( $this ) );
+		}
+
+		$this->has_changed = false;
+	}
+
+	/**
+	 * Get a data port job instance from its id.
+	 *
+	 * @param string $job_id The job id.
+	 *
+	 * @return Sensei_Data_Port_Job|null
+	 */
+	private function get_job( $job_id ) {
+
+		foreach ( $this->data_port_jobs as $job ) {
+			if ( $job_id === $job['id'] && is_a( $job['handler'], 'Sensei_Data_Port_Job', true ) ) {
+				return $job['handler']::get( $job['id'] );
+			}
+		}
+
+		return null;
+	}
+}

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -116,6 +116,7 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 			'id'      => $job_id,
 		];
 
+		// TODO: This method should break to two steps, create and start.
 		$job = new Sensei_Import_Job( $job_id );
 		Sensei_Scheduler::instance()->schedule_job( $job );
 	}

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -146,7 +146,7 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 	 */
 	public function cancel_all_jobs() {
 		foreach ( $this->data_port_jobs as $job ) {
-			if ( $job['handler'] instanceof \Sensei_Data_Port_Job ) {
+			if ( is_subclass_of( $job['handler'], 'Sensei_Data_Port_Job', true ) ) {
 				$job_instance = $job['handler']::get( $job['id'] );
 
 				if ( null !== $job_instance ) {
@@ -191,7 +191,7 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 	private function get_job( $job_id ) {
 
 		foreach ( $this->data_port_jobs as $job ) {
-			if ( $job_id === $job['id'] && is_a( $job['handler'], 'Sensei_Data_Port_Job', true ) ) {
+			if ( $job_id === $job['id'] && is_subclass_of( $job['handler'], 'Sensei_Data_Port_Job', true ) ) {
 				return $job['handler']::get( $job['id'] );
 			}
 		}

--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * File containing the Sensei_Import_Job class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * This class represents a data import job.
+ */
+class Sensei_Import_Job extends Sensei_Data_Port_Job {
+
+	/**
+	 * The array of the import tasks.
+	 *
+	 * @var Sensei_Data_Port_Task_Interface[]
+	 */
+	private $tasks;
+
+	/**
+	 * Sensei_Import_Job constructor.
+	 *
+	 * @param string $job_id  The job id.
+	 * @param array  $args    Arguments for the import job.
+	 * @param string $json    JSON string to restore the state from.
+	 */
+	public function __construct( $job_id, $args = [], $json = '' ) {
+		parent::__construct( $job_id, $args, $json );
+		// TODO: Generate the tasks from the arguments and/or from the internal state.
+		$this->tasks = [];
+	}
+
+	/**
+	 * Get the tasks of this import job.
+	 *
+	 * @return Sensei_Data_Port_Task_Interface[]
+	 */
+	public function get_tasks() {
+		return $this->tasks;
+	}
+
+}

--- a/tests/framework/data-port/class-sensei-data-port-job-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-job-mock.php
@@ -8,24 +8,29 @@
 
 class Sensei_Data_Port_Job_Mock extends Sensei_Data_Port_Job {
 
-	private static $tasks;
+	private $tasks;
 
-	public static function create( $tasks ) {
-		self::$tasks = $tasks;
+	private static $restore_mock;
 
-		return new self( 'test-job' );
-	}
+	public function __construct( $job_id, $args = [], $json = '' ) {
+		parent::__construct( $job_id, $args, $json );
 
-	public function get_name() {
-		return 'test-job';
+		$this->tasks = $args;
 	}
 
 	public function get_tasks() {
-		return self::$tasks;
+		return $this->tasks;
 	}
 
 	public function log( $title, $message, $type, $id ) {
 		$this->add_log_entry( $title, $message, $type, $id );
 	}
 
+	public static function get( $job_id ) {
+		return self::$restore_mock;
+	}
+
+	public static function set_restore_mock( $mock ) {
+		self::$restore_mock = $mock;
+	}
 }

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-manager.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-manager.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * This file contains the Sensei_Data_Port_Manager_Test class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/data-port/class-sensei-data-port-job-mock.php';
+
+/**
+ * Tests for Sensei_Data_Port_Manager class.
+ *
+ * @group data-port
+ */
+class Sensei_Data_Port_Manager_Test extends WP_UnitTestCase {
+
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->set_data_port_jobs( [] );
+	}
+
+	public function testJobIsResumed() {
+		$job = $this->mock_job_method( 'test-job', 'run' );
+		Sensei_Data_Port_Job_Mock::set_restore_mock( $job );
+
+		$this->set_data_port_jobs(
+			[
+				[
+					'user_id' => 1,
+					'time'    => time(),
+					'handler' => 'Sensei_Data_Port_Job_Mock',
+					'id'      => 'test-job',
+				],
+			]
+		);
+
+		$job->expects( $this->once() )->method( 'run' );
+
+		Sensei_Data_Port_Manager::instance()->run_data_port_job( [ 'job_id' => 'test-job' ] );
+	}
+
+	public function testStartingJobStoresState() {
+		Sensei_Data_Port_Manager::instance()->start_import_job( 1234 );
+		Sensei_Data_Port_Manager::instance()->persist();
+
+		$json = get_option( Sensei_Data_Port_Manager::OPTION_NAME );
+		$this->assertRegExp( '/.*user_id.*1234/', $json, 'User id should be stored in JSON.' );
+		$this->assertRegExp( '/.*handler.*Sensei_Import_Job/', $json, 'Handler should equal to Sensei_Import_Job.' );
+	}
+
+	public function testCancelledJobsAreRemoved() {
+		Sensei_Data_Port_Manager::instance()->start_import_job( 1 );
+		$this->set_data_port_jobs(
+			[
+				[
+					'user_id' => 1,
+					'time'    => time(),
+					'handler' => 'Sensei_Data_Port_Job_Mock',
+					'id'      => 'first-job',
+				],
+				[
+					'user_id' => 1,
+					'time'    => time(),
+					'handler' => 'Sensei_Data_Port_Job_Mock',
+					'id'      => 'second-job',
+				],
+				[
+					'user_id' => 1,
+					'time'    => time(),
+					'handler' => 'Sensei_Data_Port_Job_Mock',
+					'id'      => 'third-job',
+				],
+			]
+		);
+
+		Sensei_Data_Port_Manager::instance()->persist();
+		$port_jobs = json_decode( get_option( Sensei_Data_Port_Manager::OPTION_NAME ), true );
+		$this->assertCount( 3, $port_jobs );
+
+		Sensei_Data_Port_Manager::instance()->cancel_job( 'first-job' );
+		Sensei_Data_Port_Manager::instance()->persist();
+		$port_jobs = json_decode( get_option( Sensei_Data_Port_Manager::OPTION_NAME ), true );
+		$this->assertCount( 2, $port_jobs );
+		$this->assertEquals( 'second-job', array_values( $port_jobs )[0]['id'] );
+		$this->assertEquals( 'third-job', array_values( $port_jobs )[1]['id'] );
+
+		Sensei_Data_Port_Manager::instance()->cancel_all_jobs();
+		Sensei_Data_Port_Manager::instance()->persist();
+		$port_jobs = json_decode( get_option( Sensei_Data_Port_Manager::OPTION_NAME ), true );
+		$this->assertCount( 0, $port_jobs );
+	}
+
+	private function set_data_port_jobs( $jobs ) {
+		$property = new ReflectionProperty( 'Sensei_Data_Port_Manager', 'data_port_jobs' );
+		$property->setAccessible( true );
+		$property->setValue( Sensei_Data_Port_Manager::instance(), $jobs );
+	}
+
+	private function mock_job_method( $job_id, $method ) {
+		return $this->getMockBuilder( Sensei_Data_Port_Job_Mock::class )
+			->setConstructorArgs( [ $job_id ] )
+			->setMethods( [ $method ] )
+			->getMock();
+	}
+}

--- a/tests/unit-tests/data-port/test-class-sensei-data-port.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port.php
@@ -23,7 +23,7 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 		$first_completed  = $this->mock_task_method( true, 100, 100, 'run' );
 		$second_completed = $this->mock_task_method( true, 100, 100, 'run' );
 
-		$job = Sensei_Data_Port_Job_Mock::create( [ $first_completed, $second_completed ] );
+		$job = new Sensei_Data_Port_Job_Mock( 'test-job', [ $first_completed, $second_completed ] );
 
 		$first_completed->expects( $this->never() )->method( 'run' );
 		$second_completed->expects( $this->never() )->method( 'run' );
@@ -45,7 +45,7 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 		$completed = $this->mock_task_method( true, 100, 100, 'run' );
 		$pending   = $this->mock_task_method( false, 25, 100, 'run' );
 
-		$job = Sensei_Data_Port_Job_Mock::create( [ $completed, $pending ] );
+		$job = new Sensei_Data_Port_Job_Mock( 'test-job', [ $completed, $pending ] );
 
 		$completed->expects( $this->never() )->method( 'run' );
 		$pending->expects( $this->once() )->method( 'run' );
@@ -67,7 +67,7 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 		$first_pending  = $this->mock_task_method( false, 50, 100, 'run' );
 		$second_pending = $this->mock_task_method( false, 0, 100, 'run' );
 
-		$job = Sensei_Data_Port_Job_Mock::create( [ $first_pending, $second_pending ] );
+		$job = new Sensei_Data_Port_Job_Mock( 'test-job', [ $first_pending, $second_pending ] );
 
 		$first_pending->expects( $this->once() )->method( 'run' );
 		$second_pending->expects( $this->never() )->method( 'run' );
@@ -90,7 +90,7 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 		$first_completed  = $this->mock_task_method( true, 100, 100, 'clean_up' );
 		$second_completed = $this->mock_task_method( true, 100, 100, 'clean_up' );
 
-		$job = Sensei_Data_Port_Job_Mock::create( [ $first_completed, $second_completed ] );
+		$job = new Sensei_Data_Port_Job_Mock( 'test-job', [ $first_completed, $second_completed ] );
 
 		$first_completed->expects( $this->once() )->method( 'clean_up' );
 		$second_completed->expects( $this->once() )->method( 'clean_up' );
@@ -99,7 +99,7 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 	}
 
 	public function testLogMessagePagination() {
-		$job = Sensei_Data_Port_Job_Mock::create( [ new Sensei_Data_Port_Task_Mock( true, 100, 100 ) ] );
+		$job = new Sensei_Data_Port_Job_Mock( 'test-job', [ new Sensei_Data_Port_Task_Mock( true, 100, 100 ) ] );
 
 		$job->log( 'First course', 'First failed', 'course', '1' );
 		$job->log( 'First lesson', 'First failed', 'lesson', '1' );
@@ -209,18 +209,18 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 	}
 
 	public function testStateIsPersisted() {
-		$job = Sensei_Data_Port_Job_Mock::create( [ new Sensei_Data_Port_Task_Mock( true, 100, 100 ) ] );
+		$job = new Sensei_Data_Port_Job_Mock( 'test-job', [ new Sensei_Data_Port_Task_Mock( true, 100, 100 ) ] );
 
-		$this->assertFalse( get_option( Sensei_Data_Port_Job::OPTION_PREFIX . 'test-job' ), 'Option should not be stored if persist is not called.' );
+		$this->assertFalse( get_option( $job->get_name() ), 'Option should not be stored if persist is not called.' );
 
 		$job->persist();
 
-		$this->assertNotFalse( get_option( Sensei_Data_Port_Job::OPTION_PREFIX . 'test-job' ), 'Option should be stored if persist is called.' );
+		$this->assertNotFalse( get_option( $job->get_name() ), 'Option should be stored if persist is called.' );
 
 		$job->clean_up();
 		$job->persist();
 
-		$this->assertFalse( get_option( Sensei_Data_Port_Job::OPTION_PREFIX . 'test-job' ), 'Option should not be stored if persist is not called.' );
+		$this->assertFalse( get_option( $job->get_name() ), 'Option should not be stored if persist is not called.' );
 	}
 
 	private function mock_task_method( $is_complete, $completed_cycles, $total_cycles, $method ) {

--- a/tests/unit-tests/data-port/test-class-sensei-data-port.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port.php
@@ -215,7 +215,7 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 
 		$job->persist();
 
-		$this->assertNotFalse( get_option( $job->get_name() ), 'Option should be stored if persist is called.' );
+		$this->assertNotFalse( get_option( Sensei_Data_Port_Job::OPTION_PREFIX . 'test-job' ), 'Option should be stored if persist is called.' );
 
 		$job->clean_up();
 		$job->persist();


### PR DESCRIPTION
### Overview
This PR brings us one step closer to write some code which actually does something 😄 . It introduces a new class `Sensei_Data_Port_Manager` which has the responsibility of creating/deleting new data port jobs and registering any needed hooks. I imagine that this class will be also responsible to trigger garbage collection but this will be done as part of another PR.

### Testing instructions
Not much to test yet, just check the coverage of the unit tests.
