### PR TITLE
Restrict teacher to be able to access their own courses only

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2362,6 +2362,35 @@ class Sensei_Utils {
 	}
 
 	/**
+	 * Get the course id of the current post.
+	 *
+	 * @return int|null The course id or null if it was not found.
+	 */
+	public static function get_current_course() {
+		global $post;
+
+		$post_type = get_post_type( $post );
+		$course_id = null;
+
+		switch ( $post_type ) {
+			case 'course':
+				$course_id = $post->ID;
+				break;
+
+			case 'lesson':
+				$course_id = Sensei()->lesson->get_course_id( $post->ID );
+				break;
+
+			case 'quiz':
+				$lesson_id = (int) get_post_meta( $post->ID, '_quiz_lesson', true );
+				$course_id = $lesson_id ? Sensei()->lesson->get_course_id( $lesson_id ) : null;
+				break;
+		}
+
+		return $course_id ? $course_id : null;
+	}
+
+	/**
 	 * Restore the global WP_Query
 	 *
 	 * @since 1.9.0

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -44,7 +44,8 @@ function is_sensei() {
 }
 
 /**
- * Determine if a user is an admin that can access all of Sensei without restrictions.
+ * Determine if a user is an admin that can access all of Sensei without restrictions or if he is a teacher accessing
+ * his own course.
  *
  * @since 1.4.0
  * @since 3.0.0 Added `$user_id` argument. Preserves backward compatibility.

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -62,7 +62,18 @@ function sensei_all_access( $user_id = null ) {
 		return false;
 	}
 
-	$access = user_can( $user_id, 'manage_sensei' ) || user_can( $user_id, 'manage_sensei_grades' );
+	$access = false;
+
+	if ( user_can( $user_id, 'manage_sensei' ) ) {
+		$access = true;
+	} else {
+		$course_id = Sensei_Utils::get_current_course();
+
+		if ( $course_id ) {
+			$teacher = (int) get_post( $course_id )->post_author;
+			$access  = $user_id === $teacher;
+		}
+	}
 
 	if ( has_filter( 'sensei_all_access' ) ) {
 		// For backwards compatibility with filter, we temporarily need to change the current user.
@@ -285,29 +296,7 @@ function sensei_user_login_url() {
  * @return bool
  */
 function sensei_is_login_required() {
-	global $post;
-
-	$post_type = get_post_type( $post );
-	$course_id = null;
-
-	switch ( $post_type ) {
-		case 'course':
-			$course_id = $post->ID;
-			break;
-
-		case 'lesson':
-			$course_id = Sensei()->lesson->get_course_id( $post->ID );
-			break;
-
-		case 'quiz':
-			$lesson_id = intval( get_post_meta( $post->ID, '_quiz_lesson', true ) );
-			$course_id = $lesson_id ? Sensei()->lesson->get_course_id( $lesson_id ) : null;
-			break;
-	}
-
-	if ( ! $course_id ) {
-		$course_id = null;
-	}
+	$course_id = Sensei_Utils::get_current_course();
 
 	$login_required = isset( Sensei()->settings->settings['access_permission'] ) && ( true == Sensei()->settings->settings['access_permission'] );
 


### PR DESCRIPTION
Fixes #3120

### Changes proposed in this Pull Request

* Refactors `sensei_all_access` function to allow a teacher to access his own courses only.
* I checked all usages of `sensei_all_access` and didn't find any cases where this change would cause issues.
* Users can revert to the previous functionality by using the following snippet:
```
add_filter( 'sensei_user_all_access', function( $access, $user_id) {
	if ( user_can( $user_id, 'manage_sensei_grades') ) {
		return true;
	}

	return $access;
}, 10, 2);
```

### Testing instructions

* Create two courses with two different teachers.
* Try to access the courses with both teachers.
* Observe that each teacher is able to access his own courses only.