### PR TITLE
Hide import counters when nothing is imported

### DIFF
--- a/assets/data-port/import/data/selectors.js
+++ b/assets/data-port/import/data/selectors.js
@@ -115,7 +115,7 @@ export const getSuccessResults = ( { done } ) =>
 		count:
 			get( done, [ 'results', key, 'success' ], 0 ) +
 			get( done, [ 'results', key, 'warning' ], 0 ),
-	} ) );
+	} ) ).filter( ( { count } ) => count > 0 );
 
 /**
  * Get logs by severity.

--- a/assets/data-port/import/data/selectors.test.js
+++ b/assets/data-port/import/data/selectors.test.js
@@ -238,7 +238,7 @@ describe( 'Importer selectors', () => {
 						success: 2,
 					},
 					question: {
-						success: 3,
+						success: 0,
 					},
 				},
 			},
@@ -252,10 +252,6 @@ describe( 'Importer selectors', () => {
 			{
 				key: 'lesson',
 				count: 2,
-			},
-			{
-				key: 'question',
-				count: 3,
 			},
 		];
 

--- a/assets/data-port/import/done/done-page.js
+++ b/assets/data-port/import/done/done-page.js
@@ -74,14 +74,24 @@ export const DonePage = ( {
 			<section className="sensei-data-port-step">
 				<Section className="sensei-data-port-step__body">
 					<h2>{ __( 'Completed', 'sensei-lms' ) }</h2>
-					<p className="sensei-import-done__section-description">
-						{ __(
-							'The following content was imported:',
-							'sensei-lms'
-						) }
-					</p>
+					{ successResults.length > 0 ? (
+						<>
+							<p className="sensei-import-done__section-description">
+								{ __(
+									'The following content was imported:',
+									'sensei-lms'
+								) }
+							</p>
 
-					<ImportSuccessResults successResults={ successResults } />
+							<ImportSuccessResults
+								successResults={ successResults }
+							/>
+						</>
+					) : (
+						<p className="sensei-import-done__section-description">
+							{ __( 'No content was imported.', 'sensei-lms' ) }
+						</p>
+					) }
 
 					<div className="sensei-data-port-step__footer">
 						<Button isPrimary onClick={ restartImporter }>

--- a/assets/data-port/import/done/done-page.test.js
+++ b/assets/data-port/import/done/done-page.test.js
@@ -42,6 +42,15 @@ describe( '<DonePage />', () => {
 		expect( success ).toContain( '0 lessons' );
 	} );
 
+	it( 'should show message saying that no content was imported', () => {
+		const { queryByText } = render( <DonePage successResults={ [] } /> );
+
+		expect(
+			queryByText( 'The following content was imported:' )
+		).toBeFalsy();
+		expect( queryByText( 'No content was imported.' ) ).toBeTruthy();
+	} );
+
 	it( 'should show import log', () => {
 		const logs = {
 			error: [


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/pull/3394#issuecomment-657570373

### Changes proposed in this Pull Request

* Hide import counters when nothing is imported.

### Testing instructions

* Import some CSV which results in no imported content and make sure that the message `No content was imported.` appears in the Done page without any counter.
* Import some a Course CSV with valid lines. It should show counters only to the imported courses.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="800" alt="Screen Shot 2020-07-13 at 14 22 26" src="https://user-images.githubusercontent.com/876340/87333959-4c661e00-c514-11ea-8bfe-47ff0759253a.png">

<img width="799" alt="Screen Shot 2020-07-13 at 14 25 20" src="https://user-images.githubusercontent.com/876340/87334233-b383d280-c514-11ea-897a-192e0cfd7fb2.png">
