### PR TITLE
Enable legacy quiz meta boxes if the Classic Editor plugin is activated

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -28,6 +28,15 @@ class Sensei_Lesson {
 	private $lesson_id_updating;
 
 	/**
+	 * Message to display on the legacy quiz meta boxes.
+	 *
+	 * @since 3.9.1
+	 *
+	 * @var string
+	 */
+	private $legacy_quiz_message;
+
+	/**
 	 * Constructor.
 	 *
 	 * @since  1.0.0
@@ -42,6 +51,19 @@ class Sensei_Lesson {
 		$this->question_order = '';
 
 		$this->allowed_html = Sensei_Wp_Kses::get_default_wp_kses_allowed_html();
+
+		$this->legacy_quiz_message = '<em>' .
+			sprintf(
+				__(
+					'*Note that this functionality has been moved to the <a href="%1$s">quiz block</a> ' .
+					'and will not be supported going forward. Please consider switching to the ' .
+					'<a href="%2$s">block editor</a>.</em>',
+					'sensei-lms'
+				),
+				'https://senseilms.com/lesson/quizzes/',
+				'https://wordpress.org/support/article/wordpress-editor/'
+			) .
+		'</em>';
 
 		// Admin actions
 		if ( is_admin() ) {
@@ -190,10 +212,10 @@ class Sensei_Lesson {
 
 		if ( ! Sensei()->quiz->is_block_based_editor_enabled() ) {
 			// Add Meta Box for Quiz Settings
-			add_meta_box( 'lesson-quiz-settings', esc_html__( 'Quiz Settings', 'sensei-lms' ), array( $this, 'lesson_quiz_settings_meta_box_content' ), $this->token, 'normal', 'default' );
+			add_meta_box( 'lesson-quiz-settings', esc_html__( 'Quiz Settings*', 'sensei-lms' ), array( $this, 'lesson_quiz_settings_meta_box_content' ), $this->token, 'normal', 'default' );
 
 			// Add Meta Box for Lesson Quiz Questions
-			add_meta_box( 'lesson-quiz', esc_html__( 'Quiz Questions', 'sensei-lms' ), array( $this, 'lesson_quiz_meta_box_content' ), $this->token, 'normal', 'default' );
+			add_meta_box( 'lesson-quiz', esc_html__( 'Quiz Questions*', 'sensei-lms' ), array( $this, 'lesson_quiz_meta_box_content' ), $this->token, 'normal', 'default' );
 		}
 
 		// Remove "Custom Settings" meta box.
@@ -811,8 +833,8 @@ class Sensei_Lesson {
 	} // End lesson_course_meta_box_content()
 
 	public function quiz_panel( $quiz_id = 0 ) {
-
 		$html  = wp_nonce_field( 'sensei-save-post-meta', 'woo_' . $this->token . '_nonce', true, false );
+		$html .= $this->legacy_quiz_message;
 		$html .= '<div id="add-quiz-main">';
 		if ( 0 == $quiz_id ) {
 			$html .= '<p>';
@@ -1999,7 +2021,7 @@ class Sensei_Lesson {
 	public function lesson_quiz_settings_meta_box_content() {
 		global $post;
 
-		$html = '';
+		$html = $this->legacy_quiz_message;
 
 		// Get quiz panel
 		$quiz_id   = 0;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -52,6 +52,8 @@ class Sensei_Lesson {
 
 		$this->allowed_html = Sensei_Wp_Kses::get_default_wp_kses_allowed_html();
 
+		// translators: %1$s is a link to the quiz documentation.
+		// %2$s is a link to a support article about the WordPress editor.
 		$this->legacy_quiz_message = '<em>' .
 			sprintf(
 				__(

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -52,14 +52,11 @@ class Sensei_Lesson {
 
 		$this->allowed_html = Sensei_Wp_Kses::get_default_wp_kses_allowed_html();
 
-		// translators: %1$s is a link to the quiz documentation.
-		// %2$s is a link to a support article about the WordPress editor.
 		$this->legacy_quiz_message = '<em>' .
 			sprintf(
+				// translators: %1$s is a link to the quiz documentation, %2$s is a link to a support article about the WordPress editor.
 				__(
-					'*Note that this functionality has been moved to the <a href="%1$s">quiz block</a> ' .
-					'and will not be supported going forward. Please consider switching to the ' .
-					'<a href="%2$s">block editor</a>.</em>',
+					'*Note that this functionality has been moved to the <a href="%1$s">quiz block</a> and will not be supported going forward. Please consider switching to the <a href="%2$s">block editor</a>.</em>',
 					'sensei-lms'
 				),
 				'https://senseilms.com/lesson/quizzes/',

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -61,8 +61,13 @@ class Sensei_Quiz {
 	 * @return bool
 	 */
 	public function is_block_based_editor_enabled() {
-		// If custom question types have been registered, disable the block based quiz editor for now.
-		$is_block_based_editor_enabled = ! has_filter( 'sensei_question_types' );
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			include_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		// If custom question types have been registered, or the Classic Editor plugin is activated,
+		// disable the block based quiz editor for now.
+		$is_block_based_editor_enabled = ! has_filter( 'sensei_question_types' ) && ! is_plugin_active( 'classic-editor/classic-editor.php' );
 
 		/**
 		 * Filter to change whether the block based editor should be used instead of the legacy


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Enables the quiz meta boxes if the Classic Editor plugin is activated.
* Add messaging to quiz meta boxes to encourage updating to the block editor.

### Testing instructions

* Install and activate the Classic Editor plugin.
* Create a new lesson or edit an existing one and ensure the quiz meta boxes are visible.
* Deactivate the Classic Editor plugin and activate the Code Snippets plugin.
* Add the following snippet:
```
add_filter( 'sensei_question_types', 'sensei_add_question_type' );

function sensei_add_question_type( $question_types ) {
	$question_types['test'] = 'Test Question Type';
	return $question_types;
}
```
* Create a new lesson or edit an existing one and ensure the quiz meta boxes are visible.
* Deactivate the Code Snippets plugin.
* Create a new lesson or edit an existing one and ensure the quiz meta boxes are no longer visible.

### Screenshots
![Screen Shot 2021-03-29 at 1 28 42 PM](https://user-images.githubusercontent.com/1190420/112875888-c6363b80-9092-11eb-89c2-6870bbf17bb2.jpg)