### PR TITLE
Add question grade toolbar 

### DIFF
--- a/assets/blocks/quiz/question-block/block.json
+++ b/assets/blocks/quiz/question-block/block.json
@@ -20,7 +20,10 @@
       "type": "object"
     },
     "options": {
-      "type": "object"
+      "type": "object",
+      "default": {
+        "grade": 1
+      }
     }
   }
 }

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -3,9 +3,7 @@ $block: '.sensei-lms-question-block';
 @import '../answer-blocks/option-toggle';
 
 .sensei-lms-question-block {
-
-	$answer-box-color: currentColor;
-
+	
 	.editor-styles-wrapper .wp-block &__title, .editor-styles-wrapper .wp-block &__index {
 		font-size: 24px;
 		margin-top: 0;
@@ -29,6 +27,14 @@ $block: '.sensei-lms-question-block';
 		}
 	}
 
+	&__grade {
+		position: absolute;
+		right: 0;
+		top: 0;
+		font-size: 12px;
+		opacity: .9;
+	}
+
 	&__type-selector {
 
 		&__popover .sensei-toolbar-dropdown__option {
@@ -43,7 +49,7 @@ $block: '.sensei-lms-question-block';
 	}
 
 	&__text-input-placeholder, &__file-input-placeholder {
-		border: 2px solid $answer-box-color;
+		border: 2px solid currentColor;
 		border-radius: 2px;
 		padding: 5px;
 		min-height: 52px;
@@ -86,11 +92,15 @@ $block: '.sensei-lms-question-block';
 			opacity: 0.6;
 			font-size: 14px;
 			font-family: sans-serif;
-			margin-right: 2px;
-			margin-left: 12px;
-			padding: 4px;
 			height: auto;
 			line-height: inherit;
+
+			.edit-post-visual-editor & {
+				margin-right: 0;
+				margin-left: 12px;
+				padding: 4px;
+				padding-right: 0;
+			}
 		}
 	}
 

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -11,6 +11,9 @@ $block: '.sensei-lms-question-block';
 		margin-bottom: 0;
 		line-height: 1.25;
 	}
+	.editor-styles-wrapper .wp-block &__title {
+		margin-right: 56px;
+	}
 
 	&__index {
 		position: absolute;
@@ -32,6 +35,7 @@ $block: '.sensei-lms-question-block';
 		position: absolute;
 		right: 0;
 		top: 0;
+		line-height: 32px;
 		font-size: 12px;
 		opacity: .9;
 	}

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -1,6 +1,7 @@
 $block: '.sensei-lms-question-block';
 
 @import '../answer-blocks/option-toggle';
