### PR TITLE
Exit fullscreen on Ready step

### DIFF
--- a/assets/onboarding/fullscreen.scss
+++ b/assets/onboarding/fullscreen.scss
@@ -1,5 +1,18 @@
 
 body.sensei-wp-admin-fullscreen {
+	#adminmenumain, #wpcontent {
+		transition: margin-left 300ms cubic-bezier(0.42, 0, 0.58, 1);
+	}
+	#adminmenumain {
+		margin-left: 0;
+	}
+}
+
+body.sensei-wp-admin-fullscreen--active {
+
+	#adminmenumain {
+		margin-left: -160px;
+	}
 
 	#wpwrap {
 		top: 0;
@@ -9,7 +22,6 @@ body.sensei-wp-admin-fullscreen {
 		min-height: 100%;
 	}
 
-	#adminmenumain,
 	#wpcontent > *,
 	.error,
 	.notice,
@@ -17,6 +29,13 @@ body.sensei-wp-admin-fullscreen {
 	.updated,
 	#wpfooter {
 		display: none;
+	}
+
+	#wpadminbar {
+		display: block;
+		* {
+			display: none;
+		}
 	}
 
 	#wpcontent {

--- a/assets/onboarding/ready/index.jsx
+++ b/assets/onboarding/ready/index.jsx
@@ -1,73 +1,81 @@
 import { Card, H, Link, List, Section } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
+import { useWpAdminFullscreen } from '../../react-hooks';
 import { MailingListSignupForm } from './mailinglist-signup-form';
 import { formatString } from '../helpers/format-string.js';
 
 /**
  * Ready step for Setup Wizard.
  */
-export const Ready = () => (
-	<>
-		<div className="sensei-onboarding__title">
-			<H>
-				{ __(
-					`You're ready to start creating online courses!`,
-					'sensei-lms'
-				) }
-			</H>
-		</div>
-		<Card className="sensei-onboarding__card">
-			<Section className="sensei-onboarding__mailinglist-signup">
-				<H>{ __( `Join our mailing list`, 'sensei-lms' ) }</H>
-				<p>
+export const Ready = () => {
+	useWpAdminFullscreen( [], false );
+
+	return (
+		<>
+			<div className="sensei-onboarding__title">
+				<H>
 					{ __(
-						`We're here for you — get tips, product updates, and inspiration straight to your mailbox.`,
+						`You're ready to start creating online courses!`,
 						'sensei-lms'
 					) }
-				</p>
-				<MailingListSignupForm />
-			</Section>
-			<Section>
-				<H>{ __( `What's next?`, 'sensei-lms' ) }</H>
-				<List
-					items={ [
-						{
-							title: __( 'Create some courses', 'sensei-lms' ),
-							content: `You're ready to create online courses.`,
-							after: (
-								<Button
-									className="sensei-onboarding__button"
-									isPrimary
-									href="post-new.php?post_type=course"
-								>
-									Create a course
-								</Button>
-							),
-						},
-						{
-							title: 'Learn more',
-							content: formatString(
-								__(
-									'Visit SenseiLMS.com to learn how to {{link}}create your first course.{{/link}}',
+				</H>
+			</div>
+			<Card className="sensei-onboarding__card">
+				<Section className="sensei-onboarding__mailinglist-signup">
+					<H>{ __( `Join our mailing list`, 'sensei-lms' ) }</H>
+					<p>
+						{ __(
+							`We're here for you — get tips, product updates, and inspiration straight to your mailbox.`,
+							'sensei-lms'
+						) }
+					</p>
+					<MailingListSignupForm />
+				</Section>
+				<Section>
+					<H>{ __( `What's next?`, 'sensei-lms' ) }</H>
+					<List
+						items={ [
+							{
+								title: __(
+									'Create some courses',
 									'sensei-lms'
 								),
-								{
-									link: (
-										<Link
-											className="link__color-primary"
-											href="https://senseilms.com/lesson/courses/"
-											target="_blank"
-											type="external"
-										/>
+								content: `You're ready to create online courses.`,
+								after: (
+									<Button
+										className="sensei-onboarding__button"
+										isPrimary
+										href="post-new.php?post_type=course"
+									>
+										Create a course
+									</Button>
+								),
+							},
+							{
+								title: 'Learn more',
+								content: formatString(
+									__(
+										'Visit SenseiLMS.com to learn how to {{link}}create your first course.{{/link}}',
+										'sensei-lms'
 									),
-								}
-							),
-						},
-					] }
-					className="sensei-onboarding__item-list"
-				/>
-			</Section>
-		</Card>
-	</>
-);
+									{
+										link: (
+											<Link
+												className="link__color-primary"
+												href="https://senseilms.com/lesson/courses/"
+												target="_blank"
+												type="external"
+											/>
+										),
+									}
+								),
+							},
+						] }
+						className="sensei-onboarding__item-list"
+					/>
+				</Section>
+			</Card>
+		</>
+	);
+};

--- a/assets/onboarding/style.scss
+++ b/assets/onboarding/style.scss
@@ -33,6 +33,11 @@
 				color: darken($primary, 20%);
 			}
 		}
