### PR TITLE
Fix progress bar issues after design review

### DIFF
--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -1,4 +1,5 @@
 import { createBlock } from '@wordpress/blocks';
+import { useEffect } from '@wordpress/element';
 import { select, useDispatch, useSelect } from '@wordpress/data';
 import { Icon } from '@wordpress/components';
 import classnames from 'classnames';
@@ -43,13 +44,6 @@ export const EditLessonBlock = ( props ) => {
 	const { setLessonStatus, trackLesson, ignoreLesson } = useDispatch(
 		COURSE_STATUS_STORE
 	);
-
-	// If the lesson has a title, add it to the tracked lessons in the status store.
-	if ( title.length > 0 ) {
-		trackLesson( clientId );
-	} else {
-		ignoreLesson( clientId );
-	}
 
 	/**
 	 * Update lesson title.
@@ -103,6 +97,15 @@ export const EditLessonBlock = ( props ) => {
 				break;
 		}
 	};
+
+	// If the lesson has a title, add it to the tracked lessons in the status store.
+	useEffect( () => {
+		if ( title.length > 0 ) {
+			trackLesson( clientId );
+		} else {
+			ignoreLesson( clientId );
+		}
+	}, [ clientId, trackLesson, ignoreLesson, title ] );
 
 	let postStatus = '';
 	if ( ! id && title.length ) {

--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -40,7 +40,16 @@ export const EditLessonBlock = ( props ) => {
 		insertBlocksAfter,
 	} = props;
 	const { selectNextBlock, removeBlock } = useDispatch( 'core/block-editor' );
-	const { setLessonStatus } = useDispatch( COURSE_STATUS_STORE );
+	const { setLessonStatus, trackLesson, ignoreLesson } = useDispatch(
+		COURSE_STATUS_STORE
+	);
+
+	// If the lesson has a title, add it to the tracked lessons in the status store.
+	if ( title.length > 0 ) {
+		trackLesson( clientId );
+	} else {
+		ignoreLesson( clientId );
+	}
 
 	/**
 	 * Update lesson title.

--- a/assets/blocks/course-outline/lesson-block/edit.test.js
+++ b/assets/blocks/course-outline/lesson-block/edit.test.js
@@ -28,6 +28,8 @@ describe( '<EditLessonBlock />', () => {
 	useDispatch.mockImplementation( () => ( {
 		selectNextBlock: selectNextBlockMock,
 		removeBlock: removeBlockMock,
+		ignoreLesson: jest.fn(),
+		trackLesson: jest.fn(),
 	} ) );
 
 	beforeEach( () => {

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -21,12 +21,13 @@ import { Status, StatusControl } from '../status-control';
  * @param {Function} props.attributes          The block attributes.
  * @param {number}   props.attributes.id       The lesson id.
  * @param {string}   props.attributes.fontSize The lesson block font size.
+ * @param {string}   props.attributes.title    The lesson title.
  */
 export const LessonBlockSettings = ( {
 	previewStatus,
 	setPreviewStatus,
 	setAttributes,
-	attributes: { id, fontSize },
+	attributes: { id, fontSize, title },
 } ) => {
 	const { fontSizes } = useSelect( ( select ) =>
 		select( 'core/block-editor' ).getSettings()
@@ -73,6 +74,7 @@ export const LessonBlockSettings = ( {
 						status={ previewStatus }
 						setStatus={ setPreviewStatus }
 						options={ [ Status.NOT_STARTED, Status.COMPLETED ] }
+						disabled={ ! title }
 					/>
 				</PanelBody>
 			</InspectorControls>

--- a/assets/blocks/course-outline/module-block/module-status.js
+++ b/assets/blocks/course-outline/module-block/module-status.js
@@ -14,21 +14,26 @@ import { useDispatch, useSelect } from '@wordpress/data';
  */
 export const ModuleStatus = ( { clientId } ) => {
 	const { setModuleStatus } = useDispatch( COURSE_STATUS_STORE );
-	const status = useSelect(
-		( select ) => select( COURSE_STATUS_STORE ).getModuleStatus( clientId ),
+
+	const counts = useSelect(
+		( select ) =>
+			select( COURSE_STATUS_STORE ).getModuleLessonCounts( clientId ),
 		[ clientId ]
 	);
 
-	const lessonIds = useSelect(
-		( select ) =>
-			select( 'core/block-editor' ).getClientIdsOfDescendants( [
-				clientId,
-			] ),
-		[ clientId ]
-	);
+	let status = Status.IN_PROGRESS;
+
+	if ( 0 === counts.completedLessonsCount ) {
+		status = Status.NOT_STARTED;
+	} else if (
+		counts.totalLessonsCount === counts.completedLessonsCount &&
+		counts.totalLessonsCount > 0
+	) {
+		status = Status.COMPLETED;
+	}
 
 	const options =
-		lessonIds.length > 1
+		counts.totalLessonsCount > 1
 			? [ Status.NOT_STARTED, Status.IN_PROGRESS, Status.COMPLETED ]
 			: [ Status.NOT_STARTED, Status.COMPLETED ];
 
@@ -58,6 +63,7 @@ export const ModuleStatus = ( { clientId } ) => {
 					<StatusControl
 						options={ options }
 						status={ status }
+						disabled={ 0 === counts.totalLessonsCount }
 						setStatus={ ( newStatus ) => {
 							setModuleStatus( clientId, newStatus );
 						} }

--- a/assets/blocks/course-outline/status-control/index.js
+++ b/assets/blocks/course-outline/status-control/index.js
@@ -1,4 +1,4 @@
-import { RadioControl } from '@wordpress/components';
+import { RadioControl, Disabled } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -26,11 +26,13 @@ export const StatusLabels = {
  * @param {Array}    props.options   The ordered Status constants to include.
  * @param {string}   props.status    The index of the current status.
  * @param {Function} props.setStatus A callback which is called with the index when a status is selected.
+ * @param {boolean}  props.disabled  Flag which disables the controls.
  */
 export const StatusControl = ( {
 	options = [ Status.IN_PROGRESS, Status.COMPLETED ],
 	status,
 	setStatus,
+	disabled,
 	...props
 } ) => {
 	const statusOptions = options.map( ( statusOption ) => ( {
@@ -38,7 +40,7 @@ export const StatusControl = ( {
 		value: statusOption,
 	} ) );
 
-	return (
+	let radioControl = (
 		<RadioControl
 			className="wp-block-sensei-lms-course-outline-status-control"
 			help={ __(
@@ -51,4 +53,10 @@ export const StatusControl = ( {
 			onChange={ ( value ) => setStatus( value ) }
 		/>
 	);
+
+	if ( disabled ) {
+		radioControl = <Disabled>{ radioControl }</Disabled>;
+	}
+
+	return radioControl;
 };

--- a/assets/blocks/course-outline/status-store.js
+++ b/assets/blocks/course-outline/status-store.js
@@ -133,36 +133,30 @@ const selectors = {
 			: Status.NOT_STARTED,
 
 	/**
-	 * Calculates and gets the module status.
+	 * Returns the number of total and completed lessons of a module.
 	 *
 	 * @param {Object} state                  The state.
 	 * @param {Array}  state.completedLessons The ids of the completed lessons.
 	 * @param {Array}  state.trackedLessons   The ids of  all the lessons.
 	 * @param {string} moduleId               The module id.
 	 *
-	 * @return {string} The lesson status.
+	 * @return {Object} The module lesson counts.
 	 */
-	getModuleStatus( { completedLessons, trackedLessons }, moduleId ) {
+	getModuleLessonCounts( { completedLessons, trackedLessons }, moduleId ) {
 		const moduleLessons = selectData( 'core/block-editor' )
 			.getClientIdsOfDescendants( [ moduleId ] )
 			.filter( ( descendantId ) =>
 				trackedLessons.includes( descendantId )
 			);
 
-		const completedLessonsCount = moduleLessons.filter( ( lessonId ) =>
+		const completedModuleLessons = moduleLessons.filter( ( lessonId ) =>
 			completedLessons.includes( lessonId )
-		).length;
+		);
 
-		if ( 0 === completedLessonsCount ) {
-			return Status.NOT_STARTED;
-		} else if (
-			moduleLessons.length === completedLessonsCount &&
-			moduleLessons.length > 0
-		) {
-			return Status.COMPLETED;
-		}
-
-		return Status.IN_PROGRESS;
+		return {
+			completedLessonsCount: completedModuleLessons.length,
+			totalLessonsCount: moduleLessons.length,
+		};
 	},
 };
 

--- a/assets/blocks/course-outline/status-store.js
+++ b/assets/blocks/course-outline/status-store.js
@@ -5,7 +5,7 @@ import { select, controls } from '@wordpress/data-controls';
 
 const DEFAULT_STATE = {
 	completedLessons: [],
-	totalLessonsCount: 0,
+	trackedLessons: [],
 };
 
 /**
@@ -37,45 +37,55 @@ const actions = {
 	 * @return {Object} Yields the lesson update actions.
 	 */
 	*setModuleStatus( moduleId, status ) {
-		const lessonIds = yield select(
+		const trackedLessonIds = yield select(
+			COURSE_STATUS_STORE,
+			'getTrackedLessons'
+		);
+
+		const moduleDescendants = yield select(
 			'core/block-editor',
 			'getClientIdsOfDescendants',
 			[ moduleId ]
 		);
 
-		if ( 0 === lessonIds.length ) {
+		const moduleLessons = moduleDescendants.filter( ( descendantId ) =>
+			trackedLessonIds.includes( descendantId )
+		);
+
+		if ( 0 === moduleLessons.length ) {
 			return;
 		}
 
 		if ( Status.COMPLETED === status || Status.NOT_STARTED === status ) {
-			yield* lessonIds.map( ( lessonId ) =>
+			yield* moduleLessons.map( ( lessonId ) =>
 				actions.setLessonStatus( lessonId, status )
 			);
 		} else {
-			yield* lessonIds
+			yield* moduleLessons
 				.slice( 1 )
 				.map( ( lessonId ) =>
 					actions.setLessonStatus( lessonId, Status.NOT_STARTED )
 				);
 
-			return actions.setLessonStatus( lessonIds[ 0 ], Status.COMPLETED );
+			return actions.setLessonStatus(
+				moduleLessons[ 0 ],
+				Status.COMPLETED
+			);
 		}
 	},
 
 	/**
 	 * Creates the action to update state after a an update of the outline's structure.
 	 *
-	 * @param {string}   outlineId          The outline block id.
-	 * @param {number}   totalLessonsCount  The count of the lessons.
-	 * @param {string[]} outlineDescendants The descendants of the outline block.
+	 * @param {string}   outlineId      The outline block id.
+	 * @param {string[]} trackedLessons The ids of all tracked lessons.
 	 *
 	 * @return {Object} The action.
 	 */
-	refreshStructure( outlineId, totalLessonsCount, outlineDescendants ) {
+	refreshStructure( outlineId, trackedLessons ) {
 		return {
-			type: 'REFRESH_BLOCK_IDS',
-			newDescendantIds: outlineDescendants,
-			totalLessonsCount,
+			type: 'REFRESH_STRUCTURE',
+			trackedLessons,
 		};
 	},
 };
@@ -85,16 +95,26 @@ const actions = {
  */
 const selectors = {
 	/**
-	 * Get the lesson counts.
+	 * Get all the lessons that are tracked by the store.
 	 *
-	 * @param {Object} state                   The state.
-	 * @param {number} state.totalLessonsCount The number of lessons.
-	 * @param {Array}  state.completedLessons  The ids of the completed lessons.
+	 * @param {Object} state                The state.
+	 * @param {Array}  state.trackedLessons The tracked lessons.
 	 *
 	 * @return {Object} An object with the total and completed lesson counts.
 	 */
-	getLessonCounts: ( { totalLessonsCount, completedLessons } ) => ( {
-		totalLessonsCount,
+	getTrackedLessons: ( { trackedLessons } ) => trackedLessons,
+
+	/**
+	 * Get the lesson counts.
+	 *
+	 * @param {Object} state                  The state.
+	 * @param {Array}  state.trackedLessons   The ids of all the lessons.
+	 * @param {Array}  state.completedLessons The ids of the completed lessons.
+	 *
+	 * @return {Object} An object with the total and completed lesson counts.
+	 */
+	getLessonCounts: ( { trackedLessons, completedLessons } ) => ( {
+		totalLessonsCount: trackedLessons.length,
 		completedLessonsCount: completedLessons.length,
 	} ),
 
@@ -108,9 +128,7 @@ const selectors = {
 	 * @return {string} The lesson status.
 	 */
 	getLessonStatus: ( { completedLessons }, lessonId ) =>
-		completedLessons.some(
-			( completedLessonId ) => lessonId === completedLessonId
-		)
+		completedLessons.includes( lessonId )
 			? Status.COMPLETED
 			: Status.NOT_STARTED,
 
@@ -119,26 +137,27 @@ const selectors = {
 	 *
 	 * @param {Object} state                  The state.
 	 * @param {Array}  state.completedLessons The ids of the completed lessons.
+	 * @param {Array}  state.trackedLessons   The ids of  all the lessons.
 	 * @param {string} moduleId               The module id.
 	 *
 	 * @return {string} The lesson status.
 	 */
-	getModuleStatus( { completedLessons }, moduleId ) {
-		const lessonIds = selectData(
-			'core/block-editor'
-		).getClientIdsOfDescendants( [ moduleId ] );
+	getModuleStatus( { completedLessons, trackedLessons }, moduleId ) {
+		const moduleLessons = selectData( 'core/block-editor' )
+			.getClientIdsOfDescendants( [ moduleId ] )
+			.filter( ( descendantId ) =>
+				trackedLessons.includes( descendantId )
+			);
 
-		const completedLessonsCount = lessonIds.filter( ( lessonId ) =>
-			completedLessons.some(
-				( completedLessonId ) => lessonId === completedLessonId
-			)
+		const completedLessonsCount = moduleLessons.filter( ( lessonId ) =>
+			completedLessons.includes( lessonId )
 		).length;
 
 		if ( 0 === completedLessonsCount ) {
 			return Status.NOT_STARTED;
 		} else if (
-			lessonIds.length === completedLessonsCount &&
-			lessonIds.length > 0
+			moduleLessons.length === completedLessonsCount &&
+			moduleLessons.length > 0
 		) {
 			return Status.COMPLETED;
 		}
@@ -181,30 +200,25 @@ const reducers = {
 	},
 
 	/**
-	 * Checks if a lesson has been removed and updates the lessons.
+	 * Updates internal state according to a new array of lessons.
 	 *
-	 * @param {Object} action                   The action.
-	 * @param {Array}  action.newDescendantIds  The ids of all descendants of the outline block.
-	 * @param {number} action.totalLessonsCount The number of total lessons.
-	 * @param {Object} state                    The state.
+	 * @param {Object} action                The action.
+	 * @param {Array}  action.trackedLessons The ids of all lessons of the outline block.
+	 * @param {Object} state                 The state.
 	 *
 	 * @return {Object} The new state.
 	 */
-	REFRESH_BLOCK_IDS: ( { newDescendantIds, totalLessonsCount }, state ) => {
+	REFRESH_STRUCTURE: ( { trackedLessons }, state ) => {
 		let completedLessons = [ ...state.completedLessons ];
 
-		completedLessons.forEach( ( lesson ) => {
-			if ( ! newDescendantIds.includes( lesson ) ) {
-				completedLessons = completedLessons.filter(
-					( completedLessonId ) => completedLessonId !== lesson
-				);
-			}
-		} );
+		completedLessons = completedLessons.filter( ( completedLessonId ) =>
+			trackedLessons.includes( completedLessonId )
+		);
 
 		return {
 			...state,
-			totalLessonsCount,
 			completedLessons,
+			trackedLessons,
 		};
 	},
 	DEFAULT: ( action, state ) => state,

--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -54,3 +54,9 @@ $dark-gray: #1a1d20;
 		}
 	}
 }
+
+.components-disabled {
+	label {
+		color: #828282;
+	}
+}

--- a/assets/blocks/course-progress/block.json
+++ b/assets/blocks/course-progress/block.json
@@ -16,15 +16,13 @@
       "type": "string"
     },
     "customBarColor": {
-      "type": "string",
-      "default": "#0064B4"
+      "type": "string"
     },
     "barBackgroundColor": {
       "type": "string"
     },
     "customBarBackgroundColor": {
-      "type": "string",
-      "default": "#E6E6E6"
+      "type": "string"
     },
     "height": {
       "type": "integer"

--- a/assets/blocks/course-progress/edit.js
+++ b/assets/blocks/course-progress/edit.js
@@ -2,7 +2,6 @@ import { withColorSettings } from '../../shared/blocks/settings';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { useSelect } from '@wordpress/data';
-import { useState } from '@wordpress/element';
 import { COURSE_STATUS_STORE } from '../course-outline/status-store';
 import { CourseProgressSettings } from './settings';
 
@@ -32,13 +31,8 @@ export const EditCourseProgressBlock = ( {
 		[]
 	);
 
-	const [ manualPercentage, setManualPercentage ] = useState( undefined );
-
 	let progress = 0;
-
-	if ( undefined !== manualPercentage ) {
-		progress = manualPercentage;
-	} else if ( 0 !== totalLessonsCount ) {
+	if ( 0 !== totalLessonsCount ) {
 		progress =
 			Math.round(
 				( ( 100 * completedLessonsCount ) / totalLessonsCount +
@@ -95,8 +89,6 @@ export const EditCourseProgressBlock = ( {
 				</div>
 			</div>
 			<CourseProgressSettings
-				setManualPercentage={ setManualPercentage }
-				manualPercentage={ manualPercentage }
 				borderRadius={ borderRadius }
 				setBorderRadius={ ( newRadius ) =>
 					setAttributes( { borderRadius: newRadius } )

--- a/assets/blocks/course-progress/edit.js
+++ b/assets/blocks/course-progress/edit.js
@@ -57,7 +57,7 @@ export const EditCourseProgressBlock = ( {
 		className: barColor?.class,
 		style: {
 			backgroundColor: barColor?.color,
-			width: Math.max( 4, progress ) + '%',
+			width: Math.max( 3, progress ) + '%',
 			borderRadius,
 		},
 	};

--- a/assets/blocks/course-progress/settings.js
+++ b/assets/blocks/course-progress/settings.js
@@ -34,10 +34,6 @@ export function CourseProgressSettings( {
 				<PanelRow>
 					<RangeControl
 						label={ 'Border radius' }
-						help={ __(
-							'Set the border radius of the progress bar.',
-							'sensei-lms'
-						) }
 						value={ borderRadius }
 						onChange={ setBorderRadius }
 						min={ 0 }
@@ -49,10 +45,6 @@ export function CourseProgressSettings( {
 				<PanelRow>
 					<RangeControl
 						label={ __( 'Height', 'sensei-lms' ) }
-						help={ __(
-							'Set the progress bar height.',
-							'sensei-lms'
-						) }
 						value={ height }
 						onChange={ setHeight }
 						min={ 1 }

--- a/assets/blocks/course-progress/settings.js
+++ b/assets/blocks/course-progress/settings.js
@@ -5,17 +5,13 @@ import { __ } from '@wordpress/i18n';
 /**
  * The course progress block settings.
  *
- * @param {Object}   props                     Component properties.
- * @param {number}   props.manualPercentage    The value of the percentage.
- * @param {Function} props.setManualPercentage Callback to set the value of manual percentage.
- * @param {number}   props.borderRadius        The value of the bar radius.
- * @param {Function} props.setBorderRadius     Callback to set the value of border radius.
- * @param {number}   props.height              The value of the bar height.
- * @param {Function} props.setHeight           Callback to set the value of height.
+ * @param {Object}   props                 Component properties.
+ * @param {number}   props.borderRadius    The value of the bar radius.
+ * @param {Function} props.setBorderRadius Callback to set the value of border radius.
+ * @param {number}   props.height          The value of the bar height.
+ * @param {Function} props.setHeight       Callback to set the value of height.
  */
 export function CourseProgressSettings( {
-	manualPercentage,
-	setManualPercentage,
 	borderRadius,
 	setBorderRadius,
 	height,
@@ -30,22 +26,6 @@ export function CourseProgressSettings( {
 
 	return (
 		<InspectorControls>
-			<PanelBody
-				title={ __( 'Progress percentage', 'sensei-lms' ) }
-				initialOpen={ false }
-			>
-				<RangeControl
-					help={ __(
-						'Preview the progress bar for different percentage values.',
-						'sensei-lms'
-					) }
-					value={ manualPercentage }
-					onChange={ setManualPercentage }
-					min={ 0 }
-					max={ 100 }
-					allowReset={ true }
-				/>
-			</PanelBody>
 			<PanelBody
 				title={ __( 'Progress bar settings', 'sensei-lms' ) }
 				initialOpen={ false }

--- a/assets/blocks/course-progress/settings.js
+++ b/assets/blocks/course-progress/settings.js
@@ -47,7 +47,7 @@ export function CourseProgressSettings( {
 				/>
 			</PanelBody>
 			<PanelBody
-				title={ __( 'Styling', 'sensei-lms' ) }
+				title={ __( 'Progress bar settings', 'sensei-lms' ) }
 				initialOpen={ false }
 				className="wp-block-sensei-lms-progress-styling-controls"
 			>
@@ -61,7 +61,7 @@ export function CourseProgressSettings( {
 						value={ borderRadius }
 						onChange={ setBorderRadius }
 						min={ 0 }
-						max={ 50 }
+						max={ 15 }
 						allowReset={ true }
 						initialPosition={ initialBorderRadius }
 					/>
@@ -76,7 +76,7 @@ export function CourseProgressSettings( {
 						value={ height }
 						onChange={ setHeight }
 						min={ 1 }
-						max={ 40 }
+						max={ 25 }
 						allowReset={ true }
 						initialPosition={ initialHeight }
 					/>

--- a/assets/blocks/course-progress/style.scss
+++ b/assets/blocks/course-progress/style.scss
@@ -12,10 +12,12 @@
 .wp-block-sensei-lms-progress-bar {
 	height: 14px;
 	border-radius: 2px;
+	background-color: #E6E6E6;
 
 	div {
 		height: 100%;
 		border-radius: 2px;
+		background-color: #0064B4;
 	}
 }
 

--- a/includes/blocks/class-sensei-course-progress-block.php
+++ b/includes/blocks/class-sensei-course-progress-block.php
@@ -72,7 +72,7 @@ class Sensei_Course_Progress_Block {
 			],
 			[ 'borderRadius' => 'border-radius' ]
 		);
-		$bar_css['inline_styles'][] = 'width: ' . ( 4 > $percentage ? 4 : $percentage ) . '%';
+		$bar_css['inline_styles'][] = 'width: ' . ( 3 > $percentage ? 3 : $percentage ) . '%';
 
 		// translators: Placeholder %d is the lesson count.
 		$lessons_text = sprintf( _n( '%d Lesson', '%d Lessons', $total_lessons, 'sensei-lms' ), $total_lessons );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Applies fixes proposed [here](https://github.com/Automattic/sensei/pull/3733#issuecomment-714798626).
* Resolves the issue where when the colors of the bar was cleared, the bar was lost.
* Removes the progress preview setting.
* Stops tracking of lessons with no title.
* Each issue is fixed in a single commit, so you may want to review this commit by commit.

### Testing instructions
First issue:
* Open the progress bar in the editor.
* Observe that the maximum values for settings and the title of them are correct.

Second issue:
* Set a color to the progress bar.
* Reset it and observe that the progress bar is still displayed.

Third issue:
* Observe that the progress setting was removed.

Last issue:
* Play around with the module and lessons settings and verify the following:
    * When a lesson has no title, it isn't tracked in the progress block and it's status cannot be updated.
    * When a title is typed in the lesson, it is tracked and its status can be updated.
    * Module status settings are not affected by lessons with no title.
    * When a lesson/module is added/removed, the progress bar is still correct.