### PR TITLE
Add Import base UI

### DIFF
--- a/assets/data-port/import.jsx
+++ b/assets/data-port/import.jsx
@@ -32,10 +32,16 @@ const SenseiImportPage = () => {
 	return (
 		<div className="sensei-import-wrapper">
 			<DataPortStepper steps={ steps } />
-			<button onClick={ () => dispatch( { type: 'MOVE_TO_NEXT'} ) }>Move to next step!</button>
-			<button onClick={ () => dispatch( { type: 'COMPLETE_CURRENT'} ) }>Complete current!</button>
+			<button onClick={ () => dispatch( { type: 'MOVE_TO_NEXT' } ) }>
+				Move to next step!
+			</button>
+			<button onClick={ () => dispatch( { type: 'COMPLETE_CURRENT' } ) }>
+				Complete current!
+			</button>
 			{ /* eslint-disable-next-line no-console */ }
-			<button onClick={ () => console.log( getCurrentStep( steps ) ) }>Check current step!</button>
+			<button onClick={ () => console.log( getCurrentStep( steps ) ) }>
+				Check current step!
+			</button>
 		</div>
 	);
 };

--- a/assets/data-port/import.jsx
+++ b/assets/data-port/import.jsx
@@ -1,0 +1,64 @@
+import { __ } from '@wordpress/i18n';
+import { render, useState } from '@wordpress/element';
+import DataPortStepper from './stepper';
+
+const initialSteps = [
+	{
+		key: 'upload',
+		description: __( 'Upload CSV Files' ),
+		isActive: true,
+		isComplete: false,
+	},
+	{
+		key: 'import',
+		description: __( 'Import' ),
+		isActive: false,
+		isComplete: false,
+	},
+	{
+		key: 'completed',
+		description: __( 'Done' ),
+		isActive: false,
+		isComplete: false,
+	}
+];
+
+
+
+/**
+ * Sensei onboarding page.
+ */
+const SenseiImportPage = () => {
+	const [ steps, setSteps ] = useState( initialSteps );
+
+	function moveToNext() {
+		const newSteps = [ ...steps ];
+
+		for ( let i = 0; i < newSteps.length; i++ ) {
+			if ( ! newSteps[i].isComplete ) {
+				newSteps[i].isComplete = true;
+				newSteps[i].isActive = false;
+
+				if ( i + 1 < newSteps.length ) {
+					newSteps[ i + 1 ].isActive = true;
+				}
+
+				setSteps( newSteps );
+				return;
+			}
+		}
+	}
+
+	return (
+		<div className='sensei-import-wrapper'>
+			<DataPortStepper
+				steps={ steps }
+			/>
+			<button onClick={ moveToNext }>
+				Try me!
+			</button>
+		</div>
+	);
+};
+
+render( <SenseiImportPage />, document.getElementById( 'sensei-import-page' ) );

--- a/assets/data-port/import.jsx
+++ b/assets/data-port/import.jsx
@@ -5,25 +5,23 @@ import DataPortStepper from './stepper';
 const initialSteps = [
 	{
 		key: 'upload',
-		description: __( 'Upload CSV Files' ),
+		description: __( 'Upload CSV Files', 'sensei-lms' ),
 		isActive: true,
 		isComplete: false,
 	},
 	{
 		key: 'import',
-		description: __( 'Import' ),
+		description: __( 'Import', 'sensei-lms' ),
 		isActive: false,
 		isComplete: false,
 	},
 	{
 		key: 'completed',
-		description: __( 'Done' ),
+		description: __( 'Done', 'sensei-lms' ),
 		isActive: false,
 		isComplete: false,
-	}
+	},
 ];
