### PR TITLE
Allow line wrapping for module, lesson titles 

### DIFF
--- a/assets/blocks/course-outline/lesson-block/edit.test.js
+++ b/assets/blocks/course-outline/lesson-block/edit.test.js
@@ -3,7 +3,6 @@ import { EditLessonBlock } from './edit';
 import { useDispatch } from '@wordpress/data';
 import { createBlock } from '@wordpress/blocks';
 
-jest.mock( '@wordpress/block-editor' );
 jest.mock( '@wordpress/data' );
 
 jest.mock( '@wordpress/blocks' );

--- a/assets/blocks/course-outline/single-line-input/index.js
+++ b/assets/blocks/course-outline/single-line-input/index.js
@@ -1,34 +1,34 @@
-import classnames from 'classnames';
+import { PlainText } from '@wordpress/block-editor';
+import { ENTER } from '@wordpress/keycodes';
 
 /**
  * Single line input component.
  *
  * @param {Object}   props           Component props.
- * @param {string}   props.className Additional classname for the input.
  * @param {Function} props.onChange  Change callback.
+ * @param {Function} props.onKeyDown Keydown callback.
  */
-const SingleLineInput = ( { className, onChange, ...props } ) => {
-	const classes = classnames(
-		className,
-		'wp-block-sensei-lms-course-outline__clean-input'
-	);
-
+const SingleLineInput = ( { onChange, onKeyDown, ...props } ) => {
 	/**
 	 * Handle change.
 	 *
-	 * @param {Object} event              Input change event object.
-	 * @param {Object} event.target       Change target object.
-	 * @param {string} event.target.value Change value.
+	 * @param {string} value Change value.
 	 */
-	const handleChange = ( { target: { value } } ) => {
-		onChange( value );
+	const handleChange = ( value ) => {
+		onChange( value.replace( /\n/g, '' ) );
+	};
+
+	const handleKeyDown = ( e ) => {
+		if ( onKeyDown ) onKeyDown( e );
+		if ( ENTER === e.keyCode ) {
+			e.preventDefault();
+		}
 	};
 
 	return (
-		<input
-			type="text"
-			className={ classes }
+		<PlainText
 			onChange={ handleChange }
+			onKeyDown={ handleKeyDown }
 			{ ...props }
 		/>
 	);

--- a/assets/blocks/course-outline/single-line-input/index.test.js
+++ b/assets/blocks/course-outline/single-line-input/index.test.js
@@ -1,38 +1,45 @@
 import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import SingleLineInput from './index';
 
 describe( '<SingleLineInput />', () => {
 	it( 'Should render the single line input correctly', () => {
-		const { container } = render(
+		const { getByRole } = render(
 			<SingleLineInput
 				className="custom-class"
 				placeholder="extra props"
 			/>
 		);
 
-		const input = container.querySelector( 'input' );
+		const input = getByRole( 'textbox' );
 
 		expect( input ).toBeTruthy();
 		expect( input.classList.contains( 'custom-class' ) ).toBeTruthy();
-		expect(
-			input.classList.contains(
-				'wp-block-sensei-lms-course-outline__clean-input'
-			)
-		).toBeTruthy();
 		expect( input.getAttribute( 'placeholder' ) ).toEqual( 'extra props' );
 	} );
 
 	it( 'Should call the onChange', () => {
 		const onChangeMock = jest.fn();
-		const { container } = render(
+		const { getByRole } = render(
 			<SingleLineInput onChange={ onChangeMock } />
 		);
 
-		fireEvent.change( container.firstChild, {
+		fireEvent.change( getByRole( 'textbox' ), {
 			target: { value: 'changed' },
 		} );
 
 		expect( onChangeMock ).toBeCalledWith( 'changed' );
+	} );
+
+	it( 'Should not allow line breaks', () => {
+		const onChangeMock = jest.fn();
+		const { getByRole } = render(
+			<SingleLineInput onChange={ onChangeMock } />
+		);
+
+		userEvent.type( getByRole( 'textbox' ), ' input {enter}line' );
+
+		expect( onChangeMock ).toHaveBeenLastCalledWith( 'input line ' );
 	} );
 } );

--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -1,26 +1,6 @@
 $dark-gray: #1a1d20;
 .block-editor {
 	.wp-block-sensei-lms-course-outline {
-		&__clean-input[type='text'] {
-			display: block;
-			width: 100%;
-			padding: 0;
-			margin: 0;
-			box-shadow: none;
-			font-family: inherit;
-			font-size: inherit;
-			color: inherit;
-			line-height: inherit;
-			border: none;
-			background-color: transparent;
-
-			&:focus {
-				border: none;
-				outline: none;
-				box-shadow: none;
-				color: inherit;
-			}
-		}
 
 		.block-editor-block-list__block {
 			margin-top: 0;
@@ -43,12 +23,17 @@ $dark-gray: #1a1d20;
 				border-bottom: 4px solid $dark-gray;
 			}
 		}
+
+		&__title-input {
+			background: none;
+		}
 	}
 
 	.wp-block-sensei-lms-course-outline-lesson {
 
-		&__input[type='text'] {
+		&__input {
 			margin: 20px 16px;
+			background: none;
 		}
 
 		&__post-status {


### PR DESCRIPTION
Fixes #3690

### Changes proposed in this Pull Request

* Update SingleLineInput to use PlainText component, which has an auto-sizing textarea underneath
* Add some extra handlers to prevent inserting line breaks

### Testing instructions

* Add a module or lesson block to the outline, type a lot of text
* Paste text with line breaks
* Press enter
* In all cases the content should not have line breaks
* The input field should grow to multiple lines if it has long content

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="646" alt="image" src="https://user-images.githubusercontent.com/176949/95474127-0f7bbd00-0985-11eb-969f-89b66ae751e1.png">

