### PR TITLE
Add quiz settings

### DIFF
--- a/assets/blocks/editor-components/editor-components-style.scss
+++ b/assets/blocks/editor-components/editor-components-style.scss
@@ -1,1 +1,2 @@
+@import './number-control/number-control';
 @import './toolbar-dropdown/toolbar-dropdown';

--- a/assets/blocks/editor-components/number-control/index.js
+++ b/assets/blocks/editor-components/number-control/index.js
@@ -30,18 +30,26 @@ const NumberControl = ( {
 	...props
 } ) => (
 	<BaseControl id={ id } label={ label } help={ help }>
-		<input
-			type="number"
-			id={ id }
-			onChange={ ( e ) => onChange( parseInt( e.target.value, 10 ) ) }
-			value={ null === value ? '' : value }
-			{ ...props }
-		/>
-		{ allowReset && (
-			<Button isSmall isSecondary onClick={ () => onChange( null ) }>
-				{ resetLabel || __( 'Reset', 'sensei-lms' ) }
-			</Button>
-		) }
+		<div className="sensei-number-control">
+			<input
+				className="sensei-number-control__input"
+				type="number"
+				id={ id }
+				onChange={ ( e ) => onChange( parseInt( e.target.value, 10 ) ) }
+				value={ null === value ? '' : value }
+				{ ...props }
+			/>
+			{ allowReset && (
+				<Button
+					className="sensei-number-control__button"
+					isSmall
+					isSecondary
+					onClick={ () => onChange( null ) }
+				>
+					{ resetLabel || __( 'Reset', 'sensei-lms' ) }
+				</Button>
+			) }
+		</div>
 	</BaseControl>
 );
 

