### PR TITLE
Add bundle analyzer script

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,8 +78,9 @@
     "tar-fs": "2.1.0"
   },
   "scripts": {
-    "build": "npm run --silent build:assets -- --json > node_modules/.cache/sensei-lms/build-stats.json && npm run archive && npx webpack-bundle-analyzer node_modules/.cache/sensei-lms/build-stats.json assets/dist",
+    "build": "npm run build:assets && npm run archive",
     "build:assets": "rm -rf ./assets/dist && cross-env NODE_ENV=production npx calypso-build",
+    "build:analyzer": "npm run --silent build:assets -- --json > node_modules/.cache/sensei-lms/build-stats.json && npx webpack-bundle-analyzer node_modules/.cache/sensei-lms/build-stats.json assets/dist",
     "build:docs": "rm -rf hookdocs/ && jsdoc -c hookdoc-conf.json",
     "build:vendor": "cp ./node_modules/select2/dist/css/select2.min.css ./node_modules/select2/dist/js/select2.full.js ./node_modules/select2/dist/js/select2.full.min.js ./assets/vendor/select2",
     "archive": "composer archive --file=$npm_package_name --format=zip",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "tar-fs": "2.1.0"
   },
   "scripts": {
-    "build": "npm run build:assets && npm run archive",
+    "build": "npm run --silent build:assets -- --json > node_modules/.cache/sensei-lms/build-stats.json && npm run archive && npx webpack-bundle-analyzer node_modules/.cache/sensei-lms/build-stats.json assets/dist",
     "build:assets": "rm -rf ./assets/dist && cross-env NODE_ENV=production npx calypso-build",
     "build:docs": "rm -rf hookdocs/ && jsdoc -c hookdoc-conf.json",
     "build:vendor": "cp ./node_modules/select2/dist/css/select2.min.css ./node_modules/select2/dist/js/select2.full.js ./node_modules/select2/dist/js/select2.full.min.js ./assets/vendor/select2",


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It just adds a bundle analyzer script to the `build` script. So when we build the project through the `npm run build`, we'll see a result with our bundle status to confirm if everything is okay with  the packages and we're not including MBs by any accident. :)

Some related discussions here: https://github.com/Automattic/sensei/pull/4122#discussion_r602356434

* I think the build script is a good place to do that because we usually use that only when making the release builds. But feel free to suggest different ideas.

### Testing instructions

* Just run ~~`npm run build`~~ `npm run build:analyzer`, and make sure that in the end of the process a browser will open with the bundle status.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1674" alt="Screen Shot 2021-03-26 at 15 43 45" src="https://user-images.githubusercontent.com/876340/112678742-12db0600-8e4a-11eb-881c-d2a42ab49125.png">
