### PR TITLE
Add settings and basic UI to category question block

### DIFF
--- a/assets/blocks/course-outline/module-block/module-edit.js
+++ b/assets/blocks/course-outline/module-block/module-edit.js
@@ -70,7 +70,12 @@ export const ModuleEdit = ( props ) => {
 		outlineClassName: '',
 	};
 
-	useAutoInserter( { name: 'sensei-lms/course-outline-lesson' }, props );
+	const isEmptyBlock = ( attributes ) => ! attributes.title;
+
+	useAutoInserter(
+		{ name: 'sensei-lms/course-outline-lesson', isEmptyBlock },
+		props
+	);
 
 	/**
 	 * Handle update name.

--- a/assets/blocks/quiz/category-question-block/block.json
+++ b/assets/blocks/quiz/category-question-block/block.json
@@ -1,0 +1,28 @@
+{
+  "name": "sensei-lms/quiz-category-question",
+  "parent": [ "sensei-lms/quiz" ],
+  "category": "sensei-lms",
+  "supports": {
+    "html": false
+  },
+  "attributes": {
+    "id": {
+      "type": "integer"
+    },
+    "type": {
+      "type": "string",
+      "default": "category-question"
+    },
+		"categoryName": {
+			"type": "string",
+			"source": false
+		},
+    "options": {
+      "type": "object",
+      "default": {
+				"category": null,
+				"number": 1
+      }
+    }
+  }
+}

--- a/assets/blocks/quiz/category-question-block/block.json
+++ b/assets/blocks/quiz/category-question-block/block.json
@@ -14,8 +14,7 @@
       "default": "category-question"
     },
 		"categoryName": {
-			"type": "string",
-			"source": false
+			"type": "string"
 		},
     "options": {
       "type": "object",

--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -1,0 +1,57 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { useBlockIndex } from '../../../shared/blocks/block-index';
+
+/**
+ * Quiz category question block editor.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.attributes              Block attributes.
+ * @param {Object}   props.attributes.categoryName Category name.
+ * @param {Function} props.setAttributes           Set block attributes.
+ */
+const CategoryQuestionEdit = ( props ) => {
+	const {
+		attributes: { categoryName, options },
+		clientId,
+	} = props;
+	const number = options.number ?? 1;
+	const index = useBlockIndex( clientId );
+
+	const nextNumber = index;
+	let range = nextNumber;
+	if ( number !== 1 ) {
+		range += '-' + ( nextNumber + number - 1 );
+	}
+
+	const questionIndex = (
+		<h2 className="sensei-lms-question-block__index">{ range }.</h2>
+	);
+
+	const categoryDescription = sprintf(
+		// translators: Temporary placeholder is either the category name or ID.
+		__( 'Term %s', 'sensei-lms' ),
+		categoryName ? categoryName : options.category
+	);
+
+	return (
+		<div
+			className={ `sensei-lms-question-block ${
+				! options.category ? 'is-draft' : ''
+			}` }
+		>
+			{ questionIndex }
+			<h2 className="sensei-lms-question-block__title">
+				{ categoryDescription }
+			</h2>
+		</div>
+	);
+};
+
+export default CategoryQuestionEdit;

