### PR TITLE
Change module inserter to new lesson block

### DIFF
--- a/assets/blocks/course-outline/lesson-block/edit.test.js
+++ b/assets/blocks/course-outline/lesson-block/edit.test.js
@@ -1,5 +1,5 @@
 import { render, fireEvent, waitFor } from '@testing-library/react';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, select } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
 import { EditLessonBlock } from './edit';
@@ -31,6 +31,13 @@ describe( '<EditLessonBlock />', () => {
 		selectNextBlock: selectNextBlockMock,
 		removeBlock: removeBlockMock,
 	} ) );
+
+	beforeEach( () => {
+		select.mockReturnValue( {
+			getBlock: () => null,
+			getNextBlockClientId: () => null,
+		} );
+	} );
 
 	createBlock.mockImplementation( createBlockMock );
 
@@ -67,7 +74,7 @@ describe( '<EditLessonBlock />', () => {
 		expect( setAttributesMock ).toBeCalledWith( { title: 'Test' } );
 	} );
 
-	it( 'Should create new block when pressing enter with title filled', async () => {
+	it( 'Should create new block when pressing enter', async () => {
 		const insertBlocksAfterMock = jest.fn();
 
 		const { getByPlaceholderText } = render(
@@ -88,7 +95,11 @@ describe( '<EditLessonBlock />', () => {
 		await waitFor( () => expect( insertBlocksAfterMock ).toBeCalled() );
 	} );
 
-	it( 'Should not create new block when pressing enter with title empty', async () => {
+	it( 'Should not create new block when there is already one after it', async () => {
+		select.mockReturnValue( {
+			getBlock: () => ( { clientId: '1', attributes: { title: '' } } ),
+			getNextBlockClientId: () => null,
+		} );
 		const insertBlocksAfterMock = jest.fn();
 
 		const { getByPlaceholderText } = render(
@@ -106,8 +117,14 @@ describe( '<EditLessonBlock />', () => {
 		await waitFor( () => expect( insertBlocksAfterMock ).not.toBeCalled() );
 	} );
 
-	it( 'Should focus on the next block when pressing enter and there is a next block', async () => {
-		selectNextBlockMock.mockReturnValue( [ '123' ] );
+	it( 'Should focus on the next block when pressing enter and there is a next empty block', async () => {
+		select.mockReturnValue( {
+			getBlock: () => ( {
+				clientId: '1',
+				attributes: { title: '' },
+			} ),
+			getNextBlockClientId: () => null,
+		} );
 		const insertBlocksAfterMock = jest.fn();
 
 		const { getByPlaceholderText } = render(

--- a/assets/blocks/course-outline/lesson-block/edit.test.js
+++ b/assets/blocks/course-outline/lesson-block/edit.test.js
@@ -3,10 +3,7 @@ import { EditLessonBlock } from './edit';
 import { useDispatch, select } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
-jest.mock( '@wordpress/block-editor' );
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn(),
-} ) );
+jest.mock( '@wordpress/data' );
 
 jest.mock( '@wordpress/blocks' );
 jest.mock( '../../../shared/blocks/settings', () => ( {

--- a/assets/blocks/course-outline/lesson-block/edit.test.js
+++ b/assets/blocks/course-outline/lesson-block/edit.test.js
@@ -4,20 +4,12 @@ import { createBlock } from '@wordpress/blocks';
 
 import { EditLessonBlock } from './edit';
 
-jest.mock( '@wordpress/data', () => ( {
-	useDispatch: jest.fn(),
-} ) );
+jest.mock( '@wordpress/block-editor' );
+jest.mock( '@wordpress/data' );
 
-jest.mock( '@wordpress/blocks', () => ( {
-	createBlock: jest.fn(),
-} ) );
-
-jest.mock( '@wordpress/block-editor', () => ( {
-	withColors() {
-		return ( Component ) => ( props ) => (
-			<Component { ...props } backgroundColor={ {} } textColor={ {} } />
-		);
-	},
+jest.mock( '@wordpress/blocks' );
+jest.mock( '../../../shared/blocks/settings', () => ( {
+	withColorSettings: () => ( Component ) => Component,
 } ) );
 
 jest.mock( './settings', () => ( {

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -82,7 +82,6 @@ export const EditModuleBlock = ( props ) => {
 				{ __( 'Lessons', 'sensei-lms' ) }
 			</h3>
 			<InnerBlocks
-				template={ [ [ 'sensei-lms/course-outline-lesson', {} ] ] }
 				allowedBlocks={ [ 'sensei-lms/course-outline-lesson' ] }
 				templateInsertUpdatesSelection={ false }
 				renderAppender={ () => null }

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -13,6 +13,7 @@ import { OutlineAttributesContext } from '../course-block/edit';
 import SingleLineInput from '../single-line-input';
 import { ModuleStatus } from './module-status';
 import { ModuleBlockSettings } from './settings';
+import { useInsertLessonBlock } from './use-insert-lesson-block';
 
 /**
  * Edit module block component.
@@ -22,9 +23,9 @@ import { ModuleBlockSettings } from './settings';
  * @param {Object}   props.attributes             Block attributes.
  * @param {string}   props.attributes.title       Module title.
  * @param {string}   props.attributes.description Module description.
+ * @param {string}   props.attributes.blockStyle  Selected block style.
  * @param {Object}   props.mainColor              Header main color.
  * @param {Object}   props.textColor              Header text color.
- * @param {string}   props.attributes.blockStyle  Selected block style.
  * @param {Function} props.setAttributes          Block set attributes function.
  */
 export const EditModuleBlock = ( props ) => {
@@ -39,6 +40,9 @@ export const EditModuleBlock = ( props ) => {
 	const {
 		outlineAttributes: { collapsibleModules },
 	} = useContext( OutlineAttributesContext ) || { outlineAttributes: {} };
+
+	useInsertLessonBlock( props );
+
 	/**
 	 * Handle update name.
 	 *
@@ -81,6 +85,7 @@ export const EditModuleBlock = ( props ) => {
 				template={ [ [ 'sensei-lms/course-outline-lesson', {} ] ] }
 				allowedBlocks={ [ 'sensei-lms/course-outline-lesson' ] }
 				templateInsertUpdatesSelection={ false }
+				renderAppender={ () => null }
 			/>
 		</>
 	);

--- a/assets/blocks/course-outline/module-block/edit.test.js
+++ b/assets/blocks/course-outline/module-block/edit.test.js
@@ -15,6 +15,7 @@ jest.mock( '@wordpress/block-editor', () => ( {
 	),
 } ) );
 jest.mock( '../use-block-creator', () => jest.fn() );
+jest.mock( './use-insert-lesson-block' );
 jest.mock( '../course-block/edit', () => jest.fn() );
 jest.mock( '@wordpress/element', () => ( {
 	...jest.requireActual( '@wordpress/element' ),

--- a/assets/blocks/course-outline/module-block/use-insert-lesson-block.js
+++ b/assets/blocks/course-outline/module-block/use-insert-lesson-block.js
@@ -34,12 +34,19 @@ export const useInsertLessonBlock = ( props ) => {
 		) || isSelected;
 
 	useEffect( () => {
+		if ( ! hasSelected ) setImplicitLessonBlockClientId( null );
+	}, [ hasSelected ] );
+	useEffect( () => {
 		const lastLessonBlock =
 			lessonBlocks.length && lessonBlocks[ lessonBlocks.length - 1 ];
 		const hasEmptyLastLessonBlock =
 			lastLessonBlock && ! lastLessonBlock.attributes.title;
 
-		if ( hasSelected && ! hasEmptyLastLessonBlock ) {
+		if (
+			hasSelected &&
+			! hasEmptyLastLessonBlock &&
+			! implicitLessonBlockClientId
+		) {
 			addBlock( 'sensei-lms/course-outline-lesson' );
 		}
 		if (

--- a/assets/blocks/course-outline/module-block/use-insert-lesson-block.js
+++ b/assets/blocks/course-outline/module-block/use-insert-lesson-block.js
@@ -1,0 +1,46 @@
+import { createBlock } from '@wordpress/blocks';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback, useEffect } from '@wordpress/element';
+
+/**
+ * Insert an empty lesson block to the end of the module when it's selected.
+ *
+ * @param {Object} props Block properties.
+ */
+export const useInsertLessonBlock = ( props ) => {
+	const { clientId, isSelected } = props;
+	const { insertBlock, removeBlock } = useDispatch( 'core/block-editor' );
+
+	const addBlock = useCallback(
+		( name ) =>
+			insertBlock( createBlock( name ), undefined, clientId, false ),
+		[ insertBlock, clientId ]
+	);
+
+	const lessonBlocks = useSelect( ( select ) =>
+		select( 'core/block-editor' ).getBlocks( clientId )
+	);
+
+	const hasSelected =
+		useSelect( ( select ) =>
+			select( 'core/block-editor' ).hasSelectedInnerBlock( clientId )
+		) || isSelected;
+
+	useEffect( () => {
+		const lastLessonBlock =
+			lessonBlocks.length && lessonBlocks[ lessonBlocks.length - 1 ];
+		const hasEmptyLastLessonBlock =
+			lastLessonBlock && ! lastLessonBlock.attributes.title;
+
+		if ( hasSelected && ! hasEmptyLastLessonBlock ) {
+			addBlock( 'sensei-lms/course-outline-lesson' );
+		}
+		if (
+			! hasSelected &&
+			hasEmptyLastLessonBlock &&
+			1 !== lessonBlocks.length
+		) {
+			removeBlock( lastLessonBlock.clientId, false );
+		}
+	}, [ lessonBlocks, hasSelected, addBlock, removeBlock ] );
+};

--- a/assets/blocks/course-outline/module-block/use-insert-lesson-block.js
+++ b/assets/blocks/course-outline/module-block/use-insert-lesson-block.js
@@ -34,9 +34,6 @@ export const useInsertLessonBlock = ( props ) => {
 		) || isSelected;
 
 	useEffect( () => {
-		if ( ! hasSelected ) setImplicitLessonBlockClientId( null );
-	}, [ hasSelected ] );
-	useEffect( () => {
 		const lastLessonBlock =
 			lessonBlocks.length && lessonBlocks[ lessonBlocks.length - 1 ];
 		const hasEmptyLastLessonBlock =
@@ -49,20 +46,16 @@ export const useInsertLessonBlock = ( props ) => {
 		) {
 			addBlock( 'sensei-lms/course-outline-lesson' );
 		}
-		if (
-			! hasSelected &&
-			hasEmptyLastLessonBlock &&
-			lastLessonBlock.clientId === implicitLessonBlockClientId &&
-			1 !== lessonBlocks.length
-		) {
-			removeBlock( lastLessonBlock.clientId, false );
+		if ( ! hasSelected ) {
+			if (
+				hasEmptyLastLessonBlock &&
+				lastLessonBlock.clientId === implicitLessonBlockClientId &&
+				1 !== lessonBlocks.length
+			) {
+				removeBlock( lastLessonBlock.clientId, false );
+			}
 			setImplicitLessonBlockClientId( null );
 		}
-	}, [
-		lessonBlocks,
-		hasSelected,
-		addBlock,
-		removeBlock,
-		implicitLessonBlockClientId,
-	] );
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [ hasSelected ] );
 };

--- a/assets/blocks/course-outline/module-block/use-insert-lesson-block.js
+++ b/assets/blocks/course-outline/module-block/use-insert-lesson-block.js
@@ -1,6 +1,6 @@
 import { createBlock } from '@wordpress/blocks';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useEffect } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 
 /**
  * Insert an empty lesson block to the end of the module when it's selected.
@@ -8,12 +8,19 @@ import { useCallback, useEffect } from '@wordpress/element';
  * @param {Object} props Block properties.
  */
 export const useInsertLessonBlock = ( props ) => {
+	const [
+		implicitLessonBlockClientId,
+		setImplicitLessonBlockClientId,
+	] = useState( null );
 	const { clientId, isSelected } = props;
 	const { insertBlock, removeBlock } = useDispatch( 'core/block-editor' );
 
 	const addBlock = useCallback(
-		( name ) =>
-			insertBlock( createBlock( name ), undefined, clientId, false ),
+		( name ) => {
+			const block = createBlock( name );
+			insertBlock( block, undefined, clientId, false );
+			setImplicitLessonBlockClientId( block.clientId );
+		},
 		[ insertBlock, clientId ]
 	);
 
@@ -38,9 +45,17 @@ export const useInsertLessonBlock = ( props ) => {
 		if (
 			! hasSelected &&
 			hasEmptyLastLessonBlock &&
+			lastLessonBlock.clientId === implicitLessonBlockClientId &&
 			1 !== lessonBlocks.length
 		) {
 			removeBlock( lastLessonBlock.clientId, false );
+			setImplicitLessonBlockClientId( null );
 		}
-	}, [ lessonBlocks, hasSelected, addBlock, removeBlock ] );
+	}, [
+		lessonBlocks,
+		hasSelected,
+		addBlock,
+		removeBlock,
+		implicitLessonBlockClientId,
+	] );
 };

--- a/assets/blocks/course-outline/module-block/use-insert-lesson-block.test.js
+++ b/assets/blocks/course-outline/module-block/use-insert-lesson-block.test.js
@@ -61,22 +61,18 @@ describe( 'useInsertLessonBlock', () => {
 	} );
 
 	it( 'removes inserted lesson block on blur', () => {
+		const blocks = [ { attributes: { title: 'Lesson 1' } } ];
+		insertBlock.mockImplementation( ( block ) => blocks.push( block ) );
 		mockSelect( {
 			hasSelectedInnerBlock: () => false,
-			getBlocks: () => [ { attributes: { title: 'Lesson 1' } } ],
+			getBlocks: () => blocks,
 		} );
 		const { rerender } = render( <ModuleBlock isSelected={ true } /> );
 
 		expect( insertBlock ).toHaveBeenCalledTimes( 1 );
-		mockSelect( {
-			hasSelectedInnerBlock: () => false,
-			getBlocks: () => [
-				{ attributes: { title: 'Lesson 1' } },
-				{ attributes: { title: '' }, clientId: 'new-lesson' },
-			],
-		} );
+
 		rerender( <ModuleBlock isSelected={ false } /> );
 
-		expect( removeBlock ).toHaveBeenCalledWith( 'new-lesson', false );
+		expect( removeBlock ).toHaveBeenCalledTimes( 1 );
 	} );
 } );

--- a/assets/blocks/course-outline/module-block/use-insert-lesson-block.test.js
+++ b/assets/blocks/course-outline/module-block/use-insert-lesson-block.test.js
@@ -1,0 +1,82 @@
+import { render } from '@testing-library/react';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { registerTestLessonBlock } from '../test-helpers';
+import { useInsertLessonBlock } from './use-insert-lesson-block';
+
+registerTestLessonBlock();
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: jest.fn(),
+	useSelect: jest.fn(),
+} ) );
+
+describe( 'useInsertLessonBlock', () => {
+	const ModuleBlock = ( props ) => {
+		useInsertLessonBlock( props );
+
+		return <div>Module</div>;
+	};
+
+	const removeBlock = jest.fn();
+	const insertBlock = jest.fn();
+
+	const mockSelect = ( value ) =>
+		useSelect.mockImplementation( ( fn ) => fn( () => value ) );
+
+	useDispatch.mockImplementation( () => ( {
+		insertBlock,
+		removeBlock,
+	} ) );
+
+	beforeEach( () => {
+		removeBlock.mockClear();
+		insertBlock.mockClear();
+		mockSelect( {
+			hasSelectedInnerBlock: () => false,
+			getBlocks: () => [],
+		} );
+	} );
+
+	it( 'does not insert lesson block when not selected', () => {
+		render( <ModuleBlock isSelected={ false } /> );
+
+		expect( insertBlock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'inserts a lesson block when selected', () => {
+		render( <ModuleBlock isSelected={ true } /> );
+
+		expect( insertBlock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'inserts a lesson block when inner block selected', () => {
+		mockSelect( {
+			hasSelectedInnerBlock: () => true,
+			getBlocks: () => [ { attributes: { title: 'Lesson 1' } } ],
+		} );
+
+		render( <ModuleBlock isSelected={ false } /> );
+
+		expect( insertBlock ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'removes inserted lesson block on blur', () => {
+		mockSelect( {
+			hasSelectedInnerBlock: () => false,
+			getBlocks: () => [ { attributes: { title: 'Lesson 1' } } ],
+		} );
+		const { rerender } = render( <ModuleBlock isSelected={ true } /> );
+
+		expect( insertBlock ).toHaveBeenCalledTimes( 1 );
+		mockSelect( {
+			hasSelectedInnerBlock: () => false,
+			getBlocks: () => [
+				{ attributes: { title: 'Lesson 1' } },
+				{ attributes: { title: '' }, clientId: 'new-lesson' },
+			],
+		} );
+		rerender( <ModuleBlock isSelected={ false } /> );
+
+		expect( removeBlock ).toHaveBeenCalledWith( 'new-lesson', false );
+	} );
+} );


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Hide the inserter in the module block
* Append a new lesson block when the module is selected and there is no empty lesson block at the end
  * This means it also creates a new empty block once the user start filling in the title of the current one
  * This block is removed when the module is not selected, unless it's the only lesson block
* Also update Enter key behavior for the lesson block: it now inserts a new lesson even between lessons. This is more consistent with the default block behavior and also makes it easier to add lessons between existing ones.
  * Enter does not insert block if there is already an empty lesson block after it, just jumps to that one 

### Testing instructions

* Add a module to a course outline
* Check that it has an empty lesson block
* Add lessons
* Check that there is always an empty lesson block at the end when the module is selected
--
* Press enter in an existing lesson block
* Check that a new lesson block is inserted after it 


<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![QuickTime movie](https://user-images.githubusercontent.com/176949/95236286-049b1e00-0807-11eb-9c0d-c8d1ce6d9b0f.gif)

#### Pressing enter in lesson blocks:

![QuickTime movie](https://user-images.githubusercontent.com/176949/95236751-a02c8e80-0807-11eb-871e-70072eeaf98a.gif)

