### PR TITLE
Progress bar improvements

### DIFF
--- a/assets/blocks/course-progress/block.json
+++ b/assets/blocks/course-progress/block.json
@@ -26,5 +26,10 @@
       "type": "string",
       "default": "#E6E6E6"
     }
+  },
+  "example": {
+    "attributes": {
+      "customBarBackgroundColor": "#999999"
+    }
   }
 }

--- a/assets/blocks/course-progress/block.json
+++ b/assets/blocks/course-progress/block.json
@@ -25,6 +25,12 @@
     "customBarBackgroundColor": {
       "type": "string",
       "default": "#E6E6E6"
+    },
+    "height": {
+      "type": "integer"
+    },
+    "borderRadius": {
+      "type": "integer"
     }
   },
   "example": {

--- a/assets/blocks/course-progress/edit.js
+++ b/assets/blocks/course-progress/edit.js
@@ -4,23 +4,28 @@ import classnames from 'classnames';
 import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { COURSE_STATUS_STORE } from '../course-outline/status-store';
-import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, RangeControl } from '@wordpress/components';
+import { CourseProgressSettings } from './settings';
 
 /**
  * Edit course progress bar component.
  *
- * @param {Object} props                    Component properties.
- * @param {string} props.className          Custom class name.
- * @param {Object} props.barColor           Color object for the progress bar.
- * @param {Object} props.barBackgroundColor Color object for the background of the progress bar.
- * @param {Object} props.textColor          Color object for the text.
+ * @param {Object}   props                         Component properties.
+ * @param {string}   props.className               Custom class name.
+ * @param {Object}   props.barColor                Color object for the progress bar.
+ * @param {Object}   props.barBackgroundColor      Color object for the background of the progress bar.
+ * @param {Object}   props.textColor               Color object for the text.
+ * @param {Object}   props.attributes              Component attributes.
+ * @param {number}   props.attributes.height       The height of the progress bar.
+ * @param {number}   props.attributes.borderRadius The border radius of the progress bar.
+ * @param {Function} props.setAttributes           Callback to set the component attributes.
  */
 export const EditCourseProgressBlock = ( {
 	className,
 	barColor,
 	barBackgroundColor,
 	textColor,
+	attributes: { height, borderRadius },
+	setAttributes,
 } ) => {
 	const { totalLessonsCount, completedLessonsCount } = useSelect(
 		( select ) => select( COURSE_STATUS_STORE ).getLessonCounts(),
@@ -52,7 +57,8 @@ export const EditCourseProgressBlock = ( {
 		className: barColor?.class,
 		style: {
 			backgroundColor: barColor?.color,
-			width: Math.max( 2, progress ) + '%',
+			width: Math.max( 4, progress ) + '%',
+			borderRadius,
 		},
 	};
 	const barBackgroundAttributes = {
@@ -62,6 +68,8 @@ export const EditCourseProgressBlock = ( {
 		),
 		style: {
 			backgroundColor: barBackgroundColor?.color,
+			height,
+			borderRadius,
 		},
 	};
 
@@ -86,25 +94,18 @@ export const EditCourseProgressBlock = ( {
 					<div { ...barAttributes } />
 				</div>
 			</div>
-
-			<InspectorControls>
-				<PanelBody
-					title={ __( 'Progress percentage', 'sensei-lms' ) }
-					initialOpen={ false }
-				>
-					<RangeControl
-						help={ __(
-							'Preview the progress bar for different percentage values.',
-							'sensei-lms'
-						) }
-						value={ manualPercentage }
-						onChange={ setManualPercentage }
-						min={ 0 }
-						max={ 100 }
-						allowReset={ true }
-					/>
-				</PanelBody>
-			</InspectorControls>
+			<CourseProgressSettings
+				setManualPercentage={ setManualPercentage }
+				manualPercentage={ manualPercentage }
+				borderRadius={ borderRadius }
+				setBorderRadius={ ( newRadius ) =>
+					setAttributes( { borderRadius: newRadius } )
+				}
+				height={ height }
+				setHeight={ ( newHeight ) =>
+					setAttributes( { height: newHeight } )
+				}
+			/>
 		</>
 	);
 };

--- a/assets/blocks/course-progress/settings.js
+++ b/assets/blocks/course-progress/settings.js
@@ -75,7 +75,7 @@ export function CourseProgressSettings( {
 						) }
 						value={ height }
 						onChange={ setHeight }
-						min={ 0 }
+						min={ 1 }
 						max={ 40 }
 						allowReset={ true }
 						initialPosition={ initialHeight }

--- a/assets/blocks/course-progress/settings.js
+++ b/assets/blocks/course-progress/settings.js
@@ -1,0 +1,87 @@
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, PanelRow, RangeControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * The course progress block settings.
+ *
+ * @param {Object}   props                     Component properties.
+ * @param {number}   props.manualPercentage    The value of the percentage.
+ * @param {Function} props.setManualPercentage Callback to set the value of manual percentage.
+ * @param {number}   props.borderRadius        The value of the bar radius.
+ * @param {Function} props.setBorderRadius     Callback to set the value of border radius.
+ * @param {number}   props.height              The value of the bar height.
+ * @param {Function} props.setHeight           Callback to set the value of height.
+ */
+export function CourseProgressSettings( {
+	manualPercentage,
+	setManualPercentage,
+	borderRadius,
+	setBorderRadius,
+	height,
+	setHeight,
+} ) {
+	const initialHeight = 14;
+	const initialBorderRadius = 2;
+
+	borderRadius =
+		undefined === borderRadius ? initialBorderRadius : borderRadius;
+	height = undefined === height ? initialHeight : height;
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Progress percentage', 'sensei-lms' ) }
+				initialOpen={ false }
+			>
+				<RangeControl
+					help={ __(
+						'Preview the progress bar for different percentage values.',
+						'sensei-lms'
+					) }
+					value={ manualPercentage }
+					onChange={ setManualPercentage }
+					min={ 0 }
+					max={ 100 }
+					allowReset={ true }
+				/>
+			</PanelBody>
+			<PanelBody
+				title={ __( 'Styling', 'sensei-lms' ) }
+				initialOpen={ false }
+				className="wp-block-sensei-lms-progress-styling-controls"
+			>
+				<PanelRow>
+					<RangeControl
+						label={ 'Border radius' }
+						help={ __(
+							'Set the border radius of the progress bar.',
+							'sensei-lms'
+						) }
+						value={ borderRadius }
+						onChange={ setBorderRadius }
+						min={ 0 }
+						max={ 50 }
+						allowReset={ true }
+						initialPosition={ initialBorderRadius }
+					/>
+				</PanelRow>
+				<PanelRow>
+					<RangeControl
+						label={ __( 'Height', 'sensei-lms' ) }
+						help={ __(
+							'Set the progress bar height.',
+							'sensei-lms'
+						) }
+						value={ height }
+						onChange={ setHeight }
+						min={ 0 }
+						max={ 40 }
+						allowReset={ true }
+						initialPosition={ initialHeight }
+					/>
+				</PanelRow>
+			</PanelBody>
+		</InspectorControls>
+	);
+}

--- a/assets/blocks/course-progress/style.scss
+++ b/assets/blocks/course-progress/style.scss
@@ -18,3 +18,9 @@
 		border-radius: 2px;
 	}
 }
+
+.wp-block-sensei-lms-progress-styling-controls {
+	.components-range-control {
+		width: 100%;
+	}
+}

--- a/includes/blocks/class-sensei-block-helpers.php
+++ b/includes/blocks/class-sensei-block-helpers.php
@@ -19,11 +19,12 @@ class Sensei_Block_Helpers {
 	 * Build CSS classes (for named colors) and inline styles from block attributes.
 	 *
 	 * @param array $block_attributes  The block attributes.
-	 * @param array $colors Color      attributes and their style property.
+	 * @param array $colors            An array with the color attribute as keys and the style property as values.
+	 * @param array $size_styles       An array with the sizing attribute as keys and the style property as values.
 	 *
 	 * @return array Colors CSS classes and inline styles.
 	 */
-	public static function build_styles( array $block_attributes, array $colors = [] ) : array {
+	public static function build_styles( array $block_attributes, array $colors = [], array $size_styles = [] ) : array {
 		$attributes = [
 			'css_classes'   => [],
 			'inline_styles' => [],
@@ -57,8 +58,10 @@ class Sensei_Block_Helpers {
 			}
 		}
 
-		if ( ! empty( $block_attributes['fontSize'] ) ) {
-			$attributes['inline_styles'][] = sprintf( 'font-size: %spx', $block_attributes['fontSize'] );
+		foreach ( $size_styles as $attribute_name => $css_class ) {
+			if ( isset( $block_attributes[ $attribute_name ] ) && is_int( $block_attributes[ $attribute_name ] ) ) {
+				$attributes['inline_styles'][] = sprintf( '%s: %spx', $css_class, $block_attributes[ $attribute_name ] );
+			}
 		}
 
 		return $attributes;

--- a/includes/blocks/class-sensei-course-outline-lesson-block.php
+++ b/includes/blocks/class-sensei-course-outline-lesson-block.php
@@ -31,7 +31,7 @@ class Sensei_Course_Outline_Lesson_Block {
 			$classes[] = 'completed';
 		}
 
-		$css = Sensei_Block_Helpers::build_styles( $block['attributes'] ?? [] );
+		$css = Sensei_Block_Helpers::build_styles( $block['attributes'] ?? [], [], [ 'fontSize' => 'font-size' ] );
 
 		return '
 			<a href="' . esc_url( get_permalink( $lesson_id ) ) . '" ' . Sensei_Block_Helpers::render_style_attributes( $classes, $css ) . '>

--- a/includes/blocks/class-sensei-course-progress-block.php
+++ b/includes/blocks/class-sensei-course-progress-block.php
@@ -51,22 +51,28 @@ class Sensei_Course_Progress_Block {
 		$total_lessons = count( Sensei()->course->course_lessons( get_the_ID() ) );
 		$percentage    = Sensei_Utils::quotient_as_absolute_rounded_percentage( $completed, $total_lessons, 2 );
 
-		$text_css                   = Sensei_Block_Helpers::build_styles( $attributes );
-		$bar_background_css         = Sensei_Block_Helpers::build_styles(
+		$text_css           = Sensei_Block_Helpers::build_styles( $attributes );
+		$bar_background_css = Sensei_Block_Helpers::build_styles(
 			$attributes,
 			[
 				'textColor'          => null,
 				'barBackgroundColor' => 'background-color',
+			],
+			[
+				'height'       => 'height',
+				'borderRadius' => 'border-radius',
 			]
 		);
+
 		$bar_css                    = Sensei_Block_Helpers::build_styles(
 			$attributes,
 			[
 				'textColor' => null,
 				'barColor'  => 'background-color',
-			]
+			],
+			[ 'borderRadius' => 'border-radius' ]
 		);
-		$bar_css['inline_styles'][] = 'width: ' . ( 2 > $percentage ? 2 : $percentage ) . '%';
+		$bar_css['inline_styles'][] = 'width: ' . ( 4 > $percentage ? 4 : $percentage ) . '%';
 
 		// translators: Placeholder %d is the lesson count.
 		$lessons_text = sprintf( _n( '%d Lesson', '%d Lessons', $total_lessons, 'sensei-lms' ), $total_lessons );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds an example for the progress bar block.
* Adds two extra settings for the progress bar radius and height. These could be probably be done with CSS by a user but thought that it might be nice to be able to try them in the editor directly. I am happy to remove them if we think that they are not needed.

![Oct-22-2020 18-09-11](https://user-images.githubusercontent.com/53191348/96891958-d453b080-1491-11eb-98af-fdd7a31a22de.gif)

### Testing instructions

* Hover on the 'Course progress' block and check the example.
* Add a progress bar to a course.
* Play around with the new height and border radius settings.
* Save the block and observe the changes in the frontend.
