### PR TITLE
Send usage tracking data as soon as user opts in

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -299,10 +299,11 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 	 * @return bool Success.
 	 */
 	public function submit_welcome( $data ) {
-
 		$this->mark_step_complete( 'welcome' );
-		Sensei()->usage_tracking->set_tracking_enabled( (bool) $data['usage_tracking'] );
 		$this->setup_wizard->pages->create_pages();
+
+		Sensei()->usage_tracking->set_tracking_enabled( (bool) $data['usage_tracking'] );
+		Sensei()->usage_tracking->send_usage_data();
 
 		return true;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Send `sensei_stats_log` and `sensei_system_log` data as soon as the user opts in to usage tracking in the setup wizard.

### Testing instructions

* Open the setup wizard.
* Click the _Continue_ button and check the box to opt in to usage tracking.
* Click the _Continue_ button on the modal.
* In Tracks, check that the `sensei_stats_log` and `sensei_system_log` events were logged for your site (there will be up to a 15 minute delay).
* Go back to the Welcome step.
* Click the _Continue_ button and _uncheck_ the box to opt out of usage tracking.
* Click the _Continue_ button on the modal.
* In Tracks, check that the `sensei_stats_log` and `sensei_system_log` events were not logged again for your site.