### PR TITLE
[Try] Separate settings for button alignment and text alignment - alternative approach

### DIFF
--- a/assets/blocks/button/button-props.js
+++ b/assets/blocks/button/button-props.js
@@ -45,18 +45,43 @@ export function getButtonProps( props ) {
 /**
  * Class and style attributes for the wrapper element.
  *
- * @param {Object} props                  Block properties.
- * @param {string} props.className        Block classname.
- * @param {Object} props.attributes       Block attributes.
- * @param {string} props.attributes.align Alignment attribute.
+ * @param {Object} props                       Block properties.
+ * @param {string} props.className             Block classname.
+ * @param {Object} props.attributes            Block attributes.
+ * @param {string} props.attributes.blockAlign Block alignment attribute.
+ * @param {string} props.attributes.textAlign  Text alignment attribute.
+ *
  * @return {{className}} Output HTML attributes.
  */
-export function getButtonWrapperProps( { className, attributes: { align } } ) {
-	return {
-		className: classnames(
-			className,
-			'wp-block-sensei-button',
-			`has-text-align-${ align || 'full' }`
-		),
+export function getButtonWrapperProps( {
+	className,
+	attributes: { blockAlign, textAlign },
+} ) {
+	const wrapperProps = {
+		className: classnames( className, 'wp-block-sensei-button', {
+			[ `wp-block-sensei-button__block-align-${ blockAlign }` ]: blockAlign,
+			alignfull: 'full' === blockAlign,
+			[ `wp-block-sensei-button__text-align-${ textAlign }` ]: textAlign,
+		} ),
 	};
+
+	return wrapperProps;
+}
+
+/**
+ * Block additional wrapper props.
+ *
+ * @param {Object} attributes            Block attributes.
+ * @param {string} attributes.blockAlign Block align.
+ *
+ * @return {Object} Additional wrapper props.
+ */
+export function getEditWrapperProps( { blockAlign } ) {
+	const props = {};
+
+	if ( 'full' === blockAlign ) {
+		props[ 'data-align' ] = blockAlign;
+	}
+
+	return props;
 }

--- a/assets/blocks/button/button.scss
+++ b/assets/blocks/button/button.scss
@@ -1,15 +1,30 @@
-
 .wp-block-sensei-button {
-
-}
-.wp-block-sensei-lms-button-take-course {
-
-	.block-editor-rich-text {
-		display: block;
+	&__block-align-wide,
+	&__block-align-full {
+		.wp-block-button__link {
+			display: block;
+			width: 100%;
+			flex: 1;
+		}
 	}
-	&.has-text-align-full .wp-block-button__link {
-		display: block;
-		width: 100%;
-		flex: 1;
+
+	&__block-align-center {
+		text-align: center;
+	}
+	&__block-align-left {
+		text-align: left;
+	}
+	&__block-align-right {
+		text-align: right;
+	}
+
+	&__text-align-center .wp-block-button__link {
+		text-align: center;
+	}
+	&__text-align-left .wp-block-button__link {
+		text-align: left;
+	}
+	&__text-align-right .wp-block-button__link {
+		text-align: right;
 	}
 }

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -4,6 +4,7 @@ import { merge } from 'lodash';
 import './color-hooks';
 import { EditButtonBlock } from './edit-button';
 import { saveButtonBlock } from './save-button';
+import { getEditWrapperProps } from './button-props';
 
 /**
  * Button block styles.
@@ -44,7 +45,10 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 					source: 'html',
 					selector: options.tagName,
 				},
-				align: {
+				textAlign: {
+					type: 'string',
+				},
+				blockAlign: {
 					type: 'string',
 				},
 				borderRadius: {
@@ -65,6 +69,7 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 				html: false,
 			},
 			styles: [ BlockStyles.Fill, BlockStyles.Outline ],
+			getEditWrapperProps,
 			edit( props ) {
 				return <EditButtonBlock { ...props } { ...options } />;
 			},

--- a/assets/blocks/button/save-button.test.js
+++ b/assets/blocks/button/save-button.test.js
@@ -10,19 +10,19 @@ describe( 'saveButtonBlock', () => {
 		);
 
 		const { classList } = container.firstChild;
-		expect( classList ).toContain( 'has-text-align-full' );
+		expect( classList ).toContain( 'has-block-align-full' );
 		expect( classList ).toContain( 'wp-block-sensei-button' );
 	} );
 
 	it( 'sets wrapper alignment from attribute', () => {
 		const { container } = render(
 			saveButtonBlock( {
-				attributes: { text: 'Button', align: 'center' },
+				attributes: { text: 'Button', blockAlign: 'center' },
 			} )
 		);
 
 		const { classList } = container.firstChild;
-		expect( classList ).toContain( 'has-text-align-center' );
+		expect( classList ).toContain( 'has-block-align-center' );
 	} );
 
 	it( 'renders content as tagName', () => {

--- a/assets/blocks/button/settings-button.js
+++ b/assets/blocks/button/settings-button.js
@@ -1,5 +1,6 @@
 import {
 	AlignmentToolbar,
+	BlockAlignmentToolbar,
 	BlockControls,
 	InspectorControls,
 } from '@wordpress/block-editor';
@@ -45,14 +46,20 @@ export const BorderPanel = ( { borderRadius, setAttributes } ) => {
  */
 export const ButtonBlockSettings = ( props ) => {
 	const { attributes, setAttributes } = props;
-	const { borderRadius, align } = attributes;
+	const { borderRadius, textAlign, blockAlign } = attributes;
 	return (
 		<>
 			<BlockControls>
 				<AlignmentToolbar
-					value={ align }
-					onChange={ ( nextAlign ) => {
-						setAttributes( { align: nextAlign } );
+					value={ textAlign }
+					onChange={ ( value ) => {
+						setAttributes( { textAlign: value } );
+					} }
+				/>
+				<BlockAlignmentToolbar
+					value={ blockAlign }
+					onChange={ ( value ) => {
+						setAttributes( { blockAlign: value } );
 					} }
 				/>
 			</BlockControls>


### PR DESCRIPTION
Although I believe it's not the most recommended approach working with Gutenberg (it's different from how the original block alignment works), it's an alternative for #3736 where the button is contained in the same space, just moving it to the left, center, right and full.