### PR TITLE
Remove direct access to Setup Wizard features feedback screen

### DIFF
--- a/assets/setup-wizard/features/index.js
+++ b/assets/setup-wizard/features/index.js
@@ -6,10 +6,6 @@ import { uniq } from 'lodash';
 import { INSTALLED_STATUS } from './feature-status';
 import { logEvent } from '../log-event';
 import { useQueryStringRouter } from '../query-string-router';
-import {
-	getParam,
-	updateQueryString,
-} from '../query-string-router/url-functions';
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 import {
 	getWccomProductId,
@@ -65,15 +61,6 @@ const Features = () => {
 	const { submitStep: submitInstallation } = useSetupWizardStep(
 		'features-installation'
 	);
-
-	// Open directly in the feedback screen when there is a temporary feedback param.
-	useEffect( () => {
-		if ( getParam( 'feedback' ) ) {
-			// Remove temporary param.
-			updateQueryString( 'feedback', null, true );
-			toggleFeedback( true );
-		}
-	}, [] );
 
 	// Mark as selected also the already submitted slugs (Except the installed ones).
 	useEffect( () => {

--- a/assets/setup-wizard/features/index.test.js
+++ b/assets/setup-wizard/features/index.test.js
@@ -1,6 +1,5 @@
 import { render, fireEvent } from '@testing-library/react';
 
-import { mockSearch } from '../../tests-helper/functions';
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 import QueryStringRouter, { Route } from '../query-string-router';
 import { updateQueryString } from '../query-string-router/url-functions';
@@ -126,23 +125,6 @@ describe( '<Features />', () => {
 		expect(
 			container.querySelector( '.sensei-setup-wizard__icon-status' )
 		).toBeTruthy();
-	} );
-
-	it( 'Should display installation feedback when feedback is an URL param', () => {
-		mockSearch( 'feedback=1' );
-		useFeaturesPolling.mockReturnValue( {
-			selected: [ 'test' ],
-			options: [ { slug: 'test', title: 'Test', status: 'installed' } ],
-		} );
-
-		const { queryByText } = render(
-			<QueryStringRouter>
-				<Features />
-			</QueryStringRouter>
-		);
-
-		expect( queryByText( 'Plugin installed' ) ).toBeTruthy();
-		mockSearch( '' );
 	} );
 
 	it( 'Should display installation error', () => {


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Remove unused code that would have been used for a WC.com redirect to the installation progress screen

### Testing instructions

* Open `/wp-admin/admin.php?page=sensei_setup_wizard&step=features&feedback=1`
* The feature selection screen should show, not the installation progress screen.
