### PR TITLE
Add passmark range validation

### DIFF
--- a/includes/data-port/models/class-sensei-data-port-lesson-schema.php
+++ b/includes/data-port/models/class-sensei-data-port-lesson-schema.php
@@ -102,7 +102,8 @@ class Sensei_Data_Port_Lesson_Schema extends Sensei_Data_Port_Schema {
 				'default' => false,
 			],
 			self::COLUMN_PASSMARK       => [
-				'type' => 'int',
+				'type'      => 'int',
+				'validator' => [ $this, 'validate_passmark' ],
 			],
 			self::COLUMN_NUM_QUESTIONS  => [
 				'type'    => 'int',
@@ -128,6 +129,23 @@ class Sensei_Data_Port_Lesson_Schema extends Sensei_Data_Port_Schema {
 				'type' => 'string',
 			],
 		];
+	}
+
+	/**
+	 * Validate passmark.
+	 *
+	 * @access private
+	 *
+	 * @param string                     $field Field name.
+	 * @param Sensei_Import_Lesson_Model $model Lesson model.
+	 *
+	 * @return boolean Is valid.
+	 */
+	public function validate_passmark( $field, Sensei_Import_Lesson_Model $model ) {
+		$data  = $model->get_data();
+		$value = $data[ $field ];
+
+		return 0 <= $value && 100 >= $value;
 	}
 
 	/**

--- a/includes/data-port/models/class-sensei-data-port-lesson-schema.php
+++ b/includes/data-port/models/class-sensei-data-port-lesson-schema.php
@@ -131,7 +131,7 @@ class Sensei_Data_Port_Lesson_Schema extends Sensei_Data_Port_Schema {
 	}
 
 	/**
-	 * Get question post type.
+	 * Get lesson post type.
 	 *
 	 * @return string
 	 */

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
@@ -200,6 +200,33 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests passmark validation.
+	 */
+	public function testPassmarkValidation() {
+		$lesson_data_with_invalid_minimum_passmark = [
+			Sensei_Data_Port_Lesson_Schema::COLUMN_TITLE => 'Required title',
+			Sensei_Data_Port_Lesson_Schema::COLUMN_PASSMARK => -1,
+		];
+		$lesson_data_with_invalid_maximum_passmark = [
+			Sensei_Data_Port_Lesson_Schema::COLUMN_TITLE => 'Required title',
+			Sensei_Data_Port_Lesson_Schema::COLUMN_PASSMARK => 101,
+		];
+		$lesson_data_with_valid_passmark           = [
+			Sensei_Data_Port_Lesson_Schema::COLUMN_TITLE => 'Required title',
+			Sensei_Data_Port_Lesson_Schema::COLUMN_PASSMARK => 50,
+		];
+
+		$model = Sensei_Import_Lesson_Model::from_source_array( $lesson_data_with_invalid_minimum_passmark, new Sensei_Data_Port_Lesson_Schema() );
+		$this->assertFalse( $model->is_valid() );
+
+		$model = Sensei_Import_Lesson_Model::from_source_array( $lesson_data_with_invalid_maximum_passmark, new Sensei_Data_Port_Lesson_Schema() );
+		$this->assertFalse( $model->is_valid() );
+
+		$model = Sensei_Import_Lesson_Model::from_source_array( $lesson_data_with_valid_passmark, new Sensei_Data_Port_Lesson_Schema() );
+		$this->assertTrue( $model->is_valid() );
+	}
+
+	/**
 	 * Tests creating a lesson and updating all its values.
 	 */
 	public function testLessonIsInsertedAndUpdated() {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add passmark range validations, accepting only numbers between `0` and `100`. 

### Testing instructions

* It doesn't appear on the screen yet, so I recommend test running the test or debugging the code.