### PR TITLE
Add isPreview flag to button blocks

### DIFF
--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -63,6 +63,10 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 				style: {
 					type: 'object',
 				},
+				isPreview: {
+					type: 'boolean',
+					default: false,
+				},
 			},
 			supports: {
 				color: {
@@ -85,6 +89,7 @@ export const createButtonBlockType = ( { settings, ...options } ) => {
 			example: {
 				attributes: {
 					align: 'center',
+					isPreview: true,
 				},
 			},
 		},


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add an isPreview attribute flag which is true for preview blocks (blocks displayed in 'Styles' and block selector)

### Testing instructions

* This should be tested together with [this PR](https://github.com/Automattic/sensei-wc-paid-courses/pull/552)