### PR TITLE
Improve base button extendability

### DIFF
--- a/assets/blocks/button/button.scss
+++ b/assets/blocks/button/button.scss
@@ -1,0 +1,7 @@
+.wp-block-sensei-button
+{
+	margin: 1em 0;
+	&__notice {
+		margin: .5em 0;
+	}
+}

--- a/assets/blocks/button/edit-button.js
+++ b/assets/blocks/button/edit-button.js
@@ -10,22 +10,32 @@ import { ButtonBlockSettings } from './settings-button';
  * @param {Object} props
  */
 export const EditButtonBlock = ( props ) => {
-	const { attributes, setAttributes } = props;
-	const { placeholder, text } = attributes;
+	const { placeholder, attributes, setAttributes } = props;
+	const { text } = attributes;
 	const { colors } = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getSettings();
 	}, [] );
 
+	const isReadonly = undefined !== props.text;
+
 	return (
 		<div { ...getButtonWrapperProps( props ) }>
-			<RichText
-				placeholder={ placeholder || __( 'Add text…', 'sensei-lms' ) }
-				value={ text }
-				onChange={ ( value ) => setAttributes( { text: value } ) }
-				withoutInteractiveFormatting
-				{ ...getButtonProps( { ...props, colors } ) }
-				identifier="text"
-			/>
+			{ isReadonly ? (
+				<div { ...getButtonProps( { ...props, colors } ) }>
+					{ props.text }
+				</div>
+			) : (
+				<RichText
+					placeholder={
+						placeholder || __( 'Add text…', 'sensei-lms' )
+					}
+					value={ text }
+					onChange={ ( value ) => setAttributes( { text: value } ) }
+					withoutInteractiveFormatting
+					{ ...getButtonProps( { ...props, colors } ) }
+					identifier="text"
+				/>
+			) }
 			<ButtonBlockSettings { ...props } />
 		</div>
 	);

--- a/assets/blocks/single-course.scss
+++ b/assets/blocks/single-course.scss
@@ -3,3 +3,4 @@
 @import 'contact-teacher/contact-teacher';
 @import 'course-outline/style';
 @import 'course-progress/style';
+@import 'button/button';

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -835,6 +835,11 @@ section.entry span.course-lesson-progress { margin-left: 10px; }
         content: '\f00c';
       }
     }
