### PR TITLE
Added login notice to single lesson & single quiz pages.

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -776,7 +776,7 @@ section.entry span.course-lesson-progress { margin-left: 10px; }
 /*-------------------------------------------------------------------------------------------*/
 /* 1. Info Boxes */
 /*-------------------------------------------------------------------------------------------*/
-.sensei, .course-container, .course, .lesson, .quiz, .learner-info  {
+.sensei, .course-container, .course, .module-container, .lesson, .quiz, .learner-info  {
   p.sensei-message, div.sensei-message {
     clear: both;
     margin: 1.387em 0 1.618em 0;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4141,7 +4141,7 @@ class Sensei_Lesson {
 	}
 
 	/**
-	 * Show a message offering a login link when login is required 
+	 * Show a message offering a login link when login is required
 	 * and user is not logged in yet.
 	 *
 	 * @since 3.2.0
@@ -4150,13 +4150,13 @@ class Sensei_Lesson {
 
 		$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
 
-		// bail out when user is logged in or login is not required
-		if ( is_user_logged_in() 
+		// Bail out when user is logged in or login is not required.
+		if ( is_user_logged_in()
 			|| empty( $course_id )
-			|| 'course' !== get_post_type( $course_id ) 
+			|| 'course' !== get_post_type( $course_id )
 			|| sensei_all_access()
-			|| Sensei_Utils::is_preview_lesson( get_the_ID()
-			|| ! sensei_is_login_required() ) 
+			|| Sensei_Utils::is_preview_lesson( get_the_ID() )
+			|| ! sensei_is_login_required()
 		) {
 			return;
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4141,6 +4141,41 @@ class Sensei_Lesson {
 	}
 
 	/**
+	 * Show a message offering a login link when login is required 
+	 * and user is not logged in yet.
+	 *
+	 * @since 3.2.0
+	 */
+	public static function login_notice() {
+
+		$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
+
+		// bail out when user is logged in or login is not required
+		if ( is_user_logged_in() 
+			|| empty( $course_id )
+			|| 'course' !== get_post_type( $course_id ) 
+			|| sensei_all_access()
+			|| Sensei_Utils::is_preview_lesson( get_the_ID()
+			|| ! sensei_is_login_required() ) 
+		) {
+			return;
+		}
+
+		$anchor_before = '<a href="' . esc_url( sensei_user_login_url() ) . '" >';
+		$anchor_after  = '</a>';
+		$message       = sprintf(
+			// translators: Placeholders are an opening and closing <a> tag linking to the login URL.
+			__( 'or %1$slog in%2$s to access the lesson content, when you are already enrolled in this course.', 'sensei-lms' ),
+			$anchor_before,
+			$anchor_after
+		);
+		$notice_level = 'info';
+
+		Sensei()->notices->add_notice( $message, $notice_level );
+
+	}
+
+	/**
 	 * Outputs the the lesson archive header.
 	 *
 	 * @since  1.9.0

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4057,7 +4057,7 @@ class Sensei_Lesson {
 	} // end user_not_taking_course_message
 
 	/**
-	 * Outputs the lessons course signup lingk
+	 * Outputs the lessons course signup link
 	 *
 	 * This hook runs inside the single lesson page.
 	 *
@@ -4067,12 +4067,12 @@ class Sensei_Lesson {
 
 		$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
 
-		if ( empty( $course_id ) || 'course' !== get_post_type( $course_id ) || sensei_all_access() || Sensei_Utils::is_preview_lesson( get_the_ID() ) ) {
+		if ( empty( $course_id ) || Sensei_Utils::is_preview_lesson( get_the_ID() ) ) {
 			return;
 		}
 
-		$show_course_signup_notice = sensei_is_login_required() && ! Sensei_Course::is_user_enrolled( $course_id );
-
+		$show_course_signup_notice = is_user_logged_in() && ! Sensei()->course->can_access_course_content( $course_id );
+		
 		/**
 		 * Filter for if we should show the course sign up notice on the lesson page.
 		 *

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4148,7 +4148,7 @@ class Sensei_Lesson {
 	 * @return bool True if login for the lesson is required.
 	 */
 	public static function user_should_login( $lesson_id ) {
-		if ( 'integer' != gettype($lesson_id) || $lesson_id <= 0 ) {
+		if ( 'integer' !== gettype( $lesson_id ) || $lesson_id <= 0 ) {
 			return false;
 		}
 		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
@@ -4167,18 +4167,18 @@ class Sensei_Lesson {
 
 	/**
 	 * Creates a login notice when appropriate.
-	 * 
+	 *
 	 * @version 3.2.0
-	 * 
+	 *
 	 * @return;
 	 */
 	public static function login_notice() {
 
-		$login_notice = Sensei_Utils::login_notice('lesson');
-        if ( false === $login_notice ) {
-            return;
-        }
-		$message      = wp_kses_post($login_notice);
+		$login_notice = Sensei_Utils::login_notice( 'lesson' );
+		if ( false === $login_notice ) {
+			return;
+		}
+		$message      = wp_kses_post( $login_notice );
 		$notice_level = 'info';
 
 		Sensei()->notices->add_notice( $message, $notice_level );

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4141,10 +4141,10 @@ class Sensei_Lesson {
 	}
 
 	/**
-	 * Determine if user should login in to get acces to a lesson and quiz.
+	 * Determines if user should login in to get acces to a lesson or quiz.
 	 *
 	 * @since 3.2.0
-	 * @param int $lesson_id
+	 * @param int $lesson_id Lesson ID.
 	 * @return bool True if login for the lesson is required.
 	 */
 	public static function user_should_login( $lesson_id ) {
@@ -4166,23 +4166,19 @@ class Sensei_Lesson {
 	}
 
 	/**
-	 * Creates a login notice when appropriate.
+	 * Adds a login notice when appropriate.
 	 *
-	 * @version 3.2.0
-	 *
-	 * @return;
+	 * @since 3.2.0
+	 * @return void
 	 */
 	public static function login_notice() {
-
 		$login_notice = Sensei_Utils::login_notice( 'lesson' );
 		if ( false === $login_notice ) {
 			return;
 		}
 		$message      = wp_kses_post( $login_notice );
 		$notice_level = 'info';
-
 		Sensei()->notices->add_notice( $message, $notice_level );
-
 	}
 
 	/**

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1212,7 +1212,6 @@ class Sensei_Quiz {
 
 		$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_id );
 		$status    = Sensei_Utils::sensei_user_quiz_status_message( $lesson_id, get_current_user_id() );
-		$messages  = Sensei()->frontend->messages;
 		$message   = '<div class="sensei-message ' . esc_attr( $status['box_class'] ) . '">' . wp_kses_post( $status['message'] ) . '</div>';
 		$messages  = Sensei()->frontend->messages;
 
@@ -1224,6 +1223,25 @@ class Sensei_Quiz {
 		echo $message;
 	}
 
+	/**
+	 * Creates a login notice when appropriate.
+	 * 
+	 * @version 3.2.0
+	 * 
+	 * @param $quiz_id
+	 */
+	public static function login_notice( $quiz_id ) {
+
+		$login_notice = Sensei_Utils::login_notice('quiz');
+        if ( false === $login_notice ) {
+            return;
+        }
+		$message      = wp_kses_post($login_notice);
+		$notice_level = 'info';
+
+		Sensei()->notices->add_notice( $message, $notice_level );
+	}
+	
 	/**
 	 * The quiz action buttons needed to output quiz
 	 * action such as reset complete and save.

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1225,23 +1225,22 @@ class Sensei_Quiz {
 
 	/**
 	 * Creates a login notice when appropriate.
-	 * 
+	 *
 	 * @version 3.2.0
-	 * 
-	 * @param $quiz_id
+	 * @return  void
 	 */
-	public static function login_notice( $quiz_id ) {
+	public static function login_notice() {
 
-		$login_notice = Sensei_Utils::login_notice('quiz');
-        if ( false === $login_notice ) {
-            return;
-        }
-		$message      = wp_kses_post($login_notice);
+		$login_notice = Sensei_Utils::login_notice( 'quiz' );
+		if ( false === $login_notice ) {
+			return;
+		}
+		$message      = wp_kses_post( $login_notice );
 		$notice_level = 'info';
 
 		Sensei()->notices->add_notice( $message, $notice_level );
 	}
-	
+
 	/**
 	 * The quiz action buttons needed to output quiz
 	 * action such as reset complete and save.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1394,8 +1394,7 @@ class Sensei_Utils {
 	 * in a given context, and user is not logged in yet.
 	 *
 	 * @since 3.2.0
-	 * @param string $context
-	 * @param int    $id Post id.
+	 * @param string $context Either 'lesson' or 'quiz'.
 	 * @return bool|string false When user doesn't need to login, or a string message containing a login link.
 	 */
 	public static function login_notice( $context = 'lesson' ) {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1390,6 +1390,42 @@ class Sensei_Utils {
 	}
 
 	/**
+	 * Show a message offering a login link when login is required,
+	 * in a given context, and user is not logged in yet.
+	 *
+	 * @since 3.2.0
+	 * @param string $context 'lesson' or 'quiz'
+	 * @param int $id post id
+	 * @return bool|string false when user doesn't need to login, or a string message containing a login link.
+	 */
+	public static function login_notice( $context = 'lesson' ) {
+		$lesson_id = get_the_ID();
+
+		if ( ! in_array( $context, ['lesson', 'quiz'], true )
+ 			|| $context !== get_post_type( $id ) ) {
+			return false;
+		}
+		if ( 'quiz' === $context ) {
+			$lesson_id = Sensei()->quiz->get_lesson_id( $lesson_id );
+		}
+		if ( ! Sensei()->lesson->user_should_login( $lesson_id ) ) {
+			return false;
+		}
+
+		$anchor_before = '<a href="' . esc_url( sensei_user_login_url() ) . '" >';
+		$anchor_after  = '</a>';
+		$message       = sprintf(
+			// translators: Placeholders %1$s and %2$s are an opening and closing <a> tag linking to the login URL, %3$s is the context ("lesson" or "quiz")
+			__( 'or %1$slog in%2$s to access the %3$s content, when you are already enrolled in this course.', 'sensei-lms' ),
+			$anchor_before,
+			$anchor_after,
+			$context
+		);
+
+		return $message;
+	}
+
+	/**
 	 * Start course for user
 	 *
 	 * @since  1.4.8

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1390,12 +1390,13 @@ class Sensei_Utils {
 	}
 
 	/**
-	 * Show a message offering a login link when login is required,
-	 * in a given context, and user is not logged in yet.
+	 * Determines if a user still has to log in to see a given content (lesson or quiz).
+	 * Returns false, when no login action is needed,
+	 * or a message containing a invitation to login and a link to do so.
 	 *
 	 * @since 3.2.0
 	 * @param string $context Either 'lesson' or 'quiz'.
-	 * @return bool|string false When user doesn't need to login, or a string message containing a login link.
+	 * @return bool|string False When user doesn't need to login, or a string message containing a login link.
 	 */
 	public static function login_notice( $context = 'lesson' ) {
 		$lesson_id = get_the_ID();

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1402,7 +1402,7 @@ class Sensei_Utils {
 		$lesson_id = get_the_ID();
 
 		if ( ! in_array( $context, ['lesson', 'quiz'], true )
- 			|| $context !== get_post_type( $id ) ) {
+ 			|| $context !== get_post_type( $lesson_id ) ) {
 			return false;
 		}
 		if ( 'quiz' === $context ) {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1394,15 +1394,15 @@ class Sensei_Utils {
 	 * in a given context, and user is not logged in yet.
 	 *
 	 * @since 3.2.0
-	 * @param string $context 'lesson' or 'quiz'
-	 * @param int $id post id
-	 * @return bool|string false when user doesn't need to login, or a string message containing a login link.
+	 * @param string $context
+	 * @param int    $id Post id.
+	 * @return bool|string false When user doesn't need to login, or a string message containing a login link.
 	 */
 	public static function login_notice( $context = 'lesson' ) {
 		$lesson_id = get_the_ID();
 
-		if ( ! in_array( $context, ['lesson', 'quiz'], true )
- 			|| $context !== get_post_type( $lesson_id ) ) {
+		if ( ! in_array( $context, [ 'lesson', 'quiz' ], true )
+			|| get_post_type( $lesson_id ) !== $context ) {
 			return false;
 		}
 		if ( 'quiz' === $context ) {
@@ -1415,7 +1415,7 @@ class Sensei_Utils {
 		$anchor_before = '<a href="' . esc_url( sensei_user_login_url() ) . '" >';
 		$anchor_after  = '</a>';
 		$message       = sprintf(
-			// translators: Placeholders %1$s and %2$s are an opening and closing <a> tag linking to the login URL, %3$s is the context ("lesson" or "quiz")
+			// translators: Placeholders %1$s and %2$s are an opening and closing <a> tag linking to the login URL, %3$s is the context ("lesson" or "quiz").
 			__( 'or %1$slog in%2$s to access the %3$s content, when you are already enrolled in this course.', 'sensei-lms' ),
 			$anchor_before,
 			$anchor_after,
@@ -1429,8 +1429,8 @@ class Sensei_Utils {
 	 * Start course for user
 	 *
 	 * @since  1.4.8
-	 * @param  integer $user_id   User ID
-	 * @param  integer $course_id Course ID
+	 * @param  integer $user_id   User ID.
+	 * @param  integer $course_id Course ID.
 	 * @return bool|int False if they haven't started; Comment ID of course progress if they have.
 	 */
 	public static function user_start_course( $user_id = 0, $course_id = 0 ) {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1217,7 +1217,6 @@ class Sensei_Utils {
 		$box_class = 'info';
 		$message   = __( "You have not taken this lesson's quiz yet", 'sensei-lms' );
 		$extra     = '';
-
 		if ( $lesson_id > 0 && $user_id > 0 ) {
 			// Course ID
 			$course_id = absint( get_post_meta( $lesson_id, '_lesson_course', true ) );
@@ -1255,19 +1254,17 @@ class Sensei_Utils {
 			// Quiz questions
 			$has_quiz_questions = Sensei_Lesson::lesson_quiz_has_questions( $lesson_id );
 
-			if ( ! $started_course ) {
+			if ( ! is_user_logged_in() ) { // should never occur, since user_id > 0 is true
+				$status    = 'login_required';
+				$box_class = 'info';
+				$message   = __( 'You must be logged in to take this quiz', 'sensei-lms' );
+			} elseif ( ! $started_course ) {
 				$status    = 'not_started_course';
 				$box_class = 'info';
 				// translators: Placeholders are an opening and closing <a> tag linking to the course permalink.
 				$message = sprintf( __( 'Please sign up for %1$sthe course%2$s before taking this quiz', 'sensei-lms' ), '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr( __( 'Sign Up', 'sensei-lms' ) ) . '">', '</a>' );
-
-			} elseif ( ! is_user_logged_in() ) {
-
-				$status    = 'login_required';
-				$box_class = 'info';
-				$message   = __( 'You must be logged in to take this quiz', 'sensei-lms' );
-
 			}
+
 			// Lesson/Quiz is marked as complete thus passing any quiz restrictions
 			elseif ( $lesson_complete ) {
 
@@ -1390,17 +1387,14 @@ class Sensei_Utils {
 	}
 
 	/**
-	 * Determines if a user still has to log in to see a given content (lesson or quiz).
-	 * Returns false, when no login action is needed,
-	 * or a message containing a invitation to login and a link to do so.
+	 * Returns a login notice, or false when login is not required.
 	 *
 	 * @since 3.2.0
-	 * @param string $context Either 'lesson' or 'quiz'.
-	 * @return bool|string False When user doesn't need to login, or a string message containing a login link.
+	 * @param  string      $context Either 'lesson' or 'quiz'.
+	 * @return string|bool          Login notice, or false.
 	 */
 	public static function login_notice( $context = 'lesson' ) {
 		$lesson_id = get_the_ID();
-
 		if ( ! in_array( $context, [ 'lesson', 'quiz' ], true )
 			|| get_post_type( $lesson_id ) !== $context ) {
 			return false;
@@ -1411,17 +1405,16 @@ class Sensei_Utils {
 		if ( ! Sensei()->lesson->user_should_login( $lesson_id ) ) {
 			return false;
 		}
-
 		$anchor_before = '<a href="' . esc_url( sensei_user_login_url() ) . '" >';
 		$anchor_after  = '</a>';
+		$context_label = 'lesson' === $context ? __( 'lesson', 'sensei-lms' ) : __( 'quiz', 'sensei-lms' );
 		$message       = sprintf(
 			// translators: Placeholders %1$s and %2$s are an opening and closing <a> tag linking to the login URL, %3$s is the context ("lesson" or "quiz").
-			__( 'or %1$slog in%2$s to access the %3$s content, when you are already enrolled in this course.', 'sensei-lms' ),
+			__( 'Please %1$slog in%2$s to access the %3$s.', 'sensei-lms' ),
 			$anchor_before,
 			$anchor_after,
-			$context
+			$context_label
 		);
-
 		return $message;
 	}
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -909,7 +909,7 @@ class Sensei_Main {
 					$this->permissions_message['title'] = get_the_title( $post->ID ) . ': ' . __( 'Restricted Access', 'sensei-lms' );
 					$course_link                        = '<a href="' . esc_url( get_permalink( get_post_meta( get_post_meta( $post->ID, '_quiz_lesson', true ), '_lesson_course', true ) ) ) . '">' . __( 'course', 'sensei-lms' ) . '</a>';
 					// translators: The placeholder %1$s is a link to the Course.
-					$this->permissions_message['message'] = sprintf( __( 'Please sign up for the %1$s before taking this Quiz.', 'sensei-lms' ), $course_link );
+					$this->permissions_message['message'] = sprintf( __( 'Please sign up for the %1$s before taking this quiz.', 'sensei-lms' ), $course_link );
 				} // End if().
 				break;
 			default:

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -140,6 +140,10 @@ add_action( 'sensei_single_quiz_content_inside_before', array( 'Sensei_Quiz', 's
 // hook in the quiz user message
 add_action( 'sensei_single_quiz_content_inside_before', array( 'Sensei_Quiz', 'the_user_status_message' ), 40 );
 
+// since 3.2.0
+// hook in the login notice
+add_action( 'sensei_single_quiz_content_inside_before', array( 'Sensei_Quiz', 'login_notice' ), 40 );
+
 // @since 1.9.0
 // hook in the question title, description and quesiton media
 add_action( 'sensei_quiz_question_inside_before', array( 'Sensei_Question', 'the_question_title' ), 10 );
@@ -333,5 +337,6 @@ add_action( 'sensei_teacher_archive_course_loop_before', array( 'Sensei_Teacher'
 add_action( 'sensei_course_results_content_inside_before', array( $sensei->notices, 'maybe_print_notices' ) );
 add_action( 'sensei_single_course_content_inside_before', array( $sensei->notices, 'maybe_print_notices' ), 40 );
 add_action( 'sensei_single_lesson_content_inside_before', array( $sensei->notices, 'maybe_print_notices' ), 40 );
+add_action( 'sensei_single_quiz_content_inside_before', array( $sensei->notices, 'maybe_print_notices' ), 40 );
 add_action( 'sensei_taxonomy_module_content_inside_before', array( $sensei->notices, 'maybe_print_notices' ), 40 );
 

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -141,7 +141,7 @@ add_action( 'sensei_single_quiz_content_inside_before', array( 'Sensei_Quiz', 's
 add_action( 'sensei_single_quiz_content_inside_before', array( 'Sensei_Quiz', 'the_user_status_message' ), 40 );
 
 // since 3.2.0
-// hook in the login notice
+// hook in the login notice.
 add_action( 'sensei_single_quiz_content_inside_before', array( 'Sensei_Quiz', 'login_notice' ), 40 );
 
 // @since 1.9.0

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -195,8 +195,8 @@ add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson'
 // hook the single lesson course_signup_link
 add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'course_signup_link' ), 30 );
 
-// @since 1.9.0
-// hook the single lesson course_signup_link
+// @since 3.2.0
+// hook the single lesson login_notice
 add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'login_notice' ), 30 );
 
 // @since 1.9.0

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -73,6 +73,10 @@ add_action( 'sensei_single_course_content_inside_before', array( 'Sensei_Course'
 // hook the single course title on the single course page
 add_action( 'sensei_single_course_content_inside_before', array( $sensei->course, 'course_image' ), 20 );
 
+// @since 1.9.10
+// hook in the course prerequisite completion message
+add_action( 'sensei_single_course_content_inside_before', array( 'Sensei_Course', 'prerequisite_complete_message' ), 20 );
+
 // @1.9.0
 // Filter the content and replace it with the excerpt if the user doesn't have full access
 add_filter( 'the_content', array( 'Sensei_Course', 'single_course_content' ) );
@@ -187,13 +191,13 @@ add_action( 'sensei_single_lesson_content_inside_after', 'sensei_the_single_less
 // hook in the lesson prerequisite completion message
 add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'prerequisite_complete_message' ), 20 );
 
-// @since 1.9.10
-// hook in the course prerequisite completion message
-add_action( 'sensei_single_course_content_inside_before', array( 'Sensei_Course', 'prerequisite_complete_message' ), 20 );
-
 // @since 1.9.0
 // hook the single lesson course_signup_link
 add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'course_signup_link' ), 30 );
+
+// @since 1.9.0
+// hook the single lesson course_signup_link
+add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'login_notice' ), 30 );
 
 // @since 1.9.0
 // Add the quiz specific buttons and notices to the lesson

--- a/templates/single-lesson.php
+++ b/templates/single-lesson.php
@@ -35,8 +35,16 @@ if ( have_posts() ) {
 		 * @param integer $lesson_id
 		 *
 		 * @hooked deprecated_lesson_image_hook - 10
-		 * @hooked Sensei_Lesson::lesson_image() -  17
+		 * @hooked Sensei_Lesson::maybe_start_lesson - 10
+		 * @hooked Sensei_Lesson::the_title - 15
+		 * @hooked Sensei_Lesson::lesson_image -  17
+		 * @hooked Sensei_Lesson::user_lesson_quiz_status_message - 20
+		 * @hooked Sensei_Lesson::prerequisite_complete_message - 20
 		 * @hooked deprecate_lesson_single_main_content_hook - 20
+		 * @hooked Sensei_Lesson::course_signup_link - 30
+		 * @hooked Sensei_Lesson::login_notice - 30
+		 * @hooked Sensei_Messages::send_message_link - 30
+		 * @hooked Sensei_Notices::maybe_print_notices 40
 		 */
 		do_action( 'sensei_single_lesson_content_inside_before', get_the_ID() );
 

--- a/templates/single-quiz.php
+++ b/templates/single-quiz.php
@@ -26,8 +26,14 @@ get_sensei_header();
 		 *
 		 * @since 1.9.0
 		 *
-		 * @hooked Sensei_Quiz::the_title               - 20
-		 * @hooked Sensei_Quiz::the_user_status_message - 40
+		 * @hooked Sensei_Quiz::start_quiz_questions_loop       - 10
+		 * @hooked Sensei_Quiz::user_quiz_submit_listener       - 10
+		 * @hooked Sensei_Quiz::user_save_quiz_answers_listener - 10
+		 * @hooked Sensei_Quiz::the_title                       - 20
+		 * @hooked Sensei_Quiz::the_user_status_message         - 40
+		 * @hooked Sensei_Quiz::login_notice                    - 40
+		 * @hooked Sensei_Quiz::maybe_print_notices             - 40
+		 * @hooked Sensei_Quiz::load_global_quiz_data           - 80
 		 * @param integer $quiz_id
 		 */
 		do_action( 'sensei_single_quiz_content_inside_before', get_the_ID() );


### PR DESCRIPTION
Fixes #3150

### Changes proposed in this Pull Request

* Add login notice to single lesson & single quiz page, when user is not logged and login is required to get access.
* Also moved the add_action for "sensei_single_course_content_inside_before" up in templates.php, since it belongs to the single course hooks and was inserted between the single lesson hooks.