### PR TITLE
Add assets js files to the package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -36,6 +36,7 @@ var paths = {
 		'node_modules/select2/dist/js/select2.full.min.js',
 	],
 	packageContents: [
+		'assets/**/*.js',
 		'assets/dist/**/*',
 		'assets/vendor/**/*',
 		'changelog.txt',
@@ -96,7 +97,7 @@ gulp.task( 'build-unsafe', gulp.series( 'clean', 'webpack', 'vendor' ) );
 
 gulp.task( 'copy-package', function() {
 	return gulp
-		.src( paths.packageContents, { base: '.' } )
+		.src( paths.packageContents, { base: '.', ignore: '**/*.test.js' } )
 		.pipe( gulp.dest( paths.packageDir ) );
 } );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes the translation references in the http://translate.wordpress.org/
  * Our source files are used as reference in our pot files, but it wasn't in our package. This change add the `js` source files to our package.

### Testing instructions

* Run `gulp package` and make sure all assets JS are in the generated package.
  * Previously, the `build/sensei-lms/assets/setup-wizard` wasn't in the package, for example.