### PR TITLE
Fix existing questions filter in WP 5.7

### DIFF
--- a/assets/blocks/quiz/quiz-block/questions-modal/questions.js
+++ b/assets/blocks/quiz/quiz-block/questions-modal/questions.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { keyBy, uniq } from 'lodash';
+import { keyBy, uniq, omitBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -14,25 +14,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import questionTypesConfig from '../../answer-blocks';
-
-/**
- * Remove properties with empty string as value from an object.
- *
- * @param {Object} object Object to be cleaned.
- *
- * @return {Object} Cleaned object.
- */
-const cleanObject = ( object ) =>
-	Object.entries( object ).reduce( ( acc, [ key, value ] ) => {
-		if ( '' !== value ) {
-			return {
-				...acc,
-				[ key ]: value,
-			};
-		}
-
-		return acc;
-	}, {} );
 
 /**
  * Questions for selection.
@@ -53,7 +34,7 @@ const Questions = ( {
 		( select ) =>
 			select( 'core' ).getEntityRecords( 'postType', 'question', {
 				per_page: 100,
-				...cleanObject( filters ),
+				...omitBy( filters, ( v ) => v === '' ),
 			} ),
 		[ filters ]
 	);

--- a/assets/blocks/quiz/quiz-block/questions-modal/questions.js
+++ b/assets/blocks/quiz/quiz-block/questions-modal/questions.js
@@ -16,6 +16,25 @@ import { __ } from '@wordpress/i18n';
 import questionTypesConfig from '../../answer-blocks';
 
 /**
+ * Remove properties with empty string as value from an object.
+ *
+ * @param {Object} object Object to be cleaned.
+ *
+ * @return {Object} Cleaned object.
+ */
+const cleanObject = ( object ) =>
+	Object.entries( object ).reduce( ( acc, [ key, value ] ) => {
+		if ( '' !== value ) {
+			return {
+				...acc,
+				[ key ]: value,
+			};
+		}
+
+		return acc;
+	}, {} );
+
+/**
  * Questions for selection.
  *
  * @param {Object}   props
@@ -34,7 +53,7 @@ const Questions = ( {
 		( select ) =>
 			select( 'core' ).getEntityRecords( 'postType', 'question', {
 				per_page: 100,
-				...filters,
+				...cleanObject( filters ),
 			} ),
 		[ filters ]
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes an issue while fetching questions. Basically, the solution was to remove empty strings from the filters before fetching.

### Testing instructions

* Access an env using WP 5.7.
* Create some questions with different types and categories.
* Create a lesson.
* In the quiz, click on "+", and "Add Existing Question(s)".
* Make sure the existing questions are loaded. Try to filter it, and make sure it filters properly using the 3 fields.