### PR TITLE
Add file error handler

### DIFF
--- a/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
+++ b/includes/data-port/import-tasks/class-sensei-import-file-process-task.php
@@ -79,11 +79,11 @@ abstract class Sensei_Import_File_Process_Task
 				$this->reader = new Sensei_Import_CSV_Reader( get_attached_file( $attachment_id ), $completed_lines );
 			} catch ( Exception $e ) {
 				$this->get_job()->add_log_entry(
-					__( 'Uploaded file could not be opened while continuing.', 'sensei-lms' ),
+					__( 'Uploaded file could not be opened.', 'sensei-lms' ),
 					Sensei_Data_Port_Job::LOG_LEVEL_ERROR,
 					[
 						'type' => $this->get_model_key(),
-						'code' => 'sensei_data_port_job_unreadable_file_continuing',
+						'code' => 'sensei_data_port_job_unreadable_file',
 					]
 				);
 


### PR DESCRIPTION
Fixes #3453

### Changes proposed in this Pull Request

* Add file error handler. This error usually would occur while resuming a job.

### Testing instructions

The easiest way I found to simulate this issue was changing the line:
`$this->reader = new Sensei_Import_CSV_Reader( get_attached_file( $attachment_id ), $completed_lines );`
to:
`$this->reader = new Sensei_Import_CSV_Reader( 'bananas', $completed_lines );`

And then try importing a file.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1062" alt="Screen Shot 2020-07-28 at 16 20 37" src="https://user-images.githubusercontent.com/876340/88711295-5c722600-d0ee-11ea-91d3-d1c2a6dc9e27.png">
