### PR TITLE
Remove question categories section from block settings

### DIFF
--- a/assets/blocks/quiz/question-block/question-settings.js
+++ b/assets/blocks/quiz/question-block/question-settings.js
@@ -37,10 +37,6 @@ const QuestionSettings = ( {
 					/>
 				) ) }
 			</PanelBody>
-			<PanelBody
-				title={ __( 'Question Categories', 'sensei-lms' ) }
-				initialOpen={ false }
-			></PanelBody>
 		</InspectorControls>
 	);
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This just removes the empty Question Category section from question block's settings added in #3979, since we ended up not wanting to do it here.

### Testing instructions

* Ensure the block settings for a question block has no category section

