### PR TITLE
Remove unnecessary component button styles in Importer

### DIFF
--- a/assets/data-port/import.js
+++ b/assets/data-port/import.js
@@ -28,6 +28,13 @@ const SenseiImportPage = () => {
 		fetchImporterData();
 	}, [ fetchImporterData ] );
 
+	// Add `sensei-color` to body tag.
+	useLayoutEffect( () => {
+		document.body.classList.add( [ 'sensei-color' ] );
+
+		return () => document.body.classList.remove( [ 'sensei-color' ] );
+	} );
+
 	if ( isFetching ) {
 		return <Spinner className="sensei-import__main-loader" />;
 	}

--- a/assets/data-port/import/upload-level/upload-level.js
+++ b/assets/data-port/import/upload-level/upload-level.js
@@ -71,6 +71,7 @@ export const UploadLevels = ( {
 						<FormFileUpload
 							// Include key to redraw after each upload attempt for onChange of the same file.
 							key={ levelState.inProgress }
+							isSecondary
 							accept={ [ '.csv', '.txt' ] }
 							onChange={ ( event ) =>
 								uploadFile(

--- a/assets/data-port/style.scss
+++ b/assets/data-port/style.scss
@@ -159,24 +159,12 @@ $alert-red: #d94f4f;
 				display: flex;
 				justify-content: flex-end;
 				align-items: center;
+			}
 
-				.components-button {
-					padding: 6px 24px;
-					background: $green;
-					border-color: $green;
-					height: 40px;
-					margin-left: auto;
-
-					&:not(:disabled):not([aria-disabled="true"]):hover {
-						background: darken($primary, 20%);
-						border-color: darken($primary, 20%);
-					}
-
-					&:disabled,
-					&[aria-disabled="true"] {
-						color: lighten($primary, 30%);
-					}
-				}
+			.components-button {
+				padding: 6px 24px;
+				height: 40px;
+				margin-left: auto;
 			}
 		}
 	}
@@ -202,15 +190,9 @@ $alert-red: #d94f4f;
 			}
 
 			.components-button {
+				padding: 6px 14px;
 				margin: 13px 0;
-				border: 1px solid $primary;
 				border-radius: 3px;
-				color: $primary;
-
-				&:not(:disabled):not([aria-disabled="true"]):not(.is-primary):hover {
-					color: darken($primary, 10%);
-					box-shadow: inset 0 0 0 1px lighten($primary, 20%), inset 0 0 0 2px $white;
-				}
 			}
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* As a followup to @yscik's comment https://github.com/Automattic/sensei/pull/3306#discussion_r442142939, this adds `sensei-colors` class to the `<body>` tag and removes unnecessary styles.

### Testing instructions

* Ensure no visual regression on the importer.