### PR TITLE
Allow draft questions if they are not in a quiz

### DIFF
--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -110,6 +110,10 @@ class Sensei_Blocks {
 	 *                               `register_block_type_from_metadata` if it's defined.
 	 */
 	public static function register_sensei_block( $block_name, $block_args, $file_or_folder = null ) {
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( $block_name ) ) {
+			return;
+		}
+
 		/**
 		 * Filter the args of the Sensei blocks.
 		 *

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1222,7 +1222,7 @@ class Sensei_Quiz {
 		$sensei_question_loop['total']     = 0;
 		$sensei_question_loop['questions'] = array();
 
-		$questions = Sensei()->lesson->lesson_quiz_questions( get_the_ID() );
+		$questions = Sensei()->lesson->lesson_quiz_questions( get_the_ID(), 'publish' );
 
 		if ( count( $questions ) > 0 ) {
 

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -64,11 +64,12 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 	/**
 	 * Helper method to save or update a question.
 	 *
-	 * @param array $question The question JSON array.
+	 * @param array  $question The question JSON array.
+	 * @param string $status Question status.
 	 *
 	 * @return int|WP_Error Question id on success.
 	 */
-	private function save_question( $question ) {
+	private function save_question( $question, $status = 'publish' ) {
 		$question_id = $question['id'] ?? null;
 
 		if (
@@ -101,13 +102,18 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		$post_args = [
 			'ID'          => $question_id,
 			'post_title'  => $question['title'],
-			'post_status' => 'publish',
+			'post_status' => $status,
 			'post_type'   => 'question',
 			'meta_input'  => $this->get_question_meta( $question ),
 			'tax_input'   => [
 				'question-type' => $question['type'],
 			],
 		];
+
+		// Force publish the question if it's part of a quiz.
+		if ( ! empty( get_post_meta( $question_id, '_quiz_id', false ) ) ) {
+			$post_args['post_status'] = 'publish';
+		}
 
 		if ( isset( $question['description'] ) ) {
 			$post_args['post_content'] = $question['description'];

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -100,15 +100,18 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		$is_new = null === $question_id;
 
 		$post_args = [
-			'ID'          => $question_id,
-			'post_title'  => $question['title'],
-			'post_status' => $status,
-			'post_type'   => 'question',
-			'meta_input'  => $this->get_question_meta( $question ),
-			'tax_input'   => [
+			'ID'         => $question_id,
+			'post_title' => $question['title'],
+			'post_type'  => 'question',
+			'meta_input' => $this->get_question_meta( $question ),
+			'tax_input'  => [
 				'question-type' => $question['type'],
 			],
 		];
+
+		if ( $status ) {
+			$post_args['post_status'] = $status;
+		}
 
 		// Force publish the question if it's part of a quiz.
 		if ( ! empty( get_post_meta( $question_id, '_quiz_id', false ) ) ) {

--- a/includes/rest-api/class-sensei-rest-api-questions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-questions-controller.php
@@ -131,7 +131,7 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 			return $response;
 		}
 
-		$question_id = $this->update_question( $request['id'], $block );
+		$question_id = $this->update_question( $request['id'], $block, $request['status'] );
 
 		if ( is_wp_error( $question_id ) ) {
 			switch ( $question_id->get_error_code() ) {
@@ -176,12 +176,13 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 	/**
 	 * Update question with attributes from the block.
 	 *
-	 * @param int   $id    Question ID.
-	 * @param array $block Question block.
+	 * @param int    $id     Question ID.
+	 * @param array  $block  Question block.
+	 * @param string $status Question status.
 	 *
 	 * @return int|WP_Error Question id on success.
 	 */
-	private function update_question( $id, $block ) {
+	private function update_question( $id, $block, $status ) {
 		$attrs       = $block['attrs'];
 		$description = serialize_blocks( $block['innerBlocks'] );
 		$question    = array_merge(
@@ -192,7 +193,7 @@ class Sensei_REST_API_Questions_Controller extends WP_REST_Posts_Controller {
 			]
 		);
 
-		return $this->save_question( $question );
+		return $this->save_question( $question, $status );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update to force the question to publish only if it's part of a quiz (directly or through a category).
* It doesn't change the legacy code to allow the draft, only the block-based code.
* It also adds an extra check to avoid register already registered blocks. This currently only happens during the tests using the method: `Sensei_REST_API_Questions_Controller::get_question_block_from_content`. It was registering an error [here](https://core.trac.wordpress.org/browser/tags/5.7/src/wp-includes/class-wp-block-type-registry.php#L75).

### Testing instructions

* Create a question, save it as `draft`, and make sure it saves properly.
* Add the question to a quiz, and make sure the question now is published.
* Try to update the question to draft again, and make sure it's not possible.
* Remove the question from the quiz, try to update the question to draft again, and make sure it'll work.
* Add a category to the question, save as draft, and make sure it's allowed.
* Publish the question.
* Use the filter `sensei_quiz_enable_block_based_editor` (returning false) or just `return false` directly in the `Sensei_Quiz::is_block_based_editor_enabled` to force the question meta boxes appear in the lesson.
* Add the category to a quiz.
* Disable the legacy meta boxes.
* Try to switch the question to draft, and make sure it's not allowed.
* Enable the legacy meta boxes.
* Remove the category from the quiz.
* Disable the legacy meta boxes.
* Try to switch the question to draft, and make sure it works.