### PR TITLE
Add eslint jsdoc alignment plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,8 @@ module.exports = {
 				allowedTextDomain: 'sensei-lms',
 			},
 		],
-		'react-hooks/exhaustive-deps': 'warn'
+		'react-hooks/exhaustive-deps': 'warn',
+		'jsdoc-alignment/lines-alignment': 'error',
 	},
-	plugins: [ 'jest' ],
+	plugins: [ 'jest', 'jsdoc-alignment' ],
 };

--- a/assets/data-port/export/export-page.js
+++ b/assets/data-port/export/export-page.js
@@ -7,9 +7,9 @@ import { ExportSelectContentPage } from './export-select-content-page';
 /**
  * Export page.
  *
- * @param {Object} props
- * @param {Object} props.job
- * @param {Object} props.error
+ * @param {Object}   props
+ * @param {Object}   props.job
+ * @param {Object}   props.error
  * @param {Function} props.start
  * @param {Function} props.reset
  * @param {Function} props.cancel

--- a/assets/data-port/export/export-progress-page.js
+++ b/assets/data-port/export/export-progress-page.js
@@ -6,10 +6,10 @@ import { Notice } from '../notice';
 
 /**
  * @typedef Job
- * @property {string}       status      Export status.
- * @property {number}       percentage  Export progress percentage.
- * @property {ExportFile[]} files       Exported files.
- * @property {string}       error       Error message.
+ * @property {string}       status     Export status.
+ * @property {number}       percentage Export progress percentage.
+ * @property {ExportFile[]} files      Exported files.
+ * @property {string}       error      Error message.
  */
 /**
  * @typedef ExportFile

--- a/assets/data-port/export/store/actions.js
+++ b/assets/data-port/export/store/actions.js
@@ -159,9 +159,9 @@ export const checkForActiveJob = function* () {
 /**
  * Perform REST API request for a job and apply returned job state.
  *
- * @param {Object} options            apiFetch request object.
- * @param {string?} options.endpoint  Request sub-path in exporter API.
- * @param {string?} options.jobId     Override job ID
+ * @param {Object}  options          apiFetch request object.
+ * @param {string?} options.endpoint Request sub-path in exporter API.
+ * @param {string?} options.jobId    Override job ID
  * @return {JobResponse|LogsResponse} Job or logs response.
  */
 const sendJobRequest = function* ( options = {} ) {

--- a/assets/data-port/import/data/actions.js
+++ b/assets/data-port/import/data/actions.js
@@ -24,8 +24,8 @@ import { buildJobEndpointUrl } from '../helpers/url';
 
 /**
  * @typedef  {Object} FetchFromAPIAction
- * @property {string} type               Action type.
- * @property {Object} request            Object that is used to fetch.
+ * @property {string} type    Action type.
+ * @property {Object} request Object that is used to fetch.
  */
 /**
  * Fetch action creator.
@@ -187,8 +187,8 @@ export const successStartImport = ( data ) => ( {
 
 /**
  * @typedef  {Object}         ErrorStartImportAction
- * @property {string}         type   Action type.
- * @property {Object|boolean} error  Error object or false.
+ * @property {string}         type  Action type.
+ * @property {Object|boolean} error Error object or false.
  */
 /**
  * Error start import job creator.
@@ -205,12 +205,12 @@ export const errorStartImport = ( error ) => ( {
 /**
  * Upload a file for a level.
  *
- * @param {string}   jobId                 The job identifier.
- * @param {string}   level                 Level identifier.
- * @param {Object}   uploadData            Data to submit.
+ * @param {string}   jobId               The job identifier.
+ * @param {string}   level               Level identifier.
+ * @param {Object}   uploadData          Data to submit.
  * @param {Object}   [options]
- * @param {Function} [options.onSuccess]   Callback on success.
- * @param {Function} [options.onError]     Callback on error.
+ * @param {Function} [options.onSuccess] Callback on success.
+ * @param {Function} [options.onError]   Callback on error.
  */
 export function* uploadFileForLevel(
 	jobId,
@@ -259,9 +259,9 @@ export const throwEarlyUploadError = ( level, errorMsg ) =>
 
 /**
  * @typedef  {Object} StartFileUploadAction
- * @property {string} type        Action type.
- * @property {string} level       Level identifier.
- * @property {Object} uploadData  Error object or false.
+ * @property {string} type       Action type.
+ * @property {string} level      Level identifier.
+ * @property {Object} uploadData Error object or false.
  */
 /**
  * Start file upload action creator.
@@ -279,9 +279,9 @@ export const startFileUploadAction = ( level, uploadData ) => ( {
 
 /**
  * @typedef  {Object} SuccessFileUploadAction
- * @property {string} type    Action type.
- * @property {string} level   Level identifier.
- * @property {Object} data    Data object.
+ * @property {string} type  Action type.
+ * @property {string} level Level identifier.
+ * @property {Object} data  Data object.
  */
 /**
  * Success upload file action.
@@ -298,9 +298,9 @@ export const successFileUpload = ( level, data ) => ( {
 
 /**
  * @typedef  {Object}         ErrorFileUploadAction
- * @property {string}         type              Action type.
- * @property {string}         level             Level identifier.
- * @property {Object|boolean} error             Error object or false.
+ * @property {string}         type  Action type.
+ * @property {string}         level Level identifier.
+ * @property {Object|boolean} error Error object or false.
  */
 /**
  * Error submit action creator.
@@ -350,8 +350,8 @@ export function* deleteLevelFile( jobId, level ) {
 
 /**
  * @typedef  {Object} StartDeleteLevelFileAction
- * @property {string} type        Action type.
- * @property {string} level       Level identifier.
+ * @property {string} type  Action type.
+ * @property {string} level Level identifier.
  */
 /**
  * Start file upload action creator.
@@ -367,9 +367,9 @@ export const startDeleteLevelFileAction = ( level ) => ( {
 
 /**
  * @typedef  {Object} SuccessDeleteLevelFileAction
- * @property {string} type    Action type.
- * @property {string} level   Level identifier.
- * @property {Object} data    Data object.
+ * @property {string} type  Action type.
+ * @property {string} level Level identifier.
+ * @property {Object} data  Data object.
  */
 /**
  * Success delete level file action.
@@ -386,15 +386,15 @@ export const successDeleteLevelFileAction = ( level, data ) => ( {
 
 /**
  * @typedef  {Object}  ErrorSuccessDeleteLevelFileAction
- * @property {string}  type              Action type.
- * @property {string}  level             Level identifier.
- * @property {Object}  error             Error object or false.
+ * @property {string} type  Action type.
+ * @property {string} level Level identifier.
+ * @property {Object} error Error object or false.
  */
 /**
  * Error delete level file action creator.
  *
- * @param {string}  level Level identifier.
- * @param {Object}  error Error object or false.
+ * @param {string} level Level identifier.
+ * @param {Object} error Error object or false.
  *
  * @return {ErrorSuccessDeleteLevelFileAction} Error delete level file action.
  */

--- a/assets/data-port/import/data/controls.js
+++ b/assets/data-port/import/data/controls.js
@@ -6,7 +6,7 @@ export default {
 	/**
 	 * Fetch control.
 	 *
-	 * @param  {{request: Object}} action Action with the request object that is used to fetch.
+	 * @param {{request: Object}} action Action with the request object that is used to fetch.
 	 *
 	 * @return {Promise} API fetch promise.
 	 */

--- a/assets/data-port/import/data/normalizer.js
+++ b/assets/data-port/import/data/normalizer.js
@@ -41,12 +41,12 @@ export const parseCompletedSteps = ( data ) => {
 /**
  *  * Normalize importer data.
  *
- * @param {Object} input          Importer data.
- * @param {number} input.id       The job id.
- * @param {Object} input.files    Files raw data.
- * @param {string} input.status   Job status.
- * @param {Object} input.results  Results of the job.
- * @param {Object} input.data     Job data.
+ * @param {Object} input         Importer data.
+ * @param {number} input.id      The job id.
+ * @param {Object} input.files   Files raw data.
+ * @param {string} input.status  Job status.
+ * @param {Object} input.results Results of the job.
+ * @param {Object} input.data    Job data.
  *
  * @return {Object} Normalized importer data.
  */

--- a/assets/data-port/import/data/reducer.js
+++ b/assets/data-port/import/data/reducer.js
@@ -64,9 +64,9 @@ const DEFAULT_STATE = {
 
 /**
  *
- * @param {Object}         state      Current state.
- * @param {{type: string}} levelKey   Level to update.
- * @param {Object}         attributes Attributes to set.
+ * @param {Object} state      Current state.
+ * @param {{type:  string}}   levelKey   Level to update.
+ * @param {Object} attributes Attributes to set.
  * @return {Object} State updated.
  */
 const updateLevelState = ( state, levelKey, attributes ) => ( {
@@ -80,8 +80,8 @@ const updateLevelState = ( state, levelKey, attributes ) => ( {
 /**
  * Data importer reducer.
  *
- * @param {Object}         state  Current state.
- * @param {{type: string}} action Action to update the state.
+ * @param {Object} state    Current state.
+ * @param {{type:  string}} action Action to update the state.
  *
  * @return {Object} State updated.
  */

--- a/assets/data-port/import/data/selectors.js
+++ b/assets/data-port/import/data/selectors.js
@@ -34,8 +34,8 @@ export const getFetchError = ( state ) => state.fetchError;
 /**
  * Step state selector.
  *
- * @param {Object}  state Current state.
- * @param {string}  step  Step name.
+ * @param {Object} state Current state.
+ * @param {string} step  Step name.
  *
  * @return {Object} Step data.
  */
@@ -44,8 +44,8 @@ export const getStepData = ( state, step ) => state[ step ];
 /**
  * Get navigation steps with their state.
  *
- * @param {Object} state                 Current state.
- * @param {Array}  state.completedSteps  An array of the completed steps.
+ * @param {Object} state                Current state.
+ * @param {Array}  state.completedSteps An array of the completed steps.
  *
  * @return {Array} Navigation steps.
  */
@@ -66,9 +66,9 @@ export const getNavigationSteps = ( { completedSteps } ) => {
 /**
  * Get whether step is complete or not.
  *
- * @param {Object} state                 Current state.
- * @param {Array}  state.completedSteps  An array of the completed steps.
- * @param {string} step                  Step name.
+ * @param {Object} state                Current state.
+ * @param {Array}  state.completedSteps An array of the completed steps.
+ * @param {string} step                 Step name.
  *
  * @return {boolean} Step complete.
  */
@@ -95,8 +95,8 @@ export const isReadyToStart = ( state ) => {
 /**
  * Get uploaded level keys.
  *
- * @param {Object} state         Current state.
- * @param {Object} state.upload  The upload status of all levels.
+ * @param {Object} state        Current state.
+ * @param {Object} state.upload The upload status of all levels.
  *
  * @return {string[]} Array of uploaded level keys.
  */
@@ -108,8 +108,8 @@ export const getUploadedLevelKeys = ( { upload } ) =>
 /**
  * Get success results.
  *
- * @param {Object} state       Current state.
- * @param {Object} state.done  The object which contains the results of the job.
+ * @param {Object} state      Current state.
+ * @param {Object} state.done The object which contains the results of the job.
  *
  * @return {Array} Success results.
  */
@@ -144,8 +144,8 @@ export const getLogsBySeverity = ( { done, upload } ) => {
 /**
  * Get logs fetch error.
  *
- * @param {Object} state       Current state.
- * @param {Object} state.done  The object which contains the logs of the job.
+ * @param {Object} state      Current state.
+ * @param {Object} state.done The object which contains the logs of the job.
  *
  * @return {Object|boolean} Error object or false.
  */

--- a/assets/data-port/import/done/done-page.js
+++ b/assets/data-port/import/done/done-page.js
@@ -7,13 +7,13 @@ import ImportSuccessResults from './import-success-results';
 /**
  * Done page of the importer.
  *
- * @param {Object}   input                  DonePage input.
- * @param {Function} input.restartImporter  A callback to be called when the importer gets restarted.
- * @param {Array}    input.successResults   The results of the job.
- * @param {Object}   input.logs             The logs of the job.
- * @param {boolean}  input.isFetching       Whether the logs of the job are currently fetching.
- * @param {boolean}  input.fetchError       Whether there was an error during fetching.
- * @param {Function} input.retry            Callback to be called when fetching is retried.
+ * @param {Object}   input                 DonePage input.
+ * @param {Function} input.restartImporter A callback to be called when the importer gets restarted.
+ * @param {Array}    input.successResults  The results of the job.
+ * @param {Object}   input.logs            The logs of the job.
+ * @param {boolean}  input.isFetching      Whether the logs of the job are currently fetching.
+ * @param {boolean}  input.fetchError      Whether there was an error during fetching.
+ * @param {Function} input.retry           Callback to be called when fetching is retried.
  */
 export const DonePage = ( {
 	restartImporter,

--- a/assets/data-port/import/done/import-log.js
+++ b/assets/data-port/import/done/import-log.js
@@ -23,9 +23,9 @@ const createTitleWithLink = ( title, editLink ) => {
 /**
  * ImportLog component.
  *
- * @param {Object} input        ImportLog input.
- * @param {Array}  input.items  An array of log items.
- * @param {string} input.type   Log type.
+ * @param {Object} input       ImportLog input.
+ * @param {Array}  input.items An array of log items.
+ * @param {string} input.type  Log type.
  */
 export const ImportLog = ( { items, type } ) => (
 	<div className="sensei-import-done__log-data">

--- a/assets/data-port/import/done/import-success-results.js
+++ b/assets/data-port/import/done/import-success-results.js
@@ -18,8 +18,8 @@ const getPostTypeLabel = ( { key, count } ) => {
 /**
  * ImportSuccessResults component.
  *
- * @param {Object} input                 ImportSuccessResults input.
- * @param {Array}  input.successResults  An array of counts of successfully imported items.
+ * @param {Object} input                ImportSuccessResults input.
+ * @param {Array}  input.successResults An array of counts of successfully imported items.
  */
 const ImportSuccessResults = ( { successResults } ) => (
 	<ul className="sensei-import-bullet-list">

--- a/assets/data-port/import/import-progress/import-progress-page.js
+++ b/assets/data-port/import/import-progress/import-progress-page.js
@@ -5,8 +5,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * This component displays the import progress page of the importer.
  *
- * @param {Object} input        ImportProgressPage input.
- * @param {Object} input.state  The import state.
+ * @param {Object} input       ImportProgressPage input.
+ * @param {Object} input.state The import state.
  */
 export const ImportProgressPage = ( { state } ) => {
 	const { percentage } = state;

--- a/assets/data-port/import/upload-level/upload-level.js
+++ b/assets/data-port/import/upload-level/upload-level.js
@@ -48,12 +48,12 @@ const uploadFile = (
  * A component which displays a list of upload levels. Each level has each own description, upload button and a
  * placeholder for messages.
  *
- * @param {Object}   input                        UploadLevels input.
- * @param {number}   input.jobId                  The job id.
- * @param {Object}   input.state                  The import state.
- * @param {Function} input.uploadFileForLevel     Callback for action to upload file.
- * @param {Function} input.throwEarlyUploadError  Callback for throwing an early upload error.
- * @param {Function} input.deleteLevelFile        The import state.
+ * @param {Object}   input                       UploadLevels input.
+ * @param {number}   input.jobId                 The job id.
+ * @param {Object}   input.state                 The import state.
+ * @param {Function} input.uploadFileForLevel    Callback for action to upload file.
+ * @param {Function} input.throwEarlyUploadError Callback for throwing an early upload error.
+ * @param {Function} input.deleteLevelFile       The import state.
  */
 export const UploadLevels = ( {
 	jobId,

--- a/assets/data-port/import/upload/upload-page.js
+++ b/assets/data-port/import/upload/upload-page.js
@@ -9,10 +9,10 @@ import { formatString } from '../../../shared/helpers/format-string.js';
 /**
  * This component displays the upload page of the importer.
  *
- * @param {Object}   input                    UploadPage input.
- * @param {Object}   input.state              The import state.
- * @param {boolean}  input.isReady            Whether the upload is finished.
- * @param {Function} input.submitStartImport  Callback which is called when start button is clicked.
+ * @param {Object}   input                   UploadPage input.
+ * @param {Object}   input.state             The import state.
+ * @param {boolean}  input.isReady           Whether the upload is finished.
+ * @param {Function} input.submitStartImport Callback which is called when start button is clicked.
  */
 export const UploadPage = ( { state, isReady, submitStartImport } ) => {
 	const { isSubmitting, errorMsg } = state;

--- a/assets/data-port/notice.js
+++ b/assets/data-port/notice.js
@@ -4,9 +4,9 @@ import classnames from 'classnames';
 /**
  * Sensei data port error notice.
  *
- * @param {Object}  input          Notice input.
- * @param {string}  input.message  The message to be displayed.
- * @param {boolean} input.isError  Whether the message is an error.
+ * @param {Object}  input         Notice input.
+ * @param {string}  input.message The message to be displayed.
+ * @param {boolean} input.isError Whether the message is an error.
  */
 export const Notice = ( { message, isError } ) => {
 	const messageClasses = classnames( {

--- a/assets/data-port/stepper/index.js
+++ b/assets/data-port/stepper/index.js
@@ -2,10 +2,10 @@ import classnames from 'classnames';
 
 /**
  * @typedef  {Object}   Step
- * @property {string}   key          Unique key for the step.
- * @property {string}   description  A description of the step that is going to be displayed.
- * @property {boolean}  isActive     True if the step is the currently active one.
- * @property {boolean}  isComplete   True if the step is completed.
+ * @property {string}  key         Unique key for the step.
+ * @property {string}  description A description of the step that is going to be displayed.
+ * @property {boolean} isActive    True if the step is the currently active one.
+ * @property {boolean} isComplete  True if the step is completed.
  */
 /**
  * A simple component to display a stepper on data port pages.

--- a/assets/js/grading-general.js
+++ b/assets/js/grading-general.js
@@ -1,5 +1,4 @@
-jQuery(document).ready( function( $ ) {
-
+jQuery( document ).ready( function ( $ ) {
 	/***************************************************************************************************
 	 * 	1 - Helper Functions.
 	 ***************************************************************************************************/
@@ -9,28 +8,32 @@ jQuery(document).ready( function( $ ) {
 	 * @since  1.2.0
 	 * @return boolean
 	 */
-	jQuery.fn.exists = function() {
-		return this.length>0;
+	jQuery.fn.exists = function () {
+		return this.length > 0;
 	};
 
 	/**
 	 * Calculates the total grade based on the questions already graded
 	 * @return void
 	 */
-	jQuery.fn.calculateTotalGrade = function() {
+	jQuery.fn.calculateTotalGrade = function () {
 		var question_id;
 		var question_grade;
 		var total_grade = 0;
 		var total_graded_questions = 0;
-		jQuery( '.question_box.user_right' ).each( function() {
+		jQuery( '.question_box.user_right' ).each( function () {
 			question_id = jQuery( this ).find( '.question_id' ).val();
-			question_grade = parseInt( jQuery( this ).find( '#question_' + question_id + '_grade' ).val() );
+			question_grade = parseInt(
+				jQuery( this )
+					.find( '#question_' + question_id + '_grade' )
+					.val()
+			);
 			total_grade += question_grade;
 			total_graded_questions++;
-		});
-		jQuery( '.question_box.user_wrong' ).each( function() {
+		} );
+		jQuery( '.question_box.user_wrong' ).each( function () {
 			total_graded_questions++;
-		});
+		} );
 
 		jQuery( '#total_graded_questions' ).val( total_graded_questions );
 
@@ -39,7 +42,9 @@ jQuery(document).ready( function( $ ) {
 		var percent = '0';
 
 		if ( 0 < quiz_grade_total ) {
-			percent = parseFloat( total_grade * 100 / quiz_grade_total ).toFixed(2);
+			percent = parseFloat(
+				( total_grade * 100 ) / quiz_grade_total
+			).toFixed( 2 );
 		}
 
 		percent = percent.replace( '.00', '' );
@@ -49,36 +54,41 @@ jQuery(document).ready( function( $ ) {
 		jQuery( '.total_grade_percent' ).html( percent );
 		jQuery( '.quiz_grade_total' ).html( quiz_grade_total );
 
-		if( total_questions == total_graded_questions ) {
+		if ( total_questions == total_graded_questions ) {
 			jQuery( '#all_questions_graded' ).val( 'yes' );
 			jQuery( '.grade-button' ).val( 'Grade' );
 		} else {
 			jQuery( '#all_questions_graded' ).val( 'no' );
 			jQuery( '.grade-button' ).val( 'Save' );
 		}
-
 	};
 
 	/**
 	 * Automatically grades questions where possible
 	 * @return void
 	 */
-	$.fn.autoGrade = function() {
-		$( '.question_box' ).each( function() {
+	$.fn.autoGrade = function () {
+		$( '.question_box' ).each( function () {
 			var $this = $( this );
 			var all_correct = false;
 
 			// Only grade questions that haven't already been graded.
-			if ( ! $this.hasClass( 'user_right' )
-				&& ! $this.hasClass( 'user_wrong' )
-				&& ! $this.hasClass( 'zero-graded' ) ) {
+			if (
+				! $this.hasClass( 'user_right' ) &&
+				! $this.hasClass( 'user_wrong' ) &&
+				! $this.hasClass( 'zero-graded' )
+			) {
 				var user_answer, correct_answer;
 
 				$this.addClass( 'ungraded' );
 
 				if ( $this.hasClass( 'gap-fill' ) ) {
-					user_answer = $this.find( '.user-answer .highlight' ).html();
-					correct_answer = $this.find( '.correct-answer .highlight' ).html();
+					user_answer = $this
+						.find( '.user-answer .highlight' )
+						.html();
+					correct_answer = $this
+						.find( '.correct-answer .highlight' )
+						.html();
 				} else {
 					user_answer = $this.find( '.user-answer' ).html();
 					correct_answer = $this.find( '.correct-answer' ).html();
@@ -96,33 +106,66 @@ jQuery(document).ready( function( $ ) {
 						var correct_answers = correct_answer.split( '<br>' );
 						all_correct = true;
 
-						user_answers.forEach( function( user_answer ) {
-							if ( -1 === $.inArray ( user_answer, correct_answers ) ) {
+						user_answers.forEach( function ( user_answer ) {
+							if (
+								-1 === $.inArray( user_answer, correct_answers )
+							) {
 								all_correct = false;
 							}
 						} );
 					}
 
-					if ( all_correct || ( user_answer === correct_answer ) ) { // Right answer
-						$this.addClass( 'user_right' ).removeClass( 'user_wrong' ).removeClass( 'ungraded' );
-						$this.find( '.grading-mark.icon_right input' ).attr( 'checked', true );
-						$this.find( '.grading-mark.icon_wrong input' ).attr( 'checked', false );
-						$this.find( 'input.question-grade' ).val( $this.find( 'input.question_total_grade' ).val() );
-					} else { // Wrong answer
-						$this.addClass( 'user_wrong' ).removeClass( 'user_right' ).removeClass( 'ungraded' );
-						$this.find( '.grading-mark.icon_wrong input' ).attr( 'checked', true );
-						$this.find( '.grading-mark.icon_right input' ).attr( 'checked', false );
+					if ( all_correct || user_answer === correct_answer ) {
+						// Right answer
+						$this
+							.addClass( 'user_right' )
+							.removeClass( 'user_wrong' )
+							.removeClass( 'ungraded' );
+						$this
+							.find( '.grading-mark.icon_right input' )
+							.attr( 'checked', true );
+						$this
+							.find( '.grading-mark.icon_wrong input' )
+							.attr( 'checked', false );
+						$this
+							.find( 'input.question-grade' )
+							.val(
+								$this.find( 'input.question_total_grade' ).val()
+							);
+					} else {
+						// Wrong answer
+						$this
+							.addClass( 'user_wrong' )
+							.removeClass( 'user_right' )
+							.removeClass( 'ungraded' );
+						$this
+							.find( '.grading-mark.icon_wrong input' )
+							.attr( 'checked', true );
+						$this
+							.find( '.grading-mark.icon_right input' )
+							.attr( 'checked', false );
 						$this.find( 'input.question-grade' ).val( 0 );
 					}
-				} else { // Manual grading
-					$this.find( '.grading-mark.icon_wrong input' ).attr( 'checked', false );
-					$this.find( '.grading-mark.icon_right input' ).attr( 'checked', false );
-					$this.removeClass( 'user_wrong' ).removeClass( 'user_right' );
+				} else {
+					// Manual grading
+					$this
+						.find( '.grading-mark.icon_wrong input' )
+						.attr( 'checked', false );
+					$this
+						.find( '.grading-mark.icon_right input' )
+						.attr( 'checked', false );
+					$this
+						.removeClass( 'user_wrong' )
+						.removeClass( 'user_right' );
 				}
-			// Question with a grade value of 0.
+				// Question with a grade value of 0.
 			} else if ( jQuery( this ).hasClass( 'zero-graded' ) ) {
-				$this.find( '.grading-mark.icon_wrong input' ).attr( 'checked', false );
-				$this.find( '.grading-mark.icon_right input' ).attr( 'checked', false );
+				$this
+					.find( '.grading-mark.icon_wrong input' )
+					.attr( 'checked', false );
+				$this
+					.find( '.grading-mark.icon_right input' )
+					.attr( 'checked', false );
 				$this.find( 'input.question-grade' ).val( 0 );
 			}
 		} );
@@ -132,24 +175,31 @@ jQuery(document).ready( function( $ ) {
 
 	/**
 	 * Resets all graded questions
-	 * @param  obj	scope	Scope of questions to reset
+	 * @param obj scope Scope of questions to reset
 	 * @return void
 	 */
-	jQuery.fn.resetGrades = function() {
-		jQuery( '.question_box' ).find( '.grading-mark.icon_wrong input' ).attr( 'checked', false );
-		jQuery( '.question_box' ).find( '.grading-mark.icon_right input' ).attr( 'checked', false );
-		jQuery( '.question_box' ).removeClass( 'user_wrong' ).removeClass( 'user_right' ).removeClass( 'ungraded' );
+	jQuery.fn.resetGrades = function () {
+		jQuery( '.question_box' )
+			.find( '.grading-mark.icon_wrong input' )
+			.attr( 'checked', false );
+		jQuery( '.question_box' )
+			.find( '.grading-mark.icon_right input' )
+			.attr( 'checked', false );
+		jQuery( '.question_box' )
+			.removeClass( 'user_wrong' )
+			.removeClass( 'user_right' )
+			.removeClass( 'ungraded' );
 		jQuery( '.question-grade' ).val( '0' );
 		jQuery.fn.calculateTotalGrade();
 	};
 
-	jQuery.fn.getQueryVariable = function(variable) {
-		var query = window.location.search.substring(1);
-		var vars = query.split('&');
-		for (var i=0;i<vars.length;i++) {
-			var pair = vars[i].split('=');
-			if(pair[0] == variable){
-				return pair[1];
+	jQuery.fn.getQueryVariable = function ( variable ) {
+		var query = window.location.search.substring( 1 );
+		var vars = query.split( '&' );
+		for ( var i = 0; i < vars.length; i++ ) {
+			var pair = vars[ i ].split( '=' );
+			if ( pair[ 0 ] == variable ) {
+				return pair[ 1 ];
 			}
 		}
 		return false;
@@ -165,28 +215,30 @@ jQuery(document).ready( function( $ ) {
 	 * @since 1.3.0
 	 * @access public
 	 */
-	jQuery( '#grading-course-options' ).on( 'change', '', function() {
+	jQuery( '#grading-course-options' ).on( 'change', '', function () {
 		// Populate the Lessons select box
-		var courseId = jQuery(this).val();
+		var courseId = jQuery( this ).val();
 		jQuery.get(
 			ajaxurl,
 			{
 				action: 'get_lessons_dropdown',
 				course_id: courseId,
 			},
-			function( response ) {
+			function ( response ) {
 				// Check for a response
 				if ( '' != response ) {
 					// Empty the results div's
 					jQuery( '#learners-to-grade' ).empty();
 					jQuery( '#learners-graded' ).empty();
 					// Populate the Lessons drop down
-					jQuery( '#grading-lesson-options' ).empty().append( response );
+					jQuery( '#grading-lesson-options' )
+						.empty()
+						.append( response );
 					// Add Chosen to the drop down
 					if ( jQuery( '#grading-lesson-options' ).exists() ) {
 						// Show the Lessons label
 						jQuery( '#grading-lesson-options-label' ).show();
-						jQuery( '#grading-lesson-options' ).trigger('change');
+						jQuery( '#grading-lesson-options' ).trigger( 'change' );
 					} // End If Statement
 				} else {
 					// Failed
@@ -194,7 +246,7 @@ jQuery(document).ready( function( $ ) {
 			}
 		);
 		return false;
-	});
+	} );
 
 	/**
 	 * Lesson Change Event.
@@ -202,10 +254,10 @@ jQuery(document).ready( function( $ ) {
 	 * @since 1.3.0
 	 * @access public
 	 */
-	jQuery( '#grading-lesson-options' ).on( 'change', '', function() {
+	jQuery( '#grading-lesson-options' ).on( 'change', '', function () {
 		// Populate the Lessons select box
-		var lessonId    = jQuery(this).val();
-		var courseId    = jQuery( '#grading-course-options' ).val();
+		var lessonId = jQuery( this ).val();
+		var courseId = jQuery( '#grading-course-options' ).val();
 		var gradingView = jQuery.fn.getQueryVariable( 'view' );
 
 		// Perform the AJAX call to get the select box.
@@ -217,7 +269,7 @@ jQuery(document).ready( function( $ ) {
 				lesson_id: lessonId,
 				view: gradingView,
 			},
-			function( response ) {
+			function ( response ) {
 				// Check for a response
 				if ( '' != response ) {
 					window.location = response;
@@ -227,7 +279,7 @@ jQuery(document).ready( function( $ ) {
 			}
 		);
 		return false;
-	});
+	} );
 
 	/***************************************************************************************************
 	 * 	3 - Grading User Quiz Functions.
@@ -239,16 +291,28 @@ jQuery(document).ready( function( $ ) {
 	 * @since 1.3.0
 	 * @access public
 	 */
-	jQuery( '.grading-mark' ).on( 'change', 'input', function() {
-		if( this.value == 'right' ) {
-			jQuery( '#' + this.name + '_box' ).addClass( 'user_right' ).removeClass( 'user_wrong ungraded' );
-			jQuery( '#' + this.name + '_box' ).find( 'input.question-grade' ).val( jQuery( '#' + this.name + '_box' ).find( 'input.question_total_grade' ).val() );
+	jQuery( '.grading-mark' ).on( 'change', 'input', function () {
+		if ( this.value == 'right' ) {
+			jQuery( '#' + this.name + '_box' )
+				.addClass( 'user_right' )
+				.removeClass( 'user_wrong ungraded' );
+			jQuery( '#' + this.name + '_box' )
+				.find( 'input.question-grade' )
+				.val(
+					jQuery( '#' + this.name + '_box' )
+						.find( 'input.question_total_grade' )
+						.val()
+				);
 		} else {
-			jQuery( '#' + this.name + '_box' ).addClass( 'user_wrong' ).removeClass( 'user_right ungraded' );
-			jQuery( '#' + this.name + '_box' ).find( 'input.question-grade' ).val( 0 );
+			jQuery( '#' + this.name + '_box' )
+				.addClass( 'user_wrong' )
+				.removeClass( 'user_right ungraded' );
+			jQuery( '#' + this.name + '_box' )
+				.find( 'input.question-grade' )
+				.val( 0 );
 		}
 		jQuery.fn.calculateTotalGrade();
-	});
+	} );
 
 	/**
 	 * Grade value change event
@@ -256,20 +320,48 @@ jQuery(document).ready( function( $ ) {
 	 * @since 1.4.0
 	 * @access public
 	 */
-	jQuery( '.question-grade' ).on( 'change', '', function() {
+	jQuery( '.question-grade' ).on( 'change', '', function () {
 		var grade = parseInt( jQuery( this ).val() );
 		var question_label = this.id.replace( '_grade', '' );
-		if( grade > 0 ) {
-			jQuery( '#' + question_label + '_box' ).addClass( 'user_right' ).removeClass( 'user_wrong' );
-			jQuery( '#' + question_label + '_box .grading-mark input.' + question_label + '_right_option' ).attr( 'checked', 'checked' );
-			jQuery( '#' + question_label + '_box .grading-mark input.' + question_label + '_wrong_option' ).attr( 'checked', false );
+		if ( grade > 0 ) {
+			jQuery( '#' + question_label + '_box' )
+				.addClass( 'user_right' )
+				.removeClass( 'user_wrong' );
+			jQuery(
+				'#' +
+					question_label +
+					'_box .grading-mark input.' +
+					question_label +
+					'_right_option'
+			).attr( 'checked', 'checked' );
+			jQuery(
+				'#' +
+					question_label +
+					'_box .grading-mark input.' +
+					question_label +
+					'_wrong_option'
+			).attr( 'checked', false );
 		} else {
-			jQuery( '#' + question_label + '_box' ).addClass( 'user_wrong' ).removeClass( 'user_right' );
-			jQuery( '#' + question_label + '_box .grading-mark input.' + question_label + '_wrong_option' ).attr( 'checked', 'checked' );
-			jQuery( '#' + question_label + '_box .grading-mark input.' + question_label + '_right_option' ).attr( 'checked', false );
+			jQuery( '#' + question_label + '_box' )
+				.addClass( 'user_wrong' )
+				.removeClass( 'user_right' );
+			jQuery(
+				'#' +
+					question_label +
+					'_box .grading-mark input.' +
+					question_label +
+					'_wrong_option'
+			).attr( 'checked', 'checked' );
+			jQuery(
+				'#' +
+					question_label +
+					'_box .grading-mark input.' +
+					question_label +
+					'_right_option'
+			).attr( 'checked', false );
 		}
 		jQuery.fn.calculateTotalGrade();
-	});
+	} );
 
 	/**
 	 * Grade reset event
@@ -277,9 +369,13 @@ jQuery(document).ready( function( $ ) {
 	 * @since 1.3.0
 	 * @access public
 	 */
-	jQuery( '.sensei-grading-main .buttons' ).on( 'click', '.reset-button', function() {
-		jQuery.fn.resetGrades();
-	});
+	jQuery( '.sensei-grading-main .buttons' ).on(
+		'click',
+		'.reset-button',
+		function () {
+			jQuery.fn.resetGrades();
+		}
+	);
 
 	/**
 	 * Auto grade event
@@ -287,22 +383,30 @@ jQuery(document).ready( function( $ ) {
 	 * @since 1.3.0
 	 * @access public
 	 */
-	jQuery( '.sensei-grading-main .buttons' ).on( 'click', '.autograde-button', function() {
-		// Toggle manual-grade questions to auto-grade for question types that are able to be
-		// automatically graded, so that they will now be scored.
-		$( '.boolean.manual-grade, .multiple-choice.manual-grade, .gap-fill.manual-grade' )
-			.addClass( 'auto-grade' )
-			.removeClass( 'manual-grade' );
-		jQuery.fn.autoGrade();
-	});
+	jQuery( '.sensei-grading-main .buttons' ).on(
+		'click',
+		'.autograde-button',
+		function () {
+			// Toggle manual-grade questions to auto-grade for question types that are able to be
+			// automatically graded, so that they will now be scored.
+			$(
+				'.boolean.manual-grade, .multiple-choice.manual-grade, .gap-fill.manual-grade'
+			)
+				.addClass( 'auto-grade' )
+				.removeClass( 'manual-grade' );
+			jQuery.fn.autoGrade();
+		}
+	);
 
 	/***************************************************************************************************
 	 * 	4 - Load Select2 Dropdowns.
 	 ***************************************************************************************************/
 
 	// Grading Overview Drop Downs
-	if ( jQuery( '#grading-course-options' ).exists() ) { jQuery( '#grading-course-options' ).select2(); }
-	if ( jQuery( '#grading-lesson-options' ).exists() ) { jQuery( '#grading-lesson-options' ).select2(); }
-
-
-});
+	if ( jQuery( '#grading-course-options' ).exists() ) {
+		jQuery( '#grading-course-options' ).select2();
+	}
+	if ( jQuery( '#grading-lesson-options' ).exists() ) {
+		jQuery( '#grading-lesson-options' ).select2();
+	}
+} );

--- a/assets/js/lesson-metadata.js
+++ b/assets/js/lesson-metadata.js
@@ -330,7 +330,7 @@ jQuery( document ).ready( function () {
 	/**
 	 * Upload media file to questions
 	 *
-	 * @param  object  button        Button that was clicked
+	 * @param object button Button that was clicked
 	 * @return void
 	 *
 	 * @since  1.5.0

--- a/assets/setup-wizard/data/actions.js
+++ b/assets/setup-wizard/data/actions.js
@@ -15,8 +15,8 @@ import { normalizeSetupWizardData } from './normalizer';
 
 /**
  * @typedef  {Object} FetchFromAPIAction
- * @property {string} type               Action type.
- * @property {Object} request            Object that is used to fetch.
+ * @property {string} type    Action type.
+ * @property {Object} request Object that is used to fetch.
  */
 /**
  * Fetch action creator.
@@ -48,8 +48,8 @@ export function* fetchSetupWizardData() {
 
 /**
  * @typedef  {Object} SuccessSetupWizardDataAction
- * @property {string} type                         Action type.
- * @property {Object} data                         Setup wizard data.
+ * @property {string} type Action type.
+ * @property {Object} data Setup wizard data.
  */
 /**
  * Success fetch action creator.
@@ -65,8 +65,8 @@ export const successFetch = ( data ) => ( {
 
 /**
  * @typedef  {Object}         ErrorFetchAction
- * @property {string}         type             Action type.
- * @property {Object|boolean} error            Error object or false.
+ * @property {string}         type  Action type.
+ * @property {Object|boolean} error Error object or false.
  */
 /**
  * Error fetch action creator.
@@ -116,8 +116,8 @@ export const successSubmit = ( step ) => ( {
 
 /**
  * @typedef  {Object}         ErrorSubmitAction
- * @property {string}         type              Action type.
- * @property {Object|boolean} error             Error object or false.
+ * @property {string}         type  Action type.
+ * @property {Object|boolean} error Error object or false.
  */
 /**
  * Error submit action creator.

--- a/assets/setup-wizard/data/controls.js
+++ b/assets/setup-wizard/data/controls.js
@@ -7,7 +7,7 @@ export default {
 	/**
 	 * Fetch control.
 	 *
-	 * @param  {{request: Object}} action Action with the request object that is used to fetch.
+	 * @param {{request: Object}} action Action with the request object that is used to fetch.
 	 *
 	 * @return {Promise} API fetch promise.
 	 */

--- a/assets/setup-wizard/data/reducer.js
+++ b/assets/setup-wizard/data/reducer.js
@@ -35,9 +35,9 @@ const DEFAULT_STATE = {
 
 /**
  * @typedef  {Object} Feature
- * @property {string} slug    Feature slug.
- * @property {string} status  Feature status.
- * @property {Object} error   Feature error.
+ * @property {string} slug   Feature slug.
+ * @property {string} status Feature status.
+ * @property {Object} error  Feature error.
  */
 /**
  * Update status pre-installation.
@@ -64,8 +64,8 @@ const updatePreInstallation = ( selected, options ) =>
 /**
  * Setup wizard reducer.
  *
- * @param {Object}         state  Current state.
- * @param {{type: string}} action Action to update the state.
+ * @param {Object} state    Current state.
+ * @param {{type:  string}} action Action to update the state.
  *
  * @return {Object} State updated.
  */

--- a/assets/setup-wizard/data/selectors.js
+++ b/assets/setup-wizard/data/selectors.js
@@ -52,9 +52,9 @@ export const getStepData = ( state, step ) => state.data[ step ];
 /**
  * Get navigation steps with their state.
  *
- * @param {Object} input                      getNavigationSteps input.
- * @param {Object} input.data                 The current state.
- * @param {Array}  input.data.completedSteps  The completed steps.
+ * @param {Object} input                     getNavigationSteps input.
+ * @param {Object} input.data                The current state.
+ * @param {Array}  input.data.completedSteps The completed steps.
  *
  * @return {Array} Navigation steps.
  */
@@ -75,10 +75,10 @@ export const getNavigationSteps = ( { data: { completedSteps } } ) => {
 /**
  * Get whether step is complete or not.
  *
- * @param {Object} input                      getNavigationSteps input.
- * @param {Object} input.data                 The current state.
- * @param {Array}  input.data.completedSteps  The completed steps.
- * @param {Array}  step                       The step to check if it is completed.
+ * @param {Object} input                     getNavigationSteps input.
+ * @param {Object} input.data                The current state.
+ * @param {Array}  input.data.completedSteps The completed steps.
+ * @param {Array}  step                      The step to check if it is completed.
  *
  * @return {boolean} Step complete.
  */

--- a/assets/setup-wizard/features/index.js
+++ b/assets/setup-wizard/features/index.js
@@ -17,7 +17,7 @@ import FeaturesSelection from './features-selection';
 
 /**
  * @typedef  {Object} Feature
- * @property {string} slug    Feature slug.
+ * @property {string} slug Feature slug.
  */
 /**
  * Filter installed features to don't select them.

--- a/assets/setup-wizard/features/installation-feedback.js
+++ b/assets/setup-wizard/features/installation-feedback.js
@@ -15,9 +15,9 @@ import useFeaturesPolling from './use-features-polling';
 /**
  * Installation feedback component.
  *
- * @param {Object}    props
- * @param {Function}  props.onContinue Callback to continue to the next step.
- * @param {Function}  props.onRetry    Callback to retry installations.
+ * @param {Object}   props
+ * @param {Function} props.onContinue Callback to continue to the next step.
+ * @param {Function} props.onRetry    Callback to retry installations.
  */
 const InstallationFeedback = ( { onContinue, onRetry } ) => {
 	const [ hasInstalling, setHasInstalling ] = useState( true );

--- a/assets/setup-wizard/log-event.js
+++ b/assets/setup-wizard/log-event.js
@@ -1,8 +1,8 @@
 /**
  * Send log event.
  *
- * @param {string} eventName Event name.
- * @param {Array} properties Event properties.
+ * @param {string} eventName  Event name.
+ * @param {Array}  properties Event properties.
  */
 export const logEvent = ( eventName, properties ) => {
 	window.sensei_log_event( eventName, properties );
@@ -20,8 +20,8 @@ logEvent.enable = ( enabled ) => {
 /**
  * Send log event when link is opened.
  *
- * @param {string} eventName Event name.
- * @param {Array} properties Event properties.
+ * @param {string} eventName  Event name.
+ * @param {Array}  properties Event properties.
  * @return {Object} Element attributes.
  */
 export const logLink = ( eventName, properties ) => {

--- a/assets/setup-wizard/navigation/index.js
+++ b/assets/setup-wizard/navigation/index.js
@@ -20,8 +20,8 @@ const addClickHandlers = ( steps, { goTo } ) =>
 /**
  * Navigation component.
  *
- * @param {Object} input        Navigation input.
- * @param {Array}  input.steps  The available steps.
+ * @param {Object} input       Navigation input.
+ * @param {Array}  input.steps The available steps.
  */
 const Navigation = ( { steps } ) => {
 	const { currentRoute, goTo } = useQueryStringRouter();

--- a/assets/setup-wizard/query-string-router/index.js
+++ b/assets/setup-wizard/query-string-router/index.js
@@ -81,8 +81,8 @@ export { default as Route } from './route';
  * @return {QueryStringRouterContext} Query string router context.
  *
  * @typedef  {Object}           QueryStringRouterContext
- * @property {string}           currentRoute             Current route.
- * @property {function(string)} goTo                     Function to navigate between routes.
+ * @property {string}           currentRoute Current route.
+ * @property {function(string)} goTo         Function to navigate between routes.
  */
 export const useQueryStringRouter = () =>
 	useContext( QueryStringRouterContext );

--- a/assets/setup-wizard/query-string-router/route.js
+++ b/assets/setup-wizard/query-string-router/route.js
@@ -3,9 +3,9 @@ import { useQueryStringRouter } from './index';
 /**
  * Route component. It works inner the `QueryStringRouter context.
  *
- * @param {Object}  props
- * @param {string}  props.route        Route name.
- * @param {Object}  props.children     Render this children if it matches the route.
+ * @param {Object} props
+ * @param {string} props.route    Route name.
+ * @param {Object} props.children Render this children if it matches the route.
  *
  * @return {Object|null} Return the children if the routes match. Otherwise return null.
  */

--- a/assets/setup-wizard/query-string-router/url-functions.js
+++ b/assets/setup-wizard/query-string-router/url-functions.js
@@ -1,7 +1,7 @@
 /**
  * Get parameter from URL.
  *
- * @param {string} name  Name of the param to get.
+ * @param {string} name Name of the param to get.
  *
  * @return {string|null} The value in the param. If it's empty, return null.
  */

--- a/assets/shared/helpers/format-string.js
+++ b/assets/shared/helpers/format-string.js
@@ -18,7 +18,7 @@ export const formattingComponents = {
  * @example formatString(' Welcome to {{strong}}Sensei{{/strong}}!')
  *
  * @param {string} mixedString Template string.
- * @param {Object} components Replacements.
+ * @param {Object} components  Replacements.
  */
 export const formatString = ( mixedString, components = {} ) =>
 	interpolateComponents( {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21317,6 +21317,23 @@
         }
       }
     },
+    "eslint-plugin-jsdoc-alignment": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc-alignment/-/eslint-plugin-jsdoc-alignment-0.0.3.tgz",
+      "integrity": "sha512-OQTdhdXco/ryWWC8sNSTBva3QvVqUgz1J2okaxX08y51VWHgXWuUW2rpYqKcP6rA41laapkD0gmAKGN821ClcQ==",
+      "dev": true,
+      "requires": {
+        "requireindex": "~1.1.0"
+      },
+      "dependencies": {
+        "requireindex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
+          "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
+          "dev": true
+        }
+      }
+    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21318,9 +21318,9 @@
       }
     },
     "eslint-plugin-jsdoc-alignment": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc-alignment/-/eslint-plugin-jsdoc-alignment-0.0.3.tgz",
-      "integrity": "sha512-OQTdhdXco/ryWWC8sNSTBva3QvVqUgz1J2okaxX08y51VWHgXWuUW2rpYqKcP6rA41laapkD0gmAKGN821ClcQ==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc-alignment/-/eslint-plugin-jsdoc-alignment-0.0.4.tgz",
+      "integrity": "sha512-cNZeGTymRYEYbQjpcinyYLjNFGl1W+r1IxmvyO5VMD/vm1fIRvrFPI6Ave8E6WnkqlH/cEQOeyI6oIK+UbUEIA==",
       "dev": true,
       "requires": {
         "requireindex": "~1.1.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cross-env": "7.0.2",
     "eslint": "7.6.0",
     "eslint-config-prettier": "6.11.0",
-    "eslint-plugin-jsdoc-alignment": "0.0.3",
+    "eslint-plugin-jsdoc-alignment": "0.0.4",
     "extract-zip": "2.0.1",
     "gettext-parser": "4.0.4",
     "husky": "4.2.5",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "cross-env": "7.0.2",
     "eslint": "7.6.0",
     "eslint-config-prettier": "6.11.0",
+    "eslint-plugin-jsdoc-alignment": "0.0.3",
     "extract-zip": "2.0.1",
     "gettext-parser": "4.0.4",
     "husky": "4.2.5",


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It introduces a new [eslint plugin to validate the JSDoc alignment](https://github.com/Automattic/eslint-plugin-jsdoc-alignment), following the [WP standards](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/#aligning-comments).
* This PR also already ran the plugin auto fix to fix the current unformatted JSDocs.

### Testing instructions

* Make sure the auto fixed JSDocs are correct.
* Edit/add a JSDoc, making the alignment wrong, like that:
```
/**
 * Function description.
 *
 * @param {string} lorem Description.
 * @param {int}    sit        Description multi words.
 */
```
* Run `npm run lint-js` and make sure the error is logged in the terminal.
* Run `npm run lint-js:fix` and make sure it was automatically fixed.