### PR TITLE
Add progress bar settings to the Learner Courses block

### DIFF
--- a/assets/blocks/course-progress-block/course-progress-edit.js
+++ b/assets/blocks/course-progress-block/course-progress-edit.js
@@ -18,7 +18,7 @@ import {
 	withDefaultColor,
 } from '../../shared/blocks/settings';
 import { COURSE_STATUS_STORE } from '../course-outline/status-preview/status-store';
-import CourseProgressSettings from './course-progress-settings';
+import CourseProgressSettings from '../editor-components/course-progress-settings';
 import ToggleLegacyCourseMetaboxesWrapper from '../toggle-legacy-course-metaboxes-wrapper';
 
 /**

--- a/assets/blocks/course-progress-block/course-progress.scss
+++ b/assets/blocks/course-progress-block/course-progress.scss
@@ -20,13 +20,3 @@
 		background-color: #0064B4;
 	}
 }
-
-.wp-block-sensei-lms-progress-styling-controls {
-	.components-range-control {
-		width: 100%;
-	}
-
-	.components-base-control__label {
-		max-width: 100%;
-	}
-}

--- a/assets/blocks/editor-components/course-progress-settings/course-progress-settings.scss
+++ b/assets/blocks/editor-components/course-progress-settings/course-progress-settings.scss
@@ -1,0 +1,9 @@
+.sensei-course-progress-settings {
+	.components-range-control {
+		width: 100%;
+	}
+
+	.components-base-control__label {
+		max-width: 100%;
+	}
+}

--- a/assets/blocks/editor-components/course-progress-settings/index.js
+++ b/assets/blocks/editor-components/course-progress-settings/index.js
@@ -6,7 +6,7 @@ import { PanelBody, PanelRow, RangeControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 
 /**
- * The course progress block settings.
+ * The course progress settings.
  *
  * @param {Object}   props                 Component properties.
  * @param {number}   props.borderRadius    The value of the bar radius.
@@ -32,7 +32,7 @@ const CourseProgressSettings = ( {
 			<PanelBody
 				title={ __( 'Progress bar settings', 'sensei-lms' ) }
 				initialOpen={ false }
-				className="wp-block-sensei-lms-progress-styling-controls"
+				className="sensei-course-progress-settings"
 			>
 				<PanelRow>
 					<RangeControl

--- a/assets/blocks/editor-components/course-progress-settings/index.js
+++ b/assets/blocks/editor-components/course-progress-settings/index.js
@@ -36,7 +36,7 @@ const CourseProgressSettings = ( {
 			>
 				<PanelRow>
 					<RangeControl
-						label={ 'Border radius' }
+						label={ __( 'Border radius', 'sensei-lms' ) }
 						value={ borderRadius }
 						onChange={ setBorderRadius }
 						min={ 0 }

--- a/assets/blocks/editor-components/editor-components-style.scss
+++ b/assets/blocks/editor-components/editor-components-style.scss
@@ -1,3 +1,4 @@
+@import './course-progress-settings/course-progress-settings';
 @import './input-control/input-control';
 @import './number-control/number-control';
 @import './toolbar-dropdown/toolbar-dropdown';

--- a/assets/blocks/learner-courses-block/block.json
+++ b/assets/blocks/learner-courses-block/block.json
@@ -13,7 +13,9 @@
         "courseDescriptionEnabled": true,
         "featuredImageEnabled": false,
         "courseCategoryEnabled": false,
-        "progressBarEnabled": true
+        "progressBarEnabled": true,
+        "progressBarBorderRadius": 10,
+        "progressBarHeight": 14
       }
     }
   }

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -120,8 +120,12 @@ const LearnerCoursesEdit = ( {
 			<section
 				className={ className }
 				style={ {
-					'--progress-bar-height': `${ options.progressBarHeight }px`,
-					'--progress-bar-border-radius': `${ options.progressBarBorderRadius }px`,
+					...( undefined !== options.progressBarHeight && {
+						'--progress-bar-height': `${ options.progressBarHeight }px`,
+					} ),
+					...( undefined !== options.progressBarBorderRadius && {
+						'--progress-bar-border-radius': `${ options.progressBarBorderRadius }px`,
+					} ),
 				} }
 			>
 				<ul className="wp-block-sensei-lms-learner-courses__filter">

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -117,7 +117,13 @@ const LearnerCoursesEdit = ( {
 
 	return (
 		<>
-			<section className={ className }>
+			<section
+				className={ className }
+				style={ {
+					'--progress-bar-height': `${ options.progressBarHeight }px`,
+					'--progress-bar-border-radius': `${ options.progressBarBorderRadius }px`,
+				} }
+			>
 				<ul className="wp-block-sensei-lms-learner-courses__filter">
 					{ filters.map( ( { label, value } ) => (
 						<li

--- a/assets/blocks/learner-courses-block/learner-courses-settings.js
+++ b/assets/blocks/learner-courses-block/learner-courses-settings.js
@@ -14,6 +14,11 @@ import { grid, list } from '@wordpress/icons';
 import { __, sprintf, _n } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import CourseProgressSettings from '../editor-components/course-progress-settings';
+
+/**
  * Learner Settings component.
  *
  * @param {Object}   props
@@ -104,6 +109,22 @@ const LearnerCoursesSettings = ( { options, setOptions } ) => {
 							/>
 						</PanelRow>
 					</PanelBody>
+				) }
+				{ options.progressBarEnabled && (
+					<CourseProgressSettings
+						borderRadius={ options.progressBarBorderRadius }
+						setBorderRadius={ ( value ) => {
+							setOptions( {
+								progressBarBorderRadius: value,
+							} );
+						} }
+						height={ options.progressBarHeight }
+						setHeight={ ( value ) => {
+							setOptions( {
+								progressBarHeight: value,
+							} );
+						} }
+					/>
 				) }
 			</InspectorControls>
 			<BlockControls>

--- a/assets/blocks/learner-courses-block/learner-courses-settings.test.js
+++ b/assets/blocks/learner-courses-block/learner-courses-settings.test.js
@@ -21,11 +21,18 @@ describe( '<LearnerCoursesSettings />', () => {
 			courseDescriptionEnabled: true,
 			featuredImageEnabled: false,
 			courseCategoryEnabled: true,
-			progressBarEnabled: false,
+			progressBarEnabled: true,
 			layoutView: 'grid',
 			columns: 2,
+			progressBarHeight: 20,
+			progressBarBorderRadius: 10,
 		};
-		const { queryByLabelText, queryByTestId } = render(
+		const {
+			queryByLabelText,
+			queryAllByLabelText,
+			queryByText,
+			queryByTestId,
+		} = render(
 			<LearnerCoursesSettings
 				options={ options }
 				setOptions={ () => {} }
@@ -52,6 +59,15 @@ describe( '<LearnerCoursesSettings />', () => {
 		expect( queryByTestId( 'grid' ) ).toHaveClass( 'is-pressed' );
 
 		expect( queryByLabelText( 'Layout' ).value ).toEqual( '2' );
+
+		// Open progress bar settings.
+		fireEvent.click( queryByText( 'Progress bar settings' ) );
+
+		expect( queryAllByLabelText( 'Height' )[ 0 ].value ).toEqual( '20' );
+
+		expect( queryAllByLabelText( 'Border radius' )[ 0 ].value ).toEqual(
+			'10'
+		);
 	} );
 
 	it( 'Should call the setOptions correctly when changing the fields', () => {
@@ -64,9 +80,16 @@ describe( '<LearnerCoursesSettings />', () => {
 			progressBarEnabled: true,
 			layoutView: 'grid',
 			columns: 2,
+			progressBarHeight: 20,
+			progressBarBorderRadius: 10,
 		};
 
-		const { queryByLabelText, queryByTestId } = render(
+		const {
+			queryByLabelText,
+			queryAllByLabelText,
+			queryByText,
+			queryByTestId,
+		} = render(
 			<LearnerCoursesSettings
 				options={ options }
 				setOptions={ setOptionsMock }
@@ -109,6 +132,23 @@ describe( '<LearnerCoursesSettings />', () => {
 		expect( setOptionsMock ).toBeCalledWith( {
 			columns: '3',
 		} );
+
+		// Open progress bar settings.
+		fireEvent.click( queryByText( 'Progress bar settings' ) );
+
+		fireEvent.change( queryAllByLabelText( 'Height' )[ 0 ], {
+			target: { value: '10', checkValidity: false },
+		} );
+		expect( setOptionsMock ).toBeCalledWith( {
+			progressBarHeight: 10,
+		} );
+
+		fireEvent.change( queryAllByLabelText( 'Border radius' )[ 0 ], {
+			target: { value: '5', checkValidity: false },
+		} );
+		expect( setOptionsMock ).toBeCalledWith( {
+			progressBarBorderRadius: 5,
+		} );
 	} );
 
 	it( 'Should not show layout setting when layout view is "list"', () => {
@@ -124,5 +164,20 @@ describe( '<LearnerCoursesSettings />', () => {
 		);
 
 		expect( queryByLabelText( 'Layout' ) ).toBeFalsy();
+	} );
+
+	it( 'Should not show progress bar settings when progress bar is disabled', () => {
+		const options = {
+			progressBarEnabled: false,
+		};
+
+		const { queryByText } = render(
+			<LearnerCoursesSettings
+				options={ options }
+				setOptions={ () => {} }
+			/>
+		);
+
+		expect( queryByText( 'Progress bar settings' ) ).toBeFalsy();
 	} );
 } );

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -126,12 +126,6 @@ $courses-list: '#{$block}__courses-list';
 							margin: 0 7px;
 						}
 					}
-
-					#{$block} {
-						&__progress-bar {
-							height: 16px;
-						}
-					}
 				}
 			}
 		}

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -153,9 +153,11 @@ $courses-list: '#{$block}__courses-list';
 	}
 
 	&__progress-bar {
-		height: 24px;
+		height: 14px; /* IE11 fallback */
+		height: var( --progress-bar-height, 14px );
 		border: 1px solid #CCC;
-		border-radius: 20px;
+		border-radius: 10px; /* IE11 fallback */
+		border-radius: var( --progress-bar-border-radius, 10px );
 		overflow: hidden;
 
 		&__fill  {

--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -42,6 +42,10 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	 * @access private
 	 */
 	public function enqueue_block_editor_assets() {
-		Sensei()->assets->enqueue( 'sensei-single-page-blocks-style', 'blocks/single-page-style.css' );
+		Sensei()->assets->enqueue(
+			'sensei-single-page-blocks-style',
+			'blocks/single-page-style.css',
+			[ 'sensei-editor-components-style' ]
+		);
 	}
 }


### PR DESCRIPTION
Based on https://github.com/Automattic/sensei/pull/4126

### Changes proposed in this Pull Request

* Add progress bar settings to the Learner Courses block.

### Testing instructions

* Create a page.
* Add the Learner Courses block.
* Disable the progress bar, and make sure the settings disappear. Enable again, and make sure it appears.
* Play with the height and border-radius, and make sure it works properly changing the styles in the editor.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video


https://user-images.githubusercontent.com/876340/112893325-e5dc5c80-90b0-11eb-9f5c-15c23fdc66d4.mov

