### PR TITLE
Add learner courses frontend styles

### DIFF
--- a/assets/blocks/course-progress-block/course-progress.scss
+++ b/assets/blocks/course-progress-block/course-progress.scss
@@ -1,1 +1,1 @@
-@import '../../shared/blocks/course-progress/course-progress'
+@import '../../shared/blocks/course-progress/course-progress';

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -157,11 +157,13 @@ const LearnerCoursesEdit = ( {
 					/>
 				) }
 				{ completed && (
-					<div className="wp-block-button">
-						{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-						<a className="wp-block-button__link" href="#">
-							{ __( 'View Results', 'sensei-lms' ) }
-						</a>
+					<div className="sensei-results-links wp-block-buttons is-content-justification-right">
+						<div className="wp-block-button">
+							{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+							<a className="wp-block-button__link" href="#">
+								{ __( 'View Results', 'sensei-lms' ) }
+							</a>
+						</div>
 					</div>
 				) }
 			</li>

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -36,7 +36,7 @@ const FeaturedImagePlaceholder = () => (
  * @param {Object} props
  * @param {string} props.tagName   HTML tag.
  * @param {Array}  props.variables CSS variables.
- * @param {Array}  props.children  Children elements.
+ * @param {Object} props.children  Children elements.
  * @param {*}      props.className Classes.
  */
 const StylesWrapper = ( {

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -175,6 +175,7 @@ const LearnerCoursesEdit = ( {
 							</div>
 						</div>
 					) }
+					<div className="clearfix" />
 				</section>
 			</li>
 		);

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -37,7 +37,7 @@ const FeaturedImagePlaceholder = () => (
  * @param {string} props.tagName   HTML tag.
  * @param {Array}  props.variables CSS variables.
  * @param {Object} props.children  Children elements.
- * @param {*}      props.className Classes.
+ * @param {string} props.className Classes.
  */
 const StylesWrapper = ( {
 	tagName: TagName = 'div',

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -124,7 +124,7 @@ const LearnerCoursesEdit = ( {
 			>
 				{ options.courseCategoryEnabled && (
 					<small className="wp-block-sensei-lms-learner-courses__courses-list__category">
-						{ __( 'Category name', 'sensei-lms' ) }
+						{ __( 'Category Name', 'sensei-lms' ) }
 					</small>
 				) }
 				<h3 className="wp-block-sensei-lms-learner-courses__courses-list__title">

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -34,18 +34,23 @@ const FeaturedImagePlaceholder = () => (
  * Wrapper for CSS variables & related classes.
  *
  * @param {Object} props
- * @param {string} props.tag       HTML tag.
+ * @param {string} props.tagName   HTML tag.
  * @param {Array}  props.variables CSS variables.
  * @param {Array}  props.children  Children elements.
  * @param {*}      props.className Classes.
  */
-const StylesWrapper = ( { tag, variables, children, className } ) => {
+const StylesWrapper = ( {
+	tagName: TagName = 'div',
+	variables,
+	children,
+	className,
+	...props
+} ) => {
 	const isEmpty = ( value ) => {
 		return [ undefined, null, 'undefinedpx' ].includes( value );
 	};
-	const Tag = tag || 'div';
 	return (
-		<Tag
+		<TagName
 			className={ classnames( className, {
 				'has-sensei-primary-color': !! variables.primaryColor,
 				'has-sensei-accent-color': !! variables.accentColor,
@@ -60,9 +65,10 @@ const StylesWrapper = ( { tag, variables, children, className } ) => {
 				},
 				isEmpty
 			) }
+			{ ...props }
 		>
 			{ children }
-		</Tag>
+		</TagName>
 	);
 };
 
@@ -173,6 +179,7 @@ const LearnerCoursesEdit = ( {
 	return (
 		<>
 			<StylesWrapper
+				tagName="section"
 				className={ className }
 				variables={ {
 					primaryColor: options.primaryColor,

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -18,6 +18,55 @@ import CourseProgress from '../../shared/blocks/course-progress';
 import LearnerCoursesSettings from './learner-courses-settings';
 
 /**
+ * Featured image placeholder element.
+ */
+const FeaturedImagePlaceholder = () => (
+	<div
+		className="wp-block-sensei-lms-learner-courses__courses-list__featured-image"
+		role="img"
+		aria-label="Featured image"
+	>
+		<Icon icon={ image } size={ 48 } />
+	</div>
+);
+
+/**
+ * Wrapper for CSS variables & related classes.
+ *
+ * @param {Object} props
+ * @param {string} props.tag       HTML tag.
+ * @param {Array}  props.variables CSS variables.
+ * @param {Array}  props.children  Children elements.
+ * @param {*}      props.className Classes.
+ */
+const StylesWrapper = ( { tag, variables, children, className } ) => {
+	const isEmpty = ( value ) => {
+		return [ undefined, null, 'undefinedpx' ].includes( value );
+	};
+	const Tag = tag || 'div';
+	return (
+		<Tag
+			className={ classnames( className, {
+				'has-sensei-primary-color': !! variables.primaryColor,
+				'has-sensei-accent-color': !! variables.accentColor,
+			} ) }
+			style={ omitBy(
+				{
+					'--sensei-progress-bar-height': variables.progressBarHeight,
+					'--sensei-progress-bar-border-radius':
+						variables.progressBarBorderRadius,
+					'--sensei-primary-color': variables.primaryColor,
+					'--sensei-accent-color': variables.accentColor,
+				},
+				isEmpty
+			) }
+		>
+			{ children }
+		</Tag>
+	);
+};
+
+/**
  * Learner Settings component.
  *
  * @param {Object}   props
@@ -73,92 +122,80 @@ const LearnerCoursesEdit = ( {
 				className="wp-block-sensei-lms-learner-courses__courses-list__item"
 				key={ index }
 			>
-				{ options.featuredImageEnabled && (
-					<div
-						className="wp-block-sensei-lms-learner-courses__courses-list__featured-image"
-						role="img"
-						aria-label="Featured image"
-					>
-						<Icon icon={ image } size={ 48 } />
+				{ options.courseCategoryEnabled && (
+					<small className="wp-block-sensei-lms-learner-courses__courses-list__category">
+						{ __( 'Category name', 'sensei-lms' ) }
+					</small>
+				) }
+				<h3 className="wp-block-sensei-lms-learner-courses__courses-list__title">
+					{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+					<a href="#">{ __( 'Course Title', 'sensei-lms' ) }</a>
+				</h3>
+				{ options.featuredImageEnabled && <FeaturedImagePlaceholder /> }
+
+				{ completed && (
+					<div>
+						<em className="wp-block-sensei-lms-learner-courses__courses-list__badge">
+							{ __( 'Completed', 'sensei-lms' ) }
+						</em>
 					</div>
 				) }
-				<div>
-					{ options.courseCategoryEnabled && (
-						<small className="wp-block-sensei-lms-learner-courses__courses-list__category">
-							{ __( 'Category name', 'sensei-lms' ) }
-						</small>
-					) }
-					<header className="wp-block-sensei-lms-learner-courses__courses-list__header">
-						<h3 className="wp-block-sensei-lms-learner-courses__courses-list__title">
-							{ __( 'Course title goes here', 'sensei-lms' ) }
-						</h3>
-						{ completed && (
-							<em className="wp-block-sensei-lms-learner-courses__courses-list__badge">
-								{ __( 'Completed', 'sensei-lms' ) }
-							</em>
-						) }
-					</header>
-					{ options.courseDescriptionEnabled && (
-						<p className="wp-block-sensei-lms-learner-courses__courses-list__description">
-							{ __(
-								'Here is a short course description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas arcu turpis mauris…',
-								'sensei-lms'
-							) }
-						</p>
-					) }
 
-					{ options.progressBarEnabled && (
-						<CourseProgress
-							lessonsCount={ 3 }
-							completedCount={ completed ? 3 : 1 }
-							hidePercentage
-						/>
-					) }
-				</div>
+				{ options.courseDescriptionEnabled && (
+					<p className="wp-block-sensei-lms-learner-courses__courses-list__description">
+						{ __(
+							'This is a preview of the course description…',
+							'sensei-lms'
+						) }
+					</p>
+				) }
+				{ options.progressBarEnabled && (
+					<CourseProgress
+						lessonsCount={ 3 }
+						completedCount={ completed ? 3 : 1 }
+						hidePercentage
+					/>
+				) }
+				{ completed && (
+					<div className="wp-block-button">
+						{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+						<a className="wp-block-button__link" href="#">
+							{ __( 'View Results', 'sensei-lms' ) }
+						</a>
+					</div>
+				) }
 			</li>
 		);
 	};
 
 	return (
 		<>
-			<section
+			<StylesWrapper
 				className={ className }
-				style={ omitBy(
-					{
-						'--progress-bar-height': `${ options.progressBarHeight }px`,
-						'--progress-bar-border-radius': `${ options.progressBarBorderRadius }px`,
-						'--primary-color': options.primaryColor,
-						'--accent-color': options.accentColor,
-					},
-					// Exclude not set values.
-					( value ) => {
-						return [ undefined, null, 'undefinedpx' ].includes(
-							value
-						);
-					}
-				) }
+				variables={ {
+					primaryColor: options.primaryColor,
+					accentColor: options.accentColor,
+					progressBarHeight: `${ options.progressBarHeight }px`,
+					progressBarBorderRadius: `${ options.progressBarBorderRadius }px`,
+				} }
 			>
-				<ul className="wp-block-sensei-lms-learner-courses__filter">
+				<p className="wp-block-sensei-lms-learner-courses__filter">
 					{ filters.map( ( { label, value } ) => (
-						<li
+						<a
 							key={ value }
+							href={ `#${ value }` }
+							onClick={ filterHandler( value ) }
 							className={ classnames(
 								'wp-block-sensei-lms-learner-courses__filter__item',
 								{
-									'--is-active': value === filter,
+									active: value === filter,
 								}
 							) }
 						>
-							<a
-								className="wp-block-sensei-lms-learner-courses__filter__link"
-								href={ `#${ value }` }
-								onClick={ filterHandler( value ) }
-							>
-								{ label }
-							</a>
-						</li>
+							{ label }
+						</a>
 					) ) }
-				</ul>
+				</p>
 				<ul
 					className={ classnames(
 						'wp-block-sensei-lms-learner-courses__courses-list',
@@ -170,7 +207,7 @@ const LearnerCoursesEdit = ( {
 						coursesPlaceholderMap
 					) }
 				</ul>
-			</section>
+			</StylesWrapper>
 			<LearnerCoursesSettings
 				options={ options }
 				setOptions={ setOptions }

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -125,53 +125,57 @@ const LearnerCoursesEdit = ( {
 
 		return (
 			<li
-				className="wp-block-sensei-lms-learner-courses__courses-list__item"
+				className="wp-block-sensei-lms-learner-courses__courses-list__item course"
 				key={ index }
 			>
-				{ options.courseCategoryEnabled && (
-					<small className="wp-block-sensei-lms-learner-courses__courses-list__category">
-						{ __( 'Category Name', 'sensei-lms' ) }
-					</small>
-				) }
-				<h3 className="wp-block-sensei-lms-learner-courses__courses-list__title">
-					{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-					<a href="#">{ __( 'Course Title', 'sensei-lms' ) }</a>
-				</h3>
-				{ options.featuredImageEnabled && <FeaturedImagePlaceholder /> }
+				<section className="entry">
+					{ options.courseCategoryEnabled && (
+						<small className="wp-block-sensei-lms-learner-courses__courses-list__category">
+							{ __( 'Category Name', 'sensei-lms' ) }
+						</small>
+					) }
+					<h3 className="wp-block-sensei-lms-learner-courses__courses-list__title">
+						{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+						<a href="#">{ __( 'Course Title', 'sensei-lms' ) }</a>
+					</h3>
+					{ options.featuredImageEnabled && (
+						<FeaturedImagePlaceholder />
+					) }
 
-				{ completed && (
-					<div>
-						<em className="wp-block-sensei-lms-learner-courses__courses-list__badge">
-							{ __( 'Completed', 'sensei-lms' ) }
-						</em>
-					</div>
-				) }
-
-				{ options.courseDescriptionEnabled && (
-					<p className="wp-block-sensei-lms-learner-courses__courses-list__description">
-						{ __(
-							'This is a preview of the course description…',
-							'sensei-lms'
-						) }
-					</p>
-				) }
-				{ options.progressBarEnabled && (
-					<CourseProgress
-						lessonsCount={ 3 }
-						completedCount={ completed ? 3 : 1 }
-						hidePercentage
-					/>
-				) }
-				{ completed && (
-					<div className="sensei-results-links wp-block-buttons is-content-justification-right">
-						<div className="wp-block-button">
-							{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-							<a className="wp-block-button__link" href="#">
-								{ __( 'View Results', 'sensei-lms' ) }
-							</a>
+					{ completed && (
+						<div>
+							<em className="wp-block-sensei-lms-learner-courses__courses-list__badge">
+								{ __( 'Completed', 'sensei-lms' ) }
+							</em>
 						</div>
-					</div>
-				) }
+					) }
+
+					{ options.courseDescriptionEnabled && (
+						<p className="wp-block-sensei-lms-learner-courses__courses-list__description">
+							{ __(
+								'This is a preview of the course description…',
+								'sensei-lms'
+							) }
+						</p>
+					) }
+					{ options.progressBarEnabled && (
+						<CourseProgress
+							lessonsCount={ 3 }
+							completedCount={ completed ? 3 : 1 }
+							hidePercentage
+						/>
+					) }
+					{ completed && (
+						<div className="sensei-results-links wp-block-buttons is-content-justification-right">
+							<div className="wp-block-button">
+								{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+								<a className="wp-block-button__link" href="#">
+									{ __( 'View Results', 'sensei-lms' ) }
+								</a>
+							</div>
+						</div>
+					) }
+				</section>
 			</li>
 		);
 	};

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -143,7 +143,7 @@ const LearnerCoursesEdit = ( {
 					) }
 
 					{ completed && (
-						<div>
+						<div className="wp-block-sensei-lms-learner-courses__courses-list__badge__wrapper">
 							<em className="wp-block-sensei-lms-learner-courses__courses-list__badge">
 								{ __( 'Completed', 'sensei-lms' ) }
 							</em>

--- a/assets/blocks/learner-courses-block/learner-courses-editor.scss
+++ b/assets/blocks/learner-courses-block/learner-courses-editor.scss
@@ -1,1 +1,21 @@
 @import '../../shared/blocks/course-progress/course-progress-settings';
+
+$block: '.wp-block-sensei-lms-learner-courses';
+$courses-list: '#{$block}__courses-list';
+
+
+.editor-styles-wrapper #{$courses-list} {
+
+	&__featured-image {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: 100px;
+		height: 100px;
+		flex-shrink: 0;
+		background-color: #C3C4C7;
+		background-size: cover;
+		background-position: 50% 50%;
+		fill: #FFF;
+	}
+}

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -20,6 +20,15 @@ $courses-list: '#{$block}__courses-list';
 	clear: both;
 }
 
+.sensei-pagination {
+	.page-numbers li {
+		display: inline-block;
+		list-style: none;
+		padding: 0;
+		margin: 12px;
+	}
+}
+
 /* Learner courses styles */
 
 .editor-styles-wrapper #{$block}__filter,

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -3,19 +3,28 @@
 $block: '.wp-block-sensei-lms-learner-courses';
 $courses-list: '#{$block}__courses-list';
 
-#{$block} {
-	&__filter,
-	.editor-styles-wrapper &__filter {
+
+	.editor-styles-wrapper #{$block}__filter,
+	#user-course-status-toggle {
 		display: flex;
 		border-bottom: 1px solid currentColor;
 		padding: 0;
-		margin: 0;
+		margin: 0 0 24px;
 		list-style: none;
 
-		&__item {
+		&__item, a {
 			margin: 0 (34px/2);
 			padding: 5px 0;
 			line-height: 1.25;
+
+			&:not(.active) {
+				color: var(--sensei-primary-color, inherit);
+			}
+			text-decoration: none;
+
+			&:hover {
+				text-decoration: underline;
+			}
 
 			&:first-child {
 				margin-left: 0;
@@ -25,8 +34,8 @@ $courses-list: '#{$block}__courses-list';
 				margin-right: 0;
 			}
 
-			&.--is-active {
-				color: var( --accent-color, inherit );
+			&.active {
+				color: inherit;
 				border-bottom: solid 3px currentColor;
 			}
 		}
@@ -37,14 +46,14 @@ $courses-list: '#{$block}__courses-list';
 		}
 	}
 
+#{$block} {
 	#{$courses-list},
 	.editor-styles-wrapper #{$courses-list} {
 		list-style: none;
-		padding: 50px 0 0;
+		padding: 0;
 		margin: 0;
 
 		&__item {
-			display: flex;
 			padding: 0 0 40px;
 			margin: 0;
 		}
@@ -53,54 +62,46 @@ $courses-list: '#{$block}__courses-list';
 			display: flex;
 			align-items: center;
 			justify-content: center;
-			width: 149px;
-			height: 149px;
-			margin-right: 24px;
+			width: 100px;
+			height: 100px;
+			margin: 0 24px 12px 0;
 			flex-shrink: 0;
 			background-color: #C3C4C7;
 			background-size: cover;
 			background-position: 50% 50%;
 			fill: #FFF;
+			float: left;
 		}
 
 		&__category {
-			display: block;
-			font-size: 12px;
+			font-size: 70%;
 			text-transform: uppercase;
 		}
 
-		&__header {
-			margin: 0 0 9px;
-			display: flex;
-			justify-content: flex-start;
-			align-items: center;
-		}
-
 		&__title {
-			margin: 0;
-			font-size: 24px;
-			font-weight: bold;
-			color: var( --primary-color, inherit );
+			&, .wp-block & {
+				margin: 1rem 0;
+				clear: none;
+			}
+			.has-primary-color & a {
+				color: var( --sensei-primary-color, inherit );
+			}
 		}
 
 		&__badge {
 			display: inline-block;
-			vertical-align: middle;
-			margin-left: 18px;
-			padding: 3px 11px;
-			color: var( --primary-color, inherit );
+			padding: 2px 8px;
+			margin-top: 12px;
+			color: var( --sensei-accent-color, inherit );
 			border: 1px solid currentColor;
 			border-radius: 4px;
-			font-size: 8px;
+			font-size: 70%;
 			text-transform: uppercase;
 			font-style: normal;
 		}
 
 		&__description {
 			margin: 9px 0 18px;
-			font-size: 12px;
-			line-height: 1.25;
-			opacity: 0.9;
 		}
 
 		@media (min-width: 920px) {
@@ -119,6 +120,7 @@ $courses-list: '#{$block}__courses-list';
 					&__featured-image {
 						width: 100%;
 						height: 108px;
+						margin: 0;
 						margin-bottom: 20px;
 					}
 				}
@@ -138,19 +140,63 @@ $courses-list: '#{$block}__courses-list';
 	}
 
 	.sensei-course-progress {
+
 		&__heading {
-			font-size: 12px;
+			clear: both;
 		}
 
 		&__bar {
-			height: var( --progress-bar-height, 14px );
-			border-radius: var( --progress-bar-border-radius, 10px );
+			height: var( --sensei-progress-bar-height, 14px );
+			border-radius: var( --sensei-progress-bar-border-radius, 10px );
 
 			div  {
 				background-color: currentColor;
-				background-color: var( --accent-color, currentColor );
-				border-radius: var( --progress-bar-border-radius, 10px );
+				background-color: var( --sensei-accent-color, currentColor );
+				border-radius: var( --sensei-progress-bar-border-radius, 10px );
 			}
+		}
+	}
+
+	&.has-sensei-primary-color {
+
+		.course-title a, #{$courses-list}__title a {
+			color: var(--sensei-primary-color, inherit);
+		}
+
+		.wp-block-button__link, .button {
+			background-color: var(--sensei-primary-color, inherit);
+			color: #fff;
+		}
+	}
+}
+
+
+/* Spacing defaults */
+
+.sensei .entry-content {
+	section {
+		padding: 0;
+	}
+}
+
+
+/* Courses */
+.course,
+.course-container {
+	margin: 0 0 1.618em;
+	padding: 0 0 1em;
+	list-style: none;
+}
+.course {
+	.course-title {
+		margin: 16px 0;
+	}
+	.sensei-results-links {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		&, .entry-content & > * {
+			margin: 0 0 0 12px;
 		}
 	}
 }

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -4,169 +4,160 @@ $block: '.wp-block-sensei-lms-learner-courses';
 $courses-list: '#{$block}__courses-list';
 
 
-	.editor-styles-wrapper #{$block}__filter,
-	#user-course-status-toggle {
-		display: flex;
-		border-bottom: 1px solid currentColor;
-		padding: 0;
-		margin: 0 0 24px;
-		list-style: none;
+.editor-styles-wrapper #{$block}__filter,
+#user-course-status-toggle {
+	display: flex;
+	border-bottom: 1px solid currentColor;
+	padding: 0;
+	margin: 0 0 24px;
+	list-style: none;
 
-		&__item, a {
-			margin: 0 (34px/2);
-			padding: 5px 0;
-			line-height: 1.25;
+	&__item, a {
+		margin: 0 (34px/2);
+		padding: 5px 0;
+		line-height: 1.25;
 
-			&:not(.active) {
-				color: var(--sensei-primary-color, inherit);
-			}
-			text-decoration: none;
-
-			&:hover {
-				text-decoration: underline;
-			}
-
-			&:first-child {
-				margin-left: 0;
-			}
-
-			&:last-child {
-				margin-right: 0;
-			}
-
-			&.active {
-				color: inherit;
-				border-bottom: solid 3px currentColor;
-			}
-		}
-
-		& &__link {
-			color: inherit;
-			text-decoration: none;
-		}
-	}
-
-#{$block} {
-	#{$courses-list},
-	.editor-styles-wrapper #{$courses-list} {
-		list-style: none;
-		padding: 0;
-		margin: 0;
-
-		&__item {
-			padding: 0 0 40px;
-			margin: 0;
-		}
-
-		&__featured-image {
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			width: 100px;
-			height: 100px;
-			margin: 0 24px 12px 0;
-			flex-shrink: 0;
-			background-color: #C3C4C7;
-			background-size: cover;
-			background-position: 50% 50%;
-			fill: #FFF;
-			float: left;
-		}
-
-		&__category {
-			font-size: 70%;
-			text-transform: uppercase;
-		}
-
-		&__title {
-			&, .wp-block & {
-				margin: 1rem 0;
-				clear: none;
-			}
-			.has-primary-color & a {
-				color: var( --sensei-primary-color, inherit );
-			}
-		}
-
-		&__badge {
-			display: inline-block;
-			padding: 2px 8px;
-			margin-top: 12px;
-			color: var( --sensei-accent-color, inherit );
-			border: 1px solid currentColor;
-			border-radius: 4px;
-			font-size: 70%;
-			text-transform: uppercase;
-			font-style: normal;
-		}
-
-		&__description {
-			margin: 9px 0 18px;
-		}
-
-		@media (min-width: 920px) {
-			&.--is-grid-view {
-				display: flex;
-				flex-flow: row wrap;
-				margin: 0 -7px;
-
-				#{$courses-list} {
-					&__item {
-						display: block;
-						width: calc( 50% - 22px );
-						margin: 0 11px;
-					}
-
-					&__featured-image {
-						width: 100%;
-						height: 108px;
-						margin: 0;
-						margin-bottom: 20px;
-					}
-				}
-
-				&.--is-3-columns {
-					margin: 0 -11px;
-
-					#{$courses-list} {
-						&__item {
-							width: calc( 100% / 3 - 14px );
-							margin: 0 7px;
-						}
-					}
-				}
-			}
-		}
-	}
-
-	.sensei-course-progress {
-
-		&__heading {
-			clear: both;
-		}
-
-		&__bar {
-			height: var( --sensei-progress-bar-height, 14px );
-			border-radius: var( --sensei-progress-bar-border-radius, 10px );
-
-			div  {
-				background-color: currentColor;
-				background-color: var( --sensei-accent-color, currentColor );
-				border-radius: var( --sensei-progress-bar-border-radius, 10px );
-			}
-		}
-	}
-
-	&.has-sensei-primary-color {
-
-		.course-title a, #{$courses-list}__title a {
+		&:not(.active) {
 			color: var(--sensei-primary-color, inherit);
 		}
 
-		.wp-block-button__link, .button {
-			background-color: var(--sensei-primary-color, inherit);
-			color: #fff;
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
 		}
+
+		&:first-child {
+			margin-left: 0;
+		}
+
+		&:last-child {
+			margin-right: 0;
+		}
+
+		&.active {
+			color: inherit;
+			border-bottom: solid 3px currentColor;
+		}
+	}
+
+	& &__link {
+		color: inherit;
+		text-decoration: none;
+	}
+}
+
+#{$courses-list},
+.editor-styles-wrapper #{$courses-list} {
+	list-style: none;
+	padding: 0;
+	margin: 0;
+
+	&__item {
+		padding: 0 0 40px;
+		margin: 0;
+	}
+
+	&__featured-image {
+		float: left;
+		margin: 0 24px 12px 0;
+	}
+
+	&__category {
+		font-size: 70%;
+		text-transform: uppercase;
+	}
+
+	&__title {
+		&, .wp-block & {
+			margin: 1rem 0;
+			clear: none;
+		}
+
+		.has-primary-color & a {
+			color: var(--sensei-primary-color, inherit);
+		}
+	}
+
+	&__badge {
+		display: inline-block;
+		padding: 2px 8px;
+		margin-top: 12px;
+		color: var(--sensei-accent-color, inherit);
+		border: 1px solid currentColor;
+		border-radius: 4px;
+		font-size: 70%;
+		text-transform: uppercase;
+		font-style: normal;
+	}
+
+	&__description {
+		margin: 9px 0 18px;
+	}
+}
+
+
+#{$courses-list}.--is-grid-view, #{$block}--is-grid-view .course-container {
+	@media (min-width: 920px) {
+		display: flex;
+		flex-flow: row wrap;
+		margin: 0 -7px;
+
+		#{$courses-list}__item, .course {
+			display: block;
+			flex: 1 0 calc(50% - 22px);
+			margin: 0 11px;
+		}
+
+		//&__featured-image {
+		//	width: 100%;
+		//	height: 108px;
+		//	margin: 0;
+		//	margin-bottom: 20px;
+		//}
+
+
+		&.--is-3-columns {
+			margin: 0 -11px;
+
+			#{$courses-list} {
+				&__item {
+					width: calc(100% / 3 - 14px);
+					margin: 0 7px;
+				}
+			}
+		}
+	}
+}
+
+
+.sensei-course-progress {
+
+	&__heading {
+		clear: both;
+	}
+
+	&__bar {
+		height: var(--sensei-progress-bar-height, 14px);
+		border-radius: var(--sensei-progress-bar-border-radius, 10px);
+
+		div {
+			background-color: currentColor;
+			background-color: var(--sensei-accent-color, currentColor);
+			border-radius: var(--sensei-progress-bar-border-radius, 10px);
+		}
+	}
+}
+
+#{$block}.has-sensei-primary-color {
+
+	.course-title a, #{$courses-list}__title a {
+		color: var(--sensei-primary-color, inherit);
+	}
+
+	.wp-block-button__link, .button {
+		background-color: var(--sensei-primary-color, inherit);
+		color: #fff;
 	}
 }
 
@@ -179,6 +170,10 @@ $courses-list: '#{$block}__courses-list';
 	}
 }
 
+.sensei-block-wrapper {
+	margin-top: 28px;
+	margin-bottom: 28px;
+}
 
 /* Courses */
 .course,
@@ -187,16 +182,22 @@ $courses-list: '#{$block}__courses-list';
 	padding: 0 0 1em;
 	list-style: none;
 }
+
 .course {
 	.course-title {
 		margin: 16px 0;
 	}
-	.sensei-results-links {
-		display: flex;
-		align-items: center;
-		justify-content: flex-end;
-		&, .entry-content & > * {
-			margin: 0 0 0 12px;
+}
+
+.sensei-results-links {
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
+	margin-right: -12px;
+
+	&, .entry-content & {
+		* {
+			margin: 6px 12px;
 		}
 	}
 }

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -54,8 +54,8 @@ $courses-list: '#{$block}__courses-list';
 	margin: 0;
 
 	&__item {
-		padding: 0 0 40px;
 		margin: 0;
+		padding: 0;
 	}
 
 	&__featured-image {
@@ -69,9 +69,8 @@ $courses-list: '#{$block}__courses-list';
 	}
 
 	&__title {
-		&, .wp-block & {
-			margin: 1rem 0;
-			clear: none;
+		&, .editor-styles-wrapper .wp-block & {
+			margin: 16px 0;
 		}
 
 		.has-primary-color & a {
@@ -82,7 +81,7 @@ $courses-list: '#{$block}__courses-list';
 	&__badge {
 		display: inline-block;
 		padding: 2px 8px;
-		margin-top: 12px;
+		margin: 12px 0;
 		color: var(--sensei-accent-color, inherit);
 		border: 1px solid currentColor;
 		border-radius: 4px;
@@ -158,12 +157,17 @@ $courses-list: '#{$block}__courses-list';
 /* Courses */
 .course,
 .course-container {
-	margin: 0 0 1.618em;
-	padding: 0 0 1em;
+	margin: 0;
+	padding: 0;
 	list-style: none;
+
+	.entry {
+		margin: 24px 0;
+	}
 }
 
 .course {
+	border-bottom: 1px solid #e2e2e2;
 	.course-title {
 		margin: 16px 0;
 	}
@@ -174,6 +178,11 @@ $courses-list: '#{$block}__courses-list';
 	align-items: center;
 	justify-content: flex-end;
 	margin-right: -12px;
+	.entry-content & {
+		margin-bottom: 0;
+
+	}
+
 	flex-wrap: wrap;
 
 	&, .entry-content & {

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -92,7 +92,7 @@ $courses-list: '#{$block}__courses-list';
 
 	&__title {
 		&, .editor-styles-wrapper .wp-block & {
-			margin: 16px 0;
+			margin: 0 0 16px;
 		}
 
 		.has-primary-color & a {

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -3,13 +3,27 @@
 $block: '.wp-block-sensei-lms-learner-courses';
 $courses-list: '#{$block}__courses-list';
 
+/* Spacing defaults */
+
+.sensei .entry-content {
+	section {
+		padding: 0;
+	}
+}
+
+.sensei-block-wrapper {
+	margin-top: 28px;
+	margin-bottom: 28px;
+}
+
+/* Learner courses styles */
 
 .editor-styles-wrapper #{$block}__filter,
 #user-course-status-toggle {
 	display: flex;
 	border-bottom: 1px solid currentColor;
 	padding: 0;
-	margin: 0 0 24px;
+	margin: 0;
 	list-style: none;
 
 	&__item, a {
@@ -56,6 +70,10 @@ $courses-list: '#{$block}__courses-list';
 	&__item {
 		margin: 0;
 		padding: 0;
+
+		.sensei-block-wrapper {
+			display: none;
+		}
 	}
 
 	&__featured-image {
@@ -79,9 +97,11 @@ $courses-list: '#{$block}__courses-list';
 	}
 
 	&__badge {
+		&__wrapper {
+			margin: 16px 0;
+		}
 		display: inline-block;
 		padding: 2px 8px;
-		margin: 12px 0;
 		color: var(--sensei-accent-color, inherit);
 		border: 1px solid currentColor;
 		border-radius: 4px;
@@ -140,54 +160,58 @@ $courses-list: '#{$block}__courses-list';
 	}
 }
 
+#{$block} {
 
-/* Spacing defaults */
-
-.sensei .entry-content {
-	section {
+	.course,
+	.course-container {
+		margin: 0;
 		padding: 0;
-	}
-}
+		list-style: none;
 
-.sensei-block-wrapper {
-	margin-top: 28px;
-	margin-bottom: 28px;
-}
+		.entry {
+			margin: 24px 0;
+		}
+		.thumbnail {
+			margin-bottom: 6px;
+		}
 
-/* Courses */
-.course,
-.course-container {
-	margin: 0;
-	padding: 0;
-	list-style: none;
+		.sensei-block-wrapper {
+			clear: both;
+			margin: 16px 0;
+		}
 
-	.entry {
-		margin: 24px 0;
-	}
-}
-
-.course {
-	border-bottom: 1px solid #e2e2e2;
-	.course-title {
-		margin: 16px 0;
-	}
-}
-
-.sensei-results-links {
-	display: flex;
-	align-items: center;
-	justify-content: flex-end;
-	margin-right: -12px;
-	.entry-content & {
-		margin-bottom: 0;
-
-	}
-
-	flex-wrap: wrap;
-
-	&, .entry-content & {
-		* {
-			margin: 6px 12px;
+		.course-excerpt:empty {
+			padding-top: 28px;
 		}
 	}
+
+	.course {
+		border-bottom: 1px solid #e2e2e2;
+		clear: both;
+
+		.course-title {
+			margin: 0 0 16px;
+		}
+	}
+
+	.sensei-results-links {
+		display: flex;
+		align-items: center;
+		justify-content: flex-end;
+		margin-right: -12px;
+
+		.entry-content & {
+			margin-bottom: 0;
+
+		}
+
+		flex-wrap: wrap;
+
+		&, .entry-content & {
+			* {
+				margin: 6px 12px;
+			}
+		}
+	}
+
 }

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -108,28 +108,8 @@ $courses-list: '#{$block}__courses-list';
 			flex: 1 0 calc(50% - 22px);
 			margin: 0 11px;
 		}
-
-		//&__featured-image {
-		//	width: 100%;
-		//	height: 108px;
-		//	margin: 0;
-		//	margin-bottom: 20px;
-		//}
-
-
-		&.--is-3-columns {
-			margin: 0 -11px;
-
-			#{$courses-list} {
-				&__item {
-					width: calc(100% / 3 - 14px);
-					margin: 0 7px;
-				}
-			}
-		}
 	}
 }
-
 
 .sensei-course-progress {
 

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -194,6 +194,7 @@ $courses-list: '#{$block}__courses-list';
 	align-items: center;
 	justify-content: flex-end;
 	margin-right: -12px;
+	flex-wrap: wrap;
 
 	&, .entry-content & {
 		* {

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -16,6 +16,10 @@ $courses-list: '#{$block}__courses-list';
 	margin-bottom: 28px;
 }
 
+.clearfix {
+	clear: both;
+}
+
 /* Learner courses styles */
 
 .editor-styles-wrapper #{$block}__filter,

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -131,7 +131,7 @@ $courses-list: '#{$block}__courses-list';
 
 #{$block}.has-sensei-primary-color {
 
-	.course-title a, #{$courses-list}__title a {
+	.course-title a, #{$courses-list}__title a, a {
 		color: var(--sensei-primary-color, inherit);
 	}
 

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -155,6 +155,7 @@ $courses-list: '#{$block}__courses-list';
 		align-items: center;
 		justify-content: flex-end;
 		margin-right: -12px;
+		clear: both;
 
 		.entry-content & {
 			margin-bottom: 0;

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -116,50 +116,6 @@ $courses-list: '#{$block}__courses-list';
 }
 
 
-#{$courses-list}.--is-grid-view, #{$block}--is-grid-view .course-container {
-	@media (min-width: 920px) {
-		display: flex;
-		flex-flow: row wrap;
-		margin: 0 -7px;
-
-		#{$courses-list}__item, .course {
-			display: block;
-			flex: 1 0 calc(50% - 22px);
-			margin: 0 11px;
-		}
-	}
-}
-
-.sensei-course-progress {
-
-	&__heading {
-		clear: both;
-	}
-
-	&__bar {
-		height: var(--sensei-progress-bar-height, 14px);
-		border-radius: var(--sensei-progress-bar-border-radius, 10px);
-
-		div {
-			background-color: currentColor;
-			background-color: var(--sensei-accent-color, currentColor);
-			border-radius: var(--sensei-progress-bar-border-radius, 10px);
-		}
-	}
-}
-
-#{$block}.has-sensei-primary-color {
-
-	.course-title a, #{$courses-list}__title a, a {
-		color: var(--sensei-primary-color, inherit);
-	}
-
-	.wp-block-button__link, .button {
-		background-color: var(--sensei-primary-color, inherit);
-		color: #fff;
-	}
-}
-
 #{$block} {
 
 	.course,
@@ -214,4 +170,48 @@ $courses-list: '#{$block}__courses-list';
 		}
 	}
 
+}
+
+#{$courses-list}.--is-grid-view, #{$block}--is-grid-view .course-container {
+	@media (min-width: 920px) {
+		display: flex;
+		flex-flow: row wrap;
+		margin: 0 -7px;
+
+		#{$courses-list}__item, .course {
+			display: block;
+			flex: 1 0 calc(50% - 22px);
+			margin: 0 11px;
+		}
+	}
+}
+
+.sensei-course-progress {
+
+	&__heading {
+		clear: both;
+	}
+
+	&__bar {
+		height: var(--sensei-progress-bar-height, 14px);
+		border-radius: var(--sensei-progress-bar-border-radius, 10px);
+
+		div {
+			background-color: currentColor;
+			background-color: var(--sensei-accent-color, currentColor);
+			border-radius: var(--sensei-progress-bar-border-radius, 10px);
+		}
+	}
+}
+
+#{$block}.has-sensei-primary-color {
+
+	.course-title a, #{$courses-list}__title a, a {
+		color: var(--sensei-primary-color, inherit);
+	}
+
+	.wp-block-button__link, .button {
+		background-color: var(--sensei-primary-color, inherit);
+		color: #fff;
+	}
 }

