### PR TITLE
Fix messages alignment in TwentyTwenty theme

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -783,7 +783,8 @@ section.entry span.course-lesson-progress { margin-left: 10px; }
 .sensei, .course-container, .course, .lesson, .quiz, .learner-info  {
   p.sensei-message, div.sensei-message {
     clear: both;
-    margin: 1.387em 0 1.618em 0;
+    margin-top: 1.387em;
+    margin-bottom: 1.618em;
     padding: 1em 1.618em;
     border:none!important;
     @include border_radius(5px);


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR just fixes the message alignment for when the custom template for Single Course page is removed. It currently would break in the  TwentyTwenty theme.

### Testing instructions

* Activate the TwentyTwenty theme.
* Activate the [feature flag](https://href.li/?https://github.com/Automattic/sensei/pull/3706) to disable the custom template for the Single Course page.
* Checkout this branch on WC Paid Courses: `add/purchase-block-single-product`
* Attach a product to a course.
* Go to the course and click on the purchase button.
* Make sure you see the gray message centered.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1679" alt="Screen Shot 2020-11-10 at 15 06 03" src="https://user-images.githubusercontent.com/876340/98713408-58e57080-2366-11eb-8fa3-38b937371aa0.png">
