### PR TITLE
Fix teacher change issue on saving block editor meta boxes

### DIFF
--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -1,4 +1,4 @@
-import { select, dispatch } from '@wordpress/data';
+import { select, dispatch, subscribe } from '@wordpress/data';
 
 ( () => {
 	const COURSE_OUTLINE_NAME = 'sensei-lms/course-outline';
@@ -11,6 +11,29 @@ import { select, dispatch } from '@wordpress/data';
 	const blockEditorSelector = select( 'core/block-editor' );
 	const editPostSelector = select( 'core/edit-post' );
 	const editPostDispatcher = dispatch( 'core/edit-post' );
+
+	const teacherIdSelect = document.getElementsByName(
+		'sensei-course-teacher-author'
+	);
+
+	if ( editPostSelector && teacherIdSelect.length ) {
+		let isSavingMetaboxes = false;
+
+		subscribe( () => {
+			if ( editPostSelector.isSavingMetaBoxes() !== isSavingMetaboxes ) {
+				isSavingMetaboxes = editPostSelector.isSavingMetaBoxes();
+
+				if ( ! isSavingMetaboxes ) {
+					const currentTeacherId = teacherIdSelect[ 0 ].value;
+					if ( currentTeacherId ) {
+						document.getElementsByName(
+							'post_author_override'
+						)[ 0 ].value = currentTeacherId;
+					}
+				}
+			}
+		} );
+	}
 
 	/**
 	 * Toggle meta boxes depending on the blocks.

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -257,6 +257,7 @@ class Sensei_Teacher {
 		$users = $this->get_teachers_and_authors();
 
 		?>
+		<input type="hidden" name="post_author_override" value="<?php echo intval( $current_author ); ?>" />
 		<select name="sensei-course-teacher-author" class="sensei course teacher">
 
 			<?php foreach ( $users as $user_id ) { ?>


### PR DESCRIPTION
Fixes #3790

### Changes proposed in this Pull Request

* Set (and continuously update) `post_author_override` field to prevent the WP core functionality from switching the post author momentarily to the admin currently editing.

### Testing instructions

* Check issue to verify fixed.
* Check to make sure nothing unintentional happens when saving/changing teacher in block and classic editor.
