### PR TITLE
Add warnings in cases where the email will be ignored

### DIFF
--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -17,13 +17,13 @@ class Sensei_Data_Port_Utilities {
 	const CHARS_WHITESPACE_AND_QUOTES = " \"\t\n\r\0\x0B";
 
 	/**
-	 * Create a user. If the user exists, the method simply returns the user id..
+	 * Create a user. If the user exists, the method simply returns the user.
 	 *
 	 * @param string $username  The username.
 	 * @param string $email     User's email.
 	 * @param string $role      The user's role.
 	 *
-	 * @return int|WP_Error  User id on success, WP_Error on failure.
+	 * @return WP_User|WP_Error  WP_User on success, WP_Error on failure.
 	 */
 	public static function create_user( $username, $email = '', $role = '' ) {
 		$user = get_user_by( 'login', $username );
@@ -35,18 +35,14 @@ class Sensei_Data_Port_Utilities {
 				return $user_id;
 			}
 
-			if ( ! empty( $role ) ) {
-				$user = get_user_by( 'ID', $user_id );
+			$user = get_user_by( 'ID', $user_id );
 
-				if ( $user ) {
-					$user->set_role( $role );
-				}
+			if ( ! empty( $role ) && $user ) {
+				$user->set_role( $role );
 			}
-
-			return $user_id;
 		}
 
-		return $user->ID;
+		return $user;
 	}
 
 	/**

--- a/includes/data-port/models/class-sensei-import-course-model.php
+++ b/includes/data-port/models/class-sensei-import-course-model.php
@@ -35,12 +35,33 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 		$teacher = $this->get_default_author();
 
 		$teacher_username = $this->get_value( Sensei_Data_Port_Course_Schema::COLUMN_TEACHER_USERNAME );
+		$teacher_email    = $this->get_value( Sensei_Data_Port_Course_Schema::COLUMN_TEACHER_EMAIL );
 
 		if ( ! empty( $teacher_username ) ) {
-			$teacher = Sensei_Data_Port_Utilities::create_user( $teacher_username, $this->get_value( Sensei_Data_Port_Course_Schema::COLUMN_TEACHER_EMAIL ), 'teacher' );
+			$teacher_user = Sensei_Data_Port_Utilities::create_user( $teacher_username, $teacher_email, 'teacher' );
 
-			if ( is_wp_error( $teacher ) ) {
-				return $teacher;
+			if ( is_wp_error( $teacher_user ) ) {
+				return $teacher_user;
+			}
+
+			if ( ! empty( $teacher_email ) && $teacher_email !== $teacher_user->user_email ) {
+				$this->add_line_warning(
+					__( 'The user with the supplied username has a different email. Teacher email will be ignored.', 'sensei-lms' ),
+					[
+						'code' => 'sensei_data_port_wrong_teacher_email',
+					]
+				);
+			}
+
+			$teacher = $teacher_user->ID;
+		} else {
+			if ( ! empty( $teacher_email ) ) {
+				$this->add_line_warning(
+					__( 'Teacher username is empty, email will be ignored.', 'sensei-lms' ),
+					[
+						'code' => 'sensei_data_port_no_teacher',
+					]
+				);
 			}
 		}
 

--- a/includes/data-port/models/class-sensei-import-course-model.php
+++ b/includes/data-port/models/class-sensei-import-course-model.php
@@ -57,7 +57,7 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 		} else {
 			if ( ! empty( $teacher_email ) ) {
 				$this->add_line_warning(
-					__( 'Teacher username is empty, email will be ignored.', 'sensei-lms' ),
+					__( 'Teacher Username is empty. Course teacher is set to the currently logged in user.', 'sensei-lms' ),
 					[
 						'code' => 'sensei_data_port_no_teacher',
 					]

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
@@ -381,7 +381,7 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 		$logs = $job->get_logs();
 
 		$this->assertCount( 2, $logs, 'There should be two warnings created.' );
-		$this->assertStringStartsWith( 'Teacher username is empty', $logs[0]['message'], 'The first warning should be about username being empty.' );
+		$this->assertStringStartsWith( 'Teacher Username is empty', $logs[0]['message'], 'The first warning should be about username being empty.' );
 		$this->assertStringStartsWith( 'The user with the supplied username has a different email', $logs[1]['message'], 'The second warning should be about email being different.' );
 
 	}

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-utilites.php
@@ -18,13 +18,13 @@ class Sensei_Data_Port_Utilities_Test extends WP_UnitTestCase {
 
 
 	public function testUserIsCreatedIfDoesNotExist() {
-		$user_id = Sensei_Data_Port_Utilities::create_user( 'testuser', 'testemail@test.com' );
+		$user_id = Sensei_Data_Port_Utilities::create_user( 'testuser', 'testemail@test.com' )->ID;
 
 		$user = get_user_by( 'login', 'testuser' );
 		$this->assertEquals( $user_id, $user->ID );
 		$this->assertContains( 'subscriber', $user->roles );
 
-		$user_id = Sensei_Data_Port_Utilities::create_user( 'testuser2', 'testemail2@test.com', 'teacher' );
+		$user_id = Sensei_Data_Port_Utilities::create_user( 'testuser2', 'testemail2@test.com', 'teacher' )->ID;
 
 		$user = get_user_by( 'login', 'testuser2' );
 		$this->assertEquals( $user_id, $user->ID );


### PR DESCRIPTION
Fixes #3447

### Changes proposed in this Pull Request
A warning has been added in the following two cases:
* When a teacher email is supplied and the teacher username is empty.
* When the teacher email is different from the user's with the the supplied username.

### Testing instructions
Import couses which cover the following cases:
* Teacher email is supplied but the username is empty -> Course is created with the current user as a teacher and a warning is displayed
* Teacher email is different than the supplied user's-> Course is created with the supplied user as a teacher and a warning is displayed
* Both email and username are correct -> No warnings are displayed.