### PR TITLE
Make usage tracking pixel calls non-blocking

### DIFF
--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -189,7 +189,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * @param array    $properties Event Properties.
 	 * @param null|int $event_timestamp When the event occurred.
 	 *
-	 * @return null|WP_Error
+	 * @return bool
 	 **/
 	public function send_event( $event, $properties = array(), $event_timestamp = null ) {
 
@@ -198,7 +198,7 @@ abstract class Sensei_Usage_Tracking_Base {
 			return false;
 		}
 
-		$pixel      = 'http://pixel.wp.com/t.gif';
+		$pixel      = 'https://pixel.wp.com/t.gif';
 		$event_name = $this->get_event_prefix() . '_' . $event;
 		$user       = wp_get_current_user();
 
@@ -222,27 +222,18 @@ abstract class Sensei_Usage_Tracking_Base {
 			$p[] = rawurlencode( $key ) . '=' . rawurlencode( $value );
 		}
 
-		$pixel   .= '?' . implode( '&', $p ) . '&_=_'; // EOF marker.
-		$response = wp_remote_get(
+		$pixel .= '?' . implode( '&', $p ) . '&_=_'; // EOF marker.
+
+		wp_safe_remote_get(
 			$pixel,
 			array(
-				'blocking'    => true,
+				'blocking'    => false,
 				'timeout'     => 1,
 				'redirection' => 2,
 				'httpversion' => '1.1',
 				'user-agent'  => $this->get_event_prefix() . '_usage_tracking',
 			)
 		);
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		$code = isset( $response['response']['code'] ) ? $response['response']['code'] : 0;
-
-		if ( 200 !== $code ) {
-			return new WP_Error( 'request_failed', 'HTTP Request failed', $code );
-		}
 
 		return true;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Changes our usage tracking calls to be non-blocking. This should make sure lots of calls (especially during import) don't slow things down. This changes the signature of that method, but we never use the return so I thought it seemed safe.
* Also changes to use `https` for the pixel.
* For a confidence check, both of these changes are implemented in [WooCommerce](https://github.com/woocommerce/woocommerce/blob/730df27bc6b92c41e7572f850d80c3afe40f9679/includes/tracks/class-wc-tracks-client.php#L109-L124).

### Testing instructions

* Make sure usage tracking gets sent normally.