### PR TITLE
Update toggle metaboxes

### DIFF
--- a/assets/blocks/button/edit-button.js
+++ b/assets/blocks/button/edit-button.js
@@ -13,12 +13,12 @@ import useToggleLegacyMetaboxes from '../use-toggle-legacy-metaboxes';
  */
 export const EditButtonBlock = ( props ) => {
 	const { placeholder, attributes, setAttributes, tagName } = props;
-	const { text } = attributes;
+	const { text, isPreview } = attributes;
 	const { colors } = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getSettings();
 	}, [] );
 
-	useToggleLegacyMetaboxes();
+	useToggleLegacyMetaboxes( { ignoreToggle: isPreview } );
 
 	const isReadonly = undefined !== props.text;
 	const buttonProps = getButtonProps( { ...props, colors } );

--- a/assets/blocks/button/edit-button.js
+++ b/assets/blocks/button/edit-button.js
@@ -1,8 +1,10 @@
 import { RichText } from '@wordpress/block-editor';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
+
 import { getButtonProps, getButtonWrapperProps } from './button-props';
 import { ButtonBlockSettings } from './settings-button';
+import useToggleLegacyMetaboxes from '../use-toggle-legacy-metaboxes';
 
 /**
  * Edit component for a Button block.
@@ -15,6 +17,8 @@ export const EditButtonBlock = ( props ) => {
 	const { colors } = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getSettings();
 	}, [] );
+
+	useToggleLegacyMetaboxes();
 
 	const isReadonly = undefined !== props.text;
 	const buttonProps = getButtonProps( { ...props, colors } );

--- a/assets/blocks/course-outline/course-block/edit.js
+++ b/assets/blocks/course-outline/course-block/edit.js
@@ -11,6 +11,7 @@ import { withDefaultBlockStyle } from '../../../shared/blocks/settings';
 import { COURSE_STATUS_STORE } from '../status-store';
 import { getCourseInnerBlocks } from '../get-course-inner-blocks';
 import { getActiveStyleClass, applyStyleClass } from '../apply-style-class';
+import useToggleLegacyMetaboxes from '../../use-toggle-legacy-metaboxes';
 
 /**
  * A React context which contains the attributes and the setAttributes callback of the Outline block.
@@ -93,15 +94,7 @@ const EditCourseOutlineBlock = ( {
 	attributes,
 	setAttributes,
 } ) => {
-	// Toggle legacy metaboxes.
-	useEffect( () => {
-		if ( attributes.isPreview ) return;
-		window.sensei_toggleLegacyMetaboxes( false );
-
-		return () => {
-			window.sensei_toggleLegacyMetaboxes( true );
-		};
-	}, [ attributes.isPreview ] );
+	useToggleLegacyMetaboxes();
 
 	const { setBlocks } = useBlocksCreator( clientId );
 

--- a/assets/blocks/course-outline/course-block/edit.js
+++ b/assets/blocks/course-outline/course-block/edit.js
@@ -94,7 +94,7 @@ const EditCourseOutlineBlock = ( {
 	attributes,
 	setAttributes,
 } ) => {
-	useToggleLegacyMetaboxes();
+	useToggleLegacyMetaboxes( { ignoreToggle: attributes.isPreview } );
 
 	const { setBlocks } = useBlocksCreator( clientId );
 

--- a/assets/blocks/course-progress/block.json
+++ b/assets/blocks/course-progress/block.json
@@ -29,11 +29,16 @@
     },
     "borderRadius": {
       "type": "integer"
+    },
+    "isPreview": {
+      "type": "boolean",
+      "default": false
     }
   },
   "example": {
     "attributes": {
-      "customBarBackgroundColor": "#999999"
+      "customBarBackgroundColor": "#999999",
+      "isPreview": true
     }
   }
 }

--- a/assets/blocks/course-progress/edit.js
+++ b/assets/blocks/course-progress/edit.js
@@ -4,6 +4,7 @@ import classnames from 'classnames';
 import { useSelect } from '@wordpress/data';
 import { COURSE_STATUS_STORE } from '../course-outline/status-store';
 import { CourseProgressSettings } from './settings';
+import useToggleLegacyMetaboxes from '../use-toggle-legacy-metaboxes';
 
 /**
  * Edit course progress bar component.
@@ -26,6 +27,8 @@ export const EditCourseProgressBlock = ( {
 	attributes: { height, borderRadius },
 	setAttributes,
 } ) => {
+	useToggleLegacyMetaboxes();
+
 	const { totalLessonsCount, completedLessonsCount } = useSelect(
 		( select ) => select( COURSE_STATUS_STORE ).getLessonCounts(),
 		[]

--- a/assets/blocks/course-progress/edit.js
+++ b/assets/blocks/course-progress/edit.js
@@ -17,6 +17,7 @@ import useToggleLegacyMetaboxes from '../use-toggle-legacy-metaboxes';
  * @param {Object}   props.attributes              Component attributes.
  * @param {number}   props.attributes.height       The height of the progress bar.
  * @param {number}   props.attributes.borderRadius The border radius of the progress bar.
+ * @param {boolean}  props.attributes.isPreview    Is preview flag.
  * @param {Function} props.setAttributes           Callback to set the component attributes.
  */
 export const EditCourseProgressBlock = ( {
@@ -24,10 +25,10 @@ export const EditCourseProgressBlock = ( {
 	barColor,
 	barBackgroundColor,
 	textColor,
-	attributes: { height, borderRadius },
+	attributes: { height, borderRadius, isPreview },
 	setAttributes,
 } ) => {
-	useToggleLegacyMetaboxes();
+	useToggleLegacyMetaboxes( { ignoreToggle: isPreview } );
 
 	const { totalLessonsCount, completedLessonsCount } = useSelect(
 		( select ) => select( COURSE_STATUS_STORE ).getLessonCounts(),

--- a/assets/blocks/use-toggle-legacy-metaboxes.js
+++ b/assets/blocks/use-toggle-legacy-metaboxes.js
@@ -1,10 +1,13 @@
 import { useEffect } from '@wordpress/element';
 
-const useToggleLegacyMetaboxes = () => {
+const useToggleLegacyMetaboxes = ( { ignoreToggle = false } ) => {
 	useEffect( () => {
+		if ( ignoreToggle ) {
+			return;
+		}
 		window.sensei_toggle_legacy_metaboxes();
 		return window.sensei_toggle_legacy_metaboxes;
-	}, [] );
+	}, [ ignoreToggle ] );
 };
 
 export default useToggleLegacyMetaboxes;

--- a/assets/blocks/use-toggle-legacy-metaboxes.js
+++ b/assets/blocks/use-toggle-legacy-metaboxes.js
@@ -2,8 +2,8 @@ import { useEffect } from '@wordpress/element';
 
 const useToggleLegacyMetaboxes = () => {
 	useEffect( () => {
-		window.sensei_toggleLegacyMetaboxes();
-		return window.sensei_toggleLegacyMetaboxes;
+		window.sensei_toggle_legacy_metaboxes();
+		return window.sensei_toggle_legacy_metaboxes;
 	}, [] );
 };
 

--- a/assets/blocks/use-toggle-legacy-metaboxes.js
+++ b/assets/blocks/use-toggle-legacy-metaboxes.js
@@ -1,0 +1,10 @@
+import { useEffect } from '@wordpress/element';
+
+const useToggleLegacyMetaboxes = () => {
+	useEffect( () => {
+		window.sensei_toggleLegacyMetaboxes();
+		return window.sensei_toggleLegacyMetaboxes;
+	}, [] );
+};
+
+export default useToggleLegacyMetaboxes;

--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -15,8 +15,10 @@ import { select, dispatch } from '@wordpress/data';
 	/**
 	 * Toggle meta boxes depending on the blocks.
 	 */
-	window.sensei_toggleLegacyMetaboxes = () => {
-		if ( ! blockEditorSelector ) return;
+	window.sensei_toggle_legacy_metaboxes = () => {
+		if ( ! blockEditorSelector ) {
+			return;
+		}
 
 		const outlineBlockCount = blockEditorSelector.getGlobalBlockCount(
 			COURSE_OUTLINE_NAME
@@ -53,7 +55,7 @@ import { select, dispatch } from '@wordpress/data';
 } )();
 
 jQuery( document ).ready( function ( $ ) {
-	window.sensei_toggleLegacyMetaboxes();
+	window.sensei_toggle_legacy_metaboxes();
 
 	$( '#course-prerequisite-options' ).select2( { width: '100%' } );
 

--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -1,36 +1,59 @@
-/**
- * It enables or disables the legacy meta boxes.
- *
- * @param {boolean} enable Whether enable or disable.
- */
-window.sensei_toggleLegacyMetaboxes = ( enable ) => {
-	// Side-effect - Prevent submit modules.
-	document
-		.querySelectorAll( '#module_course_mb input' )
-		.forEach( ( input ) => {
-			input.disabled = ! enable;
-		} );
+import { select, dispatch } from '@wordpress/data';
 
-	const editPostSelector = wp.data.select( 'core/edit-post' );
-	const editPostDispatcher = wp.data.dispatch( 'core/edit-post' );
-
-	const legacyMetaboxes = [
-		'meta-box-course-lessons',
-		'meta-box-module_course_mb',
-		'meta-box-course-video',
+( () => {
+	const COURSE_OUTLINE_NAME = 'sensei-lms/course-outline';
+	const OTHER_COURSE_BLOCKS = [
+		'sensei-lms/button-take-course',
+		'sensei-lms/button-contact-teacher',
+		'sensei-lms/course-progress',
 	];
 
-	legacyMetaboxes.forEach( ( legacyMetabox ) => {
-		if (
-			enable !== editPostSelector.isEditorPanelEnabled( legacyMetabox )
-		) {
-			editPostDispatcher.toggleEditorPanelEnabled( legacyMetabox );
-		}
-	} );
-};
+	const blockEditorSelector = select( 'core/block-editor' );
+	const editPostSelector = select( 'core/edit-post' );
+	const editPostDispatcher = dispatch( 'core/edit-post' );
+
+	/**
+	 * Toggle meta boxes depending on the blocks.
+	 */
+	window.sensei_toggleLegacyMetaboxes = () => {
+		if ( ! blockEditorSelector ) return;
+
+		const outlineBlockCount = blockEditorSelector.getGlobalBlockCount(
+			COURSE_OUTLINE_NAME
+		);
+		const otherCourseBlocksCount = OTHER_COURSE_BLOCKS.reduce(
+			( sum, blockName ) =>
+				sum + blockEditorSelector.getGlobalBlockCount( blockName ),
+			0
+		);
+
+		const legacyMetaboxes = [
+			{ name: 'meta-box-course-lessons', deps: outlineBlockCount },
+			{ name: 'meta-box-module_course_mb', deps: outlineBlockCount },
+			{
+				name: 'meta-box-course-video',
+				deps: outlineBlockCount + otherCourseBlocksCount,
+			},
+		];
+
+		legacyMetaboxes.forEach( ( { name, deps } ) => {
+			const enable = deps === 0;
+			if ( enable !== editPostSelector.isEditorPanelEnabled( name ) ) {
+				editPostDispatcher.toggleEditorPanelEnabled( name );
+			}
+		} );
+
+		// Prevent submit modules.
+		document
+			.querySelectorAll( '#module_course_mb input' )
+			.forEach( ( input ) => {
+				input.disabled = outlineBlockCount > 0;
+			} );
+	};
+} )();
 
 jQuery( document ).ready( function ( $ ) {
-	window.sensei_toggleLegacyMetaboxes( true );
+	window.sensei_toggleLegacyMetaboxes();
 
 	$( '#course-prerequisite-options' ).select2( { width: '100%' } );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This updates the legacy metaboxes toggle.
  * The lesson and module metaboxes should appear only when we don't have the outline block in the editor.
  * The video metabox should appear if we don't have any course block in the editor.

### Testing instructions

* Access a legacy course in the editor, and make sure all legacy metaboxes appear.
* Access a new course.
* Keep some new blocks, but remove the outline. Make sure the video metabox is not appearing, but the module and lesson metaboxes are appearing.
* Add the outline block, and make sure the legacy metaboxes don't appear.