### PR TITLE
Do not allow duplicate notices to be displayed

### DIFF
--- a/includes/blocks/class-sensei-block-contact-teacher.php
+++ b/includes/blocks/class-sensei-block-contact-teacher.php
@@ -59,24 +59,16 @@ class Sensei_Block_Contact_Teacher {
 		$contact_form_open = isset( $_GET['contact'] );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
-		$message_sent = ( isset( $_GET['send'] ) && 'complete' === $_GET['send'] );
-		$notice       = $message_sent ? $this->confirmation_notice() : '';
+		if ( isset( $_GET['send'] ) && 'complete' === $_GET['send'] ) {
+			Sensei()->notices->add_notice( __( 'Your private message has been sent.', 'sensei-lms' ), 'tick', 'sensei-contact-teacher-confirm' );
+		}
 
 		$contact_form = $this->teacher_contact_form( $post );
 
 		return '<div id="private_message" class="sensei-block-wrapper sensei-collapsible">
 				' . ( $this->add_button_attributes( $content, $contact_form_link ) ) . '
-				' . $notice . '
 				<div class="sensei-collapsible__content ' . ( $contact_form_open ? '' : 'collapsed' ) . '">' . $contact_form . '</div>
 			</div>';
-	}
-
-	/**
-	 * Render a notice confirming the message was sent.
-	 */
-	private function confirmation_notice() {
-		$confirmation_message = __( 'Your private message has been sent.', 'sensei-lms' );
-		return '<div class="sensei-message tick">' . esc_html( $confirmation_message ) . '</div>';
 	}
 
 	/**

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -52,7 +52,7 @@ class Sensei_Block_Take_Course {
 
 		if ( Sensei_Course::can_current_user_manually_enrol( $course_id ) ) {
 			if ( ! Sensei_Course::is_prerequisite_complete( $course_id ) ) {
-				Sensei()->notices->add_notice( Sensei()->course::get_course_prerequisite_message( $course_id ), 'info' );
+				Sensei()->notices->add_notice( Sensei()->course::get_course_prerequisite_message( $course_id ), 'info', 'sensei-take-course-prerequisite' );
 				$html = $this->render_disabled( $content );
 			} else {
 				$html = $this->render_with_start_course_form( $course_id, $content );

--- a/includes/blocks/class-sensei-course-outline-course-block.php
+++ b/includes/blocks/class-sensei-course-outline-course-block.php
@@ -61,17 +61,14 @@ class Sensei_Course_Outline_Course_Block {
 		$class_name = Sensei_Block_Helpers::block_class_with_default_style( $attributes );
 		$css        = Sensei_Block_Helpers::build_styles( $attributes );
 
-		$notice = '';
-
 		if ( ! empty( $attributes['preview_drafts'] ) ) {
-			$notice = '<div class="sensei-message info">' . esc_html__( 'One or more lessons in this course are not published. Unpublished lessons and empty modules are only displayed in preview mode and will not be displayed to learners.', 'sensei-lms' ) . '</div>';
+			Sensei()->notices->add_notice( __( 'One or more lessons in this course are not published. Unpublished lessons and empty modules are only displayed in preview mode and will not be displayed to learners.', 'sensei-lms' ), 'info', 'sensei-course-outline-drafts' );
 		}
 
 		$icons = $this->render_svg_icon_library();
 
 		return '
 			' . ( ! empty( $blocks ) ? $icons : '' ) . '
-			' . $notice . '
 			<section ' . Sensei_Block_Helpers::render_style_attributes( [ 'wp-block-sensei-lms-course-outline', 'sensei-block-wrapper', $class_name ], $css ) . '>
 				' .
 			implode(

--- a/includes/blocks/class-sensei-course-outline-course-block.php
+++ b/includes/blocks/class-sensei-course-outline-course-block.php
@@ -51,11 +51,8 @@ class Sensei_Course_Outline_Course_Block {
 		$post_id    = $outline['post_id'];
 
 		if ( empty( $blocks ) ) {
-			return '
-				<div class="sensei-message info">
-					' . __( 'There is no published content in this course yet.', 'sensei-lms' ) . '
-				</div>
-			';
+			Sensei()->notices->add_notice( __( 'There is no published content in this course yet.', 'sensei-lms' ), 'info', 'sensei-course-outline-no-content' );
+			return '';
 		}
 
 		$class_name = Sensei_Block_Helpers::block_class_with_default_style( $attributes );

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -70,16 +70,24 @@ class Sensei_Notices {
 	 *  Add a notice to the array of notices for display at a later stage.
 	 *
 	 * @param string $content Content.
-	 * @param string $type Defaults to alert options( alert, tick , download , info   ).
+	 * @param string $type    Defaults to alert options( alert, tick , download , info   ).
+	 * @param string $key     Notices with the same key will be overwritten.
 	 *
 	 * @return void
 	 */
