### PR TITLE
Add validation to post object before logging the course update.

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3549,8 +3549,13 @@ class Sensei_Course {
 			return;
 		}
 
-		$course_id     = $this->course_id_updating;
-		$post          = get_post( $course_id );
+		$course_id = $this->course_id_updating;
+		$post      = get_post( $course_id );
+
+		if ( empty( $post ) ) {
+			return;
+		}
+
 		$content       = $post->post_content;
 		$product_ids   = get_post_meta( $course_id, '_course_woocommerce_product', false );
 		$product_count = empty( $product_ids ) ? 0 : count( array_filter( $product_ids, 'is_numeric' ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR fixes an issue with some tests when the `shutdown` is firing after cleaning the created courses.

### Testing instructions

* Run `phpunit --filter testSaveIdenticalModules` and make sure no error appears.
* Also activate the logs (`wp-admin -> Sensei LMS -> Settings -> Enable usage tracking`), save a course and make sure `sensei_course_update` is logged.