### PR TITLE
Update features selection to don't check when it's installed

### DIFF
--- a/assets/onboarding/features/features-selection.jsx
+++ b/assets/onboarding/features/features-selection.jsx
@@ -50,10 +50,7 @@ const FeaturesSelection = ( {
 								/>
 							}
 							onChange={ toggleItem( id ) }
-							checked={
-								selectedIds.includes( id ) ||
-								status === INSTALLED_STATUS
-							}
+							checked={ selectedIds.includes( id ) }
 							disabled={ status === INSTALLED_STATUS }
 							className={ `sensei-onboarding__checkbox ${
 								status === INSTALLED_STATUS


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update features selection to don't check when it's installed. It's only marked as disabled. Change requested here: https://github.com/Automattic/sensei/pull/3121#issuecomment-630752042

### Testing instructions

* Open the feature steps in `/wp-admin/admin.php?page=sensei_onboarding&step=features` and check if the "Course progress" and "Media attachments" are disabled and not checked. - These data are still mocked.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="579" alt="Screen Shot 2020-05-19 at 10 27 42" src="https://user-images.githubusercontent.com/876340/82332125-63c4d700-99bb-11ea-87d1-253924ec8806.png">
