### PR TITLE
Question blocks: Add single line, multi line answer boxes

### DIFF
--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -19,38 +19,41 @@ import SingleLineAnswer from './single-line';
 const questionTypes = {
 	multichoice: {
 		title: __( 'Multiple Choice', 'sensei-lms' ),
-		description: __(
-			'Select one or more answers from a list of choices.',
-			'sensei-lms'
-		),
+		description: __( 'Select from a list of options.', 'sensei-lms' ),
 		edit: () => <div> [Multiple Choice] </div>,
 	},
 	truefalse: {
 		title: __( 'True / False', 'sensei-lms' ),
-		description: __( 'True or false question.', 'sensei-lms' ),
+		description: __(
+			'Select whether a statement is true or false.',
+			'sensei-lms'
+		),
 		edit: () => <div> [True/False] </div>,
 	},
 	gap: {
 		title: __( 'Gap Fill', 'sensei-lms' ),
-		description: __(
-			'Fill in the missing part of a sentence.',
-			'sensei-lms'
-		),
+		description: __( 'Fill in the blank.', 'sensei-lms' ),
 		edit: () => <div> [Gap Fill] </div>,
 	},
 	'single-line': {
 		title: __( 'Single-line', 'sensei-lms' ),
-		description: __( 'Require a written answer.', 'sensei-lms' ),
+		description: __(
+			'Short answer to an open-ended question.',
+			'sensei-lms'
+		),
 		edit: SingleLineAnswer,
 	},
 	'multi-line': {
 		title: __( 'Multi-line', 'sensei-lms' ),
-		description: __( 'Require a written answer.', 'sensei-lms' ),
+		description: __(
+			'Long answer to an open-ended question.',
+			'sensei-lms'
+		),
 		edit: MultiLineAnswer,
 	},
 	'file-upload': {
 		title: __( 'File Upload', 'sensei-lms' ),
-		description: __( 'Require a file to be uploaded.', 'sensei-lms' ),
+		description: __( 'Upload a file or document.', 'sensei-lms' ),
 		edit: () => <div> [File Upload] </div>,
 	},
 };

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -1,5 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
+import MultiLineAnswer from './multi-line';
+import SingleLineAnswer from './single-line';
 
 /**
  * @typedef QuestionType
@@ -36,12 +38,17 @@ const questionTypes = {
 		),
 		edit: () => <div> [Gap Fill] </div>,
 	},
-	open: {
-		title: __( 'Open-Ended', 'sensei-lms' ),
+	'single-line': {
+		title: __( 'Single-line', 'sensei-lms' ),
 		description: __( 'Require a written answer.', 'sensei-lms' ),
-		edit: () => <div> [Open-Ended] </div>,
+		edit: SingleLineAnswer,
 	},
-	file: {
+	'multi-line': {
+		title: __( 'Multi-line', 'sensei-lms' ),
+		description: __( 'Require a written answer.', 'sensei-lms' ),
+		edit: MultiLineAnswer,
+	},
+	'file-upload': {
 		title: __( 'File Upload', 'sensei-lms' ),
 		description: __( 'Require a file to be uploaded.', 'sensei-lms' ),
 		edit: () => <div> [File Upload] </div>,

--- a/assets/blocks/quiz/answer-blocks/multi-line.js
+++ b/assets/blocks/quiz/answer-blocks/multi-line.js
@@ -9,7 +9,7 @@ const MultiLineAnswer = () => {
 			<small className="sensei-lms-question-block__input-label">
 				{ __( 'Answer:', 'sensei-lms' ) }
 			</small>
-			<div className="sensei-lms-question-block__text-input-placeholder multi-line rich-text" />
+			<div className="sensei-lms-question-block__text-input-placeholder multi-line" />
 		</div>
 	);
 };

--- a/assets/blocks/quiz/answer-blocks/multi-line.js
+++ b/assets/blocks/quiz/answer-blocks/multi-line.js
@@ -1,0 +1,17 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Question block multi-line answer component.
+ */
+const MultiLineAnswer = () => {
+	return (
+		<div className="sensei-lms-question-block__answer sensei-lms-question-block__answer--multi-line">
+			<small className="sensei-lms-question-block__input-label">
+				{ __( 'Answer:', 'sensei-lms' ) }
+			</small>
+			<div className="sensei-lms-question-block__text-input-placeholder multi-line rich-text" />
+		</div>
+	);
+};
+
+export default MultiLineAnswer;

