### PR TITLE
Translate block ids during importing

### DIFF
--- a/includes/data-port/class-sensei-data-port-utilities.php
+++ b/includes/data-port/class-sensei-data-port-utilities.php
@@ -504,4 +504,35 @@ class Sensei_Data_Port_Utilities {
 		return 'id:' . implode( ',id:', (array) $ids );
 	}
 
+	/**
+	 * Helper method which gets a module by name and checks if the module can be applied to a course's lesson.
+	 *
+	 * @param string $module_name  The module name.
+	 * @param int    $course_id    Course ID.
+	 *
+	 * @return WP_Error|WP_Term  WP_Error when the module can't be applied to the lesson, WP_Term otherwise.
+	 */
+	public static function get_module_for_course( $module_name, $course_id ) {
+		$module = get_term_by( 'name', $module_name, 'module' );
+
+		if ( ! $module ) {
+			return new WP_Error(
+				'sensei_data_port_module_not_found',
+				// translators: Placeholder is the term which errored.
+				sprintf( __( 'Module does not exist: %s.', 'sensei-lms' ), $module_name )
+			);
+		}
+
+		$course_modules = wp_list_pluck( wp_get_post_terms( $course_id, 'module' ), 'term_id' );
+
+		if ( ! in_array( $module->term_id, $course_modules, true ) ) {
+			return new WP_Error(
+				'sensei_data_port_module_not_part_of_course',
+				// translators: First placeholder is the term which errored, second is the course id.
+				sprintf( __( 'Module %1$s is not part of course %2$s.', 'sensei-lms' ), $module_name, $course_id )
+			);
+		}
+
+		return $module;
+	}
 }

--- a/includes/data-port/class-sensei-import-block-migrator.php
+++ b/includes/data-port/class-sensei-import-block-migrator.php
@@ -87,8 +87,20 @@ class Sensei_Import_Block_Migrator {
 			return $outline_block;
 		}
 
+		// Inner blocks are represented as an entry to the 'innerBlocks' array and a null value in the 'innerContent' array.
+		$inner_block_index   = 0;
 		$mapped_inner_blocks = [];
-		foreach ( $outline_block['innerBlocks'] as $inner_block ) {
+		$inner_content       = [];
+
+		foreach ( $outline_block['innerContent'] as $chunk ) {
+			// If the content is not an inner block there is nothing to do.
+			if ( is_string( $chunk ) ) {
+				$inner_content[] = $chunk;
+				continue;
+			}
+
+			$inner_block = $outline_block['innerBlocks'][ $inner_block_index ];
+			// If the inner block is a Sensei one, map it.
 			if ( 'sensei-lms/course-outline-module' === $inner_block['blockName'] ) {
 				$mapped_block = $this->map_module_block_id( $inner_block );
 			} elseif ( 'sensei-lms/course-outline-lesson' === $inner_block['blockName'] ) {
@@ -97,12 +109,17 @@ class Sensei_Import_Block_Migrator {
 				$mapped_block = $inner_block;
 			}
 
+			// Add the entries in 'innerBlocks' and 'innerContent' arrays only if it was successfully mapped.
 			if ( false !== $mapped_block ) {
 				$mapped_inner_blocks[] = $mapped_block;
+				$inner_content[]       = $chunk;
 			}
+
+			$inner_block_index++;
 		}
 
-		$outline_block['innerBlocks'] = $mapped_inner_blocks;
+		$outline_block['innerBlocks']  = $mapped_inner_blocks;
+		$outline_block['innerContent'] = $inner_content;
 
 		return $outline_block;
 	}

--- a/includes/data-port/class-sensei-import-block-migrator.php
+++ b/includes/data-port/class-sensei-import-block-migrator.php
@@ -61,18 +61,34 @@ class Sensei_Import_Block_Migrator {
 		}
 
 		$blocks = parse_blocks( $post_content );
+		$blocks = $this->map_blocks( $blocks );
 
+		return serialize_blocks( $blocks );
+	}
+
+	/**
+	 * Goes through each block and its inner blocks, searches for the outline block and maps it.
+	 *
+	 * @param array $blocks The blocks.
+	 *
+	 * @return array The mapped blocks.
+	 */
+	private function map_blocks( $blocks ) {
 		$i = 0;
 		foreach ( $blocks as $block ) {
 			if ( 'sensei-lms/course-outline' === $block['blockName'] ) {
-				$mapped_block = $this->map_outline_block_ids( $block );
+				$blocks[ $i ] = $this->map_outline_block_ids( $block );
 				break;
 			}
+
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$blocks[ $i ]['innerBlocks'] = $this->map_blocks( $block['innerBlocks'] );
+			}
+
 			$i++;
 		}
