### PR TITLE
Add toolbar dropdown component for the editor

### DIFF
--- a/assets/blocks/editor-components/styles.scss
+++ b/assets/blocks/editor-components/styles.scss
@@ -1,0 +1,1 @@
+@import './toolbar-dropdown/styles';

--- a/assets/blocks/editor-components/toolbar-dropdown/index.js
+++ b/assets/blocks/editor-components/toolbar-dropdown/index.js
@@ -20,8 +20,9 @@ import classnames from 'classnames';
  * @param {DropdownOption[]} props.options        Dropdown options.
  * @param {string}           [props.optionsLabel] Options label.
  * @param {Object}           props.icon           Icon for the toolbar.
- * @param {string}           props.value          Current value.
- * @param {Function}         props.onChange       Change function.
+ * @param {string}           props.value          Current dropdown value.
+ * @param {Function}         props.onChange       Dropdown change callback, which receive
+ *                                                the new value as argument.
  */
 const ToolbarDropdown = ( {
 	options,

--- a/assets/blocks/editor-components/toolbar-dropdown/index.js
+++ b/assets/blocks/editor-components/toolbar-dropdown/index.js
@@ -1,0 +1,78 @@
+import {
+	Button,
+	Dropdown,
+	MenuGroup,
+	MenuItem,
+	NavigableMenu,
+} from '@wordpress/components';
+import classnames from 'classnames';
+
+/**
+ * @typedef {Object} DropdownOption
+ *
+ * @property {string} label Option label.
+ * @property {string} value Option value.
+ */
+/**
+ * Dropdown for the editor toolbar.
+ *
+ * @param {Object}           props
+ * @param {DropdownOption[]} props.options        Dropdown options.
+ * @param {string}           [props.optionsLabel] Options label.
+ * @param {Object}           props.icon           Icon for the toolbar.
+ * @param {string}           props.value          Current value.
+ * @param {Function}         props.onChange       Change function.
+ */
+const ToolbarDropdown = ( {
+	options,
+	optionsLabel,
+	icon,
+	value,
+	onChange,
+} ) => {
+	const selectedOption = options.find( ( option ) => value === option.value );
+
+	return (
+		<Dropdown
+			renderToggle={ ( { isOpen, onToggle } ) => (
+				<Button
+					onClick={ onToggle }
+					icon={ icon }
+					aria-expanded={ isOpen }
+					aria-haspopup="true"
+				>
+					{ selectedOption.label }
+				</Button>
+			) }
+			renderContent={ ( { onClose } ) => (
+				<NavigableMenu role="menu" stopNavigationEvents>
+					<MenuGroup label={ optionsLabel }>
+						{ options.map( ( option ) => {
+							const isSelected =
+								option.value === selectedOption.value;
+
+							return (
+								<MenuItem
+									key={ option.value }
+									role="menuitemradio"
+									isSelected={ isSelected }
+									className={ classnames( {
+										'sensei-toolbar-dropdown-item-checked': isSelected,
+									} ) }
+									onClick={ () => {
+										onChange( option.value );
+										onClose();
+									} }
+								>
+									{ option.label }
+								</MenuItem>
+							);
+						} ) }
+					</MenuGroup>
+				</NavigableMenu>
+			) }
+		/>
+	);
+};
+
+export default ToolbarDropdown;

--- a/assets/blocks/editor-components/toolbar-dropdown/index.js
+++ b/assets/blocks/editor-components/toolbar-dropdown/index.js
@@ -35,6 +35,7 @@ const ToolbarDropdown = ( {
 
 	return (
 		<Dropdown
+			popoverProps={ { isAlternate: true } }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
 					onClick={ onToggle }

--- a/assets/blocks/editor-components/toolbar-dropdown/styles.scss
+++ b/assets/blocks/editor-components/toolbar-dropdown/styles.scss
@@ -1,0 +1,11 @@
+.sensei-toolbar-dropdown-item-checked {
+	position: relative;
+	padding-right: 30px;
+	&::after {
+		font-family: dashicons;
+		content: "\f147";
+		font-size: 20px;
+		position: absolute;
+		right: 0;
+	}
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,6 +31,7 @@ const files = [
 	'data-port/import.js',
 	'data-port/export.js',
 	'data-port/style.scss',
+	'blocks/editor-components/styles.scss',
 	'blocks/course-outline/frontend.js',
 	'blocks/sensei-single-course-blocks.js',
 	'blocks/single-course.scss',


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR introduces a generic dropdown to be used in toolbars, so we can use that for the restriction block, for the quiz blocks, and so on. Part of the code was borrowed from https://github.com/Automattic/sensei/pull/3849. Thank you, @gkaragia!

### Testing instructions

You can test that in the [`add/lesson-actions-preview` WIP branch](https://github.com/Automattic/sensei/pull/3903).

* Go to the lessons editor, and add the Lesson actions block.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/104960525-259d0e80-59b3-11eb-88f0-c7778d3d3b8e.mov
