### PR TITLE
Update module reorder to use Sensei_Course_Structure

### DIFF
--- a/assets/css/modules-admin.css
+++ b/assets/css/modules-admin.css
@@ -29,7 +29,7 @@
 .sortable-module-list .module.ui-sortable-helper span:before {
 	color: #444;
 }
-.sortable-module-list .module.alternate {
+.sortable-module-list .module:nth-child(odd) {
 	background: #F9F9F9;
 }
 .sortable-module-list .ui-sortable-placeholder {

--- a/assets/js/modules-admin.js
+++ b/assets/js/modules-admin.js
@@ -41,18 +41,6 @@ jQuery( document ).ready( function () {
 					orderString += ',';
 				}
 				orderString += jQuery( this ).find( 'span' ).attr( 'rel' );
-
-				jQuery( this ).removeClass( 'alternate' );
-				jQuery( this ).removeClass( 'first' );
-				jQuery( this ).removeClass( 'last' );
-				if ( i == 0 ) {
-					jQuery( this ).addClass( 'first alternate' );
-				} else {
-					var r = i % 2;
-					if ( 0 == r ) {
-						jQuery( this ).addClass( 'alternate' );
-					}
-				}
 			} );
 
 		jQuery( 'input[name="module-order"]' ).val( orderString );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1523,7 +1523,7 @@ class Sensei_Admin {
 
 			$order = array_map( 'absint', explode( ',', $order_string ) );
 
-			$course_structure = Sensei_Course_Structure::sort_structure( $course_structure, $order );
+			$course_structure = Sensei_Course_Structure::sort_structure( $course_structure, $order, 'lesson' );
 
 			// Sort module lessons.
 			foreach ( $course_structure as $key => $module ) {
@@ -1540,7 +1540,7 @@ class Sensei_Admin {
 					$order = sanitize_text_field( wp_unslash( $_POST[ 'lesson-order-module-' . $module['id'] ] ) );
 					$order = array_map( 'absint', explode( ',', $order ) );
 
-					$course_structure[ $key ]['lessons'] = Sensei_Course_Structure::sort_structure( $course_structure[ $key ]['lessons'], $order );
+					$course_structure[ $key ]['lessons'] = Sensei_Course_Structure::sort_structure( $course_structure[ $key ]['lessons'], $order, 'lesson' );
 				}
 			}
 

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -748,7 +748,7 @@ class Sensei_Course_Structure {
 			function( $a, $b ) use ( $order, $type ) {
 				// One of the types is not being sorted.
 				if ( $type !== $a['type'] || $type !== $b['type'] ) {
-					// If types are equal, keep in the current order.
+					// If types are equal, keep in the current positions.
 					if ( $a['type'] === $b['type'] ) {
 						return 0;
 					}
@@ -760,8 +760,14 @@ class Sensei_Course_Structure {
 				$a_position = array_search( $a['id'], $order, true );
 				$b_position = array_search( $b['id'], $order, true );
 
+				// If both weren't sorted, keep the current positions.
 				if ( false === $a_position && false === $b_position ) {
 					return 0;
+				}
+
+				// Keep not sorted items in the end.
+				if ( false === $a_position ) {
+					return 1;
 				}
 
 				return false === $b_position || $a_position < $b_position ? -1 : 1;

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -736,21 +736,22 @@ class Sensei_Course_Structure {
 	/**
 	 * Sort structure.
 	 *
-	 * @param array $structure     Structure to be sorted.
-	 * @param int[] $lessons_order Order to sort.
+	 * @param array  $structure Structure to be sorted.
+	 * @param int[]  $order     Order to sort the lessons.
+	 * @param string $type      Type to be sorted (lesson or module).
 	 *
 	 * @return array Sorted structure.
 	 */
-	public static function sort_structure( $structure, $lessons_order ) {
+	public static function sort_structure( $structure, $order, $type ) {
 		usort(
 			$structure,
-			function( $a, $b ) use ( $lessons_order ) {
-				if ( 'lesson' !== $a['type'] || 'lesson' !== $b['type'] ) {
+			function( $a, $b ) use ( $order, $type ) {
+				if ( $type !== $a['type'] || $type !== $b['type'] ) {
 					return 0;
 				}
 
-				$a_position = array_search( $a['id'], $lessons_order, true );
-				$b_position = array_search( $b['id'], $lessons_order, true );
+				$a_position = array_search( $a['id'], $order, true );
+				$b_position = array_search( $b['id'], $order, true );
 
 				if ( false === $a_position && false === $b_position ) {
 					return 0;

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -746,8 +746,15 @@ class Sensei_Course_Structure {
 		usort(
 			$structure,
 			function( $a, $b ) use ( $order, $type ) {
+				// One of the types is not being sorted.
 				if ( $type !== $a['type'] || $type !== $b['type'] ) {
-					return 0;
+					// If types are equal, keep in the current order.
+					if ( $a['type'] === $b['type'] ) {
+						return 0;
+					}
+
+					// Always keep the modules before the lessons.
+					return 'module' === $a['type'] ? - 1 : 1;
 				}
 
 				$a_position = array_search( $a['id'], $order, true );

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1044,6 +1044,7 @@ class Sensei_Core_Modules {
 	public function handle_order_modules() {
 		check_admin_referer( 'order_modules' );
 
+		$ordered = false;
 		if ( isset( $_POST['module-order'] ) && 0 < strlen( $_POST['module-order'] ) ) {
 			$ordered = $this->save_course_module_order( esc_attr( $_POST['module-order'] ), esc_attr( $_POST['course_id'] ) );
 		}

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1125,20 +1125,8 @@ class Sensei_Core_Modules {
 							. esc_url( admin_url( 'admin-post.php' ) )
 							. '" class="validate">' . "\n";
 						$html .= '<ul class="sortable-module-list">' . "\n";
-						$count = 0;
 						foreach ( $modules as $module ) {
-							$count++;
-							$class = $this->taxonomy;
-							if ( $count == 1 ) {
-								$class .= ' first';
-							}
-							if ( $count == count( $modules ) ) {
-								$class .= ' last';
-							}
-							if ( $count % 2 != 0 ) {
-								$class .= ' alternate';
-							}
-							$html .= '<li class="' . esc_attr( $class ) . '"><span rel="' . esc_attr( $module->term_id ) . '" style="width: 100%;"> ' . esc_html( $module->name ) . '</span></li>' . "\n";
+							$html .= '<li class="' . $this->taxonomy . '"><span rel="' . esc_attr( $module->term_id ) . '" style="width: 100%;"> ' . esc_html( $module->name ) . '</span></li>' . "\n";
 						}
 						$html .= '</ul>' . "\n";
 						$html .= '<input type="hidden" name="action" value="order_modules" />' . "\n";

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1216,8 +1216,11 @@ class Sensei_Core_Modules {
 	 */
 	private function save_course_module_order( $order_string = '', $course_id = 0 ) {
 		if ( $order_string && $course_id ) {
+			remove_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70 );
 			$course_structure = Sensei_Course_Structure::instance( $course_id )->get( 'edit' );
-			$order            = array_map( 'absint', explode( ',', $order_string ) );
+			add_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70, 3 );
+
+			$order = array_map( 'absint', explode( ',', $order_string ) );
 
 			$course_structure = Sensei_Course_Structure::sort_structure( $course_structure, $order, 'module' );
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1110,8 +1110,7 @@ class Sensei_Core_Modules {
 			if ( isset( $_GET['course_id'] ) ) {
 				$course_id = intval( $_GET['course_id'] );
 				if ( $course_id > 0 ) {
-					$modules = $this->get_course_modules( $course_id );
-					$modules = $this->append_teacher_name_to_module( $modules, array( 'module' ), array() );
+					$modules = $this->get_course_modules_structure( $course_id );
 					if ( $modules ) {
 
 						$order = $this->get_course_module_order( $course_id );
@@ -1126,7 +1125,7 @@ class Sensei_Core_Modules {
 							. '" class="validate">' . "\n";
 						$html .= '<ul class="sortable-module-list">' . "\n";
 						foreach ( $modules as $module ) {
-							$html .= '<li class="' . $this->taxonomy . '"><span rel="' . esc_attr( $module->term_id ) . '" style="width: 100%;"> ' . esc_html( $module->name ) . '</span></li>' . "\n";
+							$html .= '<li class="' . $this->taxonomy . '"><span rel="' . esc_attr( $module['id'] ) . '" style="width: 100%;"> ' . esc_html( $module['title'] ) . '</span></li>' . "\n";
 						}
 						$html .= '</ul>' . "\n";
 						$html .= '<input type="hidden" name="action" value="order_modules" />' . "\n";
@@ -1177,6 +1176,24 @@ class Sensei_Core_Modules {
 			?>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Get course modules.
+	 *
+	 * @param int $course_id Course ID.
+	 *
+	 * @return array Modules.
+	 */
+	private function get_course_modules_structure( $course_id ) {
+		$course_structure = Sensei_Course_Structure::instance( $course_id )->get( 'edit' );
+
+		return array_filter(
+			$course_structure,
+			function( $item ) {
+				return 'module' === $item['type'];
+			}
+		);
 	}
 
 	/**

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1111,15 +1111,7 @@ class Sensei_Core_Modules {
 				$course_id = intval( $_GET['course_id'] );
 				if ( $course_id > 0 ) {
 					$modules = $this->get_course_modules_structure( $course_id );
-					if ( $modules ) {
-
-						$order = $this->get_course_module_order( $course_id );
-
-						$order_string = '';
-						if ( $order ) {
-							$order_string = implode( ',', $order );
-						}
-
+					if ( ! empty( $modules ) ) {
 						$html .= '<form id="editgrouping" method="post" action="'
 							. esc_url( admin_url( 'admin-post.php' ) )
 							. '" class="validate">' . "\n";
@@ -1130,7 +1122,7 @@ class Sensei_Core_Modules {
 						$html .= '</ul>' . "\n";
 						$html .= '<input type="hidden" name="action" value="order_modules" />' . "\n";
 						$html .= wp_nonce_field( 'order_modules', '_wpnonce', true, false ) . "\n";
-						$html .= '<input type="hidden" name="module-order" value="' . esc_attr( $order_string ) . '" />' . "\n";
+						$html .= '<input type="hidden" name="module-order" value="" />' . "\n";
 						$html .= '<input type="hidden" name="course_id" value="' . esc_attr( $course_id ) . '" />' . "\n";
 						$html .= '<input type="submit" class="button-primary" value="' . esc_attr__( 'Save module order', 'sensei-lms' ) . '" />' . "\n";
 						$html .= '<a href="' . esc_url( admin_url( 'post.php?post=' . $course_id . '&action=edit' ) ) . '" class="button-secondary">' . esc_html__( 'Edit course', 'sensei-lms' ) . '</a>' . "\n";

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1074,119 +1074,119 @@ class Sensei_Core_Modules {
 		?>
 		<div id="<?php echo esc_attr( $this->order_page_slug ); ?>"
 			 class="wrap <?php echo esc_attr( $this->order_page_slug ); ?>">
-		<h1><?php esc_html_e( 'Order Modules', 'sensei-lms' ); ?></h1>
-							  <?php
+			<h1><?php esc_html_e( 'Order Modules', 'sensei-lms' ); ?></h1>
+			<?php
 
-								$html = '';
+			$html = '';
 
-								if ( isset( $_GET['ordered'] ) && $_GET['ordered'] ) {
-									$html .= '<div class="updated fade">' . "\n";
-									$html .= '<p>' . esc_html__( 'The module order has been saved for this course.', 'sensei-lms' ) . '</p>' . "\n";
-									$html .= '</div>' . "\n";
-								}
+			if ( isset( $_GET['ordered'] ) && $_GET['ordered'] ) {
+				$html .= '<div class="updated fade">' . "\n";
+				$html .= '<p>' . esc_html__( 'The module order has been saved for this course.', 'sensei-lms' ) . '</p>' . "\n";
+				$html .= '</div>' . "\n";
+			}
 
-								$courses = Sensei()->course->get_all_courses();
+			$courses = Sensei()->course->get_all_courses();
 
-								$html .= '<form action="' . esc_url( admin_url( 'edit.php' ) ) . '" method="get">' . "\n";
-								$html .= '<input type="hidden" name="post_type" value="course" />' . "\n";
-								$html .= '<input type="hidden" name="page" value="' . esc_attr( $this->order_page_slug ) . '" />' . "\n";
-								$html .= '<select id="module-order-course" name="course_id">' . "\n";
-								$html .= '<option value="">' . esc_html__( 'Select a course', 'sensei-lms' ) . '</option>' . "\n";
+			$html .= '<form action="' . esc_url( admin_url( 'edit.php' ) ) . '" method="get">' . "\n";
+			$html .= '<input type="hidden" name="post_type" value="course" />' . "\n";
+			$html .= '<input type="hidden" name="page" value="' . esc_attr( $this->order_page_slug ) . '" />' . "\n";
+			$html .= '<select id="module-order-course" name="course_id">' . "\n";
+			$html .= '<option value="">' . esc_html__( 'Select a course', 'sensei-lms' ) . '</option>' . "\n";
 
-								foreach ( $courses as $course ) {
-									if ( has_term( '', $this->taxonomy, $course->ID ) ) {
-										$course_id = '';
-										if ( isset( $_GET['course_id'] ) ) {
-											$course_id = intval( $_GET['course_id'] );
-										}
-										$html .= '<option value="' . esc_attr( intval( $course->ID ) ) . '" ' . selected( $course->ID, $course_id, false ) . '>' . esc_html( get_the_title( $course->ID ) ) . '</option>' . "\n";
-									}
-								}
+			foreach ( $courses as $course ) {
+				if ( has_term( '', $this->taxonomy, $course->ID ) ) {
+					$course_id = '';
+					if ( isset( $_GET['course_id'] ) ) {
+						$course_id = intval( $_GET['course_id'] );
+					}
+					$html .= '<option value="' . esc_attr( intval( $course->ID ) ) . '" ' . selected( $course->ID, $course_id, false ) . '>' . esc_html( get_the_title( $course->ID ) ) . '</option>' . "\n";
+				}
+			}
 
-								$html .= '</select>' . "\n";
-								$html .= '<input type="submit" class="button-primary module-order-select-course-submit" value="' . esc_attr__( 'Select', 'sensei-lms' ) . '" />' . "\n";
-								$html .= '</form>' . "\n";
+			$html .= '</select>' . "\n";
+			$html .= '<input type="submit" class="button-primary module-order-select-course-submit" value="' . esc_attr__( 'Select', 'sensei-lms' ) . '" />' . "\n";
+			$html .= '</form>' . "\n";
 
-								if ( isset( $_GET['course_id'] ) ) {
-									$course_id = intval( $_GET['course_id'] );
-									if ( $course_id > 0 ) {
-										$modules = $this->get_course_modules( $course_id );
-										$modules = $this->append_teacher_name_to_module( $modules, array( 'module' ), array() );
-										if ( $modules ) {
+			if ( isset( $_GET['course_id'] ) ) {
+				$course_id = intval( $_GET['course_id'] );
+				if ( $course_id > 0 ) {
+					$modules = $this->get_course_modules( $course_id );
+					$modules = $this->append_teacher_name_to_module( $modules, array( 'module' ), array() );
+					if ( $modules ) {
 
-											$order = $this->get_course_module_order( $course_id );
+						$order = $this->get_course_module_order( $course_id );
 
-											$order_string = '';
-											if ( $order ) {
-												$order_string = implode( ',', $order );
-											}
+						$order_string = '';
+						if ( $order ) {
+							$order_string = implode( ',', $order );
+						}
 
-											$html .= '<form id="editgrouping" method="post" action="'
-												. esc_url( admin_url( 'admin-post.php' ) )
-												. '" class="validate">' . "\n";
-											$html .= '<ul class="sortable-module-list">' . "\n";
-											$count = 0;
-											foreach ( $modules as $module ) {
-												$count++;
-												$class = $this->taxonomy;
-												if ( $count == 1 ) {
-													$class .= ' first';
-												}
-												if ( $count == count( $modules ) ) {
-													$class .= ' last';
-												}
-												if ( $count % 2 != 0 ) {
-													$class .= ' alternate';
-												}
-												$html .= '<li class="' . esc_attr( $class ) . '"><span rel="' . esc_attr( $module->term_id ) . '" style="width: 100%;"> ' . esc_html( $module->name ) . '</span></li>' . "\n";
-											}
-											$html .= '</ul>' . "\n";
-											$html .= '<input type="hidden" name="action" value="order_modules" />' . "\n";
-											$html .= wp_nonce_field( 'order_modules', '_wpnonce', true, false ) . "\n";
-											$html .= '<input type="hidden" name="module-order" value="' . esc_attr( $order_string ) . '" />' . "\n";
-											$html .= '<input type="hidden" name="course_id" value="' . esc_attr( $course_id ) . '" />' . "\n";
-											$html .= '<input type="submit" class="button-primary" value="' . esc_attr__( 'Save module order', 'sensei-lms' ) . '" />' . "\n";
-											$html .= '<a href="' . esc_url( admin_url( 'post.php?post=' . $course_id . '&action=edit' ) ) . '" class="button-secondary">' . esc_html__( 'Edit course', 'sensei-lms' ) . '</a>' . "\n";
-											$html .= '</form>';
-										}
-									}
-								}
+						$html .= '<form id="editgrouping" method="post" action="'
+							. esc_url( admin_url( 'admin-post.php' ) )
+							. '" class="validate">' . "\n";
+						$html .= '<ul class="sortable-module-list">' . "\n";
+						$count = 0;
+						foreach ( $modules as $module ) {
+							$count++;
+							$class = $this->taxonomy;
+							if ( $count == 1 ) {
+								$class .= ' first';
+							}
+							if ( $count == count( $modules ) ) {
+								$class .= ' last';
+							}
+							if ( $count % 2 != 0 ) {
+								$class .= ' alternate';
+							}
+							$html .= '<li class="' . esc_attr( $class ) . '"><span rel="' . esc_attr( $module->term_id ) . '" style="width: 100%;"> ' . esc_html( $module->name ) . '</span></li>' . "\n";
+						}
+						$html .= '</ul>' . "\n";
+						$html .= '<input type="hidden" name="action" value="order_modules" />' . "\n";
+						$html .= wp_nonce_field( 'order_modules', '_wpnonce', true, false ) . "\n";
+						$html .= '<input type="hidden" name="module-order" value="' . esc_attr( $order_string ) . '" />' . "\n";
+						$html .= '<input type="hidden" name="course_id" value="' . esc_attr( $course_id ) . '" />' . "\n";
+						$html .= '<input type="submit" class="button-primary" value="' . esc_attr__( 'Save module order', 'sensei-lms' ) . '" />' . "\n";
+						$html .= '<a href="' . esc_url( admin_url( 'post.php?post=' . $course_id . '&action=edit' ) ) . '" class="button-secondary">' . esc_html__( 'Edit course', 'sensei-lms' ) . '</a>' . "\n";
+						$html .= '</form>';
+					}
+				}
+			}
 
-								echo wp_kses(
-									$html,
-									array_merge(
-										wp_kses_allowed_html( 'post' ),
-										array(
-											// Explicitly allow form tag for WP.com.
-											'form'   => array(
-												'action' => array(),
-												'class'  => array(),
-												'id'     => array(),
-												'method' => array(),
-											),
-											'input'  => array(
-												'class' => array(),
-												'name'  => array(),
-												'type'  => array(),
-												'value' => array(),
-											),
-											'option' => array(
-												'selected' => array(),
-												'value'    => array(),
-											),
-											'select' => array(
-												'id'   => array(),
-												'name' => array(),
-											),
-											'span'   => array(
-												'rel'   => array(),
-												'style' => array(),
-											),
-										)
-									)
-								);
+			echo wp_kses(
+				$html,
+				array_merge(
+					wp_kses_allowed_html( 'post' ),
+					array(
+						// Explicitly allow form tag for WP.com.
+						'form'   => array(
+							'action' => array(),
+							'class'  => array(),
+							'id'     => array(),
+							'method' => array(),
+						),
+						'input'  => array(
+							'class' => array(),
+							'name'  => array(),
+							'type'  => array(),
+							'value' => array(),
+						),
+						'option' => array(
+							'selected' => array(),
+							'value'    => array(),
+						),
+						'select' => array(
+							'id'   => array(),
+							'name' => array(),
+						),
+						'span'   => array(
+							'rel'   => array(),
+							'style' => array(),
+						),
+					)
+				)
+			);
 
-								?>
+			?>
 		</div>
 		<?php
 	}

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -1039,6 +1039,312 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Make sure structure is properly sorted.
+	 *
+	 * @dataProvider sortStructureData
+	 */
+	public function testSortStructure( $expected, $structure, $order, $type ) {
+		$this->assertEquals(
+			$expected,
+			Sensei_Course_Structure::sort_structure( $structure, $order, $type )
+		);
+	}
+
+	/**
+	 * Data source for sort structure tests.
+	 *
+	 * @return array[]
+	 */
+	public function sortStructureData() {
+		return [
+			// Sort lessons.
+			[
+				// Expected.
+				[
+					[
+						'type' => 'module',
+						'id'   => 11,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 1,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 2,
+					],
+				],
+				// Structure.
+				[
+					[
+						'type' => 'module',
+						'id'   => 11,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 2,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 1,
+					],
+				],
+				[ 1, 2 ],
+				'lesson',
+			],
+			// Sort modules.
+			[
+				// Expected.
+				[
+					[
+						'type' => 'module',
+						'id'   => 11,
+					],
+					[
+						'type' => 'module',
+						'id'   => 12,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 1,
+					],
+				],
+				// Structure.
+				[
+					[
+						'type' => 'module',
+						'id'   => 12,
+					],
+					[
+						'type' => 'module',
+						'id'   => 11,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 1,
+					],
+				],
+				// Order.
+				[ 11, 12 ],
+				// Type.
+				'module',
+			],
+			// Sort lessons with unordered lessons.
+			[
+				// Expected.
+				[
+					[
+						'type' => 'module',
+						'id'   => 11,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 1,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 2,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 3,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 4,
+					],
+				],
+				// Structure.
+				[
+					[
+						'type' => 'module',
+						'id'   => 11,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 3,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 4,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 2,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 1,
+					],
+				],
+				// Order.
+				[ 1, 2 ],
+				// Type.
+				'lesson',
+			],
+			// Sort lessons with unexising IDs.
+			[
+				// Expected.
+				[
+					[
+						'type' => 'module',
+						'id'   => 11,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 1,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 2,
+					],
+				],
+				// Structure.
+				[
+					[
+						'type' => 'module',
+						'id'   => 11,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 2,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 1,
+					],
+				],
+				// Order.
+				[ 1, 2, 3, 4 ],
+				// Type.
+				'lesson',
+			],
+			// Sort lessons with mixed lessons and modules.
+			[
+				// Expected.
+				[
+					[
+						'type' => 'module',
+						'id'   => 12,
+					],
+					[
+						'type' => 'module',
+						'id'   => 11,
+					],
+					[
+						'type' => 'module',
+						'id'   => 13,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 1,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 2,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 3,
+					],
+				],
+				// Structure.
+				[
+					[
+						'type' => 'module',
+						'id'   => 12,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 3,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 2,
+					],
+					[
+						'type' => 'module',
+						'id'   => 11,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 1,
+					],
+					[
+						'type' => 'module',
+						'id'   => 13,
+					],
+				],
+				// Order.
+				[ 1, 2, 3 ],
+				// Type.
+				'lesson',
+			],
+			// Sort modules with mixed lessons and modules.
+			[
+				// Expected.
+				[
+					[
+						'type' => 'module',
+						'id'   => 11,
+					],
+					[
+						'type' => 'module',
+						'id'   => 12,
+					],
+					[
+						'type' => 'module',
+						'id'   => 13,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 3,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 1,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 2,
+					],
+				],
+				// Structure.
+				[
+					[
+						'type' => 'module',
+						'id'   => 12,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 3,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 1,
+					],
+					[
+						'type' => 'module',
+						'id'   => 11,
+					],
+					[
+						'type' => 'lesson',
+						'id'   => 2,
+					],
+					[
+						'type' => 'module',
+						'id'   => 13,
+					],
+				],
+				// Order.
+				[ 11, 12, 13 ],
+				// Type.
+				'module',
+			],
+		];
+	}
+
+	/**
 	 * Reset the course structure instances array.
 	 */
 	private function resetInstances() {


### PR DESCRIPTION
After working in #3664, PR #3655 didn't make more sense. So closes #3655 in favor of this PR.

### Changes proposed in this Pull Request

* Refactor module reorder page to use `Sensei_Course_Structure`.

### Testing instructions

It should not change the current behavior.

* Create a course with modules.
* Go to wp-admin > Courses > Order Modules.
* Select the course with modules.
* Reorder the modules, save.
* Check the course page and make sure it was reordered properly.

The code created in #3664 was partially refactored, so it worths retest the lessons reorder too.