### PR TITLE
Add BOM removal

### DIFF
--- a/includes/data-port/class-sensei-import-csv-reader.php
+++ b/includes/data-port/class-sensei-import-csv-reader.php
@@ -190,6 +190,9 @@ class Sensei_Import_CSV_Reader {
 			return [];
 		}
 
+		// Remove BOM if it's present.
+		$column_names[0] = str_replace( "\xEF\xBB\xBF", '', $column_names[0] );
+
 		// Make the column names of the CSV file case insensitive.
 		return array_map(
 			function ( $name ) {

--- a/tests/framework/data-port/data-files/test_csv_reader_with_bom.csv
+++ b/tests/framework/data-port/data-files/test_csv_reader_with_bom.csv
@@ -1,0 +1,13 @@
+﻿First Column   ,    second column,third column
+
+
+
+
+first data 1,second data 1,third data 1
+first data 2,second data 2,third data 2
+
+first data 3,second data 3,
+,,third data 4
+first data 5,second data 5
+first data 6,second data 6,third data 6
+first data 7,second data 7,third data 7

--- a/tests/unit-tests/data-port/test-class-sensei-import-csv-reader.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-csv-reader.php
@@ -69,6 +69,15 @@ class Sensei_Import_CSV_Reader_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that file with BOM passes validation.
+	 */
+	public function testFileWithBOMPassValidation() {
+		$file = SENSEI_TEST_FRAMEWORK_DIR . '/data-port/data-files/test_csv_reader_with_bom.csv';
+
+		$this->assertTrue( Sensei_Import_CSV_Reader::validate_csv_file( $file, [], [ 'first column', 'second column', 'third column' ] ) );
+	}
+
+	/**
 	 * Tests that lines that are empty are returned by read_lines() as empty arrays.
 	 */
 	public function testEmptyLinesAreReturnedAsEmpty() {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* While working in a delimiter conversion to test, I accessed a site that generated a file with BOM and it didn't work because it didn't recognize the first column name, so this PR introduces a replace in the first column of the column names (our first part of the file where the BOM will be)

### Testing instructions

* Save a valid CSV file to import as UTF-8 with BOM.
* Import it and make sure it's working properly.