### PR TITLE
Change learner management actions UI

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -563,6 +563,12 @@
 				color: #fff;
 			}
 		}
+
+		.row-actions {
+			a {
+				cursor: pointer;
+			}
+		}
 	}
 }
 

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -529,6 +529,7 @@
 			span  {
 				padding: 5px 10px;
 				@include border_radius(3px);
+				white-space: nowrap;
 			}
 			.ungraded  {
 				background: darken($bg_light, 5%);
@@ -554,6 +555,7 @@
 			span  {
 				padding: 5px 10px;
 				@include border_radius(3px);
+				white-space: nowrap;
 			}
 			.not-enrolled  {
 				background: darken($bg_light, 5%);

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -570,10 +570,6 @@
 			a {
 				cursor: pointer;
 			}
-			.disabled {
-				color: inherit;
-				cursor: not-allowed;
-			}
 		}
 	}
 }

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -570,6 +570,10 @@
 			a {
 				cursor: pointer;
 			}
+			.disabled {
+				color: inherit;
+				cursor: not-allowed;
+			}
 		}
 	}
 }

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -469,15 +469,6 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 									esc_html__( 'Enroll', 'sensei-lms' ) .
 								'</a>' .
 							'</span>';
-					} else {
-						$manual_enrolment_disabled_reason = __( 'Enrollment is given by another provider.', 'sensei-lms' );
-
-						$row_actions[] =
-							'<span>' .
-								'<a class="learner-action disabled" disabled="disabled" title="' . esc_attr( $manual_enrolment_disabled_reason ) . '">' .
-									esc_html__( 'Enroll', 'sensei-lms' ) .
-								'</a>' .
-							'</span>';
 					}
 				}
 

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -488,7 +488,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$column_data = apply_filters(
 					'sensei_learners_main_column_data',
 					array(
-						'title'            => '<strong><a class="row-title" href="' . esc_url( admin_url( 'user-edit.php?user_id=' . $user_activity->user_id ) ) . '" title="' . esc_attr( $a_title ) . '">' . esc_html( $title ) . '</a></strong><div class="row-actions visible">' . implode( ' | ', $row_actions ) . '</div>',
+						'title'            => '<strong><a class="row-title" href="' . esc_url( admin_url( 'user-edit.php?user_id=' . $user_activity->user_id ) ) . '" title="' . esc_attr( $a_title ) . '">' . esc_html( $title ) . '</a></strong><div class="row-actions">' . implode( ' | ', $row_actions ) . '</div>',
 						'date_started'     => get_comment_meta( $user_activity->comment_ID, 'start', true ),
 						'date_completed'   => ( 'complete' === $user_activity->comment_approved ) ? $user_activity->comment_date : '',
 						'user_status'      => $progress_status_html,

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -444,7 +444,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 						$row_actions[] =
 							'<span class="delete">' .
 								'<a class="learner-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="withdraw" href="' . esc_url( $withdraw_action_url ) . '">' .
-									esc_html__( 'Remove enrollment', 'sensei-lms' ) .
+									esc_html__( 'Remove Enrollment', 'sensei-lms' ) .
 								'</a>' .
 							'</span>';
 					} elseif ( ! $is_user_enrolled ) {
@@ -473,10 +473,10 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				}
 
 				$reset_action = 'reset_progress';
-				$reset_label  = esc_html__( 'Reset progress', 'sensei-lms' );
+				$reset_label  = esc_html__( 'Reset Progress', 'sensei-lms' );
 				if ( 'course' === $post_type && ! $is_user_enrolled ) {
 					$reset_action = 'remove_progress';
-					$reset_label  = esc_html__( 'Remove progress', 'sensei-lms' );
+					$reset_label  = esc_html__( 'Remove Progress', 'sensei-lms' );
 				}
 
 				$row_actions[] =

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -406,7 +406,8 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$a_title              = sprintf( esc_html__( 'Edit &#8220;%s&#8221;', 'sensei-lms' ), esc_html( $title ) );
 				$edit_start_date_form = $this->get_edit_start_date_form( $user_activity, $post_id, $post_type, $object_type );
 
-				$actions = [];
+				$actions     = [];
+				$row_actions = [];
 
 				$enrolment_manager         = Sensei_Course_Enrolment_Manager::instance();
 				$manual_enrolment_provider = $enrolment_manager->get_manual_enrolment_provider();
@@ -428,7 +429,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 							'sensei-learner-action-withdraw'
 						);
 
