### PR TITLE
Update learner management messages to be more generic

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -752,38 +752,38 @@ class Sensei_Learner_Management {
 				case 'error_enrol':
 					$notice = [
 						'error',
-						__( 'An error occurred while manually enrolling the learner.', 'sensei-lms' ),
+						__( 'An error occurred while enrolling the learner.', 'sensei-lms' ),
 					];
 					break;
 				case 'error_enrol_multiple':
 					$notice = [
 						'error',
-						__( 'An error occurred while manually enrolling the learners.', 'sensei-lms' ),
+						__( 'An error occurred while enrolling the learners.', 'sensei-lms' ),
 					];
 					break;
 				case 'error_withdraw':
 					$notice = [
 						'error',
-						__( 'An error occurred removing the learner\'s manual enrollment', 'sensei-lms' ),
+						__( 'An error occurred removing the learner\'s enrollment', 'sensei-lms' ),
 					];
 					break;
 				case 'success_withdraw':
 					$notice = [
 						'updated',
-						__( 'Learner\'s manual enrollment has been removed.', 'sensei-lms' ),
+						__( 'Learner\'s enrollment has been removed.', 'sensei-lms' ),
 					];
 					break;
 				case 'success_enrol':
 					$notice = [
 						'updated',
-						__( 'Learner has been manually enrolled.', 'sensei-lms' ),
+						__( 'Learner has been enrolled.', 'sensei-lms' ),
 					];
 					break;
 				case 'success_bulk':
 				case 'success_enrol_multiple':
 					$notice = [
 						'updated',
-						__( 'Learners have been manually enrolled.', 'sensei-lms' ),
+						__( 'Learners have been enrolled.', 'sensei-lms' ),
 					];
 					break;
 			}

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -764,7 +764,7 @@ class Sensei_Learner_Management {
 				case 'error_withdraw':
 					$notice = [
 						'error',
-						__( 'An error occurred removing the learner\'s enrollment', 'sensei-lms' ),
+						__( 'An error occurred removing the learner\'s enrollment.', 'sensei-lms' ),
 					];
 					break;
 				case 'success_withdraw':


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Similar to this commit: https://github.com/Automattic/sensei/pull/3456/commits/1fd33921edfd83f433917a28fafb87a45670ad67, it update the feedback messages to be more generic. Another approach to keep the original messages would be to customize the messages for any different situation, but I believe it doesn't worth adding the complexity in the code.

For restore enrolment, it has a specific message added here: https://github.com/Automattic/sensei/pull/3465/commits/700af0d44ff0c5e937672338a22b9e4e297c915c through this PR: https://github.com/Automattic/sensei/pull/3465

### Testing instructions

Check the feedback message on the top of the screen in each case:

* Enroll a user manually.
* Remove the user.
* Enroll a user through any other provider, and remove the user through the Learner Management.
* Restore the enrollment.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="639" alt="Screen Shot 2020-07-23 at 18 36 36" src="https://user-images.githubusercontent.com/876340/88341166-7a691080-cd13-11ea-8823-2a55aec02bc2.png">