### PR TITLE
Add loop to single-course.php page

### DIFF
--- a/templates/single-course.php
+++ b/templates/single-course.php
@@ -7,7 +7,7 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     3.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -41,7 +41,12 @@ get_sensei_header();
 
 	<section class="entry fix">
 
-		<?php the_content(); ?>
+		<?php
+		while ( have_posts() ) {
+			the_post();
+			the_content();
+		}
+		?>
 
 	</section>
 

--- a/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-cpt.php
+++ b/tests/unit-tests/unsupported-theme-handlers/test-class-sensei-unsupported-theme-handler-cpt.php
@@ -112,6 +112,7 @@ class Sensei_Unsupported_Theme_Handler_CPT_Test extends WP_UnitTestCase {
 	 */
 	public function testShouldUseSinglePostRenderer() {
 		$this->handler->handle_request();
+		remove_filter( 'the_content', array( $this->handler, 'cpt_page_content_filter' ) );
 
 		$renderer         = new Sensei_Renderer_Single_Post(
 			$this->course->ID,


### PR DESCRIPTION
Fixes #2772
Fixes #2767 (I think)

### Changes proposed in this Pull Request

* This might be as simple as initializing the loop 🤞.
* Our other templates seem to do this with this:
```
if ( have_posts() ) {
	the_post();
}
```
Which makes sense on these singular pages, but it seems like WordPress convention is still to put it in the `while(){}` loop. I'm not 100% sure why, but think it is because `have_posts()` cleans up/rewinds when it hits the end of the query. I went with that strategy (followed what `single-product.php` looks like in Woo). It also seemed like the smallest change.
* For lessons and quizzes, `the_post()` is called at the top, but I kept it to just around `the_content()` to limit possible unforeseen changes if we're in the loop for the actions.

### Testing instructions

* I tested with a few themes, but we should make sure we test on a few more.
* Make sure no notice is logged when viewing a single course page.
* I looked through the other templates and they all seem to get called inside the loop or call `the_post()` within. This could use verification for #2767.