### PR TITLE
Add chevron to lesson block

### DIFF
--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -1,6 +1,7 @@
 import { createBlock } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
+import { chevronRight, Icon } from '@wordpress/icons';
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
 import { withColorSettings } from '../../../shared/blocks/settings';
@@ -142,6 +143,10 @@ export const EditLessonBlock = ( props ) => {
 					style={ { fontSize } }
 				/>
 				{ isSelected && status }
+				<Icon
+					icon={ chevronRight }
+					className="wp-block-sensei-lms-course-outline-lesson__chevron"
+				/>
 			</div>
 		</>
 	);

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -152,21 +152,19 @@ $spacing: 16px;
 	margin: 1px 0;
 	position: relative;
 	font-size: 1em;
-
-	> a {
-		flex: 1;
+	color: inherit;
+	font-family: inherit;
+	line-height: inherit;
+	text-decoration: inherit;
+	border: none;
+	font-weight: normal;
+	&:hover {
 		color: inherit;
-		font-family: inherit;
-		font-size: inherit;
-		line-height: inherit;
-		text-decoration: inherit;
-		border: none;
-		font-weight: normal;
-		padding: 20px $spacing;
-		&:hover {
-			color: inherit;
-		}
+	}
 
+	> span {
+		flex: 1;
+		padding: 20px $spacing;
 	}
 
 	&__chevron {
@@ -207,7 +205,7 @@ $spacing: 16px;
 		text-align: center;
 	}
 
-	&:hover a::after {
+	&:hover::after {
 		content: '';
 		position: absolute;
 		pointer-events: none;

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -154,7 +154,6 @@ $spacing: 16px;
 	font-size: 1em;
 
 	> a {
-		display: block;
 		flex: 1;
 		color: inherit;
 		font-family: inherit;
@@ -167,6 +166,14 @@ $spacing: 16px;
 		&:hover {
 			color: inherit;
 		}
+
+	}
+
+	&__chevron {
+		fill: currentColor;
+		width: 24px;
+		height: 24px;
+		margin: 0 16px;
 	}
 
 	.entry-content & {
@@ -200,7 +207,7 @@ $spacing: 16px;
 		text-align: center;
 	}
 
-	&:hover::after {
+	&:hover a::after {
 		content: '';
 		position: absolute;
 		pointer-events: none;

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -188,7 +188,7 @@ class Sensei_Course_Outline_Block {
 			]
 		);
 
-		$icons = '<svg xmlns="http://www.w3.org/2000/svg">
+		$icons = '<svg xmlns="http://www.w3.org/2000/svg" style="display: none">
 			<symbol id="sensei-chevron-right" viewBox="0 0 24 24">
 				<path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z" fill="" />
 			</symbol>

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -195,7 +195,7 @@ class Sensei_Course_Outline_Block {
 		</svg>';
 
 		return '
-			' . $icons . '
+			' . ( ! empty( $structure ) ? $icons : '' ) . '
 			<section ' . Sensei_Block_Helpers::render_style_attributes( [ 'wp-block-sensei-lms-course-outline', $class_name ], $css ) . '>
 				' .
 			implode(

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -236,13 +236,12 @@ class Sensei_Course_Outline_Block {
 		$css = Sensei_Block_Helpers::build_styles( $block );
 
 		return '
-			<div ' . Sensei_Block_Helpers::render_style_attributes( $classes, $css ) . '>
-				<a
-				href="' . esc_url( get_permalink( $lesson_id ) ) . '">
+			<a href="' . esc_url( get_permalink( $lesson_id ) ) . '" ' . Sensei_Block_Helpers::render_style_attributes( $classes, $css ) . '>
+				<span>
 					' . $block['title'] . '
-				</a>
+				</span>
 				<svg class="wp-block-sensei-lms-course-outline-lesson__chevron"><use xlink:href="#sensei-chevron-right"></use></svg>
-			</div>
+			</a>
 		';
 	}
 

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -188,7 +188,14 @@ class Sensei_Course_Outline_Block {
 			]
 		);
 
+		$icons = '<svg xmlns="http://www.w3.org/2000/svg">
+			<symbol id="sensei-chevron-right" viewBox="0 0 24 24">
+				<path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z" fill="" />
+			</symbol>
+		</svg>';
+
 		return '
+			' . $icons . '
 			<section ' . Sensei_Block_Helpers::render_style_attributes( [ 'wp-block-sensei-lms-course-outline', $class_name ], $css ) . '>
 				' .
 			implode(
@@ -234,6 +241,7 @@ class Sensei_Course_Outline_Block {
 				href="' . esc_url( get_permalink( $lesson_id ) ) . '">
 					' . $block['title'] . '
 				</a>
+				<svg class="wp-block-sensei-lms-course-outline-lesson__chevron"><use xlink:href="#sensei-chevron-right"></use></svg>
 			</div>
 		';
 	}


### PR DESCRIPTION
Depends on #3650, which contains making the entire lesson box clickable 

### Changes proposed in this Pull Request

* Add chevron icon to the right of the lesson block
* On the frontend, it's added as an `<svg>` element, to make sure it picks up the text color
  * Uses reusable svg `<symbol>`, so the icon definition is shared between lessons. This library element is rendered in the Outline block HTML.

### Testing instructions

* View a course with outline block and lessons in the editor and frontend
* Check that the icon is there
* Adjust text color for a lesson block
* Check that the icon uses the text color

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="648" alt="image" src="https://user-images.githubusercontent.com/176949/95108215-42327500-073b-11eb-88ac-22fae68ca56f.png">

