### PR TITLE
Importer: Add helper to allow for warnings during import

### DIFF
--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -159,7 +159,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	 * @param string $job_id  The job id.
 	 * @param int    $user_id The user id.
 	 *
-	 * @return Sensei_Data_Port_Job
+	 * @return static
 	 */
 	public static function create( $job_id, $user_id ) {
 		$job = new static( $job_id );

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -131,6 +131,8 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 	 * Create a data import job.
 	 *
 	 * @param int $user_id  The user which started the job.
+	 *
+	 * @return Sensei_Import_Job
 	 */
 	public function create_import_job( $user_id ) {
 		$job_id = md5( uniqid( '', true ) );

--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -74,6 +74,21 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 	}
 
 	/**
+	 * Add warning for a line.
+	 *
+	 * @param string $model_key   Model key.
+	 * @param int    $line_number Line number.
+	 * @param string $message     Warning message.
+	 * @param array  $log_data    Log data.
+	 */
+	public function add_line_warning( $model_key, $line_number, $message, $log_data = [] ) {
+		$log_data['line'] = $line_number;
+
+		$this->set_line_result( $model_key, $line_number, self::RESULT_WARNING );
+		$this->add_log_entry( $message, self::LOG_LEVEL_NOTICE, $log_data );
+	}
+
+	/**
 	 * Get the configuration for expected files.
 	 *
 	 * @return array {

--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -58,6 +58,8 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 	/**
 	 * Set a line result value.
 	 *
+	 * @access private
+	 *
 	 * @param string $model_key   Model key.
 	 * @param int    $line_number Line number.
 	 * @param int    $result      Result value from class constants RESULT_ERROR, RESULT_WARNING, RESULT_SUCCESS.
@@ -75,6 +77,8 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 
 	/**
 	 * Add warning for a line.
+	 *
+	 * @access private
 	 *
 	 * @param string $model_key   Model key.
 	 * @param int    $line_number Line number.

--- a/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
+++ b/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
@@ -203,7 +203,7 @@ abstract class Sensei_Import_File_Process_Task
 	 * @param int            $line_number  The line number in the file.
 	 * @param WP_Error|array $data         The current line as returned from Sensei_Import_CSV_Reader::read_lines().
 	 *
-	 * @return mixed
+	 * @return bool
 	 */
 	protected function process_line( $line_number, $data ) {
 		if ( empty( $data ) ) {

--- a/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
+++ b/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
@@ -238,7 +238,7 @@ abstract class Sensei_Import_File_Process_Task
 				)
 			);
 
-			$this->get_job()->increment_result( $model->get_model_key(), Sensei_Import_Job::RESULT_ERROR );
+			$this->get_job()->set_line_result( $model->get_model_key(), $line_number, Sensei_Import_Job::RESULT_ERROR );
 
 			return false;
 		}
@@ -255,12 +255,12 @@ abstract class Sensei_Import_File_Process_Task
 				)
 			);
 
-			$this->get_job()->increment_result( $model->get_model_key(), Sensei_Import_Job::RESULT_ERROR );
+			$this->get_job()->set_line_result( $model->get_model_key(), $line_number, Sensei_Import_Job::RESULT_ERROR );
 
 			return false;
 		}
 
-		$this->get_job()->increment_result( $model->get_model_key(), Sensei_Import_Job::RESULT_SUCCESS );
+		$this->get_job()->set_line_result( $model->get_model_key(), $line_number, Sensei_Import_Job::RESULT_SUCCESS );
 
 		return true;
 	}

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -198,6 +198,21 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 	}
 
 	/**
+	 * Add warning for a line in the model.
+	 *
+	 * @param string $message  Warning message.
+	 * @param array  $log_data Log data.
+	 */
+	protected function add_line_warning( $message, $log_data = [] ) {
+		$this->task->get_job()->add_line_warning(
+			$this->get_model_key(),
+			$this->line_number,
+			$message,
+			$this->get_error_data( $log_data )
+		);
+	}
+
+	/**
 	 * Stores an import id to the job.
 	 */
 	protected function store_import_id() {

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -71,7 +71,6 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 		return $self;
 	}
 
