### PR TITLE
Add learner messages button block

### DIFF
--- a/assets/blocks/button/button-edit.js
+++ b/assets/blocks/button/button-edit.js
@@ -8,11 +8,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import {
-	getButtonProps,
-	getButtonWrapperProps,
-	isLinkStyle,
-} from './button-props';
+import { getButtonProps, getButtonWrapperProps } from './button-props';
 import ButtonSettings from './button-settings';
 
 /**
@@ -30,11 +26,7 @@ const ButtonEdit = ( props ) => {
 	const isReadonly = undefined !== props.text;
 	const buttonProps = getButtonProps( { ...props, colors } );
 
-	let buttonTagName = tagName;
-
-	if ( ! tagName ) {
-		buttonTagName = isLinkStyle( props ) ? 'a' : 'button';
-	}
+	const buttonTagName = tagName || 'a';
 
 	return (
 		<div { ...getButtonWrapperProps( props ) }>
@@ -47,7 +39,6 @@ const ButtonEdit = ( props ) => {
 					}
 					value={ text }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
-					withoutInteractiveFormatting
 					{ ...buttonProps }
 					tagName={ buttonTagName }
 					identifier="text"

--- a/assets/blocks/button/button-edit.js
+++ b/assets/blocks/button/button-edit.js
@@ -17,7 +17,7 @@ import ButtonSettings from './button-settings';
  * @param {Object} props
  */
 const ButtonEdit = ( props ) => {
-	const { placeholder, attributes, setAttributes, tagName } = props;
+	const { placeholder, attributes, setAttributes } = props;
 	const { text } = attributes;
 	const { colors } = useSelect( ( select ) => {
 		return select( 'core/block-editor' ).getSettings();
@@ -25,8 +25,6 @@ const ButtonEdit = ( props ) => {
 
 	const isReadonly = undefined !== props.text;
 	const buttonProps = getButtonProps( { ...props, colors } );
-
-	const buttonTagName = tagName || 'a';
 
 	return (
 		<div { ...getButtonWrapperProps( props ) }>
@@ -40,7 +38,7 @@ const ButtonEdit = ( props ) => {
 					value={ text }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
 					{ ...buttonProps }
-					tagName={ buttonTagName }
+					tagName="a"
 					identifier="text"
 					withoutInteractiveFormatting={ true }
 				/>

--- a/assets/blocks/button/button-edit.js
+++ b/assets/blocks/button/button-edit.js
@@ -42,6 +42,7 @@ const ButtonEdit = ( props ) => {
 					{ ...buttonProps }
 					tagName={ buttonTagName }
 					identifier="text"
+					withoutInteractiveFormatting={ true }
 				/>
 			) }
 			<ButtonSettings { ...props } />

--- a/assets/blocks/learner-messages-button-block/index.js
+++ b/assets/blocks/learner-messages-button-block/index.js
@@ -1,0 +1,34 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { BlockStyles, createButtonBlockType } from '../button';
+
+/**
+ * Learner messages button block.
+ */
+export default createButtonBlockType( {
+	tagName: 'a',
+	settings: {
+		name: 'sensei-lms/button-learner-messages',
+		description: __(
+			'Links to the page where learners can view their messages. This block is only displayed if the user is logged in and private messaging is enabled.',
+			'sensei-lms'
+		),
+		title: __( 'Learner Messages Button', 'sensei-lms' ),
+		attributes: {
+			text: {
+				default: __( 'My Messages', 'sensei-lms' ),
+			},
+		},
+		styles: [
+			BlockStyles.Fill,
+			{ ...BlockStyles.Outline, isDefault: true },
+			BlockStyles.Link,
+		],
+	},
+} );

--- a/assets/blocks/single-page.js
+++ b/assets/blocks/single-page.js
@@ -3,5 +3,6 @@
  */
 import registerSenseiBlocks from './register-sensei-blocks';
 import LearnerCoursesBlock from './learner-courses-block';
+import LearnerMessagesButtonBlock from './learner-messages-button-block';
 
-registerSenseiBlocks( [ LearnerCoursesBlock ] );
+registerSenseiBlocks( [ LearnerCoursesBlock, LearnerMessagesButtonBlock ] );

--- a/assets/blocks/take-course-block/index.js
+++ b/assets/blocks/take-course-block/index.js
@@ -13,7 +13,6 @@ import ToggleLegacyCourseMetaboxesWrapper from '../toggle-legacy-course-metaboxe
  * Take course button block.
  */
 export default createButtonBlockType( {
-	tagName: 'button',
 	EditWrapper: ToggleLegacyCourseMetaboxesWrapper,
 	settings: {
 		name: 'sensei-lms/button-take-course',

--- a/includes/blocks/class-sensei-learner-messages-button-block.php
+++ b/includes/blocks/class-sensei-learner-messages-button-block.php
@@ -38,6 +38,8 @@ class Sensei_Learner_Messages_Button_Block {
 	/**
 	 * Render the learner messages button.
 	 *
+	 * @access private
+	 *
 	 * @param array  $attributes Block attributes.
 	 * @param string $content    Block HTML.
 	 *

--- a/includes/blocks/class-sensei-learner-messages-button-block.php
+++ b/includes/blocks/class-sensei-learner-messages-button-block.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * File containing the Sensei_Learner_Messages_Button_Block class.
+ *
+ * @package sensei
+ * @since 3.10.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Block for Learner Messages button.
+ */
+class Sensei_Learner_Messages_Button_Block {
+
+	/**
+	 * Sensei_Block_Take_Course constructor.
+	 */
+	public function __construct() {
+		$this->register_block();
+	}
+
+
+	/**
+	 * Register learner messages block.
+	 *
+	 * @access private
+	 */
+	public function register_block() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/button-learner-messages',
+			[ 'render_callback' => [ $this, 'render_learner_messages_block' ] ]
+		);
+	}
+
+	/**
+	 * Render the learner messages button.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block HTML.
+	 *
+	 * @return string Link to the learner messages button.
+	 */
+	public function render_learner_messages_block( $attributes, $content ): string {
+		if ( Sensei()->settings->settings['messages_disable'] ?? false ) {
+			return '';
+		}
+
+		$message_url = esc_url( get_post_type_archive_link( 'sensei_message' ) );
+
+		return preg_replace(
+			'/<a /',
+			'<a href="' . $message_url . '" ',
+			$content,
+			1
+		);
+	}
+}

--- a/includes/blocks/class-sensei-learner-messages-button-block.php
+++ b/includes/blocks/class-sensei-learner-messages-button-block.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Learner_Messages_Button_Block {
 
 	/**
-	 * Sensei_Block_Take_Course constructor.
+	 * Sensei_Learner_Messages_Button_Block constructor.
 	 */
 	public function __construct() {
 		$this->register_block();

--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -25,6 +25,7 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	 */
 	public function initialize_blocks() {
 		new Sensei_Learner_Courses_Block();
+		new Sensei_Learner_Messages_Button_Block();
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3863

### Changes proposed in this Pull Request

* Switches to only use `a` tags from within the editor for buttons. This is to fix the spaces issue from #3863.
* Introduces the Learner Messages Button block. I appended "Button" onto the name because I imagine we'll eventually want a block that actually shows Learner Messages.
* Disabled the ability to add a link inline buttons. That seems to not be desirable. 

### Testing instructions

* Try adding the block to a page.
* Ensure the link works.
* Disable learner messages in Sensei setting. Ensure the button doesn't appear.
* Try removing and adding spaces to Lesson Action button blocks.