### PR TITLE
Adds Enrollment Debugger to Sensei Tools

### DIFF
--- a/assets/css/enrolment-debug.scss
+++ b/assets/css/enrolment-debug.scss
@@ -1,0 +1,125 @@
+$positive_bg: rgba( 151, 195, 78, 0.5 );
+$negative_bg: rgba( 195, 150, 137, 0.74 );
+$neutral_bg: rgba( 0, 0, 0, 0.1 );
+
+.sensei-lms-tool-info {
+	.info {
+		display: inline-block;
+		padding: 1em;
+		margin: 0 .25em 0 0;
+		font-size: 14px;
+		background-color: $neutral_bg;
+
+		&.info-positive {
+			background-color: $positive_bg;
+		}
+
+		&.info-negative {
+			background-color: $negative_bg;
+		}
+	}
+
+	.info-buttons {
+		display: inline-block;
+		padding: .25em;
+	}
+}
+
+.sensei-lms-enrolment-debug {
+	.provider {
+		display: block;
+		margin: .5em 0;
+		padding: .5em;
+		border: 1px solid $neutral_bg;
+
+		.name {
+			padding: 1em;
+			background-color: $neutral_bg;
+
+			.tag {
+				display: inline;
+				float: right;
+				border-radius: 5px;
+				background-color: rgba( 255, 255, 255, .5 );
+				padding: .5em;
+				margin: -.5em 0;
+			}
+		}
+
+		&.enrolled {
+			.name {
+				background-color: $positive_bg;
+			}
+		}
+
+		.provider-details {
+			display: flex;
+			flex-direction: row;
+
+			.column {
+				flex: 3;
+				padding: .25em;
+			}
+
+			.column.column-history {
+				flex: 2;
+			}
+		}
+
+		.debug {
+			.message {
+				display: block;
+				padding: .4em;
+			}
+			.message:nth-child(even) {
+				background-color: rgba( 0, 0, 0, .05 );
+			}
+		}
+
+		.history,
+		.logs {
+			.message,
+			.history-item {
+				display: flex;
+				flex-wrap: nowrap;
+				padding: .4em;
+			}
+
+			.message:nth-child(even) {
+				background-color: rgba( 0, 0, 0, .05 );
+			}
+
+			.time {
+				border-radius: 5px;
+				background-color: rgba( 255, 255, 255, .5 );
+				padding: .25em;
+				text-align: center;
+				flex: 2;
+				margin-right: .25em;
+			}
+
+			.content {
+				flex: 3;
+				display: inline;
+			}
+
+			.history-item {
+				background-color: $neutral_bg;
+
+				&.positive {
+					background-color: $positive_bg;
+				}
+
+				&.negative {
+					background-color: $negative_bg;
+				}
+			}
+		}
+
+		.history {
+			.content {
+				flex: 1;
+			}
+		}
+	}
+}