--- a/includes/blocks/class-sensei-block-helpers.php
+++ b/includes/blocks/class-sensei-block-helpers.php
@@ -14,17 +14,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Block_Helpers {
 
-
 	/**
 	 * Build CSS classes (for named colors) and inline styles from block attributes.
 	 *
-	 * @param array $block_attributes  The block attributes.
-	 * @param array $colors            An array with the color attribute as keys and the style property as values.
-	 * @param array $size_styles       An array with the sizing attribute as keys and the style property as values.
+	 * @param array $block_attributes The block attributes.
+	 * @param array $colors           An array with the color attribute as keys and the style property as values.
+	 * @param array $size_styles      An array with the sizing attribute as keys and the style property as values.
 	 *
 	 * @return array Colors CSS classes and inline styles.
 	 */
-	public static function build_styles( array $block_attributes, array $colors = [], array $size_styles = [] ) : array {
+	public static function build_styles( array $block_attributes, array $colors = [], array $size_styles = [] ): array {
 		$attributes = [
 			'css_classes'   => [],
 			'inline_styles' => [],
@@ -79,12 +78,12 @@ class Sensei_Block_Helpers {
 	/**
 	 * Render class and style HTML attributes.
 	 *
-	 * @param string|string[] $class_names An array of classes or a single class.
-	 * @param array           $css         {
-	 *     An array of classes and inline styles.
+	 * @param string|string[] $class_names   An array of classes or a single class.
+	 * @param array           $css           {
+	 *                                       An array of classes and inline styles.
 	 *
-	 *     @type string[] $css_classes   An array of classes.
-	 *     @type string[] $inline_styles An array of inline css.
+	 * @type string[]         $css_classes   An array of classes.
+	 * @type string[]         $inline_styles An array of inline css.
 	 * }
 	 *
 	 * @return string
@@ -127,5 +126,41 @@ class Sensei_Block_Helpers {
 		return $class_name;
 	}
 
+	/**
+	 * Generate CSS for the given variables. Skips variables with an empty value.
+	 *
+	 * @param array  $variables CSS variable key - value pairs.
+	 * @param string $separator Separator string between variables.
+	 *
+	 * @return array CSS styles and classlist.
+	 */
+	public static function css_variables( $variables, $separator = "\n" ) {
+		$style   = '';
+		$classes = '';
+		foreach ( $variables as $variable => $value ) {
+			if ( ! isset( $value ) || '' === $value ) {
+				continue;
+			}
+			$style   .= '--sensei-' . $variable . ': ' . $value . ';' . $separator;
+			$classes .= ' has-sensei-' . $variable . ' ';
+		}
+
+		return [ $style, $classes ];
+	}
+
+	/**
+	 * Add unit postfix to a value. Returns null if value is empty.
+	 *
+	 * @param string $value Value.
+	 * @param string $unit  Unit.
+	 *
+	 * @return string|null Postfixed value or null if empty.
+	 */
+	public static function css_unit( $value, $unit = 'px' ) {
+		if ( ! isset( $value ) || '' === $value ) {
+			return null;
+		}
+		return '' . $value . $unit;
+	}
 
 }

--- a/includes/blocks/class-sensei-blocks-initializer.php
+++ b/includes/blocks/class-sensei-blocks-initializer.php
@@ -63,7 +63,10 @@ abstract class Sensei_Blocks_Initializer {
 
 		$this->initialize_blocks();
 
-		add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
+		if ( is_admin() || Sensei()->blocks->has_sensei_blocks() ) {
+			add_action( 'enqueue_block_assets', [ $this, 'enqueue_block_assets' ] );
+		}
+
 		add_action( 'enqueue_block_editor_assets', [ $this, 'enqueue_block_editor_assets' ] );
 	}
 

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -151,26 +151,20 @@ class Sensei_Blocks {
 	}
 
 	/**
-	 * Check if the current post has Sensei blocks.
+	 * Check if the current post has any Sensei blocks.
+	 *
+	 * @param int|WP_Post|null $post
 	 *
 	 * @return bool
 	 */
-	public function has_sensei_blocks() {
-		global $post;
-
-		if ( ! $post ) {
-			return false;
+	public function has_sensei_blocks( $post = null ) {
+		if ( ! is_string( $post ) ) {
+			$wp_post = get_post( $post );
+			if ( $wp_post instanceof WP_Post ) {
+				$post = $wp_post->post_content;
+			}
 		}
 
-		switch ( $post->post_type ) {
-			case 'course':
-				return Sensei()->course->has_sensei_blocks();
-			case 'lesson':
-				return Sensei()->lesson->has_sensei_blocks();
-			case 'quiz':
-				return Sensei()->quiz->has_sensei_blocks();
-			default:
-				return false;
-		}
+		return false !== strpos( (string) $post, '<!-- wp:sensei-lms/' );
 	}
 }

--- a/includes/blocks/class-sensei-course-progress-block.php
+++ b/includes/blocks/class-sensei-course-progress-block.php
@@ -47,6 +47,10 @@ class Sensei_Course_Progress_Block {
 
 		$course_id = $attributes['postId'] ?? get_the_ID();
 
+		if ( ! Sensei()->course::is_user_enrolled( $course_id ) ) {
+			return '';
+		}
+
 		$completed     = count( Sensei()->course->get_completed_lesson_ids( $course_id ) );
 		$total_lessons = count( Sensei()->course->course_lessons( $course_id ) );
 		$percentage    = Sensei_Utils::quotient_as_absolute_rounded_percentage( $completed, $total_lessons );

--- a/includes/blocks/class-sensei-course-progress-block.php
+++ b/includes/blocks/class-sensei-course-progress-block.php
@@ -44,12 +44,11 @@ class Sensei_Course_Progress_Block {
 	 * @return string The HTML of the block.
 	 */
 	public function render_course_progress( $attributes ) : string {
-		if ( ! Sensei()->course::is_user_enrolled( get_the_ID() ) ) {
-			return '';
-		}
 
-		$completed     = count( Sensei()->course->get_completed_lesson_ids( get_the_ID() ) );
-		$total_lessons = count( Sensei()->course->course_lessons( get_the_ID() ) );
+		$course_id = $attributes['postId'] ?? get_the_ID();
+
+		$completed     = count( Sensei()->course->get_completed_lesson_ids( $course_id ) );
+		$total_lessons = count( Sensei()->course->course_lessons( $course_id ) );
 		$percentage    = Sensei_Utils::quotient_as_absolute_rounded_percentage( $completed, $total_lessons );
 
 		$text_css           = Sensei_Block_Helpers::build_styles( $attributes );

--- a/includes/blocks/class-sensei-learner-courses-block.php
+++ b/includes/blocks/class-sensei-learner-courses-block.php
@@ -50,6 +50,10 @@ class Sensei_Learner_Courses_Block {
 			]
 		);
 
+		if ( 'grid' === $attributes['options']['layoutView'] ) {
+			$class .= ' wp-block-sensei-lms-learner-courses--is-grid-view';
+		}
+
 		return '<div class="wp-block-sensei-lms-learner-courses ' . $class . ' " style="' . esc_attr( $style ) . '">' . $shortcode->render() . '</div>';
 	}
 }

--- a/includes/blocks/class-sensei-learner-courses-block.php
+++ b/includes/blocks/class-sensei-learner-courses-block.php
@@ -27,8 +27,6 @@ class Sensei_Learner_Courses_Block {
 			],
 			Sensei()->assets->src_path( 'blocks/learner-courses-block' )
 		);
-
-		add_filter( 'body_class', array( $this, 'add_sensei_body_class' ), 10, 1 );
 	}
 
 	/**
@@ -43,22 +41,15 @@ class Sensei_Learner_Courses_Block {
 
 		$shortcode = new Sensei_Shortcode_User_Courses( [ 'options' => $attributes['options'] ?? [] ], null, null );
 
-		return $shortcode->render();
-	}
+		list( $style, $class ) = Sensei_Block_Helpers::css_variables(
+			[
+				'accent-color'               => $attributes['options']['accentColor'] ?? null,
+				'primary-color'              => $attributes['options']['primaryColor'] ?? null,
+				'progress-bar-height'        => Sensei_Block_Helpers::css_unit( $attributes['options']['progressBarHeight'] ?? null, 'px' ),
+				'progress-bar-border-radius' => Sensei_Block_Helpers::css_unit( $attributes['options']['progressBarBorderRadius'] ?? null, 'px' ),
+			]
+		);
 
-	/**
-	 * Add sensei to body classes if block is used.
-	 *
-	 * @param array $classes
-	 *
-	 * @access private
-	 * @return array
-	 */
-	public function add_sensei_body_class( $classes ) {
-
-		if ( has_block( self::NAME ) ) {
-			$classes[] = 'sensei';
-		}
-		return $classes;
+		return '<div class="wp-block-sensei-lms-learner-courses ' . $class . ' " style="' . esc_attr( $style ) . '">' . $shortcode->render() . '</div>';
 	}
 }

--- a/includes/blocks/class-sensei-learner-courses-block.php
+++ b/includes/blocks/class-sensei-learner-courses-block.php
@@ -50,7 +50,7 @@ class Sensei_Learner_Courses_Block {
 			]
 		);
 
-		if ( 'grid' === $attributes['options']['layoutView'] ) {
+		if ( isset( $attributes['options']['layoutView'] ) && 'grid' === $attributes['options']['layoutView'] ) {
 			$class .= ' wp-block-sensei-lms-learner-courses--is-grid-view';
 		}
 

--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -34,6 +34,8 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	 * @access private
 	 */
 	public function enqueue_block_assets() {
+
+		Sensei()->assets->disable_frontend_styles();
 		Sensei()->assets->enqueue( 'sensei-single-page-blocks', 'blocks/single-page.js', [], true );
 		Sensei()->assets->enqueue(
 			'sensei-single-page-blocks-style',

--- a/includes/class-sensei-assets.php
+++ b/includes/class-sensei-assets.php
@@ -250,4 +250,12 @@ class Sensei_Assets {
 		_deprecated_function( __METHOD__, '3.10.0' );
 	}
 
+
+	/**
+	 * Disable loading frontend.css for the current page.
+	 */
+	public function disable_frontend_styles() {
+		add_filter( 'sensei_disable_styles', '__return_true' );
+	}
+
 }

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -35,6 +35,7 @@ function is_sensei() {
 			|| Sensei_Utils::is_learner_profile_page()
 			|| Sensei_Utils::is_course_results_page()
 			|| Sensei_Utils::is_teacher_archive_page()
+			|| Sensei()->blocks->has_sensei_blocks()
 		) {
 			$is_sensei = true;
 		}

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -368,7 +368,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 			}
 
 			remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'the_course_meta' ) );
