### PR TITLE
Remove package resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -149,15 +149,6 @@
             "@babel/types": "^7.10.4"
           }
         },
-        "@babel/helper-module-imports": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-          "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
-          "dev": true,
-          "requires": {
-            "@babel/types": "^7.10.4"
-          }
-        },
         "@babel/helper-plugin-utils": {
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
@@ -195,106 +186,69 @@
           "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
           "dev": true
         },
-        "@babel/plugin-syntax-class-properties": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
-          "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
-          }
-        },
-        "@babel/plugin-syntax-numeric-separator": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-          "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4"
-          }
-        },
         "@babel/preset-env": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.10.4.tgz",
-          "integrity": "sha512-tcmuQ6vupfMZPrLrc38d0sF2OjLT3/bZ0dry5HchNCQbrokoQi4reXqclvkkAT5b+gWc23meVWpve5P/7+w/zw==",
+          "version": "7.8.4",
+          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.8.4.tgz",
+          "integrity": "sha512-HihCgpr45AnSOHRbS5cWNTINs0TwaR8BS8xIIH+QwiW8cKL0llV91njQMpeMReEPVs+1Ao0x3RLEBLtt1hOq4w==",
           "dev": true,
           "requires": {
-            "@babel/compat-data": "^7.10.4",
-            "@babel/helper-compilation-targets": "^7.10.4",
-            "@babel/helper-module-imports": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
-            "@babel/plugin-proposal-class-properties": "^7.10.4",
-            "@babel/plugin-proposal-dynamic-import": "^7.10.4",
-            "@babel/plugin-proposal-json-strings": "^7.10.4",
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-            "@babel/plugin-proposal-numeric-separator": "^7.10.4",
-            "@babel/plugin-proposal-object-rest-spread": "^7.10.4",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
-            "@babel/plugin-proposal-optional-chaining": "^7.10.4",
-            "@babel/plugin-proposal-private-methods": "^7.10.4",
-            "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
+            "@babel/compat-data": "^7.8.4",
+            "@babel/helper-compilation-targets": "^7.8.4",
+            "@babel/helper-module-imports": "^7.8.3",
+            "@babel/helper-plugin-utils": "^7.8.3",
+            "@babel/plugin-proposal-async-generator-functions": "^7.8.3",
+            "@babel/plugin-proposal-dynamic-import": "^7.8.3",
+            "@babel/plugin-proposal-json-strings": "^7.8.3",
+            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
+            "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
+            "@babel/plugin-proposal-optional-catch-binding": "^7.8.3",
+            "@babel/plugin-proposal-optional-chaining": "^7.8.3",
+            "@babel/plugin-proposal-unicode-property-regex": "^7.8.3",
             "@babel/plugin-syntax-async-generators": "^7.8.0",
-            "@babel/plugin-syntax-class-properties": "^7.10.4",
             "@babel/plugin-syntax-dynamic-import": "^7.8.0",
             "@babel/plugin-syntax-json-strings": "^7.8.0",
             "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-            "@babel/plugin-syntax-numeric-separator": "^7.10.4",
             "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
             "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
             "@babel/plugin-syntax-optional-chaining": "^7.8.0",
-            "@babel/plugin-syntax-top-level-await": "^7.10.4",
-            "@babel/plugin-transform-arrow-functions": "^7.10.4",
-            "@babel/plugin-transform-async-to-generator": "^7.10.4",
-            "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
-            "@babel/plugin-transform-block-scoping": "^7.10.4",
-            "@babel/plugin-transform-classes": "^7.10.4",
-            "@babel/plugin-transform-computed-properties": "^7.10.4",
-            "@babel/plugin-transform-destructuring": "^7.10.4",
-            "@babel/plugin-transform-dotall-regex": "^7.10.4",
-            "@babel/plugin-transform-duplicate-keys": "^7.10.4",
-            "@babel/plugin-transform-exponentiation-operator": "^7.10.4",
-            "@babel/plugin-transform-for-of": "^7.10.4",
-            "@babel/plugin-transform-function-name": "^7.10.4",
-            "@babel/plugin-transform-literals": "^7.10.4",
-            "@babel/plugin-transform-member-expression-literals": "^7.10.4",
-            "@babel/plugin-transform-modules-amd": "^7.10.4",
-            "@babel/plugin-transform-modules-commonjs": "^7.10.4",
-            "@babel/plugin-transform-modules-systemjs": "^7.10.4",
-            "@babel/plugin-transform-modules-umd": "^7.10.4",
-            "@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
-            "@babel/plugin-transform-new-target": "^7.10.4",
-            "@babel/plugin-transform-object-super": "^7.10.4",
-            "@babel/plugin-transform-parameters": "^7.10.4",
-            "@babel/plugin-transform-property-literals": "^7.10.4",
-            "@babel/plugin-transform-regenerator": "^7.10.4",
-            "@babel/plugin-transform-reserved-words": "^7.10.4",
-            "@babel/plugin-transform-shorthand-properties": "^7.10.4",
-            "@babel/plugin-transform-spread": "^7.10.4",
-            "@babel/plugin-transform-sticky-regex": "^7.10.4",
-            "@babel/plugin-transform-template-literals": "^7.10.4",
-            "@babel/plugin-transform-typeof-symbol": "^7.10.4",
-            "@babel/plugin-transform-unicode-escapes": "^7.10.4",
-            "@babel/plugin-transform-unicode-regex": "^7.10.4",
-            "@babel/preset-modules": "^0.1.3",
-            "@babel/types": "^7.10.4",
-            "browserslist": "^4.12.0",
+            "@babel/plugin-syntax-top-level-await": "^7.8.3",
+            "@babel/plugin-transform-arrow-functions": "^7.8.3",
+            "@babel/plugin-transform-async-to-generator": "^7.8.3",
+            "@babel/plugin-transform-block-scoped-functions": "^7.8.3",
+            "@babel/plugin-transform-block-scoping": "^7.8.3",
+            "@babel/plugin-transform-classes": "^7.8.3",
+            "@babel/plugin-transform-computed-properties": "^7.8.3",
+            "@babel/plugin-transform-destructuring": "^7.8.3",
+            "@babel/plugin-transform-dotall-regex": "^7.8.3",
+            "@babel/plugin-transform-duplicate-keys": "^7.8.3",
+            "@babel/plugin-transform-exponentiation-operator": "^7.8.3",
+            "@babel/plugin-transform-for-of": "^7.8.4",
+            "@babel/plugin-transform-function-name": "^7.8.3",
+            "@babel/plugin-transform-literals": "^7.8.3",
+            "@babel/plugin-transform-member-expression-literals": "^7.8.3",
+            "@babel/plugin-transform-modules-amd": "^7.8.3",
+            "@babel/plugin-transform-modules-commonjs": "^7.8.3",
+            "@babel/plugin-transform-modules-systemjs": "^7.8.3",
+            "@babel/plugin-transform-modules-umd": "^7.8.3",
+            "@babel/plugin-transform-named-capturing-groups-regex": "^7.8.3",
+            "@babel/plugin-transform-new-target": "^7.8.3",
+            "@babel/plugin-transform-object-super": "^7.8.3",
+            "@babel/plugin-transform-parameters": "^7.8.4",
+            "@babel/plugin-transform-property-literals": "^7.8.3",
+            "@babel/plugin-transform-regenerator": "^7.8.3",
+            "@babel/plugin-transform-reserved-words": "^7.8.3",
+            "@babel/plugin-transform-shorthand-properties": "^7.8.3",
+            "@babel/plugin-transform-spread": "^7.8.3",
+            "@babel/plugin-transform-sticky-regex": "^7.8.3",
+            "@babel/plugin-transform-template-literals": "^7.8.3",
+            "@babel/plugin-transform-typeof-symbol": "^7.8.4",
+            "@babel/plugin-transform-unicode-regex": "^7.8.3",
+            "@babel/types": "^7.8.3",
+            "browserslist": "^4.8.5",
             "core-js-compat": "^3.6.2",
             "invariant": "^2.2.2",
             "levenary": "^1.1.1",
             "semver": "^5.5.0"
-          },
-          "dependencies": {
-            "@babel/plugin-proposal-class-properties": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
-              "integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
-              "dev": true,
-              "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.10.4",
-                "@babel/helper-plugin-utils": "^7.10.4"
-              }
-            }
           }
         },
         "@babel/template": {
@@ -10555,16 +10509,6 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
     },
