### PR TITLE
Log the quiz editor being used on a site

### DIFF
--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -241,6 +241,7 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 		$system_data                 = [];
 		$system_data['version']      = Sensei()->version;
 		$system_data['wcpc_version'] = defined( 'SENSEI_WC_PAID_COURSES_VERSION' ) ? SENSEI_WC_PAID_COURSES_VERSION : null;
+		$system_data['quiz_editor']  = Sensei()->quiz->is_block_based_editor_enabled() ? 'block' : 'metabox';
 
 		return array_merge( $system_data, parent::get_system_data() );
 	}

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -238,10 +238,10 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	 * @return array
 	 */
 	public function get_system_data() {
-		$system_data                 = [];
-		$system_data['version']      = Sensei()->version;
-		$system_data['wcpc_version'] = defined( 'SENSEI_WC_PAID_COURSES_VERSION' ) ? SENSEI_WC_PAID_COURSES_VERSION : null;
-		$system_data['quiz_editor']  = Sensei()->quiz->is_block_based_editor_enabled() ? 'block' : 'metabox';
+		$system_data                          = [];
+		$system_data['version']               = Sensei()->version;
+		$system_data['wcpc_version']          = defined( 'SENSEI_WC_PAID_COURSES_VERSION' ) ? SENSEI_WC_PAID_COURSES_VERSION : null;
+		$system_data['is_legacy_quiz_editor'] = Sensei()->quiz->is_block_based_editor_enabled() ? 0 : 1;
 
 		return array_merge( $system_data, parent::get_system_data() );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Logs a `quiz_editor` property on the `sensei_system_log` event that is `block` if they are using the block-based quiz editor or `metabox` if they are using the legacy metabox editor.

### Testing instructions

* Run the tracking event and verify it logs the property correctly.