### PR TITLE
Expand multiple questions in quiz REST API

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-internal.php
+++ b/includes/rest-api/class-sensei-rest-api-internal.php
@@ -48,7 +48,7 @@ class Sensei_REST_API_Internal {
 			new Sensei_REST_API_Import_Controller( $this->namespace ),
 			new Sensei_REST_API_Export_Controller( $this->namespace ),
 			new Sensei_REST_API_Course_Structure_Controller( $this->namespace ),
-			new Sensei_REST_API_Quiz_Controller( $this->namespace ),
+			new Sensei_REST_API_Lesson_Quiz_Controller( $this->namespace ),
 		];
 
 		foreach ( $this->controllers as $controller ) {

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the class Sensei_REST_API_Quiz_Controller.
+ * File containing the class Sensei_REST_API_Lesson_Quiz_Controller.
  *
  * @package sensei
  */
@@ -10,13 +10,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Sensei Course Structure REST API endpoints.
+ * Sensei Lesson Quiz REST API endpoints.
  *
  * @package Sensei
  * @author  Automattic
  * @since   3.9.0
  */
-class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
+class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 
 	/**
 	 * Routes namespace.
@@ -30,7 +30,7 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $rest_base = 'quiz';
+	protected $rest_base = 'lesson-quiz';
 
 	/**
 	 * Sensei_REST_API_Quiz_Controller constructor.
@@ -47,7 +47,7 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/(?P<quiz_id>[0-9]+)',
+			$this->rest_base . '/(?P<lesson_id>[0-9]+)',
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
@@ -76,11 +76,11 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 	 * @return bool|WP_Error Whether the user can read a quiz. Error if not found.
 	 */
 	public function can_user_get_quiz( WP_REST_Request $request ) {
-		$quiz = get_post( (int) $request->get_param( 'quiz_id' ) );
-		if ( ! $quiz || 'quiz' !== $quiz->post_type ) {
+		$lesson = get_post( (int) $request->get_param( 'lesson_id' ) );
+		if ( ! $lesson || 'lesson' !== $lesson->post_type ) {
 			return new WP_Error(
-				'sensei_quiz_missing_quiz',
-				__( 'Quiz not found.', 'sensei-lms' ),
+				'sensei_lesson_quiz_missing_lesson',
+				__( 'Lesson not found.', 'sensei-lms' ),
 				[ 'status' => 404 ]
 			);
 		}
@@ -89,7 +89,7 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 			return false;
 		}
 
-		return wp_get_current_user()->ID === (int) $quiz->post_author || current_user_can( 'manage_options' );
+		return wp_get_current_user()->ID === (int) $lesson->post_author || current_user_can( 'manage_options' );
 	}
 
 	/**
@@ -100,12 +100,15 @@ class Sensei_REST_API_Quiz_Controller extends \WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function get_quiz( WP_REST_Request $request ) : WP_REST_Response {
-		$quiz = get_post( (int) $request->get_param( 'quiz_id' ) );
+		$lesson = get_post( (int) $request->get_param( 'lesson_id' ) );
+		$quiz   = Sensei()->lesson->lesson_quizzes( $lesson->ID );
 
-		$this->get_quiz_questions( $quiz );
+		if ( ! $quiz ) {
+			return new WP_REST_Response();
+		}
 
 		$response = new WP_REST_Response();
-		$response->set_data( $this->get_quiz_data( $quiz ) );
+		$response->set_data( $this->get_quiz_data( get_post( $quiz ) ) );
 
 		return $response;
 	}

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -104,7 +104,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 		$quiz   = Sensei()->lesson->lesson_quizzes( $lesson->ID );
 
 		if ( ! $quiz ) {
-			return new WP_REST_Response();
+			return new WP_REST_Response( null, 204 );
 		}
 
 		$response = new WP_REST_Response();

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -181,7 +181,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 		$args = [
 			'post_type'        => 'question',
 			'posts_per_page'   => $number,
-			'orderby'          => 'rand',
+			'orderby'          => 'title',
 			'tax_query'        => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Query limited by the number of questions.
 				[
 					'taxonomy' => 'question-category',

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -207,31 +207,10 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 	 * @return array The question array.
 	 */
 	private function get_question( WP_Post $question ) : array {
-		if ( 'question' === $question->post_type ) {
-			$common_properties        = $this->get_question_common_properties( $question );
-			$type_specific_properties = $this->get_question_type_specific_properties( $question, $common_properties['type'] );
+		$common_properties        = $this->get_question_common_properties( $question );
+		$type_specific_properties = $this->get_question_type_specific_properties( $question, $common_properties['type'] );
 
-			return array_merge( $common_properties, $type_specific_properties );
-		}
-
-		if ( 'multiple_question' === $question->post_type ) {
-			$term_id = get_post_meta( $question->ID, 'category', true );
-			$term    = get_term( $term_id, 'question-category' );
-
-			if ( ! $term || is_wp_error( $term_id ) ) {
-				return [];
-			}
-
-			return [
-				'type'      => 'question-category',
-				'title'     => $question->post_title,
-				'term_id'   => (int) $term_id,
-				'name'      => $term->name,
-				'questions' => (int) get_post_meta( $question->ID, 'number', true ),
-			];
-		}
-
-		return [];
+		return array_merge( $common_properties, $type_specific_properties );
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -258,7 +258,16 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 				break;
 		}
 
-		return $type_specific_properties;
+		/**
+		 * Allows modification of type specific question properties.
+		 *
+		 * @since 3.9.0
+		 *
+		 * @param array   $type_specific_properties The properties of the question.
+		 * @param string  $question_type            The question type.
+		 * @param WP_Post $question                 The question post.
+		 */
+		return apply_filters( 'sensei_question_type_specific_properties', $type_specific_properties, $question_type, $question );
 	}
 
 	/**


### PR DESCRIPTION
This PR implements the changes that were discussed [here](https://github.com/Automattic/sensei/pull/3959#issuecomment-774027270)

### Changes proposed in this Pull Request

* The endpoint is renamed to `lesson-quiz` and the lesson id is used to retrieve the quiz.
* Posts with`multiple_question` type are now expanded to return the questions instead.
* It is expected that when the user saves the quiz for the first time using the new editor, the `multiple_question` post will be dropped and the questions are going to be saved instead (will be implemented as part of another PR).
* For now the questions returned are picked randomly. We might need to revise this when we implement saving.

### Testing instructions

* Test the `/sensei-internal/v1/lesson-quiz/<lesson_id>' endpoint and observe that returned data are correct.
* Specifically create a quiz which has a question category in it and observe that the category is expanded to normal questions.