### PR TITLE
Fix/issue3206 keep existing post list columns

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -55,6 +55,7 @@ class Sensei_Course {
 			// Custom Write Panel Columns
 			add_filter( 'manage_course_posts_columns', array( $this, 'add_column_headings' ), 10, 1 );
 			add_action( 'manage_course_posts_custom_column', array( $this, 'add_column_data' ), 10, 2 );
+			add_filter( 'default_hidden_columns', array( $this, 'set_default_visible_columns' ), 10, 2 );
 
 			// Enqueue scripts.
 			add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_scripts' ) );
@@ -664,7 +665,8 @@ class Sensei_Course {
 	} // End course_manage_meta_box_content()
 
 	/**
-	 * Add column headings to the "lesson" post list screen.
+	 * Add column headings to the "course" post list screen,
+	 * while moving the existing ones to the end.
 	 *
 	 * @access public
 	 * @since  1.0.0
@@ -680,9 +682,43 @@ class Sensei_Course {
 		if ( isset( $defaults['date'] ) ) {
 			$new_columns['date'] = $defaults['date'];
 		}
+		foreach($defaults as $column_key => $column_value) {
+			if ( ! isset( $new_columns[ $column_key ] ) ) {
+				$new_columns[ $column_key ] = $column_value;
+			}
+		}
 
 		return $new_columns;
 	} // End add_column_headings()
+
+	/**
+	 * Hide all columns by default, leaving only a default list.
+	 *
+	 * @access public
+	 * @since  3.1.0-dev
+	 * @param  array $hidden_columns
+	 * @return WP_Screen $screen
+	 */
+	public function set_default_visible_columns( $hidden_columns, $screen ){
+		$default_course_columns = [
+			'cb',
+			'title',
+			'course-prerequisite',
+			'course-category',
+			'date'
+		];
+		if ( ! $screen instanceof WP_Screen || 'edit-course' !== $screen->id ){
+			return $hidden_columns;
+		}
+		$columns = get_column_headers ($screen);
+		foreach( $columns as $column => $column_value ) {
+			if ( !in_array ( $column, $default_course_columns, true ) ) {
+				$hidden_columns[] = $column;
+			}
+		}
+
+		return $hidden_columns;
+	} // End set_default_visible_columns()
 
 	/**
 	 * Add data for our newly-added custom columns.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -696,9 +696,9 @@ class Sensei_Course {
 	 *
 	 * @access public
 	 * @since  3.1.0-dev
-	 * @param  array $hidden_columns
+	 * @param  array     $hidden_columns
 	 * @param  WP_Screen $screen
-	 * @return array $hidden_columns
+	 * @return array     $hidden_columns
 	 */
 	public function set_default_visible_columns( $hidden_columns, $screen ) {
 		$default_course_columns = [

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -682,7 +682,7 @@ class Sensei_Course {
 		if ( isset( $defaults['date'] ) ) {
 			$new_columns['date'] = $defaults['date'];
 		}
-		foreach($defaults as $column_key => $column_value) {
+		foreach ( $defaults as $column_key => $column_value ) {
 			if ( ! isset( $new_columns[ $column_key ] ) ) {
 				$new_columns[ $column_key ] = $column_value;
 			}
@@ -697,22 +697,23 @@ class Sensei_Course {
 	 * @access public
 	 * @since  3.1.0-dev
 	 * @param  array $hidden_columns
-	 * @return WP_Screen $screen
+	 * @param  WP_Screen $screen
+	 * @return array $hidden_columns
 	 */
-	public function set_default_visible_columns( $hidden_columns, $screen ){
+	public function set_default_visible_columns( $hidden_columns, $screen ) {
 		$default_course_columns = [
 			'cb',
 			'title',
 			'course-prerequisite',
 			'course-category',
-			'date'
+			'date',
 		];
-		if ( ! $screen instanceof WP_Screen || 'edit-course' !== $screen->id ){
+		if ( ! $screen instanceof WP_Screen || 'edit-course' !== $screen->id ) {
 			return $hidden_columns;
 		}
-		$columns = get_column_headers ($screen);
-		foreach( $columns as $column => $column_value ) {
-			if ( !in_array ( $column, $default_course_columns, true ) ) {
+		$columns = get_column_headers( $screen );
+		foreach ( $columns as $column => $column_value ) {
+			if ( ! in_array( $column, $default_course_columns, true ) ) {
 				$hidden_columns[] = $column;
 			}
 		}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -674,7 +674,7 @@ class Sensei_Course {
 	 * @return array $new_columns
 	 */
 	public function add_column_headings( $defaults ) {
-		$new_columns                        = array();
+		$new_columns                        = [];
 		$new_columns['cb']                  = '<input type="checkbox" />';
 		$new_columns['title']               = _x( 'Course Title', 'column name', 'sensei-lms' );
 		$new_columns['course-prerequisite'] = _x( 'Pre-requisite Course', 'column name', 'sensei-lms' );

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2230,8 +2230,7 @@ class Sensei_Lesson {
 		if ( isset( $defaults['date'] ) ) {
 			$new_columns['date'] = $defaults['date'];
 		}
-
-		foreach($defaults as $column_key => $column_value) {
+		foreach ( $defaults as $column_key => $column_value ) {
 			if ( ! isset( $new_columns[ $column_key ] ) ) {
 				$new_columns[ $column_key ] = $column_value;
 			}
@@ -2246,22 +2245,23 @@ class Sensei_Lesson {
 	 * @access public
 	 * @since  3.1.0-dev
 	 * @param  array $hidden_columns
-	 * @return WP_Screen $screen
+	 * @param  WP_Screen $screen
+	 * @return array $hidden_columns
 	 */
-	public function set_default_visible_columns( $hidden_columns, $screen ){
+	public function set_default_visible_columns( $hidden_columns, $screen ) {
 		$default_lesson_columns = [
 			'cb',
 			'title',
 			'lesson-course',
 			'lesson-prerequisite',
-			'date'
+			'date',
 		];
-		if ( ! $screen instanceof WP_Screen || 'edit-lesson' !== $screen->id ){
+		if ( ! $screen instanceof WP_Screen || 'edit-lesson' !== $screen->id ) {
 			return $hidden_columns;
 		}
-		$columns = get_column_headers ($screen);
-		foreach( $columns as $column => $column_value ) {
-			if ( !in_array ( $column, $default_lesson_columns, true ) ) {
+		$columns = get_column_headers( $screen );
+		foreach ( $columns as $column => $column_value ) {
+			if ( ! in_array( $column, $default_lesson_columns, true ) ) {
 				$hidden_columns[] = $column;
 			}
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -47,6 +47,7 @@ class Sensei_Lesson {
 			// Custom Write Panel Columns
 			add_filter( 'manage_edit-lesson_columns', array( $this, 'add_column_headings' ), 10, 1 );
 			add_action( 'manage_posts_custom_column', array( $this, 'add_column_data' ), 10, 2 );
+			add_filter( 'default_hidden_columns', array( $this, 'set_default_visible_columns' ), 10, 2 );
 
 			// Add/Update question
 			add_action( 'wp_ajax_lesson_update_question', array( $this, 'lesson_update_question' ) );
@@ -2212,7 +2213,8 @@ class Sensei_Lesson {
 	} // End enqueue_styles()
 
 	/**
-	 * Add column headings to the "lesson" post list screen.
+	 * Add column headings to the "lesson" post list screen,
+	 * while moving the existing ones to the end.
 	 *
 	 * @access public
 	 * @since  1.0.0
@@ -2220,7 +2222,7 @@ class Sensei_Lesson {
 	 * @return array $new_columns
 	 */
 	public function add_column_headings( $defaults ) {
-		$new_columns                        = array();
+		$new_columns                        = [];
 		$new_columns['cb']                  = '<input type="checkbox" />';
 		$new_columns['title']               = _x( 'Lesson Title', 'column name', 'sensei-lms' );
 		$new_columns['lesson-course']       = _x( 'Course', 'column name', 'sensei-lms' );
@@ -2228,8 +2230,44 @@ class Sensei_Lesson {
 		if ( isset( $defaults['date'] ) ) {
 			$new_columns['date'] = $defaults['date'];
 		}
+
+		foreach($defaults as $column_key => $column_value) {
+			if ( ! isset( $new_columns[ $column_key ] ) ) {
+				$new_columns[ $column_key ] = $column_value;
+			}
+		}
+
 		return $new_columns;
 	} // End add_column_headings()
+
+	/**
+	 * Hide all columns by default, leaving only a default set.
+	 *
+	 * @access public
+	 * @since  3.1.0-dev
+	 * @param  array $hidden_columns
+	 * @return WP_Screen $screen
+	 */
+	public function set_default_visible_columns( $hidden_columns, $screen ){
+		$default_lesson_columns = [
+			'cb',
+			'title',
+			'lesson-course',
+			'lesson-prerequisite',
+			'date'
+		];
+		if ( ! $screen instanceof WP_Screen || 'edit-lesson' !== $screen->id ){
+			return $hidden_columns;
+		}
+		$columns = get_column_headers ($screen);
+		foreach( $columns as $column => $column_value ) {
+			if ( !in_array ( $column, $default_lesson_columns, true ) ) {
+				$hidden_columns[] = $column;
+			}
+		}
+
+		return $hidden_columns;
+	} // End set_default_visible_columns()
 
 	/**
 	 * Add data for our newly-added custom columns.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2244,9 +2244,9 @@ class Sensei_Lesson {
 	 *
 	 * @access public
 	 * @since  3.1.0-dev
-	 * @param  array $hidden_columns
+	 * @param  array     $hidden_columns
 	 * @param  WP_Screen $screen
-	 * @return array $hidden_columns
+	 * @return array     $hidden_columns
 	 */
 	public function set_default_visible_columns( $hidden_columns, $screen ) {
 		$default_lesson_columns = [

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -75,8 +75,8 @@ class Sensei_Question {
 			$new_columns['date'] = $defaults['date'];
 		}
 		// Unset renamed existing columns.
-		unset( $defaults[ 'taxonomy-question-type' ] );
-		unset( $defaults[ 'taxonomy-question-category' ] );
+		unset( $defaults['taxonomy-question-type'] );
+		unset( $defaults['taxonomy-question-category'] );
 
 		foreach ( $defaults as $column_key => $column_value ) {
 			if ( ! isset( $new_columns[ $column_key ] ) ) {
@@ -93,9 +93,9 @@ class Sensei_Question {
 	 *
 	 * @access public
 	 * @since  3.1.0-dev
-	 * @param  array $hidden_columns
+	 * @param  array     $hidden_columns
 	 * @param  WP_Screen $screen
-	 * @return array $hidden_columns
+	 * @return array     $hidden_columns
 	 */
 	public function set_default_visible_columns( $hidden_columns, $screen ) {
 		$default_question_columns = [

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -74,11 +74,11 @@ class Sensei_Question {
 		if ( isset( $defaults['date'] ) ) {
 			$new_columns['date'] = $defaults['date'];
 		}
-		// unset renamed columns
-		unset( $defaults['taxonomy-question-type'] ); 
-		unset( $defaults['taxonomy-question-category'] ); 
-		
-		foreach($defaults as $column_key => $column_value) {
+		// Unset renamed existing columns.
+		unset( $defaults[ 'taxonomy-question-type' ] );
+		unset( $defaults[ 'taxonomy-question-category' ] );
+
+		foreach ( $defaults as $column_key => $column_value ) {
 			if ( ! isset( $new_columns[ $column_key ] ) ) {
 				$new_columns[ $column_key ] = $column_value;
 			}
@@ -94,22 +94,23 @@ class Sensei_Question {
 	 * @access public
 	 * @since  3.1.0-dev
 	 * @param  array $hidden_columns
-	 * @return WP_Screen $screen
+	 * @param  WP_Screen $screen
+	 * @return array $hidden_columns
 	 */
-	public function set_default_visible_columns( $hidden_columns, $screen ){
+	public function set_default_visible_columns( $hidden_columns, $screen ) {
 		$default_question_columns = [
 			'cb',
 			'title',
 			'question-type',
 			'question-category',
-			'date'
+			'date',
 		];
-		if ( ! $screen instanceof WP_Screen || 'edit-question' !== $screen->id ){
+		if ( ! $screen instanceof WP_Screen || 'edit-question' !== $screen->id ) {
 			return $hidden_columns;
 		}
-		$columns = get_column_headers ($screen);
-		foreach( $columns as $column => $column_value ) {
-			if ( !in_array ( $column, $default_question_columns, true ) ) {
+		$columns = get_column_headers( $screen );
+		foreach ( $columns as $column => $column_value ) {
+			if ( ! in_array( $column, $default_question_columns, true ) ) {
 				$hidden_columns[] = $column;
 			}
 		}


### PR DESCRIPTION
Fixes #3206 

### Changes proposed in this Pull Request

* the change impacts the the course, lesson and question post list in admin the goal is to respect added columns by other plugins not build specifically for sensei lms
* in method 'add_column_headings' keep existing columns when adding moving them behind the Sensei LMS columns
* To retain the same clean default presentation a new method "set_default_visible_columns" is added, hooking into the 'default_hidden_columns' filter, hiding all columns except for the sensei-LMS ones that are set by 'add_column_headings'. So this edit respects both the desire for a clean default presentation and the admins options to use the display/screensettings in WordPress.
* I found that the question columns had 2 existing columns added under another name/key in Sensei_Question::add_column_headings , so they either had to use the default name again, or the default version should be omitted from the transfer. I have decided the latter, since that seem to pose the least risk for unforseen problems.

### Testing instructions

* I tested manually and using Kint and Query monitor and checked the error log for reported errors.
* the pages that are intended to be impacted are the course-, lesson- and the question list in wp-admin. Mostly there should be extra columns visible in the screen settings that can be pulled out at the top of the edit-lists pages. They should be unchecked (hidden) by default and remembered if manually changed.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
