### PR TITLE
Fix email not sending when a learner starts a course

### DIFF
--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -158,7 +158,7 @@ class Sensei_Templates {
 		 * @since  3.6.0
 		 * @access private
 		 */
-		if ( ! apply_filters( 'sensei_use_sensei_template', true ) ) {
+		if ( ! apply_filters( 'sensei_use_sensei_template', true ) && ! isset( $email_template ) ) {
 			return $template;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This fixes an issue reported by a user where they were seeing the following PHP warning:
```
Filename cannot be empty in wp-content/plugins/sensei-lms/includes/class-sensei-emails.php on line 213
```

This warning prevented an email from being sent to a teacher when a learner started a course.

### Testing instructions

* Ensure the _A learner starts their course_ email notification setting is checked.
* Create a new course.
* As a learner, start taking the course.
* Ensure an email is sent to the teacher informing them that the learner has started the course and that no warning is logged.