-		$blocks[ $i ] = $mapped_block;
 
-		return serialize_blocks( $blocks );
+		return $blocks;
 	}
 
 	/**

--- a/includes/data-port/class-sensei-import-block-migrator.php
+++ b/includes/data-port/class-sensei-import-block-migrator.php
@@ -1,0 +1,189 @@
+<?php
+/**
+ * File containing the Sensei_Import_Course_Content_Migrator class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * This class is responsible for migrating post content which contains Sensei blocks.
+ */
+class Sensei_Import_Block_Migrator {
+
+	/**
+	 * The course id.
+	 *
+	 * @var int
+	 */
+	private $course_id;
+
+	/**
+	 * The data port task.
+	 *
+	 * @var Sensei_Data_Port_Task
+	 */
+	private $task;
+
+	/**
+	 * The course import model.
+	 *
+	 * @var Sensei_Import_Model
+	 */
+	private $import_model;
+
+	/**
+	 * Sensei_Import_Course_Content_Migrator constructor.
+	 *
+	 * @param int                   $course_id    The course which gets migrated.
+	 * @param Sensei_Data_Port_Task $task         The data port task which this migration is part of.
+	 * @param Sensei_Import_Model   $import_model The import model.
+	 */
+	public function __construct( int $course_id, Sensei_Data_Port_Task $task, Sensei_Import_Model $import_model ) {
+		$this->course_id    = $course_id;
+		$this->task         = $task;
+		$this->import_model = $import_model;
+	}
+
+	/**
+	 * Migrates the imported post content to use the ids of the newly created lessons and modules.
+	 *
+	 * @param string $post_content The post content.
+	 *
+	 * @return string The migrated post content.
+	 */
+	public function migrate( string $post_content ) : string {
+		if ( ! has_block( 'sensei-lms/course-outline', $post_content ) ) {
+			return $post_content;
+		}
+
+		$blocks = parse_blocks( $post_content );
+
+		$i = 0;
+		foreach ( $blocks as $block ) {
+			if ( 'sensei-lms/course-outline' === $block['blockName'] ) {
+				$mapped_block = $this->map_outline_block_ids( $block );
+				break;
+			}
+			$i++;
+		}
+		$blocks[ $i ] = $mapped_block;
+
+		return serialize_blocks( $blocks );
+	}
+
+	/**
+	 * Maps the ids of an outlined block to use the newly created values.
+	 *
+	 * @param array $outline_block The outline block.
+	 *
+	 * @return array The mapped block.
+	 */
+	private function map_outline_block_ids( array $outline_block ) : array {
+		if ( empty( $outline_block['innerBlocks'] ) ) {
+			return $outline_block;
+		}
+
+		$mapped_inner_blocks = [];
+		foreach ( $outline_block['innerBlocks'] as $inner_block ) {
+			if ( 'sensei-lms/course-outline-module' === $inner_block['blockName'] ) {
+				$mapped_block = $this->map_module_block_id( $inner_block );
+			} elseif ( 'sensei-lms/course-outline-lesson' === $inner_block['blockName'] ) {
+				$mapped_block = $this->map_lesson_block_id( $inner_block );
+			} else {
+				$mapped_block = $inner_block;
+			}
+
+			if ( false !== $mapped_block ) {
+				$mapped_inner_blocks[] = $mapped_block;
+			}
+		}
+
+		$outline_block['innerBlocks'] = $mapped_inner_blocks;
+
+		return $outline_block;
+	}
+
+	/**
+	 * Map the ids of a lesson block.
+	 *
+	 * @param array $lesson_block The lesson block.
+	 *
+	 * @return bool|array The lesson block or false if the id couldn't be mapped.
+	 */
+	private function map_lesson_block_id( array $lesson_block ) {
+		if ( empty( $lesson_block['attrs']['id'] ) ) {
+			return false;
+		}
+
+		// We first check for the lesson id to be a lesson which was imported during the import process. If that fails
+		// we check if the lesson already exists in the database. This could happen in case of a course update.
+		$lesson_id = $this->task->get_job()->translate_import_id( Sensei_Data_Port_Lesson_Schema::POST_TYPE, 'id:' . $lesson_block['attrs']['id'] );
+
+		if ( null === $lesson_id && null === $this->task->get_job()->translate_import_id( Sensei_Data_Port_Lesson_Schema::POST_TYPE, $lesson_block['attrs']['id'] ) ) {
+			$this->import_model->add_line_warning(
+				// translators: The %s is the lesson id.
+				sprintf( __( 'Lesson with id %s which is referenced in course outline block not found.', 'sensei-lms' ), $lesson_block['attrs']['id'] ),
+				[
+					'code' => 'sensei_data_port_course_lesson_not_found',
+				]
+			);
+
+			return false;
+		}
+
+		$lesson_block['attrs']['id'] = $lesson_id;
+
+		return $lesson_block;
+	}
+
+	/**
+	 * Map the ids of a module block.
+	 *
+	 * @param array $module_block The module block.
+	 *
+	 * @return bool|array The mapped module block or false if the block couldn't be mapped.
+	 */
+	private function map_module_block_id( array $module_block ) {
+		if ( empty( $module_block['attrs']['title'] ) ) {
+			$this->import_model->add_line_warning(
+				__( 'No title for module found.', 'sensei-lms' ),
+				[
+					'code' => 'sensei_data_port_module_title_not_found',
+				]
+			);
+
+			return false;
+		}
+
+		$term = Sensei_Data_Port_Utilities::get_module_for_course( $module_block['attrs']['title'], $this->course_id );
+
+		if ( is_wp_error( $term ) ) {
+			$this->import_model->add_line_warning( $term->get_error_message(), [ 'code' => $term->get_error_code() ] );
+
+			return false;
+		}
+
+		$module_inner_blocks = [];
+
+		foreach ( $module_block['innerBlocks'] as $inner_block ) {
+			if ( 'sensei-lms/course-outline-lesson' === $inner_block['blockName'] ) {
+				$mapped_lesson_block = $this->map_lesson_block_id( $inner_block );
+
+				if ( false !== $mapped_lesson_block ) {
+					$module_inner_blocks[] = $mapped_lesson_block;
+				}
+			} else {
+				$module_inner_blocks[] = $inner_block;
+			}
+		}
+
+		$module_block['attrs']['id'] = $term->term_id;
+		$module_block['innerBlocks'] = $module_inner_blocks;
+
+		return $module_block;
+	}
+}

