### PR TITLE
Use rootDir in Jest ignore patterns for Travis CI compatibility

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,9 @@ const baseConfig = require( '@wordpress/scripts/config/jest-unit.config.js' );
 
 module.exports = {
 	...baseConfig,
-	testPathIgnorePatterns: [ '/node_modules/', '/build/', '/assets/dist/' ],
+	testPathIgnorePatterns: [
+		'/node_modules/',
+		'<rootDir>/build/',
+		'<rootDir>/assets/dist/',
+	],
 };

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "run-phpcs": "./vendor/bin/phpcs --encoding=utf-8",
     "start": "calypso-build --watch",
     "test": "npm run test-php && npm run test-js",
-    "test-js": "wp-scripts test-unit-js --passWithNoTests",
+    "test-js": "wp-scripts test-unit-js",
     "test-php": "./vendor/bin/phpunit"
   },
   "husky": {


### PR DESCRIPTION
Fixes Travis JS unit tests.

### Changes proposed in this Pull Request

* Add <rootDir> to ignore patterns, as Travis checks out the files in a `build/` directory, which this picked up. 
