### PR TITLE
Add Exit Survey

### DIFF
--- a/assets/admin/exit-survey/exit-survey.scss
+++ b/assets/admin/exit-survey/exit-survey.scss
@@ -50,7 +50,7 @@
 	left: 0;
 	right: 0;
 	bottom: 0;
-	background: rgba(#000, 0.3);
+	background: rgba(#000, 0.7);
 	display: flex;
 	align-items: center;
 	justify-content: center;

--- a/assets/admin/exit-survey/exit-survey.scss
+++ b/assets/admin/exit-survey/exit-survey.scss
@@ -1,0 +1,66 @@
+
+.sensei-exit-survey {
+
+	@import '../../shared/styles/wp-admin';
+
+	display: flex;
+	flex-direction: column;
+	background: #fff;
+	font-size: 14px;
+	line-height: 1.5;
+
+	&__content {
+		flex: 1;
+		padding: 20px;
+	}
+
+	&__buttons {
+		padding: 20px;
+		display: flex;
+		justify-content: center;
+
+		.button {
+			margin: 0 5px;
+		}
+	}
+
+	&__item {
+		margin: 15px 0;
+	}
+
+	&__details {
+		margin: 15px 0;
+		margin-left: 25px;
+
+		input {
+			width: 100%;
+			padding: 4px 8px;
+		}
+	}
+
+	&__radio:not(:checked) ~ &__details {
+		display: none;
+	}
+
+}
+
+#sensei-exit-survey-modal {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(#000, 0.3);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 100050;
+
+	.sensei-modal {
+		width: 36rem;
+		height: 36rem;
+		background: #fff;
+		box-shadow: 0 3px 6px rgba(#ccc, 0.3);
+		border-radius: 3px;
+	}
+}

--- a/assets/admin/exit-survey/form-item.js
+++ b/assets/admin/exit-survey/form-item.js
@@ -6,6 +6,7 @@
  * @param {string} props.label        Option text label.
  * @param {string} props.detailsLabel Label for details field.
  */
+
 export const ExitSurveyFormItem = ( { id, label, detailsLabel } ) => {
 	const idAttr = `sensei-exit-reason__${ id }`;
 	const detailsIdAttr = `${ idAttr }-details`;
@@ -24,6 +25,7 @@ export const ExitSurveyFormItem = ( { id, label, detailsLabel } ) => {
 					<input
 						id={ detailsIdAttr }
 						name={ `details-${ id }` }
+						defaultValue=""
 						type="text"
 						placeholder={ detailsLabel }
 					/>

--- a/assets/admin/exit-survey/form-item.js
+++ b/assets/admin/exit-survey/form-item.js
@@ -1,0 +1,34 @@
+/**
+ * Exit survey reason item with details text field.
+ *
+ * @param {Object} props
+ * @param {string} props.id           Option key.
+ * @param {string} props.label        Option text label.
+ * @param {string} props.detailsLabel Label for details field.
+ */
+export const ExitSurveyFormItem = ( { id, label, detailsLabel } ) => {
+	const idAttr = `sensei-exit-reason__${ id }`;
+	const detailsIdAttr = `${ idAttr }-details`;
+	return (
+		<div key={ label } className="sensei-exit-survey__item">
+			<input
+				id={ idAttr }
+				type="radio"
+				name="reason"
+				value={ id }
+				className="sensei-exit-survey__radio"
+			/>
+			<label htmlFor={ idAttr }> { label }</label>
+			{ detailsLabel && (
+				<div className="sensei-exit-survey__details">
+					<input
+						id={ detailsIdAttr }
+						name={ `details-${ id }` }
+						type="text"
+						placeholder={ detailsLabel }
+					/>
+				</div>
+			) }
+		</div>
+	);
+};

--- a/assets/admin/exit-survey/form-item.js
+++ b/assets/admin/exit-survey/form-item.js
@@ -6,7 +6,6 @@
  * @param {string} props.label        Option text label.
  * @param {string} props.detailsLabel Label for details field.
  */
-
 export const ExitSurveyFormItem = ( { id, label, detailsLabel } ) => {
 	const idAttr = `sensei-exit-reason__${ id }`;
 	const detailsIdAttr = `${ idAttr }-details`;

--- a/assets/admin/exit-survey/form-item.js
+++ b/assets/admin/exit-survey/form-item.js
@@ -10,7 +10,7 @@ export const ExitSurveyFormItem = ( { id, label, detailsLabel } ) => {
 	const idAttr = `sensei-exit-reason__${ id }`;
 	const detailsIdAttr = `${ idAttr }-details`;
 	return (
-		<div key={ label } className="sensei-exit-survey__item">
+		<div className="sensei-exit-survey__item">
 			<input
 				id={ idAttr }
 				type="radio"

--- a/assets/admin/exit-survey/form.js
+++ b/assets/admin/exit-survey/form.js
@@ -44,7 +44,9 @@ export const ExitSurveyForm = ( { submit, skip } ) => {
 						'sensei-lms'
 					) }
 				</p>
-				{ reasons.map( ExitSurveyFormItem ) }
+				{ reasons.map( ( reason ) => (
+					<ExitSurveyFormItem key={ reason.id } { ...reason } />
+				) ) }
 			</div>
 			<div className="sensei-exit-survey__buttons">
 				<button

--- a/assets/admin/exit-survey/form.js
+++ b/assets/admin/exit-survey/form.js
@@ -1,0 +1,67 @@
+import { useCallback, useRef, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { ExitSurveyFormItem } from './form-item';
+import { reasons } from './reasons';
+
+/**
+ * Exit survey form.
+ *
+ * @param {Object}   props
+ * @param {Function} props.submit Callback to submit feedback.
+ * @param {Function} props.skip   Callback to skip feedback.
+ */
+export const ExitSurveyForm = ( { submit, skip } ) => {
+	const form = useRef( null );
+	const [ , updateInput ] = useState( null );
+
+	const submitForm = useCallback(
+		( e ) => {
+			e.preventDefault();
+			const formData = new window.FormData( form.current );
+			const reason = formData.get( 'reason' );
+			submit( {
+				reason,
+				details: reason && formData.get( `details-${ reason }` ),
+			} );
+		},
+		[ submit ]
+	);
+
+	const hasInput = !! form.current?.elements?.reason?.value;
+
+	return (
+		<form
+			onChange={ updateInput }
+			className="sensei-modal sensei-exit-survey"
+			ref={ form }
+			onSubmit={ submitForm }
+		>
+			<div className="sensei-exit-survey__content">
+				<h2>{ __( 'Quick Feedback', 'sensei-lms' ) }</h2>
+				<p>
+					{ __(
+						'If you have a moment, please let us know why you are deactivating so that we can work to improve our product.',
+						'sensei-lms'
+					) }
+				</p>
+				{ reasons.map( ExitSurveyFormItem ) }
+			</div>
+			<div className="sensei-exit-survey__buttons">
+				<button
+					className="button button-primary"
+					type="submit"
+					disabled={ ! hasInput }
+				>
+					{ __( 'Submit Feedback', 'sensei-lms' ) }
+				</button>
+				<button
+					className="button button-secondary"
+					onClick={ skip }
+					type="button"
+				>
+					{ __( 'Skip Feedback', 'sensei-lms' ) }
+				</button>
+			</div>
+		</form>
+	);
+};

--- a/assets/admin/exit-survey/form.test.js
+++ b/assets/admin/exit-survey/form.test.js
@@ -1,0 +1,52 @@
+import { screen, render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ExitSurveyForm } from './form';
+import '@testing-library/jest-dom';
+
+describe( '<ExitSurveyForm />', () => {
+	beforeEach( () => {} );
+
+	const buttons = {
+		submit: () => screen.getByRole( 'button', { name: 'Submit Feedback' } ),
+		skip: () => screen.getByRole( 'button', { name: 'Skip Feedback' } ),
+	};
+
+	it( 'Submit is disabled until an item is selected', () => {
+		const { getByLabelText } = render( <ExitSurveyForm /> );
+
+		expect( buttons.submit() ).toBeDisabled();
+
+		userEvent.click( getByLabelText( 'I found a better plugin' ) );
+
+		expect( buttons.submit() ).not.toBeDisabled();
+	} );
+
+	it( 'Skip button skips submission', () => {
+		const skip = jest.fn();
+		const submit = jest.fn();
+		render( <ExitSurveyForm submit={ submit } skip={ skip } /> );
+		userEvent.click( buttons.skip() );
+
+		expect( skip ).toHaveBeenCalled();
+		expect( submit ).not.toHaveBeenCalled();
+	} );
+
+	it( 'Submits selected reason and details', () => {
+		const submit = jest.fn();
+		const { getByLabelText, getByPlaceholderText } = render(
+			<ExitSurveyForm submit={ submit } />
+		);
+
+		userEvent.click( getByLabelText( 'I found a better plugin' ) );
+		userEvent.type(
+			getByPlaceholderText( "What's the name of the plugin?" ),
+			'Test detail'
+		);
+		userEvent.click( buttons.submit() );
+
+		expect( submit ).toHaveBeenCalledWith( {
+			reason: 'found-better-plugin',
+			details: 'Test detail',
+		} );
+	} );
+} );

--- a/assets/admin/exit-survey/index.js
+++ b/assets/admin/exit-survey/index.js
@@ -27,6 +27,9 @@ import { render } from '@wordpress/element';
 		} );
 	};
 
+	/**
+	 * Exit survey modal.
+	 */
 	class ExitSurveyModal {
 		href;
 		container;
@@ -40,7 +43,7 @@ import { render } from '@wordpress/element';
 			this.href = href;
 		}
 		/**
-		 * Open exit survey modal.
+		 * Create and open a modal with an exit survey form.
 		 *
 		 */
 		open = () => {

--- a/assets/admin/exit-survey/index.js
+++ b/assets/admin/exit-survey/index.js
@@ -1,0 +1,95 @@
+import { ExitSurveyForm } from './form';
+import { render } from '@wordpress/element';
+
+( function senseiExitSurvey() {
+	/**
+	 * Add exit survey modal when clicking the Deactivate link for Sensei LMS plugin.
+	 */
+	const addExitSurveyOnDeactivate = () => {
+		const getDeactivateLinkElement = ( slug ) =>
+			document.querySelector(
+				`#the-list [data-slug="${ slug }"] span.deactivate a`
+			);
+
+		const deactivateLinks = [
+			getDeactivateLinkElement( 'sensei-lms' ),
+			getDeactivateLinkElement( 'woothemes-sensei' ),
+		].filter( ( e ) => !! e );
+
+		deactivateLinks.forEach( ( link ) => {
+			link.addEventListener( 'click', ( event ) => {
+				event.preventDefault();
+
+				new ExitSurveyModal( {
+					href: event.target.href,
+				} ).open();
+			} );
+		} );
+	};
+
+	class ExitSurveyModal {
+		href;
+		container;
+
+		/**
+		 * Exit survey constructor.
+		 *
+		 * @param {string} href Link to deactivate plugin.
+		 */
+		constructor( { href } ) {
+			this.href = href;
+		}
+		/**
+		 * Open exit survey modal.
+		 *
+		 */
+		open = () => {
+			let container = document.querySelector( '#sensei-exit-survey' );
+			if ( ! container ) {
+				container = document.createElement( 'div' );
+				container.setAttribute( 'id', 'sensei-exit-survey-modal' );
+				document.body.appendChild( container );
+			}
+
+			this.container = container;
+
+			render(
+				<ExitSurveyForm
+					submit={ this.submitExitSurvey }
+					skip={ this.closeAndDeactivate }
+				/>,
+				container
+			);
+		};
+
+		/**
+		 * Submit exit survey to AJAX endpoint.
+		 *
+		 * @param {Object} data
+		 */
+		submitExitSurvey = async ( data ) => {
+			const body = new window.FormData();
+			body.append( 'action', 'exit_survey' );
+			body.append( '_wpnonce', window.sensei_exit_survey?.nonce );
+			body.append( 'reason', data.reason );
+			body.append( 'details', data.details );
+
+			await window.fetch( window.ajaxurl, {
+				method: 'POST',
+				body,
+			} );
+
+			this.closeAndDeactivate();
+		};
+
+		/**
+		 * Close survey modal and continue plugin deactivation.
+		 */
+		closeAndDeactivate = () => {
+			this.container.remove();
+			window.location = this.href;
+		};
+	}
+
+	addExitSurveyOnDeactivate();
+} )();

--- a/assets/admin/exit-survey/reasons.js
+++ b/assets/admin/exit-survey/reasons.js
@@ -1,0 +1,35 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Exit survey reasons
+ */
+export const reasons = [
+	{
+		id: 'no-longer-need',
+		label: __( 'I no longer need the plugin', 'sensei-lms' ),
+	},
+	{
+		id: 'not-working',
+		label: __( "The plugin isn't working", 'sensei-lms' ),
+		detailsLabel: __( "What isn't working properly?", 'sensei-lms' ),
+	},
+	{
+		id: 'different-functionality',
+		label: __( "I'm looking for different functionality", 'sensei-lms' ),
+		detailsLabel: __( 'What functionality is missing?', 'sensei-lms' ),
+	},
+	{
+		id: 'found-better-plugin',
+		label: __( 'I found a better plugin', 'sensei-lms' ),
+		detailsLabel: __( "What's the name of the plugin?", 'sensei-lms' ),
+	},
+	{
+		id: 'temporary',
+		label: __( "It's a temporary deactivation", 'sensei-lms' ),
+	},
+	{
+		id: 'other',
+		label: 'Other',
+		detailsLabel: __( 'Why are you deactivating?', 'sensei-lms' ),
+	},
+];

--- a/assets/shared/styles/wp-admin.scss
+++ b/assets/shared/styles/wp-admin.scss
@@ -1,0 +1,56 @@
+@import 'variables';
+
+.button {
+	background-color: transparent;
+	border-color: $primary;
+	color: $primary;
+	padding: 6px 12px;
+	border-radius: 2px;
+
+	&:hover,
+	&:active {
+		color: lighten($primary, 5%);
+		border-color: lighten($primary, 5%);
+	}
+
+	&:focus {
+		color: darken($primary, 5%);
+		border-color: darken($primary, 5%);
+	}
+}
+
+.button.button-primary {
+	background-color: $primary;
+	border-color: $primary;
+	color: #fff;
+
+	&:hover,
+	&:active {
+		background-color: lighten($primary, 5%);
+		border-color: lighten($primary, 5%);
+	}
+
+	&:focus {
+		background-color: darken($primary, 5%);
+		border-color: darken($primary, 5%);
+		box-shadow: 0 0 0 1px #fff, 0 0 0 3px $primary;
+	}
+}
+
+.button.button-secondary {
+	&:hover, &:active {
+		background-color: transparent;
+	}
+
+	&:focus {
+		box-shadow: 0 0 0 1px $primary;
+	}
+}
+
+input[type=radio],
+input[type=text] {
+	&:focus {
+		border-color: $primary;
+		box-shadow: 0 0 0 1px $primary;
+	}
+}

--- a/includes/admin/class-sensei-exit-survey.php
+++ b/includes/admin/class-sensei-exit-survey.php
@@ -63,7 +63,11 @@ class Sensei_Exit_Survey {
 
 		update_option( 'sensei_exit_survey_data', $feedback );
 
-		Sensei()->usage_tracking->send_anonymous_event( 'plugin_deactivate', $feedback );
+		if ( Sensei()->usage_tracking->is_tracking_enabled() ) {
+			Sensei()->usage_tracking->send_event( 'plugin_deactivate', $feedback );
+		} else {
+			Sensei()->usage_tracking->send_anonymous_event( 'plugin_deactivate', $feedback );
+		}
 	}
 
 }

--- a/includes/admin/class-sensei-exit-survey.php
+++ b/includes/admin/class-sensei-exit-survey.php
@@ -64,7 +64,7 @@ class Sensei_Exit_Survey {
 		update_option( 'sensei_exit_survey_data', $feedback );
 
 		if ( Sensei()->usage_tracking->is_tracking_enabled() ) {
-			Sensei()->usage_tracking->send_event( 'plugin_deactivate', $feedback );
+			sensei_log_event( 'plugin_deactivate', $feedback );
 		} else {
 			Sensei()->usage_tracking->send_anonymous_event( 'plugin_deactivate', $feedback );
 		}

--- a/includes/admin/class-sensei-exit-survey.php
+++ b/includes/admin/class-sensei-exit-survey.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * File containing Sensei_Exit_Survey class.
+ *
+ * @package Sensei\Admin
+ * @since   3.5.3
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Exit survey upon plugin deactivation.
+ *
+ * @since 3.5.3
+ */
+class Sensei_Exit_Survey {
+
+
+	/**
+	 * Sensei_Exit_Survey constructor.
+	 */
+	public function __construct() {
+		add_action( 'wp_ajax_exit_survey', array( $this, 'save_exit_survey' ) );
+
+	}
+
+	/**
+	 * Save feedback from exit survey AJAX request.
+	 */
+	public function save_exit_survey() {
+		check_ajax_referer( 'sensei_exit_survey' );
+
+		$feedback = [
+			'reason'  => isset( $_POST['reason'] ) ? sanitize_text_field( wp_unslash( $_POST['reason'] ) ) : null,
+			'details' => isset( $_POST['details'] ) ? sanitize_text_field( wp_unslash( $_POST['details'] ) ) : null,
+		];
+
+		update_option( 'sensei_exit_survey_data', $feedback );
+
+		sensei_log_event( 'deactivate', $feedback );
+	}
+
+}

--- a/includes/admin/class-sensei-exit-survey.php
+++ b/includes/admin/class-sensei-exit-survey.php
@@ -63,7 +63,7 @@ class Sensei_Exit_Survey {
 
 		update_option( 'sensei_exit_survey_data', $feedback );
 
-		sensei_log_event( 'deactivate', $feedback );
+		Sensei()->usage_tracking->send_anonymous_event( 'deactivate', $feedback );
 	}
 
 }

--- a/includes/admin/class-sensei-exit-survey.php
+++ b/includes/admin/class-sensei-exit-survey.php
@@ -63,7 +63,7 @@ class Sensei_Exit_Survey {
 
 		update_option( 'sensei_exit_survey_data', $feedback );
 
-		Sensei()->usage_tracking->send_anonymous_event( 'deactivate', $feedback );
+		Sensei()->usage_tracking->send_anonymous_event( 'plugin_deactivate', $feedback );
 	}
 
 }

--- a/includes/admin/class-sensei-exit-survey.php
+++ b/includes/admin/class-sensei-exit-survey.php
@@ -22,8 +22,32 @@ class Sensei_Exit_Survey {
 	 * Sensei_Exit_Survey constructor.
 	 */
 	public function __construct() {
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
 		add_action( 'wp_ajax_exit_survey', array( $this, 'save_exit_survey' ) );
 
+	}
+
+	/**
+	 * Enqueues admin scripts when needed on different screens.
+	 *
+	 * @since  2.0.0
+	 * @access private
+	 */
+	public function enqueue_admin_assets() {
+		$screen = get_current_screen();
+		if ( in_array( $screen->id, [ 'plugins', 'plugins-network' ], true ) ) {
+			Sensei()->assets->enqueue( 'sensei-admin-exit-survey', 'admin/exit-survey/index.js', [], true );
+			Sensei()->assets->enqueue( 'sensei-admin-exit-survey', 'admin/exit-survey/exit-survey.css', [], 'screen' );
+			wp_set_script_translations( 'sensei-admin-exit-survey', 'sensei-lms' );
+
+			wp_localize_script(
+				'sensei-admin-exit-survey',
+				'sensei_exit_survey',
+				[
+					'nonce' => wp_create_nonce( 'sensei_exit_survey' ),
+				]
+			);
+		}
 	}
 
 	/**

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -111,6 +111,7 @@ class Sensei_Autoloader {
 			 */
 			'Sensei_Learner_Management'                  => 'admin/class-sensei-learner-management.php',
 			'Sensei_Extensions'                          => 'admin/class-sensei-extensions.php',
+			'Sensei_Exit_Survey'                         => 'admin/class-sensei-exit-survey.php',
 			'Sensei_Learners_Admin_Bulk_Actions_Controller' => 'admin/class-sensei-learners-admin-bulk-actions-controller.php',
 			'Sensei_Learners_Admin_Bulk_Actions_View'    => 'admin/class-sensei-learners-admin-bulk-actions-view.php',
 			'Sensei_Learners_Main'                       => 'admin/class-sensei-learners-main.php',

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -61,6 +61,7 @@ class Sensei_Data_Cleaner {
 		'sensei_suggest_setup_wizard',
 		'sensei-data-port-jobs',
 		'sensei_setup_wizard_data',
+		'sensei_exit_survey_data',
 		'sensei_flush_rewrite_rules',
 		'sensei_needs_language_pack_install',
 		'woothemes_sensei_language_pack_version',

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -409,6 +409,8 @@ class Sensei_Main {
 			new Sensei_Import();
 			new Sensei_Export();
 
+			new Sensei_Exit_Survey();
+
 			if ( $this->feature_flags->is_enabled( 'rest_api_testharness' ) ) {
 				$this->test_harness = new Sensei_Admin_Rest_Api_Testharness( $this->main_plugin_file_name );
 			}

--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -4,7 +4,7 @@
  * Tracks.
  *
  * @package Sensei
- **/
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -27,14 +27,14 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * The name of the cron job action for regularly logging usage data.
 	 *
 	 * @var string
-	 **/
+	 */
 	private $job_name;
 
 	/**
 	 * Callback function for the usage tracking job.
 	 *
 	 * @var array
-	 **/
+	 */
 	private $callback;
 
 
@@ -46,7 +46,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * Subclass instances.
 	 *
 	 * @var array
-	 **/
+	 */
 	private static $instances = array();
 
 	/**
@@ -61,6 +61,8 @@ abstract class Sensei_Usage_Tracking_Base {
 	 *
 	 * This function cannot be abstract (because it is static) but it *must* be
 	 * implemented by subclasses.
+	 *
+	 * @throws Exception Method is not implemented in subclass.
 	 */
 	public static function get_instance() {
 		throw new Exception( 'Usage Tracking subclasses must implement get_instance. See class-usage-tracking-base.php' );
@@ -76,7 +78,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * Get prefix for actions and strings. Should be unique to this plugin.
 	 *
 	 * @return string The prefix string
-	 **/
+	 */
 	abstract protected function get_prefix();
 
 	/**
@@ -84,14 +86,14 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * strings to be translated.
 	 *
 	 * @return string The text domain string
-	 **/
+	 */
 	abstract protected function get_text_domain();
 
 	/**
 	 * Determine whether usage tracking is enabled.
 	 *
 	 * @return bool true if usage tracking is enabled, false otherwise.
-	 **/
+	 */
 	abstract protected function get_tracking_enabled();
 
 	/**
@@ -99,7 +101,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 *
 	 * @param bool $enable true if usage tracking should be enabled, false if
 	 *                     it should be disabled.
-	 **/
+	 */
 	abstract protected function set_tracking_enabled( $enable );
 
 	/**
@@ -107,7 +109,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 *
 	 * @return bool true if the current user is allowed to manage the tracking
 	 * options, false otherwise.
-	 **/
+	 */
 	abstract protected function current_user_can_manage_tracking();
 
 	/**
@@ -116,7 +118,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * is being tracked.
 	 *
 	 * @return string the text to display in the opt-in dialog.
-	 **/
+	 */
 	abstract protected function opt_in_dialog_text();
 
 	/**
@@ -141,7 +143,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * This class is meant to be a singleton, and assumes that the subclass is
 	 * implemented as such. If multiple instances are instantiated, the results
 	 * are undefined.
-	 **/
+	 */
 	protected function __construct() {
 		// Init instance vars.
 		$this->job_name = $this->get_prefix() . '_usage_tracking_send_usage_data';
@@ -176,7 +178,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * data to be logged periodically to Tracks.
 	 *
 	 * @param callable $callback the callback returning the usage data to be logged.
-	 **/
+	 */
 	public function set_callback( $callback ) {
 		$this->callback = $callback;
 	}
@@ -282,7 +284,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * Set up a regular cron job to send usage data. The job will only send
 	 * the data if tracking is enabled, so it is safe to call this function,
 	 * and schedule the job, before the user opts into tracking.
-	 **/
+	 */
 	public function schedule_tracking_task() {
 		if ( ! wp_next_scheduled( $this->job_name ) ) {
 			wp_schedule_event( time(), $this->get_prefix() . '_usage_tracking_two_weeks', $this->job_name );
@@ -292,7 +294,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	/**
 	 * Unschedule the job scheduled by schedule_tracking_task if any is
 	 * scheduled. This should be called on plugin deactivation.
-	 **/
+	 */
 	public function unschedule_tracking_task() {
 		if ( wp_next_scheduled( $this->job_name ) ) {
 			wp_clear_scheduled_hook( $this->job_name );
@@ -303,7 +305,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * Check if tracking is enabled.
 	 *
 	 * @return bool true if tracking is enabled, false otherwise
-	 **/
+	 */
 	public function is_tracking_enabled() {
 		// Defer to the plugin-specific function.
 		return $this->get_tracking_enabled();
@@ -312,7 +314,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	/**
 	 * Call the usage data callback and send the usage data to Tracks. Only
 	 * sends data if tracking is enabled.
-	 **/
+	 */
 	public function send_usage_data() {
 		if ( ! self::is_tracking_enabled() || ! is_callable( $this->callback ) ) {
 			return;
@@ -347,7 +349,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * externally.
 	 *
 	 * @param array $schedules the existing cron schedules.
-	 **/
+	 */
 	public function add_usage_tracking_two_week_schedule( $schedules ) {
 		$day_in_seconds = 86400;
 		$schedules[ $this->get_prefix() . '_usage_tracking_two_weeks' ] = array(
@@ -453,7 +455,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * Hide the opt-in for enabling usage tracking.
 	 *
 	 * @deprecated 3.1.0 - Opt-in moved to Setup Wizard
-	 **/
+	 */
 	protected function hide_tracking_opt_in() {
 		_deprecated_function( __METHOD__, '3.1.0', 'Sensei_Setup_Wizard::skip_setup_wizard' );
 	}
@@ -462,7 +464,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * Determine whether the opt-in for enabling usage tracking is hidden.
 	 *
 	 * @deprecated 3.1.0 - Opt-in moved to Setup Wizard
-	 **/
+	 */
 	protected function is_opt_in_hidden() {
 		_deprecated_function( __METHOD__, '3.1.0', 'Sensei_Setup_Wizard::setup_wizard_notice' );
 	}
@@ -472,7 +474,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * text.
 	 *
 	 * @deprecated 3.1.0 - Opt-in moved to Setup Wizard
-	 **/
+	 */
 	protected function opt_in_dialog_text_allowed_html() {
 		_deprecated_function( __METHOD__, '3.1.0', 'Sensei_Setup_Wizard::setup_wizard_notice' );
 	}
@@ -482,7 +484,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * called externally.
 	 *
 	 * @deprecated 3.1.0 - Opt-in moved to Setup Wizard
-	 **/
+	 */
 	public function maybe_display_tracking_opt_in() {
 		_deprecated_function( __METHOD__, '3.1.0', 'Sensei_Setup_Wizard::setup_wizard_notice' );
 	}
@@ -492,7 +494,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * externally.
 	 *
 	 * @deprecated 3.1.0 - Opt-in moved to Setup Wizard
-	 **/
+	 */
 	public function handle_tracking_opt_in() {
 		_deprecated_function( __METHOD__, '3.1.0', 'Sensei_Setup_Wizard::setup_wizard_notice' );
 	}
@@ -502,7 +504,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * on it. Should not be called externally.
 	 *
 	 * @deprecated 3.1.0
-	 **/
+	 */
 	public function enqueue_script_deps() {
 		_deprecated_function( __METHOD__, '3.1.0' );
 	}
@@ -512,7 +514,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * externally.
 	 *
 	 * @deprecated 3.1.0
-	 **/
+	 */
 	public function output_opt_in_js() {
 		_deprecated_function( __METHOD__, '3.1.0' );
 	}

--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -181,12 +181,12 @@ abstract class Sensei_Usage_Tracking_Base {
 	}
 
 	/**
-	 * Send an event to Tracks if tracking is enabled.
+	 * Send an event to Tracks if tracking is enabled, including site information.
 	 *
-	 * @param string   $event The event name. The prefix string will be
-	 *   automatically prepended to this, so please supply this string without a
-	 *   prefix.
-	 * @param array    $properties Event Properties.
+	 * @param string   $event           The event name. The prefix string will be
+	 *                                  automatically prepended to this, so please supply this string without a
+	 *                                  prefix.
+	 * @param array    $properties      Event Properties.
 	 * @param null|int $event_timestamp When the event occurred.
 	 *
 	 * @return bool
@@ -198,13 +198,7 @@ abstract class Sensei_Usage_Tracking_Base {
 			return false;
 		}
 
-		$pixel      = 'https://pixel.wp.com/t.gif';
-		$event_name = $this->get_event_prefix() . '_' . $event;
-		$user       = wp_get_current_user();
-
-		if ( null === $event_timestamp ) {
-			$event_timestamp = time();
-		}
+		$user = wp_get_current_user();
 
 		$properties['admin_email'] = get_option( 'admin_email' );
 		$properties['_ut']         = $this->get_event_prefix() . ':site_url';
@@ -213,6 +207,32 @@ abstract class Sensei_Usage_Tracking_Base {
 		// to ever add event tracking at the user level.
 		$properties['_ui'] = str_replace( 'www.', '', wp_parse_url( site_url(), PHP_URL_HOST ) );
 		$properties['_ul'] = $user->user_login;
+
+		return $this->send_anonymous_event( $event, $properties, $event_timestamp );
+
+	}
+
+
+	/**
+	 * Send an event to Tracks.
+	 *
+	 * @param string   $event           The event name. The prefix string will be
+	 *                                  automatically prepended to this, so please supply this string without a
+	 *                                  prefix.
+	 * @param array    $properties      Event Properties.
+	 * @param null|int $event_timestamp When the event occurred.
+	 *
+	 * @return bool
+	 **/
+	public function send_anonymous_event( $event, $properties = array(), $event_timestamp = null ) {
+
+		$pixel      = 'https://pixel.wp.com/t.gif';
+		$event_name = $this->get_event_prefix() . '_' . $event;
+
+		if ( null === $event_timestamp ) {
+			$event_timestamp = time();
+		}
+
 		$properties['_en'] = $event_name;
 		$properties['_ts'] = $event_timestamp . '000';
 		$properties['_rt'] = round( microtime( true ) * 1000 );  // log time.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11469,6 +11469,26 @@
         "@types/testing-library__react-hooks": "^3.0.0"
       }
     },
+    "@testing-library/user-event": {
+      "version": "12.1.9",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.1.9.tgz",
+      "integrity": "sha512-1LlqPjj/tRvC+y5eqQDGRFzG2QaVqKVMCNN7pg9p73D8/HrwZozO8jlhXKWPmemFe6BhVwaDiKMTX5AoN9u9Yw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.10.2"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+          "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        }
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11298,6 +11298,146 @@
         }
       }
     },
+    "@testing-library/jest-dom": {
+      "version": "5.11.4",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.11.4.tgz",
+      "integrity": "sha512-6RRn3epuweBODDIv3dAlWjOEHQLpGJHB2i912VS3JQtsD22+ENInhdDNl4ZZQiViLlIfFinkSET/J736ytV9sw==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.9.2",
+        "@types/testing-library__jest-dom": "^5.9.1",
+        "aria-query": "^4.2.2",
+        "chalk": "^3.0.0",
+        "css": "^3.0.0",
+        "css.escape": "^1.5.1",
+        "lodash": "^4.17.15",
+        "redent": "^3.0.0"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.12.1",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.12.1.tgz",
+          "integrity": "sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==",
+          "dev": true,
+          "requires": {
+            "regenerator-runtime": "^0.13.4"
+          }
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "atob": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+          "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "css": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/css/-/css-3.0.0.tgz",
+          "integrity": "sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==",
+          "dev": true,
+          "requires": {
+            "inherits": "^2.0.4",
+            "source-map": "^0.6.1",
+            "source-map-resolve": "^0.6.0"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "indent-string": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+          "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+          "dev": true
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "dev": true
+        },
+        "redent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+          "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+          "dev": true,
+          "requires": {
+            "indent-string": "^4.0.0",
+            "strip-indent": "^3.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "source-map-resolve": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.6.0.tgz",
+          "integrity": "sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==",
+          "dev": true,
+          "requires": {
+            "atob": "^2.1.2",
+            "decode-uri-component": "^0.2.0"
+          }
+        },
+        "strip-indent": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+          "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+          "dev": true,
+          "requires": {
+            "min-indent": "^1.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "@testing-library/react": {
       "version": "10.4.8",
       "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-10.4.8.tgz",
@@ -11586,6 +11726,15 @@
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
       "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==",
       "dev": true
+    },
+    "@types/testing-library__jest-dom": {
+      "version": "5.9.5",
+      "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz",
+      "integrity": "sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==",
+      "dev": true,
+      "requires": {
+        "@types/jest": "*"
+      }
     },
     "@types/testing-library__react-hooks": {
       "version": "3.4.0",
@@ -19337,6 +19486,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
       "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+      "dev": true
+    },
+    "css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=",
       "dev": true
     },
     "cssesc": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@babel/core": "7.11.1",
     "@babel/preset-env": "7.11.0",
     "@sheerun/mutationobserver-shim": "0.3.3",
+    "@testing-library/jest-dom": "5.11.4",
     "@testing-library/react": "10.4.8",
     "@testing-library/react-hooks": "3.3.0",
     "@woocommerce/e2e-environment": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@testing-library/jest-dom": "5.11.4",
     "@testing-library/react": "10.4.8",
     "@testing-library/react-hooks": "3.3.0",
+    "@testing-library/user-event": "12.1.9",
     "@woocommerce/e2e-environment": "0.1.5",
     "@wordpress/babel-plugin-makepot": "3.7.0",
     "@wordpress/babel-preset-default": "4.17.0",

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -112,21 +112,16 @@ export const AdminFlow = {
 
 		if ( deactivateLink ) {
 			await deactivateLink.click();
+			await page.click(
+				`#sensei-exit-survey-modal button:not(:disabled)`
+			);
 		}
 	},
 	activatePlugin: async ( slug, forceReactivate = false ) => {
 		await AdminFlow.goToPlugins();
 
-		const deactivateLink = await AdminFlow.findPluginAction(
-			slug,
-			'deactivate'
-		);
-
-		if ( deactivateLink ) {
-			if ( forceReactivate ) {
-				await deactivateLink.click();
-				await page.waitForNavigation();
-			} else return;
+		if ( forceReactivate ) {
+			await AdminFlow.deactivatePlugin();
 		}
 
 		const activate = await AdminFlow.findPluginAction( slug, 'activate' );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -1,7 +1,7 @@
 import { loginUser } from '@wordpress/e2e-test-utils';
 import { adminUrl } from './helpers';
 
-const isSessionCookieSet = function( cookies ) {
+const isSessionCookieSet = function ( cookies ) {
 	let result = false;
 
 	if ( ! Array.isArray( cookies ) ) {
@@ -112,9 +112,10 @@ export const AdminFlow = {
 
 		if ( deactivateLink ) {
 			await deactivateLink.click();
-			await page.click(
+			const exitSurvey = page.$(
 				`#sensei-exit-survey-modal button:not(:disabled)`
 			);
+			if ( exitSurvey ) await exitSurvey.click();
 		}
 	},
 	activatePlugin: async ( slug, forceReactivate = false ) => {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,7 +31,8 @@ const files = [
 	'data-port/import.js',
 	'data-port/export.js',
 	'data-port/style.scss',
-
+	'admin/exit-survey/index.js',
+	'admin/exit-survey/exit-survey.scss',
 	'css/frontend.scss',
 	'css/admin-custom.css',
 	'css/extensions.scss',


### PR DESCRIPTION
Fixes #2374

### Changes proposed in this Pull Request

* When clicking `Deactivate` on the plugins screen, open up a modal with an exit survey form
* Add AJAX action to save the submitted feedback and send track event 
* Send the event anonymously, with a hashed site ID, when usage tracking is disabled

### Testing instructions

* Go to the Plugins screen, and click `Deactivate` on the Sensei LMS plugin
* A modal should open up
* Clicking `Skip Feedback` should continue with deactivating plugin
-- 
* Do it again, select a reason, type in details and submit
* A `sensei_plugin_deactivate` track event should be sent, with the selected reason and details

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="590" alt="image" src="https://user-images.githubusercontent.com/176949/96722681-ef4cf480-13ad-11eb-91bf-3ee872ce26fc.png">


![QuickTime movie](https://user-images.githubusercontent.com/176949/96722578-d2182600-13ad-11eb-83bf-139df8c5f35d.gif)

