### PR TITLE
Update text in Lesson Actions and Restricted Course Content blocks

### DIFF
--- a/assets/blocks/lesson-actions/complete-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/complete-lesson-block/index.js
@@ -10,7 +10,7 @@ export default createButtonBlockType( {
 	settings: {
 		name: 'sensei-lms/button-complete-lesson',
 		parent: [ 'sensei-lms/lesson-actions' ],
-		title: __( 'Complete lesson', 'sensei-lms' ),
+		title: __( 'Complete Lesson', 'sensei-lms' ),
 		description: __(
 			'Enable an enrolled user to mark the lesson as complete.',
 			'sensei-lms'
@@ -23,7 +23,7 @@ export default createButtonBlockType( {
 		],
 		attributes: {
 			text: {
-				default: __( 'Complete lesson', 'sensei-lms' ),
+				default: __( 'Complete Lesson', 'sensei-lms' ),
 			},
 		},
 	},

--- a/assets/blocks/lesson-actions/lesson-actions-block/edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/edit.js
@@ -41,7 +41,7 @@ const EditLessonActionsBlock = ( {
 		blocks: [
 			{
 				blockName: 'sensei-lms/button-reset-lesson',
-				label: __( 'Reset lesson', 'sensei-lms' ),
+				label: __( 'Reset Lesson', 'sensei-lms' ),
 			},
 		],
 	} );

--- a/assets/blocks/lesson-actions/lesson-actions-block/index.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/index.js
@@ -6,7 +6,7 @@ import edit from './edit';
 import save from './save';
 
 export default {
-	title: __( 'Lesson actions', 'sensei-lms' ),
+	title: __( 'Lesson Actions', 'sensei-lms' ),
 	description: __(
 		'Enable an enrolled user to perform specific actions for a lesson.',
 		'sensei-lms'

--- a/assets/blocks/lesson-actions/next-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/next-lesson-block/index.js
@@ -9,7 +9,7 @@ export default createButtonBlockType( {
 	tagName: 'button',
 	settings: {
 		name: 'sensei-lms/button-next-lesson',
-		title: __( 'Next lesson', 'sensei-lms' ),
+		title: __( 'Next Lesson', 'sensei-lms' ),
 		parent: [ 'sensei-lms/lesson-actions' ],
 		description: __(
 			'Enable a user to move to the next lesson.',
@@ -23,7 +23,7 @@ export default createButtonBlockType( {
 		],
 		attributes: {
 			text: {
-				default: __( 'Next lesson', 'sensei-lms' ),
+				default: __( 'Next Lesson', 'sensei-lms' ),
 			},
 		},
 	},

--- a/assets/blocks/lesson-actions/reset-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/reset-lesson-block/index.js
@@ -9,10 +9,10 @@ export default createButtonBlockType( {
 	tagName: 'button',
 	settings: {
 		name: 'sensei-lms/button-reset-lesson',
-		title: __( 'Reset lesson', 'sensei-lms' ),
+		title: __( 'Reset Lesson', 'sensei-lms' ),
 		parent: [ 'sensei-lms/lesson-actions' ],
 		description: __(
-			'Enable an enrolled user to reset their progress in the lesson.',
+			'Enable an enrolled user to reset their lesson progress.',
 			'sensei-lms'
 		),
 		keywords: [
@@ -25,7 +25,7 @@ export default createButtonBlockType( {
 		],
 		attributes: {
 			text: {
-				default: __( 'Reset lesson', 'sensei-lms' ),
+				default: __( 'Reset Lesson', 'sensei-lms' ),
 			},
 		},
 		styles: [

--- a/assets/blocks/lesson-actions/view-quiz-block/index.js
+++ b/assets/blocks/lesson-actions/view-quiz-block/index.js
@@ -9,10 +9,10 @@ export default createButtonBlockType( {
 	tagName: 'button',
 	settings: {
 		name: 'sensei-lms/button-view-quiz',
-		title: __( 'View quiz', 'sensei-lms' ),
+		title: __( 'View Quiz', 'sensei-lms' ),
 		parent: [ 'sensei-lms/lesson-actions' ],
 		description: __(
-			"Enable an enrolled user to take a lesson's quiz.",
+			'Enable an enrolled user to view the quiz.',
 			'sensei-lms'
 		),
 		keywords: [
@@ -22,7 +22,7 @@ export default createButtonBlockType( {
 		],
 		attributes: {
 			text: {
-				default: __( 'View quiz', 'sensei-lms' ),
+				default: __( 'View Quiz', 'sensei-lms' ),
 			},
 		},
 	},

--- a/assets/blocks/restricted-content/edit.js
+++ b/assets/blocks/restricted-content/edit.js
@@ -12,8 +12,8 @@ export const RestrictOptions = {
 };
 
 export const RestrictOptionLabels = {
-	[ RestrictOptions.ENROLLED ]: __( 'Enrolled Users', 'sensei-lms' ),
-	[ RestrictOptions.UNENROLLED ]: __( 'Unenrolled Users', 'sensei-lms' ),
+	[ RestrictOptions.ENROLLED ]: __( 'Enrolled', 'sensei-lms' ),
+	[ RestrictOptions.UNENROLLED ]: __( 'Not Enrolled', 'sensei-lms' ),
 	[ RestrictOptions.COURSE_COMPLETED ]: __(
 		'Course Completed',
 		'sensei-lms'

--- a/assets/blocks/restricted-content/index.js
+++ b/assets/blocks/restricted-content/index.js
@@ -8,7 +8,7 @@ import { createBlock } from '@wordpress/blocks';
 export default {
 	title: __( 'Restricted Course Content', 'sensei-lms' ),
 	description: __(
-		'Content inside this container block can be restricted to a specified group of users. Possible options are enrolled users, not enrolled users and users who have completed the course',
+		'Display conditional course content to users.',
 		'sensei-lms'
 	),
 	keywords: [
@@ -17,7 +17,7 @@ export default {
 		__( 'Locked', 'sensei-lms' ),
 		__( 'Private', 'sensei-lms' ),
 		__( 'Completed', 'sensei-lms' ),
-		__( 'Unenrolled', 'sensei-lms' ),
+		__( 'Not Enrolled', 'sensei-lms' ),
 		__( 'Restricted', 'sensei-lms' ),
 	],
 	icon: () => <Icon icon="lock" />,


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR simplifies some of the text in the Restricted Course Content block and removes the use of "unenrolled".

The Lesson Actions inner blocks have been changed to use the same case for text as is already used elsewhere in Sensei. This will make it easier for translators, since plugins like Say What? are case-sensitive. If we use the same case everywhere, then any existing translations will be automatically picked up by the blocks.

### Testing instructions

* Add the Restricted Course Content and Lesson Actions blocks.
* Ensure the text is updated.