### PR TITLE
Add module link to the course outline block when the module has a description

### DIFF
--- a/assets/blocks/course-outline/module-block/module-block.scss
+++ b/assets/blocks/course-outline/module-block/module-block.scss
@@ -40,6 +40,10 @@
 			&::before, &::after {
 				content: none;
 			}
+
+			a {
+				color: inherit;
+			}
 		}
 
 		#{$block}__description {

--- a/includes/blocks/class-sensei-course-outline-module-block.php
+++ b/includes/blocks/class-sensei-course-outline-module-block.php
@@ -65,7 +65,7 @@ class Sensei_Course_Outline_Module_Block {
 			$module_link = get_term_link( $block['id'], Sensei()->modules->taxonomy );
 
 			if ( ! is_wp_error( $module_link ) ) {
-				$module_link = add_query_arg( 'course_id', $course_id, $module_link );
+				$module_link = esc_url( add_query_arg( 'course_id', $course_id, $module_link ) );
 				$title       = '<a href="' . $module_link . '">' . $title . '</a>';
 			}
 		}

--- a/includes/blocks/class-sensei-course-outline-module-block.php
+++ b/includes/blocks/class-sensei-course-outline-module-block.php
@@ -62,10 +62,12 @@ class Sensei_Course_Outline_Module_Block {
 
 		if ( ! empty( $block['description'] ) ) {
 			$description = '<div class="wp-block-sensei-lms-course-outline-module__description">' . wp_kses_post( $block['description'] ) . '</div>';
-
 			$module_link = get_term_link( $block['id'], Sensei()->modules->taxonomy );
-			$module_link = add_query_arg( 'course_id', $course_id, $module_link );
-			$title       = '<a href=" ' . $module_link . ' ">' . $title . '</a>';
+
+			if ( ! is_wp_error( $module_link ) ) {
+				$module_link = add_query_arg( 'course_id', $course_id, $module_link );
+				$title       = '<a href="' . $module_link . '">' . $title . '</a>';
+			}
 		}
 
 		return '

--- a/includes/blocks/class-sensei-course-outline-module-block.php
+++ b/includes/blocks/class-sensei-course-outline-module-block.php
@@ -57,14 +57,21 @@ class Sensei_Course_Outline_Module_Block {
 
 		}
 
-		$description = ! empty( $block['description'] )
-			? '<div class="wp-block-sensei-lms-course-outline-module__description">' . wp_kses_post( $block['description'] ) . '</div>'
-			: '';
+		$title       = esc_html( $block['title'] );
+		$description = '';
+
+		if ( ! empty( $block['description'] ) ) {
+			$description = '<div class="wp-block-sensei-lms-course-outline-module__description">' . wp_kses_post( $block['description'] ) . '</div>';
+
+			$module_link = get_term_link( $block['id'], Sensei()->modules->taxonomy );
+			$module_link = add_query_arg( 'course_id', $course_id, $module_link );
+			$title       = '<a href=" ' . $module_link . ' ">' . $title . '</a>';
+		}
 
 		return '
 			<section class="wp-block-sensei-lms-course-outline-module ' . esc_attr( $class_name ) . '">
 				<header ' . Sensei_Block_Helpers::render_style_attributes( 'wp-block-sensei-lms-course-outline-module__header', $header_css ) . '>
-					<h2 class="wp-block-sensei-lms-course-outline-module__title">' . esc_html( $block['title'] ) . '</h2>
+					<h2 class="wp-block-sensei-lms-course-outline-module__title">' . $title . '</h2>
 					' . $progress_indicator .
 			( ! empty( $outline_attributes['collapsibleModules'] ) ?
 				'<button type="button" class="wp-block-sensei-lms-course-outline__arrow">

--- a/tests/unit-tests/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/test-class-sensei-course-outline-block.php
@@ -54,14 +54,15 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 	 */
 	public function testModulesRendered() {
 		$post_content = file_get_contents( 'sample-data/outline-block-post-content.html', true );
+		$module       = $this->factory->module->create_and_get();
 
 		$this->mockPostCourseStructure(
 			[
 				[
-					'id'          => 1,
+					'id'          => $module->term_id,
 					'type'        => 'module',
-					'title'       => 'Test Module',
-					'description' => 'Module description',
+					'title'       => $module->name,
+					'description' => $module->description,
 					'lessons'     => [
 						[
 							'id'    => 1,
@@ -72,11 +73,46 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 				],
 			]
 		);
-		$result = do_blocks( $post_content );
 
-		$this->assertContains( 'Test Module', $result );
-		$this->assertContains( 'Module description', $result );
+		$result      = do_blocks( $post_content );
+		$module_link = get_term_link( $module->term_id, Sensei()->modules->taxonomy );
+
+		$this->assertContains( $module->name, $result );
+		$this->assertContains( $module->description, $result );
+		$this->assertContains( $module_link, $result );
 		$this->assertContains( 'Test Lesson', $result );
+	}
+
+	/**
+	 * Test module without description in the structure is rendered.
+	 */
+	public function testModuleWithoutDescriptionRendered() {
+		$post_content = file_get_contents( 'sample-data/outline-block-post-content.html', true );
+		$module       = $this->factory->module->create_and_get();
+
+		$this->mockPostCourseStructure(
+			[
+				[
+					'id'          => $module->term_id,
+					'type'        => 'module',
+					'title'       => $module->name,
+					'description' => '',
+					'lessons'     => [
+						[
+							'id'    => 1,
+							'type'  => 'lesson',
+							'title' => 'Test Lesson',
+						],
+					],
+				],
+			]
+		);
+
+		$result      = do_blocks( $post_content );
+		$module_link = get_term_link( $module->term_id, Sensei()->modules->taxonomy );
+
+		$this->assertContains( $module->name, $result );
+		$this->assertNotContains( $module_link, $result );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3713

### Changes proposed in this Pull Request

* Add a link to the module when it has a description to reproduce the current behavior when using blocks.

### Testing instructions

1. Add the course outline block to a course.
2. Add a module to the block. Give it a description.
3. Add a lesson to the module and publish it.
4. Publish the course and view it in the frontend.
5. Click on the module, and make sure it goes to the module page with the title and description.