### PR TITLE
Add quiz options attribute normalizer

### DIFF
--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -86,3 +86,23 @@ const findQuestionBlock = ( blocks, { id, title } ) => {
 		( ! attributes.id && attributes.title === title );
 	return blocks.find( compare );
 };
+
+/**
+ * Normalize quiz options attribute coming from REST API.
+ *
+ * @param {Object}  options                       Quiz options.
+ * @param {boolean} options.pass_required         Whether is pass required.
+ * @param {number}  options.quiz_passmark         Percentage quiz passmark.
+ * @param {boolean} options.auto_grade            Whether auto grade.
+ * @param {boolean} options.allow_retakes         Whether allow retakes.
+ * @param {boolean} options.ramdom_question_order Whether random question order.
+ * @param {number}  options.show_questions        Number of questions to show.
+ */
+export const normalizeQuizOptionsAttribute = ( options ) => ( {
+	passRequired: options.pass_required,
+	quizPassmark: options.quiz_passmark,
+	autoGrade: options.auto_grade,
+	allowRetakes: options.allow_retakes,
+	randomQuestionOrder: options.ramdom_question_order,
+	showQuestions: options.show_questions,
+} );

--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -2,7 +2,11 @@ import { dispatch, select, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { registerStructureStore } from '../../shared/structure/structure-store';
-import { parseQuestionBlocks, syncQuestionBlocks } from './data';
+import {
+	parseQuestionBlocks,
+	syncQuestionBlocks,
+	normalizeQuizOptionsAttribute,
+} from './data';
 
 export const QUIZ_STORE = 'sensei/quiz-structure';
 
@@ -46,7 +50,7 @@ registerStructureStore( {
 		}
 
 		yield dispatch( 'core/block-editor' ).updateBlockAttributes( clientId, {
-			options: structure.options,
+			options: normalizeQuizOptionsAttribute( structure.options ),
 		} );
 
 		const questionBlocks = yield select( 'core/block-editor' ).getBlocks(


### PR DESCRIPTION
It's the second part of https://github.com/Automattic/sensei/pull/3987

### Changes proposed in this Pull Request

* It normalizes the data coming from the API to the quiz `options` attribute.

### Testing instructions

* Just make sure the quiz settings are rendered with the data coming from `/wp-json/sensei-internal/v1/lesson-quiz/636?context=edit&_locale=user`