### PR TITLE
Update lesson actions alignments

### DIFF
--- a/assets/blocks/lesson-actions/complete-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/complete-lesson-block/index.js
@@ -27,4 +27,8 @@ export default createButtonBlockType( {
 			},
 		},
 	},
+	alignmentOptions: {
+		controls: [ 'left', 'full' ],
+		default: 'left',
+	},
 } );

--- a/assets/blocks/lesson-actions/next-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/next-lesson-block/index.js
@@ -27,4 +27,8 @@ export default createButtonBlockType( {
 			},
 		},
 	},
+	alignmentOptions: {
+		controls: [ 'left', 'full' ],
+		default: 'left',
+	},
 } );

--- a/assets/blocks/lesson-actions/reset-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/reset-lesson-block/index.js
@@ -34,4 +34,8 @@ export default createButtonBlockType( {
 			BlockStyles.Link,
 		],
 	},
+	alignmentOptions: {
+		controls: [ 'left', 'full' ],
+		default: 'left',
+	},
 } );

--- a/assets/blocks/lesson-actions/view-quiz-block/index.js
+++ b/assets/blocks/lesson-actions/view-quiz-block/index.js
@@ -26,4 +26,8 @@ export default createButtonBlockType( {
 			},
 		},
 	},
+	alignmentOptions: {
+		controls: [ 'left', 'full' ],
+		default: 'left',
+	},
 } );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* In a conversation with @gkaragia, we decided to allow only _left_ and _full_ alignment for the lesson actions buttons. The center and right don't look to make sense in any case.

Notice that it's restricted directly in the button. So if we decide use these buttons out of the _Lesson actions_, probably we need to update this approach to a more complex one, probably using attributes, or identifying the parent block.

### Testing instructions

* Add the _Lesson actions_ block to a lesson, and make sure you can align the buttons to the _left_ or _full_.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="689" alt="Screen Shot 2021-01-22 at 10 40 22" src="https://user-images.githubusercontent.com/876340/105497909-40ff6680-5c9e-11eb-83d1-3dc4105b1483.png">
