### PR TITLE
Log when a quiz is graded.

### DIFF
--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -721,6 +721,12 @@ class Sensei_Grading {
 
 		}
 
+		// Log event: when a quiz is graded.
+		$event_properties = array(
+			'question_count' => $count,
+		);
+		sensei_log_event( 'grading_quiz_grade', $event_properties );
+
 		wp_safe_redirect( esc_url_raw( $load_url ) );
 		exit;
 


### PR DESCRIPTION
Fixes #2629 

### Changes proposed in this Pull Request

* Log when a quiz is graded.
* Logs `question_count` (Number of questions in the quiz)