### PR TITLE
Add lesson preview badge to the course outline

### DIFF
--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -99,6 +99,7 @@ export const extractStructure = ( blocks ) => {
 		} ),
 		lesson: ( block ) => ( {
 			draft: block.attributes.draft,
+			preview: block.attributes.preview,
 		} ),
 	};
 

--- a/assets/blocks/course-outline/data.test.js
+++ b/assets/blocks/course-outline/data.test.js
@@ -36,6 +36,12 @@ describe( 'extractStructure', () => {
 				innerBlocks: [],
 				isValid: true,
 			},
+			{
+				name: 'sensei-lms/course-outline-lesson',
+				attributes: { title: 'L3', draft: true, preview: true },
+				innerBlocks: [],
+				isValid: true,
+			},
 		] );
 
 		expect( data ).toEqual( [
@@ -49,6 +55,7 @@ describe( 'extractStructure', () => {
 				],
 			},
 			{ type: 'lesson', title: 'L2' },
+			{ type: 'lesson', title: 'L3', draft: true, preview: true },
 		] );
 	} );
 } );

--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -23,6 +23,7 @@ import { COURSE_STATUS_STORE } from '../status-store';
  * @param {number}   props.attributes.id       Lesson Post ID
  * @param {number}   props.attributes.fontSize Lesson title font size.
  * @param {boolean}  props.attributes.draft    Draft status of lesson.
+ * @param {boolean}  props.attributes.preview  Whether lesson has preview enabled.
  * @param {Object}   props.backgroundColor     Background color object.
  * @param {Object}   props.textColor           Text color object.
  * @param {Function} props.setAttributes       Block set attributes function.
