### PR TITLE
fixed array-string conversion notice

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1446,7 +1446,7 @@ class Sensei_Core_Modules {
 		if ( isset( $course_id ) && 0 < $course_id ) {
 
 			// the course should contain the same module taxonomy term for this to be valid
-			if ( ! has_term( $module, $this->taxonomy, $course_id ) ) {
+			if ( ! has_term( $module->term_id, $this->taxonomy, $course_id ) ) {
 				return false;
 			}
 


### PR DESCRIPTION
Fixes #3245 

### Changes proposed in this Pull Request

* Sensei_Core_Modules::get_lesson_module() causes a array/string conversion notice by passing a module's WP_Term object to has_term() instead of just a term_id, name or slug. This fixes that by passing the modules term_id instead.

### Testing instructions

* open a lesson that is part of a module /lesson/{lesson-slug}. Check php log. The notice isn't there any more

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

--

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

--

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
