### PR TITLE
Add editable flag to question REST API responses

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -313,6 +313,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			],
 			'type'        => Sensei()->question->get_question_type( $question->ID ),
 			'shared'      => ! empty( $question_meta['_quiz_id'] ) && count( $question_meta['_quiz_id'] ) > 1,
+			'editable'    => current_user_can( get_post_type_object( 'question' )->cap->edit_post, $question->ID ),
 			'categories'  => wp_get_post_terms( $question->ID, 'question-category', [ 'fields' => 'ids' ] ),
 		];
 	}
@@ -534,6 +535,11 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			'shared'      => [
 				'type'        => 'boolean',
 				'description' => 'Whether the question has been added on other quizzes',
+				'readonly'    => true,
+			],
+			'editable'    => [
+				'type'        => 'boolean',
+				'description' => 'Whether the question can be edited by the current user',
 				'readonly'    => true,
 			],
 			'categories'  => [

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
@@ -69,6 +69,52 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 	}
 
 	/**
+	 * Tests getting a quiz that has a question owned by current user.
+	 */
+	public function testGetCurrentTeachersQuestion() {
+		$this->login_as_teacher();
+
+		list( $lesson_id, $quiz_id ) = $this->create_lesson_with_quiz();
+
+		$this->factory->question->create(
+			[
+				'quiz_id'                              => $quiz_id,
+				'question_type'                        => 'single-line',
+				'add_question_right_answer_singleline' => 'NOTES',
+			]
+		);
+
+		$response_data = $this->send_get_request( $lesson_id );
+
+		$this->assertEquals( 'single-line', $response_data['questions'][0]['type'] );
+		$this->assertEquals( true, $response_data['questions'][0]['editable'] );
+	}
+
+	/**
+	 * Tests getting a quiz that has a question owned by another user.
+	 */
+	public function testGetAnotherTeachersQuestion() {
+		$this->login_as_teacher();
+
+		list( $lesson_id, $quiz_id ) = $this->create_lesson_with_quiz();
+
+		$this->login_as_teacher_b();
+		$this->factory->question->create(
+			[
+				'quiz_id'                              => $quiz_id,
+				'question_type'                        => 'single-line',
+				'add_question_right_answer_singleline' => 'NOTES',
+			]
+		);
+
+		$this->login_as_teacher();
+		$response_data = $this->send_get_request( $lesson_id );
+
+		$this->assertEquals( 'single-line', $response_data['questions'][0]['type'] );
+		$this->assertEquals( false, $response_data['questions'][0]['editable'] );
+	}
+
+	/**
 	 * Tests that a quiz is only accessed by admins and the teacher that created it.
 	 */
 	public function testGetAnotherTeachersCourse() {

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-questions-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-questions-controller.php
@@ -177,6 +177,7 @@ class Sensei_REST_API_Questions_Controller_Tests extends WP_Test_REST_TestCase {
 				'type'       => 'multiple-choice',
 				'id'         => $question_id,
 				'shared'     => false,
+				'editable'   => true,
 				'categories' => [],
 				'options'    => [
 					'grade'          => 2,


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds `editable` flag for all question related endpoint responses (`/sensei-internal/v1/lesson-quiz/{lesson_id}` and `/wp-json/sensei-internal/v1/question-options/{question_id}`, although the later will always return `true` because only editable questions are returned).

### Testing instructions

* As teacher A, create a lesson with a couple of questions.
* Change one question `post_author` to teacher B's ID.
* Request `GET /sensei-internal/v1/lesson-quiz/{lesson_id}` and make sure the `editable` flag is `true` for the question they author and `false` for the one they do not.
* Do the same request as an admin and verify both questions show up as editable.