### PR TITLE
Integrate extensions page with real data

### DIFF
--- a/assets/extensions/all-extensions.js
+++ b/assets/extensions/all-extensions.js
@@ -8,68 +8,58 @@ import { __ } from '@wordpress/i18n';
  */
 import Card from './card';
 
-const AllExtensions = () => (
-	<>
-		<section className="sensei-extensions__section sensei-extensions__grid__col --col-12">
-			<h2 className="sensei-extensions__section__title">
-				{ __( 'Featured', 'sensei-lms' ) }
-			</h2>
-			<ul className="sensei-extensions__section__content sensei-extensions__featured-list">
-				<li className="sensei-extensions__featured-list__item">
-					<div className="sensei-extensions__featured-list__card-wrapper">
-						<Card />
-					</div>
-				</li>
-				<li className="sensei-extensions__featured-list__item">
-					<div className="sensei-extensions__featured-list__card-wrapper">
-						<Card />
-					</div>
-				</li>
-				<li className="sensei-extensions__featured-list__item">
-					<div className="sensei-extensions__featured-list__card-wrapper">
-						<Card />
-					</div>
-				</li>
-			</ul>
-		</section>
+const AllExtensions = ( { extensions } ) => {
+	return (
+		<>
+			<section className="sensei-extensions__section sensei-extensions__grid__col --col-12">
+				<h2 className="sensei-extensions__section__title">
+					{ __( 'Featured', 'sensei-lms' ) }
+				</h2>
+				<ul className="sensei-extensions__section__content sensei-extensions__featured-list">
+					{ extensions.map( ( extension ) => (
+						<li
+							key={ extension.product_slug }
+							className="sensei-extensions__featured-list__item"
+						>
+							<Card extension={ extension } />
+						</li>
+					) ) }
+				</ul>
+			</section>
 
-		<section className="sensei-extensions__section sensei-extensions__grid__col --col-8">
-			<h2 className="sensei-extensions__section__title">
-				{ __( 'Course creation', 'sensei-lms' ) }
-			</h2>
-			<ul className="sensei-extensions__section__content sensei-extensions__large-list">
-				<li className="sensei-extensions__large-list__item">
-					<Card />
-				</li>
-				<li className="sensei-extensions__large-list__item">
-					<Card />
-				</li>
-				<li className="sensei-extensions__large-list__item">
-					<Card />
-				</li>
-				<li className="sensei-extensions__large-list__item">
-					<Card />
-				</li>
-			</ul>
-		</section>
+			<section className="sensei-extensions__section sensei-extensions__grid__col --col-8">
+				<h2 className="sensei-extensions__section__title">
+					{ __( 'Course creation', 'sensei-lms' ) }
+				</h2>
+				<ul className="sensei-extensions__section__content sensei-extensions__large-list">
+					{ extensions.map( ( extension ) => (
+						<li
+							key={ extension.product_slug }
+							className="sensei-extensions__large-list__item"
+						>
+							<Card extension={ extension } />
+						</li>
+					) ) }
+				</ul>
+			</section>
 
-		<section className="sensei-extensions__section sensei-extensions__grid__col --col-4">
-			<h2 className="sensei-extensions__section__title">
-				{ __( 'Learner engagement', 'sensei-lms' ) }
-			</h2>
-			<ul className="sensei-extensions__section__content sensei-extensions__small-list">
-				<li className="sensei-extensions__small-list__item">
-					<Card />
-				</li>
-				<li className="sensei-extensions__small-list__item">
-					<Card />
-				</li>
-				<li className="sensei-extensions__small-list__item">
-					<Card />
-				</li>
-			</ul>
-		</section>
-	</>
-);
+			<section className="sensei-extensions__section sensei-extensions__grid__col --col-4">
+				<h2 className="sensei-extensions__section__title">
+					{ __( 'Learner engagement', 'sensei-lms' ) }
+				</h2>
+				<ul className="sensei-extensions__section__content sensei-extensions__small-list">
+					{ extensions.map( ( extension ) => (
+						<li
+							key={ extension.product_slug }
+							className="sensei-extensions__small-list__item"
+						>
+							<Card extension={ extension } />
+						</li>
+					) ) }
+				</ul>
+			</section>
+		</>
+	);
+};
 
 export default AllExtensions;

--- a/assets/extensions/all-extensions.js
+++ b/assets/extensions/all-extensions.js
@@ -26,7 +26,9 @@ const AllExtensions = ( { extensions } ) => {
 								key={ extension.product_slug }
 								className="sensei-extensions__featured-list__item"
 							>
-								<Card extension={ extension } />
+								<div className="sensei-extensions__featured-list__card-wrapper">
+									<Card extension={ extension } />
+								</div>
 							</li>
 						) ) }
 					</ul>

