### PR TITLE
REST API: Set up questions CPT

### DIFF
--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -640,6 +640,7 @@ class Sensei_PostTypes {
 			'query_var'         => false,
 			'show_in_nav_menus' => false,
 			'show_admin_column' => true,
+			'show_in_rest'      => true,
 			'rewrite'           => array( 'slug' => esc_attr( apply_filters( 'sensei_question_type_slug', _x( 'question-type', 'taxonomy archive slug', 'sensei-lms' ) ) ) ),
 		);
 
@@ -678,6 +679,7 @@ class Sensei_PostTypes {
 			'query_var'         => false,
 			'show_in_nav_menus' => false,
 			'show_admin_column' => true,
+			'show_in_rest'      => true,
 			'capabilities'      => array(
 				'manage_terms' => 'manage_categories',
 				'edit_terms'   => 'edit_questions',

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -394,26 +394,29 @@ class Sensei_PostTypes {
 		$with_front = Sensei()->get_legacy_flag( Sensei_Main::LEGACY_FLAG_WITH_FRONT ) ? true : false;
 
 		$args = array(
-			'labels'              => $this->create_post_type_labels( $this->labels['question']['singular'], $this->labels['question']['plural'], $this->labels['question']['menu'] ),
-			'public'              => false,
-			'publicly_queryable'  => true,
-			'show_ui'             => true,
-			'show_in_menu'        => true,
-			'show_in_nav_menus'   => false,
-			'query_var'           => true,
-			'exclude_from_search' => true,
-			'rewrite'             => array(
+			'labels'                => $this->create_post_type_labels( $this->labels['question']['singular'], $this->labels['question']['plural'], $this->labels['question']['menu'] ),
+			'public'                => false,
+			'publicly_queryable'    => true,
+			'show_ui'               => true,
+			'show_in_menu'          => true,
+			'show_in_nav_menus'     => false,
+			'query_var'             => true,
+			'exclude_from_search'   => true,
+			'rewrite'               => array(
 				'slug'       => esc_attr( apply_filters( 'sensei_question_slug', _x( 'question', 'post type single slug', 'sensei-lms' ) ) ),
 				'with_front' => $with_front,
 				'feeds'      => true,
 				'pages'      => true,
 			),
-			'map_meta_cap'        => true,
-			'capability_type'     => 'question',
-			'has_archive'         => true,
-			'hierarchical'        => false,
-			'menu_position'       => 51,
-			'supports'            => array( 'title', 'revisions' ),
+			'map_meta_cap'          => true,
+			'capability_type'       => 'question',
+			'has_archive'           => true,
+			'hierarchical'          => false,
+			'menu_position'         => 51,
+			'supports'              => array( 'title', 'revisions' ),
+			'show_in_rest'          => true,
+			'rest_base'             => 'questions',
+			'rest_controller_class' => 'Sensei_REST_API_Questions_Controller',
 		);
 
 		/**

--- a/includes/rest-api/class-sensei-rest-api-questions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-questions-controller.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Sensei REST API: Sensei_REST_API_Questions_Controller class.
+ *
+ * @package sensei-lms
+ * @since 3.9.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+} // Exit if accessed directly.
+
+/**
+ * A REST controller for Sensei LMS question CPT.
+ *
+ * @since 3.9.0
+ *
+ * @see WP_REST_Posts_Controller
+ */
+class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
+	/**
+	 * Constructor.
+	 *
+	 * @param string $post_type Post type.
+	 */
+	public function __construct( $post_type ) {
+		parent::__construct( $post_type );
+
+		// This filter is needed in order for teachers to only see their own questions.
+		add_filter( 'rest_question_query', [ $this, 'exclude_others_questions' ], 10, 2 );
+
+		register_rest_field(
+			'question',
+			'question-type-slug',
+			[
+				'get_callback' => function ( $object ) {
+					return Sensei()->question->get_question_type( $object['id'] );
+				},
+				'context'      => [ 'view' ],
+				'schema'       => [
+					'description' => __( 'The question type term slug.', 'sensei-lms' ),
+					'type'        => 'string',
+					'readOnly'    => true,
+				],
+			]
+		);
+	}
+
+	/**
+	 * Modifies the query for teachers so only their own questions are returned.
+	 *
+	 * @access private
+	 *
+	 * @param array           $args The query args.
+	 * @param WP_REST_Request $request The current REST request.
+	 * @return array The modified query args.
+	 */
+	public function exclude_others_questions( $args, $request ) {
+		if ( current_user_can( 'manage_sensei' ) ) {
+			return $args;
+		}
+
+		$current_user = wp_get_current_user();
+
+		$args['author'] = $current_user->ID;
+
+		return $args;
+	}
+
+	/**
+	 * Checks if a given request has access to read posts.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		$parent_check = parent::get_items_permissions_check( $request );
+
+		if ( is_wp_error( $parent_check ) ) {
+			return $parent_check;
+		}
+
+		$post_type = get_post_type_object( $this->post_type );
+
+		if ( ! current_user_can( $post_type->cap->edit_posts ) ) {
+			return new WP_Error(
+				'rest_forbidden_context',
+				__( 'Sorry, you are not allowed to view posts in this post type.', 'sensei-lms' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+}

--- a/includes/rest-api/class-sensei-rest-api-questions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-questions-controller.php
@@ -60,9 +60,8 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 			return $args;
 		}
 
-		$current_user = wp_get_current_user();
-
-		$args['author'] = $current_user->ID;
+		$current_user   = wp_get_current_user();
+		$args['author'] = $current_user ? $current_user->ID : -1;
 
 		return $args;
 	}

--- a/tests/framework/factories/class-wp-unittest-factory-for-question.php
+++ b/tests/framework/factories/class-wp-unittest-factory-for-question.php
@@ -29,7 +29,10 @@ class WP_UnitTest_Factory_For_Question extends WP_UnitTest_Factory_For_Post_Sens
 		$this->question_count++;
 		if ( isset( $args['quiz_id'] ) && ! isset( $args['post_author'] ) ) {
 			$args['post_author'] = get_post( $args['quiz_id'] )->post_author;
+		} elseif ( ! isset( $args['quiz_id'] ) ) {
+			$args['quiz_id'] = null;
 		}
+
 		$args = array_merge( $this->get_sample_question_data( $type ), $args );
 		return Sensei()->lesson->lesson_save_question( $args );
 	}

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-questions-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-questions-controller.php
@@ -111,7 +111,7 @@ class Sensei_REST_API_Questions_Controller_Tests extends WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * Tests to make sure teachers can access their own questions.
+	 * Tests to make sure admins can access all questions.
 	 */
 	public function testAdminCanAccessAllQuestions() {
 		$question_ids = [];

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-questions-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-questions-controller.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Sensei REST API: Sensei_REST_API_Questions_Controller tests
+ *
+ * @package sensei-lms
+ * @since 3.9.0
+ */
+
+/**
+ * Class Sensei_REST_API_Questions_Controller tests.
+ *
+ * @group rest-api
+ */
+class Sensei_REST_API_Questions_Controller_Tests extends WP_Test_REST_TestCase {
+	use Sensei_Test_Login_Helpers;
+
+	/**
+	 * A server instance that we use in tests to dispatch requests.
+	 *
+	 * @var WP_REST_Server $server
+	 */
+	protected $server;
+
+	/**
+	 * Sensei post factory.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Test specific setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		$this->factory = new Sensei_Factory();
+
+		do_action( 'rest_api_init' );
+
+		// We need to re-instantiate the controller on each tests to register any hooks.
+		new Sensei_REST_API_Questions_Controller( 'question' );
+	}
+
+	/**
+	 * Test specific teardown.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		global $wp_rest_server;
+		$wp_rest_server = null;
+	}
+
+	/**
+	 * Class wide setup.
+	 *
+	 * @param WP_UnitTest_Factory $factory Helper factory to create WP objects.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		$teacher_role = new Sensei_Teacher();
+		$teacher_role->create_role();
+	}
+
+	/**
+	 * Tests to make sure guests cannot access questions.
+	 */
+	public function testGuestsCannotAccessQuestions() {
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/questions' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_status(), 401 );
+	}
+
+	/**
+	 * Tests to make sure visitors cannot access questions.
+	 */
+	public function testVisitorsCannotAccessQuestions() {
+		$this->login_as_student();
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/questions' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_status(), 403 );
+	}
+
+	/**
+	 * Tests to make sure teachers can access their own questions.
+	 */
+	public function testTeacherCanAccessTheirOwnQuestions() {
+		$this->login_as_teacher();
+		$a = $this->factory->question->create();
+
+		$this->login_as_teacher_b();
+		$teacher_b_question = $this->factory->question->create();
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/questions' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_status(), 200 );
+
+		$data = $response->get_data();
+
+		$this->assertEquals( 1, count( $data ), 'Should only have one question' );
+		$this->assertEquals( $teacher_b_question, $data[0]['id'], 'Should only see teacher B\'s question' );
+		$this->assertEquals( Sensei()->question->get_question_type( $teacher_b_question ), $data[0]['question-type-slug'], 'Question type slug should be filled' );
+	}
+
+	/**
+	 * Tests to make sure teachers can access their own questions.
+	 */
+	public function testAdminCanAccessAllQuestions() {
+		$question_ids = [];
+		$this->login_as_teacher();
+		$question_ids[] = $this->factory->question->create();
+
+		$this->login_as_teacher_b();
+		$question_ids[] = $this->factory->question->create();
+
+		$this->login_as_admin();
+		$question_ids[] = $this->factory->question->create();
+
+		$request  = new WP_REST_Request( 'GET', '/wp/v2/questions' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( $response->get_status(), 200 );
+
+		$data = $response->get_data();
+
+		$this->assertEquals( count( $question_ids ), count( $data ), 'Should see all questions' );
+
+		$fetched_question_ids = wp_list_pluck( $data, 'id' );
+		sort( $fetched_question_ids );
+
+		$this->assertEquals( $question_ids, $fetched_question_ids, 'All question IDs should be returned' );
+	}
+}


### PR DESCRIPTION
This will be used by the existing question selector. It will not be used to save question settings.

### Changes proposed in this Pull Request

* Exposes and protects the CPT REST API endpoints for questions.
* Exposes `question-type` and `question-category` taxonomies.
* Note: As with other views, teachers can only access their own questions.
* Even though the _term ID_ for the question type is already added, I also added `question-type-slug` for ease.

Helpful docs: [Posts REST API Endpoints](https://developer.wordpress.org/rest-api/reference/posts/#example-request) | Taxonomy REST API Endpoints 
### Testing instructions

The following example endpoints should be tested.
* `GET /wp-json/wp/v2/question-type` (used to get term IDs for filter form; note: name isn't friendly so for labels we'll have to map with our question answer map)
* `GET /wp-json/wp/v2/question-category` (used to get term IDs and labels for question categories)
* `GET /wp-json/wp/v2/questions?per_page=100`
*  `GET /wp-json/wp/v2/questions?per_page=100&search=elephants`
*  `GET /wp-json/wp/v2/questions?per_page=100&question-type=46` (where `46` is the term ID for the question type)
*  `GET /wp-json/wp/v2/questions?per_page=100&question-category=11` (where `11` is the term ID for the question category)