### PR TITLE
Put the importer behind a feature flag

### DIFF
--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -21,6 +21,7 @@ class Sensei_Feature_Flags {
 				'rest_api_v1'                  => false,
 				'rest_api_v1_skip_permissions' => false,
 				'enrolment_provider_tooltip'   => false,
+				'importer'                     => false,
 			)
 		);
 	}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -393,7 +393,10 @@ class Sensei_Main {
 		Sensei_Course_Enrolment_Manager::instance()->init();
 		$this->enrolment_scheduler = Sensei_Enrolment_Job_Scheduler::instance();
 		$this->enrolment_scheduler->init();
-		Sensei_Data_Port_Manager::instance()->init();
+
+		if ( $this->feature_flags->is_enabled( 'importer' ) ) {
+			Sensei_Data_Port_Manager::instance()->init();
+		}
 
 		// Setup Wizard.
 		$this->setup_wizard = Sensei_Setup_Wizard::instance();
@@ -406,7 +409,9 @@ class Sensei_Main {
 			// Load Analysis Reports
 			$this->analysis = new Sensei_Analysis( $this->main_plugin_file_name );
 
-			new Sensei_Import();
+			if ( $this->feature_flags->is_enabled( 'importer' ) ) {
+				new Sensei_Import();
+			}
 
 			if ( $this->feature_flags->is_enabled( 'rest_api_testharness' ) ) {
 				$this->test_harness = new Sensei_Admin_Rest_Api_Testharness( $this->main_plugin_file_name );
@@ -583,7 +588,10 @@ class Sensei_Main {
 	public function deactivation() {
 		$this->usage_tracking->unschedule_tracking_task();
 		Sensei_Scheduler::instance()->cancel_all_jobs();
-		Sensei_Data_Port_Manager::instance()->cancel_all_jobs();
+
+		if ( $this->feature_flags->is_enabled( 'importer' ) ) {
+			Sensei_Data_Port_Manager::instance()->cancel_all_jobs();
+		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Disables Importer / Data Port functionality unless feature flag is disabled.
* Note: Snippet/filter option might not work because this is checked on plugin load. Constant in `wp-config.php` is best bet.

### Testing instructions

* Make sure `Import` doesn't show up in admin menu under `Sensei LMS`.
* Add this to `wp-config.php`:
```php
define( 'SENSEI_FEATURE_FLAG_IMPORTER', true );
```
* Verify it now shows up.

