### PR TITLE
Fix warnings before insert post

### DIFF
--- a/includes/data-port/models/class-sensei-import-lesson-model.php
+++ b/includes/data-port/models/class-sensei-import-lesson-model.php
@@ -262,16 +262,22 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 	 */
 	private function sync_lesson() {
 
-		$course_not_found = false;
-		$value            = $this->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_COURSE );
+		$value = $this->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_COURSE );
 		if ( ! empty( $value ) ) {
 			$course = $this->task->get_job()->translate_import_id( Sensei_Data_Port_Course_Schema::POST_TYPE, $value );
 
 			$this->course_id = $course;
 
 			if ( empty( $this->course_id ) ) {
-				$course_not_found = true;
-				$this->course_id  = null;
+				$this->add_line_warning(
+					// translators: Placeholder is the term which errored.
+					sprintf( __( 'Course does not exist: %s.', 'sensei-lms' ), $value ),
+					[
+						'code' => 'sensei_data_port_lesson_course_missing',
+					]
+				);
+
+				$this->course_id = null;
 			}
 		} else {
 			$this->course_id = null;
@@ -292,17 +298,6 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 		}
 
 		$this->set_post_id( $post_id );
-
-		if ( $course_not_found ) {
-			$this->add_line_warning(
-				// translators: Placeholder is the term which errored.
-				sprintf( __( 'Course does not exist: %s.', 'sensei-lms' ), $value ),
-				[
-					'code' => 'sensei_data_port_lesson_course_missing',
-				]
-			);
-		}
-
 		$this->store_import_id();
 
 		$result = $this->add_thumbnail_to_post( Sensei_Data_Port_Lesson_Schema::COLUMN_IMAGE );


### PR DESCRIPTION
### Changes proposed in this Pull Request

In some cases, the lessons log warnings before creating the post.

In these cases, it doesn't have the post ID. This PR fixes that, deferring the warning to after the post creation.

### Testing instructions

* Import a CSV file with the content:
```csv
ID,Lesson,Slug,Description,Excerpt,Status,Course,Module,Prerequisite,Preview,Tags,Image,Length,Complexity,Video,Pass Required,Passmark,Number of Questions,Random Question Order,Auto-Grade,Quiz Reset,Allow Comments,Questions
,Piano Lesson 2,,,,,,,,,,,-1,easy,,,,,,,,,
,Piano Lesson 4,,,,,,,,,,,0.5,hard,,,,,,,,,
,Piano Lesson 5,,,,,99999999,,,,,,,,,,,,,,,,
```
* Make sure you see warnings for the 3 cases in the logs.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1150" alt="Screen Shot 2020-07-20 at 15 40 25" src="https://user-images.githubusercontent.com/876340/87973737-5bfadf00-ca9f-11ea-97f1-e1a2c99e0502.png">
