### PR TITLE
[Try] Course outline block prototype with rendering with Twig template engine on frontend

### DIFF
--- a/assets/course-builder/index.js
+++ b/assets/course-builder/index.js
@@ -135,15 +135,7 @@ const CourseOutlineEditorBlock = ( { clientId, attributes: { _version } } ) => {
 
 const CourseLessonBlock = ( { attributes: { title, id }, setAttributes } ) => {
 	return (
-		<div
-			className="sensei-course-block-editor__lesson"
-			style={ {
-				borderBottom: '1px solid #32af7d',
-				padding: '0.25em',
-				display: 'flex',
-				alignItems: 'center',
-			} }
-		>
+		<Lesson>
 			<div style={ { flex: '1' } }>
 				<PlainText
 					style={ { fontSize: '1.5em', fontWeight: 600 } }
@@ -162,6 +154,6 @@ const CourseLessonBlock = ( { attributes: { title, id }, setAttributes } ) => {
 					Edit Lesson
 				</Button>
 			) }
-		</div>
+		</Lesson>
 	);
 };

--- a/assets/course-builder/index.js
+++ b/assets/course-builder/index.js
@@ -21,9 +21,6 @@ const Lesson = ( { id, href, templating, children } ) => {
 
 	return (
 		<>
-			<style>{ `
-				.test_lesson { background: red; }
-			` }</style>
 			<div
 				className={ className }
 				style={ {
@@ -41,6 +38,9 @@ const Lesson = ( { id, href, templating, children } ) => {
 
 const CourseOutlineWrapper = ( { children } ) => (
 	<div style={ { borderLeft: '2px solid #32af7d', padding: '1rem' } }>
+		<style>{ `
+			.test_lesson { background: red; }
+		` }</style>
 		<h1>Course outline</h1>
 		{ children }
 	</div>

--- a/assets/course-builder/index.js
+++ b/assets/course-builder/index.js
@@ -5,25 +5,37 @@ import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { createBlock, registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks, PlainText } from '@wordpress/block-editor';
+import classnames from 'classnames';
 
 /**
  * Components.
  */
-const Lesson = ( { href, children } ) => {
+const Lesson = ( { id, href, templating, children } ) => {
 	const content = href ? <a href={ href }>{ children }</a> : children;
 
+	const className = templating
+		? 'sensei-course-block-editor__lesson {% if lesson.id is divisible by(2) %}test_lesson{% endif %}'
+		: classnames( 'sensei-course-block-editor__lesson', {
+				test_lesson: id % 2 === 0,
+		  } );
+
 	return (
-		<div
-			className="sensei-course-block-editor__lesson"
-			style={ {
-				borderBottom: '1px solid #32af7d',
-				padding: '0.25em',
-				display: 'flex',
-				alignItems: 'center',
-			} }
-		>
-			{ content }
-		</div>
+		<>
+			<style>{ `
+				.test_lesson { background: red; }
+			` }</style>
+			<div
+				className={ className }
+				style={ {
+					borderBottom: '1px solid #32af7d',
+					padding: '0.25em',
+					display: 'flex',
+					alignItems: 'center',
+				} }
+			>
+				{ content }
+			</div>
+		</>
 	);
 };
 
@@ -110,7 +122,9 @@ const CourseOutlineFrontendBlock = ( { innerBlocks } ) => {
 	return (
 		<CourseOutlineWrapper>
 			{ '{% for lesson in data %}' }
-			<Lesson href="{{ lesson.permalink }}">{ `{{ lesson.title }}` }</Lesson>
+			<Lesson href="{{ lesson.permalink }}" templating>
+				{ `{{ lesson.title }}` }
+			</Lesson>
 			{ '{% endfor %}' }
 			<InnerBlocks.Content />
 		</CourseOutlineWrapper>
@@ -154,7 +168,7 @@ registerBlockType( 'sensei/course-lesson', {
 
 const CourseLessonBlock = ( { attributes: { title, id }, setAttributes } ) => {
 	return (
-		<Lesson>
+		<Lesson id={ id }>
 			<div style={ { flex: '1' } }>
 				<PlainText
 					style={ { fontSize: '1.5em', fontWeight: 600 } }

--- a/assets/course-builder/index.js
+++ b/assets/course-builder/index.js
@@ -30,10 +30,10 @@ registerBlockType( 'sensei-lms/course-outline', {
 		return <CourseOutlineEditorBlock { ...props } />;
 	},
 
-	async save( { innerBlocks } ) {
+	save( { innerBlocks } ) {
 		const courseId = select( 'core/editor' ).getCurrentPostId();
 		if ( courseId ) {
-			await apiFetch( {
+			apiFetch( {
 				path: `sensei-internal/v1/course-builder/course-lessons/${ courseId }`,
 				method: 'POST',
 				data: {
@@ -42,7 +42,14 @@ registerBlockType( 'sensei-lms/course-outline', {
 			} );
 		}
 
-		return <InnerBlocks.Content />;
+		return (
+			<>
+				## template ##
+				<Lesson href="{{ href }}">{ `{{ lessonTitle }}` }</Lesson>
+				## template ##
+				<InnerBlocks.Content />
+			</>
+		);
 	},
 } );
 
@@ -77,6 +84,24 @@ registerBlockType( 'sensei/course-lesson', {
 		return null;
 	},
 } );
+
+const Lesson = ( { href, children } ) => {
+	const content = href ? <a href={ href }>{ children }</a> : children;
+
+	return (
+		<div
+			className="sensei-course-block-editor__lesson"
+			style={ {
+				borderBottom: '1px solid #32af7d',
+				padding: '0.25em',
+				display: 'flex',
+				alignItems: 'center',
+			} }
+		>
+			{ content }
+		</div>
+	);
+};
 
 const CourseOutlineEditorBlock = ( { clientId, attributes: { _version } } ) => {
 	const courseId = select( 'core/editor' ).getCurrentPostId();

--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,8 @@
 		"sirbrillig/phpcs-variable-analysis": "2.8.3",
 		"sirbrillig/phpcs-no-get-current-user": "1.0.1"
 	},
-	"prefer-stable": true
+	"prefer-stable": true,
+	"require": {
+		"twig/twig": "^3.0"
+	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,11 +1,237 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2cb36d323103f4741505a4c114fb1d29",
-    "packages": [],
+    "content-hash": "819cc0853b86b0aa8db6960853a9f703",
+    "packages": [
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-14T12:35:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.18.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/a6977d63bf9a0ad4c65cd352709e230876f9904a",
+                "reference": "a6977d63bf9a0ad4c65cd352709e230876f9904a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-14T12:35:20+00:00"
+        },
+        {
+            "name": "twig/twig",
+            "version": "v3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/twigphp/Twig.git",
+                "reference": "9b76b1535483cdf4edf01bb787b0217b62bd68a5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/9b76b1535483cdf4edf01bb787b0217b62bd68a5",
+                "reference": "9b76b1535483cdf4edf01bb787b0217b62bd68a5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-mbstring": "^1.3"
+            },
+            "require-dev": {
+                "psr/container": "^1.0",
+                "symfony/phpunit-bridge": "^4.4.9|^5.0.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Twig\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com",
+                    "homepage": "http://fabien.potencier.org",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Twig Team",
+                    "role": "Contributors"
+                },
+                {
+                    "name": "Armin Ronacher",
+                    "email": "armin.ronacher@active-4.com",
+                    "role": "Project Founder"
+                }
+            ],
+            "description": "Twig, the flexible, fast, and secure template language for PHP",
+            "homepage": "https://twig.symfony.com",
+            "keywords": [
+                "templating"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/twig/twig",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-08-05T15:13:19+00:00"
+        }
+    ],
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
@@ -127,6 +353,20 @@
                 "constructor",
                 "instantiate"
             ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-29T17:27:14+00:00"
         },
         {
@@ -174,6 +414,12 @@
                 "duplicate",
                 "object",
                 "object graph"
+            ],
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-29T13:22:24+00:00"
         },
@@ -1744,68 +1990,6 @@
             "time": "2020-04-17T01:09:41+00:00"
         },
         {
-            "name": "symfony/polyfill-ctype",
-            "version": "v1.18.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
-                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.3"
-            },
-            "suggest": {
-                "ext-ctype": "For best performance"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.18-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Gert de Pagter",
-                    "email": "BackEndTea@gmail.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill for ctype functions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "ctype",
-                "polyfill",
-                "portable"
-            ],
-            "time": "2020-07-14T12:35:20+00:00"
-        },
-        {
             "name": "theseer/tokenizer",
             "version": "1.2.0",
             "source": {
@@ -1843,6 +2027,12 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
             "time": "2020-07-12T23:59:07+00:00"
         },
         {
@@ -1949,5 +2139,6 @@
     "platform": [],
     "platform-dev": {
         "php": "^5.4 || ^7"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/includes/class-sensei-bootstrap.php
+++ b/includes/class-sensei-bootstrap.php
@@ -40,6 +40,7 @@ class Sensei_Bootstrap {
 	}
 
 	private function init_autoloader() {
+		require_once __DIR__ . '/../vendor/autoload.php';
 		require_once dirname( __FILE__ ) . '/class-sensei-autoloader.php';
 		$this->autoloader = new Sensei_Autoloader();
 	}

--- a/includes/course-builder/class-sensei-course-outline-block.php
+++ b/includes/course-builder/class-sensei-course-outline-block.php
@@ -35,23 +35,27 @@ class Sensei_Course_Outline_Block {
 	/**
 	 * Render course outline block.
 	 *
+	 * @param array  $attributes
+	 * @param string $content
+	 *
 	 * @return string
 	 */
-	public function render() {
+	public function render( $attributes, $content ) {
 
 		global $post;
+
+		$templates = explode( '## template ##', $content );
+
+		$loader = new \Twig\Loader\ArrayLoader( [] );
+		$twig = new \Twig\Environment( $loader );
+		$lesson_template = $twig->createTemplate( $templates[ 1 ] );
 
 		$lessons = Sensei()->course_outline->course_lessons( $post->ID );
 
 		$r = '<div style="border-left: 2px solid #32af7d; padding: 1rem; "><h1>Course outline</h1>';
 
 		foreach ( $lessons->posts as $lesson ) {
-			$r .= '
-		<div style="border-bottom: 1px solid #eee; padding: 0.5rem; ">
-			<h2>
-				<a href="' . get_permalink( $lesson ) . '">' . $lesson->post_title . '</a>
-			</h2>
-			</div>';
+			$r .= $lesson_template->render( [ 'href' => get_permalink( $lesson ), 'lessonTitle' => $lesson->post_title ] );
 		}
 
 		$r .= '</div>';

--- a/includes/course-builder/class-sensei-course-outline-block.php
+++ b/includes/course-builder/class-sensei-course-outline-block.php
@@ -20,7 +20,7 @@ class Sensei_Course_Outline_Block {
 		register_block_type(
 			'sensei-lms/course-outline',
 			[
-				'render_callback' => [ __CLASS__, 'render' ],
+				'render_callback' => [ $this, 'render' ],
 				'editor_script'   => 'sensei-course-builder',
 				'attributes'      => [
 					'course_id' => [

--- a/includes/course-builder/class-sensei-course-outline-block.php
+++ b/includes/course-builder/class-sensei-course-outline-block.php
@@ -44,21 +44,16 @@ class Sensei_Course_Outline_Block {
 
 		global $post;
 
-		$templates = explode( '## template ##', $content );
+		$loader   = new \Twig\Loader\ArrayLoader( [] );
+		$twig     = new \Twig\Environment( $loader );
+		$template = $twig->createTemplate( $content );
 
-		$loader = new \Twig\Loader\ArrayLoader( [] );
-		$twig = new \Twig\Environment( $loader );
-		$lesson_template = $twig->createTemplate( $templates[ 1 ] );
+		// Call the same API as the block editor.
+		$request  = new WP_REST_Request( 'GET', '/sensei-internal/v1/course-builder/course-lessons/' . $post->ID );
+		$response = rest_do_request( $request );
+		$server   = rest_get_server();
+		$data     = $server->response_to_data( $response, false );
 
-		$lessons = Sensei()->course_outline->course_lessons( $post->ID );
-
-		$r = '<div style="border-left: 2px solid #32af7d; padding: 1rem; "><h1>Course outline</h1>';
-
-		foreach ( $lessons->posts as $lesson ) {
-			$r .= $lesson_template->render( [ 'href' => get_permalink( $lesson ), 'lessonTitle' => $lesson->post_title ] );
-		}
-
-		$r .= '</div>';
-		return $r;
+		return $template->render( [ 'data' => $data ] );
 	}
 }

--- a/includes/course-builder/class-sensei-course-outline.php
+++ b/includes/course-builder/class-sensei-course-outline.php
@@ -74,9 +74,10 @@ class Sensei_Course_Outline {
 		return array_map(
 			function( $post ) {
 				return [
-					'id'     => $post->ID,
-					'title'  => $post->post_title,
-					'status' => $post->post_status,
+					'id'        => $post->ID,
+					'title'     => $post->post_title,
+					'status'    => $post->post_status,
+					'permalink' => get_permalink( $post->ID ),
 				];
 			},
 			$query->posts


### PR DESCRIPTION
This prototype is an alternative to: https://github.com/Automattic/sensei/pull/3508

- It saves templates in the `post_content`.
  - Maybe we could save it in an `option` through API or something like that, otherwise, we would have the templates duplicated in all posts.
- When loading the site, it gets the `$content` string, `explode` the templates and write the content from the post metas using these templates.

#### UPDATE:
I updated the POC to have a single template and we can put all the logic in the template. It also gives us a new advantage, if we want to save things in the post_content (maybe add contact button/progress?). I also added an edge case to add a background red on lessons with id number divisible by 2 (useful for the design customizations, for example).

Just to clarify, in this solution, our post_content would be something like (created with our React components used on  the Editor):

```html
<div style="border-left:2px solid #32af7d;padding:1rem">
  <h1>Course outline</h1>
  <style>.test_lesson { background: red; }</style>
  {% for lesson in data %}
    <div class="sensei-course-block-editor__lesson {% if lesson.id is divisible by(2) %}test_lesson{% endif %}" style="border-bottom:1px solid #32af7d;padding:0.25em;display:flex;align-items:center">
      <a href="{{ lesson.permalink }}">{{ lesson.title }}</a>
    </div>
  {% endfor %}
</div>
```

### Screenshot / Video

![Aug-13-2020 11-40-21](https://user-images.githubusercontent.com/876340/90148576-d72b7a00-dd59-11ea-9405-48debd2b3042.gif)

