### PR TITLE
Round course progress percentage to nearest integer

### DIFF
--- a/assets/blocks/course-progress-block/course-progress-edit.js
+++ b/assets/blocks/course-progress-block/course-progress-edit.js
@@ -53,12 +53,9 @@ export const CourseProgressEdit = ( props ) => {
 
 	let progress = 0;
 	if ( 0 !== totalLessonsCount ) {
-		progress =
-			Math.round(
-				( ( 100 * completedLessonsCount ) / totalLessonsCount +
-					Number.EPSILON ) *
-					100
-			) / 100;
+		progress = Math.round(
+			( 100 * completedLessonsCount ) / totalLessonsCount
+		);
 	}
 
 	const wrapperAttributes = {

--- a/includes/blocks/class-sensei-course-progress-block.php
+++ b/includes/blocks/class-sensei-course-progress-block.php
@@ -50,7 +50,7 @@ class Sensei_Course_Progress_Block {
 
 		$completed     = count( Sensei()->course->get_completed_lesson_ids( get_the_ID() ) );
 		$total_lessons = count( Sensei()->course->course_lessons( get_the_ID() ) );
-		$percentage    = Sensei_Utils::quotient_as_absolute_rounded_percentage( $completed, $total_lessons, 2 );
+		$percentage    = Sensei_Utils::quotient_as_absolute_rounded_percentage( $completed, $total_lessons );
 
 		$text_css           = Sensei_Block_Helpers::build_styles( $attributes );
 		$bar_background_css = Sensei_Block_Helpers::build_styles(


### PR DESCRIPTION
Fixes #4118.

### Changes proposed in this Pull Request

Rounds course progress block percentage to nearest integer.

### Testing instructions

1. Create a course with 3 lessons and publish everything.
2. As an admin, start taking the course and complete the first lesson.
3. Go back to the single course page and ensure the course progress percentage is rounded to 33%. It should match the percentage on the _My Courses_ page.
4. Open the course in the editor.
5. Mark a lesson as completed in the course outline block and ensure the course progress percentage is rounded to 33%.