### PR TITLE
Add course outline empty state

### DIFF
--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -1,0 +1,72 @@
+import { createBlock } from '@wordpress/blocks';
+import { invert } from 'lodash';
+
+/**
+ * Course structure data.
+ *
+ * @global
+ * @typedef {[CourseLessonData,CourseModuleData]} CourseStructure
+ */
+/**
+ * @typedef CourseModuleData
+ * @param {string}             type        Block type ('module')
+ * @param {string?}            title       Module title
+ * @param {number?}            id          Module ID
+ * @param {string?}            description Module description
+ * @param {CourseLessonData[]} lessons     Module lessons
+ */
+/**
+ * @typedef CourseLessonData
+ * @param {string}  type  Block type ('lesson')
+ * @param {string?} title Lesson title
+ * @param {number?} id    Lesson ID
+ */
+
+export const blockNames = {
+	module: 'sensei-lms/course-outline-module',
+	lesson: 'sensei-lms/course-outline-lesson',
+};
+
+export const blockTypes = invert( blockNames );
+
+/**
+ *
+ * Convert course structure to blocks.
+ *
+ * @param {[CourseLessonData,CourseModuleData]} blockData
+ * @return {Object[]} Blocks.
+ */
+export const convertToBlocks = ( blockData ) =>
+	blockData.map( ( { type, lessons, ...block } ) =>
+		createBlock(
+			blockNames[ type ],
+			block,
+			lessons ? convertToBlocks( lessons ) : []
+		)
+	);
+
+/**
+ * Convert blocks to course structure.
+ *
+ * @param {Object[]} blocks Blocks.
+ * @return {CourseStructure} Course structure
+ */
+export const extractBlocksData = ( blocks ) => {
+	const extractBlockData = {
+		module: ( block ) => ( {
+			...block.attributes,
+			lessons: extractBlocksData( block.innerBlocks ),
+		} ),
+		lesson: ( block ) => ( {
+			...block.attributes,
+		} ),
+	};
+
+	return blocks.map( ( block ) => {
+		const type = blockTypes[ block.name ];
+		return {
+			type,
+			...extractBlockData[ type ]( block ),
+		};
+	} );
+};

--- a/assets/blocks/course-outline/data.test.js
+++ b/assets/blocks/course-outline/data.test.js
@@ -1,0 +1,92 @@
+import { convertToBlocks, extractBlocksData } from './data';
+import './lesson-block';
+import './module-block';
+
+describe( 'convertToBlocks', () => {
+	it( 'creates blocks from structure', () => {
+		const blocks = convertToBlocks( [
+			{
+				type: 'module',
+				description: 'Module 1',
+				title: 'M1',
+				lessons: [
+					{ type: 'lesson', title: 'M1L1' },
+					{ type: 'lesson', title: 'M1L2' },
+				],
+			},
+			{ type: 'lesson', title: 'L2' },
+		] );
+
+		expect( blocks ).toEqual( [
+			expect.objectContaining( {
+				name: 'sensei-lms/course-outline-module',
+				attributes: { title: 'M1', description: 'Module 1' },
+				innerBlocks: [
+					expect.objectContaining( {
+						name: 'sensei-lms/course-outline-lesson',
+						attributes: { title: 'M1L1' },
+						innerBlocks: [],
+						isValid: true,
+					} ),
+					expect.objectContaining( {
+						name: 'sensei-lms/course-outline-lesson',
+						attributes: { title: 'M1L2' },
+						innerBlocks: [],
+						isValid: true,
+					} ),
+				],
+				isValid: true,
+			} ),
+			expect.objectContaining( {
+				name: 'sensei-lms/course-outline-lesson',
+				attributes: { title: 'L2' },
+				innerBlocks: [],
+				isValid: true,
+			} ),
+		] );
+	} );
+} );
+describe( 'extractBlocksData', () => {
+	it( 'creates structure from blocks', () => {
+		const data = extractBlocksData( [
+			{
+				name: 'sensei-lms/course-outline-module',
+				attributes: { title: 'M1', description: 'Module 1' },
+				innerBlocks: [
+					{
+						name: 'sensei-lms/course-outline-lesson',
+						attributes: { title: 'M1L1' },
+						innerBlocks: [],
+						isValid: true,
+					},
+					{
+						name: 'sensei-lms/course-outline-lesson',
+						attributes: { title: 'M1L2' },
+						innerBlocks: [],
+						isValid: true,
+					},
+				],
+				isValid: true,
+			},
+			{
+				name: 'sensei-lms/course-outline-lesson',
+				attributes: { title: 'L2' },
+				innerBlocks: [],
+				isValid: true,
+			},
+		] );
+
+		expect( data ).toEqual( [
+			{
+				type: 'module',
+				description: 'Module 1',
+				title: 'M1',
+				lessons: [
+					{ type: 'lesson', title: 'M1L1' },
+					{ type: 'lesson', title: 'M1L2' },
+				],
+			},
+			{ type: 'lesson', title: 'L2' },
+		] );
+	} );
+} );

