### PR TITLE
Add data port logs REST API endpoint

### DIFF
--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -614,4 +614,48 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	private function set_user_id( $user_id ) {
 		$this->user_id = $user_id;
 	}
+
+	/**
+	 * Get the descriptor for a log entry.
+	 *
+	 * @param array $entry Log entry.
+	 *
+	 * @return string|null
+	 */
+	public static function get_log_entry_descriptor( $entry ) {
+		$data = ! empty( $entry['data'] ) ? $entry['data'] : [];
+
+		$descriptor = [];
+		if ( ! empty( $data['entry_title'] ) ) {
+			$descriptor[] = $data['entry_title'];
+		}
+
+		if ( ! empty( $data['entry_id'] ) ) {
+			// translators: Placeholder is ID of entry in source file.
+			$descriptor[] = sprintf( __( 'ID: %s', 'sensei-lms' ), $data['entry_id'] );
+		}
+
+		if ( empty( $descriptor ) ) {
+			return null;
+		}
+
+		return implode( '; ', $descriptor );
+	}
+
+	/**
+	 * Translate error severity level from integer to string.
+	 *
+	 * @param int $level Integer level.
+	 *
+	 * @return string
+	 */
+	public static function translate_log_severity_level( $level ) {
+		$map = [
+			self::LOG_LEVEL_INFO   => 'info',
+			self::LOG_LEVEL_NOTICE => 'notice',
+			self::LOG_LEVEL_ERROR  => 'error',
+		];
+
+		return isset( $map[ $level ] ) ? $map[ $level ] : 'info';
+	}
 }

