### PR TITLE
Change importer progress bar to be full only when it's complete

### DIFF
--- a/assets/data-port/import.js
+++ b/assets/data-port/import.js
@@ -1,6 +1,11 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import { render, useLayoutEffect } from '@wordpress/element';
+import {
+	render,
+	useState,
+	useEffect,
+	useLayoutEffect,
+} from '@wordpress/element';
 import { DataPortStepper } from './stepper';
 import registerImportStore from './import/data';
 import { Spinner } from '@woocommerce/components';
@@ -22,6 +27,20 @@ const SenseiImportPage = () => {
 	}, [] );
 
 	const { fetchCurrentJobState } = useDispatch( 'sensei/import' );
+
+	const [ currentStep, setCurrentStep ] = useState();
+
+	useEffect( () => {
+		const newStep = navigationSteps.find( ( step ) => step.isNext );
+
+		if ( 'complete' === newStep.key ) {
+			setTimeout( () => {
+				setCurrentStep( newStep );
+			}, 1000 ); // CSS animation time to complete the progress bar.
+		} else {
+			setCurrentStep( newStep );
+		}
+	}, [ navigationSteps ] );
 
 	// We want to show the loading before any content.
 	useLayoutEffect( () => {
@@ -51,8 +70,6 @@ const SenseiImportPage = () => {
 			</Notice>
 		);
 	}
-
-	const currentStep = navigationSteps.find( ( step ) => step.isNext );
 
 	return (
 		<div className="sensei-import-wrapper">

--- a/assets/data-port/import.js
+++ b/assets/data-port/import.js
@@ -1,11 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
-import {
-	render,
-	useState,
-	useEffect,
-	useLayoutEffect,
-} from '@wordpress/element';
+import { render, useLayoutEffect } from '@wordpress/element';
 import { DataPortStepper } from './stepper';
 import registerImportStore from './import/data';
 import { Spinner } from '@woocommerce/components';
@@ -27,20 +22,6 @@ const SenseiImportPage = () => {
 	}, [] );
 
 	const { fetchCurrentJobState } = useDispatch( 'sensei/import' );
-
-	const [ currentStep, setCurrentStep ] = useState();
-
-	useEffect( () => {
-		const newStep = navigationSteps.find( ( step ) => step.isNext );
-
-		if ( 'complete' === newStep.key ) {
-			setTimeout( () => {
-				setCurrentStep( newStep );
-			}, 1000 ); // CSS animation time to complete the progress bar.
-		} else {
-			setCurrentStep( newStep );
-		}
-	}, [ navigationSteps ] );
 
 	// We want to show the loading before any content.
 	useLayoutEffect( () => {
@@ -70,6 +51,8 @@ const SenseiImportPage = () => {
 			</Notice>
 		);
 	}
+
+	const currentStep = navigationSteps.find( ( step ) => step.isNext );
 
 	return (
 		<div className="sensei-import-wrapper">

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -461,7 +461,8 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 			 */
 			do_action( 'sensei_data_port_complete', $this );
 		} else {
-			$this->percentage = 100 * $completed_cycles / $total_cycles;
+			// The calc is based in 90% as maximum when it's not completed yet.
+			$this->percentage = 90 * $completed_cycles / $total_cycles;
 		}
 
 		$this->has_changed = true;

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
@@ -78,7 +78,7 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			[
 				'status'     => 'pending',
-				'percentage' => 62.5,
+				'percentage' => 56.25,
 			],
 			$job->get_status()
 		);
@@ -101,7 +101,7 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 		$this->assertEquals(
 			[
 				'status'     => 'pending',
-				'percentage' => 25,
+				'percentage' => 22.5,
 			],
 			$job->get_status()
 		);


### PR DESCRIPTION
Fixes #3448

### Changes proposed in this Pull Request

* Update the backend progress calc to be based on 90% as maximum. And send 100% only when it's totally complete.
* Update the frontend to delay 1 second before moving to the Done step. So the user can see the progress bar full.

### Testing instructions

* Go to the importer.
* Import CSV files.
* Make sure when the progress bar is full, it immediately moves to the Done step.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![Jul-29-2020 10-21-12](https://user-images.githubusercontent.com/876340/88805265-4cf1ec00-d185-11ea-87a0-e5930c778d44.gif)
