### PR TITLE
Remove data port task clean_up methods

### DIFF
--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -263,10 +263,6 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	 * Delete any stored state for this job.
 	 */
 	public function clean_up() {
-		foreach ( $this->get_tasks() as $task ) {
-			$task->clean_up();
-		}
-
 		foreach ( array_keys( $this->files ) as $file_key ) {
 			$this->delete_file( $file_key );
 		}
@@ -342,8 +338,6 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	 * @return Sensei_Data_Port_Task_Interface
 	 */
 	protected function initialize_task( $task_class ) {
-		// @todo Implement restoring of task state.
-
 		return new $task_class( $this );
 	}
 

--- a/includes/data-port/class-sensei-data-port-task-interface.php
+++ b/includes/data-port/class-sensei-data-port-task-interface.php
@@ -40,9 +40,4 @@ interface Sensei_Data_Port_Task_Interface {
 	 */
 	public function get_completion_ratio();
 
-	/**
-	 * Performs any required cleanup of the task.
-	 */
-	public function clean_up();
-
 }

--- a/includes/data-port/export-tasks/class-sensei-export-package.php
+++ b/includes/data-port/export-tasks/class-sensei-export-package.php
@@ -94,11 +94,4 @@ class Sensei_Export_Package
 			'total'     => 1,
 		];
 	}
-
-	/**
-	 * Performs any required cleanup of the task.
-	 */
-	public function clean_up() {
-		// Nothing to do.
-	}
 }

--- a/includes/data-port/export-tasks/class-sensei-export-task.php
+++ b/includes/data-port/export-tasks/class-sensei-export-task.php
@@ -202,13 +202,6 @@ abstract class Sensei_Export_Task
 	}
 
 	/**
-	 * Performs any required cleanup of the task.
-	 */
-	public function clean_up() {
-
-	}
-
-	/**
 	 * Attach the file to the job.
 	 *
 	 * @param string $tmp_file

--- a/includes/data-port/import-tasks/class-sensei-import-courses.php
+++ b/includes/data-port/import-tasks/class-sensei-import-courses.php
@@ -46,13 +46,6 @@ class Sensei_Import_Courses extends Sensei_Import_File_Process_Task {
 	}
 
 	/**
-	 * Performs any required cleanup of the task.
-	 */
-	public function clean_up() {
-		// Nothing to do.
-	}
-
-	/**
 	 * Validate an uploaded source file before saving it.
 	 *
 	 * @param string $file_path File path of the file to validate.

--- a/includes/data-port/import-tasks/class-sensei-import-lessons.php
+++ b/includes/data-port/import-tasks/class-sensei-import-lessons.php
@@ -46,13 +46,6 @@ class Sensei_Import_Lessons extends Sensei_Import_File_Process_Task {
 	}
 
 	/**
-	 * Performs any required cleanup of the task.
-	 */
-	public function clean_up() {
-		// Nothing to do.
-	}
-
-	/**
 	 * Validate an uploaded source file before saving it.
 	 *
 	 * @param string $file_path File path of the file to validate.

--- a/includes/data-port/import-tasks/class-sensei-import-questions.php
+++ b/includes/data-port/import-tasks/class-sensei-import-questions.php
@@ -47,13 +47,6 @@ class Sensei_Import_Questions
 	}
 
 	/**
-	 * Performs any required cleanup of the task.
-	 */
-	public function clean_up() {
-		// Nothing to clean.
-	}
-
-	/**
 	 * Validate an uploaded source file before saving it.
 	 *
 	 * @param string $file_path File path of the file to validate.

--- a/tests/framework/data-port/class-sensei-data-port-task-mock.php
+++ b/tests/framework/data-port/class-sensei-data-port-task-mock.php
@@ -33,6 +33,4 @@ class Sensei_Data_Port_Task_Mock implements Sensei_Data_Port_Task_Interface {
 		];
 	}
 
-	public function clean_up() {}
-
 }

--- a/tests/framework/data-port/class-sensei-import-file-process-task-mock.php
+++ b/tests/framework/data-port/class-sensei-import-file-process-task-mock.php
@@ -19,7 +19,5 @@ class Sensei_Import_File_Process_Task_Mock extends Sensei_Import_File_Process_Ta
 		return Sensei_Import_Model_Mock::MODEL_KEY;
 	}
 
-	public function clean_up() {}
-
 	public static function validate_source_file( $file_path ) {}
 }

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-job.php
@@ -107,19 +107,6 @@ class Sensei_Data_Port_Job_Test extends WP_UnitTestCase {
 		);
 	}
 
-
-	public function testCleanupCallsAllTaskCleanup() {
-		$first_completed  = $this->mock_task_method( true, 100, 100, 'clean_up' );
-		$second_completed = $this->mock_task_method( true, 100, 100, 'clean_up' );
-
-		$job = Sensei_Data_Port_Job_Mock::create_with_tasks( 'test-job', [ $first_completed, $second_completed ] );
-
-		$first_completed->expects( $this->once() )->method( 'clean_up' );
-		$second_completed->expects( $this->once() )->method( 'clean_up' );
-
-		$job->clean_up();
-	}
-
 	public function testGetLogs() {
 		$job = Sensei_Data_Port_Job_Mock::create_with_tasks( 'test-job', [ new Sensei_Data_Port_Task_Mock( true, 100, 100 ) ] );
 		$job->add_log_entry( 'First log entry', Sensei_Data_Port_Job::LOG_LEVEL_NOTICE, [ 'line' => 1 ] );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* All clean up ended up happening on the job level.
* There is a very small risk as this was in the released importer classes, but since they were never used and the importer isn't really overridable it feels safe.

### Testing instructions

* Ensure tests pass.