### PR TITLE
Extract inner block attributes on server-side 

### DIFF
--- a/assets/blocks/course-outline/course-outline-block.js
+++ b/assets/blocks/course-outline/course-outline-block.js
@@ -1,5 +1,6 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
+import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import { extractStructure } from './data';
 
@@ -20,9 +21,6 @@ registerBlockType( 'sensei-lms/course-outline', {
 		id: {
 			type: 'int',
 		},
-		blocks: {
-			type: 'object',
-		},
 	},
 	edit( props ) {
 		return <EditCourseOutlineBlock { ...props } />;
@@ -31,6 +29,6 @@ registerBlockType( 'sensei-lms/course-outline', {
 		dispatch( COURSE_STORE ).setEditorStructure(
 			extractStructure( innerBlocks )
 		);
-		return null;
+		return <InnerBlocks.Content />;
 	},
 } );

--- a/assets/blocks/course-outline/data.test.js
+++ b/assets/blocks/course-outline/data.test.js
@@ -101,7 +101,7 @@ describe( 'syncStructureToBlocks', () => {
 			},
 		];
 
-		const newBlocks = syncStructureToBlocks( changed, blocks, [] );
+		const newBlocks = syncStructureToBlocks( changed, blocks );
 
 		expect( newBlocks ).toEqual( [
 			{

--- a/assets/blocks/course-outline/edit.js
+++ b/assets/blocks/course-outline/edit.js
@@ -1,7 +1,6 @@
 import { InnerBlocks } from '@wordpress/block-editor';
 import { useSelect, withSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
-import { extractStructure, getChildBlockAttributes } from './data';
 import { CourseOutlinePlaceholder } from './placeholder';
 import { COURSE_STORE } from './store';
 import { useBlocksCreator } from './use-block-creator';
@@ -9,31 +8,13 @@ import { useBlocksCreator } from './use-block-creator';
 /**
  * Edit course outline block component.
  *
- * @param {Object}   props               Component props.
- * @param {string}   props.clientId      Block client ID.
- * @param {string}   props.className     Custom class name.
- * @param {Object[]} props.structure     Course module and lesson blocks
- * @param {Function} props.setAttributes
+ * @param {Object}   props           Component props.
+ * @param {string}   props.clientId  Block client ID.
+ * @param {string}   props.className Custom class name.
+ * @param {Object[]} props.structure Course module and lesson blocks
  */
-const EditCourseOutlineBlock = ( {
-	clientId,
-	className,
-	structure,
-	setAttributes,
-} ) => {
+const EditCourseOutlineBlock = ( { clientId, className, structure } ) => {
 	const { setBlocks } = useBlocksCreator( clientId );
-
-	const blocks = useSelect(
-		( select ) => select( 'core/block-editor' ).getBlocks( clientId ),
-		[ clientId ]
-	);
-
-	useEffect( () => {
-		if ( blocks.length )
-			setAttributes( {
-				blocks: getChildBlockAttributes( extractStructure( blocks ) ),
-			} );
-	}, [ setAttributes, blocks ] );
 
 	const isEmpty = useSelect(
 		( select ) =>

--- a/assets/blocks/course-outline/lesson-block/index.js
+++ b/assets/blocks/course-outline/lesson-block/index.js
@@ -25,4 +25,7 @@ registerBlockType( 'sensei-lms/course-outline-lesson', {
 	edit( props ) {
 		return <EditLessonBlock { ...props } />;
 	},
+	save( { className } ) {
+		return <div className={ className } />;
+	},
 } );

--- a/assets/blocks/course-outline/module-block/index.js
+++ b/assets/blocks/course-outline/module-block/index.js
@@ -1,3 +1,4 @@
+import { InnerBlocks } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
 
@@ -29,5 +30,12 @@ registerBlockType( 'sensei-lms/course-outline-module', {
 	},
 	edit( props ) {
 		return <EditModuleBlock { ...props } />;
+	},
+	save( { className } ) {
+		return (
+			<div className={ className }>
+				<InnerBlocks.Content />
+			</div>
+		);
 	},
 } );

--- a/assets/blocks/course-outline/use-block-creator.js
+++ b/assets/blocks/course-outline/use-block-creator.js
@@ -11,25 +11,21 @@ import { syncStructureToBlocks } from './data';
 export const useBlocksCreator = ( clientId ) => {
 	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
 
-	const { getBlock } = useSelect(
+	const { getBlocks } = useSelect(
 		( select ) => select( 'core/block-editor' ),
 		[]
 	);
 
 	const setBlocks = useCallback(
 		( blockData ) => {
-			const block = getBlock( clientId );
+			const blocks = getBlocks( clientId );
 			replaceInnerBlocks(
 				clientId,
-				syncStructureToBlocks(
-					blockData,
-					block.innerBlocks || [],
-					block.attributes.blocks
-				),
+				syncStructureToBlocks( blockData, blocks ),
 				false
 			);
 		},
-		[ clientId, replaceInnerBlocks, getBlock ]
+		[ clientId, replaceInnerBlocks, getBlocks ]
 	);
 
 	return { setBlocks };

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -72,7 +72,7 @@ class Sensei_Course_Outline_Block {
 				'render_callback' => [ $this, 'render_course_outline' ],
 				'attributes'      => [
 					'id' => [
-						'type' => 'int',
+						'type' => 'number',
 					],
 				],
 			]
@@ -84,7 +84,7 @@ class Sensei_Course_Outline_Block {
 				'render_callback' => [ $this, 'process_lesson_block' ],
 				'attributes'      => [
 					'id' => [
-						'type' => 'int',
+						'type' => 'number',
 					],
 				],
 			]
@@ -96,7 +96,7 @@ class Sensei_Course_Outline_Block {
 				'render_callback' => [ $this, 'process_module_block' ],
 				'attributes'      => [
 					'id' => [
-						'type' => 'int',
+						'type' => 'number',
 					],
 				],
 			]

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -168,7 +168,7 @@ class Sensei_Course_Outline_Block {
 			$block_class .= ' ' . $attributes['className'];
 		}
 
-		return '		
+		return '
 			<section class="' . $block_class . '">
 				' .
 			implode(
@@ -196,6 +196,7 @@ class Sensei_Course_Outline_Block {
 	 *
 	 * @param array $block Block information.
 	 *
+	 * @access private
 	 * @return string Lesson HTML
 	 */
 	public function render_lesson_block( $block ) {
@@ -211,6 +212,7 @@ class Sensei_Course_Outline_Block {
 	 *
 	 * @param array $block Block information.
 	 *
+	 * @access private
 	 * @return string Module HTML
 	 */
 	public function render_module_block( $block ) {

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -69,7 +69,7 @@ class Sensei_Course_Outline_Block {
 		register_block_type(
 			'sensei-lms/course-outline',
 			[
-				'render_callback' => [ $this, 'render_callback' ],
+				'render_callback' => [ $this, 'render_course_outline' ],
 				'attributes'      => [
 					'id' => [
 						'type' => 'int',
@@ -81,7 +81,7 @@ class Sensei_Course_Outline_Block {
 		register_block_type(
 			'sensei-lms/course-outline-lesson',
 			[
-				'render_callback' => [ $this, 'render_lesson' ],
+				'render_callback' => [ $this, 'process_lesson_block' ],
 				'attributes'      => [
 					'id' => [
 						'type' => 'int',
@@ -93,7 +93,7 @@ class Sensei_Course_Outline_Block {
 		register_block_type(
 			'sensei-lms/course-outline-module',
 			[
-				'render_callback' => [ $this, 'render_module' ],
+				'render_callback' => [ $this, 'process_module_block' ],
 				'attributes'      => [
 					'id' => [
 						'type' => 'int',
@@ -110,8 +110,8 @@ class Sensei_Course_Outline_Block {
 	 *
 	 * @return string
 	 */
-	public function render_lesson( $attributes ) {
-		$block_attributes['lesson'][ $attributes['id'] ] = $attributes;
+	public function process_lesson_block( $attributes ) {
+		$this->block_attributes['lesson'][ $attributes['id'] ] = $attributes;
 		return '';
 	}
 
@@ -122,8 +122,8 @@ class Sensei_Course_Outline_Block {
 	 *
 	 * @return string
 	 */
-	public function render_module( $attributes ) {
-		$block_attributes['module'][ $attributes['id'] ] = $attributes;
+	public function process_module_block( $attributes ) {
+		$this->block_attributes['module'][ $attributes['id'] ] = $attributes;
 		return '';
 	}
 

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -199,7 +199,7 @@ class Sensei_Course_Outline_Block {
 	 * @access private
 	 * @return string Lesson HTML
 	 */
-	public function render_lesson_block( $block ) {
+	protected function render_lesson_block( $block ) {
 		return '
 			<a class="wp-block-sensei-lms-course-outline-lesson" href="#">
 				' . $block['title'] . '
@@ -215,7 +215,7 @@ class Sensei_Course_Outline_Block {
 	 * @access private
 	 * @return string Module HTML
 	 */
-	public function render_module_block( $block ) {
+	protected function render_module_block( $block ) {
 		if ( empty( $block['lessons'] ) ) {
 			return '';
 		}

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -69,7 +69,7 @@ class Sensei_Course_Outline_Block {
 		register_block_type(
 			'sensei-lms/course-outline',
 			[
-				'render_callback' => [ $this, 'render_course_outline' ],
+				'render_callback' => [ $this, 'render_course_outline_block' ],
 				'attributes'      => [
 					'id' => [
 						'type' => 'number',
@@ -107,7 +107,7 @@ class Sensei_Course_Outline_Block {
 	 * Extract attributes from module block.
 	 *
 	 * @param array $attributes
-	 *
+	 * @access private
 	 * @return string
 	 */
 	public function process_lesson_block( $attributes ) {
@@ -119,7 +119,7 @@ class Sensei_Course_Outline_Block {
 	 * Extract attributes from module block.
 	 *
 	 * @param array $attributes
-	 *
+	 * @access private
 	 * @return string
 	 */
 	public function process_module_block( $attributes ) {
@@ -138,7 +138,9 @@ class Sensei_Course_Outline_Block {
 		}
 		foreach ( $structure as &$block ) {
 			$block['attributes'] = $this->block_attributes[ $block['type'] ][ $block['id'] ] ?? [];
-			self::add_block_attributes( $block['lessons'] );
+			if ( ! empty( $block['lessons'] ) ) {
+				self::add_block_attributes( $block['lessons'] );
+			}
 		}
 	}
 
@@ -151,7 +153,7 @@ class Sensei_Course_Outline_Block {
 	 *
 	 * @return string Block HTML.
 	 */
-	public function render_course_outline( $attributes ) {
+	public function render_course_outline_block( $attributes ) {
 
 		global $post;
 
@@ -174,11 +176,11 @@ class Sensei_Course_Outline_Block {
 				array_map(
 					function( $block ) {
 						if ( 'module' === $block['type'] ) {
-							return $this->get_module_block_html( $block );
+							return $this->render_module_block( $block );
 						}
 
 						if ( 'lesson' === $block['type'] ) {
-							return $this->get_lesson_block_html( $block );
+							return $this->render_lesson_block( $block );
 						}
 					},
 					$structure
@@ -196,7 +198,7 @@ class Sensei_Course_Outline_Block {
 	 *
 	 * @return string Lesson HTML
 	 */
-	private function get_lesson_block_html( $block ) {
+	public function render_lesson_block( $block ) {
 		return '
 			<a class="wp-block-sensei-lms-course-outline-lesson" href="#">
 				' . $block['title'] . '
@@ -211,7 +213,7 @@ class Sensei_Course_Outline_Block {
 	 *
 	 * @return string Module HTML
 	 */
-	private function get_module_block_html( $block ) {
+	public function render_module_block( $block ) {
 		if ( empty( $block['lessons'] ) ) {
 			return '';
 		}
@@ -230,7 +232,7 @@ class Sensei_Course_Outline_Block {
 			implode(
 				'',
 				array_map(
-					[ $this, 'get_lesson_block_html' ],
+					[ $this, 'render_lesson_block' ],
 					$block['lessons']
 				)
 			)

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -58,7 +58,7 @@ class Sensei_Course_Structure {
 	 *
 	 * @return array
 	 */
-	public function get() : array {
+	public function get() {
 		$structure = [];
 
 		$all_lessons       = Sensei()->course->course_lessons( $this->course_id, 'any', 'ids' );
@@ -138,7 +138,7 @@ class Sensei_Course_Structure {
 	 *
 	 * @return WP_Term[]
 	 */
-	private function get_modules() : array {
+	private function get_modules() {
 		$modules = Sensei()->modules->get_course_modules( $this->course_id );
 
 		if ( is_wp_error( $modules ) ) {
@@ -471,7 +471,7 @@ class Sensei_Course_Structure {
 	 *     @type array $2 $module_titles All the module titles.
 	 * }
 	 */
-	private function flatten_structure( array $structure ) : array {
+	private function flatten_structure( array $structure ) {
 		$lesson_ids    = [];
 		$module_ids    = [];
 		$module_titles = [];

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -137,5 +137,8 @@ class Sensei_Unit_Tests_Bootstrap {
 		return self::$instance;
 	}
 }
+
+define( 'SENSEI_FEATURE_FLAG_COURSE_OUTLINE', true );
+
 Sensei_Unit_Tests_Bootstrap::instance();
 

--- a/tests/unit-tests/sample-data/outline-block-post-content.html
+++ b/tests/unit-tests/sample-data/outline-block-post-content.html
@@ -1,0 +1,25 @@
+<!-- wp:sensei-lms/course-outline -->
+	<!-- wp:sensei-lms/course-outline-module {"id":1,"title":"Test Module 1","description":"Module description 1"} -->
+	<div class="wp-block-sensei-lms-course-outline-module">
+		<!-- wp:sensei-lms/course-outline-lesson {"id":1,"title":"Module 1 Lesson 1"} -->
+			<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+		<!-- /wp:sensei-lms/course-outline-lesson -->
+		<!-- wp:sensei-lms/course-outline-lesson {"id":2,"title":"Module 1 Lesson 2"} -->
+			<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+		<!-- /wp:sensei-lms/course-outline-lesson -->
+		<!-- wp:sensei-lms/course-outline-lesson {"id":3,"title":"Module 1 Lesson 3"} -->
+		<div class="wp-block-sensei-lms-course-outline-lesson"></div><!-- /wp:sensei-lms/course-outline-lesson -->
+	</div>
+	<!-- /wp:sensei-lms/course-outline-module -->
+
+	<!-- wp:sensei-lms/course-outline-module {"id":2,"title":"Test Module 2","description":"Module description 2"} -->
+	<div class="wp-block-sensei-lms-course-outline-module">
+		<!-- wp:sensei-lms/course-outline-lesson {"id":4,"title":"Module 2 Lesson 4"} -->
+			<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+		<!-- /wp:sensei-lms/course-outline-lesson --> </div>
+	<!-- /wp:sensei-lms/course-outline-module -->
+
+	<!-- wp:sensei-lms/course-outline-lesson {"id":5,"title":"Standalone Lesson 5"} -->
+		<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+	<!-- /wp:sensei-lms/course-outline-lesson -->
+<!-- /wp:sensei-lms/course-outline -->

--- a/tests/unit-tests/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/test-class-sensei-course-outline-block.php
@@ -96,13 +96,13 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 		$mock->expects( $this->once() )->method( 'render_lesson_block' )->with(
 			$this->equalTo(
 				[
-					'id'    => 1,
-					'type'  => 'lesson',
-					'title' => 'Test Lesson',
+					'id'         => 1,
+					'type'       => 'lesson',
+					'title'      => 'Test Lesson',
 					'attributes' => [
 						'id'    => 1,
 						'style' => 'blue',
-					]
+					],
 				]
 			)
 		);

--- a/tests/unit-tests/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/test-class-sensei-course-outline-block.php
@@ -124,11 +124,12 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 				'innerContent' => [ [] ],
 				'innerBlocks'  => [
 					[
-						'blockName' => 'sensei-lms/course-outline-lesson',
-						'attrs'     => [
+						'blockName'    => 'sensei-lms/course-outline-lesson',
+						'attrs'        => [
 							'id'    => 1,
 							'style' => 'blue',
 						],
+						'innerContent' => [],
 					],
 				],
 			]

--- a/tests/unit-tests/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/test-class-sensei-course-outline-block.php
@@ -1,0 +1,160 @@
+<?php
+
+/**
+ * Tests for Sensei_Course_Outline_Block class.
+ *
+ * @group course-structure
+ */
+class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->factory = new Sensei_Factory();
+
+	}
+
+	/**
+	 * Test the course structure is used for rendering.
+	 */
+	public function testBlockRendered() {
+		$post_content = file_get_contents( 'sample-data/outline-block-post-content.html', true );
+
+		$this->mockPostCourseStructure( [] );
+		$result = do_blocks( $post_content );
+
+		$this->assertDiscardWhitespace( '<section class="wp-block-sensei-lms-course-outline"></section>', $result );
+	}
+
+	/**
+	 * Test lesson in the structure is rendered.
+	 */
+	public function testLessonsRendered() {
+		$post_content = file_get_contents( 'sample-data/outline-block-post-content.html', true );
+
+		$this->mockPostCourseStructure(
+			[
+				[
+					'id'    => 1,
+					'type'  => 'lesson',
+					'title' => 'Test Lesson',
+				],
+			]
+		);
+		$result = do_blocks( $post_content );
+
+		$this->assertContains( 'Test Lesson', $result );
+	}
+
+
+	/**
+	 * Test module with a lesson in the structure is rendered.
+	 */
+	public function testModulesRendered() {
+		$post_content = file_get_contents( 'sample-data/outline-block-post-content.html', true );
+
+		$this->mockPostCourseStructure(
+			[
+				[
+					'id'          => 1,
+					'type'        => 'module',
+					'title'       => 'Test Module',
+					'description' => 'Module description',
+					'lessons'     => [
+						[
+							'id'    => 1,
+							'type'  => 'lesson',
+							'title' => 'Test Lesson',
+						],
+					],
+				],
+			]
+		);
+		$result = do_blocks( $post_content );
+
+		$this->assertContains( 'Test Module', $result );
+		$this->assertContains( 'Module description', $result );
+		$this->assertContains( 'Test Lesson', $result );
+	}
+
+	/**
+	 * Test that attributes parsed from the block are passed over to the dynamic render function.
+	 */
+	public function testBlockAttributesMatched() {
+
+		unregister_block_type( 'sensei-lms/course-outline' );
+		unregister_block_type( 'sensei-lms/course-outline-lesson' );
+		unregister_block_type( 'sensei-lms/course-outline-module' );
+
+		$mock = $this->getMockBuilder( Sensei_Course_Outline_Block::class )
+			->setMethods( [ 'render_lesson_block' ] )
+			->getMock();
+
+		$mock->expects( $this->once() )->method( 'render_lesson_block' )->with(
+			$this->equalTo(
+				[
+					'id'    => 1,
+					'type'  => 'lesson',
+					'title' => 'Test Lesson',
+					'attributes' => [
+						'id'    => 1,
+						'style' => 'blue',
+					]
+				]
+			)
+		);
+
+		$mock->register_blocks();
+
+		$this->mockPostCourseStructure(
+			[
+				[
+					'id'    => 1,
+					'type'  => 'lesson',
+					'title' => 'Test Lesson',
+				],
+			]
+		);
+		render_block(
+			[
+				'blockName'    => 'sensei-lms/course-outline',
+				'attrs'        => [ 'id' => 1 ],
+				'innerContent' => [ [] ],
+				'innerBlocks'  => [
+					[
+						'blockName' => 'sensei-lms/course-outline-lesson',
+						'attrs'     => [
+							'id'    => 1,
+							'style' => 'blue',
+						],
+					],
+				],
+			]
+		);
+	}
+
+
+	/**
+	 * Mock global post ID and its course structure.
+	 *
+	 * @param array $structure
+	 */
+	private function mockPostCourseStructure( $structure = [] ) {
+
+		$GLOBALS['post'] = (object) [ 'ID' => 0 ];
+
+		$mock = $this->getMockBuilder( Sensei_Course_Structure::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get' ] )
+			->getMock();
+
+		$mock->method( 'get' )->willReturn( $structure );
+
+		$instances = new ReflectionProperty( Sensei_Course_Structure::class, 'instances' );
+		$instances->setAccessible( true );
+		$instances->setValue( [ 0 => $mock ] );
+	}
+}

--- a/tests/unit-tests/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/test-class-sensei-course-outline-block.php
@@ -6,7 +6,6 @@
  * @group course-structure
  */
 class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
-	use Sensei_Test_Login_Helpers;
 
 	/**
 	 * Set up the test.


### PR DESCRIPTION
Replaces #3615, #3624

Turns out the inner block attributes are available in PHP when they are registered with a `render_callback`. This is a lot less messy than the previous approaches.

### Changes proposed in this Pull Request

* Register the module, lesson block in PHP, and save their attributes in their render_callback
* Assign these attributes to the module and lesson items in course structure during the Outline block rendering.

### Testing instructions

* Not much, this will be used in #3620 and other block customization PRs

