### PR TITLE
Filter extensions by dotorg in the Setup Wizard

### DIFF
--- a/includes/admin/class-sensei-onboarding.php
+++ b/includes/admin/class-sensei-onboarding.php
@@ -457,7 +457,7 @@ class Sensei_Onboarding {
 
 				return $this->get_feature_with_status( $extension, $installing_plugins );
 			},
-			$sensei_extensions->get_extensions( 'plugin', 'setup-wizard-extensions' )
+			$sensei_extensions->get_extensions( 'plugin', 'setup-wizard-extensions', [ 'hosted-location' => 'dotorg' ] )
 		);
 
 		return $extensions;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update the Sensei extensions URL adding the `hosted-location=dotorg`. When we add support to WooCommerce plugins installation, we should just remove this argument.

### Testing instructions

* Remove the transient with the name `%sensei_extensions_%`.
* Go to /wp-admin/admin.php?page=sensei_onboarding&step=features and make sure that only dotorg extensions appear.