### PR TITLE
Limit "Number of Questions" setting to number of questions in quiz

### DIFF
--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -8,6 +8,7 @@ import {
 	RangeControl,
 	ToggleControl,
 } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -22,8 +23,13 @@ import NumberControl from '../../editor-components/number-control';
  * @param {Object}   props.attributes         Block attributes
  * @param {Object}   props.attributes.options Current setting options.
  * @param {Function} props.setAttributes      Set attributes function.
+ * @param {string}   props.clientId           Block ID.
  */
-const QuizSettings = ( { attributes: { options = {} }, setAttributes } ) => {
+const QuizSettings = ( {
+	attributes: { options = {} },
+	setAttributes,
+	clientId,
+} ) => {
 	const {
 		passRequired = false,
 		quizPassmark = 100,
@@ -35,6 +41,17 @@ const QuizSettings = ( { attributes: { options = {} }, setAttributes } ) => {
 
 	const createChangeHandler = ( optionKey ) => ( value ) =>
 		setAttributes( { options: { ...options, [ optionKey ]: value } } );
+
+	const questionCount = useSelect(
+		( select ) =>
+			select( 'core/block-editor' )
+				.getBlock( clientId )
+				.innerBlocks.filter(
+					( questionBlock ) =>
+						undefined !== questionBlock?.attributes?.title
+				).length,
+		[ clientId ]
+	);
 
 	return (
 		<InspectorControls>
@@ -99,6 +116,7 @@ const QuizSettings = ( { attributes: { options = {} }, setAttributes } ) => {
 						allowReset
 						resetLabel={ __( 'All', 'sensei-lms' ) }
 						min={ 0 }
+						max={ questionCount }
 						step={ 1 }
 						value={ showQuestions }
 						placeholder={ __( 'All', 'sensei-lms' ) }

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -9,6 +9,7 @@ import {
 	ToggleControl,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
+import { useEffect } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -43,15 +44,26 @@ const QuizSettings = ( {
 		setAttributes( { options: { ...options, [ optionKey ]: value } } );
 
 	const questionCount = useSelect(
-		( select ) =>
-			select( 'core/block-editor' )
+		( select ) => {
+			const count = select( 'core/block-editor' )
 				.getBlock( clientId )
 				.innerBlocks.filter(
 					( questionBlock ) =>
 						undefined !== questionBlock?.attributes?.title
-				).length,
+				).length;
+
+			return count;
+		},
 		[ clientId ]
 	);
+
+	useEffect( () => {
+		if ( showQuestions > questionCount ) {
+			setAttributes( {
+				options: { ...options, showQuestions: questionCount },
+			} );
+		}
+	}, [ options, questionCount, setAttributes, showQuestions ] );
 
 	return (
 		<InspectorControls>

--- a/assets/blocks/quiz/quiz-block/quiz-settings.test.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.test.js
@@ -23,6 +23,8 @@ jest.mock( '@wordpress/data', () => {
 	};
 } );
 
+const setAttributesMock = jest.fn();
+
 describe( '<QuizSettings />', () => {
 	it( 'Should render the settings with the defined values', () => {
 		const { queryByLabelText, queryAllByLabelText } = render(
@@ -37,6 +39,7 @@ describe( '<QuizSettings />', () => {
 						showQuestions: 5,
 					},
 				} }
+				setAttributes={ setAttributesMock }
 			/>
 		);
 
@@ -77,7 +80,6 @@ describe( '<QuizSettings />', () => {
 			randomQuestionOrder: true,
 			showQuestions: 0,
 		};
-		const setAttributesMock = jest.fn();
 
 		const { queryByLabelText, queryAllByLabelText } = render(
 			<QuizSettings

--- a/assets/blocks/quiz/quiz-block/quiz-settings.test.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.test.js
@@ -13,6 +13,16 @@ jest.mock( '@wordpress/block-editor', () => ( {
 	InspectorControls: ( { children } ) => children,
 } ) );
 
+jest.mock( '@wordpress/data', () => {
+	const module = jest.requireActual( '@wordpress/data' );
+
+	return {
+		combineReducers: module.combineReducers,
+		registerStore: module.registerStore,
+		useSelect: () => 2,
+	};
+} );
+
 describe( '<QuizSettings />', () => {
 	it( 'Should render the settings with the defined values', () => {
 		const { queryByLabelText, queryAllByLabelText } = render(

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3334,10 +3334,13 @@ class Sensei_Lesson {
 
 				// Get number of questions to show
 				$show_questions = intval( get_post_meta( $quiz_id, '_show_questions', true ) );
-				if ( $show_questions ) {
 
-					// Get random set of array keys from selected questions array
-					$selected_questions = array_rand( $questions_array, $show_questions );
+				if ( $show_questions ) {
+					// Get random set of array keys from selected questions array.
+					$selected_questions = array_rand(
+						$questions_array,
+						$show_questions > count( $questions_array ) ? count( $questions_array ) : $show_questions
+					);
 
 					// Loop through all questions and pick the the ones to be shown based on the random key selection
 					$questions = array();


### PR DESCRIPTION
### Changes proposed in this Pull Request

The _Number of Questions_ quiz setting had no upper limit. When the setting exceeded the number of questions in the quiz, the quiz would not be displayed on the front end. This PR addresses the display issue and sets a maximum upper limit on the setting equal to the number of questions in the quiz. Only questions that have a title are included in the count.

### Testing instructions

* Open a lesson with existing questions. Ensure you can't set _Number of Questions_ to a value that exceeds the number of questions.
* Add a new question, enter a title, and verify the maximum limit increases by 1.
* Remove a question (or clear the title) and verify the maximum limit decreases by 1.