### PR TITLE
Hide previous quiz meta boxes when quiz block has been added

### DIFF
--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -11,6 +11,7 @@ import { useAutoInserter } from '../../../shared/blocks/use-auto-inserter';
 import questionBlock from '../question-block';
 import { useQuizStructure } from '../quiz-store';
 import QuizSettings from './quiz-settings';
+import ToggleLegacyQuizMetaboxesWrapper from '../../toggle-legacy-quiz-metaboxes-wrapper';
 
 /**
  * Quiz block editor.
@@ -27,7 +28,7 @@ const QuizEdit = ( props ) => {
 
 	const { isPostTemplate } = props.attributes;
 
-	return (
+	const content = (
 		<>
 			<div className="sensei-lms-quiz-block__separator">
 				<span>{ __( 'Lesson Quiz', 'sensei-lms' ) }</span>
@@ -42,6 +43,12 @@ const QuizEdit = ( props ) => {
 			<div className="sensei-lms-quiz-block__separator" />
 			<QuizSettings { ...props } />
 		</>
+	);
+
+	return (
+		<ToggleLegacyQuizMetaboxesWrapper { ...props }>
+			{ content }
+		</ToggleLegacyQuizMetaboxesWrapper>
 	);
 };
 

--- a/assets/blocks/toggle-legacy-quiz-metaboxes-wrapper.js
+++ b/assets/blocks/toggle-legacy-quiz-metaboxes-wrapper.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
+ * Wrapper to toggle the quiz metaboxes.
+ *
+ * @param {Object} props
+ * @param {Object} props.children Wrapped children.
+ */
+const ToggleLegacyQuizMetaboxesWrapper = ( { children } ) => {
+	useEffect( () => {
+		if ( ! window.sensei_toggle_legacy_quiz_metaboxes ) {
+			return;
+		}
+
+		window.sensei_toggle_legacy_quiz_metaboxes();
+
+		return window.sensei_toggle_legacy_quiz_metaboxes;
+	}, [] );
+
+	return children;
+};
+
+export default ToggleLegacyQuizMetaboxesWrapper;

--- a/assets/js/lesson-metadata.js
+++ b/assets/js/lesson-metadata.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { escapeHTML } from '@wordpress/escape-html';
+import { dispatch, select } from '@wordpress/data';
 
 jQuery( document ).ready( function () {
 	var file_frame;
@@ -9,6 +10,36 @@ jQuery( document ).ready( function () {
 	/***************************************************************************************************
 	 * 	1 - Helper Functions.
 	 ***************************************************************************************************/
+
+	const blockEditorSelector = select( 'core/block-editor' );
+	const editPostSelector = select( 'core/edit-post' );
+	const editPostDispatcher = dispatch( 'core/edit-post' );
+	const LESSON_QUIZ_NAME = 'sensei-lms/quiz';
+
+	/**
+	 * Toggle meta boxes depending on the blocks.
+	 */
+	window.sensei_toggle_legacy_quiz_metaboxes = () => {
+		if ( ! blockEditorSelector ) {
+			return;
+		}
+
+		const quizBlockCount = blockEditorSelector.getGlobalBlockCount(
+			LESSON_QUIZ_NAME
+		);
+
+		const legacyMetaboxes = [
+			{ name: 'meta-box-lesson-quiz', deps: quizBlockCount },
+			{ name: 'meta-box-lesson-quiz-settings', deps: quizBlockCount },
+		];
+
+		legacyMetaboxes.forEach( ( { name, deps } ) => {
+			const enable = deps === 0;
+			if ( enable !== editPostSelector.isEditorPanelEnabled( name ) ) {
+				editPostDispatcher.toggleEditorPanelEnabled( name );
+			}
+		} );
+	};
 
 	/**
 	 * exists checks if selector exists


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Hide _Quiz Settings_ and _Quiz Questions_ meta boxes when quiz block has been added.
* Followed the same pattern as course outline meta boxes.

### Testing instructions

* Add a quiz block. Notice quiz meta boxes disappear. 
* Remove quiz block. Notice quiz meta boxes reappear. 