### PR TITLE
Update default border radius in the progress bar

### DIFF
--- a/assets/blocks/course-progress/settings.js
+++ b/assets/blocks/course-progress/settings.js
@@ -18,7 +18,7 @@ export function CourseProgressSettings( {
 	setHeight,
 } ) {
 	const initialHeight = 14;
-	const initialBorderRadius = 2;
+	const initialBorderRadius = 10;
 
 	borderRadius =
 		undefined === borderRadius ? initialBorderRadius : borderRadius;

--- a/assets/blocks/course-progress/style.scss
+++ b/assets/blocks/course-progress/style.scss
@@ -11,12 +11,12 @@
 
 .wp-block-sensei-lms-progress-bar {
 	height: 14px;
-	border-radius: 2px;
+	border-radius: 10px;
 	background-color: #E6E6E6;
 
 	div {
 		height: 100%;
-		border-radius: 2px;
+		border-radius: 10px;
 		background-color: #0064B4;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update default border radius in the progress bar to `10px`.

Notice that considering our current height, it's the maximum border-radius. Increase more will only have effect increasing the height too.

### Testing instructions

* Create a new course with a progress bar, and make sure the default radius is `10px`.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="636" alt="Screen Shot 2020-11-16 at 11 42 11" src="https://user-images.githubusercontent.com/876340/99266014-16f27980-2801-11eb-844d-8ba97d9bb45e.png">
