### PR TITLE
Log legacy flags in system usage tracking

### DIFF
--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -243,6 +243,11 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 		$system_data['wcpc_version']          = defined( 'SENSEI_WC_PAID_COURSES_VERSION' ) ? SENSEI_WC_PAID_COURSES_VERSION : null;
 		$system_data['is_legacy_quiz_editor'] = Sensei()->quiz->is_block_based_editor_enabled() ? 0 : 1;
 
+		$legacy_flags = Sensei()->get_legacy_flags();
+		foreach ( $legacy_flags as $flag => $value ) {
+			$system_data[ 'legacy_flag_' . sanitize_key( $flag ) ] = $value ? 1 : 0;
+		}
+
 		return array_merge( $system_data, parent::get_system_data() );
 	}
 }

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -654,7 +654,7 @@ class Sensei_Main {
 	 * @param bool   $value Boolean value to set.
 	 */
 	public function set_legacy_flag( $flag, $value ) {
-		$legacy_flags          = json_decode( get_option( self::LEGACY_FLAG_OPTION, '{}' ), true );
+		$legacy_flags          = $this->get_legacy_flags();
 		$legacy_flags[ $flag ] = (bool) $value;
 
 		update_option( self::LEGACY_FLAG_OPTION, wp_json_encode( $legacy_flags ) );
@@ -669,13 +669,22 @@ class Sensei_Main {
 	 * @return bool
 	 */
 	public function get_legacy_flag( $flag, $default = false ) {
-		$legacy_flags = json_decode( get_option( self::LEGACY_FLAG_OPTION, '{}' ), true );
+		$legacy_flags = $this->get_legacy_flags();
 
 		if ( isset( $legacy_flags[ $flag ] ) ) {
 			return (bool) $legacy_flags[ $flag ];
 		}
 
 		return (bool) $default;
+	}
+
+	/**
+	 * Get the legacy flags that have been set.
+	 *
+	 * @return array
+	 */
+	public function get_legacy_flags() {
+		return json_decode( get_option( self::LEGACY_FLAG_OPTION, '{}' ), true );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-usage-tracking.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking.php
@@ -22,6 +22,22 @@ class Sensei_Usage_Tracking_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests to ensure legacy flags are reported in usage tracking.
+	 */
+	public function testLegacyFlagsReported() {
+		$usage_tracking = Sensei_Usage_Tracking::get_instance();
+		$test_key       = 'legacy_flag_with_front';
+
+		$this->assertArrayNotHasKey( $test_key, $usage_tracking->get_system_data() );
+
+		Sensei()->set_legacy_flag( Sensei_Main::LEGACY_FLAG_WITH_FRONT, true );
+
+		$data = $usage_tracking->get_system_data();
+		$this->assertArrayHasKey( $test_key, $data );
+		$this->assertEquals( 1, $data[ $test_key ] );
+	}
+
+	/**
 	 * Tests that WCCOM extensions are logged as sensei_plugin_install when activated.
 	 *
 	 * @covers Sensei_Usage_Tracking::log_wccom_plugin_install


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Includes the set legacy flags in system usage tracking reports. For now, this will be `with_front` and after #4054 `multiple_questions` (for when these were used on update).