### PR TITLE
Importer: Cast boolean-like strings to boolean

### DIFF
--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -116,7 +116,11 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 						$value = floatval( $value );
 						break;
 					case 'bool':
-						$value = boolval( $value );
+						if ( ! in_array( $value, [ '0', '1', 'true', 'false' ], true ) ) {
+							$value = null;
+						} else {
+							$value = in_array( $value, [ '1', 'true' ], true );
+						}
 						break;
 					case 'slug':
 						$value = sanitize_title( $value );

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
@@ -51,7 +51,7 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 					Sensei_Data_Port_Course_Schema::COLUMN_TEACHER_EMAIL    => 'em\<ail#@host.com',
 					Sensei_Data_Port_Course_Schema::COLUMN_MODULES          => '<randomtag>   First,Second   </randomtag>',
 					Sensei_Data_Port_Course_Schema::COLUMN_PREREQUISITE     => '<randomtag>prerequisite</randomtag>',
-					Sensei_Data_Port_Course_Schema::COLUMN_FEATURED         => '<randomtag>featured</randomtag>',
+					Sensei_Data_Port_Course_Schema::COLUMN_FEATURED         => 'true',
 					Sensei_Data_Port_Course_Schema::COLUMN_CATEGORIES       => '<randomtag>   First,Second   </randomtag>',
 					Sensei_Data_Port_Course_Schema::COLUMN_IMAGE            => 'localfilename.png',
 					Sensei_Data_Port_Course_Schema::COLUMN_VIDEO            => '<randomtag>video</randomtag>',
@@ -71,7 +71,7 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 					Sensei_Data_Port_Course_Schema::COLUMN_CATEGORIES       => 'First,Second',
 					Sensei_Data_Port_Course_Schema::COLUMN_IMAGE            => 'localfilename.png',
 					Sensei_Data_Port_Course_Schema::COLUMN_VIDEO            => 'video',
-					Sensei_Data_Port_Course_Schema::COLUMN_NOTIFICATIONS    => true,
+					Sensei_Data_Port_Course_Schema::COLUMN_NOTIFICATIONS    => null,
 				],
 			],
 			[
@@ -85,11 +85,11 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 					Sensei_Data_Port_Course_Schema::COLUMN_TEACHER_EMAIL    => 'otheremail@host.com',
 					Sensei_Data_Port_Course_Schema::COLUMN_MODULES          => 'Second,First',
 					Sensei_Data_Port_Course_Schema::COLUMN_PREREQUISITE     => 'Updated prerequisite',
-					Sensei_Data_Port_Course_Schema::COLUMN_FEATURED         => false,
+					Sensei_Data_Port_Course_Schema::COLUMN_FEATURED         => 'false',
 					Sensei_Data_Port_Course_Schema::COLUMN_CATEGORIES       => 'First,Third',
 					Sensei_Data_Port_Course_Schema::COLUMN_IMAGE            => 'updatedfilename.png',
 					Sensei_Data_Port_Course_Schema::COLUMN_VIDEO            => 'Updated video',
-					Sensei_Data_Port_Course_Schema::COLUMN_NOTIFICATIONS    => false,
+					Sensei_Data_Port_Course_Schema::COLUMN_NOTIFICATIONS    => 'false',
 				],
 				[
 					Sensei_Data_Port_Course_Schema::COLUMN_ID               => 'id',
@@ -155,7 +155,7 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 
 		foreach ( $tested_fields as $tested_field ) {
 			if ( isset( $expected_model_content[ $tested_field ] ) ) {
-				$this->assertEquals( $expected_model_content[ $tested_field ], $model->get_value( $tested_field ) );
+				$this->assertEquals( $expected_model_content[ $tested_field ], $model->get_value( $tested_field ), "Field {$tested_field} did not match the expected value" );
 			}
 		}
 	}

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
@@ -49,7 +49,7 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 					Sensei_Data_Port_Lesson_Schema::COLUMN_EXCERPT        => '<randomtag>excerpt</randomtag>',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_STATUS         => 'publish',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_PREREQUISITE   => '<randomtag>prerequisite</randomtag>',
-					Sensei_Data_Port_Lesson_Schema::COLUMN_PREVIEW        => 'preview',
+					Sensei_Data_Port_Lesson_Schema::COLUMN_PREVIEW        => 'badvalue',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_TAGS           => '<randomtag>   First,Second   </randomtag>',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_IMAGE          => 'localfilename.png',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_LENGTH         => '12',
@@ -71,7 +71,7 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 					Sensei_Data_Port_Lesson_Schema::COLUMN_EXCERPT        => 'excerpt',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_STATUS         => 'publish',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_PREREQUISITE   => 'prerequisite',
-					Sensei_Data_Port_Lesson_Schema::COLUMN_PREVIEW        => true,
+					Sensei_Data_Port_Lesson_Schema::COLUMN_PREVIEW        => null,
 					Sensei_Data_Port_Lesson_Schema::COLUMN_TAGS           => 'First,Second',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_IMAGE          => 'localfilename.png',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_LENGTH         => 12,