-
 	/**
 	 * Check to see if the post already exists in the database.
 	 *

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -125,8 +125,7 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 			}
 
 			if ( is_wp_error( $new_value ) ) {
-				return new WP_Error(
-					'sensei_import_question_meta_field_invalid',
+				$this->add_line_warning(
 					sprintf(
 						// translators: First placeholder is name of field, second placeholder is error returned.
 						__( 'Meta field "%1$s" is invalid: %2$s', 'sensei-lms' ),
@@ -134,6 +133,8 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 						$new_value->get_error_message()
 					)
 				);
+
+				continue;
 			}
 
 			$current_value = null;

--- a/includes/rest-api/class-sensei-rest-api-data-port-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-data-port-controller.php
@@ -320,7 +320,7 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 			'id'      => $job->get_job_id(),
 			'status'  => $job->get_status(),
 			'files'   => $job->get_files_data(),
-			'results' => $job->get_results(),
+			'results' => $job->get_result_counts(),
 		];
 	}
 

--- a/includes/rest-api/class-sensei-rest-api-import-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-import-controller.php
@@ -236,6 +236,11 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 		$schema = parent::get_item_schema();
 
 		$results_schema = [];
+		$result_keys    = [
+			'error',
+			'warning',
+			'success',
+		];
 
 		foreach ( Sensei_Import_Job::get_default_results() as $model_key => $results ) {
 			$results_schema[ $model_key ] = [
@@ -243,7 +248,7 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 				'properties' => [],
 			];
 
-			foreach ( $results as $result_key => $result ) {
+			foreach ( $result_keys as $result_key => $count ) {
 				$results_schema[ $model_key ]['properties'][ $result_key ] = [
 					// translators: %1$s placeholder is object type; %2$s is result descriptor (success, error).
 					'description' => sprintf( __( 'Number of %1$s items with %2$s result', 'sensei-lms' ), $model_key, $result_key ),

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
@@ -261,13 +261,13 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 			Sensei_Data_Port_Lesson_Schema::COLUMN_PASSMARK => 50,
 		];
 
-		$model = Sensei_Import_Lesson_Model::from_source_array( $lesson_data_with_invalid_minimum_passmark, new Sensei_Data_Port_Lesson_Schema() );
+		$model = Sensei_Import_Lesson_Model::from_source_array( 1, $lesson_data_with_invalid_minimum_passmark, new Sensei_Data_Port_Lesson_Schema() );
 		$this->assertFalse( $model->is_valid() );
 
-		$model = Sensei_Import_Lesson_Model::from_source_array( $lesson_data_with_invalid_maximum_passmark, new Sensei_Data_Port_Lesson_Schema() );
+		$model = Sensei_Import_Lesson_Model::from_source_array( 2, $lesson_data_with_invalid_maximum_passmark, new Sensei_Data_Port_Lesson_Schema() );
 		$this->assertFalse( $model->is_valid() );
 
-		$model = Sensei_Import_Lesson_Model::from_source_array( $lesson_data_with_valid_passmark, new Sensei_Data_Port_Lesson_Schema() );
+		$model = Sensei_Import_Lesson_Model::from_source_array( 3, $lesson_data_with_valid_passmark, new Sensei_Data_Port_Lesson_Schema() );
 		$this->assertTrue( $model->is_valid() );
 	}
 

--- a/tests/unit-tests/data-port/test-class-sensei-import-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-job.php
@@ -154,6 +154,39 @@ class Sensei_Import_Job_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test `Sensei_Import_Job::add_line_warning` marks line as having a warning and adds log entries.
+	 */
+	public function testAddLineWarning() {
+		$expected_results = $this->get_default_result_counts();
+		$job              = Sensei_Import_Job::create( 'test-job', 0 );
+		$this->assertEquals( $expected_results, $job->get_result_counts(), 'Should equal the default value' );
+
+		$expected_logs = [
+			[
+				'message' => 'Test warning A',
+				'level'   => Sensei_Import_Job::LOG_LEVEL_NOTICE,
+				'data'    => [
+					'line' => 1,
+				],
+			],
+			[
+				'message' => 'Test warning B',
+				'level'   => Sensei_Import_Job::LOG_LEVEL_NOTICE,
+				'data'    => [
+					'line' => 1,
+				],
+			],
+		];
+
+		$job->add_line_warning( Sensei_Import_Course_Model::MODEL_KEY, 1, $expected_logs[0]['message'] );
+		$job->add_line_warning( Sensei_Import_Course_Model::MODEL_KEY, 1, $expected_logs[1]['message'] );
+		$expected_results[ Sensei_Import_Course_Model::MODEL_KEY ]['warning']++;
+
+		$this->assertEquals( $expected_results, $job->get_result_counts(), 'Should have 1 warning' );
+		$this->assertEquals( $expected_logs, $job->get_logs() );
+	}
+
+	/**
 	 * Get a temporary file from a source file.
 	 *
 	 * @param string $file_path File to copy.

--- a/tests/unit-tests/data-port/test-class-sensei-import-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-job.php
@@ -123,22 +123,34 @@ class Sensei_Import_Job_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test incrementResult method.
+	 * Test set_line_result method.
 	 */
