### PR TITLE
Add the learner courses block on setup

### DIFF
--- a/assets/blocks/learner-messages-button-block/index.js
+++ b/assets/blocks/learner-messages-button-block/index.js
@@ -9,6 +9,12 @@ import { __ } from '@wordpress/i18n';
 import { BlockStyles, createButtonBlockType } from '../button';
 import MessagesDisabledNotice from './messages-disabled-notice';
 
+const attributes = {
+	text: {
+		default: __( 'My Messages', 'sensei-lms' ),
+	},
+};
+
 /**
  * Learner messages button block.
  */
@@ -21,15 +27,17 @@ export default createButtonBlockType( {
 			'sensei-lms'
 		),
 		title: __( 'Learner Messages Button', 'sensei-lms' ),
-		attributes: {
-			text: {
-				default: __( 'My Messages', 'sensei-lms' ),
-			},
-		},
+		attributes,
 		styles: [
 			BlockStyles.Fill,
 			{ ...BlockStyles.Outline, isDefault: true },
 			BlockStyles.Link,
+		],
+		deprecated: [
+			{
+				attributes,
+				save: () => null,
+			},
 		],
 	},
 	EditWrapper: MessagesDisabledNotice,

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -64,11 +64,25 @@ class Sensei_Setup_Wizard_Pages {
 		Sensei()->settings->set( 'course_page', $new_course_page_id );
 
 		// My Courses page.
-		$new_my_course_page_id = $this->create_page( esc_sql( _x( 'my-courses', 'page_slug', 'sensei-lms' ) ), __( 'My Courses', 'sensei-lms' ), '[sensei_user_courses]' );
+		$new_my_course_page_id = $this->create_page( esc_sql( _x( 'my-courses', 'page_slug', 'sensei-lms' ) ), __( 'My Courses', 'sensei-lms' ), $this->get_learner_courses_block_content() );
 		Sensei()->settings->set( 'my_course_page', $new_my_course_page_id );
 
 		Sensei()->initiate_rewrite_rules_flush();
 	}
 
+	/**
+	 * Get the block content for learner courses.
+	 *
+	 * @return string
+	 */
+	private function get_learner_courses_block_content() {
+		return serialize_block(
+			[
+				'blockName'    => 'sensei-lms/learner-courses',
+				'innerContent' => [],
+				'attrs'        => [],
+			]
+		);
+	}
 
 }

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -64,7 +64,7 @@ class Sensei_Setup_Wizard_Pages {
 		Sensei()->settings->set( 'course_page', $new_course_page_id );
 
 		// My Courses page.
-		$new_my_course_page_id = $this->create_page( esc_sql( _x( 'my-courses', 'page_slug', 'sensei-lms' ) ), __( 'My Courses', 'sensei-lms' ), $this->get_learner_courses_block_content() );
+		$new_my_course_page_id = $this->create_page( esc_sql( _x( 'my-courses', 'page_slug', 'sensei-lms' ) ), __( 'My Courses', 'sensei-lms' ), $this->get_learner_courses_page_content() );
 		Sensei()->settings->set( 'my_course_page', $new_my_course_page_id );
 
 		Sensei()->initiate_rewrite_rules_flush();
@@ -75,14 +75,25 @@ class Sensei_Setup_Wizard_Pages {
 	 *
 	 * @return string
 	 */
-	private function get_learner_courses_block_content() {
-		return serialize_block(
+	private function get_learner_courses_page_content() {
+		$blocks   = [];
+		$blocks[] = serialize_block(
+			[
+				'blockName'    => 'sensei-lms/button-learner-messages',
+				'innerContent' => [],
+				'attrs'        => [],
+			]
+		);
+
+		$blocks[] = serialize_block(
 			[
 				'blockName'    => 'sensei-lms/learner-courses',
 				'innerContent' => [],
 				'attrs'        => [],
 			]
 		);
+
+		return implode( $blocks );
 	}
 
 }

--- a/includes/blocks/class-sensei-learner-messages-button-block.php
+++ b/includes/blocks/class-sensei-learner-messages-button-block.php
@@ -69,6 +69,14 @@ class Sensei_Learner_Messages_Button_Block {
 
 		$message_url = esc_url( get_post_type_archive_link( 'sensei_message' ) );
 
+		// Render the default content if this page hasn't been edited since it was auto-generated.
+		if ( empty( $attributes ) && empty( $content ) ) {
+			return '
+			<div class="wp-block-sensei-lms-button-learner-messages is-style-outline wp-block-sensei-button wp-block-button has-text-align-left">
+				<a href="' . $message_url . '" class="wp-block-button__link">' . esc_html__( 'My Messages', 'sensei-lms' ) . '</a>
+			</div>';
+		}
+
 		return preg_replace(
 			'/<a /',
 			'<a href="' . $message_url . '" ',


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds the `sensei-lms/learner-courses` block to the Learner Courses page created during Sensei's setup.

### Testing instructions

* In a fresh install, activate Sensei and go through the setup wizard. 
* Edit the My Courses page and verify the Learner Courses block has been added.
