### PR TITLE
Add lesson actions block setup

### DIFF
--- a/assets/blocks/lesson-actions/complete-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/complete-lesson-block/index.js
@@ -1,0 +1,30 @@
+import { __ } from '@wordpress/i18n';
+
+import { createButtonBlockType } from '../../button';
+
+/**
+ * Complete lesson button block.
+ */
+export default createButtonBlockType( {
+	tagName: 'button',
+	settings: {
+		name: 'sensei-lms/button-complete-lesson',
+		parent: [ 'sensei-lms/lesson-actions' ],
+		title: __( 'Complete lesson', 'sensei-lms' ),
+		description: __(
+			'Enable an enrolled user to complete the lesson.',
+			'sensei-lms'
+		),
+		keywords: [
+			__( 'Complete', 'sensei-lms' ),
+			__( 'Finish', 'sensei-lms' ),
+			__( 'Lesson', 'sensei-lms' ),
+			__( 'Button', 'sensei-lms' ),
+		],
+		attributes: {
+			text: {
+				default: 'Complete lesson',
+			},
+		},
+	},
+} );

--- a/assets/blocks/lesson-actions/complete-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/complete-lesson-block/index.js
@@ -12,7 +12,7 @@ export default createButtonBlockType( {
 		parent: [ 'sensei-lms/lesson-actions' ],
 		title: __( 'Complete lesson', 'sensei-lms' ),
 		description: __(
-			'Enable an enrolled user to complete the lesson.',
+			'Enable an enrolled user to mark the lesson as complete.',
 			'sensei-lms'
 		),
 		keywords: [

--- a/assets/blocks/lesson-actions/index.js
+++ b/assets/blocks/lesson-actions/index.js
@@ -1,0 +1,4 @@
+export { default as LessonActionsBlock } from './lesson-actions-block';
+export { default as CompleteLessonBlock } from './complete-lesson-block';
+export { default as NextLessonBlock } from './next-lesson-block';
+export { default as ResetLessonBlock } from './reset-lesson-block';

--- a/assets/blocks/lesson-actions/lesson-actions-block/block.json
+++ b/assets/blocks/lesson-actions/lesson-actions-block/block.json
@@ -1,0 +1,7 @@
+{
+  "name": "sensei-lms/lesson-actions",
+  "category": "sensei-lms",
+  "supports": {
+    "html": false
+  }
+}

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -1,0 +1,24 @@
+import { InnerBlocks } from '@wordpress/block-editor';
+
+const innerBlocksTemplate = [
+	[ 'sensei-lms/button-complete-lesson', {} ],
+	[ 'sensei-lms/button-next-lesson', {} ],
+	[ 'sensei-lms/button-reset-lesson', {} ],
+];
+
+/**
+ * Edit lesson actions block component.
+ */
+const EditLessonActionsBlock = () => (
+	<InnerBlocks
+		allowedBlocks={ [
+			'sensei-lms/button-complete-lesson',
+			'sensei-lms/button-next-lesson',
+			'sensei-lms/button-reset-lesson',
+		] }
+		template={ innerBlocksTemplate }
+		templateLock="all"
+	/>
+);
+
+export default EditLessonActionsBlock;

--- a/assets/blocks/lesson-actions/lesson-actions-block/index.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/index.js
@@ -1,0 +1,33 @@
+import { __ } from '@wordpress/i18n';
+import { button as icon } from '../../../icons/wordpress-icons';
+import metadata from './block.json';
+
+import edit from './edit';
+import save from './save';
+
+export default {
+	title: __( 'Lesson actions', 'sensei-lms' ),
+	description: __(
+		'Enable an enrolled user to complete the lesson, or reset their progress.',
+		'sensei-lms'
+	),
+	keywords: [
+		__( 'Lesson', 'sensei-lms' ),
+		__( 'Actions', 'sensei-lms' ),
+		__( 'Buttons', 'sensei-lms' ),
+		__( 'Complete', 'sensei-lms' ),
+		__( 'Next', 'sensei-lms' ),
+		__( 'Reset', 'sensei-lms' ),
+	],
+	example: {
+		innerBlocks: [
+			{ name: 'sensei-lms/button-complete-lesson' },
+			{ name: 'sensei-lms/button-next-lesson' },
+			{ name: 'sensei-lms/button-reset-lesson' },
+		],
+	},
+	...metadata,
+	icon,
+	edit,
+	save,
+};

--- a/assets/blocks/lesson-actions/lesson-actions-block/index.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/index.js
@@ -8,7 +8,7 @@ import save from './save';
 export default {
 	title: __( 'Lesson actions', 'sensei-lms' ),
 	description: __(
-		'Enable an enrolled user to complete the lesson, or reset their progress.',
+		'Enable an enrolled user to perform specific actions for a lesson.',
 		'sensei-lms'
 	),
 	keywords: [

--- a/assets/blocks/lesson-actions/lesson-actions-block/save.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/save.js
@@ -1,0 +1,5 @@
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function saveLessonActionsBlock() {
+	return <InnerBlocks.Content />;
+}

--- a/assets/blocks/lesson-actions/next-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/next-lesson-block/index.js
@@ -12,7 +12,7 @@ export default createButtonBlockType( {
 		title: __( 'Next lesson', 'sensei-lms' ),
 		parent: [ 'sensei-lms/lesson-actions' ],
 		description: __(
-			'Enable an enrolled user to navigate to the next lesson.',
+			'Enable a user to move to the next lesson.',
 			'sensei-lms'
 		),
 		keywords: [

--- a/assets/blocks/lesson-actions/next-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/next-lesson-block/index.js
@@ -1,0 +1,30 @@
+import { __ } from '@wordpress/i18n';
+
+import { createButtonBlockType } from '../../button';
+
+/**
+ * Next lesson button block.
+ */
+export default createButtonBlockType( {
+	tagName: 'button',
+	settings: {
+		name: 'sensei-lms/button-next-lesson',
+		title: __( 'Next lesson', 'sensei-lms' ),
+		parent: [ 'sensei-lms/lesson-actions' ],
+		description: __(
+			'Enable an enrolled user to navigate to the next lesson.',
+			'sensei-lms'
+		),
+		keywords: [
+			__( 'Next', 'sensei-lms' ),
+			__( 'Continue', 'sensei-lms' ),
+			__( 'Lesson', 'sensei-lms' ),
+			__( 'Button', 'sensei-lms' ),
+		],
+		attributes: {
+			text: {
+				default: 'Next lesson',
+			},
+		},
+	},
+} );

--- a/assets/blocks/lesson-actions/reset-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/reset-lesson-block/index.js
@@ -1,0 +1,37 @@
+import { __ } from '@wordpress/i18n';
+
+import { BlockStyles, createButtonBlockType } from '../../button';
+
+/**
+ * Reset lesson button block.
+ */
+export default createButtonBlockType( {
+	tagName: 'button',
+	settings: {
+		name: 'sensei-lms/button-reset-lesson',
+		title: __( 'Reset lesson', 'sensei-lms' ),
+		parent: [ 'sensei-lms/lesson-actions' ],
+		description: __(
+			'Enable an enrolled user to reset their progress.',
+			'sensei-lms'
+		),
+		keywords: [
+			__( 'Reset', 'sensei-lms' ),
+			__( 'Restart', 'sensei-lms' ),
+			__( 'Revert', 'sensei-lms' ),
+			__( 'Progress', 'sensei-lms' ),
+			__( 'Lesson', 'sensei-lms' ),
+			__( 'Button', 'sensei-lms' ),
+		],
+		attributes: {
+			text: {
+				default: 'Reset lesson',
+			},
+		},
+		styles: [
+			BlockStyles.Fill,
+			{ ...BlockStyles.Outline, isDefault: true },
+			BlockStyles.Link,
+		],
+	},
+} );

--- a/assets/blocks/lesson-actions/reset-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/reset-lesson-block/index.js
@@ -12,7 +12,7 @@ export default createButtonBlockType( {
 		title: __( 'Reset lesson', 'sensei-lms' ),
 		parent: [ 'sensei-lms/lesson-actions' ],
 		description: __(
-			'Enable an enrolled user to reset their progress.',
+			'Enable an enrolled user to reset their progress in the lesson.',
 			'sensei-lms'
 		),
 		keywords: [

--- a/assets/blocks/sensei-single-lesson-blocks.js
+++ b/assets/blocks/sensei-single-lesson-blocks.js
@@ -1,0 +1,14 @@
+import registerSenseiBlocks from './register-sensei-blocks';
+import {
+	LessonActionsBlock,
+	CompleteLessonBlock,
+	NextLessonBlock,
+	ResetLessonBlock,
+} from './lesson-actions';
+
+registerSenseiBlocks( [
+	LessonActionsBlock,
+	CompleteLessonBlock,
+	NextLessonBlock,
+	ResetLessonBlock,
+] );

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -21,13 +21,6 @@ class Sensei_Blocks {
 	public $course;
 
 	/**
-	 * Lesson blocks.
-	 *
-	 * @var Sensei_Lesson_Blocks
-	 */
-	public $lesson;
-
-	/**
 	 * Sensei_Blocks constructor.
 	 */
 	public function __construct() {
@@ -40,7 +33,7 @@ class Sensei_Blocks {
 
 		// Init blocks.
 		$this->course = new Sensei_Course_Blocks();
-		$this->lesson = new Sensei_Lesson_Blocks();
+		new Sensei_Lesson_Blocks();
 	}
 
 	/**

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -21,6 +21,13 @@ class Sensei_Blocks {
 	public $course;
 
 	/**
+	 * Lesson blocks.
+	 *
+	 * @var Sensei_Lesson_Blocks
+	 */
+	public $lesson;
+
+	/**
 	 * Sensei_Blocks constructor.
 	 */
 	public function __construct() {
@@ -33,6 +40,7 @@ class Sensei_Blocks {
 
 		// Init blocks.
 		$this->course = new Sensei_Course_Blocks();
+		$this->lesson = new Sensei_Lesson_Blocks();
 	}
 
 	/**

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * File containing the class Sensei_Lesson_Blocks.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Lesson_Blocks
+ */
+class Sensei_Lesson_Blocks {
+	/**
+	 * Sensei_Blocks constructor.
+	 */
+	public function __construct() {
+		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
+	}
+
+	/**
+	 * Enqueue editor assets.
+	 *
+	 * @access private
+	 */
+	public function enqueue_block_editor_assets() {
+		if ( 'lesson' !== get_post_type() ) {
+			return;
+		}
+
+		Sensei()->assets->enqueue( 'sensei-single-lesson-blocks', 'blocks/sensei-single-lesson-blocks.js', [], true );
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,7 @@ const files = [
 	'blocks/sensei-single-course-blocks.js',
 	'blocks/single-course.scss',
 	'blocks/single-course.editor.scss',
+	'blocks/sensei-single-lesson-blocks.js',
 	'admin/exit-survey/index.js',
 	'admin/exit-survey/exit-survey.scss',
 	'css/enrolment-debug.scss',


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/3821

### Changes proposed in this Pull Request

* It introduces a basic block setup for the lesson actions.
* The target branch is temporarily the `change/isolate-course-blocks` branch until https://github.com/Automattic/sensei/pull/3885 gets merged.
* Design, preview state, settings will be part of future PRs.

### Testing instructions

* Create a lesson, and play with the "Lesson actions" block.