### PR TITLE
Add features installation tracking

### DIFF
--- a/assets/onboarding/features/index.jsx
+++ b/assets/onboarding/features/index.jsx
@@ -97,6 +97,10 @@ const Features = () => {
 
 	const retryInstallation = ( selected ) => {
 		submitInstallation( { selected } );
+
+		logEvent( 'setup_wizard_features_install_retry', {
+			slug: selected.join( ',' ),
+		} );
 	};
 
 	const goToNextStep = () => {

--- a/assets/onboarding/features/index.jsx
+++ b/assets/onboarding/features/index.jsx
@@ -110,9 +110,11 @@ const Features = () => {
 	const goToNextStep = ( skip = false ) => {
 		goTo( 'ready' );
 
-		const eventName = skip
-			? 'setup_wizard_features_install_cancel'
-			: 'setup_wizard_features_continue';
+		const eventName =
+			true === skip
+				? 'setup_wizard_features_install_cancel'
+				: 'setup_wizard_features_continue';
+
 		logEvent( eventName, {
 			slug: selectedSlugs.join( ',' ),
 		} );

--- a/assets/onboarding/features/index.jsx
+++ b/assets/onboarding/features/index.jsx
@@ -93,6 +93,10 @@ const Features = () => {
 				},
 			}
 		);
+
+		logEvent( 'setup_wizard_features_install', {
+			slug: selectedSlugs.join( ',' ),
+		} );
 	};
 
 	const retryInstallation = ( selected ) => {

--- a/assets/onboarding/features/index.jsx
+++ b/assets/onboarding/features/index.jsx
@@ -107,10 +107,13 @@ const Features = () => {
 		} );
 	};
 
-	const goToNextStep = () => {
+	const goToNextStep = ( skip = false ) => {
 		goTo( 'ready' );
 
-		logEvent( 'setup_wizard_features_continue', {
+		const eventName = skip
+			? 'setup_wizard_features_install_cancel'
+			: 'setup_wizard_features_continue';
+		logEvent( eventName, {
 			slug: selectedSlugs.join( ',' ),
 		} );
 	};
@@ -149,7 +152,7 @@ const Features = () => {
 					isSubmitting={ isSubmitting }
 					errorNotice={ errorNotice }
 					onInstall={ startInstallation }
-					onSkip={ goToNextStep }
+					onSkip={ () => goToNextStep( true ) }
 				/>
 			) }
 		</>

--- a/assets/onboarding/features/index.test.js
+++ b/assets/onboarding/features/index.test.js
@@ -205,4 +205,59 @@ describe( '<Features />', () => {
 			}
 		);
 	} );
+
+	it( 'Should log installation skipping', () => {
+		const { queryByText, getByLabelText } = render(
+			<QueryStringRouter>
+				<Features />
+			</QueryStringRouter>
+		);
+
+		// Check the first feature.
+		fireEvent.click( getByLabelText( 'Test 1' ) );
+
+		fireEvent.click( queryByText( 'Continue' ) );
+		fireEvent.click( queryByText( "I'll do it later" ) );
+
+		expect( window.sensei_log_event ).toHaveBeenCalledWith(
+			'setup_wizard_features_install_cancel',
+			{
+				slug: 'test-1',
+			}
+		);
+	} );
+
+	it( 'Should log installation retries', () => {
+		useFeaturesPolling.mockReturnValue( {
+			selected: [ 'test-1', 'test-2' ],
+			options: [
+				{ slug: 'test-1', title: 'Test 1', status: 'error' },
+				{ slug: 'test-2', title: 'Test 2', status: 'error' },
+			],
+		} );
+
+		const { queryByText, getByLabelText } = render(
+			<QueryStringRouter>
+				<Features />
+			</QueryStringRouter>
+		);
+		fireEvent.click( getByLabelText( 'Test 1' ) );
+		fireEvent.click( getByLabelText( 'Test 2' ) );
+
+		// Submit data.
+		fireEvent.click( queryByText( 'Continue' ) );
+
+		// Confirm the installation.
+		fireEvent.click( queryByText( 'Install now' ) );
+
+		// Retry installations.
+		fireEvent.click( queryByText( 'Retry' ) );
+
+		expect( window.sensei_log_event ).toHaveBeenCalledWith(
+			'setup_wizard_features_install_retry',
+			{
+				slug: 'test-1,test-2',
+			}
+		);
+	} );
 } );

