### PR TITLE
Always show View Quiz button

### DIFF
--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-editor.scss
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-editor.scss
@@ -21,17 +21,3 @@
 		}
 	}
 }
-
-.wp-block[data-type="sensei-lms/lesson-actions"] {
-	&.is-selected .wp-block-sensei-lms-button-next-lesson__wrapper,
-	&.is-selected .wp-block-sensei-lms-button-complete-lesson__wrapper {
-		&:before {
-			position: absolute;
-			content: '';
-			top: 6px;
-			bottom: 6px;
-			margin-left: -9px;
-			pointer-events: none;
-		}
-	}
-}

--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-editor.scss
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-editor.scss
@@ -1,9 +1,6 @@
 .wp-block-sensei-lms-lesson-actions {
-	position: relative;
-
 	&__preview-completed {
-		.wp-block-sensei-lms-button-complete-lesson,
-		.wp-block-sensei-lms-button-view-quiz {
+		.wp-block-sensei-lms-button-complete-lesson {
 			opacity: 0.1;
 		}
 	}
@@ -26,18 +23,15 @@
 }
 
 .wp-block[data-type="sensei-lms/lesson-actions"] {
-
-	&.is-selected .wp-block-sensei-lms-button-next-lesson__wrapper {
-		position: static;
+	&.is-selected .wp-block-sensei-lms-button-next-lesson__wrapper,
+	&.is-selected .wp-block-sensei-lms-button-complete-lesson__wrapper {
 		&:before {
 			position: absolute;
 			content: '';
-			left: 12px;
-			right: 12px;
-			border-top: var(--wp-admin-border-width-focus, 1.5px) solid var(--wp-admin-theme-color, rgba(66,88,99,.4));
-			margin-top: -9px;
+			top: 6px;
+			bottom: 6px;
+			margin-left: -9px;
 			pointer-events: none;
 		}
 	}
 }
-

--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions.scss
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions.scss
@@ -1,5 +1,5 @@
 .wp-block-sensei-lms-lesson-actions {
 	.wp-block-sensei-lms-button-next-lesson__wrapper {
-		clear: both;
+		//clear: both;
 	}
 }

--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions.scss
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions.scss
@@ -1,5 +1,0 @@
-.wp-block-sensei-lms-lesson-actions {
-	.wp-block-sensei-lms-button-next-lesson__wrapper {
-		//clear: both;
-	}
-}

--- a/assets/blocks/single-lesson-style.scss
+++ b/assets/blocks/single-lesson-style.scss
@@ -1,1 +1,0 @@
-@import './lesson-actions/lesson-actions-block/lesson-actions';

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -34,11 +34,7 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 			return;
 		}
 
-		Sensei()->assets->enqueue(
-			'sensei-single-lesson-blocks-style',
-			'blocks/single-lesson-style.css',
-			[ 'sensei-shared-blocks-style' ]
-		);
+		Sensei()->assets->enqueue( 'sensei-shared-blocks-style', 'blocks/shared-style.css' );
 
 		if ( ! is_admin() ) {
 			Sensei()->assets->enqueue_script( 'sensei-blocks-frontend' );

--- a/includes/blocks/class-sensei-view-quiz-block.php
+++ b/includes/blocks/class-sensei-view-quiz-block.php
@@ -40,7 +40,7 @@ class Sensei_View_Quiz_Block {
 	public function render( array $attributes, string $content ) : string {
 		$lesson = get_post();
 
-		if ( empty( $lesson ) || Sensei_Utils::user_completed_lesson( $lesson->ID ) ) {
+		if ( empty( $lesson ) ) {
 			return '';
 		}
 

--- a/tests/unit-tests/blocks/test-class-sensei-lesson-actions-blocks.php
+++ b/tests/unit-tests/blocks/test-class-sensei-lesson-actions-blocks.php
@@ -102,7 +102,7 @@ class Sensei_Lesson_Actions_Blocks extends WP_UnitTestCase {
 		$this->assertNotEmpty( $view_quiz->render( [], '' ), 'View quiz button is not displayed when there is a quiz to the lesson.' );
 
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'passed' );
-		$this->assertEmpty( $view_quiz->render( [], '' ), 'View quiz button is displayed when the user has completed the lesson.' );
+		$this->assertNotEmpty( $view_quiz->render( [], '' ), 'View quiz button is not displayed when the user has completed the lesson.' );
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -36,7 +36,6 @@ const files = [
 	'blocks/single-course-style.scss',
 	'blocks/single-course-style-editor.scss',
 	'blocks/single-lesson.js',
-	'blocks/single-lesson-style.scss',
 	'blocks/single-lesson-style-editor.scss',
 	'blocks/shared.js',
 	'blocks/shared-style.scss',


### PR DESCRIPTION
Fixes #3945

### Changes proposed in this Pull Request

* Updates the View quiz button to always be displayed when there is a quiz.
* Changes the buttons to be on the same line in the editor (thanks @yscik)
* Removes the border separator as it doesn't make much sense now that we always display view quiz.

### Testing instructions

* Create a lesson and try different combinations (having or not a quiz, having or not a 'Reset Quiz' button).
* Try different states in the editor and observe the button positioning.
* Observe that the buttons are displayed normally in the frontend.