### PR TITLE
Fix export answers order

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -1679,7 +1679,7 @@ class Sensei_Lesson {
 
 					$answers_sorted = $answers;
 					if ( $question_id && count( $answer_order ) > 0 ) {
-						$answers_sorted = $this->get_answers_sorted( $answers, $answer_order );
+						$answers_sorted = Sensei()->question->get_answers_sorted( $answers, $answer_order );
 					}
 
 					foreach ( $answers_sorted as $id => $answer ) {
@@ -1908,7 +1908,7 @@ class Sensei_Lesson {
 	/**
 	 * Get answers ID (text md5).
 	 *
-	 * @param string[] $answer Answer text.
+	 * @param string $answer Answer text.
 	 *
 	 * @return string Answer ID.
 	 */
@@ -1920,54 +1920,6 @@ class Sensei_Lesson {
 		}
 
 		return $answer_id;
-	}
-
-	/**
-	 * Get answers by ID keys.
-	 *
-	 * @param string[] $answers Answers string.
-	 *
-	 * @return string[] Answers with the correct ID keys.
-	 */
-	public function get_answers_by_id( $answers = [] ) {
-		$answers_by_id = [];
-
-		foreach( $answers as $answer ) {
-			$answers_by_id[ $this->get_answer_id( $answer ) ] = $answer;
-		}
-
-		return $answers_by_id;
-	}
-
-	/**
-	 * Get answers sorted.
-	 *
-	 * @param string[]        $answers      Answers string by ID.
-	 * @param string[]|string $answer_order Sorted answers IDs.
-	 *
-	 * @return string[] The sorted answers.
-	 */
-	public function get_answers_sorted( $answers, $answer_order ) {
-		$answers_sorted = [];
-
-		if ( is_string( $answer_order ) ) {
-			$answer_order =  explode( ',', $answer_order );
-		}
-
-		foreach ( $answer_order as $answer_id ) {
-			if ( isset( $answers[ $answer_id ] ) ) {
-				$answers_sorted[ $answer_id ] = $answers[ $answer_id ];
-				unset( $answers[ $answer_id ] );
-			}
-		}
-
-		if ( count( $answers ) > 0 ) {
-			foreach ( $answers as $id => $answer ) {
-				$answers_sorted[ $id ] = $answer;
-			}
-		}
-
-		return $answers_sorted;
 	}
 
 	/**

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -1679,19 +1679,7 @@ class Sensei_Lesson {
 
 					$answers_sorted = $answers;
 					if ( $question_id && count( $answer_order ) > 0 ) {
-						$answers_sorted = array();
-						foreach ( $answer_order as $answer_id ) {
-							if ( isset( $answers[ $answer_id ] ) ) {
-								$answers_sorted[ $answer_id ] = $answers[ $answer_id ];
-								unset( $answers[ $answer_id ] );
-							}
-						}
-
-						if ( count( $answers ) > 0 ) {
-							foreach ( $answers as $id => $answer ) {
-								$answers_sorted[ $id ] = $answer;
-							}
-						}
+						$answers_sorted = $this->get_answers_sorted( $answers, $answer_order );
 					}
 
 					foreach ( $answers_sorted as $id => $answer ) {
@@ -1917,8 +1905,14 @@ class Sensei_Lesson {
 		die();
 	}
 
+	/**
+	 * Get answers ID (text md5).
+	 *
+	 * @param string[] $answer Answer text.
+	 *
+	 * @return string Answer ID.
+	 */
 	public function get_answer_id( $answer = '' ) {
-
 		$answer_id = '';
 
 		if ( $answer ) {
@@ -1926,7 +1920,54 @@ class Sensei_Lesson {
 		}
 
 		return $answer_id;
+	}
 
+	/**
+	 * Get answers by ID keys.
+	 *
+	 * @param string[] $answers Answers string.
+	 *
+	 * @return string[] Answers with the correct ID keys.
+	 */
+	public function get_answers_by_id( $answers = [] ) {
+		$answers_by_id = [];
+
+		foreach( $answers as $answer ) {
+			$answers_by_id[ $this->get_answer_id( $answer ) ] = $answer;
+		}
+
+		return $answers_by_id;
+	}
+
+	/**
+	 * Get answers sorted.
+	 *
+	 * @param string[]        $answers      Answers string by ID.
+	 * @param string[]|string $answer_order Sorted answers IDs.
+	 *
+	 * @return string[] The sorted answers.
+	 */
+	public function get_answers_sorted( $answers, $answer_order ) {
+		$answers_sorted = [];
+
+		if ( is_string( $answer_order ) ) {
+			$answer_order =  explode( ',', $answer_order );
+		}
+
+		foreach ( $answer_order as $answer_id ) {
+			if ( isset( $answers[ $answer_id ] ) ) {
+				$answers_sorted[ $answer_id ] = $answers[ $answer_id ];
+				unset( $answers[ $answer_id ] );
+			}
+		}
+
+		if ( count( $answers ) > 0 ) {
+			foreach ( $answers as $id => $answer ) {
+				$answers_sorted[ $id ] = $answer;
+			}
+		}
+
+		return $answers_sorted;
 	}
 
 	/**

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1269,7 +1269,7 @@ class Sensei_Question {
 	public function get_answers_by_id( $answers = [] ) {
 		$answers_by_id = [];
 
-		foreach( $answers as $answer ) {
+		foreach ( $answers as $answer ) {
 			$answers_by_id[ Sensei()->lesson->get_answer_id( $answer ) ] = $answer;
 		}
 
@@ -1288,7 +1288,7 @@ class Sensei_Question {
 		$answers_sorted = [];
 
 		if ( is_string( $answer_order ) ) {
-			$answer_order =  explode( ',', $answer_order );
+			$answer_order = explode( ',', $answer_order );
 		}
 
 		foreach ( $answer_order as $answer_id ) {

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1260,6 +1260,54 @@ class Sensei_Question {
 	} // get_correct_answer
 
 	/**
+	 * Get answers by ID keys.
+	 *
+	 * @param string[] $answers Answers string.
+	 *
+	 * @return string[] Answers with the correct ID keys.
+	 */
+	public function get_answers_by_id( $answers = [] ) {
+		$answers_by_id = [];
+
+		foreach( $answers as $answer ) {
+			$answers_by_id[ Sensei()->lesson->get_answer_id( $answer ) ] = $answer;
+		}
+
+		return $answers_by_id;
+	}
+
+	/**
+	 * Get answers sorted.
+	 *
+	 * @param string[]        $answers      Answers string by ID.
+	 * @param string[]|string $answer_order Sorted answers IDs.
+	 *
+	 * @return string[] The sorted answers.
+	 */
+	public function get_answers_sorted( $answers, $answer_order ) {
+		$answers_sorted = [];
+
+		if ( is_string( $answer_order ) ) {
+			$answer_order =  explode( ',', $answer_order );
+		}
+
+		foreach ( $answer_order as $answer_id ) {
+			if ( isset( $answers[ $answer_id ] ) ) {
+				$answers_sorted[ $answer_id ] = $answers[ $answer_id ];
+				unset( $answers[ $answer_id ] );
+			}
+		}
+
+		if ( count( $answers ) > 0 ) {
+			foreach ( $answers as $id => $answer ) {
+				$answers_sorted[ $id ] = $answer;
+			}
+		}
+
+		return $answers_sorted;
+	}
+
+	/**
 	 * Log an event when a question is initially published.
 	 *
 	 * @since 2.1.0

--- a/includes/data-port/export-tasks/class-sensei-export-questions.php
+++ b/includes/data-port/export-tasks/class-sensei-export-questions.php
@@ -110,20 +110,26 @@ class Sensei_Export_Questions
 
 		switch ( $question_type ) {
 			case 'multiple-choice':
+				$answers_right = Sensei()->lesson->get_answers_by_id( (array) $meta['_question_right_answer'] );
+				$answers_wrong = Sensei()->lesson->get_answers_by_id( $meta['_question_wrong_answers'] );
+
 				$answers_right = array_map(
 					function( $value ) {
 						return 'Right:' . $value;
 					},
-					(array) $meta['_question_right_answer']
+					$answers_right
 				);
 				$answers_wrong = array_map(
 					function( $value ) {
 						return 'Wrong:' . $value;
 					},
-					$meta['_question_wrong_answers']
+					$answers_wrong
 				);
 
-				$columns[ Schema::COLUMN_ANSWER ] = Sensei_Data_Port_Utilities::serialize_list( array_merge( $answers_right, $answers_wrong ) );
+				$answers = array_merge( $answers_right, $answers_wrong );
+				$answers = Sensei()->lesson->get_answers_sorted( $answers, $meta['_answer_order'] );
+
+				$columns[ Schema::COLUMN_ANSWER ] = Sensei_Data_Port_Utilities::serialize_list( $answers );
 
 				break;
 			case 'boolean':

--- a/includes/data-port/export-tasks/class-sensei-export-questions.php
+++ b/includes/data-port/export-tasks/class-sensei-export-questions.php
@@ -110,8 +110,8 @@ class Sensei_Export_Questions
 
 		switch ( $question_type ) {
 			case 'multiple-choice':
-				$answers_right = Sensei()->lesson->get_answers_by_id( (array) $meta['_question_right_answer'] );
-				$answers_wrong = Sensei()->lesson->get_answers_by_id( $meta['_question_wrong_answers'] );
+				$answers_right = Sensei()->question->get_answers_by_id( (array) $meta['_question_right_answer'] );
+				$answers_wrong = Sensei()->question->get_answers_by_id( $meta['_question_wrong_answers'] );
 
 				$answers_right = array_map(
 					function( $value ) {
@@ -127,7 +127,7 @@ class Sensei_Export_Questions
 				);
 
 				$answers = array_merge( $answers_right, $answers_wrong );
-				$answers = Sensei()->lesson->get_answers_sorted( $answers, $meta['_answer_order'] );
+				$answers = Sensei()->question->get_answers_sorted( $answers, $meta['_answer_order'] );
 
 				$columns[ Schema::COLUMN_ANSWER ] = Sensei_Data_Port_Utilities::serialize_list( $answers );
 

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
@@ -171,7 +171,7 @@ class Sensei_Export_Questions_Tests extends WP_UnitTestCase {
 				'question_right_answers' => [ 'Right answer' ],
 				'question_wrong_answers' => [ 'Wrong,comma', 'Wrong 1', 'Wrong,comma,"quote"' ],
 				'random_order'           => 'no',
-				'answer_order'           => 'ac70b9a3f24b5b657826b567057169a2,b13d55d1ff11d676253fa5e4b0517bd7,030fd8dc91a34a0248eef3a515560a00,89dc5589bfebac1468e8823afd5a4861'
+				'answer_order'           => 'ac70b9a3f24b5b657826b567057169a2,b13d55d1ff11d676253fa5e4b0517bd7,030fd8dc91a34a0248eef3a515560a00,89dc5589bfebac1468e8823afd5a4861',
 			]
 		);
 

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
@@ -169,8 +169,9 @@ class Sensei_Export_Questions_Tests extends WP_UnitTestCase {
 				'quiz_id'                => null,
 				'question_type'          => 'multiple-choice',
 				'question_right_answers' => [ 'Right answer' ],
-				'question_wrong_answers' => [ 'Wrong 1', 'Wrong,comma', 'Wrong,comma,"quote"' ],
+				'question_wrong_answers' => [ 'Wrong,comma', 'Wrong 1', 'Wrong,comma,"quote"' ],
 				'random_order'           => 'no',
+				'answer_order'           => 'ac70b9a3f24b5b657826b567057169a2,b13d55d1ff11d676253fa5e4b0517bd7,030fd8dc91a34a0248eef3a515560a00,89dc5589bfebac1468e8823afd5a4861'
 			]
 		);
 
@@ -178,7 +179,7 @@ class Sensei_Export_Questions_Tests extends WP_UnitTestCase {
 
 		$this->assertArraySubset(
 			[
-				'answer'              => 'Right:Right answer,Wrong:Wrong 1,"Wrong:Wrong,comma","Wrong:Wrong,comma,\"quote\""',
+				'answer'              => 'Wrong:Wrong 1,"Wrong:Wrong,comma","Wrong:Wrong,comma,\"quote\"",Right:Right answer',
 				'random answer order' => '0',
 			],
 			$result[0]


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix the order of the exporting answers, using the `_answer_order` to export in the correct order.

### Testing instructions

* Create a multiple choice question shuffling right and wrong answers order.
* Export the questions and make sure the answers were exported in the correct order.