### PR TITLE
Refactor lesson reorder page to use `Sensei_Course_Structure`

### DIFF
--- a/assets/css/admin-custom.css
+++ b/assets/css/admin-custom.css
@@ -49,7 +49,7 @@ div.question_boolean_fields { margin-bottom: 10px; }
 .sortable-course-list .course.ui-sortable-helper span:before {
     color: #444;
 }
-.sortable-course-list .course.alternate {
+.sortable-course-list .course:nth-child(odd) {
     background: #F9F9F9;
 }
 .sortable-course-list .ui-sortable-placeholder {
@@ -90,7 +90,7 @@ div.question_boolean_fields { margin-bottom: 10px; }
 .sortable-lesson-list .lesson.ui-sortable-helper span:before {
     color: #444;
 }
-.sortable-lesson-list .lesson.alternate {
+.sortable-lesson-list .lesson:nth-child(odd) {
     background: #F9F9F9;
 }
 .sortable-lesson-list .ui-sortable-placeholder {

--- a/assets/js/admin/ordering.js
+++ b/assets/js/admin/ordering.js
@@ -3,24 +3,6 @@ jQuery( document ).ready( function ( $ ) {
 	$( '.sortable-course-list, .sortable-lesson-list' ).sortable();
 	$( '.sortable-tab-list' ).disableSelection();
 
-	$.fn.fixOrderingList = function ( container, type ) {
-		container.find( '.' + type ).each( function ( i ) {
-			$( this ).removeClass( 'alternate' );
-			$( this ).removeClass( 'first' );
-			$( this ).removeClass( 'last' );
-
-			if ( 0 === i ) {
-				$( this ).addClass( 'first alternate' );
-			} else {
-				var r = i % 2;
-
-				if ( 0 === r ) {
-					$( this ).addClass( 'alternate' );
-				}
-			}
-		} );
-	};
-
 	/* Order Courses */
 	$( '.sortable-course-list' ).bind( 'sortstop', function () {
 		var orderString = '';
@@ -36,8 +18,6 @@ jQuery( document ).ready( function ( $ ) {
 			} );
 
 		$( 'input[name="course-order"]' ).val( orderString );
-
-		$.fn.fixOrderingList( $( this ), 'course' );
 	} );
 
 	/* Order Lessons */
@@ -61,7 +41,5 @@ jQuery( document ).ready( function ( $ ) {
 			} );
 
 		$( 'input[name="' + order_input + '"]' ).val( orderString );
-
-		$.fn.fixOrderingList( $( this ), 'lesson' );
 	} );
 } );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1475,7 +1475,7 @@ class Sensei_Admin {
 							'style' => array(),
 						),
 						'ul'     => array(
-							'class' => array(),
+							'class'          => array(),
 							'data-module-id' => array(),
 						),
 					)
@@ -1519,9 +1519,10 @@ class Sensei_Admin {
 
 			foreach ( $modules as $module ) {
 				// phpcs:ignore WordPress.Security.NonceVerification
-				if ( isset( $_POST[ 'lesson-order-module-' . $module['id'] ] ) && $_POST[ 'lesson-order-module-' . $module['id'] ] ) {
+				if ( ! empty( $_POST[ 'lesson-order-module-' . $module['id'] ] ) ) {
 					// phpcs:ignore WordPress.Security.NonceVerification
-					$order             = explode( ',', $_POST[ 'lesson-order-module-' . $module['id'] ] );
+					$order             = sanitize_text_field( wp_unslash( $_POST[ 'lesson-order-module-' . $module['id'] ] ) );
+					$order             = array_map( 'absint', explode( ',', $order ) );
 					$ordered_lessons   = [];
 					$ordered_lessons   = $this->get_concatenated_lessons( $ordered_lessons, $order, $lessons_by_id );
 					$module['lessons'] = $ordered_lessons;

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1545,8 +1545,6 @@ class Sensei_Admin {
 			if ( true === Sensei_Course_Structure::instance( $course_id )->save( $ordered_course_structure ) ) {
 				return true;
 			}
-
-			return false;
 		}
 
 		return false;

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1350,151 +1350,151 @@ class Sensei_Admin {
 
 		?>
 		<div id="<?php echo esc_attr( $this->lesson_order_page_slug ); ?>" class="wrap <?php echo esc_attr( $this->lesson_order_page_slug ); ?>">
-		<h1><?php esc_html_e( 'Order Lessons', 'sensei-lms' ); ?></h1>
-							  <?php
+			<h1><?php esc_html_e( 'Order Lessons', 'sensei-lms' ); ?></h1>
+			<?php
 
-								$html = '';
+			$html = '';
 
-								if ( isset( $_GET['ordered'] ) && $_GET['ordered'] ) {
-									$html .= '<div class="updated fade">' . "\n";
-									$html .= '<p>' . esc_html__( 'The lesson order has been saved.', 'sensei-lms' ) . '</p>' . "\n";
-									$html .= '</div>' . "\n";
-								}
+			if ( isset( $_GET['ordered'] ) && $_GET['ordered'] ) {
+				$html .= '<div class="updated fade">' . "\n";
+				$html .= '<p>' . esc_html__( 'The lesson order has been saved.', 'sensei-lms' ) . '</p>' . "\n";
+				$html .= '</div>' . "\n";
+			}
 
-								$args = array(
-									'post_type'      => 'course',
-									'post_status'    => array( 'publish', 'draft', 'future', 'private' ),
-									'posts_per_page' => -1,
-									'orderby'        => 'name',
-									'order'          => 'ASC',
-								);
+			$args = array(
+				'post_type'      => 'course',
+				'post_status'    => array( 'publish', 'draft', 'future', 'private' ),
+				'posts_per_page' => -1,
+				'orderby'        => 'name',
+				'order'          => 'ASC',
+			);
 
-								$courses = get_posts( $args );
+			$courses = get_posts( $args );
 
-								$html .= '<form action="' . esc_url( admin_url( 'edit.php' ) ) . '" method="get">' . "\n";
-								$html .= '<input type="hidden" name="post_type" value="lesson" />' . "\n";
-								$html .= '<input type="hidden" name="page" value="lesson-order" />' . "\n";
-								$html .= '<select id="lesson-order-course" name="course_id">' . "\n";
-								$html .= '<option value="">' . esc_html__( 'Select a course', 'sensei-lms' ) . '</option>' . "\n";
+			$html .= '<form action="' . esc_url( admin_url( 'edit.php' ) ) . '" method="get">' . "\n";
+			$html .= '<input type="hidden" name="post_type" value="lesson" />' . "\n";
+			$html .= '<input type="hidden" name="page" value="lesson-order" />' . "\n";
+			$html .= '<select id="lesson-order-course" name="course_id">' . "\n";
+			$html .= '<option value="">' . esc_html__( 'Select a course', 'sensei-lms' ) . '</option>' . "\n";
 
-								foreach ( $courses as $course ) {
-									$course_id = '';
-									if ( isset( $_GET['course_id'] ) ) {
-										$course_id = intval( $_GET['course_id'] );
-									}
-									$html .= '<option value="' . esc_attr( intval( $course->ID ) ) . '" ' . selected( $course->ID, $course_id, false ) . '>' . esc_html( get_the_title( $course->ID ) ) . '</option>' . "\n";
-								}
+			foreach ( $courses as $course ) {
+				$course_id = '';
+				if ( isset( $_GET['course_id'] ) ) {
+					$course_id = intval( $_GET['course_id'] );
+				}
+				$html .= '<option value="' . esc_attr( intval( $course->ID ) ) . '" ' . selected( $course->ID, $course_id, false ) . '>' . esc_html( get_the_title( $course->ID ) ) . '</option>' . "\n";
+			}
 
-								$html .= '</select>' . "\n";
-								$html .= '<input type="submit" class="button-primary lesson-order-select-course-submit" value="' . esc_attr__( 'Select', 'sensei-lms' ) . '" />' . "\n";
-								$html .= '</form>' . "\n";
+			$html .= '</select>' . "\n";
+			$html .= '<input type="submit" class="button-primary lesson-order-select-course-submit" value="' . esc_attr__( 'Select', 'sensei-lms' ) . '" />' . "\n";
+			$html .= '</form>' . "\n";
 
-								if ( isset( $_GET['course_id'] ) ) {
-									$course_id = intval( $_GET['course_id'] );
-									if ( $course_id > 0 ) {
-										$course_structure = Sensei_Course_Structure::instance( $course_id )->get( 'edit' );
-										$modules          = array_filter(
-											$course_structure,
-											function( $item ) {
-												return 'module' === $item['type'];
-											}
-										);
+			if ( isset( $_GET['course_id'] ) ) {
+				$course_id = intval( $_GET['course_id'] );
+				if ( $course_id > 0 ) {
+					$course_structure = Sensei_Course_Structure::instance( $course_id )->get( 'edit' );
+					$modules          = array_filter(
+						$course_structure,
+						function( $item ) {
+							return 'module' === $item['type'];
+						}
+					);
 
-										$order_string = $this->get_lesson_order( $course_id );
+					$order_string = $this->get_lesson_order( $course_id );
 
-										$html .= '<form id="editgrouping" method="post" action="'
-											. esc_url( admin_url( 'admin-post.php' ) ) . '" class="validate">' . "\n";
+					$html .= '<form id="editgrouping" method="post" action="'
+						. esc_url( admin_url( 'admin-post.php' ) ) . '" class="validate">' . "\n";
 
-										$has_lessons = false;
+					$has_lessons = false;
 
-										foreach ( $modules as $module ) {
-											if ( count( $module['lessons'] ) > 0 ) {
-												$has_lessons = true;
+					foreach ( $modules as $module ) {
+						if ( count( $module['lessons'] ) > 0 ) {
+							$has_lessons = true;
 
-												$html .= '<h3>' . esc_html( $module['title'] ) . '</h3>' . "\n";
-												$html .= '<ul class="sortable-lesson-list" data-module-id="' . esc_attr( $module['id'] ) . '">' . "\n";
+							$html .= '<h3>' . esc_html( $module['title'] ) . '</h3>' . "\n";
+							$html .= '<ul class="sortable-lesson-list" data-module-id="' . esc_attr( $module['id'] ) . '">' . "\n";
 
-												foreach ( $module['lessons'] as $lesson ) {
-													$html .= '<li class="lesson"><span rel="' . esc_attr( $lesson['id'] ) . '" style="width: 100%;"> ' . esc_html( $lesson['title'] ) . '</span></li>' . "\n";
-												}
+							foreach ( $module['lessons'] as $lesson ) {
+								$html .= '<li class="lesson"><span rel="' . esc_attr( $lesson['id'] ) . '" style="width: 100%;"> ' . esc_html( $lesson['title'] ) . '</span></li>' . "\n";
+							}
 
-												$html .= '</ul>' . "\n";
+							$html .= '</ul>' . "\n";
 
-												$html .= '<input type="hidden" name="lesson-order-module-' . esc_attr( $module['id'] ) . '" value="" />' . "\n";
-											}
-										}
+							$html .= '<input type="hidden" name="lesson-order-module-' . esc_attr( $module['id'] ) . '" value="" />' . "\n";
+						}
+					}
 
-										// Other Lessons
-										$other_lessons = array_filter(
-											$course_structure,
-											function( $item ) {
-												return 'lesson' === $item['type'];
-											}
-										);
-										if ( 0 < count( $other_lessons ) ) {
-											$has_lessons = true;
+					// Other Lessons
+					$other_lessons = array_filter(
+						$course_structure,
+						function( $item ) {
+							return 'lesson' === $item['type'];
+						}
+					);
+					if ( 0 < count( $other_lessons ) ) {
+						$has_lessons = true;
 
-											$html .= '<h3>' . esc_html__( 'Other Lessons', 'sensei-lms' ) . '</h3>' . "\n";
-											$html .= '<ul class="sortable-lesson-list" data-module-id="0">' . "\n";
+						$html .= '<h3>' . esc_html__( 'Other Lessons', 'sensei-lms' ) . '</h3>' . "\n";
+						$html .= '<ul class="sortable-lesson-list" data-module-id="0">' . "\n";
 
-											foreach ( $other_lessons as $other_lesson ) {
-												$html .= '<li class="lesson"><span rel="' . esc_attr( $other_lesson['id'] ) . '" style="width: 100%;"> ' . esc_html( $other_lesson['title'] ) . '</span></li>' . "\n";
-											}
-											$html .= '</ul>' . "\n";
-										} else {
-											$html .= '<p><em>' . esc_html__( 'There are no lessons in this course.', 'sensei-lms' ) . '</em></p>';
-										}
+						foreach ( $other_lessons as $other_lesson ) {
+							$html .= '<li class="lesson"><span rel="' . esc_attr( $other_lesson['id'] ) . '" style="width: 100%;"> ' . esc_html( $other_lesson['title'] ) . '</span></li>' . "\n";
+						}
+						$html .= '</ul>' . "\n";
+					} else {
+						$html .= '<p><em>' . esc_html__( 'There are no lessons in this course.', 'sensei-lms' ) . '</em></p>';
+					}
 
-										if ( $has_lessons ) {
-											$html .= '<input type="hidden" name="action" value="order_lessons" />' . "\n";
-											$html .= wp_nonce_field( 'order_lessons', '_wpnonce', true, false ) . "\n";
-											$html .= '<input type="hidden" name="lesson-order" value="' . esc_attr( $order_string ) . '" />' . "\n";
-											$html .= '<input type="hidden" name="course_id" value="' . esc_attr( $course_id ) . '" />' . "\n";
-											$html .= '<input type="submit" class="button-primary" value="' . esc_attr__( 'Save lesson order', 'sensei-lms' ) . '" />' . "\n";
-											$html .= '</form>';
-										}
-									}
-								}
+					if ( $has_lessons ) {
+						$html .= '<input type="hidden" name="action" value="order_lessons" />' . "\n";
+						$html .= wp_nonce_field( 'order_lessons', '_wpnonce', true, false ) . "\n";
+						$html .= '<input type="hidden" name="lesson-order" value="' . esc_attr( $order_string ) . '" />' . "\n";
+						$html .= '<input type="hidden" name="course_id" value="' . esc_attr( $course_id ) . '" />' . "\n";
+						$html .= '<input type="submit" class="button-primary" value="' . esc_attr__( 'Save lesson order', 'sensei-lms' ) . '" />' . "\n";
+						$html .= '</form>';
+					}
+				}
+			}
 
-								echo wp_kses(
-									$html,
-									array_merge(
-										wp_kses_allowed_html( 'post' ),
-										array(
-											// Explicitly allow form tag for WP.com.
-											'form'   => array(
-												'action' => array(),
-												'class'  => array(),
-												'id'     => array(),
-												'method' => array(),
-											),
-											'input'  => array(
-												'class' => array(),
-												'name'  => array(),
-												'type'  => array(),
-												'value' => array(),
-											),
-											'option' => array(
-												'selected' => array(),
-												'value'    => array(),
-											),
-											'select' => array(
-												'id'   => array(),
-												'name' => array(),
-											),
-											'span'   => array(
-												'rel'   => array(),
-												'style' => array(),
-											),
-											'ul'     => array(
-												'class' => array(),
-												'data-module-id' => array(),
-											),
-										)
-									)
-								);
+			echo wp_kses(
+				$html,
+				array_merge(
+					wp_kses_allowed_html( 'post' ),
+					array(
+						// Explicitly allow form tag for WP.com.
+						'form'   => array(
+							'action' => array(),
+							'class'  => array(),
+							'id'     => array(),
+							'method' => array(),
+						),
+						'input'  => array(
+							'class' => array(),
+							'name'  => array(),
+							'type'  => array(),
+							'value' => array(),
+						),
+						'option' => array(
+							'selected' => array(),
+							'value'    => array(),
+						),
+						'select' => array(
+							'id'   => array(),
+							'name' => array(),
+						),
+						'span'   => array(
+							'rel'   => array(),
+							'style' => array(),
+						),
+						'ul'     => array(
+							'class' => array(),
+							'data-module-id' => array(),
+						),
+					)
+				)
+			);
 
-								?>
+			?>
 		</div>
 		<?php
 	}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1525,7 +1525,7 @@ class Sensei_Admin {
 				if (
 					// phpcs:ignore WordPress.Security.NonceVerification
 					! empty( $_POST[ 'lesson-order-module-' . $module['id'] ] )
-					&& ! empty ( $course_structure[ $key ]['lessons'] )
+					&& ! empty( $course_structure[ $key ]['lessons'] )
 				) {
 					// phpcs:ignore WordPress.Security.NonceVerification
 					$order = sanitize_text_field( wp_unslash( $_POST[ 'lesson-order-module-' . $module['id'] ] ) );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1517,6 +1517,7 @@ class Sensei_Admin {
 			$lessons_by_id            = $this->get_lessons_by_id( $course_structure );
 			$ordered_course_structure = [];
 
+			// Ordered module lessons.
 			foreach ( $modules as $module ) {
 				// phpcs:ignore WordPress.Security.NonceVerification
 				if ( ! empty( $_POST[ 'lesson-order-module-' . $module['id'] ] ) ) {
@@ -1532,9 +1533,11 @@ class Sensei_Admin {
 			}
 
 			if ( $order_string ) {
+				// Add ordered lessons to the structure.
 				$order                    = explode( ',', $order_string );
 				$ordered_course_structure = $this->get_concatenated_lessons( $ordered_course_structure, $order, $lessons_by_id );
 
+				// Add to the structure lessons that weren't in the `$order_string`.
 				$other_lessons            = $this->get_course_structure( $course_structure, 'lesson' );
 				$not_ordered_ids          = array_diff( wp_list_pluck( $other_lessons, 'id' ), wp_list_pluck( $ordered_course_structure, 'id' ) );
 				$ordered_course_structure = $this->get_concatenated_lessons( $ordered_course_structure, $not_ordered_ids, $lessons_by_id );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1400,8 +1400,6 @@ class Sensei_Admin {
 						}
 					);
 
-					$order_string = $this->get_lesson_order( $course_id );
-
 					$html .= '<form id="editgrouping" method="post" action="'
 						. esc_url( admin_url( 'admin-post.php' ) ) . '" class="validate">' . "\n";
 
@@ -1448,7 +1446,7 @@ class Sensei_Admin {
 					if ( $has_lessons ) {
 						$html .= '<input type="hidden" name="action" value="order_lessons" />' . "\n";
 						$html .= wp_nonce_field( 'order_lessons', '_wpnonce', true, false ) . "\n";
-						$html .= '<input type="hidden" name="lesson-order" value="' . esc_attr( $order_string ) . '" />' . "\n";
+						$html .= '<input type="hidden" name="lesson-order" value="" />' . "\n";
 						$html .= '<input type="hidden" name="course_id" value="' . esc_attr( $course_id ) . '" />' . "\n";
 						$html .= '<input type="submit" class="button-primary" value="' . esc_attr__( 'Save lesson order', 'sensei-lms' ) . '" />' . "\n";
 						$html .= '</form>';
@@ -1499,7 +1497,18 @@ class Sensei_Admin {
 		<?php
 	}
 
+	/**
+	 * Get lesson order.
+	 *
+	 * @deprecated 3.6.0
+	 *
+	 * @param integer $course_id Course ID.
+	 *
+	 * @return string Order string.
+	 */
 	public function get_lesson_order( $course_id = 0 ) {
+		_deprecated_function( __METHOD__, '3.6.0' );
+
 		$order_string = get_post_meta( $course_id, '_lesson_order', true );
 		return $order_string;
 	}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1392,13 +1392,8 @@ class Sensei_Admin {
 			if ( isset( $_GET['course_id'] ) ) {
 				$course_id = intval( $_GET['course_id'] );
 				if ( $course_id > 0 ) {
-					$course_structure = Sensei_Course_Structure::instance( $course_id )->get( 'edit' );
-					$modules          = array_filter(
-						$course_structure,
-						function( $item ) {
-							return 'module' === $item['type'];
-						}
-					);
+					$course_structure = $this->get_course_structure( $course_id );
+					$modules          = $this->get_course_structure( $course_structure, 'module' );
 
 					$html .= '<form id="editgrouping" method="post" action="'
 						. esc_url( admin_url( 'admin-post.php' ) ) . '" class="validate">' . "\n";
@@ -1423,12 +1418,7 @@ class Sensei_Admin {
 					}
 
 					// Other Lessons
-					$other_lessons = array_filter(
-						$course_structure,
-						function( $item ) {
-							return 'lesson' === $item['type'];
-						}
-					);
+					$other_lessons = $this->get_course_structure( $course_structure, 'lesson' );
 					if ( 0 < count( $other_lessons ) ) {
 						$has_lessons = true;
 
@@ -1560,6 +1550,31 @@ class Sensei_Admin {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Get course structure.
+	 *
+	 * @param int|array   $course_structure Structure array or course ID to get the structure.
+	 * @param null|string $type             Optional type to filter the content.
+	 *
+	 * @return array Course structure.
+	 */
+	private function get_course_structure( $course_structure = null, $type = null ) {
+		$course_structure = is_array( $course_structure )
+			? $course_structure
+			: Sensei_Course_Structure::instance( $course_structure )->get( 'edit' );
+
+		if ( isset( $type ) ) {
+			$course_structure = array_filter(
+				$course_structure,
+				function( $item ) use ( $type ) {
+					return $type === $item['type'];
+				}
+			);
+		}
+
+		return $course_structure;
 	}
 
 	function sensei_add_custom_menu_items() {

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1228,7 +1228,6 @@ class Sensei_Admin {
 									$html .= '<form id="editgrouping" method="post" action="'
 										. esc_url( admin_url( 'admin-post.php' ) ) . '" class="validate">' . "\n";
 									$html .= '<ul class="sortable-course-list">' . "\n";
-									$count = 0;
 									foreach ( $all_course_ids as $course_id ) {
 										$course = get_post( $course_id );
 										if ( empty( $course ) || in_array( $course->post_status, array( 'trash', 'auto-draft' ), true ) ) {
@@ -1236,22 +1235,13 @@ class Sensei_Admin {
 											continue;
 										}
 										$new_course_order[] = $course_id;
-										$count++;
-										$class = 'course';
-										if ( $count == 1 ) {
-											$class .= ' first'; }
-										if ( $count == count( $all_course_ids ) ) {
-											$class .= ' last'; }
-										if ( $count % 2 != 0 ) {
-											$class .= ' alternate';
-										}
 
 										$title = $course->post_title;
 										if ( $course->post_status === 'draft' ) {
 											$title .= ' (Draft)';
 										}
 
-										$html .= '<li class="' . esc_attr( $class ) . '"><span rel="' . esc_attr( $course->ID ) . '" style="width: 100%;"> ' . esc_html( $title ) . '</span></li>' . "\n";
+										$html .= '<li class="course"><span rel="' . esc_attr( $course->ID ) . '" style="width: 100%;"> ' . esc_html( $title ) . '</span></li>' . "\n";
 									}
 									$html .= '</ul>' . "\n";
 
@@ -1443,19 +1433,9 @@ class Sensei_Admin {
 												$html .= '<h3>' . esc_html( $module->name ) . '</h3>' . "\n";
 												$html .= '<ul class="sortable-lesson-list" data-module-id="' . esc_attr( $module->term_id ) . '">' . "\n";
 
-												$count = 0;
 												foreach ( $lessons as $lesson ) {
-													$count++;
-													$class = 'lesson';
-													if ( $count == 1 ) {
-														$class .= ' first'; }
-													if ( $count == count( $lessons ) ) {
-														$class .= ' last'; }
-													if ( $count % 2 != 0 ) {
-														$class .= ' alternate';
-													}
 
-													$html .= '<li class="' . esc_attr( $class ) . '"><span rel="' . esc_attr( $lesson->ID ) . '" style="width: 100%;"> ' . esc_html( $lesson->post_title ) . '</span></li>' . "\n";
+													$html .= '<li class="lesson"><span rel="' . esc_attr( $lesson->ID ) . '" style="width: 100%;"> ' . esc_html( $lesson->post_title ) . '</span></li>' . "\n";
 
 													$displayed_lessons[] = $lesson->ID;
 												}
@@ -1484,7 +1464,6 @@ class Sensei_Admin {
 											}
 
 											$html         .= '<ul class="sortable-lesson-list" data-module-id="0">' . "\n";
-											$count         = 0;
 											$other_lessons = array();
 
 											foreach ( $lessons as $lesson ) {
@@ -1497,19 +1476,7 @@ class Sensei_Admin {
 											}
 
 											foreach ( $other_lessons as $other_lesson ) {
-												$count++;
-												$class = 'lesson';
-
-												if ( $count == 1 ) {
-													$class .= ' first'; }
-												if ( $count === count( $other_lessons ) ) {
-													$class .= ' last'; }
-												if ( $count % 2 != 0 ) {
-
-													$class .= ' alternate';
-
-												}
-												$html .= '<li class="' . esc_attr( $class ) . '"><span rel="' . esc_attr( $other_lesson->ID ) . '" style="width: 100%;"> ' . esc_html( $other_lesson->post_title ) . '</span></li>' . "\n";
+												$html .= '<li class="lesson"><span rel="' . esc_attr( $other_lesson->ID ) . '" style="width: 100%;"> ' . esc_html( $other_lesson->post_title ) . '</span></li>' . "\n";
 
 												$displayed_lessons[] = $other_lesson->ID;
 											}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1511,8 +1511,11 @@ class Sensei_Admin {
 		 */
 
 		if ( $course_id ) {
+			remove_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70 );
 			$course_structure = $this->get_course_structure( intval( $course_id ) );
-			$order            = array_map( 'absint', explode( ',', $order_string ) );
+			add_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70, 3 );
+
+			$order = array_map( 'absint', explode( ',', $order_string ) );
 
 			$course_structure = Sensei_Course_Structure::sort_structure( $course_structure, $order );
 

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -689,4 +689,34 @@ class Sensei_Course_Structure {
 
 		return true;
 	}
+
+	/**
+	 * Sort structure.
+	 *
+	 * @param array $structure     Structure to be sorted.
+	 * @param int[] $lessons_order Order to sort.
+	 *
+	 * @return array Sorted structure.
+	 */
+	public static function sort_structure( $structure, $lessons_order ) {
+		usort(
+			$structure,
+			function( $a, $b ) use ( $lessons_order ) {
+				if ( 'lesson' !== $a['type'] || 'lesson' !== $b['type'] ) {
+					return 0;
+				}
+
+				$a_position = array_search( $a['id'], $lessons_order, true );
+				$b_position = array_search( $b['id'], $lessons_order, true );
+
+				if ( false === $a_position && false === $b_position ) {
+					return 0;
+				}
+
+				return false === $b_position || $a_position < $b_position ? -1 : 1;
+			}
+		);
+
+		return $structure;
+	}
 }

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -58,9 +58,17 @@ class Sensei_Course_Structure {
 	/**
 	 * Get the course structure.
 	 *
+	 * @see Sensei_Course_Structure::prepare_lesson()
+	 * @see Sensei_Course_Structure::prepare_module()
+	 *
 	 * @param string $context Context that structure is being retrieved for. Possible values: edit, view.
 	 *
-	 * @return array
+	 * @return array {
+	 *     An array which has course structure information.
+	 *
+	 *     @type array Each element is an array with either module or lesson information as defined in prepare_lesson()
+	 *                 and prepare_module().
+	 * }
 	 */
 	public function get( $context = 'view' ) {
 		$context = in_array( $context, [ 'view', 'edit' ], true ) ? $context : 'view';
@@ -95,10 +103,22 @@ class Sensei_Course_Structure {
 	/**
 	 * Prepare the result for a module.
 	 *
+	 * @see Sensei_Course_Structure::prepare_lesson()
+	 *
 	 * @param WP_Term      $module_term        Module term.
 	 * @param array|string $lesson_post_status Lesson post status(es).
+	 *
+	 * @return array {
+	 *     An array which has module information.
+	 *
+	 *     @type string $type        The type of the array which is 'module'.
+	 *     @type int    $id          The module term id.
+	 *     @type string $title       The module name.
+	 *     @type string $description The module description.
+	 *     @type array  $lessons     An array of the module lessons. See Sensei_Course_Structure::prepare_lesson().
+	 * }
 	 */
-	private function prepare_module( WP_Term $module_term, $lesson_post_status ) {
+	private function prepare_module( WP_Term $module_term, $lesson_post_status ) : array {
 		$lessons = $this->get_module_lessons( $module_term->term_id, $lesson_post_status );
 		$module  = [
 			'type'        => 'module',
@@ -120,9 +140,16 @@ class Sensei_Course_Structure {
 	 *
 	 * @param WP_Post $lesson_post Lesson post object.
 	 *
-	 * @return array
+	 * @return array {
+	 *     An array which has lesson information.
+	 *
+	 *     @type string $type  The type of the array which is 'lesson'.
+	 *     @type int    $id    The lesson post id.
+	 *     @type string $title The lesson title.
+	 *     @type bool   $draft True if the lesson is a draft.
+	 * }
 	 */
-	private function prepare_lesson( WP_Post $lesson_post ) {
+	private function prepare_lesson( WP_Post $lesson_post ) : array {
 		return [
 			'type'  => 'lesson',
 			'id'    => $lesson_post->ID,
@@ -139,7 +166,7 @@ class Sensei_Course_Structure {
 	 *
 	 * @return WP_Post[]
 	 */
-	private function get_module_lessons( int $module_term_id, $lesson_post_status ) {
+	private function get_module_lessons( int $module_term_id, $lesson_post_status ) : array {
 		$lessons_query = Sensei()->modules->get_lessons_query( $this->course_id, $module_term_id, $lesson_post_status );
 
 		return $lessons_query instanceof WP_Query ? $lessons_query->posts : [];
@@ -150,7 +177,7 @@ class Sensei_Course_Structure {
 	 *
 	 * @return WP_Term[]
 	 */
-	private function get_modules() {
+	private function get_modules() : array {
 		$modules = Sensei()->modules->get_course_modules( $this->course_id );
 
 		if ( is_wp_error( $modules ) ) {
@@ -163,7 +190,9 @@ class Sensei_Course_Structure {
 	/**
 	 * Save a new course structure.
 	 *
-	 * @param array $raw_structure Course structure to save in its raw, un-sanitized form.
+	 * @see Sensei_Course_Structure::get()
+	 *
+	 * @param array $raw_structure Course structure to save in its raw, un-sanitized form as returned by get().
 	 *
 	 * @return bool|WP_Error
 	 */
@@ -228,7 +257,9 @@ class Sensei_Course_Structure {
 	/**
 	 * Save a module item.
 	 *
-	 * @param array $item Item to save.
+	 * @see Sensei_Course_Structure::prepare_module()
+	 *
+	 * @param array $item Item to save as returned from prepare_module().
 	 *
 	 * @return false|array[] {
 	 *     If successful, we return this:
@@ -375,6 +406,8 @@ class Sensei_Course_Structure {
 	/**
 	 * Save a lesson item.
 	 *
+	 * @see Sensei_Course_Structure::prepare_lesson()
+	 *
 	 * @param array $item      Item to save.
 	 * @param int   $module_id Module ID.
 	 *
@@ -497,7 +530,9 @@ class Sensei_Course_Structure {
 	/**
 	 * Parses the lesson IDs and module IDs from the structure.
 	 *
-	 * @param array $structure Structure to flatten.
+	 * @see Sensei_Course_Structure::get()
+	 *
+	 * @param array $structure Structure to flatten as returned by get().
 	 *
 	 * @return array[] {
 	 *     @type array $0 $lesson_ids    All the lesson IDs.
@@ -505,7 +540,7 @@ class Sensei_Course_Structure {
 	 *     @type array $2 $module_titles All the module titles.
 	 * }
 	 */
-	private function flatten_structure( array $structure ) {
+	private function flatten_structure( array $structure ) : array {
 		$lesson_ids    = [];
 		$module_ids    = [];
 		$module_titles = [];
@@ -546,7 +581,9 @@ class Sensei_Course_Structure {
 	/**
 	 * Parse, validate, and sanitize the structure input.
 	 *
-	 * @param array $raw_structure Structure array.
+	 * @see Sensei_Course_Structure::get()
+	 *
+	 * @param array $raw_structure Structure array as returned by get().
 	 *
 	 * @return WP_Error|array False if the input is invalid.
 	 */
@@ -588,7 +625,10 @@ class Sensei_Course_Structure {
 	/**
 	 * Validate and sanitize input item of structure.
 	 *
-	 * @param array $raw_item Raw item to sanitize.
+	 * @see Sensei_Course_Structure::prepare_lesson()
+	 * @see Sensei_Course_Structure::prepare_module()
+	 *
+	 * @param array $raw_item Module or lesson as returned by prepare_lesson or prepare_module.
 	 *
 	 * @return array|WP_Error
 	 */
@@ -654,6 +694,9 @@ class Sensei_Course_Structure {
 
 	/**
 	 * Validate item is build correctly.
+	 *
+	 * @see Sensei_Course_Structure::prepare_lesson()
+	 * @see Sensei_Course_Structure::prepare_module()
 	 *
 	 * @param array $raw_item Raw item to sanitize.
 	 *

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -42,7 +42,6 @@ class Sensei_Lesson {
 			add_action( 'save_post', array( $this, 'meta_box_save' ) );
 			add_action( 'save_post', array( $this, 'quiz_update' ) );
 			add_action( 'save_post', array( $this, 'add_lesson_to_course_order' ) );
-			add_action( 'transition_post_status', array( $this, 'on_lesson_published' ), 10, 3 );
 
 			// Custom Write Panel Columns
 			add_filter( 'manage_edit-lesson_columns', array( $this, 'add_column_headings' ), 10, 1 );
@@ -423,6 +422,8 @@ class Sensei_Lesson {
 	 *
 	 * Hooked into `post_save`
 	 *
+	 * @since 3.6.0 It order all lessons that is part of a course, regardless their status.
+	 *
 	 * @access public
 	 * @param int $lesson_id
 	 * @return void
@@ -438,34 +439,28 @@ class Sensei_Lesson {
 			return;
 		}
 
-		if ( ! in_array( get_post_status( $lesson_id ), array( 'publish', 'future', 'pending' ), true ) ) {
-			return;
-		}
-
 		$course_id = intval( get_post_meta( $lesson_id, '_lesson_course', true ) );
 
 		if ( empty( $course_id ) ) {
 			return;
 		}
 
-		$order_string_array = explode( ',', get_post_meta( intval( $course_id ), '_lesson_order', true ) );
-		$order_ids          = array_map( 'intval', $order_string_array );
-
-		if ( ! empty( $order_ids ) && ! in_array( $lesson_id, $order_ids ) ) {
-				$order_ids[] = $lesson_id;
-				// assumes Sensei admin is loaded
-				Sensei()->admin->save_lesson_order( implode( ',', $order_ids ), $course_id );
-		}
+		// Assumes Sensei admin is loaded.
+		Sensei()->admin->save_lesson_order( '', $course_id );
 	}
 
 	/**
 	 * to actions when the status of the lesson changes to publish
+	 *
+	 * @deprecated 3.6.0
 	 *
 	 * @param string  $new_status
 	 * @param string  $old_status
 	 * @param WP_Post $post
 	 */
 	public function on_lesson_published( $new_status, $old_status, $post ) {
+		_deprecated_function( __METHOD__, '3.6.0' );
+
 		if ( 'lesson' != get_post_type( $post ) ) {
 			return;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It basically refactors the listing and the saving for the lessons reorder.
* It also removes some logic that was used to add styles to the reordering pages. These styles were added through CSS files only.

We could also refactor more things here, like moving all the reorder logic of courses, modules, and lessons to a separate class, and add all logic there. Or we could move them to their specific classes because the logic to order courses and lessons are in the `Sensei_Admin` class, and the logic to order the modules is in the `Sensei_Core_Modules` class. But I focused only on refactor them to use the `Sensei_Course_Structure`. If someone thinks it worths invest time in a bigger refactor in all this code now, we can go ahead.

### Testing instructions

**Note:** You can review the code here, and test directly in the #3672 because this code was partially refactored there, so you can prevent retest the same thing twice.

In summary, it should work as currently.

* Create some courses (some with modules and lessons, some with only lessons, some without content).
* Go to WP-admin > Lessons > Order Lessons, and reorder the content from the created courses.
* Go to the course pages and make sure the content was reordered.

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* `Sensei_Admin::get_lesson_order`
* `Sensei_Lesson::on_lesson_published`