### PR TITLE
Fix alignment of progress bar settings for 5.4

### DIFF
--- a/assets/blocks/course-progress/style.scss
+++ b/assets/blocks/course-progress/style.scss
@@ -25,4 +25,8 @@
 	.components-range-control {
 		width: 100%;
 	}
+
+	.components-base-control__label {
+		max-width: 100%;
+	}
 }


### PR DESCRIPTION
There was an issue in WP 5.4 where the progress bar controls did not appear correctly (see screenshot below).
![Screenshot 2020-11-24 at 1 51 02 PM](https://user-images.githubusercontent.com/53191348/100090731-500f9700-2e5c-11eb-906d-7c1aa145b75e.png)


### Changes proposed in this Pull Request

* Add CSS fix for the controls to appear correctly.

### Testing instructions

* Open the progress bar settings in both latest and 5.4 and ensure that the progress bar settings appear correctly.