--- a/assets/onboarding/features/index.test.js
+++ b/assets/onboarding/features/index.test.js
@@ -168,7 +168,7 @@ describe( '<Features />', () => {
 		);
 	} );
 
-	it( 'Should log event after installing when features selected', () => {
+	it( 'Should log events after installing features and continuing', () => {
 		useFeaturesPolling.mockReturnValue( {
 			selected: [ 'test-1', 'test-2' ],
 			options: [
@@ -189,6 +189,13 @@ describe( '<Features />', () => {
 
 		fireEvent.click( queryByText( 'Continue' ) );
 		fireEvent.click( queryByText( 'Install now' ) );
+		expect( window.sensei_log_event ).toHaveBeenCalledWith(
+			'setup_wizard_features_install',
+			{
+				slug: 'test-2,test-1',
+			}
+		);
+
 		fireEvent.click( queryByText( 'Continue' ) );
 
 		expect( window.sensei_log_event ).toHaveBeenCalledWith(

--- a/assets/onboarding/features/index.test.js
+++ b/assets/onboarding/features/index.test.js
@@ -169,13 +169,21 @@ describe( '<Features />', () => {
 	} );
 
 	it( 'Should log event after installing when features selected', () => {
+		useFeaturesPolling.mockReturnValue( {
+			selected: [ 'test-1', 'test-2' ],
+			options: [
+				{ slug: 'test-1', title: 'Test 1' },
+				{ slug: 'test-2', title: 'Test 2' },
+			],
+		} );
+
 		const { queryByText, getByLabelText } = render(
 			<QueryStringRouter>
 				<Features />
 			</QueryStringRouter>
 		);
 
-		// Check the first feature.
+		// Check the two features.
 		fireEvent.click( getByLabelText( 'Test 1' ) );
 		fireEvent.click( getByLabelText( 'Test 2' ) );
 

--- a/includes/admin/class-sensei-plugins-installation.php
+++ b/includes/admin/class-sensei-plugins-installation.php
@@ -233,26 +233,39 @@ class Sensei_Plugins_Installation {
 		}
 
 		$this->set_installing_plugins( $installing_plugins );
+
+		sensei_log_event(
+			'setup_wizard_features_install_error',
+			[
+				'slug'  => $slug,
+				'error' => $message,
+			]
+		);
 	}
 
 	/**
 	 * Complete installation removing the plugin from the transient.
 	 *
-	 * @param string $plugin_slug
+	 * @param string $slug
 	 */
-	private function complete_installation( $plugin_slug ) {
+	private function complete_installation( $slug ) {
 		$installing_plugins = $this->get_installing_plugins();
 
 		if ( ! empty( $installing_plugins ) ) {
 			$installing_plugins = array_filter(
 				$installing_plugins,
-				function( $plugin ) use ( $plugin_slug ) {
-					return $plugin->product_slug !== $plugin_slug;
+				function( $plugin ) use ( $slug ) {
+					return $plugin->product_slug !== $slug;
 				}
 			);
 
 			$this->set_installing_plugins( $installing_plugins );
 		}
+
+		sensei_log_event(
+			'setup_wizard_features_install_success',
+			[ 'slug' => $slug ]
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3195

### Changes proposed in this Pull Request

* Add feature installation tracks. Track details in the issue #3195

### Testing instructions

(If you don't have more plugins to install during the tests, just deactivate or uninstall them)

* Go to the setup wizard.
* Go to the Features step.
* Install some features and make sure the event `sensei_setup_wizard_features_install` was tracked with the slugs while starting the installation. When the installations finish, make sure the event `sensei_setup_wizard_features_install_success` was tracked.
* Repeat the process simulating an error. You can add a 
```php
throw new Exception( "Error message" );
```
before the line (`includes/admin/class-sensei-plugins-installation.php`):
```php
$result = activate_plugin( $installed ? $installed_plugins[ $plugin_file ] : $plugin_slug . '/' . $plugin_file );
```
* Make sure that the event `sensei_setup_wizard_features_install_error` was tracked for each error.
* Retry the installations and make sure that the event `sensei_setup_wizard_features_install_retry` was tracked.
* Repeat the process, but instead of to install, click on "I'll do it later" and make sure the event `sensei_setup_wizard_features_install_cancel ` was tracked.