### PR TITLE
Update PHP and Wordpress versions in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,11 @@ jobs:
       script:
         - ./tests/bin/run-wp-unit-tests.sh
     - stage: test
+      php: 7.4
+      env: WP_VERSION=trunk
+      script:
+        - ./tests/bin/run-wp-unit-tests.sh
+    - stage: test
       php: 7.1
       env: WP_VERSION=latest
       script:
@@ -69,22 +74,17 @@ jobs:
       script:
         - ./tests/bin/run-wp-unit-tests.sh
     - stage: test
-      php: 5.6
+      php: 7.0
+      env: WP_VERSION=5.4
+      script:
+        - ./tests/bin/run-wp-unit-tests.sh
+    - stage: test
+      php: 7.0
       env: WP_VERSION=5.3
       script:
         - ./tests/bin/run-wp-unit-tests.sh
     - stage: test
-      php: 5.6
-      env: WP_VERSION=latest
-      script:
-        - ./tests/bin/run-wp-unit-tests.sh
-    - stage: test
-      php: 5.6
-      env: WP_VERSION=trunk
-      script:
-        - ./tests/bin/run-wp-unit-tests.sh
-    - stage: test
-      php: 5.6
+      php: 7.0
       env: WP_VERSION=latest WP_MULTISITE=1
       script:
       - ./tests/bin/run-wp-unit-tests.sh


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Run CI tests against supported Wordpress and PHP versions:
  * PHP 7.0, 7.1, 7.4
  * Wordpress 5.3, 5.4, latest, trunk

### Testing instructions

* Tests itself

