### PR TITLE
Minor tool fixes and additions

### DIFF
--- a/assets/css/tools.scss
+++ b/assets/css/tools.scss
@@ -1,11 +1,18 @@
 table#sensei-tools {
 	th, td {
-		padding: 2em;
+		padding: 1.5em;
 		> div {
-			margin-bottom: .5em;
-
 			&.name {
 				font-weight: bold;
+				margin-bottom: .5em;
+			}
+
+			&.description {
+				margin-bottom: .5em;
+			}
+
+			&.notice {
+				margin-bottom: 0;
 			}
 		}
 	}

--- a/assets/css/tools.scss
+++ b/assets/css/tools.scss
@@ -1,0 +1,12 @@
+table#sensei-tools {
+	th, td {
+		padding: 2em;
+		> div {
+			margin-bottom: .5em;
+
+			&.name {
+				font-weight: bold;
+			}
+		}
+	}
+}

--- a/includes/admin/class-sensei-tools.php
+++ b/includes/admin/class-sensei-tools.php
@@ -154,6 +154,8 @@ class Sensei_Tools {
 	 * Output the tools page.
 	 */
 	public function output() {
+		Sensei()->assets->enqueue( 'sensei-tools', 'css/tools.css' );
+
 		$tools = $this->get_tools();
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/includes/admin/class-sensei-tools.php
+++ b/includes/admin/class-sensei-tools.php
@@ -122,6 +122,14 @@ class Sensei_Tools {
 
 			$tool = $tools[ $tool_id ];
 
+			if ( ! $tool->is_available() ) {
+				$this->add_user_message( __( 'This tool is not currently available. Please try again later.', 'sensei-lms' ), true );
+
+				wp_safe_redirect( $this->get_tools_url() );
+
+				exit;
+			}
+
 			if ( $this->is_interactive_tool( $tool ) ) {
 				// Let the tool do its own nonce check and processing.
 				$tool->process();

--- a/includes/admin/tools/class-sensei-tool-enrolment-debug.php
+++ b/includes/admin/tools/class-sensei-tool-enrolment-debug.php
@@ -407,4 +407,13 @@ class Sensei_Tool_Enrolment_Debug implements Sensei_Tool_Interface, Sensei_Tool_
 
 		return $row_data;
 	}
+
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
+	public function is_available() {
+		return true;
+	}
 }

--- a/includes/admin/tools/class-sensei-tool-ensure-roles.php
+++ b/includes/admin/tools/class-sensei-tool-ensure-roles.php
@@ -54,4 +54,13 @@ class Sensei_Tool_Ensure_Roles implements Sensei_Tool_Interface {
 
 		Sensei_Tools::instance()->add_user_message( __( 'Sensei LMS specific roles and capabilities have been set up again.', 'sensei-lms' ) );
 	}
+
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
+	public function is_available() {
+		return true;
+	}
 }

--- a/includes/admin/tools/class-sensei-tool-interface.php
+++ b/includes/admin/tools/class-sensei-tool-interface.php
@@ -41,4 +41,11 @@ interface Sensei_Tool_Interface {
 	 * Process the tool action. Nonce will be checked for non-interactive tools.
 	 */
 	public function process();
+
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
+	public function is_available();
 }

--- a/includes/admin/tools/class-sensei-tool-module-slugs-mismatch.php
+++ b/includes/admin/tools/class-sensei-tool-module-slugs-mismatch.php
@@ -140,4 +140,13 @@ class Sensei_Tool_Module_Slugs_Mismatch implements Sensei_Tool_Interface {
 
 		return $message;
 	}
+
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
+	public function is_available() {
+		return true;
+	}
 }

--- a/includes/admin/tools/class-sensei-tool-recalculate-course-enrolment.php
+++ b/includes/admin/tools/class-sensei-tool-recalculate-course-enrolment.php
@@ -101,4 +101,13 @@ class Sensei_Tool_Recalculate_Course_Enrolment implements Sensei_Tool_Interface,
 		wp_safe_redirect( Sensei_Tools::instance()->get_tools_url() );
 		exit;
 	}
+
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
+	public function is_available() {
+		return true;
+	}
 }

--- a/includes/admin/tools/class-sensei-tool-recalculate-enrolment.php
+++ b/includes/admin/tools/class-sensei-tool-recalculate-enrolment.php
@@ -52,4 +52,13 @@ class Sensei_Tool_Recalculate_Enrolment implements Sensei_Tool_Interface {
 
 		Sensei_Tools::instance()->add_user_message( __( 'Course enrollment cache has been invalidated and is being recalculated.', 'sensei-lms' ) );
 	}
+
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
+	public function is_available() {
+		return true;
+	}
 }

--- a/includes/admin/tools/class-sensei-tool-remove-deleted-user-data.php
+++ b/includes/admin/tools/class-sensei-tool-remove-deleted-user-data.php
@@ -68,4 +68,13 @@ class Sensei_Tool_Remove_Deleted_User_Data implements Sensei_Tool_Interface {
 			Sensei()->flush_comment_counts_cache( $post_id );
 		}
 	}
+
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
+	public function is_available() {
+		return true;
+	}
 }

--- a/includes/admin/views/html-admin-page-tools.php
+++ b/includes/admin/views/html-admin-page-tools.php
@@ -23,10 +23,8 @@ require __DIR__ . '/html-admin-page-tools-header.php';
 		?>
 			<tr>
 				<th>
