### PR TITLE
Importer: Delete existing files immediately on upload attempt

### DIFF
--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -444,7 +444,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 		// Save the attachment.
 		$id = wp_insert_attachment( $attachment_args, $file_save_path );
 
-		// Make sure to clean up any previous file.
+		// Make sure to clean up any previous file if it wasn't already removed.
 		if ( isset( $this->files[ $file_key ] ) ) {
 			$this->delete_file( $file_key );
 		}

--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -116,6 +116,13 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 	 * @return true|WP_Error
 	 */
 	public function save_file( $file_key, $tmp_file, $file_name ) {
+		$files = $this->get_files();
+
+		// Make sure to clean up any previous file.
+		if ( isset( $files[ $file_key ] ) ) {
+			$this->delete_file( $file_key );
+		}
+
 		$check_file = $this->check_file( $file_key, $tmp_file, $file_name );
 
 		if ( is_wp_error( $check_file ) ) {

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
@@ -264,7 +264,7 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 	 */
 	public function testDeleteFileExists() {
 		if ( ! version_compare( get_bloginfo( 'version' ), '5.0.0', '>=' ) ) {
-			$this->markTestSkipped( 'Test fails with 4.9 due to text/csv getting interpretted as text/plain.' );
+			$this->markTestSkipped( 'Test fails with 4.9 due to text/csv getting interpreted as text/plain.' );
 		}
 
 		$test_file = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/questions.csv';


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Immediately deletes existing files for a file key on upload attempt.

### Testing instructions

* Using the REST API endpoint, upload a valid CSV file for `questions`.
* Attempt to upload an invalid file (JPEG!) for `questions`.
* Verify that the old CSV file has been deleted.
