### PR TITLE
Check post type when translating db ids

### DIFF
--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -377,25 +377,28 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 			return $this->get_import_id( $post_type, substr( $import_id, 3 ) );
 		}
 
+		$post_args = [
+			'post_type'      => $post_type,
+			'posts_per_page' => 1,
+			'post_status'    => 'any',
+			'fields'         => 'ids',
+		];
+
 		if ( 0 === strpos( $import_id, 'slug:' ) ) {
-			$post = get_posts(
-				[
-					'post_type'      => $post_type,
-					'post_name__in'  => [ substr( $import_id, 5 ) ],
-					'posts_per_page' => 1,
-					'post_status'    => 'any',
-					'fields'         => 'ids',
-				]
-			);
+			$post_args['post_name__in'] = [ substr( $import_id, 5 ) ];
+		} else {
+			$post_id = (int) $import_id;
 
-			return empty( $post ) ? null : $post[0];
+			if ( empty( $post_id ) ) {
+				return null;
+			}
+
+			$post_args['p'] = $post_id;
 		}
 
-		if ( null !== get_post( (int) $import_id ) ) {
-			return (int) $import_id;
-		}
+		$post = get_posts( $post_args );
 
-		return null;
+		return empty( $post ) ? null : $post[0];
 	}
 
 }

--- a/tests/unit-tests/data-port/test-class-sensei-import-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-job.php
@@ -22,6 +22,7 @@ class Sensei_Import_Job_Test extends WP_UnitTestCase {
 	public function setUp() {
 		// Make sure CSVs are allowed on WordPress multi-site.
 		update_site_option( 'upload_filetypes', 'csv' );
+		$this->factory = new Sensei_Factory();
 
 		return parent::setUp();
 	}
@@ -184,6 +185,28 @@ class Sensei_Import_Job_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected_results, $job->get_result_counts(), 'Should have 1 warning' );
 		$this->assertEquals( $expected_logs, $job->get_logs() );
+	}
+
+	/**
+	 * Tests translating an import ID.
+	 */
+	public function testTranslateImportId() {
+		$course_id = $this->factory->course->create(
+			[
+				'post_name' => 'a-course',
+			]
+		);
+		$job       = Sensei_Import_Job::create( 'test-job', 0 );
+
+		$this->assertEquals( $course_id, $job->translate_import_id( 'course', $course_id ) );
+		$this->assertNull( $job->translate_import_id( 'lesson', $course_id ) );
+
+		$this->assertEquals( $course_id, $job->translate_import_id( 'course', 'slug:a-course' ) );
+		$this->assertNull( $job->translate_import_id( 'course', 'slug:another-course' ) );
+
+		$job->set_import_id( 'course', 'source_id', $course_id );
+		$this->assertEquals( $course_id, $job->translate_import_id( 'course', 'id:source_id' ) );
+		$this->assertNull( $job->translate_import_id( 'course', 'id:another_source_id' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3437

### Changes proposed in this Pull Request

* Updates `translate_import_id` method to check for the post type when a database id has been supplied.
* The issue described in #3437 can potentially happen with other ids too (i.e. lesson and course prerequisites)

### Testing instructions

* Follow the instruction in #3437
* Make sure that a warning is displayed.
