### PR TITLE
Remove underline from `ins` inside the button

### DIFF
--- a/assets/blocks/button/button.scss
+++ b/assets/blocks/button/button.scss
@@ -22,4 +22,8 @@
 	&__notice {
 		margin: .5em 0;
 	}
+
+	ins {
+		text-decoration: none;
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It's for the case when we show product prices inside the button with the HTML format coming from WooCommerce.

### Testing instructions

* Simulate a block button with the `<ins>` tag inside. Eg.: `<div class="wp-block-sensei-button"><div class="wp-block-button__link" tagname="button"><div><del><span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol">R$</span>10,00</span></del> <ins><span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol">R$</span>0,00</span></ins> - Purchase Course</div></div></div>`

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="422" alt="Screen Shot 2020-11-13 at 17 49 38" src="https://user-images.githubusercontent.com/876340/99119822-9ea96f80-25d8-11eb-8903-33f987b38357.png">
