### PR TITLE
Set e2e tests against WP 5.6 until 5.7 docker image fixed

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        wp: [ 'latest' ]
+        wp: [ '5.6.2' ]
         php: [ '7.4' ]
     env:
       WP_VERSION: ${{ matrix.wp }}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* There appears to be [an issue](https://github.com/docker-library/wordpress/issues/576) with WordPress 5.7's official docker image.