--- a/assets/blocks/editor-components/number-control/index.js
+++ b/assets/blocks/editor-components/number-control/index.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import { BaseControl, Button } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Number control component.
+ *
+ * It can use or be replaced by the
+ * WordPress [NumberControl]{@link https://github.com/WordPress/gutenberg/tree/master/packages/components/src/number-control} when it's stable.
+ *
+ * @param {Object}   props                    Component props.
+ * @param {string}   [props.id]               Component id used to connect label and input - required if label is set.
+ * @param {string}   [props.label]            Input label.
+ * @param {number}   [props.value]            Input value.
+ * @param {string}   [props.help]             Help text.
+ * @param {boolean}  [props.allowReset=false] Whether reset is allowed.
+ * @param {string}   [props.resetLabel]       Reset button custom label.
+ * @param {Function} props.onChange           Change function, which receives value as argument.
+ */
+const NumberControl = ( {
+	id,
+	label,
+	value,
+	help,
+	allowReset = false,
+	resetLabel,
+	onChange,
+	...props
+} ) => (
+	<BaseControl id={ id } label={ label } help={ help }>
+		<input
+			type="number"
+			id={ id }
+			onChange={ ( e ) => onChange( e.target.value ) }
+			value={ null === value ? '' : value }
+			{ ...props }
+		/>
+		{ allowReset && (
+			<Button isSmall isSecondary onClick={ () => onChange( null ) }>
+				{ resetLabel || __( 'Reset', 'sensei-lms' ) }
+			</Button>
+		) }
+	</BaseControl>
+);
+
+export default NumberControl;

--- a/assets/blocks/editor-components/number-control/index.js
+++ b/assets/blocks/editor-components/number-control/index.js
@@ -17,7 +17,7 @@ import { __ } from '@wordpress/i18n';
  * @param {string}   [props.help]             Help text.
  * @param {boolean}  [props.allowReset=false] Whether reset is allowed.
  * @param {string}   [props.resetLabel]       Reset button custom label.
- * @param {Function} props.onChange           Change function, which receives value as argument.
+ * @param {Function} props.onChange           Change function, which receives number as argument.
  */
 const NumberControl = ( {
 	id,
@@ -33,7 +33,7 @@ const NumberControl = ( {
 		<input
 			type="number"
 			id={ id }
-			onChange={ ( e ) => onChange( e.target.value ) }
+			onChange={ ( e ) => onChange( parseInt( e.target.value, 10 ) ) }
 			value={ null === value ? '' : value }
 			{ ...props }
 		/>

--- a/assets/blocks/editor-components/number-control/index.test.js
+++ b/assets/blocks/editor-components/number-control/index.test.js
@@ -1,0 +1,65 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import NumberControl from './index';
+
+describe( '<NumberControl />', () => {
+	it( 'Should render the input with the correct value', () => {
+		const { queryByDisplayValue } = render(
+			<NumberControl value={ 10 } />
+		);
+
+		expect( queryByDisplayValue( '10' ) ).toBeTruthy();
+	} );
+
+	it( 'Should render with label', () => {
+		const { queryByLabelText } = render(
+			<NumberControl id="test" label="Test" value={ 10 } />
+		);
+
+		expect( queryByLabelText( 'Test' ).value ).toEqual( '10' );
+	} );
+
+	it( 'Should render with reset button', () => {
+		const { queryByText } = render( <NumberControl allowReset /> );
+
+		expect( queryByText( 'Reset' ) ).toBeTruthy();
+	} );
+
+	it( 'Should render with reset button with custom label', () => {
+		const { queryByText } = render(
+			<NumberControl allowReset resetLabel="Custom reset" />
+		);
+
+		expect( queryByText( 'Custom reset' ) ).toBeTruthy();
+	} );
+
+	it( 'Should call the change event', () => {
+		const onChangeMock = jest.fn();
+		const { queryByDisplayValue } = render(
+			<NumberControl value={ 10 } onChange={ onChangeMock } />
+		);
+
+		fireEvent.change( queryByDisplayValue( '10' ), {
+			target: { value: '20' },
+		} );
+
+		expect( onChangeMock ).toBeCalledWith( 20 );
+	} );
+
+	it( 'Should call the change event with null when resetting', () => {
+		const onChangeMock = jest.fn();
+		const { queryByText } = render(
+			<NumberControl value={ 10 } allowReset onChange={ onChangeMock } />
+		);
+
+		fireEvent.click( queryByText( 'Reset' ) );
+
+		expect( onChangeMock ).toBeCalledWith( null );
+	} );
+} );

--- a/assets/blocks/editor-components/number-control/number-control.scss
+++ b/assets/blocks/editor-components/number-control/number-control.scss
@@ -1,0 +1,13 @@
+.sensei-number-control {
+	display: flex;
+	justify-content: space-between;
+
+	&__input {
+		flex: 1;
+	}
+
+	&__button.components-button.is-small {
+		height: auto;
+		margin-left: 8px;
+	}
+}

--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import { useAutoInserter } from '../../../shared/blocks/use-auto-inserter';
 import questionBlock from '../question-block';
 import { useQuizStructure } from '../quiz-store';
+import QuizSettings from './quiz-settings';
 
 /**
  * Quiz block editor.
@@ -31,6 +32,7 @@ const QuizEdit = ( props ) => {
 			</div>
 			<InnerBlocks allowedBlocks={ [ 'sensei-lms/quiz-question' ] } />
 			<div className="sensei-lms-quiz-block__separator" />
+			<QuizSettings { ...props } />
 		</>
 	);
 };

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -56,7 +56,7 @@ const QuizSettings = ( { attributes: { options = {} }, setAttributes } ) => {
 				{ passRequired && (
 					<PanelRow>
 						<RangeControl
-							label={ 'Passing Grade' }
+							label={ 'Passing Grade (%)' }
 							value={ quizPassmark }
 							onChange={ createChangeHandler( 'quizPassmark' ) }
 							min={ 0 }

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -46,7 +46,7 @@ const QuizSettings = ( { attributes: { options = {} }, setAttributes } ) => {
 					<ToggleControl
 						checked={ passRequired }
 						onChange={ createChangeHandler( 'passRequired' ) }
-						label={ __( 'Pass required', 'sensei-lms' ) }
+						label={ __( 'Pass Required', 'sensei-lms' ) }
 					/>
 				</PanelRow>
 				{ passRequired && (

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -67,7 +67,7 @@ const QuizSettings = ( { attributes: { options = {} }, setAttributes } ) => {
 						onChange={ createChangeHandler( 'autoGrade' ) }
 						label={ __( 'Auto Grade', 'sensei-lms' ) }
 						help={ __(
-							'Only applicable for multiple choice, true/false abd gap fill questions.',
+							'Only applicable for multiple choice, true/false and gap fill questions.',
 							'sensei-lms'
 						) }
 					/>

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -71,7 +71,7 @@ const QuizSettings = ( { attributes: { options = {} }, setAttributes } ) => {
 						onChange={ createChangeHandler( 'autoGrade' ) }
 						label={ __( 'Auto Grade', 'sensei-lms' ) }
 						help={ __(
-							'Only applicable for multiple choice, true/false and gap fill questions.',
+							'Grades quiz and displays answer explanation immediately after completion. Only applicable if quiz is limited to Multiple Choice, True/False and Gap Fill questions. Questions that have a grade of zero are skipped during autograding.',
 							'sensei-lms'
 						) }
 					/>

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -25,12 +25,12 @@ import NumberControl from '../../editor-components/number-control';
  */
 const QuizSettings = ( { attributes: { options = {} }, setAttributes } ) => {
 	const {
-		passRequired,
-		quizPassmark,
-		autoGrade,
-		allowRetakes,
-		randomQuestionOrder,
-		showQuestions,
+		passRequired = false,
+		quizPassmark = 100,
+		autoGrade = true,
+		allowRetakes = true,
+		randomQuestionOrder = false,
+		showQuestions = null,
 	} = options;
 
 	const createChangeHandler = ( optionKey ) => ( value ) =>

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -1,0 +1,120 @@
+/**
+ * WordPress dependencies
+ */
+import { InspectorControls } from '@wordpress/block-editor';
+import {
+	BaseControl,
+	Button,
+	PanelBody,
+	PanelRow,
+	RangeControl,
+	ToggleControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Quiz settings.
+ *
+ * @param {Object}   props                    Block props.
+ * @param {Object}   props.attributes         Block attributes
+ * @param {Object}   props.attributes.options Current setting options.
+ * @param {Function} props.setAttributes      Set attributes function.
+ */
+const QuizSettings = ( { attributes: { options = {} }, setAttributes } ) => {
+	const {
+		passRequired,
+		quizPassmark,
+		autoGrade,
+		allowRetakes,
+		randomQuestionOrder,
+		showQuestions,
+	} = options;
+
+	const createChangeHandler = ( optionKey ) => ( value ) =>
+		setAttributes( { options: { ...options, [ optionKey ]: value } } );
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Quiz Settings', 'sensei-lms' ) }
+				initialOpen={ true }
+			>
+				<PanelRow>
+					<ToggleControl
+						checked={ passRequired }
+						onChange={ createChangeHandler( 'passRequired' ) }
+						label={ __( 'Pass required', 'sensei-lms' ) }
+					/>
+				</PanelRow>
+				{ passRequired && (
+					<PanelRow>
+						<RangeControl
+							label={ 'Passing Grade' }
+							value={ quizPassmark }
+							onChange={ createChangeHandler( 'quizPassmark' ) }
+							min={ 0 }
+							max={ 100 }
+							initialPosition={ 100 }
+						/>
+					</PanelRow>
+				) }
+				<PanelRow>
+					<ToggleControl
+						checked={ autoGrade }
+						onChange={ createChangeHandler( 'autoGrade' ) }
+						label={ __( 'Auto Grade', 'sensei-lms' ) }
+						help={ __(
+							'Only applicable for multiple choice, true/false abd gap fill questions.',
+							'sensei-lms'
+						) }
+					/>
+				</PanelRow>
+				<PanelRow>
+					<ToggleControl
+						checked={ allowRetakes }
+						onChange={ createChangeHandler( 'allowRetakes' ) }
+						label={ __( 'Allow Retakes', 'sensei-lms' ) }
+					/>
+				</PanelRow>
+				<PanelRow>
+					<ToggleControl
+						checked={ randomQuestionOrder }
+						onChange={ createChangeHandler(
+							'randomQuestionOrder'
+						) }
+						label={ __( 'Random Question Order', 'sensei-lms' ) }
+					/>
+				</PanelRow>
+				<PanelRow>
+					<BaseControl
+						id="sensei-quiz-settings-show-questions"
+						label={ __( 'Number of Questions', 'sensei-lms' ) }
+						help={ __(
+							'Display a random selection of questions.',
+							'sensei-lms'
+						) }
+					>
+						<input
+							type="number"
+							id="sensei-quiz-settings-show-questions"
+							min={ 0 }
+							step={ 1 }
+							value={ showQuestions }
+							placeholder={ __( 'All', 'sensei-lms' ) }
+							onChange={ ( e ) =>
+								createChangeHandler( 'showQuestions' )(
+									e.value
+								)
+							}
+						/>
+						<Button isSmall isSecondary onClick={ () => {} }>
+							{ __( 'All', 'sensei-lms' ) }
+						</Button>
+					</BaseControl>
+				</PanelRow>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default QuizSettings;

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -3,14 +3,17 @@
  */
 import { InspectorControls } from '@wordpress/block-editor';
 import {
-	BaseControl,
-	Button,
 	PanelBody,
 	PanelRow,
 	RangeControl,
 	ToggleControl,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import NumberControl from '../../editor-components/number-control';
 
 /**
  * Quiz settings.
@@ -86,31 +89,21 @@ const QuizSettings = ( { attributes: { options = {} }, setAttributes } ) => {
 					/>
 				</PanelRow>
 				<PanelRow>
-					<BaseControl
+					<NumberControl
 						id="sensei-quiz-settings-show-questions"
 						label={ __( 'Number of Questions', 'sensei-lms' ) }
 						help={ __(
 							'Display a random selection of questions.',
 							'sensei-lms'
 						) }
-					>
-						<input
-							type="number"
-							id="sensei-quiz-settings-show-questions"
-							min={ 0 }
-							step={ 1 }
-							value={ showQuestions }
-							placeholder={ __( 'All', 'sensei-lms' ) }
-							onChange={ ( e ) =>
-								createChangeHandler( 'showQuestions' )(
-									e.value
-								)
-							}
-						/>
-						<Button isSmall isSecondary onClick={ () => {} }>
-							{ __( 'All', 'sensei-lms' ) }
-						</Button>
-					</BaseControl>
+						allowReset
+						resetLabel={ __( 'All', 'sensei-lms' ) }
+						min={ 0 }
+						step={ 1 }
+						value={ showQuestions }
+						placeholder={ __( 'All', 'sensei-lms' ) }
+						onChange={ createChangeHandler( 'showQuestions' ) }
+					/>
 				</PanelRow>
 			</PanelBody>
 		</InspectorControls>

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -47,6 +47,10 @@ const QuizSettings = ( { attributes: { options = {} }, setAttributes } ) => {
 						checked={ passRequired }
 						onChange={ createChangeHandler( 'passRequired' ) }
 						label={ __( 'Pass Required', 'sensei-lms' ) }
+						help={ __(
+							'Require passing the quiz to complete lesson.',
+							'sensei-lms'
+						) }
 					/>
 				</PanelRow>
 				{ passRequired && (

--- a/assets/blocks/quiz/quiz-block/quiz-settings.test.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.test.js
@@ -31,7 +31,7 @@ describe( '<QuizSettings />', () => {
 		);
 
 		expect( queryByLabelText( 'Pass Required' ).checked ).toEqual( true );
-		expect( queryAllByLabelText( 'Passing Grade' )[ 0 ].value ).toEqual(
+		expect( queryAllByLabelText( 'Passing Grade (%)' )[ 0 ].value ).toEqual(
 			'50'
 		);
 		expect( queryByLabelText( 'Auto Grade' ).checked ).toEqual( false );
@@ -55,7 +55,7 @@ describe( '<QuizSettings />', () => {
 			/>
 		);
 
-		expect( queryByLabelText( 'Passing Grade' ) ).toBeFalsy();
+		expect( queryByLabelText( 'Passing Grade (%)' ) ).toBeFalsy();
 	} );
 
 	it( 'Should call the setAttributes correctly when changing the fields', () => {
@@ -84,7 +84,7 @@ describe( '<QuizSettings />', () => {
 			},
 		} );
 
-		fireEvent.change( queryAllByLabelText( 'Passing Grade' )[ 0 ], {
+		fireEvent.change( queryAllByLabelText( 'Passing Grade (%)' )[ 0 ], {
 			target: { value: '50' },
 		} );
 		expect( setAttributesMock ).toBeCalledWith( {

--- a/assets/blocks/quiz/quiz-block/quiz-settings.test.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.test.js
@@ -1,0 +1,131 @@
+/**
+ * External dependencies
+ */
+import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import QuizSettings from './quiz-settings';
+
+jest.mock( '@wordpress/block-editor', () => ( {
+	...jest.requireActual( '@wordpress/block-editor' ),
+	InspectorControls: ( { children } ) => children,
+} ) );
+
+describe( '<QuizSettings />', () => {
+	it( 'Should render the settings with the defined values', () => {
+		const { queryByLabelText, queryAllByLabelText } = render(
+			<QuizSettings
+				attributes={ {
+					options: {
+						passRequired: true,
+						quizPassmark: 50,
+						autoGrade: false,
+						allowRetakes: false,
+						randomQuestionOrder: true,
+						showQuestions: 5,
+					},
+				} }
+			/>
+		);
+
+		expect( queryByLabelText( 'Pass Required' ).checked ).toEqual( true );
+		expect( queryAllByLabelText( 'Passing Grade' )[ 0 ].value ).toEqual(
+			'50'
+		);
+		expect( queryByLabelText( 'Auto Grade' ).checked ).toEqual( false );
+		expect( queryByLabelText( 'Allow Retakes' ).checked ).toEqual( false );
+		expect( queryByLabelText( 'Random Question Order' ).checked ).toEqual(
+			true
+		);
+		expect( queryByLabelText( 'Number of Questions' ).value ).toEqual(
+			'5'
+		);
+	} );
+
+	it( 'Should not render the Passing Grade field when Pass Required is false', () => {
+		const { queryByLabelText } = render(
+			<QuizSettings
+				attributes={ {
+					options: {
+						passRequired: false,
+					},
+				} }
+			/>
+		);
+
+		expect( queryByLabelText( 'Passing Grade' ) ).toBeFalsy();
+	} );
+
+	it( 'Should call the setAttributes correctly when changing the fields', () => {
+		const defaultOptions = {
+			passRequired: true,
+			quizPassmark: 0,
+			autoGrade: true,
+			allowRetakes: true,
+			randomQuestionOrder: true,
+			showQuestions: 0,
+		};
+		const setAttributesMock = jest.fn();
+
+		const { queryByLabelText, queryAllByLabelText } = render(
+			<QuizSettings
+				attributes={ { options: defaultOptions } }
+				setAttributes={ setAttributesMock }
+			/>
+		);
+
+		fireEvent.click( queryByLabelText( 'Pass Required' ) );
+		expect( setAttributesMock ).toBeCalledWith( {
+			options: {
+				...defaultOptions,
+				passRequired: false,
+			},
+		} );
+
+		fireEvent.change( queryAllByLabelText( 'Passing Grade' )[ 0 ], {
+			target: { value: '50' },
+		} );
+		expect( setAttributesMock ).toBeCalledWith( {
+			options: {
+				...defaultOptions,
+				quizPassmark: 50,
+			},
+		} );
+
+		fireEvent.click( queryByLabelText( 'Auto Grade' ) );
+		expect( setAttributesMock ).toBeCalledWith( {
+			options: {
+				...defaultOptions,
+				passRequired: false,
+			},
+		} );
+
+		fireEvent.click( queryByLabelText( 'Allow Retakes' ) );
+		expect( setAttributesMock ).toBeCalledWith( {
+			options: {
+				...defaultOptions,
+				allowRetakes: false,
+			},
+		} );
+
+		fireEvent.click( queryByLabelText( 'Random Question Order' ) );
+		expect( setAttributesMock ).toBeCalledWith( {
+			options: {
+				...defaultOptions,
+				randomQuestionOrder: false,
+			},
+		} );
+
+		fireEvent.change( queryByLabelText( 'Number of Questions' ), {
+			target: { value: '10' },
+		} );
+		expect( setAttributesMock ).toBeCalledWith( {
+			options: {
+				...defaultOptions,
+				showQuestions: 10,
+			},
+		} );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds the quiz settings.

This PR doesn't include:

* Sync with the API.
* After https://github.com/Automattic/sensei/pull/3979 gets merged, we can refactor the _question grade setting_ to use the same `NumberControl` component.

### Testing instructions

* Add a quiz block to a lesson.
* Change the settings in the sidebar, and make sure everything is changed/saved properly.
* The _Passing Grade_ field is shown conditionally based on the _Passing Required_ selection.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/108271433-91f46480-714f-11eb-994d-240fc5d5af7a.mov

