### PR TITLE
Set color to inherit for module title input

### DIFF
--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -12,10 +12,9 @@ $dark-gray: #1a1d20;
 		}
 	}
 
-	.wp-block-sensei-lms-course-outline-module {
-		&__title-input {
-			background: none;
-		}
+	textarea.wp-block-sensei-lms-course-outline-module__title-input {
+		color: inherit;
+		background: none;
 	}
 
 	.wp-block-sensei-lms-course-outline-lesson {
@@ -35,6 +34,10 @@ $dark-gray: #1a1d20;
 			opacity: 0.5;
 			border-radius: 6px;
 		}
+	}
+
+	textarea.wp-block-sensei-lms-course-outline-lesson__input {
+		color: inherit;
 	}
 
 	.wp-block-sensei-lms-course-outline-status-control {

--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -15,6 +15,11 @@ $dark-gray: #1a1d20;
 	textarea.wp-block-sensei-lms-course-outline-module__title-input {
 		color: inherit;
 		background: none;
+		
+		&::placeholder {
+			color: inherit;
+			opacity: 0.5;
+		}
 	}
 
 	.wp-block-sensei-lms-course-outline-lesson {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This fixes an issue where the text was not viewable when the module title was selected.
* Additionally, the lesson title color would be always set to black when focused.
* It is reproducable in 5.4 only.
![record](https://user-images.githubusercontent.com/53191348/99809552-1cc2c480-2b4b-11eb-88a2-039cd9946507.gif)

### Testing instructions

* On WP 5.4 create a course outline block.
* With default module style and color type in some text in the module header.
* Observe that the text typed remains white.
* Select a color for the lesson title text.
* Type some in the lesson title and observe that the selected color is retained.
* Ensure that nothing is broken in 5.5.