### PR TITLE
Disable block based question editor when question category is used in quizzes

### DIFF
--- a/includes/admin/class-sensei-status.php
+++ b/includes/admin/class-sensei-status.php
@@ -67,10 +67,41 @@ class Sensei_Status {
 		$section['fields']['template_overrides']     = $this->get_template_overrides_info();
 		$section['fields']['is_calculation_pending'] = $this->get_is_calculation_pending_info();
 		$section['fields']['legacy_enrolment']       = $this->get_legacy_enrolment_info();
+		$section['fields']['legacy_flags']           = $this->get_legacy_flags_info();
 
 		$info['sensei-lms'] = $section;
 
 		return $info;
+	}
+
+	/**
+	 * Adds information on which legacy update flags have been set in Sensei.
+	 *
+	 * @return array
+	 */
+	private function get_legacy_flags_info() {
+		$legacy_flags       = Sensei()->get_legacy_flags();
+		$legacy_flags_human = [];
+
+		if ( ! empty( $legacy_flags[ Sensei_Main::LEGACY_FLAG_WITH_FRONT ] ) ) {
+			$legacy_flags_human[] = esc_html__( 'Permalink structure for CPTs will be prepended with site/post slug prefix', 'sensei-lms' );
+		}
+
+		if ( ! empty( $legacy_flags[ Sensei_Main::LEGACY_FLAG_MULTIPLE_QUESTIONS_EXIST ] ) ) {
+			$legacy_flags_human[] = esc_html__( 'Quizzes were detected using the `Multiple Questions` (Category) feature, which is currently not supported in the block based quiz editor', 'sensei-lms' );
+		}
+
+		if ( empty( $legacy_flags_human ) ) {
+			$value_legacy_flags = esc_html__( 'No legacy update flags have been set', 'sensei-lms' );
+		} else {
+			$value_legacy_flags = implode( '; ', $legacy_flags_human );
+		}
+
+		return [
+			'label' => __( 'Legacy update flags', 'sensei-lms' ),
+			'value' => $value_legacy_flags,
+			'debug' => wp_json_encode( $legacy_flags ),
+		];
 	}
 
 	/**

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -61,6 +61,12 @@ class Sensei_Quiz {
 		// If custom question types have been registered, disable the block based quiz editor for now.
 		$is_block_based_editor_enabled = ! has_filter( 'sensei_question_types' );
 
+		// If quizzes were using the multiple_questions CPT on update, disable the block based
+		// editor until support is added.
+		if ( Sensei()->get_legacy_flag( Sensei_Main::LEGACY_FLAG_MULTIPLE_QUESTIONS_EXIST ) ) {
+			$is_block_based_editor_enabled = false;
+		}
+
 		/**
 		 * Filter to change whether the block based editor should be used instead of the legacy
 		 * metabox based editor. This is to allow sites to migrate over to the block based

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -75,9 +75,28 @@ class Sensei_Updates {
 		$this->v3_7_check_rewrite_front();
 		$this->v3_7_add_comment_indexes();
 		$this->v3_9_fix_question_author();
+		$this->v3_9_add_multiple_questions_flag();
 
 		// Flush rewrite cache.
 		Sensei()->initiate_rewrite_rules_flush();
+	}
+
+	/**
+	 * Adds a flag to check if the `multiple_questions` CPT is on active quizzes upon upgrade.
+	 *
+	 * This will help with preventing the question block editor from being used until support for these are added.
+	 *
+	 * @since 3.9.0
+	 */
+	private function v3_9_add_multiple_questions_flag() {
+		// Only run this if we're upgrading and the current version (before upgrade) is less than 3.9.0.
+		if ( ! $this->is_upgrade || version_compare( $this->current_version, '3.9.0', '>=' ) ) {
+			return;
+		}
+
+		if ( $this->has_multiple_questions() ) {
+			Sensei()->set_legacy_flag( Sensei_Main::LEGACY_FLAG_MULTIPLE_QUESTIONS_EXIST, true );
+		}
 	}
 
 	/**
@@ -233,6 +252,55 @@ class Sensei_Updates {
 		$activity_sample = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
 
 		return ! empty( $activity_sample );
+	}
+
+	/**
+	 * Check if the `multiple_questions` CPT is in use on any quiz.
+	 *
+	 * Note: These are left behind unused when removed from a quiz or a quiz is deleted so we need to only include ones
+	 * on quizzes that are still around in some form.
+	 *
+	 * @return bool
+	 */
+	private function has_multiple_questions() {
+		$multiple_question_query = new WP_Query(
+			[
+				'post_type'        => 'multiple_question',
+				'fields'           => 'ids',
+				'no_found_rows'    => true,
+				'suppress_filters' => 1,
+				'posts_per_page'   => 1,
+				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Used once on update.
+				'meta_query'       => [
+					[
+						'key'   => '_quiz_id',
+						'value' => $this->get_quiz_ids(),
+					],
+				],
+			]
+		);
+
+		return count( $multiple_question_query->posts );
+	}
+
+	/**
+	 * Get an array of quiz post IDs.
+	 *
+	 * @return int[]
+	 */
+	private function get_quiz_ids() {
+		$query = new WP_Query(
+			[
+				'post_type'        => 'quiz',
+				'fields'           => 'ids',
+				'post_status'      => [ 'draft', 'publish' ],
+				'posts_per_page'   => -1,
+				'no_found_rows'    => true,
+				'suppress_filters' => 1,
+			]
+		);
+
+		return array_map( 'intval', $query->posts );
 	}
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -657,7 +657,7 @@ class Sensei_Main {
 	 * @param bool   $value Boolean value to set.
 	 */
 	public function set_legacy_flag( $flag, $value ) {
-		$legacy_flags          = json_decode( get_option( self::LEGACY_FLAG_OPTION, '{}' ), true );
+		$legacy_flags          = $this->get_legacy_flags();
 		$legacy_flags[ $flag ] = (bool) $value;
 
 		update_option( self::LEGACY_FLAG_OPTION, wp_json_encode( $legacy_flags ) );
@@ -672,13 +672,22 @@ class Sensei_Main {
 	 * @return bool
 	 */
 	public function get_legacy_flag( $flag, $default = false ) {
-		$legacy_flags = json_decode( get_option( self::LEGACY_FLAG_OPTION, '{}' ), true );
+		$legacy_flags = $this->get_legacy_flags();
 
 		if ( isset( $legacy_flags[ $flag ] ) ) {
 			return (bool) $legacy_flags[ $flag ];
 		}
 
 		return (bool) $default;
+	}
+
+	/**
+	 * Get the legacy flags that have been set.
+	 *
+	 * @return array
+	 */
+	public function get_legacy_flags() {
+		return json_decode( get_option( self::LEGACY_FLAG_OPTION, '{}' ), true );
 	}
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -11,9 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.0.0
  */
 class Sensei_Main {
-	const COMMENT_COUNT_TRANSIENT_PREFIX = 'sensei_comment_counts_';
-	const LEGACY_FLAG_OPTION             = 'sensei-legacy-flags';
-	const LEGACY_FLAG_WITH_FRONT         = 'with_front';
+	const COMMENT_COUNT_TRANSIENT_PREFIX       = 'sensei_comment_counts_';
+	const LEGACY_FLAG_OPTION                   = 'sensei-legacy-flags';
+	const LEGACY_FLAG_WITH_FRONT               = 'with_front';
+	const LEGACY_FLAG_MULTIPLE_QUESTIONS_EXIST = 'multiple_questions';
 
 	/**
 	 * @var string


### PR DESCRIPTION
### Changes proposed in this Pull Request

* We currently don't support question categories in a non-breaking way. Until we add support for using the `multiple_question` CPT/category based questions into the block editor, this will disable the block based question/quiz editor when these are found to be in-use on update.

### Testing instructions

From `version/3.8.0` tag...
* Create multiple questions and assign them to a category.
* Create a lesson with a quiz and add a Category Question using the category from above.
* Save.
* Ensure your `sensei-version` option is set to `3.8.0` or `3.8.1` (not `3.9.0-dev`).

Switch to this branch...
* Load any page. 
* Edit the quiz and questions and verify the original metabox editor is used and not the block based editor.
