### PR TITLE
Add sample course check to show notice to install WooCommerce Paid Courses

### DIFF
--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -100,7 +100,7 @@ class Sensei_WCPC_Prompt {
 			// Not edit course page.
 			|| 'edit-course' !== get_current_screen()->id
 			// No published course.
-			|| 0 === wp_count_posts( 'course' )->publish
+			|| ! $this->has_published_courses()
 			// WCPC is installed.
 			|| $this->is_wcpc_installed()
 			// WooCommerce is not active.
@@ -192,5 +192,30 @@ class Sensei_WCPC_Prompt {
 		}
 
 		return null !== Sensei_Plugins_Installation::instance()->get_installed_plugin_path( $this->wcpc_extension->plugin_file );
+	}
+
+	/**
+	 * Check if there are published courses.
+	 *
+	 * @return boolean
+	 */
+	private function has_published_courses() {
+		$course_args = [
+			'post_type'        => 'course',
+			'posts_per_page'   => 1,
+			'post_status'      => 'publish',
+			'suppress_filters' => 0,
+			'fields'           => 'ids',
+		];
+
+		$sample_course = get_page_by_path( Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG, OBJECT, 'course' );
+
+		if ( $sample_course ) {
+			$course_args['post__not_in'] = [ $sample_course->ID ];
+		}
+
+		$courses_query = new WP_Query( $course_args );
+
+		return 0 !== $courses_query->found_posts;
 	}
 }

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -208,8 +208,8 @@ class Sensei_WCPC_Prompt {
 			'fields'           => 'ids',
 		];
 
+		// Ignores the sample course in the query.
 		$sample_course = get_page_by_path( Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG, OBJECT, 'course' );
-
 		if ( $sample_course ) {
 			$course_args['post__not_in'] = [ $sample_course->ID ];
 		}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3492,7 +3492,7 @@ class Sensei_Course {
 			'module_count'  => count( wp_get_post_terms( $course->ID, 'module' ) ),
 			'lesson_count'  => $this->course_lesson_count( $course->ID ),
 			'product_count' => $product_count,
-			'sample_course' => 'getting-started-with-sensei-lms' === $course->post_name ? 1 : 0,
+			'sample_course' => Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG === $course->post_name ? 1 : 0,
 		];
 		sensei_log_event( 'course_publish', $event_properties );
 	}
@@ -3589,7 +3589,7 @@ class Sensei_Course {
 			'module_count'              => count( wp_get_post_terms( $course_id, 'module' ) ),
 			'lesson_count'              => $this->course_lesson_count( $course_id ),
 			'product_count'             => $product_count,
-			'sample_course'             => 'getting-started-with-sensei-lms' === $post->post_name ? 1 : 0,
+			'sample_course'             => Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG === $post->post_name ? 1 : 0,
 		];
 
 		sensei_log_event( 'course_update', $event_properties );

--- a/includes/data-port/class-sensei-data-port-manager.php
+++ b/includes/data-port/class-sensei-data-port-manager.php
@@ -17,6 +17,7 @@ class Sensei_Data_Port_Manager implements JsonSerializable {
 	const JOB_STALE_AGE_SECONDS = DAY_IN_SECONDS;
 	const OPTION_RUNNING_JOB    = 'sensei-data-port-jobs-running';
 	const SAMPLE_COURSE_ID      = 2990;
+	const SAMPLE_COURSE_SLUG    = 'getting-started-with-sensei-lms';
 
 	/**
 	 * An array of all in progress data port jobs. It has the following format:

--- a/tests/unit-tests/admin/test-class-sensei-wcpc-prompt.php
+++ b/tests/unit-tests/admin/test-class-sensei-wcpc-prompt.php
@@ -105,6 +105,24 @@ class Sensei_WCPC_Prompt_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that WCPC installation notice is not displayed with the sample course only.
+	 *
+	 * @return void
+	 */
+	public function testWCPCNoticeIsNotDisplayedWithSampleCourseOnly() {
+		$instance = new Sensei_WCPC_Prompt();
+
+		set_current_screen( 'edit-course' );
+		$this->factory->course->create( [ 'post_name' => Sensei_Data_Port_Manager::SAMPLE_COURSE_SLUG ] );
+
+		ob_start();
+		$instance->wcpc_prompt();
+		$output = ob_get_clean();
+
+		$this->assertEmpty( $output );
+	}
+
+	/**
 	 * Tests that WCPC installation notice is not displayed in no course pages.
 	 *
 	 * @return void


### PR DESCRIPTION
### Changes proposed in this Pull Request

* As the https://github.com/Automattic/sensei/pull/3876#issuecomment-757994050, it introduces a check to ignore the sample course when checking if the user contains published courses to show the WCPC prompt.

### Testing instructions

1. Create an environment with WCPC not installed, WooCommerce activated, and no courses.
2. Through the setup wizard (in the ready step), install and publish the sample course (you need to have only this course published).
3. Go to the _WP-admin > Courses_ page (`/wp-admin/edit.php?post_type=course`), and make sure you **don't** see the WCPC installation notice.
4. Create a new course, and publish it.
5. Go to the _WP-admin > Courses_ page again, and make sure now you see the notice to install the WCPC.