### PR TITLE
Refactor WooCommerce help tab prevention in Sensei pages

### DIFF
--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -254,6 +254,7 @@ class Sensei_Onboarding {
 			]
 		);
 	}
+
 	/**
 	 * Register REST API route.
 	 */

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -49,7 +49,7 @@ class Sensei_Onboarding {
 			add_action( 'admin_menu', [ $this, 'admin_menu' ], 20 );
 			add_action( 'admin_notices', [ $this, 'setup_wizard_notice' ] );
 			add_action( 'admin_init', array( $this, 'skip_setup_wizard' ) );
-			add_action( 'current_screen', [ $this, 'add_onboarding_help_tab' ] );
+			add_action( 'current_screen', [ $this, 'add_setup_wizard_help_tab' ] );
 
 			// Maybe prevent WooCommerce help tab.
 			add_filter( 'woocommerce_enable_admin_help_tab', [ $this, 'should_enable_woocommerce_help_tab' ] );
@@ -229,13 +229,13 @@ class Sensei_Onboarding {
 	}
 
 	/**
-	 * Add onboarding help tab.
+	 * Add setup wizard help tab.
 	 *
 	 * @param WP_Screen $screen Current screen.
 	 *
 	 * @access private
 	 */
-	public function add_onboarding_help_tab( $screen ) {
+	public function add_setup_wizard_help_tab( $screen ) {
 		$link_track_event = 'setup_wizard_click';
 
 		if ( ! $screen || ! $this->should_show_help_screen( $screen->id ) || ! current_user_can( 'manage_sensei' ) ) {
@@ -244,7 +244,7 @@ class Sensei_Onboarding {
 
 		$screen->add_help_tab(
 			[
-				'id'      => 'sensei_lms_onboarding_tab',
+				'id'      => 'sensei_lms_setup_wizard_tab',
 				'title'   => __( 'Setup wizard', 'sensei-lms' ),
 				'content' =>
 					'<h2>' . __( 'Sensei LMS Onboarding', 'sensei-lms' ) . '</h2>' .

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -51,10 +51,8 @@ class Sensei_Onboarding {
 			add_action( 'admin_init', array( $this, 'skip_setup_wizard' ) );
 			add_action( 'current_screen', [ $this, 'add_onboarding_help_tab' ] );
 
-			if ( $this->should_prevent_woocommerce_help_tab() ) {
-				// Prevent WooCommerce help tab.
-				add_filter( 'woocommerce_enable_admin_help_tab', '__return_false' );
-			}
+			// Maybe prevent WooCommerce help tab.
+			add_filter( 'woocommerce_enable_admin_help_tab', [ $this, 'should_enable_woocommerce_help_tab' ] );
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 			if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
@@ -84,21 +82,6 @@ class Sensei_Onboarding {
 			}
 		}
 
-	}
-
-	/**
-	 * Check if should prevent woocommerce help tab or not.
-	 *
-	 * @return boolean
-	 */
-	private function should_prevent_woocommerce_help_tab() {
-		$post_types_to_prevent = [ 'course', 'lesson', 'sensei_message' ];
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
-		return isset( $_GET['post_type'] ) && (
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
-			in_array( $_GET['post_type'], $post_types_to_prevent, true )
-		);
 	}
 
 	/**
@@ -212,6 +195,26 @@ class Sensei_Onboarding {
 		) {
 			update_option( self::SUGGEST_SETUP_WIZARD_OPTION, 0 );
 		}
+	}
+
+	/**
+	 * Prevent displaying WooCommerce help tab in Sensei admin pages.
+	 *
+	 * @access private
+	 *
+	 * @param boolean $allow Allow showing the WooCommerce help tab.
+	 *
+	 * @return boolean
+	 */
+	public function should_enable_woocommerce_help_tab( $allow ) {
+		$post_types_to_prevent = [ 'course', 'lesson', 'sensei_message' ];
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
+		if ( isset( $_GET['post_type'] ) && in_array( $_GET['post_type'], $post_types_to_prevent, true ) ) {
+			return false;
+		}
+
+		return $allow;
 	}
 
 	/**

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -208,6 +208,34 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test if WooCommerce help tab is being prevented in the Sensei pages.
+	 *
+	 * @covers Sensei_Onboarding::should_enable_woocommerce_help_tab
+	 */
+	public function testShouldEnableWooCommerceHelpTab() {
+		$_GET['post_type'] = 'course';
+
+		$this->assertFalse(
+			Sensei()->onboarding->should_enable_woocommerce_help_tab( true ),
+			'Should not allow WooCommerce help tab for course post type'
+		);
+	}
+
+	/**
+	 * Test if WooCommerce help tab is being untouched in no Sensei pages.
+	 *
+	 * @covers Sensei_Onboarding::should_enable_woocommerce_help_tab
+	 */
+	public function testShouldEnableWooCommerceHelpTabNoSenseiPage() {
+		$_GET['post_type'] = 'woocommerce';
+
+		$this->assertTrue(
+			Sensei()->onboarding->should_enable_woocommerce_help_tab( true ),
+			'Should not touch WooCommerce help tab for no Sensei pages'
+		);
+	}
+
+	/**
 	 * Test add onboarding help tab to edit course screen.
 	 *
 	 * @covers Sensei_Onboarding::add_onboarding_help_tab

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -236,11 +236,11 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test add onboarding help tab to edit course screen.
+	 * Test add setup wizard help tab to edit course screen.
 	 *
-	 * @covers Sensei_Onboarding::add_onboarding_help_tab
+	 * @covers Sensei_Onboarding::add_setup_wizard_help_tab
 	 */
-	public function testAddOnboardingHelpTab() {
+	public function testAddSetupWizardHelpTab() {
 		// Create and login as administrator.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -248,19 +248,19 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 		set_current_screen( 'edit-course' );
 		$screen = get_current_screen();
 
-		$screen->remove_help_tab( 'sensei_lms_onboarding_tab' );
-		Sensei()->onboarding->add_onboarding_help_tab( $screen );
-		$created_tab = $screen->get_help_tab( 'sensei_lms_onboarding_tab' );
+		$screen->remove_help_tab( 'sensei_lms_setup_wizard_tab' );
+		Sensei()->onboarding->add_setup_wizard_help_tab( $screen );
+		$created_tab = $screen->get_help_tab( 'sensei_lms_setup_wizard_tab' );
 
-		$this->assertNotNull( $created_tab, 'Should create the onboarding tab to edit course screens.' );
+		$this->assertNotNull( $created_tab, 'Should create the setup wizard tab to edit course screens.' );
 	}
 
 	/**
-	 * Test add onboarding help tab in non edit course screens.
+	 * Test add setup wizard help tab in non edit course screens.
 	 *
-	 * @covers Sensei_Onboarding::add_onboarding_help_tab
+	 * @covers Sensei_Onboarding::add_setup_wizard_help_tab
 	 */
-	public function testAddOnboardingHelpTabNonEditCourseScreen() {
+	public function testAddSetupWizardHelpTabNonEditCourseScreen() {
 		// Create and login as administrator.
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
@@ -268,19 +268,19 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 		set_current_screen( 'edit-lesson' );
 		$screen = get_current_screen();
 
-		$screen->remove_help_tab( 'sensei_lms_onboarding_tab' );
-		Sensei()->onboarding->add_onboarding_help_tab( $screen );
-		$created_tab = $screen->get_help_tab( 'sensei_lms_onboarding_tab' );
+		$screen->remove_help_tab( 'sensei_lms_setup_wizard_tab' );
+		Sensei()->onboarding->add_setup_wizard_help_tab( $screen );
+		$created_tab = $screen->get_help_tab( 'sensei_lms_setup_wizard_tab' );
 
-		$this->assertNull( $created_tab, 'Should not create the onboarding tab to non edit course screens.' );
+		$this->assertNull( $created_tab, 'Should not create the setup wizard tab to non edit course screens.' );
 	}
 
 	/**
-	 * Test add onboarding help tab for no admin user.
+	 * Test add setup wizard help tab for no admin user.
 	 *
-	 * @covers Sensei_Onboarding::add_onboarding_help_tab
+	 * @covers Sensei_Onboarding::add_setup_wizard_help_tab
 	 */
-	public function testAddOnboardingHelpTabNoAdmin() {
+	public function testAddSetupWizardHelpTabNoAdmin() {
 		// Create and login as teacher.
 		$teacher_id = $this->factory->user->create( array( 'role' => 'teacher' ) );
 		wp_set_current_user( $teacher_id );
@@ -288,10 +288,10 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 		set_current_screen( 'edit-course' );
 		$screen = get_current_screen();
 
-		$screen->remove_help_tab( 'sensei_lms_onboarding_tab' );
-		Sensei()->onboarding->add_onboarding_help_tab( $screen );
-		$created_tab = $screen->get_help_tab( 'sensei_lms_onboarding_tab' );
+		$screen->remove_help_tab( 'sensei_lms_setup_wizard_tab' );
+		Sensei()->onboarding->add_setup_wizard_help_tab( $screen );
+		$created_tab = $screen->get_help_tab( 'sensei_lms_setup_wizard_tab' );
 
-		$this->assertNull( $created_tab, 'Should not create the onboarding tab to no admin user.' );
+		$this->assertNull( $created_tab, 'Should not create the setup wizard tab to no admin user.' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Refactor in how to prevent the WooCommerce help tab. https://github.com/Automattic/sensei/pull/3093#discussion_r421589539 cc @alexsanford 
* Renaming from "onboarding" to "setup wizard".

### Testing instructions

* Activate WooCommerce, WooCommerce Memberships and Sensei LMS plugins.
* Go to `wp-admin`
* Go to the course menu `Courses`.
* Click on the "Help ▼" button located in the top right.
* Make sure appears only the Onboarding help tab (`Setup wizard`) and WooCommerce help tabs and links don't appear.
* Click on the `Setup wizard` button.
* Make sure you're in the onboarding area and the `sensei_setup_wizard_click` event was logged (you can use https://github.com/Automattic/event-monitor updating the URL in `sensei/includes/lib/usage-tracking/class-usage-tracking-base.php`).
* Go to `wp-admin`.
* Go to the non-course screens.
* Make sure that the Onboarding help tab doesn't appear.

Related - #3093