### PR TITLE
REST API: Retrieve individual question options

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-internal.php
+++ b/includes/rest-api/class-sensei-rest-api-internal.php
@@ -49,6 +49,7 @@ class Sensei_REST_API_Internal {
 			new Sensei_REST_API_Export_Controller( $this->namespace ),
 			new Sensei_REST_API_Course_Structure_Controller( $this->namespace ),
 			new Sensei_REST_API_Lesson_Quiz_Controller( $this->namespace ),
+			new Sensei_REST_API_Question_Options_Controller( $this->namespace ),
 		];
 
 		foreach ( $this->controllers as $controller ) {

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -391,6 +391,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 				'questions' => [
 					'type'     => 'array',
 					'required' => true,
+					'items'    => $this->get_single_question_schema(),
 				],
 			],
 		];

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -89,6 +89,9 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 	/**
 	 * Sanitization method for questions.
 	 *
+	 * This can be replaced by `rest_sanitize_request_arg` in the callback once we no longer support WordPress
+	 * versions before 5.6 (when `oneOf` support was added).
+	 *
 	 * @param array $questions The questions.
 	 *
 	 * @return array|WP_Error The sanitized questions.
@@ -110,6 +113,9 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 
 	/**
 	 * Validation method for questions.
+	 *
+	 * This can be replaced by `rest_validate_request_arg` in the callback once we no longer support WordPress
+	 * versions before 5.6 (when `oneOf` support was added).
 	 *
 	 * @param array $questions The questions.
 	 *

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -453,7 +453,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	 *
 	 * @return array The properties
 	 */
