### PR TITLE
Use archive-lesson template on lesson archive page

### DIFF
--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -220,7 +220,7 @@ class Sensei_Templates {
 			$find[] = $file;
 			$find[] = Sensei()->template_url . $file;
 
-		} elseif ( is_tax( 'lesson-tag' ) ) {
+		} elseif ( is_tax( 'lesson-tag' ) || is_post_type_archive( 'lesson' ) ) {
 
 			// possible backward compatible template include if theme overrides 'taxonomy-lesson-tag.php'
 			// this template was removed in 1.9.0 and replaced by archive-lesson.php


### PR DESCRIPTION
Fixes #1358.

### Changes proposed in this Pull Request

Use the `archive-lesson.php` template when viewing the lesson archive page.

### Testing instructions

Visit http://yourdomain.com/lesson and ensure the `archive-lesson.php` template is used instead of the theme's `archive.php` template.

### Screenshot / Video

#### Before
![Screen Shot 2020-09-15 at 8 46 41 AM](https://user-images.githubusercontent.com/1190420/93211995-ff7b0f80-f72f-11ea-94dc-fc5250d72d49.jpg)

#### After
![Screen Shot 2020-09-15 at 8 47 20 AM](https://user-images.githubusercontent.com/1190420/93212067-17eb2a00-f730-11ea-9a14-69e9d22b5b08.jpg)