### PR TITLE
Keep polling in the background for wccom extensions install status

### DIFF
--- a/assets/setup-wizard/features/installation-feedback.js
+++ b/assets/setup-wizard/features/installation-feedback.js
@@ -8,6 +8,7 @@ import FeatureDescription from './feature-description';
 import FeatureStatus, {
 	INSTALLING_STATUS,
 	ERROR_STATUS,
+	EXTERNAL_STATUS,
 } from './feature-status';
 import useFeaturesPolling from './use-features-polling';
 
@@ -20,10 +21,11 @@ import useFeaturesPolling from './use-features-polling';
  */
 const InstallationFeedback = ( { onContinue, onRetry } ) => {
 	const [ hasInstalling, setHasInstalling ] = useState( true );
+	const [ isPolling, setIsPolling ] = useState( true );
 	const [ hasError, setHasError ] = useState( false );
 
 	// Polling is active while some feature is installing.
-	const featuresData = useFeaturesPolling( hasInstalling );
+	const featuresData = useFeaturesPolling( isPolling );
 	const features = featuresData.options.filter( ( feature ) =>
 		featuresData.selected.includes( feature.slug )
 	);
@@ -32,6 +34,13 @@ const InstallationFeedback = ( { onContinue, onRetry } ) => {
 	useEffect( () => {
 		setHasInstalling(
 			features.some( ( feature ) => feature.status === INSTALLING_STATUS )
+		);
+		setIsPolling(
+			features.some( ( feature ) =>
+				[ INSTALLING_STATUS, EXTERNAL_STATUS ].includes(
+					feature.status
+				)
+			)
 		);
 
 		setHasError(


### PR DESCRIPTION

This will allow the wizard to show the plugin as successfully installed after finishing the purchase flow.
Before that, the plugin is still shown with the `external` icon and does not block `Continue` to the Ready step.

### Changes proposed in this Pull Request

* Keep updating the status in the Setup Wizard installation feedback screen for WC.com-hosted features. 

### Testing instructions

* Start installation of a paid feature on the Setup Wizard. Keep the tab open.
* After finishing the purchase and auto-install flow, and going back to the tab, the status should update to `Installed`.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video 

See #3330
