### PR TITLE
Remove three-column layout in Learner Courses block

### DIFF
--- a/assets/blocks/learner-courses-block/block.json
+++ b/assets/blocks/learner-courses-block/block.json
@@ -9,7 +9,6 @@
       "type": "object",
       "default": {
         "layoutView": "list",
-        "columns": 2,
         "courseDescriptionEnabled": true,
         "featuredImageEnabled": false,
         "courseCategoryEnabled": false,

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -162,11 +162,10 @@ const LearnerCoursesEdit = ( {
 				<ul
 					className={ classnames(
 						'wp-block-sensei-lms-learner-courses__courses-list',
-						`--is-${ options.layoutView }-view`,
-						`--is-${ options.columns }-columns`
+						`--is-${ options.layoutView }-view`
 					) }
 				>
-					{ Array.from( { length: options.columns } ).map(
+					{ Array.from( { length: 2 } ).map(
 						coursesPlaceholderMap
 					) }
 				</ul>

--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -165,9 +165,7 @@ const LearnerCoursesEdit = ( {
 						`--is-${ options.layoutView }-view`
 					) }
 				>
-					{ Array.from( { length: 2 } ).map(
-						coursesPlaceholderMap
-					) }
+					{ Array.from( { length: 2 } ).map( coursesPlaceholderMap ) }
 				</ul>
 			</section>
 			<LearnerCoursesSettings

--- a/assets/blocks/learner-courses-block/learner-courses-settings.js
+++ b/assets/blocks/learner-courses-block/learner-courses-settings.js
@@ -15,7 +15,7 @@ import {
 	SelectControl,
 } from '@wordpress/components';
 import { grid, list } from '@wordpress/icons';
-import { __, sprintf, _n } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -103,10 +103,12 @@ const LearnerCoursesSettings = ( { options, setOptions } ) => {
 					<PanelRow>
 						<SelectControl
 							label={ __( 'Layout', 'sensei-lms' ) }
-							options={ layoutViewTogglers.map( ( { view, label } ) => ( {
-								value: view,
-								label,
-							} ) ) }
+							options={ layoutViewTogglers.map(
+								( { view, label } ) => ( {
+									value: view,
+									label,
+								} )
+							) }
 							value={ options.layoutView }
 							onChange={ ( value ) => {
 								setOptions( { layoutView: value } );

--- a/assets/blocks/learner-courses-block/learner-courses-settings.js
+++ b/assets/blocks/learner-courses-block/learner-courses-settings.js
@@ -96,37 +96,24 @@ const LearnerCoursesSettings = ( { options, setOptions } ) => {
 						</PanelRow>
 					) ) }
 				</PanelBody>
-				{ 'grid' === options.layoutView && (
-					<PanelBody
-						title={ __( 'Styling', 'sensei-lms' ) }
-						initialOpen={ true }
-					>
-						<PanelRow>
-							<SelectControl
-								label={ __( 'Layout', 'sensei-lms' ) }
-								options={ [ 2, 3 ].map( ( columns ) => ( {
-									value: columns,
-									label: sprintf(
-										// translators: placeholder is number of columns.
-										_n(
-											'%d column',
-											'%d columns',
-											columns,
-											'sensei-lms'
-										),
-										columns
-									),
-								} ) ) }
-								value={ options.columns }
-								onChange={ ( value ) => {
-									setOptions( {
-										columns: value,
-									} );
-								} }
-							/>
-						</PanelRow>
-					</PanelBody>
-				) }
+				<PanelBody
+					title={ __( 'Styling', 'sensei-lms' ) }
+					initialOpen={ true }
+				>
+					<PanelRow>
+						<SelectControl
+							label={ __( 'Layout', 'sensei-lms' ) }
+							options={ layoutViewTogglers.map( ( { view, label } ) => ( {
+								value: view,
+								label,
+							} ) ) }
+							value={ options.layoutView }
+							onChange={ ( value ) => {
+								setOptions( { layoutView: value } );
+							} }
+						/>
+					</PanelRow>
+				</PanelBody>
 				{ options.progressBarEnabled && (
 					<CourseProgressSettings
 						borderRadius={ options.progressBarBorderRadius }

--- a/assets/blocks/learner-courses-block/learner-courses-settings.test.js
+++ b/assets/blocks/learner-courses-block/learner-courses-settings.test.js
@@ -24,7 +24,6 @@ describe( '<LearnerCoursesSettings />', () => {
 			courseCategoryEnabled: true,
 			progressBarEnabled: true,
 			layoutView: 'grid',
-			columns: 2,
 			progressBarHeight: 20,
 			progressBarBorderRadius: 10,
 		};
@@ -59,7 +58,7 @@ describe( '<LearnerCoursesSettings />', () => {
 		expect( queryByTestId( 'list' ) ).not.toHaveClass( 'is-pressed' );
 		expect( queryByTestId( 'grid' ) ).toHaveClass( 'is-pressed' );
 
-		expect( queryByLabelText( 'Layout' ).value ).toEqual( '2' );
+		expect( queryByLabelText( 'Layout' ).value ).toEqual( 'grid' );
 
 		// Open progress bar settings.
 		fireEvent.click( queryByText( 'Progress bar settings' ) );
@@ -80,7 +79,6 @@ describe( '<LearnerCoursesSettings />', () => {
 			courseCategoryEnabled: true,
 			progressBarEnabled: true,
 			layoutView: 'grid',
-			columns: 2,
 			progressBarHeight: 20,
 			progressBarBorderRadius: 10,
 		};
@@ -127,13 +125,6 @@ describe( '<LearnerCoursesSettings />', () => {
 			layoutView: 'grid',
 		} );
 
-		fireEvent.change( queryByLabelText( 'Layout' ), {
-			target: { value: '3' },
-		} );
-		expect( setOptionsMock ).toBeCalledWith( {
-			columns: '3',
-		} );
-
 		// Open progress bar settings.
 		fireEvent.click( queryByText( 'Progress bar settings' ) );
 
@@ -150,21 +141,6 @@ describe( '<LearnerCoursesSettings />', () => {
 		expect( setOptionsMock ).toBeCalledWith( {
 			progressBarBorderRadius: 5,
 		} );
-	} );
-
-	it( 'Should not show layout setting when layout view is "list"', () => {
-		const options = {
-			layoutView: 'list',
-		};
-
-		const { queryByLabelText } = render(
-			<LearnerCoursesSettings
-				options={ options }
-				setOptions={ () => {} }
-			/>
-		);
-
-		expect( queryByLabelText( 'Layout' ) ).toBeFalsy();
 	} );
 
 	it( 'Should not show progress bar settings when progress bar is disabled', () => {

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -122,17 +122,6 @@ $courses-list: '#{$block}__courses-list';
 						margin-bottom: 20px;
 					}
 				}
-
-				&.--is-3-columns {
-					margin: 0 -11px;
-
-					#{$courses-list} {
-						&__item {
-							width: calc( 100% / 3 - 14px );
-							margin: 0 7px;
-						}
-					}
-				}
 			}
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

- Change the _Layout_ setting in the Learner Courses block to select between _Grid view_ or _List view_.
- Eliminate the 3-column layout since it will be hard to make that look good on all themes.

### Testing instructions

Switch between _Grid view_ and _List view_ in the _Layout_ block setting and ensure the block layout is updated and the appropriate toolbar option is selected.