-    "@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "@types/node": "*"
-      }
-    },
     "@typescript-eslint/experimental-utils": {
       "version": "2.34.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
@@ -13649,6 +13593,16 @@
             "fill-range": "^7.0.1"
           }
         },
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -13818,6 +13772,18 @@
             "debug": "^4.1.1",
             "get-stream": "^5.1.0",
             "yauzl": "^2.10.0"
+          },
+          "dependencies": {
+            "@types/yauzl": {
+              "version": "2.9.1",
+              "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+              "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+              "dev": true,
+              "optional": true,
+              "requires": {
+                "@types/node": "*"
+              }
+            }
           }
         },
         "fill-range": {
@@ -14335,6 +14301,16 @@
           "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
           "dev": true
         },
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        },
         "puppeteer": {
           "version": "npm:puppeteer-core@3.0.0",
           "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
@@ -14353,6 +14329,36 @@
             "tar-fs": "^2.0.0",
             "unbzip2-stream": "^1.3.3",
             "ws": "^7.2.3"
+          },
+          "dependencies": {
+            "chownr": {
+              "version": "1.1.4",
+              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+              "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+              "dev": true
+            },
+            "tar-fs": {
+              "version": "2.1.0",
+              "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
+              "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+              "dev": true,
+              "requires": {
+                "chownr": "^1.1.1",
+                "mkdirp-classic": "^0.5.2",
+                "pump": "^3.0.0",
+                "tar-stream": "^2.0.0"
+              }
+            },
+            "unbzip2-stream": {
+              "version": "1.4.3",
+              "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+              "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+              "dev": true,
+              "requires": {
+                "buffer": "^5.2.1",
+                "through": "^2.3.8"
+              }
+            }
           }
         },
         "randombytes": {
@@ -38607,30 +38613,6 @@
         "inherits": "2"
       }
     },
