### PR TITLE
Add sticky footer to confirmation modal 

### DIFF
--- a/assets/setup-wizard/features/confirmation-modal.js
+++ b/assets/setup-wizard/features/confirmation-modal.js
@@ -50,44 +50,46 @@ const ConfirmationModal = ( {
 			} ) ) }
 		/>
 
-		<p>
-			{ __(
-				"You won't have access to this functionality until the extensions have been installed.",
-				'sensei-lms'
-			) }
-		</p>
-		{ features.some( getWccomProductId ) && (
+		<div className="sensei-setup-wizard__modal-footer">
 			<p>
-				<strong>
-					{ __(
-						'WooCommerce.com will open in a new tab so that you can complete the purchase process.',
-						'sensei-lms'
-					) }
-				</strong>
+				{ __(
+					"You won't have access to this functionality until the extensions have been installed.",
+					'sensei-lms'
+				) }
 			</p>
-		) }
+			{ features.some( getWccomProductId ) && (
+				<p>
+					<strong>
+						{ __(
+							'WooCommerce.com will open in a new tab so that you can complete the purchase process.',
+							'sensei-lms'
+						) }
+					</strong>
+				</p>
+			) }
 
-		{ errorNotice }
+			{ errorNotice }
 
-		<div className="sensei-setup-wizard__group-buttons group-right">
-			<Button
-				className="sensei-setup-wizard__button"
-				isTertiary
-				isBusy={ isSubmitting }
-				disabled={ isSubmitting }
-				onClick={ onSkip }
-			>
-				{ __( "I'll do it later", 'sensei-lms' ) }
-			</Button>
-			<Button
-				className="sensei-setup-wizard__button"
-				isPrimary
-				isBusy={ isSubmitting }
-				disabled={ isSubmitting }
-				onClick={ onInstall }
-			>
-				{ __( 'Install now', 'sensei-lms' ) }
-			</Button>
+			<div className="sensei-setup-wizard__group-buttons group-right">
+				<Button
+					className="sensei-setup-wizard__button"
+					isTertiary
+					isBusy={ isSubmitting }
+					disabled={ isSubmitting }
+					onClick={ onSkip }
+				>
+					{ __( "I'll do it later", 'sensei-lms' ) }
+				</Button>
+				<Button
+					className="sensei-setup-wizard__button"
+					isPrimary
+					isBusy={ isSubmitting }
+					disabled={ isSubmitting }
+					onClick={ onInstall }
+				>
+					{ __( 'Install now', 'sensei-lms' ) }
+				</Button>
+			</div>
 		</div>
 	</Modal>
 );

--- a/assets/setup-wizard/style.scss
+++ b/assets/setup-wizard/style.scss
@@ -210,9 +210,27 @@
 		}
 	}
 
+	&__modal-footer {
+		position: sticky;
+		bottom: 0;
+		padding: 16px 0;
+		margin-bottom: -24px;
+		background: #fff;
+		border-top: 1px solid #e2e4e7;
+	}
+
 	&__features-confirmation-modal {
 		width: 520px;
 		max-width: 100%;
+
+		@media (max-height: 500px) {
+			.components-modal__header, .sensei-setup-wizard__modal-footer {
+				position: static;
+			}
+		}
+		.woocommerce-list__item:last-child {
+			border-bottom: 0;
+		}
 
 		.components-modal__header {
 			padding: 25px 0;
@@ -222,6 +240,8 @@
 			.components-modal__header-heading {
 				font-size: 20px;
 			}
+
+
 		}
 
 		.woocommerce-list {


### PR DESCRIPTION
Makes a long list of extensions a bit more viewable in the confirmation screen.
See alternative in the comment.

### Changes proposed in this Pull Request

* Always show the bottom button row of the modal

### Testing instructions

* Deactivate most Sensei extensions
* Open the Setup wizard features screen, select a lot, `Continue`
* Optionally resize the browser window height
* Confirm modal footer & buttons should always stay on screen

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![Confirm scrolling](https://user-images.githubusercontent.com/176949/85781611-2d027f00-b726-11ea-9e56-16b8fcb7ed74.gif)