### PR TITLE
Group selected lessons into a module

### DIFF
--- a/assets/blocks/course-outline/module-block/index.js
+++ b/assets/blocks/course-outline/module-block/index.js
@@ -4,6 +4,7 @@ import { __ } from '@wordpress/i18n';
 import { ModuleIcon } from '../../../icons';
 
 import EditModuleBlock from './edit';
+import transforms from './transforms';
 
 registerBlockType( 'sensei-lms/course-outline-module', {
 	title: __( 'Module', 'sensei-lms' ),
@@ -32,6 +33,7 @@ registerBlockType( 'sensei-lms/course-outline-module', {
 	edit( props ) {
 		return <EditModuleBlock { ...props } />;
 	},
+	transforms,
 	save( { className } ) {
 		return (
 			<div className={ className }>

--- a/assets/blocks/course-outline/module-block/transforms.js
+++ b/assets/blocks/course-outline/module-block/transforms.js
@@ -1,0 +1,33 @@
+import { createBlock } from '@wordpress/blocks';
+
+/**
+ * Module block transform.
+ */
+export default {
+	from: [
+		{
+			type: 'block',
+			blocks: [ 'sensei-lms/course-outline-lesson' ],
+			isMultiBlock: true,
+			/**
+			 * Group selected lesson blocks into a module.
+			 *
+			 * @param {Object[]} blocks Attributes of the selected blocks.
+			 */
+			transform( blocks ) {
+				const innerBlocks = blocks.map( ( block ) => {
+					return createBlock(
+						'sensei-lms/course-outline-lesson',
+						block
+					);
+				} );
+
+				return createBlock(
+					'sensei-lms/course-outline-module',
+					{},
+					innerBlocks
+				);
+			},
+		},
+	],
+};


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Add a transform that allows grouping the selected lessons into a module

### Testing instructions

* Create one or more standalone lessons
* Select them with shift-click
* Click the block icon and transform to Module
* Lessons should be in a new module
--
* Ensure that it's not working for lessons already in a module

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![QuickTime movie](https://user-images.githubusercontent.com/176949/94315754-72cc1f00-ff83-11ea-85a5-a01e26e16962.gif)