-	private function get_common_question_properties_schema() : array {
+	public function get_common_question_properties_schema() : array {
 		return [
 			'id'          => [
 				'type'        => 'integer',

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -416,7 +416,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	 */
 	public function get_single_question_schema() {
 		$single_question_schema = [
-			'anyOf' => [
+			'oneOf' => [
 				[
 					'$ref' => '#/definitions/question_multiple_choice',
 				],
@@ -435,7 +435,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 				[
 					'$ref' => '#/definitions/question_file_upload',
 				],
-			]
+			],
 		];
 
 		if ( ! is_wp_version_compatible( '5.6.0' ) ) {

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -410,6 +410,85 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	}
 
 	/**
+	 * Get the schema for a single question.
+	 *
+	 * @return array
+	 */
+	public function get_single_question_schema() {
+		$single_question_schema = [
+			'anyOf' => [
+				[
+					'$ref' => '#/definitions/question_multiple_choice',
+				],
+				[
+					'$ref' => '#/definitions/question_boolean',
+				],
+				[
+					'$ref' => '#/definitions/question_gap_fill',
+				],
+				[
+					'$ref' => '#/definitions/question_single_line',
+				],
+				[
+					'$ref' => '#/definitions/question_multi_line',
+				],
+				[
+					'$ref' => '#/definitions/question_file_upload',
+				],
+			]
+		];
+
+		if ( ! is_wp_version_compatible( '5.6.0' ) ) {
+			$single_question_schema = [];
+		}
+
+		/*
+		 * Add additional question types to the REST API schema.
+		 *
+		 * @since 3.9.0
+		 * @hook sensei_rest_api_schema_single_question
+		 *
+		 * @param {Array} $schema Schema for a single question.
+		 *
+		 * @return {array}
+		 */
+		return apply_filters( 'sensei_rest_api_schema_single_question', $single_question_schema );
+	}
+
+	/**
+	 * Helper method which returns the question schema definitions.
+	 *
+	 * @return array The definitions
+	 */
+	private function get_question_definitions() : array {
+		$question_definitions = [
+			'question_multiple_choice' => $this->get_multiple_choice_schema(),
+			'question_boolean'         => $this->get_boolean_schema(),
+			'question_gap_fill'        => $this->get_gap_fill_schema(),
+			'question_single_line'     => $this->get_single_question_schema(),
+			'question_multi_line'      => $this->get_multi_line_schema(),
+			'question_file_upload'     => $this->get_file_upload_schema(),
+		];
+
+		if ( ! is_wp_version_compatible( '5.6.0' ) ) {
+			// These aren't used in versions before 5.6.0 so we can just clear them out.
+			$question_definitions = [];
+		}
+
+		/*
+		 * Add additional definitions to the question types.
+		 *
+		 * @since 3.9.0
+		 * @hook sensei_rest_api_schema_question_type_definitions
+		 *
+		 * @param {Array} $schema Schema definitions for questions.
+		 *
+		 * @return {array}
+		 */
+		return apply_filters( 'sensei_rest_api_schema_question_type_definitions', $question_definitions );
+	}
+
+	/**
 	 * Helper method which returns the schema for common question properties.
 	 *
 	 * @return array The properties

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -439,7 +439,9 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		];
 
 		if ( ! is_wp_version_compatible( '5.6.0' ) ) {
-			$single_question_schema = [];
+			$single_question_schema = [
+				'type' => 'object',
+			];
 		}
 
 		/*

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -313,10 +313,13 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		 * Allows modification of type specific question properties.
 		 *
 		 * @since 3.9.0
+		 * @hook sensei_question_type_specific_properties
 		 *
-		 * @param array   $type_specific_properties The properties of the question.
-		 * @param string  $question_type            The question type.
-		 * @param WP_Post $question                 The question post.
+		 * @param {array}   $type_specific_properties The properties of the question.
+		 * @param {string}  $question_type            The question type.
+		 * @param {WP_Post} $question                 The question post.
+		 *
+		 * @return {array}
 		 */
 		return apply_filters( 'sensei_question_type_specific_properties', $type_specific_properties, $question_type, $question );
 	}

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -417,24 +417,12 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	public function get_single_question_schema() {
 		$single_question_schema = [
 			'oneOf' => [
-				[
-					'$ref' => '#/definitions/question_multiple_choice',
-				],
-				[
-					'$ref' => '#/definitions/question_boolean',
-				],
-				[
-					'$ref' => '#/definitions/question_gap_fill',
-				],
-				[
-					'$ref' => '#/definitions/question_single_line',
-				],
-				[
-					'$ref' => '#/definitions/question_multi_line',
-				],
-				[
-					'$ref' => '#/definitions/question_file_upload',
-				],
+				$this->get_multiple_choice_schema(),
+				$this->get_boolean_schema(),
+				$this->get_gap_fill_schema(),
+				$this->get_single_line_schema(),
+				$this->get_multi_line_schema(),
+				$this->get_file_upload_schema(),
 			],
 		];
 
@@ -455,39 +443,6 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		 * @return {array}
 		 */
 		return apply_filters( 'sensei_rest_api_schema_single_question', $single_question_schema );
-	}
-
-	/**
-	 * Helper method which returns the question schema definitions.
-	 *
-	 * @return array The definitions
-	 */
-	private function get_question_definitions() : array {
-		$question_definitions = [
-			'question_multiple_choice' => $this->get_multiple_choice_schema(),
-			'question_boolean'         => $this->get_boolean_schema(),
-			'question_gap_fill'        => $this->get_gap_fill_schema(),
-			'question_single_line'     => $this->get_single_question_schema(),
-			'question_multi_line'      => $this->get_multi_line_schema(),
-			'question_file_upload'     => $this->get_file_upload_schema(),
-		];
-
-		if ( ! is_wp_version_compatible( '5.6.0' ) ) {
-			// These aren't used in versions before 5.6.0 so we can just clear them out.
-			$question_definitions = [];
-		}
-
-		/*
-		 * Add additional definitions to the question types.
-		 *
-		 * @since 3.9.0
-		 * @hook sensei_rest_api_schema_question_type_definitions
-		 *
-		 * @param {Array} $schema Schema definitions for questions.
-		 *
-		 * @return {array}
-		 */
-		return apply_filters( 'sensei_rest_api_schema_question_type_definitions', $question_definitions );
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-question-options-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-question-options-controller.php
@@ -62,7 +62,7 @@ class Sensei_REST_API_Question_Options_Controller extends \WP_REST_Controller {
 						],
 					],
 				],
-				'schema' => [ $this, 'get_multiple_schema' ],
+				'schema' => [ $this, 'get_multiple_question_schema' ],
 			]
 		);
 
@@ -84,7 +84,7 @@ class Sensei_REST_API_Question_Options_Controller extends \WP_REST_Controller {
 						],
 					],
 				],
