### PR TITLE
Log when an existing question is added to a quiz.

### DIFF
--- a/assets/js/lesson-metadata.js
+++ b/assets/js/lesson-metadata.js
@@ -1118,6 +1118,9 @@ jQuery(document).ready( function() {
 
 			dataToPost = 'questions=' + questions;
 			dataToPost += '&quiz_id=' + jQuery( '#quiz_id' ).attr( 'value' );
+			dataToPost += '&question_status=' + jQuery( '#existing-status' ).attr( 'value' );
+			dataToPost += '&question_type=' + jQuery( '#existing-type' ).attr( 'value' );
+			dataToPost += '&question_category=' + jQuery( '#existing-category' ).attr( 'value' );
 
 			var questionCount = parseInt( jQuery( '#question_counter' ).attr( 'value' ) );
 			dataToPost += '&question_count=' + questionCount;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2579,10 +2579,16 @@ class Sensei_Lesson {
 		// Log event: when an existing question is added to a quiz.
 		if ( count( $number_of_added_questions ) > 0 ) {
 
+			// If no question category received, log 'all'. If question category received, but term not found, log '0'.
+			$question_category_to_log = 'all';
+			if ( $question_data['question_category'] ) {
+				$question_category_to_log = get_term_by( 'slug', $question_data['question_category'], 'question-category' ) ? get_term_by( 'slug', $question_data['question_category'], 'question-category' )->term_id : '0';
+			}
+
 			$event_properties = array(
 				'question_status'   => $question_data['question_status'],
 				'question_type'     => $question_data['question_type'] ? $question_data['question_type'] : 'all',
-				'question_category' => $question_data['question_category'] ? get_term_by( 'slug', $question_data['question_category'], 'question-category' )->term_id : 'all',
+				'question_category' => $question_category_to_log,
 				'question_count'    => $number_of_added_questions,
 			);
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2547,6 +2547,10 @@ class Sensei_Lesson {
 
 		$return = '';
 
+		// Variables used for logging.
+		$number_of_added_questions   = 0;
+		$at_least_one_question_added = false;
+
 		if ( is_array( $question_data ) ) {
 
 			if ( isset( $question_data['questions'] ) && '' != $question_data['questions'] ) {
@@ -2561,6 +2565,8 @@ class Sensei_Lesson {
 
 					if ( ! in_array( $quiz_id, $quizzes ) ) {
 
+						$at_least_one_question_added = true;
+						$number_of_added_questions++;
 						++$question_count;
 						add_post_meta( $question_id, '_quiz_id', $quiz_id, false );
 						$lesson_id = get_post_meta( $quiz_id, '_quiz_lesson', true );
@@ -2572,6 +2578,19 @@ class Sensei_Lesson {
 					}
 				}
 			}
+		}
+
+		// Log event: when an existing question is added to a quiz.
+		if ( $at_least_one_question_added ) {
+
+			$event_properties = array(
+				'question_status'      => $question_data['question_status'],
+				'question_type'        => $question_data['question_type'] ? $question_data['question_type'] : 'all',
+				'question_category_id' => $question_data['question_category'] ? get_term_by( 'slug', $question_data['question_category'], 'question-category' )->term_id : 'all',
+				'question_count'       => $number_of_added_questions,
+			);
+
+			sensei_log_event( 'quiz_question_add_existing', $event_properties );
 		}
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in methods that generate `$return`.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2557,19 +2557,19 @@ class Sensei_Lesson {
 
 				foreach ( $questions as $question_id ) {
 
-					++$question_count;
-
 					$quizzes = get_post_meta( $question_id, '_quiz_id', false );
+
 					if ( ! in_array( $quiz_id, $quizzes ) ) {
+
+						++$question_count;
 						add_post_meta( $question_id, '_quiz_id', $quiz_id, false );
 						$lesson_id = get_post_meta( $quiz_id, '_quiz_lesson', true );
 						update_post_meta( $lesson_id, '_quiz_has_questions', '1' );
+						add_post_meta( $question_id, '_quiz_question_order' . $quiz_id, $quiz_id . '000' . $question_count );
+						$question_type = Sensei()->question->get_question_type( $question_id );
+						$return       .= $this->quiz_panel_question( $question_type, $question_count, $question_id );
+
 					}
-
-					add_post_meta( $question_id, '_quiz_question_order' . $quiz_id, $quiz_id . '000' . $question_count );
-					$question_type = Sensei()->question->get_question_type( $question_id );
-
-					$return .= $this->quiz_panel_question( $question_type, $question_count, $question_id );
 				}
 			}
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2586,7 +2586,7 @@ class Sensei_Lesson {
 			$event_properties = array(
 				'question_status'      => $question_data['question_status'],
 				'question_type'        => $question_data['question_type'] ? $question_data['question_type'] : 'all',
-				'question_category_id' => $question_data['question_category'] ? get_term_by( 'slug', $question_data['question_category'], 'question-category' )->term_id : 'all',
+				'question_category' => $question_data['question_category'] ? get_term_by( 'slug', $question_data['question_category'], 'question-category' )->term_id : 'all',
 				'question_count'       => $number_of_added_questions,
 			);
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2548,8 +2548,7 @@ class Sensei_Lesson {
 		$return = '';
 
 		// Variables used for logging.
-		$number_of_added_questions   = 0;
-		$at_least_one_question_added = false;
+		$number_of_added_questions = 0;
 
 		if ( is_array( $question_data ) ) {
 
@@ -2564,7 +2563,6 @@ class Sensei_Lesson {
 					$quizzes = get_post_meta( $question_id, '_quiz_id', false );
 
 					if ( ! in_array( $quiz_id, $quizzes ) ) {
-
 						$at_least_one_question_added = true;
 						$number_of_added_questions++;
 						++$question_count;
@@ -2574,14 +2572,13 @@ class Sensei_Lesson {
 						add_post_meta( $question_id, '_quiz_question_order' . $quiz_id, $quiz_id . '000' . $question_count );
 						$question_type = Sensei()->question->get_question_type( $question_id );
 						$return       .= $this->quiz_panel_question( $question_type, $question_count, $question_id );
-
 					}
 				}
 			}
 		}
 
 		// Log event: when an existing question is added to a quiz.
-		if ( $at_least_one_question_added ) {
+		if ( count( $number_of_added_questions ) > 0 ) {
 
 			$event_properties = array(
 				'question_status'   => $question_data['question_status'],

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2584,10 +2584,10 @@ class Sensei_Lesson {
 		if ( $at_least_one_question_added ) {
 
 			$event_properties = array(
-				'question_status'      => $question_data['question_status'],
-				'question_type'        => $question_data['question_type'] ? $question_data['question_type'] : 'all',
+				'question_status'   => $question_data['question_status'],
+				'question_type'     => $question_data['question_type'] ? $question_data['question_type'] : 'all',
 				'question_category' => $question_data['question_category'] ? get_term_by( 'slug', $question_data['question_category'], 'question-category' )->term_id : 'all',
-				'question_count'       => $number_of_added_questions,
+				'question_count'    => $number_of_added_questions,
 			);
 
 			sensei_log_event( 'quiz_question_add_existing', $event_properties );

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2563,7 +2563,6 @@ class Sensei_Lesson {
 					$quizzes = get_post_meta( $question_id, '_quiz_id', false );
 
 					if ( ! in_array( $quiz_id, $quizzes ) ) {
-						$at_least_one_question_added = true;
 						$number_of_added_questions++;
 						++$question_count;
 						add_post_meta( $question_id, '_quiz_id', $quiz_id, false );


### PR DESCRIPTION
Fixes #2664 

### Changes proposed in this Pull Request

* Log when an existing question is added to a quiz.
* Logs 'question_status' (value of status filter)
* Logs 'question_type' (value of type filter)
* Logs 'question_category_id' (ID of question category filter)
* Logs 'question_count' (number of questions being added to a quiz)
