### PR TITLE
Remove file source URL from imported media description

### DIFF
--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -176,7 +176,7 @@ class Sensei_Data_Port_Utilities {
 		}
 
 		$attachment_args = [
-			'post_content'   => $file_url,
+			'post_content'   => '',
 			'post_title'     => basename( $file_path ),
 			'post_mime_type' => $wp_filetype['type'],
 			'guid'           => $file_url,


### PR DESCRIPTION
Fixes #3371

### Changes proposed in this Pull Request

* Removes the source URL from the imported media description.

### Testing instructions

* Import files that import media. Verify the description field isn't set.

cc: @gkaragia I didn't see it being used anywhere else but let me know if I missed something.