### PR TITLE
Add points suffix to question grade controls

### DIFF
--- a/assets/blocks/editor-components/number-control/index.js
+++ b/assets/blocks/editor-components/number-control/index.js
@@ -12,9 +12,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Number control component.
  *
- * It can use or be replaced by the
- * WordPress [NumberControl]{@link https://github.com/WordPress/gutenberg/tree/master/packages/components/src/number-control} when it's stable.
- *
  * @param {Object}   props                    Component props.
  * @param {string}   [props.className]        Additional classnames for the input.
  * @param {string}   [props.id]               Component id used to connect label and input - required if label is set.
@@ -24,6 +21,7 @@ import { __ } from '@wordpress/i18n';
  * @param {boolean}  [props.allowReset=false] Whether reset is allowed.
  * @param {string}   [props.resetLabel]       Reset button custom label.
  * @param {Function} props.onChange           Change function, which receives number as argument.
+ * @param {string}   props.suffix             Input suffix.
  */
 const NumberControl = ( {
 	className,
@@ -34,21 +32,31 @@ const NumberControl = ( {
 	allowReset = false,
 	resetLabel,
 	onChange,
+	suffix,
 	...props
 } ) => (
 	<BaseControl id={ id } label={ label } help={ help }>
 		<div className="sensei-number-control">
-			<input
-				className={ classnames(
-					'sensei-number-control__input',
-					className
+			<div className="sensei-number-control__input-container">
+				<input
+					className={ classnames(
+						'sensei-number-control__input',
+						className
+					) }
+					type="number"
+					id={ id }
+					onChange={ ( e ) =>
+						onChange( parseInt( e.target.value, 10 ) )
+					}
+					value={ null === value ? '' : value }
+					{ ...props }
+				/>
+				{ suffix && (
+					<span className="sensei-number-control__input-suffix">
+						{ suffix }
+					</span>
 				) }
-				type="number"
-				id={ id }
-				onChange={ ( e ) => onChange( parseInt( e.target.value, 10 ) ) }
-				value={ null === value ? '' : value }
-				{ ...props }
-			/>
+			</div>
 			{ allowReset && (
 				<Button
 					className="sensei-number-control__button"

--- a/assets/blocks/editor-components/number-control/number-control.scss
+++ b/assets/blocks/editor-components/number-control/number-control.scss
@@ -1,3 +1,5 @@
+@import '../../../shared/styles/wp-colors';
+
 .sensei-number-control {
 	display: flex;
 	justify-content: space-between;
@@ -5,6 +7,23 @@
 	&__input {
 		flex: 1;
 		min-width: 0;
+	}
+
+	&__input-container {
+		position: relative;
+	}
+
+	&__input-suffix {
+		position: absolute;
+		right: 22px;
+		top: 0;
+		bottom: 0;
+		font-size: 10px;
+		text-transform: uppercase;
+		display: flex;
+		align-items: center;
+		color: $gray-700;
+		pointer-events: none;
 	}
 
 	&__button.components-button.is-small {

--- a/assets/blocks/quiz/question-block/question-grade-control.js
+++ b/assets/blocks/quiz/question-block/question-grade-control.js
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { useMemo } from '@wordpress/element';
+import { _n } from '@wordpress/i18n';
+/**
+ * External dependencies
+ */
+import { v4 as uuid } from 'uuid';
+/**
+ * Internal dependencies
+ */
+import NumberControl from '../../editor-components/number-control';
+
+/**
+ * Question Grade control. Number spinner with points suffix.
+ *
+ * @param {Object} props NumberControl props.
+ */
+export const QuestionGradeControl = ( props ) => {
+	const id = useMemo( () => uuid(), [] );
+	return (
+		<NumberControl
+			id={ id }
+			min={ 0 }
+			step={ 1 }
+			{ ...props }
+			suffix={ _n( 'Point', 'Points', props.value, 'sensei-lms' ) }
+		/>
+	);
+};

--- a/assets/blocks/quiz/question-block/question-grade-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-grade-toolbar.js
@@ -2,7 +2,10 @@
  * WordPress dependencies
  */
 import { ToolbarGroup } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { QuestionGradeControl } from './question-grade-control';
 
 /**
  * Question grade toolbar control.
@@ -15,14 +18,7 @@ export const QuestionGradeToolbar = ( { value, onChange } ) => {
 	return (
 		<>
 			<ToolbarGroup className="sensei-lms-question-block__grade-toolbar">
-				<input
-					type="number"
-					min="0"
-					step="1"
-					value={ value }
-					onChange={ ( e ) => onChange( +e.target.value ) }
-					title={ __( 'Question grade', 'sensei-lms' ) }
-				/>
+				<QuestionGradeControl value={ value } onChange={ onChange } />
 			</ToolbarGroup>
 		</>
 	);

--- a/assets/blocks/quiz/question-block/question-grade-toolbar.scss
+++ b/assets/blocks/quiz/question-block/question-grade-toolbar.scss
@@ -1,19 +1,26 @@
 .sensei-lms-question-block__grade-toolbar {
+	align-items: center;
+	padding: 0 12px;
 	input[type=number] {
-		align-self: center;
-		width: 42px;
+		width: 100px;
+		font-weight: bold;
 		height: 32px;
 		min-height: 0;
 		padding: 2px;
-		margin: 0 12px;
+		padding-left: 10px;
 		background: none;
 		border-width: 1px;
+
 		&:not(:focus) {
 			border-color: currentColor;
 		}
+
 		border-radius: 2px;
 		outline: none;
-		text-align: center;
-		font-weight: bold;
 	}
+	.components-base-control__field {
+		margin: 0;
+	}
+
 }
+

--- a/assets/blocks/quiz/question-block/settings/question-grade-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-grade-settings.js
@@ -2,11 +2,17 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { QuestionGradeControl } from '../question-grade-control';
+/**
+ * Internal dependencies
+ */
 
 /**
  * Internal dependencies
  */
-import NumberControl from '../../../editor-components/number-control';
 
 /**
  * Question block grade settings.
@@ -15,20 +21,11 @@ import NumberControl from '../../../editor-components/number-control';
  * @param {Object}   props.options
  * @param {number}   props.options.grade Question grade.
  * @param {Function} props.setOptions
- * @param {string}   props.clientId
  */
-const QuestionGradeSettings = ( {
-	options: { grade = 1 },
-	setOptions,
-	clientId,
-} ) => {
-	const id = `sensei-lms-question-block__grade-control-${ clientId }`;
+const QuestionGradeSettings = ( { options: { grade = 1 }, setOptions } ) => {
 	return (
-		<NumberControl
-			id={ id }
+		<QuestionGradeControl
 			label={ __( 'Grade', 'sensei-lms' ) }
-			min={ 0 }
-			step={ 1 }
 			value={ grade }
 			onChange={ ( nextGrade ) =>
 				setOptions( { grade: nextGrade ?? 1 } )


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Add `Point`/`Points` suffix to the question grade control in the toolbar & settings panel
* Update number control with basic suffix support
  — diverging from the original Gutenberg component. There are also some upcoming G2 component that could be used for this when they are stable & match our supported WP versions. 
* Move toolbar and settings grade control to a shared component 

### Testing instructions

* Add a question to a  lesson quiz, or edit a single question
* Adjust grading from toolbar or settings

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="270" alt="image" src="https://user-images.githubusercontent.com/176949/112365924-81985200-8cd8-11eb-86c7-161388d83ebf.png">

--- 

<img width="687" alt="image" src="https://user-images.githubusercontent.com/176949/112365939-85c46f80-8cd8-11eb-9462-e2cb93bf4c5b.png">

