### PR TITLE
Fix module status on frontend

### DIFF
--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -286,11 +286,11 @@ class Sensei_Course_Outline_Block {
 		}
 
 		if ( $module_progress < 100 ) {
-			$module_status   = __( 'Completed', 'sensei-lms' );
-			$indicator_class = 'completed';
-		} else {
 			$module_status   = __( 'In Progress', 'sensei-lms' );
 			$indicator_class = '';
+		} else {
+			$module_status   = __( 'Completed', 'sensei-lms' );
+			$indicator_class = 'completed';
 		}
 
 		return '


### PR DESCRIPTION
### Changes proposed in this Pull Request

Fix the logic for "In Progress" vs. "Completed" module status on the frontend.

### Testing instructions

* Create a course with the Course Outline block, and add at least two Modules, each with at least two Lessons.
* Start taking the Course.
* Complete all Lessons in one Module.
* Complete some, but not all, Lessons in another module.
* Visit the Course page. Ensure the Module statuses are correct.