### PR TITLE
Fix lesson module metabox saving with Yoast installed

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -291,10 +291,10 @@ class Sensei_Core_Modules {
 	 * @return mixed            Post ID on permissions failure, boolean true on success
 	 */
 	public function save_lesson_module( $post_id ) {
-		global $post;
+		$post = get_post( $post_id );
 
 		// Verify post type and nonce
-		if ( ( get_post_type() != 'lesson' ) || ! isset( $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ] )
+		if ( ( get_post_type( $post ) != 'lesson' ) || ! isset( $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ] )
 			|| ! wp_verify_nonce( $_POST[ 'woo_lesson_' . $this->taxonomy . '_nonce' ], plugin_basename( $this->file ) ) ) {
 			return $post_id;
 		}


### PR DESCRIPTION
Fixes #3977

### Changes proposed in this Pull Request

Tweak metabox saving code for lesson module metabox.

### Notes

The `$post` variable and the `$post_id` for the `save_lesson_module` method did not always match. Specifically, when saving the Lesson metaboxes, the Lesson's Quiz is also saved. At that point, the global `$post` variable was set to the Quiz, not the Lesson. For some reason, when Yoast is installed, that variable does not get set back to the Lesson. In my testing, the Lesson Module metabox was processed later than the Quiz, and the incorrect `$post` variable caused the method not to run.

This change ensures that the `$post` variable in the function matches the given `$post_id`, regardless of the global `$post`.

### Testing instructions

* See the issue to reproduce the bug.
* Ensure that changing the Lesson's Module works now.
* Try editing the Lesson's Quiz, and make sure that still works properly.
