### PR TITLE
Add read-only question blocks

### DIFF
--- a/assets/blocks/quiz/answer-blocks/gap-fill.js
+++ b/assets/blocks/quiz/answer-blocks/gap-fill.js
@@ -67,4 +67,32 @@ const GapFillAnswer = ( {
 	);
 };
 
+/**
+ * Read-only answer component gap fill question block.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.attributes
+ * @param {string}   props.attributes.before Text before the gap.
+ * @param {string}   props.attributes.after  Text after the gap.
+ * @param {string[]} props.attributes.gap    Right answers.
+ */
+GapFillAnswer.view = ( { attributes: { before, after, gap } } ) => {
+	return (
+		<ul className="sensei-lms-question-block__answer sensei-lms-question-block__answer--gap-fill">
+			<li>{ before }</li>
+			<li className="sensei-lms-question-block__answer--gap-fill__right-answers sensei-lms-question-block__text-input-placeholder">
+				{ gap.map( ( answer ) => (
+					<span
+						key={ answer }
+						className="sensei-lms-question-block__answer--gap-fill__token"
+					>
+						{ answer }
+					</span>
+				) ) }
+			</li>
+			<li>{ after }</li>
+		</ul>
+	);
+};
+
 export default GapFillAnswer;

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -38,6 +38,7 @@ const questionTypes = {
 		title: __( 'Multiple Choice', 'sensei-lms' ),
 		description: __( 'Select from a list of options.', 'sensei-lms' ),
 		edit: MultipleChoiceAnswer,
+		view: MultipleChoiceAnswer.view,
 		settings: [
 			QuestionGradeSettings,
 			QuestionMultipleChoiceSettings,
@@ -51,12 +52,14 @@ const questionTypes = {
 			'sensei-lms'
 		),
 		edit: TrueFalseAnswer,
+		view: TrueFalseAnswer.view,
 		settings: [ QuestionGradeSettings, QuestionAnswerFeedbackSettings ],
 	},
 	'gap-fill': {
 		title: __( 'Gap Fill', 'sensei-lms' ),
 		description: __( 'Fill in the blank.', 'sensei-lms' ),
 		edit: GapFillAnswer,
+		view: GapFillAnswer.view,
 		settings: [ QuestionGradeSettings, QuestionAnswerFeedbackSettings ],
 	},
 	'single-line': {
@@ -66,6 +69,7 @@ const questionTypes = {
 			'sensei-lms'
 		),
 		edit: SingleLineAnswer,
+		view: SingleLineAnswer,
 		settings: [ QuestionGradeSettings, QuestionGradingNotesSettings ],
 	},
 	'multi-line': {
@@ -75,12 +79,14 @@ const questionTypes = {
 			'sensei-lms'
 		),
 		edit: MultiLineAnswer,
+		view: MultiLineAnswer,
 		settings: [ QuestionGradeSettings, QuestionGradingNotesSettings ],
 	},
 	'file-upload': {
 		title: __( 'File Upload', 'sensei-lms' ),
 		description: __( 'Upload a file or document.', 'sensei-lms' ),
 		edit: FileUploadAnswer,
+		view: FileUploadAnswer,
 		settings: [ QuestionGradeSettings, QuestionGradingNotesSettings ],
 	},
 };

--- a/assets/blocks/quiz/answer-blocks/true-false.js
+++ b/assets/blocks/quiz/answer-blocks/true-false.js
@@ -61,4 +61,32 @@ const TrueFalseAnswer = ( {
 	);
 };
 
+/**
+ * Read-only answer component true/false question block.
+ *
+ * @param {Object}  props
+ * @param {Object}  props.attributes
+ * @param {boolean} props.attributes.correct The correct answer.
+ */
+TrueFalseAnswer.view = ( { attributes: { correct = true } } ) => {
+	const options = [
+		{ label: __( 'True', 'sensei-lms' ), value: true },
+		{ label: __( 'False', 'sensei-lms' ), value: false },
+	];
+	return (
+		<ul className="sensei-lms-question-block__answer sensei-lms-question-block__answer--true-false">
+			{ options.map( ( { label, value } ) => (
+				<li
+					key={ value }
+					className="sensei-lms-question-block__answer--true-false__option"
+				>
+					<OptionToggle isChecked={ correct === value }>
+						<span>{ label }</span>
+					</OptionToggle>
+				</li>
+			) ) }
+		</ul>
+	);
+};
+
 export default TrueFalseAnswer;

