### PR TITLE
Add a message for course outline block without published content

### DIFF
--- a/includes/blocks/class-sensei-course-outline-course-block.php
+++ b/includes/blocks/class-sensei-course-outline-course-block.php
@@ -47,6 +47,14 @@ class Sensei_Course_Outline_Course_Block {
 		$blocks     = $outline['blocks'];
 		$post_id    = $outline['post_id'];
 
+		if ( empty( $blocks ) ) {
+			return '
+				<div class="sensei-message info">
+					' . __( 'There is no published content in this course yet.', 'sensei-lms' ) . '
+				</div>
+			';
+		}
+
 		$class_name = Sensei_Block_Helpers::block_class_with_default_style( $attributes );
 		$css        = Sensei_Block_Helpers::build_styles( $attributes );
 

--- a/tests/unit-tests/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/test-class-sensei-course-outline-block.php
@@ -17,15 +17,15 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the course structure is used for rendering.
+	 * Test that a message is shown when there is no content.
 	 */
-	public function testBlockRendered() {
+	public function testEmptyBlock() {
 		$post_content = file_get_contents( 'sample-data/outline-block-post-content.html', true );
 
 		$this->mockPostCourseStructure( [] );
 		$result = do_blocks( $post_content );
 
-		$this->assertDiscardWhitespace( '<section class="wp-block-sensei-lms-course-outline is-style-default" style=""></section>', $result );
+		$this->assertContains( 'There is no published content in this course yet.', $result );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Show an empty course message when it contains the Course Outline Block without published modules or lessons.

### Testing instructions

* Create a course.
* Add the Course Outline block.
* Publish without add any module or lesson (Or add it as draft).
* Visit the course and make sure you see the "There is no content in this course yet." message instead of the empty `div`.
* Add and publish a lesson.
* Visit the course again and make sure you see the content and not the message.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="714" alt="Screen Shot 2020-10-19 at 14 16 05" src="https://user-images.githubusercontent.com/876340/96489325-ad894600-1215-11eb-86f6-b31f0135d300.png">
