### PR TITLE
Fix Travis phpunit issue

### DIFF
--- a/tests/bin/run-wp-unit-tests.sh
+++ b/tests/bin/run-wp-unit-tests.sh
@@ -5,5 +5,9 @@ if [[ ${TRAVIS_PHP_VERSION} > 7.1 ]]; then
 fi
 
 if [[ ! -z "$WP_VERSION" ]]; then
-	phpunit
+	if [[ ${TRAVIS_PHP_VERSION} > 7.1 ]]; then
+		./vendor/bin/phpunit
+	else
+		phpunit
+	fi
 fi


### PR DESCRIPTION
### Changes proposed in this Pull Request

* For PHP version 7.4, travis has phpunit version 8 installed globally which is not supported by WP unit tests. I updated the tests to use the locally installed phpunit for version 7.4.

### Testing instructions

* Check that the build passes.