--- a/includes/data-port/class-sensei-import-block-migrator.php
+++ b/includes/data-port/class-sensei-import-block-migrator.php
@@ -191,7 +191,7 @@ class Sensei_Import_Block_Migrator {
 	 *
 	 * @param array    $block The block to map its inner blocks.
 	 * @param callable $map   The mapping function to apply to the inner blocks. It accepts a block as an argument and
-	 *                        should return the mapped block or false if the block shouldn't be mapped.
+	 *                        should return the mapped block or false if the block shouldn't be included in the mapped block.
 	 *
 	 * @return array The mapped block.
 	 */

--- a/includes/data-port/import-tasks/class-sensei-import-associations.php
+++ b/includes/data-port/import-tasks/class-sensei-import-associations.php
@@ -284,7 +284,7 @@ class Sensei_Import_Associations
 			return false;
 		}
 
-		$term = $this->get_module_for_course( $module_ref, $course_id );
+		$term = Sensei_Data_Port_Utilities::get_module_for_course( $module_ref, $course_id );
 		if ( is_wp_error( $term ) ) {
 			$add_warning_helper( $term->get_error_message(), $term->get_error_code() );
 
@@ -299,38 +299,6 @@ class Sensei_Import_Associations
 		}
 
 		return $term->term_id;
