### PR TITLE
Add prettier configuration

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	...require( '@wordpress/prettier-config' ),
+};

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "@wordpress/icons": "2.4.0",
     "@wordpress/jest-preset-default": "6.2.0",
     "@wordpress/postcss-themes": "2.6.0",
+    "@wordpress/prettier-config": "0.3.0",
     "@wordpress/scripts": "12.1.1",
     "buffer": "5.6.0",
     "chownr": "2.0.0",
@@ -63,9 +64,9 @@
     "prettier": "npm:wp-prettier@2.0.5",
     "pump": "3.0.0",
     "puppeteer-core": "npm:puppeteer-core@3.0.0",
+    "react-test-renderer": "16.13.1",
     "tar-fs": "2.1.0",
     "unbzip2-stream": "1.4.3",
-    "react-test-renderer": "16.13.1",
     "wp-hookdoc": "0.2.0"
   },
   "resolutions": {


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR purpose is adding the prettier configurations to the project. So we don't need to bother more about formatting our code, like an annoying situation when our line get a little bigger and we have to reformat a lot of indentation.

It'll reformat our JS and CSS files.

Similar to the `npm run format-js` that we're using in Husky, we can have old files being committed reformatted until it happens for all our files. In this case, a good recommendation is to commit the reformatting separately. If that bothers us, we can run it one time to all the codebase.

### Testing instructions

* Activate the auto-format in your editor, and triggered by your preference, if your editor has options for that (save, type, paste...). In  the VSCode, for example, I like to use it on save:

<img width="775" alt="Screen Shot 2020-08-26 at 11 42 32" src="https://user-images.githubusercontent.com/876340/91318296-735d7400-e791-11ea-9b7a-2fa7f7204ccd.png">

* Go to a CSS and JS file, edit it in a way that it needs reformating.
* Save (or another trigger that you choose) and make sure it was automatically formatted.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![prettier](https://user-images.githubusercontent.com/876340/91319268-9177a400-e792-11ea-8cae-5516ef8d4067.gif)
