### PR TITLE
Add validation to multiple choice questions without a right answer.

### DIFF
--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -37,6 +37,20 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 	 * @return true|WP_Error
 	 */
 	public function sync_post() {
+		$question_type = $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_TYPE );
+
+		// Check if multiple choice has a right answer.
+		if ( 'multiple-choice' === $question_type ) {
+			$answers = $this->parse_multiple_choice_answers();
+
+			if ( empty( $answers['_question_right_answer'] ) ) {
+				return new WP_Error(
+					'sensei_data_port_question_without_right_answer',
+					__( 'Question does not contain a right answer.', 'sensei-lms' )
+				);
+			}
+		}
+
 		$post_id = wp_insert_post( $this->get_post_array(), true );
 
 		if ( is_wp_error( $post_id ) ) {

--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -288,6 +288,10 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 	 * @return array
 	 */
 	private function parse_multiple_choice_answers() {
+		if ( isset( $this->processed_multiple_choice_answers ) ) {
+			return $this->processed_multiple_choice_answers;
+		}
+
 		$values = [
 			'_question_right_answer'  => [],
 			'_question_wrong_answers' => [],
@@ -320,6 +324,8 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 		$values['_answer_order']       = implode( ',', $values['_answer_order'] );
 		$values['_right_answer_count'] = count( $values['_question_right_answer'] );
 		$values['_wrong_answer_count'] = count( $values['_question_wrong_answers'] );
+
+		$this->processed_multiple_choice_answers = $values;
 
 		return $values;
 	}

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
@@ -137,6 +137,19 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 				],
 				false,
 			],
+			'invalid-multiple-choice'         => [
+				[
+					Sensei_Data_Port_Question_Schema::COLUMN_ID     => '<strong>1234</strong>',
+					Sensei_Data_Port_Question_Schema::COLUMN_ANSWER => 'Wrong:No, Wrong:"Maybe, it depends"',
+					Sensei_Data_Port_Question_Schema::COLUMN_TYPE   => 'multiple-choice',
+				],
+				[
+					Sensei_Data_Port_Question_Schema::COLUMN_ID     => '1234',
+					Sensei_Data_Port_Question_Schema::COLUMN_ANSWER => 'Wrong:No, Wrong:"Maybe, it depends"',
+					Sensei_Data_Port_Question_Schema::COLUMN_TYPE   => 'multiple-choice',
+				],
+				false,
+			],
 			'valid-gap-fill'                  => [
 				[
 					Sensei_Data_Port_Question_Schema::COLUMN_ID              => '<strong>1234</strong>',
@@ -292,6 +305,20 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected_answer_order, get_post_meta( $post->ID, '_answer_order', true ) );
 		$this->assertTrue( has_term( 'multiple-choice', Sensei_Data_Port_Question_Schema::TAXONOMY_QUESTION_TYPE, $post->ID ), 'Expected the question type to be correct' );
+	}
+
+	/**
+	 * Check to make sure multiple choice with no answer throws error.
+	 */
+	public function testMultipleChoiceNoAnswer() {
+		$test_data = $this->lineData()['invalid-multiple-choice'][0];
+
+		$task   = new Sensei_Import_Questions( Sensei_Import_Job::create( 'test', 0 ) );
+		$model  = Sensei_Import_Question_Model::from_source_array( 1, $test_data, new Sensei_Data_Port_Question_Schema(), $task );
+		$result = $model->sync_post();
+
+		$this->assertWPError( $result );
+		$this->assertEquals( 'sensei_data_port_question_without_right_answer', $result->get_error_code() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3395

### Changes proposed in this Pull Request

* Add validation to multiple choice questions without a right answer.

Initially, I considered do it with a regular expression validation in the schema, but although it looks cleaner, I found 3 cons:
  * It would not show a friendly message (unless we refactored some codes).
  * It would be a code disconnected from the code that parses it, which could cause some issues in the future while maintaining.
  * The regular expression would be very complex considering answers choices with coma, quotes, and so on.

So I decided to do it in the model, where the data is parsed. And I had to anticipate de multiple choice answers parsing to before the post creation.

### Testing instructions

* Import a file like mentioned in the issue:
```
ID,Question,Slug,Description,Status,Type,Grade,Random Answer Order,Media,Categories,Answer,Feedback,Text Before Gap,Gap,Text After Gap,Upload Notes,Teacher Notes
4,What minor key signature has no accidentals (sharps or flats)?,,,,,3,false,,,Wrong:Answer,,,,,,
6,How many white keys does a standard piano have?,,,,,,,,,,,,,,,
```
* Make sure the questions weren't created and an error appear in the log saying `Question does not contain a right answer.`
* Import a CSV file with valid questions (with at least a right answer) and make sure it's imported correctly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="838" alt="Screen Shot 2020-07-13 at 17 22 49" src="https://user-images.githubusercontent.com/876340/87349929-7ed04500-c52d-11ea-850f-6ef3e0a51c5d.png">