### PR TITLE
Gap fill question: add input as answer when unfocusing

### DIFF
--- a/assets/blocks/quiz/answer-blocks/gap-fill.js
+++ b/assets/blocks/quiz/answer-blocks/gap-fill.js
@@ -25,6 +25,14 @@ const GapFillAnswer = ( {
 	setAttributes,
 	hasSelected,
 } ) => {
+	const addIncompleteToken = ( { target } ) => {
+		if ( ! target?.value ) {
+			return;
+		}
+		setAttributes( { gap: [ ...gap, target.value ] } );
+		setInputValue( target, '' );
+	};
+
 	return (
 		<ul className="sensei-lms-question-block__answer sensei-lms-question-block__answer--gap-fill">
 			<li>
@@ -37,7 +45,10 @@ const GapFillAnswer = ( {
 					}
 				/>
 			</li>
-			<li className="sensei-lms-question-block__answer--gap-fill__right-answers">
+			<li
+				className="sensei-lms-question-block__answer--gap-fill__right-answers"
+				onBlur={ addIncompleteToken }
+			>
 				<FormTokenField
 					className={
 						'sensei-lms-question-block__text-input-placeholder'
@@ -100,3 +111,15 @@ GapFillAnswer.view = ( { attributes: { before, after, gap } } ) => {
 };
 
 export default GapFillAnswer;
+
+/**
+ * Update input value, making sure React event handlers are triggered.
+ *
+ * @param {HTMLInputElement} node       Input element.
+ * @param {string}           inputValue New input value.
+ */
+const setInputValue = ( node, inputValue ) => {
+	delete node.value;
+	node.value = inputValue;
+	node.dispatchEvent( new window.Event( 'change', { bubbles: true } ) );
+};

--- a/assets/blocks/quiz/answer-blocks/gap-fill.js
+++ b/assets/blocks/quiz/answer-blocks/gap-fill.js
@@ -29,7 +29,7 @@ const GapFillAnswer = ( {
 		if ( ! target?.value ) {
 			return;
 		}
-		setAttributes( { gap: [ ...gap, target.value ] } );
+		setAttributes( { gap: [ ...( gap ?? [] ), target.value ] } );
 		setInputValue( target, '' );
 	};
 


### PR DESCRIPTION

Having to press Enter or comma on the Gap Fill answers input field to add the typed-in answer is pretty unclear. This automatically adds the input value as a token (and as a right answer) when the user leaves the field, with workarounds for limitations of the underlying `FormTokenField` component.

### Changes proposed in this Pull Request

* Add input content as answer on blur if there are any, and clear input 

### Testing instructions

* Add a Gap fill question to a quiz
* Type in a right answer without pressing Enter or comma
* Click outside the input. 
* Check that the answer typed in is saved


<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![QuickTime movie](https://user-images.githubusercontent.com/176949/112355360-dbdfe580-8ccd-11eb-9098-7f3bd2ad7324.gif)

