### PR TITLE
Fix lesson passmark test

### DIFF
--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
@@ -261,13 +261,13 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 			Sensei_Data_Port_Lesson_Schema::COLUMN_PASSMARK => 50,
 		];
 
-		$model = Sensei_Import_Lesson_Model::from_source_array( $lesson_data_with_invalid_minimum_passmark, new Sensei_Data_Port_Lesson_Schema() );
+		$model = Sensei_Import_Lesson_Model::from_source_array( 1, $lesson_data_with_invalid_minimum_passmark, new Sensei_Data_Port_Lesson_Schema() );
 		$this->assertFalse( $model->is_valid() );
 
-		$model = Sensei_Import_Lesson_Model::from_source_array( $lesson_data_with_invalid_maximum_passmark, new Sensei_Data_Port_Lesson_Schema() );
+		$model = Sensei_Import_Lesson_Model::from_source_array( 1, $lesson_data_with_invalid_maximum_passmark, new Sensei_Data_Port_Lesson_Schema() );
 		$this->assertFalse( $model->is_valid() );
 
-		$model = Sensei_Import_Lesson_Model::from_source_array( $lesson_data_with_valid_passmark, new Sensei_Data_Port_Lesson_Schema() );
+		$model = Sensei_Import_Lesson_Model::from_source_array( 1, $lesson_data_with_valid_passmark, new Sensei_Data_Port_Lesson_Schema() );
 		$this->assertTrue( $model->is_valid() );
 	}
 


### PR DESCRIPTION
This PR just fixes the lesson passmark test adding the new param (line number) to the `Sensei_Import_Lesson_Model::from_source_array`