### PR TITLE
Ensure sensei_course_start hook works without custom template for single course

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -73,7 +73,7 @@ class Sensei_Frontend {
 		add_action( 'sensei_reset_lesson_button', array( $this, 'sensei_reset_lesson_button' ) );
 		add_action( 'sensei_course_archive_meta', array( $this, 'sensei_course_archive_meta' ) );
 		add_action( 'sensei_lesson_meta', array( $this, 'sensei_lesson_meta' ), 10 );
-		add_action( 'sensei_single_course_content_inside_before', array( $this, 'sensei_course_start' ), 10 );
+		add_action( 'wp', array( $this, 'sensei_course_start' ), 10 );
 		add_filter( 'wp_login_failed', array( $this, 'sensei_login_fail_redirect' ), 10 );
 		add_filter( 'init', array( $this, 'sensei_handle_login_request' ), 10 );
 		add_action( 'init', array( $this, 'sensei_process_registration' ), 2 );
@@ -1249,7 +1249,8 @@ class Sensei_Frontend {
 
 		// Handle user starting the course.
 		if (
-			isset( $_POST['course_start'] )
+			is_singular( 'course' )
+			&& isset( $_POST['course_start'] )
 			&& wp_verify_nonce( $_POST['woothemes_sensei_start_course_noonce'], 'woothemes_sensei_start_course_noonce' )
 			&& Sensei_Course::can_current_user_manually_enrol( $post->ID )
 		) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix `sensei_course_start` hook when using theme template for Single Course page.

### Testing instructions

* Add the following code to your `wp-config.php` file: `define( 'SENSEI_FEATURE_FLAG_OPTIONAL_TEMPLATES', true );`. See [this PR](https://github.com/Automattic/sensei/pull/3706) for more details.
* Create a new course using blocks.
* Publish the course, and open it on the frontend.
* Ensure that clicking the "Take Course" button starts you in the course.
* Remove `define( 'SENSEI_FEATURE_FLAG_OPTIONAL_TEMPLATES', true );` from `wp-config.php` and test again. Ensure that it still works.
* Test on both a [supported theme](https://github.com/Automattic/sensei/tree/master/includes/theme-integrations) and an unsupported theme.