### PR TITLE
Update question block validation visuals

### DIFF
--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -84,9 +84,9 @@ const questionTypes = {
 		settings: [ QuestionAnswerFeedbackSettings ],
 		validate: ( { before, after, gap } = {} ) => {
 			return {
+				noGap: ! gap?.length,
 				noBefore: ! before,
 				noAfter: ! after,
-				noGap: ! gap?.length,
 			};
 		},
 		messages: {

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -53,7 +53,7 @@ const questionTypes = {
 		},
 		messages: {
 			noAnswers: __(
-				'Add at least two answer choices to this question.',
+				'Add at least one right and one wrong answer.',
 				'sensei-lms'
 			),
 			noRightAnswer: __(
@@ -90,12 +90,9 @@ const questionTypes = {
 			};
 		},
 		messages: {
-			noBefore: __( 'Add some text before the gap.', 'sensei-lms' ),
-			noAfter: __( 'Add some text after the gap.', 'sensei-lms' ),
-			noGap: __(
-				'Add a right answer for the gap to this question.',
-				'sensei-lms'
-			),
+			noGap: __( 'Add a right answer to this question.', 'sensei-lms' ),
+			noBefore: __( 'Add text before and after the gap.', 'sensei-lms' ),
+			noAfter: __( 'Add text before and after the gap.', 'sensei-lms' ),
 		},
 	},
 	'single-line': {

--- a/assets/blocks/quiz/question-block/question-block-helpers.js
+++ b/assets/blocks/quiz/question-block/question-block-helpers.js
@@ -58,9 +58,7 @@ export const QuestionValidationNotice = ( {
  */
 export const BlockValidationNotice = ( { errors = [] } ) => {
 	if ( ! errors || ! errors.length ) return null;
-	const errorItems = errors?.map?.( ( error ) => (
-		<div key={ error }>{ error }</div>
-	) );
+	const error = errors[ 0 ];
 	return (
 		<div className="sensei-lms-block-validation-notice">
 			<Icon
@@ -68,7 +66,7 @@ export const BlockValidationNotice = ( { errors = [] } ) => {
 				className="sensei-lms-block-validation-notice__icon"
 			/>
 			<div className="sensei-lms-block-validation-notice__issues">
-				{ errorItems }
+				<div key={ error }>{ error }</div>
 			</div>
 		</div>
 	);

--- a/assets/blocks/quiz/question-block/question-block-helpers.js
+++ b/assets/blocks/quiz/question-block/question-block-helpers.js
@@ -59,21 +59,17 @@ export const QuestionValidationNotice = ( {
 export const BlockValidationNotice = ( { errors = [] } ) => {
 	if ( ! errors || ! errors.length ) return null;
 	const errorItems = errors?.map?.( ( error ) => (
-		<li key={ error }>{ error }</li>
+		<div key={ error }>{ error }</div>
 	) );
 	return (
-		<div className="sensei-lms-block-validation__notice">
-			<Tooltip
-				text={
-					<ul className="sensei-lms-block-validation__notice__tooltip-content">
-						{ errorItems }
-					</ul>
-				}
-			>
-				<span>
-					<Icon icon={ alert } size={ 32 } />
-				</span>
-			</Tooltip>
+		<div className="sensei-lms-block-validation-notice">
+			<Icon
+				icon={ alert }
+				className="sensei-lms-block-validation-notice__icon"
+			/>
+			<div className="sensei-lms-block-validation-notice__issues">
+				{ errorItems }
+			</div>
 		</div>
 	);
 };

--- a/assets/blocks/quiz/question-block/question-block-helpers.js
+++ b/assets/blocks/quiz/question-block/question-block-helpers.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Tooltip } from '@wordpress/components';
+import { Notice, Tooltip } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, info } from '@wordpress/icons';
 /**
@@ -60,14 +60,16 @@ export const BlockValidationNotice = ( { errors = [] } ) => {
 	if ( ! errors || ! errors.length ) return null;
 	const error = errors[ 0 ];
 	return (
-		<div className="sensei-lms-block-validation-notice">
+		<Notice
+			isDismissible={ false }
+			status="warning"
+			className="sensei-lms-block-validation-notice"
+		>
 			<Icon
 				icon={ alert }
 				className="sensei-lms-block-validation-notice__icon"
 			/>
-			<div className="sensei-lms-block-validation-notice__issues">
-				<div key={ error }>{ error }</div>
-			</div>
-		</div>
+			{ error }
+		</Notice>
 	);
 };

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -243,11 +243,6 @@ $block: '.sensei-lms-question-block';
 		}
 	}
 
-	.sensei-lms-block-validation__notice {
-		position: absolute;
-		left: -72px;
-	}
-
 	.block-editor-inner-blocks {
 		margin-top: 28px;
 		margin-bottom: 28px;

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -17,6 +17,11 @@ $block: '.sensei-lms-question-block';
 		margin-right: 56px;
 	}
 
+	&.is-invalid {
+		box-shadow: 0 0 0 1.5px $alert-red;
+		border-radius: 1px;
+	}
+
 	&__index {
 		position: absolute;
 		right: 100%;

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -17,11 +17,6 @@ $block: '.sensei-lms-question-block';
 		margin-right: 56px;
 	}
 
-	&.is-invalid {
-		box-shadow: 0 0 0 1.5px $alert-red;
-		border-radius: 1px;
-	}
-
 	&__index {
 		position: absolute;
 		right: 100%;

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -102,7 +102,6 @@ const QuestionEdit = ( props ) => {
 			}` }
 		>
 			{ questionIndex }
-			<QuestionValidationNotice { ...props } />
 			<h2 className="sensei-lms-question-block__title">
 				<SingleLineInput
 					placeholder={ __( 'Question Title', 'sensei-lms' ) }
@@ -146,6 +145,7 @@ const QuestionEdit = ( props ) => {
 					) }
 				</>
 			) }
+			<QuestionValidationNotice { ...props } />
 			<BlockControls>
 				<>
 					<QuestionTypeToolbar

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -7,6 +7,10 @@ import { useCallback } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { __, _n, sprintf } from '@wordpress/i18n';
 /**
+ * External dependencies
+ */
+import cn from 'classnames';
+/**
  * Internal dependencies
  */
 
@@ -80,6 +84,9 @@ const QuestionEdit = ( props ) => {
 		</h2>
 	);
 
+	const isInvalid =
+		props.meta.showValidationErrors && props.meta.validationErrors?.length;
+
 	const questionGrade = (
 		<div className="sensei-lms-question-block__grade">
 			{ formatGradeLabel( options.grade ) }
@@ -97,9 +104,10 @@ const QuestionEdit = ( props ) => {
 
 	return (
 		<div
-			className={ `sensei-lms-question-block ${
-				! title ? 'is-draft' : ''
-			}` }
+			className={ cn( 'sensei-lms-question-block', {
+				'is-draft': ! title,
+				'is-invalid': isInvalid,
+			} ) }
 		>
 			{ questionIndex }
 			<h2 className="sensei-lms-question-block__title">

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -86,11 +86,21 @@ $gray-400: #ccc;
 	}
 }
 
-.sensei-lms-block-validation__notice {
-	position: absolute;
-	left: -24px;
-	svg {
+.sensei-lms-block-validation-notice {
+	background: #fff;
+	&__issues * {
+		color: $gray-900!important;
+	}
+	border-radius: 2px;
+	padding: 4px;
+	display: inline-flex;
+	font-size: 13px;
+	border: 1px solid $gray-900;
+	margin: 4px 0;
+
+	&__icon {
 		fill: $alert-red;
+		margin-right: 4px;
 	}
 
 	&__tooltip-content {

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -99,7 +99,7 @@ $gray-400: #ccc;
 	margin: 4px 0;
 
 	&__icon {
-		fill: $alert-red;
+		fill: $gray-900;
 		margin-right: 4px;
 	}
 

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -87,23 +87,19 @@ $gray-400: #ccc;
 }
 
 .sensei-lms-block-validation-notice {
-	background: #fff;
-	&__issues * {
-		color: $gray-900!important;
-	}
-	border-radius: 2px;
-	padding: 4px;
-	display: inline-flex;
-	font-size: 13px;
-	border: 1px solid $gray-900;
+
+	display: inline-block;
 	margin: 4px 0;
+
+	.components-notice__content {
+		display: flex;
+		&, * {
+			color: $gray-900!important;
+		}
+	}
 
 	&__icon {
 		fill: $gray-900;
 		margin-right: 4px;
-	}
-
-	&__tooltip-content {
-		text-align: left;
 	}
 }


### PR DESCRIPTION
Updates styles & positioning for the in-block validation messages.

### Changes proposed in this Pull Request

* Move validation message from icon tooltip to notice at the bottom of the block
* ~~Add red outline to invalid blocks~~

### Testing instructions

* Create a lesson with quiz, with a few questions that has incomplete answers
* Try to publish, click `View Issues` in the incomplete questions notice

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="745" alt="image" src="https://user-images.githubusercontent.com/176949/112194040-c6ed4e80-8c08-11eb-94b3-63eb7ce9397f.png">

([Earlier version](https://user-images.githubusercontent.com/176949/112030318-727b9d80-8b3a-11eb-8de4-cc6503ae4dd2.png))

<img width="686" alt="image" src="">

Note that these elements are only visible once the user explicitly turned them off by clicking View Issues in the incomplete questions notice. (See #4077)
