### PR TITLE
Fix placeholder icon and buttons for Wordpress 5.3

### DIFF
--- a/assets/blocks/course-outline/course-block/placeholder.js
+++ b/assets/blocks/course-outline/course-block/placeholder.js
@@ -9,6 +9,7 @@ import settings from './index';
  */
 export const CourseOutlinePlaceholder = ( { addBlock } ) => (
 	<Placeholder
+		className="wp-block-sensei-lms-course-outline__placeholder"
 		label={ __( 'Course Outline', 'sensei-lms' ) }
 		icon={ <BlockIcon icon={ settings.icon } showColors /> }
 		instructions={ __(
@@ -16,10 +17,18 @@ export const CourseOutlinePlaceholder = ( { addBlock } ) => (
 			'sensei-lms'
 		) }
 	>
-		<Button isDefault onClick={ () => addBlock( 'module' ) }>
+		<Button
+			isDefault
+			onClick={ () => addBlock( 'module' ) }
+			className="is-large"
+		>
 			{ __( 'Create a module', 'sensei-lms' ) }
-		</Button>{ ' ' }
-		<Button isDefault onClick={ () => addBlock( 'lesson' ) }>
+		</Button>
+		<Button
+			isDefault
+			onClick={ () => addBlock( 'lesson' ) }
+			className="is-large"
+		>
 			{ __( 'Create a lesson', 'sensei-lms' ) }
 		</Button>
 	</Placeholder>

--- a/assets/blocks/course-outline/course-block/placeholder.js
+++ b/assets/blocks/course-outline/course-block/placeholder.js
@@ -1,7 +1,7 @@
+import { BlockIcon } from '@wordpress/block-editor';
 import { Button, Placeholder } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import settings from './index';
-
 /**
  * Placeholder for empty Course Outline block.
  *
@@ -10,16 +10,16 @@ import settings from './index';
 export const CourseOutlinePlaceholder = ( { addBlock } ) => (
 	<Placeholder
 		label={ __( 'Course Outline', 'sensei-lms' ) }
-		icon={ settings.icon() }
+		icon={ <BlockIcon icon={ settings.icon } showColors /> }
 		instructions={ __(
 			'Build and display a course outline. A course is made up of modules (optional) and lessons. You can use modules to group related lessons together.',
 			'sensei-lms'
 		) }
 	>
-		<Button isSecondary onClick={ () => addBlock( 'module' ) }>
+		<Button isDefault onClick={ () => addBlock( 'module' ) }>
 			{ __( 'Create a module', 'sensei-lms' ) }
-		</Button>
-		<Button isSecondary onClick={ () => addBlock( 'lesson' ) }>
+		</Button>{ ' ' }
+		<Button isDefault onClick={ () => addBlock( 'lesson' ) }>
 			{ __( 'Create a lesson', 'sensei-lms' ) }
 		</Button>
 	</Placeholder>

--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -26,8 +26,15 @@
 			margin-top: 0;
 			margin-bottom: 0;
 		}
-	}
 
+		&__placeholder {
+			.components-button {
+				margin-right: 12px;
+				margin-bottom: 12px;
+			}
+		}
+
+	}
 	.wp-block-sensei-lms-course-outline-lesson {
 
 		&__draft,


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Fix Course outline placeholder icon and buttons on Wordpress 5.3

### Testing instructions

* Create a new course on a Wordpress 5.3 install
* Check that placeholder looks right 


<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="550" alt="image" src="https://user-images.githubusercontent.com/176949/94812628-44bd6380-03f7-11eb-9ca4-f03da33a3920.png">

