### PR TITLE
Fix not being able to save course when Yoast SEO is activated

### DIFF
--- a/includes/blocks/class-sensei-block-contact-teacher.php
+++ b/includes/blocks/class-sensei-block-contact-teacher.php
@@ -46,7 +46,10 @@ class Sensei_Block_Contact_Teacher {
 	public function render_contact_teacher_block( $attributes, $content ): string {
 		global $post;
 
-		if ( ! empty( Sensei()->settings->settings['messages_disable'] ) || ! is_user_logged_in() ) {
+		if ( ! $post
+			|| ! empty( Sensei()->settings->settings['messages_disable'] )
+			|| ! is_user_logged_in()
+		) {
 			return '';
 		}
 

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -42,6 +42,11 @@ class Sensei_Block_Take_Course {
 	 */
 	public function render_take_course_block( $attributes, $content ): string {
 		global $post;
+
+		if ( ! $post ) {
+			return '';
+		}
+
 		$course_id = $post->ID;
 		$html      = '';
 

--- a/includes/blocks/class-sensei-course-outline-block.php
+++ b/includes/blocks/class-sensei-course-outline-block.php
@@ -179,6 +179,10 @@ class Sensei_Course_Outline_Block {
 	public function get_block_structure() {
 		global $post;
 
+		if ( ! $post ) {
+			return [];
+		}
+
 		$context    = 'view';
 		$attributes = $this->block_attributes['course'];
 		$is_preview = is_preview() && $this->can_current_user_edit_course( $post->ID );

--- a/includes/blocks/class-sensei-course-outline-course-block.php
+++ b/includes/blocks/class-sensei-course-outline-course-block.php
@@ -42,6 +42,9 @@ class Sensei_Course_Outline_Course_Block {
 	 * @return string Block HTML.
 	 */
 	public function render_course_outline_block( $outline ) {
+		if ( empty( $outline ) ) {
+			return '';
+		}
 
 		$attributes = $outline['attributes'];
 		$blocks     = $outline['blocks'];


### PR DESCRIPTION
Fixes #3867.

### Changes proposed in this Pull Request

When the Yoast SEO plugin is activated, `$post` is not set on the first call to some functions, resulting in a fatal error. This PR adds a check that bails early if `$post` is not set. I checked all other files in `includes/blocks` and no others are using `global $post`.

### Testing instructions

* Activate Yoast SEO.
* Create a new course with some modules and lessons.
* Save the course and ensure that saving works.
* Check that an existing course also saves.