### PR TITLE
Use store in step components

### DIFF
--- a/assets/onboarding/data/actions.js
+++ b/assets/onboarding/data/actions.js
@@ -7,7 +7,7 @@ import {
 	START_SUBMIT_SETUP_WIZARD_DATA,
 	SUCCESS_SUBMIT_SETUP_WIZARD_DATA,
 	ERROR_SUBMIT_SETUP_WIZARD_DATA,
-	SET_WELCOME_STEP_DATA,
+	SET_STEP_DATA,
 } from './constants';
 
 /**
@@ -124,40 +124,43 @@ export const errorSubmit = ( error ) => ( {
 } );
 
 /**
- * Submit welcome step action creator.
+ * Submit step action creator.
  *
- * @param {boolean} usageTracking Usage tracking.
+ * @param {string} step     Step name.
+ * @param {Object} stepData Data to submit.
  */
-export function* submitWelcomeStep( usageTracking ) {
-	const welcomeStepData = { usage_tracking: usageTracking };
+export function* submitStep( step, stepData ) {
 	yield startSubmit();
 
 	try {
 		yield fetchFromAPI( {
-			path: API_BASE_PATH + 'welcome',
+			path: API_BASE_PATH + step,
 			method: 'POST',
-			data: welcomeStepData,
+			data: stepData,
 		} );
 		yield successSubmit();
-		yield setWelcomeStepData( welcomeStepData );
+		yield setStepData( step, stepData );
 	} catch ( error ) {
 		yield errorSubmit( error );
 	}
 }
 
 /**
- * @typedef  {Object} SetWelcomeStepDataAction
+ * @typedef  {Object} SetStepDataAction
  * @property {string} type                     Action type.
- * @property {Object} data                     Welcome step data.
+ * @property {string} step                     Step name.
+ * @property {Object} data                     Step data.
  */
 /**
  * Set welcome step data action creator.
  *
- * @param {Object} data Welcome data object.
+ * @param {string} step Step name.
+ * @param {Object} data Step data object.
  *
- * @return {SetWelcomeStepDataAction} Set welcome step data action.
+ * @return {SetStepDataAction} Set welcome step data action.
  */
-export const setWelcomeStepData = ( data ) => ( {
-	type: SET_WELCOME_STEP_DATA,
+export const setStepData = ( step, data ) => ( {
+	type: SET_STEP_DATA,
+	step,
 	data,
 } );

--- a/assets/onboarding/data/actions.js
+++ b/assets/onboarding/data/actions.js
@@ -147,9 +147,9 @@ export function* submitStep( step, stepData ) {
 
 /**
  * @typedef  {Object} SetStepDataAction
- * @property {string} type                     Action type.
- * @property {string} step                     Step name.
- * @property {Object} data                     Step data.
+ * @property {string} type Action type.
+ * @property {string} step Step name.
+ * @property {Object} data Step data.
  */
 /**
  * Set welcome step data action creator.

--- a/assets/onboarding/data/actions.test.js
+++ b/assets/onboarding/data/actions.test.js
@@ -165,7 +165,7 @@ describe( 'Setup wizard actions', () => {
 		expect( gen.next().value ).toEqual( expectedSetDataAction );
 	} );
 
-	it( 'Should catch error on the submit welcome step action', () => {
+	it( 'Should catch error on the submit step action', () => {
 		const gen = submitStep( 'test', true );
 
 		// Start submit action.
@@ -183,7 +183,7 @@ describe( 'Setup wizard actions', () => {
 		expect( gen.throw( error ).value ).toEqual( expectedErrorAction );
 	} );
 
-	it( 'Should return the set welcome step data action', () => {
+	it( 'Should return the set step data action', () => {
 		const data = { usage_tracking: true };
 		const expectedAction = {
 			type: SET_STEP_DATA,

--- a/assets/onboarding/data/actions.test.js
+++ b/assets/onboarding/data/actions.test.js
@@ -7,7 +7,7 @@ import {
 	START_SUBMIT_SETUP_WIZARD_DATA,
 	SUCCESS_SUBMIT_SETUP_WIZARD_DATA,
 	ERROR_SUBMIT_SETUP_WIZARD_DATA,
-	SET_WELCOME_STEP_DATA,
+	SET_STEP_DATA,
 } from './constants';
 import {
 	fetchFromAPI,
@@ -18,8 +18,8 @@ import {
 	startSubmit,
 	successSubmit,
 	errorSubmit,
-	submitWelcomeStep,
-	setWelcomeStepData,
+	submitStep,
+	setStepData,
 } from './actions';
 
 describe( 'Setup wizard actions', () => {
@@ -128,9 +128,8 @@ describe( 'Setup wizard actions', () => {
 		expect( errorSubmit( error ) ).toEqual( expectedAction );
 	} );
 
-	it( 'Should generate the submit welcome step action', () => {
-		const usageTracking = true;
-		const gen = submitWelcomeStep( usageTracking );
+	it( 'Should generate the submit step action', () => {
+		const gen = submitStep( 'welcome', { usage_tracking: true } );
 
 		// Start submit action.
 		const expectedStartSubmitAction = {
@@ -145,7 +144,7 @@ describe( 'Setup wizard actions', () => {
 				path: API_BASE_PATH + 'welcome',
 				method: 'POST',
 				data: {
-					usage_tracking: usageTracking,
+					usage_tracking: true,
 				},
 			},
 		};
@@ -159,14 +158,15 @@ describe( 'Setup wizard actions', () => {
 
 		// Set data action.
 		const expectedSetDataAction = {
-			type: SET_WELCOME_STEP_DATA,
-			data: { usage_tracking: usageTracking },
+			type: SET_STEP_DATA,
+			step: 'welcome',
+			data: { usage_tracking: true },
 		};
 		expect( gen.next().value ).toEqual( expectedSetDataAction );
 	} );
 
 	it( 'Should catch error on the submit welcome step action', () => {
-		const gen = submitWelcomeStep( true );
+		const gen = submitStep( 'test', true );
 
 		// Start submit action.
 		gen.next();
@@ -186,10 +186,11 @@ describe( 'Setup wizard actions', () => {
 	it( 'Should return the set welcome step data action', () => {
 		const data = { usage_tracking: true };
 		const expectedAction = {
-			type: SET_WELCOME_STEP_DATA,
+			type: SET_STEP_DATA,
 			data,
+			step: 'welcome',
 		};
 
-		expect( setWelcomeStepData( data ) ).toEqual( expectedAction );
+		expect( setStepData( 'welcome', data ) ).toEqual( expectedAction );
 	} );
 } );

--- a/assets/onboarding/data/constants.js
+++ b/assets/onboarding/data/constants.js
@@ -27,4 +27,4 @@ export const ERROR_SUBMIT_SETUP_WIZARD_DATA = 'ERROR_SUBMIT_SETUP_WIZARD_DATA';
 /**
  * Welcome step action type constants.
  */
-export const SET_WELCOME_STEP_DATA = 'SET_WELCOME_STEP_DATA';
+export const SET_STEP_DATA = 'SET_STEP_DATA';

--- a/assets/onboarding/data/reducer.js
+++ b/assets/onboarding/data/reducer.js
@@ -17,6 +17,13 @@ const DEFAULT_STATE = {
 		welcome: {
 			usage_tracking: false,
 		},
+		purpose: {
+			selected: [],
+			other: '',
+		},
+		features: {
+			selected: [],
+		},
 	},
 };
 

--- a/assets/onboarding/data/reducer.js
+++ b/assets/onboarding/data/reducer.js
@@ -5,7 +5,7 @@ import {
 	START_SUBMIT_SETUP_WIZARD_DATA,
 	SUCCESS_SUBMIT_SETUP_WIZARD_DATA,
 	ERROR_SUBMIT_SETUP_WIZARD_DATA,
-	SET_WELCOME_STEP_DATA,
+	SET_STEP_DATA,
 } from './constants';
 
 const DEFAULT_STATE = {
@@ -74,13 +74,13 @@ export default ( state = DEFAULT_STATE, action ) => {
 				submitError: action.error,
 			};
 
-		case SET_WELCOME_STEP_DATA:
+		case SET_STEP_DATA:
 			return {
 				...state,
 				data: {
 					...state.data,
-					welcome: {
-						...state.data.welcome,
+					[ action.step ]: {
+						...state.data[ action.step ],
 						...action.data,
 					},
 				},

--- a/assets/onboarding/data/reducer.test.js
+++ b/assets/onboarding/data/reducer.test.js
@@ -5,7 +5,7 @@ import {
 	START_SUBMIT_SETUP_WIZARD_DATA,
 	SUCCESS_SUBMIT_SETUP_WIZARD_DATA,
 	ERROR_SUBMIT_SETUP_WIZARD_DATA,
-	SET_WELCOME_STEP_DATA,
+	SET_STEP_DATA,
 } from './constants';
 import reducer from './reducer';
 
@@ -97,11 +97,12 @@ describe( 'Setup wizard reducer', () => {
 		expect( state.submitError ).toEqual( error );
 	} );
 
-	it( 'Should set the welcome data on SET_WELCOME_STEP_DATA action', () => {
+	it( 'Should set the step data on SET_STEP_DATA action', () => {
 		const data = { usage_tracking: true };
 		const state = reducer( undefined, {
-			type: SET_WELCOME_STEP_DATA,
+			type: SET_STEP_DATA,
 			data,
+			step: 'welcome',
 		} );
 
 		expect( state.data.welcome ).toEqual( data );

--- a/assets/onboarding/data/selectors.js
+++ b/assets/onboarding/data/selectors.js
@@ -42,3 +42,5 @@ export const getSubmitError = ( state ) => state.submitError;
  * @return {boolean} Usage tracking value.
  */
 export const getUsageTracking = ( state ) => state.data.welcome.usage_tracking;
+
+export const getStepData = ( state, step ) => state.data[ step ];

--- a/assets/onboarding/data/selectors.js
+++ b/assets/onboarding/data/selectors.js
@@ -35,12 +35,11 @@ export const isSubmitting = ( state ) => state.isSubmitting;
 export const getSubmitError = ( state ) => state.submitError;
 
 /**
- * Usage tracking selector.
+ * Step state selector.
  *
  * @param {Object} state Current state.
+ * @param {string} step Step name.
  *
- * @return {boolean} Usage tracking value.
+ * @return {Object} Step data.
  */
-export const getUsageTracking = ( state ) => state.data.welcome.usage_tracking;
-
 export const getStepData = ( state, step ) => state.data[ step ];

--- a/assets/onboarding/data/selectors.test.js
+++ b/assets/onboarding/data/selectors.test.js
@@ -3,7 +3,7 @@ import {
 	getFetchError,
 	isSubmitting,
 	getSubmitError,
-	getUsageTracking,
+	getStepData,
 } from './selectors';
 
 describe( 'Setup wizard selectors', () => {
@@ -50,6 +50,8 @@ describe( 'Setup wizard selectors', () => {
 			},
 		};
 
-		expect( getUsageTracking( state ) ).toBeTruthy();
+		expect( getStepData( state, 'welcome' ) ).toEqual( {
+			usage_tracking: true,
+		} );
 	} );
 } );

--- a/assets/onboarding/purpose/index.jsx
+++ b/assets/onboarding/purpose/index.jsx
@@ -3,7 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { Button, CheckboxControl, TextControl } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { useQueryStringRouter } from '../query-string-router';
-import { useSetupWizardStore } from '../use-setup-wizard-store.js';
+import { useSetupWizardStep } from '../use-setup-wizard-step.js';
 
 const purposes = [
 	{
@@ -46,7 +46,7 @@ const purposes = [
 export const Purpose = () => {
 	const { goTo } = useQueryStringRouter();
 
-	const { stepData, submitStep, isSubmitting } = useSetupWizardStore(
+	const { stepData, submitStep, isSubmitting } = useSetupWizardStep(
 		'purpose'
 	);
 

--- a/assets/onboarding/purpose/index.jsx
+++ b/assets/onboarding/purpose/index.jsx
@@ -46,20 +46,19 @@ const purposes = [
 export const Purpose = () => {
 	const { goTo } = useQueryStringRouter();
 
-	const { stepData, submitStep, isSubmitting } = useSetupWizardStep(
-		'purpose'
-	);
+	const {
+		stepData,
+		submitStep,
+		isSubmitting,
+		errorNotice,
+	} = useSetupWizardStep( 'purpose' );
 
 	const [ { selected, other }, setFormState ] = useState( {
 		selected: [],
 		other: '',
 	} );
 
-	useEffect( () => {
-		if ( stepData && stepData.selected ) {
-			setFormState( stepData );
-		}
-	}, [ stepData ] );
+	useEffect( () => setFormState( stepData ), [ stepData ] );
 
 	const isEmpty = ! selected.length;
 
@@ -72,10 +71,7 @@ export const Purpose = () => {
 		} ) );
 	};
 
-	const submitPage = async () => {
-		await submitStep( { selected, other } );
-		goTo( 'features' );
-	};
+	const submitPage = () => submitStep( { selected, other } );
 
 	return (
 		<>
@@ -114,7 +110,7 @@ export const Purpose = () => {
 						/>
 					) }
 				</div>
-
+				{ errorNotice }
 				<Button
 					isPrimary
 					isBusy={ isSubmitting }

--- a/assets/onboarding/purpose/index.jsx
+++ b/assets/onboarding/purpose/index.jsx
@@ -45,12 +45,14 @@ const purposes = [
  */
 export const Purpose = () => {
 	const { goTo } = useQueryStringRouter();
+	const [ submittedData, toggleSubmittedData ] = useState( false );
 
 	const {
 		stepData,
 		submitStep,
 		isSubmitting,
 		errorNotice,
+		error,
 	} = useSetupWizardStep( 'purpose' );
 
 	const [ { selected, other }, setFormState ] = useState( {
@@ -71,7 +73,17 @@ export const Purpose = () => {
 		} ) );
 	};
 
-	const submitPage = () => submitStep( { selected, other } );
+	useEffect( () => {
+		if ( submittedData && ! error ) {
+			goTo( 'features' );
+		}
+		toggleSubmittedData( false );
+	}, [ submittedData, error, goTo ] );
+
+	const submitPage = async () => {
+		await submitStep( { selected, other } );
+		toggleSubmittedData( true );
+	};
 
 	return (
 		<>

--- a/assets/onboarding/purpose/index.jsx
+++ b/assets/onboarding/purpose/index.jsx
@@ -3,7 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { Button, CheckboxControl, TextControl } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { useQueryStringRouter } from '../query-string-router';
-import { useOnboardingApi } from '../use-onboarding-api';
+import { useSetupWizardStore } from '../use-setup-wizard-store.js';
 
 const purposes = [
 	{
@@ -46,7 +46,9 @@ const purposes = [
 export const Purpose = () => {
 	const { goTo } = useQueryStringRouter();
 
-	const { data, submit, isBusy } = useOnboardingApi( 'purpose' );
+	const { stepData, submitStep, isSubmitting } = useSetupWizardStore(
+		'purpose'
+	);
 
 	const [ { selected, other }, setFormState ] = useState( {
 		selected: [],
@@ -54,10 +56,10 @@ export const Purpose = () => {
 	} );
 
 	useEffect( () => {
-		if ( data && data.selected ) {
-			setFormState( data );
+		if ( stepData && stepData.selected ) {
+			setFormState( stepData );
 		}
-	}, [ data ] );
+	}, [ stepData ] );
 
 	const isEmpty = ! selected.length;
 
@@ -71,7 +73,7 @@ export const Purpose = () => {
 	};
 
 	const submitPage = async () => {
-		await submit( { selected, other } );
+		await submitStep( { selected, other } );
 		goTo( 'features' );
 	};
 
@@ -115,8 +117,8 @@ export const Purpose = () => {
 
 				<Button
 					isPrimary
-					isBusy={ isBusy }
-					disabled={ isBusy || isEmpty }
+					isBusy={ isSubmitting }
+					disabled={ isSubmitting || isEmpty }
 					className="sensei-onboarding__button sensei-onboarding__button-card"
 					onClick={ submitPage }
 				>

--- a/assets/onboarding/style.scss
+++ b/assets/onboarding/style.scss
@@ -284,4 +284,8 @@
 			}
 		}
 	}
+
+	&__submit-error {
+		margin: 0;
+	}
 }

--- a/assets/onboarding/use-setup-wizard-step.js
+++ b/assets/onboarding/use-setup-wizard-step.js
@@ -2,14 +2,13 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { Notice } from '@wordpress/components';
 
 /**
- *
  * @typedef {Object} StepStoreHookHandle
  *
- * @property {boolean}          isSubmitting     Submitting state.
- * @property {Object}           stepData         Data for the step.
- * @property {Object}           error            Submit error.
- * @property {Element}          errorNotice      Error notice element.
- * @property {Function}         submitStep       Method to POST to endpoint.
+ * @property {boolean}  isSubmitting Submitting state.
+ * @property {Object}   stepData     Data for the step.
+ * @property {Object}   error        Submit error.
+ * @property {Element}  errorNotice  Error notice element.
+ * @property {Function} submitStep   Method to POST to endpoint.
  */
 /**
  * Use Setup Wizard State store and REST API for the given step.

--- a/assets/onboarding/use-setup-wizard-step.js
+++ b/assets/onboarding/use-setup-wizard-step.js
@@ -18,7 +18,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * @param {string} step Setup Wizard step endpoint name.
  * @return {StepStoreHookHandle} handle
  */
-export const useSetupWizardStore = ( step ) => {
+export const useSetupWizardStep = ( step ) => {
 	const { stepData, isSubmitting, error } = useSelect(
 		( select ) => ( {
 			stepData: select( 'sensei/setup-wizard' ).getStepData( step ),

--- a/assets/onboarding/use-setup-wizard-step.js
+++ b/assets/onboarding/use-setup-wizard-step.js
@@ -1,13 +1,15 @@
 import { useSelect, useDispatch } from '@wordpress/data';
+import { Notice } from '@wordpress/components';
 
 /**
  *
  * @typedef {Object} StepStoreHookHandle
  *
- * @property {boolean}          isSubmitting Submitting state.
- * @property {Object}           stepData     API response from GET call to endpoint.
- * @property {Object}           error        Submit error.
- * @property {function(Object)} submitStep   Method to POST to endpoint.
+ * @property {boolean}          isSubmitting     Submitting state.
+ * @property {Object}           stepData         Data for the step.
+ * @property {Object}           error            Submit error.
+ * @property {Element}          errorNotice      Error notice element.
+ * @property {Function}         submitStep       Method to POST to endpoint.
  */
 /**
  * Use Setup Wizard State store and REST API for the given step.
@@ -29,10 +31,23 @@ export const useSetupWizardStep = ( step ) => {
 	);
 	const { submitStep } = useDispatch( 'sensei/setup-wizard' );
 
+	const errorNotice = error ? (
+		<Notice
+			status="error"
+			className="sensei-onboarding__submit-error"
+			isDismissible={ false }
+		>
+			{ error.message }
+		</Notice>
+	) : null;
+
+	const submitStepForComponent = ( formData ) => submitStep( step, formData );
+
 	return {
 		stepData,
-		submitStep: submitStep.bind( null, step ),
+		submitStep: submitStepForComponent,
 		isSubmitting,
 		error,
+		errorNotice,
 	};
 };

--- a/assets/onboarding/use-setup-wizard-store.js
+++ b/assets/onboarding/use-setup-wizard-store.js
@@ -18,7 +18,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * @param {string} step Onboarding step endpoint name.
  * @return {OnboardingApiHandle} handle
  */
-export const useOnboardingApi = ( step ) => {
+export const useSetupWizardStore = ( step ) => {
 	const { stepData, isSubmitting, error } = useSelect(
 		( select ) => ( {
 			stepData: select( 'sensei/setup-wizard' ).getStepData( step ),

--- a/assets/onboarding/use-setup-wizard-store.js
+++ b/assets/onboarding/use-setup-wizard-store.js
@@ -2,7 +2,7 @@ import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
  *
- * @typedef {Object} OnboardingApiHandle
+ * @typedef {Object} StepStoreHookHandle
  *
  * @property {boolean}          isSubmitting Submitting state.
  * @property {Object}           stepData     API response from GET call to endpoint.
@@ -10,13 +10,13 @@ import { useSelect, useDispatch } from '@wordpress/data';
  * @property {function(Object)} submitStep   Method to POST to endpoint.
  */
 /**
- * Use Onboarding REST API for the given step.
+ * Use Setup Wizard State store and REST API for the given step.
  *
- * Loads data via the GET method for the endpoint, and provides a submit function that sends data to the endpoint
+ * Gets step-specific data, and provides a submit function that sends step form data to the step endpoint
  * via POST request.
  *
- * @param {string} step Onboarding step endpoint name.
- * @return {OnboardingApiHandle} handle
+ * @param {string} step Setup Wizard step endpoint name.
+ * @return {StepStoreHookHandle} handle
  */
 export const useSetupWizardStore = ( step ) => {
 	const { stepData, isSubmitting, error } = useSelect(

--- a/assets/onboarding/welcome/index.jsx
+++ b/assets/onboarding/welcome/index.jsx
@@ -1,10 +1,10 @@
-import { useSelect, useDispatch } from '@wordpress/data';
 import { Card, H, Link } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { UsageModal } from './usage-modal';
 import { useQueryStringRouter } from '../query-string-router';
+import { useSetupWizardStore } from '../use-setup-wizard-store.js';
 
 /**
  * Welcome step for Onboarding Wizard.
@@ -15,15 +15,9 @@ export const Welcome = () => {
 
 	const { goTo } = useQueryStringRouter();
 
-	const { usageTracking, isSubmitting, error } = useSelect(
-		( select ) => ( {
-			usageTracking: select( 'sensei/setup-wizard' ).getUsageTracking(),
-			isSubmitting: select( 'sensei/setup-wizard' ).isSubmitting(),
-			error: select( 'sensei/setup-wizard' ).getSubmitError(),
-		} ),
-		[]
+	const { stepData, submitStep, isSubmitting, error } = useSetupWizardStore(
+		'welcome'
 	);
-	const { submitWelcomeStep } = useDispatch( 'sensei/setup-wizard' );
 
 	useEffect( () => {
 		if ( submittedData && ! error ) {
@@ -36,7 +30,7 @@ export const Welcome = () => {
 	}, [ submittedData, error, goTo ] );
 
 	const submitPage = async ( allowUsageTracking ) => {
-		await submitWelcomeStep( allowUsageTracking );
+		await submitStep( { usage_tracking: allowUsageTracking } );
 		toggleSubmittedData( true );
 	};
 
@@ -70,7 +64,7 @@ export const Welcome = () => {
 			</div>
 			{ usageModalActive && (
 				<UsageModal
-					tracking={ usageTracking }
+					tracking={ stepData.usageTracking }
 					isSubmitting={ isSubmitting }
 					onClose={ () => toggleUsageModal( false ) }
 					onContinue={ submitPage }

--- a/assets/onboarding/welcome/index.jsx
+++ b/assets/onboarding/welcome/index.jsx
@@ -15,9 +15,13 @@ export const Welcome = () => {
 
 	const { goTo } = useQueryStringRouter();
 
-	const { stepData, submitStep, isSubmitting, error } = useSetupWizardStep(
-		'welcome'
-	);
+	const {
+		stepData,
+		submitStep,
+		isSubmitting,
+		errorNotice,
+		error,
+	} = useSetupWizardStep( 'welcome' );
 
 	useEffect( () => {
 		if ( submittedData && ! error ) {
@@ -68,7 +72,9 @@ export const Welcome = () => {
 					isSubmitting={ isSubmitting }
 					onClose={ () => toggleUsageModal( false ) }
 					onContinue={ submitPage }
-				/>
+				>
+					{ errorNotice }
+				</UsageModal>
 			) }
 		</>
 	);

--- a/assets/onboarding/welcome/index.jsx
+++ b/assets/onboarding/welcome/index.jsx
@@ -64,7 +64,7 @@ export const Welcome = () => {
 			</div>
 			{ usageModalActive && (
 				<UsageModal
-					tracking={ stepData.usageTracking }
+					tracking={ stepData.usage_tracking }
 					isSubmitting={ isSubmitting }
 					onClose={ () => toggleUsageModal( false ) }
 					onContinue={ submitPage }

--- a/assets/onboarding/welcome/index.jsx
+++ b/assets/onboarding/welcome/index.jsx
@@ -4,7 +4,7 @@ import { Button } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
 import { UsageModal } from './usage-modal';
 import { useQueryStringRouter } from '../query-string-router';
-import { useSetupWizardStore } from '../use-setup-wizard-store.js';
+import { useSetupWizardStep } from '../use-setup-wizard-step.js';
 
 /**
  * Welcome step for Onboarding Wizard.
@@ -15,7 +15,7 @@ export const Welcome = () => {
 
 	const { goTo } = useQueryStringRouter();
 
-	const { stepData, submitStep, isSubmitting, error } = useSetupWizardStore(
+	const { stepData, submitStep, isSubmitting, error } = useSetupWizardStep(
 		'welcome'
 	);
 

--- a/assets/onboarding/welcome/usage-modal.jsx
+++ b/assets/onboarding/welcome/usage-modal.jsx
@@ -19,6 +19,7 @@ export const UsageModal = ( {
 	onContinue,
 	onClose,
 	isSubmitting,
+	children,
 } ) => {
 	const trackingMessage = interpolateComponents( {
 		mixedString: __(
@@ -58,6 +59,7 @@ export const UsageModal = ( {
 						onChange={ () => setAllowTracking( ! allowTracking ) }
 					/>
 				</div>
+				{ children }
 				<Button
 					className="sensei-onboarding__button sensei-onboarding__button-modal"
 					isPrimary

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+const baseConfig = require( '@wordpress/scripts/config/jest-unit.config.js' );
+
+module.exports = {
+	...baseConfig,
+	testPathIgnorePatterns: [ '/node_modules/', '/build/', '/assets/dist/' ],
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Makes the submit action and related things generic - a `submitStep` action a the `getStepData` accept an additional `step` parameter. 
* Changes the `useOnboardingApi` hook to `useSetupWizardStep` and wrap the store's select and dispatch hooks
* Add an error notice
* [Maintenance] Excludes the `build` and `assets/dist` files from JS unit tests, as it was picking up test files from there

### Testing instructions

* Tests run
* Welcome and Purpose step work properly

