### PR TITLE
Use semantic heading structure on course results page

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -690,16 +690,20 @@ section.entry span.course-lesson-progress { margin-left: 10px; }
 
 /* Course Results */
 .course-results-lessons {
-  h2, h3, h4 {
+  h2 {
     margin: 20px 0;
-    &.total-grade {
-      text-decoration: underline;
-      .lesson-grade {
-        text-decoration: underline;
-      }
-    }
+  }
+  h3, h4 {
+    margin: 20px 0;
+
     .lesson-grade {
       float: right;
+    }
+  }
+  h3.total-grade {
+    text-decoration: underline;
+    .lesson-grade {
+      text-decoration: underline;
     }
   }
 }

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -7,7 +7,7 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     3.1.0
+ * @version     3.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -120,7 +120,7 @@ global $course;
 			if ( $course_has_lessons_in_modules ) :
 				?>
 				<h3><?php esc_html_e( 'Other Lessons', 'sensei-lms' ); ?></h3>
-			<?php endif; // $course_has_lessons_in_modules ?>
+			<?php endif; ?>
 
 			<?php foreach ( $lessons as $lesson ) : ?>
 
@@ -138,9 +138,8 @@ global $course;
 						}
 					}
 				}
-				?>
 
-				<?php echo $course_has_lessons_in_modules ? '<h4>' : '<h3>'; ?>
+				echo $course_has_lessons_in_modules ? '<h4>' : '<h3>'; ?>
 
 					<a href="<?php echo esc_url_raw( get_permalink( $lesson->ID ) ); ?>" title="
 										<?php

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -119,7 +119,7 @@ global $course;
 			// lesson title will already appear above
 			if ( $course_has_lessons_in_modules ) :
 				?>
-				<h3><?php esc_html_e( 'Other Lessons', 'sensei-lms' ); ?></h3>
+				<h2><?php esc_html_e( 'Other Lessons', 'sensei-lms' ); ?></h2>
 			<?php endif; ?>
 
 			<?php foreach ( $lessons as $lesson ) : ?>
@@ -138,15 +138,15 @@ global $course;
 						}
 					}
 				}
-
-				echo $course_has_lessons_in_modules ? '<h4>' : '<h3>';
 				?>
 
+				<h3>
+
 					<a href="<?php echo esc_url_raw( get_permalink( $lesson->ID ) ); ?>" title="
-										<?php
-										// translators: Placeholder it the lesson title.
-										esc_attr( sprintf( __( 'Start %s', 'sensei-lms' ), $lesson->post_title ) )
-										?>
+						<?php
+						// translators: Placeholder it the lesson title.
+						esc_attr( sprintf( __( 'Start %s', 'sensei-lms' ), $lesson->post_title ) )
+						?>
 					" >
 
 						<?php echo esc_html( $lesson->post_title ); ?>
@@ -155,14 +155,14 @@ global $course;
 
 					<span class="lesson-grade"><?php echo esc_html( $lesson_grade ); ?></span>
 
-				<?php echo $course_has_lessons_in_modules ? '</h4>' : '</h3>'; ?>
+				</h3>
 
 			<?php endforeach; // lessons ?>
 
 		<?php endif; // lessons count > 0 ?>
 
 
-		<h3 class="total-grade">
+		<h2 class="total-grade">
 
 			<?php esc_html_e( 'Total Grade', 'sensei-lms' ); ?>
 			<span class="lesson-grade">
@@ -176,7 +176,7 @@ global $course;
 
 			</span>
 
-		</h3>
+		</h2>
 
 	</article>
 

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -139,7 +139,8 @@ global $course;
 					}
 				}
 
-				echo $course_has_lessons_in_modules ? '<h4>' : '<h3>'; ?>
+				echo $course_has_lessons_in_modules ? '<h4>' : '<h3>'; 
+				?>
 
 					<a href="<?php echo esc_url_raw( get_permalink( $lesson->ID ) ); ?>" title="
 										<?php

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -139,7 +139,7 @@ global $course;
 					}
 				}
 
-				echo $course_has_lessons_in_modules ? '<h4>' : '<h3>'; 
+				echo $course_has_lessons_in_modules ? '<h4>' : '<h3>';
 				?>
 
 					<a href="<?php echo esc_url_raw( get_permalink( $lesson->ID ) ); ?>" title="


### PR DESCRIPTION
Fixes #3200 

### Changes proposed in this Pull Request
* Fixes Non-semantic use of headings on course results page.
* Wraps module-name in `<h3>` tag.
* Wraps lesson-title in `<h4>` tag when in modules, otherwise `<h3>` tag.
* Adjusts scss/css to keep grades floating to right.

### Testing instructions
* Impacts course results pages `/course/{course-slug}/results/`

### Changed Template
- `templates/course-results/lessons.php` - Use semantic heading structure