### PR TITLE
Always use numeric grade from manual grading

### DIFF
--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -110,7 +110,7 @@ class Sensei_Grading_User_Quiz {
 			<div class="buttons">
 				<input type="submit" value="<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>" class="grade-button button-primary" title="Saves grades as currently marked on this page" />
 				<input type="button" value="<?php esc_attr_e( 'Auto grade', 'sensei-lms' ); ?>" class="autograde-button button-secondary" title="Where possible, automatically grades questions that have not yet been graded" />
-				<input type="reset" value="<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>" class="reset-button button-secondary" title="Resets all questions to ungraded and total grade to 0" />
+				<input type="button" value="<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>" class="reset-button button-link button-link-delete" title="Resets all questions to ungraded and total grade to 0" />
 			</div>
 			<div class="clear"></div><br/>
 			<?php
@@ -339,7 +339,7 @@ class Sensei_Grading_User_Quiz {
 			<div class="buttons">
 				<input type="submit" value="<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>" class="grade-button button-primary" title="Saves grades as currently marked on this page" />
 				<input type="button" value="<?php esc_attr_e( 'Auto grade', 'sensei-lms' ); ?>" class="autograde-button button-secondary" title="Where possible, automatically grades questions that have not yet been graded" />
-				<input type="reset" value="<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>" class="reset-button button-secondary" title="Resets all questions to ungraded and total grade to 0" />
+				<input type="button" value="<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>" class="reset-button button-link button-link-delete" title="Resets all questions to ungraded and total grade to 0" />
 			</div>
 			<div class="clear"></div>
 			<script type="text/javascript">

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -633,14 +633,9 @@ class Sensei_Grading {
 			++$count;
 			$question_id = $question->ID;
 
-			if ( isset( $_POST[ 'question_' . $question_id ] ) ) {
+			if ( isset( $_POST[ 'question_' . $question_id . '_grade' ] ) ) {
 
-				$question_grade = 0;
-				if ( $_POST[ 'question_' . $question_id ] == 'right' ) {
-
-					$question_grade = $_POST[ 'question_' . $question_id . '_grade' ];
-
-				}
+				$question_grade = absint( wp_unslash( $_POST[ 'question_' . $question_id . '_grade' ] ) ) ?? 0;
 
 				// add data to the array that will, after the loop, be stored on the lesson status
 				$all_question_grades[ $question_id ] = $question_grade;


### PR DESCRIPTION
Fixes #3674

### Changes proposed in this Pull Request

* Removes logic that only sets the grade to the numeric value submitted by the teacher if the Right checkbox was also selected, and sets it to 0 otherwise. And in some cases when neither the right or wrong mark was set, it wouldn't update the grade.
  * The grading page already sets the numeric value when the Right/Wrong mark is clicked, so the grade will always be set to what to user submitted, without any unexpected implicit behavior.

### Testing instructions

* From the issue:

    Create a quiz with a few of questions and set it to manual grading.
    Answer the quiz with a user.
    Go to grading and try entering a grade for each answer and click Save/Grade
    Observe that the grades are ~not~ saved.
*  Check that grades can be updated even for auto-graded questions. 
