### PR TITLE
Fix lesson course dropdown width

### DIFF
--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -1,5 +1,5 @@
 jQuery( document ).ready( function( $ ) {
-	$( '#course-prerequisite-options' ).select2( { width:'resolve' } );
+	$( '#course-prerequisite-options' ).select2( { width: '100%' } );
 
 	function trackLinkClickCallback( event_name ) {
 		return function() {
@@ -9,7 +9,9 @@ jQuery( document ).ready( function( $ ) {
 
 			// Get course status from post state if it's available.
 			if ( wp.data && wp.data.select( 'core/editor' ) ) {
-				properties.course_status = wp.data.select( 'core/editor' ).getCurrentPostAttribute( 'status' );
+				properties.course_status = wp.data
+					.select( 'core/editor' )
+					.getCurrentPostAttribute( 'status' );
 			}
 
 			sensei_log_event( event_name, properties );
@@ -17,8 +19,12 @@ jQuery( document ).ready( function( $ ) {
 	}
 
 	// Log when the "Add Lesson" link is clicked.
-	$( 'a.add-course-lesson' ).click( trackLinkClickCallback( 'course_add_lesson_click' ) );
+	$( 'a.add-course-lesson' ).click(
+		trackLinkClickCallback( 'course_add_lesson_click' )
+	);
 
 	// Log when the "Edit Lesson" link is clicked.
-	$( 'a.edit-lesson-action' ).click( trackLinkClickCallback( 'course_edit_lesson_click' ) );
+	$( 'a.edit-lesson-action' ).click(
+		trackLinkClickCallback( 'course_edit_lesson_click' )
+	);
 } );

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2282,7 +2282,7 @@ class Sensei_Utils {
 					'class' => array(),
 					'id'    => array(),
 					'name'  => array(),
-					'style'  => array(),
+					'style' => array(),
 				),
 			)
 		);

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2282,6 +2282,7 @@ class Sensei_Utils {
 					'class' => array(),
 					'id'    => array(),
 					'name'  => array(),
+					'style'  => array(),
 				),
 			)
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix the Course dropdown on the edit lesson page not being full width. 

Before:
<kbd><img width="272" alt="Screenshot 2020-05-29 at 18 50 37" src="https://user-images.githubusercontent.com/176949/83284938-b8e3c280-a1dd-11ea-9db0-75ed2a79822a.png"></kbd> <kbd><img width="276" alt="Screenshot 2020-05-29 at 18 50 57" src="https://user-images.githubusercontent.com/176949/83284925-b41f0e80-a1dd-11ea-897a-202d6771a8f9.png" border="2" /></kbd>

After:
<kbd><img width="276" alt="Screenshot 2020-05-29 at 18 49 55" src="https://user-images.githubusercontent.com/176949/83284944-baad8600-a1dd-11ea-843d-357a157aa1f9.png"></kbd>

### Testing instructions

* Edit a lesson.
* Gaze upon the Course block in the sidebar.

