### PR TITLE
Remove dist folder before the build

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
   },
   "scripts": {
     "build": "npm run build:assets && npm run archive",
-    "build:assets": "cross-env NODE_ENV=production npx calypso-build",
+    "build:assets": "rm -rf ./assets/dist && cross-env NODE_ENV=production npx calypso-build",
     "build:docs": "rm -rf hookdocs/ && jsdoc -c hookdoc-conf.json",
     "build:vendor": "cp ./node_modules/select2/dist/css/select2.min.css ./node_modules/select2/dist/js/select2.full.js ./node_modules/select2/dist/js/select2.full.min.js ./assets/vendor/select2",
     "archive": "composer archive --file=$npm_package_name --format=zip",


### PR DESCRIPTION
### Changes proposed in this Pull Request

* While releasing Sensei, I noticed that it was sending some files that weren't part of the package. So I noticed that the assets weren't clean before the build. This PR just introduces it.

### Testing instructions

* Create a file `assets/dist/test.txt`.
* Run `npm run build`.
* Make sure the file doesn't exist after the build.

### Other considered approaches

Another approach would be adding the Webpack plugin `clean-webpack-plugin`. But I decided just run a remove before the script, so we avoid adding more dependencies.