### PR TITLE
Importer: Consolidate process_line to parent file process class

### DIFF
--- a/includes/data-port/import-tasks/class-sensei-import-courses.php
+++ b/includes/data-port/import-tasks/class-sensei-import-courses.php
@@ -26,6 +26,17 @@ class Sensei_Import_Courses
 	}
 
 	/**
+	 * Get the class name of the model handled by this task.
+	 *
+	 * @return string
+	 */
+	public function get_model_class() {
+		// @todo Implement.
+
+		return null;
+	}
+
+	/**
 	 * Process a single CSV line.
 	 *
 	 * @param int   $line_number  The line number in the file.

--- a/includes/data-port/import-tasks/class-sensei-import-lessons.php
+++ b/includes/data-port/import-tasks/class-sensei-import-lessons.php
@@ -26,15 +26,14 @@ class Sensei_Import_Lessons
 	}
 
 	/**
-	 * Process a single CSV line.
+	 * Get the class name of the model handled by this task.
 	 *
-	 * @param int   $line_number  The line number in the file.
-	 * @param array $line         The current line as returned from Sensei_Import_CSV_Reader::read_lines().
-	 *
-	 * @return mixed
+	 * @return string
 	 */
-	protected function process_line( $line_number, $line ) {
-		return true;
+	public function get_model_class() {
+		// @todo Implement.
+
+		return null;
 	}
 
 	/**

--- a/includes/data-port/import-tasks/class-sensei-import-questions.php
+++ b/includes/data-port/import-tasks/class-sensei-import-questions.php
@@ -26,6 +26,15 @@ class Sensei_Import_Questions
 	}
 
 	/**
+	 * Get the class name of the model handled by this task.
+	 *
+	 * @return string
+	 */
+	public function get_model_class() {
+		return Sensei_Data_Port_Question_Model::class;
+	}
+
+	/**
 	 * Process a single CSV line.
 	 *
 	 * @param int   $line_number  The line number in the file.

--- a/includes/data-port/models/class-sensei-data-port-model.php
+++ b/includes/data-port/models/class-sensei-data-port-model.php
@@ -28,6 +28,13 @@ abstract class Sensei_Data_Port_Model {
 	private $post_id;
 
 	/**
+	 * The default author to be used in courses if none is provided.
+	 *
+	 * @var int
+	 */
+	private $default_author;
+
+	/**
 	 * Sensei_Data_Port_Model constructor.
 	 */
 	private function __construct() {
@@ -37,13 +44,15 @@ abstract class Sensei_Data_Port_Model {
 	/**
 	 * Set up item from an array.
 	 *
-	 * @param array $data Data to restore item from.
+	 * @param array $data            Data to restore item from.
+	 * @param int   $default_author  The default author.
 	 *
 	 * @return static
 	 */
-	public static function from_source_array( $data ) {
+	public static function from_source_array( $data, $default_author = 0 ) {
 		$self = new static();
 		$self->restore_from_source_array( $data );
+		$self->default_author = $default_author;
 
 		$post_id = $self->get_existing_post_id();
 		if ( $post_id ) {
@@ -66,6 +75,15 @@ abstract class Sensei_Data_Port_Model {
 	 * @return true|WP_Error
 	 */
 	abstract public function sync_post();
+
+	/**
+	 * Get the data to return with any errors.
+	 *
+	 * @param array $base_data Base error data to pass along.
+	 *
+	 * @return array
+	 */
+	abstract public function get_error_data( $base_data = [] );
 
 	/**
 	 * Get the value of a field.
@@ -322,5 +340,14 @@ abstract class Sensei_Data_Port_Model {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Get the default author.
+	 *
+	 * @return int
+	 */
+	public function get_default_author(): int {
+		return $this->default_author;
 	}
 }

--- a/includes/data-port/models/class-sensei-data-port-model.php
+++ b/includes/data-port/models/class-sensei-data-port-model.php
@@ -79,11 +79,11 @@ abstract class Sensei_Data_Port_Model {
 	/**
 	 * Get the data to return with any errors.
 	 *
-	 * @param array $base_data Base error data to pass along.
+	 * @param array $data Base error data to pass along.
 	 *
 	 * @return array
 	 */
-	abstract public function get_error_data( $base_data = [] );
+	abstract public function get_error_data( $data = [] );
 
 	/**
 	 * Get the value of a field.
@@ -347,7 +347,7 @@ abstract class Sensei_Data_Port_Model {
 	 *
 	 * @return int
 	 */
-	public function get_default_author(): int {
+	public function get_default_author() {
 		return $this->default_author;
 	}
 }

--- a/includes/data-port/models/class-sensei-data-port-question-model.php
+++ b/includes/data-port/models/class-sensei-data-port-question-model.php
@@ -147,4 +147,30 @@ class Sensei_Data_Port_Question_Model extends Sensei_Data_Port_Model {
 			],
 		];
 	}
+
+	/**
+	 * Get the data to return with any errors.
+	 *
+	 * @param array $data Base error data to pass along.
+	 *
+	 * @return array
+	 */
+	public function get_error_data( $data = [] ) {
+		$entry_id = $this->get_value( self::COLUMN_ID );
+		if ( $entry_id ) {
+			$data['entry_id'] = $entry_id;
+		}
+
+		$entry_title = $this->get_value( self::COLUMN_QUESTION );
+		if ( $entry_id ) {
+			$data['entry_title'] = $entry_title;
+		}
+
+		$post_id = $this->get_post_id();
+		if ( $post_id ) {
+			$data['post_id'] = $post_id;
+		}
+
+		return $data;
+	}
 }

--- a/tests/framework/data-port/class-sensei-data-port-model-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-model-mock.php
@@ -19,6 +19,10 @@ class Sensei_Data_Port_Model_Mock extends Sensei_Data_Port_Model {
 		parent::set_post_id( $id );
 	}
 
+	public function get_error_data( $data = [] ) {
+		return $data;
+	}
+
 	public static function get_schema() {
 		return [
 			'test-string-allow-html' => [

--- a/tests/framework/data-port/class-sensei-import-file-process-task-mock.php
+++ b/tests/framework/data-port/class-sensei-import-file-process-task-mock.php
@@ -11,8 +11,9 @@ class Sensei_Import_File_Process_Task_Mock extends Sensei_Import_File_Process_Ta
 		return 'mock-key';
 	}
 
-	protected function process_line( $line_number, $line ) {}
-
+	public function get_model_class() {
+		return Sensei_Data_Port_Model_Mock::class;
+	}
 
 	public function clean_up() {}
 


### PR DESCRIPTION
I noticed that our `process_line` methods were eerily close. I think we can consolidate them with a few minor changes to the model. 

### Changes proposed in this Pull Request

* Bring the `process_line` method up to the parent class. 
* Add `get_error_data` to the model to pass descriptive data.

### Testing instructions

* Observe passing tests.