### PR TITLE
Add a return to the setup wizard post

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -462,10 +462,10 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 	 * Complete setup wizard
 	 */
 	public function complete_setup_wizard() {
-
 		$this->mark_step_complete( 'ready' );
 		$this->setup_wizard->finish_setup_wizard();
 
+		return true;
 	}
 
 }


### PR DESCRIPTION
Fixes #3458

### Changes proposed in this Pull Request

* Fix an issue that showed an error while going to the Ready step and going back to the other steps.

### Testing instructions

1. Delete the `sensei_setup_wizard_data` option.
2. Open the onboarding wizard in admin.
3. Complete the steps until you get to the 'Ready' step.
4. Click and navigate to 'Purpose' or 'Features' and make sure the error doesn't appear.