### PR TITLE
Add features installation feedback URL

### DIFF
--- a/assets/setup-wizard/features/index.js
+++ b/assets/setup-wizard/features/index.js
@@ -6,6 +6,10 @@ import { uniq } from 'lodash';
 import { INSTALLED_STATUS } from './feature-status';
 import { logEvent } from '../log-event';
 import { useQueryStringRouter } from '../query-string-router';
+import {
+	getParam,
+	updateQueryString,
+} from '../query-string-router/url-functions';
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 import ConfirmationModal from './confirmation-modal';
 import InstallationFeedback from './installation-feedback';
@@ -65,6 +69,15 @@ const Features = () => {
 			] )
 		);
 	}, [ submittedSlugs, features ] );
+
+	// Open directly in the feedback screen when there is a temporary feedback param.
+	useEffect( () => {
+		if ( getParam( 'feedback' ) ) {
+			// Remove temporary param.
+			updateQueryString( 'feedback', null, true );
+			toggleFeedback( true );
+		}
+	}, [] );
 
 	const getSelectedFeatures = () =>
 		features.filter( ( feature ) =>

--- a/assets/setup-wizard/features/index.test.js
+++ b/assets/setup-wizard/features/index.test.js
@@ -2,7 +2,7 @@ import { render, fireEvent } from '@testing-library/react';
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 
 import QueryStringRouter, { Route } from '../query-string-router';
-import { updateRouteURL } from '../query-string-router/url-functions';
+import { updateQueryString } from '../query-string-router/url-functions';
 import Features from './index';
 import useFeaturesPolling from './use-features-polling';
 
@@ -39,7 +39,7 @@ describe( '<Features />', () => {
 
 	afterEach( () => {
 		// Clear URL param.
-		updateRouteURL( 'step', '' );
+		updateQueryString( 'step', '' );
 
 		delete window.sensei_log_event;
 	} );

--- a/assets/setup-wizard/features/index.test.js
+++ b/assets/setup-wizard/features/index.test.js
@@ -1,6 +1,7 @@
 import { render, fireEvent } from '@testing-library/react';
-import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 
+import { mockSearch } from '../../tests-helper/functions';
+import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 import QueryStringRouter, { Route } from '../query-string-router';
 import { updateQueryString } from '../query-string-router/url-functions';
 import Features from './index';
@@ -257,5 +258,22 @@ describe( '<Features />', () => {
 				slug: 'test-1,test-2',
 			}
 		);
+	} );
+
+	it( 'Should display installation feedback when feedback is an URL param', () => {
+		mockSearch( 'feedback=1' );
+		useFeaturesPolling.mockReturnValue( {
+			selected: [ 'test' ],
+			options: [ { slug: 'test', title: 'Test', status: 'installed' } ],
+		} );
+
+		const { queryByText } = render(
+			<QueryStringRouter>
+				<Features />
+			</QueryStringRouter>
+		);
+
+		expect( queryByText( 'Plugin installed' ) ).toBeTruthy();
+		mockSearch( '' );
 	} );
 } );

--- a/assets/setup-wizard/query-string-router/index.js
+++ b/assets/setup-wizard/query-string-router/index.js
@@ -6,7 +6,7 @@ import {
 } from '@wordpress/element';
 
 import { useEventListener } from '../../react-hooks';
