### PR TITLE
Add WCPC installation notice

### DIFF
--- a/assets/css/admin-custom.css
+++ b/assets/css/admin-custom.css
@@ -114,28 +114,6 @@ div.question_boolean_fields { margin-bottom: 10px; }
     padding-left: 0.5em;
 }
 
-.sensei-wcpc-notice {
-	display: flex;
-	align-items: center;
-}
-.sensei-wcpc-notice .sensei-wcpc-notice__text {
-	flex: 1;
-	padding-right: 20px;
-}
-.sensei-wcpc-notice .sensei-wcpc-notice__dismissible-link {
-	margin-left: 10px;
-	text-decoration: none;
-	color: #72777c;
-}
-.sensei-wcpc-notice .sensei-wcpc-notice__dismissible-link:hover {
-	color: #c00;
-}
-.sensei-wcpc-notice .sensei-wcpc-notice__dismissible-link::before {
-	content: "\f335";
-	display: block;
-	width: 20px;
-	height: 20px;
-	font: normal 20px/20px dashicons;
-	text-align: center;
-	color: inherit;
+.sensei-dismissible-link {
+    text-decoration: none;
 }

--- a/assets/css/admin-custom.css
+++ b/assets/css/admin-custom.css
@@ -113,3 +113,29 @@ div.question_boolean_fields { margin-bottom: 10px; }
     margin-bottom: 2em !important;
     padding-left: 0.5em;
 }
+
+.sensei-wcpc-notice {
+	display: flex;
+	align-items: center;
+}
+.sensei-wcpc-notice .sensei-wcpc-notice__text {
+	flex: 1;
+	padding-right: 20px;
+}
+.sensei-wcpc-notice .sensei-wcpc-notice__dismissible-link {
+	margin-left: 10px;
+	text-decoration: none;
+	color: #72777c;
+}
+.sensei-wcpc-notice .sensei-wcpc-notice__dismissible-link:hover {
+	color: #c00;
+}
+.sensei-wcpc-notice .sensei-wcpc-notice__dismissible-link::before {
+	content: "\f335";
+	display: block;
+	width: 20px;
+	height: 20px;
+	font: normal 20px/20px dashicons;
+	text-align: center;
+	color: inherit;
+}

--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -33,5 +33,3 @@ body #menu-posts-question div.wp-menu-image:before {
 li.menu-icon-lesson .wp-menu-image img, li.menu-icon-course .wp-menu-image img { display: none; }
 
 .edit-php.post-type-quiz .add-new-h2 { display: none; }
-
-.sensei-dismissible-link { text-decoration: none; }

--- a/assets/css/global.css
+++ b/assets/css/global.css
@@ -33,3 +33,5 @@ body #menu-posts-question div.wp-menu-image:before {
 li.menu-icon-lesson .wp-menu-image img, li.menu-icon-course .wp-menu-image img { display: none; }
 
 .edit-php.post-type-quiz .add-new-h2 { display: none; }
+
+.sensei-dismissible-link { text-decoration: none; }

