### PR TITLE
Fix some question filters in API docs

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -57,11 +57,8 @@ class Sensei_Question {
 		 *
 		 * @hook sensei_question_types
 		 *
-		 * @param {array} $types {
-		 *  @type {string} $id   Question type ID.
-		 *  @type {string} $text Question type text.
-		 * }
-		 * @return {array} Associative array of question types.
+		 * @param {string[]} $types Question types.
+		 * @return {string[]} Associative array of question types.
 		 */
 		return apply_filters( 'sensei_question_types', $types );
 	}

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -571,7 +571,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			];
 		}
 
-		/*
+		/**
 		 * Add additional question types to the REST API schema.
 		 *
 		 * @since 3.9.0


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix `sensei_question_types` [displaying incorrectly](https://automattic.github.io/sensei/sensei_question_types.html) in the API docs.
* Fix `sensei_rest_api_schema_single_question` not displaying at all.

### Testing instructions

* `composer install`
* `npm run build:docs`
* Open `hookdocs/index.html` and ensure both filters are listed and display correctly.