### PR TITLE
Fix question import issues

### DIFF
--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -207,7 +207,7 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 			case 'boolean':
 				$answers_raw = $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_ANSWER );
 				$values      = [
-					'_question_right_answer' => in_array( $answers_raw, [ '1', 'true' ], true ) ? 1 : 0,
+					'_question_right_answer' => in_array( $answers_raw, [ '1', 'true' ], true ) ? 'true' : 'false',
 				];
 
 				break;

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -207,7 +207,7 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 			case 'boolean':
 				$answers_raw = $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_ANSWER );
 				$values      = [
-					'_question_right_answer' => 1 === intval( $answers_raw ) ? 1 : 0,
+					'_question_right_answer' => in_array( $answers_raw, [ '1', 'true' ], true ) ? 1 : 0,
 				];
 
 				break;

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -153,7 +153,7 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 		$fields = [];
 
 		$fields['_question_grade']  = $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_GRADE );
-		$fields['_random_order']    = $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_RANDOM_ORDER );
+		$fields['_random_order']    = $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_RANDOM_ORDER ) ? 'yes' : 'no';
 		$fields['_answer_feedback'] = $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_FEEDBACK );
 		$fields['_question_media']  = $this->get_question_media_value();
 

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -230,9 +230,14 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 
 				break;
 			case 'single-line':
-			case 'multi-line':
 				$values = [
 					'_question_right_answer' => $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_ANSWER ),
+				];
+
+				break;
+			case 'multi-line':
+				$values = [
+					'_question_right_answer' => $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_TEACHER_NOTES ),
 				];
 
 				break;

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
@@ -287,7 +287,7 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 		);
 		$this->assertEquals( 1, get_post_meta( $post->ID, '_right_answer_count', true ) );
 		$this->assertEquals( 2, get_post_meta( $post->ID, '_wrong_answer_count', true ) );
-		$this->assertEquals( $expected_data[ Sensei_Data_Port_Question_Schema::COLUMN_RANDOM_ORDER ], get_post_meta( $post->ID, '_random_order', true ) );
+		$this->assertEquals( 'yes', get_post_meta( $post->ID, '_random_order', true ) );
 		$this->assertEquals( $expected_data[ Sensei_Data_Port_Question_Schema::COLUMN_GRADE ], get_post_meta( $post->ID, '_question_grade', true ) );
 
 		$this->assertEquals( $expected_answer_order, get_post_meta( $post->ID, '_answer_order', true ) );

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
@@ -386,7 +386,7 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'draft', $post->post_status, 'Post status should be draft by default' );
 		$this->assertEquals( '', $post->post_name, 'Post name should be empty for drafts' );
 
-		$this->assertEquals( $expected_data[ Sensei_Data_Port_Question_Schema::COLUMN_ANSWER ], get_post_meta( $post->ID, '_question_right_answer', true ) );
+		$this->assertEquals( 'true', get_post_meta( $post->ID, '_question_right_answer', true ) );
 		$this->assertEquals( null, get_post_meta( $post->ID, '_question_wrong_answers', true ) );
 		$this->assertEquals( null, get_post_meta( $post->ID, '_right_answer_count', true ) );
 		$this->assertEquals( null, get_post_meta( $post->ID, '_wrong_answer_count', true ) );


### PR DESCRIPTION
Fixes #3386 
Fixes #3385

### Changes proposed in this Pull Request

* Fixes teacher note import for multi-line questions.
* Fixes `Randomise Answer Order` import.
* Allows both `1` and `true` for correct boolean answers. 

### Testing instructions

* See issues.