### PR TITLE
Remove module animation setting and replace with collapsible modules setting

### DIFF
--- a/assets/blocks/course-outline/course-block/block.json
+++ b/assets/blocks/course-outline/course-block/block.json
@@ -9,7 +9,7 @@
     "id": {
       "type": "integer"
     },
-    "animationsEnabled": {
+    "collapsibleModules": {
       "type": "boolean",
       "default": true
     }

--- a/assets/blocks/course-outline/course-block/edit.js
+++ b/assets/blocks/course-outline/course-block/edit.js
@@ -41,15 +41,6 @@ const EditCourseOutlineBlock = ( {
 
 	const { setBlocks } = useBlocksCreator( clientId );
 
-	/**
-	 * Handle update animationsEnabled setting.
-	 *
-	 * @param {boolean} value Value of the setting.
-	 */
-	const updateAnimationsEnabled = ( value ) => {
-		setAttributes( { animationsEnabled: value } );
-	};
-
 	const isEmpty = useSelect(
 		( select ) =>
 			! select( 'core/block-editor' ).getBlocks( clientId ).length,
@@ -73,8 +64,10 @@ const EditCourseOutlineBlock = ( {
 	return (
 		<>
 			<OutlineBlockSettings
-				animationsEnabled={ attributes.animationsEnabled }
-				setAnimationsEnabled={ updateAnimationsEnabled }
+				collapsibleModules={ attributes.collapsibleModules }
+				setCollapsibleModules={ ( value ) =>
+					setAttributes( { collapsibleModules: value } )
+				}
 			/>
 
 			<section className={ className }>

--- a/assets/blocks/course-outline/course-block/settings.js
+++ b/assets/blocks/course-outline/course-block/settings.js
@@ -6,24 +6,25 @@ import { PanelBody, ToggleControl } from '@wordpress/components';
  * Inspector controls for outline block.
  *
  * @param {Object}   props
- * @param {boolean}  props.animationsEnabled    Whether animations are enabled.
- * @param {Function} props.setAnimationsEnabled Callback to be called when animations enabling is updated.
+ * @param {boolean}  props.collapsibleModules    Whether collapsible modules are enabled.
+ * @param {Function} props.setCollapsibleModules Callback to be called when collapsible modules setting is updated.
  */
 export function OutlineBlockSettings( {
-	animationsEnabled,
-	setAnimationsEnabled,
+	collapsibleModules,
+	setCollapsibleModules,
 } ) {
 	return (
 		<InspectorControls>
 			<PanelBody
-				title={ __( 'Animation', 'sensei-lms' ) }
+				title={ __( 'Modules', 'sensei-lms' ) }
 				initialOpen={ false }
 			>
 				<ToggleControl
-					checked={ animationsEnabled }
-					onChange={ setAnimationsEnabled }
-					label={ __(
-						'Animate the expanding and collapsing of modules',
+					checked={ collapsibleModules }
+					onChange={ setCollapsibleModules }
+					label={ __( 'Collapsible modules', 'sensei-lms' ) }
+					help={ __(
+						'Modules can be collapsed or expanded.',
 						'sensei-lms'
 					) }
 				/>

--- a/assets/blocks/course-outline/frontend.js
+++ b/assets/blocks/course-outline/frontend.js
@@ -8,6 +8,15 @@
 	};
 
 	onReady( () => {
+		if (
+			0 ===
+			document.querySelectorAll(
+				'.wp-block-sensei-lms-course-outline__arrow'
+			).length
+		) {
+			return;
+		}
+
 		const modules = document.querySelectorAll(
 			'.wp-block-sensei-lms-course-outline-module'
 		);

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -79,14 +79,14 @@ const EditModuleBlock = ( {
 		</>
 	);
 
-	const animationWrapper = (
+	const animationWrapper = collapsibleModules && (
 		<AnimateHeight
 			className="wp-block-sensei-lms-collapsible"
 			duration={ 500 }
 			animateOpacity
 			height={ isExpanded ? 'auto' : 0 }
 		>
-			{ collapsibleModules && moduleContent }
+			{ moduleContent }
 		</AnimateHeight>
 	);
 

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -72,13 +72,11 @@ const EditModuleBlock = ( {
 					{ __( 'Lessons', 'sensei-lms' ) }
 				</h3>
 			</div>
-      <InnerBlocks
-        template={ [
-          [ 'sensei-lms/course-outline-lesson', {} ],
-        ] }
-        allowedBlocks={ [ 'sensei-lms/course-outline-lesson' ] }
-        templateInsertUpdatesSelection={ false }
-      />
+			<InnerBlocks
+				template={ [ [ 'sensei-lms/course-outline-lesson', {} ] ] }
+				allowedBlocks={ [ 'sensei-lms/course-outline-lesson' ] }
+				templateInsertUpdatesSelection={ false }
+			/>
 		</>
 	);
 

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -24,7 +24,7 @@ const EditModuleBlock = ( {
 	setAttributes,
 } ) => {
 	const {
-		outlineAttributes: { animationsEnabled },
+		outlineAttributes: { collapsibleModules },
 	} = useContext( OutlineAttributesContext );
 
 	/**
@@ -57,6 +57,39 @@ const EditModuleBlock = ( {
 
 	const [ isExpanded, setExpanded ] = useState( true );
 
+	const moduleContent = (
+		<>
+			<div className="wp-block-sensei-lms-course-outline-module__description">
+				<RichText
+					className="wp-block-sensei-lms-course-outline-module__description-input"
+					placeholder={ __( 'Module description', 'sensei-lms' ) }
+					value={ description }
+					onChange={ updateDescription }
+				/>
+			</div>
+			<div className="wp-block-sensei-lms-course-outline-module__lessons-title">
+				<h3 className="wp-block-sensei-lms-course-outline__clean-heading">
+					{ __( 'Lessons', 'sensei-lms' ) }
+				</h3>
+			</div>
+			<InnerBlocks
+				template={ [ [ 'sensei-lms/course-outline-lesson', {} ] ] }
+				allowedBlocks={ [ 'sensei-lms/course-outline-lesson' ] }
+			/>
+		</>
+	);
+
+	const animationWrapper = (
+		<AnimateHeight
+			className="wp-block-sensei-lms-collapsible"
+			duration={ 500 }
+			animateOpacity
+			height={ isExpanded ? 'auto' : 0 }
+		>
+			{ collapsibleModules && moduleContent }
+		</AnimateHeight>
+	);
+
 	return (
 		<>
 			<ModuleBlockSettings
@@ -84,51 +117,26 @@ const EditModuleBlock = ( {
 							{ indicatorText }
 						</span>
 					</div>
-					<button
-						type="button"
-						className={ classnames(
-							'wp-block-sensei-lms-course-outline__arrow',
-							'dashicons',
-							isExpanded
-								? 'dashicons-arrow-up-alt2'
-								: 'dashicons-arrow-down-alt2'
-						) }
-						onClick={ () => setExpanded( ! isExpanded ) }
-					>
-						<span className="screen-reader-text">
-							{ __( 'Toggle module content', 'sensei-lms' ) }
-						</span>
-					</button>
-				</header>
-				<AnimateHeight
-					className="wp-block-sensei-lms-collapsible"
-					duration={ animationsEnabled ? 500 : 0 }
-					animateOpacity
-					height={ isExpanded ? 'auto' : 0 }
-				>
-					<div className="wp-block-sensei-lms-course-outline-module__description">
-						<RichText
-							className="wp-block-sensei-lms-course-outline-module__description-input"
-							placeholder={ __(
-								'Module description',
-								'sensei-lms'
+					{ collapsibleModules && (
+						<button
+							type="button"
+							className={ classnames(
+								'wp-block-sensei-lms-course-outline__arrow',
+								'dashicons',
+								isExpanded
+									? 'dashicons-arrow-up-alt2'
+									: 'dashicons-arrow-down-alt2'
 							) }
-							value={ description }
-							onChange={ updateDescription }
-						/>
-					</div>
-					<div className="wp-block-sensei-lms-course-outline-module__lessons-title">
-						<h3 className="wp-block-sensei-lms-course-outline__clean-heading">
-							{ __( 'Lessons', 'sensei-lms' ) }
-						</h3>
-					</div>
-					<InnerBlocks
-						template={ [
-							[ 'sensei-lms/course-outline-lesson', {} ],
-						] }
-						allowedBlocks={ [ 'sensei-lms/course-outline-lesson' ] }
-					/>
-				</AnimateHeight>
+							onClick={ () => setExpanded( ! isExpanded ) }
+						>
+							<span className="screen-reader-text">
+								{ __( 'Toggle module content', 'sensei-lms' ) }
+							</span>
+						</button>
+					) }
+				</header>
+
+				{ collapsibleModules ? animationWrapper : moduleContent }
 			</section>
 		</>
 	);

--- a/assets/blocks/course-outline/module-block/edit.test.js
+++ b/assets/blocks/course-outline/module-block/edit.test.js
@@ -18,7 +18,7 @@ jest.mock( '../use-block-creator', () => jest.fn() );
 jest.mock( '../course-block/edit', () => jest.fn() );
 jest.mock( '@wordpress/element', () => ( {
 	...jest.requireActual( '@wordpress/element' ),
-	useContext: () => ( { outlineAttributes: { animationsEnabled: true } } ),
+	useContext: () => ( { outlineAttributes: { collapsibleModules: true } } ),
 } ) );
 
 describe( '<EditLessonBlock />', () => {

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -128,11 +128,9 @@ $dark-gray: #1a1d20;
 }
 
 .wp-block-sensei-lms-collapsible {
-	&.animated {
-		opacity: 1;
-		overflow: hidden;
-		transition: height 0.5s ease-in-out, opacity 0.5s ease-in-out;
-	}
+	opacity: 1;
+	overflow: hidden;
+	transition: height 0.5s ease-in-out, opacity 0.5s ease-in-out;
 
 	&.collapsed {
 		opacity: 0;

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -251,8 +251,6 @@ class Sensei_Course_Outline_Block {
 
 		$progress_indicator = $this->get_progress_indicator( $block['id'], $course_id );
 
-		$animated = empty( $outline_attributes['animationsEnabled'] ) ? '' : 'animated';
-
 		return '
 			<section class="wp-block-sensei-lms-course-outline-module">
 				<header class="wp-block-sensei-lms-course-outline-module__name">
@@ -262,7 +260,7 @@ class Sensei_Course_Outline_Block {
 						<span class="screen-reader-text">' . __( 'Toggle module content', 'sensei-lms' ) . '</span>
 					</button>
 				</header>
-				<div class="wp-block-sensei-lms-collapsible ' . $animated . '">
+				<div class="wp-block-sensei-lms-collapsible">
 					<div class="wp-block-sensei-lms-course-outline-module__description">
 						' . $block['description'] . '
 					</div>

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -255,11 +255,12 @@ class Sensei_Course_Outline_Block {
 			<section class="wp-block-sensei-lms-course-outline-module">
 				<header class="wp-block-sensei-lms-course-outline-module__name">
 					<h2 class="wp-block-sensei-lms-course-outline__clean-heading">' . $block['title'] . '</h2>
-					' . $progress_indicator . '
-					<button type="button" class="wp-block-sensei-lms-course-outline__arrow dashicons dashicons-arrow-up-alt2">
+					' . $progress_indicator .
+					( ! empty( $outline_attributes['collapsibleModules'] ) ?
+					'<button type="button" class="wp-block-sensei-lms-course-outline__arrow dashicons dashicons-arrow-up-alt2">
 						<span class="screen-reader-text">' . __( 'Toggle module content', 'sensei-lms' ) . '</span>
-					</button>
-				</header>
+					</button>' : '' ) .
+				'</header>
 				<div class="wp-block-sensei-lms-collapsible">
 					<div class="wp-block-sensei-lms-course-outline-module__description">
 						' . $block['description'] . '


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Replaces module animation setting with _Collapsible modules_ toggle.

### Testing instructions

* Create a new course.
* Add a module to the course outline block.
* Ensure the module is collapsible by default in both the editor and on the front-end.
* Disable the _Collapsible modules_ setting.
* Ensure the module arrow is removed in the editor and on the front-end.