### PR TITLE
Update module reorder to use Sensei_Course_Structure

### DIFF
--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -356,7 +356,7 @@ class Sensei_Course_Structure {
 	 *
 	 * @param array $module_order Module order to save.
 	 */
-	private function save_module_order( array $module_order ) {
+	public function save_module_order( array $module_order ) {
 		$current_module_order_raw = get_post_meta( $this->course_id, '_module_order', true );
 		$current_module_order     = $current_module_order_raw ? array_map( 'intval', $current_module_order_raw ) : [];
 

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -150,7 +150,7 @@ class Sensei_Course_Structure {
 	 *
 	 * @return WP_Term[]
 	 */
-	private function get_modules() {
+	public function get_modules() {
 		$modules = Sensei()->modules->get_course_modules( $this->course_id );
 
 		if ( is_wp_error( $modules ) ) {

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1120,11 +1120,11 @@ class Sensei_Core_Modules {
 								if ( isset( $_GET['course_id'] ) ) {
 									$course_id = intval( $_GET['course_id'] );
 									if ( $course_id > 0 ) {
-										$modules = $this->get_course_modules( $course_id );
+										$modules = Sensei_Course_Structure::instance( $course_id )->get_modules();
 										$modules = $this->append_teacher_name_to_module( $modules, array( 'module' ), array() );
 										if ( $modules ) {
 
-											$order = $this->get_course_module_order( $course_id );
+											$order = wp_list_pluck( $modules, 'term_id' );
 
 											$order_string = '';
 											if ( $order ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Refactor module reorder page to use `Sensei_Course_Structure`.

### Testing instructions

It should not change the current behavior.

* Create a course with modules.
* Go to wp-admin > Courses > Order Modules.
* Select the course with modules.
* Reorder the modules, save.
* Check the course page and make sure it was reordered properly.