### PR TITLE
Fix module, lesson title styles

### DIFF
--- a/assets/blocks/course-outline/lesson-block/lesson-block.scss
+++ b/assets/blocks/course-outline/lesson-block/lesson-block.scss
@@ -6,7 +6,7 @@
 	position: relative;
 
 
-	&, .entry-content &, .entry .entry-content & {
+	&, .entry-content &, .sensei .entry-content &:not(.button) {
 		font-size: 1em;
 
 		font-family: inherit;

--- a/assets/blocks/course-outline/module-block/module-block.scss
+++ b/assets/blocks/course-outline/module-block/module-block.scss
@@ -42,6 +42,10 @@ $block: '.wp-block-sensei-lms-course-outline-module';
 
 		a {
 			color: inherit;
+			text-decoration: inherit;
+			&:hover {
+				text-decoration: underline;
+			}
 		}
 	}
 

--- a/assets/blocks/course-outline/module-block/module-block.scss
+++ b/assets/blocks/course-outline/module-block/module-block.scss
@@ -40,7 +40,8 @@ $block: '.wp-block-sensei-lms-course-outline-module';
 			content: none;
 		}
 
-		a {
+		a:not(.button) {
+			font-weight: inherit;
 			color: inherit;
 			text-decoration: inherit;
 			&:hover {

--- a/assets/blocks/course-outline/module-block/module-block.scss
+++ b/assets/blocks/course-outline/module-block/module-block.scss
@@ -32,7 +32,8 @@ $block: '.wp-block-sensei-lms-course-outline-module';
 	}
 
 	#{$block}__title {
-		font-size: 1em;
+		font-size: 1.1em;
+		font-weight: inherit;
 		flex: 1;
 		margin: 0;
 		color: inherit;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix visual regression - Modules titles had underline on some themes when links to the module page were added 
* Storefront also has a pretty large specificity on link styles, so this picks up that arms race 😩 

### Testing instructions

* View a course with modules and lessons in an outline block on Storefront theme
* Ensure that module header and lesson styles look the same as the editor (with no underlines)
* Also check that things look right on other theme