-			add_action( 'sensei_course_content_inside_before', array( $this, 'course_completed_badge' ) );
+			add_action( 'sensei_course_content_inside_before', array( $this, 'course_completed_badge' ), 40 );
 
 			if ( false === $this->options['featuredImageEnabled'] ) {
 				add_action( 'sensei_course_content_inside_before', array( $this, 'course_category' ), 3 );

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -82,6 +82,13 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	private $page_id = 0;
 
 	/**
+	 * Rendering as a block.
+	 *
+	 * @var bool
+	 */
+	private $is_block = false;
+
+	/**
 	 * Setup the shortcode object
 	 *
 	 * @since 1.9.0
@@ -142,6 +149,8 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 			$this->order = isset( $attributes['order'] ) ? $attributes['order'] : 'ASC';
 
 		}
+
+		$this->is_block = ! empty( $attributes['options'] );
 
 		$this->options = wp_parse_args(
 			$attributes['options'],
@@ -315,9 +324,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		ob_start();
 		echo '<section id="sensei-user-courses">';
 
-		$use_blocks = ! empty( $this->options );
-
-		if ( ! $use_blocks ) {
+		if ( ! $this->is_block ) {
 			Sensei_Messages::the_my_messages_link();
 		}
 
@@ -349,23 +356,19 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	 */
 	public function attach_shortcode_hooks() {
 
-		// attach the toggle functionality
-		// don't show the toggle action if the user specified complete or active for this shortcode
+		// Don't show the toggle action if the user specified complete or active for this shortcode.
 		if ( $this->is_shortcode_initial_status_all ) {
-
 			add_action( 'sensei_loop_course_before', array( $this, 'course_toggle_actions' ) );
-			add_action( 'wp_footer', array( $this, 'print_course_toggle_actions_inline_script' ), 90 );
-
 		}
 
-		// add extra classes to distinguish the course based on user completed or active
 		add_filter( 'sensei_course_loop_content_class', array( $this, 'course_status_class_tagging' ), 20, 2 );
 
-		if ( false === $this->options['featuredImageEnabled'] ) {
-			remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'course_image' ), 30, 1 );
-		}
+		if ( $this->is_block ) {
 
-		if ( false === $this->options['courseCategoryEnabled'] ) {
+			if ( false === $this->options['featuredImageEnabled'] ) {
+				remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'course_image' ), 30 );
+			}
+
 			remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'the_course_meta' ) );
 		}
 