--- a/includes/admin/class-sensei-tools.php
+++ b/includes/admin/class-sensei-tools.php
@@ -58,6 +58,7 @@ class Sensei_Tools {
 	 */
 	public function init() {
 		add_action( 'admin_menu', [ $this, 'add_menu_pages' ], 90 );
+		add_filter( 'sensei_learners_main_column_data', [ Sensei_Tool_Enrolment_Debug::class, 'add_debug_action' ], 10, 3 );
 	}
 
 	/**
@@ -72,6 +73,7 @@ class Sensei_Tools {
 			$tools[] = new Sensei_Tool_Recalculate_Course_Enrolment();
 			$tools[] = new Sensei_Tool_Ensure_Roles();
 			$tools[] = new Sensei_Tool_Remove_Deleted_User_Data();
+			$tools[] = new Sensei_Tool_Enrolment_Debug();
 
 			/**
 			 * Array of the tools available to Sensei LMS.

--- a/includes/admin/tools/class-sensei-tool-enrolment-debug.php
+++ b/includes/admin/tools/class-sensei-tool-enrolment-debug.php
@@ -369,10 +369,13 @@ class Sensei_Tool_Enrolment_Debug implements Sensei_Tool_Interface {
 		 * Show the enrolment debug button on learner management.
 		 *
 		 * @since 3.7.0
+		 * @hook sensei_show_enrolment_debug_button
 		 *
-		 * @param bool $show_button Whether to show the button.
-		 * @param int  $user_id     User ID.
-		 * @param int  $course_id   Course ID.
+		 * @param {bool} $show_button Whether to show the button.
+		 * @param {int}  $user_id     User ID.
+		 * @param {int}  $course_id   Course ID.
+		 *
+		 * @return {bool}
 		 */
 		$show_button = apply_filters( 'sensei_show_enrolment_debug_button', false, $item->user_id, $course_id );
 		if (

--- a/includes/admin/tools/class-sensei-tool-enrolment-debug.php
+++ b/includes/admin/tools/class-sensei-tool-enrolment-debug.php
@@ -1,0 +1,392 @@
+<?php
+/**
+ * File containing Sensei_Tool_Enrolment_Debug class.
+ *
+ * @package sensei-lms
+ * @since 3.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Sensei_Tool_Enrolment_Debug class.
+ *
+ * @since 3.7.0
+ */
+class Sensei_Tool_Enrolment_Debug implements Sensei_Tool_Interface {
+	const NONCE_ACTION = 'enrolment-debug';
+
+	/**
+	 * Get the ID of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return 'enrolment-debug';
+	}
+
+	/**
+	 * Get the name of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Debug Course Enrollment', 'sensei-lms' );
+	}
+
+	/**
+	 * Get the description of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return __( 'Check what the enrollment status is between a course and learner.', 'sensei-lms' );
+	}
+
+	/**
+	 * Is the tool a single action?
+	 *
+	 * @return bool
+	 */
+	public function is_single_action() {
+		return false;
+	}
+
+	/**
+	 * Run the tool.
+	 */
+	public function run() {
+		Sensei()->assets->enqueue( 'sensei-enrolment-debug', 'css/enrolment-debug.css' );
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce checked in `process_input`.
+		if ( ! empty( $_GET['course_id'] ) || ! empty( $_GET['user_id'] ) ) {
+			$results = $this->process_input();
+
+			// If there was an error, go back to the tool page.
+			if ( ! $results ) {
+				wp_safe_redirect( Sensei_Tools::instance()->get_tool_url( $this ) );
+				wp_die();
+			}
+
+			include __DIR__ . '/views/html-enrolment-debug.php';
+		}
+
+		$user_query_args = [
+			'number'  => 100,
+			'orderby' => 'display_name',
+			'order'   => 'ASC',
+		];
+		$user_search     = new WP_User_Query( $user_query_args );
+
+		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Variable used in view.
+		$users = false;
+		if ( $user_search->get_total() < 100 ) {
+			$users = $user_search->get_results();
+		}
+
+		$course_query_args = [
+			'posts_per_page' => 100,
+			'orderby'        => 'title',
+			'order'          => 'ASC',
+			'post_type'      => 'course',
+			'post_status'    => 'any',
+		];
+		$course_search     = new WP_Query( $course_query_args );
+
+		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Variable used in view.
+		$courses = false;
+		if ( $course_search->found_posts < 100 ) {
+			$courses = $course_search->get_posts();
+		}
+
+		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- Variable used in view.
+		$tool_id = $this->get_id();
+
+		include __DIR__ . '/views/html-enrolment-debug-form.php';
+	}
+
+	/**
+	 * Process form input.
+	 *
+	 * @return false|array
+	 */
+	private function process_input() {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Don't modify the nonce.
+		if ( empty( $_GET['_wpnonce'] ) || ! wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), self::NONCE_ACTION ) ) {
+			Sensei_Tools::instance()->trigger_invalid_request( $this );
+
+			return false;
+		}
+
+		if ( empty( $_GET['user_id'] ) ) {
+			Sensei_Tools::instance()->add_user_message( __( 'Please select a user.', 'sensei-lms' ), true );
+
+			return false;
+		}
+
+		if ( empty( $_GET['course_id'] ) ) {
+			Sensei_Tools::instance()->add_user_message( __( 'Please select a course ID.', 'sensei-lms' ), true );
+
+			return false;
+		}
+
+		$user_id   = intval( $_GET['user_id'] );
+		$course_id = intval( $_GET['course_id'] );
+
+		$user = get_user_by( 'ID', $user_id );
+		if ( ! $user ) {
+			Sensei_Tools::instance()->add_user_message( __( 'Invalid user ID selected.', 'sensei-lms' ), true );
+
+			return false;
+		}
+
+		$course = get_post( $course_id );
+		if ( ! $course || 'course' !== get_post_type( $course ) ) {
+			Sensei_Tools::instance()->add_user_message( __( 'Invalid course ID selected.', 'sensei-lms' ), true );
+
+			return false;
+		}
+
+		return $this->get_debug_results( $user, $course );
+	}
+
+	/**
+	 * Get the debug results for a user/course.
+	 *
+	 * @param WP_User $user   User object.
+	 * @param WP_Post $course Course post object.
+	 *
+	 * @return array
+	 */
+	private function get_debug_results( WP_User $user, WP_Post $course ) {
+		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
+		$course_enrolment  = Sensei_Course_Enrolment::get_course_instance( $course->ID );
+		$provider_results  = $course_enrolment->get_enrolment_check_results( $user->ID );
+		$is_enrolled       = $course_enrolment->is_enrolled( $user->ID );
+
+		$results_stale = false;
+		if ( ! $provider_results || $provider_results->get_version_hash() !== $course_enrolment->get_current_enrolment_result_version() ) {
+			$results_stale    = true;
+			$provider_results = $course_enrolment->get_enrolment_check_results( $user->ID );
+		}
+
+		$provider_results_arr = $provider_results->get_provider_results();
+		$debug_results        = [
+			'course'        => $course->post_title,
+			'course_id'     => $course->ID,
+			'user'          => $user->display_name . ' (' . $user->ID . ')',
+			'user_id'       => $user->ID,
+			'is_enrolled'   => $is_enrolled,
+			'is_removed'    => $course_enrolment->is_learner_removed( $user->ID ),
+			'results_stale' => $results_stale,
+			'results_match' => true,
+			'results_time'  => self::format_date( $provider_results->get_time() ),
+			'providers'     => [],
+			'progress'      => false,
+		];
+
+		$course_progress_id = Sensei_Utils::has_started_course( $course->ID, $user->ID );
+		if ( $course_progress_id ) {
+			$course_progress = get_comment( $course_progress_id );
+			$user_start_date = get_comment_meta( $course_progress_id, 'start', true );
+			$status          = esc_html__( 'In Progress', 'sensei-lms' );
+
+			if ( 'complete' === $course_progress->comment_approved ) {
+				$status           = esc_html__( 'Completed', 'sensei-lms' );
+				$percent_complete = 100;
+			} else {
+				$percent_complete = $this->get_percent_complete( $user->ID, $course->ID );
+			}
+
+			$last_activity_time = $this->get_last_progress_activity_date( $user->ID, $course->ID, $course_progress_id );
+
+			$debug_results['progress'] = [
+				'start_date'       => self::format_date( strtotime( $user_start_date ) ),
+				'last_activity'    => $last_activity_time ? self::format_date( $last_activity_time ) : false,
+				'status'           => $status,
+				'percent_complete' => $percent_complete,
+			];
+		}
+
+		$providers = $enrolment_manager->get_all_enrolment_providers();
+		foreach ( $providers as $provider ) {
+			$provider_info = [
+				'id'             => $provider->get_id(),
+				'name'           => $provider->get_name(),
+				'handles_course' => $provider->handles_enrolment( $course->ID ),
+				'is_enrolled'    => null,
+				'debug'          => false,
+				'logs'           => false,
+				'history'        => false,
+			];
+
+			if ( $provider_info['handles_course'] ) {
+				$provider_info['is_enrolled'] = $provider->is_enrolled( $user->ID, $course->ID );
+				if (
+					! isset( $provider_results_arr[ $provider->get_id() ] )
+					|| $provider_results_arr[ $provider->get_id() ] !== $provider_info['is_enrolled']
+				) {
+					$debug_results['results_match'] = false;
+				}
+			} else {
+				if ( isset( $provider_results_arr[ $provider->get_id() ] ) ) {
+					$debug_results['results_match'] = false;
+				}
+			}
+
+			if (
+				interface_exists( 'Sensei_Course_Enrolment_Provider_Debug_Interface' )
+				&& $provider instanceof Sensei_Course_Enrolment_Provider_Debug_Interface
+			) {
+				$provider_info['debug'] = $provider->debug( $user->ID, $course->ID );
+			}
+
+			if ( class_exists( 'Sensei_Enrolment_Provider_Journal_Store' ) ) {
+				$provider_info['logs']    = Sensei_Enrolment_Provider_Journal_Store::get_provider_logs( $provider, $user->ID, $course->ID );
+				$provider_info['history'] = Sensei_Enrolment_Provider_Journal_Store::get_provider_history( $provider, $user->ID, $course->ID );
+			}
+
+			$debug_results['providers'][ $provider_info['id'] ] = $provider_info;
+		}
+
+		return $debug_results;
+	}
+
+
+	/**
+	 * Get the unix timestamp of the last progress activity.
+	 *
+	 * @param int $user_id            User ID.
+	 * @param int $course_id          Course post ID.
+	 * @param int $course_progress_id Course progress comment ID.
+	 *
+	 * @return int|false
+	 */
+	private function get_last_progress_activity_date( $user_id, $course_id, $course_progress_id ) {
+		$dates = [];
+
+		$course_progress = get_comment( $course_progress_id );
+		if ( ! $course_progress ) {
+			return false;
+		}
+
+		$dates[] = strtotime( $course_progress->comment_date_gmt );
+
+		$course_lessons = Sensei()->course->course_lessons( $course_id );
+
+		foreach ( $course_lessons as $lesson ) {
+			$lesson_status = Sensei_Utils::user_lesson_status( $lesson->ID, $user_id );
+			if ( $lesson_status ) {
+				$dates[] = strtotime( $lesson_status->comment_date_gmt );
+			}
+		}
+
+		return max( $dates );
+	}
+
+
+	/**
+	 * Get the percent complete for a user's progress in a course.
+	 *
+	 * @param int $user_id   User ID.
+	 * @param int $course_id Course post ID.
+	 *
+	 * @return false|float
+	 */
+	private function get_percent_complete( $user_id, $course_id ) {
+		$completed_lesson_ids = [];
+
+		$course_lessons = Sensei()->course->course_lessons( $course_id );
+
+		if ( empty( $course_lessons ) ) {
+			return 0;
+		}
+
+		foreach ( $course_lessons as $lesson ) {
+			$is_lesson_completed = Sensei_Utils::user_completed_lesson( $lesson->ID, $user_id );
+			if ( $is_lesson_completed ) {
+				$completed_lesson_ids[] = $lesson->ID;
+			}
+		}
+
+		return round( ( count( $completed_lesson_ids ) / count( $course_lessons ) ) * 100 );
+	}
+
+	/**
+	 * Get the URL for the enrolment debug tool for a user/course.
+	 *
+	 * @param int $user_id   User ID.
+	 * @param int $course_id Course post ID.
+	 *
+	 * @return string
+	 */
+	public static function get_enrolment_debug_url( $user_id, $course_id ) {
+		return wp_nonce_url(
+			add_query_arg(
+				[
+					'course_id' => $course_id,
+					'user_id'   => $user_id,
+				],
+				Sensei_Tools::instance()->get_tool_url( new self() )
+			),
+			self::NONCE_ACTION
+		);
+	}
+
+	/**
+	 * Format the date time to be human readable.
+	 *
+	 * @param int|float $time Format the time.
+	 *
+	 * @return string
+	 */
+	public static function format_date( $time ) {
+		$time             = round( $time );
+		$date_time_format = get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
+
+		if ( function_exists( 'wp_date' ) ) {
+			$formatted_time = wp_date( $date_time_format, $time );
+		} else {
+			$formatted_time = date_i18n( $date_time_format, $time );
+		}
+
+		return $formatted_time;
+	}
+
+	/**
+	 * Add debug button to row.
+	 *
+	 * @param array $row_data  Row data for learner management.
+	 * @param array $item      Activity information for row.
+	 * @param int   $course_id Course post ID.
+	 *
+	 * @return array
+	 */
+	public static function add_debug_action( $row_data, $item, $course_id = null ) {
+		/**
+		 * Show the enrolment debug button on learner management.
+		 *
+		 * @since 3.7.0
+		 *
+		 * @param bool $show_button Whether to show the button.
+		 * @param int  $user_id     User ID.
+		 * @param int  $course_id   Course ID.
+		 */
+		$show_button = apply_filters( 'sensei_show_enrolment_debug_button', false, $item->user_id, $course_id );
+		if (
+			! $course_id
+			|| ! current_user_can( 'manage_sensei' )
+			|| ! $show_button
+			|| 'course' !== get_post_type( $course_id )
+		) {
+			return $row_data;
+		}
+
+		$button_url           = self::get_enrolment_debug_url( $item->user_id, $course_id );
+		$row_data['actions'] .= ' <a class="button" href="' . esc_url( $button_url ) . '">' . esc_html__( 'Debug Enrollment', 'sensei-lms' ) . '</a>';
+
+		return $row_data;
+	}
+}

