### PR TITLE
Add travis tests against WP 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,19 @@
 sudo: false
 dist: trusty
 language: php
+
+# Shared code for e2e jobs.
+e2e_defaults: &e2e_defaults
+  language: node_js
+  node_js: '10.17'
+  script:
+    - npm run build
+    - npm run e2e-docker:up
+    - npm run test:e2e
+  after_script:
+    - npm run e2e-docker:down
+    - echo "In case of E2E test failures, screenshots can be found in the slack channel `#evergreen-github`"
+
 notifications:
   email:
     on_success: never
@@ -112,13 +125,8 @@ jobs:
         - composer install
         - ./scripts/linter-ci
     - stage: test
-      language: node_js
-      node_js: '10.17'
+      <<: *e2e_defaults
       env: RUN_E2E=1
-      script:
-        - npm run build
-        - npm run e2e-docker:up
-        - npm run test:e2e
-      after_script:
-        - npm run e2e-docker:down
-        - echo "In case of E2E test failures, screenshots can be found in the slack channel `#evergreen-github`"
+    - stage: test
+      <<: *e2e_defaults
+      env: WP_VERSION=5.0 RUN_E2E=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,3 +130,12 @@ jobs:
     - stage: test
       <<: *e2e_defaults
       env: WP_VERSION=5.0 RUN_E2E=1
+    - stage: test
+      <<: *e2e_defaults
+      env: WP_VERSION=5.1 RUN_E2E=1
+    - stage: test
+      <<: *e2e_defaults
+      env: WP_VERSION=5.2 RUN_E2E=1
+    - stage: test
+      <<: *e2e_defaults
+      env: WP_VERSION=5.3 RUN_E2E=1

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,10 @@ version: '3.3'
 services:
 
   wordpress-www:
+    build:
+      context: ../../../tests/e2e/docker/wordpress
+      args:
+        WP_VERSION: "${WP_VERSION:-latest}"
     volumes:
       # This path is relative to the first config file
       # which is in node_modules/@woocommerce/e2e/env

--- a/tests/e2e/docker/wordpress/Dockerfile
+++ b/tests/e2e/docker/wordpress/Dockerfile
@@ -1,0 +1,2 @@
+ARG  WP_VERSION=latest
+FROM wordpress:${WP_VERSION}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR overrides some `@woocommerce/e2e-environment` configurations to allow run the e2e tests against different WordPress versions.
* This also adds the new job to Travis to run the e2e tests against the WP 5.0.

### Testing instructions

* Check the Travis logs.