### PR TITLE
Add lesson length validation

### DIFF
--- a/includes/data-port/models/class-sensei-import-lesson-model.php
+++ b/includes/data-port/models/class-sensei-import-lesson-model.php
@@ -418,9 +418,20 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 			$meta['_lesson_complexity'] = $value;
 		}
 
+		// Lesson length.
 		$value = $this->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_LENGTH );
+
 		if ( null !== $value ) {
-			$meta['_lesson_length'] = $value;
+			if ( 1 > $value ) {
+				$this->add_line_warning(
+					__( 'Length must be greater than or equal to 1.', 'sensei-lms' ),
+					[
+						'code' => 'sensei_data_port_lesson_length_negative',
+					]
+				);
+			} else {
+				$meta['_lesson_length'] = intval( $value );
+			}
 		}
 
 		return $meta;

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
@@ -574,6 +574,31 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests lesson length validation.
+	 */
+	public function testLessonLengthValidation() {
+		$lesson_data_with_negative_length = [
+			Sensei_Data_Port_Lesson_Schema::COLUMN_TITLE  => 'Required title',
+			Sensei_Data_Port_Lesson_Schema::COLUMN_LENGTH => -1,
+		];
+
+		$task  = new Sensei_Import_Lessons( Sensei_Import_Job::create( 'test', 0 ) );
+		$model = Sensei_Import_Lesson_Model::from_source_array( 1, $lesson_data_with_negative_length, new Sensei_Data_Port_Lesson_Schema(), $task );
+		$model->sync_post();
+
+		$created_post_id = get_posts(
+			[
+				'post_type'      => 'lesson',
+				'posts_per_page' => 1,
+				'post_status'    => 'any',
+				'fields'         => 'ids',
+			]
+		)[0];
+
+		$this->assertEquals( get_post_meta( $created_post_id, '_lesson_length', true ), '' );
+	}
+
+	/**
 	 * Tests creation and updating of quizzes.
 	 */
 	public function testQuizIsInsertedAndUpdated() {


### PR DESCRIPTION
Partial fix for #3426

### Changes proposed in this Pull Request

* Add lesson length validation. It validates only if the number is greater than or equal to 1. The `int` validation is part of https://github.com/Automattic/sensei/pull/3443.

### Testing instructions

1. Import the following lessons data:
```
ID,Lesson,Slug,Description,Excerpt,Status,Course,Module,Prerequisite,Preview,Tags,Image,Length,Complexity,Video,Pass Required,Passmark,Number of Questions,Random Question Order,Auto-Grade,Quiz Reset,Allow Comments,Questions
,Piano Lesson 2,,,,,,,,,,,-1,easy,,,,,,,,,
,Piano Lesson 4,,,,,,,,,,,0.5,hard,,,,,,,,,
```
2. Make sure you see warnings for both options that must be greater than or equal to 1.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1145" alt="Screen Shot 2020-07-21 at 16 43 22" src="https://user-images.githubusercontent.com/876340/88099269-540b6f80-cb71-11ea-8bc9-832295f9c287.png">
