### PR TITLE
Lesson Actions: Fully hide inactive buttons and add state separator

### DIFF
--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-editor.scss
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-editor.scss
@@ -34,7 +34,7 @@
 			content: '';
 			left: 12px;
 			right: 12px;
-			border-top: var(--wp-admin-border-width-focus) solid var(--wp-admin-theme-color);
+			border-top: var(--wp-admin-border-width-focus, 1.5px) solid var(--wp-admin-theme-color, rgba(66,88,99,.4));
 			margin-top: -9px;
 			pointer-events: none;
 		}

--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-editor.scss
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-editor.scss
@@ -1,4 +1,6 @@
 .wp-block-sensei-lms-lesson-actions {
+	position: relative;
+
 	&__preview-completed {
 		.wp-block-sensei-lms-button-complete-lesson,
 		.wp-block-sensei-lms-button-view-quiz {
@@ -22,3 +24,20 @@
 		}
 	}
 }
+
+.wp-block[data-type="sensei-lms/lesson-actions"] {
+
+	&.is-selected .wp-block-sensei-lms-button-next-lesson__wrapper {
+		position: static;
+		&:before {
+			position: absolute;
+			content: '';
+			left: 12px;
+			right: 12px;
+			border-top: var(--wp-admin-border-width-focus) solid var(--wp-admin-theme-color);
+			margin-top: -9px;
+			pointer-events: none;
+		}
+	}
+}
+

--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-editor.scss
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-editor.scss
@@ -12,13 +12,13 @@
 		}
 	}
 	&__no-quiz {
-		.wp-block-sensei-lms-button-view-quiz {
-			opacity: 0.1;
+		.wp-block-sensei-lms-button-view-quiz__wrapper {
+			display: none;
 		}
 	}
 	&__complete_lessons-not-allowed {
-		.wp-block-sensei-lms-button-complete-lesson {
-			opacity: 0.1;
+		.wp-block-sensei-lms-button-complete-lesson__wrapper {
+			display: none;
 		}
 	}
 }


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Remove buttons that won't be displayed on the frontend instead of just fading them, so it works like it will on the frontend
* Add an extra separator between the two states when the block is selected

### Testing instructions

* Edit a lesson with lesson actions block
* With no quiz, `View Quiz` should not appear 
* Add quiz questions — `View Quiz` and `Complete Lesson` should appear
* Check on `The passmark must be achieved before the lesson is complete.` — `Complete Lesson` should disappear

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="611" alt="image" src="https://user-images.githubusercontent.com/176949/106300276-94e9ec80-6256-11eb-8289-0009b05c54a0.png">

Block selection with separator:
<img width="641" alt="image" src="https://user-images.githubusercontent.com/176949/106301461-08d8c480-6258-11eb-9c22-69520448c534.png">
