### PR TITLE
Importer: Fix division by zero when there are no association tasks

### DIFF
--- a/includes/data-port/import-tasks/class-sensei-import-associations.php
+++ b/includes/data-port/import-tasks/class-sensei-import-associations.php
@@ -390,8 +390,12 @@ class Sensei_Import_Associations
 		$completed            = 0;
 
 		if ( isset( $this->total_tasks ) ) {
-			$remaining = $this->get_remaining_tasks();
-			$completed = floor( ( ( $this->total_tasks - $remaining ) / $this->total_tasks ) * $artificial_task_size );
+			if ( 0 === $this->total_tasks ) {
+				$completed = $artificial_task_size;
+			} else {
+				$remaining = $this->get_remaining_tasks();
+				$completed = floor( ( ( $this->total_tasks - $remaining ) / $this->total_tasks ) * $artificial_task_size );
+			}
 		}
 
 		return [


### PR DESCRIPTION
Fixes #3556

### Changes proposed in this Pull Request

* Fixes division by zero when there are no association tasks in importer.

### Testing instructions

* Import only questions and verify nothing appears in debug log. (See issue)
