### PR TITLE
Only add "first" and "last" CSS classes for grid layouts on course archive page

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2462,11 +2462,11 @@ class Sensei_Course {
 
 		// Apply "first" and "last" CSS classes for grid-based layouts.
 		if ( 1 !== $sensei_course_loop['columns'] ) {
-			if ( 0 == ( $sensei_course_loop['counter'] - 1 ) % $sensei_course_loop['columns'] || 1 == $sensei_course_loop['columns'] ) {
+			if ( 0 === ( $sensei_course_loop['counter'] - 1 ) % $sensei_course_loop['columns'] ) {
 				$extra_classes[] = 'first';
 			}
 
-			if ( 0 == $sensei_course_loop['counter'] % $sensei_course_loop['columns'] ) {
+			if ( 0 === $sensei_course_loop['counter'] % $sensei_course_loop['columns'] ) {
 				$extra_classes[] = 'last';
 			}
 		}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2459,12 +2459,16 @@ class Sensei_Course {
 		$sensei_course_loop['counter']++;
 
 		$extra_classes = array();
-		if ( 0 == ( $sensei_course_loop['counter'] - 1 ) % $sensei_course_loop['columns'] || 1 == $sensei_course_loop['columns'] ) {
-			$extra_classes[] = 'first';
-		}
 
-		if ( 0 == $sensei_course_loop['counter'] % $sensei_course_loop['columns'] ) {
-			$extra_classes[] = 'last';
+		// Apply "first" and "last" CSS classes for grid-based layouts.
+		if ( 1 !== $sensei_course_loop['columns'] ) {
+			if ( 0 == ( $sensei_course_loop['counter'] - 1 ) % $sensei_course_loop['columns'] || 1 == $sensei_course_loop['columns'] ) {
+				$extra_classes[] = 'first';
+			}
+
+			if ( 0 == $sensei_course_loop['counter'] % $sensei_course_loop['columns'] ) {
+				$extra_classes[] = 'last';
+			}
 		}
 
 		// add the item number to the classes as well.
@@ -2475,13 +2479,14 @@ class Sensei_Course {
 		 * which is called from the course loop content-course.php
 		 *
 		 * @since 1.9.0
+		 * @hook sensei_course_loop_content_class
 		 *
-		 * @param array $extra_classes
-		 * @param WP_Post $loop_current_course
+		 * @param {array} $extra_classes
+		 * @param {WP_Post} $loop_current_course
 		 */
 		return apply_filters( 'sensei_course_loop_content_class', $extra_classes, get_post() );
 
-	}//end get_course_loop_content_class()
+	}
 
 	/**
 	 * Get the number of columns set for Sensei courses


### PR DESCRIPTION
Fixes #3260.

### Changes proposed in this Pull Request
Remove the _first_ and _last_ CSS classes from non-grid layouts on the course archive page.

Note that I was no longer able to reproduce https://github.com/Automattic/sensei/issues/3260#issuecomment-640078326, so made the above change instead.

### Testing instructions

* Visit the course archive page.
* Ensure that the list items inside `.course-container` don't have _first_ or _last_ CSS classes applied.
* Add the following snippet:
```
add_filter( 'sensei_course_loop_number_of_columns', 'update_course_columns' );

function update_course_columns() {
	return 2;
}
```
* Refresh the course archive page.
* Ensure that the first list item inside `.course-container` has the _first_ CSS class applied, and that the last item has the _last_ CSS class applied.