### PR TITLE
Log when course completion (without notification) is bulk recalculated.

### DIFF
--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -240,6 +240,21 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 			}
 		}
 
+		// Log event: when course completion (without notification) is bulk recalculated.
+		if ( 'recalculate_course_completion' === $sensei_bulk_action ) {
+
+			$filter_value = ! empty( $_POST['sensei_learners_bulk_action_filter'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_learners_bulk_action_filter'] ) ) : '-1'; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce already checked.
+
+			$event_properties = array(
+				'course_id'     => $filter_value,
+				'course_count'  => count( $course_ids ),
+				'learner_count' => count( $user_ids ),
+			);
+
+			sensei_log_event( 'learner_management_course_completion_bulk_recalculate_no_notify', $event_properties );
+
+		} // End log event.
+
 		$this->redirect_to_learner_admin_index( 'action-success' );
 	}
 

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -241,7 +241,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 		}
 
 		// Log event: when course completion (without notification) is bulk recalculated.
-		if ( 'recalculate_course_completion' === $sensei_bulk_action ) {
+		if ( self::RECALCULATE_COURSE_COMPLETION === $sensei_bulk_action ) {
 
 			$filter_value = ! empty( $_POST['sensei_learners_bulk_action_filter'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_learners_bulk_action_filter'] ) ) : '-1'; // phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce already checked.
 

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -294,6 +294,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		<input type="hidden" id="bulk-action-user-ids"  name="bulk_action_user_ids" value="">
 		<input type="hidden" id="sensei-bulk-action"  name="sensei_bulk_action" value="">
 		<input type="hidden" id="bulk-action-course-ids"  name="bulk_action_course_ids" value="">
+		<input type="hidden" id="sensei-learners-bulk-action-filter"  name="sensei_learners_bulk_action_filter" value="<?php echo esc_attr( $this->query_args['filter_by_course_id'] ); ?>">
 		<?php wp_nonce_field( Sensei_Learners_Admin_Bulk_Actions_Controller::NONCE_SENSEI_BULK_LEARNER_ACTIONS, Sensei_Learners_Admin_Bulk_Actions_Controller::SENSEI_BULK_LEARNER_ACTIONS_NONCE_FIELD ); ?>
 		<button type="submit" id="bulk-learner-action-submit" class="button button-primary action"><?php echo esc_html__( 'Apply', 'sensei-lms' ); ?></button>
 		</form>


### PR DESCRIPTION
Fixes #2641 

### Changes proposed in this Pull Request

* Log when course completion (without notification) is bulk recalculated.
* Logs `course_id` (Course ID filter)
* Logs `course_count` (Number of courses to recalculate completion for)
* Logs `learner_count` (Number of learners having their course completion recalculated)