-import { updateRouteURL, getCurrentRouteFromURL } from './url-functions';
+import { updateQueryString, getParam } from './url-functions';
 
 /**
  * Query string router context.
@@ -26,9 +26,7 @@ const QueryStringRouterContext = createContext();
  */
 const QueryStringRouter = ( { paramName, defaultRoute, children } ) => {
 	// Current route.
-	const [ currentRoute, setRoute ] = useState(
-		getCurrentRouteFromURL( paramName )
-	);
+	const [ currentRoute, setRoute ] = useState( getParam( paramName ) );
 
 	// Provider value.
 	const providerValue = useMemo( () => {
@@ -40,7 +38,7 @@ const QueryStringRouter = ( { paramName, defaultRoute, children } ) => {
 		 * @param {boolean} replace  Flag to mark if should replace or push state.
 		 */
 		const goTo = ( newRoute, replace = false ) => {
-			updateRouteURL( paramName, newRoute, replace );
+			updateQueryString( paramName, newRoute, replace );
 			setRoute( newRoute );
 		};
 
@@ -58,7 +56,7 @@ const QueryStringRouter = ( { paramName, defaultRoute, children } ) => {
 	useEventListener(
 		'popstate',
 		() => {
-			setRoute( getCurrentRouteFromURL( paramName ) );
+			setRoute( getParam( paramName ) );
 		},
 		[ paramName ]
 	);

--- a/assets/setup-wizard/query-string-router/url-functions.js
+++ b/assets/setup-wizard/query-string-router/url-functions.js
@@ -1,45 +1,29 @@
 /**
- * Add param to the URL with pushState.
- *
- * @param {string}  paramName  Param name to be added to the URL.
- * @param {string}  paramValue Param value to be added to the URL.
- * @param {boolean} replace    Flag if it should replace the state. Otherwise it'll push a new.
- */
-const pushQueryStringState = ( paramName, paramValue, replace = false ) => {
-	const { search } = window.location;
-	const historyMethod = replace ? 'replaceState' : 'pushState';
-	const searchParams = new URLSearchParams( search );
-
-	searchParams.set( paramName, paramValue );
-	window.history[ historyMethod ]( {}, '', `?${ searchParams.toString() }` );
-};
-
-/**
  * Get parameter from URL.
  *
  * @param {string} name  Name of the param to get.
  *
  * @return {string|null} The value in the param. If it's empty, return null.
  */
-const getParam = ( name ) =>
+export const getParam = ( name ) =>
 	new URLSearchParams( window.location.search ).get( name ) || null;
 
 /**
- * Update URL with new route.
+ * Update query string.
  *
- * @param {string}  paramName Param name that the route is associated.
- * @param {string}  newRoute  Text that represents the new route.
- * @param {boolean} replace   Flag if it should replace the state. Otherwise it'll push a new.
+ * @param {string}  paramName  Param name to be added to the URL.
+ * @param {string}  paramValue Param value to be added to the URL.
+ * @param {boolean} replace    Flag if it should replace the state. Otherwise it'll push a new.
  */
-export const updateRouteURL = ( paramName, newRoute, replace = false ) => {
-	pushQueryStringState( paramName, newRoute, replace );
-};
+export const updateQueryString = ( paramName, paramValue, replace = false ) => {
+	const { search } = window.location;
+	const historyMethod = replace ? 'replaceState' : 'pushState';
+	const searchParams = new URLSearchParams( search );
 
-/**
- * Get current route from URL.
- *
- * @param {string} paramName Param name that the route is associated.
- *
- * @return {string} Current route key.
- */
-export const getCurrentRouteFromURL = ( paramName ) => getParam( paramName );
+	if ( null === paramValue ) {
+		searchParams.delete( paramName );
+	} else {
+		searchParams.set( paramName, paramValue );
+	}
+	window.history[ historyMethod ]( {}, '', `?${ searchParams.toString() }` );
+};

--- a/assets/setup-wizard/query-string-router/url-functions.test.js
+++ b/assets/setup-wizard/query-string-router/url-functions.test.js
@@ -1,4 +1,4 @@
-import { updateRouteURL, getCurrentRouteFromURL } from './url-functions';
+import { getParam, updateQueryString } from './url-functions';
 import { mockSearch } from '../../tests-helper/functions';
 
 describe( 'URL functions', () => {
@@ -6,11 +6,33 @@ describe( 'URL functions', () => {
 		mockSearch( '' );
 	} );
 
-	describe( 'updateRouteURL', () => {
+	describe( 'getParam', () => {
+		it( 'Should return the URL param', () => {
+			mockSearch( 'param=123&other-param=value' );
+			const value = getParam( 'param' );
+
+			expect( value ).toEqual( '123' );
+		} );
+
+		it( 'Should return null when there is no param', () => {
+			const value = getParam( 'param' );
+
+			expect( value ).toBeNull();
+		} );
+
+		it( 'Should return null when param is empty', () => {
+			mockSearch( 'route=' );
+			const value = getParam( 'param' );
+
+			expect( value ).toBeNull();
+		} );
+	} );
+
+	describe( 'updateQueryString', () => {
 		it( 'Should add a param to the current URL', () => {
 			const pushStateSpy = jest.spyOn( window.history, 'pushState' );
 
-			updateRouteURL( 'route', 'test-route' );
+			updateQueryString( 'route', 'test-route' );
 
 			expect( pushStateSpy ).toHaveBeenCalledWith(
 				{},
@@ -24,7 +46,7 @@ describe( 'URL functions', () => {
 
 			const pushStateSpy = jest.spyOn( window.history, 'pushState' );
 
-			updateRouteURL( 'route', 'test-route' );
+			updateQueryString( 'route', 'test-route' );
 
 			expect( pushStateSpy ).toHaveBeenCalledWith(
 				{},
@@ -33,13 +55,13 @@ describe( 'URL functions', () => {
 			);
 		} );
 
-		it( 'Should update the route with the replaceState when flag is true', () => {
+		it( 'Should update the param with the replaceState when flag is true', () => {
 			const replaceStateSpy = jest.spyOn(
 				window.history,
 				'replaceState'
 			);
 
-			updateRouteURL( 'route', 'test-route', true );
+			updateQueryString( 'route', 'test-route', true );
 
 			expect( replaceStateSpy ).toHaveBeenCalledWith(
 				{},
@@ -47,22 +69,14 @@ describe( 'URL functions', () => {
 				'?route=test-route'
 			);
 		} );
-	} );
 
-	describe( 'getCurrentRouteFromURL', () => {
-		it( 'Should return the current route key', () => {
-			mockSearch( 'route=test-route&other-param=value' );
-			const currentRoute = getCurrentRouteFromURL( 'route' );
+		it( 'Should remove param from query string', () => {
+			mockSearch( 'param=123' );
+			const pushStateSpy = jest.spyOn( window.history, 'pushState' );
 
-			expect( currentRoute ).toEqual( 'test-route' );
-		} );
+			updateQueryString( 'param', null );
 
-		it( 'Should return empty key when there is no a route', () => {
-			mockSearch( 'route=' );
-
-			const currentRoute = getCurrentRouteFromURL( 'route' );
-
-			expect( currentRoute ).toBeNull();
+			expect( pushStateSpy ).toHaveBeenCalledWith( {}, '', '?' );
 		} );
 	} );
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add features installation feedback URL.
  * It will be used to send the user direct to the installation feedback when coming from the WC installation.
* After access the page, the param is removed automatically. It ensures that while navigating between the steps, the user will navigate normally to the features step not getting stuck in the installation feedback.

### Testing instructions

* Go to Setup Wizard.
* Navigate to the Features step.
* Install some items.
* Access directly the link: `/wp-admin/admin.php?page=sensei_setup_wizard&step=features&feedback=1` and make sure that you were direct to the installation feedback.
* Continue to the ready step.
* Click on the feature step and make sure you are on the features selection screen.