### PR TITLE
Log when the Export submenu is clicked

### DIFF
--- a/assets/js/admin/event-logging.js
+++ b/assets/js/admin/event-logging.js
@@ -5,6 +5,11 @@ const adminTracking = [
 			'#toplevel_page_sensei a[href="admin.php?page=sensei_import"]',
 		eventName: 'import_click',
 	},
+	{
+		selector:
+			'#toplevel_page_sensei a[href="admin.php?page=sensei_export"]',
+		eventName: 'export_click',
+	},
 ];
 
 window.sensei_log_event = function( event_name, properties ) {


### PR DESCRIPTION
Fixes #3108

### Changes proposed in this Pull Request

* Logs when the `Export` submenu item is clicked

### Testing instructions

* Click on `Export` under `Sensei LMS` with usage tracking enabled.
* Confirm event is tracked.