### PR TITLE
Clean comment cache in Sensei_Updates class

### DIFF
--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -1613,19 +1613,19 @@ class Sensei_Updates {
 				);
 				// Check it doesn't already exist
 				$sql        = $wpdb->prepare( $check_existing_sql, $lesson_id, $user_id );
-				$comment_ID = $wpdb->get_var( $sql );
-				if ( ! $comment_ID ) {
+				$comment_id = $wpdb->get_var( $sql );
+				if ( ! $comment_id ) {
 					// Bypassing WP wp_insert_comment( $data ), so no actions/filters are run
 					$wpdb->insert( $wpdb->comments, $data );
-					$comment_ID = (int) $wpdb->insert_id;
+					$comment_id = (int) $wpdb->insert_id;
 
-					if ( $comment_ID && ! empty( $meta_data ) ) {
+					if ( $comment_id && ! empty( $meta_data ) ) {
 						foreach ( $meta_data as $key => $value ) {
 							// Bypassing WP add_comment_meta(() so no actions/filters are run
 							if ( $wpdb->get_var(
 								$wpdb->prepare(
 									"SELECT COUNT(*) FROM $wpdb->commentmeta WHERE comment_id = %d AND meta_key = %s ",
-									$comment_ID,
+									$comment_id,
 									$key
 								)
 							) ) {
@@ -1635,15 +1635,15 @@ class Sensei_Updates {
 							$wpdb->insert(
 								$wpdb->commentmeta,
 								array(
-									'comment_id' => $comment_ID,
+									'comment_id' => $comment_id,
 									'meta_key'   => $key,
 									'meta_value' => $value,
 								)
 							);
 						}
 					}
-					update_meta_cache( 'comment', array( $comment_ID ) );
-					clean_comment_cache( $comment_ID );
+					update_meta_cache( 'comment', array( $comment_id ) );
+					clean_comment_cache( $comment_id );
 				}
 			}
 		}
@@ -1761,19 +1761,19 @@ class Sensei_Updates {
 				);
 				// Check it doesn't already exist
 				$sql        = $wpdb->prepare( $check_existing_sql, $course_id, $user_id );
-				$comment_ID = $wpdb->get_var( $sql );
-				if ( ! $comment_ID ) {
+				$comment_id = $wpdb->get_var( $sql );
+				if ( ! $comment_id ) {
 					// Bypassing WP wp_insert_comment( $data ), so no actions/filters are run
 					$wpdb->insert( $wpdb->comments, $data );
-					$comment_ID = (int) $wpdb->insert_id;
+					$comment_id = (int) $wpdb->insert_id;
 
-					if ( $comment_ID && ! empty( $meta_data ) ) {
+					if ( $comment_id && ! empty( $meta_data ) ) {
 						foreach ( $meta_data as $key => $value ) {
 							// Bypassing WP wp_insert_comment( $data ), so no actions/filters are run
 							if ( $wpdb->get_var(
 								$wpdb->prepare(
 									"SELECT COUNT(*) FROM $wpdb->commentmeta WHERE comment_id = %d AND meta_key = %s ",
-									$comment_ID,
+									$comment_id,
 									$key
 								)
 							) ) {
@@ -1783,15 +1783,15 @@ class Sensei_Updates {
 							$wpdb->insert(
 								$wpdb->commentmeta,
 								array(
-									'comment_id' => $comment_ID,
+									'comment_id' => $comment_id,
 									'meta_key'   => $key,
 									'meta_value' => $value,
 								)
 							);
 						}
 					}
-					update_meta_cache( 'comment', array( $comment_ID ) );
-					clean_comment_cache( $comment_ID );
+					update_meta_cache( 'comment', array( $comment_id ) );
+					clean_comment_cache( $comment_id );
 				}
 			}
 		}
@@ -1979,7 +1979,7 @@ class Sensei_Updates {
 				// Excape data
 				$answer = wp_slash( $answer );
 
-				$comment_ID = $answer['comment_ID'];
+				$comment_id = $answer['comment_ID'];
 
 				$meta_data = array();
 
@@ -2002,7 +2002,7 @@ class Sensei_Updates {
 				);
 				$data = array_merge( $answer, $data );
 
-				$rval = $wpdb->update( $wpdb->comments, $data, compact( 'comment_ID' ) );
+				$rval = $wpdb->update( $wpdb->comments, $data, compact( 'comment_id' ) );
 				if ( $rval ) {
 					if ( ! empty( $meta_data ) ) {
 						foreach ( $meta_data as $key => $value ) {
@@ -2010,7 +2010,7 @@ class Sensei_Updates {
 							if ( $wpdb->get_var(
 								$wpdb->prepare(
 									"SELECT COUNT(*) FROM $wpdb->commentmeta WHERE comment_id = %d AND meta_key = %s ",
-									$comment_ID,
+									$comment_id,
 									$key
 								)
 							) ) {
@@ -2020,15 +2020,15 @@ class Sensei_Updates {
 							$wpdb->insert(
 								$wpdb->commentmeta,
 								array(
-									'comment_id' => $comment_ID,
+									'comment_id' => $comment_id,
 									'meta_key'   => $key,
 									'meta_value' => $value,
 								)
 							);
 						}
 					}
-					update_meta_cache( 'comment', array( $comment_ID ) );
-					clean_comment_cache( $comment_ID );
+					update_meta_cache( 'comment', array( $comment_id ) );
+					clean_comment_cache( $comment_id );
 				}
 			}
 		}
@@ -2051,13 +2051,13 @@ class Sensei_Updates {
 		global $wpdb;
 
 		// Update 'sensei_user_answer' entries to use comment_approved = 'log' so they don't appear in counts
-		$comment_ids = $wpdb->get_col( "SELECT comment_ID FROM $wpdb->comments WHERE comment_type = 'sensei_user_answer'" );
-		$wpdb->query( "UPDATE $wpdb->comments SET comment_approved = 'log' WHERE comment_type = 'sensei_user_answer' " );
+		$comment_ids = $wpdb->get_col( "SELECT comment_ID FROM $wpdb->comments WHERE comment_type = 'sensei_user_answer'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- intentionally running a direct SQL query for not triggering all the filters and actions.
+		$wpdb->query( "UPDATE $wpdb->comments SET comment_approved = 'log' WHERE comment_type = 'sensei_user_answer' " ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- intentionally running a direct SQL query for not triggering all the filters and actions.
 		clean_comment_cache( $comment_ids );
 
 		// Mark all old Sensei comment types with comment_approved = 'legacy' so they no longer appear in counts, but can be restored if required
-		$comment_ids = $wpdb->get_col( "SELECT comment_ID FROM $wpdb->comments WHERE comment_type IN ('sensei_course_start', 'sensei_course_end', 'sensei_lesson_start', 'sensei_lesson_end', 'sensei_quiz_  asked', 'sensei_user_grade', 'sensei_answer_notes', 'sensei_quiz_grade')" );
-		$wpdb->query( "UPDATE $wpdb->comments SET comment_approved = 'legacy' WHERE comment_type IN ('sensei_course_start', 'sensei_course_end', 'sensei_lesson_start', 'sensei_lesson_end', 'sensei_quiz_asked', 'sensei_user_grade', 'sensei_answer_notes', 'sensei_quiz_grade') " );
+		$comment_ids = $wpdb->get_col( "SELECT comment_ID FROM $wpdb->comments WHERE comment_type IN ('sensei_course_start', 'sensei_course_end', 'sensei_lesson_start', 'sensei_lesson_end', 'sensei_quiz_  asked', 'sensei_user_grade', 'sensei_answer_notes', 'sensei_quiz_grade')" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- intentionally running a direct SQL query for not triggering all the filters and actions.
+		$wpdb->query( "UPDATE $wpdb->comments SET comment_approved = 'legacy' WHERE comment_type IN ('sensei_course_start', 'sensei_course_end', 'sensei_lesson_start', 'sensei_lesson_end', 'sensei_quiz_asked', 'sensei_user_grade', 'sensei_answer_notes', 'sensei_quiz_grade') " ); // phpcs::ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- intentionally running a direct SQL query for not triggering all the filters and actions.
 		clean_comment_cache( $comment_ids );
 
 		return true;
@@ -2109,8 +2109,8 @@ class Sensei_Updates {
 	public function remove_legacy_comments() {
 		global $wpdb;
 
-		$comment_ids = $wpdb->get_col( "SELECT comment_ID FROM $wpdb->comments WHERE comment_approved = 'legacy'" );
-		$wpdb->delete( $wpdb->comments, array( 'comment_approved' => 'legacy' ) );
+		$comment_ids = $wpdb->get_col( "SELECT comment_ID FROM $wpdb->comments WHERE comment_approved = 'legacy'" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- intentionally running a direct SQL query for not triggering all the filters and actions.
+		$wpdb->delete( $wpdb->comments, array( 'comment_approved' => 'legacy' ) ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- intentionally running a direct SQL query for not triggering all the filters and actions.
 		clean_comment_cache( $comment_ids );
 
 		return true;

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -1642,6 +1642,7 @@ class Sensei_Updates {
 							);
 						}
 					}
+					update_meta_cache( 'comment', array( $comment_ID ) );
 					clean_comment_cache( $comment_ID );
 				}
 			}
@@ -1789,6 +1790,7 @@ class Sensei_Updates {
 							);
 						}
 					}
+					update_meta_cache( 'comment', array( $comment_ID ) );
 					clean_comment_cache( $comment_ID );
 				}
 			}
@@ -2025,6 +2027,7 @@ class Sensei_Updates {
 							);
 						}
 					}
+					update_meta_cache( 'comment', array( $comment_ID ) );
 					clean_comment_cache( $comment_ID );
 				}
 			}

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -1642,6 +1642,7 @@ class Sensei_Updates {
 							);
 						}
 					}
