### PR TITLE
Add pre-commit hook to lint only newer PHP files

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
     "*.{js,jsx}": [
       "npm run format-js",
       "wp-scripts lint-js"
+    ],
+    "*.php": [
+      "scripts/linter-new-php"
     ]
   }
 }

--- a/scripts/linter-new-php
+++ b/scripts/linter-new-php
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+created=`git log --diff-filter=A --follow --format=%at -- "$1" | tail -1`
+
+# Created after 2020-01-01
+if [[ $created > 1577833200 ]] ;
+then
+    echo "Linting $1"
+    ./vendor/bin/phpcs -q $1
+else
+  echo "Skipping linting for $1"
+  exit 0
+fi


### PR DESCRIPTION

Had an idea after #3116 that we could run PHPCS in pre-commit hooks only for files added to git after a certain date. This is easier to run locally than the `linter-ci` script but still allows not cleaning up older files. 

### Changes proposed in this Pull Request

* Run PHPCS linting on pre-commit hook for `.php` files added after `2020-01-01`

### Testing instructions

* Try to commit a bad change in a new file, like `includes/admin/class-sensei-onboarding.php`
* Should be blocked with lint errors
* Try to commit a change in an older file like `includes/class-sensei-admin.php`
* It shall pass
* Revert that commit :) 