--- a/assets/extensions/all-extensions.js
+++ b/assets/extensions/all-extensions.js
@@ -9,23 +9,29 @@ import { __ } from '@wordpress/i18n';
 import Card from './card';
 
 const AllExtensions = ( { extensions } ) => {
+	const featuredExtensions = extensions.filter(
+		( extension ) => extension.is_featured
+	);
+
 	return (
 		<>
-			<section className="sensei-extensions__section sensei-extensions__grid__col --col-12">
-				<h2 className="sensei-extensions__section__title">
-					{ __( 'Featured', 'sensei-lms' ) }
-				</h2>
-				<ul className="sensei-extensions__section__content sensei-extensions__featured-list">
-					{ extensions.map( ( extension ) => (
-						<li
-							key={ extension.product_slug }
-							className="sensei-extensions__featured-list__item"
-						>
-							<Card extension={ extension } />
-						</li>
-					) ) }
-				</ul>
-			</section>
+			{ featuredExtensions.length > 0 && (
+				<section className="sensei-extensions__section sensei-extensions__grid__col --col-12">
+					<h2 className="sensei-extensions__section__title">
+						{ __( 'Featured', 'sensei-lms' ) }
+					</h2>
+					<ul className="sensei-extensions__section__content sensei-extensions__featured-list">
+						{ featuredExtensions.map( ( extension ) => (
+							<li
+								key={ extension.product_slug }
+								className="sensei-extensions__featured-list__item"
+							>
+								<Card extension={ extension } />
+							</li>
+						) ) }
+					</ul>
+				</section>
+			) }
 
 			<section className="sensei-extensions__section sensei-extensions__grid__col --col-8">
 				<h2 className="sensei-extensions__section__title">

--- a/assets/extensions/card.js
+++ b/assets/extensions/card.js
@@ -8,20 +8,13 @@ import { __ } from '@wordpress/i18n';
  */
 import ExtensionActions from './extension-actions';
 
-// prettier-ignore
-// const extensionMock = {"hash":"d1a69640d53a32a9fb13e93d1c8f3104","title":"WooCommerce Paid Courses","image":null,"excerpt":"Sell your courses using the most popular eCommerce platform on the web \u2013 WooCommerce.","link":"https:\/\/senseilms.com\/product\/woocommerce-paid-courses\/","price":"$129.00","is_featured":false,"product_slug":"sensei-wc-paid-courses","hosted_location":"external","type":"plugin","plugin_file":"woothemes-sensei\/woothemes-sensei.php","wccom_product_id":"152116"};
-// prettier-ignore
-// const extensionMock = {"version":"5.0.0.0.0.0","hash":"d1a69640d53a32a9fb13e93d1c8f3104","title":"WooCommerce Paid Courses","image":null,"excerpt":"Sell your courses using the most popular eCommerce platform on the web \u2013 WooCommerce.","link":"https:\/\/senseilms.com\/product\/woocommerce-paid-courses\/","price":"$129.00","is_featured":false,"product_slug":"sensei-wc-paid-courses","hosted_location":"external","type":"plugin","plugin_file":"woothemes-sensei\/woothemes-sensei.php","wccom_product_id":"152116"};
-// prettier-ignore
-const extensionMock = {"version":"5.0.0.0.0.0","has_update":true,"hash":"d1a69640d53a32a9fb13e93d1c8f3104","title":"WooCommerce Paid Courses","image":null,"excerpt":"Sell your courses using the most popular eCommerce platform on the web \u2013 WooCommerce.","link":"https:\/\/senseilms.com\/product\/woocommerce-paid-courses\/","price":"$129.00","is_featured":false,"product_slug":"sensei-wc-paid-courses","hosted_location":"external","type":"plugin","plugin_file":"woothemes-sensei\/woothemes-sensei.php","wccom_product_id":"152116"};
-
 /**
  * Extensions card component.
  *
  * @param {Object}  props           Component props.
  * @param {boolean} props.extension Extension object.
  */
-const Card = ( { extension = extensionMock } ) => (
+const Card = ( { extension } ) => (
 	<article className="sensei-extensions__card">
 		<header className="sensei-extensions__card__header">
 			<h3 className="sensei-extensions__card__title">

--- a/assets/extensions/extension-actions.js
+++ b/assets/extensions/extension-actions.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -22,7 +23,7 @@ const ExtensionActions = ( { extension = {}, buttonLabel } ) => {
 	if ( ! buttonLabel ) {
 		if ( extension.has_update ) {
 			buttonLabel = __( 'Update', 'sensei-lms' );
-		} else if ( extension.version ) {
+		} else if ( extension.is_installed ) {
 			buttonLabel = (
 				<>
 					<Icon
@@ -35,9 +36,12 @@ const ExtensionActions = ( { extension = {}, buttonLabel } ) => {
 			);
 			disabledButton = true;
 		} else {
-			buttonLabel = `${ __( 'Install', 'sensei-lms' ) } - ${
-				extension.price
+			const buttonText = `${ __( 'Install', 'sensei-lms' ) } - ${
+				extension.price !== 0
+					? extension.price
+					: __( 'Free', 'sensei-lms' )
 			}`;
+			buttonLabel = <RawHTML>{ buttonText }</RawHTML>;
 		}
 	}
 
@@ -48,7 +52,7 @@ const ExtensionActions = ( { extension = {}, buttonLabel } ) => {
 					className="button button-primary"
 					disabled={ disabledButton }
 				>
-					{ buttonLabel || __( 'Install - $29.99', 'sensei-lms' ) }
+					{ buttonLabel }
 				</button>
 			</li>
 			{ extension.link && (

--- a/assets/extensions/extension-actions.js
+++ b/assets/extensions/extension-actions.js
@@ -3,7 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
-import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -36,12 +35,11 @@ const ExtensionActions = ( { extension = {}, buttonLabel } ) => {
 			);
 			disabledButton = true;
 		} else {
-			const buttonText = `${ __( 'Install', 'sensei-lms' ) } - ${
-				extension.price !== 0
+			buttonLabel = `${ __( 'Install', 'sensei-lms' ) } - ${
+				extension.price !== '0'
 					? extension.price
 					: __( 'Free', 'sensei-lms' )
 			}`;
-			buttonLabel = <RawHTML>{ buttonText }</RawHTML>;
 		}
 	}
 

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -52,7 +52,6 @@ $wordpress-break: 961px;
 	&__grid {
 		display: flex;
 		flex-wrap: wrap;
-		align-items: flex-start;
 
 		&__col {
 			box-sizing: border-box;
@@ -243,7 +242,6 @@ $wordpress-break: 961px;
 				padding-left: 20px;
 				flex-shrink: 0;
 				flex-direction: row-reverse;
-				margin-left: auto;
 			}
 			.sensei-extensions__extension-actions__details-link {
 				margin-right: 10px;
@@ -254,7 +252,6 @@ $wordpress-break: 961px;
 	&__grid-list {
 		margin: 0;
 		padding: 0;
-		align-items: stretch;
 
 		&__item {
 			margin: 0 0 15px;

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -52,6 +52,7 @@ $wordpress-break: 961px;
 	&__grid {
 		display: flex;
 		flex-wrap: wrap;
+		align-items: flex-start;
 
 		&__col {
 			box-sizing: border-box;
@@ -242,6 +243,7 @@ $wordpress-break: 961px;
 				padding-left: 20px;
 				flex-shrink: 0;
 				flex-direction: row-reverse;
+				margin-left: auto;
 			}
 			.sensei-extensions__extension-actions__details-link {
 				margin-right: 10px;
@@ -252,6 +254,7 @@ $wordpress-break: 961px;
 	&__grid-list {
 		margin: 0;
 		padding: 0;
+		align-items: stretch;
 
 		&__item {
 			margin: 0 0 15px;
@@ -259,6 +262,7 @@ $wordpress-break: 961px;
 
 		&__item-wrapper {
 			@include white-box;
+			height: 100%
 		}
 	}
 

--- a/assets/extensions/filtered-extensions.js
+++ b/assets/extensions/filtered-extensions.js
@@ -3,49 +3,19 @@
  */
 import Card from './card';
 
-const FilteredExtensions = () => (
+const FilteredExtensions = ( { extensions } ) => (
 	<section className="sensei-extensions__section">
 		<ul className="sensei-extensions__grid sensei-extensions__grid-list">
-			<li className="sensei-extensions__grid-list__item sensei-extensions__grid__col --col-4">
-				<div className="sensei-extensions__grid-list__item-wrapper">
-					<Card />
-				</div>
-			</li>
-			<li className="sensei-extensions__grid-list__item sensei-extensions__grid__col --col-4">
-				<div className="sensei-extensions__grid-list__item-wrapper">
-					<Card />
-				</div>
-			</li>
-			<li className="sensei-extensions__grid-list__item sensei-extensions__grid__col --col-4">
-				<div className="sensei-extensions__grid-list__item-wrapper">
-					<Card />
-				</div>
-			</li>
-			<li className="sensei-extensions__grid-list__item sensei-extensions__grid__col --col-4">
-				<div className="sensei-extensions__grid-list__item-wrapper">
-					<Card />
-				</div>
-			</li>
-			<li className="sensei-extensions__grid-list__item sensei-extensions__grid__col --col-4">
-				<div className="sensei-extensions__grid-list__item-wrapper">
-					<Card />
-				</div>
-			</li>
-			<li className="sensei-extensions__grid-list__item sensei-extensions__grid__col --col-4">
-				<div className="sensei-extensions__grid-list__item-wrapper">
-					<Card />
-				</div>
-			</li>
-			<li className="sensei-extensions__grid-list__item sensei-extensions__grid__col --col-4">
-				<div className="sensei-extensions__grid-list__item-wrapper">
-					<Card />
-				</div>
-			</li>
-			<li className="sensei-extensions__grid-list__item sensei-extensions__grid__col --col-4">
-				<div className="sensei-extensions__grid-list__item-wrapper">
-					<Card />
-				</div>
-			</li>
+			{ extensions.map( ( extension ) => (
+				<li
+					key={ extension.product_slug }
+					className="sensei-extensions__grid-list__item sensei-extensions__grid__col --col-4"
+				>
+					<div className="sensei-extensions__grid-list__item-wrapper">
+						<Card extension={ extension } />
+					</div>
+				</li>
+			) ) }
 		</ul>
 	</section>
 );

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -14,20 +14,17 @@ import UpdateNotification from './update-notification';
 import QueryStringRouter, { Route } from '../shared/query-string-router';
 import AllExtensions from './all-extensions';
 import FilteredExtensions from './filtered-extensions';
-
-// prettier-ignore
-const extensionsMock = [{"version":"5.0.0.0.0.0","hash":"d1a69640d53a32a9fb13e93d1c8f3104","title":"WooCommerce Paid Courses","image":null,"excerpt":"Sell your courses using the most popular eCommerce platform on the web \u2013 WooCommerce.","link":"https:\/\/senseilms.com\/product\/woocommerce-paid-courses\/","price":"&#36;129.00","is_featured":false,"product_slug":"sensei-wc-paid-courses","hosted_location":"external","type":"plugin","plugin_file":"woothemes-sensei\/woothemes-sensei.php","wccom_product_id":"152116"},{"hash":"372d3f309fef061977fb2f7ba36d74d2","title":"Sensei Content Drip","image":null,"excerpt":"Keep students engaged and improve knowledge retention by setting a delivery schedule for course content.","has_update":true,"version":"4.0.0","link":"https:\/\/senseilms.com\/product\/sensei-content-drip\/","price":"&#36;29.00","is_featured":false,"product_slug":"sensei-content-drip","hosted_location":"external","type":"plugin","plugin_file":"sensei-content-drip\/sensei-content-drip.php","wccom_product_id":"543363"},{"hash":"08040837089cdf46631a10aca5258e16","title":"Sensei LMS Certificates","image":null,"excerpt":"Award your students with a certificate of completion and a sense of accomplishment after finishing a course.","link":"https:\/\/senseilms.com\/product\/sensei-certificates\/","price":0,"is_featured":false,"product_slug":"sensei-certificates","hosted_location":"dotorg","type":"plugin","plugin_file":"sensei-certificates\/woothemes-sensei-certificates.php"},{"hash":"99adff456950dd9629a5260c4de21858","title":"Sensei LMS Course Progress","image":null,"excerpt":"Enable your students to easily see their progress and pick up where they left off in a course.","link":"https:\/\/senseilms.com\/product\/sensei-course-progress\/","price":0,"is_featured":false,"product_slug":"sensei-course-progress","hosted_location":"dotorg","type":"plugin","plugin_file":"sensei-course-progress\/sensei-course-progress.php"},{"hash":"35309226eb45ec366ca86a4329a2b7c3","title":"Sensei LMS Media Attachments","image":null,"excerpt":"Provide your students with easy access to additional learning materials, from audio files to slideshows and PDFs.","link":"https:\/\/senseilms.com\/product\/sensei-media-attachments\/","price":0,"is_featured":false,"product_slug":"sensei-media-attachments","hosted_location":"dotorg","type":"plugin","plugin_file":"sensei-media-attachments\/sensei-media-attachments.php"},{"hash":"748ba69d3e8d1af87f84fee909eef339","title":"Sensei Share Your Grade","image":null,"excerpt":"Let your students strut their stuff (and promote your course) by sharing their progress on social media.","link":"https:\/\/senseilms.com\/product\/sensei-share-your-grade\/","price":0,"is_featured":false,"product_slug":"sensei-share-your-grade","hosted_location":"external","type":"plugin","plugin_file":"sensei-share-your-grade\/sensei-share-your-grade.php"},{"hash":"d63fbf8c3173730f82b150c5ef38b8ff","title":"Sensei Course Participants","image":null,"excerpt":"Increase course enrolments by showing site visitors just how popular your courses are.","link":"https:\/\/senseilms.com\/product\/sensei-course-participants\/","price":0,"is_featured":false,"product_slug":"sensei-course-participants","hosted_location":"external","type":"plugin","plugin_file":"sensei-course-participants\/sensei-course-participants.php"},{"hash":"73f104c9fba50050eea11d9d075247cc","title":"Sensei LMS Post to Course Creator","image":null,"excerpt":"Turn your blog posts into online courses.","link":"https:\/\/senseilms.com\/product\/sensei-lms-post-to-course-creator\/","price":0,"is_featured":false,"product_slug":"sensei-post-to-course","hosted_location":"dotorg","type":"plugin","plugin_file":"sensei-post-to-course\/sensei-post-to-course.php"},{"hash":"4fc848051e4459b8a6afeb210c3664ec","title":"Sensei LMS Modules for Divi","image":null,"excerpt":"Edit and style Sensei LMS elements using the Divi Builder.","link":"https:\/\/senseilms.com\/product\/sensei-lms-modules-for-divi\/","price":0,"is_featured":false,"product_slug":"sensei-lms-divi","hosted_location":"dotorg","type":"plugin","plugin_file":"sensei-lms-divi\/sensei-lms-divi.php"},{"hash":"f0bda020d2470f2e74990a07a607ebd9","title":"Collapsible Content for Sensei LMS","image":null,"excerpt":"Simplify the online learning experience for your students by enabling the collapsing and expanding of course content.","link":"https:\/\/senseilms.com\/product\/collapsible-content-for-sensei-lms\/","price":0,"is_featured":false,"product_slug":"collapsible-content-for-sensei-lms","hosted_location":"dotorg","type":"plugin","plugin_file":"collapsible-content-for-sensei-lms\/sensei-collapsible-content.php"}];
+import { __ } from '@wordpress/i18n';
 
 const Main = () => {
 	const [ extensions, setExtensions ] = useState( false );
 
 	useEffect( () => {
-		// TODO: Update to real endpoint.
-		apiFetch( { path: '/sensei-internal/v1/setup-wizard/features' } ).then(
-			() => {
-				setExtensions( extensionsMock );
-			}
-		);
+		apiFetch( { path: '/sensei-internal/v1/sensei-plugins' } )
+			.then( ( result ) => {
+				setExtensions( result );
+			} )
+			.catch( () => setExtensions( [] ) );
 	}, [] );
 
 	if ( false === extensions ) {
@@ -38,28 +35,66 @@ const Main = () => {
 		);
 	}
 
+	const freeExtensions = extensions.filter(
+		( extension ) => extension.price === 0
+	);
+	// TODO: Specify which plugins are third party
+	const thirdPartyExtensions = extensions.filter(
+		( extension ) => extension.price === 0
+	);
+	const installedExtensions = extensions.filter(
+		( extension ) => extension.is_installed
+	);
+
+	const tabs = [
+		{
+			id: 'all',
+			label: __( 'All', 'sensei-lms' ),
+			count: extensions.length,
+		},
+		{
+			id: 'free',
+			label: __( 'Free', 'sensei-lms' ),
+			count: freeExtensions.length,
+		},
+		{
+			id: 'third-party',
+			label: __( 'Third party', 'sensei-lms' ),
+			count: thirdPartyExtensions.length,
+		},
+		{
+			id: 'installed',
+			label: __( 'Installed', 'sensei-lms' ),
+			count: installedExtensions.length,
+		},
+	];
+
 	return (
 		<main className="sensei-extensions">
 			<div className="sensei-extensions__grid">
 				<QueryStringRouter paramName="tab" defaultRoute="all">
 					<div className="sensei-extensions__section sensei-extensions__grid__col --col-12">
 						<Header />
-						<Tabs />
+						<Tabs tabs={ tabs } />
 					</div>
 
 					<UpdateNotification extensions={ extensions } />
 
 					<Route route="all">
-						<AllExtensions />
+						<AllExtensions extensions={ extensions } />
 					</Route>
 					<Route route="free">
-						<FilteredExtensions />
+						<FilteredExtensions extensions={ freeExtensions } />
 					</Route>
 					<Route route="third-party">
-						<FilteredExtensions />
+						<FilteredExtensions
+							extensions={ thirdPartyExtensions }
+						/>
 					</Route>
 					<Route route="installed">
-						<FilteredExtensions />
+						<FilteredExtensions
+							extensions={ installedExtensions }
+						/>
 					</Route>
 				</QueryStringRouter>
 			</div>

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -36,11 +36,11 @@ const Main = () => {
 	}
 
 	const freeExtensions = extensions.filter(
-		( extension ) => extension.price === 0
+		( extension ) => extension.price === '0'
 	);
 	// TODO: Specify which plugins are third party
 	const thirdPartyExtensions = extensions.filter(
-		( extension ) => extension.price === 0
+		( extension ) => extension.price === '0'
 	);
 	const installedExtensions = extensions.filter(
 		( extension ) => extension.is_installed

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -20,7 +20,7 @@ const Main = () => {
 	const [ extensions, setExtensions ] = useState( false );
 
 	useEffect( () => {
-		apiFetch( { path: '/sensei-internal/v1/sensei-plugins' } )
+		apiFetch( { path: '/sensei-internal/v1/sensei-extensions' } )
 			.then( ( result ) => {
 				setExtensions( result );
 			} )

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -51,21 +51,25 @@ const Main = () => {
 			id: 'all',
 			label: __( 'All', 'sensei-lms' ),
 			count: extensions.length,
+			content: <AllExtensions extensions={ extensions } />,
 		},
 		{
 			id: 'free',
 			label: __( 'Free', 'sensei-lms' ),
 			count: freeExtensions.length,
+			content: <FilteredExtensions extensions={ freeExtensions } />,
 		},
 		{
 			id: 'third-party',
 			label: __( 'Third party', 'sensei-lms' ),
 			count: thirdPartyExtensions.length,
+			content: <FilteredExtensions extensions={ thirdPartyExtensions } />,
 		},
 		{
 			id: 'installed',
 			label: __( 'Installed', 'sensei-lms' ),
 			count: installedExtensions.length,
+			content: <FilteredExtensions extensions={ installedExtensions } />,
 		},
 	];
 
@@ -79,23 +83,11 @@ const Main = () => {
 					</div>
 
 					<UpdateNotification extensions={ extensions } />
-
-					<Route route="all">
-						<AllExtensions extensions={ extensions } />
-					</Route>
-					<Route route="free">
-						<FilteredExtensions extensions={ freeExtensions } />
-					</Route>
-					<Route route="third-party">
-						<FilteredExtensions
-							extensions={ thirdPartyExtensions }
-						/>
-					</Route>
-					<Route route="installed">
-						<FilteredExtensions
-							extensions={ installedExtensions }
-						/>
-					</Route>
+					{ tabs.map( ( tab ) => (
+						<Route key={ tab.id } route={ tab.id }>
+							{ tab.content }
+						</Route>
+					) ) }
 				</QueryStringRouter>
 			</div>
 		</main>

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -20,7 +20,9 @@ const Main = () => {
 	const [ extensions, setExtensions ] = useState( false );
 
 	useEffect( () => {
-		apiFetch( { path: '/sensei-internal/v1/sensei-extensions' } )
+		apiFetch( {
+			path: '/sensei-internal/v1/sensei-extensions?type=plugin',
+		} )
 			.then( ( result ) => {
 				setExtensions( result );
 			} )

--- a/assets/extensions/tabs.js
+++ b/assets/extensions/tabs.js
@@ -1,39 +1,15 @@
 /**
- * WordPress dependencies
- */
-import { __ } from '@wordpress/i18n';
-
-/**
  * Internal dependencies
  */
 import { useQueryStringRouter } from '../shared/query-string-router';
 
-const tabs = [
-	{
-		id: 'all',
-		label: __( 'All', 'sensei-lms' ),
-	},
-	{
-		id: 'free',
-		label: __( 'Free', 'sensei-lms' ),
-	},
-	{
-		id: 'third-party',
-		label: __( 'Third party', 'sensei-lms' ),
-	},
-	{
-		id: 'installed',
-		label: __( 'Installed', 'sensei-lms' ),
-	},
-];
-
-const Tabs = () => {
+const Tabs = ( { tabs } ) => {
 	const { currentRoute, goTo } = useQueryStringRouter();
 
 	return (
 		<nav>
 			<ul className="subsubsub sensei-extensions__tabs">
-				{ tabs.map( ( { id, label } ) => (
+				{ tabs.map( ( { id, label, count } ) => (
 					<li key={ id } className="sensei-extensions__tabs__tab">
 						<a
 							href={ `#${ id }-extensions` }
@@ -46,7 +22,8 @@ const Tabs = () => {
 								'aria-current': 'page',
 							} ) }
 						>
-							{ label } <span className="count">(3)</span>
+							{ label }
+							<span className="count">({ count })</span>
 						</a>
 					</li>
 				) ) }

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -122,7 +122,9 @@ final class Sensei_Extensions {
 		// Includes installed version, and whether it has update.
 		$extensions = array_map(
 			function( $extension ) use ( $installed_plugins ) {
-				if ( isset( $installed_plugins[ $extension->plugin_file ] ) ) {
+				$extension->is_installed = isset( $installed_plugins[ $extension->plugin_file ] );
+
+				if ( $extension->is_installed ) {
 					$extension->installed_version = $installed_plugins[ $extension->plugin_file ]['Version'];
 					$extension->has_update        = isset( $extension->version ) && version_compare( $extension->version, $extension->installed_version, '>' );
 				}

--- a/includes/rest-api/class-sensei-rest-api-extensions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-extensions-controller.php
@@ -68,6 +68,17 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 								return (bool) $param;
 							},
 						],
+						'type'       => [
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => function( $param ) {
+								if ( 'plugin' === $param || 'theme' === $param ) {
+									return $param;
+								}
+
+								return null;
+							},
+						],
 					],
 				],
 				'schema' => [ $this, 'get_item_schema' ],
@@ -102,9 +113,9 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response The response which contains the extensions.
 	 */
 	public function get_extensions( WP_REST_Request $request ) : WP_REST_Response {
-		$plugins = Sensei_Extensions::instance()->get_extensions( 'plugin' );
+		$params  = $request->get_params();
+		$plugins = Sensei_Extensions::instance()->get_extensions( $params['type'] );
 
-		$params           = $request->get_params();
 		$filtered_plugins = array_filter(
 			$plugins,
 			function( $plugin ) use ( $params ) {

--- a/includes/rest-api/class-sensei-rest-api-extensions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-extensions-controller.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Sensei REST API: Sensei_REST_API_Plugins_Controller class.
+ * Sensei REST API: Sensei_REST_API_Extensions_Controller class.
  *
  * @package sensei-lms
  * @since   3.11.0
@@ -11,13 +11,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 } // Exit if accessed directly.
 
 /**
- * A REST controller for Sensei related plugins.
+ * A REST controller for Sensei related extensions.
  *
  * @since 3.11.0
  *
  * @see   WP_REST_Controller
  */
-class Sensei_REST_API_Plugins_Controller extends WP_REST_Controller {
+class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 	/**
 	 * Routes namespace.
 	 *
@@ -30,10 +30,10 @@ class Sensei_REST_API_Plugins_Controller extends WP_REST_Controller {
 	 *
 	 * @var string
 	 */
-	protected $rest_base = 'sensei-plugins';
+	protected $rest_base = 'sensei-extensions';
 
 	/**
-	 * Sensei_REST_API_Plugins_Controller constructor.
+	 * Sensei_REST_API_Extensions_Controller constructor.
 	 *
 	 * @param string $namespace Routes namespace.
 	 */
@@ -42,7 +42,7 @@ class Sensei_REST_API_Plugins_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Register the REST API endpoints for plugins.
+	 * Register the REST API endpoints for extensions.
 	 */
 	public function register_routes() {
 		register_rest_route(
@@ -51,7 +51,7 @@ class Sensei_REST_API_Plugins_Controller extends WP_REST_Controller {
 			[
 				[
 					'methods'             => WP_REST_Server::READABLE,
-					'callback'            => [ $this, 'get_plugins' ],
+					'callback'            => [ $this, 'get_extensions' ],
 					'permission_callback' => [ $this, 'can_user_manage_plugins' ],
 					'args'                => [
 						'installed'  => [
@@ -80,7 +80,7 @@ class Sensei_REST_API_Plugins_Controller extends WP_REST_Controller {
 	 *
 	 * @param WP_REST_Request $request WordPress request object.
 	 *
-	 * @return bool|WP_Error Whether the user can manage plugins.
+	 * @return bool|WP_Error Whether the user can manage extensions.
 	 */
 	public function can_user_manage_plugins( WP_REST_Request $request ) {
 		if ( ! current_user_can( 'activate_plugins' ) ) {
@@ -95,13 +95,13 @@ class Sensei_REST_API_Plugins_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Returns the requested plugins.
+	 * Returns the requested extensions.
 	 *
 	 * @param WP_REST_Request $request The request.
 	 *
-	 * @return WP_REST_Response The response which contains the plugins.
+	 * @return WP_REST_Response The response which contains the extensions.
 	 */
-	public function get_plugins( WP_REST_Request $request ) : WP_REST_Response {
+	public function get_extensions( WP_REST_Request $request ) : WP_REST_Response {
 		$plugins = Sensei_Extensions::instance()->get_extensions( 'plugin' );
 
 		$params           = $request->get_params();
@@ -154,35 +154,35 @@ class Sensei_REST_API_Plugins_Controller extends WP_REST_Controller {
 					],
 					'title'            => [
 						'type'        => 'string',
-						'description' => 'Plugin title.',
+						'description' => 'Extension title.',
 					],
 					'image'            => [
 						'type'        => 'string',
-						'description' => 'Plugin image.',
+						'description' => 'Extension image.',
 					],
 					'excerpt'          => [
 						'type'        => 'string',
-						'description' => 'Plugin excerpt',
+						'description' => 'Extension excerpt',
 					],
 					'link'             => [
 						'type'        => 'string',
-						'description' => 'Plugin link.',
+						'description' => 'Extension link.',
 					],
 					'price'            => [
 						'type'        => 'string',
-						'description' => 'Plugin price.',
+						'description' => 'Extension price.',
 					],
 					'is_featured'      => [
 						'type'        => 'boolean',
-						'description' => 'Whether its a featured plugin.',
+						'description' => 'Whether its a featured extension.',
 					],
 					'product_slug'     => [
 						'type'        => 'string',
-						'description' => 'Plugin product slug.',
+						'description' => 'Extension product slug.',
 					],
 					'hosted_location'  => [
 						'type'        => 'string',
-						'description' => 'Where the plugin is hosted (dotorg or external)',
+						'description' => 'Where the extension is hosted (dotorg or external)',
 					],
 					'type'             => [
 						'type'        => 'string',
@@ -194,7 +194,7 @@ class Sensei_REST_API_Plugins_Controller extends WP_REST_Controller {
 					],
 					'version'          => [
 						'type'        => 'string',
-						'description' => 'Plugin version.',
+						'description' => 'Extension version.',
 					],
 					'wccom_product_id' => [
 						'type'        => 'string',
@@ -202,11 +202,11 @@ class Sensei_REST_API_Plugins_Controller extends WP_REST_Controller {
 					],
 					'is_installed'     => [
 						'type'        => 'boolean',
-						'description' => 'Whether the plugin is installed.',
+						'description' => 'Whether the extension is installed.',
 					],
 					'has_update'       => [
 						'type'        => 'boolean',
-						'description' => 'Whether the plugin has available updates.',
+						'description' => 'Whether the extension has available updates.',
 					],
 				],
 			],

--- a/includes/rest-api/class-sensei-rest-api-internal.php
+++ b/includes/rest-api/class-sensei-rest-api-internal.php
@@ -50,7 +50,7 @@ class Sensei_REST_API_Internal {
 			new Sensei_REST_API_Course_Structure_Controller( $this->namespace ),
 			new Sensei_REST_API_Lesson_Quiz_Controller( $this->namespace ),
 			new Sensei_REST_API_Question_Options_Controller( $this->namespace ),
-			new Sensei_REST_API_Plugins_Controller( $this->namespace ),
+			new Sensei_REST_API_Extensions_Controller( $this->namespace ),
 		];
 
 		foreach ( $this->controllers as $controller ) {

--- a/includes/rest-api/class-sensei-rest-api-internal.php
+++ b/includes/rest-api/class-sensei-rest-api-internal.php
@@ -50,6 +50,7 @@ class Sensei_REST_API_Internal {
 			new Sensei_REST_API_Course_Structure_Controller( $this->namespace ),
 			new Sensei_REST_API_Lesson_Quiz_Controller( $this->namespace ),
 			new Sensei_REST_API_Question_Options_Controller( $this->namespace ),
+			new Sensei_REST_API_Plugins_Controller( $this->namespace ),
 		];
 
 		foreach ( $this->controllers as $controller ) {

--- a/includes/rest-api/class-sensei-rest-api-plugins-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-plugins-controller.php
@@ -122,8 +122,17 @@ class Sensei_REST_API_Plugins_Controller extends WP_REST_Controller {
 			}
 		);
 
+		$mapped_plugins = array_map(
+			function( $plugin ) {
+				$plugin->price = html_entity_decode( $plugin->price );
+
+				return $plugin;
+			},
+			$filtered_plugins
+		);
+
 		$response = new WP_REST_Response();
-		$response->set_data( array_values( $filtered_plugins ) );
+		$response->set_data( array_values( $mapped_plugins ) );
 
 		return $response;
 	}

--- a/includes/rest-api/class-sensei-rest-api-plugins-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-plugins-controller.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Sensei REST API: Sensei_REST_API_Plugins_Controller class.
+ *
+ * @package sensei-lms
+ * @since   3.11.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+} // Exit if accessed directly.
+
+/**
+ * A REST controller for Sensei related plugins.
+ *
+ * @since 3.11.0
+ *
+ * @see   WP_REST_Controller
+ */
+class Sensei_REST_API_Plugins_Controller extends WP_REST_Controller {
+	/**
+	 * Routes namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace;
+
+	/**
+	 * Routes prefix.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'sensei-plugins';
+
+	/**
+	 * Sensei_REST_API_Plugins_Controller constructor.
+	 *
+	 * @param string $namespace Routes namespace.
+	 */
+	public function __construct( $namespace ) {
+		$this->namespace = $namespace;
+	}
+
+	/**
+	 * Register the REST API endpoints for plugins.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			[
+				[
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => [ $this, 'get_plugins' ],
+					'permission_callback' => [ $this, 'can_user_manage_plugins' ],
+					'args'                => [
+						'installed'  => [
+							'type'              => 'bool',
+							'required'          => false,
+							'sanitize_callback' => function( $param ) {
+								return (bool) $param;
+							},
+						],
+						'has_update' => [
+							'type'              => 'bool',
+							'required'          => false,
+							'sanitize_callback' => function( $param ) {
+								return (bool) $param;
+							},
+						],
+					],
+				],
+				'schema' => [ $this, 'get_item_schema' ],
+			]
+		);
+	}
+
+	/**
+	 * Check user permission for managing plugins.
+	 *
+	 * @param WP_REST_Request $request WordPress request object.
+	 *
+	 * @return bool|WP_Error Whether the user can manage plugins.
+	 */
+	public function can_user_manage_plugins( WP_REST_Request $request ) {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return new WP_Error(
+				'rest_cannot_view_plugins',
+				__( 'Sorry, you are not allowed to manage plugins for this site.', 'sensei-lms' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Returns the requested plugins.
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response The response which contains the plugins.
+	 */
+	public function get_plugins( WP_REST_Request $request ) : WP_REST_Response {
+		$plugins = Sensei_Extensions::instance()->get_extensions( 'plugin' );
+
+		$params           = $request->get_params();
+		$filtered_plugins = array_filter(
+			$plugins,
+			function( $plugin ) use ( $params ) {
+				$should_return = true;
+
+				if ( isset( $params['installed'] ) ) {
+					$should_return = $plugin->is_installed === $params['installed'];
+				}
+
+				if ( isset( $params['has_update'] ) ) {
+					$should_return = isset( $plugin->has_update ) && $plugin->has_update;
+				}
+
+				return $should_return;
+			}
+		);
+
+		$response = new WP_REST_Response();
+		$response->set_data( array_values( $filtered_plugins ) );
+
+		return $response;
+	}
+
+	/**
+	 * Schema for the endpoint.
+	 *
+	 * @return array Schema object.
+	 */
+	public function get_item_schema() : array {
+		return [
+			'type'  => 'array',
+			'items' => [
+				'type'       => 'object',
+				'properties' => [
+					'hash'             => [
+						'type'        => 'string',
+						'description' => 'Product ID.',
+					],
+					'title'            => [
+						'type'        => 'string',
+						'description' => 'Plugin title.',
+					],
+					'image'            => [
+						'type'        => 'string',
+						'description' => 'Plugin image.',
+					],
+					'excerpt'          => [
+						'type'        => 'string',
+						'description' => 'Plugin excerpt',
+					],
+					'link'             => [
+						'type'        => 'string',
+						'description' => 'Plugin link.',
+					],
+					'price'            => [
+						'type'        => 'string',
+						'description' => 'Plugin price.',
+					],
+					'is_featured'      => [
+						'type'        => 'boolean',
+						'description' => 'Whether its a featured plugin.',
+					],
+					'product_slug'     => [
+						'type'        => 'string',
+						'description' => 'Plugin product slug.',
+					],
+					'hosted_location'  => [
+						'type'        => 'string',
+						'description' => 'Where the plugin is hosted (dotorg or external)',
+					],
+					'type'             => [
+						'type'        => 'string',
+						'description' => 'Whether this is a plugin or a theme',
+					],
+					'plugin_file'      => [
+						'type'        => 'string',
+						'description' => 'Main plugin file.',
+					],
+					'version'          => [
+						'type'        => 'string',
+						'description' => 'Plugin version.',
+					],
+					'wccom_product_id' => [
+						'type'        => 'string',
+						'description' => 'WooCommerce.com product ID.',
+					],
+					'is_installed'     => [
+						'type'        => 'boolean',
+						'description' => 'Whether the plugin is installed.',
+					],
+					'has_update'       => [
+						'type'        => 'boolean',
+						'description' => 'Whether the plugin has available updates.',
+					],
+				],
+			],
+		];
+	}
+
+}

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
@@ -390,6 +390,7 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 			'product_slug' => 'slug-1',
 			'plugin_file'  => 'test/test.php',
 			'status'       => 'installing',
+			'is_installed' => false,
 		];
 		$sensei_extensions  = Sensei()->setup_wizard->get_sensei_extensions();
 

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -510,21 +510,25 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 				'product_slug' => 'slug-1',
 				'status'       => 'installing',
 				'plugin_file'  => 'test/test.php',
+				'is_installed' => false,
 			],
 			(object) [
 				'product_slug' => 'slug-2',
 				'status'       => 'error',
 				'error'        => 'Error message',
 				'plugin_file'  => 'test/test.php',
+				'is_installed' => false,
 			],
 			(object) [
 				'product_slug' => 'slug-3',
 				'status'       => 'installed',
 				'plugin_file'  => 'test/test-installed.php',
+				'is_installed' => false,
 			],
 			(object) [
 				'product_slug' => 'slug-4',
 				'plugin_file'  => 'test/test.php',
+				'is_installed' => false,
 			],
 			get_transient( Sensei_Utils::WC_INFORMATION_TRANSIENT ),
 		];
@@ -560,6 +564,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 			(object) [
 				'product_slug' => 'allowed',
 				'plugin_file'  => 'test/test.php',
+				'is_installed' => false,
 			],
 		];
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Introduces a new REST endpoint point `sensei-plugins` which is used by the extensions page.
* Switch fronted to use the new edpoint.
* Various fixes after integrating with real data.
* There is definitely more work/testing needed but I decided to raise the PR before pausing.
* There is missing functionality (handling updates, connecting to WC.com etc) which is going to be handled as part of another PR.
* We also need to specify the categories which every plugin falls into (i.e. featured, course creation, learner engagment)

### Testing instructions

* Visit the extensions page and observe that the content is generated with real data.
* As it is now there are no plugins categorised as 'Featured',  'Course creation' and 'Learner engagment' so this list will either contain every plugin or none at all. 
* You can modify the main plugin files of each plugin to test various scenarios.
