### PR TITLE
Avoid overriding non-editable question

### DIFF
--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import { camelCase, snakeCase, omit, keyBy } from 'lodash';
+
+/**
  * WordPress dependencies
  */
 import { dispatch, select, useDispatch } from '@wordpress/data';
@@ -14,10 +19,6 @@ import {
 	syncQuestionBlocks,
 	normalizeAttributes,
 } from './data';
-/**
- * External dependencies
- */
-import { camelCase, snakeCase, omit } from 'lodash';
 
 export const QUIZ_STORE = 'sensei/quiz-structure';
 
@@ -110,10 +111,18 @@ registerStructureStore( {
 
 		const questionBlockAttributes = parseQuestionBlocks( questionBlocks );
 
+		const serverQuestionsById = keyBy(
+			select( QUIZ_STORE ).getServerStructure().questions,
+			'id'
+		);
+
 		return {
 			options,
 			questions: questionBlockAttributes.map( ( question ) =>
-				omit( question, READ_ONLY_ATTRIBUTES )
+				// Avoid overriding non-editable question.
+				question.editable
+					? omit( question, READ_ONLY_ATTRIBUTES )
+					: serverQuestionsById[ question.id ]
 			),
 		};
 	},


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix an issue that caused an infinite saving loop on quizzes when having non-editable questions.
  * The solution was using the original question object when it's not editable.

### Testing instructions

1. Use the filter `sensei_quiz_enable_block_based_editor` (returning false) or just `return false` directly in the `Sensei_Quiz::is_block_based_editor_enabled` to force no block editor for questions.
2. Login as admin.
3. Create a course with a lesson, and set the course to a teacher.
4. Create a question, including a description and include the question in the created lesson.
5. Log-in as the teacher.
6. Reactivate the block editor undoing the first step.
7. Go to the lesson page, save it, and make sure it saves properly (without infinite loop).