### PR TITLE
Update sanitization warning messages

### DIFF
--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -132,8 +132,8 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 								$this->add_line_warning(
 									sprintf(
 										// translators: Placeholder is the column name.
-										__( 'Error in column "%s": It must be a whole number.', 'sensei-lms' ),
-										$key
+										__( '%s must be a whole number.', 'sensei-lms' ),
+										ucwords( $key )
 									),
 									[
 										'code' => 'sensei_data_port_int_sanitization',
@@ -151,8 +151,8 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 								$this->add_line_warning(
 									sprintf(
 										// translators: Placeholder is the column name.
-										__( 'Error in column "%s": It must be a number.', 'sensei-lms' ),
-										$key
+										__( '%s must be a number.', 'sensei-lms' ),
+										ucwords( $key )
 									),
 									[
 										'code' => 'sensei_data_port_float_sanitization',
@@ -171,8 +171,8 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 							$this->add_line_warning(
 								sprintf(
 									// translators: Placeholder %1$s is the column name. %2$s is the accepted values.
-									__( 'Error in column "%1$s": It must be one of the following: %2$s.', 'sensei-lms' ),
-									$key,
+									__( '%1$s must be one of the following: %2$s.', 'sensei-lms' ),
+									ucwords( $key ),
 									implode( ', ', $accepted_options )
 								),
 								[
@@ -192,8 +192,8 @@ abstract class Sensei_Import_Model extends Sensei_Data_Port_Model {
 							$this->add_line_warning(
 								sprintf(
 									// translators: Placeholder is the column name.
-									__( 'Error in column "%s": It contains invalid characters.', 'sensei-lms' ),
-									$key
+									__( '%s contains invalid characters.', 'sensei-lms' ),
+									ucwords( $key )
 								),
 								[
 									'code' => 'sensei_data_port_slug_sanitization',

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-model.php
@@ -153,8 +153,8 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $model->get_data() );
 
 		$model->add_warnings_to_job();
-		$this->assertJobHasLogEntry( $job, 'Error in column "favorite_int": It must be a whole number.' );
-		$this->assertJobHasLogEntry( $job, 'Error in column "other_int": It must be a whole number.' );
+		$this->assertJobHasLogEntry( $job, 'Favorite_int must be a whole number.' );
+		$this->assertJobHasLogEntry( $job, 'Other_int must be a whole number.' );
 	}
 
 	/**
@@ -176,7 +176,7 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $model->get_data() );
 
 		$model->add_warnings_to_job();
-		$this->assertJobHasLogEntry( $job, 'Error in column "favorite_float": It must be a number.' );
+		$this->assertJobHasLogEntry( $job, 'Favorite_float must be a number.' );
 	}
 
 	/**
@@ -198,7 +198,7 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $model->get_data() );
 
 		$model->add_warnings_to_job();
-		$this->assertJobHasLogEntry( $job, 'Error in column "favorite_bool": It must be one of the following: 0, 1, true, false.' );
+		$this->assertJobHasLogEntry( $job, 'Favorite_bool must be one of the following: 0, 1, true, false.' );
 	}
 
 	/**
@@ -220,7 +220,7 @@ class Sensei_Data_Port_Model_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $model->get_data() );
 
 		$model->add_warnings_to_job();
-		$this->assertJobHasLogEntry( $job, 'Error in column "slug": It contains invalid characters.' );
+		$this->assertJobHasLogEntry( $job, 'Slug contains invalid characters.' );
 	}
 
 	/**


### PR DESCRIPTION
Changes mentioned here: https://github.com/Automattic/sensei/pull/3486#issuecomment-666630736

This is temporarily using the branch from https://github.com/Automattic/sensei/pull/3486 as the target, because it also changes a message created there.

### Changes proposed in this Pull Request

* Update sanitization warning messages

Just pointing out that with this approach we can have a mix of languages in the message. For example: "Number Of Questions deve ser um número inteiro". But I think it's not so bad.

### Testing instructions

* Import the following Lessons CSV:

```
ID,Lesson,Slug,Description,Excerpt,Status,Course,Module,Prerequisite,Preview,Tags,Image,Length,Complexity,Video,Pass Required,Passmark,Number of Questions,Random Question Order,Auto-Grade,Quiz Reset,Allow Comments,Questions
,Warnings,slúg-@,,,,,,,abc,,,,,,,bla,2.5,,,,,
```

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1067" alt="Screen Shot 2020-07-30 at 18 38 17" src="https://user-images.githubusercontent.com/876340/88977548-7cdbe500-d294-11ea-9e68-5603d965a69e.png">
