### PR TITLE
Fix the blocks color styles

### DIFF
--- a/assets/blocks/course-outline/lesson-block/lesson-block.scss
+++ b/assets/blocks/course-outline/lesson-block/lesson-block.scss
@@ -16,7 +16,7 @@
 		font-weight: normal;
 		margin: 0;
 
-		&:not(.has-color) {
+		&:not(.has-text-color) {
 			color: inherit;
 
 			&:hover {

--- a/assets/blocks/course-outline/module-block/block.json
+++ b/assets/blocks/course-outline/module-block/block.json
@@ -49,6 +49,9 @@
     "defaultBorderColor": {
       "type": "string"
     },
+    "defaultBorderColorValue": {
+      "type": "string"
+    },
     "className": {
       "type": "string"
     },

--- a/assets/blocks/course-outline/module-block/module-block.scss
+++ b/assets/blocks/course-outline/module-block/module-block.scss
@@ -92,11 +92,11 @@ $block: '.wp-block-sensei-lms-course-outline-module';
 	}
 
 	#{$block}__header {
-		&:not(.has-background-color) {
+		&:not(.has-background) {
 			background-color: $dark-gray;
 		}
 
-		&:not(.has-color) {
+		&:not(.has-text-color) {
 			color: #FFF;
 		}
 	}

--- a/assets/shared/blocks/settings.js
+++ b/assets/shared/blocks/settings.js
@@ -149,9 +149,16 @@ export const withDefaultColor = ( colorConfigs ) => ( Component ) => (
 				}
 
 				if ( attributes[ colorKey ] !== slug ) {
-					setAttributes( {
-						[ colorKey ]: slug,
-					} );
+					const colorAttributes = {};
+					colorAttributes[ colorKey ] = slug;
+
+					// Border color is not compatible with all themes as className, so the color value is needed.
+					if ( 'border-color' === style ) {
+						colorAttributes[ `${ colorKey }Value` ] =
+							probeColor.color;
+					}
+
+					setAttributes( colorAttributes );
 				}
 			}
 		);

--- a/includes/blocks/class-sensei-block-helpers.php
+++ b/includes/blocks/class-sensei-block-helpers.php
@@ -39,6 +39,11 @@ class Sensei_Block_Helpers {
 			$colors
 		);
 
+		$has_style_classes = [
+			'color'            => 'has-text-color',
+			'background-color' => 'has-background',
+		];
+
 		foreach ( $colors as $color => $style ) {
 
 			if ( ! $style ) {
@@ -48,8 +53,8 @@ class Sensei_Block_Helpers {
 			$custom_color  = $block_attributes[ 'custom' . ucfirst( $color ) ] ?? null;
 			$default_color = $block_attributes[ 'default' . ucfirst( $color ) ] ?? null;
 
-			if ( $custom_color || $named_color ) {
-				$attributes['css_classes'][] = sprintf( 'has-%s', $style );
+			if ( isset( $has_style_classes[ $style ] ) && ( $custom_color || $named_color || $default_color ) ) {
+				$attributes['css_classes'][] = $has_style_classes[ $style ];
 			}
 
 			$named_class = 'border-color' === $style ? 'border-color-%s' : 'has-%s-%s';

--- a/includes/blocks/class-sensei-course-outline-module-block.php
+++ b/includes/blocks/class-sensei-course-outline-module-block.php
@@ -173,8 +173,11 @@ class Sensei_Course_Outline_Module_Block {
 		if ( $should_have_border ) {
 			$class_names[] = 'wp-block-sensei-lms-course-outline-module-bordered';
 
-			if ( ! empty( $block_attributes['borderColorValue'] ) ) {
-				$inline_styles[] = sprintf( 'border-color: %s;', $block_attributes['borderColorValue'] );
+			$border_color_value = ! empty( $block_attributes['defaultBorderColorValue'] ) ? $block_attributes['defaultBorderColorValue'] : '';
+			$border_color_value = ! empty( $block_attributes['borderColorValue'] ) ? $block_attributes['borderColorValue'] : $border_color_value;
+
+			if ( ! empty( $border_color_value ) ) {
+				$inline_styles[] = sprintf( 'border-color: %s;', $border_color_value );
 			}
 		}
 

--- a/includes/blocks/class-sensei-course-outline-module-block.php
+++ b/includes/blocks/class-sensei-course-outline-module-block.php
@@ -44,8 +44,9 @@ class Sensei_Course_Outline_Module_Block {
 			$header_css = Sensei_Block_Helpers::build_styles(
 				$block['attributes'],
 				[
-					'mainColor'   => $is_default_style ? 'background-color' : null,
-					'borderColor' => null,
+					'mainColor'       => $is_default_style ? 'background-color' : null,
+					'backgroundColor' => null,
+					'borderColor'     => null,
 				]
 			);
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix the blocks color styles.
  * It fixes an issue with styles in the frontend. Basically, it wasn't adding the `has-background` class when it had a default color defined, and the correct name for the `has` classes are: `has-text-color `, and `has-background`
  * It also fixes the default border to use inline style because the TwentyTwenty One doesn't have the same border class as TwentyTwenty (`border-color-accent`).

### Testing instructions

* Create a course with modules and lessons using WP 5.6, and the theme Twenty Twenty-One.
* Make sure the default colors work properly in the frontend.
* Play with the colors, and make sure everything works properly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="678" alt="Screen Shot 2020-12-11 at 12 23 19" src="https://user-images.githubusercontent.com/876340/101921417-bc53ff80-3bab-11eb-89e9-97a958dfab48.png">
