### PR TITLE
Multiple choice question is correct only when all right answers are checked

### DIFF
--- a/assets/js/grading-general.js
+++ b/assets/js/grading-general.js
@@ -101,6 +101,10 @@ jQuery(document).ready( function( $ ) {
 								all_correct = false;
 							}
 						} );
+
+						if ( user_answers.length !== correct_answers.length ) {
+							all_correct = false;
+						}
 					}
 
 					if ( all_correct || ( user_answer === correct_answer ) ) { // Right answer

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -891,7 +891,7 @@ class Sensei_Grading {
 				$all_question_grades[ $question_id ] = $achievable_grade;
 			} elseif ( in_array( $question_type, $autogradable_question_types ) ) {
 				// Get user question grade
-				$question_grade                      = Sensei_Utils::sensei_grade_question_auto( $question_id, $question_type, $answer, $user_id );
+				$question_grade                      = Sensei_Grading::grade_question_auto( $question_id, $question_type, $answer, $user_id );
 				$all_question_grades[ $question_id ] = $question_grade;
 				$grade_total                        += $question_grade;
 

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -891,7 +891,7 @@ class Sensei_Grading {
 				$all_question_grades[ $question_id ] = $achievable_grade;
 			} elseif ( in_array( $question_type, $autogradable_question_types ) ) {
 				// Get user question grade
-				$question_grade                      = Sensei_Grading::grade_question_auto( $question_id, $question_type, $answer, $user_id );
+				$question_grade                      = self::grade_question_auto( $question_id, $question_type, $answer, $user_id );
 				$all_question_grades[ $question_id ] = $question_grade;
 				$grade_total                        += $question_grade;
 


### PR DESCRIPTION
Fixes #3511

### Changes proposed in this Pull Request

* Fixes the grading question check to be similar to the user feedback. (The check for the user feedback is in PHP while for the grading it's in JavaScript - It should be all refactored at some point).
* It also fixes a deprecated method call.

### Testing instructions

1. Create a lesson with a quiz that has a multiple choice question that has multiple correct answers.
1. Take the quiz. Select only one correct answer. Complete the quiz.
1. Make sure it appears as an incorrect question in the grading (WP-admin > Sensei LMS > Grading).