### PR TITLE
[Try] Course outline block prototype

### DIFF
--- a/assets/course-builder/index.js
+++ b/assets/course-builder/index.js
@@ -1,0 +1,142 @@
+import apiFetch from '@wordpress/api-fetch';
+import { Button } from '@wordpress/components';
+import { select, dispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { createBlock, registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks, PlainText } from '@wordpress/block-editor';
+
+registerBlockType( 'sensei-lms/course-outline', {
+	title: __( 'Course Outline', 'sensei-lms' ),
+	icon: {
+		src: 'book',
+		foreground: '#32af7d',
+	},
+	category: 'layout',
+	keywords: [],
+	description: __( 'Course modules and lessons.', 'sensei-lms' ),
+	supports: {
+		align: [ 'wide', 'full' ],
+		html: false,
+	},
+	attributes: {
+		_version: {
+			type: 'int',
+			default: 0,
+		},
+	},
+
+	edit( props ) {
+		return <CourseOutlineEditorBlock { ...props } />;
+	},
+
+	async save( { innerBlocks } ) {
+		const courseId = select( 'core/editor' ).getCurrentPostId();
+		if ( courseId ) {
+			await apiFetch( {
+				path: `sensei-internal/v1/course-builder/course-lessons/${ courseId }`,
+				method: 'POST',
+				data: {
+					lessons: innerBlocks.map( ( block ) => block.attributes ),
+				},
+			} );
+		}
+
+		return <InnerBlocks.Content />;
+	},
+} );
+
+registerBlockType( 'sensei/course-lesson', {
+	title: __( 'Lesson', 'sensei-lms' ),
+	parent: [ 'sensei-lms/course-outline' ],
+	icon: {
+		src: 'playlist-audio',
+		foreground: '#32af7d',
+	},
+	category: 'layout',
+	keywords: [],
+	description: __( 'Lesson.', 'sensei-lms' ),
+	supports: {
+		align: [ 'wide', 'full' ],
+		html: false,
+	},
+	attributes: {
+		title: {
+			type: 'string',
+		},
+		id: {
+			type: 'int',
+		},
+	},
+
+	edit( props ) {
+		return <CourseLessonBlock { ...props } />;
+	},
+
+	save() {
+		return null;
+	},
+} );
+
+const CourseOutlineEditorBlock = ( { clientId, attributes: { _version } } ) => {
+	const courseId = select( 'core/editor' ).getCurrentPostId();
+	useEffect( () => {
+		( async () => {
+			const result = await apiFetch( {
+				path: `sensei-internal/v1/course-builder/course-lessons/${ courseId }`,
+			} );
+
+			const lessonBlocks = result.map( ( lesson ) =>
+				createBlock( 'sensei/course-lesson', {
+					title: lesson.title,
+					id: lesson.id,
+				} )
+			);
+			dispatch( 'core/block-editor' ).replaceInnerBlocks(
+				clientId,
+				lessonBlocks,
+				false
+			);
+		} )();
+	}, [ clientId, courseId, _version ] );
+
+	return (
+		<div>
+			<h1>Course outline</h1>
+			<InnerBlocks allowedBlocks={ [ 'sensei/course-lesson' ] } />
+		</div>
+	);
+};
+
+const CourseLessonBlock = ( { attributes: { title, id }, setAttributes } ) => {
+	return (
+		<div
+			className="sensei-course-block-editor__lesson"
+			style={ {
+				borderBottom: '1px solid #32af7d',
+				padding: '0.25em',
+				display: 'flex',
+				alignItems: 'center',
+			} }
+		>
+			<div style={ { flex: '1' } }>
+				<PlainText
+					style={ { fontSize: '1.5em', fontWeight: 600 } }
+					value={ title }
+					onChange={ ( val ) => setAttributes( { title: val } ) }
+				/>
+				<small>{ id ? `Lesson ${ id }` : 'Unsaved lesson' }</small>
+			</div>
+			{ id && (
+				<Button
+					href={ `post.php?post=${ id }&action=edit` }
+					target="lesson"
+					isSecondary
+					isSmall
+				>
+					Edit Lesson
+				</Button>
+			) }
+		</div>
+	);
+};

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -70,6 +70,7 @@ class Sensei_Autoloader {
 			new Sensei_Autoloader_Bundle( 'data-port' ),
 			new Sensei_Autoloader_Bundle( 'data-port/import-tasks' ),
 			new Sensei_Autoloader_Bundle( 'data-port/models' ),
+			new Sensei_Autoloader_Bundle( 'course-builder' ),
 		);
 
 		// Add Sensei custom auto loader.

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -209,6 +209,13 @@ class Sensei_Main {
 	public $setup_wizard;
 
 	/**
+	 * Course outline.
+	 *
+	 * @var Sensei_Course_Outline
+	 */
+	public $course_outline;
+
+	/**
 	 * Constructor method.
 	 *
 	 * @param  string $file The base file of the plugin.
@@ -370,6 +377,8 @@ class Sensei_Main {
 
 		// Add the quiz class
 		$this->quiz = $this->post_types->quiz;
+
+		$this->course_outline = new Sensei_Course_Outline();
 
 		// load the modules class after all plugsin are loaded
 		$this->load_modules_class();

--- a/includes/course-builder/class-sensei-course-lesson-block.php
+++ b/includes/course-builder/class-sensei-course-lesson-block.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * File containing the class Sensei_Course_Lesson_Block.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Course_Lesson_Block
+ */
+class Sensei_Course_Lesson_Block {
+	/**
+	 * Register lesson block.
+	 */
+	public function register_block_type() {
+		register_block_type(
+			'sensei-lms/course-lesson',
+			array(
+				'render_callback' => array( $this, 'render' ),
+				'editor_script'   => 'sensei-course-builder',
+				'attributes'      => [
+					'lesson_id' => [
+						'type' => 'int'
+					]
+				],
+				'supports'        => [],
+			)
+		);
+	}
+
+	public function render( $attributes, $content ) {
+
+	}
+}

--- a/includes/course-builder/class-sensei-course-outline-block.php
+++ b/includes/course-builder/class-sensei-course-outline-block.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * File containing the class Sensei_Course_Outline_Block.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Course_Outline_Block
+ */
+class Sensei_Course_Outline_Block {
+	/**
+	 * Register course outline block.
+	 */
+	public function register_block_type() {
+		register_block_type(
+			'sensei-lms/course-outline',
+			[
+				'render_callback' => [ __CLASS__, 'render' ],
+				'editor_script'   => 'sensei-course-builder',
+				'attributes'      => [
+					'course_id' => [
+						'type' => 'int',
+					],
+				],
+				'supports'        => [],
+			]
+		);
+	}
+
+	/**
+	 * Render course outline block.
+	 *
+	 * @return string
+	 */
+	public function render() {
+
+		global $post;
+
+		$lessons = Sensei()->course_outline->course_lessons( $post->ID );
+
+		$r = '<div style="border-left: 2px solid #32af7d; padding: 1rem; "><h1>Course outline</h1>';
+
+		foreach ( $lessons->posts as $lesson ) {
+			$r .= '
+		<div style="border-bottom: 1px solid #eee; padding: 0.5rem; ">
+			<h2>
+				<a href="' . get_permalink( $lesson ) . '">' . $lesson->post_title . '</a>
+			</h2>
+			</div>';
+		}
+
+		$r .= '</div>';
+		return $r;
+	}
+}

--- a/includes/course-builder/class-sensei-course-outline.php
+++ b/includes/course-builder/class-sensei-course-outline.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * File containing the class Sensei_Course_Outline.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Course_Outline
+ */
+class Sensei_Course_Outline {
+
+	/**
+	 * Sensei_Course_Outline constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', [ $this, 'register_blocks' ] );
+		add_action( 'rest_api_init', [ $this, 'register_rest' ] );
+	}
+
+	/**
+	 * Register blocks.
+	 */
+	public function register_blocks() {
+		Sensei()->assets->register( 'sensei-course-builder', 'course-builder/index.js', [], true );
+
+		$blocks = [
+			new Sensei_Course_Outline_Block(),
+			new Sensei_Course_Lesson_Block(),
+		];
+		foreach ( $blocks as $block ) {
+			$block->register_block_type();
+		}
+
+	}
+
+	/**
+	 * Register REST endpoints.
+	 */
+	public function register_rest() {
+
+		register_rest_route(
+			'sensei-internal/v1/course-builder',
+			'course-lessons/(?P<course_id>\d+)',
+			array(
+				array(
+					'methods'  => WP_REST_Server::READABLE,
+					'callback' => array( $this, 'request_get_course_lessons' ),
+				),
+				array(
+					'methods'  => WP_REST_Server::EDITABLE,
+					'callback' => array( $this, 'request_update_course_lessons' ),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Get lessons for course in correct order.
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return array[]
+	 */
+	public function request_get_course_lessons( WP_REST_Request $request ) {
+
+		$course_id = intval( $request->get_param( 'course_id' ) );
+
+		$query = $this->course_lessons( $course_id );
+		return array_map(
+			function( $post ) {
+				return [
+					'id'     => $post->ID,
+					'title'  => $post->post_title,
+					'status' => $post->post_status,
+				];
+			},
+			$query->posts
+		);
+	}
+
+
+	/**
+	 * Update course lessons and order based on blocks.
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return mixed
+	 */
+	public function request_update_course_lessons( WP_REST_Request $request ) {
+		$data      = $request->get_json_params();
+		$lessons   = $data['lessons'];
+		$course_id = $request->get_param( 'course_id' );
+
+		foreach ( $lessons as $index => $lesson ) {
+			if ( ! $lesson['id'] && $lesson['title'] ) {
+				$lessons[ $index ]['id'] = wp_insert_post(
+					[
+						'post_type'  => 'lesson',
+						'post_title' => $lesson['title'],
+						'meta_input' => [
+							'_lesson_course' => $course_id,
+						],
+					]
+				);
+			} else {
+				wp_update_post(
+					[
+						'ID'         => $lesson['id'],
+						'post_title' => $lesson['title'],
+					]
+				);
+			}
+		}
+
+		$lesson_order = implode( ',', array_column( $lessons, 'id' ) );
+
+		update_post_meta( $course_id, '_lesson_order', $lesson_order );
+
+		return $lessons;
+	}
+
+	/**
+	 * @param int $course_id
+	 *
+	 * @return WP_Query
+	 */
+	public function course_lessons( int $course_id ): WP_Query {
+		$course_lesson_query_args = array(
+			'post_type'        => 'lesson',
+			'post_status'      => 'any',
+			'posts_per_page'   => 500,
+			'orderby'          => 'date',
+			'order'            => 'ASC',
+			'meta_query'       => array(
+				array(
+					'key'   => '_lesson_course',
+					'value' => $course_id,
+				),
+			),
+			'suppress_filters' => 0,
+		);
+
+		// setting lesson order.
+		$course_lesson_order = get_post_meta( $course_id, '_lesson_order', true );
+		$all_ids             = get_posts(
+			array(
+				'post_type'      => 'lesson',
+				'post_status'    => 'any',
+				'posts_per_page' => -1,
+				'fields'         => 'ids',
+				'meta_key'       => '_lesson_course',
+				'meta_value'     => intval( $course_id ),
+			)
+		);
+		if ( ! empty( $course_lesson_order ) ) {
+			$course_lesson_query_args['post__in'] = array_merge( explode( ',', $course_lesson_order ), $all_ids );
+			$course_lesson_query_args['orderby']  = 'post__in';
+			unset( $course_lesson_query_args['order'] );
+
+		}
+		return new WP_Query( $course_lesson_query_args );
+}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@babel/plugin-proposal-class-properties": "7.8.3",
         "@babel/plugin-transform-react-jsx": "7.8.3",
         "@babel/plugin-transform-runtime": "7.8.3",
-        "@babel/preset-env": "7.8.4",
+        "@babel/preset-env": "7.11.0",
         "@babel/preset-react": "7.8.3",
         "@babel/preset-typescript": "7.8.3",
         "@types/webpack-env": "1.15.0",
@@ -226,92 +226,7 @@
           }
         },
         "@babel/preset-env": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
-          "integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
-          "dev": true,
-          "requires": {
-            "@babel/compat-data": "^7.11.0",
-            "@babel/helper-compilation-targets": "^7.10.4",
-            "@babel/helper-module-imports": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
-            "@babel/plugin-proposal-class-properties": "^7.10.4",
-            "@babel/plugin-proposal-dynamic-import": "^7.10.4",
-            "@babel/plugin-proposal-export-namespace-from": "^7.10.4",
-            "@babel/plugin-proposal-json-strings": "^7.10.4",
-            "@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-            "@babel/plugin-proposal-numeric-separator": "^7.10.4",
-            "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
-            "@babel/plugin-proposal-optional-chaining": "^7.11.0",
-            "@babel/plugin-proposal-private-methods": "^7.10.4",
-            "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
-            "@babel/plugin-syntax-async-generators": "^7.8.0",
-            "@babel/plugin-syntax-class-properties": "^7.10.4",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.0",
-            "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-            "@babel/plugin-syntax-json-strings": "^7.8.0",
-            "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-            "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-            "@babel/plugin-syntax-optional-chaining": "^7.8.0",
-            "@babel/plugin-syntax-top-level-await": "^7.10.4",
-            "@babel/plugin-transform-arrow-functions": "^7.10.4",
-            "@babel/plugin-transform-async-to-generator": "^7.10.4",
-            "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
-            "@babel/plugin-transform-block-scoping": "^7.10.4",
-            "@babel/plugin-transform-classes": "^7.10.4",
-            "@babel/plugin-transform-computed-properties": "^7.10.4",
-            "@babel/plugin-transform-destructuring": "^7.10.4",
-            "@babel/plugin-transform-dotall-regex": "^7.10.4",
-            "@babel/plugin-transform-duplicate-keys": "^7.10.4",
-            "@babel/plugin-transform-exponentiation-operator": "^7.10.4",
-            "@babel/plugin-transform-for-of": "^7.10.4",
-            "@babel/plugin-transform-function-name": "^7.10.4",
-            "@babel/plugin-transform-literals": "^7.10.4",
-            "@babel/plugin-transform-member-expression-literals": "^7.10.4",
-            "@babel/plugin-transform-modules-amd": "^7.10.4",
-            "@babel/plugin-transform-modules-commonjs": "^7.10.4",
-            "@babel/plugin-transform-modules-systemjs": "^7.10.4",
-            "@babel/plugin-transform-modules-umd": "^7.10.4",
-            "@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
-            "@babel/plugin-transform-new-target": "^7.10.4",
-            "@babel/plugin-transform-object-super": "^7.10.4",
-            "@babel/plugin-transform-parameters": "^7.10.4",
-            "@babel/plugin-transform-property-literals": "^7.10.4",
-            "@babel/plugin-transform-regenerator": "^7.10.4",
-            "@babel/plugin-transform-reserved-words": "^7.10.4",
-            "@babel/plugin-transform-shorthand-properties": "^7.10.4",
-            "@babel/plugin-transform-spread": "^7.11.0",
-            "@babel/plugin-transform-sticky-regex": "^7.10.4",
-            "@babel/plugin-transform-template-literals": "^7.10.4",
-            "@babel/plugin-transform-typeof-symbol": "^7.10.4",
-            "@babel/plugin-transform-unicode-escapes": "^7.10.4",
-            "@babel/plugin-transform-unicode-regex": "^7.10.4",
-            "@babel/preset-modules": "^0.1.3",
-            "@babel/types": "^7.11.0",
-            "browserslist": "^4.12.0",
-            "core-js-compat": "^3.6.2",
-            "invariant": "^2.2.2",
-            "levenary": "^1.1.1",
-            "semver": "^5.5.0"
-          },
-          "dependencies": {
-            "@babel/plugin-proposal-class-properties": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
-              "integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
-              "dev": true,
-              "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.10.4",
-                "@babel/helper-plugin-utils": "^7.10.4"
-              }
-            }
-          }
+          "version": "7.11.0"
         },
         "@babel/template": {
           "version": "7.10.4",
@@ -569,7 +484,7 @@
       "requires": {
         "@babel/cli": "^7.8.3",
         "@babel/core": "^7.8.3",
-        "@babel/preset-env": "^7.8.3",
+        "@babel/preset-env": "7.11.0",
         "@slack/web-api": "^5.6.0",
         "@wordpress/e2e-test-utils": "^3.0.0",
         "config": "^3.2.4",
@@ -763,214 +678,7 @@
           }
         },
         "@babel/preset-env": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
-          "integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
-          "dev": true,
-          "requires": {
-            "@babel/compat-data": "^7.11.0",
-            "@babel/helper-compilation-targets": "^7.10.4",
-            "@babel/helper-module-imports": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
-            "@babel/plugin-proposal-class-properties": "^7.10.4",
-            "@babel/plugin-proposal-dynamic-import": "^7.10.4",
-            "@babel/plugin-proposal-export-namespace-from": "^7.10.4",
-            "@babel/plugin-proposal-json-strings": "^7.10.4",
-            "@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-            "@babel/plugin-proposal-numeric-separator": "^7.10.4",
-            "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
-            "@babel/plugin-proposal-optional-chaining": "^7.11.0",
-            "@babel/plugin-proposal-private-methods": "^7.10.4",
-            "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
-            "@babel/plugin-syntax-async-generators": "^7.8.0",
-            "@babel/plugin-syntax-class-properties": "^7.10.4",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.0",
-            "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-            "@babel/plugin-syntax-json-strings": "^7.8.0",
-            "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-            "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-            "@babel/plugin-syntax-optional-chaining": "^7.8.0",
-            "@babel/plugin-syntax-top-level-await": "^7.10.4",
-            "@babel/plugin-transform-arrow-functions": "^7.10.4",
-            "@babel/plugin-transform-async-to-generator": "^7.10.4",
-            "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
-            "@babel/plugin-transform-block-scoping": "^7.10.4",
-            "@babel/plugin-transform-classes": "^7.10.4",
-            "@babel/plugin-transform-computed-properties": "^7.10.4",
-            "@babel/plugin-transform-destructuring": "^7.10.4",
-            "@babel/plugin-transform-dotall-regex": "^7.10.4",
-            "@babel/plugin-transform-duplicate-keys": "^7.10.4",
-            "@babel/plugin-transform-exponentiation-operator": "^7.10.4",
-            "@babel/plugin-transform-for-of": "^7.10.4",
-            "@babel/plugin-transform-function-name": "^7.10.4",
-            "@babel/plugin-transform-literals": "^7.10.4",
-            "@babel/plugin-transform-member-expression-literals": "^7.10.4",
-            "@babel/plugin-transform-modules-amd": "^7.10.4",
-            "@babel/plugin-transform-modules-commonjs": "^7.10.4",
-            "@babel/plugin-transform-modules-systemjs": "^7.10.4",
-            "@babel/plugin-transform-modules-umd": "^7.10.4",
-            "@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
-            "@babel/plugin-transform-new-target": "^7.10.4",
-            "@babel/plugin-transform-object-super": "^7.10.4",
-            "@babel/plugin-transform-parameters": "^7.10.4",
-            "@babel/plugin-transform-property-literals": "^7.10.4",
-            "@babel/plugin-transform-regenerator": "^7.10.4",
-            "@babel/plugin-transform-reserved-words": "^7.10.4",
-            "@babel/plugin-transform-shorthand-properties": "^7.10.4",
-            "@babel/plugin-transform-spread": "^7.11.0",
-            "@babel/plugin-transform-sticky-regex": "^7.10.4",
-            "@babel/plugin-transform-template-literals": "^7.10.4",
-            "@babel/plugin-transform-typeof-symbol": "^7.10.4",
-            "@babel/plugin-transform-unicode-escapes": "^7.10.4",
-            "@babel/plugin-transform-unicode-regex": "^7.10.4",
-            "@babel/preset-modules": "^0.1.3",
-            "@babel/types": "^7.11.0",
-            "browserslist": "^4.12.0",
-            "core-js-compat": "^3.6.2",
-            "invariant": "^2.2.2",
-            "levenary": "^1.1.1",
-            "semver": "^5.5.0"
-          },
-          "dependencies": {
-            "@babel/compat-data": {
-              "version": "7.11.0",
-              "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.11.0.tgz",
-              "integrity": "sha512-TPSvJfv73ng0pfnEOh17bYMPQbI95+nGWc71Ss4vZdRBHTDqmM9Z8ZV4rYz8Ks7sfzc95n30k6ODIq5UGnXcYQ==",
-              "dev": true,
-              "requires": {
-                "browserslist": "^4.12.0",
-                "invariant": "^2.2.4",
-                "semver": "^5.5.0"
-              }
-            },
-            "@babel/helper-compilation-targets": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.10.4.tgz",
-              "integrity": "sha512-a3rYhlsGV0UHNDvrtOXBg8/OpfV0OKTkxKPzIplS1zpx7CygDcWWxckxZeDd3gzPzC4kUT0A4nVFDK0wGMh4MQ==",
-              "dev": true,
-              "requires": {
-                "@babel/compat-data": "^7.10.4",
-                "browserslist": "^4.12.0",
-                "invariant": "^2.2.4",
-                "levenary": "^1.1.1",
-                "semver": "^5.5.0"
-              }
-            },
-            "@babel/helper-create-class-features-plugin": {
-              "version": "7.10.5",
-              "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz",
-              "integrity": "sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==",
-              "dev": true,
-              "requires": {
-                "@babel/helper-function-name": "^7.10.4",
-                "@babel/helper-member-expression-to-functions": "^7.10.5",
-                "@babel/helper-optimise-call-expression": "^7.10.4",
-                "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/helper-replace-supers": "^7.10.4",
-                "@babel/helper-split-export-declaration": "^7.10.4"
-              }
-            },
-            "@babel/helper-member-expression-to-functions": {
-              "version": "7.11.0",
-              "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-              "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
-              "dev": true,
-              "requires": {
-                "@babel/types": "^7.11.0"
-              }
-            },
-            "@babel/helper-validator-identifier": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-              "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
-              "dev": true
-            },
-            "@babel/plugin-proposal-class-properties": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz",
-              "integrity": "sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==",
-              "dev": true,
-              "requires": {
-                "@babel/helper-create-class-features-plugin": "^7.10.4",
-                "@babel/helper-plugin-utils": "^7.10.4"
-              }
-            },
-            "@babel/plugin-proposal-nullish-coalescing-operator": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.10.4.tgz",
-              "integrity": "sha512-wq5n1M3ZUlHl9sqT2ok1T2/MTt6AXE0e1Lz4WzWBr95LsAZ5qDXe4KnFuauYyEyLiohvXFMdbsOTMyLZs91Zlw==",
-              "dev": true,
-              "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
-              }
-            },
-            "@babel/plugin-proposal-numeric-separator": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.10.4.tgz",
-              "integrity": "sha512-73/G7QoRoeNkLZFxsoCCvlg4ezE4eM+57PnOqgaPOozd5myfj7p0muD1mRVJvbUWbOzD+q3No2bWbaKy+DJ8DA==",
-              "dev": true,
-              "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/plugin-syntax-numeric-separator": "^7.10.4"
-              }
-            },
-            "@babel/plugin-proposal-optional-chaining": {
-              "version": "7.11.0",
-              "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.11.0.tgz",
-              "integrity": "sha512-v9fZIu3Y8562RRwhm1BbMRxtqZNFmFA2EG+pT2diuU8PT3H6T/KXoZ54KgYisfOFZHV6PfvAiBIZ9Rcz+/JCxA==",
-              "dev": true,
-              "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4",
-                "@babel/helper-skip-transparent-expression-wrappers": "^7.11.0",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.0"
-              }
-            },
-            "@babel/plugin-syntax-class-properties": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz",
-              "integrity": "sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==",
-              "dev": true,
-              "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-              }
-            },
-            "@babel/plugin-syntax-numeric-separator": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-              "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-              "dev": true,
-              "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-              }
-            },
-            "@babel/plugin-syntax-top-level-await": {
-              "version": "7.10.4",
-              "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.10.4.tgz",
-              "integrity": "sha512-ni1brg4lXEmWyafKr0ccFWkJG0CeMt4WV1oyeBW6EFObF4oOHclbkj5cARxAPQyAQ2UTuplJyK4nfkXIMMFvsQ==",
-              "dev": true,
-              "requires": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-              }
-            },
-            "@babel/types": {
-              "version": "7.11.0",
-              "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-              "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
-              "dev": true,
-              "requires": {
-                "@babel/helper-validator-identifier": "^7.10.4",
-                "lodash": "^4.17.19",
-                "to-fast-properties": "^2.0.0"
-              }
-            }
-          }
+          "version": "7.11.0"
         },
         "@babel/template": {
           "version": "7.10.4",
@@ -5575,9 +5283,6 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
-      "integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
       "dev": true,
       "requires": {
         "@babel/compat-data": "^7.11.0",
@@ -5760,7 +5465,8 @@
           "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA==",
           "dev": true
         }
-      }
+      },
+      "version": "7.11.0"
     },
     "@babel/preset-modules": {
       "version": "0.1.3",
@@ -10002,7 +9708,7 @@
       "requires": {
         "@babel/core": "^7.9.0",
         "@babel/plugin-transform-react-constant-elements": "^7.9.0",
-        "@babel/preset-env": "^7.9.5",
+        "@babel/preset-env": "7.11.0",
         "@babel/preset-react": "^7.9.4",
         "@svgr/core": "^5.4.0",
         "@svgr/plugin-jsx": "^5.4.0",
@@ -10129,80 +9835,7 @@
           }
         },
         "@babel/preset-env": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
