### PR TITLE
Add title and link to the import logs

### DIFF
--- a/assets/data-port/import/done/done-page.test.js
+++ b/assets/data-port/import/done/done-page.test.js
@@ -47,21 +47,38 @@ describe( '<DonePage />', () => {
 			error: [
 				{
 					type: 'lesson',
-					title: 'Lesson title',
 					line: 7,
 					severity: 'error',
 					descriptor: 'ID: 7',
 					message: 'Error message.',
+					post: {
+						title: null,
+						edit_link: null,
+					},
 				},
 			],
 			notice: [
 				{
 					type: 'question',
-					title: 'Question title',
 					line: 1,
 					severity: 'notice',
 					descriptor: 'ID: 1',
 					message: 'Warning message.',
+					post: {
+						title: 'Question title 1',
+						edit_link: 'http://test.com/',
+					},
+				},
+				{
+					type: 'question',
+					line: 2,
+					severity: 'notice',
+					descriptor: 'ID: 1',
+					message: 'Warning message.',
+					post: {
+						title: 'Question title 2',
+						edit_link: null,
+					},
 				},
 			],
 		};
@@ -70,15 +87,21 @@ describe( '<DonePage />', () => {
 
 		expect( getByText( 'Failed' ) ).toBeTruthy();
 		expect( getByText( 'Partial' ) ).toBeTruthy();
+		expect(
+			getByText( 'Question title 1' ).getAttribute( 'href' )
+		).toEqual( 'http://test.com/' );
 
 		const rows = container.querySelectorAll(
 			'.sensei-import-done__log-data tbody tr'
 		);
 		expect( rows[ 0 ].textContent ).toMatch(
-			[ 'Lessons', 'Lesson title', '7', 'Error message.' ].join( '' )
+			[ 'Lessons', 'No title', '7', 'Error message.' ].join( '' )
 		);
 		expect( rows[ 1 ].textContent ).toMatch(
-			[ 'Question title', '1', 'Warning message.' ].join( '' )
+			[ 'Question title 1', '1', 'Warning message.' ].join( '' )
+		);
+		expect( rows[ 2 ].textContent ).toMatch(
+			[ 'Question title 2', '2', 'Warning message.' ].join( '' )
 		);
 	} );
 

--- a/assets/data-port/import/done/import-log.js
+++ b/assets/data-port/import/done/import-log.js
@@ -13,6 +13,26 @@ const logTypeLabel = {
 };
 
 /**
+ * Create title with link.
+ *
+ * @param {string} title    Post title.
+ * @param {string} editLink Post edit link.
+ */
+const createTitleWithLink = ( title, editLink ) => {
+	const titleText = title || __( 'No title', 'sensei-lms' );
+
+	if ( editLink ) {
+		return (
+			<a href={ editLink } target="_blank" rel="noreferrer">
+				{ titleText }
+			</a>
+		);
+	}
+
+	return titleText;
+};
+
+/**
  * ImportLog component.
  */
 export const ImportLog = ( { items, type } ) => (
@@ -34,7 +54,12 @@ export const ImportLog = ( { items, type } ) => (
 						{ type === 'error' && (
 							<td>{ postTypeLabels[ item.type ] }</td>
 						) }
-						<td>{ item.title }</td>
+						<td>
+							{ createTitleWithLink(
+								item.post.title,
+								item.post.edit_link
+							) }
+						</td>
 						<td>{ item.line }</td>
 						<td>{ item.message }</td>
 					</tr>

--- a/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
+++ b/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
@@ -135,6 +135,7 @@ abstract class Sensei_Import_File_Process_Task
 
 			$task_method = 'handle_' . $next_task;
 			$callback    = [ $this, $task_method ];
+
 			call_user_func( $callback, $next_task_args );
 
 			if ( empty( $this->post_process_tasks[ $next_task ] ) ) {

--- a/includes/data-port/import-tasks/class-sensei-import-prerequisite-trait.php
+++ b/includes/data-port/import-tasks/class-sensei-import-prerequisite-trait.php
@@ -26,11 +26,13 @@ trait Sensei_Import_Prerequisite_Trait {
 		$reference         = sanitize_text_field( $task[1] );
 		$line_number       = (int) $task[2];
 		$reference_post_id = $this->get_job()->translate_import_id( $post_type, $reference );
+		$post_title        = $task[3];
 
 		$error_data = [
-			'line'    => $line_number,
-			'type'    => $model_key,
-			'post_id' => $post_id,
+			'line'        => $line_number,
+			'type'        => $model_key,
+			'post_id'     => $post_id,
+			'entry_title' => $post_title,
 		];
 
 		if ( ! $reference_post_id ) {
@@ -76,13 +78,14 @@ trait Sensei_Import_Prerequisite_Trait {
 	 * @param string $reference   Reference to the prerequisite.
 	 * @param int    $line_number Line number.
 	 */
-	public function add_prerequisite_task( $post_id, $reference, $line_number ) {
+	public function add_prerequisite_task( $post_id, $reference, $line_number, $post_title ) {
 		$this->add_post_process_task(
 			'prerequisite',
 			[
 				$post_id,
 				$reference,
 				$line_number,
+				$post_title,
 			]
 		);
 	}

--- a/includes/data-port/models/class-sensei-import-course-model.php
+++ b/includes/data-port/models/class-sensei-import-course-model.php
@@ -48,7 +48,8 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 		remove_action( 'save_post', array( Sensei()->course, 'save_course_notification_meta_box' ) );
 		remove_action( 'save_post', array( Sensei()->course, 'meta_box_save' ) );
 
-		$post_id = wp_insert_post( $this->get_course_args( $teacher ), true );
+		$post_args = $this->get_course_args( $teacher );
+		$post_id   = wp_insert_post( $post_args, true );
 
 		add_action( 'transition_post_status', array( Sensei()->teacher, 'notify_admin_teacher_course_creation' ), 10, 3 );
 		add_action( 'save_post', array( Sensei()->course, 'save_course_notification_meta_box' ) );
@@ -80,7 +81,7 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 
 		$prerequisite = $this->get_value( Sensei_Data_Port_Course_Schema::COLUMN_PREREQUISITE );
 		if ( $prerequisite ) {
-			$this->task->add_prerequisite_task( $post_id, $prerequisite, $this->line_number );
+			$this->task->add_prerequisite_task( $post_id, $prerequisite, $this->line_number, $post_args['post_title'] );
 		} elseif ( '' === $prerequisite ) {
 			delete_post_meta( $post_id, '_course_prerequisite' );
 		}

--- a/includes/data-port/models/class-sensei-import-lesson-model.php
+++ b/includes/data-port/models/class-sensei-import-lesson-model.php
@@ -262,22 +262,16 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 	 */
 	private function sync_lesson() {
 
-		$value = $this->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_COURSE );
+		$course_not_found = false;
+		$value            = $this->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_COURSE );
 		if ( ! empty( $value ) ) {
 			$course = $this->task->get_job()->translate_import_id( Sensei_Data_Port_Course_Schema::POST_TYPE, $value );
 
 			$this->course_id = $course;
 
 			if ( empty( $this->course_id ) ) {
-				$this->add_line_warning(
-					// translators: Placeholder is the term which errored.
-					sprintf( __( 'Course does not exist: %s.', 'sensei-lms' ), $value ),
-					[
-						'code' => 'sensei_data_port_lesson_course_missing',
-					]
-				);
-
-				$this->course_id = null;
+				$course_not_found = true;
+				$this->course_id  = null;
 			}
 		} else {
 			$this->course_id = null;
@@ -298,6 +292,17 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 		}
 
 		$this->set_post_id( $post_id );
+
+		if ( $course_not_found ) {
+			$this->add_line_warning(
+				// translators: Placeholder is the term which errored.
+				sprintf( __( 'Course does not exist: %s.', 'sensei-lms' ), $value ),
+				[
+					'code' => 'sensei_data_port_lesson_course_missing',
+				]
+			);
+		}
+
 		$this->store_import_id();
 
 		$result = $this->add_thumbnail_to_post( Sensei_Data_Port_Lesson_Schema::COLUMN_IMAGE );

--- a/includes/data-port/models/class-sensei-import-lesson-model.php
+++ b/includes/data-port/models/class-sensei-import-lesson-model.php
@@ -283,7 +283,8 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 			$this->course_id = null;
 		}
 
-		$post_id = wp_insert_post( $this->get_lesson_args(), true );
+		$post_args = $this->get_lesson_args();
+		$post_id   = wp_insert_post( $post_args, true );
 
 		if ( is_wp_error( $post_id ) ) {
 			return $post_id;
@@ -311,7 +312,7 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 
 		$prerequisite = $this->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_PREREQUISITE );
 		if ( $prerequisite ) {
-			$this->task->add_prerequisite_task( $post_id, $prerequisite, $this->line_number );
+			$this->task->add_prerequisite_task( $post_id, $prerequisite, $this->line_number, $post_args['post_title'] );
 		} elseif ( '' === $prerequisite ) {
 			delete_post_meta( $post_id, '_lesson_prerequisite' );
 		}

--- a/includes/rest-api/class-sensei-rest-api-data-port-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-data-port-controller.php
@@ -345,6 +345,11 @@ abstract class Sensei_REST_API_Data_Port_Controller extends \WP_REST_Controller 
 					'severity'   => Sensei_Data_Port_Job::translate_log_severity_level( $entry['level'] ),
 					'descriptor' => Sensei_Data_Port_Job::get_log_entry_descriptor( $entry ),
 					'message'    => $entry['message'],
+					'post'       => [
+						'id'        => isset( $data['post_id'] ) ? $data['post_id'] : null,
+						'title'     => isset( $data['entry_title'] ) ? $data['entry_title'] : null,
+						'edit_link' => isset( $data['post_id'] ) ? get_edit_post_link( $data['post_id'], '&' ) : null,
+					],
 				];
 			},
 			array_slice( $log_entries, $offset, self::LOG_PAGE_SIZE )

--- a/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-courses.php
+++ b/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-courses.php
@@ -45,6 +45,7 @@ class Sensei_Import_Courses_Tests extends WP_UnitTestCase {
 			$course_id,
 			'slug:a-secret-course',
 			1,
+			'Post title',
 		];
 
 		$method->invoke( $task, $task_args );
@@ -72,6 +73,7 @@ class Sensei_Import_Courses_Tests extends WP_UnitTestCase {
 			$course_id,
 			'slug:a-secret-course',
 			1,
+			'Post title',
 		];
 
 		$method->invoke( $task, $task_args );
@@ -98,6 +100,7 @@ class Sensei_Import_Courses_Tests extends WP_UnitTestCase {
 			$course_id,
 			'slug:a-missing-course',
 			1,
+			'Post title',
 		];
 
 		$method->invoke( $task, $task_args );

--- a/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-lessons.php
+++ b/tests/unit-tests/data-port/import-tasks/test-class-sensei-import-lessons.php
@@ -45,6 +45,7 @@ class Sensei_Import_Lessons_Tests extends WP_UnitTestCase {
 			$lesson_id,
 			'slug:a-secret-lesson',
 			1,
+			'Post title',
 		];
 
 		$method->invoke( $task, $task_args );
@@ -72,6 +73,7 @@ class Sensei_Import_Lessons_Tests extends WP_UnitTestCase {
 			$lesson_id,
 			'slug:a-secret-lesson',
 			1,
+			'Post title',
 		];
 
 		$method->invoke( $task, $task_args );
@@ -98,6 +100,7 @@ class Sensei_Import_Lessons_Tests extends WP_UnitTestCase {
 			$lesson_id,
 			'slug:a-missing-lesson',
 			1,
+			'Post title',
 		];
 
 		$method->invoke( $task, $task_args );

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-import-controller.php
@@ -184,6 +184,7 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 
 		$expected_status_codes = [ 401, 403 ];
 		$job_id                = 'doesnotexit';
+		$course_id             = $this->factory->post->create();
 
 		$entries = [
 			[
@@ -195,6 +196,7 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 						'line'        => 100,
 						'entry_title' => 'Test Course A',
 						'entry_id'    => '123',
+						'post_id'     => $course_id,
 					],
 				],
 				'expected' => [
@@ -203,6 +205,11 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 					'severity'   => 'notice',
 					'descriptor' => 'Test Course A; ID: 123',
 					'message'    => 'Test message A',
+					'post'       => [
+						'id'        => $course_id,
+						'title'     => 'Test Course A',
+						'edit_link' => 'http://example.org/wp-admin/post.php?post=' . $course_id . '&action=edit',
+					],
 				],
 			],
 			[
@@ -222,6 +229,11 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 					'severity'   => 'notice',
 					'descriptor' => 'Test Course B',
 					'message'    => 'Test message B',
+					'post'       => [
+						'id'        => null,
+						'title'     => 'Test Course B',
+						'edit_link' => null,
+					],
 				],
 			],
 			[
@@ -241,6 +253,11 @@ class Sensei_REST_API_Import_Controller_Tests extends WP_Test_REST_TestCase {
 					'severity'   => 'error',
 					'descriptor' => null,
 					'message'    => 'Test message C',
+					'post'       => [
+						'id'        => null,
+						'title'     => null,
+						'edit_link' => null,
+					],
 				],
 			],
 		];


### PR DESCRIPTION
Fixes #3337

This PR is based in the #3379, and contains the final part to complete the issue.

### Changes proposed in this Pull Request

* Add title and link to the partial logs API and to the screen.
  * When there is no title, I added the placeholder `No title`.
* Besides to add the information to the logs, we needed to fix 2 scenarios:
  * The prerequisites that didn't have the title ready for the logs.
  * When importing lessons without course, it wasn't getting the ID, so we needed to postpone the warning in the code until the post be created.

### Testing instructions

* Import Donna's files and check if the results contain the title and the correct link to the post edit page.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="799" alt="Screen Shot 2020-07-10 at 17 45 29" src="https://user-images.githubusercontent.com/876340/87201562-361e4f00-c2d5-11ea-9b6b-fb0eb7f2aa91.png">
