### PR TITLE
Fix upload levels notice style

### DIFF
--- a/assets/data-port/import/upload-level/upload-level.js
+++ b/assets/data-port/import/upload-level/upload-level.js
@@ -88,37 +88,42 @@ export const UploadLevels = ( {
 					);
 				}
 
+				/* eslint-disable jsx-a11y/label-has-for */
 				return (
 					<li key={ level.key } className="sensei-upload-file-line">
-						<p className="sensei-upload-file-line__description">
-							{ level.description }
-						</p>
-						<FormFileUpload
-							// Include key to redraw after each upload attempt for onChange of the same file.
-							key={ levelState.isUploading }
-							isSecondary
-							accept={ [ '.csv', '.txt' ] }
-							disabled={
-								levelState.isUploading || levelState.isDeleting
-							}
-							onChange={ ( event ) =>
-								uploadFile(
-									jobId,
-									event.target.files,
-									level.key,
-									uploadFileForLevel,
-									throwEarlyUploadError
-								)
-							}
-						>
-							{ levelState.isUploading
-								? __( 'Uploading…', 'sensei-lms' )
-								: __( 'Upload', 'sensei-lms' ) }
-						</FormFileUpload>
+						<label className="sensei-upload-file-line__field-wrapper">
+							<span className="sensei-upload-file-line__description">
+								{ level.description }
+							</span>
+							<FormFileUpload
+								// Include key to redraw after each upload attempt for onChange of the same file.
+								key={ levelState.isUploading }
+								isSecondary
+								accept={ [ '.csv', '.txt' ] }
+								disabled={
+									levelState.isUploading ||
+									levelState.isDeleting
+								}
+								onChange={ ( event ) =>
+									uploadFile(
+										jobId,
+										event.target.files,
+										level.key,
+										uploadFileForLevel,
+										throwEarlyUploadError
+									)
+								}
+							>
+								{ levelState.isUploading
+									? __( 'Uploading…', 'sensei-lms' )
+									: __( 'Upload', 'sensei-lms' ) }
+							</FormFileUpload>
+						</label>
 						{ message }
 						{ deleteButton }
 					</li>
 				);
+				/* eslint-enable */
 			} ) }
 		</ol>
 	);

--- a/assets/data-port/import/upload/upload-page.scss
+++ b/assets/data-port/import/upload/upload-page.scss
@@ -1,16 +1,23 @@
 .sensei-upload-page {
 	.sensei-upload-file-line {
-		width: 100%;
-		display: inline-flex;
+		display: flex;
 		list-style-type: none;
 		margin: 0 -24px;
 		padding: 0 24px;
-		height: 62px;
+
+		@media (max-width: 783px) {
+			display: block;
+		}
+
+		&__field-wrapper {
+			display: flex;
+			flex: 0 0 43%;
+		}
 
 		&__description {
-			flex-basis: 25%;
-			margin: 18px 0;
-			flex-shrink: 0;
+			flex: 1;
+			margin: 24px 0;
+			font-size: 14px;
 		}
 
 		&__delete-button,
@@ -25,8 +32,7 @@
 		}
 
 		.components-form-file-upload {
-			flex-basis: 18%;
-			flex-shrink: 0;
+			flex: 0 0 120px;
 		}
 
 		.components-button {

--- a/assets/data-port/style.scss
+++ b/assets/data-port/style.scss
@@ -154,7 +154,7 @@ $alert-red: #d94f4f;
 				}
 
 				&__message {
-					margin: auto;
+					margin: 6px auto;
 				}
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes an issue with big error messages - more than 3 lines. (See screenshots)
* And I took the opportunity also to improve the uploads accessibility, adding the label tag.
* And I also added a class to improve the screen in small resolutions.

### Testing instructions

* Go to the importer.
* Upload a CSV with a lot of errors in any field. (I imported the lessons CSV in the courses field)

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Before the changes:
<img width="791" alt="Screen Shot 2020-07-01 at 17 08 53" src="https://user-images.githubusercontent.com/876340/86287808-40e33080-bbbf-11ea-8ef4-5e4f40248927.png">

After the changes:
<img width="822" alt="Screen Shot 2020-07-01 at 17 07 35" src="https://user-images.githubusercontent.com/876340/86287828-4a6c9880-bbbf-11ea-9b38-358808e71f7e.png">
