### PR TITLE
Change featured image enabled logic

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -980,6 +980,7 @@ class Sensei_Course {
 	 * @return string | void
 	 */
 	public function course_image( $course_id = 0, $width = '100', $height = '100', $return = false ) {
+		global $sensei_is_block;
 
 		if ( is_a( $course_id, 'WP_Post' ) ) {
 
@@ -1010,7 +1011,7 @@ class Sensei_Course {
 
 			} else {
 
-				if ( ! Sensei()->settings->settings['course_archive_image_enable'] ) {
+				if ( ! Sensei()->settings->settings['course_archive_image_enable'] && ! $sensei_is_block ) {
 					return '';
 				} // End If Statement
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -322,7 +322,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['course_archive_image_enable'] = array(
 			'name'        => __( 'Course Archive Image', 'sensei-lms' ),
-			'description' => __( 'Output the Course Image on the Course Archive Page.', 'sensei-lms' ),
+			'description' => __( 'Output the Course Image on the Course Archive Page (does not apply when using blocks).', 'sensei-lms' ),
 			'type'        => 'checkbox',
 			'default'     => true,
 			'section'     => 'course-settings',

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -302,6 +302,9 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	public function render() {
 		// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		global $wp_query;
+		global $sensei_is_block;
+
+		$sensei_is_block = $this->is_block;
 
 		if ( false === is_user_logged_in() ) {
 			// show the login form
@@ -322,7 +325,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		ob_start();
 		echo '<section id="sensei-user-courses">';
 
-		if ( ! $this->is_block ) {
+		if ( ! $sensei_is_block ) {
 			Sensei_Messages::the_my_messages_link();
 		}
 
@@ -342,6 +345,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		wp_reset_query();
 
 		$this->detach_shortcode_hooks();
+		$sensei_is_block = false;
 
 		return $shortcode_output;
 


### PR DESCRIPTION
Fixes #4182

### Changes proposed in this Pull Request

* Skips the `course_archive_image_enable` setting when it's a block (it's handled by the block settings).
* Also adds a parenthesis to the settings making explicit that it doesn't apply to blocks.

The approach used for this was creating a global variable, so we don't create a new filter and we avoid a big change for something that is likely temporary.

### Testing instructions

* Create a course with a featured image.
* Enroll in this course.
* Create a page with the `[sensei_user_courses]` shortcode, and another one with the Learner Courses block. For the block, enable the _"Featured Image"_ setting in the sidebar.
* Go to Sensei LMS > Settings > Courses, check the _"Output the Course Image on the Course Archive Page (not applied for blocks)."_ option, and make sure the featured image appears in both created pages.
* Uncheck the setting, and make sure the featured image is disabled only for the page with the shortcode.
* Go to the block, and disable the _"Featured image"_ option, and make sure it doesn't appear in the page with the block too.