### PR TITLE
[Early POC] Investigate alternative learner progress storage

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -240,6 +240,15 @@ class Sensei_Data_Cleaner {
 	);
 
 	/**
+	 * Tables to drop.
+	 *
+	 * @var string[]
+	 */
+	private static $tables = array(
+		'sensei_lms_progress',
+	);
+
+	/**
 	 * Cleanup all data.
 	 *
 	 * @access public
@@ -253,6 +262,7 @@ class Sensei_Data_Cleaner {
 		self::cleanup_transients();
 		self::cleanup_options();
 		self::cleanup_user_meta();
+		self::cleanup_tables();
 	}
 
 	/**
@@ -422,6 +432,20 @@ class Sensei_Data_Cleaner {
 
 		foreach ( self::$post_meta as $post_meta ) {
 			$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => $post_meta ) );
+		}
+	}
+
+	/**
+	 * Drop Sensei LMS tables.
+	 *
+	 * @access private
+	 */
+	private static function cleanup_tables() {
+		global $wpdb;
+
+		foreach ( self::$tables as $table ) {
+			$table = $wpdb->prefix . $table;
+			$wpdb->query( "DROP TABLE IF EXISTS {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		}
 	}
 }

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -534,7 +534,7 @@ class Sensei_Main {
 	private function update_database_tables() {
 		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 
-		dbDelta( self::get_schema() );
+		dbDelta( $this->get_schema() );
 	}
 
 	/**
@@ -545,7 +545,7 @@ class Sensei_Main {
 	 *
 	 * @return string
 	 */
-	private static function get_schema() {
+	private function get_schema() {
 		global $wpdb;
 
 		$collate = '';
@@ -554,50 +554,23 @@ class Sensei_Main {
 			$collate = $wpdb->get_charset_collate();
 		}
 
+		// @todo Optimize indexes for progress table.
 		return "
 CREATE TABLE `{$wpdb->prefix}sensei_lms_progress` (
   `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
   `parent_post_id` bigint(20) unsigned DEFAULT NULL,
   `post_id` bigint(20) unsigned NOT NULL,
   `user_id` bigint(20) unsigned NOT NULL,
-  `type` varchar(20) NOT NULL DEFAULT '',
-  `status` varchar(50) NOT NULL DEFAULT '',
-  `data` longtext,
+  `type` varchar(20) COLLATE utf8mb4_unicode_520_ci NOT NULL DEFAULT '',
+  `status` varchar(50) COLLATE utf8mb4_unicode_520_ci NOT NULL DEFAULT '',
+  `data` longtext COLLATE utf8mb4_unicode_520_ci,
   `date_created` datetime NOT NULL,
   `date_modified` datetime NOT NULL,
   PRIMARY KEY (`id`),
+  UNIQUE KEY `key_fields` (`parent_post_id`,`post_id`,`user_id`,`type`),
   KEY `status` (`status`)
-) $collate;
+) {$collate};
 		";
-	}
-
-	/**
-	 * Return a list of Sensei LMS tables. Used to make sure all Sensei tables are dropped when uninstalling the plugin
-	 * in a single site or multi site environment.
-	 *
-	 * @return array WC tables.
-	 */
-	public static function get_tables() {
-		global $wpdb;
-
-		$tables = array(
-			"{$wpdb->prefix}sensei_lms_progress",
-		);
-
-		return $tables;
-	}
-
-	/**
-	 * Drop Sensei LMS tables.
-	 */
-	public static function drop_tables() {
-		global $wpdb;
-
-		$tables = self::get_tables();
-
-		foreach ( $tables as $table ) {
-			$wpdb->query( "DROP TABLE IF EXISTS {$table}" ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-		}
 	}
 
 	/**

--- a/includes/progress/class-sensei-progress-course.php
+++ b/includes/progress/class-sensei-progress-course.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * File containing the class Sensei_Progress_Course.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class for course progress record.
+ */
+class Sensei_Progress_Course extends Sensei_Progress {
+
+	/**
+	 * Get the record type (course, lesson).
+	 *
+	 * @return string
+	 */
+	public function get_record_type() {
+		return 'course';
+	}
+}

--- a/includes/progress/class-sensei-progress-lesson.php
+++ b/includes/progress/class-sensei-progress-lesson.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * File containing the class Sensei_Progress_Lesson.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class for lesson progress record.
+ */
+class Sensei_Progress_Lesson extends Sensei_Progress {
+
+	/**
+	 * Get the record type (course, lesson).
+	 *
+	 * @return string
+	 */
+	public function get_record_type() {
+		return 'lesson';
+	}
+}

--- a/includes/progress/class-sensei-progress-manager.php
+++ b/includes/progress/class-sensei-progress-manager.php
@@ -13,7 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Singleton handling the management of progress.
  */
 class Sensei_Progress_Manager {
-	const COURSE_DATA_STORE_META = '_progress_data_store';
+	const COURSE_DATA_STORE_META  = '_progress_data_store';
+	const INITIAL_PROGRESS_STATUS = 'not-started';
 
 	/**
 	 * Instance of singleton.
@@ -54,11 +55,69 @@ class Sensei_Progress_Manager {
 	}
 
 	/**
+	 * Query progress results.
+	 *
+	 * @param array $args Arguments used in query.
+	 *
+	 * @return Sensei_Progress_Data_Results
+	 */
+	public function query( $args = [] ) {
+		$data_source = null;
+		if ( isset( $args['post_id'] ) ) {
+			$parent_post_id = isset( $args['parent_post_id'] ) ? $args['parent_post_id'] : null;
+			$data_source    = $this->get_data_store( $args['post_id'], $parent_post_id );
+		}
+
+		if ( ! $data_source ) {
+			return $this->query_all( $args );
+		}
+
+		return $data_source->query( $args );
+	}
+
+	/**
+	 * Query progress results from both data sources.
+	 *
+	 * @param array $args Arguments used in query.
+	 *
+	 * @return Sensei_Progress_Data_Results
+	 */
+	private function query_all( $args = [] ) {
+		$data_stores = $this->get_data_stores();
+
+		if ( ! isset( $args['number'] ) || ! empty( $args['count'] ) ) {
+			return $data_stores['table']->query( $args )->merge( $data_stores['comments']->query( $args ) );
+		}
+
+		$table_results = $data_stores['table']->query( $args );
+
+		$number = (int) $args['number'];
+		$offset = isset( $args['offset'] ) ? (int) $args['offset'] : 0;
+
+		$number -= count( $table_results->get_results() );
+		if ( $number > 0 ) {
+			$offset        -= $table_results->get_total_found();
+			$args['number'] = $number;
+			$args['offset'] = $offset;
+
+			$comments_results = $data_stores['comments']->query( $args );
+		} else {
+			$args['count'] = true;
+			unset( $args['number'], $args['offset'] );
+
+			$comments_results = $data_stores['comments']->query( $args );
+		}
+
+		return $table_results->merge( $comments_results );
+	}
+
+	/**
 	 * Get the record by type.
 	 *
 	 * @param string $type Type of record.
 	 *
 	 * @return string Class name for record.
+	 * @throws Exception When type does not exist.
 	 */
 	public function get_record_class_name( $type ) {
 		$map = [
@@ -66,20 +125,24 @@ class Sensei_Progress_Manager {
 			'lesson' => Sensei_Progress_Lesson::class,
 		];
 
-		return isset( $map[ $type ] ) ? $map[ $type ] : null;
+		if ( ! isset( $map[ $type ] ) ) {
+			throw new Exception( sprintf( 'Unknown progress record type: %s', $type ) );
+		}
+
+		return $map[ $type ];
 	}
 
 	/**
-	 * Get a specific progress item.
+	 * Get a specific progress item. If the item doesn't exist, it will return a fresh result.
 	 *
-	 * @param int      $user_id        User ID.
 	 * @param string   $type           Type of progress item (course, lesson).
+	 * @param int      $user_id        User ID.
 	 * @param int      $post_id        Post ID.
 	 * @param int|null $parent_post_id Post parent ID.
 	 *
-	 * @return Sensei_Progress|null
+	 * @return Sensei_Progress
 	 */
-	public function get_progress( $user_id, $type, $post_id, $parent_post_id = null ) {
+	public function get_progress( $type, $user_id, $post_id, $parent_post_id = null ) {
 		$data_store = $this->get_data_store( $post_id, $parent_post_id );
 
 		if ( ! $data_store ) {
@@ -100,7 +163,36 @@ class Sensei_Progress_Manager {
 			return $progress_results->get_results()[0];
 		}
 
-		return null;
+		$record_class = $this->get_record_class_name( $type );
+
+		return new $record_class(
+			$user_id,
+			$post_id,
+			$parent_post_id,
+			self::INITIAL_PROGRESS_STATUS
+		);
+	}
+
+	/**
+	 * Save progress object.
+	 *
+	 * @param Sensei_Progress $progress Progress object.
+	 *
+	 * @return bool
+	 */
+	public function save( Sensei_Progress $progress ) {
+		$progress->set_date_modified( new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) ) );
+
+		if ( $progress->get_data_store() ) {
+			return $progress->get_data_store()->save( $progress );
+		}
+
+		$data_store = $this->get_data_store( $progress->get_post_id(), $progress->get_parent_post_id() );
+		if ( ! $data_store ) {
+			return false;
+		}
+
+		return $data_store->save( $progress );
 	}
 
 	/**
@@ -112,21 +204,10 @@ class Sensei_Progress_Manager {
 	 * @return Sensei_Progress_Data_Store_Interface|false
 	 */
 	public function get_data_store( $post_id, $parent_post_id = null ) {
-		// @todo make this a blog wide option.
-		$default_data_store = 'comments';
+		// @todo should this a blog wide option?
+		$default_data_store = 'table';
 
-		$course_id = null;
-		if ( $parent_post_id && 'course' === get_post_type( $parent_post_id ) ) {
-			$course_id = $parent_post_id;
-		} elseif ( 'course' === get_post_type( $post_id ) ) {
-			$course_id = $post_id;
-		} elseif ( 'lesson' === get_post_type( $post_id ) ) {
-			$course_id = (int) get_post_meta( $post_id, '_lesson_course', true );
-		}
-
-		if ( empty( $course_id ) ) {
-			return false;
-		}
+		$course_id = $this->get_course_id( $post_id, $parent_post_id );
 
 		$course_data_store = get_post_meta( $course_id, self::COURSE_DATA_STORE_META, true );
 		if ( ! $course_data_store ) {
@@ -139,6 +220,40 @@ class Sensei_Progress_Manager {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Check if a data store is set to a particular data store key.
+	 *
+	 * @param string                               $test_data_store_key Data store key to check for.
+	 * @param Sensei_Progress_Data_Store_Interface $data_store          Data store object to test.
+	 *
+	 * @return bool
+	 */
+	public function is_data_store( $test_data_store_key, Sensei_Progress_Data_Store_Interface $data_store ) {
+		$data_stores = $this->get_data_stores();
+
+		return ! isset( $data_stores[ $test_data_store_key ] ) || $data_stores[ $test_data_store_key ] !== $data_store;
+	}
+
+	/**
+	 * Helper to get a course ID.
+	 *
+	 * @param int      $post_id        Post ID.
+	 * @param int|null $parent_post_id Parent post ID.
+	 *
+	 * @return int|null
+	 */
+	public function get_course_id( $post_id, $parent_post_id = null ) {
+		if ( $parent_post_id && 'course' === get_post_type( $parent_post_id ) ) {
+			return $parent_post_id;
+		} elseif ( 'course' === get_post_type( $post_id ) ) {
+			return $post_id;
+		} elseif ( 'lesson' === get_post_type( $post_id ) ) {
+			return (int) get_post_meta( $post_id, '_lesson_course', true );
+		}
+
+		return null;
 	}
 
 	/**

--- a/includes/progress/class-sensei-progress-manager.php
+++ b/includes/progress/class-sensei-progress-manager.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * File containing the class Sensei_Progress_Manager.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Singleton handling the management of progress.
+ */
+class Sensei_Progress_Manager {
+	const COURSE_DATA_STORE_META = '_progress_data_store';
+
+	/**
+	 * Instance of singleton.
+	 *
+	 * @var self
+	 */
+	private static $instance;
+
+	/**
+	 * Instantiated data store objects.
+	 *
+	 * @var Sensei_Progress_Data_Store_Interface[]
+	 */
+	private $data_stores;
+
+	/**
+	 * Fetches an instance of the class.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new static();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Sensei_Progress_Manager constructor. Private so it can only be initialized internally.
+	 */
+	private function __construct() {
+		$this->data_stores = [
+			'table'    => new Sensei_Progress_Data_Store_Table(),
+			'comments' => new Sensei_Progress_Data_Store_Comments(),
+		];
+
+		$this->data_stores['hybrid'] = new Sensei_Progress_Data_Store_Hybrid( $this->data_stores );
+	}
+
+	/**
+	 * Get the record by type.
+	 *
+	 * @param string $type Type of record.
+	 *
+	 * @return string Class name for record.
+	 */
+	public function get_record_class_name( $type ) {
+		$map = [
+			'course' => Sensei_Progress_Course::class,
+			'lesson' => Sensei_Progress_Lesson::class,
+		];
+
+		return isset( $map[ $type ] ) ? $map[ $type ] : null;
+	}
+
+	/**
+	 * Get a specific progress item.
+	 *
+	 * @param int      $user_id        User ID.
+	 * @param string   $type           Type of progress item (course, lesson).
+	 * @param int      $post_id        Post ID.
+	 * @param int|null $parent_post_id Post parent ID.
+	 *
+	 * @return Sensei_Progress|null
+	 */
+	public function get_progress( $user_id, $type, $post_id, $parent_post_id = null ) {
+		$data_store = $this->get_data_store( $post_id, $parent_post_id );
+
+		if ( ! $data_store ) {
+			return null;
+		}
+
+		$progress_results = $data_store->query(
+			[
+				'user_id'        => (int) $user_id,
+				'post_id'        => (int) $post_id,
+				'parent_post_id' => (int) $parent_post_id,
+				'type'           => $type,
+				'number'         => 1,
+			]
+		);
+
+		if ( ! empty( $progress_results->get_results() ) ) {
+			return $progress_results->get_results()[0];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the progress data store for a post.
+	 *
+	 * @param int      $post_id        Post ID for the progress record.
+	 * @param int|null $parent_post_id Parent post ID for the progress record.
+	 *
+	 * @return Sensei_Progress_Data_Store_Interface|false
+	 */
+	public function get_data_store( $post_id, $parent_post_id = null ) {
+		// @todo make this a blog wide option.
+		$default_data_store = 'comments';
+
+		$course_id = null;
+		if ( $parent_post_id && 'course' === get_post_type( $parent_post_id ) ) {
+			$course_id = $parent_post_id;
+		} elseif ( 'course' === get_post_type( $post_id ) ) {
+			$course_id = $post_id;
+		} elseif ( 'lesson' === get_post_type( $post_id ) ) {
+			$course_id = (int) get_post_meta( $post_id, '_lesson_course', true );
+		}
+
+		if ( empty( $course_id ) ) {
+			return false;
+		}
+
+		$course_data_store = get_post_meta( $course_id, self::COURSE_DATA_STORE_META, true );
+		if ( ! $course_data_store ) {
+			$course_data_store = $default_data_store;
+		}
+
+		$data_stores = $this->get_data_stores();
+		if ( isset( $data_stores[ $course_data_store ] ) ) {
+			return $data_stores[ $course_data_store ];
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get the data stores.
+	 *
+	 * @return Sensei_Progress_Data_Store_Interface[]
+	 */
+	public function get_data_stores() {
+		return $this->data_stores;
+	}
+}

--- a/includes/progress/class-sensei-progress.php
+++ b/includes/progress/class-sensei-progress.php
@@ -1,0 +1,322 @@
+<?php
+/**
+ * File containing the abstract class Sensei_Progress.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Base class for progress objects.
+ */
+abstract class Sensei_Progress {
+
+	/**
+	 * Post ID of the object this progress record is associated with.
+	 *
+	 * @var int
+	 */
+	private $post_id;
+
+	/**
+	 * Post ID of the parent object for this record, usually the course ID if a lesson or quiz.
+	 *
+	 * @var int
+	 */
+	private $parent_post_id;
+
+	/**
+	 * User ID for this progress record.
+	 *
+	 * @var int
+	 */
+	private $user_id;
+
+	/**
+	 * Progress record status.
+	 *
+	 * @var string
+	 */
+	private $status;
+
+	/**
+	 * Date this record was first created.
+	 *
+	 * @var DateTimeImmutable
+	 */
+	private $date_created;
+
+	/**
+	 * Date this record was last modified.
+	 *
+	 * @var DateTimeImmutable
+	 */
+	private $date_modified;
+
+	/**
+	 * Meta data associated with this record.
+	 *
+	 * @var array|callable
+	 */
+	private $data;
+
+	/**
+	 * Data store owning this record.
+	 *
+	 * @var Sensei_Progress_Data_Store_Interface
+	 */
+	private $data_store;
+
+	/**
+	 * Unique identifier for progress record in data store.
+	 *
+	 * @var int
+	 */
+	private $data_store_id;
+
+	/**
+	 * Sensei_Progress constructor.
+	 *
+	 * @param int                                       $user_id        User ID.
+	 * @param int                                       $post_id        Post ID for the course, lesson, or quiz.
+	 * @param int|null                                  $parent_post_id Parent post ID, usually the course ID for lesson or quizzes.
+	 * @param string                                    $status         Progress record status.
+	 * @param array|callable                            $data           Meta data. This can be an array or a lazy callable
+	 *                                                                  that returns an array the first time it is called.
+	 * @param DateTimeImmutable|null                    $date_created   Date record was first created.
+	 * @param DateTimeImmutable|null                    $date_modified  Date record was last modified.
+	 * @param Sensei_Progress_Data_Store_Interface|null $data_store     Data store.
+	 * @param int|null                                  $data_store_id  Unique identifier for the data store.
+	 */
+	final public function __construct(
+		$user_id,
+		$post_id,
+		$parent_post_id,
+		$status,
+		$data = [],
+		DateTimeImmutable $date_created = null,
+		DateTimeImmutable $date_modified = null,
+		Sensei_Progress_Data_Store_Interface $data_store = null,
+		$data_store_id = null
+	) {
+		$this->user_id        = $user_id;
+		$this->post_id        = $post_id;
+		$this->parent_post_id = $parent_post_id;
+		$this->status         = $status;
+		$this->data           = $data;
+		$this->date_created   = isset( $date_created ) ? $date_created : current_datetime();
+		$this->date_modified  = isset( $date_modified ) ? $date_modified : current_datetime();
+		$this->data_store     = $data_store;
+		$this->data_store_id  = $data_store_id;
+	}
+
+	/**
+	 * Help with deprecated WP comment properties.
+	 *
+	 * @param string $name Property name.
+	 */
+	public function __get( $name ) {
+		$map = [
+			'comment_ID'       => [ $this, 'get_data_store_id' ],
+			'comment_post_ID'  => [ $this, 'get_post_id' ],
+			'comment_date'     => function() {
+				return $this->get_date_created()->setTimezone( wp_timezone() )->format( 'Y-m-d H:i:s' );
+			},
+			'comment_date_gmt' => function() {
+				return $this->get_date_created()->format( 'Y-m-d H:i:s' );
+			},
+			'comment_approved' => [ $this, 'get_status' ],
+			'comment_type'     => function() {
+				return 'sensei_' . $this->get_record_type() . '_status';
+			},
+			'user_id'          => [ $this, 'get_user_id' ],
+		];
+
+		if ( isset( $map[ $name ] ) ) {
+			_doing_it_wrong( __CLASS__, esc_html( sprintf( 'Progress record is being accessed using a deprecated property (%s)', $name ) ), '[STORAGE_MILESTONE]' );
+
+			return call_user_func( $map[ $name ] );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Get the record type (course, lesson).
+	 *
+	 * @return string
+	 */
+	abstract public function get_record_type();
+
+	/**
+	 * Get the unique identifier used by the data store.
+	 *
+	 * @return int
+	 */
+	public function get_data_store_id() {
+		return $this->data_store_id;
+	}
+
+	/**
+	 * Get the data store storing this record.
+	 *
+	 * @return Sensei_Progress_Data_Store_Interface|null
+	 */
+	public function get_data_store() {
+		return $this->data_store;
+	}
+
+	/**
+	 * Set the data store record storage reference.
+	 *
+	 * @param Sensei_Progress_Data_Store_Interface $data_store Data store object.
+	 * @param int                                  $id         Unique identifier in data store.
+	 */
+	public function set_storage_ref( Sensei_Progress_Data_Store_Interface $data_store, $id ) {
+		$this->data_store = $data_store;
+		$this->id         = $id;
+	}
+
+	/**
+	 * Copy the record for storage in a new data store.
+	 *
+	 * @return static
+	 */
+	public function copy() {
+		return new static( $this->user_id, $this->post_id, $this->parent_post_id, $this->status, $this->data );
+	}
+
+	/**
+	 * Get the post ID for the course, lesson, and quiz.
+	 *
+	 * @return int
+	 */
+	public function get_post_id() {
+		return $this->post_id;
+	}
+
+	/**
+	 * Set the post ID for the course, lesson, and quiz.
+	 *
+	 * @param int $post_id Post ID.
+	 */
+	public function set_post_id( $post_id ) {
+		$this->post_id = $post_id;
+	}
+
+	/**
+	 * Get the parent post ID, usually the course ID for lesson or quizzes.
+	 *
+	 * @return int
+	 */
+	public function get_parent_post_id() {
+		return $this->parent_post_id;
+	}
+
+	/**
+	 * Set the parent post ID, usually the course ID for lesson or quizzes.
+	 *
+	 * @param int $parent_post_id Parent post ID.
+	 */
+	public function set_parent_post_id( $parent_post_id ) {
+		$this->parent_post_id = $parent_post_id;
+	}
+
+	/**
+	 * Get the user ID for this record.
+	 *
+	 * @return int User ID.
+	 */
+	public function get_user_id() {
+		return $this->user_id;
+	}
+
+	/**
+	 * Set the user ID for this record.
+	 *
+	 * @param int $user_id
+	 */
+	public function set_user_id( $user_id ) {
+		$this->user_id = $user_id;
+	}
+
+	/**
+	 * Get the date this record was created.
+	 *
+	 * @return DateTimeImmutable
+	 */
+	public function get_date_created() {
+		return $this->date_created;
+	}
+
+	/**
+	 * Set the date this record was created.
+	 *
+	 * @param DateTimeImmutable $date_created Date created.
+	 */
+	public function set_date_created( $date_created ) {
+		$this->date_created = $date_created;
+	}
+
+	/**
+	 * Get the date this record was modified.
+	 *
+	 * @return DateTimeImmutable
+	 */
+	public function get_date_modified() {
+		return $this->date_modified;
+	}
+
+	/**
+	 * Set the date this record was last modified.
+	 *
+	 * @param DateTimeImmutable $date_modified Date modified.
+	 */
+	public function set_date_modified( $date_modified ) {
+		$this->date_modified = $date_modified;
+	}
+
+	/**
+	 * Get the record status.
+	 *
+	 * @return string
+	 */
+	public function get_status() {
+		return $this->status;
+	}
+
+	/**
+	 * Set the record status.
+	 *
+	 * @param string $status
+	 */
+	public function set_status( $status ) {
+		$this->status = $status;
+	}
+
+	/**
+	 * Get the data associated with this record.
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		// Load lazy data.
+		if ( is_callable( $this->data ) ) {
+			$this->data = call_user_func( $this->data );
+		}
+
+		return $this->data;
+	}
+
+	/**
+	 * Set the data associated with this record.
+	 *
+	 * @param array $data
+	 */
+	public function set_data( $data ) {
+		$this->data = $data;
+	}
+}

--- a/includes/progress/class-sensei-progress.php
+++ b/includes/progress/class-sensei-progress.php
@@ -107,8 +107,8 @@ abstract class Sensei_Progress {
 		$this->parent_post_id = $parent_post_id;
 		$this->status         = $status;
 		$this->data           = $data;
-		$this->date_created   = isset( $date_created ) ? $date_created : current_datetime();
-		$this->date_modified  = isset( $date_modified ) ? $date_modified : current_datetime();
+		$this->date_created   = isset( $date_created ) ? $date_created : new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+		$this->date_modified  = isset( $date_modified ) ? $date_modified : new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
 		$this->data_store     = $data_store;
 		$this->data_store_id  = $data_store_id;
 	}
@@ -172,8 +172,8 @@ abstract class Sensei_Progress {
 	/**
 	 * Set the data store record storage reference.
 	 *
-	 * @param Sensei_Progress_Data_Store_Interface $data_store Data store object.
-	 * @param int                                  $id         Unique identifier in data store.
+	 * @param Sensei_Progress_Data_Store_Interface|null $data_store Data store object.
+	 * @param int|null                                  $id         Unique identifier in data store.
 	 */
 	public function set_storage_ref( Sensei_Progress_Data_Store_Interface $data_store, $id ) {
 		$this->data_store = $data_store;

--- a/includes/progress/data-store/class-sensei-progress-data-results.php
+++ b/includes/progress/data-store/class-sensei-progress-data-results.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * File containing the class Sensei_Progress_Data_Results.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Data store results.
+ */
+class Sensei_Progress_Data_Results {
+	/**
+	 * Data store that queried results.
+	 *
+	 * @var Sensei_Progress_Data_Store_Interface
+	 */
+	private $data_store;
+
+	/**
+	 * Arguments used for query.
+	 *
+	 * @var array
+	 */
+	private $args;
+
+	/**
+	 * Results of query.
+	 *
+	 * @var Sensei_Progress[]
+	 */
+	private $results;
+
+	/**
+	 * Number of total results found.
+	 *
+	 * @var int
+	 */
+	private $total_found;
+
+	/**
+	 * Sensei_Progress_Data_Results constructor.
+	 *
+	 * @param Sensei_Progress_Data_Store_Interface $data_store
+	 * @param array                                $args
+	 * @param Sensei_Progress[]                    $results
+	 * @param int                                  $total_found
+	 */
+	public function __construct(
+		Sensei_Progress_Data_Store_Interface $data_store,
+		$args,
+		$results,
+		$total_found
+	) {
+		$this->data_store  = $data_store;
+		$this->args        = $args;
+		$this->results     = $results;
+		$this->total_found = $total_found;
+	}
+
+	/**
+	 * Get the data store object that produced these results.
+	 *
+	 * @return Sensei_Progress_Data_Store_Interface
+	 */
+	public function get_data_store() {
+		return $this->data_store;
+	}
+
+	/**
+	 * Get the arguments used to query for the results.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		return $this->args;
+	}
+
+	/**
+	 * Get the results.
+	 *
+	 * @return Sensei_Progress[]
+	 */
+	public function get_results() {
+		return $this->results;
+	}
+
+	/**
+	 * Get the total number of results available.
+	 *
+	 * @return int
+	 */
+	public function get_total_found() {
+		return $this->total_found;
+	}
+}

--- a/includes/progress/data-store/class-sensei-progress-data-results.php
+++ b/includes/progress/data-store/class-sensei-progress-data-results.php
@@ -13,12 +13,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Data store results.
  */
 class Sensei_Progress_Data_Results {
-	/**
-	 * Data store that queried results.
-	 *
-	 * @var Sensei_Progress_Data_Store_Interface
-	 */
-	private $data_store;
 
 	/**
 	 * Arguments used for query.
@@ -44,30 +38,18 @@ class Sensei_Progress_Data_Results {
 	/**
 	 * Sensei_Progress_Data_Results constructor.
 	 *
-	 * @param Sensei_Progress_Data_Store_Interface $data_store
-	 * @param array                                $args
-	 * @param Sensei_Progress[]                    $results
-	 * @param int                                  $total_found
+	 * @param array             $args
+	 * @param Sensei_Progress[] $results
+	 * @param int               $total_found
 	 */
 	public function __construct(
-		Sensei_Progress_Data_Store_Interface $data_store,
 		$args,
 		$results,
 		$total_found
 	) {
-		$this->data_store  = $data_store;
 		$this->args        = $args;
 		$this->results     = $results;
 		$this->total_found = $total_found;
-	}
-
-	/**
-	 * Get the data store object that produced these results.
-	 *
-	 * @return Sensei_Progress_Data_Store_Interface
-	 */
-	public function get_data_store() {
-		return $this->data_store;
 	}
 
 	/**
@@ -80,7 +62,7 @@ class Sensei_Progress_Data_Results {
 	}
 
 	/**
-	 * Get the results.
+	 * Get the results. Note: If this was just a `count` query, only the `total_found` will be populated.
 	 *
 	 * @return Sensei_Progress[]
 	 */
@@ -95,5 +77,19 @@ class Sensei_Progress_Data_Results {
 	 */
 	public function get_total_found() {
 		return $this->total_found;
+	}
+
+	/**
+	 * Merge another data store's results.
+	 *
+	 * @param Sensei_Progress_Data_Results $results
+	 *
+	 * @return $this
+	 */
+	public function merge( Sensei_Progress_Data_Results $results ) {
+		$this->results     = array_merge( $this->results, $results->get_results() );
+		$this->total_found = $this->total_found + $results->get_total_found();
+
+		return $this;
 	}
 }

--- a/includes/progress/data-store/class-sensei-progress-data-store-comments.php
+++ b/includes/progress/data-store/class-sensei-progress-data-store-comments.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * File containing the class Sensei_Progress_Data_Store_Comments.
+ *
+ * @since [STORAGE_MILESTONE]
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Data store for managing progress in WP Comments table.
+ */
+class Sensei_Progress_Data_Store_Comments implements Sensei_Progress_Data_Store_Interface {
+	/**
+	 * Query progress results.
+	 *
+	 * @param array $args Arguments used in query.
+	 *
+	 * @return Sensei_Progress_Data_Results
+	 */
+	public function query( $args = [] ) {
+		// The data store doesn't recognized progress records tied to parent ID.
+		unset( $args['parent_post_id'] );
+
+		if ( isset( $args['type'] ) ) {
+			$args['type'] = 'sensei_' . $args['type'] . '_status';
+		}
+
+		$query        = new WP_Comment_Query();
+		$comments_raw = $query->query( $args );
+
+		/**
+		 * It runs while getting the comments for the given request.
+		 *
+		 * @deprecated [STORAGE_MILESTONE]
+		 *
+		 * @param int|array $comments
+		 */
+		$comments_raw = apply_filters_deprecated( 'sensei_check_for_activity', [ $comments_raw ], '[STORAGE_MILESTONE]' );
+		$records      = [];
+		foreach ( $comments_raw as $comment ) {
+			$records[] = $this->comment_to_record( $comment );
+		}
+
+		return new Sensei_Progress_Data_Results(
+			$this,
+			$args,
+			$records,
+			$comments_raw->found_comments
+		);
+	}
+
+	/**
+	 * Convert a comment record to a progress record.
+	 *
+	 * @param WP_Comment $comment Comment object.
+	 *
+	 * @return Sensei_Progress
+	 */
+	private function comment_to_record( WP_Comment $comment ) {
+		$record_class = Sensei_Progress_Manager::instance()->get_record_class_name( $this->get_record_type( $comment ) );
+
+		$lazy_data = function() use ( $comment ) {
+			$data = [];
+			foreach ( get_comment_meta( $comment->comment_ID ) as $meta_key => $values ) {
+				$data[ $meta_key ] = $values[0];
+			}
+
+			return $data;
+		};
+
+		return new $record_class(
+			(int) $comment->user_id,
+			(int) $comment->comment_post_ID,
+			null,
+			$comment->comment_approved,
+			$lazy_data,
+			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $comment->comment_date_gmt ),
+			null,
+			$this,
+			$comment->comment_ID
+		);
+	}
+
+	/**
+	 * Get a record type for a comment.
+	 *
+	 * @param WP_Comment $comment
+	 *
+	 * @return string|null
+	 */
+	private function get_record_type( WP_Comment $comment ) {
+		$map = [
+			'sensei_course_status' => 'course',
+			'sensei_lesson_status' => 'lesson',
+		];
+
+		return isset( $map[ $comment->comment_type ] ) ? $map[ $comment->comment_type ] : null;
+	}
+
+	/**
+	 * Reset progress.
+	 *
+	 * @param Sensei_Progress $progress Progress object.
+	 *
+	 * @return bool
+	 */
+	public function delete( Sensei_Progress $progress ) {
+		if ( $progress->get_data_store_id() ) {
+			$comment_id = $progress->get_data_store_id();
+		} else {
+			$comment_id = $this->fetch_existing_id( $progress );
+		}
+
+		if ( ! isset( $comment_id ) ) {
+			return false;
+		}
+
+		return wp_delete_comment( $comment_id, true );
+	}
+
+	/**
+	 * Save a progress record.
+	 *
+	 * @param Sensei_Progress $progress Progress object.
+	 *
+	 * @return bool
+	 */
+	public function save( Sensei_Progress $progress ) {
+		$comment = [];
+
+		if ( $progress->get_data_store_id() ) {
+			$comment['comment_ID'] = $progress->get_data_store_id();
+		} else {
+			$existing_id = $this->fetch_existing_id( $progress );
+			if ( $existing_id ) {
+				$comment['comment_ID'] = $existing_id;
+			}
+		}
+
+		$comment['comment_post_ID']  = $progress->get_post_id();
+		$comment['comment_date']     = $progress->get_date_created()->setTimezone( wp_timezone() )->format( 'Y-m-d H:i:s' );
+		$comment['comment_approved'] = $progress->get_status();
+		$comment['comment_type']     = 'sensei_' . $progress->get_record_type() . '_status';
+
+		if ( isset( $comment['comment_ID'] ) ) {
+			if ( ! wp_update_comment( $comment ) ) {
+				return false;
+			}
+		} else {
+			$comment_id = wp_insert_comment( $comment );
+			if ( ! $comment_id ) {
+				return false;
+			}
+
+			$progress->set_storage_ref( $this, (int) $comment_id );
+		}
+
+		foreach ( $progress->get_data() as $key => $value ) {
+			update_comment_meta( $progress->get_data_store_id(), $key, $value );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Query for existing record ID based on unique properties.
+	 *
+	 * @param Sensei_Progress $progress Progress object.
+	 *
+	 * @return int|null
+	 */
+	private function fetch_existing_id( Sensei_Progress $progress ) {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Purpose is to go around cache and check for record in live DB.
+		$comment_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT comment_ID FROM $wpdb->comments WHERE comment_post_ID = %d AND user_id = %d AND comment_type = %s ",
+				$progress->get_post_id(),
+				$progress->get_user_id(),
+				'sensei_' . $progress->get_record_type() . '_status'
+			)
+		);
+
+		if ( $comment_id ) {
+			return (int) $comment_id;
+		}
+
+		return null;
+	}
+}

--- a/includes/progress/data-store/class-sensei-progress-data-store-hybrid.php
+++ b/includes/progress/data-store/class-sensei-progress-data-store-hybrid.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * File containing the class Sensei_Progress_Data_Store_Hybrid.
+ *
+ * @since [STORAGE_MILESTONE]
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Data store for managing progress in stored in both the comments and DB table.
+ */
+class Sensei_Progress_Data_Store_Hybrid implements Sensei_Progress_Data_Store_Interface {
+	/**
+	 * Data stores for hybrid store.
+	 *
+	 * @var Sensei_Progress_Data_Store_Interface[]
+	 */
+	private $data_stores;
+
+	/**
+	 * Sensei_Progress_Data_Store_Comments constructor.
+	 *
+	 * @param Sensei_Progress_Data_Store_Interface[] $data_stores Data stores.
+	 */
+	public function __construct( $data_stores ) {
+		$this->data_stores = $data_stores;
+	}
+
+	/**
+	 * Query progress results.
+	 *
+	 * @param array $args Arguments used in query.
+	 *
+	 * @return Sensei_Progress_Data_Results
+	 */
+	public function query( $args = [] ) {
+		if ( isset( $args['number'] ) && 1 === $args['number'] ) {
+			// If we're fetching just a single record, try the table first.
+			$db_table_query = $this->data_stores['table']->query( $args );
+			if ( $db_table_query->get_total_found() > 0 ) {
+				return $db_table_query;
+			}
+
+			return $this->data_stores['comments']->query( $args );
+		}
+
+		// While the course is migrating, return other queries from the comments table.
+		return $this->data_stores['comments']->query( $args );
+	}
+
+	/**
+	 * Delete progress.
+	 *
+	 * @param Sensei_Progress $progress Progress object.
+	 *
+	 * @return bool
+	 */
+	public function delete( Sensei_Progress $progress ) {
+		if ( ! $progress->get_data_store() ) {
+			return false;
+		}
+
+		// Data store should be responsible for its own deletion.
+		return $progress->get_data_store()->delete( $progress );
+	}
+
+	/**
+	 * Save a progress record.
+	 *
+	 * @param Sensei_Progress $progress Progress object.
+	 *
+	 * @return bool
+	 */
+	public function save( Sensei_Progress $progress ) {
+		if ( ! $progress->get_data_store() ) {
+			// We should assume if no data store set, we'll want to start tracking with table data store.
+			// @todo Figure out if we should always copy the other course records (lessons) for a single course/user.
+			return $this->data_stores['table']->save( $progress );
+		}
+
+		// Data store should be responsible for its own saving.
+		return $progress->get_data_store()->save( $progress );
+	}
+}

--- a/includes/progress/data-store/class-sensei-progress-data-store-hybrid.php
+++ b/includes/progress/data-store/class-sensei-progress-data-store-hybrid.php
@@ -38,14 +38,12 @@ class Sensei_Progress_Data_Store_Hybrid implements Sensei_Progress_Data_Store_In
 	 * @return Sensei_Progress_Data_Results
 	 */
 	public function query( $args = [] ) {
-		if ( isset( $args['number'] ) && 1 === $args['number'] ) {
+		if ( isset( $args['number'] ) && 1 === (int) $args['number'] ) {
 			// If we're fetching just a single record, try the table first.
 			$db_table_query = $this->data_stores['table']->query( $args );
 			if ( $db_table_query->get_total_found() > 0 ) {
 				return $db_table_query;
 			}
-
-			return $this->data_stores['comments']->query( $args );
 		}
 
 		// While the course is migrating, return other queries from the comments table.

--- a/includes/progress/data-store/class-sensei-progress-data-store-interface.php
+++ b/includes/progress/data-store/class-sensei-progress-data-store-interface.php
@@ -19,6 +19,7 @@ interface Sensei_Progress_Data_Store_Interface {
 	 * @param array $args Arguments used in query.
 	 *
 	 * @return Sensei_Progress_Data_Results
+	 * @todo Write documentation for `$args`.
 	 */
 	public function query( $args = [] );
 

--- a/includes/progress/data-store/class-sensei-progress-data-store-interface.php
+++ b/includes/progress/data-store/class-sensei-progress-data-store-interface.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * File containing the interface Sensei_Progress_Data_Store_Interface.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Data store interface.
+ */
+interface Sensei_Progress_Data_Store_Interface {
+	/**
+	 * Query progress results.
+	 *
+	 * @param array $args Arguments used in query.
+	 *
+	 * @return Sensei_Progress_Data_Results
+	 */
+	public function query( $args = [] );
+
+	/**
+	 * Delete a progress record.
+	 *
+	 * @param Sensei_Progress $progress Progress object.
+	 *
+	 * @return bool
+	 */
+	public function delete( Sensei_Progress $progress );
+
+	/**
+	 * Save a progress record.
+	 *
+	 * @param Sensei_Progress $progress Progress object.
+	 *
+	 * @return bool
+	 */
+	public function save( Sensei_Progress $progress );
+}

--- a/includes/progress/data-store/class-sensei-progress-data-store-table.php
+++ b/includes/progress/data-store/class-sensei-progress-data-store-table.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * File containing the class Sensei_Progress_Data_Store_Table.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Data store for managing progress in our custom table.
+ */
+class Sensei_Progress_Data_Store_Table implements Sensei_Progress_Data_Store_Interface {
+	/**
+	 * Query progress results.
+	 *
+	 * @param array $args Arguments used in query.
+	 *
+	 * @return Sensei_Progress_Data_Results|false
+	 */
+	public function query( $args = [] ) {
+		global $wpdb;
+
+		// @todo Add caching.
+
+		$where = [];
+		if ( isset( $args['user_id'] ) ) {
+			$where[] = $wpdb->prepare( 'user_id=%d', $args['user_id'] );
+		}
+
+		if ( isset( $args['post_id'] ) ) {
+			$where[] = $wpdb->prepare( 'post_id=%d', $args['post_id'] );
+		}
+
+		if ( isset( $args['parent_post_id'] ) ) {
+			$where[] = $wpdb->prepare( 'parent_post_id=%d', $args['parent_post_id'] );
+		}
+
+		if (
+			isset( $args['type'] )
+			&& 'all' !== $args['type']
+			&& ( ! is_array( $args['type'] ) || ! in_array( 'all', $args['type'], true ) )
+		) {
+			$where[] = $this->where_helper( 'type', $args['type'] );
+		}
+
+		if (
+			isset( $args['status'] )
+			&& 'all' !== $args['status']
+			&& ( ! is_array( $args['status'] ) || ! in_array( 'all', $args['status'], true ) )
+		) {
+			$where[] = $this->where_helper( 'status', $args['status'] );
+		}
+
+		$query = "SELECT * FROM {$wpdb->sensei_lms_progress} WHERE " . implode( ' AND ', $where );
+
+		if ( ! empty( $args['number'] ) ) {
+			if ( ! isset( $args['offset'] ) ) {
+				$args['offset'] = 0;
+			}
+
+			$query .= ' LIMIT ' . (int) $args['offset'] . ',' . (int) $args['number'];
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching,WordPress.DB.PreparedSQL.NotPrepared -- Preparation and caching handled above.
+		$data_raw = $wpdb->get_results( $query, ARRAY_A );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.DirectDatabaseQuery.NoCaching -- Used with query above.
+		$total_number = (int) $wpdb->get_var( 'SELECT FOUND_ROWS()' );
+
+		$results = [];
+		foreach ( $data_raw as $item ) {
+			$results[] = $this->row_to_record( $item );
+		}
+
+		return new Sensei_Progress_Data_Results(
+			$this,
+			$args,
+			$results,
+			$total_number
+		);
+	}
+
+	/**
+	 * Prepare a value logical statement.
+	 *
+	 * @param string          $field       Field name.
+	 * @param string|string[] $value       Value to prepare.
+	 * @param string          $placeholder sprintf replacement for values.
+	 *
+	 * @return string
+	 */
+	private function where_helper( $field, $value, $placeholder = '%s' ) {
+		global $wpdb;
+
+		if ( is_array( $value ) ) {
+			if ( empty( $value ) ) {
+				return '1=0';
+			}
+			$values = [];
+			foreach ( $value as $v ) {
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- Placeholder is dynamic.
+				$values[] = $wpdb->prepare( $placeholder, $v );
+			}
+			return $field . ' IN (' . implode( ',', $values ) . ')';
+		}
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- Placeholder is dynamic.
+		return $wpdb->prepare( $field . '=' . $placeholder, $value );
+	}
+
+	/**
+	 * Convert a database row to a progress record.
+	 *
+	 * @param array $item Progress database record.
+	 *
+	 * @return Sensei_Progress
+	 */
+	private function row_to_record( $item ) {
+		$record_class = Sensei_Progress_Manager::instance()->get_record_class_name( $item['type'] );
+
+		if ( ! isset( $item['data'] ) ) {
+			$item['data'] = '[]';
+		}
+
+		$data = json_decode( $item['data'], true );
+
+		return new $record_class(
+			(int) $item['user_id'],
+			(int) $item['post_id'],
+			(int) $item['parent_post_id'],
+			$item['status'],
+			$data,
+			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $item['date_created'] ),
+			DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $item['date_modified'] ),
+			$this,
+			$item['id']
+		);
+	}
+
+	/**
+	 * Delete a progress record.
+	 *
+	 * @param Sensei_Progress $progress Progress object.
+	 *
+	 * @return bool
+	 */
+	public function delete( Sensei_Progress $progress ) {
+		global $wpdb;
+
+		if ( $progress->get_data_store_id() ) {
+			$record_id = $progress->get_data_store_id();
+		} else {
+			$record_id = $this->fetch_existing_id( $progress );
+		}
+
+		if ( ! isset( $record_id ) ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Handling directly.
+		$result = $wpdb->delete( $wpdb->sensei_lms_progress, [ 'id' => (int) $record_id ] );
+
+		// @todo Cache cleanup.
+
+		return false !== $result;
+	}
+
+	/**
+	 * Save a progress record.
+	 *
+	 * @param Sensei_Progress $progress Progress object.
+	 *
+	 * @return bool
+	 */
+	public function save( Sensei_Progress $progress ) {
+		global $wpdb;
+
+		$id = null;
+		if ( $progress->get_data_store_id() ) {
+			$id = $progress->get_data_store_id();
+		} else {
+			$existing_id = $this->fetch_existing_id( $progress );
+			if ( $existing_id ) {
+				$id = $existing_id;
+			}
+		}
+
+		$record                   = [];
+		$record['user_id']        = $progress->get_user_id();
+		$record['post_id']        = $progress->get_post_id();
+		$record['parent_post_id'] = $progress->get_parent_post_id();
+		$record['status']         = $progress->get_status();
+		$record['type']           = $progress->get_record_type();
+		$record['data']           = wp_json_encode( $progress->get_data() );
+		$record['date_created']   = $progress->get_date_created()->format( 'Y-m-d H:i:s' );
+		$record['date_modified']  = $progress->get_date_modified()->format( 'Y-m-d H:i:s' );
+
+		$data_value_types = [
+			'%d', // user_id.
+			'%d', // post_id.
+			'%d', // parent_post_id.
+			'%s', // status.
+			'%s', // type.
+			'%s', // data.
+			'%s', // date_created.
+			'%s', // date_modified.
+		];
+
+		if ( $id ) {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Handling directly.
+			if ( ! $wpdb->update( $wpdb->sensei_lms_progress, $record, [ 'id' => $id ], $data_value_types, [ '%d' ] ) ) {
+				return false;
+			}
+		} else {
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Handling directly.
+			$result = $wpdb->insert( $wpdb->sensei_lms_progress, $record, $data_value_types );
+			if ( ! $result ) {
+				return false;
+			}
+
+			$progress->set_storage_ref( $this, (int) $wpdb->insert_id );
+
+			// @todo Cache cleanup.
+		}
+
+		return true;
+	}
+
+	/**
+	 * Query for existing record ID based on unique properties.
+	 *
+	 * @param Sensei_Progress $progress Progress object.
+	 *
+	 * @return int|null
+	 */
+	private function fetch_existing_id( Sensei_Progress $progress ) {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Purpose is to go around cache and check for record in live DB.
+		$comment_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT id FROM $wpdb->sensei_lms_progress WHERE post_id = %d AND user_id = %d AND type = %s ",
+				$progress->get_post_id(),
+				$progress->get_user_id(),
+				$progress->get_record_type()
+			)
+		);
+
+		if ( $comment_id ) {
+			return (int) $comment_id;
+		}
+
+		return null;
+	}
+}

--- a/includes/progress/data-store/class-sensei-progress-data-store-table.php
+++ b/includes/progress/data-store/class-sensei-progress-data-store-table.php
@@ -18,7 +18,7 @@ class Sensei_Progress_Data_Store_Table implements Sensei_Progress_Data_Store_Int
 	 *
 	 * @param array $args Arguments used in query.
 	 *
-	 * @return Sensei_Progress_Data_Results|false
+	 * @return Sensei_Progress_Data_Results
 	 */
 	public function query( $args = [] ) {
 		global $wpdb;
@@ -54,7 +54,20 @@ class Sensei_Progress_Data_Store_Table implements Sensei_Progress_Data_Store_Int
 			$where[] = $this->where_helper( 'status', $args['status'] );
 		}
 
-		$query = "SELECT * FROM {$wpdb->sensei_lms_progress} WHERE " . implode( ' AND ', $where );
+		$fields = '*';
+		if ( ! empty( $args['count'] ) ) {
+			$fields = 'COUNT(*)';
+		}
+
+		$query = "SELECT {$fields} FROM {$wpdb->sensei_lms_progress} WHERE " . implode( ' AND ', $where );
+
+		if ( ! empty( $args['count'] ) ) {
+			return new Sensei_Progress_Data_Results(
+				$args,
+				[],
+				(int) $wpdb->get_var( $query )
+			);
+		}
 
 		if ( ! empty( $args['number'] ) ) {
 			if ( ! isset( $args['offset'] ) ) {
@@ -76,7 +89,6 @@ class Sensei_Progress_Data_Store_Table implements Sensei_Progress_Data_Store_Int
 		}
 
 		return new Sensei_Progress_Data_Results(
-			$this,
 			$args,
 			$results,
 			$total_number


### PR DESCRIPTION
This is 100% untested and mostly unwired investigation into introducing a custom table to store Sensei progress data. It was time-boxed during our hack week and even the MVP isn't nearly there. I might play with it more when I have an opportunity.

### Changes proposed in this Pull Request

* Adds a basic abstraction layer for progress results. For now, we have `Sensei_Progress_Course` and `Sensei_Progress_Lesson` that are pretty bare but we can build off them to take care of some of our business logic around completion. I also had `Sensei_Progress_Quiz`, but for now I kept that off and will instead eventually add a trait to `Sensei_Progress_Lesson` for quiz-related logic. We can then adapt that into `Sensei_Progress_Quiz` when/if we want to break the quiz:lesson relationship.
* Creates the concept of a progress data store. We have comments (`comments`) and now our custom table (`table`, but name could change). This will be set at a course level and will be pretty easy to create the migration job. While we're migrating, a course can switch to `hybrid` where we can probably do _most_ things (except probably Analytics). 
* To wire this up, I think we need to deprecate most of the activity/progress related methods in `Sensei_Utils`, which that plus changing their internal usage is the majority of the work. We might be able to do some things to help ease some pain (see `\Sensei_Progress::__get`), but because most of these methods return `$comment_id` and then some implementations do things such as update comment meta based on that result, we need to deprecate and replace the helper methods.
* In theory, as long as we support it, if a site had custom implementations that made it difficult to break from comments, it'd be easy for us to allow them to stick with the comments table indefinitely, although it would eventually limit them when we start thinking about different course:module:lesson:quiz relationship configurations. Additionally, we could roll this out very slowly, making it opt-in beta _and_ allow us to slowly update our plugins to use the abstraction layer. 
* Once this is fully released, new sites would only have the table store registered. 

### Design Notes
* On the table data store, I introduced a concept around `$parent_post_id`. This is mostly unused for now (although I think it will help with analytics). For now it'll just be the course ID on the lesson progress records. I think we should start doing this if we ever want to break free of the 1:many between course:lessons (allow lessons to be part of multiple courses) and most of the things we want to do with quizzes. Doing it now will open up more options in the future, which is why I included it in the implementation early. This means: if a user completes a lesson through `Course A` and then the lesson either gets moved to `Course B` or we add the ability for it to also be associated with `Course B`, their progress wouldn't be shared when they took the lesson via `Course B`. 
* We could very easily add a progress record for modules, too, if we wanted to start doing more advanced things with them (especially if we migrate from taxonomies to CPTs).
* I ran out of time so is very much an early POC. Don't take most of the other decisions very seriously (especially because I haven't even tested it).
* I started tracking `date_modified` for the progress records. I think this could be useful when we want to start doing more with analytics. 
* I switched to storing all dates in `UTC` so that it is more portable. We can always convert it to `wp_timezone()` when displayed to users.
* The query methods need to be fleshed out and documented. For now, you can get a pretty good sense of what is currently supported by looking at the `\Sensei_Progress_Data_Store_Table::query` method. I thought I'd start there and then build off that as we wire things up.

### Remaining Tasks

If we want to proceed with something like this path, it'd be a project of similar scale as splitting enrollment from progress. Some of the things we'd need to do:

- Deprecate activity/progress methods in `Sensei_Utils` but try to make their temporary replacements and non-breaking as possible (won't be easy).
- In wiring it up, I imagine we'll uncover some things that don't work as currently written.
- Update all implementations of above methods both in Sensei but also our extensions.
- Migrate job (should actually be quite easy) and possibly UI for migrating courses.
- Add caching to `Sensei_Progress_Data_Store_Table`.
- Tests!