### PR TITLE
Fix Setup Wizard features step not being saved when nothing is selected

### DIFF
--- a/assets/setup-wizard/features/index.js
+++ b/assets/setup-wizard/features/index.js
@@ -114,14 +114,16 @@ const Features = () => {
 
 	// Finish and submit features selection.
 	const finishSelection = () => {
-		if ( 0 === selectedSlugs.length ) {
-			goToNextStep();
-			return;
-		}
-
 		submitStep(
 			{ selected: selectedSlugs },
-			{ onSuccess: () => toggleConfirmation( true ) }
+			{
+				onSuccess: () => {
+					toggleConfirmation( true );
+					if ( 0 === selectedSlugs.length ) {
+						goToNextStep();
+					}
+				},
+			}
 		);
 	};
 


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Save features step, which marks it as completed, even when nothing was selected. This was not done previously, so the features step was not marked as completed

### Testing instructions

* Reset Setup Wizard data (`wp option delete sensei_setup_wizard_data`)
* Open the setup wizard, get to the features step
* Don't select anything, click continue
* Feature step should be marked as completed

