### PR TITLE
Log when the Grading page is viewed

### DIFF
--- a/assets/js/grading-general.js
+++ b/assets/js/grading-general.js
@@ -208,6 +208,10 @@ jQuery(document).ready( function( $ ) {
 		var courseId    = jQuery( '#grading-course-options' ).val();
 		var gradingView = jQuery.fn.getQueryVariable( 'view' );
 
+		if( ! gradingView ) {
+			gradingView = 'all';
+		}
+
 		// Perform the AJAX call to get the select box.
 		jQuery.get(
 			ajaxurl,

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -50,6 +50,12 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		// Actions
 		add_action( 'sensei_before_list_table', array( $this, 'data_table_header' ) );
 		add_action( 'sensei_after_list_table', array( $this, 'data_table_footer' ) );
+
+		// Log events: page views for grading section.
+		if ( isset( $_GET['page'] ) && $this->page_slug === $_GET['page'] && is_admin() ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$this->grading_log_page_views();
+		}
+
 	} // End __construct()
 
 	/**
@@ -513,6 +519,38 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 	public function data_table_footer() {
 		// Nothing right now
 	} // End data_table_footer()
+
+	/**
+	 * Logs grading section page views.
+	 *
+	 * @since 3.0.2
+	 */
+	public function grading_log_page_views() {
+
+		$view      = isset( $_GET['view'] ) ? sanitize_text_field( wp_unslash( $_GET['view'] ) ) : 'all'; // phpcs:ignore WordPress.Security.NonceVerification
+		$course_id = isset( $_GET['course_id'] ) ? sanitize_text_field( wp_unslash( $_GET['course_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+		$lesson_id = isset( $_GET['lesson_id'] ) ? sanitize_text_field( wp_unslash( $_GET['lesson_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+		$quiz_id   = isset( $_GET['quiz_id'] ) ? sanitize_text_field( wp_unslash( $_GET['quiz_id'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification
+
+		if ( isset( $_GET['user_id'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			$user_id = sanitize_text_field( wp_unslash( $_GET['user_id'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		} elseif ( isset( $_GET['user'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
+			// Handle case for Grading > Course Name > Lesson Name; where query var is 'user' instead of 'user_id'.
+			$user_id = sanitize_text_field( wp_unslash( $_GET['user'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		} else {
+			$user_id = '';
+		}
+
+			$event_properties = array(
+				'view'      => $view,
+				'course_id' => $course_id,
+				'lesson_id' => $lesson_id,
+				'quiz_id'   => $quiz_id,
+				'user_id'   => $user_id,
+			);
+			sensei_log_event( 'grading_view', $event_properties );
+
+	}
 
 } // End Class
 

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -457,7 +457,6 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 				$all_class = 'current';
 				break;
 			case 'ungraded':
-			default:
 				$ungraded_class = 'current';
 				break;
 			case 'graded':
@@ -465,6 +464,9 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 				break;
 			case 'in-progress':
 				$inprogress_class = 'current';
+				break;
+			default:
+				$all_class = 'current';
 				break;
 		endswitch;
 


### PR DESCRIPTION
Fixes #2628 

### Changes proposed in this Pull Request

* Log when the Grading page is viewed
* Logs `view` (valid values: all, ungraded*, graded, in-progress)
* Logs `course_id`
* Logs `lesson_id`
* Logs `quiz_id`
* Logs `user_id`

* The default value in the Grading page for the query is "All", but the CSS class 'current' (which highlights the current tab) was set for the "Ungraded" tab. This PR sets the current CSS class for the 'All' tab, so that it matches the actual data query.

* When you use the filter drop-downs, the JavaScript action triggered by the on-change event, grabs the 'view' parameter in the URL and appends it to the newly created URL (the one with the filter parameters). If the 'view' parameter is not defined (for example in the default Grading page) the 'view' value sent to the new URL is `false`. This PR changes this default `false` value to `all`, so that the logging function, in the default page (which has `all` as default) sends this correctly.
