### PR TITLE
Refactor module border

### DIFF
--- a/assets/blocks/course-outline/module-block/block.json
+++ b/assets/blocks/course-outline/module-block/block.json
@@ -47,7 +47,8 @@
       "type": "string"
     },
     "bordered": {
-      "type": "boolean"
+      "type": "boolean",
+      "default": true
     }
   }
 }

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -49,7 +49,7 @@ export const EditModuleBlock = ( props ) => {
 
 	// Get the border setting from the parent if none is set.
 	useEffect( () => {
-		if ( undefined === bordered ) {
+		if ( undefined === bordered && undefined !== moduleBorder ) {
 			setAttributes( { bordered: moduleBorder } );
 		}
 	}, [ bordered, moduleBorder, setAttributes ] );

--- a/includes/blocks/class-sensei-course-outline-module-block.php
+++ b/includes/blocks/class-sensei-course-outline-module-block.php
@@ -147,7 +147,7 @@ class Sensei_Course_Outline_Module_Block {
 		$class_names   = [ 'wp-block-sensei-lms-course-outline-module', 'sensei-collapsible', $class_name ];
 		$inline_styles = [];
 
-		if ( ! empty( $block_attributes['bordered'] ) ) {
+		if ( ! isset( $block_attributes['bordered'] ) || true === $block_attributes['bordered'] ) {
 			$class_names[] = 'sensei-module-bordered';
 
 			if ( ! empty( $block_attributes['borderColorValue'] ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It's just a small refactor identified while investigating/working in [this issue](https://github.com/Automattic/sensei/pull/3800).
  * It sets the default `bordered` attribute to `true` (in the editor, and in the frontend through the conditional)
  * It also just sets the parent border in case it contains the `moduleBorder` coming from the context (it's not present in the style examples in the sidebar).

### Testing instructions

* Add a new course, and make sure the borders are added as default in the editor and in the frontend.
* Change the border settings (remove/add/change color), and make sure it works properly in the editor, and in the frontend.