@@ -375,10 +378,10 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 		add_filter( 'sensei_course_loop_number_of_columns', [ $this, 'course_column_count' ] );
 
-		// attach progress meter below course
 		if ( false !== $this->options['progressBarEnabled'] ) {
 			add_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_progress' ) );
 		}
+
 		add_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_buttons' ) );
 
 	}
@@ -390,10 +393,10 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	 */
 	public function detach_shortcode_hooks() {
 
-		// remove all hooks after the output is generated
+		// Remove all hooks after the output is generated.
 		remove_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_progress' ) );
 		remove_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_buttons' ) );
-		remove_filter( 'sensei_course_loop_content_class', array( $this, 'course_status_class_tagging' ), 20, 2 );
+		remove_filter( 'sensei_course_loop_content_class', array( $this, 'course_status_class_tagging' ), 20 );
 		remove_action( 'sensei_loop_course_before', array( $this, 'course_toggle_actions' ) );
 		remove_filter( 'get_the_excerpt', '__return_false' );
 		remove_filter( 'sensei_course_loop_number_of_columns', [ $this, 'course_column_count' ] );
@@ -402,7 +405,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 			add_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'course_image' ), 30, 1 );
 		}
 
-		if ( false === $this->options['courseCategoryEnabled'] ) {
+		if ( $this->is_block ) {
 			add_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'the_course_meta' ) );
 		}
 	}
