### PR TITLE
Do not allow user to clear the alignment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ cache:
   - vendor
   - "$HOME/.composer/cache"
 before_script:
+- wget -O phpunit https://phar.phpunit.de/phpunit-6.phar; chmod +x phpunit 
 - export PATH="$HOME/.composer/vendor/bin:$PATH"
 - |
   if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 sudo: false
 dist: xenial
 language: php
+services: mysql
 
 # Shared code for e2e jobs.
 e2e_defaults: &e2e_defaults

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
-dist: trusty
+dist: xenial
 language: php
 
 # Shared code for e2e jobs.

--- a/assets/blocks/button/settings-button.js
+++ b/assets/blocks/button/settings-button.js
@@ -53,7 +53,9 @@ export const ButtonBlockSettings = ( props ) => {
 					label={ __( 'Change button alignment', 'sensei-lms' ) }
 					value={ align || props.alignmentOptions?.default }
 					onChange={ ( nextAlign ) => {
-						setAttributes( { align: nextAlign } );
+						if ( nextAlign ) {
+							setAttributes( { align: nextAlign } );
+						}
 					} }
 					{ ...props.alignmentOptions }
 				/>

--- a/tests/bin/run-wp-unit-tests.sh
+++ b/tests/bin/run-wp-unit-tests.sh
@@ -8,6 +8,6 @@ if [[ ! -z "$WP_VERSION" ]]; then
 	if [[ ${TRAVIS_PHP_VERSION} > 7.1 ]]; then
 		./vendor/bin/phpunit
 	else
-		phpunit
+		./phpunit
 	fi
 fi


### PR DESCRIPTION
### Changes proposed in this Pull Request

* There was an issue with the 'Take course' block and its alignment control. To reproduce it, select the already selected alignment option in the block and observe that the element gets full width.
* The cause of this is that when the same option is selected, the selected class gets cleared.
* With this fix, when the same option is selected no changes are applied to the block.
* There are also a few fixes in Travis to make build work again.

### Testing instructions

* Add a 'Take course' block.
* Select the already selected alignment option in the block.
* Observe that there is no change.
* Check that the alignment is correct in the frontend.