### PR TITLE
Add bulk remove/restore enrollments

### DIFF
--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -260,12 +260,6 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	 * @param string  $action    The action.
 	 */
 	private function do_user_action( $user_id, $course_id, $action ) {
-		try {
-			$manual_enrolment_provider = Sensei_Course_Enrolment_Manager::instance()->get_manual_enrolment_provider();
-		} catch ( Exception $e ) {
-			$this->redirect_to_learner_admin_index( $e->getMessage() );
-		}
-
 		switch ( $action ) {
 			case self::ENROL_RESTORE_ENROLMENT:
 				$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -268,14 +268,12 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 
 		switch ( $action ) {
 			case self::ENROL_RESTORE_ENROLMENT:
-				if ( ! $manual_enrolment_provider->is_enrolled( $user_id, $course_id ) ) {
-					$manual_enrolment_provider->enrol_learner( $user_id, $course_id );
-				}
+				$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+				$course_enrolment->enrol( $user_id );
 				break;
 			case self::REMOVE_ENROLMENT:
-				if ( $manual_enrolment_provider->is_enrolled( $user_id, $course_id ) ) {
-					$manual_enrolment_provider->withdraw_learner( $user_id, $course_id );
-				}
+				$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+				$course_enrolment->withdraw( $user_id );
 				break;
 			case self::REMOVE_PROGRESS:
 				if ( Sensei_Utils::has_started_course( $course_id, $user_id ) ) {

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -16,8 +16,8 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 
 	const NONCE_SENSEI_BULK_LEARNER_ACTIONS       = 'sensei-bulk-learner-actions';
 	const SENSEI_BULK_LEARNER_ACTIONS_NONCE_FIELD = '_sensei_bulk_learner_actions_field';
-	const MANUALLY_ENROL                          = 'manually_enrol';
-	const REMOVE_MANUAL_ENROLMENT                 = 'remove_manual_enrolment';
+	const ENROL_RESTORE_ENROLMENT                 = 'enrol_restore_enrolment';
+	const REMOVE_ENROLMENT                        = 'remove_enrolment';
 	const REMOVE_PROGRESS                         = 'remove_progress';
 	const COMPLETE_COURSE                         = 'complete_course';
 	const RECALCULATE_COURSE_COMPLETION           = 'recalculate_course_completion';
@@ -115,9 +115,9 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 		$this->learner_management = $management;
 
 		$this->known_bulk_actions = [
-			self::MANUALLY_ENROL                => __( 'Add manual enrollment', 'sensei-lms' ),
-			self::REMOVE_MANUAL_ENROLMENT       => __( 'Remove manual enrollment', 'sensei-lms' ),
-			self::REMOVE_PROGRESS               => __( 'Reset or remove progress', 'sensei-lms' ),
+			self::ENROL_RESTORE_ENROLMENT       => __( 'Enroll / Restore Enrollment', 'sensei-lms' ),
+			self::REMOVE_ENROLMENT              => __( 'Remove Enrollment', 'sensei-lms' ),
+			self::REMOVE_PROGRESS               => __( 'Reset or Remove Progress', 'sensei-lms' ),
 			self::COMPLETE_COURSE               => __( 'Recalculate Course(s) Completion (notify on complete)', 'sensei-lms' ),
 			self::RECALCULATE_COURSE_COMPLETION => __( 'Recalculate Course(s) Completion (do not notify on complete)', 'sensei-lms' ),
 		];
@@ -267,12 +267,12 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 		}
 
 		switch ( $action ) {
-			case self::MANUALLY_ENROL:
+			case self::ENROL_RESTORE_ENROLMENT:
 				if ( ! $manual_enrolment_provider->is_enrolled( $user_id, $course_id ) ) {
 					$manual_enrolment_provider->enrol_learner( $user_id, $course_id );
 				}
 				break;
-			case self::REMOVE_MANUAL_ENROLMENT:
+			case self::REMOVE_ENROLMENT:
 				if ( $manual_enrolment_provider->is_enrolled( $user_id, $course_id ) ) {
 					$manual_enrolment_provider->withdraw_learner( $user_id, $course_id );
 				}

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -311,8 +311,8 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 
 		$manual_provider = Sensei_Course_Enrolment_Manager::instance()->get_manual_enrolment_provider();
 		if ( ! $manual_provider ) {
-			unset( $bulk_actions[ Sensei_Learners_Admin_Bulk_Actions_Controller::MANUALLY_ENROL ] );
-			unset( $bulk_actions[ Sensei_Learners_Admin_Bulk_Actions_Controller::REMOVE_MANUAL_ENROLMENT ] );
+			unset( $bulk_actions[ Sensei_Learners_Admin_Bulk_Actions_Controller::ENROL_RESTORE_ENROLMENT ] );
+			unset( $bulk_actions[ Sensei_Learners_Admin_Bulk_Actions_Controller::REMOVE_ENROLMENT ] );
 		}
 
 		foreach ( $bulk_actions as $value => $translation ) {

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -309,12 +309,6 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 			'<option value="">' . esc_html__( 'Bulk Learner Actions', 'sensei-lms' ) . '</option>';
 		$bulk_actions = $this->controller->get_known_bulk_actions();
 
-		$manual_provider = Sensei_Course_Enrolment_Manager::instance()->get_manual_enrolment_provider();
-		if ( ! $manual_provider ) {
-			unset( $bulk_actions[ Sensei_Learners_Admin_Bulk_Actions_Controller::ENROL_RESTORE_ENROLMENT ] );
-			unset( $bulk_actions[ Sensei_Learners_Admin_Bulk_Actions_Controller::REMOVE_ENROLMENT ] );
-		}
-
 		foreach ( $bulk_actions as $value => $translation ) {
 			$rendered .= '<option value="' . esc_attr( $value ) . '">' . esc_html( $translation ) . '</option>';
 		}

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -561,12 +561,11 @@ class Sensei_Course_Enrolment {
 		$enrolment_manager         = Sensei_Course_Enrolment_Manager::instance();
 		$manual_enrolment_provider = $enrolment_manager->get_manual_enrolment_provider();
 
-		if ( ! ( $manual_enrolment_provider instanceof Sensei_Course_Manual_Enrolment_Provider ) ) {
-			return false;
-		}
-
 		// If user is manually enrolled, withdraw from manual provider.
-		if ( $manual_enrolment_provider->is_enrolled( $user_id, $this->course_id ) ) {
+		if (
+			$manual_enrolment_provider instanceof Sensei_Course_Manual_Enrolment_Provider &&
+			$manual_enrolment_provider->is_enrolled( $user_id, $this->course_id )
+		) {
 			$manual_enrolment_provider->withdraw_learner( $user_id, $this->course_id );
 
 			if ( ! $this->is_enrolled( $user_id, false ) ) {

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -561,16 +561,12 @@ class Sensei_Course_Enrolment {
 		$enrolment_manager         = Sensei_Course_Enrolment_Manager::instance();
 		$manual_enrolment_provider = $enrolment_manager->get_manual_enrolment_provider();
 
-		// If user is manually enrolled, withdraw from manual provider.
-		if (
-			$manual_enrolment_provider instanceof Sensei_Course_Manual_Enrolment_Provider &&
-			$manual_enrolment_provider->is_enrolled( $user_id, $this->course_id )
-		) {
+		if ( $manual_enrolment_provider instanceof Sensei_Course_Manual_Enrolment_Provider ) {
 			$manual_enrolment_provider->withdraw_learner( $user_id, $this->course_id );
+		}
 
-			if ( ! $this->is_enrolled( $user_id, false ) ) {
-				return true;
-			}
+		if ( ! $this->is_enrolled( $user_id, false ) ) {
+			return true;
 		}
 
 		// If user is still enrolled for some reason, remove them.
@@ -591,10 +587,10 @@ class Sensei_Course_Enrolment {
 		// If user is removed, just restore.
 		if ( $this->is_learner_removed( $user_id ) ) {
 			$this->restore_learner( $user_id );
+		}
 
-			if ( $this->is_enrolled( $user_id, false ) ) {
-				return true;
-			}
+		if ( $this->is_enrolled( $user_id, false ) ) {
+			return true;
 		}
 
 		// If user isn't still enrolled, enroll manually.

--- a/tests/unit-tests/test-class-sensei-learners-admin-bulk-actions-controller.php
+++ b/tests/unit-tests/test-class-sensei-learners-admin-bulk-actions-controller.php
@@ -111,6 +111,9 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller_Test extends WP_UnitTestCase
 		$_POST['bulk_action_course_ids'] = implode( ',', $courses );
 		$_POST['bulk_action_user_ids']   = implode( ',', $users );
 
+		$this->mockCourseEnrolmentIsEnrolled( $courses[0], false );
+		$this->mockCourseEnrolmentIsEnrolled( $courses[1], false );
+
 		$mock_provider = $this->getMockBuilder( Sensei_Course_Manual_Enrolment_Provider::class )
 			->disableOriginalConstructor()
 			->setMethods( [ 'withdraw_learner', 'is_enrolled' ] )
@@ -175,5 +178,33 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller_Test extends WP_UnitTestCase
 		$property = new ReflectionProperty( 'Sensei_Course_Enrolment_Manager', 'enrolment_providers' );
 		$property->setAccessible( true );
 		$property->setValue( Sensei_Course_Enrolment_Manager::instance(), [ $mock_provider->get_id() => $mock_provider ] );
+	}
+
+	/**
+	 * Helper method to mock is_enrolled method in the Sensei_Course_Enrolment class.
+	 *
+	 * @param int  $course_id   Course ID.
+	 * @param bool $is_enrolled Value that is_enrolled method will return.
+	 *
+	 * @throws ReflectionException
+	 */
+	private function mockCourseEnrolmentIsEnrolled( $course_id, $is_enrolled ) {
+		$mock = $this->getMockBuilder( Sensei_Course_Enrolment::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'is_enrolled' ] )
+			->getMock();
+
+		$mock->method( 'is_enrolled' )->willReturn( $is_enrolled );
+
+		$instances_property = new ReflectionProperty( 'Sensei_Course_Enrolment', 'instances' );
+		$instances_property->setAccessible( true );
+
+		$instances               = $instances_property->getValue();
+		$instances[ $course_id ] = $mock;
+		$instances_property->setValue( $instances );
+
+		$course_id_property = new ReflectionProperty( 'Sensei_Course_Enrolment', 'course_id' );
+		$course_id_property->setAccessible( true );
+		$course_id_property->setValue( $mock, $course_id );
 	}
 }

--- a/tests/unit-tests/test-class-sensei-learners-admin-bulk-actions-controller.php
+++ b/tests/unit-tests/test-class-sensei-learners-admin-bulk-actions-controller.php
@@ -59,7 +59,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller_Test extends WP_UnitTestCase
 		$user   = $this->factory->user->create();
 		$course = $this->factory->course->create();
 
-		$_POST['sensei_bulk_action']     = Sensei_Learners_Admin_Bulk_Actions_Controller::MANUALLY_ENROL;
+		$_POST['sensei_bulk_action']     = Sensei_Learners_Admin_Bulk_Actions_Controller::ENROL_RESTORE_ENROLMENT;
 		$_POST['bulk_action_course_ids'] = $course + 1;
 		$_POST['bulk_action_user_ids']   = $user;
 
@@ -71,13 +71,13 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
-	 * Tests that the user gets enrolled when the action is MANUALLY_ENROL and the user is not already manually enroled.
+	 * Tests that the user gets enrolled when the action is ENROL_RESTORE_ENROLMENT and the user is not already manually enroled.
 	 */
 	public function testUsersAreEnroledWhenActionIsManualEnrol() {
 		$users   = $this->factory->user->create_many( 2 );
 		$courses = $this->factory->course->create_many( 2 );
 
-		$_POST['sensei_bulk_action']     = Sensei_Learners_Admin_Bulk_Actions_Controller::MANUALLY_ENROL;
+		$_POST['sensei_bulk_action']     = Sensei_Learners_Admin_Bulk_Actions_Controller::ENROL_RESTORE_ENROLMENT;
 		$_POST['bulk_action_course_ids'] = implode( ',', $courses );
 		$_POST['bulk_action_user_ids']   = implode( ',', $users );
 
@@ -100,14 +100,14 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller_Test extends WP_UnitTestCase
 	}
 
 	/**
-	 * Tests that the manual enrolment is removed when the action is REMOVE_MANUAL_ENROLMENT and the user is not already
+	 * Tests that the manual enrolment is removed when the action is REMOVE_ENROLMENT and the user is not already
 	 * manually enroled.
 	 */
 	public function testUsersAreUnEnroledWhenActionIsRemoveManualEnrolment() {
 		$users   = $this->factory->user->create_many( 2 );
 		$courses = $this->factory->course->create_many( 2 );
 
-		$_POST['sensei_bulk_action']     = Sensei_Learners_Admin_Bulk_Actions_Controller::REMOVE_MANUAL_ENROLMENT;
+		$_POST['sensei_bulk_action']     = Sensei_Learners_Admin_Bulk_Actions_Controller::REMOVE_ENROLMENT;
 		$_POST['bulk_action_course_ids'] = implode( ',', $courses );
 		$_POST['bulk_action_user_ids']   = implode( ',', $users );
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/3479.

### Changes proposed in this Pull Request

* Add feature to remove/restore enrollments.

### Testing instructions

**Remove/restore**

* Enrol 2 or more users to a course through a provider.
* Go to the "Bulk Learner Actions".
* Select the enrolled users.
* Select the option "Remove Enrollment", select the courses which they're enrolled, and apply.
* Check that the users are not enrolled.
* Repeat the process selecting the "Enrol / Restore Enrollment" option, and make sure they're enrolled again.

**Manual provider**

* Go to the "Bulk Learner Actions".
* Select 2 or more users.
* Select the option "Enrol / Restore Enrollment", select courses which they aren't enrolled through any provider, and apply.
* Make sure now they are enrolled.
* Repeat the process selecting the "Remove Enrollment" option, and make sure they aren't enrolled.