### PR TITLE
Fix PHP notices on taxonomy pages for unsupported themes

### DIFF
--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -81,16 +81,16 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 		 * as well so we can reset it back to this later.
 		 */
 		// phpcs:disable WordPress.WP.GlobalVariablesOverride.Prohibited -- Used to mock our own page within a custom loop. Reset afterwards.
-		$post                        = $this->dummy_post;
-		$wp_query                    = clone $wp_query;
-		$wp_query->post              = $post;
-		$wp_query->posts             = array( $post );
+		$post            = $this->dummy_post;
+		$wp_query        = clone $wp_query;
+		$wp_query->post  = $post;
+		$wp_query->posts = array( $post );
 		// On taxonomy pages the queried_object must remain a WP_Term object.
 		if ( ! is_tax() ) {
 			$wp_query->queried_object    = $post;
 			$wp_query->queried_object_id = $post->ID;
 		}
-		$wp_the_query                = $wp_query;
+		$wp_the_query = $wp_query;
 		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 
 		// Prevent comments form from appearing.

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php
@@ -85,8 +85,11 @@ abstract class Sensei_Unsupported_Theme_Handler_Page_Imitator {
 		$wp_query                    = clone $wp_query;
 		$wp_query->post              = $post;
 		$wp_query->posts             = array( $post );
-		$wp_query->queried_object    = $post;
-		$wp_query->queried_object_id = $post->ID;
+		// On taxonomy pages the queried_object must remain a WP_Term object.
+		if ( ! is_tax() ) {
+			$wp_query->queried_object    = $post;
+			$wp_query->queried_object_id = $post->ID;
+		}
 		$wp_the_query                = $wp_query;
 		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 


### PR DESCRIPTION
Fixes #3186. Duplicate of #3298, but this one is going into the 3.5.3 release.

### Changes proposed in this Pull Request

The fix that was introduced in version 3.0.0 as a remedy for issue #2754 had the unintended side effect that in unsupported themes sensei taxonomy pages (module pages, lesson-tag pages & course-category-pages) where no longer recognized as a taxonomy page.

As a result those pages didn't get sensei body-classes applied to them, and notices where issued.

This change proposes to leave the queried_object as is on taxonomy pages, so these issues doesn't occur. Basically it makes the remedy in PR #2911 only apply to non-taxonomy pages.

### Testing instructions
I've already testing the following in the original PR:
* See #3186 for testing details.
* Also check that #2754 is still fixed.