### PR TITLE
Importer: Log warnings and errors

### DIFF
--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -93,6 +93,33 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 	}
 
 	/**
+	 * Add an entry to the logs.
+	 *
+	 * @param string $message Log message.
+	 * @param int    $level   Log level (see constants).
+	 * @param array  $data    Data to include with the message.
+	 */
+	public function add_log_entry( $message, $level = self::LOG_LEVEL_INFO, $data = [] ) {
+		if ( isset( $data['code'], $data['type'] ) ) {
+			$event_data = [
+				'type'  => $data['type'],
+				'error' => $data['code'],
+			];
+
+			if ( self::LOG_LEVEL_ERROR === $level ) {
+				sensei_log_event( 'import_error', $event_data );
+			} elseif ( self::LOG_LEVEL_NOTICE === $level ) {
+				sensei_log_event( 'import_warning', $event_data );
+			}
+		}
+
+		// We don't use the error code after this.
+		unset( $data['code'] );
+
+		parent::add_log_entry( $message, $level, $data );
+	}
+
+	/**
 	 * Get the configuration for expected files.
 	 *
 	 * @return array {

--- a/includes/data-port/import-tasks/class-sensei-import-courses.php
+++ b/includes/data-port/import-tasks/class-sensei-import-courses.php
@@ -37,6 +37,15 @@ class Sensei_Import_Courses extends Sensei_Import_File_Process_Task {
 	}
 
 	/**
+	 * Get the model key for this task.
+	 *
+	 * @return string
+	 */
+	public function get_model_key() {
+		return Sensei_Import_Course_Model::MODEL_KEY;
+	}
+
+	/**
 	 * Performs any required cleanup of the task.
 	 */
 	public function clean_up() {

--- a/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
+++ b/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
@@ -198,6 +198,13 @@ abstract class Sensei_Import_File_Process_Task
 	abstract public function get_model( $line_number, $data );
 
 	/**
+	 * Get the model key for this task.
+	 *
+	 * @return string
+	 */
+	abstract public function get_model_key();
+
+	/**
 	 * Process a single CSV line.
 	 *
 	 * @param int            $line_number  The line number in the file.
@@ -215,6 +222,7 @@ abstract class Sensei_Import_File_Process_Task
 				$data->get_error_message(),
 				Sensei_Data_Port_Job::LOG_LEVEL_ERROR,
 				[
+					'type' => $this->get_model_key(),
 					'line' => $line_number,
 				]
 			);

--- a/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
+++ b/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
@@ -224,6 +224,7 @@ abstract class Sensei_Import_File_Process_Task
 				[
 					'type' => $this->get_model_key(),
 					'line' => $line_number,
+					'code' => $data->get_error_code(),
 				]
 			);
 
@@ -242,6 +243,7 @@ abstract class Sensei_Import_File_Process_Task
 				$model->get_error_data(
 					[
 						'line' => $line_number,
+						'code' => 'sensei_data_port_required_field_missing',
 					]
 				)
 			);
@@ -259,6 +261,7 @@ abstract class Sensei_Import_File_Process_Task
 				$model->get_error_data(
 					[
 						'line' => $line_number,
+						'code' => $result->get_error_code(),
 					]
 				)
 			);

--- a/includes/data-port/import-tasks/class-sensei-import-lessons.php
+++ b/includes/data-port/import-tasks/class-sensei-import-lessons.php
@@ -37,6 +37,15 @@ class Sensei_Import_Lessons extends Sensei_Import_File_Process_Task {
 	}
 
 	/**
+	 * Get the model key for this task.
+	 *
+	 * @return string
+	 */
+	public function get_model_key() {
+		return Sensei_Import_Lesson_Model::MODEL_KEY;
+	}
+
+	/**
 	 * Performs any required cleanup of the task.
 	 */
 	public function clean_up() {

--- a/includes/data-port/import-tasks/class-sensei-import-prerequisite-trait.php
+++ b/includes/data-port/import-tasks/class-sensei-import-prerequisite-trait.php
@@ -26,7 +26,8 @@ trait Sensei_Import_Prerequisite_Trait {
 		$reference         = sanitize_text_field( $task[1] );
 		$line_number       = (int) $task[2];
 		$reference_post_id = $this->get_job()->translate_import_id( $post_type, $reference );
-		$error_data        = [
+
+		$error_data = [
 			'line'    => $line_number,
 			'type'    => $model_key,
 			'post_id' => $post_id,
@@ -38,7 +39,12 @@ trait Sensei_Import_Prerequisite_Trait {
 				$line_number,
 				// translators: Placeholder is reference to another post.
 				sprintf( __( 'Unable to set the prerequisite to "%s"', 'sensei-lms' ), $reference ),
-				$error_data
+				array_merge(
+					$error_data,
+					[
+						'code' => 'sensei_data_port_prerequisite_bad_reference',
+					]
+				)
 			);
 
 			return;
@@ -49,7 +55,12 @@ trait Sensei_Import_Prerequisite_Trait {
 				$model_key,
 				$line_number,
 				__( 'Unable to set the prerequisite to the same entry', 'sensei-lms' ),
-				$error_data
+				array_merge(
+					$error_data,
+					[
+						'code' => 'sensei_data_port_prerequisite_ref_match',
+					]
+				)
 			);
 
 			return;

--- a/includes/data-port/import-tasks/class-sensei-import-questions.php
+++ b/includes/data-port/import-tasks/class-sensei-import-questions.php
@@ -38,6 +38,15 @@ class Sensei_Import_Questions
 	}
 
 	/**
+	 * Get the model key for this task.
+	 *
+	 * @return string
+	 */
+	public function get_model_key() {
+		return Sensei_Import_Question_Model::MODEL_KEY;
+	}
+
+	/**
 	 * Performs any required cleanup of the task.
 	 */
 	public function clean_up() {

--- a/includes/data-port/models/class-sensei-import-course-model.php
+++ b/includes/data-port/models/class-sensei-import-course-model.php
@@ -70,7 +70,12 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 
 		$result = $this->add_thumbnail_to_post( Sensei_Data_Port_Course_Schema::COLUMN_IMAGE );
 		if ( $result instanceof WP_Error ) {
-			$this->add_line_warning( $result->get_error_message() );
+			$this->add_line_warning(
+				$result->get_error_message(),
+				[
+					'code' => $result->get_error_code(),
+				]
+			);
 		}
 
 		$prerequisite = $this->get_value( Sensei_Data_Port_Course_Schema::COLUMN_PREREQUISITE );
@@ -200,7 +205,10 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 				// translators: Placeholder is comma separated list of terms that failed to save.
 					__( 'The following terms failed to save: %s', 'sensei-lms' ),
 					implode( ', ', $failed_terms )
-				)
+				),
+				[
+					'code' => 'sensei_data_port_course_terms_failed_to_save',
+				]
 			);
 		}
 
@@ -208,7 +216,12 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 		$result       = wp_set_object_terms( $course_id, $new_term_ids, $taxonomy );
 
 		if ( is_wp_error( $result ) ) {
-			$this->add_line_warning( $result->get_error_message() );
+			$this->add_line_warning(
+				$result->get_error_message(),
+				[
+					'code' => $result->get_error_code(),
+				]
+			);
 		} elseif ( 'module' === $taxonomy ) {
 			$new_module_order = array_map( 'strval', $new_term_ids );
 			update_post_meta( $course_id, '_module_order', $new_module_order );

--- a/includes/data-port/models/class-sensei-import-lesson-model.php
+++ b/includes/data-port/models/class-sensei-import-lesson-model.php
@@ -124,7 +124,12 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 		) {
 			$pass_required = null;
 			$pass_mark     = null;
-			$this->add_line_warning( __( 'Both Passmark and Pass Required should be supplied.', 'sensei-lms' ) );
+			$this->add_line_warning(
+				__( 'Both Passmark and Pass Required should be supplied.', 'sensei-lms' ),
+				[
+					'code' => 'sensei_data_port_lesson_passmark_pass_required_missing',
+				]
+			);
 		}
 
 		if ( null !== $pass_required ) {
@@ -188,7 +193,10 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 			if ( empty( $question_id ) ) {
 				$this->add_line_warning(
 					// translators: Placeholder is the term which errored.
-					sprintf( __( 'Question does not exist: %s.', 'sensei-lms' ), $question_import_id )
+					sprintf( __( 'Question does not exist: %s.', 'sensei-lms' ), $question_import_id ),
+					[
+						'code' => 'sensei_data_port_quiz_missing_question',
+					]
 				);
 
 				continue;
@@ -263,7 +271,10 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 			if ( empty( $this->course_id ) ) {
 				$this->add_line_warning(
 					// translators: Placeholder is the term which errored.
-					sprintf( __( 'Course does not exist: %s.', 'sensei-lms' ), $value )
+					sprintf( __( 'Course does not exist: %s.', 'sensei-lms' ), $value ),
+					[
+						'code' => 'sensei_data_port_lesson_course_missing',
+					]
 				);
 
 				$this->course_id = null;
@@ -290,7 +301,12 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 
 		$result = $this->add_thumbnail_to_post( Sensei_Data_Port_Lesson_Schema::COLUMN_IMAGE );
 		if ( $result instanceof WP_Error ) {
-			$this->add_line_warning( $result->get_error_message() );
+			$this->add_line_warning(
+				$result->get_error_message(),
+				[
+					'code' => $result->get_error_code(),
+				]
+			);
 		}
 
 		$prerequisite = $this->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_PREREQUISITE );
@@ -428,7 +444,12 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 			$term = $this->get_lesson_module( $new_terms );
 
 			if ( is_wp_error( $term ) ) {
-				$this->add_line_warning( $term->get_error_message() );
+				$this->add_line_warning(
+					$term->get_error_message(),
+					[
+						'code' => $term->get_error_code(),
+					]
+				);
 			} else {
 				$terms[] = $term;
 			}
@@ -453,7 +474,10 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 						// translators: Placeholder is comma separated list of terms that failed to save.
 						__( 'The following terms failed to save: %s', 'sensei-lms' ),
 						implode( ', ', $failed_terms )
-					)
+					),
+					[
+						'code' => 'sensei_data_port_lesson_terms_failed_to_save',
+					]
 				);
 			}
 		}
