### PR TITLE
Remove mass database invalidation of enrolment results on course recalculation

### DIFF
--- a/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
+++ b/includes/enrolment/class-sensei-enrolment-course-calculation-job.php
@@ -107,7 +107,7 @@ class Sensei_Enrolment_Course_Calculation_Job implements Sensei_Background_Job_I
 
 		add_action( 'pre_user_query', [ $this, 'modify_user_query_add_user_id' ] );
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $this->course_id );
-		$user_query       = new WP_User_Query( $this->get_query_args( $course_enrolment ) );
+		$user_query       = new WP_User_Query( $this->get_query_args() );
 		remove_action( 'pre_user_query', [ $this, 'modify_user_query_add_user_id' ] );
 
 		$user_ids = $user_query->get_results();
@@ -140,31 +140,14 @@ class Sensei_Enrolment_Course_Calculation_Job implements Sensei_Background_Job_I
 	/**
 	 * Get the query arguments for the user query.
 	 *
-	 * @param Sensei_Course_Enrolment $course_enrolment Course enrolment handler.
-	 *
 	 * @return array
 	 */
-	private function get_query_args( $course_enrolment ) {
+	private function get_query_args() {
 		$user_args = [
 			'fields'  => 'ID',
 			'number'  => $this->batch_size,
 			'orderby' => 'ID',
 			'order'   => 'ASC',
-		];
-
-		$meta_key = $course_enrolment->get_enrolment_results_meta_key();
-
-		// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Ran inside of async job.
-		$user_args['meta_query'] = [
-			'relation' => 'OR',
-			[
-				'key'   => $meta_key,
-				'value' => '',
-			],
-			[
-				'key'     => $meta_key,
-				'compare' => 'NOT EXISTS',
-			],
 		];
 
 		return $user_args;

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -430,9 +430,6 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 		$job = $course_enrolment->recalculate_enrolment();
 		wp_cache_flush();
 
-		foreach ( $all_user_ids as $user_id ) {
-			$this->assertEquals( '', get_user_meta( $user_id, $course_enrolment->get_enrolment_results_meta_key(), true ), 'All users should have an enrolment result invalidated' );
-		}
 		$this->assertNotEquals( $course_enrolment->get_course_enrolment_salt(), $course_salt, 'The course salt should have been reset' );
 
 		$this->assertTrue( $job instanceof Sensei_Enrolment_Course_Calculation_Job, 'Returned job should be an instance of Sensei_Enrolment_Course_Calculation_Job' );

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-course-calculation-job.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-course-calculation-job.php
@@ -137,20 +137,7 @@ class Sensei_Enrolment_Course_Calculation_Job_Test extends WP_UnitTestCase {
 	 * @param Sensei_Course_Enrolment $course_enrolment
 	 */
 	private function invalidateAllCourseResults( $course_enrolment ) {
-		$method = new ReflectionMethod( Sensei_Course_Enrolment::class, 'invalidate_all_learner_results' );
-		$method->setAccessible( true );
-		$method->invoke( $course_enrolment );
+		$course_enrolment->reset_course_enrolment_salt();
 		wp_cache_flush();
-	}
-
-	/**
-	 * Invalidate enrolled user course enrolment results.
-	 *
-	 * @param Sensei_Course_Enrolment $course_enrolment
-	 */
-	private function invalidateEnrolledCourseResults( $course_enrolment ) {
-		$method = new ReflectionMethod( Sensei_Course_Enrolment::class, 'invalidate_enrolled_learner_results' );
-		$method->setAccessible( true );
-		$method->invoke( $course_enrolment );
 	}
 }


### PR DESCRIPTION
Fixes #3169

### Changes proposed in this Pull Request

* Removes the bulk `UPDATE` invalidation when course results need updating. This wasn't actually doing anything because the course salt reset will cause invalidation on its own. I think it would have caused chaos on large network sites.

### Testing instructions

* Unpublish a course. Verify (after the background job runs) that all learner terms are removed for that course.
* Publish a course. Verify (after the background job runs) that all appropriate learner terms are added back. 