### PR TITLE
Only show module status preview when setting panel is open

### DIFF
--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -44,12 +44,15 @@ const EditModuleBlock = ( {
 		setAttributes( { description: value } );
 	};
 
-	const [ isPreviewCompleted, setIsPreviewCompleted ] = useState( false );
+	const [ hasStatusPreview, toggleStatusPreview ] = useState( false );
+	const [ isStatusPreviewCompleted, setIsStatusPreviewCompleted ] = useState(
+		false
+	);
 
 	let indicatorText = __( 'In Progress', 'sensei-lms' );
 	let indicatorClass = null;
 
-	if ( isPreviewCompleted ) {
+	if ( isStatusPreviewCompleted ) {
 		indicatorText = __( 'Completed', 'sensei-lms' );
 		indicatorClass = 'completed';
 	}
@@ -58,12 +61,13 @@ const EditModuleBlock = ( {
 		<>
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Status', 'sensei-lms' ) }
-					initialOpen={ true }
+					title={ __( 'Preview Status', 'sensei-lms' ) }
+					opened={ hasStatusPreview }
+					onToggle={ () => toggleStatusPreview( ! hasStatusPreview ) }
 				>
 					<ModuleStatusControl
-						isPreviewCompleted={ isPreviewCompleted }
-						setIsPreviewCompleted={ setIsPreviewCompleted }
+						isPreviewCompleted={ isStatusPreviewCompleted }
+						setIsPreviewCompleted={ setIsStatusPreviewCompleted }
 					/>
 				</PanelBody>
 			</InspectorControls>
@@ -78,16 +82,18 @@ const EditModuleBlock = ( {
 							onChange={ updateName }
 						/>
 					</h2>
-					<div
-						className={ classnames(
-							'wp-block-sensei-lms-course-outline__progress-indicator',
-							indicatorClass
-						) }
-					>
-						<span className="wp-block-sensei-lms-course-outline__progress-indicator__text">
-							{ indicatorText }
-						</span>
-					</div>
+					{ hasStatusPreview && (
+						<div
+							className={ classnames(
+								'wp-block-sensei-lms-course-outline__progress-indicator',
+								indicatorClass
+							) }
+						>
+							<span className="wp-block-sensei-lms-course-outline__progress-indicator__text">
+								{ indicatorText }
+							</span>
+						</div>
+					) }
 				</header>
 				<div className="wp-block-sensei-lms-course-outline-module__description">
 					<RichText


### PR DESCRIPTION

Just a small change to #3613 that came to mind a bit late :). We don't want to actually see the status preview all the time in all modules, as it can be a bit distracting to the course building and not really relevant. 

The status is also only there on the frontend when the learner is taking the course, most of the time the modules won't have that status indicator, but there was no way to see the *empty* state in the editor. 

### Changes proposed in this Pull Request

* Don't show the learner status preview on modules by default
* Show it when the setting panel is open
* Also update the panel title to `Preview Status` to make it more clear when it's closed

### Testing instructions

* Add some modules to an outline block
* Make sure that the progress indicator is not on in their headers
* Select a module block and open it's settings
* Open the Preview Status panel
* Indicator should appear
* Toggle the preview state
* Indicator should update
* Close the Preview Status panel accordion
* Indicator should disappear

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![Module-status](https://user-images.githubusercontent.com/176949/93811089-ea324380-fc4f-11ea-9b4b-49b977f7c8dd.gif)
