### PR TITLE
Reverse the exported value of notifications

### DIFF
--- a/includes/data-port/export-tasks/class-sensei-export-courses.php
+++ b/includes/data-port/export-tasks/class-sensei-export-courses.php
@@ -40,7 +40,7 @@ class Sensei_Export_Courses
 		$featured      = get_post_meta( $post->ID, '_course_featured', true );
 		$image         = get_the_post_thumbnail_url( $post, 'full' );
 		$video         = get_post_meta( $post->ID, '_course_video_embed', true );
-		$notifications = ! get_post_meta( $post->ID, 'disable_notification', true );
+		$notifications = get_post_meta( $post->ID, 'disable_notification', true );
 		$categories    = get_the_terms( $post->ID, 'course-category' );
 		$modules       = Sensei()->modules->get_course_modules( $post->ID );
 		$lessons       = $this->get_ordered_course_lessons( $post->ID );

--- a/includes/data-port/models/class-sensei-data-port-course-schema.php
+++ b/includes/data-port/models/class-sensei-data-port-course-schema.php
@@ -27,7 +27,7 @@ class Sensei_Data_Port_Course_Schema extends Sensei_Data_Port_Schema {
 	const COLUMN_CATEGORIES       = 'categories';
 	const COLUMN_IMAGE            = 'image';
 	const COLUMN_VIDEO            = 'video';
-	const COLUMN_NOTIFICATIONS    = 'notifications';
+	const COLUMN_NOTIFICATIONS    = 'disable notifications';
 
 
 	/**

--- a/sample-data/courses.csv
+++ b/sample-data/courses.csv
@@ -1,4 +1,4 @@
-Id,Course,Slug,Description,Excerpt,"Teacher Username","Teacher Email",Lessons,Modules,Prerequisite,Featured,Categories,Image,Video,Notifications
+Id,Course,Slug,Description,Excerpt,"Teacher Username","Teacher Email",Lessons,Modules,Prerequisite,Featured,Categories,Image,Video,"Disable Notifications"
 2990,"Getting Started with Sensei LMS",getting-started-with-sensei-lms,"<!-- wp:paragraph -->
 <p>Ready to publish your first course with Sensei LMS? This document will help you get started.</p>
 <!-- /wp:paragraph -->

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-courses.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-courses.php
@@ -262,7 +262,7 @@ class Sensei_Export_Courses_Tests extends WP_UnitTestCase {
 			[
 				'featured'      => '1',
 				'video'         => '<iframe>',
-				'notifications' => '1',
+				'notifications' => '0',
 			],
 			$result[0]
 		);

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-courses.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-courses.php
@@ -260,9 +260,9 @@ class Sensei_Export_Courses_Tests extends WP_UnitTestCase {
 
 		$this->assertArraySubset(
 			[
-				'featured'      => '1',
-				'video'         => '<iframe>',
-				'notifications' => '0',
+				'featured'              => '1',
+				'video'                 => '<iframe>',
+				'disable notifications' => '0',
 			],
 			$result[0]
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request

* The 'Notifications' column should follow the value of the checkbox in admin. So a value of '1' should mean that the checkbox is enabled (and the notifications are disabled). This PR fixes the issue where the opposite was true during exporting.

### Testing instructions

* Export two courses, one with notifications disabled (checked) and one with notifications enabled (unchecked).
* Observe that in the first case the exported value is '1' and in the second it's '0'.