### PR TITLE
Fix course lessons in modules not appearing on analysis screen

### DIFF
--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -573,7 +573,6 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 			'post_type'        => 'lesson',
 			'posts_per_page'   => $args['number'],
 			'offset'           => $args['offset'],
-			'meta_key'         => '_order_' . $this->course_id,
 			'order'            => $args['order'],
 			'meta_query'       => array(
 				array(


### PR DESCRIPTION
Fixes #3964

I've put this on the `release/3.8` branch in case we do a 3.8.1, but can move it to `master` if not.

### Changes proposed in this Pull Request

* This wasn't being used. Before, we were letting the `_order_{courseId}` stick around but it wasn't being used for other queries (when the course had modules). It was being used unnecessarily in the analysis screens. 

### Testing instructions

* See issue.
