### PR TITLE
Add block icons

### DIFF
--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -4,6 +4,7 @@ import { merge } from 'lodash';
 import './color-hooks';
 import { EditButtonBlock } from './edit-button';
 import { saveButtonBlock } from './save-button';
+import { button as icon } from '../../icons/wordpress-icons';
 
 /**
  * Button block styles.
@@ -68,6 +69,7 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 				align: false,
 				html: false,
 			},
+			icon,
 			styles: [ BlockStyles.Fill, BlockStyles.Outline ],
 			edit( props ) {
 				return <EditButtonBlock { ...props } { ...options } />;

--- a/assets/blocks/course-progress/index.js
+++ b/assets/blocks/course-progress/index.js
@@ -1,4 +1,5 @@
 import { __ } from '@wordpress/i18n';
+import { ProgressIcon as icon } from '../../icons';
 import edit from './edit';
 import metadata from './block';
 
@@ -13,6 +14,7 @@ export default {
 		__( 'Bar', 'sensei-lms' ),
 		__( 'Course', 'sensei-lms' ),
 	],
+	icon,
 	...metadata,
 	edit,
 };

--- a/assets/icons/index.js
+++ b/assets/icons/index.js
@@ -1,3 +1,4 @@
 export { CourseIcon } from './course-icon';
 export { LessonIcon } from './lesson-icon';
 export { ModuleIcon } from './module-icon';
+export { ProgressIcon } from './progress-icon';

--- a/assets/icons/progress-icon.js
+++ b/assets/icons/progress-icon.js
@@ -1,27 +1,19 @@
 import { Rect, Path, SVG } from '@wordpress/components';
 
 export const ProgressIcon = () => (
-	<SVG
-		width="24"
-		height="24"
-		viewBox="0 0 24 24"
-		fill="none"
-		xmlns="http://www.w3.org/2000/svg"
-	>
+	<SVG viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 		<Rect
 			x="2.75"
 			y="7.75"
 			width="18.5"
 			height="6.5"
 			rx="3.25"
-			stroke="black"
+			stroke="currentColor"
 			stroke-width="1.5"
 			fill-opacity="0"
 		/>
 		<Path
 			d="M6 7.75 H 16.7 L 10.2 14.25 H 6 C 4.2 14.25 2.75 12.8 2.75 11 C 2.75 9.2 4.2 7.75 6 7.75Z"
-			fill="black"
-			stroke="black"
 			stroke-width="1.5"
 		/>
 	</SVG>

--- a/assets/icons/progress-icon.js
+++ b/assets/icons/progress-icon.js
@@ -1,0 +1,28 @@
+import { Rect, Path, SVG } from '@wordpress/components';
+
+export const ProgressIcon = () => (
+	<SVG
+		width="24"
+		height="24"
+		viewBox="0 0 24 24"
+		fill="none"
+		xmlns="http://www.w3.org/2000/svg"
+	>
+		<Rect
+			x="2.75"
+			y="7.75"
+			width="18.5"
+			height="6.5"
+			rx="3.25"
+			stroke="black"
+			stroke-width="1.5"
+			fill-opacity="0"
+		/>
+		<Path
+			d="M6 7.75 H 16.7 L 10.2 14.25 H 6 C 4.2 14.25 2.75 12.8 2.75 11 C 2.75 9.2 4.2 7.75 6 7.75Z"
+			fill="black"
+			stroke="black"
+			stroke-width="1.5"
+		/>
+	</SVG>
+);

--- a/assets/icons/wordpress-icons.js
+++ b/assets/icons/wordpress-icons.js
@@ -17,3 +17,9 @@ export const checked = (
 		<Path d="M9 18.6L3.5 13l1-1L9 16.4l9.5-9.9 1 1z" />
 	</SVG>
 );
+
+export const button = (
+	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+		<Path d="M19 6.5H5c-1.1 0-2 .9-2 2v7c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7c0-1.1-.9-2-2-2zm.5 9c0 .3-.2.5-.5.5H5c-.3 0-.5-.2-.5-.5v-7c0-.3.2-.5.5-.5h14c.3 0 .5.2.5.5v7zM8 13h8v-1.5H8V13z" />
+	</SVG>
+);

--- a/assets/icons/wordpress-icons.js
+++ b/assets/icons/wordpress-icons.js
@@ -1,5 +1,9 @@
 import { Path, SVG } from '@wordpress/components';
 
+/**
+ * The following components are copied from @wordpress/icons since the package is not available on WP 5.3. We should
+ * remove them once we stop supporting 5.3.
+ */
 export const chevronRight = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z" />


### PR DESCRIPTION
Fixes #3738

### Changes proposed in this Pull Request

* Adds icons to button blocks and to course progress.

### Testing instructions

* Observe that Sensei blocks have icons.
### Screenshot / Video
