### PR TITLE
Add number of questions validation

### DIFF
--- a/includes/data-port/models/class-sensei-data-port-lesson-schema.php
+++ b/includes/data-port/models/class-sensei-data-port-lesson-schema.php
@@ -106,8 +106,7 @@ class Sensei_Data_Port_Lesson_Schema extends Sensei_Data_Port_Schema {
 				'type' => 'float',
 			],
 			self::COLUMN_NUM_QUESTIONS  => [
-				'type'    => 'int',
-				'default' => '',
+				'type' => 'int',
 			],
 			self::COLUMN_RANDOMIZE      => [
 				'type'    => 'bool',

--- a/includes/data-port/models/class-sensei-import-lesson-model.php
+++ b/includes/data-port/models/class-sensei-import-lesson-model.php
@@ -152,6 +152,15 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 
 		$value = $this->get_value( Sensei_Data_Port_Lesson_Schema::COLUMN_NUM_QUESTIONS );
 		if ( null !== $value ) {
+			if ( 1 > $value ) {
+				$this->add_line_warning(
+					__( 'Number of Questions must be greater than or equal to 1.', 'sensei-lms' ),
+					[
+						'code' => 'sensei_data_port_lesson_num_questions_negative',
+					]
+				);
+				$value = null;
+			}
 			$meta['_show_questions'] = $value;
 		}
 

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
@@ -375,9 +375,17 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 			Sensei_Data_Port_Course_Schema::COLUMN_TEACHER_EMAIL => 'an_email@email.com',
 		];
 
-		Sensei_Import_Course_Model::from_source_array( 1, $no_username, new Sensei_Data_Port_Course_Schema(), $task )->sync_post();
-		Sensei_Import_Course_Model::from_source_array( 2, $wrong_email, new Sensei_Data_Port_Course_Schema(), $task )->sync_post();
-		Sensei_Import_Course_Model::from_source_array( 3, $correct_line, new Sensei_Data_Port_Course_Schema(), $task )->sync_post();
+		$model_no_username = Sensei_Import_Course_Model::from_source_array( 1, $no_username, new Sensei_Data_Port_Course_Schema(), $task );
+		$model_no_username->sync_post();
+		$model_no_username->add_warnings_to_job();
+
+		$model_wrong_email = Sensei_Import_Course_Model::from_source_array( 2, $wrong_email, new Sensei_Data_Port_Course_Schema(), $task );
+		$model_wrong_email->sync_post();
+		$model_wrong_email->add_warnings_to_job();
+
+		$model_correct_line = Sensei_Import_Course_Model::from_source_array( 3, $correct_line, new Sensei_Data_Port_Course_Schema(), $task );
+		$model_correct_line->sync_post();
+		$model_correct_line->add_warnings_to_job();
 
 		$logs = $job->get_logs();
 

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
@@ -127,7 +127,7 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 					Sensei_Data_Port_Lesson_Schema::COLUMN_VIDEO          => 'video',
 					Sensei_Data_Port_Lesson_Schema::COLUMN_PASS_REQUIRED  => true,
 					Sensei_Data_Port_Lesson_Schema::COLUMN_PASSMARK       => 23.5,
-					Sensei_Data_Port_Lesson_Schema::COLUMN_NUM_QUESTIONS  => 0,
+					Sensei_Data_Port_Lesson_Schema::COLUMN_NUM_QUESTIONS  => null,
 					Sensei_Data_Port_Lesson_Schema::COLUMN_RANDOMIZE      => false,
 					Sensei_Data_Port_Lesson_Schema::COLUMN_AUTO_GRADE     => false,
 					Sensei_Data_Port_Lesson_Schema::COLUMN_QUIZ_RESET     => true,

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
@@ -580,7 +580,7 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 	 */
 	public function testLessonNumQuestionsValidation() {
 		$lesson_data_with_less_than_one_num_questions = [
-			Sensei_Data_Port_Lesson_Schema::COLUMN_TITLE         => 'Required title',
+			Sensei_Data_Port_Lesson_Schema::COLUMN_TITLE => 'Required title',
 			Sensei_Data_Port_Lesson_Schema::COLUMN_NUM_QUESTIONS => 0,
 		];
 

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
@@ -576,6 +576,31 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests number of questions validation.
+	 */
+	public function testLessonNumQuestionsValidation() {
+		$lesson_data_with_less_than_one_num_questions = [
+			Sensei_Data_Port_Lesson_Schema::COLUMN_TITLE         => 'Required title',
+			Sensei_Data_Port_Lesson_Schema::COLUMN_NUM_QUESTIONS => 0,
+		];
+
+		$task  = new Sensei_Import_Lessons( Sensei_Import_Job::create( 'test', 0 ) );
+		$model = Sensei_Import_Lesson_Model::from_source_array( 1, $lesson_data_with_less_than_one_num_questions, new Sensei_Data_Port_Lesson_Schema(), $task );
+		$model->sync_post();
+
+		$created_post_id = get_posts(
+			[
+				'post_type'      => 'lesson',
+				'posts_per_page' => 1,
+				'post_status'    => 'any',
+				'fields'         => 'ids',
+			]
+		)[0];
+
+		$this->assertEquals( get_post_meta( $created_post_id, '_show_questions', true ), '' );
+	}
+
+	/**
 	 * Tests creation and updating of quizzes.
 	 */
 	public function testQuizIsInsertedAndUpdated() {


### PR DESCRIPTION
Fixes #3436

This PR is temporarily based in the branch of this PR: https://github.com/Automattic/sensei/pull/3443

### Changes proposed in this Pull Request

* Add validation to the field `Number of questions to show`. It should accept only numbers greater than or equal to 1.
* It also removes the default value as `''` from the `Number of questions`, so it doesn't add the meta if the value is `null`.

### Testing instructions

1. Import the following lessons data:
```
ID,Lesson,Slug,Description,Excerpt,Status,Course,Module,Prerequisite,Preview,Tags,Image,Length,Complexity,Video,Pass Required,Passmark,Number of Questions,Random Question Order,Auto-Grade,Quiz Reset,Allow Comments,Questions
,0 Questions,,,,,,,,,,,,,,,,0,,,,,
,-1 Questions,,,,,,,,,,,,,,,,-1,,,,,
,abc Questions,,,,,,,,,,,,,,,,abc,,,,,
,Decimal Question,,,,,,,,,,,,,,,,1.5,,,,,
```
* Make sure you see warnings for the invalid numbers and for numbers less than 1. Notice that for the line 4 you'll see two warnings. The first one of the sanitization, that converts the text to `0`, and the next one that tries to validate the `0`.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1144" alt="Screen Shot 2020-07-21 at 15 45 02" src="https://user-images.githubusercontent.com/876340/88093983-2cb0a480-cb69-11ea-8f0c-900593efa2f2.png">
