### PR TITLE
Log when an export job completes

### DIFF
--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -298,7 +298,7 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 		sort( $plural_content_types );
 
 		sensei_log_event(
-			'export_success',
+			'export_complete',
 			[
 				'type' => implode( ',', $plural_content_types ),
 			]

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -79,6 +79,7 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 	public function init() {
 		add_action( 'init', [ $this, 'maybe_schedule_cron_jobs' ] );
 		add_action( 'sensei_data_port_complete', [ $this, 'log_complete_import_jobs' ] );
+		add_action( 'sensei_data_port_complete', [ $this, 'log_complete_export_jobs' ] );
 		add_action( 'sensei_data_port_garbage_collection', [ $this, 'clean_old_jobs' ] );
 		add_action( Sensei_Data_Port_Job::SCHEDULED_ACTION_NAME, [ $this, 'run_scheduled_data_port_job' ] );
 		add_action( 'shutdown', [ $this, 'persist' ] );
@@ -271,6 +272,35 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 				'failed_courses'     => $results[ Sensei_Import_Course_Model::MODEL_KEY ]['error'],
 				'failed_lessons'     => $results[ Sensei_Import_Lesson_Model::MODEL_KEY ]['error'],
 				'failed_questions'   => $results[ Sensei_Import_Question_Model::MODEL_KEY ]['error'],
+			]
+		);
+	}
+
+	/**
+	 * Log when an export job is complete.
+	 *
+	 * @access private
+	 *
+	 * @param Sensei_Data_Port_Job $job The job object.
+	 */
+	public function log_complete_export_jobs( Sensei_Data_Port_Job $job ) {
+		if ( ! $job instanceof Sensei_Export_Job ) {
+			return;
+		}
+
+		$plural_content_types = array_map(
+			function( $type ) {
+				return $type . 's';
+			},
+			$job->get_content_types()
+		);
+
+		sort( $plural_content_types );
+
+		sensei_log_event(
+			'export_success',
+			[
+				'type' => implode( ',', $plural_content_types ),
 			]
 		);
 	}

--- a/includes/data-port/class-sensei-export-job.php
+++ b/includes/data-port/class-sensei-export-job.php
@@ -50,7 +50,7 @@ class Sensei_Export_Job extends Sensei_Data_Port_Job {
 				'question' => Sensei_Export_Questions::class,
 			];
 
-			foreach ( $this->get_state( self::CONTENT_TYPES_STATE_KEY ) as $type ) {
+			foreach ( $this->get_content_types() as $type ) {
 				if ( isset( $task_class[ $type ] ) ) {
 					$this->tasks[ $type ] = $this->initialize_task( $task_class[ $type ] );
 				}
@@ -111,6 +111,15 @@ class Sensei_Export_Job extends Sensei_Data_Port_Job {
 	 */
 	public function set_content_types( $content_types ) {
 		$this->set_state( self::CONTENT_TYPES_STATE_KEY, $content_types );
+	}
+
+	/**
+	 * Get the content types to be exported.
+	 *
+	 * @return array
+	 */
+	public function get_content_types() {
+		return $this->get_state( self::CONTENT_TYPES_STATE_KEY );
 	}
 
 	/**

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-manager.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-manager.php
@@ -218,6 +218,35 @@ class Sensei_Data_Port_Manager_Test extends WP_UnitTestCase {
 		$property->setValue( Sensei_Data_Port_Manager::instance(), $jobs );
 	}
 
+	/**
+	 * Tests to make sure export jobs are logged successfully.
+	 */
+	public function testLogCompleteExportJobs() {
+		$job = $this->getMockBuilder( Sensei_Export_Job::class )
+					->setConstructorArgs( [ 'test-job' ] )
+					->setMethods( [ 'get_content_types' ] )
+					->getMock();
+
+		$job->expects( $this->exactly( 1 ) )
+			->method( 'get_content_types' )
+			->willReturn(
+				[ 'lesson', 'course' ]
+			);
+
+		Sensei_Data_Port_Manager::instance()->log_complete_export_jobs( $job );
+
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_export_success' );
+		$this->assertCount( 1, $events );
+
+		$expected_data = [
+			'type' => 'courses,lessons',
+		];
+
+		foreach ( $expected_data as $key => $value ) {
+			$this->assertEquals( $value, $events[0]['url_args'][ $key ], "'{$key}' does not match" );
+		}
+	}
+
 	private function mock_job_method( $job_id, $method ) {
 		return $this->getMockBuilder( Sensei_Data_Port_Job_Mock::class )
 			->setConstructorArgs( [ $job_id ] )

--- a/tests/unit-tests/data-port/test-class-sensei-data-port-manager.php
+++ b/tests/unit-tests/data-port/test-class-sensei-data-port-manager.php
@@ -235,7 +235,7 @@ class Sensei_Data_Port_Manager_Test extends WP_UnitTestCase {
 
 		Sensei_Data_Port_Manager::instance()->log_complete_export_jobs( $job );
 
-		$events = Sensei_Test_Events::get_logged_events( 'sensei_export_success' );
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_export_complete' );
 		$this->assertCount( 1, $events );
 
 		$expected_data = [


### PR DESCRIPTION
Fixes #3111

### Changes proposed in this Pull Request

* Logs when an export job completes.

### Testing instructions

* Enable usage tracking for Sensei.
* Complete an export job.
* Ensure tracking event is fired correctly based on specs in #3111. 