### PR TITLE
Fix setup wizard navigation naming and documentation

### DIFF
--- a/assets/onboarding/index.jsx
+++ b/assets/onboarding/index.jsx
@@ -5,14 +5,14 @@ import QueryStringRouter, { Route } from './query-string-router';
 import Navigation from './navigation';
 
 /**
- * Param name used to route the onboarding wizard.
+ * Param name used to route the setup wizard.
  */
 const PARAM_NAME = 'step';
 
 /**
- * Sensei onboarding page.
+ * Sensei setup wizard page.
  */
-const SenseiOnboardingPage = () => {
+const SenseiSetupWizardPage = () => {
 	useWpAdminFullscreen( [ 'sensei-color', 'sensei-onboarding__page' ] );
 
 	return (
@@ -36,6 +36,6 @@ const SenseiOnboardingPage = () => {
 };
 
 render(
-	<SenseiOnboardingPage />,
+	<SenseiSetupWizardPage />,
 	document.getElementById( 'sensei-onboarding-page' )
 );

--- a/assets/onboarding/navigation/index.jsx
+++ b/assets/onboarding/navigation/index.jsx
@@ -5,14 +5,23 @@ import { get, uniq } from 'lodash';
 import { useQueryStringRouter } from '../query-string-router';
 
 /**
+ * @typedef  {Object} Step
+ * @property {string} key  Step key.
+ */
+/**
+ * @typedef  {Object}   StepWithNavigationState
+ * @property {boolean}  [isComplete]            Flag if it is complete.
+ * @property {Function} [onClick]               Function to navigate to the step (Enables the click on the Stepper).
+ */
+/**
  * Merge the navigation state into the steps.
  * Add isComplete and onClick - when visited.
  *
- * @param {Array}    steps        Steps list.
+ * @param {Step[]}   steps        Steps list.
  * @param {string[]} visitedSteps Key of the visited steps.
  * @param {Function} goTo         Function that update the step.
  *
- * @return {Object} Steps with navigation state merged.
+ * @return {StepWithNavigationState} Steps with navigation state merged.
  */
 const getStepsWithNavigationState = ( steps, visitedSteps, goTo ) =>
 	steps.map( ( step, index ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This fixes some documentation
* Fix naming from "onboarding" to "setup wizard" in the code related to the [navigation](https://github.com/Automattic/sensei/pull/3085).

@alexsanford, the changes you asked in https://github.com/Automattic/sensei/pull/3085 are in this new PR.

Related - #3085