### PR TITLE
Usage background job for calculating usage stats

### DIFF
--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -30,6 +30,7 @@ class Sensei_Usage_Tracking_Data {
 			'courses'                 => wp_count_posts( 'course' )->publish,
 			'course_active'           => self::get_course_active_count(),
 			'course_completed'        => self::get_course_completed_count(),
+			'course_completion_rate'  => self::get_course_completion_rate(),
 			'course_videos'           => self::get_course_videos_count(),
 			'course_no_notifications' => self::get_course_no_notifications_count(),
 			'course_prereqs'          => self::get_course_prereqs_count(),
@@ -262,6 +263,89 @@ class Sensei_Usage_Tracking_Data {
 		);
 
 		return Sensei_Utils::sensei_check_for_activity( $course_args );
+	}
+
+	/**
+	 * Calculate the average course completion rate.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @return double Average course completion rate.
+	 */
+	private static function get_course_completion_rate() {
+		$course_args             = array(
+			'post_type'      => 'course',
+			'post_status'    => 'publish',
+			'posts_per_page' => -1,
+		);
+		$courses                 = get_posts( $course_args );
+		$course_count            = count( $courses );
+		$course_completion_rates = [];
+
+		foreach ( $courses as $course ) {
+			// Calculate number of learners who are enrolled in the course.
+			$learner_terms = self::get_enrolled_learner_terms( $course->ID );
+			$enrolled_learner_count = 0;
+
+			if ( ! empty( $learner_terms ) && ! is_wp_error( $learner_terms ) ) {
+				$enrolled_learner_count = count( $learner_terms );
+			}
+
+			// Don't include this course in the calculation if no learners are enrolled.
+			if ( 0 === $enrolled_learner_count ) {
+				$course_count--;
+				continue;
+			}
+
+			// Get number of learners who are enrolled in and have completed the course.
+			$completed_course_count = self::get_completed_course_count( $course->ID, $learner_terms );
+
+			// Calculate the completion rate.
+			$course_completion_rate[] = $completed_course_count / $enrolled_learner_count;
+		}
+
+		// Average course completion rate = Sum of course completion rates / # of courses
+		return round( array_sum( $course_completion_rate ) / $course_count * 100, 2 );
+	}
+
+	/**
+	 * Get learner term data for non-admin learners who are enrolled in a course.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @param int $course_id Course ID.
+	 *
+	 * @return array|WP_Error Learner term data or empty array if no terms found.
+	 */
+	private static function get_enrolled_learner_terms( $course_id ) {
+		$term_args = array(
+			'fields'  => 'names',
+			'exclude' => self::get_admin_learner_term_ids(),
+		);
+
+		return wp_get_object_terms( $course_id, Sensei_PostTypes::LEARNER_TAXONOMY_NAME, $term_args );
+	}
+
+	/**
+	 * Get number of non-admin learners who are enrolled in and have completed the course.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @param int   $course_id Course ID.
+	 * @param array $learner_terms Learner term data.
+	 *
+	 * @return int Number of learners.
+	 */
+	private static function get_completed_course_count( $course_id, $learner_terms ) {
+		$enrolled_learner_ids = array_map( [ 'Sensei_learner', 'get_learner_id' ], $learner_terms );
+		$comment_args         = array(
+			'type'       => 'sensei_course_status',
+			'status'     => 'complete',
+			'post_id'    => $course_id,
+			'author__in' => $enrolled_learner_ids,
+		);
+
+		return Sensei_Utils::sensei_check_for_activity( $comment_args );
 	}
 
 	/**

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -10,12 +10,48 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Supplies the usage tracking data for logging.
+ * Supplies the usage tracking data for logging and sends the event.
  *
  * @package Usage Tracking
  * @since 1.9.20
  */
