### PR TITLE
Update outline block editor to reflect the frontend

### DIFF
--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -1,7 +1,8 @@
 $dark-gray: #1a1d20;
 .block-editor {
 	.wp-block-sensei-lms-course-outline {
-		padding: 1px 1em 0;
+		padding: 0 1em;
+		margin: 0 -1em;
 
 		&__placeholder {
 			.components-button {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update the outline block editor spacing, as suggested [here](https://github.com/Automattic/sensei/pull/3726#pullrequestreview-520861107).
* Now the spacings are reflecting the same as the frontend, just with a little extra hit area in the sides.

### Testing instructions

* Create an outline block, add modules, and make sure you can select the outline block by clicking on side of the block (up to `21px`)

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Just the hit area advance extra `21px` to the left and to the right of the blue line in the screenshot:

<img width="700" alt="Screen Shot 2020-11-05 at 12 11 36" src="https://user-images.githubusercontent.com/876340/98258814-17b52100-1f60-11eb-9c48-00446ed3581e.png">