### PR TITLE
Importer: Link prerequisites for courses and lessons

### DIFF
--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -277,4 +277,43 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 
 		return $results;
 	}
+
+	/**
+	 * Returns the post id for an import id or check if the post exists.
+	 *
+	 * @param string $post_type  The post type.
+	 * @param string $import_id  The import id.
+	 *
+	 * @return int|null The post id if the post exists, null otherwise.
+	 */
+	public function translate_import_id( $post_type, $import_id ) {
+		if ( empty( $import_id ) ) {
+			return null;
+		}
+
+		if ( 0 === strpos( $import_id, 'id:' ) ) {
+			return $this->get_import_id( $post_type, substr( $import_id, 3 ) );
+		}
+
+		if ( 0 === strpos( $import_id, 'slug:' ) ) {
+			$post = get_posts(
+				[
+					'post_type'      => $post_type,
+					'post_name__in'  => [ substr( $import_id, 5 ) ],
+					'posts_per_page' => 1,
+					'post_status'    => 'any',
+					'fields'         => 'ids',
+				]
+			);
+
+			return empty( $post ) ? null : $post[0];
+		}
+
+		if ( null !== get_post( (int) $import_id ) ) {
+			return (int) $import_id;
+		}
+
+		return null;
+	}
+
 }

--- a/includes/data-port/import-tasks/class-sensei-import-courses.php
+++ b/includes/data-port/import-tasks/class-sensei-import-courses.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This class handles the import task for courses.
  */
 class Sensei_Import_Courses extends Sensei_Import_File_Process_Task {
+	use Sensei_Import_Prerequisite_Trait;
 
 	/**
 	 * Return a unique key for the task.
@@ -65,43 +66,11 @@ class Sensei_Import_Courses extends Sensei_Import_File_Process_Task {
 	 * @param array $task Prerequisite task arguments.
 	 */
 	protected function handle_prerequisite( $task ) {
-		$post_id           = (int) $task[0];
-		$reference         = sanitize_text_field( $task[1] );
-		$reference_post_id = $this->get_job()->translate_import_id( Sensei_Data_Port_Course_Schema::POST_TYPE, $reference );
-
-		if (
-			! $reference_post_id
-			|| (int) $reference_post_id === $post_id
-		) {
-			$this->get_job()->add_log_entry(
-			// translators: Placeholder is reference to another post.
-				sprintf( __( 'Unable to set the prerequisite to "%s"', 'sensei-lms' ), $reference ),
-				Sensei_Data_Port_Job::LOG_LEVEL_NOTICE,
-				[
-					'type'    => Sensei_Import_Course_Model::MODEL_KEY,
-					'post_id' => $post_id,
-				]
-			);
-
-			return;
-		}
-
-		update_post_meta( $post_id, '_course_prerequisite', $reference_post_id );
-	}
-
-	/**
-	 * Add prerequisite task for course.
-	 *
-	 * @param int    $post_id   Post ID.
-	 * @param string $reference Reference to the prerequisite.
-	 */
-	public function add_prerequisite_task( $post_id, $reference ) {
-		return $this->add_post_process_task(
-			'prerequisite',
-			[
-				$post_id,
-				$reference,
-			]
+		self::handle_prerequisite_helper(
+			$task,
+			'_course_prerequisite',
+			Sensei_Data_Port_Course_Schema::POST_TYPE,
+			Sensei_Import_Course_Model::MODEL_KEY
 		);
 	}
 }

--- a/includes/data-port/import-tasks/class-sensei-import-courses.php
+++ b/includes/data-port/import-tasks/class-sensei-import-courses.php
@@ -31,7 +31,7 @@ class Sensei_Import_Courses extends Sensei_Import_File_Process_Task {
 	 * @return Sensei_Import_Course_Model
 	 */
 	public function get_model( $line ) {
-		return Sensei_Import_Course_Model::from_source_array( $line, new Sensei_Data_Port_Course_Schema(), $this->get_job() );
+		return Sensei_Import_Course_Model::from_source_array( $line, new Sensei_Data_Port_Course_Schema(), $this );
 	}
 
 	/**

--- a/includes/data-port/import-tasks/class-sensei-import-courses.php
+++ b/includes/data-port/import-tasks/class-sensei-import-courses.php
@@ -68,11 +68,14 @@ class Sensei_Import_Courses extends Sensei_Import_File_Process_Task {
 		$reference         = sanitize_text_field( $task[1] );
 		$reference_post_id = $this->get_job()->translate_import_id( Sensei_Data_Port_Course_Schema::POST_TYPE, $reference );
 
-		if ( ! $reference_post_id ) {
+		if (
+			! $reference_post_id
+			|| (int) $reference_post_id === $post_id
+		) {
 			$this->get_job()->add_log_entry(
 			// translators: Placeholder is reference to another post.
 				sprintf( __( 'Unable to set the prerequisite to "%s"', 'sensei-lms' ), $reference ),
-				Sensei_Data_Port_Job::LOG_LEVEL_ERROR,
+				Sensei_Data_Port_Job::LOG_LEVEL_NOTICE,
 				[
 					'type'    => Sensei_Import_Course_Model::MODEL_KEY,
 					'post_id' => $post_id,

--- a/includes/data-port/import-tasks/class-sensei-import-courses.php
+++ b/includes/data-port/import-tasks/class-sensei-import-courses.php
@@ -26,12 +26,13 @@ class Sensei_Import_Courses extends Sensei_Import_File_Process_Task {
 	/**
 	 * Get the model which handles this task.
 	 *
-	 * @param array $line  An associated array with the CSV line.
+	 * @param int   $line_number Line number for model.
+	 * @param array $data        An associated array with the CSV line.
 	 *
 	 * @return Sensei_Import_Course_Model
 	 */
-	public function get_model( $line ) {
-		return Sensei_Import_Course_Model::from_source_array( $line, new Sensei_Data_Port_Course_Schema(), $this );
+	public function get_model( $line_number, $data ) {
+		return Sensei_Import_Course_Model::from_source_array( $line_number, $data, new Sensei_Data_Port_Course_Schema(), $this );
 	}
 
 	/**

--- a/includes/data-port/import-tasks/class-sensei-import-courses.php
+++ b/includes/data-port/import-tasks/class-sensei-import-courses.php
@@ -55,4 +55,49 @@ class Sensei_Import_Courses extends Sensei_Import_File_Process_Task {
 
 		return Sensei_Import_CSV_Reader::validate_csv_file( $file_path, $required_fields, $optional_fields );
 	}
+
+	/**
+	 * Handle matching a prerequisite to a post.
+	 *
+	 * Note: Used by dynamic callback in `Sensei_Import_File_Process_Task::run_post_process_tasks`.
+	 *
+	 * @param array $task Prerequisite task arguments.
+	 */
+	protected function handle_prerequisite( $task ) {
+		$post_id           = (int) $task[0];
+		$reference         = sanitize_text_field( $task[1] );
+		$reference_post_id = $this->get_job()->translate_import_id( Sensei_Data_Port_Course_Schema::POST_TYPE, $reference );
+
+		if ( ! $reference_post_id ) {
+			$this->get_job()->add_log_entry(
+			// translators: Placeholder is reference to another post.
+				sprintf( __( 'Unable to set the prerequisite to "%s"', 'sensei-lms' ), $reference ),
+				Sensei_Data_Port_Job::LOG_LEVEL_ERROR,
+				[
+					'type'    => Sensei_Import_Course_Model::MODEL_KEY,
+					'post_id' => $post_id,
+				]
+			);
+
+			return;
+		}
+
+		update_post_meta( $post_id, '_course_prerequisite', $reference_post_id );
+	}
+
+	/**
+	 * Add prerequisite task for course.
+	 *
+	 * @param int    $post_id   Post ID.
+	 * @param string $reference Reference to the prerequisite.
+	 */
+	public function add_prerequisite_task( $post_id, $reference ) {
+		return $this->add_post_process_task(
+			'prerequisite',
+			[
+				$post_id,
+				$reference,
+			]
+		);
+	}
 }

--- a/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
+++ b/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
@@ -78,7 +78,7 @@ abstract class Sensei_Import_File_Process_Task
 			$this->reader             = new Sensei_Import_CSV_Reader( get_attached_file( $attachment_id ), $completed_lines );
 			$this->post_process_tasks = isset( $task_state[ self::STATE_POST_PROCESS_TASKS ] ) ? $task_state[ self::STATE_POST_PROCESS_TASKS ] : [];
 
-			$this->is_completed    = $this->reader->is_completed();
+			$this->is_completed    = $this->reader->is_completed() && empty( $this->post_process_tasks );
 			$this->total_lines     = $this->reader->get_total_lines();
 			$this->completed_lines = $completed_lines;
 		}

--- a/includes/data-port/import-tasks/class-sensei-import-lessons.php
+++ b/includes/data-port/import-tasks/class-sensei-import-lessons.php
@@ -55,4 +55,49 @@ class Sensei_Import_Lessons extends Sensei_Import_File_Process_Task {
 
 		return Sensei_Import_CSV_Reader::validate_csv_file( $file_path, $required_fields, $optional_fields );
 	}
+
+	/**
+	 * Handle matching a prerequisite to a post.
+	 *
+	 * Note: Used by dynamic callback in `Sensei_Import_File_Process_Task::run_post_process_tasks`.
+	 *
+	 * @param array $task Prerequisite task arguments.
+	 */
+	protected function handle_prerequisite( $task ) {
+		$post_id           = (int) $task[0];
+		$reference         = sanitize_text_field( $task[1] );
+		$reference_post_id = $this->get_job()->translate_import_id( Sensei_Data_Port_Lesson_Schema::POST_TYPE, $reference );
+
+		if ( ! $reference_post_id ) {
+			$this->get_job()->add_log_entry(
+				// translators: Placeholder is reference to another post.
+				sprintf( __( 'Unable to set the prerequisite to "%s"', 'sensei-lms' ), $reference ),
+				Sensei_Data_Port_Job::LOG_LEVEL_ERROR,
+				[
+					'type'    => Sensei_Import_Lesson_Model::MODEL_KEY,
+					'post_id' => $post_id,
+				]
+			);
+
+			return;
+		}
+
+		update_post_meta( $post_id, '_lesson_prerequisite', $reference_post_id );
+	}
+
+	/**
+	 * Add prerequisite task for lesson.
+	 *
+	 * @param int    $post_id   Post ID.
+	 * @param string $reference Reference to the prerequisite.
+	 */
+	public function add_prerequisite_task( $post_id, $reference ) {
+		return $this->add_post_process_task(
+			'prerequisite',
+			[
+				$post_id,
+				$reference,
+			]
+		);
+	}
 }

