### PR TITLE
Exclude right/wrong prefix in exported answers' escaped values

### DIFF
--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -460,11 +460,15 @@ class Sensei_Data_Port_Utilities {
 	 * Serialize a list into comma-separated list.
 	 * Wrap values in quotes if they contain a comma.
 	 *
+	 * @deprecated 3.5.2
+	 *
 	 * @param string[] $values
 	 *
 	 * @return string
 	 */
 	public static function serialize_list( $values = [] ) {
+		_deprecated_function( __METHOD__, '3.5.2' );
+
 		return ! empty( $values )
 			? implode( ',', array_map( 'Sensei_Data_Port_Utilities::escape_list_item', $values ) )
 			: '';

--- a/includes/data-port/export-tasks/class-sensei-export-questions.php
+++ b/includes/data-port/export-tasks/class-sensei-export-questions.php
@@ -115,13 +115,13 @@ class Sensei_Export_Questions
 
 				$answers_right = array_map(
 					function( $value ) {
-						return 'Right:' . $value;
+						return 'Right:' . Sensei_Data_Port_Utilities::escape_list_item( $value );
 					},
 					$answers_right
 				);
 				$answers_wrong = array_map(
 					function( $value ) {
-						return 'Wrong:' . $value;
+						return 'Wrong:' . Sensei_Data_Port_Utilities::escape_list_item( $value );
 					},
 					$answers_wrong
 				);
@@ -129,7 +129,7 @@ class Sensei_Export_Questions
 				$answers = array_merge( $answers_right, $answers_wrong );
 				$answers = Sensei()->question->get_answers_sorted( $answers, $meta['_answer_order'] );
 
-				$columns[ Schema::COLUMN_ANSWER ] = Sensei_Data_Port_Utilities::serialize_list( $answers );
+				$columns[ Schema::COLUMN_ANSWER ] = implode( ',', $answers );
 
 				break;
 			case 'boolean':

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-questions.php
@@ -179,7 +179,7 @@ class Sensei_Export_Questions_Tests extends WP_UnitTestCase {
 
 		$this->assertArraySubset(
 			[
-				'answer'              => 'Wrong:Wrong 1,"Wrong:Wrong,comma","Wrong:Wrong,comma,\"quote\"",Right:Right answer',
+				'answer'              => 'Wrong:Wrong 1,Wrong:"Wrong,comma",Wrong:"Wrong,comma,\"quote\"",Right:Right answer',
 				'random answer order' => '0',
 			],
 			$result[0]


### PR DESCRIPTION
Fixes #3638 

### Changes proposed in this Pull Request

* Fixes exporter so that multiple choice answers are wrapped in quotes without the `Right:`/`'Wrong:` prefix, as per the specs.

### Testing instructions

* See issue.

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* `\Sensei_Data_Port_Utilities::serialize_list` (no longer used)