### PR TITLE
Fix/#3206 keep existing post list columns

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -690,7 +690,7 @@ section.entry span.course-lesson-progress { margin-left: 10px; }
 
 /* Course Results */
 .course-results-lessons {
-  h2 {
+  h2, h3, h4 {
     margin: 20px 0;
     &.total-grade {
       text-decoration: underline;

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -55,6 +55,7 @@ class Sensei_Course {
 			// Custom Write Panel Columns
 			add_filter( 'manage_course_posts_columns', array( $this, 'add_column_headings' ), 10, 1 );
 			add_action( 'manage_course_posts_custom_column', array( $this, 'add_column_data' ), 10, 2 );
+			add_filter( 'default_hidden_columns', array( $this, 'set_default_visible_columns' ), 10, 2 );
 
 			// Enqueue scripts.
 			add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_scripts' ) );
@@ -664,7 +665,8 @@ class Sensei_Course {
 	} // End course_manage_meta_box_content()
 
 	/**
-	 * Add column headings to the "lesson" post list screen.
+	 * Add column headings to the "course" post list screen,
+	 * while moving the existing ones to the end.
 	 *
 	 * @access public
 	 * @since  1.0.0
@@ -672,7 +674,7 @@ class Sensei_Course {
 	 * @return array $new_columns
 	 */
 	public function add_column_headings( $defaults ) {
-		$new_columns                        = array();
+		$new_columns                        = [];
 		$new_columns['cb']                  = '<input type="checkbox" />';
 		$new_columns['title']               = _x( 'Course Title', 'column name', 'sensei-lms' );
 		$new_columns['course-prerequisite'] = _x( 'Pre-requisite Course', 'column name', 'sensei-lms' );
@@ -680,9 +682,44 @@ class Sensei_Course {
 		if ( isset( $defaults['date'] ) ) {
 			$new_columns['date'] = $defaults['date'];
 		}
+		foreach ( $defaults as $column_key => $column_value ) {
+			if ( ! isset( $new_columns[ $column_key ] ) ) {
+				$new_columns[ $column_key ] = $column_value;
+			}
+		}
 
 		return $new_columns;
 	} // End add_column_headings()
+
+	/**
+	 * Hide all columns by default, leaving only a default list.
+	 *
+	 * @access public
+	 * @since  3.1.0-dev
+	 * @param  array     $hidden_columns
+	 * @param  WP_Screen $screen
+	 * @return array     $hidden_columns
+	 */
+	public function set_default_visible_columns( $hidden_columns, $screen ) {
+		$default_course_columns = [
+			'cb',
+			'title',
+			'course-prerequisite',
+			'course-category',
+			'date',
+		];
+		if ( ! $screen instanceof WP_Screen || 'edit-course' !== $screen->id ) {
+			return $hidden_columns;
+		}
+		$columns = get_column_headers( $screen );
+		foreach ( $columns as $column => $column_value ) {
+			if ( ! in_array( $column, $default_course_columns, true ) ) {
+				$hidden_columns[] = $column;
+			}
+		}
+
+		return $hidden_columns;
+	} // End set_default_visible_columns()
 
 	/**
 	 * Add data for our newly-added custom columns.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -47,6 +47,7 @@ class Sensei_Lesson {
 			// Custom Write Panel Columns
 			add_filter( 'manage_edit-lesson_columns', array( $this, 'add_column_headings' ), 10, 1 );
 			add_action( 'manage_posts_custom_column', array( $this, 'add_column_data' ), 10, 2 );
+			add_filter( 'default_hidden_columns', array( $this, 'set_default_visible_columns' ), 10, 2 );
 
 			// Add/Update question
 			add_action( 'wp_ajax_lesson_update_question', array( $this, 'lesson_update_question' ) );
@@ -2212,7 +2213,8 @@ class Sensei_Lesson {
 	} // End enqueue_styles()
 
 	/**
-	 * Add column headings to the "lesson" post list screen.
+	 * Add column headings to the "lesson" post list screen,
+	 * while moving the existing ones to the end.
 	 *
 	 * @access public
 	 * @since  1.0.0
@@ -2220,7 +2222,7 @@ class Sensei_Lesson {
 	 * @return array $new_columns
 	 */
 	public function add_column_headings( $defaults ) {
-		$new_columns                        = array();
+		$new_columns                        = [];
 		$new_columns['cb']                  = '<input type="checkbox" />';
 		$new_columns['title']               = _x( 'Lesson Title', 'column name', 'sensei-lms' );
 		$new_columns['lesson-course']       = _x( 'Course', 'column name', 'sensei-lms' );
@@ -2228,8 +2230,44 @@ class Sensei_Lesson {
 		if ( isset( $defaults['date'] ) ) {
 			$new_columns['date'] = $defaults['date'];
 		}
+		foreach ( $defaults as $column_key => $column_value ) {
+			if ( ! isset( $new_columns[ $column_key ] ) ) {
+				$new_columns[ $column_key ] = $column_value;
+			}
+		}
+
 		return $new_columns;
 	} // End add_column_headings()
+
+	/**
+	 * Hide all columns by default, leaving only a default set.
+	 *
+	 * @access public
+	 * @since  3.1.0-dev
+	 * @param  array     $hidden_columns
+	 * @param  WP_Screen $screen
+	 * @return array     $hidden_columns
+	 */
+	public function set_default_visible_columns( $hidden_columns, $screen ) {
+		$default_lesson_columns = [
+			'cb',
+			'title',
+			'lesson-course',
+			'lesson-prerequisite',
+			'date',
+		];
+		if ( ! $screen instanceof WP_Screen || 'edit-lesson' !== $screen->id ) {
+			return $hidden_columns;
+		}
+		$columns = get_column_headers( $screen );
+		foreach ( $columns as $column => $column_value ) {
+			if ( ! in_array( $column, $default_lesson_columns, true ) ) {
+				$hidden_columns[] = $column;
+			}
+		}
+
+		return $hidden_columns;
+	} // End set_default_visible_columns()
 
 	/**
 	 * Add data for our newly-added custom columns.

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -29,6 +29,7 @@ class Sensei_Question {
 		if ( is_admin() ) {
 			// Custom Write Panel Columns
 			add_filter( 'manage_edit-question_columns', array( $this, 'add_column_headings' ), 10, 1 );
+			add_filter( 'default_hidden_columns', array( $this, 'set_default_visible_columns' ), 10, 2 );
 			add_action( 'manage_posts_custom_column', array( $this, 'add_column_data' ), 10, 2 );
 			add_action( 'add_meta_boxes', array( $this, 'question_edit_panel_metabox' ), 10, 2 );
 
@@ -56,7 +57,8 @@ class Sensei_Question {
 	}
 
 	/**
-	 * Add column headings to the "lesson" post list screen.
+	 * Add column headings to the "question" post list screen,
+	 * while moving the existing ones to the end.
 	 *
 	 * @access public
 	 * @since  1.3.0
@@ -64,7 +66,7 @@ class Sensei_Question {
 	 * @return array $new_columns
 	 */
 	public function add_column_headings( $defaults ) {
-		$new_columns                      = array();
+		$new_columns                      = [];
 		$new_columns['cb']                = '<input type="checkbox" />';
 		$new_columns['title']             = _x( 'Question', 'column name', 'sensei-lms' );
 		$new_columns['question-type']     = _x( 'Type', 'column name', 'sensei-lms' );
@@ -72,9 +74,49 @@ class Sensei_Question {
 		if ( isset( $defaults['date'] ) ) {
 			$new_columns['date'] = $defaults['date'];
 		}
+		// Unset renamed existing columns.
+		unset( $defaults['taxonomy-question-type'] );
+		unset( $defaults['taxonomy-question-category'] );
+
+		foreach ( $defaults as $column_key => $column_value ) {
+			if ( ! isset( $new_columns[ $column_key ] ) ) {
+				$new_columns[ $column_key ] = $column_value;
+			}
+		}
 
 		return $new_columns;
 	} // End add_column_headings()
+
+
+	/**
+	 * Hide all columns by default, leaving only a default set.
+	 *
+	 * @access public
+	 * @since  3.1.0-dev
+	 * @param  array     $hidden_columns
+	 * @param  WP_Screen $screen
+	 * @return array     $hidden_columns
+	 */
+	public function set_default_visible_columns( $hidden_columns, $screen ) {
+		$default_question_columns = [
+			'cb',
+			'title',
+			'question-type',
+			'question-category',
+			'date',
+		];
+		if ( ! $screen instanceof WP_Screen || 'edit-question' !== $screen->id ) {
+			return $hidden_columns;
+		}
+		$columns = get_column_headers( $screen );
+		foreach ( $columns as $column => $column_value ) {
+			if ( ! in_array( $column, $default_question_columns, true ) ) {
+				$hidden_columns[] = $column;
+			}
+		}
+
+		return $hidden_columns;
+	} // End set_default_visible_columns()
 
 	/**
 	 * Add data for our newly-added custom columns.

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -82,7 +82,7 @@ global $course;
 						}
 					}
 					?>
-					<h2>
+					<h4>
 
 						<a href="<?php echo esc_url_raw( get_permalink( $lesson->ID ) ); ?>"
 						   title="
@@ -100,7 +100,7 @@ global $course;
 							<?php echo esc_html( $lesson_grade ); ?>
 						</span>
 
-					</h2>
+					</h4>
 
 					<?php
 
@@ -115,16 +115,12 @@ global $course;
 		if ( 0 < count( $lessons ) ) :
 			?>
 
-			<h3>
-
-				<?php
-				// lesson title will already appear above
-				if ( $course_has_lessons_in_modules ) {
-					esc_html_e( 'Other Lessons', 'sensei-lms' );
-				}
+			<?php
+			// lesson title will already appear above
+			if ( $course_has_lessons_in_modules ) :
 				?>
-
-			</h3>
+				<h3><?php esc_html_e( 'Other Lessons', 'sensei-lms' ); ?></h3>
+			<?php endif; // $course_has_lessons_in_modules ?>
 
 			<?php foreach ( $lessons as $lesson ) : ?>
 
@@ -144,7 +140,7 @@ global $course;
 				}
 				?>
 
-				<h2>
+				<?php echo $course_has_lessons_in_modules ? '<h4>' : '<h3>'; ?>
 
 					<a href="<?php echo esc_url_raw( get_permalink( $lesson->ID ) ); ?>" title="
 										<?php
@@ -159,14 +155,14 @@ global $course;
 
 					<span class="lesson-grade"><?php echo esc_html( $lesson_grade ); ?></span>
 
-				</h2>
+				<?php echo $course_has_lessons_in_modules ? '</h4>' : '</h3>'; ?>
 
 			<?php endforeach; // lessons ?>
 
 		<?php endif; // lessons count > 0 ?>
 
 
-		<h2 class="total-grade">
+		<h3 class="total-grade">
 
 			<?php esc_html_e( 'Total Grade', 'sensei-lms' ); ?>
 			<span class="lesson-grade">
@@ -180,7 +176,7 @@ global $course;
 
 			</span>
 
-		</h2>
+		</h3>
 
 	</article>
 


### PR DESCRIPTION
Fixes #3206 

### Changes proposed in this Pull Request

* The change impacts the the course, lesson and question post list in admin and aims to respect columns that are already added by other plugins or WordPress itself.
* Method 'add_column_headings' (in Sensei_Course, Sensei_Lesson and Sensei_Question) will keep existing columns, and move them after the Sensei LMS columns
* To retain the same clean default presentation, also a new method "set_default_visible_columns" (in all three classes) is proposed, hooking into the 'default_hidden_columns' filter hook. 
This new method hides all columns except for the Sensei-LMS ones (that are set by 'add_column_headings'). So this edit respects both the desire for a clean default presentation and the admins options to use the screen settings in WordPress. It just hides instead of removes the other columns.
* In keeping the existing columns I discovered that in the question list Sensei had renamed (in Sensei_Question::add_column_headings) 2 taxonomy columns that normally removing the default prefix "taxonomy-" . I had to choose which of those to keep and have proposed to keep the renamed version and filter out the default columns, since that seemed to pose the least risk for problems. An alternative would be to keep the default columns not having to filter them out.

### Testing instructions

Impacted admin pages:
* `/wp-admin/edit.php?post_type=course`
* `/wp-admin/edit.php?post_type=lesson`
* `/wp-admin/edit.php?post_type=question`
