### PR TITLE
Enable updateSelection to prevent block crashes

### DIFF
--- a/assets/blocks/course-outline/course-outline-store.js
+++ b/assets/blocks/course-outline/course-outline-store.js
@@ -56,7 +56,7 @@ registerStructureStore( {
 		yield dispatch( 'core/block-editor' ).replaceInnerBlocks(
 			clientId,
 			syncStructureToBlocks( structure, blocks ),
-			false
+			true
 		);
 	},
 	readBlock: getEditorOutlineStructure,


### PR DESCRIPTION
Fixes #4065

### Changes proposed in this Pull Request

* It seems that this issue was caused by a Gutenberg bug and was introduced in version 9.9.
* The issue does not happen only for legacy courses, it happens whenever a course outline block which only has lessons is added.
* The crash happens only when `updateSelection` is set to false. I updated the flag to be true as it has a small impact (the block gets selected after loading) and we want to fix the issue before the next release.
* We should look into finding the root cause for this or raise a bug with Gutenberg.

### Testing instructions

* Create a course and add only lessons to it an not modules.
* Remove the course outline block.
* Try readding the block and observe that it is loaded successfully.