### PR TITLE
Fix module lessons order

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1718,7 +1718,7 @@ class Sensei_Core_Modules {
 
 		if ( version_compare( Sensei()->version, '1.6.0', '>=' ) ) {
 			$args['meta_key'] = '_order_module_' . intval( $term_id );
-			$args['orderby']  = 'meta_value_num date';
+			$args['orderby']  = 'meta_value_num date ID';
 		}
 
 		$lessons_query = new WP_Query( $args );


### PR DESCRIPTION
This issue was reproduced in Travis, and the `testGetPrevNextLessons` test was failing intermittently because sometimes it was getting the lessons in the wrong order.

I couldn't identify why it started happening recently only. I imagine it's likely related to having more tests and processing time.