### PR TITLE
Lesson actions styles fixes

### DIFF
--- a/assets/blocks/button/button-edit.js
+++ b/assets/blocks/button/button-edit.js
@@ -8,7 +8,11 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { getButtonProps, getButtonWrapperProps } from './button-props';
+import {
+	getButtonProps,
+	getButtonWrapperProps,
+	isLinkStyle,
+} from './button-props';
 import ButtonSettings from './button-settings';
 
 /**
@@ -26,6 +30,12 @@ const ButtonEdit = ( props ) => {
 	const isReadonly = undefined !== props.text;
 	const buttonProps = getButtonProps( { ...props, colors } );
 
+	let buttonTagName = tagName;
+
+	if ( ! tagName ) {
+		buttonTagName = isLinkStyle( props ) ? 'a' : 'button';
+	}
+
 	return (
 		<div { ...getButtonWrapperProps( props ) }>
 			{ isReadonly ? (
@@ -39,7 +49,7 @@ const ButtonEdit = ( props ) => {
 					onChange={ ( value ) => setAttributes( { text: value } ) }
 					withoutInteractiveFormatting
 					{ ...buttonProps }
-					tagName={ tagName }
+					tagName={ buttonTagName }
 					identifier="text"
 				/>
 			) }

--- a/assets/blocks/button/button-save.js
+++ b/assets/blocks/button/button-save.js
@@ -40,6 +40,7 @@ const ButtonSave = ( { attributes, className, tagName, blockName } ) => {
 		return (
 			<div
 				className={ classnames(
+					className,
 					'sensei-buttons-container__button-block',
 					getBlockDefaultClassName( blockName ) + '__wrapper',
 					{

--- a/assets/blocks/button/button-save.js
+++ b/assets/blocks/button/button-save.js
@@ -12,7 +12,11 @@ import { getBlockDefaultClassName } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
-import { getButtonProps, getButtonWrapperProps } from './button-props';
+import {
+	getButtonProps,
+	getButtonWrapperProps,
+	isLinkStyle,
+} from './button-props';
 
 /**
  * Save function for a Button block.
@@ -26,11 +30,17 @@ import { getButtonProps, getButtonWrapperProps } from './button-props';
 const ButtonSave = ( { attributes, className, tagName, blockName } ) => {
 	const { text, inContainer, align } = attributes;
 
+	let buttonTagName = tagName;
+
+	if ( ! tagName ) {
+		buttonTagName = isLinkStyle( { attributes } ) ? 'a' : 'button';
+	}
+
 	const content = (
 		<div { ...getButtonWrapperProps( { className, attributes } ) }>
 			<RichText.Content
 				{ ...getButtonProps( { attributes } ) }
-				tagName={ tagName }
+				tagName={ buttonTagName }
 				value={ text }
 			/>
 		</div>

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -52,7 +52,6 @@ export const createButtonBlockType = ( {
 	...options
 } ) => {
 	options = {
-		tagName: 'a',
 		alignmentOptions: {
 			controls: [ 'left', 'center', 'right', 'full' ],
 			default: 'left',
@@ -85,7 +84,7 @@ export const createButtonBlockType = ( {
 				text: {
 					type: 'string',
 					source: 'html',
-					selector: options.tagName,
+					selector: 'a,button',
 				},
 				align: {
 					type: 'string',

--- a/assets/blocks/lesson-actions/complete-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/complete-lesson-block/index.js
@@ -6,13 +6,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { createButtonBlockType } from '../../button';
+import { BlockStyles, createButtonBlockType } from '../../button';
 
 /**
  * Complete lesson button block.
  */
 export default createButtonBlockType( {
-	tagName: 'button',
 	settings: {
 		name: 'sensei-lms/button-complete-lesson',
 		parent: [ 'sensei-lms/lesson-actions' ],
@@ -35,5 +34,10 @@ export default createButtonBlockType( {
 				default: [ 'sensei-stop-double-submission' ],
 			},
 		},
+		styles: [
+			{ ...BlockStyles.Fill, isDefault: true },
+			BlockStyles.Outline,
+			BlockStyles.Link,
+		],
 	},
 } );

