### PR TITLE
Change/contact teacher button

### DIFF
--- a/assets/blocks/button/button-props.js
+++ b/assets/blocks/button/button-props.js
@@ -36,12 +36,14 @@ export function getButtonProps( props ) {
 		className: classnames(
 			{ 'wp-block-button__link': ! isLink },
 			borderProps.className,
-			colorProps.className
+			colorProps.className,
+			props.attributes.buttonClassName
 		),
 		style: {
 			...borderProps.style,
 			...colorProps.style,
 		},
+		...props.attributes.buttonAttributes,
 	};
 }
 

--- a/assets/blocks/button/button.scss
+++ b/assets/blocks/button/button.scss
@@ -26,4 +26,18 @@
 	ins {
 		text-decoration: none;
 	}
+
+	&.is-style-link {
+		button {
+			background: none;
+			border: none;
+			padding: 0;
+			font: inherit;
+			cursor: pointer;
+		}
+
+		button:hover {
+			text-decoration: underline;
+		}
+	}
 }

--- a/assets/blocks/button/edit-button.js
+++ b/assets/blocks/button/edit-button.js
@@ -10,7 +10,7 @@ import { ButtonBlockSettings } from './settings-button';
  * @param {Object} props
  */
 export const EditButtonBlock = ( props ) => {
-	const { placeholder, attributes, setAttributes, tagName } = props;
+	const { placeholder, attributes, setAttributes } = props;
 	const { text } = attributes;
 	const { colors } = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getSettings();
@@ -22,7 +22,7 @@ export const EditButtonBlock = ( props ) => {
 	return (
 		<div { ...getButtonWrapperProps( props ) }>
 			{ isReadonly ? (
-				<div { ...buttonProps }>{ props.text }</div>
+				<button { ...buttonProps }>{ props.text }</button>
 			) : (
 				<RichText
 					placeholder={
@@ -32,7 +32,7 @@ export const EditButtonBlock = ( props ) => {
 					onChange={ ( value ) => setAttributes( { text: value } ) }
 					withoutInteractiveFormatting
 					{ ...buttonProps }
-					tagName={ tagName }
+					tagName="button"
 					identifier="text"
 				/>
 			) }

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -35,7 +35,6 @@ export const BlockStyles = {
  */
 export const createButtonBlockType = ( { settings, ...options } ) => {
 	options = {
-		tagName: 'a',
 		alignmentOptions: {
 			controls: [ 'left', 'center', 'right', 'full' ],
 			default: 'left',
@@ -52,7 +51,7 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 				text: {
 					type: 'string',
 					source: 'html',
-					selector: options.tagName,
+					selector: 'button',
 				},
 				align: {
 					type: 'string',
@@ -61,6 +60,12 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 					type: 'number',
 				},
 				style: {
+					type: 'object',
+				},
+				buttonClassName: {
+					type: 'string',
+				},
+				buttonAttributes: {
 					type: 'object',
 				},
 			},

--- a/assets/blocks/button/save-button.js
+++ b/assets/blocks/button/save-button.js
@@ -7,16 +7,15 @@ import { getButtonProps, getButtonWrapperProps } from './button-props';
  * @param {Object} props
  * @param {Object} props.attributes Block attributes.
  * @param {string} props.className  Classname.
- * @param {string} props.tagName    Output HTML tag name.
  */
-export const saveButtonBlock = ( { attributes, className, tagName } ) => {
+export const saveButtonBlock = ( { attributes, className } ) => {
 	const { text } = attributes;
 
 	return (
 		<div { ...getButtonWrapperProps( { className, attributes } ) }>
 			<RichText.Content
 				{ ...getButtonProps( { attributes } ) }
-				tagName={ tagName }
+				tagName="button"
 				value={ text }
 			/>
 		</div>

--- a/assets/blocks/contact-teacher/index.js
+++ b/assets/blocks/contact-teacher/index.js
@@ -5,7 +5,6 @@ import { __ } from '@wordpress/i18n';
  * Take course button block.
  */
 export default createButtonBlockType( {
-	tagName: 'a',
 	settings: {
 		name: 'sensei-lms/button-contact-teacher',
 		description: __(
@@ -16,6 +15,14 @@ export default createButtonBlockType( {
 		attributes: {
 			text: {
 				default: 'Contact Teacher',
+			},
+			buttonClassName: {
+				default: 'sensei-collapsible__toggle',
+			},
+			buttonAttributes: {
+				default: {
+					type: 'submit',
+				},
 			},
 		},
 		styles: [ BlockStyles.Fill, BlockStyles.Outline, BlockStyles.Link ],

--- a/assets/blocks/take-course/index.js
+++ b/assets/blocks/take-course/index.js
@@ -5,7 +5,6 @@ import { createButtonBlockType } from '../button';
  * Take course button block.
  */
 export default createButtonBlockType( {
-	tagName: 'button',
 	settings: {
 		name: 'sensei-lms/button-take-course',
 		title: __( 'Take Course', 'sensei-lms' ),

--- a/includes/blocks/class-sensei-block-contact-teacher.php
+++ b/includes/blocks/class-sensei-block-contact-teacher.php
@@ -51,8 +51,6 @@ class Sensei_Block_Contact_Teacher {
 			return '';
 		}
 
-		$contact_form_link = add_query_arg( array( 'contact' => $post->post_type ) );
-
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 		$contact_form_open = isset( $_GET['contact'] );
 
@@ -63,8 +61,11 @@ class Sensei_Block_Contact_Teacher {
 		$contact_form = $this->teacher_contact_form( $post );
 
 		return '<div id="private_message" class="sensei-block-wrapper sensei-collapsible">
-				' . ( $this->add_button_attributes( $content, $contact_form_link ) ) . '
-				' . $notice . '
+					<form action="' . esc_url( get_permalink() ) . '#private_message" method="get">
+						<input type="hidden" name="contact" value="' . $post->post_type . '" /> 
+						' . $content . '
+					</form>
+					' . $notice . '
 				<div class="sensei-collapsible__content ' . ( $contact_form_open ? '' : 'collapsed' ) . '">' . $contact_form . '</div>
 			</div>';
 	}
@@ -99,22 +100,5 @@ class Sensei_Block_Contact_Teacher {
 				<button class="sensei-contact-teacher-form__submit">' . esc_html__( 'Send Message', 'sensei-lms' ) . '</button>
 				</p>
 			</form>';
-	}
-
-	/**
-	 * Add attributes to the block's <a> tag.
-	 *
-	 * @param string $content Block HTML.
-	 * @param string $href    Link URL.
-	 *
-	 * @return string Block HTML with additional href attribute.
-	 */
-	private function add_button_attributes( $content, $href ) {
-		return preg_replace(
-			'/<a(.*)class="(.*)"(.*)>(.+)<\/a>/',
-			'<a href="' . esc_url( $href ) . '#private_message" class="sensei-collapsible__toggle $2" $1 $3>$4</a>',
-			$content,
-			1
-		);
 	}
 }

--- a/tests/unit-tests/test-class-sensei-contact-teacher-block.php
+++ b/tests/unit-tests/test-class-sensei-contact-teacher-block.php
@@ -31,13 +31,15 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the saved block content is used for the button, with link added to open the form.
+	 * Test the saved block content is used for the button, and it is wrapped in a form
 	 */
-	public function testHrefAttributeAdded() {
+	public function testFormWithContactIsAdded() {
 
-		$output = $this->block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
+		$content = '<div><a class="wp-block-button__link">Contact teacher</a></div>';
+		$output  = $this->block->render_contact_teacher_block( [], $content );
 
-		$this->assertRegExp( '|<a href="/course/test/\?contact=course#private_message".*>Contact teacher</a>|', $output );
+		$this->assertContains( '<form action="#private_message" method="get">', $output );
+		$this->assertContains( $content, $output );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR updates all button elements to use a button tag. The reasons for this are the following:
  * This will make sure that our buttons appear the same as themes tends to apply different styles to different tags.
  * The button tag fits best for a11y.
  * This is the first step to handle styling consistently between themes. In the future we should look implementing something similar [with Woo](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2478).
* The 'Link' style option will be now represented by a button which means that default theme styles won't be applied. In the future we could look into using a probe to get the theme default link color.

### Testing instructions

* In the course page, create 'Contact Teacher' block.
* Try different combinations of styling and make sure that the block appears correctly.
* Test the 'Take Course' block and make sure it isn't affected.