### PR TITLE
Remove optional templates feature flag

### DIFF
--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -21,7 +21,6 @@ class Sensei_Feature_Flags {
 				'rest_api_v1'                  => false,
 				'rest_api_v1_skip_permissions' => false,
 				'enrolment_provider_tooltip'   => false,
-				'optional_templates'           => false,
 			)
 		);
 	}

--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -158,7 +158,7 @@ class Sensei_Templates {
 		 * @since  3.6.0
 		 * @access private
 		 */
-		if ( Sensei()->feature_flags->is_enabled( 'optional_templates' ) && ! apply_filters( 'sensei_use_sensei_template', true ) ) {
+		if ( ! apply_filters( 'sensei_use_sensei_template', true ) ) {
 			return $template;
 		}
 

--- a/includes/class-sensei-unsupported-themes.php
+++ b/includes/class-sensei-unsupported-themes.php
@@ -129,7 +129,7 @@ class Sensei_Unsupported_Themes {
 		 * @since  3.6.0
 		 * @access private
 		 */
-		if ( Sensei()->feature_flags->is_enabled( 'optional_templates' ) && ! apply_filters( 'sensei_use_sensei_template', true ) ) {
+		if ( ! apply_filters( 'sensei_use_sensei_template', true ) ) {
 			return;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Removes the [`optional_template` feature flag](https://github.com/Automattic/sensei/pull/3706).

### Testing instructions

* Remove the constant for this feature flag, if you have (`define( 'SENSEI_FEATURE_FLAG_OPTIONAL_TEMPLATES', true );`).
* Create a new course (with new blocks), and make sure it doesn't use the `single-course` template anymore.
* Create a legacy course (without new blocks), and make sure it still renders using the  `single-course` template.