### PR TITLE
Fix previous questions that have changed teachers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "A learning management plugin for WordPress, which provides the smoothest platform for helping you teach anything.",
 	"require-dev": {
 		"php": "^5.4 || ^7",
-		"phpunit/phpunit": "6.5.14",
+		"phpunit/phpunit": "7.5.20",
 		"dealerdirect/phpcodesniffer-composer-installer": "0.7.0",
 		"phpcompatibility/phpcompatibility-wp": "2.1.0",
 		"squizlabs/php_codesniffer": "3.5.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2cb36d323103f4741505a4c114fb1d29",
+    "content-hash": "455ee0c5784fe8f1f75dd4497199120f",
     "packages": [],
     "packages-dev": [
         {
@@ -194,22 +194,22 @@
         },
         {
             "name": "phar-io/manifest",
-            "version": "1.0.1",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0"
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/2df402786ab5368a0169091f61a7c1e0eb6852d0",
-                "reference": "2df402786ab5368a0169091f61a7c1e0eb6852d0",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
+                "reference": "7761fcacf03b4d4f16e7ccb606d4879ca431fcf4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-phar": "*",
-                "phar-io/version": "^1.0.1",
+                "phar-io/version": "^2.0",
                 "php": "^5.6 || ^7.0"
             },
             "type": "library",
@@ -245,20 +245,20 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2017-03-05T18:14:27+00:00"
+            "time": "2018-07-08T19:23:20+00:00"
         },
         {
             "name": "phar-io/version",
-            "version": "1.0.1",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/version.git",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df"
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/version/zipball/a70c0ced4be299a63d32fa96d9281d03e94041df",
-                "reference": "a70c0ced4be299a63d32fa96d9281d03e94041df",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/45a2ec53a73c70ce41d55cedef9063630abaf1b6",
+                "reference": "45a2ec53a73c70ce41d55cedef9063630abaf1b6",
                 "shasum": ""
             },
             "require": {
@@ -292,7 +292,7 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
-            "time": "2017-03-05T17:38:23+00:00"
+            "time": "2018-07-08T19:19:57+00:00"
         },
         {
             "name": "phpcompatibility/php-compatibility",
@@ -602,33 +602,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.10.3",
+            "version": "1.12.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093"
+                "reference": "245710e971a030f42e08f4912863805570f23d39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
-                "reference": "451c3cd1418cf640de218914901e51b064abb093",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
+                "reference": "245710e971a030f42e08f4912863805570f23d39",
                 "shasum": ""
             },
             "require": {
-                "doctrine/instantiator": "^1.0.2",
-                "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
-                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
+                "doctrine/instantiator": "^1.2",
+                "php": "^7.2 || ~8.0, <8.1",
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "sebastian/comparator": "^3.0 || ^4.0",
+                "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5 || ^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
+                "phpspec/phpspec": "^6.0",
+                "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.10.x-dev"
+                    "dev-master": "1.11.x-dev"
                 }
             },
             "autoload": {
@@ -661,44 +661,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-03-05T15:02:03+00:00"
+            "time": "2020-12-19T10:15:11+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.2",
+            "version": "6.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac"
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/c89677919c5dd6d3b3852f230a663118762218ac",
-                "reference": "c89677919c5dd6d3b3852f230a663118762218ac",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
+                "reference": "807e6013b00af69b6c5d9ceb4282d0393dbb9d8d",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
-                "phpunit/php-file-iterator": "^1.4.2",
+                "php": "^7.1",
+                "phpunit/php-file-iterator": "^2.0",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0.1",
+                "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
-                "sebastian/environment": "^3.0",
+                "sebastian/environment": "^3.1 || ^4.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-xdebug": "^2.6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-master": "6.1-dev"
                 }
             },
             "autoload": {
@@ -724,29 +724,32 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-04-06T15:36:58+00:00"
+            "time": "2018-10-31T16:06:48+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.5",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4"
+                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/730b01bc3e867237eaac355e06a36b85dd93a8b4",
-                "reference": "730b01bc3e867237eaac355e06a36b85dd93a8b4",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/4b49fb70f067272b659ef0174ff9ca40fdaa6357",
+                "reference": "4b49fb70f067272b659ef0174ff9ca40fdaa6357",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -761,7 +764,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -771,7 +774,13 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2017-11-27T13:52:08+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:25:21+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -816,28 +825,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/2454ae1765516d20c4ffe103d85a58a9a3bd5662",
+                "reference": "2454ae1765516d20c4ffe103d85a58a9a3bd5662",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.1-dev"
                 }
             },
             "autoload": {
@@ -852,7 +861,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -861,33 +870,39 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:20:02+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.2",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db"
+                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/472b687829041c24b25f475e14c2f38a09edf1c2",
+                "reference": "472b687829041c24b25f475e14c2f38a09edf1c2",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.1-dev"
                 }
             },
             "autoload": {
@@ -910,58 +925,64 @@
             "keywords": [
                 "tokenizer"
             ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "abandoned": true,
-            "time": "2017-11-27T05:48:46+00:00"
+            "time": "2020-11-30T08:38:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.14",
+            "version": "7.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7"
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/bac23fe7ff13dbdb461481f706f0e9fe746334b7",
-                "reference": "bac23fe7ff13dbdb461481f706f0e9fe746334b7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9467db479d1b0487c99733bb1e7944d32deded2c",
+                "reference": "9467db479d1b0487c99733bb1e7944d32deded2c",
                 "shasum": ""
             },
             "require": {
+                "doctrine/instantiator": "^1.1",
                 "ext-dom": "*",
                 "ext-json": "*",
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
-                "phar-io/manifest": "^1.0.1",
-                "phar-io/version": "^1.0",
-                "php": "^7.0",
+                "myclabs/deep-copy": "^1.7",
+                "phar-io/manifest": "^1.0.2",
+                "phar-io/version": "^2.0",
+                "php": "^7.1",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.3",
-                "phpunit/php-file-iterator": "^1.4.3",
+                "phpunit/php-code-coverage": "^6.0.7",
+                "phpunit/php-file-iterator": "^2.0.1",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.9",
-                "sebastian/comparator": "^2.1",
-                "sebastian/diff": "^2.0",
-                "sebastian/environment": "^3.1",
+                "phpunit/php-timer": "^2.1",
+                "sebastian/comparator": "^3.0",
+                "sebastian/diff": "^3.0",
+                "sebastian/environment": "^4.0",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
                 "sebastian/object-enumerator": "^3.0.3",
-                "sebastian/resource-operations": "^1.0",
+                "sebastian/resource-operations": "^2.0",
                 "sebastian/version": "^2.0.1"
             },
             "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
+                "phpunit/phpunit-mock-objects": "*"
             },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