+@import './question-grade-toolbar';
 
 .sensei-lms-question-block {
 	

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -17,6 +17,12 @@ import { QuestionGradeToolbar } from './question-grade-toolbar';
 import QuestionSettings from './question-settings';
 import { QuestionTypeToolbar } from './question-type-toolbar';
 
+/**
+ * Format the question grade as `X points`.
+ *
+ * @param {number} grade Question grade.
+ * @return {string} Grade text.
+ */
 const formatGradeLabel = ( grade ) =>
 	// Translators: placeholder is the grade for the questions.
 	sprintf( _n( '%d point', '%d points', grade, 'sensei-lms' ), grade );

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -13,6 +13,7 @@ import { useBlockIndex } from '../../../shared/blocks/block-index';
 import SingleLineInput from '../../../shared/blocks/single-line-input';
 import { useHasSelected } from '../../../shared/helpers/blocks';
 import types from '../answer-blocks';
+import { QuestionGradeToolbar } from './question-grade-toolbar';
 import QuestionSettings from './question-settings';
 import { QuestionTypeToolbar } from './question-type-toolbar';
 
@@ -106,6 +107,14 @@ const QuestionEdit = ( props ) => {
 						value={ type }
 						onSelect={ ( nextValue ) =>
 							setAttributes( { type: nextValue } )
+						}
+					/>
+					<QuestionGradeToolbar
+						value={ options.grade }
+						onChange={ ( nextGrade ) =>
+							setAttributes( {
+								options: { ...options, grade: nextGrade },
+							} )
 						}
 					/>
 				</>

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -2,19 +2,23 @@
  * WordPress dependencies
  */
 import { BlockControls, InnerBlocks } from '@wordpress/block-editor';
-import { useDispatch, select } from '@wordpress/data';
+import { select, useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { useBlockIndex } from '../../../shared/blocks/block-index';
-import { useHasSelected } from '../../../shared/helpers/blocks';
 import SingleLineInput from '../../../shared/blocks/single-line-input';
+import { useHasSelected } from '../../../shared/helpers/blocks';
 import types from '../answer-blocks';
 import QuestionSettings from './question-settings';
 import { QuestionTypeToolbar } from './question-type-toolbar';
+
+const formatGradeLabel = ( grade ) =>
+	// Translators: placeholder is the grade for the questions.
+	sprintf( _n( '%d point', '%d points', grade, 'sensei-lms' ), grade );
 
 /**
  * Quiz question block editor.
@@ -26,7 +30,7 @@ import { QuestionTypeToolbar } from './question-type-toolbar';
  */
 const QuestionEdit = ( props ) => {
 	const {
-		attributes: { title, type, answer = {} },
+		attributes: { title, type, answer = {}, options },
 		setAttributes,
 		clientId,
 	} = props;
@@ -64,6 +68,9 @@ const QuestionEdit = ( props ) => {
 					onRemove={ () => removeBlock( clientId ) }
 				/>
 			</h2>
+			<div className="sensei-lms-question-block__grade">
+				{ formatGradeLabel( options.grade ) }
+			</div>
 			{ showContent && (
 				<>
 					<InnerBlocks

--- a/assets/blocks/quiz/question-block/question-grade-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-grade-toolbar.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, ToolbarGroup } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { chevronDown, chevronUp } from '@wordpress/icons';
+
+/**
+ * Question grade toolbar control.
+ *
+ * @param {Object}   props
+ * @param {number}   props.value    Grade value.
+ * @param {Function} props.onChange Grade setter.
+ */
+export const QuestionGradeToolbar = ( { value, onChange } ) => {
+	return (
+		<>
+			<ToolbarGroup className="sensei-lms-question-block__grade-toolbar">
+				<div className="sensei-lms-question-block__grade-toolbar__wrapper">
+					<div>
+						<input
+							type="number"
+							min="0"
+							step="1"
+							value={ value }
+							onChange={ ( e ) => onChange( +e.target.value ) }
+							title={ __( 'Question grade', 'sensei-lms' ) }
+						/>
+					</div>
+
+					<div className="sensei-lms-question-block__grade-toolbar__steppers">
+						<Button
+							onClick={ () => onChange( value + 1 ) }
+							className="sensei-lms-question-block__grade-toolbar__stepper is-up-button"
+							icon={ chevronUp }
+							help={ __(
+								'Increase question grade',
+								'sensei-lms'
+							) }
+						/>
+						<Button
+							onClick={ () =>
+								onChange( Math.max( 0, value - 1 ) )
+							}
+							className="sensei-lms-question-block__grade-toolbar__stepper is-down-button"
+							icon={ chevronDown }
+							help={ __(
+								'Decrease question grade',
+								'sensei-lms'
+							) }
+						/>
+					</div>
+				</div>
+			</ToolbarGroup>
+		</>
+	);
+};

--- a/assets/blocks/quiz/question-block/question-grade-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-grade-toolbar.js
@@ -33,7 +33,7 @@ export const QuestionGradeToolbar = ( { value, onChange } ) => {
 							onClick={ () => onChange( value + 1 ) }
 							className="sensei-lms-question-block__grade-toolbar__stepper is-up-button"
 							icon={ chevronUp }
-							help={ __(
+							label={ __(
 								'Increase question grade',
 								'sensei-lms'
 							) }
@@ -44,7 +44,7 @@ export const QuestionGradeToolbar = ( { value, onChange } ) => {
 							}
 							className="sensei-lms-question-block__grade-toolbar__stepper is-down-button"
 							icon={ chevronDown }
-							help={ __(
+							label={ __(
 								'Decrease question grade',
 								'sensei-lms'
 							) }

--- a/assets/blocks/quiz/question-block/question-grade-toolbar.scss
+++ b/assets/blocks/quiz/question-block/question-grade-toolbar.scss
@@ -1,0 +1,65 @@
+.sensei-lms-question-block__grade-toolbar {
+	&__wrapper {
+		border-radius: 2px;
+		align-self: center;
+		align-items: center;
+
+		* {
+			padding: 0;
+		}
+
+		span {
+			display: inline-block;
+			margin: 0 4px;
+		}
+	}
+
+	input {
+		width: 28px;
+		height: 28px;
+		min-height: 0;
+		padding: 2px;
+		margin-left: 12px;
+		border-radius: 2px;
+		background: none;
+		border: 1px solid currentColor;
+		outline: none;
+		text-align: center;
+		font-weight: bold;
+	}
+
+	input::-webkit-outer-spin-button,
+	input::-webkit-inner-spin-button {
+		-webkit-appearance: none;
+		margin: 0;
+	}
+
+	input[type=number] {
+		-moz-appearance: textfield;
+	}
+
+	&__steppers {
+		display: flex;
+		flex-direction: column;
+	}
+
+	&__stepper {
+		.components-toolbar & {
+			height: 24px;
+			min-width: 0 !important;
+
+			svg {
+				position: relative;
+				height: 20px;
+			}
+
+			&.is-up-button svg {
+				top: 5px;
+			}
+
+			&.is-down-button svg {
+				bottom: 5px;
+			}
+		}
+	}
+}

--- a/assets/blocks/quiz/question-block/question-grade-toolbar.scss
+++ b/assets/blocks/quiz/question-block/question-grade-toolbar.scss
@@ -9,7 +9,7 @@
 		}
 	}
 
-	input {
+	input[type=number] {
 		width: 28px;
 		height: 28px;
 		min-height: 0;

--- a/assets/blocks/quiz/question-block/question-grade-toolbar.scss
+++ b/assets/blocks/quiz/question-block/question-grade-toolbar.scss
@@ -7,11 +7,6 @@
 		* {
 			padding: 0;
 		}
-
-		span {
-			display: inline-block;
-			margin: 0 4px;
-		}
 	}
 
 	input {


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Add `X points` to the question block, similar to the frontend. (The format of this is customizable for the frontend in the settings, but we are not using that setting here to keep things simple)
* Add a toolbar control to set question grade. I ended up with a single numeric display and spinner buttons to increase/decrease. 

### Testing instructions

* Add a question. Change it's grade from the toolbar/settings. Make sure the same grade is displayed everywhere. 
* Check that the toolbar controls make sense and feel right

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img src="https://user-images.githubusercontent.com/176949/108533516-5b4a5580-72d9-11eb-9c01-48adc690738b.gif" />

