### PR TITLE
Add File Upload question block

### DIFF
--- a/assets/blocks/quiz/answer-blocks/file-upload.js
+++ b/assets/blocks/quiz/answer-blocks/file-upload.js
@@ -1,0 +1,16 @@
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Question block file upload answer component.
+ */
+const FileUploadAnswer = () => {
+	return (
+		<div className="sensei-lms-question-block__answer sensei-lms-question-block__answer--file-upload">
+			<div className="sensei-lms-question-block__file-input-placeholder">
+				{ __( 'Browse…', 'sensei-lms' ) }
+			</div>
+		</div>
+	);
+};
+
+export default FileUploadAnswer;

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
+import FileUploadAnswer from './file-upload';
 import GapFillAnswer from './gap-fill';
 import MultiLineAnswer from './multi-line';
 import MultipleChoiceAnswer from './multiple-choice';
@@ -57,7 +58,7 @@ const questionTypes = {
 	'file-upload': {
 		title: __( 'File Upload', 'sensei-lms' ),
 		description: __( 'Upload a file or document.', 'sensei-lms' ),
-		edit: () => <div> [File Upload] </div>,
+		edit: FileUploadAnswer,
 	},
 };
 

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -42,7 +42,7 @@ $block: '.sensei-lms-question-block';
 		}
 	}
 
-	&__text-input-placeholder {
+	&__text-input-placeholder, &__file-input-placeholder {
 		border: 2px solid $answer-box-color;
 		border-radius: 2px;
 		padding: 5px;
@@ -51,6 +51,16 @@ $block: '.sensei-lms-question-block';
 		&.multi-line {
 			min-height: 200px;
 		}
+	}
+
+	&__file-input-placeholder {
+		text-transform: uppercase;
+		display: inline-flex;
+		padding: 5px 15px;
+		align-items: center;
+		justify-content: center;
+		font-size: 16px;
+		user-select: none;
 	}
 
 	&__input-label {


### PR DESCRIPTION
Depends on #3967 for some shared changes

### Changes proposed in this Pull Request

* Add question block answer section for File Upload type 

### Testing instructions

* Add a quiz to a lesson, set question type to File Upload
* Notice a non-interactive `Browse` button appears

### Notes
* It does not use Wordpress button styles, since it doesn't in the frontend either. We can built this into a customizable button in the future.
* On the frontend, the max file size also appears below the file upload controls. Didn't think it's worth the complexity to query that here. Also a good future task to allow customizing that setting in this block.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video


<img width="706" alt="image" src="https://user-images.githubusercontent.com/176949/107802032-22523400-6d61-11eb-81ba-b9f0e98845a8.png">
