### PR TITLE
Add shared block foundation

### DIFF
--- a/includes/blocks/class-sensei-blocks-initializer.php
+++ b/includes/blocks/class-sensei-blocks-initializer.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * File containing the Sensei_Blocks_Initializer class.
+ *
+ * @package sensei
+ * @since 3.8.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Blocks_Initializer initializes blocks for pages with a specific post type.
+ */
+abstract class Sensei_Blocks_Initializer {
+	/**
+	 * The post type to initialize blocks for.
+	 *
+	 * @var $post_type
+	 */
+	private $post_type;
+
+	/**
+	 * Sensei_Blocks_Initializer constructor.
+	 *
+	 * @param string $post_type The post type to initialize blocks for.
+	 */
+	public function __construct( $post_type ) {
+		add_action( 'template_redirect', [ $this, 'maybe_initialize_blocks' ] );
+		add_action( 'current_screen', [ $this, 'maybe_initialize_blocks' ] );
+		$this->post_type = $post_type;
+	}
+
+	/**
+	 * Check if blocks should be initialized and do initialization.
+	 *
+	 * @access private
+	 */
+	public function maybe_initialize_blocks() {
+		if ( is_admin() ) {
+			$screen = get_current_screen();
+
+			// Init blocks.
+			if ( null === $screen || ! $screen->is_block_editor || $this->post_type !== $screen->post_type ) {
+				return;
+			}
+		} elseif ( get_post_type() !== $this->post_type ) {
+			return;
+		}
+
+		$this->initialize_blocks();
+	}
+
+	/**
+	 * Initializes the blocks.
+	 */
+	abstract public function initialize_blocks();
+}

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -123,7 +123,7 @@ class Sensei_Course_Blocks {
 	}
 
 	/**
-	 * Disable single course template if there is an outline block present.
+	 * Disable single course template if the course is block based.
 	 *
 	 * @access private
 	 *

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class Sensei_Course_Blocks
  */
-class Sensei_Course_Blocks {
+class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 	/**
 	 * Course outline block.
 	 *
@@ -45,30 +45,11 @@ class Sensei_Course_Blocks {
 	 * Sensei_Course_Blocks constructor.
 	 */
 	public function __construct() {
+		parent::__construct( 'course' );
 		add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
 		add_filter( 'sensei_use_sensei_template', [ 'Sensei_Course_Blocks', 'skip_single_course_template' ] );
-		add_action( 'template_redirect', [ $this, 'maybe_initialize_blocks' ] );
-		add_action( 'current_screen', [ $this, 'maybe_initialize_blocks' ] );
-	}
 
-	/**
-	 * Check if course blocks should be initialized and do initialization.
-	 *
-	 * @access private
-	 */
-	public function maybe_initialize_blocks() {
-		if ( is_admin() ) {
-			$screen = get_current_screen();
-
-			if ( ! $screen->is_block_editor || 'course' !== $screen->post_type ) {
-				return;
-			}
-		} elseif ( 'course' !== get_post_type() ) {
-			return;
-		}
-
-		$this->initialize_blocks();
 	}
 
 	/**

--- a/includes/blocks/class-sensei-lesson-actions-block.php
+++ b/includes/blocks/class-sensei-lesson-actions-block.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * File containing the Sensei_Lesson_Actions_Block class.
+ *
+ * @package sensei
+ * @since 3.8.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Lesson_Actions_Block is responsible for rendering the 'Lesson Actions' block.
+ */
+class Sensei_Lesson_Actions_Block {
+
+	/**
+	 * Sensei_Lesson_Actions_Block constructor.
+	 */
+	public function __construct() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/lesson-actions',
+			[
+				'render_callback' => [ $this, 'render' ],
+			],
+			Sensei()->assets->src_path( 'blocks/lesson-actions/lesson-actions-block' )
+		);
+	}
+
+	/**
+	 * Renders the block.
+	 *
+	 * @param array  $attributes The block attributes.
+	 * @param string $content    The block content.
+	 *
+	 * @return string The block HTML.
+	 */
+	public function render( array $attributes, string $content ) : string {
+		return ! empty( $content ) ? '<div class="sensei-block-wrapper">' . $content . '</div>' : '';
+	}
+}

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -21,7 +21,6 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 
 		add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
-		add_filter( 'sensei_use_sensei_template', [ $this, 'use_single_lesson_template' ] );
 	}
 
 	/**
@@ -58,40 +57,5 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 	public function initialize_blocks() {
 		new Sensei_Lesson_Actions_Block();
 		new Sensei_Next_Lesson_Block();
-	}
-
-	/**
-	 * Disable single lesson template if lesson is block based.
-	 *
-	 * @access private
-	 *
-	 * @param bool $enabled
-	 *
-	 * @return bool
-	 */
-	public function use_single_lesson_template( bool $enabled ) : bool {
-		if ( is_single() && 'lesson' === get_post_type() && ! Sensei()->lesson->is_legacy_lesson( get_post() ) ) {
-			add_filter( 'the_content', [ $this, 'hide_lesson_content' ] );
-			return false;
-		}
-
-		return $enabled;
-	}
-
-	/**
-	 * Hides the post content when the user can't access the lesson.
-	 *
-	 * @param string $content The post content.
-	 *
-	 * @access private
-	 *
-	 * @return string The modified content.
-	 */
-	public function hide_lesson_content( string $content ) : string {
-		if ( in_the_loop() && is_main_query() && ! sensei_can_user_view_lesson() ) {
-			return '';
-		}
-
-		return $content;
 	}
 }

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -21,7 +21,7 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 
 		add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