--- a/includes/data-port/models/class-sensei-data-port-model.php
+++ b/includes/data-port/models/class-sensei-data-port-model.php
@@ -42,6 +42,13 @@ abstract class Sensei_Data_Port_Model {
 	}
 
 	/**
+	 * Get the model key to identify items in log entries.
+	 *
+	 * @return string
+	 */
+	abstract protected function get_model_key();
+
+	/**
 	 * Get the data to return with any errors.
 	 *
 	 * @param array $data Base error data to pass along.
@@ -49,6 +56,8 @@ abstract class Sensei_Data_Port_Model {
 	 * @return array
 	 */
 	public function get_error_data( $data = [] ) {
+		$data['type'] = $this->get_model_key();
+
 		$entry_id = $this->get_value( $this->schema->get_column_id() );
 		if ( $entry_id ) {
 			$data['entry_id'] = $entry_id;

--- a/includes/data-port/models/class-sensei-data-port-model.php
+++ b/includes/data-port/models/class-sensei-data-port-model.php
@@ -46,7 +46,7 @@ abstract class Sensei_Data_Port_Model {
 	 *
 	 * @return string
 	 */
-	abstract protected function get_model_key();
+	abstract public function get_model_key();
 
 	/**
 	 * Get the data to return with any errors.

--- a/includes/data-port/models/class-sensei-import-course-model.php
+++ b/includes/data-port/models/class-sensei-import-course-model.php
@@ -13,13 +13,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This class is responsible for importing the data for a single course.
  */
 class Sensei_Import_Course_Model extends Sensei_Import_Model {
+	const MODEL_KEY = 'course';
+
 	/**
 	 * Get the model key to identify items in log entries.
 	 *
 	 * @return string
 	 */
-	protected function get_model_key() {
-		return 'course';
+	public function get_model_key() {
+		return self::MODEL_KEY;
 	}
 
 	/**

--- a/includes/data-port/models/class-sensei-import-course-model.php
+++ b/includes/data-port/models/class-sensei-import-course-model.php
@@ -13,6 +13,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This class is responsible for importing the data for a single course.
  */
 class Sensei_Import_Course_Model extends Sensei_Import_Model {
+	/**
+	 * Get the model key to identify items in log entries.
+	 *
+	 * @return string
+	 */
+	protected function get_model_key() {
+		return 'course';
+	}
 
 	/**
 	 * Create a new question or update an existing question.

--- a/includes/data-port/models/class-sensei-import-lesson-model.php
+++ b/includes/data-port/models/class-sensei-import-lesson-model.php
@@ -13,13 +13,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Handles the import for lessons and quizzes.
  */
 class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
+	const MODEL_KEY = 'lesson';
+
 	/**
 	 * Get the model key to identify items in log entries.
 	 *
 	 * @return string
 	 */
-	protected function get_model_key() {
-		return 'lesson';
+	public function get_model_key() {
+		return self::MODEL_KEY;
 	}
 
 	/**

--- a/includes/data-port/models/class-sensei-import-lesson-model.php
+++ b/includes/data-port/models/class-sensei-import-lesson-model.php
@@ -13,6 +13,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Handles the import for lessons and quizzes.
  */
 class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
+	/**
+	 * Get the model key to identify items in log entries.
+	 *
+	 * @return string
+	 */
+	protected function get_model_key() {
+		return 'lesson';
+	}
 
 	/**
 	 * Lesson's course.

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -13,13 +13,15 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This class is responsible for importing a single question.
  */
 class Sensei_Import_Question_Model extends Sensei_Import_Model {
+	const MODEL_KEY = 'question';
+
 	/**
 	 * Get the model key to identify items in log entries.
 	 *
 	 * @return string
 	 */
-	protected function get_model_key() {
-		return 'question';
+	public function get_model_key() {
+		return self::MODEL_KEY;
 	}
 
 	/**

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -13,6 +13,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This class is responsible for importing a single question.
  */
 class Sensei_Import_Question_Model extends Sensei_Import_Model {
+	/**
+	 * Get the model key to identify items in log entries.
+	 *
+	 * @return string
+	 */
+	protected function get_model_key() {
+		return 'question';
+	}
 
 	/**
 	 * Cached question type.

--- a/includes/rest-api/class-sensei-rest-api-data-port-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-data-port-controller.php
@@ -419,35 +419,35 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 	 */
 	public function get_logs_schema() {
 		return [
-			'type' => 'object',
+			'type'       => 'object',
 			'properties' => [
 				'items' => [
-					'type'       => 'array',
-					'items'      => [
+					'type'  => 'array',
+					'items' => [
 						'type'       => 'object',
 						'properties' => [
-							'type'     => [
+							'type'       => [
 								'description' => __( 'Object type', 'sensei-lms' ),
 								'type'        => 'string',
 								'readonly'    => true,
 							],
-							'line'     => [
+							'line'       => [
 								'description' => __( 'Source file line', 'sensei-lms' ),
 								'type'        => 'integer',
 								'readonly'    => true,
 							],
-							'severity'     => [
+							'severity'   => [
 								'description' => __( 'Log severity level ', 'sensei-lms' ),
 								'type'        => 'string',
-								"enum"        => [ 'info', 'notice', 'error' ],
+								'enum'        => [ 'info', 'notice', 'error' ],
 								'readonly'    => true,
 							],
-							'descriptor'     => [
+							'descriptor' => [
 								'description' => __( 'Object descriptor', 'sensei-lms' ),
 								'type'        => 'string',
 								'readonly'    => true,
 							],
-							'message'     => [
+							'message'    => [
 								'description' => __( 'Log message', 'sensei-lms' ),
 								'type'        => 'string',
 								'readonly'    => true,

--- a/tests/framework/data-port/class-sensei-import-model-mock.php
+++ b/tests/framework/data-port/class-sensei-import-model-mock.php
@@ -6,7 +6,7 @@
  */
 
 class Sensei_Import_Model_Mock extends Sensei_Import_Model {
-	protected function get_model_key() {
+	public function get_model_key() {
 		return 'mock-model';
 	}
 

--- a/tests/framework/data-port/class-sensei-import-model-mock.php
+++ b/tests/framework/data-port/class-sensei-import-model-mock.php
@@ -6,6 +6,10 @@
  */
 
 class Sensei_Import_Model_Mock extends Sensei_Import_Model {
+	protected function get_model_key() {
+		return 'mock-model';
+	}
+
 	protected function get_existing_post_id() {
 		return null;
 	}

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
@@ -171,6 +171,7 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 			'line'        => 1,
 			'entry_id'    => 'id',
 			'entry_title' => 'Course title',
+			'type'        => 'course',
 		];
 		$this->assertEquals( $expected, $error_data );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds `GET /wp-json/sensei-internal/v1/import/{job_id}/logs` endpoint.
* Adds model key information to logs to track down where lo entries came from.

### Testing instructions

* On the frontend, start a job with files that contain errors (see examples above). 
* Sniff the job ID.
* Visit `/wp-json/sensei-internal/v1/import/{job_id}/logs`. Verify results are returned correctly.