### PR TITLE
Add Exporter page

### DIFF
--- a/assets/data-port/export.js
+++ b/assets/data-port/export.js
@@ -19,7 +19,7 @@ const SenseiExportPage = () => {
 					<p>
 						{ __(
 							'This tool enables you to generate and download one or more CSV files containing a list of all courses, ' +
-								'lessons and quizzes, or questions. Separate CSV files are generated for each content type.',
+								'lessons, or questions. Separate CSV files are generated for each content type.',
 							'sensei-lms'
 						) }
 					</p>

--- a/assets/data-port/export.js
+++ b/assets/data-port/export.js
@@ -1,0 +1,29 @@
+import { H } from '@woocommerce/components';
+import { __ } from '@wordpress/i18n';
+import { render } from '@wordpress/element';
+
+/**
+ * Sensei import page.
+ */
+const SenseiExportPage = () => {
+	return (
+		<div className="sensei-import-wrapper">
+			<section className="sensei-data-port-step sensei-export-page">
+				<header className="sensei-data-port-step__header">
+					<H>
+						{ __( 'Export content to a CSV file', 'sensei-lms' ) }
+					</H>
+					<p>
+						{ __(
+							'This tool enables you to generate and download one or more CSV files containing a list of all courses, ' +
+								'lessons and quizzes, or questions. Separate CSV files are generated for each content type.',
+							'sensei-lms'
+						) }
+					</p>
+				</header>
+			</section>
+		</div>
+	);
+};
+
+render( <SenseiExportPage />, document.getElementById( 'sensei-export-page' ) );

--- a/assets/data-port/export.js
+++ b/assets/data-port/export.js
@@ -1,11 +1,13 @@
 import { H } from '@woocommerce/components';
 import { __ } from '@wordpress/i18n';
 import { render } from '@wordpress/element';
+import { useSenseiColorTheme } from '../react-hooks/use-sensei-color-theme';
 
 /**
- * Sensei import page.
+ * Sensei export page.
  */
 const SenseiExportPage = () => {
+	useSenseiColorTheme();
 	return (
 		<div className="sensei-import-wrapper">
 			<section className="sensei-data-port-step sensei-export-page">

--- a/assets/data-port/export.js
+++ b/assets/data-port/export.js
@@ -8,9 +8,10 @@ import { useSenseiColorTheme } from '../react-hooks/use-sensei-color-theme';
  */
 const SenseiExportPage = () => {
 	useSenseiColorTheme();
+
 	return (
-		<div className="sensei-import-wrapper">
-			<section className="sensei-data-port-step sensei-export-page">
+		<div className="sensei-page-export">
+			<section className="sensei-data-port-step">
 				<header className="sensei-data-port-step__header">
 					<H>
 						{ __( 'Export content to a CSV file', 'sensei-lms' ) }

--- a/assets/data-port/import.js
+++ b/assets/data-port/import.js
@@ -51,7 +51,7 @@ const SenseiImportPage = () => {
 	const currentStep = navigationSteps.find( ( step ) => step.isNext );
 
 	return (
-		<div className="sensei-import-wrapper">
+		<div className="sensei-page-import">
 			<DataPortStepper steps={ navigationSteps } />
 			{ currentStep.container }
 		</div>

--- a/assets/data-port/import.js
+++ b/assets/data-port/import.js
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { render, useLayoutEffect } from '@wordpress/element';
+import { useSenseiColorTheme } from '../react-hooks/use-sensei-color-theme';
 import { DataPortStepper } from './stepper';
 import registerImportStore from './import/data';
 import { Spinner } from '@woocommerce/components';
@@ -28,12 +29,7 @@ const SenseiImportPage = () => {
 		fetchCurrentJobState();
 	}, [ fetchCurrentJobState ] );
 
-	// Add `sensei-color` to body tag.
-	useLayoutEffect( () => {
-		document.body.classList.add( [ 'sensei-color' ] );
-
-		return () => document.body.classList.remove( [ 'sensei-color' ] );
-	} );
+	useSenseiColorTheme();
 
 	if ( isFetching ) {
 		return <Spinner className="sensei-import__main-loader" />;

--- a/assets/data-port/style.scss
+++ b/assets/data-port/style.scss
@@ -25,167 +25,176 @@ $white: #ffffff;
 
 $alert-red: #d94f4f;
 
-@import "import/done/import-done";
-@import "import/upload/upload-page";
-@import "import/import-progress/import-progress-page";
+@import 'import/done/import-done';
+@import 'import/upload/upload-page';
+@import 'import/import-progress/import-progress-page';
 
 .sensei-import {
 	&__main-loader {
 		position: fixed;
 		left: 50%;
-		top:50%;
+		top: 50%;
 		transform: translate(-50%, -50%);
 	}
 }
 
-.sensei-import-wrapper {
+.sensei-page-import {
 	text-align: center;
 	max-width: 700px;
 	margin: 40px auto;
+}
 
-	.sensei-data-port-steps {
-		padding: 0 0 24px;
+.sensei-page-export {
+	text-align: center;
+	max-width: 700px;
+	margin: 40px auto;
+}
+
+.sensei-data-port-steps {
+	padding: 0 0 24px;
+	margin: 0;
+	list-style: none outside;
+	overflow: hidden;
+	color: #ccc;
+	width: 100%;
+	display: -webkit-inline-flex;
+	display: -ms-inline-flexbox;
+	display: inline-flex;
+
+	li {
+		width: 33.33%;
+		float: left;
+		padding: 0 0 0.8em;
 		margin: 0;
-		list-style: none outside;
-		overflow: hidden;
-		color: #ccc;
-		width: 100%;
-		display: -webkit-inline-flex;
-		display: -ms-inline-flexbox;
-		display: inline-flex;
-
-		li {
-			width: 33.33%;
-			float: left;
-			padding: 0 0 0.8em;
-			margin: 0;
-			text-align: center;
-			position: relative;
-			border-bottom: 4px solid #ccc;
-			line-height: 1.4em;
-		}
-
-		li::before {
-			content: "";
-			border: 4px solid #ccc;
-			border-radius: 100%;
-			width: 4px;
-			height: 4px;
-			position: absolute;
-			bottom: 0;
-			left: 50%;
-			margin-left: -6px;
-			margin-bottom: -8px;
-			background: #fff;
-		}
-
-		li.active {
-			border-color: $primary;
-			color: $primary;
-
-			&::before {
-				border-color: $primary;
-			}
-		}
-
-		li.done {
-			border-color: $primary;
-			color: $primary;
-
-			&::before {
-				border-color: $primary;
-				background: $primary;
-			}
-		}
+		text-align: center;
+		position: relative;
+		border-bottom: 4px solid #ccc;
+		line-height: 1.4em;
 	}
 
-	.sensei-data-port-step {
+	li::before {
+		content: '';
+		border: 4px solid #ccc;
+		border-radius: 100%;
+		width: 4px;
+		height: 4px;
+		position: absolute;
+		bottom: 0;
+		left: 50%;
+		margin-left: -6px;
+		margin-bottom: -8px;
 		background: #fff;
-		overflow: hidden;
-		padding: 0;
-		margin: 0 0 16px;
-		box-shadow: 0 1px 3px rgba(0, 0, 0, 0.13);
-		color: $text_secondary;
-		text-align: left;
+	}
 
-		&__header {
-			border-bottom: 1px solid #eee;
-			margin: 0;
-			padding: 24px 24px 0;
-		}
+	li.active {
+		border-color: $primary;
+		color: $primary;
 
-		h2 {
-			color: $text_primary;
-			font-size: 24px;
-			font-weight: normal;
-			line-height: 1em;
-		}
-
-		p {
-			line-height: 1.75em;
-			font-size: 16px;
-			color: $text_secondary;
-			margin: 24px 0;
-		}
-
-		&__body {
-			padding: 0 24px;
-			margin: 0;
-
-			p {
-				font-size: 14px;
-			}
-
-			ol {
-				margin-left: 0;
-			}
-
-			.error {
-				color: $alert-red
-			}
-
-			.sensei-data-port-notice {
-				display: inline-flex;
-				align-items: center;
-
-				&__icon {
-					margin-right: 3px;
-					vertical-align: text-bottom;
-				}
-
-				&__message {
-					margin: 6px auto;
-				}
-			}
-		}
-
-		&__footer {
-			margin: 24px -24px 0;
-			border-top: 1px solid #eee;
-			padding: 24px;
-			display: flex;
-			justify-content: flex-end;
-			align-items: center;
-
-			.components-button {
-				padding: 6px 24px;
-				height: 40px;
-			}
+		&::before {
+			border-color: $primary;
 		}
 	}
 
-	.sensei-import-bullet-list {
-		margin-left: 12px;
-		list-style: disc inside;
+	li.done {
+		border-color: $primary;
+		color: $primary;
+
+		&::before {
+			border-color: $primary;
+			background: $primary;
+		}
 	}
 }
+
+.sensei-data-port-step {
+	background: #fff;
+	overflow: hidden;
+	padding: 0;
+	margin: 0 0 16px;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.13);
+	color: $text_secondary;
+	text-align: left;
+
+	&__header {
+		border-bottom: 1px solid #eee;
+		margin: 0;
+		padding: 24px 24px 0;
+	}
+
+	h2 {
+		color: $text_primary;
+		font-size: 24px;
+		font-weight: normal;
+		line-height: 1em;
+	}
+
+	p {
+		line-height: 1.75em;
+		font-size: 16px;
+		color: $text_secondary;
+		margin: 24px 0;
+	}
+
+	&__body {
+		padding: 0 24px;
+		margin: 0;
+
+		p {
+			font-size: 14px;
+		}
+
+		ol {
+			margin-left: 0;
+		}
+
+		.error {
+			color: $alert-red
+		}
+
+		.sensei-data-port-notice {
+			display: inline-flex;
+			align-items: center;
+
+			&__icon {
+				margin-right: 3px;
+				vertical-align: text-bottom;
+			}
+
+			&__message {
+				margin: 6px auto;
+			}
+		}
+	}
+
+	&__footer {
+		margin: 24px -24px 0;
+		border-top: 1px solid #eee;
+		padding: 24px;
+		display: flex;
+		justify-content: flex-end;
+		align-items: center;
+
+		.components-button {
+			padding: 6px 24px;
+			height: 40px;
+		}
+	}
+}
+
+.sensei-import-bullet-list {
+	margin-left: 12px;
+	list-style: disc inside;
+}
+
 
 .sensei-data-table {
 	width: 100%;
 	border-spacing: 0;
+
 	td, th {
 		padding: 5px;
 	}
+
 	tbody tr:nth-child(2n+1) {
 		td, th {
 			background-color: $gray-0;

--- a/assets/react-hooks/use-sensei-color-theme.js
+++ b/assets/react-hooks/use-sensei-color-theme.js
@@ -1,0 +1,13 @@
+import { useLayoutEffect } from '@wordpress/element';
+
+/**
+ * Use Sensei color theme.
+ *
+ * Requires enqueueing the sensei-wp-components stylesheet.
+ */
+export function useSenseiColorTheme() {
+	useLayoutEffect( () => {
+		document.body.classList.add( 'sensei-color' );
+		return () => document.body.classList.remove( 'sensei-color' );
+	} );
+}

--- a/assets/react-hooks/use-sensei-color-theme.test.js
+++ b/assets/react-hooks/use-sensei-color-theme.test.js
@@ -1,0 +1,21 @@
+import { render } from '@testing-library/react';
+import { useSenseiColorTheme } from './use-sensei-color-theme';
+
+describe( 'useSenseiColorTheme', () => {
+	it( 'Should add sensei-color class to the body when mounted and remove when unmounted', () => {
+		const TestComponent = () => {
+			useSenseiColorTheme();
+			return <div />;
+		};
+
+		const { unmount } = render( <TestComponent /> );
+		expect(
+			document.body.classList.contains( 'sensei-color' )
+		).toBeTruthy();
+
+		unmount();
+		expect(
+			document.body.classList.contains( 'sensei-color' )
+		).toBeFalsy();
+	} );
+} );

--- a/assets/setup-wizard/index.js
+++ b/assets/setup-wizard/index.js
@@ -3,6 +3,7 @@ import { render, useLayoutEffect } from '@wordpress/element';
 import { Spinner } from '@woocommerce/components';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useSenseiColorTheme } from '../react-hooks/use-sensei-color-theme';
 
 import registerSetupWizardStore from './data';
 import { useWpAdminFullscreen } from '../react-hooks';
@@ -24,7 +25,8 @@ const PARAM_NAME = 'step';
  * Sensei setup wizard page.
  */
 const SenseiSetupWizardPage = () => {
-	useWpAdminFullscreen( [ 'sensei-color', 'sensei-setup-wizard__page' ] );
+	useWpAdminFullscreen( [ 'sensei-setup-wizard__page' ] );
+	useSenseiColorTheme();
 
 	const { isFetching, error, navigationSteps } = useSelect( ( select ) => {
 		const store = select( 'sensei/setup-wizard' );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -407,6 +407,7 @@ class Sensei_Main {
 			$this->analysis = new Sensei_Analysis( $this->main_plugin_file_name );
 
 			new Sensei_Import();
+			new Sensei_Export();
 
 			if ( $this->feature_flags->is_enabled( 'rest_api_testharness' ) ) {
 				$this->test_harness = new Sensei_Admin_Rest_Api_Testharness( $this->main_plugin_file_name );

--- a/includes/data-port/class-sensei-export.php
+++ b/includes/data-port/class-sensei-export.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * File containing the class Sensei_Export.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * This class is responsible for displaying the export page in admin.
+ */
+class Sensei_Export {
+
+	/**
+	 * URL Slug for Export page
+	 *
+	 * @var string
+	 */
+	public $page_slug;
+
+	/**
+	 * Sensei_Export constructor.
+	 */
+	public function __construct() {
+
+		$this->page_slug = 'sensei_export';
+
+		add_action( 'admin_menu', [ $this, 'admin_menu' ], 40 );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
+		if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
+
+			add_action(
+				'admin_print_scripts',
+				function() {
+					Sensei()->assets->enqueue( 'sensei-export', 'data-port/export.js', [], true );
+					wp_set_script_translations( 'sensei-export', 'sensei-lms' );
+				}
+			);
+
+			add_action(
+				'admin_print_styles',
+				function() {
+					Sensei()->assets->enqueue( 'sensei-export', 'data-port/style.css', [ 'sensei-wp-components' ] );
+				}
+			);
+		}
+	}
+
+	/**
+	 * Register an export submenu.
+	 */
+	public function admin_menu() {
+		if ( current_user_can( 'manage_sensei' ) ) {
+			add_submenu_page(
+				'sensei',
+				__( 'Export Content', 'sensei-lms' ),
+				__( 'Export', 'sensei-lms' ),
+				'manage_sensei',
+				$this->page_slug,
+				[ $this, 'export_page' ]
+			);
+		}
+	}
+
+	/**
+	 * Render app container for export page.
+	 */
+	public function export_page() {
+
+		?>
+		<div id="sensei-export-page-wrapper" class="wrap">
+			<h1>
+				<?php echo wp_kses_post( get_admin_page_title() ); ?>
+			</h1>
+			<div id="sensei-export-page" class="sensei-export">
+
+			</div>
+		</div>
+		<?php
+	}
+
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ const files = [
 	'shared/styles/wp-components.scss',
 	'shared/styles/wc-components.scss',
 	'data-port/import.js',
+	'data-port/export.js',
 	'data-port/style.scss',
 
 	'css/frontend.scss',


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Add an exporter page with just the static content
* Adjust some common styles and functionality

### Testing instructions

* Importer should not break
* New Export option should show under Sensei LMS, and display a draft exporter page

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
![image](https://user-images.githubusercontent.com/176949/87583278-ff34a880-c6db-11ea-9279-2f7851fdcaf1.png)
