### PR TITLE
Don't overwrite lesson meta with defaults on update

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -617,7 +617,7 @@ class Sensei_Lesson {
 
 		$value = null;
 
-		if ( 'quiz_grade_type' === $field['id'] ) {
+		if ( 'quiz_grade_type' === $field['id'] && 'list' !== $_POST['post_view'] ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$grade_type_checked = isset( $_POST[ $field['id'] ] ) && 'on' === $_POST[ $field['id'] ];
 			return $grade_type_checked ? 'auto' : 'manual';

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -621,7 +621,8 @@ class Sensei_Lesson {
 
 		$value = null;
 
-		if ( 'quiz_grade_type' === $field['id'] && 'list' !== $_POST['post_view'] ) {
+		// phpcs:ignore WordPress.Security.NonceVerification -- Only checking the origin page.
+		if ( 'quiz_grade_type' === $field['id'] && isset( $_POST['action'] ) && 'editpost' === $_POST['action'] ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$grade_type_checked = isset( $_POST[ $field['id'] ] ) && 'on' === $_POST[ $field['id'] ];
 			return $grade_type_checked ? 'auto' : 'manual';

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -600,25 +600,32 @@ class Sensei_Lesson {
 
 	} // End post_updated()
 
-	public function get_submitted_setting_value( $field = false ) {
+	/**
+	 * Get setting value from POST data.
+	 *
+	 * @access private
+	 *
+	 * @param  {string} $field Field name.
+	 *
+	 * @return string|null
+	 */
+	public function get_submitted_setting_value( $field ) {
 
 		if ( ! $field ) {
-			return;
+			return null;
 		}
 
 		$value = null;
 
-		// Since we don't do any updates here, we can ignore nonce verification.
-		if ( 'quiz_grade_type' == $field['id'] ) {
-			// phpcs:ignore WordPress.Security.NonceVerification
-			if ( isset( $_POST[ $field['id'] ] ) ) {
-				$value = 'on' === $_POST[ $field['id'] ] ? 'auto' : 'manual';
+		// phpcs:ignore WordPress.Security.NonceVerification Nonce verified in caller
+		if ( isset( $_POST[ $field['id'] ] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification Nonce verified in caller
+			$submitted = sanitize_text_field( wp_unslash( $_POST[ $field['id'] ] ) );
+			if ( 'quiz_grade_type' === $field['id'] ) {
+				$value = 'on' === $submitted ? 'auto' : 'manual';
+			} else {
+				$value = ( $submitted );
 			}
-			return $value;
-		}
-
-		if ( isset( $_POST[ $field['id'] ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-			$value = $_POST[ $field['id'] ]; // phpcs:ignore WordPress.Security.NonceVerification
 		}
 
 		return $value;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -617,15 +617,16 @@ class Sensei_Lesson {
 
 		$value = null;
 
+		if ( 'quiz_grade_type' === $field['id'] ) {
+			// phpcs:ignore WordPress.Security.NonceVerification
+			$grade_type_checked = isset( $_POST[ $field['id'] ] ) && 'on' === $_POST[ $field['id'] ];
+			return $grade_type_checked ? 'auto' : 'manual';
+		}
+
 		// phpcs:ignore WordPress.Security.NonceVerification -- Nonce verified in caller
 		if ( isset( $_POST[ $field['id'] ] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification -- Nonce verified in caller
-			$submitted = sanitize_text_field( wp_unslash( $_POST[ $field['id'] ] ) );
-			if ( 'quiz_grade_type' === $field['id'] ) {
-				$value = 'on' === $submitted ? 'auto' : 'manual';
-			} else {
-				$value = ( $submitted );
-			}
+			$value = sanitize_text_field( wp_unslash( $_POST[ $field['id'] ] ) );
 		}
 
 		return $value;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -611,10 +611,8 @@ class Sensei_Lesson {
 		// Since we don't do any updates here, we can ignore nonce verification.
 		if ( 'quiz_grade_type' == $field['id'] ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			if ( isset( $_POST[ $field['id'] ] ) && 'on' == $_POST[ $field['id'] ] ) {
-				$value = 'auto';
-			} else {
-				$value = 'manual';
+			if ( isset( $_POST[ $field['id'] ] ) ) {
+				$value = 'on' === $_POST[ $field['id'] ] ? 'auto' : 'manual';
 			}
 			return $value;
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -567,7 +567,11 @@ class Sensei_Lesson {
 						continue;
 					}
 
-					$value = $this->get_submitted_setting_value( $field ) ?? $field['default'];
+					$value = $this->get_submitted_setting_value( $field );
+					if ( null === $value ) {
+						$value = $field['default'];
+					}
+
 					if ( isset( $value ) ) {
 						add_post_meta( $quiz_id, '_' . $field['id'], $value );
 					}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -617,9 +617,9 @@ class Sensei_Lesson {
 
 		$value = null;
 
-		// phpcs:ignore WordPress.Security.NonceVerification Nonce verified in caller
+		// phpcs:ignore WordPress.Security.NonceVerification -- Nonce verified in caller
 		if ( isset( $_POST[ $field['id'] ] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification Nonce verified in caller
+			// phpcs:ignore WordPress.Security.NonceVerification -- Nonce verified in caller
 			$submitted = sanitize_text_field( wp_unslash( $_POST[ $field['id'] ] ) );
 			if ( 'quiz_grade_type' === $field['id'] ) {
 				$value = 'on' === $submitted ? 'auto' : 'manual';

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -567,7 +567,7 @@ class Sensei_Lesson {
 						continue;
 					}
 
-					$value = $this->get_submitted_setting_value( $field );
+					$value = $this->get_submitted_setting_value( $field ) ?? $field['default'];
 					if ( isset( $value ) ) {
 						add_post_meta( $quiz_id, '_' . $field['id'], $value );
 					}
@@ -606,7 +606,7 @@ class Sensei_Lesson {
 			return;
 		}
 
-		$value = false;
+		$value = null;
 
 		// Since we don't do any updates here, we can ignore nonce verification.
 		if ( 'quiz_grade_type' == $field['id'] ) {
@@ -621,8 +621,6 @@ class Sensei_Lesson {
 
 		if ( isset( $_POST[ $field['id'] ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
 			$value = $_POST[ $field['id'] ]; // phpcs:ignore WordPress.Security.NonceVerification
-		} else {
-			$value = $field['default'];
 		}
 
 		return $value;


### PR DESCRIPTION
Fixes #3582

### Changes proposed in this Pull Request

* Skip `update_post_meta` call for properties not submitted when updating quiz data on lesson save.
* Still set the defaults when adding the quiz.

### Testing instructions

* Edit a lesson and set *Number of questions to show* and *Grade quiz automatically* in Quiz Settings
* Check that it's saved
* Return to the Lessons list and perform a Quick Edit on the same lesson
* Check that the quiz settings set in step 1 are still there
--
* Create a new lesson and save it
* Check that quiz settings are the default (eg *Grade quiz automatically* is checked)

