### PR TITLE
Preload course and quiz structure

### DIFF
--- a/assets/shared/structure/structure-store.js
+++ b/assets/shared/structure/structure-store.js
@@ -12,6 +12,7 @@ import { dispatch, registerStore, select, subscribe } from '@wordpress/data';
  * Internal dependencies
  */
 import { createReducerFromActionMap } from '../data/store-helpers';
+import '../data/api-fetch-preloaded-once';
 
 /**
  * Register structure store and subscribe to block editor save.

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -119,6 +119,12 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 			'blocks/single-course-style-editor.css',
 			[ 'sensei-shared-blocks-editor-style', 'sensei-editor-components-style' ]
 		);
+
+		global $post;
+		if ( null !== $post ) {
+			Sensei()->assets->preload_data( [ sprintf( '/sensei-internal/v1/course-structure/%d?context=edit', $post->ID ) ] );
+		}
+
 	}
 
 	/**

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -53,6 +53,12 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 			'blocks/single-lesson-style-editor.css',
 			[ 'sensei-shared-blocks-editor-style', 'sensei-editor-components-style' ]
 		);
+
+		global $post;
+		if ( null !== $post ) {
+			Sensei()->assets->preload_data( [ sprintf( '/sensei-internal/v1/lesson-quiz/%d?context=edit', $post->ID ) ] );
+		}
+
 	}
 
 	/**

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -54,11 +54,6 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 			[ 'sensei-shared-blocks-editor-style', 'sensei-editor-components-style' ]
 		);
 
-		global $post;
-		if ( null !== $post ) {
-			Sensei()->assets->preload_data( [ sprintf( '/sensei-internal/v1/lesson-quiz/%d?context=edit', $post->ID ) ] );
-		}
-
 	}
 
 	/**

--- a/includes/blocks/class-sensei-quiz-blocks.php
+++ b/includes/blocks/class-sensei-quiz-blocks.php
@@ -35,6 +35,11 @@ class Sensei_Quiz_Blocks extends Sensei_Blocks_Initializer {
 		Sensei()->assets->enqueue( 'sensei-quiz-blocks-editor', 'blocks/quiz/quiz.editor.css', [ 'sensei-shared-blocks-editor-style', 'sensei-editor-components-style' ] );
 
 		wp_localize_script( 'sensei-quiz-blocks', 'sensei_quiz_blocks', [ 'category_question_enabled' => Sensei()->feature_flags->is_enabled( 'block_editor_enable_category_questions' ) ] );
+
+		global $post;
+		if ( null !== $post ) {
+			Sensei()->assets->preload_data( [ sprintf( '/sensei-internal/v1/lesson-quiz/%d?context=edit', $post->ID ) ] );
+		}
 	}
 
 	/**


### PR DESCRIPTION

Send along quiz structure and course outline data when editing a post, instead of making a separate request for it.

### Changes proposed in this Pull Request

* Preload the REST API endpoint used to load the course & quiz structures

### Testing instructions

* Make sure course outline block and quiz block both work for courses with existing lessons & lessons with a quiz
* Check that there are no network requests when these blocks are added

