### PR TITLE
Add extension card logic

### DIFF
--- a/assets/extensions/all-extensions.js
+++ b/assets/extensions/all-extensions.js
@@ -16,13 +16,19 @@ const AllExtensions = () => (
 			</h2>
 			<ul className="sensei-extensions__section__content sensei-extensions__featured-list">
 				<li className="sensei-extensions__featured-list__item">
-					<Card />
+					<div className="sensei-extensions__featured-list__card-wrapper">
+						<Card />
+					</div>
 				</li>
 				<li className="sensei-extensions__featured-list__item">
-					<Card />
+					<div className="sensei-extensions__featured-list__card-wrapper">
+						<Card />
+					</div>
 				</li>
 				<li className="sensei-extensions__featured-list__item">
-					<Card />
+					<div className="sensei-extensions__featured-list__card-wrapper">
+						<Card />
+					</div>
 				</li>
 			</ul>
 		</section>

--- a/assets/extensions/all-extensions.js
+++ b/assets/extensions/all-extensions.js
@@ -16,7 +16,7 @@ const AllExtensions = () => (
 			</h2>
 			<ul className="sensei-extensions__section__content sensei-extensions__featured-list">
 				<li className="sensei-extensions__featured-list__item">
-					<Card hasUpdate />
+					<Card />
 				</li>
 				<li className="sensei-extensions__featured-list__item">
 					<Card />

--- a/assets/extensions/card.js
+++ b/assets/extensions/card.js
@@ -23,22 +23,22 @@ const extensionMock = {"version":"5.0.0.0.0.0","has_update":true,"hash":"d1a6964
  */
 const Card = ( { extension = extensionMock } ) => (
 	<article className="sensei-extensions__card">
-		<div>
-			<header className="sensei-extensions__card__header">
-				<h3 className="sensei-extensions__card__title">
-					{ extension.title }
-				</h3>
-				{ extension.has_update && (
-					<small className="sensei-extensions__card__new-badge">
-						{ __( 'New version', 'sensei-lms' ) }
-					</small>
-				) }
-			</header>
+		<header className="sensei-extensions__card__header">
+			<h3 className="sensei-extensions__card__title">
+				{ extension.title }
+			</h3>
+			{ extension.has_update && (
+				<small className="sensei-extensions__card__new-badge">
+					{ __( 'New version', 'sensei-lms' ) }
+				</small>
+			) }
+		</header>
+		<div className="sensei-extensions__card__content">
 			<p className="sensei-extensions__card__description">
 				{ extension.excerpt }
 			</p>
+			<ExtensionActions extension={ extension } />
 		</div>
-		<ExtensionActions extension={ extension } />
 	</article>
 );
 

--- a/assets/extensions/card.js
+++ b/assets/extensions/card.js
@@ -8,6 +8,13 @@ import { __ } from '@wordpress/i18n';
  */
 import ExtensionActions from './extension-actions';
 
+// prettier-ignore
+// const extensionMock = {"hash":"d1a69640d53a32a9fb13e93d1c8f3104","title":"WooCommerce Paid Courses","image":null,"excerpt":"Sell your courses using the most popular eCommerce platform on the web \u2013 WooCommerce.","link":"https:\/\/senseilms.com\/product\/woocommerce-paid-courses\/","price":"$129.00","is_featured":false,"product_slug":"sensei-wc-paid-courses","hosted_location":"external","type":"plugin","plugin_file":"woothemes-sensei\/woothemes-sensei.php","wccom_product_id":"152116"};
+// prettier-ignore
+// const extensionMock = {"version":"5.0.0.0.0.0","hash":"d1a69640d53a32a9fb13e93d1c8f3104","title":"WooCommerce Paid Courses","image":null,"excerpt":"Sell your courses using the most popular eCommerce platform on the web \u2013 WooCommerce.","link":"https:\/\/senseilms.com\/product\/woocommerce-paid-courses\/","price":"$129.00","is_featured":false,"product_slug":"sensei-wc-paid-courses","hosted_location":"external","type":"plugin","plugin_file":"woothemes-sensei\/woothemes-sensei.php","wccom_product_id":"152116"};
+// prettier-ignore
+const extensionMock = {"version":"5.0.0.0.0.0","has_update":true,"hash":"d1a69640d53a32a9fb13e93d1c8f3104","title":"WooCommerce Paid Courses","image":null,"excerpt":"Sell your courses using the most popular eCommerce platform on the web \u2013 WooCommerce.","link":"https:\/\/senseilms.com\/product\/woocommerce-paid-courses\/","price":"$129.00","is_featured":false,"product_slug":"sensei-wc-paid-courses","hosted_location":"external","type":"plugin","plugin_file":"woothemes-sensei\/woothemes-sensei.php","wccom_product_id":"152116"};
+
 /**
  * Extensions card component.
  *

--- a/assets/extensions/card.js
+++ b/assets/extensions/card.js
@@ -27,7 +27,6 @@ const Card = ( { hasUpdate } ) => (
 					</small>
 				) }
 			</header>
-			<strong className="sensei-extensions__card__price">$ 29</strong>
 			<p className="sensei-extensions__card__description">
 				Lorem ipsum dolor sit amet, consectertur adipiscing elit. Enin
 				cras odio netus mi. Maecenas

--- a/assets/extensions/card.js
+++ b/assets/extensions/card.js
@@ -19,27 +19,26 @@ const extensionMock = {"version":"5.0.0.0.0.0","has_update":true,"hash":"d1a6964
  * Extensions card component.
  *
  * @param {Object}  props           Component props.
- * @param {boolean} props.hasUpdate Whether extensions has update.
+ * @param {boolean} props.extension Extension object.
  */
-const Card = ( { hasUpdate } ) => (
+const Card = ( { extension = extensionMock } ) => (
 	<article className="sensei-extensions__card">
 		<div>
 			<header className="sensei-extensions__card__header">
 				<h3 className="sensei-extensions__card__title">
-					Advanced quizzes
+					{ extension.title }
 				</h3>
-				{ hasUpdate && (
+				{ extension.has_update && (
 					<small className="sensei-extensions__card__new-badge">
 						{ __( 'New version', 'sensei-lms' ) }
 					</small>
 				) }
 			</header>
 			<p className="sensei-extensions__card__description">
-				Lorem ipsum dolor sit amet, consectertur adipiscing elit. Enin
-				cras odio netus mi. Maecenas
+				{ extension.excerpt }
 			</p>
 		</div>
-		<ExtensionActions detailsLink="#" />
+		<ExtensionActions extension={ extension } />
 	</article>
 );
 

--- a/assets/extensions/extension-actions.js
+++ b/assets/extensions/extension-actions.js
@@ -14,7 +14,7 @@ const ExtensionActions = ( { buttonLabel, detailsLink } ) => (
 	<ul className="sensei-extensions__extension-actions">
 		<li className="sensei-extensions__extension-actions__item">
 			<button className="button button-primary">
-				{ buttonLabel || __( 'Install', 'sensei-lms' ) }
+				{ buttonLabel || __( 'Install - $29.99', 'sensei-lms' ) }
 			</button>
 		</li>
 		{ detailsLink && (

--- a/assets/extensions/extension-actions.js
+++ b/assets/extensions/extension-actions.js
@@ -2,34 +2,69 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { checked } from '../icons/wordpress-icons';
 
 /**
  * Extension actions component.
  *
  * @param {Object} props             Component props.
+ * @param {string} props.extension   Extension object.
  * @param {string} props.buttonLabel Button label.
- * @param {string} props.detailsLink Details link.
  */
-const ExtensionActions = ( { buttonLabel, detailsLink } ) => (
-	<ul className="sensei-extensions__extension-actions">
-		<li className="sensei-extensions__extension-actions__item">
-			<button className="button button-primary">
-				{ buttonLabel || __( 'Install - $29.99', 'sensei-lms' ) }
-			</button>
-		</li>
-		{ detailsLink && (
+const ExtensionActions = ( { extension = {}, buttonLabel } ) => {
+	let disabledButton = false;
+
+	if ( ! buttonLabel ) {
+		if ( extension.has_update ) {
+			buttonLabel = __( 'Update', 'sensei-lms' );
+		} else if ( extension.version ) {
+			buttonLabel = (
+				<>
+					<Icon
+						className="sensei-extensions__extension-actions__button-icon"
+						icon={ checked }
+						size={ 14 }
+					/>{ ' ' }
+					{ __( 'Installed', 'sensei-lms' ) }
+				</>
+			);
+			disabledButton = true;
+		} else {
+			buttonLabel = `${ __( 'Install', 'sensei-lms' ) } - ${
+				extension.price
+			}`;
+		}
+	}
+
+	return (
+		<ul className="sensei-extensions__extension-actions">
 			<li className="sensei-extensions__extension-actions__item">
-				<a
-					href={ detailsLink }
-					className="sensei-extensions__extension-actions__details-link"
-					target="_blank"
-					rel="noreferrer external"
+				<button
+					className="button button-primary"
+					disabled={ disabledButton }
 				>
-					{ __( 'More details', 'sensei-lms' ) }
-				</a>
+					{ buttonLabel || __( 'Install - $29.99', 'sensei-lms' ) }
+				</button>
 			</li>
-		) }
-	</ul>
-);
+			{ extension.link && (
+				<li className="sensei-extensions__extension-actions__item">
+					<a
+						href={ extension.link }
+						className="sensei-extensions__extension-actions__details-link"
+						target="_blank"
+						rel="noreferrer external"
+					>
+						{ __( 'More details', 'sensei-lms' ) }
+					</a>
+				</li>
+			) }
+		</ul>
+	);
+};
 
 export default ExtensionActions;

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -242,19 +242,10 @@
 			margin-bottom: 10px;
 		}
 
-		&__title,
-		&__price {
-			font-size: 16px;
-			font-weight: bold;
-		}
-
 		&__title {
 			margin: 0;
-		}
-
-		&__price {
-			display: block;
-			margin-bottom: 10px;
+			font-size: 16px;
+			font-weight: bold;
 		}
 
 		&__new-badge {

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -53,6 +53,7 @@
 
 		&__col {
 			box-sizing: border-box;
+			width: 100%;
 			padding: 0 9px;
 
 			&.--col-12 {

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -16,6 +16,11 @@
 .sensei-extensions {
 	margin-right: 20px;
 
+	.button-primary {
+		min-width: 112px;
+		min-height: 36px;
+	}
+
 	&__loader {
 		height: 80vh;
 		display: flex;

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -205,7 +205,7 @@
 
 	@media (min-width: 919px) {
 		&__large-list {
-			.sensei-extensions__card {
+			.sensei-extensions__card__content {
 				display: flex;
 			}
 			.sensei-extensions__extension-actions {

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -287,5 +287,9 @@
 			font-size: 13px;
 			color: #000;
 		}
+
+		&__button-icon {
+			vertical-align: middle;
+		}
 	}
 }

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -1,6 +1,8 @@
 @import '../shared/styles/variables';
 @import '../shared/styles/wp-admin';
 
+$wordpress-break: 961px;
+
 @mixin white-box {
 	border-radius: 2px;
 	background-color: $white;
@@ -8,7 +10,7 @@
 }
 
 @mixin col-width($w) {
-	@media (min-width: 919px) {
+	@media (min-width: $wordpress-break) {
 		width: calc(#{$w} / 12 * 100%);
 	}
 }
@@ -209,7 +211,7 @@
 		}
 	}
 
-	@media (min-width: 919px) {
+	@media (min-width: $wordpress-break) {
 		&__large-list {
 			.sensei-extensions__card__content {
 				display: flex;

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -170,30 +170,36 @@ $wordpress-break: 961px;
 
 	&__featured-list {
 		@include white-box;
-		padding: 17px 10px;
+		padding: 15px;
 		margin: 0;
 
-		@media (min-width: 990px) {
+		@media (min-width: $wordpress-break) {
 			display: flex;
-			padding: 65px 10px;
+			flex-wrap: wrap;
 		}
 
-		@media (min-width: 1150px) {
-			padding: 65px 45px;
+		@media (min-width: 1200px) {
+			padding: 50px 45px;
 		}
 
 		&__item {
-			margin: 0 10px 15px;
+			box-sizing: border-box;
+			padding: 10px;
+			margin: 0;
+
+			@media (min-width: $wordpress-break) {
+				@include col-width(6);
+				padding: 15px;
+			}
+
+			@media (min-width: 1200px) {
+				@include col-width(4);
+			}
+		}
+
+		&__card-wrapper {
 			box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.16);
 			border-radius: 8px;
-
-			@media (min-width: 990px) {
-				margin-bottom: 0;
-			}
-
-			@media (min-width: 1150px) {
-				margin: 0 15px;
-			}
 		}
 	}
 
@@ -207,6 +213,19 @@ $wordpress-break: 961px;
 
 			&:not(:last-child) {
 				border-bottom: solid 1px #DCDCDE;
+			}
+		}
+	}
+
+	@media (min-width: $wordpress-break) and (max-width: 1100px) {
+		&__small-list {
+			.sensei-extensions__card__header {
+				display: block;
+			}
+			.sensei-extensions__card__new-badge {
+				display: block;
+				text-align: right;
+				padding-left: 0;
 			}
 		}
 	}

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -214,6 +214,9 @@
 			.sensei-extensions__card__content {
 				display: flex;
 			}
+			.sensei-extensions__card__description {
+				flex: 1;
+			}
 			.sensei-extensions__extension-actions {
 				padding-left: 20px;
 				flex-shrink: 0;

--- a/assets/extensions/update-notification/single.js
+++ b/assets/extensions/update-notification/single.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import ExtensionActions from '../extension-actions';
@@ -22,10 +17,7 @@ const Single = ( { extension } ) => (
 		<p className="sensei-extensions__update-notification__description">
 			{ extension.excerpt }
 		</p>
-		<ExtensionActions
-			detailsLink={ extension.link }
-			buttonLabel={ __( 'Update', 'sensei-lms' ) }
-		/>
+		<ExtensionActions extension={ extension } />
 	</>
 );
 

--- a/assets/shared/styles/_variables.scss
+++ b/assets/shared/styles/_variables.scss
@@ -1,4 +1,4 @@
-$primary: #43af99;
+$primary: #46C8AD;
 $secondary: #674399;
 $link: #50575e;
 $link-primary: $primary;


### PR DESCRIPTION
Fixes #4108

### Changes proposed in this Pull Request

* It adds the extension card logic.
* It doesn't include the update button logic.
* It doesn't include WooCommerce variations, like connect, and so on.

### Testing instructions

* Access the Extensions page, and play with the different `extensionMock` variables in `assets/extensions/card.js`.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Since we're not looping through the extensions yet (depending on a POC of how we'll display the content), I added a mock at the card level, it's why a screenshot for each variation:

<img width="1241" alt="Screen Shot 2021-04-12 at 16 30 36" src="https://user-images.githubusercontent.com/876340/114451988-4ccc3c00-9bae-11eb-9ec3-8af2be34f167.png">
<img width="1239" alt="Screen Shot 2021-04-12 at 16 30 22" src="https://user-images.githubusercontent.com/876340/114451998-505fc300-9bae-11eb-82fa-b8317f314b09.png">
<img width="1238" alt="Screen Shot 2021-04-12 at 16 30 08" src="https://user-images.githubusercontent.com/876340/114452003-5190f000-9bae-11eb-8f92-9abcf4dd417e.png">
