### PR TITLE
Fix edit lesson link for 5.4

### DIFF
--- a/assets/blocks/course-outline/lesson-block/lesson-block.scss
+++ b/assets/blocks/course-outline/lesson-block/lesson-block.scss
@@ -87,3 +87,8 @@
 		bottom: 0;
 	}
 }
+
+.block-editor-block-toolbar__slot {
+	// Prevents text toolbar items shrinking to avoid other buttons overlapping.
+	flex-shrink: 0;
+}

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -78,7 +78,11 @@ export const LessonBlockSettings = ( {
 				</PanelBody>
 			</InspectorControls>
 			<BlockControls>
-				{ id && <Toolbar>{ editLessonLink }</Toolbar> }
+				{ id && (
+					<Toolbar className="components-button">
+						{ editLessonLink }
+					</Toolbar>
+				) }
 			</BlockControls>
 		</>
 	);

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -3,8 +3,7 @@ import {
 	ExternalLink,
 	FontSizePicker,
 	PanelBody,
-	ToolbarButton,
-	ToolbarGroup,
+	Toolbar,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -79,11 +78,7 @@ export const LessonBlockSettings = ( {
 				</PanelBody>
 			</InspectorControls>
 			<BlockControls>
-				{ id && (
-					<ToolbarGroup>
-						<ToolbarButton>{ editLessonLink }</ToolbarButton>
-					</ToolbarGroup>
-				) }
+				{ id && <Toolbar>{ editLessonLink }</Toolbar> }
 			</BlockControls>
 		</>
 	);

--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -67,7 +67,8 @@ $dark-gray: #1a1d20;
 	.components-toolbar-group, .components-toolbar {
 		.wp-block-sensei-lms-course-outline-lesson__edit {
 			align-self: center;
-			margin: 0 1em;
+			margin: 0 0.8em;
+			font-size: 14px;
 		}
 	}
 }

--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -15,7 +15,7 @@ $dark-gray: #1a1d20;
 	textarea.wp-block-sensei-lms-course-outline-module__title-input {
 		color: inherit;
 		background: none;
-		
+
 		&::placeholder {
 			color: inherit;
 			opacity: 0.5;
@@ -62,6 +62,13 @@ $dark-gray: #1a1d20;
 	.block-editor-block-list__block[data-type="sensei-lms/course-outline-lesson"] {
 		margin-top: 0;
 		margin-bottom: 0;
+	}
+
+	.components-toolbar-group, .components-toolbar {
+		.wp-block-sensei-lms-course-outline-lesson__edit {
+			align-self: center;
+			margin: 0 1em;
+		}
 	}
 }
 

--- a/assets/blocks/course-outline/style.editor.scss
+++ b/assets/blocks/course-outline/style.editor.scss
@@ -67,8 +67,8 @@ $dark-gray: #1a1d20;
 	.components-toolbar-group, .components-toolbar {
 		.wp-block-sensei-lms-course-outline-lesson__edit {
 			align-self: center;
-			margin: 0 0.8em;
-			font-size: 14px;
+			font-size: 15px;
+			padding: 0.9em 0;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #3809

### Changes proposed in this Pull Request

* Replaces `ToolbarButton` and `ToolbarGroup` with `Toolbar` as `ToolbarButton` does not add elements inside a `Button` in 5.4.

### Testing instructions

* Follow instructions on #3809 for current and 5.4 version and make sure that the link is displayed correctly.
