### PR TITLE
Add setup_wizard_features_install_paid event

### DIFF
--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -613,7 +613,7 @@ class Sensei_Setup_Wizard {
 			}
 		}
 
-		if ( ! empty( $wccom_extensions ) ) {
+		if ( Sensei()->usage_tracking->is_tracking_enabled() && ! empty( $wccom_extensions ) ) {
 			$event_name       = 'setup_wizard_features_install_paid';
 			$event_properties = [ 'slug' => join( ',', $wccom_extensions ) ];
 			$event_tracked    = false;

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -616,11 +616,14 @@ class Sensei_Setup_Wizard {
 		if ( ! empty( $wccom_extensions ) ) {
 			$event_name       = 'setup_wizard_features_install_paid';
 			$event_properties = [ 'slug' => join( ',', $wccom_extensions ) ];
+			$event_tracked    = false;
 
 			if ( class_exists( 'Automattic\Jetpack\Tracking' ) ) {
-				$tracking = new Automattic\Jetpack\Tracking( 'sensei' );
-				$tracking->record_user_event( $event_name, $event_properties );
-			} else {
+				$tracking      = new Automattic\Jetpack\Tracking( 'sensei' );
+				$event_tracked = $tracking->record_user_event( $event_name, $event_properties );
+			}
+
+			if ( ! $event_tracked ) {
 				sensei_log_event( $event_name, $event_properties );
 			}
 		}

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -618,8 +618,11 @@ class Sensei_Setup_Wizard {
 			$event_properties = [ 'slug' => join( ',', $wccom_extensions ) ];
 
 			if ( class_exists( 'Automattic\Jetpack\Tracking' ) ) {
-				$tracking = new Automattic\Jetpack\Tracking( 'sensei' );
-				$tracking->record_user_event( $event_name, $event_properties );
+				$jetpack_connection = Jetpack::connection();
+				if ( $jetpack_connection->is_user_connected() ) {
+					$tracking = new Automattic\Jetpack\Tracking( 'sensei', $jetpack_connection );
+					$tracking->record_user_event( $event_name, $event_properties );
+				}
 			}
 		}
 

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -607,9 +607,21 @@ class Sensei_Setup_Wizard {
 			}
 
 			if ( isset( $extension->wccom_product_id ) ) {
-				$wccom_extensions[] = $extension->plugin_file;
+				$wccom_extensions[] = $extension->product_slug;
 			} else {
 				$extensions_to_install[] = $extension;
+			}
+		}
+
+		if ( ! empty( $wccom_extensions ) ) {
+			$event_name       = 'setup_wizard_features_install_paid';
+			$event_properties = [ 'slug' => join( ',', $wccom_extensions ) ];
+
+			if ( class_exists( 'Automattic\Jetpack\Tracking' ) ) {
+				$tracking = new Automattic\Jetpack\Tracking( 'sensei' );
+				$tracking->record_user_event( $event_name, $event_properties );
+			} else {
+				sensei_log_event( $event_name, $event_properties );
 			}
 		}
 

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -616,15 +616,10 @@ class Sensei_Setup_Wizard {
 		if ( Sensei()->usage_tracking->is_tracking_enabled() && ! empty( $wccom_extensions ) ) {
 			$event_name       = 'setup_wizard_features_install_paid';
 			$event_properties = [ 'slug' => join( ',', $wccom_extensions ) ];
-			$event_tracked    = false;
 
 			if ( class_exists( 'Automattic\Jetpack\Tracking' ) ) {
-				$tracking      = new Automattic\Jetpack\Tracking( 'sensei' );
-				$event_tracked = $tracking->record_user_event( $event_name, $event_properties );
-			}
-
-			if ( ! $event_tracked ) {
-				sensei_log_event( $event_name, $event_properties );
+				$tracking = new Automattic\Jetpack\Tracking( 'sensei' );
+				$tracking->record_user_event( $event_name, $event_properties );
 			}
 		}
 


### PR DESCRIPTION
Fixes #3334

### Changes proposed in this Pull Request

* Track a `sensei_setup_wizard_features_install_paid` event when installing WCCOM features in the Setup Wizard.
* Use Jetpack when it's set up, which sets the Wordpress.com user ID
* ~~If Jetpack is not connected, fall back to regular Sensei event tracking~~

### Testing instructions

* Set up a test site with Jetpack connected
* Go trough Sensei setup wizard and select a paid feature, click `Install now`
* Tracking event should have useridtype as `wpcom:user_id` and the Wordpress.com user id used
