### PR TITLE
Fix duplicated translations with different translators

### DIFF
--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -219,7 +219,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	private function get_learner_html( $learner ) {
 		$login = $learner->user_login;
 		$title = Sensei_Learner::get_full_name( $learner->user_id );
-		// translators: Placeholder %s is the learner's full name.
+		// translators: Placeholder is the full name of the learner.
 		$a_title = sprintf( esc_html__( 'Edit &#8220;%s&#8221;', 'sensei-lms' ), esc_html( $title ) );
 		$html    = '<strong><a class="row-title" href="' . esc_url( admin_url( 'user-edit.php?user_id=' . $learner->user_id ) ) . '" title="' . esc_attr( $a_title ) . '">' . esc_html( $login ) . '</a></strong>';
 		$html   .= ' <span>(<em>' . esc_html( $title ) . '</em>, ' . esc_html( $learner->user_email ) . ')</span>';

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1629,7 +1629,7 @@ class Sensei_Course {
 							// Course Categories
 				if ( '' != $category_output ) {
 
-					// translators: Placeholder is comma-separated list of course categories.
+					// translators: Placeholder is a comma-separated list of the Course categories.
 					$complete_html .= '<span class="course-category">' . sprintf( __( 'in %s', 'sensei-lms' ), $category_output ) . '</span>';
 
 				} // End If Statement
@@ -2213,7 +2213,7 @@ class Sensei_Course {
 
 		if ( ! empty( $category_output ) ) {
 			echo '<span class="course-category">' .
-				// translators: Placeholder is a comma-separated list of the course categories.
+				// translators: Placeholder is a comma-separated list of the Course categories.
 				wp_kses_post( sprintf( __( 'in %s', 'sensei-lms' ), $category_output ) ) .
 			'</span>';
 		} // End If Statement
@@ -2224,7 +2224,7 @@ class Sensei_Course {
 
 			$completed    = count( $this->get_completed_lesson_ids( $course->ID, get_current_user_id() ) );
 			$lesson_count = count( $this->course_lessons( $course->ID ) );
-			// translators: Placeholders are the number of lessons completed and the total number of lessons, respectively.
+			// translators: Placeholders are the counts for lessons completed and total lessons, respectively.
 			echo '<span class="course-lesson-progress">' . esc_html( sprintf( __( '%1$d of %2$d lessons completed', 'sensei-lms' ), $completed, $lesson_count ) ) . '</span>';
 		}
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1033,7 +1033,7 @@ class Sensei_Frontend {
 				?>
 				<span class="course-category">
 					<?php
-					// translators: Placeholder is a comma-separated list of course categories.
+					// translators: Placeholder is a comma-separated list of the Course categories.
 					echo sprintf( esc_html__( 'in %s', 'sensei-lms' ), wp_kses_post( $category_output ) );
 					?>
 				</span>
@@ -1187,7 +1187,7 @@ class Sensei_Frontend {
 					<?php
 					echo '&nbsp;' . wp_kses_post(
 						sprintf(
-							// translators: Placeholder is a link to view the course.
+							// translators: Placeholder is a link to the Course permalink.
 							__( 'Part of: %s', 'sensei-lms' ),
 							'<a href="' . esc_url( get_permalink( $lesson_course_id ) ) . '" title="' . esc_attr__( 'View course', 'sensei-lms' ) . '"><em>' . esc_html( get_the_title( $lesson_course_id ) ) . '</em></a>'
 						)

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -160,7 +160,7 @@ class Sensei_Grading_User_Quiz {
 								$answer_media_url      = wp_get_attachment_url( $attachment_id );
 								$answer_media_filename = basename( $answer_media_url );
 								if ( $answer_media_url && $answer_media_filename ) {
-									// translators: Placeholder is a link to the submitted file.
+									// translators: Placeholder %1$s is a link to the submitted file.
 									$user_answer_content = sprintf( __( 'Submitted file: %1$s', 'sensei-lms' ), '<a href="' . esc_url( $answer_media_url ) . '" target="_blank">' . esc_html( $answer_media_filename ) . '</a>' );
 								}
 							}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4086,7 +4086,7 @@ class Sensei_Lesson {
 			$course_link .= esc_html__( 'course', 'sensei-lms' );
 			$course_link .= '</a>';
 
-			// translators: Placeholder is a link to the Course.
+			// translators: The placeholder %1$s is a link to the Course.
 			$message_default = sprintf( esc_html__( 'Please sign up for the %1$s before starting the lesson.', 'sensei-lms' ), $course_link );
 
 			/**

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -849,7 +849,7 @@ class Sensei_Messages {
 		$sender          = get_user_by( 'login', $sender_username );
 
 		if ( $sender_username && $sender instanceof WP_User ) {
-			// translators: Placeholders are the sender's display name and the date.
+			// translators: Placeholders are the sender's display name and the date, respectively.
 			$sender_display_name = sprintf( __( 'Sent by %1$s on %2$s.', 'sensei-lms' ), $sender->display_name, get_the_date() );
 			?>
 			<p class="message-meta">

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -216,6 +216,7 @@ function sensei_do_deprecated_action( $hook_tag, $version, $alternative = '', $a
 
 	if ( has_action( $hook_tag ) ) {
 
+		// translators: Placeholders are the hook tag and the version which it was deprecated, respectively.
 		$error_message = sprintf( __( "SENSEI: The hook '%1\$s', has been deprecated since '%2\$s'.", 'sensei-lms' ), $hook_tag, $version );
 
 		if ( ! empty( $alternative ) ) {

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -426,7 +426,7 @@ class Sensei_Legacy_Shortcodes {
 						<?php if ( ! empty( $category_output ) ) { ?>
 							<span class="course-category">
 								<?php
-								// translators: Placeholder is a comma-separated list of categories.
+								// translators: Placeholder is a comma-separated list of the Course categories.
 								echo wp_kses_post( sprintf( __( 'in %s', 'sensei-lms' ), $category_output ) );
 								?>
 							</span>

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -144,7 +144,7 @@ global $course;
 
 					<a href="<?php echo esc_url_raw( get_permalink( $lesson->ID ) ); ?>" title="
 						<?php
-						// translators: Placeholder it the lesson title.
+						// translators: Placeholder is the lesson title.
 						esc_attr( sprintf( __( 'Start %s', 'sensei-lms' ), $lesson->post_title ) )
 						?>
 					" >

--- a/templates/emails/teacher-completed-course.php
+++ b/templates/emails/teacher-completed-course.php
@@ -45,7 +45,7 @@ printf( esc_html__( 'has completed and %1$s the course', 'sensei-lms' ), esc_htm
 
 <p style="<?php echo esc_attr( $small ); ?>">
 <?php
-// translators: Placeholders are an opening an closing <a> tag linking to the course learners admin page.
+// translators: Placeholders are an opening and closing <a> tag linking to the course's learners page in wp-admin.
 printf( esc_html__( 'Manage this course\'s learners %1$shere%2$s.', 'sensei-lms' ), '<a href="' . esc_url( admin_url( 'admin.php?page=sensei_learners&view=learners&course_id=' . $course_id ) ) . '">', '</a>' );
 ?>
 </p>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* We have some warnings while building our pot file. I changed all that had the same meaning, but different translators and I added one that was missing.
  * There are still 5 warnings, but these are cases where we have the same messages and translators with different meanings.

### Testing instructions

* Run `npm run i18n:build` and check that the warnings are relative only to translations with different meanings.