### PR TITLE
Log when a course is updated

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3486,6 +3486,10 @@ class Sensei_Course {
 	 * @param \WP_Post $post    Post object.
 	 */
 	public function mark_saving_course_id( $post_id, $post ) {
+		if ( ! Sensei()->feature_flags->is_enabled( 'course_outline' ) ) {
+			return;
+		}
+
 		$content = $post->post_content;
 
 		if ( has_block( 'sensei-lms/course-outline', $content ) ) {

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3561,6 +3561,7 @@ class Sensei_Course {
 			'module_count'      => count( wp_get_post_terms( $course_id, 'module' ) ),
 			'lesson_count'      => $this->course_lesson_count( $course_id ),
 			'product_count'     => $product_count,
+			'sample_course'     => 'getting-started-with-sensei-lms' === $post->post_name ? 1 : 0,
 		];
 
 		sensei_log_event( 'course_update', $event_properties );

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3560,7 +3560,7 @@ class Sensei_Course {
 			'product_count'     => $product_count,
 		];
 
-		sensei_log_event( 'course_publish', $event_properties );
+		sensei_log_event( 'course_update', $event_properties );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #2796

### Changes proposed in this Pull Request

* Add log for course update.
  * It ignores REST requests, similar to the `sensei_course_publish ` event.
  * In a conversation with @yscik, he suggested the idea to skip the post when it's being saved with a resave needed (when saves course outline block, needing to save again for ids sync). So before to log, we check if all lessons and modules contain ID (if not, a new post is coming).
  * The number of the lessons is counting only the published lessons, similar to the current `sensei_course_publish `. Is that the idea?
    * If we think this information is important for this log, maybe we could log the published lessons and the draft lessons separately.

### Testing instructions

See https://github.com/Automattic/sensei/issues/2796 to understand the correct values to be logged.

* Create a course without course outline block.
* Save and make sure it's logged with the correct values once.
* Change some information.
* Save again and make sure it's logged with the correct values one more time.
* Add the course outline block.
* Save again and make sure it's logged with the correct values one more time.
* Add / change / remove modules and lessons.
* Save again and make sure it's logged with the correct values one more time.
* Activate the WCPC, create some products, add/remove them to the product.
* Save again and make sure it's logged with the correct values one more time.