### PR TITLE
Remove source assets from package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,7 +36,8 @@ var paths = {
 		'node_modules/select2/dist/js/select2.full.min.js',
 	],
 	packageContents: [
-		'assets/**/*',
+		'assets/dist/**/*',
+		'assets/vendor/**/*',
 		'changelog.txt',
 		'CONTRIBUTING.md',
 		'LICENSE',


### PR DESCRIPTION
Now that we are serving all of our assets from the `assets/dist` and `assets/vendor` directories (as far as I can tell), we should only include those directories in the shipped package.

This also fixes an issue when deploying to wpcom where it tries to automatically build our SCSS files and fails, probably because of a version mismatch.

## Testing Instructions

- Build the package, and run it on a clean site.
- Click around to the various areas in Sensei, both WP Admin and frontend, and ensure that all JS and CSS is working properly.

If anything is not working properly, it is possible that there is still a JS or CSS file being included from outside of the `dist` or `vendor` directory.