### PR TITLE
Clear setup wizard user data option on uninstall

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -59,6 +59,7 @@ class Sensei_Data_Cleaner {
 		'sensei_course_order',
 		'skip_install_sensei_pages', // @deprecated since 3.1.0.
 		'sensei_suggest_setup_wizard',
+		'sensei_setup_wizard_data',
 		'sensei_flush_rewrite_rules',
 		'sensei_needs_language_pack_install',
 		'woothemes_sensei_language_pack_version',


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Clear setup wizard user data option on uninstall.

### Testing instructions

* Install the Sensei LMS.
* Go through the Setup Wizard.
* Uninstall the Sensei LMS.
* Install the Sensei LMS again.
* Make sure the Setup Wizard started from the beginning.