### PR TITLE
[Try] Course outline block prototype with react rendering on frontend

### DIFF
--- a/assets/course-builder/frontend.js
+++ b/assets/course-builder/frontend.js
@@ -1,0 +1,40 @@
+import { render, useEffect, useState } from '@wordpress/element';
+import apiFetch from '@wordpress/api-fetch';
+
+import Lesson from './lesson';
+import '../shared/data/api-fetch-preloaded-once';
+
+const element = document.getElementById( 'course-outline-block' );
+
+const CourseOutlineFrontend = () => {
+	const [ lessons, setLessons ] = useState( [] );
+	const [ loading, setLoading ] = useState( false );
+	useEffect( () => {
+		setLoading( true );
+		apiFetch( {
+			path: `/sensei-internal/v1/course-builder/course-lessons/${ element.dataset.id }`,
+		} ).then( ( l ) => {
+			setLessons( l );
+			setLoading( false );
+		} );
+	}, [] );
+
+	if ( loading ) {
+		return 'Loading API...';
+	}
+
+	return (
+		<div>
+			<h1>Course outline</h1>
+			{ lessons.map( ( lesson ) => (
+				<Lesson key={ lesson.id } href={ lesson.permalink }>
+					{ lesson.title }
+				</Lesson>
+			) ) }
+		</div>
+	);
+};
+
+if ( element ) {
+	render( <CourseOutlineFrontend />, element );
+}

