### PR TITLE
Fetch sensei extensions from sensei site

### DIFF
--- a/assets/onboarding/data/actions.js
+++ b/assets/onboarding/data/actions.js
@@ -10,6 +10,8 @@ import {
 	SET_STEP_DATA,
 } from './constants';
 
+import { normalizeSetupWizardData } from './normalizer';
+
 /**
  * @typedef  {Object} FetchFromAPIAction
  * @property {string} type               Action type.
@@ -37,9 +39,7 @@ export function* fetchSetupWizardData() {
 		const data = yield fetchFromAPI( {
 			path: API_BASE_PATH,
 		} );
-		yield successFetch( {
-			...data,
-		} );
+		yield successFetch( normalizeSetupWizardData( data ) );
 	} catch ( error ) {
 		yield errorFetch( error );
 	}

--- a/assets/onboarding/data/actions.test.js
+++ b/assets/onboarding/data/actions.test.js
@@ -52,10 +52,29 @@ describe( 'Setup wizard actions', () => {
 		expect( gen.next().value ).toEqual( expectedFetchAction );
 
 		// Set data action.
-		const dataObject = { x: 1 };
+		const dataObject = {
+			features: {
+				options: [
+					{
+						product_slug: 'test',
+						title: 'Test',
+					},
+				],
+			},
+		};
 		const expectedSetDataAction = {
 			type: SUCCESS_FETCH_SETUP_WIZARD_DATA,
-			data: dataObject,
+			data: {
+				features: {
+					options: [
+						{
+							product_slug: 'test',
+							slug: 'test',
+							title: 'Test — Free',
+						},
+					],
+				},
+			},
 		};
 		expect( gen.next( dataObject ).value ).toEqual( expectedSetDataAction );
 	} );

--- a/assets/onboarding/data/normalizer.js
+++ b/assets/onboarding/data/normalizer.js
@@ -1,0 +1,47 @@
+import { __ } from '@wordpress/i18n';
+
+import { INSTALLED_STATUS } from '../features/feature-status';
+
+/**
+ * Add details to title.
+ *
+ * @param {string}        title    Feature title.
+ * @param {string|number} price    Feature price.
+ * @param {string}        [status] Feature status.
+ */
+const addDetailsToTitle = ( title, price, status ) => {
+	let titleComplement;
+
+	if ( status === INSTALLED_STATUS ) {
+		titleComplement = __( 'Installed', 'sensei-lms' );
+	} else {
+		titleComplement = price
+			? `${ price } ${ __( 'per year', 'sensei-lms' ) }`
+			: __( 'Free', 'sensei-lms' );
+	}
+
+	return `${ title } — ${ titleComplement }`;
+};
+
+/**
+ * Normalize setup wizard data.
+ *
+ * @param {Object} data Setup wizard data.
+ *
+ * @return {Object} Normalized steup wizard data.
+ */
+export const normalizeSetupWizardData = ( data ) => ( {
+	...data,
+	features: {
+		...data.features,
+		options: data.features.options.map( ( feature ) => ( {
+			...feature,
+			slug: feature.product_slug,
+			title: addDetailsToTitle(
+				feature.title,
+				feature.price,
+				feature.status
+			),
+		} ) ),
+	},
+} );

--- a/assets/onboarding/data/normalizer.js
+++ b/assets/onboarding/data/normalizer.js
@@ -5,11 +5,12 @@ import { INSTALLED_STATUS } from '../features/feature-status';
 /**
  * Add details to title.
  *
- * @param {string}        title    Feature title.
- * @param {string|number} price    Feature price.
- * @param {string}        [status] Feature status.
+ * @param {Object}        feature
+ * @param {string}        feature.title    Feature title.
+ * @param {string|number} feature.price    Feature price.
+ * @param {string}        [feature.status] Feature status.
  */
-const addDetailsToTitle = ( title, price, status ) => {
+const getTitleWithDetails = ( { title, price, status } ) => {
 	let titleComplement;
 
 	if ( status === INSTALLED_STATUS ) {
@@ -37,11 +38,7 @@ export const normalizeSetupWizardData = ( data ) => ( {
 		options: data.features.options.map( ( feature ) => ( {
 			...feature,
 			slug: feature.product_slug,
-			title: addDetailsToTitle(
-				feature.title,
-				feature.price,
-				feature.status
-			),
+			title: getTitleWithDetails( feature ),
 		} ) ),
 	},
 } );

--- a/assets/onboarding/data/normalizer.test.js
+++ b/assets/onboarding/data/normalizer.test.js
@@ -1,0 +1,56 @@
+import { normalizeSetupWizardData } from './normalizer';
+
+describe( 'Data normalizer', () => {
+	it( 'Setup wizard data normalizer', () => {
+		const expectedData = {
+			features: {
+				options: [
+					{
+						product_slug: 'free',
+						slug: 'free',
+						title: 'Title — Free',
+						price: 0,
+					},
+					{
+						product_slug: 'price',
+						slug: 'price',
+						title: 'Title — $100.00 per year',
+						price: '$100.00',
+					},
+					{
+						product_slug: 'installed',
+						slug: 'installed',
+						title: 'Title — Installed',
+						price: 0,
+						status: 'installed',
+					},
+				],
+			},
+		};
+
+		const normalizedData = normalizeSetupWizardData( {
+			features: {
+				options: [
+					{
+						product_slug: 'free',
+						title: 'Title',
+						price: 0,
+					},
+					{
+						product_slug: 'price',
+						title: 'Title',
+						price: '$100.00',
+					},
+					{
+						product_slug: 'installed',
+						title: 'Title',
+						price: 0,
+						status: 'installed',
+					},
+				],
+			},
+		} );
+
+		expect( normalizedData ).toEqual( expectedData );
+	} );
+} );

--- a/assets/onboarding/data/reducer.js
+++ b/assets/onboarding/data/reducer.js
@@ -23,6 +23,7 @@ const DEFAULT_STATE = {
 		},
 		features: {
 			selected: [],
+			options: [],
 		},
 	},
 };

