### PR TITLE
Bump WP versions for travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ jobs:
         - ./tests/bin/run-wp-unit-tests.sh
     - stage: test
       php: 5.6
-      env: WP_VERSION=5.0
+      env: WP_VERSION=5.3
       script:
         - ./tests/bin/run-wp-unit-tests.sh
     - stage: test
@@ -126,16 +126,10 @@ jobs:
         - ./scripts/linter-ci
     - stage: test
       <<: *e2e_defaults
-      env: RUN_E2E=1
-    - stage: test
-      <<: *e2e_defaults
-      env: WP_VERSION=5.0 RUN_E2E=1
-    - stage: test
-      <<: *e2e_defaults
-      env: WP_VERSION=5.1 RUN_E2E=1
-    - stage: test
-      <<: *e2e_defaults
-      env: WP_VERSION=5.2 RUN_E2E=1
-    - stage: test
-      <<: *e2e_defaults
       env: WP_VERSION=5.3 RUN_E2E=1
+    - stage: test
+      <<: *e2e_defaults
+      env: WP_VERSION=5.4 RUN_E2E=1
+    - stage: test
+      <<: *e2e_defaults
+      env: WP_VERSION=5.5 RUN_E2E=1


### PR DESCRIPTION
Just bumping WP versions for Travis tests.

It started breaks in our E2E tests because it installs the Certificates plugin and its minimum WP version was already bumped.