### PR TITLE
Hide course video meta box for new courses

### DIFF
--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -17,6 +17,7 @@ window.sensei_toggleLegacyMetaboxes = ( enable ) => {
 	const legacyMetaboxes = [
 		'meta-box-course-lessons',
 		'meta-box-module_course_mb',
+		'meta-box-course-video',
 	];
 
 	legacyMetaboxes.forEach( ( legacyMetabox ) => {

--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -14,23 +14,18 @@ window.sensei_toggleLegacyMetaboxes = ( enable ) => {
 	const editPostSelector = wp.data.select( 'core/edit-post' );
 	const editPostDispatcher = wp.data.dispatch( 'core/edit-post' );
 
-	if (
-		enable !==
-		editPostSelector.isEditorPanelEnabled( 'meta-box-course-lessons' )
-	) {
-		editPostDispatcher.toggleEditorPanelEnabled(
-			'meta-box-course-lessons'
-		);
-	}
+	const legacyMetaboxes = [
+		'meta-box-course-lessons',
+		'meta-box-module_course_mb',
+	];
 
-	if (
-		enable !==
-		editPostSelector.isEditorPanelEnabled( 'meta-box-module_course_mb' )
-	) {
-		editPostDispatcher.toggleEditorPanelEnabled(
-			'meta-box-module_course_mb'
-		);
-	}
+	legacyMetaboxes.forEach( ( legacyMetabox ) => {
+		if (
+			enable !== editPostSelector.isEditorPanelEnabled( legacyMetabox )
+		) {
+			editPostDispatcher.toggleEditorPanelEnabled( legacyMetabox );
+		}
+	} );
 };
 
 jQuery( document ).ready( function ( $ ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* The course video meta box should appear only for legacy courses.

### Testing instructions

* Create a course with new blocks, and make sure the video meta box is hidden.
* Create a legacy course (with new blocks), and make sure the video meta box appears.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

#### Legacy course:
<img width="1339" alt="Screen Shot 2020-11-13 at 11 49 43" src="https://user-images.githubusercontent.com/876340/99085360-d8618280-25a6-11eb-9772-4481d048bab4.png">

#### New course:
<img width="1055" alt="Screen Shot 2020-11-13 at 11 50 25" src="https://user-images.githubusercontent.com/876340/99085374-dd263680-25a6-11eb-83fd-6957c32a8156.png">
