### PR TITLE
Show draft status in lesson block

### DIFF
--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -31,7 +31,7 @@ const EditLessonBlock = ( props ) => {
 		clientId,
 		name,
 		className,
-		attributes: { title, id, fontSize },
+		attributes: { title, id, fontSize, draft },
 		backgroundColor,
 		textColor,
 		setAttributes,
@@ -96,6 +96,12 @@ const EditLessonBlock = ( props ) => {
 		status = (
 			<div className="wp-block-sensei-lms-course-outline-lesson__unsaved">
 				{ __( 'Unsaved', 'sensei-lms' ) }
+			</div>
+		);
+	} else if ( id && draft ) {
+		status = (
+			<div className="wp-block-sensei-lms-course-outline-lesson__draft">
+				{ __( 'Draft', 'sensei-lms' ) }
 			</div>
 		);
 	}

--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -20,6 +20,7 @@ import { Statuses } from '../status-control';
  * @param {string}   props.attributes.title    Lesson title.
  * @param {number}   props.attributes.id       Lesson Post ID
  * @param {number}   props.attributes.fontSize Lesson title font size.
+ * @param {boolean}  props.attributes.draft    Draft status of lesson.
  * @param {Object}   props.backgroundColor     Background color object.
  * @param {Object}   props.textColor           Text color object.
  * @param {Function} props.setAttributes       Block set attributes function.

--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -30,6 +30,7 @@
 
 	.wp-block-sensei-lms-course-outline-lesson {
 
+		&__draft,
 		&__unsaved {
 			font-size: 12px;
 			font-weight: bold;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Using the same styling for the "Unsaved" pill, this adds a "Draft" pill next to selected lesson when its in a draft state.

### Testing instructions

* Create a course. Save a new lesson.
* Ensure Draft appears next to lesson once saved. 
* Move from Draft to Published in lesson editor.
* Refresh course editor. Ensure "Draft" no longer appears.