### PR TITLE
Update default right answer to true

### DIFF
--- a/includes/data-port/models/class-sensei-import-question-model.php
+++ b/includes/data-port/models/class-sensei-import-question-model.php
@@ -221,7 +221,7 @@ class Sensei_Import_Question_Model extends Sensei_Import_Model {
 			case 'boolean':
 				$answers_raw = $this->get_value( Sensei_Data_Port_Question_Schema::COLUMN_ANSWER );
 				$values      = [
-					'_question_right_answer' => in_array( $answers_raw, [ '1', 'true' ], true ) ? 'true' : 'false',
+					'_question_right_answer' => in_array( $answers_raw, [ '0', 'false' ], true ) ? 'false' : 'true',
 				];
 
 				break;


### PR DESCRIPTION
Fixes #3416

### Changes proposed in this Pull Request

* Update default right answer to true.

### Testing instructions

1. Create a questions CSV file with the following content:
```
ID,Question,Slug,Description,Status,Type,Grade,Random Answer Order,Media,Categories,Answer,Feedback,Text Before Gap,Gap,Text After Gap,Upload Notes,Teacher Notes
,A common grand piano has 88 keys.,,,draft,boolean,5,,,,,,,,,,

```
2. Import the question data.
3. Check the imported question. It should have the right answer as True.