-class Sensei_Usage_Tracking_Data {
+class Sensei_Usage_Tracking_Data implements Sensei_Background_Job_Interface {
+	const JOB_NAME = 'sensei_usage_tracking_send_stats_log';
+
+	/**
+	 * Get the action name for the scheduled job.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return self::JOB_NAME;
+	}
+
+	/**
+	 * Run the job.
+	 */
+	public function run() {
+		Sensei_Usage_Tracking::get_instance()->send_event( 'stats_log', $this->get_usage_data() );
+	}
+
+	/**
+	 * After the job runs, check to see if it needs to be re-queued for the next batch.
+	 *
+	 * @return bool
+	 */
+	public function is_complete() {
+		return true;
+	}
+
+	/**
+	 * Get the arguments to run with the job.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		return [];
+	}
+
 	/**
 	 * Get the usage tracking data to send.
 	 *
@@ -23,7 +59,7 @@ class Sensei_Usage_Tracking_Data {
 	 *
 	 * @return array Usage data.
 	 **/
-	public static function get_usage_data() {
+	public function get_usage_data() {
 		$question_type_count = self::get_question_type_count();
 		$quiz_stats          = self::get_quiz_stats();
 		$usage_data          = array(

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -301,11 +301,11 @@ class Sensei_Usage_Tracking_Data {
 			$completed_course_count = self::get_completed_course_count( $course->ID, $learner_terms );
 
 			// Calculate the completion rate.
-			$course_completion_rate[] = $completed_course_count / $enrolled_learner_count;
+			$course_completion_rates[] = $completed_course_count / $enrolled_learner_count;
 		}
 
 		// Average course completion rate = Sum of course completion rates / # of courses
-		return round( array_sum( $course_completion_rate ) / $course_count * 100, 2 );
+		return round( array_sum( $course_completion_rates ) / $course_count * 100, 2 );
 	}
 
 	/**

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -284,7 +284,7 @@ class Sensei_Usage_Tracking_Data {
 
 		foreach ( $courses as $course ) {
 			// Calculate number of learners who are enrolled in the course.
-			$learner_terms = self::get_enrolled_learner_terms( $course->ID );
+			$learner_terms          = self::get_enrolled_learner_terms( $course->ID );
 			$enrolled_learner_count = 0;
 
 			if ( ! empty( $learner_terms ) && ! is_wp_error( $learner_terms ) ) {
@@ -304,7 +304,7 @@ class Sensei_Usage_Tracking_Data {
 			$course_completion_rates[] = $completed_course_count / $enrolled_learner_count;
 		}
 
-		// Average course completion rate = Sum of course completion rates / # of courses
+		// Average course completion rate = Sum of course completion rates / # of courses.
 		return round( array_sum( $course_completion_rates ) / $course_count * 100, 2 );
 	}
 

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -304,6 +304,10 @@ class Sensei_Usage_Tracking_Data {
 			$course_completion_rates[] = $completed_course_count / $enrolled_learner_count;
 		}
 
+		if ( 0 === $course_count ) {
+			return '';
+		}
+
 		// Average course completion rate = Sum of course completion rates / # of courses.
 		return round( array_sum( $course_completion_rates ) / $course_count * 100, 2 );
 	}

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -29,6 +29,8 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 
 		// Filters for for events to watch and report.
 		add_action( 'activated_plugin', [ $this, 'log_wccom_plugin_install' ] );
+
+		add_action( Sensei_Usage_Tracking_Data::JOB_NAME, [ $this, 'run_stats_log_job' ] );
 	}
 
 	/*
@@ -54,6 +56,20 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 
 	public static function get_instance() {
 		return self::get_instance_for_subclass( get_class() );
+	}
+
+	/**
+	 * Schedules the calculation and submission of the stats log.
+	 */
+	protected function schedule_stats_log() {
+		Sensei_Scheduler::instance()->schedule_job( new Sensei_Usage_Tracking_Data() );
+	}
+
+	/**
+	 * Runs the stats log job.
+	 */
+	public function run_stats_log_job() {
+		( new Sensei_Usage_Tracking_Data() )->run();
 	}
 
 	protected function get_prefix() {

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -407,9 +407,6 @@ class Sensei_Main {
 		$this->view_helper = new Sensei_View_Helper();
 
 		$this->usage_tracking = Sensei_Usage_Tracking::get_instance();
-		$this->usage_tracking->set_callback(
-			array( 'Sensei_Usage_Tracking_Data', 'get_usage_data' )
-		);
 
 		// Ensure tracking job is scheduled. If the user does not opt in, no
 		// data will be sent.

--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -316,7 +316,7 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * sends data if tracking is enabled.
 	 */
 	public function send_usage_data() {
-		if ( ! self::is_tracking_enabled() || ! is_callable( $this->callback ) ) {
+		if ( ! $this->is_tracking_enabled() || ! is_callable( $this->callback ) ) {
 			return;
 		}
 
@@ -326,8 +326,8 @@ abstract class Sensei_Usage_Tracking_Base {
 			return;
 		}
 
-		self::send_event( 'system_log', $this->get_system_data() );
-		self::send_event( 'stats_log', $usage_data );
+		$this->send_event( 'system_log', $this->get_system_data() );
+		$this->send_event( 'stats_log', $usage_data );
 	}
 
 

--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -320,13 +320,14 @@ abstract class Sensei_Usage_Tracking_Base {
 			return;
 		}
 
-		$usage_data = call_user_func( $this->callback );
+		$this->send_event( 'send_usage_data' );
+		$this->send_event( 'system_log', $this->get_system_data() );
 
+		$usage_data = call_user_func( $this->callback );
 		if ( ! is_array( $usage_data ) ) {
 			return;
 		}
 
-		$this->send_event( 'system_log', $this->get_system_data() );
 		$this->send_event( 'stats_log', $usage_data );
 	}
 

--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -30,14 +30,6 @@ abstract class Sensei_Usage_Tracking_Base {
 	 */
 	private $job_name;
 
-	/**
-	 * Callback function for the usage tracking job.
-	 *
-	 * @var array
-	 */
-	private $callback;
-
-
 	/*
 	 * Class variables.
 	 */
@@ -131,6 +123,11 @@ abstract class Sensei_Usage_Tracking_Base {
 	 */
 	abstract protected function do_track_plugin( $plugin_slug );
 
+	/**
+	 * Schedules the calculation and submission of the stats log.
+	 */
+	abstract protected function schedule_stats_log();
+
 	/*
 	 * Initialization.
 	 */
@@ -172,16 +169,6 @@ abstract class Sensei_Usage_Tracking_Base {
 	/*
 	 * Public methods.
 	 */
-
-	/**
-	 * Set the Usage Data Callback. This callback should return an array of
-	 * data to be logged periodically to Tracks.
-	 *
-	 * @param callable $callback the callback returning the usage data to be logged.
-	 */
-	public function set_callback( $callback ) {
-		$this->callback = $callback;
-	}
 
 	/**
 	 * Send an event to Tracks if tracking is enabled, including site information.
@@ -316,19 +303,13 @@ abstract class Sensei_Usage_Tracking_Base {
 	 * sends data if tracking is enabled.
 	 */
 	public function send_usage_data() {
-		if ( ! $this->is_tracking_enabled() || ! is_callable( $this->callback ) ) {
+		if ( ! $this->is_tracking_enabled() ) {
 			return;
 		}
 
 		$this->send_event( 'send_usage_data' );
 		$this->send_event( 'system_log', $this->get_system_data() );
-
-		$usage_data = call_user_func( $this->callback );
-		if ( ! is_array( $usage_data ) ) {
-			return;
-		}
-
-		$this->send_event( 'stats_log', $usage_data );
+		$this->schedule_stats_log();
 	}
 
 

--- a/includes/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
+++ b/includes/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
@@ -7,8 +7,13 @@ require_once dirname( __FILE__ ) . '/../../class-usage-tracking-base.php';
  * match the one used by your plugin (usage-tracking/class-usage-tracking-base.php).
  */
 class Usage_Tracking_Test_Subclass extends Sensei_Usage_Tracking_Base {
+	public $scheduled_stats_log = false;
 
 	const TRACKING_ENABLED_OPTION_NAME = 'testing-usage-tracking-enabled';
+
+	protected function schedule_stats_log() {
+		$this->scheduled_stats_log = true;
+	}
 
 	public static function get_instance() {
 		return self::get_instance_for_subclass( get_class() );

--- a/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -150,7 +150,7 @@ class Sensei_Base_Usage_Tracking_Test extends WP_UnitTestCase {
 		$this->usage_tracking->set_tracking_enabled( true );
 
 		$this->usage_tracking->send_usage_data();
-		$this->assertEquals( 2, $this->event_counts['http_request'], 'Request sent when Usage Tracking enabled' );
+		$this->assertEquals( 3, $this->event_counts['http_request'], 'Requests sent when Usage Tracking enabled' );
 	}
 
 	/* Tests for system data */

--- a/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -20,7 +20,7 @@ class Sensei_Base_Usage_Tracking_Test extends WP_UnitTestCase {
 		parent::setUp();
 		// Update the class name here to match the Usage Tracking class.
 		$this->usage_tracking = Usage_Tracking_Test_Subclass::get_instance();
-		$this->usage_tracking->set_callback( array( $this, 'basicDataCallback' ) );
+		$this->usage_tracking->scheduled_stats_log = false;
 	}
 
 	/**
@@ -145,12 +145,15 @@ class Sensei_Base_Usage_Tracking_Test extends WP_UnitTestCase {
 		// Setting is not set, ensure the request is not sent.
 		$this->usage_tracking->send_usage_data();
 		$this->assertEquals( 0, $this->event_counts['http_request'], 'Request not sent when Usage Tracking disabled' );
+		$this->assertFalse( $this->usage_tracking->scheduled_stats_log, 'No usage tracking data should be calculated when Usage Tracking is disabled' );
 
 		// Set the setting and ensure request is sent.
 		$this->usage_tracking->set_tracking_enabled( true );
 
 		$this->usage_tracking->send_usage_data();
-		$this->assertEquals( 3, $this->event_counts['http_request'], 'Requests sent when Usage Tracking enabled' );
+		$this->assertEquals( 2, $this->event_counts['http_request'], 'Requests sent when Usage Tracking enabled' );
+		$this->assertTrue( $this->usage_tracking->scheduled_stats_log, 'Usage tracking data should be calculated when Usage Tracking is enabled' );
+
 	}
 
 	/* Tests for system data */

--- a/tests/framework/trait-sensei-scheduler-test-helpers.php
+++ b/tests/framework/trait-sensei-scheduler-test-helpers.php
@@ -54,4 +54,15 @@ trait Sensei_Scheduler_Test_Helpers {
 	public static function scheduler_use_action_scheduler() {
 		return Sensei_Scheduler_Action_Scheduler::class;
 	}
+
+	/**
+	 * Assert that an event was scheduled a certain number of times.
+	 *
+	 * @param int    $expected Number of times an event should have been scheduled.
+	 * @param string $action   Action name.
+	 * @param string $message  Message to show for failure.
+	 */
+	public function assertEventScheduledCount( $expected, $action, $message = '' ) {
+		$this->assertEquals( $expected, Sensei_Scheduler_Shim::get_scheduled_action_count( $action ), $message );
+	}
 }

--- a/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-enrolment-job-scheduler.php
@@ -131,15 +131,4 @@ class Sensei_Enrolment_Calculation_Scheduler_Test extends WP_UnitTestCase {
 		$option = get_option( Sensei_Enrolment_Job_Scheduler::CALCULATION_VERSION_OPTION_NAME );
 		$this->assertEquals( $enrolment_manager->get_enrolment_calculation_version(), $option );
 	}
-
-	/**
-	 * Assert that an event was scheduled a certain number of times.
-	 *
-	 * @param int    $expected Number of times an event should have been scheduled.
-	 * @param string $action   Action name.
-	 * @param string $message  Message to show for failure.
-	 */
-	public function assertEventScheduledCount( $expected, $action, $message = '' ) {
-		$this->assertEquals( $expected, Sensei_Scheduler_Shim::get_scheduled_action_count( $action ), $message );
-	}
 }

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -133,7 +133,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->factory->get_course_with_lessons( array( 'question_count' => 0 ) );
 		$this->factory->get_course_with_lessons( array( 'question_count' => 2 ) );
 		$this->factory->get_course_with_lessons( array( 'question_count' => 7 ) );
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( 2, $usage_data['questions_min'] );
 		$this->assertEquals( 7, $usage_data['questions_max'] );
@@ -144,7 +144,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_quiz_stats
 	 */
 	public function testGetMinMaxQuestionsNoQuestions() {
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( 0, $usage_data['quiz_total'] );
 		$this->assertEquals( null, $usage_data['questions_min'] );
@@ -162,7 +162,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 				'question_count' => 2,
 			)
 		);
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( 1, $usage_data['quiz_total'] );
 		$this->assertEquals( 2, $usage_data['questions_min'] );
@@ -195,7 +195,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 				'lesson_count'   => 4, // Missing one should be 5 questions.
 			)
 		);
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( 5, $usage_data['quiz_total'] );
 		$this->assertEquals( 1, $usage_data['questions_min'] );
@@ -231,7 +231,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 				'lesson_count'   => 2,
 			)
 		);
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( 2, $usage_data['quiz_total'] );
 		$this->assertEquals( 2, $usage_data['questions_min'] );
@@ -251,7 +251,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 				'multiple_question_count' => 0,
 			)
 		);
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( 0, $usage_data['category_questions'] );
 	}
@@ -269,7 +269,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 				'multiple_question_count' => 1,
 			)
 		);
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( 1, $usage_data['category_questions'] );
 	}
