### PR TITLE
Fix admin teacher check

### DIFF
--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -602,6 +602,9 @@ class Sensei_Teacher {
 	 * @return bool $is_admin_teacher
 	 */
 	public function is_admin_teacher() {
+		if ( ! function_exists( 'is_user_logged_in' ) ) {
+			return false;
+		}
 
 		if ( ! is_user_logged_in() ) {
 			return false;


### PR DESCRIPTION
Fixes #3539

### Changes proposed in this Pull Request

* The method `Sensei_Teacher::limit_teacher_edit_screen_post_types` is called by the filter `parse_query`, and it uses the function `is_user_logged_in`. The _Discount Rules for WooCommerce_ plugin calls `get_posts` that invoke this filter before having the `is_user_logged_in` function ready to use. So the fix just returns early when the function `is_user_logged_in` doesn't exist.

### Testing instructions

* With Sensei LMS activated, install and activate [Discount Rules for WooCommerce](https://wordpress.org/plugins/woo-discount-rules/), and make sure the activation works well.