### PR TITLE
Provide visual cue for `Complete lesson` button's availability

### DIFF
--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import usePreviewState from './use-preview-state';
 import useToggleBlocks from './use-toggle-blocks';
 import useHasQuiz from './use-has-quiz';
+import useCompleteLessonAllowed from './use-complete-lesson-allowed';
 
 import { LessonActionsBlockSettings } from './settings';
 import {
@@ -48,6 +49,11 @@ const EditLessonActionsBlock = ( {
 	const hasQuiz = useHasQuiz();
 	const quizStateClass = hasQuiz ? 'has-quiz' : 'no-quiz';
 
+	const completeLessonAllowed = useCompleteLessonAllowed();
+	const completeLessonAllowedClass = completeLessonAllowed
+		? 'allowed'
+		: 'not-allowed';
+
 	// Filter inner blocks based on the settings.
 	const filteredInnerBlocksTemplate = INNER_BLOCKS_TEMPLATE.filter(
 		( i ) => false !== toggledBlocks[ i[ 0 ] ]
@@ -64,7 +70,8 @@ const EditLessonActionsBlock = ( {
 				className={ classnames(
 					className,
 					`wp-block-sensei-lms-lesson-actions__preview-${ previewState }`,
-					`wp-block-sensei-lms-lesson-actions__${ quizStateClass }`
+					`wp-block-sensei-lms-lesson-actions__${ quizStateClass }`,
+					`wp-block-sensei-lms-lesson-actions__complete_lessons-${ completeLessonAllowedClass }`
 				) }
 			>
 				<div className="sensei-buttons-container">

--- a/assets/blocks/lesson-actions/lesson-actions-block/style.editor.scss
+++ b/assets/blocks/lesson-actions/lesson-actions-block/style.editor.scss
@@ -16,4 +16,9 @@
 			opacity: 10%;
 		}
 	}
+	&__complete_lessons-not-allowed {
+		.wp-block-sensei-lms-button-complete-lesson {
+			opacity: 10%;
+		}
+	}
 }

--- a/assets/blocks/lesson-actions/lesson-actions-block/use-complete-lesson-allowed.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/use-complete-lesson-allowed.js
@@ -1,0 +1,39 @@
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Hook to check if a lesson can be completed manually.
+ *
+ * @return {boolean} If a lesson can be marked as completed by student.
+ */
+const useCompleteLessonAllowed = () => {
+	const passRequired = document.getElementById( 'pass_required' );
+
+	const [ completeLessonAllowed, setCompleteLessonAllowed ] = useState(
+		() => {
+			return ! passRequired || ! passRequired.checked;
+		}
+	);
+
+	useEffect( () => {
+		if ( ! passRequired ) {
+			return;
+		}
+
+		const passRequiredEventHandler = () => {
+			setCompleteLessonAllowed( ! passRequired.checked );
+		};
+
+		passRequired.addEventListener( 'change', passRequiredEventHandler );
+
+		return () => {
+			passRequired.removeEventListener(
+				'change',
+				passRequiredEventHandler
+			);
+		};
+	}, [ passRequired ] );
+
+	return completeLessonAllowed;
+};
+
+export default useCompleteLessonAllowed;

--- a/assets/blocks/lesson-actions/lesson-actions-block/use-complete-lesson-allowed.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/use-complete-lesson-allowed.js
@@ -6,32 +6,36 @@ import { useEffect, useState } from '@wordpress/element';
  * @return {boolean} If a lesson can be marked as completed by student.
  */
 const useCompleteLessonAllowed = () => {
-	const passRequired = document.getElementById( 'pass_required' );
+	const passRequiredCheckbox = document.getElementById( 'pass_required' );
 
 	const [ completeLessonAllowed, setCompleteLessonAllowed ] = useState(
 		() => {
-			return ! passRequired || ! passRequired.checked;
+			return ! passRequiredCheckbox || ! passRequiredCheckbox.checked;
 		}
 	);
 
 	useEffect( () => {
-		if ( ! passRequired ) {
+		// Ignore if the checkbox isn't present.
+		if ( ! passRequiredCheckbox ) {
 			return;
 		}
 
 		const passRequiredEventHandler = () => {
-			setCompleteLessonAllowed( ! passRequired.checked );
+			setCompleteLessonAllowed( ! passRequiredCheckbox.checked );
 		};
 
-		passRequired.addEventListener( 'change', passRequiredEventHandler );
+		passRequiredCheckbox.addEventListener(
+			'change',
+			passRequiredEventHandler
+		);
 
 		return () => {
-			passRequired.removeEventListener(
+			passRequiredCheckbox.removeEventListener(
 				'change',
 				passRequiredEventHandler
 			);
 		};
-	}, [ passRequired ] );
+	}, [ passRequiredCheckbox ] );
 
 	return completeLessonAllowed;
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Provide a visual cue for the availability of the `Complete Lesson` button in the block editor.
* Should be in an enabled state when previewing an in-progress course and the `The passmark must be achieved before the lesson is complete.` quiz option is unchecked.
* Note: This doesn't change the frontend rendering.

### Testing instructions

* Toggle the `The passmark must be achieved before the lesson is complete.` checkbox in the quiz options and verify the button appears in a visibly disabled state (opacity: 10%) when checked. 

### Screenshot / Video
![2021-01-21 4 28 50 pm](https://user-images.githubusercontent.com/68693/105380509-de5a8c00-5c05-11eb-9243-db33211fcffb.gif)
