### PR TITLE
Make the error more descriptive when the attachment fetch request fails

### DIFF
--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -150,7 +150,7 @@ class Sensei_Data_Port_Utilities {
 		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
 			return new WP_Error(
 				'sensei_data_port_attachment_failure',
-				__( 'No attachment with the specified file name was found.', 'sensei-lms' )
+				__( 'Error encountered while retrieving the attachment from the provided URL.', 'sensei-lms' )
 			);
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* A minor fix which improves the error message when the request which fetches the attachment fails.

### Testing instructions

* Import a course which has an inaccessible url in the image column.
* Observe the displayed error.