### PR TITLE
Add common question block settings

### DIFF
--- a/assets/blocks/editor-components/number-control/number-control.scss
+++ b/assets/blocks/editor-components/number-control/number-control.scss
@@ -4,6 +4,7 @@
 
 	&__input {
 		flex: 1;
+		min-width: 0;
 	}
 
 	&__button.components-button.is-small {

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -15,6 +15,7 @@ import SingleLineAnswer from './single-line';
 import TrueFalseAnswer from './true-false';
 import {
 	QuestionAnswerFeedbackSettings,
+	QuestionGradeSettings,
 	QuestionGradingNotesSettings,
 	QuestionMultipleChoiceSettings,
 } from '../question-block/settings';
@@ -38,6 +39,7 @@ const questionTypes = {
 		description: __( 'Select from a list of options.', 'sensei-lms' ),
 		edit: MultipleChoiceAnswer,
 		settings: [
+			QuestionGradeSettings,
 			QuestionMultipleChoiceSettings,
 			QuestionAnswerFeedbackSettings,
 		],
@@ -49,13 +51,13 @@ const questionTypes = {
 			'sensei-lms'
 		),
 		edit: TrueFalseAnswer,
-		settings: [ QuestionAnswerFeedbackSettings ],
+		settings: [ QuestionGradeSettings, QuestionAnswerFeedbackSettings ],
 	},
 	'gap-fill': {
 		title: __( 'Gap Fill', 'sensei-lms' ),
 		description: __( 'Fill in the blank.', 'sensei-lms' ),
 		edit: GapFillAnswer,
-		settings: [ QuestionAnswerFeedbackSettings ],
+		settings: [ QuestionGradeSettings, QuestionAnswerFeedbackSettings ],
 	},
 	'single-line': {
 		title: __( 'Single-line', 'sensei-lms' ),
@@ -64,7 +66,7 @@ const questionTypes = {
 			'sensei-lms'
 		),
 		edit: SingleLineAnswer,
-		settings: [ QuestionGradingNotesSettings ],
+		settings: [ QuestionGradeSettings, QuestionGradingNotesSettings ],
 	},
 	'multi-line': {
 		title: __( 'Multi-line', 'sensei-lms' ),
@@ -73,13 +75,13 @@ const questionTypes = {
 			'sensei-lms'
 		),
 		edit: MultiLineAnswer,
-		settings: [ QuestionGradingNotesSettings ],
+		settings: [ QuestionGradeSettings, QuestionGradingNotesSettings ],
 	},
 	'file-upload': {
 		title: __( 'File Upload', 'sensei-lms' ),
 		description: __( 'Upload a file or document.', 'sensei-lms' ),
 		edit: FileUploadAnswer,
-		settings: [ QuestionGradingNotesSettings ],
+		settings: [ QuestionGradeSettings, QuestionGradingNotesSettings ],
 	},
 };
 

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -3,6 +3,7 @@ import { applyFilters } from '@wordpress/hooks';
 import {
 	QuestionAnswerFeedbackSettings,
 	QuestionGradingNotesSettings,
+	QuestionMultipleChoiceSettings,
 } from '../question-block/settings';
 import FileUploadAnswer from './file-upload';
 import GapFillAnswer from './gap-fill';
