### PR TITLE
Update learner management tables alignment

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -523,10 +523,10 @@
 	table  {
 		td  {
 			padding: 12px 7px 12px;
-			vertical-align: middle;
 		}
 		.user_status  {
 			span  {
+				display: inline-block;
 				padding: 5px 10px;
 				@include border_radius(3px);
 				white-space: nowrap;
@@ -553,6 +553,7 @@
 
 		.enrolment_status  {
 			span  {
+				display: inline-block;
 				padding: 5px 10px;
 				@include border_radius(3px);
 				white-space: nowrap;


### PR DESCRIPTION
Fixes #3472

### Changes proposed in this Pull Request

* The learner management/grading tables were updated to the default `vertical-align: top`.

### Testing instructions

* Go to the learner management.
* Check the table alignment.
* Open the learner "Manage learners" and the "Grading" for a course. Check the table alignment for both.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1127" alt="Screen Shot 2020-07-27 at 11 01 50" src="https://user-images.githubusercontent.com/876340/88551439-3fa7f680-cff9-11ea-9bfa-98b3b2d43600.png">
<img width="1130" alt="Screen Shot 2020-07-27 at 11 02 11" src="https://user-images.githubusercontent.com/876340/88551446-4171ba00-cff9-11ea-871d-ab8a54635095.png">
<img width="1121" alt="Screen Shot 2020-07-27 at 11 02 42" src="https://user-images.githubusercontent.com/876340/88551457-433b7d80-cff9-11ea-8473-6a575060b585.png">