-	}
-
-	/**
-	 * Helper method which gets a module by name and checks if the module can be applied to the lesson.
-	 *
-	 * @param string $module_name  The module name.
-	 * @param int    $course_id    Course ID.
-	 *
-	 * @return WP_Error|WP_Term  WP_Error when the module can't be applied to the lesson, WP_Term otherwise.
-	 */
-	private function get_module_for_course( $module_name, $course_id ) {
-		$module = get_term_by( 'name', $module_name, 'module' );
-
-		if ( ! $module ) {
-			return new WP_Error(
-				'sensei_data_port_module_not_found',
-				// translators: Placeholder is the term which errored.
-				sprintf( __( 'Module does not exist: %s.', 'sensei-lms' ), $module_name )
-			);
-		}
-
-		$course_modules = wp_list_pluck( wp_get_post_terms( $course_id, 'module' ), 'term_id' );
-
-		if ( ! in_array( $module->term_id, $course_modules, true ) ) {
-			return new WP_Error(
-				'sensei_data_port_module_not_part_of_course',
-				// translators: First placeholder is the term which errored, second is the course id.
-				sprintf( __( 'Module %1$s is not part of course %2$s.', 'sensei-lms' ), $module_name, $course_id )
-			);
-		}
-
-		return $module;
 	}
 
 	/**

--- a/includes/data-port/models/class-sensei-import-course-model.php
+++ b/includes/data-port/models/class-sensei-import-course-model.php
@@ -359,6 +359,8 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 			return false;
 		}
 
+		// We first check for the lesson id to be a lesson which was imported during the import process. If that fails
+		// we check if the lesson already exists in the database. This could happen in case of a course update.
 		$lesson_id = $this->task->get_job()->translate_import_id( Sensei_Data_Port_Lesson_Schema::POST_TYPE, 'id:' . $lesson_block['attrs']['id'] );
 		if ( null === $lesson_id && null === $this->task->get_job()->translate_import_id( Sensei_Data_Port_Lesson_Schema::POST_TYPE, $lesson_block['attrs']['id'] ) ) {
 			$this->add_line_warning(

--- a/includes/data-port/models/class-sensei-import-course-model.php
+++ b/includes/data-port/models/class-sensei-import-course-model.php
@@ -113,8 +113,6 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 		// We need to set the post content after modules have been created in order to map module ids properly.
 		$value = $this->get_value( Sensei_Data_Port_Course_Schema::COLUMN_DESCRIPTION );
 		if ( null !== $value ) {
-			$args['post_content'] =
-
 			wp_update_post(
 				[
 					'ID'           => $post_id,

--- a/includes/data-port/models/class-sensei-import-course-model.php
+++ b/includes/data-port/models/class-sensei-import-course-model.php
@@ -116,7 +116,7 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 			wp_update_post(
 				[
 					'ID'           => $post_id,
-					'post_content' => $this->migrate_post_contnet( $value ),
+					'post_content' => $this->migrate_post_content( $value ),
 				]
 			);
 		}
@@ -293,7 +293,7 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 	 *
 	 * @return string The migrated post content.
 	 */
