### PR TITLE
Fix SVG icon usages, replace module collapse dashicon with SVG

### DIFF
--- a/assets/blocks/course-outline/frontend.js
+++ b/assets/blocks/course-outline/frontend.js
@@ -34,8 +34,7 @@
 			moduleContent.style.height = originalHeight + 'px';
 
 			toggleButton.addEventListener( 'click', () => {
-				toggleButton.classList.toggle( 'dashicons-arrow-up-alt2' );
-				toggleButton.classList.toggle( 'dashicons-arrow-down-alt2' );
+				toggleButton.classList.toggle( 'collapsed' );
 				const collapsed = moduleContent.classList.toggle( 'collapsed' );
 
 				if ( ! collapsed ) {

--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -1,9 +1,10 @@
 import { createBlock } from '@wordpress/blocks';
 import { useDispatch } from '@wordpress/data';
 import { useState } from '@wordpress/element';
-import { chevronRight, Icon } from '@wordpress/icons';
+import { Icon } from '@wordpress/components';
 import classnames from 'classnames';
 import { __ } from '@wordpress/i18n';
+import { chevronRight } from '../../../icons/wordpress-icons';
 import { withColorSettings } from '../../../shared/blocks/settings';
 import SingleLineInput from '../single-line-input';
 import { LessonBlockSettings } from './settings';

--- a/assets/blocks/course-outline/lesson-block/edit.test.js
+++ b/assets/blocks/course-outline/lesson-block/edit.test.js
@@ -1,23 +1,14 @@
 import { render, fireEvent, waitFor } from '@testing-library/react';
+import { EditLessonBlock } from './edit';
 import { useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
-import { EditLessonBlock } from './edit';
+jest.mock( '@wordpress/block-editor' );
+jest.mock( '@wordpress/data' );
 
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn(),
-} ) );
-
-jest.mock( '@wordpress/blocks', () => ( {
-	createBlock: jest.fn(),
-} ) );
-
-jest.mock( '@wordpress/block-editor', () => ( {
-	withColors() {
-		return ( Component ) => ( props ) => (
-			<Component { ...props } backgroundColor={ {} } textColor={ {} } />
-		);
-	},
+jest.mock( '@wordpress/blocks' );
+jest.mock( '../../../shared/blocks/settings', () => ( {
+	withColorSettings: () => ( Component ) => Component,
 } ) );
 
 jest.mock( './settings', () => ( {

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -1,9 +1,11 @@
 import { InnerBlocks, RichText } from '@wordpress/block-editor';
+import { Icon } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { useContext, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import AnimateHeight from 'react-animate-height';
+import { chevronUp } from '../../../icons/wordpress-icons';
 
 import {
 	withColorSettings,
@@ -118,13 +120,11 @@ export const EditModuleBlock = ( props ) => {
 							type="button"
 							className={ classnames(
 								'wp-block-sensei-lms-course-outline__arrow',
-								'dashicons',
-								isExpanded
-									? 'dashicons-arrow-up-alt2'
-									: 'dashicons-arrow-down-alt2'
+								{ collapsed: ! isExpanded }
 							) }
 							onClick={ () => setExpanded( ! isExpanded ) }
 						>
+							<Icon icon={ chevronUp } />
 							<span className="screen-reader-text">
 								{ __( 'Toggle module content', 'sensei-lms' ) }
 							</span>

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -25,6 +25,9 @@ $spacing: 16px;
 		margin: 0 -5px 0 10px;
 		cursor: pointer;
 		svg {
+			transition: transform 250ms linear;
+		}
+		svg {
 			width: 32px;
 			height: 32px;
 			margin: -12px 0;
@@ -36,7 +39,9 @@ $spacing: 16px;
 		}
 
 		&.collapsed {
-			transform: scaleY(-1)
+			svg {
+				transform: rotate(180deg)
+			}
 		}
 	}
 }
@@ -219,7 +224,7 @@ $spacing: 16px;
 .wp-block-sensei-lms-collapsible {
 	opacity: 1;
 	overflow: hidden;
-	transition: height 0.5s ease-in-out, opacity 0.5s ease-in-out;
+	transition: height 350ms ease-in-out, opacity 350ms ease-in-out;
 
 	&.collapsed {
 		opacity: 0;

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -22,18 +22,21 @@ $spacing: 16px;
 		background: none;
 		border: 0;
 		color: inherit;
-		flex-basis: 4%;
-		margin: 0 0 0 10px;
+		margin: 0 -5px 0 10px;
 		cursor: pointer;
-		height: 24px;
-		font-size: 24px;
+		svg {
+			width: 32px;
+			height: 32px;
+			margin: -12px 0;
+			fill: currentColor;
+		}
 
 		&:hover, &:focus {
 			text-decoration: none;
 		}
 
 		&.collapsed {
-			display: none;
+			transform: scaleY(-1)
 		}
 	}
 }

--- a/assets/icons/wordpress-icons.js
+++ b/assets/icons/wordpress-icons.js
@@ -5,3 +5,9 @@ export const chevronRight = (
 		<Path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z" />
 	</SVG>
 );
+
+export const chevronUp = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z" />
+	</SVG>
+);

--- a/assets/icons/wordpress-icons.js
+++ b/assets/icons/wordpress-icons.js
@@ -1,0 +1,7 @@
+import { Path, SVG } from '@wordpress/components';
+
+export const chevronRight = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+		<Path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z" />
+	</SVG>
+);

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -193,6 +193,9 @@ class Sensei_Course_Outline_Block {
 			<symbol id="sensei-chevron-right" viewBox="0 0 24 24">
 				<path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z" fill="" />
 			</symbol>
+			<symbol id="sensei-chevron-up" viewBox="0 0 24 24">
+				<path d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z" fill="" />
+			</symbol>
 		</svg>';
 
 		return '
@@ -295,7 +298,8 @@ class Sensei_Course_Outline_Block {
 					<h2 class="wp-block-sensei-lms-course-outline-module__title">' . esc_html( $block['title'] ) . '</h2>
 					' . $progress_indicator .
 			( ! empty( $outline_attributes['collapsibleModules'] ) ?
-				'<button type="button" class="wp-block-sensei-lms-course-outline__arrow dashicons dashicons-arrow-up-alt2">
+				'<button type="button" class="wp-block-sensei-lms-course-outline__arrow">
+						<svg><use xlink:href="#sensei-chevron-up"></use></svg>
 						<span class="screen-reader-text">' . esc_html__( 'Toggle module content', 'sensei-lms' ) . '</span>
 					</button>' : '' ) .
 			'</header>

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -164,7 +164,7 @@ class Sensei_Frontend {
 
 		if ( ! $disable_styles ) {
 
-			Sensei()->assets->enqueue( Sensei()->token . '-frontend', 'css/frontend.css', [ 'dashicons' ], 'screen' );
+			Sensei()->assets->enqueue( Sensei()->token . '-frontend', 'css/frontend.css', [], 'screen' );
 
 			// Allow additional stylesheets to be loaded.
 			do_action( 'sensei_additional_styles' );


### PR DESCRIPTION

There are some build issues with `@wordpress/icons` dependencies on Wordpress 5.3 - `wp-primitivies` is not available. 
This one copies the used chevron icons, and uses the same React SVG primitives from `@wordpress/components`.

Also replaces the module collapse arrow with an SVG, similar to #3679 

### Changes proposed in this Pull Request

* Include the needed React SVG icon components
* Replace module collapse dashicon with SVG chevron

### Testing instructions

* Check that outline block works in Wordpress 5.3
* Check that lesson chevron and module collapse icons look right

