### PR TITLE
Export the correct order when lessons belong to modules

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1727,11 +1727,12 @@ class Sensei_Core_Modules {
 	 * Find the lesson in the given course that doesn't belong
 	 * to any of the courses modules
 	 *
-	 * @param $course_id
+	 * @param int    $course_id    The course id.
+	 * @param string $post_status  The status of the lessons.
 	 *
 	 * @return array $non_module_lessons
 	 */
-	public function get_none_module_lessons( $course_id ) {
+	public function get_none_module_lessons( $course_id, $post_status = 'publish' ) {
 
 		$non_module_lessons = array();
 
@@ -1767,7 +1768,7 @@ class Sensei_Core_Modules {
 
 		$args = array(
 			'post_type'        => 'lesson',
-			'post_status'      => 'publish',
+			'post_status'      => $post_status,
 			'posts_per_page'   => -1,
 			'meta_query'       => array(
 				array(


### PR DESCRIPTION
### Changes proposed in this Pull Request

* With this change the lesson order is generated correctly when a course has modules.
* The lesson order column retains the same format.
* The lessons will be ordered like `<ID of first lesson of first module>,<ID of second lesson of first module>,<ID of first lesson of second module>,...<ID of first lesson with no module>,...<ID of last lesson with no module>`

### Testing instructions

* Create a course with modules and lessons belonging to the modules.
* Set an order for both modules and lessons.
* Export the course and check that the order of the lessons is as displayed on the frontend.