### PR TITLE
Defer warnings until post is created and add warnings in sanitation

### DIFF
--- a/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
+++ b/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
@@ -272,6 +272,9 @@ abstract class Sensei_Import_File_Process_Task
 			return false;
 		}
 
+		// Add warnings to the job when post sync is ready.
+		$model->add_warnings_to_job();
+
 		$this->get_job()->set_line_result( $model->get_model_key(), $line_number, Sensei_Import_Job::RESULT_SUCCESS );
 
 		return true;

--- a/includes/data-port/models/class-sensei-import-lesson-model.php
+++ b/includes/data-port/models/class-sensei-import-lesson-model.php
@@ -270,16 +270,22 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 	 */
 	private function sync_lesson() {
 
-		$course_not_found = false;
-		$value            = $this->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_COURSE );
+		$value = $this->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_COURSE );
 		if ( ! empty( $value ) ) {
 			$course = $this->task->get_job()->translate_import_id( Sensei_Data_Port_Course_Schema::POST_TYPE, $value );
 
 			$this->course_id = $course;
 
 			if ( empty( $this->course_id ) ) {
-				$course_not_found = true;
-				$this->course_id  = null;
+				$this->add_line_warning(
+					// translators: Placeholder is the term which errored.
+					sprintf( __( 'Course does not exist: %s.', 'sensei-lms' ), $value ),
+					[
+						'code' => 'sensei_data_port_lesson_course_missing',
+					]
+				);
+
+				$this->course_id = null;
 			}
 		} else {
 			$this->course_id = null;
@@ -300,17 +306,6 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 		}
 
 		$this->set_post_id( $post_id );
-
-		if ( $course_not_found ) {
-			$this->add_line_warning(
-				// translators: Placeholder is the term which errored.
-				sprintf( __( 'Course does not exist: %s.', 'sensei-lms' ), $value ),
-				[
-					'code' => 'sensei_data_port_lesson_course_missing',
-				]
-			);
-		}
-
 		$this->store_import_id();
 
 		$result = $this->add_thumbnail_to_post( Sensei_Data_Port_Lesson_Schema::COLUMN_IMAGE );

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -163,7 +163,22 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 						}
 						break;
 					case 'bool':
-						if ( ! in_array( $value, [ '0', '1', 'true', 'false' ], true ) ) {
+						$accepted_options = [ '0', '1', 'true', 'false' ];
+
+						if ( '' === $value ) {
+							$value = null;
+						} elseif ( ! in_array( $value, $accepted_options, true ) ) {
+							$this->add_line_warning(
+								sprintf(
+									// translators: Placeholder %1$s is the column name. %2$s is the accepted values.
+									__( 'Error in column "%1$s": It must be one of the following: %2$s.', 'sensei-lms' ),
+									$key,
+									implode( ', ', $accepted_options )
+								),
+								[
+									'code' => 'sensei_data_port_float_sanitation',
+								]
+							);
 							$value = null;
 						} else {
 							$value = in_array( $value, [ '1', 'true' ], true );

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -176,7 +176,7 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 									implode( ', ', $accepted_options )
 								),
 								[
-									'code' => 'sensei_data_port_float_sanitization',
+									'code' => 'sensei_data_port_bool_sanitization',
 								]
 							);
 							$value = null;

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -125,7 +125,23 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 			if ( null !== $value ) {
 				switch ( $config['type'] ) {
 					case 'int':
-						$value = '' === $value ? null : intval( $value );
+						if ( '' === $value ) {
+							$value = null;
+						} else {
+							if ( ! is_numeric( $value ) || floor( $value ) !== floatval( $value ) ) {
+								$this->add_line_warning(
+									sprintf(
+										// translators: Placeholder is the column name.
+										__( 'Error in column "%s": It must be a whole number.', 'sensei-lms' ),
+										$key
+									),
+									[
+										'code' => 'sensei_data_port_int_sanitation',
+									]
+								);
+							}
+							$value = intval( $value );
+						}
 						break;
 					case 'float':
 						$value = '' === $value ? null : floatval( $value );

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -144,7 +144,23 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 						}
 						break;
 					case 'float':
-						$value = '' === $value ? null : floatval( $value );
+						if ( '' === $value ) {
+							$value = null;
+						} else {
+							if ( ! is_numeric( $value ) ) {
+								$this->add_line_warning(
+									sprintf(
+										// translators: Placeholder is the column name.
+										__( 'Error in column "%s": It must be a number.', 'sensei-lms' ),
+										$key
+									),
+									[
+										'code' => 'sensei_data_port_float_sanitation',
+									]
+								);
+							}
+							$value = floatval( $value );
+						}
 						break;
 					case 'bool':
 						if ( ! in_array( $value, [ '0', '1', 'true', 'false' ], true ) ) {

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -136,7 +136,7 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 										$key
 									),
 									[
-										'code' => 'sensei_data_port_int_sanitation',
+										'code' => 'sensei_data_port_int_sanitization',
 									]
 								);
 							}
@@ -155,7 +155,7 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 										$key
 									),
 									[
-										'code' => 'sensei_data_port_float_sanitation',
+										'code' => 'sensei_data_port_float_sanitization',
 									]
 								);
 							}
@@ -176,7 +176,7 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 									implode( ', ', $accepted_options )
 								),
 								[
-									'code' => 'sensei_data_port_float_sanitation',
+									'code' => 'sensei_data_port_float_sanitization',
 								]
 							);
 							$value = null;

