### PR TITLE
Open lesson from sidebar

### DIFF
--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -88,17 +88,7 @@ const EditLessonBlock = ( props ) => {
 	};
 
 	let status = '';
-	if ( id ) {
-		status = (
-			<a
-				href={ `post.php?post=${ id }&action=edit` }
-				target="lesson"
-				className="wp-block-sensei-lms-course-outline-lesson__edit"
-			>
-				{ __( 'Edit Lesson', 'sensei-lms' ) }
-			</a>
-		);
-	} else if ( title.length ) {
+	if ( ! id && title.length ) {
 		status = (
 			<div className="wp-block-sensei-lms-course-outline-lesson__unsaved">
 				{ __( 'Unsaved', 'sensei-lms' ) }

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -4,17 +4,21 @@ import {
 	PanelColorSettings,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { PanelBody, ExternalLink } from '@wordpress/components';
 
 /**
  * Inspector controls for lesson block.
  *
  * @param {Object}   props
+ * @param {Object}   props.attributes
+ * @param {number}   props.attributes.id
  * @param {Object}   props.backgroundColor
  * @param {Object}   props.textColor
  * @param {Function} props.setTextColor
  * @param {Function} props.setBackgroundColor
  */
 export function LessonBlockSettings( {
+	attributes: { id },
 	backgroundColor,
 	textColor,
 	setTextColor,
@@ -22,6 +26,25 @@ export function LessonBlockSettings( {
 } ) {
 	return (
 		<InspectorControls>
+			{ id && (
+				<PanelBody>
+					<h2>
+						<ExternalLink
+							href={ `post.php?post=${ id }&action=edit` }
+							target="lesson"
+							className="wp-block-sensei-lms-course-outline-lesson__edit"
+						>
+							{ __( 'Edit lesson', 'sensei-lms' ) }
+						</ExternalLink>
+					</h2>
+					<p>
+						{ __(
+							'Edit details such as lesson content, prerequisite, quiz settings and more.',
+							'sensei-lms'
+						) }
+					</p>
+				</PanelBody>
+			) }
 			<PanelColorSettings
 				title={ __( 'Color settings', 'sensei-lms' ) }
 				colorSettings={ [

--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -30,10 +30,6 @@
 
 	.wp-block-sensei-lms-course-outline-lesson {
 
-		&__edit {
-			flex: 0 0 auto;
-		}
-
 		&__unsaved {
 			font-size: 12px;
 			font-weight: bold;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds link to edit lesson when selecting a lesson block that has been created.
* Removes temporary edit lesson link (I think it was temporary?).
* Couple of design changes: 
  * Moved from bottom of settings to top as it is seems difficult to put things below Advanced without being hack-y.
  * Kept the link underline to be consistent with the link styles in the editor. 

### Testing instructions

* Select a lesson block for a lesson that has been created. In the block sidebar, verify the edit lesson link appears and opens the lesson in a new tab.
* In a new lesson that has not been created, verify the edit lesson link does not appear.

<img width="275" alt="Screen Shot 2020-09-21 at 9 15 04 pm" src="https://user-images.githubusercontent.com/68693/93816574-9f183080-fc4f-11ea-8e1a-dc53b4de1d9f.png">
