### PR TITLE
Hide modules description in the frontend when there is no description

### DIFF
--- a/includes/blocks/class-sensei-course-outline-module-block.php
+++ b/includes/blocks/class-sensei-course-outline-module-block.php
@@ -57,6 +57,10 @@ class Sensei_Course_Outline_Module_Block {
 
 		}
 
+		$description = ! empty( $block['description'] )
+			? '<div class="wp-block-sensei-lms-course-outline-module__description">' . wp_kses_post( $block['description'] ) . '</div>'
+			: '';
+
 		return '
 			<section class="wp-block-sensei-lms-course-outline-module ' . esc_attr( $class_name ) . '">
 				<header ' . Sensei_Block_Helpers::render_style_attributes( 'wp-block-sensei-lms-course-outline-module__header', $header_css ) . '>
@@ -70,13 +74,10 @@ class Sensei_Course_Outline_Module_Block {
 			'</header>
 					' . $style_header . '
 				<div class="wp-block-sensei-lms-collapsible">
-					<div class="wp-block-sensei-lms-course-outline-module__description">
-						' . wp_kses_post( $block['description'] ) . '
-					</div>
-							<h3 class="wp-block-sensei-lms-course-outline-module__lessons-title">
-								' . esc_html__( 'Lessons', 'sensei-lms' ) . '
-							</h3>
-						' .
+					' . $description . '
+					<h3 class="wp-block-sensei-lms-course-outline-module__lessons-title">
+						' . esc_html__( 'Lessons', 'sensei-lms' ) . '
+					</h3>' .
 			implode(
 				'',
 				array_map(


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Hide modules description in the frontend when there is no description

### Testing instructions

* Create a course, and add a module with description.
* Save it and make sure it appears with the description in the frontend.
* Clear the description and save again.
* Go to the frontend and make sure the description gap doesn't appear.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="611" alt="Screen Shot 2020-10-15 at 19 50 22" src="https://user-images.githubusercontent.com/876340/96193945-afa28a80-0f1f-11eb-83dc-1bf5be75b1d9.png">
