### PR TITLE
Fix lesson link style

### DIFF
--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -53,11 +53,12 @@ $dark-gray: #1a1d20;
 
 		&__post-status {
 			position: absolute;
-			bottom: 0;
+			bottom: 4px;
 			left: 56px;
 			font-size: 12px;
 			font-weight: 600;
-			color: #999;
+			color: inherit;
+			opacity: 0.5;
 			border-radius: 6px;
 		}
 	}

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -154,15 +154,25 @@ $spacing: 16px;
 	align-items: center;
 	margin: 1px 0;
 	position: relative;
-	font-size: 1em;
-	color: inherit;
-	font-family: inherit;
-	line-height: inherit;
-	text-decoration: inherit;
-	border: none;
-	font-weight: normal;
-	&:hover {
-		color: inherit;
+
+
+	.entry-content & {
+		font-size: 1em;
+
+		font-family: inherit;
+		line-height: inherit;
+		text-decoration: inherit;
+		border: none;
+		font-weight: normal;
+		margin: 0;
+
+		&:not(.has-color) {
+			color: inherit;
+
+			&:hover {
+				color: inherit;
+			}
+		}
 	}
 
 	> span {
@@ -177,9 +187,6 @@ $spacing: 16px;
 		margin: 0 16px;
 	}
 
-	.entry-content & {
-		margin: 0;
-	}
 
 	.entry-content &,
 	.editor-styles-wrapper & {

--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -156,7 +156,7 @@ $spacing: 16px;
 	position: relative;
 
 
-	.entry-content & {
+	&, .entry-content &, .entry .entry-content & {
 		font-size: 1em;
 
 		font-family: inherit;


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Fixes lesson blocks picking up the link style on the frontend — a regression after adjusting the HTML to make the whole block a clickable link
* Also tune the post status (`Draft`,`Unsaved`) label in the editor to use the text color with reduced opacity, so it's visible on dark backgrounds

### Testing instructions

* Open a course with lessons on the frontend
* Lesson titles should not have link styles (colors, underline)
--
* Add new lessons to an outline in the editor, set their colors to white text on dark background
* Unsaved/draft label should be visible

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
<img width="634" alt="image" src="https://user-images.githubusercontent.com/176949/95392460-178e1b00-08f9-11eb-9fc9-e468abe3c37a.png">

