### PR TITLE
REST API: Add lesson quiz question protection

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -69,18 +69,31 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	 * @return int|WP_Error Question id on success.
 	 */
 	private function save_question( $question ) {
+		$question_id = $question['id'] ?? null;
+
+		if (
+			$question_id
+			&& (
+				'question' !== get_post_type( $question_id )
+				|| ! current_user_can( get_post_type_object( 'course' )->cap->edit_post, $question_id )
+			)
+		) {
+			return new WP_Error( 'sensei_lesson_quiz_question_not_available', '', $question_id );
+		}
+
 		if ( empty( $question['title'] ) ) {
 			return new WP_Error(
 				'sensei_lesson_quiz_question_missing_title',
 				__( 'Please ensure all questions have a title before saving.', 'sensei-lms' )
 			);
 		}
+
 		if ( ! isset( $question['options'] ) ) {
 			$question['options'] = [];
 		}
 
 		$post_args = [
-			'ID'          => isset( $question['id'] ) ? $question['id'] : null,
+			'ID'          => $question_id,
 			'post_title'  => $question['title'],
 			'post_status' => 'publish',
 			'post_type'   => 'question',


### PR DESCRIPTION
### Changes proposed in this Pull Request

* For our new REST API endpoint, prevent teachers from adding other people's questions and editing questions that they are not the author of.

### Testing instructions

* I was manually modifying the `post_author` for questions already on a teacher's quiz and then saving. 