### PR TITLE
Importer: Add taxonomy utility

### DIFF
--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -63,7 +63,7 @@ class Sensei_Data_Port_Utilities {
 
 		foreach ( $term_path as $term_name ) {
 			$term_name = trim( $term_name );
-			$parent_id = isset( $last_term ) ? $last_term->term_id : null;
+			$parent_id = isset( $last_term ) ? $last_term->term_id : 0;
 
 			$term_query = new WP_Term_Query( self::get_term_query_args( $term_name, $taxonomy_name, $teacher_user_id, $parent_id ) );
 			$terms      = $term_query->get_terms();
@@ -109,20 +109,17 @@ class Sensei_Data_Port_Utilities {
 	 *
 	 * @return array
 	 */
-	private static function get_term_query_args( $term_name, $taxonomy_name, $teacher_user_id, $parent_id = null ) {
+	private static function get_term_query_args( $term_name, $taxonomy_name, $teacher_user_id, $parent_id = 0 ) {
 		$args               = [];
 		$args['number']     = 1;
 		$args['taxonomy']   = $taxonomy_name;
 		$args['hide_empty'] = false;
+		$args['parent']     = $parent_id;
 
 		if ( 'module' === $taxonomy_name ) {
 			$args['slug'] = self::get_term_slug( $term_name, $taxonomy_name, $teacher_user_id );
 		} else {
 			$args['name'] = $term_name;
-		}
-
-		if ( $parent_id ) {
-			$args['parent'] = $parent_id;
 		}
 
 		return $args;

--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -31,4 +31,126 @@ class Sensei_Data_Port_Utilities {
 
 		return $user->ID;
 	}
+
+	/**
+	 * Cet a term based on human readable string and create it if needed. If the taxonomy is hierarchical,
+	 * this method processes that as well and returns the \WP_Term object for the last in their hierarchy.
+	 *
+	 * @param string $term_name_path  Term name with optional hierarchy path, separated by " > ".
+	 * @param string $taxonomy_name   Name of the taxonomy.
+	 * @param int    $teacher_user_id User ID for the teacher (only needed for modules).
+	 *
+	 * @return WP_Term|false
+	 */
+	public static function get_term( $term_name_path, $taxonomy_name, $teacher_user_id = null ) {
+		$taxonomy = get_taxonomy( $taxonomy_name );
+		if ( ! $taxonomy ) {
+			return false;
+		}
+
+		if ( $taxonomy->hierarchical ) {
+			$term_path = preg_split( '/ ?\> ?/', $term_name_path );
+		} else {
+			$term_path = [ $term_name_path ];
+		}
+
+		/**
+		 * Last term object.
+		 *
+		 * @var WP_Term $last_term
+		 */
+		$last_term = null;
+
+		foreach ( $term_path as $term_name ) {
+			$term_name = trim( $term_name );
+			$parent_id = isset( $last_term ) ? $last_term->term_id : null;
+
+			$term_query = new WP_Term_Query( self::get_term_query_args( $term_name, $taxonomy_name, $teacher_user_id, $parent_id ) );
+			$terms      = $term_query->get_terms();
+
+			if ( ! empty( $terms ) ) {
+				$last_term = array_shift( $terms );
+			} else {
+				$last_term = self::create_term( $term_name, $taxonomy_name, $teacher_user_id, $parent_id );
+			}
+
+			if ( ! $last_term ) {
+				return false;
+			}
+		}
+
+		return $last_term;
+	}
+
+	/**
+	 * Generate the term slug.
+	 *
+	 * @param string $term_name       Term name.
+	 * @param string $taxonomy_name   Name of the taxonomy.
+	 * @param int    $teacher_user_id User ID for the teacher.
+	 *
+	 * @return string
+	 */
+	private static function get_term_slug( $term_name, $taxonomy_name, $teacher_user_id ) {
+		if ( 'module' === $taxonomy_name && ! user_can( $teacher_user_id, 'manage_options' ) ) {
+			return intval( $teacher_user_id ) . '-' . sanitize_title( $term_name );
+		}
+
+		return sanitize_title( $term_name );
+	}
+
+	/**
+	 * Generate the arguments for the term query.
+	 *
+	 * @param string $term_name       Term name.
+	 * @param string $taxonomy_name   Name of the taxonomy.
+	 * @param int    $teacher_user_id User ID for the teacher.
+	 * @param int    $parent_id       Parent ID (optional).
+	 *
+	 * @return array
+	 */
+	private static function get_term_query_args( $term_name, $taxonomy_name, $teacher_user_id, $parent_id = null ) {
+		$args               = [];
+		$args['number']     = 1;
+		$args['taxonomy']   = $taxonomy_name;
+		$args['hide_empty'] = false;
+
+		if ( 'module' === $taxonomy_name ) {
+			$args['slug'] = self::get_term_slug( $term_name, $taxonomy_name, $teacher_user_id );
+		} else {
+			$args['name'] = $term_name;
+		}
+
+		if ( $parent_id ) {
+			$args['parent'] = $parent_id;
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Create a new term.
+	 *
+	 * @param string $term_name       Term name.
+	 * @param string $taxonomy_name   Name of the taxonomy.
+	 * @param int    $teacher_user_id User ID for the teacher.
+	 * @param int    $parent_id       Parent ID (optional).
+	 *
+	 * @return WP_Term|false
+	 */
+	private static function create_term( $term_name, $taxonomy_name, $teacher_user_id, $parent_id = null ) {
+		$args         = [];
+		$args['slug'] = self::get_term_slug( $term_name, $taxonomy_name, $teacher_user_id );
+
+		if ( $parent_id ) {
+			$args['parent'] = $parent_id;
+		}
+
+		$term_arr = wp_insert_term( $term_name, $taxonomy_name, $args );
+		if ( is_wp_error( $term_arr ) ) {
+			return false;
+		}
+
+		return get_term_by( 'id', $term_arr['term_id'], $taxonomy_name );
+	}
 }

--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -33,7 +33,7 @@ class Sensei_Data_Port_Utilities {
 	}
 
 	/**
-	 * Cet a term based on human readable string and create it if needed. If the taxonomy is hierarchical,
+	 * Get a term based on human readable string and create it if needed. If the taxonomy is hierarchical,
 	 * this method processes that as well and returns the \WP_Term object for the last in their hierarchy.
 	 *
 	 * @param string $term_name_path  Term name with optional hierarchy path, separated by " > ".
@@ -49,7 +49,7 @@ class Sensei_Data_Port_Utilities {
 		}
 
 		if ( $taxonomy->hierarchical ) {
-			$term_path = preg_split( '/ ?\> ?/', $term_name_path );
+			$term_path = preg_split( '/ ?> ?/', $term_name_path );
 		} else {
 			$term_path = [ $term_name_path ];
 		}

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
@@ -46,6 +46,48 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests a matching non-parent name from a different path is not used.
+	 */
+	public function testGetTermComplexPathCourseCategory() {
+		$term_path_a   = [ 'Dinosaur', 'Pizza', 'Taco' ];
+		$term_path_b   = [ 'Pizza', 'Taco', 'Dinosaur' ];
+		$taxonomy_name = 'course-category';
+
+		$term_a = Sensei_Data_Port_Utilities::get_term( implode( ' > ', $term_path_a ), $taxonomy_name );
+		$term_b = Sensei_Data_Port_Utilities::get_term( implode( ' > ', $term_path_b ), $taxonomy_name );
+
+		$this->assertTermPathValid( $term_path_a, $term_a, $taxonomy_name );
+		$this->assertTermPathValid( $term_path_b, $term_b, $taxonomy_name );
+
+		$term_path_a_ids = [];
+		while ( $term_a ) {
+			$term_path_a_ids[] = $term_a->term_id;
+
+			if ( ! $term_a->parent ) {
+				break;
+			}
+
+			$term_a = get_term_by( 'id', $term_a->parent, $taxonomy_name );
+		}
+
+		$term_path_b_ids = [];
+		while ( $term_b ) {
+			$term_path_b_ids[] = $term_b->term_id;
+
+			if ( ! $term_b->parent ) {
+				break;
+			}
+
+			$term_b = get_term_by( 'id', $term_b->parent, $taxonomy_name );
+		}
+
+		$this->assertEquals( count( $term_path_a ), count( $term_path_a_ids ), 'A: IDs should match size of path' );
+		$this->assertEquals( count( $term_path_b ), count( $term_path_b_ids ), 'B: IDs should match size of path' );
+		$this->assertEmpty( array_intersect( $term_path_a_ids, $term_path_b_ids ), 'There should be no similar IDs in the paths' );
+	}
+
+
+	/**
 	 * Tests a term path on a non-hierarchical taxonomy.
 	 */
 	public function testGetTermNonHierarchicalPath() {

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
@@ -168,7 +168,8 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Assert a term path is valid.
+	 * Assert a term path is valid by traversing up the parent path of the last term and making
+	 * sure it matches the array `$term_path`.
 	 *
 	 * @param array         $term_path     Remaining term path.
 	 * @param WP_Term|false $last_term     Latest term to be found.

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
@@ -86,6 +86,47 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 		$this->assertEmpty( array_intersect( $term_path_a_ids, $term_path_b_ids ), 'There should be no similar IDs in the paths' );
 	}
 
+	/**
+	 * Tests a matching parent name is shared among paths.
+	 */
+	public function testGetTermComplexSharedPathCourseCategory() {
+		$term_path_a   = [ 'Dinosaur', 'Pizza', 'Taco' ];
+		$term_path_b   = [ 'Dinosaur', 'Taco' ];
+		$taxonomy_name = 'course-category';
+
+		$term_a = Sensei_Data_Port_Utilities::get_term( implode( ' > ', $term_path_a ), $taxonomy_name );
+		$term_b = Sensei_Data_Port_Utilities::get_term( implode( ' > ', $term_path_b ), $taxonomy_name );
+
+		$this->assertTermPathValid( $term_path_a, $term_a, $taxonomy_name );
+		$this->assertTermPathValid( $term_path_b, $term_b, $taxonomy_name );
+
+		$term_path_a_ids = [];
+		while ( $term_a ) {
+			$term_path_a_ids[] = $term_a->term_id;
+
+			if ( ! $term_a->parent ) {
+				break;
+			}
+
+			$term_a = get_term_by( 'id', $term_a->parent, $taxonomy_name );
+		}
+
+		$term_path_b_ids = [];
+		while ( $term_b ) {
+			$term_path_b_ids[] = $term_b->term_id;
+
+			if ( ! $term_b->parent ) {
+				break;
+			}
+
+			$term_b = get_term_by( 'id', $term_b->parent, $taxonomy_name );
+		}
+
+		$this->assertEquals( count( $term_path_a ), count( $term_path_a_ids ), 'A: IDs should match size of path' );
+		$this->assertEquals( count( $term_path_b ), count( $term_path_b_ids ), 'B: IDs should match size of path' );
+		$this->assertEquals( 1, count( array_intersect( $term_path_a_ids, $term_path_b_ids ) ), 'There should be no similar IDs in the paths' );
+		$this->assertEquals( $term_path_a_ids[2], $term_path_b_ids[1], 'The first term in each path should be the same' );
+	}
 
 	/**
 	 * Tests a term path on a non-hierarchical taxonomy.


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds a helper to create and retrieve a term based on a hierarchical string of term names separated by ` > `. 

Some Examples:
- `Module A > Module B > Module C` will create (or ensure it exists) term `Module A` with no parent, `Module B` as a child of `Module A`, and then `Module C` as a child of `Module B`. It will then return `Module C`. 
- These paths will have no similar term IDs (total terms: 6):
  - `Pizza > Taco > Dinosaur`
  - `Taco > Pizza > Dinosaur`
- These paths will have a similar ID for `Pizza` (total terms: 5):
  - `Pizza > Taco > Dinosaur`
  - `Pizza > Dinosaur > Taco`
- Likewise, a term on its own will expect no parent (total terms: 3):
  - `Pizza > Taco`
  - `Taco`

### Testing instructions

* No functional changes.
