### PR TITLE
Fix not found when there is no jobId

### DIFF
--- a/assets/data-port/import/data/resolvers.js
+++ b/assets/data-port/import/data/resolvers.js
@@ -6,6 +6,10 @@ import { buildJobEndpointUrl } from '../helpers/url';
 export const getLogsBySeverity = composeFetchAction(
 	null,
 	function* ( jobId ) {
+		if ( ! jobId ) {
+			return;
+		}
+
 		return yield fetchFromAPI( {
 			path: buildJobEndpointUrl( jobId, [ 'logs' ] ),
 		} );

--- a/assets/data-port/import/data/resolvers.test.js
+++ b/assets/data-port/import/data/resolvers.test.js
@@ -52,4 +52,11 @@ describe( 'Importer resolvers', () => {
 
 		expect( gen.next().done ).toBeTruthy();
 	} );
+
+	it( 'Should not getLogsBySeverity selector if there is no jobId', () => {
+		const gen = getLogsBySeverity( null );
+
+		gen.next();
+		expect( gen.next().done ).toBeTruthy();
+	} );
 } );


### PR DESCRIPTION
Fixes #3400

### Changes proposed in this Pull Request

* Fix 404 that happened when clicking in "Import More Content" - `import/null/logs`.

### Testing instructions

1. Go to the importer.
2. Import some content to go to the Done step.
3. Click on the `Import More Content` button.
4. Check the requests in the Browser developer tools to see that there is no more the `import/null/logs` 404 error.

Just to add these issue is related to the logs. The other 404 (`import/active`) is expected.