### PR TITLE
Add sensei blocks args filter

### DIFF
--- a/includes/blocks/class-sensei-block-contact-teacher.php
+++ b/includes/blocks/class-sensei-block-contact-teacher.php
@@ -28,7 +28,7 @@ class Sensei_Block_Contact_Teacher {
 	 * @access private
 	 */
 	public function register_block() {
-		register_block_type(
+		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/button-contact-teacher',
 			[
 				'render_callback' => [ $this, 'render_contact_teacher_block' ],

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -29,22 +29,7 @@ class Sensei_Block_Take_Course {
 	 * @access private
 	 */
 	public function register_block() {
-
-		/**
-		 * Filter the render callback of the Take Course block.
-		 *
-		 * In WordPress versions 5.5 and later, block type arguments can be filtered by using register_block_type_args
-		 * instead. This filter exists to support earlier versions only.
-		 *
-		 * @since 3.6.0
-		 * @hook sensei_take_course_block_type_args
-		 * @see register_block_type
-		 *
-		 * @param {array} $args The block arguments as defined by register_block_type.
-		 */
-		$block_args = apply_filters( 'sensei_take_course_block_type_args', [ 'render_callback' => [ $this, 'render_take_course_block' ] ] );
-
-		register_block_type( 'sensei-lms/button-take-course', $block_args );
+		Sensei_Blocks::register_sensei_block( 'sensei-lms/button-take-course', [ 'render_callback' => [ $this, 'render_take_course_block' ] ] );
 	}
 
 	/**

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -91,8 +91,8 @@ class Sensei_Blocks {
 		 * @see register_block_type_from_metadata
 		 * @see includes/blocks/compat.php
 		 *
-		 * @param {array}  $args The block arguments as defined by register_block_type.
-		 * @param {string} $args Block name.
+		 * @param {array}  $block_args The block arguments as defined by register_block_type.
+		 * @param {string} $block_name Block name.
 		 */
 		$block_args = apply_filters( 'sensei_block_type_args', $block_args, $block_name );
 

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -63,4 +63,43 @@ class Sensei_Blocks {
 			]
 		);
 	}
+
+	/**
+	 * Register Sensei block. It's a wrapper for `register_block_type` or
+	 * `register_block_type_from_metadata`, allowing to filter the args.
+	 *
+	 * @param string $block_name     Block name.
+	 * @param array  $block_args     Block arguments.
+	 * @param string $file_or_folder Path to the JSON file with metadata definition for
+	 *                               the block or path to the folder where the `block.json`
+	 *                               file is located. The block will be registered using
+	 *                               `register_block_type_from_metadata` if it's defined.
+	 */
+	public static function register_sensei_block( $block_name, $block_args, $file_or_folder = null ) {
+		/**
+		 * Filter the args of the Sensei blocks.
+		 *
+		 * In WordPress versions 5.5 and later, block type arguments can be filtered by using register_block_type_args
+		 * instead. This filter exists to support earlier versions only.
+		 *
+		 * Notice that for blocks being registered using the `$file_or_folder`, this filter runs before the
+		 * `register_block_type_from_metadata`.
+		 *
+		 * @since 3.6.0
+		 * @hook sensei_block_type_args
+		 * @see register_block_type
+		 * @see register_block_type_from_metadata
+		 * @see includes/blocks/compat.php
+		 *
+		 * @param {array}  $args The block arguments as defined by register_block_type.
+		 * @param {string} $args Block name.
+		 */
+		$block_args = apply_filters( 'sensei_block_type_args', $block_args, $block_name );
+
+		if ( null === $file_or_folder ) {
+			register_block_type( $block_name, $block_args );
+		} else {
+			register_block_type_from_metadata( $file_or_folder, $block_args );
+		}
+	}
 }

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -98,26 +98,29 @@ class Sensei_Course_Outline_Block {
 	 * @access private
 	 */
 	public function register_blocks() {
-		register_block_type_from_metadata(
-			Sensei()->assets->src_path( 'blocks/course-outline/course-block' ),
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/course-outline',
 			[
 				'render_callback' => [ $this, 'render_course_outline_block' ],
-			]
+			],
+			Sensei()->assets->src_path( 'blocks/course-outline/course-block' )
 		);
 
-		register_block_type_from_metadata(
-			Sensei()->assets->src_path( 'blocks/course-outline/module-block' ),
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/course-outline-module',
 			[
 				'render_callback' => [ $this, 'process_module_block' ],
 				'script'          => 'sensei-course-outline-frontend',
-			]
+			],
+			Sensei()->assets->src_path( 'blocks/course-outline/module-block' )
 		);
 
-		register_block_type_from_metadata(
-			Sensei()->assets->src_path( 'blocks/course-outline/lesson-block' ),
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/course-outline-lesson',
 			[
 				'render_callback' => [ $this, 'process_lesson_block' ],
-			]
+			],
+			Sensei()->assets->src_path( 'blocks/course-outline/lesson-block' )
 		);
 
 	}

--- a/includes/blocks/class-sensei-course-progress-block.php
+++ b/includes/blocks/class-sensei-course-progress-block.php
@@ -28,10 +28,11 @@ class Sensei_Course_Progress_Block {
 	 */
 	public function register_block() {
 		Sensei_Blocks::register_sensei_block(
-			Sensei()->assets->src_path( 'blocks/course-progress' ),
+			'sensei-lms/course-progress',
 			[
 				'render_callback' => [ $this, 'render_course_progress' ],
-			]
+			],
+			Sensei()->assets->src_path( 'blocks/course-progress' )
 		);
 	}
 

--- a/includes/blocks/class-sensei-course-progress-block.php
+++ b/includes/blocks/class-sensei-course-progress-block.php
@@ -27,7 +27,7 @@ class Sensei_Course_Progress_Block {
 	 * @access private
 	 */
 	public function register_block() {
-		register_block_type_from_metadata(
+		Sensei_Blocks::register_sensei_block(
 			Sensei()->assets->src_path( 'blocks/course-progress' ),
 			[
 				'render_callback' => [ $this, 'render_course_progress' ],


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It removes the `sensei_take_course_block_type_args` filter in favor of the generic `sensei_block_type_args`.

Notice that this is for backwards compatibility, and after the WP 5.5 we should use the `register_block_type_args`. See [this PR](https://github.com/Automattic/sensei/pull/3762) for more details.

### Testing instructions

* Create a course.
* Add all Sensei blocks to the course.
* Add the following filter, and make sure all the blocks render as a text "Filtered":
```php
		add_filter( 'sensei_block_type_args', function( $args ) {
			$args[ 'render_callback' ] = function() { return 'Filtered'; };
			return $args;
		} );
```

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* This introduces the `sensei_block_type_args` as replacement to `sensei_take_course_block_type_args`. It filters all the Sensei blocks, having the block name as argument.