### PR TITLE
Disable `with_front` for new installs

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -77,6 +77,7 @@ class Sensei_Data_Cleaner {
 		'sensei_courses_page_id',
 		'woothemes-sensei_courses_page_id',
 		'woothemes-sensei_user_dashboard_page_id',
+		'sensei-legacy-flags',
 	);
 
 	/**

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -152,6 +152,8 @@ class Sensei_PostTypes {
 	 * @return void
 	 */
 	public function setup_course_post_type() {
+		// If Sensei LMS was first activated pre-3.7.0 and permalinks had a front value, `with_front` will be enabled.
+		$with_front = Sensei()->get_legacy_flag( Sensei_Main::LEGACY_FLAG_WITH_FRONT ) ? true : false;
 
 		$args = array(
 			'labels'                => $this->create_post_type_labels( $this->labels['course']['singular'], $this->labels['course']['plural'], $this->labels['course']['menu'] ),
@@ -163,7 +165,7 @@ class Sensei_PostTypes {
 			'query_var'             => true,
 			'rewrite'               => array(
 				'slug'       => esc_attr( apply_filters( 'sensei_course_slug', _x( 'course', 'post type single url base', 'sensei-lms' ) ) ),
-				'with_front' => true,
+				'with_front' => $with_front,
 				'feeds'      => true,
 				'pages'      => true,
 			),
@@ -257,6 +259,9 @@ class Sensei_PostTypes {
 			array_push( $supports_array, 'comments' );
 		} // End If Statement
 
+		// If Sensei LMS was first activated pre-3.7.0 and permalinks had a front value, `with_front` will be enabled.
+		$with_front = Sensei()->get_legacy_flag( Sensei_Main::LEGACY_FLAG_WITH_FRONT ) ? true : false;
+
 		$args = array(
 			'labels'                => $this->create_post_type_labels( $this->labels['lesson']['singular'], $this->labels['lesson']['plural'], $this->labels['lesson']['menu'] ),
 			'public'                => true,
@@ -266,7 +271,7 @@ class Sensei_PostTypes {
 			'query_var'             => true,
 			'rewrite'               => array(
 				'slug'       => esc_attr( apply_filters( 'sensei_lesson_slug', _x( 'lesson', 'post type single slug', 'sensei-lms' ) ) ),
-				'with_front' => true,
+				'with_front' => $with_front,
 				'feeds'      => true,
 				'pages'      => true,
 			),
@@ -299,6 +304,8 @@ class Sensei_PostTypes {
 	 * @return void
 	 */
 	public function setup_quiz_post_type() {
+		// If Sensei LMS was first activated pre-3.7.0 and permalinks had a front value, `with_front` will be enabled.
+		$with_front = Sensei()->get_legacy_flag( Sensei_Main::LEGACY_FLAG_WITH_FRONT ) ? true : false;
 
 		$args = array(
 			'labels'              => $this->create_post_type_labels(
@@ -315,7 +322,7 @@ class Sensei_PostTypes {
 			'exclude_from_search' => true,
 			'rewrite'             => array(
 				'slug'       => esc_attr( apply_filters( 'sensei_quiz_slug', _x( 'quiz', 'post type single slug', 'sensei-lms' ) ) ),
-				'with_front' => true,
+				'with_front' => $with_front,
 				'feeds'      => true,
 				'pages'      => true,
 			),
@@ -348,6 +355,8 @@ class Sensei_PostTypes {
 	 * @return void
 	 */
 	public function setup_question_post_type() {
+		// If Sensei LMS was first activated pre-3.7.0 and permalinks had a front value, `with_front` will be enabled.
+		$with_front = Sensei()->get_legacy_flag( Sensei_Main::LEGACY_FLAG_WITH_FRONT ) ? true : false;
 
 		$args = array(
 			'labels'              => $this->create_post_type_labels( $this->labels['question']['singular'], $this->labels['question']['plural'], $this->labels['question']['menu'] ),
@@ -360,7 +369,7 @@ class Sensei_PostTypes {
 			'exclude_from_search' => true,
 			'rewrite'             => array(
 				'slug'       => esc_attr( apply_filters( 'sensei_question_slug', _x( 'question', 'post type single slug', 'sensei-lms' ) ) ),
-				'with_front' => true,
+				'with_front' => $with_front,
 				'feeds'      => true,
 				'pages'      => true,
 			),

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -12,6 +12,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Main {
 	const COMMENT_COUNT_TRANSIENT_PREFIX = 'sensei_comment_counts_';
+	const LEGACY_FLAG_OPTION             = 'sensei-legacy-flags';
+	const LEGACY_FLAG_WITH_FRONT         = 'with_front';
 
 	/**
 	 * @var string
@@ -637,6 +639,8 @@ class Sensei_Main {
 	 * @since 2.0.0
 	 */
 	public function update() {
+		global $wp_rewrite;
+
 		$current_version = get_option( 'sensei-version' );
 		$is_new_install  = ! $current_version && ! $this->course_exists();
 		$is_upgrade      = $current_version && version_compare( $this->version, $current_version, '>' );
@@ -672,8 +676,50 @@ class Sensei_Main {
 			update_option( 'sensei_enrolment_legacy', time() );
 		}
 
+		// Set up legacy `with_front` on CPT rewrite options.
+		if (
+				$is_upgrade
+				&& version_compare( '3.7.0-dev', $current_version, '>' )
+				&& '' !== trim( $wp_rewrite->front, '/' )
+			) {
+			$this->set_legacy_flag( self::LEGACY_FLAG_WITH_FRONT, true );
+		}
+
 		// Flush rewrite cache.
 		$this->initiate_rewrite_rules_flush();
+	}
+
+	/**
+	 * Sets a legacy flag to a boolean value.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @param string $flag  Short name for the flag to set.
+	 * @param bool   $value Boolean value to set.
+	 */
+	public function set_legacy_flag( $flag, $value ) {
+		$legacy_flags          = json_decode( get_option( self::LEGACY_FLAG_OPTION, '{}' ), true );
+		$legacy_flags[ $flag ] = (bool) $value;
+
+		update_option( self::LEGACY_FLAG_OPTION, wp_json_encode( $legacy_flags ) );
+	}
+
+	/**
+	 * Get a legacy flag value.
+	 *
+	 * @param string $flag    Short name for the flag to set.
+	 * @param bool   $default Boolean value to set. Defaults to false.
+	 *
+	 * @return bool
+	 */
+	public function get_legacy_flag( $flag, $default = false ) {
+		$legacy_flags = json_decode( get_option( self::LEGACY_FLAG_OPTION, '{}' ), true );
+
+		if ( isset( $legacy_flags[ $flag ] ) ) {
+			return (bool) $legacy_flags[ $flag ];
+		}
+
+		return (bool) $default;
 	}
 
 	/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-lms",
-  "version": "3.6.0",
+  "version": "3.7.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-lms",
-  "version": "3.6.0",
+  "version": "3.7.0-dev",
   "description": "Sensei LMS",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -3,7 +3,7 @@
  * Plugin Name: Sensei LMS
  * Plugin URI: https://woocommerce.com/products/sensei/
  * Description: Share your knowledge, grow your network, and strengthen your brand by launching an online course.
- * Version: 3.6.0-beta.1
+ * Version: 3.7.0-dev
  * Author: Automattic
  * Author URI: https://automattic.com
  * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -88,7 +88,7 @@ if ( ! function_exists( 'Sensei' ) ) {
 	 * @since 1.8.0
 	 */
 	function Sensei() {
-		return Sensei_Main::instance( array( 'version' => '3.6.0-beta.1' ) );
+		return Sensei_Main::instance( array( 'version' => '3.7.0-dev' ) );
 	}
 }
 


### PR DESCRIPTION
Fixes #3140

### Changes proposed in this Pull Request

* For new installs, disable `with_front` on CPT rewrite rules.
* For existing installs, if this is desired behavior, they can simply delete the `sensei-legacy-flags` option.

### Testing instructions

_Single site installs_
* In `master` branch:
  * Set up a permalink structure with front matter before variables, such as:
`/awesome/%year%/%monthnum%/%day%/%postname%/`
  * Confirm you are able to visit `http://example.com/awesome/courses-overview/`
  * Note: This is a "break" (not able to just do `/courses-overview`) similar to the issue #3140, but probably just so uncommon we never got a report.
* Switch to this branch.
* Confirm the option `sensei-legacy-flags` was created with `with_front: true`.
* Confirm you can still access the old page `http://example.com/awesome/courses-overview/`
* Save permalinks (no changes) and confirm the above still works.
* Delete the `sensei-legacy-flags` (simulating a new install) and resave permalinks (no change).
* Verify you can access the courses from `http://example.com/courses-overview`

_Multi-site installs_
* In `master` branch:
  * From the root site, make sure permalinks are the default/standard. In permalink settings, you should notice a forced front value of `/blog/`.
* Switch to this branch.
* Confirm the option `sensei-legacy-flags` was created with `with_front: true`.
* Confirm you can still access the old page `http://example.com/blog/courses-overview/`.
* Save permalinks (no changes) and confirm the above still works.
* Delete the `sensei-legacy-flags` (simulating a new install) and resave permalinks (no change).
* Verify you can access the courses from `http://example.com/courses-overview`

_Bonus points_
* Create a new install and verify `sensei-legacy-flags` is not created for single or multi-site.