### PR TITLE
Fix teacher/admin module slug conflicts

### DIFF
--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -340,6 +340,8 @@ class Sensei_Course_Structure {
 		$teacher_user_id = get_post( $this->course_id )->post_author;
 		if ( ! user_can( $teacher_user_id, 'manage_options' ) ) {
 			$args['slug'] = intval( $teacher_user_id ) . '-' . sanitize_title( $item['title'] );
+		} else {
+			$args['slug'] = sanitize_title( $item['title'] );
 		}
 
 		$create_result = wp_insert_term( $item['title'], 'module', $args );

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -776,6 +776,42 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		$this->assertEquals( $module_id, $structure[0]['id'] );
 	}
 
+
+	/**
+	 * Test that admin creates a module with a different slug than the teacher module when using the same module name.
+	 */
+	public function testAdminTeacherSameModuleName() {
+		$this->login_as_teacher();
+
+		$teacher_module_id = $this->factory->term->create(
+			[
+				'taxonomy' => Sensei()->modules->taxonomy,
+				'name'     => 'Introduction',
+				'slug'     => get_current_user_id() . '-introduction',
+			]
+		);
+
+		$this->login_as_admin();
+
+		$course_id     = $this->factory->course->create();
+		$new_structure = [
+			[
+				'type'    => 'module',
+				'title'   => 'Introduction',
+				'lessons' => [],
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$structure = $course_structure->get( 'edit' );
+
+		// Each one create its own module.
+		$this->assertNotEquals( $teacher_module_id, $structure[0]['id'] );
+	}
+
 	/**
 	 * Test to make sure existing modules owned by a different teacher aren't used when saving without a module ID.
 	 */


### PR DESCRIPTION
Fixes #3845

### Changes proposed in this Pull Request

* Fix conflicts in module slug.

### Testing instructions

* Access the wp-admin as teacher.
* Create a course with a module.
* Access as admin.
* Create another course with a module using the same name used in the previously created module.
* Save, and make sure it saves correctly.