### PR TITLE
Add E2E tests for Setup Wizard

### DIFF
--- a/tests/e2e/bin/wp-cli.sh
+++ b/tests/e2e/bin/wp-cli.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -ex
+
+docker-compose -f docker-compose.yaml -f ../../../docker-compose.yaml run --user=xfs --entrypoint='/usr/bin/env' wordpress-cli \
+	wp "$@"

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -50,6 +50,7 @@ describe( 'Setup Wizard', () => {
 		await expect( page ).toClick( '.sensei-message a', {
 			text: 'Setup Wizard',
 		} );
+		await page.waitForNavigation();
 		await expect( page ).toMatch( 'Welcome to Sensei LMS!' );
 	} );
 

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -134,7 +134,6 @@ describe( 'Setup Wizard', () => {
 
 	describe( 'Features step', () => {
 		beforeAll( async () => {
-			await AdminFlow.deactivatePlugin( 'sensei-media-attachments' );
 			await AdminFlow.deactivatePlugin( 'sensei-certificates' );
 			await openSetupWizard();
 		} );

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -44,6 +44,7 @@ describe( 'Setup Wizard', () => {
 		await cleanupSenseiData();
 
 		await AdminFlow.activatePlugin( 'sensei-lms', true );
+		await page.waitForNavigation();
 		await expect( page.url() ).toMatch(
 			'admin.php?page=sensei_setup_wizard'
 		);
@@ -180,7 +181,7 @@ describe( 'Setup Wizard', () => {
 
 			await AdminFlow.goToPlugins();
 			expect(
-				await AdminFlow.findPlugin( 'sensei-certificates' )
+				await AdminFlow.isPluginActive( 'sensei-certificates' )
 			).toBeTruthy();
 		} );
 

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -214,6 +214,19 @@ describe( 'Setup Wizard', () => {
 			);
 		} );
 
+		it( 'has newsletter sign-up form', async () => {
+			const form = await expect( page ).toMatchElement(
+				'form[action="https://senseilms.us19.list-manage.com/subscribe/post?u=7a061a9141b0911d6d9bafe3a&id=4fa225a515"]'
+			);
+
+			await expect( form ).toMatchElement(
+				'input[name="EMAIL"][value="admin@woocommercecoree2etestsuite.com"]'
+			);
+			await expect( form ).toMatchElement( 'button', {
+				text: 'Yes, please!',
+			} );
+		} );
+
 		it( 'links to course creation', async () => {
 			await expect( page ).toClick( 'a', {
 				text: 'Create a course',
@@ -232,19 +245,6 @@ describe( 'Setup Wizard', () => {
 			await expect( page.url() ).toMatch(
 				adminUrl( 'admin.php?page=sensei_import' )
 			);
-		} );
-
-		it( 'has newsletter sign-up form', async () => {
-			const form = await expect( page ).toMatchElement(
-				'form[action="https://senseilms.us19.list-manage.com/subscribe/post?u=7a061a9141b0911d6d9bafe3a&id=4fa225a515"]'
-			);
-
-			await expect( form ).toMatchElement(
-				'input[name="EMAIL"][value="admin@woocommercecoree2etestsuite.com"]'
-			);
-			await expect( form ).toMatchElement( 'button', {
-				text: 'Yes, please!',
-			} );
 		} );
 	} );
 } );

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -1,4 +1,3 @@
-import { deactivatePlugin } from '@wordpress/e2e-test-utils';
 import { cleanupSenseiData, resetSetupWizard } from '../../utils/helpers';
 import { AdminFlow } from '../../utils/flows';
 
@@ -128,8 +127,8 @@ describe( 'Setup Wizard', () => {
 
 	describe( 'Features step', () => {
 		beforeAll( async () => {
-			await deactivatePlugin( 'sensei-media-attachments' );
-			await deactivatePlugin( 'sensei-certificates' );
+			await AdminFlow.deactivatePlugin( 'sensei-media-attachments' );
+			await AdminFlow.deactivatePlugin( 'sensei-certificates' );
 			await openSetupWizard();
 		} );
 

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -1,4 +1,9 @@
-import { cleanupSenseiData, resetSetupWizard } from '../../utils/helpers';
+import toClick from 'expect-puppeteer/lib/matchers/toClick';
+import {
+	adminUrl,
+	cleanupSenseiData,
+	resetSetupWizard,
+} from '../../utils/helpers';
 import { AdminFlow } from '../../utils/flows';
 
 async function openSetupWizard() {
@@ -192,13 +197,44 @@ describe( 'Setup Wizard', () => {
 	} );
 
 	describe( 'Ready step', () => {
-		it( 'opens when it is the active step', async () => {
+		beforeEach( async () => {
 			await openSetupWizard();
+			await toClick( page, '.woocommerce-stepper__step', {
+				text: 'Ready',
+			} );
+		} );
+		it( 'is available if it is the active step', async () => {
 			await stepIsComplete( 'Features' );
 			await stepIsActive( 'Ready' );
 			await expect( page ).toMatch(
 				"You're ready to start creating online courses!"
 			);
+		} );
+		it( 'links to course creation', async () => {
+			await expect( page ).toClick( 'a', {
+				text: 'Create a course',
+			} );
+			await page.waitForNavigation();
+			await expect( page.url() ).toMatch(
+				adminUrl( 'post-new.php?post_type=course' )
+			);
+		} );
+		it( 'links to importer', async () => {
+			await expect( page ).toClick( 'a', {
+				text: 'Import content',
+			} );
+			await page.waitForNavigation();
+			await expect( page.url() ).toMatch(
+				adminUrl( 'admin.php?page=sensei_import' )
+			);
+		} );
+		it( 'has newsletter sign-up form', async () => {
+			expect( page ).toMatchElement(
+				'input[name="EMAIL"][value="admin@woocommercecoree2etestsuite.com"]'
+			);
+			expect( page ).toMatchElement( 'button', {
+				text: 'Yes, please!',
+			} );
 		} );
 	} );
 } );

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -84,6 +84,7 @@ describe( 'Setup Wizard', () => {
 				}
 			);
 		} );
+
 		it( 'marks welcome step done and goes to purpose step', async () => {
 			await stepIsComplete( 'Welcome' );
 			await stepIsActive( 'Purpose' );
@@ -165,6 +166,7 @@ describe( 'Setup Wizard', () => {
 				}
 			);
 		} );
+
 		it( 'installs selected plugins', async () => {
 			await expect( page ).toClick( 'button', { text: 'Install now' } );
 
@@ -203,6 +205,7 @@ describe( 'Setup Wizard', () => {
 				text: 'Ready',
 			} );
 		} );
+
 		it( 'is available if it is the active step', async () => {
 			await stepIsComplete( 'Features' );
 			await stepIsActive( 'Ready' );
@@ -210,6 +213,7 @@ describe( 'Setup Wizard', () => {
 				"You're ready to start creating online courses!"
 			);
 		} );
+
 		it( 'links to course creation', async () => {
 			await expect( page ).toClick( 'a', {
 				text: 'Create a course',
@@ -219,6 +223,7 @@ describe( 'Setup Wizard', () => {
 				adminUrl( 'post-new.php?post_type=course' )
 			);
 		} );
+
 		it( 'links to importer', async () => {
 			await expect( page ).toClick( 'a', {
 				text: 'Import content',
@@ -228,6 +233,7 @@ describe( 'Setup Wizard', () => {
 				adminUrl( 'admin.php?page=sensei_import' )
 			);
 		} );
+
 		it( 'has newsletter sign-up form', async () => {
 			expect( page ).toMatchElement(
 				'input[name="EMAIL"][value="admin@woocommercecoree2etestsuite.com"]'

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -1,35 +1,204 @@
+import { deactivatePlugin } from '@wordpress/e2e-test-utils';
+import { cleanupSenseiData, resetSetupWizard } from '../../utils/helpers';
 import { AdminFlow } from '../../utils/flows';
 
-describe( 'Admin can login and make sure Sensei LMS is activated', () => {
-	it( 'Should login', async () => {
-		await AdminFlow.login();
-		const adminMenuMain = await page.waitForSelector( '#adminmenumain' );
+async function openSetupWizard() {
+	return AdminFlow.goTo( 'admin.php?page=sensei_setup_wizard' );
+}
 
-		expect( adminMenuMain ).toBeTruthy();
+async function stepIsComplete( label ) {
+	return expect( page ).toMatchElement(
+		'.woocommerce-stepper__step.is-complete',
+		{
+			text: label,
+			timeout: 5000,
+		}
+	);
+}
+
+async function stepIsActive( label ) {
+	return expect( page ).toMatchElement(
+		'.woocommerce-stepper__step.is-active',
+		{
+			text: label,
+		}
+	);
+}
+
+/**
+ * Setup Wizard E2E tests.
+ *
+ * These tests should be run sequentially.
+ */
+describe( 'Setup Wizard', () => {
+	beforeAll( async () => {
+		await AdminFlow.login();
 	} );
 
-	it( 'Should make sure Sensei LMS is activated or activate it', async () => {
-		const slug = 'sensei-lms';
-		let deactivateLink;
+	it( 'opens when first activating the Sensei LMS plugin', async () => {
+		await AdminFlow.activatePlugin( 'sensei-lms' );
+		await cleanupSenseiData();
 
+		await AdminFlow.activatePlugin( 'sensei-lms', true );
+		await expect( page.url() ).toMatch(
+			'admin.php?page=sensei_setup_wizard'
+		);
+	} );
+
+	it( 'shows a notice to run the Setup Wizard', async () => {
 		await AdminFlow.goToPlugins();
 
-		deactivateLink = await page.$(
-			`tr[data-slug="${ slug }"] .deactivate a`
-		);
-		if ( deactivateLink ) {
-			return;
-		}
+		await expect( page ).toClick( '.sensei-message a', {
+			text: 'Setup Wizard',
+		} );
+		await expect( page ).toMatch( 'Welcome to Sensei LMS!' );
+	} );
 
-		await page.click( `tr[data-slug="${ slug }"] .activate a` );
+	describe( 'Welcome step', () => {
+		beforeAll( async () => await resetSetupWizard() );
 
-		// Go to the plugins page again to make sure it's in the plugin page.
-		// It can be the setup wizard.
-		await AdminFlow.goToPlugins();
-		deactivateLink = await page.waitForSelector(
-			`tr[data-slug="${ slug }"] .deactivate a`
-		);
+		it( 'opens on first launch', async () => {
+			await openSetupWizard();
+			await expect( page ).toMatch( 'Welcome to Sensei LMS!' );
+		} );
 
-		expect( deactivateLink ).toBeTruthy();
+		it( 'displays usage tracking modal when clicking continue', async () => {
+			await expect( page ).toClick( 'button', { text: 'Continue' } );
+			await expect( page ).toMatch( 'Build a Better Sensei LMS' );
+		} );
+
+		it( 'allows opting in', async () => {
+			await expect( page ).toClick( 'label', {
+				text: 'Yes, count me in!',
+			} );
+
+			await expect( page ).toClick(
+				'.sensei-setup-wizard__usage-modal button',
+				{
+					text: 'Continue',
+				}
+			);
+		} );
+		it( 'marks welcome step done and goes to purpose step', async () => {
+			await stepIsComplete( 'Welcome' );
+			await stepIsActive( 'Purpose' );
+			await expect( page ).toMatch(
+				'What is your primary purpose for offering online courses?'
+			);
+		} );
+	} );
+
+	describe( 'Purpose step', () => {
+		it( 'opens when it is the active step', async () => {
+			await openSetupWizard();
+			await stepIsComplete( 'Welcome' );
+			await stepIsActive( 'Purpose' );
+			await expect( page ).toMatch(
+				'What is your primary purpose for offering online courses?'
+			);
+		} );
+
+		it( 'disables Continue until something is selected', async () => {
+			await expect( page ).toMatchElement( 'button[disabled]', {
+				text: 'Continue',
+			} );
+		} );
+
+		it( 'allows selecting purposes', async () => {
+			await expect( page ).toClick( 'label', {
+				text: 'Promote your business',
+			} );
+			await expect( page ).toClick( 'label', { text: 'Other' } );
+			await expect( page ).toFill(
+				'.sensei-setup-wizard__textcontrol-other input',
+				'Other'
+			);
+
+			await expect( page ).toClick( 'button', { text: 'Continue' } );
+		} );
+
+		it( 'marks purpose step done and goes to features step', async () => {
+			await stepIsComplete( 'Purpose' );
+			await stepIsActive( 'Features' );
+			await expect( page ).toMatch(
+				'Enhance your online courses with these optional features.'
+			);
+		} );
+	} );
+
+	describe( 'Features step', () => {
+		beforeAll( async () => {
+			await deactivatePlugin( 'sensei-media-attachments' );
+			await deactivatePlugin( 'sensei-certificates' );
+			await openSetupWizard();
+		} );
+
+		it( 'opens when it is the active step', async () => {
+			await stepIsComplete( 'Purpose' );
+			await stepIsActive( 'Features' );
+			await expect( page ).toMatch(
+				'Enhance your online courses with these optional features.'
+			);
+		} );
+
+		it( 'allows selecting plugins', async () => {
+			await expect( page ).toClick( 'label', {
+				text: 'Sensei LMS Certificates',
+			} );
+		} );
+
+		it( 'confirms plugin installation', async () => {
+			await expect( page ).toClick( 'button', { text: 'Continue' } );
+			await expect( page ).toMatch(
+				'Would you like to install the following features now?'
+			);
+
+			await expect( page ).toMatchElement(
+				'.sensei-setup-wizard__features-confirmation-modal .woocommerce-list__item-title',
+				{
+					text: 'Sensei LMS Certificates',
+				}
+			);
+		} );
+		it( 'installs selected plugins', async () => {
+			await expect( page ).toClick( 'button', { text: 'Install now' } );
+
+			await expect( page ).toMatchElement(
+				'.woocommerce-list__item-title',
+				{
+					text: 'Sensei LMS Certificates — Installed',
+					timeout: 5000,
+				}
+			);
+			await expect( page ).toClick( 'button', { text: 'Continue' } );
+
+			await AdminFlow.goToPlugins();
+			expect(
+				await AdminFlow.findPlugin( 'sensei-certificates' )
+			).toBeTruthy();
+		} );
+
+		it( 'marks installed plugins as unavailable', async () => {
+			await openSetupWizard();
+
+			expect( page ).toClick( '.woocommerce-stepper__step', {
+				text: 'Features',
+			} );
+
+			await expect( page ).toMatchElement( '.status-installed', {
+				text: 'Sensei LMS Certificates — Installed',
+			} );
+		} );
+	} );
+
+	describe( 'Ready step', () => {
+		it( 'opens when it is the active step', async () => {
+			await openSetupWizard();
+			await stepIsComplete( 'Features' );
+			await stepIsActive( 'Ready' );
+			await expect( page ).toMatch(
+				"You're ready to start creating online courses!"
+			);
+		} );
 	} );
 } );

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -235,10 +235,14 @@ describe( 'Setup Wizard', () => {
 		} );
 
 		it( 'has newsletter sign-up form', async () => {
-			expect( page ).toMatchElement(
+			const form = await expect( page ).toMatchElement(
+				'form[action="https://senseilms.us19.list-manage.com/subscribe/post?u=7a061a9141b0911d6d9bafe3a&id=4fa225a515"]'
+			);
+
+			await expect( form ).toMatchElement(
 				'input[name="EMAIL"][value="admin@woocommercecoree2etestsuite.com"]'
 			);
-			expect( page ).toMatchElement( 'button', {
+			await expect( form ).toMatchElement( 'button', {
 				text: 'Yes, please!',
 			} );
 		} );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -94,20 +94,21 @@ export const AdminFlow = {
 		return AdminFlow.goTo( 'plugins.php' );
 	},
 
-	async findPlugin( slug ) {
-		const deactivateLink = await page.$(
-			`tr[data-slug="${ slug }"] .deactivate a`
-		);
+	async isPluginActive( slug ) {
+		return !! ( await AdminFlow.findPluginAction( slug, 'deactivate' ) );
+	},
 
-		if ( ! deactivateLink ) return false;
-
-		return deactivateLink;
+	async findPluginAction( slug, action ) {
+		return page.$( `tr[data-slug="${ slug }"] .${ action } a` );
 	},
 
 	deactivatePlugin: async ( slug ) => {
 		await AdminFlow.goToPlugins();
 
-		const deactivateLink = await AdminFlow.findPlugin( slug );
+		const deactivateLink = await AdminFlow.findPluginAction(
+			slug,
+			'deactivate'
+		);
 
 		if ( deactivateLink ) {
 			await deactivateLink.click();
@@ -116,7 +117,10 @@ export const AdminFlow = {
 	activatePlugin: async ( slug, forceReactivate = false ) => {
 		await AdminFlow.goToPlugins();
 
-		const deactivateLink = await AdminFlow.findPlugin( slug );
+		const deactivateLink = await AdminFlow.findPluginAction(
+			slug,
+			'deactivate'
+		);
 
 		if ( deactivateLink ) {
 			if ( forceReactivate ) {
@@ -125,6 +129,7 @@ export const AdminFlow = {
 			} else return;
 		}
 
-		await page.click( `tr[data-slug="${ slug }"] .activate a` );
+		const activate = await AdminFlow.findPluginAction( slug, 'activate' );
+		await activate.click();
 	},
 };

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -105,7 +105,6 @@ export const AdminFlow = {
 	},
 
 	deactivatePlugin: async ( slug ) => {
-		await AdminFlow.login();
 		await AdminFlow.goToPlugins();
 
 		const deactivateLink = await AdminFlow.findPlugin( slug );
@@ -115,7 +114,6 @@ export const AdminFlow = {
 		}
 	},
 	activatePlugin: async ( slug, forceReactivate = false ) => {
-		await AdminFlow.login();
 		await AdminFlow.goToPlugins();
 
 		const deactivateLink = await AdminFlow.findPlugin( slug );

--- a/tests/e2e/utils/helpers.js
+++ b/tests/e2e/utils/helpers.js
@@ -29,3 +29,13 @@ export function cleanupSenseiData() {
 	`;
 	return wpcli( `eval "${ code }"` );
 }
+
+export function siteUrl( url ) {
+	const baseUrl = process.env.WP_BASE_URL;
+	return [ baseUrl, url ].join( '/' );
+}
+
+export function adminUrl( url ) {
+	const baseUrl = process.env.WP_BASE_URL;
+	return [ baseUrl, 'wp-admin', url ].join( '/' );
+}

--- a/tests/e2e/utils/helpers.js
+++ b/tests/e2e/utils/helpers.js
@@ -1,0 +1,31 @@
+/*
+ * External dependencies.
+ */
+import util from 'util';
+import childProcess from 'child_process';
+
+const exec = util.promisify( childProcess.exec );
+
+/**
+ * Run a wp cli command.
+ *
+ * @param {string} command The command with arguments.
+ */
+export async function wpcli( command ) {
+	const { stdout } = await exec(
+		`${ __dirname }/../bin/wp-cli.sh ${ command }`
+	);
+	return stdout;
+}
+
+export function resetSetupWizard() {
+	return wpcli( 'option delete sensei_setup_wizard_data' );
+}
+
+export function cleanupSenseiData() {
+	const code = `
+		require 'wp-content/plugins/sensei/includes/class-sensei-data-cleaner.php';
+		Sensei_Data_Cleaner::cleanup_all();
+	`;
+	return wpcli( `eval "${ code }"` );
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add test cases for Setup Wizard flow
* Add a few related helpers

### Test cases

```
  Setup Wizard
    ✓ opens when first activating the Sensei LMS plugin (7397ms)
    ✓ shows a notice to run the Setup Wizard (1266ms)
    Welcome step
      ✓ opens on first launch (1083ms)
      ✓ displays usage tracking modal when clicking continue (112ms)
      ✓ allows opting in (116ms)
      ✓ marks welcome step done and goes to purpose step (245ms)
    Purpose step
      ✓ opens when it is the active step (1888ms)
      ✓ disables Continue until something is selected (14ms)
      ✓ allows selecting purposes (202ms)
      ✓ marks purpose step done and goes to features step (142ms)
    Features step
      ✓ opens when it is the active step (22ms)
      ✓ allows selecting plugins (27ms)
      ✓ confirms plugin installation (160ms)
      ✓ installs selected plugins (2267ms)
      ✓ marks installed plugins as unavailable (1123ms)
    Ready step
      ✓ is available if it is the active step (1015ms)
      ✓ links to course creation (2932ms)
      ✓ links to importer (1499ms)
      ✓ has newsletter sign-up form (1581ms)
```

### Testing instructions

* Runs on travis, tests itself
* Use `npm run e2e-docker:up` to set up the containers and then `npm run test:e2e` to run locally. 
* `npm run test:e2e-dev` opens a browser and runs through the cases in a visible manner

