### PR TITLE
Don't show Edit Lesson link in toolbar for empty lessons

### DIFF
--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -77,9 +77,11 @@ export const LessonBlockSettings = ( {
 				</PanelBody>
 			</InspectorControls>
 			<BlockControls>
-				<ToolbarGroup>
-					<ToolbarButton>{ editLessonLink }</ToolbarButton>
-				</ToolbarGroup>
+				{ id && (
+					<ToolbarGroup>
+						<ToolbarButton>{ editLessonLink }</ToolbarButton>
+					</ToolbarGroup>
+				) }
 			</BlockControls>
 		</>
 	);


### PR DESCRIPTION
Fixes #3718

### Changes proposed in this Pull Request

* Don't show the Edit lesson toolbar item if the lesson is not yet created (no ID)

### Testing instructions

* Add a new lesson to a course outline
* Make sure edit lesson link is not in the block toolbar

