### PR TITLE
Adjust question block controls

### DIFF
--- a/assets/blocks/quiz/answer-blocks/gap-fill.js
+++ b/assets/blocks/quiz/answer-blocks/gap-fill.js
@@ -25,6 +25,7 @@ const GapFillAnswer = ( {
 		<ul className="sensei-lms-question-block__answer sensei-lms-question-block__answer--gap-fill">
 			<li>
 				<RichText
+					className="sensei-lms-question-block__answer--gap-fill__text"
 					placeholder={ __( 'Text before the gap', 'sensei-lms' ) }
 					value={ textBefore }
 					onChange={ ( nextValue ) =>
@@ -54,6 +55,7 @@ const GapFillAnswer = ( {
 			</li>
 			<li>
 				<RichText
+					className="sensei-lms-question-block__answer--gap-fill__text"
 					placeholder={ __( 'Text after the gap', 'sensei-lms' ) }
 					value={ textAfter }
 					onChange={ ( nextValue ) =>

--- a/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
@@ -48,11 +48,7 @@ const MultipleChoiceAnswerOption = ( props ) => {
 
 	return (
 		<div className="sensei-lms-question-block__multiple-choice-answer-option">
-			<OptionToggle
-				onClick={ toggleRight }
-				isChecked={ isRight }
-				isCheckbox={ isCheckbox }
-			/>
+			<OptionToggle isChecked={ isRight } isCheckbox={ isCheckbox } />
 			<SingleLineInput
 				ref={ ref }
 				placeholder={ __( 'Add Answer', 'sensei-lms' ) }
@@ -64,14 +60,17 @@ const MultipleChoiceAnswerOption = ( props ) => {
 				{ ...inputProps }
 			/>
 			{ hasSelected && (
-				<Button
-					className="sensei-lms-question-block__answer--multiple-choice__hint"
-					onClick={ toggleRight }
-				>
-					{ isRight
-						? __( 'Right', 'sensei-lms' )
-						: __( 'Wrong', 'sensei-lms' ) }
-				</Button>
+				<div className="sensei-lms-question-block__answer--multiple-choice__toggle__wrapper">
+					<Button
+						isPrimary
+						className="sensei-lms-question-block__answer--multiple-choice__toggle"
+						onClick={ toggleRight }
+					>
+						{ isRight
+							? __( 'Right', 'sensei-lms' )
+							: __( 'Wrong', 'sensei-lms' ) }
+					</Button>
+				</div>
 			) }
 		</div>
 	);

--- a/assets/blocks/quiz/answer-blocks/multiple-choice.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice.js
@@ -4,6 +4,11 @@
 import { useState } from '@wordpress/element';
 
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * Internal dependencies
  */
 import MultipleChoiceAnswerOption from './multiple-choice-answer-option';
@@ -29,6 +34,13 @@ const MultipleChoiceAnswer = ( props ) => {
 	} = props;
 
 	const hasMultipleRight = answers.filter( ( a ) => a.isRight ).length > 1;
+
+	const hasDraft = ! answers[ answers.length - 1 ]?.title;
+
+	const answerItems = [ ...answers ];
+	if ( hasSelected && ! hasDraft ) {
+		answerItems.push( { title: '', isRight: false } );
+	}
 
 	/**
 	 * Add a new answer option.
@@ -77,8 +89,14 @@ const MultipleChoiceAnswer = ( props ) => {
 
 	return (
 		<ol className="sensei-lms-question-block__answer sensei-lms-question-block__answer--multiple-choice">
-			{ answers.map( ( answer, index ) => (
-				<li key={ index }>
+			{ answerItems.map( ( answer, index ) => (
+				<li
+					key={ index }
+					className={ classnames(
+						'sensei-lms-question-block__answer--multiple-choice__option',
+						{ 'is-draft': ! answer.title }
+					) }
+				>
 					<MultipleChoiceAnswerOption
 						hasFocus={ index === nextFocus }
 						isCheckbox={ hasMultipleRight }

--- a/assets/blocks/quiz/answer-blocks/option-toggle.js
+++ b/assets/blocks/quiz/answer-blocks/option-toggle.js
@@ -4,11 +4,6 @@
 import classnames from 'classnames';
 
 /**
- * WordPress dependencies
- */
-import { Button } from '@wordpress/components';
-
-/**
  * Internal dependencies
  */
 import { checked } from '../../../icons/wordpress-icons';
@@ -20,7 +15,7 @@ export const OptionToggle = ( {
 	children,
 	...props
 } ) => (
-	<Button
+	<div
 		className={ classnames(
 			'sensei-lms-question-block__option-toggle',
 			className
@@ -36,5 +31,5 @@ export const OptionToggle = ( {
 			{ isChecked && isCheckbox && checked }
 		</div>
 		{ children }
-	</Button>
+	</div>
 );

--- a/assets/blocks/quiz/answer-blocks/option-toggle.scss
+++ b/assets/blocks/quiz/answer-blocks/option-toggle.scss
@@ -1,6 +1,8 @@
 
 .sensei-lms-question-block__option-toggle {
 	color: inherit;
+	display: inline-flex;
+	align-items: center;
 	.edit-post-visual-editor & {
 		font-family: inherit;
 		font-size: inherit;

--- a/assets/blocks/quiz/answer-blocks/true-false.js
+++ b/assets/blocks/quiz/answer-blocks/true-false.js
@@ -43,19 +43,24 @@ const TrueFalseAnswer = ( {
 						<span>{ label }</span>
 					</OptionToggle>
 					{ hasSelected && (
-						<Button
-							className="sensei-lms-question-block__answer--true-false__hint"
-							onClick={ () =>
-								setAttributes( {
-									rightAnswer:
-										value === rightAnswer ? ! value : value,
-								} )
-							}
-						>
-							{ rightAnswer === value
-								? __( 'Right', 'sensei-lms' )
-								: __( 'Wrong', 'sensei-lms' ) }
-						</Button>
+						<div className="sensei-lms-question-block__answer--multiple-choice__toggle__wrapper">
+							<Button
+								isPrimary
+								className="sensei-lms-question-block__answer--true-false__toggle"
+								onClick={ () =>
+									setAttributes( {
+										rightAnswer:
+											value === rightAnswer
+												? ! value
+												: value,
+									} )
+								}
+							>
+								{ rightAnswer === value
+									? __( 'Right', 'sensei-lms' )
+									: __( 'Wrong', 'sensei-lms' ) }
+							</Button>
+						</div>
 					) }
 				</li>
 			) ) }

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -108,6 +108,11 @@ $block: '.sensei-lms-question-block';
 			}
 		}
 	}
+
+	&__answer--multiple-choice {
+		&__option.is-draft {
+			.sensei-lms-question-block__option-toggle, .sensei-lms-question-block__answer--multiple-choice__toggle {
+				opacity: 0.5;
 			}
 		}
 	}

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -4,13 +4,14 @@ $block: '.sensei-lms-question-block';
 @import './question-grade-toolbar';
 
 .sensei-lms-question-block {
-	
+
 	.editor-styles-wrapper .wp-block &__title, .editor-styles-wrapper .wp-block &__index {
 		font-size: 24px;
 		margin-top: 0;
 		margin-bottom: 0;
 		line-height: 1.25;
 	}
+
 	.editor-styles-wrapper .wp-block &__title {
 		margin-right: 56px;
 	}
@@ -36,8 +37,7 @@ $block: '.sensei-lms-question-block';
 		right: 0;
 		top: 0;
 		line-height: 32px;
-		font-size: 12px;
-		opacity: .9;
+		font-size: 14px;
 	}
 
 	&__type-selector {
@@ -75,8 +75,6 @@ $block: '.sensei-lms-question-block';
 	}
 
 	&__input-label {
-		opacity: 0.7;
-		font-size: 90%;
 	}
 
 	&__answer--multiple-choice, &__answer--true-false, &__answer--gap-fill {
@@ -182,6 +180,13 @@ $block: '.sensei-lms-question-block';
 			&__help {
 				display: none;
 			}
+		}
+
+		&__text {
+			border: 1px solid rgba(#ccc, 0.75);
+			padding: 12px;
+			border-radius: 2px;
+
 		}
 
 		.editor-styles-wrapper &__right-answers {

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -91,20 +91,23 @@ $block: '.sensei-lms-question-block';
 	}
 
 	&__answer--multiple-choice, &__answer--true-false {
-		&__hint {
-			text-transform: uppercase;
-			color: inherit;
-			opacity: 0.6;
-			font-size: 14px;
-			font-family: sans-serif;
-			height: auto;
-			line-height: inherit;
+		&__toggle {
+
+			&__wrapper {
+				flex-basis: 65px;
+				margin-left: 12px;
+			}
 
 			.edit-post-visual-editor & {
-				margin-right: 0;
-				margin-left: 12px;
+				margin: 0;
 				padding: 4px;
-				padding-right: 0;
+				font-size: 12px;
+				height: auto;
+				text-transform: uppercase;
+				background: #111;
+			}
+		}
+	}
 			}
 		}
 	}

--- a/assets/blocks/quiz/question-block/question-grade-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-grade-toolbar.js
@@ -1,9 +1,8 @@
 /**
  * WordPress dependencies
  */
-import { Button, ToolbarGroup } from '@wordpress/components';
+import { ToolbarGroup } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { chevronDown, chevronUp } from '@wordpress/icons';
 
 /**
  * Question grade toolbar control.
@@ -16,41 +15,14 @@ export const QuestionGradeToolbar = ( { value, onChange } ) => {
 	return (
 		<>
 			<ToolbarGroup className="sensei-lms-question-block__grade-toolbar">
-				<div className="sensei-lms-question-block__grade-toolbar__wrapper">
-					<div>
-						<input
-							type="number"
-							min="0"
-							step="1"
-							value={ value }
-							onChange={ ( e ) => onChange( +e.target.value ) }
-							title={ __( 'Question grade', 'sensei-lms' ) }
-						/>
-					</div>
-
-					<div className="sensei-lms-question-block__grade-toolbar__steppers">
-						<Button
-							onClick={ () => onChange( value + 1 ) }
-							className="sensei-lms-question-block__grade-toolbar__stepper is-up-button"
-							icon={ chevronUp }
-							label={ __(
-								'Increase question grade',
-								'sensei-lms'
-							) }
-						/>
-						<Button
-							onClick={ () =>
-								onChange( Math.max( 0, value - 1 ) )
-							}
-							className="sensei-lms-question-block__grade-toolbar__stepper is-down-button"
-							icon={ chevronDown }
-							label={ __(
-								'Decrease question grade',
-								'sensei-lms'
-							) }
-						/>
-					</div>
-				</div>
+				<input
+					type="number"
+					min="0"
+					step="1"
+					value={ value }
+					onChange={ ( e ) => onChange( +e.target.value ) }
+					title={ __( 'Question grade', 'sensei-lms' ) }
+				/>
 			</ToolbarGroup>
 		</>
 	);

--- a/assets/blocks/quiz/question-block/question-grade-toolbar.scss
+++ b/assets/blocks/quiz/question-block/question-grade-toolbar.scss
@@ -1,60 +1,19 @@
 .sensei-lms-question-block__grade-toolbar {
-	&__wrapper {
-		border-radius: 2px;
-		align-self: center;
-		align-items: center;
-
-		* {
-			padding: 0;
-		}
-	}
-
 	input[type=number] {
-		width: 28px;
-		height: 28px;
+		align-self: center;
+		width: 42px;
+		height: 32px;
 		min-height: 0;
 		padding: 2px;
-		margin-left: 12px;
-		border-radius: 2px;
+		margin: 0 12px;
 		background: none;
-		border: 1px solid currentColor;
+		border-width: 1px;
+		&:not(:focus) {
+			border-color: currentColor;
+		}
+		border-radius: 2px;
 		outline: none;
 		text-align: center;
 		font-weight: bold;
-	}
-
-	input::-webkit-outer-spin-button,
-	input::-webkit-inner-spin-button {
-		-webkit-appearance: none;
-		margin: 0;
-	}
-
-	input[type=number] {
-		-moz-appearance: textfield;
-	}
-
-	&__steppers {
-		display: flex;
-		flex-direction: column;
-	}
-
-	&__stepper {
-		.components-toolbar & {
-			height: 24px;
-			min-width: 0 !important;
-
-			svg {
-				position: relative;
-				height: 20px;
-			}
-
-			&.is-up-button svg {
-				top: 5px;
-			}
-
-			&.is-down-button svg {
-				bottom: 5px;
-			}
-		}
 	}
 }


### PR DESCRIPTION
Various adjustments following up a design review on the blocks.

### Changes proposed in this Pull Request

* Update the right/wrong controls for multi-choice and true-false answers: toggle this with a more visible button only, not the checkboxes
* Multiple choice: Auto-insert a draft answer when the block is focused, so it's easier to insert a new answer
* Gap Fill: add a light border for the Text Before / After fields so it's clearer that it should be filled
* Simplify Grade toolbar control to just use the browser number spinner
* Use (darker) text color for some static content like `Answer:` label and grade `X points` element. 

### Testing instructions

* Open a lesson with a quiz block
* Edit multiple choice options
* Edit grade from toolbar
* Gaze upon the blocks
* Check that it all looks right

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video


![QuickTime movie](https://user-images.githubusercontent.com/176949/109047302-fb3b2100-76d5-11eb-8d18-2c87af2ab0df.gif)

---- 
<img width="664" alt="image" src="https://user-images.githubusercontent.com/176949/109047276-f5ddd680-76d5-11eb-86c5-18a7b2297ccf.png">


