### PR TITLE
Lesson Actions: Add `View quiz` button

### DIFF
--- a/assets/blocks/lesson-actions/index.js
+++ b/assets/blocks/lesson-actions/index.js
@@ -2,3 +2,4 @@ export { default as LessonActionsBlock } from './lesson-actions-block';
 export { default as CompleteLessonBlock } from './complete-lesson-block';
 export { default as NextLessonBlock } from './next-lesson-block';
 export { default as ResetLessonBlock } from './reset-lesson-block';
+export { default as ViewQuizBlock } from './view-quiz-block';

--- a/assets/blocks/lesson-actions/lesson-actions-block/block.json
+++ b/assets/blocks/lesson-actions/lesson-actions-block/block.json
@@ -8,8 +8,7 @@
     "toggledBlocks": {
       "type": "object",
       "default": {
-				"sensei-lms/button-reset-lesson": true,
-				"sensei-lms/button-view-quiz": false
+				"sensei-lms/button-reset-lesson": true
       }
     }
   }

--- a/assets/blocks/lesson-actions/lesson-actions-block/block.json
+++ b/assets/blocks/lesson-actions/lesson-actions-block/block.json
@@ -8,7 +8,8 @@
     "toggledBlocks": {
       "type": "object",
       "default": {
-        "sensei-lms/button-reset-lesson": true
+				"sensei-lms/button-reset-lesson": true,
+				"sensei-lms/button-view-quiz": false
       }
     }
   }

--- a/assets/blocks/lesson-actions/lesson-actions-block/block.json
+++ b/assets/blocks/lesson-actions/lesson-actions-block/block.json
@@ -8,7 +8,7 @@
     "toggledBlocks": {
       "type": "object",
       "default": {
-				"sensei-lms/button-reset-lesson": true
+        "sensei-lms/button-reset-lesson": true
       }
     }
   }

--- a/assets/blocks/lesson-actions/lesson-actions-block/constants.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/constants.js
@@ -1,5 +1,6 @@
 // The action blocks, ordered.
 export const ACTION_BLOCKS = [
+	'sensei-lms/button-view-quiz',
 	'sensei-lms/button-complete-lesson',
 	'sensei-lms/button-next-lesson',
 	'sensei-lms/button-reset-lesson',
@@ -14,6 +15,9 @@ export const BLOCKS_DEFAULT_ATTRIBUTES = {
 		inContainer: true,
 	},
 	'sensei-lms/button-reset-lesson': {
+		inContainer: true,
+	},
+	'sensei-lms/button-view-quiz': {
 		inContainer: true,
 	},
 };
@@ -31,5 +35,8 @@ export const PREVIEW_STATE = {
 		'sensei-lms/button-next-lesson',
 		'sensei-lms/button-reset-lesson',
 	],
-	[ IN_PROGRESS_PREVIEW ]: [ 'sensei-lms/button-complete-lesson' ],
+	[ IN_PROGRESS_PREVIEW ]: [
+		'sensei-lms/button-view-quiz',
+		'sensei-lms/button-complete-lesson'
+	],
 };

