### PR TITLE
Use block button styles for quiz actions

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -374,6 +374,11 @@ a.sensei-certificate-link {
 }
 
 .quiz-blocks {
+  .wp-block-buttons {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
   .wp-block-button {
     display: flex;
     align-items: center;

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -362,14 +362,21 @@ a.sensei-certificate-link {
   }
 }
 
-.quiz, .lesson  {
-  input.quiz-submit  {
+.quiz:not(.quiz-blocks), .lesson {
+  button.quiz-submit  {
     &.complete  {
       background: $success;
     }
     &.reset  {
       background: $error;
     }
+  }
+}
+
+.quiz-blocks {
+  .wp-block-button {
+    display: flex;
+    align-items: center;
   }
 }
 
@@ -889,7 +896,7 @@ section.entry span.course-lesson-progress { margin-left: 10px; }
   }
 }
 
-.course-container, .course, .lesson, .quiz  {
+.course-container, .course, .lesson, .quiz:not(.quiz-blocks)  {
   a.button, a.button:visited,
   a.comment-reply-link,
   #commentform #submit,

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -138,4 +138,28 @@ class Sensei_Blocks {
 			register_block_type_from_metadata( $file_or_folder, $block_args );
 		}
 	}
+
+	/**
+	 * Check if the current post has Sensei blocks.
+	 *
+	 * @return bool
+	 */
+	public function has_sensei_blocks() {
+		global $post;
+
+		if ( ! $post ) {
+			return false;
+		}
+
+		switch ( $post->post_type ) {
+			case 'course':
+				return Sensei()->course->has_sensei_blocks();
+			case 'lesson':
+				return Sensei()->lesson->has_sensei_blocks();
+			case 'quiz':
+				return Sensei()->quiz->has_sensei_blocks();
+			default:
+				return false;
+		}
+	}
 }

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -118,7 +118,7 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 	 * @return bool
 	 */
 	public static function skip_single_course_template( $enabled ) {
-		return is_single() && 'course' === get_post_type() && ! Sensei()->course->is_legacy_course( get_post() )
+		return is_single() && 'course' === get_post_type() && Sensei()->course->has_sensei_blocks( get_post() )
 			? false
 			: $enabled;
 	}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3634,7 +3634,7 @@ class Sensei_Course {
 		if (
 			$post
 			&& is_singular( 'course' )
-			&& ! $this->is_legacy_course( $post )
+			&& $this->has_sensei_blocks( $post )
 		) {
 			$this->remove_legacy_course_actions();
 		}
@@ -3700,7 +3700,7 @@ class Sensei_Course {
 	 *
 	 * @return bool
 	 */
-	public function is_legacy_course( $course ) {
+	public function has_sensei_blocks( $course = null ) {
 		$course = get_post( $course );
 
 		$course_blocks = [
@@ -3718,7 +3718,7 @@ class Sensei_Course {
 
 		return true;
 	}
-}//end class
+}
 
 /**
  * Class WooThemes_Sensei_Course

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3700,6 +3700,17 @@ class Sensei_Course {
 	 *
 	 * @return bool
 	 */
+	public function is_legacy_course( $course = null ) {
+		return ! $this->has_sensei_blocks( $course );
+	}
+
+	/**
+	 * Check if a course contains Sensei blocks.
+	 *
+	 * @param int|WP_Post $course Course ID or course object.
+	 *
+	 * @return bool
+	 */
 	public function has_sensei_blocks( $course = null ) {
 		$course = get_post( $course );
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3723,11 +3723,11 @@ class Sensei_Course {
 
 		foreach ( $course_blocks as $block ) {
 			if ( has_block( $block, $course ) ) {
-				return false;
+				return true;
 			}
 		}
 
-		return true;
+		return false;
 	}
 }
 

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -255,7 +255,7 @@ class Sensei_Messages {
 
 				$class = Sensei()->blocks->has_sensei_blocks() ? '' : 'button';
 
-				$html .= '<p><a class="'. esc_attr( $class ) . ' send-message-button" href="' . esc_url( $href ) . '#private_message">' . esc_html( $contact_button_text ) . '</a></p>';
+				$html .= '<p><a class="' . esc_attr( $class ) . ' send-message-button" href="' . esc_url( $href ) . '#private_message">' . esc_html( $contact_button_text ) . '</a></p>';
 			}
 
 			if ( isset( $this->message_notice ) && isset( $this->message_notice['type'] ) && isset( $this->message_notice['notice'] ) ) {

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -253,7 +253,9 @@ class Sensei_Messages {
 					$contact_button_text = __( 'Contact Teacher', 'sensei-lms' );
 				}
 
-				$html .= '<p><a class="button send-message-button" href="' . esc_url( $href ) . '#private_message">' . esc_html( $contact_button_text ) . '</a></p>';
+				$class = Sensei()->blocks->has_sensei_blocks() ? '' : 'button';
+
+				$html .= '<p><a class="'. esc_attr( $class ) . ' send-message-button" href="' . esc_url( $href ) . '#private_message">' . esc_html( $contact_button_text ) . '</a></p>';
 			}
 
 			if ( isset( $this->message_notice ) && isset( $this->message_notice['type'] ) && isset( $this->message_notice['notice'] ) ) {

--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -122,7 +122,7 @@ class Sensei_Notices {
 	 * Adds a filter to the content to add notices added by blocks.
 	 */
 	public function setup_block_notices() {
-		if ( is_singular( 'course' ) && ! Sensei()->course->is_legacy_course( get_post() ) ) {
+		if ( is_singular( 'course' ) && Sensei()->course->has_sensei_blocks( get_post() ) ) {
 			add_filter( 'the_content', [ $this, 'prepend_notices_to_content' ] );
 		}
 	}

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1342,7 +1342,7 @@ class Sensei_Quiz {
 				value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
 			<!-- End Action Nonce's -->
 			<div class="wp-block-buttons">
-				<?php if ( true || '' == $user_quiz_grade && ( ! $user_lesson_status || 'ungraded' !== $user_lesson_status->comment_approved ) ) { ?>
+				<?php if ( '' == $user_quiz_grade && ( ! $user_lesson_status || 'ungraded' !== $user_lesson_status->comment_approved ) ) { ?>
 
 					<div class="wp-block-button">
 						<button type="submit" name="quiz_complete"
@@ -1356,7 +1356,7 @@ class Sensei_Quiz {
 
 				<?php } // End If Statement ?>
 
-				<?php if ( true || isset( $reset_quiz_allowed ) && $reset_quiz_allowed ) { ?>
+				<?php if ( isset( $reset_quiz_allowed ) && $reset_quiz_allowed ) { ?>
 
 					<div class="wp-block-button is-style-outline">
 						<button type="submit" name="quiz_reset"

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -48,6 +48,9 @@ class Sensei_Quiz {
 		// Remove post when lesson is permanently deleted.
 		add_action( 'delete_post', array( $this, 'maybe_delete_quiz' ) );
 
+		add_filter( 'body_class', [ $this, 'add_quiz_blocks_class' ] );
+		add_filter( 'post_class', [ $this, 'add_quiz_blocks_class' ] );
+
 	} // End __construct()
 
 	/**
@@ -1330,29 +1333,38 @@ class Sensei_Quiz {
 			$reset_quiz_allowed = get_post_meta( $post->ID, '_enable_quiz_reset', true );
 			?>
 
-			 <!-- Action Nonce's -->
-			 <input type="hidden" name="woothemes_sensei_complete_quiz_nonce" id="woothemes_sensei_complete_quiz_nonce"
-					value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_quiz_nonce' ) ); ?>" />
-			 <input type="hidden" name="woothemes_sensei_reset_quiz_nonce" id="woothemes_sensei_reset_quiz_nonce"
-					value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' ) ); ?>" />
-			 <input type="hidden" name="woothemes_sensei_save_quiz_nonce" id="woothemes_sensei_save_quiz_nonce"
-					value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
-			 <!-- End Action Nonce's -->
+			<!-- Action Nonce's -->
+			<input type="hidden" name="woothemes_sensei_complete_quiz_nonce" id="woothemes_sensei_complete_quiz_nonce"
+				value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_quiz_nonce' ) ); ?>" />
+			<input type="hidden" name="woothemes_sensei_reset_quiz_nonce" id="woothemes_sensei_reset_quiz_nonce"
+				value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' ) ); ?>" />
+			<input type="hidden" name="woothemes_sensei_save_quiz_nonce" id="woothemes_sensei_save_quiz_nonce"
+				value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
+			<!-- End Action Nonce's -->
+			<div class="wp-block-buttons">
+				<?php if ( true || '' == $user_quiz_grade && ( ! $user_lesson_status || 'ungraded' !== $user_lesson_status->comment_approved ) ) { ?>
 
-			 <?php if ( '' == $user_quiz_grade && ( ! $user_lesson_status || 'ungraded' !== $user_lesson_status->comment_approved ) ) { ?>
+					<div class="wp-block-button">
+						<button type="submit" name="quiz_complete"
+							class="wp-block-button__link button quiz-submit complete sensei-stop-double-submission"><?php esc_attr_e( 'Complete Quiz', 'sensei-lms' ); ?></button>
+					</div>
 
-				 <span><input type="submit" name="quiz_complete" class="quiz-submit complete sensei-stop-double-submission" value="<?php esc_attr_e( 'Complete Quiz', 'sensei-lms' ); ?>"/></span>
-
-				 <span><input type="submit" name="quiz_save" class="quiz-submit save sensei-stop-double-submission" value="<?php esc_attr_e( 'Save Quiz', 'sensei-lms' ); ?>"/></span>
+					<div class="wp-block-button is-style-outline">
+						<button type="submit" name="quiz_save"
+							class="wp-block-button__link button quiz-submit save sensei-stop-double-submission"><?php esc_attr_e( 'Save Quiz', 'sensei-lms' ); ?></button>
+					</div>
 
 				<?php } // End If Statement ?>
 
-			 <?php if ( isset( $reset_quiz_allowed ) && $reset_quiz_allowed ) { ?>
+				<?php if ( true || isset( $reset_quiz_allowed ) && $reset_quiz_allowed ) { ?>
 
-				 <span><input type="submit" name="quiz_reset" class="quiz-submit reset sensei-stop-double-submission" value="<?php esc_attr_e( 'Reset Quiz', 'sensei-lms' ); ?>"/></span>
+					<div class="wp-block-button is-style-outline">
+						<button type="submit" name="quiz_reset"
+							class="wp-block-button__link button quiz-submit reset sensei-stop-double-submission"><?php esc_attr_e( 'Reset Quiz', 'sensei-lms' ); ?></button>
+					</div>
 
 				<?php } ?>
-
+			</div>
 			<?php
 		}
 
@@ -1541,6 +1553,27 @@ class Sensei_Quiz {
 
 		update_post_meta( $this->get_lesson_id( $quiz_id ), '_quiz_has_questions', '1' );
 		update_post_meta( $quiz_id, '_question_order', array_map( 'strval', $question_ids ) );
+	}
+
+	/**
+	 * Check if a quiz's lesson has Sensei blocks.
+	 *
+	 * @param int|WP_Post $quiz Quiz ID or post object.
+	 *
+	 * @return bool
+	 */
+	public function has_sensei_blocks( $quiz = null ) {
+		$lesson_id = $this->get_lesson_id( $quiz );
+
+		return Sensei()->lesson->has_sensei_blocks( $lesson_id );
+	}
+
+	public function add_quiz_blocks_class( $classes ) {
+		if( 'quiz' === get_post_type() && $this->has_sensei_blocks() ) {
+			return array_merge( $classes, [ 'quiz-blocks' ] );
+		}
+
+		return $classes;
 	}
 
 	/**

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1568,8 +1568,15 @@ class Sensei_Quiz {
 		return Sensei()->lesson->has_sensei_blocks( $lesson_id );
 	}
 
+	/**
+	 * Add quiz-blocks class for quiz page with block-based lesson.
+	 *
+	 * @param array $classes Existing classes.
+	 *
+	 * @return array Modified classes.
+	 */
 	public function add_quiz_blocks_class( $classes ) {
-		if( 'quiz' === get_post_type() && $this->has_sensei_blocks() ) {
+		if ( 'quiz' === get_post_type() && $this->has_sensei_blocks() ) {
 			return array_merge( $classes, [ 'quiz-blocks' ] );
 		}
 


### PR DESCRIPTION
Closes #3973

This is a temporary solution to make sure that buttons on the quiz page don't stand out for new courses that use block-based buttons everywhere else. We'll want to to a wider revamp of Sensei's frontend styles in the future.

### Changes proposed in this Pull Request

* Disable Sensei button styles on the single quiz page if the lesson has Sensei blocks (lesson actions/contact teacher)
* Update quiz action buttons markup, set secondary actions to outline style
* Also update Contact teacher button style to just be a link on this page, so it's less distracting 
 
### Testing instructions

* Have a lesson with a quiz
* Add a lesson actions block. Open lesson quiz on the frontend. Check that the quiz actions look like block-based buttons.
* Remove lesson actions (and contact teacher) block from the lesson. Check that quiz actions now look like the Sensei-style variants.

### Compatibility, template changes

While this change tries to not break things, some custom CSS made for Sensei buttons might have to be updated:

* Markup for the quiz action buttons changed (`input[type=submit]` => `button`)
* CSS specificity for Sensei default button styles increased (`.quiz` => `.quiz:not(.quiz-blocks)`)

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Blocks: 

<img width="678" alt="image" src="https://user-images.githubusercontent.com/176949/109537721-84c86580-7abf-11eb-96a9-ee286b0a7112.png">

Not blocks:

<img width="665" alt="image" src="https://user-images.githubusercontent.com/176949/109537743-8bef7380-7abf-11eb-99b2-30877e7c08e8.png">
