### PR TITLE
Avoid duplicate POST on post-submit quiz page reload

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -35,10 +35,10 @@ class Sensei_Quiz {
 		add_action( 'template_redirect', array( $this, 'reset_button_click_listener' ) );
 
 		// Fire the complete quiz button submit for grading action.
-		add_action( 'sensei_single_quiz_content_inside_before', array( $this, 'user_quiz_submit_listener' ) );
+		add_action( 'template_redirect', array( $this, 'user_quiz_submit_listener' ) );
 
 		// Fire the save user answers quiz button click responder.
-		add_action( 'sensei_single_quiz_content_inside_before', array( $this, 'user_save_quiz_answers_listener' ) );
+		add_action( 'template_redirect', array( $this, 'user_save_quiz_answers_listener' ) );
 
 		// Fire the load global data function.
 		add_action( 'sensei_single_quiz_content_inside_before', array( $this, 'load_global_quiz_data' ), 80 );
@@ -178,6 +178,9 @@ class Sensei_Quiz {
 
 		// remove the hook as it should only fire once per click
 		remove_action( 'sensei_single_quiz_content_inside_before', 'user_save_quiz_answers_listener' );
+
+		// Prevent duplicate submit on page reload.
+		wp_safe_redirect( get_permalink() );
 
 	} // end user_save_quiz_answers_listener
 
@@ -354,6 +357,9 @@ class Sensei_Quiz {
 		$quiz_answers = $this->merge_quiz_answers_with_questions_asked( $_POST, $post->ID );
 
 		self::submit_answers_for_grading( $quiz_answers, $_FILES, $lesson_id, $current_user->ID );
+
+		// Prevent duplicate submit on page reload.
+		wp_safe_redirect( get_permalink() );
 
 	} // End sensei_complete_quiz()
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Some quiz submit callbacks are for unknown reasons attached to frontend rendering phase.

This became a problem when we implemented a quiz re-take delay mechanism.

People would reload quiz page to see how much time remaining to wait, but this re-POSTs quiz and resets our timer.

Solution, and relevant part to Sensei core - proper hygiene in general, is to have a simple pre-output phase GET redirect to quiz URL, that upon reload will not resubmit quiz data.

RATIONALE

Quiz submit should be an intentional operation - page reload should not cause it in the background, since it has implications about "when was quiz last submitted" and potentially other related data (our timer use case), important to online schools, being incorrect.

### Testing instructions

* Submit any quiz, passing or not - verify results are still correctly displayed