--- a/assets/onboarding/features/confirmation-modal.jsx
+++ b/assets/onboarding/features/confirmation-modal.jsx
@@ -9,9 +9,9 @@ const WC_EXTRA_DESCRIPTION = __(
 
 /**
  * @typedef  {Object} Feature
- * @property {string} id          Feature id.
- * @property {string} title       Feature title.
- * @property {string} description Feature description.
+ * @property {string} slug    Feature slug.
+ * @property {string} title   Feature title.
+ * @property {string} excerpt Feature excerpt.
  */
 /**
  * Features confirmation modal.
@@ -31,12 +31,12 @@ const ConfirmationModal = ( { features = [], onInstall, onSkip } ) => (
 		isDismissible={ false }
 	>
 		<List
-			items={ features.map( ( { id, title, description } ) => ( {
+			items={ features.map( ( { slug, title, excerpt } ) => ( {
 				title,
 				content:
-					'sensei-wc-paid-courses' === id
-						? `${ description } ${ WC_EXTRA_DESCRIPTION }`
-						: description,
+					'sensei-wc-paid-courses' === slug
+						? `${ excerpt } ${ WC_EXTRA_DESCRIPTION }`
+						: excerpt,
 			} ) ) }
 		/>
 

--- a/assets/onboarding/features/confirmation-modal.jsx
+++ b/assets/onboarding/features/confirmation-modal.jsx
@@ -2,11 +2,16 @@ import { List } from '@woocommerce/components';
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+const WC_EXTRA_DESCRIPTION = __(
+	'(The WooCommerce plugin may also be installed and activated for free.)',
+	'sensei-lms'
+);
+
 /**
  * @typedef  {Object} Feature
- * @property {string} title                          Feature title.
- * @property {string} description                    Feature description.
- * @property {string} [confirmationExtraDescription] Extra description that appears only in confirmation modal.
+ * @property {string} id          Feature id.
+ * @property {string} title       Feature title.
+ * @property {string} description Feature description.
  */
 /**
  * Features confirmation modal.
@@ -26,14 +31,13 @@ const ConfirmationModal = ( { features = [], onInstall, onSkip } ) => (
 		isDismissible={ false }
 	>
 		<List
-			items={ features.map(
-				( { title, description, confirmationExtraDescription } ) => ( {
-					title,
-					content: confirmationExtraDescription
-						? `${ description } ${ confirmationExtraDescription }`
+			items={ features.map( ( { id, title, description } ) => ( {
+				title,
+				content:
+					'sensei-wc-paid-courses' === id
+						? `${ description } ${ WC_EXTRA_DESCRIPTION }`
 						: description,
-				} )
-			) }
+			} ) ) }
 		/>
 
 		<p>

--- a/assets/onboarding/features/confirmation-modal.test.js
+++ b/assets/onboarding/features/confirmation-modal.test.js
@@ -5,14 +5,14 @@ import ConfirmationModal from './confirmation-modal';
 
 const features = [
 	{
-		id: 'first',
+		slug: 'first',
 		title: 'First',
-		description: 'Dolor',
+		excerpt: 'Dolor',
 	},
 	{
-		id: 'sensei-wc-paid-courses',
+		slug: 'sensei-wc-paid-courses',
 		title: 'Second',
-		description: 'Lorem',
+		excerpt: 'Lorem',
 	},
 ];
 

--- a/assets/onboarding/features/confirmation-modal.test.js
+++ b/assets/onboarding/features/confirmation-modal.test.js
@@ -5,13 +5,14 @@ import ConfirmationModal from './confirmation-modal';
 
 const features = [
 	{
+		id: 'first',
 		title: 'First',
 		description: 'Dolor',
 	},
 	{
+		id: 'sensei-wc-paid-courses',
 		title: 'Second',
 		description: 'Lorem',
-		confirmationExtraDescription: 'Ipsum',
 	},
 ];
 
@@ -29,7 +30,11 @@ describe( '<ConfirmationModal />', () => {
 			features.length
 		);
 		expect( screen.queryByText( 'Dolor' ) ).toBeTruthy();
-		expect( screen.queryByText( 'Lorem Ipsum' ) ).toBeTruthy();
+		expect(
+			screen.queryByText(
+				'Lorem (The WooCommerce plugin may also be installed and activated for free.)'
+			)
+		).toBeTruthy();
 	} );
 
 	it( 'Should call the callbacks', () => {

--- a/assets/onboarding/features/feature-description.jsx
+++ b/assets/onboarding/features/feature-description.jsx
@@ -4,25 +4,25 @@ import { __ } from '@wordpress/i18n';
  * Feature description component
  *
  * @param {Object} props
- * @param {string} props.description      Feature description.
- * @param {string} [props.learnMoreLink]  Learn more link.
+ * @param {string} props.excerpt          Feature excerpt.
+ * @param {string} [props.link]           Feature link.
  * @param {string} [props.errorMessage]   Error message.
  * @param {string} [props.onFeatureRetry] Retry feature installation callback.
  */
 const FeatureDescription = ( {
-	description,
-	learnMoreLink,
+	excerpt,
+	link,
 	errorMessage,
 	onFeatureRetry,
 } ) => (
 	<>
-		{ description }
-		{ learnMoreLink && (
+		{ excerpt }
+		{ link && (
 			<>
 				{ ' ' }
 				<a
 					className="sensei-onboarding__learn-more"
-					href={ learnMoreLink }
+					href={ link }
 					target="_blank"
 					rel="noopener noreferrer"
 				>

--- a/assets/onboarding/features/feature-description.test.js
+++ b/assets/onboarding/features/feature-description.test.js
@@ -4,9 +4,7 @@ import FeatureDescription from './feature-description';
 
 describe( '<FeatureDescription />', () => {
 	it( 'Should render with the description', () => {
-		const { container } = render(
-			<FeatureDescription description="test" />
-		);
+		const { container } = render( <FeatureDescription excerpt="test" /> );
 
 		expect( container.firstChild ).toMatchInlineSnapshot( 'test' );
 	} );
@@ -14,7 +12,7 @@ describe( '<FeatureDescription />', () => {
 	it( 'Should render with learn more link', () => {
 		const link = 'https://senseilms.com/';
 		const { queryByText } = render(
-			<FeatureDescription description="test" learnMoreLink={ link } />
+			<FeatureDescription excerpt="test" link={ link } />
 		);
 
 		const href = queryByText( 'Learn more' ).getAttribute( 'href' );
@@ -27,7 +25,7 @@ describe( '<FeatureDescription />', () => {
 
 		const { queryByText } = render(
 			<FeatureDescription
-				description="test"
+				excerpt="test"
 				errorMessage="Error message"
 				onFeatureRetry={ onFeatureRetryMock }
 			/>

--- a/assets/onboarding/features/features-selection.jsx
+++ b/assets/onboarding/features/features-selection.jsx
@@ -6,60 +6,58 @@ import FeatureDescription from './feature-description';
 
 /**
  * @typedef  {Object} Feature
- * @property {string} id              Feature id.
- * @property {string} title           Feature title.
- * @property {string} description     Feature description.
- * @property {string} [learnMoreLink] Feature description.
- * @property {string} [status]        Feature status.
+ * @property {string} slug     Feature slug.
+ * @property {string} title    Feature title.
+ * @property {string} excerpt  Feature excerpt.
+ * @property {string} [link]   Feature link.
+ * @property {string} [status] Feature status.
  */
 /**
  * Features confirmation modal.
  *
  * @param {Object}    props
- * @param {Feature[]} props.features    Features list.
- * @param {string[]}  props.selectedIds Selected ids.
- * @param {Function}  props.onChange    Callback to change the selection.
- * @param {Function}  props.onContinue  Callback to continue after selection.
+ * @param {Feature[]} props.features      Features list.
+ * @param {string[]}  props.selectedSlugs Selected slugs.
+ * @param {Function}  props.onChange      Callback to change the selection.
+ * @param {Function}  props.onContinue    Callback to continue after selection.
  */
 const FeaturesSelection = ( {
 	features,
-	selectedIds,
+	selectedSlugs,
 	onChange,
 	onContinue,
 } ) => {
-	const toggleItem = ( id ) => ( checked ) => {
+	const toggleItem = ( slug ) => ( checked ) => {
 		onChange( [
 			...( checked
-				? [ id, ...selectedIds ]
-				: selectedIds.filter( ( item ) => item !== id ) ),
+				? [ slug, ...selectedSlugs ]
+				: selectedSlugs.filter( ( i ) => i !== slug ) ),
 		] );
 	};
 
 	return (
 		<>
 			<div className="sensei-onboarding__checkbox-list">
-				{ features.map(
-					( { id, title, description, learnMoreLink, status } ) => (
-						<CheckboxControl
-							key={ id }
-							label={ title }
-							help={
-								<FeatureDescription
-									description={ description }
-									learnMoreLink={ learnMoreLink }
-								/>
-							}
-							onChange={ toggleItem( id ) }
-							checked={ selectedIds.includes( id ) }
-							disabled={ status === INSTALLED_STATUS }
-							className={ `sensei-onboarding__checkbox ${
-								status === INSTALLED_STATUS
-									? 'installed-status'
-									: ''
-							}` }
-						/>
-					)
-				) }
+				{ features.map( ( { slug, title, excerpt, link, status } ) => (
+					<CheckboxControl
+						key={ slug }
+						label={ title }
+						help={
+							<FeatureDescription
+								excerpt={ excerpt }
+								link={ link }
+							/>
+						}
+						onChange={ toggleItem( slug ) }
+						checked={ selectedSlugs.includes( slug ) }
+						disabled={ status === INSTALLED_STATUS }
+						className={ `sensei-onboarding__checkbox ${
+							status === INSTALLED_STATUS
+								? 'installed-status'
+								: ''
+						}` }
+					/>
+				) ) }
 			</div>
 			<Button
 				isPrimary

--- a/assets/onboarding/features/features-selection.test.js
+++ b/assets/onboarding/features/features-selection.test.js
@@ -4,14 +4,14 @@ import FeaturesSelection from './features-selection';
 
 const features = [
 	{
-		id: 'a',
+		slug: 'a',
 		title: 'Lorem',
-		description: 'Ipsum',
+		excerpt: 'Ipsum',
 	},
 	{
-		id: 'b',
+		slug: 'b',
 		title: 'Lorem',
-		description: 'Ipsum',
+		excerpt: 'Ipsum',
 	},
 ];
 
@@ -22,7 +22,7 @@ describe( '<FeaturesSelection />', () => {
 		const { container } = render(
 			<FeaturesSelection
 				features={ features }
-				selectedIds={ selectedIds }
+				selectedSlugs={ selectedIds }
 				onChange={ () => {} }
 				onContinue={ () => {} }
 			/>
@@ -43,7 +43,7 @@ describe( '<FeaturesSelection />', () => {
 		const { container, queryByText } = render(
 			<FeaturesSelection
 				features={ features }
-				selectedIds={ [ 'b' ] }
+				selectedSlugs={ [ 'b' ] }
 				onChange={ onChangeMock }
 				onContinue={ onContinueMock }
 			/>

--- a/assets/onboarding/features/index.jsx
+++ b/assets/onboarding/features/index.jsx
@@ -1,31 +1,12 @@
 import { useState } from '@wordpress/element';
 import { Card, H } from '@woocommerce/components';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
-import { INSTALLED_STATUS } from './feature-status';
 import { useQueryStringRouter } from '../query-string-router';
 import ConfirmationModal from './confirmation-modal';
 import InstallationFeedback from './installation-feedback';
 import FeaturesSelection from './features-selection';
-
-const addPriceToTitle = ( features ) =>
-	features.map( ( feature ) => {
-		let titleComplement;
-
-		if ( feature.status === INSTALLED_STATUS ) {
-			titleComplement = __( 'Installed', 'sensei-lms' );
-		} else {
-			titleComplement = feature.price
-				? `${ feature.price } ${ __( 'per year', 'sensei-lms' ) }`
-				: __( 'Free', 'sensei-lms' );
-		}
-
-		return {
-			...feature,
-			title: `${ feature.title } — ${ titleComplement }`,
-		};
-	} );
+import { useSetupWizardStep } from '../use-setup-wizard-step.js';
 
 /**
  * Features step for setup wizard.
@@ -36,14 +17,8 @@ const Features = () => {
 	const [ selectedSlugs, setSelectedSlugs ] = useState( [] );
 	const { goTo } = useQueryStringRouter();
 
-	const { features } = useSelect(
-		( select ) => ( {
-			features: addPriceToTitle(
-				select( 'sensei/setup-wizard' ).getStepData( 'features' )
-			),
-		} ),
-		[]
-	);
+	const { stepData } = useSetupWizardStep( 'features' );
+	const features = stepData.options;
 
 	const getSelectedFeatures = () =>
 		features.filter( ( feature ) =>

--- a/assets/onboarding/features/index.jsx
+++ b/assets/onboarding/features/index.jsx
@@ -33,7 +33,7 @@ const addPriceToTitle = ( features ) =>
 const Features = () => {
 	const [ confirmationActive, toggleConfirmation ] = useState( false );
 	const [ feedbackActive, toggleFeedback ] = useState( false );
-	const [ selectedFeatureIds, setSelectedFeatureIds ] = useState( [] );
+	const [ selectedSlugs, setSelectedSlugs ] = useState( [] );
 	const { goTo } = useQueryStringRouter();
 
 	const { features } = useSelect(
@@ -47,11 +47,11 @@ const Features = () => {
 
 	const getSelectedFeatures = () =>
 		features.filter( ( feature ) =>
-			selectedFeatureIds.includes( feature.id )
+			selectedSlugs.includes( feature.slug )
 		);
 
 	const finishSelection = () => {
-		if ( 0 === selectedFeatureIds.length ) {
+		if ( 0 === selectedSlugs.length ) {
 			goToNextStep();
 			return;
 		}
@@ -87,8 +87,8 @@ const Features = () => {
 				) : (
 					<FeaturesSelection
 						features={ features }
-						selectedIds={ selectedFeatureIds }
-						onChange={ setSelectedFeatureIds }
+						selectedSlugs={ selectedSlugs }
+						onChange={ setSelectedSlugs }
 						onContinue={ finishSelection }
 					/>
 				) }

--- a/assets/onboarding/features/index.jsx
+++ b/assets/onboarding/features/index.jsx
@@ -1,88 +1,31 @@
 import { useState } from '@wordpress/element';
 import { Card, H } from '@woocommerce/components';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
+import { INSTALLED_STATUS } from './feature-status';
 import { useQueryStringRouter } from '../query-string-router';
 import ConfirmationModal from './confirmation-modal';
 import InstallationFeedback from './installation-feedback';
 import FeaturesSelection from './features-selection';
-import {
-	LOADING_STATUS,
-	ERROR_STATUS,
-	INSTALLED_STATUS,
-} from './feature-status';
 
-// TODO: Make it dynamic.
-const features = [
-	{
-		id: 'paid_courses',
-		title: __( 'WooCommerce Paid Courses', 'sensei-lms' ),
-		price: '$129.00 per year',
-		description: __(
-			'Sell your online courses using the most popular eCommerce plataform on the web - WooCommerce.',
-			'sensei-lms'
-		),
-		confirmationExtraDescription: __(
-			'(The WooCommerce plugin may also be installed and activated for free.)',
-			'sensei-lms'
-		),
-		learnMoreLink:
-			'https://woocommerce.com/products/woocommerce-paid-courses/',
-		status: LOADING_STATUS,
-	},
-	{
-		id: 'course_progress',
-		title: __( 'Course progress', 'sensei-lms' ),
-		description: __(
-			'Enable your students to easily view their progress and pick up where they left off in a course.',
-			'sensei-lms'
-		),
-		learnMoreLink:
-			'https://woocommerce.com/products/sensei-course-progress/',
-		status: INSTALLED_STATUS,
-	},
-	{
-		id: 'certificates',
-		title: __( 'Certificates', 'sensei-lms' ),
-		description: __(
-			'Award your students with a certificate of completion and a sense of accomplishment after finishing a course.',
-			'sensei-lms'
-		),
-		learnMoreLink: 'https://woocommerce.com/products/sensei-certificates/',
-		errorMessage: __(
-			'Error message here, maecenas faucibus mollis interdum tristique euismod.',
-			'sensei-lms'
-		),
-		status: ERROR_STATUS,
-	},
-	{
-		id: 'media_attachments',
-		title: __( 'Media Attachments', 'sensei-lms' ),
-		description: __(
-			'Provide your students with easy access to additional learning materials, from audio files to slideshows and PDFs.',
-			'sensei-lms'
-		),
-		learnMoreLink:
-			'https://woocommerce.com/products/sensei-media-attachments/',
-		status: INSTALLED_STATUS,
-	},
-	{
-		id: 'content_drip',
-		title: __( 'Content Drip', 'sensei-lms' ),
-		price: '$29.00 per year',
-		description: __(
-			'Keep students engaged and improve knowledge retention by setting a delivery schedule for course content.',
-			'sensei-lms'
-		),
-		learnMoreLink: 'https://woocommerce.com/products/sensei-content-drip/',
-		status: LOADING_STATUS,
-	},
-].map( ( feature ) => ( {
-	...feature,
-	title: `${ feature.title } — ${
-		feature.price ? feature.price : __( 'Free', 'sensei-lms' )
-	}`,
-} ) );
+const addPriceToTitle = ( features ) =>
+	features.map( ( feature ) => {
+		let titleComplement;
+
+		if ( feature.status === INSTALLED_STATUS ) {
+			titleComplement = __( 'Installed', 'sensei-lms' );
+		} else {
+			titleComplement = feature.price
+				? `${ feature.price } ${ __( 'per year', 'sensei-lms' ) }`
+				: __( 'Free', 'sensei-lms' );
+		}
+
+		return {
+			...feature,
+			title: `${ feature.title } — ${ titleComplement }`,
+		};
+	} );
 
 /**
  * Features step for setup wizard.
@@ -92,6 +35,15 @@ const Features = () => {
 	const [ feedbackActive, toggleFeedback ] = useState( false );
 	const [ selectedFeatureIds, setSelectedFeatureIds ] = useState( [] );
 	const { goTo } = useQueryStringRouter();
+
+	const { features } = useSelect(
+		( select ) => ( {
+			features: addPriceToTitle(
+				select( 'sensei/setup-wizard' ).getStepData( 'features' )
+			),
+		} ),
+		[]
+	);
 
 	const getSelectedFeatures = () =>
 		features.filter( ( feature ) =>

--- a/assets/onboarding/features/index.test.js
+++ b/assets/onboarding/features/index.test.js
@@ -4,6 +4,15 @@ import QueryStringRouter, { Route } from '../query-string-router';
 import { updateRouteURL } from '../query-string-router/url-functions';
 import Features from './index';
 
+// Mock features data.
+jest.mock( '../use-setup-wizard-step.js', () => ( {
+	useSetupWizardStep: () => ( {
+		stepData: {
+			options: [ { slug: 'test', title: 'Test' } ],
+		},
+	} ),
+} ) );
+
 describe( '<Features />', () => {
 	afterEach( () => {
 		// Clear URL param.

--- a/assets/onboarding/features/installation-feedback.jsx
+++ b/assets/onboarding/features/installation-feedback.jsx
@@ -7,11 +7,11 @@ import FeatureStatus, { LOADING_STATUS, ERROR_STATUS } from './feature-status';
 
 /**
  * @typedef  {Object} Feature
- * @property {string} title           Feature title.
- * @property {string} description     Feature description.
- * @property {string} [learnMoreLink] Learn more link.
- * @property {string} [errorMessage]  Error message.
- * @property {string} status          Feature status.
+ * @property {string} title          Feature title.
+ * @property {string} excerpt        Feature excerpt.
+ * @property {string} [link]         Feature link.
+ * @property {string} [errorMessage] Error message.
+ * @property {string} status         Feature status.
  */
 /**
  * Installation feedback component.
@@ -72,18 +72,12 @@ const InstallationFeedback = ( { features, onContinue } ) => {
 		<div className="sensei-onboarding__features-installation-feedback">
 			<List
 				items={ features.map(
-					( {
-						title,
-						description,
-						learnMoreLink,
-						errorMessage,
-						status,
-					} ) => ( {
+					( { title, excerpt, link, errorMessage, status } ) => ( {
 						title,
 						content: (
 							<FeatureDescription
-								description={ description }
-								learnMoreLink={ learnMoreLink }
+								excerpt={ excerpt }
+								link={ link }
 								errorMessage={ errorMessage }
 								onFeatureRetry={ () => {} }
 							/>

--- a/assets/onboarding/features/installation-feedback.test.js
+++ b/assets/onboarding/features/installation-feedback.test.js
@@ -12,17 +12,17 @@ describe( '<InstallationFeedback />', () => {
 		const features = [
 			{
 				title: 'Test',
-				description: 'Test',
+				excerpt: 'Test',
 				status: LOADING_STATUS,
 			},
 			{
 				title: 'Test',
-				description: 'Test',
+				excerpt: 'Test',
 				status: ERROR_STATUS,
 			},
 			{
 				title: 'Test',
-				description: 'Test',
+				excerpt: 'Test',
 				status: INSTALLED_STATUS,
 			},
 		];
@@ -41,7 +41,7 @@ describe( '<InstallationFeedback />', () => {
 		const features = [
 			{
 				title: 'Test',
-				description: 'Test',
+				excerpt: 'Test',
 				status: INSTALLED_STATUS,
 			},
 		];
@@ -65,12 +65,12 @@ describe( '<InstallationFeedback />', () => {
 		const features = [
 			{
 				title: 'Test',
-				description: 'Test',
+				excerpt: 'Test',
 				status: ERROR_STATUS,
 			},
 			{
 				title: 'Test',
-				description: 'Test',
+				excerpt: 'Test',
 				status: INSTALLED_STATUS,
 			},
 		];

--- a/assets/onboarding/index.jsx
+++ b/assets/onboarding/index.jsx
@@ -1,6 +1,7 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { render, useLayoutEffect } from '@wordpress/element';
 import { Spinner } from '@woocommerce/components';
+import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 import registerSetupWizardStore from './data';
@@ -44,9 +45,15 @@ const SenseiSetupWizardPage = () => {
 	}
 
 	if ( error ) {
-		return __(
-			'An error has occurred. Please try again later!',
-			'sensei-lms'
+		return (
+			<Notice status="error" isDismissible={ false }>
+				{ __(
+					'An error has occurred while fetching the data. Please try again later!',
+					'sensei-lms'
+				) }
+				<br />
+				{ __( 'Error details:', 'sensei-lms' ) } { error.message }
+			</Notice>
 		);
 	}
 

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -59,12 +59,13 @@ final class Sensei_Extensions {
 	 * Call API to get Sensei extensions.
 	 *
 	 * @since  2.0.0
+	 * @since  3.1.0 The method is public.
 	 *
 	 * @param  string $type      Product type ('plugin' or 'theme').
 	 * @param  string $category  Category to fetch (null = all).
 	 * @return array
 	 */
-	private function get_extensions( $type = null, $category = null ) {
+	public function get_extensions( $type = null, $category = null ) {
 		$extension_request_key = md5( $type . '|' . $category );
 		$extensions            = get_transient( 'sensei_extensions_' . $extension_request_key );
 

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -82,7 +82,9 @@ final class Sensei_Extensions {
 				)
 			);
 			if ( ! is_wp_error( $raw_extensions ) ) {
-				$extensions = json_decode( wp_remote_retrieve_body( $raw_extensions ) )->products;
+				$json       = json_decode( wp_remote_retrieve_body( $raw_extensions ) );
+				$extensions = isset( $json->products ) ? $json->products : [];
+
 				set_transient( 'sensei_extensions_' . $extension_request_key, $extensions, DAY_IN_SECONDS );
 			}
 		}

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -388,56 +388,6 @@ class Sensei_Onboarding {
 	}
 
 	/**
-	 * Override sensei extensions.
-	 *
-	 * @param array $original_extensions Original extensions.
-	 *
-	 * @return array Overridden extensions.
-	 */
-	private function override_sensei_extensions( $original_extensions ) {
-		$override_extensions = [
-			'sensei-course-progress' => [
-				'title'  => __( 'Course progress', 'sensei-lms' ),
-				'status' => 'installed',
-			],
-			'sensei-certificates'    => [
-				'title'  => __( 'Certificates', 'sensei-lms' ),
-				'status' => 'error',
-			],
-			'sensei-wc-paid-courses' => [
-				'title'                        => __( 'WooCommerce Paid Courses', 'sensei-lms' ),
-				'confirmationExtraDescription' => __(
-					'(The WooCommerce plugin may also be installed and activated for free.)',
-					'sensei-lms'
-				),
-				'status'                       => 'loading',
-			],
-		];
-
-		return array_map(
-			function( $extension ) use ( $override_extensions ) {
-				// Decode price.
-				if ( isset( $extension['price'] ) && 0 !== $extension['price'] ) {
-					$extension['price'] = html_entity_decode( $extension['price'] );
-				}
-
-				$extension_id = $extension['id'];
-
-				if ( ! isset( $override_extensions[ $extension_id ] ) ) {
-					return $extension;
-				}
-
-				foreach ( $override_extensions[ $extension_id ] as $key => $value ) {
-					$extension[ $key ] = $value;
-				}
-
-				return $extension;
-			},
-			$original_extensions
-		);
-	}
-
-	/**
 	 * Normalize sensei extensions array.
 	 *
 	 * @param array $raw_extensions Raw extensions.
@@ -464,6 +414,11 @@ class Sensei_Onboarding {
 					unset( $extension[ $from ] );
 				}
 
+				// Decode price.
+				if ( isset( $extension['price'] ) && 0 !== $extension['price'] ) {
+					$extension['price'] = html_entity_decode( $extension['price'] );
+				}
+
 				return $extension;
 			},
 			$json['products']
@@ -487,7 +442,6 @@ class Sensei_Onboarding {
 			}
 
 			$extensions = $this->normalize_sensei_extensions( $data );
-			$extensions = $this->override_sensei_extensions( $extensions );
 
 			set_transient( self::EXTENSIONS_TRANSIENT, $extensions, DAY_IN_SECONDS );
 		}

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -395,15 +395,12 @@ class Sensei_Onboarding {
 	public function get_sensei_extensions() {
 		$sensei_extensions = Sensei_Extensions::instance();
 
+		// Decode prices.
 		$extensions = array_map(
 			function( $extension ) {
-				// Decode price.
 				if ( isset( $extension->price ) && 0 !== $extension->price ) {
 					$extension->price = html_entity_decode( $extension->price );
 				}
-
-				// Add slug property.
-				$extension->slug = $extension->product_slug;
 
 				return $extension;
 			},

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -21,7 +21,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Onboarding {
 	const SUGGEST_SETUP_WIZARD_OPTION = 'sensei_suggest_setup_wizard';
 	const USER_DATA_OPTION            = 'sensei_setup_wizard_data';
-	const EXTENSIONS_TRANSIENT        = 'sensei_setup_wizard_extensions';
 
 	/**
 	 * Default value for onboarding user data.

--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -195,6 +195,7 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 			],
 			'features'        => [
 				'selected' => $user_data['features'],
+				'options'  => $this->setup_wizard->get_sensei_extensions(),
 			],
 			'ready'           => [],
 		];

--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -246,8 +246,8 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 							'description' => 'Slugs of plugins selected by the site owner.',
 							'type'        => 'array',
 						],
-						'plugins'  => [
-							'description' => 'Slugs of selectable plugins.',
+						'options'  => [
+							'description' => 'Slugs Sensei extensions.',
 							'type'        => 'array',
 						],
 					],

--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -247,7 +247,7 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 							'type'        => 'array',
 						],
 						'options'  => [
-							'description' => 'Slugs Sensei extensions.',
+							'description' => 'Sensei extensions.',
 							'type'        => 'array',
 						],
 					],

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,6 +37,9 @@ class Sensei_Unit_Tests_Bootstrap {
 		// Enrolment checks should happen immediately in tests. Filter can be removed for specific tests.
 		tests_add_filter( 'sensei_should_defer_enrolment_check', '__return_false' );
 
+		// Prevent requests from `WP_Http::request` while testing. Filter can be overrided for specific tests.
+		tests_add_filter( 'pre_http_request', '__return_empty_array' );
+
 		// load the WP testing environment
 		require_once $this->wp_tests_dir . '/includes/bootstrap.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -37,8 +37,8 @@ class Sensei_Unit_Tests_Bootstrap {
 		// Enrolment checks should happen immediately in tests. Filter can be removed for specific tests.
 		tests_add_filter( 'sensei_should_defer_enrolment_check', '__return_false' );
 
-		// Prevent requests from `WP_Http::request` while testing. Filter can be overrided for specific tests.
-		tests_add_filter( 'pre_http_request', '__return_empty_array' );
+		// Prevent requests from `WP_Http::request` while testing.
+		tests_add_filter( 'pre_http_request', [ $this, 'prevent_requests' ], 99 );
 
 		// load the WP testing environment
 		require_once $this->wp_tests_dir . '/includes/bootstrap.php';
@@ -46,6 +46,21 @@ class Sensei_Unit_Tests_Bootstrap {
 		// load Sensei testing framework
 		$this->includes();
 	}
+
+	/**
+	 * Filter to alert to prevent requests in the tests.
+	 *
+	 * @param mixed $preempt
+	 * @return mixed
+	 */
+	public function prevent_requests( $preempt ) {
+		$error = 'You should use the filter `pre_http_request` to prevent requests in the tests';
+		if ( false === $preempt ) {
+			throw new Exception( $error );
+		}
+		return $preempt;
+	}
+
 	/**
 	 * Load Sensei.
 	 *

--- a/tests/unit-tests/admin/test-class-sensei-onboarding-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding-api.php
@@ -30,6 +30,8 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 
 		do_action( 'rest_api_init' );
 
+		// Prevent requests.
+		add_filter( 'pre_http_request', '__return_empty_array' );
 	}
 
 	/**

--- a/tests/unit-tests/admin/test-class-sensei-onboarding-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding-api.php
@@ -314,10 +314,8 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 	 * Tests that features get endpoint returns fetched data.
 	 *
 	 * @covers Sensei_REST_API_Setup_Wizard_Controller::get_data
-	 * @covers Sensei_Onboarding::get_sensei_extensions
-	 * @covers Sensei_Onboarding::normalize_sensei_extensions
 	 */
-	public function testGetFeaturesReturnsNormalizedObject() {
+	public function testGetFeaturesReturnsFetchedData() {
 		$response_body = '{ "products": [ { "product_slug": "slug-1" } ] }';
 
 		// Mock fetch from senseilms.com.
@@ -330,7 +328,7 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 
 		$data = $this->request( 'GET', '' );
 
-		$this->assertEquals( $data['features']['options'][0]->slug, 'slug-1' );
+		$this->assertEquals( count( $data['features']['options'] ), 1 );
 	}
 
 	/**

--- a/tests/unit-tests/admin/test-class-sensei-onboarding-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding-api.php
@@ -330,7 +330,7 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 
 		$data = $this->request( 'GET', '' );
 
-		$this->assertEquals( $data['features']['options'][0]['id'], 'slug-1' );
+		$this->assertEquals( $data['features']['options'][0]->slug, 'slug-1' );
 	}
 
 	/**

--- a/tests/unit-tests/admin/test-class-sensei-onboarding-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding-api.php
@@ -316,9 +316,8 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 	 * @covers Sensei_REST_API_Setup_Wizard_Controller::get_data
 	 * @covers Sensei_Onboarding::get_sensei_extensions
 	 * @covers Sensei_Onboarding::normalize_sensei_extensions
-	 * @covers Sensei_Onboarding::override_sensei_extensions
 	 */
-	public function testGetFeaturesReturnsNormalizedAndOverridenObject() {
+	public function testGetFeaturesReturnsNormalizedObject() {
 		$response_body = '{ "products": [ { "product_slug": "slug-1" } ] }';
 
 		// Mock fetch from senseilms.com.

--- a/tests/unit-tests/admin/test-class-sensei-onboarding-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding-api.php
@@ -311,6 +311,30 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * Tests that features get endpoint returns fetched data.
+	 *
+	 * @covers Sensei_REST_API_Setup_Wizard_Controller::get_data
+	 * @covers Sensei_Onboarding::get_sensei_extensions
+	 * @covers Sensei_Onboarding::normalize_sensei_extensions
+	 * @covers Sensei_Onboarding::override_sensei_extensions
+	 */
+	public function testGetFeaturesReturnsNormalizedAndOverridenObject() {
+		$response_body = '{ "products": [ { "product_slug": "slug-1" } ] }';
+
+		// Mock fetch from senseilms.com.
+		add_filter(
+			'pre_http_request',
+			function() use ( $response_body ) {
+				return [ 'body' => $response_body ];
+			}
+		);
+
+		$data = $this->request( 'GET', '' );
+
+		$this->assertEquals( $data['features']['options'][0]['id'], 'slug-1' );
+	}
+
+	/**
 	 * Create and dispatch a REST API request.
 	 *
 	 * @param string $method The request method.

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -358,13 +358,12 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that get sensei extensions returns normalized and overriden object.
+	 * Tests that get sensei extensions returns normalized object.
 	 *
 	 * @covers Sensei_Onboarding::get_sensei_extensions
 	 * @covers Sensei_Onboarding::normalize_sensei_extensions
-	 * @covers Sensei_Onboarding::override_sensei_extensions
 	 */
-	public function testGetSenseiExtensionsReturnsNormalizedAndOverridenObject() {
+	public function testGetSenseiExtensionsReturnsNormalizedObject() {
 		$expected_extensions = [
 			[
 				'id'            => 'slug-1',
@@ -377,11 +376,6 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 			[
 				'id'    => 'slug-2',
 				'price' => 0,
-			],
-			[
-				'id'     => 'sensei-certificates',
-				'title'  => 'Certificates',
-				'status' => 'error',
 			],
 		];
 
@@ -398,10 +392,6 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 				{
 					"product_slug": "slug-2",
 					"price": 0
-				},
-				{
-					"product_slug": "sensei-certificates",
-					"title": "Sensei Certificates"
 				}
 			]
 		}';

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -358,41 +358,15 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that get sensei extensions returns normalized object.
+	 * Tests that get sensei extensions and returns with decoded prices and slug.
 	 *
 	 * @covers Sensei_Onboarding::get_sensei_extensions
-	 * @covers Sensei_Onboarding::normalize_sensei_extensions
 	 */
-	public function testGetSenseiExtensionsReturnsNormalizedObject() {
-		$expected_extensions = [
-			[
-				'id'            => 'slug-1',
-				'title'         => 'Title 1',
-				'description'   => 'Excerpt 1',
-				'learnMoreLink' => 'https://senseilms.com/product/test-1/',
-				'price'         => '$1.00',
-				'plugin_file'   => 'path/file-1.php',
-			],
-			[
-				'id'    => 'slug-2',
-				'price' => 0,
-			],
-		];
-
+	public function testGetSenseiExtensionsAndReturnsWithDecodedPrices() {
 		$response_body = '{
 			"products": [
-				{
-					"product_slug": "slug-1",
-					"title": "Title 1",
-					"excerpt": "Excerpt 1",
-					"link": "https:\/\/senseilms.com\/product\/test-1\/",
-					"price": "&#36;1.00",
-					"plugin_file": "path\/file-1.php"
-				},
-				{
-					"product_slug": "slug-2",
-					"price": 0
-				}
+				{ "product_slug": "slug-1", "price": "&#36;1.00" },
+				{ "product_slug": "slug-2", "price": 0 }
 			]
 		}';
 
@@ -406,9 +380,9 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 
 		$extensions = Sensei()->onboarding->get_sensei_extensions();
 
-		$this->assertEquals( $expected_extensions, $extensions );
-
-		$transient_extensions = get_transient( \Sensei_Onboarding::EXTENSIONS_TRANSIENT );
-		$this->assertEquals( $expected_extensions, $transient_extensions );
+		$this->assertEquals( $extensions[0]->slug, 'slug-1' );
+		$this->assertEquals( $extensions[0]->price, '$1.00' );
+		$this->assertEquals( $extensions[1]->slug, 'slug-2' );
+		$this->assertEquals( $extensions[1]->price, 0 );
 	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-onboarding.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding.php
@@ -358,15 +358,15 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that get sensei extensions and returns with decoded prices and slug.
+	 * Tests that get sensei extensions and returns with decoded prices.
 	 *
 	 * @covers Sensei_Onboarding::get_sensei_extensions
 	 */
 	public function testGetSenseiExtensionsAndReturnsWithDecodedPrices() {
 		$response_body = '{
 			"products": [
-				{ "product_slug": "slug-1", "price": "&#36;1.00" },
-				{ "product_slug": "slug-2", "price": 0 }
+				{ "price": "&#36;1.00" },
+				{ "price": 0 }
 			]
 		}';
 
@@ -380,9 +380,7 @@ class Sensei_Onboarding_Test extends WP_UnitTestCase {
 
 		$extensions = Sensei()->onboarding->get_sensei_extensions();
 
-		$this->assertEquals( $extensions[0]->slug, 'slug-1' );
 		$this->assertEquals( $extensions[0]->price, '$1.00' );
-		$this->assertEquals( $extensions[1]->slug, 'slug-2' );
 		$this->assertEquals( $extensions[1]->price, 0 );
 	}
 }


### PR DESCRIPTION
Fixes #3044

### Changes proposed in this Pull Request

* Fetch the extensions from `https://senseilms.com/wp-json/senseilms-products/1.0/search?category=setup-wizard-extensions` - I created this new category `setup-wizard-extensions` to add only the extensions that we want to appear as suggestion.

### Testing instructions

* Go to `/wp-admin/admin.php?page=sensei_onboarding&step=features` and check if the extensions are being listed.

### Some questions

* Should we really override the titles? Or could we rename it in the `senseilms.com`?
* Do we need to worry about the [dynamic data](https://senseilms.com/wp-json/senseilms-products/1.0/search?category=setup-wizard-extensions) translations and currency conversion?
* Are good the links coming from the JSON? They are pointing to senseilms.com and redirecting to WC.com or WP.org.
* About the sorting, do we have a specific rule to apply in the array? I had thought about creating an array with the sort, but if we add more extensions in the future it would not appear in the order that we want.