### PR TITLE
Implement getting course structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,9 @@ before_script:
     echo "xdebug.ini does not exist"
   fi
 - |
-  if [[ ! -z "$WP_VERSION" ]] ; then
+  if [[ ! -z "$WP_VERSION" && -z "$RUN_E2E"  ]] ; then
     bash tests/bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
-    composer global require "phpunit/phpunit=4.8.*|5.7.*"
+    composer global require "phpunit/phpunit=6.5.*"
   fi
 jobs:
   include:
@@ -87,7 +87,7 @@ jobs:
       php: 7.0
       env: WP_VERSION=latest WP_MULTISITE=1
       script:
-      - ./tests/bin/run-wp-unit-tests.sh
+        - ./tests/bin/run-wp-unit-tests.sh
     - stage: test
       language: node_js
       node_js: '10.17'

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
 		"squizlabs/php_codesniffer": "3.5.5",
 		"wp-coding-standards/wpcs": "2.3.0",
 		"sirbrillig/phpcs-variable-analysis": "2.8.3",
-		"sirbrillig/phpcs-no-get-current-user": "1.0.1"
+		"sirbrillig/phpcs-no-get-current-user": "1.0.1",
+		"swaggest/json-schema": "0.12.29"
 	},
 	"prefer-stable": true,
 	"archive": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2cb36d323103f4741505a4c114fb1d29",
+    "content-hash": "9797db96a6fead6fda56358269c051c2",
     "packages": [],
     "packages-dev": [
         {
@@ -127,6 +127,20 @@
                 "constructor",
                 "instantiate"
             ],
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-29T17:27:14+00:00"
         },
         {
@@ -174,6 +188,12 @@
                 "duplicate",
                 "object",
                 "object graph"
+            ],
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-29T13:22:24+00:00"
         },