-
-
 
 /**
  * Sensei onboarding page.
@@ -35,9 +33,9 @@ const SenseiImportPage = () => {
 		const newSteps = [ ...steps ];
 
 		for ( let i = 0; i < newSteps.length; i++ ) {
-			if ( ! newSteps[i].isComplete ) {
-				newSteps[i].isComplete = true;
-				newSteps[i].isActive = false;
+			if ( ! newSteps[ i ].isComplete ) {
+				newSteps[ i ].isComplete = true;
+				newSteps[ i ].isActive = false;
 
 				if ( i + 1 < newSteps.length ) {
 					newSteps[ i + 1 ].isActive = true;
@@ -50,13 +48,9 @@ const SenseiImportPage = () => {
 	}
 
 	return (
-		<div className='sensei-import-wrapper'>
-			<DataPortStepper
-				steps={ steps }
-			/>
-			<button onClick={ moveToNext }>
-				Try me!
-			</button>
+		<div className="sensei-import-wrapper">
+			<DataPortStepper steps={ steps } />
+			<button onClick={ moveToNext }>Try me!</button>
 		</div>
 	);
 };

--- a/assets/data-port/import.jsx
+++ b/assets/data-port/import.jsx
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
-import { render, useState } from '@wordpress/element';
-import DataPortStepper from './stepper';
+import { render, useReducer } from '@wordpress/element';
+import { DataPortStepper, stepsReducer, getCurrentStep } from './stepper';
 
 const initialSteps = [
 	{
@@ -27,30 +27,15 @@ const initialSteps = [
  * Sensei onboarding page.
  */
 const SenseiImportPage = () => {
-	const [ steps, setSteps ] = useState( initialSteps );
-
-	function moveToNext() {
-		const newSteps = [ ...steps ];
-
-		for ( let i = 0; i < newSteps.length; i++ ) {
-			if ( ! newSteps[ i ].isComplete ) {
-				newSteps[ i ].isComplete = true;
-				newSteps[ i ].isActive = false;
-
-				if ( i + 1 < newSteps.length ) {
-					newSteps[ i + 1 ].isActive = true;
-				}
-
-				setSteps( newSteps );
-				return;
-			}
-		}
-	}
+	const [ steps, dispatch ] = useReducer( stepsReducer, initialSteps );
 
 	return (
 		<div className="sensei-import-wrapper">
 			<DataPortStepper steps={ steps } />
-			<button onClick={ moveToNext }>Try me!</button>
+			<button onClick={ () => dispatch( { type: 'MOVE_TO_NEXT'} ) }>Move to next step!</button>
+			<button onClick={ () => dispatch( { type: 'COMPLETE_CURRENT'} ) }>Complete current!</button>
+			{ /* eslint-disable-next-line no-console */ }
+			<button onClick={ () => console.log( getCurrentStep( steps ) ) }>Check current step!</button>
 		</div>
 	);
 };

