### PR TITLE
Include category in heading for sensei_courses shortcode when filtering by category

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3210,16 +3210,15 @@ class Sensei_Course {
 			return;
 		}
 
-		$category_slug = get_query_var( 'course-category' );
-		$term          = get_term_by( 'slug', $category_slug, 'course-category' );
+		$term = get_queried_object();
 
 		if ( ! empty( $term ) ) {
 
-			$title = __( 'Category', 'sensei-lms' ) . ' ' . $term->name;
+			$title = __( 'Course Category:', 'sensei-lms' ) . ' ' . $term->name;
 
 		} else {
 
-			$title = 'Course Category';
+			$title = __( 'Course Category', 'sensei-lms' );
 
 		}
 

--- a/includes/shortcodes/class-sensei-shortcode-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-courses.php
@@ -42,7 +42,7 @@ class Sensei_Shortcode_Courses implements Sensei_Shortcode_Interface {
 	protected $order;
 
 	/**
-	 * @var category can be completed or active or all
+	 * @var int|string course category id, slug or name
 	 */
 	protected $category;
 
@@ -57,7 +57,7 @@ class Sensei_Shortcode_Courses implements Sensei_Shortcode_Interface {
 	protected $ids;
 
 	/**
-	 * @var exclude courses by id
+	 * @var string csv of course ids
 	 */
 	protected $exclude;
 


### PR DESCRIPTION
Fixes #3532. Duplicate of #3612, but merging into the 3.5.2 branch instead of `master`.

### Changes proposed in this Pull Request

* Included category name in the heading for sensei_courses shortcode when filtering by category. The heading format is `Course Category: {category name }`
* Fixed `PHP Notice:  Trying to get property 'term_id' of non-object in /srv/www/sensei.test/public_html/wp-content/plugins/sensei/includes/class-sensei-course.php on line 3230` when viewing shortcode
* Corrected some document comments