@@ -298,7 +298,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 				),
 			)
 		);
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( 3, $usage_data['category_questions'] );
 	}
@@ -422,7 +422,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			);
 		}
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 		$this->assertEquals( count( $valid_values ), $usage_data[ $stat_key ] );
 	}
 
@@ -463,7 +463,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		// Fake out! Replicate a data integrity issue that exists in Sensei.
 		update_post_meta( $course_lessons_b['lesson_ids'][0], '_quiz_has_questions', '1' );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 		$this->assertEquals( 1, $usage_data['quiz_allow_retake'] );
 	}
 
@@ -489,7 +489,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'courses', $usage_data, 'Key' );
 		$this->assertEquals( $published, $usage_data['courses'], 'Count' );
@@ -527,7 +527,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			);
 		}
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		// Despite being enrolled in multiple courses, a learner is only counted once.
 		$this->assertArrayHasKey( 'learners', $usage_data, 'Key' );
@@ -540,7 +540,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetUsageDataLessons() {
 		$this->createLessons();
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'lessons', $usage_data, 'Key' );
 		$this->assertEquals( 3, $usage_data['lessons'], 'Count' );
@@ -558,7 +558,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		add_post_meta( $lessons[2], '_lesson_prerequisite', $lessons[1] );  // Published
 		add_post_meta( $lessons[3], '_lesson_prerequisite', $lessons[2] );  // Published
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'lesson_prereqs', $usage_data, 'Key' );
 		$this->assertEquals( 2, $usage_data['lesson_prereqs'], 'Count' );