--- a/assets/blocks/lesson-actions/next-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/next-lesson-block/index.js
@@ -6,13 +6,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { createButtonBlockType } from '../../button';
+import { BlockStyles, createButtonBlockType } from '../../button';
 
 /**
  * Next lesson button block.
  */
 export default createButtonBlockType( {
-	tagName: 'button',
 	settings: {
 		name: 'sensei-lms/button-next-lesson',
 		title: __( 'Next Lesson', 'sensei-lms' ),
@@ -32,5 +31,10 @@ export default createButtonBlockType( {
 				default: __( 'Next Lesson', 'sensei-lms' ),
 			},
 		},
+		styles: [
+			{ ...BlockStyles.Fill, isDefault: true },
+			BlockStyles.Outline,
+			BlockStyles.Link,
+		],
 	},
 } );

--- a/assets/blocks/lesson-actions/reset-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/reset-lesson-block/index.js
@@ -12,7 +12,6 @@ import { BlockStyles, createButtonBlockType } from '../../button';
  * Reset lesson button block.
  */
 export default createButtonBlockType( {
-	tagName: 'button',
 	settings: {
 		name: 'sensei-lms/button-reset-lesson',
 		title: __( 'Reset Lesson', 'sensei-lms' ),

--- a/assets/blocks/lesson-actions/view-quiz-block/index.js
+++ b/assets/blocks/lesson-actions/view-quiz-block/index.js
@@ -6,13 +6,12 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { createButtonBlockType } from '../../button';
+import { BlockStyles, createButtonBlockType } from '../../button';
 
 /**
  * View quiz button block.
  */
 export default createButtonBlockType( {
-	tagName: 'button',
 	settings: {
 		name: 'sensei-lms/button-view-quiz',
 		title: __( 'View Quiz', 'sensei-lms' ),
@@ -28,5 +27,10 @@ export default createButtonBlockType( {
 				default: __( 'View Quiz', 'sensei-lms' ),
 			},
 		},
+		styles: [
+			{ ...BlockStyles.Fill, isDefault: true },
+			BlockStyles.Outline,
+			BlockStyles.Link,
+		],
 	},
 } );

--- a/includes/blocks/class-sensei-complete-lesson-block.php
+++ b/includes/blocks/class-sensei-complete-lesson-block.php
@@ -52,7 +52,7 @@ class Sensei_Complete_Lesson_Block {
 
 		if ( false === Sensei()->lesson->lesson_has_quiz_with_questions_and_pass_required( $lesson->ID ) ) {
 
-			return $this->render_with_form( $content );
+			return $this->render_with_form( $attributes, $content );
 		}
 
 		return '';
@@ -61,14 +61,26 @@ class Sensei_Complete_Lesson_Block {
 	/**
 	 * Helper method to wrap the button content into a form.
 	 *
+	 * @param array  $attributes The block attributes.
 	 * @param string $content The block content.
 	 *
 	 * @return string The HTML to render.
 	 */
-	private function render_with_form( string $content ) : string {
+	private function render_with_form( array $attributes, string $content ) : string {
 		wp_enqueue_script( 'sensei-stop-double-submission' );
 		$nonce     = wp_nonce_field( 'woothemes_sensei_complete_lesson_noonce', 'woothemes_sensei_complete_lesson_noonce', false, false );
 		$permalink = esc_url( get_permalink() );
+
+		if ( ! empty( $attributes['className'] ) && false !== strpos( $attributes['className'], 'is-style-link' ) ) {
+			wp_enqueue_script( 'sensei-link-form-submit' );
+
+			$content = preg_replace(
+				'/<a /',
+				'<a href="javascript:void(0)" onclick="this.closest(\'form\').submit()"',
+				$content,
+				1
+			);
+		}
 
 		return '
 		<form class="lesson_button_form" method="POST" action="' . $permalink . '">

--- a/includes/blocks/class-sensei-next-lesson-block.php
+++ b/includes/blocks/class-sensei-next-lesson-block.php
@@ -50,6 +50,15 @@ class Sensei_Next_Lesson_Block {
 			return '';
 		}
 
+		if ( ! empty( $attributes['className'] ) && false !== strpos( $attributes['className'], 'is-style-link' ) ) {
+			return preg_replace(
+				'/<a /',
+				'<a href="' . esc_url( $urls['next']['url'] ) . '" ',
+				$content,
+				1
+			);
+		}
+
 		return '<a href="' . esc_url( $urls['next']['url'] ) . '" >' . $content . '</a>';
 	}
 }

--- a/includes/blocks/class-sensei-reset-lesson-block.php
+++ b/includes/blocks/class-sensei-reset-lesson-block.php
@@ -56,20 +56,31 @@ class Sensei_Reset_Lesson_Block {
 			return '';
 		}
 
-		return $this->render_with_form( $content );
+		return $this->render_with_form( $attributes, $content );
 	}
 
 	/**
 	 * Helper method to wrap the button content into a form.
 	 *
+	 * @param array  $attributes The block attributes.
 	 * @param string $content The block content.
 	 *
 	 * @return string The HTML to render.
 	 */
-	private function render_with_form( string $content ) : string {
+	private function render_with_form( array $attributes, string $content ) : string {
 		wp_enqueue_script( 'sensei-stop-double-submission' );
 		$nonce     = wp_nonce_field( 'woothemes_sensei_complete_lesson_noonce', 'woothemes_sensei_complete_lesson_noonce', false, false );
 		$permalink = esc_url( get_permalink() );
+
+		if ( ! empty( $attributes['className'] ) && false !== strpos( $attributes['className'], 'is-style-link' ) ) {
+
+			$content = preg_replace(
+				'/<a /',
+				'<a href="javascript:void(0)" onclick="this.closest(\'form\').submit()"',
+				$content,
+				1
+			);
+		}
 
 		return '
 		<form class="lesson_button_form" method="POST" action="' . $permalink . '">

--- a/includes/blocks/class-sensei-view-quiz-block.php
+++ b/includes/blocks/class-sensei-view-quiz-block.php
@@ -50,6 +50,15 @@ class Sensei_View_Quiz_Block {
 			return '';
 		}
 
+		if ( ! empty( $attributes['className'] ) && false !== strpos( $attributes['className'], 'is-style-link' ) ) {
+			return preg_replace(
+				'/<a /',
+				'<a href="' . esc_url( get_permalink( $quiz_id ) ) . '" ',
+				$content,
+				1
+			);
+		}
+
 		return '<a href="' . esc_url( get_permalink( $quiz_id ) ) . '" >' . $content . '</a>';
 	}
 }


### PR DESCRIPTION
### Overview

This PR fixes two issues in Lesson Actions block. The first issue was that when for any Lesson Action a style was selected and the button was saved, the next time the page would get reloaded the validation would fail. 
<img width="740" alt="screen-shot-2021-02-03-at-14 24 38" src="https://user-images.githubusercontent.com/53191348/107060623-dd1d8780-67df-11eb-9359-a0e4227d65a9.png">

The second issue was that the 'Link style' option for 'Reset Lesson' button, didn't display correctly. Also the other buttons did not hand a 'Link style' option at all.
<img width="512" alt="screen-shot-2021-02-03-at-14 28 13" src="https://user-images.githubusercontent.com/53191348/107060754-04745480-67e0-11eb-9e29-6436adf4a84f.png">

### Changes proposed in this Pull Request

First issue:
* For a block to be able to load the saved style option, the class has to be saved in the outer block element. For this reason the classname was added to the container of the buttons.

Second issue:
* I updated the buttons to be `<a>` when there is no tagName option explicitly defined and they have the 'Link style' option selected. Hopefully, this will change the appearence of the buttons to be consistent with the rest of the links, as themes usually apply styling to `<a>` elements.
* Old buttons define the tagname explicitly so it is not expected for existing blocks to fail validation.
* Currently when the user selects the 'Link style' option, the link is not centered. I couldn't find a way of centering it without breaking alignment buttons. I would expect that the user would select the same style option for all buttons which in that case they are aligned.

### Testing instructions

* In the Lesson Actions block, try selecting a style for a button, save and refresh. Observe that the block passes validation.
* Try the different style options and observe that the buttons behave as they should.