### PR TITLE
Fix translations with whitespace in .pot file

### DIFF
--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -79,13 +79,13 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	protected function opt_in_dialog_text() {
 		return sprintf(
 			/*
-			 * translators: the href tag contains the URL for the page telling
+			 * translators: The href tag contains the URL for the page telling
 			 * users what data Sensei tracks.
 			 */
 			__(
-				"We'd love if you helped us make Sensei LMS better by allowing us to collect
-				<a href=\"%s\" target=\"_blank\">usage tracking data</a>.
-				No sensitive information is collected, and you can opt out at any time.",
+				"We'd love if you helped us make Sensei LMS better by allowing us to collect " .
+				"<a href=\"%s\" target=\"_blank\">usage tracking data</a>. " .
+				"No sensitive information is collected, and you can opt out at any time.",
 				'sensei-lms'
 			),
 			self::SENSEI_TRACKING_INFO_URL
@@ -124,13 +124,13 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 			'name'        => __( 'Enable usage tracking', 'sensei-lms' ),
 			'description' => sprintf(
 				/*
-				 * translators: the href tag contains the URL for the page telling
+				 * translators: The href tag contains the URL for the page telling
 				 * users what data Sensei tracks.
 				 */
 				__(
-					'Help us make Sensei LMS better by allowing us to collect
-					<a href="%s" target="_blank">usage tracking data</a>.
-					No sensitive information is collected.',
+					'Help us make Sensei LMS better by allowing us to collect ' .
+					'<a href="%s" target="_blank">usage tracking data</a>. ' .
+					'No sensitive information is collected.',
 					'sensei-lms'
 				),
 				self::SENSEI_TRACKING_INFO_URL


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Remove whitespace from translated strings.

### Testing instructions

* Build the .pot file.
* Open the .pot file in Poedit.
* Ensure there are no whitespace characters in the "We'd love if you helped us make Sensei LMS better by allowing us to collect..." and "Help us make Sensei LMS better by allowing us to collect..." strings.

**Before**
![Screen Shot 2020-06-03 at 9 41 27 AM](https://user-images.githubusercontent.com/1190420/83643770-707e2900-a57e-11ea-92c5-918a66cf2ccf.jpg)

**After**
![Screen Shot 2020-06-03 at 9 51 53 AM](https://user-images.githubusercontent.com/1190420/83644953-dfa84d00-a57f-11ea-8f42-6f058a9b9854.jpg)