### PR TITLE
Use quiz state to determine if complete lesson is allowed

### DIFF
--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
@@ -58,7 +58,7 @@ const LessonActionsEdit = ( {
 	const hasQuiz = useHasQuiz();
 	const quizStateClass = hasQuiz ? 'has-quiz' : 'no-quiz';
 
-	const completeLessonAllowed = useCompleteLessonAllowed();
+	const completeLessonAllowed = useCompleteLessonAllowed( hasQuiz );
 	const completeLessonAllowedClass = completeLessonAllowed
 		? 'allowed'
 		: 'not-allowed';

--- a/assets/blocks/lesson-actions/lesson-actions-block/use-complete-lesson-allowed.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/use-complete-lesson-allowed.js
@@ -6,16 +6,16 @@ import { useEffect, useState } from '@wordpress/element';
 /**
  * Hook to check if a lesson can be completed manually.
  *
+ * @param {boolean} hasQuiz If a lesson has a quiz.
+ *
  * @return {boolean} If a lesson can be marked as completed by student.
  */
-const useCompleteLessonAllowed = () => {
+const useCompleteLessonAllowed = ( hasQuiz ) => {
 	const passRequiredCheckbox = document.getElementById( 'pass_required' );
 
-	const [ completeLessonAllowed, setCompleteLessonAllowed ] = useState(
-		() => {
-			return ! passRequiredCheckbox || ! passRequiredCheckbox.checked;
-		}
-	);
+	const [ passRequired, setPassRequired ] = useState( () => {
+		return ! passRequiredCheckbox || ! passRequiredCheckbox.checked;
+	} );
 
 	useEffect( () => {
 		// Ignore if the checkbox isn't present.
@@ -24,7 +24,7 @@ const useCompleteLessonAllowed = () => {
 		}
 
 		const passRequiredEventHandler = () => {
-			setCompleteLessonAllowed( ! passRequiredCheckbox.checked );
+			setPassRequired( ! passRequiredCheckbox.checked );
 		};
 
 		passRequiredCheckbox.addEventListener(
@@ -40,7 +40,7 @@ const useCompleteLessonAllowed = () => {
 		};
 	}, [ passRequiredCheckbox ] );
 
-	return completeLessonAllowed;
+	return ! hasQuiz || passRequired;
 };
 
 export default useCompleteLessonAllowed;


### PR DESCRIPTION
Fixes #3947

### Changes proposed in this Pull Request

* Show `Complete Lesson` button when quiz doesn't exist. 

### Testing instructions

* See issue.