### PR TITLE
Fix duplicated importing

### DIFF
--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -150,6 +150,8 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	 * @return Sensei_Data_Port_Job|null instance.
 	 */
 	public static function get( $job_id ) {
+		$option_name = self::get_option_name( $job_id );
+
 		/**
 		 * It solves an issue when we are working with the `process` endpoint,
 		 * along the scheduled job. Sometimes in the requests racing, a request
@@ -159,9 +161,9 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 		 * It's noticed more frequently when WooCommerce is not installed, and
 		 * the Sensei_Scheduler is using WP Cron.
 		 */
-		wp_cache_delete( 'alloptions', 'options' );
+		wp_cache_delete( $option_name, 'options' );
 
-		$json = get_option( self::get_option_name( $job_id ), '' );
+		$json = get_option( $option_name, '' );
 
 		if ( empty( $json ) ) {
 			return null;
@@ -416,7 +418,7 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	 */
 	public function persist() {
 		if ( ! $this->is_deleted && $this->has_changed ) {
-			update_option( self::get_option_name( $this->job_id ), wp_json_encode( $this ) );
+			update_option( self::get_option_name( $this->job_id ), wp_json_encode( $this ), false );
 		}
 
 		$this->has_changed = false;

--- a/includes/data-port/class-sensei-data-port-job.php
+++ b/includes/data-port/class-sensei-data-port-job.php
@@ -150,6 +150,17 @@ abstract class Sensei_Data_Port_Job implements Sensei_Background_Job_Interface, 
 	 * @return Sensei_Data_Port_Job|null instance.
 	 */
 	public static function get( $job_id ) {
+		/**
+		 * It solves an issue when we are working with the `process` endpoint,
+		 * along the scheduled job. Sometimes in the requests racing, a request
+		 * starts, when the other is setting some option, like the job state.
+		 * So it would get the old (cached) option.
+		 *
+		 * It's noticed more frequently when WooCommerce is not installed, and
+		 * the Sensei_Scheduler is using WP Cron.
+		 */
+		wp_cache_delete( 'alloptions', 'options' );
+
 		$json = get_option( self::get_option_name( $job_id ), '' );
 
 		if ( empty( $json ) ) {

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -321,7 +321,7 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 	 */
 	public function persist() {
 		if ( $this->has_changed ) {
-			update_option( self::OPTION_NAME, wp_json_encode( $this ) );
+			update_option( self::OPTION_NAME, wp_json_encode( $this ), false );
 		}
 
 		$this->has_changed = false;


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR solves an issue when we are working with the `process` endpoint, along the scheduled job for the importer. Sometimes in the requests racing, a request starts before the other is setting the job state option. So it would get the old (cached) option.

It's more frequently noticed when WooCommerce is not installed, and the `Sensei_Scheduler` is using WP Cron.

I tried to clear the options cache in different moments, but it was reliable only immediately before the `get_option`. I also tried to research a different approach to use instead of clearing all options, but I didn't find a good one. Ideas are very welcome if there is something different to try.

### Testing instructions

* Deactivate the WooCommerce plugin if it's activated (to use the WP Cron instead of the Action Scheduler).
* Go to the importer.
* Import the following CSV:
    ```
    Id,Course,Slug,Description,Excerpt,"Teacher Username","Teacher 
    Email",Modules,Prerequisite,Featured,Categories,Image,Video,Notifications
    ,"Course",,,,,,,,,,,,
    ```
* Make sure it imported only one course only.

This error is intermittent. For me, it happened ~80% of the tries. So I recommend you simulate the issue before to see how intermittent it'll occur in your env, so you can test better this solution (with multiple imports).