### PR TITLE
Tweak description for View Results block

### DIFF
--- a/assets/blocks/view-results-block/index.js
+++ b/assets/blocks/view-results-block/index.js
@@ -18,7 +18,7 @@ export default createButtonBlockType( {
 	settings: {
 		name: 'sensei-lms/button-view-results',
 		description: __(
-			'Allow an enrolled user to navigate to the course results page. The block is only displayed if the user is enrolled to the course.',
+			'Enable a learner to view their course results.',
 			'sensei-lms'
 		),
 		title: __( 'View Results', 'sensei-lms' ),


### PR DESCRIPTION
Tweaks the description for the _View Results_ block. I removed the bit about visibility since that should be fairly obvious, and we usually use this explanatory text when there are multiple conditions that affect the block's visibility.