### PR TITLE
Importing: Add data validation and default handling in base model

### DIFF
--- a/includes/data-port/models/class-sensei-data-port-model.php
+++ b/includes/data-port/models/class-sensei-data-port-model.php
@@ -117,7 +117,7 @@ abstract class Sensei_Data_Port_Model {
 			if ( isset( $data[ $field ] ) ) {
 				if (
 					isset( $field_config['validator'] )
-					&& ! call_user_func( $field_config['validator'], $data )
+					&& ! call_user_func( $field_config['validator'], $field, $data )
 				) {
 					return false;
 				}

--- a/includes/data-port/models/class-sensei-data-port-model.php
+++ b/includes/data-port/models/class-sensei-data-port-model.php
@@ -96,7 +96,7 @@ abstract class Sensei_Data_Port_Model {
 
 		if ( $fallback_default && isset( $config['default'] ) ) {
 			if ( is_callable( $config['default'] ) ) {
-				return call_user_func( $config['default'], $field );
+				return call_user_func( $config['default'], $field, $this->data );
 			}
 
 			return $config['default'];

--- a/includes/data-port/models/class-sensei-data-port-model.php
+++ b/includes/data-port/models/class-sensei-data-port-model.php
@@ -93,6 +93,7 @@ abstract class Sensei_Data_Port_Model {
 		$value  = isset( $this->data[ $field ] ) ? '' : null;
 		$config = $schema[ $field ];
 
+		// If we're creating a new post, get the default value.
 		if ( ! $this->get_post_id() && isset( $config['default'] ) ) {
 			if ( is_callable( $config['default'] ) ) {
 				return call_user_func( $config['default'], $field, $this->data );

--- a/includes/data-port/models/class-sensei-data-port-model.php
+++ b/includes/data-port/models/class-sensei-data-port-model.php
@@ -70,6 +70,42 @@ abstract class Sensei_Data_Port_Model {
 	abstract public function sync_post();
 
 	/**
+	 * Get the value of a field.
+	 *
+	 * @param string $field            Field name.
+	 * @param bool   $fallback_default Fallback to default value if no value exists.
+	 *
+	 * @return mixed
+	 */
+	public function get_value( $field, $fallback_default = false ) {
+		if (
+			isset( $this->data[ $field ] )
+			&& '' !== $this->data[ $field ]
+		) {
+			return $this->data[ $field ];
+		}
+
+		$schema = static::get_schema();
+		if ( ! isset( $schema[ $field ] ) ) {
+			return null;
+		}
+
+		// If the field exists, assume it is an empty string. Otherwise, set it to null.
+		$value  = isset( $this->data[ $field ] ) ? '' : null;
+		$config = $schema[ $field ];
+
+		if ( $fallback_default && isset( $config['default'] ) ) {
+			if ( is_callable( $config['default'] ) ) {
+				return call_user_func( $config['default'], $field );
+			}
+
+			return $config['default'];
+		}
+
+		return $value;
+	}
+
+	/**
 	 * Check if all required fields are set.
 	 *
 	 * @return bool
@@ -79,6 +115,13 @@ abstract class Sensei_Data_Port_Model {
 
 		foreach ( static::get_schema() as $field => $field_config ) {
 			if ( isset( $data[ $field ] ) ) {
+				if (
+					isset( $field_config['validator'] )
+					&& ! call_user_func( $field_config['validator'], $data )
+				) {
+					return false;
+				}
+
 				continue;
 			}
 
@@ -115,12 +158,7 @@ abstract class Sensei_Data_Port_Model {
 			}
 
 			$config = $schema[ $key ];
-
-			if ( ! isset( $config['default'] ) ) {
-				$config['default'] = '';
-			}
-
-			$value = trim( $value );
+			$value  = trim( $value );
 
 			if ( null !== $value ) {
 				switch ( $config['type'] ) {
@@ -242,11 +280,12 @@ abstract class Sensei_Data_Port_Model {
 	 *
 	 * @return array {
 	 *     @type array $$field_name {
-	 *          @type string $type       Type of data. Options: string, int, float, bool, slug, ref, email, url.
-	 *          @type string $pattern    Regular expression that the value should match (Optional).
-	 *          @type mixed  $default    Default value if not set or invalid. Default is `null` (Optional).
-	 *          @type bool   $required   True if a non-empty value is required. Default is `false` (Optional).
-	 *          @type bool   $allow_html True if HTML should be allowed. Default is `false` (Optional).
+	 *          @type string   $type       Type of data. Options: string, int, float, bool, slug, ref, email, url.
+	 *          @type string   $pattern    Regular expression that the value should match (Optional).
+	 *          @type mixed    $default    Default value if not set or invalid. Default is `null` (Optional).
+	 *          @type bool     $required   True if a non-empty value is required. Default is `false` (Optional).
+	 *          @type bool     $allow_html True if HTML should be allowed. Default is `false` (Optional).
+	 *          @type callable $validator  Callable to use when validating data (Optional).
 	 *     }
 	 * }
 	 */

--- a/includes/data-port/models/class-sensei-data-port-model.php
+++ b/includes/data-port/models/class-sensei-data-port-model.php
@@ -72,12 +72,11 @@ abstract class Sensei_Data_Port_Model {
 	/**
 	 * Get the value of a field.
 	 *
-	 * @param string $field            Field name.
-	 * @param bool   $fallback_default Fallback to default value if no value exists.
+	 * @param string $field Field name.
 	 *
 	 * @return mixed
 	 */
-	public function get_value( $field, $fallback_default = false ) {
+	public function get_value( $field ) {
 		if (
 			isset( $this->data[ $field ] )
 			&& '' !== $this->data[ $field ]
@@ -94,7 +93,7 @@ abstract class Sensei_Data_Port_Model {
 		$value  = isset( $this->data[ $field ] ) ? '' : null;
 		$config = $schema[ $field ];
 
-		if ( $fallback_default && isset( $config['default'] ) ) {
+		if ( ! $this->get_post_id() && isset( $config['default'] ) ) {
 			if ( is_callable( $config['default'] ) ) {
 				return call_user_func( $config['default'], $field, $this->data );
 			}

--- a/tests/framework/data-port/class-sensei-data-port-model-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-model-mock.php
@@ -14,6 +14,7 @@ class Sensei_Data_Port_Model_Mock extends Sensei_Data_Port_Model {
 		return true;
 	}
 
+	// phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
 	public function set_post_id( $id ) {
 		parent::set_post_id( $id );
 	}

--- a/tests/framework/data-port/class-sensei-data-port-model-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-model-mock.php
@@ -14,6 +14,10 @@ class Sensei_Data_Port_Model_Mock extends Sensei_Data_Port_Model {
 		return true;
 	}
 
+	public function set_post_id( $id ) {
+		parent::set_post_id( $id );
+	}
+
 	public static function get_schema() {
 		return [
 			'test-string-allow-html' => [

--- a/tests/framework/data-port/class-sensei-data-port-model-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-model-mock.php
@@ -26,7 +26,8 @@ class Sensei_Data_Port_Model_Mock extends Sensei_Data_Port_Model {
 				'allow_html' => false,
 			],
 			'favorite_int'           => [
-				'type' => 'int',
+				'type'    => 'int',
+				'default' => 0,
 			],
 			'favorite_float'         => [
 				'type' => 'float',
@@ -36,7 +37,8 @@ class Sensei_Data_Port_Model_Mock extends Sensei_Data_Port_Model {
 				'required' => true,
 			],
 			'slug'                   => [
-				'type' => 'slug',
+				'type'    => 'slug',
+				'default' => 'neat-slug',
 			],
 			'type'                   => [
 				'type'     => 'string',

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
@@ -139,11 +139,11 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 
 		$model = Sensei_Data_Port_Model_Mock::from_source_array( $data );
 
-		$model->set_post_id(1);
+		$model->set_post_id( 1 );
 		$this->assertEquals( null, $model->get_value( 'favorite_int' ), 'Null should be provided when not included in data' );
 		$this->assertEquals( null, $model->get_value( 'slug' ), 'Null should be provided when not included in data' );
 
-		$model->set_post_id(null);
+		$model->set_post_id( null );
 		$this->assertEquals( 0, $model->get_value( 'favorite_int' ), 'Default should be provided when not included in data' );
 		$this->assertEquals( 'neat-slug', $model->get_value( 'slug' ), 'Default should be provided when not included in data' );
 		$this->assertEquals( $data['email'], $model->get_value( 'email' ), 'Actual value should be provided' );

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
@@ -125,4 +125,26 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $model->get_data() );
 		$this->assertFalse( $model->is_valid(), 'Type did not match a valid field so should invalidate the entry' );
 	}
+
+	/**
+	 * Tests various scenarios with get value.
+	 */
+	public function testGetValue() {
+		$data = [
+			'test-string-allow-html' => '<em>This is great HTML</em>',
+			'test-string-no-html'    => 'Cool',
+			'email'                  => 'dinosaur@example.com',
+			'type'                   => 'cool',
+		];
+
+		$model = Sensei_Data_Port_Model_Mock::from_source_array( $data );
+
+		$this->assertEquals( 0, $model->get_value( 'favorite_int', true ), 'Default should be provided when not included in data' );
+		$this->assertEquals( null, $model->get_value( 'favorite_int', false ), 'Null should be provided when not included in data' );
+
+		$this->assertEquals( 'neat-slug', $model->get_value( 'slug', true ), 'Default should be provided when not included in data' );
+		$this->assertEquals( null, $model->get_value( 'slug', false ), 'Null should be provided when not included in data' );
+
+		$this->assertEquals( $data['email'], $model->get_value( 'email', true ), 'Actual value should be provided' );
+	}
 }

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
@@ -139,12 +139,13 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 
 		$model = Sensei_Data_Port_Model_Mock::from_source_array( $data );
 
-		$this->assertEquals( 0, $model->get_value( 'favorite_int', true ), 'Default should be provided when not included in data' );
-		$this->assertEquals( null, $model->get_value( 'favorite_int', false ), 'Null should be provided when not included in data' );
+		$model->set_post_id(1);
+		$this->assertEquals( null, $model->get_value( 'favorite_int' ), 'Null should be provided when not included in data' );
+		$this->assertEquals( null, $model->get_value( 'slug' ), 'Null should be provided when not included in data' );
 
-		$this->assertEquals( 'neat-slug', $model->get_value( 'slug', true ), 'Default should be provided when not included in data' );
-		$this->assertEquals( null, $model->get_value( 'slug', false ), 'Null should be provided when not included in data' );
-
-		$this->assertEquals( $data['email'], $model->get_value( 'email', true ), 'Actual value should be provided' );
+		$model->set_post_id(null);
+		$this->assertEquals( 0, $model->get_value( 'favorite_int' ), 'Default should be provided when not included in data' );
+		$this->assertEquals( 'neat-slug', $model->get_value( 'slug' ), 'Default should be provided when not included in data' );
+		$this->assertEquals( $data['email'], $model->get_value( 'email' ), 'Actual value should be provided' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Introduce `Sensei_Data_Port_Model::get_value` to get a value and return the default value when requested and the value was empty in the data.
* Adds ability for data validation with a callable.

### Testing instructions

* Observe tests pass.