### PR TITLE
Update copy used in exporter

### DIFF
--- a/assets/data-port/export/export-page.js
+++ b/assets/data-port/export/export-page.js
@@ -26,8 +26,8 @@ export const ExportPage = ( { job, error, start, reset, cancel } ) => {
 					</h1>
 					<p>
 						{ __(
-							'This tool enables you to generate and download one or more CSV files containing a list of all courses, ' +
-								'lessons, or questions. Separate CSV files are generated for each content type.',
+							'This tool enables you to export courses, lessons, and questions to CSV files. ' +
+								'These files are bundled together and downloaded to your computer in .zip format.',
 							'sensei-lms'
 						) }
 					</p>

--- a/assets/data-port/export/export-page.js
+++ b/assets/data-port/export/export-page.js
@@ -21,9 +21,9 @@ export const ExportPage = ( { job, error, start, reset, cancel } ) => {
 		<div className="sensei-page-export">
 			<section className="sensei-data-port-step">
 				<header className="sensei-data-port-step__header">
-					<h1>
+					<h2>
 						{ __( 'Export content to a CSV file', 'sensei-lms' ) }
-					</h1>
+					</h2>
 					<p>
 						{ __(
 							'This tool enables you to export courses, lessons, and questions to CSV files. ' +

--- a/assets/data-port/export/export-progress-page.js
+++ b/assets/data-port/export/export-progress-page.js
@@ -1,6 +1,6 @@
 import { Button } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 import { downloadFile } from '../../shared/helpers/download-file';
 import { Notice } from '../notice';
 
@@ -57,8 +57,10 @@ export const ExportProgressPage = ( { job, reset, cancel } ) => {
 						{ files && (
 							<>
 								<p>
-									{ __(
+									{ _n(
+										'The following file was exported:',
 										'The following files were exported:',
+										files.length,
 										'sensei-lms'
 									) }
 								</p>
@@ -84,7 +86,7 @@ export const ExportProgressPage = ( { job, reset, cancel } ) => {
 					</div>
 					<div className="sensei-data-port-step__footer">
 						<Button isPrimary onClick={ () => reset() }>
-							{ __( 'New Export', 'sensei-lms' ) }
+							{ __( 'Export More Content', 'sensei-lms' ) }
 						</Button>
 					</div>
 				</>

--- a/assets/data-port/export/export-progress-page.test.js
+++ b/assets/data-port/export/export-progress-page.test.js
@@ -67,7 +67,9 @@ describe( '<ExportProgressPage />', () => {
 				reset={ onReset }
 			/>
 		);
-		fireEvent.click( getByRole( 'button', { name: 'New Export' } ) );
+		fireEvent.click(
+			getByRole( 'button', { name: 'Export More Content' } )
+		);
 		expect( onReset ).toHaveBeenCalled();
 	} );
 

--- a/assets/data-port/style.scss
+++ b/assets/data-port/style.scss
@@ -53,6 +53,10 @@ $alert-red: #d94f4f;
 	text-align: center;
 	max-width: 700px;
 	margin: 40px auto;
+
+	* {
+		font-size: 14px;
+	}
 }
 
 .sensei-data-port-steps {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update the copy.
* Match font sizes to same as importer.
* Change `h1` to `h2` as an `h1` already exists on the exporter page.

### Testing instructions

* Check exporter copy to ensure it makes sense and there are no misspellings.
* Ensure font sizes used are the same as that of the importer.
* Ensure there is only one `h1` on the page.