### PR TITLE
Focus the module title input when adding a new module

### DIFF
--- a/assets/blocks/course-outline/course-block/edit.js
+++ b/assets/blocks/course-outline/course-block/edit.js
@@ -65,7 +65,7 @@ const EditCourseOutlineBlock = ( {
 	if ( isEmpty ) {
 		return (
 			<CourseOutlinePlaceholder
-				addBlock={ ( type ) => setBlocks( [ { type } ] ) }
+				addBlock={ ( type ) => setBlocks( [ { type } ], true ) }
 			/>
 		);
 	}

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -127,6 +127,7 @@ const EditModuleBlock = ( {
 							[ 'sensei-lms/course-outline-lesson', {} ],
 						] }
 						allowedBlocks={ [ 'sensei-lms/course-outline-lesson' ] }
+						templateInsertUpdatesSelection={ false }
 					/>
 				</AnimateHeight>
 			</section>

--- a/assets/blocks/course-outline/use-block-creator.js
+++ b/assets/blocks/course-outline/use-block-creator.js
@@ -19,14 +19,14 @@ export const useBlocksCreator = ( clientId ) => {
 	);
 
 	const setBlocks = useCallback(
-		( structure ) => {
+		( structure, updateSelection = false ) => {
 			const blocks = getBlocks( clientId );
 			const currentStructure = extractStructure( blocks );
 			if ( ! isEqual( currentStructure, structure ) ) {
 				replaceInnerBlocks(
 					clientId,
 					syncStructureToBlocks( structure, blocks ),
-					false
+					updateSelection
 				);
 
 				dispatch( COURSE_STORE ).setEditorDirty( true );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It update the blocks to focus the module title when creating a new module.
* It also add the focus to the input when creating through the `Placeholder`.

### Testing instructions

* Create a new course.
* Create a new module through the `Placeholder`, and make sure the focus go to the module title.
* Remove and re-add the Outline block.
* Create a new lesson through the `Placeholder`, and make sure the focus go to the lesson.
* Add a new module in the existing Outline block, and make sure the focus go to the module title.
* Add a new lesson in the existing Outline block, and make sure the focus go to the lesson.
* Add a new lesson inside the Module block, and make sure the focus to the new created lesson.