### PR TITLE
Fix lesson action buttons alignment

### DIFF
--- a/assets/blocks/button/button.scss
+++ b/assets/blocks/button/button.scss
@@ -27,3 +27,31 @@
 		text-decoration: none;
 	}
 }
+
+/**
+  * Buttons in container.
+  */
+.sensei-buttons-container {
+	margin: -12px;
+	overflow: hidden; /* Clearfix solution */
+}
+
+.sensei-buttons-container__button-block,
+body .editor-styles-wrapper .block-editor-inner-blocks .sensei-buttons-container__button-block {
+	float: left;
+	margin: 12px;
+
+	&.sensei-buttons-container__button-align-full,
+	&.sensei-buttons-container__button-align-center {
+		float: none;
+		clear: both;
+	}
+
+	&.sensei-buttons-container__button-align-right {
+		float: right;
+	}
+
+	.wp-block-sensei-button {
+		margin: 0;
+	}
+}

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { merge, find } from 'lodash';
+import classnames from 'classnames';
 
 import './color-hooks';
 import { EditButtonBlock } from './edit-button';
@@ -126,6 +127,20 @@ export const createButtonBlockType = ( {
 						{ ...options }
 					/>
 				);
+			},
+			getEditWrapperProps( { inContainer, align } ) {
+				if ( inContainer ) {
+					return {
+						className: classnames(
+							'sensei-buttons-container__button-block',
+							{
+								[ `sensei-buttons-container__button-align-${ align }` ]: align,
+							}
+						),
+					};
+				}
+
+				return {};
 			},
 			example: {
 				attributes: {

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -88,6 +88,10 @@ export const createButtonBlockType = ( {
 					type: 'boolean',
 					default: false,
 				},
+				inContainer: {
+					type: 'boolean',
+					default: false,
+				},
 			},
 			supports: {
 				color: {

--- a/assets/blocks/button/save-button.js
+++ b/assets/blocks/button/save-button.js
@@ -1,5 +1,6 @@
 import { RichText } from '@wordpress/block-editor';
 import { getButtonProps, getButtonWrapperProps } from './button-props';
+import classnames from 'classnames';
 
 /**
  * Save function for a Button block.
@@ -10,9 +11,9 @@ import { getButtonProps, getButtonWrapperProps } from './button-props';
  * @param {string} props.tagName    Output HTML tag name.
  */
 export const SaveButtonBlock = ( { attributes, className, tagName } ) => {
-	const { text } = attributes;
+	const { text, inContainer, align } = attributes;
 
-	return (
+	const content = (
 		<div { ...getButtonWrapperProps( { className, attributes } ) }>
 			<RichText.Content
 				{ ...getButtonProps( { attributes } ) }
@@ -21,4 +22,21 @@ export const SaveButtonBlock = ( { attributes, className, tagName } ) => {
 			/>
 		</div>
 	);
+
+	if ( inContainer ) {
+		return (
+			<div
+				className={ classnames(
+					'sensei-buttons-container__button-block',
+					{
+						[ `sensei-buttons-container__button-align-${ align }` ]: align,
+					}
+				) }
+			>
+				{ content }
+			</div>
+		);
+	}
+
+	return content;
 };

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -11,17 +11,24 @@ const innerBlocksTemplate = [
 
 /**
  * Edit lesson actions block component.
+ *
+ * @param {Object} props
+ * @param {string} props.className Custom class name.
  */
-const EditLessonActionsBlock = () => (
-	<InnerBlocks
-		allowedBlocks={ [
-			'sensei-lms/button-complete-lesson',
-			'sensei-lms/button-next-lesson',
-			'sensei-lms/button-reset-lesson',
-		] }
-		template={ innerBlocksTemplate }
-		templateLock="all"
-	/>
+const EditLessonActionsBlock = ( { className } ) => (
+	<div className={ className }>
+		<div className="sensei-buttons-container">
+			<InnerBlocks
+				allowedBlocks={ [
+					'sensei-lms/button-complete-lesson',
+					'sensei-lms/button-next-lesson',
+					'sensei-lms/button-reset-lesson',
+				] }
+				template={ innerBlocksTemplate }
+				templateLock="all"
+			/>
+		</div>
+	</div>
 );
 
 export default EditLessonActionsBlock;

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -1,9 +1,12 @@
 import { InnerBlocks } from '@wordpress/block-editor';
 
 const innerBlocksTemplate = [
-	[ 'sensei-lms/button-complete-lesson', {} ],
-	[ 'sensei-lms/button-next-lesson', {} ],
-	[ 'sensei-lms/button-reset-lesson', {} ],
+	[
+		'sensei-lms/button-complete-lesson',
+		{ inContainer: true, align: 'full' },
+	],
+	[ 'sensei-lms/button-next-lesson', { inContainer: true } ],
+	[ 'sensei-lms/button-reset-lesson', { inContainer: true } ],
 ];
 
 /**

--- a/assets/blocks/lesson-actions/lesson-actions-block/save.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/save.js
@@ -1,5 +1,11 @@
 import { InnerBlocks } from '@wordpress/block-editor';
 
-export default function saveLessonActionsBlock() {
-	return <InnerBlocks.Content />;
+export default function saveLessonActionsBlock( { className } ) {
+	return (
+		<div className={ className }>
+			<div className="sensei-buttons-container">
+				<InnerBlocks.Content />
+			</div>
+		</div>
+	);
 }

--- a/assets/blocks/single-lesson.editor.scss
+++ b/assets/blocks/single-lesson.editor.scss
@@ -1,0 +1,1 @@
+@import 'button/button.editor';

--- a/assets/blocks/single-lesson.scss
+++ b/assets/blocks/single-lesson.scss
@@ -1,0 +1,1 @@
+@import 'button/button';

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -17,7 +17,21 @@ class Sensei_Lesson_Blocks {
 	 * Sensei_Blocks constructor.
 	 */
 	public function __construct() {
+		add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
+	}
+
+	/**
+	 * Enqueue frontend and editor assets.
+	 *
+	 * @access private
+	 */
+	public function enqueue_block_assets() {
+		if ( 'lesson' !== get_post_type() ) {
+			return;
+		}
+
+		Sensei()->assets->enqueue( 'sensei-single-lesson', 'blocks/single-lesson.css' );
 	}
 
 	/**
@@ -31,5 +45,6 @@ class Sensei_Lesson_Blocks {
 		}
 
 		Sensei()->assets->enqueue( 'sensei-single-lesson-blocks', 'blocks/sensei-single-lesson-blocks.js', [], true );
+		Sensei()->assets->enqueue( 'sensei-single-lesson-editor', 'blocks/single-lesson.editor.css' );
 	}
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,6 +36,8 @@ const files = [
 	'blocks/single-course.scss',
 	'blocks/single-course.editor.scss',
 	'blocks/sensei-single-lesson-blocks.js',
+	'blocks/single-lesson.scss',
+	'blocks/single-lesson.editor.scss',
 	'admin/exit-survey/index.js',
 	'admin/exit-survey/exit-survey.scss',
 	'css/enrolment-debug.scss',


### PR DESCRIPTION
Part of #3821

### Changes proposed in this Pull Request

* This PR fixes the lesson action buttons alignment.
* It introduces the behavior to use the buttons inside a container. It can also be used by other blocks in the future.

The _left_ alignment aligns the element with `float: left` (default), while the _right_ alignment, sets a `float: right`. The alignment _full_ and _center_ removes the `float` and adds a `clear: both` because we don't want other elements in the same line with these alignments.

### Testing instructions

* Add the _Lesson actions_ block to a lesson, and make sure the initial layout is correct (see the [issue](https://github.com/Automattic/sensei/issues/3821)).
* Play with the alignments, and make sure it works properly in the editor, and in the frontend.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/104636715-8b6f5a80-5682-11eb-8b30-1bd321835203.mp4

