### PR TITLE
Add saving of course structure

### DIFF
--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -270,7 +270,7 @@ class Sensei_Course_Structure {
 
 		$teacher_user_id = get_post( $this->course_id )->post_author;
 		if ( ! user_can( $teacher_user_id, 'manage_options' ) ) {
-			$args['slug'] = intval( $teacher_user_id ) . '-' . sanitize_title( $item['name'] );
+			$args['slug'] = intval( $teacher_user_id ) . '-' . sanitize_title( $item['title'] );
 		}
 
 		$create_result = wp_insert_term( $item['title'], 'module', $args );

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -151,17 +151,317 @@ class Sensei_Course_Structure {
 	/**
 	 * Save a new course structure.
 	 *
-	 * @param array $raw_structure Course structure to save in its raw, unsanitized form.
+	 * @param array $raw_structure Course structure to save in its raw, un-sanitized form.
 	 *
 	 * @return bool|WP_Error
 	 */
 	public function save( array $raw_structure ) {
-		$structure = $this->validate_and_sanitize_structure( $raw_structure );
+		$structure = $this->sanitize_structure( $raw_structure );
 		if ( is_wp_error( $structure ) ) {
 			return $structure;
 		}
 
-		return false;
+		$current_structure                               = $this->get();
+		list( $current_module_ids, $current_lesson_ids ) = $this->flatten_structure( $current_structure );
+
+		$lesson_ids   = [];
+		$module_order = [];
+		$lesson_order = [];
+		foreach ( $structure as $item ) {
+			if ( 'module' === $item['type'] ) {
+				$save_module_result = $this->save_module( $item );
+				if ( ! $save_module_result ) {
+					return false;
+				}
+
+				list( $module_id, $module_lesson_ids ) = $save_module_result;
+
+				$lesson_ids     = array_merge( $lesson_ids, $module_lesson_ids );
+				$module_order[] = $module_id;
+
+			} elseif ( 'lesson' === $item['type'] ) {
+				$lesson_id = $this->save_lesson( $item );
+				if ( ! $lesson_id ) {
+					return false;
+				}
+
+				$lesson_ids[]   = $lesson_id;
+				$lesson_order[] = $lesson_id;
+
+				update_post_meta( $item['id'], '_order_' . $this->course_id, count( $lesson_ids ) );
+			}
+		}
+
+		// Save the module association.
+		$module_diff = array_diff( $current_module_ids, $module_order );
+		if ( ! empty( $module_diff ) || count( $current_module_ids ) !== count( $module_order ) ) {
+			wp_set_object_terms( $this->course_id, $module_order, 'module' );
+		}
+
+		// Save the module order.
+		$this->save_module_order( $module_order );
+
+		// Save the lesson order.
+		update_post_meta( $this->course_id, '_lesson_order', implode( ',', $lesson_order ) );
+
+		// Delete removed modules and lessons.
+		$delete_lesson_ids = array_diff( $current_lesson_ids, $lesson_ids );
+		foreach ( $delete_lesson_ids as $lesson_id ) {
+			$this->clear_lesson_associations( $lesson_id );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Save a module item.
+	 *
+	 * @param array $item Item to save.
+	 *
+	 * @return false|array[] {
+	 *     If successful, we return this:
+	 *
+	 *     @type int   $0 $module_id  Saved module ID.
+	 *     @type array $1 $lesson_ids All the lesson IDs from this module.
+	 * }
+	 */
+	private function save_module( array $item ) {
+		if ( $item['id'] ) {
+			$module_id = $this->update_module( $item );
+		} else {
+			$module_id = $this->create_module( $item );
+		}
+
+		if ( ! $module_id ) {
+			return false;
+		}
+
+		$lesson_ids       = [];
+		$lesson_order_key = '_order_module_' . $module_id;
+		foreach ( $item['lessons'] as $lesson_item ) {
+			$lesson_id = $this->save_lesson( $lesson_item, $module_id );
+			if ( ! $lesson_id ) {
+				return false;
+			}
+
+			wp_set_object_terms( $lesson_id, [ $module_id ], 'module' );
+			update_post_meta( $lesson_id, $lesson_order_key, count( $lesson_ids ) );
+
+			$lesson_ids[] = $lesson_id;
+		}
+
+		return [
+			$module_id,
+			$lesson_ids,
+		];
+	}
+
+	/**
+	 * Create a module.
+	 *
+	 * @param array $item Item to create.
+	 *
+	 * @return false|int
+	 */
+	private function create_module( array $item ) {
+		$args = [
+			'description' => $item['description'],
+		];
+
+		$teacher_user_id = get_post( $this->course_id )->post_author;
+		if ( ! user_can( $teacher_user_id, 'manage_options' ) ) {
+			$args['slug'] = intval( $teacher_user_id ) . '-' . sanitize_title( $item['name'] );
+		}
+
+		$create_result = wp_insert_term( $item['title'], 'module', $args );
+		if ( is_wp_error( $create_result ) ) {
+			return false;
+		}
+
+		return (int) $create_result['term_id'];
+	}
+
+	/**
+	 * Update an existing module.
+	 *
+	 * @param array $item Item to save.
+	 *
+	 * @return false|int
+	 */
+	private function update_module( array $item ) {
+		$term = get_term( $item['id'], 'module' );
+
+		$changed_args = [];
+		if ( $term->name !== $item['title'] ) {
+			$changed_args['name'] = $item['title'];
+		}
+		if ( $term->description !== $item['description'] ) {
+			$changed_args['description'] = $item['description'];
+		}
+
+		if ( ! empty( $changed_args ) ) {
+			$change_result = wp_update_term(
+				$item['id'],
+				'module',
+				$changed_args
+			);
+
+			if ( is_wp_error( $change_result ) ) {
+				return false;
+			}
+		}
+
+		return $term->term_id;
+	}
+
+	/**
+	 * Save module order.
+	 *
+	 * @param array $module_order Module order to save.
+	 */
+	private function save_module_order( array $module_order ) {
+		$current_module_order_raw = get_post_meta( $this->course_id, '_module_order', true );
+		$current_module_order     = $current_module_order_raw ? array_map( 'intval', $current_module_order_raw ) : [];
+
+		if (
+			( $current_module_order || ! empty( $module_order ) )
+			&& ( $current_module_order !== $module_order )
+		) {
+			if ( empty( $module_order ) ) {
+				delete_post_meta( $this->course_id, '_module_order' );
+			} else {
+				update_post_meta( $this->course_id, '_module_order', array_map( 'strval', $module_order ) );
+			}
+		}
+	}
+
+	/**
+	 * Save a lesson item.
+	 *
+	 * @param array $item      Item to save.
+	 * @param int   $module_id Module ID.
+	 *
+	 * @return false|int
+	 */
+	private function save_lesson( array $item, int $module_id = null ) {
+		if ( $item['id'] ) {
+			$lesson_id = $this->update_lesson( $item );
+		} else {
+			$lesson_id = $this->create_lesson( $item );
+		}
+
+		if ( $lesson_id ) {
+			if ( ! $module_id ) {
+				$module_id = [];
+			}
+
+			wp_set_object_terms( $lesson_id, $module_id, 'module' );
+		}
+
+		return $lesson_id;
+	}
+
+	/**
+	 * Create a lesson.
+	 *
+	 * @param array $item Item to create.
+	 *
+	 * @return false|int
+	 */
+	private function create_lesson( array $item ) {
+		$post_args = [
+			'post_title'  => $item['title'],
+			'post_type'   => 'lesson',
+			'post_status' => 'draft',
+			'meta_input'  => [
+				'_lesson_course' => $this->course_id,
+			],
+		];
+
+		$post_id = wp_insert_post( $post_args );
+		if ( ! $post_id ) {
+			return false;
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Update an existing lesson.
+	 *
+	 * @param array $item Item to save.
+	 *
+	 * @return false|int
+	 */
+	private function update_lesson( array $item ) {
+		$lesson = get_post( $item['id'] );
+		if ( $lesson->post_title !== $item['title'] ) {
+			$post_args = [
+				'ID'         => $lesson->ID,
+				'post_title' => $item['title'],
+			];
+
+			$update_result = wp_update_post( $post_args );
+			if ( ! $update_result || is_wp_error( $update_result ) ) {
+				return false;
+			}
+		}
+
+		$current_course = (int) get_post_meta( $lesson->ID, '_lesson_course', true );
+		if ( $this->course_id !== $current_course ) {
+			$this->clear_lesson_associations( $lesson->ID );
+			update_post_meta( $lesson->ID, '_lesson_course', $this->course_id );
+		}
+
+		return $lesson->ID;
+	}
+
+	/**
+	 * Clear any previous associations a lesson had with a course.
+	 *
+	 * @param int $lesson_id Lesson ID.
+	 */
+	private function clear_lesson_associations( int $lesson_id ) {
+		delete_post_meta( $lesson_id, '_lesson_course' );
+		$lesson_modules = get_the_terms( $lesson_id, 'module' );
+		if ( is_array( $lesson_modules ) ) {
+			foreach ( $lesson_modules as $module ) {
+				delete_post_meta( $lesson_id, '_order_module_' . $module->term_id );
+			}
+		}
+
+		wp_set_object_terms( $lesson_id, [], 'module' );
+	}
+
+	/**
+	 * Parses the lesson IDs and module IDs from the structure.
+	 *
+	 * @param array $structure Structure to flatten.
+	 *
+	 * @return array[] {
+	 *     @type array $0 $module_ids All the module IDs.
+	 *     @type array $1 $lesson_ids All the lesson IDs.
+	 * }
+	 */
+	private function flatten_structure( array $structure ) : array {
+		$module_ids = [];
+		$lesson_ids = [];
+
+		foreach ( $structure as $item ) {
+			if ( 'module' === $item['type'] ) {
+				$module_ids[] = $item['id'];
+				foreach ( $item['lessons'] as $lesson_item ) {
+					$lesson_ids[] = $lesson_item['id'];
+				}
+			} elseif ( 'lesson' === $item['type'] ) {
+				$lesson_ids[] = $item['id'];
+			}
+		}
+
+		return [
+			$module_ids,
+			$lesson_ids,
+		];
 	}
 
 	/**
@@ -171,7 +471,7 @@ class Sensei_Course_Structure {
 	 *
 	 * @return WP_Error|array False if the input is invalid.
 	 */
-	private function validate_and_sanitize_structure( array $raw_structure ) : bool {
+	private function sanitize_structure( array $raw_structure ) {
 		$structure = [];
 		foreach ( $raw_structure as $raw_item ) {
 			if ( ! is_array( $raw_item ) ) {
@@ -181,7 +481,7 @@ class Sensei_Course_Structure {
 				);
 			}
 
-			$item = $this->validate_and_sanitize_item( $raw_item );
+			$item = $this->sanitize_item( $raw_item );
 			if ( is_wp_error( $item ) ) {
 				return $item;
 			}
@@ -199,7 +499,71 @@ class Sensei_Course_Structure {
 	 *
 	 * @return array|WP_Error
 	 */
-	private function validate_and_sanitize_item( array $raw_item ) {
+	private function sanitize_item( array $raw_item ) {
+		$validate = $this->validate_item_structure( $raw_item );
+		if ( is_wp_error( $validate ) ) {
+			return $validate;
+		}
+
+		$item = [
+			'type'  => $raw_item['type'],
+			'id'    => ! empty( $raw_item['id'] ) ? intval( $raw_item['id'] ) : null,
+			'title' => trim( sanitize_text_field( $raw_item['title'] ) ),
+		];
+
+		if ( 'module' === $raw_item['type'] ) {
+			if ( $item['id'] ) {
+				$term = get_term( $item['id'], 'module' );
+				if ( ! $term || is_wp_error( $term ) ) {
+					return new WP_Error(
+						'sensei_course_structure_missing_module',
+						// translators: Placeholder is ID for module.
+						sprintf( __( 'Module with id "%d" was not found', 'sensei-lms' ), $item['id'] )
+					);
+				}
+			}
+
+			$item['description'] = isset( $raw_item['description'] ) ? trim( sanitize_text_field( $raw_item['description'] ) ) : null;
+			$item['lessons']     = [];
+			foreach ( $raw_item['lessons'] as $raw_lesson ) {
+				$lesson = $this->sanitize_item( $raw_lesson );
+				if ( is_wp_error( $lesson ) ) {
+					return $lesson;
+				}
+
+				if ( 'lesson' !== $lesson['type'] ) {
+					return new WP_Error(
+						'sensei_course_structure_invalid_module_lesson',
+						__( 'Module lessons array can only contain lessons.', 'sensei-lms' )
+					);
+				}
+
+				$item['lessons'][] = $lesson;
+			}
+		} elseif ( 'lesson' === $raw_item['type'] ) {
+			if ( $item['id'] ) {
+				$lesson = get_post( $item['id'] );
+				if ( ! $lesson || in_array( $lesson->post_status, [ 'trash', 'auto-draft' ], true ) || 'lesson' !== $lesson->post_type ) {
+					return new WP_Error(
+						'sensei_course_structure_missing_module',
+						// translators: Placeholder is ID for lesson.
+						sprintf( __( 'Lesson with id "%d" was not found', 'sensei-lms' ), $item['id'] )
+					);
+				}
+			}
+		}
+
+		return $item;
+	}
+
+	/**
+	 * Validate item is build correctly.
+	 *
+	 * @param array $raw_item Raw item to sanitize.
+	 *
+	 * @return true|WP_Error
+	 */
+	private function validate_item_structure( array $raw_item ) {
 		if ( ! isset( $raw_item['type'] ) || ! in_array( $raw_item['type'], [ 'module', 'lesson' ], true ) ) {
 			return new WP_Error(
 				'sensei_course_structure_invalid_item_type',
@@ -227,32 +591,6 @@ class Sensei_Course_Structure {
 			);
 		}
 
-		$item = [
-			'type'  => $raw_item['type'],
-			'id'    => ! empty( $raw_item['id'] ) ? intval( $raw_item['id'] ) : null,
-			'title' => trim( sanitize_text_field( $raw_item['title'] ) ),
-		];
-
-		if ( 'module' === $raw_item['type'] ) {
-			$item['description'] = isset( $raw_item['description'] ) ? trim( sanitize_text_field( $raw_item['description'] ) ) : null;
-			$item['lessons']     = [];
-			foreach ( $raw_item['lessons'] as $raw_lesson ) {
-				$lesson = $this->validate_and_sanitize_item( $raw_lesson );
-				if ( is_wp_error( $lesson ) ) {
-					return $lesson;
-				}
-
-				if ( 'lesson' !== $lesson['type'] ) {
-					return new WP_Error(
-						'sensei_course_structure_invalid_module_lesson',
-						__( 'Module lessons array can only contain lessons.', 'sensei-lms' )
-					);
-				}
-
-				$item['lessons'][] = $lesson;
-			}
-		}
-
-		return $item;
+		return true;
 	}
 }

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -451,14 +451,20 @@ class Sensei_Course_Structure {
 		$lesson_ids = [];
 
 		foreach ( $structure as $item ) {
+			if ( ! isset( $item['type'] ) ) {
+				continue;
+			}
+
 			if ( 'module' === $item['type'] ) {
 				if ( ! empty( $item['id'] ) ) {
 					$module_ids[] = $item['id'];
 				}
 
-				foreach ( $item['lessons'] as $lesson_item ) {
-					if ( ! empty( $lesson_item['id'] ) ) {
-						$lesson_ids[] = $lesson_item['id'];
+				if ( ! empty( $item['lessons'] ) ) {
+					foreach ( $item['lessons'] as $lesson_item ) {
+						if ( ! empty( $lesson_item['id'] ) ) {
+							$lesson_ids[] = $lesson_item['id'];
+						}
 					}
 				}
 			} elseif ( 'lesson' === $item['type'] && ! empty( $item['id'] ) ) {

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -64,7 +64,7 @@ class Sensei_Course_Structure {
 		$all_lessons       = Sensei()->course->course_lessons( $this->course_id, 'any', 'ids' );
 		$no_module_lessons = wp_list_pluck( Sensei()->modules->get_none_module_lessons( $this->course_id, 'any' ), 'ID' );
 
-		if ( count( $all_lessons ) !== count( $no_module_lessons ) ) {
+		if ( empty( $all_lessons ) || count( $all_lessons ) !== count( $no_module_lessons ) ) {
 			$modules = $this->get_modules();
 			foreach ( $modules as $module_term ) {
 				$structure[] = $this->prepare_module( $module_term );

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -449,11 +449,16 @@ class Sensei_Course_Structure {
 
 		foreach ( $structure as $item ) {
 			if ( 'module' === $item['type'] ) {
-				$module_ids[] = $item['id'];
-				foreach ( $item['lessons'] as $lesson_item ) {
-					$lesson_ids[] = $lesson_item['id'];
+				if ( ! empty( $item['id'] ) ) {
+					$module_ids[] = $item['id'];
 				}
-			} elseif ( 'lesson' === $item['type'] ) {
+
+				foreach ( $item['lessons'] as $lesson_item ) {
+					if ( ! empty( $lesson_item['id'] ) ) {
+						$lesson_ids[] = $lesson_item['id'];
+					}
+				}
+			} elseif ( 'lesson' === $item['type'] && ! empty( $item['id'] ) ) {
 				$lesson_ids[] = $item['id'];
 			}
 		}
@@ -472,6 +477,18 @@ class Sensei_Course_Structure {
 	 * @return WP_Error|array False if the input is invalid.
 	 */
 	private function sanitize_structure( array $raw_structure ) {
+		list( $module_ids, $lesson_ids ) = $this->flatten_structure( $raw_structure );
+
+		if (
+			array_unique( $module_ids ) !== $module_ids
+			|| array_unique( $lesson_ids ) !== $lesson_ids
+		) {
+			return new WP_Error(
+				'sensei_course_structure_duplicate_items',
+				__( 'Individual lesson or modules cannot appear multiple times in the same course', 'sensei-lms' )
+			);
+		}
+
 		$structure = [];
 		foreach ( $raw_structure as $raw_item ) {
 			if ( ! is_array( $raw_item ) ) {

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -543,7 +543,7 @@ class Sensei_Course_Structure {
 				}
 			}
 
-			$item['description'] = isset( $raw_item['description'] ) ? trim( sanitize_text_field( $raw_item['description'] ) ) : null;
+			$item['description'] = isset( $raw_item['description'] ) ? trim( wp_kses_post( $raw_item['description'] ) ) : null;
 			$item['lessons']     = [];
 			foreach ( $raw_item['lessons'] as $raw_lesson ) {
 				$lesson = $this->sanitize_item( $raw_lesson );

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -210,6 +210,8 @@ class Sensei_Course_Structure {
 			$this->clear_lesson_associations( $lesson_id );
 		}
 
+		delete_transient( 'sensei_' . $this->course_id . '_none_module_lessons' );
+
 		return true;
 	}
 
@@ -246,6 +248,7 @@ class Sensei_Course_Structure {
 
 			wp_set_object_terms( $lesson_id, [ $module_id ], 'module' );
 			update_post_meta( $lesson_id, $lesson_order_key, count( $lesson_ids ) );
+			delete_post_meta( $lesson_id, '_order_' . $this->course_id );
 
 			$lesson_ids[] = $lesson_id;
 		}

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -607,7 +607,7 @@ class Sensei_Course_Structure {
 				$lesson = get_post( $item['id'] );
 				if ( ! $lesson || in_array( $lesson->post_status, [ 'trash', 'auto-draft' ], true ) || 'lesson' !== $lesson->post_type ) {
 					return new WP_Error(
-						'sensei_course_structure_missing_module',
+						'sensei_course_structure_missing_lesson',
 						// translators: Placeholder is ID for lesson.
 						sprintf( __( 'Lesson with id "%d" was not found', 'sensei-lms' ), $item['id'] )
 					);

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -63,9 +63,8 @@ class Sensei_Core_Modules {
 		// Add course field to taxonomy
 		add_action( $this->taxonomy . '_add_form_fields', array( $this, 'add_module_fields' ), 50, 1 );
 		add_action( $this->taxonomy . '_edit_form_fields', array( $this, 'edit_module_fields' ), 1, 1 );
-		add_action( 'edited_' . $this->taxonomy, array( $this, 'save_module_course' ), 10, 2 );
-		add_action( 'created_' . $this->taxonomy, array( $this, 'save_module_course' ), 10, 2 );
 		add_action( 'created_' . $this->taxonomy, array( $this, 'track_module_creation' ), 10 );
+		add_action( 'admin_init', array( $this, 'add_module_admin_hooks' ) );
 		add_action( 'wp_ajax_sensei_json_search_courses', array( $this, 'search_courses_json' ) );
 
 		// Manage module taxonomy archive page
@@ -372,6 +371,17 @@ class Sensei_Core_Modules {
 			class="description"><?php echo esc_html__( 'Search for and select the courses that this module will belong to.', 'sensei-lms' ); ?>
 		</span>
 		<?php
+	}
+
+	/**
+	 * Adds hooks for use with editing a taxonomy in WP Admin.
+	 *
+	 * @since 3.6.0
+	 * @access private
+	 */
+	public function add_module_admin_hooks() {
+		add_action( 'edited_' . $this->taxonomy, array( $this, 'save_module_course' ), 10, 2 );
+		add_action( 'created_' . $this->taxonomy, array( $this, 'save_module_course' ), 10, 2 );
 	}
 
 	/**

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -437,10 +437,13 @@ class Sensei_Core_Modules {
 		 * verification.
 		 */
 
+		$is_rest_request = defined( 'REST_REQUEST' ) && REST_REQUEST;
+
 		// phpcs:ignore WordPress.Security.NonceVerification
-		if ( isset( $_POST['action'] ) && 'inline-save-tax' == $_POST['action'] ) {
+		if ( $is_rest_request || ( isset( $_POST['action'] ) && 'inline-save-tax' == $_POST['action'] ) ) {
 			return;
 		}
+
 		// Get module's existing courses
 		$args    = array(
 			'post_type'      => 'course',

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1759,7 +1759,7 @@ class Sensei_Core_Modules {
 		// exit if there are no module on this course
 		if ( empty( $course_modules ) || ! is_array( $course_modules ) ) {
 
-			return Sensei()->course->course_lessons( $course_id );
+			return Sensei()->course->course_lessons( $course_id, $post_status );
 
 		}
 

--- a/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
@@ -157,7 +157,7 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 
 		if ( false === $result ) {
 			return new WP_Error(
-				'sensei_course_structure_missing_course',
+				'sensei_course_structure_unknown_error',
 				__( 'An error occurred while saving the course structure.', 'sensei-lms' ),
 				[ 'status' => 500 ]
 			);

--- a/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
@@ -58,13 +58,6 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => [ $this, 'save_course_structure' ],
 					'permission_callback' => [ $this, 'can_user_save_structure' ],
-					'args'                => [
-						'structure' => [
-							'description' => __( 'JSON string of the structure', 'sensei-lms' ),
-							'required'    => true,
-							'type'        => 'string',
-						],
-					],
 				],
 			]
 		);
@@ -142,19 +135,16 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 		$course           = $this->get_course( intval( $request->get_param( 'course_id' ) ) );
 		$course_structure = Sensei_Course_Structure::instance( $course->ID );
 
-		$structure_input = $this->parse_input( $request->get_param( 'structure' ) );
-		if ( is_wp_error( $structure_input ) ) {
-			return $structure_input;
-		}
-
-		$raw_structure = json_decode( $structure_input, true );
-		if ( ! is_array( $raw_structure ) ) {
+		$input = json_decode( $request->get_body(), true );
+		if ( ! is_array( $input ) || ! isset( $input['structure'] ) || ! is_array( $input['structure'] ) ) {
 			return new WP_Error(
 				'sensei_course_structure_invalid_input',
 				__( 'Input for course structure was invalid.', 'sensei-lms' ),
 				[ 'status' => 400 ]
 			);
 		}
+
+		$raw_structure = $input['structure'];
 
 		$result = $course_structure->save( $raw_structure );
 		if ( is_wp_error( $result ) ) {

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
@@ -345,7 +345,7 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 		$this->assertTrue( $result );
 
 		$post = get_post( $model->get_post_id() );
-		$this->commit_transaction();
+
 		$this->assertEquals( $expected_data[ Sensei_Data_Port_Question_Schema::COLUMN_TITLE ], $post->post_title, 'Post title should match the title column' );
 		$this->assertEquals( '', $post->post_content, 'Post content should match the description column' );
 		$this->assertEquals( 'publish', $post->post_status, 'Post status should match the status column' );
@@ -376,7 +376,7 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 		$this->assertTrue( $result );
 
 		$post = get_post( $model->get_post_id() );
-		$this->commit_transaction();
+
 		$this->assertEquals( $expected_data[ Sensei_Data_Port_Question_Schema::COLUMN_TITLE ], $post->post_title, 'Post title should match the title column' );
 		$this->assertEquals( '', $post->post_content, 'Post content should match the description column' );
 		$this->assertEquals( 'draft', $post->post_status, 'Post status should be draft by default' );
@@ -407,7 +407,7 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 		$this->assertTrue( $result );
 
 		$post = get_post( $model->get_post_id() );
-		$this->commit_transaction();
+
 		$this->assertEquals( $expected_data[ Sensei_Data_Port_Question_Schema::COLUMN_TITLE ], $post->post_title, 'Post title should match the title column' );
 		$this->assertEquals( '', $post->post_content, 'Post content should match the description column' );
 		$this->assertEquals( 'draft', $post->post_status, 'Post status should be draft by default' );
@@ -438,7 +438,7 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 		$this->assertTrue( $result );
 
 		$post = get_post( $model->get_post_id() );
-		$this->commit_transaction();
+
 		$this->assertEquals( $expected_data[ Sensei_Data_Port_Question_Schema::COLUMN_TITLE ], $post->post_title, 'Post title should match the title column' );
 		$this->assertEquals( '', $post->post_content, 'Post content should match the description column' );
 		$this->assertEquals( 'draft', $post->post_status, 'Post status should be draft by default' );

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -329,7 +329,7 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		$modified_structure[0]['title']       = 'Update Module Name';
 		$modified_structure[0]['description'] = 'Now improved!';
 
-		$this->assertTrue( $course_structure->save( $new_structure ) );
+		$this->assertTrue( $course_structure->save( $modified_structure ) );
 
 		$structure = $course_structure->get();
 		$this->assertExpectedStructure( $modified_structure, $structure );

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -242,6 +242,59 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests to ensure invalid entries fail.
+	 */
+	public function testSaveInvalidItemFail() {
+		$this->login_as_teacher();
+
+		$course_id = $this->factory->course->create();
+
+		$new_structure = [
+			[
+				'type'    => 'course',
+				'title'   => 'Magical Course',
+				'lessons' => [],
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$save_result = $course_structure->save( $new_structure );
+		$this->assertWPError( $save_result );
+
+		$this->assertEquals( 'sensei_course_structure_invalid_item_type', $save_result->get_error_code() );
+
+		$structure = $course_structure->get();
+		$this->assertEquals( 0, count( $structure ) );
+	}
+
+	/**
+	 * Tests to ensure items without types fail save.
+	 */
+	public function testSaveMissingItemTypeFail() {
+		$this->login_as_teacher();
+
+		$course_id = $this->factory->course->create();
+
+		$new_structure = [
+			[
+				'title'   => 'Magical Course',
+				'lessons' => [],
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$save_result = $course_structure->save( $new_structure );
+		$this->assertWPError( $save_result );
+
+		$this->assertEquals( 'sensei_course_structure_invalid_item_type', $save_result->get_error_code() );
+
+		$structure = $course_structure->get();
+		$this->assertEquals( 0, count( $structure ) );
+	}
+
+	/**
 	 * Make sure new modules (login as teacher) are created and existing lessons are recycled.
 	 */
 	public function testSaveNewModulesExistingLessons() {

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -6,6 +6,8 @@
  * @group course-structure
  */
 class Sensei_Course_Structure_Test extends WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+
 	/**
 	 * Set up the test.
 	 */
@@ -155,6 +157,557 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		$structure        = $course_structure->get();
 
 		$this->assertExpectedStructure( $expected_structure, $structure );
+	}
+
+	/**
+	 * Make sure new lessons are created when no ID is passed.
+	 */
+	public function testSaveNewLessons() {
+		$this->login_as_teacher();
+
+		$course_id = $this->factory->course->create();
+
+		$new_structure = [
+			[
+				'type'  => 'lesson',
+				'title' => 'New lesson',
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$structure = $course_structure->get();
+
+		$this->assertEquals( 1, count( $structure ) );
+
+		$first_item = $structure[0];
+		$this->assertEquals( 'lesson', $first_item['type'], 'Course should have one lesson object' );
+		$this->assertEquals( 'lesson', get_post_type( $first_item['id'] ), 'Created post should be a lesson' );
+		$this->assertEquals( $new_structure[0]['title'], $first_item['title'], 'New title should match' );
+	}
+
+	/**
+	 * Tests to ensure lessons with empty titles are not created.
+	 */
+	public function testSaveInvalidLessonFail() {
+		$this->login_as_teacher();
+
+		$course_id = $this->factory->course->create();
+
+		$new_structure = [
+			[
+				'type'  => 'lesson',
+				'title' => '  ',
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$save_result = $course_structure->save( $new_structure );
+		$this->assertWPError( $save_result );
+
+		$this->assertEquals( 'sensei_course_structure_missing_title', $save_result->get_error_code() );
+
+		$structure = $course_structure->get();
+		$this->assertEquals( 0, count( $structure ) );
+	}
+
+	/**
+	 * Make sure new modules (login as teacher) are created and existing lessons are recycled.
+	 */
+	public function testSaveNewModulesExistingLessons() {
+		$this->login_as_teacher();
+
+		$course_id  = $this->factory->course->create();
+		$lesson_ids = $this->factory->lesson->create_many( 3 );
+
+		$new_structure = [
+			[
+				'type'    => 'module',
+				'title'   => 'New Module A',
+				'lessons' => [
+					[
+						'type'  => 'lesson',
+						'id'    => $lesson_ids[2],
+						'title' => get_the_title( $lesson_ids[2] ),
+					],
+					[
+						'type'  => 'lesson',
+						'id'    => $lesson_ids[0],
+						'title' => get_the_title( $lesson_ids[0] ),
+					],
+				],
+			],
+			[
+				'type'    => 'module',
+				'title'   => 'New Module B',
+				'lessons' => [
+					[
+						'type'  => 'lesson',
+						'id'    => $lesson_ids[1],
+						'title' => get_the_title( $lesson_ids[1] ),
+					],
+				],
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$structure = $course_structure->get();
+
+		$this->assertEquals( 2, count( $structure ) );
+
+		$this->assertEquals( 'module', $structure[0]['type'], 'Course should have two module items' );
+		$module = get_term( $structure[0]['id'], 'module' );
+		$this->assertEquals( get_current_user_id() . '-' . sanitize_title( $new_structure[0]['title'] ), $module->slug, 'Slug should be prefixed with teacher ID' );
+		$this->assertEquals( $new_structure[0]['title'], $module->name );
+		$this->assertExpectedStructure( $new_structure[0]['lessons'], $structure[0]['lessons'] );
+
+		$this->assertEquals( 'module', $structure[1]['type'], 'Course should have another module item' );
+		$module = get_term( $structure[1]['id'], 'module' );
+		$this->assertEquals( get_current_user_id() . '-' . sanitize_title( $new_structure[1]['title'] ), $module->slug, 'Slug should be prefixed with teacher ID' );
+		$this->assertEquals( $new_structure[1]['title'], $module->name );
+		$this->assertExpectedStructure( $new_structure[1]['lessons'], $structure[1]['lessons'] );
+	}
+
+	/**
+	 * Make sure new modules (logged in as admin) with no lessons are saved.
+	 */
+	public function testSaveNewModulesNoLessons() {
+		$this->login_as_admin();
+
+		$course_id = $this->factory->course->create();
+
+		$new_structure = [
+			[
+				'type'    => 'module',
+				'title'   => 'New Module A',
+				'lessons' => [],
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$structure = $course_structure->get();
+
+		$this->assertEquals( 1, count( $structure ) );
+
+		$this->assertEquals( 'module', $structure[0]['type'], 'Course should have one module item' );
+		$module = get_term( $structure[0]['id'], 'module' );
+		$this->assertEquals( sanitize_title( $new_structure[0]['title'] ), $module->slug, 'Slug should NOT be prefixed with teacher ID when logged in as an admin' );
+		$this->assertEquals( $new_structure[0]['title'], $module->name );
+		$this->assertEmpty( $structure[0]['lessons'], 'No lessons were added' );
+	}
+
+	/**
+	 * Make sure module details are updated properly.
+	 */
+	public function testSaveUpdateModuleDetails() {
+		$this->login_as_admin();
+
+		$course_id     = $this->factory->course->create();
+		$new_structure = [
+			[
+				'type'        => 'module',
+				'title'       => 'New Module A',
+				'description' => 'Very nice module',
+				'lessons'     => [],
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$modified_structure                   = $course_structure->get();
+		$modified_structure[0]['title']       = 'Update Module Name';
+		$modified_structure[0]['description'] = 'Now improved!';
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$structure = $course_structure->get();
+		$this->assertExpectedStructure( $modified_structure, $structure );
+	}
+
+	/**
+	 * Make sure lesson titles are updated properly.
+	 */
+	public function testSaveUpdateLessonTitle() {
+		$this->login_as_admin();
+
+		$course_id     = $this->factory->course->create();
+		$new_structure = [
+			[
+				'type'  => 'lesson',
+				'title' => 'New Lesson',
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$modified_structure             = $course_structure->get();
+		$modified_structure[0]['title'] = 'Improved Lesson Title';
+
+		$this->assertTrue( $course_structure->save( $modified_structure ) );
+
+		$structure = $course_structure->get();
+		$this->assertExpectedStructure( $modified_structure, $structure );
+	}
+
+	/**
+	 * Make sure lessons coming from a previous course get moved over and removed from old course.
+	 */
+	public function testSaveMoveLessonToNewCourse() {
+		$this->login_as_admin();
+
+		$course_id_a   = $this->factory->course->create();
+		$course_id_b   = $this->factory->course->create();
+		$new_structure = [
+			[
+				'type'  => 'lesson',
+				'title' => 'New Lesson',
+			],
+		];
+
+		$course_structure_a = Sensei_Course_Structure::instance( $course_id_a );
+		$course_structure_b = Sensei_Course_Structure::instance( $course_id_b );
+
+		$save_result = $course_structure_a->save( $new_structure );
+		$this->assertTrue( $save_result );
+
+		$structure = $course_structure_a->get();
+
+		// Give course A's structure to course B.
+		$this->assertTrue( $course_structure_b->save( $structure ) );
+
+		$this->assertExpectedStructure( $structure, $course_structure_b->get() );
+		$this->assertEquals( [], $course_structure_a->get() );
+	}
+
+	/**
+	 * Make sure we can properly reorder lessons.
+	 */
+	public function testSaveReorderLessons() {
+		$this->login_as_admin();
+
+		$course_id     = $this->factory->course->create();
+		$new_structure = [
+			[
+				'type'  => 'lesson',
+				'title' => 'Lesson A',
+			],
+			[
+				'type'  => 'lesson',
+				'title' => 'Lesson B',
+			],
+			[
+				'type'  => 'lesson',
+				'title' => 'Lesson C',
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$structure = $course_structure->get();
+		$this->assertEquals( $new_structure[0]['title'], $structure[0]['title'] );
+		$this->assertEquals( $new_structure[1]['title'], $structure[1]['title'] );
+		$this->assertEquals( $new_structure[2]['title'], $structure[2]['title'] );
+
+		$updated_structure = [
+			$structure[1],
+			$structure[0],
+			$structure[2],
+		];
+
+		$this->assertTrue( $course_structure->save( $updated_structure ) );
+		$this->assertExpectedStructure( $updated_structure, $course_structure->get() );
+	}
+
+	/**
+	 * Make sure we can properly reorder modules.
+	 */
+	public function testSaveReorderModules() {
+		$this->login_as_admin();
+
+		$course_id     = $this->factory->course->create();
+		$new_structure = [
+			[
+				'type'    => 'module',
+				'title'   => 'Module A',
+				'lessons' => [
+					[
+						'type'  => 'lesson',
+						'title' => 'Lesson A',
+					],
+				],
+			],
+			[
+				'type'    => 'module',
+				'title'   => 'Module B',
+				'lessons' => [
+					[
+						'type'  => 'lesson',
+						'title' => 'Lesson B',
+					],
+					[
+						'type'  => 'lesson',
+						'title' => 'Lesson C',
+					],
+				],
+			],
+			[
+				'type'    => 'module',
+				'title'   => 'Module C',
+				'lessons' => [],
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$structure = $course_structure->get();
+		$this->assertEquals( $new_structure[0]['title'], $structure[0]['title'] );
+		$this->assertEquals( $new_structure[1]['title'], $structure[1]['title'] );
+		$this->assertEquals( $new_structure[2]['title'], $structure[2]['title'] );
+
+		$updated_structure = [
+			$structure[1],
+			$structure[0],
+			$structure[2],
+		];
+
+		$this->assertTrue( $course_structure->save( $updated_structure ) );
+		$this->assertExpectedStructure( $updated_structure, $course_structure->get() );
+	}
+
+	/**
+	 * Make sure old meta is removed when we remove a lesson from a course.
+	 */
+	public function testCleanupRemoveLesson() {
+		$this->login_as_teacher();
+
+		$course_id  = $this->factory->course->create();
+		$lesson_ids = $this->factory->lesson->create_many( 2 );
+
+		$new_structure = [
+			[
+				'type'    => 'module',
+				'title'   => 'New Module A',
+				'lessons' => [
+					[
+						'type'  => 'lesson',
+						'id'    => $lesson_ids[0],
+						'title' => get_the_title( $lesson_ids[0] ),
+					],
+				],
+			],
+			[
+				'type'  => 'lesson',
+				'id'    => $lesson_ids[1],
+				'title' => get_the_title( $lesson_ids[1] ),
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$modified_structure = $course_structure->get();
+
+		$this->assertEquals( 2, count( $modified_structure ) );
+
+		$modified_structure[0]['lessons'] = [];
+		unset( $modified_structure[1] );
+
+		$this->assertTrue( $course_structure->save( $modified_structure ) );
+		$this->assertExpectedStructure( $modified_structure, $course_structure->get() );
+
+		$this->assertEquals( null, get_post_meta( $lesson_ids[0], '_lesson_course', true ), 'Course lesson meta should have been cleared' );
+		$this->assertEquals( null, get_post_meta( $lesson_ids[1], '_lesson_course', true ), 'Course lesson meta should have been cleared' );
+		$this->assertEquals( null, get_post_meta( $lesson_ids[0], '_order_' . $course_id, true ), 'Course lesson order meta should have been cleared' );
+		$this->assertEquals( null, get_post_meta( $lesson_ids[0], '_order_module_' . $modified_structure[0]['id'], true ), 'Course lesson order meta should have been cleared' );
+	}
+
+	/**
+	 * Make sure no changes are made when we save an identical course structure.
+	 */
+	public function testSaveIdenticalStructureNoChange() {
+		$this->login_as_admin();
+
+		$course_id     = $this->factory->course->create();
+		$new_structure = [
+			[
+				'type'    => 'module',
+				'title'   => 'Module A',
+				'lessons' => [
+					[
+						'type'  => 'lesson',
+						'title' => 'Lesson A',
+					],
+				],
+			],
+			[
+				'type'    => 'module',
+				'title'   => 'Module B',
+				'lessons' => [
+					[
+						'type'  => 'lesson',
+						'title' => 'Lesson B',
+					],
+				],
+			],
+			[
+				'type'    => 'module',
+				'title'   => 'Module C',
+				'lessons' => [],
+			],
+			[
+				'type'  => 'lesson',
+				'title' => 'Lesson C',
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$structure = $course_structure->get();
+
+		$this->assertTrue( $course_structure->save( $structure ) );
+		$this->assertExpectedStructure( $structure, $course_structure->get() );
+	}
+
+	/**
+	 * Make sure saving an empty array clears the structure.
+	 */
+	public function testSaveEmptyArrayClearsStructure() {
+		$this->login_as_admin();
+
+		$course_id     = $this->factory->course->create();
+		$new_structure = [
+			[
+				'type'    => 'module',
+				'title'   => 'Module A',
+				'lessons' => [
+					[
+						'type'  => 'lesson',
+						'title' => 'Lesson A',
+					],
+				],
+			],
+			[
+				'type'    => 'module',
+				'title'   => 'Module C',
+				'lessons' => [],
+			],
+			[
+				'type'  => 'lesson',
+				'title' => 'Lesson C',
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$this->assertTrue( $course_structure->save( [] ) );
+		$this->assertExpectedStructure( [], $course_structure->get() );
+	}
+
+	/**
+	 * Make sure we can move a lesson to a module.
+	 */
+	public function testSaveMoveLessonToModule() {
+		$this->login_as_admin();
+
+		$course_id     = $this->factory->course->create();
+		$new_structure = [
+			[
+				'type'    => 'module',
+				'title'   => 'Module A',
+				'lessons' => [],
+			],
+			[
+				'type'    => 'module',
+				'title'   => 'Module B',
+				'lessons' => [
+					[
+						'type'  => 'lesson',
+						'title' => 'Lesson B',
+					],
+				],
+			],
+			[
+				'type'  => 'lesson',
+				'title' => 'Lesson C',
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$modified_structure = $course_structure->get();
+
+		$modified_structure[0]['lessons'][] = $modified_structure[2];
+		unset( $modified_structure[2] );
+
+		$this->assertTrue( $course_structure->save( $modified_structure ) );
+		$this->assertExpectedStructure( $modified_structure, $course_structure->get() );
+	}
+
+	/**
+	 * Make sure we can move a lesson from a module.
+	 */
+	public function testSaveMoveLessonFromModule() {
+		$this->login_as_admin();
+
+		$course_id     = $this->factory->course->create();
+		$new_structure = [
+			[
+				'type'    => 'module',
+				'title'   => 'Module A',
+				'lessons' => [
+					[
+						'type'  => 'lesson',
+						'title' => 'Lesson A',
+					],
+				],
+			],
+			[
+				'type'    => 'module',
+				'title'   => 'Module B',
+				'lessons' => [
+					[
+						'type'  => 'lesson',
+						'title' => 'Lesson B',
+					],
+				],
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$modified_structure = $course_structure->get();
+
+		$modified_structure[]             = $modified_structure[0]['lessons'][0];
+		$modified_structure[0]['lessons'] = [];
+
+		$this->assertTrue( $course_structure->save( $modified_structure ) );
+		$this->assertExpectedStructure( $modified_structure, $course_structure->get() );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -215,6 +215,33 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests to ensure modules with empty titles are not created.
+	 */
+	public function testSaveInvalidModuleFail() {
+		$this->login_as_teacher();
+
+		$course_id = $this->factory->course->create();
+
+		$new_structure = [
+			[
+				'type'    => 'module',
+				'title'   => '  ',
+				'lessons' => [],
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$save_result = $course_structure->save( $new_structure );
+		$this->assertWPError( $save_result );
+
+		$this->assertEquals( 'sensei_course_structure_missing_title', $save_result->get_error_code() );
+
+		$structure = $course_structure->get();
+		$this->assertEquals( 0, count( $structure ) );
+	}
+
+	/**
 	 * Make sure new modules (login as teacher) are created and existing lessons are recycled.
 	 */
 	public function testSaveNewModulesExistingLessons() {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Save the course structure from the REST API request `http://example.com/wp-json/sensei-internal/v1/course-structure/{course_id}`. 
  * That request takes the structure from the request body (JSON) under `structure`.
  * For example:
```
{
   "structure":[
      {
         "type":"module",
         "id":50,
         "title":"Introduction",
         "description":"",
         "lessons":[
            {
               "type":"lesson",
               "id":1271,
               "title":"A-2 test lesson"
            },
            {
               "type":"lesson",
               "id":1261,
               "title":"A-1 test lesson"
            }
         ]
      },
      {
         "type":"module",
         "id":51,
         "title":"Mastery",
         "description":"Be really good at it",
         "lessons":[
            {
               "type":"lesson",
               "id":1272,
               "title":"B1 test lesson"
            },
            {
               "type":"lesson",
               "id":1273,
               "title":"B2 test lesson"
            }
         ]
      },
      {
         "type":"lesson",
         "id":1262,
         "title":"BB test lesson"
      }
   ]
}
```
* Updates how we hook into module/term save to override things.

### Testing instructions

* Verify setting courses when editing a module in WP Admin still works.
* Send various data to the REST API and verify that it works.