### PR TITLE
Ensure exit survey is displayed after deactivating Sensei with WooCommerce Paid Courses

### DIFF
--- a/assets/admin/exit-survey/index.js
+++ b/assets/admin/exit-survey/index.js
@@ -13,7 +13,10 @@ import { render } from '@wordpress/element';
 
 		const deactivateLinks = [
 			getDeactivateLinkElement( 'sensei-lms' ),
-			getDeactivateLinkElement( 'woothemes-sensei' ),
+			getDeactivateLinkElement( 'sensei-with-woocommerce-paid-courses' ),
+			getDeactivateLinkElement(
+				'woocommerce-com-woocommerce-paid-courses'
+			),
 		].filter( ( e ) => !! e );
 
 		deactivateLinks.forEach( ( link ) => {


### PR DESCRIPTION
Fixes #3868.

### Changes proposed in this Pull Request

The exit survey wasn't displaying when deactivating Sensei with WooCommerce Paid Courses, because the `data-slug` attribute wasn't targeting the correct value. On my Local site, the slug was set to `woocommerce-com-woocommerce-paid-courses`. When I checked my sandbox site, it was set to `sensei-with-woocommerce-paid-courses`. To be safe, I've included both.

### Testing instructions

* Activate Sensei with WooCommerce Paid Courses.
* Execute `npm run build`.
* Unzip `sensei-lms.zip` and copy the extracted `sensei-lms` folder to `woothemes-sensei/plugins`.
* Deactivate SWCPC and ensure the exit survey appears and can be submitted or skipped.
* Check that the `paid` property of the `sensei_plugin_deactivate` Tracks events is set to `1`.