### PR TITLE
Implement quiz REST fetching

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3205,9 +3205,6 @@ class Sensei_Lesson {
 		// get the users current status on the lesson
 		$user_lesson_status = Sensei_Utils::user_lesson_status( $quiz_lesson_id, $user_id );
 
-		// Set the default question order if it has not already been set for this quiz
-		$this->set_default_question_order( $quiz_id );
-
 		// If viewing quiz on the frontend then show questions in random order if set
 		if ( ! is_admin() ) {
 			$random_order = get_post_meta( $quiz_id, '_random_question_order', true );
@@ -3216,31 +3213,10 @@ class Sensei_Lesson {
 			}
 		}
 
-		// Get all questions and multiple questions
-		$question_query_args = array(
-			'post_type'        => array( 'question', 'multiple_question' ),
-			'posts_per_page'   => -1,
-			'meta_key'         => '_quiz_question_order' . $quiz_id,
-			'orderby'          => $orderby,
-			'order'            => $order,
-			'meta_query'       => array(
-				array(
-					'key'   => '_quiz_id',
-					'value' => $quiz_id,
-				),
-			),
-			'post_status'      => $post_status,
-			'suppress_filters' => 0,
-		);
+		$questions = Sensei()->quiz->get_questions( $quiz_id, $post_status, $orderby, $order );
 
-		// query the questions
-		$questions_query = new WP_Query( $question_query_args );
-
-		// Set return array to initially include all items
-		$questions = $questions_query->posts;
-
-		// set the questions array that will be manipulated within this function
-		$questions_array = $questions_query->posts;
+		// Set the questions array that will be manipulated within this function.
+		$questions_array = $questions;
 
 		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 			return $questions;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3218,10 +3218,6 @@ class Sensei_Lesson {
 		// Set the questions array that will be manipulated within this function.
 		$questions_array = $questions;
 
-		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
-			return $questions;
-		}
-
 		// If viewing quiz on frontend or in grading then only single questions must be shown
 		$selected_questions = false;
 		if ( ! is_admin() || ( is_admin() && isset( $_GET['page'] ) && 'sensei_grading' == $_GET['page'] && isset( $_GET['user'] ) && isset( $_GET['quiz_id'] ) ) ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3242,6 +3242,10 @@ class Sensei_Lesson {
 		// set the questions array that will be manipulated within this function
 		$questions_array = $questions_query->posts;
 
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return $questions;
+		}
+
 		// If viewing quiz on frontend or in grading then only single questions must be shown
 		$selected_questions = false;
 		if ( ! is_admin() || ( is_admin() && isset( $_GET['page'] ) && 'sensei_grading' == $_GET['page'] && isset( $_GET['user'] ) && isset( $_GET['quiz_id'] ) ) ) {

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1437,7 +1437,43 @@ class Sensei_Quiz {
 		return $merged;
 	}
 
-} // End Class Sensei_Quiz
+	/**
+	 * Get all the questions of a quiz.
+	 *
+	 * @param int    $quiz_id     The quiz id.
+	 * @param string $post_status Question post status.
+	 * @param string $orderby     Question order by.
+	 * @param string $order       Question order.
+	 *
+	 * @return array
+	 */
+	public function get_questions( $quiz_id, $post_status, $orderby, $order ) : array {
+
+		// Set the default question order if it has not already been set for this quiz.
+		Sensei()->lesson->set_default_question_order( $quiz_id );
+
+		// Get all questions and multiple questions.
+		$question_query_args = array(
+			'post_type'        => array( 'question', 'multiple_question' ),
+			'posts_per_page'   => - 1,
+			'meta_key'         => '_quiz_question_order' . $quiz_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Query limited by the number of questions.
+			'orderby'          => $orderby,
+			'order'            => $order,
+			'meta_query'       => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Query limited by the number of questions.
+				array(
+					'key'   => '_quiz_id',
+					'value' => $quiz_id,
+				),
+			),
+			'post_status'      => $post_status,
+			'suppress_filters' => 0,
+		);
+
+		$questions_query = new WP_Query( $question_query_args );
+
+		return $questions_query->posts;
+	}
+}
 
 
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1447,7 +1447,7 @@ class Sensei_Quiz {
 	 *
 	 * @return array
 	 */
-	public function get_questions( $quiz_id, $post_status, $orderby, $order ) : array {
+	public function get_questions( $quiz_id, $post_status = 'any', $orderby = 'meta_value_num title', $order = 'ASC' ) : array {
 
 		// Set the default question order if it has not already been set for this quiz.
 		Sensei()->lesson->set_default_question_order( $quiz_id );

--- a/includes/rest-api/class-sensei-rest-api-internal.php
+++ b/includes/rest-api/class-sensei-rest-api-internal.php
@@ -48,6 +48,7 @@ class Sensei_REST_API_Internal {
 			new Sensei_REST_API_Import_Controller( $this->namespace ),
 			new Sensei_REST_API_Export_Controller( $this->namespace ),
 			new Sensei_REST_API_Course_Structure_Controller( $this->namespace ),
+			new Sensei_REST_API_Quiz_Controller( $this->namespace ),
 		];
 
 		foreach ( $this->controllers as $controller ) {

--- a/includes/rest-api/class-sensei-rest-api-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-quiz-controller.php
@@ -298,7 +298,9 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 	 * @return array The multiple choice question properties.
 	 */
 	private function get_multiple_choice_properties( WP_Post $question ) : array {
-		$type_specific_properties['random_order'] = 'yes' === get_post_meta( $question->ID, '_random_order', true );
+		$type_specific_properties = [
+			'random_order' => 'yes' === get_post_meta( $question->ID, '_random_order', true ),
+		];
 
 		$answer_feedback = get_post_meta( $question->ID, '_answer_feedback', true );
 		if ( ! empty( $answer_feedback ) ) {

--- a/includes/rest-api/class-sensei-rest-api-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-quiz-controller.php
@@ -85,7 +85,11 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 			);
 		}
 
-		return current_user_can( get_post_type_object( 'quiz' )->cap->read_post, $quiz->ID );
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		return wp_get_current_user()->ID === (int) $quiz->post_author || current_user_can( 'manage_options' );
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-quiz-controller.php
@@ -1,0 +1,570 @@
+<?php
+/**
+ * File containing the class Sensei_REST_API_Quiz_Controller.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sensei Course Structure REST API endpoints.
+ *
+ * @package Sensei
+ * @author  Automattic
+ * @since   3.9.0
+ */
+class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
+
+	/**
+	 * Routes namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace;
+
+	/**
+	 * Routes prefix.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'quiz';
+
+	/**
+	 * Sensei_REST_API_Quiz_Controller constructor.
+	 *
+	 * @param string $namespace Routes namespace.
+	 */
+	public function __construct( $namespace ) {
+		$this->namespace = $namespace;
+	}
+
+	/**
+	 * Register the REST API endpoints for Course Structure.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/(?P<quiz_id>[0-9]+)',
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_quiz' ],
+					'permission_callback' => [ $this, 'can_user_get_quiz' ],
+					'args'                => [
+						'context' => [
+							'type'              => 'string',
+							'default'           => 'view',
+							'enum'              => [ 'view', 'edit' ],
+							'sanitize_callback' => 'sanitize_key',
+							'validate_callback' => 'rest_validate_request_arg',
+						],
+					],
+				],
+				'schema' => [ $this, 'get_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Check user permission for reading a quiz.
+	 *
+	 * @param WP_REST_Request $request WordPress request object.
+	 *
+	 * @return bool|WP_Error Whether the user can read a quiz. Error if not found.
+	 */
+	public function can_user_get_quiz( WP_REST_Request $request ) {
+		$quiz = get_post( (int) $request->get_param( 'quiz_id' ) );
+		if ( ! $quiz || 'quiz' !== $quiz->post_type ) {
+			return new WP_Error(
+				'sensei_course_structure_missing_course',
+				__( 'Course not found.', 'sensei-lms' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		return current_user_can( get_post_type_object( 'quiz' )->cap->read_post, $quiz->ID );
+	}
+
+	/**
+	 * Get the quiz.
+	 *
+	 * @param WP_REST_Request $request WordPress request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function get_quiz( WP_REST_Request $request ) : WP_REST_Response {
+		$quiz = get_post( (int) $request->get_param( 'quiz_id' ) );
+
+		$this->get_quiz_questions( $quiz );
+
+		$response = new WP_REST_Response();
+		$response->set_data( $this->get_quiz_data( $quiz ) );
+
+		return $response;
+	}
+
+	/**
+	 * Helper method which retrieves quiz options.
+	 *
+	 * @param WP_Post $quiz
+	 *
+	 * @return array
+	 */
+	private function get_quiz_data( WP_Post $quiz ) : array {
+		$post_meta = get_post_meta( $quiz->ID );
+		return [
+			'options'   => [
+				'pass_required'         => ! empty( $post_meta['_pass_required'] ) && 'on' === $post_meta['_pass_required'][0],
+				'quiz_passmark'         => empty( $post_meta['_quiz_passmark'] ) ? 0 : (int) $post_meta['_quiz_passmark'][0],
+				'auto_grade'            => ! empty( $post_meta['_quiz_grade_type'] ) && 'auto' === $post_meta['_quiz_grade_type'][0],
+				'allow_retakes'         => ! empty( $post_meta['_enable_quiz_reset'] ) && 'on' === $post_meta['_enable_quiz_reset'][0],
+				'show_questions'        => empty( $post_meta['_show_questions'] ) ? null : (int) $post_meta['_show_questions'][0],
+				'random_question_order' => ! empty( $post_meta['_random_question_order'] ) && 'yes' === $post_meta['_random_question_order'][0],
+			],
+			'questions' => $this->get_quiz_questions( $quiz ),
+		];
+	}
+
+	/**
+	 * Returns all the questions of a quiz.
+	 *
+	 * @param WP_Post $quiz The quiz.
+	 *
+	 * @return array The array of the questions as defined by the schema.
+	 */
+	private function get_quiz_questions( WP_Post $quiz ) : array {
+		$questions = Sensei()->lesson->lesson_quiz_questions( $quiz->ID );
+
+		if ( empty( $questions ) ) {
+			return [];
+		}
+
+		return array_map( [ $this, 'get_question' ], $questions );
+	}
+
+	/**
+	 * Returns a question as defined by the schema.
+	 *
+	 * @param WP_Post $question The question post.
+	 *
+	 * @return array The question array.
+	 */
+	private function get_question( WP_Post $question ) : array {
+		$common_properties        = $this->get_question_common_properties( $question );
+		$type_specific_properties = $this->get_question_type_specific_properties( $question, $common_properties['type'] );
+
+		return array_merge( $common_properties, $type_specific_properties );
+	}
+
+	/**
+	 * Generates the common question properties.
+	 *
+	 * @param WP_Post $question The question post.
+	 *
+	 * @return array The question properties.
+	 */
+	private function get_question_common_properties( WP_Post $question ) : array {
+		$question_meta = get_post_meta( $question->ID );
+		return [
+			'id'          => $question->ID,
+			'title'       => $question->post_title,
+			'description' => $question->post_content,
+			'grade'       => Sensei()->question->get_question_grade( $question->ID ),
+			'type'        => Sensei()->question->get_question_type( $question->ID ),
+			'shared'      => ! empty( $question_meta['_quiz_id'] ) && count( $question_meta['_quiz_id'] ) > 1,
+			'categories'  => wp_get_post_terms( $question->ID, 'question-category', [ 'fields' => 'ids' ] ),
+		];
+	}
+
+	/**
+	 * Generates the type specific question properties.
+	 *
+	 * @param WP_Post $question      The question post.
+	 * @param string  $question_type The question type.
+	 *
+	 * @return array The question properties.
+	 */
+	private function get_question_type_specific_properties( WP_Post $question, string $question_type ) : array {
+		$type_specific_properties = [];
+
+		switch ( $question_type ) {
+			case 'multiple-choice':
+				$type_specific_properties = $this->get_multiple_choice_properties( $question );
+				break;
+			case 'boolean':
+				break;
+		}
+
+		return $type_specific_properties;
+	}
+
+	/**
+	 * Helper method which generates the properties for multiple choice questions.
+	 *
+	 * @param WP_Post $question The question post.
+	 *
+	 * @return array The multiple choice question properties.
+	 */
+	private function get_multiple_choice_properties( WP_Post $question ) : array {
+		$type_specific_properties['random_order']    = ! empty( get_post_meta( $question->ID, '_random_order', true ) ) && 'yes' === get_post_meta( $question->ID, '_random_order', true );
+		$type_specific_properties['answer_feedback'] = empty( get_post_meta( $question->ID, '_answer_feedback', true ) ) ? null : get_post_meta( $question->ID, '_answer_feedback', true );
+
+		$correct_answers = $this->get_answers_array( $question, '_question_right_answer', true );
+		$wrong_answers   = $this->get_answers_array( $question, '_question_wrong_answers', false );
+
+		$answer_order       = empty( get_post_meta( $question->ID, '_answer_order', true ) ) ? '' : get_post_meta( $question->ID, '_answer_order', true );
+		$all_answers_sorted = Sensei()->question->get_answers_sorted( array_merge( $correct_answers, $wrong_answers ), $answer_order );
+
+		$type_specific_properties['options'] = array_values( $all_answers_sorted );
+
+		return $type_specific_properties;
+	}
+
+	/**
+	 * Helper method which transforms the answers question meta to an associative array. This is the format that is expected by
+	 * Sensei_Question::get_answers_sorted.
+	 *
+	 * @param WP_Post $question   The question post.
+	 * @param string  $meta_key   The answers meta key.
+	 * @param bool    $is_correct Whether the questions are correct.
+	 *
+	 * @see Sensei_Question::get_answers_sorted
+	 *
+	 * @return array The answers array.
+	 */
+	private function get_answers_array( WP_Post $question, string $meta_key, bool $is_correct ) : array {
+		$answers = empty( get_post_meta( $question->ID, $meta_key, true ) ) ? [] : get_post_meta( $question->ID, $meta_key, true );
+		if ( ! is_array( $answers ) ) {
+			$answers = [ $answers ];
+		}
+
+		$result = [];
+		foreach ( $answers as $correct_answer ) {
+			$result[ Sensei()->lesson->get_answer_id( $correct_answer ) ] = [
+				'label'   => $correct_answer,
+				'correct' => $is_correct,
+			];
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Schema for the endpoint.
+	 *
+	 * @return array Schema object.
+	 */
+	public function get_schema() : array {
+		return [
+			'definitions' => $this->get_question_definitions(),
+			'type'        => 'object',
+			'properties'  => [
+				'options'   => [
+					'type'       => 'object',
+					'properties' => [
+						'pass_required'         => [
+							'type'        => 'boolean',
+							'description' => 'Pass required to complete lesson',
+							'default'     => false,
+						],
+						'quiz_passmark'         => [
+							'type'        => 'integer',
+							'description' => 'Score grade between 0 and 100 required to pass the quiz',
+							'default'     => 100,
+						],
+						'auto_grade'            => [
+							'type'        => 'boolean',
+							'description' => 'Whether auto-grading should take place',
+							'default'     => true,
+						],
+						'allow_retakes'         => [
+							'type'        => 'boolean',
+							'description' => 'Allow quizzes to be taken again',
+							'default'     => true,
+						],
+						'show_questions'        => [
+							'type'        => 'boolean',
+							'description' => 'Number of questions to show randomly',
+							'default'     => null,
+						],
+						'random_question_order' => [
+							'type'        => 'boolean',
+							'description' => 'Show questions in a random order',
+							'default'     => false,
+						],
+					],
+				],
+				'questions' => [
+					'type'        => 'array',
+					'description' => 'Questions in quiz',
+					'items'       => [
+						'oneOf' => [
+							[
+								'$ref' => '#/definitions/question_category',
+							],
+							[
+								'$ref' => '#/definitions/question_multiple_choice',
+							],
+							[
+								'$ref' => '#/definitions/question_boolean',
+							],
+							[
+								'$ref' => '#/definitions/question_gap_fill',
+							],
+							[
+								'$ref' => '#/definitions/question_single_line',
+							],
+							[
+								'$ref' => '#/definitions/question_multi_line',
+							],
+							[
+								'$ref' => '#/definitions/question_file_upload',
+							],
+						],
+					],
+				],
+			],
+			'required'    => [
+				'options',
+				'questions',
+			],
+		];
+	}
+
+	/**
+	 * Helper method which returns the question schema definitions.
+	 *
+	 * @return array The definitions
+	 */
+	private function get_question_definitions() : array {
+		return [
+			'question_category'        => [
+				'type'       => 'object',
+				'properties' => [
+					'type'      => [
+						'const' => 'question-category',
+					],
+					'term_id'   => [
+						'type'        => 'integer',
+						'description' => 'Term ID',
+					],
+					'name'      => [
+						'type'        => 'string',
+						'description' => 'Category name',
+						'readOnly'    => true,
+					],
+					'questions' => [
+						'type'        => 'integer',
+						'description' => 'Number of questions',
+						'readOnly'    => true,
+					],
+				],
+				'required'   => [
+					'term_id',
+				],
+			],
+			'question'                 => [
+				'type'       => 'object',
+				'properties' => [
+					'id'          => [
+						'type'        => 'integer',
+						'description' => 'Question post ID',
+					],
+					'title'       => [
+						'type'        => 'string',
+						'description' => 'Question text',
+					],
+					'description' => [
+						'type'        => 'string',
+						'description' => 'Question description',
+					],
+					'grade'       => [
+						'type'        => 'integer',
+						'description' => 'Points this question is worth',
+						'default'     => 1,
+					],
+					'shared'      => [
+						'type'        => 'boolean',
+						'description' => 'Whether the question has been added on other quizzes',
+						'readOnly'    => false,
+					],
+					'categories'  => [
+						'type'        => 'array',
+						'description' => 'Category term IDs attached to the question',
+						'items'       => [
+							'type'        => 'integer',
+							'description' => 'Term IDs',
+						],
+					],
+				],
+				'required'   => [
+					'title',
+				],
+			],
+			'question_multiple_choice' => [
+				'allOf' => [
+					[
+						'$ref' => '#/definitions/question',
+					],
+					[
+						'properties' => [
+							'type'            => [
+								'const' => 'multiple-choice',
+							],
+							'options'         => [
+								'type'        => 'array',
+								'description' => 'Options for the multiple choice',
+								'items'       => [
+									'type'       => 'object',
+									'properties' => [
+										'label'   => [
+											'type'        => 'string',
+											'description' => 'Label for answer option',
+										],
+										'correct' => [
+											'type'        => 'boolean',
+											'description' => 'Whether this answer is correct',
+										],
+									],
+								],
+							],
+							'random_order'    => [
+								'type'        => 'boolean',
+								'description' => 'Should options be randomized when displayed to quiz takers',
+								'default'     => false,
+							],
+							'answer_feedback' => [
+								'type'        => 'string',
+								'description' => 'Feedback to show quiz takers once quiz is submitted',
+							],
+						],
+						'required'   => [
+							'options',
+						],
+					],
+				],
+			],
+			'question_boolean'         => [
+				'allOf' => [
+					[
+						'$ref' => '#/definitions/question',
+					],
+					[
+						'properties' => [
+							'type'            => [
+								'const' => 'boolean',
+							],
+							'answer'          => [
+								'type'        => 'boolean',
+								'description' => 'Correct answer for question',
+							],
+							'answer_feedback' => [
+								'type'        => 'string',
+								'description' => 'Feedback to show quiz takers once quiz is submitted',
+							],
+						],
+						'required'   => [
+							'answer',
+						],
+					],
+				],
+			],
+			'question_gap_fill'        => [
+				'allOf' => [
+					[
+						'$ref' => '#/definitions/question',
+					],
+					[
+						'properties' => [
+							'type'   => [
+								'const' => 'gap-fill',
+							],
+							'before' => [
+								'type'        => 'string',
+								'description' => 'Text before the gap',
+							],
+							'gap'    => [
+								'type'        => 'array',
+								'description' => 'Gap text answers',
+								'items'       => [
+									'type'        => 'string',
+									'description' => 'Gap answers',
+								],
+							],
+							'after'  => [
+								'type'        => 'string',
+								'description' => 'Text after the gap',
+							],
+						],
+						'required'   => [
+							'before',
+							'gap',
+							'after',
+						],
+					],
+				],
+			],
+			'question_single_line'     => [
+				'allOf' => [
+					[
+						'$ref' => '#/definitions/question',
+					],
+					[
+						'properties' => [
+							'type'   => [
+								'const' => 'single-line',
+							],
+							'answer' => [
+								'type'        => 'string',
+								'description' => 'Teacher notes for grading',
+							],
+						],
+					],
+				],
+			],
+			'question_multi_line'      => [
+				'allOf' => [
+					[
+						'$ref' => '#/definitions/question',
+					],
+					[
+						'properties' => [
+							'type'          => [
+								'const' => 'multi-line',
+							],
+							'teacher_notes' => [
+								'type'        => 'string',
+								'description' => 'Teacher notes for grading',
+							],
+						],
+					],
+				],
+			],
+			'question_file_upload'     => [
+				'allOf' => [
+					[
+						'$ref' => '#/definitions/question',
+					],
+					[
+						'properties' => [
+							'type'         => [
+								'const' => 'file-upload',
+							],
+							'student_help' => [
+								'type'        => 'string',
+								'description' => 'Description for student explaining what needs to be uploaded',
+							],
+							'answer'       => [
+								'type'        => 'string',
+								'description' => 'Teacher notes for grading',
+							],
+						],
+					],
+				],
+			],
+		];
+	}
+}

--- a/includes/rest-api/class-sensei-rest-api-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-quiz-controller.php
@@ -250,7 +250,7 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 
 				$student_help = get_post_meta( $question->ID, '_question_wrong_answers', true );
 				if ( ! empty( $student_help[0] ) ) {
-					$type_specific_properties['student_help'][0] = $student_help;
+					$type_specific_properties['student_help'] = $student_help[0];
 				}
 				break;
 		}

--- a/includes/rest-api/class-sensei-rest-api-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-quiz-controller.php
@@ -205,6 +205,29 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 			case 'gap-fill':
 				$type_specific_properties = $this->get_gap_fill_properties( $question );
 				break;
+			case 'single-line':
+				$answer = get_post_meta( $question->ID, '_question_right_answer', true );
+				if ( ! empty( $answer ) ) {
+					$type_specific_properties['teacher_notes'] = $answer;
+				}
+				break;
+			case 'multi-line':
+				$teacher_notes = get_post_meta( $question->ID, '_question_right_answer', true );
+				if ( ! empty( $teacher_notes ) ) {
+					$type_specific_properties['teacher_notes'] = $teacher_notes;
+				}
+				break;
+			case 'file-upload':
+				$teacher_notes = get_post_meta( $question->ID, '_question_right_answer', true );
+				if ( ! empty( $teacher_notes ) ) {
+					$type_specific_properties['teacher_notes'] = $teacher_notes;
+				}
+
+				$student_help = get_post_meta( $question->ID, '_question_wrong_answers', true );
+				if ( ! empty( $student_help[0] ) ) {
+					$type_specific_properties['student_help'][0] = $student_help;
+				}
+				break;
 		}
 
 		return $type_specific_properties;
@@ -564,10 +587,10 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 					],
 					[
 						'properties' => [
-							'type'   => [
+							'type'          => [
 								'const' => 'single-line',
 							],
-							'answer' => [
+							'teacher_notes' => [
 								'type'        => 'string',
 								'description' => 'Teacher notes for grading',
 							],
@@ -600,14 +623,14 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 					],
 					[
 						'properties' => [
-							'type'         => [
+							'type'          => [
 								'const' => 'file-upload',
 							],
-							'student_help' => [
+							'student_help'  => [
 								'type'        => 'string',
 								'description' => 'Description for student explaining what needs to be uploaded',
 							],
-							'answer'       => [
+							'teacher_notes' => [
 								'type'        => 'string',
 								'description' => 'Teacher notes for grading',
 							],

--- a/includes/rest-api/class-sensei-rest-api-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-quiz-controller.php
@@ -140,7 +140,7 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 	 * @return array The array of the questions as defined by the schema.
 	 */
 	private function get_quiz_questions( WP_Post $quiz ) : array {
-		$questions = Sensei()->lesson->lesson_quiz_questions( $quiz->ID );
+		$questions = Sensei()->quiz->get_questions( $quiz->ID );
 
 		if ( empty( $questions ) ) {
 			return [];

--- a/includes/rest-api/class-sensei-rest-api-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-quiz-controller.php
@@ -384,7 +384,7 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 							'default'     => true,
 						],
 						'show_questions'        => [
-							'type'        => 'boolean',
+							'type'        => [ 'integer', 'null' ],
 							'description' => 'Number of questions to show randomly',
 							'default'     => null,
 						],
@@ -399,7 +399,7 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 					'type'        => 'array',
 					'description' => 'Questions in quiz',
 					'items'       => [
-						'oneOf' => [
+						'anyOf' => [
 							[
 								'$ref' => '#/definitions/question_category',
 							],
@@ -600,11 +600,6 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 								'type'        => 'string',
 								'description' => 'Text after the gap',
 							],
-						],
-						'required'   => [
-							'before',
-							'gap',
-							'after',
 						],
 					],
 				],

--- a/includes/rest-api/class-sensei-rest-api-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-quiz-controller.php
@@ -121,12 +121,12 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 		$post_meta = get_post_meta( $quiz->ID );
 		return [
 			'options'   => [
-				'pass_required'         => ! empty( $post_meta['_pass_required'] ) && 'on' === $post_meta['_pass_required'][0],
-				'quiz_passmark'         => empty( $post_meta['_quiz_passmark'] ) ? 0 : (int) $post_meta['_quiz_passmark'][0],
-				'auto_grade'            => ! empty( $post_meta['_quiz_grade_type'] ) && 'auto' === $post_meta['_quiz_grade_type'][0],
-				'allow_retakes'         => ! empty( $post_meta['_enable_quiz_reset'] ) && 'on' === $post_meta['_enable_quiz_reset'][0],
-				'show_questions'        => empty( $post_meta['_show_questions'] ) ? null : (int) $post_meta['_show_questions'][0],
-				'random_question_order' => ! empty( $post_meta['_random_question_order'] ) && 'yes' === $post_meta['_random_question_order'][0],
+				'pass_required'         => ! empty( $post_meta['_pass_required'][0] ) && 'on' === $post_meta['_pass_required'][0],
+				'quiz_passmark'         => empty( $post_meta['_quiz_passmark'][0] ) ? 0 : (int) $post_meta['_quiz_passmark'][0],
+				'auto_grade'            => ! empty( $post_meta['_quiz_grade_type'][0] ) && 'auto' === $post_meta['_quiz_grade_type'][0],
+				'allow_retakes'         => ! empty( $post_meta['_enable_quiz_reset'][0] ) && 'on' === $post_meta['_enable_quiz_reset'][0],
+				'show_questions'        => empty( $post_meta['_show_questions'][0] ) ? null : (int) $post_meta['_show_questions'][0],
+				'random_question_order' => ! empty( $post_meta['_random_question_order'][0] ) && 'yes' === $post_meta['_random_question_order'][0],
 			],
 			'questions' => $this->get_quiz_questions( $quiz ),
 		];

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-quiz-controller.php
@@ -44,7 +44,6 @@ class Sensei_REST_API_Quiz_Controller_Tests extends WP_Test_REST_TestCase {
 		$this->server   = $wp_rest_server;
 
 		do_action( 'rest_api_init' );
-		define( 'REST_REQUEST', true );
 
 		$this->factory = new Sensei_Factory();
 	}

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-quiz-controller.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Sensei REST API: Sensei_REST_API_Quiz_Controller_Tests tests
+ *
+ * @package sensei-lms
+ * @since 3.9.0
+ * @group rest-api
+ */
+
+/**
+ * Class Sensei_REST_API_Quiz_Controller tests.
+ */
+class Sensei_REST_API_Quiz_Controller_Tests extends WP_Test_REST_TestCase {
+	use Sensei_Test_Login_Helpers;
+	use Sensei_REST_API_Test_Helpers;
+
+	/**
+	 * A server instance that we use in tests to dispatch requests.
+	 *
+	 * @var WP_REST_Server $server
+	 */
+	protected $server;
+
+	/**
+	 * Sensei post factory.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Quiz route.
+	 */
+	const REST_ROUTE = '/sensei-internal/v1/quiz/';
+
+	/**
+	 * Test specific setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		do_action( 'rest_api_init' );
+
+		$this->factory = new Sensei_Factory();
+	}
+
+	/**
+	 * Tests that a simple request response matches the schema.
+	 */
+	public function testGetSimple() {
+		$this->login_as_teacher();
+
+		$course_result = $this->factory->get_course_with_lessons(
+			[
+				'module_count'   => 1,
+				'lesson_count'   => 1,
+				'question_count' => 5,
+			]
+		);
+
+		$quiz_id  = Sensei()->lesson->lesson_quizzes( $course_result['lesson_ids'][0] );
+		$request  = new WP_REST_Request( 'GET', self::REST_ROUTE . $quiz_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_status(), 200 );
+
+		$endpoint = new Sensei_REST_API_Quiz_Controller( '' );
+		$this->assertMeetsSchema( $endpoint->get_schema(), $response->get_data() );
+	}
+}

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-quiz-controller.php
@@ -270,7 +270,7 @@ class Sensei_REST_API_Quiz_Controller_Tests extends WP_Test_REST_TestCase {
 	/**
 	 * Tests multiple line question properties.
 	 */
-	public function testMultilineAnswers() {
+	public function testMultilineQuestion() {
 		$this->login_as_teacher();
 
 		$quiz_id = $this->factory->quiz->create();
@@ -291,7 +291,7 @@ class Sensei_REST_API_Quiz_Controller_Tests extends WP_Test_REST_TestCase {
 	/**
 	 * Tests file upload question properties.
 	 */
-	public function testFileUploadAnswers() {
+	public function testFileUploadQuestion() {
 		$this->login_as_teacher();
 
 		$quiz_id = $this->factory->quiz->create();
@@ -309,6 +309,54 @@ class Sensei_REST_API_Quiz_Controller_Tests extends WP_Test_REST_TestCase {
 		$this->assertEquals( 'file-upload', $response_data['questions'][0]['type'] );
 		$this->assertEquals( 'Teacher note', $response_data['questions'][0]['teacher_notes'] );
 		$this->assertEquals( 'User note', $response_data['questions'][0]['student_help'] );
+	}
+
+	/**
+	 * Tests question category properties.
+	 */
+	public function testQuestionCategory() {
+		$this->login_as_teacher();
+
+		$quiz_id = $this->factory->quiz->create();
+		$this->factory->multiple_question->create(
+			[
+				'quiz_id'    => $quiz_id,
+				'meta_input' => [
+					'number' => 3,
+				],
+			]
+		);
+		$response_data = $this->send_and_validate( $quiz_id );
+
+		$this->assertEquals( 'question-category', $response_data['questions'][0]['type'] );
+		$this->assertEquals( 3, $response_data['questions'][0]['questions'] );
+	}
+
+	/**
+	 * Tests single line question properties.
+	 */
+	public function testQuestionCommonProperties() {
+		$this->login_as_teacher();
+
+		$quiz_id     = $this->factory->quiz->create();
+		$question_id = $this->factory->question->create(
+			[
+				'quiz_id'              => $quiz_id,
+				'question_type'        => 'single-line',
+				'question'             => 'Will it blend?',
+				'question_description' => 'That is the question.',
+				'question_grade'       => 10,
+			]
+		);
+
+		add_post_meta( $question_id, '_quiz_id', $quiz_id, false );
+
+		$response_data = $this->send_and_validate( $quiz_id );
+
+		$this->assertTrue( $response_data['questions'][0]['shared'] );
+		$this->assertEquals( 'Will it blend?', $response_data['questions'][0]['title'] );
+		$this->assertEquals( 'That is the question.', $response_data['questions'][0]['description'] );
+		$this->assertEquals( 10, $response_data['questions'][0]['grade'] );
 	}
 
 	/**

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-quiz-controller.php
@@ -138,12 +138,7 @@ class Sensei_REST_API_Quiz_Controller_Tests extends WP_Test_REST_TestCase {
 		];
 		$quiz_id   = $this->factory->quiz->create( $quiz_args );
 
-		$request  = new WP_REST_Request( 'GET', self::REST_ROUTE . $quiz_id );
-		$response = $this->server->dispatch( $request );
-
-		$response_data = $response->get_data();
-		$endpoint      = new Sensei_REST_API_Quiz_Controller( '' );
-		$this->assertMeetsSchema( $endpoint->get_schema(), $response_data );
+		$response_data = $this->send_and_validate( $quiz_id );
 
 		$this->assertTrue( $response_data['options']['pass_required'] );
 		$this->assertTrue( $response_data['options']['auto_grade'] );
@@ -164,12 +159,7 @@ class Sensei_REST_API_Quiz_Controller_Tests extends WP_Test_REST_TestCase {
 		];
 		$another_quiz_id   = $this->factory->quiz->create( $another_quiz_args );
 
-		$request  = new WP_REST_Request( 'GET', self::REST_ROUTE . $another_quiz_id );
-		$response = $this->server->dispatch( $request );
-
-		$response_data = $response->get_data();
-		$endpoint      = new Sensei_REST_API_Quiz_Controller( '' );
-		$this->assertMeetsSchema( $endpoint->get_schema(), $response_data );
+		$response_data = $this->send_and_validate( $another_quiz_id );
 
 		$this->assertFalse( $response_data['options']['pass_required'] );
 		$this->assertFalse( $response_data['options']['auto_grade'] );
@@ -177,5 +167,165 @@ class Sensei_REST_API_Quiz_Controller_Tests extends WP_Test_REST_TestCase {
 		$this->assertFalse( $response_data['options']['random_question_order'] );
 		$this->assertEquals( 0, $response_data['options']['quiz_passmark'] );
 		$this->assertEquals( 3, $response_data['options']['show_questions'] );
+	}
+
+	/**
+	 * Tests multiple choice question properties.
+	 */
+	public function testMultipleChoiceQuestion() {
+		$this->login_as_teacher();
+
+		$quiz_id = $this->factory->quiz->create();
+		$this->factory->question->create(
+			[
+				'quiz_id'                => $quiz_id,
+				'question_type'          => 'multiple-choice',
+				'question_right_answers' => [ 'Right answer' ],
+				'question_wrong_answers' => [ 'Wrong,comma', 'Wrong 1' ],
+				'random_order'           => 'no',
+				'answer_order'           => 'ac70b9a3f24b5b657826b567057169a2,b13d55d1ff11d676253fa5e4b0517bd7,89dc5589bfebac1468e8823afd5a4861',
+				'answer_feedback'        => 'Some feedback',
+			]
+		);
+		$response_data = $this->send_and_validate( $quiz_id );
+
+		$this->assertFalse( $response_data['questions'][0]['random_order'] );
+		$this->assertEquals( 'Some feedback', $response_data['questions'][0]['answer_feedback'] );
+		$this->assertEquals( 'multiple-choice', $response_data['questions'][0]['type'] );
+		$this->assertEquals( 'Wrong 1', $response_data['questions'][0]['options'][0]['label'] );
+		$this->assertFalse( $response_data['questions'][0]['options'][0]['correct'] );
+		$this->assertEquals( 'Right answer', $response_data['questions'][0]['options'][2]['label'] );
+		$this->assertTrue( $response_data['questions'][0]['options'][2]['correct'] );
+	}
+
+	/**
+	 * Tests true/false question properties.
+	 */
+	public function testBooleanQuestion() {
+		$this->login_as_teacher();
+
+		$quiz_id = $this->factory->quiz->create();
+		$this->factory->question->create(
+			[
+				'quiz_id'                       => $quiz_id,
+				'question_type'                 => 'boolean',
+				'answer_feedback'               => 'Some feedback',
+				'question_right_answer_boolean' => 'false',
+			]
+		);
+
+		$response_data = $this->send_and_validate( $quiz_id );
+
+		$this->assertFalse( $response_data['questions'][0]['answer'] );
+		$this->assertEquals( 'Some feedback', $response_data['questions'][0]['answer_feedback'] );
+		$this->assertEquals( 'boolean', $response_data['questions'][0]['type'] );
+	}
+
+	/**
+	 * Tests gap fill question properties.
+	 */
+	public function testGapFillQuestion() {
+		$this->login_as_teacher();
+
+		$quiz_id = $this->factory->quiz->create();
+		$this->factory->question->create(
+			[
+				'quiz_id'                                => $quiz_id,
+				'question_type'                          => 'gap-fill',
+				'add_question_right_answer_gapfill_pre'  => 'BEFORE',
+				'add_question_right_answer_gapfill_gap'  => 'THE GAP|GAP',
+				'add_question_right_answer_gapfill_post' => 'AFTER',
+			]
+		);
+
+		$response_data = $this->send_and_validate( $quiz_id );
+
+		$this->assertEquals( 'gap-fill', $response_data['questions'][0]['type'] );
+		$this->assertEquals( 'BEFORE', $response_data['questions'][0]['before'] );
+		$this->assertEquals( 'THE GAP', $response_data['questions'][0]['gap'][0] );
+		$this->assertEquals( 'GAP', $response_data['questions'][0]['gap'][1] );
+		$this->assertEquals( 'AFTER', $response_data['questions'][0]['after'] );
+	}
+
+	/**
+	 * Tests single line question properties.
+	 */
+	public function testSingleLineQuestion() {
+		$this->login_as_teacher();
+
+		$quiz_id = $this->factory->quiz->create();
+		$this->factory->question->create(
+			[
+				'quiz_id'                              => $quiz_id,
+				'question_type'                        => 'single-line',
+				'add_question_right_answer_singleline' => 'NOTES',
+			]
+		);
+
+		$response_data = $this->send_and_validate( $quiz_id );
+
+		$this->assertEquals( 'single-line', $response_data['questions'][0]['type'] );
+		$this->assertEquals( 'NOTES', $response_data['questions'][0]['teacher_notes'] );
+	}
+
+	/**
+	 * Tests multiple line question properties.
+	 */
+	public function testMultilineAnswers() {
+		$this->login_as_teacher();
+
+		$quiz_id = $this->factory->quiz->create();
+		$this->factory->question->create(
+			[
+				'quiz_id'                             => $quiz_id,
+				'question_type'                       => 'multi-line',
+				'add_question_right_answer_multiline' => 'NOTES',
+			]
+		);
+
+		$response_data = $this->send_and_validate( $quiz_id );
+
+		$this->assertEquals( 'multi-line', $response_data['questions'][0]['type'] );
+		$this->assertEquals( 'NOTES', $response_data['questions'][0]['teacher_notes'] );
+	}
+
+	/**
+	 * Tests file upload question properties.
+	 */
+	public function testFileUploadAnswers() {
+		$this->login_as_teacher();
+
+		$quiz_id = $this->factory->quiz->create();
+		$this->factory->question->create(
+			[
+				'quiz_id'                              => $quiz_id,
+				'question_type'                        => 'file-upload',
+				'add_question_right_answer_fileupload' => 'Teacher note',
+				'add_question_wrong_answer_fileupload' => 'User note',
+			]
+		);
+
+		$response_data = $this->send_and_validate( $quiz_id );
+
+		$this->assertEquals( 'file-upload', $response_data['questions'][0]['type'] );
+		$this->assertEquals( 'Teacher note', $response_data['questions'][0]['teacher_notes'] );
+		$this->assertEquals( 'User note', $response_data['questions'][0]['student_help'] );
+	}
+
+	/**
+	 * Helper method to send and validate a GET request.
+	 *
+	 * @param int $quiz_id The quiz id.
+	 *
+	 * @return array Response data.
+	 */
+	private function send_and_validate( int $quiz_id ) : array {
+		$request  = new WP_REST_Request( 'GET', self::REST_ROUTE . $quiz_id );
+		$response = $this->server->dispatch( $request );
+
+		$endpoint = new Sensei_REST_API_Quiz_Controller( '' );
+		$this->assertMeetsSchema( $endpoint->get_schema(), $response->get_data() );
+
+		return $response->get_data();
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Implements the REST API endpoint fetching according to the schema introduced in #3890.
* There were minor updates to the schema, mainly minor fixes.
* Question related code belong to a question-related class but I postponed doing it until we define the question endpoint. The method separation was done with that refactor in mind.

### Testing instructions

* Try the endpoint '/sensei-internal/v1/quiz/<quiz_id>' for various quizzes and observe that the returned data are correct.
* Observe that one teacher cannot access the quizzes created by another and that an admin can access everything.