### PR TITLE
Add success track event for WC.com installs

### DIFF
--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Setup_Wizard {
 	const SUGGEST_SETUP_WIZARD_OPTION = 'sensei_suggest_setup_wizard';
 	const WC_INFORMATION_TRANSIENT    = 'sensei_woocommerce_plugin_information';
-	const WCCOM_INSTALLING            = 'sensei_setup_wizard_wccom_installing';
+	const WCCOM_INSTALLING_TRANSIENT  = 'sensei_setup_wizard_wccom_installing';
 	const USER_DATA_OPTION            = 'sensei_setup_wizard_data';
 	const MC_LIST_ID                  = '4fa225a515';
 	const MC_USER_ID                  = '7a061a9141b0911d6d9bafe3a';
@@ -605,7 +605,7 @@ class Sensei_Setup_Wizard {
 			}
 		}
 
-		set_transient( self::WCCOM_INSTALLING, $wccom_extensions, 10 * 60 );
+		set_transient( self::WCCOM_INSTALLING_TRANSIENT, $wccom_extensions, 10 * 60 );
 
 		Sensei_Plugins_Installation::instance()->install_plugins( $extensions_to_install );
 	}
@@ -618,7 +618,7 @@ class Sensei_Setup_Wizard {
 	public function log_wccom_plugin_install( $plugin_file ) {
 
 		$plugin_name   = dirname( $plugin_file );
-		$wccom_plugins = get_transient( self::WCCOM_INSTALLING );
+		$wccom_plugins = get_transient( self::WCCOM_INSTALLING_TRANSIENT );
 
 		if ( empty( $wccom_plugins ) ) {
 			return;

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -617,7 +617,7 @@ class Sensei_Setup_Wizard {
 	 */
 	public function log_wccom_plugin_install( $plugin_file ) {
 
-		$plugin_file   = plugin_basename( $plugin_file );
+		$plugin_name   = dirname( $plugin_file );
 		$wccom_plugins = get_transient( self::WCCOM_INSTALLING );
 
 		if ( empty( $wccom_plugins ) ) {
@@ -625,21 +625,11 @@ class Sensei_Setup_Wizard {
 		}
 
 		if ( in_array( $plugin_file, $wccom_plugins, true ) ) {
-
-			$extensions = $this->get_sensei_extensions();
-			$plugin     = array_filter(
-				$extensions,
-				function( $extension ) use ( $plugin_file ) {
-					return $plugin_file === $extension->plugin_file;
-				}
+			sensei_log_event(
+				'setup_wizard_features_install_success',
+				[ 'slug' => $plugin_name ]
 			);
 
-			if ( ! empty( $plugin ) ) {
-				sensei_log_event(
-					'setup_wizard_features_install_success',
-					[ 'slug' => $plugin[0]->product_slug ]
-				);
-			}
 		}
 	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -584,7 +584,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 
 		Sensei()->setup_wizard->install_extensions( [ 'test-wccom-plugin' ] );
 
-		do_action( 'activated_plugin', 'test-plugin/test-plugin.php' );
+		do_action( 'activated_plugin', 'test-wccom-plugin/test-wccom-plugin.php' );
 
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_setup_wizard_features_install_success' );
 

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -39,6 +39,8 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		// Save original current screen.
 		global $current_screen;
 		$this->original_screen = $current_screen;
+
+		Sensei_Test_Events::reset();
 	}
 
 	/**
@@ -553,5 +555,39 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 
 		// Revert mocked instance.
 		$property->setValue( $real_instance );
+	}
+
+	/**
+	 * Tests that WCCOM extensions are logged as setup_wizard_features_install_success when activated.
+	 *
+	 * @covers Sensei_Setup_Wizard::log_wccom_plugin_install
+	 */
+	public function testWccomInstallSuccessLogged() {
+
+		$get_sensei_extensions = wp_json_encode(
+			[
+				'products' => [
+					(object) [
+						'product_slug'     => 'test-wccom-plugin',
+						'plugin_file'      => 'test-plugin/test-plugin.php',
+						'wccom_product_id' => '00000',
+					],
+				],
+			]
+		);
+		add_filter(
+			'pre_http_request',
+			function() use ( $get_sensei_extensions ) {
+				return [ 'body' => $get_sensei_extensions ];
+			}
+		);
+
+		Sensei()->setup_wizard->install_extensions( [ 'test-wccom-plugin' ] );
+
+		do_action( 'activated_plugin', 'test-plugin/test-plugin.php' );
+
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_setup_wizard_features_install_success' );
+
+		$this->assertEquals( 'test-wccom-plugin', $events[0]['url_args']['slug'] );
 	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -569,7 +569,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 				'products' => [
 					(object) [
 						'product_slug'     => 'test-wccom-plugin',
-						'plugin_file'      => 'test-plugin/test-plugin.php',
+						'plugin_file'      => 'test-wccom-plugin/test-wccom-plugin.php',
 						'wccom_product_id' => '00000',
 					],
 				],


### PR DESCRIPTION

This is done indirectly and only for success, as we can't really pick up errors and retries from WooCommerce.com. 

### Changes proposed in this Pull Request

* Set up a 10-minute transient with the plugins selected for WC.com purchase. 
* When a plugin activation happens, and it's one of those plugins, send a `setup_wizard_features_install_success` event. 

### Testing instructions

* Enter setup wizard, make sure usage tracking is enabled
* Select a paid extension, click `Continue` and `Install now`
* Purchase the extension on WooCommerce.com, then click `Add to Site` and wait for successful install. 
* A `setup_wizard_features_install_success` event should be sent with the extension slug. 