--- a/assets/blocks/quiz/answer-blocks/single-line.js
+++ b/assets/blocks/quiz/answer-blocks/single-line.js
@@ -1,0 +1,17 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Question block single-line answer component.
+ */
+const SingleLineAnswer = () => {
+	return (
+		<div className="sensei-lms-question-block__answer sensei-lms-question-block__answer--single-line">
+			<small className="sensei-lms-question-block__input-label">
+				{ __( 'Answer:', 'sensei-lms' ) }
+			</small>
+			<div className="sensei-lms-question-block__text-input-placeholder" />
+		</div>
+	);
+};
+
+export default SingleLineAnswer;

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -47,22 +47,7 @@ $block: '.sensei-lms-question-block';
 		min-height: 52px;
 
 		&.multi-line {
-			min-height: 250px;
-		}
-		&.rich-text {
-			position: relative;
-			&:before {
-				content: '';
-				position: absolute;
-				left: 0;
-
-				right: 0;
-				top: 40px;
-				margin: 2px;
-				height: 2px;
-				border-radius: 1px;
-				background: $answer-box-color;
-			}
+			min-height: 200px;
 		}
 	}
 

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -5,6 +5,40 @@ $block: '.sensei-lms-question-block';
 	$answer-box-color: #333;
 	$answer-box-color: #333;
 
+	.editor-styles-wrapper .wp-block &__title, .editor-styles-wrapper .wp-block &__index {
+		font-size: 24px;
+		margin-top: 0;
+		margin-bottom: 0;
+		line-height: 1.25;
+	}
+
+	&__index {
+		position: absolute;
+		right: 100%;
+		text-align: right;
+		top: 0;
+		font-weight: bold;
+
+		#{$block}.is-draft & {
+			opacity: .62;
+		}
+
+		.editor-styles-wrapper .wp-block & {
+			margin-right: 10px;
+		}
+	}
+
+	&__type-selector {
+
+		&__popover .sensei-toolbar-dropdown__option {
+			padding: 12px;
+		}
+
+		&__option__description {
+			color: #757575;
+			font-size: 90%;
+		}
+	}
 
 	&__text-input-placeholder {
 		border: 2px solid $answer-box-color;

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -1,0 +1,39 @@
+
+$block: '.sensei-lms-question-block';
+.sensei-lms-question-block {
+
+	$answer-box-color: #333;
+	$answer-box-color: #333;
+
+
+	&__text-input-placeholder {
+		border: 2px solid $answer-box-color;
+		border-radius: 2px;
+		padding: 5px;
+		min-height: 52px;
+
+		&.multi-line {
+			min-height: 250px;
+		}
+		&.rich-text {
+			position: relative;
+			&:before {
+				content: '';
+				position: absolute;
+				left: 0;
+
+				right: 0;
+				top: 40px;
+				margin: 2px;
+				height: 2px;
+				border-radius: 1px;
+				background: $answer-box-color;
+			}
+		}
+	}
+
+	&__input-label {
+		color: #444;
+	}
+
+}

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -37,6 +37,7 @@ $block: '.sensei-lms-question-block';
 		&__option__description {
 			color: #757575;
 			font-size: 90%;
+			margin-top: 3px;
 		}
 	}
 

