### PR TITLE
Fix hookdoc configurations

### DIFF
--- a/hookdoc-conf.json
+++ b/hookdoc-conf.json
@@ -2,14 +2,17 @@
   "opts": {
       "destination": "hookdocs",
       "template": "node_modules/wp-hookdoc/template",
-      "readme": "./.github/hookdoc-tmpl/README.md"
+      "readme": "./.github/hookdoc-tmpl/README.md",
+      "recurse": true
   },
   "source": {
       "include": [
-        "./",
-        "includes"
+        "./"
       ],
-      "includePattern": ".+\\.(php)?$"
+      "includePattern": ".+\\.(php)?$",
+      "exclude": [
+        "node_modules"
+      ]
   },
   "plugins": [
     "node_modules/wp-hookdoc/plugin",


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix hookdoc configurations

### Testing instructions

* Run `npm run build:docs` and make sure hooks from inner folders are added to the documentation. (e.g. `sensei_import_csv_delimiter`)
