### PR TITLE
Use Sensei_Notices in take course block

### DIFF
--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -52,7 +52,7 @@ class Sensei_Block_Take_Course {
 
 		if ( Sensei_Course::can_current_user_manually_enrol( $course_id ) ) {
 			if ( ! Sensei_Course::is_prerequisite_complete( $course_id ) ) {
-				$this->add_notice( Sensei()->course::get_course_prerequisite_message( $course_id ), 'info' );
+				Sensei()->notices->add_notice( Sensei()->course::get_course_prerequisite_message( $course_id ), 'info' );
 				$html = $this->render_disabled( $content );
 			} else {
 				$html = $this->render_with_start_course_form( $course_id, $content );
@@ -170,17 +170,5 @@ class Sensei_Block_Take_Course {
 		_deprecated_function( __METHOD__, '3.8.0', 'Sensei_Course::get_course_prerequisite_message' );
 
 		return Sensei()->course::get_course_prerequisite_message( $course_id );
-	}
-
-	/**
-	 * Helper method to avoid adding notices in the editor.
-	 *
-	 * @param string $content The notice content.
-	 * @param string $type    The notice type.
-	 */
-	private function add_notice( string $content, string $type ) {
-		if ( ! is_admin() ) {
-			Sensei()->notices->add_notice( $content, $type );
-		}
 	}
 }

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Block_Take_Course {
 
 	/**
-	 * Sensei_Contact_Teacher_Block constructor.
+	 * Sensei_Block_Take_Course constructor.
 	 */
 	public function __construct() {
 		add_action( 'init', [ $this, 'register_block' ] );
@@ -52,7 +52,8 @@ class Sensei_Block_Take_Course {
 
 		if ( Sensei_Course::can_current_user_manually_enrol( $course_id ) ) {
 			if ( ! Sensei_Course::is_prerequisite_complete( $course_id ) ) {
-				$html = $this->render_disabled_with_prerequisite( $course_id, $content );
+				$this->add_notice( Sensei()->course::get_course_prerequisite_message( $course_id ), 'info' );
+				$html = $this->render_disabled( $content );
 			} else {
 				$html = $this->render_with_start_course_form( $course_id, $content );
 			}
@@ -144,17 +145,15 @@ class Sensei_Block_Take_Course {
 	}
 
 	/**
-	 * Render disabled state when a prerequisite course is required.
+	 * Render with a disabled state.
 	 *
-	 * @param int    $course_id
 	 * @param string $content Block HTML.
 	 *
 	 * @return string
 	 */
-	private function render_disabled_with_prerequisite( $course_id, $content ) {
-		$notice  = '<div class="wp-block-sensei-button__notice">' . $this->get_course_prerequisite_message( $course_id ) . '</div>';
+	private function render_disabled( $content ) {
 		$content = preg_replace( '/(\<button)/i', '<button disabled="disabled"', $content );
-		$content = preg_replace( '/(<\/button>)/', '$1 ' . $notice, $content );
+
 		return $content;
 	}
 
@@ -163,34 +162,25 @@ class Sensei_Block_Take_Course {
 	 *
 	 * @param int $course_id
 	 *
+	 * @deprecated 3.8.0 use Sensei_Course::get_course_prerequisite_message.
+	 *
 	 * @return string
 	 */
 	public function get_course_prerequisite_message( $course_id ) {
-		$course_prerequisite_id   = absint( get_post_meta( $course_id, '_course_prerequisite', true ) );
-		$course_title             = get_the_title( $course_prerequisite_id );
-		$prerequisite_course_link = '<a href="' . esc_url( get_permalink( $course_prerequisite_id ) )
-			. '" title="'
-			. sprintf(
-			// translators: Placeholder $1$s is the course title.
-				esc_attr__( 'You must first complete: %1$s', 'sensei-lms' ),
-				$course_title
-			)
-			. '">' . $course_title . '</a>';
+		_deprecated_function( __METHOD__, '3.8.0', 'Sensei_Course::get_course_prerequisite_message' );
 
-		$complete_prerequisite_message = sprintf(
-		// translators: Placeholder $1$s is the course title.
-			esc_html__( 'You must first complete %1$s before taking this course.', 'sensei-lms' ),
-			$prerequisite_course_link
-		);
+		return Sensei()->course::get_course_prerequisite_message( $course_id );
+	}
 
-		/**
-		 * Filter sensei_course_complete_prerequisite_message.
-		 *
-		 * @param string $complete_prerequisite_message the message to filter
-		 *
-		 * @since 1.9.10
-		 */
-		return apply_filters( 'sensei_course_complete_prerequisite_message', $complete_prerequisite_message );
-
+	/**
+	 * Helper method to avoid adding notices in the editor.
+	 *
+	 * @param string $content The notice content.
+	 * @param string $type    The notice type.
+	 */
+	private function add_notice( string $content, string $type ) {
+		if ( ! is_admin() ) {
+			Sensei()->notices->add_notice( $content, $type );
+		}
 	}
 }

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3446,34 +3446,45 @@ class Sensei_Course {
 	 * @since 1.9.10
 	 */
 	public static function prerequisite_complete_message() {
-		if ( ! self::is_prerequisite_complete( get_the_ID(), get_current_user_id() ) ) {
-			$course_prerequisite_id   = absint( get_post_meta( get_the_ID(), '_course_prerequisite', true ) );
-			$course_title             = get_the_title( $course_prerequisite_id );
-			$prerequisite_course_link = '<a href="' . esc_url( get_permalink( $course_prerequisite_id ) )
-				. '" title="'
-				. sprintf(
-					// translators: Placeholder $1$s is the course title.
-					esc_attr__( 'You must first complete: %1$s', 'sensei-lms' ),
-					$course_title
-				)
-				 . '">' . $course_title . '</a>';
-
-			$complete_prerequisite_message = sprintf(
-				// translators: Placeholder $1$s is the course title.
-				esc_html__( 'You must first complete %1$s before viewing this course', 'sensei-lms' ),
-				$prerequisite_course_link
-			);
-
-			/**
-			 * Filter sensei_course_complete_prerequisite_message.
-			 *
-			 * @since 1.9.10
-			 * @param string $complete_prerequisite_message the message to filter
-			 */
-			$filtered_message = apply_filters( 'sensei_course_complete_prerequisite_message', $complete_prerequisite_message );
-
-			Sensei()->notices->add_notice( $filtered_message, 'info' );
+		if ( ! self::is_prerequisite_complete( get_the_ID() ) ) {
+			$message = self::get_course_prerequisite_message( get_the_ID() );
+			Sensei()->notices->add_notice( $message, 'info' );
 		}
+	}
+
+	/**
+	 * Generate the HTML of the course prerequisite notice.
+	 *
+	 * @param int $course_id The course id.
+	 *
+	 * @return string The HTML.
+	 */
+	public static function get_course_prerequisite_message( int $course_id ) : string {
+		$course_prerequisite_id   = absint( get_post_meta( $course_id, '_course_prerequisite', true ) );
+		$course_title             = get_the_title( $course_prerequisite_id );
+		$prerequisite_course_link = '<a href="' . esc_url( get_permalink( $course_prerequisite_id ) )
+			. '" title="'
+			. sprintf(
+				// translators: Placeholder $1$s is the course title.
+				esc_attr__( 'You must first complete: %1$s', 'sensei-lms' ),
+				$course_title
+			)
+			. '">' . $course_title . '</a>';
+
+		$complete_prerequisite_message = sprintf(
+			// translators: Placeholder $1$s is the course title.
+			esc_html__( 'You must first complete %1$s before taking this course.', 'sensei-lms' ),
+			$prerequisite_course_link
+		);
+
+		/**
+		 * Filter sensei_course_complete_prerequisite_message.
+		 *
+		 * @param string $complete_prerequisite_message the message to filter
+		 *
+		 * @since 1.9.10
+		 */
+		return apply_filters( 'sensei_course_complete_prerequisite_message', $complete_prerequisite_message );
 	}
 
 	/**

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -62,6 +62,8 @@ class Sensei_Notices {
 				),
 			)
 		);
+
+		add_action( 'template_redirect', [ $this, 'setup_block_notices' ] );
 	}
 
 	/**
@@ -83,8 +85,7 @@ class Sensei_Notices {
 		if ( $this->has_printed ) {
 			$this->maybe_print_notices();
 		}
-
-	} // end add_notice()
+	}
 
 	/**
 	 * Output all notices added
@@ -97,7 +98,8 @@ class Sensei_Notices {
 
 				$classes = 'sensei-message ' . $notice['type'];
 
-				echo '<div class="' . esc_attr( $classes ) . '">' . wp_kses( $notice['content'], $this->allowed_html ) . '</div>';
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in generate_notice
+				echo $this->generate_notice( $notice['type'], $notice['content'] );
 			}
 			// empty the notice queue to avoid reprinting the same notices.
 			$this->clear_notices();
@@ -106,8 +108,50 @@ class Sensei_Notices {
 
 		// set this to print immediately if notices are added after the notices were printed.
 		$this->has_printed = true;
+	}
 
-	} // end print_notice()
+	/**
+	 * Adds a filter to the content to add notices added by blocks.
+	 */
+	public function setup_block_notices() {
+		if ( is_singular( 'course' ) && ! Sensei()->course->is_legacy_course( get_post() ) ) {
+			add_filter( 'the_content', [ $this, 'prepend_notices_to_content' ] );
+		}
+	}
+
+	/**
+	 * Adds the notices before main content.
+	 *
+	 * @param string $content The post content.
+	 *
+	 * @return string The modified content.
+	 */
+	public function prepend_notices_to_content( string $content ) : string {
+		if ( in_the_loop() && is_main_query() ) {
+
+			ob_start();
+			$this->maybe_print_notices();
+			$notice = ob_get_clean();
+
+			return $notice . $content;
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Helper method which generates the HTML for a notice.
+	 *
+	 * @param string $type    Notice type.
+	 * @param string $content Notice content.
+	 *
+	 * @return string The HTML
+	 */
+	public function generate_notice( string $type, string $content ) : string {
+		$classes = 'sensei-message ' . $type;
+
+		return '<div class="' . esc_attr( $classes ) . '">' . wp_kses( $content, $this->allowed_html ) . '</div>';
+	}
 
 	/**
 	 *  Clear all notices
@@ -117,9 +161,8 @@ class Sensei_Notices {
 	public function clear_notices() {
 		// assign an empty array to clear all existing notices.
 		$this->notices = array();
-	} // end clear_notices()
-
-} // end Woothemes_Sensei_Notices
+	}
+}
 
 /**
  * Class Woothemes_Sensei_Notices

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -442,13 +442,13 @@ class Sensei_Main {
 			// Load Frontend Class
 			$this->frontend = new Sensei_Frontend();
 
-			// Load notice Class
-			$this->notices = new Sensei_Notices();
-
 			// Load built in themes support integration
 			$this->theme_integration_loader = new Sensei_Theme_Integration_Loader();
 
 		}
+
+		// Load notice Class
+		$this->notices = new Sensei_Notices();
 
 		// Load Grading Functionality
 		$this->grading = new Sensei_Grading( $this->main_plugin_file_name );

--- a/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
@@ -108,10 +108,14 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 
 		$result = $this->block->render_take_course_block( [], '<button>Take Course</button>' );
 
-		$notice = '/You must first complete <a .*>' . preg_quote( $course_pre->post_title, '/' ) . '<\/a> before taking this course/';
-
 		$this->assertContains( '<button disabled="disabled">Take Course</button>', $result, 'Button should be disabled' );
-		$this->assertRegExp( $notice, $result, 'Should contain notice of the prerequisite course' );
+
+		ob_start();
+		Sensei()->notices->maybe_print_notices();
+		$actual_notices = ob_get_clean();
+		$notice         = '/You must first complete <a .*>' . preg_quote( $course_pre->post_title, '/' ) . '<\/a> before taking this course/';
+
+		$this->assertRegExp( $notice, $actual_notices, 'Should contain notice of the prerequisite course' );
 
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR updates blocks to use the existing class for notices `Sensei_Notices`.
* A filter has been added in `the_content` which prepends the notices to the top of the content.
* The functionality of notices has been kept the same. We could consider adding more features to it (e.g. persistance between requests) when the need arises.
* The notices are able to to be added in single course pages only. More cases will be added as we blockify more content.

### Testing instructions

* Create a course with a prerequisite.
* Try to access the course and observe the notice in the top the page.