### PR TITLE
Make invalid category question save message more descriptive

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -114,7 +114,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			'post_status' => 'publish',
 			'post_type'   => 'multiple_question',
 			'meta_input'  => [
-				'category' => $question_category ? $question_category->term_id : '',
+				'category' => $question_category->term_id,
 				'number'   => $question_number,
 			],
 		];

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -92,6 +92,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		$question_id          = isset( $question['id'] ) ? (int) $question['id'] : null;
 		$question_number      = (int) $question['options']['number'];
 		$question_category_id = (int) $question['options']['category'];
+		$question_category    = false;
 
 		if ( $question_category_id ) {
 			$question_category = get_term( $question_category_id, 'question-category' );

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -98,7 +98,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 		}
 
 		if ( ! $question_category || is_wp_error( $question_category ) ) {
-			return new WP_Error( 'sensei_lesson_quiz_question_invalid_category', esc_html__( 'Invalid question category selected', 'sensei-lms' ), $question_id );
+			return new WP_Error( 'sensei_lesson_quiz_question_invalid_category', esc_html__( 'Invalid question category selected.', 'sensei-lms' ), $question_id );
 		}
 
 		if ( ! $question_number ) {

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -88,7 +88,6 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			$question['options'] = [];
 		}
 
-		$category             = null;
 		$question_id          = isset( $question['id'] ) ? (int) $question['id'] : null;
 		$question_number      = (int) $question['options']['number'];
 		$question_category_id = (int) $question['options']['category'];
@@ -106,10 +105,8 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			$question_number = 1;
 		}
 
-		$category = get_term( $question_category, 'question-category' );
-
 		// translators: Placeholders are the question number and the question category name.
-		$post_title = sprintf( esc_html__( '%1$s Question(s) from %2$s', 'sensei-lms' ), $question_number, $category->name );
+		$post_title = sprintf( esc_html__( '%1$s Question(s) from %2$s', 'sensei-lms' ), $question_number, $question_category->name );
 
 		$post_args = [
 			'ID'          => $question_id,
@@ -117,7 +114,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			'post_status' => 'publish',
 			'post_type'   => 'multiple_question',
 			'meta_input'  => [
-				'category' => $category->term_id,
+				'category' => $question_category ? $question_category->term_id : '',
 				'number'   => $question_number,
 			],
 		];
@@ -720,7 +717,7 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 				'type'       => 'object',
 				'properties' => [
 					'category' => [
-						'type'        => 'integer',
+						'type'        => [ 'integer', 'null' ],
 						'description' => 'Term ID of the category where questions are picked',
 						'required'    => true,
 					],


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Shows a real validation message when trying to save a category question without a category.
* I tried to initially save it with the invalid options, but that led to a can of worms.

### Testing instructions

* Save a quiz with a just added category question without a category selected.