### PR TITLE
Handle quiz status based on block presence and question count

### DIFF
--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -12,6 +12,7 @@ import questionBlock from '../question-block';
 import { useQuizStructure } from '../quiz-store';
 import QuizAppender from './quiz-appender';
 import QuizSettings from './quiz-settings';
+import { useHasQuestions } from './use-has-questions';
 
 /**
  * Quiz block editor.
@@ -25,6 +26,8 @@ const QuizEdit = ( props ) => {
 		{ name: questionBlock.name, selectFirstBlock: true },
 		props
 	);
+
+	useHasQuestions( props.clientId );
 
 	const { isPostTemplate } = props.attributes;
 

--- a/assets/blocks/quiz/quiz-block/use-has-questions.js
+++ b/assets/blocks/quiz/quiz-block/use-has-questions.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { select, dispatch } from '@wordpress/data';
+
+/**
+ * Monitor for questions and disable the lesson quiz when none have been added.
+ *
+ * @param {string} clientId The quiz block client id.
+ */
+export const useHasQuestions = ( clientId ) => {
+	const questionBlocks = select( 'core/block-editor' )
+		.getBlocks( clientId )
+		.filter( ( block ) => !! block.attributes.title );
+
+	// Monitor for valid questions.
+	useEffect( () => {
+		const quizHasQuestions = select( 'core/editor' ).getEditedPostAttribute(
+			'meta'
+		)?._quiz_has_questions; // eslint-disable-line camelcase
+
+		if ( questionBlocks.length ) {
+			dispatch( 'core/editor' ).editPost( {
+				meta: { _quiz_has_questions: 1 },
+			} );
+		} else if ( quizHasQuestions ) {
+			dispatch( 'core/editor' ).editPost( {
+				meta: { _quiz_has_questions: null },
+			} );
+		}
+	}, [ questionBlocks ] );
+
+	// Monitor for quiz block removal.
+	useEffect( () => {
+		return () => {
+			dispatch( 'core/editor' ).editPost( {
+				meta: { _quiz_has_questions: null },
+			} );
+		};
+	}, [] );
+};

--- a/assets/blocks/quiz/quiz-block/use-has-questions.js
+++ b/assets/blocks/quiz/quiz-block/use-has-questions.js
@@ -16,9 +16,8 @@ export const useHasQuestions = ( clientId ) => {
 
 	// Monitor for valid questions.
 	useEffect( () => {
-		const quizHasQuestions = select( 'core/editor' ).getEditedPostAttribute(
-			'meta'
-		)?._quiz_has_questions; // eslint-disable-line camelcase
+		const { _quiz_has_questions: quizHasQuestions } =
+			select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {};
 
 		if ( questionBlocks.length ) {
 			dispatch( 'core/editor' ).editPost( {

--- a/assets/blocks/quiz/quiz-block/use-has-questions.js
+++ b/assets/blocks/quiz/quiz-block/use-has-questions.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { useEffect } from '@wordpress/element';
-import { select, dispatch } from '@wordpress/data';
+import { dispatch, useSelect, select as selectData } from '@wordpress/data';
 
 /**
  * Monitor for questions and disable the lesson quiz when none have been added.
@@ -10,14 +10,16 @@ import { select, dispatch } from '@wordpress/data';
  * @param {string} clientId The quiz block client id.
  */
 export const useHasQuestions = ( clientId ) => {
-	const questionBlocks = select( 'core/block-editor' )
-		.getBlocks( clientId )
-		.filter( ( block ) => !! block.attributes.title );
+	const questionBlocks = useSelect( ( select ) =>
+		select( 'core/block-editor' )
+			.getBlocks( clientId )
+			.filter( ( block ) => !! block.attributes.title )
+	);
 
 	// Monitor for valid questions.
 	useEffect( () => {
 		const { _quiz_has_questions: quizHasQuestions } =
-			select( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {};
+			selectData( 'core/editor' ).getEditedPostAttribute( 'meta' ) || {};
 
 		if ( questionBlocks.length ) {
 			dispatch( 'core/editor' ).editPost( {

--- a/includes/rest-api/class-sensei-rest-api-lessons-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lessons-controller.php
@@ -19,6 +19,36 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_REST_API_Lessons_Controller extends WP_REST_Posts_Controller {
 	/**
+	 * Sensei_REST_API_Lessons_Controller constructor.
+	 *
+	 * @param string $post_type The post type.
+	 */
+	public function __construct( $post_type ) {
+		parent::__construct( $post_type );
+
+		register_post_meta(
+			'lesson',
+			'_quiz_has_questions',
+			[
+				'show_in_rest'      => true,
+				'single'            => true,
+				'type'              => 'boolean',
+				'sanitize_callback' => function( $value ) {
+					if ( null === $value ) {
+						return $value;
+					}
+
+					return $value ? 1 : null;
+				},
+				'auth_callback'     => function( $allowed, $meta_key, $post_id ) {
+					return current_user_can( 'edit_post', $post_id );
+				},
+			]
+		);
+
+	}
+
+	/**
 	 * Adds the quiz block if missing when a quiz is active on the lesson.
 	 *
 	 * @param array           $prepared Prepared response array.


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Deletes `_quiz_has_questions` lesson meta when quiz block is removed from frontend.
* Deletes `_quiz_has_questions` lesson meta when no questions have titles.
* Enables `_quiz_has_questions` lesson meta flag when valid question is added.

### Testing instructions

* Open an existing lesson with a quiz. Remove the quiz block and save. 
  * Notice the lesson's `_quiz_has_questions` post meta has been deleted. 
  * Visit the lesson on the frontend. Verify the quiz is not visible.
* Add back the quiz block and save.
  * Notice the lesson's `_quiz_has_questions` post meta has a value of `1`.
  * Visit the lesson on the frontend. Verify the quiz is visible and accessible.
* Remove the questions in the quiz block and save.
  * Notice the lesson's `_quiz_has_questions` post meta has been deleted. 
  * Visit the lesson on the frontend. Verify the quiz is not visible.