-					<p>
-						<div class="name"><strong><?php echo esc_html( $tool->get_name() ); ?></strong></div>
-						<div class="description"><?php echo esc_html( $tool->get_description() ); ?></div>
-					</p>
+					<div class="name"><?php echo esc_html( $tool->get_name() ); ?></div>
+					<div class="description"><?php echo esc_html( $tool->get_description() ); ?></div>
 				</th>
 				<td>
 					<p>
@@ -38,10 +36,10 @@ require __DIR__ . '/html-admin-page-tools-header.php';
 						}
 
 						if ( $tool->is_available() ) {
-							echo '<a href="' . esc_url( $url ) .'" class="button button-large">' .  esc_html( $label ) . '</a>';
+							echo '<a href="' . esc_url( $url ) . '" class="button button-large">' . esc_html( $label ) . '</a>';
 						} else {
 							$helper = __( 'This tool is not currently available', 'sensei-lms' );
-							echo '<button class="button button-large" disabled="disabled">' .  esc_html( $label ) . '</button>';
+							echo '<button class="button button-large" disabled="disabled">' . esc_html( $label ) . '</button>';
 						}
 						?>
 					</p>

--- a/includes/admin/views/html-admin-page-tools.php
+++ b/includes/admin/views/html-admin-page-tools.php
@@ -25,6 +25,17 @@ require __DIR__ . '/html-admin-page-tools-header.php';
 				<th>
 					<div class="name"><?php echo esc_html( $tool->get_name() ); ?></div>
 					<div class="description"><?php echo esc_html( $tool->get_description() ); ?></div>
+					<?php
+					/**
+					 * Display additional information to a tools listing, such as status.
+					 *
+					 * @hook sensei_tools_listing_after_{$tool_id}
+					 * @since 3.7.0
+					 *
+					 * @param Sensei_Tool_Interface $tool Tool object.
+					 */
+					do_action( "sensei_tools_listing_after_{$tool->get_id()}", $tool );
+					?>
 				</th>
 				<td>
 					<p>

--- a/includes/admin/views/html-admin-page-tools.php
+++ b/includes/admin/views/html-admin-page-tools.php
@@ -36,8 +36,14 @@ require __DIR__ . '/html-admin-page-tools-header.php';
 						if ( ! Sensei_Tools::instance()->is_interactive_tool( $tool ) ) {
 							$label = __( 'Run Action', 'sensei-lms' );
 						}
+
+						if ( $tool->is_available() ) {
+							echo '<a href="' . esc_url( $url ) .'" class="button button-large">' .  esc_html( $label ) . '</a>';
+						} else {
+							$helper = __( 'This tool is not currently available', 'sensei-lms' );
+							echo '<button class="button button-large" disabled="disabled">' .  esc_html( $label ) . '</button>';
+						}
 						?>
-						<a href="<?php echo esc_url( $url ); ?>" class="button button-large"><?php echo esc_html( $label ); ?></a>
 					</p>
 				</td>
 			</tr>

--- a/includes/admin/views/html-admin-page-tools.php
+++ b/includes/admin/views/html-admin-page-tools.php
@@ -27,12 +27,12 @@ require __DIR__ . '/html-admin-page-tools-header.php';
 					<div class="description"><?php echo esc_html( $tool->get_description() ); ?></div>
 					<?php
 					/**
-					 * Display additional information to a tools listing, such as status.
+					 * Display additional information for a specific tool, such as status.
 					 *
 					 * @hook sensei_tools_listing_after_{$tool_id}
 					 * @since 3.7.0
 					 *
-					 * @param Sensei_Tool_Interface $tool Tool object.
+					 * @param {Sensei_Tool_Interface} $tool Tool object.
 					 */
 					do_action( "sensei_tools_listing_after_{$tool->get_id()}", $tool );
 					?>
@@ -50,7 +50,7 @@ require __DIR__ . '/html-admin-page-tools-header.php';
 							echo '<a href="' . esc_url( $url ) . '" class="button button-large">' . esc_html( $label ) . '</a>';
 						} else {
 							$helper = __( 'This tool is not currently available', 'sensei-lms' );
-							echo '<button class="button button-large" disabled="disabled">' . esc_html( $label ) . '</button>';
+							echo '<button class="button button-large" disabled="disabled" title="' . esc_attr( $helper ) . '">' . esc_html( $label ) . '</button>';
 						}
 						?>
 					</p>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,6 +37,7 @@ const files = [
 	'blocks/single-course.editor.scss',
 	'admin/exit-survey/index.js',
 	'admin/exit-survey/exit-survey.scss',
+	'css/tools.scss',
 	'css/enrolment-debug.scss',
 	'css/frontend.scss',
 	'css/admin-custom.css',


### PR DESCRIPTION
These are some minor changes to the tools API that I found when implementing on Sensei Certificates. These shouldn't require a new beta as they're not very controversial/critical.

### Changes proposed in this Pull Request

* Adds `Sensei_Tool_Interface::is_available` so we can disable tools (for example: queue a background job and disable tool while job is running).
* Adds `sensei_tools_listing_after_{$tool_id}` action so we can provide some additional status on a running tool's background job.
* Fixes some HTML issues on the tools page.

### Testing instructions

* All built-in tools are always available. I thought about making recalculate learners based on background job, but since this just resets the salt, it didn't seem right. If you want to see what a job would look like if disabled, set `return false` in one of the built-in tool's `is_available()` method.
* Add this snippet to test action:
```php
add_action(
	'sensei_tools_listing_after_ensure-roles',
	function() {
		echo '<div class="notice inline notice-info"><p>This task is in progress.</p></div>';
	}
);
```

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_tools_listing_after_{$tool_id}`: Show additional context on tool listing page.