### PR TITLE
Add category question validation

### DIFF
--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { compose } from '@wordpress/compose';
 
 /**
  * Internal dependencies
@@ -10,6 +11,13 @@ import { useQuestionNumber } from '../question-number';
 import { useQuestionCategories } from '../question-categories';
 import CategoryQuestionSettings from './category-question-settings';
 import { useEffect } from '@wordpress/element';
+import { withBlockMeta } from '../../../shared/blocks/block-metadata';
+import { withBlockValidation } from '../../../shared/blocks/block-validation';
+import {
+	validateCategoryQuestionBlock,
+	getCategoryQuestionBlockValidationErrorMessages,
+} from './category-question-validation';
+import { QuestionValidationNotice } from '../question-block/question-block-helpers';
 
 /**
  * Quiz category question block editor.
@@ -82,8 +90,17 @@ const CategoryQuestionEdit = ( props ) => {
 							')' }
 				</h2>
 			</div>
+			<QuestionValidationNotice
+				{ ...props }
+				getErrorMessages={
+					getCategoryQuestionBlockValidationErrorMessages
+				}
+			/>
 		</>
 	);
 };
 
-export default CategoryQuestionEdit;
+export default compose(
+	withBlockMeta,
+	withBlockValidation( validateCategoryQuestionBlock )
+)( CategoryQuestionEdit );

--- a/assets/blocks/quiz/category-question-block/category-question-edit.js
+++ b/assets/blocks/quiz/category-question-block/category-question-edit.js
@@ -61,10 +61,11 @@ const CategoryQuestionEdit = ( props ) => {
 			>
 				{ questionIndex }
 				<h2 className="sensei-lms-question-block__title">
-					<strong>
-						{ categoryName ??
-							__( 'Category Question', 'sensei-lms' ) }
-					</strong>
+					{ categoryName ? (
+						<strong>{ categoryName }</strong>
+					) : (
+						__( 'Category Question', 'sensei-lms' )
+					) }
 					{ categoryName &&
 						number > 0 &&
 						' (' +

--- a/assets/blocks/quiz/category-question-block/category-question-settings.js
+++ b/assets/blocks/quiz/category-question-block/category-question-settings.js
@@ -88,7 +88,7 @@ const CategoryQuestionSettings = ( {
 							onChange={ ( nextNumber ) =>
 								nextNumber &&
 								setOptions( {
-									number: nextNumber,
+									number: nextNumber || 1,
 								} )
 							}
 						/>

--- a/assets/blocks/quiz/category-question-block/category-question-validation.js
+++ b/assets/blocks/quiz/category-question-block/category-question-validation.js
@@ -1,0 +1,28 @@
+/**
+ * Internal dependencies
+ */
+import blockSettings from '.';
+
+/**
+ * Validate category question block.
+ *
+ * @param {Object} attributes Block attributes.
+ * @return {Array} Validation errors.
+ */
+export const validateCategoryQuestionBlock = ( attributes ) => {
+	const { options } = attributes;
+	const hasCategory = options?.category > 0;
+
+	return {
+		noCategory: ! hasCategory,
+	};
+};
+
+/**
+ * Get messages for the validation errors.
+ *
+ * @param {string} errors Error codes.
+ * @return {string} Error message.
+ */
+export const getCategoryQuestionBlockValidationErrorMessages = ( errors ) =>
+	errors.map( ( error ) => blockSettings.messages[ error ] );

--- a/assets/blocks/quiz/category-question-block/index.js
+++ b/assets/blocks/quiz/category-question-block/index.js
@@ -27,4 +27,7 @@ export default {
 	},
 	edit,
 	save: () => <InnerBlocks.Content />,
+	messages: {
+		noCategory: __( 'Assign a category to this question.', 'sensei-lms' ),
+	},
 };

--- a/assets/blocks/quiz/question-block/question-block-helpers.js
+++ b/assets/blocks/quiz/question-block/question-block-helpers.js
@@ -8,7 +8,6 @@ import { Icon, info } from '@wordpress/icons';
  * Internal dependencies
  */
 import { alert } from '../../../icons/wordpress-icons';
-import { getQuestionBlockValidationErrorMessages } from './question-validation';
 
 /**
  * Display a notice about the question being shared across quizzes.
@@ -30,23 +29,22 @@ export const SharedQuestionNotice = () => (
 /**
  * Display validation notice for the question block if there are errors.
  *
- * @param {Object}  props
- * @param {Object}  props.meta
- * @param {Object}  props.attributes
- * @param {string}  props.attributes.type           Question type.
- * @param {Array}   props.meta.validationErrors     Validation errors  codes
- * @param {boolean} props.meta.showValidationErrors Display validation errors.
+ * @param {Object}   props
+ * @param {Object}   props.meta
+ * @param {Object}   props.attributes
+ * @param {string}   props.attributes.type           Question type.
+ * @param {Array}    props.meta.validationErrors     Validation errors  codes
+ * @param {boolean}  props.meta.showValidationErrors Display validation errors.
+ * @param {Function} props.getErrorMessages          Get validation error messages.
  */
 export const QuestionValidationNotice = ( {
 	attributes: { type },
 	meta: { validationErrors, showValidationErrors },
+	getErrorMessages,
 } ) => {
 	if ( ! showValidationErrors || ! validationErrors?.length ) return null;
 
-	const validationMessages = getQuestionBlockValidationErrorMessages(
-		validationErrors,
-		type
-	);
+	const validationMessages = getErrorMessages( validationErrors, type );
 
 	return <BlockValidationNotice errors={ validationMessages } />;
 };

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -10,6 +10,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
  * External dependencies
  */
 import cn from 'classnames';
+
 /**
  * Internal dependencies
  */
@@ -25,7 +26,10 @@ import {
 	SharedQuestionNotice,
 } from './question-block-helpers';
 import { QuestionGradeToolbar } from './question-grade-toolbar';
-import { validateQuestionBlock } from './question-validation';
+import {
+	validateQuestionBlock,
+	getQuestionBlockValidationErrorMessages,
+} from './question-validation';
 import QuestionView from './question-view';
 import QuestionSettings from './question-settings';
 import { QuestionTypeToolbar } from './question-type-toolbar';
@@ -155,7 +159,10 @@ const QuestionEdit = ( props ) => {
 					) }
 				</>
 			) }
-			<QuestionValidationNotice { ...props } />
+			<QuestionValidationNotice
+				{ ...props }
+				getErrorMessages={ getQuestionBlockValidationErrorMessages }
+			/>
 			<BlockControls>
 				<>
 					<QuestionTypeToolbar


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Refactors numbering of questions a bit because I liked' @renatho's `Array.reduce` in quiz settings.
* Made it so the category question title isn't bold until category is selected, per design.
* Fixes an issue with question numbering and clearing out the number of questions field.
* Adds question category validation.

### Testing instructions

* Add a category question to a new lesson quiz.
* Click publish.
* Verify a validation notice shows up below the category question,