### PR TITLE
Tweak extensions page design

### DIFF
--- a/assets/extensions/all-extensions.js
+++ b/assets/extensions/all-extensions.js
@@ -16,13 +16,19 @@ const AllExtensions = () => (
 			</h2>
 			<ul className="sensei-extensions__section__content sensei-extensions__featured-list">
 				<li className="sensei-extensions__featured-list__item">
-					<Card />
+					<div className="sensei-extensions__featured-list__card-wrapper">
+						<Card />
+					</div>
 				</li>
 				<li className="sensei-extensions__featured-list__item">
-					<Card />
+					<div className="sensei-extensions__featured-list__card-wrapper">
+						<Card />
+					</div>
 				</li>
 				<li className="sensei-extensions__featured-list__item">
-					<Card />
+					<div className="sensei-extensions__featured-list__card-wrapper">
+						<Card />
+					</div>
 				</li>
 			</ul>
 		</section>

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -53,6 +53,7 @@
 
 		&__col {
 			box-sizing: border-box;
+			width: 100%;
 			padding: 0 9px;
 
 			&.--col-12 {

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -16,6 +16,11 @@
 .sensei-extensions {
 	margin-right: 20px;
 
+	.button-primary {
+		min-width: 112px;
+		min-height: 36px;
+	}
+
 	&__loader {
 		height: 80vh;
 		display: flex;

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -1,6 +1,8 @@
 @import '../shared/styles/variables';
 @import '../shared/styles/wp-admin';
 
+$wordpress-break: 961px;
+
 @mixin white-box {
 	border-radius: 2px;
 	background-color: $white;
@@ -8,7 +10,7 @@
 }
 
 @mixin col-width($w) {
-	@media (min-width: 919px) {
+	@media (min-width: $wordpress-break) {
 		width: calc(#{$w} / 12 * 100%);
 	}
 }
@@ -209,7 +211,7 @@
 		}
 	}
 
-	@media (min-width: 919px) {
+	@media (min-width: $wordpress-break) {
 		&__large-list {
 			.sensei-extensions__card__content {
 				display: flex;

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -170,30 +170,36 @@ $wordpress-break: 961px;
 
 	&__featured-list {
 		@include white-box;
-		padding: 17px 10px;
+		padding: 15px;
 		margin: 0;
 
-		@media (min-width: 990px) {
+		@media (min-width: $wordpress-break) {
 			display: flex;
-			padding: 65px 10px;
+			flex-wrap: wrap;
 		}
 
-		@media (min-width: 1150px) {
-			padding: 65px 45px;
+		@media (min-width: 1200px) {
+			padding: 50px 45px;
 		}
 
 		&__item {
-			margin: 0 10px 15px;
+			box-sizing: border-box;
+			padding: 10px;
+			margin: 0;
+
+			@media (min-width: $wordpress-break) {
+				@include col-width(6);
+				padding: 15px;
+			}
+
+			@media (min-width: 1200px) {
+				@include col-width(4);
+			}
+		}
+
+		&__card-wrapper {
 			box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.16);
 			border-radius: 8px;
-
-			@media (min-width: 990px) {
-				margin-bottom: 0;
-			}
-
-			@media (min-width: 1150px) {
-				margin: 0 15px;
-			}
 		}
 	}
 
@@ -207,6 +213,19 @@ $wordpress-break: 961px;
 
 			&:not(:last-child) {
 				border-bottom: solid 1px #DCDCDE;
+			}
+		}
+	}
+
+	@media (min-width: $wordpress-break) and (max-width: 1100px) {
+		&__small-list {
+			.sensei-extensions__card__header {
+				display: block;
+			}
+			.sensei-extensions__card__new-badge {
+				display: block;
+				text-align: right;
+				padding-left: 0;
 			}
 		}
 	}

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -214,6 +214,9 @@
 			.sensei-extensions__card__content {
 				display: flex;
 			}
+			.sensei-extensions__card__description {
+				flex: 1;
+			}
 			.sensei-extensions__extension-actions {
 				padding-left: 20px;
 				flex-shrink: 0;

--- a/assets/shared/styles/_variables.scss
+++ b/assets/shared/styles/_variables.scss
@@ -1,4 +1,4 @@
-$primary: #43AF99;
+$primary: #46C8AD;
 $secondary: #674399;
 $link: #50575e;
 $link-primary:  $primary;


### PR DESCRIPTION
Based on https://github.com/Automattic/sensei/pull/4180

### Changes proposed in this Pull Request

* It fixes some design issues.
  * Fix button color.
  * Update button min size.
  * Fix grid (other tabs) issue in small resolutions.
  * Fix the position of the buttons in the large list.
  * Update responsive break to the same WordPress break.
  * Tweak the featured list to have an additional responsive break (2 items per line).

### Testing instructions

* Go to wp-admin > Sensei LMS > Extensions, and check the page design.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/114603187-d2fb8780-9c6d-11eb-9d88-177815b65bc2.mov

