### PR TITLE
Change setup wizard notice to Continue when user has started it

### DIFF
--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -286,7 +286,7 @@ class Sensei_Setup_Wizard {
 				<a href="<?php echo esc_url( $setup_url ); ?>" class="button-primary">
 					<?php
 					if ( $setup_wizard_in_progress ) {
-						esc_html_e( 'Continue the Setup Wizard', 'sensei-lms' );
+						esc_html_e( 'Complete Setup', 'sensei-lms' );
 					} else {
 						esc_html_e( 'Run the Setup Wizard', 'sensei-lms' );
 					}

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -271,7 +271,8 @@ class Sensei_Setup_Wizard {
 			return;
 		}
 
-		$setup_wizard_in_progress = (bool) get_option( self::USER_DATA_OPTION, false );
+		$setup_wizard_user_data   = get_option( self::USER_DATA_OPTION, false );
+		$setup_wizard_in_progress = $setup_wizard_user_data && ! empty( $setup_wizard_user_data['steps'] );
 
 		$setup_url = admin_url( 'admin.php?page=' . $this->page_slug );
 

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -271,6 +271,8 @@ class Sensei_Setup_Wizard {
 			return;
 		}
 
+		$setup_wizard_in_progress = (bool) get_option( self::USER_DATA_OPTION, false );
+
 		$setup_url = admin_url( 'admin.php?page=' . $this->page_slug );
 
 		$skip_url = add_query_arg( 'sensei_skip_setup_wizard', '1' );
@@ -281,7 +283,13 @@ class Sensei_Setup_Wizard {
 
 			<p class="submit">
 				<a href="<?php echo esc_url( $setup_url ); ?>" class="button-primary">
-					<?php esc_html_e( 'Run the Setup Wizard', 'sensei-lms' ); ?>
+					<?php
+					if ( $setup_wizard_in_progress ) {
+						esc_html_e( 'Continue the Setup Wizard', 'sensei-lms' );
+					} else {
+						esc_html_e( 'Run the Setup Wizard', 'sensei-lms' );
+					}
+					?>
 				</a>
 
 				<a class="button" href="<?php echo esc_url( $skip_url ); ?>">

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -204,7 +204,7 @@ class Sensei_Main {
 	/**
 	 * Setup wizard.
 	 *
-	 * @var Sensei_Wizard
+	 * @var Sensei_Setup_Wizard
 	 */
 	public $setup_wizard;
 

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -104,7 +104,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		Sensei()->setup_wizard->setup_wizard_notice();
 		$html = ob_get_clean();
 
-		$pos_setup_button = strpos( $html, 'Continue the Setup Wizard' );
+		$pos_setup_button = strpos( $html, 'Complete Setup' );
 
 		$this->assertNotFalse( $pos_setup_button, 'Should return the notice HTML' );
 	}

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -85,6 +85,31 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test setup wizard notice says continue when user completed a step.
+	 *
+	 * @covers Sensei_Setup_Wizard::setup_wizard_notice
+	 * @covers Sensei_Setup_Wizard::should_current_page_display_setup_wizard
+	 */
+	public function testSetupWizardNoticeContinue() {
+		// Create and login as admin.
+		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		set_current_screen( 'dashboard' );
+		update_option( \Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
+
+		Sensei()->setup_wizard->update_wizard_user_data( [ 'steps' => [ 'welcome' ] ] );
+
+		ob_start();
+		Sensei()->setup_wizard->setup_wizard_notice();
+		$html = ob_get_clean();
+
+		$pos_setup_button = strpos( $html, 'Continue the Setup Wizard' );
+
+		$this->assertNotFalse( $pos_setup_button, 'Should return the notice HTML' );
+	}
+
+	/**
 	 * Test setup wizard notice in screen with Sensei prefix.
 	 *
 	 * @covers Sensei_Setup_Wizard::setup_wizard_notice


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Change setup wizard notice to say `Continue the Setup Wizard` when user has started it.

### Testing instructions

* Add a clean Sensei install, get redirected to Setup Wizard
* Finish the welcome step, then close the wizard
* Open the plugins page, where this notice should be displayed with the updated text

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
<img width="832" alt="image" src="https://user-images.githubusercontent.com/176949/85872344-e0737e00-b7cf-11ea-9a32-6ffd5c545df3.png">