--- a/assets/blocks/lesson-actions/lesson-actions-block/constants.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/constants.js
@@ -9,7 +9,6 @@ export const ACTION_BLOCKS = [
 export const BLOCKS_DEFAULT_ATTRIBUTES = {
 	'sensei-lms/button-complete-lesson': {
 		inContainer: true,
-		align: 'full',
 	},
 	'sensei-lms/button-next-lesson': {
 		inContainer: true,

--- a/assets/blocks/lesson-actions/lesson-actions-block/constants.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/constants.js
@@ -36,6 +36,6 @@ export const PREVIEW_STATE = {
 	],
 	[ IN_PROGRESS_PREVIEW ]: [
 		'sensei-lms/button-view-quiz',
-		'sensei-lms/button-complete-lesson'
+		'sensei-lms/button-complete-lesson',
 	],
 };

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -1,57 +1,17 @@
-import { useState, useEffect } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
 
 import usePreviewState from './use-preview-state';
 import useToggleBlocks from './use-toggle-blocks';
+import useHasQuiz from './use-has-quiz';
+
 import { LessonActionsBlockSettings } from './settings';
 import {
 	ACTION_BLOCKS,
 	INNER_BLOCKS_TEMPLATE,
 	IN_PROGRESS_PREVIEW,
 } from './constants';
-
-/**
- * Has quiz hook.
- *
- * @param {Object}   options            Hook options.
- * @param {Function} options.quizToggle Toggle the quiz block.
- *
- * @return {boolean} If a quiz exists with questions.
- */
-const useHasQuiz = ( { quizToggle } ) => {
-	const [ quizEventListener ] = useState( null );
-	const [ hasQuiz, setHasQuiz ] = useState( () => {
-		const questionCount = document.getElementById( 'question_counter' );
-
-		return questionCount && parseInt( questionCount.value, 10 ) > 0;
-	} );
-
-	useEffect( () => {
-		quizToggle( hasQuiz );
-	}, [ hasQuiz, quizToggle ] );
-
-	useEffect( () => {
-		const quizToggleEventHandler = ( event ) => {
-			setHasQuiz( event.detail.questions > 0 );
-		};
-
-		window.addEventListener(
-			'sensei-quiz-editor-question-count-updated',
-			quizToggleEventHandler
-		);
-
-		return () => {
-			window.removeEventListener(
-				'sensei-quiz-editor-question-count-updated',
-				quizToggleEventHandler
-			);
-		};
-	}, [ quizEventListener ] );
-
-	return hasQuiz;
-};
 
 /**
  * Edit lesson actions block component.

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -1,3 +1,4 @@
+import { useState, useEffect } from '@wordpress/element';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 import classnames from 'classnames';
@@ -10,6 +11,47 @@ import {
 	INNER_BLOCKS_TEMPLATE,
 	IN_PROGRESS_PREVIEW,
 } from './constants';
+
+/**
+ * Has quiz hook.
+ *
+ * @param {Object}   options            Hook options.
+ * @param {Function} options.quizToggle Toggle the quiz block.
+ *
+ * @return {boolean} If a quiz exists with questions.
+ */
+const useHasQuiz = ( { quizToggle } ) => {
+	const [ quizEventListener ] = useState( null );
+	const [ hasQuiz, setHasQuiz ] = useState( () => {
+		const questionCount = document.getElementById( 'question_counter' );
+
+		return questionCount && parseInt( questionCount.value, 10 ) > 0;
+	} );
+
+	useEffect( () => {
+		quizToggle( hasQuiz );
+	}, [ hasQuiz, quizToggle ] );
+
+	useEffect( () => {
+		const quizToggleEventHandler = ( event ) => {
+			setHasQuiz( event.detail.questions > 0 );
+		};
+
+		window.addEventListener(
+			'sensei-quiz-editor-question-count-updated',
+			quizToggleEventHandler
+		);
+
+		return () => {
+			window.removeEventListener(
+				'sensei-quiz-editor-question-count-updated',
+				quizToggleEventHandler
+			);
+		};
+	}, [ quizEventListener ] );
+
+	return hasQuiz;
+};
 
 /**
  * Edit lesson actions block component.
@@ -40,7 +82,16 @@ const EditLessonActionsBlock = ( {
 				blockName: 'sensei-lms/button-reset-lesson',
 				label: __( 'Reset lesson', 'sensei-lms' ),
 			},
+			{
+				blockName: 'sensei-lms/button-view-quiz',
+			},
 		],
+	} );
+
+	useHasQuiz( {
+		quizToggle: toggleBlocks.find(
+			( i ) => i.blockName === 'sensei-lms/button-view-quiz'
+		).onToggle,
 	} );
 
 	// Filter inner blocks based on the settings.
@@ -48,12 +99,14 @@ const EditLessonActionsBlock = ( {
 		( i ) => false !== toggledBlocks[ i[ 0 ] ]
 	);
 
+	const userToggleBlocks = toggleBlocks.filter( ( i ) => false !== i.label );
+
 	return (
 		<>
 			<LessonActionsBlockSettings
 				previewState={ previewState }
 				onPreviewChange={ onPreviewChange }
-				toggleBlocks={ toggleBlocks }
+				toggleBlocks={ userToggleBlocks }
 			/>
 			<div
 				className={ classnames(

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -42,36 +42,29 @@ const EditLessonActionsBlock = ( {
 				blockName: 'sensei-lms/button-reset-lesson',
 				label: __( 'Reset lesson', 'sensei-lms' ),
 			},
-			{
-				blockName: 'sensei-lms/button-view-quiz',
-			},
 		],
 	} );
 
-	useHasQuiz( {
-		quizToggle: toggleBlocks.find(
-			( i ) => i.blockName === 'sensei-lms/button-view-quiz'
-		).onToggle,
-	} );
+	const hasQuiz = useHasQuiz();
+	const quizStateClass = hasQuiz ? 'has-quiz' : 'no-quiz';
 
 	// Filter inner blocks based on the settings.
 	const filteredInnerBlocksTemplate = INNER_BLOCKS_TEMPLATE.filter(
 		( i ) => false !== toggledBlocks[ i[ 0 ] ]
 	);
 
-	const userToggleBlocks = toggleBlocks.filter( ( i ) => false !== i.label );
-
 	return (
 		<>
 			<LessonActionsBlockSettings
 				previewState={ previewState }
 				onPreviewChange={ onPreviewChange }
-				toggleBlocks={ userToggleBlocks }
+				toggleBlocks={ toggleBlocks }
 			/>
 			<div
 				className={ classnames(
 					className,
-					`wp-block-sensei-lms-lesson-actions__preview-${ previewState }`
+					`wp-block-sensei-lms-lesson-actions__preview-${ previewState }`,
+					`wp-block-sensei-lms-lesson-actions__${ quizStateClass }`
 				) }
 			>
 				<div className="sensei-buttons-container">

--- a/assets/blocks/lesson-actions/lesson-actions-block/style.editor.scss
+++ b/assets/blocks/lesson-actions/lesson-actions-block/style.editor.scss
@@ -1,12 +1,18 @@
 .wp-block-sensei-lms-lesson-actions {
 	&__preview-completed {
-		.wp-block-sensei-lms-button-complete-lesson {
+		.wp-block-sensei-lms-button-complete-lesson,
+		.wp-block-sensei-lms-button-view-quiz {
 			opacity: 10%;
 		}
 	}
 	&__preview-in-progress {
 		.wp-block-sensei-lms-button-reset-lesson,
 		.wp-block-sensei-lms-button-next-lesson {
+			opacity: 10%;
+		}
+	}
+	&__no-quiz {
+		.wp-block-sensei-lms-button-view-quiz {
 			opacity: 10%;
 		}
 	}

--- a/assets/blocks/lesson-actions/lesson-actions-block/use-has-quiz.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/use-has-quiz.js
@@ -3,21 +3,14 @@ import { useEffect, useState } from '@wordpress/element';
 /**
  * Has quiz hook.
  *
- * @param {Object}   options            Hook options.
- * @param {Function} options.quizToggle Toggle the quiz block.
- *
  * @return {boolean} If a quiz exists with questions.
  */
-export const useHasQuiz = ( { quizToggle } ) => {
+const useHasQuiz = () => {
 	const [ hasQuiz, setHasQuiz ] = useState( () => {
 		const questionCount = document.getElementById( 'question_counter' );
 
 		return questionCount && parseInt( questionCount.value, 10 ) > 0;
 	} );
-
-	useEffect( () => {
-		quizToggle( hasQuiz );
-	}, [ hasQuiz ] );
 
 	useEffect( () => {
 		const quizToggleEventHandler = ( event ) => {
@@ -39,3 +32,5 @@ export const useHasQuiz = ( { quizToggle } ) => {
 
 	return hasQuiz;
 };
+
+export default useHasQuiz;

--- a/assets/blocks/lesson-actions/lesson-actions-block/use-has-quiz.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/use-has-quiz.js
@@ -1,0 +1,42 @@
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Has quiz hook.
+ *
+ * @param {Object}   options            Hook options.
+ * @param {Function} options.quizToggle Toggle the quiz block.
+ *
+ * @return {boolean} If a quiz exists with questions.
+ */
+export const useHasQuiz = ( { quizToggle } ) => {
+	const [ quizEventListener ] = useState( null );
+	const [ hasQuiz, setHasQuiz ] = useState( () => {
+		const questionCount = document.getElementById( 'question_counter' );
+
+		return questionCount && parseInt( questionCount.value, 10 ) > 0;
+	} );
+
+	useEffect( () => {
+		quizToggle( hasQuiz );
+	}, [ hasQuiz ] );
+
+	useEffect( () => {
+		const quizToggleEventHandler = ( event ) => {
+			setHasQuiz( event.detail.questions > 0 );
+		};
+
+		window.addEventListener(
+			'sensei-quiz-editor-question-count-updated',
+			quizToggleEventHandler
+		);
+
+		return () => {
+			window.removeEventListener(
+				'sensei-quiz-editor-question-count-updated',
+				quizToggleEventHandler
+			);
+		};
+	}, [ quizEventListener ] );
+
+	return hasQuiz;
+};

--- a/assets/blocks/lesson-actions/lesson-actions-block/use-has-quiz.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/use-has-quiz.js
@@ -9,7 +9,6 @@ import { useEffect, useState } from '@wordpress/element';
  * @return {boolean} If a quiz exists with questions.
  */
 export const useHasQuiz = ( { quizToggle } ) => {
-	const [ quizEventListener ] = useState( null );
 	const [ hasQuiz, setHasQuiz ] = useState( () => {
 		const questionCount = document.getElementById( 'question_counter' );
 
@@ -36,7 +35,7 @@ export const useHasQuiz = ( { quizToggle } ) => {
 				quizToggleEventHandler
 			);
 		};
-	}, [ quizEventListener ] );
+	}, [] );
 
 	return hasQuiz;
 };

--- a/assets/blocks/lesson-actions/view-quiz-block/index.js
+++ b/assets/blocks/lesson-actions/view-quiz-block/index.js
@@ -1,0 +1,29 @@
+import { __ } from '@wordpress/i18n';
+
+import { createButtonBlockType } from '../../button';
+
+/**
+ * View quiz button block.
+ */
+export default createButtonBlockType( {
+	tagName: 'button',
+	settings: {
+		name: 'sensei-lms/button-view-quiz',
+		title: __( 'View quiz', 'sensei-lms' ),
+		parent: [ 'sensei-lms/lesson-actions' ],
+		description: __(
+			"Enable an enrolled user to take a lesson's quiz.",
+			'sensei-lms'
+		),
+		keywords: [
+			__( 'Quiz', 'sensei-lms' ),
+			__( 'Lesson', 'sensei-lms' ),
+			__( 'Button', 'sensei-lms' ),
+		],
+		attributes: {
+			text: {
+				default: 'View quiz',
+			},
+		},
+	},
+} );

--- a/assets/blocks/sensei-single-lesson-blocks.js
+++ b/assets/blocks/sensei-single-lesson-blocks.js
@@ -4,6 +4,7 @@ import {
 	CompleteLessonBlock,
 	NextLessonBlock,
 	ResetLessonBlock,
+	ViewQuizBlock,
 } from './lesson-actions';
 
 registerSenseiBlocks( [
@@ -11,4 +12,5 @@ registerSenseiBlocks( [
 	CompleteLessonBlock,
 	NextLessonBlock,
 	ResetLessonBlock,
+	ViewQuizBlock,
 ] );

--- a/assets/js/lesson-metadata.js
+++ b/assets/js/lesson-metadata.js
@@ -177,6 +177,12 @@ jQuery( document ).ready( function () {
 			jQuery( '#no-questions-message' ).removeClass( 'hidden' );
 		}
 
+		const questionCountUpdated = new CustomEvent(
+			'sensei-quiz-editor-question-count-updated',
+			{ detail: { questions: newValue } }
+		);
+		window.dispatchEvent( questionCountUpdated );
+
 		jQuery.fn.updateQuestionRows();
 	};
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds the `View quiz` button when a lesson's quiz has questions.
* Simplifies implementation by removing default full width style of `Complete lesson`.
* This does not change logic of displaying `Complete lesson` button.
* This implementation will need to be updated when we introduce the quiz editor.

### Post merge tasks
- Create card to update this implementation in new quiz editor.

### Testing instructions

* Try adding and removing questions. When questions exist, the `View quiz` button should show up in the Lesson Actions block.
