### PR TITLE
Migrate question media (using Deprecated Blocks API)

### DIFF
--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -61,13 +61,8 @@ export function syncQuestionBlocks( structure, blocks ) {
 				...attributes,
 			};
 
-			let innerBlocks =
+			const innerBlocks =
 				( description && rawHandler( { HTML: description } ) ) || [];
-
-			[ block.attributes, innerBlocks ] = prepareQuestionBlock(
-				block.attributes,
-				innerBlocks
-			);
 
 			dispatch( 'core/block-editor' ).replaceInnerBlocks(
 				block.clientId,

--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -55,7 +55,8 @@ export function syncQuestionBlocks( structure, blocks ) {
 
 		const innerBlocks =
 			( description && rawHandler( { HTML: description } ) ) ||
-			block?.innerBlocks;
+			block?.innerBlocks ||
+			[];
 
 		if ( media ) {
 			innerBlocks.push( getMediaBlock( media ) );

--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -3,6 +3,7 @@
  */
 import { createBlock, getBlockContent, rawHandler } from '@wordpress/blocks';
 import { renderToString } from '@wordpress/element';
+import { dispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -60,8 +61,11 @@ export function syncQuestionBlocks( structure, blocks ) {
 				...block.attributes,
 				...attributes,
 			};
-			block.innerBlocks =
-				( description && rawHandler( { HTML: description } ) ) || [];
+
+			dispatch( 'core/block-editor' ).replaceInnerBlocks(
+				block.clientId,
+				( description && rawHandler( { HTML: description } ) ) || []
+			);
 		}
 
 		return block;

--- a/assets/blocks/quiz/question-block/index.js
+++ b/assets/blocks/quiz/question-block/index.js
@@ -8,6 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import edit from './question-edit';
+import deprecated from './question-deprecated';
 import metadata from './block.json';
 import icon from '../../../icons/question-icon';
 
@@ -23,6 +24,7 @@ export default {
 	example: {
 		attributes: { title: __( 'Example Quiz Question', 'sensei-lms' ) },
 	},
+	deprecated,
 	edit,
 	save: () => <InnerBlocks.Content />,
 };

--- a/assets/blocks/quiz/question-block/question-deprecated.js
+++ b/assets/blocks/quiz/question-block/question-deprecated.js
@@ -1,0 +1,100 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+import { createBlock } from '@wordpress/blocks';
+import { renderToString } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { omit } from 'lodash';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+
+/**
+ * Helper method to get a related block for each type of media.
+ *
+ * @param {Object}   media       Question media.
+ * @param {number}   media.id    Media attachment id.
+ * @param {string}   media.url   Media attachment url.
+ * @param {string}   media.type  Media attachment type.
+ * @param {Function} media.title Media attachment title.
+ */
+const getMediaBlock = ( media ) => {
+	switch ( media.type ) {
+		case 'image':
+			return createBlock( 'core/image', {
+				id: media.id,
+				url: media.url,
+			} );
+		case 'audio':
+			return createBlock( 'core/audio', {
+				id: media.id,
+				src: media.url,
+			} );
+		case 'video':
+			return createBlock( 'core/video', {
+				id: media.id,
+				src: media.url,
+			} );
+		default:
+			const link = <a href={ media.url }>{ media.title }</a>;
+			return createBlock( 'core/paragraph', {
+				content: renderToString( link ),
+			} );
+	}
+};
+
+export default [
+	{
+		onProgrammaticCreation: true,
+		isEligible( props ) {
+			return !! props.media;
+		},
+		attributes: {
+			...metadata.attributes,
+			media: {
+				type: 'object',
+			},
+		},
+		migrate( attributes, innerBlocks ) {
+			return [
+				omit( attributes, 'media' ),
+				[ ...innerBlocks, getMediaBlock( attributes.media ) ],
+			];
+		},
+		save() {
+			return <InnerBlocks.Content />;
+		},
+	},
+	{
+		onProgrammaticCreation: true,
+		isEligible( props ) {
+			return (
+				props.type === 'file-upload' && !! props.options?.studentHelp
+			);
+		},
+		attributes: metadata.attributes,
+		migrate( attributes, innerBlocks ) {
+			return [
+				{
+					...attributes,
+					options: omit( attributes.options, 'studentHelp' ),
+				},
+				[
+					...innerBlocks,
+					createBlock( 'core/paragraph', {
+						content: attributes.options.studentHelp,
+					} ),
+				],
+			];
+		},
+		save() {
+			return <InnerBlocks.Content />;
+		},
+	},
+];

--- a/assets/blocks/quiz/question-block/question-deprecated.js
+++ b/assets/blocks/quiz/question-block/question-deprecated.js
@@ -54,7 +54,7 @@ export default [
 		onProgrammaticCreation: true,
 		isEligible( attributes ) {
 			return (
-				!! attributes.media ||
+				attributes.media ||
 				( attributes.type === 'file-upload' &&
 					!! attributes.options?.studentHelp )
 			);
@@ -69,7 +69,7 @@ export default [
 			const migratedInnerBlocks = [ ...innerBlocks ];
 
 			// Add the media to the description (if it exists).
-			if ( !! attributes.media ) {
+			if ( attributes.media ) {
 				migratedInnerBlocks.push( getMediaBlock( attributes.media ) );
 			}
 

--- a/assets/blocks/quiz/question-block/question-deprecated.js
+++ b/assets/blocks/quiz/question-block/question-deprecated.js
@@ -52,11 +52,11 @@ const getMediaBlock = ( media ) => {
 export default [
 	{
 		onProgrammaticCreation: true,
-		isEligible( props ) {
+		isEligible( attributes ) {
 			return (
-				!! props.media ||
-				( props.type === 'file-upload' &&
-					!! props.options?.studentHelp )
+				!! attributes.media ||
+				( attributes.type === 'file-upload' &&
+					!! attributes.options?.studentHelp )
 			);
 		},
 		attributes: {

--- a/assets/blocks/quiz/question-block/question-deprecated.js
+++ b/assets/blocks/quiz/question-block/question-deprecated.js
@@ -68,6 +68,11 @@ export default [
 		migrate( attributes, innerBlocks ) {
 			const migratedInnerBlocks = [ ...innerBlocks ];
 
+			// Add the media to the description (if it exists).
+			if ( !! attributes.media ) {
+				migratedInnerBlocks.push( getMediaBlock( attributes.media ) );
+			}
+
 			// Add the student help text to the description (if it exists).
 			if (
 				attributes.type === 'file-upload' &&
@@ -78,11 +83,6 @@ export default [
 						content: attributes.options.studentHelp,
 					} )
 				);
-			}
-
-			// Add the media to the description (if it exists).
-			if ( !! attributes.media ) {
-				migratedInnerBlocks.push( getMediaBlock( attributes.media ) );
 			}
 
 			return [

--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -21,7 +21,12 @@ import { camelCase, snakeCase, omit } from 'lodash';
 
 export const QUIZ_STORE = 'sensei/quiz-structure';
 
-const READ_ONLY_ATTRIBUTES = [ 'categories', 'shared', 'options.studentHelp' ];
+const READ_ONLY_ATTRIBUTES = [
+	'categories',
+	'shared',
+	'options.studentHelp',
+	'media',
+];
 
 /**
  * Syncronize this block with quiz data.

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -385,7 +385,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 
 			if ( ! empty( $mimetype_array[0] ) ) {
 				$question_media['type']  = $mimetype_array[0];
-				$question_media['url']   = wp_get_attachment_url( $question_media_id );
+				$question_media['url']   = esc_url( wp_get_attachment_url( $question_media_id ) );
 				$question_media['id']    = $attachment->ID;
 				$question_media['title'] = $attachment->post_title;
 			}

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -444,7 +444,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 				break;
 			case 'file-upload':
 				$student_help                                       = get_post_meta( $question->ID, '_question_wrong_answers', true );
-				$type_specific_properties['options']['studentHelp'] = empty( $student_help[0] ) ? null : $student_help[0];
+				$type_specific_properties['options']['studentHelp'] = empty( $student_help[0] ) ? null : esc_html( $student_help[0] );
 				break;
 		}
 

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -358,7 +358,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		];
 
 		if ( ! empty( $question_meta['_question_media'][0] ) ) {
-			$question_media = $this->get_question_media( (int) $question_meta['_question_media'][0] );
+			$question_media = $this->get_question_media( (int) $question_meta['_question_media'][0], $question->ID );
 
 			if ( ! empty( $question_media ) ) {
 				$common_properties['media'] = $question_media;
@@ -372,10 +372,11 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	 * Helper method to get question media.
 	 *
 	 * @param int $question_media_id The attachment id.
+	 * @param int $question_id       The question id.
 	 *
 	 * @return array Media info. It includes the type, id, url and title.
 	 */
-	private function get_question_media( int $question_media_id ) : array {
+	private function get_question_media( int $question_media_id, int $question_id ) : array {
 		$question_media = [];
 		$mimetype       = get_post_mime_type( $question_media_id );
 		$attachment     = get_post( $question_media_id );
@@ -384,8 +385,11 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			$mimetype_array = explode( '/', $mimetype );
 
 			if ( ! empty( $mimetype_array[0] ) ) {
+				// This filter is documented in class-sensei-question.php.
+				$image_size              = apply_filters( 'sensei_question_image_size', 'medium', $question_id );
 				$question_media['type']  = $mimetype_array[0];
-				$question_media['url']   = esc_url( wp_get_attachment_url( $question_media_id ) );
+				$attachment_src          = wp_get_attachment_image_src( $question_media_id, $image_size );
+				$question_media['url']   = esc_url( $attachment_src[0] );
 				$question_media['id']    = $attachment->ID;
 				$question_media['title'] = $attachment->post_title;
 			}

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -96,6 +96,8 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			$question['type'] = 'multiple-choice';
 		}
 
+		$is_new = null === $question_id;
+
 		$post_args = [
 			'ID'          => $question_id,
 			'post_title'  => $question['title'],
@@ -113,6 +115,10 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 
 		$result = wp_insert_post( $post_args );
 
+		if ( ! $is_new && ! is_wp_error( $result ) ) {
+			$this->migrate_non_editor_question( $result, $question['type'] );
+		}
+
 		/**
 		 * This action is triggered when a question is created or updated by the lesson quiz REST endpoint.
 		 *
@@ -126,6 +132,20 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		do_action( 'sensei_rest_api_question_saved', $result, $question['type'], $question );
 
 		return $result;
+	}
+
+	/**
+	 * Helper method to delete question meta that were deprecated by the block editor.
+	 *
+	 * @param int    $question_id   Question post id.
+	 * @param string $question_type Question type.
+	 */
+	private function migrate_non_editor_question( int $question_id, string $question_type ) {
+		delete_post_meta( $question_id, '_question_media' );
+
+		if ( 'file-upload' === $question_type ) {
+			delete_post_meta( $question_id, '_question_wrong_answers' );
+		}
 	}
 
 	/**
@@ -610,6 +630,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			],
 			'media'       => [
 				'type'       => 'object',
+				'readonly'   => true,
 				'properties' => [
 					'id'    => [
 						'type'        => 'integer',
@@ -789,7 +810,6 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 					'teacherNotes' => [
 						'type'        => [ 'string', 'null' ],
 						'description' => 'Teacher notes for grading',
-
 					],
 				],
 			],
@@ -852,6 +872,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 					'studentHelp'  => [
 						'type'        => [ 'string', 'null' ],
 						'description' => 'Description for student explaining what needs to be uploaded',
+						'readonly'    => true,
 					],
 				],
 			],

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -385,11 +385,16 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			$mimetype_array = explode( '/', $mimetype );
 
 			if ( ! empty( $mimetype_array[0] ) ) {
-				// This filter is documented in class-sensei-question.php.
-				$image_size              = apply_filters( 'sensei_question_image_size', 'medium', $question_id );
+				if ( 'image' === $mimetype_array[0] ) {
+					// This filter is documented in class-sensei-question.php.
+					$image_size            = apply_filters( 'sensei_question_image_size', 'medium', $question_id );
+					$attachment_src        = wp_get_attachment_image_src( $question_media_id, $image_size );
+					$question_media['url'] = esc_url( $attachment_src[0] );
+				} else {
+					$question_media['url'] = esc_url( wp_get_attachment_url( $question_media_id ) );
+				}
+
 				$question_media['type']  = $mimetype_array[0];
-				$attachment_src          = wp_get_attachment_image_src( $question_media_id, $image_size );
-				$question_media['url']   = esc_url( $attachment_src[0] );
 				$question_media['id']    = $attachment->ID;
 				$question_media['title'] = $attachment->post_title;
 			}

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -396,7 +396,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 
 				$question_media['type']  = $mimetype_array[0];
 				$question_media['id']    = $attachment->ID;
-				$question_media['title'] = $attachment->post_title;
+				$question_media['title'] = esc_html( $attachment->post_title );
 			}
 		}
 


### PR DESCRIPTION
Replaces #4035

@gkaragia and I talked about possibly using the Deprecated Blocks API. This is essentially #4035 but moves the code to use the Deprecated Blocks API. For programmatically created question blocks (quiz editor), it will manually run the deprecated migrations so we don't duplicate code. 

This PR should additionally work in the single question editor.