### PR TITLE
Add a temporary solution to a React error in the quiz appender

### DIFF
--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -3,7 +3,7 @@
  */
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useState, useCallback } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -44,11 +44,19 @@ const QuizEdit = ( props ) => {
 		setExistingQuestionsModalOpen,
 	] = useState( false );
 
-	const openExistingQuestionsModal = () =>
-		setExistingQuestionsModalOpen( true );
-
 	const closeExistingQuestionsModal = () =>
 		setExistingQuestionsModalOpen( false );
+
+	/* Temporary solution. See https://github.com/WordPress/gutenberg/pull/29911 */
+	const renderAppenderComponent = useCallback(
+		() => (
+			<QuizAppender
+				clientId={ clientId }
+				openModal={ () => setExistingQuestionsModalOpen( true ) }
+			/>
+		),
+		[ clientId ]
+	);
 
 	return (
 		<>
@@ -62,12 +70,7 @@ const QuizEdit = ( props ) => {
 					'sensei-lms/quiz-category-question',
 				] }
 				templateInsertUpdatesSelection={ false }
-				renderAppender={ () => (
-					<QuizAppender
-						clientId={ clientId }
-						openModal={ openExistingQuestionsModal }
-					/>
-				) }
+				renderAppender={ renderAppenderComponent }
 			/>
 			{ isExistingQuestionsModalOpen && (
 				<QuestionsModal


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It adds a temporary solution because the `renderAppender` should receive a function/class component, instead of a render prop. And we can't use this because we need to send props to the component unless we use context or use the store for these props.
  * The https://github.com/WordPress/gutenberg/pull/29911 PR fixes it adding support to render prop, but if it's merged we still need to wait until we support all versions with the fix.

### Testing instructions

* Create a lesson, and open the browser console.
* Click on the last question.
* Click on the inserter and no errors should happen.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/111702758-86ae5a80-881b-11eb-8199-6c1a416bdc66.mov