-						$actions[] = '<a class="learner-action button" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="withdraw" href="' . esc_url( $withdraw_action_url ) . '">' . esc_html__( 'Remove manual enrollment', 'sensei-lms' ) . '</a>';
+						$row_actions[] = '<span class="delete"><a class="learner-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="withdraw" href="' . esc_url( $withdraw_action_url ) . '">' . esc_html__( 'Remove enrollment', 'sensei-lms' ) . '</a></span>';
 					} elseif ( ! $is_user_enrolled ) {
 						$enrol_action_url = wp_nonce_url(
 							add_query_arg(
@@ -445,11 +446,11 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 							'sensei-learner-action-enrol'
 						);
 
-						$actions[] = '<a class="learner-action button" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="enrol" href="' . esc_url( $enrol_action_url ) . '">' . esc_html__( 'Manually enroll learner', 'sensei-lms' ) . '</a>';
+						$row_actions[] = '<span><a class="learner-action" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="enrol" href="' . esc_url( $enrol_action_url ) . '">' . esc_html__( 'Enroll', 'sensei-lms' ) . '</a></span>';
 					} else {
 						$manual_enrolment_disabled_reason = __( 'Enrollment is given by another provider.', 'sensei-lms' );
 
-						$actions[] = '<a class="learner-action button disabled" disabled="disabled" title="' . esc_attr( $manual_enrolment_disabled_reason ) . '">' . esc_html__( 'Manually enroll learner', 'sensei-lms' ) . '</a>';
+						$row_actions[] = '<span><a class="learner-action disabled" disabled="disabled" title="' . esc_attr( $manual_enrolment_disabled_reason ) . '">' . esc_html__( 'Enroll', 'sensei-lms' ) . '</a></span>';
 					}
 				}
 
@@ -460,7 +461,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 					$reset_label  = esc_html__( 'Remove progress', 'sensei-lms' );
 				}
 
-				$actions[] = '<a class="learner-async-action button" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="' . esc_attr( $reset_action ) . '" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' . $reset_label . '</a>';
+				$row_actions[] = '<span class="delete"><a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="' . esc_attr( $reset_action ) . '" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' . $reset_label . '</a></span>';
 
 				if ( $edit_start_date_form ) {
 					$actions[] = $edit_start_date_form;
@@ -487,7 +488,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$column_data = apply_filters(
 					'sensei_learners_main_column_data',
 					array(
-						'title'            => '<strong><a class="row-title" href="' . esc_url( admin_url( 'user-edit.php?user_id=' . $user_activity->user_id ) ) . '" title="' . esc_attr( $a_title ) . '">' . esc_html( $title ) . '</a></strong>',
+						'title'            => '<strong><a class="row-title" href="' . esc_url( admin_url( 'user-edit.php?user_id=' . $user_activity->user_id ) ) . '" title="' . esc_attr( $a_title ) . '">' . esc_html( $title ) . '</a></strong><div class="row-actions visible">' . implode( ' | ', $row_actions ) . '</div>',
 						'date_started'     => get_comment_meta( $user_activity->comment_ID, 'start', true ),
 						'date_completed'   => ( 'complete' === $user_activity->comment_approved ) ? $user_activity->comment_date : '',
 						'user_status'      => $progress_status_html,

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -351,11 +351,17 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 				if ( 'complete' === $user_activity->comment_approved || 'graded' === $user_activity->comment_approved || 'passed' === $user_activity->comment_approved ) {
 
-					$progress_status_html = '<span class="graded">' . esc_html__( 'Completed', 'sensei-lms' ) . '</span>';
+					$progress_status_html =
+						'<span class="graded">' .
+							esc_html__( 'Completed', 'sensei-lms' ) .
+						'</span>';
 
 				} else {
 
-					$progress_status_html = '<span class="in-progress">' . esc_html__( 'In Progress', 'sensei-lms' ) . '</span>';
+					$progress_status_html =
+						'<span class="in-progress">' .
+							esc_html__( 'In Progress', 'sensei-lms' ) .
+						'</span>';
 
 				}
 
@@ -381,7 +387,10 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 								$item_class = 'provides-enrolment';
 							}
 
-							$enrolment_tooltip_html[] = '<li class="' . esc_attr( $item_class ) . '">' . esc_html( $name ) . '</li>';
+							$enrolment_tooltip_html[] =
+								'<li class="' . esc_attr( $item_class ) . '">' .
+									esc_html( $name ) .
+								'</li>';
 						}
 
 						$enrolment_tooltip_html[] = '</ul>';
@@ -399,7 +408,10 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 					$enrolment_label_extra_class = 'not-enrolled';
 				}
 
