### PR TITLE
Fix existing questions modal autoclosed

### DIFF
--- a/assets/blocks/quiz/quiz-block/questions-modal/actions.js
+++ b/assets/blocks/quiz/quiz-block/questions-modal/actions.js
@@ -34,8 +34,6 @@ const Actions = ( {
 			.then( closeModal )
 			.catch( () => {
 				setErrorAddingSelected( true );
-			} )
-			.finally( () => {
 				setIsAddingSelected( false );
 			} );
 	};

--- a/assets/blocks/quiz/quiz-block/questions-modal/index.js
+++ b/assets/blocks/quiz/quiz-block/questions-modal/index.js
@@ -19,13 +19,20 @@ import Actions from './actions';
 import { unescape } from 'lodash';
 
 /**
+ * Internal dependencies
+ */
+import { useAddExistingQuestions } from '../use-add-existing-questions';
+
+/**
  * Questions modal content.
  *
  * @param {Object}   props
- * @param {Function} props.onClose  Close callback
- * @param {Function} props.onSelect Callback to add selected questions.
+ * @param {string}   props.clientId Quiz block ID.
+ * @param {Function} props.onClose  Close callback.
  */
-const QuestionsModal = ( { onClose, onSelect } ) => {
+const QuestionsModal = ( { clientId, onClose } ) => {
+	const addExistingQuestions = useAddExistingQuestions( clientId );
+
 	const [ filters, setFilters ] = useState( {
 		search: '',
 		'question-type': '',
@@ -86,7 +93,7 @@ const QuestionsModal = ( { onClose, onSelect } ) => {
 			<Actions
 				selectedQuestionIds={ selectedQuestionIds }
 				setSelectedQuestionIds={ setSelectedQuestionIds }
-				onAdd={ onSelect }
+				onAdd={ addExistingQuestions }
 				closeModal={ onClose }
 				setErrorAddingSelected={ setErrorAddingSelected }
 			/>

--- a/assets/blocks/quiz/quiz-block/quiz-appender.js
+++ b/assets/blocks/quiz/quiz-block/quiz-appender.js
@@ -4,27 +4,24 @@
 import { createBlock } from '@wordpress/blocks';
 import { DropdownMenu } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
-import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { plus } from '@wordpress/icons';
+
 /**
  * Internal dependencies
  */
 import quizIcon from '../../../icons/quiz-icon';
 import questionBlock from '../question-block';
-import QuestionsModal from './questions-modal';
-import { useAddExistingQuestions } from './use-add-existing-questions';
 
 /**
  * Quiz block inserter for adding new or existing questions.
  *
- * @param {Object} props
- * @param {string} props.clientId Quiz block ID.
+ * @param {Object}   props
+ * @param {string}   props.clientId  Quiz block ID.
+ * @param {Function} props.openModal Open modal callback.
  */
-const QuizAppender = ( { clientId } ) => {
-	const addExistingQuestions = useAddExistingQuestions( clientId );
+const QuizAppender = ( { clientId, openModal } ) => {
 	const { insertBlock } = useDispatch( 'core/block-editor' );
-	const [ isModalOpen, setModalOpen ] = useState( false );
 
 	const addNewQuestionBlock = () =>
 		insertBlock(
@@ -51,7 +48,7 @@ const QuizAppender = ( { clientId } ) => {
 					{
 						title: __( 'Existing Question(s)', 'sensei-lms' ),
 						icon: quizIcon,
-						onClick: () => setModalOpen( true ),
+						onClick: openModal,
 					},
 				] }
 			/>
@@ -62,13 +59,6 @@ const QuizAppender = ( { clientId } ) => {
 					'sensei-lms'
 				) }
 			/>
-
-			{ isModalOpen && (
-				<QuestionsModal
-					onClose={ () => setModalOpen( false ) }
-					onSelect={ addExistingQuestions }
-				/>
-			) }
 		</div>
 	);
 };

--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -3,6 +3,7 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -11,6 +12,7 @@ import { useAutoInserter } from '../../../shared/blocks/use-auto-inserter';
 import questionBlock from '../question-block';
 import { useQuizStructure } from '../quiz-store';
 import QuizAppender from './quiz-appender';
+import QuestionsModal from './questions-modal';
 import QuizSettings from './quiz-settings';
 import { useUpdateQuizHasQuestionsMeta } from './use-update-quiz-has-questions-meta';
 
@@ -20,6 +22,7 @@ import { useUpdateQuizHasQuestionsMeta } from './use-update-quiz-has-questions-m
  * @param {Object} props
  */
 const QuizEdit = ( props ) => {
+	const { clientId } = props;
 	useQuizStructure( props );
 
 	useAutoInserter(
@@ -27,9 +30,20 @@ const QuizEdit = ( props ) => {
 		props
 	);
 
-	useUpdateQuizHasQuestionsMeta( props.clientId );
+	useUpdateQuizHasQuestionsMeta( clientId );
+
+	const [
+		isExistingQuestionsModalOpen,
+		setExistingQuestionsModalOpen,
+	] = useState( false );
 
 	const { isPostTemplate } = props.attributes;
+
+	const openExistingQuestionsModal = () =>
+		setExistingQuestionsModalOpen( true );
+
+	const closeExistingQuestionsModal = () =>
+		setExistingQuestionsModalOpen( false );
 
 	return (
 		<>
@@ -42,8 +56,19 @@ const QuizEdit = ( props ) => {
 					isPostTemplate ? [ [ 'sensei-lms/quiz-question', {} ] ] : []
 				}
 				templateInsertUpdatesSelection={ false }
-				renderAppender={ () => <QuizAppender { ...props } /> }
+				renderAppender={ () => (
+					<QuizAppender
+						clientId={ clientId }
+						openModal={ openExistingQuestionsModal }
+					/>
+				) }
 			/>
+			{ isExistingQuestionsModalOpen && (
+				<QuestionsModal
+					clientId={ clientId }
+					onClose={ closeExistingQuestionsModal }
+				/>
+			) }
 			<div className="sensei-lms-quiz-block__separator" />
 			<QuizSettings { ...props } />
 		</>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This fixes an issue that the existing questions modal was being closed automatically after inserting the blocks.
  * The issue happened because the modal was being unmounted, and we were updating some states when it was unmounted.
  * Basically the safer solution is to render the modal in the parent component instead trust in the `renderAppender` for that, and also control the open/close state there.

### Testing instructions

* Just use the Existing Questions modal, add some questions, and make sure it's working properly. Check the browser console to make sure no errors happen.

### Video with the error


https://user-images.githubusercontent.com/876340/111369630-0dc1ce00-8676-11eb-9fc9-c33c48b55966.mov

