### PR TITLE
[Refactor] Prepare structure store for quiz block

### DIFF
--- a/assets/blocks/course-outline/outline-block/outline-edit.js
+++ b/assets/blocks/course-outline/outline-block/outline-edit.js
@@ -100,14 +100,14 @@ const useApplyStyleToModules = ( clientId, className, isPreview ) => {
 const OutlineEdit = ( props ) => {
 	const { clientId, className, attributes, setAttributes } = props;
 
-	const { fetchCourseStructure } = useDispatch( COURSE_STORE );
 	const { updateBlockAttributes } = useDispatch( 'core/block-editor' );
+	const { loadStructure } = useDispatch( COURSE_STORE );
 
 	useEffect( () => {
 		if ( ! attributes.isPreview ) {
-			fetchCourseStructure();
+			loadStructure();
 		}
-	}, [ attributes.isPreview, fetchCourseStructure ] );
+	}, [ attributes.isPreview, loadStructure ] );
 
 	const { setBlocks } = useBlocksCreator( clientId );
 

--- a/assets/blocks/course-outline/store.js
+++ b/assets/blocks/course-outline/store.js
@@ -1,30 +1,23 @@
 /**
  * External dependencies
  */
-import { isEqual } from 'lodash';
 
 /**
  * WordPress dependencies
  */
-import { apiFetch, controls as dataControls } from '@wordpress/data-controls';
-import { dispatch, registerStore, select, subscribe } from '@wordpress/data';
+import { dispatch, select } from '@wordpress/data';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
-import { createReducerFromActionMap } from '../../shared/data/store-helpers';
+import { registerStructureStore } from '../../shared/structure/structure-store';
+
 import {
 	syncStructureToBlocks,
 	extractStructure,
 	getFirstBlockByName,
 } from './data';
