### PR TITLE
Fix renaming modules issue

### DIFF
--- a/includes/admin/class-sensei-tools.php
+++ b/includes/admin/class-sensei-tools.php
@@ -74,6 +74,7 @@ class Sensei_Tools {
 			$tools[] = new Sensei_Tool_Ensure_Roles();
 			$tools[] = new Sensei_Tool_Remove_Deleted_User_Data();
 			$tools[] = new Sensei_Tool_Enrolment_Debug();
+			$tools[] = new Sensei_Tool_Module_Slugs_Mismatch();
 
 			/**
 			 * Array of the tools available to Sensei LMS.

--- a/includes/admin/tools/class-sensei-tool-module-slugs-mismatch.php
+++ b/includes/admin/tools/class-sensei-tool-module-slugs-mismatch.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * File containing Sensei_Tool_Module_Slugs_Mismatch class.
+ *
+ * @package sensei-lms
+ * @since 3.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Sensei_Tool_Module_Slugs_Mismatch class.
+ *
+ * @since 3.7.0
+ */
+class Sensei_Tool_Module_Slugs_Mismatch implements Sensei_Tool_Interface {
+	/**
+	 * Get the ID of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_id() {
+		return 'module-slugs-mismatch';
+	}
+
+	/**
+	 * Get the name of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return __( 'Module slugs mismatch', 'sensei-lms' );
+	}
+
+	/**
+	 * Get the description of the tool.
+	 *
+	 * @return string
+	 */
+	public function get_description() {
+		return __( 'Fix module slugs that do not match the module name.', 'sensei-lms' );
+	}
+
+	/**
+	 * Run the tool.
+	 */
+	public function process() {
+		$terms   = $this->get_module_terms();
+		$updated = [];
+		$errors  = [];
+
+		foreach ( $terms as $key => $term ) {
+			$correct_slug = $this->get_correct_slug( $term );
+
+			if ( $correct_slug !== $term->slug ) {
+				$change_result = wp_update_term(
+					$term->term_id,
+					'module',
+					[
+						'slug' => $correct_slug,
+					]
+				);
+
+				if ( is_wp_error( $change_result ) ) {
+					$errors[] = $term->term_id;
+				} else {
+					$updated[] = $term->term_id;
+				}
+			}
+		}
+
+		$message = $this->get_feedback_message( $updated, $errors );
+
+		Sensei_Tools::instance()->add_user_message( $message, ! empty( $errors ) );
+	}
+
+	/**
+	 * Get module terms.
+	 *
+	 * @return \WP_Term[] Module terms.
+	 */
+	private function get_module_terms() {
+		remove_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70 );
+		$terms = get_terms(
+			[
+				'hide_empty' => false,
+				'taxonomy'   => 'module',
+			]
+		);
+		add_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70, 3 );
+
+		return $terms;
+	}
+
+	/**
+	 * Get correct slug.
+	 *
+	 * @param \WP_Term $term Module term.
+	 *
+	 * @return string Correct slug.
+	 */
+	private function get_correct_slug( $term ) {
+		$sanitized_title = sanitize_title( $term->name );
+
+		return preg_replace( '/(\d+-)?(.*)/', '$1' . $sanitized_title, $term->slug, 1 );
+	}
+
+	/**
+	 * Get feedback message.
+	 *
+	 * @param int[] $updated ID of the terms that were updated.
+	 * @param int[] $errors  ID of the terms that had error.
+	 *
+	 * @return string Feedback message.
+	 */
+	private function get_feedback_message( $updated, $errors ) {
+		$message = '';
+
+		if ( ! empty( $updated ) ) {
+			$message .= sprintf(
+				// translators: %1$s is the IDs of the updated terms.
+				__( 'Module slugs were updated in the terms with IDs: %1$s.', 'sensei-lms' ),
+				implode( ', ', $updated )
+			);
+		}
+
+		if ( ! empty( $errors ) ) {
+			$message .= ' ' . sprintf(
+				// translators: %1$s is terms with error on update.
+				__( 'Errors happened while updating slugs for the terms with IDs: %1$s.', 'sensei-lms' ),
+				implode( ', ', $errors )
+			);
+		}
+
+		if ( empty( $message ) ) {
+			$message .= ' ' . __( 'There were no slugs mismatch.', 'sensei-lms' );
+		}
+
+		return $message;
+	}
+}

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -132,6 +132,7 @@ class Sensei_Autoloader {
 			'Sensei_Tool_Recalculate_Enrolment'          => 'admin/tools/class-sensei-tool-recalculate-enrolment.php',
 			'Sensei_Tool_Ensure_Roles'                   => 'admin/tools/class-sensei-tool-ensure-roles.php',
 			'Sensei_Tool_Remove_Deleted_User_Data'       => 'admin/tools/class-sensei-tool-remove-deleted-user-data.php',
+			'Sensei_Tool_Module_Slugs_Mismatch'          => 'admin/tools/class-sensei-tool-module-slugs-mismatch.php',
 			'Sensei_Tool_Enrolment_Debug'                => 'admin/tools/class-sensei-tool-enrolment-debug.php',
 
 			/**

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -271,7 +271,12 @@ class Sensei_Course_Structure {
 	 */
 	private function save_module( array $item ) {
 		if ( $item['id'] ) {
-			$module_id = $this->update_module( $item );
+			$term = get_term( $item['id'], 'module' );
+			$slug = $this->get_module_slug( $item['title'] );
+
+			$module_id = $term->slug === $slug
+				? $this->update_module( $item )
+				: $this->create_module( $item );
 		} else {
 			$module_id = $this->create_module( $item );
 		}

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -274,9 +274,13 @@ class Sensei_Course_Structure {
 			$term = get_term( $item['id'], 'module' );
 			$slug = $this->get_module_slug( $item['title'] );
 
-			$module_id = $term->slug === $slug
-				? $this->update_module( $item )
-				: $this->create_module( $item );
+			// Slug has changed.
+			if ( $term->slug !== $slug ) {
+				$existing_module_id = $this->get_existing_module( $item['title'] );
+				$module_id          = $existing_module_id ? $existing_module_id : $this->create_module( $item );
+			} else {
+				$module_id = $this->update_module( $item );
+			}
 		} else {
 			$module_id = $this->create_module( $item );
 		}

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -309,13 +309,7 @@ class Sensei_Course_Structure {
 	 * @return int|null Term ID if found.
 	 */
 	private function get_existing_module( string $module_name ) {
-		$slug = sanitize_title( $module_name );
-
-		$teacher_user_id = get_post( $this->course_id )->post_author;
-		if ( ! user_can( $teacher_user_id, 'manage_options' ) ) {
-			$slug = intval( $teacher_user_id ) . '-' . $slug;
-		}
-
+		$slug            = $this->get_module_slug( $module_name );
 		$existing_module = get_term_by( 'slug', $slug, 'module' );
 
 		if ( $existing_module ) {
@@ -335,14 +329,8 @@ class Sensei_Course_Structure {
 	private function create_module( array $item ) {
 		$args = [
 			'description' => $item['description'],
+			'slug'        => $this->get_module_slug( $item['title'] ),
 		];
-
-		$teacher_user_id = get_post( $this->course_id )->post_author;
-		if ( ! user_can( $teacher_user_id, 'manage_options' ) ) {
-			$args['slug'] = intval( $teacher_user_id ) . '-' . sanitize_title( $item['title'] );
-		} else {
-			$args['slug'] = sanitize_title( $item['title'] );
-		}
 
 		$create_result = wp_insert_term( $item['title'], 'module', $args );
 		if ( is_wp_error( $create_result ) ) {
@@ -383,6 +371,21 @@ class Sensei_Course_Structure {
 		}
 
 		return $term->term_id;
+	}
+
+	/**
+	 * Get module slug.
+	 *
+	 * @param string $title Module title.
+	 *
+	 * @return string Slug.
+	 */
+	private function get_module_slug( $title ) {
+		$teacher_user_id = get_post( $this->course_id )->post_author;
+
+		return user_can( $teacher_user_id, 'manage_options' )
+			? sanitize_title( $title )
+			: intval( $teacher_user_id ) . '-' . sanitize_title( $title );
 	}
 
 	/**

--- a/tests/unit-tests/admin/tools/test-class-sensei-tool-module-slugs-mismatch.php
+++ b/tests/unit-tests/admin/tools/test-class-sensei-tool-module-slugs-mismatch.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This file contains the Sensei_Tool_Module_Slugs_Mismatch_Tests class.
+ *
+ * @package sensei
+ */
+
+/**
+ * Tests for Sensei_Tool_Module_Slugs_Mismatch class.
+ *
+ * @group tools
+ */
+class Sensei_Tool_Module_Slugs_Mismatch_Tests extends WP_UnitTestCase {
+	/**
+	 * Factory object.
+	 *
+	 * @var Sensei_Factory
+	 */
+	private $factory;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+	}
+
+	/**
+	 * Tests to make the slugs are fixed.
+	 */
+	public function testRunFixSlugs() {
+		$args        = [
+			'slug' => 'wrong-slug',
+		];
+		$term_result = wp_insert_term( 'My module', 'module', $args );
+
+		$this->assertNotFalse( get_term_by( 'slug', 'wrong-slug', 'module' ) );
+		$this->assertFalse( get_term_by( 'slug', 'my-module', 'module' ) );
+
+		$tool = new Sensei_Tool_Module_Slugs_Mismatch();
+		$tool->process();
+
+		$this->assertFalse( get_term_by( 'slug', 'wrong-slug', 'module' ) );
+		$this->assertNotFalse( get_term_by( 'slug', 'my-module', 'module' ) );
+	}
+
+	/**
+	 * Tests to make the slugs are fixed keeping the teacher ID prefix.
+	 */
+	public function testRunFixSlugsKeepingTeacherIDPrefix() {
+		$args        = [
+			'slug' => '1-wrong-slug',
+		];
+		$term_result = wp_insert_term( 'My module', 'module', $args );
+
+		$this->assertNotFalse( get_term_by( 'slug', '1-wrong-slug', 'module' ) );
+		$this->assertFalse( get_term_by( 'slug', '1-my-module', 'module' ) );
+
+		$tool = new Sensei_Tool_Module_Slugs_Mismatch();
+		$tool->process();
+
+		$this->assertFalse( get_term_by( 'slug', '1-wrong-slug', 'module' ) );
+		$this->assertNotFalse( get_term_by( 'slug', '1-my-module', 'module' ) );
+	}
+}

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
@@ -309,7 +309,7 @@ class Sensei_REST_API_Course_Structure_Controller_Tests extends WP_Test_REST_Tes
 	}
 
 	/**
-	 * Tests to make sure an admin can modify another teacher's course structure with `POST /sensei-internal/v1/course-structure/{course_id}`.
+	 * Tests to make sure a teacher cannot modify another teacher's course structure with `POST /sensei-internal/v1/course-structure/{course_id}`.
 	 */
 	public function testPostDifferentTeacher() {
 		$this->login_as_teacher();

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-structure-controller.php
@@ -283,7 +283,7 @@ class Sensei_REST_API_Course_Structure_Controller_Tests extends WP_Test_REST_Tes
 	 * Tests a simple `POST /sensei-internal/v1/course-structure/{course_id}` request response matches the schema.
 	 */
 	public function testPostSimple() {
-		$this->login_as_teacher();
+		$this->login_as_admin();
 
 		$course_response = $this->factory->get_course_with_lessons(
 			[

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -574,13 +574,41 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		$this->assertTrue( $course_structure->save( $new_structure ) );
 
 		$modified_structure                   = $course_structure->get( 'edit' );
-		$modified_structure[0]['title']       = 'Update Module Name';
 		$modified_structure[0]['description'] = 'Now improved!';
 
 		$this->assertTrue( $course_structure->save( $modified_structure ) );
 
 		$structure = $course_structure->get( 'edit' );
 		$this->assertExpectedStructure( $modified_structure, $structure );
+	}
+
+	/**
+	 * Make sure new term is created when changing the module title.
+	 */
+	public function testSaveUpdateModuleName() {
+		$this->login_as_admin();
+
+		$course_id     = $this->factory->course->create();
+		$new_structure = [
+			[
+				'type'        => 'module',
+				'title'       => 'New Module A',
+				'description' => 'Very nice module',
+				'lessons'     => [],
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+
+		$this->assertTrue( $course_structure->save( $new_structure ) );
+
+		$modified_structure             = $course_structure->get( 'edit' );
+		$modified_structure[0]['title'] = 'Update Module Name';
+
+		$this->assertTrue( $course_structure->save( $modified_structure ) );
+
+		$structure = $course_structure->get( 'edit' );
+		$this->assertNotEquals( $modified_structure[0]['id'], $structure[0]['id'] );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -157,6 +157,8 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 	 * Test getting course structure when just modules with no lessons and one rogue lesson while in edit context.
 	 */
 	public function testGetModulesWithEmptyLessonsEdit() {
+		$this->login_as_admin();
+
 		$course_id = $this->factory->course->create();
 
 		$lessons = $this->factory->lesson->create_many( 1 );
@@ -191,6 +193,8 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 	 * Test getting course structure when a module has no published lessons while in view context.
 	 */
 	public function testGetModulesWithEmptyLessonsView() {
+		$this->login_as_admin();
+
 		$course_id = $this->factory->course->create();
 
 		$lessons            = $this->factory->lesson->create_many( 2 );
@@ -238,6 +242,8 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 	 * Test getting course structure when there is a mix of modules and lessons on the first level.
 	 */
 	public function testGetModulesLessonsMix() {
+		$this->login_as_admin();
+
 		$course_id = $this->factory->course->create();
 
 		$lessons = $this->factory->lesson->create_many( 5 );


### PR DESCRIPTION
Fixes #3848

### Changes proposed in this Pull Request

* Considering the UX is a little different than the legacy courses, I changed a little the approach.
  * In the legacy courses, when we change a module name, it's expected to change in all parts where we use it, but considering the UI for the blocks, it doesn't make sense. If the user just renames a module in a course, probably they won't expect this module is renamed in other courses too.
   With this PR, in the blocks, if they rename the module we create a new one, or we associate to another module with the same name (if it exists).
* This PR also introduces a tool to fix module slugs which doesn't match the module name.

### Testing instructions

**Test 1**

- Create a new course.
- Create a module called "Name A", and save.
- Rename this module to "Name B", and save.
- Create a new module called "Name A", and make sure it works properly.

**Test 2**

- Create a new course.
- Create a module called "Test A", and save.
- Rename this module to "Test B", and save.
- Create a new course.
- Create a new module called "Test A", and save.
- Create a new module called "Test B", and save.
- Rename the "Test B" to "Test C", and save.
- Go to the first course, and make sure the module continues as "Test B".

**Slugs mismatch tool**

Test as an admin and as a teacher.

- Create a course with modules.
- Go to WP-admin > Courses > Modules.
- Change the slug to not match correctly the module name.
- Go to WP-admin > Sensei LMS > Tools.
- Run the action for the _"Module slugs mismatch"_.
- Confirm if the slug was fixed and the course continues working properly.

### Things I thought that we could implement, but I didn't for now

- When we rename a module (it creates a new one with the new respective slug), and the old name is not associated with any other course, we could delete the term. But considering we're still supporting legacy courses, maybe the user could consider it an unexpected behavior.
- We could also create a tool to remove unused modules.

### Known issues

I imagine these issues are less critical, and probably should be solved when the modules approach is refactored from taxonomy to some other thing.

- The module conflicts were solved, but it still carries the module description. When the same module is associated with different courses (in case the module name is the same), it will carry the module description.
- If the user renames a module through `wp-admin/edit-tags.php?taxonomy=module` causing a title/slug mismatch, it can cause issues. This PR also introduces a tool to fix module slugs mismatch.
- Modules with different text which create the same slug, like "Test A" and "Test A!" can cause issues, like changing the module text in different courses.