### PR TITLE
Bump minimum required WordPress version to 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ jobs:
         - ./tests/bin/run-wp-unit-tests.sh
     - stage: test
       php: 5.6
-      env: WP_VERSION=4.9
+      env: WP_VERSION=5.0
       script:
         - ./tests/bin/run-wp-unit-tests.sh
     - stage: test

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Sensei LMS ===
 Contributors: automattic, alexsanford1, donnapep, jakeom, gikaragia, renathoc, yscik, dwainm, panosktn, jeffikus
 Tags: elearning, lms, learning management system, teach, tutor
-Requires at least: 4.9
+Requires at least: 5.0
 Tested up to: 5.4
 Requires PHP: 5.6
 Stable tag: 3.0.1

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -7,8 +7,8 @@
  * Author: Automattic
  * Author URI: https://automattic.com
  * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- * Requires at least: 4.9
- * Tested up to: 5.3
+ * Requires at least: 5.0
+ * Tested up to: 5.4
  * Requires PHP: 5.6
  * Text Domain: sensei-lms
  * Domain path: /lang/


### PR DESCRIPTION
- Bump the minimum required WordPress version to 5.0
- Update tested version to 5.4