### PR TITLE
Add View Results button

### DIFF
--- a/assets/blocks/single-course.js
+++ b/assets/blocks/single-course.js
@@ -6,6 +6,7 @@ import TakeCourseBlock from './take-course-block';
 import CourseProgressBlock from './course-progress-block';
 import { OutlineBlock, LessonBlock, ModuleBlock } from './course-outline';
 import ConditionalContentBlock from './conditional-content-block';
+import ViewResults from './view-results-block';
 
 registerSenseiBlocks( [
 	OutlineBlock,
@@ -14,4 +15,5 @@ registerSenseiBlocks( [
 	TakeCourseBlock,
 	CourseProgressBlock,
 	ConditionalContentBlock,
+	ViewResults,
 ] );

--- a/assets/blocks/view-results-block/index.js
+++ b/assets/blocks/view-results-block/index.js
@@ -18,7 +18,7 @@ export default createButtonBlockType( {
 	settings: {
 		name: 'sensei-lms/button-view-results',
 		description: __(
-			'Allow an enrolled user to view the course results. The block is only displayed if the user is enrolled to the course.',
+			'Allow an enrolled user to navigate to the course results page. The block is only displayed if the user is enrolled to the course.',
 			'sensei-lms'
 		),
 		title: __( 'View Results', 'sensei-lms' ),

--- a/assets/blocks/view-results-block/index.js
+++ b/assets/blocks/view-results-block/index.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { BlockStyles, createButtonBlockType } from '../button';
+import ToggleLegacyCourseMetaboxesWrapper from '../toggle-legacy-course-metaboxes-wrapper';
+
+/**
+ * View results button block.
+ */
+export default createButtonBlockType( {
+	tagName: 'a',
+	EditWrapper: ToggleLegacyCourseMetaboxesWrapper,
+	settings: {
+		name: 'sensei-lms/button-view-results',
+		description: __(
+			'Allow an enrolled user to view the course results. The block is only displayed if the user is enrolled to the course.',
+			'sensei-lms'
+		),
+		title: __( 'View Results', 'sensei-lms' ),
+		attributes: {
+			text: {
+				default: __( 'View Results', 'sensei-lms' ),
+			},
+		},
+		styles: [
+			BlockStyles.Fill,
+			{ ...BlockStyles.Outline, isDefault: true },
+			BlockStyles.Link,
+		],
+	},
+} );

--- a/includes/blocks/class-sensei-block-view-results.php
+++ b/includes/blocks/class-sensei-block-view-results.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * File containing the Sensei_Block_View_Results class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Block for View Results button.
+ */
+class Sensei_Block_View_Results {
+
+	/**
+	 * Sensei_Block_View_Results constructor.
+	 */
+	public function __construct() {
+		$this->register_block();
+	}
+
+	/**
+	 * Register View Results button block.
+	 *
+	 * @access private
+	 */
+	public function register_block() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/button-view-results',
+			[
+				'render_callback' => [ $this, 'render' ],
+			]
+		);
+	}
+
+	/**
+	 * Render the View Results button.
+	 *
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block HTML.
+	 *
+	 * @return string The HTML of the block.
+	 */
+	public function render( $attributes, $content ): string {
+		if ( ! Sensei()->course::is_user_enrolled( get_the_ID() ) ) {
+			return '';
+		}
+
+		$results_link = esc_url( Sensei()->course_results->get_permalink( get_the_ID() ) );
+
+		return preg_replace(
+			'/<a(.*)>/',
+			'<a href="' . $results_link . '" $1>',
+			$content,
+			1
+		);
+	}
+}

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -59,6 +59,7 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 		$this->contact_teacher = new Sensei_Block_Contact_Teacher();
 		$this->take_course     = new Sensei_Block_Take_Course();
 		new Sensei_Conditional_Content_Block();
+		new Sensei_Block_View_Results();
 
 		$post_type_object = get_post_type_object( 'course' );
 


### PR DESCRIPTION
### Overview
As we have removed the 'View Results' buttons in the latest version of the 'My Courses' page and from course progress bar, there isn't a way for users to add a navigation link to the course results page. This PR tries to deal with this issue.

### Changes proposed in this Pull Request
* Adds a 'View Results' button block in Sensei courses which navigates to the course results page.

### Alternatives considered
* We could possibly look into saving all information in post content to avoid making this a dynamic block. This however would require from users to enclose the block in 'Conditional Content' block, if they want it to be displayed to enrolled users only. Since we didn't follow this approach in other course blocks, I rejected it.
* I also considered adding the block to the course template, but I think that the template feels a bit cluttered already so I avoid it.

### Testing instructions

* Add the 'View Results' block in a course.
* With an enrolled user try the block in the frontend.
* Observe that the description of the block is suitable.