@@ -80,8 +80,8 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 					Sensei_Data_Port_Lesson_Schema::COLUMN_PASS_REQUIRED  => true,
 					Sensei_Data_Port_Lesson_Schema::COLUMN_PASSMARK       => 23,
 					Sensei_Data_Port_Lesson_Schema::COLUMN_NUM_QUESTIONS  => 0,
-					Sensei_Data_Port_Lesson_Schema::COLUMN_RANDOMIZE      => true,
-					Sensei_Data_Port_Lesson_Schema::COLUMN_AUTO_GRADE     => true,
+					Sensei_Data_Port_Lesson_Schema::COLUMN_RANDOMIZE      => false,
+					Sensei_Data_Port_Lesson_Schema::COLUMN_AUTO_GRADE     => false,
 					Sensei_Data_Port_Lesson_Schema::COLUMN_QUIZ_RESET     => true,
 					Sensei_Data_Port_Lesson_Schema::COLUMN_ALLOW_COMMENTS => true,
 				],
@@ -94,18 +94,18 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 					Sensei_Data_Port_Lesson_Schema::COLUMN_DESCRIPTION    => 'Updated description',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_EXCERPT        => 'Updated excerpt',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_STATUS         => 'draft',
-					Sensei_Data_Port_Lesson_Schema::COLUMN_PREVIEW        => false,
+					Sensei_Data_Port_Lesson_Schema::COLUMN_PREVIEW        => 'false',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_TAGS           => 'New First, New Second ',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_LENGTH         => 15,
 					Sensei_Data_Port_Lesson_Schema::COLUMN_COMPLEXITY     => 'hard',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_VIDEO          => 'Updated video',
-					Sensei_Data_Port_Lesson_Schema::COLUMN_PASS_REQUIRED  => false,
+					Sensei_Data_Port_Lesson_Schema::COLUMN_PASS_REQUIRED  => 'false',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_PASSMARK       => 0,
 					Sensei_Data_Port_Lesson_Schema::COLUMN_NUM_QUESTIONS  => 6,
-					Sensei_Data_Port_Lesson_Schema::COLUMN_RANDOMIZE      => false,
-					Sensei_Data_Port_Lesson_Schema::COLUMN_AUTO_GRADE     => false,
-					Sensei_Data_Port_Lesson_Schema::COLUMN_QUIZ_RESET     => false,
-					Sensei_Data_Port_Lesson_Schema::COLUMN_ALLOW_COMMENTS => false,
+					Sensei_Data_Port_Lesson_Schema::COLUMN_RANDOMIZE      => 'false',
+					Sensei_Data_Port_Lesson_Schema::COLUMN_AUTO_GRADE     => 'false',
+					Sensei_Data_Port_Lesson_Schema::COLUMN_QUIZ_RESET     => 'false',
+					Sensei_Data_Port_Lesson_Schema::COLUMN_ALLOW_COMMENTS => 'false',
 				],
 				[
 					Sensei_Data_Port_Lesson_Schema::COLUMN_ID             => 'id',
@@ -194,7 +194,7 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 
 		foreach ( $tested_fields as $tested_field ) {
 			if ( isset( $expected_model_content[ $tested_field ] ) ) {
-				$this->assertEquals( $expected_model_content[ $tested_field ], $model->get_value( $tested_field ) );
+				$this->assertEquals( $expected_model_content[ $tested_field ], $model->get_value( $tested_field ), "The field {$tested_field} did not match what was expected" );
 			}
 		}
 	}
@@ -558,7 +558,7 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 			$this->assertEquals( 'manual', get_post_meta( $quiz->ID, '_quiz_grade_type', true ) );
 		}
 
-		if ( true === (bool) $line_data[ Sensei_Data_Port_Lesson_Schema::COLUMN_AUTO_GRADE ] ) {
+		if ( true === (bool) $line_data[ Sensei_Data_Port_Lesson_Schema::COLUMN_QUIZ_RESET ] ) {
 			$this->assertEquals( 'on', get_post_meta( $quiz->ID, '_enable_quiz_reset', true ) );
 		} else {
 			$this->assertEmpty( get_post_meta( $quiz->ID, '_enable_quiz_reset', true ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Casts values of `"1"` and `"true"` to `true` and `"0"` and `"false"` to `false`. All other values are `null` and considered invalid.
 
### Testing instructions

* Import files with these as values for expected fields and verify they are translated to correct values.