### PR TITLE
Add Sensei version to Extension messages transient

### DIFF
--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -134,7 +134,8 @@ final class Sensei_Extensions {
 	 * @return array
 	 */
 	private function get_messages() {
-		$extension_messages = get_transient( 'sensei_extensions_messages' );
+		$transient_key = implode( '_', [ 'sensei_extensions_messages', Sensei()->version, get_locale() ] );
+		$extension_messages = get_transient( $transient_key );
 		if ( false === $extension_messages ) {
 			$raw_messages = wp_safe_remote_get(
 				add_query_arg(
@@ -145,10 +146,11 @@ final class Sensei_Extensions {
 					self::SENSEILMS_PRODUCTS_API_BASE_URL . '/messages'
 				)
 			);
+
 			if ( ! is_wp_error( $raw_messages ) ) {
 				$extension_messages = json_decode( wp_remote_retrieve_body( $raw_messages ) );
 				if ( $extension_messages ) {
-					set_transient( 'sensei_extensions_messages', $extension_messages, DAY_IN_SECONDS );
+					set_transient( $transient_key, $extension_messages, DAY_IN_SECONDS );
 				}
 			}
 		}

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -134,7 +134,7 @@ final class Sensei_Extensions {
 	 * @return array
 	 */
 	private function get_messages() {
-		$transient_key = implode( '_', [ 'sensei_extensions_messages', Sensei()->version, get_locale() ] );
+		$transient_key      = implode( '_', [ 'sensei_extensions_messages', Sensei()->version, get_locale() ] );
 		$extension_messages = get_transient( $transient_key );
 		if ( false === $extension_messages ) {
 			$raw_messages = wp_safe_remote_get(

--- a/includes/admin/views/html-admin-page-extensions-messages.php
+++ b/includes/admin/views/html-admin-page-extensions-messages.php
@@ -28,6 +28,6 @@ if ( ! empty( $messages ) ) {
 			$action_str = ' <a href="' . esc_url( $action_url ) . '" rel="noopener" target="' . esc_attr( $action_target ) . '" class="button">' . esc_html( $action_label ) . '</a>';
 		}
 
-		echo '<div class="notice notice-' . esc_attr( $message_type ) . ' below-h2"><p><strong>' . esc_html( $message->message ) . '</strong>' . wp_kses_post( $action_str ) . '</p></div>';
+		echo '<div class="notice notice-' . esc_attr( $message_type ) . ' below-h2"><p><strong>' . esc_html( $message->message ) . '</strong></p><p>' . wp_kses_post( $action_str ) . '</p></div>';
 	}
 }


### PR DESCRIPTION
If we put an update notice here, it won't expire until up till 24h (transient). This should fix that issue.

### Changes proposed in this Pull Request

* Adds Sensei version to Extension messages transient. 
* Moves message button below message to match our WCPC message.
