### PR TITLE
Update block descriptions for Lesson Actions blocks

### DIFF
--- a/assets/blocks/lesson-actions/complete-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/complete-lesson-block/index.js
@@ -18,7 +18,7 @@ export default createButtonBlockType( {
 		parent: [ 'sensei-lms/lesson-actions' ],
 		title: __( 'Complete Lesson', 'sensei-lms' ),
 		description: __(
-			'Enable an enrolled user to mark the lesson as complete. The button is displayed when the learner is enrolled and there is no required quiz linked to the lesson.',
+			'Enable a learner to mark the lesson as complete. This block is only displayed if the lesson has no quiz or the quiz is optional.',
 			'sensei-lms'
 		),
 		keywords: [

--- a/assets/blocks/lesson-actions/lesson-actions-block/index.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/index.js
@@ -14,7 +14,7 @@ import save from './lesson-actions-save';
 export default {
 	title: __( 'Lesson Actions', 'sensei-lms' ),
 	description: __(
-		'Enable an enrolled user to perform specific actions for a lesson.',
+		'Enable a learner to perform specific actions for a lesson.',
 		'sensei-lms'
 	),
 	keywords: [

--- a/assets/blocks/lesson-actions/next-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/next-lesson-block/index.js
@@ -18,7 +18,7 @@ export default createButtonBlockType( {
 		title: __( 'Next Lesson', 'sensei-lms' ),
 		parent: [ 'sensei-lms/lesson-actions' ],
 		description: __(
-			'Enable a user to move to the next lesson. The button is displayed when the learner has completed the lesson.',
+			'Enable a learner to move to the next lesson. This block is only displayed if the current lesson has been completed.',
 			'sensei-lms'
 		),
 		keywords: [

--- a/assets/blocks/lesson-actions/reset-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/reset-lesson-block/index.js
@@ -18,7 +18,7 @@ export default createButtonBlockType( {
 		title: __( 'Reset Lesson', 'sensei-lms' ),
 		parent: [ 'sensei-lms/lesson-actions' ],
 		description: __(
-			'Enable an enrolled user to reset their lesson progress. The button is displayed when the learner has completed the lesson and resetting progress is allowed.',
+			'Enable a learner to reset their progress. This block is only displayed if the quiz has been completed and retakes are enabled.',
 			'sensei-lms'
 		),
 		keywords: [

--- a/assets/blocks/lesson-actions/view-quiz-block/index.js
+++ b/assets/blocks/lesson-actions/view-quiz-block/index.js
@@ -17,10 +17,7 @@ export default createButtonBlockType( {
 		name: 'sensei-lms/button-view-quiz',
 		title: __( 'View Quiz', 'sensei-lms' ),
 		parent: [ 'sensei-lms/lesson-actions' ],
-		description: __(
-			'Enable an enrolled user to view the quiz. The button is displayed when the lesson is not completed and there is a quiz linked to it.',
-			'sensei-lms'
-		),
+		description: __( 'Enable a learner to view the quiz.', 'sensei-lms' ),
 		keywords: [
 			__( 'Quiz', 'sensei-lms' ),
 			__( 'Lesson', 'sensei-lms' ),


### PR DESCRIPTION
Updated the block descriptions for all blocks used in _Lesson Actions_ to use consistent language with the existing course blocks.

- enrolled user => learner
- It feels like overkill to stipulate that the _View Quiz_ block is only visible when the lesson has a quiz. That should be obvious. Additionally, I removed the condition that the block is "displayed when the lesson is not completed", as that is not true.

### Testing instructions
- Add the Lesson Actions block to a lesson.
- Ensure the block descriptions are updated.