### PR TITLE
Fix Learner Courses list width

### DIFF
--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -82,7 +82,7 @@ const LearnerCoursesEdit = ( {
 						<Icon icon={ image } size={ 48 } />
 					</div>
 				) }
-				<div>
+				<div className="wp-block-sensei-lms-learner-courses__courses-list__course-info">
 					{ options.courseCategoryEnabled && (
 						<small className="wp-block-sensei-lms-learner-courses__courses-list__category">
 							{ __( 'Category name', 'sensei-lms' ) }

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -65,6 +65,10 @@ $courses-list: '#{$block}__courses-list';
 
 		&__course-info {
 			flex: 1;
+
+			@media (min-width: 920px) {
+				padding-right: 20%;
+			}
 		}
 
 		&__category {

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -63,6 +63,10 @@ $courses-list: '#{$block}__courses-list';
 			fill: #FFF;
 		}
 
+		&__course-info {
+			flex: 1;
+		}
+
 		&__category {
 			display: block;
 			font-size: 12px;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix Learner Courses list width.

### Testing instructions

* Add a Learner Courses block to a page, activate the Divi and Astra theme, and make sure the list appears in full width.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="900" alt="Screen Shot 2021-04-09 at 10 27 43" src="https://user-images.githubusercontent.com/876340/114187770-bfbf8380-991e-11eb-9127-46cca16e1533.png">
