### PR TITLE
Update placeholder text

### DIFF
--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -119,7 +119,7 @@ const EditModuleBlock = ( {
 						<RichText
 							className="wp-block-sensei-lms-course-outline-module__description-input"
 							placeholder={ __(
-								'Description about the module',
+								'Module description',
 								'sensei-lms'
 							) }
 							value={ description }

--- a/assets/blocks/course-outline/module-block/edit.test.js
+++ b/assets/blocks/course-outline/module-block/edit.test.js
@@ -42,12 +42,9 @@ describe( '<EditLessonBlock />', () => {
 			/>
 		);
 
-		fireEvent.change(
-			getByPlaceholderText( 'Description about the module' ),
-			{
-				target: { value: 'Test' },
-			}
-		);
+		fireEvent.change( getByPlaceholderText( 'Module description' ), {
+			target: { value: 'Test' },
+		} );
 
 		expect( setAttributesMock ).toBeCalledWith( { description: 'Test' } );
 	} );

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -838,9 +838,9 @@ class Sensei_PostTypes {
 	 */
 	public function enter_title_here( $title ) {
 		if ( get_post_type() == 'course' ) {
-			$title = __( 'Enter a title for this course here', 'sensei-lms' );
+			$title = __( 'Course name', 'sensei-lms' );
 		} elseif ( get_post_type() == 'lesson' ) {
-			$title = __( 'Enter a title for this lesson here', 'sensei-lms' );
+			$title = __( 'Lesson name', 'sensei-lms' );
 		}
 
 		return $title;


### PR DESCRIPTION
Updated some placeholder text in Course editor.

To test:

- Set the feature flag to enable the Course Outline block (`define( 'SENSEI_FEATURE_FLAG_COURSE_OUTLINE', true );`)
- Click on Courses > Add New.
- Click on Create a Module.

You should see the placeholders that say "Course name" and "Module description".