### PR TITLE
Importer: Log file upload errors

### DIFF
--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -408,6 +408,15 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 			return new WP_Error( 'sensei_data_port_upload_path_unavailable', $uploads['error'] );
 		}
 
+		$file_configs = static::get_file_config();
+
+		if ( ! isset( $file_configs[ $file_key ] ) ) {
+			return new WP_Error(
+				'sensei_data_port_unknown_file_key',
+				__( 'Unexpected file key used.', 'sensei-lms' )
+			);
+		}
+
 		$filename       = wp_unique_filename( $uploads['path'], $stored_file_name );
 		$file_save_path = $uploads['path'] . "/$filename";
 
@@ -420,15 +429,6 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 
 		if ( ! $move_new_file || ! file_exists( $file_save_path ) ) {
 			return new WP_Error( 'sensei_data_port_file_save_failed', __( 'Error saving file.', 'sensei-lms' ) );
-		}
-
-		$file_configs = static::get_file_config();
-
-		if ( ! isset( $file_configs[ $file_key ] ) ) {
-			return new WP_Error(
-				'sensei_data_port_unknown_file_key',
-				__( 'Unexpected file key used.', 'sensei-lms' )
-			);
 		}
 
 		$file_config = $file_configs[ $file_key ];

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
@@ -35,6 +35,8 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 
 		// We need to re-instansiate the controller on each tests to register any hooks.
 		new Sensei_REST_API_Messages_Controller( 'sensei_message' );
+
+		Sensei_Test_Events::reset();
 	}
 
 	/**
@@ -445,6 +447,9 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 
 			$this->assertTrue( isset( $data['files']['questions']['name'] ) );
 			$this->assertEquals( basename( $test_file ), $data['files']['questions']['name'] );
+
+			$events = Sensei_Test_Events::get_logged_events( 'sensei_import_upload_error' );
+			$this->assertEmpty( $events );
 		}
 	}
 
@@ -508,6 +513,9 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 
 			$this->assertTrue( isset( $data['files']['questions']['name'] ) );
 			$this->assertEquals( basename( $test_file ), $data['files']['questions']['name'] );
+
+			$events = Sensei_Test_Events::get_logged_events( 'sensei_import_upload_error' );
+			$this->assertEmpty( $events );
 		}
 	}
 
@@ -549,6 +557,11 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 
 		$this->assertTrue( isset( $data['code'], $data['message'] ) );
 		$this->assertEquals( 'sensei_data_port_unexpected_file_type', $data['code'] );
+
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_import_upload_error' );
+		$this->assertNotEmpty( $events );
+		$this->assertEquals( 'questions', $events[0]['url_args']['type'] );
+		$this->assertEquals( 'sensei_data_port_unexpected_file_type', $events[0]['url_args']['error'] );
 	}
 
 	/**
@@ -589,6 +602,11 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 
 		$this->assertTrue( isset( $data['code'], $data['message'] ) );
 		$this->assertEquals( 'sensei_data_port_unknown_file_key', $data['code'] );
+
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_import_upload_error' );
+		$this->assertNotEmpty( $events );
+		$this->assertEquals( 'dinosaurs', $events[0]['url_args']['type'] );
+		$this->assertEquals( 'sensei_data_port_unknown_file_key', $events[0]['url_args']['error'] );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Logs file upload errors when setting up an import job.
* Fixes an issue with describing file upload errors.

### Testing instructions

* Ensure you have usage tracking enabled.
* Add this snippet:
```php
add_filter( 'pre_http_request', function( $preempt, $r, $url ) {
	$event_monitor_url = 'http://localhost:8888/pixel/';
	$host                      = parse_url( $url, PHP_URL_HOST );
	$path                      = parse_url( $url, PHP_URL_PATH );
	if ( 'pixel.wp.com' === $host && '/t.gif' === $path ) {
		error_log( 'Logging Tracks event:' );
		error_log( $url );
		
		$http    = _wp_http_get_object();
		$new_url = $event_monitor_url . '?' . parse_url( $url, PHP_URL_QUERY );
		return $http->request( $new_url, $r );
	}
	return $preempt;
}, 10, 3 );
```
* Ignore the event monitor unless you have a listening service set up there.
* Go to Sensei LMS > Import. 
* Create a very large file. I used:
`dd if=/dev/zero of=file.txt count=500024 bs=1024`
* Upload that file to one of the fields. You should see a tracks event logged in your error logger/event monitor for `sensei_import_upload_error` with `error=sensei_import_upload_failed_max_file_size`.
* Upload a file with an unknown column. You should see `sensei_import_upload_error` with `error=sensei_data_port_job_unknown_columns`.