### PR TITLE
Add feature flag to disable single course template

### DIFF
--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -28,7 +28,7 @@ class Sensei_Course_Outline_Block {
 	 * Sensei_Course_Outline_Block constructor.
 	 */
 	public function __construct() {
-		add_filter( 'sensei_single_course_legacy_template', [ 'Sensei_Course_Outline_Block', 'using_legacy_single_course_template' ] );
+		add_filter( 'sensei_use_sensei_template', [ 'Sensei_Course_Outline_Block', 'skip_single_course_template' ] );
 		add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
 		add_action( 'init', [ $this, 'register_course_template' ], 101 );
@@ -36,15 +36,15 @@ class Sensei_Course_Outline_Block {
 	}
 
 	/**
-	 * Whether legacy single course template should be used.
+	 * Disable single course template if there is an outline block present.
 	 *
 	 * @param bool $enabled
 	 *
 	 * @return bool
 	 */
-	public static function using_legacy_single_course_template( $enabled ) {
-		return Sensei()->feature_flags->is_enabled( 'single_course_no_template' )
-			? ! has_block( 'sensei-lms/course-outline' )
+	public static function skip_single_course_template( $enabled ) {
+		return is_single() && 'course' === get_post_type() && has_block( 'sensei-lms/course-outline' )
+			? false
 			: $enabled;
 	}
 

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -28,10 +28,24 @@ class Sensei_Course_Outline_Block {
 	 * Sensei_Course_Outline_Block constructor.
 	 */
 	public function __construct() {
+		add_filter( 'sensei_single_course_legacy_template', [ 'Sensei_Course_Outline_Block', 'using_legacy_single_course_template' ] );
 		add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
 		add_action( 'init', [ $this, 'register_course_template' ], 101 );
 		add_action( 'init', [ $this, 'register_blocks' ] );
+	}
+
+	/**
+	 * Whether legacy single course template should be used.
+	 *
+	 * @param bool $enabled
+	 *
+	 * @return bool
+	 */
+	public static function using_legacy_single_course_template( $enabled ) {
+		return Sensei()->feature_flags->is_enabled( 'single_course_no_template' )
+			? ! has_block( 'sensei-lms/course-outline' )
+			: $enabled;
 	}
 
 	/**

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -38,6 +38,8 @@ class Sensei_Course_Outline_Block {
 	/**
 	 * Disable single course template if there is an outline block present.
 	 *
+	 * @access private
+	 *
 	 * @param bool $enabled
 	 *
 	 * @return bool

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -22,6 +22,7 @@ class Sensei_Feature_Flags {
 				'rest_api_v1_skip_permissions' => false,
 				'enrolment_provider_tooltip'   => false,
 				'course_outline'               => false,
+				'single_course_no_template'    => false,
 			)
 		);
 	}

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -22,7 +22,7 @@ class Sensei_Feature_Flags {
 				'rest_api_v1_skip_permissions' => false,
 				'enrolment_provider_tooltip'   => false,
 				'course_outline'               => false,
-				'single_course_no_template'    => false,
+				'optional_templates'           => false,
 			)
 		);
 	}

--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -162,7 +162,7 @@ class Sensei_Templates {
 			*/
 			$file = null;
 
-		} elseif ( is_single() && get_post_type() == 'course' ) {
+		} elseif ( is_single() && get_post_type() == 'course' && apply_filters( 'sensei_single_course_legacy_template', true ) ) {
 
 			// possible backward compatible template include if theme overrides content-single-course.php
 			// this template was removed in 1.9.0 and code all moved into the main single-course.php file

--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -148,6 +148,16 @@ class Sensei_Templates {
 		$find = array( 'sensei.php' );
 		$file = '';
 
+		/**
+		 * Filters if Sensei templates and content wrappers should be used. For development purposes.
+		 *
+		 * @hook   sensei_use_sensei_template
+		 *
+		 * @param  {bool} $use_templates Whether to use Sensei templates for the request.
+		 *
+		 * @since  3.6.0
+		 * @access private
+		 */
 		if ( Sensei()->feature_flags->is_enabled( 'optional_templates' ) && ! apply_filters( 'sensei_use_sensei_template', true ) ) {
 			return $template;
 		}

--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -148,6 +148,10 @@ class Sensei_Templates {
 		$find = array( 'sensei.php' );
 		$file = '';
 
+		if ( Sensei()->feature_flags->is_enabled( 'optional_templates' ) && ! apply_filters( 'sensei_use_sensei_template', true ) ) {
+			return $template;
+		}
+
 		if ( isset( $email_template ) && $email_template ) {
 
 			$file   = 'emails/' . $email_template;
@@ -162,7 +166,7 @@ class Sensei_Templates {
 			*/
 			$file = null;
 
-		} elseif ( is_single() && get_post_type() == 'course' && apply_filters( 'sensei_single_course_legacy_template', true ) ) {
+		} elseif ( is_single() && get_post_type() == 'course' ) {
 
 			// possible backward compatible template include if theme overrides content-single-course.php
 			// this template was removed in 1.9.0 and code all moved into the main single-course.php file

--- a/includes/class-sensei-unsupported-themes.php
+++ b/includes/class-sensei-unsupported-themes.php
@@ -119,7 +119,16 @@ class Sensei_Unsupported_Themes {
 			return;
 		}
 
-		// Skip if custom template is disabled.
+		/**
+		 * Filters if Sensei templates and content wrappers should be used. For development purposes.
+		 *
+		 * @hook   sensei_use_sensei_template
+		 *
+		 * @param  {bool} $use_templates Whether to use Sensei templates for the request.
+		 *
+		 * @since  3.6.0
+		 * @access private
+		 */
 		if ( Sensei()->feature_flags->is_enabled( 'optional_templates' ) && ! apply_filters( 'sensei_use_sensei_template', true ) ) {
 			return;
 		}

--- a/includes/class-sensei-unsupported-themes.php
+++ b/includes/class-sensei-unsupported-themes.php
@@ -119,6 +119,11 @@ class Sensei_Unsupported_Themes {
 			return;
 		}
 
+		// Skip if custom template is disabled.
+		if ( Sensei()->feature_flags->is_enabled( 'optional_templates' ) && ! apply_filters( 'sensei_use_sensei_template', true ) ) {
+			return;
+		}
+
 		// Use the first handler that can handle this request.
 		foreach ( $this->_handlers as $handler ) {
 			if ( $handler->can_handle_request() ) {

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -61,7 +61,7 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 	 * @return bool
 	 */
 	public function can_handle_request() {
-		return is_single() && get_post_type() === $this->post_type && apply_filters( 'sensei_single_' . $this->post_type . '_legacy_template', true );
+		return is_single() && get_post_type() === $this->post_type;
 	}
 
 	/**

--- a/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
+++ b/includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php
@@ -61,7 +61,7 @@ class Sensei_Unsupported_Theme_Handler_CPT implements Sensei_Unsupported_Theme_H
 	 * @return bool
 	 */
 	public function can_handle_request() {
-		return is_single() && get_post_type() === $this->post_type;
+		return is_single() && get_post_type() === $this->post_type && apply_filters( 'sensei_single_' . $this->post_type . '_legacy_template', true );
 	}
 
 	/**


### PR DESCRIPTION
Putting this up for an easy way to test stuff without the custom templates.

### Changes proposed in this Pull Request

* Add feature flag to skip Sensei's templates and unsupported theme handler for the single course page when there is a Course Outline block

### Testing instructions

* Add `define( 'SENSEI_FEATURE_FLAG_OPTIONAL_TEMPLATES', true );` to `wp-config.php`
* View a course with an outline block
* Dynamic Sensei content should not be visible
* Wide/full blocks should work if the theme supports them

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* New: `sensei_use_sensei_template`: Return false to not use Sensei templates and theme handler for the request

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

#### Before

<img width="937" alt="image" src="https://user-images.githubusercontent.com/176949/96052432-d7d9ad00-0e7d-11eb-9a0e-bc3e17a97d6b.png">

#### After
<img width="987" alt="image" src="https://user-images.githubusercontent.com/176949/96052413-ca242780-0e7d-11eb-8447-a5b50ff8db27.png">

