### PR TITLE
Fix/lesson actions alignment

### DIFF
--- a/assets/blocks/button/button.scss
+++ b/assets/blocks/button/button.scss
@@ -32,14 +32,15 @@
   * Buttons in container.
   */
 .sensei-buttons-container {
-	margin: -12px;
+	margin: -9px;
 	overflow: hidden; /* Clearfix solution */
 }
 
 .sensei-buttons-container__button-block,
 body .editor-styles-wrapper .sensei-buttons-container .block-editor-inner-blocks .sensei-buttons-container__button-block {
 	float: left;
-	margin: 12px;
+	margin: 0;
+	padding: 9px;
 
 	&.sensei-buttons-container__button-align-full,
 	&.sensei-buttons-container__button-align-center {
@@ -52,6 +53,6 @@ body .editor-styles-wrapper .sensei-buttons-container .block-editor-inner-blocks
 	}
 
 	.wp-block-sensei-button {
-		margin: 0;
+		margin: 0; /* Remove extra margin from some themes */
 	}
 }

--- a/assets/blocks/button/button.scss
+++ b/assets/blocks/button/button.scss
@@ -37,7 +37,7 @@
 }
 
 .sensei-buttons-container__button-block,
-body .editor-styles-wrapper .block-editor-inner-blocks .sensei-buttons-container__button-block {
+body .editor-styles-wrapper .sensei-buttons-container .block-editor-inner-blocks .sensei-buttons-container__button-block {
 	float: left;
 	margin: 12px;
 


### PR DESCRIPTION
Fixes the issue mentioned [here](https://github.com/Automattic/sensei/pull/3910#issuecomment-764719641). cc @alexsanford 

### Changes proposed in this Pull Request

* Fixes _Seedlet_ alignment.
* Fix _Lesson actions_ spacings. It was changed to `padding`, so we keep the correct spacing when using the full-width alignment to a button.

### Testing instructions

* Add a _Lesson actions_ block to a lesson, play with the alignments, and make sure everything looks correctly aligned in the frontend and in the editor.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="512" alt="Screen Shot 2021-01-21 at 13 14 18" src="https://user-images.githubusercontent.com/876340/105378451-98dc9580-5bea-11eb-8f7c-fe44792a193d.png">