--- a/assets/blocks/quiz/question-block/block.json
+++ b/assets/blocks/quiz/question-block/block.json
@@ -24,6 +24,11 @@
       "default": {
         "grade": 1
       }
+    },
+    "editable": {
+      "type": "boolean",
+      "default": true,
+      "source": false
     }
   }
 }

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -58,6 +58,7 @@ $block: '.sensei-lms-question-block';
 		border-radius: 2px;
 		padding: 5px;
 		min-height: 52px;
+		display: flex;
 
 		&.multi-line {
 			min-height: 200px;
@@ -89,6 +90,9 @@ $block: '.sensei-lms-question-block';
 	}
 
 	&__answer--multiple-choice, &__answer--true-false {
+		.editor-styles-wrapper & li {
+			min-height: 35px;
+		}
 		&__toggle {
 
 			&__wrapper {
@@ -126,12 +130,12 @@ $block: '.sensei-lms-question-block';
 			}
 
 		}
-
 		.editor-styles-wrapper & li {
 			min-height: 45px;
 			display: flex;
 			align-items: baseline;
 		}
+
 	}
 
 	&__multiple-choice-answer-option {
@@ -204,6 +208,15 @@ $block: '.sensei-lms-question-block';
 			padding: 4px;
 			height: auto;
 			line-height: inherit;
+		}
+
+		&__token {
+			font-size: inherit;
+			background: var(--wp-admin-theme-color, #333);
+			color: #fff;
+			padding: 6px;
+			margin-right: 4px;
+			border-radius: 2px;
 		}
 	}
 

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -15,6 +15,7 @@ import { useHasSelected } from '../../../shared/helpers/blocks';
 import types from '../answer-blocks';
 import { SharedQuestionNotice } from './question-block-helpers';
 import { QuestionGradeToolbar } from './question-grade-toolbar';
+import QuestionView from './question-view';
 import QuestionSettings from './question-settings';
 import { QuestionTypeToolbar } from './question-type-toolbar';
 
