### PR TITLE
Analysis export: Remove report name from nonce action

### DIFF
--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -692,7 +692,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 			$url_args['user_id'] = $this->user_id;
 		}
 		$url = add_query_arg( $url_args, admin_url( 'admin.php' ) );
-		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download-' . $report, '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
+		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download', '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
 	} // End data_table_footer()
 
 	/**

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -359,7 +359,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 			),
 			admin_url( 'admin.php' )
 		);
-		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download-' . $report, '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
+		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download', '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
 	} // End data_table_footer()
 
 	/**

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -729,7 +729,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			),
 			admin_url( 'admin.php' )
 		);
-		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download-' . $report, '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
+		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download', '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
 	} // End data_table_footer()
 
 	/**

--- a/includes/class-sensei-analysis-user-profile-list-table.php
+++ b/includes/class-sensei-analysis-user-profile-list-table.php
@@ -340,7 +340,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 			),
 			admin_url( 'admin.php' )
 		);
-		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download-' . $report, '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
+		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download', '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
 	}
 
 	/**

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -573,7 +573,7 @@ class Sensei_Analysis {
 			$report = sanitize_text_field( $_GET['sensei_report_download'] );
 
 			// Simple verification to ensure intent, Note that a Nonce is per user, so the URL can't be shared
-			if ( ! wp_verify_nonce( $_REQUEST['_sdl_nonce'], 'sensei_csv_download-' . $report ) ) {
+			if ( ! wp_verify_nonce( $_REQUEST['_sdl_nonce'], 'sensei_csv_download' ) ) {
 				wp_die( esc_html__( 'Invalid request', 'sensei-lms' ) );
 			}
 


### PR DESCRIPTION
Fixes #3471

### Changes proposed in this Pull Request

* Remove report name (containing course slug) from nonce action name. This is not really needed there and the underlying hash function seems to have an issue with some special characters.

### Testing instructions

* From the issue:

    > Create a course with a Hebrew title (e.g. קרעע).
    > Assign a lesson to the course.
    > Go to Sensei LMS > Analysis > Courses.
    > Click on the course in the list.
    > Click Export all rows (CSV).

* Ensure exporting also works for all other tables (user, lesson)

