### PR TITLE
Update to fail gracefully when returning no extensions for Setup Wizard

### DIFF
--- a/assets/setup-wizard/features/features-selection.jsx
+++ b/assets/setup-wizard/features/features-selection.jsx
@@ -1,4 +1,4 @@
-import { Button, CheckboxControl } from '@wordpress/components';
+import { Button, CheckboxControl, Notice } from '@wordpress/components';
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 
@@ -42,6 +42,11 @@ const FeaturesSelection = ( {
 	return (
 		<>
 			<div className="sensei-setup-wizard__checkbox-list">
+				{ ( ! features || features.length === 0 ) && (
+					<Notice status="error" isDismissible={ false }>
+						{ __( 'No features found.', 'sensei-lms' ) }
+					</Notice>
+				) }
 				{ features.map( ( { slug, title, excerpt, link, status } ) => (
 					<CheckboxControl
 						key={ slug }

--- a/assets/setup-wizard/features/features-selection.test.js
+++ b/assets/setup-wizard/features/features-selection.test.js
@@ -42,6 +42,20 @@ describe( '<FeaturesSelection />', () => {
 		);
 	} );
 
+	it( 'Should render with no features', () => {
+		const { queryAllByText } = render(
+			<FeaturesSelection
+				features={ [] }
+				selectedSlugs={ [] }
+				onChange={ () => {} }
+				onContinue={ () => {} }
+			/>
+		);
+
+		// The notice renders more than one div for accessibility.
+		expect( queryAllByText( 'No features found.' ) ).not.toHaveLength( 0 );
+	} );
+
 	it( 'Should render features selection with submitting status', () => {
 		const { container } = render(
 			<FeaturesSelection

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -455,8 +455,13 @@ class Sensei_Setup_Wizard {
 			wp_cache_delete( 'alloptions', 'options' );
 		}
 
-		$sensei_extensions  = Sensei_Extensions::instance();
+		$extensions_filter  = [ 'hosted-location' => 'dotorg' ];
+		$extensions         = Sensei_Extensions::instance()->get_extensions( 'plugin', 'setup-wizard-extensions', $extensions_filter );
 		$installing_plugins = Sensei_Plugins_Installation::instance()->get_installing_plugins();
+
+		if ( ! $extensions ) {
+			$extensions = [];
+		}
 
 		$extensions = array_map(
 			function( $extension ) use ( $installing_plugins ) {
@@ -467,7 +472,7 @@ class Sensei_Setup_Wizard {
 
 				return $this->get_feature_with_status( $extension, $installing_plugins );
 			},
-			$sensei_extensions->get_extensions( 'plugin', 'setup-wizard-extensions', [ 'hosted-location' => 'dotorg' ] )
+			$extensions
 		);
 
 		return $extensions;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fail gracefully when returning no extensions for Setup Wizard

### Testing instructions

* Remove from the database the option with the name like `%sensei_extensions_%`.
* Turn off the internet.
* Go to the setup wizard and navigate to the features step.
* You should see an error with the message "No features found.".

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="677" alt="Screen Shot 2020-06-09 at 11 42 01" src="https://user-images.githubusercontent.com/876340/84162085-5d6bcd00-aa46-11ea-8029-3ce11e581deb.png">
