### PR TITLE
Fix module block title color

### DIFF
--- a/assets/blocks/course-outline/style.scss
+++ b/assets/blocks/course-outline/style.scss
@@ -115,6 +115,10 @@ $spacing: 16px;
 			&:not(.has-color) {
 				color: #FFF;
 			}
+
+			h2 {
+				color: inherit;
+			}
 		}
 
 		#{$block}__progress-indicator {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Ensure the Module block title `h2` tag is the correct color.

### Testing instructions

* Install the GeneratePress theme.
* Create a course, add the Course Outline block, add a Module and a Lesson.
* Ensure that the text color for the Module is white by default, and can be changed to any other color using the sidebar. Note that GeneratePress overrides the CSS such that on `master`, this color was dark (barely visible against the black background) and could not be changed.

### Screenshots

#### Before

Without color:

<img width="1344" alt="Screen Shot 2020-10-14 at 17 39 28" src="https://user-images.githubusercontent.com/842193/96042710-5c680380-0e5d-11eb-818c-cc91b058c9a1.png">

---

With color:

<img width="1347" alt="Screen Shot 2020-10-14 at 17 39 44" src="https://user-images.githubusercontent.com/842193/96042744-668a0200-0e5d-11eb-9e02-e39f8c15a313.png">

---

Zoomed in:

<img width="1910" alt="Screen Shot 2020-10-14 at 17 41 22" src="https://user-images.githubusercontent.com/842193/96042880-a224cc00-0e5d-11eb-89b4-5344f40dd879.png">

---

#### After

Without color:

<img width="1362" alt="Screen Shot 2020-10-14 at 17 38 10" src="https://user-images.githubusercontent.com/842193/96042615-2fb3ec00-0e5d-11eb-96de-fa4a00698748.png">

---

With color:

<img width="1344" alt="Screen Shot 2020-10-14 at 17 38 49" src="https://user-images.githubusercontent.com/842193/96042662-45c1ac80-0e5d-11eb-9e9e-c8a2420295d0.png">
