### PR TITLE
Fix page "dancing" while clicking on quiz appender

### DIFF
--- a/assets/blocks/quiz/quiz-block/quiz-appender.js
+++ b/assets/blocks/quiz/quiz-block/quiz-appender.js
@@ -59,6 +59,7 @@ const QuizAppender = ( { clientId, openModal } ) => {
 				icon={ plus }
 				toggleProps={ {
 					className: 'block-editor-inserter__toggle',
+					onMouseDown: ( event ) => event.preventDefault(),
 				} }
 				label={ __( 'Add Block', 'sensei-lms' ) }
 				controls={ controls }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes the page "dancing" while clicking on the quiz appended.

### Testing instructions

* Add many question to a quiz until you have a scroll (it was also one of the causes besides the answers toggle).
* Click in the last empty question.
* Click on the appender, and make sure the page doesn't "dance"

More details on how to reproduce it, in the following video.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/111818251-b7df6700-88bd-11eb-9d67-b7dda2ad6e56.mov

