### PR TITLE
Restrict one quiz per lesson

### DIFF
--- a/assets/blocks/quiz/quiz-block/block.json
+++ b/assets/blocks/quiz/quiz-block/block.json
@@ -11,6 +11,10 @@
     },
     "options": {
       "type": "object"
+		},
+    "isPostTemplate": {
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -30,7 +30,11 @@ const QuizEdit = ( props ) => {
 			<div className="sensei-lms-quiz-block__separator">
 				<span>{ __( 'Lesson Quiz', 'sensei-lms' ) }</span>
 			</div>
-			<InnerBlocks allowedBlocks={ [ 'sensei-lms/quiz-question' ] } />
+			<InnerBlocks
+				allowedBlocks={ [ 'sensei-lms/quiz-question' ] }
+				template={ [ [ 'sensei-lms/quiz-question', {} ] ] }
+				templateInsertUpdatesSelection={ false }
+			/>
 			<div className="sensei-lms-quiz-block__separator" />
 			<QuizSettings { ...props } />
 		</>

--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -25,6 +25,8 @@ const QuizEdit = ( props ) => {
 		props
 	);
 
+	const { isPostTemplate } = props.attributes;
+
 	return (
 		<>
 			<div className="sensei-lms-quiz-block__separator">
@@ -32,7 +34,9 @@ const QuizEdit = ( props ) => {
 			</div>
 			<InnerBlocks
 				allowedBlocks={ [ 'sensei-lms/quiz-question' ] }
-				template={ [ [ 'sensei-lms/quiz-question', {} ] ] }
+				template={
+					isPostTemplate ? [ [ 'sensei-lms/quiz-question', {} ] ] : []
+				}
 				templateInsertUpdatesSelection={ false }
 			/>
 			<div className="sensei-lms-quiz-block__separator" />

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -71,6 +71,10 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 			[ 'sensei-lms/lesson-actions' ],
 		];
 
+		if ( Sensei()->feature_flags->is_enabled( 'quiz_blocks' ) ) {
+			$post_type_object->template[] = [ 'sensei-lms/quiz' ];
+		}
+
 		if ( ! Sensei()->lesson->has_sensei_blocks() ) {
 			return;
 		}

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -72,7 +72,7 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		];
 
 		if ( Sensei()->feature_flags->is_enabled( 'quiz_blocks' ) ) {
-			$post_type_object->template[] = [ 'sensei-lms/quiz' ];
+			$post_type_object->template[] = [ 'sensei-lms/quiz', [ 'isPostTemplate' => true ] ];
 		}
 
 		if ( ! Sensei()->lesson->has_sensei_blocks() ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Allow only one quiz per post.
* Add quiz to the lesson blocks template (also restricted by `quiz_blocks` feature flag).
* This PR also adds a template to the quiz InnerBlocks containing an empty question. So it always starts with an empty question. Previously it was always adding the empty question because of the `useAutoInserter` feature. But it depends on having the focus on the block, that happens when adding a new block, but not when it's added through the template.

### Testing instructions

* Add a new lesson.
* Make sure a quiz was added to the end of the blocks template.
* Make sure you can't add one more quiz.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="993" alt="Screen Shot 2021-02-16 at 17 53 18" src="https://user-images.githubusercontent.com/876340/108120336-e29c8c80-707f-11eb-92af-00ed492e86d3.png">