@@ -571,7 +571,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetLessonPrerequisiteCountNoPrerequisites() {
 		$lessons = $this->createLessons();
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'lesson_prereqs', $usage_data, 'Key' );
 		$this->assertEquals( 0, $usage_data['lesson_prereqs'], 'Count' );
@@ -589,7 +589,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		add_post_meta( $lessons[2], '_lesson_preview', 'preview' ); // Published
 		add_post_meta( $lessons[3], '_lesson_preview', 'preview' ); // Published
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'lesson_previews', $usage_data, 'Key' );
 		$this->assertEquals( 2, $usage_data['lesson_previews'], 'Count' );
@@ -602,7 +602,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetLessonPreviewCountNoPreviews() {
 		$lessons = $this->createLessons();
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'lesson_previews', $usage_data, 'Key' );
 		$this->assertEquals( 0, $usage_data['lesson_previews'], 'Count' );
@@ -621,7 +621,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		wp_set_object_terms( $lessons[2], $terms[1], 'module', false ); // Published
 		wp_set_object_terms( $lessons[4], $terms[2], 'module', false ); // Published
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'lesson_modules', $usage_data, 'Key' );
 		$this->assertEquals( 2, $usage_data['lesson_modules'], 'Count' );
@@ -634,7 +634,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetLessonModuleCountNoModules() {
 		$lessons = $this->createLessons();
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'lesson_modules', $usage_data, 'Key' );
 		$this->assertEquals( 0, $usage_data['lesson_modules'], 'Count' );
