### PR TITLE
Importer: Attempt to convert encoding to UTF-8

### DIFF
--- a/tests/framework/data-port/data-files/test_csv_reader_latin1.csv
+++ b/tests/framework/data-port/data-files/test_csv_reader_latin1.csv
@@ -1,0 +1,3 @@
+"First Column","second column"
+"première","© Dinosaurs"
+"°äöüßÄÖÜâêáé","second data 2"

--- a/tests/unit-tests/data-port/test-class-sensei-import-csv-reader.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-csv-reader.php
@@ -123,6 +123,34 @@ class Sensei_Import_CSV_Reader_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that latin1 characters are converted to UTF-8.
+	 */
+	public function testEncodingIsNormalized() {
+		$file = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/test_csv_reader_latin1.csv';
+
+		$reader = new Sensei_Import_CSV_Reader( $file, 0, 4 );
+
+		$batch = $reader->read_lines();
+
+		$this->assertEquals(
+			[
+				'first column'  => 'première',
+				'second column' => '© Dinosaurs',
+			],
+			$batch[0]
+		);
+
+		$this->assertEquals(
+			[
+				'first column'  => '°äöüßÄÖÜâêáé',
+				'second column' => 'second data 2',
+			],
+			$batch[1]
+		);
+
+	}
+
+	/**
 	 * Test the values of various data lines.
 	 */
 	public function testValuesReturnedAreCorrect() {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Attempts to convert to UTF-8 when on a site with `blog_charset` set to `UTF-8` (the _vast_ majority of WordPress sites).
* If `mb_*` isn't available, it will strip out non-UTF-8 characters.

The strategy I used is modified form of what core uses in the private function `_wp_json_convert_string`. This is also a similar strategy that WooCommerce uses for their importer.

### Testing instructions

* Try various characters in other encoding types. Most should hopefully be converted to their UTF-8 counterparts.