### PR TITLE
Refactor modules collapsing script to use domReady

### DIFF
--- a/assets/blocks/course-outline/frontend.js
+++ b/assets/blocks/course-outline/frontend.js
@@ -1,48 +1,40 @@
-( () => {
-	const onReady = ( fn ) => {
-		if ( 'loading' !== document.readyState ) {
-			fn();
-		} else {
-			document.addEventListener( 'DOMContentLoaded', fn );
-		}
-	};
+import domReady from '@wordpress/dom-ready';
 
-	onReady( () => {
-		if (
-			0 ===
-			document.querySelectorAll(
-				'.wp-block-sensei-lms-course-outline__arrow'
-			).length
-		) {
-			return;
-		}
+domReady( () => {
+	if (
+		0 ===
+		document.querySelectorAll(
+			'.wp-block-sensei-lms-course-outline__arrow'
+		).length
+	) {
+		return;
+	}
 
-		const modules = document.querySelectorAll(
-			'.wp-block-sensei-lms-course-outline-module'
+	const modules = document.querySelectorAll(
+		'.wp-block-sensei-lms-course-outline-module'
+	);
+
+	modules.forEach( ( module ) => {
+		const moduleContent = module.querySelector(
+			'.wp-block-sensei-lms-collapsible'
 		);
 
-		modules.forEach( ( module ) => {
-			const moduleContent = module.querySelector(
-				'.wp-block-sensei-lms-collapsible'
-			);
+		const originalHeight = moduleContent.offsetHeight;
+		const toggleButton = module.querySelector(
+			'.wp-block-sensei-lms-course-outline__arrow'
+		);
 
-			const originalHeight = moduleContent.offsetHeight;
-			const toggleButton = module.querySelector(
-				'.wp-block-sensei-lms-course-outline__arrow'
-			);
+		moduleContent.style.height = originalHeight + 'px';
 
-			moduleContent.style.height = originalHeight + 'px';
+		toggleButton.addEventListener( 'click', () => {
+			toggleButton.classList.toggle( 'collapsed' );
+			const collapsed = moduleContent.classList.toggle( 'collapsed' );
 
-			toggleButton.addEventListener( 'click', () => {
-				toggleButton.classList.toggle( 'collapsed' );
-				const collapsed = moduleContent.classList.toggle( 'collapsed' );
-
-				if ( ! collapsed ) {
-					moduleContent.style.height = originalHeight + 'px';
-				} else {
-					moduleContent.style.height = '0px';
-				}
-			} );
+			if ( ! collapsed ) {
+				moduleContent.style.height = originalHeight + 'px';
+			} else {
+				moduleContent.style.height = '0px';
+			}
 		} );
 	} );
-} )();
+} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -13144,17 +13144,17 @@
       }
     },
     "@wordpress/dom-ready": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.10.0.tgz",
-      "integrity": "sha512-ibeuUU0bz66ZtFxu4jyo9YLxTkmLZCSiSo/NApwtzbyE3+cGS05XrAAhM/M79OjysOFaKNyh6sp0YA7ZZU47eg==",
+      "version": "2.11.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dom-ready/-/dom-ready-2.11.0.tgz",
+      "integrity": "sha512-q9MZqYPHUtioT/2tgzyAtnEFXRgUJ6eMxLDQaOprBQkGoD2Ue/V+wEX6cJGy+x8AafFataPC2i2jPsnYqE9+zQ==",
       "requires": {
-        "@babel/runtime": "^7.9.2"
+        "@babel/runtime": "^7.11.2"
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.11.2",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
-          "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+          "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
           "requires": {
             "regenerator-runtime": "^0.13.4"
           }
@@ -15716,7 +15716,7 @@
           "dev": true
         },
         "puppeteer": {
-          "version": "npm:puppeteer@3.0.0",
+          "version": "npm:puppeteer-core@3.0.0",
           "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-3.0.0.tgz",
           "integrity": "sha512-oWjZFGMc0q2ak+8OxdmMffS79LIT0UEtmpV4h1/AARvESIqqKljf8mrfP+dQ2kas7XttsAZIxRBuWu7Y5JH8KQ==",
           "dev": true,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@wordpress/components": "9.4.1",
     "@wordpress/data": "4.22.3",
     "@wordpress/data-controls": "1.16.3",
+    "@wordpress/dom-ready": "2.11.0",
     "@wordpress/element": "2.16.0",
     "@wordpress/i18n": "3.14.0",
     "@wordpress/url": "2.17.0",


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Just a small refactor to use the WP domReady dependency instead of implementing our own.

### Testing instructions

* Just make sure the modules continue collapsing/expanding properly.