### PR TITLE
Fix resetting the "Number of Questions" quiz setting

### DIFF
--- a/includes/data-port/models/class-sensei-import-lesson-model.php
+++ b/includes/data-port/models/class-sensei-import-lesson-model.php
@@ -152,7 +152,7 @@ class Sensei_Import_Lesson_Model extends Sensei_Import_Model {
 						'code' => 'sensei_data_port_lesson_num_questions_negative',
 					]
 				);
-				$value = null;
+				$value = '';
 			}
 			$meta['_show_questions'] = $value;
 		}

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -250,9 +250,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 		}
 
 		if ( array_key_exists( 'show_questions', $quiz_options ) ) {
-			$meta_input['_show_questions'] = $quiz_options['show_questions'];
-		} else {
-			$meta_input['_show_questions'] = '';
+			$meta_input['_show_questions'] = empty( $quiz_options['show_questions'] ) ? '' : $quiz_options['show_questions'];
 		}
 
 		if ( isset( $quiz_options['random_question_order'] ) ) {

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -251,6 +251,8 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 
 		if ( isset( $quiz_options['show_questions'] ) ) {
 			$meta_input['_show_questions'] = $quiz_options['show_questions'];
+		} else {
+			$meta_input['_show_questions'] = '';
 		}
 
 		if ( isset( $quiz_options['random_question_order'] ) ) {

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -249,7 +249,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 			$meta_input['_enable_quiz_reset'] = true === $quiz_options['allow_retakes'] ? 'on' : '';
 		}
 
-		if ( isset( $quiz_options['show_questions'] ) ) {
+		if ( array_key_exists( 'show_questions', $quiz_options ) ) {
 			$meta_input['_show_questions'] = $quiz_options['show_questions'];
 		} else {
 			$meta_input['_show_questions'] = '';


### PR DESCRIPTION
### Changes proposed in this Pull Request

When resetting the _Number of Questions_ quiz setting, it was reverting to the previous value because `$quiz_options['show_questions']` was set to `null` and so was never updated.

Now for the `null` case, `show_questions` is set to an empty string, which is what the old meta box did.

### Testing instructions

* Add multiple questions to a quiz block.
* Set _Number of Questions_ to a number and save.
* Click on _All_ to reset the field.
* Save and ensure the field is still empty.