### PR TITLE
Add import attachments validation

### DIFF
--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -82,11 +82,8 @@ class Sensei_Data_Port_Utilities {
 				);
 			}
 
-			$attachment_id = $attachments[0];
-
-			$attachment_mime_type = get_post_mime_type( $attachment_id );
-			$file                 = get_attached_file( $attachment_id );
-			$valid_mime_type      = self::validate_file_mime_type( $attachment_mime_type, $allowed_mime_types, $file );
+			$attachment_id   = $attachments[0];
+			$valid_mime_type = self::validate_file_mime_type_by_attachment_id( $attachment_id, $allowed_mime_types );
 
 			if ( is_wp_error( $valid_mime_type ) ) {
 				return $valid_mime_type;
@@ -131,12 +128,9 @@ class Sensei_Data_Port_Utilities {
 			]
 		);
 
-		$attachment_id = $existing_attachment[0];
-
 		if ( ! empty( $existing_attachment ) ) {
-			$attachment_mime_type = get_post_mime_type( $attachment_id );
-			$file                 = get_attached_file( $attachment_id );
-			$valid_mime_type      = self::validate_file_mime_type( $attachment_mime_type, $allowed_mime_types, $file );
+			$attachment_id   = $existing_attachment[0];
+			$valid_mime_type = self::validate_file_mime_type_by_attachment_id( $attachment_id, $allowed_mime_types );
 
 			if ( is_wp_error( $valid_mime_type ) ) {
 				return $valid_mime_type;
@@ -206,6 +200,21 @@ class Sensei_Data_Port_Utilities {
 		wp_update_attachment_metadata( $attachment_id, wp_generate_attachment_metadata( $attachment_id, $file_path ) );
 
 		return $attachment_id;
+	}
+
+	/**
+	 * Validate file mime type by attachment ID.
+	 *
+	 * @param int   $attachment_id      Attachment ID.
+	 * @param array $allowed_mime_types Allowed mime types.
+	 *
+	 * @return true|WP_Error
+	 */
+	private static function validate_file_mime_type_by_attachment_id( $attachment_id, $allowed_mime_types = null ) {
+		$file_path   = get_attached_file( $attachment_id );
+		$wp_filetype = wp_check_filetype_and_ext( $file_path, basename( $file_path ) );
+
+		return self::validate_file_mime_type( $wp_filetype['type'], $allowed_mime_types, $file_path );
 	}
 
 	/**

--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -83,6 +83,13 @@ class Sensei_Data_Port_Utilities {
 			}
 
 			$attachment_id = $attachments[0];
+
+			$attachment_mime_type = get_post_mime_type( $attachment_id );
+			$valid_mime_type      = self::validate_file_mime_type( $attachment_mime_type, $allowed_mime_types, $source );
+
+			if ( is_wp_error( $valid_mime_type ) ) {
+				return $valid_mime_type;
+			}
 		} else {
 			// In case a local URL is provided, try to convert it to the attachment.
 			$attachment_id = attachment_url_to_postid( $source );

--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -200,6 +200,10 @@ class Sensei_Data_Port_Utilities {
 	 * @return true|WP_Error
 	 */
 	public static function validate_file_mime_type( $mime_type, $allowed_mime_types = null, $file_name = null ) {
+		if ( null === $allowed_mime_types ) {
+			return true;
+		}
+
 		$valid_mime_type  = $mime_type && in_array( $mime_type, $allowed_mime_types, true );
 		$valid_extensions = self::mime_types_extensions( $allowed_mime_types );
 

--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -85,7 +85,8 @@ class Sensei_Data_Port_Utilities {
 			$attachment_id = $attachments[0];
 
 			$attachment_mime_type = get_post_mime_type( $attachment_id );
-			$valid_mime_type      = self::validate_file_mime_type( $attachment_mime_type, $allowed_mime_types, $source );
+			$file                 = get_attached_file( $attachment_id );
+			$valid_mime_type      = self::validate_file_mime_type( $attachment_mime_type, $allowed_mime_types, $file );
 
 			if ( is_wp_error( $valid_mime_type ) ) {
 				return $valid_mime_type;
@@ -130,15 +131,18 @@ class Sensei_Data_Port_Utilities {
 			]
 		);
 
+		$attachment_id = $existing_attachment[0];
+
 		if ( ! empty( $existing_attachment ) ) {
-			$attachment_mime_type = get_post_mime_type( $existing_attachment[0] );
-			$valid_mime_type      = self::validate_file_mime_type( $attachment_mime_type, $allowed_mime_types, $external_url );
+			$attachment_mime_type = get_post_mime_type( $attachment_id );
+			$file                 = get_attached_file( $attachment_id );
+			$valid_mime_type      = self::validate_file_mime_type( $attachment_mime_type, $allowed_mime_types, $file );
 
 			if ( is_wp_error( $valid_mime_type ) ) {
 				return $valid_mime_type;
 			}
 
-			return $existing_attachment[0];
+			return $attachment_id;
 		}
 
 		/**

--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -156,14 +156,11 @@ class Sensei_Data_Port_Utilities {
 		$file_path = $upload_result['file'];
 		$file_url  = $upload_result['url'];
 
-		$wp_filetype = wp_check_filetype_and_ext( $file_path, basename( $file_path ) );
+		$wp_filetype     = wp_check_filetype_and_ext( $file_path, basename( $file_path ) );
+		$valid_mime_type = self::validate_file_mime_type( $wp_filetype['type'], $allowed_mime_types, $file_path );
 
-		if ( null !== $allowed_mime_types ) {
-			$valid_mime_type = self::validate_file_mime_type( $wp_filetype, $allowed_mime_types, $file_path );
-
-			if ( is_wp_error( $valid_mime_type ) ) {
-				return $valid_mime_type;
-			}
+		if ( is_wp_error( $valid_mime_type ) ) {
+			return $valid_mime_type;
 		}
 
 		$attachment_args = [
@@ -196,18 +193,18 @@ class Sensei_Data_Port_Utilities {
 	/**
 	 * Validate file mime type.
 	 *
-	 * @param array  $wp_filetype        File type returned from the function `wp_check_filetype_and_ext`.
+	 * @param string $mime_type          File mime type.
 	 * @param array  $allowed_mime_types Allowed mime types.
 	 * @param string $file_name          File name to validate by extension, as fallback for administrators.
 	 *
 	 * @return true|WP_Error
 	 */
-	public static function validate_file_mime_type( $wp_filetype, $allowed_mime_types, $file_name = null ) {
-		$valid_mime_type  = $wp_filetype['type'] && in_array( $wp_filetype['type'], $allowed_mime_types, true );
+	public static function validate_file_mime_type( $mime_type, $allowed_mime_types = null, $file_name = null ) {
+		$valid_mime_type  = $mime_type && in_array( $mime_type, $allowed_mime_types, true );
 		$valid_extensions = self::mime_types_extensions( $allowed_mime_types );
 
 		// If we cannot determine the type, allow check based on extension for administrators.
-		if ( ! $wp_filetype['type'] && current_user_can( 'unfiltered_upload' ) && null !== $file_name ) {
+		if ( ! $mime_type && current_user_can( 'unfiltered_upload' ) && null !== $file_name ) {
 			$valid_mime_type = in_array( pathinfo( $file_name, PATHINFO_EXTENSION ), $valid_extensions, true );
 		}
 

--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -124,6 +124,13 @@ class Sensei_Data_Port_Utilities {
 		);
 
 		if ( ! empty( $existing_attachment ) ) {
+			$attachment_mime_type = get_post_mime_type( $existing_attachment[0] );
+			$valid_mime_type      = self::validate_file_mime_type( $attachment_mime_type, $allowed_mime_types, $external_url );
+
+			if ( is_wp_error( $valid_mime_type ) ) {
+				return $valid_mime_type;
+			}
+
 			return $existing_attachment[0];
 		}
 

--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -167,7 +167,7 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 		if ( isset( $file_config['mime_types'] ) ) {
 			$wp_filetype = wp_check_filetype_and_ext( $tmp_file, $file_name, $file_config['mime_types'] );
 
-			$valid_mime_type = Sensei_Data_Port_Utilities::validate_file_mime_type( $wp_filetype, $file_config['mime_types'], $file_name );
+			$valid_mime_type = Sensei_Data_Port_Utilities::validate_file_mime_type( $wp_filetype['type'], $file_config['mime_types'], $file_name );
 
 			if ( is_wp_error( $valid_mime_type ) ) {
 				$valid_mime_type->add_data( [ 'status' => 400 ] );

--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -167,21 +167,11 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 		if ( isset( $file_config['mime_types'] ) ) {
 			$wp_filetype = wp_check_filetype_and_ext( $tmp_file, $file_name, $file_config['mime_types'] );
 
-			$valid_mime_type  = $wp_filetype['type'] && in_array( $wp_filetype['type'], $file_config['mime_types'], true );
-			$valid_extensions = $this->mime_types_extensions( $file_config['mime_types'] );
+			$valid_mime_type = Sensei_Data_Port_Utilities::validate_file_mime_type( $wp_filetype, $file_config['mime_types'], $file_name );
 
-			// If we cannot determine the type, allow check based on extension for administrators.
-			if ( ! $wp_filetype['type'] && current_user_can( 'unfiltered_upload' ) ) {
-				$valid_mime_type = in_array( pathinfo( $file_name, PATHINFO_EXTENSION ), $valid_extensions, true );
-			}
-
-			if ( ! $valid_mime_type ) {
-				return new WP_Error(
-					'sensei_data_port_unexpected_file_type',
-					// translators: Placeholder is list of file extensions.
-					sprintf( __( 'File type is not supported. Must be one of the following: %s.', 'sensei-lms' ), implode( ', ', $valid_extensions ) ),
-					[ 'status' => 400 ]
-				);
+			if ( is_wp_error( $valid_mime_type ) ) {
+				$valid_mime_type->add_data( [ 'status' => 400 ] );
+				return $valid_mime_type;
 			}
 		}
 
@@ -193,22 +183,6 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 		}
 
 		return true;
-	}
-
-	/**
-	 * Get an array of extensions.
-	 *
-	 * @param array $mime_types Array of mime types.
-	 *
-	 * @return array Array of valid extensions.
-	 */
-	private function mime_types_extensions( $mime_types ) {
-		$extensions = [];
-		foreach ( array_keys( $mime_types ) as $ext_list ) {
-			$extensions = array_merge( $extensions, explode( '|', $ext_list ) );
-		}
-
-		return array_unique( $extensions );
 	}
 
 	/**

--- a/includes/data-port/models/class-sensei-data-port-course-schema.php
+++ b/includes/data-port/models/class-sensei-data-port-course-schema.php
@@ -73,7 +73,8 @@ class Sensei_Data_Port_Course_Schema extends Sensei_Data_Port_Schema {
 				'type' => 'string',
 			],
 			self::COLUMN_IMAGE            => [
-				'type' => 'url-or-file',
+				'type'       => 'url-or-file',
+				'mime_types' => $this->get_allowed_mime_types( 'image' ),
 			],
 			self::COLUMN_VIDEO            => [
 				'type' => 'video',

--- a/includes/data-port/models/class-sensei-data-port-lesson-schema.php
+++ b/includes/data-port/models/class-sensei-data-port-lesson-schema.php
@@ -85,7 +85,8 @@ class Sensei_Data_Port_Lesson_Schema extends Sensei_Data_Port_Schema {
 				'type' => 'string',
 			],
 			self::COLUMN_IMAGE          => [
-				'type' => 'url-or-file',
+				'type'       => 'url-or-file',
+				'mime_types' => $this->get_allowed_mime_types( 'image' ),
 			],
 			self::COLUMN_LENGTH         => [
 				'type' => 'int',

--- a/includes/data-port/models/class-sensei-data-port-question-schema.php
+++ b/includes/data-port/models/class-sensei-data-port-question-schema.php
@@ -100,7 +100,8 @@ class Sensei_Data_Port_Question_Schema extends Sensei_Data_Port_Schema {
 				'default' => true,
 			],
 			self::COLUMN_MEDIA           => [
-				'type' => 'url-or-file',
+				'type'       => 'url-or-file',
+				'mime_types' => $this->get_allowed_mime_types(),
 			],
 			self::COLUMN_CATEGORIES      => [
 				'type' => 'string',

--- a/includes/data-port/models/class-sensei-data-port-schema.php
+++ b/includes/data-port/models/class-sensei-data-port-schema.php
@@ -109,4 +109,24 @@ abstract class Sensei_Data_Port_Schema {
 			)
 		);
 	}
+
+	/**
+	 * Get allowed mime types.
+	 *
+	 * @param string $filter_type Filter to get the allowed mime types filtered by a specific type.
+	 *
+	 * @return array Allowed mime types.
+	 */
+	protected function get_allowed_mime_types( $filter_type = null ) {
+		if ( null === $filter_type ) {
+			return get_allowed_mime_types();
+		}
+
+		return array_filter(
+			get_allowed_mime_types(),
+			function( $mime_type ) use ( $filter_type ) {
+				return 0 === strpos( $mime_type, $filter_type );
+			}
+		);
+	}
 }

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -186,7 +186,7 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 		if ( '' === $thumbnail ) {
 			delete_post_meta( $post_id, '_thumbnail_id' );
 		} else {
-			$attachment_id = Sensei_Data_Port_Utilities::get_attachment_from_source( $thumbnail );
+			$attachment_id = Sensei_Data_Port_Utilities::get_attachment_from_source( $thumbnail, 0, $this->schema->get_schema()[ $column_name ]['mime_types'] );
 
 			if ( is_wp_error( $attachment_id ) ) {
 				return $attachment_id;

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -183,7 +183,9 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 	 * @return null|string
 	 */
 	private function get_question_media_value() {
-		$value = $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_MEDIA );
+		$column_name = Sensei_Data_Port_Question_Schema::COLUMN_MEDIA;
+
+		$value = $this->get_value( $column_name );
 		if ( null === $value ) {
 			return null;
 		}
@@ -192,7 +194,7 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 			return '';
 		}
 
-		return Sensei_Data_Port_Utilities::get_attachment_from_source( $value, $this->get_post_id() );
+		return Sensei_Data_Port_Utilities::get_attachment_from_source( $value, $this->get_post_id(), $this->schema->get_schema()[ $column_name ]['mime_types'] );
 	}
 
 	/**

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
@@ -359,6 +359,28 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that if a file has been already uploaded from an external url, but the mime type is invalid.
+	 */
+	public function testAttachmentFailsWhenExistantMimeTypeIsInvalid() {
+		$thumbnail_id = $this->factory->attachment->create(
+			[
+				'file'           => 'existant-file.png',
+				'post_mime_type' => 'image/png',
+			]
+		);
+		$external_url = 'http://anexternalurl.com/files/downloaded-file.png';
+		update_post_meta( $thumbnail_id, '_sensei_attachment_source_key', md5( $external_url ) );
+
+		$allowed_mime_types = [
+			'jpg|jpeg|jpe' => 'image/jpeg',
+		];
+
+		$result = Sensei_Data_Port_Utilities::get_attachment_from_source( $external_url, 0, $allowed_mime_types );
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( 'sensei_data_port_unexpected_file_type', $result->get_error_code() );
+	}
+
+	/**
 	 * Tests that a file is uploaded and an attachment is created if the HTTP call is successful.
 	 */
 	public function testAttachmentIsCreatedWhenHTTPCallSuccessful() {

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
@@ -323,16 +323,10 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that an error is returned when mime type is invalid.
+	 * Tests attachment mime type validation for existant local file.
 	 */
-	public function testAttachmentMimeType() {
-		$thumbnail_id = $this->factory->attachment->create(
-			[
-				'file'           => 'existant-file.png',
-				'post_mime_type' => 'image/png',
-			]
-		);
-
+	public function testExistantLocalAttachmentMimeTypeValidation() {
+		$thumbnail_id       = $this->factory->attachment->create( [ 'file' => 'existant-file.png' ] );
 		$allowed_mime_types = [
 			'jpg|jpeg|jpe' => 'image/jpeg',
 		];
@@ -340,12 +334,19 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 		$result = Sensei_Data_Port_Utilities::get_attachment_from_source( 'existant-file.png', 0, $allowed_mime_types );
 		$this->assertInstanceOf( 'WP_Error', $result );
 		$this->assertEquals( 'sensei_data_port_unexpected_file_type', $result->get_error_code() );
+
+		$allowed_mime_types = [
+			'png' => 'image/png',
+		];
+
+		$result = Sensei_Data_Port_Utilities::get_attachment_from_source( 'existant-file.png', 0, $allowed_mime_types );
+		$this->assertEquals( $thumbnail_id, $result );
 	}
 
 	/**
-	 * Tests that an error is returned when mime type is invalid.
+	 * Tests attachment mime type validation for external file.
 	 */
-	public function testExternalAttachmentMimeType() {
+	public function testExternalAttachmentMimeTypeValidation() {
 		tests_add_filter(
 			'pre_http_request',
 			function() {
@@ -358,10 +359,6 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 			}
 		);
 
-		$allowed_mime_types = [
-			'jpg|jpeg|jpe' => 'image/jpeg',
-		];
-
 		tests_add_filter(
 			'wp_check_filetype_and_ext',
 			function() {
@@ -373,21 +370,27 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 			}
 		);
 
+		$allowed_mime_types = [
+			'jpg|jpeg|jpe' => 'image/jpeg',
+		];
+
 		$result = Sensei_Data_Port_Utilities::get_attachment_from_source( 'http://anexternalurl.com/files/downloaded-file.png', 0, $allowed_mime_types );
 		$this->assertInstanceOf( 'WP_Error', $result );
 		$this->assertEquals( 'sensei_data_port_unexpected_file_type', $result->get_error_code() );
+
+		$allowed_mime_types = [
+			'png' => 'image/png',
+		];
+
+		$result = Sensei_Data_Port_Utilities::get_attachment_from_source( 'http://anexternalurl.com/files/downloaded-file.png', 0, $allowed_mime_types );
+		$this->assertTrue( is_int( $result ) );
 	}
 
 	/**
-	 * Tests that if a file has been already uploaded from an external url, but the mime type is invalid.
+	 * Tests attachment mime type validation for existant external file.
 	 */
-	public function testAttachmentFailsWhenExistantMimeTypeIsInvalid() {
-		$thumbnail_id = $this->factory->attachment->create(
-			[
-				'file'           => 'existant-file.png',
-				'post_mime_type' => 'image/png',
-			]
-		);
+	public function testExistantExternalAttachmentMimeTypeValidation() {
+		$thumbnail_id = $this->factory->attachment->create( [ 'file' => 'existant-file.png' ] );
 		$external_url = 'http://anexternalurl.com/files/downloaded-file.png';
 		update_post_meta( $thumbnail_id, '_sensei_attachment_source_key', md5( $external_url ) );
 
@@ -398,6 +401,13 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 		$result = Sensei_Data_Port_Utilities::get_attachment_from_source( $external_url, 0, $allowed_mime_types );
 		$this->assertInstanceOf( 'WP_Error', $result );
 		$this->assertEquals( 'sensei_data_port_unexpected_file_type', $result->get_error_code() );
+
+		$allowed_mime_types = [
+			'png' => 'image/png',
+		];
+
+		$result = Sensei_Data_Port_Utilities::get_attachment_from_source( $external_url, 0, $allowed_mime_types );
+		$this->assertEquals( $thumbnail_id, $result );
 	}
 
 	/**
@@ -426,31 +436,21 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that a file with accepted mimetype returns true.
+	 * Tests mime type validation.
 	 */
-	public function testMimeTypeValid() {
-		$external_url = 'http://anexternalurl.com/files/new-file.png';
-
+	public function testMimeTypeValidation() {
+		$file_name          = '/new-file.png';
 		$allowed_mime_types = [
 			'png' => 'image/png',
 		];
-
-		$is_valid = Sensei_Data_Port_Utilities::validate_file_mime_type( 'image/png', $allowed_mime_types, $external_url );
+		$is_valid           = Sensei_Data_Port_Utilities::validate_file_mime_type( 'image/png', $allowed_mime_types, $file_name );
 
 		$this->assertTrue( $is_valid );
-	}
-
-	/**
-	 * Tests that a file with not accepted mimetype returns an error.
-	 */
-	public function testMimeTypeInvalid() {
-		$external_url = 'http://anexternalurl.com/files/new-file.png';
 
 		$allowed_mime_types = [
 			'jpg|jpeg|jpe' => 'image/jpeg',
 		];
-
-		$is_valid = Sensei_Data_Port_Utilities::validate_file_mime_type( 'image/png', $allowed_mime_types, $external_url );
+		$is_valid           = Sensei_Data_Port_Utilities::validate_file_mime_type( 'image/png', $allowed_mime_types, $file_name );
 
 		$this->assertInstanceOf( 'WP_Error', $is_valid );
 	}

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
@@ -319,7 +319,7 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 
 		$result = Sensei_Data_Port_Utilities::get_attachment_from_source( 'http://anexternalurl.com/files/downloaded-file.png' );
 		$this->assertInstanceOf( 'WP_Error', $result );
-		$this->assertEquals( 'error_code', $result->get_error_code() );
+		$this->assertEquals( 'sensei_data_port_attachment_failure', $result->get_error_code() );
 	}
 
 	/**
@@ -329,7 +329,12 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 		tests_add_filter(
 			'pre_http_request',
 			function() {
-				return [ 'body' => 'random content' ];
+				return [
+					'body'     => 'random content',
+					'response' => [
+						'code' => 200,
+					],
+				];
 			}
 		);
 

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
@@ -389,17 +389,11 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 	public function testMimeTypeValid() {
 		$external_url = 'http://anexternalurl.com/files/new-file.png';
 
-		$wp_filetype = [
-			'ext'             => 'png',
-			'type'            => 'image/png',
-			'proper_filename' => false,
-		];
-
 		$allowed_mime_types = [
 			'png' => 'image/png',
 		];
 
-		$is_valid = Sensei_Data_Port_Utilities::validate_file_mime_type( $wp_filetype, $allowed_mime_types, $external_url );
+		$is_valid = Sensei_Data_Port_Utilities::validate_file_mime_type( 'image/png', $allowed_mime_types, $external_url );
 
 		$this->assertTrue( $is_valid );
 	}
@@ -410,17 +404,11 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 	public function testMimeTypeInvalid() {
 		$external_url = 'http://anexternalurl.com/files/new-file.png';
 
-		$wp_filetype = [
-			'ext'             => 'png',
-			'type'            => 'image/png',
-			'proper_filename' => false,
-		];
-
 		$allowed_mime_types = [
 			'jpg|jpeg|jpe' => 'image/jpeg',
 		];
 
-		$is_valid = Sensei_Data_Port_Utilities::validate_file_mime_type( $wp_filetype, $allowed_mime_types, $external_url );
+		$is_valid = Sensei_Data_Port_Utilities::validate_file_mime_type( 'image/png', $allowed_mime_types, $external_url );
 
 		$this->assertInstanceOf( 'WP_Error', $is_valid );
 	}

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
@@ -325,7 +325,27 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that an error is returned when mime type is invalid.
 	 */
-	public function testAttachmentCreationFailsWhenMimeTypeIsInvalid() {
+	public function testAttachmentMimeType() {
+		$thumbnail_id = $this->factory->attachment->create(
+			[
+				'file'           => 'existant-file.png',
+				'post_mime_type' => 'image/png',
+			]
+		);
+
+		$allowed_mime_types = [
+			'jpg|jpeg|jpe' => 'image/jpeg',
+		];
+
+		$result = Sensei_Data_Port_Utilities::get_attachment_from_source( 'existant-file.png', 0, $allowed_mime_types );
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( 'sensei_data_port_unexpected_file_type', $result->get_error_code() );
+	}
+
+	/**
+	 * Tests that an error is returned when mime type is invalid.
+	 */
+	public function testExternalAttachmentMimeType() {
 		tests_add_filter(
 			'pre_http_request',
 			function() {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add import attachments validation.

### Testing instructions

* Create import files to courses, lessons, and questions.
* Try to import courses/lessons with video/audio files. It should accept only images.
* Also try to import files from a not found URL.
* Check the logs after the process to see if it got the errors of invalid formats and not found image.