### PR TITLE
Change contact teacher button default style

### DIFF
--- a/assets/blocks/button/edit-button.js
+++ b/assets/blocks/button/edit-button.js
@@ -4,7 +4,6 @@ import { __ } from '@wordpress/i18n';
 
 import { getButtonProps, getButtonWrapperProps } from './button-props';
 import { ButtonBlockSettings } from './settings-button';
-import { useSetDefaultStyle } from '../../shared/blocks/settings';
 
 /**
  * Edit component for a Button block.
@@ -12,20 +11,11 @@ import { useSetDefaultStyle } from '../../shared/blocks/settings';
  * @param {Object} props
  */
 export const EditButtonBlock = ( props ) => {
-	const {
-		placeholder,
-		attributes,
-		setAttributes,
-		clientId,
-		defaultStyle,
-		tagName,
-	} = props;
+	const { placeholder, attributes, setAttributes, tagName } = props;
 	const { text } = attributes;
 	const { colors } = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getSettings();
 	}, [] );
-
-	useSetDefaultStyle( clientId, defaultStyle );
 
 	const isReadonly = undefined !== props.text;
 	const buttonProps = getButtonProps( { ...props, colors } );

--- a/assets/blocks/button/edit-button.js
+++ b/assets/blocks/button/edit-button.js
@@ -1,32 +1,10 @@
-import { useEffect } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 import { getButtonProps, getButtonWrapperProps } from './button-props';
 import { ButtonBlockSettings } from './settings-button';
-
-/**
- * Hook to set the default style if no style is defined.
- *
- * @param {string} clientId     Block client ID.
- * @param {string} defaultStyle Default block style.
- */
-const useDefaultStyle = ( clientId, defaultStyle ) => {
-	const attributesSelector = ( select ) =>
-		select( 'core/block-editor' ).getBlock( clientId ).attributes;
-
-	const { className = '' } = useSelect( attributesSelector, [ clientId ] );
-	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
-
-	useEffect( () => {
-		if ( ! className.match( /is-style-\w+/ ) && defaultStyle ) {
-			updateBlockAttributes( clientId, {
-				className: `${ className } is-style-${ defaultStyle }`,
-			} );
-		}
-	}, [ clientId, className, defaultStyle, updateBlockAttributes ] );
-};
+import { useSetDefaultStyle } from '../../shared/blocks/settings';
 
 /**
  * Edit component for a Button block.
@@ -47,7 +25,7 @@ export const EditButtonBlock = ( props ) => {
 		return select( 'core/block-editor' ).getSettings();
 	}, [] );
 
-	useDefaultStyle( clientId, defaultStyle );
+	useSetDefaultStyle( clientId, defaultStyle );
 
 	const isReadonly = undefined !== props.text;
 	const buttonProps = getButtonProps( { ...props, colors } );

--- a/assets/blocks/button/edit-button.js
+++ b/assets/blocks/button/edit-button.js
@@ -1,8 +1,32 @@
+import { useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { RichText } from '@wordpress/block-editor';
-import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+
 import { getButtonProps, getButtonWrapperProps } from './button-props';
 import { ButtonBlockSettings } from './settings-button';
+
+/**
+ * Hook to set the default style if no style is defined.
+ *
+ * @param {string} clientId     Block client ID.
+ * @param {string} defaultStyle Default block style.
+ */
+const useDefaultStyle = ( clientId, defaultStyle ) => {
+	const attributesSelector = ( select ) =>
+		select( 'core/block-editor' ).getBlock( clientId ).attributes;
+
+	const { className = '' } = useSelect( attributesSelector, [ clientId ] );
+	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+
+	useEffect( () => {
+		if ( ! className.match( /is-style-\w+/ ) && defaultStyle ) {
+			updateBlockAttributes( clientId, {
+				className: `${ className } is-style-${ defaultStyle }`,
+			} );
+		}
+	}, [ clientId, className, defaultStyle, updateBlockAttributes ] );
+};
 
 /**
  * Edit component for a Button block.
@@ -10,11 +34,20 @@ import { ButtonBlockSettings } from './settings-button';
  * @param {Object} props
  */
 export const EditButtonBlock = ( props ) => {
-	const { placeholder, attributes, setAttributes, tagName } = props;
+	const {
+		placeholder,
+		attributes,
+		setAttributes,
+		clientId,
+		defaultStyle,
+		tagName,
+	} = props;
 	const { text } = attributes;
 	const { colors } = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getSettings();
 	}, [] );