--- a/assets/data-port/stepper/index.jsx
+++ b/assets/data-port/stepper/index.jsx
@@ -1,6 +1,76 @@
 import classnames from 'classnames';
 
 /**
+ * Helper method to update the steps when moving to the next one.
+ *
+ * @param  {Array} steps  The current steps.
+ * @return {Array}        The steps after moving.
+ */
+const moveToNext = ( steps ) => {
+	const newSteps = [ ...steps ];
+
+	for ( let i = 0; i < newSteps.length; i++ ) {
+		if ( newSteps[ i ].isActive ) {
+			newSteps[ i ].isComplete = true;
+
+			if ( i + 1 < newSteps.length ) {
+				newSteps[ i + 1 ].isActive = true;
+				newSteps[ i ].isActive = false;
+			}
+
+			return newSteps;
+		}
+	}
+
+	throw new Error( 'No active step.' );
+};
+
+/**
+ * Helper method to update the steps when the active step is completed.
+ *
+ * @param  {Array} steps  The current steps.
+ * @return {Array}        The steps after completing the current one.
+ */
+const completeCurrentStep = ( steps ) => {
+	const newSteps = steps.map( ( step ) => {
+		if ( step.isActive ) {
+			step.isComplete = true;
+		}
+
+		return step;
+	} );
+
+	return newSteps;
+};
+
+/**
+ * Get the key of the current active step.
+ *
+ * @param  {Array} steps  The current steps.
+ * @return {string}       The key of the active step.
+ */
+const getCurrentStep = ( steps ) => {
+	for ( const step of steps ) {
+		if ( step.isActive ) {
+			return step.key;
+		}
+	}
+
+	throw new Error( 'No active step.' );
+};
+
+const stepsReducer = ( state, action ) => {
+	switch ( action.type ) {
+		case 'MOVE_TO_NEXT':
+			return moveToNext( state );
+		case 'COMPLETE_CURRENT':
+			return completeCurrentStep( state );
+		default:
+			throw new Error( `Unknown action ${ action.type }.`);
+	}
+};
+
+/**
  * A simple component to display a stepper on data port pages.
  *
  * @param {Array} steps The array of the steps.
@@ -24,4 +94,4 @@ const DataPortStepper = ( { steps } ) => {
 	);
 };
 
-export default DataPortStepper;
+export { DataPortStepper, getCurrentStep, stepsReducer };

--- a/assets/data-port/stepper/index.jsx
+++ b/assets/data-port/stepper/index.jsx
@@ -50,10 +50,10 @@ const completeCurrentStep = ( steps ) => {
  * @return {string}       The key of the active step.
  */
 const getCurrentStep = ( steps ) => {
-	for ( const step of steps ) {
-		if ( step.isActive ) {
-			return step.key;
-		}
+	const currentStep = steps.find( ( step ) => step.isActive );
+
+	if ( currentStep ) {
+		return currentStep.key;
 	}
 
 	throw new Error( 'No active step.' );
@@ -71,16 +71,16 @@ const stepsReducer = ( state, action ) => {
 };
 
 /**
- * @typedef  {Object} Step
- * @property {string} key          Unique key for the step.
- * @property {string} description  A description of the step that is going to be displayed.
- * @property {string} isActive     True if the step is the currently active one.
- * @property {string} isComplete   True if the step is completed.
+ * @typedef  {Object}   Step
+ * @property {string}   key          Unique key for the step.
+ * @property {string}   description  A description of the step that is going to be displayed.
+ * @property {boolean}  isActive     True if the step is the currently active one.
+ * @property {boolean}  isComplete   True if the step is completed.
  */
 /**
  * A simple component to display a stepper on data port pages.
  *
- * @param {Array} steps The array of the steps.
+ * @param {Step[]} steps The array of the steps.
  */
 const DataPortStepper = ( { steps } ) => (
 	<ol className="sensei-progress-steps">

--- a/assets/data-port/stepper/index.jsx
+++ b/assets/data-port/stepper/index.jsx
@@ -1,0 +1,29 @@
+import classnames from 'classnames';
+
+/**
+ * A simple component to display a stepper on data port pages.
+ *
+ * @param {array} steps The array of the steps.
+ */
+const DataPortStepper = ( { steps } ) => {
+	return(
+		<ol className='sensei-progress-steps'>
+			{
+				steps.map( ( step ) => {
+					let stepClass = classnames( {
+						active: step.isActive,
+						done: step.isComplete,
+					});
+
+					return (
+						<li className={ stepClass}>
+							{ step.description }
+						</li>
+					);
+				} )
+			}
+		</ol>
+	);
+}
+
+export default DataPortStepper;

--- a/assets/data-port/stepper/index.jsx
+++ b/assets/data-port/stepper/index.jsx
@@ -3,27 +3,25 @@ import classnames from 'classnames';
 /**
  * A simple component to display a stepper on data port pages.
  *
- * @param {array} steps The array of the steps.
+ * @param {Array} steps The array of the steps.
  */
 const DataPortStepper = ( { steps } ) => {
-	return(
-		<ol className='sensei-progress-steps'>
-			{
-				steps.map( ( step ) => {
-					let stepClass = classnames( {
-						active: step.isActive,
-						done: step.isComplete,
-					});
+	return (
+		<ol className="sensei-progress-steps">
+			{ steps.map( ( step ) => {
+				const stepClass = classnames( {
+					active: step.isActive,
+					done: step.isComplete,
+				} );
 
-					return (
-						<li className={ stepClass}>
-							{ step.description }
-						</li>
-					);
-				} )
-			}
+				return (
+					<li key={ step.key } className={ stepClass }>
+						{ step.description }
+					</li>
+				);
+			} ) }
 		</ol>
 	);
-}
+};
 
 export default DataPortStepper;

--- a/assets/data-port/stepper/index.jsx
+++ b/assets/data-port/stepper/index.jsx
@@ -11,11 +11,11 @@ const moveToNext = ( steps ) => {
 
 	for ( let i = 0; i < newSteps.length; i++ ) {
 		if ( newSteps[ i ].isActive ) {
-			newSteps[ i ].isComplete = true;
+			newSteps[ i ] = { ...newSteps[ i ], isComplete: true };
 
 			if ( i + 1 < newSteps.length ) {
-				newSteps[ i + 1 ].isActive = true;
-				newSteps[ i ].isActive = false;
+				newSteps[ i + 1 ] = { ...newSteps[ i + 1 ], isActive: true };
+				newSteps[ i ] = { ...newSteps[ i ], isActive: false };
 			}
 
 			return newSteps;
@@ -34,7 +34,7 @@ const moveToNext = ( steps ) => {
 const completeCurrentStep = ( steps ) =>
 	steps.map( ( step ) => {
 		if ( step.isActive ) {
-			step.isComplete = true;
+			return { ...step, isComplete: true };
 		}
 
 		return step;

--- a/assets/data-port/stepper/index.jsx
+++ b/assets/data-port/stepper/index.jsx
@@ -66,32 +66,37 @@ const stepsReducer = ( state, action ) => {
 		case 'COMPLETE_CURRENT':
 			return completeCurrentStep( state );
 		default:
-			throw new Error( `Unknown action ${ action.type }.`);
+			throw new Error( `Unknown action ${ action.type }.` );
 	}
 };
 
+/**
+ * @typedef  {Object} Step
+ * @property {string} key          Unique key for the step.
+ * @property {string} description  A description of the step that is going to be displayed.
+ * @property {string} isActive     True if the step is the currently active one.
+ * @property {string} isComplete   True if the step is completed.
+ */
 /**
  * A simple component to display a stepper on data port pages.
  *
  * @param {Array} steps The array of the steps.
  */
-const DataPortStepper = ( { steps } ) => {
-	return (
-		<ol className="sensei-progress-steps">
-			{ steps.map( ( step ) => {
-				const stepClass = classnames( {
-					active: step.isActive,
-					done: step.isComplete,
-				} );
+const DataPortStepper = ( { steps } ) => (
+	<ol className="sensei-progress-steps">
+		{ steps.map( ( step ) => {
+			const stepClass = classnames( {
+				active: step.isActive,
+				done: step.isComplete,
+			} );
 
-				return (
-					<li key={ step.key } className={ stepClass }>
-						{ step.description }
-					</li>
-				);
-			} ) }
-		</ol>
-	);
-};
+			return (
+				<li key={ step.key } className={ stepClass }>
+					{ step.description }
+				</li>
+			);
+		} ) }
+	</ol>
+);
 
 export { DataPortStepper, getCurrentStep, stepsReducer };

--- a/assets/data-port/stepper/index.jsx
+++ b/assets/data-port/stepper/index.jsx
@@ -31,17 +31,14 @@ const moveToNext = ( steps ) => {
  * @param  {Array} steps  The current steps.
  * @return {Array}        The steps after completing the current one.
  */
-const completeCurrentStep = ( steps ) => {
-	const newSteps = steps.map( ( step ) => {
+const completeCurrentStep = ( steps ) =>
+	steps.map( ( step ) => {
 		if ( step.isActive ) {
 			step.isComplete = true;
 		}
 
 		return step;
 	} );
-
-	return newSteps;
-};
 
 /**
  * Get the key of the current active step.

--- a/assets/data-port/style.scss
+++ b/assets/data-port/style.scss
@@ -1,0 +1,63 @@
+$primary: #32af7d;
+
+.sensei-import-wrapper {
+	text-align: center;
+	max-width: 700px;
+	margin: 40px auto;
+
+	.sensei-progress-steps {
+		padding: 0 0 24px;
+		margin: 0;
+		list-style: none outside;
+		overflow: hidden;
+		color: #ccc;
+		width: 100%;
+		display: -webkit-inline-flex;
+		display: -ms-inline-flexbox;
+		display: inline-flex;
+
+		li {
+			width: 25%;
+			float: left;
+			padding: 0 0 0.8em;
+			margin: 0;
+			text-align: center;
+			position: relative;
+			border-bottom: 4px solid #ccc;
+			line-height: 1.4em;
+		}
+
+		li::before {
+			content: "";
+			border: 4px solid #ccc;
+			border-radius: 100%;
+			width: 4px;
+			height: 4px;
+			position: absolute;
+			bottom: 0;
+			left: 50%;
+			margin-left: -6px;
+			margin-bottom: -8px;
+			background: #fff;
+		}
+
+		li.active {
+			border-color: $primary;
+			color: $primary;
+
+			&::before {
+				border-color: $primary;
+			}
+		}
+
+		li.done {
+			border-color: $primary;
+			color: $primary;
+
+			&::before {
+				border-color: $primary;
+				background: $primary;
+			}
+		}
+	}
+}

--- a/includes/class-sensei-autoloader-bundle.php
+++ b/includes/class-sensei-autoloader-bundle.php
@@ -40,8 +40,8 @@ class Sensei_Autoloader_Bundle {
 
 		// Check for file in the main includes directory.
 		$class_file_path = $this->include_path . 'class-' . str_replace( '_', '-', strtolower( $class ) ) . '.php';
-		if ( file_exists( $class_file_path ) ) {
 
+		if ( file_exists( $class_file_path ) ) {
 			require_once $class_file_path;
 			return true;
 		}
@@ -49,8 +49,8 @@ class Sensei_Autoloader_Bundle {
 		// Lastly check legacy types.
 		$stripped_woothemes_from_class = str_replace( 'woothemes_', '', strtolower( $class ) ); // Remove woothemes.
 		$legacy_class_file_path        = $this->include_path . 'class-' . str_replace( '_', '-', strtolower( $stripped_woothemes_from_class ) ) . '.php';
-		if ( file_exists( $legacy_class_file_path ) ) {
 
+		if ( file_exists( $legacy_class_file_path ) ) {
 			require_once $legacy_class_file_path;
 			return true;
 		}

--- a/includes/class-sensei-autoloader-bundle.php
+++ b/includes/class-sensei-autoloader-bundle.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * File containing the class Sensei_Autoloader_Bundle.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // security check, don't load file outside WP.
+}
+
+/**
+ * A Sensei_Autoloader_Bundle is a directory of which all classes are going to be loaded.
+ */
+class Sensei_Autoloader_Bundle {
+	/**
+	 * Path to the includes directory within Sensei.
+	 *
+	 * @var string
+	 */
+	private $include_path;
+
+	/**
+	 * Sensei_Autoloader_Bundle constructor.
+	 *
+	 * @param string $bundle_identifier_path  Path relative to includes.
+	 */
+	public function __construct( $bundle_identifier_path = '' ) {
+		// Setup a relative path for the current autoload instance.
+		$this->include_path = trailingslashit( trailingslashit( untrailingslashit( __DIR__ ) ) . $bundle_identifier_path );
+	}
+
+	/**
+	 * Load a class of bundle.
+	 *
+	 * @param string $class The class name.
+	 * @return bool
+	 */
+	public function load_class( $class ) {
+
+		// Check for file in the main includes directory.
+		$class_file_path = $this->include_path . 'class-' . str_replace( '_', '-', strtolower( $class ) ) . '.php';
+		if ( file_exists( $class_file_path ) ) {
+
+			require_once $class_file_path;
+			return true;
+		}
+
+		// Lastly check legacy types.
+		$stripped_woothemes_from_class = str_replace( 'woothemes_', '', strtolower( $class ) ); // Remove woothemes.
+		$legacy_class_file_path        = $this->include_path . 'class-' . str_replace( '_', '-', strtolower( $stripped_woothemes_from_class ) ) . '.php';
+		if ( file_exists( $legacy_class_file_path ) ) {
+
+			require_once $legacy_class_file_path;
+			return true;
+		}
+
+		return false;
+
+	}
+}

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -1,50 +1,12 @@
 <?php
+/**
+ * File containing the class Sensei_Autoloader.
+ *
+ * @package sensei
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // security check, don't load file outside WP
-}
-
-class Sensei_Autoloader_Bundle {
-	/**
-	 * @var path to the includes directory within Sensei.
-	 */
-	private $include_path = 'includes';
-
-	/**
-	 * Sensei_Autoloader_Bundle constructor.
-	 *
-	 * @param string $namespace_path path relative to includes
-	 */
-	public function __construct( $bundle_identifier_path = '' ) {
-		// setup a relative path for the current autoload instance
-		$this->include_path = trailingslashit( trailingslashit( untrailingslashit( dirname( __FILE__ ) ) ) . $bundle_identifier_path );
-	}
-
-	/**
-	 * @param $class string
-	 * @return bool
-	 */
-	public function load_class( $class ) {
-
-		// check for file in the main includes directory
-		$class_file_path = $this->include_path . 'class-' . str_replace( '_', '-', strtolower( $class ) ) . '.php';
-		if ( file_exists( $class_file_path ) ) {
-
-			require_once $class_file_path;
-			return true;
-		}
-
-		// lastly check legacy types
-		$stripped_woothemes_from_class = str_replace( 'woothemes_', '', strtolower( $class ) ); // remove woothemes
-		$legacy_class_file_path        = $this->include_path . 'class-' . str_replace( '_', '-', strtolower( $stripped_woothemes_from_class ) ) . '.php';
-		if ( file_exists( $legacy_class_file_path ) ) {
-
-			require_once $legacy_class_file_path;
-			return true;
-		}
-
-		return false;
-
-	}//end load_class()
+	exit; // security check, don't load file outside WP.
 }
 
 /**
@@ -59,16 +21,25 @@ class Sensei_Autoloader_Bundle {
 class Sensei_Autoloader {
 
 	/**
-	 * @var path to the includes directory within Sensei.
+	 * Path to the includes directory within Sensei.
+	 *
+	 * @var string
 	 */
 	private $include_path = 'includes';
 
 	/**
-	 * @var array $class_file_map. List of classes mapped to their files
+	 * List of classes mapped to their files.
+	 *
+	 * @var array
 	 */
-	private $class_file_map = array();
+	private $class_file_map;
 
-	private $autoloader_bundles = array();
+	/**
+	 * An array of bundle directories to be loaded.
+	 *
+	 * @var array
+	 */
+	private $autoloader_bundles;
 
 	/**
 	 * Constructor
@@ -77,16 +48,18 @@ class Sensei_Autoloader {
 	 */
 	public function __construct() {
 
-		// make sure we do not override an existing autoload function
+		// Make sure we do not override an existing autoload function.
 		if ( function_exists( '__autoload' ) ) {
 			spl_autoload_register( '__autoload' );
 		}
 
-		// setup a relative path for the current autoload instance
-		$this->include_path = trailingslashit( untrailingslashit( dirname( __FILE__ ) ) );
+		// Setup a relative path for the current autoload instance.
+		$this->include_path = trailingslashit( untrailingslashit( __DIR__ ) );
 
-		// setup the class file map
+		// Setup the class file map.
 		$this->initialize_class_file_map();
+
+		require_once __DIR__ . '/class-sensei-autoloader-bundle.php';
 
 		$this->autoloader_bundles = array(
 			new Sensei_Autoloader_Bundle( 'rest-api' ),
@@ -101,7 +74,7 @@ class Sensei_Autoloader {
 			$this->autoloader_bundles[] = new Sensei_Autoloader_Bundle( 'data-port' );
 		}
 
-		// add Sensei custom auto loader
+		// Add Sensei custom auto loader.
 		spl_autoload_register( array( $this, 'autoload' ) );
 
 	}
@@ -193,17 +166,19 @@ class Sensei_Autoloader {
 
 	/**
 	 * Autoload all sensei files as the class names are used.
+	 *
+	 * @param string $class The class name.
 	 */
 	public function autoload( $class ) {
 
-		// only handle classes with the word `sensei` in it
+		// Only handle classes with the word `sensei` in it.
 		if ( ! is_numeric( strpos( strtolower( $class ), 'sensei' ) ) ) {
 
 			return;
 
 		}
 
-		// exit if we didn't provide mapping for this class
+		// Exit if we didn't provide mapping for this class.
 		if ( isset( $this->class_file_map[ $class ] ) ) {
 
 			$file_location = $this->include_path . $this->class_file_map[ $class ];
@@ -217,9 +192,5 @@ class Sensei_Autoloader {
 				return;
 			}
 		}
-
-		return;
-
-	}//end autoload()
-
+	}
 }

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -97,6 +97,10 @@ class Sensei_Autoloader {
 			new Sensei_Autoloader_Bundle( 'data-port' ),
 		);
 
+		if ( is_admin() ) {
+			$this->autoloader_bundles[] = new Sensei_Autoloader_Bundle( 'data-port' );
+		}
+
 		// add Sensei custom auto loader
 		spl_autoload_register( array( $this, 'autoload' ) );
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -406,6 +406,8 @@ class Sensei_Main {
 			// Load Analysis Reports
 			$this->analysis = new Sensei_Analysis( $this->main_plugin_file_name );
 
+			new Sensei_Import();
+
 			if ( $this->feature_flags->is_enabled( 'rest_api_testharness' ) ) {
 				$this->test_harness = new Sensei_Admin_Rest_Api_Testharness( $this->main_plugin_file_name );
 			}

--- a/includes/data-port/class-sensei-import.php
+++ b/includes/data-port/class-sensei-import.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * File containing the class Sensei_Import.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * This class is responsible for displaying the import page in admin.
+ */
+class Sensei_Import {
+
+	/**
+	 * URL Slug for Import page
+	 *
+	 * @var string
+	 */
+	public $page_slug;
+
+	/**
+	 * Sensei_Import constructor.
+	 */
+	public function __construct() {
+
+		$this->page_slug = 'sensei_import';
+
+		add_action( 'admin_menu', [ $this, 'admin_menu' ], 20 );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
+		if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
+
+			add_action(
+				'admin_print_scripts',
+				function() {
+					Sensei()->assets->enqueue( 'sensei-import', 'data-port/import.js', [], true );
+				}
+			);
+
+			add_action(
+				'admin_print_styles',
+				function() {
+					Sensei()->assets->enqueue( 'sensei-import', 'data-port/style.css', [ 'wp-components' ] );
+				}
+			);
+		}
+	}
+
+	/**
+	 * Register an import submenu.
+	 */
+	public function admin_menu() {
+		if ( current_user_can( 'manage_sensei' ) ) {
+			add_submenu_page(
+				'sensei',
+				__( 'Import', 'sensei-lms' ),
+				__( 'Import', 'sensei-lms' ),
+				'manage_sensei',
+				$this->page_slug,
+				[ $this, 'import_page' ]
+			);
+		}
+	}
+
+	/**
+	 * Render app container for import page.
+	 */
+	public function import_page() {
+
+		?>
+		<div id="sensei-import-page" class="sensei-import">
+
+		</div>
+		<?php
+	}
+
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,8 @@ const files = [
 	'js/user-dashboard.js',
 	'onboarding/index.jsx',
 	'onboarding/style.scss',
+	'data-port/import.jsx',
+	'data-port/style.scss',
 
 	'css/frontend/sensei.scss',
 	'css/admin-custom.css',


### PR DESCRIPTION
Original PR: #3180 by @gkaragia 
Reviews from @renatho 
Accidentally closed by myself when renaming the base class 😢 

-----------
### Changes proposed in this Pull Request

* Adds the page and the stepper for the importer
* All CSS was taken from [here](https://github.com/woocommerce/woocommerce/blob/master/assets/css/admin.scss#L6894)
* I defined our own stepper component as it seems that for importer/exporter the stepper is going to be much lighter than the `@woocommerce/components` one and wanted to avoid the extra complexity.

### Testing instructions

* Navigate to Sensei LMS > Import and click the buttons to test the stepper.
