### PR TITLE
Add course layout block patterns

### DIFF
--- a/includes/blocks/class-sensei-course-block-patterns.php
+++ b/includes/blocks/class-sensei-course-block-patterns.php
@@ -26,6 +26,7 @@ class Sensei_Course_Block_Patterns {
 	 */
 	public function register_patterns() {
 
+		$this->register_sensei_pattern_category();
 		$this->register_course_media_pattern();
 		$this->register_course_cover_pattern();
 
@@ -38,9 +39,11 @@ class Sensei_Course_Block_Patterns {
 		register_block_pattern(
 			'sensei-lms/course-media',
 			array(
-				'title'       => __( 'Course media', 'sensei-lms' ),
-				'description' => _x( 'Course layout with an image and text header.', 'Block pattern description', 'sensei-lms' ),
-				'content'     => '<!-- wp:media-text -->
+				'title'         => __( 'Course layout with media', 'sensei-lms' ),
+				'description'   => __( 'Course layout with an image and text header.', 'sensei-lms' ),
+				'categories'    => [ 'sensei-lms' ],
+				'viewportWidth' => 800,
+				'content'       => '<!-- wp:media-text -->
 <div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->
 <p>Course introduction.</p>
 <!-- /wp:paragraph -->
@@ -75,9 +78,11 @@ class Sensei_Course_Block_Patterns {
 		register_block_pattern(
 			'sensei-lms/course-cover',
 			array(
-				'title'       => __( 'Course with Cover', 'sensei-lms' ),
-				'description' => _x( 'Course layout with a cover for introduction.', 'Block pattern description', 'sensei-lms' ),
-				'content'     => '<!-- wp:cover {"url":"' . $cover_image_url . '","contentPosition":"center center","align":"full"} -->
+				'title'         => __( 'Course layout with cover', 'sensei-lms' ),
+				'description'   => __( 'Course layout with a cover for introduction.', 'sensei-lms' ),
+				'categories'    => [ 'sensei-lms' ],
+				'viewportWidth' => 800,
+				'content'       => '<!-- wp:cover {"url":"' . $cover_image_url . '","contentPosition":"center center","align":"full"} -->
 <div class="wp-block-cover alignfull has-background-dim is-position-center-center" style="background-image:url(' . $cover_image_url . ')"><div class="wp-block-cover__inner-container"><!-- wp:paragraph -->
 <p>Course Introduction</p>
 <!-- /wp:paragraph -->
@@ -100,6 +105,13 @@ class Sensei_Course_Block_Patterns {
 <!-- /wp:sensei-lms/button-contact-teacher -->',
 			)
 		);
+	}
+
+	/**
+	 * Register Sensei LMS block pattern category.
+	 */
+	public function register_sensei_pattern_category() {
+		register_block_pattern_category( 'sensei-lms', [ 'label' => __( 'Sensei LMS', 'sensei-lms' ) ] );
 	}
 
 }

--- a/includes/blocks/class-sensei-course-block-patterns.php
+++ b/includes/blocks/class-sensei-course-block-patterns.php
@@ -42,6 +42,9 @@ class Sensei_Course_Block_Patterns {
 	 * Register block pattern for course layout with media.
 	 */
 	public function register_course_media_pattern() {
+
+		$sample_img = 'https://images.unsplash.com/photo-1443948308135-d57fc66de368?&auto=format&fit=crop&w=1275&q=80';
+
 		register_block_pattern(
 			'sensei-lms/course-media',
 			array(
@@ -49,8 +52,8 @@ class Sensei_Course_Block_Patterns {
 				'description'   => __( 'Course layout with an image and text header.', 'sensei-lms' ),
 				'categories'    => [ 'sensei-lms' ],
 				'viewportWidth' => 800,
-				'content'       => '<!-- wp:media-text -->
-<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->
+				'content'       => '<!-- wp:media-text { "mediaLink": "' . $sample_img . '", "mediaType":"image"} -->
+<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"><img src="' . $sample_img . '"  alt="" /></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->
 <p>Course introduction.</p>
 <!-- /wp:paragraph -->
 
@@ -79,7 +82,7 @@ class Sensei_Course_Block_Patterns {
 	 */
 	public function register_course_cover_pattern() {
 
-		$cover_image_url = 'https://images.unsplash.com/photo-1585320806297-9794b3e4eeae?&auto=format&fit=crop&w=2978&q=80';
+		$sample_img = 'https://images.unsplash.com/photo-1585320806297-9794b3e4eeae?&auto=format&fit=crop&w=2978&q=80';
 
 		register_block_pattern(
 			'sensei-lms/course-cover',
@@ -88,8 +91,8 @@ class Sensei_Course_Block_Patterns {
 				'description'   => __( 'Course layout with a cover for introduction.', 'sensei-lms' ),
 				'categories'    => [ 'sensei-lms' ],
 				'viewportWidth' => 800,
-				'content'       => '<!-- wp:cover {"url":"' . $cover_image_url . '","contentPosition":"center center","align":"full"} -->
-<div class="wp-block-cover alignfull has-background-dim is-position-center-center" style="background-image:url(' . $cover_image_url . ')"><div class="wp-block-cover__inner-container"><!-- wp:paragraph -->
+				'content'       => '<!-- wp:cover {"url":"' . $sample_img . '","contentPosition":"center center","align":"full"} -->
+<div class="wp-block-cover alignfull has-background-dim is-position-center-center" style="background-image:url(' . $sample_img . ')"><div class="wp-block-cover__inner-container"><!-- wp:paragraph -->
 <p>Course Introduction</p>
 <!-- /wp:paragraph -->
 

--- a/includes/blocks/class-sensei-course-block-patterns.php
+++ b/includes/blocks/class-sensei-course-block-patterns.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * File containing the Sensei_Course_Block_Patterns class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Course_Block_Patterns
+ */
+class Sensei_Course_Block_Patterns {
+
+	/**
+	 * Sensei_Course_Block_Patterns constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', [ $this, 'register_patterns' ] );
+	}
+
+	/**
+	 * Register course block patterns.
+	 */
+	public function register_patterns() {
+
+		$this->register_course_media_pattern();
+		$this->register_course_cover_pattern();
+
+	}
+
+	/**
+	 * Register block pattern for course layout with media.
+	 */
+	public function register_course_media_pattern() {
+		register_block_pattern(
+			'sensei-lms/course-media',
+			array(
+				'title'       => __( 'Course media', 'sensei-lms' ),
+				'description' => _x( 'Course layout with an image and text header.', 'Block pattern description', 'sensei-lms' ),
+				'content'     => '<!-- wp:media-text -->
+<div class="wp-block-media-text alignwide is-stacked-on-mobile"><figure class="wp-block-media-text__media"></figure><div class="wp-block-media-text__content"><!-- wp:paragraph -->
+<p>Course introduction.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:sensei-lms/button-take-course {"align":"full"} -->
+<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><button class="wp-block-button__link">Take Course</button></div>
+<!-- /wp:sensei-lms/button-take-course --></div></div>
+<!-- /wp:media-text -->
+
+<!-- wp:sensei-lms/course-progress /-->
+
+<!-- wp:heading -->
+<h2>Course Outline</h2>
+<!-- /wp:heading -->
+
+<!-- wp:sensei-lms/course-outline {"moduleBorder":false,"className":"is-style-minimal"} /-->
+
+<!-- wp:sensei-lms/button-contact-teacher {"align":"right","className":"is-style-link"} -->
+<div class="wp-block-sensei-lms-button-contact-teacher is-style-link wp-block-sensei-button wp-block-button has-text-align-right"><a class="">Contact Teacher</a></div>
+<!-- /wp:sensei-lms/button-contact-teacher -->',
+			)
+		);
+	}
+
+	/**
+	 * Register block pattern for course layout with cover.
+	 */
+	public function register_course_cover_pattern() {
+
+		$cover_image_url = 'https://images.unsplash.com/photo-1585320806297-9794b3e4eeae?&auto=format&fit=crop&w=2978&q=80';
+
+		register_block_pattern(
+			'sensei-lms/course-cover',
+			array(
+				'title'       => __( 'Course with Cover', 'sensei-lms' ),
+				'description' => _x( 'Course layout with a cover for introduction.', 'Block pattern description', 'sensei-lms' ),
+				'content'     => '<!-- wp:cover {"url":"' . $cover_image_url . '","contentPosition":"center center","align":"full"} -->
+<div class="wp-block-cover alignfull has-background-dim is-position-center-center" style="background-image:url(' . $cover_image_url . ')"><div class="wp-block-cover__inner-container"><!-- wp:paragraph -->
+<p>Course Introduction</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:sensei-lms/button-take-course {"className":"is-style-default"} -->
+<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link">Take Course</button></div>
+<!-- /wp:sensei-lms/button-take-course -->
+
+<!-- wp:sensei-lms/course-progress {} /--></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:heading -->
+<h2>Course Outline</h2>
+<!-- /wp:heading -->
+
+<!-- wp:sensei-lms/course-outline {"moduleBorder":false,"className":"is-style-minimal"} /-->
+
+<!-- wp:sensei-lms/button-contact-teacher {"align":"right","className":"is-style-link"} -->
+<div class="wp-block-sensei-lms-button-contact-teacher is-style-link wp-block-sensei-button wp-block-button has-text-align-right"><a class="">Contact Teacher</a></div>
+<!-- /wp:sensei-lms/button-contact-teacher -->',
+			)
+		);
+	}
+
+}

--- a/includes/blocks/class-sensei-course-block-patterns.php
+++ b/includes/blocks/class-sensei-course-block-patterns.php
@@ -18,13 +18,19 @@ class Sensei_Course_Block_Patterns {
 	 * Sensei_Course_Block_Patterns constructor.
 	 */
 	public function __construct() {
-		add_action( 'init', [ $this, 'register_patterns' ] );
+		add_action( 'current_screen', [ $this, 'register_patterns' ] );
 	}
 
 	/**
 	 * Register course block patterns.
 	 */
 	public function register_patterns() {
+
+		$current_screen = get_current_screen();
+
+		if ( 'course' !== $current_screen->post_type ) {
+			return;
+		}
 
 		$this->register_sensei_pattern_category();
 		$this->register_course_media_pattern();

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -42,7 +42,12 @@ class Sensei_Course_Blocks {
 	public $take_course;
 
 	/**
-	 * Sensei_Blocks constructor .
+	 * @var Sensei_Course_Block_Patterns
+	 */
+	public $block_patterns;
+
+	/**
+	 * Sensei_Blocks constructor.
 	 *
 	 * @param Sensei_Main $sensei
 	 */
@@ -57,6 +62,7 @@ class Sensei_Course_Blocks {
 		$this->progress        = new Sensei_Course_Progress_Block();
 		$this->contact_teacher = new Sensei_Block_Contact_Teacher();
 		$this->take_course     = new Sensei_Block_Take_Course();
+		$this->block_patterns  = new Sensei_Course_Block_Patterns();
 	}
 
 	/**


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Add `Course layout with media` block pattern
* Add `Course layout with cover` block pattern
* Both contain the a course intro section with a Take Course CTA, an outline with header, and the progress & contact teacher button

### Testing instructions

* Create a new course
* Delete existing blocks
* Click the block inserter in the top toolbar, go to Patterns and find these at the bottom

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="336" alt="image" src="https://user-images.githubusercontent.com/176949/102092721-a438e600-3e20-11eb-8399-7ec60b691882.png">


### Open questions

Should sample images be included? Most core/template patterns have them, but it's not really recommended. For the cover block, a color has to be set in the pattern if there is no image, and the previews look a bit worse:

<img width="327" alt="image" src="https://user-images.githubusercontent.com/176949/102093567-98015880-3e21-11eb-808e-a82c72d2c3b0.png">
