### PR TITLE
Fix structure saving

### DIFF
--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -71,9 +71,11 @@ export const syncStructureToBlocks = ( structure, blocks ) => {
  * @param {[CourseLessonData,CourseModuleData]} item   Structure item.
  * @return {Object} The block, if found.
  */
-const findBlock = ( blocks, { id, type } ) => {
+const findBlock = ( blocks, { id, type, title } ) => {
 	const compare = ( { name, attributes } ) =>
-		id === attributes.id && blockNames[ type ] === name;
+		( id === attributes.id ||
+			( ! attributes.id && attributes.title === title ) ) &&
+		blockNames[ type ] === name;
 	return (
 		blocks.find( compare ) ||
 		( 'lesson' === type &&

--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -92,9 +92,12 @@ const findBlock = ( blocks, { id, type } ) => {
 export const extractStructure = ( blocks ) => {
 	const extractBlockData = {
 		module: ( block ) => ( {
+			description: block.attributes.description,
 			lessons: extractStructure( block.innerBlocks ),
 		} ),
-		lesson: () => ( {} ),
+		lesson: ( block ) => ( {
+			draft: block.attributes.draft,
+		} ),
 	};
 
 	return blocks
@@ -102,8 +105,8 @@ export const extractStructure = ( blocks ) => {
 			const type = blockTypes[ block.name ];
 			return {
 				type,
-				className: block.className,
-				...block.attributes,
+				id: block.attributes.id,
+				title: block.attributes.title,
 				...extractBlockData[ type ]( block ),
 			};
 		} )

--- a/assets/blocks/course-outline/lesson-block/index.js
+++ b/assets/blocks/course-outline/lesson-block/index.js
@@ -27,6 +27,10 @@ registerBlockType( 'sensei-lms/course-outline-lesson', {
 			type: 'string',
 			default: '',
 		},
+		draft: {
+			type: 'boolean',
+			default: true,
+		},
 		backgroundColor: {
 			type: 'string',
 		},

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -1,6 +1,7 @@
 import { apiFetch, controls as dataControls } from '@wordpress/data-controls';
 import { dispatch, registerStore, select, subscribe } from '@wordpress/data';
 import { createReducerFromActionMap } from '../../shared/data/store-helpers';
+import { isEqual } from 'lodash';
 
 const DEFAULT_STATE = {
 	structure: [],
@@ -24,8 +25,7 @@ const actions = {
 	 * Persist editor's course structure to the REST API
 	 */
 	*save() {
-		const { shouldSave, getEditorStructure } = select( COURSE_STORE );
-		if ( ! ( yield shouldSave() ) ) return;
+		const { getEditorStructure } = select( COURSE_STORE );
 
 		yield { type: 'SAVING', isSaving: true };
 		const courseId = yield select( 'core/editor' ).getCurrentPostId();
@@ -43,7 +43,12 @@ const actions = {
 		yield { type: 'SAVING', isSaving: false };
 	},
 	setStructure: ( structure ) => ( { type: 'SET_SERVER', structure } ),
-	setEditorStructure: ( structure ) => ( { type: 'SET_EDITOR', structure } ),
+	setEditorStructure: ( structure ) => {
+		return { type: 'SET_EDITOR', structure };
+	},
+	setEditorDirty: ( isDirty ) => {
+		return { type: 'SET_DIRTY', isDirty };
+	},
 };
 
 /**
@@ -56,14 +61,21 @@ const reducers = {
 		editor: structure,
 		isDirty: false,
 	} ),
-	SET_EDITOR: ( { structure }, state ) => ( {
-		...state,
-		editor: structure,
-		isDirty: true,
-	} ),
+	SET_EDITOR: ( { structure }, state ) => {
+		const isDirty = ! isEqual( structure, state.structure );
+		return {
+			...state,
+			editor: structure,
+			isDirty,
+		};
+	},
 	SAVING: ( { isSaving }, state ) => ( {
 		...state,
 		isSaving,
+	} ),
+	SET_DIRTY: ( { isDirty }, state ) => ( {
+		...state,
+		isDirty,
 	} ),
 	DEFAULT: ( action, state ) => state,
 };
@@ -90,14 +102,28 @@ export const COURSE_STORE = 'sensei/course-structure';
  * Register course structure store and subscribe to block editor save.
  */
 const registerCourseStructureStore = () => {
-	subscribe( () => {
+	let wasSaving;
+	subscribe( function saveStructureOnPostSave() {
 		const editor = select( 'core/editor' );
 
 		if ( ! editor ) return;
 
-		if ( editor.isSavingPost() && ! editor.isAutosavingPost() ) {
-			dispatch( COURSE_STORE ).save();
+		const isSaving = editor.isSavingPost() && ! editor.isAutosavingPost();
+		const shouldSave = select( COURSE_STORE ).shouldSave();
+
+		if ( shouldSave ) {
+			if ( isSaving && ! wasSaving ) {
+				dispatch( COURSE_STORE ).save();
+			}
+
+			// Save the post again if the blocks were updated.
+			if ( ! isSaving && wasSaving ) {
+				wasSaving = true;
+				dispatch( 'core/editor' ).savePost();
+			}
 		}
+
+		wasSaving = isSaving;
 	} );
 
 	registerStore( COURSE_STORE, {

--- a/assets/blocks/course-outline/use-block-creator.js
+++ b/assets/blocks/course-outline/use-block-creator.js
@@ -1,7 +1,8 @@
-import { useDispatch, useSelect } from '@wordpress/data';
+import { dispatch, useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { extractStructure, syncStructureToBlocks } from './data';
 import { isEqual } from 'lodash';
+import { COURSE_STORE } from './store';
 
 /**
  * Blocks creator hook.
@@ -27,6 +28,8 @@ export const useBlocksCreator = ( clientId ) => {
 					syncStructureToBlocks( structure, blocks ),
 					false
 				);
+
+				dispatch( COURSE_STORE ).setEditorDirty( true );
 			}
 		},
 		[ clientId, replaceInnerBlocks, getBlocks ]

--- a/assets/blocks/course-outline/use-block-creator.js
+++ b/assets/blocks/course-outline/use-block-creator.js
@@ -1,6 +1,7 @@
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import { syncStructureToBlocks } from './data';
+import { extractStructure, syncStructureToBlocks } from './data';
+import { isEqual } from 'lodash';
 
 /**
  * Blocks creator hook.
@@ -17,13 +18,16 @@ export const useBlocksCreator = ( clientId ) => {
 	);
 
 	const setBlocks = useCallback(
-		( blockData ) => {
+		( structure ) => {
 			const blocks = getBlocks( clientId );
-			replaceInnerBlocks(
-				clientId,
-				syncStructureToBlocks( blockData, blocks ),
-				false
-			);
+			const currentStructure = extractStructure( blocks );
+			if ( ! isEqual( currentStructure, structure ) ) {
+				replaceInnerBlocks(
+					clientId,
+					syncStructureToBlocks( structure, blocks ),
+					false
+				);
+			}
 		},
 		[ clientId, replaceInnerBlocks, getBlocks ]
 	);


### PR DESCRIPTION

This fixes a few issues caused by the blocks being updated after saving:
* IDs not being assigned to the new blocks on first save
* Posts having a newer version autosaved if the user doesn't save the post again
* Post always being displayed as dirty after save 

Looks like saving the post again is seamless to the user, and this is the cleanest of the possible solutions.

### Changes proposed in this Pull Request

* Add check to only update the blocks if the structure is different
* Add check to only save the structure if it changed
* Save the post again when the blocks were updated after the structure was saved ( = IDs were assigned to new lessons/modules)

### Testing instructions

* Create course with outline block, add lessons, customize their colors
* Publish the post
* Post should be marked as saved (course meta boxes might interfere with this one)
* IDs should be saved in the post_content for the lesson blocks
* After publishing the lessons, their style on the frontend should also look like as set in the editor
--
* Reloading a course post after saving should not show a *Newer autosaved version is available* message.
