### PR TITLE
Fix title in the import logs

### DIFF
--- a/includes/data-port/models/class-sensei-data-port-model.php
+++ b/includes/data-port/models/class-sensei-data-port-model.php
@@ -64,7 +64,7 @@ abstract class Sensei_Data_Port_Model {
 		}
 
 		$entry_title = $this->get_value( $this->schema->get_column_title() );
-		if ( $entry_id ) {
+		if ( $entry_title ) {
 			$data['entry_title'] = $entry_title;
 		}
 


### PR DESCRIPTION
Fixes #3415

### Changes proposed in this Pull Request

* Fix question title 

### Testing instructions

1. Create a questions CSV file with the following content:
```
ID,Question,Slug,Description,Status,Type,Grade,Random Answer Order,Media,Categories,Answer,Feedback,Text Before Gap,Gap,Text After Gap,Upload Notes,Teacher Notes
1,How many keys are on the common grand piano?,,Grand pianos are the largest type of piano.,draft,multiple-choice,0,0,,,"Wrong:87, Wrong:88, Wrong:89",<strong>This is my <span style=”color:red;”>feedback</span>.</strong>,Before,and,after,Upload Notes,Teacher Notes
,Test,,,,,,,,,Wrong:Incorrect,,,,,,
```
2. Import the question data.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1144" alt="Screen Shot 2020-07-17 at 13 56 54" src="https://user-images.githubusercontent.com/876340/87811660-64e87800-c835-11ea-8731-cdf65c4f73f1.png">
