### PR TITLE
Update Reset Lesson block description

### DIFF
--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-settings.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-settings.js
@@ -37,7 +37,7 @@ const LessonActionsSettings = ( {
 				<ToolbarDropdown
 					options={ [
 						{
-							label: __( 'In progress', 'sensei-lms' ),
+							label: __( 'In Progress', 'sensei-lms' ),
 							value: IN_PROGRESS_PREVIEW,
 						},
 						{

--- a/assets/blocks/lesson-actions/reset-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/reset-lesson-block/index.js
@@ -18,7 +18,7 @@ export default createButtonBlockType( {
 		title: __( 'Reset Lesson', 'sensei-lms' ),
 		parent: [ 'sensei-lms/lesson-actions' ],
 		description: __(
-			'Enable a learner to reset their progress. This block is only displayed if the quiz has been completed and retakes are enabled.',
+			'Enable a learner to reset their progress. This block is only displayed if the lesson is completed and has no quiz, or the quiz is completed and retakes are enabled.',
 			'sensei-lms'
 		),
 		keywords: [


### PR DESCRIPTION
In https://github.com/Automattic/sensei/pull/3929, the conditions for displaying the _Reset Lesson_ button were changed such that it's now also displayed when a lesson is completed and has no quiz. This logic is a bit confusing, so we'll probably need to simplify it at some point.

Given these changes, this PR updates the block description for the _Reset Lesson_ block.

### Testing instructions
* Add the _Lesson Actions_ block to a lesson.
* Ensure the block descriptions for the _Reset Lesson_ block is updated.