### PR TITLE
Add shared question notice

### DIFF
--- a/assets/blocks/quiz/question-block/question-block-helpers.js
+++ b/assets/blocks/quiz/question-block/question-block-helpers.js
@@ -13,7 +13,7 @@ export const SharedQuestionNotice = () => (
 		<Icon icon={ info } />
 		<Tooltip
 			text={ __(
-				'Changes to this question will affect other quizzes.',
+				'Any updates made to this question will also update it in any other quiz that includes it.',
 				'sensei-lms'
 			) }
 		>

--- a/assets/blocks/quiz/question-block/question-block-helpers.js
+++ b/assets/blocks/quiz/question-block/question-block-helpers.js
@@ -1,0 +1,23 @@
+/**
+ * WordPress dependencies
+ */
+import { Tooltip } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Icon, info } from '@wordpress/icons';
+
+/**
+ * Display a notice about the question being shared across quizzes.
+ */
+export const SharedQuestionNotice = () => (
+	<div className="sensei-lms-question-block__notice">
+		<Icon icon={ info } />
+		<Tooltip
+			text={ __(
+				'Changes to this question will affect other quizzes.',
+				'sensei-lms'
+			) }
+		>
+			<span>{ __( 'Shared Question', 'sensei-lms' ) }</span>
+		</Tooltip>
+	</div>
+);

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -212,4 +212,9 @@ $block: '.sensei-lms-question-block';
 			fill: currentColor;
 		}
 	}
+
+	.block-editor-inner-blocks {
+		margin-top: 28px;
+		margin-bottom: 28px;
+	}
 }

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -191,4 +191,25 @@ $block: '.sensei-lms-question-block';
 			text-align: right;
 		}
 	}
+
+	&__notice {
+		display: inline-flex;
+		align-items: center;
+		border-radius: 2px;
+		border-width: 0;
+		right: 0;
+		font-size: 12px;
+		padding: 1px 4px;
+		padding-left: 0;
+		margin-top: 2px;
+		background: rgba(#ccc, 0.2);
+		position: absolute;
+		cursor: default;
+		user-select: none;
+
+		svg {
+			height: 18px;
+			fill: currentColor;
+		}
+	}
 }

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -13,6 +13,7 @@ import { useBlockIndex } from '../../../shared/blocks/block-index';
 import SingleLineInput from '../../../shared/blocks/single-line-input';
 import { useHasSelected } from '../../../shared/helpers/blocks';
 import types from '../answer-blocks';
+import { SharedQuestionNotice } from './question-block-helpers';
 import { QuestionGradeToolbar } from './question-grade-toolbar';
 import QuestionSettings from './question-settings';
 import { QuestionTypeToolbar } from './question-type-toolbar';
@@ -37,7 +38,7 @@ const formatGradeLabel = ( grade ) =>
  */
 const QuestionEdit = ( props ) => {
 	const {
-		attributes: { title, type, answer = {}, options },
+		attributes: { title, type, answer = {}, options, shared },
 		setAttributes,
 		clientId,
 	} = props;
@@ -78,6 +79,7 @@ const QuestionEdit = ( props ) => {
 			<div className="sensei-lms-question-block__grade">
 				{ formatGradeLabel( options.grade ) }
 			</div>
+			{ hasSelected && shared && <SharedQuestionNotice /> }
 			{ showContent && (
 				<>
 					<InnerBlocks


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Adds a notice if a question is used in multiple quizzes.
  — visible when the question block is focused
  — has an extra tooltip explaining *Changes to this question will affect other quizzes.*

### Testing instructions

* Add some existing questions to a lesson (that are already used somewhere else). Save & reload the editor.
* Check that a `Shared question` notice is displayed for these questions in the block editor.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
<img src="https://user-images.githubusercontent.com/176949/108543981-1bd63600-72e6-11eb-925a-e28cbef3527f.gif" />


