### PR TITLE
Add filter for enabling/disabling enrolment related background jobs

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -147,7 +147,7 @@ class Sensei_Course_Enrolment {
 	/**
 	 * Marks all enrolment results as invalid for a course and enqueues an async job to recalculate.
 	 *
-	 * @return Sensei_Enrolment_Course_Calculation_Job
+	 * @return Sensei_Enrolment_Course_Calculation_Job|null
 	 */
 	public function recalculate_enrolment() {
 		$this->invalidate_all_learner_results();

--- a/includes/enrolment/class-sensei-enrolment-job-scheduler.php
+++ b/includes/enrolment/class-sensei-enrolment-job-scheduler.php
@@ -49,9 +49,28 @@ class Sensei_Enrolment_Job_Scheduler {
 		add_filter( 'sensei_background_job_actions', [ $this, 'get_background_jobs' ] );
 
 		add_action( Sensei_Enrolment_Learner_Calculation_Job::NAME, [ $this, 'run_learner_calculation' ] );
-
-		// Handle job that ensures a course's enrolment is up-to-date.
 		add_action( Sensei_Enrolment_Course_Calculation_Job::NAME, [ $this, 'run_course_calculation' ] );
+	}
+
+	/**
+	 * Check if an enrolment background job is enabled.
+	 *
+	 * @since 3.1.0
+	 *
+	 * @param string $enrolment_job_name Job handler name.
+	 *
+	 * @return bool
+	 */
+	public function is_background_job_enabled( $enrolment_job_name ) {
+		/**
+		 * Check if a specific enrolment background job is enabled.
+		 *
+		 * @since 3.1.0
+		 *
+		 * @param bool   $is_job_enabled     True if the job is enabled.
+		 * @param string $enrolment_job_name Name of the job.
+		 */
+		return apply_filters( 'sensei_is_enrolment_background_job_enabled', true, $enrolment_job_name );
 	}
 
 	/**
@@ -59,9 +78,13 @@ class Sensei_Enrolment_Job_Scheduler {
 	 *
 	 * @param int $course_id Course post ID.
 	 *
-	 * @return Sensei_Enrolment_Course_Calculation_Job Job object.
+	 * @return Sensei_Enrolment_Course_Calculation_Job|null Job object.
 	 */
 	public function start_course_calculation_job( $course_id ) {
+		if ( ! $this->is_background_job_enabled( Sensei_Enrolment_Course_Calculation_Job::NAME ) ) {
+			return null;
+		}
+
 		$args = [
 			'course_id' => $course_id,
 		];
@@ -101,6 +124,10 @@ class Sensei_Enrolment_Job_Scheduler {
 	 * @access private
 	 */
 	public function maybe_start_learner_calculation() {
+		if ( ! $this->is_background_job_enabled( Sensei_Enrolment_Learner_Calculation_Job::NAME ) ) {
+			return;
+		}
+
 		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
 		$current_version   = $enrolment_manager->get_enrolment_calculation_version();
 
@@ -124,6 +151,10 @@ class Sensei_Enrolment_Job_Scheduler {
 	 * @access private
 	 */
 	public function run_learner_calculation() {
+		if ( ! $this->is_background_job_enabled( Sensei_Enrolment_Learner_Calculation_Job::NAME ) ) {
+			return;
+		}
+
 		$job                 = new Sensei_Enrolment_Learner_Calculation_Job();
 		$completion_callback = function() {
 			$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
@@ -145,6 +176,10 @@ class Sensei_Enrolment_Job_Scheduler {
 	 * @param array $args Arguments for the job.
 	 */
 	public function run_course_calculation( $args ) {
+		if ( ! $this->is_background_job_enabled( Sensei_Enrolment_Course_Calculation_Job::NAME ) ) {
+			return;
+		}
+
 		$job = new Sensei_Enrolment_Course_Calculation_Job( $args );
 		Sensei_Scheduler::instance()->run( $job );
 	}


### PR DESCRIPTION
Fixes #3168

### Changes proposed in this Pull Request

* Adds new filter to help disable all/some enrolment background jobs `sensei_is_enrolment_background_job_enabled`.

### Testing instructions

* Add snippet:
```php
add_filter( 'sensei_is_enrolment_background_job_enabled', '__return_false' );
```
* Unpublish a course.
* Verify no Sensei jobs are queued within WP Cron or Action Scheduler.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_is_enrolment_background_job_enabled`
