### PR TITLE
Fix components toggle

### DIFF
--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -63,7 +63,11 @@ const useToggleBlocks = ( {
 			newBlocks = [
 				...parentBlock.innerBlocks,
 				createBlock( blockName, blocksAttributes[ blockName ] || {} ),
-			];
+			].sort(
+				( a, b ) =>
+					ALLOWED_BLOCKS.indexOf( a.name ) -
+					ALLOWED_BLOCKS.indexOf( b.name )
+			);
 		} else if ( ! on && toggledBlock ) {
 			// Remove block.
 			newBlocks = parentBlock.innerBlocks.filter(

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -6,7 +6,8 @@ import { __ } from '@wordpress/i18n';
 
 import { LessonActionsBlockSettings } from './settings';
 
-const ALLOWED_BLOCKS = [
+// The action blocks, ordered.
+const ACTION_BLOCKS = [
 	'sensei-lms/button-complete-lesson',
 	'sensei-lms/button-next-lesson',
 	'sensei-lms/button-reset-lesson',
@@ -25,7 +26,7 @@ const BLOCKS_DEFAULT_ATTRIBUTES = {
 	},
 };
 
-const INNER_BLOCKS_TEMPLATE = ALLOWED_BLOCKS.map( ( blockName ) => [
+const INNER_BLOCKS_TEMPLATE = ACTION_BLOCKS.map( ( blockName ) => [
 	blockName,
 	{ ...BLOCKS_DEFAULT_ATTRIBUTES[ blockName ] },
 ] );
@@ -77,8 +78,8 @@ const useToggleBlocks = ( {
 				} ),
 			].sort(
 				( a, b ) =>
-					ALLOWED_BLOCKS.indexOf( a.name ) -
-					ALLOWED_BLOCKS.indexOf( b.name )
+					ACTION_BLOCKS.indexOf( a.name ) -
+					ACTION_BLOCKS.indexOf( b.name )
 			);
 		} else if ( ! on && toggledBlock ) {
 			// Remove block.
@@ -147,7 +148,7 @@ const EditLessonActionsBlock = ( {
 			<div className="sensei-buttons-container">
 				<LessonActionsBlockSettings toggleBlocks={ toggleBlocks } />
 				<InnerBlocks
-					allowedBlocks={ ALLOWED_BLOCKS }
+					allowedBlocks={ ACTION_BLOCKS }
 					template={ filteredInnerBlocksTemplate }
 					templateLock="all"
 				/>

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -11,14 +11,23 @@ const ALLOWED_BLOCKS = [
 	'sensei-lms/button-next-lesson',
 	'sensei-lms/button-reset-lesson',
 ];
+
+const BLOCKS_DEFAULT_ATTRIBUTES = {
+	'sensei-lms/button-complete-lesson': {
+		inContainer: true,
+		align: 'full',
+	},
+	'sensei-lms/button-next-lesson': {
+		inContainer: true,
+	},
+	'sensei-lms/button-reset-lesson': {
+		inContainer: true,
+	},
+};
+
 const INNER_BLOCKS_TEMPLATE = ALLOWED_BLOCKS.map( ( blockName ) => [
 	blockName,
-	{
-		inContainer: true,
-		...( 'sensei-lms/button-complete-lesson' === blockName && {
-			align: 'full',
-		} ),
-	},
+	{ ...BLOCKS_DEFAULT_ATTRIBUTES[ blockName ] },
 ] );
 
 /**
@@ -59,10 +68,13 @@ const useToggleBlocks = ( {
 		let newBlocks = null;
 
 		if ( on && ! toggledBlock ) {
-			// Add block using the previous attributes if it exists.
+			// Add block using the default attributes, and the previous attributes if it exists.
 			newBlocks = [
 				...parentBlock.innerBlocks,
-				createBlock( blockName, blocksAttributes[ blockName ] || {} ),
+				createBlock( blockName, {
+					...BLOCKS_DEFAULT_ATTRIBUTES[ blockName ],
+					...blocksAttributes[ blockName ],
+				} ),
 			].sort(
 				( a, b ) =>
 					ALLOWED_BLOCKS.indexOf( a.name ) -


### PR DESCRIPTION
### Changes proposed in this Pull Request

It fixes 2 issues with the _Lesson actions_ components toggle.

**Issue:** When toggling a component different than the last one, it was missing the attributes. It happened because we were adding the block always at the end of the array, and it causes some issues in the `InnerBlock` because it's [different from the `template` order](https://github.com/WordPress/gutenberg/blob/master/packages/blocks/src/api/templates.js#L61).
**Solution:** When the component is enabled, it's added in the correct order.

**Issue:** When disabling components, and refreshing the page, if we enable them again it misses the default attributes because it's not in the `InnerBlock` templates when loading the page.
**Solution:** When restoring a block, it adds the default attributes.

### Testing instructions

* Just for test, add the Complete lesson block as able to toggle in the `useToggleBlocks`, adding the following item to the `blocks` array:
```
{
    blockName: 'sensei-lms/button-complete-lesson',
    label: __( 'Complete lesson', 'sensei-lms' ),
},
```
* Change the styles for the complete and the reset buttons.
* Disable, and enable them, and make sure they are in the correct position with the same styles.
* Disable both, save, refresh the page, restore them again, and make sure they are with the default alignment in the correct position.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/105062367-4ae45800-5a59-11eb-858d-5451cdb88536.mov
