### PR TITLE
Fix metabox individual question editor

### DIFF
--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -417,11 +417,15 @@ class Sensei_PostTypes {
 			'has_archive'           => true,
 			'hierarchical'          => false,
 			'menu_position'         => 51,
-			'supports'              => array( 'title', 'revisions', 'editor' ),
+			'supports'              => array( 'title', 'revisions' ),
 			'show_in_rest'          => true,
 			'rest_base'             => 'questions',
 			'rest_controller_class' => 'Sensei_REST_API_Questions_Controller',
 		);
+
+		if ( Sensei()->quiz->is_block_based_editor_enabled() ) {
+			$args['supports'][] = 'editor';
+		}
 
 		/**
 		 * Filter the arguments passed in when registering the Sensei Question post type.


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Only add the `editor` supports when the block based editor is enabled.

### Testing instructions

* Disable the block based editor. `add_filter( 'sensei_quiz_enable_block_based_editor', '__return_false' );`
* Go to the individual question editor.
* Verify the metabox loads correctly and the block editor does not.
