### PR TITLE
Add refresh modules button after changing course teacher

### DIFF
--- a/assets/js/modules-admin.js
+++ b/assets/js/modules-admin.js
@@ -1,5 +1,3 @@
-import { __ } from '@wordpress/i18n';
-
 /**
  * Get the url qiuery paramater by name
  *
@@ -194,26 +192,13 @@ jQuery( document ).ready( function () {
 	);
 	if ( courseTeacherInput ) {
 		courseTeacherInput.addEventListener( 'change', () => {
-			document.querySelector( '#taxonomy-module' ).innerHTML = `
-				<p>
-					${ __(
-						'Since the Teacher field was changed, you must refresh the page to modify the modules.',
-						'sensei-lms'
-					) }
-				</p>
-				<button class="button" id="modules-refresh-button">
-					${ __( 'Refresh now', 'sensei-lms' ) }
-				</button>
-				<div><small>Remember to save your changes before refreshing the page.</small></div>
-			`;
-
-			// Add event to refresh button.
-			const refreshButton = document.querySelector(
-				'#modules-refresh-button'
+			const modulesMetabox = document.querySelector(
+				'#module_course_mb'
 			);
-			refreshButton.addEventListener( 'click', () => {
-				window.location.reload();
-			} );
+
+			if ( modulesMetabox ) {
+				modulesMetabox.parentNode.removeChild( modulesMetabox );
+			}
 		} );
 	}
 

--- a/assets/js/modules-admin.js
+++ b/assets/js/modules-admin.js
@@ -1,3 +1,5 @@
+import { __ } from '@wordpress/i18n';
+
 /**
  * Get the url qiuery paramater by name
  *
@@ -181,6 +183,38 @@ jQuery( document ).ready( function () {
 			}
 		} );
 	} );
+
+	/**
+	 * After changing the course teacher, it prevents updating the modules
+	 * until the next page refresh. Otherwise, some issues can happen because
+	 * the modules list in the frontend can be out of date with the server.
+	 */
+	const courseTeacherInput = document.querySelector(
+		'select[name="sensei-course-teacher-author"]'
+	);
+	if ( courseTeacherInput ) {
+		courseTeacherInput.addEventListener( 'change', () => {
+			document.querySelector( '#taxonomy-module' ).innerHTML = `
+				<p>
+					${ __(
+						'You must refresh the page to modify the modules after updating the course teacher.',
+						'sensei-lms'
+					) }
+				</p>
+				<button class="button" id="modules-refresh-button">
+					${ __( 'Refresh now', 'sensei-lms' ) }
+				</button>
+			`;
+
+			// Add event to refresh button.
+			const refreshButton = document.querySelector(
+				'#modules-refresh-button'
+			);
+			refreshButton.addEventListener( 'click', () => {
+				window.location.reload();
+			} );
+		} );
+	}
 
 	// Get Course modules (if any) on course select change
 	var $courseSelect = jQuery( '#lesson-course-options' ),

--- a/assets/js/modules-admin.js
+++ b/assets/js/modules-admin.js
@@ -197,13 +197,14 @@ jQuery( document ).ready( function () {
 			document.querySelector( '#taxonomy-module' ).innerHTML = `
 				<p>
 					${ __(
-						'You must refresh the page to modify the modules after updating the course teacher.',
+						'Since the Teacher field was changed, you must refresh the page to modify the modules.',
 						'sensei-lms'
 					) }
 				</p>
 				<button class="button" id="modules-refresh-button">
 					${ __( 'Refresh now', 'sensei-lms' ) }
 				</button>
+				<div><small>Remember to save your changes before refreshing the page.</small></div>
 			`;
 
 			// Add event to refresh button.


### PR DESCRIPTION
Part of #3813 (fix for legacy courses only)

### Changes proposed in this Pull Request

* This fix is for the legacy courses only. When we change the teacher, new modules are created for the new teacher, but the frontend checkboxes continue with the old values, causing issues if the user saves the post again. So the cleaner solution I found for legacy courses is preventing the user to update the modules until the next refresh, replacing the form by a message with a refresh button.

### Testing instructions

* Create 2 teachers.
* As a teacher, create a legacy course (without Sensei blocks).
* Add a module with a lesson.
* Check that the frontend shows the course with the module and the lesson.
* Log in as admin, and change the course teacher to the other teacher.
* Make sure you can't update the modules.
* Save the post again, and make sure the course continues working properly in the frontend with the module and the lesson.
* Click on "Refresh now", and make sure you can change the modules.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![Jan-05-2021 16-37-06](https://user-images.githubusercontent.com/876340/103691036-4ce7ea80-4f74-11eb-9386-fb9e9d367085.gif)
