### PR TITLE
Add lesson block color customization

### DIFF
--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -1,5 +1,7 @@
+import { withColors } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
+import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import SingleLineInput from '../single-line-input';
 import { LessonBlockSettings } from './settings';
@@ -14,20 +16,24 @@ import { LessonBlockSettings } from './settings';
  * @param {Object}   props.attributes        Block attributes.
  * @param {string}   props.attributes.title  Lesson title.
  * @param {number}   props.attributes.id     Lesson Post ID
- * @param {Object}   props.attributes.style  Custom visual settings.
+ * @param {Object}   props.backgroundColor   Background color object.
+ * @param {Object}   props.textColor         Text color object.
  * @param {Function} props.setAttributes     Block set attributes function.
  * @param {Function} props.insertBlocksAfter Insert blocks after function.
  * @param {boolean}  props.isSelected        Is block selected.
  */
-const EditLessonBlock = ( {
-	clientId,
-	name,
-	className,
-	attributes: { title, id, style = {} },
-	setAttributes,
-	insertBlocksAfter,
-	isSelected,
-} ) => {
+const EditLessonBlock = ( props ) => {
+	const {
+		clientId,
+		name,
+		className,
+		attributes: { title, id },
+		backgroundColor,
+		textColor,
+		setAttributes,
+		insertBlocksAfter,
+		isSelected,
+	} = props;
 	const { selectNextBlock, removeBlock } = useDispatch( 'core/block-editor' );
 
 	/**
@@ -100,16 +106,22 @@ const EditLessonBlock = ( {
 		);
 	}
 
+	const colorStyles = {
+		className: classnames(
+			className,
+			backgroundColor?.class,
+			textColor?.class
+		),
+		style: {
+			backgroundColor: backgroundColor?.color,
+			color: textColor?.color,
+		},
+	};
+
 	return (
 		<>
-			<LessonBlockSettings { ...{ style, setAttributes } } />
-			<div
-				className={ className }
-				style={ {
-					backgroundColor: style.backgroundColor,
-					color: style.textColor,
-				} }
-			>
+			<LessonBlockSettings { ...props } />
+			<div { ...colorStyles }>
 				<SingleLineInput
 					className="wp-block-sensei-lms-course-outline-lesson__input"
 					placeholder={ __( 'Lesson name', 'sensei-lms' ) }
@@ -123,4 +135,7 @@ const EditLessonBlock = ( {
 	);
 };
 
-export default EditLessonBlock;
+export default withColors( {
+	backgroundColor: 'background-color',
+	textColor: 'color',
+} )( EditLessonBlock );

--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -2,6 +2,7 @@ import { createBlock } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import SingleLineInput from '../single-line-input';
+import { LessonBlockSettings } from './settings';
 
 /**
  * Edit lesson block component.
@@ -13,6 +14,7 @@ import SingleLineInput from '../single-line-input';
  * @param {Object}   props.attributes        Block attributes.
  * @param {string}   props.attributes.title  Lesson title.
  * @param {number}   props.attributes.id     Lesson Post ID
+ * @param {Object}   props.attributes.style  Custom visual settings.
  * @param {Function} props.setAttributes     Block set attributes function.
  * @param {Function} props.insertBlocksAfter Insert blocks after function.
  * @param {boolean}  props.isSelected        Is block selected.
@@ -21,7 +23,7 @@ const EditLessonBlock = ( {
 	clientId,
 	name,
 	className,
-	attributes: { title, id },
+	attributes: { title, id, style = {} },
 	setAttributes,
 	insertBlocksAfter,
 	isSelected,
@@ -99,16 +101,25 @@ const EditLessonBlock = ( {
 	}
 
 	return (
-		<div className={ className }>
-			<SingleLineInput
-				className="wp-block-sensei-lms-course-outline-lesson__input"
-				placeholder={ __( 'Lesson name', 'sensei-lms' ) }
-				value={ title }
-				onChange={ handleChange }
-				onKeyDown={ handleKeyDown }
-			/>
-			{ isSelected && status }
-		</div>
+		<>
+			<LessonBlockSettings { ...{ style, setAttributes } } />
+			<div
+				className={ className }
+				style={ {
+					backgroundColor: style.backgroundColor,
+					color: style.textColor,
+				} }
+			>
+				<SingleLineInput
+					className="wp-block-sensei-lms-course-outline-lesson__input"
+					placeholder={ __( 'Lesson name', 'sensei-lms' ) }
+					value={ title }
+					onChange={ handleChange }
+					onKeyDown={ handleKeyDown }
+				/>
+				{ isSelected && status }
+			</div>
+		</>
 	);
 };
 

--- a/assets/blocks/course-outline/lesson-block/edit.test.js
+++ b/assets/blocks/course-outline/lesson-block/edit.test.js
@@ -12,6 +12,18 @@ jest.mock( '@wordpress/blocks', () => ( {
 	createBlock: jest.fn(),
 } ) );
 
+jest.mock( '@wordpress/block-editor', () => ( {
+	withColors() {
+		return ( Component ) => ( props ) => (
+			<Component { ...props } backgroundColor={ {} } textColor={ {} } />
+		);
+	},
+} ) );
+
+jest.mock( './settings', () => ( {
+	LessonBlockSettings: () => '',
+} ) );
+
 describe( '<EditLessonBlock />', () => {
 	const selectNextBlockMock = jest.fn();
 	const removeBlockMock = jest.fn();

--- a/assets/blocks/course-outline/lesson-block/index.js
+++ b/assets/blocks/course-outline/lesson-block/index.js
@@ -26,9 +26,17 @@ registerBlockType( 'sensei-lms/course-outline-lesson', {
 			type: 'string',
 			default: '',
 		},
-		style: {
-			type: 'object',
-			default: {},
+		backgroundColor: {
+			type: 'string',
+		},
+		customBackgroundColor: {
+			type: 'string',
+		},
+		textColor: {
+			type: 'string',
+		},
+		customTextColor: {
+			type: 'string',
 		},
 	},
 	edit( props ) {

--- a/assets/blocks/course-outline/lesson-block/index.js
+++ b/assets/blocks/course-outline/lesson-block/index.js
@@ -11,7 +11,12 @@ registerBlockType( 'sensei-lms/course-outline-lesson', {
 	keywords: [ __( 'Outline', 'sensei-lms' ), __( 'Lesson', 'sensei-lms' ) ],
 	supports: {
 		html: false,
-		customClassName: false,
+		customClassName: true,
+	},
+	example: {
+		attributes: {
+			title: 'Start learning',
+		},
 	},
 	attributes: {
 		id: {
@@ -20,6 +25,10 @@ registerBlockType( 'sensei-lms/course-outline-lesson', {
 		title: {
 			type: 'string',
 			default: '',
+		},
+		style: {
+			type: 'object',
+			default: {},
 		},
 	},
 	edit( props ) {

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -1,0 +1,46 @@
+import {
+	ContrastChecker,
+	InspectorControls,
+	PanelColorSettings,
+} from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import { colorSetting } from '../../../shared/blocks/settings';
+
+/**
+ * Inspector controls for lesson block.
+ *
+ * @param {Object}   props
+ * @param {Function} props.setAttributes
+ * @param {Object}   props.style
+ */
+export function LessonBlockSettings( { style, setAttributes } ) {
+	return (
+		<InspectorControls>
+			<PanelColorSettings
+				title={ __( 'Color settings', 'sensei-lms' ) }
+				colorSettings={ [
+					colorSetting(
+						'backgroundColor',
+						__( 'Background color', 'sensei-lms' ),
+						{ style, setAttributes }
+					),
+					colorSetting(
+						'textColor',
+						__( 'Text color', 'sensei-lms' ),
+						{ style, setAttributes }
+					),
+				] }
+			>
+				{
+					<ContrastChecker
+						{ ...{
+							textColor: style.textColor,
+							backgroundColor: style.mainColor,
+						} }
+						isLargeText={ false }
+					/>
+				}
+			</PanelColorSettings>
+		</InspectorControls>
+	);
+}

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -4,38 +4,44 @@ import {
 	PanelColorSettings,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { colorSetting } from '../../../shared/blocks/settings';
 
 /**
  * Inspector controls for lesson block.
  *
  * @param {Object}   props
- * @param {Function} props.setAttributes
- * @param {Object}   props.style
+ * @param {Object}   props.backgroundColor
+ * @param {Object}   props.textColor
+ * @param {Function} props.setTextColor
+ * @param {Function} props.setBackgroundColor
  */
-export function LessonBlockSettings( { style, setAttributes } ) {
+export function LessonBlockSettings( {
+	backgroundColor,
+	textColor,
+	setTextColor,
+	setBackgroundColor,
+} ) {
 	return (
 		<InspectorControls>
 			<PanelColorSettings
 				title={ __( 'Color settings', 'sensei-lms' ) }
 				colorSettings={ [
-					colorSetting(
-						'backgroundColor',
-						__( 'Background color', 'sensei-lms' ),
-						{ style, setAttributes }
-					),
-					colorSetting(
-						'textColor',
-						__( 'Text color', 'sensei-lms' ),
-						{ style, setAttributes }
-					),
+					{
+						value: backgroundColor.color,
+						label: __( 'Background color', 'sensei-lms' ),
+						onChange: setBackgroundColor,
+					},
+					{
+						value: textColor.color,
+						label: __( 'Text color', 'sensei-lms' ),
+						onChange: setTextColor,
+					},
 				] }
 			>
 				{
 					<ContrastChecker
 						{ ...{
-							textColor: style.textColor,
-							backgroundColor: style.mainColor,
+							textColor: textColor.color,
+							backgroundColor: backgroundColor.color,
 						} }
 						isLargeText={ false }
 					/>

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -18,7 +18,7 @@ $dark-gray: #1a1d20;
 
 .wp-block-sensei-lms-course-outline-module {
 	border: solid 1px $dark-gray;
-	margin-bottom: 25px;
+	margin: 1.5em 0;
 
 	&__name {
 		padding: 15px 25px;
@@ -48,6 +48,10 @@ $dark-gray: #1a1d20;
 	display: flex;
 	align-items: center;
 	padding: 20px 25px;
+	> a {
+		color: inherit;
+	}
+
 	.entry-content & {
 		margin: 0;
 	}

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -48,9 +48,10 @@ $dark-gray: #1a1d20;
 	display: flex;
 	align-items: center;
 	padding: 20px 25px;
-	color: $dark-gray;
+	.entry-content & {
+		margin: 0;
+	}
 	font-size: 16px;
-	text-decoration: none;
 
 	&::before {
 		content: '';
@@ -70,7 +71,6 @@ $dark-gray: #1a1d20;
 /**
  * Overrides
  */
-.entry-content .wp-block-sensei-lms-course-outline,
 .editor-styles-wrapper .wp-block-sensei-lms-course-outline .wp-block {
 	h1,
 	h2,

--- a/assets/shared/blocks/settings.js
+++ b/assets/shared/blocks/settings.js
@@ -1,0 +1,23 @@
+/**
+ * Build PanelColorSettings configuration.
+ *
+ * @param {string}   name                Style attribute name.
+ * @param {string}   label               Control label.
+ * @param {Object}   props               Component props.
+ * @param {Object}   props.style
+ * @param {Function} props.setAttributes
+ * @return {Object} Configuration.
+ */
+export const colorSetting = ( name, label, { style, setAttributes } ) => {
+	return {
+		value: style[ name ],
+		onChange: ( colorValue ) =>
+			setAttributes( {
+				style: {
+					...style,
+					[ name ]: colorValue,
+				},
+			} ),
+		label,
+	};
+};

--- a/includes/blocks/class-sensei-block-helpers.php
+++ b/includes/blocks/class-sensei-block-helpers.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class Sensei_Course_Block_Helpers
  */
-class Sensei_Course_Block_Helpers {
+class Sensei_Block_Helpers {
 
 
 	/**

--- a/includes/blocks/class-sensei-block-helpers.php
+++ b/includes/blocks/class-sensei-block-helpers.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * File containing the Sensei_Course_Block_Helpers class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Course_Block_Helpers
+ */
+class Sensei_Course_Block_Helpers {
+
+
+	/**
+	 * Build CSS classes (for named colors) and inline styles from block attributes.
+	 *
+	 * @param array $block  Block.
+	 * @param array $colors Color attributes and their style property.
+	 *
+	 * @return array Colors CSS classes and inline styles.
+	 */
+	public static function build_styles( $block, $colors = [] ) {
+		$block_attributes = $block['attributes'] ?? [];
+		$attributes       = [
+			'css_classes'   => [],
+			'inline_styles' => [],
+		];
+
+		$colors = array_merge(
+			[
+				'textColor'       => 'color',
+				'backgroundColor' => 'background-color',
+			],
+			$colors
+		);
+
+		foreach ( $colors as $color => $style ) {
+
+			$named_color  = $block_attributes[ $color ] ?? null;
+			$custom_color = $block_attributes[ 'custom' . ucfirst( $color ) ] ?? null;
+
+			if ( $custom_color || $named_color ) {
+				$attributes['css_classes'][] = sprintf( 'has-%s', $style );
+			}
+			if ( $named_color ) {
+				$attributes['css_classes'][] = sprintf( 'has-%s-%s', $named_color, $style );
+			} elseif ( $custom_color ) {
+				$attributes['inline_styles'][] = sprintf( '%s: %s;', $style, $custom_color );
+			}
+		}
+
+		return $attributes;
+	}
+
+	/**
+	 * Render class and style HTML attributes.
+	 *
+	 * @param string|string[] $class_names
+	 * @param array           $css
+	 *
+	 * @return string
+	 */
+	public static function render_style_attributes( $class_names, $css ) {
+
+		$class_names = array_merge( is_array( $class_names ) ? $class_names : [ $class_names ], $css['css_classes'] );
+		return sprintf(
+			'class="%s" style="%s"',
+			esc_attr( implode( ' ', array_map( 'sanitize_html_class', $class_names ) ) ),
+			esc_attr( implode( '; ', $css['inline_styles'] ) )
+		);
+	}
+
+
+}

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -40,6 +40,10 @@ class Sensei_Course_Outline_Block {
 	 * @access private
 	 */
 	public function enqueue_block_assets() {
+		if ( 'course' !== get_post_type() ) {
+			return;
+		}
+
 		Sensei()->assets->enqueue( 'sensei-course-outline', 'blocks/course-outline/style.css' );
 	}
 
@@ -49,6 +53,10 @@ class Sensei_Course_Outline_Block {
 	 * @access private
 	 */
 	public function enqueue_block_editor_assets() {
+		if ( 'course' !== get_post_type() ) {
+			return;
+		}
+
 		Sensei()->assets->enqueue( 'sensei-course-outline', 'blocks/course-outline/index.js' );
 		Sensei()->assets->enqueue( 'sensei-course-outline-editor', 'blocks/course-outline/style.editor.css' );
 	}
@@ -206,10 +214,15 @@ class Sensei_Course_Outline_Block {
 	 * @return string Lesson HTML
 	 */
 	protected function render_lesson_block( $block ) {
+		$style = $block['attributes']['style'] ?? [];
 		return '
-			<a class="wp-block-sensei-lms-course-outline-lesson" href="#">
-				' . $block['title'] . '
-			</a>
+			<h3 style="background-color: ' . esc_attr( $style['backgroundColor'] ) . '" class="wp-block-sensei-lms-course-outline-lesson">
+				<a
+				style="color: ' . esc_attr( $style['textColor'] ) . '"
+				href="' . esc_url( get_permalink( $block['id'] ) ) . '">
+					' . $block['title'] . '
+				</a>
+			</h3>
 		';
 	}
 

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -121,6 +121,7 @@ class Sensei_Course_Outline_Block {
 	 * Extract attributes from module block.
 	 *
 	 * @param array $attributes
+	 *
 	 * @access private
 	 * @return string
 	 */
@@ -133,6 +134,7 @@ class Sensei_Course_Outline_Block {
 	 * Extract attributes from module block.
 	 *
 	 * @param array $attributes
+	 *
 	 * @access private
 	 * @return string
 	 */
@@ -214,11 +216,11 @@ class Sensei_Course_Outline_Block {
 	 * @return string Lesson HTML
 	 */
 	protected function render_lesson_block( $block ) {
-		$style = $block['attributes']['style'] ?? [];
+
+		$css = Sensei_Course_Block_Helpers::build_styles( $block );
 		return '
-			<h3 style="' . self::style_attr( $style, [ 'background-color' => 'backgroundColor' ] ) . '" class="wp-block-sensei-lms-course-outline-lesson">
+			<h3 ' . Sensei_Course_Block_Helpers::render_style_attributes( 'wp-block-sensei-lms-course-outline-lesson', $css ) . '>
 				<a
-				style="' . self::style_attr( $style, [ 'color' => 'textColor' ] ) . '"
 				href="' . esc_url( get_permalink( $block['id'] ) ) . '">
 					' . $block['title'] . '
 				</a>
@@ -247,7 +249,7 @@ class Sensei_Course_Outline_Block {
 					' . $block['description'] . '
 				</div>
 						<div class="wp-block-sensei-lms-course-outline-module__lessons-title">
-							<h3 class="wp-block-sensei-lms-course-outline__clean-heading">' . __( 'Lessons', 'sensei-lms' ) . '</h3>
+							<div class="wp-block-sensei-lms-course-outline__clean-heading">' . __( 'Lessons', 'sensei-lms' ) . '</div>
 						</div>
 					' .
 			implode(
@@ -260,25 +262,6 @@ class Sensei_Course_Outline_Block {
 			. '
 			</section>
 		';
-	}
-
-	/**
-	 * Create a HTML style attribute.
-	 *
-	 * @param array $block_style Block style attributes.
-	 * @param array $rules       CSS rules, with values being array keys in the block style array.
-	 *
-	 * @return string
-	 */
-	private static function style_attr( $block_style, $rules ) {
-		$result = '';
-		foreach ( $rules as $rule => $value ) {
-			if ( ! empty( $block_style[ $value ] ) ) {
-				$result .= $rule . ': ' . esc_attr( $block_style[ $value ] );
-			}
-		}
-
-		return esc_attr( $result );
 	}
 
 	/**

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -217,9 +217,9 @@ class Sensei_Course_Outline_Block {
 	 */
 	protected function render_lesson_block( $block ) {
 
-		$css = Sensei_Course_Block_Helpers::build_styles( $block );
+		$css = Sensei_Block_Helpers::build_styles( $block );
 		return '
-			<h3 ' . Sensei_Course_Block_Helpers::render_style_attributes( 'wp-block-sensei-lms-course-outline-lesson', $css ) . '>
+			<h3 ' . Sensei_Block_Helpers::render_style_attributes( 'wp-block-sensei-lms-course-outline-lesson', $css ) . '>
 				<a
 				href="' . esc_url( get_permalink( $block['id'] ) ) . '">
 					' . $block['title'] . '

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -216,9 +216,9 @@ class Sensei_Course_Outline_Block {
 	protected function render_lesson_block( $block ) {
 		$style = $block['attributes']['style'] ?? [];
 		return '
-			<h3 style="background-color: ' . esc_attr( $style['backgroundColor'] ) . '" class="wp-block-sensei-lms-course-outline-lesson">
+			<h3 style="' . self::style_attr( $style, [ 'background-color' => 'backgroundColor' ] ) . '" class="wp-block-sensei-lms-course-outline-lesson">
 				<a
-				style="color: ' . esc_attr( $style['textColor'] ) . '"
+				style="' . self::style_attr( $style, [ 'color' => 'textColor' ] ) . '"
 				href="' . esc_url( get_permalink( $block['id'] ) ) . '">
 					' . $block['title'] . '
 				</a>
@@ -260,6 +260,25 @@ class Sensei_Course_Outline_Block {
 			. '
 			</section>
 		';
+	}
+
+	/**
+	 * Create a HTML style attribute.
+	 *
+	 * @param array $block_style Block style attributes.
+	 * @param array $rules       CSS rules, with values being array keys in the block style array.
+	 *
+	 * @return string
+	 */
+	private static function style_attr( $block_style, $rules ) {
+		$result = '';
+		foreach ( $rules as $rule => $value ) {
+			if ( ! empty( $block_style[ $value ] ) ) {
+				$result .= $rule . ': ' . esc_attr( $block_style[ $value ] );
+			}
+		}
+
+		return esc_attr( $result );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add inspector controls to lesson block for Text Color and Background Color
* Add styles and classes when rendering based on the colors set

### Testing instructions

* Open a course with lessons/create them in the block editor
* Select a lesson block and open block settings
* Change colors under Color Settings
* Save the post & view it on the frontend
* Make sure custom colors are used.

### Notes

* Adds classes for *named colors*, which pick up the theme colors, eg `has-accent-background-color`
* Wordpress 5.5 Gutenberg has a one line solution for most of this — `__experimentalColor` hooks up the inspector controls and attribute setup. We can move to that in the far future :)

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video  

#### Intended use case:

<img width="984" alt="image" src="https://user-images.githubusercontent.com/176949/93529552-640aba00-f93c-11ea-9abf-522d875cd354.png">

#### Theme support:

![QuickTime movie](https://user-images.githubusercontent.com/176949/93529327-04acaa00-f93c-11ea-8db5-99de25d2be7c.gif)

#### Wordpress 5.3:

![image](https://user-images.githubusercontent.com/176949/93529426-2a39b380-f93c-11ea-8cdf-23a1899ac2b7.png)