+                "ext-soap": "*",
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "phpunit/php-invoker": "^2.0"
             },
             "bin": [
                 "phpunit"
@@ -969,7 +990,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5.x-dev"
+                    "dev-master": "7.5-dev"
                 }
             },
             "autoload": {
@@ -995,67 +1016,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-02-01T05:22:47+00:00"
-        },
-        {
-            "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "reference": "cd1cf05c553ecfec36b170070573e540b67d3f1f",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
-                "phpunit/php-text-template": "^1.2.1",
-                "sebastian/exporter": "^3.1"
-            },
-            "conflict": {
-                "phpunit/phpunit": "<6.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.5.11"
-            },
-            "suggest": {
-                "ext-soap": "*"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "5.0.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Mock Object library for PHPUnit",
-            "homepage": "https://github.com/sebastianbergmann/phpunit-mock-objects/",
-            "keywords": [
-                "mock",
-                "xunit"
-            ],
-            "abandoned": true,
-            "time": "2018-08-09T05:50:03+00:00"
+            "time": "2020-01-08T08:45:45+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -1110,30 +1071,30 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "2.1.3",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9"
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/34369daee48eafb2651bea869b4b15d75ccc35f9",
-                "reference": "34369daee48eafb2651bea869b4b15d75ccc35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/1071dfcef776a57013124ff35e1fc41ccd294758",
+                "reference": "1071dfcef776a57013124ff35e1fc41ccd294758",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0",
-                "sebastian/diff": "^2.0 || ^3.0",
+                "php": ">=7.1",
+                "sebastian/diff": "^3.0",
                 "sebastian/exporter": "^3.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.4"
+                "phpunit/phpunit": "^8.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1.x-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1146,6 +1107,10 @@
                 "BSD-3-Clause"
             ],
             "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
                 {
                     "name": "Jeff Welch",
                     "email": "whatthejeff@gmail.com"
@@ -1157,10 +1122,6 @@
                 {
                     "name": "Bernhard Schussek",
                     "email": "bschussek@2bepublished.at"
-                },
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Provides the functionality to compare PHP values for equality",
@@ -1170,32 +1131,39 @@
                 "compare",
                 "equality"
             ],
