### PR TITLE
Add quiz column to lessons list

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2325,6 +2325,7 @@ class Sensei_Lesson {
 		$new_columns['title']               = _x( 'Lesson Title', 'column name', 'sensei-lms' );
 		$new_columns['lesson-course']       = _x( 'Course', 'column name', 'sensei-lms' );
 		$new_columns['lesson-prerequisite'] = _x( 'Pre-requisite Lesson', 'column name', 'sensei-lms' );
+		$new_columns['lesson-quiz']         = _x( 'Quiz', 'column name', 'sensei-lms' );
 		if ( isset( $defaults['date'] ) ) {
 			$new_columns['date'] = $defaults['date'];
 		}
@@ -2378,6 +2379,17 @@ class Sensei_Lesson {
 					echo '<a href="' . esc_url( get_edit_post_link( absint( $lesson_prerequisite_id ) ) ) . '" title="' . esc_attr( sprintf( __( 'Edit %s', 'sensei-lms' ), get_the_title( absint( $lesson_prerequisite_id ) ) ) ) . '">' . esc_html( get_the_title( absint( $lesson_prerequisite_id ) ) ) . '</a>';
 					_post_states( $lesson_prerequisite_post );
 				} // End If Statement
+				break;
+			case 'lesson-quiz':
+				$quiz_id = get_post_meta( $id, '_lesson_quiz', true );
+
+				$questions      = $quiz_id ? get_post_meta( $quiz_id, '_question_order', true ) : null;
+				$question_count = is_array( $questions ) ? count( $questions ) : null;
+				if ( $question_count > 0 ) {
+					// translators: Placeholder is the number of questions.
+					echo esc_html( sprintf( _n( '%d question', '%d questions', $question_count, 'sensei-lms' ), $question_count ) );
+				}
+
 				break;
 			default:
 				break;


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Add a quiz column to the admin Lessons page, with number of questions in the lesson displayed

### Testing instructions

* Navigate to Wp-admin > Lessons
* Check that lessons that have a quiz have the number of questions displayed

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1052" alt="image" src="https://user-images.githubusercontent.com/176949/110507741-97b2e980-8100-11eb-97e6-b8746570f443.png">

