### PR TITLE
Update modules content overflow to auto

### DIFF
--- a/assets/blocks/course-outline/frontend.js
+++ b/assets/blocks/course-outline/frontend.js
@@ -5,7 +5,7 @@ jQuery( document ).ready( () => {
 			.closest( '.wp-block-sensei-lms-course-outline-module' )
 			.children( '.wp-block-sensei-lms-collapsible' );
 
-		moduleDetails.toggleClass( 'collapsed' );
+		moduleDetails.toggleClass( 'collapsed expanded' );
 		jQuery( this ).toggleClass( 'dashicons-arrow-up-alt2' );
 		jQuery( this ).toggleClass( 'dashicons-arrow-down-alt2' );
 	}

--- a/assets/blocks/course-outline/frontend.js
+++ b/assets/blocks/course-outline/frontend.js
@@ -1,30 +1,40 @@
 ( () => {
-	const modules = document.querySelectorAll(
-		'.wp-block-sensei-lms-course-outline-module'
-	);
+	const onReady = ( fn ) => {
+		if ( 'loading' !== document.readyState ) {
+			fn();
+		} else {
+			document.addEventListener( 'DOMContentLoaded', fn );
+		}
+	};
 
-	modules.forEach( ( module ) => {
-		const moduleContent = module.querySelector(
-			'.wp-block-sensei-lms-collapsible.animated'
+	onReady( () => {
+		const modules = document.querySelectorAll(
+			'.wp-block-sensei-lms-course-outline-module'
 		);
 
-		const originalHeight = moduleContent.offsetHeight;
-		const toggleButton = module.querySelector(
-			'.wp-block-sensei-lms-course-outline__arrow'
-		);
+		modules.forEach( ( module ) => {
+			const moduleContent = module.querySelector(
+				'.wp-block-sensei-lms-collapsible.animated'
+			);
 
-		moduleContent.style.height = originalHeight + 'px';
+			const originalHeight = moduleContent.offsetHeight;
+			const toggleButton = module.querySelector(
+				'.wp-block-sensei-lms-course-outline__arrow'
+			);
 
-		toggleButton.addEventListener( 'click', () => {
-			toggleButton.classList.toggle( 'dashicons-arrow-up-alt2' );
-			toggleButton.classList.toggle( 'dashicons-arrow-down-alt2' );
-			const collapsed = moduleContent.classList.toggle( 'collapsed' );
+			moduleContent.style.height = originalHeight + 'px';
 
-			if ( ! collapsed ) {
-				moduleContent.style.height = originalHeight + 'px';
-			} else {
-				moduleContent.style.height = '0px';
-			}
+			toggleButton.addEventListener( 'click', () => {
+				toggleButton.classList.toggle( 'dashicons-arrow-up-alt2' );
+				toggleButton.classList.toggle( 'dashicons-arrow-down-alt2' );
+				const collapsed = moduleContent.classList.toggle( 'collapsed' );
+
+				if ( ! collapsed ) {
+					moduleContent.style.height = originalHeight + 'px';
+				} else {
+					moduleContent.style.height = '0px';
+				}
+			} );
 		} );
 	} );
 } )();

--- a/assets/blocks/course-outline/frontend.js
+++ b/assets/blocks/course-outline/frontend.js
@@ -1,21 +1,30 @@
-/* global jQuery */
-jQuery( document ).ready( () => {
-	function toggleModuleDetails() {
-		const moduleDetails = jQuery( this )
-			.closest( '.wp-block-sensei-lms-course-outline-module' )
-			.children( '.wp-block-sensei-lms-collapsible' );
+( () => {
+	const modules = document.querySelectorAll(
+		'.wp-block-sensei-lms-course-outline-module'
+	);
 
-		moduleDetails.toggleClass( 'collapsed expanded' );
-		jQuery( this ).toggleClass( 'dashicons-arrow-up-alt2' );
-		jQuery( this ).toggleClass( 'dashicons-arrow-down-alt2' );
-	}
+	modules.forEach( ( module ) => {
+		const moduleContent = module.querySelector(
+			'.wp-block-sensei-lms-collapsible.animated'
+		);
 
-	const arrowButton = jQuery( '.wp-block-sensei-lms-course-outline__arrow' );
+		const originalHeight = moduleContent.offsetHeight;
+		const toggleButton = module.querySelector(
+			'.wp-block-sensei-lms-course-outline__arrow'
+		);
 
-	arrowButton.click( toggleModuleDetails );
-	arrowButton.keydown( function ( e ) {
-		if ( 13 === e.which ) {
-			toggleModuleDetails.call( this );
-		}
+		moduleContent.style.height = originalHeight + 'px';
+
+		toggleButton.addEventListener( 'click', () => {
+			toggleButton.classList.toggle( 'dashicons-arrow-up-alt2' );
+			toggleButton.classList.toggle( 'dashicons-arrow-down-alt2' );
+			const collapsed = moduleContent.classList.toggle( 'collapsed' );
+
+			if ( ! collapsed ) {
+				moduleContent.style.height = originalHeight + 'px';
+			} else {
+				moduleContent.style.height = '0px';
+			}
+		} );
 	} );
-} );
+} )();

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -107,7 +107,8 @@ const EditModuleBlock = ( {
 					className={ classnames(
 						'wp-block-sensei-lms-collapsible',
 						{ animated: animationsEnabled },
-						{ collapsed: ! isExpanded }
+						{ collapsed: ! isExpanded },
+						{ expanded: isExpanded }
 					) }
 				>
 					<div className="wp-block-sensei-lms-course-outline-module__description">

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -2,8 +2,9 @@ import { __ } from '@wordpress/i18n';
 import { InnerBlocks, RichText } from '@wordpress/block-editor';
 import { useState, useContext } from '@wordpress/element';
 import classnames from 'classnames';
-import { OutlineAttributesContext } from '../course-block/edit';
+import AnimateHeight from 'react-animate-height';
 
+import { OutlineAttributesContext } from '../course-block/edit';
 import SingleLineInput from '../single-line-input';
 import { ModuleBlockSettings } from './settings';
 
@@ -103,13 +104,11 @@ const EditModuleBlock = ( {
 						tabIndex={ 0 }
 					/>
 				</header>
-				<div
-					className={ classnames(
-						'wp-block-sensei-lms-collapsible',
-						{ animated: animationsEnabled },
-						{ collapsed: ! isExpanded },
-						{ expanded: isExpanded }
-					) }
+				<AnimateHeight
+					className="wp-block-sensei-lms-collapsible"
+					duration={ animationsEnabled ? 500 : 0 }
+					animateOpacity
+					height={ isExpanded ? 'auto' : 0 }
 				>
 					<div className="wp-block-sensei-lms-course-outline-module__description">
 						<RichText
@@ -133,7 +132,7 @@ const EditModuleBlock = ( {
 						] }
 						allowedBlocks={ [ 'sensei-lms/course-outline-lesson' ] }
 					/>
-				</div>
+				</AnimateHeight>
 			</section>
 		</>
 	);

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -94,7 +94,11 @@ const EditModuleBlock = ( {
 								: 'dashicons-arrow-down-alt2'
 						) }
 						onClick={ () => setExpanded( ! isExpanded ) }
-					/>
+					>
+						<span className="screen-reader-text">
+							{ __( 'Toggle module content', 'sensei-lms' ) }
+						</span>
+					</button>
 				</header>
 				<AnimateHeight
 					className="wp-block-sensei-lms-collapsible"

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -57,12 +57,6 @@ const EditModuleBlock = ( {
 
 	const [ isExpanded, setExpanded ] = useState( true );
 
-	function handleKeyDown( e ) {
-		if ( 13 === e.keyCode ) {
-			setExpanded( ! isExpanded );
-		}
-	}
-
 	return (
 		<>
 			<ModuleBlockSettings
@@ -90,7 +84,8 @@ const EditModuleBlock = ( {
 							{ indicatorText }
 						</span>
 					</div>
-					<div
+					<button
+						type="button"
 						className={ classnames(
 							'wp-block-sensei-lms-course-outline__arrow',
 							'dashicons',
@@ -99,9 +94,6 @@ const EditModuleBlock = ( {
 								: 'dashicons-arrow-down-alt2'
 						) }
 						onClick={ () => setExpanded( ! isExpanded ) }
-						onKeyDown={ handleKeyDown }
-						role="button"
-						tabIndex={ 0 }
 					/>
 				</header>
 				<AnimateHeight

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -1,5 +1,10 @@
 $dark-gray: #1a1d20;
 
+@keyframes module-animation {
+	0% { opacity: 0; margin-top: -50px }
+	100% { opacity: 1; margin-top: 0px }
+}
+
 .wp-block-sensei-lms-course-outline {
 
 	&__clean-heading {
@@ -119,21 +124,12 @@ $dark-gray: #1a1d20;
 }
 
 .wp-block-sensei-lms-collapsible {
+	&.animated.expanded {
+		animation: module-animation 0.5s ease-in-out;
+	}
 
 	&.collapsed {
 		display: none;
-	}
-
-	&.animated {
-		max-height: 2000px;
-		transition: max-height 0.5s ease-in;
-		overflow: auto;
-
-		&.collapsed {
-			display: block;
-			max-height: 0;
-			transition: max-height 0.5s cubic-bezier(0, 1, 0.35, 1);
-		}
 	}
 }
 

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -119,8 +119,14 @@ $dark-gray: #1a1d20;
 }
 
 .wp-block-sensei-lms-collapsible {
+	&.animated {
+		opacity: 1;
+		overflow: hidden;
+		transition: height 0.5s ease-in-out, opacity 0.5s ease-in-out;
+	}
+
 	&.collapsed {
-		display: none;
+		opacity: 0;
 	}
 }
 

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -1,10 +1,5 @@
 $dark-gray: #1a1d20;
 
-@keyframes module-animation {
-	0% { opacity: 0; margin-top: -50px }
-	100% { opacity: 1; margin-top: 0px }
-}
-
 .wp-block-sensei-lms-course-outline {
 
 	&__clean-heading {
@@ -124,10 +119,6 @@ $dark-gray: #1a1d20;
 }
 
 .wp-block-sensei-lms-collapsible {
-	&.animated.expanded {
-		animation: module-animation 0.5s ease-in-out;
-	}
-
 	&.collapsed {
 		display: none;
 	}

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -39,13 +39,22 @@ $dark-gray: #1a1d20;
 		}
 	}
 
-	&__arrow {
-		fill: #FFF;
+	&__arrow[type="button"] {
+		display: block;
+		padding: 0;
+		margin: 0;
+		background: 0;
+		border: 0;
+		color: #FFF;
 		flex-basis: 4%;
 		margin-left: auto;
 		cursor: pointer;
 		height: 24px;
 		font-size: 24px;
+
+		&:hover, &:focus {
+			text-decoration: none;
+		}
 
 		&.collapsed {
 			display: none;

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -127,7 +127,7 @@ $dark-gray: #1a1d20;
 	&.animated {
 		max-height: 2000px;
 		transition: max-height 0.5s ease-in;
-		overflow: hidden;
+		overflow: auto;
 
 		&.collapsed {
 			display: block;

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -251,7 +251,9 @@ class Sensei_Course_Outline_Block {
 				<header class="wp-block-sensei-lms-course-outline-module__name">
 					<h2 class="wp-block-sensei-lms-course-outline__clean-heading">' . $block['title'] . '</h2>
 					' . $progress_indicator . '
-					<button type="button" class="wp-block-sensei-lms-course-outline__arrow dashicons dashicons-arrow-up-alt2" />
+					<button type="button" class="wp-block-sensei-lms-course-outline__arrow dashicons dashicons-arrow-up-alt2">
+						<span class="screen-reader-text">' . __( 'Toggle module content', 'sensei-lms' ) . '</span>
+					</button>
 				</header>
 				<div class="wp-block-sensei-lms-collapsible expanded ' . $animated . '">
 					<div class="wp-block-sensei-lms-course-outline-module__description">

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -251,7 +251,7 @@ class Sensei_Course_Outline_Block {
 				<header class="wp-block-sensei-lms-course-outline-module__name">
 					<h2 class="wp-block-sensei-lms-course-outline__clean-heading">' . $block['title'] . '</h2>
 					' . $progress_indicator . '
-					<div role="button" tabindex="0" class="wp-block-sensei-lms-course-outline__arrow dashicons dashicons-arrow-up-alt2"/>
+					<button type="button" class="wp-block-sensei-lms-course-outline__arrow dashicons dashicons-arrow-up-alt2" />
 				</header>
 				<div class="wp-block-sensei-lms-collapsible expanded ' . $animated . '">
 					<div class="wp-block-sensei-lms-course-outline-module__description">

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -45,6 +45,10 @@ class Sensei_Course_Outline_Block {
 		}
 
 		Sensei()->assets->enqueue( 'sensei-course-outline', 'blocks/course-outline/style.css' );
+
+		if ( ! is_admin() ) {
+			Sensei()->assets->enqueue( 'sensei-course-outline-frontend', 'blocks/course-outline/frontend.js' );
+		}
 	}
 
 	/**

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -253,7 +253,7 @@ class Sensei_Course_Outline_Block {
 					' . $progress_indicator . '
 					<div role="button" tabindex="0" class="wp-block-sensei-lms-course-outline__arrow dashicons dashicons-arrow-up-alt2"/>
 				</header>
-				<div class="wp-block-sensei-lms-collapsible ' . $animated . '">
+				<div class="wp-block-sensei-lms-collapsible expanded ' . $animated . '">
 					<div class="wp-block-sensei-lms-course-outline-module__description">
 						' . $block['description'] . '
 					</div>

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -255,7 +255,7 @@ class Sensei_Course_Outline_Block {
 						<span class="screen-reader-text">' . __( 'Toggle module content', 'sensei-lms' ) . '</span>
 					</button>
 				</header>
-				<div class="wp-block-sensei-lms-collapsible expanded ' . $animated . '">
+				<div class="wp-block-sensei-lms-collapsible ' . $animated . '">
 					<div class="wp-block-sensei-lms-course-outline-module__description">
 						' . $block['description'] . '
 					</div>

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -144,7 +144,7 @@ class Sensei_Frontend {
 			}
 
 			Sensei()->assets->register( Sensei()->token . '-user-dashboard', 'js/user-dashboard.js', [ 'jquery-ui-tabs' ], true );
-			Sensei()->assets->register( 'sensei-course-outline-frontend', 'blocks/course-outline/frontend.js', [ 'jquery' ], true );
+			Sensei()->assets->register( 'sensei-course-outline-frontend', 'blocks/course-outline/frontend.js', [], true );
 
 			// Allow additional scripts to be loaded.
 			do_action( 'sensei_additional_scripts' );

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -144,7 +144,6 @@ class Sensei_Frontend {
 			}
 
 			Sensei()->assets->register( Sensei()->token . '-user-dashboard', 'js/user-dashboard.js', [ 'jquery-ui-tabs' ], true );
-			Sensei()->assets->register( 'sensei-course-outline-frontend', 'blocks/course-outline/frontend.js', [], true );
 
 			// Allow additional scripts to be loaded.
 			do_action( 'sensei_additional_scripts' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -35010,6 +35010,15 @@
         "object-assign": "^4.1.0"
       }
     },
+    "react-animate-height": {
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/react-animate-height/-/react-animate-height-2.0.23.tgz",
+      "integrity": "sha512-DucSC/1QuxWEFzR9IsHMzrf2nrcZ6qAmLIFoENa2kLK7h72XybcMA9o073z7aHccFzdMEW0/fhAdnQG7a4rDow==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.1"
+      }
+    },
     "react-autosize-textarea": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/react-autosize-textarea/-/react-autosize-textarea-3.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@wordpress/i18n": "3.14.0",
     "@wordpress/url": "2.17.0",
     "interpolate-components": "1.1.1",
+    "react-animate-height": "2.0.23",
     "select2": "4.0.13"
   },
   "devDependencies": {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update overflow to auto. It allows the user to scroll into the module if there are many lessons.
* If we don't want this scroll when there are many lessons, we could change the animation for something that doesn't depend on the `max-height` (scale/opacity/translate).

### Testing instructions

* Add many lessons to a module until to be more than `2000px` height.
* Make sure you can scroll through the content.
* Collapse and expand the module box, and make sure the animation still works properly.