### PR TITLE
Fix/add random string quiz upload

### DIFF
--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -59,7 +59,7 @@ class Sensei_Grading_User_Quiz {
 	 * @since  1.3.0
 	 * @return array
 	 */
-	private function build_data_array() {
+	public function build_data_array() {
 		return Sensei_Utils::sensei_get_quiz_questions( $this->quiz_id );
 	}
 

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -64,6 +64,23 @@ class Sensei_Grading_User_Quiz {
 	}
 
 	/**
+	 * Helper method which removes the hash from a filename if it starts with one.
+	 *
+	 * @param string $filename  The filename.
+	 *
+	 * @return string
+	 */
+	public static function remove_hash_prefix( $filename ) {
+		$starts_with_hash = preg_match( '/^[a-f0-9]{32}_/', $filename );
+
+		if ( $starts_with_hash ) {
+			return substr( $filename, 33 );
+		}
+
+		return $filename;
+	}
+
+	/**
 	 * Display output to the admin view
 	 *
 	 * This view is shown when grading a quiz for a single user in admin under grading
@@ -181,7 +198,7 @@ class Sensei_Grading_User_Quiz {
 							if ( 0 < intval( $attachment_id ) ) {
 								$answer_media_url      = wp_get_attachment_url( $attachment_id );
 								$filename_raw          = basename( $answer_media_url );
-								$answer_media_filename = preg_match( '/^[a-f0-9]{32}_/', $filename_raw ) ? substr( $filename_raw, 33 ) : $filename_raw;
+								$answer_media_filename = self::remove_hash_prefix( $filename_raw );
 
 								if ( $answer_media_url && $answer_media_filename ) {
 									// translators: Placeholder %1$s is a link to the submitted file.

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -1,6 +1,12 @@
 <?php
+/**
+ * File containing the Sensei_Grading_User_Quiz class.
+ *
+ * @package sensei
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 /**
@@ -12,32 +18,50 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.3.0
  */
 class Sensei_Grading_User_Quiz {
-	public $user_id;
-	public $lesson_id;
-	public $quiz_id;
+	/**
+	 * The user id which this quiz is for.
+	 *
+	 * @var int
+	 */
+	private $user_id;
 
 	/**
-	 * Constructor
+	 * The lesson id which the quiz belongs to.
+	 *
+	 * @var int
+	 */
+	private $lesson_id;
+
+	/**
+	 * The quiz id.
+	 *
+	 * @var int
+	 */
+	private $quiz_id;
+
+	/**
+	 * Sensei_Grading_User_Quiz constructor.
 	 *
 	 * @since  1.3.0
+	 *
+	 * @param int $user_id  The user id.
+	 * @param int $quiz_id  The quiz id.
 	 */
 	public function __construct( $user_id = 0, $quiz_id = 0 ) {
 		$this->user_id   = intval( $user_id );
 		$this->quiz_id   = intval( $quiz_id );
 		$this->lesson_id = get_post_meta( $this->quiz_id, '_quiz_lesson', true );
-	} // End __construct()
+	}
 
 	/**
-	 * build_data_array builds the data for use on the page
-	 * Overloads the parent method
+	 * Builds the data for use on the page.
 	 *
 	 * @since  1.3.0
 	 * @return array
 	 */
-	public function build_data_array() {
-		$data_array = Sensei_Utils::sensei_get_quiz_questions( $this->quiz_id );
-		return $data_array;
-	} // End build_data_array()
+	private function build_data_array() {
+		return Sensei_Utils::sensei_get_quiz_questions( $this->quiz_id );
+	}
 
 	/**
 	 * Display output to the admin view
@@ -45,10 +69,9 @@ class Sensei_Grading_User_Quiz {
 	 * This view is shown when grading a quiz for a single user in admin under grading
 	 *
 	 * @since  1.3.0
-	 * @return html
 	 */
 	public function display() {
-		// Get data for the user
+		// Get data for the user.
 		$questions = $this->build_data_array();
 
 		$count                 = 0;
@@ -152,9 +175,9 @@ class Sensei_Grading_User_Quiz {
 						$type_name  = __( 'File Upload', 'sensei-lms' );
 						$grade_type = 'manual-grade';
 
-						// Get uploaded file
+						// Get uploaded file.
 						if ( $user_answer_content ) {
-							$attachment_id    = $user_answer_content;
+							$attachment_id = $user_answer_content;
 							if ( 0 < intval( $attachment_id ) ) {
 								$answer_media_url      = wp_get_attachment_url( $attachment_id );
 								$filename_raw          = basename( $answer_media_url );
@@ -170,7 +193,7 @@ class Sensei_Grading_User_Quiz {
 						}
 						break;
 					default:
-						// Nothing
+						// Nothing.
 						break;
 				}
 
@@ -260,7 +283,7 @@ class Sensei_Grading_User_Quiz {
 							<?php
 							foreach ( $right_answer as $_right_answer ) {
 
-								if ( 'multi-line' == Sensei()->question->get_question_type( $question->ID ) ) {
+								if ( 'multi-line' === Sensei()->question->get_question_type( $question->ID ) ) {
 									$_right_answer = htmlspecialchars_decode( nl2br( $_right_answer ) );
 								}
 
@@ -282,12 +305,12 @@ class Sensei_Grading_User_Quiz {
 
 			$quiz_grade = intval( $user_quiz_grade );
 			$all_graded = 'no';
-			if ( intval( $count ) == intval( $graded_count ) ) {
+			if ( intval( $count ) === intval( $graded_count ) ) {
 				$all_graded = 'yes';
 			}
 
 			?>
-		  <input type="hidden" name="total_grade" id="total_grade" value="<?php echo esc_attr( $user_quiz_grade_total ); ?>" />
+			<input type="hidden" name="total_grade" id="total_grade" value="<?php echo esc_attr( $user_quiz_grade_total ); ?>" />
 			<input type="hidden" name="total_questions" id="total_questions" value="<?php echo esc_attr( $count ); ?>" />
 			<input type="hidden" name="quiz_grade_total" id="quiz_grade_total" value="<?php echo esc_attr( $quiz_grade_total ); ?>" />
 			<input type="hidden" name="total_graded_questions" id="total_graded_questions" value="<?php echo esc_attr( $graded_count ); ?>" />
@@ -310,9 +333,8 @@ class Sensei_Grading_User_Quiz {
 			</script>
 		</form>
 		<?php
-	} // End display()
-
-} // End Class
+	}
+}
 
 /**
  * Class WooThemes_Sensei_Grading_User_Quiz

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -155,10 +155,11 @@ class Sensei_Grading_User_Quiz {
 						// Get uploaded file
 						if ( $user_answer_content ) {
 							$attachment_id    = $user_answer_content;
-							$answer_media_url = $answer_media_filename = '';
 							if ( 0 < intval( $attachment_id ) ) {
 								$answer_media_url      = wp_get_attachment_url( $attachment_id );
-								$answer_media_filename = basename( $answer_media_url );
+								$filename_raw          = basename( $answer_media_url );
+								$answer_media_filename = preg_match( '/^[a-f0-9]{32}_/', $filename_raw ) ? substr( $filename_raw, 33 ) : $filename_raw;
+
 								if ( $answer_media_url && $answer_media_filename ) {
 									// translators: Placeholder %1$s is a link to the submitted file.
 									$user_answer_content = sprintf( __( 'Submitted file: %1$s', 'sensei-lms' ), '<a href="' . esc_url( $answer_media_url ) . '" target="_blank">' . esc_html( $answer_media_filename ) . '</a>' );

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -128,8 +128,8 @@ class Sensei_Grading {
 	 * @return object                 class instance object
 	 */
 	public function load_data_object( $name = '', $data = 0, $optional_data = null ) {
-		// User constructors directly.
-		_deprecated_function( __METHOD__, '2.0.0' );
+		// Use constructors directly.
+		_deprecated_function( __METHOD__, '3.3.0', 'new Sensei_Grading_{$name}' );
 
 		// Load Analysis data
 		$object_name = 'Sensei_Grading_' . $name;

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -120,12 +120,17 @@ class Sensei_Grading {
 	 * load_data_object creates new instance of class
 	 *
 	 * @since  1.3.0
+	 * @deprecated 3.3.0  Use constructors instead.
+	 *
 	 * @param  string    $name          Name of class
 	 * @param  integer   $data          constructor arguments
 	 * @param  undefined $optional_data optional constructor arguments
 	 * @return object                 class instance object
 	 */
 	public function load_data_object( $name = '', $data = 0, $optional_data = null ) {
+		// User constructors directly.
+		_deprecated_function( __METHOD__, '2.0.0' );
+
 		// Load Analysis data
 		$object_name = 'Sensei_Grading_' . $name;
 		if ( is_null( $optional_data ) ) {
@@ -181,7 +186,9 @@ class Sensei_Grading {
 		if ( ! empty( $_GET['view'] ) ) {
 			$view = esc_html( $_GET['view'] );
 		}
-		$sensei_grading_overview = $this->load_data_object( 'Main', compact( 'course_id', 'lesson_id', 'user_id', 'view' ) );
+
+		$sensei_grading_overview = new Sensei_Grading_Main( compact( 'course_id', 'lesson_id', 'user_id', 'view' ) );
+		$sensei_grading_overview->prepare_items();
 
 		// Wrappers
 		do_action( 'grading_before_container' );
@@ -218,7 +225,9 @@ class Sensei_Grading {
 		if ( isset( $_GET['quiz_id'] ) ) {
 			$quiz_id = intval( $_GET['quiz_id'] );
 		}
-		$sensei_grading_user_profile = $this->load_data_object( 'User_Quiz', $user_id, $quiz_id );
+
+		$sensei_grading_user_profile = new Sensei_Grading_User_Quiz( $user_id, $quiz_id );
+
 		// Wrappers
 		do_action( 'grading_before_container' );
 		do_action( 'grading_wrapper_container', 'top' );

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -966,7 +966,8 @@ class Sensei_Question {
 			if ( 0 < intval( $attachment_id ) ) {
 
 				$answer_media_url      = wp_get_attachment_url( $attachment_id );
-				$answer_media_filename = basename( $answer_media_url );
+				$filename_raw          = basename( $answer_media_url );
+				$answer_media_filename = preg_match( '/^[a-f0-9]{32}_/', $filename_raw ) ? substr( $filename_raw, 33 ) : $filename_raw;
 
 			}
 

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -967,7 +967,7 @@ class Sensei_Question {
 
 				$answer_media_url      = wp_get_attachment_url( $attachment_id );
 				$filename_raw          = basename( $answer_media_url );
-				$answer_media_filename = preg_match( '/^[a-f0-9]{32}_/', $filename_raw ) ? substr( $filename_raw, 33 ) : $filename_raw;
+				$answer_media_filename = Sensei_Grading_User_Quiz::remove_hash_prefix( $filename_raw );
 
 			}
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -420,7 +420,8 @@ class Sensei_Utils {
 		 */
 		$file_upload_args = apply_filters( 'sensei_file_upload_args', array( 'test_form' => false ) );
 
-		$file_return = wp_handle_upload( $file, $file_upload_args );
+		$file['name'] = md5( uniqid() ) . '_' . $file['name'];
+		$file_return  = wp_handle_upload( $file, $file_upload_args );
 
 		if ( isset( $file_return['error'] ) || isset( $file_return['upload_error_handler'] ) ) {
 			return false;


### PR DESCRIPTION
Fixes #1659

### Changes proposed in this Pull Request

* Adds a random hash to the filename of the uploaded file in order to make it hard to guess the url. The url is still publicly accessible though.

### Testing instructions

* Have a lesson with a 'file-upload' question.
* Upload a file with a student.
* Observe that the filename is displayed normally but clicking the filename goes to a url which has a random hash in its name.
* Go to grading in admin and open the quiz to grade it.
* Observe the same with step 3.
