### PR TITLE
Log when the course order is updated.

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1387,6 +1387,12 @@ class Sensei_Admin {
 
 		update_option( 'sensei_course_order', implode( ',', $order ) );
 
+		// Log event: when the course order is updated.
+		$event_properties = array(
+			'course_count' => count( $order ),
+		);
+		sensei_log_event( 'course_order_update', $event_properties );
+
 		return true;
 	}
 


### PR DESCRIPTION
Fixes #2655 

### Changes proposed in this Pull Request

* Log when the course order is updated.
* Logs "course_count" (number of courses displayed on Order Courses page).