@@ -462,7 +486,12 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 		$result       = wp_set_object_terms( $this->get_post_id(), $new_term_ids, $taxonomy );
 
 		if ( is_wp_error( $result ) ) {
-			$this->add_line_warning( $result->get_error_message() );
+			$this->add_line_warning(
+				$result->get_error_message(),
+				[
+					'code' => $result->get_error_code(),
+				]
+			);
 		}
 	}
 

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -124,7 +124,10 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 						__( 'Meta field "%1$s" is invalid: %2$s', 'sensei-lms' ),
 						$field,
 						$new_value->get_error_message()
-					)
+					),
+					[
+						'code' => 'sensei_data_port_invalid_meta',
+					]
 				);
 
 				continue;

--- a/tests/framework/data-port/class-sensei-import-file-process-task-mock.php
+++ b/tests/framework/data-port/class-sensei-import-file-process-task-mock.php
@@ -15,6 +15,10 @@ class Sensei_Import_File_Process_Task_Mock extends Sensei_Import_File_Process_Ta
 		return Sensei_Import_Model_Mock::from_source_array( $line_number, $data, new Sensei_Data_Port_Schema_Mock() );
 	}
 
+	public function get_model_key() {
+		return Sensei_Import_Model_Mock::MODEL_KEY;
+	}
+
 	public function clean_up() {}
 
 	public static function validate_source_file( $file_path ) {}

--- a/tests/framework/data-port/class-sensei-import-model-mock.php
+++ b/tests/framework/data-port/class-sensei-import-model-mock.php
@@ -6,8 +6,10 @@
  */
 
 class Sensei_Import_Model_Mock extends Sensei_Import_Model {
+	const MODEL_KEY = 'mock-model';
+
 	public function get_model_key() {
-		return 'mock-model';
+		return self::MODEL_KEY;
 	}
 
 	protected function get_existing_post_id() {


### PR DESCRIPTION
Fixes #3368

### Changes proposed in this Pull Request

* Logs `sensei_import_error` for errors and `sensei_import_warning` for warnings. 
* Needed a slight refactor to pass down error codes. I'm preventing them from being stored because they aren't used anywhere else. Some warnings needed new error codes.

### Testing instructions

* Import Donna's files with known errors.
* Verify events are filed for all warnings and errors.