@@ -662,7 +662,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'messages', $usage_data, 'Key' );
 		$this->assertEquals( $published, $usage_data['messages'], 'Count' );
@@ -672,7 +672,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 */
 	public function testGetUsageDataModules() {
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'modules', $usage_data, 'Key' );
 		$this->assertEquals( 0, $usage_data['modules'], 'Count' );
@@ -685,7 +685,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetUsageDataMaxModules() {
 		$this->setupCoursesAndModules();
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'modules_max', $usage_data, 'Key' );
 		$this->assertEquals( 3, $usage_data['modules_max'], 'Count' ); // Course 2 has 3 modules.
@@ -698,7 +698,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetUsageDataMinModules() {
 		$this->setupCoursesAndModules();
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'modules_min', $usage_data, 'Key' );
 		$this->assertEquals( 2, $usage_data['modules_min'], 'Count' ); // Courses 1 and 2 have 2 modules.
@@ -726,7 +726,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'questions', $usage_data, 'Key' );
 		$this->assertEquals( $published, $usage_data['questions'], 'Count' );
@@ -759,7 +759,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		wp_set_post_terms( $questions[8], array( 'multi-line' ), 'question-type' );
 		wp_set_post_terms( $questions[9], array( 'boolean' ), 'question-type' );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'question_multiple_choice', $usage_data, 'Multiple choice key' );
 		$this->assertArrayHasKey( 'question_gap_fill', $usage_data, 'Gap fill key' );
