### PR TITLE
Update default answers to empty string instead of null

### DIFF
--- a/assets/blocks/quiz/answer-blocks/multiple-choice.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice.js
@@ -5,8 +5,8 @@ import MultipleChoiceAnswerOption from './multiple-choice-answer-option';
  * Default answer options for new blocks.
  */
 const DEFAULT_ANSWERS = [
-	{ title: null, isRight: true },
-	{ title: null, isRight: false },
+	{ title: '', isRight: true },
+	{ title: '', isRight: false },
 ];
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes a React issue that we can't add a value null to an input. It was being thrown in the console when focusing on the question.
* @yscik, in a check I think it can't cause any issue (also because the `insertAnswer` creates a new question like this). But I'd appreciate if you could take a look to confirm.

### Testing instructions

* Open the console.
* Create a new lesson, and focus on the question.
* Make sure you don't see an error in the console.