### PR TITLE
Change Github workflows to run for every branch

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,6 +2,7 @@ name: E2E
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, edited]
     branches:
       - master
       - 'feature/**'
@@ -9,6 +10,7 @@ on:
 
 jobs:
   test:
+    if: ${{ github.event.action != 'edited' || github.event.changes.base }}
     name: E2E Tests
     runs-on: ubuntu-16.04
     strategy:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,16 +1,10 @@
 name: E2E
 
 on:
-  pull_request:
-    types: [synchronize, opened, reopened, edited]
-    branches:
-      - master
-      - 'feature/**'
-      - 'release/**'
+  pull_request
 
 jobs:
   test:
-    if: ${{ github.event.action != 'edited' || github.event.changes.base }}
     name: E2E Tests
     runs-on: ubuntu-16.04
     strategy:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -2,6 +2,7 @@ name: PHP Linting and Tests
 
 on:
   pull_request:
+    types: [synchronize, opened, reopened, edited]
     branches:
       - master
       - 'feature/**'
@@ -9,6 +10,7 @@ on:
 
 jobs:
   lint:
+    if: ${{ github.event.action != 'edited' || github.event.changes.base }}
     name:    PHP Linting
     runs-on: ubuntu-16.04
     steps:
@@ -41,6 +43,7 @@ jobs:
       - name: Check WPCOM rules
         run: ./vendor/bin/phpcs -sn --standard=./wpcom-phpcs.xml .
   test:
+    if: ${{ github.event.action != 'edited' || github.event.changes.base }}
     name: PHP Unit Tests
     runs-on: ubuntu-16.04
     strategy:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,16 +1,10 @@
 name: PHP Linting and Tests
 
 on:
-  pull_request:
-    types: [synchronize, opened, reopened, edited]
-    branches:
-      - master
-      - 'feature/**'
-      - 'release/**'
+  pull_request
 
 jobs:
   lint:
-    if: ${{ github.event.action != 'edited' || github.event.changes.base }}
     name:    PHP Linting
     runs-on: ubuntu-16.04
     steps:
@@ -43,7 +37,6 @@ jobs:
       - name: Check WPCOM rules
         run: ./vendor/bin/phpcs -sn --standard=./wpcom-phpcs.xml .
   test:
-    if: ${{ github.event.action != 'edited' || github.event.changes.base }}
     name: PHP Unit Tests
     runs-on: ubuntu-16.04
     strategy:


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Github wasn't running the jobs when editing the base branch in a PR. A common example is:
   Create a feature in `add/structure` based on `master`. And before merging it to `master`, create `add/new-structure` based on `add/structure`. Merge the `add/structure` in `master`, and the `add/new-structure` PR will automatically change the base, but the jobs will get stuck as waiting for status.
* @jom found the https://github.com/actions/runner/issues/980 issue, and I tried to implement the suggestion (see https://github.com/Automattic/sensei/commit/45a22e36db021b9738f21ac221e596a31bc329d6), but we had a worse issue. If we edit the PR (title, description...), it skips the jobs, but either way, it keeps them as waiting for status. See screenshot:
<img width="961" alt="Screen Shot 2021-04-09 at 12 06 09" src="https://user-images.githubusercontent.com/876340/114205073-4d579f00-9930-11eb-9fcc-6aaeb0cf789c.png">

It seems like a Github issue for me. But I created this PR for a more comfortable solution for us (similar to the JS workflow which runs for every branch). It will still not run the workflows when the base is automatically updated, but it'll not add the jobs as waiting for status without a possible action until doing a new push.