### PR TITLE
Show legacy meta boxes by default

### DIFF
--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -1,4 +1,20 @@
 jQuery( document ).ready( function ( $ ) {
+	const editPostSelector = wp.data.select( 'core/edit-post' );
+	const editPostDispatcher = wp.data.dispatch( 'core/edit-post' );
+
+	const isLegacyMetaBoxesDisabled =
+		! editPostSelector.isEditorPanelEnabled( 'meta-box-course-lessons' ) ||
+		! editPostSelector.isEditorPanelEnabled( 'meta-box-course-lessons' );
+
+	if ( isLegacyMetaBoxesDisabled ) {
+		editPostDispatcher.toggleEditorPanelEnabled(
+			'meta-box-course-lessons'
+		);
+		editPostDispatcher.toggleEditorPanelEnabled(
+			'meta-box-module_course_mb'
+		);
+	}
+
 	$( '#course-prerequisite-options' ).select2( { width: '100%' } );
 
 	function trackLinkClickCallback( event_name ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* When adding the Course Outline Block, we disable these meta boxes, but it's persisted in local storage by default, so we need re-check when loading the editor. Otherwise, it could load a course without Outline Block without the meta boxes if this preference is already persisted.

### Testing instructions

* Create a course without Outline block.
* Then create a course with Outline block. Make sure the meta boxes are not appearing when the Outline block is added.
* Open the already created course without Outline, and make sure it shows the meta boxes.