### PR TITLE
Handle lesson hooks for lessons which contain a block

### DIFF
--- a/includes/blocks/class-sensei-block-contact-teacher.php
+++ b/includes/blocks/class-sensei-block-contact-teacher.php
@@ -19,6 +19,7 @@ class Sensei_Block_Contact_Teacher {
 	 */
 	public function __construct() {
 		$this->register_block();
+		$this->add_notices();
 	}
 
 	/**
@@ -33,7 +34,14 @@ class Sensei_Block_Contact_Teacher {
 				'render_callback' => [ $this, 'render_contact_teacher_block' ],
 			]
 		);
+	}
 
+	/**
+	 * Check if a notice should be displayed.
+	 *
+	 * @access private
+	 */
+	public function add_notices() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 		if ( isset( $_GET['send'] ) && 'complete' === $_GET['send'] ) {
 			Sensei()->notices->add_notice( __( 'Your private message has been sent.', 'sensei-lms' ), 'tick', 'sensei-contact-teacher-confirm' );

--- a/includes/blocks/class-sensei-block-contact-teacher.php
+++ b/includes/blocks/class-sensei-block-contact-teacher.php
@@ -33,6 +33,11 @@ class Sensei_Block_Contact_Teacher {
 				'render_callback' => [ $this, 'render_contact_teacher_block' ],
 			]
 		);
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
+		if ( isset( $_GET['send'] ) && 'complete' === $_GET['send'] ) {
+			Sensei()->notices->add_notice( __( 'Your private message has been sent.', 'sensei-lms' ), 'tick', 'sensei-contact-teacher-confirm' );
+		}
 	}
 
 	/**
@@ -57,11 +62,6 @@ class Sensei_Block_Contact_Teacher {
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 		$contact_form_open = isset( $_GET['contact'] );
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
-		if ( isset( $_GET['send'] ) && 'complete' === $_GET['send'] ) {
-			Sensei()->notices->add_notice( __( 'Your private message has been sent.', 'sensei-lms' ), 'tick', 'sensei-contact-teacher-confirm' );
-		}
 
 		$contact_form = $this->teacher_contact_form( $post );
 

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -79,6 +79,10 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		new Sensei_View_Quiz_Block();
 		new Sensei_Block_Contact_Teacher();
 
+		if ( Sensei()->lesson->has_sensei_blocks() ) {
+			$this->remove_block_related_content();
+		}
+
 		$post_type_object = get_post_type_object( 'lesson' );
 
 		$post_type_object->template = [
@@ -90,6 +94,15 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 			[ 'sensei-lms/lesson-actions' ],
 		];
 	}
+
+	/**
+	 * Helper method to remove functionality which is provided by blocks.
+	 */
+	private function remove_block_related_content() {
+		// Remove contact teacher button.
+		remove_action( 'sensei_single_lesson_content_inside_before', [ Sensei()->post_types->messages, 'send_message_link' ], 30 );
+	}
+
 
 	/**
 	 * Register lesson post metas.

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -101,6 +101,9 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 	private function remove_block_related_content() {
 		// Remove contact teacher button.
 		remove_action( 'sensei_single_lesson_content_inside_before', [ Sensei()->post_types->messages, 'send_message_link' ], 30 );
+
+		// Remove footer buttons.
+		remove_action( 'sensei_single_lesson_content_inside_after', [ 'Sensei_Lesson', 'footer_quiz_call_to_action' ] );
 	}
 
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4698,13 +4698,13 @@ class Sensei_Lesson {
 	}
 
 	/**
-	 * Check if a lesson is legacy.
+	 * Check if a lesson has Sensei blocks.
 	 *
 	 * @param int|WP_Post $lesson Lesson ID or lesson object.
 	 *
 	 * @return bool
 	 */
