### PR TITLE
Activate learner courses example

### DIFF
--- a/assets/blocks/learner-courses-block/index.js
+++ b/assets/blocks/learner-courses-block/index.js
@@ -25,6 +25,7 @@ export default {
 		__( 'Student', 'sensei-lms' ),
 		__( 'Learner', 'sensei-lms' ),
 	],
+	example: {},
 	icon,
 	edit,
 	...metadata,


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Since https://github.com/Automattic/sensei/pull/4153 PR was closed, it just activates the thumbnail example to the block.

### Testing instructions

* Go to the blocks selection (blue plus button in the left top corner of the screen), and make sure you see a thumbnail when you hover the Learner Courses block.