### PR TITLE
Configure Renovate to create separate PRs for non-dev dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,11 @@
     {
       "depTypeList": ["dependencies"],
       "extends": ["schedule:monthly"]
+    },
+    {
+      "depTypeList": ["require-dev"],
+      "extends": ["schedule:monthly"],
+      "groupName": "require-dev"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -10,8 +10,7 @@
     },
     {
       "depTypeList": ["dependencies"],
-      "extends": ["schedule:monthly"],
-      "groupName": "dependencies"
+      "extends": ["schedule:monthly"]
     }
   ]
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request
- Configure Renovate so that non-dev dependencies are updated in separate PRs. Since these are riskier updates, it seems better to put them in separate PRs so that they can be tested and merged independently.
- Configure composer updates so that they're grouped in the same PR and scheduled monthly.