### PR TITLE
REST API: Add file upload/delete for importer

### DIFF
--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -410,8 +410,16 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 		}
 
 		$file_configs = static::get_file_config();
-		$file_config  = $file_configs[ $file_key ];
-		$mime_types   = isset( $file_config['mime_types'] ) ? $file_config['mime_types'] : null;
+
+		if ( ! isset( $file_configs[ $file_key ] ) ) {
+			return new WP_Error(
+				'sensei_data_port_unknown_file_key',
+				__( 'Unexpected file key used.', 'sensei-lms' )
+			);
+		}
+
+		$file_config = $file_configs[ $file_key ];
+		$mime_types  = isset( $file_config['mime_types'] ) ? $file_config['mime_types'] : null;
 
 		$file_save_url = $uploads['url'] . "/$filename";
 		$wp_filetype   = wp_check_filetype_and_ext( $file_save_path, $file_name, $mime_types );

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -89,6 +89,17 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	private $percentage;
 
 	/**
+	 * Files that have been saved and associated with this job.
+	 *
+	 * @var array {
+	 *     File attachment IDs indexed with the file key.
+	 *
+	 *     @type int $$file_key Attachment post ID.
+	 * }
+	 */
+	private $files;
+
+	/**
 	 * Sensei_Data_Port_Job constructor. A data port instance can be created either when a new data port job is
 	 * registered or when an existing one is restored from a JSON string.
 	 *
@@ -106,6 +117,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 		} else {
 			$this->logs         = [];
 			$this->results      = [];
+			$this->files        = [];
 			$this->is_completed = false;
 			$this->is_started   = false;
 			$this->has_changed  = true;
@@ -194,6 +206,10 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 			$task->clean_up();
 		}
 
+		foreach ( array_keys( $this->files ) as $file_key ) {
+			$this->delete_file( $file_key );
+		}
+
 		$this->is_deleted = true;
 		delete_option( self::get_option_name( $this->job_id ) );
 	}
@@ -232,6 +248,31 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	abstract public function get_tasks();
 
 	/**
+	 * Get the configuration for expected files.
+	 *
+	 * @return array {
+	 *    @type array $$component {
+	 *        @type callable $validator  Callback to handle validating the file before save (optional).
+	 *        @type array    $mime_types Expected mime-types for the file.
+	 *    }
+	 * }
+	 */
+	abstract public static function get_file_config();
+
+	/**
+	 * Initialize and restore state of task.
+	 *
+	 * @param string $task_class Class name of task class.
+	 *
+	 * @return Sensei_Data_Port_Task_Interface
+	 */
+	protected function initialize_task( $task_class ) {
+		// @todo Implement restoring of task state.
+
+		return new $task_class( $this );
+	}
+
+	/**
 	 * Serialize state to JSON.
 	 *
 	 * @return array
@@ -244,6 +285,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 			'c' => $this->is_completed,
 			'i' => $this->is_started,
 			'p' => $this->percentage,
+			'f' => $this->files,
 		];
 	}
 
@@ -265,6 +307,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 		$this->is_completed = $json_arr['c'];
 		$this->is_started   = $json_arr['i'];
 		$this->percentage   = $json_arr['p'];
+		$this->files        = $json_arr['f'];
 	}
 
 	/**
@@ -334,6 +377,162 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 		} else {
 			$this->percentage = 100 * $completed_cycles / $total_cycles;
 		}
+	}
+
+	/**
+	 * Save a file associated with this job.
+	 *
+	 * @param string       $file_key Key for the file being saved.
+	 * @param string|array $tmp_file Temporary path where the file is stored or array from `$_FILES`.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function save_file( $file_key, $tmp_file ) {
+		$file_configs = static::get_file_config();
+
+		if ( ! isset( $file_configs[ $file_key ] ) ) {
+			return new WP_Error( 'sensei_data_port_unknown_file_key', __( 'Unexpected file key used', 'sensei-lms' ) );
+		}
+
+		// Include filesystem functions to get access to wp_handle_upload().
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+
+		if ( is_array( $tmp_file ) ) {
+			if ( ! isset( $tmp_file['tmp_name'], $tmp_file['name'], $tmp_file['type'] ) ) {
+				return new WP_Error( 'sensei_data_port_unexpected_file_input', __( 'Unexpected file passed for saving', 'sensei-lms' ) );
+			}
+
+			$tmp_file_path = $tmp_file['tmp_name'];
+		} else {
+			$tmp_file_path = $tmp_file;
+			$tmp_file      = [
+				'name'     => basename( $tmp_file_path ),
+				'type'     => wp_check_filetype_and_ext( $tmp_file_path, basename( $tmp_file_path ) ),
+				'tmp_name' => $tmp_file_path,
+				'size'     => filesize( $tmp_file_path ),
+				'error'    => UPLOAD_ERR_OK,
+			];
+		}
+
+		if (
+			! file_exists( $tmp_file_path )
+			|| ( isset( $tmp_file['error'] ) && UPLOAD_ERR_OK !== $tmp_file['error'] )
+		) {
+			return new WP_Error( 'sensei_data_port_upload_error', __( 'File upload failed', 'sensei-lms' ) );
+		}
+
+		$file_config = $file_configs[ $file_key ];
+
+		if ( isset( $file_config['validator'] ) ) {
+			$validation_result = call_user_func( $file_config['validator'], $tmp_file_path );
+			if ( is_wp_error( $validation_result ) ) {
+				return $validation_result;
+			}
+		}
+
+		$overrides = [
+			'test_form' => false,
+			'mimes'     => $file_config['mime_types'],
+		];
+
+		$uploaded_file_name = $tmp_file['name'];
+
+		// Make the file path less predictable.
+		$tmp_file['name'] = substr( md5( uniqid() ), 0, 8 ) . '_' . $tmp_file['name'];
+
+		$file = wp_handle_upload( $tmp_file, $overrides );
+		if ( isset( $file['error'] ) ) {
+			return new WP_Error( 'sensei_data_port_file_save_error', $file['error'] );
+		}
+
+		// Construct the object array.
+		$attachment_args = array(
+			'post_title'     => $uploaded_file_name,
+			'post_content'   => $file['url'],
+			'post_mime_type' => $file['type'],
+			'guid'           => $file['url'],
+			'context'        => 'sensei-import',
+			'post_status'    => 'private',
+		);
+
+		// Save the attachment.
+		$id = wp_insert_attachment( $attachment_args, $file['file'] );
+
+		// Make sure to clean up any previous file.
+		if ( isset( $this->files[ $file_key ] ) ) {
+			$this->delete_file( $file_key );
+		}
+
+		$this->files[ $file_key ] = $id;
+		$this->has_changed        = true;
+
+		return true;
+	}
+
+	/**
+	 * Get the files associated with this job.
+	 *
+	 * @return array
+	 */
+	public function get_files() {
+		return $this->files;
+	}
+
+	/**
+	 * Get injectable files data.
+	 *
+	 * @return array
+	 */
+	public function get_files_data() {
+		$data = [];
+		foreach ( $this->files as $file_key => $file_post_id ) {
+			$file = get_post( $file_post_id );
+			if ( ! $file ) {
+				continue;
+			}
+
+			$data[ $file_key ] = [
+				'name' => $file->post_title,
+				'url'  => wp_get_attachment_url( $file_post_id ),
+			];
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Get the file path for the stored file.
+	 *
+	 * @param string $file_key Key for the file being saved.
+	 *
+	 * @return false|string
+	 */
+	public function get_file_path( $file_key ) {
+		if ( ! isset( $this->files[ $file_key ] ) ) {
+			return false;
+		}
+
+		return get_attached_file( $this->files[ $file_key ] );
+	}
+
+	/**
+	 * Delete the attachment and file for an associated file.
+	 *
+	 * @param string $file_key Key for the file being saved.
+	 *
+	 * @return bool
+	 */
+	public function delete_file( $file_key ) {
+		if ( ! isset( $this->files[ $file_key ] ) ) {
+			return false;
+		}
+
+		$file_id = $this->files[ $file_key ];
+
+		unset( $this->files[ $file_key ] );
+		$this->has_changed = true;
+
+		return wp_delete_attachment( $file_id, true );
 	}
 
 	/**

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -508,7 +508,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	private function mime_types_extensions( $mime_types ) {
 		$extensions = [];
 		foreach ( array_keys( $mime_types ) as $ext_list ) {
-			$extensions = array_merge( $extensions, explode( ',', $ext_list ) );
+			$extensions = array_merge( $extensions, explode( '|', $ext_list ) );
 		}
 
 		return array_unique( $extensions );

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -422,7 +422,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 		$file_save_url = $uploads['url'] . "/$filename";
 		$wp_filetype   = wp_check_filetype_and_ext( $file_save_path, $file_name, $mime_types );
 
-		// Construct the object array.
+		// Construct the attachment arguments array.
 		$attachment_args = array(
 			'post_title'     => $file_name,
 			'post_content'   => $file_save_url,

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -390,12 +390,6 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	 * @return true|WP_Error
 	 */
 	public function save_file( $file_key, $tmp_file, $file_name ) {
-		$check_file = $this->check_file( $file_key, $tmp_file, $file_name );
-
-		if ( is_wp_error( $check_file ) ) {
-			return $check_file;
-		}
-
 		// Make the file path less predictable.
 		$stored_file_name = substr( md5( uniqid() ), 0, 8 ) . '_' . $file_name;
 
@@ -444,74 +438,6 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 		$this->has_changed        = true;
 
 		return true;
-	}
-
-	/**
-	 * Check a file before saving it.
-	 *
-	 * @param string $file_key  Key for the file being saved.
-	 * @param string $tmp_file  Temporary path where the file is stored.
-	 * @param string $file_name File name.
-	 *
-	 * @return true|WP_Error
-	 */
-	private function check_file( $file_key, $tmp_file, $file_name ) {
-		$file_configs = static::get_file_config();
-
-		if ( ! isset( $file_configs[ $file_key ] ) ) {
-			return new WP_Error(
-				'sensei_data_port_unknown_file_key',
-				__( 'Unexpected file key used', 'sensei-lms' )
-			);
-		}
-
-		$file_config = $file_configs[ $file_key ];
-
-		if ( isset( $file_config['validator'] ) ) {
-			$validation_result = call_user_func( $file_config['validator'], $tmp_file );
-			if ( is_wp_error( $validation_result ) ) {
-				return $validation_result;
-			}
-		}
-
-		if ( isset( $file_config['mime_types'] ) ) {
-			$wp_filetype = wp_check_filetype_and_ext( $tmp_file, $file_name, $file_config['mime_types'] );
-
-			$valid_mime_type  = $wp_filetype['type'] && in_array( $wp_filetype['type'], $file_config['mime_types'], true );
-			$valid_extensions = $this->mime_types_extensions( $file_config['mime_types'] );
-
-			// If we cannot determine the type, allow check based on extension for administrators.
-			if ( ! $wp_filetype['type'] && current_user_can( 'unfiltered_upload' ) ) {
-				$valid_mime_type = in_array( pathinfo( $file_name, PATHINFO_EXTENSION ), $valid_extensions, true );
-			}
-
-			if ( ! $valid_mime_type ) {
-				return new WP_Error(
-					'sensei_data_port_unexpected_file_type',
-					// translators: Placeholder is list of file extensions.
-					sprintf( __( 'File type is not supported. Must be one of the following: %s', 'sensei-lms' ), implode( ', ', $valid_extensions ) ),
-					[ 'status' => 400 ]
-				);
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * Get an array of extensions.
-	 *
-	 * @param array $mime_types Array of mime types.
-	 *
-	 * @return array Array of valid extensions.
-	 */
-	private function mime_types_extensions( $mime_types ) {
-		$extensions = [];
-		foreach ( array_keys( $mime_types ) as $ext_list ) {
-			$extensions = array_merge( $extensions, explode( '|', $ext_list ) );
-		}
-
-		return array_unique( $extensions );
 	}
 
 	/**

--- a/includes/data-port/class-sensei-data-port-task.php
+++ b/includes/data-port/class-sensei-data-port-task.php
@@ -20,6 +20,11 @@ abstract class Sensei_Data_Port_Task {
 	 */
 	private $job;
 
+	/**
+	 * Sensei_Data_Port_Task constructor.
+	 *
+	 * @param Sensei_Data_Port_Job $job Job object for this task.
+	 */
 	public function __construct( Sensei_Data_Port_Job $job ) {
 		$this->job = $job;
 	}

--- a/includes/data-port/class-sensei-data-port-task.php
+++ b/includes/data-port/class-sensei-data-port-task.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * File containing the Sensei_Data_Port_Task class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * This class has the shared logic for data port tasks..
+ */
+abstract class Sensei_Data_Port_Task {
+	/**
+	 * Data port job for this task.
+	 *
+	 * @var Sensei_Data_Port_Job
+	 */
+	private $job;
+
+	public function __construct( Sensei_Data_Port_Job $job ) {
+		$this->job = $job;
+	}
+
+	/**
+	 * Get the job for this task.
+	 *
+	 * @return Sensei_Data_Port_Job
+	 */
+	public function get_job() {
+		return $this->job;
+	}
+}

--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -30,8 +30,23 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 	 */
 	public function __construct( $job_id, $args = [], $json = '' ) {
 		parent::__construct( $job_id, $args, $json );
+
+		$this->import_task_files();
+
 		// TODO: Generate the tasks from the arguments and/or from the internal state.
-		$this->tasks = [];
+		$this->tasks              = [];
+		$this->tasks['questions'] = $this->initialize_task( Sensei_Import_Questions::class );
+		$this->tasks['lessons']   = $this->initialize_task( Sensei_Import_Lessons::class );
+		$this->tasks['courses']   = $this->initialize_task( Sensei_Import_Courses::class );
+	}
+
+	/**
+	 * Ensure the task files have been included.
+	 */
+	private function import_task_files() {
+		include_once __DIR__ . '/import-tasks/class-sensei-import-questions.php';
+		include_once __DIR__ . '/import-tasks/class-sensei-import-courses.php';
+		include_once __DIR__ . '/import-tasks/class-sensei-import-lessons.php';
 	}
 
 	/**
@@ -43,4 +58,39 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 		return $this->tasks;
 	}
 
+	/**
+	 * Get the configuration for expected files.
+	 *
+	 * @return array {
+	 *    @type array $$component {
+	 *        @type callable $validator  Callback to handle validating the file before save (optional).
+	 *        @type array    $mime_types Expected mime-types for the file.
+	 *    }
+	 * }
+	 */
+	public static function get_file_config() {
+		$files = [];
+
+		$csv_mime_types = [
+			'csv' => 'text/csv',
+			'txt' => 'text/plain',
+		];
+
+		$files['questions'] = [
+			'validator'  => [ Sensei_Import_Questions::class, 'validate_source_file' ],
+			'mime_types' => $csv_mime_types,
+		];
+
+		$files['courses'] = [
+			'validator'  => [ Sensei_Import_Courses::class, 'validate_source_file' ],
+			'mime_types' => $csv_mime_types,
+		];
+
+		$files['lessons'] = [
+			'validator'  => [ Sensei_Import_Lessons::class, 'validate_source_file' ],
+			'mime_types' => $csv_mime_types,
+		];
+
+		return $files;
+	}
 }

--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -129,7 +129,7 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 		if ( ! isset( $file_configs[ $file_key ] ) ) {
 			return new WP_Error(
 				'sensei_data_port_unknown_file_key',
-				__( 'Unexpected file key used', 'sensei-lms' )
+				__( 'Unexpected file key used.', 'sensei-lms' )
 			);
 		}
 
@@ -157,7 +157,7 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 				return new WP_Error(
 					'sensei_data_port_unexpected_file_type',
 					// translators: Placeholder is list of file extensions.
-					sprintf( __( 'File type is not supported. Must be one of the following: %s', 'sensei-lms' ), implode( ', ', $valid_extensions ) ),
+					sprintf( __( 'File type is not supported. Must be one of the following: %s.', 'sensei-lms' ), implode( ', ', $valid_extensions ) ),
 					[ 'status' => 400 ]
 				);
 			}

--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -44,9 +44,9 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 	 * Ensure the task files have been included.
 	 */
 	private function import_task_files() {
-		include_once __DIR__ . '/import-tasks/class-sensei-import-questions.php';
-		include_once __DIR__ . '/import-tasks/class-sensei-import-courses.php';
-		include_once __DIR__ . '/import-tasks/class-sensei-import-lessons.php';
+		require_once __DIR__ . '/import-tasks/class-sensei-import-questions.php';
+		require_once __DIR__ . '/import-tasks/class-sensei-import-courses.php';
+		require_once __DIR__ . '/import-tasks/class-sensei-import-lessons.php';
 	}
 
 	/**

--- a/includes/data-port/import-tasks/class-sensei-import-courses.php
+++ b/includes/data-port/import-tasks/class-sensei-import-courses.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * File containing the Sensei_Import_Courses class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * This class handles the import task for courses.
+ */
+class Sensei_Import_Courses
+	extends Sensei_Data_Port_Task
+	implements Sensei_Data_Port_Task_Interface {
+
+	/**
+	 * Run this task.
+	 */
+	public function run() {
+		// @todo Implement.
+	}
+
+	/**
+	 * Returns true if the task is completed.
+	 *
+	 * @return boolean
+	 */
+	public function is_completed() {
+		// @todo Implement.
+
+		return false;
+	}
+
+	/**
+	 * Returns the completion ratio of this task. The ration has the following format:
+	 *
+	 * {
+	 *
+	 *     @type integer $completed  Number of completed actions.
+	 *     @type integer $total      Number of total actions.
+	 * }
+	 *
+	 * @return array
+	 */
+	public function get_completion_ratio() {
+		// @todo Implement.
+
+		return [
+			'completed' => 0,
+			'total'     => 0,
+		];
+	}
+
+	/**
+	 * Performs any required cleanup of the task.
+	 */
+	public function clean_up() {
+		// @todo Implement.
+	}
+
+	/**
+	 * Validate an uploaded source file before saving it.
+	 *
+	 * @param string $file_path File path of the file to validate.
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function validate_source_file( $file_path ) {
+		// @todo Implement.
+
+		return true;
+	}
+}

--- a/includes/data-port/import-tasks/class-sensei-import-lessons.php
+++ b/includes/data-port/import-tasks/class-sensei-import-lessons.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * File containing the Sensei_Import_Lessons class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * This class handles the import task for lessons.
+ */
+class Sensei_Import_Lessons
+	extends Sensei_Data_Port_Task
+	implements Sensei_Data_Port_Task_Interface {
+
+	/**
+	 * Run this task.
+	 */
+	public function run() {
+		// @todo Implement.
+	}
+
+	/**
+	 * Returns true if the task is completed.
+	 *
+	 * @return boolean
+	 */
+	public function is_completed() {
+		// @todo Implement.
+
+		return false;
+	}
+
+	/**
+	 * Returns the completion ratio of this task. The ration has the following format:
+	 *
+	 * {
+	 *
+	 *     @type integer $completed  Number of completed actions.
+	 *     @type integer $total      Number of total actions.
+	 * }
+	 *
+	 * @return array
+	 */
+	public function get_completion_ratio() {
+		// @todo Implement.
+
+		return [
+			'completed' => 0,
+			'total'     => 0,
+		];
+	}
+
+	/**
+	 * Performs any required cleanup of the task.
+	 */
+	public function clean_up() {
+		// @todo Implement.
+	}
+
+	/**
+	 * Validate an uploaded source file before saving it.
+	 *
+	 * @param string $file_path File path of the file to validate.
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function validate_source_file( $file_path ) {
+		// @todo Implement.
+
+		return true;
+	}
+}

--- a/includes/data-port/import-tasks/class-sensei-import-questions.php
+++ b/includes/data-port/import-tasks/class-sensei-import-questions.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * File containing the Sensei_Import_Questions class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * This class handles the import task for questions.
+ */
+class Sensei_Import_Questions
+	extends Sensei_Data_Port_Task
+	implements Sensei_Data_Port_Task_Interface {
+
+	/**
+	 * Run this task.
+	 */
+	public function run() {
+		// @todo Implement.
+	}
+
+	/**
+	 * Returns true if the task is completed.
+	 *
+	 * @return boolean
+	 */
+	public function is_completed() {
+		// @todo Implement.
+
+		return false;
+	}
+
+	/**
+	 * Returns the completion ratio of this task. The ration has the following format:
+	 *
+	 * {
+	 *
+	 *     @type integer $completed  Number of completed actions.
+	 *     @type integer $total      Number of total actions.
+	 * }
+	 *
+	 * @return array
+	 */
+	public function get_completion_ratio() {
+		// @todo Implement.
+
+		return [
+			'completed' => 0,
+			'total'     => 0,
+		];
+	}
+
+	/**
+	 * Performs any required cleanup of the task.
+	 */
+	public function clean_up() {
+		// @todo Implement.
+	}
+
+	/**
+	 * Validate an uploaded source file before saving it.
+	 *
+	 * @param string $file_path File path of the file to validate.
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function validate_source_file( $file_path ) {
+		// @todo Implement.
+
+		return true;
+	}
+}

--- a/includes/rest-api/class-sensei-rest-api-data-port-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-data-port-controller.php
@@ -50,7 +50,7 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 	abstract protected function create_job();
 
 	/**
-	 * Register the REST API endpoints for the Importer.
+	 * Register the REST API endpoints for the class..
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -177,6 +177,7 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 		return [
 			'id'     => $job->get_job_id(),
 			'status' => $job->get_status(),
+			'files'  => $job->get_files_data(),
 		];
 	}
 
@@ -186,6 +187,27 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 	 * @return array
 	 */
 	public function get_item_schema() {
+		$file_properties = [];
+
+		$handler_class = $this->get_handler_class();
+		$files         = $handler_class::get_file_config();
+
+		foreach ( $files as $file_key => $file_config ) {
+			$file_properties[ $file_key ] = [
+				'type'       => 'object',
+				'properties' => [
+					'name' => [
+						'description' => __( 'File name', 'sensei-lms' ),
+						'type'        => 'string',
+					],
+					'url'  => [
+						'description' => __( 'Direct download URL for the file', 'sensei-lms' ),
+						'type'        => 'string',
+					],
+				],
+			];
+		}
+
 		return [
 			'type'       => 'object',
 			'properties' => [
@@ -198,14 +220,18 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 					'type'       => 'object',
 					'properties' => [
 						'status'     => [
-							'description' => __( 'Status of the job (setup, pending, or complete).', 'sensei-lms' ),
+							'description' => __( 'Status of the job (setup, pending, or complete)', 'sensei-lms' ),
 							'type'        => 'string',
 						],
 						'percentage' => [
-							'description' => __( 'Percent complete.', 'sensei-lms' ),
+							'description' => __( 'Percent complete', 'sensei-lms' ),
 							'type'        => 'integer',
 						],
 					],
+				],
+				'files'  => [
+					'type'       => 'object',
+					'properties' => $file_properties,
 				],
 			],
 		];

--- a/includes/rest-api/class-sensei-rest-api-import-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-import-controller.php
@@ -103,7 +103,7 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 		// Check to make sure the upload succeeded.
 		if (
 			! isset( $files['file']['tmp_name'], $files['file']['error'] )
-			|| ! is_uploaded_file( $files['file']['tmp_name'] )
+			|| ! $this->is_uploaded_file( $files['file']['tmp_name'] )
 			|| UPLOAD_ERR_OK !== $files['file']['error']
 		) {
 			return new WP_Error(
@@ -123,6 +123,23 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 		$response->set_data( $this->prepare_to_serve_job( $job ) );
 
 		return $response;
+	}
+
+	/**
+	 * Check if a file was uploaded.
+	 *
+	 * @param string $filename Temporary file path to check.
+	 *
+	 * @return bool
+	 */
+	private function is_uploaded_file( $filename ) {
+		// Disable this check in tests as it isn't possible to bypass. This is the constant
+		// WordPress core uses to see if we're within tests.
+		if ( defined( 'DIR_TESTDATA' ) && DIR_TESTDATA ) {
+			return true;
+		}
+
+		return is_uploaded_file( $filename );
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-import-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-import-controller.php
@@ -106,10 +106,7 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 			|| ! $this->is_uploaded_file( $files['file']['tmp_name'] )
 			|| UPLOAD_ERR_OK !== $files['file']['error']
 		) {
-			return new WP_Error(
-				'sensei_data_port_job_upload_failed',
-				__( 'Upload was not successful.', 'sensei-lms' )
-			);
+			return $this->describe_upload_error( $files['file'] );
 		}
 
 		$result = $job->save_file( $request->get_param( 'file_key' ), $files['file']['tmp_name'], $files['file']['name'] );
@@ -140,6 +137,44 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 		}
 
 		return is_uploaded_file( $filename );
+	}
+
+	/**
+	 * Describe an upload error.
+	 *
+	 * @param array $file Array entry from `$_FILES`.
+	 *
+	 * @return WP_Error
+	 */
+	private function describe_upload_error( $file ) {
+		switch ( $file['error_code'] ) {
+			case 1:
+			case 2:
+				$error_message = __( 'The file uploaded exceeds the maximum file size allowed.', 'sensei-lms' );
+				break;
+			case 3:
+				$error_message = __( 'The file was only partially uploaded. Please try again.', 'sensei-lms' );
+				break;
+			case 4:
+				$error_message = __( 'No file was uploaded.', 'sensei-lms' );
+				break;
+			case 6:
+				$error_message = __( 'Missing a temporary folder to store the uploaded file.', 'sensei-lms' );
+				break;
+			case 7:
+				$error_message = __( 'Failed to write the uploaded file to disk. Please contact your host to fix a possible permissions issue.', 'sensei-lms' );
+				break;
+			case 8:
+				$error_message = __( 'A PHP Extension prevented the file upload. Please contact your host.', 'sensei-lms' );
+				break;
+			default:
+				$error_message = __( 'File upload error.', 'sensei-lms' );
+		}
+
+		return new WP_Error(
+			'sensei_data_port_job_upload_failed',
+			$error_message
+		);
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-import-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-import-controller.php
@@ -80,7 +80,7 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 		if ( ! isset( $files['file'] ) ) {
 			return new WP_Error(
 				'sensei_data_port_invalid_file',
-				__( 'No file was uploaded', 'sensei-lms' ),
+				__( 'No file was uploaded.', 'sensei-lms' ),
 				[ 'status' => 400 ]
 			);
 		}
@@ -95,7 +95,7 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 		if ( ! $job || $job->is_started() ) {
 			return new WP_Error(
 				'sensei_data_port_job_started',
-				__( 'Job has already been started', 'sensei-lms' ),
+				__( 'Job has already been started.', 'sensei-lms' ),
 				[ 'status' => 400 ]
 			);
 		}
@@ -108,7 +108,7 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 		) {
 			return new WP_Error(
 				'sensei_data_port_job_upload_failed',
-				__( 'Upload was not successful', 'sensei-lms' )
+				__( 'Upload was not successful.', 'sensei-lms' )
 			);
 		}
 
@@ -155,7 +155,7 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 		if ( ! $job ) {
 			return new WP_Error(
 				'sensei_data_port_job_does_not_exist',
-				__( 'No active job has been found', 'sensei-lms' ),
+				__( 'No active job has been found.', 'sensei-lms' ),
 				[ 'status' => 404 ]
 			);
 		}
@@ -163,7 +163,7 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 		if ( ! $job->get_file_path( $request->get_param( 'file_key' ) ) ) {
 			return new WP_Error(
 				'sensei_data_port_job_file_not_found',
-				__( 'File does not exist', 'sensei-lms' ),
+				__( 'File does not exist.', 'sensei-lms' ),
 				[ 'status' => 404 ]
 			);
 		}
@@ -171,7 +171,7 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 		if ( $job->is_started() ) {
 			return new WP_Error(
 				'sensei_data_port_job_started',
-				__( 'Job has already been started', 'sensei-lms' ),
+				__( 'Job has already been started.', 'sensei-lms' ),
 				[ 'status' => 400 ]
 			);
 		}
@@ -181,7 +181,7 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 		if ( ! $result ) {
 			return new WP_Error(
 				'sensei_data_port_unable_to_delete_file',
-				__( 'Job file could not be deleted', 'sensei-lms' ),
+				__( 'Job file could not be deleted.', 'sensei-lms' ),
 				[ 'status' => 500 ]
 			);
 		}

--- a/includes/rest-api/class-sensei-rest-api-import-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-import-controller.php
@@ -42,4 +42,149 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 	protected function create_job() {
 		return Sensei_Data_Port_Manager::instance()->create_import_job( get_current_user_id() );
 	}
+
+	/**
+	 * Register the REST API endpoints for the class.
+	 */
+	public function register_routes() {
+		parent::register_routes();
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/file/(?P<file_key>[a-z-]+)',
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'request_post_file' ],
+					'permission_callback' => [ $this, 'can_user_access_rest_api' ],
+				],
+				[
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'request_delete_file' ],
+					'permission_callback' => [ $this, 'can_user_access_rest_api' ],
+				],
+				'schema' => [ $this, 'get_file_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Handle the request to upload a file.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function request_post_file( $request ) {
+		$files = $request->get_file_params();
+		if ( ! isset( $files['file'] ) ) {
+			return new WP_Error(
+				'sensei_data_port_invalid_file',
+				__( 'No file was uploaded', 'sensei-lms' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$data_port_manager = Sensei_Data_Port_Manager::instance();
+		$job               = $data_port_manager->get_active_job( $this->get_handler_class(), get_current_user_id() );
+		if ( ! $job ) {
+			$job = $this->create_job();
+		}
+
+		// Check if the job has started or if there was an error creating the job.
+		if ( ! $job || $job->is_started() ) {
+			return new WP_Error(
+				'sensei_data_port_job_started',
+				__( 'Job has already been started', 'sensei-lms' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		// Check to make sure the upload succeeded.
+		if (
+			! isset( $files['file']['tmp_name'], $files['file']['error'] )
+			|| ! is_uploaded_file( $files['file']['tmp_name'] )
+			|| UPLOAD_ERR_OK !== $files['file']['error']
+		) {
+			return new WP_Error(
+				'sensei_data_port_job_upload_failed',
+				__( 'Upload was not successful', 'sensei-lms' )
+			);
+		}
+
+		$result = $job->save_file( $request->get_param( 'file_key' ), $files['file']['tmp_name'], $files['file']['name'] );
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		$response = new WP_REST_Response();
+		$response->set_status( 200 );
+		$response->set_data( $this->prepare_to_serve_job( $job ) );
+
+		return $response;
+	}
+
+	/**
+	 * Handle the request to delete a file.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function request_delete_file( $request ) {
+		$data_port_manager = Sensei_Data_Port_Manager::instance();
+		$job               = $data_port_manager->get_active_job( $this->get_handler_class(), get_current_user_id() );
+		if ( ! $job ) {
+			return new WP_Error(
+				'sensei_data_port_job_does_not_exist',
+				__( 'No active job has been found', 'sensei-lms' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( ! $job->get_file_path( $request->get_param( 'file_key' ) ) ) {
+			return new WP_Error(
+				'sensei_data_port_job_file_not_found',
+				__( 'File does not exist', 'sensei-lms' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( $job->is_started() ) {
+			return new WP_Error(
+				'sensei_data_port_job_started',
+				__( 'Job has already been started', 'sensei-lms' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$result = $job->delete_file( $request->get_param( 'file_key' ) );
+
+		if ( ! $result ) {
+			return new WP_Error(
+				'sensei_data_port_unable_to_delete_file',
+				__( 'Job file could not be deleted', 'sensei-lms' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		$response = new WP_REST_Response();
+		$response->set_status( 200 );
+		$response->set_data( $this->prepare_to_serve_job( $job ) );
+
+		return $response;
+	}
+
+	/**
+	 * Get the schema for the client on file related requests.
+	 *
+	 * @return array
+	 */
+	public function get_file_item_schema() {
+		return [
+			'job' => $this->get_item_schema(),
+		];
+	}
+
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,9 +3,9 @@
         bootstrap="tests/bootstrap.php"
         backupGlobals="false"
         colors="true"
-        convertErrorsToExceptions="true"
-        convertNoticesToExceptions="true"
-        convertWarningsToExceptions="true"
+		convertErrorsToExceptions="false"
+		convertNoticesToExceptions="false"
+		convertWarningsToExceptions="false"
         verbose="true"
         syntaxCheck="true"
 >

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,9 +3,9 @@
         bootstrap="tests/bootstrap.php"
         backupGlobals="false"
         colors="true"
-		convertErrorsToExceptions="true"
-		convertNoticesToExceptions="true"
-		convertWarningsToExceptions="true"
+        convertErrorsToExceptions="true"
+        convertNoticesToExceptions="true"
+        convertWarningsToExceptions="true"
         verbose="true"
         syntaxCheck="true"
 >

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,9 +3,9 @@
         bootstrap="tests/bootstrap.php"
         backupGlobals="false"
         colors="true"
-		convertErrorsToExceptions="false"
-		convertNoticesToExceptions="false"
-		convertWarningsToExceptions="false"
+		convertErrorsToExceptions="true"
+		convertNoticesToExceptions="true"
+		convertWarningsToExceptions="true"
         verbose="true"
         syntaxCheck="true"
 >

--- a/tests/framework/data-port/class-sensei-data-port-job-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-job-mock.php
@@ -35,7 +35,21 @@ class Sensei_Data_Port_Job_Mock extends Sensei_Data_Port_Job {
 	}
 
 	public static function get_file_config() {
-		return [];
+		$files = [];
+
+		$csv_mime_types = [
+			'csv' => 'text/csv',
+			'txt' => 'text/plain',
+		];
+
+		$files['questions'] = [
+			'validator'  => function( $file ) {
+				return true;
+			},
+			'mime_types' => $csv_mime_types,
+		];
+
+		return $files;
 	}
 
 }

--- a/tests/framework/data-port/class-sensei-data-port-job-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-job-mock.php
@@ -33,4 +33,9 @@ class Sensei_Data_Port_Job_Mock extends Sensei_Data_Port_Job {
 	public static function set_restore_mock( $mock ) {
 		self::$restore_mock = $mock;
 	}
+
+	public static function get_file_config() {
+		return [];
+	}
+
 }

--- a/tests/framework/data-port/data-files/invalid_file_type.tsv
+++ b/tests/framework/data-port/data-files/invalid_file_type.tsv
@@ -1,0 +1,2 @@
+ID	Question	Slug	Description	Status	Type	Grade	Randomise	Media	Categories	Answer	Feedback	Text Before Gap	Gap	Text After Gap	Upload Notes	Teacher Notes
+100	Do you like dinosaurs?	do-you-like-dinosaurs	A simple question about liking dinosaurs.	publish	multiple-choice	1	0		Dinosaurs	"Right: Yes	 Wrong: No"

--- a/tests/framework/data-port/data-files/questions.csv
+++ b/tests/framework/data-port/data-files/questions.csv
@@ -1,0 +1,2 @@
+ID,Question,Slug,Description,Status,Type,Grade,Randomise,Media,Categories,Answer,Feedback,Text Before Gap,Gap,Text After Gap,Upload Notes,Teacher Notes
+100,Do you like dinosaurs?,do-you-like-dinosaurs,A simple question about liking dinosaurs.,publish,multiple-choice,1,0,,Dinosaurs,"Right: Yes, Wrong: No",,,,,,

--- a/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-courses.php
+++ b/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-courses.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file contains the Sensei_Import_Courses class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tests for Sensei_Import_Courses class.
+ *
+ * @group data-port
+ */
+class Sensei_Import_Courses_Tests extends WP_UnitTestCase {
+	/**
+	 * Set up before class.
+	 */
+	public static function setUpBeforeClass() {
+		new Sensei_Import_Job( '' );
+	}
+
+	/**
+	 * Placeholder test.
+	 */
+	public function testClassExists() {
+		$this->assertTrue( class_exists( 'Sensei_Import_Courses' ) );
+	}
+}

--- a/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-lessons.php
+++ b/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-lessons.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file contains the Sensei_Import_Lessons class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tests for Sensei_Import_Lessons class.
+ *
+ * @group data-port
+ */
+class Sensei_Import_Lessons_Tests extends WP_UnitTestCase {
+	/**
+	 * Set up before class.
+	 */
+	public static function setUpBeforeClass() {
+		new Sensei_Import_Job( '' );
+	}
+
+	/**
+	 * Placeholder test.
+	 */
+	public function testClassExists() {
+		$this->assertTrue( class_exists( 'Sensei_Import_Lessons' ) );
+	}
+}

--- a/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-questions.php
+++ b/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-questions.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file contains the Sensei_Import_Questions class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tests for Sensei_Import_Questions class.
+ *
+ * @group data-port
+ */
+class Sensei_Import_Questions_Tests extends WP_UnitTestCase {
+	/**
+	 * Set up before class.
+	 */
+	public static function setUpBeforeClass() {
+		new Sensei_Import_Job( '' );
+	}
+
+	/**
+	 * Placeholder test.
+	 */
+	public function testClassExists() {
+		$this->assertTrue( class_exists( 'Sensei_Import_Questions' ) );
+	}
+}

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
@@ -246,43 +246,6 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test saving a valid file to the job.
-	 */
-	public function testSaveFileValid() {
-		if ( ! version_compare( get_bloginfo( 'version' ), '5.0.0', '>=' ) ) {
-			$this->markTestSkipped( 'Test fails with 4.9 due to text/csv getting interpretted as text/plain.' );
-		}
-
-		$test_file = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/questions.csv';
-		$test_file = $this->get_tmp_file( $test_file );
-		$job       = new Sensei_Data_Port_Job_Mock( 'test-job' );
-
-		$result = $job->save_file( 'questions', $test_file, basename( $test_file ) );
-
-		$this->assertTrue( $result, 'Valid file with a valid file key should be stored' );
-		$this->assertTrue( isset( $job->get_files()['questions'] ) );
-
-		$attachment = get_post( $job->get_files()['questions'] );
-		$this->assertTrue( $attachment instanceof WP_Post );
-
-		$this->assertEquals( basename( $test_file ), $attachment->post_title );
-	}
-
-	/**
-	 * Test saving a non CSV file to a job.
-	 */
-	public function testSaveFileBadFile() {
-		$test_file = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/invalid_file_type.tsv';
-		$test_file = $this->get_tmp_file( $test_file );
-		$job       = new Sensei_Data_Port_Job_Mock( 'test-job' );
-
-		$result = $job->save_file( 'questions', $test_file, basename( $test_file ) );
-
-		$this->assertWPError( $result, 'Invalid file should result in a WP Error' );
-		$this->assertEquals( 'sensei_data_port_unexpected_file_type', $result->get_error_code() );
-	}
-
-	/**
 	 * Test saving a unknown file key to a job.
 	 */
 	public function testSaveFileBadFileKey() {

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
@@ -29,6 +29,15 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 		return parent::setUp();
 	}
 
+	/**
+	 * Tear down after tests.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		delete_site_option( 'upload_filetypes' );
+	}
+
 	public function testJobWithCompletedTasksIsCompleted() {
 		$first_completed  = $this->mock_task_method( true, 100, 100, 'run' );
 		$second_completed = $this->mock_task_method( true, 100, 100, 'run' );

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
@@ -19,6 +19,16 @@ require_once SENSEI_TEST_FRAMEWORK_DIR . '/data-port/class-sensei-data-port-task
  */
 class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 
+	/**
+	 * Set up the tests.
+	 */
+	public function setUp() {
+		// Make sure CSVs are allowed on WordPress multi-site.
+		update_site_option( 'upload_filetypes', 'csv' );
+
+		return parent::setUp();
+	}
+
 	public function testJobWithCompletedTasksIsCompleted() {
 		$first_completed  = $this->mock_task_method( true, 100, 100, 'run' );
 		$second_completed = $this->mock_task_method( true, 100, 100, 'run' );
@@ -230,6 +240,10 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 	 * Test saving a valid file to the job.
 	 */
 	public function testSaveFileValid() {
+		if ( ! version_compare( get_bloginfo( 'version' ), '5.0.0', '>=' ) ) {
+			$this->markTestSkipped( 'Test fails with 4.9 due to text/csv getting interpretted as text/plain.' );
+		}
+
 		$test_file = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/questions.csv';
 		$test_file = $this->get_tmp_file( $test_file );
 		$job       = new Sensei_Data_Port_Job_Mock( 'test-job' );
@@ -277,6 +291,10 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 	 * Test deleting an existing file from a job.
 	 */
 	public function testDeleteFileExists() {
+		if ( ! version_compare( get_bloginfo( 'version' ), '5.0.0', '>=' ) ) {
+			$this->markTestSkipped( 'Test fails with 4.9 due to text/csv getting interpretted as text/plain.' );
+		}
+
 		$test_file = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/questions.csv';
 		$test_file = $this->get_tmp_file( $test_file );
 		$job       = new Sensei_Data_Port_Job_Mock( 'test-job' );

--- a/tests/unit-tests/data-port/test-class-sensei-import-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-job.php
@@ -17,6 +17,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Import_Job_Test extends WP_UnitTestCase {
 
 	/**
+	 * Set up the tests.
+	 */
+	public function setUp() {
+		// Make sure CSVs are allowed on WordPress multi-site.
+		update_site_option( 'upload_filetypes', 'csv' );
+
+		return parent::setUp();
+	}
+
+	/**
+	 * Tear down after tests.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		delete_site_option( 'upload_filetypes' );
+	}
+
+	/**
 	 * Test saving a valid file to the job.
 	 */
 	public function testSaveFileValid() {

--- a/tests/unit-tests/data-port/test-class-sensei-import-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-job.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * This file contains the Sensei_Import_Job_Test class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tests for Sensei_Import_Job class.
+ *
+ * @group data-port
+ */
+class Sensei_Import_Job_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test saving a valid file to the job.
+	 */
+	public function testSaveFileValid() {
+		if ( ! version_compare( get_bloginfo( 'version' ), '5.0.0', '>=' ) ) {
+			$this->markTestSkipped( 'Test fails with 4.9 due to text/csv getting interpretted as text/plain.' );
+		}
+
+		$test_file = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/questions.csv';
+		$test_file = $this->get_tmp_file( $test_file );
+		$job       = new Sensei_Import_Job( 'test-job' );
+
+		$result = $job->save_file( 'questions', $test_file, basename( $test_file ) );
+
+		$this->assertTrue( $result, 'Valid file with a valid file key should be stored' );
+		$this->assertTrue( isset( $job->get_files()['questions'] ) );
+
+		$attachment = get_post( $job->get_files()['questions'] );
+		$this->assertTrue( $attachment instanceof WP_Post );
+
+		$this->assertEquals( basename( $test_file ), $attachment->post_title );
+	}
+
+	/**
+	 * Test saving a non CSV file to a job.
+	 */
+	public function testSaveFileBadFile() {
+		$test_file = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/invalid_file_type.tsv';
+		$test_file = $this->get_tmp_file( $test_file );
+		$job       = new Sensei_Import_Job( 'test-job' );
+
+		$result = $job->save_file( 'questions', $test_file, basename( $test_file ) );
+
+		$this->assertWPError( $result, 'Invalid file should result in a WP Error' );
+		$this->assertEquals( 'sensei_data_port_unexpected_file_type', $result->get_error_code() );
+	}
+
+	/**
+	 * Get a temporary file from a source file.
+	 *
+	 * @param string $file_path File to copy.
+	 *
+	 * @return string
+	 */
+	private function get_tmp_file( $file_path ) {
+		$tmp = wp_tempnam( basename( $file_path ) ) . '.' . pathinfo( $file_path, PATHINFO_EXTENSION );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		file_put_contents( $tmp, file_get_contents( $file_path ) );
+
+		return $tmp;
+	}
+}

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
@@ -30,6 +30,9 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 
 		do_action( 'rest_api_init' );
 
+		// Make sure CSVs are allowed on WordPress multi-site.
+		update_site_option( 'upload_filetypes', 'csv' );
+
 		// We need to re-instansiate the controller on each tests to register any hooks.
 		new Sensei_REST_API_Messages_Controller( 'sensei_message' );
 	}
@@ -269,6 +272,10 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 	 * @param bool   $is_authorized Is the user authenticated and authorized.
 	 */
 	public function testPostFileValidFile( $user_role, $is_authorized ) {
+		if ( ! version_compare( get_bloginfo( 'version' ), '5.0.0', '>=' ) ) {
+			$this->markTestSkipped( 'Test fails with 4.9 due to text/csv getting interpretted as text/plain.' );
+		}
+
 		wp_logout();
 
 		$user_description = 'Guest';
@@ -405,6 +412,10 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 	 * @param bool   $is_authorized Is the user authenticated and authorized.
 	 */
 	public function testDeleteFileExists( $user_role, $is_authorized ) {
+		if ( ! version_compare( get_bloginfo( 'version' ), '5.0.0', '>=' ) ) {
+			$this->markTestSkipped( 'Test fails with 4.9 due to text/csv getting interpretted as text/plain.' );
+		}
+
 		wp_logout();
 
 		$user_description = 'Guest';

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
@@ -45,6 +45,8 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 
 		global $wp_rest_server;
 		$wp_rest_server = null;
+
+		delete_site_option( 'upload_filetypes' );
 	}
 
 	/**

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
@@ -261,14 +261,233 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * Tests `POST /import/file/{file_key}`.
+	 *
+	 * @dataProvider userDataSources
+	 *
+	 * @param string $user_role     User role to run the request as.
+	 * @param bool   $is_authorized Is the user authenticated and authorized.
+	 */
+	public function testPostFileValidFile( $user_role, $is_authorized ) {
+		wp_logout();
+
+		$user_description = 'Guest';
+		if ( $user_role ) {
+			$user_id          = $this->factory->user->create( [ 'role' => $user_role ] );
+			$user_description = ucfirst( $user_role );
+			wp_set_current_user( $user_id );
+		}
+
+		$expected_status_codes = [ 401, 403 ];
+		if ( $is_authorized ) {
+			$expected_status_codes = [ 200 ];
+
+			$job = Sensei_Data_Port_Manager::instance()->create_import_job( get_current_user_id() );
+			$job->persist();
+			Sensei_Data_Port_Manager::instance()->persist();
+		}
+
+		$test_file = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/questions.csv';
+		$test_file = $this->get_tmp_file( $test_file );
+
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/import/file/questions' );
+		$request->set_file_params(
+			[
+				'file' => [
+					'name'     => basename( $test_file ),
+					'size'     => filesize( $test_file ),
+					'tmp_name' => $test_file,
+					'type'     => 'text/csv',
+					'error'    => UPLOAD_ERR_OK,
+				],
+			]
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertTrue( in_array( $response->get_status(), $expected_status_codes, true ), "{$user_description} requests should produce status of " . implode( ', ', $expected_status_codes ) );
+
+		if ( $is_authorized ) {
+			$data = $response->get_data();
+			$this->assertResultValidJob( $data );
+
+			$this->assertTrue( isset( $data['files']['questions']['name'] ) );
+			$this->assertEquals( basename( $test_file ), $data['files']['questions']['name'] );
+		}
+	}
+
+	/**
+	 * Tests `POST /import/file/{file_key}` with an invalid file type.
+	 */
+	public function testPostFileInvalidFileType() {
+		wp_logout();
+
+		$user_role = 'administrator';
+		$user_id   = $this->factory->user->create( [ 'role' => $user_role ] );
+		wp_set_current_user( $user_id );
+
+		$job = Sensei_Data_Port_Manager::instance()->create_import_job( get_current_user_id() );
+		$job->persist();
+		Sensei_Data_Port_Manager::instance()->persist();
+
+		$test_file = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/invalid_file_type.tsv';
+		$test_file = $this->get_tmp_file( $test_file );
+
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/import/file/questions' );
+		$request->set_file_params(
+			[
+				'file' => [
+					'name'     => basename( $test_file ),
+					'size'     => filesize( $test_file ),
+					'tmp_name' => $test_file,
+					'type'     => 'text/tsv',
+					'error'    => UPLOAD_ERR_OK,
+				],
+			]
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 400, $response->get_status(), 'Invalid upload file types should result in a 400 status code.' );
+
+		$data = $response->get_data();
+
+		$this->assertTrue( isset( $data['code'], $data['message'] ) );
+		$this->assertEquals( 'sensei_data_port_unexpected_file_type', $data['code'] );
+	}
+
+	/**
+	 * Tests `POST /import/file/{file_key}` with an invalid file key.
+	 */
+	public function testPostFileInvalidFileKey() {
+		wp_logout();
+
+		$user_role = 'administrator';
+		$user_id   = $this->factory->user->create( [ 'role' => $user_role ] );
+		wp_set_current_user( $user_id );
+
+		$job = Sensei_Data_Port_Manager::instance()->create_import_job( get_current_user_id() );
+		$job->persist();
+		Sensei_Data_Port_Manager::instance()->persist();
+
+		$test_file = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/questions.csv';
+		$test_file = $this->get_tmp_file( $test_file );
+
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/import/file/dinosaurs' );
+		$request->set_file_params(
+			[
+				'file' => [
+					'name'     => basename( $test_file ),
+					'size'     => filesize( $test_file ),
+					'tmp_name' => $test_file,
+					'type'     => 'text/tsv',
+					'error'    => UPLOAD_ERR_OK,
+				],
+			]
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 500, $response->get_status(), 'Invalid file key should result in a 500 status code.' );
+
+		$data = $response->get_data();
+
+		$this->assertTrue( isset( $data['code'], $data['message'] ) );
+		$this->assertEquals( 'sensei_data_port_unknown_file_key', $data['code'] );
+	}
+
+	/**
+	 * Tests `DELETE /import/file/{file_key}` for a file that exists.
+	 *
+	 * @dataProvider userDataSources
+	 *
+	 * @param string $user_role     User role to run the request as.
+	 * @param bool   $is_authorized Is the user authenticated and authorized.
+	 */
+	public function testDeleteFileExists( $user_role, $is_authorized ) {
+		wp_logout();
+
+		$user_description = 'Guest';
+		if ( $user_role ) {
+			$user_id          = $this->factory->user->create( [ 'role' => $user_role ] );
+			$user_description = ucfirst( $user_role );
+			wp_set_current_user( $user_id );
+		}
+
+		$test_file             = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/questions.csv';
+		$test_file             = $this->get_tmp_file( $test_file );
+		$expected_status_codes = [ 401, 403 ];
+		if ( $is_authorized ) {
+			$expected_status_codes = [ 200 ];
+
+			$job = Sensei_Data_Port_Manager::instance()->create_import_job( get_current_user_id() );
+			$job->save_file( 'questions', $test_file, basename( $test_file ) );
+			$job->persist();
+			Sensei_Data_Port_Manager::instance()->persist();
+		}
+
+		$request  = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/import/file/questions' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertTrue( in_array( $response->get_status(), $expected_status_codes, true ), "{$user_description} requests should produce status of " . implode( ', ', $expected_status_codes ) );
+
+		if ( $is_authorized ) {
+			$data = $response->get_data();
+			$this->assertResultValidJob( $data );
+
+			$this->assertFalse( isset( $data['files']['questions']['name'] ) );
+		}
+	}
+
+	/**
+	 * Tests `DELETE /import/file/{file_key}` when file does not exist.
+	 *
+	 * @dataProvider userDataSources
+	 *
+	 * @param string $user_role     User role to run the request as.
+	 * @param bool   $is_authorized Is the user authenticated and authorized.
+	 */
+	public function testDeleteFileNotExists( $user_role, $is_authorized ) {
+		wp_logout();
+
+		$user_description = 'Guest';
+		if ( $user_role ) {
+			$user_id          = $this->factory->user->create( [ 'role' => $user_role ] );
+			$user_description = ucfirst( $user_role );
+			wp_set_current_user( $user_id );
+		}
+
+		$expected_status_codes = [ 401, 403 ];
+		if ( $is_authorized ) {
+			$expected_status_codes = [ 404 ];
+
+			$job = Sensei_Data_Port_Manager::instance()->create_import_job( get_current_user_id() );
+			$job->persist();
+			Sensei_Data_Port_Manager::instance()->persist();
+		}
+
+		$request  = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/import/file/questions' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertTrue( in_array( $response->get_status(), $expected_status_codes, true ), "{$user_description} requests should produce status of " . implode( ', ', $expected_status_codes ) );
+
+		if ( $is_authorized ) {
+			$data = $response->get_data();
+			$this->assertTrue( isset( $data['code'], $data['message'] ) );
+			$this->assertEquals( 'sensei_data_port_job_file_not_found', $data['code'] );
+		}
+	}
+
+	/**
 	 * Assert that a REST API response is valid.
 	 *
 	 * @param $result
 	 */
 	protected function assertResultValidJob( $result, $expected = [] ) {
-		$this->assertTrue( isset( $result['id'], $result['status'] ) );
+		$this->assertTrue( isset( $result['id'], $result['status'], $result['files'] ) );
 		$this->assertTrue( is_string( $result['id'] ) );
 		$this->assertTrue( is_array( $result['status'] ) );
+		$this->assertTrue( is_array( $result['files'] ) );
 		$this->assertNotEmpty( $result['id'] );
 		$this->assertNotEmpty( $result['status'] );
 		$this->assertTrue( isset( $result['status']['status'], $result['status']['percentage'] ) );
@@ -276,5 +495,21 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 		foreach ( $expected as $key => $value ) {
 			$this->assertEquals( $result[ $key ], $value );
 		}
+	}
+
+	/**
+	 * Get a temporary file from a source file.
+	 *
+	 * @param string $file_path File to copy.
+	 *
+	 * @return string
+	 */
+	private function get_tmp_file( $file_path ) {
+		$tmp = wp_tempnam( basename( $file_path ) ) . '.' . pathinfo( $file_path, PATHINFO_EXTENSION );
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_put_contents, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+		file_put_contents( $tmp, file_get_contents( $file_path ) );
+
+		return $tmp;
 	}
 }

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
@@ -275,7 +275,7 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 	 */
 	public function testPostFileValidFile( $user_role, $is_authorized ) {
 		if ( ! version_compare( get_bloginfo( 'version' ), '5.0.0', '>=' ) ) {
-			$this->markTestSkipped( 'Test fails with 4.9 due to text/csv getting interpretted as text/plain.' );
+			$this->markTestSkipped( 'Test fails with 4.9 due to text/csv getting interpreted as text/plain.' );
 		}
 
 		wp_logout();
@@ -415,7 +415,7 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 	 */
 	public function testDeleteFileExists( $user_role, $is_authorized ) {
 		if ( ! version_compare( get_bloginfo( 'version' ), '5.0.0', '>=' ) ) {
-			$this->markTestSkipped( 'Test fails with 4.9 due to text/csv getting interpretted as text/plain.' );
+			$this->markTestSkipped( 'Test fails with 4.9 due to text/csv getting interpreted as text/plain.' );
 		}
 
 		wp_logout();


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This adds the basic `POST` and `DELETE` endpoints for importer file assets.
* Files upload accepts uploads via multi-part forms with the `file` parameter.
* This was already quite a large PR so I'm leaving the file validation to future PRs (potential the PRs for the individual import tasks).  A good chunk of this is placeholder classes/tests for the import tasks.
* Multiple `POST`s for the same file key will replace the old file (and delete it).
* I followed WooCommerce's lead by using WP attachments. I think this will make it more compatibility with places like VIP Go. I'm creating them with a `post_status` of `private` which seems to keep it out of the public REST API media endpoint and the media library.
* `{file_key}` would be `questions`, `courses`, and `lessons`.

### Endpoints Added
- `POST /wp-json/sensei-internal/v1/import/file/{file_key}`
- `DELETE /wp-json/sensei-internal/v1/import/file/{file_key}`

### Testing instructions

* Using your favorite REST API client, upload a CSV file using `file` form field on multi-part form:
`GET /wp-json/sensei-internal/v1/import/file/questions`
* Try the same using a non-CSV. It shouldn't work.
* Try deleting the file using:
`DELETE /wp-json/sensei-internal/v1/import/file/questions`