### PR TITLE
Change gap fill before/after to plain text input

### DIFF
--- a/assets/blocks/quiz/answer-blocks/gap-fill.js
+++ b/assets/blocks/quiz/answer-blocks/gap-fill.js
@@ -1,9 +1,13 @@
 /**
  * WordPress dependencies
  */
-import { RichText } from '@wordpress/block-editor';
 import { FormTokenField } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import SingleLineInput from '../../../shared/blocks/single-line-input/single-line-input';
 
 /**
  * Question block gap fill answer component.
@@ -24,7 +28,7 @@ const GapFillAnswer = ( {
 	return (
 		<ul className="sensei-lms-question-block__answer sensei-lms-question-block__answer--gap-fill">
 			<li>
-				<RichText
+				<SingleLineInput
 					className="sensei-lms-question-block__answer--gap-fill__text"
 					placeholder={ __( 'Text before the gap', 'sensei-lms' ) }
 					value={ before }
@@ -54,7 +58,7 @@ const GapFillAnswer = ( {
 				) }
 			</li>
 			<li>
-				<RichText
+				<SingleLineInput
 					className="sensei-lms-question-block__answer--gap-fill__text"
 					placeholder={ __( 'Text after the gap', 'sensei-lms' ) }
 					value={ after }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Changes the before/after to plain text input.
* RichText was causing issues and HTML is currently escaped in the template.