@@ -29,7 +30,10 @@ const questionTypes = {
 		title: __( 'Multiple Choice', 'sensei-lms' ),
 		description: __( 'Select from a list of options.', 'sensei-lms' ),
 		edit: MultipleChoiceAnswer,
-		settings: [ QuestionAnswerFeedbackSettings ],
+		settings: [
+			QuestionMultipleChoiceSettings,
+			QuestionAnswerFeedbackSettings,
+		],
 	},
 	truefalse: {
 		title: __( 'True / False', 'sensei-lms' ),

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -1,5 +1,9 @@
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
+import {
+	QuestionAnswerFeedbackSettings,
+	QuestionGradingNotesSettings,
+} from '../question-block/settings';
 import FileUploadAnswer from './file-upload';
 import GapFillAnswer from './gap-fill';
 import MultiLineAnswer from './multi-line';
@@ -25,6 +29,7 @@ const questionTypes = {
 		title: __( 'Multiple Choice', 'sensei-lms' ),
 		description: __( 'Select from a list of options.', 'sensei-lms' ),
 		edit: MultipleChoiceAnswer,
+		settings: [ QuestionAnswerFeedbackSettings ],
 	},
 	truefalse: {
 		title: __( 'True / False', 'sensei-lms' ),
@@ -33,11 +38,13 @@ const questionTypes = {
 			'sensei-lms'
 		),
 		edit: TrueFalseAnswer,
+		settings: [ QuestionAnswerFeedbackSettings ],
 	},
 	gap: {
 		title: __( 'Gap Fill', 'sensei-lms' ),
 		description: __( 'Fill in the blank.', 'sensei-lms' ),
 		edit: GapFillAnswer,
+		settings: [ QuestionAnswerFeedbackSettings ],
 	},
 	'single-line': {
 		title: __( 'Single-line', 'sensei-lms' ),
@@ -46,6 +53,7 @@ const questionTypes = {
 			'sensei-lms'
 		),
 		edit: SingleLineAnswer,
+		settings: [ QuestionGradingNotesSettings ],
 	},
 	'multi-line': {
 		title: __( 'Multi-line', 'sensei-lms' ),
@@ -54,11 +62,13 @@ const questionTypes = {
 			'sensei-lms'
 		),
 		edit: MultiLineAnswer,
+		settings: [ QuestionGradingNotesSettings ],
 	},
 	'file-upload': {
 		title: __( 'File Upload', 'sensei-lms' ),
 		description: __( 'Upload a file or document.', 'sensei-lms' ),
 		edit: FileUploadAnswer,
+		settings: [ QuestionGradingNotesSettings ],
 	},
 };
 

--- a/assets/blocks/quiz/question-block/block.json
+++ b/assets/blocks/quiz/question-block/block.json
@@ -18,6 +18,9 @@
     },
     "answer": {
       "type": "object"
+    },
+    "options": {
+      "type": "object"
     }
   }
 }

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -139,6 +139,7 @@ $block: '.sensei-lms-question-block';
 				background: var(--wp-admin-theme-color, #333);
 				color: #fff;
 				align-items: center;
+
 				* {
 					background: none;
 					color: inherit;
@@ -172,6 +173,31 @@ $block: '.sensei-lms-question-block';
 			line-height: inherit;
 			text-align: right;
 		}
+	}
+
+	&__grade-control {
+
+		.components-base-control__label {
+			margin-bottom: 8px;
+			display: block;
+		}
+
+		&__controls {
+			display: flex;
+
+			input {
+				min-width: 0;
+			}
+
+			.components-button.is-small {
+				height: auto;
+			}
+
+			> * + * {
+				margin-left: 8px;
+			}
+		}
+
 	}
 
 

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -176,31 +176,4 @@ $block: '.sensei-lms-question-block';
 			text-align: right;
 		}
 	}
-
-	&__grade-control {
-
-		.components-base-control__label {
-			margin-bottom: 8px;
-			display: block;
-		}
-
-		&__controls {
-			display: flex;
-
-			input {
-				min-width: 0;
-			}
-
-			.components-button.is-small {
-				height: auto;
-			}
-
-			> * + * {
-				margin-left: 8px;
-			}
-		}
-
-	}
-
-
 }

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -77,7 +77,9 @@ $block: '.sensei-lms-question-block';
 				list-style: none;
 			}
 		}
+	}
 