-	private function migrate_post_contnet( $post_content ) {
+	private function migrate_post_content( $post_content ) {
 		if ( ! has_block( 'sensei-lms/course-outline', $post_content ) ) {
 			return $post_content;
 		}

--- a/includes/data-port/models/class-sensei-import-course-model.php
+++ b/includes/data-port/models/class-sensei-import-course-model.php
@@ -110,6 +110,19 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 		$this->set_course_terms( Sensei_Data_Port_Course_Schema::COLUMN_MODULES, 'module', $teacher );
 		$this->set_course_terms( Sensei_Data_Port_Course_Schema::COLUMN_CATEGORIES, 'course-category' );
 
+		// We need to set the post content after modules have been created in order to map module ids properly.
+		$value = $this->get_value( Sensei_Data_Port_Course_Schema::COLUMN_DESCRIPTION );
+		if ( null !== $value ) {
+			$args['post_content'] =
+
+			wp_update_post(
+				[
+					'ID'           => $post_id,
+					'post_content' => $this->migrate_post_contnet( $value ),
+				]
+			);
+		}
+
 		$course_lessons = $this->get_value( Sensei_Data_Port_Course_Schema::COLUMN_LESSONS );
 		if ( null !== $course_lessons ) {
 			/**
@@ -146,11 +159,6 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 
 		if ( $this->is_new() ) {
 			$args['post_status'] = 'draft';
-		}
-
-		$value = $this->get_value( Sensei_Data_Port_Course_Schema::COLUMN_DESCRIPTION );
-		if ( null !== $value ) {
-			$args['post_content'] = $value;
 		}
 
 		$value = $this->get_value( Sensei_Data_Port_Course_Schema::COLUMN_TITLE );
@@ -278,5 +286,141 @@ class Sensei_Import_Course_Model extends Sensei_Import_Model {
 		if ( 'module' === $taxonomy ) {
 			delete_post_meta( $course_id, '_module_order' );
 		}
+	}
+
+	/**
+	 * Migrates the imported post content to use the ids of the newly created lessons and modules.
+	 *
+	 * @param string $post_content The post content.
+	 *
+	 * @return string The migrated post content.
+	 */
+	private function migrate_post_contnet( $post_content ) {
+		if ( ! has_block( 'sensei-lms/course-outline', $post_content ) ) {
+			return $post_content;
+		}
+
+		$blocks = parse_blocks( $post_content );
+
+		$i = 0;
+		foreach ( $blocks as $block ) {
+			if ( 'sensei-lms/course-outline' === $block['blockName'] ) {
+				$mapped_block = $this->map_outline_block_ids( $block );
+				break;
+			}
+			$i++;
+		}
+		$blocks[ $i ] = $mapped_block;
+
+		return serialize_blocks( $blocks );
+	}
+
+	/**
+	 * Maps the ids of an outlined block to use the newly created values.
+	 *
+	 * @param array $outline_block The outline block.
+	 *
+	 * @return array The mapped block.
+	 */
+	private function map_outline_block_ids( $outline_block ) {
+		if ( empty( $outline_block['innerBlocks'] ) ) {
+			return $outline_block;
+		}
+
+		$mapped_inner_blocks = [];
+		foreach ( $outline_block['innerBlocks'] as $inner_block ) {
+			if ( 'sensei-lms/course-outline-module' === $inner_block['blockName'] ) {
+				$mapped_block = $this->map_module_block_id( $inner_block );
+			} elseif ( 'sensei-lms/course-outline-lesson' === $inner_block['blockName'] ) {
+				$mapped_block = $this->map_lesson_block_id( $inner_block );
+			} else {
+				$mapped_block = $inner_block;
+			}
+
+			if ( false !== $mapped_block ) {
+				$mapped_inner_blocks[] = $mapped_block;
+			}
+		}
+
+		$outline_block['innerBlocks'] = $mapped_inner_blocks;
+
+		return $outline_block;
+	}
+
+	/**
+	 * Map the ids of a lesson block.
+	 *
+	 * @param array $lesson_block The lesson block.
+	 *
+	 * @return bool|array The lesson block or false if the id couldn't be mapped.
+	 */
+	private function map_lesson_block_id( $lesson_block ) {
+		if ( empty( $lesson_block['attrs']['id'] ) ) {
+			return false;
+		}
+
+		$lesson_id = $this->task->get_job()->translate_import_id( Sensei_Data_Port_Lesson_Schema::POST_TYPE, 'id:' . $lesson_block['attrs']['id'] );
+		if ( null === $lesson_id && null === $this->task->get_job()->translate_import_id( Sensei_Data_Port_Lesson_Schema::POST_TYPE, $lesson_block['attrs']['id'] ) ) {
+			$this->add_line_warning(
+				// translators: The %s is the lesson id.
+				sprintf( __( 'Lesson with id %s which is referenced in course outline block not found.', 'sensei-lms' ), $lesson_block['attrs']['id'] ),
+				[
+					'code' => 'sensei_data_port_course_lesson_not_found',
+				]
+			);
+
+			return false;
+		}
+
+		$lesson_block['attrs']['id'] = $lesson_id;
+
+		return $lesson_block;
+	}
+
+	/**
+	 * Map the ids of a module block.
+	 *
+	 * @param array $module_block The module block.
+	 *
+	 * @return bool|array The mapped module block or false if the block couldn't be mapped.
+	 */
+	private function map_module_block_id( $module_block ) {
+		if ( empty( $module_block['attrs']['title'] ) ) {
+			$this->add_line_warning(
+				__( 'No title for module found.', 'sensei-lms' ),
+				[
+					'code' => 'sensei_data_port_module_title_not_found',
+				]
+			);
+
+			return false;
+		}
+
+		$term = Sensei_Data_Port_Utilities::get_module_for_course( $module_block['attrs']['title'], $this->get_post_id() );
+
+		if ( is_wp_error( $term ) ) {
+			$this->add_line_warning( $term->get_error_message(), [ 'code' => $term->get_error_code() ] );
+
+			return false;
+		}
+
+		$module_inner_blocks = [];
+
+		foreach ( $module_block['innerBlocks'] as $inner_block ) {
+			if ( 'sensei-lms/course-outline-lesson' === $inner_block['blockName'] ) {
+				$mapped_lesson_block = $this->map_lesson_block_id( $inner_block );
+
+				if ( false !== $mapped_lesson_block ) {
+					$module_inner_blocks[] = $mapped_lesson_block;
+				}
+			} else {
+				$module_inner_blocks[] = $inner_block;
+			}
+		}
+
+		$module_block['attrs']['id'] = $term->term_id;
+		$module_block['innerBlocks'] = $module_inner_blocks;
+
+		return $module_block;
 	}
 }

--- a/includes/data-port/models/class-sensei-import-model.php
+++ b/includes/data-port/models/class-sensei-import-model.php
@@ -433,7 +433,7 @@ abstract class Sensei_Import_Model {
 	 * @param string $message  Warning message.
 	 * @param array  $log_data Log data.
 	 */
-	protected function add_line_warning( $message, $log_data = [] ) {
+	public function add_line_warning( $message, $log_data = [] ) {
 		$this->deferred_warnings[] = [
 			'message'  => $message,
 			'log_data' => $log_data,

--- a/tests/unit-tests/data-port/test-class-sensei-import-block-migrator.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-block-migrator.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * This file contains the Sensei_Import_Block_Migrator_Test class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/data-port/class-sensei-data-port-job-mock.php';
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/data-port/class-sensei-import-model-mock.php';
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/data-port/class-sensei-data-port-schema-mock.php';
+
+/**
+ * Tests for Sensei_Import_Block_Migrator class.
+ *
+ * @group data-port
+ */
+class Sensei_Import_Block_Migrator_Test extends WP_UnitTestCase {
+
+	/**
+	 * Set up the tests.
+	 */
+	public function setUp() {
+		$this->factory = new Sensei_Factory();
+
+		return parent::setUp();
+	}
+
+	public function testContentWithNoBlockUnmodified() {
+		$job  = new Sensei_Data_Port_Job_Mock( 'test' );
+		$task = new Sensei_Import_Courses( $job );
+
+		$migrator = new Sensei_Import_Block_Migrator( 1, $task, Sensei_Import_Model_Mock::from_source_array( 1, [], new Sensei_Data_Port_Schema_Mock() ) );
+
+		$content = '
+			<!-- wp:paragraph -->
+				<p>Some content</p>
+			<!-- /wp:paragraph -->';
+
+		$this->assertEquals( $content, $migrator->migrate( $content ) );
+	}
+
+	public function testLessonBlockIsMapped() {
+		$job = $this->getMockBuilder( Sensei_Import_Job::class )
+			->setConstructorArgs( [ 'test' ] )
+			->getMock();
+
+		$job->method( 'translate_import_id' )
+			->willReturn( 20 );
+
+		$task = new Sensei_Import_Courses( $job );
+
+		$migrator = new Sensei_Import_Block_Migrator( 1, $task, Sensei_Import_Model_Mock::from_source_array( 1, [], new Sensei_Data_Port_Schema_Mock() ) );
+
+		$content = '
+			<!-- wp:sensei-lms/course-outline -->
+				<!-- wp:sensei-lms/course-outline-lesson {"id":10,"title":"Without module","draft":false} -->
+					<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+				<!-- /wp:sensei-lms/course-outline-lesson -->
+			<!-- /wp:sensei-lms/course-outline -->';
+
+		$expected_content = '
+			<!-- wp:sensei-lms/course-outline -->
+				<!-- wp:sensei-lms/course-outline-lesson {"id":20,"title":"Without module","draft":false} -->
+					<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+				<!-- /wp:sensei-lms/course-outline-lesson -->
+			<!-- /wp:sensei-lms/course-outline -->';
+
+		$this->assertEquals( $expected_content, $migrator->migrate( $content ) );
+	}
+
+	public function testLessonBlockIsNotIncludedWhenNotMapped() {
+		$job = $this->getMockBuilder( Sensei_Import_Job::class )
+			->setConstructorArgs( [ 'test' ] )
+			->getMock();
+
+		$job->method( 'translate_import_id' )
+			->willReturn( null );
+
+		$task = new Sensei_Import_Courses( $job );
+
+		$migrator = new Sensei_Import_Block_Migrator( 1, $task, Sensei_Import_Model_Mock::from_source_array( 1, [], new Sensei_Data_Port_Schema_Mock() ) );
+
+		$matched_lesson_id     = $this->factory->lesson->create( [ 'post_title' => 'Title Matched' ] );
+		$not_matched_lesson_id = $this->factory->lesson->create( [ 'post_title' => 'Title Not Matched' ] );
+
+		$content = '
+			<!-- wp:sensei-lms/course-outline -->
+			<!-- wp:sensei-lms/course-outline-lesson {"id":10,"title":"Without module","draft":false} -->
+			<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+			<!-- /wp:sensei-lms/course-outline-lesson -->
+			<!-- wp:sensei-lms/course-outline-lesson {"id":' . $matched_lesson_id . ',"title":"Title Matched","draft":false} -->
+			<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+			<!-- /wp:sensei-lms/course-outline-lesson -->
+			<!-- wp:sensei-lms/course-outline-lesson {"id":' . $not_matched_lesson_id . ',"title":"Not Matching","draft":false} -->
+			<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+			<!-- /wp:sensei-lms/course-outline-lesson -->
+			<!-- /wp:sensei-lms/course-outline -->';
+
+		$expected_content = '
+			<!-- wp:sensei-lms/course-outline -->
+			
+			<!-- wp:sensei-lms/course-outline-lesson {"id":' . $matched_lesson_id . ',"title":"Title Matched","draft":false} -->
+			<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+			<!-- /wp:sensei-lms/course-outline-lesson -->
+			
+			<!-- /wp:sensei-lms/course-outline -->';
+
+		$this->assertEquals( $expected_content, $migrator->migrate( $content ) );
+	}
+
+	public function testModuleBlockIsMapped() {
+		$job = $this->getMockBuilder( Sensei_Import_Job::class )
+			->setConstructorArgs( [ 'test' ] )
+			->getMock();
+
+		$job->method( 'translate_import_id' )
+			->willReturn( 20 );
+
+		$task = new Sensei_Import_Courses( $job );
+
+		$module_id = $this->factory->module->create( [ 'name' => 'Module' ] );
+		$course_id = $this->factory->course->create();
+		wp_set_object_terms( $course_id, $module_id, 'module' );
+
+		$migrator = new Sensei_Import_Block_Migrator( $course_id, $task, Sensei_Import_Model_Mock::from_source_array( 1, [], new Sensei_Data_Port_Schema_Mock() ) );
+
+		$content = '
+		<!-- wp:sensei-lms/course-outline -->
+			<!-- wp:sensei-lms/course-outline-module {"id":50,"title":"Module","description":"Module desc"} -->
+				<!-- wp:sensei-lms/course-outline-lesson {"id":10,"title":"Lesson","draft":false} -->
+				<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+				<!-- /wp:sensei-lms/course-outline-lesson -->
+			<!-- /wp:sensei-lms/course-outline-module -->
+		<!-- /wp:sensei-lms/course-outline -->';
+
+		$expected_content = '
+		<!-- wp:sensei-lms/course-outline -->
+			<!-- wp:sensei-lms/course-outline-module {"id":' . $module_id . ',"title":"Module","description":"Module desc"} -->
+				<!-- wp:sensei-lms/course-outline-lesson {"id":20,"title":"Lesson","draft":false} -->
+				<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+				<!-- /wp:sensei-lms/course-outline-lesson -->
+			<!-- /wp:sensei-lms/course-outline-module -->
+		<!-- /wp:sensei-lms/course-outline -->';
+
+		$this->assertEquals( $expected_content, $migrator->migrate( $content ) );
+	}
+
+	public function testNotFoundModuleIsNotMapped() {
+		$job = $this->getMockBuilder( Sensei_Import_Job::class )
+			->setConstructorArgs( [ 'test' ] )
+			->getMock();
+
+		$task = new Sensei_Import_Courses( $job );
+
+		$migrator = new Sensei_Import_Block_Migrator( 1, $task, Sensei_Import_Model_Mock::from_source_array( 1, [], new Sensei_Data_Port_Schema_Mock() ) );
+
+		$content = '
+		<!-- wp:sensei-lms/course-outline -->
+			<!-- wp:sensei-lms/course-outline-module {"id":50,"title":"Module","description":"Module desc"} -->
+				<!-- wp:sensei-lms/course-outline-lesson {"id":10,"title":"Lesson","draft":false} -->
+				<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+				<!-- /wp:sensei-lms/course-outline-lesson -->
+			<!-- /wp:sensei-lms/course-outline-module -->
+		<!-- /wp:sensei-lms/course-outline -->';
+
+		$expected_content = '
+		<!-- wp:sensei-lms/course-outline -->
+			
+		<!-- /wp:sensei-lms/course-outline -->';
+
+		$this->assertEquals( $expected_content, $migrator->migrate( $content ) );
+	}
+}

--- a/tests/unit-tests/data-port/test-class-sensei-import-block-migrator.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-block-migrator.php
@@ -191,4 +191,67 @@ class Sensei_Import_Block_Migrator_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected_content, $migrator->migrate( $content ) );
 	}
+
+	/**
+	 * Tests that an outline block is handled correctly when it is an inner block.
+	 */
+	public function testOutlineBlockIsMappedWhenItsInnerBlock() {
+		$job = $this->getMockBuilder( Sensei_Import_Job::class )
+			->setConstructorArgs( [ 'test' ] )
+			->getMock();
+
+		$job->method( 'translate_import_id' )
+			->willReturn( 20 );
+
+		$task = new Sensei_Import_Courses( $job );
+
+		$migrator = new Sensei_Import_Block_Migrator( 1, $task, Sensei_Import_Model_Mock::from_source_array( 1, [], new Sensei_Data_Port_Schema_Mock() ) );
+
+		$content = '
+			<!-- wp:group -->
+				<div class="wp-block-group"><div class="wp-block-group__inner-container">
+				<!-- wp:group -->
+					<div class="wp-block-group"><div class="wp-block-group__inner-container">
+						<!-- wp:sensei-lms/course-outline -->
+							<!-- wp:sensei-lms/course-outline-lesson {"id":10,"title":"Without module","draft":false} -->
+								<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+							<!-- /wp:sensei-lms/course-outline-lesson -->
+						<!-- /wp:sensei-lms/course-outline -->
+			
+						<!-- wp:paragraph -->
+							<p>A paragraph</p>
+						<!-- /wp:paragraph -->
+						</div></div>
+				<!-- /wp:group -->
+			
+				<!-- wp:paragraph -->
+					<p>Another paragraph</p>
+				<!-- /wp:paragraph --></div></div>
+			<!-- /wp:group -->';
+
+		$expected_content = '
+			<!-- wp:group -->
+				<div class="wp-block-group"><div class="wp-block-group__inner-container">
+				<!-- wp:group -->
+					<div class="wp-block-group"><div class="wp-block-group__inner-container">
+						<!-- wp:sensei-lms/course-outline -->
+							<!-- wp:sensei-lms/course-outline-lesson {"id":20,"title":"Without module","draft":false} -->
+								<div class="wp-block-sensei-lms-course-outline-lesson"></div>
+							<!-- /wp:sensei-lms/course-outline-lesson -->
+						<!-- /wp:sensei-lms/course-outline -->
+			
+						<!-- wp:paragraph -->
+							<p>A paragraph</p>
+						<!-- /wp:paragraph -->
+						</div></div>
+				<!-- /wp:group -->
+			
+				<!-- wp:paragraph -->
+					<p>Another paragraph</p>
+				<!-- /wp:paragraph --></div></div>
+			<!-- /wp:group -->';
+
+		$this->assertEquals( $expected_content, $migrator->migrate( $content ) );
+	}
+
 }

--- a/tests/unit-tests/data-port/test-class-sensei-import-block-migrator.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-block-migrator.php
@@ -29,6 +29,9 @@ class Sensei_Import_Block_Migrator_Test extends WP_UnitTestCase {
 		return parent::setUp();
 	}
 
+	/**
+	 * Tests that content is not modified when Sensei blocks do not exists.
+	 */
 	public function testContentWithNoBlockUnmodified() {
 		$job  = new Sensei_Data_Port_Job_Mock( 'test' );
 		$task = new Sensei_Import_Courses( $job );
@@ -43,6 +46,9 @@ class Sensei_Import_Block_Migrator_Test extends WP_UnitTestCase {
 		$this->assertEquals( $content, $migrator->migrate( $content ) );
 	}
 
+	/**
+	 * Tests that a lesson block has it's id mapped when translate_import_id returns a value.
+	 */
 	public function testLessonBlockIsMapped() {
 		$job = $this->getMockBuilder( Sensei_Import_Job::class )
 			->setConstructorArgs( [ 'test' ] )
@@ -72,6 +78,11 @@ class Sensei_Import_Block_Migrator_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_content, $migrator->migrate( $content ) );
 	}
 
+	/**
+	 * Tests that lessons are not mapped when:
+	 * 1) translate_import_id doesn't return a translated id and the id doesn't exist in the database.
+	 * 2) The lesson id exists in the database but the Titles do not match.
+	 */
 	public function testLessonBlockIsNotIncludedWhenNotMapped() {
 		$job = $this->getMockBuilder( Sensei_Import_Job::class )
 			->setConstructorArgs( [ 'test' ] )
@@ -112,6 +123,9 @@ class Sensei_Import_Block_Migrator_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_content, $migrator->migrate( $content ) );
 	}
 
+	/**
+	 * Tests that a module block is mapped when the module with the given name exists and it is linked with the course.
+	 */
 	public function testModuleBlockIsMapped() {
 		$job = $this->getMockBuilder( Sensei_Import_Job::class )
 			->setConstructorArgs( [ 'test' ] )
@@ -149,6 +163,9 @@ class Sensei_Import_Block_Migrator_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected_content, $migrator->migrate( $content ) );
 	}
 
+	/**
+	 * Tests that modules which do not exist in the databases are not mapped.
+	 */
 	public function testNotFoundModuleIsNotMapped() {
 		$job = $this->getMockBuilder( Sensei_Import_Job::class )
 			->setConstructorArgs( [ 'test' ] )


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Translates the ids of the outline block to the newly created ones during importing.
* It uses the existing methods to translate ids for lessons.
* For modules the matching is done by name, similarily with the rest of the import functionality. This doesn't handle very well cases where modules with the same name exist but there is no alternative with the current import/export file structure.
* Module description is not imported/exported as there is no column for it. @donnapep maybe we should look into that?
 
### Testing instructions

* Create courses and lessons with the outline block and try to cover many edge cases.
* Export the content.
* On another site or with the original content deleted imported the previously exported content.
* Observe that the courses and lessons are linked correctly in the outline block.
* Update a course which has an outline block by using import.
* Observe that the course is updated and no warnings are displayed.