### PR TITLE
Add warning for invalid slug on importer

### DIFF
--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -192,7 +192,7 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 							$this->add_line_warning(
 								sprintf(
 									// translators: Placeholder is the column name.
-									__( 'Error in column "%s": It must only contain letters without accents, numbers and dashes.', 'sensei-lms' ),
+									__( 'Error in column "%s": It contains invalid characters.', 'sensei-lms' ),
 									$key
 								),
 								[

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -185,7 +185,22 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 						}
 						break;
 					case 'slug':
-						$value = sanitize_title( $value );
+						$raw_value = $value;
+						$value     = sanitize_title( $value );
+
+						if ( $raw_value !== $value ) {
+							$this->add_line_warning(
+								sprintf(
+									// translators: Placeholder is the column name.
+									__( 'Error in column "%s": It must only contain letters without accents, numbers and dashes.', 'sensei-lms' ),
+									$key
+								),
+								[
+									'code' => 'sensei_data_port_slug_sanitization',
+								]
+							);
+						}
+
 						break;
 					case 'email':
 						$value = sanitize_email( $value );

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
@@ -220,7 +220,7 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $model->get_data() );
 
 		$model->add_warnings_to_job();
-		$this->assertJobHasLogEntry( $job, 'Error in column "slug": It must only contain letters without accents, numbers and dashes.' );
+		$this->assertJobHasLogEntry( $job, 'Error in column "slug": It contains invalid characters.' );
 	}
 
 	/**

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
@@ -202,6 +202,28 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Check that slug is sanitized correctly and adds the warnings.
+	 */
+	public function testSanitizeSlug() {
+		$data = [
+			'slug' => 'slúg-@',
+		];
+
+		$expected = [
+			'slug' => 'slug',
+		];
+
+		$job   = Sensei_Import_Job::create( 'test', 0 );
+		$task  = new Sensei_Import_Courses( $job );
+		$model = Sensei_Import_Model_Mock::from_source_array( 1, $data, new Sensei_Data_Port_Schema_Mock(), $task );
+
+		$this->assertEquals( $expected, $model->get_data() );
+
+		$model->add_warnings_to_job();
+		$this->assertJobHasLogEntry( $job, 'Error in column "slug": It must only contain letters without accents, numbers and dashes.' );
+	}
+
+	/**
 	 * Tests various scenarios with get value.
 	 */
 	public function testGetValue() {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Log a warning when importing content with an invalid slug.

### Testing instructions

* Import the courses CSV:
```
ID,Course,Slug,Description,Excerpt,Teacher Username,Teacher Email,Modules,Prerequisite,Featured,Categories,Image,Video,Notifications
,Course with invalid slug,slúg-@,,,,,,,,,,,
,Course with valid slug,valid-slug,,,,,,,,,,,
```

The first one should show a warning and import with the "slug" slug and the second should be imported without warning.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1061" alt="Screen Shot 2020-07-29 at 12 20 00" src="https://user-images.githubusercontent.com/876340/88819068-df01f080-d195-11ea-8760-7e7efa9e7b8f.png">