--- a/assets/course-builder/index.js
+++ b/assets/course-builder/index.js
@@ -5,6 +5,7 @@ import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks, PlainText } from '@wordpress/block-editor';
+import Lesson from './lesson';
 
 registerBlockType( 'sensei-lms/course-outline', {
 	title: __( 'Course Outline', 'sensei-lms' ),
@@ -110,15 +111,7 @@ const CourseOutlineEditorBlock = ( { clientId, attributes: { _version } } ) => {
 
 const CourseLessonBlock = ( { attributes: { title, id }, setAttributes } ) => {
 	return (
-		<div
-			className="sensei-course-block-editor__lesson"
-			style={ {
-				borderBottom: '1px solid #32af7d',
-				padding: '0.25em',
-				display: 'flex',
-				alignItems: 'center',
-			} }
-		>
+		<Lesson>
 			<div style={ { flex: '1' } }>
 				<PlainText
 					style={ { fontSize: '1.5em', fontWeight: 600 } }
@@ -137,6 +130,6 @@ const CourseLessonBlock = ( { attributes: { title, id }, setAttributes } ) => {
 					Edit Lesson
 				</Button>
 			) }
-		</div>
+		</Lesson>
 	);
 };

--- a/assets/course-builder/lesson.js
+++ b/assets/course-builder/lesson.js
@@ -1,0 +1,19 @@
+const Lesson = ( { href, children } ) => {
+	const content = href ? <a href={ href }>{ children }</a> : children;
+
+	return (
+		<div
+			className="sensei-course-block-editor__lesson"
+			style={ {
+				borderBottom: '1px solid #32af7d',
+				padding: '0.25em',
+				display: 'flex',
+				alignItems: 'center',
+			} }
+		>
+			{ content }
+		</div>
+	);
+};
+
+export default Lesson;

--- a/includes/course-builder/class-sensei-course-outline-block.php
+++ b/includes/course-builder/class-sensei-course-outline-block.php
@@ -20,7 +20,7 @@ class Sensei_Course_Outline_Block {
 		register_block_type(
 			'sensei-lms/course-outline',
 			[
-				'render_callback' => [ __CLASS__, 'render' ],
+				'render_callback' => [ $this, 'render' ],
 				'editor_script'   => 'sensei-course-builder',
 				'attributes'      => [
 					'course_id' => [

--- a/includes/course-builder/class-sensei-course-outline-block.php
+++ b/includes/course-builder/class-sensei-course-outline-block.php
@@ -35,26 +35,14 @@ class Sensei_Course_Outline_Block {
 	/**
 	 * Render course outline block.
 	 *
+	 * @param array  $attributes
+	 * @param string $content
+	 *
 	 * @return string
 	 */
-	public function render() {
-
+	public function render( $attributes, $content ) {
+		// If we need something about the $attributes, or the $content saved, we can use here.
 		global $post;
-
-		$lessons = Sensei()->course_outline->course_lessons( $post->ID );
-
-		$r = '<div style="border-left: 2px solid #32af7d; padding: 1rem; "><h1>Course outline</h1>';
-
-		foreach ( $lessons->posts as $lesson ) {
-			$r .= '
-		<div style="border-bottom: 1px solid #eee; padding: 0.5rem; ">
-			<h2>
-				<a href="' . get_permalink( $lesson ) . '">' . $lesson->post_title . '</a>
-			</h2>
-			</div>';
-		}
-
-		$r .= '</div>';
-		return $r;
+		return '<div id="course-outline-block" data-id="' . $post->ID . '">Loading page!</div>';
 	}
 }

--- a/includes/course-builder/class-sensei-course-outline.php
+++ b/includes/course-builder/class-sensei-course-outline.php
@@ -19,6 +19,8 @@ class Sensei_Course_Outline {
 	 */
 	public function __construct() {
 		add_action( 'init', [ $this, 'register_blocks' ] );
+		// add_action( 'wp_enqueue_scripts', [ $this, 'frontend_scripts' ] );
+		add_action( 'wp_print_scripts', [ $this, 'frontend_scripts' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest' ] );
 	}
 
@@ -36,6 +38,14 @@ class Sensei_Course_Outline {
 			$block->register_block_type();
 		}
 
+	}
+
+	public function frontend_scripts() {
+		// TOOD: Should load only for the pages with the block.
+		Sensei()->assets->enqueue( 'sensei-course-builder-frontend', 'course-builder/frontend.js', [ 'wp-element' ], true );
+
+		global $post;
+		Sensei()->assets->preload_data( [ '/sensei-internal/v1/course-builder/course-lessons/' . $post->ID ] );
 	}
 
 	/**
@@ -74,9 +84,10 @@ class Sensei_Course_Outline {
 		return array_map(
 			function( $post ) {
 				return [
-					'id'     => $post->ID,
-					'title'  => $post->post_title,
-					'status' => $post->post_status,
+					'id'        => $post->ID,
+					'title'     => $post->post_title,
+					'status'    => $post->post_status,
+					'permalink' => get_permalink( $post->ID ),
 				];
 			},
 			$query->posts

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,7 @@ const files = [
 	'data-port/import.js',
 	'data-port/style.scss',
 	'course-builder/index.js',
+	'course-builder/frontend.js',
 
 	'css/frontend.scss',
 	'css/admin-custom.css',


### PR DESCRIPTION
This prototype is an alternative to: https://github.com/Automattic/sensei/pull/3508

- It basically renders the frontend content in React.
- It also uses the preload option to give a better experience without waiting for the API fetch.
- This PR is using the same Lesson component for the editor and the frontend. We can share more things, but I reused only the `Lesson` for the POC, and if we go ahead with this approach, we can think of good architecture to reuse the maximum possible.

With this solution, we're appending the at least the dependencies - The sizes are the min files (not gzipped):
- react-dom (114 KB)
- react (13 KB)
- lodash (73 KB)
- i18n (10 KB)

And we should probably avoid using the WP components (707 KB), and other big libs, unless it's totally necessary for some purpose.

If we go ahead with this solution, we should also check some optimizations for the bundle. An idea is to think about using the `preact`, but we should explore the other WP plugins to see how they are handling that.

### Screenshot / Video

![Aug-12-2020 16-40-17](https://user-images.githubusercontent.com/876340/90060091-8fa1e100-dcba-11ea-8d54-7dd4c8e78a05.gif)