--- a/includes/admin/class-sensei-plugins-installation.php
+++ b/includes/admin/class-sensei-plugins-installation.php
@@ -196,6 +196,31 @@ class Sensei_Plugins_Installation {
 	}
 
 	/**
+	 * Get plugin path if it's installed, otherwise returns null.
+	 *
+	 * @since 3.7.0
+	 *
+	 * @param string $plugin_file       Plugin filename or path.
+	 * @param array  $installed_plugins Installed plugins. If it's not passed, it will get the installed plugins.
+	 *
+	 * @return string|null Plugin path or null if plugin is not installed.
+	 */
+	public function get_installed_plugin_path( $plugin_file, $installed_plugins = null ) {
+		if ( ! $installed_plugins ) {
+			$installed_plugins = $this->get_installed_plugins();
+		}
+
+		// Get filename if it is the complete path.
+		$plugin_file = $this->get_file_name_from_path( $plugin_file );
+
+		if ( ! isset( $installed_plugins[ $plugin_file ] ) ) {
+			return null;
+		}
+
+		return $installed_plugins[ $plugin_file ];
+	}
+
+	/**
 	 * Check whether plugin is active.
 	 *
 	 * @param string $plugin_file       Plugin filename or path.
@@ -208,14 +233,13 @@ class Sensei_Plugins_Installation {
 			$installed_plugins = $this->get_installed_plugins();
 		}
 
-		// Get filename if it is the complete path.
-		$plugin_file = $this->get_file_name_from_path( $plugin_file );
+		$plugin_path = $this->get_installed_plugin_path( $plugin_file );
 
-		if ( ! isset( $installed_plugins[ $plugin_file ] ) ) {
+		if ( null === $plugin_path ) {
 			return false;
 		}
 
-		return is_plugin_active( $installed_plugins[ $plugin_file ] );
+		return is_plugin_active( $plugin_path );
 	}
 
 	/**

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -540,17 +540,11 @@ class Sensei_Setup_Wizard {
 			}
 		}
 
-		if ( Sensei()->usage_tracking->is_tracking_enabled() && ! empty( $wccom_extensions ) ) {
+		if ( ! empty( $wccom_extensions ) ) {
 			$event_name       = 'setup_wizard_features_install_paid';
 			$event_properties = [ 'slug' => join( ',', $wccom_extensions ) ];
 
-			if ( class_exists( 'Automattic\Jetpack\Tracking' ) ) {
-				$jetpack_connection = Jetpack::connection();
-				if ( $jetpack_connection->is_user_connected() ) {
-					$tracking = new Automattic\Jetpack\Tracking( 'sensei', $jetpack_connection );
-					$tracking->record_user_event( $event_name, $event_properties );
-				}
-			}
+			sensei_log_jetpack_event( $event_name, $event_properties );
 		}
 
 		set_transient( self::WCCOM_INSTALLING_TRANSIENT, $wccom_extensions, 10 * 60 );

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -20,7 +20,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Setup_Wizard {
 	const SUGGEST_SETUP_WIZARD_OPTION = 'sensei_suggest_setup_wizard';
-	const WC_INFORMATION_TRANSIENT    = 'sensei_woocommerce_plugin_information';
 	const WCCOM_INSTALLING_TRANSIENT  = 'sensei_setup_wizard_wccom_installing';
 	const USER_DATA_OPTION            = 'sensei_setup_wizard_data';
 	const MC_LIST_ID                  = '4fa225a515';
@@ -451,7 +450,7 @@ class Sensei_Setup_Wizard {
 			$wc_params = WC_Admin_Addons::get_in_app_purchase_url_params();
 
 		} else {
-			$wc_info = $this->get_woocommerce_information();
+			$wc_info = Sensei_Utils::get_woocommerce_plugin_information();
 
 			$wc_params = [
 				'wccom-site'          => site_url(),
@@ -498,70 +497,6 @@ class Sensei_Setup_Wizard {
 	}
 
 	/**
-	 * Get WooCommerce data.
-	 *
-	 * @return array WooCommerce information.
-	 */
-	private function get_woocommerce_information() {
-		$wc_information = get_transient( self::WC_INFORMATION_TRANSIENT );
-
-		if ( false !== $wc_information ) {
-			return $wc_information;
-		}
-
-		if ( ! function_exists( 'plugins_api' ) ) {
-			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
-		}
-
-		$wc_slug            = 'woocommerce';
-		$plugin_information = plugins_api(
-			'plugin_information',
-			[
-				'slug'   => $wc_slug,
-				'fields' => [
-					'short_description' => true,
-					'description'       => false,
-					'sections'          => false,
-					'tested'            => false,
-					'requires'          => false,
-					'requires_php'      => false,
-					'rating'            => false,
-					'ratings'           => false,
-					'downloaded'        => false,
-					'downloadlink'      => false,
-					'last_updated'      => false,
-					'added'             => false,
-					'tags'              => false,
-					'compatibility'     => false,
-					'homepage'          => false,
-					'versions'          => false,
-					'donate_link'       => false,
-					'reviews'           => false,
-					'banners'           => false,
-					'icons'             => false,
-					'active_installs'   => false,
-					'group'             => false,
-					'contributors'      => false,
-				],
-			]
-		);
-
-		$wc_information = (object) [
-			'product_slug' => $wc_slug,
-			'title'        => $plugin_information->name,
-			'excerpt'      => $plugin_information->short_description,
-			'plugin_file'  => 'woocommerce/woocommerce.php',
-			'link'         => 'https://wordpress.org/plugins/' . $wc_slug,
-			'unselectable' => true,
-			'version'      => $plugin_information->version,
-		];
-
-		set_transient( self::WC_INFORMATION_TRANSIENT, $wc_information, DAY_IN_SECONDS );
-
-		return $wc_information;
-	}
-
-	/**
 	 * Get Sensei extensions for setup wizard.
 	 *
 	 * @param boolean $clear_active_plugins_cache Clear cache for `is_plugin_active`.
@@ -576,7 +511,7 @@ class Sensei_Setup_Wizard {
 		$extensions = Sensei_Extensions::instance()->get_extensions( 'plugin', 'setup-wizard-extensions' );
 
 		// Add WooCommerce.
-		array_push( $extensions, $this->get_woocommerce_information() );
+		array_push( $extensions, Sensei_Utils::get_woocommerce_plugin_information() );
 
 		$installing_plugins = Sensei_Plugins_Installation::instance()->get_installing_plugins();
 		$selected_plugins   = $this->get_wizard_user_data( 'features' )['selected'];

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -439,30 +439,13 @@ class Sensei_Setup_Wizard {
 	/**
 	 * Get data used for WooCommerce.com purchase redirect for feature installation.
 	 *
+	 * @deprecated 3.7.0
 	 * @return array The data.
 	 */
 	public function get_woocommerce_connect_data() {
+		_deprecated_function( __METHOD__, '3.7.0', 'Sensei_Utils::get_woocommerce_connect_data' );
 
-		$wc_params                = [];
-		$is_woocommerce_installed = Sensei_Utils::is_woocommerce_active( '3.7.0' ) && class_exists( 'WC_Admin_Addons' );
-
-		if ( $is_woocommerce_installed ) {
-			$wc_params = WC_Admin_Addons::get_in_app_purchase_url_params();
-
-		} else {
-			$wc_info = Sensei_Utils::get_woocommerce_plugin_information();
-
-			$wc_params = [
-				'wccom-site'          => site_url(),
-				'wccom-woo-version'   => $wc_info->version,
-				'wccom-connect-nonce' => wp_create_nonce( 'connect' ),
-			];
-		}
-
-		$wc_params['wccom-back'] = rawurlencode( 'admin.php' );
-
-		return $wc_params;
-
+		return Sensei_Utils::get_woocommerce_connect_data();
 	}
 
 	/**

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -43,7 +43,7 @@ class Sensei_WCPC_Prompt {
 
 		?>
 		<div class="notice notice-info is-dismissible">
-			<p><?php esc_html_e( 'Sell and monetize your courses by installing a WooCommerce extension.', 'sensei-lms' ); ?> <a href="https://woocommerce.com/products/woocommerce-paid-courses/" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Learn more', 'sensei-lms' ); ?></a></p>
+			<p><?php esc_html_e( 'Sell and monetize your courses by installing a WooCommerce extension.', 'sensei-lms' ); ?> <a href="https://woocommerce.com/products/woocommerce-paid-courses/" target="_blank" rel="noopener noreferrer" data-sensei-log-event="wcpc_upgrade_learn_more"><?php esc_html_e( 'Learn more', 'sensei-lms' ); ?></a></p>
 			<p><a href="<?php echo esc_url( $install_url ); ?>" class="button-primary"><?php esc_html_e( 'Install now', 'sensei-lms' ); ?></a></p>
 			<a href="<?php echo esc_url( $dismiss_url ); ?>" class="notice-dismiss sensei-dismissible-link">
 				<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'sensei-lms' ); ?></span>

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -32,11 +32,7 @@ class Sensei_WCPC_Prompt {
 	 * @access private
 	 */
 	public function wcpc_prompt() {
-		if (
-			get_option( self::DISMISS_PROMPT_OPTION, 0 )
-			|| ! Sensei_Utils::is_woocommerce_active()
-			|| ! current_user_can( 'manage_sensei' )
-		) {
+		if ( ! $this->should_show_prompt() ) {
 			return;
 		}
 
@@ -52,6 +48,30 @@ class Sensei_WCPC_Prompt {
 			</a>
 		</div>
 		<?php
+	}
+
+	/**
+	 * If should show prompt in the context contitions.
+	 *
+	 * @return boolean
+	 */
+	private function should_show_prompt() {
+		if (
+			// Not edit course page.
+			'edit-course' !== get_current_screen()->id
+			// No published course.
+			|| 0 === wp_count_posts( 'course' )->publish
+			// Sensei_WC_Paid_Courses class exists.
+			|| class_exists( 'Sensei_WC_Paid_Courses\Sensei_WC_Paid_Courses' )
+			// WooCommerce is not active.
+			|| ! Sensei_Utils::is_woocommerce_active()
+			// User is not admin.
+			|| ! current_user_can( 'manage_sensei' )
+		) {
+			return false;
+		}
+
+		return 0 === get_option( self::DISMISS_PROMPT_OPTION, 0 );
 	}
 
 	/**

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -43,15 +43,25 @@ class Sensei_WCPC_Prompt {
 		$install_url = add_query_arg( 'sensei_wcpc_prompt_install', '1' );
 		$install_url = wp_nonce_url( $install_url, 'sensei_wcpc_prompt_install' );
 
+		$link = '<a href="https://woocommerce.com/products/woocommerce-paid-courses/" target="_blank" rel="noopener noreferrer" data-sensei-log-event="wcpc_upgrade_learn_more">' . __( 'WooCommerce Paid Courses extension', 'sensei-lms' ) . '</a>';
+
 		?>
-		<div class="notice notice-info is-dismissible">
-			<p>
-				<?php esc_html_e( 'Monetize and sell your courses by installing the WooCommerce Paid Courses extension.', 'sensei-lms' ); ?>
-				<a href="https://woocommerce.com/products/woocommerce-paid-courses/" target="_blank" rel="noopener noreferrer" data-sensei-log-event="wcpc_upgrade_learn_more"><?php esc_html_e( 'Learn more', 'sensei-lms' ); ?></a>
-				<?php esc_html_e( 'or', 'sensei-lms' ); ?>
-				<a href="<?php echo esc_url( $install_url ); ?>" class="button-primary" data-sensei-log-event="wcpc_upgrade_install"><?php esc_html_e( 'Install now', 'sensei-lms' ); ?></a>
+		<div class="sensei-wcpc-notice notice notice-info">
+			<p class="sensei-wcpc-notice__text">
+				<?php
+					echo sprintf(
+						// translators: Placeholder is the learn more link.
+						esc_html__( 'Monetize and sell your courses by installing the %s.', 'sensei-lms' ),
+						wp_kses_post( $link )
+					);
+				?>
 			</p>
-			<a href="<?php echo esc_url( $dismiss_url ); ?>" class="notice-dismiss sensei-dismissible-link">
+			<p>
+				<a href="<?php echo esc_url( $install_url ); ?>" class="button-primary" data-sensei-log-event="wcpc_upgrade_install">
+					<?php esc_html_e( 'Install extension', 'sensei-lms' ); ?>
+				</a>
+			</p>
+			<a href="<?php echo esc_url( $dismiss_url ); ?>" class="sensei-wcpc-notice__dismissible-link">
 				<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'sensei-lms' ); ?></span>
 			</a>
 		</div>

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -40,7 +40,7 @@ class Sensei_WCPC_Prompt {
 		$dismiss_url = wp_nonce_url( $dismiss_url, 'sensei_dismiss_wcpc_prompt' );
 
 		$install_url = 'https://woocommerce.com/cart';
-		$install_url = add_query_arg( Sensei_Setup_Wizard::instance()->get_woocommerce_connect_data(), $install_url );
+		$install_url = add_query_arg( Sensei_Utils::get_woocommerce_connect_data(), $install_url );
 		$install_url = add_query_arg(
 			[
 				'wccom-replace-with' => $this->get_wcpc_wccom_product_id(),

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -39,15 +39,7 @@ class Sensei_WCPC_Prompt {
 		$dismiss_url = add_query_arg( 'sensei_dismiss_wcpc_prompt', '1' );
 		$dismiss_url = wp_nonce_url( $dismiss_url, 'sensei_dismiss_wcpc_prompt' );
 
-		$install_url = 'https://woocommerce.com/cart';
-		$install_url = add_query_arg( Sensei_Utils::get_woocommerce_connect_data(), $install_url );
-		$install_url = add_query_arg(
-			[
-				'wccom-replace-with' => $this->get_wcpc_wccom_product_id(),
-				'wccom-back'         => rawurlencode( 'plugins.php' ),
-			],
-			$install_url
-		);
+		$install_url = $this->get_wcpc_install_url();
 
 		?>
 		<div class="notice notice-info is-dismissible">
@@ -61,22 +53,43 @@ class Sensei_WCPC_Prompt {
 	}
 
 	/**
+	 * Get WCPC install URL.
+	 *
+	 * @access private
+	 *
+	 * @return string WCPC install URL.
+	 */
+	protected function get_wcpc_install_url() {
+		$install_url = 'https://woocommerce.com/cart';
+		$install_url = add_query_arg( Sensei_Utils::get_woocommerce_connect_data(), $install_url );
+		$install_url = add_query_arg(
+			[
+				'wccom-replace-with' => $this->get_wcpc_wccom_product_id(),
+				'wccom-back'         => rawurlencode( 'plugins.php' ),
+			],
+			$install_url
+		);
+
+		return $install_url;
+	}
+
+	/**
 	 * If should show prompt in the context contitions.
 	 *
 	 * @return boolean
 	 */
 	private function should_show_prompt() {
 		if (
+			// User is not admin.
+			! current_user_can( 'manage_sensei' )
 			// Not edit course page.
-			'edit-course' !== get_current_screen()->id
+			|| 'edit-course' !== get_current_screen()->id
 			// No published course.
 			|| 0 === wp_count_posts( 'course' )->publish
 			// Sensei_WC_Paid_Courses class exists.
 			|| class_exists( 'Sensei_WC_Paid_Courses\Sensei_WC_Paid_Courses' )
 			// WooCommerce is not active.
 			|| ! Sensei_Utils::is_woocommerce_active()
-			// User is not admin.
-			|| ! current_user_can( 'manage_sensei' )
 		) {
 			return false;
 		}

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * File containing Sensei_WCPC_Prompt class.
+ *
+ * @package Sensei\Admin
+ * @since   3.7.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Exit survey upon plugin deactivation.
+ *
+ * @since 3.7.0
+ */
+class Sensei_WCPC_Prompt {
+	const DISMISS_PROMPT_OPTION = 'sensei_dismiss_wcpc_prompt';
+
+	/**
+	 * Sensei_WCPC_Prompt constructor.
+	 */
+	public function __construct() {
+		add_action( 'admin_notices', [ $this, 'wcpc_prompt' ] );
+		add_action( 'admin_init', [ $this, 'dismiss_prompt' ] );
+	}
+
+	/**
+	 * WooCommerce Paid Courses plugin prompt.
+	 *
+	 * @access private
+	 */
+	public function wcpc_prompt() {
+		if (
+			get_option( self::DISMISS_PROMPT_OPTION, 0 )
+			|| ! Sensei_Utils::is_woocommerce_active()
+			|| ! current_user_can( 'manage_sensei' )
+		) {
+			return;
+		}
+
+		$dismiss_url = add_query_arg( 'sensei_dismiss_wcpc_prompt', '1' );
+		$dismiss_url = wp_nonce_url( $dismiss_url, 'sensei_dismiss_wcpc_prompt' );
+
+		?>
+		<div class="notice notice-info is-dismissible">
+			<p><?php esc_html_e( 'Sell and monetize your courses by installing a WooCommerce extension.', 'sensei-lms' ); ?> <a href="https://woocommerce.com/products/woocommerce-paid-courses/" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Learn more', 'sensei-lms' ); ?></a></p>
+			<p><a href="#" class="button-primary"><?php esc_html_e( 'Install now', 'sensei-lms' ); ?></a></p>
+			<a href="<?php echo esc_url( $dismiss_url ); ?>" class="notice-dismiss sensei-dismissible-link">
+				<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'sensei-lms' ); ?></span>
+			</a>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Dismiss WCPC prompt.
+	 *
+	 * @access private
+	 */
+	public function dismiss_prompt() {
+		if (
+			isset( $_GET['sensei_dismiss_wcpc_prompt'] )
+			&& '1' === $_GET['sensei_dismiss_wcpc_prompt']
+			&& isset( $_GET['_wpnonce'] )
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Don't touch the nonce.
+			&& wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'sensei_dismiss_wcpc_prompt' )
+			&& current_user_can( 'manage_sensei' )
+		) {
+			update_option( self::DISMISS_PROMPT_OPTION, 1 );
+		}
+	}
+}

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -43,8 +43,17 @@ class Sensei_WCPC_Prompt {
 
 		?>
 		<div class="notice notice-info is-dismissible">
-			<p><?php esc_html_e( 'Sell and monetize your courses by installing a WooCommerce extension.', 'sensei-lms' ); ?> <a href="https://woocommerce.com/products/woocommerce-paid-courses/" target="_blank" rel="noopener noreferrer" data-sensei-log-event="wcpc_upgrade_learn_more"><?php esc_html_e( 'Learn more', 'sensei-lms' ); ?></a></p>
-			<p><a href="<?php echo esc_url( $install_url ); ?>" class="button-primary"><?php esc_html_e( 'Install now', 'sensei-lms' ); ?></a></p>
+			<p>
+				<?php esc_html_e( 'Sell and monetize your courses by installing a WooCommerce extension.', 'sensei-lms' ); ?>
+				<a href="https://woocommerce.com/products/woocommerce-paid-courses/" target="_blank" rel="noopener noreferrer" data-sensei-log-event="wcpc_upgrade_learn_more">
+					<?php esc_html_e( 'Learn more', 'sensei-lms' ); ?>
+				</a>
+			</p>
+			<p>
+				<a href="<?php echo esc_url( $install_url ); ?>" class="button-primary">
+					<?php esc_html_e( 'Install now', 'sensei-lms' ); ?>
+				</a>
+			</p>
 			<a href="<?php echo esc_url( $dismiss_url ); ?>" class="notice-dismiss sensei-dismissible-link">
 				<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'sensei-lms' ); ?></span>
 			</a>

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Exit survey upon plugin deactivation.
+ * WCPC prompt to install the Paid Courses plugin.
  *
  * @since 3.7.0
  */

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -46,8 +46,8 @@ class Sensei_WCPC_Prompt {
 		$link = '<a href="https://woocommerce.com/products/woocommerce-paid-courses/" target="_blank" rel="noopener noreferrer" data-sensei-log-event="wcpc_upgrade_learn_more">' . __( 'WooCommerce Paid Courses extension', 'sensei-lms' ) . '</a>';
 
 		?>
-		<div class="sensei-wcpc-notice notice notice-info">
-			<p class="sensei-wcpc-notice__text">
+		<div class="notice notice-info is-dismissible">
+			<p>
 				<?php
 					echo sprintf(
 						// translators: Placeholder is the learn more link.
@@ -61,7 +61,7 @@ class Sensei_WCPC_Prompt {
 					<?php esc_html_e( 'Install extension', 'sensei-lms' ); ?>
 				</a>
 			</p>
-			<a href="<?php echo esc_url( $dismiss_url ); ?>" class="sensei-wcpc-notice__dismissible-link">
+			<a href="<?php echo esc_url( $dismiss_url ); ?>" class="notice-dismiss sensei-dismissible-link">
 				<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'sensei-lms' ); ?></span>
 			</a>
 		</div>

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -97,7 +97,7 @@ class Sensei_WCPC_Prompt {
 			return false;
 		}
 
-		return 0 === get_option( self::DISMISS_PROMPT_OPTION, 0 );
+		return '0' === get_option( self::DISMISS_PROMPT_OPTION, '0' );
 	}
 
 	/**

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -39,10 +39,20 @@ class Sensei_WCPC_Prompt {
 		$dismiss_url = add_query_arg( 'sensei_dismiss_wcpc_prompt', '1' );
 		$dismiss_url = wp_nonce_url( $dismiss_url, 'sensei_dismiss_wcpc_prompt' );
 
+		$install_url = 'https://woocommerce.com/cart';
+		$install_url = add_query_arg( Sensei_Setup_Wizard::instance()->get_woocommerce_connect_data(), $install_url );
+		$install_url = add_query_arg(
+			[
+				'wccom-replace-with' => $this->get_wcpc_wccom_product_id(),
+				'wccom-back'         => rawurlencode( 'plugins.php' ),
+			],
+			$install_url
+		);
+
 		?>
 		<div class="notice notice-info is-dismissible">
 			<p><?php esc_html_e( 'Sell and monetize your courses by installing a WooCommerce extension.', 'sensei-lms' ); ?> <a href="https://woocommerce.com/products/woocommerce-paid-courses/" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Learn more', 'sensei-lms' ); ?></a></p>
-			<p><a href="#" class="button-primary"><?php esc_html_e( 'Install now', 'sensei-lms' ); ?></a></p>
+			<p><a href="<?php echo esc_url( $install_url ); ?>" class="button-primary"><?php esc_html_e( 'Install now', 'sensei-lms' ); ?></a></p>
 			<a href="<?php echo esc_url( $dismiss_url ); ?>" class="notice-dismiss sensei-dismissible-link">
 				<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'sensei-lms' ); ?></span>
 			</a>
@@ -72,6 +82,25 @@ class Sensei_WCPC_Prompt {
 		}
 
 		return 0 === get_option( self::DISMISS_PROMPT_OPTION, 0 );
+	}
+
+	/**
+	 * Get WCPC WCCom product ID.
+	 *
+	 * @return string
+	 */
+	private function get_wcpc_wccom_product_id() {
+		$extensions = Sensei_Extensions::instance()->get_extensions( 'plugin' );
+
+		$wcpc_wccom_product_id = '';
+		foreach ( $extensions as $extension ) {
+			if ( 'sensei-wc-paid-courses' === $extension->product_slug ) {
+				$wcpc_wccom_product_id = $extension->wccom_product_id;
+				break;
+			}
+		}
+
+		return $wcpc_wccom_product_id;
 	}
 
 	/**

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -44,15 +44,10 @@ class Sensei_WCPC_Prompt {
 		?>
 		<div class="notice notice-info is-dismissible">
 			<p>
-				<?php esc_html_e( 'Sell and monetize your courses by installing a WooCommerce extension.', 'sensei-lms' ); ?>
-				<a href="https://woocommerce.com/products/woocommerce-paid-courses/" target="_blank" rel="noopener noreferrer" data-sensei-log-event="wcpc_upgrade_learn_more">
-					<?php esc_html_e( 'Learn more', 'sensei-lms' ); ?>
-				</a>
-			</p>
-			<p>
-				<a href="<?php echo esc_url( $install_url ); ?>" class="button-primary">
-					<?php esc_html_e( 'Install now', 'sensei-lms' ); ?>
-				</a>
+				<?php esc_html_e( 'Monetize and sell your courses by installing the WooCommerce Paid Courses extension.', 'sensei-lms' ); ?>
+				<a href="https://woocommerce.com/products/woocommerce-paid-courses/" target="_blank" rel="noopener noreferrer" data-sensei-log-event="wcpc_upgrade_learn_more"><?php esc_html_e( 'Learn more', 'sensei-lms' ); ?></a>
+				<?php esc_html_e( 'or', 'sensei-lms' ); ?>
+				<a href="<?php echo esc_url( $install_url ); ?>" class="button-primary" data-sensei-log-event="wcpc_upgrade_install"><?php esc_html_e( 'Install now', 'sensei-lms' ); ?></a>
 			</p>
 			<a href="<?php echo esc_url( $dismiss_url ); ?>" class="notice-dismiss sensei-dismissible-link">
 				<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'sensei-lms' ); ?></span>

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -113,6 +113,7 @@ class Sensei_Autoloader {
 			'Sensei_Learner_Management'                  => 'admin/class-sensei-learner-management.php',
 			'Sensei_Extensions'                          => 'admin/class-sensei-extensions.php',
 			'Sensei_Exit_Survey'                         => 'admin/class-sensei-exit-survey.php',
+			'Sensei_WCPC_Prompt'                         => 'admin/class-sensei-wcpc-prompt.php',
 			'Sensei_Learners_Admin_Bulk_Actions_Controller' => 'admin/class-sensei-learners-admin-bulk-actions-controller.php',
 			'Sensei_Learners_Admin_Bulk_Actions_View'    => 'admin/class-sensei-learners-admin-bulk-actions-view.php',
 			'Sensei_Learners_Main'                       => 'admin/class-sensei-learners-main.php',

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -83,6 +83,7 @@ class Sensei_Data_Cleaner {
 		'widget_sensei_lesson_component',
 		'widget_sensei_course_categories',
 		'widget_sensei_category_courses',
+		'sensei_dismiss_wcpc_prompt',
 	);
 
 	/**

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2556,6 +2556,33 @@ class Sensei_Utils {
 	}
 
 	/**
+	 * Get data used for WooCommerce.com purchase redirect.
+	 *
+	 * @return array The data.
+	 */
+	public static function get_woocommerce_connect_data() {
+		$wc_params                = [];
+		$is_woocommerce_installed = self::is_woocommerce_active( '3.7.0' ) && class_exists( 'WC_Admin_Addons' );
+
+		if ( $is_woocommerce_installed ) {
+			$wc_params = WC_Admin_Addons::get_in_app_purchase_url_params();
+
+		} else {
+			$wc_info = self::get_woocommerce_plugin_information();
+
+			$wc_params = [
+				'wccom-site'          => site_url(),
+				'wccom-woo-version'   => $wc_info->version,
+				'wccom-connect-nonce' => wp_create_nonce( 'connect' ),
+			];
+		}
+
+		$wc_params['wccom-back'] = rawurlencode( 'admin.php' );
+
+		return $wc_params;
+	}
+
+	/**
 	 * Hard - Resets a Learner's Course Progress
 	 *
 	 * @param $course_id int

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -14,6 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 class Sensei_Utils {
+	const WC_INFORMATION_TRANSIENT = 'sensei_woocommerce_plugin_information';
+
 	/**
 	 * Get the placeholder thumbnail image.
 	 *
@@ -2489,6 +2491,69 @@ class Sensei_Utils {
 		return true;
 	}
 
+	/**
+	 * Get WooCommerce plugin information.
+	 *
+	 * @return array WooCommerce information.
+	 */
+	public static function get_woocommerce_plugin_information() {
+		$wc_information = get_transient( self::WC_INFORMATION_TRANSIENT );
+
+		if ( false !== $wc_information ) {
+			return $wc_information;
+		}
+
+		if ( ! function_exists( 'plugins_api' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+		}
+
+		$wc_slug            = 'woocommerce';
+		$plugin_information = plugins_api(
+			'plugin_information',
+			[
+				'slug'   => $wc_slug,
+				'fields' => [
+					'short_description' => true,
+					'description'       => false,
+					'sections'          => false,
+					'tested'            => false,
+					'requires'          => false,
+					'requires_php'      => false,
+					'rating'            => false,
+					'ratings'           => false,
+					'downloaded'        => false,
+					'downloadlink'      => false,
+					'last_updated'      => false,
+					'added'             => false,
+					'tags'              => false,
+					'compatibility'     => false,
+					'homepage'          => false,
+					'versions'          => false,
+					'donate_link'       => false,
+					'reviews'           => false,
+					'banners'           => false,
+					'icons'             => false,
+					'active_installs'   => false,
+					'group'             => false,
+					'contributors'      => false,
+				],
+			]
+		);
+
+		$wc_information = (object) [
+			'product_slug' => $wc_slug,
+			'title'        => $plugin_information->name,
+			'excerpt'      => $plugin_information->short_description,
+			'plugin_file'  => 'woocommerce/woocommerce.php',
+			'link'         => 'https://wordpress.org/plugins/' . $wc_slug,
+			'unselectable' => true,
+			'version'      => $plugin_information->version,
+		];
+
+		set_transient( self::WC_INFORMATION_TRANSIENT, $wc_information, DAY_IN_SECONDS );
+
+		return $wc_information;
+	}
 
 	/**
 	 * Hard - Resets a Learner's Course Progress

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -439,6 +439,7 @@ class Sensei_Main {
 			new Sensei_Import();
 			new Sensei_Export();
 			new Sensei_Exit_Survey();
+			new Sensei_WCPC_Prompt();
 		} else {
 
 			// Load Frontend Class

--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -293,7 +293,7 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 		return [
 			'selected' => $user_data['features']['selected'],
 			'options'  => $this->setup_wizard->get_sensei_extensions( $clear_active_plugins_cache ),
-			'wccom'    => $this->setup_wizard->get_woocommerce_connect_data(),
+			'wccom'    => Sensei_Utils::get_woocommerce_connect_data(),
 		];
 	}
 

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -389,3 +389,23 @@ function sensei_log_event( $event_name, $properties = [] ) {
 
 	Sensei_Usage_Tracking::get_instance()->send_event( $event_name, $properties );
 }
+
+/**
+ * Track a Sensei event with Jetpack, when Jetpack is available.
+ *
+ * @since 3.7.0
+ *
+ * @param string $event_name The name of the event, without the `sensei_` prefix.
+ * @param array  $properties The event properties to be sent.
+ */
+function sensei_log_jetpack_event( $event_name, $properties = [] ) {
+	if ( ! class_exists( 'Automattic\Jetpack\Tracking' ) || ! Sensei()->usage_tracking->is_tracking_enabled() ) {
+		return;
+	}
+
+	$jetpack_connection = Jetpack::connection();
+	if ( $jetpack_connection->is_user_connected() ) {
+		$tracking = new Automattic\Jetpack\Tracking( 'sensei', $jetpack_connection );
+		$tracking->record_user_event( $event_name, $properties );
+	}
+}

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
@@ -24,7 +24,7 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 	public static function setUpBeforeClass() {
 		// Mock WooCommerce plugin information.
 		set_transient(
-			Sensei_Setup_Wizard::WC_INFORMATION_TRANSIENT,
+			Sensei_Utils::WC_INFORMATION_TRANSIENT,
 			(object) [
 				'product_slug' => 'woocommerce',
 				'title'        => 'WooCommerce',

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -17,7 +17,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	public static function setUpBeforeClass() {
 		// Mock WooCommerce plugin information.
 		set_transient(
-			Sensei_Setup_Wizard::WC_INFORMATION_TRANSIENT,
+			Sensei_Utils::WC_INFORMATION_TRANSIENT,
 			(object) [
 				'product_slug' => 'woocommerce',
 				'title'        => 'WooCommerce',
@@ -457,7 +457,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that get sensei extensions with statuses.
 	 *
-	 * @covers Sensei_Setup_Wizard::get_woocommerce_information
+	 * @covers Sensei_Utils::get_woocommerce_plugin_information
 	 * @covers Sensei_Setup_Wizard::get_feature_with_status
 	 * @covers Sensei_Setup_Wizard::get_sensei_extensions
 	 */
@@ -526,7 +526,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 				'product_slug' => 'slug-4',
 				'plugin_file'  => 'test/test.php',
 			],
-			get_transient( Sensei_Setup_Wizard::WC_INFORMATION_TRANSIENT ),
+			get_transient( Sensei_Utils::WC_INFORMATION_TRANSIENT ),
 		];
 		$extensions          = Sensei()->setup_wizard->get_sensei_extensions();
 

--- a/tests/unit-tests/admin/test-class-sensei-wcpc-prompt.php
+++ b/tests/unit-tests/admin/test-class-sensei-wcpc-prompt.php
@@ -54,14 +54,7 @@ class Sensei_WCPC_Prompt_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function testWCPCNoticeIsDisplayed() {
-		$instance = $this->getMockBuilder( Sensei_WCPC_Prompt::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'get_wcpc_install_url' ] )
-			->getMock();
-
-		$instance->expects( $this->any() )
-			->method( 'get_wcpc_install_url' )
-			->will( $this->returnValue( 'https://install_url' ) );
+		$instance = new Sensei_WCPC_Prompt();
 
 		set_current_screen( 'edit-course' );
 		$this->factory->course->create();

--- a/tests/unit-tests/admin/test-class-sensei-wcpc-prompt.php
+++ b/tests/unit-tests/admin/test-class-sensei-wcpc-prompt.php
@@ -63,7 +63,7 @@ class Sensei_WCPC_Prompt_Test extends WP_UnitTestCase {
 		$instance->wcpc_prompt();
 		$output = ob_get_clean();
 
-		$this->assertContains( 'Install now', $output );
+		$this->assertContains( 'Install extension', $output );
 	}
 
 	/**

--- a/tests/unit-tests/admin/test-class-sensei-wcpc-prompt.php
+++ b/tests/unit-tests/admin/test-class-sensei-wcpc-prompt.php
@@ -25,6 +25,19 @@ class Sensei_WCPC_Prompt_Test extends WP_UnitTestCase {
 		// Mock that WooCommerce is active.
 		update_option( 'active_plugins', [ 'woocommerce/woocommerce.php' => 'woocommerce/woocommerce.php' ] );
 
+		// Mock extensions.
+		set_transient(
+			'sensei_extensions_' . md5( 'plugin||[]' ),
+			[
+				(object) [
+					'product_slug'     => 'sensei-wc-paid-courses',
+					'plugin_file'      => 'woothemes-sensei/woothemes-sensei.php',
+					'wccom_product_id' => '152116',
+				],
+			],
+			DAY_IN_SECONDS
+		);
+
 		// Save original current screen.
 		global $current_screen;
 		$this->original_screen = $current_screen;
@@ -54,7 +67,15 @@ class Sensei_WCPC_Prompt_Test extends WP_UnitTestCase {
 	 * @return void
 	 */
 	public function testWCPCNoticeIsDisplayed() {
-		$instance = new Sensei_WCPC_Prompt();
+		// Mock as WCPC not installed.
+		$instance = $this->getMockBuilder( Sensei_WCPC_Prompt::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'is_wcpc_installed' ] )
+			->getMock();
+
+		$instance->expects( $this->any() )
+			->method( 'is_wcpc_installed' )
+			->will( $this->returnValue( false ) );
 
 		set_current_screen( 'edit-course' );
 		$this->factory->course->create();

--- a/tests/unit-tests/admin/test-class-sensei-wcpc-prompt.php
+++ b/tests/unit-tests/admin/test-class-sensei-wcpc-prompt.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * This file contains the Sensei_Setup_Wizard_Test class.
+ *
+ * @package sensei
+ */
+
+/**
+ * Tests for Sensei_WCPC_Prompt class.
+ */
+class Sensei_WCPC_Prompt_Test extends WP_UnitTestCase {
+
+	use Sensei_Test_Login_Helpers;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setup() {
+		parent::setup();
+
+		$this->factory = new Sensei_Factory();
+
+		$this->login_as_admin();
+
+		// Mock that WooCommerce is active.
+		update_option( 'active_plugins', [ 'woocommerce/woocommerce.php' => 'woocommerce/woocommerce.php' ] );
+
+		// Save original current screen.
+		global $current_screen;
+		$this->original_screen = $current_screen;
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		// Restore current screen.
+		global $current_screen;
+		$current_screen = $this->original_screen;
+	}
+
+	/**
+	 * Testing the WCPC prompt class to make sure it is loaded.
+	 */
+	public function testClassInstance() {
+		$this->assertTrue( class_exists( 'Sensei_WCPC_Prompt' ), 'Sensei Setup Wizard class does not exist' );
+	}
+
+	/**
+	 * Tests that WCPC installation notice is displayed.
+	 *
+	 * @return void
+	 */
+	public function testWCPCNoticeIsDisplayed() {
+		$instance = $this->getMockBuilder( Sensei_WCPC_Prompt::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'get_wcpc_install_url' ] )
+			->getMock();
+
+		$instance->expects( $this->any() )
+			->method( 'get_wcpc_install_url' )
+			->will( $this->returnValue( 'https://install_url' ) );
+
+		set_current_screen( 'edit-course' );
+		$this->factory->course->create();
+
+		ob_start();
+		$instance->wcpc_prompt();
+		$output = ob_get_clean();
+
+		$this->assertContains( 'Install now', $output );
+	}
+
+	/**
+	 * Tests that WCPC installation notice is not displayed without any course.
+	 *
+	 * @return void
+	 */
+	public function testWCPCNoticeIsNotDisplayedWithoutCourse() {
+		$instance = new Sensei_WCPC_Prompt();
+
+		set_current_screen( 'edit-course' );
+
+		ob_start();
+		$instance->wcpc_prompt();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Tests that WCPC installation notice is not displayed in no course pages.
+	 *
+	 * @return void
+	 */
+	public function testWCPCNoticeIsNotDisplayedInNoCoursesPages() {
+		$instance = new Sensei_WCPC_Prompt();
+
+		set_current_screen( 'no-course-page' );
+		$this->factory->course->create();
+
+		ob_start();
+		$instance->wcpc_prompt();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Tests that WCPC installation notice is not displayed when WooCommerce is not active.
+	 *
+	 * @return void
+	 */
+	public function testWCPCNoticeIsNotDisplayedWithoutWooCommerce() {
+		update_option( 'active_plugins', [] );
+
+		$instance = new Sensei_WCPC_Prompt();
+
+		set_current_screen( 'edit-course' );
+		$this->factory->course->create();
+
+		ob_start();
+		$instance->wcpc_prompt();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
+	 * Tests that WCPC installation notice is not displayed when dismissed.
+	 *
+	 * @return void
+	 */
+	public function testWCPCNoticeIsNotDisplayedWhenDismissed() {
+		$instance = new Sensei_WCPC_Prompt();
+
+		set_current_screen( 'edit-course' );
+		$this->factory->course->create();
+
+		// Dismiss prompt.
+		$_GET['sensei_dismiss_wcpc_prompt'] = '1';
+		$_GET['_wpnonce']                   = wp_create_nonce( 'sensei_dismiss_wcpc_prompt' );
+		$instance->dismiss_prompt();
+
+		ob_start();
+		$instance->wcpc_prompt();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+}

--- a/tests/unit-tests/test-class-sensei-usage-tracking.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking.php
@@ -29,7 +29,7 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	public function testWccomInstallSuccessLogged() {
 		// Mock WooCommerce plugin information.
 		set_transient(
-			Sensei_Setup_Wizard::WC_INFORMATION_TRANSIENT,
+			Sensei_Utils::WC_INFORMATION_TRANSIENT,
 			(object) [
 				'product_slug' => 'woocommerce',
 				'title'        => 'WooCommerce',


### PR DESCRIPTION
Fixes #2789

### Changes proposed in this Pull Request

* This PR introduces a WCPC prompt suggesting the user to install the plugin to sell their courses.

### Testing instructions

1. Create a scenario with the following conditions:
    * At least one course has been published.
    * WCPC is not installed.
    * WooCommerce is installed.
2. Go to the _WP-admin > Courses_ page (`/wp-admin/edit.php?post_type=course`), and make sure you see the WCPC installation notice.
3. Click on "Learn more" and make sure you go to the extension page.
4. Click on the "X" button to dismiss the notice. Make sure the notice doesn't appear after refreshing the page.
5. Remove the `sensei_dismiss_wcpc_prompt` option to see the notice again.
6. Click on "Install now", and make sure you can install the extension.

Also, make sure the events were logged as described in the [issue](https://github.com/Automattic/sensei/issues/2789#issuecomment-743250846).

Also, install a paid extension through the setup wizard, in a site with Jetpack (connected), and make sure the `sensei_setup_wizard_features_install_paid` event continue being logged properly.

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* `Sensei_Setup_Wizard::get_woocommerce_connect_data`. Use `Sensei_Utils::get_woocommerce_connect_data` instead.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

The text and links/buttons had some tweaks after a conversation with @donnapep. This screenshot is the final result:

<img width="1207" alt="Screen Shot 2021-01-07 at 11 38 47" src="https://user-images.githubusercontent.com/876340/103905107-f34eff80-50dc-11eb-9cd0-a72d63929534.png">
