### PR TITLE
Add delimiter detection

### DIFF
--- a/includes/data-port/class-sensei-import-csv-reader.php
+++ b/includes/data-port/class-sensei-import-csv-reader.php
@@ -60,7 +60,7 @@ class Sensei_Import_CSV_Reader {
 	public function __construct( $csv_file, $completed_lines = 0, $lines_per_batch = 30 ) {
 		$this->file = new SplFileObject( $csv_file );
 		$this->file->setFlags( SplFileObject::READ_CSV );
-		$this->set_delimiter();
+		$this->detect_delimiter();
 
 		$this->file->seek( PHP_INT_MAX );
 		$this->total_lines     = $this->file->key();
@@ -74,7 +74,7 @@ class Sensei_Import_CSV_Reader {
 	 *
 	 * The delimiter detection works testing the delimiter which find more columns.
 	 */
-	private function set_delimiter() {
+	private function detect_delimiter() {
 		/**
 		 * Filters the default CSV delimiter.
 		 *

--- a/includes/data-port/class-sensei-import-csv-reader.php
+++ b/includes/data-port/class-sensei-import-csv-reader.php
@@ -101,7 +101,7 @@ class Sensei_Import_CSV_Reader {
 		 */
 		$delimiters         = apply_filters( 'sensei_import_csv_delimiter_options', [ ',', ';', "\t", '|' ] );
 		$max_columns        = 0;
-		$selected_delimiter = '';
+		$selected_delimiter = $delimiters[0];
 
 		foreach ( $delimiters as $delimiter ) {
 			$this->file->setCsvControl( $delimiter );

--- a/tests/framework/data-port/data-files/test_csv_reader_tabs.csv
+++ b/tests/framework/data-port/data-files/test_csv_reader_tabs.csv
@@ -1,0 +1,13 @@
+First Column   	    second column	third column
+
+
+
+
+first data 1	second data 1	third data 1
+first data 2	second data 2	third data 2
+
+first data 3	second data 3
+		third data 4
+first data 5	second data 5
+first data 6	second data 6	third data 6
+first data 7	second data 7	third data 7

--- a/tests/unit-tests/data-port/test-class-sensei-import-csv-reader.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-csv-reader.php
@@ -78,6 +78,15 @@ class Sensei_Import_CSV_Reader_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that file with tab delimiter passes validation.
+	 */
+	public function testFileWithTabDelimiterPassValidation() {
+		$file = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/test_csv_reader_tabs.csv';
+
+		$this->assertTrue( Sensei_Import_CSV_Reader::validate_csv_file( $file, [], [ 'first column', 'second column', 'third column' ] ) );
+	}
+
+	/**
 	 * Tests that lines that are empty are returned by read_lines() as empty arrays.
 	 */
 	public function testEmptyLinesAreReturnedAsEmpty() {


### PR DESCRIPTION
This feature is in discussion, so not necessarily will be merged. So I'd like to see opinions if we should merge it or not.

I think it's important, because if the users generate the CSV with a different separator than we expect, probably they'll not understand what error is happening.

### Changes proposed in this Pull Request

* This PR introduces a delimiter detection for the CSV file being imported.
* The detection occurs through the delimiter with more columns detected.
  * Users still can force it through the filter, or adding more options to be checked.

### Testing instructions

* Import the files changing the delimiters to `;`, tab and `|`, and make sure that it's imported correctly.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_import_csv_delimiter` - updated the default to `false` instead of `,`.
* `sensei_import_csv_delimiter_options` - Filters the CSV delimiter options.