### PR TITLE
Move contact block up in the course post template

### DIFF
--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -86,8 +86,8 @@ class Sensei_Course_Outline_Block {
 
 		$post_type_object->template = [
 			[ 'sensei-lms/button-take-course' ],
-			[ 'sensei-lms/course-progress' ],
 			[ 'sensei-lms/button-contact-teacher' ],
+			[ 'sensei-lms/course-progress' ],
 			[ 'sensei-lms/course-outline' ],
 		];
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Move contact block up in the course post template

### Testing instructions

Create a new course, and make sure the initial block order is:
1. Take course
2. Contact teacher
3. Course progress
4. Outline

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="695" alt="Screen Shot 2020-11-23 at 11 03 13" src="https://user-images.githubusercontent.com/876340/99971093-80cbcf80-2d7b-11eb-8546-e678b0ca81c6.png">
