### PR TITLE
Log when users click `Generate CSV` in exporter

### DIFF
--- a/assets/data-port/export/export-select-content-page.js
+++ b/assets/data-port/export/export-select-content-page.js
@@ -49,7 +49,7 @@ export const ExportSelectContentPage = ( { onSubmit, job } ) => {
 						disabled={ ! hasSelected || isLoading }
 						isBusy={ isLoading }
 					>
-						{ __( 'Generate CSV', 'sensei-lms' ) }
+						{ __( 'Continue', 'sensei-lms' ) }
 					</Button>
 				</div>
 			</div>

--- a/assets/data-port/export/export-select-content-page.test.js
+++ b/assets/data-port/export/export-select-content-page.test.js
@@ -9,7 +9,7 @@ describe( '<SelectExportContentPage />', () => {
 		);
 
 		fireEvent.click( getByLabelText( 'Lessons' ) );
-		fireEvent.click( getByRole( 'button', { name: 'Generate CSV' } ) );
+		fireEvent.click( getByRole( 'button', { name: 'Continue' } ) );
 		expect( onSubmit ).toHaveBeenCalledWith( [ 'lesson' ] );
 	} );
 
@@ -20,11 +20,11 @@ describe( '<SelectExportContentPage />', () => {
 		);
 
 		expect(
-			getByRole( 'button', { name: 'Generate CSV' } ).disabled
+			getByRole( 'button', { name: 'Continue' } ).disabled
 		).toBeTruthy();
 		fireEvent.click( getByLabelText( 'Lessons' ) );
 		expect(
-			getByRole( 'button', { name: 'Generate CSV' } ).disabled
+			getByRole( 'button', { name: 'Continue' } ).disabled
 		).toBeFalsy();
 	} );
 } );

--- a/assets/data-port/export/store/actions.js
+++ b/assets/data-port/export/store/actions.js
@@ -211,7 +211,7 @@ const startJob = function* ( types ) {
 		.map( ( typeSingular ) => typeSingular + 's' )
 		.join( ',' );
 
-	window.sensei_log_event( 'export_generate_csv_click', { type } );
+	window.sensei_log_event( 'export_continue_click', { type } );
 
 	yield updateJob( job );
 	return job;

--- a/assets/data-port/export/store/actions.js
+++ b/assets/data-port/export/store/actions.js
@@ -206,6 +206,13 @@ const startJob = function* ( types ) {
 		data: { content_types: types },
 	} );
 
+	// Log when users start an export.
+	const type = types
+		.map( ( typeSingular ) => typeSingular + 's' )
+		.join( ',' );
+
+	window.sensei_log_event( 'export_generate_csv_click', { type } );
+
 	yield updateJob( job );
 	return job;
 };

--- a/assets/data-port/export/store/index.test.js
+++ b/assets/data-port/export/store/index.test.js
@@ -3,6 +3,7 @@ import { apiFetch } from '@wordpress/data-controls';
 import registerExportStore, { EXPORT_STORE } from './index';
 import * as actions from './actions';
 
+window.sensei_log_event = jest.fn();
 jest.mock( '@wordpress/data-controls', () => {
 	const originalModule = jest.requireActual( '@wordpress/data-controls' );
 


### PR DESCRIPTION
Fixes #3109

### Changes proposed in this Pull Request

* Log the event `sensei_export_generate_csv_click` when users click the `Generate CSV` button in the exporter.

### Testing instructions

* Go to the exporter, select 1 or more types, and click `Generate CSV`.
* Notice the event is fired with specs from #3109.