### PR TITLE
Fixes #3307: Removes empty lessons section & title from single course page.

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3177,21 +3177,16 @@ class Sensei_Course {
 		 * Filter documented in class-sensei-messages.php the_title
 		 */
 		$title = wp_kses_post( apply_filters( 'sensei_single_title', get_the_title( $post ), $post->post_type ) );
-		if ( $title ):
-		?>
-		<header>
-
-			<h1>
-
-				<?php
-				echo wp_kses_post( $title );
-				?>
-
-			</h1>
-
-		</header>
-
-		<?php
+		if ( $title ) :
+			?>
+			<header>
+				<h1>
+					<?php
+					echo wp_kses_post( $title );
+					?>
+				</h1>
+			</header>
+			<?php
 		endif;
 
 	}//end the_title()

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3184,7 +3184,7 @@ class Sensei_Course {
 			<h1>
 
 				<?php
-				echo $title;
+				echo wp_kses_post( $title );
 				?>
 
 			</h1>

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2810,7 +2810,7 @@ class Sensei_Course {
 
 		} elseif ( empty( $none_module_lessons ) ) { // if the none module lessons are simply empty the title should not be shown
 
-			$title = '';
+			return;
 		}
 
 		/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3161,7 +3161,7 @@ class Sensei_Course {
 	}
 
 	/**
-	 * Output the title for the single lesson page
+	 * Output the title for the single course page
 	 *
 	 * @global $post
 	 * @since 1.9.0
@@ -3173,16 +3173,18 @@ class Sensei_Course {
 		}
 		global $post;
 
+		/**
+		 * Filter documented in class-sensei-messages.php the_title
+		 */
+		$title = wp_kses_post( apply_filters( 'sensei_single_title', get_the_title( $post ), $post->post_type ) );
+		if ( $title ):
 		?>
 		<header>
 
 			<h1>
 
 				<?php
-				/**
-				 * Filter documented in class-sensei-messages.php the_title
-				 */
-				echo wp_kses_post( apply_filters( 'sensei_single_title', get_the_title( $post ), $post->post_type ) );
+				echo $title;
 				?>
 
 			</h1>
@@ -3190,6 +3192,7 @@ class Sensei_Course {
 		</header>
 
 		<?php
+		endif;
 
 	}//end the_title()
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4195,7 +4195,7 @@ class Sensei_Lesson {
 			<h1>
 
 				<?php
-				echo $title;
+				echo wp_kses_post( $title );
 				?>
 
 			</h1>

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4184,22 +4184,24 @@ class Sensei_Lesson {
 		$is_preview = isset( $post->ID )
 			&& Sensei_Utils::is_preview_lesson( $post->ID )
 			&& ! Sensei_Course::is_user_enrolled( $course_id, $current_user->ID );
-
+		/**
+		 * Filter documented in class-sensei-messages.php the_title
+		 */
+		$title = wp_kses_post( apply_filters( 'sensei_single_title', get_the_title( $post ), $post->post_type ) );
+		if ( $title || $is_preview ):
 		?>
 		<header class="lesson-title">
-
+			<?php if ( $title ): ?>
 			<h1>
 
 				<?php
-				/**
-				 * Filter documented in class-sensei-messages.php the_title
-				 */
-				echo wp_kses_post( apply_filters( 'sensei_single_title', get_the_title( $post ), $post->post_type ) );
+				echo $title;
 				?>
 
 			</h1>
 
-			<?php
+			<?php 
+			endif;
 			if ( $is_preview ) {
 				echo wp_kses_post( Sensei()->frontend->sensei_lesson_preview_title_tag( $course_id ) );
 			}
@@ -4208,6 +4210,7 @@ class Sensei_Lesson {
 		</header>
 
 		<?php
+		endif;
 
 	}//end the_title()
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4188,28 +4188,28 @@ class Sensei_Lesson {
 		 * Filter documented in class-sensei-messages.php the_title
 		 */
 		$title = wp_kses_post( apply_filters( 'sensei_single_title', get_the_title( $post ), $post->post_type ) );
-		if ( $title || $is_preview ):
-		?>
-		<header class="lesson-title">
-			<?php if ( $title ): ?>
-			<h1>
+		if ( $title || $is_preview ) :
+			?>
+			<header class="lesson-title">
+				<?php if ( $title ) : ?>
+					<h1>
 
-				<?php
-				echo wp_kses_post( $title );
+						<?php
+						echo wp_kses_post( $title );
+						?>
+
+					</h1>
+
+					<?php 
+				endif;
+				if ( $is_preview ) {
+					echo wp_kses_post( Sensei()->frontend->sensei_lesson_preview_title_tag( $course_id ) );
+				}
 				?>
 
-			</h1>
+			</header>
 
-			<?php 
-			endif;
-			if ( $is_preview ) {
-				echo wp_kses_post( Sensei()->frontend->sensei_lesson_preview_title_tag( $course_id ) );
-			}
-			?>
-
-		</header>
-
-		<?php
+			<?php
 		endif;
 
 	}//end the_title()

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4193,14 +4193,11 @@ class Sensei_Lesson {
 			<header class="lesson-title">
 				<?php if ( $title ) : ?>
 					<h1>
-
 						<?php
 						echo wp_kses_post( $title );
 						?>
-
 					</h1>
-
-					<?php 
+					<?php
 				endif;
 				if ( $is_preview ) {
 					echo wp_kses_post( Sensei()->frontend->sensei_lesson_preview_title_tag( $course_id ) );

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -745,22 +745,23 @@ class Sensei_Messages {
 		} else {
 			$title = esc_html( get_the_title( $post->ID ) );
 		}
-
+		/**
+		 * Filter Sensei single title
+		 *
+		 * @since 1.8.0
+		 * @param string $title
+		 * @param string $template
+		 * @param string $post_type
+		 */
+		$title = wp_kses_post( apply_filters( 'sensei_single_title', $title, $post->post_type ) );
+		if ( $title ):
 		?>
 		<header>
 
 			<h1>
 
 				<?php
-				/**
-				 * Filter Sensei single title
-				 *
-				 * @since 1.8.0
-				 * @param string $title
-				 * @param string $template
-				 * @param string $post_type
-				 */
-				echo wp_kses_post( apply_filters( 'sensei_single_title', $title, $post->post_type ) );
+				echo $title;
 				?>
 
 			</h1>
@@ -768,7 +769,7 @@ class Sensei_Messages {
 		</header>
 
 		<?php
-
+		endif;
 	} // End sensei_single_title()
 
 	/**

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -765,7 +765,7 @@ class Sensei_Messages {
 			</header>
 			<?php
 		endif;
-	} // End sensei_single_title()
+	}//end the_title()
 
 	/**
 	 * Generates the my messages

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -761,7 +761,7 @@ class Sensei_Messages {
 			<h1>
 
 				<?php
-				echo $title;
+				echo wp_kses_post( $title );
 				?>
 
 			</h1>

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -754,21 +754,16 @@ class Sensei_Messages {
 		 * @param string $post_type
 		 */
 		$title = wp_kses_post( apply_filters( 'sensei_single_title', $title, $post->post_type ) );
-		if ( $title ):
-		?>
-		<header>
-
-			<h1>
-
-				<?php
-				echo wp_kses_post( $title );
-				?>
-
-			</h1>
-
-		</header>
-
-		<?php
+		if ( $title ) :
+			?>
+			<header>
+				<h1>
+					<?php
+					echo wp_kses_post( $title );
+					?>
+				</h1>
+			</header>
+			<?php
 		endif;
 	} // End sensei_single_title()
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1195,7 +1195,7 @@ class Sensei_Quiz {
 			 <h1>
 
 				<?php
-				echo $title;
+				echo wp_kses_post( $title );
 				?>
 
 			 </h1>

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1184,16 +1184,18 @@ class Sensei_Quiz {
 	 * @since 1.9.0
 	 */
 	public static function the_title() {
+		/**
+		 * Filter documented in class-sensei-messages.php the_title
+		 */
+		$title = wp_kses_post( apply_filters( 'sensei_single_title', get_the_title( get_post() ), get_post_type( get_the_ID() ) ) );
+		if ( $title ):
 		?>
 		 <header>
 
 			 <h1>
 
 				<?php
-				/**
-				 * Filter documented in class-sensei-messages.php the_title
-				 */
-				echo wp_kses_post( apply_filters( 'sensei_single_title', get_the_title( get_post() ), get_post_type( get_the_ID() ) ) );
+				echo $title;
 				?>
 
 			 </h1>
@@ -1201,7 +1203,8 @@ class Sensei_Quiz {
 		 </header>
 
 		 <?php
-	}//end the_title()
+		endif;
+	} //end the_title()
 
 	/**
 	 * Output the sensei quiz status message.

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1188,21 +1188,16 @@ class Sensei_Quiz {
 		 * Filter documented in class-sensei-messages.php the_title
 		 */
 		$title = wp_kses_post( apply_filters( 'sensei_single_title', get_the_title( get_post() ), get_post_type( get_the_ID() ) ) );
-		if ( $title ):
-		?>
-		 <header>
-
-			 <h1>
-
-				<?php
-				echo wp_kses_post( $title );
-				?>
-
-			 </h1>
-
-		 </header>
-
-		 <?php
+		if ( $title ) :
+			?>
+			<header>
+				<h1>
+					<?php
+					echo wp_kses_post( $title );
+					?>
+				</h1>
+			</header>
+			<?php
 		endif;
 	} //end the_title()
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1199,7 +1199,7 @@ class Sensei_Quiz {
 			</header>
 			<?php
 		endif;
-	} //end the_title()
+	}//end the_title()
 
 	/**
 	 * Output the sensei quiz status message.

--- a/templates/single-course/lessons.php
+++ b/templates/single-course/lessons.php
@@ -27,7 +27,7 @@ if ( have_posts() ) :
 	?>
 
 	<section class="course-lessons">
-	
+
 	<?php
 	// start course lessons loop
 	while ( have_posts() ) :

--- a/templates/single-course/lessons.php
+++ b/templates/single-course/lessons.php
@@ -7,97 +7,90 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.9.0
+ * @version     3.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-?>
 
-<section class="course-lessons">
+/**
+ * Actions just before the sensei single course lessons loop begins
+ *
+ * @hooked Sensei_Course::load_single_course_lessons_query
+ * @since 1.9.0
+ */
+do_action( 'sensei_single_course_lessons_before' );
 
-	<?php
-
-		/**
-		 * Actions just before the sensei single course lessons loop begins
-		 *
-		 * @hooked Sensei_Course::load_single_course_lessons_query
-		 * @since 1.9.0
-		 */
-		do_action( 'sensei_single_course_lessons_before' );
-
+// lessons loaded into loop in the sensei_single_course_lessons_before hook
+if ( have_posts() ) :
 	?>
 
+	<section class="course-lessons">
+	
 	<?php
+	// start course lessons loop
+	while ( have_posts() ) :
+		the_post();
+		?>
 
-	// lessons loaded into loop in the sensei_single_course_lessons_before hook
-	if ( have_posts() ) :
+		<article <?php post_class(); ?> >
 
-		// start course lessons loop
-		while ( have_posts() ) :
-			the_post();
+			<?php
+
+				/**
+				 * The hook is inside the course lesson on the single course. It fires
+				 * for each lesson. It is just before the lesson excerpt.
+				 *
+				 * @since 1.9.0
+				 *
+				 * @param $lessons_id
+				 *
+				 * @hooked Sensei_Lesson::the_lesson_meta -  5
+				 * @hooked Sensei_Lesson::the_lesson_thumbnail - 8
+				 */
+				do_action( 'sensei_single_course_inside_before_lesson', get_the_ID() );
+
 			?>
 
-			<article <?php post_class(); ?> >
+			<section class="entry">
 
 				<?php
-
-					/**
-					 * The hook is inside the course lesson on the single course. It fires
-					 * for each lesson. It is just before the lesson excerpt.
-					 *
-					 * @since 1.9.0
-					 *
-					 * @param $lessons_id
-					 *
-					 * @hooked Sensei_Lesson::the_lesson_meta -  5
-					 * @hooked Sensei_Lesson::the_lesson_thumbnail - 8
-					 */
-					do_action( 'sensei_single_course_inside_before_lesson', get_the_ID() );
-
+				/**
+				 * Display the lesson excerpt
+				 */
+				the_excerpt();
 				?>
 
-				<section class="entry">
+			</section>
 
-					<?php
-					/**
-					 * Display the lesson excerpt
-					 */
-					the_excerpt();
-					?>
+			<?php
 
-				</section>
+				/**
+				 * The hook is inside the course lesson on the single course. It is just before the lesson closing markup.
+				 * It fires for each lesson.
+				 *
+				 * @since 1.9.0
+				 */
+				do_action( 'sensei_single_course_inside_after_lesson', get_the_ID() );
 
-				<?php
+			?>
 
-					/**
-					 * The hook is inside the course lesson on the single course. It is just before the lesson closing markup.
-					 * It fires for each lesson.
-					 *
-					 * @since 1.9.0
-					 */
-					do_action( 'sensei_single_course_inside_after_lesson', get_the_ID() );
+		</article>
 
-				?>
+	<?php endwhile; // end course lessons loop ?>
 
-			</article>
+	</section>
 
-		<?php endwhile; // end course lessons loop ?>
+<?php endif;
 
-	<?php endif; ?>
+/**
+ * Actions just before the sensei single course lessons loop begins
+ *
+ * @hooked Sensei_Course::reset_single_course_query
+ *
+ * @since 1.9.0
+ */
+do_action( 'sensei_single_course_lessons_after' );
 
-	<?php
-
-		/**
-		 * Actions just before the sensei single course lessons loop begins
-		 *
-		 * @hooked Sensei_Course::reset_single_course_query
-		 *
-		 * @since 1.9.0
-		 */
-		do_action( 'sensei_single_course_lessons_after' );
-
-	?>
-
-</section>
+?>


### PR DESCRIPTION
Fixes #3307 

### Changes proposed in this Pull Request

* Remove empty lessons html from single course page
* In the process moves actions 'sensei_single_course_lessons_before' and 'sensei_single_course_lessons_after' outside of the course-lessons section, so the section can be dependent on post having been found.
* In Sensei LMS the above actions seem only to be used for for setting up and resetting the query and some globals, so moving them outside the section should be possible.

### Testing instructions

* Works on single course page ( /course/{course-slug}/ ) and a page using the [sensei_course_page] shortcode.