### PR TITLE
Add support for inner block attributes

### DIFF
--- a/assets/blocks/course-outline/course-outline-block.js
+++ b/assets/blocks/course-outline/course-outline-block.js
@@ -2,7 +2,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
-import { extractBlocksData } from './data';
+import { extractStructure } from './data';
 
 import EditCourseOutlineBlock from './edit';
 import { COURSE_STORE } from './store';
@@ -22,7 +22,7 @@ registerBlockType( 'sensei-lms/course-outline', {
 	},
 	save( { innerBlocks } ) {
 		dispatch( COURSE_STORE ).setEditorStructure(
-			extractBlocksData( innerBlocks )
+			extractStructure( innerBlocks )
 		);
 		return <InnerBlocks.Content />;
 	},

--- a/assets/blocks/course-outline/course-outline-block.js
+++ b/assets/blocks/course-outline/course-outline-block.js
@@ -21,6 +21,9 @@ registerBlockType( 'sensei-lms/course-outline', {
 		id: {
 			type: 'int',
 		},
+		blocks: {
+			type: 'object',
+		},
 	},
 	edit( props ) {
 		return <EditCourseOutlineBlock { ...props } />;

--- a/assets/blocks/course-outline/course-outline-block.js
+++ b/assets/blocks/course-outline/course-outline-block.js
@@ -17,6 +17,11 @@ registerBlockType( 'sensei-lms/course-outline', {
 		html: false,
 		multiple: false,
 	},
+	attributes: {
+		id: {
+			type: 'int',
+		},
+	},
 	edit( props ) {
 		return <EditCourseOutlineBlock { ...props } />;
 	},

--- a/assets/blocks/course-outline/course-outline-block.js
+++ b/assets/blocks/course-outline/course-outline-block.js
@@ -1,7 +1,6 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { InnerBlocks } from '@wordpress/block-editor';
 import { extractStructure } from './data';
 
 import EditCourseOutlineBlock from './edit';
@@ -28,14 +27,10 @@ registerBlockType( 'sensei-lms/course-outline', {
 	edit( props ) {
 		return <EditCourseOutlineBlock { ...props } />;
 	},
-	save( { innerBlocks, className } ) {
+	save( { innerBlocks } ) {
 		dispatch( COURSE_STORE ).setEditorStructure(
 			extractStructure( innerBlocks )
 		);
-		return (
-			<div className={ className }>
-				<InnerBlocks.Content />
-			</div>
-		);
+		return null;
 	},
 } );

--- a/assets/blocks/course-outline/course-outline-block.js
+++ b/assets/blocks/course-outline/course-outline-block.js
@@ -20,10 +20,14 @@ registerBlockType( 'sensei-lms/course-outline', {
 	edit( props ) {
 		return <EditCourseOutlineBlock { ...props } />;
 	},
-	save( { innerBlocks } ) {
+	save( { innerBlocks, className } ) {
 		dispatch( COURSE_STORE ).setEditorStructure(
 			extractStructure( innerBlocks )
 		);
-		return <InnerBlocks.Content />;
+		return (
+			<div className={ className }>
+				<InnerBlocks.Content />
+			</div>
+		);
 	},
 } );

--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -51,15 +51,12 @@ export const convertToBlocks = ( blockData ) =>
  * @param {Object[]} blocks Blocks.
  * @return {CourseStructure} Course structure
  */
-export const extractBlocksData = ( blocks ) => {
+export const extractStructure = ( blocks ) => {
 	const extractBlockData = {
 		module: ( block ) => ( {
-			...block.attributes,
-			lessons: extractBlocksData( block.innerBlocks ),
+			lessons: extractStructure( block.innerBlocks ),
 		} ),
-		lesson: ( block ) => ( {
-			...block.attributes,
-		} ),
+		lesson: () => ( {} ),
 	};
 
 	return blocks
@@ -67,6 +64,8 @@ export const extractBlocksData = ( blocks ) => {
 			const type = blockTypes[ block.name ];
 			return {
 				type,
+				className: block.className,
+				...block.attributes,
 				...extractBlockData[ type ]( block ),
 			};
 		} )

--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -46,7 +46,7 @@ export const syncStructureToBlocks = ( structure, blocks, attributeMap ) => {
 		if ( item.id ) {
 			attributes = {
 				...attributes,
-				...attributeMap[ `${ type }-${ item.id }` ],
+				...( attributeMap[ `${ type }-${ item.id }` ] || {} ),
 			};
 		}
 		if ( ! block ) {

--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -35,13 +35,20 @@ export const blockTypes = invert( blockNames );
  * Matches blocks based on lesson/module ID.
  *
  * @param {CourseStructure} structure
- * @param {Object[]}        blocks    Existing blocks.
- * @return   {Object[]} Updated blocks.
+ * @param {Object[]}        blocks       Existing blocks.
+ * @param {Object[]}        attributeMap Attributes for inner blocks.
+ * @return {Object[]} Updated blocks.
  */
-export const syncStructureToBlocks = ( structure, blocks ) => {
+export const syncStructureToBlocks = ( structure, blocks, attributeMap ) => {
 	return ( structure || [] ).map( ( item ) => {
-		const { type, lessons, ...attributes } = item;
+		let { type, lessons, ...attributes } = item;
 		let block = findBlock( blocks, item );
+		if ( item.id ) {
+			attributes = {
+				...attributes,
+				...attributeMap[ `${ type }-${ item.id }` ],
+			};
+		}
 		if ( ! block ) {
 			block = createBlock( blockNames[ type ], attributes );
 		} else {
@@ -51,7 +58,8 @@ export const syncStructureToBlocks = ( structure, blocks ) => {
 		if ( 'module' === type ) {
 			block.innerBlocks = syncStructureToBlocks(
 				lessons,
-				block.innerBlocks
+				block.innerBlocks,
+				attributeMap
 			);
 		}
 
@@ -126,4 +134,8 @@ export function getChildBlockAttributes( structure ) {
 			] );
 		return { ...result, ...getChildBlockAttributes( block.lessons ) };
 	}, {} );
+}
+
+export function applyBlockAttributes( { id, type }, blockAttributes ) {
+	return blockAttributes[ `${ type }-${ id }` ];
 }

--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -1,5 +1,5 @@
 import { createBlock } from '@wordpress/blocks';
-import { invert } from 'lodash';
+import { invert, omit } from 'lodash';
 
 /**
  * Course structure data.
@@ -104,3 +104,26 @@ export const extractStructure = ( blocks ) => {
 		} )
 		.filter( ( block ) => !! block.title );
 };
+
+/**
+ * Get a map of non-structure attributes for the inner blocks,
+ * indexed by post type and ID.
+ *
+ * @param {CourseStructure} structure Structure extracted from blocks.
+ * @return {Object} Block attribute map.
+ */
+export function getChildBlockAttributes( structure ) {
+	if ( ! structure ) return {};
+
+	return structure.reduce( ( result, block ) => {
+		if ( block.id )
+			result[ `${ block.type }-${ block.id }` ] = omit( block, [
+				'title',
+				'description',
+				'lessons',
+				'id',
+				'type',
+			] );
+		return { ...result, ...getChildBlockAttributes( block.lessons ) };
+	}, {} );
+}

--- a/assets/blocks/course-outline/data.test.js
+++ b/assets/blocks/course-outline/data.test.js
@@ -1,7 +1,12 @@
 import { createBlock } from '@wordpress/blocks';
 import { extractStructure, syncStructureToBlocks } from './data';
-import './lesson-block';
-import './module-block';
+import {
+	registerTestLessonBlock,
+	registerTestModuleBlock,
+} from './test-helpers';
+
+registerTestLessonBlock();
+registerTestModuleBlock();
 
 describe( 'extractStructure', () => {
 	it( 'creates structure from blocks', () => {

--- a/assets/blocks/course-outline/data.test.js
+++ b/assets/blocks/course-outline/data.test.js
@@ -1,54 +1,11 @@
-import { convertToBlocks, extractBlocksData } from './data';
+import { createBlock } from '@wordpress/blocks';
+import { extractStructure, syncStructureToBlocks } from './data';
 import './lesson-block';
 import './module-block';
 
-describe( 'convertToBlocks', () => {
-	it( 'creates blocks from structure', () => {
-		const blocks = convertToBlocks( [
-			{
-				type: 'module',
-				description: 'Module 1',
-				title: 'M1',
-				lessons: [
-					{ type: 'lesson', title: 'M1L1' },
-					{ type: 'lesson', title: 'M1L2' },
-				],
-			},
-			{ type: 'lesson', title: 'L2' },
-		] );
-
-		expect( blocks ).toEqual( [
-			expect.objectContaining( {
-				name: 'sensei-lms/course-outline-module',
-				attributes: { title: 'M1', description: 'Module 1' },
-				innerBlocks: [
-					expect.objectContaining( {
-						name: 'sensei-lms/course-outline-lesson',
-						attributes: { title: 'M1L1' },
-						innerBlocks: [],
-						isValid: true,
-					} ),
-					expect.objectContaining( {
-						name: 'sensei-lms/course-outline-lesson',
-						attributes: { title: 'M1L2' },
-						innerBlocks: [],
-						isValid: true,
-					} ),
-				],
-				isValid: true,
-			} ),
-			expect.objectContaining( {
-				name: 'sensei-lms/course-outline-lesson',
-				attributes: { title: 'L2' },
-				innerBlocks: [],
-				isValid: true,
-			} ),
-		] );
-	} );
-} );
-describe( 'extractBlocksData', () => {
+describe( 'extractStructure', () => {
 	it( 'creates structure from blocks', () => {
-		const data = extractBlocksData( [
+		const data = extractStructure( [
 			{
 				name: 'sensei-lms/course-outline-module',
 				attributes: { title: 'M1', description: 'Module 1' },
@@ -87,6 +44,103 @@ describe( 'extractBlocksData', () => {
 				],
 			},
 			{ type: 'lesson', title: 'L2' },
+		] );
+	} );
+} );
+
+describe( 'syncStructureToBlocks', () => {
+	it( 'merges with existing blocks', () => {
+		const blocks = [
+			createBlock(
+				'sensei-lms/course-outline-module',
+				{
+					title: 'M1',
+					description: 'Module 1',
+					id: 1,
+					style: { color: 'red' },
+				},
+				[
+					createBlock( 'sensei-lms/course-outline-lesson', {
+						title: 'M1L1',
+						id: 3,
+						style: { color: 'red' },
+					} ),
+					createBlock( 'sensei-lms/course-outline-lesson', {
+						title: 'M1L3 New',
+						style: { color: 'red' },
+					} ),
+					createBlock( 'sensei-lms/course-outline-lesson', {
+						title: 'M1L4 Removed',
+						id: 5,
+					} ),
+				]
+			),
+			createBlock( 'sensei-lms/course-outline-lesson', {
+				title: 'L2',
+				id: 8,
+				style: { color: 'red' },
+			} ),
+		];
+
+		const changed = [
+			{ type: 'lesson', title: 'L2', id: 8 },
+			{
+				type: 'module',
+				description: 'Module 1',
+				id: 1,
+				title: 'M1',
+				lessons: [
+					{ type: 'lesson', title: 'M1L2', id: 4 },
+					{ type: 'lesson', title: 'M1L1', id: 3 },
+				],
+			},
+		];
+
+		const newBlocks = syncStructureToBlocks( changed, blocks );
+
+		expect( newBlocks ).toEqual( [
+			{
+				name: 'sensei-lms/course-outline-lesson',
+				attributes: { title: 'L2', id: 8, style: { color: 'red' } },
+				innerBlocks: [],
+				clientId: blocks[ 1 ].clientId,
+				isValid: true,
+			},
+			{
+				name: 'sensei-lms/course-outline-module',
+				attributes: {
+					title: 'M1',
+					id: 1,
+					description: 'Module 1',
+					style: { color: 'red' },
+				},
+				clientId: blocks[ 0 ].clientId,
+				isValid: true,
+				innerBlocks: [
+					{
+						name: 'sensei-lms/course-outline-lesson',
+						attributes: {
+							title: 'M1L2',
+							id: 4,
+							style: {},
+						},
+						innerBlocks: [],
+						isValid: true,
+						clientId: expect.anything(),
+					},
+					{
+						name: 'sensei-lms/course-outline-lesson',
+						attributes: {
+							title: 'M1L1',
+							id: 3,
+							style: { color: 'red' },
+						},
+						innerBlocks: [],
+						clientId: blocks[ 0 ].innerBlocks[ 1 ].clientId,
+						isValid: true,
+					},
+				],
+			},
 		] );
 	} );
 } );

--- a/assets/blocks/course-outline/data.test.js
+++ b/assets/blocks/course-outline/data.test.js
@@ -96,7 +96,7 @@ describe( 'syncStructureToBlocks', () => {
 			},
 		];
 
-		const newBlocks = syncStructureToBlocks( changed, blocks );
+		const newBlocks = syncStructureToBlocks( changed, blocks, [] );
 
 		expect( newBlocks ).toEqual( [
 			{

--- a/assets/blocks/course-outline/edit.js
+++ b/assets/blocks/course-outline/edit.js
@@ -34,15 +34,6 @@ const EditCourseOutlineBlock = ( {
 		} );
 	}, [ setAttributes, blocks ] );
 
-	const courseId = useSelect(
-		( select ) => select( 'core/editor' ).getCurrentPostId(),
-		[]
-	);
-	useEffect( () => setAttributes( { id: courseId } ), [
-		setAttributes,
-		courseId,
-	] );
-
 	const isEmpty = useSelect(
 		( select ) =>
 			! select( 'core/block-editor' ).getBlocks( clientId ).length,

--- a/assets/blocks/course-outline/edit.js
+++ b/assets/blocks/course-outline/edit.js
@@ -29,9 +29,10 @@ const EditCourseOutlineBlock = ( {
 	);
 
 	useEffect( () => {
-		setAttributes( {
-			blocks: getChildBlockAttributes( extractStructure( blocks ) ),
-		} );
+		if ( blocks.length )
+			setAttributes( {
+				blocks: getChildBlockAttributes( extractStructure( blocks ) ),
+			} );
 	}, [ setAttributes, blocks ] );
 
 	const isEmpty = useSelect(

--- a/assets/blocks/course-outline/edit.js
+++ b/assets/blocks/course-outline/edit.js
@@ -8,13 +8,28 @@ import { useBlocksCreator } from './use-block-creator';
 /**
  * Edit course outline block component.
  *
- * @param {Object}   props           Component props.
- * @param {string}   props.clientId  Block client ID.
- * @param {string}   props.className Custom class name.
- * @param {Object[]} props.structure Course module and lesson blocks
+ * @param {Object}   props               Component props.
+ * @param {string}   props.clientId      Block client ID.
+ * @param {string}   props.className     Custom class name.
+ * @param {Object[]} props.structure     Course module and lesson blocks
+ * @param {Function} props.setAttributes
  */
-const EditCourseOutlineBlock = ( { clientId, className, structure } ) => {
+const EditCourseOutlineBlock = ( {
+	clientId,
+	className,
+	structure,
+	setAttributes,
+} ) => {
 	const { setBlocks } = useBlocksCreator( clientId );
+
+	const courseId = useSelect(
+		( select ) => select( 'core/editor' ).getCurrentPostId(),
+		[]
+	);
+	useEffect( () => setAttributes( { id: courseId } ), [
+		setAttributes,
+		courseId,
+	] );
 
 	const isEmpty = useSelect(
 		( select ) =>

--- a/assets/blocks/course-outline/edit.js
+++ b/assets/blocks/course-outline/edit.js
@@ -1,6 +1,7 @@
 import { InnerBlocks } from '@wordpress/block-editor';
 import { useSelect, withSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+import { extractStructure, getChildBlockAttributes } from './data';
 import { CourseOutlinePlaceholder } from './placeholder';
 import { COURSE_STORE } from './store';
 import { useBlocksCreator } from './use-block-creator';
@@ -21,6 +22,17 @@ const EditCourseOutlineBlock = ( {
 	setAttributes,
 } ) => {
 	const { setBlocks } = useBlocksCreator( clientId );
+
+	const blocks = useSelect(
+		( select ) => select( 'core/block-editor' ).getBlocks( clientId ),
+		[ clientId ]
+	);
+
+	useEffect( () => {
+		setAttributes( {
+			blocks: getChildBlockAttributes( extractStructure( blocks ) ),
+		} );
+	}, [ setAttributes, blocks ] );
 
 	const courseId = useSelect(
 		( select ) => select( 'core/editor' ).getCurrentPostId(),

--- a/assets/blocks/course-outline/lesson-block/index.js
+++ b/assets/blocks/course-outline/lesson-block/index.js
@@ -6,6 +6,7 @@ registerBlockType( 'sensei-lms/course-outline-lesson', {
 	title: __( 'Lesson', 'sensei-lms' ),
 	description: __( 'Where your course content lives.', 'sensei-lms' ),
 	icon: 'list-view',
+	category: 'sensei-lms',
 	parent: [ 'sensei-lms/course-outline', 'sensei-lms/course-outline-module' ],
 	keywords: [ __( 'Outline', 'sensei-lms' ), __( 'Lesson', 'sensei-lms' ) ],
 	supports: {

--- a/assets/blocks/course-outline/module-block/index.js
+++ b/assets/blocks/course-outline/module-block/index.js
@@ -1,4 +1,3 @@
-import { InnerBlocks } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
@@ -29,8 +28,5 @@ registerBlockType( 'sensei-lms/course-outline-module', {
 	},
 	edit( props ) {
 		return <EditModuleBlock { ...props } />;
-	},
-	save() {
-		return <InnerBlocks.Content />;
 	},
 } );

--- a/assets/blocks/course-outline/module-block/index.js
+++ b/assets/blocks/course-outline/module-block/index.js
@@ -7,6 +7,7 @@ registerBlockType( 'sensei-lms/course-outline-module', {
 	title: __( 'Module', 'sensei-lms' ),
 	description: __( 'Used to group one or more lessons.', 'sensei-lms' ),
 	icon: 'list-view',
+	category: 'sensei-lms',
 	parent: [ 'sensei-lms/course-outline' ],
 	keywords: [ __( 'Outline', 'sensei-lms' ), __( 'Module', 'sensei-lms' ) ],
 	supports: {

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -64,7 +64,6 @@ const reducers = {
 	SAVING: ( { isSaving }, state ) => ( {
 		...state,
 		isSaving,
-		isDirty: isSaving ? false : state.isDirty,
 	} ),
 	DEFAULT: ( action, state ) => state,
 };

--- a/assets/blocks/course-outline/test-helpers.js
+++ b/assets/blocks/course-outline/test-helpers.js
@@ -1,0 +1,54 @@
+import { registerBlockType } from '@wordpress/blocks';
+
+export function registerTestLessonBlock( settings = {} ) {
+	registerBlockType( 'sensei-lms/course-outline-lesson', {
+		title: 'Lesson Test',
+		parent: [
+			'sensei-lms/course-outline',
+			'sensei-lms/course-outline-module',
+		],
+		category: 'layout',
+		attributes: {
+			id: {
+				type: 'int',
+			},
+			title: {
+				type: 'string',
+				default: '',
+			},
+			style: {
+				type: 'object',
+				default: {},
+			},
+		},
+		...settings,
+	} );
+}
+export function registerTestModuleBlock( settings = {} ) {
+	registerBlockType( 'sensei-lms/course-outline-module', {
+		title: 'Module Test',
+		parent: [
+			'sensei-lms/course-outline',
+			'sensei-lms/course-outline-module',
+		],
+		category: 'layout',
+		attributes: {
+			id: {
+				type: 'int',
+			},
+			title: {
+				type: 'string',
+				default: '',
+			},
+			description: {
+				type: 'string',
+				default: '',
+			},
+			style: {
+				type: 'object',
+				default: {},
+			},
+		},
+		...settings,
+	} );
+}

--- a/assets/blocks/course-outline/use-block-creator.js
+++ b/assets/blocks/course-outline/use-block-creator.js
@@ -1,6 +1,6 @@
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import { convertToBlocks } from './data';
+import { syncStructureToBlocks } from './data';
 
 /**
  * Blocks creator hook.
@@ -11,10 +11,21 @@ import { convertToBlocks } from './data';
 export const useBlocksCreator = ( clientId ) => {
 	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
 
+	const { getBlocks } = useSelect(
+		( select ) => select( 'core/block-editor' ),
+		[]
+	);
+
 	const setBlocks = useCallback(
-		( blockData ) =>
-			replaceInnerBlocks( clientId, convertToBlocks( blockData ), false ),
-		[ clientId, replaceInnerBlocks ]
+		( blockData ) => {
+			const blocks = getBlocks( clientId );
+			replaceInnerBlocks(
+				clientId,
+				syncStructureToBlocks( blockData, blocks || [] ),
+				false
+			);
+		},
+		[ clientId, replaceInnerBlocks, getBlocks ]
 	);
 
 	return { setBlocks };

--- a/assets/blocks/course-outline/use-block-creator.js
+++ b/assets/blocks/course-outline/use-block-creator.js
@@ -11,21 +11,25 @@ import { syncStructureToBlocks } from './data';
 export const useBlocksCreator = ( clientId ) => {
 	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
 
-	const { getBlocks } = useSelect(
+	const { getBlock } = useSelect(
 		( select ) => select( 'core/block-editor' ),
 		[]
 	);
 
 	const setBlocks = useCallback(
 		( blockData ) => {
-			const blocks = getBlocks( clientId );
+			const block = getBlock( clientId );
 			replaceInnerBlocks(
 				clientId,
-				syncStructureToBlocks( blockData, blocks || [] ),
+				syncStructureToBlocks(
+					blockData,
+					block.innerBlocks || [],
+					block.attributes.blocks
+				),
 				false
 			);
 		},
-		[ clientId, replaceInnerBlocks, getBlocks ]
+		[ clientId, replaceInnerBlocks, getBlock ]
 	);
 
 	return { setBlocks };

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -99,13 +99,9 @@ class Sensei_Course_Outline_Block {
 	 */
 	public function render_callback( $attributes ) {
 
-		$course_id = intval( $attributes['id'] );
+		global $post;
 
-		if ( empty( $course_id ) ) {
-			return '';
-		}
-
-		$structure = Sensei_Course_Structure::instance( $course_id )->get();
+		$structure = Sensei_Course_Structure::instance( $post->ID )->get();
 
 		$this->disable_course_legacy_content();
 

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -158,6 +158,9 @@ class Sensei_Course_Outline_Block {
 	 * @return string Module HTML
 	 */
 	private function get_module_block_html( $block ) {
+		if ( empty( $block['lessons'] ) ) {
+			return '';
+		}
 		return '
 			<section class="wp-block-sensei-lms-course-outline-module">
 				<header class="wp-block-sensei-lms-course-outline-module__name">
@@ -166,22 +169,18 @@ class Sensei_Course_Outline_Block {
 				<div class="wp-block-sensei-lms-course-outline-module__description">
 					' . $block['description'] . '
 				</div>
-				' . (
-					// Hide title if there are no lessons.
-					empty( $block['lessons'] ) ? '' : '
 						<div class="wp-block-sensei-lms-course-outline-module__lessons-title">
 							<h3 class="wp-block-sensei-lms-course-outline__clean-heading">' . __( 'Lessons', 'sensei-lms' ) . '</h3>
 						</div>
-					'
-				) .
-				implode(
-					'',
-					array_map(
-						[ $this, 'get_lesson_block_html' ],
-						$block['lessons']
-					)
+					' .
+			implode(
+				'',
+				array_map(
+					[ $this, 'get_lesson_block_html' ],
+					$block['lessons']
 				)
-				. '
+			)
+			. '
 			</section>
 		';
 	}

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -59,6 +59,11 @@ class Sensei_Course_Outline_Block {
 			'sensei-lms/course-outline',
 			[
 				'render_callback' => [ $this, 'render_callback' ],
+				'attributes'      => [
+					'id' => [
+						'type' => 'int',
+					],
+				],
 			]
 		);
 	}
@@ -69,64 +74,17 @@ class Sensei_Course_Outline_Block {
 	 * @access private
 	 *
 	 * @param array $attributes Block attributes.
+	 * @return string Block HTML.
 	 */
 	public function render_callback( $attributes ) {
-		// TODO: Fetch from API or method used in API.
-		$data = [
-			[
-				'id'          => 1,
-				'type'        => 'module',
-				'title'       => 'Module 1',
-				'description' => 'Module description 1',
-				'lessons'     => [
-					[
-						'id'    => 2,
-						'type'  => 'lesson',
-						'title' => 'Lesson 2',
-					],
-					[
-						'id'    => 3,
-						'type'  => 'lesson',
-						'title' => 'Lesson 3',
-					],
-				],
-			],
-			[
-				'id'    => 9,
-				'type'  => 'lesson',
-				'title' => 'Lesson 9',
-			],
-			[
-				'id'    => 10,
-				'type'  => 'lesson',
-				'title' => 'Lesson 10',
-			],
-			[
-				'id'          => 4,
-				'type'        => 'module',
-				'title'       => 'Module 4',
-				'description' => 'Module description 4',
-				'lessons'     => [
-					[
-						'id'    => 5,
-						'type'  => 'lesson',
-						'title' => 'Lesson 5',
-					],
-				],
-			],
-			[
-				'id'          => 6,
-				'type'        => 'module',
-				'title'       => 'Module 6',
-				'description' => 'Module description 6',
-				'lessons'     => [],
-			],
-			[
-				'id'    => 7,
-				'type'  => 'lesson',
-				'title' => 'Lesson 7',
-			],
-		];
+
+		$course_id = intval( $attributes['id'] );
+
+		if ( empty( $course_id ) ) {
+			return '';
+		}
+
+		$data = Sensei_Course_Structure::instance( $course_id )->get();
 
 		$this->disable_course_legacy_content();
 


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Render block based on the course structure data
* Add a `blocks` attribute to the Outline block, containing attributes for it's inner blocks
  * This is indexed by lesson/modules id, like `lesson-13`. This way, if things are modified/reordered outside the block editor, the renderer can still use the style & block-level settings set for that lesson/module.
* Merge with existing blocks in the editor when loading the course structure data from the backend. (Preserve their attributes.)

### Testing instructions

* Create a course, add modules and lessons, save
* View course, check that those modules and lessons are displayed in the frontend.
--
* The attributes stuff is mostly infrastructure, actual usage for block styling will be in separate PRs.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Teaser:

![image](https://user-images.githubusercontent.com/176949/93213182-d07e9100-f763-11ea-9ef3-24a1377d8b9b.png)