+
+		#wpcontent,
+		#wpbody-content {
+			padding: 0;
+		}
 	}
 
 	&__header {

--- a/assets/react-hooks/use-wp-admin-fullscreen.js
+++ b/assets/react-hooks/use-wp-admin-fullscreen.js
@@ -7,13 +7,14 @@ import { useLayoutEffect } from '@wordpress/element';
  * Fullscreen and classes are added when the component is mounted, and removed when unmounted.
  *
  * @param {string[]} bodyClasses Additional classes to be set.
+ * @param {boolean} [active]     Enable or disable fullscreen.
  */
-const useWpAdminFullscreen = ( bodyClasses = [] ) => {
+const useWpAdminFullscreen = ( bodyClasses = [], active = true ) => {
 	const classes = [ ...bodyClasses, 'sensei-wp-admin-fullscreen' ];
 
 	const setupGlobalStyles = () => {
-		toggleGlobalStyles( true );
-		return toggleGlobalStyles.bind( null, false );
+		toggleGlobalStyles( active );
+		return toggleGlobalStyles.bind( null, ! active );
 	};
 
 	const toggleGlobalStyles = ( enabled ) => {

--- a/assets/react-hooks/use-wp-admin-fullscreen.js
+++ b/assets/react-hooks/use-wp-admin-fullscreen.js
@@ -10,9 +10,10 @@ import { useLayoutEffect } from '@wordpress/element';
  * @param {boolean} [active]     Enable or disable fullscreen.
  */
 const useWpAdminFullscreen = ( bodyClasses = [], active = true ) => {
-	const classes = [ ...bodyClasses, 'sensei-wp-admin-fullscreen' ];
+	const classes = [ ...bodyClasses, 'sensei-wp-admin-fullscreen--active' ];
 
 	const setupGlobalStyles = () => {
+		document.body.classList.add( 'sensei-wp-admin-fullscreen' );
 		toggleGlobalStyles( active );
 		return toggleGlobalStyles.bind( null, ! active );
 	};
@@ -20,8 +21,6 @@ const useWpAdminFullscreen = ( bodyClasses = [], active = true ) => {
 	const toggleGlobalStyles = ( enabled ) => {
 		if ( enabled ) document.body.classList.add( ...classes );
 		else document.body.classList.remove( ...classes );
-
-		document.documentElement.classList.toggle( 'wp-toolbar', ! enabled );
 	};
 
 	useLayoutEffect( setupGlobalStyles, [ bodyClasses ] );

--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -153,7 +153,7 @@ class Sensei_Onboarding {
 	 * @return string Extended class list.
 	 */
 	public function filter_body_class( $classes ) {
-		$classes .= ' sensei-wp-admin-fullscreen ';
+		$classes .= ' sensei-wp-admin-fullscreen sensei-wp-admin-fullscreen--active ';
 		return $classes;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Exit fullscreen when reaching ready step.

### Testing instructions

* Just a draft for trying it out, does not work when ready step is accessed directly.
* Open Setup wizard features step. `?page=sensei_onboarding&step=features`
* Finish features step
* Reaching ready step exists fullscreen

### Screenshot / Video
![Screen Recording 2020-05-28 at 19 49 50](https://user-images.githubusercontent.com/176949/83175725-a6558480-a11c-11ea-9ab1-18139059623f.gif)