-	public function add_notice( $content, $type = 'alert' ) {
+	public function add_notice( string $content, string $type = 'alert', string $key = null ) {
 		// append the new notice.
-		$this->notices[] = array(
-			'content' => $content,
-			'type'    => $type,
-		);
+		if ( null === $key ) {
+			$this->notices[] = [
+				'content' => $content,
+				'type'    => $type,
+			];
+		} else {
+			$this->notices[ $key ] = [
+				'content' => $content,
+				'type'    => $type,
+			];
+		}
 
 		// if a notice is added after we've printed print it immediately.
 		if ( $this->has_printed ) {

--- a/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
@@ -106,6 +106,10 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 	 * When the course has an unmet prerequisite, button is disabled with a message.
 	 */
 	public function testDisabledWhenPrerequisiteUnmet() {
+		$property = new ReflectionProperty( 'Sensei_Notices', 'has_printed' );
+		$property->setAccessible( true );
+		$property->setValue( Sensei()->notices, false );
+
 		$course_pre = $this->factory->course->create_and_get();
 		add_post_meta( $this->course->ID, '_course_prerequisite', $course_pre->ID );
 

--- a/tests/unit-tests/blocks/test-class-sensei-contact-teacher-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-contact-teacher-block.php
@@ -49,11 +49,19 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 	 * Test success message is displayed after submitting.
 	 */
 	public function testSuccessMessageDisplayed() {
+		$property = new ReflectionProperty( 'Sensei_Notices', 'has_printed' );
+		$property->setAccessible( true );
+		$property->setValue( Sensei()->notices, false );
+
 		$_GET['send'] = 'complete';
 
-		$output = $this->block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
+		$this->block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
 
-		$this->assertContains( 'Your private message has been sent.', $output );
+		ob_start();
+		Sensei()->notices->maybe_print_notices();
+		$notices = ob_get_clean();
+
+		$this->assertContains( 'Your private message has been sent.', $notices );
 	}
 
 	/**

--- a/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-outline-block.php
@@ -28,6 +28,10 @@ class Sensei_Course_Outline_Block_Test extends WP_UnitTestCase {
 	 * Test that a message is shown when there is no content.
 	 */
 	public function testEmptyBlock() {
+		$property = new ReflectionProperty( 'Sensei_Notices', 'has_printed' );
+		$property->setAccessible( true );
+		$property->setValue( Sensei()->notices, false );
+
 		$post_content = file_get_contents( 'sample-data/outline-block-post-content.html', true );
 
 		$this->mockPostCourseStructure( [] );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This is a copy of the already approved #3909. I created a new one because of a mistake I did in git.
* This PR fixes the issue were many notices were displayed when we had multiple instances of a block in the content (each block would add its own notice).
* A new key argument was added in `Sensei_Notices::add_notice`. Notices with the same key will be displayed only once.
* All block notices have been updated to use the new key argument.

### Testing instructions

* Add many Take Course and Contant Teacher blocks.
* Use the Contact Teacher to send a message.
* Add a prerequisite to the course.
* For each case, observe that only one notice is displayed and it is displayed correctly