-            "time": "2018-02-01T13:46:46+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T08:04:30+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "2.0.1",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
+                "reference": "14f72dd46eaf2f2293cbe79c93cc0bc43161a211",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^7.5 || ^8.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -1209,45 +1177,57 @@
             ],
             "authors": [
                 {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                },
-                {
                     "name": "Sebastian Bergmann",
                     "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
                 }
             ],
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:59:04+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "3.1.0",
+            "version": "4.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5"
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
-                "reference": "cd0871b3975fb7fc44d11314fd1ee20925fce4f5",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
+                "reference": "d47bbbad83711771f167c72d4e3f25f7fcc1f8b0",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.1"
+                "phpunit/phpunit": "^7.5"
+            },
+            "suggest": {
+                "ext-posix": "*"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.1.x-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -1272,7 +1252,13 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2017-07-01T08:51:00+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:53:42+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1563,25 +1549,25 @@
         },
         {
             "name": "sebastian/resource-operations",
-            "version": "1.0.0",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/resource-operations.git",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
-                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/31d35ca87926450c44eae7e2611d45a7a65ea8b3",
+                "reference": "31d35ca87926450c44eae7e2611d45a7a65ea8b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": ">=7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1601,7 +1587,13 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
-            "time": "2015-07-28T20:34:47+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-11-30T07:30:19+00:00"
         },
         {
             "name": "sebastian/version",
@@ -1916,12 +1908,12 @@
             "version": "1.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },

--- a/includes/background-jobs/class-sensei-background-job-batch.php
+++ b/includes/background-jobs/class-sensei-background-job-batch.php
@@ -24,7 +24,7 @@ abstract class Sensei_Background_Job_Batch extends Sensei_Background_Job_Statefu
 	private $complete = false;
 
 	/**
-	 * Get the total items in the job.
+	 * Get the job batch size.
 	 *
 	 * @return int
 	 */

--- a/includes/background-jobs/class-sensei-background-job-batch.php
+++ b/includes/background-jobs/class-sensei-background-job-batch.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * File containing the class Sensei_Background_Job_Batch.
+ *
+ * @since 3.9.0
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Base class for jobs that do simple batches.
+ */
+abstract class Sensei_Background_Job_Batch extends Sensei_Background_Job_Stateful {
+	const STATE_OFFSET = 'offset';
+
+	/**
+	 * Completion flag.
+	 *
+	 * @var bool
+	 */
+	private $complete = false;
+
+	/**
+	 * Get the total items in the job.
+	 *
+	 * @return int
+	 */
+	abstract protected function get_batch_size() : int;
+
+	/**
+	 * Run batch.
+	 *
+	 * @param int $offset Current offset.
+	 *
+	 * @return bool Returns true if there is more to do.
+	 */
+	abstract protected function run_batch( int $offset ) : bool;
+
+	/**
+	 * Run the job.
+	 */
+	public function run() {
+		$offset = $this->get_state( self::STATE_OFFSET, 0 );
+		if ( $this->run_batch( $offset ) ) {
+			$this->set_state( self::STATE_OFFSET, $offset + $this->get_batch_size() );
+		} else {
+			$this->complete = true;
+		}
+	}
+
+	/**
+	 * After the job runs, check to see if it needs to be re-queued for the next batch.
+	 *
+	 * @return bool
+	 */
+	public function is_complete() {
+		return $this->complete;
+	}
+}

--- a/includes/background-jobs/class-sensei-background-job-stateful.php
+++ b/includes/background-jobs/class-sensei-background-job-stateful.php
@@ -71,7 +71,7 @@ abstract class Sensei_Background_Job_Stateful implements Sensei_Background_Job_I
 	 * @param string $id    The unique ID.
 	 * @param array  $args  Arguments needed to run.
 	 */
-	private function __construct( $id, $args = [] ) {
+	public function __construct( $id, $args = [] ) {
 		$this->id   = $id;
 		$this->args = $args;
 
@@ -93,7 +93,7 @@ abstract class Sensei_Background_Job_Stateful implements Sensei_Background_Job_I
 	private function restore_state() {
 		$state_raw = get_transient( self::TRANSIENT_PREFIX . $this->get_id() );
 
-		$state = $state_raw ? json_decode( $state_raw ) : [];
+		$state = $state_raw ? json_decode( $state_raw, true ) : [];
 		if ( ! is_array( $state ) ) {
 			$state = [];
 		}
@@ -121,11 +121,12 @@ abstract class Sensei_Background_Job_Stateful implements Sensei_Background_Job_I
 	/**
 	 * Get a state variable.
 	 *
-	 * @param mixed $default The default value.
+	 * @param string $key   State key to update.
+	 * @param mixed  $default The default value.
 	 *
 	 * @return mixed
 	 */
-	public function get_state( string $key, $default = null ) {
+	public function get_state( $key, $default = null ) {
 		return $this->state[ $key ] ?? $default;
 	}
 
@@ -135,7 +136,7 @@ abstract class Sensei_Background_Job_Stateful implements Sensei_Background_Job_I
 	 * @param string $key   State key to update.
 	 * @param mixed  $value Value to set.
 	 */
-	public function set_state( string $key, $value ) {
+	public function set_state( $key, $value ) {
 		$current_value = $this->state[ $key ] ?? null;
 		if ( $current_value !== $value ) {
 			$this->changed = true;

--- a/includes/background-jobs/class-sensei-background-job-stateful.php
+++ b/includes/background-jobs/class-sensei-background-job-stateful.php
@@ -14,9 +14,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Base class for jobs that require state.
  */
 abstract class Sensei_Background_Job_Stateful implements Sensei_Background_Job_Interface {
-	const NAME             = 'sensei_background_job_stateful';
-	const TRANSIENT_PREFIX = 'sensei_background_job_';
-	const TRANSIENT_LIFE   = DAY_IN_SECONDS;
+	const NAME                         = 'sensei_background_job_stateful';
+	const TRANSIENT_PREFIX             = 'sensei_background_job_';
+	const TRANSIENT_EXPIRATION_SECONDS = DAY_IN_SECONDS;
 
 	/**
 	 * ID for the job.
@@ -168,7 +168,7 @@ abstract class Sensei_Background_Job_Stateful implements Sensei_Background_Job_I
 			return;
 		}
 
-		set_transient( $this->get_state_transient_name(), wp_json_encode( $this->state ), self::TRANSIENT_LIFE );
+		set_transient( $this->get_state_transient_name(), wp_json_encode( $this->state ), self::TRANSIENT_EXPIRATION_SECONDS );
 	}
 
 	/**

--- a/includes/background-jobs/class-sensei-background-job-stateful.php
+++ b/includes/background-jobs/class-sensei-background-job-stateful.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * File containing the class Sensei_Background_Job_Stateful.
+ *
+ * @since 3.9.0
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Base class for jobs that require state.
+ */
+abstract class Sensei_Background_Job_Stateful implements Sensei_Background_Job_Interface {
+	const NAME             = 'sensei_background_job_stateful';
+	const TRANSIENT_PREFIX = 'sensei_background_job_';
+	const TRANSIENT_LIFE   = DAY_IN_SECONDS;
+
+	/**
+	 * ID for the job.
+	 *
+	 * @var string
+	 */
+	private $id;
+
+	/**
+	 * Arguments for the job.
+	 *
+	 * @var array
+	 */
+	private $args;
+
+	/**
+	 * State for the current job.
+	 *
+	 * @var array
+	 */
+	private $state;
+
+	/**
+	 * Set if the state has changed.
+	 *
+	 * @var bool
+	 */
+	private $changed = false;
+
+	/**
+	 * Set if the job has been deleted.
+	 *
+	 * @var bool
+	 */
+	private $deleted = false;
+
+	/**
+	 * Set up and enqueue job.
+	 *
+	 * @param array $args The job arguments.
+	 */
+	public static function start( $args = [] ) {
+		$instance = new static( md5( uniqid() ), $args );
+		Sensei_Scheduler::instance()->schedule_job( $instance );
+
+		return $instance;
+	}
+
+	/**
+	 * Sensei_Background_Job_Stateful constructor.
+	 *
+	 * @param string $id    The unique ID.
+	 * @param array  $args  Arguments needed to run.
+	 */
+	private function __construct( $id, $args = [] ) {
+		$this->id   = $id;
+		$this->args = $args;
+
+		$this->restore_state();
+	}
+
+	/**
+	 * Get the action name for the scheduled job.
+	 *
+	 * @return string
+	 */
+	public function get_name() {
+		return self::NAME;
+	}
+
+	/**
+	 * Restore a job state.
+	 */
+	private function restore_state() {
+		$state_raw = get_transient( self::TRANSIENT_PREFIX . $this->get_id() );
+
+		$state = $state_raw ? json_decode( $state_raw ) : [];
+		if ( ! is_array( $state ) ) {
+			$state = [];
+		}
+
+		$this->state = $state;
+	}
+
+	/**
+	 * Clean up.
+	 */
+	public function cleanup() {
+		delete_transient( self::TRANSIENT_PREFIX . $this->get_id() );
+		$this->deleted = true;
+	}
+
+	/**
+	 * Get the job ID.
+	 *
+	 * @return string
+	 */
+	public function get_id() : string {
+		return $this->id;
+	}
+
+	/**
+	 * Get a state variable.
+	 *
+	 * @param mixed $default The default value.
+	 *
+	 * @return mixed
+	 */
+	public function get_state( string $key, $default = null ) {
+		return $this->state[ $key ] ?? $default;
+	}
+
+	/**
+	 * Update state.
+	 *
+	 * @param string $key   State key to update.
+	 * @param mixed  $value Value to set.
+	 */
+	public function set_state( string $key, $value ) {
+		$current_value = $this->state[ $key ] ?? null;
+		if ( $current_value !== $value ) {
+			$this->changed = true;
+		}
+
+		$this->state[ $key ] = $value;
+	}
+
+	/**
+	 * Persist the state.
+	 */
+	public function persist() {
+		if ( $this->deleted || ! $this->changed ) {
+			return;
+		}
+
+		set_transient( self::TRANSIENT_PREFIX . $this->get_id(), wp_json_encode( $this->state ), self::TRANSIENT_LIFE );
+	}
+
+	/**
+	 * Get the arguments to run with the job.
+	 *
+	 * @return array
+	 */
+	public function get_args() {
+		return array_merge(
+			$this->args,
+			[
+				'id'    => $this->id,
+				'class' => static::class,
+			]
+		);
+	}
+}

--- a/includes/background-jobs/class-sensei-background-job-stateful.php
+++ b/includes/background-jobs/class-sensei-background-job-stateful.php
@@ -54,24 +54,12 @@ abstract class Sensei_Background_Job_Stateful implements Sensei_Background_Job_I
 	private $deleted = false;
 
 	/**
-	 * Set up and enqueue job.
-	 *
-	 * @param array $args The job arguments.
-	 */
-	public static function start( $args = [] ) {
-		$instance = new static( null, $args );
-		Sensei_Scheduler::instance()->schedule_job( $instance );
-
-		return $instance;
-	}
-
-	/**
 	 * Sensei_Background_Job_Stateful constructor.
 	 *
-	 * @param string $id    The unique ID.
 	 * @param array  $args  Arguments needed to run.
+	 * @param string $id    The unique ID.
 	 */
-	public function __construct( $id, $args = [] ) {
+	public function __construct( $args = [], $id = null ) {
 		if ( null === $id ) {
 			$id = md5( static::class );
 			if ( $this->allow_multiple_instances() ) {

--- a/includes/background-jobs/class-sensei-background-job-stateful.php
+++ b/includes/background-jobs/class-sensei-background-job-stateful.php
@@ -59,7 +59,7 @@ abstract class Sensei_Background_Job_Stateful implements Sensei_Background_Job_I
 	 * @param array $args The job arguments.
 	 */
 	public static function start( $args = [] ) {
-		$instance = new static( md5( uniqid() ), $args );
+		$instance = new static( null, $args );
 		Sensei_Scheduler::instance()->schedule_job( $instance );
 
 		return $instance;
@@ -72,11 +72,25 @@ abstract class Sensei_Background_Job_Stateful implements Sensei_Background_Job_I
 	 * @param array  $args  Arguments needed to run.
 	 */
 	public function __construct( $id, $args = [] ) {
+		if ( null === $id ) {
+			$id = md5( static::class );
+			if ( $this->allow_multiple_instances() ) {
+				$id = md5( uniqid() );
+			}
+		}
+
 		$this->id   = $id;
 		$this->args = $args;
 
 		$this->restore_state();
 	}
+
+	/**
+	 * Can multiple instances be enqueued at the same time?
+	 *
+	 * @return bool
+	 */
+	abstract protected function allow_multiple_instances() : bool;
 
 	/**
 	 * Get the action name for the scheduled job.

--- a/includes/background-jobs/class-sensei-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler.php
@@ -52,23 +52,24 @@ class Sensei_Scheduler {
 		if (
 			! isset( $args['id'], $args['class'] )
 			|| ! class_exists( $args['class'] )
-			|| is_subclass_of( $args['class'], Sensei_Background_Job_Stateful::class )
+			|| ! is_subclass_of( $args['class'], Sensei_Background_Job_Stateful::class )
 		) {
 			return false;
 		}
 
-		$id        = $args['id'];
-		$className = $args['class'];
+		$id         = $args['id'];
+		$class_name = $args['class'];
 		unset( $args['id'], $args['class'] );
 
-		$job = new $className( $id, $args );
-		self::instance()->run( $job );
+		$job = new $class_name( $id, $args );
+		self::instance()->run(
+			$job,
+			function() use ( $job ) {
+				$job->cleanup();
+			}
+		);
 
-		if ( $job->is_complete() ) {
-			$job->cleanup();
-		} else {
-			$job->persist();
-		}
+		$job->persist();
 	}
 
 	/**

--- a/includes/background-jobs/class-sensei-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler.php
@@ -61,7 +61,7 @@ class Sensei_Scheduler {
 		$class_name = $args['class'];
 		unset( $args['id'], $args['class'] );
 
-		$job = new $class_name( $id, $args );
+		$job = new $class_name( $args, $id );
 		self::instance()->run(
 			$job,
 			function() use ( $job ) {

--- a/includes/background-jobs/class-sensei-scheduler.php
+++ b/includes/background-jobs/class-sensei-scheduler.php
@@ -46,19 +46,22 @@ class Sensei_Scheduler {
 	/**
 	 * Run a stateful job.
 	 *
-	 * @param array $args The job arguments..
+	 * @param array $args The job arguments.
+	 *
+	 * @return bool
 	 */
-	public static function run_stateful_job( $args ) {
+	public static function run_stateful_job( $args ) : bool {
 		if (
-			! isset( $args['id'], $args['class'] )
-			|| ! class_exists( $args['class'] )
-			|| ! is_subclass_of( $args['class'], Sensei_Background_Job_Stateful::class )
+			empty( $args['id'] )
+			|| empty( $args['class'] )
+			|| ! class_exists( (string) $args['class'] )
+			|| ! is_subclass_of( (string) $args['class'], Sensei_Background_Job_Stateful::class )
 		) {
 			return false;
 		}
 
-		$id         = $args['id'];
-		$class_name = $args['class'];
+		$id         = (string) $args['id'];
+		$class_name = (string) $args['class'];
 		unset( $args['id'], $args['class'] );
 
 		$job = new $class_name( $args, $id );
@@ -70,6 +73,8 @@ class Sensei_Scheduler {
 		);
 
 		$job->persist();
+
+		return true;
 	}
 
 	/**

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -159,6 +159,11 @@ class Sensei_Autoloader {
 			'Sensei_Renderer_Single_Post'                => 'renderers/class-sensei-renderer-single-post.php',
 
 			/**
+			 * Update tasks.
+			 */
+			'Sensei_Update_Fix_Question_Author'          => 'update-tasks/class-sensei-update-fix-question-author.php',
+
+			/**
 			 * Unsupported theme handlers.
 			 */
 			'Sensei_Unsupported_Theme_Handler_Interface' => 'unsupported-theme-handlers/interface-sensei-unsupported-theme-handler.php',

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -221,6 +221,7 @@ class Sensei_Data_Cleaner {
 		'sensei_activation_redirect',
 		'sensei_woocommerce_plugin_information',
 		'sensei_extensions_.*',
+		'sensei_background_job_.*',
 	);
 
 	/**

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -88,8 +88,7 @@ class Sensei_Updates {
 		if ( ! $this->is_upgrade || version_compare( $this->current_version, '3.9.0', '>' ) ) {
 			return;
 		}
-
-		Sensei_Update_Fix_Question_Author::start();
+		Sensei_Scheduler::instance()->schedule_job( new Sensei_Update_Fix_Question_Author() );
 	}
 
 	/**

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -74,9 +74,22 @@ class Sensei_Updates {
 		$this->v3_0_check_legacy_enrolment();
 		$this->v3_7_check_rewrite_front();
 		$this->v3_7_add_comment_indexes();
+		$this->v3_9_fix_question_author();
 
 		// Flush rewrite cache.
 		Sensei()->initiate_rewrite_rules_flush();
+	}
+
+	/**
+	 * Enqueue job to fix question post authors from previous course teacher changes.
+	 */
+	private function v3_9_fix_question_author() {
+		// Only run this if we're upgrading and the current version (before upgrade) is less than 3.9.0.
+		if ( ! $this->is_upgrade || version_compare( $this->current_version, '3.9.0', '>' ) ) {
+			return;
+		}
+
+		Sensei_Update_Fix_Question_Author::start();
 	}
 
 	/**

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -85,9 +85,10 @@ class Sensei_Updates {
 	 */
 	private function v3_9_fix_question_author() {
 		// Only run this if we're upgrading and the current version (before upgrade) is less than 3.9.0.
-		if ( ! $this->is_upgrade || version_compare( $this->current_version, '3.9.0', '>' ) ) {
+		if ( ! $this->is_upgrade || version_compare( $this->current_version, '3.9.0', '>=' ) ) {
 			return;
 		}
+
 		Sensei_Scheduler::instance()->schedule_job( new Sensei_Update_Fix_Question_Author() );
 	}
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -425,6 +425,8 @@ class Sensei_Main {
 		// Setup Wizard.
 		$this->setup_wizard = Sensei_Setup_Wizard::instance();
 
+		Sensei_Scheduler::init();
+
 		// Differentiate between administration and frontend logic.
 		if ( is_admin() ) {
 			// Load Admin Class

--- a/includes/update-tasks/class-sensei-update-fix-question-author.php
+++ b/includes/update-tasks/class-sensei-update-fix-question-author.php
@@ -24,6 +24,15 @@ class Sensei_Update_Fix_Question_Author extends Sensei_Background_Job_Batch {
 	}
 
 	/**
+	 * Can multiple instances be enqueued at the same time?
+	 *
+	 * @return bool
+	 */
+	protected function allow_multiple_instances() : bool {
+		return false;
+	}
+
+	/**
 	 * Run batch.
 	 *
 	 * @param int $offset Current offset.

--- a/includes/update-tasks/class-sensei-update-fix-question-author.php
+++ b/includes/update-tasks/class-sensei-update-fix-question-author.php
@@ -11,11 +11,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Fix question post authors for previous course teacher changes.
+ * Fix question post authors from previous course teacher changes.
  */
 class Sensei_Update_Fix_Question_Author extends Sensei_Background_Job_Batch {
 	/**
-	 * Get the total items in the job.
+	 * Get the job batch size.
 	 *
 	 * @return int
 	 */

--- a/includes/update-tasks/class-sensei-update-fix-question-author.php
+++ b/includes/update-tasks/class-sensei-update-fix-question-author.php
@@ -58,12 +58,12 @@ class Sensei_Update_Fix_Question_Author extends Sensei_Background_Job_Batch {
 	 *
 	 * @return WP_Query
 	 */
-	private function get_quiz_query( int $offset ) : WP_Query {
+	protected function get_quiz_query( int $offset ) : WP_Query {
 		return new WP_Query(
 			[
 				'post_type'      => 'quiz',
 				'post_status'    => 'any',
-				'orderby'        => 'id',
+				'orderby'        => 'ID',
 				'order'          => 'ASC',
 				'offset'         => (int) $offset,
 				'posts_per_page' => $this->get_batch_size(),

--- a/includes/update-tasks/class-sensei-update-fix-question-author.php
+++ b/includes/update-tasks/class-sensei-update-fix-question-author.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * File containing the class Sensei_Update_Fix_Question_Author.
+ *
+ * @since 3.9.0
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Fix question post authors for previous course teacher changes.
+ */
+class Sensei_Update_Fix_Question_Author extends Sensei_Background_Job_Batch {
+	/**
+	 * Get the total items in the job.
+	 *
+	 * @return int
+	 */
+	protected function get_batch_size() : int {
+		return 10;
+	}
+
+	/**
+	 * Run batch.
+	 *
+	 * @param int $offset Current offset.
+	 *
+	 * @return bool Returns true if there is more to do.
+	 */
+	protected function run_batch( int $offset ) : bool {
+		$query     = $this->get_quiz_query( $offset );
+		$remaining = $query->found_posts - $offset;
+
+		foreach ( $query->posts as $quiz ) {
+			Sensei()->quiz->update_quiz_author( $quiz->ID, $quiz->post_author );
+			$remaining--;
+		}
+
+		return $remaining > 0;
+	}
+
+	/**
+	 * Get the quiz offset.
+	 *
+	 * @param int $offset Current offset.
+	 *
+	 * @return WP_Query
+	 */
+	private function get_quiz_query( int $offset ) : WP_Query {
+		return new WP_Query(
+			[
+				'post_type'      => 'quiz',
+				'post_status'    => 'any',
+				'orderby'        => 'id',
+				'order'          => 'ASC',
+				'offset'         => (int) $offset,
+				'posts_per_page' => $this->get_batch_size(),
+			]
+		);
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-lms",
-  "version": "3.8.1",
+  "version": "3.9.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sensei-lms",
-  "version": "3.8.1",
+  "version": "3.9.0-dev",
   "description": "Sensei LMS",
   "author": "Automattic",
   "license": "GPL-2.0-or-later",

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -94,7 +94,7 @@ if ( ! function_exists( 'Sensei' ) ) {
 	 */
 	function Sensei() {
 		// phpcs:enable
-		return Sensei_Main::instance( array( 'version' => '3.8.1' ) );
+		return Sensei_Main::instance( array( 'version' => '3.9.0-dev' ) );
 	}
 }
 

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -3,7 +3,7 @@
  * Plugin Name: Sensei LMS
  * Plugin URI: https://woocommerce.com/products/sensei/
  * Description: Share your knowledge, grow your network, and strengthen your brand by launching an online course.
- * Version: 3.8.1
+ * Version: 3.9.0-dev
  * Author: Automattic
  * Author URI: https://automattic.com
  * License: GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html

--- a/tests/framework/class-sensei-background-job-stateful-stub.php
+++ b/tests/framework/class-sensei-background-job-stateful-stub.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Stub implementing Sensei_Background_Job_Stateful.
+ *
+ * @package sensei-tests
+ */
+
+/**
+ * Stub to help test the background job stateful runner.
+ *
+ * @since 3.9.0
+ */
+class Sensei_Background_Job_Stateful_Stub extends Sensei_Background_Job_Stateful {
+	/**
+	 * Run job.
+	 */
+	public function run() {
+		$this->set_state( 'run', $this->get_state( 'run', 0 ) + 1 );
+	}
+
+	/**
+	 * Check if complete.
+	 *
+	 * @return bool
+	 */
+	public function is_complete() {
+		$run_for = $this->get_args()['run_for'] ?? 5;
+
+		return $this->get_state( 'run', 0 ) > $run_for;
+	}
+
+	protected function allow_multiple_instances(): bool {
+		return true;
+	}
+
+}

--- a/tests/framework/data-port/trait-sensei-data-port-test-helpers.php
+++ b/tests/framework/data-port/trait-sensei-data-port-test-helpers.php
@@ -24,8 +24,8 @@ trait Sensei_Data_Port_Test_Helpers {
 	 * @param string               $log_entry Log message to look for.
 	 * @param null                 $message   Message to show in assertion.
 	 */
-	protected function assertJobHasLogEntry( Sensei_Data_Port_Job $job, $log_entry, $message = null ) {
-		$logs = $job->get_logs();
+	protected function assertJobHasLogEntry( Sensei_Data_Port_Job $job, $log_entry, $message = '' ) {
+		$logs      = $job->get_logs();
 		$has_entry = false;
 		foreach ( $logs as $log ) {
 			if ( $log_entry === $log['message'] ) {

--- a/tests/unit-tests/background-jobs/test-class-sensei-background-job-batch.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-background-job-batch.php
@@ -10,7 +10,7 @@ class Sensei_Background_Job_Batch_Test extends WP_UnitTestCase {
 	 * Tests to make sure offset is incremented by batch size.
 	 */
 	public function testRun() {
-		$instance = $this->getMock( [ 'run_batch' ], 10 );
+		$instance = $this->getInstanceMock( [ 'run_batch' ], 10 );
 
 		$instance->expects( $this->exactly( 3 ) )
 			->method( 'run_batch' )
@@ -37,11 +37,11 @@ class Sensei_Background_Job_Batch_Test extends WP_UnitTestCase {
 	 *
 	 * @return \PHPUnit\Framework\MockObject\MockObject|Sensei_Background_Job_Batch
 	 */
-	private function getMock( $methods = [], $batch_size = 10 ) {
+	private function getInstanceMock( $methods = [], $batch_size = 10 ) {
 		$methods[] = 'get_batch_size';
-		$mock = $this->getMockBuilder( Sensei_Background_Job_Batch::class )
-			->setMethods( $methods )
-			->getMockForAbstractClass();
+		$mock      = $this->getMockBuilder( Sensei_Background_Job_Batch::class )
+						->setMethods( $methods )
+						->getMockForAbstractClass();
 
 		$mock->expects( $this->any() )->method( 'get_batch_size' )->willReturn( $batch_size );
 

--- a/tests/unit-tests/background-jobs/test-class-sensei-background-job-batch.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-background-job-batch.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * Tests for Sensei_Background_Job_Batch class.
+ *
+ * @group background-jobs
+ */
+class Sensei_Background_Job_Batch_Test extends WP_UnitTestCase {
+	/**
+	 * Tests to make sure offset is incremented by batch size.
+	 */
+	public function testRun() {
+		$instance = $this->getMock( [ 'run_batch' ], 10 );
+
+		$instance->expects( $this->exactly( 3 ) )
+			->method( 'run_batch' )
+			->withConsecutive( [ 0 ], [ 10 ], [ 20 ] )
+			->willReturnOnConsecutiveCalls( true, true, false );
+
+		$instance->run();
+		$this->assertFalse( $instance->is_complete() );
+
+		$instance->run();
+		$this->assertFalse( $instance->is_complete() );
+
+		$instance->run();
+		$this->assertTrue( $instance->is_complete() );
+
+		$this->assertEquals( 20, $instance->get_state( Sensei_Background_Job_Batch::STATE_OFFSET ) );
+	}
+
+	/**
+	 * Get mock for class.
+	 *
+	 * @param array $methods    Methods for mocking.
+	 * @param int   $batch_size Batch size.
+	 *
+	 * @return \PHPUnit\Framework\MockObject\MockObject|Sensei_Background_Job_Batch
+	 */
+	private function getMock( $methods = [], $batch_size = 10 ) {
+		$methods[] = 'get_batch_size';
+		$mock = $this->getMockBuilder( Sensei_Background_Job_Batch::class )
+			->setMethods( $methods )
+			->getMockForAbstractClass();
+
+		$mock->expects( $this->any() )->method( 'get_batch_size' )->willReturn( $batch_size );
+
+		return $mock;
+	}
+}

--- a/tests/unit-tests/background-jobs/test-class-sensei-background-job-stateful.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-background-job-stateful.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * Tests for Sensei_Background_Job_Stateful class.
+ *
+ * @group background-jobs
+ */
+class Sensei_Background_Job_Stateful_Test extends WP_UnitTestCase {
+
+	/**
+	 * Simple test to make sure state is set and fetched in the object correctly.
+	 *
+	 * @covers \Sensei_Background_Job_Stateful::get_state
+	 * @covers \Sensei_Background_Job_Stateful::set_state
+	 */
+	public function testSetGetState() {
+		$instance = $this->getMock();
+		$instance->set_state( 'test', 'value' );
+		$this->assertEquals( 'value', $instance->get_state( 'test' ) );
+	}
+
+	/**
+	 * Simple test to make sure state persists between calls.
+	 *
+	 * @covers \Sensei_Background_Job_Stateful::get_state
+	 * @covers \Sensei_Background_Job_Stateful::set_state
+	 * @covers \Sensei_Background_Job_Stateful::persist
+	 * @covers \Sensei_Background_Job_Stateful::restore_state
+	 */
+	public function testStatePersists() {
+		$id = 'state-test';
+		$instance_a = $this->getMock( $id );
+		$instance_a->set_state( 'test', 'value' );
+		$instance_a->persist();
+
+		$instance_b = $this->getMock( $id );
+		$this->assertEquals( 'value', $instance_b->get_state( 'test' ) );
+	}
+
+	/**
+	 * Make sure state does not persist after cleanup.
+	 *
+	 * @covers \Sensei_Background_Job_Stateful::get_state
+	 * @covers \Sensei_Background_Job_Stateful::set_state
+	 * @covers \Sensei_Background_Job_Stateful::persist
+	 * @covers \Sensei_Background_Job_Stateful::restore_state
+	 * @covers \Sensei_Background_Job_Stateful::cleanup
+	 */
+	public function testStateDoesNotPersistAfterCleanup() {
+		$id = 'state-test';
+		$instance_a = $this->getMock( $id );
+		$instance_a->set_state( 'test', 'value' );
+		$instance_a->cleanup();
+		$instance_a->persist();
+
+		$instance_b = $this->getMock( $id );
+		$this->assertEquals( null, $instance_b->get_state( 'test' ) );
+	}
+
+	/**
+	 * Make sure state is not shared when arguments change.
+	 *
+	 * @covers \Sensei_Background_Job_Stateful::get_state_transient_name
+	 * @covers \Sensei_Background_Job_Stateful::restore_state
+	 */
+	public function testStateNotSharedWithDifferentArguments() {
+		$id = 'state-test';
+		$instance_a = $this->getMock( $id, [ 'dinosaurs' => true ] );
+		$instance_a->set_state( 'test', 'value' );
+		$instance_a->persist();
+
+		$instance_b = $this->getMock( $id, [ 'dinosaurs' => false ] );
+		$this->assertEquals( null, $instance_b->get_state( 'test' ) );
+	}
+
+	/**
+	 * @param string $id                       The job ID.
+	 * @param array  $args                     The job args.
+	 * @param array  $methods                  The methods to mock.
+	 * @param false  $allow_multiple_instances If multiple instances are allowed of this job.
+	 *
+	 * @return \PHPUnit\Framework\MockObject\MockObject|Sensei_Background_Job_Stateful
+	 */
+	private function getMock( $id = null, $args = [], $methods = [], $allow_multiple_instances = false ) {
+		$methods[] = 'allow_multiple_instances';
+
+		$mock = $this->getMockBuilder( Sensei_Background_Job_Stateful::class )
+					 ->setConstructorArgs( [ $args, $id ] )
+					 ->setMethods( $methods )
+					 ->getMockForAbstractClass();
+
+		$mock->expects( $this->any() )->method( 'allow_multiple_instances' )->willReturn( $allow_multiple_instances );
+
+		return $mock;
+	}
+}

--- a/tests/unit-tests/background-jobs/test-class-sensei-background-job-stateful.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-background-job-stateful.php
@@ -14,7 +14,7 @@ class Sensei_Background_Job_Stateful_Test extends WP_UnitTestCase {
 	 * @covers \Sensei_Background_Job_Stateful::set_state
 	 */
 	public function testSetGetState() {
-		$instance = $this->getMock();
+		$instance = $this->getInstanceMock();
 		$instance->set_state( 'test', 'value' );
 		$this->assertEquals( 'value', $instance->get_state( 'test' ) );
 	}
@@ -28,12 +28,12 @@ class Sensei_Background_Job_Stateful_Test extends WP_UnitTestCase {
 	 * @covers \Sensei_Background_Job_Stateful::restore_state
 	 */
 	public function testStatePersists() {
-		$id = 'state-test';
-		$instance_a = $this->getMock( $id );
+		$id         = 'state-test';
+		$instance_a = $this->getInstanceMock( $id );
 		$instance_a->set_state( 'test', 'value' );
 		$instance_a->persist();
 
-		$instance_b = $this->getMock( $id );
+		$instance_b = $this->getInstanceMock( $id );
 		$this->assertEquals( 'value', $instance_b->get_state( 'test' ) );
 	}
 
@@ -47,13 +47,13 @@ class Sensei_Background_Job_Stateful_Test extends WP_UnitTestCase {
 	 * @covers \Sensei_Background_Job_Stateful::cleanup
 	 */
 	public function testStateDoesNotPersistAfterCleanup() {
-		$id = 'state-test';
-		$instance_a = $this->getMock( $id );
+		$id         = 'state-test';
+		$instance_a = $this->getInstanceMock( $id );
 		$instance_a->set_state( 'test', 'value' );
 		$instance_a->cleanup();
 		$instance_a->persist();
 
-		$instance_b = $this->getMock( $id );
+		$instance_b = $this->getInstanceMock( $id );
 		$this->assertEquals( null, $instance_b->get_state( 'test' ) );
 	}
 
@@ -64,16 +64,18 @@ class Sensei_Background_Job_Stateful_Test extends WP_UnitTestCase {
 	 * @covers \Sensei_Background_Job_Stateful::restore_state
 	 */
 	public function testStateNotSharedWithDifferentArguments() {
-		$id = 'state-test';
-		$instance_a = $this->getMock( $id, [ 'dinosaurs' => true ] );
+		$id         = 'state-test';
+		$instance_a = $this->getInstanceMock( $id, [ 'dinosaurs' => true ] );
 		$instance_a->set_state( 'test', 'value' );
 		$instance_a->persist();
 
-		$instance_b = $this->getMock( $id, [ 'dinosaurs' => false ] );
+		$instance_b = $this->getInstanceMock( $id, [ 'dinosaurs' => false ] );
 		$this->assertEquals( null, $instance_b->get_state( 'test' ) );
 	}
 
 	/**
+	 * Get the instance of the test object.
+	 *
 	 * @param string $id                       The job ID.
 	 * @param array  $args                     The job args.
 	 * @param array  $methods                  The methods to mock.
@@ -81,13 +83,13 @@ class Sensei_Background_Job_Stateful_Test extends WP_UnitTestCase {
 	 *
 	 * @return \PHPUnit\Framework\MockObject\MockObject|Sensei_Background_Job_Stateful
 	 */
-	private function getMock( $id = null, $args = [], $methods = [], $allow_multiple_instances = false ) {
+	private function getInstanceMock( $id = null, $args = [], $methods = [], $allow_multiple_instances = false ) {
 		$methods[] = 'allow_multiple_instances';
 
 		$mock = $this->getMockBuilder( Sensei_Background_Job_Stateful::class )
-					 ->setConstructorArgs( [ $args, $id ] )
-					 ->setMethods( $methods )
-					 ->getMockForAbstractClass();
+						->setConstructorArgs( [ $args, $id ] )
+						->setMethods( $methods )
+						->getMockForAbstractClass();
 
 		$mock->expects( $this->any() )->method( 'allow_multiple_instances' )->willReturn( $allow_multiple_instances );
 

--- a/tests/unit-tests/background-jobs/test-class-sensei-scheduler.php
+++ b/tests/unit-tests/background-jobs/test-class-sensei-scheduler.php
@@ -5,6 +5,8 @@
  * @package sensei
  */
 
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/class-sensei-background-job-stateful-stub.php';
+
 /**
  * Tests for Sensei_Scheduler class.
  *
@@ -23,7 +25,6 @@ class Sensei_Scheduler_Test extends WP_UnitTestCase {
 		add_filter( 'sensei_scheduler_class', [ __CLASS__, 'scheduler_use_wp_cron' ] );
 	}
 
-
 	/**
 	 * Clean up after all tests.
 	 */
@@ -39,4 +40,57 @@ class Sensei_Scheduler_Test extends WP_UnitTestCase {
 	public function testInstance() {
 		$this->assertTrue( Sensei_Scheduler::instance() instanceof Sensei_Scheduler_WP_Cron, 'Scheduler should be handled by the WP cron handler when told to do so' );
 	}
+
+	/**
+	 * Test running a stateful job and making sure it reschedules and saves state.
+	 */
+	public function testRunStatefulJob() {
+		$job_args = [ 'run_for' => 1 ];
+		$job_a    = new Sensei_Background_Job_Stateful_Stub( $job_args );
+		$run_args = $job_a->get_args();
+
+		$job_a->set_state( 'test', 'value' );
+		$job_a->persist();
+
+		$this->assertTrue( Sensei_Scheduler::run_stateful_job( $run_args ) );
+		$job_b = new Sensei_Background_Job_Stateful_Stub( $job_args, $job_a->get_id() );
+
+		$this->assertEquals( 'value', $job_b->get_state( 'test' ) );
+		$this->assertEquals( 1, $job_b->get_state( 'run' ) );
+		$this->assertTrue( Sensei_Scheduler::run_stateful_job( $run_args ) );
+
+		// Job should have been cleaned up.
+		$job_c = new Sensei_Background_Job_Stateful_Stub( $job_args, $job_a->get_id() );
+		$this->assertEquals( null, $job_c->get_state( 'test' ) );
+		$this->assertEquals( null, $job_c->get_state( 'run' ) );
+	}
+
+	/**
+	 * Test to make sure it doesn't attempt to run jobs of an unexpected class.
+	 */
+	public function testRunStatefulJobIgnoreUnknownClasses() {
+		$this->assertFalse(
+			Sensei_Scheduler::run_stateful_job(
+				[
+					'id'    => 'test',
+					'class' => Sensei_Main::class,
+				]
+			)
+		);
+	}
+
+	/**
+	 * Test to make sure it doesn't attempt to run jobs without an ID.
+	 */
+	public function testRunStatefulJobIgnoreWithoutId() {
+		$this->assertFalse(
+			Sensei_Scheduler::run_stateful_job(
+				[
+					'id'    => '',
+					'class' => Sensei_Background_Job_Stateful_Stub::class,
+				]
+			)
+		);
+	}
+
 }

--- a/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-enrolment-manager.php
@@ -364,7 +364,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	 * @param int $user_id   User ID.
 	 * @param int $course_id Course post ID.
 	 */
-	private function assertEnrolmentCheckDeferred( $user_id, $course_id, $message = null ) {
+	private function assertEnrolmentCheckDeferred( $user_id, $course_id, $message = '' ) {
 		$property = new ReflectionProperty( Sensei_Course_Enrolment_Manager::class, 'deferred_enrolment_checks' );
 		$property->setAccessible( true );
 		$deferred = $property->getValue( Sensei_Course_Enrolment_Manager::instance() );
@@ -378,7 +378,7 @@ class Sensei_Course_Enrolment_Manager_Test extends WP_UnitTestCase {
 	 * @param int $user_id   User ID.
 	 * @param int $course_id Course post ID.
 	 */
-	private function assertEnrolmentCheckNotDeferred( $user_id, $course_id, $message = null ) {
+	private function assertEnrolmentCheckNotDeferred( $user_id, $course_id, $message = '' ) {
 		$property = new ReflectionProperty( Sensei_Course_Enrolment_Manager::class, 'deferred_enrolment_checks' );
 		$property->setAccessible( true );
 		$deferred = $property->getValue( Sensei_Course_Enrolment_Manager::instance() );

--- a/tests/unit-tests/test-class-sensei-updates.php
+++ b/tests/unit-tests/test-class-sensei-updates.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * This file contains the Sensei_Updates_Test class.
+ *
+ * @package sensei
+ */
+
+/**
+ * Tests for the class `Sensei_Updates`.
+ *
+ * @group update-tasks
+ */
+class Sensei_Updates_Test extends WP_UnitTestCase {
+	use Sensei_Scheduler_Test_Helpers;
+
+	/**
+	 * Setup function.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		Sensei_Scheduler_Shim::reset();
+		self::restoreShimScheduler();
+
+	}
+
+	/**
+	 * Clean up after all tests.
+	 */
+	public static function tearDownAfterClass() {
+		self::resetScheduler();
+
+		return parent::tearDownAfterClass();
+	}
+
+	/**
+	 * Test to make sure question update fix is enqueued when coming from 3.8.0.
+	 */
+	public function testFixQuestionsEnqueuedWhenComingFrom38() {
+		$updates = new Sensei_Updates( '3.8.0', false, true );
+		$updates->run_updates();
+
+		$job            = new Sensei_Update_Fix_Question_Author();
+		$next_scheduled = Sensei_Scheduler_Shim::get_next_scheduled( $job );
+		$this->assertNotFalse( $next_scheduled );
+	}
+
+	/**
+	 * Test to make sure question update fix is not enqueued in future.
+	 */
+	public function testFixQuestionsNotEnqueuedWhenComingFrom39() {
+		$updates = new Sensei_Updates( '3.9.0', false, true );
+		$updates->run_updates();
+
+		$job            = new Sensei_Update_Fix_Question_Author();
+		$next_scheduled = Sensei_Scheduler_Shim::get_next_scheduled( $job );
+		$this->assertFalse( $next_scheduled );
+
+		$updates = new Sensei_Updates( '3.9.1', false, true );
+		$updates->run_updates();
+
+		$job            = new Sensei_Update_Fix_Question_Author();
+		$next_scheduled = Sensei_Scheduler_Shim::get_next_scheduled( $job );
+		$this->assertFalse( $next_scheduled );
+	}
+
+
+	/**
+	 * Test to make sure question update fix is not enqueued on fresh installs.
+	 */
+	public function testFixQuestionsNotEnqueuedOnNewInstalls() {
+		$updates = new Sensei_Updates( null, true, false );
+		$updates->run_updates();
+
+		$job            = new Sensei_Update_Fix_Question_Author();
+		$next_scheduled = Sensei_Scheduler_Shim::get_next_scheduled( $job );
+		$this->assertFalse( $next_scheduled );
+
+		$updates = new Sensei_Updates( '3.9.1', false, true );
+		$updates->run_updates();
+
+		$job            = new Sensei_Update_Fix_Question_Author();
+		$next_scheduled = Sensei_Scheduler_Shim::get_next_scheduled( $job );
+		$this->assertFalse( $next_scheduled );
+	}
+}

--- a/tests/unit-tests/update-tasks/test-class-sensei-update-fix-question-author.php
+++ b/tests/unit-tests/update-tasks/test-class-sensei-update-fix-question-author.php
@@ -1,0 +1,145 @@
+<?php
+
+/**
+ * Tests for Sensei_Update_Fix_Question_Author class.
+ *
+ * @group update-tasks
+ * @group background-jobs
+ */
+class Sensei_Update_Fix_Question_Author_Test extends WP_UnitTestCase {
+	/**
+	 * Quiz mock.
+	 *
+	 * @var \PHPUnit\Framework\MockObject\MockObject|Sensei_Quiz
+	 */
+	private $quiz_mock;
+
+	/**
+	 * Sensei Factory.
+	 *
+	 * @var Sensei_Factory
+	 */
+	private $factory;
+
+	/**
+	 * Set up the tests.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->factory   = new Sensei_Factory();
+		$this->quiz_mock = Sensei()->quiz = $this->getMockBuilder( Sensei_Quiz::class )->setMethods( [ 'update_quiz_author' ] )->getMock();
+	}
+
+	/**
+	 * Tests a simple batch of quiz posts.
+	 */
+	public function testSimpleBatch() {
+		$batch_size   = 10;
+		$total_count  = 11;
+		$fake_quizzes = $this->getFakeQuizzes( $total_count );
+		$this->quiz_mock->expects( $this->exactly( $total_count ) )->method( 'update_quiz_author' );
+
+		$instance_a = $this->getInstanceMock( array_slice( $fake_quizzes, 0, $batch_size ), $total_count, $batch_size );
+
+		$instance_a->run();
+		$instance_a->persist();
+		$this->assertFalse( $instance_a->is_complete() );
+
+		$instance_b = $this->getInstanceMock( array_slice( $fake_quizzes, $batch_size, $batch_size ), $total_count, $batch_size, $instance_a->get_id() );
+
+		$instance_b->run();
+		$this->assertTrue( $instance_b->is_complete() );
+	}
+
+	/**
+	 * Tests for when the batch size equals the number of quizzes
+	 */
+	public function testExactBatchSize() {
+		$batch_size   = 10;
+		$total_count  = 10;
+		$fake_quizzes = $this->getFakeQuizzes( $total_count );
+		$this->quiz_mock->expects( $this->exactly( $total_count ) )->method( 'update_quiz_author' );
+
+		$instance = $this->getInstanceMock( array_slice( $fake_quizzes, 0, $batch_size ), $total_count, $batch_size );
+
+		$instance->run();
+		$this->assertTrue( $instance->is_complete() );
+	}
+
+	/**
+	 * Tests to make sure the quiz query is pulling correctly.
+	 */
+	public function testQuizQuery() {
+		$total_count = 11;
+
+		$this->factory->post->create();
+		$quiz_ids           = $this->factory->quiz->create_many( $total_count );
+		$expected_arguments = [];
+		foreach ( $quiz_ids as $quiz_id ) {
+			$expected_arguments[] = [ $quiz_id, get_current_user_id() ];
+		}
+
+		$method_mock = $this->quiz_mock->expects( $this->exactly( $total_count ) )->method( 'update_quiz_author' );
+		call_user_func_array( [ $method_mock, 'withConsecutive' ], $expected_arguments );
+
+		$instance_a = new Sensei_Update_Fix_Question_Author();
+		$instance_a->run();
+		$instance_a->persist();
+
+		$this->assertFalse( $instance_a->is_complete() );
+
+		$instance_b = new Sensei_Update_Fix_Question_Author( [], $instance_a->get_id() );
+		$instance_b->run();
+
+		$this->assertTrue( $instance_b->is_complete() );
+	}
+
+	/**
+	 * Get mock for question author.
+	 *
+	 * @param array  $quiz_query_response Posts to return.
+	 * @param int    $query_total_results Total results.
+	 * @param int    $batch_size          Batch size.
+	 * @param string $id                  Job ID.
+	 *
+	 * @return \PHPUnit\Framework\MockObject\MockObject|Sensei_Update_Fix_Question_Author
+	 */
+	private function getInstanceMock( $quiz_query_response = [], $query_total_results = 15, $batch_size = 10, $id = null ) {
+		$mock = $this->getMockBuilder( Sensei_Update_Fix_Question_Author::class )
+						->setMethods( [ 'get_quiz_query', 'get_batch_size' ] )
+						->setConstructorArgs( [ [], $id ] )
+						->getMock();
+
+		$query              = new WP_Query();
+		$query->found_posts = $query_total_results;
+		$query->posts       = $quiz_query_response;
+		$query->post_count  = count( $quiz_query_response );
+
+		$mock->expects( $this->once() )->method( 'get_quiz_query' )->willReturn( $query );
+		$mock->expects( $this->any() )->method( 'get_batch_size' )->willReturn( $batch_size );
+
+		return $mock;
+	}
+
+	/**
+	 * Get an array of WP_Post objects that haven't been inserted.
+	 *
+	 * @param int $n Number to return.
+	 *
+	 * @return WP_Post[]
+	 */
+	private function getFakeQuizzes( $n ) {
+		$fake_posts = array_map(
+			function( $id ) {
+				$quiz            = new WP_Post( new stdClass() );
+				$quiz->ID        = $id;
+				$quiz->post_type = 'quiz';
+
+				return $quiz;
+			},
+			range( 1, $n )
+		);
+
+		return $fake_posts;
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Introduces a stateful and simple batch background job base classes. This will massively simplify these types of jobs in the future and make it really easy to use.
* Adds a job that is enqueued when updating from pre-3.9.0 that attempts to fix questions.
* Updates PHPUnit to 7.5 to match WordPress core and get benefit of some PHP 7.4 fixes.

### Testing instructions

On `version/3.8.0` tag...
* As teacher A, add a course with 11 lessons + quizzes. Add one question to each quiz.
* As admin, change course teacher from teacher A to teacher B.
* Make sure your `sensei-version` option is less than 3.9.0.

Switch to this branch...
* Load any WP page.
* Observe a `sensei_background_job_stateful` event scheduled (in WP cron or ActionScheduler) with arg `class` of `Sensei_Update_Fix_Question_Author`.
* Observe it will batch through quizzes.
* Make sure all questions from are transferred to teacher B from the course created above.