### PR TITLE
Log template overrides

### DIFF
--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -274,8 +274,9 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 			'mismatch'      => 0,
 		];
 
-		foreach ( $template_overrides as $template => $versions ) {
-			$property_key          = preg_replace( '/[^0-9_a-z]/', '_', strtr( strtolower( $template ), [ '.php' => '' ] ) );
+		foreach ( $template_overrides as $template_path => $versions ) {
+			// Sanitize the template path as a tracks property and remove anything unexpected from the `@version` tag.
+			$property_key          = preg_replace( '/[^0-9_a-z]/', '_', strtr( strtolower( $template_path ), [ '.php' => '' ] ) );
 			$data[ $property_key ] = preg_replace( '/[^0-9.]/', '', $versions['theme_version'] );
 
 			if ( empty( $data[ $property_key ] ) ) {

--- a/includes/class-sensei-usage-tracking.php
+++ b/includes/class-sensei-usage-tracking.php
@@ -258,6 +258,40 @@ class Sensei_Usage_Tracking extends Sensei_Usage_Tracking_Base {
 	}
 
 	/**
+	 * Get the template override data.
+	 *
+	 * @return array
+	 */
+	public function get_template_data() {
+		$theme              = wp_get_theme();
+		$template_overrides = Sensei_Status::instance()->get_template_override_status();
+
+		$data = [
+			'version'       => Sensei()->version,
+			'theme'         => $theme['Name'],
+			'theme_version' => $theme['Version'],
+			'templates'     => count( $template_overrides ),
+			'mismatch'      => 0,
+		];
+
+		foreach ( $template_overrides as $template => $versions ) {
+			$property_key          = preg_replace( '/[^0-9_a-z]/', '_', strtr( strtolower( $template ), [ '.php' => '' ] ) );
+			$data[ $property_key ] = preg_replace( '/[^0-9.]/', '', $versions['theme_version'] );
+
+			if ( empty( $data[ $property_key ] ) ) {
+				$data[ $property_key ] = 'unknown';
+			}
+
+			if ( $versions['theme_version'] !== $versions['sensei_version'] ) {
+				$data['mismatch']++;
+				$data[ $property_key ] .= '*';
+			}
+		}
+
+		return $data;
+	}
+
+	/**
 	 * Collect system data to track.
 	 *
 	 * @return array

--- a/includes/lib/usage-tracking/class-usage-tracking-base.php
+++ b/includes/lib/usage-tracking/class-usage-tracking-base.php
@@ -322,6 +322,7 @@ abstract class Sensei_Usage_Tracking_Base {
 
 		$this->send_event( 'send_usage_data' );
 		$this->send_event( 'system_log', $this->get_system_data() );
+		$this->send_event( 'template_log', $this->get_template_data() );
 
 		$usage_data = call_user_func( $this->callback );
 		if ( ! is_array( $usage_data ) ) {

--- a/includes/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
+++ b/includes/lib/usage-tracking/tests/support/class-usage-tracking-test-subclass.php
@@ -45,6 +45,10 @@ class Usage_Tracking_Test_Subclass extends Sensei_Usage_Tracking_Base {
 		return false;
 	}
 
+	public function get_template_data() {
+		return [];
+	}
+
 	protected function get_plugins() {
 		return array(
 			'Hello.php'                                 => array(

--- a/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
+++ b/includes/lib/usage-tracking/tests/test-class-usage-tracking.php
@@ -150,7 +150,7 @@ class Sensei_Base_Usage_Tracking_Test extends WP_UnitTestCase {
 		$this->usage_tracking->set_tracking_enabled( true );
 
 		$this->usage_tracking->send_usage_data();
-		$this->assertEquals( 3, $this->event_counts['http_request'], 'Requests sent when Usage Tracking enabled' );
+		$this->assertEquals( 4, $this->event_counts['http_request'], 'Requests sent when Usage Tracking enabled' );
 	}
 
 	/* Tests for system data */


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Logs template overrides. In addition to overridden templates, it also logs the template version (if it exists) and suffixes the template version for `*` when it doesn't match Sensei's version. Whatever analysis we do on versions will be pretty manual so I thought we could filter it out if necessary.
* I'm logging some things again that we get in the system log, specifically the theme name/version and Sensei version. @donnapep, if this info is pretty easy to join with the system data we send near the same time, we could remove it from this request. 
* So we could have the template names be properties, I translate all bad characters to `_` and remove the `.php` file extension.
* Properties:
   * `version`: Sensei version.
   * `theme`: Active theme name.
   * `theme_version`: Active theme version.
   * `templates`: Number of overridden templates.
   * `mismatch`: Number of templates that have versions that don't match the current versions in Sensei.
   * `[sanitized_template_file]`: Version of template installed. Shows as `unknown` if template doesn't have `@version` tag. Suffixed with `*` for ease in identifying templates that don't match Sensei's version number. 

Example for an older version of Aardvark:
<img width="282" alt="Screen Shot 2021-03-23 at 10 34 47 pm" src="https://user-images.githubusercontent.com/68693/112227718-fcedfb00-8c27-11eb-84aa-115191c089f0.png">

### Testing instructions

* Enable usage tracking; Run the `sensei_usage_tracking_send_usage_data` event manually. Verify results.