@@ -410,14 +413,19 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	/**
 	 * Hooks into sensei_course_content_inside_after
 	 *
-	 * @param $course
+	 * @param int $course_id Course ID.
 	 */
 	public function attach_course_progress( $course_id ) {
 
-		$percentage = Sensei()->course->get_completion_percentage( $course_id, get_current_user_id() );
-		echo wp_kses_post( Sensei()->course->get_progress_meter( $percentage ) );
+		if ( $this->is_block ) {
+			$progress_block = ( new Sensei_Course_Progress_Block() )->render_course_progress( [ 'postId' => $course_id ] );
+			echo wp_kses_post( $progress_block );
+		} else {
+			$percentage = Sensei()->course->get_completion_percentage( $course_id, get_current_user_id() );
+			echo wp_kses_post( Sensei()->course->get_progress_meter( $percentage ) );
+		}
 
-	}//end attach_course_progress()
+	}
 
 
 	/**
@@ -431,7 +439,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 		Sensei()->course->the_course_action_buttons( get_post( $course_id ) );
 
-	}//end attach_course_buttons()
+	}
 
 	/**
 	 * Add a the user status class for the given course.

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -369,6 +369,11 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 			remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'the_course_meta' ) );
 			add_action( 'sensei_course_content_inside_before', array( $this, 'course_completed_badge' ) );
+
+			if ( false === $this->options['featuredImageEnabled'] ) {
+				add_action( 'sensei_course_content_inside_before', array( $this, 'course_category' ), 3 );
+			}
+
 		}
 
 		if ( false === $this->options['courseDescriptionEnabled'] ) {
@@ -450,6 +455,19 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 						</em>
 					</div>';
 		}
+	}
+
+	/**
+	 * Display course categories.
+	 *
+	 * @param int|WP_Post $course
+	 */
+	public function course_category( $course ) {
+		$category_output = get_the_term_list( $course, 'course-category', '', ', ', '' );
+		echo '<div class="wp-block-sensei-lms-learner-courses__courses-list__category">
+						' . wp_kses_post( $category_output ) . '
+					</div>';
+
 	}
 
 	/**

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -450,7 +450,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	 */
 	public function course_completed_badge( $course ) {
 		if ( Sensei_Utils::user_completed_course( $course, get_current_user_id() ) ) {
-			echo '<div>
+			echo '<div class="wp-block-sensei-lms-learner-courses__courses-list__badge__wrapper">
 						<em class="wp-block-sensei-lms-learner-courses__courses-list__badge">
 							' . esc_html__( 'Completed', 'sensei-lms' ) . '
 						</em>

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -373,7 +373,6 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 			if ( false === $this->options['featuredImageEnabled'] ) {
 				add_action( 'sensei_course_content_inside_before', array( $this, 'course_category' ), 3 );
 			}
-
 		}
 
 		if ( false === $this->options['courseDescriptionEnabled'] ) {

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -368,6 +368,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 			}
 
 			remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'the_course_meta' ) );
