### PR TITLE
Importer: Log notices instead of failing imports entirely

### DIFF
--- a/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
+++ b/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
@@ -230,7 +230,7 @@ abstract class Sensei_Import_File_Process_Task
 		if ( ! $model->is_valid() ) {
 			$this->get_job()->add_log_entry(
 				__( 'A required field is missing or one of the fields is malformed. Line skipped.', 'sensei-lms' ),
-				Sensei_Data_Port_Job::LOG_LEVEL_NOTICE,
+				Sensei_Data_Port_Job::LOG_LEVEL_ERROR,
 				$model->get_error_data(
 					[
 						'line' => $line_number,

--- a/includes/data-port/import-tasks/class-sensei-import-prerequisite-trait.php
+++ b/includes/data-port/import-tasks/class-sensei-import-prerequisite-trait.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Sensei_Import_Lessons class.
+ * File containing the Sensei_Import_Prerequisite_Trait trait.
  *
  * @package sensei
  */
@@ -33,10 +33,11 @@ trait Sensei_Import_Prerequisite_Trait {
 		];
 
 		if ( ! $reference_post_id ) {
-			$this->get_job()->add_log_entry(
+			$this->get_job()->add_line_warning(
+				$model_key,
+				$line_number,
 				// translators: Placeholder is reference to another post.
 				sprintf( __( 'Unable to set the prerequisite to "%s"', 'sensei-lms' ), $reference ),
-				Sensei_Data_Port_Job::LOG_LEVEL_NOTICE,
 				$error_data
 			);
 
@@ -44,9 +45,10 @@ trait Sensei_Import_Prerequisite_Trait {
 		}
 
 		if ( (int) $reference_post_id === $post_id ) {
-			$this->get_job()->add_log_entry(
+			$this->get_job()->add_line_warning(
+				$model_key,
+				$line_number,
 				__( 'Unable to set the prerequisite to the same entry', 'sensei-lms' ),
-				Sensei_Data_Port_Job::LOG_LEVEL_NOTICE,
 				$error_data
 			);
 
@@ -64,7 +66,7 @@ trait Sensei_Import_Prerequisite_Trait {
 	 * @param int    $line_number Line number.
 	 */
 	public function add_prerequisite_task( $post_id, $reference, $line_number ) {
-		return $this->add_post_process_task(
+		$this->add_post_process_task(
 			'prerequisite',
 			[
 				$post_id,

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -37,9 +37,7 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 	 * @return true|WP_Error
 	 */
 	public function sync_post() {
-		$postarr = $this->get_post_array();
-
-		$post_id = wp_insert_post( $postarr, true );
+		$post_id = wp_insert_post( $this->get_post_array(), true );
 
 		if ( is_wp_error( $post_id ) ) {
 			return $post_id;
@@ -56,10 +54,7 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 		$this->store_import_id();
 
 		// Sync meta. This happens outside of the post save because question media needs the post ID.
-		$meta_result = $this->sync_meta();
-		if ( is_wp_error( $meta_result ) ) {
-			return $meta_result;
-		}
+		$this->sync_meta();
 
 		return true;
 	}
@@ -108,8 +103,6 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 
 	/**
 	 * Synchronize the post meta.
-	 *
-	 * @return true|WP_Error
 	 */
 	private function sync_meta() {
 		$current_meta = get_post_meta( $this->get_post_id() );
@@ -143,20 +136,9 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 			}
 
 			if ( $new_value !== $current_value ) {
-				if ( false === update_post_meta( $this->get_post_id(), $field, $new_value ) ) {
-					return new WP_Error(
-						'sensei_import_question_meta_field_failed',
-						sprintf(
-							// translators: First placeholder is name of field.
-							__( 'Meta field "$1%s" is could not be saved.', 'sensei-lms' ),
-							$field
-						)
-					);
-				}
+				update_post_meta( $this->get_post_id(), $field, $new_value );
 			}
 		}
-
-		return true;
 	}
 
 	/**

--- a/tests/framework/data-port/trait-sensei-data-port-test-helpers.php
+++ b/tests/framework/data-port/trait-sensei-data-port-test-helpers.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * File with trait Sensei_Data_Port_Test_Helpers.
+ *
+ * @package sensei-tests
+ */
+
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Using PHPUnit conventions.
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Helpers for data port related tests.
+ *
+ * @since 3.2.0
+ */
+trait Sensei_Data_Port_Test_Helpers {
+	/**
+	 * Assert a job has a log entry.
+	 *
+	 * @param Sensei_Data_Port_Job $job       Job object.
+	 * @param string               $log_entry Log message to look for.
+	 * @param null                 $message   Message to show in assertion.
+	 */
+	protected function assertJobHasLogEntry( Sensei_Data_Port_Job $job, $log_entry, $message = null ) {
+		$logs = $job->get_logs();
+		$has_entry = false;
+		foreach ( $logs as $log ) {
+			if ( $log_entry === $log['message'] ) {
+				$has_entry = true;
+				break;
+			}
+		}
+
+		$this->assertTrue( $has_entry, $message );
+	}
+}

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
@@ -9,12 +9,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/data-port/trait-sensei-data-port-test-helpers.php';
+
 /**
  * Tests for Sensei_Import_Course_Model class.
  *
  * @group data-port
  */
 class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
+	use Sensei_Data_Port_Test_Helpers;
+
 	/**
 	 * Sensei factory object.
 	 *
@@ -322,14 +326,15 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that an error is returned when the attachment does not exist.
+	 * Tests that a warning is logged when the attachment does not exist.
 	 */
-	public function testSyncPostFailsWhenAttachmentNotFound() {
-		$task   = new Sensei_Import_Courses( Sensei_Import_Job::create( 'test', 0 ) );
+	public function testSyncPostWarnsWhenAttachmentNotFound() {
+		$job    = Sensei_Import_Job::create( 'test', 0 );
+		$task   = new Sensei_Import_Courses( $job );
 		$model  = Sensei_Import_Course_Model::from_source_array( 1, $this->lineData()[0][0], new Sensei_Data_Port_Course_Schema(), $task );
 		$result = $model->sync_post();
 
-		$this->assertInstanceOf( 'WP_Error', $result );
-		$this->assertEquals( 'sensei_data_port_attachment_not_found', $result->get_error_code() );
+		$this->assertTrue( $result );
+		$this->assertJobHasLogEntry( $job, 'No attachment with the specified file name was found.' );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This treats most issues during import as warnings to be logged instead of errors that stop an object's import. Exceptions to this are mostly for creating top-level post entries / rmissing equired fields.

### Testing instructions

* Use Donna's test import CSVs.
* Verify the entries that were being prematurely errored are now running and throwing warnings when appropriate.
* Note: This doesn't fix all the pending issues still in those CSVs, but it should at least let us see what notices we need to add and/or fix. 