--- a/includes/data-port/import-tasks/class-sensei-import-lessons.php
+++ b/includes/data-port/import-tasks/class-sensei-import-lessons.php
@@ -68,11 +68,14 @@ class Sensei_Import_Lessons extends Sensei_Import_File_Process_Task {
 		$reference         = sanitize_text_field( $task[1] );
 		$reference_post_id = $this->get_job()->translate_import_id( Sensei_Data_Port_Lesson_Schema::POST_TYPE, $reference );
 
-		if ( ! $reference_post_id ) {
+		if (
+			! $reference_post_id
+			|| (int) $reference_post_id === $post_id
+		) {
 			$this->get_job()->add_log_entry(
 				// translators: Placeholder is reference to another post.
 				sprintf( __( 'Unable to set the prerequisite to "%s"', 'sensei-lms' ), $reference ),
-				Sensei_Data_Port_Job::LOG_LEVEL_ERROR,
+				Sensei_Data_Port_Job::LOG_LEVEL_NOTICE,
 				[
 					'type'    => Sensei_Import_Lesson_Model::MODEL_KEY,
 					'post_id' => $post_id,

--- a/includes/data-port/import-tasks/class-sensei-import-lessons.php
+++ b/includes/data-port/import-tasks/class-sensei-import-lessons.php
@@ -31,7 +31,7 @@ class Sensei_Import_Lessons extends Sensei_Import_File_Process_Task {
 	 * @return Sensei_Import_Lesson_Model
 	 */
 	public function get_model( $line ) {
-		return Sensei_Import_Lesson_Model::from_source_array( $line, new Sensei_Data_Port_Lesson_Schema(), $this->get_job() );
+		return Sensei_Import_Lesson_Model::from_source_array( $line, new Sensei_Data_Port_Lesson_Schema(), $this );
 	}
 
 	/**

--- a/includes/data-port/import-tasks/class-sensei-import-lessons.php
+++ b/includes/data-port/import-tasks/class-sensei-import-lessons.php
@@ -66,43 +66,11 @@ class Sensei_Import_Lessons extends Sensei_Import_File_Process_Task {
 	 * @param array $task Prerequisite task arguments.
 	 */
 	protected function handle_prerequisite( $task ) {
-		$post_id           = (int) $task[0];
-		$reference         = sanitize_text_field( $task[1] );
-		$reference_post_id = $this->get_job()->translate_import_id( Sensei_Data_Port_Lesson_Schema::POST_TYPE, $reference );
-
-		if (
-			! $reference_post_id
-			|| (int) $reference_post_id === $post_id
-		) {
-			$this->get_job()->add_log_entry(
-				// translators: Placeholder is reference to another post.
-				sprintf( __( 'Unable to set the prerequisite to "%s"', 'sensei-lms' ), $reference ),
-				Sensei_Data_Port_Job::LOG_LEVEL_NOTICE,
-				[
-					'type'    => Sensei_Import_Lesson_Model::MODEL_KEY,
-					'post_id' => $post_id,
-				]
-			);
-
-			return;
-		}
-
-		update_post_meta( $post_id, '_lesson_prerequisite', $reference_post_id );
-	}
-
-	/**
-	 * Add prerequisite task for lesson.
-	 *
-	 * @param int    $post_id   Post ID.
-	 * @param string $reference Reference to the prerequisite.
-	 */
-	public function add_prerequisite_task( $post_id, $reference ) {
-		return $this->add_post_process_task(
-			'prerequisite',
-			[
-				$post_id,
-				$reference,
-			]
+		self::handle_prerequisite_helper(
+			$task,
+			'_lesson_prerequisite',
+			Sensei_Data_Port_Lesson_Schema::POST_TYPE,
+			Sensei_Import_Lesson_Model::MODEL_KEY
 		);
 	}
 }

--- a/includes/data-port/import-tasks/class-sensei-import-lessons.php
+++ b/includes/data-port/import-tasks/class-sensei-import-lessons.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This class handles the import task for lessons.
  */
 class Sensei_Import_Lessons extends Sensei_Import_File_Process_Task {
+	use Sensei_Import_Prerequisite_Trait;
 
 	/**
 	 * Return a unique key for the task.
@@ -26,12 +27,13 @@ class Sensei_Import_Lessons extends Sensei_Import_File_Process_Task {
 	/**
 	 * Get the model which handles this task.
 	 *
-	 * @param array $line  An associated array with the CSV line.
+	 * @param int   $line_number Line number for model.
+	 * @param array $data        An associated array with the CSV line.
 	 *
 	 * @return Sensei_Import_Lesson_Model
 	 */
-	public function get_model( $line ) {
-		return Sensei_Import_Lesson_Model::from_source_array( $line, new Sensei_Data_Port_Lesson_Schema(), $this );
+	public function get_model( $line_number, $data ) {
+		return Sensei_Import_Lesson_Model::from_source_array( $line_number, $data, new Sensei_Data_Port_Lesson_Schema(), $this );
 	}
 
 	/**

--- a/includes/data-port/import-tasks/class-sensei-import-prerequisite-trait.php
+++ b/includes/data-port/import-tasks/class-sensei-import-prerequisite-trait.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * File containing the Sensei_Import_Lessons class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * This trait contains shared methods related to prerequisite handling.
+ */
+trait Sensei_Import_Prerequisite_Trait {
+	/**
+	 * Helper for handling the prerequisite post-process task.
+	 *
+	 * @param array  $task       Raw post-process task attribute array.
+	 * @param string $meta_field Meta field that holds the pre-req.
+	 * @param string $post_type  Post type that is being handled.
+	 * @param string $model_key  Model key.
+	 */
+	private function handle_prerequisite_helper( $task, $meta_field, $post_type, $model_key ) {
+		$post_id           = (int) $task[0];
+		$reference         = sanitize_text_field( $task[1] );
+		$line_number       = (int) $task[2];
+		$reference_post_id = $this->get_job()->translate_import_id( $post_type, $reference );
+		$error_data        = [
+			'line'    => $line_number,
+			'type'    => $model_key,
+			'post_id' => $post_id,
+		];
+
+		if ( ! $reference_post_id ) {
+			$this->get_job()->add_log_entry(
+				// translators: Placeholder is reference to another post.
+				sprintf( __( 'Unable to set the prerequisite to "%s"', 'sensei-lms' ), $reference ),
+				Sensei_Data_Port_Job::LOG_LEVEL_NOTICE,
+				$error_data
+			);
+
+			return;
+		}
+
+		if ( (int) $reference_post_id === $post_id ) {
+			$this->get_job()->add_log_entry(
+				__( 'Unable to set the prerequisite to the same entry', 'sensei-lms' ),
+				Sensei_Data_Port_Job::LOG_LEVEL_NOTICE,
+				$error_data
+			);
+
+			return;
+		}
+
+		update_post_meta( $post_id, $meta_field, $reference_post_id );
+	}
+
+	/**
+	 * Add prerequisite task for lesson.
+	 *
+	 * @param int    $post_id     Post ID.
+	 * @param string $reference   Reference to the prerequisite.
+	 * @param int    $line_number Line number.
+	 */
+	public function add_prerequisite_task( $post_id, $reference, $line_number ) {
+		return $this->add_post_process_task(
+			'prerequisite',
+			[
+				$post_id,
+				$reference,
+				$line_number,
+			]
+		);
+	}
+}

--- a/includes/data-port/import-tasks/class-sensei-import-questions.php
+++ b/includes/data-port/import-tasks/class-sensei-import-questions.php
@@ -33,7 +33,7 @@ class Sensei_Import_Questions
 	 * @return Sensei_Import_Question_Model
 	 */
 	public function get_model( $line ) {
-		return Sensei_Import_Question_Model::from_source_array( $line, new Sensei_Data_Port_Question_Schema(), $this->get_job() );
+		return Sensei_Import_Question_Model::from_source_array( $line, new Sensei_Data_Port_Question_Schema(), $this );
 	}
 
 	/**

--- a/includes/data-port/import-tasks/class-sensei-import-questions.php
+++ b/includes/data-port/import-tasks/class-sensei-import-questions.php
@@ -28,12 +28,13 @@ class Sensei_Import_Questions
 	/**
 	 * Get the model which handles this task.
 	 *
-	 * @param array $line  An associated array with the CSV line.
+	 * @param int   $line_number Line number for model.
+	 * @param array $data        An associated array with the CSV line.
 	 *
 	 * @return Sensei_Import_Question_Model
 	 */
-	public function get_model( $line ) {
-		return Sensei_Import_Question_Model::from_source_array( $line, new Sensei_Data_Port_Question_Schema(), $this );
+	public function get_model( $line_number, $data ) {
+		return Sensei_Import_Question_Model::from_source_array( $line_number, $data, new Sensei_Data_Port_Question_Schema(), $this );
 	}
 
 	/**

--- a/includes/data-port/models/class-sensei-import-course-model.php
+++ b/includes/data-port/models/class-sensei-import-course-model.php
@@ -66,6 +66,13 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 		$this->set_post_id( $post_id );
 		$this->store_import_id();
 
+		$prerequisite = $this->get_value( Sensei_Data_Port_Course_Schema::COLUMN_PREREQUISITE );
+		if ( $prerequisite ) {
+			$this->task->add_prerequisite_task( $post_id, $prerequisite );
+		} elseif ( '' === $prerequisite ) {
+			delete_post_meta( $post_id, '_course_prerequisite' );
+		}
+
 		$result = $this->set_course_terms( Sensei_Data_Port_Course_Schema::COLUMN_MODULES, 'module', $teacher );
 
 		if ( is_wp_error( $result ) ) {

--- a/includes/data-port/models/class-sensei-import-course-model.php
+++ b/includes/data-port/models/class-sensei-import-course-model.php
@@ -68,7 +68,7 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 
 		$prerequisite = $this->get_value( Sensei_Data_Port_Course_Schema::COLUMN_PREREQUISITE );
 		if ( $prerequisite ) {
-			$this->task->add_prerequisite_task( $post_id, $prerequisite );
+			$this->task->add_prerequisite_task( $post_id, $prerequisite, $this->line_number );
 		} elseif ( '' === $prerequisite ) {
 			delete_post_meta( $post_id, '_course_prerequisite' );
 		}

--- a/includes/data-port/models/class-sensei-import-lesson-model.php
+++ b/includes/data-port/models/class-sensei-import-lesson-model.php
@@ -309,7 +309,7 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 
 		$prerequisite = $this->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_PREREQUISITE );
 		if ( $prerequisite ) {
-			$this->task->add_prerequisite_task( $post_id, $prerequisite );
+			$this->task->add_prerequisite_task( $post_id, $prerequisite, $this->line_number );
 		} elseif ( '' === $prerequisite ) {
 			delete_post_meta( $post_id, '_lesson_prerequisite' );
 		}

--- a/includes/data-port/models/class-sensei-import-lesson-model.php
+++ b/includes/data-port/models/class-sensei-import-lesson-model.php
@@ -196,7 +196,7 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 		$question_ids        = [];
 
 		foreach ( $question_import_ids as $question_import_id ) {
-			$question_id = $this->translate_import_id( Sensei_Data_Port_Question_Schema::POST_TYPE, $question_import_id );
+			$question_id = $this->task->get_job()->translate_import_id( Sensei_Data_Port_Question_Schema::POST_TYPE, $question_import_id );
 
 			if ( empty( $question_id ) ) {
 				return new WP_Error(
@@ -270,7 +270,7 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 
 		$value = $this->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_COURSE );
 		if ( ! empty( $value ) ) {
-			$course = $this->translate_import_id( Sensei_Data_Port_Course_Schema::POST_TYPE, $value );
+			$course = $this->task->get_job()->translate_import_id( Sensei_Data_Port_Course_Schema::POST_TYPE, $value );
 
 			if ( empty( $course ) ) {
 				return new WP_Error(

--- a/includes/data-port/models/class-sensei-import-lesson-model.php
+++ b/includes/data-port/models/class-sensei-import-lesson-model.php
@@ -307,6 +307,13 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 		$this->set_post_id( $post_id );
 		$this->store_import_id();
 
+		$prerequisite = $this->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_PREREQUISITE );
+		if ( $prerequisite ) {
+			$this->task->add_prerequisite_task( $post_id, $prerequisite );
+		} elseif ( '' === $prerequisite ) {
+			delete_post_meta( $post_id, '_lesson_prerequisite' );
+		}
+
 		if ( null !== $this->course_id && $this->is_new() ) {
 			$old_lesson_order = get_post_meta( $this->course_id, '_lesson_order', true );
 			$new_lesson_order = empty( $old_lesson_order ) ? $this->get_post_id() : $old_lesson_order . ',' . $this->get_post_id();

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -15,6 +15,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 
 	/**
+	 * The line number being imported.
+	 *
+	 * @var int
+	 */
+	protected $line_number;
+
+	/**
 	 * The default author to be used in courses if none is provided.
 	 *
 	 * @var int
@@ -38,14 +45,16 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 	/**
 	 * Set up item from an array.
 	 *
-	 * @param array                           $data   Data to restore item from.
-	 * @param Sensei_Data_Port_Schema         $schema The schema for the item.
-	 * @param Sensei_Import_File_Process_Task $task   The import task.
+	 * @param int                             $line_number Line number.
+	 * @param array                           $data        Data to restore item from.
+	 * @param Sensei_Data_Port_Schema         $schema      The schema for the item.
+	 * @param Sensei_Import_File_Process_Task $task        The import task.
 	 *
 	 * @return static
 	 */
-	public static function from_source_array( $data, Sensei_Data_Port_Schema $schema, Sensei_Import_File_Process_Task $task = null ) {
+	public static function from_source_array( $line_number, $data, Sensei_Data_Port_Schema $schema, Sensei_Import_File_Process_Task $task = null ) {
 		$self                 = new static();
+		$self->line_number    = $line_number;
 		$self->schema         = $schema;
 		$self->task           = $task;
 		$self->default_author = null === $task ? 0 : $task->get_job()->get_user_id();

--- a/tests/framework/data-port/class-sensei-import-file-process-task-mock.php
+++ b/tests/framework/data-port/class-sensei-import-file-process-task-mock.php
@@ -11,8 +11,8 @@ class Sensei_Import_File_Process_Task_Mock extends Sensei_Import_File_Process_Ta
 		return 'mock-key';
 	}
 
-	public function get_model( $line ) {
-		return Sensei_Import_Model_Mock::from_source_array( $line, new Sensei_Data_Port_Schema_Mock() );
+	public function get_model( $line_number, $data ) {
+		return Sensei_Import_Model_Mock::from_source_array( $line_number, $data, new Sensei_Data_Port_Schema_Mock() );
 	}
 
 	public function clean_up() {}

--- a/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-courses.php
+++ b/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-courses.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * This file contains the Sensei_Import_Lessons class.
+ * This file contains the Sensei_Import_Courses_Tests class.
  *
  * @package sensei
  */
@@ -10,11 +10,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Tests for Sensei_Import_Lessons class.
+ * Tests for Sensei_Import_Courses class.
  *
  * @group data-port
  */
-class Sensei_Import_Lessons_Tests extends WP_UnitTestCase {
+class Sensei_Import_Courses_Tests extends WP_UnitTestCase {
 
 	/**
 	 * Setup function.
@@ -29,54 +29,54 @@ class Sensei_Import_Lessons_Tests extends WP_UnitTestCase {
 	 * Test to make sure prerequisites are handled correctly.
 	 */
 	public function testHandlePrerequisiteHandled() {
-		$lesson_id        = $this->factory->lesson->create();
-		$lesson_prereq_id = $this->factory->lesson->create(
+		$course_id        = $this->factory->course->create();
+		$course_prereq_id = $this->factory->course->create(
 			[
-				'post_name' => 'a-secret-lesson',
+				'post_name' => 'a-secret-course',
 			]
 		);
 
 		$job    = Sensei_Import_Job::create( 'test', 0 );
-		$task   = new Sensei_Import_Lessons( $job );
+		$task   = new Sensei_Import_courses( $job );
 		$method = new ReflectionMethod( $task, 'handle_prerequisite' );
 		$method->setAccessible( true );
 
 		$task_args = [
-			$lesson_id,
-			'slug:a-secret-lesson',
+			$course_id,
+			'slug:a-secret-course',
 			1,
 		];
 
 		$method->invoke( $task, $task_args );
 
-		$this->assertEquals( (string) $lesson_prereq_id, get_post_meta( $lesson_id, '_lesson_prerequisite', true ) );
+		$this->assertEquals( (string) $course_prereq_id, get_post_meta( $course_id, '_course_prerequisite', true ) );
 	}
 
 	/**
 	 * Test to make sure prerequisites can't be set to themselves.
 	 */
 	public function testHandlePrerequisiteNoLoop() {
-		$lesson_prereq_id = $this->factory->lesson->create(
+		$course_prereq_id = $this->factory->course->create(
 			[
-				'post_name' => 'a-secret-lesson',
+				'post_name' => 'a-secret-course',
 			]
 		);
-		$lesson_id        = $lesson_prereq_id;
+		$course_id        = $course_prereq_id;
 
 		$job    = Sensei_Import_Job::create( 'test', 0 );
-		$task   = new Sensei_Import_Lessons( $job );
+		$task   = new Sensei_Import_courses( $job );
 		$method = new ReflectionMethod( $task, 'handle_prerequisite' );
 		$method->setAccessible( true );
 
 		$task_args = [
-			$lesson_id,
-			'slug:a-secret-lesson',
+			$course_id,
+			'slug:a-secret-course',
 			1,
 		];
 
 		$method->invoke( $task, $task_args );
 
-		$this->assertEquals( null, get_post_meta( $lesson_id, '_lesson_prerequisite', true ) );
+		$this->assertEquals( null, get_post_meta( $course_id, '_course_prerequisite', true ) );
 
 		$logs = $job->get_logs();
 		$this->assertTrue( isset( $logs[0] ), 'A log entry should have been written' );
@@ -87,25 +87,25 @@ class Sensei_Import_Lessons_Tests extends WP_UnitTestCase {
 	 * Test to make we log when a bad reference comes through.
 	 */
 	public function testHandlePrerequisiteLogNoticeBad() {
-		$lesson_id = $this->factory->lesson->create();
+		$course_id = $this->factory->course->create();
 
 		$job    = Sensei_Import_Job::create( 'test', 0 );
-		$task   = new Sensei_Import_Lessons( $job );
+		$task   = new Sensei_Import_courses( $job );
 		$method = new ReflectionMethod( $task, 'handle_prerequisite' );
 		$method->setAccessible( true );
 
 		$task_args = [
-			$lesson_id,
-			'slug:a-missing-lesson',
+			$course_id,
+			'slug:a-missing-course',
 			1,
 		];
 
 		$method->invoke( $task, $task_args );
 
-		$this->assertEquals( null, get_post_meta( $lesson_id, '_lesson_prerequisite', true ) );
+		$this->assertEquals( null, get_post_meta( $course_id, '_course_prerequisite', true ) );
 
 		$logs = $job->get_logs();
 		$this->assertTrue( isset( $logs[0] ), 'A log entry should have been written' );
-		$this->assertEquals( 'Unable to set the prerequisite to "slug:a-missing-lesson"', $logs[0]['message'], 'Log entry should warn users when they try to set a prereq to the same object' );
+		$this->assertEquals( 'Unable to set the prerequisite to "slug:a-missing-course"', $logs[0]['message'], 'Log entry should warn users when they try to set a prereq to the same object' );
 	}
 }

--- a/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-file-process-task.php
+++ b/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-file-process-task.php
@@ -24,6 +24,49 @@ class Sensei_Import_File_Process_Task_Tests extends WP_UnitTestCase {
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/data-port/class-sensei-data-port-job-mock.php';
 	}
 
+
+	/**
+	 * Tests that post process tasks run in batches.
+	 */
+	public function testHandlesPostProcessTasks() {
+		$attachment_id     = wp_insert_attachment( [], SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/test_csv_reader.csv' );
+		$file_process_task = $this->mock_task_method(
+			$this->create_job_stub(
+				[ 'mock-key' => $attachment_id ],
+				[ 'completed-lines' => 10 ]
+			),
+			[ 'process_line', 'handle_something' ]
+		);
+
+		$file_process_task
+			->expects( $this->exactly( 70 ) )
+			->method( 'handle_something' );
+
+		$file_process_task
+			->expects( $this->any() )
+			->method( 'process_line' )
+			->will(
+				$this->returnCallback(
+					function( $line_number, $line ) use ( $file_process_task ) {
+						if ( 12 === $line_number ) {
+							for ( $i = 0; $i < 70; $i++ ) {
+								$file_process_task->add_post_process_task( 'something', [ $i ] );
+							}
+						}
+					}
+				)
+			);
+
+		$file_process_task->run();
+		$this->assertFalse( $file_process_task->is_completed(), 'Lines have been processed, but post-process tasks have not' );
+
+		$file_process_task->run();
+		$this->assertFalse( $file_process_task->is_completed(), 'Post process tasks have not finished' );
+
+		$file_process_task->run();
+		$this->assertTrue( $file_process_task->is_completed(), 'Post process tasks have finished' );
+	}
+
 	/**
 	 * Tests that process_line is called with correct data.
 	 */
@@ -85,9 +128,12 @@ class Sensei_Import_File_Process_Task_Tests extends WP_UnitTestCase {
 	}
 
 	private function mock_task_method( $job, $method ) {
+		if ( ! is_array( $method ) ) {
+			$method = [ $method ];
+		}
 		return $this->getMockBuilder( Sensei_Import_File_Process_Task_Mock::class )
 			->setConstructorArgs( [ $job ] )
-			->setMethods( [ $method ] )
+			->setMethods( $method )
 			->getMock();
 	}
 

--- a/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-file-process-task.php
+++ b/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-file-process-task.php
@@ -41,7 +41,7 @@ class Sensei_Import_File_Process_Task_Tests extends WP_UnitTestCase {
 			->method( 'process_line' )
 			->withConsecutive(
 				[
-					11,
+					12,
 					[
 						'first column'  => 'first data 6',
 						'second column' => 'second data 6',
@@ -49,7 +49,7 @@ class Sensei_Import_File_Process_Task_Tests extends WP_UnitTestCase {
 					],
 				],
 				[
-					12,
+					13,
 					[
 						'first column'  => 'first data 7',
 						'second column' => 'second data 7',
@@ -57,7 +57,7 @@ class Sensei_Import_File_Process_Task_Tests extends WP_UnitTestCase {
 					],
 				],
 				[
-					13,
+					14,
 					[],
 				]
 			);

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
@@ -135,7 +135,8 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 	 * @dataProvider lineData
 	 */
 	public function testInputIsSanitized( $input_line, $expected_model_content ) {
-		$model         = Sensei_Import_Course_Model::from_source_array( $input_line, new Sensei_Data_Port_Course_Schema(), Sensei_Import_Job::create( 'test', 0 ) );
+		$task          = new Sensei_Import_Courses( Sensei_Import_Job::create( 'test', 0 ) );
+		$model         = Sensei_Import_Course_Model::from_source_array( $input_line, new Sensei_Data_Port_Course_Schema(), $task );
 		$tested_fields = [
 			Sensei_Data_Port_Course_Schema::COLUMN_ID,
 			Sensei_Data_Port_Course_Schema::COLUMN_TITLE,
@@ -181,7 +182,8 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 	 */
 	public function testCourseIsInsertedAndUpdated() {
 		$thumbnail_id = $this->factory->attachment->create( [ 'file' => 'localfilename.png' ] );
-		$model        = Sensei_Import_Course_Model::from_source_array( $this->lineData()[0][0], new Sensei_Data_Port_Course_Schema(), Sensei_Import_Job::create( 'test', 0 ) );
+		$task         = new Sensei_Import_Courses( Sensei_Import_Job::create( 'test', 0 ) );
+		$model        = Sensei_Import_Course_Model::from_source_array( $this->lineData()[0][0], new Sensei_Data_Port_Course_Schema(), $task );
 		$result       = $model->sync_post();
 
 		$this->assertTrue( $result );
@@ -198,7 +200,8 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 		$this->verify_course( $created_post, $this->lineData()[0][1], $thumbnail_id );
 
 		$thumbnail_id = $this->factory->attachment->create( [ 'file' => 'updatedfilename.png' ] );
-		$model        = Sensei_Import_Course_Model::from_source_array( $this->lineData()[1][0], new Sensei_Data_Port_Course_Schema(), Sensei_Import_Job::create( 'test', 0 ) );
+		$task         = new Sensei_Import_Courses( Sensei_Import_Job::create( 'test', 0 ) );
+		$model        = Sensei_Import_Course_Model::from_source_array( $this->lineData()[1][0], new Sensei_Data_Port_Course_Schema(), $task );
 		$result       = $model->sync_post();
 
 		$this->assertTrue( $result );
@@ -278,7 +281,8 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 	 * Tests that an error is returned when the attachment does not exist.
 	 */
 	public function testSyncPostFailsWhenAttachmentNotFound() {
-		$model  = Sensei_Import_Course_Model::from_source_array( $this->lineData()[0][0], new Sensei_Data_Port_Course_Schema(), Sensei_Import_Job::create( 'test', 0 ) );
+		$task   = new Sensei_Import_Courses( Sensei_Import_Job::create( 'test', 0 ) );
+		$model  = Sensei_Import_Course_Model::from_source_array( $this->lineData()[0][0], new Sensei_Data_Port_Course_Schema(), $task );
 		$result = $model->sync_post();
 
 		$this->assertInstanceOf( 'WP_Error', $result );

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
@@ -136,7 +136,7 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 	 */
 	public function testInputIsSanitized( $input_line, $expected_model_content ) {
 		$task          = new Sensei_Import_Courses( Sensei_Import_Job::create( 'test', 0 ) );
-		$model         = Sensei_Import_Course_Model::from_source_array( $input_line, new Sensei_Data_Port_Course_Schema(), $task );
+		$model         = Sensei_Import_Course_Model::from_source_array( 1, $input_line, new Sensei_Data_Port_Course_Schema(), $task );
 		$tested_fields = [
 			Sensei_Data_Port_Course_Schema::COLUMN_ID,
 			Sensei_Data_Port_Course_Schema::COLUMN_TITLE,
@@ -165,7 +165,7 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 	 * Tests that error data has the correct values.
 	 */
 	public function testErrorDataAreGeneratedCorrectly() {
-		$model      = Sensei_Import_Course_Model::from_source_array( $this->lineData()[0][0], new Sensei_Data_Port_Course_Schema() );
+		$model      = Sensei_Import_Course_Model::from_source_array( 1, $this->lineData()[0][0], new Sensei_Data_Port_Course_Schema() );
 		$error_data = $model->get_error_data( [ 'line' => 1 ] );
 
 		$expected = [
@@ -183,7 +183,7 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 	public function testCourseIsInsertedAndUpdated() {
 		$thumbnail_id = $this->factory->attachment->create( [ 'file' => 'localfilename.png' ] );
 		$task         = new Sensei_Import_Courses( Sensei_Import_Job::create( 'test', 0 ) );
-		$model        = Sensei_Import_Course_Model::from_source_array( $this->lineData()[0][0], new Sensei_Data_Port_Course_Schema(), $task );
+		$model        = Sensei_Import_Course_Model::from_source_array( 1, $this->lineData()[0][0], new Sensei_Data_Port_Course_Schema(), $task );
 		$result       = $model->sync_post();
 
 		$this->assertTrue( $result );
@@ -201,7 +201,7 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 
 		$thumbnail_id = $this->factory->attachment->create( [ 'file' => 'updatedfilename.png' ] );
 		$task         = new Sensei_Import_Courses( Sensei_Import_Job::create( 'test', 0 ) );
-		$model        = Sensei_Import_Course_Model::from_source_array( $this->lineData()[1][0], new Sensei_Data_Port_Course_Schema(), $task );
+		$model        = Sensei_Import_Course_Model::from_source_array( 1, $this->lineData()[1][0], new Sensei_Data_Port_Course_Schema(), $task );
 		$result       = $model->sync_post();
 
 		$this->assertTrue( $result );
@@ -282,7 +282,7 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 	 */
 	public function testSyncPostFailsWhenAttachmentNotFound() {
 		$task   = new Sensei_Import_Courses( Sensei_Import_Job::create( 'test', 0 ) );
-		$model  = Sensei_Import_Course_Model::from_source_array( $this->lineData()[0][0], new Sensei_Data_Port_Course_Schema(), $task );
+		$model  = Sensei_Import_Course_Model::from_source_array( 1, $this->lineData()[0][0], new Sensei_Data_Port_Course_Schema(), $task );
 		$result = $model->sync_post();
 
 		$this->assertInstanceOf( 'WP_Error', $result );

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
@@ -32,6 +32,50 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test to make sure prerequisites are queued for processing after all other lines have been processed.
+	 */
+	public function testPrerequisiteQueued() {
+		$course_id = $this->factory->course->create(
+			[
+				'post_name' => 'the-last-course',
+			]
+		);
+		$job       = Sensei_Import_Job::create( 'test', 0 );
+		$task      = $this->getMockBuilder( Sensei_Import_Courses::class )
+						->setConstructorArgs( [ $job ] )
+						->setMethods( [ 'add_prerequisite_task' ] )
+						->getMock();
+
+		$data_a = [
+			Sensei_Data_Port_Course_Schema::COLUMN_ID    => '1234',
+			Sensei_Data_Port_Course_Schema::COLUMN_TITLE => 'Course title a',
+			Sensei_Data_Port_Course_Schema::COLUMN_SLUG  => 'the-last-course',
+			Sensei_Data_Port_Course_Schema::COLUMN_PREREQUISITE => 'slug:a-prereq-course',
+		];
+
+		$data_b = [
+			Sensei_Data_Port_Course_Schema::COLUMN_ID    => '1235',
+			Sensei_Data_Port_Course_Schema::COLUMN_TITLE => 'Course title b',
+			Sensei_Data_Port_Course_Schema::COLUMN_SLUG  => 'the-very-last-course',
+			Sensei_Data_Port_Course_Schema::COLUMN_PREREQUISITE => '',
+		];
+
+		$task->expects( $this->once() )
+			->method( 'add_prerequisite_task' )
+			->with(
+				$this->equalTo( $course_id ),
+				$this->equalTo( 'slug:a-prereq-course' ),
+				$this->equalTo( 1 )
+			);
+
+		$model_a = Sensei_Import_Course_Model::from_source_array( 1, $data_a, new Sensei_Data_Port_Course_Schema(), $task );
+		$model_a->sync_post();
+
+		$model_b = Sensei_Import_Course_Model::from_source_array( 2, $data_b, new Sensei_Data_Port_Course_Schema(), $task );
+		$model_b->sync_post();
+	}
+
+	/**
 	 * Returns an array with the data used by the tests. Each element is an array of line input data and expected
 	 * output following the format of Sensei_Data_Port_Course_Model::data.
 	 *

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
@@ -66,7 +66,7 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 			'type'                   => 'cool',
 		];
 
-		$model = Sensei_Import_Model_Mock::from_source_array( $data, new Sensei_Data_Port_Schema_Mock() );
+		$model = Sensei_Import_Model_Mock::from_source_array( 1, $data, new Sensei_Data_Port_Schema_Mock() );
 
 		$this->assertEquals( $data, $model->get_data() );
 		$this->assertTrue( $model->is_valid() );
@@ -90,7 +90,7 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 
 		$data['unknown_column'] = 1;
 
-		$model = Sensei_Import_Model_Mock::from_source_array( $data, new Sensei_Data_Port_Schema_Mock() );
+		$model = Sensei_Import_Model_Mock::from_source_array( 1, $data, new Sensei_Data_Port_Schema_Mock() );
 
 		$this->assertEquals( $expected, $model->get_data() );
 		$this->assertTrue( $model->is_valid() );
@@ -122,7 +122,7 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 
 		$data['unknown_column'] = 1;
 
-		$model = Sensei_Import_Model_Mock::from_source_array( $data, new Sensei_Data_Port_Schema_Mock() );
+		$model = Sensei_Import_Model_Mock::from_source_array( 1, $data, new Sensei_Data_Port_Schema_Mock() );
 
 		$this->assertEquals( $expected, $model->get_data() );
 		$this->assertFalse( $model->is_valid(), 'Type did not match a valid field so should invalidate the entry' );
@@ -139,7 +139,7 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 			'type'                   => 'cool',
 		];
 
-		$model = Sensei_Import_Model_Mock::from_source_array( $data, new Sensei_Data_Port_Schema_Mock() );
+		$model = Sensei_Import_Model_Mock::from_source_array( 1, $data, new Sensei_Data_Port_Schema_Mock() );
 
 		$property = new ReflectionProperty( 'Sensei_Import_Model', 'is_new' );
 		$property->setAccessible( true );

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
@@ -48,7 +48,7 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 			]
 		);
 
-		$model = Sensei_Import_Question_Model::from_source_array( $data, new Sensei_Data_Port_Question_Schema() );
+		$model = Sensei_Import_Question_Model::from_source_array( 1, $data, new Sensei_Data_Port_Question_Schema() );
 
 		$this->assertEquals( $post_id, $model->get_post_id() );
 	}
@@ -69,7 +69,7 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 			]
 		);
 
-		$model = Sensei_Import_Question_Model::from_source_array( $data, new Sensei_Data_Port_Question_Schema() );
+		$model = Sensei_Import_Question_Model::from_source_array( 1, $data, new Sensei_Data_Port_Question_Schema() );
 
 		$this->assertEquals( null, $model->get_post_id() );
 	}
@@ -224,7 +224,7 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 	 * @dataProvider lineData
 	 */
 	public function testInputIsSanitized( $input_line, $expected_model_content, $is_valid ) {
-		$model         = Sensei_Import_Question_Model::from_source_array( $input_line, new Sensei_Data_Port_Question_Schema() );
+		$model         = Sensei_Import_Question_Model::from_source_array( 1, $input_line, new Sensei_Data_Port_Question_Schema() );
 		$tested_fields = [
 			Sensei_Data_Port_Question_Schema::COLUMN_TITLE,
 			Sensei_Data_Port_Question_Schema::COLUMN_ANSWER,
@@ -265,7 +265,8 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 		$expected_data         = $this->lineData()['full'][1];
 		$expected_answer_order = implode( ',', [ md5( 'No' ), md5( 'Yes' ), md5( 'Maybe, it depends' ) ] );
 
-		$model  = Sensei_Import_Question_Model::from_source_array( $test_data, new Sensei_Data_Port_Question_Schema(), Sensei_Import_Job::create( 'test', 0 ) );
+		$task   = new Sensei_Import_Questions( Sensei_Import_Job::create( 'test', 0 ) );
+		$model  = Sensei_Import_Question_Model::from_source_array( 1, $test_data, new Sensei_Data_Port_Question_Schema(), $task );
 		$result = $model->sync_post();
 		$this->assertTrue( $result );
 
@@ -311,7 +312,8 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 			]
 		);
 
-		$model  = Sensei_Import_Question_Model::from_source_array( $test_data, new Sensei_Data_Port_Question_Schema(), Sensei_Import_Job::create( 'test', 0 ) );
+		$task   = new Sensei_Import_Questions( Sensei_Import_Job::create( 'test', 0 ) );
+		$model  = Sensei_Import_Question_Model::from_source_array( 1, $test_data, new Sensei_Data_Port_Question_Schema(), $task );
 		$result = $model->sync_post();
 		$this->assertTrue( $result );
 
@@ -341,7 +343,8 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 		$test_data     = $this->lineData()['valid-file-upload'][0];
 		$expected_data = $this->lineData()['valid-file-upload'][1];
 
-		$model  = Sensei_Import_Question_Model::from_source_array( $test_data, new Sensei_Data_Port_Question_Schema(), Sensei_Import_Job::create( 'test', 0 ) );
+		$task   = new Sensei_Import_Questions( Sensei_Import_Job::create( 'test', 0 ) );
+		$model  = Sensei_Import_Question_Model::from_source_array( 1, $test_data, new Sensei_Data_Port_Question_Schema(), $task );
 		$result = $model->sync_post();
 		$this->assertTrue( $result );
 
@@ -371,7 +374,8 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 		$test_data     = $this->lineData()['valid-boolean'][0];
 		$expected_data = $this->lineData()['valid-boolean'][1];
 
-		$model  = Sensei_Import_Question_Model::from_source_array( $test_data, new Sensei_Data_Port_Question_Schema(), Sensei_Import_Job::create( 'test', 0 ) );
+		$task   = new Sensei_Import_Questions( Sensei_Import_Job::create( 'test', 0 ) );
+		$model  = Sensei_Import_Question_Model::from_source_array( 1, $test_data, new Sensei_Data_Port_Question_Schema(), $task );
 		$result = $model->sync_post();
 		$this->assertTrue( $result );
 
@@ -401,7 +405,8 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 		$test_data     = $this->lineData()['valid-single-line'][0];
 		$expected_data = $this->lineData()['valid-single-line'][1];
 
-		$model  = Sensei_Import_Question_Model::from_source_array( $test_data, new Sensei_Data_Port_Question_Schema(), Sensei_Import_Job::create( 'test', 0 ) );
+		$task   = new Sensei_Import_Questions( Sensei_Import_Job::create( 'test', 0 ) );
+		$model  = Sensei_Import_Question_Model::from_source_array( 1, $test_data, new Sensei_Data_Port_Question_Schema(), $task );
 		$result = $model->sync_post();
 		$this->assertTrue( $result );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds post-processing ability to the file processor. Post-processing tasks happen in batches after all lines in the task file have been processed.
* Adds shared prerequisite post-processing tasks to match a prerequisite based on reference and associate them with the lesson or course in the appropriate post meta.
* Required Refactor: Pass line number and the task (instead of the job) to the models. This allowed us to log the line number and put shared logic for courses and lessons in the task level.
* Required Refactor: Move the `translate_import_id` method from the model to job class.
* Fix: Passing the "real" line number down so that the zero-index line number isn't logged for users.
* Known issue: These post-process tasks don't affect the progress of the import. Progress will hang while we handle these. It'd be a bit of a pain to fix this, but be we could probably figure out a way.

### Testing instructions

* Using Donna's test files, run the WP CLI command (filling in the parameters):
```
wp sensei-import --lessons=import/donna-lessons.csv --courses=import/donna-courses.csv --questions=import/donna-questions.csv --user=jake
```
* Verify prerequisites are stored when appropriate.
* Verify logs are added for bad prerequisites.