### PR TITLE
Log `sensei_plugin_update` event on plugin update

### DIFF
--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -328,7 +328,6 @@ class Sensei_Updates {
 	 * Get the days since release.
 	 *
 	 * @return int|null
-	 * @throws Exception
 	 */
 	private function get_days_since_release() {
 		$releases = $this->get_changelog_release_dates();
@@ -358,7 +357,7 @@ class Sensei_Updates {
 		$releases = [];
 		preg_match_all( "/((?'year'\d{4})[\-\.](?'month'\d{1,2})[\-\.](?'day'\d{1,2}).*version\s+(?'version'[\d\.\-a-z]+))/", $changelog, $releases_raw, PREG_SET_ORDER );
 
-		foreach( $releases_raw as $release ) {
+		foreach ( $releases_raw as $release ) {
 			if ( empty( $release['version'] ) || empty( $release['year'] ) || empty( $release['month'] ) || empty( $release['day'] ) ) {
 				continue;
 			}
@@ -380,6 +379,7 @@ class Sensei_Updates {
 			return false;
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local file usage.
 		return file_get_contents( $changelog_path );
 	}
 

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -330,7 +330,7 @@ class Sensei_Updates {
 	 * @return int|null
 	 */
 	private function get_days_since_release() {
-		$releases = $this->get_changelog_release_dates();
+		$releases = $this->get_changelog_release_dates( Sensei()->version );
 
 		if ( ! isset( $releases[ Sensei()->version ] ) ) {
 			return null;
@@ -346,16 +346,23 @@ class Sensei_Updates {
 	/**
 	 * Get the release dates from the changelog.
 	 *
+	 * @param string $version Filter to just include a single version (Optional).
+	 *
 	 * @return DateTimeImmutable[]
 	 */
-	private function get_changelog_release_dates() {
+	private function get_changelog_release_dates( $version = null ) {
+		$releases  = [];
 		$changelog = $this->get_changelog();
 		if ( ! $changelog ) {
-			return [];
+			return $releases;
 		}
 
-		$releases = [];
-		preg_match_all( "/((?'year'\d{4})[\-\.](?'month'\d{1,2})[\-\.](?'day'\d{1,2}).*version\s+(?'version'[\d\.\-a-z]+))/", $changelog, $releases_raw, PREG_SET_ORDER );
+		$version_match = '[\d\.\-a-z]+';
+		if ( $version ) {
+			$version_match = preg_quote( $version, '/' );
+		}
+
+		preg_match_all( "/((?'year'\d{4})[\-\.](?'month'\d{1,2})[\-\.](?'day'\d{1,2}).*version\s+(?'version'{$version_match}))[^\S]/", $changelog, $releases_raw, PREG_SET_ORDER );
 
 		foreach ( $releases_raw as $release ) {
 			if ( empty( $release['version'] ) || empty( $release['year'] ) || empty( $release['month'] ) || empty( $release['day'] ) ) {

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -311,12 +311,15 @@ class Sensei_Updates {
 	 * Logs the system update.
 	 */
 	private function log_update() {
-		sensei_log_event(
-			'update',
+		wp_schedule_single_event(
+			time(),
+			'sensei_log_update',
 			[
-				'from_version'       => $this->current_version,
-				'to_version'         => Sensei()->version,
-				'days_since_release' => $this->get_days_since_release(),
+				[
+					'from_version'       => $this->current_version,
+					'to_version'         => Sensei()->version,
+					'days_since_release' => $this->get_days_since_release(),
+				],
 			]
 		);
 	}

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -71,6 +71,10 @@ class Sensei_Updates {
 			return;
 		}
 
+		if ( $this->is_upgrade ) {
+			$this->log_update();
+		}
+
 		$this->v3_0_check_legacy_enrolment();
 		$this->v3_7_check_rewrite_front();
 		$this->v3_7_add_comment_indexes();
@@ -301,6 +305,79 @@ class Sensei_Updates {
 		);
 
 		return array_map( 'intval', $query->posts );
+	}
+
+	/**
+	 * Logs the system update.
+	 */
+	private function log_update() {
+		sensei_log_event(
+			'update',
+			[
+				'from_version'       => $this->current_version,
+				'to_version'         => Sensei()->version,
+				'days_since_release' => $this->get_days_since_release(),
+			]
+		);
+	}
+
+	/**
+	 * Get the days since release.
+	 *
+	 * @return int|null
+	 * @throws Exception
+	 */
+	private function get_days_since_release() {
+		$releases = $this->get_changelog_release_dates();
+
+		if ( ! isset( $releases[ Sensei()->version ] ) ) {
+			return null;
+		}
+
+		$today = ( new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) ) )->setTime( 0, 0, 0 );
+		$diff  = $releases[ Sensei()->version ]->diff( $today );
+		$days  = false !== $diff->d ? (int) $diff->d : null;
+
+		return $days;
+	}
+
+	/**
+	 * Get the release dates from the changelog.
+	 *
+	 * @return DateTimeImmutable[]
+	 */
+	private function get_changelog_release_dates() {
+		$changelog = $this->get_changelog();
+		if ( ! $changelog ) {
+			return [];
+		}
+
+		$releases = [];
+		preg_match_all( "/((?'year'\d{4})[\-\.](?'month'\d{1,2})[\-\.](?'day'\d{1,2}).*version\s+(?'version'[\d\.\-a-z]+))/", $changelog, $releases_raw, PREG_SET_ORDER );
+
+		foreach( $releases_raw as $release ) {
+			if ( empty( $release['version'] ) || empty( $release['year'] ) || empty( $release['month'] ) || empty( $release['day'] ) ) {
+				continue;
+			}
+
+			$releases[ $release['version'] ] = DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', sprintf( '%04d-%02d-%02d 00:00:00', $release['year'], $release['month'], $release['day'] ), new DateTimeZone( 'UTC' ) );
+		}
+
+		return $releases;
+	}
+
+	/**
+	 * Get the changelog contents.
+	 *
+	 * @return false|string
+	 */
+	protected function get_changelog() {
+		$changelog_path = dirname( __DIR__ ) . DIRECTORY_SEPARATOR . 'changelog.txt';
+		if ( ! is_readable( $changelog_path ) ) {
+			return false;
+		}
+
+		return file_get_contents( $changelog_path );
 	}
 
 	/**

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -133,7 +133,7 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	 */
 	public function log_update( $args ) {
 		sensei_log_event(
-			'updated',
+			'plugin_update',
 			$args
 		);
 	}

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -138,6 +138,13 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 		);
 	}
 
+	/**
+	 * Add setting field.
+	 *
+	 * @param array $fields Setting fields.
+	 *
+	 * @return array
+	 */
 	public function add_setting_field( $fields ) {
 		$fields[ self::SENSEI_SETTING_NAME ] = array(
 			'name'        => __( 'Enable usage tracking', 'sensei-lms' ),

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -133,7 +133,7 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	 */
 	public function log_update( $args ) {
 		sensei_log_event(
-			'update',
+			'updated',
 			$args
 		);
 	}

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -29,6 +29,9 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 
 		// Filters for for events to watch and report.
 		add_action( 'activated_plugin', [ $this, 'log_wccom_plugin_install' ] );
+
+		// Log when Sensei is updated.
+		add_action( 'sensei_log_update', [ $this, 'log_update' ] );
 	}
 
 	/*
@@ -119,6 +122,21 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	/*
 	 * Hooks.
 	 */
+
+	/**
+	 * Log an update event.
+	 *
+	 * @since 3.9.0
+	 * @access internal
+	 *
+	 * @param array $args Deferred event parameters.
+	 */
+	public function log_update( $args ) {
+		sensei_log_event(
+			'update',
+			$args
+		);
+	}
 
 	public function add_setting_field( $fields ) {
 		$fields[ self::SENSEI_SETTING_NAME ] = array(

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -103,6 +103,7 @@ class Sensei_Unit_Tests_Bootstrap {
 	 */
 	public function includes() {
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-test-login-helpers.php';
+		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-wp-cron-helpers.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-rest-api-test-helpers.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
 		require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-manual-test-helpers.php';

--- a/tests/framework/trait-sensei-wp-cron-helpers.php
+++ b/tests/framework/trait-sensei-wp-cron-helpers.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * File with trait Sensei_WP_Cron_Helpers.
+ *
+ * @package sensei-tests
+ */
+
+// phpcs:disable WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Using PHPUnit conventions.
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Helpers for simulating WP Cron.
+ *
+ * @since 3.9.0
+ */
+trait Sensei_WP_Cron_Helpers {
+	/**
+	 * Run all scheduled instances of an event.
+	 *
+	 * @param string $event Event that should run.
+	 */
+	private function runAllScheduledEvents( $event ) {
+		$cron = _get_cron_array();
+		foreach ( $cron as $time => $events ) {
+			if ( isset( $events[ $event ] ) ) {
+				foreach ( $events[ $event ] as $config ) {
+					// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.DynamicHooknameFound -- Special test helper.
+					do_action_ref_array( $event, $config['args'] );
+				}
+			}
+		}
+	}
+}

--- a/tests/unit-tests/test-class-sensei-updates.php
+++ b/tests/unit-tests/test-class-sensei-updates.php
@@ -160,7 +160,7 @@ class Sensei_Updates_Test extends WP_UnitTestCase {
 		$updates->run_updates();
 		$this->runAllScheduledEvents( 'sensei_log_update' );
 
-		$events = Sensei_Test_Events::get_logged_events( 'sensei_update' );
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_updated' );
 
 		$this->assertTrue( isset( $events[0]['url_args']['days_since_release'] ) );
 		$this->assertEquals( '0', $events[0]['url_args']['days_since_release'] );
@@ -179,7 +179,7 @@ class Sensei_Updates_Test extends WP_UnitTestCase {
 		$updates->run_updates();
 		$this->runAllScheduledEvents( 'sensei_log_update' );
 
-		$events = Sensei_Test_Events::get_logged_events( 'sensei_update' );
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_updated' );
 
 		$this->assertTrue( isset( $events[0]['url_args']['days_since_release'] ) );
 		$this->assertEquals( '1', $events[0]['url_args']['days_since_release'] );

--- a/tests/unit-tests/test-class-sensei-updates.php
+++ b/tests/unit-tests/test-class-sensei-updates.php
@@ -12,6 +12,7 @@
  */
 class Sensei_Updates_Test extends WP_UnitTestCase {
 	use Sensei_Scheduler_Test_Helpers;
+	use Sensei_WP_Cron_Helpers;
 
 	/**
 	 * Sensei factory.
@@ -157,6 +158,7 @@ class Sensei_Updates_Test extends WP_UnitTestCase {
 		Sensei()->version = '3.9.0';
 		$updates          = $this->getUpdateMockWithChangelog( [ '3.7.0', false, true ], $this->getChangelog( '3.9.0', $today ) );
 		$updates->run_updates();
+		$this->runAllScheduledEvents( 'sensei_log_update' );
 
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_update' );
 
@@ -175,6 +177,7 @@ class Sensei_Updates_Test extends WP_UnitTestCase {
 		Sensei()->version = '3.9.0';
 		$updates          = $this->getUpdateMockWithChangelog( [ '3.7.0', false, true ], $this->getChangelog( '3.9.0', $yesterday ) );
 		$updates->run_updates();
+		$this->runAllScheduledEvents( 'sensei_log_update' );
 
 		$events = Sensei_Test_Events::get_logged_events( 'sensei_update' );
 

--- a/tests/unit-tests/test-class-sensei-updates.php
+++ b/tests/unit-tests/test-class-sensei-updates.php
@@ -26,6 +26,7 @@ class Sensei_Updates_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
+		Sensei_Test_Events::reset();
 		Sensei_Scheduler_Shim::reset();
 		self::restoreShimScheduler();
 
@@ -126,6 +127,110 @@ class Sensei_Updates_Test extends WP_UnitTestCase {
 		$job            = new Sensei_Update_Fix_Question_Author();
 		$next_scheduled = Sensei_Scheduler_Shim::get_next_scheduled( $job );
 		$this->assertFalse( $next_scheduled );
+	}
+
+	/**
+	 * Test to make sure changelog parser generally works.
+	 */
+	public function testChangelogParser() {
+		$updates = new Sensei_Updates( '3.9.0', false, true );
+
+		$method = new ReflectionMethod( $updates, 'get_changelog_release_dates' );
+		$method->setAccessible( true );
+
+		$releases = $method->invoke( $updates );
+
+		// Spot check a few releases.
+		$this->assertArrayHasKey( '3.8.0', $releases );
+		$this->assertEquals( '2021-02-09', $releases['3.8.0']->format( 'Y-m-d' ) );
+
+		$this->assertArrayHasKey( '2.0.0', $releases );
+		$this->assertEquals( '2019-04-02', $releases['2.0.0']->format( 'Y-m-d' ) );
+	}
+
+	/**
+	 * Test that it fires an update event with `days_since_release` set to 0 when today.
+	 */
+	public function testDaysSinceReleaseToday() {
+		$today = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+
+		Sensei()->version = '3.9.0';
+		$updates          = $this->getUpdateMockWithChangelog( [ '3.7.0', false, true ], $this->getChangelog( '3.9.0', $today ) );
+		$updates->run_updates();
+
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_update' );
+
+		$this->assertTrue( isset( $events[0]['url_args']['days_since_release'] ) );
+		$this->assertEquals( '0', $events[0]['url_args']['days_since_release'] );
+		$this->assertEquals( '3.7.0', $events[0]['url_args']['from_version'] );
+		$this->assertEquals( Sensei()->version, $events[0]['url_args']['to_version'] );
+	}
+
+	/**
+	 * Test that it fires an update event with `days_since_release` set to 1 when yesterday.
+	 */
+	public function testDaysSinceReleaseYesterday() {
+		$yesterday = new DateTimeImmutable( 'yesterday', new DateTimeZone( 'UTC' ) );
+
+		Sensei()->version = '3.9.0';
+		$updates          = $this->getUpdateMockWithChangelog( [ '3.7.0', false, true ], $this->getChangelog( '3.9.0', $yesterday ) );
+		$updates->run_updates();
+
+		$events = Sensei_Test_Events::get_logged_events( 'sensei_update' );
+
+		$this->assertTrue( isset( $events[0]['url_args']['days_since_release'] ) );
+		$this->assertEquals( '1', $events[0]['url_args']['days_since_release'] );
+		$this->assertEquals( '3.7.0', $events[0]['url_args']['from_version'] );
+		$this->assertEquals( Sensei()->version, $events[0]['url_args']['to_version'] );
+	}
+
+	/**
+	 * Get mock to override changelog.
+	 *
+	 * @param array  $construtor_args Arguments for constructor.
+	 * @param string $changelog      Changelog content.
+	 *
+	 * @return \PHPUnit\Framework\MockObject\MockObject|Sensei_Updates
+	 */
+	private function getUpdateMockWithChangelog( $construtor_args, $changelog ) {
+		$mock = $this->getMockBuilder( Sensei_Updates::class )
+					->setMethods( [ 'get_changelog' ] )
+					->setConstructorArgs( $construtor_args )
+					->getMock();
+
+		$mock->expects( $this->any() )
+			->method( 'get_changelog' )
+			->willReturn( $changelog );
+
+		return $mock;
+	}
+
+	/**
+	 * Get mocked changelog.
+	 *
+	 * @param string            $latest_version      Latest version string.
+	 * @param DateTimeImmutable $latest_version_date Latest version date.
+	 *
+	 * @return string
+	 */
+	private function getChangelog( string $latest_version, DateTimeImmutable $latest_version_date ) {
+		$date_str = $latest_version_date->format( 'Y-m-d' );
+
+		return <<<END
+{$date_str} - version {$latest_version}
+* Fix: Fix something broken.
+* Change: Changed something to be better.
+
+2021.03.07 - version 3.8.1
+* Fix: Fix something [#1](https://github.com/Automattic/sensei/pull/1)
+* Fix: Fix something [#2](https://github.com/Automattic/sensei/pull/2)
+* Fix: Fix something [#3](https://github.com/Automattic/sensei/pull/3)
+* Fix: Fix something [#4](https://github.com/Automattic/sensei/pull/4) 👏 helper
+
+2021.03.01 - version 3.8.0
+* Fix: Fix something [#5](https://github.com/Automattic/sensei/pull/5)
+* Fix: Fix something [#6](https://github.com/Automattic/sensei/pull/6)
+END;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Logs the event `sensei_plugin_update` on plugin update.
* Parameters:
  * `from_version`: Version we're updating from.
  * `to_version`: Version that was just installed.
  * `days_since_release`: Days since the installed version was released (based on changelog). 
* Later on, it would be nice to add a flag to determine if this is from an auto-update, but it would be a bit more difficult so I thought we can add that in v2 of this event.

### Testing instructions

In order to test, you'll need to change this line in `sensei-lms.php`:
```
return Sensei_Main::instance( array( 'version' => '3.9.0-dev' ) );
```
 
to 
```
return Sensei_Main::instance( array( 'version' => '3.8.1' ) );
```

and then update your `sensei-version` option to be `3.8.0` (or something earlier).

Then load one screen in WordPress and monitor for the `sensei_plugin_update` event with the correct parameters (it is scheduled with WP cron so might take a second page load).