### PR TITLE
Add importer link in the setup wizard

### DIFF
--- a/assets/setup-wizard/ready/index.js
+++ b/assets/setup-wizard/ready/index.js
@@ -71,6 +71,25 @@ export const Ready = () => {
 								),
 							},
 							{
+								title: __( 'Import content', 'sensei-lms' ),
+								content: __(
+									'Transfer existing content to your site — just import a CSV file.',
+									'sensei-lms'
+								),
+								after: (
+									<Button
+										className="sensei-setup-wizard__button"
+										isSecondary
+										href="admin.php?page=sensei_import"
+										{ ...logLink(
+											'setup_wizard_ready_import_content'
+										) }
+									>
+										{ __( 'Import content', 'sensei-lms' ) }
+									</Button>
+								),
+							},
+							{
 								title: 'Learn more',
 								content: formatString(
 									__(

--- a/assets/setup-wizard/ready/index.js
+++ b/assets/setup-wizard/ready/index.js
@@ -63,7 +63,10 @@ export const Ready = () => {
 											'setup_wizard_ready_create_course'
 										) }
 									>
-										Create a course
+										{ __(
+											'Create a course',
+											'sensei-lms'
+										) }
 									</Button>
 								),
 							},


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add importer link in the setup wizard
  * I took the opportunity to also track this click with an event name: `sensei_setup_wizard_ready_import_content`
  * The button is different than the design because we were already using a different secondary button on the other screens.

I didn't add the button behind a feature flag because our next release will be with the Importer and it would demand some extra complexity.

### Testing instructions

* Go to the Ready step in the Setup Wizard.
* Click on the `Import content` button and make sure it goes to the importer.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="585" alt="Screen Shot 2020-07-01 at 10 49 39" src="https://user-images.githubusercontent.com/876340/86252472-a61c2f00-bb89-11ea-9944-e18c4ac0e5d5.png">
