### PR TITLE
Removes user filter temporarily, while running preload queries

### DIFF
--- a/includes/class-sensei-assets.php
+++ b/includes/class-sensei-assets.php
@@ -193,11 +193,15 @@ class Sensei_Assets {
 	 * @param string[] $rest_routes REST routes to preload.
 	 */
 	public function preload_data( $rest_routes ) {
+		// Temporarily removes the user filter when loading from preload.
+		remove_action( 'pre_get_posts', array( Sensei()->teacher, 'filter_queries' ) );
 		$preload_data = array_reduce(
 			$rest_routes,
 			'rest_preload_api_request',
 			[]
 		);
+		add_action( 'pre_get_posts', array( Sensei()->teacher, 'filter_queries' ) );
+
 		wp_add_inline_script(
 			'wp-api-fetch',
 			sprintf( 'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );', wp_json_encode( $preload_data ) ),


### PR DESCRIPTION
### Changes proposed in this Pull Request

* @jom digged into an issue with me, and we figured out that when we introduced the preload to the quiz and course outline, a filter (`Sensei_Teacher::filter_queries`) started being applied for the queries used in the REST (because it wasn't being loaded through the rest, but through the screens).
* Since we don't use this filter in the new stuff we're working on (stuff we use through the `Sensei_Assets::preload_data`), probably it's not a problem to temporarily remove this filter for these cases.

### Testing instructions

* Create a lesson owned by a teacher.
* As admin user, add question owned by the admin to the quiz.
* Access the lesson with the teacher, and make sure you see the questions.