### PR TITLE
Show teacher's questions only when using category questions

### DIFF
--- a/assets/blocks/quiz/category-question-block/category-question-settings.js
+++ b/assets/blocks/quiz/category-question-block/category-question-settings.js
@@ -78,10 +78,10 @@ const CategoryQuestionSettings = ( {
 		getQuestionCategoryById,
 	] = useQuestionCategories();
 
-	const [ error, setError ] = useState( null );
+	const [ questionsFetchError, setQuestionsFetchError ] = useState( null );
 	const categoryQuestionsCount = useCategoryQuestionsCount(
 		options.category,
-		setError
+		setQuestionsFetchError
 	);
 
 	const categoryOptions = [
@@ -127,7 +127,7 @@ const CategoryQuestionSettings = ( {
 									}
 								);
 
-								setError( null );
+								setQuestionsFetchError( null );
 							} }
 						/>
 						<NumberControl
@@ -142,7 +142,7 @@ const CategoryQuestionSettings = ( {
 								} )
 							}
 						/>
-						{ error !== null && (
+						{ questionsFetchError !== null && (
 							<Notice status="error" isDismissible={ false }>
 								{ sprintf(
 									// translators: The underlying error message.
@@ -150,12 +150,12 @@ const CategoryQuestionSettings = ( {
 										'An error occurred while retrieving questions: %s',
 										'sensei-lms'
 									),
-									error
+									questionsFetchError
 								) }
 							</Notice>
 						) }
 						{ categoryQuestionsCount !== false &&
-							error === null &&
+							questionsFetchError === null &&
 							options.number > categoryQuestionsCount && (
 								<Notice
 									status="warning"

--- a/assets/blocks/quiz/category-question-block/category-question-settings.js
+++ b/assets/blocks/quiz/category-question-block/category-question-settings.js
@@ -4,12 +4,56 @@
 import { InspectorControls } from '@wordpress/block-editor';
 import { Notice, PanelBody, SelectControl } from '@wordpress/components';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
  */
 import NumberControl from '../../editor-components/number-control';
 import { useQuestionCategories } from '../question-categories';
+
+/**
+ * Calculate the number of questions that are available in a category.
+ *
+ * @param {number}   categoryId The category id.
+ * @param {Function} onError    Called when an error happens.
+ *
+ * @return {number|boolean} The number of questions in a category or false if unknown.
+ */
+const useCategoryQuestionsCount = ( categoryId, onError ) => {
+	const [ categoriesQuestionCount, setCategoriesQuestionCount ] = useState(
+		{}
+	);
+
+	useEffect( () => {
+		if (
+			categoryId &&
+			! categoriesQuestionCount.hasOwnProperty( categoryId )
+		) {
+			apiFetch( {
+				path: `/wp/v2/questions?question-category=${ categoryId }`,
+				method: 'GET',
+				parse: false,
+			} )
+				.then( ( res ) => {
+					categoriesQuestionCount[ categoryId ] = +res.headers.get(
+						'X-WP-Total'
+					);
+					setCategoriesQuestionCount( {
+						...categoriesQuestionCount,
+					} );
+				} )
+				.catch( ( res ) => {
+					res.json().then( ( error ) => onError( error.message ) );
+				} );
+		}
+	}, [ categoryId, categoriesQuestionCount, onError ] );
+
+	return categoriesQuestionCount.hasOwnProperty( categoryId )
+		? categoriesQuestionCount[ categoryId ]
+		: false;
+};
 
 /**
  * Category question block settings controls.
@@ -34,6 +78,12 @@ const CategoryQuestionSettings = ( {
 		getQuestionCategoryById,
 	] = useQuestionCategories();
 
+	const [ error, setError ] = useState( null );
+	const categoryQuestionsCount = useCategoryQuestionsCount(
+		options.category,
+		setError
+	);
+
 	const categoryOptions = [
 		{
 			value: '',
@@ -44,8 +94,6 @@ const CategoryQuestionSettings = ( {
 			label: questionCategory.name,
 		} ) ),
 	];
-
-	const questionCategory = getQuestionCategoryById( options.category );
 
 	return (
 		<InspectorControls>
@@ -78,6 +126,8 @@ const CategoryQuestionSettings = ( {
 											nextQuestionCategory?.name,
 									}
 								);
+
+								setError( null );
 							} }
 						/>
 						<NumberControl
@@ -92,9 +142,21 @@ const CategoryQuestionSettings = ( {
 								} )
 							}
 						/>
-
-						{ questionCategory &&
-							options.number > questionCategory.count && (
+						{ error !== null && (
+							<Notice status="error" isDismissible={ false }>
+								{ sprintf(
+									// translators: The underlying error message.
+									__(
+										'An error occurred while retrieving questions: %s',
+										'sensei-lms'
+									),
+									error
+								) }
+							</Notice>
+						) }
+						{ categoryQuestionsCount !== false &&
+							error === null &&
+							options.number > categoryQuestionsCount && (
 								<Notice
 									status="warning"
 									isDismissible={ false }
@@ -104,10 +166,10 @@ const CategoryQuestionSettings = ( {
 										_n(
 											'The selected category has %d question.',
 											'The selected category has %d questions.',
-											questionCategory.count,
+											categoryQuestionsCount,
 											'sensei-lms'
 										),
-										questionCategory.count
+										categoryQuestionsCount
 									) }
 								</Notice>
 							) }

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -852,12 +852,14 @@ class Sensei_Frontend {
 	/**
 	 * Gets the quiz answers for the current user.
 	 *
-	 * @deprecated use Sensei_Quiz::get_user_answers
+	 * @deprecated 3.10.0 use Sensei_Quiz::get_user_answers
 	 * @param int $lesson_id Lesson ID.
 	 * @return array Quiz answers for the current user.
 	 */
 	public function sensei_get_user_quiz_answers( $lesson_id = 0 ) {
 		global $current_user;
+
+		_deprecated_function( __METHOD__, '3.10.0', 'Sensei_Quiz::get_user_answers' );
 
 		$user_answers = array();
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3374,6 +3374,7 @@ class Sensei_Lesson {
 						 * this filter.
 						 *
 						 * @since 3.10.0
+						 * @hook sensei_filter_category_questions_by_author
 						 *
 						 * @param {array}  $quiz_id The quiz id.
 						 *

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3304,6 +3304,7 @@ class Sensei_Lesson {
 
 		// If viewing quiz on frontend or in grading then only single questions must be shown.
 		$selected_questions = false;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Input used for comparisons.
 		if ( ! is_admin() || ( is_admin() && isset( $_GET['page'] ) && 'sensei_grading' === $_GET['page'] && isset( $_GET['user'] ) && isset( $_GET['quiz_id'] ) ) ) {
 
 			// Fetch the questions that the user was asked in their quiz if they have already completed it.
@@ -3351,7 +3352,7 @@ class Sensei_Lesson {
 						$question_number = (int) get_post_meta( $question->ID, 'number', true );
 						$quiz_author     = get_post( $quiz_id )->post_author;
 
-						$qargs         = [
+						$qargs = [
 							'post_type'        => 'question',
 							'posts_per_page'   => $question_number,
 							'orderby'          => $orderby,

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3355,7 +3355,6 @@ class Sensei_Lesson {
 							'post_type'        => 'question',
 							'posts_per_page'   => $question_number,
 							'orderby'          => $orderby,
-							'author'           => $quiz_author,
 							'tax_query'        => [
 								[
 									'taxonomy' => 'question-category',
@@ -3367,6 +3366,11 @@ class Sensei_Lesson {
 							'suppress_filters' => 0,
 							'post__not_in'     => $existing_questions,
 						];
+
+						if ( ! user_can( $quiz_author, 'manage_options' ) ) {
+							$qargs['author'] = $quiz_author;
+						}
+
 						$cat_questions = get_posts( $qargs );
 
 						// Merge results into return array.

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3368,7 +3368,20 @@ class Sensei_Lesson {
 							'post__not_in'     => $existing_questions,
 						];
 
-						if ( ! user_can( $quiz_author, 'manage_options' ) ) {
+						/**
+						 * When a question category is expanded to its questions, if the quiz owner is not an admin,
+						 * only the questions owned by the teacher are included. This behaviour can be disabled with
+						 * this filter.
+						 *
+						 * @since 3.10.0
+						 *
+						 * @param {array}  $quiz_id The quiz id.
+						 *
+						 * @return {array} Whether questions should be filtered by author.
+						 */
+						$should_filter = apply_filters( 'sensei_filter_category_questions_by_author', true, $quiz_id );
+
+						if ( $should_filter && ! user_can( $quiz_author, 'manage_options' ) ) {
 							$qargs['author'] = $quiz_author;
 						}
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3349,6 +3349,7 @@ class Sensei_Lesson {
 						// If this is a multiple question then get the specified amount of questions from the specified category.
 						$question_cat    = (int) get_post_meta( $question->ID, 'category', true );
 						$question_number = (int) get_post_meta( $question->ID, 'number', true );
+						$quiz_author     = get_post( $quiz_id )->post_author;
 
 						$qargs         = [
 							'post_type'        => 'question',

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1211,7 +1211,7 @@ class Sensei_Quiz {
 
 		global $sensei_question_loop;
 
-		// intialize the questions loop object
+		// Initialise the questions loop object.
 		$sensei_question_loop['current']   = -1;
 		$sensei_question_loop['total']     = 0;
 		$sensei_question_loop['questions'] = array();
@@ -1219,23 +1219,24 @@ class Sensei_Quiz {
 		$questions = Sensei()->lesson->lesson_quiz_questions( get_the_ID(), 'publish' );
 
 		if ( count( $questions ) > 0 ) {
-
 			$sensei_question_loop['total']     = count( $questions );
 			$sensei_question_loop['questions'] = $questions;
 			$sensei_question_loop['quiz_id']   = get_the_ID();
-
 		}
-
-	}//end start_quiz_questions_loop()
+	}
 
 	/**
 	 * Initialize the quiz question loop on the single quiz template
 	 *
 	 * The function will create a global quiz loop varialbe.
 	 *
+	 * @deprecated 3.10.0
+	 *
 	 * @since 1.9.0
 	 */
 	public static function stop_quiz_questions_loop() {
+
+		_deprecated_function( __METHOD__, '3.10.0' );
 
 		$sensei_question_loop              = [];
 		$sensei_question_loop['total']     = 0;

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -774,17 +774,8 @@ function sensei_quiz_has_questions() {
 		return false;
 	}
 
-	if ( $sensei_question_loop['current'] + 1 < $sensei_question_loop['total'] ) {
-
-		return true;
-
-	} else {
-
-		return false;
-
-	}
-
-}//end sensei_quiz_has_questions()
+	return $sensei_question_loop['current'] + 1 < $sensei_question_loop['total'];
+}
 
 /**
  * This funciton must only be run inside the quiz question loop.


### PR DESCRIPTION
### Overview
In the quiz editor, when a category question was added, all questions were included regardless if they belong to the teacher or not. With this change this is now fixed.

### Changes proposed in this Pull Request

* If the quiz author is not admin, then only the questions that he owns are displayed when a category question is expanded.
* If the quiz author is an admin all questions are added since as an admin he has access to all questions.
* In the quiz editor, the question counts have been updated in order for the warning to displayed correctly.
* While I was searching the code, I also did some cleanup.
* @donnapep since this is going to reduce the questions that a quiz has in some of the cases, we might want to mention it in the next release post. Users can use the `sensei_filter_category_questions_by_author` to restore the previous behaviour.

### Testing instructions

* With a teacher, create some questions and add them to a category.
* Do the same with another teacher or with an admin.
* Login with the first teacher and try adding a question category to a lesson's quiz.
* Observe that only the questions that the teacher owns are taken into account.
* Observe in the frontend and in grading that the correct questions are included.
* Repeat the same with an admin and observe that all questions are included.

### New/Updated Hooks

* `sensei_filter_category_questions_by_author` If this filter returns false and the quiz is not owned by an admin, category questions will include questions that are owned by other teachers.