### PR TITLE
Change course outline styling to distinguish lessons that belong to a module and lessons that do not

### DIFF
--- a/assets/blocks/course-outline/course-block/block.json
+++ b/assets/blocks/course-outline/course-block/block.json
@@ -49,7 +49,9 @@
           {
             "name": "sensei-lms/course-outline-lesson",
             "attributes": {
-              "title": "Lesson"
+              "title": "Lesson",
+              "id": 1,
+              "draft": false
             }
           }
         ]
@@ -57,13 +59,17 @@
       {
         "name": "sensei-lms/course-outline-lesson",
         "attributes": {
-          "title": "First Lesson"
+          "title": "First Lesson",
+          "id": 2,
+          "draft": false
         }
       },
       {
         "name": "sensei-lms/course-outline-lesson",
         "attributes": {
-          "title": "Second Lesson"
+          "title": "Second Lesson",
+          "id": 3,
+          "draft": false
         }
       }
     ]

--- a/assets/blocks/course-outline/course-block/course-block.scss
+++ b/assets/blocks/course-outline/course-block/course-block.scss
@@ -1,4 +1,3 @@
-
 .wp-block-sensei-lms-course-outline {
 
 	.wp-block-sensei-lms-course-outline-module {

--- a/assets/blocks/course-outline/course-block/course-block.scss
+++ b/assets/blocks/course-outline/course-block/course-block.scss
@@ -1,11 +1,14 @@
 
 .wp-block-sensei-lms-course-outline {
 
-	margin: 1em 0;
-	border: 0 solid $dark-gray;
+	.wp-block-sensei-lms-course-outline-module {
+		margin: 1em 0;
+		border: 0 solid $dark-gray;
+	}
 
-	&.is-style-default {
+	&.is-style-default .wp-block-sensei-lms-course-outline-module {
 		border-width: 1px;
+
 		.block-editor-block-styles__item & {
 			border-width: 4px;
 			margin: 1px;

--- a/assets/blocks/course-outline/module-block/index.js
+++ b/assets/blocks/course-outline/module-block/index.js
@@ -26,6 +26,8 @@ export default {
 				name: 'sensei-lms/course-outline-lesson',
 				attributes: {
 					title: __( 'Lesson', 'sensei-lms' ),
+					id: 1,
+					draft: false,
 				},
 			},
 		],

--- a/assets/blocks/course-outline/module-block/module-block.scss
+++ b/assets/blocks/course-outline/module-block/module-block.scss
@@ -100,7 +100,7 @@
 
 	.block-editor-block-styles__item & {
 		font-size: 150%;
-		.block-editor-inner-blocks, #{$block}__progress-indicator, .wp-block-sensei-lms-course-outline__arrow {
+		#{$block}__progress-indicator, .wp-block-sensei-lms-course-outline__arrow {
 			display: none;
 		}
 	}

--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -2,11 +2,6 @@ $dark-gray: #1a1d20;
 .block-editor {
 	.wp-block-sensei-lms-course-outline {
 
-		.block-editor-block-list__block {
-			margin-top: 0;
-			margin-bottom: 0;
-		}
-
 		&__placeholder {
 			.components-button {
 				margin-right: 12px;
@@ -52,5 +47,10 @@ $dark-gray: #1a1d20;
 		.components-base-control__help {
 			margin-top: 10px;
 		}
+	}
+
+	.block-editor-block-list__block[data-type="sensei-lms/course-outline-lesson"] {
+		margin-top: 0;
+		margin-bottom: 0;
 	}
 }

--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -1,6 +1,7 @@
 $dark-gray: #1a1d20;
 .block-editor {
 	.wp-block-sensei-lms-course-outline {
+		padding: 1px 1em 0;
 
 		&__placeholder {
 			.components-button {


### PR DESCRIPTION
Fixes #3701

Closes #3719

### Changes proposed in this Pull Request

* Change course outline block styles to distinguish lessons that belong to a module and lessons that do not.
  * The borders are now in the modules instead of the whole course outline block. The border-style setting continues in the course outline block though.
  * The orphan lessons are without border, regardless of the customizations.
* This PR also fixes the style examples of the course outline block and of the module block.
* It also introduces an extra padding in the Course Outline Block inside the editor to make the block selection easier.

### Testing instructions

* Create a course.
* Add modules with lessons, and independent lessons (in the course outline block level).
* Save it and visit the frontend course page. Make sure the styles working properly as the editor.
* In the editor, check the styles examples (thumbnails in the sidebar) of the course outline block and of the module. And make sure the lessons in the module InnerBlocks are appearing.
* Also make sure that the Course Outline Block contains extra padding in the editor and it's easier to select that.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

#### With border - expanded

<img width="606" alt="Screen Shot 2020-10-20 at 17 03 14" src="https://user-images.githubusercontent.com/876340/96638309-4abbab80-12f6-11eb-9537-cc87672e3cb3.png">

#### With border - collapsed

<img width="604" alt="Screen Shot 2020-10-20 at 17 03 21" src="https://user-images.githubusercontent.com/876340/96638319-4db69c00-12f6-11eb-98a6-329e5179f716.png">

#### Without border - expanded

<img width="596" alt="Screen Shot 2020-10-20 at 17 03 44" src="https://user-images.githubusercontent.com/876340/96638328-4f805f80-12f6-11eb-87c3-87f6eb538c78.png">

#### Without border - collapsed

<img width="605" alt="Screen Shot 2020-10-20 at 17 03 51" src="https://user-images.githubusercontent.com/876340/96638334-51e2b980-12f6-11eb-8845-590e278f0cdf.png">

#### Padding in the Course Outline Block editor

<img width="642" alt="Screen Shot 2020-10-23 at 16 08 53" src="https://user-images.githubusercontent.com/876340/97044232-29eb9400-154a-11eb-9cfe-8a6232b31f40.png">
