### PR TITLE
Fix undo when using Outline block

### DIFF
--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -46,7 +46,9 @@ export const syncStructureToBlocks = ( structure, blocks, attributeMap ) => {
 		if ( item.id ) {
 			attributes = {
 				...attributes,
-				...( attributeMap[ `${ type }-${ item.id }` ] || {} ),
+				...( ( attributeMap &&
+					attributeMap[ `${ type }-${ item.id }` ] ) ||
+					{} ),
 			};
 		}
 		if ( ! block ) {

--- a/assets/blocks/course-outline/edit.js
+++ b/assets/blocks/course-outline/edit.js
@@ -22,8 +22,7 @@ const EditCourseOutlineBlock = ( {
 	structure,
 	setAttributes,
 } ) => {
-	const { setBlocks } = useBlocksCreator( clientId );
-
+	const { setBlockStructure } = useBlocksCreator( clientId );
 	const { getBlocks } = useSelect(
 		( select ) => select( 'core/block-editor' ),
 		[]
@@ -51,14 +50,14 @@ const EditCourseOutlineBlock = ( {
 
 	useEffect( () => {
 		if ( structure && structure.length ) {
-			setBlocks( structure );
+			setBlockStructure( structure );
 		}
-	}, [ structure, setBlocks ] );
+	}, [ structure, setBlockStructure ] );
 
 	if ( isEmpty ) {
 		return (
 			<CourseOutlinePlaceholder
-				addBlock={ ( type ) => setBlocks( [ { type } ] ) }
+				addBlock={ ( type ) => setBlockStructure( [ { type } ] ) }
 			/>
 		);
 	}

--- a/assets/blocks/course-outline/edit.js
+++ b/assets/blocks/course-outline/edit.js
@@ -1,10 +1,11 @@
 import { InnerBlocks } from '@wordpress/block-editor';
-import { useSelect, withSelect } from '@wordpress/data';
-import { useEffect } from '@wordpress/element';
+import { useDispatch, useSelect, withSelect } from '@wordpress/data';
+import { useCallback, useEffect } from '@wordpress/element';
 import { extractStructure, getChildBlockAttributes } from './data';
 import { CourseOutlinePlaceholder } from './placeholder';
 import { COURSE_STORE } from './store';
 import { useBlocksCreator } from './use-block-creator';
+import { useSavePost } from './use-save-post';
 
 /**
  * Edit course outline block component.
@@ -23,17 +24,24 @@ const EditCourseOutlineBlock = ( {
 } ) => {
 	const { setBlocks } = useBlocksCreator( clientId );
 
-	const blocks = useSelect(
-		( select ) => select( 'core/block-editor' ).getBlocks( clientId ),
-		[ clientId ]
+	const { getBlocks } = useSelect(
+		( select ) => select( 'core/block-editor' ),
+		[]
 	);
 
-	useEffect( () => {
-		if ( blocks.length )
-			setAttributes( {
-				blocks: getChildBlockAttributes( extractStructure( blocks ) ),
-			} );
-	}, [ setAttributes, blocks ] );
+	const { save: saveStructure } = useDispatch( COURSE_STORE );
+
+	const saveChildAttributes = useCallback( () => {
+		const childBlockAttributes = getChildBlockAttributes(
+			extractStructure( getBlocks( clientId ) )
+		);
+		setAttributes( {
+			blocks: childBlockAttributes,
+		} );
+	}, [ setAttributes, clientId, getBlocks ] );
+
+	useSavePost( saveChildAttributes );
+	useSavePost( saveStructure );
 
 	const isEmpty = useSelect(
 		( select ) =>

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -1,5 +1,5 @@
+import { dispatch, registerStore, select } from '@wordpress/data';
 import { apiFetch, controls as dataControls } from '@wordpress/data-controls';
-import { dispatch, registerStore, select, subscribe } from '@wordpress/data';
 import { createReducerFromActionMap } from '../../shared/data/store-helpers';
 
 const DEFAULT_STATE = {
@@ -90,16 +90,6 @@ export const COURSE_STORE = 'sensei/course-structure';
  * Register course structure store and subscribe to block editor save.
  */
 const registerCourseStructureStore = () => {
-	subscribe( () => {
-		const editor = select( 'core/editor' );
-
-		if ( ! editor ) return;
-
-		if ( editor.isSavingPost() && ! editor.isAutosavingPost() ) {
-			dispatch( COURSE_STORE ).save();
-		}
-	} );
-
 	registerStore( COURSE_STORE, {
 		reducer: createReducerFromActionMap( reducers, DEFAULT_STATE ),
 		actions,

--- a/assets/blocks/course-outline/use-block-creator.js
+++ b/assets/blocks/course-outline/use-block-creator.js
@@ -16,7 +16,7 @@ export const useBlocksCreator = ( clientId ) => {
 		[]
 	);
 
-	const setBlocks = useCallback(
+	const setBlockStructure = useCallback(
 		( blockData ) => {
 			const block = getBlock( clientId );
 			replaceInnerBlocks(
@@ -32,5 +32,5 @@ export const useBlocksCreator = ( clientId ) => {
 		[ clientId, replaceInnerBlocks, getBlock ]
 	);
 
-	return { setBlocks };
+	return { setBlockStructure };
 };

--- a/assets/blocks/course-outline/use-save-post.js
+++ b/assets/blocks/course-outline/use-save-post.js
@@ -1,0 +1,39 @@
+import { dispatch } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
+
+let listeners = [];
+let savePost;
+
+/**
+ * Wrap core/editor savePost action to run registered callbacks before saving.
+ */
+function setupSavePostHook() {
+	if ( savePost ) return;
+	const editor = dispatch( 'core/editor' );
+	savePost = editor.savePost;
+
+	editor.savePost = () => {
+		listeners.forEach( ( callback ) => callback() );
+		savePost();
+	};
+}
+
+/**
+ * Add a callback to be run before saving the post.
+ *
+ * @param {Function} callback Function to call when saving.
+ */
+export function useSavePost( callback ) {
+	useEffect( () => {
+		setupSavePostHook();
+
+		const callbackwp = () => {
+			callback();
+		};
+		listeners.push( callbackwp );
+
+		return () => {
+			listeners = listeners.filter( ( item ) => item !== callbackwp );
+		};
+	}, [ callback ] );
+}


### PR DESCRIPTION

The current way of setting inner block attributes on the parent block breaks all Undo/Redo functionality in the editor. Oops.

### Changes proposed in this Pull Request

* Add a different method to hook into saving the post, to be able to run things before
* Only update Outline block with inner block attributes before saving 

### Testing instructions

* Check that Outline block works as before, and changed saved are visible on the frontend
* Check that undo/redo works in the editor while an Outline block is in there 
