### PR TITLE
Fix preferred assert method: change to assertSame

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -68,6 +68,6 @@ You can run specific tests by providing the path and filename to the test class.
 * Each test file should roughly correspond to an associated source file, e.g. the `test-class-woothemes-sensei.php` test file covers code in `class-woothemes-sensei.php`.
 * Each test method should cover a single method or function with one or more assertions.
 * A single method or function can have multiple associated test methods if it's a large or complex method.
-* Prefer `assertsEquals()` where possible as it tests both type & equality.
+* Prefer `assertSame()` where possible as it tests both type & equality.
 * Remember that only methods prefixed with `test` will be run.
 * Filters persist between test cases so be sure to remove them in your test method or in the `tearDown()` method.


### PR DESCRIPTION
Fixes #

### Changes proposed in this Pull Request

Probably there is an error with `assertsEquals` in the documentation.
1. There is no assertsEquals method in PHPUnit or inside sensei repository. Probably it was supposed to be assertEquals.
2. But [assertEquals](https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertEquals) doesn't check type, [assertSame](https://phpunit.de/manual/6.5/en/appendixes.assertions.html#appendixes.assertions.assertSame) makes this check.