-
-const DEFAULT_STATE = {
-	serverStructure: null,
-	isSavingStructure: false,
-	hasStructureUpdate: false,
-};
 
 const getEditorOutlineBlock = () =>
 	getFirstBlockByName(
@@ -42,81 +35,15 @@ const getEditorOutlineStructure = () => {
 	return extractStructure( outlineBlock.innerBlocks );
 };
 
-const actions = {
-	/**
-	 * Fetch course structure data from REST API.
-	 */
-	*fetchCourseStructure() {
+export const COURSE_STORE = 'sensei/course-structure';
+
+registerStructureStore( {
+	storeName: COURSE_STORE,
+	*getEndpoint() {
 		const courseId = yield select( 'core/editor' ).getCurrentPostId();
-		const result = yield apiFetch( {
-			path: `/sensei-internal/v1/course-structure/${ courseId }?context=edit`,
-		} );
-		yield actions.setStructure( result );
+		return `course-structure/${ courseId }`;
 	},
-
-	/**
-	 * Persist editor's course structure to the REST API.
-	 *
-	 * @param {Array} editorStructure
-	 */
-	*saveStructure( editorStructure ) {
-		yield { type: 'SAVING', isSavingStructure: true };
-		const courseId = yield select( 'core/editor' ).getCurrentPostId();
-
-		try {
-			const result = yield apiFetch( {
-				path: `/sensei-internal/v1/course-structure/${ courseId }`,
-				method: 'POST',
-				data: { structure: editorStructure },
-			} );
-			yield actions.setStructure( result, editorStructure );
-		} catch ( error ) {
-			const errorMessage = sprintf(
-				/* translators: Error message. */
-				__(
-					'Course modules and lessons could not be updated. %s',
-					'sensei-lms'
-				),
-				error.message
-			);
-			yield dispatch( 'core/notices' ).createErrorNotice( errorMessage, {
-				id: 'course-outline-save-error',
-			} );
-		}
-
-		yield { type: 'SAVING', isSavingStructure: false };
-	},
-
-	/**
-	 * Set fetched structure.
-	 *
-	 * @param {Array} serverStructure
-	 * @param {Array} editorStructure
-	 */
-	*setStructure( serverStructure, editorStructure = null ) {
-		yield actions.setServerStructure( serverStructure, editorStructure );
-		yield actions.updateOutlineBlock( serverStructure );
-	},
-
-	/**
-	 * Keep last fetched server state for comparison.
-	 *
-	 * @param {Array} serverStructure
-	 * @param {Array} editorStructure
-	 */
-	setServerStructure: ( serverStructure, editorStructure = null ) => ( {
-		type: 'SET_SERVER_STRUCTURE',
-		serverStructure,
-		hasStructureUpdate:
-			editorStructure && ! isEqual( serverStructure, editorStructure ),
-	} ),
-
-	/**
-	 * Update outline block.
-	 *
-	 * @param {Array} structure
-	 */
-	*updateOutlineBlock( structure ) {
+	*updateBlock( structure ) {
 		const { clientId = null } = getEditorOutlineBlock();
 
 		if ( ! clientId || ! structure || 0 === structure.length ) {
@@ -132,109 +59,22 @@ const actions = {
 			false
 		);
 	},
-
-	/**
-	 * Clear structure update.
-	 */
-	clearStructureUpdate: () => ( { type: 'CLEAR_STRUCTURE_UPDATE' } ),
-};
-
-/**
- * Course structure reducers.
- */
-const reducers = {
-	SET_SERVER_STRUCTURE: (
-		{ serverStructure, hasStructureUpdate },
-		state
-	) => {
-		return {
-			...state,
-			serverStructure,
-			hasStructureUpdate,
-		};
+	readBlock: getEditorOutlineStructure,
+	*saveError( error ) {
+		const errorMessage = sprintf(
+			/* translators: Error message. */
+			__(
+				'Course modules and lessons could not be updated. %s',
+				'sensei-lms'
+			),
+			error.message
+		);
+		yield dispatch( 'core/notices' ).createErrorNotice( errorMessage, {
+			id: 'course-outline-save-error',
+		} );
 	},
-	SAVING: ( { isSavingStructure }, state ) => ( {
-		...state,
-		isSavingStructure,
-	} ),
-	CLEAR_STRUCTURE_UPDATE: ( action, state ) => ( {
-		...state,
-		hasStructureUpdate: false,
-	} ),
-	DEFAULT: ( action, state ) => state,
-};
-
-/**
- * Course structure selectors.
- */
-const selectors = {
-	shouldResavePost: ( { hasStructureUpdate } ) => hasStructureUpdate,
-	getIsSavingStructure: ( { isSavingStructure } ) => isSavingStructure,
-	getServerStructure: ( { serverStructure } ) => serverStructure,
-};
-
-export const COURSE_STORE = 'sensei/course-structure';
-
-/**
- * Register course structure store and subscribe to block editor save.
- */
-const registerCourseStructureStore = () => {
-	// Set to true when savings starts, and false when it ends.
-	let postSaving = false;
-
-	const startSave = () => {
-		const serverStructure = select( COURSE_STORE ).getServerStructure();
-		const editorStructure = getEditorOutlineStructure();
-
-		if (
-			! editorStructure ||
-			isEqual( serverStructure, editorStructure )
-		) {
-			return;
-		}
-
+	clearError() {
 		// Clear error notices.
 		dispatch( 'core/notices' ).removeNotice( 'course-outline-save-error' );
-		dispatch( COURSE_STORE ).saveStructure( editorStructure );
-	};
-
-	const finishSave = () => {
-		const shouldResavePost = select( COURSE_STORE ).shouldResavePost();
-
-		if ( ! shouldResavePost ) {
-			return;
-		}
-
-		dispatch( 'core/editor' ).savePost();
-		dispatch( COURSE_STORE ).clearStructureUpdate();
-	};
-
-	subscribe( function saveStructureOnPostSave() {
-		const editor = select( 'core/editor' );
-
-		if ( ! editor ) return;
-
-		const isSavingPost =
-			editor.isSavingPost() && ! editor.isAutosavingPost();
-		const isSavingStructure = select( COURSE_STORE ).getIsSavingStructure();
-
-		if ( ! postSaving && isSavingPost ) {
-			// First update where post is saving.
-			postSaving = true;
-			startSave();
-		} else if ( postSaving && ! isSavingPost && ! isSavingStructure ) {
-			// First update where post is no longer saving and editor is sync.
-			postSaving = false;
-			finishSave();
-		}
-	} );
-
-	registerStore( COURSE_STORE, {
-		reducer: createReducerFromActionMap( reducers, DEFAULT_STATE ),
-		actions,
-		selectors,
-		controls: { ...dataControls },
-	} );
-};
-
-registerCourseStructureStore();
+	},
+} );

--- a/assets/shared/structure/structure-store.js
+++ b/assets/shared/structure/structure-store.js
@@ -40,7 +40,7 @@ export function registerStructureStore( {
 
 	const actions = {
 		/**
-		 * Fetch course structure data from REST API.
+		 * Fetch structure data from REST API.
 		 */
 		*loadStructure() {
 			const endpoint = yield* getEndpoint();
@@ -51,7 +51,7 @@ export function registerStructureStore( {
 		},
 
 		/**
-		 * Persist editor's course structure to the REST API.
+		 * Persist editor's structure to the REST API.
 		 *
 		 * @param {Array} editorStructure
 		 */
@@ -107,7 +107,7 @@ export function registerStructureStore( {
 	};
 
 	/**
-	 * Course structure reducers.
+	 * Structure store reducers.
 	 */
 	const reducers = {
 		SET_SERVER_STRUCTURE: (
@@ -132,7 +132,7 @@ export function registerStructureStore( {
 	};
 
 	/**
-	 * Course structure selectors.
+	 * Store state selectors.
 	 */
 	const selectors = {
 		shouldResavePost: ( { hasStructureUpdate } ) => hasStructureUpdate,
@@ -173,7 +173,9 @@ export function registerStructureStore( {
 		subscribe( function saveStructureOnPostSave() {
 			const editor = select( 'core/editor' );
 
-			if ( ! editor ) return;
+			if ( ! editor ) {
+				return;
+			}
 
 			const isSavingPost =
 				editor.isSavingPost() && ! editor.isAutosavingPost();

--- a/assets/shared/structure/structure-store.js
+++ b/assets/shared/structure/structure-store.js
@@ -1,0 +1,203 @@
+/**
+ * External dependencies
+ */
+import { isEqual } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { apiFetch, controls as dataControls } from '@wordpress/data-controls';
+import { dispatch, registerStore, select, subscribe } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { createReducerFromActionMap } from '../data/store-helpers';
+
+/**
+ * Register structure store and subscribe to block editor save.
+ *
+ * @param {Object}   opts
+ * @param {string}   opts.storeName   Name of store.
+ * @param {Function} opts.getEndpoint REST API endpoint.
+ * @param {Function} opts.saveError   Handler for displaying errors.
+ * @param {Function} opts.clearError  Handler for clearing errors.
+ * @param {Function} opts.updateBlock Update block with given structure.
+ * @param {Function} opts.readBlock   Extract structure from block.
+ */
+export function registerStructureStore( {
+	storeName,
+	getEndpoint,
+	saveError,
+	clearError,
+	updateBlock,
+	readBlock,
+} ) {
+	const DEFAULT_STATE = {
+		serverStructure: null,
+		isSavingStructure: false,
+		hasStructureUpdate: false,
+	};
+
+	const actions = {
+		/**
+		 * Fetch course structure data from REST API.
+		 */
+		*loadStructure() {
+			const endpoint = yield* getEndpoint();
+			const result = yield apiFetch( {
+				path: `/sensei-internal/v1/${ endpoint }?context=edit`,
+			} );
+			yield actions.setStructure( result );
+		},
+
+		/**
+		 * Persist editor's course structure to the REST API.
+		 *
+		 * @param {Array} editorStructure
+		 */
+		*saveStructure( editorStructure ) {
+			yield { type: 'SAVING', isSavingStructure: true };
+
+			try {
+				const endpoint = yield* getEndpoint();
+				const result = yield apiFetch( {
+					path: `/sensei-internal/v1/${ endpoint }`,
+					method: 'POST',
+					data: { structure: editorStructure },
+				} );
+				yield actions.setStructure( result, editorStructure );
+			} catch ( error ) {
+				yield saveError( error );
+			}
+
+			yield { type: 'SAVING', isSavingStructure: false };
+		},
+
+		/**
+		 * Set fetched structure.
+		 *
+		 * @param {Array} serverStructure
+		 * @param {Array} editorStructure
+		 */ *setStructure( serverStructure, editorStructure = null ) {
+			yield actions.setServerStructure(
+				serverStructure,
+				editorStructure
+			);
+			yield updateBlock( serverStructure );
+		},
+
+		/**
+		 * Keep last fetched server state for comparison.
+		 *
+		 * @param {Array} serverStructure
+		 * @param {Array} editorStructure
+		 */
+		setServerStructure: ( serverStructure, editorStructure = null ) => ( {
+			type: 'SET_SERVER_STRUCTURE',
+			serverStructure,
+			hasStructureUpdate:
+				editorStructure &&
+				! isEqual( serverStructure, editorStructure ),
+		} ),
+
+		/**
+		 * Clear structure update.
+		 */
+		clearStructureUpdate: () => ( { type: 'CLEAR_STRUCTURE_UPDATE' } ),
+	};
+
+	/**
+	 * Course structure reducers.
+	 */
+	const reducers = {
+		SET_SERVER_STRUCTURE: (
+			{ serverStructure, hasStructureUpdate },
+			state
+		) => {
+			return {
+				...state,
+				serverStructure,
+				hasStructureUpdate,
+			};
+		},
+		SAVING: ( { isSavingStructure }, state ) => ( {
+			...state,
+			isSavingStructure,
+		} ),
+		CLEAR_STRUCTURE_UPDATE: ( action, state ) => ( {
+			...state,
+			hasStructureUpdate: false,
+		} ),
+		DEFAULT: ( action, state ) => state,
+	};
+
+	/**
+	 * Course structure selectors.
+	 */
+	const selectors = {
+		shouldResavePost: ( { hasStructureUpdate } ) => hasStructureUpdate,
+		getIsSavingStructure: ( { isSavingStructure } ) => isSavingStructure,
+		getServerStructure: ( { serverStructure } ) => serverStructure,
+	};
+
+	const subscribeToPostSave = () => {
+		// Set to true when savings starts, and false when it ends.
+		let postSaving = false;
+
+		const startSave = () => {
+			const serverStructure = select( storeName ).getServerStructure();
+			const editorStructure = readBlock();
+
+			if (
+				! editorStructure ||
+				isEqual( serverStructure, editorStructure )
+			) {
+				return;
+			}
+
+			clearError();
+			dispatch( storeName ).saveStructure( editorStructure );
+		};
+
+		const finishSave = () => {
+			const shouldResavePost = select( storeName ).shouldResavePost();
+
+			if ( ! shouldResavePost ) {
+				return;
+			}
+
+			dispatch( 'core/editor' ).savePost();
+			dispatch( storeName ).clearStructureUpdate();
+		};
+
+		subscribe( function saveStructureOnPostSave() {
+			const editor = select( 'core/editor' );
+
+			if ( ! editor ) return;
+
+			const isSavingPost =
+				editor.isSavingPost() && ! editor.isAutosavingPost();
+			const isSavingStructure = select(
+				storeName
+			).getIsSavingStructure();
+
+			if ( ! postSaving && isSavingPost ) {
+				// First update where post is saving.
+				postSaving = true;
+				startSave();
+			} else if ( postSaving && ! isSavingPost && ! isSavingStructure ) {
+				// First update where post is no longer saving and editor is sync.
+				postSaving = false;
+				finishSave();
+			}
+		} );
+	};
+
+	subscribeToPostSave();
+	registerStore( storeName, {
+		reducer: createReducerFromActionMap( reducers, DEFAULT_STATE ),
+		actions,
+		selectors,
+		controls: { ...dataControls },
+	} );
+}


### PR DESCRIPTION
Part of #3776 

### Changes proposed in this Pull Request

* Break out generic structure store from course outline
* Most of the store logic can then be shared with the upcoming Quiz block, with configuration to translate the blocks to and from a data structure

### Testing instructions

* Ensure Course Outline block on a course page still works as expected

