### PR TITLE
Fix Course Outline block for Wordpress 5.3

### DIFF
--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -1,0 +1,45 @@
+
+.edit-post-visual-editor {
+	.wp-block-sensei-lms-course-outline {
+		&__clean-input[type='text'] {
+			display: block;
+			width: 100%;
+			padding: 0;
+			margin: 0;
+			box-shadow: none;
+			font-family: inherit;
+			font-size: inherit;
+			color: inherit;
+			line-height: inherit;
+			border: none;
+			background-color: transparent;
+
+			&:focus {
+				border: none;
+				outline: none;
+				box-shadow: none;
+				color: inherit;
+			}
+		}
+
+		.block-editor-block-list__block {
+			margin-top: 0;
+			margin-bottom: 0;
+		}
+	}
+
+	.wp-block-sensei-lms-course-outline-lesson {
+
+		&__edit {
+			flex: 0 0 auto;
+		}
+
+		&__unsaved {
+			font-size: 12px;
+			font-weight: bold;
+			background: #DCDCDE;
+			padding: 0 10px;
+			border-radius: 6px;
+		}
+	}
+}

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -1,25 +1,6 @@
 $dark-gray: #1a1d20;
 
 .wp-block-sensei-lms-course-outline {
-	&__clean-input[type='text'] {
-		display: block;
-		width: 100%;
-		padding: 0;
-		margin: 0;
-		box-shadow: none;
-		font-family: inherit;
-		font-size: inherit;
-		color: inherit;
-		line-height: inherit;
-		border: none;
-		background-color: transparent;
-
-		&:focus {
-			border: none;
-			outline: none;
-			box-shadow: none;
-		}
-	}
 
 	&__clean-heading {
 		padding: 0;
@@ -28,12 +9,11 @@ $dark-gray: #1a1d20;
 		font-size: inherit;
 		color: inherit;
 		line-height: inherit;
+		&:before, &:after {
+			content: none;
+		}
 	}
 
-	.block-editor-block-list__block {
-		margin-top: 0;
-		margin-bottom: 0;
-	}
 }
 
 .wp-block-sensei-lms-course-outline-module {
@@ -84,16 +64,7 @@ $dark-gray: #1a1d20;
 		border-radius: 50%;
 	}
 
-	&__edit {
-		flex: 0 0 auto;
-	}
-	&__unsaved {
-		font-size: 12px;
-		font-weight: bold;
-		background: #DCDCDE;
-		padding: 0 10px;
-		border-radius: 6px;
-	}
+
 }
 
 /**

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -17,7 +17,8 @@ class Sensei_Course_Outline_Block {
 	 * Sensei_Course_Outline_Block constructor.
 	 */
 	public function __construct() {
-		add_action( 'enqueue_block_assets', [ $this, 'enqueue_assets' ] );
+		add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
 		add_action( 'init', [ $this, 'register_course_template' ], 101 );
 		add_action( 'init', [ $this, 'register_block' ] );
 	}
@@ -27,13 +28,18 @@ class Sensei_Course_Outline_Block {
 	 *
 	 * @access private
 	 */
-	public function enqueue_assets() {
-		if ( 'course' !== get_post_type() ) {
-			return;
-		}
+	public function enqueue_block_assets() {
+		Sensei()->assets->enqueue( 'sensei-course-outline', 'blocks/course-outline/style.css' );
+	}
 
-		Sensei()->assets->enqueue( 'sensei-course-outline-script', 'blocks/course-outline/index.js' );
-		Sensei()->assets->enqueue( 'sensei-course-outline-style', 'blocks/course-outline/style.css' );
+	/**
+	 * Enqueue editor assets.
+	 *
+	 * @access private
+	 */
+	public function enqueue_block_editor_assets() {
+		Sensei()->assets->enqueue( 'sensei-course-outline', 'blocks/course-outline/index.js' );
+		Sensei()->assets->enqueue( 'sensei-course-outline-editor', 'blocks/course-outline/style.editor.css' );
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,7 @@ const files = [
 	'data-port/style.scss',
 	'blocks/course-outline/index.js',
 	'blocks/course-outline/style.scss',
+	'blocks/course-outline/style.editor.scss',
 
 	'css/frontend.scss',
 	'css/admin-custom.css',


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Add more specificity to some editor styles so they take override the defaults and look as intentend
* Separate editor styles and don't load editor CSS and JS on the frontend.

### Testing instructions

* Open a course for editing on a Wordpress 5.3 site
* Ensure the outline block looks and works mostly like on newer versions

