### PR TITLE
Build the hook docs when code is committed to master

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -2,8 +2,8 @@ name: Build Hook Docs
 
 on:
  push:
-   tags:
-    - '*'
+   branches:
+    - master
 
 jobs:
   hookdocs:


### PR DESCRIPTION
### Changes proposed in this Pull Request

The hook docs were not generated when a new Sensei version was tagged. It doesn't actually look like there is an option to do this. Instead, the next best thing would be to generate them whenever code is committed to `master`.

### Testing instructions
N/A