### PR TITLE
Improve handling of module with numbers in title

### DIFF
--- a/tests/unit-tests/admin/tools/test-class-sensei-tool-module-slugs-mismatch.php
+++ b/tests/unit-tests/admin/tools/test-class-sensei-tool-module-slugs-mismatch.php
@@ -28,37 +28,102 @@ class Sensei_Tool_Module_Slugs_Mismatch_Tests extends WP_UnitTestCase {
 	 * Tests to make the slugs are fixed.
 	 */
 	public function testRunFixSlugs() {
-		$args        = [
+		$args = [
 			'slug' => 'wrong-slug',
 		];
-		$term_result = wp_insert_term( 'My module', 'module', $args );
+		wp_insert_term( 'My module', 'module', $args );
 
-		$this->assertNotFalse( get_term_by( 'slug', 'wrong-slug', 'module' ) );
+		self::assertNotFalse( get_term_by( 'slug', 'wrong-slug', 'module' ) );
 		$this->assertFalse( get_term_by( 'slug', 'my-module', 'module' ) );
 
 		$tool = new Sensei_Tool_Module_Slugs_Mismatch();
 		$tool->process();
 
 		$this->assertFalse( get_term_by( 'slug', 'wrong-slug', 'module' ) );
-		$this->assertNotFalse( get_term_by( 'slug', 'my-module', 'module' ) );
+		self::assertNotFalse( get_term_by( 'slug', 'my-module', 'module' ) );
 	}
 
 	/**
 	 * Tests to make the slugs are fixed keeping the teacher ID prefix.
 	 */
 	public function testRunFixSlugsKeepingTeacherIDPrefix() {
-		$args        = [
+		$args = [
 			'slug' => '1-wrong-slug',
 		];
-		$term_result = wp_insert_term( 'My module', 'module', $args );
+		wp_insert_term( 'My module', 'module', $args );
 
-		$this->assertNotFalse( get_term_by( 'slug', '1-wrong-slug', 'module' ) );
+		self::assertNotFalse( get_term_by( 'slug', '1-wrong-slug', 'module' ) );
 		$this->assertFalse( get_term_by( 'slug', '1-my-module', 'module' ) );
 
 		$tool = new Sensei_Tool_Module_Slugs_Mismatch();
 		$tool->process();
 
 		$this->assertFalse( get_term_by( 'slug', '1-wrong-slug', 'module' ) );
-		$this->assertNotFalse( get_term_by( 'slug', '1-my-module', 'module' ) );
+		self::assertNotFalse( get_term_by( 'slug', '1-my-module', 'module' ) );
+	}
+
+	/**
+	 * Tests that modules that have a name which start with a number are not modified by the tool.
+	 */
+	public function testRunModulesWithNumbersInNameNotModified() {
+		wp_insert_term( '01 My module', 'module' );
+		wp_insert_term( '100-200-My module', 'module' );
+
+		self::assertNotFalse( get_term_by( 'slug', '01-my-module', 'module' ) );
+		self::assertNotFalse( get_term_by( 'slug', '100-200-my-module', 'module' ) );
+
+		$tool = new Sensei_Tool_Module_Slugs_Mismatch();
+		$tool->process();
+
+		self::assertNotFalse( get_term_by( 'slug', '01-my-module', 'module' ) );
+		self::assertNotFalse( get_term_by( 'slug', '100-200-my-module', 'module' ) );
+	}
+
+	/**
+	 * Tests that modules which start with a number and have a teacher assigned to them are fixed correctly.
+	 */
+	public function testRunModulesWithNumbersInNameFixedCorrectly() {
+		// The wrong slug begins with a teacher id.
+		$args = [
+			'slug' => '1-wrong-slug',
+		];
+		wp_insert_term( '15 My module', 'module', $args );
+
+		self::assertNotFalse( get_term_by( 'slug', '1-wrong-slug', 'module' ) );
+		$this->assertFalse( get_term_by( 'slug', '1-15-my-module', 'module' ) );
+
+		$tool = new Sensei_Tool_Module_Slugs_Mismatch();
+		$tool->process();
+
+		self::assertNotFalse( get_term_by( 'slug', '1-15-my-module', 'module' ), 'Teacher id was not prepended to the module name.' );
+		$this->assertFalse( get_term_by( 'slug', '1-wrong-slug', 'module' ) );
+
+		// The wrong slug begins with the same numbers as the module name.
+		$args = [
+			'slug' => '15-wrong-slug',
+		];
+		wp_insert_term( '15 My module', 'module', $args );
+
+		self::assertNotFalse( get_term_by( 'slug', '15-wrong-slug', 'module' ) );
+		$this->assertFalse( get_term_by( 'slug', '15-my-module', 'module' ) );
+
+		$tool = new Sensei_Tool_Module_Slugs_Mismatch();
+		$tool->process();
+
+		self::assertNotFalse( get_term_by( 'slug', '15-my-module', 'module' ) );
+		$this->assertFalse( get_term_by( 'slug', '15-wrong-slug', 'module' ) );
+
+		// Test that modules with a name which begins with the teacher's id, are not modified.
+		$args = [
+			'slug' => '15-15-my-module',
+		];
+		wp_insert_term( '15 My module', 'module', $args );
+
+		self::assertNotFalse( get_term_by( 'slug', '15-15-my-module', 'module' ) );
+
+		$tool = new Sensei_Tool_Module_Slugs_Mismatch();
+		$tool->process();
+
+		self::assertNotFalse( get_term_by( 'slug', '15-15-my-module', 'module' ), 'Module with a name which begins with the teacher id has been modified.' );
 	}
 }


### PR DESCRIPTION
There was an issue with the 'Module slugs mismatch' tool in case the module name had numbers in the beggining. In that case `$sanitized_title` variable would begin with a number which would get appended to the backreference of preg_replace and cause weird behaviour.

### Changes proposed in this Pull Request

* Fixes the above issue by switching to `preg_match`. We could use curly braces and keep `preg_replace` but I think that using `preg_match` is a bit easier to understand.
* The number in the beginning of the slug is not prepended if the title begins with the same number. This is to avoid infinitely adding any starting numbers.
* There are still cases that the tool does not work correctly but I don't think that we can make it 100% accurate as long as we store the teacher id in the module slug and allow the users to modify the slug freely.

### Testing instructions

* Create a module with a name which starts with numbers.
* Run the tool and observe that the module slug is not modified.
* Manually modify the module slug and rerun the tool.
* Observe that the module slug is updated to the module title correctly.
* Create a module which is owned by a teacher and repeat the above steps.