### PR TITLE
Target the correct element when resetting input fields in quiz questions

### DIFF
--- a/assets/js/lesson-metadata.js
+++ b/assets/js/lesson-metadata.js
@@ -76,7 +76,7 @@ jQuery( document ).ready( function () {
 	 * @access public
 	 */
 	jQuery.fn.resetAddQuestionForm = function () {
-		jQuery( '#add-new-question' )
+		jQuery( '#tab-new-content' )
 			.find( 'div' )
 			.find( 'input' )
 			.each( function () {


### PR DESCRIPTION
Fixes #3603.

### Changes proposed in this Pull Request

The wrong element was being targeted when resetting the value of input fields. The `#add-new-question` element encompassed all of the tabs in the _Quiz Questions_ meta box. This PR changes it so that only the _New Question_ tab is targeted.

### Testing instructions

1. Add a question to a lesson and save.
2. Refresh the page.
3. In the _New Question_ tab, fill out some fields but don't save.
4. Click _Edit_ on the question you added in step 1.
5. Ensure the data you entered in step 3 is cleared.
6. Click _Update_ for the edited question.
7. Click the _Existing Questions_ tab and select one or more questions to add to the quiz.
8. Click _Add Selected Question(s)_.
9. Ensure the question is added to the quiz and that no PHP warning is logged.