### PR TITLE
Do not add quiz question block when it already exists (auto-draft)

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-questions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-questions-controller.php
@@ -87,6 +87,11 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 		$description = $attributes['description'];
 		unset( $attributes['description'] );
 
+		// For auto-draft questions, just pass back the `post_content` when it already has the quiz question block.
+		if ( has_block( 'sensei-lms/quiz-question', $question ) ) {
+			return $question->post_content;
+		}
+
 		// Wrap legacy question description in a paragraph block.
 		if ( ! has_blocks( $description ) ) {
 			$description = serialize_block(


### PR DESCRIPTION
### Changes proposed in this Pull Request

* On auto-draft posts, the quiz question block gets saved into the post content (as it should because we don't want to set the meta). Do not attempt to double-add it when it already exists in the post content.

### Testing instructions

* Go to WP Admin > Questions > Add New.
* [Optionally] Type a question title.
* Wait for auto-draft to be saved (you'll see the `post_id` in the URL).
* Refresh the editor.
* Note that the question block isn't embedded in another question block.