@@ -792,7 +792,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		// Set the question to use an invalid type.
 		wp_set_post_terms( $question, array( 'automattic' ), 'question-type' );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayNotHasKey( 'question_automattic', $usage_data, 'Multiple choice key' );
 	}
@@ -824,7 +824,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		add_post_meta( $questions[1], '_question_media', $media[1] );
 		add_post_meta( $questions[2], '_question_media', $media[2] );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'question_media', $usage_data, 'Key' );
 		$this->assertEquals( 3, $usage_data['question_media'], 'Count' );
@@ -844,7 +844,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			)
 		);
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'question_media', $usage_data, 'Key' );
 		$this->assertEquals( 0, $usage_data['question_media'], 'Count' );
@@ -874,7 +874,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		add_post_meta( $questions[1], '_random_order', 'no' );
 		add_post_meta( $questions[2], '_random_order', 'yes' );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'question_random_order', $usage_data, 'Key' );
 		$this->assertEquals( 2, $usage_data['question_random_order'], 'Count' );
@@ -910,7 +910,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		add_post_meta( $questions[4], '_random_order', 'yes' );
 		add_post_meta( $questions[5], '_random_order', 'yes' );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'question_random_order', $usage_data, 'Key' );
 		$this->assertEquals( 0, $usage_data['question_random_order'], 'Count' );
@@ -927,7 +927,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->factory->user->create_many( 10, array( 'role' => 'subscriber' ) );
 		$this->factory->user->create_many( $teachers, array( 'role' => 'teacher' ) );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'teachers', $usage_data, 'Key' );
 		$this->assertEquals( $teachers, $usage_data['teachers'], 'Count' );
@@ -943,7 +943,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->setupCoursesAndModules();
 		$this->enrollUsers();
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'course_active', $usage_data, 'Key' );
 		$this->assertEquals( 10, $usage_data['course_active'], 'Count' );
@@ -959,7 +959,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->setupCoursesAndModules();
 		$this->enrollUsers();
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'course_completed', $usage_data, 'Key' );
 		$this->assertEquals( 5, $usage_data['course_completed'], 'Count' );
