### PR TITLE
Remove duplicate progress comments after inserting a new one to mitigate duplication issue

### DIFF
--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -125,6 +125,10 @@ class Sensei_Learner {
 	 * @param array $args
 	 */
 	public function remove_duplicate_progress( $args ) {
+		if ( empty( $args['post_id'] ) || empty( $args['user_id'] ) || empty( $args['type'] ) ) {
+			return;
+		}
+
 		add_action(
 			'shutdown',
 			function() use ( $args ) {

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -151,6 +151,16 @@ class Sensei_Learner {
 				$serialized_comment_ids = implode( ',', $comment_ids );
 
 				if ( ! empty( $comment_ids ) ) {
+					sensei_log_event(
+						'remove_duplicate_progress_comments',
+						[
+							'post_id'     => $args['post_id'],
+							'user_id'     => $args['user_id'],
+							'type'        => $args['type'],
+							'comment_ids' => $serialized_comment_ids,
+						]
+					);
+
 					$wpdb->query(
 						$wpdb->prepare(
 							"DELETE FROM $wpdb->comments WHERE comment_ID IN ( " . $serialized_comment_ids . " )",

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -165,8 +165,13 @@ class Sensei_Learner {
 						]
 					);
 
-					$wpdb->query( "DELETE FROM $wpdb->comments WHERE comment_ID IN ( " . $serialized_comment_ids . ' )' );
-					$wpdb->query( "DELETE FROM $wpdb->commentmeta WHERE comment_id IN ( " . $serialized_comment_ids . ' )' );
+					$format_comment_ids = implode( ', ', array_fill( 0, count( $comment_ids ), '%s' ) );
+
+					$sql = "DELETE FROM $wpdb->comments WHERE comment_ID IN ( $format_comment_ids )";
+					$wpdb->query( call_user_func_array( [ $wpdb, 'prepare' ], array_merge( [ $sql ], $comment_ids ) ) );
+
+					$sql = "DELETE FROM $wpdb->commentmeta WHERE comment_id IN ( $format_comment_ids )";
+					$wpdb->query( call_user_func_array( [ $wpdb, 'prepare' ], array_merge( [ $sql ], $comment_ids ) ) );
 
 					clean_comment_cache( $comment_ids );
 				}

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -161,18 +161,8 @@ class Sensei_Learner {
 						]
 					);
 
-					$wpdb->query(
-						$wpdb->prepare(
-							"DELETE FROM $wpdb->comments WHERE comment_ID IN ( " . $serialized_comment_ids . " )",
-							implode( ',', $comment_ids )
-						)
-					);
-					$wpdb->query(
-						$wpdb->prepare(
-							"DELETE FROM $wpdb->commentmeta WHERE comment_id IN ( " . $serialized_comment_ids . " )",
-							implode( ',', $comment_ids )
-						)
-					);
+					$wpdb->query( "DELETE FROM $wpdb->comments WHERE comment_ID IN ( " . $serialized_comment_ids . ' )' );
+					$wpdb->query( "DELETE FROM $wpdb->commentmeta WHERE comment_id IN ( " . $serialized_comment_ids . ' )' );
 				}
 				// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 			}

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -148,9 +148,9 @@ class Sensei_Learner {
 					0
 				);
 
-				$serialized_comment_ids = implode( ',', $comment_ids );
-
 				if ( ! empty( $comment_ids ) ) {
+					$serialized_comment_ids = implode( ',', $comment_ids );
+
 					sensei_log_event(
 						'remove_duplicate_progress_comments',
 						[

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -163,6 +163,8 @@ class Sensei_Learner {
 
 					$wpdb->query( "DELETE FROM $wpdb->comments WHERE comment_ID IN ( " . $serialized_comment_ids . ' )' );
 					$wpdb->query( "DELETE FROM $wpdb->commentmeta WHERE comment_id IN ( " . $serialized_comment_ids . ' )' );
+
+					clean_comment_cache( $comment_ids );
 				}
 				// phpcs:enable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared
 			}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -73,13 +73,8 @@ class Sensei_Utils {
 		// Check if comment exists first
 		$comment_id = $wpdb->get_var( $wpdb->prepare( "SELECT comment_ID FROM $wpdb->comments WHERE comment_post_ID = %d AND user_id = %d AND comment_type = %s ", $args['post_id'], $args['user_id'], $args['type'] ) );
 		if ( ! $comment_id ) {
-			// Try to remove the comment before inserting to mitigate duplicate inserts issue.
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->comments WHERE comment_post_ID = %d AND user_id = %d AND comment_type = %s ", $args['post_id'], $args['user_id'], $args['type'] ) );
-
 			// Add the comment
 			$comment_id = wp_insert_comment( $data );
-
 		} elseif ( isset( $args['action'] ) && 'update' == $args['action'] ) {
 			// Update the comment if an update was requested
 			$data['comment_ID'] = $comment_id;

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -74,6 +74,7 @@ class Sensei_Utils {
 		$comment_id = $wpdb->get_var( $wpdb->prepare( "SELECT comment_ID FROM $wpdb->comments WHERE comment_post_ID = %d AND user_id = %d AND comment_type = %s ", $args['post_id'], $args['user_id'], $args['type'] ) );
 		if ( ! $comment_id ) {
 			// Try to remove the comment before inserting to mitigate duplicate inserts issue.
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->comments WHERE comment_post_ID = %d AND user_id = %d AND comment_type = %s ", $args['post_id'], $args['user_id'], $args['type'] ) );
 
 			// Add the comment

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -73,6 +73,9 @@ class Sensei_Utils {
 		// Check if comment exists first
 		$comment_id = $wpdb->get_var( $wpdb->prepare( "SELECT comment_ID FROM $wpdb->comments WHERE comment_post_ID = %d AND user_id = %d AND comment_type = %s ", $args['post_id'], $args['user_id'], $args['type'] ) );
 		if ( ! $comment_id ) {
+			// Try to remove the comment before inserting to mitigate duplicate inserts issue.
+			$wpdb->query( $wpdb->prepare( "DELETE FROM $wpdb->comments WHERE comment_post_ID = %d AND user_id = %d AND comment_type = %s ", $args['post_id'], $args['user_id'], $args['type'] ) );
+
 			// Add the comment
 			$comment_id = wp_insert_comment( $data );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This is another change trying to mitigate the issue #2748. Related to https://github.com/Automattic/sensei/pull/3838.
  * It basically adds a redundancy to prevent duplication insert. In the hook `sensei_log_activity_after`, we are adding a new hook to the `shutdown` to remove keep only the first comment for the context (user, post ID, type), and remove the others which should not exist.
  * It could be done only when it's an insert, but to prevent changes, or add more complexity (like class attributes, or a new hook), I added it to the `sensei_log_activity_after` that will also happen after an update.
* It also introduces the event `sensei_remove_duplicate_progress_comments`, so we can monitor where and when it's happening, or if it was fixed by https://github.com/Automattic/sensei/pull/3838 🤞.

### Testing instructions

* Since the issue is hard to reproduce, the only way to test is debugging the code, and changing the database while it's running.
  * A good way to test is duplicating the line `$comment_id = wp_insert_comment( $data );`
* It's good also to test creating some courses, lessons and quizzes, enroll on them, remove enrollment, reset progress, and so on, and make sure everything is working properly.