### PR TITLE
Add return documentation to filter

### DIFF
--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -41,6 +41,8 @@ class Sensei_Block_Take_Course {
 		 * @see register_block_type
 		 *
 		 * @param {array} $args The block arguments as defined by register_block_type.
+		 *
+		 * @return {array} The filtered arguments.
 		 */
 		$block_args = apply_filters( 'sensei_take_course_block_type_args', [ 'render_callback' => [ $this, 'render_take_course_block' ] ] );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds return docs to filter as without it the filter is [documented](https://automattic.github.io/sensei/sensei_take_course_block_type_args.html) as an action.