### PR TITLE
Changes for question type extensibility

### DIFF
--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -107,4 +107,4 @@ const questionTypes = {
  *                                             returned from the 'sensei_quiz_mapped_api_attributes' filter, will be
  *                                             passed to all settings components.
  */
-export default applyFilters( 'sensei_quiz_question_types', questionTypes );
+export default applyFilters( 'sensei-lms.quiz.questionTypes', questionTypes );

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -94,17 +94,16 @@ const questionTypes = {
 /**
  * Filters the quiz editor question types in order to support custom ones.
  *
- * @see sensei_quiz_mapped_api_attributes
- * @see sensei_quiz_mapped_block_attributes
- *
  * @param {Object}   questionTypes             The question types.
  * @param {string}   questionTypes.title       The title of the question.
  * @param {string}   questionTypes.description The description of the question.
- * @param {Function} questionTypes.edit        The block edit function for the question. Attributes under 'answer', as
- *                                             returned from the 'sensei_quiz_mapped_api_attributes' filter, will be
- *                                             passed to this component.
- * @param {Array}    questionTypes.settings    An array of settings components to use in the sidebar. Attributes under 'options', as
- *                                             returned from the 'sensei_quiz_mapped_api_attributes' filter, will be
- *                                             passed to all settings components.
+ * @param {Function} questionTypes.edit        The block edit function for the question. Attributes under
+ *                                             'answer', will be passed to this component.
+ * @param {Array}    questionTypes.settings    An array of settings components to use in the sidebar.
+ *                                             Attributes under 'options', will be passed to all settings
+ *                                             components.
  */
-export default applyFilters( 'sensei-lms.quiz.questionTypes', questionTypes );
+export default applyFilters(
+	'sensei-lms.Question.questionTypes',
+	questionTypes
+);

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -15,7 +15,6 @@ import SingleLineAnswer from './single-line';
 import TrueFalseAnswer from './true-false';
 import {
 	QuestionAnswerFeedbackSettings,
-	QuestionGradeSettings,
 	QuestionGradingNotesSettings,
 	QuestionMultipleChoiceSettings,
 } from '../question-block/settings';
@@ -40,7 +39,6 @@ const questionTypes = {
 		edit: MultipleChoiceAnswer,
 		view: MultipleChoiceAnswer.view,
 		settings: [
-			QuestionGradeSettings,
 			QuestionMultipleChoiceSettings,
 			QuestionAnswerFeedbackSettings,
 		],
@@ -53,14 +51,14 @@ const questionTypes = {
 		),
 		edit: TrueFalseAnswer,
 		view: TrueFalseAnswer.view,
-		settings: [ QuestionGradeSettings, QuestionAnswerFeedbackSettings ],
+		settings: [ QuestionAnswerFeedbackSettings ],
 	},
 	'gap-fill': {
 		title: __( 'Gap Fill', 'sensei-lms' ),
 		description: __( 'Fill in the blank.', 'sensei-lms' ),
 		edit: GapFillAnswer,
 		view: GapFillAnswer.view,
-		settings: [ QuestionGradeSettings, QuestionAnswerFeedbackSettings ],
+		settings: [ QuestionAnswerFeedbackSettings ],
 	},
 	'single-line': {
 		title: __( 'Single Line', 'sensei-lms' ),
@@ -70,7 +68,7 @@ const questionTypes = {
 		),
 		edit: SingleLineAnswer,
 		view: SingleLineAnswer,
-		settings: [ QuestionGradeSettings, QuestionGradingNotesSettings ],
+		settings: [ QuestionGradingNotesSettings ],
 	},
 	'multi-line': {
 		title: __( 'Multi Line', 'sensei-lms' ),
@@ -80,22 +78,21 @@ const questionTypes = {
 		),
 		edit: MultiLineAnswer,
 		view: MultiLineAnswer,
-		settings: [ QuestionGradeSettings, QuestionGradingNotesSettings ],
+		settings: [ QuestionGradingNotesSettings ],
 	},
 	'file-upload': {
 		title: __( 'File Upload', 'sensei-lms' ),
 		description: __( 'Upload a file or document.', 'sensei-lms' ),
 		edit: FileUploadAnswer,
 		view: FileUploadAnswer,
-		settings: [ QuestionGradeSettings, QuestionGradingNotesSettings ],
+		settings: [ QuestionGradingNotesSettings ],
 	},
 };
 
+// Commonly used core settings for use in custom question types.
 const availableCoreSettings = {
 	QuestionAnswerFeedbackSettings,
-	QuestionGradeSettings,
 	QuestionGradingNotesSettings,
-	QuestionMultipleChoiceSettings,
 };
 
 /**

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -91,6 +91,13 @@ const questionTypes = {
 	},
 };
 
+const availableCoreSettings = {
+	QuestionAnswerFeedbackSettings,
+	QuestionGradeSettings,
+	QuestionGradingNotesSettings,
+	QuestionMultipleChoiceSettings,
+};
+
 /**
  * Filters the quiz editor question types in order to support custom ones.
  *
@@ -102,8 +109,10 @@ const questionTypes = {
  * @param {Array}    questionTypes.settings    An array of settings components to use in the sidebar.
  *                                             Attributes under 'options', will be passed to all settings
  *                                             components.
+ * @param {Object}   availableCoreSettings     Core settings that can be included in custom question types.
  */
 export default applyFilters(
 	'sensei-lms.Question.questionTypes',
-	questionTypes
+	questionTypes,
+	availableCoreSettings
 );

--- a/assets/blocks/quiz/question-block/question-settings.js
+++ b/assets/blocks/quiz/question-block/question-settings.js
@@ -6,6 +6,11 @@ import { PanelBody } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import { QuestionGradeSettings } from '../question-block/settings';
+
+/**
  * Question block settings controls.
  *
  * @param {Object}     props                    Block props.
@@ -29,13 +34,15 @@ const QuestionSettings = ( {
 				title={ __( 'Question Settings', 'sensei-lms' ) }
 				initialOpen={ true }
 			>
-				{ controls.map( ( SettingControl ) => (
-					<SettingControl
-						key={ SettingControl }
-						{ ...props }
-						{ ...{ options, setOptions } }
-					/>
-				) ) }
+				{ [ QuestionGradeSettings, ...controls ].map(
+					( SettingControl ) => (
+						<SettingControl
+							key={ SettingControl }
+							{ ...props }
+							{ ...{ options, setOptions } }
+						/>
+					)
+				) }
 			</PanelBody>
 		</InspectorControls>
 	);

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -142,6 +142,7 @@ class Sensei_Grading_User_Quiz {
 				$right_answer        = get_post_meta( $question_id, '_question_right_answer', true );
 				$user_answer_content = Sensei()->quiz->get_user_question_answer( $lesson_id, $question_id, $user_id );
 				$type_name           = __( 'Multiple Choice', 'sensei-lms' );
+				$grade_type          = 'manual-grade';
 
 				switch ( $type ) {
 					case 'boolean':

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -25,7 +25,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	 * @return array The question schema.
 	 */
 	private function get_question_schema( string $type ): array {
-		$schema = [];
+		$schema = $this->get_common_question_properties_schema();
 		switch ( $type ) {
 			case 'multiple-choice':
 				$schema = $this->get_multiple_choice_schema();
@@ -53,13 +53,12 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		 * @since  3.9.0
 		 * @hook   sensei_rest_api_schema_question_type
 		 *
-		 * @param  {Array}  $schema        Schema for a single question.
-		 * @param  {string} $type          Question type.
-		 * @param  {Array}  $common_schema Schema that is common for all question types.
+		 * @param  {Array}  $schema Schema for a single question.
+		 * @param  {string} $type   Question type.
 		 *
 		 * @return {array}
 		 */
-		return apply_filters( 'sensei_rest_api_schema_question_type', $schema, $type, $this->get_common_question_properties_schema() );
+		return apply_filters( 'sensei_rest_api_schema_question_type', $schema, $type );
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -53,12 +53,13 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		 * @since  3.9.0
 		 * @hook   sensei_rest_api_schema_question_type
 		 *
-		 * @param  {Array} $schema Schema for a single question.
-		 * @param  {string} $type Question type.
+		 * @param  {Array}  $schema        Schema for a single question.
+		 * @param  {string} $type          Question type.
+		 * @param  {Array}  $common_schema Schema that is common for all question types.
 		 *
 		 * @return {array}
 		 */
-		return apply_filters( 'sensei_rest_api_schema_question_type', $schema, $type );
+		return apply_filters( 'sensei_rest_api_schema_question_type', $schema, $type, $this->get_common_question_properties_schema() );
 	}
 
 	/**


### PR DESCRIPTION
Our API looks pretty feature-complete for adding custom question types. Here are a few things to smooth/fix.

### Changes proposed in this Pull Request

* Change filter name to match block editor convention (`sensei-lms.Question.questionTypes`).
* Pass along common grade settings to question type filter to ease adding common filters.
* Forces the `grade` setting on all questions since it is foundational to make Sensei work (for now). Also, it is in the toolbar.