### PR TITLE
Log when the Continue button is clicked on the Import Content page

### DIFF
--- a/assets/data-port/import/data/selectors.js
+++ b/assets/data-port/import/data/selectors.js
@@ -88,3 +88,15 @@ export const isReadyToStart = ( state ) => {
 
 	return hasUploaded && ! inProgress;
 };
+
+/**
+ * Get uploaded level keys.
+ *
+ * @param {Object} state Current state.
+ *
+ * @return {string[]} Array of uploaded level keys.
+ */
+export const getUploadedLevelKeys = ( { upload } ) =>
+	levels
+		.filter( ( { key } ) => upload[ key ].isUploaded )
+		.map( ( { key } ) => key );

--- a/assets/data-port/import/data/selectors.test.js
+++ b/assets/data-port/import/data/selectors.test.js
@@ -6,6 +6,7 @@ import {
 	isCompleteStep,
 	isFetching,
 	isReadyToStart,
+	getUploadedLevelKeys,
 } from './selectors';
 
 describe( 'Importer selectors', () => {
@@ -200,5 +201,25 @@ describe( 'Importer selectors', () => {
 		};
 
 		expect( isReadyToStart( state ) ).toBeFalsy();
+	} );
+
+	it( 'Should return the uploaded level keys', () => {
+		const state = {
+			upload: {
+				courses: {
+					isUploaded: false,
+				},
+				lessons: {
+					isUploaded: true,
+				},
+				questions: {
+					isUploaded: true,
+				},
+			},
+		};
+
+		const expected = [ 'lessons', 'questions' ];
+
+		expect( getUploadedLevelKeys( state ) ).toEqual( expected );
 	} );
 } );

--- a/assets/data-port/import/upload/index.js
+++ b/assets/data-port/import/upload/index.js
@@ -1,7 +1,6 @@
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { UploadPage } from './upload-page';
-import { partial } from 'lodash';
 
 export default compose(
 	withSelect( ( select ) => {
@@ -16,10 +15,15 @@ export default compose(
 		const { submitStartImport } = dispatch( 'sensei/import' );
 
 		return {
-			submitStartImport: partial(
-				submitStartImport,
-				select( 'sensei/import' ).getJobId()
-			),
+			submitStartImport: () => {
+				submitStartImport( select( 'sensei/import' ).getJobId() );
+
+				// Log continue to import from uploaded files.
+				const type = select( 'sensei/import' )
+					.getUploadedLevelKeys()
+					.join( ',' );
+				window.sensei_log_event( 'import_continue_click', { type } );
+			},
 		};
 	} )
 )( UploadPage );


### PR DESCRIPTION
Fixes #3114

### Changes proposed in this Pull Request

* Add log to import continue click.

### Testing instructions

* Go to the importer.
* Select some files.
* Click on `Continue` and make sure it was logged with:
  `event_name`: `import_continue_click` and `type`: selected files separated by comma.