+					clean_comment_cache( $comment_ID );
 				}
 			}
 		}
@@ -1788,6 +1789,7 @@ class Sensei_Updates {
 							);
 						}
 					}
+					clean_comment_cache( $comment_ID );
 				}
 			}
 		}
@@ -2023,6 +2025,7 @@ class Sensei_Updates {
 							);
 						}
 					}
+					clean_comment_cache( $comment_ID );
 				}
 			}
 		}
@@ -2045,10 +2048,14 @@ class Sensei_Updates {
 		global $wpdb;
 
 		// Update 'sensei_user_answer' entries to use comment_approved = 'log' so they don't appear in counts
+		$comment_ids = $wpdb->get_col( "SELECT comment_ID FROM $wpdb->comments WHERE comment_type = 'sensei_user_answer'" );
 		$wpdb->query( "UPDATE $wpdb->comments SET comment_approved = 'log' WHERE comment_type = 'sensei_user_answer' " );
+		clean_comment_cache( $comment_ids );
 
 		// Mark all old Sensei comment types with comment_approved = 'legacy' so they no longer appear in counts, but can be restored if required
+		$comment_ids = $wpdb->get_col( "SELECT comment_ID FROM $wpdb->comments WHERE comment_type IN ('sensei_course_start', 'sensei_course_end', 'sensei_lesson_start', 'sensei_lesson_end', 'sensei_quiz_  asked', 'sensei_user_grade', 'sensei_answer_notes', 'sensei_quiz_grade')" );
 		$wpdb->query( "UPDATE $wpdb->comments SET comment_approved = 'legacy' WHERE comment_type IN ('sensei_course_start', 'sensei_course_end', 'sensei_lesson_start', 'sensei_lesson_end', 'sensei_quiz_asked', 'sensei_user_grade', 'sensei_answer_notes', 'sensei_quiz_grade') " );
+		clean_comment_cache( $comment_ids );
 
 		return true;
 	}
