### PR TITLE
Add import submenu tracking

### DIFF
--- a/assets/js/admin/event-logging.js
+++ b/assets/js/admin/event-logging.js
@@ -1,3 +1,12 @@
+// Used to add tracking to WP core elements, where we can't add custom code.
+const adminTracking = [
+	{
+		selector:
+			'#toplevel_page_sensei a[href="admin.php?page=sensei_import"]',
+		eventName: 'import_click',
+	},
+];
+
 window.sensei_log_event = function( event_name, properties ) {
 	if ( sensei_event_logging.enabled ) {
 		let data = {
@@ -11,9 +20,16 @@ window.sensei_log_event = function( event_name, properties ) {
 
 		jQuery.get( ajaxurl, data );
 	}
-}
+};
 
 jQuery( document ).ready( function( $ ) {
+	adminTracking.forEach( function( tracking ) {
+		$( tracking.selector ).attr(
+			'data-sensei-log-event',
+			tracking.eventName
+		);
+	} );
+
 	$( 'body' ).on( 'click', 'a[data-sensei-log-event]', function( event ) {
 		let sensei_event_name = $( event.target ).data( 'sensei-log-event' );
 		sensei_log_event( sensei_event_name );

--- a/assets/js/admin/event-logging.js
+++ b/assets/js/admin/event-logging.js
@@ -8,18 +8,36 @@ const adminTracking = [
 ];
 
 window.sensei_log_event = function( event_name, properties ) {
-	if ( sensei_event_logging.enabled ) {
-		let data = {
-			action: 'sensei_log_event',
-			event_name: event_name,
-		};
+	const actionName = 'sensei_log_event';
+
+	if ( ! sensei_event_logging.enabled ) {
+		return;
+	}
+
+	if ( navigator.sendBeacon ) {
+		const formData = new FormData();
+
+		formData.append( 'action', actionName );
+		formData.append( 'event_name', event_name );
 
 		if ( properties ) {
-			data.properties = properties;
+			formData.append( 'properties', JSON.stringify( properties ) );
 		}
 
-		jQuery.get( ajaxurl, data );
+		navigator.sendBeacon( ajaxurl, formData );
+		return;
 	}
+
+	let data = {
+		action: actionName,
+		event_name: event_name,
+	};
+
+	if ( properties ) {
+		data.properties = properties;
+	}
+
+	jQuery.get( ajaxurl, data );
 };
 
 jQuery( document ).ready( function( $ ) {

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1831,6 +1831,10 @@ class Sensei_Admin {
 		$event_name = $_REQUEST['event_name'];
 		$properties = isset( $_REQUEST['properties'] ) ? $_REQUEST['properties'] : [];
 
+		if ( is_string( $properties ) ) {
+			$properties = json_decode( stripslashes( $properties ), true );
+		}
+
 		// Set the source to js-event.
 		add_filter(
 			'sensei_event_logging_source',


### PR DESCRIPTION
Fixes #3112

### Changes proposed in this Pull Request

* Add import submenu tracking.
* This PR also introduces the `adminTracking` array to track WP core elements which we can't add custom code.
* Also refactor tracking script to use `sendBeacon` to be safer.
* To support older browsers, `jQuery.get` is used as the fallback method instead of `navigator.sendBeacon`.

### Testing instructions

* Go to Sensei LMS Settings.
* Make sure the `Enable usage tracking` checkbox is checked.
* Click in the `Sensei LMS > Import` menu.
* Make sure the event `sensei_import_click` was logged.