### PR TITLE
Create quiz when creating empty lesson in course structure

### DIFF
--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -420,7 +420,31 @@ class Sensei_Course_Structure {
 			return false;
 		}
 
+		$this->create_quiz( $post_id );
+
 		return $post_id;
+	}
+
+	/**
+	 * Create an empty quiz for the lesson.
+	 *
+	 * @param int $lesson_id Lesson ID to create quiz for.
+	 */
+	private function create_quiz( int $lesson_id ) {
+		$lesson = get_post( $lesson_id );
+
+		$post_args = [
+			'post_content' => '',
+			'post_status'  => $lesson->post_status,
+			'post_title'   => $lesson->post_title,
+			'post_type'    => 'quiz',
+			'post_parent'  => $lesson_id,
+			'meta_input'   => [
+				'_quiz_lesson' => $lesson_id,
+			],
+		];
+
+		wp_insert_post( $post_args );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -313,6 +313,13 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		$this->assertEquals( 'lesson', $first_item['type'], 'Course should have one lesson object' );
 		$this->assertEquals( 'lesson', get_post_type( $first_item['id'] ), 'Created post should be a lesson' );
 		$this->assertEquals( $new_structure[0]['title'], $first_item['title'], 'New title should match' );
+
+		$quiz_id = Sensei()->lesson->lesson_quizzes( $first_item['id'] );
+		$this->assertTrue( ! empty( $quiz_id ), 'A quiz should have been created for the lesson' );
+
+		$quiz = get_post( $quiz_id );
+		$this->assertEquals( $first_item['id'], $quiz->post_parent, 'Quiz post parent should be set to lesson' );
+		$this->assertEquals( $first_item['title'], $quiz->post_title, 'Quiz post title should be set to be the same as the lesson' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Creates a quiz alongside the draft lesson. This prevents one save in the editor before having access to the quiz.

### Testing instructions

* From course outline block, add a new lesson. Save the post.
* Go in to edit the post. Ensure the quiz settings/question editor appear with their default settings.