### PR TITLE
Fix setup wizard page title

### DIFF
--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -100,11 +100,13 @@ class Sensei_Onboarding {
 
 	/**
 	 * Register an Onboarding submenu.
+	 *
+	 * @link https://developer.wordpress.org/reference/functions/add_submenu_page/#comment-445
 	 */
 	public function admin_menu() {
 		if ( current_user_can( 'manage_sensei' ) ) {
 			add_submenu_page(
-				null,
+				'options.php',
 				__( 'Onboarding', 'sensei-lms' ),
 				__( 'Onboarding', 'sensei-lms' ),
 				'manage_sensei',

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -99,7 +99,7 @@ class Sensei_Onboarding {
 	}
 
 	/**
-	 * Register an Onboarding submenu.
+	 * Register an setup wizard hidden submenu.
 	 *
 	 * @link https://developer.wordpress.org/reference/functions/add_submenu_page/#comment-445
 	 */
@@ -107,19 +107,19 @@ class Sensei_Onboarding {
 		if ( current_user_can( 'manage_sensei' ) ) {
 			add_submenu_page(
 				'options.php',
-				__( 'Onboarding', 'sensei-lms' ),
-				__( 'Onboarding', 'sensei-lms' ),
+				__( 'Setup Wizard', 'sensei-lms' ),
+				__( 'Setup Wizard', 'sensei-lms' ),
 				'manage_sensei',
 				$this->page_slug,
-				[ $this, 'onboarding_page' ]
+				[ $this, 'setup_wizard_page' ]
 			);
 		}
 	}
 
 	/**
-	 * Render app container for Onboarding Wizard.
+	 * Render app container for setup wizard.
 	 */
-	public function onboarding_page() {
+	public function setup_wizard_page() {
 
 		?>
 		<div id="sensei-onboarding-page" class="sensei-onboarding">

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -99,7 +99,7 @@ class Sensei_Onboarding {
 	}
 
 	/**
-	 * Register an setup wizard hidden submenu.
+	 * Register the hidden setup wizard submenu.
 	 *
 	 * @link https://developer.wordpress.org/reference/functions/add_submenu_page/#comment-445
 	 */

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -107,8 +107,8 @@ class Sensei_Onboarding {
 		if ( current_user_can( 'manage_sensei' ) ) {
 			add_submenu_page(
 				'options.php',
-				__( 'Setup Wizard', 'sensei-lms' ),
-				__( 'Setup Wizard', 'sensei-lms' ),
+				__( 'Sensei LMS - Setup Wizard', 'sensei-lms' ),
+				__( 'Sensei LMS - Setup Wizard', 'sensei-lms' ),
 				'manage_sensei',
 				$this->page_slug,
 				[ $this, 'setup_wizard_page' ]


### PR DESCRIPTION
### Changes proposed in this Pull Request

* I realized that this change https://github.com/Automattic/sensei/commit/0255d195d25a92097498fc619b8dc2607a997be5 created an issue that removed the page title. So this PR fixes it.

### Testing instructions

* Go to `/wp-admin/admin.php?page=sensei_onboarding`.
* Check the title page. It should be "Setup Wizard".

Related - #3093