### PR TITLE
Improve extensions page responsive styles

### DIFF
--- a/assets/extensions/extensions.js
+++ b/assets/extensions/extensions.js
@@ -11,8 +11,10 @@ import Card from './card';
 const Extensions = () => (
 	<>
 		<section className="sensei-extensions__section --col-12">
-			<h2>{ __( 'Featured', 'sensei-lms' ) }</h2>
-			<ul className="sensei-extensions__featured-list">
+			<h2 className="sensei-extensions__section__title">
+				{ __( 'Featured', 'sensei-lms' ) }
+			</h2>
+			<ul className="sensei-extensions__section__content sensei-extensions__featured-list">
 				<li className="sensei-extensions__featured-list__item">
 					<Card hasUpdate />
 				</li>
@@ -26,8 +28,10 @@ const Extensions = () => (
 		</section>
 
 		<section className="sensei-extensions__section --col-8">
-			<h2>{ __( 'Course creation', 'sensei-lms' ) }</h2>
-			<ul className="sensei-extensions__large-list">
+			<h2 className="sensei-extensions__section__title">
+				{ __( 'Course creation', 'sensei-lms' ) }
+			</h2>
+			<ul className="sensei-extensions__section__content sensei-extensions__large-list">
 				<li className="sensei-extensions__large-list__item">
 					<Card />
 				</li>
@@ -44,8 +48,10 @@ const Extensions = () => (
 		</section>
 
 		<section className="sensei-extensions__section --col-4">
-			<h2>{ __( 'Learner engagement', 'sensei-lms' ) }</h2>
-			<ul className="sensei-extensions__small-list">
+			<h2 className="sensei-extensions__section__title">
+				{ __( 'Learner engagement', 'sensei-lms' ) }
+			</h2>
+			<ul className="sensei-extensions__section__content sensei-extensions__small-list">
 				<li className="sensei-extensions__small-list__item">
 					<Card />
 				</li>

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -8,7 +8,9 @@
 }
 
 @mixin col-width($w) {
-	width: calc(#{$w} / 12 * 100%);
+	@media (min-width: 919px) {
+		width: calc(#{$w} / 12 * 100%);
+	}
 }
 
 .sensei-extensions {
@@ -20,6 +22,9 @@
 	}
 
 	&__section {
+		display: flex;
+		flex-direction: column;
+		width: 100%;
 		box-sizing: border-box;
 		margin-bottom: 38px;
 		padding: 0 9px;
@@ -71,6 +76,14 @@
 		&.--col-1 {
 			@include col-width( 1 );
 		}
+
+		&__title {
+			margin: 0 0 17px;
+		}
+
+		&__content {
+			flex: 1;
+		}
 	}
 
 	&__tabs {
@@ -109,20 +122,37 @@
 
 	&__featured-list {
 		@include white-box;
-		display: flex;
+		padding: 17px 10px;
 		margin: 0;
-		padding: 65px 45px;
+
+		@media (min-width: 990px) {
+			display: flex;
+			padding: 65px 10px;
+		}
+
+		@media (min-width: 1150px) {
+			padding: 65px 45px;
+		}
 
 		&__item {
-			margin: 0 15px;
+			margin: 0 10px 15px;
 			box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.16);
 			border-radius: 8px;
+
+			@media (min-width: 990px) {
+				margin-bottom: 0;
+			}
+
+			@media (min-width: 1150px) {
+				margin: 0 15px;
+			}
 		}
 	}
 
 	&__small-list,
 	&__large-list {
 		@include white-box;
+		margin: 0;
 
 		&__item {
 			margin: 0;
@@ -133,18 +163,19 @@
 		}
 	}
 
-	&__large-list {
-		.sensei-extensions__card {
-			display: flex;
-		}
-		.sensei-extensions__extension-actions {
-			flex-shrink: 0;
-			flex-direction: row-reverse;
-		}
-
-		.sensei-extensions__extension-actions__details-link {
-			margin-left: 0;
-			margin-right: 10px;
+	@media (min-width: 919px) {
+		&__large-list {
+			.sensei-extensions__card {
+				display: flex;
+			}
+			.sensei-extensions__extension-actions {
+				padding-left: 20px;
+				flex-shrink: 0;
+				flex-direction: row-reverse;
+			}
+			.sensei-extensions__extension-actions__details-link {
+				margin-right: 10px;
+			}
 		}
 	}
 
@@ -174,7 +205,10 @@
 		}
 
 		&__new-badge {
+			padding-left: 10px;
 			font-size: 12px;
+			white-space: nowrap;
+
 			&::before {
 				content: "";
 				display: inline-block;


### PR DESCRIPTION
Based on https://github.com/Automattic/sensei/pull/4162

### Changes proposed in this Pull Request

* Improve responsive styles for the extensions page.

### Testing instructions

* Open the extensions page, resize the window to multiple sizes, and make sure it works well.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Sorry for the video quality. But I had to reduce a lot to upload here.

https://user-images.githubusercontent.com/876340/114046621-5f1d4180-985f-11eb-92c9-eaf0edbd71fe.mov

