### PR TITLE
Hide modules and lessons meta boxes in course editor when outline is added

### DIFF
--- a/assets/blocks/course-outline/course-block/edit.js
+++ b/assets/blocks/course-outline/course-block/edit.js
@@ -2,7 +2,6 @@ import { InnerBlocks } from '@wordpress/block-editor';
 import { useSelect, withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { createContext, useEffect } from '@wordpress/element';
-import { noop } from 'lodash';
 
 import { CourseOutlinePlaceholder } from './placeholder';
 import { COURSE_STORE } from '../store';
@@ -112,12 +111,20 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 		editPost.isEditorPanelEnabled( 'meta-box-module_course_mb' );
 
 	const toggleLegacyMetaboxes = ( enable ) => {
-		// If the `enable` is already as requested, do nothing.
-		const toggleFn =
-			enable === hasLegacyMetaBoxes ? noop : toggleEditorPanelEnabled;
+		// Side-effect - Prevent submit modules.
+		document
+			.querySelectorAll( '#module_course_mb input' )
+			.forEach( ( input ) => {
+				input.disabled = ! enable;
+			} );
 
-		toggleFn( 'meta-box-course-lessons' );
-		toggleFn( 'meta-box-module_course_mb' );
+		// If the `enable` is already as requested, do nothing.
+		if ( enable === hasLegacyMetaBoxes ) {
+			return;
+		}
+
+		toggleEditorPanelEnabled( 'meta-box-course-lessons' );
+		toggleEditorPanelEnabled( 'meta-box-module_course_mb' );
 	};
 
 	return { toggleLegacyMetaboxes };

--- a/assets/blocks/course-outline/course-block/edit.js
+++ b/assets/blocks/course-outline/course-block/edit.js
@@ -99,27 +99,31 @@ const EditCourseOutlineBlock = ( {
 	);
 };
 
+const applyWithSelect = withSelect( ( select ) => ( {
+	structure: select( COURSE_STORE ).getStructure(),
+} ) );
+
+const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
+	const editPost = select( 'core/edit-post' );
+	const { toggleEditorPanelEnabled } = dispatch( 'core/edit-post' );
+
+	const hasLegacyMetaBoxes =
+		editPost.isEditorPanelEnabled( 'meta-box-course-lessons' ) ||
+		editPost.isEditorPanelEnabled( 'meta-box-module_course_mb' );
+
+	const toggleLegacyMetaboxes = ( enable ) => {
+		// If the `enable` is already as requested, do nothing.
+		const toggleFn =
+			enable === hasLegacyMetaBoxes ? noop : toggleEditorPanelEnabled;
+
+		toggleFn( 'meta-box-course-lessons' );
+		toggleFn( 'meta-box-module_course_mb' );
+	};
+
+	return { toggleLegacyMetaboxes };
+} );
+
 export default compose(
-	withSelect( ( select ) => ( {
-		structure: select( COURSE_STORE ).getStructure(),
-	} ) ),
-	withDispatch( ( dispatch, ownProps, { select } ) => {
-		const editPost = select( 'core/edit-post' );
-		const { toggleEditorPanelEnabled } = dispatch( 'core/edit-post' );
-
-		const hasLegacyMetaBoxes =
-			editPost.isEditorPanelEnabled( 'meta-box-course-lessons' ) ||
-			editPost.isEditorPanelEnabled( 'meta-box-module_course_mb' );
-
-		const toggleLegacyMetaboxes = ( enable ) => {
-			// If the `enable` is already as requested, do nothing.
-			const toggleFn =
-				enable === hasLegacyMetaBoxes ? noop : toggleEditorPanelEnabled;
-
-			toggleFn( 'meta-box-course-lessons' );
-			toggleFn( 'meta-box-module_course_mb' );
-		};
-
-		return { toggleLegacyMetaboxes };
-	} )
+	applyWithSelect,
+	applyWithDispatch
 )( EditCourseOutlineBlock );

--- a/assets/blocks/course-outline/course-block/edit.js
+++ b/assets/blocks/course-outline/course-block/edit.js
@@ -1,6 +1,9 @@
 import { InnerBlocks } from '@wordpress/block-editor';
-import { useSelect, withSelect } from '@wordpress/data';
+import { useSelect, withSelect, withDispatch } from '@wordpress/data';
+import { compose } from '@wordpress/compose';
 import { createContext, useEffect } from '@wordpress/element';
+import { noop } from 'lodash';
+
 import { CourseOutlinePlaceholder } from './placeholder';
 import { COURSE_STORE } from '../store';
 import { useBlocksCreator } from '../use-block-creator';
