### PR TITLE
Add categories to the calc of maximum number of questions in a quiz

### DIFF
--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -16,6 +16,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import NumberControl from '../../editor-components/number-control';
+import { isQuestionEmpty } from '../data';
 
 /**
  * Quiz settings.
@@ -43,18 +44,24 @@ const QuizSettings = ( {
 	const createChangeHandler = ( optionKey ) => ( value ) =>
 		setAttributes( { options: { ...options, [ optionKey ]: value } } );
 
-	const questionCount = useSelect(
-		( select ) => {
-			const count = select( 'core/block-editor' )
+	const questions = useSelect(
+		( select ) =>
+			select( 'core/block-editor' )
 				.getBlock( clientId )
 				.innerBlocks.filter(
 					( questionBlock ) =>
-						undefined !== questionBlock?.attributes?.title
-				).length;
-
-			return count;
-		},
+						! isQuestionEmpty( questionBlock.attributes )
+				),
 		[ clientId ]
+	);
+
+	const questionCount = questions.reduce(
+		( count, question ) =>
+			count +
+			( question.attributes.type === 'category-question'
+				? question.attributes.options.number
+				: 1 ),
+		0
 	);
 
 	useEffect( () => {

--- a/assets/blocks/quiz/quiz-block/quiz-settings.test.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.test.js
@@ -19,7 +19,36 @@ jest.mock( '@wordpress/data', () => {
 	return {
 		combineReducers: module.combineReducers,
 		registerStore: module.registerStore,
-		useSelect: () => 2,
+		useSelect: () => [
+			{
+				attributes: {
+					title: 'Question 1',
+					type: 'multiple-choice',
+				},
+			},
+			{
+				attributes: {
+					title: 'Question 2',
+					type: 'multiple-choice',
+				},
+			},
+			{
+				attributes: {
+					type: 'category-question',
+					options: {
+						number: 2,
+					},
+				},
+			},
+			{
+				attributes: {
+					type: 'category-question',
+					options: {
+						number: 3,
+					},
+				},
+			},
+		],
 	};
 } );
 
@@ -69,6 +98,18 @@ describe( '<QuizSettings />', () => {
 		);
 
 		expect( queryByLabelText( 'Passing Grade (%)' ) ).toBeFalsy();
+	} );
+
+	it( 'Should have the maximum number of questions defined by the the number of questions added to the quiz', () => {
+		const { queryByLabelText } = render(
+			<QuizSettings
+				attributes={ {
+					options: {},
+				} }
+			/>
+		);
+
+		expect( queryByLabelText( 'Number of Questions' ).max ).toEqual( '7' );
 	} );
 
 	it( 'Should call the setAttributes correctly when changing the fields', () => {


### PR DESCRIPTION
Based on https://github.com/Automattic/sensei/pull/4080

~~It doesn't add any feature flag (removed in https://github.com/Automattic/sensei/pull/4088). So I think we could wait to merge it until we confirm we go ahead with the categories, otherwise, I can add the feature flag here too.~~ EDIT: Actually it's not a big deal to don't have the feature flag here because of the code has backward compatibility.

### Changes proposed in this Pull Request

* Fix the maximum number of questions in the quiz to calc with categories.
  * In the https://github.com/Automattic/sensei/pull/4080, the label "Maximum Number of Questions" was suggested because the user can remove questions from the categories, but it wasn't changed for now, so I kept the same label in the Quiz settings.

### Testing instructions

* Add questions and categories with different number of questions.
* Select the quiz block, check the input "Number of questions" in the settings, and make sure the maximum number is the maximum number of questions added to the quiz, considering the category questions.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1230" alt="Screen Shot 2021-03-18 at 11 44 00" src="https://user-images.githubusercontent.com/876340/111645261-49c47280-87df-11eb-9d94-d776a297f98b.png">
