### PR TITLE
Change question author when possible on teacher change

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1395,10 +1395,14 @@ class Sensei_Question {
 		}
 
 		$can_question_change_author = true;
-		$quiz_ids = get_post_meta( $question->ID, '_quiz_id' );
+		$quiz_ids = array_filter( get_post_meta( $question->ID, '_quiz_id' ) );
 		foreach ( $quiz_ids as $quiz_id ) {
 			$quiz = get_post( $quiz_id );
-			if ( $new_author_id !== (int) $quiz->post_author ) {
+			if (
+				$quiz
+				&& 'quiz' === $quiz->post_type
+				&& $new_author_id !== (int) $quiz->post_author
+			) {
 				$can_question_change_author = false;
 				break;
 			}

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1395,7 +1395,7 @@ class Sensei_Question {
 		}
 
 		$can_question_change_author = true;
-		$quiz_ids = array_filter( get_post_meta( $question->ID, '_quiz_id' ) );
+		$quiz_ids                   = array_filter( get_post_meta( $question->ID, '_quiz_id' ) );
 		foreach ( $quiz_ids as $quiz_id ) {
 			$quiz = get_post( $quiz_id );
 			if (

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1471,7 +1471,7 @@ class Sensei_Quiz {
 	 * @param string $orderby     Question order by.
 	 * @param string $order       Question order.
 	 *
-	 * @return array
+	 * @return WP_Post[]
 	 */
 	public function get_questions( $quiz_id, $post_status = 'any', $orderby = 'meta_value_num title', $order = 'ASC' ) : array {
 
@@ -1561,6 +1561,35 @@ class Sensei_Quiz {
 		foreach ( $question_ids as $question_id ) {
 			delete_post_meta( $question_id, '_quiz_id', $quiz_id );
 			delete_post_meta( $question_id, '_quiz_question_order' . $quiz_id );
+		}
+	}
+
+	/**
+	 * Update the quiz author.
+	 *
+	 * @param int $quiz_id       Quiz post ID.
+	 * @param int $new_author_id New author.
+	 */
+	public function update_quiz_author( int $quiz_id, int $new_author_id ) {
+		if ( 'quiz' !== get_post_type( $quiz_id ) ) {
+			return;
+		}
+
+		wp_update_post(
+			[
+				'ID'          => $quiz_id,
+				'post_author' => $new_author_id,
+			]
+		);
+
+		// Update quiz question author if possible.
+		$questions = Sensei()->quiz->get_questions( $quiz_id );
+		foreach ( $questions as $question ) {
+			if ( $new_author_id === (int) $question->post_author ) {
+				continue;
+			}
+
+			Sensei()->question->maybe_update_question_author( $question->ID, $new_author_id );
 		}
 	}
 }

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -523,23 +523,9 @@ class Sensei_Teacher {
 			);
 
 			// Update quiz author.
-			$lesson_quizzes = Sensei()->lesson->lesson_quizzes( $lesson->ID );
-			if ( is_array( $lesson_quizzes ) ) {
-				foreach ( $lesson_quizzes as $quiz_id ) {
-					wp_update_post(
-						array(
-							'ID'          => $quiz_id,
-							'post_author' => $new_author,
-						)
-					);
-				}
-			} elseif ( ! empty( $lesson_quizzes ) ) {
-				wp_update_post(
-					array(
-						'ID'          => $lesson_quizzes,
-						'post_author' => $new_author,
-					)
-				);
+			$lesson_quiz_id = Sensei()->lesson->lesson_quizzes( $lesson->ID );
+			if ( ! empty( $lesson_quiz_id ) ) {
+				Sensei()->quiz->update_quiz_author( (int) $lesson_quiz_id, (int) $new_author );
 			}
 		}
 

--- a/tests/framework/trait-sensei-test-login-helpers.php
+++ b/tests/framework/trait-sensei-test-login-helpers.php
@@ -44,6 +44,10 @@ trait Sensei_Test_Login_Helpers {
 		return $this->login_as( $this->get_user_by_role( 'teacher', '_b' ) );
 	}
 
+	protected function login_as_teacher_c() {
+		return $this->login_as( $this->get_user_by_role( 'teacher', '_c' ) );
+	}
+
 	protected function login_as_student() {
 		return $this->login_as( $this->get_user_by_role( 'subscriber' ) );
 	}
@@ -54,6 +58,7 @@ trait Sensei_Test_Login_Helpers {
 
 	protected function login_as( $user_id ) {
 		wp_set_current_user( $user_id );
+
 		return $this;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Changes question `post_author` when possible (not shared by other quizzes not owned by new author).

### Testing instructions

As Teacher A
* Create two courses with lessons. In a Course A's lesson, add a couple of questions to the quiz. In course B's lesson, add a couple of new questions and add one question from course B's lesson questions.

As an Admin:
* Change the teacher of Course A from Teacher A to Teacher B.
* Verify the questions that were _just_ in course A have a `post_author` of Teacher B's user ID.
* Change the teacher of Course B from Teacher A to Teacher B.
* Verify that all remaining questions now have the `post_author` as Teacher B's user ID.