### PR TITLE
Fix module selector when animation is turned off

### DIFF
--- a/assets/blocks/course-outline/frontend.js
+++ b/assets/blocks/course-outline/frontend.js
@@ -14,7 +14,7 @@
 
 		modules.forEach( ( module ) => {
 			const moduleContent = module.querySelector(
-				'.wp-block-sensei-lms-collapsible.animated'
+				'.wp-block-sensei-lms-collapsible'
 			);
 
 			const originalHeight = moduleContent.offsetHeight;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix issue introduced [hehe](https://github.com/Automattic/sensei/pull/3646) when the animation is turned off.

### Testing instructions

* Create a course with modules.
* Go turn the animation off.
* Go to the frontend and make sure the modules toggle without animation.
* Turn the animation on, go to the frontend and make sure it's animating.