### PR TITLE
Add color settings to Learner Courses block

### DIFF
--- a/assets/blocks/learner-courses-block/block.json
+++ b/assets/blocks/learner-courses-block/block.json
@@ -15,7 +15,9 @@
         "courseCategoryEnabled": false,
         "progressBarEnabled": true,
         "progressBarBorderRadius": 10,
-        "progressBarHeight": 14
+        "progressBarHeight": 14,
+        "primaryColor": null,
+        "accentColor": null
       }
     }
   }

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import classnames from 'classnames';
+import { omitBy } from 'lodash';
 
 /**
  * WordPress dependencies
@@ -119,14 +120,20 @@ const LearnerCoursesEdit = ( {
 		<>
 			<section
 				className={ className }
-				style={ {
-					...( undefined !== options.progressBarHeight && {
+				style={ omitBy(
+					{
 						'--progress-bar-height': `${ options.progressBarHeight }px`,
-					} ),
-					...( undefined !== options.progressBarBorderRadius && {
 						'--progress-bar-border-radius': `${ options.progressBarBorderRadius }px`,
-					} ),
-				} }
+						'--primary-color': options.primaryColor,
+						'--accent-color': options.accentColor,
+					},
+					// Exclude not set values.
+					( value ) => {
+						return [ undefined, null, 'undefinedpx' ].includes(
+							value
+						);
+					}
+				) }
 			>
 				<ul className="wp-block-sensei-lms-learner-courses__filter">
 					{ filters.map( ( { label, value } ) => (

--- a/assets/blocks/learner-courses-block/learner-courses-settings.js
+++ b/assets/blocks/learner-courses-block/learner-courses-settings.js
@@ -1,7 +1,11 @@
 /**
  * WordPress dependencies
  */
-import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	InspectorControls,
+	PanelColorSettings,
+} from '@wordpress/block-editor';
 import {
 	PanelBody,
 	PanelRow,
@@ -55,6 +59,19 @@ const LearnerCoursesSettings = ( { options, setOptions } ) => {
 			view: 'grid',
 			label: __( 'Grid view', 'sensei-lms' ),
 			icon: grid,
+		},
+	];
+
+	const colorSettings = [
+		{
+			optionKey: 'primaryColor',
+			label: __( 'Primary color', 'sensei-lms' ),
+			value: options.primaryColor,
+		},
+		{
+			optionKey: 'accentColor',
+			label: __( 'Accent color', 'sensei-lms' ),
+			value: options.accentColor,
 		},
 	];
 
@@ -126,6 +143,18 @@ const LearnerCoursesSettings = ( { options, setOptions } ) => {
 						} }
 					/>
 				) }
+				<PanelColorSettings
+					title={ __( 'Color settings', 'sensei-lms' ) }
+					initialOpen={ false }
+					colorSettings={ colorSettings.map(
+						( { optionKey, ...settings } ) => ( {
+							...settings,
+							onChange: ( value ) => {
+								setOptions( { [ optionKey ]: value } );
+							},
+						} )
+					) }
+				/>
 			</InspectorControls>
 			<BlockControls>
 				<ToolbarGroup>

--- a/assets/blocks/learner-courses-block/learner-courses-settings.test.js
+++ b/assets/blocks/learner-courses-block/learner-courses-settings.test.js
@@ -13,6 +13,7 @@ jest.mock( '@wordpress/block-editor', () => ( {
 	...jest.requireActual( '@wordpress/block-editor' ),
 	InspectorControls: ( { children } ) => children,
 	BlockControls: ( { children } ) => children,
+	PanelColorSettings: () => 'Color settings',
 } ) );
 
 describe( '<LearnerCoursesSettings />', () => {

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -24,11 +24,13 @@ $courses-list: '#{$block}__courses-list';
 			}
 
 			&.--is-active {
-				border-bottom: solid 3px #000;
+				color: var( --accent-color, inherit );
+				border-bottom: solid 3px currentColor;
 			}
 		}
 
-		&__link {
+		& &__link {
+			color: inherit;
 			text-decoration: none;
 		}
 	}
@@ -76,6 +78,7 @@ $courses-list: '#{$block}__courses-list';
 			margin: 0;
 			font-size: 24px;
 			font-weight: bold;
+			color: var( --primary-color, inherit );
 		}
 
 		&__badge {
@@ -157,6 +160,7 @@ $courses-list: '#{$block}__courses-list';
 		&__fill  {
 			height: 100%;
 			background-color: #888;
+			background-color: var( --accent-color, #888 );
 		}
 	}
 }

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -5,7 +5,7 @@ $courses-list: '#{$block}__courses-list';
 	&__filter,
 	.editor-styles-wrapper &__filter {
 		display: flex;
-		border-bottom: 1px solid #000;
+		border-bottom: 1px solid currentColor;
 		padding: 0;
 		margin: 0;
 		list-style: none;
@@ -86,7 +86,8 @@ $courses-list: '#{$block}__courses-list';
 			vertical-align: middle;
 			margin-left: 18px;
 			padding: 3px 11px;
-			border: 1px solid #000;
+			color: var( --primary-color, inherit );
+			border: 1px solid currentColor;
 			border-radius: 4px;
 			font-size: 8px;
 			text-transform: uppercase;
@@ -152,15 +153,15 @@ $courses-list: '#{$block}__courses-list';
 	&__progress-bar {
 		height: 14px; /* IE11 fallback */
 		height: var( --progress-bar-height, 14px );
-		border: 1px solid #CCC;
+		border: 1px solid currentColor;
 		border-radius: 10px; /* IE11 fallback */
 		border-radius: var( --progress-bar-border-radius, 10px );
 		overflow: hidden;
 
 		&__fill  {
 			height: 100%;
-			background-color: #888;
-			background-color: var( --accent-color, #888 );
+			background-color: currentColor;
+			background-color: var( --accent-color, currentColor );
 		}
 	}
 }


### PR DESCRIPTION
Based on https://github.com/Automattic/sensei/pull/4138

### Changes proposed in this Pull Request

* This is a pretty simple approach to color settings to the Learner Courses block using CSS variables.
* It's not trying to set any theme primary color on the first editor load. I think we can avoid this until Global Styles is done, so we make our code cleaner.
* For now, I used pretty simple variables names, without any Global Styles standard. I think it's safer for now, and when Global Styles is released we can easily tweak it to get the global styles variables and set the block variables in the correct standards.
* This PR also changes the default colors to inherit the theme text colors by default. - Probably a good solution for this: https://github.com/Automattic/sensei/pull/4126#issuecomment-810234635.

### Testing instructions

* Create a page.
* Add the Learner Courses block.
* Play with the color settings (in the sidebar), and make sure it works properly. Save, and make sure it's persisted after the page refresh.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/113042132-2f8c7c00-9171-11eb-9581-af85a0f6d092.mov

