### PR TITLE
Enrollment Debug: Handle exceptions in enrollment providers better

### DIFF
--- a/assets/css/enrolment-debug.scss
+++ b/assets/css/enrolment-debug.scss
@@ -99,8 +99,14 @@ $neutral_bg: rgba( 0, 0, 0, 0.1 );
 			}
 
 			.content {
-				flex: 3;
+				flex: 5;
 				display: inline;
+
+				details {
+					max-width: 500px;
+					max-height: 200px;
+					overflow: scroll;
+				}
 			}
 
 			.history-item {

--- a/includes/admin/tools/views/html-enrolment-debug.php
+++ b/includes/admin/tools/views/html-enrolment-debug.php
@@ -134,10 +134,12 @@ $allowed_debug_html = [
 				echo '</div>';
 			}
 
-			echo '<div class="info info-neutral">';
-			// translators: %s placeholder is datetime results were last calculated.
-			echo esc_html( sprintf( __( 'Last calculated on %s', 'sensei-lms' ), $results['results_time'] ) );
-			echo '</div>';
+			if ( $results['results_time'] ) {
+				echo '<div class="info info-neutral">';
+				// translators: %s placeholder is datetime results were last calculated.
+				echo esc_html( sprintf( __( 'Last calculated on %s', 'sensei-lms' ), $results['results_time'] ) );
+				echo '</div>';
+			}
 			?>
 		</td>
 	</tr>
@@ -204,7 +206,21 @@ $allowed_debug_html = [
 						foreach ( $provider['logs'] as $message ) {
 							$column[] = '<div class="message">';
 							$column[] = '<span class="time">' . Sensei_Tool_Enrolment_Debug::format_date( $message['timestamp'] ) . '</span>';
-							$column[] = '<span class="content">' . esc_html( $message['message'] ) . '</span>';
+
+							$column[] = '<span class="content">';
+							$column[] = esc_html( $message['message'] );
+
+							if ( ! empty( $message['data'] ) ) {
+								$column[] = '<details>';
+								$column[] = '<summary>' . esc_html__( 'More information...', 'sensei-lms' ) . '</summary>';
+								$column[] = '<pre>';
+								// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r -- Special debug case.
+								$column[] = esc_html( print_r( $message['data'], true ) );
+								$column[] = '</pre>';
+								$column[] = '</details>';
+							}
+							$column[] = '</span>';
+
 							$column[] = '</div>';
 						}
 						$column[] = '</div>';


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Handle exceptions in enrollment providers better by displaying them in the logs.
* Handles cases where enrollment results are never calculated (unpublished course, manually removed from course, exception in provider, etc).

### Testing instructions

* Manually add a `throw new Exception( 'Boom' );` into a provider's `is_enrolled` method.
* Ensure it shows up when debugging enrollment information. 

### Screenshot / Video

<img width="1331" alt="Screen Shot 2021-02-18 at 12 35 07 pm" src="https://user-images.githubusercontent.com/68693/108357742-be5ac000-71e5-11eb-93ce-b8a81dd921cd.png">