### PR TITLE
Order logs by log type

### DIFF
--- a/assets/data-port/import/data/selectors.js
+++ b/assets/data-port/import/data/selectors.js
@@ -131,22 +131,12 @@ export const getSuccessResults = ( { done } ) =>
  * @return {Object} Object with the logs by severity.
  */
 export const getLogsBySeverity = ( { done, upload } ) => {
-	const sortObject = DONE_KEYS.reduce(
-		( acc, cur, index ) => ( {
-			...acc,
-			[ cur ]: index,
-		} ),
-		{}
-	);
-
 	const items = get( done, 'logs.items', [] )
 		// Add filename to the results.
 		.map( ( i ) => ( {
 			...i,
 			filename: get( upload, i.type + 's.filename', '' ),
-		} ) )
-		// Sort the results by type.
-		.sort( ( a, b ) => sortObject[ a.type ] - sortObject[ b.type ] );
+		} ) );
 
 	return groupBy( items, 'severity' );
 };

--- a/assets/data-port/import/data/selectors.test.js
+++ b/assets/data-port/import/data/selectors.test.js
@@ -269,14 +269,14 @@ describe( 'Importer selectors', () => {
 							line: 1,
 						},
 						{
-							type: 'question',
-							severity: 'notice',
-							line: 2,
-						},
-						{
 							type: 'lesson',
 							severity: 'notice',
 							line: 3,
+						},
+						{
+							type: 'question',
+							severity: 'notice',
+							line: 2,
 						},
 					],
 				},

--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -398,4 +398,12 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 		return null;
 	}
 
+	/**
+	 * Logs are order by log type first and then by line number. The method defines the ordering by type.
+	 *
+	 * @return array An array of log types which defines the log order.
+	 */
+	protected function get_log_type_order() {
+		return [ Sensei_Import_Course_Model::MODEL_KEY, Sensei_Import_Lesson_Model::MODEL_KEY, Sensei_Import_Question_Model::MODEL_KEY ];
+	}
 }

