### PR TITLE
Add lesson actions block settings

### DIFF
--- a/assets/blocks/lesson-actions/lesson-actions-block/block.json
+++ b/assets/blocks/lesson-actions/lesson-actions-block/block.json
@@ -5,7 +5,7 @@
     "html": false
   },
   "attributes": {
-    "activeBlocks": {
+    "toggledBlocks": {
       "type": "object",
       "default": {
         "sensei-lms/button-reset-lesson": true

--- a/assets/blocks/lesson-actions/lesson-actions-block/block.json
+++ b/assets/blocks/lesson-actions/lesson-actions-block/block.json
@@ -5,9 +5,11 @@
     "html": false
   },
   "attributes": {
-    "resetLessonOn": {
-      "type": "boolean",
-      "default": true
+    "activeBlocks": {
+      "type": "object",
+      "default": {
+        "sensei-lms/button-reset-lesson": true
+      }
     }
   }
 }

--- a/assets/blocks/lesson-actions/lesson-actions-block/block.json
+++ b/assets/blocks/lesson-actions/lesson-actions-block/block.json
@@ -3,5 +3,11 @@
   "category": "sensei-lms",
   "supports": {
     "html": false
+  },
+  "attributes": {
+    "resetLesson": {
+      "type": "boolean",
+      "default": true
+    }
   }
 }

--- a/assets/blocks/lesson-actions/lesson-actions-block/block.json
+++ b/assets/blocks/lesson-actions/lesson-actions-block/block.json
@@ -5,7 +5,7 @@
     "html": false
   },
   "attributes": {
-    "resetLesson": {
+    "resetLessonOn": {
       "type": "boolean",
       "default": true
     }

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -18,17 +18,17 @@ const innerBlocksTemplate = [
  * Edit lesson actions block component.
  *
  * @param {Object}   props
- * @param {string}   props.className              Custom class name.
- * @param {string}   props.clientId               Block ID.
- * @param {Function} props.setAttributes          Block set attributes function.
- * @param {Object}   props.attributes             Block attributes.
- * @param {boolean}  props.attributes.resetLesson Whether reset lesson is enabled.
+ * @param {string}   props.className                Custom class name.
+ * @param {string}   props.clientId                 Block ID.
+ * @param {Function} props.setAttributes            Block set attributes function.
+ * @param {Object}   props.attributes               Block attributes.
+ * @param {boolean}  props.attributes.resetLessonOn Whether reset lesson is enabled.
  */
 const EditLessonActionsBlock = ( {
 	className,
 	clientId,
 	setAttributes,
-	attributes: { resetLesson },
+	attributes: { resetLessonOn },
 } ) => {
 	const block = useSelect(
 		( select ) => select( 'core/block-editor' ).getBlock( clientId ),
@@ -37,7 +37,7 @@ const EditLessonActionsBlock = ( {
 	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
 	const [ resetLessonAttributes, setResetLessonAttributes ] = useState( {} );
 
-	const setResetLesson = ( on ) => {
+	const toggleResetLesson = ( on ) => {
 		const resetLessonBlock = block.innerBlocks.find(
 			( i ) => i.name === 'sensei-lms/button-reset-lesson'
 		);
@@ -66,15 +66,15 @@ const EditLessonActionsBlock = ( {
 			replaceInnerBlocks( clientId, newBlocks, false );
 		}
 
-		setAttributes( { resetLesson: on } );
+		setAttributes( { resetLessonOn: on } );
 	};
 
 	return (
 		<div className={ className }>
 			<div className="sensei-buttons-container">
 				<LessonActionsBlockSettings
-					resetLesson={ resetLesson }
-					setResetLesson={ setResetLesson }
+					resetLessonOn={ resetLessonOn }
+					toggleResetLesson={ toggleResetLesson }
 				/>
 				<InnerBlocks
 					allowedBlocks={ [

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -69,6 +69,12 @@ const EditLessonActionsBlock = ( {
 		setAttributes( { resetLessonOn: on } );
 	};
 
+	const filteredInnerBlocksTemplate = resetLessonOn
+		? innerBlocksTemplate
+		: innerBlocksTemplate.filter(
+				( i ) => 'sensei-lms/button-reset-lesson' !== i[ 0 ]
+		  );
+
 	return (
 		<div className={ className }>
 			<div className="sensei-buttons-container">
@@ -82,7 +88,7 @@ const EditLessonActionsBlock = ( {
 						'sensei-lms/button-next-lesson',
 						'sensei-lms/button-reset-lesson',
 					] }
-					template={ innerBlocksTemplate }
+					template={ filteredInnerBlocksTemplate }
 					templateLock="all"
 				/>
 			</div>

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -1,5 +1,7 @@
 import { InnerBlocks } from '@wordpress/block-editor';
 
+import { LessonActionsBlockSettings } from './settings';
+
 const innerBlocksTemplate = [
 	[
 		'sensei-lms/button-complete-lesson',
@@ -12,12 +14,25 @@ const innerBlocksTemplate = [
 /**
  * Edit lesson actions block component.
  *
- * @param {Object} props
- * @param {string} props.className Custom class name.
+ * @param {Object}   props
+ * @param {string}   props.className              Custom class name.
+ * @param {Function} props.setAttributes          Block set attributes function.
+ * @param {Object}   props.attributes             Block attributes.
+ * @param {boolean}  props.attributes.resetLesson Whether reset lesson is enabled.
  */
-const EditLessonActionsBlock = ( { className } ) => (
+const EditLessonActionsBlock = ( {
+	className,
+	setAttributes,
+	attributes: { resetLesson },
+} ) => (
 	<div className={ className }>
 		<div className="sensei-buttons-container">
+			<LessonActionsBlockSettings
+				resetLesson={ resetLesson }
+				setResetLesson={ ( newValue ) =>
+					setAttributes( { resetLesson: newValue } )
+				}
+			/>
 			<InnerBlocks
 				allowedBlocks={ [
 					'sensei-lms/button-complete-lesson',

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -5,12 +5,12 @@ import { useSelect, useDispatch } from '@wordpress/data';
 
 import { LessonActionsBlockSettings } from './settings';
 
-const allowedBlocks = [
+const ALLOWED_BLOCKS = [
 	'sensei-lms/button-complete-lesson',
 	'sensei-lms/button-next-lesson',
 	'sensei-lms/button-reset-lesson',
 ];
-const innerBlocksTemplate = allowedBlocks.map( ( blockName ) => [
+const INNER_BLOCKS_TEMPLATE = ALLOWED_BLOCKS.map( ( blockName ) => [
 	blockName,
 	{
 		inContainer: true,
@@ -85,7 +85,7 @@ const EditLessonActionsBlock = ( {
 	};
 
 	// Filter inner blocks based on the settings.
-	const filteredInnerBlocksTemplate = innerBlocksTemplate.filter(
+	const filteredInnerBlocksTemplate = INNER_BLOCKS_TEMPLATE.filter(
 		( i ) => false !== activeBlocks[ i[ 0 ] ]
 	);
 
@@ -97,7 +97,7 @@ const EditLessonActionsBlock = ( {
 					toggleBlock={ toggleBlock }
 				/>
 				<InnerBlocks
-					allowedBlocks={ allowedBlocks }
+					allowedBlocks={ ALLOWED_BLOCKS }
 					template={ filteredInnerBlocksTemplate }
 					templateLock="all"
 				/>

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -2,6 +2,7 @@ import { useState } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
 
 import { LessonActionsBlockSettings } from './settings';
 
@@ -21,6 +22,78 @@ const INNER_BLOCKS_TEMPLATE = ALLOWED_BLOCKS.map( ( blockName ) => [
 ] );
 
 /**
+ * Toggle blocks hook.
+ *
+ * @param {Object}   options                Hook options.
+ * @param {string}   options.parentClientId Parent client ID.
+ * @param {Function} options.setAttributes  Set attributes function.
+ * @param {Object}   options.toggledBlocks  Toggled blocks, where the key is the block name.
+ * @param {Object[]} options.blocks         Blocks to prepare to toggle.
+ *
+ * @return {Object[]} Blocks prepared to toggle.
+ */
+const useToggleBlocks = ( {
+	parentClientId,
+	setAttributes,
+	toggledBlocks,
+	blocks,
+} ) => {
+	const parentBlock = useSelect(
+		( select ) => select( 'core/block-editor' ).getBlock( parentClientId ),
+		[]
+	);
+	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const [ blocksAttributes, setBlocksAttributes ] = useState( {} );
+
+	/**
+	 * Toggle block.
+	 *
+	 * @param {string} blockName Block name.
+	 *
+	 * @return {Function} Function to toggle the block.
+	 */
+	const toggleBlock = ( blockName ) => ( on ) => {
+		const toggledBlock = parentBlock.innerBlocks.find(
+			( i ) => i.name === blockName
+		);
+		let newBlocks = null;
+
+		if ( on && ! toggledBlock ) {
+			// Add block using the previous attributes if it exists.
+			newBlocks = [
+				...parentBlock.innerBlocks,
+				createBlock( blockName, blocksAttributes[ blockName ] || {} ),
+			];
+		} else if ( ! on && toggledBlock ) {
+			// Remove block.
+			newBlocks = parentBlock.innerBlocks.filter(
+				( i ) => i.name !== blockName
+			);
+
+			// Save block attributes to restore, if needed.
+			setBlocksAttributes( ( attrs ) => ( {
+				...attrs,
+				[ blockName ]: toggledBlock.attributes,
+			} ) );
+		}
+
+		if ( newBlocks ) {
+			replaceInnerBlocks( parentClientId, newBlocks, false );
+		}
+
+		setAttributes( {
+			toggledBlocks: { ...toggledBlocks, [ blockName ]: on },
+		} );
+	};
+
+	return blocks.map( ( block ) => ( {
+		active: false !== toggledBlocks[ block.blockName ],
+		onToggle: toggleBlock( block.blockName ),
+		label: block.label,
+	} ) );
+};
+
+/**
  * Edit lesson actions block component.
  *
  * @param {Object}   props
@@ -36,53 +109,17 @@ const EditLessonActionsBlock = ( {
 	setAttributes,
 	attributes: { toggledBlocks },
 } ) => {
-	const block = useSelect(
-		( select ) => select( 'core/block-editor' ).getBlock( clientId ),
-		[]
-	);
-	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
-	const [ blocksAttributes, setBlocksAttributes ] = useState( {} );
-
-	/**
-	 * Toggle block.
-	 *
-	 * @param {string} blockName Block name.
-	 *
-	 * @return {Function} Function to toggle the block.
-	 */
-	const toggleBlock = ( blockName ) => ( on ) => {
-		const toggledBlock = block.innerBlocks.find(
-			( i ) => i.name === blockName
-		);
-		let newBlocks = null;
-
-		if ( on && ! toggledBlock ) {
-			// Add block.
-			newBlocks = [
-				...block.innerBlocks,
-				createBlock( blockName, blocksAttributes[ blockName ] || {} ),
-			];
-		} else if ( ! on && toggledBlock ) {
-			// Remove block.
-			newBlocks = block.innerBlocks.filter(
-				( i ) => i.name !== blockName
-			);
-
-			// Save block attributes to restore, if needed.
-			setBlocksAttributes( ( attrs ) => ( {
-				...attrs,
-				[ blockName ]: toggledBlock.attributes,
-			} ) );
-		}
-
-		if ( newBlocks ) {
-			replaceInnerBlocks( clientId, newBlocks, false );
-		}
-
-		setAttributes( {
-			toggledBlocks: { ...toggledBlocks, [ blockName ]: on },
-		} );
-	};
+	const toggleBlocks = useToggleBlocks( {
+		parentClientId: clientId,
+		setAttributes,
+		toggledBlocks,
+		blocks: [
+			{
+				blockName: 'sensei-lms/button-reset-lesson',
+				label: __( 'Reset lesson', 'sensei-lms' ),
+			},
+		],
+	} );
 
 	// Filter inner blocks based on the settings.
 	const filteredInnerBlocksTemplate = INNER_BLOCKS_TEMPLATE.filter(
@@ -92,10 +129,7 @@ const EditLessonActionsBlock = ( {
 	return (
 		<div className={ className }>
 			<div className="sensei-buttons-container">
-				<LessonActionsBlockSettings
-					toggledBlocks={ toggledBlocks }
-					toggleBlock={ toggleBlock }
-				/>
+				<LessonActionsBlockSettings toggleBlocks={ toggleBlocks } />
 				<InnerBlocks
 					allowedBlocks={ ALLOWED_BLOCKS }
 					template={ filteredInnerBlocksTemplate }

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -24,17 +24,17 @@ const INNER_BLOCKS_TEMPLATE = ALLOWED_BLOCKS.map( ( blockName ) => [
  * Edit lesson actions block component.
  *
  * @param {Object}   props
- * @param {string}   props.className               Custom class name.
- * @param {string}   props.clientId                Block ID.
- * @param {Function} props.setAttributes           Block set attributes function.
- * @param {Object}   props.attributes              Block attributes.
- * @param {Object}   props.attributes.activeBlocks Active blocks, where the key is the block name.
+ * @param {string}   props.className                Custom class name.
+ * @param {string}   props.clientId                 Block ID.
+ * @param {Function} props.setAttributes            Block set attributes function.
+ * @param {Object}   props.attributes               Block attributes.
+ * @param {Object}   props.attributes.toggledBlocks Toggled blocks, where the key is the block name.
  */
 const EditLessonActionsBlock = ( {
 	className,
 	clientId,
 	setAttributes,
-	attributes: { activeBlocks },
+	attributes: { toggledBlocks },
 } ) => {
 	const block = useSelect(
 		( select ) => select( 'core/block-editor' ).getBlock( clientId ),
@@ -80,20 +80,20 @@ const EditLessonActionsBlock = ( {
 		}
 
 		setAttributes( {
-			activeBlocks: { ...activeBlocks, [ blockName ]: on },
+			toggledBlocks: { ...toggledBlocks, [ blockName ]: on },
 		} );
 	};
 
 	// Filter inner blocks based on the settings.
 	const filteredInnerBlocksTemplate = INNER_BLOCKS_TEMPLATE.filter(
-		( i ) => false !== activeBlocks[ i[ 0 ] ]
+		( i ) => false !== toggledBlocks[ i[ 0 ] ]
 	);
 
 	return (
 		<div className={ className }>
 			<div className="sensei-buttons-container">
 				<LessonActionsBlockSettings
-					activeBlocks={ activeBlocks }
+					toggledBlocks={ toggledBlocks }
 					toggleBlock={ toggleBlock }
 				/>
 				<InnerBlocks

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -1,3 +1,4 @@
+import { useState } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { createBlock } from '@wordpress/blocks';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -34,25 +35,31 @@ const EditLessonActionsBlock = ( {
 		[]
 	);
 	const { replaceInnerBlocks } = useDispatch( 'core/block-editor' );
+	const [ resetLessonAttributes, setResetLessonAttributes ] = useState( {} );
 
 	const setResetLesson = ( on ) => {
 		const resetLessonBlock = block.innerBlocks.find(
 			( i ) => i.name === 'sensei-lms/button-reset-lesson'
 		);
-
 		let newBlocks = null;
 
 		if ( on && ! resetLessonBlock ) {
 			// Add block.
 			newBlocks = [
 				...block.innerBlocks,
-				createBlock( 'sensei-lms/button-reset-lesson' ),
+				createBlock(
+					'sensei-lms/button-reset-lesson',
+					resetLessonAttributes
+				),
 			];
 		} else if ( ! on && resetLessonBlock ) {
 			// Remove block.
 			newBlocks = block.innerBlocks.filter(
 				( i ) => i.name !== 'sensei-lms/button-reset-lesson'
 			);
+
+			// Save block attributes to restore, if needed.
+			setResetLessonAttributes( resetLessonBlock.attributes );
 		}
 
 		if ( newBlocks ) {

--- a/assets/blocks/lesson-actions/lesson-actions-block/settings.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/settings.js
@@ -3,25 +3,29 @@ import { PanelBody, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
+ * @typedef {Object} ToggleBlock
+ *
+ * @property {string}   label    Toggle label.
+ * @property {boolean}  active   Whether block is active.
+ * @property {Function} onToggle Toggle function.
+ */
+/**
  * Inspector controls for lesson actions block.
  *
- * @param {Object}   props
- * @param {Object}   props.toggledBlocks Toggled blocks, where the key is the block name.
- * @param {Function} props.toggleBlock   Toggle block.
+ * @param {Object}        props
+ * @param {ToggleBlock[]} props.toggleBlocks Blocks to toggle.
  */
-export const LessonActionsBlockSettings = ( {
-	toggledBlocks,
-	toggleBlock,
-} ) => (
+export const LessonActionsBlockSettings = ( { toggleBlocks } ) => (
 	<InspectorControls>
 		<PanelBody title={ __( 'Additional Actions', 'sensei-lms' ) }>
-			<ToggleControl
-				checked={
-					false !== toggledBlocks[ 'sensei-lms/button-reset-lesson' ]
-				}
-				onChange={ toggleBlock( 'sensei-lms/button-reset-lesson' ) }
-				label={ __( 'Reset lesson', 'sensei-lms' ) }
-			/>
+			{ toggleBlocks.map( ( block ) => (
+				<ToggleControl
+					key={ block.label }
+					checked={ block.active }
+					onChange={ block.onToggle }
+					label={ block.label }
+				/>
+			) ) }
 		</PanelBody>
 	</InspectorControls>
 );

--- a/assets/blocks/lesson-actions/lesson-actions-block/settings.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/settings.js
@@ -6,18 +6,17 @@ import { __ } from '@wordpress/i18n';
  * Inspector controls for lesson actions block.
  *
  * @param {Object}   props
- * @param {boolean}  props.resetLessonOn     Whether reset lesson is enabled.
- * @param {Function} props.toggleResetLesson Toggle reset lesson.
+ * @param {Object}   props.activeBlocks Active blocks, where the key is the block name.
+ * @param {Function} props.toggleBlock  Toggle block.
  */
-export const LessonActionsBlockSettings = ( {
-	resetLessonOn,
-	toggleResetLesson,
-} ) => (
+export const LessonActionsBlockSettings = ( { activeBlocks, toggleBlock } ) => (
 	<InspectorControls>
 		<PanelBody title={ __( 'Additional Actions', 'sensei-lms' ) }>
 			<ToggleControl
-				checked={ resetLessonOn }
-				onChange={ toggleResetLesson }
+				checked={
+					false !== activeBlocks[ 'sensei-lms/button-reset-lesson' ]
+				}
+				onChange={ toggleBlock( 'sensei-lms/button-reset-lesson' ) }
 				label={ __( 'Reset lesson', 'sensei-lms' ) }
 			/>
 		</PanelBody>

--- a/assets/blocks/lesson-actions/lesson-actions-block/settings.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/settings.js
@@ -1,0 +1,24 @@
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Inspector controls for lesson actions block.
+ *
+ * @param {Object}   props
+ * @param {boolean}  props.resetLesson    Whether reset lesson is enabled.
+ * @param {Function} props.setResetLesson Set reset lesson attribute.
+ */
+export function LessonActionsBlockSettings( { resetLesson, setResetLesson } ) {
+	return (
+		<InspectorControls>
+			<PanelBody title={ __( 'Additional Actions', 'sensei-lms' ) }>
+				<ToggleControl
+					checked={ resetLesson }
+					onChange={ setResetLesson }
+					label={ __( 'Reset lesson', 'sensei-lms' ) }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+}

--- a/assets/blocks/lesson-actions/lesson-actions-block/settings.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/settings.js
@@ -6,15 +6,18 @@ import { __ } from '@wordpress/i18n';
  * Inspector controls for lesson actions block.
  *
  * @param {Object}   props
- * @param {Object}   props.activeBlocks Active blocks, where the key is the block name.
- * @param {Function} props.toggleBlock  Toggle block.
+ * @param {Object}   props.toggledBlocks Toggled blocks, where the key is the block name.
+ * @param {Function} props.toggleBlock   Toggle block.
  */
-export const LessonActionsBlockSettings = ( { activeBlocks, toggleBlock } ) => (
+export const LessonActionsBlockSettings = ( {
+	toggledBlocks,
+	toggleBlock,
+} ) => (
 	<InspectorControls>
 		<PanelBody title={ __( 'Additional Actions', 'sensei-lms' ) }>
 			<ToggleControl
 				checked={
-					false !== activeBlocks[ 'sensei-lms/button-reset-lesson' ]
+					false !== toggledBlocks[ 'sensei-lms/button-reset-lesson' ]
 				}
 				onChange={ toggleBlock( 'sensei-lms/button-reset-lesson' ) }
 				label={ __( 'Reset lesson', 'sensei-lms' ) }

--- a/assets/blocks/lesson-actions/lesson-actions-block/settings.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/settings.js
@@ -6,19 +6,20 @@ import { __ } from '@wordpress/i18n';
  * Inspector controls for lesson actions block.
  *
  * @param {Object}   props
- * @param {boolean}  props.resetLesson    Whether reset lesson is enabled.
- * @param {Function} props.setResetLesson Set reset lesson attribute.
+ * @param {boolean}  props.resetLessonOn     Whether reset lesson is enabled.
+ * @param {Function} props.toggleResetLesson Toggle reset lesson.
  */
-export function LessonActionsBlockSettings( { resetLesson, setResetLesson } ) {
-	return (
-		<InspectorControls>
-			<PanelBody title={ __( 'Additional Actions', 'sensei-lms' ) }>
-				<ToggleControl
-					checked={ resetLesson }
-					onChange={ setResetLesson }
-					label={ __( 'Reset lesson', 'sensei-lms' ) }
-				/>
-			</PanelBody>
-		</InspectorControls>
-	);
-}
+export const LessonActionsBlockSettings = ( {
+	resetLessonOn,
+	toggleResetLesson,
+} ) => (
+	<InspectorControls>
+		<PanelBody title={ __( 'Additional Actions', 'sensei-lms' ) }>
+			<ToggleControl
+				checked={ resetLessonOn }
+				onChange={ toggleResetLesson }
+				label={ __( 'Reset lesson', 'sensei-lms' ) }
+			/>
+		</PanelBody>
+	</InspectorControls>
+);


### PR DESCRIPTION
Part of #3821

### Changes proposed in this Pull Request

* It introduces the settings to the Lesson Actions, including the Reset Lesson action.
  * It persists the button state while it's being toggled until the user refreshes the page.

### Testing instructions

* Go to the lesson editor.
* Add the _Lesson actions_ block.
* Edit the _Reset lesson_ button.
* In the _Lesson actions_ sidebar settings, disable the _Reset lesson_.
* Enable the button again, and make sure the previous settings continue in the button.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="304" alt="Screen Shot 2021-01-12 at 18 15 20" src="https://user-images.githubusercontent.com/876340/104375450-25f46000-5502-11eb-8d3b-18dfa4e4dbec.png">
