### PR TITLE
Add "Educate students" option to Purpose step of setup wizard

### DIFF
--- a/assets/setup-wizard/purpose/index.js
+++ b/assets/setup-wizard/purpose/index.js
@@ -36,9 +36,11 @@ const purposes = [
 	},
 	{
 		id: 'educate_students',
-		title: 'Educate students',
-		description:
+		title: __( 'Educate students', 'sensei-lms' ),
+		description: __(
 			'You are an educator who would like to create an online classroom.',
+			'sensei-lms'
+		),
 	},
 	{
 		id: 'other',

--- a/assets/setup-wizard/purpose/index.js
+++ b/assets/setup-wizard/purpose/index.js
@@ -35,6 +35,12 @@ const purposes = [
 			'You work at a company that regularly trains new or existing employees.',
 	},
 	{
+		id: 'educate_students',
+		title: 'Educate students',
+		description:
+			'You are an educator who would like to create an online classroom.',
+	},
+	{
 		id: 'other',
 		title: 'Other',
 	},

--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -44,7 +44,7 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 	/**
 	 * Available 'purpose' options.
 	 */
-	const PURPOSES = [ 'share_knowledge', 'generate_income', 'promote_business', 'provide_certification', 'train_employees', 'other' ];
+	const PURPOSES = [ 'share_knowledge', 'generate_income', 'promote_business', 'provide_certification', 'train_employees', 'educate_students', 'other' ];
 
 	/**
 	 * Sensei_REST_API_Setup_Wizard_Controller constructor.


### PR DESCRIPTION
Fixes #3310.

### Changes proposed in this Pull Request

* Adds a new "Educate students" option to the Purpose step of the setup wizard.

### Testing instructions

* Proceed to the _Purpose_ step of the setup wizard.
* Select _Educate students_ and click _Continue_.
* Complete the wizard, exit to courses and then re-open the wizard.
* Proceed to the _Purpose_ step of the setup wizard.
* Ensure _Educate students_ is selected.