### PR TITLE
Handle block based and legacy single course frontend rendering

### DIFF
--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -171,8 +171,6 @@ class Sensei_Course_Outline_Block {
 
 		$structure = Sensei_Course_Structure::instance( $post->ID )->get( 'view' );
 
-		$this->disable_course_legacy_content();
-
 		$this->add_block_attributes( $structure );
 
 		$block_class = 'wp-block-sensei-lms-course-outline';
@@ -307,16 +305,6 @@ class Sensei_Course_Outline_Block {
 						<span class="wp-block-sensei-lms-course-outline__progress-indicator__text"> ' . $module_status . ' </span>
 					</div>
 		';
-	}
-
-	/**
-	 * Disable course legacy content.
-	 */
-	private function disable_course_legacy_content() {
-		// TODO: Check the best approach for backwards compatibility.
-		remove_action( 'sensei_single_course_content_inside_after', 'course_single_lessons' );
-		remove_action( 'sensei_single_course_content_inside_after', [ 'Sensei_Course', 'the_course_lessons_title' ], 9 );
-		remove_action( 'sensei_single_course_content_inside_after', [ Sensei()->modules, 'load_course_module_content_template' ], 8 );
 	}
 
 }

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3472,7 +3472,7 @@ class Sensei_Course {
 			&& is_singular( 'course' )
 			&& ! $this->is_legacy_course( $post )
 		) {
-			$this->remove_legacy_course_actions();;
+			$this->remove_legacy_course_actions();
 		}
 	}
 
