### PR TITLE
Log when an import job completes

### DIFF
--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -387,6 +387,16 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 		if ( ! $has_incomplete_task || 0 === $total_cycles ) {
 			$this->is_completed = true;
 			$this->percentage   = 100;
+
+			/**
+			 * Trigger an action when a data port job is complete.
+			 *
+			 * @since 3.2.0
+			 * @hook sensei_data_port_complete
+			 *
+			 * @param {Sensei_Data_Port_Job} $data_port_job The data port job object.
+			 */
+			do_action( 'sensei_data_port_complete', $this );
 		} else {
 			$this->percentage = 100 * $completed_cycles / $total_cycles;
 		}

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -362,9 +362,10 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 			return;
 		}
 
-		$completed_cycles   = 0;
-		$total_cycles       = 0;
-		$has_processed_task = false;
+		$completed_cycles    = 0;
+		$total_cycles        = 0;
+		$has_processed_task  = false;
+		$has_incomplete_task = false;
 
 		foreach ( $this->get_tasks() as $task ) {
 
@@ -373,13 +374,17 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 				$has_processed_task = true;
 			}
 
+			if ( ! $task->is_completed() ) {
+				$has_incomplete_task = true;
+			}
+
 			$ratio = $task->get_completion_ratio();
 
 			$completed_cycles += $ratio['completed'];
 			$total_cycles     += $ratio['total'];
 		}
 
-		if ( ! $has_processed_task || 0 === $total_cycles ) {
+		if ( ! $has_incomplete_task || 0 === $total_cycles ) {
 			$this->is_completed = true;
 			$this->percentage   = 100;
 		} else {

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -225,12 +225,12 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 		sensei_log_event(
 			'import_complete',
 			[
-				'courses'          => $results[ Sensei_Import_Course_Model::MODEL_KEY ]['success'] + $results[ Sensei_Import_Course_Model::MODEL_KEY ]['warning'],
-				'lessons'          => $results[ Sensei_Import_Lesson_Model::MODEL_KEY ]['success'] + $results[ Sensei_Import_Lesson_Model::MODEL_KEY ]['warning'],
-				'questions'        => $results[ Sensei_Import_Question_Model::MODEL_KEY ]['success'] + $results[ Sensei_Import_Question_Model::MODEL_KEY ]['warning'],
-				'failed_courses'   => $results[ Sensei_Import_Course_Model::MODEL_KEY ]['error'],
-				'failed_lessons'   => $results[ Sensei_Import_Lesson_Model::MODEL_KEY ]['error'],
-				'failed_questions' => $results[ Sensei_Import_Question_Model::MODEL_KEY ]['error'],
+				'imported_courses'   => $results[ Sensei_Import_Course_Model::MODEL_KEY ]['success'] + $results[ Sensei_Import_Course_Model::MODEL_KEY ]['warning'],
+				'imported_lessons'   => $results[ Sensei_Import_Lesson_Model::MODEL_KEY ]['success'] + $results[ Sensei_Import_Lesson_Model::MODEL_KEY ]['warning'],
+				'imported_questions' => $results[ Sensei_Import_Question_Model::MODEL_KEY ]['success'] + $results[ Sensei_Import_Question_Model::MODEL_KEY ]['warning'],
+				'failed_courses'     => $results[ Sensei_Import_Course_Model::MODEL_KEY ]['error'],
+				'failed_lessons'     => $results[ Sensei_Import_Lesson_Model::MODEL_KEY ]['error'],
+				'failed_questions'   => $results[ Sensei_Import_Question_Model::MODEL_KEY ]['error'],
 			]
 		);
 	}

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-manager.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-manager.php
@@ -185,12 +185,12 @@ class Sensei_Data_Port_Manager_Test extends WP_UnitTestCase {
 		$this->assertCount( 1, $events );
 
 		$expected_data = [
-			'courses'          => 4,
-			'lessons'          => 4,
-			'questions'        => 5,
-			'failed_courses'   => 2,
-			'failed_lessons'   => 2,
-			'failed_questions' => 1,
+			'imported_courses'   => 4,
+			'imported_lessons'   => 4,
+			'imported_questions' => 5,
+			'failed_courses'     => 2,
+			'failed_lessons'     => 2,
+			'failed_questions'   => 1,
 		];
 
 		foreach ( $expected_data as $key => $value ) {


### PR DESCRIPTION
Fixes #3115

### Changes proposed in this Pull Request

* Log `sensei_import_complete` when an import job completes.
* Introduces new action `sensei_data_port_complete` to listen for these events

### Testing instructions

* Complete a job with a mix of successfuly imports, imports with warnings, and errors. 
* Observe event is fired which matches requirements of #3115.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* Added new action `sensei_data_port_complete`: Fires when job completes and is provided the `Sensei_Data_Port_Job` object.