### PR TITLE
Add meta handler for remove/restore learner

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -483,7 +483,7 @@ class Sensei_Course_Enrolment {
 	 *
 	 * @return boolean Success flag.
 	 */
-	public function restore_removed_learner( $user_id ) {
+	public function restore_learner( $user_id ) {
 		$removed_learners = $this->get_removed_learners();
 
 		unset( $removed_learners[ $user_id ] );

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -29,6 +29,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Course_Enrolment {
 	const META_PREFIX_ENROLMENT_RESULTS = 'sensei_course_enrolment_';
 	const META_COURSE_ENROLMENT_VERSION = '_course_enrolment_version';
+	const META_PREFIX_REMOVED_LEARNER   = 'sensei_removed_learner_';
 
 	/**
 	 * Courses instances.
@@ -443,5 +444,16 @@ class Sensei_Course_Enrolment {
 		update_post_meta( $this->course_id, self::META_COURSE_ENROLMENT_VERSION, $new_salt );
 
 		return $new_salt;
+	}
+
+	/**
+	 * Get removed learner meta key.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return string The meta key.
+	 */
+	private function get_removed_learner_meta_key( $user_id ) {
+		return self::META_PREFIX_REMOVED_LEARNER . $user_id;
 	}
 }

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -456,4 +456,40 @@ class Sensei_Course_Enrolment {
 	private function get_removed_learner_meta_key( $user_id ) {
 		return self::META_PREFIX_REMOVED_LEARNER . $user_id;
 	}
+
+	/**
+	 * Remove learner from the course, overriding the providers rule.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return int|false Meta ID on success, false on failure.
+	 */
+	public function remove_learner( $user_id ) {
+		$meta_key = $this->get_removed_learner_meta_key( $user_id );
+		return add_post_meta( $this->course_id, $meta_key, true, true );
+	}
+
+	/**
+	 * Restore removed learner enrolment, giving the control back to the providers.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return boolean Success flag.
+	 */
+	public function restore_removed_learner( $user_id ) {
+		$meta_key = $this->get_removed_learner_meta_key( $user_id );
+		return delete_post_meta( $this->course_id, $meta_key );
+	}
+
+	/**
+	 * Check if the user is removed.
+	 *
+	 * @param int $user_id
+	 *
+	 * @return boolean Whether the learner is removed.
+	 */
+	public function check_removed_learner( $user_id ) {
+		$meta_key = $this->get_removed_learner_meta_key( $user_id );
+		return (bool) get_post_meta( $this->course_id, $meta_key, true );
+	}
 }

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -475,7 +475,7 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 		$this->assertNotFalse( $course_enrolment->remove_learner( $user_id ) );
 		$this->assertTrue( $course_enrolment->is_learner_removed( $user_id ) );
 
-		$this->assertTrue( $course_enrolment->restore_removed_learner( $user_id ) );
+		$this->assertTrue( $course_enrolment->restore_learner( $user_id ) );
 		$this->assertFalse( $course_enrolment->is_learner_removed( $user_id ) );
 	}
 

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -473,10 +473,10 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
 		$this->assertNotFalse( $course_enrolment->remove_learner( $user_id ) );
-		$this->assertTrue( $course_enrolment->check_removed_learner( $user_id ) );
+		$this->assertTrue( $course_enrolment->is_learner_removed( $user_id ) );
 
 		$this->assertTrue( $course_enrolment->restore_removed_learner( $user_id ) );
-		$this->assertFalse( $course_enrolment->check_removed_learner( $user_id ) );
+		$this->assertFalse( $course_enrolment->is_learner_removed( $user_id ) );
 	}
 
 	/**

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment.php
@@ -465,6 +465,33 @@ class Sensei_Course_Enrolment_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests remove and restore learner.
+	 */
+	public function testRemoveAndRestoreLearner() {
+		$course_id        = $this->getSimpleCourse();
+		$user_id          = 123;
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+
+		$this->assertNotFalse( $course_enrolment->remove_learner( $user_id ) );
+		$this->assertTrue( $course_enrolment->check_removed_learner( $user_id ) );
+
+		$this->assertTrue( $course_enrolment->restore_removed_learner( $user_id ) );
+		$this->assertFalse( $course_enrolment->check_removed_learner( $user_id ) );
+	}
+
+	/**
+	 * Tests that it is not possible to remove again a learner already removed.
+	 */
+	public function testRemoveLearnerTwice() {
+		$course_id        = $this->getSimpleCourse();
+		$user_id          = 123;
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+
+		$this->assertNotFalse( $course_enrolment->remove_learner( $user_id ) );
+		$this->assertFalse( $course_enrolment->remove_learner( $user_id ) );
+	}
+
+	/**
 	 * Helper for `\Sensei_Class_Course_Enrolment_Test::testEnrolmentCheckVersionCachingWorks`.
 	 */
 	private function resetAndSetUpVersionedProvider( $bump_version ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add methods to handle the "remove enrollment" data.
  * Our naming in the screen will be `Remove Enrollment` / `Restore Enrollment`. But for these methods, I named `remove_learner` / `restore_removed_learner` because it seems to make more sense for this part of the implementation. We are adding the learners to a "blacklist" meta in the course. WDYT?
* Part of the task was `Remove meta on plugin uninstall`, but I skipped that because the meta is connected to the course post. I noticed that the course posts are moved to the trash on uninstall instead of to be removed, so it doesn't remove the meta immediately after the uninstall, but when the post is removed, the meta will be too.


### Testing instructions

* There are no tests for now. Just running the unit tests.