-				$enrolment_status_html = '<span class="sensei-tooltip ' . esc_attr( $enrolment_label_extra_class ) . '" data-tooltip="' . esc_attr( htmlentities( $enrolment_tooltip_html ) ) . '">' . esc_html( $enrolment_label ) . '</span>';
+				$enrolment_status_html =
+					'<span class="sensei-tooltip ' . esc_attr( $enrolment_label_extra_class ) . '" data-tooltip="' . esc_attr( htmlentities( $enrolment_tooltip_html ) ) . '">' .
+						esc_html( $enrolment_label ) .
+					'</span>';
 
 				$title = Sensei_Learner::get_full_name( $user_activity->user_id );
 				// translators: Placeholder is the full name of the learner.
@@ -429,7 +441,12 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 							'sensei-learner-action-withdraw'
 						);
 
-						$row_actions[] = '<span class="delete"><a class="learner-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="withdraw" href="' . esc_url( $withdraw_action_url ) . '">' . esc_html__( 'Remove enrollment', 'sensei-lms' ) . '</a></span>';
+						$row_actions[] =
+							'<span class="delete">' .
+								'<a class="learner-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="withdraw" href="' . esc_url( $withdraw_action_url ) . '">' .
+									esc_html__( 'Remove enrollment', 'sensei-lms' ) .
+								'</a>' .
+							'</span>';
 					} elseif ( ! $is_user_enrolled ) {
 						$enrol_action_url = wp_nonce_url(
 							add_query_arg(
@@ -446,11 +463,21 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 							'sensei-learner-action-enrol'
 						);
 
-						$row_actions[] = '<span><a class="learner-action" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="enrol" href="' . esc_url( $enrol_action_url ) . '">' . esc_html__( 'Enroll', 'sensei-lms' ) . '</a></span>';
+						$row_actions[] =
+							'<span>' .
+								'<a class="learner-action" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="enrol" href="' . esc_url( $enrol_action_url ) . '">' .
+									esc_html__( 'Enroll', 'sensei-lms' ) .
+								'</a>' .
+							'</span>';
 					} else {
 						$manual_enrolment_disabled_reason = __( 'Enrollment is given by another provider.', 'sensei-lms' );
 
-						$row_actions[] = '<span><a class="learner-action disabled" disabled="disabled" title="' . esc_attr( $manual_enrolment_disabled_reason ) . '">' . esc_html__( 'Enroll', 'sensei-lms' ) . '</a></span>';
+						$row_actions[] =
+							'<span>' .
+								'<a class="learner-action disabled" disabled="disabled" title="' . esc_attr( $manual_enrolment_disabled_reason ) . '">' .
+									esc_html__( 'Enroll', 'sensei-lms' ) .
+								'</a>' .
+							'</span>';
 					}
 				}
 
@@ -461,7 +488,12 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 					$reset_label  = esc_html__( 'Remove progress', 'sensei-lms' );
 				}
 