--- a/includes/admin/tools/views/html-enrolment-debug-form.php
+++ b/includes/admin/tools/views/html-enrolment-debug-form.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * File containing enrolment debug tool form.
+ *
+ * @package sensei-lms
+ * @since 3.7.0
+ *
+ * @var false|WP_User $users   List of all users or false if too big.
+ * @var false|WP_Post $courses List of all courses or false if too big.
+ * @var string        $tool_id Tool ID for this tool.
+ */
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+?>
+<form method="get" action="">
+	<?php wp_nonce_field( Sensei_Tool_Enrolment_Debug::NONCE_ACTION, '_wpnonce', false ); ?>
+	<input type="hidden" name="page" value="sensei-tools">
+	<input type="hidden" name="tool" value="<?php echo esc_attr( $tool_id ); ?>">
+	<table class="form-table" role="presentation">
+	<tr class="form-field form-required">
+		<th scope="row"><label for="user_id"><?php esc_html_e( 'User', 'sensei-lms' ); ?> <span class="description">(<?php esc_html_e( 'Required', 'sensei-lms' ); ?>)</span></label></th>
+		<td>
+		<?php
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Pre-selects user.
+		$user_value = isset( $_GET['user_id'] ) ? intval( $_GET['user_id'] ) : null;
+		if ( $users ) {
+			?>
+			<select name="user_id" id="user_id" class="input">
+				<option value="""></option>
+				<?php
+				foreach ( $users as $user ) {
+					echo '<option value="' . intval( $user->ID ) . '"';
+					if ( $user_value === $user->ID ) {
+						echo ' selected="selected"';
+					}
+					echo '>';
+					echo esc_html( $user->display_name ) . ' (' . intval( $user->ID ) . ')';
+					echo '</option>';
+				}
+				?>
+			</select>
+			<?php
+		} else {
+			echo '<input type="number" name="user_id" class="input" value="' . esc_attr( $user_value ) . '" size="20" placeholder="' . esc_attr__( 'User ID', 'sensei-lms' ) . '">';
+		}
+		?>
+		</td>
+	</tr>
+		<tr class="form-field form-required">
+			<th scope="row"><label for="course_id"><?php esc_html_e( 'Course', 'sensei-lms' ); ?> <span class="description">(<?php esc_html_e( 'Required', 'sensei-lms' ); ?>)</span></label></th>
+			<td>
+			<?php
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Pre-selects course.
+			$course_value = isset( $_GET['course_id'] ) ? intval( $_GET['course_id'] ) : null;
+			if ( $courses ) {
+				?>
+				<select name="course_id" id="course_id" class="input">
+					<option value="""></option>
+					<?php
+					foreach ( $courses as $course ) {
+						echo '<option value="' . intval( $course->ID ) . '"';
+						if ( $course_value === $course->ID ) {
+							echo ' selected="selected"';
+						}
+						echo '>';
+						echo esc_html( $course->post_title ) . ' (' . intval( $course->ID ) . ')';
+						echo '</option>';
+					}
+					?>
+				</select>
+				<?php
+			} else {
+				echo '<input type="number" name="course_id" class="input" value="' . esc_attr( $course_value ) . '" size="20" placeholder="' . esc_attr__( 'Course ID', 'sensei-lms' ) . '">';
+			}
+			?>
+			</td>
+		</tr>
+	</table>
+	<p class="submit">
+		<input type="submit" class="button button-primary" name="submit" value="<?php esc_attr_e( 'View Enrollment Information', 'sensei-lms' ); ?>" />
+	</p>
+</form>

