### PR TITLE
Unescape question category term names in existing question modal

### DIFF
--- a/assets/blocks/quiz/quiz-block/questions-modal/index.js
+++ b/assets/blocks/quiz/quiz-block/questions-modal/index.js
@@ -14,6 +14,11 @@ import Questions from './questions';
 import Actions from './actions';
 
 /**
+ * External dependencies
+ */
+import { unescape } from 'lodash';
+
+/**
  * Questions modal content.
  *
  * @param {Object}   props
@@ -30,11 +35,24 @@ const QuestionsModalContent = ( { setOpen, addExistingQuestions } ) => {
 	const [ errorAddingSelected, setErrorAddingSelected ] = useState( false );
 	const [ selectedQuestionIds, setSelectedQuestionIds ] = useState( [] );
 
-	const questionCategories = useSelect( ( select ) =>
-		select( 'core' ).getEntityRecords( 'taxonomy', 'question-category', {
-			per_page: -1,
-		} )
-	);
+	const questionCategories = useSelect( ( select ) => {
+		const terms = select( 'core' ).getEntityRecords(
+			'taxonomy',
+			'question-category',
+			{
+				per_page: -1,
+			}
+		);
+
+		if ( terms && terms.length ) {
+			return terms.map( ( term ) => ( {
+				...term,
+				name: unescape( term.name ),
+			} ) );
+		}
+
+		return terms;
+	} );
 
 	return (
 		<Modal


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Unescapes term name on existing questions modal.

### Testing instructions

* Create a question category with encoded characters (like an `&`) and assign it to a question.
* Edit a lesson and click `Add Existing Question`.
* Ensure the category name displays correctly (and not `&amp;`) in both the filter select and the table.

### Screenshot
(Bug)

<img width="702" alt="Screen Shot 2021-03-05 at 11 02 25 am" src="https://user-images.githubusercontent.com/68693/110113261-c7818a80-7daa-11eb-870a-65ff8de52e7b.png">
