### PR TITLE
Add filter login required

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -970,7 +970,7 @@ class Sensei_Main {
 			return true;
 		}
 
-		if ( isset( $this->settings->settings['access_permission'] ) && ( true == $this->settings->settings['access_permission'] ) ) {
+		if ( sensei_is_login_required() ) {
 			if ( is_user_logged_in() ) {
 				return true;
 			} else {

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -290,16 +290,22 @@ function sensei_is_login_required() {
 	$post_type = get_post_type( $post );
 	$course_id = null;
 
-	if ( 'course' === $post_type ) {
-		$course_id = $post->ID;
-	} elseif ( 'lesson' === $post_type ) {
-		$course_id = Sensei()->lesson->get_course_id( $post->ID );
+	switch ( $post_type ) {
+		case 'course':
+			$course_id = $post->ID;
+			break;
+
+		case 'lesson':
+			$course_id = Sensei()->lesson->get_course_id( $post->ID );
+			break;
+
+		case 'quiz':
+			$lesson_id = intval( get_post_meta( $post->ID, '_quiz_lesson', true ) );
+			$course_id = $lesson_id ? Sensei()->lesson->get_course_id( $lesson_id ) : null;
+			break;
 	}
 
-	if (
-		! $course_id
-		|| 'course' !== get_post_type( $course_id )
-	) {
+	if ( ! $course_id ) {
 		$course_id = null;
 	}
 

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -281,14 +281,42 @@ function sensei_user_login_url() {
  * duplicate of Sensei()->access_settings().
  *
  * @since 1.9.0
+ * @since 3.5.2 Added hook to filter the return.
  * @return bool
  */
 function sensei_is_login_required() {
+	global $post;
+
+	$post_type = get_post_type( $post );
+	$course_id = null;
+
+	if ( 'course' === $post_type ) {
+		$course_id = $post->ID;
+	} elseif ( 'lesson' === $post_type ) {
+		$course_id = Sensei()->lesson->get_course_id( $post->ID );
+	}
+
+	if (
+		! $course_id
+		|| 'course' !== get_post_type( $course_id )
+	) {
+		$course_id = null;
+	}
 
 	$login_required = isset( Sensei()->settings->settings['access_permission'] ) && ( true == Sensei()->settings->settings['access_permission'] );
 
-	return $login_required;
-
+	/**
+	 * Filters the access_permission that says if the user must be logged
+	 * to view the lesson content.
+	 *
+	 * @since 3.5.2
+	 *
+	 * @hook sensei_is_login_required
+	 *
+	 * @param {bool}     $must_be_logged_to_view_lesson True if user need to be logged to see the lesson.
+	 * @param {int|null} $course_id                     Course post ID.
+	 */
+	return apply_filters( 'sensei_is_login_required', $login_required, $course_id );
 }
 
 /**


### PR DESCRIPTION
Dependency for 530-gh-sensei-wc-paid-courses to fix the issue 526-gh-sensei-wc-paid-courses

### Changes proposed in this Pull Request

* Introduces a new hook to filter the `sensei_is_login_required` function return.

### Testing instructions

* Check 530-gh-sensei-wc-paid-courses

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_is_login_required` Filters the access_permission that says if the user must be logged to view the lesson content.