### PR TITLE
Update filter name for consistency

### DIFF
--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -224,15 +224,15 @@ class Sensei_Learner {
 		];
 
 		/**
-		 * Filters the arguments of the query which fetches a user's enrolled courses.
+		 * Filters the arguments of the query which fetches a learner's enrolled courses.
 		 *
 		 * @since 3.3.0
-		 * @hook sensei_user_enrolled_courses_args
+		 * @hook sensei_learner_enrolled_courses_args
 		 *
 		 * @param {array} $query_args  The query args.
 		 * @param {int}   $user_id     The user id.
 		 */
-		return apply_filters( 'sensei_user_enrolled_courses_args', $query_args, $user_id );
+		return apply_filters( 'sensei_learner_enrolled_courses_args', $query_args, $user_id );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

After reviewing #3347, I realized that the filter should be called `sensei_learner_enrolled_courses_args` to be consistent with the other hooks in this class.

### Testing instructions

* Add the following snippet:

```
add_filter(
	'sensei_learner_enrolled_courses_args',
	function( $args, $user_id ) {
		error_log( $user_id);
		error_log( print_r($args,true) );

		return $args;
	},
	10,
	2
);
```

* Navigate to 'My courses' page and observe that the arguments are logged.

### New/Updated Hooks

* `sensei_learner_enrolled_courses_args` - Customize the query arguments used to fetch the courses a user is enrolled in.