### PR TITLE
Add endpoint to start a data port job

### DIFF
--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -260,6 +260,13 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	abstract public static function get_file_config();
 
 	/**
+	 * Check if a job is ready to be started.
+	 *
+	 * @return bool
+	 */
+	abstract public function is_ready();
+
+	/**
 	 * Initialize and restore state of task.
 	 *
 	 * @param string $task_class Class name of task class.

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -123,12 +123,20 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 	 * Starts a data port job.
 	 *
 	 * @param Sensei_Data_Port_Job $job Job object.
+	 *
+	 * @return bool
 	 */
 	public function start_job( Sensei_Data_Port_Job $job ) {
+		if ( ! $job->is_ready() ) {
+			return false;
+		}
+
 		$this->has_changed = true;
 
 		$job->start();
 		Sensei_Scheduler::instance()->schedule_job( $job );
+
+		return true;
 	}
 
 	/**

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -127,7 +127,7 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 	 * @return bool
 	 */
 	public function start_job( Sensei_Data_Port_Job $job ) {
-		if ( ! $job->is_ready() ) {
+		if ( ! $job->is_ready() || $job->is_started() ) {
 			return false;
 		}
 

--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -95,6 +95,17 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 	}
 
 	/**
+	 * Check if a job is ready to be started.
+	 *
+	 * @return bool
+	 */
+	public function is_ready() {
+		$files = $this->get_files();
+
+		return isset( $files['questions'] ) || isset( $files['courses'] ) || isset( $files['lessons'] );
+	}
+
+	/**
 	 * Save a file associated with this job. If this is an uploaded file, `is_uploaded_file()` check should
 	 * occur prior to this method.
 	 *

--- a/includes/rest-api/class-sensei-rest-api-data-port-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-data-port-controller.php
@@ -185,6 +185,14 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 			);
 		}
 
+		if ( $job->is_started() ) {
+			return new WP_Error(
+				'sensei_data_port_job_already_started',
+				__( 'Job has already been started.', 'sensei-lms' ),
+				array( 'status' => 400 )
+			);
+		}
+
 		if ( ! Sensei_Data_Port_Manager::instance()->start_job( $job ) ) {
 			return new WP_Error(
 				'sensei_data_port_job_could_not_be_started',

--- a/tests/framework/data-port/class-sensei-data-port-job-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-job-mock.php
@@ -52,4 +52,7 @@ class Sensei_Data_Port_Job_Mock extends Sensei_Data_Port_Job {
 		return $files;
 	}
 
+	public function is_ready() {
+		return true;
+	}
 }

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
@@ -100,7 +100,7 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 
 		if ( $is_authorized ) {
 			$this->assertTrue( isset( $response->get_data()['code'] ) );
-			$this->assertEquals( 'rest_no_active_job', $response->get_data()['code'] );
+			$this->assertEquals( 'sensei_data_port_no_active_job', $response->get_data()['code'] );
 		}
 	}
 
@@ -215,7 +215,7 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 
 		if ( $is_authorized ) {
 			$this->assertTrue( isset( $response->get_data()['code'] ) );
-			$this->assertEquals( 'rest_no_active_job', $response->get_data()['code'] );
+			$this->assertEquals( 'sensei_data_port_no_active_job', $response->get_data()['code'] );
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds an endpoint to start a data port job when ready.

### Testing instructions

* Create a new import job and make sure it has at least one file.
* `POST /wp-json/sensei-internal/v1/import/start` and verify it passes back the job object and the job has been scheduled.