-          "integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
-          "dev": true,
-          "requires": {
-            "@babel/compat-data": "^7.11.0",
-            "@babel/helper-compilation-targets": "^7.10.4",
-            "@babel/helper-module-imports": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
-            "@babel/plugin-proposal-class-properties": "^7.10.4",
-            "@babel/plugin-proposal-dynamic-import": "^7.10.4",
-            "@babel/plugin-proposal-export-namespace-from": "^7.10.4",
-            "@babel/plugin-proposal-json-strings": "^7.10.4",
-            "@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-            "@babel/plugin-proposal-numeric-separator": "^7.10.4",
-            "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
-            "@babel/plugin-proposal-optional-chaining": "^7.11.0",
-            "@babel/plugin-proposal-private-methods": "^7.10.4",
-            "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
-            "@babel/plugin-syntax-async-generators": "^7.8.0",
-            "@babel/plugin-syntax-class-properties": "^7.10.4",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.0",
-            "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-            "@babel/plugin-syntax-json-strings": "^7.8.0",
-            "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-            "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-            "@babel/plugin-syntax-optional-chaining": "^7.8.0",
-            "@babel/plugin-syntax-top-level-await": "^7.10.4",
-            "@babel/plugin-transform-arrow-functions": "^7.10.4",
-            "@babel/plugin-transform-async-to-generator": "^7.10.4",
-            "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
-            "@babel/plugin-transform-block-scoping": "^7.10.4",
-            "@babel/plugin-transform-classes": "^7.10.4",
-            "@babel/plugin-transform-computed-properties": "^7.10.4",
-            "@babel/plugin-transform-destructuring": "^7.10.4",
-            "@babel/plugin-transform-dotall-regex": "^7.10.4",
-            "@babel/plugin-transform-duplicate-keys": "^7.10.4",
-            "@babel/plugin-transform-exponentiation-operator": "^7.10.4",
-            "@babel/plugin-transform-for-of": "^7.10.4",
-            "@babel/plugin-transform-function-name": "^7.10.4",
-            "@babel/plugin-transform-literals": "^7.10.4",
-            "@babel/plugin-transform-member-expression-literals": "^7.10.4",
-            "@babel/plugin-transform-modules-amd": "^7.10.4",
-            "@babel/plugin-transform-modules-commonjs": "^7.10.4",
-            "@babel/plugin-transform-modules-systemjs": "^7.10.4",
-            "@babel/plugin-transform-modules-umd": "^7.10.4",
-            "@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
-            "@babel/plugin-transform-new-target": "^7.10.4",
-            "@babel/plugin-transform-object-super": "^7.10.4",
-            "@babel/plugin-transform-parameters": "^7.10.4",
-            "@babel/plugin-transform-property-literals": "^7.10.4",
-            "@babel/plugin-transform-regenerator": "^7.10.4",
-            "@babel/plugin-transform-reserved-words": "^7.10.4",
-            "@babel/plugin-transform-shorthand-properties": "^7.10.4",
-            "@babel/plugin-transform-spread": "^7.11.0",
-            "@babel/plugin-transform-sticky-regex": "^7.10.4",
-            "@babel/plugin-transform-template-literals": "^7.10.4",
-            "@babel/plugin-transform-typeof-symbol": "^7.10.4",
-            "@babel/plugin-transform-unicode-escapes": "^7.10.4",
-            "@babel/plugin-transform-unicode-regex": "^7.10.4",
-            "@babel/preset-modules": "^0.1.3",
-            "@babel/types": "^7.11.0",
-            "browserslist": "^4.12.0",
-            "core-js-compat": "^3.6.2",
-            "invariant": "^2.2.2",
-            "levenary": "^1.1.1",
-            "semver": "^5.5.0"
-          }
+          "version": "7.11.0"
         },
         "@babel/preset-react": {
           "version": "7.10.4",
@@ -11711,7 +11344,7 @@
         "@babel/core": "^7.9.0",
         "@babel/plugin-transform-react-jsx": "^7.9.4",
         "@babel/plugin-transform-runtime": "^7.9.0",
-        "@babel/preset-env": "^7.9.0",
+        "@babel/preset-env": "7.11.0",
         "@babel/runtime": "^7.9.2",
         "@wordpress/babel-plugin-import-jsx-pragma": "^2.7.0",
         "@wordpress/browserslist-config": "^2.7.0",
@@ -11842,80 +11475,7 @@
           }
         },
         "@babel/preset-env": {
-          "version": "7.11.0",
-          "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.11.0.tgz",
-          "integrity": "sha512-2u1/k7rG/gTh02dylX2kL3S0IJNF+J6bfDSp4DI2Ma8QN6Y9x9pmAax59fsCk6QUQG0yqH47yJWA+u1I1LccAg==",
-          "dev": true,
-          "requires": {
-            "@babel/compat-data": "^7.11.0",
-            "@babel/helper-compilation-targets": "^7.10.4",
-            "@babel/helper-module-imports": "^7.10.4",
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/plugin-proposal-async-generator-functions": "^7.10.4",
-            "@babel/plugin-proposal-class-properties": "^7.10.4",
-            "@babel/plugin-proposal-dynamic-import": "^7.10.4",
-            "@babel/plugin-proposal-export-namespace-from": "^7.10.4",
-            "@babel/plugin-proposal-json-strings": "^7.10.4",
-            "@babel/plugin-proposal-logical-assignment-operators": "^7.11.0",
-            "@babel/plugin-proposal-nullish-coalescing-operator": "^7.10.4",
-            "@babel/plugin-proposal-numeric-separator": "^7.10.4",
-            "@babel/plugin-proposal-object-rest-spread": "^7.11.0",
-            "@babel/plugin-proposal-optional-catch-binding": "^7.10.4",
-            "@babel/plugin-proposal-optional-chaining": "^7.11.0",
-            "@babel/plugin-proposal-private-methods": "^7.10.4",
-            "@babel/plugin-proposal-unicode-property-regex": "^7.10.4",
-            "@babel/plugin-syntax-async-generators": "^7.8.0",
-            "@babel/plugin-syntax-class-properties": "^7.10.4",
-            "@babel/plugin-syntax-dynamic-import": "^7.8.0",
-            "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-            "@babel/plugin-syntax-json-strings": "^7.8.0",
-            "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-            "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
-            "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-            "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-            "@babel/plugin-syntax-optional-chaining": "^7.8.0",
-            "@babel/plugin-syntax-top-level-await": "^7.10.4",
-            "@babel/plugin-transform-arrow-functions": "^7.10.4",
-            "@babel/plugin-transform-async-to-generator": "^7.10.4",
-            "@babel/plugin-transform-block-scoped-functions": "^7.10.4",
-            "@babel/plugin-transform-block-scoping": "^7.10.4",
-            "@babel/plugin-transform-classes": "^7.10.4",
-            "@babel/plugin-transform-computed-properties": "^7.10.4",
-            "@babel/plugin-transform-destructuring": "^7.10.4",
-            "@babel/plugin-transform-dotall-regex": "^7.10.4",
-            "@babel/plugin-transform-duplicate-keys": "^7.10.4",
-            "@babel/plugin-transform-exponentiation-operator": "^7.10.4",
-            "@babel/plugin-transform-for-of": "^7.10.4",
-            "@babel/plugin-transform-function-name": "^7.10.4",
-            "@babel/plugin-transform-literals": "^7.10.4",
-            "@babel/plugin-transform-member-expression-literals": "^7.10.4",
-            "@babel/plugin-transform-modules-amd": "^7.10.4",
-            "@babel/plugin-transform-modules-commonjs": "^7.10.4",
-            "@babel/plugin-transform-modules-systemjs": "^7.10.4",
-            "@babel/plugin-transform-modules-umd": "^7.10.4",
-            "@babel/plugin-transform-named-capturing-groups-regex": "^7.10.4",
-            "@babel/plugin-transform-new-target": "^7.10.4",
-            "@babel/plugin-transform-object-super": "^7.10.4",
-            "@babel/plugin-transform-parameters": "^7.10.4",
-            "@babel/plugin-transform-property-literals": "^7.10.4",
-            "@babel/plugin-transform-regenerator": "^7.10.4",
-            "@babel/plugin-transform-reserved-words": "^7.10.4",
-            "@babel/plugin-transform-shorthand-properties": "^7.10.4",
-            "@babel/plugin-transform-spread": "^7.11.0",
-            "@babel/plugin-transform-sticky-regex": "^7.10.4",
-            "@babel/plugin-transform-template-literals": "^7.10.4",
-            "@babel/plugin-transform-typeof-symbol": "^7.10.4",
-            "@babel/plugin-transform-unicode-escapes": "^7.10.4",
-            "@babel/plugin-transform-unicode-regex": "^7.10.4",
-            "@babel/preset-modules": "^0.1.3",
-            "@babel/types": "^7.11.0",
-            "browserslist": "^4.12.0",
-            "core-js-compat": "^3.6.2",
-            "invariant": "^2.2.2",
-            "levenary": "^1.1.1",
-            "semver": "^5.5.0"
-          }
+          "version": "7.11.0"
         },
         "@babel/runtime": {
           "version": "7.11.2",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,8 @@
     "@woocommerce/components": "4.0.0",
     "@wordpress/api-fetch": "3.18.0",
     "@wordpress/base-styles": "1.9.0",
+    "@wordpress/block-editor": "4.3.5",
+    "@wordpress/blocks": "6.20.3",
     "@wordpress/components": "9.4.1",
     "@wordpress/data": "4.22.3",
     "@wordpress/element": "2.16.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,7 @@ const files = [
 	'shared/styles/wc-components.scss',
 	'data-port/import.js',
 	'data-port/style.scss',
+	'course-builder/index.js',
 
 	'css/frontend.scss',
 	'css/admin-custom.css',


### PR DESCRIPTION

This is a prototype to render a course's lessons, and allow editing, adding and reordering them.

* The outline block fetches the course's lessons and replaces it's inner blocks with `Lesson` blocks.
* On save, based on the inner lesson blocks, it updates the existing lessons with any edited titles, adds new lessons, and saves the block order as the lesson order meta in the course.
* Rendering the outline block for the frontend doesn't use any block attributes, it just outputs the lessons for the current post. 

### Notes

* For the editor, getting and updating the lessons could be implemented as a redux store. There is also an option now to implement a custom attribute provider.
* Looks like we can make inner blocks work. When loading/updating lessons from external source, they can be updated with manually created blocks, then still allowing the user to add new ones, reorder them.
* This means the single source of truth is always the lesson and course posts and meta. On opening the editor, we either override the blocks entirely, or merge their attributes with the lesson details. 
* It's not necessary to store anything in the post content, unless we want to allow other blocks mixed in inside the outline block, or use attributes on the lesson or module blocks that we don't want to store externally.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

New lesson:

![Screen Recording 2020-08-07 at 22 43 54](https://user-images.githubusercontent.com/176949/89689238-40e3f800-d904-11ea-9f01-7529e5d069ab.gif)

Reordering:

![Screen Recording 2020-08-07 at 22 44 21](https://user-images.githubusercontent.com/176949/89689572-f747dd00-d904-11ea-8b6c-c76767ee3247.gif)