-	public function testIncrementResult() {
-		$expected_results = Sensei_Import_Job::get_default_results();
+	public function testSetLineResults() {
+		$expected_results = $this->get_default_result_counts();
 		$job              = Sensei_Import_Job::create( 'test-job', 0 );
-		$this->assertEquals( $expected_results, $job->get_results(), 'Should equal the default value' );
+		$this->assertEquals( $expected_results, $job->get_result_counts(), 'Should equal the default value' );
 
 		// Try incrementing a known result.
-		$job->increment_result( Sensei_Import_Course_Model::MODEL_KEY, Sensei_Import_Job::RESULT_SUCCESS );
-		$job->increment_result( Sensei_Import_Course_Model::MODEL_KEY, Sensei_Import_Job::RESULT_SUCCESS );
-		$expected_results[ Sensei_Import_Course_Model::MODEL_KEY ][ Sensei_Import_Job::RESULT_SUCCESS ] += 2;
-		$this->assertEquals( $expected_results, $job->get_results(), 'Should have the known result incremented by 2' );
+		$job->set_line_result( Sensei_Import_Course_Model::MODEL_KEY, 1, Sensei_Import_Job::RESULT_SUCCESS );
+		$job->set_line_result( Sensei_Import_Course_Model::MODEL_KEY, 1, Sensei_Import_Job::RESULT_SUCCESS );
 
-		// Try incrementing a known result.
-		$job->increment_result( Sensei_Import_Course_Model::MODEL_KEY, 'meh' );
-		$this->assertEquals( $expected_results, $job->get_results(), 'Should not have changed' );
+		$expected_results[ Sensei_Import_Course_Model::MODEL_KEY ]['success']++;
+		$this->assertEquals( $expected_results, $job->get_result_counts(), 'Should have the known result incremented by 1' );
+
+		$job->set_line_result( Sensei_Import_Course_Model::MODEL_KEY, 2, Sensei_Import_Job::RESULT_SUCCESS );
+		$expected_results[ Sensei_Import_Course_Model::MODEL_KEY ]['success']++;
+		$this->assertEquals( $expected_results, $job->get_result_counts(), 'Should have the known result incremented by 1' );
+
+		$job->set_line_result( Sensei_Import_Course_Model::MODEL_KEY, 2, Sensei_Import_Job::RESULT_WARNING );
+		$job->set_line_result( Sensei_Import_Course_Model::MODEL_KEY, 3, Sensei_Import_Job::RESULT_ERROR );
+		$expected_results[ Sensei_Import_Course_Model::MODEL_KEY ]['success']--;
+		$expected_results[ Sensei_Import_Course_Model::MODEL_KEY ]['error']++;
+		$expected_results[ Sensei_Import_Course_Model::MODEL_KEY ]['warning']++;
+
+		$this->assertEquals( $expected_results, $job->get_result_counts(), 'Line 2 should have moved the success to warning and a new line error' );
+
+		$job->set_line_result( Sensei_Import_Course_Model::MODEL_KEY, 3, Sensei_Import_Job::RESULT_SUCCESS );
+		$this->assertEquals( $expected_results, $job->get_result_counts(), 'Result should not have changed. Once an error always an error.' );
 	}
 
 	/**
@@ -155,5 +167,27 @@ class Sensei_Import_Job_Test extends WP_UnitTestCase {
 		file_put_contents( $tmp, file_get_contents( $file_path ) );
 
 		return $tmp;
+	}
+
+	/**
+	 * Get the default value for the result counts.
+	 *
+	 * @return array
+	 */
+	private function get_default_result_counts() {
+		$results     = Sensei_Import_Job::get_default_results();
+		$result_keys = [
+			'error',
+			'warning',
+			'success',
+		];
+
+		foreach ( $results as $model_key => $counts ) {
+			foreach ( $result_keys as $result_key ) {
+				$results[ $model_key ][ $result_key ] = 0;
+			}
+		}
+
+		return $results;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This doesn't implement the warning helper (except for in one example in Questions), but instead handles the refactor to allow for easier warnings.
* Refactors results handling so that lines with warnings are not included in the success counts.
* To do this, it now has to keep track of the result for each line. What it stores is pretty minimal, but might be something to revisit if we find it has performance implications.

I was going to have this be part of one big PR, but I'll actually add the rest of the warnings in the next PR just to split it up.

### Testing instructions

* Do a test import and check REST API result. Only warnings can come through bad meta in the questions file, but you can at least see the the errors/successes. 