### PR TITLE
Fix reordering of checkboxes in export page

### DIFF
--- a/assets/data-port/export/export-select-content-page.js
+++ b/assets/data-port/export/export-select-content-page.js
@@ -29,12 +29,12 @@ export const ExportSelectContentPage = ( { onSubmit, job } ) => {
 				</p>
 
 				<div className="sensei-export__select-content__options">
-					{ Object.entries( values ).map( ( [ type, value ] ) => (
+					{ [ 'course', 'lesson', 'question' ].map( ( type ) => (
 						<CheckboxControl
 							className="sensei-export__select-content__option sensei-data-port-step__line"
 							key={ type }
 							name={ type }
-							checked={ value }
+							checked={ values[ type ] }
 							onChange={ ( v ) =>
 								updateValues( { [ type ]: v } )
 							}


### PR DESCRIPTION
Fixes #3515

### Changes proposed in this Pull Request

* Checkbox rendering was based on `Object.entries` whose order is not defined.

### Testing instructions

* Follow the instructions on the original issue and make sure that the order does not change.