### PR TITLE
Fix lessons classes

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3779,7 +3779,7 @@ class Sensei_Lesson {
 				$single_lesson_complete = Sensei_Utils::user_completed_lesson( get_the_ID(), get_current_user_id() );
 				if ( $single_lesson_complete ) {
 
-					$lesson_classes[] = 'lesson-completed';
+					$lesson_classes[] = 'completed';
 
 				} // End If Statement
 			} // End If Statement
@@ -3787,7 +3787,7 @@ class Sensei_Lesson {
 			$is_user_taking_course = Sensei_Course::is_user_enrolled( $course_id );
 			if ( Sensei_Utils::is_preview_lesson( get_the_ID() ) && ! $is_user_taking_course ) {
 
-				$lesson_classes[] = 'lesson-preview';
+				$lesson_classes[] = 'preview';
 
 			}
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3767,35 +3767,29 @@ class Sensei_Lesson {
 	 */
 	public static function single_course_lessons_classes( $classes ) {
 
-		if ( is_singular( 'course' ) ) {
+		global $post;
+		$course_id = $post->ID;
 
-			global $post;
-			$course_id = $post->ID;
+		$lesson_classes = array( 'course', 'post' );
+		if ( is_user_logged_in() ) {
 
-			$lesson_classes = array( 'course', 'post' );
-			if ( is_user_logged_in() ) {
+			// Check if Lesson is complete
+			$single_lesson_complete = Sensei_Utils::user_completed_lesson( get_the_ID(), get_current_user_id() );
+			if ( $single_lesson_complete ) {
 
-				// Check if Lesson is complete
-				$single_lesson_complete = Sensei_Utils::user_completed_lesson( get_the_ID(), get_current_user_id() );
-				if ( $single_lesson_complete ) {
+				$lesson_classes[] = 'completed';
 
-					$lesson_classes[] = 'completed';
-
-				} // End If Statement
 			} // End If Statement
+		} // End If Statement
 
-			$is_user_taking_course = Sensei_Course::is_user_enrolled( $course_id );
-			if ( Sensei_Utils::is_preview_lesson( get_the_ID() ) && ! $is_user_taking_course ) {
+		$is_user_taking_course = Sensei_Course::is_user_enrolled( $course_id );
+		if ( Sensei_Utils::is_preview_lesson( get_the_ID() ) && ! $is_user_taking_course ) {
 
-				$lesson_classes[] = 'preview';
-
-			}
-
-			$classes = array_merge( $classes, $lesson_classes );
+			$lesson_classes[] = 'preview';
 
 		}
 
-		return $classes;
+		return array_merge( $classes, $lesson_classes );
 
 	}//end single_course_lessons_classes()
 

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -89,10 +89,6 @@ add_action( 'sensei_single_course_content_inside_after', 'course_single_lessons'
 add_action( 'sensei_single_course_lessons_after', array( 'Sensei_Utils', 'restore_wp_query' ) );
 
 // @since 1.9.0
-// add post classes to the lessons on the single course page
-add_filter( 'post_class', array( 'Sensei_Lesson', 'single_course_lessons_classes' ) );
-
-// @since 1.9.0
 // lesson meta information on the single course page
 add_action( 'sensei_single_course_inside_before_lesson', array( 'Sensei_Lesson', 'the_lesson_meta' ), 5 );
 

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -17,6 +17,8 @@ function course_single_lessons() {
 		return;
 	}
 
+	add_filter( 'post_class', [ 'Sensei_Lesson', 'single_course_lessons_classes' ] );
+
 	// load backwards compatible template name if it exists in the users theme
 	$located_template = locate_template( Sensei()->template_url . 'single-course/course-lessons.php' );
 	if ( $located_template ) {
@@ -27,6 +29,8 @@ function course_single_lessons() {
 	}
 
 	Sensei_Templates::get_template( 'single-course/lessons.php' );
+
+	remove_filter( 'post_class', [ 'Sensei_Lesson', 'single_course_lessons_classes' ] );
 
 } // End course_single_lessons()
 


### PR DESCRIPTION
Fixes #2963

### Changes proposed in this Pull Request

* This PR fixes the classes applied to the lessons in the single course page.
  * Probably the best solution and the recommended approach is this: #3032. But it broke some themes, like the `Aardvark`. So to prevent change the template now for this very simple fix, we created this alternative solution. Maybe we can change it to a recommended approach (not override the main query) in a biggest refactor - Probably when working on the course builder.

### Testing instructions

* Create a new course.
* Add 3 lessons (one of them allowing preview).
* Complete one of the lessons that is not allowed to preview.
* Access the single course page.
* Make sure that the `completed` class is added to the completed lesson.
* Make sure that the `preview` class is added to the lessons allowed to preview.
* Make sure the other lesson doesn't have any of these two classes.
* Make sure all of them have the class `course` (putting a border separating the lessons).
