### PR TITLE
Add the quiz block when the quiz is enabled for lesson

### DIFF
--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -318,7 +318,7 @@ class Sensei_PostTypes {
 			'supports'              => $supports_array,
 			'show_in_rest'          => true,
 			'rest_base'             => 'lessons',
-			'rest_controller_class' => 'WP_REST_Posts_Controller',
+			'rest_controller_class' => 'Sensei_REST_API_Lessons_Controller',
 		);
 
 		/**

--- a/includes/rest-api/class-sensei-rest-api-lessons-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lessons-controller.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Sensei REST API: Sensei_REST_API_Lessons_Controller class.
+ *
+ * @package sensei-lms
+ * @since 3.9.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+} // Exit if accessed directly.
+
+/**
+ * A REST controller for Sensei LMS lessons CPT.
+ *
+ * @since 3.9.0
+ *
+ * @see WP_REST_Posts_Controller
+ */
+class Sensei_REST_API_Lessons_Controller extends WP_REST_Posts_Controller {
+	/**
+	 * Adds the quiz block if missing when a quiz is active on the lesson.
+	 *
+	 * @param array           $prepared Prepared response array.
+	 * @param WP_REST_Request $request  Full details about the request.
+	 * @return array Modified data object with additional fields.
+	 */
+	protected function add_additional_fields_to_object( $prepared, $request ) {
+		if ( ! Sensei()->quiz->is_block_based_editor_enabled() ) {
+			return $prepared;
+		}
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		if ( 'edit' === $context && isset( $prepared['content']['raw'] ) ) {
+			$post = get_post();
+			if ( Sensei()->lesson::lesson_quiz_has_questions( $post->ID ) && ! has_block( 'sensei-lms/quiz' ) ) {
+				$prepared['content']['raw'] .= serialize_block(
+					[
+						'blockName'    => 'sensei-lms/quiz',
+						'innerContent' => [],
+						'attrs'        => [],
+					]
+				);
+			}
+		}
+
+		return $prepared;
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Artificially adds the quiz block when the quiz is enabled. Will be used so lessons created before the quiz block will load the block based quiz editor.
* I initially started doing this from the frontend, but I couldn't find a non-hacky way to figure out when the block editor was ready/loaded. [Counting blocks was the best I could do](https://github.com/Automattic/sensei/compare/add/quiz-block-if-enabled-backup?expand=1#diff-f829257b4049e43fa6ec17abaa51e97d4bc539a820535374138875ddc8a460b3R25). This technically works, but I'd be worried about weird scenarios (if someone removed the template from the lesson, for example, and new lessons started with 0 blocks).

### Testing instructions

* With the block based editor disabled (`add_filter( 'sensei_quiz_enable_block_based_editor', '__return_false' );`), create a couple of lessons. One with a quiz with questions and another without questions.
* Remove the filter to re-enable the block based quiz editor.
* Edit the lesson with the quiz with questions. Ensure the block is added.
* Edit the lesson without the quiz. Ensure the block is not added.