### PR TITLE
Add notice when messages are disabled and Learner Messages Button block is used

### DIFF
--- a/assets/blocks/learner-messages-button-block/index.js
+++ b/assets/blocks/learner-messages-button-block/index.js
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { BlockStyles, createButtonBlockType } from '../button';
+import MessagesDisabledNotice from './messages-disabled-notice';
 
 /**
  * Learner messages button block.
@@ -31,4 +32,5 @@ export default createButtonBlockType( {
 			BlockStyles.Link,
 		],
 	},
+	EditWrapper: MessagesDisabledNotice,
 } );

--- a/assets/blocks/learner-messages-button-block/messages-disabled-notice.js
+++ b/assets/blocks/learner-messages-button-block/messages-disabled-notice.js
@@ -39,7 +39,10 @@ const MessagesDisabledNotice = ( { children, attributes: { isPreview } } ) => {
 					actions: [
 						{
 							url: window.sensei_messages.settings_url,
-							label: 'Go to disabled messages setting',
+							label: __(
+								'Go to disabled messages setting',
+								'sensei-lms'
+							),
 						},
 					],
 				}

--- a/assets/blocks/learner-messages-button-block/messages-disabled-notice.js
+++ b/assets/blocks/learner-messages-button-block/messages-disabled-notice.js
@@ -1,0 +1,60 @@
+/**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+import { useSelect, useDispatch } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Messages disabled notice component.
+ * It's used as a wrapper to show the notice messages is disabled and the
+ * Learner Messages block is in the editor.
+ *
+ * @param {Object} props                      Component props.
+ * @param {Object} props.children             Children to be wrapped.
+ * @param {Object} props.attributes           Block attributes.
+ * @param {Object} props.attributes.isPreview Is preview component.
+ */
+const MessagesDisabledNotice = ( { children, attributes: { isPreview } } ) => {
+	const { createWarningNotice, removeNotice } = useDispatch( 'core/notices' );
+	const blockCount = useSelect( ( select ) =>
+		select( 'core/block-editor' ).getGlobalBlockCount(
+			'sensei-lms/button-learner-messages'
+		)
+	);
+
+	useEffect( () => {
+		if ( isPreview ) {
+			return;
+		}
+
+		if ( '1' === window.sensei_messages.disabled ) {
+			createWarningNotice(
+				__(
+					'You have added the "Learner Messages Button" block to your editor, but messages are disabled in your settings.',
+					'sensei-lms'
+				),
+				{
+					id: 'sensei-messages-disabled',
+					actions: [
+						{
+							url: window.sensei_messages.settings_url,
+							label: 'Go to disabled messages setting',
+						},
+					],
+				}
+			);
+		}
+
+		return () => {
+			// Check if it's the last one.
+			if ( 1 === blockCount ) {
+				removeNotice( 'sensei-messages-disabled' );
+			}
+		};
+	}, [ isPreview, blockCount, createWarningNotice, removeNotice ] );
+
+	return children;
+};
+
+export default MessagesDisabledNotice;

--- a/includes/blocks/class-sensei-learner-messages-button-block.php
+++ b/includes/blocks/class-sensei-learner-messages-button-block.php
@@ -20,8 +20,25 @@ class Sensei_Learner_Messages_Button_Block {
 	 */
 	public function __construct() {
 		$this->register_block();
+
+		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
 	}
 
+	/**
+	 * Enqueue admin scripts.
+	 *
+	 * @access private
+	 */
+	public function admin_enqueue_scripts() {
+		wp_localize_script(
+			'sensei-single-page-blocks',
+			'sensei_messages',
+			[
+				'disabled'     => Sensei()->settings->settings['messages_disable'],
+				'settings_url' => esc_url( admin_url( 'admin.php?page=sensei-settings' ) ),
+			]
+		);
+	}
 
 	/**
 	 * Register learner messages block.


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add notice when messages are disabled and Learner Messages Button block is used

### Testing instructions

* Go to the Sensei settings, and disable the private messages.
* Create a page.
* Add the Learner Messages Button block.
* Make sure you see a warning that the messages are disabled.
* Enable the messages.
* Go to the page again with the messages block, and make sure the warning doesn't appear anymore.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/112910268-68711600-90c9-11eb-9cd0-388900e296bc.mov

