### PR TITLE
Change cursor to pointer for learner magament links

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -567,7 +567,7 @@
 		}
 
 		.row-actions {
-			a {
+			span a {
 				cursor: pointer;
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* The pointer rule wasn't applied.

### Testing instructions

* Go to Learner Management and hover over the Enrol/Restore Enrolment/Reset Progess links.
* Make sure that the cursor is a pointer.