### PR TITLE
Fix saving race condition

### DIFF
--- a/assets/blocks/course-outline/course-block/edit.js
+++ b/assets/blocks/course-outline/course-block/edit.js
@@ -1,5 +1,5 @@
 import { InnerBlocks } from '@wordpress/block-editor';
-import { useSelect, withSelect, dispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
 import { createContext, useEffect, useRef } from '@wordpress/element';
 
@@ -34,13 +34,18 @@ const useSynchronizeLessonsOnUpdate = function ( clientId, isPreview ) {
 		[ clientId ]
 	);
 
+	const { stopTrackingRemovedLessons } = useDispatch( COURSE_STATUS_STORE );
+
 	useEffect( () => {
 		if ( ! isPreview ) {
-			dispatch( COURSE_STATUS_STORE ).stopTrackingRemovedLessons(
-				outlineDescendants
-			);
+			stopTrackingRemovedLessons( outlineDescendants );
 		}
-	}, [ clientId, outlineDescendants, isPreview ] );
+	}, [
+		clientId,
+		outlineDescendants,
+		isPreview,
+		stopTrackingRemovedLessons,
+	] );
 };
 
 const useApplyStyleToModules = ( clientId, className, isPreview ) => {
@@ -83,32 +88,31 @@ const useApplyStyleToModules = ( clientId, className, isPreview ) => {
  * @param {Object}   props               Component props.
  * @param {string}   props.clientId      Block client ID.
  * @param {string}   props.className     Custom class name.
- * @param {Object[]} props.structure     Course module and lesson blocks.
  * @param {Object}   props.attributes    Block attributes.
  * @param {Function} props.setAttributes Block setAttributes callback.
  */
 const EditCourseOutlineBlock = ( {
 	clientId,
 	className,
-	structure,
 	attributes,
 	setAttributes,
 } ) => {
 	useToggleLegacyMetaboxes( { ignoreToggle: attributes.isPreview } );
+
+	const { fetchCourseStructure } = useDispatch( COURSE_STORE );
+	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+
+	useEffect( () => {
+		fetchCourseStructure();
+	}, [ fetchCourseStructure ] );
 
 	const { setBlocks } = useBlocksCreator( clientId );
 
 	const isEmpty = useSelect(
 		( select ) =>
 			! select( 'core/block-editor' ).getBlocks( clientId ).length,
-		[ clientId, structure ]
+		[ clientId ]
 	);
-
-	useEffect( () => {
-		if ( structure?.length && ! attributes.isPreview ) {
-			setBlocks( structure );
-		}
-	}, [ structure, setBlocks, attributes.isPreview ] );
 
 	useSynchronizeLessonsOnUpdate( clientId, attributes.isPreview );
 	useApplyStyleToModules( clientId, className, attributes.isPreview );
@@ -120,12 +124,9 @@ const EditCourseOutlineBlock = ( {
 		);
 
 		modules.forEach( ( module ) => {
-			dispatch( 'core/block-editor' ).updateBlockAttributes(
-				module.clientId,
-				{
-					bordered: newValue,
-				}
-			);
+			updateBlockAttributes( module.clientId, {
+				bordered: newValue,
+			} );
 		} );
 
 		setAttributes( { moduleBorder: newValue } );
@@ -170,11 +171,4 @@ const EditCourseOutlineBlock = ( {
 	);
 };
 
-const selectors = ( select ) => ( {
-	structure: select( COURSE_STORE ).getStructure(),
-} );
-
-export default compose(
-	withSelect( selectors ),
-	withDefaultBlockStyle()
-)( EditCourseOutlineBlock );
+export default compose( withDefaultBlockStyle() )( EditCourseOutlineBlock );

--- a/assets/blocks/course-outline/course-block/edit.js
+++ b/assets/blocks/course-outline/course-block/edit.js
@@ -103,8 +103,10 @@ const EditCourseOutlineBlock = ( {
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
 
 	useEffect( () => {
-		fetchCourseStructure();
-	}, [ fetchCourseStructure ] );
+		if ( ! attributes.isPreview ) {
+			fetchCourseStructure();
+		}
+	}, [ attributes.isPreview, fetchCourseStructure ] );
 
 	const { setBlocks } = useBlocksCreator( clientId );
 

--- a/assets/blocks/course-outline/course-block/save.js
+++ b/assets/blocks/course-outline/course-block/save.js
@@ -1,11 +1,5 @@
 import { InnerBlocks } from '@wordpress/block-editor';
-import { dispatch } from '@wordpress/data';
-import { extractStructure } from '../data';
-import { COURSE_STORE } from '../store';
 
-export default function saveCourseOutlineBlock( { innerBlocks } ) {
-	dispatch( COURSE_STORE ).setEditorStructure(
-		extractStructure( innerBlocks )
-	);
+export default function saveCourseOutlineBlock() {
 	return <InnerBlocks.Content />;
 }

--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -115,3 +115,30 @@ export const extractStructure = ( blocks ) => {
 		} )
 		.filter( ( block ) => 'module' === block.type || !! block.title );
 };
+
+/**
+ * Get first block by name.
+ *
+ * @param {string} blockName Block name.
+ * @param {Array}  blocks    Blocks array.
+ *
+ * @return {Object|boolean} Block or false.
+ */
+export const getFirstBlockByName = ( blockName, blocks ) => {
+	for ( let i = 0; i < blocks.length; i++ ) {
+		const block = blocks[ i ];
+		if ( blockName === block.name ) {
+			return block;
+		} else if ( block.innerBlocks && block.innerBlocks.length > 0 ) {
+			const innerBlockSearch = getFirstBlockByName(
+				blockName,
+				block.innerBlocks
+			);
+			if ( innerBlockSearch ) {
+				return innerBlockSearch;
+			}
+		}
+	}
+
+	return false;
+};

--- a/assets/blocks/course-outline/data.test.js
+++ b/assets/blocks/course-outline/data.test.js
@@ -1,5 +1,9 @@
 import { createBlock } from '@wordpress/blocks';
-import { extractStructure, syncStructureToBlocks } from './data';
+import {
+	extractStructure,
+	syncStructureToBlocks,
+	getFirstBlockByName,
+} from './data';
 import {
 	registerTestLessonBlock,
 	registerTestModuleBlock,
@@ -154,5 +158,36 @@ describe( 'syncStructureToBlocks', () => {
 				],
 			},
 		] );
+	} );
+} );
+
+describe( 'getFirstBlockByName', () => {
+	it( 'should get the first block with correct name', () => {
+		const blocks = [
+			{ name: 'a', innerBlocks: [] },
+			{
+				name: 'b',
+				innerBlocks: [ { name: 'f' }, { name: 'g' } ],
+			},
+			{
+				name: 'c',
+				innerBlocks: [
+					{ name: 'h' },
+					{
+						name: 'i',
+						innerBlocks: [
+							{ name: 'j' },
+							{ name: 'wally' },
+							{ name: 'k' },
+						],
+					},
+				],
+			},
+			{ name: 'd' },
+			{ name: 'e', innerBlocks: [] },
+		];
+		expect( getFirstBlockByName( 'wally', blocks ).name ).toEqual(
+			'wally'
+		);
 	} );
 } );

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -22,8 +22,15 @@ const getEditorOutlineBlock = () =>
 		select( 'core/block-editor' ).getBlocks()
 	);
 
