### PR TITLE
Pass original structure position to usort.

### DIFF
--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -808,6 +808,10 @@ class Sensei_Course_Structure {
 					return false === $b_position || $a_position < $b_position ? -1 : 1;
 				}
 			);
+			// Forget previous positions in structure.
+			foreach ( $structure as $key => $value ) {
+				unset $structure[ $key ]['position'];
+			}
 		}
 		return $structure;
 	}

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -774,6 +774,10 @@ class Sensei_Course_Structure {
 	public static function sort_structure( $structure, $order, $type ) {
 		if ( ! empty( $order )
 		&& [ 0 ] !== $order ) {
+			// remember current position in structure
+			foreach ($structure as $key => $value) {
+				$structure[$key]['position'] = intval( $key );
+			}
 			usort(
 				$structure,
 				function( $a, $b ) use ( $order, $type ) {
@@ -781,7 +785,7 @@ class Sensei_Course_Structure {
 					if ( $type !== $a['type'] || $type !== $b['type'] ) {
 						// If types are equal, keep in the current positions.
 						if ( $a['type'] === $b['type'] ) {
-							return 0;
+							return $a['position'] === $b['position'] ? 0 : ( $a['position'] > $b['position'] ? 1 : -1 );
 						}
 
 						// Always keep the modules before the lessons.
@@ -793,7 +797,7 @@ class Sensei_Course_Structure {
 
 					// If both weren't sorted, keep the current positions.
 					if ( false === $a_position && false === $b_position ) {
-						return 0;
+						return $a['position'] === $b['position'] ? 0 : ( $a['position'] > $b['current-pos'] ? 1 : -1 );
 					}
 
 					// Keep not sorted items in the end.

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -774,9 +774,9 @@ class Sensei_Course_Structure {
 	public static function sort_structure( $structure, $order, $type ) {
 		if ( ! empty( $order )
 		&& [ 0 ] !== $order ) {
-			// remember current position in structure
-			foreach ($structure as $key => $value) {
-				$structure[$key]['position'] = intval( $key );
+			// Remember current position in structure.
+			foreach ( $structure as $key => $value ) {
+				$structure[ $key ]['position'] = intval( $key );
 			}
 			usort(
 				$structure,

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -810,7 +810,7 @@ class Sensei_Course_Structure {
 			);
 			// Forget previous positions in structure.
 			foreach ( $structure as $key => $value ) {
-				unset $structure[ $key ]['position'];
+				unset( $structure[ $key ]['position'] );
 			}
 		}
 		return $structure;

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -797,7 +797,7 @@ class Sensei_Course_Structure {
 
 					// If both weren't sorted, keep the current positions.
 					if ( false === $a_position && false === $b_position ) {
-						return $a['position'] === $b['position'] ? 0 : ( $a['position'] > $b['current-pos'] ? 1 : -1 );
+						return $a['position'] === $b['position'] ? 0 : ( $a['position'] > $b['position'] ? 1 : -1 );
 					}
 
 					// Keep not sorted items in the end.


### PR DESCRIPTION
Fixes #3921 

### Changes proposed in this Pull Request

Although PR3951 prevented lesson pages to distort the lesson order, by basically skipping the sorting in sort_structure(), it hasn't solved the reason why the usort() call failed in the first place.

The reason is that the callback tries to retain the original order in $structure without having information about the order of this structure. Simply returning 0 doesn't tell usort to keep the original order, it says  the order doesn't matter, so it can do what it wants.

I first thought that each comparison could better return -1, since that implies an actual difference between the compared values, but that only works if usort calls the entries in sequence and that is not what is does. Using vardumps I found It first compairs the first entry with the middle one and then that one with the last and compairs that middle one with every other entry and so on. 

That means usort actually needs to be fed with an actual order-indication (0, 1 or -1) and thus the callback needs info about the original order of $structure to correctly determine that response in cases the order should remain unchanged.

So in order to fix that part of the usort, this pr proposes to save the original order in the structure and really compare the original order so usort doesn't fail in any scenario. It would even work without PR3951, although that PR is a more efficient solution for situations where no $order is passed to sort_structure.

* remember the original order of $structure in `Sensei_Course_Structure->sort_structure()`
* return the actual order result where lesson_order should remain as it was.

### Testing instructions
* We had 47 lessons without modules when this originally went wrong when saving a lesson.
* The way I tested it is to use sort_structure() without the condition added in PR3951. The original order is kept in the same testcase as I used to test PR3951.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
