### PR TITLE
Strip HTML from plugin installation error message

### DIFF
--- a/includes/admin/class-sensei-plugins-installation.php
+++ b/includes/admin/class-sensei-plugins-installation.php
@@ -225,6 +225,9 @@ class Sensei_Plugins_Installation {
 	 * @param string $message Error message.
 	 */
 	private function save_error( $slug, $message ) {
+
+		$message = wp_kses( $message, [] );
+
 		$installing_plugins = $this->get_installing_plugins();
 		$key                = array_search( $slug, wp_list_pluck( $installing_plugins, 'product_slug' ), true );
 


### PR DESCRIPTION
Fixes #3546

Went with the easier solution of just removing formatting from the error message, since there is not really an easy & safe way to render that HTML.

### Changes proposed in this Pull Request

* Strip HTML from plugin installation error message in Setup Wizard features installation. 
* Add a bit of spacing for the error message.

### Testing instructions

* From the issue:

> 1. Setup an env with WP 5.2 or less.
> 2. Go to the Setup Wizard.
> 3. Go to the Features step.
> 4. Install the Sensei LMS Certificates.
> 5. See error.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
<img width="506" alt="image" src="https://user-images.githubusercontent.com/176949/98248562-65885400-1f75-11eb-95ce-27ae1f248e29.png">