@@ -2099,7 +2106,9 @@ class Sensei_Updates {
 	public function remove_legacy_comments() {
 		global $wpdb;
 
+		$comment_ids = $wpdb->get_col( "SELECT comment_ID FROM $wpdb->comments WHERE comment_approved = 'legacy'" );
 		$wpdb->delete( $wpdb->comments, array( 'comment_approved' => 'legacy' ) );
+		clean_comment_cache( $comment_ids );
 
 		return true;
 	}

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -2074,7 +2074,7 @@ class Sensei_Updates {
 	public function update_comment_course_lesson_comment_counts( $n = 50, $offset = 0 ) {
 		global $wpdb;
 
-		$item_count_result = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_type IN ('course', 'lesson') " );
+		$item_count_result = $wpdb->get_var( "SELECT COUNT(*) FROM $wpdb->posts WHERE post_type IN ('course', 'lesson') " ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- intentionally running a direct SQL query for not triggering all the filters and actions.
 
 		if ( 0 == $item_count_result ) {
 			return true;


### PR DESCRIPTION
As the code modifies the comments and comment meta via SQL queries, w/o using the comments API in order to avoid filters and actions being triggered, we need to manually clean the respective caches as well, in relation to the changes in WordPress 4.6

See https://make.wordpress.org/core/2016/07/18/comments-in-4-6-can-now-be-cached-by-a-persistent-object-cache/

Fixes #3208

### Changes proposed in this Pull Request

* Call the `clean_comment_cache` and `update_meta_cache` functions on places where insert/update SQL queries are triggered.

### Testing instructions

* Have a plugin with version < 1.7.0 installed on a > WordPress 4.6 installed with a persistent object cache backend enabled, and attempt to update the plugin. It should afterwards properly clean up the caches.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->