### PR TITLE
Add extensions update counter

### DIFF
--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -101,24 +101,6 @@ final class Sensei_Extensions {
 	}
 
 	/**
-	 * Get all installed plugins by slug.
-	 *
-	 * @return array Installed plugins.
-	 */
-	private function get_installed_plugins_by_slug() {
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-
-		$installed_plugins_by_slug = [];
-
-		foreach ( get_plugins() as $key => $plugin ) {
-			$slug                               = pathinfo( $key, PATHINFO_FILENAME );
-			$installed_plugins_by_slug[ $slug ] = $plugin;
-		}
-
-		return $installed_plugins_by_slug;
-	}
-
-	/**
 	 * Map the extensions array, adding the installed properties.
 	 *
 	 * @param array $extensions Extensions.
@@ -126,13 +108,15 @@ final class Sensei_Extensions {
 	 * @return array Extensions with installed properties.
 	 */
 	private function add_installed_extensions_properties( $extensions ) {
-		$installed_plugins_by_slug = $this->get_installed_plugins_by_slug();
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		$installed_plugins = get_plugins();
 
 		// Includes installed version, and whether it has update.
 		$extensions = array_map(
-			function( $extension ) use ( $installed_plugins_by_slug ) {
-				if ( isset( $installed_plugins_by_slug[ $extension->product_slug ] ) ) {
-					$extension->installed_version = $installed_plugins_by_slug[ $extension->product_slug ]['Version'];
+			function( $extension ) use ( $installed_plugins ) {
+				if ( isset( $installed_plugins[ $extension->plugin_file ] ) ) {
+					$extension->installed_version = $installed_plugins[ $extension->plugin_file ]['Version'];
 					$extension->has_update        = isset( $extension->version ) && version_compare( $extension->version, $extension->installed_version, '>' );
 				}
 

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -17,9 +17,10 @@ class Sensei_Feature_Flags {
 		$this->default_feature_settings = (array) apply_filters(
 			'sensei_default_feature_flag_settings',
 			[
-				'rest_api_v1'                  => false,
-				'rest_api_v1_skip_permissions' => false,
-				'enrolment_provider_tooltip'   => false,
+				'rest_api_v1'                       => false,
+				'rest_api_v1_skip_permissions'      => false,
+				'enrolment_provider_tooltip'        => false,
+				'extensions_management_enhancement' => false,
 			]
 		);
 	}

--- a/tests/unit-tests/admin/test-class-sensei-extensions.php
+++ b/tests/unit-tests/admin/test-class-sensei-extensions.php
@@ -9,11 +9,119 @@
  * Tests for Sensei_Extensions class.
  */
 class Sensei_Extensions_Test extends WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+
+	/**
+	 * Test specific setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		add_filter( 'sensei_feature_flag_extensions_management_enhancement', '__return_true' );
+	}
+
+	/**
+	 * Clean up after the test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		remove_filter( 'sensei_feature_flag_extensions_management_enhancement', '__return_true' );
+	}
 
 	/**
 	 * Testing the Sensei Extensions class to make sure it is loaded.
 	 */
 	public function testClassInstance() {
 		$this->assertTrue( class_exists( 'Sensei_Extensions' ), 'Sensei Extensions class does not exist' );
+	}
+
+	/**
+	 * Tests that extensions with update are counted correctly.
+	 */
+	public function testCountExtensionsWithUpdate() {
+		$this->login_as_admin();
+
+		$extensions = [
+			(object) [
+				'product_slug' => 'sensei-extension-A',
+				'version'      => '1.0.1',
+			],
+			(object) [
+				'product_slug' => 'sensei-extension-B',
+				'version'      => '1.0.1',
+			],
+			(object) [
+				'product_slug' => 'sensei-extension-C',
+				'version'      => '1.0.1',
+			],
+			(object) [
+				'product_slug' => 'sensei-extension-E',
+				'version'      => '1.0.1',
+			],
+		];
+
+		$cache_plugins = [
+			'' => [
+				'any-folder-a/sensei-extension-A.php' => [
+					'Version' => '1.0.0',
+				],
+				'any-folder-a/sensei-extension-C.php' => [
+					'Version' => '1.0.0',
+				],
+				'any-folder-a/sensei-extension-D.php' => [
+					'Version' => '1.0.0',
+				],
+				'any-folder-a/sensei-extension-E.php' => [
+					'Version' => '1.0.1',
+				],
+			],
+		];
+
+		set_transient( 'sensei_extensions_' . md5( 'plugin||[]' ), $extensions );
+		wp_cache_set( 'plugins', $cache_plugins, 'plugins' );
+
+		Sensei_Extensions::instance()->add_admin_menu_item();
+
+		global $submenu;
+
+		$this->assertTrue(
+			in_array( 'Extensions <span class="awaiting-mod">2</span>', end( $submenu['sensei'] ), true ),
+			'Should count 2 available updates'
+		);
+	}
+
+	/**
+	 * Tests that extensions without update don't show counter.
+	 */
+	public function testCountExtensionsWithoutUpdate() {
+		$this->login_as_admin();
+
+		$extensions = [
+			(object) [
+				'product_slug' => 'sensei-extension-A',
+				'version'      => '1.0.1',
+			],
+		];
+
+		$cache_plugins = [
+			'' => [
+				'any-folder-a/sensei-extension-A.php' => [
+					'Version' => '1.0.1',
+				],
+			],
+		];
+
+		set_transient( 'sensei_extensions_' . md5( 'plugin||[]' ), $extensions );
+		wp_cache_set( 'plugins', $cache_plugins, 'plugins' );
+
+		Sensei_Extensions::instance()->add_admin_menu_item();
+
+		global $submenu;
+
+		$this->assertTrue(
+			in_array( 'Extensions', end( $submenu['sensei'] ), true ),
+			'Should not have counter when there is no available update'
+		);
 	}
 }

--- a/tests/unit-tests/admin/test-class-sensei-extensions.php
+++ b/tests/unit-tests/admin/test-class-sensei-extensions.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file contains the Sensei_Extensions_Test class.
+ *
+ * @package sensei
+ */
+
+/**
+ * Tests for Sensei_Extensions class.
+ */
+class Sensei_Extensions_Test extends WP_UnitTestCase {
+
+	/**
+	 * Testing the Sensei Extensions class to make sure it is loaded.
+	 */
+	public function testClassInstance() {
+		$this->assertTrue( class_exists( 'Sensei_Extensions' ), 'Sensei Extensions class does not exist' );
+	}
+}

--- a/tests/unit-tests/admin/test-class-sensei-extensions.php
+++ b/tests/unit-tests/admin/test-class-sensei-extensions.php
@@ -40,6 +40,10 @@ class Sensei_Extensions_Test extends WP_UnitTestCase {
 	 * Tests that extensions with update are counted correctly.
 	 */
 	public function testCountExtensionsWithUpdate() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Skip test for multisite because admin does not have the install_plugins capability used to add the submenu.' );
+		}
+
 		$this->login_as_admin();
 
 		$extensions = [
@@ -95,6 +99,10 @@ class Sensei_Extensions_Test extends WP_UnitTestCase {
 	 * Tests that extensions without update don't show counter.
 	 */
 	public function testCountExtensionsWithoutUpdate() {
+		if ( is_multisite() ) {
+			$this->markTestSkipped( 'Skip test for multisite because admin does not have the install_plugins capability used to add the submenu.' );
+		}
+
 		$this->login_as_admin();
 
 		$extensions = [

--- a/tests/unit-tests/admin/test-class-sensei-extensions.php
+++ b/tests/unit-tests/admin/test-class-sensei-extensions.php
@@ -48,20 +48,24 @@ class Sensei_Extensions_Test extends WP_UnitTestCase {
 
 		$extensions = [
 			(object) [
-				'product_slug' => 'sensei-extension-A',
+				'product_slug' => 'any-A',
 				'version'      => '1.0.1',
+				'plugin_file'  => 'any-folder-a/sensei-extension-A.php',
 			],
 			(object) [
-				'product_slug' => 'sensei-extension-B',
+				'product_slug' => 'any-B',
 				'version'      => '1.0.1',
+				'plugin_file'  => 'any-folder-b/sensei-extension-B.php',
 			],
 			(object) [
-				'product_slug' => 'sensei-extension-C',
+				'product_slug' => 'any-C',
 				'version'      => '1.0.1',
+				'plugin_file'  => 'any-folder-c/sensei-extension-C.php',
 			],
 			(object) [
-				'product_slug' => 'sensei-extension-E',
+				'product_slug' => 'any-E',
 				'version'      => '1.0.1',
+				'plugin_file'  => 'any-folder-e/sensei-extension-E.php',
 			],
 		];
 
@@ -70,13 +74,13 @@ class Sensei_Extensions_Test extends WP_UnitTestCase {
 				'any-folder-a/sensei-extension-A.php' => [
 					'Version' => '1.0.0',
 				],
-				'any-folder-a/sensei-extension-C.php' => [
+				'any-folder-c/sensei-extension-C.php' => [
 					'Version' => '1.0.0',
 				],
-				'any-folder-a/sensei-extension-D.php' => [
+				'any-folder-d/sensei-extension-D.php' => [
 					'Version' => '1.0.0',
 				],
-				'any-folder-a/sensei-extension-E.php' => [
+				'any-folder-e/sensei-extension-E.php' => [
 					'Version' => '1.0.1',
 				],
 			],
@@ -107,8 +111,9 @@ class Sensei_Extensions_Test extends WP_UnitTestCase {
 
 		$extensions = [
 			(object) [
-				'product_slug' => 'sensei-extension-A',
+				'product_slug' => 'any-A',
 				'version'      => '1.0.1',
+				'plugin_file'  => 'any-folder-a/sensei-extension-A.php',
 			],
 		];
 


### PR DESCRIPTION
Fixes #4107

### Changes proposed in this Pull Request

* The original issue mentions only paid plugins, but this PR introduces a counter for any Sensei extension. cc @donnapep 
* It depends on an update in the API: 79-gh-wpcomvip/a8c-senseilms-com
* It's behind the `extensions_management_enhancement ` feature flag.
* ~~It introduces a method `get_installed_extensions`, which lists only the Sensei installed extensions, containing the `has_update` flag that can be which for the next issues.~~ It extends the `get_extensions` method, introducing new properties related to the current installation.

### Testing instructions

* Activate the feature flag with the const: `define( 'SENSEI_FEATURE_FLAG_EXTENSIONS_MANAGEMENT_ENHANCEMENT', true );`
* Until 79-gh-wpcomvip/a8c-senseilms-com is merged, you need to mock the API to introduce the `version` property.
  * Just remember that it is cached with a transient, so the easiest way would be changing temporarily the line: 
      ```php
      $extension->has_update        = isset( $extension->version ) && version_compare( $extension->version, $extension->installed_version, '>' );
      ```
     To:
      ```php
      $extension->has_update        = version_compare( '2.3.0', $extension->installed_version, '>' );
      ```

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="165" alt="Screen Shot 2021-04-05 at 17 39 45" src="https://user-images.githubusercontent.com/876340/113624377-f0a96b00-9635-11eb-8d38-c6ea2fbe1cee.png">
