### PR TITLE
Add wp-block-button class to buttons

### DIFF
--- a/assets/blocks/button/button-props.js
+++ b/assets/blocks/button/button-props.js
@@ -59,6 +59,7 @@ export function getButtonWrapperProps( { className, attributes: { align } } ) {
 		className: classnames(
 			className,
 			'wp-block-sensei-button',
+			'wp-block-button',
 			`has-text-align-${ align || 'left' }`
 		),
 	};


### PR DESCRIPTION
Fixes the issue where the Sensei buttons with the outline style would appear black in the frontend while using. TwentyTwenty 

### Changes proposed in this Pull Request

* Adds the `wp-block-button` class to the buttons. This way any themes adding CSS for this class will be applied.

### Testing instructions

* Create a Sensei button block and set an outline style.
* Check that the button on the fronend has the correct color.