### PR TITLE
Migrate question media

### DIFF
--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -55,7 +55,8 @@ export function syncQuestionBlocks( structure, blocks ) {
 
 		const innerBlocks =
 			( description && rawHandler( { HTML: description } ) ) ||
-			block?.innerBlocks;
+			block?.innerBlocks ||
+			[];
 
 		if ( media ) {
 			innerBlocks.push( getMediaBlock( media ) );

--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -3,6 +3,7 @@
  */
 import { createBlock, getBlockContent, rawHandler } from '@wordpress/blocks';
 import { renderToString } from '@wordpress/element';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -60,8 +61,11 @@ export function syncQuestionBlocks( structure, blocks ) {
 				...block.attributes,
 				...attributes,
 			};
-			block.innerBlocks =
-				( description && rawHandler( { HTML: description } ) ) || [];
+
+			dispatch( 'core/block-editor' ).replaceInnerBlocks(
+				block.clientId,
+				( description && rawHandler( { HTML: description } ) ) || []
+			);
 		}
 
 		return block;

--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -21,7 +21,12 @@ import { camelCase, snakeCase, omit } from 'lodash';
 
 export const QUIZ_STORE = 'sensei/quiz-structure';
 
-const READ_ONLY_ATTRIBUTES = [ 'categories', 'shared', 'options.studentHelp' ];
+const READ_ONLY_ATTRIBUTES = [
+	'categories',
+	'shared',
+	'options.studentHelp',
+	'media',
+];
 
 /**
  * Syncronize this block with quiz data.

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -385,7 +385,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 
 			if ( ! empty( $mimetype_array[0] ) ) {
 				$question_media['type']  = $mimetype_array[0];
-				$question_media['url']   = wp_get_attachment_url( $question_media_id );
+				$question_media['url']   = esc_url( wp_get_attachment_url( $question_media_id ) );
 				$question_media['id']    = $attachment->ID;
 				$question_media['title'] = $attachment->post_title;
 			}

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -358,7 +358,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		];
 
 		if ( ! empty( $question_meta['_question_media'][0] ) ) {
-			$question_media = $this->get_question_media( (int) $question_meta['_question_media'][0] );
+			$question_media = $this->get_question_media( (int) $question_meta['_question_media'][0], $question->ID );
 
 			if ( ! empty( $question_media ) ) {
 				$common_properties['media'] = $question_media;
@@ -372,10 +372,11 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	 * Helper method to get question media.
 	 *
 	 * @param int $question_media_id The attachment id.
+	 * @param int $question_id       The question id.
 	 *
 	 * @return array Media info. It includes the type, id, url and title.
 	 */
-	private function get_question_media( int $question_media_id ) : array {
+	private function get_question_media( int $question_media_id, int $question_id ) : array {
 		$question_media = [];
 		$mimetype       = get_post_mime_type( $question_media_id );
 		$attachment     = get_post( $question_media_id );
@@ -384,8 +385,11 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			$mimetype_array = explode( '/', $mimetype );
 
 			if ( ! empty( $mimetype_array[0] ) ) {
+				// This filter is documented in class-sensei-question.php.
+				$image_size              = apply_filters( 'sensei_question_image_size', 'medium', $question_id );
 				$question_media['type']  = $mimetype_array[0];
-				$question_media['url']   = esc_url( wp_get_attachment_url( $question_media_id ) );
+				$attachment_src          = wp_get_attachment_image_src( $question_media_id, $image_size );
+				$question_media['url']   = esc_url( $attachment_src[0] );
 				$question_media['id']    = $attachment->ID;
 				$question_media['title'] = $attachment->post_title;
 			}

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -96,6 +96,8 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			$question['type'] = 'multiple-choice';
 		}
 
+		$is_new = null === $question_id;
+
 		$post_args = [
 			'ID'          => $question_id,
 			'post_title'  => $question['title'],
@@ -113,6 +115,10 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 
 		$result = wp_insert_post( $post_args );
 
+		if ( ! $is_new && ! is_wp_error( $result ) ) {
+			$this->migrate_non_editor_question( $result, $question['type'] );
+		}
+
 		/**
 		 * This action is triggered when a question is created or updated by the lesson quiz REST endpoint.
 		 *
@@ -126,6 +132,20 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		do_action( 'sensei_rest_api_question_saved', $result, $question['type'], $question );
 
 		return $result;
+	}
+
+	/**
+	 * Helper method to delete question meta that were deprecated by the block editor.
+	 *
+	 * @param int    $question_id   Question post id.
+	 * @param string $question_type Question type.
+	 */
+	private function migrate_non_editor_question( int $question_id, string $question_type ) {
+		delete_post_meta( $question_id, '_question_media' );
+
+		if ( 'file-upload' === $question_type ) {
+			delete_post_meta( $question_id, '_question_wrong_answers' );
+		}
 	}
 
 	/**
@@ -610,6 +630,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			],
 			'media'       => [
 				'type'       => 'object',
+				'readonly'   => true,
 				'properties' => [
 					'id'    => [
 						'type'        => 'integer',
@@ -789,7 +810,6 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 					'teacherNotes' => [
 						'type'        => [ 'string', 'null' ],
 						'description' => 'Teacher notes for grading',
-
 					],
 				],
 			],
@@ -852,6 +872,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 					'studentHelp'  => [
 						'type'        => [ 'string', 'null' ],
 						'description' => 'Description for student explaining what needs to be uploaded',
+						'readonly'    => true,
 					],
 				],
 			],

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -385,11 +385,16 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			$mimetype_array = explode( '/', $mimetype );
 
 			if ( ! empty( $mimetype_array[0] ) ) {
-				// This filter is documented in class-sensei-question.php.
-				$image_size              = apply_filters( 'sensei_question_image_size', 'medium', $question_id );
+				if ( 'image' === $mimetype_array[0] ) {
+					// This filter is documented in class-sensei-question.php.
+					$image_size            = apply_filters( 'sensei_question_image_size', 'medium', $question_id );
+					$attachment_src        = wp_get_attachment_image_src( $question_media_id, $image_size );
+					$question_media['url'] = esc_url( $attachment_src[0] );
+				} else {
+					$question_media['url'] = esc_url( wp_get_attachment_url( $question_media_id ) );
+				}
+
 				$question_media['type']  = $mimetype_array[0];
-				$attachment_src          = wp_get_attachment_image_src( $question_media_id, $image_size );
-				$question_media['url']   = esc_url( $attachment_src[0] );
 				$question_media['id']    = $attachment->ID;
 				$question_media['title'] = $attachment->post_title;
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Handles question media and student help question fields which are deprecated by the question editor.
* The fields are migrated to blocks when the question blocks are first created.
* Deprecated meta values are deleted on post save.
* We could append the blocks in the question description but then `rawHandler` would parse the question description as a block and include it in a classic editor block. Also due to block validation it seems like a fragile and hard to implement solution. We instead create the blocks using standard JS API.
* @donnapep this work will gradually remove question media. Should I remove them from tracking too?

### Testing instructions

* Disable the question editor by using:
`add_filter( 'sensei_quiz_enable_block_based_editor', '__return_false' );`
* Using the old question editor, create a bunch of questions with different types of media. Also create a file upload question with student notes.
* Have some of the questions belong to a quiz.
* Switch to the new editor and load the quiz.
* Observe that the according blocks are appended to the question description.
* Use the 'Add Existing questions' functionality to add the questions to a quiz and observe the generated blocks again.
* Save the quizzes and and reload them and observe that the blocks do not get added a second time.