--- a/assets/blocks/course-outline/edit.js
+++ b/assets/blocks/course-outline/edit.js
@@ -1,78 +1,44 @@
 import { InnerBlocks } from '@wordpress/block-editor';
+import { compose } from '@wordpress/compose';
+import { useSelect, withSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+import { CourseOutlinePlaceholder } from './placeholder';
 
-import useBlocksCreator from './use-block-creator';
-
-// TODO: Fetch from API.
-const data = [
-	{
-		id: 1,
-		type: 'module',
-		title: 'Module 1',
-		description: 'Module description 1',
-		lessons: [
-			{
-				id: 2,
-				type: 'lesson',
-				title: 'Lesson 2',
-			},
-			{
-				id: 3,
-				type: 'lesson',
-				title: 'Lesson 3',
-			},
-		],
-	},
-	{
-		id: 9,
-		type: 'lesson',
-		title: 'Lesson 9',
-	},
-	{
-		id: 10,
-		type: 'lesson',
-		title: 'Lesson 10',
-	},
-	{
-		id: 4,
-		type: 'module',
-		title: 'Module 4',
-		description: 'Module description 4',
-		lessons: [
-			{
-				id: 5,
-				type: 'lesson',
-				title: 'Lesson 5',
-			},
-		],
-	},
-	{
-		id: 6,
-		type: 'module',
-		title: 'Module 6',
-		description: 'Module description 6',
-		lessons: [],
-	},
-	{
-		id: 7,
-		type: 'lesson',
-		title: 'Lesson 7',
-	},
-];
+import { useBlocksCreator } from './use-block-creator';
 
 /**
  * Edit course outline block component.
  *
- * @param {Object} props           Component props.
- * @param {string} props.clientId  Block client ID.
- * @param {string} props.className Custom class name.
+ * @param {Object}   props           Component props.
+ * @param {string}   props.clientId  Block client ID.
+ * @param {string}   props.className Custom class name.
+ * @param {Object[]} props.blocks    Course module and lesson blocks
  */
-const EditCourseOutlineBlock = ( { clientId, className } ) => {
-	useBlocksCreator( data, clientId );
+const EditCourseOutlineBlock = ( { clientId, className, blocks } ) => {
+	const { setBlocks } = useBlocksCreator( clientId );
 
+	useEffect( () => {
+		if ( blocks && blocks.length ) {
+			setBlocks( blocks );
+		}
+	}, [ blocks, setBlocks ] );
+
+	const isEmpty = useSelect(
+		( select ) =>
+			! select( 'core/block-editor' ).getBlocks( clientId ).length,
+		[ clientId, blocks ]
+	);
+
+	if ( isEmpty ) {
+		return (
+			<CourseOutlinePlaceholder
+				addBlock={ ( type ) => setBlocks( [ { type } ] ) }
+			/>
+		);
+	}
 	return (
 		<section className={ className }>
 			<InnerBlocks
-				template={ [ [ 'sensei-lms/course-outline-module', {} ] ] }
 				allowedBlocks={ [
 					'sensei-lms/course-outline-module',
 					'sensei-lms/course-outline-lesson',
@@ -82,4 +48,10 @@ const EditCourseOutlineBlock = ( { clientId, className } ) => {
 	);
 };
 
-export default EditCourseOutlineBlock;
+export default compose(
+	withSelect( () => {
+		return {
+			blocks: [],
+		};
+	} )
+)( EditCourseOutlineBlock );

--- a/assets/blocks/course-outline/lesson-block/index.js
+++ b/assets/blocks/course-outline/lesson-block/index.js
@@ -6,7 +6,6 @@ registerBlockType( 'sensei-lms/course-outline-lesson', {
 	title: __( 'Lesson', 'sensei-lms' ),
 	description: __( 'Where your course content lives.', 'sensei-lms' ),
 	icon: 'list-view',
-	category: 'sensei-lms',
 	parent: [ 'sensei-lms/course-outline', 'sensei-lms/course-outline-module' ],
 	keywords: [ __( 'Outline', 'sensei-lms' ), __( 'Lesson', 'sensei-lms' ) ],
 	supports: {

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -2,28 +2,22 @@ import { __ } from '@wordpress/i18n';
 import { InnerBlocks, RichText } from '@wordpress/block-editor';
 
 import SingleLineInput from '../single-line-input';
-import useBlocksCreator from '../use-block-creator';
 
 /**
  * Edit module block component.
  *
  * @param {Object}   props                        Component props.
- * @param {string}   props.clientId               Block client ID.
  * @param {string}   props.className              Custom class name.
  * @param {Object}   props.attributes             Block attributes.
  * @param {string}   props.attributes.title       Module title.
  * @param {string}   props.attributes.description Module description.
- * @param {Object[]} props.attributes.lessons     Module lessons.
  * @param {Function} props.setAttributes          Block set attributes function.
  */
 const EditModuleBlock = ( {
-	clientId,
 	className,
-	attributes: { title, description, lessons },
+	attributes: { title, description },
 	setAttributes,
 } ) => {
-	useBlocksCreator( lessons, clientId );
-
 	/**
 	 * Handle update name.
 	 *

--- a/assets/blocks/course-outline/module-block/index.js
+++ b/assets/blocks/course-outline/module-block/index.js
@@ -7,7 +7,6 @@ registerBlockType( 'sensei-lms/course-outline-module', {
 	title: __( 'Module', 'sensei-lms' ),
 	description: __( 'Used to group one or more lessons.', 'sensei-lms' ),
 	icon: 'list-view',
-	category: 'sensei-lms',
 	parent: [ 'sensei-lms/course-outline' ],
 	keywords: [ __( 'Outline', 'sensei-lms' ), __( 'Module', 'sensei-lms' ) ],
 	supports: {
@@ -25,10 +24,6 @@ registerBlockType( 'sensei-lms/course-outline-module', {
 		description: {
 			type: 'string',
 			default: '',
-		},
-		lessons: {
-			type: 'array',
-			default: [],
 		},
 	},
 	edit( props ) {

--- a/assets/blocks/course-outline/placeholder.js
+++ b/assets/blocks/course-outline/placeholder.js
@@ -1,0 +1,25 @@
+import { Button, Placeholder } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Placeholder for empty Course Outline block.
+ *
+ * @param {Function} addBlock Add block
+ */
+export const CourseOutlinePlaceholder = ( { addBlock } ) => (
+	<Placeholder
+		label={ __( 'Course Outline', 'sensei-lms' ) }
+		icon="list-view"
+		instructions={ __(
+			'Build and display a course outline. A course is made up of modules (optional) and lessons. You can use modules to group related lessons together.',
+			'sensei-lms'
+		) }
+	>
+		<Button isSecondary onClick={ () => addBlock( 'module' ) }>
+			{ __( 'Create a module', 'sensei-lms' ) }
+		</Button>
+		<Button isSecondary onClick={ () => addBlock( 'lesson' ) }>
+			{ __( 'Create a lesson', 'sensei-lms' ) }
+		</Button>
+	</Placeholder>
+);

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -1,7 +1,7 @@
-$dark-gray: #1A1D20;
+$dark-gray: #1a1d20;
 
 .wp-block-sensei-lms-course-outline {
-	&__clean-input[type="text"] {
+	&__clean-input[type='text'] {
 		display: block;
 		width: 100%;
 		padding: 0;
@@ -38,9 +38,10 @@ $dark-gray: #1A1D20;
 
 .wp-block-sensei-lms-course-outline-module {
 	border: solid 1px $dark-gray;
+	margin-bottom: 25px;
 
 	&__name {
-		padding: 25px;
+		padding: 15px 25px;
 		background-color: $dark-gray;
 		font-size: 24px;
 		font-weight: bold;

--- a/assets/blocks/course-outline/use-block-creator.js
+++ b/assets/blocks/course-outline/use-block-creator.js
@@ -1,33 +1,21 @@
-import { useEffect } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
-import { createBlock } from '@wordpress/blocks';
-
-const blockNames = {
-	module: 'sensei-lms/course-outline-module',
-	lesson: 'sensei-lms/course-outline-lesson',
-};
+import { useCallback } from '@wordpress/element';
+import { convertToBlocks } from './data';
 
 /**
  * Blocks creator hook.
  * It adds blocks dynamically to the InnerBlock.
  *
- * @param {Object[]} blocksData Blocks data to insert.
- * @param {string}   clientId   Block client ID.
+ * @param {string} clientId Block client ID.
  */
-const useBlocksCreator = ( blocksData, clientId ) => {
+export const useBlocksCreator = ( clientId ) => {
 	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
 
-	useEffect( () => {
-		if ( ! blocksData || 0 === blocksData.length ) {
-			return;
-		}
+	const setBlocks = useCallback(
+		( blockData ) =>
+			replaceInnerBlocks( clientId, convertToBlocks( blockData ), false ),
+		[ clientId, replaceInnerBlocks ]
+	);
 
-		const blocks = blocksData.map( ( { type, ...block } ) =>
-			createBlock( blockNames[ type ], block )
-		);
-
-		replaceInnerBlocks( clientId, blocks, false );
-	}, [ blocksData, clientId, replaceInnerBlocks ] );
+	return { setBlocks };
 };
-
-export default useBlocksCreator;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add a placeholder if the outline is empty, with actions to create a lesson or module

### Testing instructions

* Create a new course - outline block should be already added, showing the placeholder
* Click create lesson/module
* Placeholder should disappear with a new lesson/module block added
* Delete the new block: placeholder should be visible again

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![image](https://user-images.githubusercontent.com/176949/92721925-1eac2280-f367-11ea-8411-9d9ee76fffa2.png)

