### PR TITLE
Add multiple/category questions in REST API

### DIFF
--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -17,9 +17,10 @@ class Sensei_Feature_Flags {
 		$this->default_feature_settings = (array) apply_filters(
 			'sensei_default_feature_flag_settings',
 			array(
-				'rest_api_v1'                  => false,
-				'rest_api_v1_skip_permissions' => false,
-				'enrolment_provider_tooltip'   => false,
+				'rest_api_v1'                            => false,
+				'rest_api_v1_skip_permissions'           => false,
+				'enrolment_provider_tooltip'             => false,
+				'block_editor_enable_category_questions' => false,
 			)
 		);
 	}

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -66,7 +66,10 @@ class Sensei_Quiz {
 
 		// If quizzes were using the multiple_questions CPT on update, disable the block based
 		// editor until support is added.
-		if ( Sensei()->get_legacy_flag( Sensei_Main::LEGACY_FLAG_MULTIPLE_QUESTIONS_EXIST ) ) {
+		if (
+			! Sensei()->feature_flags->is_enabled( 'block_editor_enable_category_questions' )
+			&& Sensei()->get_legacy_flag( Sensei_Main::LEGACY_FLAG_MULTIPLE_QUESTIONS_EXIST )
+		) {
 			$is_block_based_editor_enabled = false;
 		}
 

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -207,7 +207,11 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 
 		$question_ids = [];
 		foreach ( $json_params['questions'] as $question ) {
-			$question_id = $this->save_question( $question );
+			if ( isset( $question['type'] ) && 'category-question' === $question['type'] ) {
+				$question_id = $this->save_category_question( $question );
+			} else {
+				$question_id = $this->save_question( $question );
+			}
 
 			if ( is_wp_error( $question_id ) ) {
 				if ( 'sensei_lesson_quiz_question_not_available' === $question_id->get_error_code() ) {

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -89,7 +89,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		}
 
 		$category             = null;
-		$question_id          = (int) $question['id'] ?? null;
+		$question_id          = isset( $question['id'] ) ? (int) $question['id'] : null;
 		$question_number      = (int) $question['options']['number'];
 		$question_category_id = (int) $question['options']['category'];
 

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -27,6 +27,9 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	private function get_question_schema( string $type ): array {
 		$schema = $this->get_common_question_properties_schema();
 		switch ( $type ) {
+			case 'category-question':
+				$schema = $this->get_category_question_schema();
+				break;
 			case 'multiple-choice':
 				$schema = $this->get_multiple_choice_schema();
 				break;

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -731,6 +731,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		 */
 		return apply_filters( 'sensei_rest_api_schema_single_question', $single_question_schema );
 	}
+
 	/**
 	 * Helper method which returns the schema for category question properties.
 	 *

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -78,7 +78,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			$question_id
 			&& (
 				'multiple_question' !== get_post_type( $question_id )
-				|| ! current_user_can( get_post_type_object( 'course' )->cap->edit_post, $question_id )
+				|| ! current_user_can( get_post_type_object( 'multiple_question' )->cap->edit_post, $question_id )
 			)
 		) {
 			return new WP_Error( 'sensei_lesson_quiz_question_not_available', '', $question_id );
@@ -152,7 +152,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			$question_id
 			&& (
 				'question' !== get_post_type( $question_id )
-				|| ! current_user_can( get_post_type_object( 'course' )->cap->edit_post, $question_id )
+				|| ! current_user_can( get_post_type_object( 'question' )->cap->edit_post, $question_id )
 			)
 		) {
 			return new WP_Error( 'sensei_lesson_quiz_question_not_available', '', $question_id );

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -385,6 +385,27 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	}
 
 	/**
+	 * Get the multiple/category question as defined by the schema.
+	 *
+	 * @param WP_Post $question The question post.
+	 *
+	 * @return array
+	 */
+	private function get_category_question( WP_Post $question ) : array {
+		$category = (int) get_post_meta( $question->ID, 'category', true );
+		$number   = (int) get_post_meta( $question->ID, 'number', true );
+
+		return [
+			'type'    => 'category-question',
+			'id'      => $question->ID,
+			'options' => [
+				'term'   => $category,
+				'number' => $number,
+			],
+		];
+	}
+
+	/**
 	 * Generates the common question properties.
 	 *
 	 * @param WP_Post $question The question post.
@@ -606,6 +627,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	public function get_single_question_schema() {
 		$single_question_schema = [
 			'oneOf' => [
+				$this->get_category_question_schema(),
 				$this->get_multiple_choice_schema(),
 				$this->get_boolean_schema(),
 				$this->get_gap_fill_schema(),
@@ -632,6 +654,45 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		 * @return {array}
 		 */
 		return apply_filters( 'sensei_rest_api_schema_single_question', $single_question_schema );
+	}
+	/**
+	 * Helper method which returns the schema for category question properties.
+	 *
+	 * @return array The properties.
+	 */
+	private function get_category_question_schema(): array {
+		$question_category_properties = [
+			'type'    => [
+				'type'     => 'string',
+				'pattern'  => 'category-question',
+				'required' => true,
+			],
+			'id'      => [
+				'type'        => 'integer',
+				'description' => 'Multiple question post ID',
+			],
+			'options' => [
+				'type'       => 'object',
+				'properties' => [
+					'category' => [
+						'type'        => 'integer',
+						'description' => 'Term ID of the category where questions are picked',
+						'required'    => true,
+					],
+					'number'   => [
+						'type'        => 'integer',
+						'description' => 'Number of questions to select from the category',
+						'required'    => true,
+					],
+				],
+			],
+		];
+
+		return [
+			'title'      => 'Category Question',
+			'type'       => 'object',
+			'properties' => $question_category_properties,
+		];
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds a feature flag for handling multiple/category questions in block quiz editor.
`define( 'SENSEI_FEATURE_FLAG_BLOCK_EDITOR_ENABLE_CATEGORY_QUESTIONS', true );`
* Adds `category-question` type to REST API schema and handles `GET` and `POST`.
* ~Adds very simple placeholder block and that can save category blocks that already exist on the quiz. Does not attempt to set block design or UX, just purely functional stand-in.~
* ~Attempts to handle some question index/numbering things, but there are edge cases that might come up when we get to the actual block editing experience.~

Note: Removed `multiple_question` posts are actually deleted by #4060

### Testing instructions

* In `version/3.8.1`, create a lesson with some normal questions and category questions. Categories should have questions in them.
* Switch to this branch and merge #4080 (`add/multiple-questions-block`) into this.
* Add the feature flag, and load the lesson. Lesson should load with placeholder block. Reorder questions and save. Make sure order updates.
