### PR TITLE
Fix question type select in existing question modal for teachers

### DIFF
--- a/assets/blocks/quiz/quiz-block/questions-modal/filter.js
+++ b/assets/blocks/quiz/quiz-block/questions-modal/filter.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
 import { SelectControl } from '@wordpress/components';
 import { search } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
@@ -12,6 +11,7 @@ import { useState } from '@wordpress/element';
  */
 import InputControl from '../../../editor-components/input-control';
 import questionTypesConfig from '../../answer-blocks';
+import { useQuestionTypes } from '../use-question-types';
 
 /**
  * External dependencies
@@ -29,11 +29,7 @@ import { debounce } from 'lodash';
 const Filter = ( { questionCategories, filters, setFilters } ) => {
 	const { searchValue } = useState( filters.search );
 
-	const questionTypes = useSelect( ( select ) =>
-		select( 'core' ).getEntityRecords( 'taxonomy', 'question-type', {
-			per_page: -1,
-		} )
-	);
+	const questionTypes = useQuestionTypes();
 
 	const createFilterChangeHandler = ( filterKey, wait ) =>
 		debounce( ( value ) => {

--- a/assets/blocks/quiz/quiz-block/use-question-types.js
+++ b/assets/blocks/quiz/quiz-block/use-question-types.js
@@ -1,0 +1,24 @@
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from '@wordpress/element';
+
+/**
+ * Get the question types.
+ *
+ * @return {Object[]} Term objects.
+ */
+export const useQuestionTypes = () => {
+	const [ questionTypes, setQuestionTypes ] = useState( [] );
+
+	useEffect( () => {
+		const request = apiFetch( {
+			path: '/wp/v2/question-type?per_page=-1',
+		} );
+
+		request.then( setQuestionTypes );
+	}, [ setQuestionTypes ] );
+
+	return questionTypes;
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request

* `getEntityRecords`'s resolver will automatically use `context=edit` when pulling terms. Teachers are not allowed to edit question type terms, so this request was failing. 
* Changes to pull question types directly.

### Testing instructions

* As teacher, edit a lesson and click `Add Existing Questions`.
* Verify the Question Type dropdown filter is populated.
