### PR TITLE
Update text in block settings and reorder the panels in the lesson block

### DIFF
--- a/assets/blocks/course-outline/course-block/settings.js
+++ b/assets/blocks/course-outline/course-block/settings.js
@@ -16,14 +16,14 @@ export function OutlineBlockSettings( {
 	return (
 		<InspectorControls>
 			<PanelBody
-				title={ __( 'Enable Animations', 'sensei-lms' ) }
-				initialOpen={ true }
+				title={ __( 'Animation', 'sensei-lms' ) }
+				initialOpen={ false }
 			>
 				<ToggleControl
 					checked={ animationsEnabled }
 					onChange={ setAnimationsEnabled }
 					label={ __(
-						'Enable animations on module collapse/expand.',
+						'Animate the expanding and collapsing of modules',
 						'sensei-lms'
 					) }
 				/>

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -42,7 +42,7 @@ export function LessonBlockSettings( {
 	return (
 		<InspectorControls>
 			{ id && (
-				<PanelBody>
+				<PanelBody title={ __( 'Lesson', 'sensei-lms' ) }>
 					<h2>
 						<ExternalLink
 							href={ `post.php?post=${ id }&action=edit` }
@@ -60,15 +60,6 @@ export function LessonBlockSettings( {
 					</p>
 				</PanelBody>
 			) }
-			<PanelBody
-				title={ __( 'Preview Lesson Status', 'sensei-lms' ) }
-				initialOpen={ false }
-			>
-				<StatusControl
-					status={ previewStatus }
-					setStatus={ setPreviewStatus }
-				/>
-			</PanelBody>
 			<PanelBody title={ __( 'Typography', 'sensei-lms' ) }>
 				<FontSizePicker
 					fontSizes={ fontSizes }
@@ -83,14 +74,14 @@ export function LessonBlockSettings( {
 				initialOpen={ false }
 				colorSettings={ [
 					{
-						value: backgroundColor.color,
-						label: __( 'Background color', 'sensei-lms' ),
-						onChange: setBackgroundColor,
-					},
-					{
 						value: textColor.color,
 						label: __( 'Text color', 'sensei-lms' ),
 						onChange: setTextColor,
+					},
+					{
+						value: backgroundColor.color,
+						label: __( 'Background color', 'sensei-lms' ),
+						onChange: setBackgroundColor,
 					},
 				] }
 			>
@@ -104,6 +95,15 @@ export function LessonBlockSettings( {
 					/>
 				}
 			</PanelColorSettings>
+			<PanelBody
+				title={ __( 'Preview Lesson Status', 'sensei-lms' ) }
+				initialOpen={ false }
+			>
+				<StatusControl
+					status={ previewStatus }
+					setStatus={ setPreviewStatus }
+				/>
+			</PanelBody>
 		</InspectorControls>
 	);
 }

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -62,17 +62,14 @@ export function LessonBlockSettings( {
 			) }
 			<PanelBody
 				title={ __( 'Preview Lesson Status', 'sensei-lms' ) }
-				initialOpen={ true }
+				initialOpen={ false }
 			>
 				<StatusControl
 					status={ previewStatus }
 					setStatus={ setPreviewStatus }
 				/>
 			</PanelBody>
-			<PanelBody
-				title={ __( 'Typography', 'sensei-lms' ) }
-				initialOpen={ false }
-			>
+			<PanelBody title={ __( 'Typography', 'sensei-lms' ) }>
 				<FontSizePicker
 					fontSizes={ fontSizes }
 					value={ fontSize }
@@ -83,6 +80,7 @@ export function LessonBlockSettings( {
 			</PanelBody>
 			<PanelColorSettings
 				title={ __( 'Color settings', 'sensei-lms' ) }
+				initialOpen={ false }
 				colorSettings={ [
 					{
 						value: backgroundColor.color,

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -96,7 +96,7 @@ export function LessonBlockSettings( {
 				}
 			</PanelColorSettings>
 			<PanelBody
-				title={ __( 'Preview Lesson Status', 'sensei-lms' ) }
+				title={ __( 'Status', 'sensei-lms' ) }
 				initialOpen={ false }
 			>
 				<StatusControl

--- a/assets/blocks/course-outline/module-block/index.js
+++ b/assets/blocks/course-outline/module-block/index.js
@@ -8,7 +8,7 @@ import transforms from './transforms';
 
 registerBlockType( 'sensei-lms/course-outline-module', {
 	title: __( 'Module', 'sensei-lms' ),
-	description: __( 'Used to group one or more lessons.', 'sensei-lms' ),
+	description: __( 'Group related lessons together.', 'sensei-lms' ),
 	icon: ModuleIcon,
 	category: 'sensei-lms',
 	parent: [ 'sensei-lms/course-outline' ],

--- a/assets/blocks/course-outline/module-block/settings.js
+++ b/assets/blocks/course-outline/module-block/settings.js
@@ -18,7 +18,7 @@ export function ModuleBlockSettings( {
 		<InspectorControls>
 			<PanelBody
 				title={ __( 'Status', 'sensei-lms' ) }
-				initialOpen={ true }
+				initialOpen={ false }
 			>
 				<ModuleStatusControl
 					isPreviewCompleted={ isPreviewCompleted }

--- a/assets/blocks/course-outline/status-control/index.js
+++ b/assets/blocks/course-outline/status-control/index.js
@@ -41,7 +41,7 @@ export const StatusControl = ( {
 	return (
 		<SelectControl
 			help={ __(
-				'Preview a status. The actual status that the learner sees is determined by their progress in the course.',
+				'Preview a lesson status. The actual status that the learner sees is determined by their progress in the course.',
 				'sensei-lms'
 			) }
 			{ ...props }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Changes which settings panels are initially open. As per the block editor handbook:

> Panels should be expanded by default if the content is important or essential. Panels that are open by default should appear at the top.

I followed the paragraph and heading blocks lead and only opened the _Typography_ panel for the lesson block. I also opted to add a title to panel containing the _Edit Lesson_ link and open it initially as well, since it is arguably an important setting.

* Minor updates to the copy
* Moves lesson status panel to the bottom since it's not that important relative to the other panels

### Testing instructions

* Add the course outline block to a course.
* Click on each of the course outline, module and lesson blocks. The only panels that should be open by default are _Typography_ and _Lesson_ in the lesson block.