-				$row_actions[] = '<span class="delete"><a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="' . esc_attr( $reset_action ) . '" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' . $reset_label . '</a></span>';
+				$row_actions[] =
+					'<span class="delete">' .
+						'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="' . esc_attr( $reset_action ) . '" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' .
+							$reset_label .
+						'</a>' .
+					'</span>';
 
 				if ( $edit_start_date_form ) {
 					$actions[] = $edit_start_date_form;
@@ -488,7 +520,15 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$column_data = apply_filters(
 					'sensei_learners_main_column_data',
 					array(
-						'title'            => '<strong><a class="row-title" href="' . esc_url( admin_url( 'user-edit.php?user_id=' . $user_activity->user_id ) ) . '" title="' . esc_attr( $a_title ) . '">' . esc_html( $title ) . '</a></strong><div class="row-actions">' . implode( ' | ', $row_actions ) . '</div>',
+						'title'            =>
+							'<strong>' .
+								'<a class="row-title" href="' . esc_url( admin_url( 'user-edit.php?user_id=' . $user_activity->user_id ) ) . '" title="' . esc_attr( $a_title ) . '">' .
+									esc_html( $title ) .
+								'</a>' .
+							'</strong>' .
+							'<div class="row-actions">' .
+								implode( ' | ', $row_actions ) .
+							'</div>',
 						'date_started'     => get_comment_meta( $user_activity->comment_ID, 'start', true ),
 						'date_completed'   => ( 'complete' === $user_activity->comment_approved ) ? $user_activity->comment_date : '',
 						'user_status'      => $progress_status_html,
@@ -558,7 +598,12 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$column_data = apply_filters(
 					'sensei_learners_main_column_data',
 					array(
-						'title'        => '<strong><a class="row-title" href="' . esc_url( admin_url( 'post.php?action=edit&post=' . $item->ID ) ) . '" title="' . esc_attr( $a_title ) . '">' . esc_html( $title ) . '</a></strong>',
+						'title'        =>
+							'<strong>' .
+								'<a class="row-title" href="' . esc_url( admin_url( 'post.php?action=edit&post=' . $item->ID ) ) . '" title="' . esc_attr( $a_title ) . '">' .
+									esc_html( $title ) .
+								'</a>' .
+							'</strong>',
 						'num_learners' => esc_html( $lesson_learners ),
 						'updated'      => esc_html( $item->post_modified ),
 						'actions'      => '<a class="button" href="' . esc_url(
@@ -612,16 +657,21 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$column_data = apply_filters(
 					'sensei_learners_main_column_data',
 					array(
-						'title'        => '<strong><a class="row-title" href="' . esc_url(
-							add_query_arg(
-								array(
-									'page'      => 'sensei_learners',
-									'course_id' => $item->ID,
-									'view'      => 'learners',
-								),
-								admin_url( 'admin.php' )
-							)
-						) . '" title="' . esc_attr( $a_title ) . '">' . esc_html( $title ) . '</a></strong>',
+						'title'        =>
+							'<strong>' .
+								'<a class="row-title" href="' . esc_url(
+									add_query_arg(
+										array(
+											'page'      => 'sensei_learners',
+											'course_id' => $item->ID,
+											'view'      => 'learners',
+										),
+										admin_url( 'admin.php' )
+									)
+								) . '" title="' . esc_attr( $a_title ) . '">' .
+									esc_html( $title ) .
+								'</a>' .
+							'</strong>',
 						'num_learners' => esc_html( $course_learners ),
 						'updated'      => esc_html( $item->post_modified ),
 						'actions'      => '<a class="button" href="' . esc_url(

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -492,7 +492,6 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 						'date_completed'   => ( 'complete' === $user_activity->comment_approved ) ? $user_activity->comment_date : '',
 						'user_status'      => $progress_status_html,
 						'enrolment_status' => $enrolment_status_html,
-						// translators: Placeholder is the "object type"; lesson or course.
 						'actions'          => implode( ' ', $actions ),
 					),
 					$item,


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei-wc-paid-courses/issues/497

### Changes proposed in this Pull Request

* These changes handle only the design.
  * The features will be in a separate PR.

### Testing instructions

If you don't have:
* Create a course.
* Create some users.
* Start the course progress with some users.
* Manually enroll some users (Enroll link) and unenroll others.
* Enroll a user with another provider.

Then:
* Go to WP admin > Sensei LMS > Learner Management.
* Choose a course to manage the learners.
* Check the new design.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1115" alt="Screen Shot 2020-07-14 at 17 20 27" src="https://user-images.githubusercontent.com/876340/87472643-a6d7ab00-c5f6-11ea-8f5b-663a731649fd.png">

