### PR TITLE
Fix export question media

### DIFF
--- a/includes/data-port/export-tasks/class-sensei-export-questions.php
+++ b/includes/data-port/export-tasks/class-sensei-export-questions.php
@@ -63,7 +63,7 @@ class Sensei_Export_Questions
 				Schema::COLUMN_TYPE            => $question_type,
 				Schema::COLUMN_GRADE           => $grade,
 				Schema::COLUMN_RANDOM_ORDER    => 'multiple-choice' === $question_type && $meta['_random_order'] ? 1 : '',
-				Schema::COLUMN_MEDIA           => ! empty( $meta['_question_media'] ) ? wp_get_attachment_image_url( $meta['_question_media'], 'full' ) : '',
+				Schema::COLUMN_MEDIA           => $this->get_media( $meta['_question_media'] ),
 				Schema::COLUMN_CATEGORIES      => $categories ? Sensei_Data_Port_Utilities::serialize_term_list( $categories ) : '',
 				Schema::COLUMN_ANSWER          => '',
 				Schema::COLUMN_FEEDBACK        => $meta['_answer_feedback'],
@@ -75,6 +75,25 @@ class Sensei_Export_Questions
 			],
 			$this->get_answer_fields( $question_type, $meta )
 		);
+	}
+
+	/**
+	 * Get media.
+	 *
+	 * @param int $attachment Attachment ID.
+	 *
+	 * @return string Media path.
+	 */
+	private function get_media( $attachment ) {
+		if ( empty( $attachment ) ) {
+			return '';
+		}
+
+		if ( wp_attachment_is_image( $attachment ) ) {
+			return wp_get_attachment_image_url( $attachment, 'full' );
+		}
+
+		return wp_get_attachment_url( $attachment );
 	}
 
 	/**

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
@@ -111,7 +111,7 @@ class Sensei_Export_Questions_Tests extends WP_UnitTestCase {
 		);
 	}
 
-	public function testQuestionMediaExported() {
+	public function testQuestionImageMediaExported() {
 
 		$image_id = $this->factory->attachment->create(
 			[
@@ -132,6 +132,32 @@ class Sensei_Export_Questions_Tests extends WP_UnitTestCase {
 		$this->assertArraySubset(
 			[
 				'media' => 'http://example.org/wp-content/uploads/question-img.jpg',
+			],
+			$result[0]
+		);
+	}
+
+	public function testQuestionAudioMediaExported() {
+
+		$image_id = $this->factory->attachment->create(
+			[
+				'file'           => 'question-sound.mp3',
+				'post_mime_type' => 'audio/mp3',
+			]
+		);
+		$this->factory->question->create(
+			[
+				'quiz_id'        => null,
+				'question_type'  => 'single-line',
+				'question_media' => $image_id,
+			]
+		);
+
+		$result = $this->export();
+
+		$this->assertArraySubset(
+			[
+				'media' => 'http://example.org/wp-content/uploads/question-sound.mp3',
 			],
 			$result[0]
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix the question media export. It was exporting only images and now it exports also the other types.

### Testing instructions

* Create a question.
* Attach a media that is not an image (audio or video).
* Export the questions, and make sure the media was exported correctly.