### PR TITLE
Change outline block error messages

### DIFF
--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -38,12 +38,17 @@ const actions = {
 				data: { structure: yield getEditorStructure() },
 			} );
 			yield actions.setStructure( result );
+
+			yield dispatch( 'core/notices' ).removeNotice(
+				'course-outline-update-error'
+			);
 		} catch ( error ) {
 			yield dispatch( 'core/notices' ).createErrorNotice(
 				[
 					__( 'Course Outline update failed:', 'sensei-lms' ),
 					error.message,
-				].join( ' ' )
+				].join( ' ' ),
+				{ id: 'course-outline-update-error' }
 			);
 			yield actions.setEditorDirty( false );
 		}

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -39,10 +39,6 @@ const actions = {
 				data: { structure: yield getEditorStructure() },
 			} );
 			yield actions.setStructure( result );
-
-			yield dispatch( 'core/notices' ).removeNotice(
-				'course-outline-save-error'
-			);
 		} catch ( error ) {
 			const errorMessage = sprintf(
 				/* translators: Error message. */
@@ -160,6 +156,9 @@ const registerCourseStructureStore = () => {
 		}
 
 		const shouldSave = select( COURSE_STORE ).shouldSave();
+
+		// Clear error notices.
+		dispatch( 'core/notices' ).removeNotice( 'course-outline-save-error' );
 
 		if ( shouldSave && ! shouldResavePost ) {
 			dispatch( COURSE_STORE ).save();

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -42,7 +42,10 @@ const actions = {
 		} catch ( error ) {
 			const errorMessage = sprintf(
 				/* translators: Error message. */
-				__( 'The course could not be saved. %s', 'sensei-lms' ),
+				__(
+					'Course modules and lessons could not be updated. %s',
+					'sensei-lms'
+				),
 				error.message
 			);
 			yield dispatch( 'core/notices' ).createErrorNotice( errorMessage, {

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -128,22 +128,17 @@ export const COURSE_STORE = 'sensei/course-structure';
  * Register course structure store and subscribe to block editor save.
  */
 const registerCourseStructureStore = () => {
-	subscribe( function saveStructureOnPostSave() {
-		const editor = select( 'core/editor' );
-
-		if ( ! editor ) return;
-
-		const isSaving = editor.isSavingPost() && ! editor.isAutosavingPost();
+	/**
+	 * Save course structure.
+	 *
+	 * @param {boolean} isSavingPost     Whether the post is saving.
+	 * @param {boolean} shouldResavePost Whether the post should resave.
+	 */
+	const saveCourseStructure = ( isSavingPost, shouldResavePost ) => {
 		const saveCalled = select( COURSE_STORE ).getSaveCalled();
-		const shouldResavePost = select( COURSE_STORE ).shouldResavePost();
-
-		// Save the post again if the blocks were updated.
-		if ( ! isSaving && shouldResavePost ) {
-			dispatch( 'core/editor' ).savePost();
-		}
 
 		// Make sure to run the save once after every post saving.
-		if ( isSaving ) {
+		if ( isSavingPost ) {
 			if ( saveCalled ) {
 				return;
 			}
@@ -163,6 +158,23 @@ const registerCourseStructureStore = () => {
 		if ( shouldSave && ! shouldResavePost ) {
 			dispatch( COURSE_STORE ).save();
 		}
+	};
+
+	subscribe( function saveStructureOnPostSave() {
+		const editor = select( 'core/editor' );
+
+		if ( ! editor ) return;
+
+		const isSavingPost =
+			editor.isSavingPost() && ! editor.isAutosavingPost();
+		const shouldResavePost = select( COURSE_STORE ).shouldResavePost();
+
+		// Save the post again if the blocks were updated.
+		if ( ! isSavingPost && shouldResavePost ) {
+			dispatch( 'core/editor' ).savePost();
+		}
+
+		saveCourseStructure( isSavingPost, shouldResavePost );
 	} );
 
 	registerStore( COURSE_STORE, {

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -1,6 +1,6 @@
 import { apiFetch, controls as dataControls } from '@wordpress/data-controls';
 import { dispatch, registerStore, select, subscribe } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { createReducerFromActionMap } from '../../shared/data/store-helpers';
 import { isEqual } from 'lodash';
 
@@ -40,16 +40,17 @@ const actions = {
 			yield actions.setStructure( result );
 
 			yield dispatch( 'core/notices' ).removeNotice(
-				'course-outline-update-error'
+				'course-outline-save-error'
 			);
 		} catch ( error ) {
-			yield dispatch( 'core/notices' ).createErrorNotice(
-				[
-					__( 'Course Outline update failed:', 'sensei-lms' ),
-					error.message,
-				].join( ' ' ),
-				{ id: 'course-outline-update-error' }
+			const errorMessage = sprintf(
+				/* translators: Error message. */
+				__( 'The course could not be saved. %s', 'sensei-lms' ),
+				error.message
 			);
+			yield dispatch( 'core/notices' ).createErrorNotice( errorMessage, {
+				id: 'course-outline-save-error',
+			} );
 			yield actions.setEditorDirty( false );
 		}
 

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -10,7 +10,7 @@ const DEFAULT_STATE = {
 	isSaving: false,
 	isEditorDirty: false,
 	hasChanges: false,
-	saveCalled: false,
+	isSaveCalled: false,
 };
 
 const actions = {
@@ -59,8 +59,8 @@ const actions = {
 	setEditorDirty: ( isEditorDirty ) => {
 		return { type: 'SET_DIRTY', isEditorDirty };
 	},
-	setSaveCalled: ( saveCalled ) => {
-		return { type: 'SET_SAVE_CALLED', saveCalled };
+	setSaveCalled: ( isSaveCalled ) => {
+		return { type: 'SET_SAVE_CALLED', isSaveCalled };
 	},
 };
 
@@ -96,9 +96,9 @@ const reducers = {
 		...state,
 		isEditorDirty,
 	} ),
-	SET_SAVE_CALLED: ( { saveCalled }, state ) => ( {
+	SET_SAVE_CALLED: ( { isSaveCalled }, state ) => ( {
 		...state,
-		saveCalled,
+		isSaveCalled,
 	} ),
 	DEFAULT: ( action, state ) => state,
 };
@@ -119,7 +119,7 @@ const selectors = {
 	shouldSave: ( { isEditorDirty, isSaving } ) => ! isSaving && isEditorDirty,
 	shouldResavePost: ( { isEditorDirty, isSaving, hasStructureUpdate } ) =>
 		! isSaving && isEditorDirty && hasStructureUpdate,
-	getSaveCalled: ( { saveCalled } ) => saveCalled,
+	isSaveCalled: ( { isSaveCalled } ) => isSaveCalled,
 };
 
 export const COURSE_STORE = 'sensei/course-structure';
@@ -135,16 +135,16 @@ const registerCourseStructureStore = () => {
 	 * @param {boolean} shouldResavePost Whether the post should resave.
 	 */
 	const saveCourseStructure = ( isSavingPost, shouldResavePost ) => {
-		const saveCalled = select( COURSE_STORE ).getSaveCalled();
+		const isSaveCalled = select( COURSE_STORE ).isSaveCalled();
 
 		// Make sure to run the save once after every post saving.
 		if ( isSavingPost ) {
-			if ( saveCalled ) {
+			if ( isSaveCalled ) {
 				return;
 			}
 			dispatch( COURSE_STORE ).setSaveCalled( true );
 		} else {
-			if ( saveCalled ) {
+			if ( isSaveCalled ) {
 				dispatch( COURSE_STORE ).setSaveCalled( false );
 			}
 			return;

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -51,7 +51,6 @@ const actions = {
 			yield dispatch( 'core/notices' ).createErrorNotice( errorMessage, {
 				id: 'course-outline-save-error',
 			} );
-			yield actions.setEditorDirty( false );
 		}
 
 		yield { type: 'SAVING', isSaving: false };

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -718,9 +718,16 @@ class Sensei_Course_Structure {
 		}
 
 		if ( ! isset( $raw_item['title'] ) || '' === trim( sanitize_text_field( $raw_item['title'] ) ) ) {
+			if ( 'module' === $raw_item['type'] ) {
+				return new WP_Error(
+					'sensei_course_structure_modules_missing_title',
+					__( 'Please ensure all modules have a name before saving.', 'sensei-lms' )
+				);
+			}
+
 			return new WP_Error(
-				'sensei_course_structure_missing_title',
-				__( 'Please ensure all items have a name before saving.', 'sensei-lms' )
+				'sensei_course_structure_lessons_missing_title',
+				__( 'Please ensure all lessons have a name before saving.', 'sensei-lms' )
 			);
 		}
 

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -589,6 +589,7 @@ class Sensei_Course_Structure {
 	 */
 	private function sanitize_structure( array $raw_structure ) {
 		list( $lesson_ids, $module_ids, $module_titles ) = $this->flatten_structure( $raw_structure );
+		$module_titles                                   = array_filter( $module_titles );
 
 		if (
 			array_unique( $module_ids ) !== $module_ids

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -594,11 +594,17 @@ class Sensei_Course_Structure {
 		if (
 			array_unique( $module_ids ) !== $module_ids
 			|| array_unique( $lesson_ids ) !== $lesson_ids
-			|| array_unique( $module_titles ) !== $module_titles
 		) {
 			return new WP_Error(
 				'sensei_course_structure_duplicate_items',
 				__( 'Individual lesson or modules cannot appear multiple times in the same course', 'sensei-lms' )
+			);
+		}
+
+		if ( array_unique( $module_titles ) !== $module_titles ) {
+			return new WP_Error(
+				'sensei_course_structure_duplicate_module_title',
+				__( 'Different modules cannot have the same name', 'sensei-lms' )
 			);
 		}
 

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -720,7 +720,7 @@ class Sensei_Course_Structure {
 		if ( ! isset( $raw_item['title'] ) || '' === trim( sanitize_text_field( $raw_item['title'] ) ) ) {
 			return new WP_Error(
 				'sensei_course_structure_missing_title',
-				__( 'All items must have a `title` set.', 'sensei-lms' )
+				__( 'Please ensure all items have a name before saving.', 'sensei-lms' )
 			);
 		}
 

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -597,14 +597,14 @@ class Sensei_Course_Structure {
 		) {
 			return new WP_Error(
 				'sensei_course_structure_duplicate_items',
-				__( 'Individual lesson or modules cannot appear multiple times in the same course', 'sensei-lms' )
+				__( 'Individual lesson or modules cannot appear multiple times in the same course.', 'sensei-lms' )
 			);
 		}
 
 		if ( array_unique( $module_titles ) !== $module_titles ) {
 			return new WP_Error(
 				'sensei_course_structure_duplicate_module_title',
-				__( 'Different modules cannot have the same name', 'sensei-lms' )
+				__( 'Different modules cannot have the same name.', 'sensei-lms' )
 			);
 		}
 
@@ -614,7 +614,7 @@ class Sensei_Course_Structure {
 			if ( ! is_array( $raw_item ) ) {
 				return new WP_Error(
 					'sensei_course_structure_invalid_item',
-					__( 'Each item must be an array', 'sensei-lms' )
+					__( 'Each item must be an array.', 'sensei-lms' )
 				);
 			}
 

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -648,6 +648,35 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test to make sure saving a duplicated module fails.
+	 */
+	public function testSaveDuplicatedModule() {
+		$this->login_as_admin();
+
+		$course_id     = $this->factory->course->create();
+		$new_structure = [
+			[
+				'id'      => 10,
+				'type'    => 'module',
+				'title'   => 'A',
+				'lessons' => [],
+			],
+			[
+				'id'      => 10,
+				'type'    => 'module',
+				'title'   => 'B',
+				'lessons' => [],
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+		$save_result      = $course_structure->save( $new_structure );
+
+		$this->assertWPError( $save_result );
+		$this->assertEquals( 'sensei_course_structure_duplicate_items', $save_result->get_error_code() );
+	}
+
+	/**
 	 * Test to make sure saving a course with two identically named modules fails.
 	 */
 	public function testSaveIdenticalModules() {
@@ -671,7 +700,7 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		$save_result      = $course_structure->save( $new_structure );
 
 		$this->assertWPError( $save_result );
-		$this->assertEquals( 'sensei_course_structure_duplicate_items', $save_result->get_error_code() );
+		$this->assertEquals( 'sensei_course_structure_duplicate_module_title', $save_result->get_error_code() );
 	}
 
 

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -342,7 +342,7 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		$save_result = $course_structure->save( $new_structure );
 		$this->assertWPError( $save_result );
 
-		$this->assertEquals( 'sensei_course_structure_missing_title', $save_result->get_error_code() );
+		$this->assertEquals( 'sensei_course_structure_lessons_missing_title', $save_result->get_error_code() );
 
 		$structure = $course_structure->get( 'edit' );
 		$this->assertEquals( 0, count( $structure ) );
@@ -369,7 +369,7 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		$save_result = $course_structure->save( $new_structure );
 		$this->assertWPError( $save_result );
 
-		$this->assertEquals( 'sensei_course_structure_missing_title', $save_result->get_error_code() );
+		$this->assertEquals( 'sensei_course_structure_modules_missing_title', $save_result->get_error_code() );
 
 		$structure = $course_structure->get( 'edit' );
 		$this->assertEquals( 0, count( $structure ) );


### PR DESCRIPTION
Fixes #3693

### Changes proposed in this Pull Request

* Update error message.
* Remove error message when saving with success.

### Testing instructions

* Create a course with an outline block.
* Add a module without a name.
* Save it, and make sure you see the message `The course could not be saved. Please ensure all items have a name before saving.`.
* Add another module without a name (2 now), and make sure you see the same message after saving again.
* Add the same name to both modules, and make sure you see the error `The course could not be saved. Different modules cannot have the same name.`.
* Add a different name to every module and make sure it's saved and the error message disappears.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![Oct-15-2020 14-58-01](https://user-images.githubusercontent.com/876340/96168373-02b41780-0ef7-11eb-9028-f07084b0ab76.gif)
