### PR TITLE
Integrate REST api during saving

### DIFF
--- a/assets/blocks/course-outline/course-outline-store.js
+++ b/assets/blocks/course-outline/course-outline-store.js
@@ -32,7 +32,7 @@ const getEditorOutlineStructure = () => {
 		return null;
 	}
 
-	return extractStructure( outlineBlock.innerBlocks );
+	return { structure: extractStructure( outlineBlock.innerBlocks ) };
 };
 
 export const COURSE_STORE = 'sensei/course-structure';

--- a/assets/blocks/quiz/answer-blocks/gap-fill.js
+++ b/assets/blocks/quiz/answer-blocks/gap-fill.js
@@ -38,7 +38,7 @@ const GapFillAnswer = ( {
 					className={
 						'sensei-lms-question-block__text-input-placeholder'
 					}
-					value={ rightAnswers }
+					value={ rightAnswers || [] }
 					label={ false }
 					onChange={ ( nextValue ) =>
 						setAttributes( { rightAnswers: nextValue } )

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -86,7 +86,7 @@ const questionTypes = {
 };
 
 /**
- * Filters the quiz editor question types in order to support custom question types.
+ * Filters the quiz editor question types in order to support custom ones.
  *
  * @see sensei_quiz_mapped_api_attributes
  * @see sensei_quiz_mapped_block_attributes

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -86,8 +86,19 @@ const questionTypes = {
 };
 
 /**
- * Quiz editor question types.
+ * Filters the quiz editor question types in order to support custom question types.
  *
- * @param {Object.<string, QuestionType>}
+ * @see sensei_quiz_mapped_api_attributes
+ * @see sensei_quiz_mapped_block_attributes
+ *
+ * @param {Object}   questionTypes             The question types.
+ * @param {string}   questionTypes.title       The title of the question.
+ * @param {string}   questionTypes.description The description of the question.
+ * @param {Function} questionTypes.edit        The block edit function for the question. Attributes under 'answer', as
+ *                                             returned from the 'sensei_quiz_mapped_api_attributes' filter, will be
+ *                                             passed to this component.
+ * @param {Array}    questionTypes.settings    An array of settings components to use in the sidebar. Attributes under 'options', as
+ *                                             returned from the 'sensei_quiz_mapped_api_attributes' filter, will be
+ *                                             passed to all settings components.
  */
 export default applyFilters( 'sensei_quiz_question_types', questionTypes );

--- a/assets/blocks/quiz/answer-blocks/multiple-choice.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice.js
@@ -27,11 +27,15 @@ const DEFAULT_ANSWERS = [
  * @param {Object} props
  */
 const MultipleChoiceAnswer = ( props ) => {
-	const {
-		attributes: { answers = DEFAULT_ANSWERS },
-		setAttributes,
-		hasSelected,
+	const { setAttributes, hasSelected } = props;
+
+	let {
+		attributes: { answers = [] },
 	} = props;
+
+	if ( answers.length === 0 ) {
+		answers = DEFAULT_ANSWERS;
+	}
 
 	const hasMultipleRight = answers.filter( ( a ) => a.isRight ).length > 1;
 
@@ -63,6 +67,11 @@ const MultipleChoiceAnswer = ( props ) => {
 	 * @param {number} index Answer position
 	 */
 	const removeAnswer = ( index ) => {
+		// Do not allow the user to remove all the answers.
+		if ( answers.length === 1 ) {
+			return;
+		}
+
 		setFocus( index - 1 );
 		const nextAnswers = [ ...answers ];
 		nextAnswers.splice( index, 1 );

--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -46,6 +46,10 @@ import { mapKeys, mapValues, isObject } from 'lodash';
  * @return {Object[]} Updated blocks.
  */
 export function syncQuestionBlocks( structure, blocks ) {
+	if ( ! structure || structure.length === 0 ) {
+		return [ createBlock( 'sensei-lms/quiz-question', {} ) ];
+	}
+
 	return ( structure || [] ).map( ( item ) => {
 		const { description, ...question } = item;
 

--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -79,17 +79,24 @@ export function syncQuestionBlocks( structure, blocks ) {
  * Convert blocks to question structure.
  *
  * @param {Object[]} blocks Blocks.
+ *
  * @return {QuizQuestion[]} Question structure
  */
 export function parseQuestionBlocks( blocks ) {
-	return blocks
-		?.map( ( block ) => {
-			return {
-				...getApiArgsFromAttributes( block.attributes ),
-				description: getBlockContent( block ),
-			};
-		} )
-		.filter( ( block ) => !! block.title );
+	const questions = blocks?.map( ( block ) => {
+		return {
+			...getApiArgsFromAttributes( block.attributes ),
+			description: getBlockContent( block ),
+		};
+	} );
+
+	const lastQuestion = questions.pop();
+
+	if ( lastQuestion.title ) {
+		questions.push( lastQuestion );
+	}
+
+	return questions;
 }
 
 /**

--- a/assets/blocks/quiz/question-block/question-block-attributes.js
+++ b/assets/blocks/quiz/question-block/question-block-attributes.js
@@ -106,8 +106,8 @@ const getTypeAttributes = ( apiAttributes ) => {
 	 */
 	return applyFilters(
 		'sensei_quiz_mapped_api_attributes',
-		apiAttributes.type,
-		blockAttributes
+		blockAttributes,
+		apiAttributes.type
 	);
 };
 

--- a/assets/blocks/quiz/question-block/question-block-attributes.js
+++ b/assets/blocks/quiz/question-block/question-block-attributes.js
@@ -109,9 +109,9 @@ const getTypeArgs = ( attributes ) => {
 			};
 		case 'gap-fill':
 			return {
-				before: attributes.answer?.textBefore,
-				gap: attributes.answer?.rightAnswers,
-				after: attributes.answer?.textAfter,
+				before: attributes.answer?.textBefore || '',
+				gap: attributes.answer?.rightAnswers || [],
+				after: attributes.answer?.textAfter || '',
 			};
 		case 'single-line':
 			return {};

--- a/assets/blocks/quiz/question-block/question-block-attributes.js
+++ b/assets/blocks/quiz/question-block/question-block-attributes.js
@@ -114,10 +114,12 @@ const getTypeArgs = ( attributes ) => {
 				after: attributes.answer?.textAfter || '',
 			};
 		case 'single-line':
-			return {};
 		case 'multi-line':
-			return {};
 		case 'file-upload':
+			return {
+				teacher_notes: attributes.options?.gradingNotes || null,
+			};
+		default:
 			return {};
 	}
 };

--- a/assets/blocks/quiz/question-block/question-block-attributes.js
+++ b/assets/blocks/quiz/question-block/question-block-attributes.js
@@ -60,3 +60,64 @@ const getTypeAttributes = {
 		},
 	} ),
 };
+
+/**
+ * Generate the REST API arguments from block attributes.
+ *
+ * @param {Object} attributes Block attributes.
+ *
+ * @return {Object} REST API parameters.
+ */
+export const getApiArgsFromAttributes = ( attributes ) => {
+	const commonArgs = {
+		id: attributes?.id,
+		title: attributes?.title,
+		type: attributes.type,
+		grade: attributes.options?.grade,
+	};
+
+	return {
+		...commonArgs,
+		...getTypeArgs( attributes ),
+	};
+};
+
+/**
+ * Helper method to get type specific REST arguments.
+ *
+ * @param {Object} attributes Block attributes.
+ *
+ * @return {Object} Type specific arguments.
+ */
+const getTypeArgs = ( attributes ) => {
+	switch ( attributes.type ) {
+		case 'multiple-choice':
+			return {
+				answer_feedback: attributes.options?.answerFeedback || null,
+				random_order: attributes.options?.randomOrder,
+				options: attributes.answer?.answers.map(
+					( { title, isRight } ) => ( {
+						label: title,
+						correct: isRight,
+					} )
+				),
+			};
+		case 'boolean':
+			return {
+				answer: attributes.answer?.rightAnswer,
+				answer_feedback: attributes.options?.answerFeedback || null,
+			};
+		case 'gap-fill':
+			return {
+				before: attributes.answer?.textBefore,
+				gap: attributes.answer?.rightAnswers,
+				after: attributes.answer?.textAfter,
+			};
+		case 'single-line':
+			return {};
+		case 'multi-line':
+			return {};
+		case 'file-upload':
+			return {};
+	}
+};

--- a/assets/blocks/quiz/question-block/question-block-attributes.js
+++ b/assets/blocks/quiz/question-block/question-block-attributes.js
@@ -101,8 +101,8 @@ const getTypeAttributes = ( apiAttributes ) => {
 	/**
 	 * Filters the attributes that will be supplied to the question block after they are received by REST API.
 	 *
-	 * @param {string} type            The question type.
 	 * @param {Object} blockAttributes The block attributes.
+	 * @param {string} type            The question type.
 	 */
 	return applyFilters(
 		'sensei_quiz_mapped_api_attributes',

--- a/assets/blocks/quiz/question-block/question-block-attributes.js
+++ b/assets/blocks/quiz/question-block/question-block-attributes.js
@@ -92,11 +92,23 @@ const getTypeAttributes = ( apiAttributes ) => {
 			blockAttributes = {};
 			break;
 		default:
-			blockAttributes = normalizeAttributes( apiAttributes, camelCase );
+			blockAttributes = {
+				answer: normalizeAttributes( apiAttributes, camelCase ),
+			};
 			break;
 	}
 
-	return applyFilters( 'sensei_quiz_mapped_api_attributes', blockAttributes );
+	/**
+	 * Filters the attributes that will be supplied to the question block after they are received by REST API.
+	 *
+	 * @param {string} type            The question type.
+	 * @param {Object} blockAttributes The block attributes.
+	 */
+	return applyFilters(
+		'sensei_quiz_mapped_api_attributes',
+		apiAttributes.type,
+		blockAttributes
+	);
 };
 
 /**
@@ -164,9 +176,21 @@ const getTypeArgs = ( attributes ) => {
 			};
 			break;
 		default:
-			apiAttributes = normalizeAttributes( attributes, snakeCase );
+			const normalizedAttributes = normalizeAttributes(
+				attributes,
+				snakeCase
+			);
+			apiAttributes = {
+				...normalizedAttributes?.answer,
+				...normalizedAttributes?.options,
+			};
 			break;
 	}
 
+	/**
+	 * Filters the attributes that will be sent to the REST API when updating a block.
+	 *
+	 * @param {Object} apiAttributes The REST API attributes.
+	 */
 	return applyFilters( 'sensei_quiz_mapped_block_attributes', apiAttributes );
 };

--- a/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
@@ -1,3 +1,6 @@
+/**
+ * WordPress dependencies
+ */
 import { CheckboxControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 

--- a/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
@@ -8,18 +8,18 @@ import { __ } from '@wordpress/i18n';
  * Question block settings for multiple choice questions.
  *
  * @param {Object}   props
- * @param {Object}   props.options
- * @param {boolean}  props.options.randomAnswerOrder Display answer options in random order.
- * @param {Function} props.setOptions
+ * @param {Object}   props.options             Multiple choice question options.
+ * @param {boolean}  props.options.randomOrder Display options in random order.
+ * @param {Function} props.setOptions          Sets the options.
  */
 const QuestionMultipleChoiceSettings = ( {
-	options: { randomAnswerOrder = true },
+	options: { randomOrder = true },
 	setOptions,
 } ) => (
 	<CheckboxControl
 		label={ __( 'Random Order', 'sensei-lms' ) }
-		checked={ randomAnswerOrder }
-		onChange={ ( value ) => setOptions( { randomAnswerOrder: value } ) }
+		checked={ randomOrder }
+		onChange={ ( value ) => setOptions( { randomOrder: value } ) }
 	/>
 );
 

--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -21,6 +21,8 @@ import { camelCase, snakeCase, omit } from 'lodash';
 
 export const QUIZ_STORE = 'sensei/quiz-structure';
 
+const READ_ONLY_ATTRIBUTES = [ 'categories', 'shared', 'student_help' ];
+
 /**
  * Syncronize this block with quiz data.
  *
@@ -158,7 +160,7 @@ registerStructureStore( {
 		return {
 			...structure,
 			questions: structure.questions.map( ( question ) =>
-				omit( question, [ 'categories', 'shared', 'student_help' ] )
+				omit( question, READ_ONLY_ATTRIBUTES )
 			),
 		};
 	},

--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -158,7 +158,7 @@ registerStructureStore( {
 		return {
 			...structure,
 			questions: structure.questions.map( ( question ) =>
-				omit( question, [ 'categories', 'shared' ] )
+				omit( question, [ 'categories', 'shared', 'student_help' ] )
 			),
 		};
 	},

--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -157,6 +157,10 @@ registerStructureStore( {
 	 * @return {Object} The modified response.
 	 */
 	setServerStructure( structure ) {
+		if ( ! structure ) {
+			return {};
+		}
+
 		return {
 			...structure,
 			questions: structure.questions.map( ( question ) =>

--- a/assets/shared/blocks/use-auto-inserter.js
+++ b/assets/shared/blocks/use-auto-inserter.js
@@ -52,12 +52,20 @@ export const useAutoInserter = (
 
 	const lastBlock = blocks.length && blocks[ blocks.length - 1 ];
 	const hasEmptyLastBlock = lastBlock && ! lastBlock.attributes.title;
+	const hasAutoBlock =
+		null !==
+		useSelect(
+			( select ) =>
+				autoBlockClientId &&
+				select( 'core/block-editor' ).getBlock( autoBlockClientId ),
+			[ autoBlockClientId ]
+		);
 
 	useEffect( () => {
 		if (
 			hasSelected &&
 			! hasEmptyLastBlock &&
-			( ! autoBlockClientId || lastBlock.clientId === autoBlockClientId )
+			( ! hasAutoBlock || lastBlock.clientId === autoBlockClientId )
 		) {
 			createAndInsertBlock();
 		}
@@ -72,7 +80,7 @@ export const useAutoInserter = (
 			setAutoBlockClientId( null );
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [ hasSelected, hasEmptyLastBlock ] );
+	}, [ hasSelected, hasEmptyLastBlock, hasAutoBlock ] );
 
 	const isAutoBlockSelected = useSelect(
 		( select ) =>

--- a/assets/shared/blocks/use-auto-inserter.test.js
+++ b/assets/shared/blocks/use-auto-inserter.test.js
@@ -33,6 +33,7 @@ describe( 'useAutoInserter', () => {
 		hasSelectedInnerBlock: () => false,
 		isBlockSelected: () => false,
 		getBlocks: () => [],
+		getBlock: () => null,
 	};
 
 	const mockSelect = ( value ) =>

--- a/assets/shared/structure/structure-store.js
+++ b/assets/shared/structure/structure-store.js
@@ -232,7 +232,8 @@ export function registerStructureStore( {
 	};
 
 	const subscribeToPostSave = () => {
-		let postSaving = false;
+		let structureIsSaving = false;
+		let editorStartedSaving = false;
 
 		return subscribe( function saveStructureOnPostSave() {
 			const editor = select( 'core/editor' );
@@ -247,13 +248,22 @@ export function registerStructureStore( {
 				storeName
 			).getIsSavingStructure();
 
-			if ( ! postSaving && isSavingPost ) {
-				// First update where post is saving.
-				postSaving = true;
+			if ( isSavingPost ) {
+				editorStartedSaving = true;
+			}
+
+			if (
+				! structureIsSaving &&
+				! isSavingPost &&
+				editorStartedSaving
+			) {
+				// Start saving structure when post has finished saving.
+				structureIsSaving = true;
+				editorStartedSaving = false;
 				dispatch( storeName ).startPostSave();
-			} else if ( postSaving && ! isSavingPost && ! isSavingStructure ) {
-				// First update where both post and structure have finished saving.
-				postSaving = false;
+			} else if ( structureIsSaving && ! isSavingStructure ) {
+				// Call finishPostSave when structure has finished saving.
+				structureIsSaving = false;
 				dispatch( storeName ).finishPostSave();
 			}
 		} );

--- a/assets/shared/structure/structure-store.test.js
+++ b/assets/shared/structure/structure-store.test.js
@@ -56,7 +56,7 @@ describe( 'Structure store', () => {
 	} );
 
 	it( 'Saves structure when post is being saved', function () {
-		store.readBlock.mockReturnValue( 'block' );
+		store.readBlock.mockReturnValue( { structure: 'block' } );
 
 		dispatch( 'core/editor' ).savePost();
 

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -208,7 +208,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 			$question_id = $this->save_question( $question );
 
 			if ( is_wp_error( $question_id ) ) {
-				return new WP_REST_Response( $question_id );
+				return $question_id;
 			}
 
 			$question_ids[] = $question_id;

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -166,7 +166,16 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function save_quiz( WP_REST_Request $request ) {
-		$lesson  = get_post( (int) $request->get_param( 'lesson_id' ) );
+		$lesson = get_post( (int) $request->get_param( 'lesson_id' ) );
+
+		if ( 'auto-draft' === $lesson->post_status ) {
+			return new WP_Error(
+				'sensei_lesson_quiz_lesson_auto_draft',
+				__( 'Cannot update the quiz of an Auto Draft lesson.', 'sensei-lms' ),
+				[ 'status' => 400 ]
+			);
+		}
+
 		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson->ID );
 		$is_new  = null === $quiz_id;
 
@@ -186,7 +195,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 		);
 
 		if ( is_wp_error( $quiz_id ) ) {
-			return new WP_REST_Response( $quiz_id );
+			return $quiz_id;
 		}
 
 		if ( $is_new ) {

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -83,7 +83,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		 */
 		do_action( 'sensei_rest_api_question_saved', $result, $question['type'], $question );
 
-		return wp_insert_post( $post_args );
+		return $result;
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -69,6 +69,20 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			$post_args['post_title'] = $question['title'];
 		}
 
+		$result = wp_insert_post( $post_args );
+
+		/**
+		 * This action is triggered when a question is created or updated by the lesson quiz REST endpoint.
+		 *
+		 * @since 3.9.0
+		 * @hook sensei_rest_api_question_saved
+		 *
+		 * @param {int|WP_Error} $result        Result of wp_insert_post. Post ID on success or WP_Error on failure.
+		 * @param {string}       $question_type The question type.
+		 * @param {array}        $question      The question JSON arguments.
+		 */
+		do_action( 'sensei_rest_api_question_saved', $result, $question['type'], $question );
+
 		return wp_insert_post( $post_args );
 	}
 

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -51,8 +51,16 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	 * @return int|WP_Error Question id on success.
 	 */
 	private function save_question( $question ) {
+		if ( empty( $question['title'] ) ) {
+			return new WP_Error(
+				'sensei_lesson_quiz_question_missing_title',
+				__( 'Please ensure all questions have a title before saving.', 'sensei-lms' )
+			);
+		}
+
 		$post_args = [
 			'ID'          => isset( $question['id'] ) ? $question['id'] : null,
+			'post_title'  => $question['title'],
 			'post_status' => 'publish',
 			'post_type'   => 'question',
 			'meta_input'  => $this->get_question_meta( $question ),
@@ -63,10 +71,6 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 
 		if ( isset( $question['description'] ) ) {
 			$post_args['post_content'] = $question['description'];
-		}
-
-		if ( isset( $question['title'] ) ) {
-			$post_args['post_title'] = $question['title'];
 		}
 
 		$result = wp_insert_post( $post_args );

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -155,6 +155,10 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		}
 
 		if ( isset( $question['options'] ) ) {
+			$meta['_question_right_answer']  = [];
+			$meta['_question_wrong_answers'] = [];
+			$meta['_answer_order']           = [];
+
 			foreach ( $question['options'] as $option ) {
 				if ( empty( $option['label'] ) ) {
 					continue;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* The REST integration is implemented when updating the lesson's quiz.
* The settings of the quiz, although they are updated correctly, they are overwritten by the form that already exists in the lesson. The form will be hidden when [this PR](https://github.com/Automattic/sensei/pull/4009) is merged so after this point the quiz settings should work correctly. 

### Testing instructions

* Try creating and updating all different types of questions and observe that the questions are stored correctly.
* Observe that the questions are displayed correctly on the frontend.
* The quiz settings should be tested after one of the following PRs are merged and this branch is rebased: https://github.com/Automattic/sensei/pull/3972 https://github.com/Automattic/sensei/pull/4009

### New/Updated Hooks

* `sensei_rest_api_question_saved`: This action is triggered when a question is created or updated by the lesson quiz REST endpoint.
* `sensei_quiz_mapped_api_attributes`: Filters the attributes that are retrieved from the REST API in the frontend.
* `sensei_quiz_mapped_block_attributes`: Filters the attributes that will be sent to the REST API when updating a block.