-    "tar-fs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
-      "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
-      "dev": true,
-      "requires": {
-        "chownr": "^1.1.1",
-        "mkdirp-classic": "^0.5.2",
-        "pump": "^3.0.0",
-        "tar-stream": "^2.0.0"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
-      }
-    },
     "tar-stream": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
@@ -39409,28 +39391,6 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
-    },
-    "unbzip2-stream": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.2.1",
-        "through": "^2.3.8"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        }
-      }
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10509,6 +10509,16 @@
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.1.0.tgz",
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
     },
+    "@types/yauzl": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
+      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "dev": true,
+      "optional": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@typescript-eslint/experimental-utils": {
       "version": "2.34.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
@@ -13593,16 +13603,6 @@
             "fill-range": "^7.0.1"
           }
         },
-        "buffer": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "^1.0.2",
-            "ieee754": "^1.1.4"
-          }
-        },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -13772,18 +13772,6 @@
             "debug": "^4.1.1",
             "get-stream": "^5.1.0",
             "yauzl": "^2.10.0"
-          },
-          "dependencies": {
-            "@types/yauzl": {
-              "version": "2.9.1",
-              "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-              "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
-              "dev": true,
-              "optional": true,
-              "requires": {
-                "@types/node": "*"
-              }
-            }
           }
         },
         "fill-range": {
@@ -14301,16 +14289,6 @@
           "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
           "dev": true
         },
-        "pump": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-          "dev": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        },
         "puppeteer": {
           "version": "npm:puppeteer-core@3.0.0",
           "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
@@ -14329,36 +14307,6 @@
             "tar-fs": "^2.0.0",
             "unbzip2-stream": "^1.3.3",
             "ws": "^7.2.3"
-          },
-          "dependencies": {
-            "chownr": {
-              "version": "1.1.4",
-              "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-              "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-              "dev": true
-            },
-            "tar-fs": {
-              "version": "2.1.0",
-              "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
-              "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
-              "dev": true,
-              "requires": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.0.0"
-              }
-            },
-            "unbzip2-stream": {
-              "version": "1.4.3",
-              "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
-              "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
-              "dev": true,
-              "requires": {
-                "buffer": "^5.2.1",
-                "through": "^2.3.8"
-              }
-            }
           }
         },
         "randombytes": {
@@ -38613,6 +38561,30 @@
         "inherits": "2"
       }
     },
+    "tar-fs": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.0.tgz",
+      "integrity": "sha512-9uW5iDvrIMCVpvasdFHW0wJPez0K4JnMZtsuIeDI7HyMGJNxmDZDOCQROr7lXyS+iL/QMpj07qcjGYTSdRFXUg==",
+      "dev": true,
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
     "tar-stream": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.3.tgz",
@@ -39391,6 +39363,28 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "dev": true
+    },
+    "unbzip2-stream": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.3.tgz",
+      "integrity": "sha512-mlExGW4w71ebDJviH16lQLtZS32VKqsSfk80GCfUlwT/4/hNRFsoscrF/c++9xinkMzECL1uL9DDwXqFWkruPg==",
+      "dev": true,
+      "requires": {
+        "buffer": "^5.2.1",
+        "through": "^2.3.8"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        }
+      }
     },
     "unc-path-regex": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -98,8 +98,5 @@
     "*.php": [
       "scripts/linter-new-php"
     ]
-  },
-  "resolutions": {
-    "@babel/preset-env": "7.10.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -78,8 +78,7 @@
     "e2e-docker:up": "npm explore @woocommerce/e2e-environment -- npm run docker:up",
     "e2e-docker:down": "npm explore @woocommerce/e2e-environment -- npm run docker:down",
     "test:e2e": "npm explore @woocommerce/e2e-environment -- npm run test:e2e",
-    "test:e2e-dev": "npm explore @woocommerce/e2e-environment -- npm run test:e2e-dev",
-    "preinstall": "npx npm-force-resolutions"
+    "test:e2e-dev": "npm explore @woocommerce/e2e-environment -- npm run test:e2e-dev"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This was added in #3336, but causes a problem with SWCPC. The error `Build failed: Working directory for Sensei LMS has changes in it` always comes up, and the build is not created. This is because each time `npm install` is run for Sensei, it generates a new version of `package-lock.json`.

It's not clear why this was needed, but thought it best to get the discussion started.

### Testing instructions

- Run `rm -rf node_modules && npm i`.
- `package-lock.json` should be unchanged.