### PR TITLE
Fix visibility of quiz passmark percentage field

### DIFF
--- a/assets/js/lesson-metadata.js
+++ b/assets/js/lesson-metadata.js
@@ -1696,8 +1696,7 @@ jQuery( document ).ready( function () {
 	} );
 
 	jQuery( '#quiz-settings' ).on( 'change', '#pass_required', function () {
-		var checked = jQuery( this ).attr( 'checked' );
-		if ( 'checked' == checked ) {
+		if ( jQuery( this ).is( ':checked' ) ) {
 			jQuery( '.form-field.quiz_passmark' ).removeClass( 'hidden' );
 		} else {
 			jQuery( '.form-field.quiz_passmark' ).addClass( 'hidden' );


### PR DESCRIPTION
Fixes #3682.

### Changes proposed in this Pull Request

Fixes the visibility of the _Quiz passmark percentage_ field.

### Testing instructions

* Open a lesson.
* In _Quiz Settings_ check the _Pass required to complete lesson_ checkbox.
* Ensure the _Quiz passmark percentage_ field is visible.
* Uncheck the _Pass required to complete lesson_ checkbox.
* Ensure the _Quiz passmark percentage_ field is hidden.