### PR TITLE
Remove tabs and Most used view from Course module meta box

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2019,20 +2019,9 @@ class Sensei_Core_Modules {
 
 		?>
 		<div id="taxonomy-<?php echo esc_attr( $tax_name ); ?>" class="categorydiv">
-			<ul id="<?php echo esc_attr( $tax_name ); ?>-tabs" class="category-tabs">
-				<li class="tabs"><a href="#<?php echo esc_url( $tax_name ); ?>-all"><?php echo esc_html( $taxonomy->labels->all_items ); ?></a></li>
-				<li class="hide-if-no-js"><a href="#<?php echo esc_url( $tax_name ); ?>-pop"><?php esc_html_e( 'Most Used', 'sensei-lms' ); ?></a></li>
-			</ul>
-
-			<div id="<?php echo esc_attr( $tax_name ); ?>-pop" class="tabs-panel" style="display: none;">
-				<ul id="<?php echo esc_attr( $tax_name ); ?>checklist-pop" class="categorychecklist form-no-clear" >
-					<?php $popular_ids = wp_popular_terms_checklist( $tax_name ); ?>
-				</ul>
-			</div>
-
 			<div id="<?php echo esc_attr( $tax_name ); ?>-all" class="tabs-panel">
 				<?php
-				$name = ( $tax_name == 'category' ) ? 'post_category' : 'tax_input[' . $tax_name . ']';
+				$name = ( $tax_name === 'category' ) ? 'post_category' : 'tax_input[' . $tax_name . ']';
 				echo "<input type='hidden' name='" . esc_attr( $name ) . "[]' value='0' />"; // Allows for an empty term set to be sent. 0 is an invalid Term ID and will be ignored by empty() checks.
 				?>
 				<ul id="<?php echo esc_attr( $tax_name ); ?>checklist" data-wp-lists="list:<?php echo esc_attr( $tax_name ); ?>" class="categorychecklist form-no-clear">
@@ -2040,8 +2029,7 @@ class Sensei_Core_Modules {
 					wp_terms_checklist(
 						$post->ID,
 						array(
-							'taxonomy'     => $tax_name,
-							'popular_cats' => $popular_ids,
+							'taxonomy' => $tax_name,
 						)
 					);
 					?>


### PR DESCRIPTION
Fixes #3207

### Changes proposed in this Pull Request

* Remove the `Most used` functionality from the Course Modules meta box.
* Also remove the tabs as there is only one view now.

The current state of this came from copying the original Wordpress category meta box (I assume for some module quirks). 

The block editor introduced a different component for categories, and the Javascript that made the tabs work in the old one is not loaded. (There was also a separate escaping issue breaking it in the Classic editor.)

Since there is little point in the `Most used` feature here, and the new taxonomy boxes don't have it either, let's just remove it. 

### Testing instructions

* Edit a course
* Selecting modules in the sidebar should keep working

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
<img width="283" alt="Screenshot 2020-05-29 at 22 24 58" src="https://user-images.githubusercontent.com/176949/83302935-78477180-a1fc-11ea-92f8-5ee2dd8e2d5f.png">
