### PR TITLE
Change "Lessons" to "Lesson" if there is only a single lesson in a course

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1472,7 +1472,10 @@ class Sensei_Course {
 					$lesson_count = 1;
 
 				} // End If Statement
-				$active_html .= '<span class="course-lesson-count">' . esc_html( $lesson_count ) . '&nbsp;' . esc_html__( 'Lessons', 'sensei-lms' ) . '</span>';
+				$active_html .= '<span class="course-lesson-count">' .
+					// translators: Placeholder %d is the lesson count.
+					sprintf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count ) .
+				'</span>';
 				// Course Categories
 				if ( '' != $category_output ) {
 
@@ -1589,7 +1592,8 @@ class Sensei_Course {
 			}
 
 			foreach ( $completed_courses as $course_item ) {
-				$course = $course_item;
+				$course       = $course_item;
+				$lesson_count = intval( Sensei()->course->course_lesson_count( absint( $course_item->ID ) ) );
 
 				// Get Course Categories
 				$category_output = get_the_term_list( $course_item->ID, 'course-category', '', ', ', '' );
@@ -1617,10 +1621,10 @@ class Sensei_Course {
 						$complete_html .= '<p class="sensei-course-meta">';
 
 							// Lesson count for this author
-							$complete_html .= '<span class="course-lesson-count">'
-								. esc_html( Sensei()->course->course_lesson_count( absint( $course_item->ID ) ) )
-								. '&nbsp;' . esc_html__( 'Lessons', 'sensei-lms' )
-								. '</span>';
+							$complete_html .= '<span class="course-lesson-count">' .
+								// translators: Placeholder %d is the lesson count.
+								sprintf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count ) .
+							'</span>';
 
 							// Course Categories
 				if ( '' != $category_output ) {
@@ -2175,6 +2179,7 @@ class Sensei_Course {
 		$course              = get_post( $course_id );
 		$category_output     = get_the_term_list( $course->ID, 'course-category', '', ', ', '' );
 		$author_display_name = get_the_author_meta( 'display_name', $course->post_author );
+		$lesson_count        = intval( Sensei()->course->course_lesson_count( $course_id ) );
 
 		if ( isset( Sensei()->settings->settings['course_author'] ) && ( Sensei()->settings->settings['course_author'] ) ) {
 			echo '<span class="course-author">' .
@@ -2189,7 +2194,8 @@ class Sensei_Course {
 		do_action( 'sensei_course_meta_inside_before', $course->ID );
 
 		echo '<span class="course-lesson-count">' .
-			esc_html( Sensei()->course->course_lesson_count( $course->ID ) ) . '&nbsp;' . esc_html__( 'Lessons', 'sensei-lms' ) .
+			// translators: Placeholder %d is the lesson count.
+			sprintf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count ) .
 		'</span>';
 
 		if ( ! empty( $category_output ) ) {

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2793,7 +2793,7 @@ class Sensei_Course {
 		// show header if there are lessons the number of lesson in the course is the same as those that isn't assigned to a module
 		if ( ! empty( $course_lessons ) && count( $course_lessons ) == count( $none_module_lessons ) ) {
 
-			$title = __( 'Lessons', 'sensei-lms' );
+			$title = ( 1 === count( $course_lessons ) ) ? __( 'Lesson', 'sensei-lms' ) : __( 'Lessons', 'sensei-lms' );
 
 		} elseif ( empty( $none_module_lessons ) ) { // if the none module lessons are simply empty the title should not be shown
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1474,7 +1474,7 @@ class Sensei_Course {
 				} // End If Statement
 				$active_html .= '<span class="course-lesson-count">' .
 					// translators: Placeholder %d is the lesson count.
-					sprintf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count ) .
+					esc_html( sprintf( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ), $lesson_count ) ) .
 				'</span>';
 				// Course Categories
 				if ( '' != $category_output ) {
@@ -1623,7 +1623,7 @@ class Sensei_Course {
 							// Lesson count for this author
 							$complete_html .= '<span class="course-lesson-count">' .
 								// translators: Placeholder %d is the lesson count.
-								sprintf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count ) .
+								esc_html( sprintf( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ), $lesson_count ) ) .
 							'</span>';
 
 							// Course Categories
@@ -2195,7 +2195,7 @@ class Sensei_Course {
 
 		echo '<span class="course-lesson-count">' .
 			// translators: Placeholder %d is the lesson count.
-			sprintf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count ) .
+			esc_html( sprintf( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ), $lesson_count ) ) .
 		'</span>';
 
 		if ( ! empty( $category_output ) ) {

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1593,7 +1593,7 @@ class Sensei_Course {
 
 			foreach ( $completed_courses as $course_item ) {
 				$course       = $course_item;
-				$lesson_count = intval( Sensei()->course->course_lesson_count( absint( $course_item->ID ) ) );
+				$lesson_count = Sensei()->course->course_lesson_count( absint( $course_item->ID ) );
 
 				// Get Course Categories
 				$category_output = get_the_term_list( $course_item->ID, 'course-category', '', ', ', '' );
@@ -2179,7 +2179,7 @@ class Sensei_Course {
 		$course              = get_post( $course_id );
 		$category_output     = get_the_term_list( $course->ID, 'course-category', '', ', ', '' );
 		$author_display_name = get_the_author_meta( 'display_name', $course->post_author );
-		$lesson_count        = intval( Sensei()->course->course_lesson_count( $course_id ) );
+		$lesson_count        = Sensei()->course->course_lesson_count( $course_id );
 
 		if ( isset( Sensei()->settings->settings['course_author'] ) && ( Sensei()->settings->settings['course_author'] ) ) {
 			echo '<span class="course-author">' .
@@ -2195,7 +2195,7 @@ class Sensei_Course {
 
 		echo '<span class="course-lesson-count">' .
 			// translators: Placeholder %d is the lesson count.
-			sprintf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), intval( $lesson_count ) ) .
+			sprintf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count ) .
 		'</span>';
 
 		if ( ! empty( $category_output ) ) {

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2195,7 +2195,7 @@ class Sensei_Course {
 
 		echo '<span class="course-lesson-count">' .
 			// translators: Placeholder %d is the lesson count.
-			sprintf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count ) .
+			sprintf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), intval( $lesson_count ) ) .
 		'</span>';
 
 		if ( ! empty( $category_output ) ) {

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1025,7 +1025,7 @@ class Sensei_Frontend {
 				<span class="course-lesson-count">
 					<?php
 					// translators: Placeholder %d is the lesson count.
-					printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
+					echo esc_html( sprintf( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ), $lesson_count ) );
 					?>
 				</span>
 			<?php

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1025,7 +1025,7 @@ class Sensei_Frontend {
 				<span class="course-lesson-count">
 					<?php
 					// translators: Placeholder %d is the lesson count.
-					printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
+					printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), intval( $lesson_count ) );
 					?>
 				</span>
 			<?php

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1002,7 +1002,7 @@ class Sensei_Frontend {
 		$post_id           = get_the_ID();
 		$category_output   = get_the_term_list( $post_id, 'course-category', '', ', ', '' );
 		$free_lesson_count = intval( Sensei()->course->course_lesson_preview_count( $post_id ) );
-		$lesson_count      = intval( Sensei()->course->course_lesson_count( $post_id ) );
+		$lesson_count      = Sensei()->course->course_lesson_count( $post_id );
 		?>
 		<section class="entry">
 			<p class="sensei-course-meta">
@@ -1025,7 +1025,7 @@ class Sensei_Frontend {
 				<span class="course-lesson-count">
 					<?php
 					// translators: Placeholder %d is the lesson count.
-					printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), intval( $lesson_count ) );
+					printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
 					?>
 				</span>
 			<?php

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1002,6 +1002,7 @@ class Sensei_Frontend {
 		$post_id           = get_the_ID();
 		$category_output   = get_the_term_list( $post_id, 'course-category', '', ', ', '' );
 		$free_lesson_count = intval( Sensei()->course->course_lesson_preview_count( $post_id ) );
+		$lesson_count      = intval( Sensei()->course->course_lesson_count( $post_id ) );
 		?>
 		<section class="entry">
 			<p class="sensei-course-meta">
@@ -1017,11 +1018,16 @@ class Sensei_Frontend {
 
 				if ( isset( Sensei()->settings->settings['course_author'] ) && ( Sensei()->settings->settings['course_author'] ) ) {
 					?>
-			   <span class="course-author"><?php esc_html_e( 'by', 'sensei-lms' ); ?><?php the_author_link(); ?></span>
+					<span class="course-author"><?php esc_html_e( 'by', 'sensei-lms' ); ?><?php the_author_link(); ?></span>
 					<?php
 				} // End If Statement
 				?>
-			   <span class="course-lesson-count"><?php echo esc_html( Sensei()->course->course_lesson_count( $post_id ) ) . '&nbsp;' . esc_html__( 'Lessons', 'sensei-lms' ); ?></span>
+				<span class="course-lesson-count">
+					<?php
+					// translators: Placeholder %d is the lesson count.
+					printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
+					?>
+				</span>
 			<?php
 			if ( ! empty( $category_output ) ) {
 				?>

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -419,7 +419,7 @@ class Sensei_Legacy_Shortcodes {
 						<span class="course-lesson-count">
 							<?php
 							// translators: Placeholder %d is the lesson count.
-							printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
+							echo esc_html( sprintf( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ), $lesson_count ) );
 							?>
 						</span>
 

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -379,6 +379,7 @@ class Sensei_Legacy_Shortcodes {
 		$author_display_name   = $user_info->display_name;
 		$category_output       = get_the_term_list( $course_id, 'course-category', '', ', ', '' );
 		$preview_lesson_count  = intval( Sensei()->course->course_lesson_preview_count( $course_id ) );
+		$lesson_count          = intval( Sensei()->course->course_lesson_count( $course_id ) );
 		$is_user_taking_course = Sensei_Course::is_user_enrolled( $course_id, get_current_user_id() );
 		?>
 
@@ -416,8 +417,11 @@ class Sensei_Legacy_Shortcodes {
 						<?php } // End If Statement ?>
 
 						<span class="course-lesson-count">
-									<?php echo esc_html( Sensei()->course->course_lesson_count( $course_id ) ) . '&nbsp;' . esc_html__( 'Lessons', 'sensei-lms' ); ?>
-								</span>
+							<?php
+							// translators: Placeholder %d is the lesson count.
+							printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
+							?>
+						</span>
 
 						<?php if ( ! empty( $category_output ) ) { ?>
 							<span class="course-category">

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -419,7 +419,7 @@ class Sensei_Legacy_Shortcodes {
 						<span class="course-lesson-count">
 							<?php
 							// translators: Placeholder %d is the lesson count.
-							printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
+							printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), intval( $lesson_count ) );
 							?>
 						</span>
 

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -379,7 +379,7 @@ class Sensei_Legacy_Shortcodes {
 		$author_display_name   = $user_info->display_name;
 		$category_output       = get_the_term_list( $course_id, 'course-category', '', ', ', '' );
 		$preview_lesson_count  = intval( Sensei()->course->course_lesson_preview_count( $course_id ) );
-		$lesson_count          = intval( Sensei()->course->course_lesson_count( $course_id ) );
+		$lesson_count          = Sensei()->course->course_lesson_count( $course_id );
 		$is_user_taking_course = Sensei_Course::is_user_enrolled( $course_id, get_current_user_id() );
 		?>
 
@@ -419,7 +419,7 @@ class Sensei_Legacy_Shortcodes {
 						<span class="course-lesson-count">
 							<?php
 							// translators: Placeholder %d is the lesson count.
-							printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), intval( $lesson_count ) );
+							printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
 							?>
 						</span>
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -731,13 +731,13 @@ function sensei_the_module_id() {
  *
  * @since 3.1.0
  *
- * @return int|false Number of lessons in the current module, or `false` on failure.
+ * @return int Number of lessons in the current module.
  */
 function sensei_module_lesson_count() {
 	global $sensei_modules_loop;
 
-	if ( ! isset( $sensei_modules_loop['course_id'] ) || ! isset( $sensei_modules_loop['current_module']->term_id ) ) {
-		return false;
+	if ( ! isset( $sensei_modules_loop['course_id'] ) || ! isset( $sensei_modules_loop['current_module'] ) || ! isset( $sensei_modules_loop['current_module']->term_id ) ) {
+		return 0;
 	}
 
 	$course_id      = $sensei_modules_loop['course_id'];

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -726,6 +726,26 @@ function sensei_the_module_id() {
 
 }
 
+/**
+ * Gets a count of the lessons in the current module in the modules loop.
+ *
+ * @since 3.1.0
+ *
+ * @return int|false Number of lessons in the current module, or `false` on failure.
+ */
+function sensei_module_lesson_count() {
+	global $sensei_modules_loop;
+
+	if ( ! isset( $sensei_modules_loop['course_id'] ) || ! isset( $sensei_modules_loop['current_module']->term_id ) ) {
+		return false;
+	}
+
+	$course_id      = $sensei_modules_loop['course_id'];
+	$module_term_id = $sensei_modules_loop['current_module']->term_id;
+
+	return count( Sensei()->modules->get_lessons( $course_id, $module_term_id ) );
+}
+
 /************************
  *
  * Single Quiz Functions

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -31,7 +31,17 @@ global $course;
 
 	<header>
 
-		<h2>  <?php esc_html_e( 'Lessons', 'sensei-lms' ); ?> </h2>
+		<h2>
+			<?php
+			$lesson_count = Sensei()->course->course_lesson_count( $course->ID );
+
+			if ( 1 === $lesson_count ) {
+				esc_html_e( 'Lesson', 'sensei-lms' );
+			} else {
+				esc_html_e( 'Lessons', 'sensei-lms' );
+			}
+			?>
+		</h2>
 
 	</header>
 

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -7,7 +7,7 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     2.0.0
+ * @version     3.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -33,9 +33,7 @@ global $course;
 
 		<h2>
 			<?php
-			$lesson_count = Sensei()->course->course_lesson_count( $course->ID );
-
-			if ( 1 === $lesson_count ) {
+			if ( 1 === Sensei()->course->course_lesson_count( $course->ID ) ) {
 				esc_html_e( 'Lesson', 'sensei-lms' );
 			} else {
 				esc_html_e( 'Lessons', 'sensei-lms' );

--- a/templates/single-course/modules.php
+++ b/templates/single-course/modules.php
@@ -96,10 +96,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 							<h3>
 								<?php
-								$course_id    = Sensei()->lesson->get_course_id( get_the_ID() );
-								$lesson_count = Sensei()->course->course_lesson_count( $course_id );
-
-								if ( 1 === $lesson_count ) {
+								if ( 1 === sensei_module_lesson_count() ) {
 									esc_html_e( 'Lesson', 'sensei-lms' );
 								} else {
 									esc_html_e( 'Lessons', 'sensei-lms' );
@@ -123,6 +120,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 										<?php the_title(); ?>
 
 										<?php
+										$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
 										if ( Sensei_Utils::is_preview_lesson( get_the_ID() ) && ! Sensei_Course::is_user_enrolled( $course_id ) ) {
 
 											echo wp_kses_post( Sensei()->frontend->sensei_lesson_preview_title_tag( $course_id ) );

--- a/templates/single-course/modules.php
+++ b/templates/single-course/modules.php
@@ -10,7 +10,7 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     3.0.0
+ * @version     3.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/single-course/modules.php
+++ b/templates/single-course/modules.php
@@ -94,7 +94,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 						<header>
 
-							<h3><?php esc_html_e( 'Lessons', 'sensei-lms' ); ?></h3>
+							<h3>
+								<?php
+								$course_id    = Sensei()->lesson->get_course_id( get_the_ID() );
+								$lesson_count = Sensei()->course->course_lesson_count( $course_id );
+
+								if ( 1 === $lesson_count ) {
+									esc_html_e( 'Lesson', 'sensei-lms' );
+								} else {
+									esc_html_e( 'Lessons', 'sensei-lms' );
+								}
+								?>
+							</h3>
 
 						</header>
 
@@ -112,7 +123,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 										<?php the_title(); ?>
 
 										<?php
-										$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
 										if ( Sensei_Utils::is_preview_lesson( get_the_ID() ) && ! Sensei_Course::is_user_enrolled( $course_id ) ) {
 
 											echo wp_kses_post( Sensei()->frontend->sensei_lesson_preview_title_tag( $course_id ) );

--- a/widgets/class-sensei-category-courses-widget.php
+++ b/widgets/class-sensei-category-courses-widget.php
@@ -205,6 +205,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 				$user_info           = get_userdata( absint( $post_item->post_author ) );
 				$author_link         = get_author_posts_url( absint( $post_item->post_author ) );
 				$author_display_name = $user_info->display_name;
+				$lesson_count        = Sensei()->course->course_lesson_count( $post_id );
 				?>
 				<li class="fix">
 					<?php do_action( 'sensei_course_image', $post_id ); ?>
@@ -224,7 +225,12 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 						</span>
 						<br />
 					<?php } // End If Statement ?>
-					<span class="course-lesson-count"><?php echo esc_html( Sensei()->course->course_lesson_count( $post_id ) ) . '&nbsp;' . esc_html__( 'Lessons', 'sensei-lms' ); ?></span>
+					<span class="course-lesson-count">
+						<?php
+						// translators: Placeholder %d is the lesson count.
+						printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
+						?>
+					</span>
 					<br />
 					<?php
 					/** This action is documented in includes/class-sensei-frontend.php */

--- a/widgets/class-sensei-category-courses-widget.php
+++ b/widgets/class-sensei-category-courses-widget.php
@@ -228,7 +228,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 					<span class="course-lesson-count">
 						<?php
 						// translators: Placeholder %d is the lesson count.
-						printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
+						echo esc_html( sprintf( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ), $lesson_count ) );
 						?>
 					</span>
 					<br />

--- a/widgets/class-sensei-category-courses-widget.php
+++ b/widgets/class-sensei-category-courses-widget.php
@@ -228,7 +228,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 					<span class="course-lesson-count">
 						<?php
 						// translators: Placeholder %d is the lesson count.
-						printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
+						printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), intval( $lesson_count ) );
 						?>
 					</span>
 					<br />

--- a/widgets/class-sensei-category-courses-widget.php
+++ b/widgets/class-sensei-category-courses-widget.php
@@ -228,7 +228,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 					<span class="course-lesson-count">
 						<?php
 						// translators: Placeholder %d is the lesson count.
-						printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), intval( $lesson_count ) );
+						printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
 						?>
 					</span>
 					<br />

--- a/widgets/class-sensei-course-component-widget.php
+++ b/widgets/class-sensei-course-component-widget.php
@@ -282,7 +282,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 				$user_info           = get_userdata( absint( $course->post_author ) );
 				$author_link         = get_author_posts_url( absint( $course->post_author ) );
 				$author_display_name = $user_info->display_name;
-				$lesson_count        = intval( Sensei()->course->course_lesson_count( $post_id ) );
+				$lesson_count        = Sensei()->course->course_lesson_count( $post_id );
 				?>
 
 				<li class="fix">
@@ -314,7 +314,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 					<span class="course-lesson-count">
 						<?php
 						// translators: Placeholder %d is the lesson count.
-						printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), intval( $lesson_count ) );
+						printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
 						?>
 					</span>
 

--- a/widgets/class-sensei-course-component-widget.php
+++ b/widgets/class-sensei-course-component-widget.php
@@ -314,7 +314,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 					<span class="course-lesson-count">
 						<?php
 						// translators: Placeholder %d is the lesson count.
-						printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
+						printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), intval( $lesson_count ) );
 						?>
 					</span>
 

--- a/widgets/class-sensei-course-component-widget.php
+++ b/widgets/class-sensei-course-component-widget.php
@@ -282,6 +282,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 				$user_info           = get_userdata( absint( $course->post_author ) );
 				$author_link         = get_author_posts_url( absint( $course->post_author ) );
 				$author_display_name = $user_info->display_name;
+				$lesson_count        = intval( Sensei()->course->course_lesson_count( $post_id ) );
 				?>
 
 				<li class="fix">
@@ -311,7 +312,10 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 					<?php } // End If Statement ?>
 
 					<span class="course-lesson-count">
-						<?php echo esc_html( Sensei()->course->course_lesson_count( $post_id ) ) . '&nbsp;' . esc_html__( 'Lessons', 'sensei-lms' ); ?>
+						<?php
+						// translators: Placeholder %d is the lesson count.
+						printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
+						?>
 					</span>
 
 					<br />

--- a/widgets/class-sensei-course-component-widget.php
+++ b/widgets/class-sensei-course-component-widget.php
@@ -314,7 +314,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 					<span class="course-lesson-count">
 						<?php
 						// translators: Placeholder %d is the lesson count.
-						printf( esc_html( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ) ), $lesson_count );
+						echo esc_html( sprintf( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ), $lesson_count ) );
 						?>
 					</span>
 


### PR DESCRIPTION
Fixes #2890 

### Changes proposed in this Pull Request

* Change "Lessons" to "Lesson" if there is only a single lesson in a course, use `_n()` instead of strings concat.
* Improve coding standard in some places.