### PR TITLE
Close unordered list element in sensei_course_categories shortcode

### DIFF
--- a/includes/shortcodes/class-sensei-shortcode-course-categories.php
+++ b/includes/shortcodes/class-sensei-shortcode-course-categories.php
@@ -107,7 +107,7 @@ class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 			$terms_html   .= '<li class="sensei course-category" >' . $category_link . '</li>';
 
 		}
-		$terms_html .= '<ul>';
+		$terms_html .= '</ul>';
 
 		return $terms_html;
 


### PR DESCRIPTION
Fixes #3562.

Duplicate of #3611, but merging into the 3.5.2 branch instead of `master`.