--- a/includes/admin/tools/views/html-enrolment-debug.php
+++ b/includes/admin/tools/views/html-enrolment-debug.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * File containing enrolment debug tool.
+ *
+ * @package sensei-lms
+ * @since 3.7.0
+ *
+ * @var array $results Processed result.
+ */
+
+// phpcs:disable VariableAnalysis.CodeAnalysis.VariableAnalysis.UndefinedVariable
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+$allowed_debug_html = [
+	'a'      => [
+		'href' => true,
+	],
+	'strong' => true,
+	'em'     => true,
+	'span'   => [
+		'style' => true,
+		'class' => true,
+	],
+];
+?>
+<div class="sensei-lms-enrolment-debug">
+<table class="form-table sensei-lms-tool-info" role="presentation">
+	<tr>
+		<th scope="row"><?php esc_html_e( 'User', 'sensei-lms' ); ?></th>
+		<td>
+			<div class="info">
+			<?php
+			echo esc_html( $results['user'] );
+			?>
+			</div>
+			<div class="info-buttons">
+			<?php
+			$edit_url = admin_url( 'user-edit.php?user_id=' . intval( $results['user_id'] ) );
+			echo '<a href="' . esc_url( $edit_url ) . '" class="button">' . esc_html__( 'Edit User', 'sensei-lms' ) . '</a>';
+
+			if ( class_exists( 'WooCommerce' ) ) {
+				$orders_url = admin_url( sprintf( 'edit.php?post_type=shop_order&_customer_user=%d', $results['user_id'] ) );
+				echo ' <a href="' . esc_url( $orders_url ) . '" class="button">' . esc_html__( 'Orders', 'sensei-lms' ) . '</a>';
+			}
+			?>
+			</div>
+		</td>
+	</tr>
+	<tr>
+		<th scope="row"><?php esc_html_e( 'Course', 'sensei-lms' ); ?></th>
+		<td>
+			<div class="info">
+			<?php echo esc_html( $results['course'] ); ?>
+			</div>
+			<div class="info-buttons">
+				<?php
+				$view_course_url = get_permalink( $results['course_id'] );
+				echo '<a href="' . esc_url( $view_course_url ) . '" class="button">' . esc_html__( 'View Course', 'sensei-lms' ) . '</a>';
+
+				$edit_course_url = admin_url( sprintf( 'post.php?post=%d&action=edit', $results['course_id'] ) );
+				echo ' <a href="' . esc_url( $edit_course_url ) . '" class="button">' . esc_html__( 'Edit Course', 'sensei-lms' ) . '</a>';
+
+				$manage_learners_url = admin_url( sprintf( 'admin.php?page=sensei_learners&course_id=%d&view=learners', $results['course_id'] ) );
+				echo ' <a href="' . esc_url( $manage_learners_url ) . '" class="button">' . esc_html__( 'Manage Learners', 'sensei-lms' ) . '</a>';
+				?>
+			</div>
+		</td>
+	</tr>
+	<tr>
+		<th scope="row"><?php esc_html_e( 'Enrollment status', 'sensei-lms' ); ?></th>
+		<td>
+			<?php
+			if ( $results['is_enrolled'] ) {
+				echo '<div class="info info-positive">';
+				echo esc_html__( 'Enrolled', 'sensei-lms' );
+				echo '</div>';
+			} else {
+				echo '<div class="info info-negative">';
+				echo esc_html__( 'Not Enrolled', 'sensei-lms' );
+				echo '</div>';
+
+				if ( $results['is_removed'] ) {
+					echo '<div class="info info-neutral">';
+					echo esc_html__( 'Learner manually removed', 'sensei-lms' );
+					echo '</div>';
+				}
+			}
+			?>
+		</td>
+	</tr>
+	<tr>
+		<th scope="row"><?php esc_html_e( 'Course progress status', 'sensei-lms' ); ?></th>
+		<td>
+			<?php
+			if ( $results['progress'] ) {
+				echo '<div class="info info-positive">';
+				echo esc_html( $results['progress']['status'] );
+				echo ' (' . intval( $results['progress']['percent_complete'] ) . '%)';
+				echo '</div>';
+
+				echo '<div class="info info-neutral">';
+				// translators: %s placeholder is datetime progress was started.
+				echo esc_html( sprintf( __( 'Started on %s', 'sensei-lms' ), $results['progress']['start_date'] ) );
+				echo '</div>';
+
+				if ( ! empty( $results['progress']['last_activity'] ) ) {
+					echo '<div class="info info-neutral">';
+					// translators: %s placeholder is datetime progress was started.
+					echo esc_html( sprintf( __( 'Last activity on %s', 'sensei-lms' ), $results['progress']['last_activity'] ) );
+					echo '</div>';
+				}
+			} else {
+				echo '<div class="info info-negative">';
+				echo esc_html__( 'No Progress', 'sensei-lms' );
+				echo '</div>';
+			}
+			?>
+		</td>
+	</tr>
+	<tr>
+		<th scope="row"><?php esc_html_e( 'Cached enrollment status', 'sensei-lms' ); ?></th>
+		<td>
+			<?php
+			if ( $results['results_match'] ) {
+				echo '<div class="info info-positive">';
+				echo esc_html__( 'Matches Calculated Enrollment', 'sensei-lms' );
+				echo '</div>';
+			} else {
+				echo '<div class="info info-negative">';
+				echo esc_html__( 'Does Not Match Calculated Enrollment', 'sensei-lms' );
+				echo '</div>';
+			}
+
+			echo '<div class="info info-neutral">';
+			// translators: %s placeholder is datetime results were last calculated.
+			echo esc_html( sprintf( __( 'Last calculated on %s', 'sensei-lms' ), $results['results_time'] ) );
+			echo '</div>';
+			?>
+		</td>
+	</tr>
+	<tr>
+		<th scope="row"><?php esc_html_e( 'Providers', 'sensei-lms' ); ?></th>
+		<td>
+			<?php
+			foreach ( $results['providers'] as $provider ) {
+				?>
+				<div class="provider
+				<?php
+				if ( $provider['handles_course'] ) {
+					echo ' handles';
+				} else {
+					echo ' does-not-handle';
+				}
+
+				if ( $provider['is_enrolled'] ) {
+					echo ' enrolled';
+				} else {
+					echo ' is-not-enrolled';
+				}
+				?>
+				">
+					<div class="name">
+						<?php
+						echo esc_html( $provider['name'] );
+
+						if ( ! $provider['handles_course'] ) {
+							echo '<div class="tag">';
+							echo esc_html__( 'Does Not Handle Course', 'sensei-lms' );
+							echo '</div>';
+						} elseif ( $provider['is_enrolled'] ) {
+							echo '<div class="tag">';
+							echo esc_html__( 'Enrolls Learner', 'sensei-lms' );
+							echo '</div>';
+						} else {
+							echo '<div class="tag">';
+							echo esc_html__( 'Does Not Enroll Learner', 'sensei-lms' );
+							echo '</div>';
+						}
+						?>
+					</div>
+					<?php
+					$columns = [];
+					if ( ! empty( $provider['debug'] ) ) {
+						$column   = [];
+						$column[] = '<h4>' . __( 'Information', 'sensei-lms' ) . '</h4>';
+						$column[] = '<div class="debug">';
+						foreach ( $provider['debug'] as $message ) {
+							$column[] = '<div class="message">';
+							$column[] = wp_kses( $message, $allowed_debug_html );
+							$column[] = '</div>';
+						}
+						$column[] = '</div>';
+
+						$columns['info'] = $column;
+					}
+
+					if ( ! empty( $provider['logs'] ) ) {
+						$column   = [];
+						$column[] = '<div class="logs">';
+						$column[] = '<h4>' . __( 'Logs', 'sensei-lms' ) . '</h4>';
+						foreach ( $provider['logs'] as $message ) {
+							$column[] = '<div class="message">';
+							$column[] = '<span class="time">' . Sensei_Tool_Enrolment_Debug::format_date( $message['timestamp'] ) . '</span>';
+							$column[] = '<span class="content">' . esc_html( $message['message'] ) . '</span>';
+							$column[] = '</div>';
+						}
+						$column[] = '</div>';
+
+						$columns['logs'] = $column;
+					}
+
+					if ( ! empty( $provider['history'] ) ) {
+						$column   = [];
+						$column[] = '<div class="history">';
+						$column[] = '<h4>' . __( 'History', 'sensei-lms' ) . '</h4>';
+						foreach ( $provider['history'] as $history ) {
+							$item_class = 'neutral';
+							if ( null === $history['enrolment_status'] ) {
+								$description = __( 'Stopped handling', 'sensei-lms' );
+							} elseif ( $history['enrolment_status'] ) {
+								$description = __( 'Provided', 'sensei-lms' );
+								$item_class  = 'positive';
+							} else {
+								$description = __( 'Withdrawn', 'sensei-lms' );
+								$item_class  = 'negative';
+							}
+
+							$column[] = '<div class="history-item ' . esc_attr( $item_class ) . '">';
+							$column[] = '<span class="time">' . Sensei_Tool_Enrolment_Debug::format_date( $history['timestamp'] ) . '</span>';
+
+							$column[] = '<span class="content">';
+							$column[] = esc_html( $description );
+							$column[] = '</span>';
+							$column[] = '</div>';
+						}
+						$column[] = '</div>';
+
+						$columns['history'] = $column;
+					}
+
+
+					if ( ! empty( $columns ) ) {
+						echo '<div class="provider-details">';
+						foreach ( $columns as $column_id => $column ) {
+							echo '<div class="column column-' . esc_attr( $column_id ) . '">';
+							echo wp_kses_post( implode( $column ) );
+							echo '</div>';
+						}
+						echo '</div>';
+					}
+					?>
+				</div>
+				<?php
+			}
+			?>
+		</td>
+	</tr>
+</table>
+</div>
+<hr />

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -132,6 +132,7 @@ class Sensei_Autoloader {
 			'Sensei_Tool_Recalculate_Enrolment'          => 'admin/tools/class-sensei-tool-recalculate-enrolment.php',
 			'Sensei_Tool_Ensure_Roles'                   => 'admin/tools/class-sensei-tool-ensure-roles.php',
 			'Sensei_Tool_Remove_Deleted_User_Data'       => 'admin/tools/class-sensei-tool-remove-deleted-user-data.php',
+			'Sensei_Tool_Enrolment_Debug'                => 'admin/tools/class-sensei-tool-enrolment-debug.php',
 
 			/**
 			 * Shortcodes

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,6 +37,7 @@ const files = [
 	'blocks/single-course.editor.scss',
 	'admin/exit-survey/index.js',
 	'admin/exit-survey/exit-survey.scss',
+	'css/enrolment-debug.scss',
 	'css/frontend.scss',
 	'css/admin-custom.css',
 	'css/extensions.scss',


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds the enrollment debugger to Sensei Tools. 
* Mostly copied from the feature plugin. I updated it to include manually removed enrolment.

### Testing instructions

* Poke around the tool.

### New/Updated Hooks

* `sensei_show_enrolment_debug_button`:  Default `false`, shows `Debug Enrollment` to the Learner Management page to make it easier.