### PR TITLE
Fix export question randomise

### DIFF
--- a/includes/data-port/export-tasks/class-sensei-export-questions.php
+++ b/includes/data-port/export-tasks/class-sensei-export-questions.php
@@ -62,7 +62,7 @@ class Sensei_Export_Questions
 				Schema::COLUMN_STATUS          => $post->post_status,
 				Schema::COLUMN_TYPE            => $question_type,
 				Schema::COLUMN_GRADE           => $grade,
-				Schema::COLUMN_RANDOM_ORDER    => 'multiple-choice' === $question_type && $meta['_random_order'] ? 1 : '',
+				Schema::COLUMN_RANDOM_ORDER    => 'multiple-choice' === $question_type && 'yes' === $meta['_random_order'] ? 1 : '',
 				Schema::COLUMN_MEDIA           => $this->get_media( $meta['_question_media'] ),
 				Schema::COLUMN_CATEGORIES      => $categories ? Sensei_Data_Port_Utilities::serialize_term_list( $categories ) : '',
 				Schema::COLUMN_ANSWER          => '',

--- a/includes/data-port/export-tasks/class-sensei-export-questions.php
+++ b/includes/data-port/export-tasks/class-sensei-export-questions.php
@@ -62,7 +62,7 @@ class Sensei_Export_Questions
 				Schema::COLUMN_STATUS          => $post->post_status,
 				Schema::COLUMN_TYPE            => $question_type,
 				Schema::COLUMN_GRADE           => $grade,
-				Schema::COLUMN_RANDOM_ORDER    => 'multiple-choice' === $question_type && 'yes' === $meta['_random_order'] ? 1 : '',
+				Schema::COLUMN_RANDOM_ORDER    => 'multiple-choice' === $question_type && 'yes' === $meta['_random_order'] ? 1 : 0,
 				Schema::COLUMN_MEDIA           => $this->get_media( $meta['_question_media'] ),
 				Schema::COLUMN_CATEGORIES      => $categories ? Sensei_Data_Port_Utilities::serialize_term_list( $categories ) : '',
 				Schema::COLUMN_ANSWER          => '',

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
@@ -179,7 +179,7 @@ class Sensei_Export_Questions_Tests extends WP_UnitTestCase {
 		$this->assertArraySubset(
 			[
 				'answer'              => 'Right:Right answer,Wrong:Wrong 1,"Wrong:Wrong,comma","Wrong:Wrong,comma,\"quote\""',
-				'random answer order' => '',
+				'random answer order' => '0',
 			],
 			$result[0]
 		);

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
@@ -170,7 +170,7 @@ class Sensei_Export_Questions_Tests extends WP_UnitTestCase {
 				'question_type'          => 'multiple-choice',
 				'question_right_answers' => [ 'Right answer' ],
 				'question_wrong_answers' => [ 'Wrong 1', 'Wrong,comma', 'Wrong,comma,"quote"' ],
-				'random answer order'    => '1',
+				'random_order'           => 'no',
 			]
 		);
 
@@ -178,7 +178,27 @@ class Sensei_Export_Questions_Tests extends WP_UnitTestCase {
 
 		$this->assertArraySubset(
 			[
-				'answer' => 'Right:Right answer,Wrong:Wrong 1,"Wrong:Wrong,comma","Wrong:Wrong,comma,\"quote\""',
+				'answer'              => 'Right:Right answer,Wrong:Wrong 1,"Wrong:Wrong,comma","Wrong:Wrong,comma,\"quote\""',
+				'random answer order' => '',
+			],
+			$result[0]
+		);
+	}
+
+	public function testMultipleChoiceRandomOrder() {
+		$this->factory->question->create(
+			[
+				'quiz_id'       => null,
+				'question_type' => 'multiple-choice',
+				'random_order'  => 'yes',
+			]
+		);
+
+		$result = $this->export();
+
+		$this->assertArraySubset(
+			[
+				'random answer order' => '1',
 			],
 			$result[0]
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix an issue when exporting a question with the "Randomise answer order" enabled. It was always exporting as enabled. The check was updated to `'yes'`.

### Testing instructions

* Create a multiple choice question.
* Disable the option "Randomise answer order".
* Create another multiple choice question.
* Enable the option "Randomise answer order".
* Export the questions.
* Make sure the questions were exported with the correct values in the "Random Answer Order" field.