### PR TITLE
Set a default value to outlineClassNAme

### DIFF
--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -44,7 +44,10 @@ export const EditModuleBlock = ( props ) => {
 	const {
 		outlineAttributes: { collapsibleModules, moduleBorder },
 		outlineClassName,
-	} = useContext( OutlineAttributesContext ) || { outlineAttributes: {} };
+	} = useContext( OutlineAttributesContext ) || {
+		outlineAttributes: {},
+		outlineClassName: '',
+	};
 
 	useInsertLessonBlock( props );
 


### PR DESCRIPTION
Fixes an issue with the module preview. To reproduce it follow these steps:
* Select the course outline block.
* Open the sidebar to add a new block inside the outline block.
* Observe that the preview of the module block errors.

### Changes proposed in this Pull Request

* It sets a default value for outlineClassName to fix the undefined error.

### Testing instructions

* Follow the above instruction and observe that there is no error.