### PR TITLE
Skip sort_structure method for single lesson save.

### DIFF
--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -772,37 +772,39 @@ class Sensei_Course_Structure {
 	 * @return array Sorted structure.
 	 */
 	public static function sort_structure( $structure, $order, $type ) {
-		usort(
-			$structure,
-			function( $a, $b ) use ( $order, $type ) {
-				// One of the types is not being sorted.
-				if ( $type !== $a['type'] || $type !== $b['type'] ) {
-					// If types are equal, keep in the current positions.
-					if ( $a['type'] === $b['type'] ) {
+		if ( ! empty( $order ) 
+		&&  [0] !== $order ) {
+			usort(
+				$structure,
+				function( $a, $b ) use ( $order, $type ) {
+					// One of the types is not being sorted.
+					if ( $type !== $a['type'] || $type !== $b['type'] ) {
+						// If types are equal, keep in the current positions.
+						if ( $a['type'] === $b['type'] ) {
+							return 0;
+						}
+
+						// Always keep the modules before the lessons.
+						return 'module' === $a['type'] ? - 1 : 1;
+					}
+
+					$a_position = array_search( $a['id'], $order, true );
+					$b_position = array_search( $b['id'], $order, true );
+
+					// If both weren't sorted, keep the current positions.
+					if ( false === $a_position && false === $b_position ) {
 						return 0;
 					}
 
-					// Always keep the modules before the lessons.
-					return 'module' === $a['type'] ? - 1 : 1;
+					// Keep not sorted items in the end.
+					if ( false === $a_position ) {
+						return 1;
+					}
+
+					return false === $b_position || $a_position < $b_position ? -1 : 1;
 				}
-
-				$a_position = array_search( $a['id'], $order, true );
-				$b_position = array_search( $b['id'], $order, true );
-
-				// If both weren't sorted, keep the current positions.
-				if ( false === $a_position && false === $b_position ) {
-					return 0;
-				}
-
-				// Keep not sorted items in the end.
-				if ( false === $a_position ) {
-					return 1;
-				}
-
-				return false === $b_position || $a_position < $b_position ? -1 : 1;
-			}
-		);
-
+			);
+		}
 		return $structure;
 	}
 }

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -772,8 +772,8 @@ class Sensei_Course_Structure {
 	 * @return array Sorted structure.
 	 */
 	public static function sort_structure( $structure, $order, $type ) {
-		if ( ! empty( $order ) 
-		&&  [0] !== $order ) {
+		if ( ! empty( $order )
+		&& [ 0 ] !== $order ) {
 			usort(
 				$structure,
 				function( $a, $b ) use ( $order, $type ) {


### PR DESCRIPTION
Fixes #3921 

### Changes proposed in this Pull Request

* Skip Sensei_Course_Structure::sort_structure sorting when $order is empty ( or [0] ).

In analysing the problem that on single lesson save, the entire lesson order can be changed, I found that the php usort function changes the lesson order when all lessons return a 0 value. 

Note: The entry with value 0 is the result of the way $order is filled from the (empty) $order_string parameter in `Sensei_Admin->save_lesson_order()`.

`$order = array_map( 'absint', explode( ',', $order_string ) );`

In those cases the lesson order will already be sorted correctly and the intention of the callback function used in this method is to leave the structure unaffected.

This PR just makes the usort-call conditional so it skips sorting when there is nothing to sort ( e.g. $order equals [0] ). 

### Testing instructions

* I don't know exactly why and when usort fails, but in our case we had 47 lessons and no modules in the course. So all lessons where no module lessons.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
