### PR TITLE
Fix more issues with question import and deal with empty categories

### DIFF
--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -277,6 +277,10 @@ class Sensei_Data_Port_Utilities {
 	 * @return WP_Term|false
 	 */
 	public static function get_term( $term_name_path, $taxonomy_name, $teacher_user_id = null ) {
+		if ( ! $term_name_path ) {
+			return false;
+		}
+
 		$taxonomy = get_taxonomy( $taxonomy_name );
 		if ( ! $taxonomy ) {
 			return false;
@@ -394,6 +398,10 @@ class Sensei_Data_Port_Utilities {
 	 * @return array|string[]
 	 */
 	public static function split_list_safely( $str_list, $remove_quotes = false ) {
+		if ( empty( trim( $str_list ) ) ) {
+			return [];
+		}
+
 		$str_list = self::replace_curly_quotes( $str_list );
 		$list     = preg_split( '/,(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/', $str_list );
 

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -118,10 +118,10 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 			if ( null !== $value ) {
 				switch ( $config['type'] ) {
 					case 'int':
-						$value = intval( $value );
+						$value = '' === $value ? null : intval( $value );
 						break;
 					case 'float':
-						$value = floatval( $value );
+						$value = '' === $value ? null : floatval( $value );
 						break;
 					case 'bool':
 						if ( ! in_array( $value, [ '0', '1', 'true', 'false' ], true ) ) {

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -69,7 +69,7 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 			'post_type' => Sensei_Data_Port_Question_Schema::POST_TYPE,
 		];
 
-		if ( $this->is_new() ) {
+		if ( ! $this->is_new() ) {
 			$postarr['ID'] = $this->get_post_id();
 		} elseif ( get_current_user_id() ) {
 			$postarr['post_author'] = get_current_user_id();

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -213,8 +213,8 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 				break;
 			case 'file-upload':
 				$values = [
-					'_question_right_answer'  => $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_UPLOAD_NOTES ),
-					'_question_wrong_answers' => $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_TEACHER_NOTES ),
+					'_question_right_answer'  => $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_TEACHER_NOTES ),
+					'_question_wrong_answers' => [ $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_UPLOAD_NOTES ) ],
 				];
 
 				break;

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
@@ -355,8 +355,8 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'draft', $post->post_status, 'Post status should be draft by default' );
 		$this->assertEquals( '', $post->post_name, 'Post name should be empty for drafts' );
 
-		$this->assertEquals( $expected_data[ Sensei_Data_Port_Question_Schema::COLUMN_UPLOAD_NOTES ], get_post_meta( $post->ID, '_question_right_answer', true ) );
-		$this->assertEquals( $expected_data[ Sensei_Data_Port_Question_Schema::COLUMN_TEACHER_NOTES ], get_post_meta( $post->ID, '_question_wrong_answers', true ) );
+		$this->assertEquals( $expected_data[ Sensei_Data_Port_Question_Schema::COLUMN_TEACHER_NOTES ], get_post_meta( $post->ID, '_question_right_answer', true ) );
+		$this->assertEquals( [ $expected_data[ Sensei_Data_Port_Question_Schema::COLUMN_UPLOAD_NOTES ] ], get_post_meta( $post->ID, '_question_wrong_answers', true ) );
 		$this->assertEquals( null, get_post_meta( $post->ID, '_right_answer_count', true ) );
 		$this->assertEquals( null, get_post_meta( $post->ID, '_wrong_answer_count', true ) );
 


### PR DESCRIPTION
Fixes #3390 
Fixes #3389 
Fixes #3388 

### Changes proposed in this Pull Request

* Fixes issue where empty categories were getting set to a category (#3390)
* Fixes issue where `int` and `float` values weren't getting set to their default (#3389)
* Fixes issue where file upload questions weren't getting their upload notes and teacher notes set correctly. (#3388)
* Fixes issue with updating existing questions.

### Testing instructions

* See issues.