### PR TITLE
Add single question block editor

### DIFF
--- a/assets/blocks/quiz/question-block/index.js
+++ b/assets/blocks/quiz/question-block/index.js
@@ -10,6 +10,7 @@ import { __ } from '@wordpress/i18n';
 import edit from './question-edit';
 import metadata from './block.json';
 import icon from '../../../icons/question-icon';
+import { createQuestionBlockAttributes } from './question-block-attributes';
 
 /**
  * Quiz question block definition.
@@ -18,6 +19,35 @@ export default {
 	...metadata,
 	title: __( 'Question', 'sensei-lms' ),
 	icon,
+	deprecated: [
+		{
+			attributes: {
+				grade: { type: 'number' },
+				type: { type: 'string' },
+				title: { type: 'string' },
+				id: { type: 'number' },
+				categories: { type: 'array' },
+				shared: { type: 'boolean' },
+				answer_feedback: { type: 'string' },
+				teacher_notes: { type: 'string' },
+				before: { type: 'string' },
+				after: { type: 'string' },
+				gap: { type: 'array' },
+				options: { type: 'array' },
+				random_order: { type: 'boolean' },
+				answer: { type: 'boolean' },
+			},
+			isEligible: ( attr ) => {
+				return null !== attr.grade;
+			},
+			migrate: ( attr ) => {
+				return createQuestionBlockAttributes( attr );
+			},
+			save: () => {
+				return <InnerBlocks.Content />;
+			},
+		},
+	],
 	usesContext: [ 'sensei-lms/quizId' ],
 	description: __( 'The building block of all quizzes.', 'sensei-lms' ),
 	example: {

--- a/assets/blocks/quiz/question-block/index.js
+++ b/assets/blocks/quiz/question-block/index.js
@@ -18,6 +18,7 @@ export default {
 	...metadata,
 	title: __( 'Question', 'sensei-lms' ),
 	icon,
+	usesContext: [ 'sensei-lms/quizId' ],
 	description: __( 'The building block of all quizzes.', 'sensei-lms' ),
 	example: {
 		attributes: { title: __( 'Example Quiz Question', 'sensei-lms' ) },

--- a/assets/blocks/quiz/question-block/index.js
+++ b/assets/blocks/quiz/question-block/index.js
@@ -10,7 +10,6 @@ import { __ } from '@wordpress/i18n';
 import edit from './question-edit';
 import metadata from './block.json';
 import icon from '../../../icons/question-icon';
-import { createQuestionBlockAttributes } from './question-block-attributes';
 
 /**
  * Quiz question block definition.
@@ -19,35 +18,6 @@ export default {
 	...metadata,
 	title: __( 'Question', 'sensei-lms' ),
 	icon,
-	deprecated: [
-		{
-			attributes: {
-				grade: { type: 'number' },
-				type: { type: 'string' },
-				title: { type: 'string' },
-				id: { type: 'number' },
-				categories: { type: 'array' },
-				shared: { type: 'boolean' },
-				answer_feedback: { type: 'string' },
-				teacher_notes: { type: 'string' },
-				before: { type: 'string' },
-				after: { type: 'string' },
-				gap: { type: 'array' },
-				options: { type: 'array' },
-				random_order: { type: 'boolean' },
-				answer: { type: 'boolean' },
-			},
-			isEligible: ( attr ) => {
-				return null !== attr.grade;
-			},
-			migrate: ( attr ) => {
-				return createQuestionBlockAttributes( attr );
-			},
-			save: () => {
-				return <InnerBlocks.Content />;
-			},
-		},
-	],
 	usesContext: [ 'sensei-lms/quizId' ],
 	description: __( 'The building block of all quizzes.', 'sensei-lms' ),
 	example: {

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -57,7 +57,7 @@ const QuestionEdit = ( props ) => {
 	const AnswerBlock = type && types[ type ];
 
 	const hasSelected = useHasSelected( props );
-	const isSingle = ! ( 'sensei-lms/quizId' in context );
+	const isSingle = context && ! ( 'sensei-lms/quizId' in context );
 	const showContent = title || hasSelected || isSingle;
 
 	return (

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -41,6 +41,7 @@ const QuestionEdit = ( props ) => {
 		attributes: { title, type, answer = {}, options, shared },
 		setAttributes,
 		clientId,
+		context,
 	} = props;
 
 	const { removeBlock, selectBlock } = useDispatch( 'core/block-editor' );
@@ -56,7 +57,8 @@ const QuestionEdit = ( props ) => {
 	const AnswerBlock = type && types[ type ];
 
 	const hasSelected = useHasSelected( props );
-	const showContent = title || hasSelected;
+	const isSingle = ! ( 'sensei-lms/quizId' in context );
+	const showContent = title || hasSelected || isSingle;
 
 	return (
 		<div
@@ -64,7 +66,11 @@ const QuestionEdit = ( props ) => {
 				! title ? 'is-draft' : ''
 			}` }
 		>
-			<h2 className="sensei-lms-question-block__index">{ index + 1 }.</h2>
+			{ ! isSingle && (
+				<h2 className="sensei-lms-question-block__index">
+					{ index + 1 }.
+				</h2>
+			) }
 			<h2 className="sensei-lms-question-block__title">
 				<SingleLineInput
 					placeholder={ __( 'Add Question', 'sensei-lms' ) }
@@ -95,6 +101,7 @@ const QuestionEdit = ( props ) => {
 							],
 						] }
 						templateInsertUpdatesSelection={ false }
+						templateLock={ false }
 					/>
 					{ AnswerBlock?.edit && (
 						<AnswerBlock.edit

--- a/assets/blocks/quiz/quiz-block/index.js
+++ b/assets/blocks/quiz/quiz-block/index.js
@@ -29,6 +29,9 @@ const quizBlock = {
 		__( 'Assessment', 'sensei-lms' ),
 		__( 'Evaluation', 'sensei-lms' ),
 	],
+	providesContext: {
+		'sensei-lms/quizId': 'id',
+	},
 	example: {
 		innerBlocks: [
 			{

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -4,6 +4,7 @@ $gray-400: #ccc;
 
 @import 'question-block/question-block.editor';
 @import 'quiz-block/questions-modal/questions-modal-style';
+@import 'single-question.editor';
 
 .wp-block[data-type='sensei-lms/quiz'] {
 	.editor-styles-wrapper & {

--- a/assets/blocks/quiz/single-question.editor.scss
+++ b/assets/blocks/quiz/single-question.editor.scss
@@ -1,0 +1,9 @@
+body.post-type-question {
+	.edit-post-visual-editor__post-title-wrapper {
+		display: none;
+	}
+
+	.editor-styles-wrapper {
+		padding: 64px 0;
+	}
+}

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -83,7 +83,7 @@ class Sensei_Blocks {
 	 * @return array Filtered categories.
 	 */
 	public function sensei_block_categories( $categories, $post ) {
-		if ( 'course' !== $post->post_type && 'lesson' !== $post->post_type ) {
+		if ( ! in_array( $post->post_type, [ 'course', 'lesson', 'question' ], true ) ) {
 			return $categories;
 		}
 

--- a/includes/blocks/class-sensei-quiz-blocks.php
+++ b/includes/blocks/class-sensei-quiz-blocks.php
@@ -32,7 +32,7 @@ class Sensei_Quiz_Blocks extends Sensei_Blocks_Initializer {
 		}
 
 		Sensei()->assets->enqueue( 'sensei-quiz-blocks', 'blocks/quiz/index.js', [], true );
-		Sensei()->assets->enqueue( 'sensei-quiz-blocks-editor', 'blocks/quiz/quiz.editor.css' );
+		Sensei()->assets->enqueue( 'sensei-quiz-blocks-editor', 'blocks/quiz/quiz.editor.css', [ 'sensei-shared-blocks-editor-style', 'sensei-editor-components-style' ] );
 	}
 
 	/**
@@ -53,6 +53,15 @@ class Sensei_Quiz_Blocks extends Sensei_Blocks_Initializer {
 
 		new Sensei_Block_Quiz();
 		new Sensei_Block_Quiz_Question();
+
+		$post_type_object = get_post_type_object( 'question' );
+
+		$post_type_object->template      = [
+			[ 'sensei-lms/quiz-question' ],
+		];
+		$post_type_object->template_lock = 'insert';
 	}
+
+
 
 }

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -413,7 +413,7 @@ class Sensei_PostTypes {
 			'has_archive'           => true,
 			'hierarchical'          => false,
 			'menu_position'         => 51,
-			'supports'              => array( 'title', 'revisions' ),
+			'supports'              => array( 'title', 'revisions', 'editor' ),
 			'show_in_rest'          => true,
 			'rest_base'             => 'questions',
 			'rest_controller_class' => 'Sensei_REST_API_Questions_Controller',

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -306,7 +306,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		$question_meta = get_post_meta( $question->ID );
 		return [
 			'id'          => $question->ID,
-			'title'       => $question->post_title,
+			'title'       => 'auto-draft' !== $question->post_status ? $question->post_title : '',
 			'description' => $question->post_content,
 			'options'     => [
 				'grade' => Sensei()->question->get_question_grade( $question->ID ),

--- a/includes/rest-api/class-sensei-rest-api-questions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-questions-controller.php
@@ -73,6 +73,7 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 				[
 					'blockName'    => 'core/paragraph',
 					'innerContent' => [ $description ],
+					'attrs'        => [],
 				]
 			);
 		}

--- a/includes/rest-api/class-sensei-rest-api-questions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-questions-controller.php
@@ -65,7 +65,8 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 
 		$post        = $this->get_post( $request['id'] );
 		$attrs       = $this->get_question( $post );
-		$description = $response->data['content']['raw'];
+		$description = $attrs['description'];
+		unset( $attrs['description'] );
 
 		if ( ! has_blocks( $description ) ) {
 			$description = serialize_block(

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-questions-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-questions-controller.php
@@ -3,7 +3,7 @@
  * Sensei REST API: Sensei_REST_API_Questions_Controller tests
  *
  * @package sensei-lms
- * @since 3.9.0
+ * @since   3.9.0
  */
 
 /**
@@ -138,4 +138,114 @@ class Sensei_REST_API_Questions_Controller_Tests extends WP_Test_REST_TestCase {
 
 		$this->assertEquals( $question_ids, $fetched_question_ids, 'All question IDs should be returned' );
 	}
+
+	public function testPostContentIsQuestionBlock() {
+
+		$question_id = $this->factory->question->create(
+			[
+				'question_type' => 'single-line',
+			]
+		);
+
+		$blocks = $this->request_question( $question_id );
+
+		$this->assertCount( 1, $blocks );
+		$this->assertEquals( 'sensei-lms/quiz-question', $blocks[0]['blockName'] );
+
+	}
+
+	public function testPostContentQuestionBlockAttributes() {
+		$question_id = $this->factory->question->create(
+			[
+				'question'               => 'Test Question',
+				'question_type'          => 'multiple-choice',
+				'question_description'   => 'Text description',
+				'question_grade'         => 2,
+				'question_right_answers' => [ 'Right answer' ],
+				'question_wrong_answers' => [ 'Wrong,comma', 'Wrong 1' ],
+				'random_order'           => 'no',
+				'answer_order'           => 'ac70b9a3f24b5b657826b567057169a2,b13d55d1ff11d676253fa5e4b0517bd7,89dc5589bfebac1468e8823afd5a4861',
+				'answer_feedback'        => 'Some feedback',
+			]
+		);
+
+		$blocks = $this->request_question( $question_id );
+
+		$this->assertEquals(
+			[
+				'title'      => 'Test Question',
+				'type'       => 'multiple-choice',
+				'id'         => $question_id,
+				'shared'     => false,
+				'categories' => [],
+				'options'    => [
+					'grade'          => 2,
+					'answerFeedback' => 'Some feedback',
+					'randomOrder'    => false,
+				],
+				'answer'     => [
+					'answers' => [
+						[
+							'label'   => 'Wrong 1',
+							'correct' => false,
+						],
+						[
+							'label'   => 'Wrong,comma',
+							'correct' => false,
+						],
+						[
+							'label'   => 'Right answer',
+							'correct' => true,
+						],
+					],
+				],
+			],
+			$blocks[0]['attrs']
+		);
+
+	}
+
+	public function testPostContentQuestionBlockInnerBlocks() {
+		$question_id = $this->factory->question->create(
+			[
+				'question'             => 'Test Question',
+				'question_type'        => 'single-line',
+				'question_description' => 'Text description',
+			]
+		);
+
+		$blocks = $this->request_question( $question_id );
+
+		$this->assertEquals(
+			[
+				[
+					'blockName'    => 'core/paragraph',
+					'innerHTML'    => 'Text description',
+					'innerContent' => [ 'Text description' ],
+					'innerBlocks'  => [],
+					'attrs'        => [],
+				],
+			],
+			$blocks[0]['innerBlocks']
+		);
+
+	}
+
+	/**
+	 * Request question for editing, and return blocks parsed from content.
+	 *
+	 * @param int $question_id
+	 *
+	 * @return array[]
+	 */
+	private function request_question( int $question_id ): array {
+
+		$this->login_as_admin();
+
+		$request = new WP_REST_Request( 'GET', '/wp/v2/questions/' . $question_id );
+		$request->set_param( 'context', 'edit' );
+		$response = $this->server->dispatch( $request );
+		return parse_blocks( $response->get_data()['content']['raw'] );
+	}
+
 }


### PR DESCRIPTION

This is a bit different, instead of using a separate REST API call to fetch question data and sync blocks, the post content is replaced by a serialized question block on the normal question endpoint (which the block editor uses to load the post). This is a lot simpler than the dedicated store, and we'll need to deal with filtering post content on saving the question post anyway.


### Changes proposed in this Pull Request

* Enable block editor for question post type
* Add a question block to the post content in the GET question endpoint
* Map server-side attributes to block attributes via block migration
  * This might have to be moved to PHP for saving, but we can probably just merge the API and block attributes formats to avoid having to do any mapping

### Testing instructions

* Open various existing questions for editing
* Make sure their settings, answer types and content are picked up

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1198" alt="image" src="https://user-images.githubusercontent.com/176949/109570691-c1f61d00-7aea-11eb-9a3e-26e6ab30fbd5.png">