@@ -14,20 +17,31 @@ export const OutlineAttributesContext = createContext();
 /**
  * Edit course outline block component.
  *
- * @param {Object}   props               Component props.
- * @param {string}   props.clientId      Block client ID.
- * @param {string}   props.className     Custom class name.
- * @param {Object[]} props.structure     Course module and lesson blocks.
- * @param {Object}   props.attributes    Block attributes.
- * @param {Function} props.setAttributes Block setAttributes callback.
+ * @param {Object}   props                       Component props.
+ * @param {string}   props.clientId              Block client ID.
+ * @param {string}   props.className             Custom class name.
+ * @param {Object[]} props.structure             Course module and lesson blocks.
+ * @param {Function} props.toggleLegacyMetaboxes Function to toggle metaboxes.
+ * @param {Object}   props.attributes            Block attributes.
+ * @param {Function} props.setAttributes         Block setAttributes callback.
  */
 const EditCourseOutlineBlock = ( {
 	clientId,
 	className,
 	structure,
+	toggleLegacyMetaboxes,
 	attributes,
 	setAttributes,
 } ) => {
+	// Toggle legacy metaboxes.
+	useEffect( () => {
+		toggleLegacyMetaboxes( false );
+
+		return () => {
+			toggleLegacyMetaboxes( true );
+		};
+	}, [ toggleLegacyMetaboxes ] );
+
 	const { setBlocks } = useBlocksCreator( clientId );
 
 	/**
@@ -85,8 +99,27 @@ const EditCourseOutlineBlock = ( {
 	);
 };
 
-export default withSelect( ( select ) => {
-	return {
+export default compose(
+	withSelect( ( select ) => ( {
 		structure: select( COURSE_STORE ).getStructure(),
-	};
-} )( EditCourseOutlineBlock );
+	} ) ),
+	withDispatch( ( dispatch, ownProps, { select } ) => {
+		const editPost = select( 'core/edit-post' );
+		const { toggleEditorPanelEnabled } = dispatch( 'core/edit-post' );
+
+		const hasLegacyMetaBoxes =
+			editPost.isEditorPanelEnabled( 'meta-box-course-lessons' ) ||
+			editPost.isEditorPanelEnabled( 'meta-box-module_course_mb' );
+
+		const toggleLegacyMetaboxes = ( enable ) => {
+			// If the `enable` is already as requested, do nothing.
+			const toggleFn =
+				enable === hasLegacyMetaBoxes ? noop : toggleEditorPanelEnabled;
+
+			toggleFn( 'meta-box-course-lessons' );
+			toggleFn( 'meta-box-module_course_mb' );
+		};
+
+		return { toggleLegacyMetaboxes };
+	} )
+)( EditCourseOutlineBlock );

--- a/assets/blocks/course-outline/course-block/edit.js
+++ b/assets/blocks/course-outline/course-block/edit.js
@@ -98,11 +98,11 @@ const EditCourseOutlineBlock = ( {
 	);
 };
 
-const applyWithSelect = withSelect( ( select ) => ( {
+const selectors = ( select ) => ( {
 	structure: select( COURSE_STORE ).getStructure(),
-} ) );
+} );
 
-const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
+const dispatches = ( dispatch, ownProps, { select } ) => {
 	const editPost = select( 'core/edit-post' );
 	const { toggleEditorPanelEnabled } = dispatch( 'core/edit-post' );
 
@@ -128,9 +128,9 @@ const applyWithDispatch = withDispatch( ( dispatch, ownProps, { select } ) => {
 	};
 
 	return { toggleLegacyMetaboxes };
-} );
+};
 
 export default compose(
-	applyWithSelect,
-	applyWithDispatch
+	withSelect( selectors ),
+	withDispatch( dispatches )
 )( EditCourseOutlineBlock );

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -130,7 +130,7 @@ class Sensei_Core_Modules {
 
 		}
 
-		if ( 'course' == $post_type && ! Sensei()->feature_flags->is_enabled( 'course_outline' ) ) {
+		if ( 'course' == $post_type ) {
 			// Course modules selection metabox
 			add_meta_box( $this->taxonomy . '_course_mb', __( 'Course Modules', 'sensei-lms' ), array( $this, 'course_module_metabox' ), 'course', 'side', 'core' );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Hide modules and lessons meta boxes in course editor when outline is added.
* Show modules and lessons meta boxes in course editor when outline is added.
* It also enables/disables the inputs of the modules in the frontend to prevent them to submit, which conflict with the outline course structure, when it's added.

If we add some modules through the outline, it won't sync with the modules meta box until the page update. I think it'd be overengineering because the users likely won't edit the courses adding/removing the outline. But if someone thinks it's really important, we can add this feature.

### Testing instructions

* Open the course editor.
* Remove the outline and make sure the lessons and modules meta boxes are appearing.
* Add the outline and make sure the lessons and modules meta boxes are hidden.
* Add/remove some modules and lessons through the outline, save and make sure it's saving correctly.