@@ -1014,7 +1014,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			);
 		}
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'course_completion_rate', $usage_data, 'Key' );
 		// Course 1 - 5 non-admin learners enrolled, 0 completed; Completion rate = 0
@@ -1054,7 +1054,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		update_post_meta( $course_ids_without_video[1], '_course_video_embed', '   ' );
 		update_post_meta( $course_ids_without_video[2], '_course_video_embed', "\t\n" );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'course_videos', $usage_data, 'Key' );
 		$this->assertEquals( $with_video, $usage_data['course_videos'], 'Count' );
@@ -1085,7 +1085,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			update_post_meta( $course_id, 'disable_notification', true );
 		}
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'course_no_notifications', $usage_data, 'Key' );
 		$this->assertEquals( $with_disabled_notification, $usage_data['course_no_notifications'], 'Count' );
@@ -1119,7 +1119,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		// Another value for no prereq
 		update_post_meta( $course_ids_without_prereq[1], '_course_prerequisite', '0' );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'course_prereqs', $usage_data, 'Key' );
 		$this->assertEquals( $with_prereq, $usage_data['course_prereqs'], 'Count' );
@@ -1150,7 +1150,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			update_post_meta( $course_id, '_course_featured', 'featured' );
 		}
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'course_featured', $usage_data, 'Key' );
 		$this->assertEquals( $featured, $usage_data['course_featured'], 'Count' );
@@ -1177,7 +1177,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			$this->manuallyEnrolStudentInCourse( $subscriber, $course_id );
 		}
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'enrolments', $usage_data, 'Key' );
 		$this->assertEquals( $enrolments, $usage_data['enrolments'], 'Count' );
@@ -1191,7 +1191,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
 		update_option( Sensei_Enrolment_Job_Scheduler::CALCULATION_VERSION_OPTION_NAME, $enrolment_manager->get_enrolment_calculation_version() );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'enrolments', $usage_data, 'Key' );
 		$this->assertEquals( 1, $usage_data['enrolment_calculated'], 'Boolean int' );
@@ -1204,7 +1204,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function testGetIsEnrolmentCalculatedFalse() {
 		delete_option( Sensei_Enrolment_Job_Scheduler::CALCULATION_VERSION_OPTION_NAME );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'enrolments', $usage_data, 'Key' );
 		$this->assertEquals( 0, $usage_data['enrolment_calculated'], 'Boolean int' );
@@ -1232,7 +1232,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			$this->manuallyEnrolStudentInCourse( $user, $course_id );
 		}
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( $enrolments, $usage_data['enrolments'] );
 	}
@@ -1256,7 +1256,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 			$this->manuallyEnrolStudentInCourse( $subscriber, $course_id );
 		}
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( 0, $usage_data['enrolments'] );
 	}
@@ -1293,7 +1293,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		update_comment_meta( $comment_ids[1], 'start', $last_enrolment_date );
 		update_comment_meta( $comment_ids[2], 'start', '2018-10-01 13:25:25' );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'enrolment_last', $usage_data, 'Key' );
 		$this->assertEquals( $last_enrolment_date, $usage_data['enrolment_last'], 'Count' );
@@ -1332,7 +1332,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		update_comment_meta( $comment_ids[1], 'start', '2018-11-09 09:48:05' ); // Admin.
 		update_comment_meta( $comment_ids[2], 'start', '2018-10-01 13:25:25' ); // Admin.
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( $last_enrolment_date, $usage_data['enrolment_last'] );
 	}
@@ -1367,7 +1367,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		update_comment_meta( $comment_ids[1], 'start', '2018-11-09 09:48:05' );
 		update_comment_meta( $comment_ids[2], 'start', '2018-10-01 13:25:25' );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( 'N/A', $usage_data['enrolment_last'] );
 	}
@@ -1404,7 +1404,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		update_comment_meta( $comment_ids[1], 'start', $first_enrolment_date );
 		update_comment_meta( $comment_ids[2], 'start', '2018-10-01 13:25:25' );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'enrolment_first', $usage_data, 'Key' );
 		$this->assertEquals( $first_enrolment_date, $usage_data['enrolment_first'], 'Count' );
