### PR TITLE
Add Edit Lesson button to toolbar

### DIFF
--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -32,20 +32,22 @@ export const LessonBlockSettings = ( {
 		select( 'core/block-editor' ).getSettings()
 	);
 
+	const editLessonLink = (
+		<ExternalLink
+			href={ `post.php?post=${ id }&action=edit` }
+			target="lesson"
+			className="wp-block-sensei-lms-course-outline-lesson__edit"
+		>
+			{ __( 'Edit lesson', 'sensei-lms' ) }
+		</ExternalLink>
+	);
+
 	return (
 		<>
 			<InspectorControls>
 				{ id && (
 					<PanelBody title={ __( 'Lesson', 'sensei-lms' ) }>
-						<h2>
-							<ExternalLink
-								href={ `post.php?post=${ id }&action=edit` }
-								target="lesson"
-								className="wp-block-sensei-lms-course-outline-lesson__edit"
-							>
-								{ __( 'Edit lesson', 'sensei-lms' ) }
-							</ExternalLink>
-						</h2>
+						<h2>{ editLessonLink }</h2>
 						<p>
 							{ __(
 								'Edit details such as lesson content, prerequisite, quiz settings and more.',
@@ -76,15 +78,7 @@ export const LessonBlockSettings = ( {
 			</InspectorControls>
 			<BlockControls>
 				<ToolbarGroup>
-					<ToolbarButton>
-						<ExternalLink
-							href={ `post.php?post=${ id }&action=edit` }
-							target="lesson"
-							className="wp-block-sensei-lms-course-outline-lesson__edit"
-						>
-							{ __( 'Edit lesson', 'sensei-lms' ) }
-						</ExternalLink>
-					</ToolbarButton>
+					<ToolbarButton>{ editLessonLink }</ToolbarButton>
 				</ToolbarGroup>
 			</BlockControls>
 		</>

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -1,5 +1,11 @@
-import { InspectorControls } from '@wordpress/block-editor';
-import { ExternalLink, FontSizePicker, PanelBody } from '@wordpress/components';
+import { InspectorControls, BlockControls } from '@wordpress/block-editor';
+import {
+	ExternalLink,
+	FontSizePicker,
+	PanelBody,
+	ToolbarButton,
+	ToolbarGroup,
+} from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -27,10 +33,50 @@ export const LessonBlockSettings = ( {
 	);
 
 	return (
-		<InspectorControls>
-			{ id && (
-				<PanelBody title={ __( 'Lesson', 'sensei-lms' ) }>
-					<h2>
+		<>
+			<InspectorControls>
+				{ id && (
+					<PanelBody title={ __( 'Lesson', 'sensei-lms' ) }>
+						<h2>
+							<ExternalLink
+								href={ `post.php?post=${ id }&action=edit` }
+								target="lesson"
+								className="wp-block-sensei-lms-course-outline-lesson__edit"
+							>
+								{ __( 'Edit lesson', 'sensei-lms' ) }
+							</ExternalLink>
+						</h2>
+						<p>
+							{ __(
+								'Edit details such as lesson content, prerequisite, quiz settings and more.',
+								'sensei-lms'
+							) }
+						</p>
+					</PanelBody>
+				) }
+				<PanelBody title={ __( 'Typography', 'sensei-lms' ) }>
+					<FontSizePicker
+						fontSizes={ fontSizes }
+						value={ fontSize }
+						onChange={ ( value ) => {
+							setAttributes( { fontSize: value } );
+						} }
+					/>
+				</PanelBody>
+				<PanelBody
+					title={ __( 'Status', 'sensei-lms' ) }
+					initialOpen={ false }
+				>
+					<StatusControl
+						status={ previewStatus }
+						setStatus={ setPreviewStatus }
+						options={ [ Status.NOT_STARTED, Status.COMPLETED ] }
+					/>
+				</PanelBody>
+			</InspectorControls>
+			<BlockControls>
+				<ToolbarGroup>
+					<ToolbarButton>
 						<ExternalLink
 							href={ `post.php?post=${ id }&action=edit` }
 							target="lesson"
@@ -38,34 +84,9 @@ export const LessonBlockSettings = ( {
 						>
 							{ __( 'Edit lesson', 'sensei-lms' ) }
 						</ExternalLink>
-					</h2>
-					<p>
-						{ __(
-							'Edit details such as lesson content, prerequisite, quiz settings and more.',
-							'sensei-lms'
-						) }
-					</p>
-				</PanelBody>
-			) }
-			<PanelBody title={ __( 'Typography', 'sensei-lms' ) }>
-				<FontSizePicker
-					fontSizes={ fontSizes }
-					value={ fontSize }
-					onChange={ ( value ) => {
-						setAttributes( { fontSize: value } );
-					} }
-				/>
-			</PanelBody>
-			<PanelBody
-				title={ __( 'Status', 'sensei-lms' ) }
-				initialOpen={ false }
-			>
-				<StatusControl
-					status={ previewStatus }
-					setStatus={ setPreviewStatus }
-					options={ [ Status.NOT_STARTED, Status.COMPLETED ] }
-				/>
-			</PanelBody>
-		</InspectorControls>
+					</ToolbarButton>
+				</ToolbarGroup>
+			</BlockControls>
+		</>
 	);
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add link to edit Lesson from the Lesson block toolbar.

### Testing instructions

* Create a course, add the Course Outline block, add a Lesson block.
* Click the edit icon in the Lesson block toolbar.
* The Lesson editor should open in a new tab.