### PR TITLE
Fix PHP notice when saving new lesson in course outline block

### DIFF
--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -122,7 +122,10 @@ class Sensei_Course_Outline_Block {
 	 * @return string
 	 */
 	public function process_lesson_block( $attributes ) {
-		$this->block_attributes['lesson'][ $attributes['id'] ] = $attributes;
+		if ( array_key_exists( 'id', $attributes ) ) {
+			$this->block_attributes['lesson'][ $attributes['id'] ] = $attributes;
+		}
+
 		return '';
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

Checks that the `id` key exists before accessing it.

### Testing instructions

* Add a new lesson to the course outline block.
* Save the course.
* Check that the following PHP notice is not logged:
```
PHP Notice:  Undefined index: id in /Users/donnapep/Local Sites/sensei/app/public/wp-content/plugins/sensei-lms/includes/blocks/class-sensei-course-outline-block.php on line 126
```