@@ -490,16 +510,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.0",
+            "version": "5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "3170448f5769fe19f456173d833734e0ff1b84df"
+                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/3170448f5769fe19f456173d833734e0ff1b84df",
-                "reference": "3170448f5769fe19f456173d833734e0ff1b84df",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d870572532cd70bc3fab58f2e23ad423c8404c44",
+                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44",
                 "shasum": ""
             },
             "require": {
@@ -538,7 +558,7 @@
                 }
             ],
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2020-07-20T20:05:34+00:00"
+            "time": "2020-08-15T11:14:08+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
@@ -584,6 +604,50 @@
             ],
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "time": "2020-06-27T10:12:23+00:00"
+        },
+        {
+            "name": "phplang/scope-exit",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phplang/scope-exit.git",
+                "reference": "239b73abe89f9414aa85a7ca075ec9445629192b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phplang/scope-exit/zipball/239b73abe89f9414aa85a7ca075ec9445629192b",
+                "reference": "239b73abe89f9414aa85a7ca075ec9445629192b",
+                "shasum": ""
+            },
+            "require-dev": {
+                "phpunit/phpunit": "*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpLang\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD"
+            ],
+            "authors": [
+                {
+                    "name": "Sara Golemon",
+                    "email": "pollita@php.net",
+                    "homepage": "https://twitter.com/SaraMG",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Emulation of SCOPE_EXIT construct from C++",
+            "homepage": "https://github.com/phplang/scope-exit",
+            "keywords": [
+                "cleanup",
+                "exit",
+                "scope"
+            ],
+            "time": "2016-09-17T00:15:18+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -895,6 +959,7 @@
             "keywords": [
                 "tokenizer"
             ],
+            "abandoned": true,
             "time": "2017-11-27T05:48:46+00:00"
         },
         {
@@ -1744,8 +1809,91 @@
             "time": "2020-04-17T01:09:41+00:00"
         },
         {
+            "name": "swaggest/json-diff",
+            "version": "v3.7.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swaggest/json-diff.git",
+                "reference": "e452a9c6444905a486280c7d56503a6468303f69"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swaggest/json-diff/zipball/e452a9c6444905a486280c7d56503a6468303f69",
+                "reference": "e452a9c6444905a486280c7d56503a6468303f69",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.23"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Swaggest\\JsonDiff\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Viacheslav Poturaev",
+                    "email": "vearutop@gmail.com"
+                }
+            ],
+            "description": "JSON diff/rearrange/patch/pointer library for PHP",
+            "time": "2020-05-26T21:53:21+00:00"
+        },
+        {
+            "name": "swaggest/json-schema",
+            "version": "v0.12.29",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/swaggest/php-json-schema.git",
+                "reference": "7564d4a5fc8c068479698a30e5a7c589ea32a9c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/swaggest/php-json-schema/zipball/7564d4a5fc8c068479698a30e5a7c589ea32a9c6",
+                "reference": "7564d4a5fc8c068479698a30e5a7c589ea32a9c6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "php": ">=5.4",
+                "phplang/scope-exit": "^1.0",
+                "swaggest/json-diff": "^3.5.1"
+            },
+            "require-dev": {
+                "phpunit/php-code-coverage": "2.2.4",
+                "phpunit/phpunit": "4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Swaggest\\JsonSchema\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Viacheslav Poturaev",
+                    "email": "vearutop@gmail.com"
+                }
+            ],
+            "description": "High definition PHP structures with JSON-schema based validation",
+            "time": "2020-03-19T08:41:40+00:00"
+        },
+        {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.18.0",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -1803,6 +1951,20 @@
                 "polyfill",
                 "portable"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-07-14T12:35:20+00:00"
         },
         {
@@ -1843,6 +2005,12 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
             "time": "2020-07-12T23:59:07+00:00"
         },
         {
@@ -1949,5 +2117,6 @@
     "platform": [],
     "platform-dev": {
         "php": "^5.4 || ^7"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -153,9 +153,9 @@ class Sensei_Course_Structure {
 	 *
 	 * @param array $structure Course structure to save.
 	 *
-	 * @return bool
+	 * @return true|WP_Error
 	 */
-	public function save( array $structure ) : bool {
+	public function save( array $structure ) {
 		// TODO: Implement.
 
 		return false;

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * File containing the class Sensei_Course_Structure.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Contains methods for retrieving and saving a Sensei course's structure.
+ *
+ * @since 3.6.0
+ */
+class Sensei_Course_Structure {
+	/**
+	 * Course instances.
+	 *
+	 * @var self[]
+	 */
+	private static $instances = [];
+
+	/**
+	 * The course post ID.
+	 *
+	 * @var int
+	 */
+	private $course_id;
+
+	/**
+	 * Get an instance of this class for a course.
+	 *
+	 * @param int $course_id The course post ID.
+	 *
+	 * @return static
+	 */
+	public static function instance( int $course_id ) : self {
+		if ( ! isset( self::$instances[ $course_id ] ) ) {
+			self::$instances[ $course_id ] = new static( $course_id );
+		}
+
+		return self::$instances[ $course_id ];
+	}
+
+	/**
+	 * Sensei_Course_Structure constructor.
+	 *
+	 * @param int $course_id The course post ID.
+	 */
+	private function __construct( int $course_id ) {
+		$this->course_id = $course_id;
+	}
+
+	/**
+	 * Get the course structure.
+	 *
+	 * @return array
+	 */
+	public function get() : array {
+		$structure = [];
+
+		$all_lessons       = Sensei()->course->course_lessons( $this->course_id, 'any', 'ids' );
+		$no_module_lessons = wp_list_pluck( Sensei()->modules->get_none_module_lessons( $this->course_id, 'any' ), 'ID' );
+
+		if ( count( $all_lessons ) !== count( $no_module_lessons ) ) {
+			$modules = $this->get_modules();
+			foreach ( $modules as $module_term ) {
+				$structure[] = $this->prepare_module( $module_term );
+			}
+		}
+
+		foreach ( array_intersect( $all_lessons, $no_module_lessons ) as $lesson_id ) {
+			$lesson = get_post( $lesson_id );
+			if ( ! $lesson ) {
+				continue;
+			}
+
+			$structure[] = $this->prepare_lesson( $lesson );
+		}
+
+		return $structure;
+	}
+
+	/**
+	 * Prepare the result for a module.
+	 *
+	 * @param WP_Term $module_term Module term.
+	 */
+	private function prepare_module( WP_Term $module_term ) {
+		$lessons = $this->get_module_lessons( $module_term->term_id );
+		$module  = [
+			'type'        => 'module',
+			'id'          => $module_term->term_id,
+			'title'       => $module_term->name,
+			'description' => $module_term->description,
+			'lessons'     => [],
+		];
+
+		foreach ( $lessons as $lesson ) {
+			$module['lessons'][] = $this->prepare_lesson( $lesson );
+		}
+
+		return $module;
+	}
+
+	/**
+	 * Prepare the result for a lesson.
+	 *
+	 * @param WP_Post $lesson_post Lesson post object.
+	 *
+	 * @return array
+	 */
+	private function prepare_lesson( WP_Post $lesson_post ) {
+		return [
+			'type'  => 'lesson',
+			'id'    => $lesson_post->ID,
+			'title' => $lesson_post->post_title,
+		];
+	}
+
+	/**
+	 * Get the lessons for a module.
+	 *
+	 * @param int $module_term_id Term ID for the module.
+	 *
+	 * @return WP_Post[]
+	 */
+	private function get_module_lessons( int $module_term_id ) {
+		$lessons_query = Sensei()->modules->get_lessons_query( $this->course_id, $module_term_id, 'any' );
+
+		return $lessons_query instanceof WP_Query ? $lessons_query->posts : [];
+	}
+
+	/**
+	 * Get module terms in the correct order.
+	 *
+	 * @return WP_Term[]
+	 */
+	private function get_modules() : array {
+		$modules = Sensei()->modules->get_course_modules( $this->course_id );
+
+		if ( is_wp_error( $modules ) ) {
+			$modules = [];
+		}
+
+		return $modules;
+	}
+
+	/**
+	 * Save a new course structure.
+	 *
+	 * @param array $structure Course structure to save.
+	 *
+	 * @return bool
+	 */
+	public function save( array $structure ) : bool {
+		// TODO: Implement.
+
+		return false;
+	}
+
+}

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1462,7 +1462,7 @@ class Sensei_Core_Modules {
 	 * @since 1.8.0
 	 *
 	 * @param  integer $course_id ID of course
-	 * @return array              Ordered array of module taxonomy term objects
+	 * @return WP_Term[]          Ordered array of module taxonomy term objects
 	 */
 	public function get_course_modules( $course_id = 0 ) {
 
@@ -1675,11 +1675,13 @@ class Sensei_Core_Modules {
 	 *
 	 * @since 1.8.0
 	 *
-	 * @param $course_id
-	 * @param $term_id
+	 * @param int    $course_id                  Course post ID.
+	 * @param int    $term_id                    Module term ID.
+	 * @param string $course_lessons_post_status Post status for lessons.
+	 *
 	 * @return WP_Query $lessons_query
 	 */
-	public function get_lessons_query( $course_id, $term_id ) {
+	public function get_lessons_query( $course_id, $term_id, $course_lessons_post_status = null ) {
 		global $wp_query;
 		if ( empty( $term_id ) || empty( $course_id ) ) {
 
@@ -1687,7 +1689,9 @@ class Sensei_Core_Modules {
 
 		}
 
-		$course_lessons_post_status = isset( $wp_query ) && $wp_query->is_preview() ? 'all' : 'publish';
+		if ( ! $course_lessons_post_status ) {
+			$course_lessons_post_status = isset( $wp_query ) && $wp_query->is_preview() ? 'all' : 'publish';
+		}
 
 		$args = array(
 			'post_type'        => 'lesson',

--- a/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
@@ -1,0 +1,336 @@
+<?php
+/**
+ * File containing the class Sensei_REST_API_Course_Structure_Controller.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sensei Course Structure REST API endpoints.
+ *
+ * @package Sensei
+ * @author  Automattic
+ * @since   3.6.0
+ */
+class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
+
+	/**
+	 * Routes namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace;
+
+	/**
+	 * Routes prefix.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'course-structure';
+
+	/**
+	 * Sensei_REST_API_Course_Structure_Controller constructor.
+	 *
+	 * @param string $namespace Routes namespace.
+	 */
+	public function __construct( $namespace ) {
+		$this->namespace = $namespace;
+	}
+
+	/**
+	 * Register the REST API endpoints for Course Structure.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/(?P<course_id>[0-9]+)',
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_course_structure' ],
+					'permission_callback' => [ $this, 'can_user_get_structure' ],
+				],
+				[
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => [ $this, 'save_course_structure' ],
+					'permission_callback' => [ $this, 'can_user_save_structure' ],
+					'args'                => [
+						'structure' => [
+							'description' => __( 'JSON string of the structure', 'sensei-lms' ),
+							'required'    => true,
+							'type'        => 'string',
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Check user permission for reading course structure.
+	 *
+	 * @param WP_REST_Request $request WordPress request object.
+	 *
+	 * @return bool|WP_Error Whether the user can read course structure data. Error if not found.
+	 */
+	public function can_user_get_structure( WP_REST_Request $request ) {
+		$course = $this->get_course( intval( $request->get_param( 'course_id' ) ) );
+		if ( ! $course ) {
+			return new WP_Error(
+				'sensei_course_structure_missing_course',
+				__( 'Course not found.', 'sensei-lms' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		if ( ! is_user_logged_in() ) {
+			return 'publish' === get_post_status( $course );
+		}
+
+		return current_user_can( get_post_type_object( 'course' )->cap->read_post, $course->ID );
+	}
+
+	/**
+	 * Check user permission for saving course structure.
+	 *
+	 * @param WP_REST_Request $request WordPress request object.
+	 *
+	 * @return bool|WP_Error Whether the user can save course structure data. Error if not found.
+	 */
+	public function can_user_save_structure( WP_REST_Request $request ) {
+		$course = $this->get_course( intval( $request->get_param( 'course_id' ) ) );
+		if ( ! $course ) {
+			return new WP_Error(
+				'sensei_course_structure_missing_course',
+				__( 'Course not found.', 'sensei-lms' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		return is_user_logged_in() && current_user_can( get_post_type_object( 'course' )->cap->edit_post, $course->ID );
+	}
+
+	/**
+	 * Get the course structure.
+	 *
+	 * @param WP_REST_Request $request WordPress request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_course_structure( WP_REST_Request $request ) {
+		$course           = $this->get_course( intval( $request->get_param( 'course_id' ) ) );
+		$course_structure = Sensei_Course_Structure::instance( $course->ID );
+
+		$response = new WP_REST_Response();
+		$response->set_data( $course_structure->get() );
+
+		return $response;
+	}
+
+	/**
+	 * Get the course structure.
+	 *
+	 * @param WP_REST_Request $request WordPress request object.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function save_course_structure( WP_REST_Request $request ) {
+		$course           = $this->get_course( intval( $request->get_param( 'course_id' ) ) );
+		$course_structure = Sensei_Course_Structure::instance( $course->ID );
+
+		$structure_input = $this->parse_input( $request->get_param( 'structure' ) );
+		if ( is_wp_error( $structure_input ) ) {
+			return $structure_input;
+		}
+
+		if ( ! $course_structure->save( $structure_input ) ) {
+			return new WP_Error(
+				'sensei_course_structure_missing_course',
+				__( 'An error occurred while saving the course structure.', 'sensei-lms' ),
+				[ 'status' => 500 ]
+			);
+		}
+
+		$response = new WP_REST_Response();
+		$response->set_data( $course_structure->get() );
+
+		return $response;
+	}
+
+	/**
+	 * Parse and sanitize the structure input.
+	 *
+	 * @param string $structure_input JSON string of structure.
+	 *
+	 * @return WP_Error|array False if the input is invalid.
+	 */
+	private function parse_input( string $structure_input ) : bool {
+		$raw = json_decode( $structure_input, true );
+		if ( ! is_array( $raw ) ) {
+			return false;
+		}
+		$structure = [];
+		foreach ( $raw as $raw_item ) {
+			if ( ! is_array( $raw_item ) ) {
+				return new WP_Error(
+					'sensei_course_structure_invalid_item',
+					__( 'Each item must be an array', 'sensei-lms' ),
+					[ 'status' => 400 ]
+				);
+			}
+
+			$item = $this->validate_and_sanitize_item( $raw_item );
+			if ( is_wp_error( $item ) ) {
+				return $item;
+			}
+
+			$structure[] = $item;
+		}
+
+		return $structure;
+	}
+
+	/**
+	 * Validate and sanitize input item of structure.
+	 *
+	 * @param array $raw_item Raw item to sanitize.
+	 *
+	 * @return array|WP_Error
+	 */
+	private function validate_and_sanitize_item( array $raw_item ) {
+		if ( ! isset( $raw_item['type'] ) || ! in_array( $raw_item['type'], [ 'module', 'lesson' ], true ) ) {
+			return new WP_Error(
+				'sensei_course_structure_invalid_item_type',
+				__( 'All items must have a `type` set.', 'sensei-lms' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		if ( ! isset( $raw_item['title'] ) || '' === trim( sanitize_text_field( $raw_item['title'] ) ) ) {
+			return new WP_Error(
+				'sensei_course_structure_missing_title',
+				__( 'All items must have a `title` set.', 'sensei-lms' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		if (
+			'module' === $raw_item['type']
+			&& (
+				! isset( $raw_item['lessons'] )
+				|| ! is_array( $raw_item['lessons'] )
+			)
+		) {
+			return new WP_Error(
+				'sensei_course_structure_missing_lessons',
+				__( 'Module items must include a `lessons` array.', 'sensei-lms' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$item = [
+			'type'  => $raw_item['type'],
+			'id'    => ! empty( $raw_item['id'] ) ? intval( $raw_item['id'] ) : null,
+			'title' => trim( sanitize_text_field( $raw_item['title'] ) ),
+		];
+
+		if ( 'module' === $raw_item['type'] ) {
+			$item['description'] = isset( $raw_item['description'] ) ? trim( sanitize_text_field( $raw_item['description'] ) ) : null;
+			$item['lessons']     = [];
+			foreach ( $raw_item['lessons'] as $raw_lesson ) {
+				$lesson = $this->validate_and_sanitize_item( $raw_lesson );
+				if ( is_wp_error( $lesson ) ) {
+					return $lesson;
+				}
+
+				if ( 'lesson' !== $lesson['type'] ) {
+					return new WP_Error(
+						'sensei_course_structure_invalid_module_lesson',
+						__( 'Module lessons array can only contain lessons.', 'sensei-lms' ),
+						[ 'status' => 400 ]
+					);
+				}
+
+				$item['lessons'][] = $lesson;
+			}
+		}
+
+		return $item;
+	}
+
+	/**
+	 * Get the course object.
+	 *
+	 * @param int $course_id
+	 *
+	 * @return WP_Post|null
+	 */
+	private function get_course( int $course_id ) {
+		$course = get_post( $course_id );
+
+		return $course ? $course : null;
+	}
+
+	/**
+	 * Schema for the endpoint.
+	 *
+	 * @return array Schema object.
+	 */
+	public function get_schema() {
+		return [
+			'definitions' => [
+				'lesson' => [
+					'type'       => 'object',
+					'required'   => [ 'type', 'title' ],
+					'properties' => [
+						'type'  => [
+							'const' => 'lesson',
+						],
+						'id'    => [
+							'description' => __( 'Lesson post ID', 'sensei-lms' ),
+							'type'        => 'integer',
+						],
+						'title' => [
+							'description' => __( 'Lesson title', 'sensei-lms' ),
+							'type'        => 'string',
+						],
+					],
+				],
+				'module' => [
+					'type'       => 'object',
+					'required'   => [ 'type', 'title', 'lessons' ],
+					'properties' => [
+						'type'        => [
+							'const' => 'module',
+						],
+						'id'          => [
+							'description' => __( 'Module term ID', 'sensei-lms' ),
+							'type'        => 'integer',
+						],
+						'title'       => [
+							'description' => __( 'Module title', 'sensei-lms' ),
+							'type'        => 'string',
+						],
+						'description' => [
+							'description' => __( 'Module description', 'sensei-lms' ),
+							'type'        => 'string',
+						],
+						'lessons'     => [
+							'description' => __( 'Lessons in module', 'sensei-lms' ),
+							'type'        => 'array',
+							'items'       => [ '$ref' => '#/definitions/lesson' ],
+						],
+					],
+				],
+			],
+			'type'        => 'array',
+			'items'       => [
+				'oneOf' => [ [ '$ref' => '#/definitions/lesson' ], [ '$ref' => '#/definitions/module' ] ],
+			],
+		];
+	}
+}

--- a/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
@@ -147,11 +147,28 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 			return $structure_input;
 		}
 
-		$result = $course_structure->save( $structure_input );
+		$raw_structure = json_decode( $structure_input, true );
+		if ( ! is_array( $raw_structure ) ) {
+			return new WP_Error(
+				'sensei_course_structure_invalid_input',
+				__( 'Input for course structure was invalid.', 'sensei-lms' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$result = $course_structure->save( $raw_structure );
 		if ( is_wp_error( $result ) ) {
 			return new WP_Error(
 				$result->get_error_code(),
 				$result->get_error_message(),
+				[ 'status' => 400 ]
+			);
+		}
+
+		if ( false === $result ) {
+			return new WP_Error(
+				'sensei_course_structure_missing_course',
+				__( 'An error occurred while saving the course structure.', 'sensei-lms' ),
 				[ 'status' => 500 ]
 			);
 		}
@@ -160,107 +177,6 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 		$response->set_data( $course_structure->get() );
 
 		return $response;
-	}
-
-	/**
-	 * Parse and sanitize the structure input.
-	 *
-	 * @param string $structure_input JSON string of structure.
-	 *
-	 * @return WP_Error|array False if the input is invalid.
-	 */
-	private function parse_input( string $structure_input ) : bool {
-		$raw = json_decode( $structure_input, true );
-		if ( ! is_array( $raw ) ) {
-			return false;
-		}
-		$structure = [];
-		foreach ( $raw as $raw_item ) {
-			if ( ! is_array( $raw_item ) ) {
-				return new WP_Error(
-					'sensei_course_structure_invalid_item',
-					__( 'Each item must be an array', 'sensei-lms' ),
-					[ 'status' => 400 ]
-				);
-			}
-
-			$item = $this->validate_and_sanitize_item( $raw_item );
-			if ( is_wp_error( $item ) ) {
-				return $item;
-			}
-
-			$structure[] = $item;
-		}
-
-		return $structure;
-	}
-
-	/**
-	 * Validate and sanitize input item of structure.
-	 *
-	 * @param array $raw_item Raw item to sanitize.
-	 *
-	 * @return array|WP_Error
-	 */
-	private function validate_and_sanitize_item( array $raw_item ) {
-		if ( ! isset( $raw_item['type'] ) || ! in_array( $raw_item['type'], [ 'module', 'lesson' ], true ) ) {
-			return new WP_Error(
-				'sensei_course_structure_invalid_item_type',
-				__( 'All items must have a `type` set.', 'sensei-lms' ),
-				[ 'status' => 400 ]
-			);
-		}
-
-		if ( ! isset( $raw_item['title'] ) || '' === trim( sanitize_text_field( $raw_item['title'] ) ) ) {
-			return new WP_Error(
-				'sensei_course_structure_missing_title',
-				__( 'All items must have a `title` set.', 'sensei-lms' ),
-				[ 'status' => 400 ]
-			);
-		}
-
-		if (
-			'module' === $raw_item['type']
-			&& (
-				! isset( $raw_item['lessons'] )
-				|| ! is_array( $raw_item['lessons'] )
-			)
-		) {
-			return new WP_Error(
-				'sensei_course_structure_missing_lessons',
-				__( 'Module items must include a `lessons` array.', 'sensei-lms' ),
-				[ 'status' => 400 ]
-			);
-		}
-
-		$item = [
-			'type'  => $raw_item['type'],
-			'id'    => ! empty( $raw_item['id'] ) ? intval( $raw_item['id'] ) : null,
-			'title' => trim( sanitize_text_field( $raw_item['title'] ) ),
-		];
-
-		if ( 'module' === $raw_item['type'] ) {
-			$item['description'] = isset( $raw_item['description'] ) ? trim( sanitize_text_field( $raw_item['description'] ) ) : null;
-			$item['lessons']     = [];
-			foreach ( $raw_item['lessons'] as $raw_lesson ) {
-				$lesson = $this->validate_and_sanitize_item( $raw_lesson );
-				if ( is_wp_error( $lesson ) ) {
-					return $lesson;
-				}
-
-				if ( 'lesson' !== $lesson['type'] ) {
-					return new WP_Error(
-						'sensei_course_structure_invalid_module_lesson',
-						__( 'Module lessons array can only contain lessons.', 'sensei-lms' ),
-						[ 'status' => 400 ]
-					);
-				}
-
-				$item['lessons'][] = $lesson;
-			}
-		}
-
-		return $item;
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
@@ -147,10 +147,11 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 			return $structure_input;
 		}
 
-		if ( ! $course_structure->save( $structure_input ) ) {
+		$result = $course_structure->save( $structure_input );
+		if ( is_wp_error( $result ) ) {
 			return new WP_Error(
-				'sensei_course_structure_missing_course',
-				__( 'An error occurred while saving the course structure.', 'sensei-lms' ),
+				$result->get_error_code(),
+				$result->get_error_message(),
 				[ 'status' => 500 ]
 			);
 		}

--- a/includes/rest-api/class-sensei-rest-api-internal.php
+++ b/includes/rest-api/class-sensei-rest-api-internal.php
@@ -47,6 +47,7 @@ class Sensei_REST_API_Internal {
 			new Sensei_REST_API_Setup_Wizard_Controller( $this->namespace ),
 			new Sensei_REST_API_Import_Controller( $this->namespace ),
 			new Sensei_REST_API_Export_Controller( $this->namespace ),
+			new Sensei_REST_API_Course_Structure_Controller( $this->namespace ),
 		];
 
 		foreach ( $this->controllers as $controller ) {

--- a/tests/bin/run-wp-unit-tests.sh
+++ b/tests/bin/run-wp-unit-tests.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [[ ${TRAVIS_PHP_VERSION} > 7.1 ]]; then
+	composer install
+fi
+
 if [[ ! -z "$WP_VERSION" ]]; then
 	phpunit
 fi

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -114,6 +114,13 @@ class Sensei_Unit_Tests_Bootstrap {
 
 		// Testing setup for event logging.
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/class-sensei-test-events.php';
+
+		// Used for some libraries. Tests that require these libraries should be skipped if they don't exist.
+		$autoload_file = __DIR__ . '/../vendor/autoload.php';
+		if ( file_exists( $autoload_file ) ) {
+			require_once $autoload_file;
+		}
+
 		Sensei_Test_Events::init();
 	}
 	/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -102,7 +102,8 @@ class Sensei_Unit_Tests_Bootstrap {
 	 * @since 1.9
 	 */
 	public function includes() {
-		// factories
+		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-test-login-helpers.php';
+		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-rest-api-test-helpers.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-manual-test-helpers.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-scheduler-test-helpers.php';

--- a/tests/framework/factories/class-sensei-factory.php
+++ b/tests/framework/factories/class-sensei-factory.php
@@ -187,21 +187,21 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 			'lesson_count'            => 1,
 			'question_count'          => 5,
 			'multiple_question_count' => 0,
+			'module_count'            => 0,
 			'course_args'             => array(),
 			'quiz_args'               => array(),
 			'lesson_args'             => array(),
 			'question_args'           => array(),
 			'multiple_question_args'  => array(),
-			'use_module'              => false,
 		);
 		$args         = wp_parse_args( $args, $default_args );
-		$module       = false;
-		if ( $args['use_module'] ) {
-			$module = $this->module->create_and_get();
+		$module_ids   = [];
+		if ( $args['module_count'] ) {
+			$module_ids = $this->module->create_many( $args['module_count'] );
 		}
 		$course_id = $this->course->create( $args['course_args'] );
-		if ( $module ) {
-			wp_set_object_terms( $course_id, $module->term_id, 'module' );
+		if ( ! empty( $module_ids ) ) {
+			wp_set_object_terms( $course_id, $module_ids, 'module' );
 		}
 
 		if ( ! isset( $args['lesson_args']['meta_input'] ) ) {
@@ -211,9 +211,11 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 
 		$lesson_ids = $this->lesson->create_many( $args['lesson_count'], $args['lesson_args'] );
 		foreach ( $lesson_ids as $key => $lesson_id ) {
-			if ( $module ) {
-				wp_set_object_terms( $lesson_id, $module->term_id, 'module' );
-				add_post_meta( $lesson_id, '_order_module_' . $module->term_id, 0 );
+			if ( ! empty( $module_ids ) ) {
+				shuffle( $module_ids );
+
+				wp_set_object_terms( $lesson_id, $module_ids[0], 'module' );
+				add_post_meta( $lesson_id, '_order_module_' . $module_ids[0], 0 );
 			}
 			$question_count = $args['question_count'];
 			if ( is_array( $question_count ) ) {
@@ -223,6 +225,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 					$question_count = $default_args['question_count'];
 				}
 			}
+
 			$this->attach_lessons_questions( $question_count, $lesson_id, $args['question_args'], $args['quiz_args'], false );
 
 			$multiple_question_count = $args['multiple_question_count'];
@@ -239,6 +242,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 		return array(
 			'course_id'  => $course_id,
 			'lesson_ids' => $lesson_ids,
+			'modules'    => $module_ids,
 		);
 	}
 

--- a/tests/framework/trait-sensei-rest-api-test-helpers.php
+++ b/tests/framework/trait-sensei-rest-api-test-helpers.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * File with trait Sensei_Scheduler_Test_Helpers.
+ *
+ * @package sensei-tests
+ */
+
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Using PHPUnit conventions.
+
+use Swaggest\JsonSchema\Schema;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Helpers used in REST API tests.
+ *
+ * @since 3.6.0
+ */
+trait Sensei_REST_API_Test_Helpers {
+	/**
+	 * Assert the response matches the schema.
+	 *
+	 * @param array $schema Endpoint response schema.
+	 * @param array $result Request response body.
+	 */
+	public function assertMeetsSchema( $schema, $result ) {
+		// We only include `autoload.php` when PHPUnit can be installed, which is on PHP 7.2+.
+		if ( ! class_exists( Schema::class ) ) {
+			$this->markTestSkipped( 'Test requires a higher version of PHP' );
+			return;
+		}
+
+		// Object (key based arrays) should be `stdClass` objects for validation.
+		$normalized_result = json_decode( wp_json_encode( $result ) );
+		$normalized_schema = json_decode( wp_json_encode( $schema ) );
+
+		$schema = Schema::import( $normalized_schema );
+
+		try {
+			$schema->in( $normalized_result );
+		} catch ( \Exception $e ) {
+			// Cheeky way to bail and show error message.
+			$this->assertTrue( false, $e->getMessage() );
+		}
+
+		// If we made it this far, faux-assert always true.
+		$this->assertTrue( true );
+	}
+}

--- a/tests/framework/trait-sensei-test-login-helpers.php
+++ b/tests/framework/trait-sensei-test-login-helpers.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * File with trait Sensei_Test_Login_Helpers.
+ *
+ * @package sensei-tests
+ */
+
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Using PHPUnit conventions.
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Helpers for logging in as different users.
+ *
+ * @since 3.6.0
+ */
+trait Sensei_Test_Login_Helpers {
+	protected function get_user_by_role( $role, $variant = '' ) {
+		$slug = $role . $variant;
+		$user = get_user_by( 'email', 'sensei_' . $slug . '_user@example.com' );
+		if ( empty( $user ) ) {
+			$user_id = wp_create_user(
+				'sensei_' . $slug . '_user',
+				'sensei_' . $slug . '_user',
+				'sensei_' . $slug . '_user@example.com'
+			);
+			$user    = get_user_by( 'ID', $user_id );
+			$user->set_role( $role );
+		}
+		return $user->ID;
+	}
+
+	protected function login_as_admin() {
+		return $this->login_as( $this->get_user_by_role( 'administrator' ) );
+	}
+
+	protected function login_as_teacher() {
+		return $this->login_as( $this->get_user_by_role( 'teacher' ) );
+	}
+
+	protected function login_as_teacher_b() {
+		return $this->login_as( $this->get_user_by_role( 'teacher', '_b' ) );
+	}
+
+	protected function login_as_student() {
+		return $this->login_as( $this->get_user_by_role( 'subscriber' ) );
+	}
+
+	protected function login_as_student_b() {
+		return $this->login_as( $this->get_user_by_role( 'subscriber', '_b' ) );
+	}
+
+	protected function login_as( $user_id ) {
+		wp_set_current_user( $user_id );
+		return $this;
+	}
+
+	protected function logout() {
+		$this->login_as( 0 );
+		wp_logout();
+		return $this;
+	}
+}

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
@@ -1,0 +1,183 @@
+<?php
+/**
+ * Sensei REST API: Sensei_REST_API_Course_Structure_Controller_Tests tests
+ *
+ * @package sensei-lms
+ * @since 3.6.0
+ * @group course-structure
+ * @group rest-api
+ */
+
+/**
+ * Class Sensei_REST_API_Course_Structure_Controller tests.
+ */
+class Sensei_REST_API_Course_Structure_Controller_Tests extends WP_Test_REST_TestCase {
+	use Sensei_Test_Login_Helpers;
+	use Sensei_REST_API_Test_Helpers;
+
+	/**
+	 * A server instance that we use in tests to dispatch requests.
+	 *
+	 * @var WP_REST_Server $server
+	 */
+	protected $server;
+
+	/**
+	 * Sensei post factory.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Test specific setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		do_action( 'rest_api_init' );
+
+		$this->factory = new Sensei_Factory();
+	}
+
+	/**
+	 * Tests a simple `GET /sensei-internal/v1/course-structure/{course_id}` request response matches the schema.
+	 */
+	public function testGetSimple() {
+		$this->login_as_teacher();
+
+		$course_response = $this->factory->get_course_with_lessons(
+			[
+				'module_count'   => 2,
+				'lesson_count'   => 5,
+				'question_count' => 0,
+			]
+		);
+
+		$course_id = $course_response['course_id'];
+		$request   = new WP_REST_Request( 'GET', '/sensei-internal/v1/course-structure/' . $course_id );
+		$response  = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_status(), 200 );
+
+		$endpoint = new Sensei_REST_API_Course_Structure_Controller( '' );
+		$this->assertMeetsSchema( $endpoint->get_schema(), $response->get_data() );
+		$this->assertEquals( 2, count( $response->get_data() ), '2 modules should be on the root level' );
+
+		$this->assertEquals( 5, count( $response->get_data()[0]['lessons'] ) + count( $response->get_data()[1]['lessons'] ), '5 lessons should be set to the 2 modules' );
+	}
+
+	/**
+	 * Tests a `GET /sensei-internal/v1/course-structure/{course_id}` returns 404 when course doesn't exist.
+	 */
+	public function testGetMissingCourse() {
+		$this->login_as_admin();
+
+		$request  = new WP_REST_Request( 'GET', '/sensei-internal/v1/course-structure/1234' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_status(), 404 );
+	}
+
+	/**
+	 * Tests `GET /sensei-internal/v1/course-structure/{course_id}` for a teacher's draft course.
+	 */
+	public function testGetTeachersCourse() {
+		$this->login_as_teacher();
+
+		$course_id = $this->factory->course->create(
+			[
+				'post_status' => 'draft',
+			]
+		);
+
+		$request  = new WP_REST_Request( 'GET', '/sensei-internal/v1/course-structure/' . $course_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_status(), 200 );
+	}
+
+	/**
+	 * Tests `GET /sensei-internal/v1/course-structure/{course_id}` for another teacher's draft course isn't possible.
+	 */
+	public function testGetAnotherTeachersCourse() {
+		$this->login_as_teacher();
+
+		$course_id = $this->factory->course->create(
+			[
+				'post_status' => 'draft',
+			]
+		);
+
+		$this->login_as_teacher_b();
+
+		$request  = new WP_REST_Request( 'GET', '/sensei-internal/v1/course-structure/' . $course_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_status(), 403 );
+	}
+
+	/**
+	 * Tests `GET /sensei-internal/v1/course-structure/{course_id}` as a student for an unpublished course.
+	 */
+	public function testGetStudentDraftCourse() {
+		$this->login_as_teacher();
+
+		$course_id = $this->factory->course->create(
+			[
+				'post_status' => 'draft',
+			]
+		);
+
+		$this->login_as_student();
+
+		$request  = new WP_REST_Request( 'GET', '/sensei-internal/v1/course-structure/' . $course_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_status(), 403 );
+	}
+
+	/**
+	 * Tests `GET /sensei-internal/v1/course-structure/{course_id}` as a guest for an unpublished course.
+	 */
+	public function testGetGuestDraftCourse() {
+		$this->login_as_teacher();
+
+		$course_id = $this->factory->course->create(
+			[
+				'post_status' => 'draft',
+			]
+		);
+
+		$this->logout();
+
+		$request  = new WP_REST_Request( 'GET', '/sensei-internal/v1/course-structure/' . $course_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_status(), 401 );
+	}
+
+	/**
+	 * Tests `GET /sensei-internal/v1/course-structure/{course_id}` as a guest for published course.
+	 */
+	public function testGetGuestPublishedCourse() {
+		$this->login_as_teacher();
+
+		$course_id = $this->factory->course->create(
+			[
+				'post_status' => 'publish',
+			]
+		);
+
+		$this->logout();
+
+		$request  = new WP_REST_Request( 'GET', '/sensei-internal/v1/course-structure/' . $course_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_status(), 200 );
+	}
+}

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -1,0 +1,241 @@
+<?php
+
+/**
+ * Tests for Sensei_Course_Structure_Test class.
+ *
+ * @group course-structure
+ */
+class Sensei_Course_Structure_Test extends WP_UnitTestCase {
+	/**
+	 * Set up the test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		if ( ! isset( Sensei()->admin ) ) {
+			Sensei()->admin = new Sensei_Admin();
+		}
+
+		$this->factory = new Sensei_Factory();
+		$this->resetInstances();
+	}
+
+	/**
+	 * Test getting course structure when just lessons.
+	 */
+	public function testGetJustLessons() {
+		$course_id          = $this->factory->course->create();
+		$course_lesson_args = [
+			'meta_input' => [
+				'_lesson_course' => $course_id,
+			],
+		];
+		$lessons            = $this->factory->lesson->create_many( 3, $course_lesson_args );
+		$lesson_unordered   = $this->factory->lesson->create( $course_lesson_args );
+
+		// Rogue lesson.
+		$this->factory->lesson->create();
+
+		$expected_structure = [];
+		foreach ( [ $lessons[1], $lessons[0], $lessons[2] ] as $lesson_id ) {
+			$expected_structure[] = [
+				'type' => 'lesson',
+				'id'   => $lesson_id,
+			];
+		}
+
+		$this->saveStructure( $course_id, $expected_structure );
+
+		$expected_structure[] = [
+			'type' => 'lesson',
+			'id'   => $lesson_unordered,
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+		$structure        = $course_structure->get();
+
+		$this->assertExpectedStructure( $expected_structure, $structure );
+	}
+
+	/**
+	 * Test getting course structure when just modules on the first level.
+	 */
+	public function testGetJustModules() {
+		$course_id = $this->factory->course->create();
+
+		$lessons = $this->factory->lesson->create_many( 4 );
+		$modules = $this->factory->module->create_many( 2 );
+
+		$expected_structure = [
+			[
+				'type'    => 'module',
+				'id'      => $modules[1],
+				'lessons' => [
+					[
+						'type' => 'lesson',
+						'id'   => $lessons[1],
+					],
+					[
+						'type' => 'lesson',
+						'id'   => $lessons[2],
+					],
+				],
+			],
+			[
+				'type'    => 'module',
+				'id'      => $modules[0],
+				'lessons' => [
+					[
+						'type' => 'lesson',
+						'id'   => $lessons[3],
+					],
+					[
+						'type' => 'lesson',
+						'id'   => $lessons[0],
+					],
+				],
+			],
+		];
+
+		$this->saveStructure( $course_id, $expected_structure );
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+		$structure        = $course_structure->get();
+
+		$this->assertExpectedStructure( $expected_structure, $structure );
+	}
+
+	/**
+	 * Test getting course structure when there is a mix of modules and lessons on the first level.
+	 */
+	public function testGetModulesLessonsMix() {
+		$course_id = $this->factory->course->create();
+
+		$lessons = $this->factory->lesson->create_many( 5 );
+		$modules = $this->factory->module->create_many( 2 );
+
+		$expected_structure = [
+			[
+				'type'    => 'module',
+				'id'      => $modules[1],
+				'lessons' => [
+					[
+						'type' => 'lesson',
+						'id'   => $lessons[1],
+					],
+					[
+						'type' => 'lesson',
+						'id'   => $lessons[2],
+					],
+				],
+			],
+			[
+				'type'    => 'module',
+				'id'      => $modules[0],
+				'lessons' => [
+					[
+						'type' => 'lesson',
+						'id'   => $lessons[0],
+					],
+				],
+			],
+			[
+				'type' => 'lesson',
+				'id'   => $lessons[4],
+			],
+			[
+				'type' => 'lesson',
+				'id'   => $lessons[3],
+			],
+		];
+
+		$this->saveStructure( $course_id, $expected_structure );
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+		$structure        = $course_structure->get();
+
+		$this->assertExpectedStructure( $expected_structure, $structure );
+	}
+
+	/**
+	 * Reset the course structure instances array.
+	 */
+	private function resetInstances() {
+		$instances_property = new ReflectionProperty( 'Sensei_Course_Structure', 'instances' );
+		$instances_property->setAccessible( true );
+		$instances_property->setValue( [] );
+	}
+
+	/**
+	 * Assert that a given structure matches the expected structure.
+	 *
+	 * @param array $expected_structure  Expected structure.
+	 * @param array $structure           Structure result.
+	 * @param string $level              Level description.
+	 */
+	private function assertExpectedStructure( array $expected_structure, array $structure, $level = 'the top-level' ) {
+		$this->assertEquals( count( $expected_structure ), count( $structure ), sprintf( 'Structure should have the same number of items in %s', $level ) );
+
+		foreach ( $expected_structure as $index => $expected_item ) {
+			$item = $structure[ $index ];
+			$this->assertEquals( $expected_item['id'], $item['id'], sprintf( 'Expected the same `id` for the items with index %s in %s', $index, $level ) );
+			$this->assertEquals( $expected_item['type'], $item['type'], sprintf( 'Expected the same `type` for the items with index %s in %s', $index, $level ) );
+
+			if ( 'lesson' === $expected_item['type'] ) {
+				$this->assertFalse( array_key_exists( 'lessons', $item ), sprintf( 'Expected no `lessons` key for item with index %s in %s', $index, $level ) );
+				$this->assertFalse( array_key_exists( 'description', $item ), sprintf( 'Expected no `description` key for item with index %s in %s', $index, $level ) );
+				$this->assertEquals( get_the_title( $expected_item['id'] ), $item['title'], sprintf( 'Expected the same `title` for the items with index %s in %s', $index, $level ) );
+			} else {
+				$this->assertTrue( array_key_exists( 'lessons', $item ), sprintf( 'Expected a `lessons` key for item with index %s in %s', $index, $level ) );
+				$this->assertTrue( array_key_exists( 'description', $item ), sprintf( 'Expected a `description` key for item with index %s in %s', $index, $level ) );
+				$term = get_term( $expected_item['id'] );
+				$this->assertEquals( $term->name, $item['title'], sprintf( 'Expected the same `title` for the items with index %s in %s', $index, $level ) );
+			}
+
+			if ( isset( $expected_item['lessons'] ) ) {
+				$this->assertExpectedStructure( $expected_item['lessons'], $structure[ $index ]['lessons'], 'module id:' . $expected_item['id'] );
+			}
+		}
+	}
+
+	/**
+	 * Save a structure.
+	 *
+	 * @param int   $course_id     Course ID.
+	 * @param array $structure     Structure to save.
+	 * @param int   $module_parent Module ID.
+	 */
+	private function saveStructure( int $course_id, array $structure, $module_parent = null ) {
+		$order_lesson_adjust = $module_parent ? 0 : 1;
+		$order_meta_key      = $module_parent ? '_order_module_' . $module_parent : '_order_' . $course_id;
+		$module_order        = [];
+		$lesson_order        = [];
+
+		foreach ( $structure as $item ) {
+			if ( 'lesson' === $item['type'] ) {
+				add_post_meta( $item['id'], $order_meta_key, count( $lesson_order ) + $order_lesson_adjust );
+				add_post_meta( $item['id'], '_lesson_course', $course_id );
+				$lesson_order[] = $item['id'];
+
+				if ( $module_parent ) {
+					wp_set_object_terms( $item['id'], $module_parent, 'module' );
+				}
+			} else {
+				$this->saveStructure( $course_id, $item['lessons'], $item['id'] );
+
+				$module_order[] = $item['id'];
+			}
+		}
+
+		if ( ! empty( $module_order ) ) {
+			wp_set_object_terms( $course_id, $module_order, 'module' );
+			update_post_meta( $course_id, '_module_order', array_map( 'strval', $module_order ) );
+		}
+
+		if ( ! empty( $lesson_order ) ) {
+			if ( ! $module_parent ) {
+				Sensei()->admin->save_lesson_order( implode( ',', $lesson_order ), $course_id );
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds REST API endpoints for getting and saving course structure.
* _Implements_ getting course structure.
* Changes tests to allow us to use composer packages for PHP 7.2+. This was to verify JSON schema.

### Testing instructions

* Observe tests passing.
* Set up a complex course with various lessons, some in modules. Reorder the modules and lessons.
* Visit `http://{host}/wp-json/sensei-internal/v1/course-structure/{course_id}`.
* Verify JSON response is correct.