### PR TITLE
Use the style of the outline if no style is set

### DIFF
--- a/assets/blocks/course-outline/course-block/edit.js
+++ b/assets/blocks/course-outline/course-block/edit.js
@@ -152,6 +152,7 @@ const EditCourseOutlineBlock = ( {
 				value={ {
 					outlineAttributes: attributes,
 					outlineSetAttributes: setAttributes,
+					outlineClassName: className,
 				} }
 			>
 				<OutlineBlockSettings

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -43,6 +43,7 @@ export const EditModuleBlock = ( props ) => {
 	} = props;
 	const {
 		outlineAttributes: { collapsibleModules, moduleBorder },
+		outlineClassName,
 	} = useContext( OutlineAttributesContext ) || { outlineAttributes: {} };
 
 	useInsertLessonBlock( props );
@@ -82,6 +83,15 @@ export const EditModuleBlock = ( props ) => {
 			default: { background: mainColor?.color },
 			minimal: { borderColor: mainColor?.color },
 		}[ style[ 1 ] ];
+	} else {
+		const outlineStyle = outlineClassName.match( /is-style-(\w+)/ );
+
+		if ( outlineStyle ) {
+			blockStyleColors = {
+				default: { background: mainColor?.color },
+				minimal: { borderColor: mainColor?.color },
+			}[ outlineStyle[ 1 ] ];
+		}
 	}
 
 	return (

--- a/assets/blocks/course-outline/module-block/edit.test.js
+++ b/assets/blocks/course-outline/module-block/edit.test.js
@@ -21,7 +21,10 @@ jest.mock( './use-insert-lesson-block' );
 jest.mock( '../course-block/edit', () => jest.fn() );
 jest.mock( '@wordpress/element', () => ( {
 	...jest.requireActual( '@wordpress/element' ),
-	useContext: () => ( { outlineAttributes: { collapsibleModules: true } } ),
+	useContext: () => ( {
+		outlineAttributes: { collapsibleModules: true },
+		outlineClassName: '',
+	} ),
 } ) );
 
 describe( '<EditModuleBlock />', () => {


### PR DESCRIPTION
Fixes an issue where the color of the module title was not set. To reproduct the issue follow these steps:

* Create a new outline block.
* Without modifying styles in both outline and module block, change the module's background color.
* Observe that the color is not changed in the module.

### Changes proposed in this Pull Request

* Fixes the above issue by setting the style of the module to be equal with the outline's if none is defined.

### Testing instructions

* Follow the above instructions and observe that the color is now set.