### PR TITLE
Remove abandoned `multiple_question` posts

### DIFF
--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -162,6 +162,7 @@ class Sensei_Autoloader {
 			 * Update tasks.
 			 */
 			'Sensei_Update_Fix_Question_Author'          => 'update-tasks/class-sensei-update-fix-question-author.php',
+			'Sensei_Update_Remove_Abandoned_Multiple_Question' => 'update-tasks/class-sensei-update-remove-abandoned-multiple-question.php',
 
 			/**
 			 * Unsupported theme handlers.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2577,16 +2577,27 @@ class Sensei_Lesson {
 		$question_id_to_remove      = $question_data['question_id'];
 		$quiz_id_to_be_removed_from = $question_data['quiz_id'];
 
-		// remove the question from the lesson quiz
-		$quizzes = get_post_meta( $question_id_to_remove, '_quiz_id', false );
-		foreach ( $quizzes as $quiz_id ) {
-			if ( $quiz_id == $quiz_id_to_be_removed_from ) {
+		if ( 'multiple_question' !== get_post_type( $question_id_to_remove ) ) {
+			die( '' );
+		}
+
+		$found_quiz = false;
+		$quizzes    = get_post_meta( $question_id_to_remove, '_quiz_id', false );
+		foreach ( $quizzes as $index => $quiz_id ) {
+			$same_quiz = (int) $quiz_id === (int) $quiz_id_to_be_removed_from;
+			if ( $same_quiz || empty( $quiz_id ) ) {
 				delete_post_meta( $question_id_to_remove, '_quiz_id', $quiz_id );
-				die( 'Deleted' );
+
+				$found_quiz = $found_quiz || $same_quiz;
+				unset( $quizzes[ $index ] );
 			}
 		}
 
-		die( '' );
+		if ( empty( $quizzes ) ) {
+			wp_delete_post( $question_id_to_remove, true );
+		}
+
+		die( $found_quiz ? 'Deleted' : '' );
 	}
 
 	public function get_question_category_limit() {

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1561,6 +1561,13 @@ class Sensei_Quiz {
 		foreach ( $question_ids as $question_id ) {
 			delete_post_meta( $question_id, '_quiz_id', $quiz_id );
 			delete_post_meta( $question_id, '_quiz_question_order' . $quiz_id );
+
+			if (
+				'multiple_question' === get_post_type( $question_id )
+				&& empty( array_filter( get_post_meta( $question_id, '_quiz_id', false ) ) )
+			) {
+				wp_delete_post( $question_id, true );
+			}
 		}
 	}
 

--- a/includes/class-sensei-updates.php
+++ b/includes/class-sensei-updates.php
@@ -75,9 +75,22 @@ class Sensei_Updates {
 		$this->v3_7_check_rewrite_front();
 		$this->v3_7_add_comment_indexes();
 		$this->v3_9_fix_question_author();
+		$this->v3_9_remove_abandoned_multiple_question();
 
 		// Flush rewrite cache.
 		Sensei()->initiate_rewrite_rules_flush();
+	}
+
+	/**
+	 * Enqueue job to remove the abandoned `multiple_question`.
+	 */
+	private function v3_9_remove_abandoned_multiple_question() {
+		// Only run this if we're upgrading and the current version (before upgrade) is less than 3.9.0.
+		if ( ! $this->is_upgrade || version_compare( $this->current_version, '3.9.0', '>=' ) ) {
+			return;
+		}
+
+		Sensei_Scheduler::instance()->schedule_job( new Sensei_Update_Remove_Abandoned_Multiple_Question() );
 	}
 
 	/**

--- a/includes/update-tasks/class-sensei-update-remove-abandoned-multiple-question.php
+++ b/includes/update-tasks/class-sensei-update-remove-abandoned-multiple-question.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * File containing the class Sensei_Update_Remove_Abandoned_Multiple_Question.
+ *
+ * @since 3.9.0
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Remove abandoned multiple_question posts.
+ */
+class Sensei_Update_Remove_Abandoned_Multiple_Question extends Sensei_Background_Job_Batch {
+	/**
+	 * Get the job batch size.
+	 *
+	 * @return int
+	 */
+	protected function get_batch_size() : int {
+		return 30;
+	}
+
+	/**
+	 * Can multiple instances be enqueued at the same time?
+	 *
+	 * @return bool
+	 */
+	protected function allow_multiple_instances() : bool {
+		return false;
+	}
+
+	/**
+	 * Run batch.
+	 *
+	 * @param int $offset Current offset.
+	 *
+	 * @return bool Returns true if there is more to do.
+	 */
+	protected function run_batch( int $offset ) : bool {
+		$query     = $this->get_multiple_question_query( $offset );
+		$remaining = $query->found_posts - $offset;
+
+		foreach ( $query->posts as $question ) {
+			if ( 'multiple_question' === $question->post_type && $this->is_abandoned( $question ) ) {
+				wp_delete_post( $question->ID, true );
+			}
+
+			$remaining--;
+		}
+
+		return $remaining > 0;
+	}
+
+	/**
+	 * Check to see if a post is abandoned.
+	 *
+	 * @param WP_Post $question Question post to check.
+	 *
+	 * @return bool
+	 */
+	private function is_abandoned( WP_Post $question ) : bool {
+		$quizzes    = array_filter( get_post_meta( $question->ID, '_quiz_id', false ) );
+		$quiz_found = false;
+
+		foreach ( $quizzes as $quiz_id ) {
+			if ( 'quiz' === get_post_type( $quiz_id ) ) {
+				$quiz_found = true;
+				break;
+			}
+		}
+
+		return ! $quiz_found;
+	}
+
+	/**
+	 * Get the abandoned `multiple_question` posts.
+	 *
+	 * @param int $offset Current offset.
+	 *
+	 * @return WP_Query
+	 */
+	protected function get_multiple_question_query( int $offset ) : WP_Query {
+		return new WP_Query(
+			[
+				'post_type'      => 'multiple_question',
+				'post_status'    => 'any',
+				'orderby'        => 'ID',
+				'order'          => 'ASC',
+				'offset'         => (int) $offset,
+				'posts_per_page' => $this->get_batch_size(),
+			]
+		);
+	}
+}

--- a/tests/unit-tests/update-tasks/test-class-sensei-update-remove-abandoned-multiple-question.php
+++ b/tests/unit-tests/update-tasks/test-class-sensei-update-remove-abandoned-multiple-question.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Tests for Sensei_Update_Remove_Abandoned_Multiple_Question class.
+ *
+ * @group update-tasks
+ * @group background-jobs
+ */
+class Sensei_Update_Remove_Abandoned_Multiple_Question_Test extends WP_UnitTestCase {
+
+	/**
+	 * Sensei Factory.
+	 *
+	 * @var Sensei_Factory
+	 */
+	private $factory;
+
+	/**
+	 * Set up the tests.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->factory = new Sensei_Factory();
+	}
+
+	/**
+	 * Tests a simple batch of quiz posts.
+	 */
+	public function testBasicRun() {
+		$quiz_id               = $this->factory->quiz->create();
+		$quiz_id_b             = $this->factory->quiz->create();
+		$multiple_question_ids = $this->factory->multiple_question->create_many(
+			4,
+			[
+				'quiz_id'              => $quiz_id,
+				'question_number'      => 1,
+				'question_category_id' => 0,
+			]
+		);
+
+		$kept_question_id         = $multiple_question_ids[0];
+		$deleted_question_id      = $multiple_question_ids[1];
+		$cleared_question_id      = $multiple_question_ids[2];
+		$shared_question_id       = $multiple_question_ids[3];
+		$deleted_quiz_question_id = $this->factory->multiple_question->create();
+		$abandoned_question_id    = $this->factory->multiple_question->create();
+
+		delete_post_meta( $deleted_question_id, '_quiz_id', $quiz_id );
+
+		// This also isn't done, but make sure we test for it in case it ever was.
+		update_post_meta( $cleared_question_id, '_quiz_id', '', $quiz_id );
+
+		// Note: This should never have happened, but just in case we did at one point.
+		add_post_meta( $shared_question_id, '_quiz_id', $quiz_id_b, false );
+		delete_post_meta( $shared_question_id, '_quiz_id', $quiz_id );
+
+		add_post_meta( $deleted_quiz_question_id, '_quiz_id', 99999999, false );
+
+		$instance = new Sensei_Update_Remove_Abandoned_Multiple_Question( [], '' );
+		$instance->run();
+
+		$this->assertTrue( 'multiple_question' === get_post_type( $kept_question_id ) );
+		$this->assertTrue( 'multiple_question' === get_post_type( $shared_question_id ) );
+		$this->assertNull( get_post( $deleted_question_id ) );
+		$this->assertNull( get_post( $cleared_question_id ) );
+		$this->assertNull( get_post( $abandoned_question_id ) );
+		$this->assertNull( get_post( $deleted_quiz_question_id ) );
+	}
+
+
+	/**
+	 * Get mock for Sensei_Update_Remove_Abandoned_Multiple_Question.
+	 *
+	 * @param array  $question_query_response Posts to return.
+	 * @param int    $query_total_results     Total results.
+	 * @param int    $batch_size              Batch size.
+	 * @param string $id                      Job ID.
+	 *
+	 * @return \PHPUnit\Framework\MockObject\MockObject|Sensei_Update_Fix_Question_Author
+	 */
+	private function getInstanceMock( $question_query_response = [], $query_total_results = 15, $batch_size = 10, $id = null ) {
+		$mock = $this->getMockBuilder( Sensei_Update_Remove_Abandoned_Multiple_Question::class )
+						->setMethods( [ 'get_multiple_question_query', 'get_batch_size' ] )
+						->setConstructorArgs( [ [], $id ] )
+						->getMock();
+
+		$query              = new WP_Query();
+		$query->found_posts = $query_total_results;
+		$query->posts       = $question_query_response;
+		$query->post_count  = count( $question_query_response );
+
+		$mock->expects( $this->once() )->method( 'get_multiple_question_query' )->willReturn( $query );
+		$mock->expects( $this->any() )->method( 'get_batch_size' )->willReturn( $batch_size );
+
+		return $mock;
+	}
+
+	/**
+	 * Get an array of WP_Post objects that haven't been inserted.
+	 *
+	 * @param int $n Number to return.
+	 *
+	 * @return WP_Post[]
+	 */
+	private function getFakeQuizzes( $n ) {
+		$fake_posts = array_map(
+			function( $id ) {
+				$quiz            = new WP_Post( new stdClass() );
+				$quiz->ID        = $id;
+				$quiz->post_type = 'quiz';
+
+				return $quiz;
+			},
+			range( 1, $n )
+		);
+
+		return $fake_posts;
+	}
+}


### PR DESCRIPTION
# Based on #4030

**Note: This is low priority for 3.9 so review last**

### Changes proposed in this Pull Request

* Previously, we just left `multiple_question` posts after removing them from a quiz. They are never recycled.
* This deletes `multiple_question` posts in the metabox quiz editor when removed from a quiz.
* Although they aren't recycled, the code assumes they _could_ be so I only delete them if there are no more quizzes using them.
* Creates an update batch job to delete the ones in the database.

### Testing instructions

On `version/3.8`...
* Create multiple questions and assign them to a question category.
* Create a quiz and add a `Category Question` for that category.
* Delete that category question.

Switch to this branch...
* After the job runs, verify that the `multiple_question` post is deleted from above.
* On a new quiz *using the metabox quiz editor*, add a `Category Question` and remove it. 
* Verify the new `multiple_question` post is deleted.