+			add_action( 'sensei_course_content_inside_before', array( $this, 'course_completed_badge' ) );
 		}
 
 		if ( false === $this->options['courseDescriptionEnabled'] ) {
@@ -434,6 +435,21 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 		Sensei()->course->the_course_action_buttons( get_post( $course_id ) );
 
+	}
+
+	/**
+	 * Add Completed badge to completed courses.
+	 *
+	 * @param int|WP_Post $course
+	 */
+	public function course_completed_badge( $course ) {
+		if ( Sensei_Utils::user_completed_course( $course, get_current_user_id() ) ) {
+			echo '<div>
+						<em class="wp-block-sensei-lms-learner-courses__courses-list__badge">
+							' . esc_html__( 'Completed', 'sensei-lms' ) . '
+						</em>
+					</div>';
+		}
 	}
 
 	/**

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -164,8 +164,6 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 			]
 		);
 
-		$this->options['columns'] = 'grid' === $this->options['layoutView'] ? $this->options['columns'] : 1;
-
 	}
 
 	private function is_my_courses() {
@@ -376,8 +374,6 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 			add_filter( 'get_the_excerpt', '__return_false' );
 		}
 
-		add_filter( 'sensei_course_loop_number_of_columns', [ $this, 'course_column_count' ] );
-
 		if ( false !== $this->options['progressBarEnabled'] ) {
 			add_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_progress' ) );
 		}
@@ -399,7 +395,6 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		remove_filter( 'sensei_course_loop_content_class', array( $this, 'course_status_class_tagging' ), 20 );
 		remove_action( 'sensei_loop_course_before', array( $this, 'course_toggle_actions' ) );
 		remove_filter( 'get_the_excerpt', '__return_false' );
-		remove_filter( 'sensei_course_loop_number_of_columns', [ $this, 'course_column_count' ] );
 
 		if ( false === $this->options['featuredImageEnabled'] ) {
 			add_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'course_image' ), 30, 1 );
@@ -506,16 +501,6 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		<?php
 	}
 
-	/**
-	 * Set grid/list layout and number of columns.
-	 *
-	 * @access private
-	 *
-	 * @return integer
-	 */
-	public function course_column_count() {
-		return $this->options['columns'];
-	}
 
 	/**
 	 * Load the javascript for the toggle functionality

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -363,28 +363,28 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 		if ( $this->is_block ) {
 
-			if ( false === $this->options['featuredImageEnabled'] ) {
+			remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'the_course_meta' ) );
+
+			if ( ! $this->options['featuredImageEnabled'] ) {
 				remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'course_image' ), 30 );
 			}
 
-			remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'the_course_meta' ) );
 			add_action( 'sensei_course_content_inside_before', array( $this, 'course_completed_badge' ), 40 );
 
-			if ( false === $this->options['featuredImageEnabled'] ) {
+			if ( $this->options['courseCategoryEnabled'] ) {
 				add_action( 'sensei_course_content_inside_before', array( $this, 'course_category' ), 3 );
+			}
+
+			if ( ! $this->options['courseDescriptionEnabled'] ) {
+				add_filter( 'get_the_excerpt', '__return_false' );
+			}
+
+			if ( $this->options['progressBarEnabled'] ) {
+				add_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_progress' ) );
 			}
 		}
 
-		if ( false === $this->options['courseDescriptionEnabled'] ) {
-			add_filter( 'get_the_excerpt', '__return_false' );
-		}
-
-		if ( false !== $this->options['progressBarEnabled'] ) {
-			add_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_progress' ) );
-		}
-
 		add_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_buttons' ) );
-
 	}
 
 	/**
@@ -395,6 +395,8 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	public function detach_shortcode_hooks() {
 
 		// Remove all hooks after the output is generated.
+		remove_action( 'sensei_course_content_inside_before', array( $this, 'course_category' ), 3 );
+		remove_action( 'sensei_course_content_inside_before', array( $this, 'course_completed_badge' ), 40 );
 		remove_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_progress' ) );
 		remove_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_buttons' ) );
 		remove_filter( 'sensei_course_loop_content_class', array( $this, 'course_status_class_tagging' ), 20 );


### PR DESCRIPTION
Some solutions here are intermediary at best. The CSS rules are a mixture of the naming style used for blocks, and the frontend classes in the shortcode/templates that can't be changed easily for now. 

### Changes proposed in this Pull Request

* Update frontend styles for Learner Courses block
* Apply customizations with CSS variables
* Do not load Sensei's `frontend.css` for pages with this block
* Change the block layout to what's currently feasible on the frontend
  * Featured image is a floated 100x100 square, even in grid mode. — there is more nuance in Sensei around these images, including filters and settings. It can also pick up a lesson's image, didn't want to move away from that now. Also, I didn't way an easy way to display these images responsively as per the original grid design.
* Add View Results button in the editor. This button (and View Certificate, and possibly some others) are still added on the frontend as they were before.
* Update color customization for consistency: Primary color affects title, buttons(?) and links in the tabs. Accent color affects the progress bar & completed badge.

Wider changes:
* Add having Sensei blocks on the page for `is_sensei`'s condition — adds `.sensei` class to body on pages using Sensei blocks. 

### Testing instructions

* Add a Learner Courses block to a page, publish & view
* Check that it picks up block styles
* Check that list/grid layout works
* Check that color & progress bar customizations work 
* Check in different themes
* Check that the original My courses (sensei_user_courses) shortcode works as previously
* Check that hiding elements of the course entry (featured image, category, description) works

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="850" alt="image" src="https://user-images.githubusercontent.com/176949/114201028-15635280-9956-11eb-89da-8e37f8f2a58f.png">


<img width="649" alt="image" src="https://user-images.githubusercontent.com/176949/114200521-93732980-9955-11eb-80aa-8295654c55ec.png">


