### PR TITLE
Replace my courses login form with standard Wordpress login form

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -75,7 +75,7 @@ class Sensei_Frontend {
 		add_action( 'sensei_lesson_meta', array( $this, 'sensei_lesson_meta' ), 10 );
 		add_action( 'wp', array( $this, 'sensei_course_start' ), 10 );
 		add_filter( 'wp_login_failed', array( $this, 'sensei_login_fail_redirect' ), 10 );
-		add_filter( 'init', array( $this, 'sensei_handle_login_request' ), 10 );
+		add_filter( 'login_form_middle', array( $this, 'sensei_login_form_flag_field' ), 10, 2 );
 		add_action( 'init', array( $this, 'sensei_process_registration' ), 2 );
 
 		add_action( 'sensei_pagination', array( $this, 'sensei_breadcrumb' ), 80, 1 );
@@ -1450,10 +1450,8 @@ class Sensei_Frontend {
 
 		// if not posted from the sensei login form let
 		// WordPress or any other party handle the failed request.
-		if ( ! isset( $_REQUEST['form'] ) || 'sensei-login' != $_REQUEST['form'] ) {
-
+		if ( ! isset( $_REQUEST['sensei-login'] ) ) {
 			return;
-
 		}
 
 		// Get the reffering page, where did the post submission come from?
@@ -1465,7 +1463,27 @@ class Sensei_Frontend {
 			wp_redirect( esc_url_raw( add_query_arg( 'login', 'failed', $referrer ) ) );
 			exit;
 		}
-	}//end sensei_login_fail_redirect()
+	}
+
+	/**
+	 * Add a 'sensei-login' hidden field to the Sensei login form so the request can be identified and redirected properly.
+	 *
+	 * @access private
+	 * @hooked login_form_middle
+	 * @since 3.7.0
+	 *
+	 * @param string $content Form middle HTML.
+	 * @param array  $args    wp_login_form arguments.
+	 *
+	 * @return string
+	 */
+	public function sensei_login_form_flag_field( $content, $args ) {
+		if ( ! empty( $args ) && isset( $args['sensei-login'] ) ) {
+			$content .= '<input type="hidden" name="sensei-login" value="1" />';
+		}
+
+		return $content;
+	}
 
 	/**
 	 * Handle the login reques from all sensei intiated login forms.

--- a/templates/user/login-form.php
+++ b/templates/user/login-form.php
@@ -25,7 +25,7 @@ do_action( 'sensei_login_form_before' );
 
 <h2><?php esc_html_e( 'Login', 'sensei-lms' ); ?></h2>
 
-<?php wp_login_form(); ?>
+<?php wp_login_form( [ 'sensei-login' => true ] ); ?>
 
 <a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'sensei-lms' ); ?></a>
 

--- a/templates/user/login-form.php
+++ b/templates/user/login-form.php
@@ -20,84 +20,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.9.0
  */
 do_action( 'sensei_login_form_before' );
+
 ?>
 
 <h2><?php esc_html_e( 'Login', 'sensei-lms' ); ?></h2>
 
-<form method="post" name="sensi-login-form" id="loginform" class="login sensei">
+<?php wp_login_form(); ?>
 
-	<?php
-	/**
-	 *  Executes inside the sensei login form before all the default fields.
-	 *
-	 * @since 1.6.2
-	 */
-		do_action( 'sensei_login_form_inside_before' );
-	?>
-
-	<p class="sensei-login-username form-row form-row-wide">
-
-				<label for="sensei_user_login"><?php esc_html_e( 'Username or Email', 'sensei-lms' ); ?> </label>
-
-				<input type="text" name="log" id="sensei_user_login" class="input" value="" size="20">
-
-	</p>
-
-	<p class="sensei-login-password form-row form-row-wide">
-
-				<label for="sensei_user_pass"> <?php esc_html_e( 'Password', 'sensei-lms' ); ?>  </label>
-
-				<input type="password" name="pwd" id="sensei_user_pass" class="input txt text" value="" size="20">
-
-	</p>
-
-	<?php
-	/**
-	 *  Executes inside the sensei login form after the password field.
-	 *
-	 *  You can use the action to add extra form login fields.
-	 *
-	 * @since 1.6.2
-	 */
-		do_action( 'sensei_login_form_inside_after_password_field' );
-	?>
-
-	<p class='sensei-login-submit'>
-
-		<input type="submit" class="button" name="login" value="<?php esc_attr_e( 'Login', 'sensei-lms' ); ?>" />
-
-		<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'sensei-lms' ); ?></a>
-
-	</p>
-
-	<p class='remember_me' >
-
-		<label for="rememberme" class="inline">
-
-			<input name="rememberme" type="checkbox" id="rememberme" value="forever" /> <?php esc_html_e( 'Remember me', 'sensei-lms' ); ?>
-
-		</label>
-
-	</p>
-
-	<?php
-	/**
-	 *  Executes inside the sensei login form after all the default fields.
-	 *
-	 * @since 1.6.2
-	 */
-		do_action( 'sensei_login_form_inside_after' );
-	?>
-
-	<?php wp_nonce_field( 'sensei-login' ); ?>
-
-	<input type="hidden" name="redirect" value="<?php echo esc_url_raw( sensei_get_current_page_url() ); ?>" />
-
-	<input type="hidden" name="form" value="sensei-login" />
-
-	<div class="clear"></div>
-
-</form>
+<a href="<?php echo esc_url( wp_lostpassword_url() ); ?>"><?php esc_html_e( 'Lost your password?', 'sensei-lms' ); ?></a>
 
 <?php
 /**


### PR DESCRIPTION
Fixes #3312

### Changes proposed in this Pull Request

* Use `wp_login_form` to render login form in My Courses page

### TODO 

- [x] Handle wrong password redirect (#407)
- [ ] Display error messages on failed attempt

### Testing instructions

* Visit the My Courses page and use the login form

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### Removed Hooks

These hooks are removed in favor of their core counterparts:

* `sensei_login_form_inside_before` -> `login_form_top`
* `sensei_login_form_inside_after_password_field` -> `login_form_middle`
* `sensei_login_form_inside_after` -> `login_form_bottom`

We could also just deprecate them, and set it up so they are still called from these core hooks, but that might do more harm if the user added callbacks to both the sensei login and core login hooks. 

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