+	&__answer--multiple-choice, &__answer--true-false {
 		&__hint {
 			text-transform: uppercase;
 			color: inherit;

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -103,7 +103,7 @@ const QuestionEdit = ( props ) => {
 					/>
 				</>
 			</BlockControls>
-			<QuestionSettings { ...props } />
+			<QuestionSettings controls={ AnswerBlock?.settings } { ...props } />
 		</div>
 	);
 };

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -13,6 +13,7 @@ import { useBlockIndex } from '../../../shared/blocks/block-index';
 import { useHasSelected } from '../../../shared/helpers/blocks';
 import SingleLineInput from '../../../shared/blocks/single-line-input';
 import types from '../answer-blocks';
+import QuestionSettings from './question-settings';
 import { QuestionTypeToolbar } from './question-type-toolbar';
 
 /**
@@ -102,6 +103,7 @@ const QuestionEdit = ( props ) => {
 					/>
 				</>
 			</BlockControls>
+			<QuestionSettings { ...props } />
 		</div>
 	);
 };

--- a/assets/blocks/quiz/question-block/question-settings.js
+++ b/assets/blocks/quiz/question-block/question-settings.js
@@ -1,6 +1,7 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { QuestionGradeSettings } from './settings';
 
 /**
  * Question block settings controls.
@@ -18,6 +19,8 @@ const QuestionSettings = ( {
 } ) => {
 	const setOptions = ( next ) =>
 		setAttributes( { options: { ...options, ...next } } );
+
+	controls = [ QuestionGradeSettings, ...controls ];
 
 	return (
 		<InspectorControls>

--- a/assets/blocks/quiz/question-block/question-settings.js
+++ b/assets/blocks/quiz/question-block/question-settings.js
@@ -1,0 +1,43 @@
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Question block settings controls.
+ *
+ * @param {Object}     props                    Block props.
+ * @param {Function[]} props.controls           Additional setting controls.
+ * @param {Object}     props.attributes         Block attributes.
+ * @param {Object}     props.attributes.options Block options attribute.
+ * @param {Function}   props.setAttributes      Update block attributes.
+ */
+const QuestionSettings = ( {
+	controls = [],
+	attributes: { options = {} },
+	setAttributes,
+} ) => {
+	const setOptions = ( next ) =>
+		setAttributes( { options: { ...options, ...next } } );
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Question Settings', 'sensei-lms' ) }
+				initialOpen={ true }
+			>
+				{ controls.map( ( SettingControl ) => (
+					<SettingControl
+						key={ SettingControl }
+						{ ...{ options, setOptions } }
+					/>
+				) ) }
+			</PanelBody>
+			<PanelBody
+				title={ __( 'Question Categories', 'sensei-lms' ) }
+				initialOpen={ false }
+			></PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default QuestionSettings;

--- a/assets/blocks/quiz/question-block/question-settings.js
+++ b/assets/blocks/quiz/question-block/question-settings.js
@@ -16,6 +16,7 @@ const QuestionSettings = ( {
 	controls = [],
 	attributes: { options = {} },
 	setAttributes,
+	...props
 } ) => {
 	const setOptions = ( next ) =>
 		setAttributes( { options: { ...options, ...next } } );
@@ -31,6 +32,7 @@ const QuestionSettings = ( {
 				{ controls.map( ( SettingControl ) => (
 					<SettingControl
 						key={ SettingControl }
+						{ ...props }
 						{ ...{ options, setOptions } }
 					/>
 				) ) }

--- a/assets/blocks/quiz/question-block/question-settings.js
+++ b/assets/blocks/quiz/question-block/question-settings.js
@@ -1,6 +1,13 @@
+/**
+ * WordPress dependencies
+ */
 import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { QuestionGradeSettings } from './settings';
 
 /**

--- a/assets/blocks/quiz/question-block/question-settings.js
+++ b/assets/blocks/quiz/question-block/question-settings.js
@@ -6,11 +6,6 @@ import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
- */
-import { QuestionGradeSettings } from './settings';
-
-/**
  * Question block settings controls.
  *
  * @param {Object}     props                    Block props.
@@ -27,8 +22,6 @@ const QuestionSettings = ( {
 } ) => {
 	const setOptions = ( next ) =>
 		setAttributes( { options: { ...options, ...next } } );
-
-	controls = [ QuestionGradeSettings, ...controls ];
 
 	return (
 		<InspectorControls>

--- a/assets/blocks/quiz/question-block/settings/index.js
+++ b/assets/blocks/quiz/question-block/settings/index.js
@@ -1,1 +1,3 @@
+export { default as QuestionAnswerFeedbackSettings } from './question-answer-feedback-settings';
+export { default as QuestionGradingNotesSettings } from './question-grading-notes-settings';
 export { default as QuestionGradeSettings } from './question-grade-settings';

--- a/assets/blocks/quiz/question-block/settings/index.js
+++ b/assets/blocks/quiz/question-block/settings/index.js
@@ -1,0 +1,1 @@
+export { default as QuestionGradeSettings } from './question-grade-settings';

--- a/assets/blocks/quiz/question-block/settings/index.js
+++ b/assets/blocks/quiz/question-block/settings/index.js
@@ -1,3 +1,4 @@
 export { default as QuestionAnswerFeedbackSettings } from './question-answer-feedback-settings';
 export { default as QuestionGradingNotesSettings } from './question-grading-notes-settings';
 export { default as QuestionGradeSettings } from './question-grade-settings';
+export { default as QuestionMultipleChoiceSettings } from './question-multiple-choice-settings';

--- a/assets/blocks/quiz/question-block/settings/question-answer-feedback-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-answer-feedback-settings.js
@@ -1,0 +1,27 @@
+import { TextareaControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Question block answer feedback settings control.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.options
+ * @param {string}   props.options.answerFeedback Learner feedback.
+ * @param {Function} props.setOptions
+ */
+const QuestionAnswerFeedbackSettings = ( {
+	options: { answerFeedback },
+	setOptions,
+} ) => (
+	<TextareaControl
+		label={ __( 'Answer Feedback', 'sensei-lms' ) }
+		onChange={ ( value ) => setOptions( { answerFeedback: value } ) }
+		value={ answerFeedback }
+		help={ __(
+			'Displayed to the user after the quiz has been graded.',
+			'sensei-lms'
+		) }
+	/>
+);
+
+export default QuestionAnswerFeedbackSettings;

--- a/assets/blocks/quiz/question-block/settings/question-answer-feedback-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-answer-feedback-settings.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { TextareaControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 

--- a/assets/blocks/quiz/question-block/settings/question-grade-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-grade-settings.js
@@ -1,0 +1,49 @@
+import { BaseControl, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Question block grade settings.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.options
+ * @param {number}   props.options.grade Question grade.
+ * @param {Function} props.setOptions
+ * @param {string}   props.clientId
+ */
+const QuestionGradeSettings = ( {
+	options: { grade = 1 },
+	setOptions,
+	clientId,
+} ) => {
+	const id = `sensei-lms-question-block__grade-control-${ clientId }`;
+	return (
+		<BaseControl
+			id={ id }
+			label={ __( 'Grade', 'sensei-lms' ) }
+			className="sensei-lms-question-block__grade-control"
+		>
+			<div className="sensei-lms-question-block__grade-control__controls">
+				<input
+					id={ id }
+					className=""
+					type="number"
+					min={ 1 }
+					step={ 1 }
+					value={ grade }
+					onChange={ ( event ) =>
+						setOptions( { grade: event.target.value } )
+					}
+				/>
+				<Button
+					isSmall
+					isSecondary
+					onClick={ () => setOptions( { grade: 1 } ) }
+				>
+					{ __( 'Reset', 'sensei-lms' ) }
+				</Button>
+			</div>
+		</BaseControl>
+	);
+};
+
+export default QuestionGradeSettings;

--- a/assets/blocks/quiz/question-block/settings/question-grade-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-grade-settings.js
@@ -1,5 +1,12 @@
-import { BaseControl, Button } from '@wordpress/components';
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import NumberControl from '../../../editor-components/number-control';
 
 /**
  * Question block grade settings.
@@ -17,32 +24,15 @@ const QuestionGradeSettings = ( {
 } ) => {
 	const id = `sensei-lms-question-block__grade-control-${ clientId }`;
 	return (
-		<BaseControl
+		<NumberControl
 			id={ id }
 			label={ __( 'Grade', 'sensei-lms' ) }
-			className="sensei-lms-question-block__grade-control"
-		>
-			<div className="sensei-lms-question-block__grade-control__controls">
-				<input
-					id={ id }
-					className=""
-					type="number"
-					min={ 1 }
-					step={ 1 }
-					value={ grade }
-					onChange={ ( event ) =>
-						setOptions( { grade: event.target.value } )
-					}
-				/>
-				<Button
-					isSmall
-					isSecondary
-					onClick={ () => setOptions( { grade: 1 } ) }
-				>
-					{ __( 'Reset', 'sensei-lms' ) }
-				</Button>
-			</div>
-		</BaseControl>
+			value={ grade }
+			onChange={ ( nextGrade ) =>
+				setOptions( { grade: nextGrade ?? 1 } )
+			}
+			allowReset={ true }
+		/>
 	);
 };
 

--- a/assets/blocks/quiz/question-block/settings/question-grade-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-grade-settings.js
@@ -27,6 +27,8 @@ const QuestionGradeSettings = ( {
 		<NumberControl
 			id={ id }
 			label={ __( 'Grade', 'sensei-lms' ) }
+			min={ 0 }
+			step={ 1 }
 			value={ grade }
 			onChange={ ( nextGrade ) =>
 				setOptions( { grade: nextGrade ?? 1 } )

--- a/assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js
@@ -1,0 +1,27 @@
+import { TextareaControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Question block grading notes settings control.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.options
+ * @param {string}   props.options.gradingNotes Notes for teacher when grading.
+ * @param {Function} props.setOptions
+ */
+const QuestionGradingNotesSettings = ( {
+	options: { gradingNotes },
+	setOptions,
+} ) => (
+	<TextareaControl
+		label={ __( 'Grading Notes', 'sensei-lms' ) }
+		onChange={ ( value ) => setOptions( { gradingNotes: value } ) }
+		value={ gradingNotes }
+		help={ __(
+			'Displayed to the teacher when grading the question.',
+			'sensei-lms'
+		) }
+	/>
+);
+
+export default QuestionGradingNotesSettings;

--- a/assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { TextareaControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 

--- a/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
@@ -1,0 +1,23 @@
+import { CheckboxControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Question block settings for multiple choice questions.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.options
+ * @param {boolean}  props.options.randomAnswerOrder Display answer options in random order.
+ * @param {Function} props.setOptions
+ */
+const QuestionMultipleChoiceSettings = ( {
+	options: { randomAnswerOrder = true },
+	setOptions,
+} ) => (
+	<CheckboxControl
+		label={ __( 'Random Order', 'sensei-lms' ) }
+		checked={ randomAnswerOrder }
+		onChange={ ( value ) => setOptions( { randomAnswerOrder: value } ) }
+	/>
+);
+
+export default QuestionMultipleChoiceSettings;


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Add settings to the question blocks, stored in the `options` attribute
* All question blocks: **Grade**
* True/false, multiple choice, gap fill: **Answer Feedback**
* Single line, multi line, file upload: **Grading Notes** (formerly Guide/Teacher Notes)
* Multi choice: **Random order**
* Add panel for question categories (not implemented in this PR)

### Testing instructions

* Add a quiz to the lesson with all type of questions
* Change the various settings from the sidebar
* Make sure they are persisted when saving the post. (In the post, this is not tied to the REST API)

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="280" alt="image" src="https://user-images.githubusercontent.com/176949/107983451-131ff000-6fc6-11eb-93bc-89ed94ff237d.png">
