### PR TITLE
Update event name on import button from setup wizard

### DIFF
--- a/assets/setup-wizard/ready/index.js
+++ b/assets/setup-wizard/ready/index.js
@@ -82,7 +82,7 @@ export const Ready = () => {
 										isSecondary
 										href="admin.php?page=sensei_import"
 										{ ...logLink(
-											'setup_wizard_ready_import_content'
+											'setup_wizard_ready_import'
 										) }
 									>
 										{ __( 'Import content', 'sensei-lms' ) }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update event name on import button from setup wizard

### Testing instructions

* Make sure the Sensei logging is enabled.
* Go to the setup wizard.
* Go to the ready step.
* Click on `Import content` button and make sure the correct name was logged.