@@ -33,7 +34,7 @@ export const EditLessonBlock = ( props ) => {
 		clientId,
 		name,
 		className,
-		attributes: { title, id, fontSize, draft },
+		attributes: { title, id, fontSize, draft, preview },
 		backgroundColor,
 		textColor,
 		setAttributes,
@@ -145,6 +146,8 @@ export const EditLessonBlock = ( props ) => {
 					onKeyDown={ handleKeyDown }
 					style={ { fontSize } }
 				/>
+
+				{ preview && <span>Preview</span> }
 
 				{ postStatus && (
 					<div className="wp-block-sensei-lms-course-outline-lesson__post-status">

--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -149,7 +149,7 @@ export const EditLessonBlock = ( props ) => {
 
 				{ preview && (
 					<span className="wp-block-sensei-lms-course-outline-lesson__badge">
-						Preview
+						{ __( 'Preview', 'sensei-lms' ) }
 					</span>
 				) }
 

--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -147,7 +147,11 @@ export const EditLessonBlock = ( props ) => {
 					style={ { fontSize } }
 				/>
 
-				{ preview && <span>Preview</span> }
+				{ preview && (
+					<span className="wp-block-sensei-lms-course-outline-lesson__badge">
+						Preview
+					</span>
+				) }
 
 				{ postStatus && (
 					<div className="wp-block-sensei-lms-course-outline-lesson__post-status">

--- a/assets/blocks/course-outline/lesson-block/edit.test.js
+++ b/assets/blocks/course-outline/lesson-block/edit.test.js
@@ -57,6 +57,17 @@ describe( '<EditLessonBlock />', () => {
 		expect( container.querySelector( '.custom-class' ) ).toBeTruthy();
 	} );
 
+	it( 'Should render the edit lesson block with preview correctly', () => {
+		const { getByText } = render(
+			<EditLessonBlock
+				className="custom-class"
+				attributes={ { title: 'Test', preview: true } }
+			/>
+		);
+
+		expect( getByText( 'Preview' ) ).toBeTruthy();
+	} );
+
 	it( 'Should set the title attribute on changing the input value', () => {
 		const setAttributesMock = jest.fn();
 		const { getByPlaceholderText } = render(

--- a/assets/blocks/course-outline/lesson-block/lesson-block.scss
+++ b/assets/blocks/course-outline/lesson-block/lesson-block.scss
@@ -45,6 +45,17 @@
 		}
 	}
 
+	&__badge {
+		.wp-block-sensei-lms-course-outline-lesson & {
+			flex: 0 0 auto;
+			font-size: 0.6em;
+			color: $dark-gray;
+			border: solid 1px $dark-gray;
+			border-radius: 3px;
+			padding: 0 2px;
+		}
+	}
+
 	&__status {
 		display: inline-block;
 		width: 24px;

--- a/assets/blocks/course-outline/lesson-block/lesson-block.scss
+++ b/assets/blocks/course-outline/lesson-block/lesson-block.scss
@@ -49,10 +49,10 @@
 		.wp-block-sensei-lms-course-outline-lesson & {
 			flex: 0 0 auto;
 			font-size: 0.6em;
-			color: $dark-gray;
+			color: inherit;
 			text-transform: uppercase;
 			padding: 5px 10px;
-			border: solid 1px $dark-gray;
+			border: solid 1px currentColor;
 			border-radius: 3px;
 		}
 	}

--- a/assets/blocks/course-outline/lesson-block/lesson-block.scss
+++ b/assets/blocks/course-outline/lesson-block/lesson-block.scss
@@ -50,9 +50,10 @@
 			flex: 0 0 auto;
 			font-size: 0.6em;
 			color: $dark-gray;
+			text-transform: uppercase;
+			padding: 5px 10px;
 			border: solid 1px $dark-gray;
 			border-radius: 3px;
-			padding: 0 2px;
 		}
 	}
 

--- a/includes/blocks/class-sensei-course-outline-course-block.php
+++ b/includes/blocks/class-sensei-course-outline-course-block.php
@@ -73,7 +73,7 @@ class Sensei_Course_Outline_Course_Block {
 						}
 
 						if ( 'lesson' === $block['type'] ) {
-							return Sensei()->blocks->course_outline->lesson->render_lesson_block( $block );
+							return Sensei()->blocks->course_outline->lesson->render_lesson_block( $block, $post_id );
 						}
 					},
 					$blocks

--- a/includes/blocks/class-sensei-course-outline-lesson-block.php
+++ b/includes/blocks/class-sensei-course-outline-lesson-block.php
@@ -17,11 +17,12 @@ class Sensei_Course_Outline_Lesson_Block {
 	/**
 	 * Get lesson block HTML.
 	 *
-	 * @param array $block Block information.
+	 * @param array $block     Block information.
+	 * @param int   $course_id The course id.
 	 *
 	 * @return string Lesson HTML
 	 */
-	public function render_lesson_block( $block ) {
+	public function render_lesson_block( $block, $course_id ) {
 		$lesson_id = $block['id'];
 		$classes   = [ 'wp-block-sensei-lms-course-outline-lesson' ];
 
@@ -31,7 +32,12 @@ class Sensei_Course_Outline_Lesson_Block {
 			$classes[] = 'completed';
 		}
 
-		$css = Sensei_Block_Helpers::build_styles( $block['attributes'] ?? [], [], [ 'fontSize' => 'font-size' ] );
+		$css           = Sensei_Block_Helpers::build_styles( $block['attributes'] ?? [], [], [ 'fontSize' => 'font-size' ] );
+		$preview_badge = '';
+
+		if ( isset( $block['preview'] ) && true === $block['preview'] && ! Sensei_Course::is_user_enrolled( $course_id ) ) {
+			$preview_badge = '<span>Preview</span>';
+		}
 
 		return '
 			<a href="' . esc_url( get_permalink( $lesson_id ) ) . '" ' . Sensei_Block_Helpers::render_style_attributes( $classes, $css ) . '>
@@ -41,6 +47,7 @@ class Sensei_Course_Outline_Lesson_Block {
 				<span>
 					' . esc_html( $block['title'] ) . '
 				</span>
+				' . $preview_badge . '
 				<svg class="wp-block-sensei-lms-course-outline-lesson__chevron"><use xlink:href="#sensei-chevron-right"></use></svg>
 			</a>
 		';

--- a/includes/blocks/class-sensei-course-outline-lesson-block.php
+++ b/includes/blocks/class-sensei-course-outline-lesson-block.php
@@ -36,7 +36,7 @@ class Sensei_Course_Outline_Lesson_Block {
 		$preview_badge = '';
 
 		if ( isset( $block['preview'] ) && true === $block['preview'] && ! Sensei_Course::is_user_enrolled( $course_id ) ) {
-			$preview_badge = '<span>Preview</span>';
+			$preview_badge = '<span class="wp-block-sensei-lms-course-outline-lesson__badge">Preview</span>';
 		}
 
 		return '

--- a/includes/blocks/class-sensei-course-outline-lesson-block.php
+++ b/includes/blocks/class-sensei-course-outline-lesson-block.php
@@ -36,7 +36,11 @@ class Sensei_Course_Outline_Lesson_Block {
 		$preview_badge = '';
 
 		if ( isset( $block['preview'] ) && true === $block['preview'] && ! Sensei_Course::is_user_enrolled( $course_id ) ) {
-			$preview_badge = '<span class="wp-block-sensei-lms-course-outline-lesson__badge">Preview</span>';
+			$preview_badge = '
+				<span class="wp-block-sensei-lms-course-outline-lesson__badge">
+					' . esc_html__( 'Preview', 'sensei-lms' ) . '
+				</span>
+			';
 		}
 
 		return '

--- a/includes/blocks/class-sensei-course-outline-module-block.php
+++ b/includes/blocks/class-sensei-course-outline-module-block.php
@@ -90,7 +90,9 @@ class Sensei_Course_Outline_Module_Block {
 			implode(
 				'',
 				array_map(
-					[ Sensei()->blocks->course_outline->lesson, 'render_lesson_block' ],
+					function( $block ) use ( $course_id ) {
+						return Sensei()->blocks->course_outline->lesson->render_lesson_block( $block, $course_id );
+					},
 					$block['lessons']
 				)
 			)

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -151,10 +151,11 @@ class Sensei_Course_Structure {
 	 */
 	private function prepare_lesson( WP_Post $lesson_post ) : array {
 		return [
-			'type'  => 'lesson',
-			'id'    => $lesson_post->ID,
-			'title' => $lesson_post->post_title,
-			'draft' => 'draft' === $lesson_post->post_status,
+			'type'    => 'lesson',
+			'id'      => $lesson_post->ID,
+			'title'   => $lesson_post->post_title,
+			'draft'   => 'draft' === $lesson_post->post_status,
+			'preview' => Sensei_Utils::is_preview_lesson( $lesson_post->ID ),
 		];
 	}
 

--- a/tests/unit-tests/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/test-class-sensei-course-outline-block.php
@@ -48,6 +48,52 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 		$this->assertContains( 'Test Lesson', $result );
 	}
 
+	/**
+	 * Test lesson preview badge is rendered.
+	 */
+	public function testLessonPreviewRendered() {
+		$post_content = file_get_contents( 'sample-data/outline-block-post-content.html', true );
+
+		$this->mockPostCourseStructure(
+			[
+				[
+					'id'      => 1,
+					'type'    => 'lesson',
+					'title'   => 'Test Lesson',
+					'preview' => true,
+				],
+			]
+		);
+		$result = do_blocks( $post_content );
+
+		$this->assertContains( 'Preview', $result );
+	}
+
+	/**
+	 * Test lesson preview badge is not rendered.
+	 */
+	public function testLessonNoPreviewRendered() {
+		$post_content = file_get_contents( 'sample-data/outline-block-post-content.html', true );
+
+		$this->mockPostCourseStructure(
+			[
+				[
+					'id'      => 1,
+					'type'    => 'lesson',
+					'title'   => 'Test Lesson',
+					'preview' => false,
+				],
+				[
+					'id'    => 2,
+					'type'  => 'lesson',
+					'title' => 'Test Lesson 2',
+				],
+			]
+		);
+		$result = do_blocks( $post_content );
+
+		$this->assertNotContains( 'Preview', $result );
+	}
 
 	/**
 	 * Test module with a lesson in the structure is rendered.

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -287,6 +287,34 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test getting course structure with preview lesson.
+	 */
+	public function testGetPreviewLesson() {
+		$course_id = $this->factory->course->create();
+		$lessons   = $this->factory->lesson->create_many( 2 );
+
+		$expected_structure = [
+			[
+				'type'    => 'lesson',
+				'id'      => $lessons[0],
+				'preview' => false,
+			],
+			[
+				'type'    => 'lesson',
+				'id'      => $lessons[1],
+				'preview' => true,
+			],
+		];
+
+		$this->saveStructure( $course_id, $expected_structure );
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+		$structure        = $course_structure->get( 'view' );
+
+		$this->assertExpectedStructure( $expected_structure, $structure );
+	}
+
+	/**
 	 * Make sure new lessons are created when no ID is passed.
 	 */
 	public function testSaveNewLessons() {
@@ -1432,6 +1460,10 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 				add_post_meta( $item['id'], $order_meta_key, count( $lesson_order ) + $order_lesson_adjust );
 				add_post_meta( $item['id'], '_lesson_course', $course_id );
 				$lesson_order[] = $item['id'];
+
+				if ( isset( $item['preview'] ) && true === $item['preview'] ) {
+					add_post_meta( $item['id'], '_lesson_preview', 'preview' );
+				}
 
 				if ( $module_parent ) {
 					wp_set_object_terms( $item['id'], $module_parent, 'module' );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add preview badge to the lessons in the course outline editor.
* Add preview badge to the lessons in the frontend when the preview is enabled and the user is not enrolled (same as the current behavior in the legacy course).

### Testing instructions

* Create a course.
* Add some modules with lessons and some lessons without module.
* Update some lessons in the modules and others without modules to allow preview.
* Access the course editor and make sure you see a preview badge in the lessons that have the preview enabled.
* Access the course page in the frontend with a not enrolled user, and make sure you see the badge in the preview lessons. Enroll the user and make sure you don't see the preview badges anymore.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="598" alt="Screen Shot 2020-10-22 at 11 54 38" src="https://user-images.githubusercontent.com/876340/96889865-6a211880-145d-11eb-98ce-961a3bb01dfb.png">
