### PR TITLE
Fix question editor in WordPress 5.5

### DIFF
--- a/assets/js/admin/ordering.js
+++ b/assets/js/admin/ordering.js
@@ -1,10 +1,10 @@
-jQuery( document ).ready( function( $ ) {
+jQuery( document ).ready( function ( $ ) {
 	$( '#lesson-order-course' ).select2( { width: 'resolve' } );
 	$( '.sortable-course-list, .sortable-lesson-list' ).sortable();
 	$( '.sortable-tab-list' ).disableSelection();
 
-	$.fn.fixOrderingList = function( container, type ) {
-		container.find( '.' + type ).each( function( i ) {
+	$.fn.fixOrderingList = function ( container, type ) {
+		container.find( '.' + type ).each( function ( i ) {
 			$( this ).removeClass( 'alternate' );
 			$( this ).removeClass( 'first' );
 			$( this ).removeClass( 'last' );
@@ -12,34 +12,36 @@ jQuery( document ).ready( function( $ ) {
 			if ( 0 === i ) {
 				$( this ).addClass( 'first alternate' );
 			} else {
-				var r = ( i % 2 );
+				var r = i % 2;
 
-				if (  0 === r ) {
+				if ( 0 === r ) {
 					$( this ).addClass( 'alternate' );
 				}
 			}
-		});
+		} );
 	};
 
 	/* Order Courses */
 	$( '.sortable-course-list' ).bind( 'sortstop', function () {
 		var orderString = '';
 
-		$( this ).find( '.course' ).each( function ( i ) {
-			if ( i > 0 ) {
-				orderString += ',';
-			}
+		$( this )
+			.find( '.course' )
+			.each( function ( i ) {
+				if ( i > 0 ) {
+					orderString += ',';
+				}
 
-			orderString += $( this ).find( 'span' ).attr( 'rel' );
-		});
+				orderString += $( this ).find( 'span' ).attr( 'rel' );
+			} );
 
-		$( 'input[name="course-order"]' ).attr( 'value', orderString );
+		$( 'input[name="course-order"]' ).val( orderString );
 
 		$.fn.fixOrderingList( $( this ), 'course' );
 	} );
 
 	/* Order Lessons */
-	$( '.sortable-lesson-list' ).bind( 'sortstop', function() {
+	$( '.sortable-lesson-list' ).bind( 'sortstop', function () {
 		var orderString = '';
 		var module_id = $( this ).attr( 'data-module-id' );
 		var order_input = 'lesson-order';
@@ -48,15 +50,17 @@ jQuery( document ).ready( function( $ ) {
 			order_input = 'lesson-order-module-' + module_id;
 		}
 
-		$( this ).find( '.lesson' ).each( function( i ) {
-			if ( i > 0 ) {
-				orderString += ',';
-			}
+		$( this )
+			.find( '.lesson' )
+			.each( function ( i ) {
+				if ( i > 0 ) {
+					orderString += ',';
+				}
 
-			orderString += $( this ).find( 'span' ).attr( 'rel' );
-		});
+				orderString += $( this ).find( 'span' ).attr( 'rel' );
+			} );
 
-		$( 'input[name="' + order_input + '"]' ).attr( 'value', orderString );
+		$( 'input[name="' + order_input + '"]' ).val( orderString );
 
 		$.fn.fixOrderingList( $( this ), 'lesson' );
 	} );

--- a/assets/js/lesson-metadata.js
+++ b/assets/js/lesson-metadata.js
@@ -1,5 +1,4 @@
-jQuery(document).ready( function() {
-
+jQuery( document ).ready( function () {
 	var file_frame;
 
 	/***************************************************************************************************
@@ -11,8 +10,8 @@ jQuery(document).ready( function() {
 	 * @since  1.2.0
 	 * @return boolean
 	 */
-	jQuery.fn.exists = function() {
-		return this.length>0;
+	jQuery.fn.exists = function () {
+		return this.length > 0;
 	};
 
 	/**
@@ -21,19 +20,31 @@ jQuery(document).ready( function() {
 	 * @since 1.0.0
 	 * @access public
 	 */
-	jQuery.fn.validateQuestionInput = function( action, jqueryObject ) {
+	jQuery.fn.validateQuestionInput = function ( action, jqueryObject ) {
 		// Validate Actions
 		if ( 'add' == action ) {
 			// Check for empty questions
-			if ( jQuery( '#add_question' ).val().replace(/^\s+|\s+$/g, '').length != 0 ) {
+			if (
+				jQuery( '#add_question' )
+					.val()
+					.replace( /^\s+|\s+$/g, '' ).length != 0
+			) {
 				return true;
 			} else {
 				return false;
 			}
 		} else if ( 'edit' == action ) {
 			// Check for empty questions
-			var tableRowId = jqueryObject.closest('tr').prev('tr').find('td:first').text();
-			if ( jQuery( '#question_' + tableRowId ).val().replace(/^\s+|\s+$/g, '').length != 0 ) {
+			var tableRowId = jqueryObject
+				.closest( 'tr' )
+				.prev( 'tr' )
+				.find( 'td:first' )
+				.text();
+			if (
+				jQuery( '#question_' + tableRowId )
+					.val()
+					.replace( /^\s+|\s+$/g, '' ).length != 0
+			) {
 				return true;
 			} else {
 				return false;
@@ -50,12 +61,12 @@ jQuery(document).ready( function() {
 	 * @since 1.0.0
 	 * @access public
 	 */
-	jQuery.fn.resetQuestionTable = function() {
-		jQuery( 'tr.question-quick-edit' ).each( function() {
-			if ( !jQuery(this).hasClass( 'hidden' ) ) {
-				jQuery(this).addClass('hidden');
+	jQuery.fn.resetQuestionTable = function () {
+		jQuery( 'tr.question-quick-edit' ).each( function () {
+			if ( ! jQuery( this ).hasClass( 'hidden' ) ) {
+				jQuery( this ).addClass( 'hidden' );
 			}
-		});
+		} );
 	};
 
 	/**
@@ -64,15 +75,21 @@ jQuery(document).ready( function() {
 	 * @since 1.0.0
 	 * @access public
 	 */
-	jQuery.fn.resetAddQuestionForm = function() {
-		jQuery( '#add-new-question' ).find('div').find('input').each( function() {
-			if ( jQuery( this ).attr( 'type' ) != 'radio' ) {
-				jQuery(this).attr( 'value', '' );
-			} // End If Statement
-		});
-		jQuery( '#add-new-question' ).find('div').find('textarea').each( function() {
-			jQuery(this).attr( 'value', '' );
-		});
+	jQuery.fn.resetAddQuestionForm = function () {
+		jQuery( '#add-new-question' )
+			.find( 'div' )
+			.find( 'input' )
+			.each( function () {
+				if ( jQuery( this ).attr( 'type' ) != 'radio' ) {
+					jQuery( this ).val( '' );
+				} // End If Statement
+			} );
+		jQuery( '#add-new-question' )
+			.find( 'div' )
+			.find( 'textarea' )
+			.each( function () {
+				jQuery( this ).val( '' );
+			} );
 	};
 
 	/**
@@ -81,52 +98,52 @@ jQuery(document).ready( function() {
 	 * @since 1.3.0
 	 * @access public
 	 */
-	jQuery.fn.checkQuizGradeType = function( latest_questionType ) {
-
+	jQuery.fn.checkQuizGradeType = function ( latest_questionType ) {
 		// Fetch all current question types
 		var questionType;
 		var types = [];
-		jQuery( '#add-question-metadata > table > tbody > tr input.question_type' ).each( function() {
+		jQuery(
+			'#add-question-metadata > table > tbody > tr input.question_type'
+		).each( function () {
 			questionType = jQuery( this ).val();
 			types.push( questionType );
-		});
+		} );
 
 		// Add latest question to array if it exists
-		if( latest_questionType ) {
+		if ( latest_questionType ) {
 			types.push( latest_questionType );
 		}
 
 		var currentType;
 		var disableAuto = false;
-		for( var i = 0; i < types.length; i++ ) {
-			currentType = types[i];
+		for ( var i = 0; i < types.length; i++ ) {
+			currentType = types[ i ];
 
-			if( ! disableAuto ) {
+			if ( ! disableAuto ) {
 				switch ( currentType ) {
-				case 'multiple-choice':
-					disableAuto = false;
-					break;
-				case 'boolean':
-					disableAuto = false;
-					break;
-				case 'gap-fill':
-					disableAuto = false;
-					break;
-				case 'multi-line':
-					disableAuto = true;
-					break;
-				case 'single-line':
-					disableAuto = true;
-					break;
-				case 'file-upload':
-					disableAuto = true;
-					break;
-				default :
-					disableAuto = false;
-					break;
+					case 'multiple-choice':
+						disableAuto = false;
+						break;
+					case 'boolean':
+						disableAuto = false;
+						break;
+					case 'gap-fill':
+						disableAuto = false;
+						break;
+					case 'multi-line':
+						disableAuto = true;
+						break;
+					case 'single-line':
+						disableAuto = true;
+						break;
+					case 'file-upload':
+						disableAuto = true;
+						break;
+					default:
+						disableAuto = false;
+						break;
 				} // End Switch Statement
 			}
-
 		}
 
 		// Save quiz grade type
@@ -139,9 +156,9 @@ jQuery(document).ready( function() {
 	 * @since 1.0.0
 	 * @access public
 	 */
-	jQuery.fn.updateQuestionCount = function( increment, operator ) {
+	jQuery.fn.updateQuestionCount = function ( increment, operator ) {
 		// Get current value
-		var currentValue = parseInt( jQuery( '#question_counter' ).attr( 'value' ) );
+		var currentValue = parseInt( jQuery( '#question_counter' ).val() );
 		var newValue = currentValue;
 		increment = parseInt( increment );
 		// Increment or Decrement
@@ -151,9 +168,9 @@ jQuery(document).ready( function() {
 			newValue = currentValue + increment;
 		}
 		// Set new value
-		jQuery( '#question_counter' ).attr( 'value', newValue );
+		jQuery( '#question_counter' ).val( newValue );
 		if ( newValue > 0 ) {
-			if ( !jQuery( '#no-questions-message' ).hasClass( 'hidden' ) ) {
+			if ( ! jQuery( '#no-questions-message' ).hasClass( 'hidden' ) ) {
 				jQuery( '#no-questions-message' ).addClass( 'hidden' );
 			}
 		} else {
@@ -169,19 +186,21 @@ jQuery(document).ready( function() {
 	 * @since 1.3.0
 	 * access public
 	 */
-	jQuery.fn.saveQuizGradeType = function() {
-
-		var quiz_grade_type = jQuery( 'input#quiz_grade_type' ).is( ':checked' ) ? 'auto' : 'manual';
+	jQuery.fn.saveQuizGradeType = function () {
+		var quiz_grade_type = jQuery( 'input#quiz_grade_type' ).is( ':checked' )
+			? 'auto'
+			: 'manual';
 
 		var dataToPost = 'quiz_grade_type' + '=' + quiz_grade_type;
-		dataToPost += '&quiz_id' + '=' + jQuery( '#quiz_id' ).attr( 'value' );
+		dataToPost += '&quiz_id' + '=' + jQuery( '#quiz_id' ).val();
 
 		jQuery.post(
 			ajaxurl,
 			{
-				action : 'lesson_update_grade_type',
-				lesson_update_grade_type_nonce : woo_localized_data.lesson_update_grade_type_nonce,
-				data : dataToPost
+				action: 'lesson_update_grade_type',
+				lesson_update_grade_type_nonce:
+					woo_localized_data.lesson_update_grade_type_nonce,
+				data: dataToPost,
 			},
 			function () {}
 		);
@@ -194,19 +213,19 @@ jQuery(document).ready( function() {
 	 * @since 1.5.0
 	 * access public
 	 */
-	jQuery.fn.saveQuestionOrder = function( question_order ) {
-
+	jQuery.fn.saveQuestionOrder = function ( question_order ) {
 		var dataToPost = 'question_order' + '=' + question_order;
-		dataToPost += '&quiz_id' + '=' + jQuery( '#quiz_id' ).attr( 'value' );
+		dataToPost += '&quiz_id' + '=' + jQuery( '#quiz_id' ).val();
 
 		jQuery.post(
 			ajaxurl,
 			{
-				action : 'lesson_update_question_order',
-				lesson_update_question_order_nonce : woo_localized_data.lesson_update_question_order_nonce,
-				data : dataToPost
+				action: 'lesson_update_question_order',
+				lesson_update_question_order_nonce:
+					woo_localized_data.lesson_update_question_order_nonce,
+				data: dataToPost,
 			},
-			function() {}
+			function () {}
 		);
 		return false;
 	};
@@ -217,21 +236,25 @@ jQuery(document).ready( function() {
 	 * @since 1.5.0
 	 * access public
 	 */
-	jQuery.fn.saveQuestionOrderRandom = function() {
-
-		var random_question_order = jQuery( 'input#random_question_order' ).is( ':checked' ) ? 'yes' : 'no';
+	jQuery.fn.saveQuestionOrderRandom = function () {
+		var random_question_order = jQuery( 'input#random_question_order' ).is(
+			':checked'
+		)
+			? 'yes'
+			: 'no';
 
 		var dataToPost = 'random_question_order' + '=' + random_question_order;
-		dataToPost += '&quiz_id' + '=' + jQuery( '#quiz_id' ).attr( 'value' );
+		dataToPost += '&quiz_id' + '=' + jQuery( '#quiz_id' ).val();
 
 		jQuery.post(
 			ajaxurl,
 			{
-				action : 'lesson_update_question_order_random',
-				lesson_update_question_order_random_nonce : woo_localized_data.lesson_update_question_order_random_nonce,
-				data : dataToPost
+				action: 'lesson_update_question_order_random',
+				lesson_update_question_order_random_nonce:
+					woo_localized_data.lesson_update_question_order_random_nonce,
+				data: dataToPost,
 			},
-			function() {}
+			function () {}
 		);
 		return false;
 	};
@@ -242,37 +265,44 @@ jQuery(document).ready( function() {
 	 * @since 1.5.0
 	 * @access public
 	 */
-	jQuery.fn.updateQuestionRows = function() {
+	jQuery.fn.updateQuestionRows = function () {
 		var row_number = 1;
 		var row_class = 'alternate';
-		jQuery( '#add-question-metadata' ).find( 'td.question-number' ).each( function() {
-			jQuery( this ).find( 'span.number' ).text( row_number );
-			jQuery( this ).closest( 'tbody' ).removeClass().addClass( row_class );
-			if( 'alternate' == row_class ) {
-				row_class = '';
-			} else {
-				row_class = 'alternate';
-			}
-
-			if( '' != jQuery( this ).find( 'span.total-number' ).text() ) {
-				var total_number = parseInt( jQuery( this ).find( 'span.total-number' ).text() );
-				var end_number = row_number + total_number - 1;
-				var multiple_numbers = '';
-
-				if( row_number == end_number ) {
-					multiple_numbers = row_number;
+		jQuery( '#add-question-metadata' )
+			.find( 'td.question-number' )
+			.each( function () {
+				jQuery( this ).find( 'span.number' ).text( row_number );
+				jQuery( this )
+					.closest( 'tbody' )
+					.removeClass()
+					.addClass( row_class );
+				if ( 'alternate' == row_class ) {
+					row_class = '';
 				} else {
-					multiple_numbers = row_number + ' - ' + end_number ;
+					row_class = 'alternate';
 				}
 
-				jQuery( this ).find( 'span.row-numbers' ).text( multiple_numbers );
-				row_number += total_number;
+				if ( '' != jQuery( this ).find( 'span.total-number' ).text() ) {
+					var total_number = parseInt(
+						jQuery( this ).find( 'span.total-number' ).text()
+					);
+					var end_number = row_number + total_number - 1;
+					var multiple_numbers = '';
 
-			} else {
-				row_number++;
-			}
+					if ( row_number == end_number ) {
+						multiple_numbers = row_number;
+					} else {
+						multiple_numbers = row_number + ' - ' + end_number;
+					}
 
-		});
+					jQuery( this )
+						.find( 'span.row-numbers' )
+						.text( multiple_numbers );
+					row_number += total_number;
+				} else {
+					row_number++;
+				}
+			} );
 	};
 
 	/**
@@ -280,15 +310,19 @@ jQuery(document).ready( function() {
 	 *
 	 * @since 1.5.0
 	 */
-	jQuery.fn.updateQuestionOrder = function() {
+	jQuery.fn.updateQuestionOrder = function () {
 		var orderString = '';
 
-		jQuery( '#sortable-questions' ).find( 'input.row_question_id' ).each( function ( i ) {
-			if ( i > 0 ) { orderString += ','; }
-			orderString += jQuery( this ).val();
-		});
+		jQuery( '#sortable-questions' )
+			.find( 'input.row_question_id' )
+			.each( function ( i ) {
+				if ( i > 0 ) {
+					orderString += ',';
+				}
+				orderString += jQuery( this ).val();
+			} );
 
-		jQuery( 'input#question-order' ).attr( 'value', orderString );
+		jQuery( 'input#question-order' ).val( orderString );
 
 		jQuery.fn.saveQuestionOrder( orderString );
 	};
@@ -301,43 +335,57 @@ jQuery(document).ready( function() {
 	 *
 	 * @since  1.5.0
 	 */
-	jQuery.fn.uploadQuestionMedia = function( button ) {
-		var button_id = button.attr('id');
+	jQuery.fn.uploadQuestionMedia = function ( button ) {
+		var button_id = button.attr( 'id' );
 		var field_id = button_id.replace( '_button', '' );
 		var preview_id = button_id.replace( '_button', '_preview' );
 		var link_id = button_id.replace( '_button', '_link' );
 		var delete_id = button_id.replace( '_button', '_button_delete' );
 
 		// Create the media frame.
-		file_frame = wp.media.frames.file_frame = wp.media({
+		file_frame = wp.media.frames.file_frame = wp.media( {
 			title: button.data( 'uploader_title' ),
 			button: { text: button.data( 'uploader_button_text' ) },
-			multiple: false
-		});
+			multiple: false,
+		} );
 
 		// When a file is selected, run a callback.
-		file_frame.on( 'select', function() {
-			var attachment = file_frame.state().get('selection').first().toJSON();
+		file_frame.on( 'select', function () {
+			var attachment = file_frame
+				.state()
+				.get( 'selection' )
+				.first()
+				.toJSON();
 			jQuery( '#' + field_id ).val( attachment.id );
 
 			var filetype = attachment.type;
 			var preview_image = false;
-			if( 'image' == filetype ) {
+			if ( 'image' == filetype ) {
 				preview_image = true;
 			}
 
 			var media_title = attachment.title;
-			if( ! media_title || media_title == '' ) {
+			if ( ! media_title || media_title == '' ) {
 				media_title = attachment.filename;
 			}
 
-			var link_text = '<a class="' + filetype + '" href="' + attachment.url + '" target="_blank">' + media_title + '</a>';
+			var link_text =
+				'<a class="' +
+				filetype +
+				'" href="' +
+				attachment.url +
+				'" target="_blank">' +
+				media_title +
+				'</a>';
 			jQuery( '#' + link_id ).removeClass( 'hidden' );
 			jQuery( '#' + link_id ).html( link_text );
 
-			if( preview_image ) {
+			if ( preview_image ) {
 				jQuery( '#' + preview_id ).removeClass( 'hidden' );
-				jQuery( '#' + preview_id ).attr( 'src', attachment.sizes.thumbnail.url );
+				jQuery( '#' + preview_id ).attr(
+					'src',
+					attachment.sizes.thumbnail.url
+				);
 			} else {
 				jQuery( '#' + preview_id ).addClass( 'hidden' );
 				jQuery( '#' + preview_id ).attr( 'src', '' );
@@ -345,15 +393,14 @@ jQuery(document).ready( function() {
 
 			button.text( woo_localized_data.change_file );
 			jQuery( '#' + delete_id ).removeClass( 'hidden' );
-
-		});
+		} );
 
 		// Open the modal
 		file_frame.open();
 	};
 
-	jQuery.fn.deleteQuestionMedia = function( button ) {
-		var button_id = button.attr('id');
+	jQuery.fn.deleteQuestionMedia = function ( button ) {
+		var button_id = button.attr( 'id' );
 		var add_button_id = button_id.replace( '_button_delete', '_button' );
 		var field_id = button_id.replace( '_button_delete', '' );
 		var preview_id = button_id.replace( '_button_delete', '_preview' );
@@ -374,19 +421,21 @@ jQuery(document).ready( function() {
 	 *
 	 * @since 1.5.0
 	 */
-	jQuery.fn.updateAnswerOrder = function( answer_parent ) {
+	jQuery.fn.updateAnswerOrder = function ( answer_parent ) {
 		var answer_id = '';
 		var orderString = '';
 
 		answer_parent.find( 'input.question_answer' ).each( function ( i ) {
 			answer_id = jQuery( this ).attr( 'rel' );
-			if( '' != answer_id ) {
-				if ( i > 0 ) { orderString += ','; }
+			if ( '' != answer_id ) {
+				if ( i > 0 ) {
+					orderString += ',';
+				}
 				orderString += jQuery( this ).attr( 'rel' );
 			}
-		});
+		} );
 
-		answer_parent.find( 'input.answer_order' ).attr( 'value', orderString );
+		answer_parent.find( 'input.answer_order' ).val( orderString );
 	};
 
 	/**
@@ -395,21 +444,26 @@ jQuery(document).ready( function() {
 	 * @since 1.0.8
 	 * @access public
 	 */
-	jQuery.fn.htmlentities = function( str ) {
-		return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+	jQuery.fn.htmlentities = function ( str ) {
+		return String( str )
+			.replace( /&/g, '&amp;' )
+			.replace( /</g, '&lt;' )
+			.replace( />/g, '&gt;' )
+			.replace( /"/g, '&quot;' );
 	};
 
-	jQuery.fn.ucwords = function( str ) {
+	jQuery.fn.ucwords = function ( str ) {
 		str = str.toLowerCase();
 		str = str.replace( '-', ' ' );
 		str = str.replace( 'boolean', 'True/False' );
-		return str.replace(/(^([a-zA-Z{M}]))|([ -][a-zA-Z{M}])/g,
-			function($1){
-				return $1.toUpperCase();
-			});
+		return str.replace( /(^([a-zA-Z{M}]))|([ -][a-zA-Z{M}])/g, function (
+			$1
+		) {
+			return $1.toUpperCase();
+		} );
 	};
 
-	jQuery.fn.filterExistingQuestions = function( page ) {
+	jQuery.fn.filterExistingQuestions = function ( page ) {
 		var dataToPost = '';
 		var questionStatus = '';
 		var questionType = '';
@@ -422,22 +476,22 @@ jQuery(document).ready( function() {
 		questionStatus = jQuery( '#existing-status' ).val();
 		dataToPost += 'question_status=' + questionStatus;
 
-		if( '' != jQuery( '#existing-type' ).val() ) {
+		if ( '' != jQuery( '#existing-type' ).val() ) {
 			questionType = jQuery( '#existing-type' ).val();
 			dataToPost += '&question_type=' + questionType;
 		}
 
-		if( '' != jQuery( '#existing-category' ).val() ) {
+		if ( '' != jQuery( '#existing-category' ).val() ) {
 			questionCat = jQuery( '#existing-category' ).val();
 			dataToPost += '&question_category=' + questionCat;
 		}
 
-		if( '' != jQuery( '#existing-search' ).val() ) {
+		if ( '' != jQuery( '#existing-search' ).val() ) {
 			questionSearch = jQuery( '#existing-search' ).val();
 			dataToPost += '&question_search=' + questionSearch;
 		}
 
-		if( ! page ) {
+		if ( ! page ) {
 			questionPage = jQuery( '#existing-page' ).val();
 		} else {
 			questionPage = page;
@@ -448,11 +502,12 @@ jQuery(document).ready( function() {
 		jQuery.post(
 			ajaxurl,
 			{
-				action : 'filter_existing_questions',
-				filter_existing_questions_nonce : woo_localized_data.filter_existing_questions_nonce,
-				data : dataToPost
+				action: 'filter_existing_questions',
+				filter_existing_questions_nonce:
+					woo_localized_data.filter_existing_questions_nonce,
+				data: dataToPost,
 			},
-			function( response ) {
+			function ( response ) {
 				if ( response ) {
 					var count = parseInt( response.count );
 					var page = parseInt( response.page );
@@ -463,16 +518,24 @@ jQuery(document).ready( function() {
 
 					jQuery( '#existing-page' ).val( page );
 
-					if( 1 < page ) {
-						jQuery( '#existing-pagination .prev' ).removeClass( 'no-paging' );
+					if ( 1 < page ) {
+						jQuery( '#existing-pagination .prev' ).removeClass(
+							'no-paging'
+						);
 					} else {
-						jQuery( '#existing-pagination .prev' ).addClass( 'no-paging' );
+						jQuery( '#existing-pagination .prev' ).addClass(
+							'no-paging'
+						);
 					}
 
-					if( last_row <= count ) {
-						jQuery( '#existing-pagination .next' ).removeClass( 'no-paging' );
+					if ( last_row <= count ) {
+						jQuery( '#existing-pagination .next' ).removeClass(
+							'no-paging'
+						);
 					} else {
-						jQuery( '#existing-pagination .next' ).addClass( 'no-paging' );
+						jQuery( '#existing-pagination .next' ).addClass(
+							'no-paging'
+						);
 					}
 				}
 			}
@@ -480,11 +543,14 @@ jQuery(document).ready( function() {
 		return false;
 	};
 
-	jQuery.fn.scrollToElement = function( target ) {
+	jQuery.fn.scrollToElement = function ( target ) {
 		var topoffset = 30;
 		var speed = 800;
 		var destination = jQuery( target ).offset().top - topoffset;
-		jQuery( 'html:not(:animated),body:not(:animated)' ).animate( { scrollTop: destination}, speed );
+		jQuery( 'html:not(:animated),body:not(:animated)' ).animate(
+			{ scrollTop: destination },
+			speed
+		);
 		return false;
 	};
 
@@ -498,22 +564,46 @@ jQuery(document).ready( function() {
 	 * @since 1.3.0
 	 * @access public
 	 */
-	jQuery( 'input.gapfill-field' ).each( function() {
+	jQuery( 'input.gapfill-field' ).each( function () {
 		// Handles change events like paste, tabbing, and click change selectors
-		jQuery( this ).change(function() {
-			var gapPre = jQuery( this ).parent('div').find('input[name=add_question_right_answer_gapfill_pre]').val();
-			var gapGap = jQuery( this ).parent('div').find('input[name=add_question_right_answer_gapfill_gap]').val();
-			var gapPost = jQuery( this ).parent('div').find('input[name=add_question_right_answer_gapfill_post]').val();
-			jQuery( this ).parent('div').find('p.gapfill-preview').html( gapPre + ' <u>' + gapGap + '</u> ' + gapPost );
-		});
+		jQuery( this ).change( function () {
+			var gapPre = jQuery( this )
+				.parent( 'div' )
+				.find( 'input[name=add_question_right_answer_gapfill_pre]' )
+				.val();
+			var gapGap = jQuery( this )
+				.parent( 'div' )
+				.find( 'input[name=add_question_right_answer_gapfill_gap]' )
+				.val();
+			var gapPost = jQuery( this )
+				.parent( 'div' )
+				.find( 'input[name=add_question_right_answer_gapfill_post]' )
+				.val();
+			jQuery( this )
+				.parent( 'div' )
+				.find( 'p.gapfill-preview' )
+				.html( gapPre + ' <u>' + gapGap + '</u> ' + gapPost );
+		} );
 		// Handles the pressing up of the key, general typing
-		jQuery( this ).keyup(function() {
-			var gapPre = jQuery( this ).parent('div').find('input[name=add_question_right_answer_gapfill_pre]').val();
-			var gapGap = jQuery( this ).parent('div').find('input[name=add_question_right_answer_gapfill_gap]').val();
-			var gapPost = jQuery( this ).parent('div').find('input[name=add_question_right_answer_gapfill_post]').val();
-			jQuery( this ).parent('div').find('p.gapfill-preview').html( gapPre + ' <u>' + gapGap + '</u> ' + gapPost );
-		});
-	});
+		jQuery( this ).keyup( function () {
+			var gapPre = jQuery( this )
+				.parent( 'div' )
+				.find( 'input[name=add_question_right_answer_gapfill_pre]' )
+				.val();
+			var gapGap = jQuery( this )
+				.parent( 'div' )
+				.find( 'input[name=add_question_right_answer_gapfill_gap]' )
+				.val();
+			var gapPost = jQuery( this )
+				.parent( 'div' )
+				.find( 'input[name=add_question_right_answer_gapfill_post]' )
+				.val();
+			jQuery( this )
+				.parent( 'div' )
+				.find( 'p.gapfill-preview' )
+				.html( gapPre + ' <u>' + gapGap + '</u> ' + gapPost );
+		} );
+	} );
 
 	/**
 	 * Quiz grade type checkbox change event
@@ -521,34 +611,62 @@ jQuery(document).ready( function() {
 	 * @since 1.3.0
 	 * @access public
 	 */
-	jQuery( '#add-quiz-metadata' ).on( 'change', '#quiz_grade_type', function() {
-		jQuery.fn.saveQuizGradeType();
-	});
+	jQuery( '#add-quiz-metadata' ).on(
+		'change',
+		'#quiz_grade_type',
+		function () {
+			jQuery.fn.saveQuizGradeType();
+		}
+	);
 
 	/***************************************************************************************************
 	 * 	3 - Load Chosen Dropdowns.
 	 ***************************************************************************************************/
 
 	// Lessons Write Panel
-	if ( jQuery( '#lesson-complexity-options' ).exists() ) { jQuery( '#lesson-complexity-options' ).select2({width:'resolve'}); }
-	if ( jQuery( '#lesson-prerequisite-options' ).exists() ) { jQuery( '#lesson-prerequisite-options' ).select2({width:'resolve'}); }
-	if ( jQuery( '#lesson-course-options' ).exists() ) { jQuery( '#lesson-course-options' ).select2({width:'resolve'}); }
-	if ( jQuery( '#lesson-module-options' ).exists() ) { jQuery( '#lesson-module-options' ).select2({width:'resolve'}); }
+	if ( jQuery( '#lesson-complexity-options' ).exists() ) {
+		jQuery( '#lesson-complexity-options' ).select2( { width: 'resolve' } );
+	}
+	if ( jQuery( '#lesson-prerequisite-options' ).exists() ) {
+		jQuery( '#lesson-prerequisite-options' ).select2( {
+			width: 'resolve',
+		} );
+	}
+	if ( jQuery( '#lesson-course-options' ).exists() ) {
+		jQuery( '#lesson-course-options' ).select2( { width: 'resolve' } );
+	}
+	if ( jQuery( '#lesson-module-options' ).exists() ) {
+		jQuery( '#lesson-module-options' ).select2( { width: 'resolve' } );
+	}
 
 	// Quiz edit panel
-	if ( jQuery( '#add-question-type-options' ).exists() ) { jQuery( '#add-question-type-options' ).select2({width:'resolve'}); }
-	if ( jQuery( '#add-question-category-options' ).exists() ) { jQuery( '#add-question-category-options' ).select2({width:'resolve'}); }
-	if ( jQuery( '#add-multiple-question-options' ).exists() ) { jQuery( '#add-multiple-question-options' ).select2({width:'resolve'}); }
+	if ( jQuery( '#add-question-type-options' ).exists() ) {
+		jQuery( '#add-question-type-options' ).select2( { width: 'resolve' } );
+	}
+	if ( jQuery( '#add-question-category-options' ).exists() ) {
+		jQuery( '#add-question-category-options' ).select2( {
+			width: 'resolve',
+		} );
+	}
+	if ( jQuery( '#add-multiple-question-options' ).exists() ) {
+		jQuery( '#add-multiple-question-options' ).select2( {
+			width: 'resolve',
+		} );
+	}
 
 	// Courses Write Panel
-	if ( jQuery( '#add-multiple-question-category-options' ).exists() ) { jQuery( '#add-multiple-question-category-options' ).select2({width:'resolve'}); }
+	if ( jQuery( '#add-multiple-question-category-options' ).exists() ) {
+		jQuery( '#add-multiple-question-category-options' ).select2( {
+			width: 'resolve',
+		} );
+	}
 
 	// Sensei Settings Panel
-	jQuery( 'div.woothemes-sensei-settings form select' ).each( function() {
-		if ( !jQuery( this ).hasClass( 'range-input' ) ) {
-			jQuery( this ).select2({width:'resolve'});
+	jQuery( 'div.woothemes-sensei-settings form select' ).each( function () {
+		if ( ! jQuery( this ).hasClass( 'range-input' ) ) {
+			jQuery( this ).select2( { width: 'resolve' } );
 		} // End If Statement
-	});
+	} );
 
 	/***************************************************************************************************
 	 * 	4 - Quiz Question Functions.
@@ -560,49 +678,81 @@ jQuery(document).ready( function() {
 	 * @since 1.0.0
 	 * @access public
 	 */
-	jQuery( '#add-question-actions' ).on( 'change', 'select.question-type-select', function() {
-		// Show the correct Question Type
-		var select       = jQuery(this);
-		var title        = jQuery( '#question-edit-panel > .ui-sortable-handle > span' );
-		var questionType = select.val();
+	jQuery( '#add-question-actions' ).on(
+		'change',
+		'select.question-type-select',
+		function () {
+			// Show the correct Question Type
+			var select = jQuery( this );
+			var title = jQuery(
+				'#question-edit-panel > .ui-sortable-handle > span'
+			);
+			var questionType = select.val();
 
-		if ( title.length > 0 ) {
-			var questionLabel = select.find( `option[value="${questionType}"]` ).text();
+			if ( title.length > 0 ) {
+				var questionLabel = select
+					.find( `option[value="${ questionType }"]` )
+					.text();
 
-			title.text( questionLabel );
+				title.text( questionLabel );
+			}
+
+			jQuery( '#add-new-question' )
+				.find( 'div.question_default_fields' )
+				.hide();
+			jQuery( '#add-new-question' )
+				.find( 'div.question_boolean_fields' )
+				.hide();
+			jQuery( '#add-new-question' )
+				.find( 'div.question_gapfill_fields' )
+				.hide();
+			jQuery( '#add-new-question' )
+				.find( 'div.question_multiline_fields' )
+				.hide();
+			jQuery( '#add-new-question' )
+				.find( 'div.question_singleline_fields' )
+				.hide();
+			jQuery( '#add-new-question' )
+				.find( 'div.question_fileupload_fields' )
+				.hide();
+
+			jQuery( '.add_question_random_order' ).hide();
+
+			switch ( questionType ) {
+				case 'multiple-choice':
+					jQuery( '#add-new-question' )
+						.find( 'div.question_default_fields' )
+						.show();
+					jQuery( '.add_question_random_order' ).show();
+					break;
+				case 'boolean':
+					jQuery( '#add-new-question' )
+						.find( 'div.question_boolean_fields' )
+						.show();
+					break;
+				case 'gap-fill':
+					jQuery( '#add-new-question' )
+						.find( 'div.question_gapfill_fields' )
+						.show();
+					break;
+				case 'multi-line':
+					jQuery( '#add-new-question' )
+						.find( 'div.question_multiline_fields' )
+						.show();
+					break;
+				case 'single-line':
+					jQuery( '#add-new-question' )
+						.find( 'div.question_singleline_fields' )
+						.show();
+					break;
+				case 'file-upload':
+					jQuery( '#add-new-question' )
+						.find( 'div.question_fileupload_fields' )
+						.show();
+					break;
+			} // End Switch Statement
 		}
-
-		jQuery( '#add-new-question' ).find( 'div.question_default_fields' ).hide();
-		jQuery( '#add-new-question' ).find( 'div.question_boolean_fields' ).hide();
-		jQuery( '#add-new-question' ).find( 'div.question_gapfill_fields' ).hide();
-		jQuery( '#add-new-question' ).find( 'div.question_multiline_fields' ).hide();
-		jQuery( '#add-new-question' ).find( 'div.question_singleline_fields' ).hide();
-		jQuery( '#add-new-question' ).find( 'div.question_fileupload_fields' ).hide();
-
-		jQuery( '.add_question_random_order' ).hide();
-
-		switch ( questionType ) {
-		case 'multiple-choice':
-			jQuery( '#add-new-question' ).find( 'div.question_default_fields' ).show();
-			jQuery( '.add_question_random_order' ).show();
-			break;
-		case 'boolean':
-			jQuery( '#add-new-question' ).find( 'div.question_boolean_fields' ).show();
-			break;
-		case 'gap-fill':
-			jQuery( '#add-new-question' ).find( 'div.question_gapfill_fields' ).show();
-			break;
-		case 'multi-line':
-			jQuery( '#add-new-question' ).find( 'div.question_multiline_fields' ).show();
-			break;
-		case 'single-line':
-			jQuery( '#add-new-question' ).find( 'div.question_singleline_fields' ).show();
-			break;
-		case 'file-upload':
-			jQuery( '#add-new-question' ).find( 'div.question_fileupload_fields' ).show();
-			break;
-		} // End Switch Statement
-	});
+	);
 
 	/**
 	 * Edit Question Click Event.
@@ -610,17 +760,27 @@ jQuery(document).ready( function() {
 	 * @since 1.0.0
 	 * @access public
 	 */
-	jQuery( '#add-question-metadata' ).on( 'click', 'a.question_table_edit', function() {
-		// Display the question for edit
-		var questionId = jQuery(this).closest('tr').next('tr').find('.question_original_counter').text();
-		jQuery( '#add-question-actions button.add_question_answer' ).removeClass('hidden');
+	jQuery( '#add-question-metadata' ).on(
+		'click',
+		'a.question_table_edit',
+		function () {
+			// Display the question for edit
+			var questionId = jQuery( this )
+				.closest( 'tr' )
+				.next( 'tr' )
+				.find( '.question_original_counter' )
+				.text();
+			jQuery(
+				'#add-question-actions button.add_question_answer'
+			).removeClass( 'hidden' );
 
-		jQuery.fn.resetAddQuestionForm();
-		jQuery.fn.resetQuestionTable();
+			jQuery.fn.resetAddQuestionForm();
+			jQuery.fn.resetQuestionTable();
 
-		jQuery(this).closest('tr').next('tr').removeClass('hidden');
-		jQuery( '#question_' + questionId ).focus();
-	});
+			jQuery( this ).closest( 'tr' ).next( 'tr' ).removeClass( 'hidden' );
+			jQuery( '#question_' + questionId ).focus();
+		}
+	);
 
 	/**
 	 * Cancel Events Click Event - edit question.
@@ -628,10 +788,16 @@ jQuery(document).ready( function() {
 	 * @since 1.0.0
 	 * @access public
 	 */
-	jQuery( '#add-question-metadata' ).on( 'click', 'a.lesson_question_cancel', function() {
-		// Hide the edit question panel
-		jQuery( this ).closest('tr.question-quick-edit').addClass( 'hidden' );
-	});
+	jQuery( '#add-question-metadata' ).on(
+		'click',
+		'a.lesson_question_cancel',
+		function () {
+			// Hide the edit question panel
+			jQuery( this )
+				.closest( 'tr.question-quick-edit' )
+				.addClass( 'hidden' );
+		}
+	);
 
 	/**
 	 * Add Question Save Click Event - Ajax.
@@ -639,135 +805,240 @@ jQuery(document).ready( function() {
 	 * @since 1.0.0
 	 * @access public
 	 */
-	jQuery( '#add-new-question' ).on( 'click', 'a.add_question_save', function() {
-		var dataToPost = '';
-		var questionGrade = '';
-		var questionType = 'multiple-choice';
-		var questionCategory = '';
-		var radioValue = 'true';
-		// Validate Inputs
-		var validInput = jQuery.fn.validateQuestionInput( 'add', jQuery(this) );
-		if ( validInput ) {
-			// Setup data to post
-			dataToPost += 'quiz_id' + '=' + jQuery( '#quiz_id' ).attr( 'value' );
-			dataToPost += '&action=add';
-			if ( jQuery( '#add-question-type-options' ).val() != '' ) {
-				questionType = jQuery( '#add-question-type-options' ).val();
-			} // End If Statement
-
-			if ( jQuery( '#add-question-category-options' ).val() != '' ) {
-				questionCategory = jQuery( '#add-question-category-options' ).val();
-			} // End If Statement
-
-			var divFieldsClass = 'question_default_fields';
-			switch ( questionType ) {
-			case 'multiple-choice':
-				divFieldsClass = 'question_default_fields';
-				break;
-			case 'boolean':
-				divFieldsClass = 'question_boolean_fields';
-				break;
-			case 'gap-fill':
-				divFieldsClass = 'question_gapfill_fields';
-				break;
-			case 'multi-line':
-				divFieldsClass = 'question_multiline_fields';
-				break;
-			case 'single-line':
-				divFieldsClass = 'question_singleline_fields';
-				break;
-			case 'file-upload':
-				divFieldsClass = 'question_fileupload_fields';
-				break;
-			} // End Switch Statement
-
-			// Handle Required Fields
-			jQuery( '#add-new-question' ).find( 'div.question_required_fields' ).find( 'input' ).each( function() {
-				if ( jQuery( this ).attr( 'type' ) != 'radio' ) {
-					dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( this ).attr( 'value' ) );
-				} // End If Statement
-			});
-
-			// Handle textarea required field
-			if ( jQuery( '#add-new-question' ).find( 'div.question_required_fields' ).find( 'textarea' ).val() != '' ) {
-				dataToPost += '&' + jQuery( '#add-new-question' ).find( 'div.question_required_fields' ).find( 'textarea' ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( '#add-new-question' ).find( 'div.question_required_fields' ).find( 'textarea' ).val() );
-			} // End If Statement
-
-			// Handle Question Input Fields
-			var radioCount = 0;
-			jQuery( '#add-new-question' ).find( 'div.' + divFieldsClass ).find( 'input' ).each( function() {
-				if ( jQuery( this ).attr( 'type' ) == 'radio' ) {
-					// Only get the selected radio button
-					if ( radioCount == 0 ) {
-						radioValue = jQuery( 'input[name=' + jQuery( this ).attr( 'name' ) + ']:checked' ).attr( 'value' );
-						dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + encodeURIComponent( radioValue );
-						radioCount++;
-					} // End If Statement
-				} else {
-					dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( this ).attr( 'value' ) );
-				} // End If Statement
-			});
-			// Handle Question Textarea Fields
-			if ( jQuery( '#add_question_right_answer_essay' ).val() != '' && divFieldsClass == 'question_essay_fields' ) {
-				dataToPost += '&' + jQuery( '#add_question_right_answer_essay' ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( '#add_question_right_answer_essay' ).val() );
-			} // End If Statement
-			if ( jQuery( '#add_question_right_answer_multiline' ).val() != '' && divFieldsClass == 'question_multiline_fields' ) {
-				dataToPost += '&' + jQuery( '#add_question_right_answer_multiline' ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( '#add_question_right_answer_multiline' ).val() );
-			} // End If Statement
-			dataToPost += '&' + 'question_type' + '=' + questionType;
-			dataToPost += '&' + 'question_category' + '=' + questionCategory;
-			questionGrade = jQuery( '#add-question-grade' ).val();
-			dataToPost += '&' + 'question_grade' + '=' + questionGrade;
-
-			var questionCount = parseInt( jQuery( '#question_counter' ).attr( 'value' ) );
-			dataToPost += '&' + 'question_count' + '=' + questionCount;
-
-			var answer_order = jQuery( '#add-new-question' ).find( '.answer_order' ).attr( 'value' );
-			dataToPost += '&' + 'answer_order' + '=' + answer_order;
-
-			var question_media = jQuery( '#add-new-question' ).find( '.question_media' ).attr( 'value' );
-			dataToPost += '&' + 'question_media' + '=' + question_media;
-
-			if ( '' != jQuery( 'div#add-new-question' ).find( 'div.' + divFieldsClass ).find( '.answer_feedback' ).exists() ) {
-				var answer_feedback = jQuery( '#add-new-question' ).find( 'div.' + divFieldsClass ).find( '.answer_feedback' ).attr( 'value' );
-				dataToPost += '&' + 'answer_feedback' + '=' + encodeURIComponent( answer_feedback );
-			}
-
-			var random_order = 'no';
-			if ( jQuery( 'div#add-new-question' ).find( '.random_order' ).is(':checked') ) {
-				random_order = 'yes';
-			}
-			dataToPost += '&' + 'random_order' + '=' + random_order;
-
-			// Perform the AJAX call.
-			jQuery.post(
-				ajaxurl,
-				{
-					action : 'lesson_update_question',
-					lesson_update_question_nonce : woo_localized_data.lesson_update_question_nonce,
-					data : dataToPost
-				},
-				function( response ) {
-					// Check for a valid response
-					if ( response ) {
-						jQuery.fn.updateQuestionCount( 1, '+' );
-						jQuery( '#add-question-metadata table' ).append( response );
-						jQuery.fn.resetAddQuestionForm();
-						jQuery.fn.checkQuizGradeType( questionType );
-
-						var max_questions = jQuery( '#show_questions' ).attr( 'max' );
-						max_questions++;
-						jQuery( '#show_questions' ).attr( 'max', max_questions );
-
-						jQuery.fn.scrollToElement( '#lesson-quiz' );
-					}
-				}
+	jQuery( '#add-new-question' ).on(
+		'click',
+		'a.add_question_save',
+		function () {
+			var dataToPost = '';
+			var questionGrade = '';
+			var questionType = 'multiple-choice';
+			var questionCategory = '';
+			var radioValue = 'true';
+			// Validate Inputs
+			var validInput = jQuery.fn.validateQuestionInput(
+				'add',
+				jQuery( this )
 			);
-			return false;
-		} else {
-			jQuery( '#add_question' ).focus();
+			if ( validInput ) {
+				// Setup data to post
+				dataToPost += 'quiz_id' + '=' + jQuery( '#quiz_id' ).val();
+				dataToPost += '&action=add';
+				if ( jQuery( '#add-question-type-options' ).val() != '' ) {
+					questionType = jQuery( '#add-question-type-options' ).val();
+				} // End If Statement
+
+				if ( jQuery( '#add-question-category-options' ).val() != '' ) {
+					questionCategory = jQuery(
+						'#add-question-category-options'
+					).val();
+				} // End If Statement
+
+				var divFieldsClass = 'question_default_fields';
+				switch ( questionType ) {
+					case 'multiple-choice':
+						divFieldsClass = 'question_default_fields';
+						break;
+					case 'boolean':
+						divFieldsClass = 'question_boolean_fields';
+						break;
+					case 'gap-fill':
+						divFieldsClass = 'question_gapfill_fields';
+						break;
+					case 'multi-line':
+						divFieldsClass = 'question_multiline_fields';
+						break;
+					case 'single-line':
+						divFieldsClass = 'question_singleline_fields';
+						break;
+					case 'file-upload':
+						divFieldsClass = 'question_fileupload_fields';
+						break;
+				} // End Switch Statement
+
+				// Handle Required Fields
+				jQuery( '#add-new-question' )
+					.find( 'div.question_required_fields' )
+					.find( 'input' )
+					.each( function () {
+						if ( jQuery( this ).attr( 'type' ) != 'radio' ) {
+							dataToPost +=
+								'&' +
+								jQuery( this ).attr( 'name' ) +
+								'=' +
+								encodeURIComponent( jQuery( this ).val() );
+						} // End If Statement
+					} );
+
+				// Handle textarea required field
+				if (
+					jQuery( '#add-new-question' )
+						.find( 'div.question_required_fields' )
+						.find( 'textarea' )
+						.val() != ''
+				) {
+					dataToPost +=
+						'&' +
+						jQuery( '#add-new-question' )
+							.find( 'div.question_required_fields' )
+							.find( 'textarea' )
+							.attr( 'name' ) +
+						'=' +
+						encodeURIComponent(
+							jQuery( '#add-new-question' )
+								.find( 'div.question_required_fields' )
+								.find( 'textarea' )
+								.val()
+						);
+				} // End If Statement
+
+				// Handle Question Input Fields
+				var radioCount = 0;
+				jQuery( '#add-new-question' )
+					.find( 'div.' + divFieldsClass )
+					.find( 'input' )
+					.each( function () {
+						if ( jQuery( this ).attr( 'type' ) == 'radio' ) {
+							// Only get the selected radio button
+							if ( radioCount == 0 ) {
+								radioValue = jQuery(
+									'input[name=' +
+										jQuery( this ).attr( 'name' ) +
+										']:checked'
+								).val();
+								dataToPost +=
+									'&' +
+									jQuery( this ).attr( 'name' ) +
+									'=' +
+									encodeURIComponent( radioValue );
+								radioCount++;
+							} // End If Statement
+						} else {
+							dataToPost +=
+								'&' +
+								jQuery( this ).attr( 'name' ) +
+								'=' +
+								encodeURIComponent( jQuery( this ).val() );
+						} // End If Statement
+					} );
+				// Handle Question Textarea Fields
+				if (
+					jQuery( '#add_question_right_answer_essay' ).val() != '' &&
+					divFieldsClass == 'question_essay_fields'
+				) {
+					dataToPost +=
+						'&' +
+						jQuery( '#add_question_right_answer_essay' ).attr(
+							'name'
+						) +
+						'=' +
+						encodeURIComponent(
+							jQuery( '#add_question_right_answer_essay' ).val()
+						);
+				} // End If Statement
+				if (
+					jQuery( '#add_question_right_answer_multiline' ).val() !=
+						'' &&
+					divFieldsClass == 'question_multiline_fields'
+				) {
+					dataToPost +=
+						'&' +
+						jQuery( '#add_question_right_answer_multiline' ).attr(
+							'name'
+						) +
+						'=' +
+						encodeURIComponent(
+							jQuery(
+								'#add_question_right_answer_multiline'
+							).val()
+						);
+				} // End If Statement
+				dataToPost += '&' + 'question_type' + '=' + questionType;
+				dataToPost +=
+					'&' + 'question_category' + '=' + questionCategory;
+				questionGrade = jQuery( '#add-question-grade' ).val();
+				dataToPost += '&' + 'question_grade' + '=' + questionGrade;
+
+				var questionCount = parseInt(
+					jQuery( '#question_counter' ).val()
+				);
+				dataToPost += '&' + 'question_count' + '=' + questionCount;
+
+				var answer_order = jQuery( '#add-new-question' )
+					.find( '.answer_order' )
+					.val();
+				dataToPost += '&' + 'answer_order' + '=' + answer_order;
+
+				var question_media = jQuery( '#add-new-question' )
+					.find( '.question_media' )
+					.val();
+				dataToPost += '&' + 'question_media' + '=' + question_media;
+
+				if (
+					'' !=
+					jQuery( 'div#add-new-question' )
+						.find( 'div.' + divFieldsClass )
+						.find( '.answer_feedback' )
+						.exists()
+				) {
+					var answer_feedback = jQuery( '#add-new-question' )
+						.find( 'div.' + divFieldsClass )
+						.find( '.answer_feedback' )
+						.val();
+					dataToPost +=
+						'&' +
+						'answer_feedback' +
+						'=' +
+						encodeURIComponent( answer_feedback );
+				}
+
+				var random_order = 'no';
+				if (
+					jQuery( 'div#add-new-question' )
+						.find( '.random_order' )
+						.is( ':checked' )
+				) {
+					random_order = 'yes';
+				}
+				dataToPost += '&' + 'random_order' + '=' + random_order;
+
+				// Perform the AJAX call.
+				jQuery.post(
+					ajaxurl,
+					{
+						action: 'lesson_update_question',
+						lesson_update_question_nonce:
+							woo_localized_data.lesson_update_question_nonce,
+						data: dataToPost,
+					},
+					function ( response ) {
+						// Check for a valid response
+						if ( response ) {
+							jQuery.fn.updateQuestionCount( 1, '+' );
+							jQuery( '#add-question-metadata table' ).append(
+								response
+							);
+							jQuery.fn.resetAddQuestionForm();
+							jQuery.fn.checkQuizGradeType( questionType );
+
+							var max_questions = jQuery(
+								'#show_questions'
+							).attr( 'max' );
+							max_questions++;
+							jQuery( '#show_questions' ).attr(
+								'max',
+								max_questions
+							);
+
+							jQuery.fn.scrollToElement( '#lesson-quiz' );
+						}
+					}
+				);
+				return false;
+			} else {
+				jQuery( '#add_question' ).focus();
+			}
 		}
-	});
+	);
 
 	/**
 	 * Add Multiple Questions Save Click Event - Ajax.
@@ -775,69 +1046,93 @@ jQuery(document).ready( function() {
 	 * @since 1.6.0
 	 * @access public
 	 */
-	jQuery( '#add-new-question' ).on( 'click', 'a.add_multiple_save', function() {
-		var dataToPost = '';
-		var questionCategory = '';
-		var questionNumber = 0;
+	jQuery( '#add-new-question' ).on(
+		'click',
+		'a.add_multiple_save',
+		function () {
+			var dataToPost = '';
+			var questionCategory = '';
+			var questionNumber = 0;
 
-		dataToPost += 'quiz_id' + '=' + jQuery( '#quiz_id' ).attr( 'value' );
+			dataToPost += 'quiz_id' + '=' + jQuery( '#quiz_id' ).val();
 
-		if ( jQuery( '#add-multiple-question-count' ).val() != '' ) {
-			questionNumber = parseInt( jQuery( '#add-multiple-question-count' ).val() );
-		} // End If Statement
-		dataToPost += '&' + 'question_number' + '=' + questionNumber;
+			if ( jQuery( '#add-multiple-question-count' ).val() != '' ) {
+				questionNumber = parseInt(
+					jQuery( '#add-multiple-question-count' ).val()
+				);
+			} // End If Statement
+			dataToPost += '&' + 'question_number' + '=' + questionNumber;
 
-		var maxAllowed = parseInt( jQuery( '#add-multiple-question-count' ).attr( 'max' ) );
-
-		// Only allow submission if selected number is not greater than the amount of questions in the category
-		if( questionNumber > maxAllowed ) {
-			alert( woo_localized_data.too_many_for_cat );
-			jQuery( '#add-multiple-question-count' ).focus();
-			return false;
-		}
-
-		if ( jQuery( '#add-multiple-question-category-options' ).val() != '' ) {
-			questionCategory = jQuery( '#add-multiple-question-category-options' ).val();
-		} // End If Statement
-		dataToPost += '&' + 'question_category' + '=' + questionCategory;
-
-		var questionCount = parseInt( jQuery( '#question_counter' ).attr( 'value' ) );
-		dataToPost += '&' + 'question_count' + '=' + questionCount;
-
-		if( questionCategory && questionNumber ) {
-			// Perform the AJAX call.
-			jQuery.post(
-				ajaxurl,
-				{
-					action : 'lesson_add_multiple_questions',
-					lesson_add_multiple_questions_nonce : woo_localized_data.lesson_add_multiple_questions_nonce,
-					data : dataToPost
-				},
-				function( response ) {
-					// Check for a valid response
-					if ( response ) {
-						jQuery( '#add-multiple-question-category-options' ).val('');
-						jQuery( '#add-multiple-question-count' ).val('1');
-
-						jQuery.fn.updateQuestionCount( questionNumber, '+' );
-						jQuery( '#add-question-metadata table' ).append( response );
-
-						jQuery.fn.updateQuestionOrder();
-
-						var max_questions = jQuery( '#show_questions' ).attr( 'max' );
-						max_questions += questionNumber;
-						jQuery( '#show_questions' ).attr( 'max', max_questions );
-
-						jQuery.fn.scrollToElement( '#lesson-quiz' );
-					}
-				}
+			var maxAllowed = parseInt(
+				jQuery( '#add-multiple-question-count' ).attr( 'max' )
 			);
-			return false;
-		} else {
-			jQuery( '#add-multiple-question-category-options' ).focus();
-		}
 
-	});
+			// Only allow submission if selected number is not greater than the amount of questions in the category
+			if ( questionNumber > maxAllowed ) {
+				alert( woo_localized_data.too_many_for_cat );
+				jQuery( '#add-multiple-question-count' ).focus();
+				return false;
+			}
+
+			if (
+				jQuery( '#add-multiple-question-category-options' ).val() != ''
+			) {
+				questionCategory = jQuery(
+					'#add-multiple-question-category-options'
+				).val();
+			} // End If Statement
+			dataToPost += '&' + 'question_category' + '=' + questionCategory;
+
+			var questionCount = parseInt( jQuery( '#question_counter' ).val() );
+			dataToPost += '&' + 'question_count' + '=' + questionCount;
+
+			if ( questionCategory && questionNumber ) {
+				// Perform the AJAX call.
+				jQuery.post(
+					ajaxurl,
+					{
+						action: 'lesson_add_multiple_questions',
+						lesson_add_multiple_questions_nonce:
+							woo_localized_data.lesson_add_multiple_questions_nonce,
+						data: dataToPost,
+					},
+					function ( response ) {
+						// Check for a valid response
+						if ( response ) {
+							jQuery(
+								'#add-multiple-question-category-options'
+							).val( '' );
+							jQuery( '#add-multiple-question-count' ).val( '1' );
+
+							jQuery.fn.updateQuestionCount(
+								questionNumber,
+								'+'
+							);
+							jQuery( '#add-question-metadata table' ).append(
+								response
+							);
+
+							jQuery.fn.updateQuestionOrder();
+
+							var max_questions = jQuery(
+								'#show_questions'
+							).attr( 'max' );
+							max_questions += questionNumber;
+							jQuery( '#show_questions' ).attr(
+								'max',
+								max_questions
+							);
+
+							jQuery.fn.scrollToElement( '#lesson-quiz' );
+						}
+					}
+				);
+				return false;
+			} else {
+				jQuery( '#add-multiple-question-category-options' ).focus();
+			}
+		}
+	);
 
 	/**
 	 * Edit Question Save Click Event - Ajax.
@@ -845,137 +1140,288 @@ jQuery(document).ready( function() {
 	 * @since 1.0.0
 	 * @access public
 	 */
-	jQuery( '#add-question-metadata' ).on( 'click', 'a.question_table_save', function() {
-		var dataToPost = '';
-		var tableRowId = '';
-		var questionType;
-		var questionGrade;
-		var validInput = jQuery.fn.validateQuestionInput( 'edit', jQuery(this) );
-		if ( validInput ) {
-			// Setup the data to post
-			dataToPost += 'quiz_id' + '=' + jQuery( '#quiz_id' ).attr( 'value' );
-			dataToPost += '&action=save';
-			jQuery( this ).closest( 'td' ).children( 'input' ).each( function() {
-				dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( this ).attr( 'value' ) );
-			});
-			tableRowId = jQuery( this ).closest('td').find('span.question_original_counter').text();
-			if ( jQuery( this ).closest('td').find( 'input.question_type' ).val() != '' ) {
-				questionType = jQuery( this ).closest('td').find( 'input.question_type' ).val();
-			} // End If Statement
-			var divFieldsClass = 'question_default_fields';
-			switch ( questionType ) {
-			case 'multiple-choice':
-				divFieldsClass = 'question_default_fields';
-				break;
-			case 'boolean':
-				divFieldsClass = 'question_boolean_fields';
-				break;
-			case 'gap-fill':
-				divFieldsClass = 'question_gapfill_fields';
-				break;
-			case 'essay-paste':
-				divFieldsClass = 'question_essay_fields';
-				break;
-			case 'multi-line':
-				divFieldsClass = 'question_multiline_fields';
-				break;
-			case 'single-line':
-				divFieldsClass = 'question_singleline_fields';
-				break;
-			case 'file-upload':
-				divFieldsClass = 'question_fileupload_fields';
-				break;
-			} // End Switch Statement
-			// Handle Required Fields
-			jQuery( this ).closest('td').find( 'div.question_required_fields' ).find( 'input' ).each( function() {
-				if ( jQuery( this ).attr( 'type' ) != 'radio' ) {
-					dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( this ).attr( 'value' ) );
-				} // End If Statement
-			});
-
-			// Handle textarea required field
-			if ( jQuery( this ).closest('td').find( 'div.question_required_fields' ).find( 'textarea' ).val() != '' ) {
-				dataToPost += '&' +  jQuery(this).closest('td').find( 'div.question_required_fields' ).find( 'textarea' ).attr( 'name' ) + '=' + encodeURIComponent( jQuery(this).closest('td').find( 'div.question_required_fields' ).find( 'textarea' ).val() );
-			} // End If Statement
-
-			// Handle Question Input Fields
-			var radioCount = 0;
-			jQuery( this ).closest('td').find( 'div.' + divFieldsClass ).find( 'input' ).each( function() {
-				if ( jQuery( this ).attr( 'type' ) == 'radio' ) {
-					// Only get the selected radio button
-					if ( radioCount == 0 ) {
-						dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( 'input[name=' + jQuery( this ).attr( 'name' ) + ']:checked' ).attr( 'value' ) );
-						radioCount++;
-					} // End If Statement
-				} else {
-					dataToPost += '&' + jQuery( this ).attr( 'name' ) + '=' + encodeURIComponent( jQuery( this ).attr( 'value' ) );
-				} // End If Statement
-			});
-
-			// Handle Question Textarea Fields
-			if ( jQuery(this).closest('td').find( 'div.' + divFieldsClass ).find( 'textarea' ).val() != '' && divFieldsClass == 'question_multiline_fields' ) {
-				dataToPost += '&' +  jQuery(this).closest('td').find( 'div.' + divFieldsClass ).find( 'textarea' ).attr( 'name' ) + '=' + encodeURIComponent( jQuery(this).closest('td').find( 'div.' + divFieldsClass ).find( 'textarea' ).val() );
-			} // End If Statement
-			if ( divFieldsClass == 'question_fileupload_fields' ) {
-				jQuery(this).closest('td').find( 'div.' + divFieldsClass ).find( 'textarea' ).each( function() {
-					dataToPost += '&' +  jQuery(this).attr( 'name' ) + '=' + encodeURIComponent( jQuery(this).val() );
-				});
-			} // End If Statement
-
-			dataToPost += '&' + 'question_type' + '=' + questionType;
-			questionGrade = jQuery( this ).closest('td').find( 'input.question_grade' ).val();
-			dataToPost += '&' + 'question_grade' + '=' + questionGrade;
-
-			var questionCount = parseInt( jQuery( '#question_counter' ).attr( 'value' ) );
-			dataToPost += '&' + 'question_count' + '=' + questionCount;
-
-			var answer_order = jQuery( this ).closest('td').find( '.answer_order' ).attr( 'value' );
-			dataToPost += '&' + 'answer_order' + '=' + answer_order;
-
-			var question_media = jQuery( this ).closest('td').find( '.question_media' ).attr( 'value' );
-			dataToPost += '&' + 'question_media' + '=' + question_media;
-
-			if ( '' != jQuery( this ).closest('td').find( '.answer_feedback' ).exists() ) {
-				var answer_feedback = jQuery( this ).closest('td').find( '.answer_feedback' ).attr( 'value' );
-				dataToPost += '&' + 'answer_feedback' + '=' + encodeURIComponent( answer_feedback );
-			}
-
-			var random_order = 'no';
-			if ( jQuery( this ).closest('td').find( '.random_order' ).is(':checked') ) {
-				random_order = 'yes';
-			}
-			dataToPost += '&' + 'random_order' + '=' + random_order;
-
-			// Perform the AJAX call.
-			jQuery.post(
-				ajaxurl,
-				{
-					action : 'lesson_update_question',
-					lesson_update_question_nonce : woo_localized_data.lesson_update_question_nonce,
-					data : dataToPost
-				},
-				function( response ) {
-					if ( response ) {
-
-						// show the user the of the succesful update:
-						var newQuestionTitle , newGradeTotal;
-
-						// update the question title :
-						newQuestionTitle = jQuery( '#question_' + tableRowId ).closest('tr').find('.question_required_fields input[name=question] ').val();
-						jQuery( '#question_' + tableRowId ).closest('tr').prev().find('.question-title-column').html( newQuestionTitle );
-
-						// update the grade total
-						newGradeTotal = jQuery( '#question_' + tableRowId ).closest('tr').find('.question_required_fields input[name=question_grade] ').val();
-						jQuery( '#question_' + tableRowId ).closest('tr').prev().find('.question-grade-column').html( newGradeTotal );
-
-						// hide the update field
-						jQuery( '#question_' + tableRowId ).closest('tr').addClass( 'hidden' );
-					}
-				}
+	jQuery( '#add-question-metadata' ).on(
+		'click',
+		'a.question_table_save',
+		function () {
+			var dataToPost = '';
+			var tableRowId = '';
+			var questionType;
+			var questionGrade;
+			var validInput = jQuery.fn.validateQuestionInput(
+				'edit',
+				jQuery( this )
 			);
-			return false;
+			if ( validInput ) {
+				// Setup the data to post
+				dataToPost += 'quiz_id' + '=' + jQuery( '#quiz_id' ).val();
+				dataToPost += '&action=save';
+				jQuery( this )
+					.closest( 'td' )
+					.children( 'input' )
+					.each( function () {
+						dataToPost +=
+							'&' +
+							jQuery( this ).attr( 'name' ) +
+							'=' +
+							encodeURIComponent( jQuery( this ).val() );
+					} );
+				tableRowId = jQuery( this )
+					.closest( 'td' )
+					.find( 'span.question_original_counter' )
+					.text();
+				if (
+					jQuery( this )
+						.closest( 'td' )
+						.find( 'input.question_type' )
+						.val() != ''
+				) {
+					questionType = jQuery( this )
+						.closest( 'td' )
+						.find( 'input.question_type' )
+						.val();
+				} // End If Statement
+				var divFieldsClass = 'question_default_fields';
+				switch ( questionType ) {
+					case 'multiple-choice':
+						divFieldsClass = 'question_default_fields';
+						break;
+					case 'boolean':
+						divFieldsClass = 'question_boolean_fields';
+						break;
+					case 'gap-fill':
+						divFieldsClass = 'question_gapfill_fields';
+						break;
+					case 'essay-paste':
+						divFieldsClass = 'question_essay_fields';
+						break;
+					case 'multi-line':
+						divFieldsClass = 'question_multiline_fields';
+						break;
+					case 'single-line':
+						divFieldsClass = 'question_singleline_fields';
+						break;
+					case 'file-upload':
+						divFieldsClass = 'question_fileupload_fields';
+						break;
+				} // End Switch Statement
+				// Handle Required Fields
+				jQuery( this )
+					.closest( 'td' )
+					.find( 'div.question_required_fields' )
+					.find( 'input' )
+					.each( function () {
+						if ( jQuery( this ).attr( 'type' ) != 'radio' ) {
+							dataToPost +=
+								'&' +
+								jQuery( this ).attr( 'name' ) +
+								'=' +
+								encodeURIComponent( jQuery( this ).val() );
+						} // End If Statement
+					} );
+
+				// Handle textarea required field
+				if (
+					jQuery( this )
+						.closest( 'td' )
+						.find( 'div.question_required_fields' )
+						.find( 'textarea' )
+						.val() != ''
+				) {
+					dataToPost +=
+						'&' +
+						jQuery( this )
+							.closest( 'td' )
+							.find( 'div.question_required_fields' )
+							.find( 'textarea' )
+							.attr( 'name' ) +
+						'=' +
+						encodeURIComponent(
+							jQuery( this )
+								.closest( 'td' )
+								.find( 'div.question_required_fields' )
+								.find( 'textarea' )
+								.val()
+						);
+				} // End If Statement
+
+				// Handle Question Input Fields
+				var radioCount = 0;
+				jQuery( this )
+					.closest( 'td' )
+					.find( 'div.' + divFieldsClass )
+					.find( 'input' )
+					.each( function () {
+						if ( jQuery( this ).attr( 'type' ) == 'radio' ) {
+							// Only get the selected radio button
+							if ( radioCount == 0 ) {
+								dataToPost +=
+									'&' +
+									jQuery( this ).attr( 'name' ) +
+									'=' +
+									encodeURIComponent(
+										jQuery(
+											'input[name=' +
+												jQuery( this ).attr( 'name' ) +
+												']:checked'
+										).val()
+									);
+								radioCount++;
+							} // End If Statement
+						} else {
+							dataToPost +=
+								'&' +
+								jQuery( this ).attr( 'name' ) +
+								'=' +
+								encodeURIComponent( jQuery( this ).val() );
+						} // End If Statement
+					} );
+
+				// Handle Question Textarea Fields
+				if (
+					jQuery( this )
+						.closest( 'td' )
+						.find( 'div.' + divFieldsClass )
+						.find( 'textarea' )
+						.val() != '' &&
+					divFieldsClass == 'question_multiline_fields'
+				) {
+					dataToPost +=
+						'&' +
+						jQuery( this )
+							.closest( 'td' )
+							.find( 'div.' + divFieldsClass )
+							.find( 'textarea' )
+							.attr( 'name' ) +
+						'=' +
+						encodeURIComponent(
+							jQuery( this )
+								.closest( 'td' )
+								.find( 'div.' + divFieldsClass )
+								.find( 'textarea' )
+								.val()
+						);
+				} // End If Statement
+				if ( divFieldsClass == 'question_fileupload_fields' ) {
+					jQuery( this )
+						.closest( 'td' )
+						.find( 'div.' + divFieldsClass )
+						.find( 'textarea' )
+						.each( function () {
+							dataToPost +=
+								'&' +
+								jQuery( this ).attr( 'name' ) +
+								'=' +
+								encodeURIComponent( jQuery( this ).val() );
+						} );
+				} // End If Statement
+
+				dataToPost += '&' + 'question_type' + '=' + questionType;
+				questionGrade = jQuery( this )
+					.closest( 'td' )
+					.find( 'input.question_grade' )
+					.val();
+				dataToPost += '&' + 'question_grade' + '=' + questionGrade;
+
+				var questionCount = parseInt(
+					jQuery( '#question_counter' ).val()
+				);
+				dataToPost += '&' + 'question_count' + '=' + questionCount;
+
+				var answer_order = jQuery( this )
+					.closest( 'td' )
+					.find( '.answer_order' )
+					.val();
+				dataToPost += '&' + 'answer_order' + '=' + answer_order;
+
+				var question_media = jQuery( this )
+					.closest( 'td' )
+					.find( '.question_media' )
+					.val();
+				dataToPost += '&' + 'question_media' + '=' + question_media;
+
+				if (
+					'' !=
+					jQuery( this )
+						.closest( 'td' )
+						.find( '.answer_feedback' )
+						.exists()
+				) {
+					var answer_feedback = jQuery( this )
+						.closest( 'td' )
+						.find( '.answer_feedback' )
+						.val();
+					dataToPost +=
+						'&' +
+						'answer_feedback' +
+						'=' +
+						encodeURIComponent( answer_feedback );
+				}
+
+				var random_order = 'no';
+				if (
+					jQuery( this )
+						.closest( 'td' )
+						.find( '.random_order' )
+						.is( ':checked' )
+				) {
+					random_order = 'yes';
+				}
+				dataToPost += '&' + 'random_order' + '=' + random_order;
+
+				// Perform the AJAX call.
+				jQuery.post(
+					ajaxurl,
+					{
+						action: 'lesson_update_question',
+						lesson_update_question_nonce:
+							woo_localized_data.lesson_update_question_nonce,
+						data: dataToPost,
+					},
+					function ( response ) {
+						if ( response ) {
+							// show the user the of the succesful update:
+							var newQuestionTitle, newGradeTotal;
+
+							// update the question title :
+							newQuestionTitle = jQuery(
+								'#question_' + tableRowId
+							)
+								.closest( 'tr' )
+								.find(
+									'.question_required_fields input[name=question] '
+								)
+								.val();
+							jQuery( '#question_' + tableRowId )
+								.closest( 'tr' )
+								.prev()
+								.find( '.question-title-column' )
+								.html( newQuestionTitle );
+
+							// update the grade total
+							newGradeTotal = jQuery( '#question_' + tableRowId )
+								.closest( 'tr' )
+								.find(
+									'.question_required_fields input[name=question_grade] '
+								)
+								.val();
+							jQuery( '#question_' + tableRowId )
+								.closest( 'tr' )
+								.prev()
+								.find( '.question-grade-column' )
+								.html( newGradeTotal );
+
+							// hide the update field
+							jQuery( '#question_' + tableRowId )
+								.closest( 'tr' )
+								.addClass( 'hidden' );
+						}
+					}
+				);
+				return false;
+			}
 		}
-	});
+	);
 
 	/**
 	 * Remove Question Click Event - Ajax.
@@ -983,63 +1429,97 @@ jQuery(document).ready( function() {
 	 * @since 1.0.0
 	 * @access public
 	 */
-	jQuery( '#add-question-metadata' ).on( 'click', 'a.question_table_delete', function() {
-		var dataToPost = '';
-		var tableRowId = '';
+	jQuery( '#add-question-metadata' ).on(
+		'click',
+		'a.question_table_delete',
+		function () {
+			var dataToPost = '';
+			var tableRowId = '';
 
-		var confirmDelete = confirm( woo_localized_data.confirm_remove );
+			var confirmDelete = confirm( woo_localized_data.confirm_remove );
 
-		if ( confirmDelete ) {
-			// Setup data to post
-			dataToPost += '&action=delete';
-			jQuery( this ).closest('tr').next('tr').find('td').find( 'input' ).each( function() {
-				if ( jQuery( this ).attr( 'name' ) == 'question_id' ) {
-					dataToPost += '&question_id' + '=' + jQuery( this ).attr( 'value' );
-				} // End If Statement
-			});
+			if ( confirmDelete ) {
+				// Setup data to post
+				dataToPost += '&action=delete';
+				jQuery( this )
+					.closest( 'tr' )
+					.next( 'tr' )
+					.find( 'td' )
+					.find( 'input' )
+					.each( function () {
+						if ( jQuery( this ).attr( 'name' ) == 'question_id' ) {
+							dataToPost +=
+								'&question_id' + '=' + jQuery( this ).val();
+						} // End If Statement
+					} );
 
-			dataToPost += '&quiz_id' + '=' + jQuery( '#quiz_id' ).attr( 'value' );
+				dataToPost += '&quiz_id' + '=' + jQuery( '#quiz_id' ).val();
 
-			tableRowId = jQuery( this ).closest('tr').find('td.question-number span.number').text();
-			var row_parent = jQuery( this ).closest( 'tbody' );
+				tableRowId = jQuery( this )
+					.closest( 'tr' )
+					.find( 'td.question-number span.number' )
+					.text();
+				var row_parent = jQuery( this ).closest( 'tbody' );
 
-			// Perform the AJAX call.
-			jQuery.post(
-				ajaxurl,
-				{
-					action : 'lesson_update_question',
-					lesson_update_question_nonce : woo_localized_data.lesson_update_question_nonce,
-					data : dataToPost
-				},
-				function( response ) {
-					if ( response ) {
-						// Remove the html element for the deleted question
-						jQuery( '#add-question-metadata > table > tbody > tr' ).children('td').each( function() {
-							if ( jQuery(this).find('span.number').text() == tableRowId ) {
-								jQuery(this).closest('tr').next('tr').remove();
-								jQuery(this).closest('tr').remove();
-								// Exit each() to prevent multiple row deletions
-								return false;
+				// Perform the AJAX call.
+				jQuery.post(
+					ajaxurl,
+					{
+						action: 'lesson_update_question',
+						lesson_update_question_nonce:
+							woo_localized_data.lesson_update_question_nonce,
+						data: dataToPost,
+					},
+					function ( response ) {
+						if ( response ) {
+							// Remove the html element for the deleted question
+							jQuery(
+								'#add-question-metadata > table > tbody > tr'
+							)
+								.children( 'td' )
+								.each( function () {
+									if (
+										jQuery( this )
+											.find( 'span.number' )
+											.text() == tableRowId
+									) {
+										jQuery( this )
+											.closest( 'tr' )
+											.next( 'tr' )
+											.remove();
+										jQuery( this ).closest( 'tr' ).remove();
+										// Exit each() to prevent multiple row deletions
+										return false;
+									}
+								} );
+							jQuery.fn.updateQuestionCount( 1, '-' );
+							jQuery.fn.checkQuizGradeType( false );
+							jQuery.fn.updateAnswerOrder( row_parent );
+
+							var max_questions = parseInt(
+								jQuery( '#show_questions' ).attr( 'max' )
+							);
+							max_questions--;
+							jQuery( '#show_questions' ).attr(
+								'max',
+								max_questions
+							);
+
+							var show_questions_field = parseInt(
+								jQuery( '#show_questions' ).val()
+							);
+							if ( show_questions_field > max_questions ) {
+								jQuery( '#show_questions' ).val(
+									max_questions
+								);
 							}
-						});
-						jQuery.fn.updateQuestionCount( 1, '-' );
-						jQuery.fn.checkQuizGradeType( false );
-						jQuery.fn.updateAnswerOrder( row_parent );
-
-						var max_questions = parseInt( jQuery( '#show_questions' ).attr( 'max' ) );
-						max_questions--;
-						jQuery( '#show_questions' ).attr( 'max', max_questions );
-
-						var show_questions_field = parseInt( jQuery( '#show_questions' ).val() );
-						if( show_questions_field > max_questions ) {
-							jQuery( '#show_questions' ).val( max_questions );
 						}
 					}
-				}
-			);
-			return false;
+				);
+				return false;
+			}
 		}
-	});
+	);
 
 	/**
 	 * Remove Multple Questions Row Click Event - Ajax.
@@ -1047,54 +1527,83 @@ jQuery(document).ready( function() {
 	 * @since 1.6.0
 	 * @access public
 	 */
-	jQuery( '#add-question-metadata' ).on( 'click', 'a.question_multiple_delete', function() {
-		var dataToPost = '';
+	jQuery( '#add-question-metadata' ).on(
+		'click',
+		'a.question_multiple_delete',
+		function () {
+			var dataToPost = '';
 
-		var confirmDelete = confirm( woo_localized_data.confirm_remove_multiple );
+			var confirmDelete = confirm(
+				woo_localized_data.confirm_remove_multiple
+			);
 
-		if ( confirmDelete ) {
+			if ( confirmDelete ) {
+				dataToPost +=
+					'question_id' + '=' + jQuery( this ).attr( 'rel' );
+				dataToPost += '&quiz_id' + '=' + jQuery( '#quiz_id' ).val();
 
-			dataToPost += 'question_id' + '=' + jQuery( this ).attr( 'rel' );
-			dataToPost += '&quiz_id' + '=' + jQuery( '#quiz_id' ).attr( 'value' );
+				var tableRowId = jQuery( this )
+					.closest( 'tr' )
+					.find( 'td.question-number span.number' )
+					.text();
+				var total_number = jQuery( this )
+					.closest( 'tr' )
+					.find( 'td.question-number span.total-number' )
+					.text();
 
-			var tableRowId = jQuery( this ).closest('tr').find('td.question-number span.number').text();
-			var total_number = jQuery( this ).closest('tr').find('td.question-number span.total-number').text();
+				// Perform the AJAX call.
+				jQuery.post(
+					ajaxurl,
+					{
+						action: 'lesson_remove_multiple_questions',
+						lesson_remove_multiple_questions_nonce:
+							woo_localized_data.lesson_remove_multiple_questions_nonce,
+						data: dataToPost,
+					},
+					function ( response ) {
+						if ( response ) {
+							// Remove the html element for the deleted question
+							jQuery(
+								'#add-question-metadata > table > tbody > tr'
+							)
+								.children( 'td' )
+								.each( function () {
+									if (
+										jQuery( this )
+											.find( 'span.number' )
+											.text() == tableRowId
+									) {
+										jQuery( this ).closest( 'tr' ).remove();
+										// Exit each() to prevent multiple row deletions
+										return false;
+									}
+								} );
+							jQuery.fn.updateQuestionCount( total_number, '-' );
 
-			// Perform the AJAX call.
-			jQuery.post(
-				ajaxurl,
-				{
-					action : 'lesson_remove_multiple_questions',
-					lesson_remove_multiple_questions_nonce : woo_localized_data.lesson_remove_multiple_questions_nonce,
-					data : dataToPost
-				},
-				function( response ) {
-					if ( response ) {
+							var max_questions = parseInt(
+								jQuery( '#show_questions' ).attr( 'max' )
+							);
+							max_questions -= total_number;
+							jQuery( '#show_questions' ).attr(
+								'max',
+								max_questions
+							);
 
-						// Remove the html element for the deleted question
-						jQuery( '#add-question-metadata > table > tbody > tr' ).children('td').each( function() {
-							if ( jQuery(this).find('span.number').text() == tableRowId ) {
-								jQuery(this).closest('tr').remove();
-								// Exit each() to prevent multiple row deletions
-								return false;
+							var show_questions_field = parseInt(
+								jQuery( '#show_questions' ).val()
+							);
+							if ( show_questions_field > max_questions ) {
+								jQuery( '#show_questions' ).val(
+									max_questions
+								);
 							}
-						});
-						jQuery.fn.updateQuestionCount( total_number, '-' );
-
-						var max_questions = parseInt( jQuery( '#show_questions' ).attr( 'max' ) );
-						max_questions -= total_number;
-						jQuery( '#show_questions' ).attr( 'max', max_questions );
-
-						var show_questions_field = parseInt( jQuery( '#show_questions' ).val() );
-						if( show_questions_field > max_questions ) {
-							jQuery( '#show_questions' ).val( max_questions );
 						}
 					}
-				}
-			);
-			return false;
+				);
+				return false;
+			}
 		}
-	});
+	);
 
 	/**
 	 * Add Existing Questions Click Event - Ajax.
@@ -1102,168 +1611,242 @@ jQuery(document).ready( function() {
 	 * @since 1.6.0
 	 * @access public
 	 */
-	jQuery( '#add-new-question' ).on( 'click', 'a.add_existing_save', function() {
-		var questions = '';
-		var dataToPost = '';
-		var i = 0;
-		jQuery( '#existing-questions' ).find( 'input.existing-item' ).each( function() {
-			if( jQuery( this ).is( ':checked' ) ) {
-				var question_id = jQuery( this ).val();
-				questions += question_id + ',';
-				++i;
-			}
-		});
-
-		if( questions ) {
-
-			dataToPost = 'questions=' + questions;
-			dataToPost += '&quiz_id=' + jQuery( '#quiz_id' ).attr( 'value' );
-
-			var questionCount = parseInt( jQuery( '#question_counter' ).attr( 'value' ) );
-			dataToPost += '&question_count=' + questionCount;
-
-			// Perform the AJAX call.
-			jQuery.post(
-				ajaxurl,
-				{
-					action : 'lesson_add_existing_questions',
-					lesson_add_existing_questions_nonce : woo_localized_data.lesson_add_existing_questions_nonce,
-					data : dataToPost
-				},
-				function( response ) {
-					if ( response ) {
-
-						jQuery.fn.updateQuestionCount( i, '+' );
-						jQuery( '#add-question-metadata table' ).append( response );
-
-						jQuery.fn.checkQuizGradeType();
-
-						var max_questions = jQuery( '#show_questions' ).attr( 'max' );
-						max_questions += i;
-						jQuery( '#show_questions' ).attr( 'max', max_questions );
-
-						jQuery.fn.scrollToElement( '#lesson-quiz' );
-
-						jQuery( '#existing-questions' ).find( 'input.existing-item' ).each( function() {
-							jQuery( this ).removeAttr( 'checked' );
-						});
+	jQuery( '#add-new-question' ).on(
+		'click',
+		'a.add_existing_save',
+		function () {
+			var questions = '';
+			var dataToPost = '';
+			var i = 0;
+			jQuery( '#existing-questions' )
+				.find( 'input.existing-item' )
+				.each( function () {
+					if ( jQuery( this ).is( ':checked' ) ) {
+						var question_id = jQuery( this ).val();
+						questions += question_id + ',';
+						++i;
 					}
-				}
-			);
-			return false;
+				} );
+
+			if ( questions ) {
+				dataToPost = 'questions=' + questions;
+				dataToPost += '&quiz_id=' + jQuery( '#quiz_id' ).val();
+
+				var questionCount = parseInt(
+					jQuery( '#question_counter' ).val()
+				);
+				dataToPost += '&question_count=' + questionCount;
+
+				// Perform the AJAX call.
+				jQuery.post(
+					ajaxurl,
+					{
+						action: 'lesson_add_existing_questions',
+						lesson_add_existing_questions_nonce:
+							woo_localized_data.lesson_add_existing_questions_nonce,
+						data: dataToPost,
+					},
+					function ( response ) {
+						if ( response ) {
+							jQuery.fn.updateQuestionCount( i, '+' );
+							jQuery( '#add-question-metadata table' ).append(
+								response
+							);
+
+							jQuery.fn.checkQuizGradeType();
+
+							var max_questions = jQuery(
+								'#show_questions'
+							).attr( 'max' );
+							max_questions += i;
+							jQuery( '#show_questions' ).attr(
+								'max',
+								max_questions
+							);
+
+							jQuery.fn.scrollToElement( '#lesson-quiz' );
+
+							jQuery( '#existing-questions' )
+								.find( 'input.existing-item' )
+								.each( function () {
+									jQuery( this ).removeAttr( 'checked' );
+								} );
+						}
+					}
+				);
+				return false;
+			}
 		}
-	});
+	);
 
-	jQuery( '#existing-filter-button' ).click( function() {
-		jQuery.fn.filterExistingQuestions(1);
-	});
+	jQuery( '#existing-filter-button' ).click( function () {
+		jQuery.fn.filterExistingQuestions( 1 );
+	} );
 
-	jQuery( '#existing-pagination' ).on( 'click', 'a', function() {
+	jQuery( '#existing-pagination' ).on( 'click', 'a', function () {
 		var currentPage = parseInt( jQuery( '#existing-page' ).val() );
 		var newPage = currentPage;
-		if( jQuery( this ).hasClass( 'prev' ) ) {
+		if ( jQuery( this ).hasClass( 'prev' ) ) {
 			newPage = currentPage - 1;
-		} else if( jQuery( this ).hasClass( 'next' ) ) {
+		} else if ( jQuery( this ).hasClass( 'next' ) ) {
 			newPage = currentPage + 1;
 		}
 		newPage = parseInt( newPage );
 		jQuery.fn.filterExistingQuestions( newPage );
-	});
+	} );
 
-	jQuery( '#quiz-settings' ).on( 'change', '#pass_required', function() {
-		var checked = jQuery(this).attr( 'checked' );
-		if( 'checked' == checked ) {
+	jQuery( '#quiz-settings' ).on( 'change', '#pass_required', function () {
+		var checked = jQuery( this ).attr( 'checked' );
+		if ( 'checked' == checked ) {
 			jQuery( '.form-field.quiz_passmark' ).removeClass( 'hidden' );
 		} else {
 			jQuery( '.form-field.quiz_passmark' ).addClass( 'hidden' );
-			jQuery( '#quiz_passmark' ).val(0);
+			jQuery( '#quiz_passmark' ).val( 0 );
 		}
-	});
+	} );
 
-	jQuery( '#quiz-settings' ).on( 'change', '#random_question_order', function() {
-		jQuery.fn.saveQuestionOrderRandom();
-	});
+	jQuery( '#quiz-settings' ).on(
+		'change',
+		'#random_question_order',
+		function () {
+			jQuery.fn.saveQuestionOrderRandom();
+		}
+	);
 
-	jQuery( '#add-question-main' ).on( 'blur', '.question_answer', function() {
+	jQuery( '#add-question-main' ).on( 'blur', '.question_answer', function () {
 		var answer_value = jQuery( this ).val();
 		var answer_field = jQuery( this );
 
 		jQuery.get(
 			ajaxurl,
 			{
-				action : 'question_get_answer_id',
+				action: 'question_get_answer_id',
 				answer_value: answer_value,
 			},
-			function( response ) {
+			function ( response ) {
 				if ( response ) {
 					answer_field.attr( 'rel', response );
-					jQuery.fn.updateAnswerOrder( answer_field.closest( 'div' ) );
+					jQuery.fn.updateAnswerOrder(
+						answer_field.closest( 'div' )
+					);
 				}
 			}
 		);
 
 		return false;
-	});
+	} );
 
-	jQuery( '#add-question-main' ).on( 'click', '.add_wrong_answer_option', function() {
-		var question_counter = jQuery( this ).attr( 'rel' );
-		var answer_count = jQuery('input[name="question_wrong_answers[]"]').length-1;
-		answer_count++;
-		var html = '<label class="answer" for="question_' + question_counter + '_wrong_answer_' + answer_count + '"><span>' + woo_localized_data.wrong_colon + '</span> <input type="text" id="question_' + question_counter + '_wrong_answer_' + answer_count + '" name="question_wrong_answers[]" value="" size="25" class="question_answer widefat" /> <a class="remove_answer_option"></a></label>';
-		jQuery( this ).closest( 'div' ).before( html );
-	});
+	jQuery( '#add-question-main' ).on(
+		'click',
+		'.add_wrong_answer_option',
+		function () {
+			var question_counter = jQuery( this ).attr( 'rel' );
+			var answer_count =
+				jQuery( 'input[name="question_wrong_answers[]"]' ).length - 1;
+			answer_count++;
+			var html =
+				'<label class="answer" for="question_' +
+				question_counter +
+				'_wrong_answer_' +
+				answer_count +
+				'"><span>' +
+				woo_localized_data.wrong_colon +
+				'</span> <input type="text" id="question_' +
+				question_counter +
+				'_wrong_answer_' +
+				answer_count +
+				'" name="question_wrong_answers[]" value="" size="25" class="question_answer widefat" /> <a class="remove_answer_option"></a></label>';
+			jQuery( this ).closest( 'div' ).before( html );
+		}
+	);
 
-	jQuery( '#add-question-main' ).on( 'click', '.add_right_answer_option', function() {
-		var question_counter = jQuery( this ).attr( 'rel' );
-		var answer_count = jQuery('input[name="question_right_answers[]"]').length-1;
-		answer_count++;
-		var html = '<label class="answer" for="question_' + question_counter + '_right_answer_' + answer_count + '"><span>' + woo_localized_data.right_colon + '</span> <input type="text" id="question_' + question_counter + '_right_answer_' + answer_count + '" name="question_right_answers[]" value="" size="25" class="question_answer widefat" /> <a class="remove_answer_option"></a></label>';
-		jQuery( this ).closest( 'div' ).before( html );
-	});
+	jQuery( '#add-question-main' ).on(
+		'click',
+		'.add_right_answer_option',
+		function () {
+			var question_counter = jQuery( this ).attr( 'rel' );
+			var answer_count =
+				jQuery( 'input[name="question_right_answers[]"]' ).length - 1;
+			answer_count++;
+			var html =
+				'<label class="answer" for="question_' +
+				question_counter +
+				'_right_answer_' +
+				answer_count +
+				'"><span>' +
+				woo_localized_data.right_colon +
+				'</span> <input type="text" id="question_' +
+				question_counter +
+				'_right_answer_' +
+				answer_count +
+				'" name="question_right_answers[]" value="" size="25" class="question_answer widefat" /> <a class="remove_answer_option"></a></label>';
+			jQuery( this ).closest( 'div' ).before( html );
+		}
+	);
 
-	jQuery( '#add-question-main' ).on( 'click', '.remove_answer_option', function() {
-		jQuery( this ).closest( 'label.answer' ).remove();
-	});
+	jQuery( '#add-question-main' ).on(
+		'click',
+		'.remove_answer_option',
+		function () {
+			jQuery( this ).closest( 'label.answer' ).remove();
+		}
+	);
 
 	jQuery( '.multiple-choice-answers' ).sortable( {
-		items: 'label.answer'
-	});
+		items: 'label.answer',
+	} );
 
 	jQuery( '.multiple-choice-answers' ).bind( 'sortstop', function () {
 		jQuery.fn.updateAnswerOrder( jQuery( this ) );
-	});
+	} );
 
 	jQuery( '#sortable-questions' ).sortable( {
 		items: 'tbody',
-		'start': function (event, ui) {
-			ui.placeholder.html('<tr><td colspan=\'5\'>&nbsp;</td></tr>');
-		}
-	});
+		start: function ( event, ui ) {
+			ui.placeholder.html( "<tr><td colspan='5'>&nbsp;</td></tr>" );
+		},
+	} );
 
 	jQuery( '#sortable-questions' ).bind( 'sortstop', function () {
 		jQuery.fn.updateQuestionOrder();
 		jQuery.fn.updateQuestionRows();
-	});
+	} );
 
-	jQuery('#add-question-main').on( 'click', '.upload_media_file_button', function( event ) {
-		event.preventDefault();
-		jQuery.fn.uploadQuestionMedia( jQuery( this ) );
-	});
+	jQuery( '#add-question-main' ).on(
+		'click',
+		'.upload_media_file_button',
+		function ( event ) {
+			event.preventDefault();
+			jQuery.fn.uploadQuestionMedia( jQuery( this ) );
+		}
+	);
 
-	jQuery('#add-question-main').on( 'click', '.delete_media_file_button', function( event ) {
-		event.preventDefault();
-		jQuery.fn.deleteQuestionMedia( jQuery( this ) );
-	});
+	jQuery( '#add-question-main' ).on(
+		'click',
+		'.delete_media_file_button',
+		function ( event ) {
+			event.preventDefault();
+			jQuery.fn.deleteQuestionMedia( jQuery( this ) );
+		}
+	);
 
-	jQuery('#add-question-main').on( 'click', '.question_media_preview', function( event ) {
-		event.preventDefault();
-		jQuery.fn.uploadQuestionMedia( jQuery( this ).closest( 'div' ).find( '.upload_media_file_button' ) );
-	});
+	jQuery( '#add-question-main' ).on(
+		'click',
+		'.question_media_preview',
+		function ( event ) {
+			event.preventDefault();
+			jQuery.fn.uploadQuestionMedia(
+				jQuery( this )
+					.closest( 'div' )
+					.find( '.upload_media_file_button' )
+			);
+		}
+	);
 
 	jQuery( '#add-new-question .tab-content:not(:first)' ).addClass( 'hidden' );
 
-	jQuery( '.add-question-tabs .nav-tab' ).click( function() {
-		var tab_id = jQuery( this ).attr('id');
+	jQuery( '.add-question-tabs .nav-tab' ).click( function () {
+		var tab_id = jQuery( this ).attr( 'id' );
 		var tab_content_id = tab_id + '-content';
 
 		jQuery( '#add-new-question .nav-tab' ).removeClass( 'nav-tab-active' );
@@ -1271,60 +1854,96 @@ jQuery(document).ready( function() {
 
 		jQuery( '#add-new-question .tab-content' ).addClass( 'hidden' );
 		jQuery( '#' + tab_content_id ).removeClass( 'hidden' );
-	});
+	} );
 
-	jQuery( '#add-multiple-question-category-options' ).change( function() {
+	jQuery( '#add-multiple-question-category-options' ).change( function () {
 		var cat = jQuery( this ).val();
 
 		jQuery.get(
 			ajaxurl,
 			{
-				action : 'get_question_category_limit',
+				action: 'get_question_category_limit',
 				cat: cat,
 			},
-			function( response ) {
+			function ( response ) {
 				if ( response ) {
 					var max = parseInt( response );
-					if( max ) {
-						jQuery( '#add-multiple-question-count' ).attr( 'max', max );
+					if ( max ) {
+						jQuery( '#add-multiple-question-count' ).attr(
+							'max',
+							max
+						);
 					}
 				}
 			}
 		);
-	});
+	} );
 
 	jQuery( '#existing-table th.check-column input' ).click( function () {
-		jQuery( '#existing-questions' ).find( ':checkbox' ).attr( 'checked' , this.checked );
-	});
+		jQuery( '#existing-questions' )
+			.find( ':checkbox' )
+			.attr( 'checked', this.checked );
+	} );
 
-	jQuery( 'tbody#existing-questions' ).on( 'click', 'tr td:not(.cb)', function() {
-		jQuery( this ).closest( 'tr' ).find( ':checkbox' ).each( function() {
-			jQuery( this ).prop( 'checked', ! jQuery( this ).prop( 'checked' ) );
-		});
-	});
+	jQuery( 'tbody#existing-questions' ).on(
+		'click',
+		'tr td:not(.cb)',
+		function () {
+			jQuery( this )
+				.closest( 'tr' )
+				.find( ':checkbox' )
+				.each( function () {
+					jQuery( this ).prop(
+						'checked',
+						! jQuery( this ).prop( 'checked' )
+					);
+				} );
+		}
+	);
 
 	/***************************************************************************************************
 	 * 	5 - Load Chosen Dropdowns.
 	 ***************************************************************************************************/
 
 	// Lessons Write Panel
-	if ( jQuery( '#lesson-complexity-options' ).exists() ) { jQuery( '#lesson-complexity-options' ).select2({width:'resolve'}); }
-	if ( jQuery( '#lesson-prerequisite-options' ).exists() ) { jQuery( '#lesson-prerequisite-options' ).select2({width:'resolve'}); }
-	if ( jQuery( '#lesson-course-options' ).exists() ) { jQuery( '#lesson-course-options' ).select2({width:'resolve'}); }
+	if ( jQuery( '#lesson-complexity-options' ).exists() ) {
+		jQuery( '#lesson-complexity-options' ).select2( { width: 'resolve' } );
+	}
+	if ( jQuery( '#lesson-prerequisite-options' ).exists() ) {
+		jQuery( '#lesson-prerequisite-options' ).select2( {
+			width: 'resolve',
+		} );
+	}
+	if ( jQuery( '#lesson-course-options' ).exists() ) {
+		jQuery( '#lesson-course-options' ).select2( { width: 'resolve' } );
+	}
 
 	// Quiz edit panel
-	if ( jQuery( '#add-question-type-options' ).exists() ) { jQuery( '#add-question-type-options' ).select2({width:'resolve'}); }
-	if ( jQuery( '#add-question-category-options' ).exists() ) { jQuery( '#add-question-category-options' ).select2({width:'resolve'}); }
-	if ( jQuery( '#add-multiple-question-options' ).exists() ) { jQuery( '#add-multiple-question-options' ).select2({width:'resolve'}); }
+	if ( jQuery( '#add-question-type-options' ).exists() ) {
+		jQuery( '#add-question-type-options' ).select2( { width: 'resolve' } );
+	}
+	if ( jQuery( '#add-question-category-options' ).exists() ) {
+		jQuery( '#add-question-category-options' ).select2( {
+			width: 'resolve',
+		} );
+	}
+	if ( jQuery( '#add-multiple-question-options' ).exists() ) {
+		jQuery( '#add-multiple-question-options' ).select2( {
+			width: 'resolve',
+		} );
+	}
 
 	// Courses Write Panel
-	if ( jQuery( '#add-multiple-question-category-options' ).exists() ) { jQuery( '#add-multiple-question-category-options' ).select2({width:'resolve'}); }
+	if ( jQuery( '#add-multiple-question-category-options' ).exists() ) {
+		jQuery( '#add-multiple-question-category-options' ).select2( {
+			width: 'resolve',
+		} );
+	}
 
 	// Sensei Settings Panel
-	jQuery( 'div.woothemes-sensei-settings form select' ).each( function() {
-		if ( !jQuery( this ).hasClass( 'range-input' ) ) {
-			jQuery( this).select2({width:'resolve'});
+	jQuery( 'div.woothemes-sensei-settings form select' ).each( function () {
+		if ( ! jQuery( this ).hasClass( 'range-input' ) ) {
+			jQuery( this ).select2( { width: 'resolve' } );
 		} // End If Statement
-	});
-
-});
+	} );
+} );

--- a/assets/js/modules-admin.js
+++ b/assets/js/modules-admin.js
@@ -7,60 +7,64 @@
  * @returns {string}
  */
 
-function getParameterByName(name) {
-	name = name.replace(/[\[]/, '\\[').replace(/[\]]/, '\\]');
-	var regex = new RegExp('[\\?&]' + name + '=([^&#]*)'),
-		results = regex.exec(location.search);
-	return results === null ? '' : decodeURIComponent(results[1].replace(/\+/g, ' '));
+function getParameterByName( name ) {
+	name = name.replace( /[\[]/, '\\[' ).replace( /[\]]/, '\\]' );
+	var regex = new RegExp( '[\\?&]' + name + '=([^&#]*)' ),
+		results = regex.exec( location.search );
+	return results === null
+		? ''
+		: decodeURIComponent( results[ 1 ].replace( /\+/g, ' ' ) );
 }
 
 jQuery( document ).ready( function () {
 	var _ = window._;
 
 	/**
-    * Add select to the modules select boxes
-    */
+	 * Add select to the modules select boxes
+	 */
 	// module order screen
-	jQuery( '#module-order-course' ).select2({width:'resolve'});
+	jQuery( '#module-order-course' ).select2( { width: 'resolve' } );
 
 	/**
-     * Sortable functionality
-     */
+	 * Sortable functionality
+	 */
 	jQuery( '.sortable-module-list' ).sortable();
 	jQuery( '.sortable-tab-list' ).disableSelection();
 
 	jQuery( '.sortable-module-list' ).bind( 'sortstop', function () {
 		var orderString = '';
 
-		jQuery( this ).find( '.module' ).each( function ( i ) {
-			if ( i > 0 ) { orderString += ','; }
-			orderString += jQuery( this ).find( 'span' ).attr( 'rel' );
-
-			jQuery( this ).removeClass( 'alternate' );
-			jQuery( this ).removeClass( 'first' );
-			jQuery( this ).removeClass( 'last' );
-			if( i == 0 ) {
-				jQuery( this ).addClass( 'first alternate' );
-			} else {
-				var r = ( i % 2 );
-				if( 0 == r ) {
-					jQuery( this ).addClass( 'alternate' );
+		jQuery( this )
+			.find( '.module' )
+			.each( function ( i ) {
+				if ( i > 0 ) {
+					orderString += ',';
 				}
-			}
+				orderString += jQuery( this ).find( 'span' ).attr( 'rel' );
 
-		});
+				jQuery( this ).removeClass( 'alternate' );
+				jQuery( this ).removeClass( 'first' );
+				jQuery( this ).removeClass( 'last' );
+				if ( i == 0 ) {
+					jQuery( this ).addClass( 'first alternate' );
+				} else {
+					var r = i % 2;
+					if ( 0 == r ) {
+						jQuery( this ).addClass( 'alternate' );
+					}
+				}
+			} );
 
-		jQuery( 'input[name="module-order"]' ).attr( 'value', orderString );
-	});
-
+		jQuery( 'input[name="module-order"]' ).val( orderString );
+	} );
 
 	/**
-     * Searching for courses on the modules admin edit screen
-     */
-	jQuery('select.ajax_chosen_select_courses').select2({
+	 * Searching for courses on the modules admin edit screen
+	 */
+	jQuery( 'select.ajax_chosen_select_courses' ).select2( {
 		minimumInputLength: 2,
 		placeholder: window.modulesAdmin.selectplaceholder,
-		width:'300px',
+		width: '300px',
 		multiple: true,
 		ajax: {
 			// in wp-admin ajaxurl is supplied by WordPress and is available globaly
@@ -68,67 +72,63 @@ jQuery( document ).ready( function () {
 			delay: 250,
 			dataType: 'json',
 			cache: true,
-			data: function (params) { // page is the one-based page number tracked by Select2
+			data: function ( params ) {
+				// page is the one-based page number tracked by Select2
 				return {
 					term: params.term, //search term
 					page: params.page || 1,
 					action: 'sensei_json_search_courses',
-					security: 	window.modulesAdmin.search_courses_nonce,
-					default: ''
+					security: window.modulesAdmin.search_courses_nonce,
+					default: '',
 				};
 			},
-			processResults: function (courses, page) {
-
+			processResults: function ( courses, page ) {
 				var validCourses = [];
-				jQuery.each( courses, function (i, val) {
-					if( ! jQuery.isEmptyObject( val )  ){
-						var validcourse = { id: i , text: val  };
+				jQuery.each( courses, function ( i, val ) {
+					if ( ! jQuery.isEmptyObject( val ) ) {
+						var validcourse = { id: i, text: val };
 						validCourses.push( validcourse );
 					}
-				});
+				} );
 				// wrap the users inside results for select 2 usage
 				return {
 					results: validCourses,
-					page: page
+					page: page,
 				};
-			}
-		}
-	}); // end select2
+			},
+		},
+	} ); // end select2
 
-
-
-	jQuery( '#sensei-module-add-toggle').on( 'click', function(){
-
+	jQuery( '#sensei-module-add-toggle' ).on( 'click', function () {
 		var hidden = 'wp-hidden-child';
-		var addBlock = jQuery(this).parent().next( 'p#sensei-module-add');
-		var moduleInput = addBlock.children('#newmodule');
-		if( addBlock.hasClass( hidden ) ){
-
-			addBlock.removeClass(hidden);
-			moduleInput.val('');
+		var addBlock = jQuery( this ).parent().next( 'p#sensei-module-add' );
+		var moduleInput = addBlock.children( '#newmodule' );
+		if ( addBlock.hasClass( hidden ) ) {
+			addBlock.removeClass( hidden );
+			moduleInput.val( '' );
 			moduleInput.focus();
 			return;
-		}else{
-
-			addBlock.addClass(hidden);
-
+		} else {
+			addBlock.addClass( hidden );
 		}
-	});
+	} );
 
-	jQuery( '#sensei-module-add-submit').on( 'click', function(){
-
+	jQuery( '#sensei-module-add-submit' ).on( 'click', function () {
 		// setup the fields
-		var courseId = getParameterByName('post');
-		var moduleInput = jQuery(this).parent().children( '#newmodule' );
-		var nonceField = jQuery(this).parent().children( '#add_module_nonce' );
-		var termListContainer = jQuery( '#module_course_mb #taxonomy-module #module-all ul#modulechecklist' );
+		var courseId = getParameterByName( 'post' );
+		var moduleInput = jQuery( this ).parent().children( '#newmodule' );
+		var nonceField = jQuery( this )
+			.parent()
+			.children( '#add_module_nonce' );
+		var termListContainer = jQuery(
+			'#module_course_mb #taxonomy-module #module-all ul#modulechecklist'
+		);
 
 		// get the new term value
 		var newTerm = moduleInput.val();
 		var security = nonceField.val();
 
-		if( _.isEmpty( newTerm ) || _.isEmpty( security ) ){
-
+		if ( _.isEmpty( newTerm ) || _.isEmpty( security ) ) {
 			moduleInput.focus();
 			return;
 		}
@@ -141,15 +141,14 @@ jQuery( document ).ready( function () {
 			from_page: 'course',
 		};
 
-		jQuery.post( ajaxurl, newTermData, function(response) {
+		jQuery.post( ajaxurl, newTermData, function ( response ) {
 			var termId, termName;
-			if( response.success ){
-
+			if ( response.success ) {
 				termId = response.data.termId;
 				termName = response.data.termName;
 
 				// make sure the return values are valid
-				if( ! ( parseInt( termId ) > 0 ) || _.isEmpty( termName ) ){
+				if ( ! ( parseInt( termId ) > 0 ) || _.isEmpty( termName ) ) {
 					moduleInput.focus();
 					return;
 				}
@@ -157,7 +156,12 @@ jQuery( document ).ready( function () {
 				// setup the new list item
 				var li = '<li id="module-' + termId + '">';
 				li += '<label class="selectit">';
-				li += '<input value="' + termId +  '" type="checkbox" checked="checked" name="tax_input[module][]" id="in-module-' + termId + '">';
+				li +=
+					'<input value="' +
+					termId +
+					'" type="checkbox" checked="checked" name="tax_input[module][]" id="in-module-' +
+					termId +
+					'">';
 				li += termName;
 				li += '</label></li>';
 
@@ -165,35 +169,38 @@ jQuery( document ).ready( function () {
 				termListContainer.prepend( li );
 
 				// clear the input
-				moduleInput.val('');
+				moduleInput.val( '' );
 				moduleInput.focus();
 
 				return;
-
-			}else if( typeof response.data.errors != 'undefined'
-                    &&  typeof response.data.errors.term_exists != 'undefined' ){
-
+			} else if (
+				typeof response.data.errors != 'undefined' &&
+				typeof response.data.errors.term_exists != 'undefined'
+			) {
 				termId = response.data.term.id;
 
 				// find term with id and just make sure it is
-				var termCheckBox = termListContainer.find( '#module-' + termId  + ' input');
+				var termCheckBox = termListContainer.find(
+					'#module-' + termId + ' input'
+				);
 
 				// checked also move the focus of the user there
 				termCheckBox.prop( 'checked', 'checked' );
 
 				// then empty the field that was added
 				termCheckBox.focus();
-				moduleInput.val('');
-
+				moduleInput.val( '' );
 			}
-		});
-	});
+		} );
+	} );
 
 	// Get Course modules (if any) on course select change
 	var $courseSelect = jQuery( '#lesson-course-options' ),
-		$lessonModuleMetaboxSelectContainer = jQuery( 'div#lesson-module-metabox-select' );
+		$lessonModuleMetaboxSelectContainer = jQuery(
+			'div#lesson-module-metabox-select'
+		);
 
-	$courseSelect.on('change', function () {
+	$courseSelect.on( 'change', function () {
 		if ( ! window.modulesAdmin.getCourseModulesNonce ) {
 			// console.log( 'missing modulesAdmin.getCourseModulesNonce' );
 			return;
@@ -202,19 +209,21 @@ jQuery( document ).ready( function () {
 			data = {
 				security: window.modulesAdmin.getCourseModulesNonce,
 				action: 'sensei_get_course_modules',
-				course_id: courseId
+				course_id: courseId,
 			};
 		if ( ! data.course_id ) {
 			// console.log( 'missing data.course_id' );
 			return;
 		}
 
-		jQuery.post( ajaxurl, data, function( response ) {
+		jQuery.post( ajaxurl, data, function ( response ) {
 			if ( true === response.success ) {
 				var content = response.data.content;
 				$lessonModuleMetaboxSelectContainer.html( content );
-				jQuery( 'select#lesson-module-options' ).select2( { width: 'resolve' } );
+				jQuery( 'select#lesson-module-options' ).select2( {
+					width: 'resolve',
+				} );
 			}
-		});
-	});
-});
+		} );
+	} );
+} );

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -343,7 +343,7 @@ class Sensei_Grading_User_Quiz {
 			</div>
 			<div class="clear"></div>
 			<script type="text/javascript">
-				jQuery( window ).load( function() {
+				jQuery( window ).on( 'load', function() {
 					// Calculate total grade on page load to make sure everything is set up correctly
 					jQuery.fn.autoGrade();
 				});


### PR DESCRIPTION
Fixes #3509

### Changes proposed in this Pull Request

* Replace usages of `$.attr( "value"[, newValue] )` with `$.val( [newValue] )`.
* Replace usage of `$.load( fn() )` with `$.on( "load", fn() )`.
* Pre-commit hook also did some updating of formatting.

### Testing instructions

* Rebuild assets. Upgrade to WP 5.5-rc2 or install the JQuery Migrate Helper plugin and remove the migrate helper.
* Attempt to add a new question to a quiz.
* Verify grading/auto-grading isn't broken.
* Ensure it works with WP 5.4.x as well.