-				'schema' => [ $this, 'get_single_schema' ],
+				'schema' => [ $this, 'get_single_question_schema' ],
 			]
 		);
 	}
@@ -217,24 +217,11 @@ class Sensei_REST_API_Question_Options_Controller extends \WP_REST_Controller {
 	 *
 	 * @return array Schema object.
 	 */
-	public function get_multiple_schema() : array {
+	public function get_multiple_question_schema() : array {
 		return [
-			'definitions' => $this->get_question_definitions(),
 			'type'        => 'array',
 			'description' => 'Questions in batch',
 			'items'       => $this->get_single_question_schema(),
 		];
-	}
-
-	/**
-	 * Schema for the endpoint when a single question is returned.
-	 *
-	 * @return array Schema object.
-	 */
-	public function get_single_schema() : array {
-		return array_merge(
-			[ 'definitions' => $this->get_question_definitions() ],
-			$this->get_single_question_schema()
-		);
 	}
 }

--- a/includes/rest-api/class-sensei-rest-api-question-options-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-question-options-controller.php
@@ -128,9 +128,17 @@ class Sensei_REST_API_Question_Options_Controller extends \WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function get_multiple_questions( WP_REST_Request $request ) {
+		$response     = new WP_REST_Response();
+		$question_ids = $request->get_param( 'question_ids' );
+		if ( empty( $question_ids ) ) {
+			$response->set_data( [] );
+
+			return $response;
+		}
+
 		$question_posts = get_posts(
 			[
-				'post__in'       => $request->get_param( 'question_ids' ),
+				'post__in'       => $question_ids,
 				'post_type'      => 'question',
 				'posts_per_page' => -1,
 			]
@@ -145,7 +153,6 @@ class Sensei_REST_API_Question_Options_Controller extends \WP_REST_Controller {
 			$questions[] = $this->get_question( $question_post );
 		}
 
-		$response = new WP_REST_Response();
 		$response->set_data( $questions );
 
 		return $response;

--- a/includes/rest-api/class-sensei-rest-api-question-options-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-question-options-controller.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * File containing the class Sensei_REST_API_Question_Options_Controller.
+ *
+ * @package sensei
+ * @author  Automattic
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Sensei Lesson Quiz REST API endpoints.
+ *
+ * @since 3.9.0
+ */
+class Sensei_REST_API_Question_Options_Controller extends \WP_REST_Controller {
+	use Sensei_REST_API_Question_Helpers_Trait;
+
+	/**
+	 * Routes namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace;
+
+	/**
+	 * Routes prefix.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'question-options';
+
+	/**
+	 * Sensei_REST_API_Quiz_Controller constructor.
+	 *
+	 * @param string $namespace Routes namespace.
+	 */
+	public function __construct( $namespace ) {
+		$this->namespace = $namespace;
+	}
+
+	/**
+	 * Register the REST API endpoints for quiz.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_multiple_questions' ],
+					'permission_callback' => [ $this, 'can_user_get_multiple_questions' ],
+					'args'                => [
+						'context'      => [
+							'type'              => 'string',
+							'default'           => 'view',
+							'enum'              => [ 'view', 'edit' ],
+							'sanitize_callback' => 'sanitize_key',
+							'validate_callback' => 'rest_validate_request_arg',
+						],
+						'question_ids' => [
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => [ $this, 'sanitize_multiple_questions' ],
+							'validate_callback' => 'rest_validate_request_arg',
+						],
+					],
+				],
+				'schema' => [ $this, 'get_multiple_schema' ],
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/(?P<question_id>[0-9]+)',
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_single_question' ],
+					'permission_callback' => [ $this, 'can_user_get_question' ],
+					'args'                => [
+						'context' => [
+							'type'              => 'string',
+							'default'           => 'view',
+							'enum'              => [ 'view', 'edit' ],
+							'sanitize_callback' => 'sanitize_key',
+							'validate_callback' => 'rest_validate_request_arg',
+						],
+					],
+				],
+				'schema' => [ $this, 'get_single_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Get a single question.
+	 *
+	 * @param WP_REST_Request $request WordPress request object.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_single_question( WP_REST_Request $request ) {
+		$question = get_post( (int) $request->get_param( 'question_id' ) );
+
+		if ( ! $question ) {
+			return new WP_Error(
+				'sensei_question_options_missing_question',
+				__( 'Question not found.', 'sensei-lms' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		$response = new WP_REST_Response();
+		$response->set_data( $this->get_question( $question ) );
+
+		return $response;
+	}
+
+	/**
+	 * Get multiple questions.
+	 *
+	 * @param WP_REST_Request $request WordPress request object.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_multiple_questions( WP_REST_Request $request ) {
+		$question_posts = get_posts(
+			[
+				'post__in'       => $request->get_param( 'question_ids' ),
+				'post_type'      => 'question',
+				'posts_per_page' => -1,
+			]
+		);
+
+		$questions = [];
+		foreach ( $question_posts as $question_post ) {
+			if ( ! $this->has_question_read_access( $question_post ) ) {
+				continue;
+			}
+
+			$questions[] = $this->get_question( $question_post );
+		}
+
+		$response = new WP_REST_Response();
+		$response->set_data( $questions );
+
+		return $response;
+	}
+
+	/**
+	 * Sanitize the question IDs input.
+	 *
+	 * @param string $question_ids_str Question IDs separated by a comma.
+	 *
+	 * @return int[]
+	 */
+	public function sanitize_multiple_questions( $question_ids_str ) {
+		return array_filter(
+			array_map(
+				'intval',
+				explode( ',', $question_ids_str )
+			)
+		);
+	}
+
+	/**
+	 * Check user permission for fetching multiple questions
+	 *
+	 * @return bool|WP_Error Whether the user can get questions.
+	 */
+	public function can_user_get_multiple_questions() {
+		// We'll do individual level question checks later.
+		return is_user_logged_in();
+	}
+
+	/**
+	 * Check user permission for fetching question.
+	 *
+	 * @param WP_REST_Request $request WordPress request object.
+	 *
+	 * @return bool|WP_Error Whether the user can read a question. Error if not found.
+	 */
+	public function can_user_get_question( WP_REST_Request $request ) {
+		$question = get_post( (int) $request->get_param( 'question_id' ) );
+		if ( ! $question || 'question' !== $question->post_type ) {
+			return new WP_Error(
+				'sensei_question_options_missing_question',
+				__( 'Question not found.', 'sensei-lms' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		return $this->has_question_read_access( $question );
+	}
+
+	/**
+	 * Check if current user has access to read question config.
+	 *
+	 * @param WP_Post $question
+	 *
+	 * @return bool
+	 */
+	private function has_question_read_access( WP_Post $question ) : bool {
+		if ( ! is_user_logged_in() ) {
+			return false;
+		}
+
+		return wp_get_current_user()->ID === (int) $question->post_author || current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Schema for the endpoint when multiple questions are returned.
+	 *
+	 * @return array Schema object.
+	 */
+	public function get_multiple_schema() : array {
+		return [
+			'definitions' => $this->get_question_definitions(),
+			'type'        => 'array',
+			'description' => 'Questions in batch',
+			'items'       => $this->get_single_question_schema(),
+		];
+	}
+
+	/**
+	 * Schema for the endpoint when a single question is returned.
+	 *
+	 * @return array Schema object.
+	 */
+	public function get_single_schema() : array {
+		return array_merge(
+			[ 'definitions' => $this->get_question_definitions() ],
+			$this->get_single_question_schema()
+		);
+	}
+}

--- a/includes/rest-api/class-sensei-rest-api-question-options-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-question-options-controller.php
@@ -54,13 +54,6 @@ class Sensei_REST_API_Question_Options_Controller extends \WP_REST_Controller {
 					'callback'            => [ $this, 'get_multiple_questions' ],
 					'permission_callback' => [ $this, 'can_user_get_multiple_questions' ],
 					'args'                => [
-						'context'      => [
-							'type'              => 'string',
-							'default'           => 'view',
-							'enum'              => [ 'view', 'edit' ],
-							'sanitize_callback' => 'sanitize_key',
-							'validate_callback' => 'rest_validate_request_arg',
-						],
 						'question_ids' => [
 							'type'              => 'string',
 							'required'          => true,

--- a/includes/rest-api/class-sensei-rest-api-question-options-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-question-options-controller.php
@@ -74,15 +74,6 @@ class Sensei_REST_API_Question_Options_Controller extends \WP_REST_Controller {
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => [ $this, 'get_single_question' ],
 					'permission_callback' => [ $this, 'can_user_get_question' ],
-					'args'                => [
-						'context' => [
-							'type'              => 'string',
-							'default'           => 'view',
-							'enum'              => [ 'view', 'edit' ],
-							'sanitize_callback' => 'sanitize_key',
-							'validate_callback' => 'rest_validate_request_arg',
-						],
-					],
 				],
 				'schema' => [ $this, 'get_single_question_schema' ],
 			]

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-question-options-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-question-options-controller.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * Sensei REST API: Sensei_REST_API_Question_Options_Controller_Tests tests
+ *
+ * @package sensei-lms
+ * @since 3.9.0
+ * @group rest-api
+ */
+
+/**
+ * Class Sensei_REST_API_Question_Options_Controller tests.
+ */
+class Sensei_REST_API_Question_Options_Controller_Tests extends WP_Test_REST_TestCase {
+	use Sensei_Test_Login_Helpers;
+	use Sensei_REST_API_Test_Helpers;
+
+	/**
+	 * A server instance that we use in tests to dispatch requests.
+	 *
+	 * @var WP_REST_Server $server
+	 */
+	protected $server;
+
+	/**
+	 * Sensei post factory.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Quiz route.
+	 */
+	const REST_ROUTE = '/sensei-internal/v1/question-options';
+
+	/**
+	 * Test specific setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		do_action( 'rest_api_init' );
+
+		$this->factory = new Sensei_Factory();
+	}
+
+	/**
+	 * Tests that a simple request response matches the schema.
+	 */
+	public function testGetSimple() {
+		$this->login_as_teacher();
+
+		$question_id = $this->factory->question->create();
+
+		$request  = new WP_REST_Request( 'GET', self::REST_ROUTE . '/' . $question_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data     = $response->get_data();
+		$endpoint = new Sensei_REST_API_Question_Options_Controller( '' );
+		$this->assertMeetsSchema( $endpoint->get_single_schema(), $data );
+
+		$this->assertEquals( $question_id, $data['id'] );
+	}
+
+	/**
+	 * Tests that a teacher cannot get another teacher's question options.
+	 */
+	public function testGetAnotherTeacherQuestion() {
+		$this->login_as_teacher();
+		$question_id = $this->factory->question->create();
+
+		$this->login_as_teacher_b();
+		$request  = new WP_REST_Request( 'GET', self::REST_ROUTE . '/' . $question_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * Tests that a admin can get a teacher's question options.
+	 */
+	public function testAdminGetTeacherQuestion() {
+		$this->login_as_teacher();
+		$question_id = $this->factory->question->create();
+
+		$this->login_as_teacher();
+		$request  = new WP_REST_Request( 'GET', self::REST_ROUTE . '/' . $question_id );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$endpoint = new Sensei_REST_API_Question_Options_Controller( '' );
+		$this->assertMeetsSchema( $endpoint->get_single_schema(), $response->get_data() );
+	}
+
+	/**
+	 * Tests retrieving multiple questions in bulk.
+	 */
+	public function testGetMultipleQuestions() {
+		$this->login_as_teacher();
+		$question_ids = $this->factory->question->create_many( 3 );
+
+		$request = new WP_REST_Request( 'GET', self::REST_ROUTE );
+		$request->set_param( 'question_ids', implode( ',', $question_ids ) );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$endpoint = new Sensei_REST_API_Question_Options_Controller( '' );
+		$this->assertMeetsSchema( $endpoint->get_multiple_schema(), $data );
+
+		$this->assertEquals( count( $question_ids ), count( $data ) );
+
+		$retrieved_ids = wp_list_pluck( $data, 'id' );
+		sort( $retrieved_ids );
+
+		$this->assertEquals( $question_ids, $retrieved_ids, 'Created IDs should match' );
+	}
+
+	/**
+	 * Tests retrieving multiple questions in bulk and only returns questions the user has access to.
+	 */
+	public function testGetMultipleQuestionsOtherTeacher() {
+		$this->login_as_teacher();
+		$teacher_a_question_ids = $this->factory->question->create_many( 2 );
+
+		$this->login_as_teacher_b();
+		$teacher_b_question_ids = $this->factory->question->create_many( 2 );
+
+		$all_question_ids = array_merge( $teacher_a_question_ids, $teacher_b_question_ids );
+
+		$request = new WP_REST_Request( 'GET', self::REST_ROUTE );
+		$request->set_param( 'question_ids', implode( ',', $all_question_ids ) );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$data = $response->get_data();
+
+		$endpoint = new Sensei_REST_API_Question_Options_Controller( '' );
+		$this->assertMeetsSchema( $endpoint->get_multiple_schema(), $data );
+
+		$this->assertEquals( count( $teacher_b_question_ids ), count( $data ) );
+
+		$retrieved_ids = wp_list_pluck( $data, 'id' );
+		sort( $retrieved_ids );
+
+		$this->assertEquals( $teacher_b_question_ids, $retrieved_ids, 'Created IDs should match' );
+	}
+}

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-question-options-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-question-options-controller.php
@@ -4,11 +4,12 @@
  *
  * @package sensei-lms
  * @since 3.9.0
- * @group rest-api
  */
 
 /**
  * Class Sensei_REST_API_Question_Options_Controller tests.
+ *
+ * @group rest-api
  */
 class Sensei_REST_API_Question_Options_Controller_Tests extends WP_Test_REST_TestCase {
 	use Sensei_Test_Login_Helpers;

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-question-options-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-question-options-controller.php
@@ -63,7 +63,7 @@ class Sensei_REST_API_Question_Options_Controller_Tests extends WP_Test_REST_Tes
 
 		$data     = $response->get_data();
 		$endpoint = new Sensei_REST_API_Question_Options_Controller( '' );
-		$this->assertMeetsSchema( $endpoint->get_single_schema(), $data );
+		$this->assertMeetsSchema( $endpoint->get_single_question_schema(), $data );
 
 		$this->assertEquals( $question_id, $data['id'] );
 	}
@@ -96,7 +96,7 @@ class Sensei_REST_API_Question_Options_Controller_Tests extends WP_Test_REST_Tes
 		$this->assertEquals( 200, $response->get_status() );
 
 		$endpoint = new Sensei_REST_API_Question_Options_Controller( '' );
-		$this->assertMeetsSchema( $endpoint->get_single_schema(), $response->get_data() );
+		$this->assertMeetsSchema( $endpoint->get_single_question_schema(), $response->get_data() );
 	}
 
 	/**
@@ -116,7 +116,7 @@ class Sensei_REST_API_Question_Options_Controller_Tests extends WP_Test_REST_Tes
 		$data = $response->get_data();
 
 		$endpoint = new Sensei_REST_API_Question_Options_Controller( '' );
-		$this->assertMeetsSchema( $endpoint->get_multiple_schema(), $data );
+		$this->assertMeetsSchema( $endpoint->get_multiple_question_schema(), $data );
 
 		$this->assertEquals( count( $question_ids ), count( $data ) );
 
@@ -148,7 +148,7 @@ class Sensei_REST_API_Question_Options_Controller_Tests extends WP_Test_REST_Tes
 		$data = $response->get_data();
 
 		$endpoint = new Sensei_REST_API_Question_Options_Controller( '' );
-		$this->assertMeetsSchema( $endpoint->get_multiple_schema(), $data );
+		$this->assertMeetsSchema( $endpoint->get_multiple_question_schema(), $data );
 
 		$this->assertEquals( count( $teacher_b_question_ids ), count( $data ) );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds two REST API endpoints to assist with both the individual question editor _and_ adding existing questions to a quiz.
  * `GET /wp-json/sensei-internal/v1/question-options/{question_id}`
  * `GET /wp-json/sensei-internal/v1/question-options?question_ids={question_ids_separated_by_commas}`
* Split off the question methods into a shared trait between the two controllers.
* Fix for schema.

### Testing instructions

* Try out endpoints.

### New/Updated Hooks

* `sensei_rest_api_schema_single_question`: Schema for single question.
