### PR TITLE
Prevent enrolment calculations on each update

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -17,6 +17,13 @@ class Sensei_Course_Enrolment_Manager {
 	const LEARNER_CALCULATION_META_NAME     = 'sensei_learner_calculated_version';
 
 	/**
+	 * Update this when releasing a version that requires user enrolment to get checked.
+	 * Calculated and stored enrolments will only get updated if enrolment provider
+	 * versions have changed.
+	 */
+	const ENROLMENT_VERSION = '3.8.1';
+
+	/**
 	 * Instance of singleton.
 	 *
 	 * @var self
@@ -457,9 +464,7 @@ class Sensei_Course_Enrolment_Manager {
 		$hash_components[] = $this->get_site_salt();
 		$hash_components[] = $this->get_enrolment_provider_versions_hash();
 
-		$current_hash = md5( implode( '-', $hash_components ) );
-
-		return $current_hash . '-' . Sensei()->version;
+		return md5( implode( '-', $hash_components ) ) . '-' . self::ENROLMENT_VERSION;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* We don't need to recalculate enrollment on each update. This creates a new static version we can update (similar to templates). For now, it is set on `3.8.1` to prevent the job from getting queued for people coming from 3.8.1. However, for this first update, people coming from other versions will get recalculated.

### Testing instructions

* Set your suffix for the `sensei-scheduler-calculation-version` option to `-3.8.1` (if not already).
* Switch to this branch.
* Verify no jobs are enqueued.