-	public function is_legacy_lesson( $lesson ) {
+	public function has_sensei_blocks( $lesson ) {
 		$lesson = get_post( $lesson );
 
 		$lesson_blocks = [

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4471,11 +4471,7 @@ class Sensei_Lesson {
 					echo '<div class="sensei-message ' . esc_attr( $status['box_class'] ) . '">' .
 						wp_kses_post( $status['message'] ) . '</div>';
 				}
-
-				if ( $has_quiz_questions ) {
-					// echo $status['extra'];
-				} // End If Statement
-			} // End If Statement
+			}
 		}
 
 	}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4704,20 +4704,21 @@ class Sensei_Lesson {
 	 *
 	 * @return bool
 	 */
-	public function has_sensei_blocks( $lesson ) {
+	public function has_sensei_blocks( $lesson = null ) {
 		$lesson = get_post( $lesson );
 
 		$lesson_blocks = [
 			'sensei-lms/lesson-actions',
+			'sensei-lms/button-contact-teacher',
 		];
 
 		foreach ( $lesson_blocks as $block ) {
 			if ( has_block( $block, $lesson ) ) {
-				return false;
+				return true;
 			}
 		}
 
-		return true;
+		return false;
 	}
 }
 

--- a/tests/unit-tests/blocks/test-class-sensei-contact-teacher-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-contact-teacher-block.php
@@ -10,13 +10,6 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 	use Sensei_Course_Enrolment_Manual_Test_Helpers;
 	use Sensei_Test_Login_Helpers;
 
-	/**
-	 * Contact Teacher Block.
-	 *
-	 * @var Sensei_Block_Contact_Teacher
-	 */
-	private $block;
-
 	public function setUp() {
 		parent::setUp();
 
@@ -25,7 +18,6 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 			'post_type' => 'course',
 		];
 		$_SERVER['REQUEST_URI'] = '/course/test/';
-		$this->block            = new Sensei_Block_Contact_Teacher();
 
 		$this->login_as_student();
 	}
@@ -39,8 +31,8 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 	 * Test the saved block content is used for the button, with link added to open the form.
 	 */
 	public function testHrefAttributeAdded() {
-
-		$output = $this->block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
+		$block  = new Sensei_Block_Contact_Teacher();
+		$output = $block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
 
 		$this->assertRegExp( '|<a href="/course/test/\?contact=course#private_message".*>Contact teacher</a>|', $output );
 	}
@@ -55,7 +47,7 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 
 		$_GET['send'] = 'complete';
 
-		$this->block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
+		new Sensei_Block_Contact_Teacher();
 
 		ob_start();
 		Sensei()->notices->maybe_print_notices();
@@ -68,8 +60,8 @@ class Sensei_Block_Contact_Teacher_Test extends WP_UnitTestCase {
 	 * Test a private message form is present.
 	 */
 	public function testMessageForm() {
-
-		$output = $this->block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
+		$block  = new Sensei_Block_Contact_Teacher();
+		$output = $block->render_contact_teacher_block( [], '<div><a class="wp-block-button__link">Contact teacher</a></div>' );
 
 		$this->assertRegExp( '|<form.*<input.* name="sensei_message_teacher_nonce" .*</form>|ms', $output );
 		$this->assertRegExp( '|<form.*<textarea.* name="contact_message" .*</form>|ms', $output );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Removes content that is provided by 'Contact Teacher' block and 'Lesson Actions' block.
* Add-ons will be handled as part of another PR.
* I also remove the contact teacher button as we have plans to make it available in the coming PRs.
* As we are not dropping the lesson template, there are two hook calls that are removed, `footer_quiz_call_to_action` and `send_message_link`. Method `send_message_link` adds a notice which is going to be handled by the Contact Teacher block. Method `footer_quiz_call_to_action` does not add any notices which means that no other changes for notices are required.

### Testing instructions

* Add the lesson actions block to a lesson and observe that the old 'Contant Teacher' button and the lesson actions are not displayed anymore.
* Remove the block and observe that old content appears in the frontend.
* Add a 'Contact Teacher' block in a course, send a message and observe that the notice is displayed correctly.