### PR TITLE
[Research] Extending button block

### DIFF
--- a/assets/blocks/button.core.js
+++ b/assets/blocks/button.core.js
@@ -14,11 +14,11 @@ function getButtonDef( settings ) {
 }
 
 function registerButton( settings ) {
-	registerBlockType( 'sensei-lms/button', {
+	registerBlockType( 'sensei-lms/button-core', {
 		...settings,
 		//...metadata,
-		name: 'sensei-lms/button',
-		title: 'Take Course',
+		name: 'sensei-lms/button-core',
+		title: 'Take Course Core',
 		parent: null,
 		attributes: {
 			...settings.attributes,

--- a/assets/blocks/button.js
+++ b/assets/blocks/button.js
@@ -3,13 +3,10 @@ import { addFilter } from '@wordpress/hooks';
 
 addFilter( 'blocks.registerBlockType', 'sensei-lms/button', getButtonDef );
 
-// import {
-// 	settings,
-// 	metadata,
-// } from '../../../node_modules/@wordpress/block-library/src/button';
-
+let registered = false;
 function getButtonDef( settings ) {
-	if ( settings.name === 'core/button' ) {
+	if ( settings.name === 'core/button' && ! registered ) {
+		registered = true;
 		registerButton( settings );
 	}
 
@@ -23,14 +20,20 @@ function registerButton( settings ) {
 		name: 'sensei-lms/button',
 		title: 'Take Course',
 		parent: null,
+		attributes: {
+			...settings.attributes,
+			text: {
+				...settings.attributes.text,
+				default: 'Take Course',
+			},
+		},
 		edit( props ) {
 			const ButtonEdit = settings.edit;
-
-			const r = <ButtonEdit { ...props } />;
-			const children = r.props.children.filter(
-				( c ) => c.type.name !== 'URLPicker'
+			return (
+				<>
+					<ButtonEdit { ...props } />
+				</>
 			);
-			return <>{ children }</>;
 		},
 	} );
 }

--- a/assets/blocks/button.js
+++ b/assets/blocks/button.js
@@ -1,0 +1,36 @@
+import { registerBlockType } from '@wordpress/blocks';
+import { addFilter } from '@wordpress/hooks';
+
+addFilter( 'blocks.registerBlockType', 'sensei-lms/button', getButtonDef );
+
+// import {
+// 	settings,
+// 	metadata,
+// } from '../../../node_modules/@wordpress/block-library/src/button';
+
+function getButtonDef( settings ) {
+	if ( settings.name === 'core/button' ) {
+		registerButton( settings );
+	}
+
+	return settings;
+}
+
+function registerButton( settings ) {
+	registerBlockType( 'sensei-lms/button', {
+		...settings,
+		//...metadata,
+		name: 'sensei-lms/button',
+		title: 'Take Course',
+		parent: null,
+		edit( props ) {
+			const ButtonEdit = settings.edit;
+
+			const r = <ButtonEdit { ...props } />;
+			const children = r.props.children.filter(
+				( c ) => c.type.name !== 'URLPicker'
+			);
+			return <>{ children }</>;
+		},
+	} );
+}

--- a/assets/blocks/button.own.js
+++ b/assets/blocks/button.own.js
@@ -1,0 +1,149 @@
+import {
+	RichText,
+	InspectorControls,
+	BlockControls,
+	AlignmentToolbar,
+} from '@wordpress/block-editor';
+import { registerBlockType } from '@wordpress/blocks';
+import { PanelBody, RangeControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import classnames from 'classnames';
+import { useCallback } from '@wordpress/element';
+
+const MIN_BORDER_RADIUS_VALUE = 0;
+const MAX_BORDER_RADIUS_VALUE = 50;
+const INITIAL_BORDER_RADIUS_POSITION = 5;
+
+function BorderPanel( { borderRadius = '', setAttributes } ) {
+	const initialBorderRadius = borderRadius;
+	const setBorderRadius = useCallback(
+		( newBorderRadius ) => {
+			if ( newBorderRadius === undefined )
+				setAttributes( {
+					borderRadius: initialBorderRadius,
+				} );
+			else setAttributes( { borderRadius: newBorderRadius } );
+		},
+		[ initialBorderRadius, setAttributes ]
+	);
+	return (
+		<PanelBody title={ __( 'Border settings', 'sensei-lms' ) }>
+			<RangeControl
+				value={ borderRadius }
+				label={ __( 'Border radius', 'sensei-lms' ) }
+				min={ MIN_BORDER_RADIUS_VALUE }
+				max={ MAX_BORDER_RADIUS_VALUE }
+				initialPosition={ INITIAL_BORDER_RADIUS_POSITION }
+				allowReset
+				onChange={ setBorderRadius }
+			/>
+		</PanelBody>
+	);
+}
+
+const EditButton = ( props ) => {
+	const { attributes, setAttributes, className, colorProps } = props;
+	const { borderRadius, placeholder, text, align } = attributes;
+	return (
+		<div
+			className={ classnames( className, {
+				[ `has-text-align-${ align }` ]: align,
+			} ) }
+		>
+			<RichText
+				placeholder={ placeholder || __( 'Add text…', 'sensei-lms' ) }
+				value={ text }
+				onChange={ ( value ) => setAttributes( { text: value } ) }
+				withoutInteractiveFormatting
+				className={ classnames(
+					'wp-block-button__link',
+					colorProps?.className,
+					{
+						'no-border-radius': borderRadius === 0,
+					}
+				) }
+				style={ {
+					borderRadius: borderRadius
+						? borderRadius + 'px'
+						: undefined,
+					...colorProps?.style,
+				} }
+				identifier="text"
+			/>
+			<BlockControls>
+				<AlignmentToolbar
+					value={ align }
+					onChange={ ( nextAlign ) => {
+						setAttributes( { align: nextAlign } );
+					} }
+				/>
+			</BlockControls>
+
+			<InspectorControls>
+				<BorderPanel
+					borderRadius={ borderRadius }
+					setAttributes={ setAttributes }
+				/>
+			</InspectorControls>
+		</div>
+	);
+};
+
+const edit = EditButton;
+
+registerBlockType( 'sensei-lms/button-own', {
+	name: 'sensei-lms/button-own',
+	title: 'Take Course Own',
+	category: 'sensei-lms',
+	attributes: {
+		text: {
+			type: 'string',
+			source: 'html',
+			selector: 'a',
+			default: 'Take Course',
+		},
+		align: {
+			type: 'string',
+		},
+		borderRadius: {
+			type: 'number',
+		},
+		style: {
+			type: 'object',
+		},
+	},
+	supports: {
+		align: false,
+		html: false,
+	},
+	edit,
+	save( { attributes } ) {
+		const { borderRadius, linkTarget, rel, text, title, url } = attributes;
+		//const colorProps = getColorAndStyleProps( attributes );
+		const buttonClasses = classnames(
+			'wp-block-button__link',
+			//colorProps.className,
+			{
+				'no-border-radius': borderRadius === 0,
+			}
+		);
+		const buttonStyle = {
+			borderRadius: borderRadius ? borderRadius + 'px' : undefined,
+			//...colorProps.style,
+		};
+		return (
+			<div className="wp-block-button">
+				<RichText.Content
+					tagName="a"
+					className={ buttonClasses }
+					href={ url }
+					title={ title }
+					style={ buttonStyle }
+					value={ text }
+					target={ linkTarget }
+					rel={ rel }
+				/>
+			</div>
+		);
+	},
+} );

--- a/assets/blocks/button.scss
+++ b/assets/blocks/button.scss
@@ -1,5 +1,5 @@
 
-.wp-block-sensei-lms-button {
+.wp-block-sensei-lms-button-core {
 	.wp-block-button__link {
 		display: block;
 	}

--- a/assets/blocks/button.scss
+++ b/assets/blocks/button.scss
@@ -8,3 +8,14 @@
 		display: none!important;
 	}
 }
+
+.wp-block-sensei-lms-button-own {
+	.wp-block-button__link {
+		display: block;
+	}
+	&.has-text-align-center, &.has-text-align-left, &.has-text-align-right {
+		.wp-block-button__link {
+			display: inline-block;
+		}
+	}
+}

--- a/assets/blocks/button.scss
+++ b/assets/blocks/button.scss
@@ -1,0 +1,10 @@
+
+.wp-block-sensei-lms-button {
+	.wp-block-button__link {
+		display: block;
+	}
+
+	.wp-block-button__inline-link {
+		display: none!important;
+	}
+}

--- a/assets/blocks/course-outline/index.js
+++ b/assets/blocks/course-outline/index.js
@@ -4,6 +4,7 @@ import './module-block';
 import './lesson-block';
 import './store';
 import '../button.core';
+import '../button.own';
 
 [ CourseOutlineBlock ].forEach( ( block ) => {
 	const { name, ...settings } = block;

--- a/assets/blocks/course-outline/index.js
+++ b/assets/blocks/course-outline/index.js
@@ -3,6 +3,7 @@ import CourseOutlineBlock from './course-block';
 import './module-block';
 import './lesson-block';
 import './store';
+import '../button';
 
 [ CourseOutlineBlock ].forEach( ( block ) => {
 	const { name, ...settings } = block;

--- a/assets/blocks/course-outline/index.js
+++ b/assets/blocks/course-outline/index.js
@@ -3,7 +3,7 @@ import CourseOutlineBlock from './course-block';
 import './module-block';
 import './lesson-block';
 import './store';
-import '../button';
+import '../button.core';
 
 [ CourseOutlineBlock ].forEach( ( block ) => {
 	const { name, ...settings } = block;

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -3,6 +3,9 @@ $dark-gray: #1a1d20;
 $outline: '.wp-block-sensei-lms-course-outline';
 $spacing: 16px;
 
+
+@import '../button.scss';
+
 .wp-block-sensei-lms-course-outline {
 
 	margin: 1em 0;


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Hook into block registration, copy and modify the button block definition, and register it as a Take course (core) block.
* Add a button from scratch as Take course (own)

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="629" alt="image" src="https://user-images.githubusercontent.com/176949/95324021-61e2ae00-089f-11eb-831d-0410db665b45.png">

