### PR TITLE
Update existing questions modal to not show already added questions

### DIFF
--- a/assets/blocks/quiz/quiz-block/questions-modal/index.js
+++ b/assets/blocks/quiz/quiz-block/questions-modal/index.js
@@ -63,6 +63,7 @@ const QuestionsModal = ( { clientId, onClose } ) => {
 				setFilters={ setFilters }
 			/>
 			<Questions
+				clientId={ clientId }
 				questionCategories={ questionCategories }
 				filters={ filters }
 				selectedQuestionIds={ selectedQuestionIds }

--- a/assets/blocks/quiz/quiz-block/questions-modal/questions.js
+++ b/assets/blocks/quiz/quiz-block/questions-modal/questions.js
@@ -19,18 +19,26 @@ import questionTypesConfig from '../../answer-blocks';
  * Questions for selection.
  *
  * @param {Object}   props
+ * @param {string}   props.clientId               Quiz block ID.
  * @param {Array}    props.questionCategories     Question categories.
  * @param {Object}   props.filters                Filters object.
  * @param {number[]} props.selectedQuestionIds    Seleted question IDs.
  * @param {Object}   props.setSelectedQuestionIds Seleted question IDs state setter.
  */
 const Questions = ( {
+	clientId,
 	questionCategories,
 	filters,
 	selectedQuestionIds,
 	setSelectedQuestionIds,
 } ) => {
-	const questions = useSelect(
+	// Ids of the already added questions.
+	const addedQuestionIds = useSelect( ( select ) =>
+		select( 'core/block-editor' ).getBlocks( clientId )
+	).map( ( block ) => block.attributes?.id );
+
+	// Questions by current filter.
+	let questions = useSelect(
 		( select ) =>
 			select( 'core' ).getEntityRecords( 'postType', 'question', {
 				per_page: 100,
@@ -46,6 +54,11 @@ const Questions = ( {
 			</div>
 		);
 	}
+
+	// Filter out already added questions.
+	questions = questions.filter(
+		( question ) => ! addedQuestionIds.includes( question.id )
+	);
 
 	const questionCategoriesById = keyBy( questionCategories, 'id' );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update existing questions modal to not show already added questions.

### Testing instructions

* Add some existing questions to a quiz.
* Open the existing questions modal, and make sure the already added questions don't show up in the modal.