-		add_filter( 'sensei_use_sensei_template', [ $this, 'skip_single_lesson_template' ] );
+		add_filter( 'sensei_use_sensei_template', [ $this, 'use_single_lesson_template' ] );
 	}
 
 	/**
@@ -69,9 +69,29 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 	 *
 	 * @return bool
 	 */
-	public function skip_single_lesson_template( $enabled ) {
-		return is_single() && 'lesson' === get_post_type() && ! Sensei()->lesson->is_legacy_lesson( get_post() )
-			? false
-			: $enabled;
+	public function use_single_lesson_template( bool $enabled ) : bool {
+		if ( is_single() && 'lesson' === get_post_type() && ! Sensei()->lesson->is_legacy_lesson( get_post() ) ) {
+			add_filter( 'the_content', [ $this, 'hide_lesson_content' ] );
+			return false;
+		}
+
+		return $enabled;
+	}
+
+	/**
+	 * Hides the post content when the user can't access the lesson.
+	 *
+	 * @param string $content The post content.
+	 *
+	 * @access private
+	 *
+	 * @return string The modified content.
+	 */
+	public function hide_lesson_content( string $content ) : string {
+		if ( in_the_loop() && is_main_query() && ! sensei_can_user_view_lesson() ) {
+			return '';
+		}
+
+		return $content;
 	}
 }

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -12,13 +12,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class Sensei_Lesson_Blocks
  */
-class Sensei_Lesson_Blocks {
+class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 	/**
 	 * Sensei_Blocks constructor.
 	 */
 	public function __construct() {
+		parent::__construct( 'lesson' );
+
 		add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
+		add_filter( 'sensei_use_sensei_template', [ $this, 'skip_single_lesson_template' ] );
 	}
 
 	/**
@@ -47,5 +50,25 @@ class Sensei_Lesson_Blocks {
 		Sensei()->assets->enqueue( 'sensei-single-lesson-blocks', 'blocks/sensei-single-lesson-blocks.js', [], true );
 		Sensei()->assets->enqueue( 'sensei-single-lesson-editor', 'blocks/single-lesson.editor.css' );
 		Sensei()->assets->enqueue( 'sensei-editor-components', 'blocks/editor-components/style.css' );
+	}
+
+	/**
+	 * Initializes the blocks.
+	 */
+	public function initialize_blocks() {}
+
+	/**
+	 * Disable single lesson template if lesson is block based.
+	 *
+	 * @access private
+	 *
+	 * @param bool $enabled
+	 *
+	 * @return bool
+	 */
+	public function skip_single_lesson_template( $enabled ) {
+		return is_single() && 'lesson' === get_post_type() && ! Sensei()->lesson->is_legacy_lesson( get_post() )
+			? false
+			: $enabled;
 	}
 }

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -55,7 +55,10 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 	/**
 	 * Initializes the blocks.
 	 */
-	public function initialize_blocks() {}
+	public function initialize_blocks() {
+		new Sensei_Lesson_Actions_Block();
+		new Sensei_Next_Lesson_Block();
+	}
 
 	/**
 	 * Disable single lesson template if lesson is block based.

--- a/includes/blocks/class-sensei-next-lesson-block.php
+++ b/includes/blocks/class-sensei-next-lesson-block.php
@@ -1,0 +1,53 @@
+<?php
+/**
+ * File containing the Sensei_Lesson_Actions_Block class.
+ *
+ * @package sensei
+ * @since 3.8.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Next_Lesson_Block is responsible for rendering the 'Next Lesson' block.
+ */
+class Sensei_Next_Lesson_Block {
+
+	/**
+	 * Sensei_Next_Lesson_Block constructor.
+	 */
+	public function __construct() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/button-next-lesson',
+			[
+				'render_callback' => [ $this, 'render' ],
+			]
+		);
+	}
+
+	/**
+	 * Renders the block.
+	 *
+	 * @param array  $attributes The block attributes.
+	 * @param string $content    The block content.
+	 *
+	 * @return string The block HTML.
+	 */
+	public function render( array $attributes, string $content ) : string {
+		$lesson = get_post();
+
+		if ( empty( $lesson ) ) {
+			return '';
+		}
+
+		$urls = sensei_get_prev_next_lessons( $lesson->ID );
+
+		if ( empty( $urls['next']['url'] ) ) {
+			return '';
+		}
+
+		return '<a href="' . esc_url( $urls['next']['url'] ) . '" > ' . $content . '</a>';
+	}
+}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4685,7 +4685,29 @@ class Sensei_Lesson {
 		return false;
 	}
 
-} // End Class
+	/**
+	 * Check if a lesson is legacy.
+	 *
+	 * @param int|WP_Post $lesson Lesson ID or lesson object.
+	 *
+	 * @return bool
+	 */
+	public function is_legacy_lesson( $lesson ) {
+		$lesson = get_post( $lesson );
+
+		$lesson_blocks = [
+			'sensei-lms/lesson-actions',
+		];
+
+		foreach ( $lesson_blocks as $block ) {
+			if ( has_block( $block, $lesson ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+}
 
 /**
  * Class WooThemes_Sensei_Lesson

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -124,6 +124,8 @@ class Sensei_Notices {
 	 *
 	 * @param string $content The post content.
 	 *
+	 * @access private
+	 *
 	 * @return string The modified content.
 	 */
 	public function prepend_notices_to_content( string $content ) : string {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This is just some common code for the PHP side of lesson blocks.
* It allows `Sensei_Lesson_Blocks` and `Sensei_Course_Blocks` to initialize blocks for specific post types.
* It includes some early work of the Lesson Actions frontend work.

### Testing instructions

* Make sure that the course blocks are still working.