### PR TITLE
Fix readonly button

### DIFF
--- a/assets/blocks/button/button-props.js
+++ b/assets/blocks/button/button-props.js
@@ -23,7 +23,7 @@ export function getBorderRadiusProps( { attributes: { borderRadius } } ) {
 /**
  * Class and style attributes for the button.
  *
- * @param {{attributes, tagName}} props Block properties.
+ * @param {{attributes}} props Block properties.
  * @return {{className, style}} Output HTML attributes.
  */
 export function getButtonProps( props ) {
@@ -42,7 +42,6 @@ export function getButtonProps( props ) {
 			...borderProps.style,
 			...colorProps.style,
 		},
-		tagName: props.tagName,
 	};
 }
 

--- a/assets/blocks/button/edit-button.js
+++ b/assets/blocks/button/edit-button.js
@@ -10,20 +10,19 @@ import { ButtonBlockSettings } from './settings-button';
  * @param {Object} props
  */
 export const EditButtonBlock = ( props ) => {
-	const { placeholder, attributes, setAttributes } = props;
+	const { placeholder, attributes, setAttributes, tagName } = props;
 	const { text } = attributes;
 	const { colors } = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getSettings();
 	}, [] );
 
 	const isReadonly = undefined !== props.text;
+	const buttonProps = getButtonProps( { ...props, colors } );
 
 	return (
 		<div { ...getButtonWrapperProps( props ) }>
 			{ isReadonly ? (
-				<div { ...getButtonProps( { ...props, colors } ) }>
-					{ props.text }
-				</div>
+				<div { ...buttonProps }>{ props.text }</div>
 			) : (
 				<RichText
 					placeholder={
@@ -32,7 +31,8 @@ export const EditButtonBlock = ( props ) => {
 					value={ text }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
 					withoutInteractiveFormatting
-					{ ...getButtonProps( { ...props, colors } ) }
+					{ ...buttonProps }
+					tagName={ tagName }
 					identifier="text"
 				/>
 			) }

--- a/assets/blocks/button/save-button.js
+++ b/assets/blocks/button/save-button.js
@@ -15,7 +15,8 @@ export const saveButtonBlock = ( { attributes, className, tagName } ) => {
 	return (
 		<div { ...getButtonWrapperProps( { className, attributes } ) }>
 			<RichText.Content
-				{ ...getButtonProps( { attributes, tagName } ) }
+				{ ...getButtonProps( { attributes } ) }
+				tagName={ tagName }
 				value={ text }
 			/>
 		</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It just fixes an issue when using the Purchase button block because it was sending the tagName to the DOM as an attribute from the `div`.

### Testing instructions

* Activate the WCPC plugin.
* Create a course with the Take Course button.
* Add a product to the course.
* In the editor, open the browser console.
* You should not see an error related to the `tagName` being added to the DOM.