+
+	useDefaultStyle( clientId, defaultStyle );
 
 	const isReadonly = undefined !== props.text;
 	const buttonProps = getButtonProps( { ...props, colors } );

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -92,7 +92,6 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 					<EditButtonBlockWithBlockStyle
 						{ ...props }
 						{ ...options }
-						defaultStyle={ defaultStyle }
 					/>
 				);
 			},

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { merge } from 'lodash';
+import { merge, find } from 'lodash';
 
 import './color-hooks';
 import { EditButtonBlock } from './edit-button';
@@ -46,6 +46,8 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 		? settings.styles
 		: [ { ...BlockStyles.Fill, isDefault: true }, BlockStyles.Outline ];
 
+	const defaultStyle = find( styles, 'isDefault' )?.name;
+
 	return merge(
 		{
 			name: 'sensei-lms/button',
@@ -80,7 +82,13 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 			icon,
 			styles,
 			edit( props ) {
-				return <EditButtonBlock { ...props } { ...options } />;
+				return (
+					<EditButtonBlock
+						{ ...props }
+						{ ...options }
+						defaultStyle={ defaultStyle }
+					/>
+				);
 			},
 			save( props ) {
 				return saveButtonBlock( { ...props, ...options } );

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -54,6 +54,11 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 		EditButtonBlock
 	);
 
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return -- We don't wanna recreate the component every edit render.
+	const SaveButtonBlockWithBlockStyle = withDefaultBlockStyle( defaultStyle )(
+		SaveButtonBlock
+	);
+
 	return merge(
 		{
 			name: 'sensei-lms/button',
@@ -96,7 +101,12 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 				);
 			},
 			save( props ) {
-				return SaveButtonBlock( { ...props, ...options } );
+				return (
+					<SaveButtonBlockWithBlockStyle
+						{ ...props }
+						{ ...options }
+					/>
+				);
 			},
 			example: {
 				attributes: {

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -5,6 +5,7 @@ import './color-hooks';
 import { EditButtonBlock } from './edit-button';
 import { saveButtonBlock } from './save-button';
 import { button as icon } from '../../icons/wordpress-icons';
+import { withDefaultBlockStyle } from '../../shared/blocks/settings';
 
 /**
  * Button block styles.
@@ -48,6 +49,11 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 
 	const defaultStyle = find( styles, 'isDefault' )?.name;
 
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return -- We don't wanna recreate the component every edit render.
+	const EditButtonBlockWithBlockStyle = withDefaultBlockStyle( defaultStyle )(
+		EditButtonBlock
+	);
+
 	return merge(
 		{
 			name: 'sensei-lms/button',
@@ -83,7 +89,7 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 			styles,
 			edit( props ) {
 				return (
-					<EditButtonBlock
+					<EditButtonBlockWithBlockStyle
 						{ ...props }
 						{ ...options }
 						defaultStyle={ defaultStyle }

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -3,7 +3,7 @@ import { merge, find } from 'lodash';
 
 import './color-hooks';
 import { EditButtonBlock } from './edit-button';
-import { saveButtonBlock } from './save-button';
+import { SaveButtonBlock } from './save-button';
 import { button as icon } from '../../icons/wordpress-icons';
 import { withDefaultBlockStyle } from '../../shared/blocks/settings';
 
@@ -96,7 +96,7 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 				);
 			},
 			save( props ) {
-				return saveButtonBlock( { ...props, ...options } );
+				return SaveButtonBlock( { ...props, ...options } );
 			},
 			example: {
 				attributes: {

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -13,7 +13,6 @@ export const BlockStyles = {
 	Fill: {
 		name: 'default',
 		label: __( 'Fill', 'sensei-lms' ),
-		isDefault: true,
 	},
 	Outline: {
 		name: 'outline',
@@ -42,6 +41,10 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 		},
 		...options,
 	};
+
+	const styles = settings.styles
+		? settings.styles
+		: [ { ...BlockStyles.Fill, isDefault: true }, BlockStyles.Outline ];
 
 	return merge(
 		{
@@ -75,7 +78,7 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 				html: false,
 			},
 			icon,
-			styles: [ BlockStyles.Fill, BlockStyles.Outline ],
+			styles,
 			edit( props ) {
 				return <EditButtonBlock { ...props } { ...options } />;
 			},

--- a/assets/blocks/button/save-button.js
+++ b/assets/blocks/button/save-button.js
@@ -9,7 +9,7 @@ import { getButtonProps, getButtonWrapperProps } from './button-props';
  * @param {string} props.className  Classname.
  * @param {string} props.tagName    Output HTML tag name.
  */
-export const saveButtonBlock = ( { attributes, className, tagName } ) => {
+export const SaveButtonBlock = ( { attributes, className, tagName } ) => {
 	const { text } = attributes;
 
 	return (

--- a/assets/blocks/button/save-button.test.js
+++ b/assets/blocks/button/save-button.test.js
@@ -1,10 +1,10 @@
 import { render } from '@testing-library/react';
-import { saveButtonBlock } from './save-button';
+import { SaveButtonBlock } from './save-button';
 
-describe( 'saveButtonBlock', () => {
+describe( 'SaveButtonBlock', () => {
 	it( 'sets wrapper class and default alignment', () => {
 		const { container } = render(
-			saveButtonBlock( {
+			SaveButtonBlock( {
 				attributes: { text: 'Button' },
 			} )
 		);
@@ -16,7 +16,7 @@ describe( 'saveButtonBlock', () => {
 
 	it( 'sets wrapper alignment from attribute', () => {
 		const { container } = render(
-			saveButtonBlock( {
+			SaveButtonBlock( {
 				attributes: { text: 'Button', align: 'center' },
 			} )
 		);
@@ -27,7 +27,7 @@ describe( 'saveButtonBlock', () => {
 
 	it( 'renders content as tagName', () => {
 		const { container } = render(
-			saveButtonBlock( {
+			SaveButtonBlock( {
 				tagName: 'button',
 				attributes: { text: 'Button' },
 			} )

--- a/assets/blocks/contact-teacher/index.js
+++ b/assets/blocks/contact-teacher/index.js
@@ -18,6 +18,10 @@ export default createButtonBlockType( {
 				default: 'Contact Teacher',
 			},
 		},
-		styles: [ BlockStyles.Fill, BlockStyles.Outline, BlockStyles.Link ],
+		styles: [
+			BlockStyles.Fill,
+			{ ...BlockStyles.Outline, isDefault: true },
+			BlockStyles.Link,
+		],
 	},
 } );

--- a/assets/shared/blocks/settings.js
+++ b/assets/shared/blocks/settings.js
@@ -1,3 +1,5 @@
+import { useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	ContrastChecker,
 	InspectorControls,
@@ -97,4 +99,26 @@ export const withDefaultBlockStyle = ( defaultStyleName = 'default' ) => (
 	if ( style ) extraProps.blockStyle = style[ 1 ];
 
 	return <Component { ...props } { ...extraProps } />;
+};
+
+/**
+ * Hook to set the default style if no style is defined.
+ *
+ * @param {string} clientId     Block client ID.
+ * @param {string} defaultStyle Default block style.
+ */
+export const useSetDefaultStyle = ( clientId, defaultStyle ) => {
+	const attributesSelector = ( select ) =>
+		select( 'core/block-editor' ).getBlock( clientId ).attributes;
+
+	const { className = '' } = useSelect( attributesSelector, [ clientId ] );
+	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+
+	useEffect( () => {
+		if ( ! className.match( /is-style-\w+/ ) && defaultStyle ) {
+			updateBlockAttributes( clientId, {
+				className: `${ className } is-style-${ defaultStyle }`,
+			} );
+		}
+	}, [ clientId, className, defaultStyle, updateBlockAttributes ] );
 };

--- a/assets/shared/blocks/settings.js
+++ b/assets/shared/blocks/settings.js
@@ -76,8 +76,12 @@ export const ColorSettings = ( { colorSettings, props } ) => {
 /**
  * Apply default style class if no style is selected.
  * Adds is-style-default to the className property.
+ *
+ * @param {string} defaultStyleName Default style name.
  */
-export const withDefaultBlockStyle = () => ( Component ) => ( props ) => {
+export const withDefaultBlockStyle = ( defaultStyleName = 'default' ) => (
+	Component
+) => ( props ) => {
 	let { className } = props;
 
 	const extraProps = {};
@@ -85,7 +89,7 @@ export const withDefaultBlockStyle = () => ( Component ) => ( props ) => {
 	if ( ! className || ! className.includes( 'is-style-' ) ) {
 		className = extraProps.className = [
 			className,
-			'is-style-default',
+			`is-style-${ defaultStyleName }`,
 		].join( ' ' );
 	}
 

--- a/assets/shared/blocks/settings.js
+++ b/assets/shared/blocks/settings.js
@@ -1,5 +1,3 @@
-import { useEffect } from '@wordpress/element';
-import { useSelect, useDispatch } from '@wordpress/data';
 import {
 	ContrastChecker,
 	InspectorControls,
@@ -99,26 +97,4 @@ export const withDefaultBlockStyle = ( defaultStyleName = 'default' ) => (
 	if ( style ) extraProps.blockStyle = style[ 1 ];
 
 	return <Component { ...props } { ...extraProps } />;
-};
-
-/**
- * Hook to set the default style if no style is defined.
- *
- * @param {string} clientId     Block client ID.
- * @param {string} defaultStyle Default block style.
- */
-export const useSetDefaultStyle = ( clientId, defaultStyle ) => {
-	const attributesSelector = ( select ) =>
-		select( 'core/block-editor' ).getBlock( clientId ).attributes;
-
-	const { className = '' } = useSelect( attributesSelector, [ clientId ] );
-	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
-
-	useEffect( () => {
-		if ( ! className.match( /is-style-\w+/ ) && defaultStyle ) {
-			updateBlockAttributes( clientId, {
-				className: `${ className } is-style-${ defaultStyle }`,
-			} );
-		}
-	}, [ clientId, className, defaultStyle, updateBlockAttributes ] );
 };

--- a/includes/blocks/class-sensei-block-contact-teacher.php
+++ b/includes/blocks/class-sensei-block-contact-teacher.php
@@ -62,7 +62,7 @@ class Sensei_Block_Contact_Teacher {
 		$contact_form = $this->teacher_contact_form( $post );
 
 		return '<div id="private_message" class="sensei-block-wrapper sensei-collapsible">
-				' . ( $this->add_button_attributes( $content, $contact_form_link, $attributes ) ) . '
+				' . ( $this->add_button_attributes( $content, $contact_form_link ) ) . '
 				' . $notice . '
 				<div class="sensei-collapsible__content ' . ( $contact_form_open ? '' : 'collapsed' ) . '">' . $contact_form . '</div>
 			</div>';
@@ -101,25 +101,14 @@ class Sensei_Block_Contact_Teacher {
 	}
 
 	/**
-	 * Add attributes to the block's <div> and <a> tags.
+	 * Add attributes to the block's <a> tag.
 	 *
-	 * @param string $content    Block HTML.
-	 * @param string $href       Link URL.
-	 * @param array  $attributes Block attributes.
+	 * @param string $content Block HTML.
+	 * @param string $href    Link URL.
 	 *
 	 * @return string Block HTML with additional href attribute.
 	 */
-	private function add_button_attributes( $content, $href, $attributes = [] ) {
-		// Add <div> class names.
-		$class_name = Sensei_Block_Helpers::block_class_with_default_style( $attributes, [], 'outline' );
-		$content    = preg_replace(
-			'/<div(.*?)class="(.*?)"(.*?)>/',
-			'<div class="$2 ' . esc_attr( $class_name ) . '" $1 $3>',
-			$content,
-			1
-		);
-
-		// Add <a> attributes.
+	private function add_button_attributes( $content, $href ) {
 		return preg_replace(
 			'/<a(.*)class="(.*)"(.*)>(.+)<\/a>/',
 			'<a href="' . esc_url( $href ) . '#private_message" class="sensei-collapsible__toggle $2" $1 $3>$4</a>',

--- a/includes/blocks/class-sensei-block-contact-teacher.php
+++ b/includes/blocks/class-sensei-block-contact-teacher.php
@@ -21,7 +21,6 @@ class Sensei_Block_Contact_Teacher {
 		add_action( 'init', [ $this, 'register_block' ] );
 	}
 
-
 	/**
 	 * Register progress bar block.
 	 *
@@ -63,7 +62,7 @@ class Sensei_Block_Contact_Teacher {
 		$contact_form = $this->teacher_contact_form( $post );
 
 		return '<div id="private_message" class="sensei-block-wrapper sensei-collapsible">
-				' . ( $this->add_button_attributes( $content, $contact_form_link ) ) . '
+				' . ( $this->add_button_attributes( $content, $contact_form_link, $attributes ) ) . '
 				' . $notice . '
 				<div class="sensei-collapsible__content ' . ( $contact_form_open ? '' : 'collapsed' ) . '">' . $contact_form . '</div>
 			</div>';
@@ -104,15 +103,24 @@ class Sensei_Block_Contact_Teacher {
 	/**
 	 * Add attributes to the block's <a> tag.
 	 *
-	 * @param string $content Block HTML.
-	 * @param string $href    Link URL.
+	 * @param string $content    Block HTML.
+	 * @param string $href       Link URL.
+	 * @param array  $attributes Block attributes.
 	 *
 	 * @return string Block HTML with additional href attribute.
 	 */
-	private function add_button_attributes( $content, $href ) {
+	private function add_button_attributes( $content, $href, $attributes = [] ) {
+		$class_name = Sensei_Block_Helpers::block_class_with_default_style( $attributes, [], 'outline' );
+
 		return preg_replace(
-			'/<a(.*)class="(.*)"(.*)>(.+)<\/a>/',
-			'<a href="' . esc_url( $href ) . '#private_message" class="sensei-collapsible__toggle $2" $1 $3>$4</a>',
+			'/<div(.*)class="(.*)"(.*)>(.*)<a(.*)class="(.*)"(.*)>(.+)<\/a>(.*)<\/div>/',
+			'
+				<div class="$2 ' . esc_attr( $class_name ) . '" $1 $3>
+					$4
+					<a href="' . esc_url( $href ) . '#private_message" class="sensei-collapsible__toggle $6" $5 $7>$8</a>
+					$9
+				</div>
+			',
 			$content,
 			1
 		);

--- a/includes/blocks/class-sensei-block-contact-teacher.php
+++ b/includes/blocks/class-sensei-block-contact-teacher.php
@@ -101,7 +101,7 @@ class Sensei_Block_Contact_Teacher {
 	}
 
 	/**
-	 * Add attributes to the block's <a> tag.
+	 * Add attributes to the block's <div> and <a> tags.
 	 *
 	 * @param string $content    Block HTML.
 	 * @param string $href       Link URL.
@@ -110,17 +110,19 @@ class Sensei_Block_Contact_Teacher {
 	 * @return string Block HTML with additional href attribute.
 	 */
 	private function add_button_attributes( $content, $href, $attributes = [] ) {
+		// Add <div> class names.
 		$class_name = Sensei_Block_Helpers::block_class_with_default_style( $attributes, [], 'outline' );
+		$content    = preg_replace(
+			'/<div(.*?)class="(.*?)"(.*?)>/',
+			'<div class="$2 ' . esc_attr( $class_name ) . '" $1 $3>',
+			$content,
+			1
+		);
 
+		// Add <a> attributes.
 		return preg_replace(
-			'/<div(.*)class="(.*)"(.*)>(.*)<a(.*)class="(.*)"(.*)>(.+)<\/a>(.*)<\/div>/',
-			'
-				<div class="$2 ' . esc_attr( $class_name ) . '" $1 $3>
-					$4
-					<a href="' . esc_url( $href ) . '#private_message" class="sensei-collapsible__toggle $6" $5 $7>$8</a>
-					$9
-				</div>
-			',
+			'/<a(.*)class="(.*)"(.*)>(.+)<\/a>/',
+			'<a href="' . esc_url( $href ) . '#private_message" class="sensei-collapsible__toggle $2" $1 $3>$4</a>',
 			$content,
 			1
 		);

--- a/includes/blocks/class-sensei-block-helpers.php
+++ b/includes/blocks/class-sensei-block-helpers.php
@@ -94,18 +94,19 @@ class Sensei_Block_Helpers {
 	 * Add default style to list of classes if no style is selected. If a parent classname is supplied, it will override
 	 * the default style.
 	 *
-	 * @param array $attributes        Block attributes.
-	 * @param array $parent_attributes Parent block attributes.
+	 * @param array  $attributes         Block attributes.
+	 * @param array  $parent_attributes  Parent block attributes.
+	 * @param string $default_style_name Default style name.
 	 *
 	 * @return string
 	 */
-	public static function block_class_with_default_style( $attributes, $parent_attributes = [] ) {
+	public static function block_class_with_default_style( $attributes, $parent_attributes = [], $default_style_name = 'default' ) {
 		$class_name = $attributes['className'] ?? '';
 		if ( false === strpos( $class_name, 'is-style-' ) ) {
 			$parent_class_name = $parent_attributes['className'] ?? '';
 
 			if ( false === strpos( $parent_class_name, 'is-style-' ) ) {
-				$class_name .= ' is-style-default';
+				$class_name .= ' is-style-' . $default_style_name;
 			} else {
 				preg_match( '/is-style-\w+/', $parent_class_name, $matches );
 				$class_name .= ' ' . $matches[0];

--- a/tests/unit-tests/test-class-sensei-contact-teacher-block.php
+++ b/tests/unit-tests/test-class-sensei-contact-teacher-block.php
@@ -35,7 +35,7 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 	 */
 	public function testHrefAttributeAdded() {
 
-		$output = $this->block->render_contact_teacher_block( [], '<div class=""><a class="wp-block-button__link">Contact teacher</a></div>' );
+		$output = $this->block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
 
 		$this->assertRegExp( '|<a href="/course/test/\?contact=course#private_message".*>Contact teacher</a>|', $output );
 	}
@@ -46,7 +46,7 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 	public function testSuccessMessageDisplayed() {
 		$_GET['send'] = 'complete';
 
-		$output = $this->block->render_contact_teacher_block( [], '<div class=""><a class="wp-block-button__link">Contact teacher</a></div>' );
+		$output = $this->block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
 
 		$this->assertContains( 'Your private message has been sent.', $output );
 	}
@@ -56,30 +56,10 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 	 */
 	public function testMessageForm() {
 
-		$output = $this->block->render_contact_teacher_block( [], '<div class=""><a class="wp-block-button__link">Contact teacher</a></div>' );
+		$output = $this->block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
 
 		$this->assertRegExp( '|<form.*<input.* name="sensei_message_teacher_nonce" .*</form>|ms', $output );
 		$this->assertRegExp( '|<form.*<textarea.* name="contact_message" .*</form>|ms', $output );
-	}
-
-	/**
-	 * Test default style.
-	 */
-	public function testDefaultStyle() {
-		$output = $this->block->render_contact_teacher_block( [], '<div class=""><a class="wp-block-button__link">Contact teacher</a></div>' );
-
-		$this->assertContains( 'is-style-outline', $output );
-		$this->assertNotContains( 'is-style-default', $output );
-	}
-
-	/**
-	 * Test custom style.
-	 */
-	public function testCustomStyle() {
-		$output = $this->block->render_contact_teacher_block( [ 'className' => 'is-style-default' ], '<div class=""><a class="wp-block-button__link">Contact teacher</a></div>' );
-
-		$this->assertContains( 'is-style-default', $output );
-		$this->assertNotContains( 'is-style-outline', $output );
 	}
 
 }

--- a/tests/unit-tests/test-class-sensei-contact-teacher-block.php
+++ b/tests/unit-tests/test-class-sensei-contact-teacher-block.php
@@ -35,7 +35,7 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 	 */
 	public function testHrefAttributeAdded() {
 
-		$output = $this->block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
+		$output = $this->block->render_contact_teacher_block( [], '<div class=""><a class="wp-block-button__link">Contact teacher</a></div>' );
 
 		$this->assertRegExp( '|<a href="/course/test/\?contact=course#private_message".*>Contact teacher</a>|', $output );
 	}
@@ -46,7 +46,7 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 	public function testSuccessMessageDisplayed() {
 		$_GET['send'] = 'complete';
 
-		$output = $this->block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
+		$output = $this->block->render_contact_teacher_block( [], '<div class=""><a class="wp-block-button__link">Contact teacher</a></div>' );
 
 		$this->assertContains( 'Your private message has been sent.', $output );
 	}
@@ -56,10 +56,30 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 	 */
 	public function testMessageForm() {
 
-		$output = $this->block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
+		$output = $this->block->render_contact_teacher_block( [], '<div class=""><a class="wp-block-button__link">Contact teacher</a></div>' );
 
 		$this->assertRegExp( '|<form.*<input.* name="sensei_message_teacher_nonce" .*</form>|ms', $output );
 		$this->assertRegExp( '|<form.*<textarea.* name="contact_message" .*</form>|ms', $output );
+	}
+
+	/**
+	 * Test default style.
+	 */
+	public function testDefaultStyle() {
+		$output = $this->block->render_contact_teacher_block( [], '<div class=""><a class="wp-block-button__link">Contact teacher</a></div>' );
+
+		$this->assertContains( 'is-style-outline', $output );
+		$this->assertNotContains( 'is-style-default', $output );
+	}
+
+	/**
+	 * Test custom style.
+	 */
+	public function testCustomStyle() {
+		$output = $this->block->render_contact_teacher_block( [ 'className' => 'is-style-default' ], '<div class=""><a class="wp-block-button__link">Contact teacher</a></div>' );
+
+		$this->assertContains( 'is-style-default', $output );
+		$this->assertNotContains( 'is-style-outline', $output );
 	}
 
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR introduces a check in the button styles. If it doesn't have a defined style, it adds the default (The one which contains the `isDefault: true`).

~~Notice that depending on the page load, when creating a new course it can take a little time to get the default style. It happens because of other processes. If we add a new contact block, or access the page again, it gets the default style immediately. If it bothers us, we can explore different approaches. cc @donnapep~~ See https://github.com/Automattic/sensei/pull/3787#discussion_r525533147

### Testing instructions

* Create a new course, and make sure the contact button will have the outline style as default.
* Access the course in the frontend and make sure the correct style is applied.
* Change the styles and make sure it continues working properly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="716" alt="Screen Shot 2020-11-17 at 15 37 30" src="https://user-images.githubusercontent.com/876340/99433132-e20f2100-28eb-11eb-9985-5549f5ecd7c3.png">
