### PR TITLE
Add exit link to Setup Wizard ready step

### DIFF
--- a/assets/onboarding/ready/index.jsx
+++ b/assets/onboarding/ready/index.jsx
@@ -1,4 +1,4 @@
-import { Card, H, Link, List, Section } from '@woocommerce/components';
+import { Card, H, List, Section } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { MailingListSignupForm } from './mailinglist-signup-form';
@@ -54,11 +54,12 @@ export const Ready = () => (
 								),
 								{
 									link: (
-										<Link
+										// eslint-disable-next-line jsx-a11y/anchor-has-content
+										<a
 											className="link__color-primary"
 											href="https://senseilms.com/lesson/courses/"
 											target="_blank"
-											type="external"
+											rel="noopener noreferrer"
 										/>
 									),
 								}
@@ -70,13 +71,9 @@ export const Ready = () => (
 			</Section>
 		</Card>
 		<div className="sensei-onboarding__bottom-actions">
-			<Link
-				href="edit.php?post_type=course"
-				type="wp-admin"
-				className="link__secondary"
-			>
+			<a href="edit.php?post_type=course" className="link__secondary">
 				{ __( 'Exit to Courses', 'sensei-lms' ) }
-			</Link>
+			</a>
 		</div>
 	</>
 );

--- a/assets/onboarding/ready/index.jsx
+++ b/assets/onboarding/ready/index.jsx
@@ -69,5 +69,10 @@ export const Ready = () => (
 				/>
 			</Section>
 		</Card>
+		<div className="sensei-onboarding__bottom-actions">
+			<Link href="edit.php?post_type=course" type="wp-admin">
+				{ __( 'Exit to Courses', 'sensei-lms' ) }
+			</Link>
+		</div>
 	</>
 );

--- a/assets/onboarding/ready/index.jsx
+++ b/assets/onboarding/ready/index.jsx
@@ -70,7 +70,11 @@ export const Ready = () => (
 			</Section>
 		</Card>
 		<div className="sensei-onboarding__bottom-actions">
-			<Link href="edit.php?post_type=course" type="wp-admin">
+			<Link
+				href="edit.php?post_type=course"
+				type="wp-admin"
+				className="link__secondary"
+			>
 				{ __( 'Exit to Courses', 'sensei-lms' ) }
 			</Link>
 		</div>

--- a/assets/onboarding/style.scss
+++ b/assets/onboarding/style.scss
@@ -113,6 +113,7 @@
 
 	&__bottom-actions {
 		text-align: center;
+		font-size: 14px;
 	}
 
 	&__title {

--- a/assets/onboarding/welcome/index.jsx
+++ b/assets/onboarding/welcome/index.jsx
@@ -57,7 +57,11 @@ export const Welcome = () => {
 				</Button>
 			</Card>
 			<div className="sensei-onboarding__bottom-actions">
-				<Link href="edit.php?post_type=course" type="wp-admin">
+				<Link
+					href="edit.php?post_type=course"
+					type="wp-admin"
+					className="link__secondary"
+				>
 					{ __( 'Not right now', 'sensei-lms' ) }
 				</Link>
 			</div>

--- a/assets/onboarding/wp-colors.scss
+++ b/assets/onboarding/wp-colors.scss
@@ -78,8 +78,9 @@ body.sensei-color {
 			color: lighten($link, 20%);
 		}
 
-		&:focus {
+		&:not(.components-button):focus {
 			color: darken($link, 20%);
+			box-shadow: 0 0 0 1px $link-primary, 0 0 2px 1px rgba($link-primary, 0.8);
 		}
 
 		&.link__color-primary {
@@ -95,6 +96,12 @@ body.sensei-color {
 			}
 		}
 
+		&.link__secondary {
+			transition: none;
+			&:not(:hover) {
+				text-decoration: none;
+			}
+		}
 	}
 
 	.components-checkbox-control__input[type='checkbox'] {

--- a/assets/onboarding/wp-colors.scss
+++ b/assets/onboarding/wp-colors.scss
@@ -95,13 +95,6 @@ body.sensei-color {
 				color: darken($link-primary, 20%);
 			}
 		}
-
-		&.link__secondary {
-			transition: none;
-			&:not(:hover) {
-				text-decoration: none;
-			}
-		}
 	}
 
 	.components-checkbox-control__input[type='checkbox'] {


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Add an `Exit to courses` link.
* Also fix some focus styling issues for links and secondary buttons.
* Make these bottom links the same font size as the rest of the text.

### Testing instructions

* Exit to courses on Ready step should appear and take to courses page.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="545" alt="Screenshot 2020-05-30 at 1 06 37" src="https://user-images.githubusercontent.com/176949/83312218-df235580-a211-11ea-9740-01c97b1369fa.png">
