### PR TITLE
Allow draft course prerequisites

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -320,6 +320,7 @@ class Sensei_Course {
 			'order'            => 'DESC',
 			'exclude'          => $post->ID,
 			'suppress_filters' => 0,
+			'post_status'      => 'any',
 		);
 		$posts_array = get_posts( $post_args );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

There is an issue where courses do not appear in the prerequisites meta box if they are not published. This means that if the prerequisite is not published and the course gets updated, the prerequisite relation is deleted. This PR fixes this issue.

The issue becomes more important during import as all courses are imported as draft.

### Testing instructions

* Have a course with a prerequisite.
* Switch the prerequisite to draft.
* Observe that the prerequisite is still listed in the meta box.
* Update the course and observe that the prerequisite relation is not lost.