### PR TITLE
Include flag for sample data on import events

### DIFF
--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -311,6 +311,7 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 				'failed_courses'     => $results[ Sensei_Import_Course_Model::MODEL_KEY ]['error'],
 				'failed_lessons'     => $results[ Sensei_Import_Lesson_Model::MODEL_KEY ]['error'],
 				'failed_questions'   => $results[ Sensei_Import_Question_Model::MODEL_KEY ]['error'],
+				'sample_course'      => $job->is_sample_data() ? 1 : 0,
 			]
 		);
 	}

--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -13,10 +13,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This class represents a data import job.
  */
 class Sensei_Import_Job extends Sensei_Data_Port_Job {
-	const MAPPED_ID_STATE_KEY = '_map';
-	const RESULT_ERROR        = -1;
-	const RESULT_WARNING      = 0;
-	const RESULT_SUCCESS      = 1;
+	const MAPPED_ID_STATE_KEY   = '_map';
+	const SAMPLE_DATA_STATE_KEY = '_sample';
+	const RESULT_ERROR          = -1;
+	const RESULT_WARNING        = 0;
+	const RESULT_SUCCESS        = 1;
 
 	/**
 	 * The array of the import tasks.
@@ -112,8 +113,9 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 	public function add_log_entry( $message, $level = self::LOG_LEVEL_INFO, $data = [] ) {
 		if ( isset( $data['code'], $data['type'] ) ) {
 			$event_data = [
-				'type'  => $data['type'],
-				'error' => $data['code'],
+				'type'          => $data['type'],
+				'error'         => $data['code'],
+				'sample_course' => $this->is_sample_data() ? 1 : 0,
 			];
 
 			if ( self::LOG_LEVEL_ERROR === $level ) {
@@ -208,6 +210,24 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 		}
 
 		return parent::save_file( $file_key, $tmp_file, $file_name );
+	}
+
+	/**
+	 * Sets whether this is the sample data being imported.
+	 *
+	 * @param bool $is_sample_data True if this is the sample data being imported.
+	 */
+	public function set_is_sample_data( $is_sample_data ) {
+		$this->set_state( self::SAMPLE_DATA_STATE_KEY, (bool) $is_sample_data );
+	}
+
+	/**
+	 * Whether the data being imported is the sample data.
+	 *
+	 * @return bool
+	 */
+	public function is_sample_data() {
+		return true === $this->get_state( self::SAMPLE_DATA_STATE_KEY );
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-import-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-import-controller.php
@@ -288,6 +288,7 @@ class Sensei_REST_API_Import_Controller extends Sensei_REST_API_Data_Port_Contro
 		];
 
 		$job = Sensei_Data_Port_Manager::instance()->create_import_job( get_current_user_id() );
+		$job->set_is_sample_data( true );
 
 		foreach ( $files as $file_key => $file_path ) {
 			$result = $job->save_file( $file_key, $file_path, basename( $file_path ) );


### PR DESCRIPTION
Fixes #3583 

### Changes proposed in this Pull Request

* Adds `sample_course` on import related events.
* Sets this flag when imported from setup wizard. It doesn't set this flag if someone happens to import the sample files from the repo. We might be able to do this, but it wouldn't be super clean/easy.

### Testing instructions

* Click on `Install a sample course` on the setup wizard. Ensure `sample_course` is `1` on `sensei_import_complete`. 
* Go through the process of importing a course in Sensei LMS > Import. Ensure `sample_course` is `0` on `sensei_import_complete` and for any error/warning events that are fired. Note: Even the sample files shouldn't trigger `sample_course` to be `1` on these events. 