-const getEditorOutlineStructure = () =>
-	extractStructure( getEditorOutlineBlock().innerBlocks );
+const getEditorOutlineStructure = () => {
+	const outlineBlock = getEditorOutlineBlock();
+
+	if ( ! outlineBlock ) {
+		return null;
+	}
+
+	return extractStructure( outlineBlock.innerBlocks );
+};
 
 const actions = {
 	/**
@@ -153,7 +160,10 @@ const registerCourseStructureStore = () => {
 		const serverStructure = select( COURSE_STORE ).getServerStructure();
 		const editorStructure = getEditorOutlineStructure();
 
-		if ( isEqual( serverStructure, editorStructure ) ) {
+		if (
+			! editorStructure ||
+			isEqual( serverStructure, editorStructure )
+		) {
 			return;
 		}
 

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -95,7 +95,7 @@ const reducers = {
 		...state,
 		isEditorDirty,
 	} ),
-	CLEAR_STRUCTURE_UPDATE: ( state ) => ( {
+	CLEAR_STRUCTURE_UPDATE: ( action, state ) => ( {
 		...state,
 		hasStructureUpdate: false,
 	} ),

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -48,7 +48,7 @@ const actions = {
 	 *
 	 * @param {Array} editorStructure
 	 */
-	*saveStruture( editorStructure ) {
+	*saveStructure( editorStructure ) {
 		yield { type: 'SAVING', isSavingStructure: true };
 		const courseId = yield select( 'core/editor' ).getCurrentPostId();
 
@@ -169,7 +169,7 @@ const registerCourseStructureStore = () => {
 
 		// Clear error notices.
 		dispatch( 'core/notices' ).removeNotice( 'course-outline-save-error' );
-		dispatch( COURSE_STORE ).saveStruture( editorStructure );
+		dispatch( COURSE_STORE ).saveStructure( editorStructure );
 	};
 
 	const finishSave = () => {

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -55,12 +55,11 @@ const actions = {
 		yield { type: 'SAVING', isSavingStructure: false };
 	},
 	setStructure: ( structure ) => ( { type: 'SET_SERVER', structure } ),
-	setEditorStructure: ( structure ) => {
-		return { type: 'SET_EDITOR', structure };
-	},
-	setEditorDirty: ( isEditorDirty ) => {
-		return { type: 'SET_DIRTY', isEditorDirty };
-	},
+	setEditorStructure: ( structure ) => ( { type: 'SET_EDITOR', structure } ),
+	setEditorDirty: ( isEditorDirty ) => ( {
+		type: 'SET_DIRTY',
+		isEditorDirty,
+	} ),
 };
 
 /**

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -9,7 +9,7 @@ const DEFAULT_STATE = {
 	editor: [],
 	isSavingStructure: false,
 	isEditorDirty: false,
-	hasChanges: false,
+	hasStructureUpdate: false,
 };
 
 const actions = {
@@ -60,6 +60,7 @@ const actions = {
 		type: 'SET_DIRTY',
 		isEditorDirty,
 	} ),
+	clearStructureUpdate: () => ( { type: 'CLEAR_STRUCTURE_UPDATE' } ),
 };
 
 /**
@@ -93,6 +94,10 @@ const reducers = {
 	SET_DIRTY: ( { isEditorDirty }, state ) => ( {
 		...state,
 		isEditorDirty,
+	} ),
+	CLEAR_STRUCTURE_UPDATE: ( state ) => ( {
+		...state,
+		hasStructureUpdate: false,
 	} ),
 	DEFAULT: ( action, state ) => state,
 };
@@ -144,6 +149,7 @@ const registerCourseStructureStore = () => {
 		const shouldResavePost = select( COURSE_STORE ).shouldResavePost();
 		if ( shouldResavePost ) {
 			dispatch( 'core/editor' ).savePost();
+			dispatch( COURSE_STORE ).clearStructureUpdate();
 		}
 	};
 

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -117,11 +117,9 @@ const selectors = {
 	getEditorStructure: ( { editor } ) => editor,
 	shouldSave: ( { isEditorDirty, isSavingStructure } ) =>
 		! isSavingStructure && isEditorDirty,
-	shouldResavePost: ( {
-		isEditorDirty,
-		isSavingStructure,
-		hasStructureUpdate,
-	} ) => ! isSavingStructure && isEditorDirty && hasStructureUpdate,
+	getIsSavingStructure: ( { isSavingStructure } ) => isSavingStructure,
+	shouldResavePost: ( { isSavingStructure, hasStructureUpdate } ) =>
+		! isSavingStructure && hasStructureUpdate,
 };
 
 export const COURSE_STORE = 'sensei/course-structure';
@@ -160,6 +158,7 @@ const registerCourseStructureStore = () => {
 
 		const isSavingPost =
 			editor.isSavingPost() && ! editor.isAutosavingPost();
+		const isSavingStructure = select( COURSE_STORE ).getIsSavingStructure();
 
 		// First update where post is saving.
 		if ( ! postSaving && isSavingPost ) {
@@ -167,7 +166,7 @@ const registerCourseStructureStore = () => {
 			startSave();
 
 			// First update where post is no longer saving.
-		} else if ( postSaving && ! isSavingPost ) {
+		} else if ( postSaving && ! isSavingPost && ! isSavingStructure ) {
 			postSaving = false;
 			finishSave();
 		}

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -26,7 +26,7 @@ const actions = {
 	/**
 	 * Persist editor's course structure to the REST API
 	 */
-	*save() {
+	*saveStruture() {
 		const { getEditorStructure } = select( COURSE_STORE );
 
 		yield { type: 'SAVING', isSavingStructure: true };
@@ -115,7 +115,7 @@ const resolvers = {
 const selectors = {
 	getStructure: ( { structure } ) => structure,
 	getEditorStructure: ( { editor } ) => editor,
-	shouldSave: ( { isEditorDirty, isSavingStructure } ) =>
+	shouldSaveStructure: ( { isEditorDirty, isSavingStructure } ) =>
 		! isSavingStructure && isEditorDirty,
 	getIsSavingStructure: ( { isSavingStructure } ) => isSavingStructure,
 	shouldResavePost: ( { isSavingStructure, hasStructureUpdate } ) =>
@@ -132,13 +132,15 @@ const registerCourseStructureStore = () => {
 	let postSaving = false;
 
 	const startSave = () => {
-		const shouldSave = select( COURSE_STORE ).shouldSave();
+		const shouldSaveStructure = select(
+			COURSE_STORE
+		).shouldSaveStructure();
 
 		// Clear error notices.
 		dispatch( 'core/notices' ).removeNotice( 'course-outline-save-error' );
 
-		if ( shouldSave ) {
-			dispatch( COURSE_STORE ).save();
+		if ( shouldSaveStructure ) {
+			dispatch( COURSE_STORE ).saveStruture();
 		}
 	};
 

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -7,7 +7,7 @@ import { isEqual } from 'lodash';
 const DEFAULT_STATE = {
 	structure: null,
 	editor: [],
-	isSaving: false,
+	isSavingStructure: false,
 	isEditorDirty: false,
 	hasChanges: false,
 };
@@ -29,7 +29,7 @@ const actions = {
 	*save() {
 		const { getEditorStructure } = select( COURSE_STORE );
 
-		yield { type: 'SAVING', isSaving: true };
+		yield { type: 'SAVING', isSavingStructure: true };
 		const courseId = yield select( 'core/editor' ).getCurrentPostId();
 		try {
 			const result = yield apiFetch( {
@@ -52,7 +52,7 @@ const actions = {
 			} );
 		}
 
-		yield { type: 'SAVING', isSaving: false };
+		yield { type: 'SAVING', isSavingStructure: false };
 	},
 	setStructure: ( structure ) => ( { type: 'SET_SERVER', structure } ),
 	setEditorStructure: ( structure ) => {
@@ -87,9 +87,9 @@ const reducers = {
 			hasStructureUpdate: state.hasStructureUpdate && isEditorDirty,
 		};
 	},
-	SAVING: ( { isSaving }, state ) => ( {
+	SAVING: ( { isSavingStructure }, state ) => ( {
 		...state,
-		isSaving,
+		isSavingStructure,
 	} ),
 	SET_DIRTY: ( { isEditorDirty }, state ) => ( {
 		...state,
@@ -111,9 +111,13 @@ const resolvers = {
 const selectors = {
 	getStructure: ( { structure } ) => structure,
 	getEditorStructure: ( { editor } ) => editor,
-	shouldSave: ( { isEditorDirty, isSaving } ) => ! isSaving && isEditorDirty,
-	shouldResavePost: ( { isEditorDirty, isSaving, hasStructureUpdate } ) =>
-		! isSaving && isEditorDirty && hasStructureUpdate,
+	shouldSave: ( { isEditorDirty, isSavingStructure } ) =>
+		! isSavingStructure && isEditorDirty,
+	shouldResavePost: ( {
+		isEditorDirty,
+		isSavingStructure,
+		hasStructureUpdate,
+	} ) => ! isSavingStructure && isEditorDirty && hasStructureUpdate,
 };
 
 export const COURSE_STORE = 'sensei/course-structure';

--- a/assets/blocks/course-outline/use-block-creator.js
+++ b/assets/blocks/course-outline/use-block-creator.js
@@ -31,6 +31,9 @@ export const useBlocksCreator = ( clientId ) => {
 
 				dispatch( COURSE_STORE ).setEditorDirty( true );
 			}
+
+			// Flag that the editor is sync.
+			dispatch( COURSE_STORE ).setEditorSyncing( false );
 		},
 		[ clientId, replaceInnerBlocks, getBlocks ]
 	);

--- a/assets/blocks/course-outline/use-block-creator.js
+++ b/assets/blocks/course-outline/use-block-creator.js
@@ -1,8 +1,7 @@
-import { dispatch, useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { extractStructure, syncStructureToBlocks } from './data';
 import { isEqual } from 'lodash';
-import { COURSE_STORE } from './store';
 
 /**
  * Blocks creator hook.
@@ -28,12 +27,7 @@ export const useBlocksCreator = ( clientId ) => {
 					syncStructureToBlocks( structure, blocks ),
 					updateSelection
 				);
-
-				dispatch( COURSE_STORE ).setEditorDirty( true );
 			}
-
-			// Flag that the editor is sync.
-			dispatch( COURSE_STORE ).setEditorSyncing( false );
 		},
 		[ clientId, replaceInnerBlocks, getBlocks ]
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix a saving race condition of the post and the course structure before the resaving.

#### What happened

* When the post saving finished before the course structure saving, it wasn't adding the ID to the block attributes.
  * For me (considering it's a race condition this can be different in other environments), it usually happened when trying to create a new course with 2 modules, each module with 1 lesson, and 1 lesson without a module.

### Testing instructions

* Create a new course, adding 2 modules, each module with 1 lesson, and 1 lesson without a module.
* Save the course.
* Check if the block id attributes were saved. You can check it in the database, or you can also publish at least one lesson inside a module, and make sure the module border appears when accessing the course in the frontend.

(If you wanna try to simulate the issue in the old code and you can't, maybe try creating more modules and more lessons when creating the new course)

### Context

This issue was identified because the module border wasn't appearing in some cases. The reason was the ID attribute that wasn't being saved.