### PR TITLE
Log `sensei_plugin_install` on WCCOM plugin activation

### DIFF
--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -87,8 +87,6 @@ class Sensei_Setup_Wizard {
 		$this->page_slug = 'sensei_setup_wizard';
 		$this->pages     = new Sensei_Setup_Wizard_Pages();
 
-		add_action( 'activated_plugin', [ $this, 'log_wccom_plugin_install' ] );
-
 		if ( is_admin() ) {
 
 			add_action( 'admin_menu', [ $this, 'register_wizard_page' ], 20 );
@@ -618,43 +616,6 @@ class Sensei_Setup_Wizard {
 		set_transient( self::WCCOM_INSTALLING_TRANSIENT, $wccom_extensions, 10 * 60 );
 
 		Sensei_Plugins_Installation::instance()->install_plugins( $extensions_to_install );
-	}
-
-	/**
-	 * Log plugin installation success for WooCommerce.com plugin on activation.
-	 *
-	 * @param string $plugin_file The activated plugin.
-	 */
-	public function log_wccom_plugin_install( $plugin_file ) {
-		if ( empty( $this->get_wizard_user_data( 'steps' ) ) ) {
-			return;
-		}
-
-		$plugin_name = dirname( $plugin_file );
-
-		if ( in_array( $plugin_file, $this->get_wccom_extensions(), true ) ) {
-			sensei_log_event(
-				'plugin_install',
-				[ 'slug' => $plugin_name ]
-			);
-		}
-	}
-
-	/**
-	 * Get the WooCommerce.com plugins files.
-	 *
-	 * @return string[]
-	 */
-	private function get_wccom_extensions() {
-		$wccom_extensions = [];
-
-		foreach ( $this->get_sensei_extensions() as $extension ) {
-			if ( isset( $extension->wccom_product_id ) ) {
-				$wccom_extensions[] = $extension->plugin_file;
-			}
-		}
-
-		return $wccom_extensions;
 	}
 
 	/**

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -626,21 +626,35 @@ class Sensei_Setup_Wizard {
 	 * @param string $plugin_file The activated plugin.
 	 */
 	public function log_wccom_plugin_install( $plugin_file ) {
-
-		$plugin_name   = dirname( $plugin_file );
-		$wccom_plugins = get_transient( self::WCCOM_INSTALLING_TRANSIENT );
-
-		if ( empty( $wccom_plugins ) ) {
+		if ( empty( $this->get_wizard_user_data( 'steps' ) ) ) {
 			return;
 		}
 
-		if ( in_array( $plugin_file, $wccom_plugins, true ) ) {
+		$plugin_name = dirname( $plugin_file );
+
+		if ( in_array( $plugin_file, $this->get_wccom_extensions(), true ) ) {
 			sensei_log_event(
-				'setup_wizard_features_install_success',
+				'plugin_install',
 				[ 'slug' => $plugin_name ]
 			);
-
 		}
+	}
+
+	/**
+	 * Get the WooCommerce.com plugins files.
+	 *
+	 * @return string[]
+	 */
+	private function get_wccom_extensions() {
+		$wccom_extensions = [];
+
+		foreach ( $this->get_sensei_extensions() as $extension ) {
+			if ( isset( $extension->wccom_product_id ) ) {
+				$wccom_extensions[] = $extension->plugin_file;
+			}
+		}
+
+		return $wccom_extensions;
 	}
 
 	/**

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -26,6 +26,9 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 
 		// Init event logging source filters.
 		add_action( 'init', [ $this, 'init_event_logging_sources' ] );
+
+		// Filters for for events to watch and report.
+		add_action( 'activated_plugin', [ $this, 'log_wccom_plugin_install' ] );
 	}
 
 	/*
@@ -192,6 +195,41 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 				return 'data-import';
 			}
 		);
+	}
+
+
+
+	/**
+	 * Log plugin installation success for WooCommerce.com plugin on activation.
+	 *
+	 * @param string $plugin_file The activated plugin.
+	 */
+	public function log_wccom_plugin_install( $plugin_file ) {
+		$plugin_name = dirname( $plugin_file );
+
+		if ( in_array( $plugin_file, $this->get_wccom_extensions(), true ) ) {
+			sensei_log_event(
+				'plugin_install',
+				[ 'slug' => $plugin_name ]
+			);
+		}
+	}
+
+	/**
+	 * Get the WooCommerce.com plugins files.
+	 *
+	 * @return string[]
+	 */
+	private function get_wccom_extensions() {
+		$wccom_extensions = [];
+
+		foreach ( Sensei()->setup_wizard->get_sensei_extensions() as $extension ) {
+			if ( isset( $extension->wccom_product_id ) ) {
+				$wccom_extensions[] = $extension->plugin_file;
+			}
+		}
+
+		return $wccom_extensions;
 	}
 
 	/**

--- a/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -12,7 +12,7 @@ Usage_Tracking_Test_Subclass::get_instance();
  *
  * @group usage-tracking
  */
-class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
+class Sensei_Base_Usage_Tracking_Test extends WP_UnitTestCase {
 	private $event_counts       = array();
 	private $track_http_request = array();
 

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -581,38 +581,4 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		// Revert mocked instance.
 		$property->setValue( $real_instance );
 	}
-
-	/**
-	 * Tests that WCCOM extensions are logged as sensei_plugin_install when activated.
-	 *
-	 * @covers Sensei_Setup_Wizard::log_wccom_plugin_install
-	 */
-	public function testWccomInstallSuccessLogged() {
-
-		$get_sensei_extensions = wp_json_encode(
-			[
-				'products' => [
-					(object) [
-						'product_slug'     => 'test-wccom-plugin',
-						'plugin_file'      => 'test-wccom-plugin/test-wccom-plugin.php',
-						'wccom_product_id' => '00000',
-					],
-				],
-			]
-		);
-		add_filter(
-			'pre_http_request',
-			function() use ( $get_sensei_extensions ) {
-				return [ 'body' => $get_sensei_extensions ];
-			}
-		);
-
-		Sensei()->setup_wizard->update_wizard_user_data( [ 'steps' => [ 'welcome' ] ] );
-
-		do_action( 'activated_plugin', 'test-wccom-plugin/test-wccom-plugin.php' );
-
-		$events = Sensei_Test_Events::get_logged_events( 'sensei_plugin_install' );
-
-		$this->assertEquals( 'test-wccom-plugin', $events[0]['url_args']['slug'] );
-	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -583,7 +583,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that WCCOM extensions are logged as setup_wizard_features_install_success when activated.
+	 * Tests that WCCOM extensions are logged as sensei_plugin_install when activated.
 	 *
 	 * @covers Sensei_Setup_Wizard::log_wccom_plugin_install
 	 */
@@ -607,11 +607,11 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 			}
 		);
 
-		Sensei()->setup_wizard->install_extensions( [ 'test-wccom-plugin' ] );
+		Sensei()->setup_wizard->update_wizard_user_data( [ 'steps' => [ 'welcome' ] ] );
 
 		do_action( 'activated_plugin', 'test-wccom-plugin/test-wccom-plugin.php' );
 
-		$events = Sensei_Test_Events::get_logged_events( 'sensei_setup_wizard_features_install_success' );
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_plugin_install' );
 
 		$this->assertEquals( 'test-wccom-plugin', $events[0]['url_args']['slug'] );
 	}

--- a/tests/unit-tests/test-class-sensei-usage-tracking.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking.php
@@ -6,6 +6,8 @@
  */
 
 /**
+ * Tests for the class `Sensei_Usage_Tracking`.
+ *
  * @group usage-tracking
  */
 class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {

--- a/tests/unit-tests/test-class-sensei-usage-tracking.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This file contains the Sensei_Usage_Tracking_Test class.
+ *
+ * @package sensei
+ */
+
+/**
+ * @group usage-tracking
+ */
+class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		Sensei_Test_Events::reset();
+	}
+
+	/**
+	 * Tests that WCCOM extensions are logged as sensei_plugin_install when activated.
+	 *
+	 * @covers Sensei_Usage_Tracking::log_wccom_plugin_install
+	 */
+	public function testWccomInstallSuccessLogged() {
+		// Mock WooCommerce plugin information.
+		set_transient(
+			Sensei_Setup_Wizard::WC_INFORMATION_TRANSIENT,
+			(object) [
+				'product_slug' => 'woocommerce',
+				'title'        => 'WooCommerce',
+				'excerpt'      => 'Lorem ipsum',
+				'plugin_file'  => 'woocommerce/woocommerce.php',
+				'link'         => 'https://wordpress.org/plugins/woocommerce',
+				'unselectable' => true,
+			],
+			DAY_IN_SECONDS
+		);
+
+		$get_sensei_extensions = wp_json_encode(
+			[
+				'products' => [
+					(object) [
+						'product_slug'     => 'test-wccom-plugin',
+						'plugin_file'      => 'test-wccom-plugin/test-wccom-plugin.php',
+						'wccom_product_id' => '00000',
+					],
+				],
+			]
+		);
+
+		add_filter(
+			'pre_http_request',
+			function() use ( $get_sensei_extensions ) {
+				return [ 'body' => $get_sensei_extensions ];
+			}
+		);
+
+		do_action( 'activated_plugin', 'test-wccom-plugin/test-wccom-plugin.php' );
+
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_plugin_install' );
+
+		$this->assertEquals( 'test-wccom-plugin', $events[0]['url_args']['slug'] );
+	}
+}


### PR DESCRIPTION
Fixes #3352
Fixes #3353

### Changes proposed in this Pull Request

* Replaces the old `setup_wizard_features_install_success` event with a `sensei_plugin_install` event whenever WCCOM Sensei plugin is activated. 
* Moved the old, similar code for `setup_wizard_features_install_success` to `Sensei_Usage_Tracking` since it is no longer related.

### Testing instructions

* On a fresh install, go to Sensei LMS > Settings and enable usage tracking.
* Activate SWCPC in `woothemes-sensei/woothemes-sensei.php` and verify the `sensei_plugin_install` event is fired with `slug=woothemes-sensei`.
* Activate Content Drip in `sensei-content-drip/sensei-content-drip.php` and verify the `sensei_plugin_install` event is fired with `slug=sensei-content-drip`.