### PR TITLE
Fix get modules in course structure with no lessons

### DIFF
--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -64,11 +64,9 @@ class Sensei_Course_Structure {
 		$all_lessons       = Sensei()->course->course_lessons( $this->course_id, 'any', 'ids' );
 		$no_module_lessons = wp_list_pluck( Sensei()->modules->get_none_module_lessons( $this->course_id, 'any' ), 'ID' );
 
-		if ( empty( $all_lessons ) || count( $all_lessons ) !== count( $no_module_lessons ) ) {
-			$modules = $this->get_modules();
-			foreach ( $modules as $module_term ) {
-				$structure[] = $this->prepare_module( $module_term );
-			}
+		$modules = $this->get_modules();
+		foreach ( $modules as $module_term ) {
+			$structure[] = $this->prepare_module( $module_term );
 		}
 
 		foreach ( array_intersect( $all_lessons, $no_module_lessons ) as $lesson_id ) {

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -107,6 +107,41 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		$this->assertExpectedStructure( $expected_structure, $structure );
 	}
 
+
+	/**
+	 * Test getting course structure when just modules with no lessons and one rogue lesson.
+	 */
+	public function testGetModulesWithEmptyLessons() {
+		$course_id = $this->factory->course->create();
+
+		$lessons = $this->factory->lesson->create_many( 1 );
+		$modules = $this->factory->module->create_many( 2 );
+
+		$expected_structure = [
+			[
+				'type'    => 'module',
+				'id'      => $modules[1],
+				'lessons' => [],
+			],
+			[
+				'type'    => 'module',
+				'id'      => $modules[0],
+				'lessons' => [],
+			],
+			[
+				'type' => 'lesson',
+				'id'   => $lessons[0],
+			],
+		];
+
+		$this->saveStructure( $course_id, $expected_structure );
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+		$structure        = $course_structure->get();
+
+		$this->assertExpectedStructure( $expected_structure, $structure );
+	}
+
 	/**
 	 * Test getting course structure when there is a mix of modules and lessons on the first level.
 	 */


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Removes check to see if fetching modules is necessary. I think it almost always is.
* Fixes issue where you save a module with no lessons and a lesson outside of a module. The `get` for this just returns the lessons.

### Testing instructions

* See issue description above.
* Observe tests passing.
