### PR TITLE
Update sensei category to use outline icon

### DIFF
--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -10,7 +10,7 @@ import {
 import { CourseIcon } from '../icons';
 
 updateCategory( 'sensei-lms', {
-	icon: CourseIcon( { width: '24', height: '24' } ),
+	icon: CourseIcon( { width: '20', height: '20' } ),
 } );
 
 [

--- a/assets/blocks/index.js
+++ b/assets/blocks/index.js
@@ -1,4 +1,4 @@
-import { registerBlockType } from '@wordpress/blocks';
+import { registerBlockType, updateCategory } from '@wordpress/blocks';
 import TakeCourseButtonBlock from './take-course';
 import ContactTeacherButton from './contact-teacher';
 import CourseProgressBlock from './course-progress';
@@ -7,6 +7,11 @@ import {
 	CourseOutlineLessonBlock,
 	CourseOutlineModuleBlock,
 } from './course-outline';
+import { CourseIcon } from '../icons';
+
+updateCategory( 'sensei-lms', {
+	icon: CourseIcon( { width: '24', height: '24' } ),
+} );
 
 [
 	CourseOutlineBlock,

--- a/assets/icons/course-icon.js
+++ b/assets/icons/course-icon.js
@@ -1,7 +1,7 @@
 import { Path, SVG } from '@wordpress/components';
 
-export const CourseIcon = () => (
-	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+export const CourseIcon = ( props ) => (
+	<SVG { ...props } viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
 		<Path d="M20 16V4H4v12h16z" />
 		<Path d="M18.5 5.5v9h-13v-9h13zM20 16H4V4h16v12zM6 20h2.222L11 16H8.778L6 20zM18 20h-2.222L13 16h2.222L18 20z" />
 	</SVG>

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -58,7 +58,6 @@ class Sensei_Blocks {
 				[
 					'slug'  => 'sensei-lms',
 					'title' => __( 'Sensei LMS', 'sensei-lms' ),
-					'icon'  => 'wordpress',
 				],
 			]
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Updates the Sensei category to use the course's outline icon.
* Currently we use the WordPress icon which I don't think it fits.
* We could alternatively create a new icon or do not display one at all.

### Testing instructions

* Open the blocks menu and observe that the icon beside Sensei category is updated.