### PR TITLE
Add multiple choice and true/false question blocks

### DIFF
--- a/assets/blocks/course-outline/single-line-input/index.js
+++ b/assets/blocks/course-outline/single-line-input/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { PlainText } from '@wordpress/block-editor';
+import { forwardRef } from '@wordpress/element';
 import { ENTER } from '@wordpress/keycodes';
 
 /**
@@ -11,30 +12,33 @@ import { ENTER } from '@wordpress/keycodes';
  * @param {Function} props.onChange  Change callback.
  * @param {Function} props.onKeyDown Keydown callback.
  */
-const SingleLineInput = ( { onChange, onKeyDown, ...props } ) => {
-	/**
-	 * Handle change.
-	 *
-	 * @param {string} value Change value.
-	 */
-	const handleChange = ( value ) => {
-		onChange( value.replace( /\n/g, '' ) );
-	};
+const SingleLineInput = forwardRef(
+	( { onChange, onKeyDown, ...props }, ref ) => {
+		/**
+		 * Handle change.
+		 *
+		 * @param {string} value Change value.
+		 */
+		const handleChange = ( value ) => {
+			onChange( value.replace( /\n/g, '' ) );
+		};
 
-	const handleKeyDown = ( e ) => {
-		if ( onKeyDown ) onKeyDown( e );
-		if ( ENTER === e.keyCode ) {
-			e.preventDefault();
-		}
-	};
+		const handleKeyDown = ( e ) => {
+			if ( onKeyDown ) onKeyDown( e );
+			if ( ENTER === e.keyCode ) {
+				e.preventDefault();
+			}
+		};
 
-	return (
-		<PlainText
-			onChange={ handleChange }
-			onKeyDown={ handleKeyDown }
-			{ ...props }
-		/>
-	);
-};
+		return (
+			<PlainText
+				ref={ ref }
+				onChange={ handleChange }
+				onKeyDown={ handleKeyDown }
+				{ ...props }
+			/>
+		);
+	}
+);
 
 export default SingleLineInput;

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -19,38 +19,41 @@ import SingleLineAnswer from './single-line';
 const questionTypes = {
 	multichoice: {
 		title: __( 'Multiple Choice', 'sensei-lms' ),
-		description: __(
-			'Select one or more answers from a list of choices.',
-			'sensei-lms'
-		),
+		description: __( 'Select from a list of options.', 'sensei-lms' ),
 		edit: () => <div> [Multiple Choice] </div>,
 	},
 	truefalse: {
 		title: __( 'True / False', 'sensei-lms' ),
-		description: __( 'True or false question.', 'sensei-lms' ),
+		description: __(
+			'Select whether a statement is true or false.',
+			'sensei-lms'
+		),
 		edit: () => <div> [True/False] </div>,
 	},
 	gap: {
 		title: __( 'Gap Fill', 'sensei-lms' ),
-		description: __(
-			'Fill in the missing part of a sentence.',
-			'sensei-lms'
-		),
+		description: __( 'Fill in the blank.', 'sensei-lms' ),
 		edit: () => <div> [Gap Fill] </div>,
 	},
 	'single-line': {
 		title: __( 'Single-line', 'sensei-lms' ),
-		description: __( 'Require a written answer.', 'sensei-lms' ),
+		description: __(
+			'Short answer to an open-ended question.',
+			'sensei-lms'
+		),
 		edit: SingleLineAnswer,
 	},
 	'multi-line': {
 		title: __( 'Multi-line', 'sensei-lms' ),
-		description: __( 'Require a written answer.', 'sensei-lms' ),
+		description: __(
+			'Long answer to an open-ended question.',
+			'sensei-lms'
+		),
 		edit: MultiLineAnswer,
 	},
 	'file-upload': {
 		title: __( 'File Upload', 'sensei-lms' ),
-		description: __( 'Require a file to be uploaded.', 'sensei-lms' ),
+		description: __( 'Upload a file or document.', 'sensei-lms' ),
 		edit: () => <div> [File Upload] </div>,
 	},
 };

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -3,6 +3,7 @@ import { applyFilters } from '@wordpress/hooks';
 import MultiLineAnswer from './multi-line';
 import MultipleChoiceAnswer from './multiple-choice';
 import SingleLineAnswer from './single-line';
