### PR TITLE
Add Sensei block category on the top of the categories list

### DIFF
--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -88,13 +88,13 @@ class Sensei_Blocks {
 		}
 
 		return array_merge(
-			$categories,
 			[
 				[
 					'slug'  => 'sensei-lms',
 					'title' => __( 'Sensei LMS', 'sensei-lms' ),
 				],
-			]
+			],
+			$categories
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add Sensei block category on the top of the categories list.

### Testing instructions

* Go to a course, and browse all blocks.
* Make sure the Sensei blocks appear first.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="362" alt="Screen Shot 2021-03-23 at 18 24 03" src="https://user-images.githubusercontent.com/876340/112220393-fa2dde80-8c04-11eb-9e7b-325f4bc05135.png">
