### PR TITLE
Add WooCommerce extensions to setup wizard features

### DIFF
--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -457,7 +457,7 @@ class Sensei_Setup_Wizard {
 
 		$extensions_filter = [ 'hosted-location' => 'dotorg' ];
 
-		if ( Sensei()->feature_flags->is_enabled( 'setup_wizard_wc_extensions' ) ) {
+		if ( Sensei()->feature_flags->is_enabled( 'setup_wizard_all_extensions' ) ) {
 			unset( $extensions_filter['hosted-location'] );
 		}
 

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -455,7 +455,12 @@ class Sensei_Setup_Wizard {
 			wp_cache_delete( 'alloptions', 'options' );
 		}
 
-		$extensions_filter  = [ 'hosted-location' => 'dotorg' ];
+		$extensions_filter = [ 'hosted-location' => 'dotorg' ];
+
+		if ( Sensei()->feature_flags->is_enabled( 'setup_wizard_wc_extensions' ) ) {
+			unset( $extensions_filter['hosted-location'] );
+		}
+
 		$extensions         = Sensei_Extensions::instance()->get_extensions( 'plugin', 'setup-wizard-extensions', $extensions_filter );
 		$installing_plugins = Sensei_Plugins_Installation::instance()->get_installing_plugins();
 

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -22,7 +22,7 @@ class Sensei_Feature_Flags {
 				'rest_api_v1_skip_permissions' => false,
 				'enrolment_provider_tooltip'   => false,
 				'importer'                     => false,
-				'setup_wizard_wc_extensions'   => false,
+				'setup_wizard_all_extensions'   => false,
 			)
 		);
 	}

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -22,7 +22,7 @@ class Sensei_Feature_Flags {
 				'rest_api_v1_skip_permissions' => false,
 				'enrolment_provider_tooltip'   => false,
 				'importer'                     => false,
-				'setup_wizard_all_extensions'   => false,
+				'setup_wizard_all_extensions'  => false,
 			)
 		);
 	}

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -22,6 +22,7 @@ class Sensei_Feature_Flags {
 				'rest_api_v1_skip_permissions' => false,
 				'enrolment_provider_tooltip'   => false,
 				'importer'                     => false,
+				'setup_wizard_wc_extensions'   => false,
 			)
 		);
 	}

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -358,6 +358,56 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that get sensei extensions fetch from the correct URL filtering by the dotorg only.
+	 *
+	 * @covers Sensei_Setup_Wizard::get_sensei_extensions
+	 */
+	public function testGetSenseiExtensionsWithoutWCExtensions() {
+		// Mock fetch from senseilms.com.
+		$request_url = null;
+		add_filter(
+			'pre_http_request',
+			function( $preempt, $parsed_args, $url ) use ( &$request_url ) {
+				$request_url = $url;
+				return [ 'body' => '{}' ];
+			},
+			10,
+			3
+		);
+
+		$extensions = Sensei()->setup_wizard->get_sensei_extensions();
+
+		$this->assertEquals( 'https://senseilms.com/wp-json/senseilms-products/1.0/search?category=setup-wizard-extensions&type=plugin&hosted-location=dotorg', $request_url );
+	}
+
+	/**
+	 * Tests that get sensei extensions fetch from the correct URL with WC extensions.
+	 *
+	 * @covers Sensei_Setup_Wizard::get_sensei_extensions
+	 */
+	public function testGetSenseiExtensionsWithWCExtensions() {
+		// Activate feature.
+		// It is usually activated by defining a const.
+		add_filter( 'sensei_feature_flag_setup_wizard_wc_extensions', '__return_true' );
+
+		// Mock fetch from senseilms.com.
+		$request_url = null;
+		add_filter(
+			'pre_http_request',
+			function( $preempt, $parsed_args, $url ) use ( &$request_url ) {
+				$request_url = $url;
+				return [ 'body' => '{}' ];
+			},
+			10,
+			3
+		);
+
+		$extensions = Sensei()->setup_wizard->get_sensei_extensions();
+
+		$this->assertEquals( 'https://senseilms.com/wp-json/senseilms-products/1.0/search?category=setup-wizard-extensions&type=plugin', $request_url );
+	}
+
+	/**
 	 * Tests that get sensei extensions and returns with decoded prices.
 	 *
 	 * @covers Sensei_Setup_Wizard::get_sensei_extensions

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -358,11 +358,12 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that get sensei extensions fetch from the correct URL filtering by the dotorg only.
+	 * Tests that get sensei extensions fetch from the correct URL
+	 * filtering by the dotorg only as default.
 	 *
 	 * @covers Sensei_Setup_Wizard::get_sensei_extensions
 	 */
-	public function testGetSenseiExtensionsWithoutWCExtensions() {
+	public function testGetSenseiExtensionsDotOrgExtensions() {
 		// Mock fetch from senseilms.com.
 		$request_url = null;
 		add_filter(
@@ -381,14 +382,15 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that get sensei extensions fetch from the correct URL with WC extensions.
+	 * Tests that get sensei extensions fetch from the correct URL
+	 * with all extensions type.
 	 *
 	 * @covers Sensei_Setup_Wizard::get_sensei_extensions
 	 */
-	public function testGetSenseiExtensionsWithWCExtensions() {
+	public function testGetSenseiExtensionsAllExtensions() {
 		// Activate feature.
 		// It is usually activated by defining a const.
-		add_filter( 'sensei_feature_flag_setup_wizard_wc_extensions', '__return_true' );
+		add_filter( 'sensei_feature_flag_setup_wizard_all_extensions', '__return_true' );
 
 		// Mock fetch from senseilms.com.
 		$request_url = null;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add WooCommerce extensions to setup wizard features.
* Make this feature based in a feature flag (`setup_wizard_all_extensions`)

### Testing instructions

1. Go to the setup wizard.
2. Navigate to the features step.
3. Make sure that the Paid Courses extension doesn't appear.
4. Add the feature flag const to your `wp-config.php`:
```php
define( 'SENSEI_FEATURE_FLAG_SETUP_WIZARD_ALL_EXTENSIONS', true );
```
5. Make sure now the Paid Courses extensions appear on the list.