+    &.clean {
+      background: rgba(#ccc, 0.3);
+      color: inherit;
+      padding: 1em;
+    }
     &.info {
       background:#eee;
       &:before  {

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -126,7 +126,7 @@ class Sensei_Block_Take_Course {
 	 * @return string
 	 */
 	private function render_disabled_with_prerequisite( $course_id, $content ) {
-		$notice  = '<figcaption>' . $this->get_course_prerequisite_message( $course_id ) . '</figcaption>';
+		$notice  = '<div class="wp-block-sensei-button__notice">' . $this->get_course_prerequisite_message( $course_id ) . '</div>';
 		$content = preg_replace( '/(\<button)/i', '<button disabled="disabled"', $content );
 		$content = preg_replace( '/(<\/button>)/', '$1 ' . $notice, $content );
 		return $content;

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -139,7 +139,7 @@ class Sensei_Block_Take_Course {
 	 *
 	 * @return string
 	 */
-	private function get_course_prerequisite_message( $course_id ) {
+	public function get_course_prerequisite_message( $course_id ) {
 		$course_prerequisite_id   = absint( get_post_meta( $course_id, '_course_prerequisite', true ) );
 		$course_title             = get_the_title( $course_prerequisite_id );
 		$prerequisite_course_link = '<a href="' . esc_url( get_permalink( $course_prerequisite_id ) )
@@ -153,7 +153,7 @@ class Sensei_Block_Take_Course {
 
 		$complete_prerequisite_message = sprintf(
 		// translators: Placeholder $1$s is the course title.
-			esc_html__( 'You must first complete %1$s before taking this course', 'sensei-lms' ),
+			esc_html__( 'You must first complete %1$s before taking this course.', 'sensei-lms' ),
 			$prerequisite_course_link
 		);
 

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -16,30 +16,9 @@ class Sensei_Blocks {
 	/**
 	 * Course outline block.
 	 *
-	 * @var Sensei_Course_Outline_Block
+	 * @var Sensei_Course_Blocks
 	 */
-	public $course_outline;
-
-	/**
-	 * Course progress block.
-	 *
-	 * @var Sensei_Progress_Bar_Block
-	 */
-	public $course_progress;
-
-	/**
-	 * Course progress block.
-	 *
-	 * @var Sensei_Block_Contact_Teacher
-	 */
-	public $contact_teacher;
-
-	/**
-	 * Take course block.
-	 *
-	 * @var Sensei_Block_Take_Course
-	 */
-	public $take_course;
+	public $course;
 
 	/**
 	 * Sensei_Blocks constructor .
@@ -56,10 +35,7 @@ class Sensei_Blocks {
 
 		// Init blocks.
 		if ( $sensei->feature_flags->is_enabled( 'course_outline' ) ) {
-			$this->course_outline  = new Sensei_Course_Outline_Block();
-			$this->course_progress = new Sensei_Course_Progress_Block();
-			$this->contact_teacher = new Sensei_Block_Contact_Teacher();
-			$this->take_course     = new Sensei_Block_Take_Course();
+			$this->course = new Sensei_Course_Blocks( $sensei );
 		}
 	}
 

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -50,6 +50,7 @@ class Sensei_Course_Blocks {
 
 		add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
+		add_filter( 'sensei_use_sensei_template', [ 'Sensei_Course_Blocks', 'skip_single_course_template' ] );
 
 		// Init blocks.
 		if ( $sensei->feature_flags->is_enabled( 'course_outline' ) ) {
@@ -89,6 +90,21 @@ class Sensei_Course_Blocks {
 
 		Sensei()->assets->enqueue( 'sensei-blocks', 'blocks/index.js', [], true );
 		Sensei()->assets->enqueue( 'sensei-single-course-editor', 'blocks/single-course.editor.css' );
+	}
+
+	/**
+	 * Disable single course template if there is an outline block present.
+	 *
+	 * @access private
+	 *
+	 * @param bool $enabled
+	 *
+	 * @return bool
+	 */
+	public static function skip_single_course_template( $enabled ) {
+		return is_single() && 'course' === get_post_type() && ! Sensei()->course->is_legacy_course( get_post() )
+			? false
+			: $enabled;
 	}
 
 }

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * File containing the class Sensei_Course_Blocks.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Course_Blocks
+ */
+class Sensei_Course_Blocks {
+	/**
+	 * Course outline block.
+	 *
+	 * @var Sensei_Course_Outline_Block
+	 */
+	public $outline;
+
+	/**
+	 * Course progress block.
+	 *
+	 * @var Sensei_Course_Progress_Block
+	 */
+	public $progress;
+
+	/**
+	 * Course progress block.
+	 *
+	 * @var Sensei_Block_Contact_Teacher
+	 */
+	public $contact_teacher;
+
+	/**
+	 * Take course block.
+	 *
+	 * @var Sensei_Block_Take_Course
+	 */
+	public $take_course;
+
+	/**
+	 * Sensei_Blocks constructor .
+	 *
+	 * @param Sensei_Main $sensei
+	 */
+	public function __construct( $sensei ) {
+
+		add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
+
+		// Init blocks.
+		if ( $sensei->feature_flags->is_enabled( 'course_outline' ) ) {
+			$this->outline         = new Sensei_Course_Outline_Block();
+			$this->progress        = new Sensei_Course_Progress_Block();
+			$this->contact_teacher = new Sensei_Block_Contact_Teacher();
+			$this->take_course     = new Sensei_Block_Take_Course();
+		}
+	}
+
+	/**
+	 * Enqueue frontend and editor assets.
+	 *
+	 * @access private
+	 */
+	public function enqueue_block_assets() {
+		if ( 'course' !== get_post_type() ) {
+			return;
+		}
+
+		Sensei()->assets->enqueue( 'sensei-single-course', 'blocks/single-course.css' );
+
+		if ( ! is_admin() ) {
+			Sensei()->assets->enqueue( 'sensei-single-course-frontend', 'blocks/course-outline/frontend.js' );
+		}
+	}
+
+	/**
+	 * Enqueue editor assets.
+	 *
+	 * @access private
+	 */
+	public function enqueue_block_editor_assets() {
+		if ( 'course' !== get_post_type() ) {
+			return;
+		}
+
+		Sensei()->assets->enqueue( 'sensei-blocks', 'blocks/index.js', [], true );
+		Sensei()->assets->enqueue( 'sensei-single-course-editor', 'blocks/single-course.editor.css' );
+	}
+
+}

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -57,7 +57,6 @@ class Sensei_Course_Outline_Block {
 	 * Sensei_Course_Outline_Block constructor.
 	 */
 	public function __construct() {
-		add_filter( 'sensei_use_sensei_template', [ 'Sensei_Course_Outline_Block', 'skip_single_course_template' ] );
 
 		add_action( 'init', [ $this, 'register_course_template' ], 101 );
 		add_action( 'init', [ $this, 'register_blocks' ] );
@@ -75,21 +74,6 @@ class Sensei_Course_Outline_Block {
 	 */
 	public function init() {
 		$this->block_content = null;
-	}
-
-	/**
-	 * Disable single course template if there is an outline block present.
-	 *
-	 * @access private
-	 *
-	 * @param bool $enabled
-	 *
-	 * @return bool
-	 */
-	public static function skip_single_course_template( $enabled ) {
-		return is_single() && 'course' === get_post_type() && has_block( 'sensei-lms/course-outline' )
-			? false
-			: $enabled;
 	}
 
 	/**

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -58,8 +58,7 @@ class Sensei_Course_Outline_Block {
 	 */
 	public function __construct() {
 		add_filter( 'sensei_use_sensei_template', [ 'Sensei_Course_Outline_Block', 'skip_single_course_template' ] );
-		add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
-		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
+
 		add_action( 'init', [ $this, 'register_course_template' ], 101 );
 		add_action( 'init', [ $this, 'register_blocks' ] );
 		add_action( 'init', [ $this, 'init' ] );
@@ -91,37 +90,6 @@ class Sensei_Course_Outline_Block {
 		return is_single() && 'course' === get_post_type() && has_block( 'sensei-lms/course-outline' )
 			? false
 			: $enabled;
-	}
-
-	/**
-	 * Enqueue frontend and editor assets.
-	 *
-	 * @access private
-	 */
-	public function enqueue_block_assets() {
-		if ( 'course' !== get_post_type() ) {
-			return;
-		}
-
-		Sensei()->assets->enqueue( 'sensei-single-course', 'blocks/single-course.css' );
-
-		if ( ! is_admin() ) {
-			Sensei()->assets->enqueue( 'sensei-single-course-frontend', 'blocks/course-outline/frontend.js' );
-		}
-	}
-
-	/**
-	 * Enqueue editor assets.
-	 *
-	 * @access private
-	 */
-	public function enqueue_block_editor_assets() {
-		if ( 'course' !== get_post_type() ) {
-			return;
-		}
-
-		Sensei()->assets->enqueue( 'sensei-blocks', 'blocks/index.js', [], true );
-		Sensei()->assets->enqueue( 'sensei-single-course-editor', 'blocks/single-course.editor.css' );
 	}
 
 	/**

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -120,7 +120,7 @@ class Sensei_Course_Outline_Block {
 			return;
 		}
 
-		Sensei()->assets->enqueue( 'sensei-blocks', 'blocks/index.js' );
+		Sensei()->assets->enqueue( 'sensei-blocks', 'blocks/index.js', [], true );
 		Sensei()->assets->enqueue( 'sensei-single-course-editor', 'blocks/single-course.editor.css' );
 	}
 

--- a/includes/blocks/class-sensei-course-outline-course-block.php
+++ b/includes/blocks/class-sensei-course-outline-course-block.php
@@ -76,11 +76,11 @@ class Sensei_Course_Outline_Course_Block {
 				array_map(
 					function( $block ) use ( $post_id, $attributes ) {
 						if ( 'module' === $block['type'] ) {
-							return Sensei()->blocks->course_outline->module->render_module_block( $block, $post_id, $attributes );
+							return Sensei()->blocks->course->outline->module->render_module_block( $block, $post_id, $attributes );
 						}
 
 						if ( 'lesson' === $block['type'] ) {
-							return Sensei()->blocks->course_outline->lesson->render_lesson_block( $block, $post_id );
+							return Sensei()->blocks->course->outline->lesson->render_lesson_block( $block, $post_id );
 						}
 					},
 					$blocks

--- a/includes/blocks/class-sensei-course-outline-module-block.php
+++ b/includes/blocks/class-sensei-course-outline-module-block.php
@@ -88,7 +88,7 @@ class Sensei_Course_Outline_Module_Block {
 				'',
 				array_map(
 					function( $block ) use ( $course_id ) {
-						return Sensei()->blocks->course_outline->lesson->render_lesson_block( $block, $course_id );
+						return Sensei()->blocks->course->outline->lesson->render_lesson_block( $block, $course_id );
 					},
 					$block['lessons']
 				)

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3626,6 +3626,10 @@ class Sensei_Course {
 
 		// Add message links to courses.
 		add_action( 'sensei_single_course_content_inside_before', [ $sensei->post_types->messages, 'send_message_link' ], 35 );
+
+		// Course prerequisite completion message.
+		add_action( 'sensei_single_course_content_inside_before', array( 'Sensei_Course', 'prerequisite_complete_message' ), 20 );
+
 	}
 
 	/**
@@ -3645,6 +3649,9 @@ class Sensei_Course {
 
 		// Take this course.
 		remove_action( 'sensei_single_course_content_inside_before', [ __CLASS__, 'the_course_enrolment_actions' ], 30 );
+
+		// Course prerequisite completion message.
+		remove_action( 'sensei_single_course_content_inside_before', array( 'Sensei_Course', 'prerequisite_complete_message' ), 20 );
 
 		// Add message links to courses.
 		remove_action( 'sensei_single_course_content_inside_before', [ Sensei()->post_types->messages, 'send_message_link' ], 35 );

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -176,10 +176,6 @@ add_action( 'sensei_single_lesson_content_inside_after', 'sensei_the_single_less
 // hook in the lesson prerequisite completion message
 add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'prerequisite_complete_message' ), 20 );
 
-// @since 1.9.10
-// hook in the course prerequisite completion message
-add_action( 'sensei_single_course_content_inside_before', array( 'Sensei_Course', 'prerequisite_complete_message' ), 20 );
-
 // @since 1.9.0
 // hook the single lesson course_signup_link
 add_action( 'sensei_single_lesson_content_inside_before', array( 'Sensei_Lesson', 'course_signup_link' ), 30 );

--- a/tests/unit-tests/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/test-class-sensei-course-outline-block.php
@@ -14,7 +14,7 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 		parent::setUp();
 		$this->factory = new Sensei_Factory();
 
-		Sensei()->blocks->course_outline->init();
+		Sensei()->blocks->course->outline->init();
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,8 +35,6 @@ const files = [
 	'blocks/index.js',
 	'blocks/single-course.scss',
 	'blocks/single-course.editor.scss',
-	'blocks/course-progress/index.js',
-	'blocks/course-progress/style.scss',
 
 	'css/frontend.scss',
 	'css/admin-custom.css',


### PR DESCRIPTION

Contains a few changes needed for a Purchase course button for paid courses, and some general cleanup refactoring.

### Changes proposed in this Pull Request

* Add readonly mode to button block edit components by specifying a `text` prop
* Add a new `Sensei_Course_Blocks` class to group the various single course page blocks.
* Move single course block asset enqueue functions from the outline block to the above new class.
* Enqueue the course block editor scripts in the footer, so that an extension can filter block registrations

### Testing instructions

* Everything on the single course block editor and on the frontend should still work as previously

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