+import TrueFalseAnswer from './true-false';
 
 /**
  * @typedef QuestionType
@@ -29,7 +30,7 @@ const questionTypes = {
 			'Select whether a statement is true or false.',
 			'sensei-lms'
 		),
-		edit: () => <div> [True/False] </div>,
+		edit: TrueFalseAnswer,
 	},
 	gap: {
 		title: __( 'Gap Fill', 'sensei-lms' ),

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
 import MultiLineAnswer from './multi-line';
+import MultipleChoiceAnswer from './multiple-choice';
 import SingleLineAnswer from './single-line';
 
 /**
@@ -20,7 +21,7 @@ const questionTypes = {
 	multichoice: {
 		title: __( 'Multiple Choice', 'sensei-lms' ),
 		description: __( 'Select from a list of options.', 'sensei-lms' ),
-		edit: () => <div> [Multiple Choice] </div>,
+		edit: MultipleChoiceAnswer,
 	},
 	truefalse: {
 		title: __( 'True / False', 'sensei-lms' ),

--- a/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
@@ -57,7 +57,7 @@ const MultipleChoiceAnswerOption = ( props ) => {
 	const toggleRight = () => setAttributes( { isRight: ! isRight } );
 
 	return (
-		<div className="sensei-lms-question-block__multiple-choice-answer-opion">
+		<div className="sensei-lms-question-block__multiple-choice-answer-option">
 			<OptionToggle
 				onClick={ toggleRight }
 				isChecked={ isRight }
@@ -66,7 +66,7 @@ const MultipleChoiceAnswerOption = ( props ) => {
 			<SingleLineInput
 				ref={ ref }
 				placeholder={ __( 'Add Answer', 'sensei-lms' ) }
-				className="sensei-lms-question-block__multiple-choice-answer-opion__input"
+				className="sensei-lms-question-block__multiple-choice-answer-option__input"
 				onChange={ ( nextValue ) =>
 					setAttributes( { title: nextValue } )
 				}
@@ -75,7 +75,7 @@ const MultipleChoiceAnswerOption = ( props ) => {
 			/>
 			{ hasSelected && (
 				<Button
-					className="sensei-lms-question-block__multiple-choice-answer-opion__hint"
+					className="sensei-lms-question-block__multiple-choice-answer-option__hint"
 					onClick={ toggleRight }
 				>
 					{ isRight

--- a/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
@@ -1,0 +1,90 @@
+import { Button } from '@wordpress/components';
+import { useEffect, useRef } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { ENTER, BACKSPACE } from '@wordpress/keycodes';
+import SingleLineInput from '../../course-outline/single-line-input';
+import { OptionToggle } from './option-toggle';
+
+/**
+ * Answer option in a multiple choice type question block.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.attributes         Answer attributes.
+ * @param {string}   props.attributes.title   Answer title.
+ * @param {boolean}  props.attributes.isRight Is this a right answer.
+ * @param {Function} props.setAttributes      Update answer attributes.
+ * @param {Function} props.add                Add a new answer after this.
+ * @param {Function} props.remove             Remove this answer.
+ * @param {boolean}  props.hasFocus           Should this answer receive focus.
+ * @param {boolean}  props.hasSelected        Is the question block selected.
+ * @param {boolean}  props.isCheckbox         Should display as a checkbox
+ */
+const MultipleChoiceAnswerOption = ( props ) => {
+	const {
+		attributes: { title, isRight },
+		setAttributes,
+		insertAnswerAfter,
+		removeAnswer,
+		hasFocus,
+		hasSelected,
+		isCheckbox,
+	} = props;
+
+	const onKeyDown = ( e ) => {
+		switch ( e.keyCode ) {
+			case ENTER:
+				e.preventDefault();
+				insertAnswerAfter();
+
+				break;
+			case BACKSPACE:
+				if ( ! title?.length ) {
+					e.preventDefault();
+					removeAnswer();
+				}
+				break;
+		}
+	};
+
+	const ref = useRef( null );
+
+	useEffect( () => {
+		if ( hasFocus ) {
+			ref.current?.focus();
+		}
+	}, [ hasFocus, ref ] );
+
+	const toggleRight = () => setAttributes( { isRight: ! isRight } );
+
+	return (
+		<div className="sensei-lms-question-block__multiple-choice-answer-opion">
+			<OptionToggle
+				onClick={ toggleRight }
+				isChecked={ isRight }
+				isCheckbox={ isCheckbox }
+			/>
+			<SingleLineInput
+				ref={ ref }
+				placeholder={ __( 'Add Answer', 'sensei-lms' ) }
+				className="sensei-lms-question-block__multiple-choice-answer-opion__input"
+				onChange={ ( nextValue ) =>
+					setAttributes( { title: nextValue } )
+				}
+				value={ title }
+				onKeyDown={ onKeyDown }
+			/>
+			{ hasSelected && (
+				<Button
+					className="sensei-lms-question-block__multiple-choice-answer-opion__hint"
+					onClick={ toggleRight }
+				>
+					{ isRight
+						? __( 'Right', 'sensei-lms' )
+						: __( 'Wrong', 'sensei-lms' ) }
+				</Button>
+			) }
+		</div>
+	);
+};
+
+export default MultipleChoiceAnswerOption;

