### PR TITLE
Fix outline block crash

### DIFF
--- a/assets/blocks/course-outline/course-outline-store.js
+++ b/assets/blocks/course-outline/course-outline-store.js
@@ -56,7 +56,7 @@ registerStructureStore( {
 		yield dispatch( 'core/block-editor' ).replaceInnerBlocks(
 			clientId,
 			syncStructureToBlocks( structure, blocks ),
-			true
+			false
 		);
 	},
 	readBlock: getEditorOutlineStructure,

--- a/assets/blocks/course-outline/module-block/module-edit.js
+++ b/assets/blocks/course-outline/module-block/module-edit.js
@@ -28,6 +28,8 @@ import SingleLineInput from '../../../shared/blocks/single-line-input';
 import { ModuleStatus } from './module-status';
 import ModuleSettings from './module-settings';
 
+const ALLOWED_BLOCKS = [ 'sensei-lms/course-outline-lesson' ];
+
 /**
  * Edit module block component.
  *
@@ -196,7 +198,7 @@ export const ModuleEdit = ( props ) => {
 						{ __( 'Lessons', 'sensei-lms' ) }
 					</h3>
 					<InnerBlocks
-						allowedBlocks={ [ 'sensei-lms/course-outline-lesson' ] }
+						allowedBlocks={ ALLOWED_BLOCKS }
 						templateInsertUpdatesSelection={ false }
 						renderAppender={ () => null }
 					/>

--- a/assets/blocks/course-outline/outline-block/outline-edit.js
+++ b/assets/blocks/course-outline/outline-block/outline-edit.js
@@ -17,6 +17,11 @@ import { useCourseLessonsStatusSync } from '../status-preview/use-course-lessons
 import { COURSE_STORE } from '../course-outline-store';
 import { useBlocksCreator } from '../use-block-creator';
 
+const ALLOWED_BLOCKS = [
+	'sensei-lms/course-outline-module',
+	'sensei-lms/course-outline-lesson',
+];
+
 /**
  * A React context which contains the attributes and the setAttributes callback of the Outline block.
  */
@@ -67,12 +72,7 @@ const OutlineEdit = ( props ) => {
 			<OutlineSettings { ...props } />
 
 			<section className={ className }>
-				<InnerBlocks
-					allowedBlocks={ [
-						'sensei-lms/course-outline-module',
-						'sensei-lms/course-outline-lesson',
-					] }
-				/>
+				<InnerBlocks allowedBlocks={ ALLOWED_BLOCKS } />
 			</section>
 		</OutlineAttributesContext.Provider>
 	);

--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -19,6 +19,11 @@ import QuizSettings from './quiz-settings';
 import { useUpdateQuizHasQuestionsMeta } from './use-update-quiz-has-questions-meta';
 import { isQuestionEmpty } from '../data';
 
+const ALLOWED_BLOCKS = [
+	'sensei-lms/quiz-question',
+	'sensei-lms/quiz-category-question',
+];
+
 /**
  * Quiz block editor.
  *
@@ -65,10 +70,7 @@ const QuizEdit = ( props ) => {
 				<span>{ __( 'Lesson Quiz', 'sensei-lms' ) }</span>
 			</div>
 			<InnerBlocks
-				allowedBlocks={ [
-					'sensei-lms/quiz-question',
-					'sensei-lms/quiz-category-question',
-				] }
+				allowedBlocks={ ALLOWED_BLOCKS }
 				templateInsertUpdatesSelection={ false }
 				renderAppender={ AppenderComponent }
 			/>


### PR DESCRIPTION
Fixes #4065 

### Changes proposed in this Pull Request

* This is another way to fix issue #4065 without updating the `updateSelection` flag as was done in #4125
* The fix was implemented after receiving feedback in [this issue](https://github.com/WordPress/gutenberg/issues/30350)

### Testing instructions

* Follow the intstructions in #4125 and observe that the issue is solved without the course outline block getting selected after load.