### PR TITLE
Remove the temporary feature flag for the Course Outline features

### DIFF
--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -34,9 +34,7 @@ class Sensei_Blocks {
 		add_filter( 'block_categories', [ $this, 'sensei_block_categories' ], 10, 2 );
 
 		// Init blocks.
-		if ( $sensei->feature_flags->is_enabled( 'course_outline' ) ) {
-			$this->course = new Sensei_Course_Blocks( $sensei );
-		}
+		$this->course = new Sensei_Course_Blocks( $sensei );
 	}
 
 	/**

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -53,12 +53,10 @@ class Sensei_Course_Blocks {
 		add_filter( 'sensei_use_sensei_template', [ 'Sensei_Course_Blocks', 'skip_single_course_template' ] );
 
 		// Init blocks.
-		if ( $sensei->feature_flags->is_enabled( 'course_outline' ) ) {
-			$this->outline         = new Sensei_Course_Outline_Block();
-			$this->progress        = new Sensei_Course_Progress_Block();
-			$this->contact_teacher = new Sensei_Block_Contact_Teacher();
-			$this->take_course     = new Sensei_Block_Take_Course();
-		}
+		$this->outline         = new Sensei_Course_Outline_Block();
+		$this->progress        = new Sensei_Course_Progress_Block();
+		$this->contact_teacher = new Sensei_Block_Contact_Teacher();
+		$this->take_course     = new Sensei_Block_Take_Course();
 	}
 
 	/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3486,10 +3486,7 @@ class Sensei_Course {
 	 * @param \WP_Post $post    Post object.
 	 */
 	public function mark_updating_course_id( $post_id, $post ) {
-		if (
-			! Sensei()->feature_flags->is_enabled( 'course_outline' )
-			|| 'publish' !== $post->post_status
-		) {
+		if ( 'publish' !== $post->post_status ) {
 			return;
 		}
 

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -21,7 +21,6 @@ class Sensei_Feature_Flags {
 				'rest_api_v1'                  => false,
 				'rest_api_v1_skip_permissions' => false,
 				'enrolment_provider_tooltip'   => false,
-				'course_outline'               => false,
 				'optional_templates'           => false,
 			)
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Remove the temporary feature flag for the Course Outline features.

### Testing instructions

* Remove the `course_outline` feature flag, if you have it enabled.
* Make sure the course outline block continue working properly.