### PR TITLE
Add Filter if you want to use Sensei Blocks

### DIFF
--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -41,7 +41,7 @@ class Sensei_Blocks {
 	 */
 	public function __construct( Sensei_Main $sensei ) {
 		// Skip if Gutenberg is not available.
-		if ( ! function_exists( 'register_block_type' ) ) {
+		if ( apply_filters('sensei_use_sensei_blocks', ! function_exists( 'register_block_type' ) ) ) {
 			return;
 		}
 

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -41,7 +41,7 @@ class Sensei_Blocks {
 	 */
 	public function __construct( Sensei_Main $sensei ) {
 		// Skip if Gutenberg is not available.
-		if ( apply_filters('sensei_use_sensei_blocks', ! function_exists( 'register_block_type' ) ) ) {
+		if ( apply_filters( 'sensei_use_sensei_blocks', ! function_exists( 'register_block_type' ) ) ) {
 			return;
 		}
 


### PR DESCRIPTION


Fixes #

### Changes proposed in this Pull Request

* It would be nice to have a filter if you don't want to use the blocks in general.
I love gutenberg for static pages but i think there are good reasons to stay with php templates for courses and lessons.

