### PR TITLE
Add default theme colors to Course Outline Block

### DIFF
--- a/assets/blocks/course-outline/module-block/block.json
+++ b/assets/blocks/course-outline/module-block/block.json
@@ -25,10 +25,16 @@
     "customMainColor": {
       "type": "string"
     },
+    "defaultMainColor": {
+      "type": "string"
+    },
     "textColor": {
       "type": "string"
     },
     "customTextColor": {
+      "type": "string"
+    },
+    "defaultTextColor": {
       "type": "string"
     },
     "borderColor": {

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -80,12 +80,29 @@ export const EditModuleBlock = ( props ) => {
 		className.match( styleRegex )?.[ 1 ] ||
 		outlineClassName.match( styleRegex )?.[ 1 ];
 
-	const blockStyleColors = ! style
-		? {}
-		: {
-				default: { background: mainColor?.color },
-				minimal: { borderColor: mainColor?.color },
-		  }[ style ];
+	// Header styles.
+	const headerStyles = {
+		default: {
+			background: mainColor?.color,
+			color: textColor?.color,
+		},
+		minimal: {
+			color: textColor?.color,
+		},
+	}[ style ];
+
+	// Minimal border element.
+	let minimalBorder;
+	if ( 'minimal' === style ) {
+		minimalBorder = (
+			<div
+				className="wp-block-sensei-lms-course-outline-module__name__minimal-border"
+				style={ {
+					background: mainColor?.color,
+				} }
+			/>
+		);
+	}
 
 	return (
 		<>
@@ -103,7 +120,7 @@ export const EditModuleBlock = ( props ) => {
 			>
 				<header
 					className="wp-block-sensei-lms-course-outline-module__header"
-					style={ { ...blockStyleColors, color: textColor?.color } }
+					style={ headerStyles }
 				>
 					<h2 className="wp-block-sensei-lms-course-outline-module__title">
 						<SingleLineInput
@@ -130,6 +147,7 @@ export const EditModuleBlock = ( props ) => {
 						</button>
 					) }
 				</header>
+				{ minimalBorder }
 				<AnimateHeight
 					className="wp-block-sensei-lms-collapsible"
 					duration={ 500 }

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -75,24 +75,17 @@ export const EditModuleBlock = ( props ) => {
 
 	const [ isExpanded, setExpanded ] = useState( true );
 
-	let blockStyleColors = {};
-	const style = className.match( /is-style-(\w+)/ );
+	const styleRegex = /is-style-(\w+)/;
+	const style =
+		className.match( styleRegex )?.[ 1 ] ||
+		outlineClassName.match( styleRegex )?.[ 1 ];
 
-	if ( style ) {
-		blockStyleColors = {
-			default: { background: mainColor?.color },
-			minimal: { borderColor: mainColor?.color },
-		}[ style[ 1 ] ];
-	} else {
-		const outlineStyle = outlineClassName.match( /is-style-(\w+)/ );
-
-		if ( outlineStyle ) {
-			blockStyleColors = {
+	const blockStyleColors = ! style
+		? {}
+		: {
 				default: { background: mainColor?.color },
 				minimal: { borderColor: mainColor?.color },
-			}[ outlineStyle[ 1 ] ];
-		}
-	}
+		  }[ style ];
 
 	return (
 		<>

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -8,7 +8,10 @@ import classnames from 'classnames';
 import AnimateHeight from 'react-animate-height';
 
 import { chevronUp } from '../../../icons/wordpress-icons';
-import { withColorSettings } from '../../../shared/blocks/settings';
+import {
+	withColorSettings,
+	withDefaultColor,
+} from '../../../shared/blocks/settings';
 import { OutlineAttributesContext } from '../course-block/edit';
 import SingleLineInput from '../single-line-input';
 import { ModuleStatus } from './module-status';
@@ -27,7 +30,9 @@ import { useInsertLessonBlock } from './use-insert-lesson-block';
  * @param {boolean}  props.attributes.bordered         Whether the module has a border.
  * @param {string}   props.attributes.borderColorValue The border color.
  * @param {Object}   props.mainColor                   Header main color.
+ * @param {Object}   props.defaultMainColor            Default main color.
  * @param {Object}   props.textColor                   Header text color.
+ * @param {Object}   props.defaultTextColor            Default text color.
  * @param {Object}   props.borderColor                 Border color.
  * @param {Function} props.setAttributes               Block set attributes function.
  * @param {string}   props.name                        Name of the block.
@@ -38,7 +43,9 @@ export const EditModuleBlock = ( props ) => {
 		className,
 		attributes: { title, description, bordered, borderColorValue },
 		mainColor,
+		defaultMainColor,
 		textColor,
+		defaultTextColor,
 		setAttributes,
 	} = props;
 	const {
@@ -83,8 +90,8 @@ export const EditModuleBlock = ( props ) => {
 	// Header styles.
 	const headerStyles = {
 		default: {
-			background: mainColor?.color,
-			color: textColor?.color,
+			background: mainColor?.color || defaultMainColor?.color,
+			color: textColor?.color || defaultTextColor?.color,
 		},
 		minimal: {
 			color: textColor?.color,
@@ -98,7 +105,7 @@ export const EditModuleBlock = ( props ) => {
 			<div
 				className="wp-block-sensei-lms-course-outline-module__name__minimal-border"
 				style={ {
-					background: mainColor?.color,
+					background: mainColor?.color || defaultMainColor?.color,
 				} }
 			/>
 		);
@@ -194,6 +201,16 @@ export default compose(
 					clientId,
 					{ borderColorValue: colorValue, bordered: !! colorValue }
 				),
+		},
+	} ),
+	withDefaultColor( {
+		defaultMainColor: {
+			style: 'background-color',
+			probeKey: 'primaryColor',
+		},
+		defaultTextColor: {
+			style: 'color',
+			probeKey: 'primaryContrastColor',
 		},
 	} )
 )( EditModuleBlock );

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -2,18 +2,18 @@ import { InnerBlocks, RichText } from '@wordpress/block-editor';
 import { Icon } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { useContext, useEffect, useState } from '@wordpress/element';
+import { dispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import AnimateHeight from 'react-animate-height';
-import { chevronUp } from '../../../icons/wordpress-icons';
 
+import { chevronUp } from '../../../icons/wordpress-icons';
 import { withColorSettings } from '../../../shared/blocks/settings';
 import { OutlineAttributesContext } from '../course-block/edit';
 import SingleLineInput from '../single-line-input';
 import { ModuleStatus } from './module-status';
 import { ModuleBlockSettings } from './settings';
 import { useInsertLessonBlock } from './use-insert-lesson-block';
-import { dispatch } from '@wordpress/data';
 
 /**
  * Edit module block component.

--- a/assets/blocks/course-outline/module-block/module-block.scss
+++ b/assets/blocks/course-outline/module-block/module-block.scss
@@ -68,10 +68,8 @@ $block: '.wp-block-sensei-lms-course-outline-module';
 		display: block;
 		border: none;
 		height: 4px;
-		.wp-block-sensei-lms-course-outline.is-style-default & {
-			margin-left: 4px;
-			margin-right: 4px;
-		}
+		margin-left: 4px;
+		margin-right: 4px;
 		background-color: $dark-gray;
 	}
 

--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -15,7 +15,7 @@ $dark-gray: #1a1d20;
 	textarea.wp-block-sensei-lms-course-outline-module__title-input {
 		color: inherit;
 		background: none;
-		
+
 		&::placeholder {
 			color: inherit;
 			opacity: 0.5;
@@ -48,14 +48,6 @@ $dark-gray: #1a1d20;
 	.wp-block-sensei-lms-course-outline-status-control {
 		.components-base-control__help {
 			margin-top: 10px;
-		}
-	}
-
-	.wp-block-sensei-lms-course-outline.is-style-minimal .wp-block-sensei-lms-course-outline-module:not(.is-style-default), .wp-block-sensei-lms-course-outline-module.is-style-minimal {
-		.wp-block-sensei-lms-course-outline-module__header {
-			margin: 0 4px;
-			padding: 1rem calc(1rem - 4px);
-			border-bottom: 4px solid $dark-gray;
 		}
 	}
 

--- a/assets/blocks/course-progress/block.json
+++ b/assets/blocks/course-progress/block.json
@@ -18,6 +18,9 @@
     "customBarColor": {
       "type": "string"
     },
+    "defaultBarColor": {
+      "type": "string"
+    },
     "barBackgroundColor": {
       "type": "string"
     },

--- a/assets/blocks/course-progress/edit.js
+++ b/assets/blocks/course-progress/edit.js
@@ -1,7 +1,12 @@
-import { withColorSettings } from '../../shared/blocks/settings';
+import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 import { useSelect } from '@wordpress/data';
+
+import {
+	withColorSettings,
+	withDefaultColor,
+} from '../../shared/blocks/settings';
 import { COURSE_STATUS_STORE } from '../course-outline/status-store';
 import { CourseProgressSettings } from './settings';
 
@@ -11,6 +16,7 @@ import { CourseProgressSettings } from './settings';
  * @param {Object}   props                         Component properties.
  * @param {string}   props.className               Custom class name.
  * @param {Object}   props.barColor                Color object for the progress bar.
+ * @param {Object}   props.defaultBarColor         Default bar color.
  * @param {Object}   props.barBackgroundColor      Color object for the background of the progress bar.
  * @param {Object}   props.textColor               Color object for the text.
  * @param {Object}   props.attributes              Component attributes.
@@ -21,6 +27,7 @@ import { CourseProgressSettings } from './settings';
 export const EditCourseProgressBlock = ( {
 	className,
 	barColor,
+	defaultBarColor,
 	barBackgroundColor,
 	textColor,
 	attributes: { height, borderRadius },
@@ -48,9 +55,9 @@ export const EditCourseProgressBlock = ( {
 		},
 	};
 	const barAttributes = {
-		className: barColor?.class,
+		className: barColor?.class || defaultBarColor?.className,
 		style: {
-			backgroundColor: barColor?.color,
+			backgroundColor: barColor?.color || defaultBarColor?.color,
 			width: Math.max( 3, progress ) + '%',
 			borderRadius,
 		},
@@ -102,17 +109,25 @@ export const EditCourseProgressBlock = ( {
 	);
 };
 
-export default withColorSettings( {
-	barColor: {
-		style: 'background-color',
-		label: __( 'Progress bar color', 'sensei-lms' ),
-	},
-	barBackgroundColor: {
-		style: 'background-color',
-		label: __( 'Progress bar background color', 'sensei-lms' ),
-	},
-	textColor: {
-		style: 'color',
-		label: __( 'Text color', 'sensei-lms' ),
-	},
-} )( EditCourseProgressBlock );
+export default compose(
+	withColorSettings( {
+		barColor: {
+			style: 'background-color',
+			label: __( 'Progress bar color', 'sensei-lms' ),
+		},
+		barBackgroundColor: {
+			style: 'background-color',
+			label: __( 'Progress bar background color', 'sensei-lms' ),
+		},
+		textColor: {
+			style: 'color',
+			label: __( 'Text color', 'sensei-lms' ),
+		},
+	} ),
+	withDefaultColor( {
+		defaultBarColor: {
+			style: 'background-color',
+			probeKey: 'primaryColor',
+		},
+	} )
+)( EditCourseProgressBlock );

--- a/assets/react-hooks/probe-styles.js
+++ b/assets/react-hooks/probe-styles.js
@@ -1,0 +1,45 @@
+import { memoize } from 'lodash';
+
+const { getComputedStyle } = window;
+
+/**
+ * Get probe styles (memoized).
+ *
+ * It adds elements to the DOM as a probe, and get the computed styles
+ * the default expected properties.
+ *
+ * @return {Object} Probe default styles.
+ */
+export const getProbeStyles = memoize( () => {
+	// Create temporary probe elements.
+	const editorStylesWrapperDiv = document.createElement( 'div' );
+	editorStylesWrapperDiv.className =
+		'editor-styles-wrapper sensei-probe-element';
+
+	const blockButtonDiv = document.createElement( 'div' );
+	blockButtonDiv.className = 'wp-block-button';
+
+	const buttonLinkDiv = document.createElement( 'div' );
+	buttonLinkDiv.className = 'wp-block-button__link';
+	buttonLinkDiv.textContent = 'Probe';
+
+	// Set probe position outside the screen to be hidden.
+	editorStylesWrapperDiv.style.position = 'fixed';
+	editorStylesWrapperDiv.style.top = '-100vh';
+
+	// Add probe to the screen.
+	blockButtonDiv.appendChild( buttonLinkDiv );
+	editorStylesWrapperDiv.appendChild( blockButtonDiv );
+	document.body.appendChild( editorStylesWrapperDiv );
+
+	// Save styles.
+	const styles = {
+		primaryColor: getComputedStyle( buttonLinkDiv ).backgroundColor,
+		primaryContrastColor: getComputedStyle( buttonLinkDiv ).color,
+	};
+
+	// Remove probe.
+	document.body.removeChild( editorStylesWrapperDiv );
+
+	return styles;
+} );

--- a/assets/react-hooks/probe-styles.test.js
+++ b/assets/react-hooks/probe-styles.test.js
@@ -1,0 +1,22 @@
+import { getProbeStyles } from './probe-styles';
+
+describe( 'getProbeStyles', () => {
+	it( 'Should get the probe styles', () => {
+		const styles = `.wp-block-button__link {
+			background-color: rgb(0, 0, 0);
+			color: rgb(255, 255, 255);
+		}`;
+
+		const style = document.createElement( 'style' );
+		style.appendChild( document.createTextNode( styles ) );
+
+		document.head.appendChild( style );
+
+		const probeStyles = getProbeStyles();
+
+		expect( probeStyles.primaryColor ).toEqual( 'rgb(0, 0, 0)' );
+		expect( probeStyles.primaryContrastColor ).toEqual(
+			'rgb(255, 255, 255)'
+		);
+	} );
+} );

--- a/assets/shared/helpers/colors.js
+++ b/assets/shared/helpers/colors.js
@@ -1,0 +1,30 @@
+/**
+ * Converts css color hex to rgb.
+ *
+ * @param {string} h The hex color string.
+ *
+ * @return {string} The rgb value.
+ */
+export const hexToRGB = ( h ) => {
+	// Returns if it's not an hexadecimal.
+	if ( ! h || null === h.match( '#' ) ) {
+		return h;
+	}
+
+	let r = 0,
+		g = 0,
+		b = 0;
+
+	const hexCode =
+		4 === h.length
+			? `#${ h[ 1 ] + h[ 1 ] + h[ 2 ] + h[ 2 ] + h[ 3 ] + h[ 3 ] }`
+			: h;
+
+	if ( 7 === hexCode.length ) {
+		r = parseInt( hexCode.substr( 1, 2 ), 16 ) || 0;
+		g = parseInt( hexCode.substr( 3, 2 ), 16 ) || 0;
+		b = parseInt( hexCode.substr( 5, 2 ), 16 ) || 0;
+	}
+
+	return `rgb(${ r }, ${ g }, ${ b })`;
+};

--- a/assets/shared/helpers/colors.test.js
+++ b/assets/shared/helpers/colors.test.js
@@ -1,0 +1,20 @@
+import { hexToRGB } from './colors';
+
+describe( 'hexToRGB', () => {
+	it.each( [
+		[ 'full red', '#ff0000', 'rgb(255, 0, 0)' ],
+		[ 'full green', '#00ff00', 'rgb(0, 255, 0)' ],
+		[ 'full blue', '#0000ff', 'rgb(0, 0, 255)' ],
+		[ 'black', '#000000', 'rgb(0, 0, 0)' ],
+		[ 'white', '#ffffff', 'rgb(255, 255, 255)' ],
+		[ 'invalid length', '#12345678', 'rgb(0, 0, 0)' ],
+		[ 'invalid values', '#ffXXff', 'rgb(255, 0, 255)' ],
+		[ 'already rgb', 'rgb(255, 0, 255)', 'rgb(255, 0, 255)' ],
+		[ 'undefined', undefined, undefined ],
+	] )(
+		'hexToRGB returns rgb value when given a hex string of %s',
+		( _, hex, rgbTriplet ) => {
+			expect( hexToRGB( hex ) ).toEqual( rgbTriplet );
+		}
+	);
+} );

--- a/includes/blocks/class-sensei-block-helpers.php
+++ b/includes/blocks/class-sensei-block-helpers.php
@@ -44,17 +44,21 @@ class Sensei_Block_Helpers {
 			if ( ! $style ) {
 				continue;
 			}
-			$named_color  = $block_attributes[ $color ] ?? null;
-			$custom_color = $block_attributes[ 'custom' . ucfirst( $color ) ] ?? null;
+			$named_color   = $block_attributes[ $color ] ?? null;
+			$custom_color  = $block_attributes[ 'custom' . ucfirst( $color ) ] ?? null;
+			$default_color = $block_attributes[ 'default' . ucfirst( $color ) ] ?? null;
 
 			if ( $custom_color || $named_color ) {
 				$attributes['css_classes'][] = sprintf( 'has-%s', $style );
 			}
+
+			$named_class = 'border-color' === $style ? 'border-color-%s' : 'has-%s-%s';
 			if ( $named_color ) {
-				$named_class                 = 'border-color' === $style ? 'border-color-%s' : 'has-%s-%s';
 				$attributes['css_classes'][] = sprintf( $named_class, $named_color, $style );
 			} elseif ( $custom_color ) {
 				$attributes['inline_styles'][] = sprintf( '%s: %s;', $style, $custom_color );
+			} elseif ( $default_color ) {
+				$attributes['css_classes'][] = sprintf( $named_class, $default_color, $style );
 			}
 		}
 

--- a/includes/blocks/class-sensei-block-helpers.php
+++ b/includes/blocks/class-sensei-block-helpers.php
@@ -85,12 +85,14 @@ class Sensei_Block_Helpers {
 	 * @return string
 	 */
 	public static function render_style_attributes( $class_names, $css ) {
+		$css_classes   = isset( $css['css_classes'] ) && is_array( $css['css_classes'] ) ? $css['css_classes'] : [];
+		$inline_styles = isset( $css['inline_styles'] ) && is_array( $css['inline_styles'] ) ? $css['inline_styles'] : [];
 
-		$class_names = array_merge( is_array( $class_names ) ? $class_names : [ $class_names ], $css['css_classes'] );
+		$class_names = array_merge( is_array( $class_names ) ? $class_names : [ $class_names ], $css_classes );
 		return sprintf(
 			'class="%s" style="%s"',
 			esc_attr( implode( ' ', $class_names ) ),
-			esc_attr( implode( '; ', $css['inline_styles'] ) )
+			esc_attr( implode( '; ', $inline_styles ) )
 		);
 	}
 

--- a/includes/blocks/class-sensei-course-outline-module-block.php
+++ b/includes/blocks/class-sensei-course-outline-module-block.php
@@ -33,13 +33,22 @@ class Sensei_Course_Outline_Module_Block {
 		$is_default_style = false !== strpos( $class_name, 'is-style-default' );
 		$is_minimal_style = false !== strpos( $class_name, 'is-style-minimal' );
 
-		$header_css = Sensei_Block_Helpers::build_styles(
-			$block['attributes'],
-			[
-				'mainColor'   => $is_default_style ? 'background-color' : null,
-				'borderColor' => null,
-			]
-		);
+		$header_css = [];
+
+		// Only set header CSS whether it's the default style or the text color is set.
+		if (
+			$is_default_style
+			|| ! empty( $block['attributes']['textColor'] )
+			|| ! empty( $block['attributes']['customTextColor'] )
+		) {
+			$header_css = Sensei_Block_Helpers::build_styles(
+				$block['attributes'],
+				[
+					'mainColor'   => $is_default_style ? 'background-color' : null,
+					'borderColor' => null,
+				]
+			);
+		}
 
 		$style_header = '';
 


### PR DESCRIPTION
Close #3740

### Changes proposed in this Pull Request

* This PR basically introduces the hook `useDefaultColor`. This hook, when used, will check if there is no color in some attribute, so it'll set a default color for that.

#### How it works

I got an idea from the Crowdsignal project, where they create probe elements to identify the colors that we want to use. In this case, we're getting a button background color and the text color. So we search in the theme color palette the same color to assign the correct color from the theme.

#### Known issue

There is still an issue with this solution that if the user changes to a new theme, and it has different color names, it'll miss the color selections and the new default theme colors will not be applied until the user navigate to the course editor and publish the post again.

This could be solved with an "ugly and big hack" using JavaScript in the frontend to check/apply classes making the same comparison we do in the editor code. But it sounds overkill.

#### Alternative solution

I implemented an alternative solution (#3740) where we save directly the color, instead of the respective theme colors. Peter raised a question related to this approach, where if the user customizes the theme colors, it wouldn't be automatically reflected in all courses, so it would be necessary to go to the courses and update the colors again. In summary, this solution would save the colors at the moment that the course is published and the user could override that only through CSS.

### Testing instructions

* Create a new course.
* Add modules.
* Add background colors and text colors (custom and not) to the modules.
* Go to the wp-admin > Appearance > Customize, and make sure the colors change when you change the theme default colors.
* Make sure everything reflects properly in the frontend.
* Change to a new theme to see the previously mentioned known issue.

### To handle in other PR(s)

- [x] Course progress bar default color
- [ ] Module border default color
- [x] Contact Teacher & Take Course main color (maybe it doesn't need any extra work because buttons contain specific classes)

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![Oct-28-2020 16-24-12](https://user-images.githubusercontent.com/876340/97486363-1a00f500-193a-11eb-9c1c-631bd7f3916c.gif)

![Oct-28-2020 16-18-31](https://user-images.githubusercontent.com/876340/97486386-1f5e3f80-193a-11eb-803a-40aab70148f0.gif)