### PR TITLE
Make detail fields required on exit survey

### DIFF
--- a/assets/admin/exit-survey/form.js
+++ b/assets/admin/exit-survey/form.js
@@ -27,11 +27,26 @@ export const ExitSurveyForm = ( { submit, skip } ) => {
 		[ submit ]
 	);
 
-	const hasInput = !! form.current?.elements?.reason?.value;
+	const onChange = () => {
+		const formData = new window.FormData( form.current );
+		updateInput( formData.values() );
+	};
+
+	let hasInput = false;
+	if ( form.current ) {
+		const formData = new window.FormData( form.current );
+		const detailsFieldName = `details-${ formData.get( 'reason' ) }`;
+		const detailsField =
+			form.current?.elements[ detailsFieldName ] || false;
+
+		hasInput =
+			!! formData.get( 'reason' ) &&
+			( ! detailsField || formData.get( detailsFieldName ) !== '' );
+	}
 
 	return (
 		<form
-			onChange={ updateInput }
+			onChange={ onChange }
 			className="sensei-modal sensei-exit-survey"
 			ref={ form }
 			onSubmit={ submitForm }

--- a/assets/admin/exit-survey/form.js
+++ b/assets/admin/exit-survey/form.js
@@ -41,7 +41,8 @@ export const ExitSurveyForm = ( { submit, skip } ) => {
 
 		hasInput =
 			!! formData.get( 'reason' ) &&
-			( ! detailsField || formData.get( detailsFieldName ) !== '' );
+			( ! detailsField ||
+				formData.get( detailsFieldName ).trim() !== '' );
 	}
 
 	return (

--- a/assets/admin/exit-survey/form.test.js
+++ b/assets/admin/exit-survey/form.test.js
@@ -11,12 +11,24 @@ describe( '<ExitSurveyForm />', () => {
 		skip: () => screen.getByRole( 'button', { name: 'Skip Feedback' } ),
 	};
 
-	it( 'Submit is disabled until an item is selected', () => {
-		const { getByLabelText } = render( <ExitSurveyForm /> );
+	it( 'Submit is disabled until an item is selected and details filled out (if provided)', () => {
+		const { getByLabelText, getByPlaceholderText } = render(
+			<ExitSurveyForm />
+		);
 
 		expect( buttons.submit() ).toBeDisabled();
 
+		// This reason does not require details.
+		userEvent.click( getByLabelText( 'I no longer need the plugin' ) );
+		expect( buttons.submit() ).not.toBeDisabled();
+
+		// This reason does expect details.
 		userEvent.click( getByLabelText( 'I found a better plugin' ) );
+		expect( buttons.submit() ).toBeDisabled();
+		userEvent.type(
+			getByPlaceholderText( "What's the name of the plugin?" ),
+			'Test detail'
+		);
 
 		expect( buttons.submit() ).not.toBeDisabled();
 	} );


### PR DESCRIPTION
Fixes #3774 

### Changes proposed in this Pull Request

* Make text fields required on exit survey.

### Testing instructions

* See issue.