### PR TITLE
Add single question block editor — saving

### DIFF
--- a/assets/blocks/quiz/answer-blocks/option-toggle.scss
+++ b/assets/blocks/quiz/answer-blocks/option-toggle.scss
@@ -54,6 +54,7 @@
 			svg {
 				width: 20px;
 				height: 20px;
+				fill: currentColor;
 			}
 
 			&:after {

--- a/assets/blocks/quiz/answer-blocks/true-false.js
+++ b/assets/blocks/quiz/answer-blocks/true-false.js
@@ -34,10 +34,7 @@ const TrueFalseAnswer = ( {
 					key={ value }
 					className="sensei-lms-question-block__answer--true-false__option"
 				>
-					<OptionToggle
-						onClick={ () => setAttributes( { correct: value } ) }
-						isChecked={ correct === value }
-					>
+					<OptionToggle isChecked={ correct === value }>
 						<span>{ label }</span>
 					</OptionToggle>
 					{ hasSelected && (

--- a/assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js
@@ -9,17 +9,17 @@ import { __ } from '@wordpress/i18n';
  *
  * @param {Object}   props
  * @param {Object}   props.options
- * @param {string}   props.options.gradingNotes Notes for teacher when grading.
+ * @param {string}   props.options.teacherNotes Notes for teacher when grading.
  * @param {Function} props.setOptions
  */
 const QuestionGradingNotesSettings = ( {
-	options: { gradingNotes },
+	options: { teacherNotes },
 	setOptions,
 } ) => (
 	<TextareaControl
 		label={ __( 'Grading Notes', 'sensei-lms' ) }
-		onChange={ ( value ) => setOptions( { gradingNotes: value } ) }
-		value={ gradingNotes }
+		onChange={ ( value ) => setOptions( { teacherNotes: value } ) }
+		value={ teacherNotes }
 		help={ __(
 			'Displayed to the teacher when grading the question.',
 			'sensei-lms'

--- a/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
  * @param {Function} props.setOptions          Sets the options.
  */
 const QuestionMultipleChoiceSettings = ( {
-	options: { randomOrder = true },
+	options: { randomOrder },
 	setOptions,
 } ) => (
 	<CheckboxControl

--- a/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
@@ -13,7 +13,7 @@ import { __ } from '@wordpress/i18n';
  * @param {Function} props.setOptions          Sets the options.
  */
 const QuestionMultipleChoiceSettings = ( {
-	options: { randomOrder },
+	options: { randomOrder = true },
 	setOptions,
 } ) => (
 	<CheckboxControl

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -32,7 +32,7 @@ class Sensei_Blocks {
 	 *
 	 * @var Sensei_Quiz_Blocks
 	 */
-	private $quiz;
+	public $quiz;
 
 	/**
 	 * Sensei_Blocks constructor.

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -181,7 +181,9 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	private function get_multiple_choice_meta( array $question ): array {
 		$meta = [];
 
-		$meta['_random_order'] = false !== $question['options']['randomOrder'] ? 'yes' : 'no';
+		if ( isset( $question['options']['randomOrder'] ) ) {
+			$meta['_random_order'] = $question['options']['randomOrder'] ? 'yes' : 'no';
+		}
 
 		if ( isset( $question['answer'] ) ) {
 			$meta['_question_right_answer']  = [];

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -79,6 +79,10 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			$question['options'] = [];
 		}
 
+		if ( ! isset( $question['type'] ) ) {
+			$question['type'] = 'multiple-choice';
+		}
+
 		$post_args = [
 			'ID'          => isset( $question['id'] ) ? $question['id'] : null,
 			'post_title'  => $question['title'],
@@ -171,13 +175,10 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	private function get_multiple_choice_meta( array $question ): array {
 		$meta = [];
 
-		if ( isset( $question['options']['randomOrder'] ) ) {
-			$meta['_random_order'] = $question['options']['randomOrder'] ? 'yes' : 'no';
-		}
-
 		if ( array_key_exists( 'answerFeedback', $question['options'] ) ) {
 			$meta['_answer_feedback'] = $question['options']['answerFeedback'];
 		}
+		$meta['_random_order'] = false !== $question['options']['randomOrder'] ? 'yes' : 'no';
 
 		if ( isset( $question['answer'] ) ) {
 			$meta['_question_right_answer']  = [];
@@ -410,7 +411,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	 */
 	private function get_multiple_choice_properties( WP_Post $question ): array {
 		$type_specific_properties = [
-			'options' => [ 'randomOrder' => 'yes' === get_post_meta( $question->ID, '_random_order', true ) ],
+			'options' => [ 'randomOrder' => 'no' !== get_post_meta( $question->ID, '_random_order', true ) ],
 		];
 
 		$answer_feedback                                       = get_post_meta( $question->ID, '_answer_feedback', true );
@@ -629,7 +630,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 					'randomOrder'    => [
 						'type'        => 'boolean',
 						'description' => 'Should options be randomized when displayed to quiz takers',
-						'default'     => false,
+						'default'     => true,
 					],
 					'answerFeedback' => [
 						'type'        => [ 'string', 'null' ],

--- a/includes/rest-api/class-sensei-rest-api-questions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-questions-controller.php
@@ -115,11 +115,10 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 	 */
 	public function update_item( $request ) {
 
-		$body  = $request->get_json_params();
-		$block = $this->get_question_block_from_content( $body['content'] );
+		$block = $this->get_question_block_from_content( $request['content'] );
 
 		if ( $block ) {
-			$request->set_body( '' );
+			$request['content'] = '';
 		}
 		parent::update_item( $request );
 

--- a/includes/rest-api/class-sensei-rest-api-questions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-questions-controller.php
@@ -133,7 +133,7 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 				case 'sensei_lesson_quiz_question_missing_title':
 					return new WP_Error(
 						'sensei_lesson_quiz_question_missing_title',
-						__( 'Please ensure the question have a title before saving.', 'sensei-lms' ),
+						__( 'Please ensure the question has a title before saving.', 'sensei-lms' ),
 						[ 'status' => 400 ]
 					);
 			}

--- a/includes/rest-api/class-sensei-rest-api-questions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-questions-controller.php
@@ -3,7 +3,7 @@
  * Sensei REST API: Sensei_REST_API_Questions_Controller class.
  *
  * @package sensei-lms
- * @since 3.9.0
+ * @since   3.9.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @since 3.9.0
  *
- * @see WP_REST_Posts_Controller
+ * @see   WP_REST_Posts_Controller
  */
 class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 
@@ -36,7 +36,7 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 			'question',
 			'question-type-slug',
 			[
-				'get_callback' => function ( $object ) {
+				'get_callback' => function( $object ) {
 					return Sensei()->question->get_question_type( $object['id'] );
 				},
 				'context'      => [ 'view' ],
@@ -107,12 +107,79 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 	}
 
 	/**
+	 * Update question block from post content.
+	 *
+	 * @param WP_REST_Request $request
+	 *
+	 * @return WP_Error|WP_Post|WP_REST_Response
+	 */
+	public function update_item( $request ) {
+
+		$body  = $request->get_json_params();
+		$block = $this->get_question_block_from_content( $body['content'] );
+
+		if ( $block ) {
+			$request->set_body( '' );
+		}
+		$response = parent::update_item( $request );
+
+		if ( $block ) {
+			$this->update_question( $request['id'], $block );
+		}
+
+		return $response;
+
+	}
+
+	/**
+	 * Parse and return question block if it's the first block in the content.
+	 *
+	 * @param string $post_content
+	 *
+	 * @return array|null Question block.
+	 */
+	private function get_question_block_from_content( $post_content ) {
+		if ( ! has_block( 'sensei-lms/quiz-question', $post_content ) ) {
+			return null;
+		}
+		Sensei()->blocks->quiz->initialize_blocks();
+		$block = parse_blocks( trim( $post_content ) )[0] ?? null;
+
+		if ( ! $block || 'sensei-lms/quiz-question' !== $block['blockName'] ) {
+			return null;
+		}
+
+		return $block;
+	}
+
+	/**
+	 * Update question with attributes from the block.
+	 *
+	 * @param int   $id    Question ID.
+	 * @param array $block Question block.
+	 */
+	private function update_question( $id, $block ) {
+		$attrs       = $block['attrs'];
+		$description = serialize_blocks( $block['innerBlocks'] );
+		$question    = array_merge(
+			$attrs,
+			[
+				'description' => $description,
+				'id'          => $id,
+			]
+		);
+
+		$this->save_question( $question );
+	}
+
+	/**
 	 * Modifies the query for teachers so only their own questions are returned.
 	 *
 	 * @access private
 	 *
-	 * @param array           $args The query args.
+	 * @param array           $args    The query args.
 	 * @param WP_REST_Request $request The current REST request.
+	 *
 	 * @return array The modified query args.
 	 */
 	public function exclude_others_questions( $args, $request ) {
@@ -130,6 +197,7 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 	 * Checks if a given request has access to read posts.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
+	 *
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
 	 */
 	public function get_items_permissions_check( $request ) {
@@ -151,4 +219,5 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 
 		return true;
 	}
+
 }

--- a/includes/rest-api/class-sensei-rest-api-questions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-questions-controller.php
@@ -121,13 +121,15 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 		if ( $block ) {
 			$request->set_body( '' );
 		}
-		$response = parent::update_item( $request );
+		parent::update_item( $request );
 
 		if ( $block ) {
 			$this->update_question( $request['id'], $block );
 		}
 
-		return $response;
+		// Return the updated question.
+		$response = $this->prepare_item_for_response( get_post( $request['id'] ), $request );
+		return rest_ensure_response( $response );
 
 	}
 

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-questions-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-questions-controller.php
@@ -231,6 +231,44 @@ class Sensei_REST_API_Questions_Controller_Tests extends WP_Test_REST_TestCase {
 
 	}
 
+	public function testUpdateQuestionWithBlock() {
+		$this->login_as_admin();
+		$question_id = $this->factory->question->create(
+			[
+				'question'             => 'Test Question',
+				'question_type'        => 'single-line',
+				'question_description' => 'Text description',
+			]
+		);
+
+		$this->save_question_post(
+			$question_id,
+			'
+		<!-- wp:sensei-lms/quiz-question {"title":"Test Question Modified","type":"boolean","answer":{"correct":false},"options":{"grade":2,"answerFeedback":"Feedback"}} -->
+<!-- wp:paragraph -->
+<p>Updated Question Description.</p>
+<!-- /wp:paragraph -->
+<!-- /wp:sensei-lms/quiz-question -->
+		'
+		);
+
+		$question      = get_post( $question_id );
+		$question_meta = get_post_meta( $question_id );
+
+		$this->assertEquals( 'Test Question Modified', $question->post_title );
+		$this->assertEquals(
+			'<!-- wp:paragraph -->
+<p>Updated Question Description.</p>
+<!-- /wp:paragraph -->',
+			$question->post_content
+		);
+
+		$this->assertEquals( 'boolean', Sensei()->question->get_question_type( $question_id ) );
+		$this->assertEquals( [ 2 ], $question_meta['_question_grade'] );
+		$this->assertEquals( [ 'Feedback' ], $question_meta['_answer_feedback'] );
+
+	}
+
 	/**
 	 * Request question for editing, and return blocks parsed from content.
 	 *
@@ -246,6 +284,22 @@ class Sensei_REST_API_Questions_Controller_Tests extends WP_Test_REST_TestCase {
 		$request->set_param( 'context', 'edit' );
 		$response = $this->server->dispatch( $request );
 		return parse_blocks( $response->get_data()['content']['raw'] );
+	}
+
+	private function save_question_post( int $question_id, $content ): WP_REST_Response {
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/questions/' . $question_id );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				[
+					'id'      => $question_id,
+					'content' => $content,
+				]
+			)
+		);
+
+		return $this->server->dispatch( $request );
 	}
 
 }


### PR DESCRIPTION
Depends on #4025 

### Changes proposed in this Pull Request

* Parse block when saving a post, and update question from block attributes
* Fix some implicit defaults not behaving consistently (Multiple choice random order)
* Enable answer feedback on the API for True/false and Gap fill questions. (The blocks already had these on)


### Testing instructions

* Create a new question or edit an existing one
* Change question settings and content, save
* Reload/check question elsewhere to see that everything is updated (type, options, title/description)

