### PR TITLE
Refactor autoinserter to fix blocks selection error

### DIFF
--- a/assets/shared/blocks/use-auto-inserter.js
+++ b/assets/shared/blocks/use-auto-inserter.js
@@ -26,6 +26,13 @@ export const useAutoInserter = (
 		select( 'core/block-editor' ).getBlocks( clientId )
 	);
 
+	const isAutoBlockSelected = useSelect(
+		( select ) =>
+			autoBlockClientId &&
+			select( 'core/block-editor' ).isBlockSelected( autoBlockClientId ),
+		[ autoBlockClientId ]
+	);
+
 	const isFirstBlock = 0 === blocks.length;
 
 	const createAndInsertBlock = useCallback( () => {
@@ -73,7 +80,8 @@ export const useAutoInserter = (
 			if (
 				hasEmptyLastBlock &&
 				lastBlock.clientId === autoBlockClientId &&
-				1 !== blocks.length
+				1 !== blocks.length &&
+				! isAutoBlockSelected
 			) {
 				removeBlock( lastBlock.clientId, false );
 			}
@@ -81,17 +89,4 @@ export const useAutoInserter = (
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ hasSelected, hasEmptyLastBlock, hasAutoBlock ] );
-
-	const isAutoBlockSelected = useSelect(
-		( select ) =>
-			autoBlockClientId &&
-			select( 'core/block-editor' ).isBlockSelected( autoBlockClientId ),
-		[ autoBlockClientId ]
-	);
-
-	useEffect( () => {
-		if ( isAutoBlockSelected ) {
-			setAutoBlockClientId( null );
-		}
-	}, [ isAutoBlockSelected ] );
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes a weird issue that happened with the blocks selection. I added a video with an example, but sometimes it got weirder not being able to select any block, or delaying a lot to edit some texts in the blocks. The origin of the error can be reproduced selecting the auto created empty block (in Quiz or in the Course Outline). Selecting that, you'll see an error "Callback is not a function" in `priority-queue.js` (function `runWaitingList`).
* To fix the issue, I got the purpose of that part from the commit message (_"Don't remove auto block if it has been interacted with (selected)"_). Please, let me know if I missed anything. cc @yscik
* The solution was a small refactor avoiding the mutual dependencies between the `useSelect` and the `useEffect`.

### Testing instructions

* Create a lesson with a quiz.
* Focus on the quiz block to see the new empty block in the end of the InnerBlock.
* Make sure no error is logged in the console, and that you can still select the parent blocks, the child blocks, and edit the blocks texts properly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video


https://user-images.githubusercontent.com/876340/110955337-41c08a80-8328-11eb-924d-7e5069150092.mov

