### PR TITLE
Fix preview opacity

### DIFF
--- a/assets/blocks/lesson-actions/lesson-actions-block/style.editor.scss
+++ b/assets/blocks/lesson-actions/lesson-actions-block/style.editor.scss
@@ -2,23 +2,23 @@
 	&__preview-completed {
 		.wp-block-sensei-lms-button-complete-lesson,
 		.wp-block-sensei-lms-button-view-quiz {
-			opacity: 10%;
+			opacity: 0.1;
 		}
 	}
 	&__preview-in-progress {
 		.wp-block-sensei-lms-button-reset-lesson,
 		.wp-block-sensei-lms-button-next-lesson {
-			opacity: 10%;
+			opacity: 0.1;
 		}
 	}
 	&__no-quiz {
 		.wp-block-sensei-lms-button-view-quiz {
-			opacity: 10%;
+			opacity: 0.1;
 		}
 	}
 	&__complete_lessons-not-allowed {
 		.wp-block-sensei-lms-button-complete-lesson {
-			opacity: 10%;
+			opacity: 0.1;
 		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* We were using `opacity: 10%`, which was being converted to `1%` in the build. It fixes this issue.

### Testing instructions

* Setup a site with the built assets.
* Go the the lesson editor.
* Add a Lesson Actions block.
* Make sure some buttons appear with `0.1` opacity.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="654" alt="Screen Shot 2021-01-26 at 10 08 04" src="https://user-images.githubusercontent.com/876340/105848908-67831180-5fbe-11eb-8204-4543e28321ab.png">