@@ -3490,6 +3490,9 @@ class Sensei_Course {
 		add_action( 'sensei_single_course_content_inside_after', array( __CLASS__, 'the_course_lessons_title' ), 9 );
 		add_action( 'sensei_single_course_content_inside_after', 'course_single_lessons', 10 );
 
+		// Take this course.
+		add_action( 'sensei_single_course_content_inside_before', array( __CLASS__, 'the_course_enrolment_actions' ), 30 );
+
 		// Module listing.
 		add_action( 'sensei_single_course_content_inside_after', array( $sensei->modules, 'load_course_module_content_template' ), 8 );
 
@@ -3501,10 +3504,6 @@ class Sensei_Course {
 	 * Remove legacy course actions.
 	 */
 	public function remove_legacy_course_actions() {
-		// Legacy progress bar on the single course page.
-		remove_action( 'sensei_single_course_content_inside_before', array( $this, 'the_progress_statement' ), 15 );
-		remove_action( 'sensei_single_course_content_inside_before', array( $this, 'the_progress_meter' ), 16 );
-
 		// Legacy lesson listing.
 		remove_action( 'sensei_single_course_content_inside_after', array( __CLASS__, 'the_course_lessons_title' ), 9 );
 		remove_action( 'sensei_single_course_content_inside_after', 'course_single_lessons', 10 );
@@ -3512,8 +3511,7 @@ class Sensei_Course {
 		// Module listing.
 		remove_action( 'sensei_single_course_content_inside_after', array( Sensei()->modules, 'load_course_module_content_template' ), 8 );
 
-		// Add message links to courses.
-		remove_action( 'sensei_single_course_content_inside_before', array( Sensei()->post_types->messages, 'send_message_link' ), 35 );
+		// @todo Remove additional actions from `\Sensei_Course::add_legacy_course_hooks` as implemented in blocks.
 	}
 
 	/**
@@ -3530,7 +3528,7 @@ class Sensei_Course {
 			'sensei-lms/course-outline',
 		];
 
-		foreach( $course_blocks as $block ) {
+		foreach ( $course_blocks as $block ) {
 			if ( has_block( $block, $course ) ) {
 				return false;
 			}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3483,21 +3483,21 @@ class Sensei_Course {
 	 */
 	public function add_legacy_course_hooks( $sensei ) {
 		// Legacy progress bar on the single course page.
-		add_action( 'sensei_single_course_content_inside_before', array( $this, 'the_progress_statement' ), 15 );
-		add_action( 'sensei_single_course_content_inside_before', array( $this, 'the_progress_meter' ), 16 );
+		add_action( 'sensei_single_course_content_inside_before', [ $this, 'the_progress_statement' ], 15 );
+		add_action( 'sensei_single_course_content_inside_before', [ $this, 'the_progress_meter' ], 16 );
 
 		// Legacy lesson listing.
-		add_action( 'sensei_single_course_content_inside_after', array( __CLASS__, 'the_course_lessons_title' ), 9 );
+		add_action( 'sensei_single_course_content_inside_after', [ __CLASS__, 'the_course_lessons_title' ], 9 );
 		add_action( 'sensei_single_course_content_inside_after', 'course_single_lessons', 10 );
 
 		// Take this course.
-		add_action( 'sensei_single_course_content_inside_before', array( __CLASS__, 'the_course_enrolment_actions' ), 30 );
+		add_action( 'sensei_single_course_content_inside_before', [ __CLASS__, 'the_course_enrolment_actions' ], 30 );
 
 		// Module listing.
-		add_action( 'sensei_single_course_content_inside_after', array( $sensei->modules, 'load_course_module_content_template' ), 8 );
+		add_action( 'sensei_single_course_content_inside_after', [ $sensei->modules, 'load_course_module_content_template' ], 8 );
 
 		// Add message links to courses.
-		add_action( 'sensei_single_course_content_inside_before', array( $sensei->post_types->messages, 'send_message_link' ), 35 );
+		add_action( 'sensei_single_course_content_inside_before', [ $sensei->post_types->messages, 'send_message_link' ], 35 );
 	}
 
 	/**
@@ -3505,11 +3505,11 @@ class Sensei_Course {
 	 */
 	public function remove_legacy_course_actions() {
 		// Legacy lesson listing.
-		remove_action( 'sensei_single_course_content_inside_after', array( __CLASS__, 'the_course_lessons_title' ), 9 );
+		remove_action( 'sensei_single_course_content_inside_after', [ __CLASS__, 'the_course_lessons_title' ], 9 );
 		remove_action( 'sensei_single_course_content_inside_after', 'course_single_lessons', 10 );
 
 		// Module listing.
-		remove_action( 'sensei_single_course_content_inside_after', array( Sensei()->modules, 'load_course_module_content_template' ), 8 );
+		remove_action( 'sensei_single_course_content_inside_after', [ Sensei()->modules, 'load_course_module_content_template' ], 8 );
 
 		// @todo Remove additional actions from `\Sensei_Course::add_legacy_course_hooks` as implemented in blocks.
 	}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -82,10 +82,6 @@ class Sensei_Course {
 		// Update course completion upon grading of a quiz
 		add_action( 'sensei_user_quiz_grade', array( $this, 'update_status_after_quiz_submission' ), 10, 2 );
 
-		// show the progress bar ont he single course page
-		add_action( 'sensei_single_course_content_inside_before', array( $this, 'the_progress_statement' ), 15 );
-		add_action( 'sensei_single_course_content_inside_before', array( $this, 'the_progress_meter' ), 16 );
-
 		// provide an option to block all emails related to a selected course
 		add_filter( 'sensei_send_emails', array( $this, 'block_notification_emails' ) );
 		add_action( 'save_post', array( $this, 'save_course_notification_meta_box' ) );
@@ -127,6 +123,9 @@ class Sensei_Course {
 
 		// Log event on the initial publish for a course.
 		add_action( 'sensei_course_initial_publish', [ $this, 'log_initial_publish_event' ] );
+
+		add_action( 'template_redirect', [ $this, 'setup_single_course_page' ] );
+		add_action( 'sensei_loaded', [ $this, 'add_legacy_course_hooks' ] );
 	}
 
 	/**
@@ -3459,6 +3458,86 @@ class Sensei_Course {
 		sensei_log_event( 'course_publish', $event_properties );
 	}
 
+	/**
+	 * Setup the single course page.
+	 *
+	 * @access private
+	 */
+	public function setup_single_course_page() {
+		global $post;
+
+		// Remove legacy actions on courses with new blocks.
+		if (
+			$post
+			&& is_singular( 'course' )
+			&& ! $this->is_legacy_course( $post )
+		) {
+			$this->remove_legacy_course_actions();;
+		}
+	}
+
+	/**
+	 * Adds legacy course actions.
+	 *
+	 * @param Sensei_Main $sensei Sensei object.
+	 */
+	public function add_legacy_course_hooks( $sensei ) {
+		// Legacy progress bar on the single course page.
+		add_action( 'sensei_single_course_content_inside_before', array( $this, 'the_progress_statement' ), 15 );
+		add_action( 'sensei_single_course_content_inside_before', array( $this, 'the_progress_meter' ), 16 );
+
+		// Legacy lesson listing.
+		add_action( 'sensei_single_course_content_inside_after', array( __CLASS__, 'the_course_lessons_title' ), 9 );
+		add_action( 'sensei_single_course_content_inside_after', 'course_single_lessons', 10 );
+
+		// Module listing.
+		add_action( 'sensei_single_course_content_inside_after', array( $sensei->modules, 'load_course_module_content_template' ), 8 );
+
+		// Add message links to courses.
+		add_action( 'sensei_single_course_content_inside_before', array( $sensei->post_types->messages, 'send_message_link' ), 35 );
+	}
+
+	/**
+	 * Remove legacy course actions.
+	 */
+	public function remove_legacy_course_actions() {
+		// Legacy progress bar on the single course page.
+		remove_action( 'sensei_single_course_content_inside_before', array( $this, 'the_progress_statement' ), 15 );
+		remove_action( 'sensei_single_course_content_inside_before', array( $this, 'the_progress_meter' ), 16 );
+
+		// Legacy lesson listing.
+		remove_action( 'sensei_single_course_content_inside_after', array( __CLASS__, 'the_course_lessons_title' ), 9 );
+		remove_action( 'sensei_single_course_content_inside_after', 'course_single_lessons', 10 );
+
+		// Module listing.
+		remove_action( 'sensei_single_course_content_inside_after', array( Sensei()->modules, 'load_course_module_content_template' ), 8 );
+
+		// Add message links to courses.
+		remove_action( 'sensei_single_course_content_inside_before', array( Sensei()->post_types->messages, 'send_message_link' ), 35 );
+	}
+
+	/**
+	 * Check if a course is a legacy course.
+	 *
+	 * @param int|WP_Post $course Course ID or course object.
+	 *
+	 * @return bool
+	 */
+	public function is_legacy_course( $course ) {
+		$course = get_post( $course );
+
+		$course_blocks = [
+			'sensei-lms/course-outline',
+		];
+
+		foreach( $course_blocks as $block ) {
+			if ( has_block( $block, $course ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
 }//end class
 
 /**

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -46,9 +46,6 @@ class Sensei_Messages {
 		// Block WordPress from sending comment moderator emails on the sensei messages post types
 		add_filter( 'comment_moderation_recipients', array( $this, 'stop_wp_comment_emails' ), 20, 2 );
 
-		// Add message links to courses & lessons
-		add_action( 'sensei_single_course_content_inside_before', array( $this, 'send_message_link' ), 35 );
-
 		// add message link to lesson
 		add_action( 'sensei_single_lesson_content_inside_before', array( $this, 'send_message_link' ), 30, 2 );
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -74,9 +74,6 @@ class Sensei_Core_Modules {
 
 		add_filter( 'body_class', array( $this, 'module_archive_body_class' ) );
 
-		// add modules to the single course template
-		add_action( 'sensei_single_course_content_inside_after', array( $this, 'load_course_module_content_template' ), 8 );
-
 		// Single Course modules actions. Add to single-course/course-modules.php
 		add_action( 'sensei_single_course_modules_before', array( $this, 'course_modules_title' ), 20 );
 

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -41,6 +41,13 @@ class Sensei_PostTypes {
 	public $quiz;
 
 	/**
+	 * Messages object.
+	 *
+	 * @var Sensei_Messages
+	 */
+	public $messages;
+
+	/**
 	 * Array of post ID's for which to fire an "initial publish" action.
 	 *
 	 * @var array

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -240,6 +240,15 @@ class Sensei_Main {
 		// load all hooks
 		$this->load_hooks();
 
+		/**
+		 * Fires once all global objects have been set in Sensei.
+		 *
+		 * @hook sensei_loaded
+		 * @since 3.6.0
+		 *
+		 * @param {Sensei_Main} $sensei Sensei object.
+		 */
+		do_action( 'sensei_loaded', $this );
 	} // End __construct()
 
 	/**
@@ -254,7 +263,6 @@ class Sensei_Main {
 		add_action( 'init', array( $this, 'load_localisation' ), 0 );
 
 		$this->initialize_global_objects();
-
 	}
 
 	/**

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -78,14 +78,8 @@ add_action( 'sensei_single_course_content_inside_before', array( $sensei->course
 add_filter( 'the_content', array( 'Sensei_Course', 'single_course_content' ) );
 
 // @since 1.9.0
-// add the single course lessons title
-add_action( 'sensei_single_course_content_inside_after', array( 'Sensei_Course', 'the_course_lessons_title' ), 9 );
-
-// @since 1.9.0
 // hooks in the course lessons query and remove it at the end
-// also loading the course lessons template in the middle
 add_action( 'sensei_single_course_lessons_before', array( 'Sensei_Course', 'load_single_course_lessons_query' ) );
-add_action( 'sensei_single_course_content_inside_after', 'course_single_lessons', 10 );
 add_action( 'sensei_single_course_lessons_after', array( 'Sensei_Utils', 'restore_wp_query' ) );
 
 // @since 1.9.0

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -104,7 +104,6 @@ add_action( 'sensei_single_course_modules_after', array( 'Sensei_Core_Modules', 
 
 // @since 1.9.0
 // Course meta
-add_action( 'sensei_single_course_content_inside_before', array( 'Sensei_Course', 'the_course_enrolment_actions' ), 30 );
 add_action( 'sensei_single_course_content_inside_before', array( 'Sensei_Course', 'the_course_video' ), 40 );
 
 /***************************


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Consolidates hooks for legacy courses in one method.
* Starts removing implemented actions. 
* Note: I've just consolidated the actions that we've talked about transitioning to blocks, but I've only removed the ones that we've actually implemented. We should be able to move more in as the scope changes.

### Testing instructions

* Not much should change from `master` as this was being implemented already in the course outline block PHP.
* Classic courses should appear the same.

### New/Updated Hooks

* `sensei_loaded`: For slightly late loading some actions.