### PR TITLE
Log when the quiz question order is updated.

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2628,6 +2628,13 @@ class Sensei_Lesson {
 				++$o;
 			}
 			update_post_meta( $quiz_data['quiz_id'], '_question_order', $questions );
+
+			// Log event: when a user edits the order of questions in a quiz.
+			$event_properties = array(
+				'question_count' => count( $questions ),
+			);
+			sensei_log_event( 'quiz_question_order_update', $event_properties );
+
 		}
 		die();
 	}


### PR DESCRIPTION
Fixes #2667 

### Changes proposed in this Pull Request

* Log when the quiz question order is updated.
* Logs "question_count" (number of questions in the quiz)
