### PR TITLE
Add Sensei block category to pages

### DIFF
--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -90,7 +90,7 @@ class Sensei_Blocks {
 	 * @return array Filtered categories.
 	 */
 	public function sensei_block_categories( $categories, $post ) {
-		if ( ! in_array( $post->post_type, [ 'course', 'lesson', 'question' ], true ) ) {
+		if ( ! in_array( $post->post_type, [ 'course', 'lesson', 'question', 'page' ], true ) ) {
 			return $categories;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* We were registering our blocks to the category but it wasn't being registered on pages.

### Testing instructions

* Go to create a new page in the editor. Make sure when you click to add a new block from the block gallery the Sensei LMS category appears. 
* Make sure no warnings are thrown in the console.