### PR TITLE
Add outline block icons

### DIFF
--- a/assets/blocks/course-outline/course-outline-block.js
+++ b/assets/blocks/course-outline/course-outline-block.js
@@ -2,6 +2,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import { dispatch } from '@wordpress/data';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { CourseIcon } from '../../icons';
 import { extractStructure } from './data';
 
 import EditCourseOutlineBlock from './edit';
@@ -10,7 +11,7 @@ import { COURSE_STORE } from './store';
 registerBlockType( 'sensei-lms/course-outline', {
 	title: __( 'Course Outline', 'sensei-lms' ),
 	description: __( 'Manage your Sensei LMS course outline.', 'sensei-lms' ),
-	icon: 'list-view',
+	icon: CourseIcon,
 	category: 'sensei-lms',
 	keywords: [ __( 'Outline', 'sensei-lms' ), __( 'Course', 'sensei-lms' ) ],
 	supports: {

--- a/assets/blocks/course-outline/lesson-block/index.js
+++ b/assets/blocks/course-outline/lesson-block/index.js
@@ -1,11 +1,12 @@
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import { LessonIcon } from '../../../icons';
 import EditLessonBlock from './edit';
 
 registerBlockType( 'sensei-lms/course-outline-lesson', {
 	title: __( 'Lesson', 'sensei-lms' ),
 	description: __( 'Where your course content lives.', 'sensei-lms' ),
-	icon: 'list-view',
+	icon: LessonIcon,
 	category: 'sensei-lms',
 	parent: [ 'sensei-lms/course-outline', 'sensei-lms/course-outline-module' ],
 	keywords: [ __( 'Outline', 'sensei-lms' ), __( 'Lesson', 'sensei-lms' ) ],

--- a/assets/blocks/course-outline/module-block/index.js
+++ b/assets/blocks/course-outline/module-block/index.js
@@ -1,13 +1,14 @@
 import { InnerBlocks } from '@wordpress/block-editor';
 import { registerBlockType } from '@wordpress/blocks';
 import { __ } from '@wordpress/i18n';
+import { ModuleIcon } from '../../../icons';
 
 import EditModuleBlock from './edit';
 
 registerBlockType( 'sensei-lms/course-outline-module', {
 	title: __( 'Module', 'sensei-lms' ),
 	description: __( 'Used to group one or more lessons.', 'sensei-lms' ),
-	icon: 'list-view',
+	icon: ModuleIcon,
 	category: 'sensei-lms',
 	parent: [ 'sensei-lms/course-outline' ],
 	keywords: [ __( 'Outline', 'sensei-lms' ), __( 'Module', 'sensei-lms' ) ],

--- a/assets/blocks/course-outline/placeholder.js
+++ b/assets/blocks/course-outline/placeholder.js
@@ -1,5 +1,6 @@
 import { Button, Placeholder } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { CourseIcon } from '../../icons';
 
 /**
  * Placeholder for empty Course Outline block.
@@ -9,7 +10,7 @@ import { __ } from '@wordpress/i18n';
 export const CourseOutlinePlaceholder = ( { addBlock } ) => (
 	<Placeholder
 		label={ __( 'Course Outline', 'sensei-lms' ) }
-		icon="list-view"
+		icon={ CourseIcon }
 		instructions={ __(
 			'Build and display a course outline. A course is made up of modules (optional) and lessons. You can use modules to group related lessons together.',
 			'sensei-lms'

--- a/assets/icons/course-icon.js
+++ b/assets/icons/course-icon.js
@@ -1,0 +1,8 @@
+import { Path, SVG } from '@wordpress/components';
+
+export const CourseIcon = () => (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M20 16V4H4v12h16z" />
+		<Path d="M18.5 5.5v9h-13v-9h13zM20 16H4V4h16v12zM6 20h2.222L11 16H8.778L6 20zM18 20h-2.222L13 16h2.222L18 20z" />
+	</SVG>
+);

--- a/assets/icons/index.js
+++ b/assets/icons/index.js
@@ -1,0 +1,3 @@
+export { CourseIcon } from './course-icon';
+export { LessonIcon } from './lesson-icon';
+export { ModuleIcon } from './module-icon';

--- a/assets/icons/lesson-icon.js
+++ b/assets/icons/lesson-icon.js
@@ -1,0 +1,11 @@
+import { Path, SVG } from '@wordpress/components';
+
+export const LessonIcon = () => (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path
+			d="m4 4v12h4.7773l-2.7773 4h2.2227l2.7773-4h2l2.7773 4h2.2227l-2.7773-4h4.7773v-12zm1.5 1.5h13v9h-13zm3.5 2.5v1.5h6v-1.5zm0 3v1.5h6v-1.5z"
+			clipRule="evenodd"
+			fillRule="evenodd"
+		/>
+	</SVG>
+);

--- a/assets/icons/module-icon.js
+++ b/assets/icons/module-icon.js
@@ -1,0 +1,22 @@
+import { Path, SVG } from '@wordpress/components';
+
+export const ModuleIcon = () => (
+	<SVG
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M18.5 5.5v9h-13v-9h13zM20 16H4V4h16v12z"
+		/>
+		<Path
+			fillRule="evenodd"
+			clipRule="evenodd"
+			d="M9 12h6V8H9v4zM6 20h2.222L11 16H8.778L6 20zM18 20h-2.222L13 16h2.222L18 20z"
+		/>
+	</SVG>
+);


### PR DESCRIPTION
Fixes #3587

### Changes proposed in this Pull Request

* Add icons for course, module, lesson outline blocks

### Testing instructions

* Open course editor
* Check out the new block icons

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="158" alt="image" src="https://user-images.githubusercontent.com/176949/93614279-34a68c80-f9d2-11ea-844e-2667a6679683.png">
<img width="325" alt="image" src="https://user-images.githubusercontent.com/176949/93613957-cf529b80-f9d1-11ea-9dda-27beb0bc5627.png">
<img width="158" alt="image" src="https://user-images.githubusercontent.com/176949/93614233-235d8000-f9d2-11ea-9b7d-7bab3ddb462e.png">
