### PR TITLE
Add text size setting in lesson outline block

### DIFF
--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -111,7 +111,7 @@ const EditLessonBlock = ( props ) => {
 
 	return (
 		<>
-			<LessonBlockSettings { ...props } fontSize={ fontSize } />
+			<LessonBlockSettings { ...props } />
 			<div { ...colorStyles }>
 				<SingleLineInput
 					className="wp-block-sensei-lms-course-outline-lesson__input"

--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -9,25 +9,26 @@ import { LessonBlockSettings } from './settings';
 /**
  * Edit lesson block component.
  *
- * @param {Object}   props                   Component props.
- * @param {string}   props.clientId          Block client ID.
- * @param {string}   props.name              Block name.
- * @param {string}   props.className         Custom class name.
- * @param {Object}   props.attributes        Block attributes.
- * @param {string}   props.attributes.title  Lesson title.
- * @param {number}   props.attributes.id     Lesson Post ID
- * @param {Object}   props.backgroundColor   Background color object.
- * @param {Object}   props.textColor         Text color object.
- * @param {Function} props.setAttributes     Block set attributes function.
- * @param {Function} props.insertBlocksAfter Insert blocks after function.
- * @param {boolean}  props.isSelected        Is block selected.
+ * @param {Object}   props                     Component props.
+ * @param {string}   props.clientId            Block client ID.
+ * @param {string}   props.name                Block name.
+ * @param {string}   props.className           Custom class name.
+ * @param {Object}   props.attributes          Block attributes.
+ * @param {string}   props.attributes.title    Lesson title.
+ * @param {number}   props.attributes.id       Lesson Post ID
+ * @param {number}   props.attributes.fontSize Lesson title font size.
+ * @param {Object}   props.backgroundColor     Background color object.
+ * @param {Object}   props.textColor           Text color object.
+ * @param {Function} props.setAttributes       Block set attributes function.
+ * @param {Function} props.insertBlocksAfter   Insert blocks after function.
+ * @param {boolean}  props.isSelected          Is block selected.
  */
 const EditLessonBlock = ( props ) => {
 	const {
 		clientId,
 		name,
 		className,
-		attributes: { title, id },
+		attributes: { title, id, fontSize },
 		backgroundColor,
 		textColor,
 		setAttributes,
@@ -110,7 +111,7 @@ const EditLessonBlock = ( props ) => {
 
 	return (
 		<>
-			<LessonBlockSettings { ...props } />
+			<LessonBlockSettings { ...props } fontSize={ fontSize } />
 			<div { ...colorStyles }>
 				<SingleLineInput
 					className="wp-block-sensei-lms-course-outline-lesson__input"
@@ -118,6 +119,7 @@ const EditLessonBlock = ( props ) => {
 					value={ title }
 					onChange={ handleChange }
 					onKeyDown={ handleKeyDown }
+					style={ { fontSize } }
 				/>
 				{ isSelected && status }
 			</div>

--- a/assets/blocks/course-outline/lesson-block/index.js
+++ b/assets/blocks/course-outline/lesson-block/index.js
@@ -39,6 +39,9 @@ registerBlockType( 'sensei-lms/course-outline-lesson', {
 		customTextColor: {
 			type: 'string',
 		},
+		fontSize: {
+			type: 'number',
+		},
 	},
 	edit( props ) {
 		return <EditLessonBlock { ...props } />;

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -10,15 +10,15 @@ import { useSelect } from '@wordpress/data';
 /**
  * Inspector controls for lesson block.
  *
- * @param {Object}   props                    Component props.
- * @param {Object}   props.attributes
- * @param {number}   props.attributes.id
- * @param {Object}   props.backgroundColor    The lesson title background color.
- * @param {Object}   props.textColor          The lesson title color.
- * @param {Function} props.setTextColor       Callback method to set the lesson title color.
- * @param {Function} props.setBackgroundColor Callback method to set the background color.
- * @param {Function} props.fontSize           The font size of the lesson title.
- * @param {Function} props.setAttributes      Callback method to set the lesson title font size.
+ * @param {Object}   props                     Component props.
+ * @param {Object}   props.backgroundColor     The lesson title background color.
+ * @param {Object}   props.textColor           The lesson title color.
+ * @param {Function} props.setTextColor        Callback method to set the lesson title color.
+ * @param {Function} props.setBackgroundColor  Callback method to set the background color.
+ * @param {Function} props.setAttributes       Callback method to set the lesson title font size.
+ * @param {Function} props.attributes          The block attributes.
+ * @param {number}   props.attributes.id       The lesson id.
+ * @param {Function} props.attributes.fontSize The lesson block font size.
  */
 export function LessonBlockSettings( {
 	attributes: { id },
@@ -26,8 +26,8 @@ export function LessonBlockSettings( {
 	textColor,
 	setTextColor,
 	setBackgroundColor,
-	fontSize,
 	setAttributes,
+	attributes: { fontSize },
 } ) {
 	const { fontSizes } = useSelect( ( select ) =>
 		select( 'core/block-editor' ).getSettings()

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -56,7 +56,7 @@ export function LessonBlockSettings( {
 			) }
 			<PanelBody
 				title={ __( 'Typography', 'sensei-lms' ) }
-				initialOpen={ true }
+				initialOpen={ false }
 			>
 				<FontSizePicker
 					fontSizes={ fontSizes }

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -3,19 +3,22 @@ import {
 	InspectorControls,
 	PanelColorSettings,
 } from '@wordpress/block-editor';
+import { PanelBody, FontSizePicker, ExternalLink } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { PanelBody, ExternalLink } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Inspector controls for lesson block.
  *
- * @param {Object}   props
+ * @param {Object}   props                    Component props.
  * @param {Object}   props.attributes
  * @param {number}   props.attributes.id
- * @param {Object}   props.backgroundColor
- * @param {Object}   props.textColor
- * @param {Function} props.setTextColor
- * @param {Function} props.setBackgroundColor
+ * @param {Object}   props.backgroundColor    The lesson title background color.
+ * @param {Object}   props.textColor          The lesson title color.
+ * @param {Function} props.setTextColor       Callback method to set the lesson title color.
+ * @param {Function} props.setBackgroundColor Callback method to set the background color.
+ * @param {Function} props.fontSize           The font size of the lesson title.
+ * @param {Function} props.setAttributes      Callback method to set the lesson title font size.
  */
 export function LessonBlockSettings( {
 	attributes: { id },
@@ -23,7 +26,13 @@ export function LessonBlockSettings( {
 	textColor,
 	setTextColor,
 	setBackgroundColor,
+	fontSize,
+	setAttributes,
 } ) {
+	const { fontSizes } = useSelect( ( select ) =>
+		select( 'core/block-editor' ).getSettings()
+	);
+
 	return (
 		<InspectorControls>
 			{ id && (
@@ -45,6 +54,18 @@ export function LessonBlockSettings( {
 					</p>
 				</PanelBody>
 			) }
+			<PanelBody
+				title={ __( 'Typography', 'sensei-lms' ) }
+				initialOpen={ true }
+			>
+				<FontSizePicker
+					fontSizes={ fontSizes }
+					value={ fontSize }
+					onChange={ ( value ) => {
+						setAttributes( { fontSize: value } );
+					} }
+				/>
+			</PanelBody>
 			<PanelColorSettings
 				title={ __( 'Color settings', 'sensei-lms' ) }
 				colorSettings={ [

--- a/includes/blocks/class-sensei-block-helpers.php
+++ b/includes/blocks/class-sensei-block-helpers.php
@@ -16,44 +16,51 @@ class Sensei_Block_Helpers {
 
 
 	/**
-	 * Build CSS classes (for named colors) and inline styles from block attributes.
+	 * Build CSS classes and inline styles from block attributes.
 	 *
-	 * @param array $block  Block.
-	 * @param array $colors Color attributes and their style property.
+	 * @param array $block_attributes  The block attributes array with the format$attribute_key => $attribute_value.
 	 *
-	 * @return array Colors CSS classes and inline styles.
+	 * @return array {
+	 *     An array of classes and styles.
+	 *
+	 *     @type string $css_classes   An array of classes.
+	 *     @type string $inline_styles An array of styles.
+	 * }
 	 */
-	public static function build_color_styles( $block, $colors = [] ) {
-		$block_attributes = $block['attributes'] ?? [];
-		$attributes       = [
-			'css_classes'   => [],
-			'inline_styles' => [],
-		];
+	public static function build_block_styles( $block_attributes ) {
+		$inline_styles = [];
+		$css_classes   = [];
 
-		$colors = array_merge(
-			[
-				'textColor'       => 'color',
-				'backgroundColor' => 'background-color',
-			],
-			$colors
-		);
-
-		foreach ( $colors as $color => $style ) {
-
-			$named_color  = $block_attributes[ $color ] ?? null;
-			$custom_color = $block_attributes[ 'custom' . ucfirst( $color ) ] ?? null;
-
-			if ( $custom_color || $named_color ) {
-				$attributes['css_classes'][] = sprintf( 'has-%s', $style );
-			}
-			if ( $named_color ) {
-				$attributes['css_classes'][] = sprintf( 'has-%s-%s', $named_color, $style );
-			} elseif ( $custom_color ) {
-				$attributes['inline_styles'][] = sprintf( '%s: %s;', $style, $custom_color );
+		foreach ( $block_attributes as $attribute => $value ) {
+			switch ( $attribute ) {
+				case 'backgroundColor':
+					$css_classes[] = 'has-background-color';
+					$css_classes[] = sprintf( 'has-%s-background-color', $value );
+					break;
+				case 'customBackgroundColor':
+					$css_classes[]   = 'has-background-color';
+					$inline_styles[] = sprintf( 'background-color: %s', $value );
+					break;
+				case 'textColor':
+					$css_classes[] = 'has-color';
+					$css_classes[] = sprintf( 'has-%s-color', $value );
+					break;
+				case 'customTextColor':
+					$css_classes[]   = 'has-color';
+					$inline_styles[] = sprintf( 'color: %s', $value );
+					break;
+				case 'fontSize':
+					$inline_styles[] = sprintf( 'font-size: %spx', $value );
+					break;
+				default:
+					break;
 			}
 		}
 
-		return $attributes;
+		return [
+			'css_classes'   => $css_classes,
+			'inline_styles' => $inline_styles,
+		];
 	}
 
 	/**

--- a/includes/blocks/class-sensei-block-helpers.php
+++ b/includes/blocks/class-sensei-block-helpers.php
@@ -23,7 +23,7 @@ class Sensei_Block_Helpers {
 	 *
 	 * @return array Colors CSS classes and inline styles.
 	 */
-	public static function build_styles( $block, $colors = [] ) {
+	public static function build_color_styles( $block, $colors = [] ) {
 		$block_attributes = $block['attributes'] ?? [];
 		$attributes       = [
 			'css_classes'   => [],

--- a/includes/blocks/class-sensei-block-helpers.php
+++ b/includes/blocks/class-sensei-block-helpers.php
@@ -16,51 +16,48 @@ class Sensei_Block_Helpers {
 
 
 	/**
-	 * Build CSS classes and inline styles from block attributes.
+	 * Build CSS classes (for named colors) and inline styles from block attributes.
 	 *
-	 * @param array $block_attributes  The block attributes array with the format$attribute_key => $attribute_value.
+	 * @param array $block  Block.
+	 * @param array $colors Color attributes and their style property.
 	 *
-	 * @return array {
-	 *     An array of classes and styles.
-	 *
-	 *     @type string $css_classes   An array of classes.
-	 *     @type string $inline_styles An array of styles.
-	 * }
+	 * @return array Colors CSS classes and inline styles.
 	 */
-	public static function build_block_styles( $block_attributes ) {
-		$inline_styles = [];
-		$css_classes   = [];
+	public static function build_styles( $block, $colors = [] ) {
+		$block_attributes = $block['attributes'] ?? [];
+		$attributes       = [
+			'css_classes'   => [],
+			'inline_styles' => [],
+		];
 
-		foreach ( $block_attributes as $attribute => $value ) {
-			switch ( $attribute ) {
-				case 'backgroundColor':
-					$css_classes[] = 'has-background-color';
-					$css_classes[] = sprintf( 'has-%s-background-color', $value );
-					break;
-				case 'customBackgroundColor':
-					$css_classes[]   = 'has-background-color';
-					$inline_styles[] = sprintf( 'background-color: %s', $value );
-					break;
-				case 'textColor':
-					$css_classes[] = 'has-color';
-					$css_classes[] = sprintf( 'has-%s-color', $value );
-					break;
-				case 'customTextColor':
-					$css_classes[]   = 'has-color';
-					$inline_styles[] = sprintf( 'color: %s', $value );
-					break;
-				case 'fontSize':
-					$inline_styles[] = sprintf( 'font-size: %spx', $value );
-					break;
-				default:
-					break;
+		$colors = array_merge(
+			[
+				'textColor'       => 'color',
+				'backgroundColor' => 'background-color',
+			],
+			$colors
+		);
+
+		foreach ( $colors as $color => $style ) {
+
+			$named_color  = $block_attributes[ $color ] ?? null;
+			$custom_color = $block_attributes[ 'custom' . ucfirst( $color ) ] ?? null;
+
+			if ( $custom_color || $named_color ) {
+				$attributes['css_classes'][] = sprintf( 'has-%s', $style );
+			}
+			if ( $named_color ) {
+				$attributes['css_classes'][] = sprintf( 'has-%s-%s', $named_color, $style );
+			} elseif ( $custom_color ) {
+				$attributes['inline_styles'][] = sprintf( '%s: %s;', $style, $custom_color );
 			}
 		}
 
-		return [
-			'css_classes'   => $css_classes,
-			'inline_styles' => $inline_styles,
-		];
+		if ( ! empty( $block_attributes['fontSize'] ) ) {
+			$attributes['inline_styles'][] = sprintf( 'font-size: %spx', $block_attributes['fontSize'] );
+		}
+
+		return $attributes;
 	}
 
 	/**

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -217,7 +217,12 @@ class Sensei_Course_Outline_Block {
 	 */
 	protected function render_lesson_block( $block ) {
 
-		$css = Sensei_Block_Helpers::build_styles( $block );
+		$css = Sensei_Block_Helpers::build_color_styles( $block );
+
+		if ( ! empty( $block['attributes']['fontSize'] ) ) {
+			$css['inline_styles'][] = sprintf( 'font-size: %spx', $block['attributes']['fontSize'] );
+		}
+
 		return '
 			<h3 ' . Sensei_Block_Helpers::render_style_attributes( 'wp-block-sensei-lms-course-outline-lesson', $css ) . '>
 				<a

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -217,7 +217,7 @@ class Sensei_Course_Outline_Block {
 	 */
 	protected function render_lesson_block( $block ) {
 
-		$css = Sensei_Block_Helpers::build_block_styles( $block['attributes'] ?? [] );
+		$css = Sensei_Block_Helpers::build_styles( $block );
 
 		return '
 			<h3 ' . Sensei_Block_Helpers::render_style_attributes( 'wp-block-sensei-lms-course-outline-lesson', $css ) . '>

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -217,11 +217,7 @@ class Sensei_Course_Outline_Block {
 	 */
 	protected function render_lesson_block( $block ) {
 
-		$css = Sensei_Block_Helpers::build_color_styles( $block );
-
-		if ( ! empty( $block['attributes']['fontSize'] ) ) {
-			$css['inline_styles'][] = sprintf( 'font-size: %spx', $block['attributes']['fontSize'] );
-		}
+		$css = Sensei_Block_Helpers::build_block_styles( $block['attributes'] ?? [] );
 
 		return '
 			<h3 ' . Sensei_Block_Helpers::render_style_attributes( 'wp-block-sensei-lms-course-outline-lesson', $css ) . '>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds a setting to the lesson block which controls the text size of the lesson title.
![font-size](https://user-images.githubusercontent.com/53191348/93790399-a7667080-fc3b-11ea-82f1-b06780fd8df4.gif)


### Testing instructions

* Open the course outline block and add a lesson.
* Modify the lesson title font size by using the setting in the sidebar.
* Observe the changes in the editor and in the frontend.