### PR TITLE
Add a default template to the lesson editor

### DIFF
--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
@@ -88,6 +88,7 @@ const LessonActionsEdit = ( {
 						allowedBlocks={ ACTION_BLOCKS }
 						template={ filteredInnerBlocksTemplate }
 						templateLock="all"
+						templateInsertUpdatesSelection={ false }
 					/>
 				</div>
 			</div>

--- a/assets/blocks/shared.js
+++ b/assets/blocks/shared.js
@@ -18,11 +18,7 @@ registerSenseiBlocks( [ ContactTeacherBlock ] );
 
 let postType = null;
 
-subscribe( () => {
-	if ( postType ) {
-		return;
-	}
-
+const unsubscribe = subscribe( () => {
 	postType = select( 'core/editor' ).getCurrentPostType();
 
 	if ( ! postType ) {
@@ -37,4 +33,6 @@ subscribe( () => {
 			}
 		}
 	);
+
+	unsubscribe();
 } );

--- a/assets/blocks/single-lesson.js
+++ b/assets/blocks/single-lesson.js
@@ -1,4 +1,10 @@
 /**
+ * WordPress dependencies
+ */
+import { subscribe, select, dispatch } from '@wordpress/data';
+import { createBlock } from '@wordpress/blocks';
+
+/**
  * Internal dependencies
  */
 import registerSenseiBlocks from './register-sensei-blocks';
@@ -17,3 +23,32 @@ registerSenseiBlocks( [
 	ResetLessonBlock,
 	ViewQuizBlock,
 ] );
+
+let needsTemplate;
+
+subscribe( () => {
+	if ( undefined !== needsTemplate ) {
+		return;
+	}
+
+	needsTemplate = select( 'core/editor' ).getEditedPostAttribute( 'meta' )
+		?._needs_template; // eslint-disable-line camelcase
+
+	if ( true !== needsTemplate ) {
+		return;
+	}
+
+	// Add default lesson template to the editor.
+	setTimeout( () => {
+		dispatch( 'core/block-editor' ).resetBlocks(
+			select( 'core/block-editor' )
+				.getTemplate()
+				.map( ( block ) => createBlock( ...block ) )
+		);
+	}, 1 );
+
+	// TODO: Not working yet!
+	dispatch( 'core/editor' ).editPost( {
+		meta: { _needs_template: false },
+	} );
+} );

--- a/assets/blocks/single-lesson.js
+++ b/assets/blocks/single-lesson.js
@@ -25,11 +25,7 @@ registerSenseiBlocks( [
 
 let needsTemplate;
 
-subscribe( () => {
-	if ( undefined !== needsTemplate ) {
-		return;
-	}
-
+const unsubscribe = subscribe( () => {
 	needsTemplate = select( 'core/editor' ).getEditedPostAttribute( 'meta' )
 		?._needs_template; // eslint-disable-line camelcase
 
@@ -43,4 +39,6 @@ subscribe( () => {
 	dispatch( 'core/editor' ).editPost( {
 		meta: { _needs_template: false },
 	} );
+
+	unsubscribe();
 } );

--- a/assets/blocks/single-lesson.js
+++ b/assets/blocks/single-lesson.js
@@ -47,7 +47,6 @@ subscribe( () => {
 		);
 	}, 1 );
 
-	// TODO: Not working yet!
 	dispatch( 'core/editor' ).editPost( {
 		meta: { _needs_template: false },
 	} );

--- a/assets/blocks/single-lesson.js
+++ b/assets/blocks/single-lesson.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { subscribe, select, dispatch } from '@wordpress/data';
-import { createBlock } from '@wordpress/blocks';
 
 /**
  * Internal dependencies
@@ -39,13 +38,7 @@ subscribe( () => {
 	}
 
 	// Add default lesson template to the editor.
-	setTimeout( () => {
-		dispatch( 'core/block-editor' ).resetBlocks(
-			select( 'core/block-editor' )
-				.getTemplate()
-				.map( ( block ) => createBlock( ...block ) )
-		);
-	}, 1 );
+	setTimeout( dispatch( 'core/block-editor' ).synchronizeTemplate, 1 );
 
 	dispatch( 'core/editor' ).editPost( {
 		meta: { _needs_template: false },

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -85,5 +85,18 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 			],
 			[ 'sensei-lms/lesson-actions' ],
 		];
+
+		register_post_meta(
+			'lesson',
+			'_needs_template',
+			[
+				'show_in_rest'  => true,
+				'single'        => true,
+				'type'          => 'boolean',
+				'auth_callback' => function() {
+					return current_user_can( 'manage_sensei' );
+				},
+			]
+		);
 	}
 }

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -74,5 +74,13 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		new Sensei_Lesson_Actions_Block();
 		new Sensei_Next_Lesson_Block();
 		new Sensei_Block_Contact_Teacher();
+
+		$post_type_object = get_post_type_object( 'lesson' );
+
+		$post_type_object->template = [
+			[ 'sensei-lms/button-contact-teacher' ],
+			[ 'core/paragraph' ],
+			[ 'sensei-lms/lesson-actions' ],
+		];
 	}
 }

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -81,7 +81,7 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 			[ 'sensei-lms/button-contact-teacher' ],
 			[
 				'core/paragraph',
-				[ 'placeholder' => __( 'Lesson content', 'sensei-lms' ) ],
+				[ 'placeholder' => __( 'Write lesson content...', 'sensei-lms' ) ],
 			],
 			[ 'sensei-lms/lesson-actions' ],
 		];

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -79,7 +79,10 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 
 		$post_type_object->template = [
 			[ 'sensei-lms/button-contact-teacher' ],
-			[ 'core/paragraph' ],
+			[
+				'core/paragraph',
+				[ 'placeholder' => __( 'Lesson content', 'sensei-lms' ) ],
+			],
 			[ 'sensei-lms/lesson-actions' ],
 		];
 	}

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -21,6 +21,7 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 
 		add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
+		add_action( 'init', [ $this, 'register_lesson_post_metas' ] );
 	}
 
 	/**
@@ -85,7 +86,14 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 			],
 			[ 'sensei-lms/lesson-actions' ],
 		];
+	}
 
+	/**
+	 * Register lesson post metas.
+	 *
+	 * @access private
+	 */
+	public function register_lesson_post_metas() {
 		register_post_meta(
 			'lesson',
 			'_needs_template',

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -459,7 +459,8 @@ class Sensei_Course_Structure {
 			'post_type'   => 'lesson',
 			'post_status' => 'draft',
 			'meta_input'  => [
-				'_lesson_course' => $this->course_id,
+				'_lesson_course'  => $this->course_id,
+				'_needs_template' => true,
 			],
 		];
 

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -174,7 +174,7 @@ class Sensei_PostTypes {
 			'has_archive'           => $this->get_course_post_type_archive_slug(),
 			'hierarchical'          => false,
 			'menu_position'         => 51,
-			'supports'              => array( 'title', 'editor', 'excerpt', 'thumbnail', 'revisions' ),
+			'supports'              => array( 'title', 'editor', 'excerpt', 'thumbnail', 'revisions', 'custom-fields' ),
 			'show_in_rest'          => true,
 			'rest_base'             => 'courses',
 			'rest_controller_class' => 'WP_REST_Posts_Controller',


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add a default template to the lesson editor.

### Testing instructions

* Add a new lesson, and make sure it starts with a default template:
    * Contact Teacher
    * Paragraph (_Placeholder Text_: Lesson content)
    * Lesson Actions

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1035" alt="Screen Shot 2021-01-27 at 21 21 21" src="https://user-images.githubusercontent.com/876340/106071724-9fd13f80-60e5-11eb-83e5-51a0e956ba37.png">
