### PR TITLE
Add importer progress step

### DIFF
--- a/assets/data-port/import/data/actions.js
+++ b/assets/data-port/import/data/actions.js
@@ -7,6 +7,7 @@ import {
 	START_IMPORT,
 	SUCCESS_START_IMPORT,
 	ERROR_START_IMPORT,
+	SET_STEP_DATA,
 	START_UPLOAD_IMPORT_DATA_FILE,
 	SUCCESS_UPLOAD_IMPORT_DATA_FILE,
 	ERROR_UPLOAD_IMPORT_DATA_FILE,
@@ -277,4 +278,24 @@ export const errorFileUpload = ( level, error ) => ( {
 	type: ERROR_UPLOAD_IMPORT_DATA_FILE,
 	level,
 	error,
+} );
+
+/**
+ * @typedef  {Object} SetStepDataAction
+ * @property {string} type Action type.
+ * @property {string} step Step name.
+ * @property {Object} data Step data.
+ */
+/**
+ * Set welcome step data action creator.
+ *
+ * @param {string} step Step name.
+ * @param {Object} data Step data object.
+ *
+ * @return {SetStepDataAction} Set welcome step data action.
+ */
+export const setStepData = ( step, data ) => ( {
+	type: SET_STEP_DATA,
+	step,
+	data,
 } );

--- a/assets/data-port/import/data/actions.test.js
+++ b/assets/data-port/import/data/actions.test.js
@@ -84,7 +84,7 @@ describe( 'Importer actions', () => {
 		const expectedSetDataAction = {
 			data: {
 				completedSteps: [],
-				id: 'test',
+				jobId: 'test',
 				progress: {
 					percentage: 0,
 					status: 'setup',
@@ -182,7 +182,7 @@ describe( 'Importer actions', () => {
 
 		const expectedSetDataAction = {
 			data: {
-				id: 'test',
+				jobId: 'test',
 				upload: {},
 				progress: {
 					status: 'pending',
@@ -281,7 +281,7 @@ describe( 'Importer actions', () => {
 
 		const expectedSetDataAction = {
 			data: {
-				id: 'test',
+				jobId: 'test',
 				upload: {},
 				progress: {
 					status: 'setup',
@@ -372,7 +372,7 @@ describe( 'Importer actions', () => {
 	it( 'Should return the set step data action', () => {
 		// Set data action.
 		const dataObject = {
-			id: 'test',
+			jobId: 'test',
 			progress: {
 				status: 'pending',
 				percentage: 0,
@@ -383,7 +383,7 @@ describe( 'Importer actions', () => {
 
 		const expectedSetStepDataAction = {
 			data: {
-				id: 'test',
+				jobId: 'test',
 				progress: {
 					status: 'pending',
 					percentage: 0,

--- a/assets/data-port/import/data/actions.test.js
+++ b/assets/data-port/import/data/actions.test.js
@@ -24,6 +24,7 @@ import {
 	errorStartImport,
 	uploadFileForLevel,
 	errorFileUpload,
+	setStepData,
 	startFileUploadAction,
 	successFileUpload,
 	throwEarlyUploadError,
@@ -84,7 +85,7 @@ describe( 'Importer actions', () => {
 			data: {
 				completedSteps: [],
 				id: 'test',
-				import: {
+				progress: {
 					percentage: 0,
 					status: 'setup',
 				},
@@ -183,7 +184,7 @@ describe( 'Importer actions', () => {
 			data: {
 				id: 'test',
 				upload: {},
-				import: {
+				progress: {
 					status: 'pending',
 					percentage: 0,
 				},
@@ -282,7 +283,7 @@ describe( 'Importer actions', () => {
 			data: {
 				id: 'test',
 				upload: {},
-				import: {
+				progress: {
 					status: 'setup',
 					percentage: 0,
 				},
@@ -365,6 +366,37 @@ describe( 'Importer actions', () => {
 
 		expect( throwEarlyUploadError( level, 'Test' ) ).toEqual(
 			expectedAction
+		);
+	} );
+
+	it( 'Should return the set step data action', () => {
+		// Set data action.
+		const dataObject = {
+			id: 'test',
+			progress: {
+				status: 'pending',
+				percentage: 0,
+			},
+			upload: {},
+			completedSteps: [ 'upload' ],
+		};
+
+		const expectedSetStepDataAction = {
+			data: {
+				id: 'test',
+				progress: {
+					status: 'pending',
+					percentage: 0,
+				},
+				completedSteps: [ 'upload' ],
+				upload: {},
+			},
+			step: 'progress',
+			type: 'SET_STEP_DATA',
+		};
+
+		expect( setStepData( 'progress', dataObject ) ).toEqual(
+			expectedSetStepDataAction
 		);
 	} );
 } );

--- a/assets/data-port/import/data/constants.js
+++ b/assets/data-port/import/data/constants.js
@@ -16,6 +16,11 @@ export const SUCCESS_FETCH_IMPORT_DATA = 'SUCCESS_FETCH_IMPORT_DATA';
 export const ERROR_FETCH_IMPORT_DATA = 'ERROR_FETCH_IMPORT_DATA';
 
 /**
+ * Import step action type constants.
+ */
+export const SET_STEP_DATA = 'SET_STEP_DATA';
+
+/**
  * Start import job action type constants.
  */
 export const START_IMPORT = 'START_IMPORT';

--- a/assets/data-port/import/data/index.js
+++ b/assets/data-port/import/data/index.js
@@ -4,6 +4,7 @@ import reducer from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';
 import controls from './controls';
+import * as resolvers from './resolvers';
 
 const registerImportStore = () => {
 	registerStore( 'sensei/import', {
@@ -11,6 +12,7 @@ const registerImportStore = () => {
 		actions,
 		selectors,
 		controls,
+		resolvers,
 	} );
 };
 

--- a/assets/data-port/import/data/normalizer.js
+++ b/assets/data-port/import/data/normalizer.js
@@ -31,7 +31,7 @@ export const parseCompletedSteps = ( data ) => {
 	if ( data.status === 'pending' ) {
 		return [ 'upload' ];
 	}
-	if ( data.status === 'complete' ) {
+	if ( data.status === 'completed' ) {
 		return [ 'upload', 'progress' ];
 	}
 
@@ -47,7 +47,7 @@ export const parseCompletedSteps = ( data ) => {
  */
 export const normalizeImportData = ( { files, status, ...data } ) => ( {
 	...data,
-	import: status,
+	progress: status,
 	upload: normalizeUploadsState( files ),
 	completedSteps: parseCompletedSteps( status ),
 } );

--- a/assets/data-port/import/data/normalizer.js
+++ b/assets/data-port/import/data/normalizer.js
@@ -45,8 +45,9 @@ export const parseCompletedSteps = ( data ) => {
  *
  * @return {Object} Normalized importer data.
  */
-export const normalizeImportData = ( { files, status, ...data } ) => ( {
+export const normalizeImportData = ( { id, files, status, ...data } ) => ( {
 	...data,
+	jobId: id,
 	progress: status,
 	upload: normalizeUploadsState( files ),
 	completedSteps: parseCompletedSteps( status ),

--- a/assets/data-port/import/data/normalizer.test.js
+++ b/assets/data-port/import/data/normalizer.test.js
@@ -2,7 +2,7 @@ import { normalizeImportData } from './normalizer';
 
 describe( 'Importer data normalizer', () => {
 	const expectedStateData = {
-		id: 'test',
+		jobId: 'test',
 		upload: {
 			questions: {
 				filename: 'questions.csv',

--- a/assets/data-port/import/data/normalizer.test.js
+++ b/assets/data-port/import/data/normalizer.test.js
@@ -17,7 +17,7 @@ describe( 'Importer data normalizer', () => {
 				isUploaded: true,
 			},
 		},
-		import: {
+		progress: {
 			status: 'pending',
 			percentage: 0,
 		},

--- a/assets/data-port/import/data/reducer.js
+++ b/assets/data-port/import/data/reducer.js
@@ -2,6 +2,7 @@ import {
 	START_FETCH_IMPORT_DATA,
 	SUCCESS_FETCH_IMPORT_DATA,
 	ERROR_FETCH_IMPORT_DATA,
+	SET_STEP_DATA,
 	START_IMPORT,
 	SUCCESS_START_IMPORT,
 	ERROR_START_IMPORT,
@@ -156,6 +157,16 @@ export default ( state = DEFAULT_STATE, action ) => {
 				errorMsg: action.error.message,
 				filename: null,
 			} );
+
+		case SET_STEP_DATA:
+			return {
+				...state,
+				completedSteps: action.data.completedSteps,
+				[ action.step ]: {
+					...state[ action.step ],
+					...action.data[ action.step ],
+				},
+			};
 
 		default:
 			return state;

--- a/assets/data-port/import/data/reducer.js
+++ b/assets/data-port/import/data/reducer.js
@@ -142,12 +142,19 @@ export default ( state = DEFAULT_STATE, action ) => {
 			} );
 
 		case SUCCESS_UPLOAD_IMPORT_DATA_FILE:
-			return updateLevelState( state, action.level, {
-				...action.data.upload[ action.level ],
-				inProgress: false,
-				hasError: false,
-				errorMsg: null,
-			} );
+			return updateLevelState(
+				{
+					...state,
+					id: action.data.id,
+				},
+				action.level,
+				{
+					...action.data.upload[ action.level ],
+					inProgress: false,
+					hasError: false,
+					errorMsg: null,
+				}
+			);
 
 		case ERROR_UPLOAD_IMPORT_DATA_FILE:
 			return updateLevelState( state, action.level, {

--- a/assets/data-port/import/data/reducer.js
+++ b/assets/data-port/import/data/reducer.js
@@ -14,7 +14,7 @@ import {
 import { merge } from 'lodash';
 
 const DEFAULT_STATE = {
-	id: null,
+	jobId: null,
 	isFetching: true,
 	fetchError: false,
 	completedSteps: [],
@@ -145,7 +145,7 @@ export default ( state = DEFAULT_STATE, action ) => {
 			return updateLevelState(
 				{
 					...state,
-					id: action.data.id,
+					jobId: action.data.jobId,
 				},
 				action.level,
 				{

--- a/assets/data-port/import/data/reducer.js
+++ b/assets/data-port/import/data/reducer.js
@@ -13,6 +13,7 @@ import {
 import { merge } from 'lodash';
 
 const DEFAULT_STATE = {
+	id: null,
 	isFetching: true,
 	fetchError: false,
 	completedSteps: [],

--- a/assets/data-port/import/data/reducer.test.js
+++ b/assets/data-port/import/data/reducer.test.js
@@ -3,6 +3,7 @@ import {
 	START_FETCH_IMPORT_DATA,
 	SUCCESS_FETCH_IMPORT_DATA,
 	ERROR_FETCH_IMPORT_DATA,
+	SET_STEP_DATA,
 	START_IMPORT,
 	SUCCESS_START_IMPORT,
 	ERROR_START_IMPORT,
@@ -134,5 +135,25 @@ describe( 'Importer reducer', () => {
 
 		expect( state.upload[ level ].inProgress ).toBeFalsy();
 		expect( state.upload[ level ].errorMsg ).toBe( error.message );
+	} );
+
+	it( 'Should set completedSteps and individual step data on SET_STEP_DATA action', () => {
+		const step = 'progress';
+		const data = {
+			progress: {
+				status: 'test',
+				percentage: 44,
+			},
+			completedSteps: [ 'awesome' ],
+		};
+		const state = reducer( undefined, {
+			type: SET_STEP_DATA,
+			step,
+			data,
+		} );
+
+		expect( state.progress.status ).toEqual( data.progress.status );
+		expect( state.progress.percentage ).toEqual( data.progress.percentage );
+		expect( state.completedSteps ).toEqual( data.completedSteps );
 	} );
 } );

--- a/assets/data-port/import/data/resolvers.js
+++ b/assets/data-port/import/data/resolvers.js
@@ -1,3 +1,4 @@
+import { addQueryArgs } from '@wordpress/url';
 import { API_BASE_PATH } from './constants';
 import { fetchFromAPI, setStepData } from './actions';
 import { normalizeImportData } from './normalizer';
@@ -8,7 +9,7 @@ export function* getStepData( step, jobId, shouldResolve ) {
 	}
 
 	const data = yield fetchFromAPI( {
-		path: API_BASE_PATH + '?job_id=' + jobId,
+		path: addQueryArgs( API_BASE_PATH, { job_id: jobId } ),
 	} );
 
 	return setStepData( step, normalizeImportData( data ) );

--- a/assets/data-port/import/data/resolvers.js
+++ b/assets/data-port/import/data/resolvers.js
@@ -1,0 +1,15 @@
+import { API_BASE_PATH } from './constants';
+import { fetchFromAPI, setStepData } from './actions';
+import { normalizeImportData } from './normalizer';
+
+export function* getStepData( step, jobId, shouldResolve ) {
+	if ( ! shouldResolve ) {
+		return;
+	}
+
+	const data = yield fetchFromAPI( {
+		path: API_BASE_PATH + '?job_id=' + jobId,
+	} );
+
+	return setStepData( step, normalizeImportData( data ) );
+}

--- a/assets/data-port/import/data/resolvers.test.js
+++ b/assets/data-port/import/data/resolvers.test.js
@@ -23,9 +23,10 @@ describe( 'Setup wizard resolvers', () => {
 			},
 			files: {},
 		};
+
 		// Set data action.
 		const expectedDataObject = {
-			id: 'test-id',
+			jobId: 'test-id',
 			progress: {
 				status: 'pending',
 				percentage: 44,

--- a/assets/data-port/import/data/resolvers.test.js
+++ b/assets/data-port/import/data/resolvers.test.js
@@ -1,0 +1,52 @@
+import { API_BASE_PATH, FETCH_FROM_API, SET_STEP_DATA } from './constants';
+import { getStepData } from './resolvers';
+
+describe( 'Setup wizard resolvers', () => {
+	it( 'Should resolve the getStepData selector generating the correct resolver', () => {
+		const gen = getStepData( 'progress', 'test-id', true );
+
+		// Fetch action.
+		const expectedFetchAction = {
+			type: FETCH_FROM_API,
+			request: {
+				path: API_BASE_PATH + '?job_id=test-id',
+			},
+		};
+		expect( gen.next().value ).toEqual( expectedFetchAction );
+
+		// Set data action.
+		const dataObject = {
+			id: 'test-id',
+			status: {
+				status: 'pending',
+				percentage: 44,
+			},
+			files: {},
+		};
+		// Set data action.
+		const expectedDataObject = {
+			id: 'test-id',
+			progress: {
+				status: 'pending',
+				percentage: 44,
+			},
+			upload: {},
+			completedSteps: [ 'upload' ],
+		};
+
+		const expectedSetDataAction = {
+			type: SET_STEP_DATA,
+			step: 'progress',
+			data: expectedDataObject,
+		};
+		expect( gen.next( dataObject ).value ).toEqual( expectedSetDataAction );
+
+		expect( gen.next().done ).toBeTruthy();
+	} );
+
+	it( 'Should not resolve the getStepData selector when flag is not set', () => {
+		const gen = getStepData( 'progress', 'test-id' );
+
+		expect( gen.next().done ).toBeTruthy();
+	} );
+} );

--- a/assets/data-port/import/data/selectors.js
+++ b/assets/data-port/import/data/selectors.js
@@ -15,9 +15,9 @@ export const isFetching = ( state ) => state.isFetching;
  *
  * @param {Object} state Current state.
  *
- * @return {boolean} Has fetched.
+ * @return {string} Job ID.
  */
-export const getId = ( state ) => state.id;
+export const getJobId = ( state ) => state.jobId;
 
 /**
  * Fetch importer error selector.

--- a/assets/data-port/import/data/selectors.js
+++ b/assets/data-port/import/data/selectors.js
@@ -11,6 +11,15 @@ import { levels } from '../levels';
 export const isFetching = ( state ) => state.isFetching;
 
 /**
+ * Get the import job ID.
+ *
+ * @param {Object} state Current state.
+ *
+ * @return {boolean} Has fetched.
+ */
+export const getId = ( state ) => state.id;
+
+/**
  * Fetch importer error selector.
  *
  * @param {Object} state Current state.

--- a/assets/data-port/import/data/selectors.test.js
+++ b/assets/data-port/import/data/selectors.test.js
@@ -1,5 +1,6 @@
 import {
 	getFetchError,
+	getId,
 	getNavigationSteps,
 	getStepData,
 	isCompleteStep,
@@ -14,6 +15,14 @@ describe( 'Importer selectors', () => {
 		};
 
 		expect( isFetching( state ) ).toBeTruthy();
+	} );
+
+	it( 'Should get job id', () => {
+		const state = {
+			id: 'test',
+		};
+
+		expect( getId( state ) ).toEqual( state.id );
 	} );
 
 	it( 'Should get the fetch error', () => {

--- a/assets/data-port/import/data/selectors.test.js
+++ b/assets/data-port/import/data/selectors.test.js
@@ -1,6 +1,6 @@
 import {
 	getFetchError,
-	getId,
+	getJobId,
 	getNavigationSteps,
 	getStepData,
 	isCompleteStep,
@@ -19,10 +19,10 @@ describe( 'Importer selectors', () => {
 
 	it( 'Should get job id', () => {
 		const state = {
-			id: 'test',
+			jobId: 'test',
 		};
 
-		expect( getId( state ) ).toEqual( state.id );
+		expect( getJobId( state ) ).toEqual( state.jobId );
 	} );
 
 	it( 'Should get the fetch error', () => {

--- a/assets/data-port/import/done/index.js
+++ b/assets/data-port/import/done/index.js
@@ -7,7 +7,7 @@ import { Section, H } from '@woocommerce/components';
 export const DonePage = () => {
 	return (
 		<section className="sensei-done-page">
-			<header className="sensei-import-form__header">
+			<header className="sensei-import-step__header">
 				<H>{ __( 'Done', 'sensei-lms' ) }</H>
 			</header>
 			<Section component="section">

--- a/assets/data-port/import/done/index.js
+++ b/assets/data-port/import/done/index.js
@@ -7,7 +7,7 @@ import { Section, H } from '@woocommerce/components';
 export const DonePage = () => {
 	return (
 		<section className="sensei-done-page">
-			<header className="sensei-import-step__header">
+			<header className="sensei-data-port-step__header">
 				<H>{ __( 'Done', 'sensei-lms' ) }</H>
 			</header>
 			<Section component="section">

--- a/assets/data-port/import/import-progress/import-progress-page.js
+++ b/assets/data-port/import/import-progress/import-progress-page.js
@@ -12,8 +12,8 @@ export const ImportProgressPage = ( { jobId, state } ) => {
 	useProgressPolling( isActive, jobId );
 
 	return (
-		<section className="sensei-import-step sensei-import-progress-page">
-			<header className="sensei-import-step__header">
+		<section className="sensei-data-port-step sensei-import-progress-page">
+			<header className="sensei-data-port-step__header">
 				<H>{ __( 'Importing', 'sensei-lms' ) }</H>
 				<p>
 					{ __(
@@ -22,7 +22,10 @@ export const ImportProgressPage = ( { jobId, state } ) => {
 					) }
 				</p>
 			</header>
-			<Section className="sensei-import-step__body" component="section">
+			<Section
+				className="sensei-data-port-step__body"
+				component="section"
+			>
 				<p>
 					<progress
 						className="sensei-import-progress-page__progress"

--- a/assets/data-port/import/import-progress/import-progress-page.js
+++ b/assets/data-port/import/import-progress/import-progress-page.js
@@ -1,0 +1,36 @@
+import { H, Section } from '@woocommerce/components';
+import useProgressPolling from './use-progress-polling';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * This component displays the import progress page of the importer.
+ */
+export const ImportProgressPage = ( { jobId, state } ) => {
+	const { status, percentage } = state;
+	const isActive = status !== 'completed';
+
+	useProgressPolling( isActive, jobId );
+
+	return (
+		<section className="sensei-import-step sensei-import-progress-page">
+			<header className="sensei-import-step__header">
+				<H>{ __( 'Importing', 'sensei-lms' ) }</H>
+				<p>
+					{ __(
+						'Your content is now being imported…',
+						'sensei-lms'
+					) }
+				</p>
+			</header>
+			<Section className="sensei-import-step__body" component="section">
+				<p>
+					<progress
+						className="sensei-import-progress-page__progress"
+						max="100"
+						value={ percentage }
+					/>
+				</p>
+			</Section>
+		</section>
+	);
+};

--- a/assets/data-port/import/import-progress/import-progress-page.test.js
+++ b/assets/data-port/import/import-progress/import-progress-page.test.js
@@ -1,0 +1,22 @@
+import { render } from '@testing-library/react';
+import { ImportProgressPage } from './import-progress-page';
+
+jest.mock( '@wordpress/api-fetch', () => () => Promise.resolve() );
+jest.mock( './use-progress-polling', () => jest.fn() );
+
+describe( '<ImportProgressPage /> progress bar', () => {
+	it( 'should show percent complete', async () => {
+		const state = {
+			status: 'pending',
+			percentage: 33,
+		};
+
+		const { getByRole } = render(
+			<ImportProgressPage jobId="test-job" state={ state } />
+		);
+
+		expect( getByRole( 'progressbar' ).getAttribute( 'value' ) ).toEqual(
+			'33'
+		);
+	} );
+} );

--- a/assets/data-port/import/import-progress/index.js
+++ b/assets/data-port/import/import-progress/index.js
@@ -1,18 +1,14 @@
-import { __ } from '@wordpress/i18n';
-import { Section, H } from '@woocommerce/components';
+import { withSelect } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
+import { ImportProgressPage } from './import-progress-page';
 
-/**
- * This component displays the final page when import has completed.
- */
-export const ImportProgressPage = () => {
-	return (
-		<section className="sensei-import-progress">
-			<header className="sensei-import-progress__header">
-				<H>{ __( 'Import', 'sensei-lms' ) }</H>
-			</header>
-			<Section component="section">
-				<p>Placeholder.</p>
-			</Section>
-		</section>
-	);
-};
+export default compose(
+	withSelect( ( select ) => {
+		const store = select( 'sensei/import' );
+
+		return {
+			jobId: store.getId(),
+			state: store.getStepData( 'progress' ),
+		};
+	} )
+)( ImportProgressPage );

--- a/assets/data-port/import/import-progress/index.js
+++ b/assets/data-port/import/import-progress/index.js
@@ -7,7 +7,7 @@ export default compose(
 		const store = select( 'sensei/import' );
 
 		return {
-			jobId: store.getId(),
+			jobId: store.getJobId(),
 			state: store.getStepData( 'progress' ),
 		};
 	} )

--- a/assets/data-port/import/import-progress/use-progress-polling.js
+++ b/assets/data-port/import/import-progress/use-progress-polling.js
@@ -1,0 +1,38 @@
+import { useState, useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Progress polling hook.
+ *
+ * @param {boolean} isActive Flag whether polling is active.
+ * @param {string}  jobId    ID for the current job.
+ */
+const useProgressPolling = ( isActive, jobId ) => {
+	const [ pollingCount, setPollingCount ] = useState( 0 );
+	const { invalidateResolution } = useDispatch( 'sensei/import' );
+
+	const stepState = useSelect(
+		( select ) =>
+			select( 'sensei/import' ).getStepData( 'progress', jobId, true ),
+		[ pollingCount ]
+	);
+
+	useEffect( () => {
+		if ( ! isActive ) {
+			return;
+		}
+
+		const timer = setTimeout( () => {
+			invalidateResolution( 'getStepData', [ 'progress', jobId, true ] );
+			setPollingCount( ( n ) => n + 1 );
+		}, 5000 );
+
+		return () => {
+			clearTimeout( timer );
+		};
+	}, [ pollingCount, isActive, jobId, invalidateResolution ] );
+
+	return stepState;
+};
+
+export default useProgressPolling;

--- a/assets/data-port/import/import-progress/use-progress-polling.test.js
+++ b/assets/data-port/import/import-progress/use-progress-polling.test.js
@@ -1,0 +1,51 @@
+import { render, act } from '@testing-library/react';
+import { useDispatch } from '@wordpress/data';
+
+import useProgressPolling from './use-progress-polling';
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: () => {},
+	useDispatch: jest.fn(),
+} ) );
+
+describe( 'useProgressPolling', () => {
+	const invalidateResolutionMock = jest.fn();
+
+	useDispatch.mockImplementation( () => ( {
+		invalidateResolution: invalidateResolutionMock,
+	} ) );
+
+	afterEach( () => {
+		invalidateResolutionMock.mockReset();
+	} );
+
+	it( 'Should invalidate resolution after the timer if polling is active', () => {
+		const TestComponent = () => {
+			useProgressPolling( true, 'test-job' );
+
+			return <div />;
+		};
+
+		jest.useFakeTimers();
+		render( <TestComponent /> );
+		act( () => {
+			jest.runOnlyPendingTimers();
+		} );
+
+		expect( invalidateResolutionMock ).toBeCalled();
+	} );
+
+	it( 'Should not invalidate resolution after the timer if polling is not active', () => {
+		const TestComponent = () => {
+			useProgressPolling( false, 'test-job' );
+
+			return <div />;
+		};
+
+		jest.useFakeTimers();
+		render( <TestComponent /> );
+		jest.runOnlyPendingTimers();
+
+		expect( invalidateResolutionMock ).not.toBeCalled();
+	} );
+} );

--- a/assets/data-port/import/steps.js
+++ b/assets/data-port/import/steps.js
@@ -1,6 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import UploadPage from './upload';
-import { ImportProgressPage } from './import-progress';
+import ImportProgressPage from './import-progress';
 import { DonePage } from './done';
 
 export const steps = [

--- a/assets/data-port/import/upload/upload-page.js
+++ b/assets/data-port/import/upload/upload-page.js
@@ -11,8 +11,8 @@ export const UploadPage = ( { state, isReady, submitStartImport } ) => {
 	const { isSubmitting, errorMsg } = state;
 
 	return (
-		<section className="sensei-import-form">
-			<header className="sensei-import-form__header">
+		<section className="sensei-import-step sensei-upload-page">
+			<header className="sensei-import-step__header">
 				<H>{ __( 'Import content from a CSV file', 'sensei-lms' ) }</H>
 				<p>
 					{ __(
@@ -21,7 +21,7 @@ export const UploadPage = ( { state, isReady, submitStartImport } ) => {
 					) }
 				</p>
 			</header>
-			<Section className="sensei-import-form__body" component="section">
+			<Section className="sensei-import-step__body" component="section">
 				<p>
 					{ __(
 						'Choose one or more CSV files to upload from your computer.',

--- a/assets/data-port/import/upload/upload-page.js
+++ b/assets/data-port/import/upload/upload-page.js
@@ -11,8 +11,8 @@ export const UploadPage = ( { state, isReady, submitStartImport } ) => {
 	const { isSubmitting, errorMsg } = state;
 
 	return (
-		<section className="sensei-import-step sensei-upload-page">
-			<header className="sensei-import-step__header">
+		<section className="sensei-data-port-step sensei-upload-page">
+			<header className="sensei-data-port-step__header">
 				<H>{ __( 'Import content from a CSV file', 'sensei-lms' ) }</H>
 				<p>
 					{ __(
@@ -21,7 +21,10 @@ export const UploadPage = ( { state, isReady, submitStartImport } ) => {
 					) }
 				</p>
 			</header>
-			<Section className="sensei-import-step__body" component="section">
+			<Section
+				className="sensei-data-port-step__body"
+				component="section"
+			>
 				<p>
 					{ __(
 						'Choose one or more CSV files to upload from your computer.',

--- a/assets/data-port/stepper/index.js
+++ b/assets/data-port/stepper/index.js
@@ -13,7 +13,7 @@ import classnames from 'classnames';
  * @param {Step[]} steps The array of the steps.
  */
 const DataPortStepper = ( { steps } ) => (
-	<ol className="sensei-import-steps">
+	<ol className="sensei-data-port-steps">
 		{ steps.map( ( step ) => {
 			const stepClass = classnames( {
 				active: step.isNext,

--- a/assets/data-port/stepper/index.js
+++ b/assets/data-port/stepper/index.js
@@ -13,7 +13,7 @@ import classnames from 'classnames';
  * @param {Step[]} steps The array of the steps.
  */
 const DataPortStepper = ( { steps } ) => (
-	<ol className="sensei-progress-steps">
+	<ol className="sensei-import-steps">
 		{ steps.map( ( step ) => {
 			const stepClass = classnames( {
 				active: step.isNext,

--- a/assets/data-port/style.scss
+++ b/assets/data-port/style.scss
@@ -226,6 +226,7 @@ $alert-red: #d94f4f;
 			margin: 0 auto 24px;
 			display: block;
 			background: $gray-0;
+			border: 1px solid $gray-5;
 			border-radius: 4px;
 			padding: 0;
 

--- a/assets/data-port/style.scss
+++ b/assets/data-port/style.scss
@@ -39,7 +39,7 @@ $alert-red: #d94f4f;
 	max-width: 700px;
 	margin: 40px auto;
 
-	.sensei-progress-steps {
+	.sensei-import-steps {
 		padding: 0 0 24px;
 		margin: 0;
 		list-style: none outside;
@@ -95,7 +95,7 @@ $alert-red: #d94f4f;
 		}
 	}
 
-	.sensei-import-form {
+	.sensei-import-step {
 		background: #fff;
 		overflow: hidden;
 		padding: 0;
@@ -154,42 +154,6 @@ $alert-red: #d94f4f;
 				}
 			}
 
-			.sensei-upload-file-line {
-				width: 100%;
-				display: inline-flex;
-				list-style-type: none;
-				margin: 0 -24px;
-				padding: 0 24px;
-				height: 62px;
-
-				&__description {
-					flex-basis: 25%;
-					margin: 18px 0;
-					flex-shrink: 0;
-				}
-
-				.components-form-file-upload {
-					flex-basis: 18%;
-					flex-shrink: 0;
-				}
-
-				.components-button {
-					margin: 13px 0;
-					border: 1px solid $primary;
-					border-radius: 3px;
-					color: $primary;
-
-					&:not(:disabled):not([aria-disabled="true"]):not(.is-primary):hover {
-						color: darken($primary, 10%);
-						box-shadow: inset 0 0 0 1px lighten($primary, 20%), inset 0 0 0 2px $white;
-					}
-				}
-			}
-
-			.sensei-upload-file-line:nth-child(odd) {
-				background: $gray-0;
-			}
-
 			.continue-container {
 				padding: 24px 0;
 				display: flex;
@@ -214,6 +178,44 @@ $alert-red: #d94f4f;
 					}
 				}
 			}
+		}
+	}
+
+	.sensei-upload-page {
+		.sensei-upload-file-line {
+			width: 100%;
+			display: inline-flex;
+			list-style-type: none;
+			margin: 0 -24px;
+			padding: 0 24px;
+			height: 62px;
+
+			&__description {
+				flex-basis: 25%;
+				margin: 18px 0;
+				flex-shrink: 0;
+			}
+
+			.components-form-file-upload {
+				flex-basis: 18%;
+				flex-shrink: 0;
+			}
+
+			.components-button {
+				margin: 13px 0;
+				border: 1px solid $primary;
+				border-radius: 3px;
+				color: $primary;
+
+				&:not(:disabled):not([aria-disabled="true"]):not(.is-primary):hover {
+					color: darken($primary, 10%);
+					box-shadow: inset 0 0 0 1px lighten($primary, 20%), inset 0 0 0 2px $white;
+				}
+			}
+		}
+
+		.sensei-upload-file-line:nth-child(odd) {
+			background: $gray-0;
 		}
 	}
 }

--- a/assets/data-port/style.scss
+++ b/assets/data-port/style.scss
@@ -218,4 +218,42 @@ $alert-red: #d94f4f;
 			background: $gray-0;
 		}
 	}
+
+	.sensei-import-progress-page {
+		progress {
+			width: 100%;
+			height: 42px;
+			margin: 0 auto 24px;
+			display: block;
+			background: $gray-0;
+			border-radius: 4px;
+			padding: 0;
+
+			&::-webkit-progress-bar {
+				background: transparent none;
+				border: 0;
+				border-radius: 4px;
+				padding: 0;
+				box-shadow: none;
+			}
+
+			&::-webkit-progress-value {
+				border-radius: 3px;
+				background-color: $primary;
+				transition: width 1s ease;
+			}
+
+			&::-moz-progress-bar {
+				border-radius: 3px;
+				background-color: $primary;
+				transition: width 1s ease;
+			}
+
+			&::-ms-fill {
+				border-radius: 3px;
+				background-color: $primary;
+				transition: width 1s ease;
+			}
+		}
+	}
 }

--- a/assets/data-port/style.scss
+++ b/assets/data-port/style.scss
@@ -39,7 +39,7 @@ $alert-red: #d94f4f;
 	max-width: 700px;
 	margin: 40px auto;
 
-	.sensei-import-steps {
+	.sensei-data-port-steps {
 		padding: 0 0 24px;
 		margin: 0;
 		list-style: none outside;
@@ -95,7 +95,7 @@ $alert-red: #d94f4f;
 		}
 	}
 
-	.sensei-import-step {
+	.sensei-data-port-step {
 		background: #fff;
 		overflow: hidden;
 		padding: 0;

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -271,4 +271,29 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 
 		return null;
 	}
+
+	/**
+	 * Get a specific job for a user.
+	 *
+	 * @param string $handler_class Class for the data port job.
+	 * @param string $job_id        Job ID.
+	 * @param int    $user_id       User ID.
+	 *
+	 * @return Sensei_Data_Port_Job|null
+	 */
+	public function get_job_for_user( $handler_class, $job_id, $user_id ) {
+
+		foreach ( $this->data_port_jobs as $job ) {
+			if (
+				$handler_class === $job['handler']
+				&& is_a( $job['handler'], 'Sensei_Data_Port_Job', true )
+				&& (string) $job_id === $job['id']
+				&& (int) $user_id === $job['user_id']
+			) {
+				return $job['handler']::get( $job['id'] );
+			}
+		}
+
+		return null;
+	}
 }

--- a/includes/rest-api/class-sensei-rest-api-data-port-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-data-port-controller.php
@@ -94,14 +94,21 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 	/**
 	 * Get the current import job.
 	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
-	public function request_get_job() {
-		$job = $this->get_active_job();
+	public function request_get_job( $request ) {
+		if ( ! empty( $request['job_id'] ) ) {
+			$job = $this->get_job( sanitize_text_field( $request['job_id'] ) );
+		} else {
+			$job = $this->get_active_job();
+		}
+
 		if ( ! $job ) {
 			return new WP_Error(
 				'sensei_data_port_no_active_job',
-				__( 'No job has been created.', 'sensei-lms' ),
+				__( 'No job could be found.', 'sensei-lms' ),
 				array( 'status' => 404 )
 			);
 		}
@@ -214,6 +221,17 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 	 */
 	protected function get_active_job() {
 		return Sensei_Data_Port_Manager::instance()->get_active_job( $this->get_handler_class(), get_current_user_id() );
+	}
+
+	/**
+	 * Get a specific job for this user.
+	 *
+	 * @param string $job_id The job ID.
+	 *
+	 * @return Sensei_Data_Port_Job|null
+	 */
+	protected function get_job( $job_id ) {
+		return Sensei_Data_Port_Manager::instance()->get_job_for_user( $this->get_handler_class(), $job_id, get_current_user_id() );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds a progress page.
* Changes REST API to be able to `GET` a completed job. Normally, I would have made the job ID a URL parameter, but with `/files` and `/start` needing to be non-job specific (they can only be used on the current job) it was a bit clunky.
* Using @renatho's `useFeaturePolling` as an example, I created a resolver for `getStepData` and polled for changes every 5s. 
* For the CSS, I've tried to split each step into its own parent class, but sharing `sensei-data-port-step` for common elements.
* Changed the state name `import` to `progress` just to avoid any issues using a JS keyword.

### Testing instructions

I used [Mockaroo](https://www.mockaroo.com/) to generate this large questions file. I'd recommend doing a snapshot of your database for easy restoration after using it.
[questions-big.csv.zip](https://github.com/Automattic/sensei/files/4813555/questions-big.csv.zip)

* Sensei LMS > Import.
* Upload at least one large file. If you need to slow it down, I added `sleep(1)` to the top of `\Sensei_Import_File_Process_Task::process_line()`.
* Press `Continue`. 
* Observe progress moving as the Cron/Action Scheduler job does its job. For cron, that might mean updates once a minute.
* Observe moving to the done step once the job has completed.