### PR TITLE
Only disable the redirection for Woocommerce plugin install

### DIFF
--- a/includes/admin/class-sensei-plugins-installation.php
+++ b/includes/admin/class-sensei-plugins-installation.php
@@ -408,7 +408,7 @@ class Sensei_Plugins_Installation {
 				try {
 					// Prevent WC wizard open after programmatically installation.
 					if ( 'woocommerce' === $plugin_slug ) {
-						add_filter( 'woocommerce_enable_setup_wizard', '__return_false' );
+						add_filter( 'pre_set_transient__wc_activation_redirect', '__return_false' );
 					}
 					$result = activate_plugin( $installed ? $installed_plugins[ $plugin_file ] : $plugin_slug . '/' . $plugin_file );
 


### PR DESCRIPTION

This doesn't block the WooCommerce notice to run their Setup Wizard after we install the plugin, only the redirection. 

### Changes proposed in this Pull Request

* Change `woocommerce_enable_setup_wizard` filter to a filter on `_wc_activation_redirect` transient

### Testing instructions

* Install Sensei on a clean setup, select a paid plugin in the setup wizard `Continue`, `Install now`
* Stay on Setup Wizard tab and observe WooCommerce plugin being installed. No need to complete the purchases.
* Finish Setup Wizard, `Exit to courses`
* Observe that site was not redirected to the WooCommerce setup wizard
* Check that a `Run the Setup Wizard` notice for Woocommerce is visible on the Dashboard or Plugins page.

