### PR TITLE
Fix texarea with null value

### DIFF
--- a/assets/blocks/quiz/question-block/settings/question-answer-feedback-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-answer-feedback-settings.js
@@ -19,7 +19,7 @@ const QuestionAnswerFeedbackSettings = ( {
 	<TextareaControl
 		label={ __( 'Answer Feedback', 'sensei-lms' ) }
 		onChange={ ( value ) => setOptions( { answerFeedback: value } ) }
-		value={ answerFeedback }
+		value={ answerFeedback || '' }
 		help={ __(
 			'Displayed to the learner after the quiz has been graded.',
 			'sensei-lms'

--- a/assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js
@@ -19,7 +19,7 @@ const QuestionGradingNotesSettings = ( {
 	<TextareaControl
 		label={ __( 'Grading Notes', 'sensei-lms' ) }
 		onChange={ ( value ) => setOptions( { teacherNotes: value } ) }
-		value={ teacherNotes }
+		value={ teacherNotes || '' }
 		help={ __(
 			'Displayed to the teacher when grading the question.',
 			'sensei-lms'


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes the React warning to avoid `null` in `textarea`.
```
Warning: `value` prop on `textarea` should not be null. Consider using an empty string to clear the component or `undefined` for uncontrolled components.
```

### Testing instructions

* Create a quiz with a multiple choice question and a single line question (don't change the settings).
* Save the lesson.
* Refresh the page and open the browser console.
* Focus the blocks to see the questions settings.