### PR TITLE
Add learner course block rendering

### DIFF
--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -151,26 +151,20 @@ class Sensei_Blocks {
 	}
 
 	/**
-	 * Check if the current post has Sensei blocks.
+	 * Check if the current post has any Sensei blocks.
+	 *
+	 * @param int|WP_Post|null $post
 	 *
 	 * @return bool
 	 */
-	public function has_sensei_blocks() {
-		global $post;
-
-		if ( ! $post ) {
-			return false;
+	public function has_sensei_blocks( $post = null ) {
+		if ( ! is_string( $post ) ) {
+			$wp_post = get_post( $post );
+			if ( $wp_post instanceof WP_Post ) {
+				$post = $wp_post->post_content;
+			}
 		}
 
-		switch ( $post->post_type ) {
-			case 'course':
-				return Sensei()->course->has_sensei_blocks();
-			case 'lesson':
-				return Sensei()->lesson->has_sensei_blocks();
-			case 'quiz':
-				return Sensei()->quiz->has_sensei_blocks();
-			default:
-				return false;
-		}
+		return false !== strpos( (string) $post, '<!-- wp:sensei-lms/' );
 	}
 }

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -45,7 +45,7 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 	 * Sensei_Course_Blocks constructor.
 	 */
 	public function __construct() {
-		parent::__construct( [ 'course' ] );
+		parent::__construct( [ 'course', 'page' ] );
 		add_filter( 'sensei_use_sensei_template', [ 'Sensei_Course_Blocks', 'skip_single_course_template' ] );
 
 	}

--- a/includes/blocks/class-sensei-course-progress-block.php
+++ b/includes/blocks/class-sensei-course-progress-block.php
@@ -44,12 +44,13 @@ class Sensei_Course_Progress_Block {
 	 * @return string The HTML of the block.
 	 */
 	public function render_course_progress( $attributes ) : string {
-		if ( ! Sensei()->course::is_user_enrolled( get_the_ID() ) ) {
+		$course_id = $attributes['postId'] ?? get_the_ID();
+		if ( ! Sensei()->course::is_user_enrolled( $course_id ) ) {
 			return '';
 		}
 
-		$completed     = count( Sensei()->course->get_completed_lesson_ids( get_the_ID() ) );
-		$total_lessons = count( Sensei()->course->course_lessons( get_the_ID() ) );
+		$completed     = count( Sensei()->course->get_completed_lesson_ids( $course_id ) );
+		$total_lessons = count( Sensei()->course->course_lessons( $course_id ) );
 		$percentage    = Sensei_Utils::quotient_as_absolute_rounded_percentage( $completed, $total_lessons, 2 );
 
 		$text_css           = Sensei_Block_Helpers::build_styles( $attributes );

--- a/includes/blocks/class-sensei-learner-courses-block.php
+++ b/includes/blocks/class-sensei-learner-courses-block.php
@@ -74,6 +74,7 @@ class Sensei_Learner_Courses_Block {
 	 */
 	public function render_course( $course ) {
 		$class       = 'wp-block-sensei-lms-learner-courses__courses-list';
+		$progressbar = ( new Sensei_Course_Progress_Block() )->render_course_progress( [ 'postId' => $course->ID ] );
 		$title       = get_the_title( $course );
 		$description = get_the_excerpt( $course );
 		$thumbnail   = get_the_post_thumbnail( $course, 'thumbnail', [ 'class' => $class . '__featured-image alignleft' ] );
@@ -95,6 +96,7 @@ class Sensei_Learner_Courses_Block {
 						{$description}
 					</p>
 					<div style="clear: both"></div>
+					{$progressbar}
 					{$actions}
 				</div>
 		</div>

--- a/includes/blocks/class-sensei-learner-courses-block.php
+++ b/includes/blocks/class-sensei-learner-courses-block.php
@@ -14,6 +14,13 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Learner_Courses_Block {
 	/**
+	 * User courses helper.
+	 *
+	 * @var Sensei_Shortcode_User_Courses
+	 */
+	private $user_courses;
+
+	/**
 	 * Sensei_Learner_Courses_Block constructor.
 	 */
 	public function __construct() {
@@ -34,7 +41,65 @@ class Sensei_Learner_Courses_Block {
 	 *
 	 * @return string The HTML of the block.
 	 */
-	public function render( $attributes, $content ) : string {
-		return '<p>Learner Courses block content</p>';
+	public function render( $attributes, $content ): string {
+
+		$this->user_courses = new Sensei_Shortcode_User_Courses( [], null, null );
+		$query              = $this->user_courses->setup_course_query();
+
+		$tabs    = $this->render_tabs();
+		$courses = array_map( [ $this, 'render_course' ], $query->posts );
+		$courses = join( '', $courses );
+
+		return '<section id="sensei-user-courses wp-block-sensei-lms-learner-courses">' . $tabs . $courses . '</section>';
+
 	}
+
+	/**
+	 * Render course status filter tabs.
+	 *
+	 * @return string Tabs HTML.
+	 */
+	public function render_tabs() {
+		ob_start();
+		$this->user_courses->course_toggle_actions();
+		return ob_get_clean();
+	}
+
+	/**
+	 * Render a course entry.
+	 *
+	 * @param WP_Post $course
+	 *
+	 * @return string Course entry HTML.
+	 */
+	public function render_course( $course ) {
+		$class       = 'wp-block-sensei-lms-learner-courses__courses-list';
+		$title       = get_the_title( $course );
+		$description = get_the_excerpt( $course );
+		$thumbnail   = get_the_post_thumbnail( $course, 'thumbnail', [ 'class' => $class . '__featured-image alignleft' ] );
+
+		ob_start();
+		Sensei_Course::the_course_action_buttons( $course );
+		$actions = ob_get_clean();
+
+		return <<<HTML
+<div class="{$class}__item">
+			<div>
+					<header class="{$class}__header">
+						<h3 class="{$class}__title">
+							{$title}
+						</h3>
+					</header>
+					{$thumbnail}
+					<p class="{$class}__description">
+						{$description}
+					</p>
+					<div style="clear: both"></div>
+					{$actions}
+				</div>
+		</div>
+HTML;
+
+	}
+
 }

--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -34,7 +34,7 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	 * @access private
 	 */
 	public function enqueue_block_assets() {
-		Sensei()->assets->enqueue( 'sensei-single-page-blocks', 'blocks/single-page.js', [], true );
+		Sensei()->assets->enqueue( 'sensei-single-page-blocks-style', 'blocks/single-page-style.css' );
 	}
 
 	/**
@@ -43,6 +43,6 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	 * @access private
 	 */
 	public function enqueue_block_editor_assets() {
-		Sensei()->assets->enqueue( 'sensei-single-page-blocks-style', 'blocks/single-page-style.css' );
+		Sensei()->assets->enqueue( 'sensei-single-page-blocks', 'blocks/single-page.js', [], true );
 	}
 }

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -35,6 +35,7 @@ function is_sensei() {
 			|| Sensei_Utils::is_learner_profile_page()
 			|| Sensei_Utils::is_course_results_page()
 			|| Sensei_Utils::is_teacher_archive_page()
+			|| Sensei()->blocks->has_sensei_blocks()
 		) {
 			$is_sensei = true;
 		}

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -167,7 +167,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	 *
 	 * @since 1.9.0
 	 */
-	protected function setup_course_query() {
+	public function setup_course_query() {
 		$learner_manager = Sensei_Learner::instance();
 		$user_id         = get_current_user_id();
 		$empty_callback  = [ $this, 'no_course_message_output' ];
@@ -194,6 +194,8 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		if ( empty( $this->query->found_posts ) ) {
 			add_action( 'sensei_loop_course_inside_before', $empty_callback );
 		}
+
+		return $this->query;
 
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add render callback with new HTML markup for Learner Courses block (based on #4126)
* Use query built by `Sensei_Shortcode_User_Courses`
* Use progress bar block 

### Testing instructions

* 

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
