### PR TITLE
Only run E2E tests on release branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ language: php
 
 # Shared code for e2e jobs.
 e2e_defaults: &e2e_defaults
+  if: branch =~ /^release\//
   language: node_js
   node_js: '10.17'
   script:
@@ -47,12 +48,6 @@ before_script:
   fi
 jobs:
   include:
-    # There are no JS blocks to test yet. Uncomment below when we start adding
-    # blocks.
-    #- stage: test
-    #  script:
-    #    - npm install || exit 1
-    #    - npm run test-js || exit 1
     - stage: test
       php: 7.4
       env: WP_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: php
 
 # Shared code for e2e jobs.
 e2e_defaults: &e2e_defaults
-  if: branch =~ /^release\//
+  if: branch =~ /^release\// OR head_branch =~ /^release\//
   language: node_js
   node_js: '10.17'
   script:


### PR DESCRIPTION

Disable running E2E tests for development PRs as they don't do anything relevant for now, but have some timeout issues.

### Changes proposed in this Pull Request

* Only run E2E tests on Travis if the PR branch or the base branch is `release/*`

