### PR TITLE
Add default theme color in the module border

### DIFF
--- a/assets/blocks/course-outline/module-block/block.json
+++ b/assets/blocks/course-outline/module-block/block.json
@@ -46,6 +46,9 @@
     "borderColorValue": {
       "type": "string"
     },
+    "defaultBorderColor": {
+      "type": "string"
+    },
     "className": {
       "type": "string"
     },

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -33,7 +33,7 @@ import { useInsertLessonBlock } from './use-insert-lesson-block';
  * @param {Object}   props.defaultMainColor            Default main color.
  * @param {Object}   props.textColor                   Header text color.
  * @param {Object}   props.defaultTextColor            Default text color.
- * @param {Object}   props.borderColor                 Border color.
+ * @param {Object}   props.defaultBorderColor          Default border color.
  * @param {Function} props.setAttributes               Block set attributes function.
  * @param {string}   props.name                        Name of the block.
  */
@@ -46,6 +46,7 @@ export const EditModuleBlock = ( props ) => {
 		defaultMainColor,
 		textColor,
 		defaultTextColor,
+		defaultBorderColor,
 		setAttributes,
 	} = props;
 	const {
@@ -126,7 +127,9 @@ export const EditModuleBlock = ( props ) => {
 				className={ classnames( className, {
 					'sensei-module-bordered': bordered,
 				} ) }
-				style={ { borderColor: borderColorValue } }
+				style={ {
+					borderColor: borderColorValue || defaultBorderColor?.color,
+				} }
 			>
 				<header
 					className="wp-block-sensei-lms-course-outline-module__header"
@@ -214,6 +217,10 @@ export default compose(
 		defaultTextColor: {
 			style: 'color',
 			probeKey: 'primaryContrastColor',
+		},
+		defaultBorderColor: {
+			style: 'border-color',
+			probeKey: 'primaryColor',
 		},
 	} )
 )( EditModuleBlock );

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -125,7 +125,7 @@ export const EditModuleBlock = ( props ) => {
 			/>
 			<section
 				className={ classnames( className, {
-					'sensei-module-bordered': bordered,
+					'wp-block-sensei-lms-course-outline-module-bordered': bordered,
 				} ) }
 				style={ {
 					borderColor: borderColorValue || defaultBorderColor?.color,

--- a/assets/blocks/course-outline/module-block/module-block.scss
+++ b/assets/blocks/course-outline/module-block/module-block.scss
@@ -79,10 +79,10 @@ $block: '.wp-block-sensei-lms-course-outline-module';
 			display: none;
 		}
 	}
+}
 
-	&.sensei-module-bordered {
-		border: 1px solid $dark-gray;
-	}
+#{$block}-bordered {
+	border: 1px solid $dark-gray;
 }
 
 .wp-block-sensei-lms-course-outline.is-style-default #{$block}:not(.is-style-minimal), #{$block}.is-style-default {

--- a/includes/blocks/class-sensei-course-outline-module-block.php
+++ b/includes/blocks/class-sensei-course-outline-module-block.php
@@ -163,7 +163,7 @@ class Sensei_Course_Outline_Module_Block {
 		);
 
 		if ( ! empty( $block_attributes['bordered'] ) ) {
-			$class_names[] = 'sensei-module-bordered';
+			$class_names[] = 'wp-block-sensei-lms-course-outline-module-bordered';
 
 			if ( ! empty( $block_attributes['borderColorValue'] ) ) {
 				$inline_styles[] = sprintf( 'border-color: %s;', $block_attributes['borderColorValue'] );

--- a/includes/blocks/class-sensei-course-outline-module-block.php
+++ b/includes/blocks/class-sensei-course-outline-module-block.php
@@ -155,6 +155,12 @@ class Sensei_Course_Outline_Module_Block {
 	private function get_block_html_attributes( $class_name, $block_attributes ) : string {
 		$class_names   = [ 'wp-block-sensei-lms-course-outline-module', 'sensei-collapsible', $class_name ];
 		$inline_styles = [];
+		$css           = Sensei_Block_Helpers::build_styles(
+			$block_attributes,
+			[
+				'textColor' => null,
+			]
+		);
 
 		if ( ! empty( $block_attributes['bordered'] ) ) {
 			$class_names[] = 'sensei-module-bordered';
@@ -167,8 +173,8 @@ class Sensei_Course_Outline_Module_Block {
 		return Sensei_Block_Helpers::render_style_attributes(
 			$class_names,
 			[
-				'css_classes'   => [],
-				'inline_styles' => $inline_styles,
+				'css_classes'   => $css['css_classes'],
+				'inline_styles' => array_merge( $css['inline_styles'], $inline_styles ),
 			]
 		);
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add default theme color in the module border

### Testing instructions

* Create a new course, and make sure the border is automatically set to the theme color.
* Access the frontend and make sure, the border is the same.
* Remove/add the border from the module, and change the colors, and make sure everything works properly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="685" alt="Screen Shot 2020-11-27 at 19 23 57" src="https://user-images.githubusercontent.com/876340/100487182-1ea9fc00-30e6-11eb-83f1-6e111802f0fe.png">
