### PR TITLE
Center text within Setup Wizard buttons

### DIFF
--- a/assets/setup-wizard/style.scss
+++ b/assets/setup-wizard/style.scss
@@ -63,7 +63,6 @@
 		padding-right: 25px;
 		text-align: center;
 		font-size: 14px;
-		line-height: 36px;
 		font-weight: 500;
 		align-items: center;
 	}


### PR DESCRIPTION
Fixes #3571

### Changes proposed in this Pull Request

Vertically center the text inside the buttons within the Setup Wizard (see screenshots in the issue). Note that I was only able to see this issue when using Safari.

### Testing instructions

Go through the Setup Wizard and ensure the button text is centered within the buttons.