--- a/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
@@ -76,7 +76,7 @@ const MultipleChoiceAnswerOption = ( props ) => {
 			/>
 			{ hasSelected && (
 				<Button
-					className="sensei-lms-question-block__multiple-choice-answer-option__hint"
+					className="sensei-lms-question-block__answer--multiple-choice__hint"
 					onClick={ toggleRight }
 				>
 					{ isRight

--- a/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
@@ -50,7 +50,8 @@ const MultipleChoiceAnswerOption = ( props ) => {
 
 	useEffect( () => {
 		if ( hasFocus ) {
-			ref.current?.focus();
+			const el = ref.current?.textarea || ref.current;
+			el?.focus();
 		}
 	}, [ hasFocus, ref ] );
 

--- a/assets/blocks/quiz/answer-blocks/multiple-choice.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice.js
@@ -1,0 +1,94 @@
+import { useState } from '@wordpress/element';
+import MultipleChoiceAnswerOption from './multiple-choice-answer-option';
+
+/**
+ * Default answer options for new blocks.
+ */
+const DEFAULT_ANSWERS = [
+	{ title: null, isRight: true },
+	{ title: null, isRight: false },
+];
+
+/**
+ * Question block multiple choice answer component.
+ *
+ * @param {Object} props
+ */
+const MultipleChoiceAnswer = ( props ) => {
+	const {
+		attributes: { answers = DEFAULT_ANSWERS },
+		setAttributes,
+		hasSelected,
+	} = props;
+
+	const hasMultipleRight = answers.filter( ( a ) => a.isRight ).length > 1;
+
+	/**
+	 * Add a new answer option.
+	 *
+	 * @param {number} index Answer position
+	 */
+	const insertAnswer = ( index ) => {
+		const nextAnswers = [ ...answers ];
+		const newAnswer = { title: '', isRight: false };
+		nextAnswers.splice( index + 1, 0, newAnswer );
+		setAttributes( {
+			answers: nextAnswers,
+		} );
+		setFocus( index + 1 );
+	};
+
+	/**
+	 * Remove an answer option.
+	 *
+	 * @param {number} index Answer position
+	 */
+	const removeAnswer = ( index ) => {
+		setFocus( index - 1 );
+		const nextAnswers = [ ...answers ];
+		nextAnswers.splice( index, 1 );
+		setAttributes( {
+			answers: nextAnswers,
+		} );
+	};
+
+	/**
+	 * Updat answer attributes.
+	 *
+	 * @param {number} index Answer position
+	 * @param {Object} next  Updated answer
+	 */
+	const updateAnswer = ( index, next ) => {
+		{
+			const nextAnswers = [ ...answers ];
+			nextAnswers[ index ] = { ...nextAnswers[ index ], ...next };
+			setAttributes( { answers: nextAnswers } );
+		}
+	};
+
+	const [ nextFocus, setFocus ] = useState( null );
+
+	return (
+		<ol className="sensei-lms-question-block__answer sensei-lms-question-block__answer--multiple-choice">
+			{ answers.map( ( answer, index ) => (
+				<li key={ index }>
+					<MultipleChoiceAnswerOption
+						hasFocus={ index === nextFocus }
+						isCheckbox={ hasMultipleRight }
+						attributes={ answer }
+						setAttributes={ ( next ) =>
+							updateAnswer( index, next )
+						}
+						insertAnswerAfter={ () => insertAnswer( index ) }
+						removeAnswer={ () => removeAnswer( index ) }
+						{ ...{
+							hasSelected,
+						} }
+					/>
+				</li>
+			) ) }
+		</ol>
+	);
+};
+
+export default MultipleChoiceAnswer;

--- a/assets/blocks/quiz/answer-blocks/multiple-choice.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice.js
@@ -10,7 +10,7 @@ const DEFAULT_ANSWERS = [
 ];
 
 /**
- * Question block multiple choice answer component.
+ * Answer component for question blocks with multiple choice type.
  *
  * @param {Object} props
  */

--- a/assets/blocks/quiz/answer-blocks/multiple-choice.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice.js
@@ -53,7 +53,7 @@ const MultipleChoiceAnswer = ( props ) => {
 	};
 
 	/**
-	 * Updat answer attributes.
+	 * Update answer attributes.
 	 *
 	 * @param {number} index Answer position
 	 * @param {Object} next  Updated answer

--- a/assets/blocks/quiz/answer-blocks/option-toggle.js
+++ b/assets/blocks/quiz/answer-blocks/option-toggle.js
@@ -1,0 +1,29 @@
+import { Button } from '@wordpress/components';
+import classnames from 'classnames';
+import { checked } from '../../../icons/wordpress-icons';
+
+export const OptionToggle = ( {
+	className,
+	isChecked,
+	isCheckbox,
+	children,
+	...props
+} ) => (
+	<Button
+		className={ classnames(
+			'sensei-lms-question-block__option-toggle',
+			className
+		) }
+		{ ...props }
+	>
+		<div
+			className={ classnames(
+				'sensei-lms-question-block__option-toggle__control',
+				{ 'is-checked': isChecked, 'is-checkbox': isCheckbox }
+			) }
+		>
+			{ isChecked && isCheckbox && checked }
+		</div>
+		{ children }
+	</Button>
+);

--- a/assets/blocks/quiz/answer-blocks/option-toggle.scss
+++ b/assets/blocks/quiz/answer-blocks/option-toggle.scss
@@ -1,5 +1,6 @@
 
 .sensei-lms-question-block__option-toggle {
+	color: inherit;
 	.edit-post-visual-editor & {
 		font-family: inherit;
 		font-size: inherit;

--- a/assets/blocks/quiz/answer-blocks/option-toggle.scss
+++ b/assets/blocks/quiz/answer-blocks/option-toggle.scss
@@ -1,0 +1,53 @@
+
+.sensei-lms-question-block__option-toggle {
+	.edit-post-visual-editor & {
+		font-family: inherit;
+		font-size: inherit;
+		padding: 12px 2px;
+		margin-right: 10px;
+		margin-left: -2px;
+		margin-top: -2px;
+	}
+
+	&__control {
+		width: 26px;
+		height: 26px;
+		border-radius: 50%;
+		box-shadow: inset 0 0 0 1.5px currentColor;
+		margin: 2px;
+		position: relative;
+
+		&:after {
+			position: absolute;
+			content: '';
+			left: 0;
+			top: 0;
+			bottom: 0;
+			right: 0;
+			margin: auto;
+			width: 12px;
+			height: 12px;
+			border-radius: 50%;
+		}
+
+		&.is-checked:after {
+			background: currentColor;
+		}
+
+		&.is-checkbox {
+			border-radius: 4px;
+			display: flex;
+			align-items: center;
+			justify-content: center;
+
+			svg {
+				width: 20px;
+				height: 20px;
+			}
+
+			&:after {
+				content: none;
+			}
+		}
+	}
+}

--- a/assets/blocks/quiz/answer-blocks/option-toggle.scss
+++ b/assets/blocks/quiz/answer-blocks/option-toggle.scss
@@ -3,10 +3,11 @@
 	.edit-post-visual-editor & {
 		font-family: inherit;
 		font-size: inherit;
-		padding: 12px 2px;
+		padding: 2px;
 		margin-right: 10px;
-		margin-left: -2px;
-		margin-top: -2px;
+		align-self: flex-start;
+		height: auto;
+		line-height: inherit;
 	}
 
 	&__control {
@@ -14,7 +15,6 @@
 		height: 26px;
 		border-radius: 50%;
 		box-shadow: inset 0 0 0 1.5px currentColor;
-		margin: 2px;
 		position: relative;
 
 		&:after {

--- a/assets/blocks/quiz/answer-blocks/option-toggle.scss
+++ b/assets/blocks/quiz/answer-blocks/option-toggle.scss
@@ -4,11 +4,17 @@
 	.edit-post-visual-editor & {
 		font-family: inherit;
 		font-size: inherit;
-		padding: 2px;
+		padding: 0;
 		margin-right: 10px;
-		align-self: flex-start;
-		height: auto;
 		line-height: inherit;
+		height: auto;
+	}
+
+	&:before {
+		// Text baseline alignment helper.
+		content: 'A';
+		visibility: hidden;
+		width: 0;
 	}
 
 	&__control {
@@ -17,6 +23,8 @@
 		border-radius: 50%;
 		box-shadow: inset 0 0 0 1.5px currentColor;
 		position: relative;
+		align-items: center;
+
 
 		&:after {
 			position: absolute;

--- a/assets/blocks/quiz/answer-blocks/true-false.js
+++ b/assets/blocks/quiz/answer-blocks/true-false.js
@@ -1,0 +1,38 @@
+import { __ } from '@wordpress/i18n';
+import { OptionToggle } from './option-toggle';
+
+/**
+ * Answer component for question blocks with true/false type.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.attributes
+ * @param {boolean}  props.attributes.rightAnswer The correct answer.
+ * @param {Function} props.setAttributes
+ */
+const TrueFalseAnswer = ( {
+	attributes: { rightAnswer = true },
+	setAttributes,
+} ) => {
+	const options = [
+		{ label: __( 'True', 'sensei-lms' ), value: true },
+		{ label: __( 'False', 'sensei-lms' ), value: false },
+	];
+	return (
+		<ul className="sensei-lms-question-block__answer sensei-lms-question-block__answer--true-false">
+			{ options.map( ( { label, value } ) => (
+				<li key={ value }>
+					<OptionToggle
+						onClick={ () =>
+							setAttributes( { rightAnswer: value } )
+						}
+						isChecked={ rightAnswer === value }
+					>
+						<span>{ label }</span>
+					</OptionToggle>
+				</li>
+			) ) }
+		</ul>
+	);
+};
+
+export default TrueFalseAnswer;

--- a/assets/blocks/quiz/answer-blocks/true-false.js
+++ b/assets/blocks/quiz/answer-blocks/true-false.js
@@ -1,3 +1,4 @@
+import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { OptionToggle } from './option-toggle';
 
@@ -8,10 +9,12 @@ import { OptionToggle } from './option-toggle';
  * @param {Object}   props.attributes
  * @param {boolean}  props.attributes.rightAnswer The correct answer.
  * @param {Function} props.setAttributes
+ * @param {boolean}  props.hasSelected            Is question block selected.
  */
 const TrueFalseAnswer = ( {
 	attributes: { rightAnswer = true },
 	setAttributes,
+	hasSelected,
 } ) => {
 	const options = [
 		{ label: __( 'True', 'sensei-lms' ), value: true },
@@ -20,7 +23,10 @@ const TrueFalseAnswer = ( {
 	return (
 		<ul className="sensei-lms-question-block__answer sensei-lms-question-block__answer--true-false">
 			{ options.map( ( { label, value } ) => (
-				<li key={ value }>
+				<li
+					key={ value }
+					className="sensei-lms-question-block__answer--true-false__option"
+				>
 					<OptionToggle
 						onClick={ () =>
 							setAttributes( { rightAnswer: value } )
@@ -29,6 +35,21 @@ const TrueFalseAnswer = ( {
 					>
 						<span>{ label }</span>
 					</OptionToggle>
+					{ hasSelected && (
+						<Button
+							className="sensei-lms-question-block__answer--true-false__hint"
+							onClick={ () =>
+								setAttributes( {
+									rightAnswer:
+										value === rightAnswer ? ! value : value,
+								} )
+							}
+						>
+							{ rightAnswer === value
+								? __( 'Right', 'sensei-lms' )
+								: __( 'Wrong', 'sensei-lms' ) }
+						</Button>
+					) }
 				</li>
 			) ) }
 		</ul>

--- a/assets/blocks/quiz/question-block/block.json
+++ b/assets/blocks/quiz/question-block/block.json
@@ -15,6 +15,9 @@
     "type": {
       "type": "string",
       "default": "multichoice"
+    },
+    "answer": {
+      "type": "object"
     }
   }
 }

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -4,8 +4,7 @@ $block: '.sensei-lms-question-block';
 
 .sensei-lms-question-block {
 
-	$answer-box-color: #333;
-	$answer-box-color: #333;
+	$answer-box-color: currentColor;
 
 	.editor-styles-wrapper .wp-block &__title, .editor-styles-wrapper .wp-block &__index {
 		font-size: 24px;
@@ -55,7 +54,8 @@ $block: '.sensei-lms-question-block';
 	}
 
 	&__input-label {
-		color: #444;
+		opacity: 0.7;
+		font-size: 90%;
 	}
 
 	&__answer--multiple-choice, &__answer--true-false {
@@ -88,6 +88,7 @@ $block: '.sensei-lms-question-block';
 
 			.editor-styles-wrapper & {
 				margin: 0;
+				background-color: transparent;
 			}
 
 			&:focus {
@@ -98,7 +99,8 @@ $block: '.sensei-lms-question-block';
 
 		&__hint {
 			text-transform: uppercase;
-			color: #757575;
+			color: inherit;
+			opacity: 0.6;
 			font-size: 14px;
 			font-family: sans-serif;
 			margin-right: 2px;

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -49,7 +49,7 @@ $block: '.sensei-lms-question-block';
 		min-height: 52px;
 
 		&.multi-line {
-      min-height: 200px;
+			min-height: 200px;
 		}
 	}
 
@@ -90,6 +90,7 @@ $block: '.sensei-lms-question-block';
 				margin-right: 12px;
 			}
 		}
+
 		&__option {
 			min-height: 42px;
 			display: flex;

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -69,19 +69,17 @@ $block: '.sensei-lms-question-block';
 	}
 
 	&__answer--true-false {
-		display: flex;
-
 		#{$block}__option-toggle {
-			margin-right: 24px;
-
+			min-height: 34px;
 			&__control {
 				margin-right: 12px;
 			}
 		}
 	}
 
-	&__multiple-choice-answer-opion {
+	&__multiple-choice-answer-option {
 		display: flex;
+		align-items: baseline;
 		margin: 12px 0;
 
 		&__input {
@@ -104,7 +102,9 @@ $block: '.sensei-lms-question-block';
 			font-family: sans-serif;
 			margin-right: 2px;
 			margin-left: 12px;
-			margin-top: -2px;
+			padding: 4px;
+			height: auto;
+			line-height: inherit;
 		}
 	}
 

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -92,7 +92,7 @@ $block: '.sensei-lms-question-block';
 		}
 
 		&__option {
-			min-height: 42px;
+			min-height: 45px;
 			display: flex;
 			align-items: baseline;
 		}
@@ -100,7 +100,7 @@ $block: '.sensei-lms-question-block';
 
 	&__multiple-choice-answer-option {
 		display: flex;
-		align-items: baseline;
+		align-items: flex-start;
 		margin: 12px 0;
 
 		&__input {

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -67,14 +67,33 @@ $block: '.sensei-lms-question-block';
 				list-style: none;
 			}
 		}
+
+		&__hint {
+			text-transform: uppercase;
+			color: inherit;
+			opacity: 0.6;
+			font-size: 14px;
+			font-family: sans-serif;
+			margin-right: 2px;
+			margin-left: 12px;
+			padding: 4px;
+			height: auto;
+			line-height: inherit;
+		}
 	}
 
 	&__answer--true-false {
 		#{$block}__option-toggle {
-			min-height: 34px;
+			flex: 1;
+
 			&__control {
 				margin-right: 12px;
 			}
+		}
+		&__option {
+			min-height: 42px;
+			display: flex;
+			align-items: baseline;
 		}
 	}
 
@@ -97,18 +116,6 @@ $block: '.sensei-lms-question-block';
 			}
 		}
 
-		&__hint {
-			text-transform: uppercase;
-			color: inherit;
-			opacity: 0.6;
-			font-size: 14px;
-			font-family: sans-serif;
-			margin-right: 2px;
-			margin-left: 12px;
-			padding: 4px;
-			height: auto;
-			line-height: inherit;
-		}
 	}
 
 

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -49,8 +49,10 @@ $block: '.sensei-lms-question-block';
 		&.multi-line {
 			min-height: 250px;
 		}
+
 		&.rich-text {
 			position: relative;
+
 			&:before {
 				content: '';
 				position: absolute;
@@ -69,5 +71,95 @@ $block: '.sensei-lms-question-block';
 	&__input-label {
 		color: #444;
 	}
+
+	&__answer--multiple-choice, &__answer--true-false {
+		.editor-styles-wrapper & {
+			margin: 28px 0;
+			padding: 0;
+
+			li {
+				list-style: none;
+			}
+		}
+	}
+	&__option-toggle {
+		.edit-post-visual-editor & {
+			font-family: inherit;
+			font-size: inherit;
+			padding: 12px 2px;
+			margin-right: 10px;
+			margin-left: -2px;
+			margin-top: -2px;
+		}
+
+		&__control {
+			width: 26px;
+			height: 26px;
+			border-radius: 50%;
+			box-shadow: inset 0 0 0 1.5px currentColor;
+			margin: 2px;
+			position: relative;
+
+			&:after {
+				position: absolute;
+				content: '';
+				left: 0;
+				top: 0;
+				bottom: 0;
+				right: 0;
+				margin: auto;
+				width: 12px;
+				height: 12px;
+				border-radius: 50%;
+			}
+
+			&.is-checked:after {
+				background: currentColor;
+			}
+
+			&.is-checkbox {
+				border-radius: 4px;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+
+				svg {
+					width: 20px;
+					height: 20px;
+				}
+				&:after {
+					content: none;
+				}
+			}
+		}
+	}
+	&__multiple-choice-answer-opion {
+		display: flex;
+		margin: 12px 0;
+
+		&__input {
+			flex: 1;
+
+			.editor-styles-wrapper & {
+				margin: 0;
+			}
+
+			&:focus {
+				box-shadow: none;
+				border-color: transparent;
+			}
+		}
+
+		&__hint {
+			text-transform: uppercase;
+			color: #757575;
+			font-size: 14px;
+			font-family: sans-serif;
+			margin-right: 2px;
+			margin-left: 12px;
+			margin-top: -2px;
+		}
+	}
+
 
 }

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -1,5 +1,7 @@
-
 $block: '.sensei-lms-question-block';
+
+@import '../answer-blocks/option-toggle';
+
 .sensei-lms-question-block {
 
 	$answer-box-color: #333;
@@ -82,57 +84,19 @@ $block: '.sensei-lms-question-block';
 			}
 		}
 	}
-	&__option-toggle {
-		.edit-post-visual-editor & {
-			font-family: inherit;
-			font-size: inherit;
-			padding: 12px 2px;
-			margin-right: 10px;
-			margin-left: -2px;
-			margin-top: -2px;
-		}
 
-		&__control {
-			width: 26px;
-			height: 26px;
-			border-radius: 50%;
-			box-shadow: inset 0 0 0 1.5px currentColor;
-			margin: 2px;
-			position: relative;
+	&__answer--true-false {
+		display: flex;
 
-			&:after {
-				position: absolute;
-				content: '';
-				left: 0;
-				top: 0;
-				bottom: 0;
-				right: 0;
-				margin: auto;
-				width: 12px;
-				height: 12px;
-				border-radius: 50%;
-			}
+		#{$block}__option-toggle {
+			margin-right: 24px;
 
-			&.is-checked:after {
-				background: currentColor;
-			}
-
-			&.is-checkbox {
-				border-radius: 4px;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-
-				svg {
-					width: 20px;
-					height: 20px;
-				}
-				&:after {
-					content: none;
-				}
+			&__control {
+				margin-right: 12px;
 			}
 		}
 	}
+
 	&__multiple-choice-answer-opion {
 		display: flex;
 		margin: 12px 0;

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -89,11 +89,11 @@ $block: '.sensei-lms-question-block';
 			.editor-styles-wrapper & {
 				margin: 0;
 				background-color: transparent;
-			}
 
-			&:focus {
-				box-shadow: none;
-				border-color: transparent;
+				&:focus {
+					box-shadow: none;
+					border-color: transparent;
+				}
 			}
 		}
 

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -1,13 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { RichText, InnerBlocks, BlockControls } from '@wordpress/block-editor';
+import { BlockControls, InnerBlocks, RichText } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { useBlockIndex } from '../../../shared/blocks/block-index';
+import { useHasSelected } from '../../../shared/helpers/blocks';
 import types from '../answer-blocks';
 import { QuestionTypeToolbar } from './question-type-toolbar';
 
@@ -28,6 +29,8 @@ const QuestionEdit = ( props ) => {
 
 	const index = useBlockIndex( clientId );
 	const AnswerBlock = type && types[ type ];
+
+	const hasSelected = useHasSelected( props );
 
 	return (
 		<div
@@ -64,6 +67,7 @@ const QuestionEdit = ( props ) => {
 					setAttributes={ ( next ) =>
 						setAttributes( { answer: { ...answer, ...next } } )
 					}
+					{ ...{ hasSelected } }
 				/>
 			) }
 			<BlockControls>

--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -3,7 +3,6 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import QuizSettings from './quiz-settings';
 
 /**
  * Quiz block editor.
@@ -18,7 +17,6 @@ const QuizEdit = () => {
 				allowedBlocks={ [ 'sensei-lms/quiz-question' ] }
 				template={ [ [ 'sensei-lms/quiz-question' ] ] }
 			/>
-			<QuizSettings { ...props } />
 			<div className="sensei-lms-quiz-block__separator" />
 		</>
 	);

--- a/assets/shared/helpers/blocks.js
+++ b/assets/shared/helpers/blocks.js
@@ -1,0 +1,19 @@
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Are the block or any of it's descendants selected.
+ *
+ * @param {Object}  props
+ * @param {boolean} props.isSelected Block selected
+ * @param {string}  props.clientId   Block ID
+ * @return {boolean} Selection state
+ */
+export const useHasSelected = ( { isSelected, clientId } ) => {
+	return (
+		useSelect(
+			( select ) =>
+				select( 'core/block-editor' ).hasSelectedInnerBlock( clientId ),
+			[ clientId ]
+		) || isSelected
+	);
+};


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Add components to manage multi choice question type answer options
* Also add for true/false since they share much

### Features
- [x] Add/remove options with enter and backspace
- [x] Toggle right/wrong answers with the checkbox or the hint
- [x] Show right/wrong hint when block is focused
- [x] Show radio/checkbox depending on whether there are multiple right answers 

### Not done in this PR
- Converting block attributes to/from REST API schema

### Testing instructions

* Add a quiz and a question block
* Add and edit answers
* Change right answers
* Make sure everything works as expected and feels right
--
* Add another question, set to True/False type
* Change which one is the right answer

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="695" alt="image" src="https://user-images.githubusercontent.com/176949/107411757-3141a800-6b0f-11eb-8bab-fc73feab029e.png">

--- 

<img width="600" src="https://user-images.githubusercontent.com/176949/107401220-f174c380-6b02-11eb-853c-77a4160f2ed6.gif" />