@@ -38,12 +39,18 @@ const formatGradeLabel = ( grade ) =>
  */
 const QuestionEdit = ( props ) => {
 	const {
-		attributes: { title, type, answer = {}, options, shared },
+		attributes: {
+			title,
+			type,
+			answer = {},
+			options,
+			shared,
+			editable = true,
+		},
 		setAttributes,
 		clientId,
 		context,
 	} = props;
-
 	const { removeBlock, selectBlock } = useDispatch( 'core/block-editor' );
 
 	const selectDescription = useCallback( () => {
@@ -60,17 +67,32 @@ const QuestionEdit = ( props ) => {
 	const isSingle = context && ! ( 'sensei-lms/quizId' in context );
 	const showContent = title || hasSelected || isSingle;
 
+	const questionIndex = ! isSingle && (
+		<h2 className="sensei-lms-question-block__index">{ index + 1 }.</h2>
+	);
+
+	const questionGrade = (
+		<div className="sensei-lms-question-block__grade">
+			{ formatGradeLabel( options.grade ) }
+		</div>
+	);
+
+	if ( ! editable ) {
+		return (
+			<QuestionView
+				{ ...props }
+				{ ...{ questionGrade, questionIndex, AnswerBlock } }
+			/>
+		);
+	}
+
 	return (
 		<div
 			className={ `sensei-lms-question-block ${
 				! title ? 'is-draft' : ''
 			}` }
 		>
-			{ ! isSingle && (
-				<h2 className="sensei-lms-question-block__index">
-					{ index + 1 }.
-				</h2>
-			) }
+			{ questionIndex }
 			<h2 className="sensei-lms-question-block__title">
 				<SingleLineInput
 					placeholder={ __( 'Add Question', 'sensei-lms' ) }
@@ -82,9 +104,7 @@ const QuestionEdit = ( props ) => {
 					onRemove={ () => removeBlock( clientId ) }
 				/>
 			</h2>
-			<div className="sensei-lms-question-block__grade">
-				{ formatGradeLabel( options.grade ) }
-			</div>
+			{ questionGrade }
 			{ hasSelected && shared && <SharedQuestionNotice /> }
 			{ showContent && (
 				<>

--- a/assets/blocks/quiz/question-block/question-view.js
+++ b/assets/blocks/quiz/question-block/question-view.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { BlockControls } from '@wordpress/block-editor';
+import { BlockControls, InspectorControls } from '@wordpress/block-editor';
 import { getBlockContent } from '@wordpress/blocks';
-import { Toolbar, ToolbarButton } from '@wordpress/components';
+import { PanelBody, Toolbar, ToolbarButton } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { RawHTML } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -40,17 +40,37 @@ const QuestionView = ( {
 			{ questionGrade }
 			<RawHTML>{ getBlockContent( block ) }</RawHTML>
 			{ AnswerBlock?.view && <AnswerBlock.view attributes={ answer } /> }
-			{ ! editable && (
-				<BlockControls>
-					<Toolbar>
-						<ToolbarButton disabled>
-							{ __( 'Locked', 'sensei-lms' ) }
-						</ToolbarButton>
-					</Toolbar>
-				</BlockControls>
-			) }
+			{ ! editable && <NotEditableNotice /> }
 		</div>
 	);
 };
+
+/**
+ * Display toolbar and sidebar notices that the question is not editable.
+ */
+const NotEditableNotice = () => (
+	<>
+		<BlockControls>
+			<Toolbar>
+				<ToolbarButton disabled>
+					{ __( 'Locked', 'sensei-lms' ) }
+				</ToolbarButton>
+			</Toolbar>
+		</BlockControls>
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Question Details', 'sensei-lms' ) }
+				initialOpen={ true }
+			>
+				<div>
+					{ __(
+						'You are not allowed to edit this question.',
+						'sensei-lms'
+					) }
+				</div>
+			</PanelBody>
+		</InspectorControls>
+	</>
+);
 
 export default QuestionView;

--- a/assets/blocks/quiz/question-block/question-view.js
+++ b/assets/blocks/quiz/question-block/question-view.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { BlockControls } from '@wordpress/block-editor';
+import { getBlockContent } from '@wordpress/blocks';
+import { Toolbar, ToolbarButton } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
+import { RawHTML } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Read-only question block.
+ *
+ * @param {Object}  props
+ * @param {string}  props.clientId
+ * @param {Object}  props.attributes
+ * @param {string}  props.attributes.title    Question title.
+ * @param {Object}  props.attributes.answer   Answer attributes.
+ * @param {boolean} props.attributes.editable Is editing enabled.
+ * @param {Element} props.questionIndex       Index element.
+ * @param {Element} props.questionGrade       Grade label element.
+ * @param {Element} props.AnswerBlock         Answer component config.
+ */
+const QuestionView = ( {
+	clientId,
+	attributes: { title, answer, editable },
+	questionIndex,
+	questionGrade,
+	AnswerBlock,
+} ) => {
+	const block = useSelect(
+		( select ) => select( 'core/block-editor' ).getBlock( clientId ),
+		[ clientId ]
+	);
+
+	return (
+		<div className="sensei-lms-question-block">
+			{ questionIndex }
+			<h2 className="sensei-lms-question-block__title">{ title }</h2>
+			{ questionGrade }
+			<RawHTML>{ getBlockContent( block ) }</RawHTML>
+			{ AnswerBlock?.view && <AnswerBlock.view attributes={ answer } /> }
+			{ ! editable && (
+				<BlockControls>
+					<Toolbar>
+						<ToolbarButton disabled>
+							{ __( 'Locked', 'sensei-lms' ) }
+						</ToolbarButton>
+					</Toolbar>
+				</BlockControls>
+			) }
+		</div>
+	);
+};
+
+export default QuestionView;


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Show a read-only state in the editor if the question is not editable by the current user

### Testing instructions

* Create a quiz as an admin, transfer course/lesson to teacher
* Edit lesson with quiz as a teacher
* Ensure question blocks cannot be edited

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="695" alt="image" src="https://user-images.githubusercontent.com/176949/110501513-89fa6580-80fa-11eb-9928-969ebd8d7a6f.png">