--- a/tests/framework/data-port/class-sensei-data-port-schema-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-schema-mock.php
@@ -22,8 +22,15 @@ class Sensei_Data_Port_Schema_Mock extends Sensei_Data_Port_Schema {
 				'type'    => 'int',
 				'default' => 0,
 			],
+			'other_int'              => [
+				'type'    => 'int',
+				'default' => 0,
+			],
 			'favorite_float'         => [
 				'type' => 'float',
+			],
+			'favorite_bool'          => [
+				'type' => 'bool',
 			],
 			'email'                  => [
 				'type'     => 'email',

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
@@ -333,6 +333,7 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 		$task   = new Sensei_Import_Courses( $job );
 		$model  = Sensei_Import_Course_Model::from_source_array( 1, $this->lineData()[0][0], new Sensei_Data_Port_Course_Schema(), $task );
 		$result = $model->sync_post();
+		$model->add_warnings_to_job();
 
 		$this->assertTrue( $result );
 		$this->assertJobHasLogEntry( $job, 'No attachment with the specified file name was found.' );

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
@@ -349,6 +349,7 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 		$task   = new Sensei_Import_Lessons( $job );
 		$model  = Sensei_Import_Lesson_Model::from_source_array( 1, $lesson_data_with_course, new Sensei_Data_Port_Lesson_Schema(), $task );
 		$result = $model->sync_post();
+		$model->add_warnings_to_job();
 
 		$this->assertTrue( $result, 'Lesson should still be created when a course which does not exist is supplied.' );
 		$this->assertJobHasLogEntry( $job, "Course does not exist: {$lesson_data_with_course[ Sensei_Data_Port_Lesson_Schema::COLUMN_COURSE ]}." );
@@ -425,6 +426,7 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 		$task   = new Sensei_Import_Lessons( $job );
 		$model  = Sensei_Import_Lesson_Model::from_source_array( 1, $lesson_data_with_module, new Sensei_Data_Port_Lesson_Schema(), $task );
 		$result = $model->sync_post();
+		$model->add_warnings_to_job();
 
 		$this->assertTrue( $result, 'Lesson should still be created when a module supplied when no course is.' );
 		$this->assertJobHasLogEntry( $job, 'Module is defined while no course is specified.' );
@@ -444,6 +446,7 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 		$task   = new Sensei_Import_Lessons( $job );
 		$model  = Sensei_Import_Lesson_Model::from_source_array( 1, $lesson_data_with_module, new Sensei_Data_Port_Lesson_Schema(), $task );
 		$result = $model->sync_post();
+		$model->add_warnings_to_job();
 
 		$this->assertTrue( $result, 'Lesson should still be created when a module supplied for a lesson does not exist.' );
 		$this->assertJobHasLogEntry( $job, "Module does not exist: {$lesson_data_with_module[ Sensei_Data_Port_Lesson_Schema::COLUMN_MODULE ]}." );
@@ -451,6 +454,7 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 		$term   = Sensei_Data_Port_Utilities::get_term( 'the-module', 'module' );
 		$model  = Sensei_Import_Lesson_Model::from_source_array( 1, $lesson_data_with_module, new Sensei_Data_Port_Lesson_Schema(), $task );
 		$result = $model->sync_post();
+		$model->add_warnings_to_job();
 
 		$this->assertTrue( $result, 'Lesson should still be created when a module supplied for a lesson is not associated with the course.' );
 		$this->assertJobHasLogEntry( $job, "Module the-module is not part of course {$course_model->get_post_id()}." );

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
@@ -28,7 +28,9 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 		$optional_mock_fields = [
 			'test-string-no-html',
 			'favorite_int',
+			'other_int',
 			'favorite_float',
+			'favorite_bool',
 			'slug',
 		];
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

In the Importer tests, some issues related to the logs were detected, like:
* Title or ID not appearing in the logs in some scenarios.
* And data being sanitized without notifying the user in the logs.

For now, it's a POC to add warnings while sanitizing data. Besides that, it also defers all the warnings created by the models, which ensure that we always have ID and title ready to use.

This partially fixes the issue: https://github.com/Automattic/sensei/issues/3436

Also, partially replaces these solutions: https://github.com/Automattic/sensei/pull/3438, https://github.com/Automattic/sensei/pull/3440

It is important to note that if we go ahead with this solution, the same warning will appear generically for any column based on the type. For now, it introduces the log only for the `int`, checking if it's an integer number, but we can also add it for some other types (maybe for the `float` and the `bool`?).

And it's also important to notice that for the sanitizing, it's introducing only warnings. It continues sanitizing like before. For the numbers with decimals, for example, it sanitizes just removing the decimals. And for texts, it transforms to `0`.

This is a **proposal**. But if it makes sense, I'll continue this PR writing the unit tests, adding the column name for all the schemas, maybe add warnings for other types, and finishes the related issue and PRs.

### Testing instructions

* Import the CSV:
```
ID,Lesson,Slug,Description,Excerpt,Status,Course,Module,Prerequisite,Preview,Tags,Image,Length,Complexity,Video,Pass Required,Passmark,Number of Questions,Random Question Order,Auto-Grade,Quiz Reset,Allow Comments,Questions
,0 Questions,,,,,,,,,,,,,,1,2.5,0,,,,,
,-1 Questions,,,,,,,,,,,,,,abc,1,-1,,,,,
,abc Questions,,,,,,,,,,,,,,,,abc,,,,,
,Decimal Question,,,,,,,,,,,,,,,,1.5,,,,,
```
* Make sure you see warnings for lines 4 and 5, that is not whole numbers. And for the line 3, the sanitize error (must be one of: 0, 1, true, false) and other error checked in the model (that passmark and passmark required should be supplied).