### PR TITLE
Stop course duplication on teacher update

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3047,13 +3047,15 @@ class Sensei_Lesson {
 
 
 	/**
-	 * lesson_quizzes function.
+	 * Get the quizzes of a lesson
 	 *
 	 * @access public
-	 * @param int    $lesson_id (default: 0)
-	 * @param string $post_status (default: 'publish')
-	 * @param string $fields (default: 'ids')
-	 * @return int $quiz_id
+	 *
+	 * @param int    $lesson_id   The lesson id (default: 0).
+	 * @param string $post_status The post status (default: 'any').
+	 * @param string $fields      The fields to return (default: 'ids').
+	 *
+	 * @return int|null $quiz_id
 	 */
 	public function lesson_quizzes( $lesson_id = 0, $post_status = 'any', $fields = 'ids' ) {
 
@@ -3073,7 +3075,7 @@ class Sensei_Lesson {
 		$quiz_id     = array_shift( $posts_array );
 
 		return $quiz_id;
-	} // End lesson_quizzes()
+	}
 
 
 	/**

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -479,14 +479,15 @@ class Sensei_Teacher {
 	}
 
 	/**
-	 * Sensei_Teacher::update_course_lessons_author
-	 *
-	 * Update all course lessons and their quiz with a new author
+	 * Update all course lessons and their quiz with a new author.
 	 *
 	 * @since 1.8.0
 	 * @access public
-	 * @parameters
-	 * @return array $users user id array
+	 *
+	 * @param int $course_id  The course id.
+	 * @param int $new_author The new authors id.
+	 *
+	 * @return bool True when the author is updated.
 	 */
 	public function update_course_lessons_author( $course_id, $new_author ) {
 
@@ -494,25 +495,25 @@ class Sensei_Teacher {
 			return false;
 		}
 
-		// get a list of course lessons
+		// Get a list of course lessons.
 		$lessons = Sensei()->course->course_lessons( $course_id, null );
 
 		if ( empty( $lessons ) || ! is_array( $lessons ) ) {
 			return false;
 		}
 
-		// Temporarily remove the author match filter
+		// Temporarily remove the author match filter.
 		remove_filter( 'wp_insert_post_data', array( $this, 'update_lesson_teacher' ), 99 );
 
-		// update each lesson and quiz author
+		// Update each lesson and quiz author.
 		foreach ( $lessons as $lesson ) {
 
-			// don't update if the author is tha same as the new author
+			// Don't update if the author is tha same as the new author.
 			if ( $new_author == $lesson->post_author ) {
 				continue;
 			}
 
-			// update lesson author
+			// Update lesson author.
 			wp_update_post(
 				array(
 					'ID'          => $lesson->ID,
@@ -520,12 +521,10 @@ class Sensei_Teacher {
 				)
 			);
 
-			// update quiz author
-			// get the lessons quiz
+			// Update quiz author.
 			$lesson_quizzes = Sensei()->lesson->lesson_quizzes( $lesson->ID );
 			if ( is_array( $lesson_quizzes ) ) {
 				foreach ( $lesson_quizzes as $quiz_id ) {
-					// update quiz with new author
 					wp_update_post(
 						array(
 							'ID'          => $quiz_id,
@@ -533,7 +532,7 @@ class Sensei_Teacher {
 						)
 					);
 				}
-			} else {
+			} elseif ( ! empty( $lesson_quizzes ) ) {
 				wp_update_post(
 					array(
 						'ID'          => $lesson_quizzes,
@@ -541,14 +540,13 @@ class Sensei_Teacher {
 					)
 				);
 			}
-		} // End foreach().
+		}
 
-		// Reinstate the author match filter
+		// Reinstate the author match filter.
 		add_filter( 'wp_insert_post_data', array( $this, 'update_lesson_teacher' ), 99, 2 );
 
 		return true;
-
-	}//end update_course_lessons_author()
+	}
 
 
 


### PR DESCRIPTION
This fixes the issue of courses duplicating when the teacher was updated. The issue happened when the lesson has no quizzes linked. Normally lessons which are created in admin always have a quiz linked. However when created with other means (e.g. WPML translations), a quiz will not exist and code which relies on it won't work as expected.

### Changes proposed in this Pull Request

* We now check if there is a quiz to the lesson before trying to update.
* I also had a look in other cases to check what happens if `lesson_quizzes` returns null.

### Testing instructions

* Have a course with a lesson.
* Delete the quiz from the database to simulate that no quiz has been created with the lesson.
* Update the teacher of the course.
* Observe that no duplicates of the course are created.
