### PR TITLE
Add sample_course property to publish event

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3440,6 +3440,7 @@ class Sensei_Course {
 			'module_count'  => count( wp_get_post_terms( $course->ID, 'module' ) ),
 			'lesson_count'  => $this->course_lesson_count( $course->ID ),
 			'product_count' => $product_count,
+			'sample_course' => 'getting-started-with-sensei-lms' === $course->post_name ? 1 : 0,
 		];
 		sensei_log_event( 'course_publish', $event_properties );
 	}


### PR DESCRIPTION
Fixes #3591 

### Changes proposed in this Pull Request

* Adds a `sample_course` property to `sensei_course_publish` event.
* The course is considered a sample one if it has a slug of `getting-started-with-sensei-lms`. I imagine that the number of users which change the slug of the sample course before publishing will be very low. Also there is a very low chance of someone publishing a non-sample course with the same slug.
* Registered the property as part of this PR: 345-gh-tracks-events-registration.

### Testing instructions

* Publish the sample course and observe in tracks that the event has a `sample_course` property.