### PR TITLE
Update block alignment component

### DIFF
--- a/assets/blocks/button/settings-button.js
+++ b/assets/blocks/button/settings-button.js
@@ -1,5 +1,5 @@
 import {
-	AlignmentToolbar,
+	BlockAlignmentToolbar,
 	BlockControls,
 	InspectorControls,
 } from '@wordpress/block-editor';
@@ -49,7 +49,7 @@ export const ButtonBlockSettings = ( props ) => {
 	return (
 		<>
 			<BlockControls>
-				<AlignmentToolbar
+				<BlockAlignmentToolbar
 					label={ __( 'Change button alignment', 'sensei-lms' ) }
 					value={ align || props.alignmentOptions?.default }
 					onChange={ ( nextAlign ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR just replaces the `AlignmentToolbar` from the buttons' alignment by `BlockAlignmentToolbar`, which contains a different design for blocks alignment.

### Testing instructions

* Create a course.
* Add the take course button block.
* Make sure the alignment layer has the same design than other components with block alignment.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="274" alt="Screen Shot 2020-11-16 at 16 25 21" src="https://user-images.githubusercontent.com/876340/99298368-60a28a80-2828-11eb-90be-c542d5011e50.png">
