### PR TITLE
Do not initialize blocks when they don't exist

### DIFF
--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -59,6 +59,10 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 	 * Initializes the blocks.
 	 */
 	public function initialize_blocks() {
+		if ( ! Sensei()->lesson->has_sensei_blocks() ) {
+			return;
+		}
+
 		new Sensei_Lesson_Actions_Block();
 		new Sensei_Next_Lesson_Block();
 		new Sensei_Complete_Lesson_Block();
@@ -66,9 +70,7 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		new Sensei_View_Quiz_Block();
 		new Sensei_Block_Contact_Teacher();
 
-		if ( Sensei()->lesson->has_sensei_blocks() ) {
-			$this->remove_block_related_content();
-		}
+		$this->remove_block_related_content();
 
 		$post_type_object = get_post_type_object( 'lesson' );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fixes an issue where a duplicate notice is displayed in non block-based lessons.
<img width="512" alt="twosuccessnoticespm" src="https://user-images.githubusercontent.com/53191348/107009532-dbcb6b00-679d-11eb-816e-98f2bfff37af.png">

### Testing instructions

* Try sending a message to the teacher from a lesson which has no blocks and observe that no duplicate notices are displayed.
* Try sending a message from a lesson with the Contact teacher block and observe that no duplicate notices are displayed.