### PR TITLE
Allow for different context when getting course structure

### DIFF
--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -16,7 +16,7 @@ const actions = {
 	*fetchCourseStructure() {
 		const courseId = yield select( 'core/editor' ).getCurrentPostId();
 		const result = yield apiFetch( {
-			path: `/sensei-internal/v1/course-structure/${ courseId }`,
+			path: `/sensei-internal/v1/course-structure/${ courseId }?context=edit`,
 		} );
 		yield actions.setStructure( result );
 	},

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -101,7 +101,7 @@ class Sensei_Course_Outline_Block {
 
 		global $post;
 
-		$structure = Sensei_Course_Structure::instance( $post->ID )->get();
+		$structure = Sensei_Course_Structure::instance( $post->ID )->get( 'view' );
 
 		$this->disable_course_legacy_content();
 

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -202,7 +202,7 @@ class Sensei_Course_Structure {
 				$lesson_ids[]   = $lesson_id;
 				$lesson_order[] = $lesson_id;
 
-				update_post_meta( $item['id'], '_order_' . $this->course_id, count( $lesson_ids ) );
+				update_post_meta( $lesson_id, '_order_' . $this->course_id, count( $lesson_order ) );
 			}
 		}
 

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -64,11 +64,9 @@ class Sensei_Course_Structure {
 		$all_lessons       = Sensei()->course->course_lessons( $this->course_id, 'any', 'ids' );
 		$no_module_lessons = wp_list_pluck( Sensei()->modules->get_none_module_lessons( $this->course_id, 'any' ), 'ID' );
 
-		if ( empty( $all_lessons ) || count( $all_lessons ) !== count( $no_module_lessons ) ) {
-			$modules = $this->get_modules();
-			foreach ( $modules as $module_term ) {
-				$structure[] = $this->prepare_module( $module_term );
-			}
+		$modules = $this->get_modules();
+		foreach ( $modules as $module_term ) {
+			$structure[] = $this->prepare_module( $module_term );
 		}
 
 		foreach ( array_intersect( $all_lessons, $no_module_lessons ) as $lesson_id ) {

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -127,6 +127,7 @@ class Sensei_Course_Structure {
 			'type'  => 'lesson',
 			'id'    => $lesson_post->ID,
 			'title' => $lesson_post->post_title,
+			'draft' => 'draft' === $lesson_post->post_status,
 		];
 	}
 

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -73,7 +73,7 @@ class Sensei_Course_Structure {
 
 		$modules = $this->get_modules();
 		foreach ( $modules as $module_term ) {
-			$module = $this->prepare_module( $module_term, $published_lessons_only );
+			$module = $this->prepare_module( $module_term, $post_status );
 
 			if ( ! empty( $module['lessons'] ) || 'edit' === $context ) {
 				$structure[] = $module;
@@ -95,11 +95,11 @@ class Sensei_Course_Structure {
 	/**
 	 * Prepare the result for a module.
 	 *
-	 * @param WP_Term $module_term            Module term.
-	 * @param bool    $published_lessons_only Only include published lessons.
+	 * @param WP_Term      $module_term        Module term.
+	 * @param array|string $lesson_post_status Lesson post status(es).
 	 */
-	private function prepare_module( WP_Term $module_term, bool $published_lessons_only ) {
-		$lessons = $this->get_module_lessons( $module_term->term_id, $published_lessons_only );
+	private function prepare_module( WP_Term $module_term, $lesson_post_status ) {
+		$lessons = $this->get_module_lessons( $module_term->term_id, $lesson_post_status );
 		$module  = [
 			'type'        => 'module',
 			'id'          => $module_term->term_id,
@@ -134,15 +134,13 @@ class Sensei_Course_Structure {
 	/**
 	 * Get the lessons for a module.
 	 *
-	 * @param int  $module_term_id         Term ID for the module.
-	 * @param bool $published_lessons_only Only include published lessons.
+	 * @param int          $module_term_id     Term ID for the module.
+	 * @param array|string $lesson_post_status Lesson post status(es).
 	 *
 	 * @return WP_Post[]
 	 */
-	private function get_module_lessons( int $module_term_id, bool $published_lessons_only ) {
-		$post_status = $published_lessons_only ? self::PUBLISHED_POST_STATUSES : 'any';
-
-		$lessons_query = Sensei()->modules->get_lessons_query( $this->course_id, $module_term_id, $post_status );
+	private function get_module_lessons( int $module_term_id, $lesson_post_status ) {
+		$lessons_query = Sensei()->modules->get_lessons_query( $this->course_id, $module_term_id, $lesson_post_status );
 
 		return $lessons_query instanceof WP_Query ? $lessons_query->posts : [];
 	}

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -208,8 +208,6 @@ class Sensei_Course_Structure {
 			$this->clear_lesson_associations( $lesson_id );
 		}
 
-		delete_transient( 'sensei_' . $this->course_id . '_none_module_lessons' );
-
 		return true;
 	}
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1090,21 +1090,22 @@ class Sensei_Course {
 	 * course_lessons function.
 	 *
 	 * @access public
+	 *
 	 * @param int    $course_id   (default: 0)
 	 * @param string $post_status (default: 'publish')
 	 * @param string $fields      (default: 'all'). WP only allows 3 types, but we will limit it to only 'ids' or 'all'
-	 * @param array  $base_args   Base arguments for the WP query.
+	 * @param array  $query_args  Base arguments for the WP query.
 	 *
 	 * @return array{ type WP_Post }  $posts_array
 	 */
-	public function course_lessons( $course_id = 0, $post_status = 'publish', $fields = 'all', $base_args = [] ) {
+	public function course_lessons( $course_id = 0, $post_status = 'publish', $fields = 'all', $query_args = [] ) {
 
 		if ( is_a( $course_id, 'WP_Post' ) ) {
 			$course_id = $course_id->ID;
 		}
 
-		$post_args = array_merge(
-			$base_args,
+		$query_args = array_merge(
+			$query_args,
 			[
 				'post_type'        => 'lesson',
 				'posts_per_page'   => -1,
@@ -1115,16 +1116,16 @@ class Sensei_Course {
 			]
 		);
 
-		if ( ! isset( $post_args['meta_query'] ) ) {
-			$post_args['meta_query'] = [];
+		if ( ! isset( $query_args['meta_query'] ) ) {
+			$query_args['meta_query'] = [];
 		}
 
-		$post_args['meta_query'][] = [
+		$query_args['meta_query'][] = [
 			'key'   => '_lesson_course',
 			'value' => intval( $course_id ),
 		];
 
-		$query_results = new WP_Query( $post_args );
+		$query_results = new WP_Query( $query_args );
 		$lessons       = $query_results->posts;
 
 		// re order the lessons. This could not be done via the OR meta query as there may be lessons
@@ -1156,7 +1157,7 @@ class Sensei_Course {
 		// return the requested fields
 		// runs after the sensei_course_get_lessons filter so the filter always give an array of lesson
 		// objects
-		if ( 'ids' == $fields ) {
+		if ( 'ids' === $fields ) {
 			$lesson_objects = $lessons;
 			$lessons        = array();
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1090,31 +1090,40 @@ class Sensei_Course {
 	 * course_lessons function.
 	 *
 	 * @access public
-	 * @param int    $course_id (default: 0)
+	 * @param int    $course_id   (default: 0)
 	 * @param string $post_status (default: 'publish')
-	 * @param string $fields (default: 'all'). WP only allows 3 types, but we will limit it to only 'ids' or 'all'
+	 * @param string $fields      (default: 'all'). WP only allows 3 types, but we will limit it to only 'ids' or 'all'
+	 * @param array  $base_args   Base arguments for the WP query.
+	 *
 	 * @return array{ type WP_Post }  $posts_array
 	 */
-	public function course_lessons( $course_id = 0, $post_status = 'publish', $fields = 'all' ) {
+	public function course_lessons( $course_id = 0, $post_status = 'publish', $fields = 'all', $base_args = [] ) {
 
 		if ( is_a( $course_id, 'WP_Post' ) ) {
 			$course_id = $course_id->ID;
 		}
 
-		$post_args     = array(
-			'post_type'        => 'lesson',
-			'posts_per_page'   => -1,
-			'orderby'          => 'date',
-			'order'            => 'ASC',
-			'meta_query'       => array(
-				array(
-					'key'   => '_lesson_course',
-					'value' => intval( $course_id ),
-				),
-			),
-			'post_status'      => $post_status,
-			'suppress_filters' => 0,
+		$post_args = array_merge(
+			$base_args,
+			[
+				'post_type'        => 'lesson',
+				'posts_per_page'   => -1,
+				'orderby'          => 'date',
+				'order'            => 'ASC',
+				'post_status'      => $post_status,
+				'suppress_filters' => 0,
+			]
 		);
+
+		if ( ! isset( $post_args['meta_query'] ) ) {
+			$post_args['meta_query'] = [];
+		}
+
+		$post_args['meta_query'][] = [
+			'key'   => '_lesson_course',
+			'value' => intval( $course_id ),
+		];
+
 		$query_results = new WP_Query( $post_args );
 		$lessons       = $query_results->posts;
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -34,9 +34,6 @@ class Sensei_Core_Modules {
 		// Save lesson meta box
 		add_action( 'save_post', array( $this, 'save_lesson_module' ), 10, 1 );
 
-		// Reset the none modules lessons transient
-		add_action( 'save_post', array( 'Sensei_Core_Modules', 'reset_none_modules_transient' ) );
-
 		// Frontend styling
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 
@@ -1691,8 +1688,7 @@ class Sensei_Core_Modules {
 	 * @param array|string $course_lessons_post_status Post status for lessons. Can be an array of statuses.
 	 *
 	 * @return WP_Query $lessons_query
-	 *@since 1.8.0
-	 *
+	 * @since 1.8.0
 	 */
 	public function get_lessons_query( $course_id, $term_id, $course_lessons_post_status = null ) {
 		global $wp_query;
@@ -1760,7 +1756,7 @@ class Sensei_Core_Modules {
 		$base_args      = [];
 
 		if ( ! empty( $course_modules ) && is_array( $course_modules ) ) {
-			$term_ids = wp_list_pluck( $course_modules, 'term_id' );
+			$term_ids               = wp_list_pluck( $course_modules, 'term_id' );
 			$base_args['tax_query'] = [
 				[
 					'taxonomy' => 'module',
@@ -2298,25 +2294,14 @@ class Sensei_Core_Modules {
 	 * When a course is save make sure to reset the transient set
 	 * for it when determining the none module lessons.
 	 *
-	 * @sine 1.9.0
-	 * @param $post_id
+	 * @since 1.9.0
+	 * @deprecated 3.6.0
+	 *
+	 * @param int $post_id The post ID.
 	 */
 	public static function reset_none_modules_transient( $post_id ) {
-
-		// this should only apply to course and lesson post types
-		if ( in_array( get_post_type( $post_id ), array( 'course', 'lesson' ) ) ) {
-
-			$course_id = '';
-
-			if ( 'lesson' == get_post_type( $post_id ) ) {
-
-				$course_id = Sensei()->lesson->get_course_id( $post_id );
-
-			}
-
-		} // end if is a course or a lesson
-
-	} // end reset_none_modules_transient
+		_deprecated_function( __METHOD__, '3.6.0' );
+	}
 
 	/**
 	 * Setup the single course module loop.

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1686,13 +1686,13 @@ class Sensei_Core_Modules {
 	/**
 	 * Returns all lessons for the given module ID
 	 *
-	 * @since 1.8.0
-	 *
-	 * @param int    $course_id                  Course post ID.
-	 * @param int    $term_id                    Module term ID.
-	 * @param string $course_lessons_post_status Post status for lessons.
+	 * @param int          $course_id                  Course post ID.
+	 * @param int          $term_id                    Module term ID.
+	 * @param array|string $course_lessons_post_status Post status for lessons. Can be an array of statuses.
 	 *
 	 * @return WP_Query $lessons_query
+	 *@since 1.8.0
+	 *
 	 */
 	public function get_lessons_query( $course_id, $term_id, $course_lessons_post_status = null ) {
 		global $wp_query;
@@ -1759,13 +1759,6 @@ class Sensei_Core_Modules {
 			return $non_module_lessons;
 		}
 
-		// save some time and check if we already have the saved
-		if ( get_transient( 'sensei_' . $course_id . '_none_module_lessons' ) ) {
-
-			return get_transient( 'sensei_' . $course_id . '_none_module_lessons' );
-
-		}
-
 		// create terms array which must be excluded from other arrays
 		$course_modules = $this->get_course_modules( $course_id );
 
@@ -1811,7 +1804,6 @@ class Sensei_Core_Modules {
 
 		if ( isset( $wp_lessons_query->posts ) && count( $wp_lessons_query->posts ) > 0 ) {
 			$non_module_lessons = $wp_lessons_query->get_posts();
-			set_transient( 'sensei_' . $course_id . '_none_module_lessons', $non_module_lessons, 10 * DAY_IN_SECONDS );
 		}
 
 		return $non_module_lessons;
@@ -2357,11 +2349,6 @@ class Sensei_Core_Modules {
 
 			}
 
-			if ( ! empty( $course_id ) ) {
-
-				delete_transient( 'sensei_' . $course_id . '_none_module_lessons' );
-
-			}
 		} // end if is a course or a lesson
 
 	} // end reset_none_modules_transient

--- a/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
@@ -230,6 +230,11 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 							'description' => __( 'Lesson title', 'sensei-lms' ),
 							'type'        => 'string',
 						],
+						'draft' => [
+							'description' => __( 'Whether the lesson is currently a draft', 'sensei-lms' ),
+							'type'        => 'boolean',
+							'readOnly'    => true,
+						],
 					],
 				],
 				'module' => [

--- a/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
@@ -53,6 +53,15 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => [ $this, 'get_course_structure' ],
 					'permission_callback' => [ $this, 'can_user_get_structure' ],
+					'args'                => [
+						'context' => [
+							'type'              => 'string',
+							'default'           => 'view',
+							'enum'              => [ 'view', 'edit' ],
+							'sanitize_callback' => 'sanitize_key',
+							'validate_callback' => 'rest_validate_request_arg',
+						],
+					],
 				],
 				[
 					'methods'             => WP_REST_Server::EDITABLE,
@@ -104,7 +113,18 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 			);
 		}
 
-		return is_user_logged_in() && current_user_can( get_post_type_object( 'course' )->cap->edit_post, $course->ID );
+		return $this->can_current_user_edit_course( $course->ID );
+	}
+
+	/**
+	 * Check user permission for editing a course.
+	 *
+	 * @param int $course_id Course post ID.
+	 *
+	 * @return bool Whether the user can edit the course.
+	 */
+	private function can_current_user_edit_course( $course_id ) {
+		return is_user_logged_in() && current_user_can( get_post_type_object( 'course' )->cap->edit_post, $course_id );
 	}
 
 	/**
@@ -118,8 +138,13 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 		$course           = $this->get_course( intval( $request->get_param( 'course_id' ) ) );
 		$course_structure = Sensei_Course_Structure::instance( $course->ID );
 
+		$context = 'view';
+		if ( 'edit' === $request['context'] && $this->can_current_user_edit_course( $course->ID ) ) {
+			$context = 'edit';
+		}
+
 		$response = new WP_REST_Response();
-		$response->set_data( $course_structure->get() );
+		$response->set_data( $course_structure->get( $context ) );
 
 		return $response;
 	}
@@ -164,7 +189,7 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 		}
 
 		$response = new WP_REST_Response();
-		$response->set_data( $course_structure->get() );
+		$response->set_data( $course_structure->get( 'edit' ) );
 
 		return $response;
 	}

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
@@ -180,4 +180,103 @@ class Sensei_REST_API_Course_Structure_Controller_Tests extends WP_Test_REST_Tes
 
 		$this->assertEquals( $response->get_status(), 200 );
 	}
+
+	/**
+	 * Context data for test testGetContextParam.
+	 *
+	 * @return array
+	 */
+	public function contextData() {
+		return [
+			'guest_view'   => [ 'view', false, false ],
+			'guest_edit'   => [ 'edit', false, false ],
+			'teacher_view' => [ 'view', true, false ],
+			'teacher_edit' => [ 'edit', true, true ],
+		];
+	}
+
+	/**
+	 * Tests `GET /sensei-internal/v1/course-structure/{course_id}` with various contexts and users.
+	 *
+	 * @dataProvider contextData
+	 */
+	public function testGetContextParam( string $context, bool $has_edit_access, bool $show_unpublished ) {
+		$this->login_as_teacher();
+
+		$course_id = $this->factory->course->create(
+			[
+				'post_status' => 'publish',
+			]
+		);
+
+		$lesson_ids = $this->factory->lesson->create_many( 2 );
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+		$course_structure->save(
+			[
+				[
+					'type'    => 'module',
+					'title'   => 'Module with Draft Lesson',
+					'lessons' => [
+						[
+							'type'  => 'lesson',
+							'title' => 'Draft Lesson in Module',
+						],
+					],
+				],
+				[
+					'type'    => 'module',
+					'title'   => 'Module with Published Lesson',
+					'lessons' => [
+						[
+							'type'  => 'lesson',
+							'id'    => $lesson_ids[0],
+							'title' => get_the_title( $lesson_ids[0] ),
+						],
+					],
+				],
+				[
+					'type'  => 'lesson',
+					'title' => 'Draft Lesson outside Module',
+				],
+				[
+					'type'  => 'lesson',
+					'id'    => $lesson_ids[1],
+					'title' => get_the_title( $lesson_ids[1] ),
+				],
+			]
+		);
+
+		if ( ! $has_edit_access ) {
+			$this->logout();
+		}
+
+		$request = new WP_REST_Request( 'GET', '/sensei-internal/v1/course-structure/' . $course_id );
+		$request->set_param( 'context', $context );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_status(), 200 );
+
+		$data = $response->get_data();
+
+		if ( $show_unpublished ) {
+			$this->assertEquals( 4, count( $data ), 'Both modules and root lessons should be included' );
+			$this->assertEquals( 'module', $data[0]['type'], 'First item should be module with unpublished lesson' );
+			$this->assertEquals( 'Module with Draft Lesson', $data[0]['title'], 'First item should be module with unpublished lesson' );
+			$this->assertEquals( 'module', $data[1]['type'], 'Second item should be module with published lesson' );
+			$this->assertEquals( 'Module with Published Lesson', $data[1]['title'], 'Second item should be module with published lesson' );
+			$this->assertEquals( 'lesson', $data[2]['type'], 'Third item should be unpublished lesson at root' );
+			$this->assertFalse( in_array( $data[2]['id'], $lesson_ids, true ), 'Unpublished lesson at root should be included' );
+			$this->assertEquals( 'lesson', $data[3]['type'], 'Forth item should be published lesson at root' );
+			$this->assertEquals( $lesson_ids[1], $data[3]['id'], 'Published lesson at root should be included' );
+		} else {
+			$this->assertEquals( 2, count( $data ), 'Module with published lesson and published root lesson should be included' );
+			$this->assertEquals( 'module', $data[0]['type'], 'First item should be module with published lesson' );
+			$this->assertEquals( 'Module with Published Lesson', $data[0]['title'], 'First item should be module with published lesson' );
+			$this->assertEquals( 'lesson', $data[1]['type'], 'Second item should be published lesson at root' );
+			$this->assertEquals( $lesson_ids[1], $data[1]['id'], 'Published lesson at root should be included' );
+		}
+	}
+
 }

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -107,6 +107,41 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		$this->assertExpectedStructure( $expected_structure, $structure );
 	}
 
+
+	/**
+	 * Test getting course structure when just modules with no lessons and one rogue lesson.
+	 */
+	public function testGetModulesWithEmptyLessons() {
+		$course_id = $this->factory->course->create();
+
+		$lessons = $this->factory->lesson->create_many( 1 );
+		$modules = $this->factory->module->create_many( 2 );
+
+		$expected_structure = [
+			[
+				'type'    => 'module',
+				'id'      => $modules[1],
+				'lessons' => [],
+			],
+			[
+				'type'    => 'module',
+				'id'      => $modules[0],
+				'lessons' => [],
+			],
+			[
+				'type' => 'lesson',
+				'id'   => $lessons[0],
+			],
+		];
+
+		$this->saveStructure( $course_id, $expected_structure );
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+		$structure        = $course_structure->get();
+
+		$this->assertExpectedStructure( $expected_structure, $structure );
+	}
+
 	/**
 	 * Test getting course structure when there is a mix of modules and lessons on the first level.
 	 */


### PR DESCRIPTION
# Changes proposed in this Pull Request

* Adds `$context` parameter for `Sensei_Course_Structure::get`. When this is `view`, empty modules and draft lessons will not be included.
* Also adds `?context={view|edit}` argument for REST API endpoints. 
* Uses `edit` context in editor and `view` in frontend renderer. 
* Adds a read-only attribute on `lesson` objects in the structure for whether a lesson is in its `draft` state. I was thinking just putting the post status, but with all the variations this seemed to be what we really want.

Fixes and refactors:
* Removes caching in helper method for getting lessons not associated with modules. Cache would have been polluted since https://github.com/Automattic/sensei/commit/b4ddd9dfec0f7c45d5d2d6e430753e367b2878c7 as it didn't factor in post status argument.
* Adds some missing tests for the `POST` course structure endpoint.
* Removes check to see if fetching modules is necessary. I think it almost always is. (originally in #3618).
* Fixes lesson ordering bug where new lessons weren't getting ordered correctly.
* Refactors `Sensei_Core_Modules::get_none_module_lessons` to use `Sensei_Course::course_lessons`. Fixes unnecessary double queries and always returns lessons in the correct order. 

### Testing instructions

* In editor, ensure empty modules and unpublished lessons appear.
* On frontend, when viewing a course, empty modules and unpublished lessons should not be displayed.

### Deprecated Methods
- `\Sensei_Core_Modules::reset_none_modules_transient`