### PR TITLE
Filter the block templates

### DIFF
--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -62,7 +62,7 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 
 		$post_type_object = get_post_type_object( 'course' );
 
-		$blocks = [
+		$block_template = [
 			[ 'sensei-lms/button-take-course' ],
 			[ 'sensei-lms/button-contact-teacher' ],
 			[ 'sensei-lms/course-progress' ],
@@ -75,11 +75,12 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 		 * @hook  sensei_course_block_template
 		 * @since 3.9.0
 		 *
-		 * @param {string[][]} $blocks Blocks to add to the course block template.
+		 * @param {string[][]} $template          Array of blocks to use as the default initial state for a course.
+		 * @param {string[][]} $original_template Original block template.
 		 *
-		 * @return {string[][]} Blocks to add to the course block template.
+		 * @return {string[][]} Array of blocks to use as the default initial state for a course.
 		 */
-		$post_type_object->template = apply_filters( 'sensei_course_block_template', $blocks );
+		$post_type_object->template = apply_filters( 'sensei_course_block_template', $block_template, $post_type_object->template );
 	}
 
 	/**

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -62,12 +62,24 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 
 		$post_type_object = get_post_type_object( 'course' );
 
-		$post_type_object->template = [
+		$blocks = [
 			[ 'sensei-lms/button-take-course' ],
 			[ 'sensei-lms/button-contact-teacher' ],
 			[ 'sensei-lms/course-progress' ],
 			[ 'sensei-lms/course-outline' ],
 		];
+
+		/**
+		 * Customize the course block template.
+		 *
+		 * @hook  sensei_course_block_template
+		 * @since 3.9.0
+		 *
+		 * @param {string[][]} $blocks Blocks to add to the course block template.
+		 *
+		 * @return {string[][]} Blocks to add to the course block template.
+		 */
+		$post_type_object->template = apply_filters( 'sensei_course_block_template', $blocks );
 	}
 
 	/**

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -62,7 +62,7 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 
 		$post_type_object = get_post_type_object( 'lesson' );
 
-		$post_type_object->template = [
+		$blocks = [
 			[ 'sensei-lms/button-contact-teacher' ],
 			[
 				'core/paragraph',
@@ -72,8 +72,20 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		];
 
 		if ( Sensei()->quiz->is_block_based_editor_enabled() ) {
-			$post_type_object->template[] = [ 'sensei-lms/quiz', [ 'isPostTemplate' => true ] ];
+			$blocks[] = [ 'sensei-lms/quiz', [ 'isPostTemplate' => true ] ];
 		}
+
+		/**
+		 * Customize the lesson block template.
+		 *
+		 * @hook  sensei_lesson_block_template
+		 * @since 3.9.0
+		 *
+		 * @param {string[][]} $blocks Blocks to add to the lesson block template.
+		 *
+		 * @return {string[][]} Blocks to add to the lesson block template.
+		 */
+		$post_type_object->template = apply_filters( 'sensei_lesson_block_template', $blocks );
 
 		if ( ! Sensei()->lesson->has_sensei_blocks() ) {
 			return;

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -62,7 +62,7 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 
 		$post_type_object = get_post_type_object( 'lesson' );
 
-		$blocks = [
+		$block_template = [
 			[ 'sensei-lms/button-contact-teacher' ],
 			[
 				'core/paragraph',
@@ -72,7 +72,7 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		];
 
 		if ( Sensei()->quiz->is_block_based_editor_enabled() ) {
-			$blocks[] = [ 'sensei-lms/quiz', [ 'isPostTemplate' => true ] ];
+			$block_template[] = [ 'sensei-lms/quiz', [ 'isPostTemplate' => true ] ];
 		}
 
 		/**
@@ -81,11 +81,12 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		 * @hook  sensei_lesson_block_template
 		 * @since 3.9.0
 		 *
-		 * @param {string[][]} $blocks Blocks to add to the lesson block template.
+		 * @param {string[][]} $template          Array of blocks to use as the default initial state for a lesson.
+		 * @param {string[][]} $original_template Original block template.
 		 *
-		 * @return {string[][]} Blocks to add to the lesson block template.
+		 * @return {string[][]} Array of blocks to use as the default initial state for a lesson.
 		 */
-		$post_type_object->template = apply_filters( 'sensei_lesson_block_template', $blocks );
+		$post_type_object->template = apply_filters( 'sensei_lesson_block_template', $block_template, $post_type_object->template );
 
 		if ( ! Sensei()->lesson->has_sensei_blocks() ) {
 			return;


### PR DESCRIPTION
Fixes #3878.

### Changes proposed in this Pull Request

Add filters to the block templates to facilitate customization.

### Testing instructions

* Add the following code snippet:
```
add_filter( 'sensei_course_block_template', 'adjust_course_block_template' );
add_filter( 'sensei_lesson_block_template', 'adjust_lesson_block_template' );

function adjust_course_block_template( $blocks ) {
  array_push( $blocks, [ 'core/gallery' ] );

  return $blocks;
}

function adjust_lesson_block_template( $blocks ) {
  array_push( $blocks, [ 'core/image' ] );

  return $blocks;
}
```
* Create a new course and lesson and ensure the blocks are added to the page.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New Filters

* `sensei_course_block_template` - Customize the course block template.
* `sensei_lesson_block_template` - Customize the lesson block template.