--- a/tests/framework/data-port/class-sensei-data-port-job-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-job-mock.php
@@ -62,4 +62,8 @@ class Sensei_Data_Port_Job_Mock extends Sensei_Data_Port_Job {
 	public function is_ready() {
 		return true;
 	}
+
+	protected function get_log_type_order() {
+		return [ Sensei_Import_Course_Model::MODEL_KEY, Sensei_Import_Lesson_Model::MODEL_KEY, Sensei_Import_Question_Model::MODEL_KEY ];
+	}
 }

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
@@ -122,26 +122,127 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 
 	public function testGetLogs() {
 		$job = Sensei_Data_Port_Job_Mock::create_with_tasks( 'test-job', [ new Sensei_Data_Port_Task_Mock( true, 100, 100 ) ] );
-		$job->add_log_entry( 'First log entry', Sensei_Data_Port_Job::LOG_LEVEL_NOTICE );
-		$job->add_log_entry( 'Second log entry', Sensei_Data_Port_Job::LOG_LEVEL_ERROR );
-		$job->add_log_entry( 'Third log entry', Sensei_Data_Port_Job::LOG_LEVEL_INFO, [ 'test' => true ] );
+		$job->add_log_entry( 'First log entry', Sensei_Data_Port_Job::LOG_LEVEL_NOTICE, [ 'line' => 1 ] );
+		$job->add_log_entry( 'Second log entry', Sensei_Data_Port_Job::LOG_LEVEL_ERROR, [ 'line' => 3 ] );
+		$job->add_log_entry(
+			'Third log entry',
+			Sensei_Data_Port_Job::LOG_LEVEL_INFO,
+			[
+				'line' => 2,
+				'test' => true,
+			]
+		);
 
 		$expected = [
 			[
 				'message' => 'First log entry',
 				'level'   => Sensei_Data_Port_Job::LOG_LEVEL_NOTICE,
-				'data'    => [],
-			],
-			[
-				'message' => 'Second log entry',
-				'level'   => Sensei_Data_Port_Job::LOG_LEVEL_ERROR,
-				'data'    => [],
+				'data'    => [
+					'line' => 1,
+				],
 			],
 			[
 				'message' => 'Third log entry',
 				'level'   => Sensei_Data_Port_Job::LOG_LEVEL_INFO,
 				'data'    => [
 					'test' => true,
+					'line' => 2,
+				],
+			],
+			[
+				'message' => 'Second log entry',
+				'level'   => Sensei_Data_Port_Job::LOG_LEVEL_ERROR,
+				'data'    => [
+					'line' => 3,
+				],
+			],
+		];
+
+		$this->assertEquals( $expected, $job->get_logs() );
+	}
+
+	public function testLogOrder() {
+		$job = Sensei_Data_Port_Job_Mock::create_with_tasks( 'test-job', [ new Sensei_Data_Port_Task_Mock( true, 100, 100 ) ] );
+
+		$job->add_log_entry(
+			'Third Question log entry',
+			Sensei_Data_Port_Job::LOG_LEVEL_INFO,
+			[
+				'type' => Sensei_Import_Question_Model::MODEL_KEY,
+				'line' => 2,
+			]
+		);
+		$job->add_log_entry(
+			'Second Question log entry',
+			Sensei_Data_Port_Job::LOG_LEVEL_INFO,
+			[
+				'type' => Sensei_Import_Question_Model::MODEL_KEY,
+				'line' => 1,
+			]
+		);
+		$job->add_log_entry(
+			'Fourth Question log entry',
+			Sensei_Data_Port_Job::LOG_LEVEL_INFO,
+			[
+				'type' => Sensei_Import_Question_Model::MODEL_KEY,
+				'line' => 3,
+			]
+		);
+
+		$job->add_log_entry( 'Lesson log entry', Sensei_Data_Port_Job::LOG_LEVEL_ERROR, [ 'type' => Sensei_Import_Lesson_Model::MODEL_KEY ] );
+		$job->add_log_entry( 'Course log entry', Sensei_Data_Port_Job::LOG_LEVEL_NOTICE, [ 'type' => Sensei_Import_Course_Model::MODEL_KEY ] );
+		$job->add_log_entry( 'Generic log entry', Sensei_Data_Port_Job::LOG_LEVEL_INFO );
+		$job->add_log_entry( 'First Question log entry', Sensei_Data_Port_Job::LOG_LEVEL_INFO, [ 'type' => Sensei_Import_Question_Model::MODEL_KEY ] );
+
+		$expected = [
+			[
+				'message' => 'Generic log entry',
+				'level'   => Sensei_Data_Port_Job::LOG_LEVEL_INFO,
+				'data'    => [],
+			],
+			[
+				'message' => 'Course log entry',
+				'level'   => Sensei_Data_Port_Job::LOG_LEVEL_NOTICE,
+				'data'    => [
+					'type' => Sensei_Import_Course_Model::MODEL_KEY,
+				],
+			],
+			[
+				'message' => 'Lesson log entry',
+				'level'   => Sensei_Data_Port_Job::LOG_LEVEL_ERROR,
+				'data'    => [
+					'type' => Sensei_Import_Lesson_Model::MODEL_KEY,
+				],
+			],
+			[
+				'message' => 'First Question log entry',
+				'level'   => Sensei_Data_Port_Job::LOG_LEVEL_INFO,
+				'data'    => [
+					'type' => Sensei_Import_Question_Model::MODEL_KEY,
+				],
+			],
+			[
+				'message' => 'Second Question log entry',
+				'level'   => Sensei_Data_Port_Job::LOG_LEVEL_INFO,
+				'data'    => [
+					'type' => Sensei_Import_Question_Model::MODEL_KEY,
+					'line' => 1,
+				],
+			],
+			[
+				'message' => 'Third Question log entry',
+				'level'   => Sensei_Data_Port_Job::LOG_LEVEL_INFO,
+				'data'    => [
+					'type' => Sensei_Import_Question_Model::MODEL_KEY,
+					'line' => 2,
+				],
+			],
+			[
+				'message' => 'Fourth Question log entry',
+				'level'   => Sensei_Data_Port_Job::LOG_LEVEL_INFO,
+				'data'    => [
+					'type' => Sensei_Import_Question_Model::MODEL_KEY,
+					'line' => 3,
 				],
 			],
 		];

--- a/tests/unit-tests/data-port/test-class-sensei-import-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-job.php
@@ -173,16 +173,16 @@ class Sensei_Import_Job_Test extends WP_UnitTestCase {
 				'message' => 'Test warning B',
 				'level'   => Sensei_Import_Job::LOG_LEVEL_NOTICE,
 				'data'    => [
-					'line' => 1,
+					'line' => 2,
 				],
 			],
 		];
 
 		$job->add_line_warning( Sensei_Import_Course_Model::MODEL_KEY, 1, $expected_logs[0]['message'] );
-		$job->add_line_warning( Sensei_Import_Course_Model::MODEL_KEY, 1, $expected_logs[1]['message'] );
-		$expected_results[ Sensei_Import_Course_Model::MODEL_KEY ]['warning']++;
+		$job->add_line_warning( Sensei_Import_Course_Model::MODEL_KEY, 2, $expected_logs[1]['message'] );
+		$expected_results[ Sensei_Import_Course_Model::MODEL_KEY ]['warning'] = 2;
 
-		$this->assertEquals( $expected_results, $job->get_result_counts(), 'Should have 1 warning' );
+		$this->assertEquals( $expected_results, $job->get_result_counts(), 'Should have 2 warnings' );
 		$this->assertEquals( $expected_logs, $job->get_logs() );
 	}
 


### PR DESCRIPTION
Fixes #3441

### Changes proposed in this Pull Request

* Updates the logs in `Sensei_Data_Port_Job` to be ordered by type.
* At the moment `get_logs` processes all logs in every case. We could optimize it a bit by implementing pagination  and process only the rows that get eventually returned.
* `Sensei_Data_Port_Job::logs` is a bit too big to be an array. I considered introducing a new class for it but I decided against it for now as it requires many changes.

### Testing instructions

* Try imporing many files at once and ensure that there warnings for every level.
* Check that the logs are printed by the order: Course > Lesson > Question