### PR TITLE
Add purchase flow for WooCommerce.com-hosted plugins

### DIFF
--- a/assets/setup-wizard/data/reducer.js
+++ b/assets/setup-wizard/data/reducer.js
@@ -8,7 +8,8 @@ import {
 	SET_STEP_DATA,
 } from './constants';
 
-import { INSTALLING_STATUS } from '../features/feature-status';
+import { EXTERNAL_STATUS, INSTALLING_STATUS } from '../features/feature-status';
+import { getWccomProductId } from '../helpers/woocommerce-com';
 
 const DEFAULT_STATE = {
 	isFetching: true,
@@ -51,7 +52,9 @@ const updatePreInstallation = ( selected, options ) =>
 		if ( selected.includes( feature.slug ) ) {
 			return {
 				...feature,
-				status: INSTALLING_STATUS,
+				status: getWccomProductId( feature )
+					? EXTERNAL_STATUS
+					: INSTALLING_STATUS,
 				error: null,
 			};
 		}

--- a/assets/setup-wizard/features/confirmation-modal.js
+++ b/assets/setup-wizard/features/confirmation-modal.js
@@ -1,7 +1,7 @@
 import { List } from '@woocommerce/components';
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { getWcProductId } from '../helpers/woocommerce-com';
+import { getWccomProductId } from '../helpers/woocommerce-com';
 
 import { getFeatureObservation } from './feature-description-utils';
 import FeatureDescription from './feature-description';
@@ -56,7 +56,7 @@ const ConfirmationModal = ( {
 				'sensei-lms'
 			) }
 		</p>
-		{ features.some( getWcProductId ) && (
+		{ features.some( getWccomProductId ) && (
 			<p>
 				<strong>
 					{ __(

--- a/assets/setup-wizard/features/confirmation-modal.js
+++ b/assets/setup-wizard/features/confirmation-modal.js
@@ -55,6 +55,16 @@ const ConfirmationModal = ( {
 				'sensei-lms'
 			) }
 		</p>
+		{ features.some( ( { slug } ) => 'woocommerce' === slug ) && (
+			<p>
+				<strong>
+					{ __(
+						'WooCommerce.com will open in a new tab so that you can complete the purchase process.',
+						'sensei-lms'
+					) }
+				</strong>
+			</p>
+		) }
 
 		{ errorNotice }
 

--- a/assets/setup-wizard/features/confirmation-modal.js
+++ b/assets/setup-wizard/features/confirmation-modal.js
@@ -1,6 +1,7 @@
 import { List } from '@woocommerce/components';
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { getWcProductId } from '../helpers/woocommerce-com';
 
 import { getFeatureObservation } from './feature-description-utils';
 import FeatureDescription from './feature-description';
@@ -55,7 +56,7 @@ const ConfirmationModal = ( {
 				'sensei-lms'
 			) }
 		</p>
-		{ features.some( ( { slug } ) => 'woocommerce' === slug ) && (
+		{ features.some( getWcProductId ) && (
 			<p>
 				<strong>
 					{ __(

--- a/assets/setup-wizard/features/feature-description-utils.js
+++ b/assets/setup-wizard/features/feature-description-utils.js
@@ -1,4 +1,5 @@
 import { sprintf, __ } from '@wordpress/i18n';
+import { getWcProductId } from '../helpers/woocommerce-com';
 
 /**
  * @typedef  {Object} Feature
@@ -18,7 +19,7 @@ export const getFeatureObservation = ( slug, selectedFeatures ) => {
 	}
 
 	const titles = selectedFeatures
-		.filter( ( feature ) => feature.wccom_product_id )
+		.filter( getWcProductId )
 		.map( ( feature ) => feature.rawTitle )
 		.join( __( ' and ', 'sensei-lms' ) );
 

--- a/assets/setup-wizard/features/feature-description-utils.js
+++ b/assets/setup-wizard/features/feature-description-utils.js
@@ -25,7 +25,7 @@ export const getFeatureObservation = ( slug, selectedFeatures ) => {
 	return sprintf(
 		// translators: Placeholder is the plugin titles.
 		__(
-			'* WooCommerce is required to receive updates for %1$s. Once WooCommerce is installed, you will be taken to WooCommerce.com to complete the purchase process.',
+			'* WooCommerce is required to receive updates for %1$s.',
 			'sensei-lms'
 		),
 		titles

--- a/assets/setup-wizard/features/feature-description-utils.js
+++ b/assets/setup-wizard/features/feature-description-utils.js
@@ -1,5 +1,5 @@
 import { sprintf, __ } from '@wordpress/i18n';
-import { getWcProductId } from '../helpers/woocommerce-com';
+import { getWccomProductId } from '../helpers/woocommerce-com';
 
 /**
  * @typedef  {Object} Feature
@@ -19,7 +19,7 @@ export const getFeatureObservation = ( slug, selectedFeatures ) => {
 	}
 
 	const titles = selectedFeatures
-		.filter( getWcProductId )
+		.filter( getWccomProductId )
 		.map( ( feature ) => feature.rawTitle )
 		.join( __( ' and ', 'sensei-lms' ) );
 

--- a/assets/setup-wizard/features/feature-status.js
+++ b/assets/setup-wizard/features/feature-status.js
@@ -1,4 +1,4 @@
-import { Dashicon, Spinner } from '@wordpress/components';
+import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 import CheckIcon from './check-icon';
@@ -9,7 +9,6 @@ import CheckIcon from './check-icon';
 export const INSTALLING_STATUS = 'installing';
 export const ERROR_STATUS = 'error';
 export const INSTALLED_STATUS = 'installed';
-export const EXTERNAL_STATUS = 'external';
 
 const statusComponents = {
 	[ INSTALLING_STATUS ]: (
@@ -34,13 +33,6 @@ const statusComponents = {
 				{ __( 'Plugin installed', 'sensei-lms' ) }
 			</span>
 		</i>
-	),
-	[ EXTERNAL_STATUS ]: (
-		<Dashicon icon="external">
-			<span className="screen-reader-text">
-				{ __( 'Purchasing plugin', 'sensei-lms' ) }
-			</span>
-		</Dashicon>
 	),
 };
 

--- a/assets/setup-wizard/features/feature-status.js
+++ b/assets/setup-wizard/features/feature-status.js
@@ -1,4 +1,4 @@
-import { Spinner } from '@wordpress/components';
+import { Dashicon, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 import CheckIcon from './check-icon';
@@ -9,6 +9,7 @@ import CheckIcon from './check-icon';
 export const INSTALLING_STATUS = 'installing';
 export const ERROR_STATUS = 'error';
 export const INSTALLED_STATUS = 'installed';
+export const EXTERNAL_STATUS = 'external';
 
 const statusComponents = {
 	[ INSTALLING_STATUS ]: (
@@ -33,6 +34,13 @@ const statusComponents = {
 				{ __( 'Plugin installed', 'sensei-lms' ) }
 			</span>
 		</i>
+	),
+	[ EXTERNAL_STATUS ]: (
+		<Dashicon icon="external">
+			<span className="screen-reader-text">
+				{ __( 'Purchasing plugin', 'sensei-lms' ) }
+			</span>
+		</Dashicon>
 	),
 };
 

--- a/assets/setup-wizard/features/features-selection.js
+++ b/assets/setup-wizard/features/features-selection.js
@@ -63,7 +63,7 @@ const FeaturesSelection = ( {
 							}
 							onChange={ toggleItem( slug ) }
 							checked={ selectedSlugs.includes( slug ) }
-							disabled={ 'installed' === status }
+							disabled={ !! status }
 							className={ classnames(
 								'sensei-setup-wizard__checkbox',
 								{

--- a/assets/setup-wizard/features/features-selection.js
+++ b/assets/setup-wizard/features/features-selection.js
@@ -63,7 +63,7 @@ const FeaturesSelection = ( {
 							}
 							onChange={ toggleItem( slug ) }
 							checked={ selectedSlugs.includes( slug ) }
-							disabled={ !! status }
+							disabled={ 'installed' === status }
 							className={ classnames(
 								'sensei-setup-wizard__checkbox',
 								{

--- a/assets/setup-wizard/features/features-selection.js
+++ b/assets/setup-wizard/features/features-selection.js
@@ -63,7 +63,11 @@ const FeaturesSelection = ( {
 							}
 							onChange={ toggleItem( slug ) }
 							checked={ selectedSlugs.includes( slug ) }
-							disabled={ !! status }
+							disabled={ [
+								'installed',
+								'installing',
+								'error',
+							].includes( status ) }
 							className={ classnames(
 								'sensei-setup-wizard__checkbox',
 								{

--- a/assets/setup-wizard/features/features-selection.test.js
+++ b/assets/setup-wizard/features/features-selection.test.js
@@ -138,7 +138,7 @@ describe( '<FeaturesSelection />', () => {
 		expect( onContinueMock ).toBeCalled();
 	} );
 
-	it( 'Should render the features with installation status as disabled and the installed with specific class', () => {
+	it( 'Should render the features with installed status as disabled and the installed with specific class', () => {
 		const selectedSlugs = [ 'empty-status', 'installing', 'installed' ];
 		const { container } = render(
 			<FeaturesSelection
@@ -150,7 +150,7 @@ describe( '<FeaturesSelection />', () => {
 		);
 		expect(
 			container.querySelectorAll( 'input:checked:disabled' ).length
-		).toEqual( 2 );
+		).toEqual( 1 );
 		expect(
 			container.querySelectorAll( '.status-installed' ).length
 		).toEqual( 1 );

--- a/assets/setup-wizard/features/features-selection.test.js
+++ b/assets/setup-wizard/features/features-selection.test.js
@@ -150,7 +150,7 @@ describe( '<FeaturesSelection />', () => {
 		);
 		expect(
 			container.querySelectorAll( 'input:checked:disabled' ).length
-		).toEqual( 1 );
+		).toEqual( 2 );
 		expect(
 			container.querySelectorAll( '.status-installed' ).length
 		).toEqual( 1 );

--- a/assets/setup-wizard/features/index.js
+++ b/assets/setup-wizard/features/index.js
@@ -123,7 +123,7 @@ const Features = () => {
 		) {
 			setSelectedSlugs( ( prev ) => [ ...prev, wcSlug ] );
 		}
-	}, [ getSelectedFeatures, features, isWooCommerceInstalled ] );
+	}, [ getSelectedFeatures, isWooCommerceInstalled ] );
 
 	// Finish and submit features selection.
 	const finishSelection = () => {

--- a/assets/setup-wizard/features/index.js
+++ b/assets/setup-wizard/features/index.js
@@ -12,7 +12,7 @@ import {
 } from '../query-string-router/url-functions';
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 import {
-	getWcProductId,
+	getWccomProductId,
 	getWoocommerceComPurchaseUrl,
 } from '../helpers/woocommerce-com';
 import ConfirmationModal from './confirmation-modal';
@@ -107,7 +107,7 @@ const Features = () => {
 		const isWooCommerceSelected = selectedFeatures.some(
 			( feature ) => feature.slug === wcSlug
 		);
-		const needWooCommerce = selectedFeatures.some( getWcProductId );
+		const needWooCommerce = selectedFeatures.some( getWccomProductId );
 
 		if ( ! needWooCommerce && isWooCommerceSelected ) {
 			setSelectedSlugs( ( prev ) =>
@@ -163,7 +163,8 @@ const Features = () => {
 	const installFromWooCommerce = () => {
 		const pendingWcFeatures = getSelectedFeatures().filter(
 			( feature ) =>
-				getWcProductId( feature ) && INSTALLED_STATUS !== feature.status
+				getWccomProductId( feature ) &&
+				INSTALLED_STATUS !== feature.status
 		);
 		if ( ! pendingWcFeatures.length ) return;
 		const wcPurchaseUrl = getWoocommerceComPurchaseUrl(

--- a/assets/setup-wizard/features/index.js
+++ b/assets/setup-wizard/features/index.js
@@ -11,7 +11,10 @@ import {
 	updateQueryString,
 } from '../query-string-router/url-functions';
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
-import { getWoocommerceComPurchaseUrl } from '../helpers/woocommerce-com';
+import {
+	getWcProductId,
+	getWoocommerceComPurchaseUrl,
+} from '../helpers/woocommerce-com';
 import ConfirmationModal from './confirmation-modal';
 import InstallationFeedback from './installation-feedback';
 import FeaturesSelection from './features-selection';
@@ -38,7 +41,7 @@ const filterInstalledFeatures = ( submittedSlugs, features ) =>
 	} );
 
 const wcSlug = 'woocommerce';
-const getWcProductId = ( feature ) => feature.wccom_product_id;
+
 /**
  * Features step for setup wizard.
  */
@@ -164,7 +167,7 @@ const Features = () => {
 		);
 		if ( ! pendingWcFeatures.length ) return;
 		const wcPurchaseUrl = getWoocommerceComPurchaseUrl(
-			pendingWcFeatures.map( getWcProductId ),
+			pendingWcFeatures,
 			stepData.wccom
 		);
 		window.open( wcPurchaseUrl );

--- a/assets/setup-wizard/features/index.js
+++ b/assets/setup-wizard/features/index.js
@@ -142,6 +142,7 @@ const Features = () => {
 		} );
 
 		installFromWpOrg();
+		installFromWooCommerce();
 	};
 
 	const installFromWpOrg = () => {
@@ -156,22 +157,18 @@ const Features = () => {
 		);
 	};
 
-	const installFromWooCommerce = useCallback( () => {
+	const installFromWooCommerce = () => {
 		const pendingWcFeatures = getSelectedFeatures().filter(
 			( feature ) =>
 				getWcProductId( feature ) && INSTALLED_STATUS !== feature.status
 		);
+		if ( ! pendingWcFeatures.length ) return;
 		const wcPurchaseUrl = getWoocommerceComPurchaseUrl(
 			pendingWcFeatures.map( getWcProductId ),
 			stepData.wccom
 		);
-		window.location.href = wcPurchaseUrl;
-	}, [ getSelectedFeatures, stepData.wccom ] );
-
-	useEffect( () => {
-		if ( feedbackActive && isWooCommerceInstalled() )
-			installFromWooCommerce();
-	}, [ feedbackActive, isWooCommerceInstalled, installFromWooCommerce ] );
+		window.open( wcPurchaseUrl );
+	};
 
 	// Retry features installation.
 	const retryInstallation = ( selected ) => {

--- a/assets/setup-wizard/features/index.test.js
+++ b/assets/setup-wizard/features/index.test.js
@@ -322,4 +322,50 @@ describe( '<Features />', () => {
 		fireEvent.click( getByLabelText( /Need/ ) );
 		expect( getByLabelText( /WooCommerce/ ).checked ).toBeFalsy();
 	} );
+
+	it( 'Should open WooCommerce.com cart when selecting paid features', () => {
+		window.open = jest.fn();
+
+		mockStepData( {
+			selected: [],
+			options: [
+				{
+					slug: 'woocommerce',
+					title: 'WooCommerce',
+					status: 'installed',
+				},
+				{ slug: 'wc-1', title: 'WC1', wccom_product_id: '123' },
+				{ slug: 'wc-2', title: 'WC2', wccom_product_id: '456' },
+			],
+			wccom: {
+				'wccom-site': 'http://localhost',
+				'wccom-woo-version': '4.0.0',
+				'wccom-connect-nonce': '0000',
+			},
+		} );
+
+		useFeaturesPolling.mockReturnValue( {
+			selected: [ 'wc-1', 'wc-2' ],
+			options: [
+				{ slug: 'wc-1', title: 'WC1', status: 'external' },
+				{ slug: 'wc-2', title: 'WC2', status: 'external' },
+			],
+		} );
+
+		const { queryByText, getByLabelText } = render(
+			<QueryStringRouter paramName="step">
+				<Features />
+			</QueryStringRouter>
+		);
+
+		fireEvent.click( getByLabelText( 'WC1' ) );
+		fireEvent.click( getByLabelText( 'WC2' ) );
+
+		fireEvent.click( queryByText( 'Continue' ) );
+		fireEvent.click( queryByText( 'Install now' ) );
+
+		expect( window.open ).toHaveBeenCalledWith(
+			'https://woocommerce.com/cart?wccom-replace-with=123%2C456&wccom-site=http%3A%2F%2Flocalhost&wccom-woo-version=4.0.0&wccom-connect-nonce=0000'
+		);
+	} );
 } );

--- a/assets/setup-wizard/helpers/woocommerce-com.js
+++ b/assets/setup-wizard/helpers/woocommerce-com.js
@@ -13,7 +13,7 @@ import { addQueryArgs } from '@wordpress/url';
  */
 export const getWoocommerceComPurchaseUrl = ( features, wccomData ) => {
 	return addQueryArgs( 'https://woocommerce.com/cart', {
-		'wccom-replace-with': features.map( getWcProductId ).join( ',' ),
+		'wccom-replace-with': features.map( getWccomProductId ).join( ',' ),
 		...( wccomData || {} ),
 	} );
 };
@@ -25,4 +25,4 @@ export const getWoocommerceComPurchaseUrl = ( features, wccomData ) => {
  *
  * @return {string} The product ID.
  */
-export const getWcProductId = ( feature ) => feature.wccom_product_id;
+export const getWccomProductId = ( feature ) => feature.wccom_product_id;

--- a/assets/setup-wizard/helpers/woocommerce-com.js
+++ b/assets/setup-wizard/helpers/woocommerce-com.js
@@ -1,0 +1,11 @@
+/**
+ * External dependencies
+ */
+import { addQueryArgs } from '@wordpress/url';
+
+export const getWoocommerceComPurchaseUrl = ( productIds, wccomData ) => {
+	return addQueryArgs( 'https://woocommerce.com/cart', {
+		'wccom-replace-with': productIds.join( ',' ),
+		...wccomData,
+	} );
+};

--- a/assets/setup-wizard/helpers/woocommerce-com.js
+++ b/assets/setup-wizard/helpers/woocommerce-com.js
@@ -3,9 +3,26 @@
  */
 import { addQueryArgs } from '@wordpress/url';
 
-export const getWoocommerceComPurchaseUrl = ( productIds, wccomData ) => {
+/**
+ * Get WooCommerce.com checkout URL for the given plugins
+ *
+ * @param {Array}  features  List of features to be installed.
+ * @param {Object} wccomData Woocommerce.com connect parameters
+ *
+ * @return {string} The checkout URL
+ */
+export const getWoocommerceComPurchaseUrl = ( features, wccomData ) => {
 	return addQueryArgs( 'https://woocommerce.com/cart', {
-		'wccom-replace-with': productIds.join( ',' ),
+		'wccom-replace-with': features.map( getWcProductId ).join( ',' ),
 		...( wccomData || {} ),
 	} );
 };
+
+/**
+ * Get the WooCommerce.com product ID for the feature.
+ *
+ * @param {Object} feature The feature.
+ *
+ * @return {string} The product ID.
+ */
+export const getWcProductId = ( feature ) => feature.wccom_product_id;

--- a/assets/setup-wizard/helpers/woocommerce-com.js
+++ b/assets/setup-wizard/helpers/woocommerce-com.js
@@ -6,6 +6,6 @@ import { addQueryArgs } from '@wordpress/url';
 export const getWoocommerceComPurchaseUrl = ( productIds, wccomData ) => {
 	return addQueryArgs( 'https://woocommerce.com/cart', {
 		'wccom-replace-with': productIds.join( ',' ),
-		...wccomData,
+		...( wccomData || {} ),
 	} );
 };

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -466,8 +466,8 @@ class Sensei_Setup_Wizard {
 	private function get_feature_with_status( $extension, $installing_plugins, $selected_plugins ) {
 		$installing_key = array_search( $extension->product_slug, wp_list_pluck( $installing_plugins, 'product_slug' ), true );
 
-		if ( in_array( $extension->product_slug, $selected_plugins, true ) ) {
-			$extension->status = isset( $extension->wccom_product_id ) ? 'external' : 'selected';
+		if ( in_array( $extension->product_slug, $selected_plugins, true ) && isset( $extension->wccom_product_id ) ) {
+			$extension->status = 'installing';
 		}
 		if ( false !== $installing_key ) {
 			if ( isset( $installing_plugins[ $installing_key ]->error ) ) {

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -459,7 +459,7 @@ class Sensei_Setup_Wizard {
 		$installing_key = array_search( $extension->product_slug, wp_list_pluck( $installing_plugins, 'product_slug' ), true );
 
 		if ( in_array( $extension->product_slug, $selected_plugins, true ) && isset( $extension->wccom_product_id ) ) {
-			$extension->status = 'installing';
+			$extension->status = 'external';
 		}
 		if ( false !== $installing_key ) {
 			if ( isset( $installing_plugins[ $installing_key ]->error ) ) {

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -424,14 +424,6 @@ class Sensei_Setup_Wizard {
 	 */
 	public function get_woocommerce_connect_data() {
 
-		$back_admin_path          = add_query_arg(
-			[
-				'page'     => $this->page_slug,
-				'step'     => 'features',
-				'feedback' => 1,
-			],
-			'admin.php'
-		);
 		$wc_params                = [];
 		$is_woocommerce_installed = Sensei_Utils::is_woocommerce_active( '3.7.0' ) && class_exists( 'WC_Admin_Addons' );
 
@@ -448,7 +440,7 @@ class Sensei_Setup_Wizard {
 			];
 		}
 
-		$wc_params['wccom-back'] = rawurlencode( $back_admin_path );
+		$wc_params['wccom-back'] = rawurlencode( 'admin.php' );
 
 		return $wc_params;
 

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -452,12 +452,16 @@ class Sensei_Setup_Wizard {
 	 *
 	 * @param stdClass   $extension          Extension object.
 	 * @param stdClass[] $installing_plugins Plugins which are installing.
+	 * @param stdClass[] $selected_plugins   Plugins selected for installation.
 	 *
 	 * @return stdClass Extension with status.
 	 */
-	private function get_feature_with_status( $extension, $installing_plugins ) {
+	private function get_feature_with_status( $extension, $installing_plugins, $selected_plugins ) {
 		$installing_key = array_search( $extension->product_slug, wp_list_pluck( $installing_plugins, 'product_slug' ), true );
 
+		if ( in_array( $extension->product_slug, $selected_plugins, true ) ) {
+			$extension->status = 'selected';
+		}
 		if ( false !== $installing_key ) {
 			if ( isset( $installing_plugins[ $installing_key ]->error ) ) {
 				$extension->error  = $installing_plugins[ $installing_key ]->error;
@@ -561,19 +565,20 @@ class Sensei_Setup_Wizard {
 		array_push( $extensions, $this->get_woocommerce_information() );
 
 		$installing_plugins = Sensei_Plugins_Installation::instance()->get_installing_plugins();
+		$selected_plugins   = $this->get_wizard_user_data( 'features' )['selected'];
 
 		if ( ! $extensions ) {
 			$extensions = [];
 		}
 
 		$extensions = array_map(
-			function( $extension ) use ( $installing_plugins ) {
+			function( $extension ) use ( $installing_plugins, $selected_plugins ) {
 				// Decode price.
 				if ( isset( $extension->price ) && 0 !== $extension->price ) {
 					$extension->price = html_entity_decode( $extension->price );
 				}
 
-				return $this->get_feature_with_status( $extension, $installing_plugins );
+				return $this->get_feature_with_status( $extension, $installing_plugins, $selected_plugins );
 			},
 			$extensions
 		);

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -418,6 +418,36 @@ class Sensei_Setup_Wizard {
 	}
 
 	/**
+	 * Get data used for WooCommerce.com purchase redirect for feature installation.
+	 *
+	 * @return array The data.
+	 */
+	public function get_woocommerce_connect_data() {
+
+		$is_woocommerce_installed = Sensei_Utils::is_plugin_present_and_activated( 'Woocommerce', 'woocommerce/woocommerce.php' );
+
+		if ( ! $is_woocommerce_installed ) {
+			return [];
+		}
+
+		$back_admin_path = add_query_arg(
+			[
+				'page'     => $this->page_slug,
+				'step'     => 'features',
+				'feedback' => 1,
+			],
+			'admin.php'
+		);
+
+		return [
+			'wccom-site'          => site_url(),
+			'wccom-back'          => $back_admin_path,
+			'wccom-woo-version'   => WC()->version,
+			'wccom-connect-nonce' => wp_create_nonce( 'connect' ),
+		];
+	}
+
+	/**
 	 * Get feature with status.
 	 *
 	 * @param stdClass   $extension          Extension object.

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -590,9 +590,10 @@ class Sensei_Setup_Wizard {
 		$extensions_to_install = array_filter(
 			array_map(
 				function( $extension ) use ( $extension_slugs ) {
-					$key = array_search( $extension->product_slug, $extension_slugs, true );
+					$key       = array_search( $extension->product_slug, $extension_slugs, true );
+					$is_wc_com = isset( $extension->wccom_product_id );
 
-					return false !== $key ? $extension : false;
+					return ( false !== $key && ! $is_wc_com ) ? $extension : false;
 				},
 				$this->get_sensei_extensions()
 			)

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -460,7 +460,7 @@ class Sensei_Setup_Wizard {
 		$installing_key = array_search( $extension->product_slug, wp_list_pluck( $installing_plugins, 'product_slug' ), true );
 
 		if ( in_array( $extension->product_slug, $selected_plugins, true ) ) {
-			$extension->status = 'selected';
+			$extension->status = isset( $extension->wccom_product_id ) ? 'external' : 'selected';
 		}
 		if ( false !== $installing_key ) {
 			if ( isset( $installing_plugins[ $installing_key ]->error ) ) {

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -561,13 +561,7 @@ class Sensei_Setup_Wizard {
 			wp_cache_delete( 'alloptions', 'options' );
 		}
 
-		$extensions_filter = [ 'hosted-location' => 'dotorg' ];
-
-		if ( Sensei()->feature_flags->is_enabled( 'setup_wizard_all_extensions' ) ) {
-			unset( $extensions_filter['hosted-location'] );
-		}
-
-		$extensions = Sensei_Extensions::instance()->get_extensions( 'plugin', 'setup-wizard-extensions', $extensions_filter );
+		$extensions = Sensei_Extensions::instance()->get_extensions( 'plugin', 'setup-wizard-extensions' );
 
 		// Add WooCommerce.
 		array_push( $extensions, $this->get_woocommerce_information() );

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -22,7 +22,6 @@ class Sensei_Feature_Flags {
 				'rest_api_v1_skip_permissions' => false,
 				'enrolment_provider_tooltip'   => false,
 				'importer'                     => false,
-				'setup_wizard_all_extensions'  => false,
 			)
 		);
 	}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2463,6 +2463,29 @@ class Sensei_Utils {
 	}
 
 	/**
+	 * Checks if the given version pf WooCommerce plugin is installed and activated.
+	 *
+	 * @param string $minimum_version
+	 *
+	 * @return bool
+	 * @since Sensei 3.2.0
+	 */
+	public static function is_woocommerce_active( $minimum_version = null ) {
+		$is_active = self::is_plugin_present_and_activated( 'Woocommerce', 'woocommerce/woocommerce.php' );
+
+		if ( ! $is_active ) {
+			return false;
+		}
+
+		if ( null !== $minimum_version ) {
+			return version_compare( WC()->version, $minimum_version, '>=' );
+		}
+
+		return true;
+	}
+
+
+	/**
 	 * Hard - Resets a Learner's Course Progress
 	 *
 	 * @param $course_id int

--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -293,6 +293,7 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 		return [
 			'selected' => $user_data['features']['selected'],
 			'options'  => $this->setup_wizard->get_sensei_extensions( $clear_active_plugins_cache ),
+			'wccom'    => $this->setup_wizard->get_woocommerce_connect_data(),
 		];
 	}
 

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
@@ -32,6 +32,7 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 				'plugin_file'  => 'woocommerce/woocommerce.php',
 				'link'         => 'https://wordpress.org/plugins/woocommerce',
 				'unselectable' => true,
+				'version'      => '4.0.0',
 			],
 			DAY_IN_SECONDS
 		);

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -378,38 +378,11 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 
 	/**
 	 * Tests that get sensei extensions fetch from the correct URL
-	 * filtering by the dotorg only as default.
-	 *
-	 * @covers Sensei_Setup_Wizard::get_sensei_extensions
-	 */
-	public function testGetSenseiExtensionsDotOrgExtensions() {
-		// Mock fetch from senseilms.com.
-		$request_url = null;
-		add_filter(
-			'pre_http_request',
-			function( $preempt, $parsed_args, $url ) use ( &$request_url ) {
-				$request_url = $url;
-				return [ 'body' => '{}' ];
-			},
-			10,
-			3
-		);
-
-		$extensions = Sensei()->setup_wizard->get_sensei_extensions();
-
-		$this->assertEquals( 'https://senseilms.com/wp-json/senseilms-products/1.0/search?category=setup-wizard-extensions&type=plugin&hosted-location=dotorg', $request_url );
-	}
-
-	/**
-	 * Tests that get sensei extensions fetch from the correct URL
 	 * with all extensions type.
 	 *
 	 * @covers Sensei_Setup_Wizard::get_sensei_extensions
 	 */
 	public function testGetSenseiExtensionsAllExtensions() {
-		// Activate feature.
-		// It is usually activated by defining a const.
-		add_filter( 'sensei_feature_flag_setup_wizard_all_extensions', '__return_true' );
 
 		// Mock fetch from senseilms.com.
 		$request_url = null;


### PR DESCRIPTION
Part of #3139

### Changes proposed in this Pull Request

* When selecting any paid extension, open a new tab for WooCommerce.com checkout with the cart with the paid extensions added
* Meanwhile continue installing the rest of the extensions from Wordpress.org
* Remove the feature flag `setup_wizard_all_extensions` that hides these extensions by default.

### Testing instructions

* An internet-accessible test site is required
* Install Sensei and access the Setup Wizard features step `/wp-admin/admin.php?page=sensei_setup_wizard&step=features`
* Select a paid plugin, click `Continue` and `Install now`
* A new tab should open with a WooCommerce.com checkout screen for the selected plugin.
* Complete the purchase.
* Click `Add to Site` button on the order summary screen.
* Select the site to install the plugin to, or add a new site and go trough the process, connecting and authorizing the site to WooCommerce.com
* The plugin should be installed and activated on the site.
* Back on the the setup wizard tab, it should show the plugin as installed. 
--
* For easier testing of checkout, add this to `includes/admin/class-sensei-setup-wizard.php#L582` to make `Sensei LMS Certificates` purchased and installed via the WC.com flow without any need for payment shenanigans.
  ```
	if ( 'sensei-certificates' === $extension->product_slug ) {
					$extension->price = '$0.00';
					$extension->wccom_product_id = 247548;
				}
  ```

