### PR TITLE
Add question type selector

### DIFF
--- a/assets/blocks/editor-components/toolbar-dropdown/index.js
+++ b/assets/blocks/editor-components/toolbar-dropdown/index.js
@@ -29,12 +29,14 @@ import { checked } from '../../../icons/wordpress-icons';
  * Dropdown for the editor toolbar.
  *
  * @param {Object}           props
- * @param {DropdownOption[]} props.options        Dropdown options.
- * @param {string}           [props.optionsLabel] Options label.
- * @param {Object}           props.icon           Icon for the toolbar.
- * @param {string}           props.value          Current dropdown value.
- * @param {Function}         props.onChange       Dropdown change callback, which receive
- *                                                the new value as argument.
+ * @param {DropdownOption[]} props.options             Dropdown options.
+ * @param {string}           [props.optionsLabel]      Options label.
+ * @param {Object}           props.icon                Icon for the toolbar.
+ * @param {string}           props.value               Current dropdown value.
+ * @param {Function}         props.onChange            Dropdown change callback, which receive the new value as argument.
+ * @param {Object}           props.toggleProps         Props passed to the toggle element.
+ * @param {Object}           props.popoverProps        Props passed to the popover component.
+ * @param {Function}         props.renderMenuItemProps Render function for a menu item. Should return a props object.
  */
 const ToolbarDropdown = ( {
 	options,
@@ -42,6 +44,10 @@ const ToolbarDropdown = ( {
 	icon,
 	value,
 	onChange,
+	toggleProps,
+	renderMenuItemProps,
+	popoverProps,
+	...props
 } ) => {
 	const selectedOption = options.find( ( option ) => value === option.value );
 
@@ -52,7 +58,11 @@ const ToolbarDropdown = ( {
 				isAlternate: true,
 				position: 'bottom right left',
 				focusOnMount: true,
-				className: classnames( 'sensei-toolbar-dropdown__popover' ),
+				...popoverProps,
+				className: classnames(
+					popoverProps?.className,
+					'sensei-toolbar-dropdown__popover'
+				),
 			} }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
@@ -60,35 +70,47 @@ const ToolbarDropdown = ( {
 					icon={ icon }
 					aria-expanded={ isOpen }
 					aria-haspopup="true"
-				>
-					{ selectedOption.label }
-				</Button>
+					{ ...toggleProps }
+					children={
+						toggleProps?.children
+							? toggleProps?.children( selectedOption )
+							: selectedOption?.label
+					}
+				/>
 			) }
 			renderContent={ ( { onClose } ) => (
 				<NavigableMenu role="menu" stopNavigationEvents>
 					<MenuGroup label={ optionsLabel }>
 						{ options.map( ( option ) => {
 							const isSelected =
-								option.value === selectedOption.value;
-
+								option.value === selectedOption?.value;
+							const menuItemProps = renderMenuItemProps?.(
+								option
+							);
 							return (
 								<MenuItem
 									key={ option.value }
 									role="menuitemradio"
 									isSelected={ isSelected }
 									icon={ isSelected ? checked : null }
+									className={ classnames(
+										'sensei-toolbar-dropdown__option',
+										{ 'is-selected': isSelected },
+										menuItemProps?.className
+									) }
 									onClick={ () => {
 										onChange( option.value );
 										onClose();
 									} }
-								>
-									{ option.label }
-								</MenuItem>
+									children={ option.label }
+									{ ...menuItemProps }
+								/>
 							);
 						} ) }
 					</MenuGroup>
 				</NavigableMenu>
 			) }
+			{ ...props }
 		/>
 	);
 };

--- a/assets/blocks/editor-components/toolbar-dropdown/index.js
+++ b/assets/blocks/editor-components/toolbar-dropdown/index.js
@@ -15,6 +15,11 @@ import {
 } from '@wordpress/components';
 
 /**
+ * Internal dependencies
+ */
+import { checked } from '../../../icons/wordpress-icons';
+
+/**
  * @typedef {Object} DropdownOption
  *
  * @property {string} label Option label.
@@ -42,7 +47,13 @@ const ToolbarDropdown = ( {
 
 	return (
 		<Dropdown
-			popoverProps={ { isAlternate: true } }
+			className="sensei-toolbar-dropdown"
+			popoverProps={ {
+				isAlternate: true,
+				position: 'bottom right left',
+				focusOnMount: true,
+				className: classnames( 'sensei-toolbar-dropdown__popover' ),
+			} }
 			renderToggle={ ( { isOpen, onToggle } ) => (
 				<Button
 					onClick={ onToggle }
@@ -65,9 +76,7 @@ const ToolbarDropdown = ( {
 									key={ option.value }
 									role="menuitemradio"
 									isSelected={ isSelected }
-									className={ classnames( {
-										'sensei-toolbar-dropdown-item-checked': isSelected,
-									} ) }
+									icon={ isSelected ? checked : null }
 									onClick={ () => {
 										onChange( option.value );
 										onClose();

--- a/assets/blocks/editor-components/toolbar-dropdown/index.js
+++ b/assets/blocks/editor-components/toolbar-dropdown/index.js
@@ -29,14 +29,14 @@ import { checked } from '../../../icons/wordpress-icons';
  * Dropdown for the editor toolbar.
  *
  * @param {Object}           props
- * @param {DropdownOption[]} props.options             Dropdown options.
- * @param {string}           [props.optionsLabel]      Options label.
- * @param {Object}           props.icon                Icon for the toolbar.
- * @param {string}           props.value               Current dropdown value.
- * @param {Function}         props.onChange            Dropdown change callback, which receive the new value as argument.
- * @param {Object}           props.toggleProps         Props passed to the toggle element.
- * @param {Object}           props.popoverProps        Props passed to the popover component.
- * @param {Function}         props.renderMenuItemProps Render function for a menu item. Should return a props object.
+ * @param {DropdownOption[]} props.options          Dropdown options.
+ * @param {string}           [props.optionsLabel]   Options label.
+ * @param {Object}           props.icon             Icon for the toolbar.
+ * @param {string}           props.value            Current dropdown value.
+ * @param {Function}         props.onChange         Dropdown change callback, which receive the new value as argument.
+ * @param {Object}           props.toggleProps      Props passed to the toggle element.
+ * @param {Object}           props.popoverProps     Props passed to the popover component.
+ * @param {Function}         props.getMenuItemProps Render function for a menu item. Should return a props object.
  */
 const ToolbarDropdown = ( {
 	options,
@@ -45,7 +45,7 @@ const ToolbarDropdown = ( {
 	value,
 	onChange,
 	toggleProps,
-	renderMenuItemProps,
+	getMenuItemProps,
 	popoverProps,
 	...props
 } ) => {
@@ -73,7 +73,7 @@ const ToolbarDropdown = ( {
 					{ ...toggleProps }
 					children={
 						toggleProps?.children
-							? toggleProps?.children( selectedOption )
+							? toggleProps.children( selectedOption )
 							: selectedOption?.label
 					}
 				/>
@@ -84,9 +84,7 @@ const ToolbarDropdown = ( {
 						{ options.map( ( option ) => {
 							const isSelected =
 								option.value === selectedOption?.value;
-							const menuItemProps = renderMenuItemProps?.(
-								option
-							);
+							const menuItemProps = getMenuItemProps?.( option );
 							return (
 								<MenuItem
 									key={ option.value }

--- a/assets/blocks/editor-components/toolbar-dropdown/toolbar-dropdown.scss
+++ b/assets/blocks/editor-components/toolbar-dropdown/toolbar-dropdown.scss
@@ -1,11 +1,23 @@
-.sensei-toolbar-dropdown-item-checked {
-	position: relative;
-	padding-right: 30px;
-	&::after {
-		font-family: dashicons;
-		content: "\f147";
-		font-size: 20px;
-		position: absolute;
-		right: 0;
+.sensei-toolbar-dropdown {
+	&__popover.components-popover[data-x-axis='right'] {
+		.components-popover__content {
+			margin-left: 0;
+			min-width: 300px;
+		}
+	}
+
+	&__option {
+		text-align: left;
+		height: auto;
+		min-height: 32px;
+		border-radius: 2px;
+
+		.components-menu-item__item {
+			white-space: normal;
+		}
+
+		&.is-selected {
+			background-color: #f0f0f0;
+		}
 	}
 }

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -1,0 +1,56 @@
+import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * @typedef QuestionType
+ *
+ * @property {string}   title       Question type name.
+ * @property {string}   description Question type description.
+ * @property {Function} edit        Editor component.
+ */
+
+/**
+ * Question type definitions.
+ *
+ * @type {Object.<string, QuestionType>}
+ */
+const questionTypes = {
+	multichoice: {
+		title: __( 'Multiple Choice', 'sensei-lms' ),
+		description: __(
+			'Select one or more answers from a list of choices.',
+			'sensei-lms'
+		),
+		edit: () => <div> [Multiple Choice] </div>,
+	},
+	truefalse: {
+		title: __( 'True / False', 'sensei-lms' ),
+		description: __( 'True or false question.', 'sensei-lms' ),
+		edit: () => <div> [True/False] </div>,
+	},
+	gap: {
+		title: __( 'Gap Fill', 'sensei-lms' ),
+		description: __(
+			'Fill in the missing part of a sentence.',
+			'sensei-lms'
+		),
+		edit: () => <div> [Gap Fill] </div>,
+	},
+	open: {
+		title: __( 'Open-Ended', 'sensei-lms' ),
+		description: __( 'Require a written answer.', 'sensei-lms' ),
+		edit: () => <div> [Open-Ended] </div>,
+	},
+	file: {
+		title: __( 'File Upload', 'sensei-lms' ),
+		description: __( 'Require a file to be uploaded.', 'sensei-lms' ),
+		edit: () => <div> [File Upload] </div>,
+	},
+};
+
+/**
+ * Quiz editor question types.
+ *
+ * @param {Object.<string, QuestionType>}
+ */
+export default applyFilters( 'sensei_quiz_question_types', questionTypes );

--- a/assets/blocks/quiz/question-block/block.json
+++ b/assets/blocks/quiz/question-block/block.json
@@ -11,6 +11,10 @@
     },
     "title": {
       "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "default": "multichoice"
     }
   }
 }

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -3,6 +3,7 @@
  */
 import { RichText, InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import types from '../answer-blocks';
 
 /**
  * Quiz question block editor.
@@ -14,9 +15,11 @@ import { __ } from '@wordpress/i18n';
  */
 const QuestionEdit = ( props ) => {
 	const {
-		attributes: { title },
+		attributes: { title, type, answer = {} },
 		setAttributes,
 	} = props;
+
+	const AnswerBlock = type && types[ type ];
 
 	return (
 		<div className="sensei-lms-question-block">
@@ -42,6 +45,14 @@ const QuestionEdit = ( props ) => {
 					],
 				] }
 			/>
+			{ AnswerBlock?.edit && (
+				<AnswerBlock.edit
+					attributes={ answer }
+					setAttributes={ ( next ) =>
+						setAttributes( { answer: { ...answer, ...next } } )
+					}
+				/>
+			) }
 		</div>
 	);
 };

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -1,9 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { RichText, InnerBlocks } from '@wordpress/block-editor';
+import { RichText, InnerBlocks, BlockControls } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import types from '../answer-blocks';
+import { QuestionTypeToolbar } from './question-type-toolbar';
 
 /**
  * Quiz question block editor.
@@ -53,6 +58,16 @@ const QuestionEdit = ( props ) => {
 					}
 				/>
 			) }
+			<BlockControls>
+				<>
+					<QuestionTypeToolbar
+						value={ type }
+						onSelect={ ( nextValue ) =>
+							setAttributes( { type: nextValue } )
+						}
+					/>
+				</>
+			</BlockControls>
 		</div>
 	);
 };

--- a/assets/blocks/quiz/question-block/question-type-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-type-toolbar.js
@@ -1,0 +1,51 @@
+import { Toolbar } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import ToolbarDropdown from '../../editor-components/toolbar-dropdown';
+import types from '../answer-blocks';
+
+const options = Object.entries( types ).map( ( [ value, settings ] ) => ( {
+	...settings,
+	label: settings.title,
+	value,
+} ) );
+
+/**
+ * Question type selector toolbar control.
+ *
+ * @param {Object}   props
+ * @param {string}   props.value    Selected type.
+ * @param {Function} props.onSelect Selection callback.
+ */
+export const QuestionTypeToolbar = ( { value, onSelect } ) => {
+	return (
+		<Toolbar className="sensei-lms-question-block__type-selector__toolbar">
+			<ToolbarDropdown
+				className="sensei-lms-question-block__type-selector"
+				label={ __( 'Question Type', 'sensei-lms' ) }
+				options={ options }
+				value={ value }
+				onChange={ ( nextValue ) => onSelect( nextValue ) }
+				optionsLabel={ __( 'Question Type', 'sensei-lms' ) }
+				popoverProps={ {
+					className:
+						'sensei-lms-question-block__type-selector__popover',
+				} }
+				toggleProps={ {
+					children: ( selectedOption ) => (
+						<b>{ selectedOption?.title }</b>
+					),
+				} }
+				renderMenuItemProps={ ( option ) => ( {
+					children: (
+						<div>
+							<strong> { option.title }</strong>
+							<div className="sensei-lms-question-block__type-selector__option__description">
+								{ option.description }
+							</div>
+						</div>
+					),
+				} ) }
+			/>
+		</Toolbar>
+	);
+};

--- a/assets/blocks/quiz/question-block/question-type-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-type-toolbar.js
@@ -35,7 +35,7 @@ export const QuestionTypeToolbar = ( { value, onSelect } ) => {
 						<b>{ selectedOption?.title }</b>
 					),
 				} }
-				renderMenuItemProps={ ( option ) => ( {
+				getMenuItemProps={ ( option ) => ( {
 					children: (
 						<div>
 							<strong> { option.title }</strong>

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -7,4 +7,19 @@
 		line-height: 1.25;
 	}
 
+	&__type-selector {
+		&__toolbar {
+			order: -1;
+		}
+
+		&__popover .sensei-toolbar-dropdown__option {
+			padding: 12px;
+		}
+
+		&__option__description {
+			color: #757575;
+			font-size: 90%;
+		}
+	}
+
 }

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -8,9 +8,6 @@
 	}
 
 	&__type-selector {
-		&__toolbar {
-			order: -1;
-		}
 
 		&__popover .sensei-toolbar-dropdown__option {
 			padding: 12px;


### PR DESCRIPTION
Part of #3888 

### Changes proposed in this Pull Request

* Add question types and a selector toolbar to the Question block
* Extend `ToolbarDropdown` component and fix alignment & some styles
* Add `sensei_quiz_question_types` hook for the question types

### Testing instructions

* Edit a lesson block and add a quiz with questions
* Change the question types in the toolbar
* Ensure the correct placeholder is shown in the questions answer section
--
* `ToolbarDropdown`: Check that preview selector in the lesson actions block still works correctly
--
* Hook: Add the following snippet somewhere (for example, in `sensei-single-lesson-blocks.js`), and check that the new type shows up in the editor:

```js
import { addFilter } from '@wordpress/hooks';

addFilter( 'sensei_quiz_question_types', 'sample-ext', ( types ) => ( {
	...types,
	ext: {
		title: 'Sample Extension Type',
		description: 'Hook Example.',
		edit: () => <div>EXTENSION</div>,
	},
} ) );
```

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_quiz_question_types` (JS) — Filter question types available in the editor. 
    Note that a script using this will have to be enqueued before `sensei-quiz-blocks` (priority: 10)

### Screenshots

<img width="523" alt="image" src="https://user-images.githubusercontent.com/176949/106191854-b04bed80-61ab-11eb-8fd5-ee319bbed3ed.png">

