### PR TITLE
Add Gap Fill question block

### DIFF
--- a/assets/blocks/quiz/answer-blocks/gap-fill.js
+++ b/assets/blocks/quiz/answer-blocks/gap-fill.js
@@ -1,0 +1,65 @@
+import { RichText } from '@wordpress/block-editor';
+import { FormTokenField } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Question block gap fill answer component.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.attributes
+ * @param {string}   props.attributes.textBefore   Text before the gap.
+ * @param {string}   props.attributes.textAfter    Text after the gap.
+ * @param {string[]} props.attributes.rightAnswers Right answers.
+ * @param {Function} props.setAttributes
+ * @param {boolean}  props.hasSelected             Is the question block selected.
+ */
+const GapFillAnswer = ( {
+	attributes: { textBefore, textAfter, rightAnswers },
+	setAttributes,
+	hasSelected,
+} ) => {
+	return (
+		<ul className="sensei-lms-question-block__answer sensei-lms-question-block__answer--gap-fill">
+			<li>
+				<RichText
+					placeholder={ __( 'Text before the gap', 'sensei-lms' ) }
+					value={ textBefore }
+					onChange={ ( nextValue ) =>
+						setAttributes( { before: nextValue } )
+					}
+				/>
+			</li>
+			<li className="sensei-lms-question-block__answer--gap-fill__right-answers">
+				<FormTokenField
+					className={
+						'sensei-lms-question-block__text-input-placeholder'
+					}
+					value={ rightAnswers }
+					label={ false }
+					onChange={ ( nextValue ) =>
+						setAttributes( { rightAnswers: nextValue } )
+					}
+				/>
+				{ hasSelected && (
+					<div className="sensei-lms-question-block__answer--gap-fill__hint">
+						{ __(
+							'Add right answers. Separate with commas or the Enter key.',
+							'sensei-lms'
+						) }
+					</div>
+				) }
+			</li>
+			<li>
+				<RichText
+					placeholder={ __( 'Text after the gap', 'sensei-lms' ) }
+					value={ textAfter }
+					onChange={ ( nextValue ) =>
+						setAttributes( { textAfter: nextValue } )
+					}
+				/>
+			</li>
+		</ul>
+	);
+};
+
+export default GapFillAnswer;

--- a/assets/blocks/quiz/answer-blocks/gap-fill.js
+++ b/assets/blocks/quiz/answer-blocks/gap-fill.js
@@ -25,7 +25,7 @@ const GapFillAnswer = ( {
 					placeholder={ __( 'Text before the gap', 'sensei-lms' ) }
 					value={ textBefore }
 					onChange={ ( nextValue ) =>
-						setAttributes( { before: nextValue } )
+						setAttributes( { textBefore: nextValue } )
 					}
 				/>
 			</li>

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
+import GapFillAnswer from './gap-fill';
 import MultiLineAnswer from './multi-line';
 import MultipleChoiceAnswer from './multiple-choice';
 import SingleLineAnswer from './single-line';
@@ -35,7 +36,7 @@ const questionTypes = {
 	gap: {
 		title: __( 'Gap Fill', 'sensei-lms' ),
 		description: __( 'Fill in the blank.', 'sensei-lms' ),
-		edit: () => <div> [Gap Fill] </div>,
+		edit: GapFillAnswer,
 	},
 	'single-line': {
 		title: __( 'Single-line', 'sensei-lms' ),

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -58,7 +58,7 @@ $block: '.sensei-lms-question-block';
 		font-size: 90%;
 	}
 
-	&__answer--multiple-choice, &__answer--true-false {
+	&__answer--multiple-choice, &__answer--true-false, &__answer--gap-fill {
 		.editor-styles-wrapper & {
 			margin: 28px 0;
 			padding: 0;
@@ -108,6 +108,61 @@ $block: '.sensei-lms-question-block';
 			padding: 4px;
 			height: auto;
 			line-height: inherit;
+		}
+	}
+
+	&__answer--gap-fill {
+
+		.components-form-token-field {
+			&__input-container {
+				margin: 0;
+				font-size: inherit;
+				font-family: inherit;
+				align-items: center;
+
+				& input[type='text'].components-form-token-field__input {
+					font-size: inherit;
+					color: inherit;
+				}
+			}
+
+			&__token {
+				font-size: inherit;
+				background: var(--wp-admin-theme-color, #333);
+				color: #fff;
+				align-items: center;
+				* {
+					background: none;
+					color: inherit;
+				}
+			}
+
+			&__token-text {
+				padding: 4px 4px 4px 8px;
+			}
+
+			&__label {
+				display: none;
+			}
+
+			&__help {
+				display: none;
+			}
+		}
+
+		.editor-styles-wrapper &__right-answers {
+			margin: 12px 0;
+		}
+
+		&__hint {
+			color: inherit;
+			opacity: 0.6;
+			font-size: 12px;
+			font-family: sans-serif;
+			padding: 4px;
+			height: auto;
+			line-height: inherit;
+			text-align: right;
 		}
 	}
 


### PR DESCRIPTION
Depends on #3967 for some shared changes

### Changes proposed in this Pull Request

* Add answer section for Gap Fill question type
* Has a Text before, text after rich text fields
* And a token field for the right answers
* Add a hint for the token field when the block is focused (`Add right answers. Separate with commas or the Enter key.`)

### Testing instructions

* Add a quiz to a lesson and set a question's type to Gap Fill
* Fill in the editable areas and he right answers
* Check that everything works well and feels right

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="684" alt="image" src="https://user-images.githubusercontent.com/176949/107797252-077cc100-6d5b-11eb-95a2-786e07921c46.png">


<img width=684 src="https://user-images.githubusercontent.com/176949/107796800-8b827900-6d5a-11eb-8c42-efca64b655bc.gif" />

