### PR TITLE
Add dependency group eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
 		wp: true,
 	},
 	rules: {
+		'@wordpress/dependency-group': 'warn',
 		'@wordpress/i18n-text-domain': [
 			'error',
 			{

--- a/assets/admin/exit-survey/form.js
+++ b/assets/admin/exit-survey/form.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { useCallback, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { ExitSurveyFormItem } from './form-item';
 import { reasons } from './reasons';
 

--- a/assets/admin/exit-survey/form.test.js
+++ b/assets/admin/exit-survey/form.test.js
@@ -1,7 +1,14 @@
+/**
+ * External dependencies
+ */
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { ExitSurveyForm } from './form';
 import '@testing-library/jest-dom';
+
+/**
+ * Internal dependencies
+ */
+import { ExitSurveyForm } from './form';
 
 describe( '<ExitSurveyForm />', () => {
 	beforeEach( () => {} );

--- a/assets/admin/exit-survey/index.js
+++ b/assets/admin/exit-survey/index.js
@@ -1,5 +1,12 @@
-import { ExitSurveyForm } from './form';
+/**
+ * WordPress dependencies
+ */
 import { render } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
+import { ExitSurveyForm } from './form';
 
 ( function senseiExitSurvey() {
 	/**

--- a/assets/admin/exit-survey/reasons.js
+++ b/assets/admin/exit-survey/reasons.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/assets/blocks/course-outline/lesson-block/lesson-settings.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-settings.js
@@ -10,11 +10,11 @@ import {
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
-import { Status } from '../status-preview';
 
 /**
  * Internal dependencies
  */
+import { Status } from '../status-preview';
 import { StatusControl } from '../status-preview/status-control';
 
 /**

--- a/assets/blocks/course-outline/lesson-block/use-lesson-preview-status.js
+++ b/assets/blocks/course-outline/lesson-block/use-lesson-preview-status.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { COURSE_STATUS_STORE } from '../status-preview/status-store';
 
 /**

--- a/assets/blocks/course-outline/outline-block/outline-settings.js
+++ b/assets/blocks/course-outline/outline-block/outline-settings.js
@@ -4,6 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { InspectorControls } from '@wordpress/block-editor';
 import { PanelBody, ToggleControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import { useSharedModuleStyles } from './use-shared-module-styles';
 
 /**

--- a/assets/blocks/course-outline/outline-block/use-shared-module-styles.js
+++ b/assets/blocks/course-outline/outline-block/use-shared-module-styles.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect, useRef } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { applyStyleClass, getActiveStyleClass } from '../apply-style-class';
 import { getCourseInnerBlocks } from '../data';
 

--- a/assets/blocks/course-outline/status-preview/status-control/index.test.js
+++ b/assets/blocks/course-outline/status-preview/status-control/index.test.js
@@ -3,11 +3,11 @@
  */
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { Status } from '../index';
 
 /**
  * Internal dependencies
  */
+import { Status } from '../index';
 import { StatusControl } from './index';
 
 describe( '<StatusControl />', () => {

--- a/assets/blocks/course-outline/status-preview/use-course-lessons-status-sync.js
+++ b/assets/blocks/course-outline/status-preview/use-course-lessons-status-sync.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { COURSE_STATUS_STORE } from './status-store';
 
 /**

--- a/assets/blocks/quiz/answer-blocks/file-upload.js
+++ b/assets/blocks/quiz/answer-blocks/file-upload.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/assets/blocks/quiz/answer-blocks/gap-fill.js
+++ b/assets/blocks/quiz/answer-blocks/gap-fill.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { RichText } from '@wordpress/block-editor';
 import { FormTokenField } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
 import FileUploadAnswer from './file-upload';
 import GapFillAnswer from './gap-fill';
 import MultiLineAnswer from './multi-line';

--- a/assets/blocks/quiz/answer-blocks/multi-line.js
+++ b/assets/blocks/quiz/answer-blocks/multi-line.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
@@ -1,6 +1,13 @@
+/**
+ * WordPress dependencies
+ */
 import { Button } from '@wordpress/components';
 import { useEffect, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import SingleLineInput from '../../../shared/blocks/single-line-input';
 import { OptionToggle } from './option-toggle';
 

--- a/assets/blocks/quiz/answer-blocks/multiple-choice.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice.js
@@ -1,4 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import MultipleChoiceAnswerOption from './multiple-choice-answer-option';
 
 /**

--- a/assets/blocks/quiz/answer-blocks/option-toggle.js
+++ b/assets/blocks/quiz/answer-blocks/option-toggle.js
@@ -1,5 +1,16 @@
-import { Button } from '@wordpress/components';
+/**
+ * External dependencies
+ */
 import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Button } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import { checked } from '../../../icons/wordpress-icons';
 
 export const OptionToggle = ( {

--- a/assets/blocks/quiz/answer-blocks/single-line.js
+++ b/assets/blocks/quiz/answer-blocks/single-line.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 
 /**

--- a/assets/blocks/quiz/answer-blocks/true-false.js
+++ b/assets/blocks/quiz/answer-blocks/true-false.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { OptionToggle } from './option-toggle';
 
 /**

--- a/assets/blocks/quiz/question-block/question-type-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-type-toolbar.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { Toolbar } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import ToolbarDropdown from '../../editor-components/toolbar-dropdown';
 import types from '../answer-blocks';
 

--- a/assets/blocks/quiz/quiz-block/index.js
+++ b/assets/blocks/quiz/quiz-block/index.js
@@ -3,11 +3,11 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import icon from '../../../icons/question-icon';
 
 /**
  * Internal dependencies
  */
+import icon from '../../../icons/question-icon';
 import edit from './quiz-edit';
 import metadata from './block.json';
 

--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -3,6 +3,10 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { useAutoInserter } from '../../../shared/blocks/use-auto-inserter';
 import questionBlock from '../question-block';
 

--- a/assets/data-port/export.js
+++ b/assets/data-port/export.js
@@ -1,4 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { render } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import SenseiExportPage from './export/index';
 
 render( <SenseiExportPage />, document.getElementById( 'sensei-export-page' ) );

--- a/assets/data-port/export/export-page.js
+++ b/assets/data-port/export/export-page.js
@@ -1,4 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { useSenseiColorTheme } from '../../react-hooks/use-sensei-color-theme';
 import { Notice } from '@wordpress/components';
 import { ExportProgressPage } from './export-progress-page';

--- a/assets/data-port/export/export-page.test.js
+++ b/assets/data-port/export/export-page.test.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
 import { ExportPage } from './export-page';
 
 describe( '<ExportPage />', () => {

--- a/assets/data-port/export/export-progress-page.js
+++ b/assets/data-port/export/export-progress-page.js
@@ -1,6 +1,13 @@
+/**
+ * WordPress dependencies
+ */
 import { Button } from '@wordpress/components';
 import { useEffect } from '@wordpress/element';
 import { __, _n } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { downloadFile } from '../../shared/helpers/download-file';
 import { Notice } from '../notice';
 

--- a/assets/data-port/export/export-progress-page.test.js
+++ b/assets/data-port/export/export-progress-page.test.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
 import { ExportProgressPage } from './export-progress-page';
 
 describe( '<ExportProgressPage />', () => {

--- a/assets/data-port/export/export-select-content-page.js
+++ b/assets/data-port/export/export-select-content-page.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { Button, CheckboxControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { useMergeReducer } from '../../react-hooks/use-merge-reducer';
 import { getSelectedKeys } from '../../shared/helpers/data';
 import { postTypeLabels } from '../../shared/helpers/labels';

--- a/assets/data-port/export/export-select-content-page.test.js
+++ b/assets/data-port/export/export-select-content-page.test.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
 import { ExportSelectContentPage } from './export-select-content-page';
 
 describe( '<SelectExportContentPage />', () => {

--- a/assets/data-port/export/index.js
+++ b/assets/data-port/export/index.js
@@ -1,7 +1,14 @@
-import { ExportPage } from './export-page';
-import registerExportStore, { EXPORT_STORE } from './store';
+/**
+ * WordPress dependencies
+ */
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import { ExportPage } from './export-page';
+import registerExportStore, { EXPORT_STORE } from './store';
 
 registerExportStore();
 

--- a/assets/data-port/export/store/actions.js
+++ b/assets/data-port/export/store/actions.js
@@ -1,4 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { apiFetch, select } from '@wordpress/data-controls';
+
+/**
+ * Internal dependencies
+ */
 import { EXPORT_STORE } from './index';
 import { cancelTimeout, timeout } from '../../../shared/data/timeout-controls';
 

--- a/assets/data-port/export/store/index.js
+++ b/assets/data-port/export/store/index.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { registerStore } from '@wordpress/data';
 import { controls as dataControls } from '@wordpress/data-controls';
+
+/**
+ * Internal dependencies
+ */
 import scheduleControls from '../../../shared/data/timeout-controls';
 import { createReducerFromActionMap } from '../../../shared/data/store-helpers';
 

--- a/assets/data-port/export/store/index.test.js
+++ b/assets/data-port/export/store/index.test.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { select } from '@wordpress/data';
 import { apiFetch } from '@wordpress/data-controls';
+
+/**
+ * Internal dependencies
+ */
 import registerExportStore, { EXPORT_STORE } from './index';
 import * as actions from './actions';
 

--- a/assets/data-port/import.js
+++ b/assets/data-port/import.js
@@ -1,6 +1,13 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { render, useLayoutEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { useSenseiColorTheme } from '../react-hooks/use-sensei-color-theme';
 import { DataPortStepper } from './stepper';
 import registerImportStore from './import/data';

--- a/assets/data-port/import/data/actions.js
+++ b/assets/data-port/import/data/actions.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import {
 	API_SPECIAL_ACTIVE_JOB_ID,
 	FETCH_FROM_API,
@@ -17,7 +20,6 @@ import {
 	SET_JOB_STATE,
 	WAIT,
 } from './constants';
-
 import { composeFetchAction } from '../../../shared/data/store-helpers';
 import { normalizeImportData } from './normalizer';
 import { buildJobEndpointUrl } from '../helpers/url';

--- a/assets/data-port/import/data/actions.test.js
+++ b/assets/data-port/import/data/actions.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import {
 	API_BASE_PATH,
 	FETCH_FROM_API,
@@ -14,7 +17,6 @@ import {
 	ERROR_DELETE_IMPORT_DATA_FILE,
 	SUCCESS_DELETE_IMPORT_DATA_FILE,
 } from './constants';
-
 import {
 	fetchFromAPI,
 	loadCurrentJobState,

--- a/assets/data-port/import/data/controls.js
+++ b/assets/data-port/import/data/controls.js
@@ -1,5 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * Internal dependencies
+ */
 import { FETCH_FROM_API, WAIT } from './constants';
 
 export default {

--- a/assets/data-port/import/data/controls.test.js
+++ b/assets/data-port/import/data/controls.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { FETCH_FROM_API } from './constants';
 import controls from './controls';
 

--- a/assets/data-port/import/data/index.js
+++ b/assets/data-port/import/data/index.js
@@ -1,5 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { registerStore } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
 import reducer from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';

--- a/assets/data-port/import/data/normalizer.test.js
+++ b/assets/data-port/import/data/normalizer.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { normalizeImportData } from './normalizer';
 
 describe( 'Importer data normalizer', () => {

--- a/assets/data-port/import/data/reducer.js
+++ b/assets/data-port/import/data/reducer.js
@@ -1,3 +1,11 @@
+/**
+ * External dependencies
+ */
+import { merge } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
 import {
 	START_LOAD_CURRENT_JOB_STATE,
 	SUCCESS_LOAD_CURRENT_JOB_STATE,
@@ -16,8 +24,6 @@ import {
 	SET_IMPORT_LOG,
 	ERROR_FETCH_IMPORT_LOG,
 } from './constants';
-
-import { merge } from 'lodash';
 
 const DEFAULT_STATE = {
 	jobId: null,

--- a/assets/data-port/import/data/reducer.test.js
+++ b/assets/data-port/import/data/reducer.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import reducer from './reducer';
 import {
 	START_LOAD_CURRENT_JOB_STATE,

--- a/assets/data-port/import/data/resolvers.js
+++ b/assets/data-port/import/data/resolvers.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { SET_IMPORT_LOG, ERROR_FETCH_IMPORT_LOG } from './constants';
 import { composeFetchAction } from '../../../shared/data/store-helpers';
 import { fetchFromAPI } from './actions';

--- a/assets/data-port/import/data/resolvers.test.js
+++ b/assets/data-port/import/data/resolvers.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import {
 	API_BASE_PATH,
 	FETCH_FROM_API,

--- a/assets/data-port/import/data/selectors.js
+++ b/assets/data-port/import/data/selectors.js
@@ -1,6 +1,13 @@
+/**
+ * External dependencies
+ */
+import { get, groupBy } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
 import { steps } from '../steps';
 import { levels } from '../levels';
-import { get, groupBy } from 'lodash';
 
 const DONE_KEYS = [ 'course', 'lesson', 'question' ];
 

--- a/assets/data-port/import/data/selectors.test.js
+++ b/assets/data-port/import/data/selectors.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import {
 	getFetchError,
 	getJobId,

--- a/assets/data-port/import/done/done-page.js
+++ b/assets/data-port/import/done/done-page.js
@@ -1,6 +1,17 @@
-import { __ } from '@wordpress/i18n';
+/**
+ * External dependencies
+ */
 import { Section } from '@woocommerce/components';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
 import { Button, Spinner, Notice } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
 import { ImportLog } from './import-log';
 import ImportSuccessResults from './import-success-results';
 

--- a/assets/data-port/import/done/done-page.test.js
+++ b/assets/data-port/import/done/done-page.test.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
 import { DonePage } from './done-page';
 
 describe( '<DonePage />', () => {

--- a/assets/data-port/import/done/import-log.js
+++ b/assets/data-port/import/done/import-log.js
@@ -1,5 +1,16 @@
-import { __ } from '@wordpress/i18n';
+/**
+ * External dependencies
+ */
 import { kebabCase } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { logTypeLabels } from '../../../shared/helpers/labels';
 
 /**

--- a/assets/data-port/import/done/import-success-results.js
+++ b/assets/data-port/import/done/import-success-results.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { _n } from '@wordpress/i18n';
 
 /**

--- a/assets/data-port/import/done/index.js
+++ b/assets/data-port/import/done/index.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
 import { DonePage } from './done-page';
 
 export default compose(

--- a/assets/data-port/import/helpers/url.js
+++ b/assets/data-port/import/helpers/url.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { API_BASE_PATH } from '../data/constants';
 
 /**

--- a/assets/data-port/import/helpers/url.test.js
+++ b/assets/data-port/import/helpers/url.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { API_BASE_PATH } from '../data/constants';
 import { buildJobEndpointUrl } from './url';
 

--- a/assets/data-port/import/import-progress/import-progress-page.js
+++ b/assets/data-port/import/import-progress/import-progress-page.js
@@ -1,6 +1,17 @@
+/**
+ * External dependencies
+ */
 import { H, Section } from '@woocommerce/components';
-import useProgressPolling from './use-progress-polling';
+
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import useProgressPolling from './use-progress-polling';
 
 /**
  * This component displays the import progress page of the importer.

--- a/assets/data-port/import/import-progress/import-progress-page.test.js
+++ b/assets/data-port/import/import-progress/import-progress-page.test.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
 import { ImportProgressPage } from './import-progress-page';
 
 jest.mock( '@wordpress/api-fetch', () => () => Promise.resolve() );

--- a/assets/data-port/import/import-progress/index.js
+++ b/assets/data-port/import/import-progress/index.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { withSelect } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
 import { ImportProgressPage } from './import-progress-page';
 
 export default compose(

--- a/assets/data-port/import/import-progress/use-progress-polling.js
+++ b/assets/data-port/import/import-progress/use-progress-polling.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 

--- a/assets/data-port/import/levels.js
+++ b/assets/data-port/import/levels.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 
 export const levels = [

--- a/assets/data-port/import/steps.js
+++ b/assets/data-port/import/steps.js
@@ -1,4 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import UploadPage from './upload';
 import ImportProgressPage from './import-progress';
 import DonePage from './done';

--- a/assets/data-port/import/upload-level/index.js
+++ b/assets/data-port/import/upload-level/index.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
 import { UploadLevels } from './upload-level';
 
 export default compose(

--- a/assets/data-port/import/upload-level/upload-level.js
+++ b/assets/data-port/import/upload-level/upload-level.js
@@ -1,10 +1,21 @@
 /* global FormData */
 
-import { Button, FormFileUpload } from '@wordpress/components';
+/**
+ * External dependencies
+ */
 import { Spinner } from '@woocommerce/components';
-import { Notice } from '../../notice';
+
+/**
+ * WordPress dependencies
+ */
+import { Button, FormFileUpload } from '@wordpress/components';
 import { closeSmall } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { Notice } from '../../notice';
 import { levels } from '../levels';
 
 /**

--- a/assets/data-port/import/upload-level/upload-level.test.js
+++ b/assets/data-port/import/upload-level/upload-level.test.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { fireEvent, render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
 import { UploadLevels } from './upload-level';
 
 describe( '<UploadLevels />', () => {

--- a/assets/data-port/import/upload/index.js
+++ b/assets/data-port/import/upload/index.js
@@ -1,5 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { withSelect, withDispatch } from '@wordpress/data';
 import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
 import { UploadPage } from './upload-page';
 
 export default compose(

--- a/assets/data-port/import/upload/upload-page.js
+++ b/assets/data-port/import/upload/upload-page.js
@@ -1,7 +1,17 @@
+/**
+ * External dependencies
+ */
 import { H, Section } from '@woocommerce/components';
+
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
 import UploadLevels from '../upload-level';
 import { Notice } from '../../notice';
 import { formatString } from '../../../shared/helpers/format-string.js';

--- a/assets/data-port/import/upload/upload-page.test.js
+++ b/assets/data-port/import/upload/upload-page.test.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
 import { UploadPage } from './upload-page';
 
 jest.mock( '@wordpress/api-fetch', () => () => Promise.resolve() );

--- a/assets/data-port/notice.js
+++ b/assets/data-port/notice.js
@@ -1,5 +1,12 @@
-import { Dashicon } from '@wordpress/components';
+/**
+ * External dependencies
+ */
 import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Dashicon } from '@wordpress/components';
 
 /**
  * Sensei data port error notice.

--- a/assets/data-port/stepper/index.js
+++ b/assets/data-port/stepper/index.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import classnames from 'classnames';
 
 /**

--- a/assets/icons/course-icon.js
+++ b/assets/icons/course-icon.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { Path, SVG } from '@wordpress/components';
 
 export const CourseIcon = ( props ) => (

--- a/assets/icons/lesson-icon.js
+++ b/assets/icons/lesson-icon.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { Path, SVG } from '@wordpress/components';
 
 export const LessonIcon = () => (

--- a/assets/icons/module-icon.js
+++ b/assets/icons/module-icon.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { Path, SVG } from '@wordpress/components';
 
 export const ModuleIcon = () => (

--- a/assets/icons/progress-icon.js
+++ b/assets/icons/progress-icon.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { Rect, Path, SVG } from '@wordpress/components';
 
 export const ProgressIcon = () => (

--- a/assets/icons/question-icon.js
+++ b/assets/icons/question-icon.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { Path, SVG } from '@wordpress/components';
 
 const questionIcon = (

--- a/assets/icons/sensei-icon.js
+++ b/assets/icons/sensei-icon.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { G, Path, SVG } from '@wordpress/components';
 
 export const SenseiIcon = ( props ) => (

--- a/assets/icons/wordpress-icons.js
+++ b/assets/icons/wordpress-icons.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { Path, SVG } from '@wordpress/components';
 
 /**

--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { select, dispatch, subscribe } from '@wordpress/data';
 
 ( () => {

--- a/assets/react-hooks/probe-styles.js
+++ b/assets/react-hooks/probe-styles.js
@@ -1,7 +1,17 @@
-import { useState, useEffect } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
+/**
+ * External dependencies
+ */
 import { mapValues, keyBy, memoize } from 'lodash';
 
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
 import { hexToRGB } from '../shared/helpers/colors';
 
 const { getComputedStyle } = window;

--- a/assets/react-hooks/probe-styles.test.js
+++ b/assets/react-hooks/probe-styles.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { getProbeStyles } from './probe-styles';
 
 describe( 'getProbeStyles', () => {

--- a/assets/react-hooks/use-event-listener.js
+++ b/assets/react-hooks/use-event-listener.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { useEffect, useCallback } from '@wordpress/element';
 
 /**

--- a/assets/react-hooks/use-event-listener.test.js
+++ b/assets/react-hooks/use-event-listener.test.js
@@ -1,5 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render, fireEvent } from '@testing-library/react';
 
+/**
+ * Internal dependencies
+ */
 import useEventListener from './use-event-listener';
 
 describe( 'useEventListener', () => {

--- a/assets/react-hooks/use-merge-reducer.js
+++ b/assets/react-hooks/use-merge-reducer.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { useReducer } from '@wordpress/element';
 
 /**

--- a/assets/react-hooks/use-merge-reducer.test.js
+++ b/assets/react-hooks/use-merge-reducer.test.js
@@ -1,5 +1,12 @@
-import { useMergeReducer } from './use-merge-reducer';
+/**
+ * External dependencies
+ */
 import { act, renderHook } from '@testing-library/react-hooks';
+
+/**
+ * Internal dependencies
+ */
+import { useMergeReducer } from './use-merge-reducer';
 
 describe( 'useMergeReducer', () => {
 	it( 'partially updates the state', () => {

--- a/assets/react-hooks/use-sensei-color-theme.js
+++ b/assets/react-hooks/use-sensei-color-theme.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { useLayoutEffect } from '@wordpress/element';
 
 /**

--- a/assets/react-hooks/use-sensei-color-theme.test.js
+++ b/assets/react-hooks/use-sensei-color-theme.test.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
 import { useSenseiColorTheme } from './use-sensei-color-theme';
 
 describe( 'useSenseiColorTheme', () => {

--- a/assets/react-hooks/use-wp-admin-fullscreen.js
+++ b/assets/react-hooks/use-wp-admin-fullscreen.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { useLayoutEffect } from '@wordpress/element';
 
 const toggleGlobalStyles = ( enabled, classes ) => {

--- a/assets/react-hooks/use-wp-admin-fullscreen.test.js
+++ b/assets/react-hooks/use-wp-admin-fullscreen.test.js
@@ -1,5 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render } from '@testing-library/react';
 
+/**
+ * Internal dependencies
+ */
 import useWpAdminFullscreen from './use-wp-admin-fullscreen';
 
 describe( 'useWpAdminFullscreen', () => {

--- a/assets/setup-wizard/data/actions.js
+++ b/assets/setup-wizard/data/actions.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import {
 	API_BASE_PATH,
 	FETCH_FROM_API,
@@ -10,7 +13,6 @@ import {
 	SET_STEP_DATA,
 	APPLY_STEP_DATA,
 } from './constants';
-
 import { normalizeSetupWizardData } from './normalizer';
 
 /**

--- a/assets/setup-wizard/data/actions.test.js
+++ b/assets/setup-wizard/data/actions.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import {
 	API_BASE_PATH,
 	FETCH_FROM_API,

--- a/assets/setup-wizard/data/controls.js
+++ b/assets/setup-wizard/data/controls.js
@@ -1,5 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * Internal dependencies
+ */
 import { FETCH_FROM_API, APPLY_STEP_DATA } from './constants';
 import { logEvent } from '../log-event';
 

--- a/assets/setup-wizard/data/controls.test.js
+++ b/assets/setup-wizard/data/controls.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { FETCH_FROM_API } from './constants';
 import controls from './controls';
 

--- a/assets/setup-wizard/data/index.js
+++ b/assets/setup-wizard/data/index.js
@@ -1,5 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { registerStore } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
 import reducer from './reducer';
 import * as actions from './actions';
 import * as selectors from './selectors';

--- a/assets/setup-wizard/data/normalizer.js
+++ b/assets/setup-wizard/data/normalizer.js
@@ -1,5 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
 import { INSTALLED_STATUS } from '../features/feature-status';
 
 /**

--- a/assets/setup-wizard/data/normalizer.test.js
+++ b/assets/setup-wizard/data/normalizer.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { normalizeFeaturesData, normalizeSetupWizardData } from './normalizer';
 
 describe( 'Data normalizer', () => {

--- a/assets/setup-wizard/data/reducer.js
+++ b/assets/setup-wizard/data/reducer.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import {
 	START_FETCH_SETUP_WIZARD_DATA,
 	SUCCESS_FETCH_SETUP_WIZARD_DATA,

--- a/assets/setup-wizard/data/reducer.test.js
+++ b/assets/setup-wizard/data/reducer.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import {
 	START_FETCH_SETUP_WIZARD_DATA,
 	SUCCESS_FETCH_SETUP_WIZARD_DATA,

--- a/assets/setup-wizard/data/resolvers.js
+++ b/assets/setup-wizard/data/resolvers.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { API_BASE_PATH } from './constants';
 import { fetchFromAPI, setStepData } from './actions';
 import { normalizeFeaturesData } from './normalizer';

--- a/assets/setup-wizard/data/resolvers.test.js
+++ b/assets/setup-wizard/data/resolvers.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { API_BASE_PATH, FETCH_FROM_API, SET_STEP_DATA } from './constants';
 import { getStepData } from './resolvers';
 

--- a/assets/setup-wizard/data/selectors.js
+++ b/assets/setup-wizard/data/selectors.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { steps } from '../steps';
 
 /**

--- a/assets/setup-wizard/data/selectors.test.js
+++ b/assets/setup-wizard/data/selectors.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import {
 	isFetching,
 	getFetchError,

--- a/assets/setup-wizard/data/use-setup-wizard-step.js
+++ b/assets/setup-wizard/data/use-setup-wizard-step.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { useCallback } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { Notice } from '@wordpress/components';

--- a/assets/setup-wizard/features/check-icon.test.js
+++ b/assets/setup-wizard/features/check-icon.test.js
@@ -1,5 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render } from '@testing-library/react';
 
+/**
+ * Internal dependencies
+ */
 import CheckIcon from './check-icon';
 
 describe( '<CheckIcon />', () => {

--- a/assets/setup-wizard/features/confirmation-modal.js
+++ b/assets/setup-wizard/features/confirmation-modal.js
@@ -1,8 +1,18 @@
+/**
+ * External dependencies
+ */
 import { List } from '@woocommerce/components';
+
+/**
+ * WordPress dependencies
+ */
 import { Button, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { getWccomProductId } from '../helpers/woocommerce-com';
 
+/**
+ * Internal dependencies
+ */
+import { getWccomProductId } from '../helpers/woocommerce-com';
 import { getFeatureObservation } from './feature-description-utils';
 import FeatureDescription from './feature-description';
 

--- a/assets/setup-wizard/features/confirmation-modal.test.js
+++ b/assets/setup-wizard/features/confirmation-modal.test.js
@@ -1,6 +1,12 @@
+/**
+ * External dependencies
+ */
 import { render, fireEvent } from '@testing-library/react';
 import { screen } from '@testing-library/dom';
 
+/**
+ * Internal dependencies
+ */
 import ConfirmationModal from './confirmation-modal';
 
 const features = [

--- a/assets/setup-wizard/features/feature-description-utils.js
+++ b/assets/setup-wizard/features/feature-description-utils.js
@@ -1,4 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { sprintf, __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { getWccomProductId } from '../helpers/woocommerce-com';
 
 /**

--- a/assets/setup-wizard/features/feature-description-utils.test.js
+++ b/assets/setup-wizard/features/feature-description-utils.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { getFeatureObservation } from './feature-description-utils';
 
 describe( '<FeatureDescription />', () => {

--- a/assets/setup-wizard/features/feature-description.js
+++ b/assets/setup-wizard/features/feature-description.js
@@ -1,4 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { logLink } from '../log-event';
 
 /**

--- a/assets/setup-wizard/features/feature-description.test.js
+++ b/assets/setup-wizard/features/feature-description.test.js
@@ -1,5 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render, fireEvent } from '@testing-library/react';
 
+/**
+ * Internal dependencies
+ */
 import FeatureDescription from './feature-description';
 
 describe( '<FeatureDescription />', () => {

--- a/assets/setup-wizard/features/feature-status.js
+++ b/assets/setup-wizard/features/feature-status.js
@@ -1,6 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { Dashicon, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
 import CheckIcon from './check-icon';
 
 /**

--- a/assets/setup-wizard/features/feature-status.test.js
+++ b/assets/setup-wizard/features/feature-status.test.js
@@ -1,5 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render } from '@testing-library/react';
 
+/**
+ * Internal dependencies
+ */
 import FeatureStatus, {
 	INSTALLING_STATUS,
 	ERROR_STATUS,

--- a/assets/setup-wizard/features/features-selection.js
+++ b/assets/setup-wizard/features/features-selection.js
@@ -1,7 +1,17 @@
-import { Button, CheckboxControl, Notice } from '@wordpress/components';
+/**
+ * External dependencies
+ */
 import classnames from 'classnames';
+
+/**
+ * WordPress dependencies
+ */
+import { Button, CheckboxControl, Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
 import FeatureDescription from './feature-description';
 
 /**

--- a/assets/setup-wizard/features/features-selection.test.js
+++ b/assets/setup-wizard/features/features-selection.test.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
 import FeaturesSelection from './features-selection';
 
 const features = [

--- a/assets/setup-wizard/features/index.js
+++ b/assets/setup-wizard/features/index.js
@@ -1,8 +1,18 @@
-import { useState, useEffect, useCallback } from '@wordpress/element';
+/**
+ * External dependencies
+ */
 import { Card, H } from '@woocommerce/components';
-import { __ } from '@wordpress/i18n';
 import { uniq } from 'lodash';
 
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { INSTALLED_STATUS } from './feature-status';
 import { logEvent } from '../log-event';
 import { useQueryStringRouter } from '../query-string-router';

--- a/assets/setup-wizard/features/index.test.js
+++ b/assets/setup-wizard/features/index.test.js
@@ -1,5 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render, fireEvent } from '@testing-library/react';
 
+/**
+ * Internal dependencies
+ */
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 import QueryStringRouter, { Route } from '../query-string-router';
 import { updateQueryString } from '../query-string-router/url-functions';

--- a/assets/setup-wizard/features/installation-feedback.js
+++ b/assets/setup-wizard/features/installation-feedback.js
@@ -1,8 +1,18 @@
-import { useState, useEffect } from '@wordpress/element';
+/**
+ * External dependencies
+ */
 import { List } from '@woocommerce/components';
+
+/**
+ * WordPress dependencies
+ */
+import { useState, useEffect } from '@wordpress/element';
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Internal dependencies
+ */
 import { getFeatureObservation } from './feature-description-utils';
 import FeatureDescription from './feature-description';
 import FeatureStatus, {

--- a/assets/setup-wizard/features/installation-feedback.test.js
+++ b/assets/setup-wizard/features/installation-feedback.test.js
@@ -1,6 +1,16 @@
+/**
+ * External dependencies
+ */
 import { render, fireEvent, act, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
 import { useState, useEffect } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
 import InstallationFeedback from './installation-feedback';
 import useFeaturesPolling from './use-features-polling';
 import {

--- a/assets/setup-wizard/features/use-features-polling.js
+++ b/assets/setup-wizard/features/use-features-polling.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { useState, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 

--- a/assets/setup-wizard/features/use-features-polling.test.js
+++ b/assets/setup-wizard/features/use-features-polling.test.js
@@ -1,6 +1,16 @@
+/**
+ * External dependencies
+ */
 import { render, act } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
 import { useDispatch } from '@wordpress/data';
 
+/**
+ * Internal dependencies
+ */
 import useFeaturesPolling from './use-features-polling';
 
 jest.mock( '@wordpress/data', () => ( {

--- a/assets/setup-wizard/helpers/woocommerce-com.js
+++ b/assets/setup-wizard/helpers/woocommerce-com.js
@@ -1,5 +1,5 @@
 /**
- * External dependencies
+ * WordPress dependencies
  */
 import { addQueryArgs } from '@wordpress/url';
 

--- a/assets/setup-wizard/index.js
+++ b/assets/setup-wizard/index.js
@@ -1,13 +1,23 @@
+/**
+ * External dependencies
+ */
+import { Spinner } from '@woocommerce/components';
+
+/**
+ * WordPress dependencies
+ */
 import { useSelect, useDispatch } from '@wordpress/data';
 import { render, useLayoutEffect } from '@wordpress/element';
-import { Spinner } from '@woocommerce/components';
 import { Notice } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { useSenseiColorTheme } from '../react-hooks/use-sensei-color-theme';
 import '../shared/data/api-fetch-preloaded-once';
 import registerSetupWizardStore from './data';
 import { useWpAdminFullscreen } from '../react-hooks';
-
 import QueryStringRouter, { Route } from './query-string-router';
 import Navigation from './navigation';
 

--- a/assets/setup-wizard/log-event.test.js
+++ b/assets/setup-wizard/log-event.test.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render, fireEvent } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
 import { logLink } from './log-event';
 
 describe( 'logOnClick', () => {

--- a/assets/setup-wizard/navigation/index.js
+++ b/assets/setup-wizard/navigation/index.js
@@ -1,4 +1,11 @@
+/**
+ * External dependencies
+ */
 import { Stepper } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
 import { useQueryStringRouter } from '../query-string-router';
 
 /**

--- a/assets/setup-wizard/purpose/index.js
+++ b/assets/setup-wizard/purpose/index.js
@@ -1,7 +1,18 @@
+/**
+ * External dependencies
+ */
 import { Card, H } from '@woocommerce/components';
+
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { Button, CheckboxControl, TextControl } from '@wordpress/components';
 import { useState, useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { useQueryStringRouter } from '../query-string-router';
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 

--- a/assets/setup-wizard/query-string-router/index.js
+++ b/assets/setup-wizard/query-string-router/index.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import {
 	useState,
 	useMemo,
@@ -5,6 +8,9 @@ import {
 	createContext,
 } from '@wordpress/element';
 
+/**
+ * Internal dependencies
+ */
 import { useEventListener } from '../../react-hooks';
 import { updateQueryString, getParam } from './url-functions';
 

--- a/assets/setup-wizard/query-string-router/index.test.js
+++ b/assets/setup-wizard/query-string-router/index.test.js
@@ -1,5 +1,11 @@
+/**
+ * External dependencies
+ */
 import { render, fireEvent } from '@testing-library/react';
 
+/**
+ * Internal dependencies
+ */
 import QueryStringRouter, { Route, useQueryStringRouter } from './index';
 import { mockSearch } from '../../tests-helper/functions';
 

--- a/assets/setup-wizard/query-string-router/route.js
+++ b/assets/setup-wizard/query-string-router/route.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { useQueryStringRouter } from './index';
 
 /**

--- a/assets/setup-wizard/query-string-router/route.test.js
+++ b/assets/setup-wizard/query-string-router/route.test.js
@@ -1,6 +1,16 @@
-import { useEffect } from '@wordpress/element';
+/**
+ * External dependencies
+ */
 import { render } from '@testing-library/react';
 
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import QueryStringRouter, { Route, useQueryStringRouter } from './index';
 
 const GoToSecondRoute = () => {

--- a/assets/setup-wizard/query-string-router/url-functions.test.js
+++ b/assets/setup-wizard/query-string-router/url-functions.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { getParam, updateQueryString } from './url-functions';
 import { mockSearch } from '../../tests-helper/functions';
 

--- a/assets/setup-wizard/ready/index.js
+++ b/assets/setup-wizard/ready/index.js
@@ -1,8 +1,18 @@
-import { useEffect } from '@wordpress/element';
+/**
+ * External dependencies
+ */
 import { Card, H, List, Section } from '@woocommerce/components';
+
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
 import { MailingListSignupForm } from './mailinglist-signup-form';
 import { formatString } from '../../shared/helpers/format-string.js';
 import { logLink } from '../log-event';

--- a/assets/setup-wizard/ready/index.test.js
+++ b/assets/setup-wizard/ready/index.test.js
@@ -1,6 +1,16 @@
+/**
+ * External dependencies
+ */
 import { fireEvent, render, act, waitFor } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * Internal dependencies
+ */
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 import { Ready } from './index';
 

--- a/assets/setup-wizard/ready/mailinglist-signup-form.js
+++ b/assets/setup-wizard/ready/mailinglist-signup-form.js
@@ -1,6 +1,17 @@
+/**
+ * External dependencies
+ */
 import { List } from '@woocommerce/components';
+
+/**
+ * WordPress dependencies
+ */
 import { Button, TextControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { logLink } from '../log-event';
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';
 

--- a/assets/setup-wizard/ready/use-sample-course-installer.js
+++ b/assets/setup-wizard/ready/use-sample-course-installer.js
@@ -1,6 +1,12 @@
+/**
+ * WordPress dependencies
+ */
 import { useEffect, useState } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 
+/**
+ * Internal dependencies
+ */
 import { buildJobEndpointUrl } from '../../data-port/import/helpers/url';
 import { logEvent } from '../log-event';
 

--- a/assets/setup-wizard/steps.js
+++ b/assets/setup-wizard/steps.js
@@ -1,4 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
 import { Welcome } from './welcome';
 import { Purpose } from './purpose';
 import Features from './features';

--- a/assets/setup-wizard/welcome/index.js
+++ b/assets/setup-wizard/welcome/index.js
@@ -1,7 +1,18 @@
+/**
+ * External dependencies
+ */
 import { Card, H, Link } from '@woocommerce/components';
+
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
 import { useState } from '@wordpress/element';
+
+/**
+ * Internal dependencies
+ */
 import { UsageModal } from './usage-modal';
 import { useQueryStringRouter } from '../query-string-router';
 import { useSetupWizardStep } from '../data/use-setup-wizard-step';

--- a/assets/setup-wizard/welcome/usage-modal.js
+++ b/assets/setup-wizard/welcome/usage-modal.js
@@ -1,6 +1,13 @@
-import { Button, Modal, CheckboxControl } from '@wordpress/components';
+/**
+ * External dependencies
+ */
 import { Link } from '@woocommerce/components';
 import interpolateComponents from 'interpolate-components';
+
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal, CheckboxControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useState, useEffect } from '@wordpress/element';
 

--- a/assets/shared/blocks/block-index.js
+++ b/assets/shared/blocks/block-index.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { useSelect } from '@wordpress/data';
 
 /**

--- a/assets/shared/blocks/settings.js
+++ b/assets/shared/blocks/settings.js
@@ -1,3 +1,11 @@
+/**
+ * External dependencies
+ */
+import { mapValues, upperFirst } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
 import { useState, useEffect } from '@wordpress/element';
 import {
 	ContrastChecker,
@@ -7,8 +15,10 @@ import {
 	getColorClassName,
 } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { mapValues, upperFirst } from 'lodash';
 
+/**
+ * Internal dependencies
+ */
 import { useColorsByProbe } from '../../react-hooks/probe-styles';
 
 /**

--- a/assets/shared/blocks/single-line-input/index.js
+++ b/assets/shared/blocks/single-line-input/index.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import SingleLineInput from './single-line-input';
 
 export default SingleLineInput;

--- a/assets/shared/blocks/single-line-input/single-line-input.js
+++ b/assets/shared/blocks/single-line-input/single-line-input.js
@@ -1,10 +1,14 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { PlainText } from '@wordpress/block-editor';
 import { forwardRef } from '@wordpress/element';
 import { ENTER, BACKSPACE } from '@wordpress/keycodes';
-import classnames from 'classnames';
 
 /**
  * Single line input component.

--- a/assets/shared/blocks/use-keydown-inserter.js
+++ b/assets/shared/blocks/use-keydown-inserter.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { createBlock } from '@wordpress/blocks';
 import { select, useDispatch } from '@wordpress/data';
 import { ENTER, BACKSPACE } from '@wordpress/keycodes';

--- a/assets/shared/data/api-fetch-preloaded-once.js
+++ b/assets/shared/data/api-fetch-preloaded-once.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { addQueryArgs } from '@wordpress/url';
 import apiFetch from '@wordpress/api-fetch';
 

--- a/assets/shared/data/api-fetch-preloaded-once.test.js
+++ b/assets/shared/data/api-fetch-preloaded-once.test.js
@@ -1,4 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
 import { preloadedDataUsedOnceMiddleware } from './api-fetch-preloaded-once';
 
 describe( 'preloadedDataUsedOnceMiddleware', () => {

--- a/assets/shared/data/timeout-controls.test.js
+++ b/assets/shared/data/timeout-controls.test.js
@@ -1,4 +1,11 @@
+/**
+ * WordPress dependencies
+ */
 import { registerStore } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
 import controls, { timeout } from './timeout-controls';
 
 const delayedAction = () => ( { type: 'TEST_TIMEOUT_ACTION' } );

--- a/assets/shared/helpers/blocks.js
+++ b/assets/shared/helpers/blocks.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { useSelect } from '@wordpress/data';
 
 /**

--- a/assets/shared/helpers/colors.test.js
+++ b/assets/shared/helpers/colors.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { hexToRGB } from './colors';
 
 describe( 'hexToRGB', () => {

--- a/assets/shared/helpers/data.test.js
+++ b/assets/shared/helpers/data.test.js
@@ -1,3 +1,6 @@
+/**
+ * Internal dependencies
+ */
 import { getSelectedKeys } from './data';
 
 describe( 'getSelectedKeys', () => {

--- a/assets/shared/helpers/format-string.js
+++ b/assets/shared/helpers/format-string.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 import interpolateComponents from 'interpolate-components';
 
 export const formattingComponents = {

--- a/assets/shared/helpers/labels.js
+++ b/assets/shared/helpers/labels.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { __ } from '@wordpress/i18n';
 
 export const postTypeLabels = {


### PR DESCRIPTION
Fixes #3942

### Changes proposed in this Pull Request

* Add dependency group eslint rule.

### Testing instructions

* Run `npm run lint-js` and make sure everything is correct.
* Remove a dependency group comment and make sure a warning will appear.