### PR TITLE
Fix quiz settings

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1051,6 +1051,12 @@ class Sensei_Admin {
 					$html .= checked( $checked_value, $data, false );
 					$html .= disabled( $field['disabled'], true, false );
 					$html .= " /> \n";
+
+					// Input hidden to identify if checkbox is present.
+					$html .= '<input type="hidden" ';
+					$html .= 'name="contains_' . esc_attr( $field['id'] ) . '" ';
+					$html .= 'value="1" ';
+					$html .= " /> \n";
 					break;
 
 				case 'checkbox_multi':

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -542,7 +542,7 @@ class Sensei_Lesson {
 			foreach ( $settings as $field ) {
 				if ( 'random_question_order' != $field['id'] ) {
 					$value = $this->get_submitted_setting_value( $field );
-					if ( isset( $value ) ) {
+					if ( isset( $value ) && $value !== '-1' ) {
 						update_post_meta( $quiz_id, '_' . $field['id'], $value );
 					}
 				}
@@ -620,6 +620,10 @@ class Sensei_Lesson {
 		}
 
 		$value = null;
+
+		if ( isset( $_POST[ 'contains_' . $field['id'] ] ) ) {
+			$value = '';
+		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification -- Only checking the origin page.
 		if ( 'quiz_grade_type' === $field['id'] && isset( $_POST['action'] ) && 'editpost' === $_POST['action'] ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -542,7 +542,7 @@ class Sensei_Lesson {
 			foreach ( $settings as $field ) {
 				if ( 'random_question_order' != $field['id'] ) {
 					$value = $this->get_submitted_setting_value( $field );
-					if ( isset( $value ) && $value !== '-1' ) {
+					if ( isset( $value ) && '-1' !== $value ) {
 						update_post_meta( $quiz_id, '_' . $field['id'], $value );
 					}
 				}
@@ -621,6 +621,7 @@ class Sensei_Lesson {
 
 		$value = null;
 
+		// phpcs:ignore WordPress.Security.NonceVerification -- Only checking the field existence.
 		if ( isset( $_POST[ 'contains_' . $field['id'] ] ) ) {
 			$value = '';
 		}


### PR DESCRIPTION
Fixes #3582

### Changes proposed in this Pull Request

* Fixes this error: https://github.com/Automattic/sensei/pull/3589#issuecomment-694852402
* It also fixes when the user selects "No change" on the Quick edit.

This solution is a bit hacky, but I think it's enough until we refactor this part.

### Testing instructions

* Create a lesson.
* Edit the lesson.
* Scroll until the quiz settings.
* Uncheck _Pass required to complete lesson_ and _ Allow user to retake the quiz_.
* Save the lesson.
* Refreshes the page, and make sure it's still unchecked.
* Check the same options, refresh the page and make sure it's checked.
* Go to the _All Lessons_ page in WP-admin.
* Hover the same lesson and click on _Quick Edit_.
* Mark the option `-- No change --` in the fields _Pass required_  and _Enable quiz reset button_, and make sure it didn't change.
* Try to save the _Quick Edit_ fields and the Lesson post, and make sure the data are properly saved in all situations.