### PR TITLE
Add learner courses styles

### DIFF
--- a/assets/blocks/learner-courses-block/index.js
+++ b/assets/blocks/learner-courses-block/index.js
@@ -36,6 +36,7 @@ export default {
 			label: __( 'Filled', 'sensei-lms' ),
 		},
 	],
+	example: {},
 	icon,
 	edit,
 	...metadata,

--- a/assets/blocks/learner-courses-block/index.js
+++ b/assets/blocks/learner-courses-block/index.js
@@ -25,6 +25,17 @@ export default {
 		__( 'Student', 'sensei-lms' ),
 		__( 'Learner', 'sensei-lms' ),
 	],
+	styles: [
+		{
+			name: 'minimal',
+			label: __( 'Minimal', 'sensei-lms' ),
+			isDefault: true,
+		},
+		{
+			name: 'filled',
+			label: __( 'Filled', 'sensei-lms' ),
+		},
+	],
 	icon,
 	edit,
 	...metadata,

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -39,21 +39,19 @@ $courses-list: '#{$block}__courses-list';
 		}
 	}
 
-	&.is-style-filled {
-		#{$block} {
-			&__filter,
-			.editor-styles-wrapper &__filter {
-				&__item {
-					padding: 7px (34px/2);
-					margin: 0;
-					&.--is-active {
-						border-bottom: 0;
-						background-color: currentColor;
-						background-color: var( --accent-color, currentColor );
+	&.is-style-filled #{$block} {
+		&__filter,
+		.editor-styles-wrapper &__filter {
+			&__item {
+				padding: 7px (34px/2);
+				margin: 0;
+				&.--is-active {
+					border-bottom: 0;
+					background-color: currentColor;
+					background-color: var( --accent-color, currentColor );
 
-						#{$block}__filter__link {
-							color: #FFF;
-						}
+					#{$block}__filter__link {
+						color: #FFF;
 					}
 				}
 			}

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -9,11 +9,14 @@ $courses-list: '#{$block}__courses-list';
 		padding: 0;
 		margin: 0;
 		list-style: none;
+		font-size: 18px;
+		font-weight: bold;
 
 		&__item {
 			margin: 0 (34px/2);
 			padding: 5px 0;
 			line-height: 1.25;
+			opacity: 0.8;
 
 			&:first-child {
 				margin-left: 0;
@@ -26,6 +29,7 @@ $courses-list: '#{$block}__courses-list';
 			&.--is-active {
 				color: var( --accent-color, inherit );
 				border-bottom: solid 3px currentColor;
+				opacity: 1;
 			}
 		}
 

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -35,6 +35,27 @@ $courses-list: '#{$block}__courses-list';
 		}
 	}
 
+	&.is-style-filled {
+		#{$block} {
+			&__filter,
+			.editor-styles-wrapper &__filter {
+				&__item {
+					padding: 7px (34px/2);
+					margin: 0;
+					&.--is-active {
+						border-bottom: 0;
+						background-color: currentColor;
+						background-color: var( --accent-color, currentColor );
+
+						#{$block}__filter__link {
+							color: #FFF;
+						}
+					}
+				}
+			}
+		}
+	}
+
 	#{$courses-list},
 	.editor-styles-wrapper #{$courses-list} {
 		list-style: none;


### PR DESCRIPTION
Based on https://github.com/Automattic/sensei/pull/4142

### Changes proposed in this Pull Request

* Add styles to the Learner Courses block.
* Activate thumbnail example to the block.
* Notice that the [design has changed](https://user-images.githubusercontent.com/72030923/110220994-7d2a0780-7e97-11eb-8e20-9b566393a1ac.png) a little, but the filled variation wasn't updated (at least, I didn't find it 😜), so I deduced the spacings and so on. So feel free to suggest improvements to this. cc @sruj09 @pablohoneyhoney 

### Testing instructions

* Add the Learner Courses block to a page.
* Play with the styles, and make sure it works properly.
* Go to the blocks selection, and make sure you see a thumbnail when you hover it.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/113204848-ef49fe00-9243-11eb-95a8-d6e96d871381.mov