@@ -1443,7 +1443,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		update_comment_meta( $comment_ids[1], 'start', '2018-10-01 13:25:25' ); // Admin.
 		update_comment_meta( $comment_ids[2], 'start', $first_enrolment_date ); // Subscriber.
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( $first_enrolment_date, $usage_data['enrolment_first'] );
 	}
@@ -1478,7 +1478,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		update_comment_meta( $comment_ids[1], 'start', '2018-11-09 09:48:05' );
 		update_comment_meta( $comment_ids[2], 'start', '2018-10-01 13:25:25' );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertEquals( 'N/A', $usage_data['enrolment_first'] );
 	}
@@ -1512,7 +1512,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		}
 		update_post_meta( $lesson_without_length_ids[0], '_lesson_length', '' );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'lesson_length', $usage_data, 'Key' );
 		$this->assertEquals( $lessons_with_length, $usage_data['lesson_length'], 'Count' );
@@ -1547,7 +1547,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		}
 		update_post_meta( $lesson_without_complexity_ids[0], '_lesson_complexity', '' );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'lesson_complexity', $usage_data, 'Key' );
 		$this->assertEquals( $lessons_with_complexity, $usage_data['lesson_complexity'], 'Count' );
@@ -1585,7 +1585,7 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		update_post_meta( $lesson_without_video_ids[1], '_lesson_video_embed', '    ' );
 		update_post_meta( $lesson_without_video_ids[2], '_lesson_video_embed', "\t\n" );
 
-		$usage_data = Sensei_Usage_Tracking_Data::get_usage_data();
+		$usage_data = ( new Sensei_Usage_Tracking_Data() )->get_usage_data();
 
 		$this->assertArrayHasKey( 'lesson_videos', $usage_data, 'Key' );
 		$this->assertEquals( $lessons_with_video, $usage_data['lesson_videos'], 'Count' );

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -977,12 +977,11 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 		$this->setupCoursesAndModules();
 
 		// Create some admins and subscribers.
-		$subscribers = $this->factory->user->create_many( 5, array( 'role' => 'subscriber' ) );
 		$admins      = $this->factory->user->create_many( 2, array( 'role' => 'administrator' ) );
-		$users       = array_merge( $subscribers, $admins );
+		$subscribers = $this->factory->user->create_many( 5, array( 'role' => 'subscriber' ) );
 
 		// Enroll some learners in some courses.
-		foreach ( $users as $user ) {
+		foreach ( array_merge( $admins, $subscribers ) as $user ) {
 			$this->factory->comment->create(
 				array(
 					'user_id'          => $user,
@@ -999,6 +998,19 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 					'comment_type'     => 'sensei_course_status',
 					'comment_approved' => 'complete',
 				)
+			);
+
+			// Set term data.
+			wp_set_object_terms(
+				$this->course_ids[0],
+				'user-' . $user,
+				Sensei_PostTypes::LEARNER_TAXONOMY_NAME
+			);
+
+			wp_set_object_terms(
+				$this->course_ids[1],
+				'user-' . $user,
+				Sensei_PostTypes::LEARNER_TAXONOMY_NAME
 			);
 		}
 

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -966,6 +966,8 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Course completion rate.
+	 *
 	 * @covers Sensei_Usage_Tracking_Data::get_usage_data
 	 * @covers Sensei_Usage_Tracking_Data::get_course_completion_rate
 	 * @covers Sensei_Usage_Tracking_Data::get_enrolled_learner_terms


### PR DESCRIPTION
### Changes proposed in this Pull Request

* From https://github.com/Automattic/sensei/pull/3777, I'm a bit worried our stats log data request will timeout on larger sites. I've added a `sensei_send_usage_data` event so we can track how many sites start to send us usage data but then time out.
* We can build off of this PR if we want to generate usage data in multiple steps. So far this WIP doesn't attempt to do that, but we can if we notice failures.

### Testing instructions

* TBC.