--- a/assets/blocks/quiz/quiz-block/index.js
+++ b/assets/blocks/quiz/quiz-block/index.js
@@ -3,6 +3,7 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import icon from '../../../icons/question-icon';
 
 /**
  * Internal dependencies
@@ -16,6 +17,7 @@ import metadata from './block.json';
 const quizBlock = {
 	...metadata,
 	title: __( 'Quiz', 'sensei-lms' ),
+	icon,
 	description: __(
 		'A collection of questions students need to answer.',
 		'sensei-lms'

--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -2,6 +2,8 @@
  * WordPress dependencies
  */
 import { InnerBlocks } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+import QuizSettings from './quiz-settings';
 
 /**
  * Quiz block editor.
@@ -9,10 +11,15 @@ import { InnerBlocks } from '@wordpress/block-editor';
 const QuizEdit = () => {
 	return (
 		<>
+			<div className="sensei-lms-quiz-block__separator">
+				<span>{ __( 'Lesson Quiz', 'sensei-lms' ) }</span>
+			</div>
 			<InnerBlocks
 				allowedBlocks={ [ 'sensei-lms/quiz-question' ] }
 				template={ [ [ 'sensei-lms/quiz-question' ] ] }
 			/>
+			<QuizSettings { ...props } />
+			<div className="sensei-lms-quiz-block__separator" />
 		</>
 	);
 };

--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -3,7 +3,6 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import QuizSettings from './quiz-settings';
 
 /**
  * Quiz block editor.
@@ -18,7 +17,6 @@ const QuizEdit = () => {
 				allowedBlocks={ [ 'sensei-lms/quiz-question' ] }
 				template={ [ [ 'sensei-lms/quiz-question' ] ] }
 			/>
-			<QuizSettings { ...props } />
 			<div className="sensei-lms-quiz-block__separator" />
 		</>
 	);

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -1,38 +1,7 @@
-.sensei-lms-question-block {
-
-	.editor-styles-wrapper .wp-block &__title, .editor-styles-wrapper .wp-block &__index {
-		font-size: 24px;
-		margin-top: 0;
-		margin-bottom: 0;
-		line-height: 1.25;
 	}
 
-	&__index {
-		position: absolute;
-		right: 100%;
-		text-align: right;
-		top: 0;
-		font-weight: bold;
 
-		.sensei-lms-question-block.is-draft & {
-			opacity: .62;
 		}
 
-		.editor-styles-wrapper .wp-block & {
-			margin-right: 10px;
 		}
 	}
-
-	&__type-selector {
-
-		&__popover .sensei-toolbar-dropdown__option {
-			padding: 12px;
-		}
-
-		&__option__description {
-			color: #757575;
-			font-size: 90%;
-		}
-	}
-
-}

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -26,17 +26,17 @@ $gray-400: #ccc;
 	&__separator {
 		position: relative;
 		text-align: center;
+		display: flex;
+		align-items: center;
 		margin-top: $default-block-margin;
 		margin-bottom: $default-block-margin;
-		height: 24px;
 
-		&:before {
+		&::before, &::after {
 			content: '';
-			position: absolute;
-			top: 20px;
-			left: -100%;
-			right: -100%;
-			border-top: 1px solid $gray-400;
+			flex: 1;
+			background-color: currentColor;
+			opacity: 0.5;
+			height: 1px;
 		}
 
 		& > span {
@@ -45,11 +45,9 @@ $gray-400: #ccc;
 			text-transform: uppercase;
 			font-weight: 600;
 			font-family: $default-font;
-			color: $gray-700;
+			opacity: 0.7;
 			border-radius: 4px;
-			background: $white;
 			padding: 6px 24px;
-			height: 24px;
 		}
 	}
 }

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -1,7 +1,50 @@
+@import '~@wordpress/base-styles/variables';
+$gray-700: #757575;
+$gray-400: #ccc;
+
+@import 'question-block/question-block.editor';
+
+.wp-block[data-type="sensei-lms/quiz"] {
+	margin-left: -10px;
+	margin-right: -10px;
+	max-width: none;
+	position: relative;
+
+	& > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-list-appender {
+		margin: auto;
+		position: relative;
+		left: -40px;
 	}
+}
+.sensei-lms-quiz-block {
 
+	&__separator {
+		position: relative;
+		text-align: center;
+		margin-top: $default-block-margin;
+		margin-bottom: $default-block-margin;
+		height: 24px;
 
+		&:before {
+			content: '';
+			position: absolute;
+			top: 20px;
+			left: -100%;
+			right: -100%;
+			border-top: 1px solid $gray-400;
 		}
 
+		& > span {
+			font-size: $default-font-size;
+			position: relative;
+			text-transform: uppercase;
+			font-weight: 600;
+			font-family: $default-font;
+			color: $gray-700;
+			border-radius: 4px;
+			background: $white;
+			padding: 6px 24px;
+			height: 24px;
 		}
 	}
+}

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -4,16 +4,21 @@ $gray-400: #ccc;
 
 @import 'question-block/question-block.editor';
 
-.wp-block[data-type="sensei-lms/quiz"] {
-	margin-left: -10px;
-	margin-right: -10px;
-	max-width: none;
-	position: relative;
+.wp-block[data-type='sensei-lms/quiz'] {
+	.editor-styles-wrapper & {
+		margin-left: 0;
+		margin-right: 0;
+		max-width: none;
+		position: relative;
+	}
 
 	& > .block-editor-inner-blocks > .block-editor-block-list__layout > .block-list-appender {
 		margin: auto;
 		position: relative;
 		left: -40px;
+	}
+	& > .block-editor-inner-blocks > .block-editor-block-list__layout {
+		margin-left: 0px;
 	}
 }
 .sensei-lms-quiz-block {

--- a/assets/blocks/single-lesson-style-editor.scss
+++ b/assets/blocks/single-lesson-style-editor.scss
@@ -1,2 +1,1 @@
 @import './lesson-actions/lesson-actions-block/lesson-actions-editor';
-@import 'quiz/quiz.editor';


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add answer boxes to single and multi-line question types.
   — Includes the `Answer:` label displayed on the frontend.

* Section off the Quiz inside the lesson editor. (see screenshot 2) 
   — The quiz block was hard to work with and differentiate from the lesson content. In the future, this can be styled differently based on whether the quiz would be in the lesson page, or on a separate page (or displayed as one question per page).

* Update question type help texts

### Testing instructions

* Add a Quiz block to a lesson. Add questions and set the types to single line or multi line. 

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="705" alt="image" src="https://user-images.githubusercontent.com/176949/107403001-e458d400-6b04-11eb-836a-d3512b1d7d16.png">

Quiz sectioning:
<img width="1170" alt="image" src="https://user-images.githubusercontent.com/176949/107248415-907dba80-6a32-11eb-9f01-50057a0a3c4b.png">

