### PR TITLE
Log on learner management actions

### DIFF
--- a/assets/js/learners-general.js
+++ b/assets/js/learners-general.js
@@ -105,7 +105,7 @@ jQuery( document ).ready( function ( $ ) {
 			withdraw:
 				window.woo_learners_general_data.remove_from_course_confirm,
 			enrol: window.woo_learners_general_data.enrol_in_course_confirm,
-			restore:
+			restore_enrollment:
 				window.woo_learners_general_data.restore_enrollment_confirm,
 		};
 

--- a/assets/js/learners-general.js
+++ b/assets/js/learners-general.js
@@ -190,6 +190,8 @@ jQuery( document ).ready( function ( $ ) {
 					}
 				}
 			);
+
+			window.sensei_log_event( 'learner_management_' + current_action );
 		}
 	} );
 

--- a/assets/js/learners-general.js
+++ b/assets/js/learners-general.js
@@ -101,22 +101,38 @@ jQuery( document ).ready( function ( $ ) {
 
 	jQuery( '.learner-action' ).click( function ( event ) {
 		var current_action = jQuery( this ).attr( 'data-action' );
-		var action_messages = {
-			withdraw:
-				window.woo_learners_general_data.remove_from_course_confirm,
-			enrol: window.woo_learners_general_data.enrol_in_course_confirm,
-			restore_enrollment:
-				window.woo_learners_general_data.restore_enrollment_confirm,
-		};
+		var provider = jQuery( this ).attr( 'data-provider' );
 
-		if ( typeof action_messages[ current_action ] === 'undefined' ) {
+		var actions = {
+			withdraw: {
+				message:
+					window.woo_learners_general_data.remove_from_course_confirm,
+				eventName: 'learner_management_remove_enrollment',
+			},
+			enrol: {
+				message:
+					window.woo_learners_general_data.enrol_in_course_confirm,
+				eventName: 'learner_management_enroll',
+			},
+			restore_enrollment: {
+				message:
+					window.woo_learners_general_data.restore_enrollment_confirm,
+				eventName: 'learner_management_restore_enrollment',
+			},
+		};
+		var action = actions[ current_action ];
+
+		if ( typeof action === 'undefined' ) {
 			return;
 		}
 
-		var confirm_message = action_messages[ current_action ];
+		var confirm_message = action.message;
 
 		if ( ! confirm( confirm_message ) ) {
 			event.preventDefault();
+		} else {
+			var properties = provider ? { provider: provider } : null;
+			window.sensei_log_event( action.eventName, properties );
 		}
 	} );
 

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -525,7 +525,7 @@ class Sensei_Learner_Management {
 
 		// phpcs:ignore WordPress.Security.NonceVerification -- Nonce checked below.
 		$learner_action = sanitize_text_field( wp_unslash( $_GET['learner_action'] ) );
-		if ( ! in_array( $learner_action, [ 'enrol', 'withdraw' ], true ) ) {
+		if ( ! in_array( $learner_action, [ 'enrol', 'restore', 'withdraw' ], true ) ) {
 			wp_safe_redirect( esc_url_raw( $redirect_url ) );
 			exit;
 		}
@@ -564,7 +564,7 @@ class Sensei_Learner_Management {
 
 		if ( 'withdraw' === $learner_action ) {
 			$result = $course_enrolment->withdraw( $user_id );
-		} elseif ( 'enrol' === $learner_action ) {
+		} elseif ( in_array( $learner_action, [ 'enrol', 'restore' ], true ) ) {
 			$result = $course_enrolment->enrol( $user_id );
 		}
 

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -755,6 +755,12 @@ class Sensei_Learner_Management {
 						__( 'An error occurred while manually enrolling the learner.', 'sensei-lms' ),
 					];
 					break;
+				case 'error_restore_enrollment':
+					$notice = [
+						'error',
+						__( 'An error occurred while restoring learner enrollment.', 'sensei-lms' ),
+					];
+					break;
 				case 'error_enrol_multiple':
 					$notice = [
 						'error',
@@ -777,6 +783,12 @@ class Sensei_Learner_Management {
 					$notice = [
 						'updated',
 						__( 'Learner has been manually enrolled.', 'sensei-lms' ),
+					];
+					break;
+				case 'success_restore_enrollment':
+					$notice = [
+						'updated',
+						__( 'Learner enrollment has been restored.', 'sensei-lms' ),
 					];
 					break;
 				case 'success_bulk':

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -525,7 +525,7 @@ class Sensei_Learner_Management {
 
 		// phpcs:ignore WordPress.Security.NonceVerification -- Nonce checked below.
 		$learner_action = sanitize_text_field( wp_unslash( $_GET['learner_action'] ) );
-		if ( ! in_array( $learner_action, [ 'enrol', 'restore', 'withdraw' ], true ) ) {
+		if ( ! in_array( $learner_action, [ 'enrol', 'restore_enrollment', 'withdraw' ], true ) ) {
 			wp_safe_redirect( esc_url_raw( $redirect_url ) );
 			exit;
 		}
@@ -564,7 +564,7 @@ class Sensei_Learner_Management {
 
 		if ( 'withdraw' === $learner_action ) {
 			$result = $course_enrolment->withdraw( $user_id );
-		} elseif ( in_array( $learner_action, [ 'enrol', 'restore' ], true ) ) {
+		} elseif ( in_array( $learner_action, [ 'enrol', 'restore_enrollment' ], true ) ) {
 			$result = $course_enrolment->enrol( $user_id );
 		}
 

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -464,14 +464,14 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 								array(
 									'page'             => 'sensei_learners',
 									'view'             => 'learners',
-									'learner_action'   => 'enrol',
+									'learner_action'   => $data_action,
 									'course_id'        => $this->course_id,
 									'user_id'          => $user_activity->user_id,
 									'enrolment_status' => $this->enrolment_status,
 								),
 								admin_url( 'admin.php' )
 							),
-							'sensei-learner-action-enrol'
+							'sensei-learner-action-' . $data_action
 						);
 
 						$row_actions[] =

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -456,7 +456,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 						// Check if it's enrolled by some provider.
 						if ( ! empty( $provider_results ) && in_array( true, $provider_results, true ) ) {
 							$enrol_label = esc_html__( 'Restore Enrollment', 'sensei-lms' );
-							$data_action = 'restore';
+							$data_action = 'restore_enrollment';
 						}
 
 						$enrol_action_url = wp_nonce_url(

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -426,6 +426,11 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$actions     = [];
 				$row_actions = [];
 
+				$provider_ids_with_enrollment = implode( ',', array_keys( $provider_results, true, true ) );
+				$providers_attr               = ! empty( $provider_ids_with_enrollment )
+					? 'data-provider="' . $provider_ids_with_enrollment . '"'
+					: '';
+
 				if ( 'course' === $post_type ) {
 					if ( $is_user_enrolled ) {
 						$withdraw_action_url = wp_nonce_url(
@@ -445,18 +450,20 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 						$row_actions[] =
 							'<span class="delete">' .
-								'<a class="learner-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="withdraw" href="' . esc_url( $withdraw_action_url ) . '">' .
+								'<a class="learner-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="withdraw" ' . $providers_attr . ' href="' . esc_url( $withdraw_action_url ) . '">' .
 									esc_html__( 'Remove Enrollment', 'sensei-lms' ) .
 								'</a>' .
 							'</span>';
 					} else {
-						$enrol_label = esc_html__( 'Enroll', 'sensei-lms' );
-						$data_action = 'enrol';
+						$enrol_label            = esc_html__( 'Enroll', 'sensei-lms' );
+						$data_action            = 'enrol';
+						$restore_providers_attr = '';
 
 						// Check if it's enrolled by some provider.
-						if ( ! empty( $provider_results ) && in_array( true, $provider_results, true ) ) {
-							$enrol_label = esc_html__( 'Restore Enrollment', 'sensei-lms' );
-							$data_action = 'restore_enrollment';
+						if ( ! empty( $provider_ids_with_enrollment ) ) {
+							$enrol_label            = esc_html__( 'Restore Enrollment', 'sensei-lms' );
+							$data_action            = 'restore_enrollment';
+							$restore_providers_attr = $providers_attr;
 						}
 
 						$enrol_action_url = wp_nonce_url(
@@ -476,7 +483,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 						$row_actions[] =
 							'<span>' .
-								'<a class="learner-action" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="' . $data_action . '" href="' . esc_url( $enrol_action_url ) . '">' .
+								'<a class="learner-action" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="' . $data_action . '" ' . $restore_providers_attr . ' href="' . esc_url( $enrol_action_url ) . '">' .
 									$enrol_label .
 								'</a>' .
 							'</span>';
@@ -554,6 +561,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 							'data-post-type'  => array(),
 							'data-user-id'    => array(),
 							'data-action'     => array(),
+							'data-provider'   => array(),
 						),
 						// Explicitly allow form tag for WP.com.
 						'form'  => array(


### PR DESCRIPTION
Fixes #3414
Fixes https://github.com/Automattic/sensei-wc-paid-courses/issues/512

Close #3464 (A different approach tracking through the server when needed the providers)

### Changes proposed in this Pull Request

* Add logs on the learner management actions:
  * Enroll.
  * Remove Enrollment.
  * Restore Enrollment.
  * Remove Progress.
  * Reset Progress.

### Testing instructions

* Click on the actions mentioned and make sure it's logged. For the "Remove Enrollment" and "Restore Enrollment", make sure it's logged with the respective providers that are providing the enrollment.
Check the issues #3414 and https://github.com/Automattic/sensei-wc-paid-courses/issues/512 to see the correct event names and properties.