--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -28,11 +28,7 @@ const CategoryQuestionEdit = ( props ) => {
 	const index = useQuestionIndex( clientId );
 	const [ , getCategoryTermById ] = useQuestionCategories();
 
-	const nextNumber = index;
-	let range = nextNumber;
-	if ( number !== 1 ) {
-		range += ' - ' + ( nextNumber + number - 1 );
-	}
+	const range = 1 === number ? index : `${ index } - ${ index + number - 1 }`;
 
 	const questionIndex = (
 		<h2 className="sensei-lms-question-block__index">{ range }.</h2>

--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -1,12 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import { useBlockIndex } from '../../../shared/blocks/block-index';
+import { useQuestionCategories } from '../question-categories';
+import CategoryQuestionSettings from './category-question-settings';
 
 /**
  * Quiz category question block editor.
@@ -18,39 +20,57 @@ import { useBlockIndex } from '../../../shared/blocks/block-index';
  */
 const CategoryQuestionEdit = ( props ) => {
 	const {
-		attributes: { categoryName, options },
+		attributes: {
+			options: { number = 1, category },
+		},
 		clientId,
 	} = props;
-	const number = options.number ?? 1;
 	const index = useBlockIndex( clientId );
+	const [ , getCategoryTermById ] = useQuestionCategories();
 
 	const nextNumber = index;
 	let range = nextNumber;
 	if ( number !== 1 ) {
-		range += '-' + ( nextNumber + number - 1 );
+		range += ' - ' + ( nextNumber + number - 1 );
 	}
 
 	const questionIndex = (
 		<h2 className="sensei-lms-question-block__index">{ range }.</h2>
 	);
 
-	const categoryDescription = sprintf(
-		// translators: Temporary placeholder is either the category name or ID.
-		__( 'Term %s', 'sensei-lms' ),
-		categoryName ? categoryName : options.category
-	);
+	const categoryName =
+		getCategoryTermById( category )?.name ?? props.attributes.categoryName;
 
 	return (
-		<div
-			className={ `sensei-lms-question-block ${
-				! options.category ? 'is-draft' : ''
-			}` }
-		>
-			{ questionIndex }
-			<h2 className="sensei-lms-question-block__title">
-				{ categoryDescription }
-			</h2>
-		</div>
+		<>
+			<CategoryQuestionSettings { ...props } />
+			<div
+				className={ `sensei-lms-question-block ${
+					! category ? 'is-draft' : ''
+				}` }
+			>
+				{ questionIndex }
+				<h2 className="sensei-lms-question-block__title">
+					<strong>
+						{ categoryName ??
+							__( 'Category Question', 'sensei-lms' ) }
+					</strong>
+					{ number &&
+						' (' +
+							sprintf(
+								// translators: placeholder is number of questions to show from category.
+								_n(
+									'%d question',
+									'%d questions',
+									number,
+									'sensei-lms'
+								),
+								number
+							) +
+							')' }
+				</h2>
+			</div>
+		</>
 	);
 };
 

--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -6,7 +6,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useQuestionIndex } from '../question-index';
+import { useQuestionNumber } from '../question-number';
 import { useQuestionCategories } from '../question-categories';
 import CategoryQuestionSettings from './category-question-settings';
 import { useEffect } from '@wordpress/element';
@@ -27,10 +27,13 @@ const CategoryQuestionEdit = ( props ) => {
 		clientId,
 		setAttributes,
 	} = props;
-	const index = useQuestionIndex( clientId );
+	const questionNumber = useQuestionNumber( clientId );
 	const [ , getCategoryTermById ] = useQuestionCategories();
 
-	const range = 1 === number ? index : `${ index } - ${ index + number - 1 }`;
+	const range =
+		1 === number
+			? questionNumber
+			: `${ questionNumber } - ${ questionNumber + number - 1 }`;
 
 	const questionIndex = (
 		<h2 className="sensei-lms-question-block__index">{ range }.</h2>

--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -38,14 +38,15 @@ const CategoryQuestionEdit = ( props ) => {
 
 	const categoryName =
 		getCategoryTermById( category )?.name ?? props.attributes.categoryName;
+	const categoryNameMatch = categoryName === props.attributes.categoryName;
 
 	useEffect( () => {
-		if ( categoryName && categoryName !== props.attributes.categoryName ) {
+		if ( categoryName && ! categoryNameMatch ) {
 			setAttributes( {
 				categoryName,
 			} );
 		}
-	}, [ categoryName ] );
+	}, [ categoryName, categoryNameMatch, setAttributes ] );
 
 	return (
 		<>

--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -41,7 +41,7 @@ const CategoryQuestionEdit = ( props ) => {
 		<>
 			<CategoryQuestionSettings { ...props } />
 			<div
-				className={ `sensei-lms-question-block ${
+				className={ `sensei-lms-question-block sensei-lms-category-question-block ${
 					! category ? 'is-draft' : ''
 				}` }
 			>

--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -6,7 +6,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useBlockIndex } from '../../../shared/blocks/block-index';
+import { useQuestionIndex } from '../question-index';
 import { useQuestionCategories } from '../question-categories';
 import CategoryQuestionSettings from './category-question-settings';
 
@@ -25,7 +25,7 @@ const CategoryQuestionEdit = ( props ) => {
 		},
 		clientId,
 	} = props;
-	const index = useBlockIndex( clientId );
+	const index = useQuestionIndex( clientId );
 	const [ , getCategoryTermById ] = useQuestionCategories();
 
 	const nextNumber = index;

--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -9,6 +9,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { useQuestionIndex } from '../question-index';
 import { useQuestionCategories } from '../question-categories';
 import CategoryQuestionSettings from './category-question-settings';
+import { useEffect } from '@wordpress/element';
 
 /**
  * Quiz category question block editor.
@@ -24,6 +25,7 @@ const CategoryQuestionEdit = ( props ) => {
 			options: { number = 1, category },
 		},
 		clientId,
+		setAttributes,
 	} = props;
 	const index = useQuestionIndex( clientId );
 	const [ , getCategoryTermById ] = useQuestionCategories();
@@ -36,6 +38,14 @@ const CategoryQuestionEdit = ( props ) => {
 
 	const categoryName =
 		getCategoryTermById( category )?.name ?? props.attributes.categoryName;
+
+	useEffect( () => {
+		if ( categoryName && categoryName !== props.attributes.categoryName ) {
+			setAttributes( {
+				categoryName,
+			} );
+		}
+	}, [ categoryName ] );
 
 	return (
 		<>

--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -56,7 +56,7 @@ const CategoryQuestionEdit = ( props ) => {
 							__( 'Category Question', 'sensei-lms' ) }
 					</strong>
 					{ categoryName &&
-						number &&
+						number > 0 &&
 						' (' +
 							sprintf(
 								// translators: placeholder is number of questions to show from category.

--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -55,7 +55,8 @@ const CategoryQuestionEdit = ( props ) => {
 						{ categoryName ??
 							__( 'Category Question', 'sensei-lms' ) }
 					</strong>
-					{ number &&
+					{ categoryName &&
+						number &&
 						' (' +
 							sprintf(
 								// translators: placeholder is number of questions to show from category.

--- a/assets/blocks/quiz/category-question-block/category-question-settings.js
+++ b/assets/blocks/quiz/category-question-block/category-question-settings.js
@@ -23,8 +23,11 @@ const CategoryQuestionSettings = ( {
 	attributes: { options = {} },
 	setAttributes,
 } ) => {
-	const setOptions = ( next ) =>
-		setAttributes( { options: { ...options, ...next } } );
+	const setOptions = ( next, otherAttributes = {} ) =>
+		setAttributes( {
+			...otherAttributes,
+			options: { ...options, ...next },
+		} );
 
 	const [
 		questionCategories,
@@ -79,11 +82,18 @@ const CategoryQuestionSettings = ( {
 									);
 								}
 
-								setOptions( {
-									number: numberQuestions,
-									category:
-										parseInt( nextCategory, 10 ) ?? null,
-								} );
+								setOptions(
+									{
+										number: numberQuestions,
+										category:
+											parseInt( nextCategory, 10 ) ??
+											null,
+									},
+									{
+										categoryName:
+											nextQuestionCategory?.name,
+									}
+								);
 							} }
 						/>
 						<NumberControl

--- a/assets/blocks/quiz/category-question-block/category-question-settings.js
+++ b/assets/blocks/quiz/category-question-block/category-question-settings.js
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 import { InspectorControls } from '@wordpress/block-editor';
-import { PanelBody, SelectControl } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { Notice, PanelBody, SelectControl } from '@wordpress/components';
+import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -46,10 +46,6 @@ const CategoryQuestionSettings = ( {
 	];
 
 	const questionCategory = getQuestionCategoryById( options.category );
-	let maxNumberQuestions;
-	if ( questionCategory ) {
-		maxNumberQuestions = questionCategory.count;
-	}
 
 	return (
 		<InspectorControls>
@@ -58,9 +54,9 @@ const CategoryQuestionSettings = ( {
 				initialOpen={ true }
 			>
 				{ ! categoryOptions.length && (
-					<div>
+					<Notice status="warning" isDismissible={ false }>
 						{ __( 'No question categories exist.', 'sensei-lms' ) }
-					</div>
+					</Notice>
 				) }
 				{ categoryOptions.length > 0 && (
 					<>
@@ -69,22 +65,13 @@ const CategoryQuestionSettings = ( {
 							options={ categoryOptions }
 							value={ options.category }
 							onChange={ ( nextCategory ) => {
-								let numberQuestions = options.number;
 								nextCategory = parseInt( nextCategory, 10 );
 								const nextQuestionCategory = getQuestionCategoryById(
 									nextCategory
 								);
 
-								if ( nextQuestionCategory ) {
-									numberQuestions = Math.min(
-										nextQuestionCategory.count,
-										numberQuestions
-									);
-								}
-
 								setOptions(
 									{
-										number: numberQuestions,
 										category:
 											parseInt( nextCategory, 10 ) ??
 											null,
@@ -99,21 +86,33 @@ const CategoryQuestionSettings = ( {
 						<NumberControl
 							label={ __( 'Number of Questions', 'sensei-lms' ) }
 							min={ 1 }
-							max={ maxNumberQuestions }
 							step={ 1 }
-							value={ Math.min(
-								maxNumberQuestions,
-								options.number
-							) }
+							value={ options.number }
 							onChange={ ( nextNumber ) =>
 								setOptions( {
-									number: Math.min(
-										maxNumberQuestions,
-										nextNumber
-									),
+									number: nextNumber,
 								} )
 							}
 						/>
+
+						{ questionCategory &&
+							options.number > questionCategory.count && (
+								<Notice
+									status="warning"
+									isDismissible={ false }
+								>
+									{ sprintf(
+										// translators: Placeholder is number of questions in category.
+										_n(
+											'The selected category has %d question.',
+											'The selected category has %d questions.',
+											questionCategory.count,
+											'sensei-lms'
+										),
+										questionCategory.count
+									) }
+								</Notice>
+							) }
 					</>
 				) }
 			</PanelBody>

--- a/assets/blocks/quiz/category-question-block/category-question-settings.js
+++ b/assets/blocks/quiz/category-question-block/category-question-settings.js
@@ -63,7 +63,7 @@ const CategoryQuestionSettings = ( {
 						<SelectControl
 							label={ __( 'Category', 'sensei-lms' ) }
 							options={ categoryOptions }
-							value={ options.category }
+							value={ options.category ?? '' }
 							onChange={ ( nextCategoryTermId ) => {
 								const nextQuestionCategoryTermId = getQuestionCategoryById(
 									+nextCategoryTermId
@@ -84,7 +84,7 @@ const CategoryQuestionSettings = ( {
 							label={ __( 'Number of Questions', 'sensei-lms' ) }
 							min={ 1 }
 							step={ 1 }
-							value={ options.number }
+							value={ options.number ?? 1 }
 							onChange={ ( nextNumber ) =>
 								setOptions( {
 									number: nextNumber,

--- a/assets/blocks/quiz/category-question-block/category-question-settings.js
+++ b/assets/blocks/quiz/category-question-block/category-question-settings.js
@@ -64,21 +64,18 @@ const CategoryQuestionSettings = ( {
 							label={ __( 'Category', 'sensei-lms' ) }
 							options={ categoryOptions }
 							value={ options.category }
-							onChange={ ( nextCategory ) => {
-								nextCategory = parseInt( nextCategory, 10 );
-								const nextQuestionCategory = getQuestionCategoryById(
-									nextCategory
+							onChange={ ( nextCategoryTermId ) => {
+								const nextQuestionCategoryTermId = getQuestionCategoryById(
+									+nextCategoryTermId
 								);
 
 								setOptions(
 									{
-										category:
-											parseInt( nextCategory, 10 ) ??
-											null,
+										category: +nextCategoryTermId ?? null,
 									},
 									{
 										categoryName:
-											nextQuestionCategory?.name,
+											nextQuestionCategoryTermId?.name,
 									}
 								);
 							} }

--- a/assets/blocks/quiz/category-question-block/category-question-settings.js
+++ b/assets/blocks/quiz/category-question-block/category-question-settings.js
@@ -1,0 +1,114 @@
+/**
+ * WordPress dependencies
+ */
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import NumberControl from '../../editor-components/number-control';
+import { useQuestionCategories } from '../question-categories';
+
+/**
+ * Category question block settings controls.
+ *
+ * @param {Object}   props                    Block props.
+ * @param {Object}   props.attributes         Block attributes.
+ * @param {Object}   props.attributes.options Block options attribute.
+ * @param {Function} props.setAttributes      Update block attributes.
+ */
+const CategoryQuestionSettings = ( {
+	attributes: { options = {} },
+	setAttributes,
+} ) => {
+	const setOptions = ( next ) =>
+		setAttributes( { options: { ...options, ...next } } );
+
+	const [
+		questionCategories,
+		getQuestionCategoryById,
+	] = useQuestionCategories();
+
+	const categoryOptions = [
+		{
+			value: '',
+			label: __( 'Category', 'sensei-lms' ),
+		},
+		...( questionCategories || [] ).map( ( questionCategory ) => ( {
+			value: questionCategory.id,
+			label: questionCategory.name,
+		} ) ),
+	];
+
+	const questionCategory = getQuestionCategoryById( options.category );
+	let maxNumberQuestions;
+	if ( questionCategory ) {
+		maxNumberQuestions = questionCategory.count;
+	}
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Category Question Settings', 'sensei-lms' ) }
+				initialOpen={ true }
+			>
+				{ ! categoryOptions.length && (
+					<div>
+						{ __( 'No question categories exist.', 'sensei-lms' ) }
+					</div>
+				) }
+				{ categoryOptions.length > 0 && (
+					<>
+						<SelectControl
+							label={ __( 'Category', 'sensei-lms' ) }
+							options={ categoryOptions }
+							value={ options.category }
+							onChange={ ( nextCategory ) => {
+								let numberQuestions = options.number;
+								nextCategory = parseInt( nextCategory, 10 );
+								const nextQuestionCategory = getQuestionCategoryById(
+									nextCategory
+								);
+
+								if ( nextQuestionCategory ) {
+									numberQuestions = Math.min(
+										nextQuestionCategory.count,
+										numberQuestions
+									);
+								}
+
+								setOptions( {
+									number: numberQuestions,
+									category:
+										parseInt( nextCategory, 10 ) ?? null,
+								} );
+							} }
+						/>
+						<NumberControl
+							label={ __( 'Number of Questions', 'sensei-lms' ) }
+							min={ 1 }
+							max={ maxNumberQuestions }
+							step={ 1 }
+							value={ Math.min(
+								maxNumberQuestions,
+								options.number
+							) }
+							onChange={ ( nextNumber ) =>
+								setOptions( {
+									number: Math.min(
+										maxNumberQuestions,
+										nextNumber
+									),
+								} )
+							}
+						/>
+					</>
+				) }
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default CategoryQuestionSettings;

--- a/assets/blocks/quiz/category-question-block/category-question-settings.js
+++ b/assets/blocks/quiz/category-question-block/category-question-settings.js
@@ -65,7 +65,7 @@ const CategoryQuestionSettings = ( {
 							options={ categoryOptions }
 							value={ options.category ?? '' }
 							onChange={ ( nextCategoryTermId ) => {
-								const nextQuestionCategoryTermId = getQuestionCategoryById(
+								const nextQuestionCategory = getQuestionCategoryById(
 									+nextCategoryTermId
 								);
 
@@ -75,7 +75,7 @@ const CategoryQuestionSettings = ( {
 									},
 									{
 										categoryName:
-											nextQuestionCategoryTermId?.name,
+											nextQuestionCategory?.name,
 									}
 								);
 							} }

--- a/assets/blocks/quiz/category-question-block/index.js
+++ b/assets/blocks/quiz/category-question-block/index.js
@@ -1,0 +1,30 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import edit from './category-question-edit';
+import metadata from './block.json';
+import icon from '../../../icons/question-icon';
+
+/**
+ * Quiz category question block definition.
+ */
+export default {
+	...metadata,
+	title: __( 'Category Question', 'sensei-lms' ),
+	icon,
+	usesContext: [ 'sensei-lms/quizId' ],
+	description: __( 'Pull questions from a question category.', 'sensei-lms' ),
+	example: {
+		attributes: {
+			categoryName: __( 'Test Category', 'sensei-lms' ),
+		},
+	},
+	edit,
+	save: () => <InnerBlocks.Content />,
+};

--- a/assets/blocks/quiz/category-question-block/index.js
+++ b/assets/blocks/quiz/category-question-block/index.js
@@ -22,7 +22,7 @@ export default {
 	description: __( 'Pull questions from a question category.', 'sensei-lms' ),
 	example: {
 		attributes: {
-			categoryName: __( 'Test Category', 'sensei-lms' ),
+			categoryName: __( 'Example Category', 'sensei-lms' ),
 		},
 	},
 	edit,

--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -136,6 +136,10 @@ export function parseQuestionBlocks( blocks ) {
  */
 export function createQuestionBlock( question ) {
 	if ( question.type === 'category-question' ) {
+		if ( ! window.sensei_quiz_blocks.category_question_enabled ) {
+			return createBlock( questionBlock.name, {}, [] );
+		}
+
 		return createBlock( categoryQuestionBlock.name, question, [] );
 	}
 

--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -8,6 +8,7 @@ import { dispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import questionBlock from './question-block';
+import categoryQuestionBlock from './category-question-block';
 
 /**
  * External dependencies
@@ -107,6 +108,10 @@ function prepareQuestionBlock( attributes, innerBlocks ) {
  */
 export function parseQuestionBlocks( blocks ) {
 	const questions = blocks?.map( ( block ) => {
+		if ( block.attributes.type === 'category-question' ) {
+			return block.attributes;
+		}
+
 		return {
 			...block.attributes,
 			description: getBlockContent( block ),
@@ -130,6 +135,10 @@ export function parseQuestionBlocks( blocks ) {
  * @return {QuizQuestion} Block.
  */
 export function createQuestionBlock( question ) {
+	if ( question.type === 'category-question' ) {
+		return createBlock( categoryQuestionBlock.name, question, [] );
+	}
+
 	const [ attributes, innerBlocks ] = prepareQuestionBlock(
 		question,
 		( question.description &&

--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -170,10 +170,9 @@ export function createQuestionBlock( question ) {
  * @param {Array}                             blocks
  * @param {QuizQuestion|QuizCategoryQuestion} item
  */
-export const findQuestionBlock = (
-	blocks,
-	{ id, title, options: { category } }
-) => {
+export const findQuestionBlock = ( blocks, { id, title, options } ) => {
+	const category = options?.category;
+
 	const compare = ( { attributes } ) =>
 		id === attributes.id ||
 		( ! attributes.id && attributes.title && attributes.title === title ) ||

--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -204,7 +204,7 @@ export const normalizeAttributes = ( options, mapFunction ) => {
 };
 
 /**
- * Checks whether a bock is empty.
+ * Checks whether a block is empty.
  *
  * @param {Array} attributes Question attributes.
  *

--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -178,8 +178,8 @@ export const findQuestionBlock = (
 		id === attributes.id ||
 		( ! attributes.id && attributes.title && attributes.title === title ) ||
 		( ! attributes.id &&
-			attributes.options.category &&
-			attributes.options.category === category );
+			attributes.options?.category &&
+			attributes.options?.category === category );
 	return blocks.find( compare );
 };
 

--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -32,7 +32,18 @@ import { mapKeys, mapValues, isObject } from 'lodash';
  * @property {string} title       Question title
  * @property {string} description Question description blocks
  * @property {Object} answers     Question answer settings
- * @property {Object} settings    Question settings
+ * @property {Object} options     Question options.
+ */
+
+/**
+ * Quiz category question data.
+ *
+ * @typedef {Object} QuizCategoryQuestion
+ * @property {number} id               Question ID.
+ * @property {string} type             Question type
+ * @property {Object} options          Question settings
+ * @property {number} options.category Category for question.
+ * @property {number} options.number   Number of questions to show from category.
  */
 
 /**
@@ -120,7 +131,7 @@ export function parseQuestionBlocks( blocks ) {
 
 	const lastQuestion = questions.pop();
 
-	if ( lastQuestion.title ) {
+	if ( ! isQuestionEmpty( lastQuestion ) ) {
 		questions.push( lastQuestion );
 	}
 
@@ -156,13 +167,19 @@ export function createQuestionBlock( question ) {
 /**
  * Find a question block based on question ID, or title if ID is missing.
  *
- * @param {Array}        blocks
- * @param {QuizQuestion} item
+ * @param {Array}                             blocks
+ * @param {QuizQuestion|QuizCategoryQuestion} item
  */
-export const findQuestionBlock = ( blocks, { id, title } ) => {
+export const findQuestionBlock = (
+	blocks,
+	{ id, title, options: { category } }
+) => {
 	const compare = ( { attributes } ) =>
 		id === attributes.id ||
-		( ! attributes.id && attributes.title && attributes.title === title );
+		( ! attributes.id && attributes.title && attributes.title === title ) ||
+		( ! attributes.id &&
+			attributes.options.category &&
+			attributes.options.category === category );
 	return blocks.find( compare );
 };
 
@@ -184,4 +201,19 @@ export const normalizeAttributes = ( options, mapFunction ) => {
 
 		return value;
 	} );
+};
+
+/**
+ * Checks whether a bock is empty.
+ *
+ * @param {Array} attributes Question attributes.
+ *
+ * @return {boolean} If the question is empty.
+ */
+export const isQuestionEmpty = ( attributes ) => {
+	if ( attributes.type === 'category-question' ) {
+		return ! attributes.options.category;
+	}
+
+	return ! attributes.title;
 };

--- a/assets/blocks/quiz/index.js
+++ b/assets/blocks/quiz/index.js
@@ -4,7 +4,8 @@
 import registerSenseiBlocks from '../register-sensei-blocks';
 
 import questionBlock from './question-block';
+import categoryQuestionBlock from './category-question-block';
 import quizBlock from './quiz-block';
 import './quiz-store';
 
-registerSenseiBlocks( [ quizBlock, questionBlock ] );
+registerSenseiBlocks( [ quizBlock, questionBlock, categoryQuestionBlock ] );

--- a/assets/blocks/quiz/index.js
+++ b/assets/blocks/quiz/index.js
@@ -8,4 +8,10 @@ import categoryQuestionBlock from './category-question-block';
 import quizBlock from './quiz-block';
 import './quiz-store';
 
-registerSenseiBlocks( [ quizBlock, questionBlock, categoryQuestionBlock ] );
+const blocks = [ quizBlock, questionBlock ];
+
+if ( window.sensei_quiz_blocks.category_question_enabled ) {
+	blocks.push( categoryQuestionBlock );
+}
+
+registerSenseiBlocks( blocks );

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -22,6 +22,7 @@ $block: '.sensei-lms-question-block';
 		text-align: right;
 		top: 0;
 		font-weight: bold;
+		white-space: nowrap;
 
 		#{$block}.is-draft & {
 			opacity: .62;

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -68,7 +68,7 @@ const QuestionEdit = ( props ) => {
 	const showContent = title || hasSelected || isSingle;
 
 	const questionIndex = ! isSingle && (
-		<h2 className="sensei-lms-question-block__index">{ index + 1 }.</h2>
+		<h2 className="sensei-lms-question-block__index">{ index }.</h2>
 	);
 
 	const questionGrade = (

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -9,7 +9,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useQuestionIndex } from '../question-index';
+import { useQuestionNumber } from '../question-number';
 import SingleLineInput from '../../../shared/blocks/single-line-input';
 import { useHasSelected } from '../../../shared/helpers/blocks';
 import types from '../answer-blocks';
@@ -60,7 +60,7 @@ const QuestionEdit = ( props ) => {
 		}
 	}, [ clientId, selectBlock ] );
 
-	const index = useQuestionIndex( clientId );
+	const questionNumber = useQuestionNumber( clientId );
 	const AnswerBlock = type && types[ type ];
 
 	const hasSelected = useHasSelected( props );
@@ -68,7 +68,9 @@ const QuestionEdit = ( props ) => {
 	const showContent = title || hasSelected || isSingle;
 
 	const questionIndex = ! isSingle && (
-		<h2 className="sensei-lms-question-block__index">{ index }.</h2>
+		<h2 className="sensei-lms-question-block__index">
+			{ questionNumber }.
+		</h2>
 	);
 
 	const questionGrade = (

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -9,7 +9,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useBlockIndex } from '../../../shared/blocks/block-index';
+import { useQuestionIndex } from '../question-index';
 import SingleLineInput from '../../../shared/blocks/single-line-input';
 import { useHasSelected } from '../../../shared/helpers/blocks';
 import types from '../answer-blocks';
@@ -60,7 +60,7 @@ const QuestionEdit = ( props ) => {
 		}
 	}, [ clientId, selectBlock ] );
 
-	const index = useBlockIndex( clientId );
+	const index = useQuestionIndex( clientId );
 	const AnswerBlock = type && types[ type ];
 
 	const hasSelected = useHasSelected( props );

--- a/assets/blocks/quiz/question-categories.js
+++ b/assets/blocks/quiz/question-categories.js
@@ -2,6 +2,12 @@
  * WordPress dependencies
  */
 import { useSelect } from '@wordpress/data';
+import { useMemo } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import { keyBy } from 'lodash';
 
 /**
  * Get the question categories.
@@ -18,23 +24,30 @@ export const useQuestionCategories = () => {
 			}
 		);
 
-		if ( terms && terms.length ) {
-			return terms.map( ( term ) => ( {
+		return terms ?? [];
+	}, [] );
+
+	const unescapedQuestionCategories = useMemo(
+		() =>
+			( questionCategories || [] ).map( ( term ) => ( {
 				...term,
 				name: unescape( term.name ),
-			} ) );
-		}
+			} ) ),
+		[ questionCategories ]
+	);
 
-		return terms;
-	} );
+	const questionCategoriesById = useMemo(
+		() => keyBy( unescapedQuestionCategories ?? [], 'id' ),
+		[ unescapedQuestionCategories ]
+	);
 
 	const getById = ( termId ) => {
-		if ( ! questionCategories || questionCategories.length === 0 ) {
+		if ( ! questionCategoriesById || questionCategoriesById.length === 0 ) {
 			return false;
 		}
 
-		return questionCategories.find( ( term ) => term.id === termId );
+		return questionCategoriesById[ termId ] ?? false;
 	};
 
-	return [ questionCategories, getById ];
+	return [ unescapedQuestionCategories, getById ];
 };

--- a/assets/blocks/quiz/question-categories.js
+++ b/assets/blocks/quiz/question-categories.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Get the question categories.
+ *
+ * @return {Object[]} Term objects.
+ */
+export const useQuestionCategories = () => {
+	const questionCategories = useSelect( ( select ) => {
+		const terms = select( 'core' ).getEntityRecords(
+			'taxonomy',
+			'question-category',
+			{
+				per_page: -1,
+			}
+		);
+
+		if ( terms && terms.length ) {
+			return terms.map( ( term ) => ( {
+				...term,
+				name: unescape( term.name ),
+			} ) );
+		}
+
+		return terms;
+	} );
+
+	const getById = ( termId ) => {
+		if ( ! questionCategories || questionCategories.length === 0 ) {
+			return false;
+		}
+
+		return questionCategories.find( ( term ) => term.id === termId );
+	};
+
+	return [ questionCategories, getById ];
+};

--- a/assets/blocks/quiz/question-index.js
+++ b/assets/blocks/quiz/question-index.js
@@ -4,12 +4,12 @@
 import { useSelect } from '@wordpress/data';
 
 /**
- * Get the current index (order) of the block in the block list.
+ * Get the current index (order) of the question block in a quiz.
  *
  * @param {string} clientId Block Client Id.
  * @return {number} Block index
  */
-export const useBlockIndex = ( clientId ) =>
+export const useQuestionIndex = ( clientId ) =>
 	useSelect(
 		( select ) => {
 			let number = 0;

--- a/assets/blocks/quiz/question-index.js
+++ b/assets/blocks/quiz/question-index.js
@@ -9,30 +9,33 @@ import { useSelect } from '@wordpress/data';
  * @param {string} clientId Block Client Id.
  * @return {number} Block index
  */
-export const useQuestionIndex = ( clientId ) =>
-	useSelect(
+export const useQuestionIndex = ( clientId ) => {
+	const blocks = useSelect(
 		( select ) => {
-			let number = 0;
 			const store = select( 'core/block-editor' );
-			const blocks = store.getBlocks(
-				store.getBlockRootClientId( clientId )
-			);
-
-			blocks.every( ( block ) => {
-				number++;
-
-				if ( block.clientId === clientId ) {
-					return false;
-				}
-
-				if ( block.name === 'sensei-lms/quiz-category-question' ) {
-					number += block.attributes.options?.number - 1 ?? 0;
-				}
-
-				return true;
-			} );
-
-			return number;
+			return store.getBlocks( store.getBlockRootClientId( clientId ) );
 		},
 		[ clientId ]
 	);
+
+	let number = 0;
+	if ( ! blocks || blocks.length === 0 ) {
+		return 1;
+	}
+
+	blocks.every( ( block ) => {
+		number++;
+
+		if ( block.clientId === clientId ) {
+			return false;
+		}
+
+		if ( block.name === 'sensei-lms/quiz-category-question' ) {
+			number += block.attributes.options?.number - 1 ?? 0;
+		}
+
+		return true;
+	} );
+
+	return number;
+};

--- a/assets/blocks/quiz/question-number.js
+++ b/assets/blocks/quiz/question-number.js
@@ -4,12 +4,12 @@
 import { useSelect } from '@wordpress/data';
 
 /**
- * Get the current index (order) of the question block in a quiz.
+ * Get the current number (order) of the question block in a quiz.
  *
  * @param {string} clientId Block Client Id.
  * @return {number} Block index
  */
-export const useQuestionIndex = ( clientId ) => {
+export const useQuestionNumber = ( clientId ) => {
 	const blocks = useSelect(
 		( select ) => {
 			const store = select( 'core/block-editor' );

--- a/assets/blocks/quiz/quiz-block/next-question-index.js
+++ b/assets/blocks/quiz/quiz-block/next-question-index.js
@@ -1,0 +1,33 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import { isQuestionEmpty } from '../data';
+
+/**
+ * Get the next question index.
+ *
+ * @param {string} clientId The client ID.
+ *
+ * @return {number} Next question index.
+ */
+export const useNextQuestionIndex = ( clientId ) => {
+	const questionBlocks = useSelect(
+		( select ) => select( 'core/block-editor' ).getBlocks( clientId ),
+		[]
+	);
+
+	const lastBlock =
+		questionBlocks.length && questionBlocks[ questionBlocks.length - 1 ];
+
+	const hasEmptyLastBlock =
+		lastBlock && isQuestionEmpty( lastBlock.attributes );
+
+	return hasEmptyLastBlock
+		? questionBlocks.length - 1
+		: questionBlocks.length;
+};

--- a/assets/blocks/quiz/quiz-block/questions-modal/index.js
+++ b/assets/blocks/quiz/quiz-block/questions-modal/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { useState } from '@wordpress/element';
-import { useSelect } from '@wordpress/data';
 import { Notice, Modal } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
@@ -12,11 +11,7 @@ import { __ } from '@wordpress/i18n';
 import Filter from './filter';
 import Questions from './questions';
 import Actions from './actions';
-
-/**
- * External dependencies
- */
-import { unescape } from 'lodash';
+import { useQuestionCategories } from '../../question-categories';
 
 /**
  * Questions modal content.
@@ -35,24 +30,7 @@ const QuestionsModal = ( { onClose, onSelect } ) => {
 	const [ errorAddingSelected, setErrorAddingSelected ] = useState( false );
 	const [ selectedQuestionIds, setSelectedQuestionIds ] = useState( [] );
 
-	const questionCategories = useSelect( ( select ) => {
-		const terms = select( 'core' ).getEntityRecords(
-			'taxonomy',
-			'question-category',
-			{
-				per_page: -1,
-			}
-		);
-
-		if ( terms && terms.length ) {
-			return terms.map( ( term ) => ( {
-				...term,
-				name: unescape( term.name ),
-			} ) );
-		}
-
-		return terms;
-	} );
+	const [ questionCategories ] = useQuestionCategories();
 
 	return (
 		<Modal

--- a/assets/blocks/quiz/quiz-block/quiz-appender.js
+++ b/assets/blocks/quiz/quiz-block/quiz-appender.js
@@ -30,6 +30,28 @@ const QuizAppender = ( { clientId } ) => {
 	const addNewQuestionBlock = ( block ) =>
 		insertBlock( createBlock( block.name ), undefined, clientId, true );
 
+	const controls = [
+		{
+			title: __( 'New Question', 'sensei-lms' ),
+			icon: questionBlock.icon,
+			onClick: () => addNewQuestionBlock( questionBlock ),
+		},
+	];
+
+	if ( window.sensei_quiz_blocks.category_question_enabled ) {
+		controls.push( {
+			title: __( 'Category Question(s)', 'sensei-lms' ),
+			icon: quizIcon,
+			onClick: () => addNewQuestionBlock( categoryQuestionBlock ),
+		} );
+	}
+
+	controls.push( {
+		title: __( 'Existing Question(s)', 'sensei-lms' ),
+		icon: quizIcon,
+		onClick: () => setModalOpen( true ),
+	} );
+
 	return (
 		<div className="sensei-lms-quiz-block__appender block-editor-default-block-appender">
 			<DropdownMenu
@@ -38,24 +60,7 @@ const QuizAppender = ( { clientId } ) => {
 					className: 'block-editor-inserter__toggle',
 				} }
 				label={ __( 'Add Block', 'sensei-lms' ) }
-				controls={ [
-					{
-						title: __( 'New Question', 'sensei-lms' ),
-						icon: questionBlock.icon,
-						onClick: () => addNewQuestionBlock( questionBlock ),
-					},
-					{
-						title: __( 'New Category Question', 'sensei-lms' ),
-						icon: quizIcon,
-						onClick: () =>
-							addNewQuestionBlock( categoryQuestionBlock ),
-					},
-					{
-						title: __( 'Existing Question(s)', 'sensei-lms' ),
-						icon: quizIcon,
-						onClick: () => setModalOpen( true ),
-					},
-				] }
+				controls={ controls }
 			/>
 			<p
 				className="sensei-lms-quiz-block__appender__placeholder"

--- a/assets/blocks/quiz/quiz-block/quiz-appender.js
+++ b/assets/blocks/quiz/quiz-block/quiz-appender.js
@@ -12,6 +12,7 @@ import { plus } from '@wordpress/icons';
  */
 import quizIcon from '../../../icons/quiz-icon';
 import questionBlock from '../question-block';
+import categoryQuestionBlock from '../category-question-block';
 import QuestionsModal from './questions-modal';
 import { useAddExistingQuestions } from './use-add-existing-questions';
 
@@ -26,13 +27,8 @@ const QuizAppender = ( { clientId } ) => {
 	const { insertBlock } = useDispatch( 'core/block-editor' );
 	const [ isModalOpen, setModalOpen ] = useState( false );
 
-	const addNewQuestionBlock = () =>
-		insertBlock(
-			createBlock( questionBlock.name ),
-			undefined,
-			clientId,
-			true
-		);
+	const addNewQuestionBlock = ( block ) =>
+		insertBlock( createBlock( block.name ), undefined, clientId, true );
 
 	return (
 		<div className="sensei-lms-quiz-block__appender block-editor-default-block-appender">
@@ -46,7 +42,13 @@ const QuizAppender = ( { clientId } ) => {
 					{
 						title: __( 'New Question', 'sensei-lms' ),
 						icon: questionBlock.icon,
-						onClick: addNewQuestionBlock,
+						onClick: () => addNewQuestionBlock( questionBlock ),
+					},
+					{
+						title: __( 'New Category Question', 'sensei-lms' ),
+						icon: quizIcon,
+						onClick: () =>
+							addNewQuestionBlock( categoryQuestionBlock ),
 					},
 					{
 						title: __( 'Existing Question(s)', 'sensei-lms' ),

--- a/assets/blocks/quiz/quiz-block/quiz-appender.js
+++ b/assets/blocks/quiz/quiz-block/quiz-appender.js
@@ -15,6 +15,7 @@ import questionBlock from '../question-block';
 import categoryQuestionBlock from '../category-question-block';
 import QuestionsModal from './questions-modal';
 import { useAddExistingQuestions } from './use-add-existing-questions';
+import { useNextQuestionIndex } from './next-question-index';
 
 /**
  * Quiz block inserter for adding new or existing questions.
@@ -26,9 +27,16 @@ const QuizAppender = ( { clientId } ) => {
 	const addExistingQuestions = useAddExistingQuestions( clientId );
 	const { insertBlock } = useDispatch( 'core/block-editor' );
 	const [ isModalOpen, setModalOpen ] = useState( false );
+	const nextInsertIndex = useNextQuestionIndex( clientId );
 
-	const addNewQuestionBlock = ( block ) =>
-		insertBlock( createBlock( block.name ), undefined, clientId, true );
+	const addNewQuestionBlock = ( block ) => {
+		insertBlock(
+			createBlock( block.name ),
+			nextInsertIndex,
+			clientId,
+			true
+		);
+	};
 
 	const controls = [
 		{

--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -37,7 +37,10 @@ const QuizEdit = ( props ) => {
 				<span>{ __( 'Lesson Quiz', 'sensei-lms' ) }</span>
 			</div>
 			<InnerBlocks
-				allowedBlocks={ [ 'sensei-lms/quiz-question' ] }
+				allowedBlocks={ [
+					'sensei-lms/quiz-question',
+					'sensei-lms/quiz-category-question',
+				] }
 				template={
 					isPostTemplate ? [ [ 'sensei-lms/quiz-question', {} ] ] : []
 				}

--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -13,6 +13,7 @@ import { useQuizStructure } from '../quiz-store';
 import QuizAppender from './quiz-appender';
 import QuizSettings from './quiz-settings';
 import { useUpdateQuizHasQuestionsMeta } from './use-update-quiz-has-questions-meta';
+import { isQuestionEmpty } from '../data';
 
 /**
  * Quiz block editor.
@@ -23,7 +24,11 @@ const QuizEdit = ( props ) => {
 	useQuizStructure( props );
 
 	useAutoInserter(
-		{ name: questionBlock.name, selectFirstBlock: true },
+		{
+			name: questionBlock.name,
+			selectFirstBlock: true,
+			isEmptyBlock: isQuestionEmpty,
+		},
 		props
 	);
 

--- a/assets/blocks/quiz/quiz-block/use-add-existing-questions.js
+++ b/assets/blocks/quiz/quiz-block/use-add-existing-questions.js
@@ -7,11 +7,8 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import {
-	createQuestionBlock,
-	findQuestionBlock,
-	isQuestionEmpty,
-} from '../data';
+import { createQuestionBlock, findQuestionBlock } from '../data';
+import { useNextQuestionIndex } from './next-question-index';
 
 const API_PATH = '/sensei-internal/v1/question-options';
 
@@ -24,6 +21,7 @@ const API_PATH = '/sensei-internal/v1/question-options';
 export const useAddExistingQuestions = ( clientId ) => {
 	const questionBlocks = select( 'core/block-editor' ).getBlocks( clientId );
 	const { insertBlock } = useDispatch( 'core/block-editor' );
+	const nextInsertIndex = useNextQuestionIndex( clientId );
 
 	return ( questionIds ) => {
 		const newQuestionIds = questionIds.filter( ( questionId ) => {
@@ -38,17 +36,7 @@ export const useAddExistingQuestions = ( clientId ) => {
 		}
 
 		// Put this before the auto-block.
-		const lastBlock =
-			questionBlocks.length &&
-			questionBlocks[ questionBlocks.length - 1 ];
-		const hasEmptyLastBlock =
-			lastBlock && isQuestionEmpty( lastBlock.attributes );
-
-		let insertIndex = questionBlocks.length;
-
-		if ( hasEmptyLastBlock ) {
-			insertIndex -= 1;
-		}
+		let insertIndex = nextInsertIndex;
 
 		return apiFetch( {
 			path: API_PATH + '?question_ids=' + newQuestionIds.join( ',' ),

--- a/assets/blocks/quiz/quiz-block/use-add-existing-questions.js
+++ b/assets/blocks/quiz/quiz-block/use-add-existing-questions.js
@@ -7,7 +7,11 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import { createQuestionBlock, findQuestionBlock } from '../data';
+import {
+	createQuestionBlock,
+	findQuestionBlock,
+	isQuestionEmpty,
+} from '../data';
 
 const API_PATH = '/sensei-internal/v1/question-options';
 
@@ -37,7 +41,8 @@ export const useAddExistingQuestions = ( clientId ) => {
 		const lastBlock =
 			questionBlocks.length &&
 			questionBlocks[ questionBlocks.length - 1 ];
-		const hasEmptyLastBlock = lastBlock && ! lastBlock.attributes.title;
+		const hasEmptyLastBlock =
+			lastBlock && isQuestionEmpty( lastBlock.attributes );
 
 		let insertIndex = questionBlocks.length;
 

--- a/assets/blocks/quiz/quiz-block/use-update-quiz-has-questions-meta.js
+++ b/assets/blocks/quiz/quiz-block/use-update-quiz-has-questions-meta.js
@@ -5,6 +5,11 @@ import { useCallback, useEffect } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 
 /**
+ * Internal dependencies
+ */
+import { isQuestionEmpty } from '../data';
+
+/**
  * Monitor for questions and disable the lesson quiz when none have been added.
  *
  * @param {string} clientId The quiz block client id.
@@ -14,7 +19,7 @@ export const useUpdateQuizHasQuestionsMeta = ( clientId ) => {
 	const questionBlocks = useSelect( ( select ) =>
 		select( 'core/block-editor' )
 			.getBlocks( clientId )
-			.filter( ( block ) => !! block.attributes.title )
+			.filter( ( block ) => ! isQuestionEmpty( block.attributes ) )
 	);
 
 	const { editedValue: quizHasQuestionsMeta, currentValue } = useSelect(

--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -26,6 +26,7 @@ const READ_ONLY_ATTRIBUTES = [
 	'shared',
 	'options.studentHelp',
 	'media',
+	'categoryName',
 ];
 
 /**

--- a/assets/shared/blocks/block-index.js
+++ b/assets/shared/blocks/block-index.js
@@ -12,11 +12,27 @@ import { useSelect } from '@wordpress/data';
 export const useBlockIndex = ( clientId ) =>
 	useSelect(
 		( select ) => {
+			let number = 0;
 			const store = select( 'core/block-editor' );
-			return store.getBlockIndex(
-				clientId,
+			const blocks = store.getBlocks(
 				store.getBlockRootClientId( clientId )
 			);
+
+			blocks.every( ( block ) => {
+				number++;
+
+				if ( block.clientId === clientId ) {
+					return false;
+				}
+
+				if ( block.name === 'sensei-lms/quiz-category-question' ) {
+					number += block.attributes.options?.number - 1 ?? 0;
+				}
+
+				return true;
+			} );
+
+			return number;
 		},
 		[ clientId ]
 	);

--- a/assets/shared/blocks/use-auto-inserter.js
+++ b/assets/shared/blocks/use-auto-inserter.js
@@ -12,14 +12,15 @@ import { noop } from 'lodash';
 /**
  * Insert an empty inner block to the end of the block when it's selected.
  *
- * @param {Object}  opts
- * @param {string}  opts.name             Block to be inserted.
- * @param {boolean} opts.selectFirstBlock Select inserted block if it's the first one.
- * @param {Object}  opts.attributes       Attributes of a new block.
- * @param {Object}  parentProps           Block properties.
+ * @param {Object}   opts
+ * @param {string}   opts.name             Block to be inserted.
+ * @param {boolean}  opts.selectFirstBlock Select inserted block if it's the first one.
+ * @param {Object}   opts.attributes       Attributes of a new block.
+ * @param {Function} opts.isEmptyBlock     Callback to check if block is empty.
+ * @param {Object}   parentProps           Block properties.
  */
 export const useAutoInserter = (
-	{ name, attributes = {}, selectFirstBlock = false },
+	{ name, attributes = {}, selectFirstBlock = false, isEmptyBlock },
 	parentProps
 ) => {
 	const { clientId } = parentProps;
@@ -50,7 +51,7 @@ export const useAutoInserter = (
 	] );
 
 	const lastBlock = blocks.length && blocks[ blocks.length - 1 ];
-	const hasEmptyLastBlock = lastBlock && ! lastBlock.attributes.title;
+	const hasEmptyLastBlock = lastBlock && isEmptyBlock( lastBlock.attributes );
 
 	useEffect( () => {
 		if ( ! hasEmptyLastBlock ) {

--- a/assets/shared/blocks/use-auto-inserter.test.js
+++ b/assets/shared/blocks/use-auto-inserter.test.js
@@ -23,7 +23,13 @@ jest.mock( '@wordpress/data', () => ( {
 
 describe( 'useAutoInserter', () => {
 	const ModuleBlock = ( props ) => {
-		useAutoInserter( { name: 'sensei-lms/course-outline-lesson' }, props );
+		useAutoInserter(
+			{
+				name: 'sensei-lms/course-outline-lesson',
+				isEmptyBlock: ( attributes ) => ! attributes.title,
+			},
+			props
+		);
 		return <div>Module</div>;
 	};
 

--- a/includes/blocks/class-sensei-block-quiz-category-question.php
+++ b/includes/blocks/class-sensei-block-quiz-category-question.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * File containing the Sensei_Block_Quiz_Category_Question class.
+ *
+ * @package sensei
+ * @since 3.9.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Block_Quiz_Category_Question is responsible for handling the 'Category Question' block.
+ */
+class Sensei_Block_Quiz_Category_Question {
+
+	/**
+	 * Sensei_Block_Quiz_Category_Question constructor.
+	 */
+	public function __construct() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/quiz-category-question',
+			[
+				'render_callback' => [ $this, 'render_quiz_category_question' ],
+			],
+			Sensei()->assets->src_path( 'blocks/quiz/category-question-block' )
+		);
+	}
+
+	/**
+	 * Renders the block as an empty string.
+	 *
+	 * @param array  $attributes The block attributes.
+	 * @param string $content    The block content.
+	 *
+	 * @return string The block HTML.
+	 */
+	public function render_quiz_category_question( array $attributes, string $content ) : string {
+		return '';
+	}
+}

--- a/includes/blocks/class-sensei-quiz-blocks.php
+++ b/includes/blocks/class-sensei-quiz-blocks.php
@@ -33,6 +33,8 @@ class Sensei_Quiz_Blocks extends Sensei_Blocks_Initializer {
 
 		Sensei()->assets->enqueue( 'sensei-quiz-blocks', 'blocks/quiz/index.js', [], true );
 		Sensei()->assets->enqueue( 'sensei-quiz-blocks-editor', 'blocks/quiz/quiz.editor.css', [ 'sensei-shared-blocks-editor-style', 'sensei-editor-components-style' ] );
+
+		wp_localize_script( 'sensei-quiz-blocks', 'sensei_quiz_blocks', [ 'category_question_enabled' => Sensei()->feature_flags->is_enabled( 'block_editor_enable_category_questions' ) ] );
 	}
 
 	/**
@@ -53,7 +55,10 @@ class Sensei_Quiz_Blocks extends Sensei_Blocks_Initializer {
 
 		new Sensei_Block_Quiz();
 		new Sensei_Block_Quiz_Question();
-		new Sensei_Block_Quiz_Category_Question();
+
+		if ( Sensei()->feature_flags->is_enabled( 'block_editor_enable_category_questions' ) ) {
+			new Sensei_Block_Quiz_Category_Question();
+		}
 
 		$post_type_object = get_post_type_object( 'question' );
 

--- a/includes/blocks/class-sensei-quiz-blocks.php
+++ b/includes/blocks/class-sensei-quiz-blocks.php
@@ -53,6 +53,7 @@ class Sensei_Quiz_Blocks extends Sensei_Blocks_Initializer {
 
 		new Sensei_Block_Quiz();
 		new Sensei_Block_Quiz_Question();
+		new Sensei_Block_Quiz_Category_Question();
 
 		$post_type_object = get_post_type_object( 'question' );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Completes the MVP of the question category block design. Initial design is a bit wanting, but it at least shouldn't break things.
* Adds the question category block to the inserter.
* Creates a new helper `isQuestionEmpty` now that some blocks don't have titles.
* Edits the current behavior by allowing a value for `Number of Questions` that is greater than the number of questions currently in the category. It warns them instead.
   * This is to fix a lot of weird issues that could happen if the category question is added but then the questions removed from category.
   * I also think it makes sense, since this is a dynamic placeholder. Questions can be added and removed and the quiz needs to handle that. It might make more sense to say "Maximum Number of Questions"
   * I think we safeguard weird selection things happen on the frontend, so that shouldn't be an issue.

I'm going to wait until the base class gets merged before putting this up for review.

### Testing instructions

* Open a quiz made in the metabox editor that has a category question. Ensure it shows up correctly and can be edited.
* Add a new category question and ensure it can be reordered and saved.

### Screenshots
<img width="737" alt="Screen Shot 2021-03-17 at 2 39 04 pm" src="https://user-images.githubusercontent.com/68693/111485453-897f5180-872e-11eb-9161-09763b52ddfe.png">
<img width="276" alt="Screen Shot 2021-03-17 at 2 39 27 pm" src="https://user-images.githubusercontent.com/68693/111485522-969c4080-872e-11eb-850f-8a36612c621a.png">
<img width="285" alt="Screen Shot 2021-03-17 at 2 40 41 pm" src="https://user-images.githubusercontent.com/68693/111485703-c3505800-872e-11eb-96d8-900d10f56542.png">
