### PR TITLE
Create module taxonomy before cleaning data

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -255,6 +255,9 @@ class Sensei_Data_Cleaner {
 	 * @access public
 	 */
 	public static function cleanup_all() {
+		// Ensure module taxonomy is created before calling functions that rely on its existence.
+		Sensei()->modules->setup_modules_taxonomy();
+
 		self::cleanup_custom_post_types();
 		self::cleanup_post_meta();
 		self::cleanup_pages();


### PR DESCRIPTION
Fixes #3988.

### Changes proposed in this Pull Request

Ensures the module taxonomy is created before any data is cleaned up. The taxonomy is normally created on `init`, but this action is not called when the plugin is being uninstalled. This prevents an _Invalid taxonomy_ `WPError` when uninstalling.

### Testing instructions

* Create a course with a module and lessons.
* Enable option to delete data on uninstall.
* Deactivate and uninstall the plugin.
* Ensure the plugin is successfully deleted.