### PR TITLE
Minor tweaks to question blocks

### DIFF
--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -108,10 +108,9 @@ $block: '.sensei-lms-question-block';
 	}
 
 	&__answer--multiple-choice {
-		&__option {
-			.sensei-lms-question-block__option-toggle, .sensei-lms-question-block__answer--multiple-choice__toggle {
-				opacity: 0.5;
-			}
+		&__option.is-draft .sensei-lms-question-block__option-toggle,
+		.sensei-lms-question-block__answer--multiple-choice__toggle {
+			opacity: 0.5;
 		}
 
 		&__option.is-draft {

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -103,8 +103,8 @@ $block: '.sensei-lms-question-block';
 				height: auto;
 				text-transform: uppercase;
 				background: #fff;
-				border: 1px solid currentColor;
-				color: currentColor;
+				border: 1px solid #1e1e1e;
+				color: #1e1e1e;
 			}
 		}
 	}

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -108,7 +108,7 @@ $block: '.sensei-lms-question-block';
 	}
 
 	&__answer--multiple-choice {
-		&__option.is-draft {
+		&__option {
 			.sensei-lms-question-block__option-toggle, .sensei-lms-question-block__answer--multiple-choice__toggle {
 				opacity: 0.5;
 			}

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -113,6 +113,12 @@ $block: '.sensei-lms-question-block';
 				opacity: 0.5;
 			}
 		}
+
+		&__option.is-draft {
+			.sensei-lms-question-block__answer--multiple-choice__toggle__wrapper {
+				display: none;
+			}
+		}
 	}
 
 	&__answer--true-false {

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -127,6 +127,11 @@ $block: '.sensei-lms-question-block';
 			&__control {
 				margin-right: 12px;
 			}
+
+		}
+
+		#{$block}__answer--true-false__toggle {
+			opacity: 0.5;
 		}
 
 		.editor-styles-wrapper & li {

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -201,7 +201,6 @@ $block: '.sensei-lms-question-block';
 			padding: 4px;
 			height: auto;
 			line-height: inherit;
-			text-align: right;
 		}
 	}
 

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -102,17 +102,14 @@ $block: '.sensei-lms-question-block';
 				font-size: 12px;
 				height: auto;
 				text-transform: uppercase;
-				background: #111;
+				background: #fff;
+				border: 1px solid currentColor;
+				color: currentColor;
 			}
 		}
 	}
 
 	&__answer--multiple-choice {
-		&__option.is-draft .sensei-lms-question-block__option-toggle,
-		.sensei-lms-question-block__answer--multiple-choice__toggle {
-			opacity: 0.5;
-		}
-
 		&__option.is-draft {
 			.sensei-lms-question-block__answer--multiple-choice__toggle__wrapper {
 				display: none;
@@ -128,10 +125,6 @@ $block: '.sensei-lms-question-block';
 				margin-right: 12px;
 			}
 
-		}
-
-		#{$block}__answer--true-false__toggle {
-			opacity: 0.5;
 		}
 
 		.editor-styles-wrapper & li {

--- a/assets/blocks/quiz/question-block/settings/question-answer-feedback-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-answer-feedback-settings.js
@@ -21,7 +21,7 @@ const QuestionAnswerFeedbackSettings = ( {
 		onChange={ ( value ) => setOptions( { answerFeedback: value } ) }
 		value={ answerFeedback }
 		help={ __(
-			'Displayed to the user after the quiz has been graded.',
+			'Displayed to the learner after the quiz has been graded.',
 			'sensei-lms'
 		) }
 	/>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Left-align the helper text for Gap Fill questions.
* Use the same colour for all right / wrong answer toggles.
* Tweak the _Answer Feedback_ helper text.

### Testing instructions

* Add a Gap Fill question and ensure the helper text is left-aligned.
* For both multiple choice and true/false questions, ensure the right/wrong answer toggles are the same color.
* Check that the _Answer Feedback_ helper text is updated for a multiple choice question.

### Screenshot / Video
![Screen Shot 2021-03-03 at 9 26 32 AM](https://user-images.githubusercontent.com/1190420/109819968-8fd7de80-7c02-11eb-9c39-8f21e01e2f2e.jpg)

![Screen Shot 2021-03-03 at 1 00 28 PM](https://user-images.githubusercontent.com/1190420/109850402-79d91680-7c20-11eb-91fc-7f93bbc51928.jpg)

![Screen Shot 2021-03-03 at 1 02 15 PM](https://user-images.githubusercontent.com/1190420/109850633-b73da400-7c20-11eb-80ff-af13d6f37b6b.jpg)