### PR TITLE
Add tracking event for Setup Wizard purpose step

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -298,12 +298,22 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 
 		$this->mark_step_complete( 'purpose' );
 
+		$purpose_data = [
+			'selected' => $form['selected'],
+			'other'    => ( in_array( 'other', $form['selected'], true ) ? $form['other'] : '' ),
+		];
+
+		sensei_log_event(
+			'setup_wizard_purpose_continue',
+			[
+				'purpose'         => join( ',', $purpose_data['selected'] ),
+				'purpose_details' => $purpose_data['other'],
+			]
+		);
+
 		return $this->setup_wizard->update_wizard_user_data(
 			[
-				'purpose' => [
-					'selected' => $form['selected'],
-					'other'    => ( in_array( 'other', $form['selected'], true ) ? $form['other'] : '' ),
-				],
+				'purpose' => $purpose_data,
 			]
 		);
 	}

--- a/tests/unit-tests/admin/test-class-sensei-onboarding-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-onboarding-api.php
@@ -28,6 +28,7 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 		$wp_rest_server = new WP_REST_Server();
 		$this->server   = $wp_rest_server;
 
+		Sensei_Test_Events::reset();
 		do_action( 'rest_api_init' );
 
 	}
@@ -308,6 +309,28 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 		$data = Sensei()->onboarding->get_wizard_user_data();
 
 		$this->assertNotContains( [ 'invalid-plugin' ], $data['features'] );
+	}
+
+	/**
+	 * Tests that submitting to features endpoint validates input against whitelist
+	 *
+	 * @covers Sensei_REST_API_Setup_Wizard_Controller::submit_purpose
+	 */
+	public function testSubmitPurposeLogged() {
+
+		$this->request(
+			'POST',
+			'purpose',
+			[
+				'selected' => [ 'share_knowledge', 'other' ],
+				'other'    => 'Test',
+			]
+		);
+
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_setup_wizard_purpose_continue' );
+		$this->assertCount( 1, $events );
+		$this->assertEquals( 'share_knowledge,other', $events[0]['url_args']['purpose'] );
+		$this->assertEquals( 'Test', $events[0]['url_args']['purpose_details'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3050

### Changes proposed in this Pull Request

* Add the `sensei_setup_wizard_purpose_continue` when saving the Purpose form. 
* `purpose` property is a comma-separated list of purpose slugs. Ex. `promote_business,train_employees,other`

### Testing instructions

* Open Setup Wizard
* Allow usage tracking
* Select purposes, fill in other text field, click Continue
* Event should appear in event monitor


