### PR TITLE
Fix block translations

### DIFF
--- a/includes/admin/class-sensei-exit-survey.php
+++ b/includes/admin/class-sensei-exit-survey.php
@@ -36,7 +36,7 @@ class Sensei_Exit_Survey {
 	public function enqueue_admin_assets() {
 		$screen = get_current_screen();
 		if ( in_array( $screen->id, [ 'plugins', 'plugins-network' ], true ) ) {
-			Sensei()->assets->enqueue( 'sensei-admin-exit-survey', 'admin/exit-survey/index.js', [ 'wp-i18n' ], true );
+			Sensei()->assets->enqueue( 'sensei-admin-exit-survey', 'admin/exit-survey/index.js', [], true );
 			Sensei()->assets->enqueue( 'sensei-admin-exit-survey', 'admin/exit-survey/exit-survey.css', [], 'screen' );
 
 			wp_localize_script(

--- a/includes/admin/class-sensei-exit-survey.php
+++ b/includes/admin/class-sensei-exit-survey.php
@@ -36,9 +36,8 @@ class Sensei_Exit_Survey {
 	public function enqueue_admin_assets() {
 		$screen = get_current_screen();
 		if ( in_array( $screen->id, [ 'plugins', 'plugins-network' ], true ) ) {
-			Sensei()->assets->enqueue( 'sensei-admin-exit-survey', 'admin/exit-survey/index.js', [], true );
+			Sensei()->assets->enqueue( 'sensei-admin-exit-survey', 'admin/exit-survey/index.js', [ 'wp-i18n' ], true );
 			Sensei()->assets->enqueue( 'sensei-admin-exit-survey', 'admin/exit-survey/exit-survey.css', [], 'screen' );
-			wp_set_script_translations( 'sensei-admin-exit-survey', 'sensei-lms' );
 
 			wp_localize_script(
 				'sensei-admin-exit-survey',

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -131,7 +131,7 @@ class Sensei_Setup_Wizard {
 	public function enqueue_scripts() {
 		$handle = 'sensei-setup-wizard';
 		Sensei()->assets->wp_compat();
-		Sensei()->assets->enqueue( $handle, 'setup-wizard/index.js', [ 'sensei-event-logging', 'wp-i18n' ], true );
+		Sensei()->assets->enqueue( $handle, 'setup-wizard/index.js', [ 'sensei-event-logging' ], true );
 		Sensei()->assets->preload_data( [ '/sensei-internal/v1/setup-wizard' ] );
 
 		wp_localize_script(

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -132,7 +132,6 @@ class Sensei_Setup_Wizard {
 		$handle = 'sensei-setup-wizard';
 		Sensei()->assets->wp_compat();
 		Sensei()->assets->enqueue( $handle, 'setup-wizard/index.js', [ 'sensei-event-logging', 'wp-i18n' ], true );
-		$this->setup_wizard_set_script_translations();
 		Sensei()->assets->preload_data( [ '/sensei-internal/v1/setup-wizard' ] );
 
 		wp_localize_script(
@@ -155,9 +154,10 @@ class Sensei_Setup_Wizard {
 	 * Set script translations.
 	 *
 	 * @access private
+	 * @deprecated 3.8.0
 	 */
 	public function setup_wizard_set_script_translations() {
-		wp_set_script_translations( 'sensei-setup-wizard', 'sensei-lms' );
+		_deprecated_function( __METHOD__, '3.8.0' );
 	}
 
 	/**

--- a/includes/class-sensei-assets.php
+++ b/includes/class-sensei-assets.php
@@ -111,6 +111,10 @@ class Sensei_Assets {
 	 */
 	private function call_wp( $action, $handle, $config ) {
 		call_user_func( $action . '_' . $config['type'], $handle, $config['url'], $config['dependencies'], $config['version'], $config['args'] );
+
+		if ( 'script' === $config['type'] && in_array( 'wp-i18n', $config['dependencies'], true ) ) {
+			wp_set_script_translations( $handle, 'sensei-lms' );
+		}
 	}
 
 	/**

--- a/includes/data-port/class-sensei-export.php
+++ b/includes/data-port/class-sensei-export.php
@@ -36,7 +36,7 @@ class Sensei_Export {
 			add_action(
 				'admin_print_scripts',
 				function() {
-					Sensei()->assets->enqueue( 'sensei-export', 'data-port/export.js', [ 'wp-i18n' ], true );
+					Sensei()->assets->enqueue( 'sensei-export', 'data-port/export.js', [], true );
 					Sensei()->assets->preload_data( [ '/sensei-internal/v1/export/active' ] );
 				}
 			);

--- a/includes/data-port/class-sensei-export.php
+++ b/includes/data-port/class-sensei-export.php
@@ -36,8 +36,7 @@ class Sensei_Export {
 			add_action(
 				'admin_print_scripts',
 				function() {
-					Sensei()->assets->enqueue( 'sensei-export', 'data-port/export.js', [], true );
-					wp_set_script_translations( 'sensei-export', 'sensei-lms' );
+					Sensei()->assets->enqueue( 'sensei-export', 'data-port/export.js', [ 'wp-i18n' ], true );
 					Sensei()->assets->preload_data( [ '/sensei-internal/v1/export/active' ] );
 				}
 			);

--- a/includes/data-port/class-sensei-import.php
+++ b/includes/data-port/class-sensei-import.php
@@ -37,8 +37,7 @@ class Sensei_Import {
 				'admin_print_scripts',
 				function() {
 					Sensei()->assets->wp_compat();
-					Sensei()->assets->enqueue( 'sensei-import', 'data-port/import.js', [], true );
-					wp_set_script_translations( 'sensei-import', 'sensei-lms' );
+					Sensei()->assets->enqueue( 'sensei-import', 'data-port/import.js', [ 'wp-i18n' ], true );
 					Sensei()->assets->preload_data( [ '/sensei-internal/v1/import/active' ] );
 				}
 			);

--- a/includes/data-port/class-sensei-import.php
+++ b/includes/data-port/class-sensei-import.php
@@ -37,7 +37,7 @@ class Sensei_Import {
 				'admin_print_scripts',
 				function() {
 					Sensei()->assets->wp_compat();
-					Sensei()->assets->enqueue( 'sensei-import', 'data-port/import.js', [ 'wp-i18n' ], true );
+					Sensei()->assets->enqueue( 'sensei-import', 'data-port/import.js', [], true );
 					Sensei()->assets->preload_data( [ '/sensei-internal/v1/import/active' ] );
 				}
 			);


### PR DESCRIPTION
This would be nice to get into 3.8.0, but if not we can bump it to a point release or 3.9.0.

### Changes proposed in this Pull Request

* Fixes issue with translations not getting loaded for blocks.
* Sniffs for dependency of `wp-i18n` and registers our text domain. According to [the docs](https://developer.wordpress.org/block-editor/developers/internationalization/#how-to-use-i18n-in-javascript), this should be an asset dependency whenever we use it in our scripts.

### Testing instructions

* Switch to Spanish.
* Extract [sensei-lms-es_ES.zip](https://github.com/Automattic/sensei/files/5944653/sensei-lms-es_ES.zip) to `wp-content/languages/plugins`. This is a current translation of Spanish that has been updated with current POT file references (and their JSON files).
* Go to create new course. Make sure the add new lesson/module placeholder text is in Spanish. I don't think the buttons were translated yet in a released POT, which is why they'll show up in English.
* Ensure the setup wizard, importer, and exporter remain translated.

<img width="635" alt="Screen Shot 2021-02-08 at 3 31 45 pm" src="https://user-images.githubusercontent.com/68693/107241392-db8fd180-6a22-11eb-9c9e-b846c7053200.png">

### Deprecations
- `Sensei_Setup_Wizard:: setup_wizard_set_script_translations `: This was `@access private`.
