### PR TITLE
Sort course filter on Lessons page in alphabetical order

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -786,7 +786,7 @@ class Sensei_Admin {
 				'post_status'      => array( 'publish', 'pending', 'draft', 'future', 'private' ),
 				'posts_per_page'   => -1,
 				'suppress_filters' => 0,
-				'orderby'          => 'menu_order date',
+				'orderby'          => 'title menu_order date',
 				'order'            => 'ASC',
 			);
 			$courses = get_posts( $args );


### PR DESCRIPTION
Fixes #3581

### Changes proposed in this Pull Request

* Sort course filter on Lessons page in alphabetical order
