### PR TITLE
Fix incorrect parameter being passed to has_term function

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1446,7 +1446,7 @@ class Sensei_Core_Modules {
 		if ( isset( $course_id ) && 0 < $course_id ) {
 
 			// the course should contain the same module taxonomy term for this to be valid
-			if ( ! has_term( $module, $this->taxonomy, $course_id ) ) {
+			if ( ! has_term( $module->term_id, $this->taxonomy, $course_id ) ) {
 				return false;
 			}
 


### PR DESCRIPTION
Fixes #3245 

### Changes proposed in this Pull Request

* Sensei_Core_Modules::get_lesson_module() causes a array/string conversion notice. This error is caused by the method by passing a module's WP_Term object to `has_term()`. `has_term()` expects a string or an array of term_ids, names or slugs only and not a WP_Term object. This PR fixes that, by passing the modules term_id instead.

### Testing instructions

* Before opening a lesson, that is part of a module /lesson/{lesson-slug} would result in this notice.
* With the PR implemented, it won't anymore.
