### PR TITLE
Add Remove Progress button in Learner Management for lessons

### DIFF
--- a/assets/js/learners-general.js
+++ b/assets/js/learners-general.js
@@ -149,9 +149,11 @@ jQuery( document ).ready( function ( $ ) {
 
 		var actions = {
 			remove_progress: {
+				lesson:
+					window.woo_learners_general_data.remove_from_lesson_confirm,
 				course:
 					window.woo_learners_general_data.remove_progress_confirm,
-				action: 'reset_user_post',
+				action: 'remove_user_from_post',
 			},
 			reset_progress: {
 				lesson: window.woo_learners_general_data.reset_lesson_confirm,

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -489,29 +489,20 @@ class Sensei_Learner_Management {
 
 			$altered = true;
 
-			switch ( $action ) {
-				case 'reset':
-					switch ( $post_type ) {
-						case 'course':
-							$altered = Sensei_Utils::reset_course_for_user( $post_id, $user_id );
-							break;
-
-						case 'lesson':
+			switch ( $post_type ) {
+				case 'course':
+					$altered = Sensei_Utils::reset_course_for_user( $post_id, $user_id );
+					break;
+				case 'lesson':
+					switch ( $action ) {
+						case 'reset':
 							$altered = Sensei()->quiz->reset_user_lesson_data( $post_id, $user_id );
 							break;
-					}
-					break;
-
-				case 'remove':
-					switch ( $post_type ) {
-						case 'course':
-							$altered = Sensei_Utils::reset_course_for_user( $post_id, $user_id );
-							break;
-
-						case 'lesson':
+						case 'remove':
 							$altered = Sensei_Utils::sensei_remove_user_from_lesson( $post_id, $user_id );
 							break;
 					}
+					break;
 			}
 
 			if ( $altered ) {

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -432,7 +432,9 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 					: '';
 
 				if ( 'course' === $post_type ) {
+					// Courses.
 					if ( $is_user_enrolled ) {
+						// Enrolled.
 						$withdraw_action_url = wp_nonce_url(
 							add_query_arg(
 								array(
@@ -454,15 +456,23 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 									esc_html__( 'Remove Enrollment', 'sensei-lms' ) .
 								'</a>' .
 							'</span>';
+
+						$row_actions[] =
+							'<span class="delete">' .
+								'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="reset_progress" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' .
+									esc_html__( 'Reset Progress', 'sensei-lms' ) .
+								'</a>' .
+							'</span>';
 					} else {
+						// Not enrolled.
 						$enrol_label            = esc_html__( 'Enroll', 'sensei-lms' );
-						$data_action            = 'enrol';
+						$enrol_data_action      = 'enrol';
 						$restore_providers_attr = '';
 
 						// Check if it's enrolled by some provider.
 						if ( ! empty( $provider_ids_with_enrollment ) ) {
 							$enrol_label            = esc_html__( 'Restore Enrollment', 'sensei-lms' );
-							$data_action            = 'restore_enrollment';
+							$enrol_data_action      = 'restore_enrollment';
 							$restore_providers_attr = $providers_attr;
 						}
 
@@ -471,38 +481,39 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 								array(
 									'page'             => 'sensei_learners',
 									'view'             => 'learners',
-									'learner_action'   => $data_action,
+									'learner_action'   => $enrol_data_action,
 									'course_id'        => $this->course_id,
 									'user_id'          => $user_activity->user_id,
 									'enrolment_status' => $this->enrolment_status,
 								),
 								admin_url( 'admin.php' )
 							),
-							'sensei-learner-action-' . $data_action
+							'sensei-learner-action-' . $enrol_data_action
 						);
 
 						$row_actions[] =
 							'<span>' .
-								'<a class="learner-action" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="' . $data_action . '" ' . $restore_providers_attr . ' href="' . esc_url( $enrol_action_url ) . '">' .
+								'<a class="learner-action" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="' . $enrol_data_action . '" ' . $restore_providers_attr . ' href="' . esc_url( $enrol_action_url ) . '">' .
 									$enrol_label .
 								'</a>' .
 							'</span>';
+
+						$row_actions[] =
+							'<span class="delete">' .
+								'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="remove_progress" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' .
+									esc_html__( 'Remove Progress', 'sensei-lms' ) .
+								'</a>' .
+							'</span>';
 					}
+				} else {
+					// Lessons.
+					$row_actions[] =
+						'<span class="delete">' .
+							'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="reset_progress" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' .
+								esc_html__( 'Reset Progress', 'sensei-lms' ) .
+							'</a>' .
+						'</span>';
 				}
-
-				$reset_action = 'reset_progress';
-				$reset_label  = esc_html__( 'Reset Progress', 'sensei-lms' );
-				if ( 'course' === $post_type && ! $is_user_enrolled ) {
-					$reset_action = 'remove_progress';
-					$reset_label  = esc_html__( 'Remove Progress', 'sensei-lms' );
-				}
-
-				$row_actions[] =
-					'<span class="delete">' .
-						'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="' . esc_attr( $reset_action ) . '" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' .
-							$reset_label .
-						'</a>' .
-					'</span>';
 
 				if ( $edit_start_date_form ) {
 					$actions[] = $edit_start_date_form;

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -513,6 +513,13 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 								esc_html__( 'Reset Progress', 'sensei-lms' ) .
 							'</a>' .
 						'</span>';
+
+					$row_actions[] =
+						'<span class="delete">' .
+							'<a class="learner-async-action delete" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-action="remove_progress" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '">' .
+								esc_html__( 'Remove Progress', 'sensei-lms' ) .
+							'</a>' .
+						'</span>';
 				}
 
 				if ( $edit_start_date_form ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This introduces a button to remove progress from lesson through Learner Management. It can also help with the issue https://github.com/Automattic/sensei/issues/2748, allowing the users to remove duplicated progress in lessons.
  * It also contains some small refactors in the related code to make it a little more clear.

### Testing instructions

* Create courses with lessons, and quizzes.
* Enroll users in the courses.
* Make some progress.
* User the Learner management features "Remove Progress", and "Reset Progress" for courses and lessons, and make sure it's working properly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="261" alt="Screen Shot 2020-12-17 at 16 40 37" src="https://user-images.githubusercontent.com/876340/102535222-ae5c1e00-4086-11eb-87b7-4130a6b55efc.png">