### PR TITLE
Fix course structure infinite loop

### DIFF
--- a/assets/blocks/course-outline/course-outline-store.js
+++ b/assets/blocks/course-outline/course-outline-store.js
@@ -77,4 +77,19 @@ registerStructureStore( {
 		// Clear error notices.
 		dispatch( 'core/notices' ).removeNotice( 'course-outline-save-error' );
 	},
+
+	/**
+	 * Prepend structure in server's response.
+	 *
+	 * @param {Object} structure The structure response.
+	 *
+	 * @return {Object} The modified response.
+	 */
+	setServerStructure( structure ) {
+		if ( ! structure ) {
+			return {};
+		}
+
+		return { structure };
+	},
 } );

--- a/assets/shared/structure/structure-store.js
+++ b/assets/shared/structure/structure-store.js
@@ -149,16 +149,10 @@ export function registerStructureStore( {
 		 */
 		*finishPostSave() {
 			yield { type: 'FINISH_POST_SAVE' };
-			const { hasUnsavedServerUpdates, hasUnsavedEditorChanges } = select(
-				storeName
-			);
+			const { hasUnsavedServerUpdates } = select( storeName );
 
 			if ( hasUnsavedServerUpdates() ) {
 				yield* actions.savePost();
-			}
-
-			if ( hasUnsavedEditorChanges() ) {
-				yield* actions.saveStructure();
 			}
 		},
 


### PR DESCRIPTION
There was an issue caused by #4011 where an infinite loop was happening when the course structure was saved.

### Changes proposed in this Pull Request

* This fixes the above issue.
* It also removes the `saveStructure` call which was happening on `finishPostSave` for the below reasons:
    * This was added as a retry mechanism but it is almost certain that if the first `saveStructure` call didn't make the server and editor structures equal, then a second call would probably not make them equal too causing an infinite loop of requests.
    * Since we intend to allow the users to modify the structure when they define custom question types, it would make development harder.

### Testing instructions

* Create and modify a course structure and observe that everything works as it should.