### PR TITLE
Add prettier JSDoc parser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,6 @@ module.exports = {
 			},
 		],
 		'react-hooks/exhaustive-deps': 'warn',
-		'jsdoc-alignment/lines-alignment': 'error',
 	},
-	plugins: [ 'jest', 'jsdoc-alignment' ],
+	plugins: [ 'jest' ],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,4 +16,13 @@ module.exports = {
 		'react-hooks/exhaustive-deps': 'warn',
 	},
 	plugins: [ 'jest' ],
+	settings: {
+		jsdoc: {
+			// Override Gutenberg rules in favor of Prettier plugin.
+			tagNamePreference: {
+				returns: 'returns',
+				yields: 'yields',
+			},
+		},
+	},
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,5 @@
 module.exports = {
 	...require( '@wordpress/prettier-config' ),
+	jsdocParser: true,
+	jsdocVerticalAlignment: true,
 };

--- a/assets/admin/exit-survey/index.js
+++ b/assets/admin/exit-survey/index.js
@@ -2,9 +2,7 @@ import { ExitSurveyForm } from './form';
 import { render } from '@wordpress/element';
 
 ( function senseiExitSurvey() {
-	/**
-	 * Add exit survey modal when clicking the Deactivate link for Sensei LMS plugin.
-	 */
+	/** Add exit survey modal when clicking the Deactivate link for Sensei LMS plugin. */
 	const addExitSurveyOnDeactivate = () => {
 		const getDeactivateLinkElement = ( slug ) =>
 			document.querySelector(
@@ -27,9 +25,7 @@ import { render } from '@wordpress/element';
 		} );
 	};
 
-	/**
-	 * Exit survey modal.
-	 */
+	/** Exit survey modal. */
 	class ExitSurveyModal {
 		href;
 		container;
@@ -42,10 +38,7 @@ import { render } from '@wordpress/element';
 		constructor( { href } ) {
 			this.href = href;
 		}
-		/**
-		 * Create and open a modal with an exit survey form.
-		 *
-		 */
+		/** Create and open a modal with an exit survey form. */
 		open = () => {
 			let container = document.querySelector( '#sensei-exit-survey' );
 			if ( ! container ) {
@@ -85,9 +78,7 @@ import { render } from '@wordpress/element';
 			this.closeAndDeactivate();
 		};
 
-		/**
-		 * Close survey modal and continue plugin deactivation.
-		 */
+		/** Close survey modal and continue plugin deactivation. */
 		closeAndDeactivate = () => {
 			this.container.remove();
 			window.location = this.href;

--- a/assets/admin/exit-survey/reasons.js
+++ b/assets/admin/exit-survey/reasons.js
@@ -1,8 +1,6 @@
 import { __ } from '@wordpress/i18n';
 
-/**
- * Exit survey reasons
- */
+/** Exit survey reasons */
 export const reasons = [
 	{
 		id: 'no-longer-need',

--- a/assets/blocks/button/button-props.js
+++ b/assets/blocks/button/button-props.js
@@ -4,10 +4,10 @@ import { getColorAndStyleProps } from './color-props';
 /**
  * Class and style attributes for border radius.
  *
- * @param {Object} props
- * @param {Object} props.attributes
- * @param {number} props.attributes.borderRadius Border radius attribute.
- * @return {{className, style}} Output HTML attributes.
+ * @param   {Object}               props
+ * @param   {Object}               props.attributes
+ * @param   {number}               props.attributes.borderRadius Border radius attribute.
+ * @returns {{ className; style }}                               Output HTML attributes.
  */
 export function getBorderRadiusProps( { attributes: { borderRadius } } ) {
 	return {
@@ -23,8 +23,8 @@ export function getBorderRadiusProps( { attributes: { borderRadius } } ) {
 /**
  * Class and style attributes for the button.
  *
- * @param {{attributes}} props Block properties.
- * @return {{className, style}} Output HTML attributes.
+ * @param   {{ attributes }}       props Block properties.
+ * @returns {{ className; style }}       Output HTML attributes.
  */
 export function getButtonProps( props ) {
 	const isLink = isLinkStyle( props );
@@ -48,11 +48,11 @@ export function getButtonProps( props ) {
 /**
  * Class and style attributes for the wrapper element.
  *
- * @param {Object} props                  Block properties.
- * @param {string} props.className        Block classname.
- * @param {Object} props.attributes       Block attributes.
- * @param {string} props.attributes.align Alignment attribute.
- * @return {{className}} Output HTML attributes.
+ * @param   {Object}        props                  Block properties.
+ * @param   {string}        props.className        Block classname.
+ * @param   {Object}        props.attributes       Block attributes.
+ * @param   {string}        props.attributes.align Alignment attribute.
+ * @returns {{ className }}                        Output HTML attributes.
  */
 export function getButtonWrapperProps( { className, attributes: { align } } ) {
 	return {
@@ -68,8 +68,8 @@ export function getButtonWrapperProps( { className, attributes: { align } } ) {
 /**
  * Check if block has the 'Link' block style.
  *
- * @param {Object} props Block props.
- * @return {boolean} Is it a link block style.
+ * @param   {Object}  props Block props.
+ * @returns {boolean}       Is it a link block style.
  */
 export const isLinkStyle = ( props ) =>
 	/\bis-style-link\b/.test( props?.attributes?.className );

--- a/assets/blocks/button/color-hooks.js
+++ b/assets/blocks/button/color-hooks.js
@@ -6,8 +6,8 @@ import { withColorSettings } from '../../shared/blocks/settings';
 /**
  * Check if block is a Sensei button.
  *
- * @param {Object|string} blockType Block settings or name.
- * @return {boolean} Is Sensei button.
+ * @param   {Object | string} blockType Block settings or name.
+ * @returns {boolean}                   Is Sensei button.
  */
 const isSenseiButton = ( blockType ) => {
 	blockType = 'string' === typeof blockType ? blockType : blockType.name;
@@ -17,8 +17,8 @@ const isSenseiButton = ( blockType ) => {
 /**
  * Add fallback Color settings and attributes if the color support key is not available.
  *
- * @param {Object} settings Block settings.
- * @return {Object} Block settings.
+ * @param   {Object} settings Block settings.
+ * @returns {Object}          Block settings.
  */
 export const addColorSettings = ( settings ) => {
 	if ( ! isSenseiButton( settings ) ) {
@@ -59,8 +59,8 @@ export const addColorSettings = ( settings ) => {
 /**
  * Remove colors from className and style props.
  *
- * @param {Object} props Block wrapper extra props.
- * @return {Object} Block wrapper extra props.
+ * @param   {Object} props Block wrapper extra props.
+ * @returns {Object}       Block wrapper extra props.
  */
 const removeColorProps = ( props ) => ( {
 	...props,
@@ -76,9 +76,9 @@ const removeColorProps = ( props ) => ( {
 /**
  * Remove extra props from the save element wrapper added by the color support hook.
  *
- * @param {Object} props     Extra save props.
- * @param {Object} blockType Block settings.
- * @return {Object} props Extra save props.
+ * @param   {Object} props     Extra save props.
+ * @param   {Object} blockType Block settings.
+ * @returns {Object}           Props Extra save props.
  */
 export const removeColorSaveProps = ( props, blockType ) => {
 	if ( ! isSenseiButton( blockType ) ) {
@@ -90,8 +90,8 @@ export const removeColorSaveProps = ( props, blockType ) => {
 /**
  * Remove extra props from the edit element wrapper added by the color support hook.
  *
- * @param {Object} settings Block settings.
- * @return {Object} settings Block settings.
+ * @param   {Object} settings Block settings.
+ * @returns {Object}          Settings Block settings.
  */
 export const removeColorEditProps = ( settings ) => {
 	if ( ! isSenseiButton( settings ) ) {

--- a/assets/blocks/button/color-props.js
+++ b/assets/blocks/button/color-props.js
@@ -1,11 +1,7 @@
-/**
- * External dependencies
- */
+/** External dependencies */
 import classnames from 'classnames';
 
-/**
- * WordPress dependencies
- */
+/** WordPress dependencies */
 import {
 	getColorClassName,
 	getColorObjectByAttributeValues,
@@ -14,8 +10,8 @@ import {
 /**
  * Get className for gradient.
  *
- * @param {string} gradientSlug
- * @return {string|undefined} Class.
+ * @param   {string}             gradientSlug
+ * @returns {string | undefined}              Class.
  */
 export const getGradientClass = ( gradientSlug ) => {
 	if ( ! gradientSlug ) {

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -7,9 +7,7 @@ import { SaveButtonBlock } from './save-button';
 import { button as icon } from '../../icons/wordpress-icons';
 import { withDefaultBlockStyle } from '../../shared/blocks/settings';
 
-/**
- * Button block styles.
- */
+/** Button block styles. */
 export const BlockStyles = {
 	Fill: {
 		name: 'default',
@@ -28,7 +26,8 @@ export const BlockStyles = {
 /**
  * Create a block type settings object for custom button-based blocks.
  *
- * Settings are merged into block settings, the rest of the options are passed on to the save and edit components.
+ * Settings are merged into block settings, the rest of the options are passed
+ * on to the save and edit components.
  *
  * @param {Object} opts
  * @param {Object} opts.settings Block settings.

--- a/assets/blocks/button/settings-button.js
+++ b/assets/blocks/button/settings-button.js
@@ -13,8 +13,8 @@ const MAX_BORDER_RADIUS_VALUE = 50;
  * Border radius control.
  *
  * @param {Object}   props
- * @param {number?}  props.borderRadius  Border radius attribute.
- * @param {Function} props.setAttributes Set block attributes.
+ * @param {number}   [props.borderRadius] Border radius attribute.
+ * @param {Function} props.setAttributes  Set block attributes.
  */
 export const BorderPanel = ( { borderRadius, setAttributes } ) => {
 	return (

--- a/assets/blocks/contact-teacher/index.js
+++ b/assets/blocks/contact-teacher/index.js
@@ -1,9 +1,7 @@
 import { BlockStyles, createButtonBlockType } from '../button';
 import { __ } from '@wordpress/i18n';
 
-/**
- * Take course button block.
- */
+/** Take course button block. */
 export default createButtonBlockType( {
 	tagName: 'a',
 	settings: {

--- a/assets/blocks/course-outline/apply-style-class.js
+++ b/assets/blocks/course-outline/apply-style-class.js
@@ -5,10 +5,9 @@ import { find } from 'lodash';
 /**
  * Checks if a block has a registered style which matches with the supplied class.
  *
- * @param {Array}  blockStyles The block's registered styles.
- * @param {string} className   The class to check.
- *
- * @return {boolean} True if there is a match.
+ * @param   {Array}   blockStyles The block's registered styles.
+ * @param   {string}  className   The class to check.
+ * @returns {boolean}             True if there is a match.
  */
 const blockHasStyle = ( blockStyles, className ) => {
 	return (
@@ -20,10 +19,9 @@ const blockHasStyle = ( blockStyles, className ) => {
 /**
  * Returns the active style class from the given className.
  *
- * @param {Array}  styles    Block style variations.
- * @param {string} className Class name.
- *
- * @return {string} The active style class.
+ * @param   {Array}  styles    Block style variations.
+ * @param   {string} className Class name.
+ * @returns {string}           The active style class.
  */
 export const getActiveStyleClass = ( styles, className ) => {
 	if ( className ) {

--- a/assets/blocks/course-outline/course-block/edit.js
+++ b/assets/blocks/course-outline/course-block/edit.js
@@ -14,7 +14,8 @@ import { getActiveStyleClass, applyStyleClass } from '../apply-style-class';
 import useToggleLegacyMetaboxes from '../../use-toggle-legacy-metaboxes';
 
 /**
- * A React context which contains the attributes and the setAttributes callback of the Outline block.
+ * A React context which contains the attributes and the setAttributes callback
+ * of the Outline block.
  */
 export const OutlineAttributesContext = createContext();
 

--- a/assets/blocks/course-outline/course-block/settings.js
+++ b/assets/blocks/course-outline/course-block/settings.js
@@ -7,7 +7,8 @@ import { PanelBody, ToggleControl } from '@wordpress/components';
  *
  * @param {Object}   props
  * @param {boolean}  props.collapsibleModules    Whether collapsible modules are enabled.
- * @param {Function} props.setCollapsibleModules Callback to be called when collapsible modules setting is updated.
+ * @param {Function} props.setCollapsibleModules Callback to be called when
+ *     collapsible modules setting is updated.
  * @param {boolean}  props.moduleBorder          Whether modules borders are enabled.
  * @param {Function} props.setModuleBorder       Callback to set module borders.
  */

--- a/assets/blocks/course-outline/get-course-inner-blocks.js
+++ b/assets/blocks/course-outline/get-course-inner-blocks.js
@@ -3,10 +3,9 @@ import { select } from '@wordpress/data';
 /**
  * Get the course outline inner blocks of a specific type.
  *
- * @param {string} outlineClientId The outline block client id.
- * @param {string} blockType       The block type to return.
- *
- * @return {Array} An array of blocks.
+ * @param   {string} outlineClientId The outline block client id.
+ * @param   {string} blockType       The block type to return.
+ * @returns {Array}                  An array of blocks.
  */
 export const getCourseInnerBlocks = ( outlineClientId, blockType ) => {
 	let allChildren = select( 'core/block-editor' ).getBlocks(

--- a/assets/blocks/course-outline/lesson-block/edit.js
+++ b/assets/blocks/course-outline/lesson-block/edit.js
@@ -56,7 +56,8 @@ export const EditLessonBlock = ( props ) => {
 	};
 
 	/**
-	 * Insert a new lesson on enter, unless there is already an empty new lesson after this one.
+	 * Insert a new lesson on enter, unless there is already an empty new lesson
+	 * after this one.
 	 */
 	const onEnter = () => {
 		const editor = select( 'core/block-editor' );

--- a/assets/blocks/course-outline/lesson-block/settings.js
+++ b/assets/blocks/course-outline/lesson-block/settings.js
@@ -16,7 +16,8 @@ import { Status, StatusControl } from '../status-control';
  * @param {Object}   props                     Component props.
  * @param {string}   props.previewStatus       Status to preview.
  * @param {Function} props.setPreviewStatus    Set status to preview.
- * @param {Function} props.setAttributes       Callback method to set the lesson title font size.
+ * @param {Function} props.setAttributes       Callback method to set the lesson
+ *     title font size.
  * @param {Function} props.attributes          The block attributes.
  * @param {number}   props.attributes.id       The lesson id.
  * @param {string}   props.attributes.fontSize The lesson block font size.

--- a/assets/blocks/course-outline/module-block/edit.js
+++ b/assets/blocks/course-outline/module-block/edit.js
@@ -27,7 +27,8 @@ import { useInsertLessonBlock } from './use-insert-lesson-block';
  * @param {Object}   props.attributes                  Block attributes.
  * @param {string}   props.attributes.title            Module title.
  * @param {string}   props.attributes.description      Module description.
- * @param {boolean}  props.attributes.borderedSelected The border setting selected by the user.
+ * @param {boolean}  props.attributes.borderedSelected The border setting
+ *     selected by the user.
  * @param {string}   props.attributes.borderColorValue The border color.
  * @param {Object}   props.mainColor                   Header main color.
  * @param {Object}   props.defaultMainColor            Default main color.

--- a/assets/blocks/course-outline/module-block/transforms.js
+++ b/assets/blocks/course-outline/module-block/transforms.js
@@ -1,8 +1,6 @@
 import { createBlock } from '@wordpress/blocks';
 
-/**
- * Module block transform.
- */
+/** Module block transform. */
 export default {
 	from: [
 		{

--- a/assets/blocks/course-outline/status-control/index.js
+++ b/assets/blocks/course-outline/status-control/index.js
@@ -1,18 +1,14 @@
 import { RadioControl, Disabled } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
-/**
- * An enum of Status constants.
- */
+/** An enum of Status constants. */
 export const Status = {
 	NOT_STARTED: 'not-started',
 	IN_PROGRESS: 'in-progress',
 	COMPLETED: 'completed',
 };
 
-/**
- * Labels for each of the statuses.
- */
+/** Labels for each of the statuses. */
 export const StatusLabels = {
 	[ Status.NOT_STARTED ]: __( 'Not Started', 'sensei-lms' ),
 	[ Status.IN_PROGRESS ]: __( 'In Progress', 'sensei-lms' ),
@@ -20,12 +16,15 @@ export const StatusLabels = {
 };
 
 /**
- * A component which controls the status preview for a block. It contains a group of buttons and a description.
+ * A component which controls the status preview for a block. It contains a
+ * group of buttons and a description.
  *
- * @param {Object}   props           Component props. Extras will be handed through to the `SelectControl` component.
+ * @param {Object}   props           Component props. Extras will be handed
+ *     through to the `SelectControl` component.
  * @param {Array}    props.options   The ordered Status constants to include.
  * @param {string}   props.status    The index of the current status.
- * @param {Function} props.setStatus A callback which is called with the index when a status is selected.
+ * @param {Function} props.setStatus A callback which is called with the index
+ *     when a status is selected.
  * @param {boolean}  props.disabled  Flag which disables the controls.
  */
 export const StatusControl = ( {

--- a/assets/blocks/course-outline/status-store.js
+++ b/assets/blocks/course-outline/status-store.js
@@ -8,17 +8,14 @@ const DEFAULT_STATE = {
 	trackedLessons: [],
 };
 
-/**
- * Status store actions.
- */
+/** Status store actions. */
 const actions = {
 	/**
 	 * Sets the status of a lesson.
 	 *
-	 * @param {string} lessonId The lesson id.
-	 * @param {string} status   The lesson status.
-	 *
-	 * @return {Object} The setLessonStatus action.
+	 * @param   {string} lessonId The lesson id.
+	 * @param   {string} status   The lesson status.
+	 * @returns {Object}          The setLessonStatus action.
 	 */
 	setLessonStatus( lessonId, status ) {
 		return {
@@ -31,10 +28,9 @@ const actions = {
 	/**
 	 * Sets the status of a module by updating the status of its lessons.
 	 *
-	 * @param {string} moduleId The module block id.
-	 * @param {string} status   The module status.
-	 *
-	 * @return {Object} Yields the lesson update actions.
+	 * @param   {string} moduleId The module block id.
+	 * @param   {string} status   The module status.
+	 * @returns {Object}          Yields the lesson update actions.
 	 */
 	*setModuleStatus( moduleId, status ) {
 		const trackedLessonIds = yield select(
@@ -77,9 +73,8 @@ const actions = {
 	/**
 	 * Creates the action to update state after a possible removal of a lesson.
 	 *
-	 * @param {string[]} descendantIds The ids of all outline block descendants.
-	 *
-	 * @return {Object} The action.
+	 * @param   {string[]} descendantIds The ids of all outline block descendants.
+	 * @returns {Object}                 The action.
 	 */
 	stopTrackingRemovedLessons( descendantIds ) {
 		return {
@@ -91,9 +86,8 @@ const actions = {
 	/**
 	 * Creates the action which marks a lesson as tracked by the store.
 	 *
-	 * @param {string} lessonId The lesson id.
-	 *
-	 * @return {Object} The action.
+	 * @param   {string} lessonId The lesson id.
+	 * @returns {Object}          The action.
 	 */
 	trackLesson( lessonId ) {
 		return {
@@ -105,9 +99,8 @@ const actions = {
 	/**
 	 * Creates the action which marks a lesson as not tracked by the store.
 	 *
-	 * @param {string} lessonId The lesson id.
-	 *
-	 * @return {Object} The action.
+	 * @param   {string} lessonId The lesson id.
+	 * @returns {Object}          The action.
 	 */
 	ignoreLesson( lessonId ) {
 		return {
@@ -117,28 +110,26 @@ const actions = {
 	},
 };
 
-/**
- * Status store selectors.
- */
+/** Status store selectors. */
 const selectors = {
 	/**
 	 * Get all the lessons that are tracked by the store.
 	 *
-	 * @param {Object} state                The state.
-	 * @param {Array}  state.trackedLessons The tracked lessons.
-	 *
-	 * @return {Object} An object with the total and completed lesson counts.
+	 * @param   {Object} state                The state.
+	 * @param   {Array}  state.trackedLessons The tracked lessons.
+	 * @returns {Object}                      An object with the total and
+	 *     completed lesson counts.
 	 */
 	getTrackedLessons: ( { trackedLessons } ) => trackedLessons,
 
 	/**
 	 * Get the lesson counts.
 	 *
-	 * @param {Object} state                  The state.
-	 * @param {Array}  state.trackedLessons   The ids of all the lessons.
-	 * @param {Array}  state.completedLessons The ids of the completed lessons.
-	 *
-	 * @return {Object} An object with the total and completed lesson counts.
+	 * @param   {Object} state                  The state.
+	 * @param   {Array}  state.trackedLessons   The ids of all the lessons.
+	 * @param   {Array}  state.completedLessons The ids of the completed lessons.
+	 * @returns {Object}                        An object with the total and
+	 *     completed lesson counts.
 	 */
 	getLessonCounts: ( { trackedLessons, completedLessons } ) => ( {
 		totalLessonsCount: trackedLessons.length,
@@ -148,11 +139,10 @@ const selectors = {
 	/**
 	 * Gets the lesson status.
 	 *
-	 * @param {Object} state                  The state.
-	 * @param {Array}  state.completedLessons The ids of the completed lessons.
-	 * @param {string} lessonId               The lesson id.
-	 *
-	 * @return {string} The lesson status.
+	 * @param   {Object} state                  The state.
+	 * @param   {Array}  state.completedLessons The ids of the completed lessons.
+	 * @param   {string} lessonId               The lesson id.
+	 * @returns {string}                        The lesson status.
 	 */
 	getLessonStatus: ( { completedLessons }, lessonId ) =>
 		completedLessons.includes( lessonId )
@@ -162,12 +152,11 @@ const selectors = {
 	/**
 	 * Returns the number of total and completed lessons of a module.
 	 *
-	 * @param {Object} state                  The state.
-	 * @param {Array}  state.completedLessons The ids of the completed lessons.
-	 * @param {Array}  state.trackedLessons   The ids of  all the lessons.
-	 * @param {string} moduleId               The module id.
-	 *
-	 * @return {Object} The module lesson counts.
+	 * @param   {Object} state                  The state.
+	 * @param   {Array}  state.completedLessons The ids of the completed lessons.
+	 * @param   {Array}  state.trackedLessons   The ids of all the lessons.
+	 * @param   {string} moduleId               The module id.
+	 * @returns {Object}                        The module lesson counts.
 	 */
 	getModuleLessonCounts( { completedLessons, trackedLessons }, moduleId ) {
 		const moduleLessons = selectData( 'core/block-editor' )
@@ -187,19 +176,16 @@ const selectors = {
 	},
 };
 
-/**
- * Status store reducer.
- */
+/** Status store reducer. */
 const reducers = {
 	/**
 	 * Updates the lesson status.
 	 *
-	 * @param {Object} action          The action.
-	 * @param {string} action.status   The lesson status.
-	 * @param {string} action.lessonId The lesson id.
-	 * @param {Object} state           The state.
-	 *
-	 * @return {Object} The new state.
+	 * @param   {Object} action          The action.
+	 * @param   {string} action.status   The lesson status.
+	 * @param   {string} action.lessonId The lesson id.
+	 * @param   {Object} state           The state.
+	 * @returns {Object}                 The new state.
 	 */
 	SET_LESSON_STATUS: ( { lessonId, status }, state ) => {
 		let completedLessons = [ ...state.completedLessons ];
@@ -223,11 +209,11 @@ const reducers = {
 	/**
 	 * Removes any lessons that don't exist in list of descendantIds.
 	 *
-	 * @param {Object} action               The action.
-	 * @param {Array}  action.descendantIds The ids of all descendants of the outline block.
-	 * @param {Object} state                The state.
-	 *
-	 * @return {Object} The new state.
+	 * @param   {Object} action               The action.
+	 * @param   {Array}  action.descendantIds The ids of all descendants of the
+	 *     outline block.
+	 * @param   {Object} state                The state.
+	 * @returns {Object}                      The new state.
 	 */
 	REMOVE_LESSONS: ( { descendantIds }, state ) => {
 		const completedLessons = state.completedLessons.filter(
@@ -256,11 +242,10 @@ const reducers = {
 	/**
 	 * Removes a lesson from the arrays of tracked lessons.
 	 *
-	 * @param {Object} action          The action.
-	 * @param {Array}  action.lessonId The ids of the lesson to ignore.
-	 * @param {Object} state           The state.
-	 *
-	 * @return {Object} The new state.
+	 * @param   {Object} action          The action.
+	 * @param   {Array}  action.lessonId The ids of the lesson to ignore.
+	 * @param   {Object} state           The state.
+	 * @returns {Object}                 The new state.
 	 */
 	IGNORE_LESSON: ( { lessonId }, state ) => {
 		const completedLessons = state.completedLessons.filter(
@@ -281,11 +266,10 @@ const reducers = {
 	/**
 	 * Adds a lesson from the arrays of tracked lessons.
 	 *
-	 * @param {Object} action          The action.
-	 * @param {Array}  action.lessonId The ids of the lesson to track.
-	 * @param {Object} state           The state.
-	 *
-	 * @return {Object} The new state.
+	 * @param   {Object} action          The action.
+	 * @param   {Array}  action.lessonId The ids of the lesson to track.
+	 * @param   {Object} state           The state.
+	 * @returns {Object}                 The new state.
 	 */
 	TRACK_LESSON: ( { lessonId }, state ) => {
 		const trackedLessons = [ ...state.trackedLessons ];

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -33,9 +33,7 @@ const getEditorOutlineStructure = () => {
 };
 
 const actions = {
-	/**
-	 * Fetch course structure data from REST API.
-	 */
+	/** Fetch course structure data from REST API. */
 	*fetchCourseStructure() {
 		const courseId = yield select( 'core/editor' ).getCurrentPostId();
 		const result = yield apiFetch( {
@@ -123,15 +121,11 @@ const actions = {
 		);
 	},
 
-	/**
-	 * Clear structure update.
-	 */
+	/** Clear structure update. */
 	clearStructureUpdate: () => ( { type: 'CLEAR_STRUCTURE_UPDATE' } ),
 };
 
-/**
- * Course structure reducers.
- */
+/** Course structure reducers. */
 const reducers = {
 	SET_SERVER_STRUCTURE: (
 		{ serverStructure, hasStructureUpdate },
@@ -154,9 +148,7 @@ const reducers = {
 	DEFAULT: ( action, state ) => state,
 };
 
-/**
- * Course structure selectors.
- */
+/** Course structure selectors. */
 const selectors = {
 	shouldResavePost: ( { hasStructureUpdate } ) => hasStructureUpdate,
 	getIsSavingStructure: ( { isSavingStructure } ) => isSavingStructure,
@@ -165,9 +157,7 @@ const selectors = {
 
 export const COURSE_STORE = 'sensei/course-structure';
 
-/**
- * Register course structure store and subscribe to block editor save.
- */
+/** Register course structure store and subscribe to block editor save. */
 const registerCourseStructureStore = () => {
 	// Set to true when savings starts, and false when it ends.
 	let postSaving = false;

--- a/assets/blocks/course-outline/use-block-creator.js
+++ b/assets/blocks/course-outline/use-block-creator.js
@@ -4,8 +4,7 @@ import { extractStructure, syncStructureToBlocks } from './data';
 import { isEqual } from 'lodash';
 
 /**
- * Blocks creator hook.
- * It adds blocks dynamically to the InnerBlock.
+ * Blocks creator hook. It adds blocks dynamically to the InnerBlock.
  *
  * @param {string} clientId Block client ID.
  */

--- a/assets/blocks/course-progress/edit.js
+++ b/assets/blocks/course-progress/edit.js
@@ -18,13 +18,15 @@ import useToggleLegacyMetaboxes from '../use-toggle-legacy-metaboxes';
  * @param {string}   props.className               Custom class name.
  * @param {Object}   props.barColor                Color object for the progress bar.
  * @param {Object}   props.defaultBarColor         Default bar color.
- * @param {Object}   props.barBackgroundColor      Color object for the background of the progress bar.
+ * @param {Object}   props.barBackgroundColor      Color object for the
+ *     background of the progress bar.
  * @param {Object}   props.textColor               Color object for the text.
  * @param {Object}   props.attributes              Component attributes.
  * @param {number}   props.attributes.height       The height of the progress bar.
  * @param {number}   props.attributes.borderRadius The border radius of the progress bar.
  * @param {boolean}  props.attributes.isPreview    Is preview flag.
- * @param {Function} props.setAttributes           Callback to set the component attributes.
+ * @param {Function} props.setAttributes           Callback to set the component
+ *     attributes.
  */
 export const EditCourseProgressBlock = ( {
 	className,

--- a/assets/blocks/take-course/index.js
+++ b/assets/blocks/take-course/index.js
@@ -1,9 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { createButtonBlockType } from '../button';
 
-/**
- * Take course button block.
- */
+/** Take course button block. */
 export default createButtonBlockType( {
 	tagName: 'button',
 	settings: {

--- a/assets/data-port/export/store/index.js
+++ b/assets/data-port/export/store/index.js
@@ -18,9 +18,7 @@ const mapJobState = ( job ) => {
 		  }
 		: EMPTY_STATE;
 };
-/**
- * Export store reducers.
- */
+/** Export store reducers. */
 const reducers = {
 	UPDATE_JOB: ( { job }, state ) =>
 		state.job ? mapJobState( job ) : state,
@@ -30,19 +28,13 @@ const reducers = {
 	DEFAULT: ( action, state ) => state,
 };
 
-/**
- * Export store resolvers.
- */
+/** Export store resolvers. */
 const resolvers = {
-	/**
-	 * Check for active job on first access.
-	 */
+	/** Check for active job on first access. */
 	getJob: () => actions.checkForActiveJob(),
 };
 
-/**
- * Export store selectors
- */
+/** Export store selectors */
 const selectors = {
 	getJobId: ( { job } ) => ( job && job.id ) || null,
 	getJob: ( { job } ) => job,

--- a/assets/data-port/import.js
+++ b/assets/data-port/import.js
@@ -9,9 +9,7 @@ import '../shared/data/api-fetch-preloaded-once';
 
 registerImportStore();
 
-/**
- * Sensei import page.
- */
+/** Sensei import page. */
 const SenseiImportPage = () => {
 	const { error, navigationSteps } = useSelect( ( select ) => {
 		const store = select( 'sensei/import' );

--- a/assets/data-port/import/data/actions.js
+++ b/assets/data-port/import/data/actions.js
@@ -24,15 +24,14 @@ import { buildJobEndpointUrl } from '../helpers/url';
 
 /**
  * @typedef  {Object} FetchFromAPIAction
- * @property {string} type    Action type.
- * @property {Object} request Object that is used to fetch.
+ * @property {string} type               Action type.
+ * @property {Object} request            Object that is used to fetch.
  */
 /**
  * Fetch action creator.
  *
- * @param {Object} request Object that is used to fetch.
- *
- * @return {FetchFromAPIAction} Fetch action.
+ * @param   {Object}             request Object that is used to fetch.
+ * @returns {FetchFromAPIAction}         Fetch action.
  */
 export const fetchFromAPI = ( request ) => ( {
 	type: FETCH_FROM_API,
@@ -44,9 +43,7 @@ export const wait = ( timeout ) => ( {
 	timeout,
 } );
 
-/**
- * Fetch importer data for current job.
- */
+/** Fetch importer data for current job. */
 export const loadCurrentJobState = composeFetchAction(
 	START_LOAD_CURRENT_JOB_STATE,
 	function* () {
@@ -103,14 +100,14 @@ export const pollJobProgress = function* ( jobId ) {
 
 /**
  * @typedef  {Object} SetJobStateAction
- * @property {string} type Action type.
- * @property {Object} data Job state.
+ * @property {string} type              Action type.
+ * @property {Object} data              Job state.
  */
 /**
  * Set job state action creator.
  *
- * @param {Object} data Job state.
- * @return {SetJobStateAction} Set job state action.
+ * @param   {Object}            data Job state.
+ * @returns {SetJobStateAction}      Set job state action.
  */
 export const setJobState = ( data ) => ( {
 	type: SET_JOB_STATE,
@@ -158,12 +155,12 @@ export function* submitStartImport( jobId, { onSuccess, onError } = {} ) {
 
 /**
  * @typedef  {Object} StartImportAction
- * @property {string} type Action type.
+ * @property {string} type              Action type.
  */
 /**
  * Start action to start import.
  *
- * @return {StartImportAction} Start import action.
+ * @returns {StartImportAction} Start import action.
  */
 export const startImport = () => ( {
 	type: START_IMPORT,
@@ -171,14 +168,14 @@ export const startImport = () => ( {
 
 /**
  * @typedef  {Object} SuccessStartImportAction
- * @property {string} type Action type.
- * @property {Object} data Data object.
+ * @property {string} type                     Action type.
+ * @property {Object} data                     Data object.
  */
 /**
  * Success submit action creator.
  *
- * @param {Object} data Importer data.
- * @return {SuccessStartImportAction} Success submit action.
+ * @param   {Object}                   data Importer data.
+ * @returns {SuccessStartImportAction}      Success submit action.
  */
 export const successStartImport = ( data ) => ( {
 	type: SUCCESS_START_IMPORT,
@@ -186,16 +183,15 @@ export const successStartImport = ( data ) => ( {
 } );
 
 /**
- * @typedef  {Object}         ErrorStartImportAction
- * @property {string}         type  Action type.
- * @property {Object|boolean} error Error object or false.
+ * @typedef  {Object}           ErrorStartImportAction
+ * @property {string}           type                   Action type.
+ * @property {Object | boolean} error                  Error object or false.
  */
 /**
  * Error start import job creator.
  *
- * @param {Object} error Error object or false.
- *
- * @return {ErrorStartImportAction} Error action.
+ * @param   {Object}                 error Error object or false.
+ * @returns {ErrorStartImportAction}       Error action.
  */
 export const errorStartImport = ( error ) => ( {
 	type: ERROR_START_IMPORT,
@@ -259,17 +255,16 @@ export const throwEarlyUploadError = ( level, errorMsg ) =>
 
 /**
  * @typedef  {Object} StartFileUploadAction
- * @property {string} type       Action type.
- * @property {string} level      Level identifier.
- * @property {Object} uploadData Error object or false.
+ * @property {string} type                  Action type.
+ * @property {string} level                 Level identifier.
+ * @property {Object} uploadData            Error object or false.
  */
 /**
  * Start file upload action creator.
  *
- * @param {string} level      Level identifier.
- * @param {Object} uploadData Data to submit.
- *
- * @return {StartFileUploadAction} Start file upload action.
+ * @param   {string}                level      Level identifier.
+ * @param   {Object}                uploadData Data to submit.
+ * @returns {StartFileUploadAction}            Start file upload action.
  */
 export const startFileUploadAction = ( level, uploadData ) => ( {
 	type: START_UPLOAD_IMPORT_DATA_FILE,
@@ -279,16 +274,16 @@ export const startFileUploadAction = ( level, uploadData ) => ( {
 
 /**
  * @typedef  {Object} SuccessFileUploadAction
- * @property {string} type  Action type.
- * @property {string} level Level identifier.
- * @property {Object} data  Data object.
+ * @property {string} type                    Action type.
+ * @property {string} level                   Level identifier.
+ * @property {Object} data                    Data object.
  */
 /**
  * Success upload file action.
  *
- * @param {string} level Level identifier.
- * @param {Object} data  Importer data.
- * @return {SuccessFileUploadAction} Success file upload action.
+ * @param   {string}                  level Level identifier.
+ * @param   {Object}                  data  Importer data.
+ * @returns {SuccessFileUploadAction}       Success file upload action.
  */
 export const successFileUpload = ( level, data ) => ( {
 	type: SUCCESS_UPLOAD_IMPORT_DATA_FILE,
@@ -297,18 +292,17 @@ export const successFileUpload = ( level, data ) => ( {
 } );
 
 /**
- * @typedef  {Object}         ErrorFileUploadAction
- * @property {string}         type  Action type.
- * @property {string}         level Level identifier.
- * @property {Object|boolean} error Error object or false.
+ * @typedef  {Object}           ErrorFileUploadAction
+ * @property {string}           type                  Action type.
+ * @property {string}           level                 Level identifier.
+ * @property {Object | boolean} error                 Error object or false.
  */
 /**
  * Error submit action creator.
  *
- * @param {string}         level Level identifier.
- * @param {Object|boolean} error Error object or false.
- *
- * @return {ErrorFileUploadAction} Error action.
+ * @param   {string}                level Level identifier.
+ * @param   {Object | boolean}      error Error object or false.
+ * @returns {ErrorFileUploadAction}       Error action.
  */
 export const errorFileUpload = ( level, error ) => ( {
 	type: ERROR_UPLOAD_IMPORT_DATA_FILE,
@@ -350,15 +344,14 @@ export function* deleteLevelFile( jobId, level ) {
 
 /**
  * @typedef  {Object} StartDeleteLevelFileAction
- * @property {string} type  Action type.
- * @property {string} level Level identifier.
+ * @property {string} type                       Action type.
+ * @property {string} level                      Level identifier.
  */
 /**
  * Start file upload action creator.
  *
- * @param {string} level Level identifier.
- *
- * @return {StartDeleteLevelFileAction} Start delete file action.
+ * @param   {string}                     level Level identifier.
+ * @returns {StartDeleteLevelFileAction}       Start delete file action.
  */
 export const startDeleteLevelFileAction = ( level ) => ( {
 	type: START_DELETE_IMPORT_DATA_FILE,
@@ -367,16 +360,16 @@ export const startDeleteLevelFileAction = ( level ) => ( {
 
 /**
  * @typedef  {Object} SuccessDeleteLevelFileAction
- * @property {string} type  Action type.
- * @property {string} level Level identifier.
- * @property {Object} data  Data object.
+ * @property {string} type                         Action type.
+ * @property {string} level                        Level identifier.
+ * @property {Object} data                         Data object.
  */
 /**
  * Success delete level file action.
  *
- * @param {string} level Level identifier.
- * @param {Object} data  Importer data.
- * @return {SuccessDeleteLevelFileAction} Success delete level file action.
+ * @param   {string}                       level Level identifier.
+ * @param   {Object}                       data  Importer data.
+ * @returns {SuccessDeleteLevelFileAction}       Success delete level file action.
  */
 export const successDeleteLevelFileAction = ( level, data ) => ( {
 	type: SUCCESS_DELETE_IMPORT_DATA_FILE,
@@ -385,18 +378,17 @@ export const successDeleteLevelFileAction = ( level, data ) => ( {
 } );
 
 /**
- * @typedef  {Object}  ErrorSuccessDeleteLevelFileAction
- * @property {string} type  Action type.
- * @property {string} level Level identifier.
- * @property {Object} error Error object or false.
+ * @typedef  {Object} ErrorSuccessDeleteLevelFileAction
+ * @property {string} type                              Action type.
+ * @property {string} level                             Level identifier.
+ * @property {Object} error                             Error object or false.
  */
 /**
  * Error delete level file action creator.
  *
- * @param {string} level Level identifier.
- * @param {Object} error Error object or false.
- *
- * @return {ErrorSuccessDeleteLevelFileAction} Error delete level file action.
+ * @param   {string}                            level Level identifier.
+ * @param   {Object}                            error Error object or false.
+ * @returns {ErrorSuccessDeleteLevelFileAction}       Error delete level file action.
  */
 export const errorDeleteLevelFileAction = ( level, error ) => ( {
 	type: ERROR_DELETE_IMPORT_DATA_FILE,
@@ -404,16 +396,12 @@ export const errorDeleteLevelFileAction = ( level, error ) => ( {
 	error,
 } );
 
-/**
- * Reset importer state.
- */
+/** Reset importer state. */
 export const resetState = () => ( {
 	type: RESET_STATE,
 } );
 
-/**
- * Restart importer.
- */
+/** Restart importer. */
 export function* restartImporter() {
 	yield resetState();
 	yield loadCurrentJobState();

--- a/assets/data-port/import/data/actions.test.js
+++ b/assets/data-port/import/data/actions.test.js
@@ -85,9 +85,7 @@ const RESPONSE_COMPLETED = {
 };
 
 describe( 'Importer actions', () => {
-	/**
-	 * API Fetch.
-	 */
+	/** API Fetch. */
 	it( 'Should return the fetch from API action', () => {
 		const requestObject = { path: '/test' };
 		const expectedAction = {
@@ -98,9 +96,7 @@ describe( 'Importer actions', () => {
 		expect( fetchFromAPI( requestObject ) ).toEqual( expectedAction );
 	} );
 
-	/**
-	 * Fetch importer data action.
-	 */
+	/** Fetch importer data action. */
 	it( 'Should generate the get current job state importer data action', () => {
 		const gen = loadCurrentJobState();
 
@@ -168,9 +164,7 @@ describe( 'Importer actions', () => {
 		expect( gen.throw( error ).value ).toEqual( expectedErrorAction );
 	} );
 
-	/**
-	 * Poll job progress.
-	 */
+	/** Poll job progress. */
 	it( 'Should generate job poll actions', () => {
 		const gen = pollJobProgress( 'test-id' );
 
@@ -206,9 +200,7 @@ describe( 'Importer actions', () => {
 		expect( gen.next().done ).toBeTruthy();
 	} );
 
-	/**
-	 * Fetch importer data action.
-	 */
+	/** Fetch importer data action. */
 	it( 'Should generate the update job state action', () => {
 		const gen = updateJobState( 'test-id' );
 
@@ -251,9 +243,7 @@ describe( 'Importer actions', () => {
 		);
 	} );
 
-	/**
-	 * Start import actions.
-	 */
+	/** Start import actions. */
 	it( 'Should generate the start import action', () => {
 		const gen = submitStartImport( 'test-id' );
 
@@ -339,9 +329,7 @@ describe( 'Importer actions', () => {
 		expect( errorStartImport( error ) ).toEqual( expectedAction );
 	} );
 
-	/**
-	 * Upload file actions.
-	 */
+	/** Upload file actions. */
 	it( 'Should generate the upload file action', () => {
 		const level = 'test';
 		const uploadData = {};
@@ -462,9 +450,7 @@ describe( 'Importer actions', () => {
 		);
 	} );
 
-	/**
-	 * Delete level file actions.
-	 */
+	/** Delete level file actions. */
 	it( 'Should generate the delete level file action', () => {
 		const level = 'test';
 

--- a/assets/data-port/import/data/constants.js
+++ b/assets/data-port/import/data/constants.js
@@ -1,53 +1,37 @@
-/**
- * Data import constants.
- */
+/** Data import constants. */
 export const API_BASE_PATH = '/sensei-internal/v1/import/';
 export const API_SPECIAL_ACTIVE_JOB_ID = 'active';
 
-/**
- * Generic fetch action type constants.
- */
+/** Generic fetch action type constants. */
 export const FETCH_FROM_API = 'FETCH_FROM_API';
 export const WAIT = 'WAIT';
 
-/**
- * Load action type constants.
- */
+/** Load action type constants. */
 export const START_LOAD_CURRENT_JOB_STATE = 'START_LOAD_CURRENT_JOB_STATE';
 export const SUCCESS_LOAD_CURRENT_JOB_STATE = 'SUCCESS_LOAD_CURRENT_JOB_STATE';
 export const ERROR_LOAD_CURRENT_JOB_STATE = 'ERROR_LOAD_CURRENT_JOB_STATE';
 export const SET_JOB_STATE = 'SET_JOB_STATE';
 
-/**
- * Start import job action type constants.
- */
+/** Start import job action type constants. */
 export const START_IMPORT = 'START_IMPORT';
 export const SUCCESS_START_IMPORT = 'SUCCESS_START_IMPORT';
 export const ERROR_START_IMPORT = 'ERROR_START_IMPORT';
 
-/**
- * Upload file constants.
- */
+/** Upload file constants. */
 export const START_UPLOAD_IMPORT_DATA_FILE = 'START_UPLOAD_IMPORT_DATA_FILE';
 export const SUCCESS_UPLOAD_IMPORT_DATA_FILE =
 	'SUCCESS_UPLOAD_IMPORT_DATA_FILE';
 export const ERROR_UPLOAD_IMPORT_DATA_FILE = 'ERROR_UPLOAD_IMPORT_DATA_FILE';
 
-/**
- * Delete level file constants.
- */
+/** Delete level file constants. */
 export const START_DELETE_IMPORT_DATA_FILE = 'START_DELETE_IMPORT_DATA_FILE';
 export const SUCCESS_DELETE_IMPORT_DATA_FILE =
 	'SUCCESS_DELETE_IMPORT_DATA_FILE';
 export const ERROR_DELETE_IMPORT_DATA_FILE = 'ERROR_DELETE_IMPORT_DATA_FILE';
 
-/**
- * Import log constants.
- */
+/** Import log constants. */
 export const SET_IMPORT_LOG = 'SET_IMPORT_LOG';
 export const ERROR_FETCH_IMPORT_LOG = 'ERROR_FETCH_IMPORT_LOG';
 
-/**
- * Reset to default state.
- */
+/** Reset to default state. */
 export const RESET_STATE = 'RESET_STATE';

--- a/assets/data-port/import/data/controls.js
+++ b/assets/data-port/import/data/controls.js
@@ -6,9 +6,9 @@ export default {
 	/**
 	 * Fetch control.
 	 *
-	 * @param {{request: Object}} action Action with the request object that is used to fetch.
-	 *
-	 * @return {Promise} API fetch promise.
+	 * @param   {{ request: Object }} action Action with the request object that is
+	 *     used to fetch.
+	 * @returns {Promise}                    API fetch promise.
 	 */
 	[ FETCH_FROM_API ]: ( { request } ) => apiFetch( request ),
 	[ WAIT ]: ( { timeout } ) =>

--- a/assets/data-port/import/data/normalizer.js
+++ b/assets/data-port/import/data/normalizer.js
@@ -1,9 +1,8 @@
 /**
  * Normalize uploads state.
  *
- * @param {Object} files Files raw data.
- *
- * @return {Object} Normalized levels data.
+ * @param   {Object} files Files raw data.
+ * @returns {Object}       Normalized levels data.
  */
 export const normalizeUploadsState = ( files ) => {
 	const levels = {};
@@ -23,9 +22,8 @@ export const normalizeUploadsState = ( files ) => {
 /**
  * Parses completed steps data.
  *
- * @param {Object} data Status data.
- *
- * @return {Array} Parsed completed steps data.
+ * @param   {Object} data Status data.
+ * @returns {Array}       Parsed completed steps data.
  */
 export const parseCompletedSteps = ( data ) => {
 	if ( data.status === 'pending' ) {
@@ -39,16 +37,15 @@ export const parseCompletedSteps = ( data ) => {
 };
 
 /**
- *  * Normalize importer data.
+ * * Normalize importer data.
  *
- * @param {Object} input         Importer data.
- * @param {number} input.id      The job id.
- * @param {Object} input.files   Files raw data.
- * @param {string} input.status  Job status.
- * @param {Object} input.results Results of the job.
- * @param {Object} input.data    Job data.
- *
- * @return {Object} Normalized importer data.
+ * @param   {Object} input         Importer data.
+ * @param   {number} input.id      The job id.
+ * @param   {Object} input.files   Files raw data.
+ * @param   {string} input.status  Job status.
+ * @param   {Object} input.results Results of the job.
+ * @param   {Object} input.data    Job data.
+ * @returns {Object}               Normalized importer data.
  */
 export const normalizeImportData = ( {
 	id,

--- a/assets/data-port/import/data/reducer.js
+++ b/assets/data-port/import/data/reducer.js
@@ -63,11 +63,10 @@ const DEFAULT_STATE = {
 };
 
 /**
- *
- * @param {Object} state      Current state.
- * @param {{type:  string}}   levelKey   Level to update.
- * @param {Object} attributes Attributes to set.
- * @return {Object} State updated.
+ * @param   {Object}           state      Current state.
+ * @param   {{ type: string }} levelKey   Level to update.
+ * @param   {Object}           attributes Attributes to set.
+ * @returns {Object}                      State updated.
  */
 const updateLevelState = ( state, levelKey, attributes ) => ( {
 	...state,
@@ -80,10 +79,9 @@ const updateLevelState = ( state, levelKey, attributes ) => ( {
 /**
  * Data importer reducer.
  *
- * @param {Object} state    Current state.
- * @param {{type:  string}} action Action to update the state.
- *
- * @return {Object} State updated.
+ * @param   {Object}           state  Current state.
+ * @param   {{ type: string }} action Action to update the state.
+ * @returns {Object}                  State updated.
  */
 export default ( state = DEFAULT_STATE, action ) => {
 	switch ( action.type ) {

--- a/assets/data-port/import/data/selectors.js
+++ b/assets/data-port/import/data/selectors.js
@@ -7,47 +7,42 @@ const DONE_KEYS = [ 'course', 'lesson', 'question' ];
 /**
  * Is fetching importer data selector.
  *
- * @param {Object} state Current state.
- *
- * @return {boolean} Is fetching.
+ * @param   {Object}  state Current state.
+ * @returns {boolean}       Is fetching.
  */
 export const isFetching = ( state ) => state.isFetching;
 
 /**
  * Get the import job ID.
  *
- * @param {Object} state Current state.
- *
- * @return {string} Job ID.
+ * @param   {Object} state Current state.
+ * @returns {string}       Job ID.
  */
 export const getJobId = ( state ) => state.jobId;
 
 /**
  * Fetch importer error selector.
  *
- * @param {Object} state Current state.
- *
- * @return {Object|boolean} Error object or false.
+ * @param   {Object}           state Current state.
+ * @returns {Object | boolean}       Error object or false.
  */
 export const getFetchError = ( state ) => state.fetchError;
 
 /**
  * Step state selector.
  *
- * @param {Object} state Current state.
- * @param {string} step  Step name.
- *
- * @return {Object} Step data.
+ * @param   {Object} state Current state.
+ * @param   {string} step  Step name.
+ * @returns {Object}       Step data.
  */
 export const getStepData = ( state, step ) => state[ step ];
 
 /**
  * Get navigation steps with their state.
  *
- * @param {Object} state                Current state.
- * @param {Array}  state.completedSteps An array of the completed steps.
- *
- * @return {Array} Navigation steps.
+ * @param   {Object} state                Current state.
+ * @param   {Array}  state.completedSteps An array of the completed steps.
+ * @returns {Array}                       Navigation steps.
  */
 export const getNavigationSteps = ( { completedSteps } ) => {
 	const navSteps = steps.map( ( step ) => ( {
@@ -66,11 +61,10 @@ export const getNavigationSteps = ( { completedSteps } ) => {
 /**
  * Get whether step is complete or not.
  *
- * @param {Object} state                Current state.
- * @param {Array}  state.completedSteps An array of the completed steps.
- * @param {string} step                 Step name.
- *
- * @return {boolean} Step complete.
+ * @param   {Object}  state                Current state.
+ * @param   {Array}   state.completedSteps An array of the completed steps.
+ * @param   {string}  step                 Step name.
+ * @returns {boolean}                      Step complete.
  */
 export const isCompleteStep = ( { completedSteps }, step ) =>
 	completedSteps.includes( step );
@@ -78,9 +72,8 @@ export const isCompleteStep = ( { completedSteps }, step ) =>
 /**
  * Get whether the importer is ready to start.
  *
- * @param {Object} state Current state.
- *
- * @return {boolean} If the importer is ready.
+ * @param   {Object}  state Current state.
+ * @returns {boolean}       If the importer is ready.
  */
 export const isReadyToStart = ( state ) => {
 	const levelsState = levels.map( ( { key } ) => state.upload[ key ] );
@@ -95,10 +88,9 @@ export const isReadyToStart = ( state ) => {
 /**
  * Get uploaded level keys.
  *
- * @param {Object} state        Current state.
- * @param {Object} state.upload The upload status of all levels.
- *
- * @return {string[]} Array of uploaded level keys.
+ * @param   {Object}   state        Current state.
+ * @param   {Object}   state.upload The upload status of all levels.
+ * @returns {string[]}              Array of uploaded level keys.
  */
 export const getUploadedLevelKeys = ( { upload } ) =>
 	levels
@@ -108,10 +100,9 @@ export const getUploadedLevelKeys = ( { upload } ) =>
 /**
  * Get success results.
  *
- * @param {Object} state      Current state.
- * @param {Object} state.done The object which contains the results of the job.
- *
- * @return {Array} Success results.
+ * @param   {Object} state      Current state.
+ * @param   {Object} state.done The object which contains the results of the job.
+ * @returns {Array}             Success results.
  */
 export const getSuccessResults = ( { done } ) =>
 	DONE_KEYS.map( ( key ) => ( {
@@ -124,11 +115,10 @@ export const getSuccessResults = ( { done } ) =>
 /**
  * Get logs by severity.
  *
- * @param {Object} state        Current state.
- * @param {Object} state.done   The object which contains the logs of the job.
- * @param {Object} state.upload The object which contains the uploads.
- *
- * @return {Object} Object with the logs by severity.
+ * @param   {Object} state        Current state.
+ * @param   {Object} state.done   The object which contains the logs of the job.
+ * @param   {Object} state.upload The object which contains the uploads.
+ * @returns {Object}              Object with the logs by severity.
  */
 export const getLogsBySeverity = ( { done, upload } ) => {
 	const items = get( done, 'logs.items', [] )
@@ -144,10 +134,9 @@ export const getLogsBySeverity = ( { done, upload } ) => {
 /**
  * Get logs fetch error.
  *
- * @param {Object} state      Current state.
- * @param {Object} state.done The object which contains the logs of the job.
- *
- * @return {Object|boolean} Error object or false.
+ * @param   {Object}           state      Current state.
+ * @param   {Object}           state.done The object which contains the logs of the job.
+ * @returns {Object | boolean}            Error object or false.
  */
 export const getLogsFetchError = ( { done } ) =>
 	get( done, 'logs.fetchError', false );

--- a/assets/data-port/import/done/done-page.js
+++ b/assets/data-port/import/done/done-page.js
@@ -8,10 +8,12 @@ import ImportSuccessResults from './import-success-results';
  * Done page of the importer.
  *
  * @param {Object}   input                 DonePage input.
- * @param {Function} input.restartImporter A callback to be called when the importer gets restarted.
+ * @param {Function} input.restartImporter A callback to be called when the
+ *     importer gets restarted.
  * @param {Array}    input.successResults  The results of the job.
  * @param {Object}   input.logs            The logs of the job.
- * @param {boolean}  input.isFetching      Whether the logs of the job are currently fetching.
+ * @param {boolean}  input.isFetching      Whether the logs of the job are
+ *     currently fetching.
  * @param {boolean}  input.fetchError      Whether there was an error during fetching.
  * @param {Function} input.retry           Callback to be called when fetching is retried.
  */

--- a/assets/data-port/import/done/import-success-results.js
+++ b/assets/data-port/import/done/import-success-results.js
@@ -3,9 +3,8 @@ import { _n } from '@wordpress/i18n';
 /**
  * Get post type label.
  *
- * @param {{key: string, count: number}} typeData Type data.
- *
- * @return {string} Translated label.
+ * @param   {{ key: string; count: number }} typeData Type data.
+ * @returns {string}                                  Translated label.
  */
 const getPostTypeLabel = ( { key, count } ) => {
 	return {

--- a/assets/data-port/import/helpers/url.js
+++ b/assets/data-port/import/helpers/url.js
@@ -3,9 +3,9 @@ import { API_BASE_PATH } from '../data/constants';
 /**
  * Build a URL for a job specific route.
  *
- * @param {string?} jobId Job identifier.
- * @param {Array?}  parts Parts of the URL.
- * @return {string} Combined URL.
+ * @param   {string} [jobId] Job identifier.
+ * @param   {Array}  [parts] Parts of the URL.
+ * @returns {string}         Combined URL.
  */
 export const buildJobEndpointUrl = ( jobId, parts = null ) => {
 	const path = [

--- a/assets/data-port/import/import-progress/use-progress-polling.js
+++ b/assets/data-port/import/import-progress/use-progress-polling.js
@@ -1,9 +1,7 @@
 import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 
-/**
- * Progress polling hook.
- */
+/** Progress polling hook. */
 const useProgressPolling = () => {
 	const { pollJobProgress } = useDispatch( 'sensei/import' );
 

--- a/assets/data-port/import/upload-level/upload-level.js
+++ b/assets/data-port/import/upload-level/upload-level.js
@@ -45,14 +45,15 @@ const uploadFile = (
 };
 
 /**
- * A component which displays a list of upload levels. Each level has each own description, upload button and a
- * placeholder for messages.
+ * A component which displays a list of upload levels. Each level has each own
+ * description, upload button and a placeholder for messages.
  *
  * @param {Object}   input                       UploadLevels input.
  * @param {number}   input.jobId                 The job id.
  * @param {Object}   input.state                 The import state.
  * @param {Function} input.uploadFileForLevel    Callback for action to upload file.
- * @param {Function} input.throwEarlyUploadError Callback for throwing an early upload error.
+ * @param {Function} input.throwEarlyUploadError Callback for throwing an early
+ *     upload error.
  * @param {Function} input.deleteLevelFile       The import state.
  */
 export const UploadLevels = ( {

--- a/assets/data-port/import/upload/upload-page.js
+++ b/assets/data-port/import/upload/upload-page.js
@@ -12,7 +12,8 @@ import { formatString } from '../../../shared/helpers/format-string.js';
  * @param {Object}   input                   UploadPage input.
  * @param {Object}   input.state             The import state.
  * @param {boolean}  input.isReady           Whether the upload is finished.
- * @param {Function} input.submitStartImport Callback which is called when start button is clicked.
+ * @param {Function} input.submitStartImport Callback which is called when start
+ *     button is clicked.
  */
 export const UploadPage = ( { state, isReady, submitStartImport } ) => {
 	const { isSubmitting, errorMsg } = state;

--- a/assets/data-port/stepper/index.js
+++ b/assets/data-port/stepper/index.js
@@ -1,9 +1,10 @@
 import classnames from 'classnames';
 
 /**
- * @typedef  {Object}   Step
+ * @typedef  {Object}  Step
  * @property {string}  key         Unique key for the step.
- * @property {string}  description A description of the step that is going to be displayed.
+ * @property {string}  description A description of the step that is going to be
+ *     displayed.
  * @property {boolean} isActive    True if the step is the currently active one.
  * @property {boolean} isComplete  True if the step is completed.
  */

--- a/assets/icons/wordpress-icons.js
+++ b/assets/icons/wordpress-icons.js
@@ -1,8 +1,8 @@
 import { Path, SVG } from '@wordpress/components';
 
 /**
- * The following components are copied from @wordpress/icons since the package is not available on WP 5.3. We should
- * remove them once we stop supporting 5.3.
+ * The following components are copied from @wordpress/icons since the package
+ * is not available on WP 5.3. We should remove them once we stop supporting 5.3.
  */
 export const chevronRight = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">

--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -12,9 +12,7 @@ import { select, dispatch } from '@wordpress/data';
 	const editPostSelector = select( 'core/edit-post' );
 	const editPostDispatcher = dispatch( 'core/edit-post' );
 
-	/**
-	 * Toggle meta boxes depending on the blocks.
-	 */
+	/** Toggle meta boxes depending on the blocks. */
 	window.sensei_toggle_legacy_metaboxes = () => {
 		if ( ! blockEditorSelector ) {
 			return;

--- a/assets/js/admin/lesson-bulk-edit.js
+++ b/assets/js/admin/lesson-bulk-edit.js
@@ -1,6 +1,4 @@
-/**
- * Lesson bulk edit screen save functionality
- */
+/** Lesson bulk edit screen save functionality */
 
 jQuery( function ( $ ) {
 	$( '#the-list' ).on( 'click', '#bulk-edit #bulk_edit ', function () {

--- a/assets/js/frontend/course-archive.js
+++ b/assets/js/frontend/course-archive.js
@@ -1,6 +1,4 @@
-/**
- * Functionality for the course archive (courses) page.
- */
+/** Functionality for the course archive (courses) page. */
 jQuery( 'form[name="sensei-course-order"] select' ).on( 'change', function () {
 	jQuery( 'form[name="sensei-course-order"]' ).submit();
 } );

--- a/assets/js/frontend/course-archive.min.js
+++ b/assets/js/frontend/course-archive.min.js
@@ -1,1 +1,4 @@
-"use strict";jQuery('form[name="sensei-course-order"] select').on("change",function(){jQuery('form[name="sensei-course-order"]').submit()});
+'use strict';
+jQuery( 'form[name="sensei-course-order"] select' ).on( 'change', function () {
+	jQuery( 'form[name="sensei-course-order"]' ).submit();
+} );

--- a/assets/react-hooks/probe-styles.js
+++ b/assets/react-hooks/probe-styles.js
@@ -9,7 +9,7 @@ const { getComputedStyle } = window;
 /**
  * Get color object by probe.
  *
- * @return {Object} Object containing the color objects, where the key is the probe key.
+ * @returns {Object} Object containing the color objects, where the key is the probe key.
  */
 export const useColorsByProbe = () => {
 	const themeColorPalette = useSelect(
@@ -43,10 +43,10 @@ export const useColorsByProbe = () => {
 /**
  * Get probe styles (memoized).
  *
- * It adds elements to the DOM as a probe, and get the computed styles
- * the default expected properties.
+ * It adds elements to the DOM as a probe, and get the computed styles the
+ * default expected properties.
  *
- * @return {Object} Probe default styles.
+ * @returns {Object} Probe default styles.
  */
 export const getProbeStyles = memoize( () => {
 	// Create temporary probe elements.

--- a/assets/react-hooks/use-merge-reducer.js
+++ b/assets/react-hooks/use-merge-reducer.js
@@ -3,8 +3,8 @@ import { useReducer } from '@wordpress/element';
 /**
  * Shallow-merge new value into state object.
  *
- * @param {Object} initialState Initial state.
- * @return {[Object, Function]} State object and updateState function.
+ * @param   {Object}               initialState Initial state.
+ * @returns {[ Object, Function ]}              State object and updateState function.
  */
 export const useMergeReducer = ( initialState ) => {
 	return useReducer(

--- a/assets/react-hooks/use-wp-admin-fullscreen.js
+++ b/assets/react-hooks/use-wp-admin-fullscreen.js
@@ -13,8 +13,8 @@ const toggleGlobalStyles = ( enabled, classes ) => {
 /**
  * Apply fullscreen view by hiding wp-admin elements via CSS.
  *
- * Allows setting additional classes on the body element.
- * Fullscreen and classes are added when the component is mounted, and removed when unmounted.
+ * Allows setting additional classes on the body element. Fullscreen and classes
+ * are added when the component is mounted, and removed when unmounted.
  *
  * @param {string[]} bodyClasses Additional classes to be set.
  */

--- a/assets/setup-wizard/data/actions.js
+++ b/assets/setup-wizard/data/actions.js
@@ -15,24 +15,21 @@ import { normalizeSetupWizardData } from './normalizer';
 
 /**
  * @typedef  {Object} FetchFromAPIAction
- * @property {string} type    Action type.
- * @property {Object} request Object that is used to fetch.
+ * @property {string} type               Action type.
+ * @property {Object} request            Object that is used to fetch.
  */
 /**
  * Fetch action creator.
  *
- * @param {Object} request Object that is used to fetch.
- *
- * @return {FetchFromAPIAction} Fetch action.
+ * @param   {Object}             request Object that is used to fetch.
+ * @returns {FetchFromAPIAction}         Fetch action.
  */
 export const fetchFromAPI = ( request ) => ( {
 	type: FETCH_FROM_API,
 	request,
 } );
 
-/**
- * Fetch setup wizard data action creator.
- */
+/** Fetch setup wizard data action creator. */
 export function* fetchSetupWizardData() {
 	yield startFetch();
 
@@ -48,15 +45,14 @@ export function* fetchSetupWizardData() {
 
 /**
  * @typedef  {Object} SuccessSetupWizardDataAction
- * @property {string} type Action type.
- * @property {Object} data Setup wizard data.
+ * @property {string} type                         Action type.
+ * @property {Object} data                         Setup wizard data.
  */
 /**
  * Success fetch action creator.
  *
- * @param {Object} data Setup wizard data.
- *
- * @return {SuccessSetupWizardDataAction} Success fetch action.
+ * @param   {Object}                       data Setup wizard data.
+ * @returns {SuccessSetupWizardDataAction}      Success fetch action.
  */
 export const successFetch = ( data ) => ( {
 	type: SUCCESS_FETCH_SETUP_WIZARD_DATA,
@@ -64,16 +60,15 @@ export const successFetch = ( data ) => ( {
 } );
 
 /**
- * @typedef  {Object}         ErrorFetchAction
- * @property {string}         type  Action type.
- * @property {Object|boolean} error Error object or false.
+ * @typedef  {Object}           ErrorFetchAction
+ * @property {string}           type             Action type.
+ * @property {Object | boolean} error            Error object or false.
  */
 /**
  * Error fetch action creator.
  *
- * @param {Object|boolean} error Error object or false.
- *
- * @return {ErrorFetchAction} Error action.
+ * @param   {Object | boolean} error Error object or false.
+ * @returns {ErrorFetchAction}       Error action.
  */
 export const errorFetch = ( error ) => ( {
 	type: ERROR_FETCH_SETUP_WIZARD_DATA,
@@ -83,7 +78,7 @@ export const errorFetch = ( error ) => ( {
 /**
  * Start fetch setup wizard data action creator.
  *
- * @return {{type: string}} Start fetch action.
+ * @returns {{ type: string }} Start fetch action.
  */
 export const startFetch = () => ( {
 	type: START_FETCH_SETUP_WIZARD_DATA,
@@ -92,10 +87,9 @@ export const startFetch = () => ( {
 /**
  * Start submit action creator.
  *
- * @param {string} step     Step name.
- * @param {Object} stepData Data to submit.
- *
- * @return {{type: string}} Start submit action.
+ * @param   {string}           step     Step name.
+ * @param   {Object}           stepData Data to submit.
+ * @returns {{ type: string }}          Start submit action.
  */
 export const startSubmit = ( step, stepData ) => ( {
 	type: START_SUBMIT_SETUP_WIZARD_DATA,
@@ -106,8 +100,8 @@ export const startSubmit = ( step, stepData ) => ( {
 /**
  * Success submit action creator.
  *
- * @param {string} step Completed step.
- * @return {{type: string, step: string}} Success submit action.
+ * @param   {string}                         step Completed step.
+ * @returns {{ type: string; step: string }}      Success submit action.
  */
 export const successSubmit = ( step ) => ( {
 	type: SUCCESS_SUBMIT_SETUP_WIZARD_DATA,
@@ -115,16 +109,15 @@ export const successSubmit = ( step ) => ( {
 } );
 
 /**
- * @typedef  {Object}         ErrorSubmitAction
- * @property {string}         type  Action type.
- * @property {Object|boolean} error Error object or false.
+ * @typedef  {Object}           ErrorSubmitAction
+ * @property {string}           type              Action type.
+ * @property {Object | boolean} error             Error object or false.
  */
 /**
  * Error submit action creator.
  *
- * @param {Object|boolean} error Error object or false.
- *
- * @return {ErrorSubmitAction} Error action.
+ * @param   {Object | boolean}  error Error object or false.
+ * @returns {ErrorSubmitAction}       Error action.
  */
 export const errorSubmit = ( error ) => ( {
 	type: ERROR_SUBMIT_SETUP_WIZARD_DATA,
@@ -167,17 +160,16 @@ export function* submitStep( step, stepData, { onSuccess, onError } = {} ) {
 
 /**
  * @typedef  {Object} SetStepDataAction
- * @property {string} type Action type.
- * @property {string} step Step name.
- * @property {Object} data Step data.
+ * @property {string} type              Action type.
+ * @property {string} step              Step name.
+ * @property {Object} data              Step data.
  */
 /**
  * Set welcome step data action creator.
  *
- * @param {string} step Step name.
- * @param {Object} data Step data object.
- *
- * @return {SetStepDataAction} Set welcome step data action.
+ * @param   {string}            step Step name.
+ * @param   {Object}            data Step data object.
+ * @returns {SetStepDataAction}      Set welcome step data action.
  */
 export const setStepData = ( step, data ) => ( {
 	type: SET_STEP_DATA,

--- a/assets/setup-wizard/data/constants.js
+++ b/assets/setup-wizard/data/constants.js
@@ -1,35 +1,23 @@
-/**
- * Setup wizard constants.
- */
+/** Setup wizard constants. */
 export const API_BASE_PATH = '/sensei-internal/v1/setup-wizard/';
 
-/**
- * Generic fetch action type constants.
- */
+/** Generic fetch action type constants. */
 export const FETCH_FROM_API = 'FETCH_FROM_API';
 
-/**
- * Fetch action type constants.
- */
+/** Fetch action type constants. */
 export const START_FETCH_SETUP_WIZARD_DATA = 'START_FETCH_SETUP_WIZARD_DATA';
 export const SUCCESS_FETCH_SETUP_WIZARD_DATA =
 	'SUCCESS_FETCH_SETUP_WIZARD_DATA';
 export const ERROR_FETCH_SETUP_WIZARD_DATA = 'ERROR_FETCH_SETUP_WIZARD_DATA';
 
-/**
- * Submit action type constants.
- */
+/** Submit action type constants. */
 export const START_SUBMIT_SETUP_WIZARD_DATA = 'START_SUBMIT_SETUP_WIZARD_DATA';
 export const SUCCESS_SUBMIT_SETUP_WIZARD_DATA =
 	'SUCCESS_SUBMIT_SETUP_WIZARD_DATA';
 export const ERROR_SUBMIT_SETUP_WIZARD_DATA = 'ERROR_SUBMIT_SETUP_WIZARD_DATA';
 
-/**
- * Welcome step action type constants.
- */
+/** Welcome step action type constants. */
 export const SET_STEP_DATA = 'SET_STEP_DATA';
 
-/**
- * Run any side-effect for state changes.
- */
+/** Run any side-effect for state changes. */
 export const APPLY_STEP_DATA = 'APPLY_STEP_DATA';

--- a/assets/setup-wizard/data/controls.js
+++ b/assets/setup-wizard/data/controls.js
@@ -7,9 +7,9 @@ export default {
 	/**
 	 * Fetch control.
 	 *
-	 * @param {{request: Object}} action Action with the request object that is used to fetch.
-	 *
-	 * @return {Promise} API fetch promise.
+	 * @param   {{ request: Object }} action Action with the request object that is
+	 *     used to fetch.
+	 * @returns {Promise}                    API fetch promise.
 	 */
 	[ FETCH_FROM_API ]: ( { request } ) => apiFetch( request ),
 	[ APPLY_STEP_DATA ]: ( { step, data } ) => {

--- a/assets/setup-wizard/data/normalizer.js
+++ b/assets/setup-wizard/data/normalizer.js
@@ -5,11 +5,11 @@ import { INSTALLED_STATUS } from '../features/feature-status';
 /**
  * Add details to title.
  *
- * @param {Object}        feature
- * @param {string}        feature.product_slug Feature slug.
- * @param {string}        feature.title        Feature title.
- * @param {string|number} feature.price        Feature price.
- * @param {string}        [feature.status]     Feature status.
+ * @param {Object}          feature
+ * @param {string}          feature.product_slug Feature slug.
+ * @param {string}          feature.title        Feature title.
+ * @param {string | number} feature.price        Feature price.
+ * @param {string}          [feature.status]     Feature status.
  */
 // eslint-disable-next-line camelcase
 const getTitleWithDetails = ( { product_slug, title, price, status } ) => {
@@ -31,9 +31,8 @@ const getTitleWithDetails = ( { product_slug, title, price, status } ) => {
 /**
  * Normalize features data.
  *
- * @param {Object} data Fatures data.
- *
- * @return {Object} Normalized features data.
+ * @param   {Object} data Fatures data.
+ * @returns {Object}      Normalized features data.
  */
 export const normalizeFeaturesData = ( data ) => ( {
 	...data,
@@ -48,9 +47,8 @@ export const normalizeFeaturesData = ( data ) => ( {
 /**
  * Normalize setup wizard data.
  *
- * @param {Object} data Setup wizard data.
- *
- * @return {Object} Normalized steup wizard data.
+ * @param   {Object} data Setup wizard data.
+ * @returns {Object}      Normalized steup wizard data.
  */
 export const normalizeSetupWizardData = ( data ) => ( {
 	...data,

--- a/assets/setup-wizard/data/reducer.js
+++ b/assets/setup-wizard/data/reducer.js
@@ -35,17 +35,16 @@ const DEFAULT_STATE = {
 
 /**
  * @typedef  {Object} Feature
- * @property {string} slug   Feature slug.
- * @property {string} status Feature status.
- * @property {Object} error  Feature error.
+ * @property {string} slug    Feature slug.
+ * @property {string} status  Feature status.
+ * @property {Object} error   Feature error.
  */
 /**
  * Update status pre-installation.
  *
- * @param {string[]}  selected Feature slugs.
- * @param {Feature[]} options  Options.
- *
- * @return {Feature[]} Updated options.
+ * @param   {string[]}  selected Feature slugs.
+ * @param   {Feature[]} options  Options.
+ * @returns {Feature[]}          Updated options.
  */
 const updatePreInstallation = ( selected, options ) =>
 	options.map( ( feature ) => {
@@ -64,10 +63,9 @@ const updatePreInstallation = ( selected, options ) =>
 /**
  * Setup wizard reducer.
  *
- * @param {Object} state    Current state.
- * @param {{type:  string}} action Action to update the state.
- *
- * @return {Object} State updated.
+ * @param   {Object}           state  Current state.
+ * @param   {{ type: string }} action Action to update the state.
+ * @returns {Object}                  State updated.
  */
 export default ( state = DEFAULT_STATE, action ) => {
 	switch ( action.type ) {

--- a/assets/setup-wizard/data/selectors.js
+++ b/assets/setup-wizard/data/selectors.js
@@ -3,36 +3,32 @@ import { steps } from '../steps';
 /**
  * Is fetching setup wizard data selector.
  *
- * @param {Object} state Current state.
- *
- * @return {boolean} Is fetching.
+ * @param   {Object}  state Current state.
+ * @returns {boolean}       Is fetching.
  */
 export const isFetching = ( state ) => state.isFetching;
 
 /**
  * Fetch setup wizard error selector.
  *
- * @param {Object} state Current state.
- *
- * @return {Object|boolean} Error object or false.
+ * @param   {Object}           state Current state.
+ * @returns {Object | boolean}       Error object or false.
  */
 export const getFetchError = ( state ) => state.fetchError;
 
 /**
  * Is submitting setup wizard data selector.
  *
- * @param {Object} state Current state.
- *
- * @return {boolean} Is submitting.
+ * @param   {Object}  state Current state.
+ * @returns {boolean}       Is submitting.
  */
 export const isSubmitting = ( state ) => state.isSubmitting;
 
 /**
  * Submit error selector.
  *
- * @param {Object} state Current state.
- *
- * @return {Object|boolean} Error object or false.
+ * @param   {Object}           state Current state.
+ * @returns {Object | boolean}       Error object or false.
  */
 export const getSubmitError = ( state ) => state.submitError;
 
@@ -40,11 +36,10 @@ export const getSubmitError = ( state ) => state.submitError;
 /**
  * Step state selector.
  *
- * @param {Object}  state         Current state.
- * @param {string}  step          Step name.
- * @param {boolean} shouldResolve Flag whether should invoke the resolver.
- *
- * @return {Object} Step data.
+ * @param   {Object}  state         Current state.
+ * @param   {string}  step          Step name.
+ * @param   {boolean} shouldResolve Flag whether should invoke the resolver.
+ * @returns {Object}                Step data.
  */
 /* eslint-enable */
 export const getStepData = ( state, step ) => state.data[ step ];
@@ -52,11 +47,10 @@ export const getStepData = ( state, step ) => state.data[ step ];
 /**
  * Get navigation steps with their state.
  *
- * @param {Object} input                     getNavigationSteps input.
- * @param {Object} input.data                The current state.
- * @param {Array}  input.data.completedSteps The completed steps.
- *
- * @return {Array} Navigation steps.
+ * @param   {Object} input                     GetNavigationSteps input.
+ * @param   {Object} input.data                The current state.
+ * @param   {Array}  input.data.completedSteps The completed steps.
+ * @returns {Array}                            Navigation steps.
  */
 export const getNavigationSteps = ( { data: { completedSteps } } ) => {
 	const navSteps = steps.map( ( step ) => ( {
@@ -75,12 +69,11 @@ export const getNavigationSteps = ( { data: { completedSteps } } ) => {
 /**
  * Get whether step is complete or not.
  *
- * @param {Object} input                     getNavigationSteps input.
- * @param {Object} input.data                The current state.
- * @param {Array}  input.data.completedSteps The completed steps.
- * @param {Array}  step                      The step to check if it is completed.
- *
- * @return {boolean} Step complete.
+ * @param   {Object}  input                     GetNavigationSteps input.
+ * @param   {Object}  input.data                The current state.
+ * @param   {Array}   input.data.completedSteps The completed steps.
+ * @param   {Array}   step                      The step to check if it is completed.
+ * @returns {boolean}                           Step complete.
  */
 export const isCompleteStep = ( { data: { completedSteps } }, step ) =>
 	completedSteps.includes( step );

--- a/assets/setup-wizard/data/use-setup-wizard-step.js
+++ b/assets/setup-wizard/data/use-setup-wizard-step.js
@@ -3,22 +3,21 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { Notice } from '@wordpress/components';
 
 /**
- * @typedef {Object} StepStoreHookHandle
- *
- * @property {boolean}  isSubmitting Submitting state.
- * @property {Object}   stepData     Data for the step.
- * @property {Object}   error        Submit error.
- * @property {Element}  errorNotice  Error notice element.
- * @property {Function} submitStep   Method to POST to endpoint.
+ * @typedef  {Object}   StepStoreHookHandle
+ * @property {boolean}  isSubmitting        Submitting state.
+ * @property {Object}   stepData            Data for the step.
+ * @property {Object}   error               Submit error.
+ * @property {Element}  errorNotice         Error notice element.
+ * @property {Function} submitStep          Method to POST to endpoint.
  */
 /**
  * Use Setup Wizard State store and REST API for the given step.
  *
- * Gets step-specific data, and provides a submit function that sends step form data to the step endpoint
- * via POST request.
+ * Gets step-specific data, and provides a submit function that sends step form
+ * data to the step endpoint via POST request.
  *
- * @param {string} step Setup Wizard step endpoint name.
- * @return {StepStoreHookHandle} handle
+ * @param   {string}              step Setup Wizard step endpoint name.
+ * @returns {StepStoreHookHandle}      Handle
  */
 export const useSetupWizardStep = ( step ) => {
 	const { stepData, isSubmitting, error, isComplete } = useSelect(

--- a/assets/setup-wizard/features/check-icon.js
+++ b/assets/setup-wizard/features/check-icon.js
@@ -1,6 +1,4 @@
-/**
- * Check icon component.
- */
+/** Check icon component. */
 const CheckIcon = () => (
 	<svg
 		xmlns="http://www.w3.org/2000/svg"

--- a/assets/setup-wizard/features/feature-description-utils.js
+++ b/assets/setup-wizard/features/feature-description-utils.js
@@ -8,10 +8,9 @@ import { getWccomProductId } from '../helpers/woocommerce-com';
 /**
  * Get a custom observation for a feature.
  *
- * @param {string}    slug             Feature slug.
- * @param {Feature[]} selectedFeatures Features list.
- *
- * @return {string|null} Feature observation.
+ * @param   {string}        slug             Feature slug.
+ * @param   {Feature[]}     selectedFeatures Features list.
+ * @returns {string | null}                  Feature observation.
  */
 export const getFeatureObservation = ( slug, selectedFeatures ) => {
 	if ( 'woocommerce' !== slug || ! selectedFeatures ) {

--- a/assets/setup-wizard/features/feature-status.js
+++ b/assets/setup-wizard/features/feature-status.js
@@ -3,9 +3,7 @@ import { __ } from '@wordpress/i18n';
 
 import CheckIcon from './check-icon';
 
-/**
- * Status constants.
- */
+/** Status constants. */
 export const INSTALLING_STATUS = 'installing';
 export const ERROR_STATUS = 'error';
 export const INSTALLED_STATUS = 'installed';
@@ -47,8 +45,8 @@ const statusComponents = {
 /**
  * Feature status component.
  *
- * @param {Object}                        props
- * @param {('loading'|'error'|'success')} props.status Feature status.
+ * @param {Object}                          props
+ * @param {'loading' | 'error' | 'success'} props.status Feature status.
  */
 const FeatureStatus = ( { status } ) => (
 	<div className="sensei-setup-wizard__icon-status">

--- a/assets/setup-wizard/features/index.js
+++ b/assets/setup-wizard/features/index.js
@@ -17,7 +17,7 @@ import FeaturesSelection from './features-selection';
 
 /**
  * @typedef  {Object} Feature
- * @property {string} slug Feature slug.
+ * @property {string} slug    Feature slug.
  */
 /**
  * Filter installed features to don't select them.
@@ -38,9 +38,7 @@ const filterInstalledFeatures = ( submittedSlugs, features ) =>
 
 const wcSlug = 'woocommerce';
 
-/**
- * Features step for setup wizard.
- */
+/** Features step for setup wizard. */
 const Features = () => {
 	const [ confirmationActive, toggleConfirmation ] = useState( false );
 	const [ feedbackActive, toggleFeedback ] = useState( false );

--- a/assets/setup-wizard/helpers/woocommerce-com.js
+++ b/assets/setup-wizard/helpers/woocommerce-com.js
@@ -1,15 +1,12 @@
-/**
- * External dependencies
- */
+/** External dependencies */
 import { addQueryArgs } from '@wordpress/url';
 
 /**
  * Get WooCommerce.com checkout URL for the given plugins
  *
- * @param {Array}  features  List of features to be installed.
- * @param {Object} wccomData Woocommerce.com connect parameters
- *
- * @return {string} The checkout URL
+ * @param   {Array}  features  List of features to be installed.
+ * @param   {Object} wccomData Woocommerce.com connect parameters
+ * @returns {string}           The checkout URL
  */
 export const getWoocommerceComPurchaseUrl = ( features, wccomData ) => {
 	return addQueryArgs( 'https://woocommerce.com/cart', {
@@ -21,8 +18,7 @@ export const getWoocommerceComPurchaseUrl = ( features, wccomData ) => {
 /**
  * Get the WooCommerce.com product ID for the feature.
  *
- * @param {Object} feature The feature.
- *
- * @return {string} The product ID.
+ * @param   {Object} feature The feature.
+ * @returns {string}         The product ID.
  */
 export const getWccomProductId = ( feature ) => feature.wccom_product_id;

--- a/assets/setup-wizard/index.js
+++ b/assets/setup-wizard/index.js
@@ -11,19 +11,13 @@ import { useWpAdminFullscreen } from '../react-hooks';
 import QueryStringRouter, { Route } from './query-string-router';
 import Navigation from './navigation';
 
-/**
- * Register setup wizard store.
- */
+/** Register setup wizard store. */
 registerSetupWizardStore();
 
-/**
- * Param name used to route the setup wizard.
- */
+/** Param name used to route the setup wizard. */
 const PARAM_NAME = 'step';
 
-/**
- * Sensei setup wizard page.
- */
+/** Sensei setup wizard page. */
 const SenseiSetupWizardPage = () => {
 	useWpAdminFullscreen( [ 'sensei-setup-wizard__page' ] );
 	useSenseiColorTheme();

--- a/assets/setup-wizard/log-event.js
+++ b/assets/setup-wizard/log-event.js
@@ -20,9 +20,9 @@ logEvent.enable = ( enabled ) => {
 /**
  * Send log event when link is opened.
  *
- * @param {string} eventName  Event name.
- * @param {Array}  properties Event properties.
- * @return {Object} Element attributes.
+ * @param   {string} eventName  Event name.
+ * @param   {Array}  properties Event properties.
+ * @returns {Object}            Element attributes.
  */
 export const logLink = ( eventName, properties ) => {
 	const isMiddleButtonEvent = ( e ) => 1 === e.button;

--- a/assets/setup-wizard/navigation/index.js
+++ b/assets/setup-wizard/navigation/index.js
@@ -4,11 +4,10 @@ import { useQueryStringRouter } from '../query-string-router';
 /**
  * Go to route when clicking steps that can be active (completed or next).
  *
- * @param {Array}    steps
- * @param {Object}   deps
- * @param {Function} deps.goTo
- *
- * @return {Array} Steps with click handlers.
+ * @param   {Array}    steps
+ * @param   {Object}   deps
+ * @param   {Function} deps.goTo
+ * @returns {Array}              Steps with click handlers.
  */
 const addClickHandlers = ( steps, { goTo } ) =>
 	steps.map( ( step ) => ( {

--- a/assets/setup-wizard/purpose/index.js
+++ b/assets/setup-wizard/purpose/index.js
@@ -60,9 +60,7 @@ const purposes = [
 	},
 ];
 
-/**
- * Purpose step for Setup Wizard.
- */
+/** Purpose step for Setup Wizard. */
 export const Purpose = () => {
 	const { goTo } = useQueryStringRouter();
 

--- a/assets/setup-wizard/query-string-router/index.js
+++ b/assets/setup-wizard/query-string-router/index.js
@@ -8,20 +8,18 @@ import {
 import { useEventListener } from '../../react-hooks';
 import { updateQueryString, getParam } from './url-functions';
 
-/**
- * Query string router context.
- */
+/** Query string router context. */
 const QueryStringRouterContext = createContext();
 
 /**
- * Query string router component.
- * It creates a provider with the following values in the context:
- * - `currentRoute`: The string of the current route.
- * - `goTo`: Functions that send the user to another route.
+ * Query string router component. It creates a provider with the following
+ * values in the context: - `currentRoute`: The string of the current route. -
+ * `goTo`: Functions that send the user to another route.
  *
  * @param {Object} props
  * @param {string} props.paramName    Param used as reference in the query string.
- * @param {string} props.defaultRoute Default route to open if there is nothing in the URL.
+ * @param {string} props.defaultRoute Default route to open if there is nothing
+ *     in the URL.
  * @param {Object} props.children     Render this children if it matches the route.
  */
 const QueryStringRouter = ( { paramName, defaultRoute, children } ) => {
@@ -31,8 +29,8 @@ const QueryStringRouter = ( { paramName, defaultRoute, children } ) => {
 	// Provider value.
 	const providerValue = useMemo( () => {
 		/**
-		 * Functions that send the user to another route.
-		 * It changes the URL and update the state of the current route.
+		 * Functions that send the user to another route. It changes the URL and
+		 * update the state of the current route.
 		 *
 		 * @param {string}  newRoute New route to send the user.
 		 * @param {boolean} replace  Flag to mark if should replace or push state.
@@ -70,19 +68,18 @@ const QueryStringRouter = ( { paramName, defaultRoute, children } ) => {
 
 export default QueryStringRouter;
 
-/**
- * Export `Route` component as part of the query string router.
- */
+/** Export `Route` component as part of the query string router. */
 export { default as Route } from './route';
 
 /**
  * Hook to access the query string router values from the context.
  *
- * @return {QueryStringRouterContext} Query string router context.
- *
- * @typedef  {Object}           QueryStringRouterContext
- * @property {string}           currentRoute Current route.
- * @property {function(string)} goTo         Function to navigate between routes.
+ * @typedef  {Object}                   QueryStringRouterContext
+ * @property {string}                   currentRoute             Current route.
+ * @property {function(string)}         goTo                     Function to
+ *     navigate between routes.
+ * @returns  {QueryStringRouterContext}                          Query string
+ *     router context.
  */
 export const useQueryStringRouter = () =>
 	useContext( QueryStringRouterContext );

--- a/assets/setup-wizard/query-string-router/route.js
+++ b/assets/setup-wizard/query-string-router/route.js
@@ -3,11 +3,11 @@ import { useQueryStringRouter } from './index';
 /**
  * Route component. It works inner the `QueryStringRouter context.
  *
- * @param {Object} props
- * @param {string} props.route    Route name.
- * @param {Object} props.children Render this children if it matches the route.
- *
- * @return {Object|null} Return the children if the routes match. Otherwise return null.
+ * @param   {Object}        props
+ * @param   {string}        props.route    Route name.
+ * @param   {Object}        props.children Render this children if it matches the route.
+ * @returns {Object | null}                Return the children if the routes
+ *     match. Otherwise return null.
  */
 const Route = ( { route, children } ) => {
 	const { currentRoute } = useQueryStringRouter();

--- a/assets/setup-wizard/query-string-router/url-functions.js
+++ b/assets/setup-wizard/query-string-router/url-functions.js
@@ -1,9 +1,8 @@
 /**
  * Get parameter from URL.
  *
- * @param {string} name Name of the param to get.
- *
- * @return {string|null} The value in the param. If it's empty, return null.
+ * @param   {string}        name Name of the param to get.
+ * @returns {string | null}      The value in the param. If it's empty, return null.
  */
 export const getParam = ( name ) =>
 	new URLSearchParams( window.location.search ).get( name ) || null;
@@ -13,7 +12,8 @@ export const getParam = ( name ) =>
  *
  * @param {string}  paramName  Param name to be added to the URL.
  * @param {string}  paramValue Param value to be added to the URL.
- * @param {boolean} replace    Flag if it should replace the state. Otherwise it'll push a new.
+ * @param {boolean} replace    Flag if it should replace the state. Otherwise
+ *     it'll push a new.
  */
 export const updateQueryString = ( paramName, paramValue, replace = false ) => {
 	const { search } = window.location;

--- a/assets/setup-wizard/ready/index.js
+++ b/assets/setup-wizard/ready/index.js
@@ -9,9 +9,7 @@ import { logLink } from '../log-event';
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 import useSampleCourseInstaller from './use-sample-course-installer';
 
-/**
- * Ready step for Setup Wizard.
- */
+/** Ready step for Setup Wizard. */
 export const Ready = () => {
 	const { submitStep, isComplete } = useSetupWizardStep( 'ready' );
 

--- a/assets/setup-wizard/ready/mailinglist-signup-form.js
+++ b/assets/setup-wizard/ready/mailinglist-signup-form.js
@@ -7,8 +7,8 @@ import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 /**
  * Sign up to Sensei Mailing list.
  *
- * Submits form to mailing list provider signup page in new tab.
- * Fills in site administrator e-mail address.
+ * Submits form to mailing list provider signup page in new tab. Fills in site
+ * administrator e-mail address.
  */
 export const MailingListSignupForm = () => {
 	const { stepData } = useSetupWizardStep( 'ready' );

--- a/assets/setup-wizard/welcome/index.js
+++ b/assets/setup-wizard/welcome/index.js
@@ -6,9 +6,7 @@ import { UsageModal } from './usage-modal';
 import { useQueryStringRouter } from '../query-string-router';
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 
-/**
- * Welcome step for Setup Wizard.
- */
+/** Welcome step for Setup Wizard. */
 export const Welcome = () => {
 	const [ usageModalActive, toggleUsageModal ] = useState( false );
 

--- a/assets/setup-wizard/welcome/usage-modal.js
+++ b/assets/setup-wizard/welcome/usage-modal.js
@@ -7,13 +7,14 @@ import { useState, useEffect } from '@wordpress/element';
 /**
  * Modal for usage tracking opt-in.
  *
+ * @class
+ *
  * @param {Object}   props
  * @param {boolean}  props.tracking     Initial tracking state.
  * @param {Function} props.onContinue   Callback for user pressing the continue button.
  * @param {Function} props.onClose      Callback for closing the modal.
  * @param {boolean}  props.isSubmitting Indicate loading state.
  * @param {string}   props.children     Children elements of the modal.
- * @class
  */
 export const UsageModal = ( {
 	tracking,

--- a/assets/shared/blocks/settings.js
+++ b/assets/shared/blocks/settings.js
@@ -37,10 +37,11 @@ export const withColorSettings = ( colorSettings ) => {
 /**
  * Color setting inspector controls.
  *
+ * @class
+ *
  * @param {Object} params
  * @param {Object} params.colorSettings Color definitions.
  * @param {Object} params.props         Component props
- * @class
  */
 export const ColorSettings = ( { colorSettings, props } ) => {
 	const colors = Object.keys( colorSettings );
@@ -78,8 +79,8 @@ export const ColorSettings = ( { colorSettings, props } ) => {
 };
 
 /**
- * Apply default style class if no style is selected.
- * Adds is-style-default to the className property.
+ * Apply default style class if no style is selected. Adds is-style-default to
+ * the className property.
  *
  * @param {string} defaultStyleName Default style name.
  */
@@ -107,20 +108,19 @@ export const withDefaultBlockStyle = ( defaultStyleName = 'default' ) => (
  * This HOC sets the default color attribute based in a probe.
  *
  * @example
- * withDefaultColor( {
- *   defaultMainColor: {
- *     style: 'background-color',
- *     probeKey: 'primaryColor',
- *   },
- * } )
+ *   withDefaultColor( {
+ *   	defaultMainColor: {
+ *   		style: 'background-color',
+ *   		probeKey: 'primaryColor',
+ *   	},
+ *   } );
  *
- * @param {Object} colorConfigs Colors config object, where the key is the
- *                              default color attribute name, and the value is
- *                              an object containing style type and probeKey.
- *                              The block attributes must register an attribute
- *                              for every key.
- *
- * @return {Function} Extended component.
+ * @param   {Object}   colorConfigs Colors config object, where the key is the
+ *     default color attribute name, and the value is
+ *     an object containing style type and probeKey.
+ *     The block attributes must register an attribute
+ *     for every key.
+ * @returns {Function}              Extended component.
  */
 export const withDefaultColor = ( colorConfigs ) => ( Component ) => (
 	props

--- a/assets/shared/data/api-fetch-preloaded-once.js
+++ b/assets/shared/data/api-fetch-preloaded-once.js
@@ -1,9 +1,7 @@
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 
-/**
- * Use data preloaded with createPreloadingMiddleware only once.
- */
+/** Use data preloaded with createPreloadingMiddleware only once. */
 export function preloadedDataUsedOnceMiddleware() {
 	const usedPreload = {};
 

--- a/assets/shared/data/store-helpers.js
+++ b/assets/shared/data/store-helpers.js
@@ -1,11 +1,12 @@
 /**
  * Compose an action creator with the given start, success and error actions.
  *
- * @param {string}   startAction   Start action type.
- * @param {Function} fetchFn       The action creator to be wrapped. Should return the resolved data.
- * @param {string}   successAction Success action type.
- * @param {string}   errorAction   Error action type.
- * @return {Function} The wrapped action creator.
+ * @param   {string}   startAction   Start action type.
+ * @param   {Function} fetchFn       The action creator to be wrapped. Should
+ *     return the resolved data.
+ * @param   {string}   successAction Success action type.
+ * @param   {string}   errorAction   Error action type.
+ * @returns {Function}               The wrapped action creator.
  */
 export const composeFetchAction = (
 	startAction,
@@ -30,12 +31,11 @@ export const composeFetchAction = (
  * Create reducer from a map of action type keys and reducer function.
  *
  * @example
- *  createSimpleReducer({ SAMPLE_ACTION: ( { actionProperty }, state ) => ({ ...state, actionProperty }) )
+ *   createSimpleReducer({ SAMPLE_ACTION: ( { actionProperty }, state ) => ({ ...state, actionProperty }) )
  *
- * @param {Object} reducers     Map of action type - reducer functions.
- * @param {Object} defaultState Default state.
- *
- * @return {Function} Store reducer.
+ * @param   {Object}   reducers     Map of action type - reducer functions.
+ * @param   {Object}   defaultState Default state.
+ * @returns {Function}              Store reducer.
  */
 export const createReducerFromActionMap = ( reducers, defaultState ) => {
 	return ( state = defaultState, action ) => {

--- a/assets/shared/data/timeout-controls.js
+++ b/assets/shared/data/timeout-controls.js
@@ -9,23 +9,19 @@ export function* timeout( action, wait ) {
 	yield action();
 }
 
-/**
- * Clear current timeout.
- */
+/** Clear current timeout. */
 export function cancelTimeout() {
 	return { type: 'CLEAR_TIMEOUT' };
 }
 
-/**
- * Manage timeout reference.
- */
+/** Manage timeout reference. */
 const scheduledTimeout = {
 	current: null,
 	/**
 	 * Create a new timeout promise.
 	 *
-	 * @param {number} wait Timeout in ms.
-	 * @return {Promise} Promise resolved after the timeout.
+	 * @param   {number}  wait Timeout in ms.
+	 * @returns {Promise}      Promise resolved after the timeout.
 	 */
 	create( wait ) {
 		return new Promise( ( resolve ) => {
@@ -35,9 +31,7 @@ const scheduledTimeout = {
 			}, wait );
 		} );
 	},
-	/**
-	 * Clear current scheduled timeout.
-	 */
+	/** Clear current scheduled timeout. */
 	clear() {
 		if ( scheduledTimeout.current ) {
 			clearTimeout( scheduledTimeout.current );

--- a/assets/shared/helpers/colors.js
+++ b/assets/shared/helpers/colors.js
@@ -1,9 +1,8 @@
 /**
  * Converts css color hex to rgb.
  *
- * @param {string} h The hex color string.
- *
- * @return {string} The rgb value.
+ * @param   {string} h The hex color string.
+ * @returns {string}   The rgb value.
  */
 export const hexToRGB = ( h ) => {
 	// Returns if it's not an hexadecimal.

--- a/assets/shared/helpers/data.js
+++ b/assets/shared/helpers/data.js
@@ -1,8 +1,8 @@
 /**
  * Return keys of a key-value map where their value is true.
  *
- * @param {Object} map Data.
- * @return {string[]} Selected keys.
+ * @param   {Object}   map Data.
+ * @returns {string[]}     Selected keys.
  */
 export const getSelectedKeys = ( map ) =>
 	Object.keys( map ).filter( ( key ) => map[ key ] );

--- a/assets/shared/helpers/format-string.js
+++ b/assets/shared/helpers/format-string.js
@@ -15,7 +15,8 @@ export const formattingComponents = {
 /**
  * Interpolate components and create a node from the given template string.
  *
- * @example formatString(' Welcome to {{strong}}Sensei{{/strong}}!')
+ * @example
+ *   formatString( ' Welcome to {{strong}}Sensei{{/strong}}!' );
  *
  * @param {string} mixedString Template string.
  * @param {Object} components  Replacements.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16465,9 +16465,9 @@
           }
         },
         "ws": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-          "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
+          "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
           "dev": true
         },
         "y18n": {
@@ -30774,6 +30774,12 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
+    "linguist-languages": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/linguist-languages/-/linguist-languages-7.12.1.tgz",
+      "integrity": "sha512-+2CmUIeNOvJ7MWn6MY5h7mpDcw62MjKjXKC1wH0zLYnDQnn/0/+j3LcWO0v4+M9Vh/yqbt0codmlA7Z82bDnLA==",
+      "dev": true
+    },
     "linkify-it": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
@@ -34643,6 +34649,24 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "prettier-plugin-jsdoc": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-jsdoc/-/prettier-plugin-jsdoc-0.2.6.tgz",
+      "integrity": "sha512-kJBrS83nSUeYwB9ut2eNBUSnfvbwApiqNAzbYPj6xcUAg/fdn98MtCTk4a4olic130pVhpknj+62M8Q0k41+tA==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "^0.7.6",
+        "linguist-languages": "^7.11.1"
+      },
+      "dependencies": {
+        "comment-parser": {
+          "version": "0.7.6",
+          "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-0.7.6.tgz",
+          "integrity": "sha512-GKNxVA7/iuTnAqGADlTWX4tkhzxZKXp5fLJqKTlQLHkE65XDUKutZ3BHaJC5IGcper2tT3QRD1xr4o3jNpgXXg==",
+          "dev": true
+        }
+      }
+    },
     "pretty-format": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
@@ -34998,9 +35022,9 @@
           }
         },
         "ws": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.0.tgz",
-          "integrity": "sha512-kyFwXuV/5ymf+IXhS6f0+eAFvydbaBW3zjpT6hUdAh/hbVjTIB5EHBGi0bPoCLSK2wcuz3BrEkB9LrYv1Nm4NQ==",
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.1.tgz",
+          "integrity": "sha512-pTsP8UAfhy3sk1lSk/O/s4tjD0CRwvMnzvwr4OKGX7ZvqZtUyx4KIJB5JWbkykPoc55tixMGgTNoh3k4FkNGFQ==",
           "dev": true
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -21904,23 +21904,6 @@
         }
       }
     },
-    "eslint-plugin-jsdoc-alignment": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc-alignment/-/eslint-plugin-jsdoc-alignment-0.0.4.tgz",
-      "integrity": "sha512-cNZeGTymRYEYbQjpcinyYLjNFGl1W+r1IxmvyO5VMD/vm1fIRvrFPI6Ave8E6WnkqlH/cEQOeyI6oIK+UbUEIA==",
-      "dev": true,
-      "requires": {
-        "requireindex": "~1.1.0"
-      },
-      "dependencies": {
-        "requireindex": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.1.0.tgz",
-          "integrity": "sha1-5UBLgVV+91225JxacgBIk/4D4WI=",
-          "dev": true
-        }
-      }
-    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "lint-staged": "10.2.11",
     "postcss-color-function": "4.1.0",
     "prettier": "npm:wp-prettier@2.0.5",
+    "prettier-plugin-jsdoc": "0.2.6",
     "pump": "3.0.0",
     "puppeteer-core": "npm:puppeteer-core@3.0.0",
     "react-test-renderer": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "cross-env": "7.0.2",
     "eslint": "7.6.0",
     "eslint-config-prettier": "6.11.0",
-    "eslint-plugin-jsdoc-alignment": "0.0.4",
     "extract-zip": "2.0.1",
     "gettext-parser": "4.0.4",
     "husky": "4.2.5",

--- a/scripts/pot-dist-references.js
+++ b/scripts/pot-dist-references.js
@@ -1,10 +1,10 @@
 /**
- * The purpose of this script is to add the dist references to the
- * pot file based on the chunks map (generated through Webpack).
+ * The purpose of this script is to add the dist references to the pot file
+ * based on the chunks map (generated through Webpack).
  *
- * If a message in the pot file contains `src/file.js` as references
- * and this file was bundled as part of the `dist/dist.js`, the
- * `dist/dist.js` will be added as a new reference to the message.
+ * If a message in the pot file contains `src/file.js` as references and this
+ * file was bundled as part of the `dist/dist.js`, the `dist/dist.js` will be
+ * added as a new reference to the message.
  */
 
 const fs = require( 'fs' );
@@ -13,9 +13,7 @@ const chunksMap = require( '../node_modules/.cache/sensei-lms/chunks-map.json' )
 
 const POT_PATH = './lang/sensei-lms.pot';
 
-/**
- * Run script to add new references.
- */
+/** Run script to add new references. */
 const run = () => {
 	const data = fs.readFileSync( POT_PATH, 'utf8' );
 	fs.writeFileSync( POT_PATH, addDistReferences( data ) );
@@ -24,9 +22,8 @@ const run = () => {
 /**
  * Add dist references to the pot string.
  *
- * @param {string} potString Current pot string to be replaced.
- *
- * @return {string} Pot string after adding new references.
+ * @param   {string} potString Current pot string to be replaced.
+ * @returns {string}           Pot string after adding new references.
  */
 const addDistReferences = ( potString ) => {
 	const chunksMapBySource = getChunksMapBySource( chunksMap );
@@ -58,10 +55,10 @@ const addDistReferences = ( potString ) => {
 /**
  * Add the dist to the reference.
  *
- * @param {string} referenceString   Current reference string to add the dist references.
- * @param {Object} chunksMapBySource Chunks map by source.
- *
- * @return {string} References with the respective dist files.
+ * @param   {string} referenceString   Current reference string to add the dist
+ *     references.
+ * @param   {Object} chunksMapBySource Chunks map by source.
+ * @returns {string}                   References with the respective dist files.
  */
 const getReferenceWithDist = ( referenceString, chunksMapBySource ) => {
 	const references = referenceString.split( '\n' );
@@ -87,10 +84,9 @@ const getReferenceWithDist = ( referenceString, chunksMapBySource ) => {
 /**
  * Add respective line to the references.
  *
- * @param {string[]} references References to add the line.
- * @param {number}   line       Line to be added to the references.
- *
- * @return {string[]} References with the respective lines.
+ * @param   {string[]} references References to add the line.
+ * @param   {number}   line       Line to be added to the references.
+ * @returns {string[]}            References with the respective lines.
  */
 const addLineToReferences = ( references, line ) =>
 	references.map( ( reference ) => reference + ':' + line );
@@ -98,9 +94,8 @@ const addLineToReferences = ( references, line ) =>
 /**
  * Invert the chunks map, getting by source.
  *
- * @param {Object} chunksMapByDist Chunks map by dist.
- *
- * @return {Object} Chunks map by source.
+ * @param   {Object} chunksMapByDist Chunks map by dist.
+ * @returns {Object}                 Chunks map by source.
  */
 const getChunksMapBySource = ( chunksMapByDist ) =>
 	Object.entries( chunksMapByDist ).reduce( ( acc, [ dist, sources ] ) => {

--- a/scripts/webpack/generate-chunks-map-plugin.js
+++ b/scripts/webpack/generate-chunks-map-plugin.js
@@ -1,6 +1,4 @@
-/**
- * External dependencies.
- */
+/** External dependencies. */
 const fs = require( 'fs' );
 const path = require( 'path' );
 

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -2,8 +2,9 @@ const path = require( 'path' );
 const mkdirp = require( 'mkdirp' );
 
 /**
- * Jest puppeteer does not support taking a screenshot on test failure atm. The below snippet is based on a solution
- * proposed here: https://github.com/smooth-code/jest-puppeteer/issues/131
+ * Jest puppeteer does not support taking a screenshot on test failure atm. The
+ * below snippet is based on a solution proposed here:
+ * https://github.com/smooth-code/jest-puppeteer/issues/131
  */
 const screenshotsPath = path.resolve( __dirname, '../screenshots' );
 
@@ -19,18 +20,18 @@ const takeScreenshot = ( testName, pageInstance = page ) => {
 };
 
 /**
- * jasmine reporter does not support async.
- * So we store the screenshot promise and wait for it before each test
+ * Jasmine reporter does not support async. So we store the screenshot promise
+ * and wait for it before each test
  */
 let screenshotPromise = Promise.resolve();
 beforeEach( () => screenshotPromise );
 afterAll( () => screenshotPromise );
 
 /**
- * Take a screenshot on Failed test.
- * Jest standard reporters run in a separate process so they don't have
- * access to the page instance. Using jasmine reporter allows us to
- * have access to the test result, test name and page instance at the same time.
+ * Take a screenshot on Failed test. Jest standard reporters run in a separate
+ * process so they don't have access to the page instance. Using jasmine
+ * reporter allows us to have access to the test result, test name and page
+ * instance at the same time.
  */
 // eslint-disable-next-line jest/no-jasmine-globals
 jasmine.getEnv().addReporter( {

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -7,8 +7,10 @@ import {
 import { AdminFlow } from '../../utils/flows';
 
 /**
- * According to this github issue https://github.com/smooth-code/jest-puppeteer/issues/324, the default timeout isn't
- * respected and actions timeout after 500ms which cause a lot of test failures. The below lines are a workaround.
+ * According to this github issue
+ * https://github.com/smooth-code/jest-puppeteer/issues/324, the default
+ * timeout isn't respected and actions timeout after 500ms which cause a lot of
+ * test failures. The below lines are a workaround.
  */
 const setDefaultOptions = require( 'expect-puppeteer' ).setDefaultOptions;
 setDefaultOptions( { timeout: 30000 } );

--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -22,9 +22,10 @@ export const CommonFlow = {
 		let retries = 0;
 
 		/**
-		 * loginUser uses internally page.waitForNavigation() to wait for the login flow to be completed. This is not
-		 * enough which leads to the session cookie not being set in some of the cases, especially on travis. To
-		 * overcome this problem, we retry 3 times to login correctly.
+		 * LoginUser uses internally page.waitForNavigation() to wait for the login
+		 * flow to be completed. This is not enough which leads to the session cookie
+		 * not being set in some of the cases, especially on travis. To overcome this
+		 * problem, we retry 3 times to login correctly.
 		 */
 		do {
 			retries++;


### PR DESCRIPTION
## This is a PR for documentation purposes of a try

It was a try to add a prettier plugin for JSDoc parser, using this [recommended plugin](https://github.com/WordPress/gutenberg/issues/24984#issuecomment-690572969). In the middle of the changes, I gave up because we were having many issues and I think the cost-benefit doesn't worth it.

In summary, some of the errors were:

**1) It throws some unhandled errors in some situations, like:**
  - > TypeError: Cannot read property 'description' of undefined
  - > RangeError: Invalid count value

The main problem with these unhandled errors is that if there is any error in a file, it skips the whole file and we can miss files without formatting.

**2) It conflicts with a [Gutenberg setting](https://github.com/WordPress/gutenberg/blob/master/packages/eslint-plugin/configs/jsdoc.js#L79).** 

It prefers `@returns` and `@yields` instead of `@return` and `@yield`, and there is no option to change that.

**3) It forces a misalignment in the descriptions with multiline.**

I believe it's a standard that we don't want. It's not explicit in the [WP standard documentation](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/javascript/#aligning-comments), but checking Gutenberg code, it uses the description aligned.

```js
/**
 * How the plugin is forcing the alignment.
 *
 * @param {Object} props Lorem ipsum dolor sit amet consectetur adipiscing elit
 *     sed do eiusmod tempor incididunt ut labore et.
 */
```

```js
/**
 * How is the standard in the Gutenberg code.
 *
 * @param {Object} props Lorem ipsum dolor sit amet consectetur adipiscing elit
 *                       sed do eiusmod tempor incididunt ut labore et.
 */
```

**4) It is removing `@since` tags when it doesn't have a description.**