### PR TITLE
Remove block end comments

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -83,7 +83,7 @@ class Sensei_Learner_Management {
 
 			add_action( 'admin_notices', array( $this, 'add_learner_notices' ) );
 			$this->bulk_actions_controller = new Sensei_Learners_Admin_Bulk_Actions_Controller( $this );
-		} // End If Statement
+		}
 
 		// Ajax functions.
 		if ( is_admin() ) {
@@ -93,7 +93,7 @@ class Sensei_Learner_Management {
 			add_action( 'wp_ajax_reset_user_post', array( $this, 'reset_user_post' ) );
 			add_action( 'wp_ajax_sensei_json_search_users', array( $this, 'json_search_users' ) );
 		}
-	} // End __construct()
+	}
 
 	/**
 	 * Add learner management menu.
@@ -107,7 +107,7 @@ class Sensei_Learner_Management {
 			add_action( "load-$learners_page", array( $this, 'load_screen_options_when_on_bulk_actions' ) );
 		}
 
-	} // End learners_admin_menu()
+	}
 
 	/**
 	 * Sets the pagination screen option value for the Bulk Learner Actions table.
@@ -184,7 +184,7 @@ class Sensei_Learner_Management {
 		);
 
 		wp_localize_script( 'sensei-learners-general', 'woo_learners_general_data', $data );
-	} // End enqueue_scripts()
+	}
 
 	/**
 	 * Enqueue styles.
@@ -197,7 +197,7 @@ class Sensei_Learner_Management {
 
 		Sensei()->assets->enqueue( 'sensei-jquery-ui', 'css/jquery-ui.css' );
 
-	} // End enqueue_styles()
+	}
 
 	/**
 	 * Loads dependent files.
@@ -213,9 +213,9 @@ class Sensei_Learner_Management {
 		);
 		foreach ( $classes_to_load as $class_file ) {
 			Sensei()->load_class( $class_file );
-		} // End For Loop
+		}
 
-	} // End load_data_table_files()
+	}
 
 	/**
 	 * Creates new instance of class.
@@ -239,12 +239,12 @@ class Sensei_Learner_Management {
 			$sensei_learners_object = new $object_name( $data );
 		} else {
 			$sensei_learners_object = new $object_name( $data, $optional_data );
-		} // End If Statement
+		}
 		if ( 'Main' === $name ) {
 			$sensei_learners_object->prepare_items();
-		} // End If Statement
+		}
 		return $sensei_learners_object;
-	} // End load_data_object()
+	}
 
 	/**
 	 * Outputs the content for the Learner Management page.
@@ -278,7 +278,7 @@ class Sensei_Learner_Management {
 		<?php
 		do_action( 'learners_wrapper_container', 'bottom' );
 		do_action( 'learners_after_container' );
-	} // End learners_default_view()
+	}
 
 	/**
 	 * Outputs the breadcrumb.
@@ -292,7 +292,7 @@ class Sensei_Learner_Management {
 		$this->$function();
 		do_action( 'sensei_learners_after_headers' );
 
-	} // End learners_headers()
+	}
 
 	/**
 	 * Wrapper for Learners area.
@@ -309,8 +309,8 @@ class Sensei_Learner_Management {
 			?>
 			</div><!--/#woothemes-sensei-->
 			<?php
-		} // End If Statement
-	} // End wrapper_container()
+		}
+	}
 
 	/**
 	 * Default nav area for Learners.
@@ -353,7 +353,7 @@ class Sensei_Learner_Management {
 				| <a href="<?php echo esc_attr( $this->bulk_actions_controller->get_url() ); ?>"><?php echo esc_html( $this->bulk_actions_controller->get_name() ); ?></a></h1>
 			</h1>
 		<?php
-	} // End learners_default_nav()
+	}
 
 	/**
 	 * Filters table by course category.
@@ -863,7 +863,7 @@ class Sensei_Learner_Management {
 		return $this->name;
 	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_Learners

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -482,7 +482,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		$offset = 0;
 		if ( ! empty( $paged ) ) {
 			$offset = $per_page * ( $paged - 1 );
-		} // End If Statement
+		}
 		if ( empty( $orderby ) ) {
 			$orderby = '';
 		}

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -285,7 +285,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		$offset = 0;
 		if ( ! empty( $paged ) ) {
 			$offset = $per_page * ( $paged - 1 );
-		} // End If Statement
+		}
 
 		switch ( $this->view ) {
 			case 'learners':
@@ -323,7 +323,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			)
 		);
 
-	} // End prepare_items()
+	}
 
 	/**
 	 * Generates content for a single row of the table in the user management
@@ -800,7 +800,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 		$this->total_items = $courses_query->found_posts;
 		return $courses_query->posts;
-	} // End get_courses()
+	}
 
 	/**
 	 * Return array of lessons.
@@ -836,7 +836,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 		$this->total_items = $lessons_query->found_posts;
 		return $lessons_query->posts;
-	} // End get_lessons()
+	}
 
 	/**
 	 * Return array of learners
@@ -910,7 +910,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		}
 		$this->total_items = $total_learners;
 		return $learners;
-	} // End get_learners()
+	}
 
 	/**
 	 * Returns a list of user ids to filter sensei activities. If no filtering is required, false is returned.
@@ -1000,7 +1000,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				break;
 		}
 		echo wp_kses_post( apply_filters( 'sensei_learners_no_items_text', $text ) );
-	} // End no_items()
+	}
 
 	/**
 	 * Output for table heading

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -83,7 +83,7 @@ class Sensei_Admin {
 		Sensei_Tools::instance()->init();
 		Sensei_Status::instance()->init();
 
-	} // End __construct()
+	}
 
 	/**
 	 * Add items to admin menu
@@ -282,7 +282,7 @@ class Sensei_Admin {
 
 		}
 
-	} // End admin_styles_global()
+	}
 
 
 	/**
@@ -1811,7 +1811,7 @@ class Sensei_Admin {
 		// phpcs:enable WordPress.Security.NonceVerification
 	}
 
-} // End Class
+}
 
 /**
  * Legacy Class WooThemes_Sensei_Admin

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -45,7 +45,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 
 		add_filter( 'sensei_list_table_search_button_text', array( $this, 'search_button' ) );
 
-	} // End __construct()
+	}
 
 	/**
 	 * Define the columns that are going to be used in the table
@@ -159,7 +159,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		if ( ! empty( $_GET['orderby'] ) ) {
 			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
 				$orderby = esc_html( $_GET['orderby'] );
-			} // End If Statement
+			}
 		}
 
 		// Handle order
@@ -172,7 +172,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
 			$search = esc_html( $_GET['s'] );
-		} // End If Statement
+		}
 		$this->search = $search;
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
@@ -182,7 +182,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$offset = 0;
 		if ( ! empty( $paged ) ) {
 			$offset = $per_page * ( $paged - 1 );
-		} // End If Statement
+		}
 
 		$args = array(
 			'number'  => $per_page,
@@ -192,7 +192,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		);
 		if ( $this->search ) {
 			$args['search'] = $this->search;
-		} // End If Statement
+		}
 
 		switch ( $this->view ) {
 			case 'user':
@@ -233,7 +233,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		if ( ! empty( $_GET['orderby'] ) ) {
 			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
 				$orderby = esc_html( $_GET['orderby'] );
-			} // End If Statement
+			}
 		}
 
 		// Handle order
@@ -246,7 +246,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
 			$search = esc_html( $_GET['s'] );
-		} // End If Statement
+		}
 		$this->search = $search;
 
 		$args = array(
@@ -255,7 +255,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		);
 		if ( $this->search ) {
 			$args['search'] = $this->search;
-		} // End If Statement
+		}
 
 		// Start the csv with the column headings
 		$column_headers = array();
@@ -332,7 +332,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 						$course_percent .= '%';
 
 					}
-				} // End If Statement
+				}
 
 				$column_data = apply_filters(
 					'sensei_analysis_course_column_data',
@@ -413,7 +413,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 						if ( is_numeric( $grade ) ) {
 							$grade .= '%';
 						}
-					} // End If Statement
+					}
 
 					$column_data = apply_filters(
 						'sensei_analysis_course_column_data',
@@ -481,7 +481,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 						if ( is_numeric( $lesson_average_grade ) ) {
 							$lesson_average_grade .= '%';
 						}
-					} // End If Statement
+					}
 
 					$column_data = apply_filters(
 						'sensei_analysis_course_column_data',
@@ -532,7 +532,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 				// Store for reuse on counts
 				$activity_args['user_id'] = (array) $learners_search->get_results();
 			}
-		} // End If Statement
+		}
 
 		$activity_args = apply_filters( 'sensei_analysis_course_filter_statuses', $activity_args );
 
@@ -559,7 +559,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 			$statuses = array( $statuses );
 		}
 		return $statuses;
-	} // End get_course_statuses()
+	}
 
 	/**
 	 * Return array of Courses' lessons
@@ -594,7 +594,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$lessons_query     = new WP_Query( apply_filters( 'sensei_analysis_course_filter_lessons', $lessons_args ) );
 		$this->total_items = $lessons_query->found_posts;
 		return $lessons_query->posts;
-	} // End get_lessons()
+	}
 
 	/**
 	 * Sets output when no items are found
@@ -615,7 +615,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 				break;
 		}
 		echo wp_kses_post( apply_filters( 'sensei_analysis_course_no_items_text', $text ) );
-	} // End no_items()
+	}
 
 	/**
 	 * Output for table heading
@@ -664,7 +664,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 			echo wp_kses_post( implode( " |</li>\n", $menu ) ) . "</li>\n";
 			echo '</ul>' . "\n";
 		}
-	} // End data_table_header()
+	}
 
 	/**
 	 * Output for table footer
@@ -692,7 +692,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		}
 		$url = add_query_arg( $url_args, admin_url( 'admin.php' ) );
 		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download', '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
-	} // End data_table_footer()
+	}
 
 	/**
 	 * The text for the search button
@@ -710,12 +710,12 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 			default:
 				$text = __( 'Search Lessons', 'sensei-lms' );
 				break;
-		} // End Switch Statement
+		}
 
 		return $text;
 	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_Analysis_Course_List_Table

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -33,7 +33,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		add_action( 'sensei_after_list_table', array( $this, 'data_table_footer' ) );
 
 		add_filter( 'sensei_list_table_search_button_text', array( $this, 'search_button' ) );
-	} // End __construct()
+	}
 
 	/**
 	 * Define the columns that are going to be used in the table
@@ -83,7 +83,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		if ( ! empty( $_GET['orderby'] ) ) {
 			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
 				$orderby = esc_html( $_GET['orderby'] );
-			} // End If Statement
+			}
 		}
 
 		// Handle order
@@ -96,7 +96,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
 			$search = esc_html( $_GET['s'] );
-		} // End If Statement
+		}
 		$this->search = $search;
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
@@ -106,7 +106,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		$offset = 0;
 		if ( ! empty( $paged ) ) {
 			$offset = $per_page * ( $paged - 1 );
-		} // End If Statement
+		}
 
 		$args = array(
 			'number'  => $per_page,
@@ -116,7 +116,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		);
 		if ( $this->search ) {
 			$args['search'] = $this->search;
-		} // End If Statement
+		}
 
 		$this->items = $this->get_lesson_statuses( $args );
 
@@ -148,7 +148,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		if ( ! empty( $_GET['orderby'] ) ) {
 			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
 				$orderby = esc_html( $_GET['orderby'] );
-			} // End If Statement
+			}
 		}
 
 		// Handle order
@@ -161,7 +161,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
 			$search = esc_html( $_GET['s'] );
-		} // End If Statement
+		}
 		$this->search = $search;
 
 		$args = array(
@@ -170,7 +170,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		);
 		if ( $this->search ) {
 			$args['search'] = $this->search;
-		} // End If Statement
+		}
 
 		// Start the csv with the column headings
 		$column_headers = array();
@@ -237,7 +237,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 			if ( is_numeric( $grade ) ) {
 				$grade .= '%';
 			}
-		} // End If Statement
+		}
 
 		$column_data = apply_filters(
 			'sensei_analysis_lesson_column_data',
@@ -292,7 +292,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 				// Store for reuse on counts
 				$activity_args['user_id'] = (array) $learners_search->get_results();
 			}
-		} // End If Statement
+		}
 
 		$activity_args = apply_filters( 'sensei_analysis_lesson_filter_statuses', $activity_args );
 
@@ -319,7 +319,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 			$statuses = array( $statuses );
 		}
 		return $statuses;
-	} // End get_lesson_statuses()
+	}
 
 	/**
 	 * no_items sets output when no items are found
@@ -330,7 +330,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 	 */
 	public function no_items() {
 		esc_html_e( 'No learners found.', 'sensei-lms' );
-	} // End no_items()
+	}
 
 	/**
 	 * data_table_header output for table heading
@@ -340,7 +340,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 	 */
 	public function data_table_header() {
 		echo '<strong>' . esc_html__( 'Learners taking this Lesson', 'sensei-lms' ) . '</strong>';
-	} // End data_table_header()
+	}
 
 	/**
 	 * data_table_footer output for table footer
@@ -360,7 +360,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 			admin_url( 'admin.php' )
 		);
 		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download', '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
-	} // End data_table_footer()
+	}
 
 	/**
 	 * the text for the search button
@@ -375,7 +375,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		return $text;
 
 	}
-} // End Class
+}
 
 
 /**

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -32,7 +32,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		add_action( 'sensei_after_list_table', array( $this, 'data_table_footer' ) );
 
 		add_filter( 'sensei_list_table_search_button_text', array( $this, 'search_button' ) );
-	} // End __construct()
+	}
 
 	/**
 	 * Define the columns that are going to be used in the table
@@ -140,7 +140,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		if ( ! empty( $_GET['orderby'] ) ) {
 			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
 				$orderby = esc_html( $_GET['orderby'] );
-			} // End If Statement
+			}
 		}
 
 		// Handle order
@@ -156,7 +156,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$offset = 0;
 		if ( ! empty( $paged ) ) {
 			$offset = $per_page * ( $paged - 1 );
-		} // End If Statement
+		}
 
 		$args = array(
 			'number'  => $per_page,
@@ -213,7 +213,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		if ( ! empty( $_GET['orderby'] ) ) {
 			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
 				$orderby = esc_html( $_GET['orderby'] );
-			} // End If Statement
+			}
 		}
 
 		// Handle order
@@ -323,7 +323,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 					$course_title            = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . apply_filters( 'the_title', $item->post_title, $item->ID ) . '</a></strong>';
 					$course_average_percent .= '%';
-				} // End If Statement
+				}
 
 				$column_data = apply_filters(
 					'sensei_analysis_overview_column_data',
@@ -407,7 +407,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					if ( is_numeric( $lesson_average_grade ) ) {
 						$lesson_average_grade .= '%';
 					}
-				} // End If Statement
+				}
 				$column_data = apply_filters(
 					'sensei_analysis_overview_column_data',
 					array(
@@ -471,7 +471,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					);
 					$user_name           = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . esc_html( $item->display_name ) . '</a></strong>';
 					$user_average_grade .= '%';
-				} // End If Statement
+				}
 				$column_data = apply_filters(
 					'sensei_analysis_overview_column_data',
 					array(
@@ -486,7 +486,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					$this
 				);
 				break;
-		} // end switch
+		}
 
 		$escaped_column_data = array();
 
@@ -527,7 +527,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$this->total_items = $courses_query->found_posts;
 		return $courses_query->posts;
 
-	} // End get_courses()
+	}
 
 	/**
 	 * Return array of lessons
@@ -558,7 +558,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$lessons_query     = new WP_Query( apply_filters( 'sensei_analysis_overview_filter_lessons', $lessons_args ) );
 		$this->total_items = $lessons_query->found_posts;
 		return $lessons_query->posts;
-	} // End get_lessons()
+	}
 
 	/**
 	 * Return array of learners
@@ -590,7 +590,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		return $learners;
 
-	} // End get_learners()
+	}
 
 	/**
 	 * Sets the stats boxes to render
@@ -635,7 +635,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			__( 'Total Completed Courses', 'sensei-lms' ) => $total_courses_ended,
 		);
 		return apply_filters( 'sensei_analysis_stats_boxes', $stats_to_render );
-	} // End stats_boxes()
+	}
 
 	/**
 	 * Sets output when no items are found
@@ -652,7 +652,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		}
 		// translators: Placeholders %1$s and %3$s are opening and closing <em> tages, %2$s is the view type.
 		echo wp_kses_post( sprintf( __( '%1$sNo %2$s found%3$s', 'sensei-lms' ), '<em>', $type, '</em>' ) );
-	} // End no_items()
+	}
 
 	/**
 	 * Output for table heading
@@ -698,7 +698,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			echo wp_kses_post( implode( " |</li>\n", $menu ) ) . "</li>\n";
 			echo '</ul>' . "\n";
 		}
-	} // End data_table_header()
+	}
 
 	/**
 	 * Output for table footer
@@ -720,7 +720,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			default:
 				$report = 'user-overview';
 				break;
-		} // End Switch Statement
+		}
 		$url = add_query_arg(
 			array(
 				'page'                   => $this->page_slug,
@@ -730,7 +730,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			admin_url( 'admin.php' )
 		);
 		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download', '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
-	} // End data_table_footer()
+	}
 
 	/**
 	 * The text for the search button
@@ -752,12 +752,12 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			default:
 				$text = __( 'Search Learners', 'sensei-lms' );
 				break;
-		} // End Switch Statement
+		}
 
 		return $text;
 	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_Analysis_Overview_List_Table

--- a/includes/class-sensei-analysis-user-profile-list-table.php
+++ b/includes/class-sensei-analysis-user-profile-list-table.php
@@ -32,7 +32,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		add_action( 'sensei_after_list_table', array( $this, 'data_table_footer' ) );
 
 		add_filter( 'sensei_list_table_search_button_text', array( $this, 'search_button' ) );
-	} // End __construct()
+	}
 
 	/**
 	 * Define the columns that are going to be used in the table
@@ -82,7 +82,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		if ( ! empty( $_GET['orderby'] ) ) {
 			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
 				$orderby = esc_html( $_GET['orderby'] );
-			} // End If Statement
+			}
 		}
 
 		// Handle order
@@ -95,7 +95,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
 			$search = esc_html( $_GET['s'] );
-		} // End If Statement
+		}
 		$this->search = $search;
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
@@ -105,7 +105,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		$offset = 0;
 		if ( ! empty( $paged ) ) {
 			$offset = $per_page * ( $paged - 1 );
-		} // End If Statement
+		}
 
 		$args = array(
 			'number'  => $per_page,
@@ -115,7 +115,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		);
 		if ( $this->search ) {
 			$args['search'] = $this->search;
-		} // End If Statement
+		}
 
 		$this->items = $this->get_course_statuses( $args );
 
@@ -147,7 +147,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		if ( ! empty( $_GET['orderby'] ) ) {
 			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
 				$orderby = esc_html( $_GET['orderby'] );
-			} // End If Statement
+			}
 		}
 
 		// Handle order
@@ -160,7 +160,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
 			$search = esc_html( $_GET['s'] );
-		} // End If Statement
+		}
 		$this->search = $search;
 
 		$args = array(
@@ -169,7 +169,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		);
 		if ( $this->search ) {
 			$args['search'] = $this->search;
-		} // End If Statement
+		}
 
 		// Start the csv with the column headings
 		$column_headers = array();
@@ -231,7 +231,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 			if ( is_numeric( $course_percent ) ) {
 				$course_percent .= '%';
 			}
-		} // End If Statement
+		}
 		$column_data = apply_filters(
 			'sensei_analysis_user_profile_column_data',
 			array(
@@ -304,7 +304,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		}
 
 		return $statuses;
-	} // End get_course_statuses()
+	}
 
 	/**
 	 * Sets output when no items are found
@@ -315,7 +315,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 	 */
 	public function no_items() {
 		echo esc_html__( 'No courses found.', 'sensei-lms' );
-	} // End no_items()
+	}
 
 	/**
 	 * Output for table heading
@@ -357,7 +357,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 		return __( 'Search Courses', 'sensei-lms' );
 	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_Analysis_User_Profile_List_Table

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -40,8 +40,8 @@ class Sensei_Analysis {
 			add_action( 'admin_init', array( $this, 'report_download_page' ) );
 
 			add_filter( 'user_search_columns', array( $this, 'user_search_columns_filter' ), 10, 3 );
-		} // End If Statement
-	} // End __construct()
+		}
+	}
 
 
 	/**
@@ -56,7 +56,7 @@ class Sensei_Analysis {
 			add_submenu_page( 'sensei', __( 'Analysis', 'sensei-lms' ), __( 'Analysis', 'sensei-lms' ), 'manage_sensei_grades', 'sensei_analysis', array( $this, 'analysis_page' ) );
 		}
 
-	} // End analysis_admin_menu()
+	}
 
 	/**
 	 * enqueue_styles function.
@@ -70,7 +70,7 @@ class Sensei_Analysis {
 
 		Sensei()->assets->enqueue( 'sensei-settings-api', 'css/settings.css' );
 
-	} // End enqueue_styles()
+	}
 
 	/**
 	 * load_data_table_files loads required files for Analysis
@@ -90,8 +90,8 @@ class Sensei_Analysis {
 		);
 		foreach ( $classes_to_load as $class_file ) {
 			Sensei()->load_class( $class_file );
-		} // End For Loop
-	} // End load_data_table_files()
+		}
+	}
 
 	/**
 	 * load_data_object creates new instance of class
@@ -111,7 +111,7 @@ class Sensei_Analysis {
 		}
 		$sensei_analysis_object->prepare_items();
 		return $sensei_analysis_object;
-	} // End load_data_object()
+	}
 
 	/**
 	 * analysis_page function.
@@ -157,8 +157,8 @@ class Sensei_Analysis {
 		} else {
 			// Overview of all Learners, all Courses, or all Lessons
 			$this->analysis_default_view( $type );
-		} // End If Statement
-	} // End analysis_page()
+		}
+	}
 
 	/**
 	 * Default view for analysis, showing an overview of all Learners, Courses and Lessons
@@ -181,7 +181,7 @@ class Sensei_Analysis {
 				do_action( 'sensei_analysis_before_stats_boxes' );
 				foreach ( $sensei_analysis_overview->stats_boxes() as $key => $value ) {
 					$this->render_stats_box( esc_html( $key ), esc_html( $value ) );
-				} // End For Loop
+				}
 				do_action( 'sensei_analysis_after_stats_boxes' );
 				?>
 			</div>
@@ -195,7 +195,7 @@ class Sensei_Analysis {
 		<?php
 		do_action( 'analysis_wrapper_container', 'bottom' );
 		do_action( 'analysis_after_container' );
-	} // End analysis_default_view()
+	}
 
 	/**
 	 * An individual users' profile view for analysis, showing their Courses
@@ -224,7 +224,7 @@ class Sensei_Analysis {
 		<?php
 		do_action( 'analysis_wrapper_container', 'bottom' );
 		do_action( 'analysis_after_container' );
-	} // End analysis_user_profile_view()
+	}
 
 	/**
 	 * An individual Course view for analysis, showing the Courses Lessons
@@ -253,7 +253,7 @@ class Sensei_Analysis {
 		<?php
 		do_action( 'analysis_wrapper_container', 'bottom' );
 		do_action( 'analysis_after_container' );
-	} // End analysis_course_view()
+	}
 
 	/**
 	 * An individual Course view for analysis, showing a specific Learners Lessons
@@ -283,7 +283,7 @@ class Sensei_Analysis {
 		<?php
 		do_action( 'analysis_wrapper_container', 'bottom' );
 		do_action( 'analysis_after_container' );
-	} // End analysis_user_course_view()
+	}
 
 	/**
 	 * An individual Course view for analysis, showing all the Learners
@@ -312,7 +312,7 @@ class Sensei_Analysis {
 		<?php
 		do_action( 'analysis_wrapper_container', 'bottom' );
 		do_action( 'analysis_after_container' );
-	} // End analysis_course_users_view()
+	}
 
 	/**
 	 * An individual Lesson view for analysis, showing all the Learners
@@ -341,7 +341,7 @@ class Sensei_Analysis {
 		<?php
 		do_action( 'analysis_wrapper_container', 'bottom' );
 		do_action( 'analysis_after_container' );
-	} // End analysis_lesson_users_view()
+	}
 
 	/**
 	 * render_stats_box outputs stats boxes
@@ -360,7 +360,7 @@ class Sensei_Analysis {
 			</div>
 		</div>
 		<?php
-	} // End render_stats_box()
+	}
 
 	/**
 	 * analysis_headers outputs analysis general headers
@@ -374,7 +374,7 @@ class Sensei_Analysis {
 		$this->$function();
 		do_action( 'sensei_analysis_after_headers' );
 
-	} // End analysis_headers()
+	}
 
 	/**
 	 * wrapper_container wrapper for analysis area
@@ -392,8 +392,8 @@ class Sensei_Analysis {
 			?>
 			</div><!--/#woothemes-sensei-->
 			<?php
-		} // End If Statement
-	} // End wrapper_container()
+		}
+	}
 
 	/**
 	 * Default nav area for Analysis, overview of Learners, Courses and Lessons
@@ -409,7 +409,7 @@ class Sensei_Analysis {
 				<?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?>
 			</h1>
 		<?php
-	} // End analysis_default_nav()
+	}
 
 	/**
 	 * Nav area for Analysis of a specific User profile
@@ -435,11 +435,11 @@ class Sensei_Analysis {
 			$user_name = Sensei_Learner::get_full_name( $user_id );
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', $url, $user_name );
 
-		} // End If Statement
+		}
 		?>
 			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
 		<?php
-	} // End analysis_user_profile_nav()
+	}
 
 	/**
 	 * Nav area for Analysis of a specific Course and its Lessons, specific to a User
@@ -463,7 +463,7 @@ class Sensei_Analysis {
 			$user_name = Sensei_Learner::get_full_name( $user_id );
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', $url, $user_name );
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), $user_data->display_name );
-		} // End If Statement
+		}
 		if ( isset( $_GET['course_id'] ) ) {
 			$course_id = intval( $_GET['course_id'] );
 			$url       = add_query_arg(
@@ -478,7 +478,7 @@ class Sensei_Analysis {
 		?>
 			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
 		<?php
-	} // End analysis_user_course_nav()
+	}
 
 	/**
 	 * Nav area for Analysis of a specific Course and displaying its Lessons
@@ -503,7 +503,7 @@ class Sensei_Analysis {
 		?>
 			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
 		<?php
-	} // End analysis_course_nav()
+	}
 
 	/**
 	 * Nav area for Analysis of a specific Course displaying its Users
@@ -528,7 +528,7 @@ class Sensei_Analysis {
 		?>
 			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
 		<?php
-	} // End analysis_course_users_nav()
+	}
 
 	/**
 	 * Nav area for Analysis of a specific Lesson displaying its Users
@@ -562,7 +562,7 @@ class Sensei_Analysis {
 		?>
 			<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $title ) ); ?></h1>
 		<?php
-	} // End analysis_lesson_users_nav()
+	}
 
 	/**
 	 * Handles CSV export requests
@@ -630,7 +630,7 @@ class Sensei_Analysis {
 				// Overview of all Learners, all Courses, or all Lessons
 				$sensei_analysis_report_object = $this->load_report_object( 'Overview', $type );
 				$event_properties['view']      = isset( $_GET['view'] ) ? $_GET['view'] : '';
-			} // End If Statement
+			}
 
 			// Handle the headers
 			$this->report_set_headers( $filename );
@@ -646,8 +646,8 @@ class Sensei_Analysis {
 
 			// Cleanly exit
 			exit;
-		} // End wp_query check
-	} // End report_download_page()
+		}
+	}
 
 	/**
 	 * Check course and lesson objects are valid posts that the user has access to.
@@ -697,7 +697,7 @@ class Sensei_Analysis {
 	public function report_set_headers( $filename = '' ) {
 		header( 'Content-Type: text/csv' );
 		header( 'Content-Disposition: attachment;filename=' . $filename . '.csv' );
-	} // End report_set_headers()
+	}
 
 	/**
 	 * Loads the right object for CSV reporting
@@ -716,7 +716,7 @@ class Sensei_Analysis {
 			$sensei_analysis_report_object = new $object_name( $data, $optional_data );
 		}
 		return $sensei_analysis_report_object;
-	} // End load_report_object()
+	}
 
 	/**
 	 * Write array data to CSV
@@ -729,9 +729,9 @@ class Sensei_Analysis {
 		$fp = fopen( 'php://output', 'w' );
 		foreach ( $report_data as $row ) {
 			fputcsv( $fp, $row );
-		} // End For Loop
+		}
 		fclose( $fp );
-	} // End report_write_download()
+	}
 
 	/**
 	 * Adds display_name to the default list of search columns for the WP User Object
@@ -748,7 +748,7 @@ class Sensei_Analysis {
 		return $search_columns;
 	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_Analysis

--- a/includes/class-sensei-course-results.php
+++ b/includes/class-sensei-course-results.php
@@ -40,7 +40,7 @@ class Sensei_Course_Results {
 		// Add class to body tag
 		add_filter( 'body_class', array( $this, 'body_class' ), 10, 1 );
 
-	} // End __construct()
+	}
 
 	/**
 	 * Setup permalink structure for course results
@@ -154,7 +154,7 @@ class Sensei_Course_Results {
 
 	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_Course_Results

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1833,7 +1833,7 @@ class Sensei_Course {
 
 					</div>
 
-				<?php }?>
+				<?php } ?>
 
 			</div>
 
@@ -1866,7 +1866,7 @@ class Sensei_Course {
 
 					</div>
 
-				<?php }?>
+				<?php } ?>
 
 			</div>
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -71,7 +71,7 @@ class Sensei_Course {
 			add_action( 'admin_enqueue_scripts', array( $this, 'register_admin_scripts' ) );
 		} else {
 			$this->my_courses_page = false;
-		} // End If Statement
+		}
 
 		self::$allowed_html = array(
 			'embed'  => array(),
@@ -316,7 +316,7 @@ class Sensei_Course {
 		// add Disable email notification box
 		add_meta_box( 'course-notifications', __( 'Course Notifications', 'sensei-lms' ), array( $this, 'course_notification_meta_box_content' ), 'course', 'normal', 'default' );
 
-	} // End meta_box_setup()
+	}
 
 	/**
 	 * course_prerequisite_meta_box_content function.
@@ -349,11 +349,11 @@ class Sensei_Course {
 			$html .= '<option value="">' . esc_html__( 'None', 'sensei-lms' ) . '</option>';
 			foreach ( $posts_array as $post_item ) {
 				$html .= '<option value="' . esc_attr( absint( $post_item->ID ) ) . '"' . selected( $post_item->ID, $select_course_prerequisite, false ) . '>' . esc_html( $post_item->post_title ) . '</option>' . "\n";
-			} // End For Loop
+			}
 			$html .= '</select>' . "\n";
 		} else {
 			$html .= '<p>' . esc_html__( 'No courses exist yet. Please add some first.', 'sensei-lms' ) . '</p>';
-		} // End If Statement
+		}
 
 		echo wp_kses(
 			$html,
@@ -378,7 +378,7 @@ class Sensei_Course {
 				)
 			)
 		);
-	} // End course_prerequisite_meta_box_content()
+	}
 
 	/**
 	 * course_featured_meta_box_content function.
@@ -398,7 +398,7 @@ class Sensei_Course {
 		$checked = '';
 		if ( isset( $course_featured ) && ( '' != $course_featured ) ) {
 			$checked = checked( 'featured', $course_featured, false );
-		} // End If Statement
+		}
 
 		$html .= '<input type="checkbox" name="course_featured" value="featured" ' . $checked . '>&nbsp;' . esc_html__( 'Feature this course', 'sensei-lms' ) . '<br>';
 
@@ -417,7 +417,7 @@ class Sensei_Course {
 				)
 			)
 		);
-	} // End course_featured_meta_box_content()
+	}
 
 	/**
 	 * course_video_meta_box_content function.
@@ -461,7 +461,7 @@ class Sensei_Course {
 				)
 			)
 		);
-	} // End course_video_meta_box_content()
+	}
 
 	/**
 	 * meta_box_save function.
@@ -486,26 +486,26 @@ class Sensei_Course {
 		/* Check if the current user has permission to edit the post. */
 		if ( ! current_user_can( $post_type->cap->edit_post, $post_id ) ) {
 			return $post_id;
-		} // End If Statement
+		}
 
 		if ( 'page' == $_POST['post_type'] ) {
 			if ( ! current_user_can( 'edit_page', $post_id ) ) {
 				return $post_id;
-			} // End If Statement
+			}
 		} else {
 			if ( ! current_user_can( 'edit_post', $post_id ) ) {
 				return $post_id;
-			} // End If Statement
-		} // End If Statement
+			}
+		}
 
 		// Save the post meta data fields
 		if ( isset( $this->meta_fields ) && is_array( $this->meta_fields ) ) {
 			foreach ( $this->meta_fields as $meta_key ) {
 				$this->save_post_meta( $meta_key, $post_id );
-			} // End For Loop
-		} // End If Statement
+			}
+		}
 
-	} // End meta_box_save()
+	}
 
 
 	/**
@@ -534,7 +534,7 @@ class Sensei_Course {
 		} else {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$new_meta_value = ( isset( $_POST[ $post_key ] ) ? sanitize_html_class( $_POST[ $post_key ] ) : '' );
-		} // End If Statement
+		}
 
 		/**
 		 * Action before saving the meta value.
@@ -565,7 +565,7 @@ class Sensei_Course {
 			return update_post_meta( $post_id, $meta_key, $new_meta_value );
 		}
 
-	} // End save_post_meta()
+	}
 
 	/**
 	 * course_lessons_meta_box_content function.
@@ -583,7 +583,7 @@ class Sensei_Course {
 
 			$posts_array = $this->course_lessons( $post->ID, 'any' );
 
-		} // End If Statement
+		}
 
 		$html  = '';
 		$html .= '<input type="hidden" name="' . esc_attr( 'woo_' . $this->token . '_noonce' ) . '" id="'
@@ -612,7 +612,7 @@ class Sensei_Course {
 
 				$html .= '</p>' . "\n";
 
-			} // End For Loop
+			}
 		}
 		$html .= '<p>';
 		if ( 0 === count( $posts_array ) ) {
@@ -646,7 +646,7 @@ class Sensei_Course {
 				)
 			)
 		);
-	} // End course_lessons_meta_box_content()
+	}
 
 	/**
 	 * course_manage_meta_box_content function.
@@ -678,7 +678,7 @@ class Sensei_Course {
 
 		echo '<ul><li><a href=' . esc_url( $manage_url ) . '>' . esc_html__( 'Manage Learners', 'sensei-lms' ) . '</a></li>';
 		echo '<li><a href=' . esc_url( $grading_url ) . '>' . esc_html__( 'Manage Grading', 'sensei-lms' ) . '</a></li></ul>';
-	} // End course_manage_meta_box_content()
+	}
 
 	/**
 	 * Add column headings to the "course" post list screen,
@@ -764,7 +764,7 @@ class Sensei_Course {
 			default:
 				break;
 		}
-	} // End add_column_data()
+	}
 
 
 	/**
@@ -819,7 +819,7 @@ class Sensei_Course {
 
 		return $results_array;
 
-	} // End course_query()
+	}
 
 
 	/**
@@ -846,8 +846,8 @@ class Sensei_Course {
 		} else {
 			if ( 0 == $amount ) {
 				$amount = $wp_query->get( 'posts_per_page' );
-			} // End If Statement
-		} // End If Statement
+			}
+		}
 
 		$stored_order = get_option( 'sensei_course_order', '' );
 		$order        = 'ASC';
@@ -1002,7 +1002,7 @@ class Sensei_Course {
 
 				if ( ! Sensei()->settings->settings['course_single_image_enable'] ) {
 					return '';
-				} // End If Statement
+				}
 				$image_thumb_size = 'course_single_image';
 				$dimensions       = Sensei()->get_image_size( $image_thumb_size );
 				$width            = $dimensions['width'];
@@ -1012,15 +1012,15 @@ class Sensei_Course {
 
 				if ( ! Sensei()->settings->settings['course_archive_image_enable'] ) {
 					return '';
-				} // End If Statement
+				}
 
 				$image_thumb_size = 'course_archive_image';
 				$dimensions       = Sensei()->get_image_size( $image_thumb_size );
 				$width            = $dimensions['width'];
 				$height           = $dimensions['height'];
 
-			} // End If Statement
-		} // End If Statement
+			}
+		}
 
 		$img_html         = '';
 		$used_placeholder = false;
@@ -1038,9 +1038,9 @@ class Sensei_Course {
 					$img_html = get_the_post_thumbnail( $lesson_item->ID, array( $width, $height ), array( 'class' => 'woo-image thumbnail alignleft' ) );
 					if ( '' !== $img_html ) {
 						break;
-					} // End If Statement
-				} // End If Statement
-			} // End For Loop
+					}
+				}
+			}
 
 			if ( '' === $img_html ) {
 
@@ -1061,9 +1061,9 @@ class Sensei_Course {
 					$img_html         = apply_filters( 'sensei_course_placeholder_image_url', '<img src="http://placehold.it/' . $width . 'x' . $height . '" class="woo-image thumbnail alignleft" />', $course_id, $width, $height );
 					$used_placeholder = true;
 
-				} // End If Statement
-			} // End If Statement
-		} // End If Statement
+				}
+			}
+		}
 
 		/**
 		 * Filter the HTML for the course image. If not blank, this will be surrounded with an anchor tag linking to the course.
@@ -1082,7 +1082,7 @@ class Sensei_Course {
 
 			$html .= '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr( get_post_field( 'post_title', $course_id ) ) . '">' . wp_kses_post( $img_html ) . '</a>';
 
-		} // End If Statement
+		}
 
 		if ( $return ) {
 
@@ -1094,7 +1094,7 @@ class Sensei_Course {
 
 		}
 
-	} // End course_image()
+	}
 
 
 	/**
@@ -1119,7 +1119,7 @@ class Sensei_Course {
 		$courses_query = new WP_Query( apply_filters( 'sensei_course_count', $post_args ) );
 
 		return count( $courses_query->posts );
-	} // End course_count()
+	}
 
 
 	/**
@@ -1204,7 +1204,7 @@ class Sensei_Course {
 
 		return $lessons;
 
-	} // End course_lessons()
+	}
 
 	/**
 	 * Used for the uasort in $this->course_lessons()
@@ -1269,7 +1269,7 @@ class Sensei_Course {
 
 		return $this->course_lessons( $course_id, $post_status );
 
-	} // End course_lessons_completed()
+	}
 
 
 	/**
@@ -1296,7 +1296,7 @@ class Sensei_Course {
 		$count         = count( $lessons_array );
 		return $count;
 
-	} // End course_author_lesson_count()
+	}
 
 	/**
 	 * course_lesson_count function.
@@ -1322,7 +1322,7 @@ class Sensei_Course {
 
 		return $count;
 
-	} // End course_lesson_count()
+	}
 
 	/**
 	 * course_lesson_preview_count function.
@@ -1356,7 +1356,7 @@ class Sensei_Course {
 
 		return $count;
 
-	} // End course_lesson_count()
+	}
 
 	/**
 	 * get_product_courses function.
@@ -1377,7 +1377,7 @@ class Sensei_Course {
 
 		return array();
 
-	} // End get_product_courses()
+	}
 
 	/**
 	 * @deprecated 2.0.0 Use `Sensei_WC_Paid_Courses\Courses::get_product_courses_query_args()` instead.
@@ -1518,7 +1518,7 @@ class Sensei_Course {
 
 					$lesson_count = 1;
 
-				} // End If Statement
+				}
 				$active_html .= '<span class="course-lesson-count">' .
 					// translators: Placeholder %d is the lesson count.
 					esc_html( sprintf( _n( '%d Lesson', '%d Lessons', $lesson_count, 'sensei-lms' ), $lesson_count ) ) .
@@ -1531,7 +1531,7 @@ class Sensei_Course {
 						. sprintf( __( 'in %s', 'sensei-lms' ), $category_output )
 						. '</span>';
 
-				} // End If Statement
+				}
 
 				// translators: Placeholders are the counts for lessons completed and total lessons, respectively.
 				$active_html .= '<span class="course-lesson-progress">' . esc_html( sprintf( __( '%1$d of %2$d lessons completed', 'sensei-lms' ), $lessons_completed, $lesson_count ) ) . '</span>';
@@ -1563,7 +1563,7 @@ class Sensei_Course {
 						$active_html .= '<span><input name="course_complete" type="submit" class="course-complete sensei-stop-double-submission" value="'
 							. esc_attr__( 'Mark as Complete', 'sensei-lms' ) . '"/> </span>';
 
-					} // End If Statement
+					}
 
 					$course_purchased = false;
 					if ( class_exists( 'Sensei_WC' ) && Sensei_WC::is_woocommerce_active() ) {
@@ -1574,8 +1574,8 @@ class Sensei_Course {
 
 							$course_purchased = Sensei_WC::has_customer_bought_product( $user->ID, $wc_post_id );
 
-						} // End If Statement
-					} // End If Statement
+						}
+					}
 
 					/**
 					 * documented in class-sensei-course.php the_course_action_buttons function
@@ -1595,7 +1595,7 @@ class Sensei_Course {
 						$active_html .= '<span><input name="course_complete" type="submit" class="course-delete" value="'
 							. esc_attr__( 'Delete Course', 'sensei-lms' ) . '"/></span>';
 
-					} // End If Statement
+					}
 
 					$active_html .= '</form>';
 
@@ -1680,7 +1680,7 @@ class Sensei_Course {
 					// translators: Placeholder is a comma-separated list of the Course categories.
 					$complete_html .= '<span class="course-category">' . sprintf( __( 'in %s', 'sensei-lms' ), $category_output ) . '</span>';
 
-				} // End If Statement
+				}
 
 						$complete_html .= '</p>';
 
@@ -1749,7 +1749,7 @@ class Sensei_Course {
 
 				$complete_html .= '</nav>';
 			}
-		} // End If Statement
+		}
 
 		if ( $manage ) {
 			$no_active_message   = __( 'You have no active courses.', 'sensei-lms' );
@@ -1833,7 +1833,7 @@ class Sensei_Course {
 
 					</div>
 
-				<?php } // End If Statement ?>
+				<?php }?>
 
 			</div>
 
@@ -1866,7 +1866,7 @@ class Sensei_Course {
 
 					</div>
 
-				<?php } // End If Statement ?>
+				<?php }?>
 
 			</div>
 
@@ -1882,7 +1882,7 @@ class Sensei_Course {
 
 		do_action( 'sensei_after_learner_course_content', $user );
 
-	} // end load_user_courses_content
+	}
 
 	/**
 	 * Returns a list of all courses
@@ -1917,7 +1917,7 @@ class Sensei_Course {
 		 */
 		return apply_filters( 'sensei_get_all_courses', $wp_query_obj->posts );
 
-	}//end get_all_courses()
+	}
 
 	/**
 	 * Generate the course meter component
@@ -1940,7 +1940,7 @@ class Sensei_Course {
 
 		return $progress_bar_html;
 
-	}//end get_progress_meter()
+	}
 
 	/**
 	 * Generate a statement that tells users
@@ -1975,7 +1975,7 @@ class Sensei_Course {
 		 */
 		return apply_filters( 'sensei_course_completion_statement', $statement );
 
-	}//end get_progress_statement()
+	}
 
 	/**
 	 * Output the course progress statement
@@ -2030,7 +2030,7 @@ class Sensei_Course {
 
 		echo wp_kses_post( $this->get_progress_meter( $percentage_completed ) );
 
-	}//end the_progress_meter()
+	}
 
 	/**
 	 * Checks how many lessons are completed
@@ -2061,7 +2061,7 @@ class Sensei_Course {
 
 		return $completed_lesson_ids;
 
-	}//end get_completed_lesson_ids()
+	}
 
 	/**
 	 * Calculate the perceantage completed in the course
@@ -2098,7 +2098,7 @@ class Sensei_Course {
 		 */
 		return apply_filters( 'sensei_course_completion_percentage', $percentage, $course_id, $user_id );
 
-	}//end get_completion_percentage()
+	}
 
 	/**
 	 * Block email notifications for the specific courses
@@ -2138,10 +2138,10 @@ class Sensei_Course {
 				return false;
 
 			}
-		}// end if
+		}
 
 		return $should_send;
-	}//end block_notification_emails()
+	}
 
 	/**
 	 * Render the course notification setting meta box
@@ -2158,7 +2158,7 @@ class Sensei_Course {
 		echo '<input id="disable_sensei_course_notification" ' . checked( $checked, true, false ) . ' type="checkbox" name="disable_sensei_course_notification" >';
 		echo '<label for="disable_sensei_course_notification">' . esc_html__( 'Disable notifications on this course?', 'sensei-lms' ) . '</label>';
 
-	}//end course_notification_meta_box_content()
+	}
 
 	/**
 	 * Store the setting for the course notification setting.
@@ -2183,7 +2183,7 @@ class Sensei_Course {
 
 		update_post_meta( $course_id, 'disable_notification', $new_val );
 
-	}//end save_course_notification_meta_box()
+	}
 
 	/**
 	 * Output a link to view course. The button text is different depending on the amount of preview lesson available.
@@ -2264,7 +2264,7 @@ class Sensei_Course {
 				// translators: Placeholder is a comma-separated list of the Course categories.
 				wp_kses_post( sprintf( __( 'in %s', 'sensei-lms' ), $category_output ) ) .
 			'</span>';
-		} // End If Statement
+		}
 
 		// number of completed lessons
 		if ( Sensei_Utils::has_started_course( $course->ID, get_current_user_id() )
@@ -2309,7 +2309,7 @@ class Sensei_Course {
 
 		return $classes;
 
-	}//end add_course_user_status_class()
+	}
 
 	/**
 	 * Prints out the course action buttons links
@@ -2346,7 +2346,7 @@ class Sensei_Course {
 					<span><input name="course_complete" type="submit" class="course-complete sensei-stop-double-submission" value="<?php esc_attr_e( 'Mark as Complete', 'sensei-lms' ); ?>" /></span>
 
 				<?php
-			} // End If Statement
+			}
 
 			$course_purchased = false;
 			if ( class_exists( 'Sensei_WC' ) && Sensei_WC::is_woocommerce_active() ) {
@@ -2357,8 +2357,8 @@ class Sensei_Course {
 					$user             = wp_get_current_user();
 					$course_purchased = Sensei_WC::has_customer_bought_product( $user->ID, $wc_post_id );
 
-				} // End If Statement
-			} // End If Statement
+				}
+			}
 
 			/**
 			 * Hide or show the delete course button.
@@ -2388,7 +2388,7 @@ class Sensei_Course {
 					<span><input name="course_complete" type="submit" class="course-delete" value="<?php echo esc_attr__( 'Delete Course', 'sensei-lms' ); ?>"/></span>
 
 				<?php
-			} // End If Statement
+			}
 
 			$has_quizzes  = Sensei()->course->course_quizzes( $course->ID, true );
 			$results_link = '';
@@ -2414,15 +2414,15 @@ class Sensei_Course {
 					</p>
 
 				<?php
-			} // end if has filter
+			}
 			?>
 				</form>
 			</section>
 
 			<?php
-		}// end if is user logged in
+		}
 
-	}//end the_course_action_buttons()
+	}
 
 	/**
 	 * This function alter the main query on the course archive page.
@@ -2480,7 +2480,7 @@ class Sensei_Course {
 
 		return $query;
 
-	}//end course_query_filter()
+	}
 
 	/**
 	 * Determine the class of the course loop
@@ -2613,7 +2613,7 @@ class Sensei_Course {
 		</form>
 
 		<?php
-	}//end course_archive_sorting()
+	}
 
 	/**
 	 * Output the course archive filter markup
@@ -2781,7 +2781,7 @@ class Sensei_Course {
 			echo wp_kses_post( apply_filters( 'course_category_archive_title', $before_html . $title . $after_html ) );
 			return;
 
-		} // End If Statement
+		}
 
 		switch ( $query_type ) {
 			case 'newcourses':
@@ -2799,11 +2799,11 @@ class Sensei_Course {
 			default:
 				$html .= $before_html . __( 'Courses', 'sensei-lms' ) . $after_html;
 				break;
-		} // End Switch Statement
+		}
 
 		echo wp_kses_post( apply_filters( 'course_archive_title', $html ) );
 
-	}//end archive_header()
+	}
 
 
 	/**
@@ -2840,7 +2840,7 @@ class Sensei_Course {
 			return '<p class="course-excerpt">' . get_post( get_the_ID() )->post_excerpt . '</p>';
 		}
 
-	}//end single_course_content()
+	}
 
 	/**
 	 * Output the the single course lessons title with markup.
@@ -2896,7 +2896,7 @@ class Sensei_Course {
 		 */
 		echo wp_kses_post( apply_filters( 'the_course_lessons_title', ob_get_clean() ) ); // output and filter the captured output and stop capturing.
 
-	}//end the_course_lessons_title()
+	}
 
 	/**
 	 * This function loads the global wp_query object with with lessons
@@ -2979,7 +2979,7 @@ class Sensei_Course {
 		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Used for lesson loop on single course page. Reset in hook to `sensei_single_course_lessons_after`.
 		$wp_query = new WP_Query( $course_lesson_query_args );
 
-	}//end load_single_course_lessons_query()
+	}
 
 	/**
 	 * Flush the rewrite rules.
@@ -3200,7 +3200,7 @@ class Sensei_Course {
 
 			$course_video_embed = wp_oembed_get( esc_url( $course_video_embed ) );
 
-		} // End If Statement
+		}
 
 		$course_video_embed = do_shortcode( $course_video_embed );
 
@@ -3214,7 +3214,7 @@ class Sensei_Course {
 			</div>
 
 			<?php
-		} // End If Statement
+		}
 	}
 
 	/**
@@ -3248,7 +3248,7 @@ class Sensei_Course {
 
 		<?php
 
-	}//end the_title()
+	}
 
 	/**
 	 * Show the title on the course category pages
@@ -3279,7 +3279,7 @@ class Sensei_Course {
 
 		echo wp_kses_post( apply_filters( 'course_category_title', $html, $term->term_id ) );
 
-	}//end course_category_title()
+	}
 
 	/**
 	 * Alter the course query to respect the order set for courses and apply
@@ -3360,7 +3360,7 @@ class Sensei_Course {
 		 */
 		return apply_filters( 'sensei_course_is_prerequisite_complete', $prerequisite_complete, $course_id );
 
-	}//end is_prerequisite_complete()
+	}
 
 	/**
 	 * Allowing user to set course archive page as front page.

--- a/includes/class-sensei-emails.php
+++ b/includes/class-sensei-emails.php
@@ -429,7 +429,7 @@ class Sensei_Emails {
 		}
 	}
 
-}//end class
+}
 
 /**
  * Class WooThemes_Sensei_Emails

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1088,7 +1088,7 @@ class Sensei_Frontend {
 
 					</article>
 
-				<?php }?>
+				<?php } ?>
 
 			</section>
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -103,7 +103,7 @@ class Sensei_Frontend {
 
 		// Hide Sensei activity comments from lesson and course pages.
 		add_filter( 'wp_list_comments_args', array( $this, 'hide_sensei_activity' ) );
-	} // End __construct()
+	}
 
 	/**
 	 * Graceful fallback for course and lesson variables on Frontend object.
@@ -149,9 +149,9 @@ class Sensei_Frontend {
 			// Allow additional scripts to be loaded.
 			do_action( 'sensei_additional_scripts' );
 
-		} // End If Statement
+		}
 
-	} // End enqueue_scripts()
+	}
 
 	/**
 	 * Enqueue frontend CSS files.
@@ -170,9 +170,9 @@ class Sensei_Frontend {
 			// Allow additional stylesheets to be loaded.
 			do_action( 'sensei_additional_styles' );
 
-		} // End If Statement
+		}
 
-	} // End enqueue_styles()
+	}
 
 
 	/**
@@ -191,7 +191,7 @@ class Sensei_Frontend {
 
 		Sensei_Templates::get_part( $slug, $name );
 
-	} // End sensei_get_template_part()
+	}
 
 	/**
 	 * Output the start of the content wrapper.
@@ -217,7 +217,7 @@ class Sensei_Frontend {
 
 		Sensei_Templates::get_template( 'globals/wrapper-start.php' );
 
-	} // End sensei_output_content_wrapper()
+	}
 
 
 	/**
@@ -244,7 +244,7 @@ class Sensei_Frontend {
 
 		Sensei_Templates::get_template( 'globals/wrapper-end.php' );
 
-	} // End sensei_output_content_wrapper_end()
+	}
 
 
 	/**
@@ -306,9 +306,9 @@ class Sensei_Frontend {
 
 			Sensei_Templates::get_template( 'globals/pagination.php' );
 
-		} // End If Statement
+		}
 
-	} // End sensei_output_content_pagination()
+	}
 
 	/**
 	 * Outputs comments for the specified pages.
@@ -320,7 +320,7 @@ class Sensei_Frontend {
 
 		Sensei_Lesson::output_comments();
 
-	} // End sensei_output_comments()
+	}
 
 	/**
 	 * Generates URLs for custom menu items.
@@ -409,7 +409,7 @@ class Sensei_Frontend {
 
 		return $item;
 
-	} // End sensei_setup_nav_menu_item()
+	}
 
 	/**
 	 *
@@ -444,7 +444,7 @@ class Sensei_Frontend {
 			}
 		}
 		return $sorted_menu_items;
-	} // End sensei_wp_nav_menu_objects
+	}
 
 	/**
 	 * Adds category nicenames to the body and post class.
@@ -457,9 +457,9 @@ class Sensei_Frontend {
 		// Handle Search Classes for Courses, Lessons, and WC Products.
 		if ( isset( $post->post_type ) && ( ( 'course' == $post->post_type ) || ( 'lesson' == $post->post_type ) || ( 'product' == $post->post_type ) ) ) {
 			$classes[] = 'post';
-		} // End If Statement
+		}
 		return $classes;
-	} // End sensei_search_results_classes()
+	}
 
 	/**
 	 * Outputs the course image.
@@ -481,11 +481,11 @@ class Sensei_Frontend {
 			echo wp_kses_post( Sensei()->course->course_image( $course_id, $width, $height ) );
 			return '';
 
-		} // End If Statement
+		}
 
 		return Sensei()->course->course_image( $course_id, $width, $height );
 
-	} // End sensei_course_image()
+	}
 
 	/**
 	 * Outputs the lesson image.
@@ -513,7 +513,7 @@ class Sensei_Frontend {
 
 		return Sensei()->lesson->lesson_image( $lesson_id, $width, $height, $widget );
 
-	} // End sensei_lesson_image()
+	}
 
 	/**
 	 * Pagination for course archive pages when filtering by course type.
@@ -553,10 +553,10 @@ class Sensei_Frontend {
 		} else {
 			$post_id    = get_the_ID();
 			$post_title = get_the_title();
-		} // End If Statement
+		}
 		?><header><h2><a href="<?php echo esc_url( get_permalink( $post_id ) ); ?>" title="<?php echo esc_attr( $post_title ); ?>"><?php echo esc_html( $post_title ); ?></a></h2></header>
 		<?php
-	} // End sensei_course_archive_course_title()
+	}
 
 	/**
 	 * Outputs the title on the course archive page.
@@ -570,7 +570,7 @@ class Sensei_Frontend {
 		?>
 		<header><h2><a href="<?php echo esc_url( get_permalink( $post_id ) ); ?>" title="<?php echo esc_attr( $post_title ); ?>"><?php echo esc_html( $post_title ); ?></a></h2></header>
 		<?php
-	} // End sensei_lesson_archive_lesson_title()
+	}
 
 	/**
 	 * Outputs the breadcrumb for lessons and quizzes.
@@ -603,7 +603,7 @@ class Sensei_Frontend {
 				return;
 			}
 			$html .= '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr__( 'Back to the course', 'sensei-lms' ) . '">' . esc_html( get_the_title( $course_id ) ) . '</a>';
-		} // End If Statement
+		}
 		// Quiz.
 		if ( is_singular( 'quiz' ) && 0 < intval( $id ) ) {
 			$lesson_id = intval( get_post_meta( $id, '_quiz_lesson', true ) );
@@ -611,14 +611,14 @@ class Sensei_Frontend {
 				return;
 			}
 			 $html .= '<a href="' . esc_url( get_permalink( $lesson_id ) ) . '" title="' . esc_attr__( 'Back to the lesson', 'sensei-lms' ) . '">' . esc_html( get_the_title( $lesson_id ) ) . '</a>';
-		} // End If Statement
+		}
 
 		// Allow other plugins to filter html.
 		$html  = apply_filters( 'sensei_breadcrumb_output', $html, $separator );
 		$html .= '</section>';
 
 		echo wp_kses_post( $html );
-	} // End sensei_breadcrumb()
+	}
 
 	/**
 	 * Outputs the lesson tags.
@@ -733,9 +733,9 @@ class Sensei_Frontend {
 				// Nothing.
 				break;
 
-		} // End Switch Statement
+		}
 
-	} // End sensei_complete_lesson()
+	}
 
 	/**
 	 * Redirect to the next lesson, if applicable.
@@ -801,7 +801,7 @@ class Sensei_Frontend {
 						foreach ( $course_lesson_ids as $lesson_item_id ) {
 							// Mark lesson as complete.
 							$activity_logged = Sensei_Utils::sensei_start_lesson( $lesson_item_id, $current_user->ID, true );
-						} // End For Loop
+						}
 
 						// Update with final stats.
 						$course_metadata = array(
@@ -817,7 +817,7 @@ class Sensei_Frontend {
 							// translators: Placeholder is the Course title.
 							. sprintf( __( '%1$s marked as complete.', 'sensei-lms' ), get_the_title( $sanitized_course_id ) )
 							. '</div></header>';
-					} // End If Statement
+					}
 
 					break;
 
@@ -845,9 +845,9 @@ class Sensei_Frontend {
 				default:
 					// Nothing.
 					break;
-			} // End Switch Statement
-		} // End If Statement
-	} // End sensei_complete_course()
+			}
+		}
+	}
 
 	/**
 	 * Gets the quiz answers for the current user.
@@ -883,14 +883,14 @@ class Sensei_Frontend {
 		}
 
 		return $user_answers;
-	} // End sensei_get_user_quiz_answers()
+	}
 
 	/**
 	 * Outputs all notices.
 	 */
 	public function sensei_frontend_messages() {
 		Sensei()->notices->maybe_print_notices();
-	} // End sensei_frontend_messages()
+	}
 
 	/**
 	 * Outputs the video for a lesson.
@@ -903,7 +903,7 @@ class Sensei_Frontend {
 			if ( 'http' == substr( $lesson_video_embed, 0, 4 ) ) {
 				// V2 - make width and height a setting for video embed.
 				$lesson_video_embed = wp_oembed_get( esc_url( $lesson_video_embed ) );
-			} // End If Statement
+			}
 
 			$lesson_video_embed = do_shortcode( html_entity_decode( $lesson_video_embed ) );
 			$lesson_video_embed = Sensei_Wp_Kses::maybe_sanitize( $lesson_video_embed, $this->allowed_html );
@@ -912,9 +912,9 @@ class Sensei_Frontend {
 				?>
 				<div class="video"><?php echo wp_kses( $lesson_video_embed, $this->allowed_html ); ?></div>
 				<?php
-			} // End If Statement
-		} // End If Statement
-	} // End sensei_lesson_video()
+			}
+		}
+	}
 
 	/**
 	 * Outputs the "Complete Lesson" button.
@@ -952,8 +952,8 @@ class Sensei_Frontend {
 
 			</form>
 			<?php
-		} // End If Statement
-	} // End sensei_complete_lesson_button()
+		}
+	}
 
 	/**
 	 * Outputs the "Reset Lesson" button.
@@ -1001,7 +1001,7 @@ class Sensei_Frontend {
 
 		Sensei_Lesson::footer_quiz_call_to_action();
 
-	} // End sensei_lesson_quiz_meta()
+	}
 
 	public function sensei_course_archive_meta() {
 		// Meta data.
@@ -1026,7 +1026,7 @@ class Sensei_Frontend {
 					?>
 					<span class="course-author"><?php esc_html_e( 'by', 'sensei-lms' ); ?><?php the_author_link(); ?></span>
 					<?php
-				} // End If Statement
+				}
 				?>
 				<span class="course-lesson-count">
 					<?php
@@ -1044,7 +1044,7 @@ class Sensei_Frontend {
 					?>
 				</span>
 				<?php
-			} // End If Statement
+			}
 
 			/**
 			 * Fires after course meta is displayed.
@@ -1066,7 +1066,7 @@ class Sensei_Frontend {
 			<?php } ?>
 		</section>
 		<?php
-	} // End sensei_course_archive_meta()
+	}
 
 	public function sensei_course_category_main_content() {
 		global $post;
@@ -1088,7 +1088,7 @@ class Sensei_Frontend {
 
 					</article>
 
-				<?php } // End While Loop ?>
+				<?php }?>
 
 			</section>
 
@@ -1101,9 +1101,9 @@ class Sensei_Frontend {
 			</p>
 
 			<?php
-		} // End If Statement
+		}
 
-	} // End sensei_course_category_main_content()
+	}
 
 	public function sensei_login_form() {
 		/*
@@ -1177,7 +1177,7 @@ class Sensei_Frontend {
 		</div>
 
 		<?php
-	} // End sensei_login_form()
+	}
 
 	public function sensei_lesson_meta( $post_id = 0 ) {
 		if ( 0 < intval( $post_id ) ) {
@@ -1205,7 +1205,7 @@ class Sensei_Frontend {
 			<p class="lesson-excerpt"><?php the_excerpt(); ?></p>
 		</section>
 			<?php
-		} // End If Statement
+		}
 	} // sensei_lesson_meta()
 
 	public function sensei_lesson_preview_title_text( $course_id ) {
@@ -1305,9 +1305,9 @@ class Sensei_Frontend {
 
 					<?php
 				}
-			} // End If Statement
-		} // End If Statement
-	} // End sensei_course_start()
+			}
+		}
+	}
 
 	/**
 	 * Handle the frontend manual enrollment of a learner.
@@ -1345,12 +1345,12 @@ class Sensei_Frontend {
 		}
 
 		Sensei_WC::course_in_cart_message();
-	} // End sensei_woocommerce_in_cart_message()
+	}
 
 	// Deprecated.
 	public function sensei_lesson_comment_count( $count ) {
 		return $count;
-	} // End sensei_lesson_comment_count()
+	}
 
 	/**
 	 * Only show excerpts for lessons and courses in search results.
@@ -1371,7 +1371,7 @@ class Sensei_Frontend {
 		}
 
 		return $content;
-	} // End sensei_search_results_excerpt()
+	}
 
 	/**
 	 * Remove active course when an order is refunded or cancelled.
@@ -1407,7 +1407,7 @@ class Sensei_Frontend {
 		}
 
 		\Sensei_WC_Paid_Courses\Courses::instance()->activate_purchased_courses( $user_id );
-	} // End activate_purchased_courses()
+	}
 
 	/**
 	 * Activate single course if already purchases.
@@ -1423,7 +1423,7 @@ class Sensei_Frontend {
 		}
 
 		\Sensei_WC_Paid_Courses\Courses::instance()->activate_purchased_single_course();
-	} // End activate_purchased_single_course()
+	}
 
 	/**
 	 * Hide Sensei activity comments from frontend (requires WordPress 4.0+).
@@ -1438,7 +1438,7 @@ class Sensei_Frontend {
 		}
 
 		return $args;
-	} // End hide_sensei_activity()
+	}
 
 	/**
 	 * Redirect failed login attempts to the front end login page
@@ -1465,7 +1465,7 @@ class Sensei_Frontend {
 			wp_redirect( esc_url_raw( add_query_arg( 'login', 'failed', $referrer ) ) );
 			exit;
 		}
-	}//end sensei_login_fail_redirect()
+	}
 
 	/**
 	 * Handle the login reques from all sensei intiated login forms.
@@ -1549,13 +1549,13 @@ class Sensei_Frontend {
 					wp_redirect( esc_url_raw( $success_redirect_url ) );
 					exit;
 
-				}   // end is_wp_error($user)
+				}
 			} else { // if username or password is empty.
 
 				wp_redirect( esc_url_raw( add_query_arg( 'login', 'emptyfields', $referrer ) ) );
 				exit;
 
-			} // end if username $_REQUEST['log']  and password $_REQUEST['pwd'] is empty
+			}
 		} elseif ( ( isset( $_GET['login'] ) ) ) {
 			// else if this request is a redircect from a previously faile login request.
 			$this->login_message_process();
@@ -1567,7 +1567,7 @@ class Sensei_Frontend {
 		// if none of the above.
 		return;
 
-	} // End  sensei_login_fail_redirect_to_front_end_login
+	}
 
 	/**
 	 * Handles Sensei specific registration requests.
@@ -1669,7 +1669,7 @@ class Sensei_Frontend {
 		wp_redirect( apply_filters( 'sensei_registration_redirect', $redirect ) );
 		exit;
 
-	} // end  sensei_process_registration)()
+	}
 
 	/**
 	 * Displays an appropriate message for a failed login attempt.
@@ -1694,9 +1694,9 @@ class Sensei_Frontend {
 
 			Sensei()->notices->add_notice( $message, 'alert' );
 
-	}//end login_message_process()
+	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_Frontend

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -50,7 +50,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		// Actions
 		add_action( 'sensei_before_list_table', array( $this, 'data_table_header' ) );
 		add_action( 'sensei_after_list_table', array( $this, 'data_table_footer' ) );
-	} // End __construct()
+	}
 
 	/**
 	 * Define the columns that are going to be used in the table
@@ -106,7 +106,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		if ( ! empty( $_GET['orderby'] ) ) {
 			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
 				$orderby = esc_html( $_GET['orderby'] );
-			} // End If Statement
+			}
 		}
 
 		// Handle order
@@ -119,7 +119,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		$search = false;
 		if ( ! empty( $_GET['s'] ) ) {
 			$search = esc_html( $_GET['s'] );
-		} // End If Statement
+		}
 		$this->search = $search;
 
 		// Searching users on statuses requires sub-selecting the statuses by user_ids
@@ -135,7 +135,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 				// Store for reuse on counts
 				$this->user_ids = $learners_search->get_results();
 			}
-		} // End If Statement
+		}
 
 		$per_page = $this->get_items_per_page( 'sensei_comments_per_page' );
 		$per_page = apply_filters( 'sensei_comments_per_page', $per_page, 'sensei_comments' );
@@ -144,7 +144,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		$offset = 0;
 		if ( ! empty( $paged ) ) {
 			$offset = $per_page * ( $paged - 1 );
-		} // End If Statement
+		}
 
 		$activity_args = array(
 			'type'    => 'sensei_lesson_status',
@@ -190,7 +190,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 			default:
 				$activity_args['status'] = 'any';
 				break;
-		} // End switch
+		}
 
 		$activity_args = apply_filters( 'sensei_grading_filter_statuses', $activity_args );
 
@@ -354,7 +354,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 
 		esc_html_e( 'No submissions found.', 'sensei-lms' );
 
-	} // End no_items()
+	}
 
 	/**
 	 * Output for table heading
@@ -500,7 +500,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 			echo '</ul>' . "\n";
 		}
 
-	} // End data_table_header()
+	}
 
 	/**
 	 * Output for table footer
@@ -510,9 +510,9 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 	 */
 	public function data_table_footer() {
 		// Nothing right now
-	} // End data_table_footer()
+	}
 
-} // End Class
+}
 
 /**
  * Class WooThems_Sensei_Grading_Main

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -43,14 +43,14 @@ class Sensei_Grading {
 			add_action( 'admin_init', array( $this, 'admin_process_grading_submission' ) );
 
 			add_action( 'admin_notices', array( $this, 'add_grading_notices' ) );
-		} // End If Statement
+		}
 
 		// Ajax functions
 		if ( is_admin() ) {
 			add_action( 'wp_ajax_get_lessons_dropdown', array( $this, 'get_lessons_dropdown' ) );
 			add_action( 'wp_ajax_get_redirect_url', array( $this, 'get_redirect_url' ) );
-		} // End If Statement
-	} // End __construct()
+		}
+	}
 
 	/**
 	 * grading_admin_menu function.
@@ -64,7 +64,7 @@ class Sensei_Grading {
 			add_submenu_page( 'sensei', __( 'Grading', 'sensei-lms' ), __( 'Grading', 'sensei-lms' ), 'manage_sensei_grades', $this->page_slug, array( $this, 'grading_page' ) );
 		}
 
-	} // End grading_admin_menu()
+	}
 
 	/**
 	 * enqueue_scripts function.
@@ -79,7 +79,7 @@ class Sensei_Grading {
 		// Load Grading JS
 		Sensei()->assets->enqueue( 'sensei-grading-general', 'js/grading-general.js', [ 'jquery', 'sensei-core-select2' ] );
 
-	} // End enqueue_scripts()
+	}
 
 	/**
 	 * enqueue_styles function.
@@ -95,7 +95,7 @@ class Sensei_Grading {
 
 		Sensei()->assets->enqueue( 'sensei-settings-api', 'css/settings.css' );
 
-	} // End enqueue_styles()
+	}
 
 	/**
 	 * load_data_table_files loads required files for Grading
@@ -113,8 +113,8 @@ class Sensei_Grading {
 		);
 		foreach ( $classes_to_load as $class_file ) {
 			Sensei()->load_class( $class_file );
-		} // End For Loop
-	} // End load_data_table_files()
+		}
+	}
 
 	/**
 	 * load_data_object creates new instance of class
@@ -137,12 +137,12 @@ class Sensei_Grading {
 			$sensei_grading_object = new $object_name( $data );
 		} else {
 			$sensei_grading_object = new $object_name( $data, $optional_data );
-		} // End If Statement
+		}
 		if ( 'Main' == $name ) {
 			$sensei_grading_object->prepare_items();
-		} // End If Statement
+		}
 		return $sensei_grading_object;
-	} // End load_data_object()
+	}
 
 	/**
 	 * grading_page function.
@@ -157,8 +157,8 @@ class Sensei_Grading {
 			$this->grading_user_quiz_view();
 		} else {
 			$this->grading_default_view();
-		} // End If Statement
-	} // End grading_page()
+		}
+	}
 
 	/**
 	 * grading_default_view default view for grading page
@@ -215,7 +215,7 @@ class Sensei_Grading {
 		<?php
 		do_action( 'grading_wrapper_container', 'bottom' );
 		do_action( 'grading_after_container' );
-	} // End grading_default_view()
+	}
 
 	/**
 	 * grading_user_quiz_view user quiz answers view for grading page
@@ -255,7 +255,7 @@ class Sensei_Grading {
 		<?php
 		do_action( 'grading_wrapper_container', 'bottom' );
 		do_action( 'grading_after_container' );
-	} // End grading_user_quiz_view()
+	}
 
 	/**
 	 * Outputs Grading general headers
@@ -269,7 +269,7 @@ class Sensei_Grading {
 		$function = 'grading_' . $args['nav'] . '_nav';
 		$this->$function();
 		do_action( 'sensei_grading_after_headers' );
-	} // End grading_headers()
+	}
 
 	/**
 	 * wrapper_container wrapper for Grading area
@@ -287,8 +287,8 @@ class Sensei_Grading {
 			?>
 			</div><!--/#woothemes-sensei-->
 			<?php
-		} // End If Statement
-	} // End wrapper_container()
+		}
+	}
 
 	/**
 	 * Default nav area for Grading
@@ -319,11 +319,11 @@ class Sensei_Grading {
 			$user_name = Sensei_Learner::get_full_name( $_GET['user_id'] );
 			$title    .= '&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;' . esc_html( $user_name ) . '</span>';
 
-		} // End If Statement
+		}
 		?>
 			<h1><?php echo wp_kses_post( apply_filters( 'sensei_grading_nav_title', $title ) ); ?></h1>
 		<?php
-	} // End grading_default_nav()
+	}
 
 	/**
 	 * Nav area for Grading specific users' quiz answers
@@ -366,11 +366,11 @@ class Sensei_Grading {
 			$user_name = Sensei_Learner::get_full_name( $_GET['user'] );
 			$title    .= '&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;' . esc_html( $user_name ) . '</span>';
 
-		} // End If Statement
+		}
 		?>
 			<h2><?php echo wp_kses_post( apply_filters( 'sensei_grading_nav_title', $title ) ); ?></h2>
 		<?php
-	} // End grading_user_quiz_nav()
+	}
 
 	/**
 	 * Return array of valid statuses for either Course or Lesson
@@ -485,7 +485,7 @@ class Sensei_Grading {
 		}
 
 		return apply_filters( 'sensei_count_statuses', $counts, $type );
-	} // End sensei_count_statuses()
+	}
 
 	/**
 	 * Build the Courses dropdown for return in AJAX
@@ -512,11 +512,11 @@ class Sensei_Grading {
 		if ( count( $courses ) > 0 ) {
 			foreach ( $courses as $course_id ) {
 				$html .= '<option value="' . esc_attr( absint( $course_id ) ) . '" ' . selected( $course_id, $selected_course_id, false ) . '>' . esc_html( get_the_title( $course_id ) ) . '</option>' . "\n";
-			} // End For Loop
-		} // End If Statement
+			}
+		}
 
 		return $html;
-	} // End lessons_drop_down_html()
+	}
 
 	/**
 	 * Build the Lessons dropdown for return in AJAX
@@ -603,12 +603,12 @@ class Sensei_Grading {
 			if ( count( $lessons ) > 0 ) {
 				foreach ( $lessons as $lesson_id ) {
 					$html .= '<option value="' . esc_attr( absint( $lesson_id ) ) . '" ' . selected( $lesson_id, $selected_lesson_id, false ) . '>' . esc_html( get_the_title( $lesson_id ) ) . '</option>' . "\n";
-				} // End For Loop
-			} // End If Statement
-		} // End If Statement
+				}
+			}
+		}
 
 		return $html;
-	} // End lessons_drop_down_html()
+	}
 
 	/**
 	 * The process grading function handles admin grading submissions.
@@ -668,7 +668,7 @@ class Sensei_Grading {
 			}
 			$all_answers_feedback[ $question_id ] = $question_feedback;
 
-		} // end for each $questions
+		}
 
 		// store all question grades on the lesson status
 		Sensei()->quiz->set_user_grades( $all_question_grades, $quiz_lesson_id, $user_id );
@@ -694,7 +694,7 @@ class Sensei_Grading {
 					$lesson_status = 'passed';
 				} else {
 					$lesson_status = 'failed';
-				} // End If Statement
+				}
 			}
 			// Student only has to partake the quiz
 			else {
@@ -718,12 +718,12 @@ class Sensei_Grading {
 				 */
 				do_action( 'sensei_user_lesson_end', $user_id, $quiz_lesson_id );
 
-			} // end if in_array
+			}
 		} else {
 			// Set to ungraded status if only a partial grading was saved.
 			Sensei_Utils::update_lesson_status( $user_id, $quiz_lesson_id, 'ungraded' );
 
-		} // end if $_POST['all_que...
+		}
 
 		if ( isset( $_POST['sensei_grade_next_learner'] ) && strlen( $_POST['sensei_grade_next_learner'] ) > 0 ) {
 
@@ -742,7 +742,7 @@ class Sensei_Grading {
 		wp_safe_redirect( esc_url_raw( $load_url ) );
 		exit;
 
-	} // end admin_process_grading_submission
+	}
 
 	public function get_redirect_url() {
 		if ( ! isset( $_GET['course_id'] ) || ! isset( $_GET['lesson_id'] ) ) {
@@ -843,8 +843,8 @@ class Sensei_Grading {
 			echo '<div class="grading-notice updated">';
 				echo '<p>' . esc_html__( 'Quiz Graded Successfully!', 'sensei-lms' ) . '</p>';
 			echo '</div>';
-		} // End If Statement
-	} // End sensei_grading_notices()
+		}
+	}
 
 	/**
 	 * Grade quiz automatically
@@ -909,8 +909,8 @@ class Sensei_Grading {
 				// There is a question that cannot be autograded
 				$quiz_autogradable = false;
 
-			} // end if in_array( $question_type...
-		}// end for each question
+			}
+		}
 
 		// Only if the whole quiz was autogradable do we set a grade
 		if ( $quiz_autogradable ) {
@@ -930,7 +930,7 @@ class Sensei_Grading {
 
 		return $grade;
 
-	} // End grade_quiz_auto()
+	}
 
 	/**
 	 * Grade question automatically
@@ -1021,10 +1021,10 @@ class Sensei_Grading {
 			 */
 			$question_grade = (int) apply_filters( 'sensei_grade_question_auto', $question_grade, $question_id, $question_type, $answer );
 
-		} // end if $question_type
+		}
 
 		return $question_grade;
-	} // end grade_question_auto
+	}
 
 	/**
 	 * Grading logic specifically for the gap fill questions
@@ -1162,7 +1162,7 @@ class Sensei_Grading {
 
 		return $sum_of_all_grades;
 
-	}//end get_lessons_users_grades_sum()
+	}
 
 	/**
 	 * Get the sum of all user grades for the given course.
@@ -1187,9 +1187,9 @@ class Sensei_Grading {
 
 		return $sum_of_all_grades;
 
-	}//end get_course_users_grades_sum()
+	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_Grading

--- a/includes/class-sensei-learner-profiles.php
+++ b/includes/class-sensei-learner-profiles.php
@@ -39,7 +39,7 @@ class Sensei_Learner_Profiles {
 
 		// Add class to body tag
 		add_filter( 'body_class', array( $this, 'learner_profile_body_class' ), 10, 1 );
-	} // End __construct().
+	}
 
 	/**
 	 * Enqueue frontend JavaScripts.
@@ -254,7 +254,7 @@ class Sensei_Learner_Profiles {
 		return $classes;
 	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_Learner_Profiles

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -137,11 +137,11 @@ class Sensei_Lesson {
 			// Frontend actions
 			// Starts lesson when the student visits for the first time and prerequisite courses have been met.
 			add_action( 'sensei_single_lesson_content_inside_before', array( __CLASS__, 'maybe_start_lesson' ) );
-		} // End If Statement
+		}
 
 		// Log event on the initial publish for a lesson.
 		add_action( 'sensei_lesson_initial_publish', [ $this, 'log_initial_publish_event' ] );
-	} // End __construct()
+	}
 
 	/**
 	 * Adds a link for editing the lesson's course if it belongs to a course.
@@ -226,7 +226,7 @@ class Sensei_Lesson {
 		// Add CSS
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 
-	} // End meta_box_setup()
+	}
 
 	/**
 	 * lesson_info_meta_box_content function.
@@ -254,7 +254,7 @@ class Sensei_Lesson {
 			$html .= '<option value="">' . esc_html__( 'None', 'sensei-lms' ) . '</option>';
 		foreach ( $complexity_array as $key => $value ) {
 			$html .= '<option value="' . esc_attr( $key ) . '"' . selected( $key, $lesson_complexity, false ) . '>' . esc_html( $value ) . '</option>' . "\n";
-		} // End For Loop
+		}
 		$html .= '</select></p>' . "\n";
 
 		$html .= '<p><label for="lesson_video_embed">' . esc_html__( 'Video Embed Code', 'sensei-lms' ) . ':</label><br/>' . "\n";
@@ -331,11 +331,11 @@ class Sensei_Lesson {
 			$html .= '<option value="">' . esc_html__( 'None', 'sensei-lms' ) . '</option>';
 			foreach ( $posts_array as $post_item ) {
 				$html .= '<option value="' . esc_attr( absint( $post_item->ID ) ) . '"' . selected( $post_item->ID, $select_lesson_prerequisite, false ) . '>' . esc_html( $post_item->post_title ) . '</option>' . "\n";
-			} // End For Loop
+			}
 			$html .= '</select>' . "\n";
 		} else {
 			$html .= '<p>' . esc_html__( 'No lessons exist yet. Please add some first.', 'sensei-lms' ) . '</p>';
-		} // End If Statement
+		}
 
 		echo wp_kses(
 			$html,
@@ -361,7 +361,7 @@ class Sensei_Lesson {
 				)
 			)
 		);
-	} // End lesson_prerequisite_meta_box_content()
+	}
 
 	/**
 	 * lesson_preview_meta_box_content function.
@@ -379,7 +379,7 @@ class Sensei_Lesson {
 		$checked = '';
 		if ( isset( $lesson_preview ) && ( '' != $lesson_preview ) ) {
 			$checked = checked( 'preview', $lesson_preview, false );
-		} // End If Statement
+		}
 
 		$html .= '<label for="lesson_preview">';
 		$html .= '<input type="checkbox" id="lesson_preview" name="lesson_preview" value="preview" ' . $checked . '>&nbsp;' . esc_html__( 'Allow this lesson to be viewed without login', 'sensei-lms' ) . '<br>';
@@ -403,7 +403,7 @@ class Sensei_Lesson {
 				)
 			)
 		);
-	} // End lesson_preview_meta_box_content()
+	}
 
 	/**
 	 * meta_box_save function.
@@ -417,13 +417,13 @@ class Sensei_Lesson {
 		// Verify the nonce before proceeding.
 		if ( ( get_post_type( $post_id ) != $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( $_POST[ 'woo_' . $this->token . '_nonce' ], 'sensei-save-post-meta' ) ) {
 			return $post_id;
-		} // End If Statement
+		}
 		// Get the post type object.
 		$post_type = get_post_type_object( get_post_type( $post_id ) );
 		// Check if the current user has permission to edit the post.
 		if ( ! current_user_can( $post_type->cap->edit_post, $post_id ) ) {
 			return $post_id;
-		} // End If Statement
+		}
 
 		// Check if the current post type is a page
 		if ( 'page' == $_POST['post_type'] ) {
@@ -432,12 +432,12 @@ class Sensei_Lesson {
 
 				return $post_id;
 
-			} // End If Statement
+			}
 		} else {
 			if ( ! current_user_can( 'edit_post', $post_id ) ) {
 				return $post_id;
-			} // End If Statement
-		} // End If Statement
+			}
+		}
 
 		// Save the post meta data fields
 		if ( isset( $this->meta_fields ) && is_array( $this->meta_fields ) ) {
@@ -447,9 +447,9 @@ class Sensei_Lesson {
 				remove_action( 'save_post', array( $this, 'meta_box_save' ) );
 				$this->save_post_meta( $meta_key, $post_id );
 
-			} // End For Loop
-		} // End If Statement
-	} // End meta_box_save()
+			}
+		}
+	}
 
 	/**
 	 * When course lessons are being ordered by the user,
@@ -530,8 +530,8 @@ class Sensei_Lesson {
 				return $post->ID;
 			} else {
 				return false;
-			} // End If Statement
-		} // End If Statement
+			}
+		}
 
 		if ( wp_is_post_revision( $post_id ) || wp_is_post_autosave( $post_id ) ) {
 			return false;
@@ -550,7 +550,7 @@ class Sensei_Lesson {
 
 		if ( isset( $_POST['quiz_id'] ) && ( 0 < absint( $_POST['quiz_id'] ) ) ) {
 			$quiz_id = absint( $_POST['quiz_id'] );
-		} // End If Statement
+		}
 		$post_title   = esc_html( $lesson->post_title );
 		$post_status  = esc_html( $lesson->post_status );
 		$post_content = '';
@@ -616,7 +616,7 @@ class Sensei_Lesson {
 
 			// Set the post terms for quiz-type
 			wp_set_post_terms( $quiz_id, array( 'multiple-choice' ), 'quiz-type' );
-		} // End If Statement
+		}
 
 		// Add default lesson order meta value
 		$course_id = get_post_meta( $post_id, '_lesson_course', true );
@@ -638,7 +638,7 @@ class Sensei_Lesson {
 		// Restore the previously disabled filter
 		add_action( 'save_post', array( $this, 'quiz_update' ) );
 
-	} // End post_updated()
+	}
 
 	/**
 	 * Get setting value from POST data.
@@ -720,7 +720,7 @@ class Sensei_Lesson {
 		} else {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$new_meta_value = ( isset( $_POST[ $post_key ] ) ? sanitize_html_class( $_POST[ $post_key ] ) : '' );
-		} // End If Statement
+		}
 
 		// quick edit work around
 		// phpcs:ignore WordPress.Security.NonceVerification
@@ -738,7 +738,7 @@ class Sensei_Lesson {
 			return update_post_meta( $post_id, $meta_key, $new_meta_value );
 		}
 
-	} // End save_post_meta()
+	}
 
 	/**
 	 * lesson_course_meta_box_content function.
@@ -752,11 +752,11 @@ class Sensei_Lesson {
 		$selected_lesson_course = 0;
 		if ( 0 < $post->ID ) {
 			$selected_lesson_course = get_post_meta( $post->ID, '_lesson_course', true );
-		} // End If Statement
+		}
 		// Handle preselected course
 		if ( isset( $_GET['course_id'] ) && ( 0 < absint( $_GET['course_id'] ) ) ) {
 			$selected_lesson_course = absint( $_GET['course_id'] );
-		} // End If Statement
+		}
 		// Get the Lesson Posts
 		$post_args   = array(
 			'post_type'        => 'course',
@@ -829,7 +829,7 @@ class Sensei_Lesson {
 				)
 			)
 		);
-	} // End lesson_course_meta_box_content()
+	}
 
 	public function quiz_panel( $quiz_id = 0 ) {
 		$html  = wp_nonce_field( 'sensei-save-post-meta', 'woo_' . $this->token . '_nonce', true, false );
@@ -846,7 +846,7 @@ class Sensei_Lesson {
 			$quiz_class = '';
 		if ( 0 == $quiz_id ) {
 			$quiz_class = 'hidden';
-		} // End If Statement
+		}
 			// Build the HTML to Output
 			$message_class = '';
 
@@ -854,7 +854,7 @@ class Sensei_Lesson {
 			$questions = array();
 		if ( 0 < $quiz_id ) {
 			$questions = $this->lesson_quiz_questions( $quiz_id );
-		} // End If Statement
+		}
 
 			$question_count = 0;
 		foreach ( $questions as $question ) {
@@ -878,7 +878,7 @@ class Sensei_Lesson {
 			$html     .= '<p class="save-note">';
 				$html .= esc_html__( 'Please save your lesson in order to add questions to your quiz.', 'sensei-lms' );
 			$html     .= '</p>';
-		} // End If Statement
+		}
 
 			$html .= '</div>';
 
@@ -1035,7 +1035,7 @@ class Sensei_Lesson {
 				if ( isset( $this->question_order ) && strlen( $this->question_order ) > 0 ) {
 					$this->question_order .= ','; }
 				$this->question_order .= $question_id;
-			} // End For Loop
+			}
 		}
 
 		return $html;
@@ -1297,7 +1297,7 @@ class Sensei_Lesson {
 						$html .= '<select id="add-question-type-options" name="question_type" class="chosen_select widefat question-type-select">' . "\n";
 		foreach ( $question_types as $type => $label ) {
 			$html .= '<option value="' . esc_attr( $type ) . '">' . esc_html( $label ) . '</option>' . "\n";
-		} // End For Loop
+		}
 						$html .= '</select></p>' . "\n";
 
 						// Question category
@@ -1308,7 +1308,7 @@ class Sensei_Lesson {
 				$html .= '<option value="">' . esc_html__( 'None', 'sensei-lms' ) . '</option>' . "\n";
 				foreach ( $question_cats as $cat ) {
 					$html .= '<option value="' . esc_attr( $cat->term_id ) . '">' . esc_html( $cat->name ) . '</option>';
-				} // End For Loop
+				}
 				$html .= '</select></p>' . "\n";
 			}
 		}
@@ -1434,7 +1434,7 @@ class Sensei_Lesson {
 					$html .= '<option value="">' . esc_html__( 'Select a Question Category', 'sensei-lms' ) . '</option>' . "\n";
 				foreach ( $question_cats as $cat ) {
 					$html .= '<option value="' . esc_attr( $cat->term_id ) . '">' . esc_html( $cat->name ) . '</option>';
-				} // End For Loop
+				}
 					$html .= '</select></p>' . "\n";
 
 					$html .= '<p>' . esc_html__( 'Number of questions:', 'sensei-lms' ) . ' <input type="number" min="1" value="1" max="1" id="add-multiple-question-count" class="small-text"/>';
@@ -1603,11 +1603,11 @@ class Sensei_Lesson {
 		if ( isset( $_POST['filter_existing_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$nonce = esc_html( $_POST['filter_existing_questions_nonce'] );
-		} // End If Statement
+		}
 
 		if ( ! wp_verify_nonce( $nonce, 'filter_existing_questions_nonce' ) ) {
 			die( '' );
-		} // End If Statement
+		}
 
 		// Parse POST data
 		$data          = $_POST['data'];
@@ -1741,7 +1741,7 @@ class Sensei_Lesson {
 							$answers[] = $wrong_answer;
 
 						}
-					} // end for each
+					}
 
 					$answers_sorted = $answers;
 					if ( $question_id && count( $answer_order ) > 0 ) {
@@ -1904,7 +1904,7 @@ class Sensei_Lesson {
 
 			$field_name = 'answer_feedback_multiple_choice';
 
-		}// end if
+		}
 
 		if ( $question_counter ) {
 			$field_name = 'answer_' . esc_attr( $question_counter ) . '_feedback';
@@ -2010,7 +2010,7 @@ class Sensei_Lesson {
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is escaped in the method.
 		echo $this->quiz_panel( $quiz_id );
 
-	} // End lesson_quiz_meta_box_content()
+	}
 
 	/**
 	 * Quiz settings metabox
@@ -2340,7 +2340,7 @@ class Sensei_Lesson {
 			}
 		}
 
-	} // End enqueue_styles()
+	}
 
 	/**
 	 * Add column headings to the "lesson" post list screen,
@@ -2400,7 +2400,7 @@ class Sensei_Lesson {
 				if ( 0 < absint( $lesson_course_id ) ) {
 					// translators: Placeholder is the course title.
 					echo '<a href="' . esc_url( get_edit_post_link( absint( $lesson_course_id ) ) ) . '" title="' . esc_attr( sprintf( __( 'Edit %s', 'sensei-lms' ), get_the_title( absint( $lesson_course_id ) ) ) ) . '">' . esc_html( get_the_title( absint( $lesson_course_id ) ) ) . '</a>';
-				} // End If Statement
+				}
 				break;
 			case 'lesson-prerequisite':
 				$lesson_prerequisite_id = get_post_meta( $id, '_lesson_prerequisite', true );
@@ -2409,12 +2409,12 @@ class Sensei_Lesson {
 					// translators: Placeholder is the title of the prerequisite lesson.
 					echo '<a href="' . esc_url( get_edit_post_link( absint( $lesson_prerequisite_id ) ) ) . '" title="' . esc_attr( sprintf( __( 'Edit %s', 'sensei-lms' ), get_the_title( absint( $lesson_prerequisite_id ) ) ) ) . '">' . esc_html( get_the_title( absint( $lesson_prerequisite_id ) ) ) . '</a>';
 					_post_states( $lesson_prerequisite_post );
-				} // End If Statement
+				}
 				break;
 			default:
 				break;
-		} // End Switch Statement
-	} // End add_column_data()
+		}
+	}
 
 	/**
 	 * Add a course from the lesson page.
@@ -2430,11 +2430,11 @@ class Sensei_Lesson {
 		if ( isset( $_POST['lesson_add_course_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$nonce = esc_html( $_POST['lesson_add_course_nonce'] );
-		} // End If Statement
+		}
 		if ( ! wp_verify_nonce( $nonce, 'lesson_add_course_nonce' )
 			|| ! current_user_can( 'edit_lessons' ) ) {
 			die( '' );
-		} // End If Statement
+		}
 		// Parse POST data
 		$data        = $_POST['data'];
 		$course_data = array();
@@ -2469,7 +2469,7 @@ class Sensei_Lesson {
 
 		echo esc_html( $updated );
 		die(); // WordPress may print out a spurious zero without this can be particularly bad if using JSON
-	} // End lesson_add_course()
+	}
 
 	/**
 	 * Whether user can edit quiz.
@@ -2494,13 +2494,13 @@ class Sensei_Lesson {
 		if ( isset( $_POST['lesson_update_question_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$nonce = esc_html( $_POST['lesson_update_question_nonce'] );
-		} // End If Statement
+		}
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_nonce' )
 			|| ! current_user_can( 'edit_questions' ) ) {
 
 			die( '' );
 
-		} // End If Statement
+		}
 
 		// Parse POST data
 		// WP slashes all incoming data regardless of Magic Quotes setting (see wp_magic_quotes()), which means that
@@ -2539,14 +2539,14 @@ class Sensei_Lesson {
 				++$question_count;
 
 				$return = $this->quiz_panel_question( $question_type, $question_count, $question_id );
-			} // End If Statement
-		} // End If Statement
+			}
+		}
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in methods that generate `$return`.
 		echo $return;
 
 		die();
-	} // End lesson_update_question()
+	}
 
 	public function lesson_add_multiple_questions() {
 
@@ -2557,12 +2557,12 @@ class Sensei_Lesson {
 		if ( isset( $_POST['lesson_add_multiple_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$nonce = esc_html( $_POST['lesson_add_multiple_questions_nonce'] );
-		} // End If Statement
+		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_add_multiple_questions_nonce' )
 			|| ! current_user_can( 'edit_lessons' ) ) {
 			die( esc_html( $return ) );
-		} // End If Statement
+		}
 
 		// Parse POST data
 		$data          = $_POST['data'];
@@ -2616,12 +2616,12 @@ class Sensei_Lesson {
 		if ( isset( $_POST['lesson_remove_multiple_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$nonce = esc_html( $_POST['lesson_remove_multiple_questions_nonce'] );
-		} // End If Statement
+		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_remove_multiple_questions_nonce' )
 		|| ! current_user_can( 'edit_lessons' ) || ! isset( $_POST['data'] ) ) {
 			die( '' );
-		} // End If Statement
+		}
 
 		// Parse POST data
 		$question_data = array();
@@ -2715,12 +2715,12 @@ class Sensei_Lesson {
 		if ( isset( $_POST['lesson_add_existing_questions_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$nonce = esc_html( $_POST['lesson_add_existing_questions_nonce'] );
-		} // End If Statement
+		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_add_existing_questions_nonce' )
 		|| ! current_user_can( 'edit_lessons' ) ) {
 			die( '' );
-		} // End If Statement
+		}
 
 		// Parse POST data
 		$data          = $_POST['data'];
@@ -2780,14 +2780,14 @@ class Sensei_Lesson {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$nonce = esc_html( $_POST['lesson_update_grade_type_nonce'] );
 
-		} // End If Statement
+		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_grade_type_nonce' )
 		|| ! current_user_can( 'edit_lessons' ) ) {
 
 			die( '' );
 
-		} // End If Statement
+		}
 
 		// Parse POST data
 		$data      = $_POST['data'];
@@ -2802,12 +2802,12 @@ class Sensei_Lesson {
 		if ( isset( $_POST['lesson_update_question_order_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$nonce = esc_html( $_POST['lesson_update_question_order_nonce'] );
-		} // End If Statement
+		}
 
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_order_nonce' )
 			|| ! current_user_can( 'edit_lessons' ) ) {
 			die( '' );
-		} // End If Statement
+		}
 
 		// Parse POST data
 		$data      = $_POST['data'];
@@ -2835,13 +2835,13 @@ class Sensei_Lesson {
 		if ( isset( $_POST['lesson_update_question_order_random_nonce'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
 			$nonce = esc_html( $_POST['lesson_update_question_order_random_nonce'] );
-		} // End If Statement
+		}
 		if ( ! wp_verify_nonce( $nonce, 'lesson_update_question_order_random_nonce' )
 			|| ! current_user_can( 'edit_lessons' ) ) {
 
 			die( '' );
 
-		} // End If Statement
+		}
 		// Parse POST data
 		$data      = $_POST['data'];
 		$quiz_data = array();
@@ -2868,16 +2868,16 @@ class Sensei_Lesson {
 		$course_title   = '';
 		if ( isset( $data['course_id'] ) && ( 0 < absint( $data['course_id'] ) ) ) {
 			$course_id = absint( $data['course_id'] );
-		} // End If Statement
+		}
 		if ( isset( $data['course_title'] ) && ( '' !== $data['course_title'] ) ) {
 			$course_title = $data['course_title'];
-		} // End If Statement
+		}
 		$post_title  = $course_title;
 		$post_status = 'publish';
 		$post_type   = 'course';
 		if ( isset( $data['course_content'] ) && ( '' !== $data['course_content'] ) ) {
 			$course_content = $data['course_content'];
-		} // End If Statement
+		}
 		$post_content = $course_content;
 		// Course Query Arguments.
 		$post_type_args = array(
@@ -2908,14 +2908,14 @@ class Sensei_Lesson {
 
 			if ( 0 < $course_category_id ) {
 				wp_set_object_terms( $course_id, $course_category_id, 'course-category' );
-			} // End If Statement.
-		} // End If Statement.
+			}
+		}
 		// Check that the insert or update saved by testing the post id.
 		if ( 0 < $course_id ) {
 			$return = $course_id;
-		} // End If Statement.
+		}
 		return $return;
-	} // End lesson_save_course().
+	}
 
 	/**
 	 * lesson_save_question function.
@@ -2938,61 +2938,61 @@ class Sensei_Lesson {
 		// Handle Question Type
 		if ( isset( $data['question_type'] ) && ( '' != $data['question_type'] ) ) {
 			$question_type = $data['question_type'];
-		} // End If Statement
+		}
 
 		if ( isset( $data['question_category'] ) && ( '' != $data['question_category'] ) ) {
 			$question_category = $data['question_category'];
-		} // End If Statement
+		}
 
 		if ( isset( $data['question_id'] ) && ( 0 < absint( $data['question_id'] ) ) ) {
 			$question_id = absint( $data['question_id'] );
-		} // End If Statement
+		}
 		if ( isset( $data['question'] ) && ( '' != $data['question'] ) ) {
 			$question_text = $data['question'];
-		} // End If Statement
+		}
 		$post_title = $question_text;
 		// Handle Default Fields (multiple choice)
 		if ( 'multiple-choice' == $question_type && isset( $data['question_right_answers'] ) && ( '' != $data['question_right_answers'] ) ) {
 			$question_right_answers = $data['question_right_answers'];
-		} // End If Statement
+		}
 		elseif ( 'multiple-choice' == $question_type && isset( $data['question_right_answer'] ) && ( '' != $data['question_right_answer'] ) ) {
 			$question_right_answer = $data['question_right_answer'];
-		} // End If Statement
+		}
 		if ( 'multiple-choice' == $question_type && isset( $data['question_wrong_answers'] ) && ( '' != $data['question_wrong_answers'] ) ) {
 			$question_wrong_answers = $data['question_wrong_answers'];
-		} // End If Statement
+		}
 		// Handle Boolean Fields - Edit
 		if ( 'boolean' == $question_type && isset( $data[ 'question_' . $question_id . '_right_answer_boolean' ] ) && ( '' != $data[ 'question_' . $question_id . '_right_answer_boolean' ] ) ) {
 			$question_right_answer = $data[ 'question_' . $question_id . '_right_answer_boolean' ];
-		} // End If Statement
+		}
 		// Handle Boolean Fields - Add
 		if ( 'boolean' == $question_type && isset( $data['question_right_answer_boolean'] ) && ( '' != $data['question_right_answer_boolean'] ) ) {
 			$question_right_answer = $data['question_right_answer_boolean'];
-		} // End If Statement
+		}
 		// Handle Gap Fill Fields
 		if ( 'gap-fill' == $question_type && isset( $data['add_question_right_answer_gapfill_gap'] ) && '' != $data['add_question_right_answer_gapfill_gap'] ) {
 			$question_right_answer = $data['add_question_right_answer_gapfill_pre'] . '||' . $data['add_question_right_answer_gapfill_gap'] . '||' . $data['add_question_right_answer_gapfill_post'];
-		} // End If Statement
+		}
 		// Handle Multi Line Fields
 		if ( 'multi-line' == $question_type && isset( $data['add_question_right_answer_multiline'] ) && ( '' != $data['add_question_right_answer_multiline'] ) ) {
 			$question_right_answer = $data['add_question_right_answer_multiline'];
-		} // End If Statement
+		}
 		// Handle Single Line Fields
 		if ( 'single-line' == $question_type && isset( $data['add_question_right_answer_singleline'] ) && ( '' != $data['add_question_right_answer_singleline'] ) ) {
 			$question_right_answer = $data['add_question_right_answer_singleline'];
-		} // End If Statement
+		}
 		// Handle File Upload Fields
 		if ( 'file-upload' == $question_type && isset( $data['add_question_right_answer_fileupload'] ) && ( '' != $data['add_question_right_answer_fileupload'] ) ) {
 			$question_right_answer = $data['add_question_right_answer_fileupload'];
-		} // End If Statement
+		}
 		if ( 'file-upload' == $question_type && isset( $data['add_question_wrong_answer_fileupload'] ) && ( '' != $data['add_question_wrong_answer_fileupload'] ) ) {
 			$question_wrong_answers = array( $data['add_question_wrong_answer_fileupload'] );
-		} // End If Statement
+		}
 
 		// Handle Question Grade
 		if ( isset( $data['question_grade'] ) && ( '' != $data['question_grade'] ) ) {
 			$question_grade = $data['question_grade'];
-		} // End If Statement
+		}
 
 		// Handle Answer Feedback
 		$answer_feedback = '';
@@ -3008,7 +3008,7 @@ class Sensei_Lesson {
 
 			$answer_feedback = $data['answer_feedback'];
 
-		} // End If Statement
+		}
 
 		$post_title  = $question_text;
 		$post_status = 'publish';
@@ -3040,7 +3040,7 @@ class Sensei_Lesson {
 			if ( 0 < count( $question_right_answers ) ) {
 				$question_right_answer = $question_right_answers;
 			}
-		} // End If Statement
+		}
 
 		$right_answer_count = is_array( $question_right_answer ) ? count( $question_right_answer ) : 1;
 
@@ -3048,7 +3048,7 @@ class Sensei_Lesson {
 		if ( is_array( $question_wrong_answers ) ) {
 			$question_wrong_answers_array = array_values( array_filter( $question_wrong_answers, 'strlen' ) );
 			$question_wrong_answers       = array();
-		} // End If Statement
+		}
 
 		foreach ( $question_wrong_answers_array as $answer ) {
 			if ( ! in_array( $answer, $question_wrong_answers ) ) {
@@ -3140,14 +3140,14 @@ class Sensei_Lesson {
 				if ( $question_category ) {
 					wp_set_post_terms( $question_id, array( $question_category ), 'question-category' );
 				}
-			} // End If Statement
-		} // End If Statement
+			}
+		}
 		// Check that the insert or update saved by testing the post id
 		if ( 0 < $question_id ) {
 			$return = $question_id;
-		} // End If Statement
+		}
 		return $return;
-	} // End lesson_question_save()
+	}
 
 
 	/**
@@ -3163,7 +3163,7 @@ class Sensei_Lesson {
 		$question_id = 0;
 		if ( isset( $data['question_id'] ) && ( 0 < absint( $data['question_id'] ) ) ) {
 			$question_id = absint( $data['question_id'] );
-		} // End If Statement
+		}
 
 		if ( empty( $question_id ) ) {
 			return false;
@@ -3200,7 +3200,7 @@ class Sensei_Lesson {
 
 		return $lesson_complexities;
 
-	} // End lesson_complexities
+	}
 
 
 	/**
@@ -3244,7 +3244,7 @@ class Sensei_Lesson {
 		$lessons_query = new WP_Query( apply_filters( 'sensei_lesson_count', $post_args ) );
 
 		return count( $lessons_query->posts );
-	} // End lesson_count()
+	}
 
 
 	/**
@@ -3538,7 +3538,7 @@ class Sensei_Lesson {
 
 					return '';
 
-				} // End If Statement
+				}
 
 				$image_thumb_size = 'lesson_single_image';
 				$dimensions       = Sensei()->get_image_size( $image_thumb_size );
@@ -3549,14 +3549,14 @@ class Sensei_Lesson {
 				if ( ! $widget && ! Sensei()->settings->settings['course_lesson_image_enable'] ) {
 
 					return '';
-				} // End If Statement
+				}
 
 				$image_thumb_size = 'lesson_archive_image';
 				$dimensions       = Sensei()->get_image_size( $image_thumb_size );
 				$width            = $dimensions['width'];
 				$height           = $dimensions['height'];
-			} // End If Statement
-		} // End If Statement
+			}
+		}
 
 		$img_element = '';
 
@@ -3579,8 +3579,8 @@ class Sensei_Lesson {
 				 */
 				$img_element = apply_filters( 'sensei_lesson_placeholder_image_url', '<img src="http://placehold.it/' . esc_url( $width ) . 'x' . esc_url( $height ) . '" class="woo-image thumbnail alignleft" />' );
 
-			} // End If Statement
-		} // End If Statement
+			}
+		}
 
 		if ( is_singular( 'lesson' ) ) {
 
@@ -3666,7 +3666,7 @@ class Sensei_Lesson {
 
 		return $lesson_course_id;
 
-	}//end get_course_id()
+	}
 
 	/**
 	 * Add the admin all lessons screen edit options.
@@ -3801,7 +3801,7 @@ class Sensei_Lesson {
 			</div>
 		</fieldset>
 		<?php
-	}//end all_lessons_edit_fields()
+	}
 
 	/**
 	 * Create the html for the edit field
@@ -3914,12 +3914,12 @@ class Sensei_Lesson {
 					unset( $checked );
 
 				}
-			} // end if quiz
-		}// end for each
+			}
+		}
 
 		die();
 
-	} // end save_all_lessons_edit_fields
+	}
 
 	/**
 	 * Loading the quick edit fields defaults.
@@ -3955,7 +3955,7 @@ class Sensei_Lesson {
 
 		wp_localize_script( 'sensei-lesson-quick-edit', 'sensei_quick_edit_' . $post_id, $data );
 
-	}//end set_quick_edit_admin_defaults()
+	}
 
 	/**
 	 * Filter the classes for lessons on the single course page.
@@ -3980,8 +3980,8 @@ class Sensei_Lesson {
 
 				$lesson_classes[] = 'completed';
 
-			} // End If Statement
-		} // End If Statement
+			}
+		}
 
 		$is_user_taking_course = Sensei_Course::is_user_enrolled( $course_id );
 		if ( Sensei_Utils::is_preview_lesson( get_the_ID() ) && ! $is_user_taking_course ) {
@@ -3992,7 +3992,7 @@ class Sensei_Lesson {
 
 		return array_merge( $classes, $lesson_classes );
 
-	}//end single_course_lessons_classes()
+	}
 
 	/**
 	 * Output the lesson meta for the given lesson
@@ -4071,7 +4071,7 @@ class Sensei_Lesson {
 
 					$meta_html .= '<span class="lesson-author">' . esc_html__( 'Author:', 'sensei-lms' ) . ' ' . '<a href="' . esc_url( get_author_posts_url( absint( get_post()->post_author ) ) ) . '" title="' . esc_attr( $user_info->display_name ) . '">' . esc_html( $user_info->display_name ) . '</a></span>';
 
-				} // End If Statement
+				}
 				if ( '' != $lesson_complexity ) {
 
 					$meta_html .= '<span class="lesson-complexity">' . esc_html__( 'Complexity:', 'sensei-lms' ) . ' ' . esc_html( $lesson_complexity ) . '</span>';
@@ -4086,7 +4086,7 @@ class Sensei_Lesson {
 
 					$meta_html .= '<span class="lesson-status in-progress">' . esc_html__( 'In Progress', 'sensei-lms' ) . '</span>';
 
-				} // End If Statement
+				}
 
 				echo wp_kses_post( $meta_html );
 
@@ -4098,7 +4098,7 @@ class Sensei_Lesson {
 
 		<?php
 
-	} // end the_lesson_meta
+	}
 
 	/**
 	 * Output the lessons thumbnail
@@ -4142,7 +4142,7 @@ class Sensei_Lesson {
 
 		return $excerpt;
 
-	}//end alter_the_lesson_excerpt()
+	}
 
 	/**
 	 * Returns the lesson prerequisite for the given lesson id.
@@ -4288,7 +4288,7 @@ class Sensei_Lesson {
 
 		_deprecated_function( __METHOD__, '3.0.0' );
 
-	} // end user_not_taking_course_message
+	}
 
 	/**
 	 * Outputs the lessons course signup lingk
@@ -4352,7 +4352,7 @@ class Sensei_Lesson {
 			Sensei()->notices->add_notice( $message, $notice_level );
 		}
 
-	}//end course_signup_link()
+	}
 
 	/**
 	 * Show a message telling the user to complete the previous message if they haven't done so yet
@@ -4455,7 +4455,7 @@ class Sensei_Lesson {
 
 		<?php
 
-	}//end the_title()
+	}
 
 	/**
 	 * Flush the rewrite rules.
@@ -4623,7 +4623,7 @@ class Sensei_Lesson {
 
 		return $content;
 
-	} // end limit_archive_content
+	}
 
 	/**
 	 * Returns all publised lesson ID's

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2954,8 +2954,7 @@ class Sensei_Lesson {
 		// Handle Default Fields (multiple choice)
 		if ( 'multiple-choice' == $question_type && isset( $data['question_right_answers'] ) && ( '' != $data['question_right_answers'] ) ) {
 			$question_right_answers = $data['question_right_answers'];
-		}
-		elseif ( 'multiple-choice' == $question_type && isset( $data['question_right_answer'] ) && ( '' != $data['question_right_answer'] ) ) {
+		} elseif ( 'multiple-choice' == $question_type && isset( $data['question_right_answer'] ) && ( '' != $data['question_right_answer'] ) ) {
 			$question_right_answer = $data['question_right_answer'];
 		}
 		if ( 'multiple-choice' == $question_type && isset( $data['question_wrong_answers'] ) && ( '' != $data['question_wrong_answers'] ) ) {

--- a/includes/class-sensei-list-table.php
+++ b/includes/class-sensei-list-table.php
@@ -71,7 +71,7 @@ class Sensei_List_Table extends WP_List_Table {
 		// Actions
 		add_action( 'sensei_before_list_table', array( $this, 'table_search_form' ), 5 );
 
-	} // End __construct()
+	}
 
 	/**
 	 * remove_sortable_columns removes all sortable columns by returning an empty array
@@ -104,12 +104,12 @@ class Sensei_List_Table extends WP_List_Table {
 		if ( $which == 'top' ) {
 			// The code that goes before the table is here
 			do_action( 'sensei_before_list_table' );
-		} // End If Statement
+		}
 		if ( $which == 'bottom' ) {
 			// The code that goes after the table is there
 			do_action( 'sensei_after_list_table' );
-		} // End If Statement
-	} // End extra_tablenav()
+		}
+	}
 
 	/**
 	 * table_search_form outputs search form for table
@@ -138,7 +138,7 @@ class Sensei_List_Table extends WP_List_Table {
 			<?php $this->search_box( apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users', 'sensei-lms' ) ), 'search_id' ); ?>
 		</form>
 		<?php
-	} // End table_search_form()
+	}
 
 	/**
 	 * get_columns Define the columns that are going to be used in the table
@@ -148,7 +148,7 @@ class Sensei_List_Table extends WP_List_Table {
 	 */
 	public function get_columns() {
 		return $this->columns;
-	} // End get_columns()
+	}
 
 	/**
 	 * get_sortable_columns Decide which columns to activate the sorting functionality on
@@ -158,7 +158,7 @@ class Sensei_List_Table extends WP_List_Table {
 	 */
 	public function get_sortable_columns() {
 		return $this->sortable_columns;
-	} // End get_sortable_columns()
+	}
 
 	/**
 	 * Overriding parent WP-List-Table get_column_info()
@@ -272,7 +272,7 @@ class Sensei_List_Table extends WP_List_Table {
 
 		esc_html_e( 'No items found.', 'sensei-lms' );
 
-	} // End no_items()
+	}
 
 	/**
 	 * get_bulk_actions sets the bulk actions list
@@ -282,7 +282,7 @@ class Sensei_List_Table extends WP_List_Table {
 	 */
 	public function get_bulk_actions() {
 		return array();
-	} // End overview_actions_filters()
+	}
 
 	/**
 	 * bulk_actions output for the bulk actions area
@@ -293,9 +293,9 @@ class Sensei_List_Table extends WP_List_Table {
 	public function bulk_actions( $which = '' ) {
 		// This will be output Above the table headers on the left
 		echo wp_kses_post( apply_filters( 'sensei_list_bulk_actions', '' ) );
-	} // End bulk_actions()
+	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_List_Table

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -64,7 +64,7 @@ class Sensei_Messages {
 		add_filter( 'comment_feed_where', array( $this, 'exclude_message_comments_from_feed_where' ) );
 		add_filter( 'user_has_cap', [ $this, 'user_messages_cap_check' ], 10, 3 );
 		add_action( 'load-edit-comments.php', [ $this, 'check_permissions_edit_comments' ] );
-	} // End __construct()
+	}
 
 	public function only_show_messages_to_owner( $query ) {
 		if ( is_admin() ) {
@@ -407,7 +407,7 @@ class Sensei_Messages {
 		}
 		return $emails;
 
-	}//end stop_wp_comment_emails()
+	}
 
 	/**
 	 * Save new message post
@@ -819,7 +819,7 @@ class Sensei_Messages {
 
 		<?php
 
-	} // End sensei_single_title()
+	}
 
 	/**
 	 * Generates the my messages
@@ -861,7 +861,7 @@ class Sensei_Messages {
 		</h2>
 
 		<?php
-	} //end the_message_header
+	}
 
 	/**
 	 * Get the message title that is going to be displayed.
@@ -909,9 +909,9 @@ class Sensei_Messages {
 			</p>
 
 			<?php
-		} // end if
+		}
 
-	} // end the_message_archive_sender
+	}
 
 	/**
 	 * Link to the users my messages page
@@ -931,7 +931,7 @@ class Sensei_Messages {
 		}
 	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_Messages

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -104,7 +104,7 @@ class Sensei_Core_Modules {
 		// remove the default modules  metabox
 		add_action( 'admin_init', array( 'Sensei_Core_Modules', 'remove_default_modules_box' ) );
 
-	} // end constructor
+	}
 
 	/**
 	 * Hook in all meta boxes related tot he modules taxonomy
@@ -157,7 +157,7 @@ class Sensei_Core_Modules {
 		} else {
 			// translators: The placeholders are opening and closing <em> tags.
 			$html .= '<p>' . sprintf( __( 'No modules are available for this lesson yet. %1$sPlease select a course first.%2$s', 'sensei-lms' ), '<em>', '</em>' ) . '</p>';
-		} // End If Statement
+		}
 		$html .= '</div>';
 
 		echo wp_kses(
@@ -232,7 +232,7 @@ class Sensei_Core_Modules {
 			 * %4$s - </a>
 			 */
 			$html .= '<p>' . wp_kses_post( sprintf( __( 'No modules are available for this lesson yet. %1$sPlease add some to %3$sthe course%4$s.%2$s', 'sensei-lms' ), '<em>', '</em>', '<a href="' . esc_url( $course_url ) . '">', '</a>' ) ) . '</p>';
-		} // End If Statement
+		}
 		return $html;
 	}
 
@@ -645,7 +645,7 @@ class Sensei_Core_Modules {
 		 * @param bool    $link_to_current    Allow for linking to the currently displayed module.
 		 */
 		return apply_filters( 'sensei_do_link_to_module', $do_link_to_module, $module, $link_to_current );
-	} // End do_link_to_module()
+	}
 
 	/**
 	 * Checks if a module taxonomy template file has been overridden.
@@ -660,7 +660,7 @@ class Sensei_Core_Modules {
 		$template = locate_template( $find );
 
 		return (bool) $template;
-	} // End is_module_tax_template_overridden()
+	}
 
 	/**
 	 * Set lesson archive template to display on module taxonomy archive page
@@ -1526,7 +1526,7 @@ class Sensei_Core_Modules {
 		$disable_styles = false;
 		if ( isset( Sensei()->settings->settings['styles_disable'] ) ) {
 			$disable_styles = Sensei()->settings->settings['styles_disable'];
-		} // End If Statement
+		}
 
 		// Add filter for theme overrides
 		$disable_styles = apply_filters( 'sensei_disable_styles', $disable_styles );
@@ -1644,7 +1644,7 @@ class Sensei_Core_Modules {
 
 		Sensei_Templates::get_template( 'single-course/modules.php' );
 
-	} // end course_module_content
+	}
 
 	/**
 	 * Returns all lessons for the given module ID
@@ -1669,7 +1669,7 @@ class Sensei_Core_Modules {
 
 		}
 
-	} // end get lessons
+	}
 
 	/**
 	 * Returns all lessons for the given module ID
@@ -1725,7 +1725,7 @@ class Sensei_Core_Modules {
 
 		return $lessons_query;
 
-	} // end get lessons
+	}
 
 	/**
 	 * Find the lesson in the given course that doesn't belong
@@ -1813,7 +1813,7 @@ class Sensei_Core_Modules {
 
 		register_taxonomy( 'module', array( 'course', 'lesson' ), $args );
 
-	}//end setup_modules_taxonomy()
+	}
 
 	/**
 	 * When the wants to edit the lesson modules redirect them to the course modules.
@@ -1831,7 +1831,7 @@ class Sensei_Core_Modules {
 			wp_safe_redirect( esc_url_raw( 'edit-tags.php?taxonomy=module&post_type=course' ) );
 		}
 
-	}//end redirect_to_lesson_module_taxonomy_to_course()
+	}
 
 	/**
 	 * Completely remove the module menu item under lessons.
@@ -1856,7 +1856,7 @@ class Sensei_Core_Modules {
 			}
 		}
 
-	}//end remove_lessons_menu_model_taxonomy()
+	}
 
 	/**
 	 * Completely remove the second modules under courses
@@ -1881,7 +1881,7 @@ class Sensei_Core_Modules {
 			}
 		}
 
-	}//end remove_courses_menu_model_taxonomy()
+	}
 
 	/**
 	 * Determine the author of a module term term by looking at
@@ -1918,12 +1918,12 @@ class Sensei_Core_Modules {
 				// look for the author in the slug
 				$owners[] = self::get_term_author( $term->slug );
 
-			}// end if term name
-		} // end for each
+			}
+		}
 
 		return $owners;
 
-	}//end get_term_authors()
+	}
 
 	/**
 	 * Looks at a term slug and figures out
@@ -2020,7 +2020,7 @@ class Sensei_Core_Modules {
 			<?php endif; ?>
 		</div>
 		<?php
-	} // end course_module_metabox
+	}
 
 
 	/**
@@ -2139,7 +2139,7 @@ class Sensei_Core_Modules {
 		$teachers_terms = $this->filter_terms_by_owner_no_infinite_loop( $terms, get_current_user_id() );
 
 		return $teachers_terms;
-	}//end filter_module_terms()
+	}
 
 	/**
 	 * Call filter_terms_by_owner without infinite loops
@@ -2189,7 +2189,7 @@ class Sensei_Core_Modules {
 
 		return $terms;
 
-	}//end filter_course_selected_terms()
+	}
 
 	/**
 	 * Filter the given terms and only return the
@@ -2221,7 +2221,7 @@ class Sensei_Core_Modules {
 
 		return $users_terms;
 
-	} // end filter terms by owner
+	}
 
 	/**
 	 * Add the teacher name next to modules. Only works in Admin for Admin users.
@@ -2332,7 +2332,7 @@ class Sensei_Core_Modules {
 		$sensei_modules_loop['current']   = -1;
 		$sensei_modules_loop['course_id'] = $course_id;
 
-	}//end setup_single_course_module_loop()
+	}
 
 	/**
 	 * Tear down the course module loop.
@@ -2350,6 +2350,6 @@ class Sensei_Core_Modules {
 
 		// set the current course to be the global post again
 		wp_reset_query();
-	}//end teardown_single_course_module_loop()
+	}
 
-} // end modules class
+}

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -98,8 +98,8 @@ class Sensei_PostTypes {
 			if ( ( $pagenow == 'post.php' || $pagenow == 'post-new.php' ) ) {
 				add_filter( 'enter_title_here', array( $this, 'enter_title_here' ), 10 );
 				add_filter( 'post_updated_messages', array( $this, 'setup_post_type_messages' ) );
-			} // End If Statement
-		} // End If Statement
+			}
+		}
 
 		// REST API functionality.
 		add_action( 'rest_api_init', [ $this, 'setup_rest_api' ] );
@@ -112,7 +112,7 @@ class Sensei_PostTypes {
 
 		$this->setup_initial_publish_action();
 
-	} // End __construct()
+	}
 
 	/**
 	 * load_posttype_objects function.
@@ -131,9 +131,9 @@ class Sensei_PostTypes {
 			$this->$posttype_token        = new $class_name();
 			$this->$posttype_token->token = $posttype_token;
 
-		} // End For Loop
+		}
 
-	} // End load_posttype_objects
+	}
 
 	/**
 	 * Set up REST API for post types.
@@ -227,7 +227,7 @@ class Sensei_PostTypes {
 		 */
 		register_post_type( 'course', apply_filters( 'sensei_register_post_type_course', $args ) );
 
-	} // End setup_course_post_type()
+	}
 
 	/**
 	 * Figure out of the course post type has an archive and what it should be.
@@ -258,7 +258,7 @@ class Sensei_PostTypes {
 
 		}
 
-	}//end get_course_post_type_archive_slug()
+	}
 
 	/**
 	 * Check if given content has any of these old shortcodes:
@@ -277,7 +277,7 @@ class Sensei_PostTypes {
 		|| has_shortcode( $content, 'freecourses' )
 		|| has_shortcode( $content, 'paidcourses' ) );
 
-	}//end has_old_shortcodes()
+	}
 
 
 	/**
@@ -293,10 +293,10 @@ class Sensei_PostTypes {
 		$allow_comments = false;
 		if ( isset( Sensei()->settings->settings['lesson_comments'] ) ) {
 			$allow_comments = Sensei()->settings->settings['lesson_comments'];
-		} // End If Statement
+		}
 		if ( $allow_comments ) {
 			array_push( $supports_array, 'comments' );
-		} // End If Statement
+		}
 
 		// If Sensei LMS was first activated pre-3.7.0 and permalinks had a front value, `with_front` will be enabled.
 		$with_front = Sensei()->get_legacy_flag( Sensei_Main::LEGACY_FLAG_WITH_FRONT ) ? true : false;
@@ -333,7 +333,7 @@ class Sensei_PostTypes {
 		 */
 		register_post_type( 'lesson', apply_filters( 'sensei_register_post_type_lesson', $args ) );
 
-	} // End setup_lesson_post_type()
+	}
 
 	/**
 	 * Setup the "quiz" post type, it's admin menu item and the appropriate labels and permissions.
@@ -384,7 +384,7 @@ class Sensei_PostTypes {
 		 */
 		register_post_type( 'quiz', apply_filters( 'sensei_register_post_type_quiz', $args ) );
 
-	} // End setup_quiz_post_type()
+	}
 
 
 	/**
@@ -435,7 +435,7 @@ class Sensei_PostTypes {
 		 */
 		register_post_type( 'question', apply_filters( 'sensei_register_post_type_question', $args ) );
 
-	} // End setup_question_post_type()
+	}
 
 	/**
 	 * Setup the "multiple_question" post type, it's admin menu item and the appropriate labels and permissions.
@@ -469,7 +469,7 @@ class Sensei_PostTypes {
 		);
 
 		register_post_type( 'multiple_question', $args );
-	} // End setup_multiple_question_post_type()
+	}
 
 	/**
 	 * Setup the "sensei_message" post type, it's admin menu item and the appropriate labels and permissions.
@@ -516,7 +516,7 @@ class Sensei_PostTypes {
 			 */
 			register_post_type( 'sensei_message', apply_filters( 'sensei_register_post_type_sensei_message', $args ) );
 		}
-	} // End setup_sensei_message_post_type()
+	}
 
 	/**
 	 * Registers the learner taxonomy.
@@ -577,7 +577,7 @@ class Sensei_PostTypes {
 
 		register_taxonomy( 'course-category', array( 'course' ), $args );
 
-	} // End setup_course_category_taxonomy()
+	}
 
 	/**
 	 * Setup the "quiz type" taxonomy, linked to the "quiz" post type.
@@ -614,7 +614,7 @@ class Sensei_PostTypes {
 		);
 
 		register_taxonomy( 'quiz-type', array( 'quiz' ), $args );
-	} // End setup_quiz_type_taxonomy()
+	}
 
 	/**
 	 * Setup the "question type" taxonomy, linked to the "question" post type.
@@ -653,7 +653,7 @@ class Sensei_PostTypes {
 		);
 
 		register_taxonomy( 'question-type', array( 'question' ), $args );
-	} // End setup_question_type_taxonomy()
+	}
 
 	/**
 	 * Setup the "question category" taxonomy, linked to the "question" post type.
@@ -698,7 +698,7 @@ class Sensei_PostTypes {
 		);
 
 		register_taxonomy( 'question-category', array( 'question' ), $args );
-	} // End setup_question_type_taxonomy()
+	}
 
 	/**
 	 * Setup the "lesson tags" taxonomy, linked to the "lesson" post type.
@@ -741,7 +741,7 @@ class Sensei_PostTypes {
 		);
 
 		register_taxonomy( 'lesson-tag', array( 'lesson' ), $args );
-	} // End setup_lesson_tag_taxonomy()
+	}
 
 	/**
 	 * Setup the singular, plural and menu label names for the post types.
@@ -788,7 +788,7 @@ class Sensei_PostTypes {
 			'menu'     => __( 'Messages', 'sensei-lms' ),
 		);
 
-	} // End setup_post_type_labels_base()
+	}
 
 	/**
 	 * Create the labels for a specified post type.
@@ -828,7 +828,7 @@ class Sensei_PostTypes {
 		);
 
 		return $labels;
-	} // End create_post_type_labels()
+	}
 
 	/**
 	 * Setup update messages for the post types.
@@ -845,7 +845,7 @@ class Sensei_PostTypes {
 		$messages['multiple_question'] = $this->create_post_type_messages( 'multiple_question' );
 
 		return $messages;
-	} // End setup_post_type_messages()
+	}
 
 	/**
 	 * Create an array of messages for a specified post type.
@@ -890,7 +890,7 @@ class Sensei_PostTypes {
 		);
 
 		return $messages;
-	} // End create_post_type_messages()
+	}
 
 	/**
 	 * Change the "Enter Title Here" text for the "slide" post type.
@@ -908,7 +908,7 @@ class Sensei_PostTypes {
 		}
 
 		return $title;
-	} // End enter_title_here()
+	}
 
 	/**
 	 * Assigns the defaults for each user role capabilities.
@@ -983,9 +983,9 @@ class Sensei_PostTypes {
 				'subscriber'    => array( 'read' ),
 
 			);
-		} // End For Loop
+		}
 
-	} // End set_role_cap_defaults()
+	}
 
 	/**
 	 * Adds a 'Edit Quiz' link to the admin bar when viewing a Quiz linked to a corresponding Lesson
@@ -1197,7 +1197,7 @@ class Sensei_PostTypes {
 		return get_post_meta( $post_id, '_sensei_already_published', true );
 	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_PostTypes

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -37,10 +37,10 @@ class Sensei_Question {
 			add_filter( 'request', array( $this, 'filter_actions' ) );
 
 			add_action( 'save_post_question', array( $this, 'save_question' ), 10, 1 );
-		} // End If Statement
+		}
 
 		add_action( 'sensei_question_initial_publish', [ $this, 'log_initial_publish_event' ] );
-	} // End __construct()
+	}
 
 	public function question_types() {
 		$types = array(
@@ -135,7 +135,7 @@ class Sensei_Question {
 
 		}
 
-	} // End add_column_data()
+	}
 
 	public function question_edit_panel_metabox( $post_type, $post ) {
 		if ( in_array( $post_type, array( 'question', 'multiple_question' ) ) ) {
@@ -465,7 +465,7 @@ class Sensei_Question {
 
 		return $question_type;
 
-	}//end get_question_type()
+	}
 
 	/**
 	 * Given a question ID, return the grade that can be achieved.
@@ -680,7 +680,7 @@ class Sensei_Question {
 
 		return $output;
 
-	} // end get_the_question_media
+	}
 
 	/**
 	 * Output the question media
@@ -803,9 +803,9 @@ class Sensei_Question {
 
 				<?php
 			}
-		}// end if we can show answer feedback
+		}
 
-	}//end answer_feedback_notes()
+	}
 
 	/**
 	 * This function has to be run inside the quiz question loop on the single quiz page.
@@ -1136,7 +1136,7 @@ class Sensei_Question {
 						$checked = checked( $answer, $question_data['user_answer_entry'], false );
 
 					}
-				} // End If Statement
+				}
 
 				// Load the answer option data
 				$question_option['ID']           = Sensei()->lesson->get_answer_id( $answer );
@@ -1149,7 +1149,7 @@ class Sensei_Question {
 				// add the speci  fic option to the list of options for this question
 				$question_answers_options[ $question_option['ID'] ] = $question_option;
 
-			} // end for each option
+			}
 
 			// Shuffle the array depending on the settings
 			$answer_options_sorted = array();
@@ -1194,8 +1194,8 @@ class Sensei_Question {
 
 					$answer_options_sorted = $question_answers_options;
 
-				} // end if $answer_order_string
-			} // end if random order
+				}
+			}
 
 			// assemble and setup the data for the templates data array
 			$question_data['answer_options'] = $answer_options_sorted;
@@ -1204,7 +1204,7 @@ class Sensei_Question {
 
 		return $question_data;
 
-	}//end multiple_choice_load_question_data()
+	}
 
 	/**
 	 * Load the gap fill question data on the sensei_get_question_template_data
@@ -1231,7 +1231,7 @@ class Sensei_Question {
 
 		return $question_data;
 
-	}//end gap_fill_load_question_data()
+	}
 
 
 	/**
@@ -1431,7 +1431,7 @@ class Sensei_Question {
 		return true;
 	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_Question

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -51,7 +51,7 @@ class Sensei_Quiz {
 		add_filter( 'body_class', [ $this, 'add_quiz_blocks_class' ] );
 		add_filter( 'post_class', [ $this, 'add_quiz_blocks_class' ] );
 
-	} // End __construct()
+	}
 
 	/**
 	 * Check if the block based quiz editor is enabled. If not, fall back to the legacy metabox editor.
@@ -149,7 +149,7 @@ class Sensei_Quiz {
 
 		return $lesson_id;
 
-	} // end lesson
+	}
 
 
 	/**
@@ -184,7 +184,7 @@ class Sensei_Quiz {
 		// remove the hook as it should only fire once per click
 		remove_action( 'sensei_single_quiz_content_inside_before', 'user_save_quiz_answers_listener' );
 
-	} // end user_save_quiz_answers_listener
+	}
 
 	/**
 	 * Save the user answers for the given lesson's quiz
@@ -245,7 +245,7 @@ class Sensei_Quiz {
 
 		return $answers_saved;
 
-	}//end save_user_answers()
+	}
 
 	/**
 	 * Get the user answers for the given lesson's quiz.
@@ -283,7 +283,7 @@ class Sensei_Quiz {
 
 			$encoded_user_answers = Sensei_Utils::get_user_data( 'quiz_answers', $lesson_id, $user_id );
 
-		} // end if transient check
+		}
 
 		if ( ! is_array( $encoded_user_answers ) ) {
 			return false;
@@ -300,7 +300,7 @@ class Sensei_Quiz {
 
 		return $answers;
 
-	}//end get_user_answers()
+	}
 
 
 	/**
@@ -330,7 +330,7 @@ class Sensei_Quiz {
 		// this function should only run once
 		remove_action( 'template_redirect', array( $this, 'reset_button_click_listener' ) );
 
-	} // end reset_button_click_listener
+	}
 
 	/**
 	 * Complete/ submit  quiz hooked function
@@ -360,7 +360,7 @@ class Sensei_Quiz {
 
 		self::submit_answers_for_grading( $quiz_answers, $_FILES, $lesson_id, $current_user->ID );
 
-	} // End sensei_complete_quiz()
+	}
 
 	/**
 	 * This function set's up the data need for the quiz page
@@ -405,7 +405,7 @@ class Sensei_Quiz {
 		$user_lesson_complete = false;
 		if ( $user_lesson_end ) {
 			$user_lesson_complete = true;
-		} // End If Statement
+		}
 
 		$reset_allowed = get_post_meta( $post->ID, '_enable_quiz_reset', true );
 		// Backwards compatibility.
@@ -424,7 +424,7 @@ class Sensei_Quiz {
 		$this->data->lesson_quiz_questions = $lesson_quiz_questions;
 		$this->data->reset_quiz_allowed    = $reset_allowed;
 
-	} // end load_global_quiz_data
+	}
 
 
 	/**
@@ -471,11 +471,11 @@ class Sensei_Quiz {
 						$answer = $attachment_id;
 					}
 				}
-			} // end if
+			}
 
 			$prepared_answers[ $question_id ] = base64_encode( maybe_serialize( $answer ) );
 
-		}// end for each $quiz_answers
+		}
 
 		return $prepared_answers;
 	} // prepare_form_submitted_answers
@@ -583,7 +583,7 @@ class Sensei_Quiz {
 
 		return true;
 
-	} // end reset_user_lesson_data
+	}
 
 	/**
 	 * Submit the users quiz answers for grading
@@ -683,7 +683,7 @@ class Sensei_Quiz {
 
 					$lesson_status = 'failed';
 
-				} // End If Statement
+				}
 			} else {
 
 				// Student only has to partake the quiz
@@ -693,7 +693,7 @@ class Sensei_Quiz {
 
 			$lesson_metadata['grade'] = $grade; // Technically already set as part of "Sensei_Utils::sensei_grade_quiz_auto()" above
 
-		} // end if ! is_wp_error( $grade ...
+		}
 
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_id, $lesson_status, $lesson_metadata );
 
@@ -727,7 +727,7 @@ class Sensei_Quiz {
 
 		return $answers_submitted;
 
-	}//end submit_answers_for_grading()
+	}
 
 	/**
 	 * Get the user question answer
@@ -787,7 +787,7 @@ class Sensei_Quiz {
 
 		return $users_answers[ $question_id ];
 
-	}//end get_user_question_answer()
+	}
 
 	/**
 	 * Saving the users quiz question grades
@@ -839,7 +839,7 @@ class Sensei_Quiz {
 
 		return $success;
 
-	}//end set_user_grades()
+	}
 
 	/**
 	 * Retrieve the users quiz question grades
@@ -879,7 +879,7 @@ class Sensei_Quiz {
 			// set the transient with the new valid data for faster retrieval in future
 			set_transient( $transient_key, $user_grades, 10 * DAY_IN_SECONDS );
 
-		} // end if transient check
+		}
 
 		// if there is no data for this user
 		if ( ! is_array( $user_grades ) ) {
@@ -888,7 +888,7 @@ class Sensei_Quiz {
 
 		return $user_grades;
 
-	}//end get_user_grades()
+	}
 
 	/**
 	 * Get the user question grade
@@ -940,11 +940,11 @@ class Sensei_Quiz {
 
 			return $fall_back_grade;
 
-		} // end if $all_user_grades...
+		}
 
 		return $all_user_grades[ $question_id ];
 
-	}//end get_user_question_grade()
+	}
 
 	/**
 	 * Save the user's answers feedback
@@ -1001,7 +1001,7 @@ class Sensei_Quiz {
 
 		return $feedback_saved;
 
-	} // end save_user_answers_feedback
+	}
 
 	/**
 	 * Get the user's answers feedback.
@@ -1046,7 +1046,7 @@ class Sensei_Quiz {
 			// set the transient with the new valid data for faster retrieval in future
 			set_transient( $transient_key, $encoded_feedback, 10 * DAY_IN_SECONDS );
 
-		} // end if transient check
+		}
 
 		// if there is no data for this user
 		if ( ! is_array( $encoded_feedback ) ) {
@@ -1061,7 +1061,7 @@ class Sensei_Quiz {
 
 		return $answers_feedback;
 
-	} // end get_user_answers_feedback
+	}
 
 	/**
 	 * Get the user's answer feedback for a specific question.
@@ -1131,7 +1131,7 @@ class Sensei_Quiz {
 		 */
 		return apply_filters( 'sensei_user_question_feedback', $feedback, $lesson_id, $question_id, $user_id );
 
-	} // end get_user_question_feedback
+	}
 
 	/**
 	 * Check if a quiz has no questions, and redirect back to lesson.
@@ -1166,7 +1166,7 @@ class Sensei_Quiz {
 
 		}
 
-	} // end quiz_has_no_questions
+	}
 
 	/**
 	 * Filter the single title and add the Quiz to it.
@@ -1273,7 +1273,7 @@ class Sensei_Quiz {
 		 </header>
 
 		 <?php
-	}//end the_title()
+	}
 
 	/**
 	 * Output the sensei quiz status message.
@@ -1360,7 +1360,7 @@ class Sensei_Quiz {
 							class="wp-block-button__link button quiz-submit save sensei-stop-double-submission"><?php esc_attr_e( 'Save Quiz', 'sensei-lms' ); ?></button>
 					</div>
 
-				<?php } // End If Statement ?>
+				<?php }?>
 
 				<?php if ( isset( $reset_quiz_allowed ) && $reset_quiz_allowed ) { ?>
 
@@ -1374,7 +1374,7 @@ class Sensei_Quiz {
 			<?php
 		}
 
-	} // End sensei_quiz_action_buttons()
+	}
 
 	/**
 	 * Fetch the quiz grade

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1360,7 +1360,7 @@ class Sensei_Quiz {
 							class="wp-block-button__link button quiz-submit save sensei-stop-double-submission"><?php esc_attr_e( 'Save Quiz', 'sensei-lms' ); ?></button>
 					</div>
 
-				<?php }?>
+				<?php } ?>
 
 				<?php if ( isset( $reset_quiz_allowed ) && $reset_quiz_allowed ) { ?>
 

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -52,7 +52,7 @@ class Sensei_Settings_API {
 		$this->tabs              = array();
 		$this->settings_version  = '';
 
-	} // End __construct()
+	}
 
 	/**
 	 * Setup the settings screen and necessary functions.
@@ -67,7 +67,7 @@ class Sensei_Settings_API {
 		add_action( 'admin_init', array( $this, 'settings_fields' ) );
 		add_action( 'init', array( $this, 'general_init' ), 5 );
 
-	} // End setup_settings()
+	}
 
 	/**
 	 * Initialise settings sections, settings fields and create tabs, if applicable.
@@ -82,8 +82,8 @@ class Sensei_Settings_API {
 		$this->get_settings();
 		if ( $this->has_tabs == true ) {
 			$this->create_tabs();
-		} // End If Statement
-	} // End general_init()
+		}
+	}
 
 	/**
 	 * Register the settings sections.
@@ -95,7 +95,7 @@ class Sensei_Settings_API {
 	public function init_sections() {
 		// Override this function in your class and assign the array of sections to $this->sections.
 		esc_html_e( 'Override init_sections() in your class.', 'sensei-lms' );
-	} // End init_sections()
+	}
 
 	/**
 	 * Register the settings fields.
@@ -107,7 +107,7 @@ class Sensei_Settings_API {
 	public function init_fields() {
 		// Override this function in your class and assign the array of sections to $this->fields.
 		esc_html_e( 'Override init_fields() in your class.', 'sensei-lms' );
-	} // End init_fields()
+	}
 
 	/**
 	 * Construct and output HTML markup for the settings tabs.
@@ -158,7 +158,7 @@ class Sensei_Settings_API {
 
 			echo wp_kses_post( $html );
 		}
-	} // End settings_tabs()
+	}
 
 	/**
 	 * Create settings tabs based on the settings sections.
@@ -176,7 +176,7 @@ class Sensei_Settings_API {
 
 			$this->tabs = $tabs;
 		}
-	} // End create_tabs()
+	}
 
 	/**
 	 * Create settings sections.
@@ -191,7 +191,7 @@ class Sensei_Settings_API {
 				add_settings_section( $k, $v['name'], array( $this, 'section_description' ), $this->token );
 			}
 		}
-	} // End create_sections()
+	}
 
 	/**
 	 * Create settings fields.
@@ -225,7 +225,7 @@ class Sensei_Settings_API {
 					$this->has_range = true; }
 			}
 		}
-	} // End create_fields()
+	}
 
 	/**
 	 * Determine the method to use for outputting a field, validating a field or checking a field.
@@ -277,7 +277,7 @@ class Sensei_Settings_API {
 		}
 
 		return $method;
-	} // End determine_method()
+	}
 
 	/**
 	 * Parse the fields into an array index on the sections property.
@@ -299,7 +299,7 @@ class Sensei_Settings_API {
 				$this->remaining_fields[ $k ] = $v;
 			}
 		}
-	} // End parse_fields()
+	}
 
 	/**
 	 * Register the settings screen within the WordPress admin.
@@ -323,7 +323,7 @@ class Sensei_Settings_API {
 			add_action( 'admin_print_styles', array( $this, 'enqueue_styles' ) );
 
 		}
-	} // End register_settings_screen()
+	}
 
 	/**
 	 * The markup for the settings screen.
@@ -374,7 +374,7 @@ class Sensei_Settings_API {
 		<?php do_action( 'settings_after_form' ); ?>
 </div><!--/#woothemes-sensei-->
 		<?php
-	} // End settings_screen()
+	}
 
 	/**
 	 * Retrieve the settings from the database.
@@ -404,7 +404,7 @@ class Sensei_Settings_API {
 		}
 
 		return $this->settings;
-	} // End get_settings()
+	}
 
 	/**
 	 * Get the raw settings option.
@@ -437,7 +437,7 @@ class Sensei_Settings_API {
 		register_setting( $this->token, $this->token, array( $this, 'validate_fields' ) );
 		$this->create_sections();
 		$this->create_fields();
-	} // End settings_fields()
+	}
 
 	/**
 	 * Display settings errors.
@@ -448,7 +448,7 @@ class Sensei_Settings_API {
 	 */
 	public function settings_errors() {
 		settings_errors( $this->token . '-errors' );
-	} // End settings_errors()
+	}
 
 	/**
 	 * Display the description for a settings section.
@@ -461,7 +461,7 @@ class Sensei_Settings_API {
 		if ( isset( $this->sections[ $section['id'] ]['description'] ) ) {
 			echo wp_kses_post( wpautop( $this->sections[ $section['id'] ]['description'] ) );
 		}
-	} // End section_description_main()
+	}
 
 	/**
 	 * Generate text input field.
@@ -478,7 +478,7 @@ class Sensei_Settings_API {
 		if ( isset( $args['data']['description'] ) ) {
 			echo '<span class="description">' . wp_kses_post( $args['data']['description'] ) . '</span>' . "\n";
 		}
-	} // End form_field_text()
+	}
 
 	/**
 	 * Generate color picker field.
@@ -496,7 +496,7 @@ class Sensei_Settings_API {
 		if ( isset( $args['data']['description'] ) ) {
 			echo '<span class="description">' . wp_kses_post( $args['data']['description'] ) . '</span>' . "\n";
 		}
-	} // End form_field_text()
+	}
 
 	/**
 	 * Generate checkbox field.
@@ -527,7 +527,7 @@ class Sensei_Settings_API {
 				)
 			) . '</label>' . "\n";
 		}
-	} // End form_field_checkbox()
+	}
 
 	/**
 	 * Generate textarea field.
@@ -544,7 +544,7 @@ class Sensei_Settings_API {
 		if ( isset( $args['data']['description'] ) ) {
 			echo '<p><span class="description">' . esc_html( $args['data']['description'] ) . '</span></p>' . "\n";
 		}
-	} // End form_field_textarea()
+	}
 
 	/**
 	 * Generate select box field.
@@ -583,7 +583,7 @@ class Sensei_Settings_API {
 				echo '<p><span class="description">' . esc_html( $args['data']['description'] ) . '</span></p>' . "\n";
 			}
 		}
-	} // End form_field_select()
+	}
 
 	/**
 	 * Generate radio button field.
@@ -619,7 +619,7 @@ class Sensei_Settings_API {
 				echo '<span class="description">' . esc_html( $args['data']['description'] ) . '</span>' . "\n";
 			}
 		}
-	} // End form_field_radio()
+	}
 
 	/**
 	 * Generate multicheck field.
@@ -677,7 +677,7 @@ class Sensei_Settings_API {
 				echo '<span class="description">' . esc_html( $args['data']['description'] ) . '</span>' . "\n";
 			}
 		}
-	} // End form_field_multicheck()
+	}
 
 	/**
 	 * Generate range field.
@@ -717,7 +717,7 @@ class Sensei_Settings_API {
 				echo '<p><span class="description">' . esc_html( $args['data']['description'] ) . '</span></p>' . "\n";
 			}
 		}
-	} // End form_field_range()
+	}
 
 	/**
 	 * Generate image-based selector form field.
@@ -755,7 +755,7 @@ class Sensei_Settings_API {
 				echo '<span class="description">' . esc_html( $args['data']['description'] ) . '</span>' . "\n";
 			}
 		}
-	} // End form_field_images()
+	}
 
 	/**
 	 * Generate information box field.
@@ -780,7 +780,7 @@ class Sensei_Settings_API {
 		$html .= '</div>' . "\n";
 
 		echo wp_kses_post( $html );
-	} // End form_field_info()
+	}
 
 
 	/**
@@ -798,7 +798,7 @@ class Sensei_Settings_API {
 				echo '<span class="description">' . esc_html( $args['data']['description'] ) . '</span>' . "\n";
 			}
 		}
-	} // End form_field_button()
+	}
 
 
 	/**
@@ -867,7 +867,7 @@ class Sensei_Settings_API {
 		// Parse error messages into the Settings API.
 		$this->parse_errors();
 		return $options;
-	} // End validate_fields()
+	}
 
 	/**
 	 * Validate text fields.
@@ -879,7 +879,7 @@ class Sensei_Settings_API {
 	 */
 	public function validate_field_text( $input ) {
 		return trim( esc_attr( $input ) );
-	} // End validate_field_text()
+	}
 
 	/**
 	 * Validate checkbox fields.
@@ -895,7 +895,7 @@ class Sensei_Settings_API {
 		} else {
 			return (bool) $input;
 		}
-	} // End validate_field_checkbox()
+	}
 
 	/**
 	 * Validate multicheck fields.
@@ -911,7 +911,7 @@ class Sensei_Settings_API {
 		$input = array_map( 'esc_attr', $input );
 
 		return $input;
-	} // End validate_field_multicheck()
+	}
 
 	/**
 	 * Validate range fields.
@@ -925,7 +925,7 @@ class Sensei_Settings_API {
 		$input = number_format( floatval( $input ), 0 );
 
 		return $input;
-	} // End validate_field_range()
+	}
 
 	/**
 	 * Validate URL fields.
@@ -937,7 +937,7 @@ class Sensei_Settings_API {
 	 */
 	public function validate_field_url( $input ) {
 		return trim( esc_url( $input ) );
-	} // End validate_field_url()
+	}
 
 	/**
 	 * Check and validate the input from text fields.
@@ -950,7 +950,7 @@ class Sensei_Settings_API {
 		$is_valid = true;
 
 		return $is_valid;
-	} // End check_field_text()
+	}
 
 	/**
 	 * Log an error internally, for processing later using $this->parse_errors().
@@ -969,7 +969,7 @@ class Sensei_Settings_API {
 			$message = sprintf( __( '%s is a required field', 'sensei-lms' ), $data['name'] );
 		}
 		$this->errors[ $key ] = $message;
-	} // End add_error()
+	}
 
 	/**
 	 * Parse logged errors.
@@ -988,7 +988,7 @@ class Sensei_Settings_API {
 			$message = sprintf( __( '%s updated', 'sensei-lms' ), $this->name );
 			add_settings_error( $this->token . '-errors', $this->token, $message, 'updated' );
 		}
-	} // End parse_errors()
+	}
 
 	/**
 	 * Return an array of field types expecting an array value returned.
@@ -999,7 +999,7 @@ class Sensei_Settings_API {
 	 */
 	protected function get_array_field_types() {
 		return array( 'multicheck' );
-	} // End get_array_field_types()
+	}
 
 	/**
 	 * Load in JavaScripts where necessary.
@@ -1022,7 +1022,7 @@ class Sensei_Settings_API {
 			wp_enqueue_script( 'sensei-settings-imageselectors' );
 		}
 
-	} // End enqueue_scripts()
+	}
 
 	/**
 	 * Load in CSS styles where necessary.
@@ -1039,7 +1039,7 @@ class Sensei_Settings_API {
 		Sensei()->assets->enqueue( 'sensei-settings-api', 'css/settings.css', [ 'farbtastic' ] );
 
 		$this->enqueue_field_styles();
-	} // End enqueue_styles()
+	}
 
 	/**
 	 * Load in CSS styles for field types where necessary.
@@ -1059,8 +1059,8 @@ class Sensei_Settings_API {
 		if ( $this->has_imageselector ) {
 			wp_enqueue_style( 'sensei-settings-imageselectors' );
 		}
-	} // End enqueue_field_styles()
-} // End Class
+	}
+}
 
 /**
  * Class WooThemes_Sensei_Settings_API

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -34,7 +34,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			$this->menu_label = __( 'Settings', 'sensei-lms' );
 			$this->page_slug  = 'sensei-settings';
 
-		} // End If Statement
+		}
 
 		$this->register_hook_listener();
 		$this->get_settings();
@@ -44,7 +44,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		// Make sure we don't trigger queries if legacy options aren't loaded in pre-loaded options.
 		add_filter( 'alloptions', [ $this, 'no_special_query_for_legacy_options' ] );
-	} // End __construct()
+	}
 
 	/**
 	 * Get settings value
@@ -100,7 +100,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			add_action( 'admin_print_scripts', array( $this, 'enqueue_scripts' ) );
 			add_action( 'admin_print_styles', array( $this, 'enqueue_styles' ) );
 		}
-	} // End register_settings_screen()
+	}
 
 	/**
 	 * Add legacy options to alloptions if they don't exist.
@@ -159,7 +159,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		);
 
 		$this->sections = apply_filters( 'sensei_settings_tabs', $sections );
-	} // End init_sections()
+	}
 
 	/**
 	 * Add settings fields.
@@ -640,7 +640,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$this->fields = apply_filters( 'sensei_settings_fields', $fields );
 
-	} // End init_fields()
+	}
 
 	/**
 	 * Get options for the duration fields.
@@ -667,7 +667,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		}
 
 		return $options;
-	} // End get_duration_options()
+	}
 
 	/**
 	 * Return an array of pages.
@@ -708,13 +708,13 @@ class Sensei_Settings extends Sensei_Settings_API {
 			if ( isset( $matches[1] ) ) {
 				$id                = $matches[1];
 				$page_items[ $id ] = trim( strip_tags( $v ) );
-			} // End If Statement
-		} // End For Loop
+			}
+		}
 
 		$pages_array = $page_items;
 
 		return $pages_array;
-	} // End pages_array()
+	}
 
 	/**
 	 * Flush the rewrite rules after the settings have been updated.
@@ -736,7 +736,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		}
 
-	}//end flush_rewrite_rules()
+	}
 
 	/**
 	 * Logs settings update from the Settings form.
@@ -830,7 +830,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		return array_filter( array_merge( $added, $removed ) );
 	}
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_Settings

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -94,7 +94,7 @@ class Sensei_Teacher {
 		add_action( 'admin_menu', array( $this, 'restrict_posts_menu_page' ), 10 );
 		add_filter( 'pre_get_comments', array( $this, 'restrict_comment_moderation' ), 10, 1 );
 
-	} // end __constructor()
+	}
 
 	/**
 	 * Sensei_Teacher::create_teacher_role
@@ -120,7 +120,7 @@ class Sensei_Teacher {
 		// add the capabilities before returning
 		$this->add_capabilities();
 
-	}//end create_role()
+	}
 
 	/**
 	 * Sensei_Teacher::add_capabilities
@@ -207,9 +207,9 @@ class Sensei_Teacher {
 			// load the capability on to the teacher role
 			$this->teacher_role->add_cap( $cap, $grant );
 
-		} // End foreach().
+		}
 
-	}//end add_capabilities()
+	}
 
 	/**
 	 * Sensei_Teacher::teacher_meta_box
@@ -236,7 +236,7 @@ class Sensei_Teacher {
 			'core'
 		);
 
-	} // end teacher_meta_box()
+	}
 
 	/**
 	 * Sensei_Teacher::teacher_meta_box_content
@@ -270,14 +270,14 @@ class Sensei_Teacher {
 					</option>
 
 				<?php
-			}// End foreach().
+			}
 			?>
 
 		</select>
 
 		<?php
 
-	} // end render_teacher_meta_box()
+	}
 
 	/**
 	 * Sensei_Teacher::get_teachers_and_authors
@@ -309,7 +309,7 @@ class Sensei_Teacher {
 
 		return array_unique( array_merge( $teachers, $authors ) );
 
-	}//end get_teachers_and_authors()
+	}
 
 	/**
 	 * Sensei_Teacher::save_teacher_meta_box
@@ -366,7 +366,7 @@ class Sensei_Teacher {
 		// notify the new teacher
 		$this->teacher_course_assigned_notification( $new_author, $course_id );
 
-	} // end save_teacher_meta_box
+	}
 
 	/**
 	 * Update all the course terms set(selected) on the given course. Moving course term ownership to
@@ -573,7 +573,7 @@ class Sensei_Teacher {
 		$query->set( 'author', $current_user->ID );
 		return $query;
 
-	}//end course_analysis_teacher_access_limit()
+	}
 
 
 	/**
@@ -604,7 +604,7 @@ class Sensei_Teacher {
 
 		return $is_admin_teacher;
 
-	} // end is_admin_teacher
+	}
 
 	/**
 	 * Show correct post counts on list table for Sensei post types
@@ -726,7 +726,7 @@ class Sensei_Teacher {
 		}
 		return $comments;
 
-	}//end filter_grading_activity_queries()
+	}
 
 	/**
 	 * Limit the grading screen totals to only show lessons in the course
@@ -854,7 +854,7 @@ class Sensei_Teacher {
 		$email->trigger( $teacher_id, $course_id );
 
 		return true;
-	} // end  teacher_course_assigned_notification
+	}
 
 	/**
 	 * Email the admin when a teacher creates a new course
@@ -951,7 +951,7 @@ class Sensei_Teacher {
 
 		do_action( 'sensei_after_sending_email' );
 
-	}//end notify_admin_teacher_course_creation()
+	}
 
 	/**
 	 * Limit the analysis view to only the users taking courses belong to this teacher.
@@ -1126,7 +1126,7 @@ class Sensei_Teacher {
 		}
 
 		return $wp_query;
-	}//end give_access_to_all_questions()
+	}
 
 	/**
 	 * Add new column heading to the course admin edit list
@@ -1145,7 +1145,7 @@ class Sensei_Teacher {
 		);
 		return array_merge( $columns, $new_columns );
 
-	}//end course_column_heading()
+	}
 
 	/**
 	 * Print out  teacher column data
@@ -1169,7 +1169,7 @@ class Sensei_Teacher {
 
 		echo '<a href="' . esc_url( get_edit_user_link( $teacher->ID ) ) . '" >' . esc_html( $teacher->display_name ) . '</a>';
 
-	}//end course_column_data()
+	}
 
 	/**
 	 * Return only courses belonging to the given teacher.
@@ -1358,7 +1358,7 @@ class Sensei_Teacher {
 		}
 
 		return $request;
-	} // End restrict_media_library()
+	}
 
 	/**
 	 * Only show current teacher's media in the media library modal on the course/lesson/quesion edit screen
@@ -1383,7 +1383,7 @@ class Sensei_Teacher {
 		}
 
 		return $query;
-	} // End restrict_media_library_modal()
+	}
 
 	/**
 	 * When saving the lesson, update the teacher if the lesson belongs to a course
@@ -1415,7 +1415,7 @@ class Sensei_Teacher {
 		$data['post_author'] = $course->post_author;
 
 		return $data;
-	} // end update_lesson_teacher
+	}
 
 	/**
 	 * Sensei_Teacher::limit_teacher_edit_screen_post_types
@@ -1462,7 +1462,7 @@ class Sensei_Teacher {
 
 		return $wp_query;
 
-	} // end limit_teacher_edit_screen_post_types()
+	}
 
 
 	/**
@@ -1497,7 +1497,7 @@ class Sensei_Teacher {
 			}
 		}
 
-	} // end teacher_login_redirect()
+	}
 
 
 
@@ -1544,7 +1544,7 @@ class Sensei_Teacher {
 			}
 		}
 
-	} // end restrict_posts_menu_page()
+	}
 
 	/**
 	 * Sensei_Teacher::restrict_comment_moderation()
@@ -1569,7 +1569,7 @@ class Sensei_Teacher {
 
 		return $clauses;
 
-	}   // end restrict_comment_moderation()
+	}
 
 	/**
 	 * Determine if a user is a teacher by ID
@@ -1592,7 +1592,7 @@ class Sensei_Teacher {
 
 		}
 
-	}//end is_a_teacher()
+	}
 
 	/**
 	 * The archive title on the teacher archive filter
@@ -1614,7 +1614,7 @@ class Sensei_Teacher {
 			</h2>
 		<?php
 
-	}//end archive_title()
+	}
 
 	/**
 	 * Removing course meta on the teacher archive page
@@ -1627,4 +1627,4 @@ class Sensei_Teacher {
 
 	}
 
-} // End Class
+}

--- a/includes/class-sensei-templates.php
+++ b/includes/class-sensei-templates.php
@@ -56,7 +56,7 @@ class Sensei_Templates {
 
 		}
 
-	} // end get part
+	}
 
 	/**
 	 * Get the template.
@@ -86,7 +86,7 @@ class Sensei_Templates {
 
 		}
 
-	} // end get template
+	}
 
 	/**
 	 * Check if the template file exists. A wrapper for WP locate_template.
@@ -130,7 +130,7 @@ class Sensei_Templates {
 		// Return what we found
 		return apply_filters( 'sensei_locate_template', $template, $template_name, $template_path );
 
-	} // end locate
+	}
 
 	/**
 	 * Determine which Sensei template to load based on the
@@ -279,11 +279,11 @@ class Sensei_Templates {
 			if ( ! $template ) {
 				$template = Sensei()->plugin_path() . '/templates/' . $file;
 			}
-		} // End If Statement
+		}
 
 		return $template;
 
-	} // End template_loader()
+	}
 
 	/**
 	 * This function loads the no-permissions template for users with no access
@@ -402,7 +402,7 @@ class Sensei_Templates {
 		$html        .= '</' . $title_html_tag . '>';
 		echo wp_kses_post( $html );
 
-	}//end the_title()
+	}
 
 	/**
 	 * Fire the sensei_complete_course action.
@@ -428,7 +428,7 @@ class Sensei_Templates {
 
 		do_action( 'sensei_frontend_messages' );
 
-	}//end fire_frontend_messages_hook()
+	}
 
 	public static function the_register_button( $post_id = '' ) {
 		global $current_user;
@@ -463,4 +463,4 @@ class Sensei_Templates {
 		}
 
 	}
-}//end class
+}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -26,7 +26,7 @@ class Sensei_Utils {
 	public static function get_placeholder_image() {
 
 		return esc_url( apply_filters( 'sensei_placeholder_thumbnail', Sensei()->plugin_url . 'assets/images/placeholder.png' ) );
-	} // End get_placeholder_image()
+	}
 
 	/**
 	 * Log an activity item.
@@ -85,7 +85,7 @@ class Sensei_Utils {
 				$data['comment_date'] = current_time( 'mysql' );
 			}
 			wp_update_comment( $data );
-		} // End If Statement
+		}
 
 		do_action( 'sensei_log_activity_after', $args, $data, $comment_id );
 
@@ -96,8 +96,8 @@ class Sensei_Utils {
 			return $comment_id;
 		} else {
 			return false;
-		} // End If Statement
-	} // End sensei_log_activity()
+		}
+	}
 
 
 	/**
@@ -169,10 +169,10 @@ class Sensei_Utils {
 			}
 
 			return $comments;
-		} // End If Statement
+		}
 		// Count comments
 		return intval( $comments ); // This is the count, check the return from WP_Comment_Query
-	} // End sensei_check_for_activity()
+	}
 
 
 	/**
@@ -202,15 +202,15 @@ class Sensei_Utils {
 					array_push( $post_ids, $value->user_id );
 				} else {
 					array_push( $post_ids, $value->comment_post_ID );
-				} // End If Statement
-			} // End For Loop
+				}
+			}
 			// Reset array indexes
 			$post_ids = array_unique( $post_ids );
 			$post_ids = array_values( $post_ids );
-		} // End If Statement
+		}
 
 		return $post_ids;
-	} // End sensei_activity_ids()
+	}
 
 
 	/**
@@ -242,14 +242,14 @@ class Sensei_Utils {
 			foreach ( $comments as $key => $value ) {
 				if ( isset( $value->comment_ID ) && 0 < $value->comment_ID ) {
 					$dataset_changes = wp_delete_comment( intval( $value->comment_ID ), true );
-				} // End If Statement
-			} // End For Loop
-		} // End If Statement
+				}
+			}
+		}
 
 		Sensei()->flush_comment_counts_cache( $args['post_id'] );
 
 		return $dataset_changes;
-	} // End sensei_delete_activities()
+	}
 
 	/**
 	 * Delete all activity for specified user.
@@ -266,7 +266,7 @@ class Sensei_Utils {
 		_deprecated_function( __METHOD__, '3.0.0', 'Sensei_Learner::delete_all_user_activity' );
 
 		return \Sensei_Learner::instance()->delete_all_user_activity( $user_id );
-	} // End delete_all_user_activity()
+	}
 
 	/**
 	 * Get value for a specified activity.
@@ -284,10 +284,10 @@ class Sensei_Utils {
 
 			if ( isset( $comment->{$args['field']} ) && '' != $comment->{$args['field']} ) {
 				$activity_value = $comment->{$args['field']};
-			} // End If Statement
+			}
 		}
 		return $activity_value;
-	} // End sensei_get_activity_value()
+	}
 
 	/**
 	 * Load the WordPress rich text editor
@@ -322,7 +322,7 @@ class Sensei_Utils {
 
 		wp_editor( $content, $editor_id, $settings );
 
-	} // End sensei_text_editor()
+	}
 
 	/**
 	 * Save quiz answers submitted by users
@@ -400,7 +400,7 @@ class Sensei_Utils {
 
 		return $answers_saved;
 
-	} // End sensei_save_quiz_answers()
+	}
 
 	public static function upload_file( $file = array() ) {
 
@@ -490,7 +490,7 @@ class Sensei_Utils {
 
 		return Sensei_Grading::grade_quiz_auto( $quiz_id, $submitted, $total_questions, $quiz_grade_type );
 
-	} // End sensei_grade_quiz_auto()
+	}
 
 	/**
 	 * Grade quiz
@@ -541,7 +541,7 @@ class Sensei_Utils {
 
 		return Sensei_Grading::grade_question_auto( $question_id, $question_type, $answer, $user_id );
 
-	} // end sensei_grade_question_auto
+	}
 
 	/**
 	 * Grade question
@@ -615,7 +615,7 @@ class Sensei_Utils {
 
 		return self::sensei_start_lesson( $lesson_id, $user_id, $complete );
 
-	}//end user_start_lesson()
+	}
 
 	/**
 	 * Mark a lesson as started for user
@@ -964,13 +964,13 @@ class Sensei_Utils {
 					self::sort_array_by_key( $return_array, $sort_key );
 				if ( isset( $_GET['order'] ) && 'desc' == esc_html( $_GET['order'] ) ) {
 					$return_array = array_reverse( $return_array, true );
-				} // End If Statement
-			} // End If Statement
+				}
+			}
 			return $return_array;
 		} else {
 			return $return_array;
-		} // End If Statement
-	} // End array_sort_reorder()
+		}
+	}
 
 	/**
 	 * sort_array_by_key sorts array by key
@@ -986,13 +986,13 @@ class Sensei_Utils {
 		reset( $array );
 		foreach ( $array as $ii => $va ) {
 			$sorter[ $ii ] = $va[ $key ];
-		} // End For Loop
+		}
 		asort( $sorter );
 		foreach ( $sorter as $ii => $va ) {
 			$ret[ $ii ] = $array[ $ii ];
-		} // End For Loop
+		}
 		$array = $ret;
-	} // End sort_array_by_key()
+	}
 
 	/**
 	 * This function returns an array of lesson quiz questions
@@ -1024,9 +1024,9 @@ class Sensei_Utils {
 			$question_args = wp_parse_args( $query_args, $defaults );
 
 			$questions_array = get_posts( $question_args );
-		} // End If Statement
+		}
 		return $questions_array;
-	} // End lesson_quiz_questions()
+	}
 
 	/**
 	 * Complete this course forcefully for this user by passing all the lessons.
@@ -1789,7 +1789,7 @@ class Sensei_Utils {
 						}
 						return false;
 				}
-			} // End If Statement
+			}
 		}
 
 		return false;
@@ -2076,7 +2076,7 @@ class Sensei_Utils {
 
 		return self::update_user_data( $data_key, $post_id, $value, $user_id );
 
-	}//end add_user_data()
+	}
 
 	/**
 	 * add user specific data to the passed in sensei post type id
@@ -2129,7 +2129,7 @@ class Sensei_Utils {
 
 		return $success;
 
-	}//end update_user_data()
+	}
 
 	/**
 	 * Get the user data stored on the passed in post type
@@ -2175,7 +2175,7 @@ class Sensei_Utils {
 
 		return $user_data_value;
 
-	}//end get_user_data()
+	}
 
 	/**
 	 * Delete the Sensei user data for the given key, Sensei post type and user combination.
@@ -2216,7 +2216,7 @@ class Sensei_Utils {
 
 		return $deleted;
 
-	}//end delete_user_data()
+	}
 
 
 	/**
@@ -2266,7 +2266,7 @@ class Sensei_Utils {
 
 			$combined_attributes .= $attribute . '="' . esc_attr( $value ) . '"' . ' ';
 
-		}// end for each
+		}
 
 		// create the select element
 		$drop_down_element .= '<select ' . $combined_attributes . ' >' . "\n";
@@ -2287,8 +2287,8 @@ class Sensei_Utils {
 
 				// add the element to the select html
 				$drop_down_element .= $element;
-			} // End For Loop
-		} // End If Statement
+			}
+		}
 
 		$drop_down_element .= '</select>' . "\n";
 
@@ -2718,7 +2718,7 @@ class Sensei_Utils {
 		return false;
 	}
 
-} // End Class
+}
 
 /**
  * Class WooThemes_Sensei_Utils

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1,7 +1,7 @@
 <?php
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
-} // End if().
+}
 
 /**
  * Responsible for loading Sensei and setting up the Main WordPress hooks.
@@ -267,7 +267,7 @@ class Sensei_Main {
 		 * @param {Sensei_Main} $sensei Sensei object.
 		 */
 		do_action( 'sensei_loaded', $this );
-	} // End __construct()
+	}
 
 	/**
 	 * Load the foundations of Sensei.
@@ -316,7 +316,7 @@ class Sensei_Main {
 
 		return self::$_instance;
 
-	} // end instance()
+	}
 
 	/**
 	 * This function is linked into the activation
@@ -522,8 +522,8 @@ class Sensei_Main {
 
 			$this->updates->update();
 
-		} // End if().
-	} // End run_updates()
+		}
+	}
 
 	/**
 	 * Register the widgets.
@@ -548,11 +548,11 @@ class Sensei_Main {
 				require_once $this->plugin_path . 'widgets/class-sensei-' . $key . '-widget.php';
 				register_widget( 'Sensei_' . $value . '_Widget' );
 			}
-		} // End foreach().
+		}
 
 		do_action( 'sensei_register_widgets' );
 
-	} // End register_widgets()
+	}
 
 	/**
 	 * Load the plugin's localisation file.
@@ -565,7 +565,7 @@ class Sensei_Main {
 
 		load_plugin_textdomain( 'sensei-lms', false, dirname( plugin_basename( $this->main_plugin_file_name ) ) . '/lang/' );
 
-	} // End load_localisation()
+	}
 
 	/**
 	 * Load the plugin textdomain from the main WordPress "languages" folder.
@@ -589,7 +589,7 @@ class Sensei_Main {
 		load_textdomain( $domain, WP_LANG_DIR . '/' . $domain . '/' . $domain . '-' . $locale . '.mo' );
 		load_plugin_textdomain( $domain, false, dirname( plugin_basename( $this->main_plugin_file_name ) ) . '/lang/' );
 
-	} // End load_plugin_textdomain()
+	}
 
 	/**
 	 * Run on activation.
@@ -626,7 +626,7 @@ class Sensei_Main {
 		register_activation_hook( $this->main_plugin_file_name, array( $this, 'activate_sensei' ) );
 		register_activation_hook( $this->main_plugin_file_name, array( $this, 'initiate_rewrite_rules_flush' ) );
 
-	} // End install()
+	}
 
 	/**
 	 * Checks for plugin update tasks and ensures the current version is set.
@@ -720,7 +720,7 @@ class Sensei_Main {
 
 		update_option( 'sensei_installed', 1 );
 
-	} // End activate_sensei()
+	}
 
 	/**
 	 * Register the plugin's version.
@@ -735,7 +735,7 @@ class Sensei_Main {
 			update_option( 'sensei-version', $this->version );
 
 		}
-	} // End register_plugin_version()
+	}
 
 	/**
 	 * Ensure that "post-thumbnails" support is available for those themes that don't register it.
@@ -749,7 +749,7 @@ class Sensei_Main {
 		if ( ! current_theme_supports( 'post-thumbnails' ) ) {
 			add_theme_support( 'post-thumbnails' ); }
 
-	} // End ensure_post_thumbnails_support()
+	}
 
 	/**
 	 * Determine the relative path to the plugin's directory.
@@ -772,7 +772,7 @@ class Sensei_Main {
 
 		return $sensei_plugin_path;
 
-	} // End plugin_path()
+	}
 
 	/**
 	 * Retrieve the ID of a specified page setting.
@@ -785,7 +785,7 @@ class Sensei_Main {
 	public function get_page_id( $page ) {
 		$page = apply_filters( 'sensei_get_' . esc_attr( $page ) . '_page_id', get_option( 'sensei_' . esc_attr( $page ) . '_page_id' ) );
 		return ( $page ) ? $page : -1;
-	} // End get_page_id()
+	}
 
 	/**
 	 * check_user_permissions function.
@@ -819,7 +819,7 @@ class Sensei_Main {
 
 				} else {
 					$prerequisite_complete = true;
-				} // End if().
+				}
 
 				// Handles restrictions on the course
 				if ( ( ! $prerequisite_complete && 0 < absint( $course_prerequisite_id ) ) ) {
@@ -845,7 +845,7 @@ class Sensei_Main {
 
 					$user_allowed = true;
 
-				} // End if().
+				}
 				break;
 			case 'lesson-single':
 				// Check for WC purchase
@@ -882,8 +882,8 @@ class Sensei_Main {
 							// translators: The placeholder %1$s is a link to the Course.
 							$this->permissions_message['message'] = sprintf( __( 'Please sign up for the %1$s before starting the lesson.', 'sensei-lms' ), $course_link );
 						}
-					} // End if().
-				} // End if().
+					}
+				}
 				break;
 			case 'quiz-single':
 				$lesson_id        = get_post_meta( $post->ID, '_quiz_lesson', true );
@@ -916,8 +916,8 @@ class Sensei_Main {
 
 							$user_allowed = true;
 
-						} // End if().
-					} // End if().
+						}
+					}
 				} elseif ( $this->access_settings() ) {
 					// Check if the user has started the course
 					if ( is_user_logged_in() && ! Sensei_Utils::user_started_course( $lesson_course_id, $current_user->ID ) && ( isset( $this->settings->settings['access_permission'] ) && ( true == $this->settings->settings['access_permission'] ) ) ) {
@@ -932,22 +932,22 @@ class Sensei_Main {
 						} else {
 							// translators: The placeholder %1$s is a link to the Course.
 							$this->permissions_message['message'] = sprintf( __( 'Please sign up for the %1$s before starting this Quiz.', 'sensei-lms' ), $course_link );
-						} // End if().
+						}
 					} else {
 						$user_allowed = true;
-					} // End if().
+					}
 				} else {
 					$this->permissions_message['title'] = get_the_title( $post->ID ) . ': ' . __( 'Restricted Access', 'sensei-lms' );
 					$course_link                        = '<a href="' . esc_url( get_permalink( get_post_meta( get_post_meta( $post->ID, '_quiz_lesson', true ), '_lesson_course', true ) ) ) . '">' . __( 'course', 'sensei-lms' ) . '</a>';
 					// translators: The placeholder %1$s is a link to the Course.
 					$this->permissions_message['message'] = sprintf( __( 'Please sign up for the %1$s before taking this Quiz.', 'sensei-lms' ), $course_link );
-				} // End if().
+				}
 				break;
 			default:
 				$user_allowed = true;
 				break;
 
-		} // End switch().
+		}
 
 		/**
 		 * filter the permissions message shown on sensei post types.
@@ -980,7 +980,7 @@ class Sensei_Main {
 		 */
 		return apply_filters( 'sensei_access_permissions', $user_allowed, $current_user->ID );
 
-	} // End get_placeholder_image()
+	}
 
 
 	/**
@@ -1001,11 +1001,11 @@ class Sensei_Main {
 				return true;
 			} else {
 				return false;
-			} // End if().
+			}
 		} else {
 			return true;
-		} // End if().
-	} // End access_settings()
+		}
+	}
 
 	/**
 	 * load_class loads in class files
@@ -1017,8 +1017,8 @@ class Sensei_Main {
 	public function load_class( $class_name = '' ) {
 		if ( '' != $class_name && '' != $this->token ) {
 			require_once dirname( __FILE__ ) . '/class-' . esc_attr( $this->token ) . '-' . esc_attr( $class_name ) . '.php';
-		} // End if().
-	} // End load_class()
+		}
+	}
 
 	/**
 	 * Filtering wp_count_comments to ensure that Sensei comments are ignored.
@@ -1352,7 +1352,7 @@ class Sensei_Main {
 		</div>
 
 		<?php
-	}//end disable_sensei_modules_extension()
+	}
 
 	/**
 	 * Sensei wide rewrite flush call.
@@ -1381,7 +1381,7 @@ class Sensei_Main {
 
 		}
 
-	} // end flush_rewrite_rules
+	}
 
 	/**
 	 * Calling this function will tell Sensei to flush rewrite
@@ -1588,7 +1588,7 @@ class Sensei_Main {
 		return trailingslashit( $this->plugin_path ) . $path;
 	}
 
-} // End Class
+}
 
 /**
  * Class Woothemes_Sensei

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -244,7 +244,7 @@ function sensei_do_deprecated_action( $hook_tag, $version, $alternative = '', $a
 
 	}
 
-}//end sensei_do_deprecated_action()
+}
 
 /**
  * Check the given post or post type id is a of the
@@ -285,7 +285,7 @@ function sensei_user_login_url() {
 
 	}
 
-}//end sensei_user_login_url()
+}
 
 /**
  * Checks the settings to see

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -116,7 +116,7 @@ class Sensei_Legacy_Shortcodes {
 
 		return self::generate_shortcode_courses( __( 'Paid Courses', 'sensei-lms' ), 'paidcourses' );
 
-	} // End paid_courses()
+	}
 
 
 	/**
@@ -131,7 +131,7 @@ class Sensei_Legacy_Shortcodes {
 
 		return self::generate_shortcode_courses( __( 'Featured Courses', 'sensei-lms' ), 'featuredcourses' );
 
-	} // End featured_courses()
+	}
 
 	/**
 	 * shortcode_free_courses function.
@@ -145,7 +145,7 @@ class Sensei_Legacy_Shortcodes {
 
 		return self::generate_shortcode_courses( __( 'Free Courses', 'sensei-lms' ), 'freecourses' );
 
-	} // End free_courses()
+	}
 
 	/**
 	 * shortcode_new_courses function.
@@ -159,7 +159,7 @@ class Sensei_Legacy_Shortcodes {
 
 		return self::generate_shortcode_courses( __( 'New Courses', 'sensei-lms' ), 'newcourses' );
 
-	} // End new_courses()
+	}
 
 	/**
 	 * Generate courses adding a title.
@@ -210,7 +210,7 @@ class Sensei_Legacy_Shortcodes {
 
 		return $content;
 
-	}//end generate_shortcode_courses()
+	}
 
 
 	/**
@@ -249,7 +249,7 @@ class Sensei_Legacy_Shortcodes {
 		$content = ob_get_clean();
 		return $content;
 
-	} // End user_courses()
+	}
 
 	/**
 	 * This function is simply to honor the legacy
@@ -277,7 +277,7 @@ class Sensei_Legacy_Shortcodes {
 
 			$amount = $wp_query->get( 'posts_per_page' );
 
-		} // End If Statement
+		}
 
 		// This is not a paginated page (or it's simply the first page of a paginated page/post)
 		global $posts_array;
@@ -319,7 +319,7 @@ class Sensei_Legacy_Shortcodes {
 				// output the course markup
 				self::the_course( $course->ID );
 
-			} // End For Loop
+			}
 
 			// More and Prev links
 			$posts_array_query = new WP_Query( Sensei()->course->course_query( $shortcode_override, $amount, $course_includes, $course_excludes ) );
@@ -360,8 +360,8 @@ class Sensei_Legacy_Shortcodes {
 
 				echo wp_kses_post( apply_filters( 'course_archive_next_link', $html ) );
 
-			} // End If Statement
-		} // End If Statement
+			}
+		}
 	}
 
 	/**
@@ -414,7 +414,7 @@ class Sensei_Legacy_Shortcodes {
 									<?php echo esc_html( $author_display_name ); ?>
 								</a>
 							</span>
-						<?php } // End If Statement ?>
+						<?php }?>
 
 						<span class="course-lesson-count">
 							<?php
@@ -430,7 +430,7 @@ class Sensei_Legacy_Shortcodes {
 								echo wp_kses_post( sprintf( __( 'in %s', 'sensei-lms' ), $category_output ) );
 								?>
 							</span>
-						<?php } // End If Statement ?>
+						<?php }?>
 
 						<?php
 						/** This action is documented in includes/class-sensei-frontend.php */
@@ -466,6 +466,6 @@ class Sensei_Legacy_Shortcodes {
 
 		<?php
 
-	} // end the_course
+	}
 
-}//end class
+}

--- a/includes/shortcodes/class-sensei-legacy-shortcodes.php
+++ b/includes/shortcodes/class-sensei-legacy-shortcodes.php
@@ -414,7 +414,7 @@ class Sensei_Legacy_Shortcodes {
 									<?php echo esc_html( $author_display_name ); ?>
 								</a>
 							</span>
-						<?php }?>
+						<?php } ?>
 
 						<span class="course-lesson-count">
 							<?php
@@ -430,7 +430,7 @@ class Sensei_Legacy_Shortcodes {
 								echo wp_kses_post( sprintf( __( 'in %s', 'sensei-lms' ), $category_output ) );
 								?>
 							</span>
-						<?php }?>
+						<?php } ?>
 
 						<?php
 						/** This action is documented in includes/class-sensei-frontend.php */

--- a/includes/shortcodes/class-sensei-shortcode-course-categories.php
+++ b/includes/shortcodes/class-sensei-shortcode-course-categories.php
@@ -111,7 +111,7 @@ class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 
 		return $terms_html;
 
-	}//end render()
+	}
 
 	/**
 	 * Convert an array of mixed ids, slugs or names to only the id's of those terms
@@ -153,7 +153,7 @@ class Sensei_Shortcode_Course_Categories implements Sensei_Shortcode_Interface {
 
 		return $cat_ids;
 
-	}//end generate_term_ids()
+	}
 
-}//end class
+}
 

--- a/includes/shortcodes/class-sensei-shortcode-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-courses.php
@@ -139,7 +139,7 @@ class Sensei_Shortcode_Courses implements Sensei_Shortcode_Interface {
 						$teachers[ $index ] = $user->ID;
 
 					}
-				} // end for each
+				}
 
 				$teacher_query_by = 'author__in';
 				$this->teacher    = $teachers;
@@ -153,7 +153,7 @@ class Sensei_Shortcode_Courses implements Sensei_Shortcode_Interface {
 			// attach teacher query by and teacher query value to the course query
 			$query_args[ $teacher_query_by ] = $this->teacher;
 
-		}// end if empty teacher
+		}
 
 		// add the course category taxonomy query
 		if ( ! empty( $this->category ) ) {
@@ -214,6 +214,6 @@ class Sensei_Shortcode_Courses implements Sensei_Shortcode_Interface {
 
 		return $shortcode_output;
 
-	}//end render()
+	}
 
 }

--- a/includes/shortcodes/class-sensei-shortcode-featured-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-featured-courses.php
@@ -123,6 +123,6 @@ class Sensei_Shortcode_Featured_Courses implements Sensei_Shortcode_Interface {
 
 		return $shortcode_output;
 
-	}//end render()
+	}
 
 }

--- a/includes/shortcodes/class-sensei-shortcode-lesson-page.php
+++ b/includes/shortcodes/class-sensei-shortcode-lesson-page.php
@@ -101,7 +101,7 @@ class Sensei_Shortcode_Lesson_Page implements Sensei_Shortcode_Interface {
 
 		return $shortcode_output;
 
-	}//end render()
+	}
 
-}//end class
+}
 

--- a/includes/shortcodes/class-sensei-shortcode-loader.php
+++ b/includes/shortcodes/class-sensei-shortcode-loader.php
@@ -209,5 +209,5 @@ class Sensei_Shortcode_Loader {
 
 	}
 
-} // end class Sensei_Shortcodes
+}
 new Sensei_Shortcode_Loader();

--- a/includes/shortcodes/class-sensei-shortcode-teachers.php
+++ b/includes/shortcodes/class-sensei-shortcode-teachers.php
@@ -71,7 +71,7 @@ class Sensei_Shortcode_Teachers implements Sensei_Shortcode_Interface {
 
 		$this->user_query = new WP_User_Query( $user_query_args );
 
-	}//end setup_teacher_query()
+	}
 
 	/**
 	 * Rendering the shortcode this class is responsible for.
@@ -126,7 +126,7 @@ class Sensei_Shortcode_Teachers implements Sensei_Shortcode_Interface {
 
 		return '<ul class="sensei-teachers">' . $users_output . '</ul>';
 
-	}//end render()
+	}
 
 	/**
 	 * remove duplicate user objects from and array of users
@@ -161,7 +161,7 @@ class Sensei_Shortcode_Teachers implements Sensei_Shortcode_Interface {
 
 		return $users;
 
-	}//end users_unique()
+	}
 
 	/**
 	 * Exclude users based ont he ids given.
@@ -186,7 +186,7 @@ class Sensei_Shortcode_Teachers implements Sensei_Shortcode_Interface {
 
 		return $users;
 
-	}//end exclude_users()
+	}
 
 	/**
 	 * Convert mixed array of user id and user names to only be an array of user_ids
@@ -277,6 +277,6 @@ class Sensei_Shortcode_Teachers implements Sensei_Shortcode_Interface {
 
 		return strcasecmp( $this->get_user_public_name( $user_1 ), $this->get_user_public_name( $user_2 ) );
 
-	}//end custom_user_sort()
+	}
 
-}//end class
+}

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -345,7 +345,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 		return $shortcode_output;
 
-	}//end render()
+	}
 
 	/**
 	 * Add hooks for the shortcode
@@ -494,7 +494,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 		return $classes;
 
-	}//end course_status_class_tagging()
+	}
 
 	/**
 	 * Output the course toggle functionality

--- a/includes/shortcodes/class-sensei-shortcode-user-messages.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-messages.php
@@ -106,6 +106,6 @@ class Sensei_Shortcode_User_Messages implements Sensei_Shortcode_Interface {
 
 		return $messages_html;
 
-	}//end render()
+	}
 
-}//end class
+}

--- a/includes/shortcodes/interface-sensei-shortcode.php
+++ b/includes/shortcodes/interface-sensei-shortcode.php
@@ -29,4 +29,4 @@ interface Sensei_Shortcode_Interface {
 	 */
 	public function render();
 
-}//end interface
+}

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -32,7 +32,7 @@ function course_single_lessons() {
 
 	remove_filter( 'post_class', [ 'Sensei_Lesson', 'single_course_lessons_classes' ] );
 
-} // End course_single_lessons()
+}
 
 	 /**
 	  * quiz_questions function.
@@ -48,7 +48,7 @@ function quiz_questions( $return = false ) {
 	_deprecated_function( __FUNCTION__, '1.9.0', 'Sensei_Templates::get_template' );
 	Sensei_Templates::get_template( 'single-quiz/quiz-questions.php' );
 
-} // End quiz_questions()
+}
 
 	 /**
 	  * quiz_question_type function.
@@ -62,7 +62,7 @@ function quiz_question_type( $question_type = 'multiple-choice' ) {
 
 	Sensei_Question::load_question_template( $question_type );
 
-} // End lesson_single_meta()
+}
 
 	 /***************************************************************************************************
 	  * Helper functions.
@@ -82,7 +82,7 @@ function sensei_check_prerequisite_course( $course_id ) {
 	_deprecated_function( __FUNCTION__, '1.9.0', 'Sensei_Course::is_prerequisite_complete' );
 	return Sensei_Course::is_prerequisite_complete( $course_id );
 
-} // End sensei_check_prerequisite_course()
+}
 
 
 	/**
@@ -128,7 +128,7 @@ function sensei_wc_add_to_cart( $course_id ) {
 	}
 
 	Sensei_WC::the_add_to_cart_button_html( $course_id );
-} // End sensei_wc_add_to_cart()
+}
 
 
 /**
@@ -147,7 +147,7 @@ function sensei_check_if_product_is_in_cart( $wc_product_id = 0 ) {
 	}
 
 	return Sensei_WC::is_product_in_cart( $wc_product_id );
-} // End sensei_check_if_product_is_in_cart()
+}
 
 	/**
 	 * sensei_simple_course_price function.
@@ -164,7 +164,7 @@ function sensei_simple_course_price( $post_id ) {
 	}
 
 	\Sensei_WC_Paid_Courses\Frontend\Courses::instance()->output_course_price( $post_id );
-} // End sensei_simple_course_price()
+}
 
 	/**
 	 * sensei_recent_comments_widget_filter function.
@@ -178,7 +178,7 @@ function sensei_recent_comments_widget_filter( $widget_args = array() ) {
 		$widget_args['post_type'] = array( 'post', 'page' );
 	}
 	return $widget_args;
-} // End sensei_recent_comments_widget_filter()
+}
 	add_filter( 'widget_comments_args', 'sensei_recent_comments_widget_filter', 10, 1 );
 
 	/**
@@ -203,10 +203,10 @@ function sensei_course_archive_filter( $query ) {
 			$amount = absint( Sensei()->settings->settings['course_archive_amount'] );
 		} else {
 			$amount = $query->get( 'posts_per_page' );
-		} // End If Statement
+		}
 		$query->set( 'posts_per_page', $amount );
-	} // End If Statement
-} // End sensei_course_archive_filter()
+	}
+}
 	add_filter( 'pre_get_posts', 'sensei_course_archive_filter', 10, 1 );
 
 	/**
@@ -217,7 +217,7 @@ function sensei_course_archive_filter( $query ) {
 	 */
 function sensei_complete_lesson_button() {
 	do_action( 'sensei_complete_lesson_button' );
-} // End sensei_complete_lesson_button()
+}
 
 	/**
 	 * sensei_reset_lesson_button description
@@ -227,7 +227,7 @@ function sensei_complete_lesson_button() {
 	 */
 function sensei_reset_lesson_button() {
 	do_action( 'sensei_reset_lesson_button' );
-} // End sensei_reset_lesson_button()
+}
 
 	/**
 	 * Returns all of the modules and lessons in a course, in order.
@@ -402,7 +402,7 @@ function sensei_get_prev_next_lessons( $lesson_id = 0 ) {
 	}
 
 	return $links;
-} // End sensei_get_prev_next_lessons()
+}
 
 /**
  * Determine if a user has completed the pre-requisite lesson.
@@ -417,7 +417,7 @@ function sensei_has_user_completed_prerequisite_lesson( $current_lesson_id, $use
 
 	return Sensei_Lesson::is_prerequisite_complete( $current_lesson_id, $user_id );
 
-} // End sensei_has_user_completed_prerequisite_lesson()
+}
 
 /*******************************
  *
@@ -491,7 +491,7 @@ function sensei_setup_module() {
 
 	}
 
-}//end sensei_setup_module()
+}
 
 /**
  * Check if the current module in the modules loop has any lessons.
@@ -581,7 +581,7 @@ function sensei_the_module_permalink() {
 	 */
 	 echo esc_url_raw( apply_filters( 'sensei_the_module_permalink', $module_url, $module_term_id, $course_id ) );
 
-}//end sensei_the_module_permalink()
+}
 
 /**
  * Returns the current module name. This must be used
@@ -793,7 +793,7 @@ function sensei_setup_the_question() {
 	$index                                    = $sensei_question_loop['current'];
 	$sensei_question_loop['current_question'] = $sensei_question_loop['questions'][ $index ];
 
-}//end sensei_setup_the_question()
+}
 
 /**
  * This function must only be run inside the quiz question loop.
@@ -809,7 +809,7 @@ function sensei_the_question_content() {
 	// load the template that displays the question information.
 	Sensei_Question::load_question_template( $question_type );
 
-}//end sensei_the_question_content()
+}
 
 /**
  * Outputs the question class. This must only be run withing the single quiz question loop.
@@ -835,7 +835,7 @@ function sensei_the_question_class() {
 
 		$html_classes .= $class . ' ';
 
-	}// end foreach
+	}
 
 	echo esc_attr( trim( $html_classes ) );
 
@@ -855,7 +855,7 @@ function sensei_get_the_question_id() {
 
 	}
 
-}//end sensei_get_the_question_id()
+}
 
 /************************
  *
@@ -971,7 +971,7 @@ function sensei_the_single_lesson_meta() {
 
 	do_action( 'sensei_lesson_meta_extra', get_the_ID() );
 
-} // end the_single_lesson_meta
+}
 
 /**
  * This function runs the most common header hooks and ensures
@@ -1008,7 +1008,7 @@ function get_sensei_header() {
 	 */
 	do_action( 'sensei_before_main_content' );
 
-}//end get_sensei_header()
+}
 
 /**
  * This function runs the most common footer hooks and ensures
@@ -1055,7 +1055,7 @@ function get_sensei_footer() {
 
 	get_footer();
 
-}//end get_sensei_footer()
+}
 
 /**
  * Output the permissions message
@@ -1192,7 +1192,7 @@ function sensei_the_lesson_excerpt( $lesson_id = '' ) {
 
 	echo wp_kses_post( Sensei_Lesson::lesson_excerpt( get_post( $lesson_id ), false ) );
 
-}//end sensei_the_lesson_excerpt()
+}
 
 /**
  * The the course result lessons template
@@ -1259,7 +1259,7 @@ function get_the_lesson_status_class() {
 
 	return $status_class;
 
-}//end get_the_lesson_status_class()
+}
 /**
  * Outputs the lesson status class
  *

--- a/includes/theme-integrations/theme-integration-loader.php
+++ b/includes/theme-integrations/theme-integration-loader.php
@@ -53,7 +53,7 @@ class Sensei_Theme_Integration_Loader {
 			'storefront',
 		);
 
-	}//end setup_themes()
+	}
 
 	/**
 	 * Get names of all themes supported by default.
@@ -122,4 +122,4 @@ class Sensei_Theme_Integration_Loader {
 		}
 	}
 
-} /// end class
+}

--- a/includes/theme-integrations/twentyfifteen.php
+++ b/includes/theme-integrations/twentyfifteen.php
@@ -115,4 +115,4 @@ class Sensei_Twentyfifteen extends Sensei__S {
 		<?php
 	}
 
-} // end class
+}

--- a/includes/theme-integrations/underscores.php
+++ b/includes/theme-integrations/underscores.php
@@ -41,4 +41,4 @@ class Sensei__S {
 		get_sidebar();
 
 	}
-} // end class
+}

--- a/templates/archive-course.php
+++ b/templates/archive-course.php
@@ -39,7 +39,7 @@
 
 		<p><?php esc_html_e( 'No courses found that match your selection.', 'sensei-lms' ); ?></p>
 
-	<?php endif;?>
+	<?php endif; ?>
 
 	<?php
 

--- a/templates/archive-course.php
+++ b/templates/archive-course.php
@@ -39,7 +39,7 @@
 
 		<p><?php esc_html_e( 'No courses found that match your selection.', 'sensei-lms' ); ?></p>
 
-	<?php endif; // End If Statement ?>
+	<?php endif;?>
 
 	<?php
 

--- a/templates/archive-lesson.php
+++ b/templates/archive-lesson.php
@@ -33,7 +33,7 @@ do_action( 'sensei_archive_before_lesson_loop' );
 
 		<p><?php esc_html_e( 'No lessons found that match your selection.', 'sensei-lms' ); ?></p>
 
-	<?php endif; // End If Statement ?>
+	<?php endif;?>
 
 	<?php
 

--- a/templates/archive-lesson.php
+++ b/templates/archive-lesson.php
@@ -33,7 +33,7 @@ do_action( 'sensei_archive_before_lesson_loop' );
 
 		<p><?php esc_html_e( 'No lessons found that match your selection.', 'sensei-lms' ); ?></p>
 
-	<?php endif;?>
+	<?php endif; ?>
 
 	<?php
 

--- a/templates/archive-message.php
+++ b/templates/archive-message.php
@@ -37,7 +37,7 @@ do_action( 'sensei_archive_before_message_loop' );
 
 		<p> <?php esc_html_e( 'You do not have any messages.', 'sensei-lms' ); ?> </p>
 
-	<?php endif; // End If Statement ?>
+	<?php endif;?>
 
 </section>
 

--- a/templates/archive-message.php
+++ b/templates/archive-message.php
@@ -37,7 +37,7 @@ do_action( 'sensei_archive_before_message_loop' );
 
 		<p> <?php esc_html_e( 'You do not have any messages.', 'sensei-lms' ); ?> </p>
 
-	<?php endif;?>
+	<?php endif; ?>
 
 </section>
 

--- a/templates/course-results/lessons.php
+++ b/templates/course-results/lessons.php
@@ -104,9 +104,9 @@ global $course;
 
 					<?php
 
-				}// end for each
-			}// end if count lesson
-		} // end for each module
+				}
+			}
+		}
 		?>
 
 		<?php

--- a/templates/single-course/lessons.php
+++ b/templates/single-course/lessons.php
@@ -83,7 +83,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			</article>
 
-		<?php endwhile; // end course lessons loop ?>
+		<?php endwhile;?>
 
 	<?php endif; ?>
 

--- a/templates/single-course/lessons.php
+++ b/templates/single-course/lessons.php
@@ -83,7 +83,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 			</article>
 
-		<?php endwhile;?>
+		<?php endwhile; ?>
 
 	<?php endif; ?>
 

--- a/templates/single-quiz.php
+++ b/templates/single-quiz.php
@@ -115,7 +115,7 @@ do_action( 'sensei_single_quiz_content_inside_before', get_the_ID() );
 		<div
 			class="sensei-message alert"> <?php esc_html_e( 'There are no questions for this Quiz yet. Check back soon.', 'sensei-lms' ); ?></div>
 
-	<?php endif;?>
+	<?php endif; ?>
 
 	<?php
 	do_action( 'sensei_quiz_back_link', Sensei()->quiz->data->quiz_lesson );

--- a/templates/single-quiz.php
+++ b/templates/single-quiz.php
@@ -115,7 +115,7 @@ do_action( 'sensei_single_quiz_content_inside_before', get_the_ID() );
 		<div
 			class="sensei-message alert"> <?php esc_html_e( 'There are no questions for this Quiz yet. Check back soon.', 'sensei-lms' ); ?></div>
 
-	<?php endif; // End If have questions. ?>
+	<?php endif;?>
 
 	<?php
 	do_action( 'sensei_quiz_back_link', Sensei()->quiz->data->quiz_lesson );

--- a/templates/single-quiz/question-type-boolean.php
+++ b/templates/single-quiz/question-type-boolean.php
@@ -58,8 +58,8 @@ $boolean_options = array( 'true', 'false' );
 					$answer_class = 'user_wrong';
 
 				}
-			} // end if right answer == current booloean options
-		}// end if $user_correct .. $question_grade
+			}
+		}
 
 		$option_value = $option ? 'true' : 'false';
 

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -45,7 +45,7 @@ foreach ( $question_data['answer_options'] as $option ) {
 		</label>
 
 	</li>
-<?php } // End For Loop ?>
+<?php }?>
 
 </ul>
 

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -45,7 +45,7 @@ foreach ( $question_data['answer_options'] as $option ) {
 		</label>
 
 	</li>
-<?php }?>
+<?php } ?>
 
 </ul>
 

--- a/templates/teacher-archive.php
+++ b/templates/teacher-archive.php
@@ -34,7 +34,7 @@ do_action( 'sensei_teacher_archive_course_loop_before' );
 
 	<p><?php esc_html_e( 'There are no courses for this teacher.', 'sensei-lms' ); ?></p>
 
-<?php endif; // End If Statement ?>
+<?php endif;?>
 
 <?php
 

--- a/templates/teacher-archive.php
+++ b/templates/teacher-archive.php
@@ -34,7 +34,7 @@ do_action( 'sensei_teacher_archive_course_loop_before' );
 
 	<p><?php esc_html_e( 'There are no courses for this teacher.', 'sensei-lms' ); ?></p>
 
-<?php endif;?>
+<?php endif; ?>
 
 <?php
 

--- a/tests/framework/factories/class-sensei-factory.php
+++ b/tests/framework/factories/class-sensei-factory.php
@@ -108,7 +108,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 		$this->module            = new WP_UnitTest_Factory_For_Module( $this );
 		$this->message           = new WP_UnitTest_Factory_For_Message( $this );
 		$this->question_category = new WP_UnitTest_Factory_For_Question_Category( $this );
-	}//end __construct()
+	}
 
 	/**
 	 * Create basic courses, lessons, and quizzes.
@@ -268,7 +268,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 			$random_index_s = array_rand( $this->basic_test_lesson_ids, $number_of_items );
 			foreach ( $random_index_s as $index ) {
 				array_push( $result, $this->basic_test_lesson_ids[ $index ] );
-			}// end for each
+			}
 		} else {
 
 			$random_index = array_rand( $this->basic_test_lesson_ids );
@@ -278,7 +278,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 
 		return $result;
 
-	} // end get_random_valid_lesson_id()
+	}
 
 	/**
 	 * Accesses the test_data course_id's and return any one of them
@@ -298,7 +298,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 			$random_index_s = array_rand( $this->basic_test_course_ids, $number_of_items );
 			foreach ( $random_index_s as $index ) {
 				array_push( $result, $this->basic_test_course_ids[ $index ] );
-			}// end for each
+			}
 		} else {
 
 			$random_index = array_rand( $this->basic_test_course_ids );
@@ -308,7 +308,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 
 		return $result;
 
-	} // end get_random_course_id()
+	}
 
 	/**
 	 * Attach modules and lessons to each course.
@@ -344,7 +344,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 
 		return $lesson_ids;
 
-	}//end get_lessons()
+	}
 
 	/**
 	 * @since 1.9.20
@@ -369,7 +369,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 
 		return $course_ids;
 
-	}//end get_courses()
+	}
 
 	/**
 	 * Get a course that has modules.
@@ -453,11 +453,11 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 				$user_quiz_answers[ $question->ID ] = '';
 
 			}
-		}// end for quiz_question_posts
+		}
 
 		return $user_quiz_answers;
 
-	}//end generate_user_quiz_answers()
+	}
 
 	/**
 	 * Generate an array of user quiz grades
@@ -479,11 +479,11 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 
 			$quiz_grades[ $question_id ] = rand( 1, 5 );
 
-		}//  end foreach
+		}
 
 		return $quiz_grades;
 
-	}//end generate_user_quiz_grades()
+	}
 
 	/**
 	 * Generate and attach lesson questions.
@@ -550,7 +550,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 				add_post_meta( $question->ID, '_quiz_question_order' . $quiz_id, $question_order );
 
 			}
-		} // end if count
+		}
 
 		return $quiz_id;
 	}
@@ -646,11 +646,11 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 				// pop the file on top of the car
 				$files[ 'file_upload_' . $question_id ] = $file;
 			}
-		} // end for each $test_user_quiz_answers
+		}
 
 		return $files;
 
-	}//end generate_test_files()
+	}
 
 	/**
 	 * Returns a random none file question id from the given user input array
@@ -679,12 +679,12 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 			if ( 'file-upload' != $type ) {
 				$answers_without_files[ $question_id ] = $answer;
 			}
-		}// end foreach
+		}
 
 		$index = array_rand( $answers_without_files );
 
 		return $index;
-	}//end get_random_none_file_question_index()
+	}
 
 
 	/**
@@ -714,12 +714,12 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 			if ( 'file-upload' == $type ) {
 				$file_type_answers[ $question_id ] = $answer;
 			}
-		}// end foreach
+		}
 
 		$index = array_rand( $file_type_answers );
 
 		return $index;
-	}//end get_random_file_question_index()
+	}
 
 
 	/**
@@ -753,7 +753,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 
 		return $answers_feedback;
 
-	} // end generate_user_answers_feedback
+	}
 
 	/**
 	 * @return int|WP_Error
@@ -795,4 +795,4 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 		return $lesson_id;
 	}
 
-}//end class
+}

--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -14,7 +14,7 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 		parent::setup();
 
 		$this->factory = new Sensei_Factory();
-	}//end setup()
+	}
 
 	public function tearDown() {
 		parent::tearDown();
@@ -29,7 +29,7 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 	public function testClassInstance() {
 		// test if the class exists
 		$this->assertTrue( class_exists( 'WooThemes_Sensei_Admin' ), 'Sensei Admin class does not exist' );
-	} // end testClassInstance
+	}
 
 	/**
 	 * Test duplicate courses with lessons.
@@ -263,4 +263,4 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 		);
 		return get_posts( $duplicated_lesson_args )[0];
 	}
-}//end class
+}

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -24,7 +24,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 
 		$this->factory = new Sensei_Factory();
 		Sensei_Test_Events::reset();
-	}//end setup()
+	}
 
 	public function tearDown() {
 		parent::tearDown();
@@ -44,7 +44,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		// test if the global sensei quiz class is loaded
 		$this->assertTrue( isset( Sensei()->course ), 'Sensei Course class is not loaded' );
 
-	} // end testClassInstance
+	}
 
 	/**
 	 * This tests Sensei_Courses::get_all_course
@@ -70,7 +70,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 			'The number of course returned is not equal to what is actually available'
 		);
 
-	}//end testGetAllCourses()
+	}
 
 	/**
 	 *
@@ -111,7 +111,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		// does it return all lessons
 		$this->assertEquals( count( $test_lessons ), count( Sensei()->course->get_completed_lesson_ids( $test_course_id, $test_user_id ) ), 'Course completed lesson count not accurate' );
 
-	}//end testGetCompletedLessonIds()
+	}
 
 	/**
 	 * This tests Sensei_Courses::get_completion_percentage
@@ -398,4 +398,4 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( $course_instance->can_access_course_content( $course_id, $user_id ), 'Standard users who are enrolled should have access to course content' );
 	}
-}//end class
+}

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -12,7 +12,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 
 		Sensei()->grading = new WooThemes_Sensei_Grading( '' );
 		$this->factory    = new Sensei_Factory();
-	}//end setUp()
+	}
 
 	public function tearDown() {
 		parent::tearDown();
@@ -27,7 +27,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		// test if the global sensei quiz class is loaded
 		$this->assertTrue( isset( Sensei()->grading ), 'Sensei Grading class is not loaded' );
 
-	} // end testClassInstance
+	}
 
 	/**
 	 * Data source for ::testGradeGapFillQuestionRegEx
@@ -92,7 +92,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 				false,
 			),
 		);
-	} // end gradeGapFillQuestions
+	}
 
 	/**
 	 * @dataProvider gradeGapFillQuestions
@@ -119,7 +119,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 			$response = Sensei_Grading::grade_gap_fill_question( $question_id, $not_found_item );
 			$this->assertFalse( $response, "Expecting {$not_found_item} to not match {$answer}" );
 		}
-	} // end testGradeGapFillQuestionRegEx
+	}
 
 	/**
 	 * Get a test question.
@@ -135,5 +135,5 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		$question['quiz_id']     = $quiz_id;
 		$question['post_author'] = get_post( $quiz_id )->post_author;
 		return Sensei()->lesson->lesson_save_question( $question );
-	} // end getTestQuestion
-}//end class
+	}
+}

--- a/tests/unit-tests/test-class-learner.php
+++ b/tests/unit-tests/test-class-learner.php
@@ -23,7 +23,7 @@ class Sensei_Class_Student_Test extends WP_UnitTestCase {
 		$this->factory = new Sensei_Factory();
 
 		self::resetEnrolmentProviders();
-	}//end setUp()
+	}
 
 	public function tearDown() {
 		parent::tearDown();
@@ -39,7 +39,7 @@ class Sensei_Class_Student_Test extends WP_UnitTestCase {
 		// test if the global sensei quiz class is loaded
 		$this->assertTrue( class_exists( 'Sensei_Learner' ), 'the Sensei student class is not loaded' );
 
-	} // end testClassInstance
+	}
 
 	/**
 	 * Tests that user enrolments terms are deleted when user is deleted.
@@ -242,7 +242,7 @@ class Sensei_Class_Student_Test extends WP_UnitTestCase {
 		$this->assertFalse( Sensei_Learner::get_full_name( 'abc' ), 'Invalid user_id should return false' );
 		$this->assertFalse( Sensei_Learner::get_full_name( 4000000 ), 'Invalid user_id should return false' );
 
-	}//end testGetLearnerFullNameBasicAssumptions()
+	}
 
 	/**
 	 * Testing the get_learner_full_name function to see if it returns what is expected.
@@ -275,6 +275,6 @@ class Sensei_Class_Student_Test extends WP_UnitTestCase {
 			'This function should return the users first name and last name.'
 		);
 
-	}//end testGetLearnerFullName()
+	}
 
-}//end class
+}

--- a/tests/unit-tests/test-class-lesson-modules.php
+++ b/tests/unit-tests/test-class-lesson-modules.php
@@ -102,4 +102,4 @@ class Sensei_Class_Lesson_Modules_Test extends WP_UnitTestCase {
 		$this->assertEquals( wp_get_object_terms( $this->lesson_id, $this->module_taxonomy ), array() );
 	}
 
-} // end class
+}

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -26,7 +26,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 
 		$this->factory = new Sensei_Factory();
 		Sensei_Test_Events::reset();
-	}//end setup()
+	}
 
 	public function tearDown() {
 		parent::tearDown();
@@ -46,7 +46,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		// test if the global sensei lesson class is loaded
 		$this->assertTrue( isset( Sensei()->lesson ), 'Sensei lesson class is not loaded on the global sensei Object' );
 
-	} // end testClassInstance
+	}
 
 
 	/**
@@ -99,7 +99,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 			'Users that has completed prerequisite should return true.'
 		);
 
-	} // end testIsPreRequisiteComplete
+	}
 
 	public function testAddLessonToCourseOrderHook() {
 		if ( ! isset( Sensei()->admin ) ) {

--- a/tests/unit-tests/test-class-modules.php
+++ b/tests/unit-tests/test-class-modules.php
@@ -37,7 +37,7 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 		// test if the global sensei quiz class is loaded
 		$this->assertTrue( isset( Sensei()->modules ), 'Sensei Modules class is not loaded' );
 
-	} // end testClassInstance
+	}
 
 	/**
 	 * @covers Sensei_Core_Modules::do_link_to_module
@@ -143,4 +143,4 @@ class Sensei_Class_Modules_Test extends WP_UnitTestCase {
 
 	}
 
-} // end class
+}

--- a/tests/unit-tests/test-class-question.php
+++ b/tests/unit-tests/test-class-question.php
@@ -21,7 +21,7 @@ class Sensei_Class_Question_Test extends WP_UnitTestCase {
 
 		$this->factory = new Sensei_Factory();
 		Sensei_Test_Events::reset();
-	}//end setup()
+	}
 
 	public function tearDown() {
 		parent::tearDown();
@@ -36,7 +36,7 @@ class Sensei_Class_Question_Test extends WP_UnitTestCase {
 		// test if the global sensei quiz class is loaded
 		$this->assertTrue( isset( Sensei()->question ), 'Sensei Question class is not loaded' );
 
-	} // end testClassInstance
+	}
 
 	/**
 	 * This tests Woothemes_Sensei()->quiz->get_question_type
@@ -78,7 +78,7 @@ class Sensei_Class_Question_Test extends WP_UnitTestCase {
 			'The method get_question_type should return false for an empty string parameter'
 		);
 
-	}//end testGetQuestionType()
+	}
 
 	/**
 	 * Test initial publish logging default property values.

--- a/tests/unit-tests/test-class-sensei-feature-flags.php
+++ b/tests/unit-tests/test-class-sensei-feature-flags.php
@@ -35,4 +35,4 @@ class Sensei_Class_Feature_Flags_Test extends WP_UnitTestCase {
 		$this->assertFalse( $flags->is_enabled( 'foo_feature' ), 'overriden by filter' );
 	}
 
-}//end class
+}

--- a/tests/unit-tests/test-class-teacher.php
+++ b/tests/unit-tests/test-class-teacher.php
@@ -27,7 +27,7 @@ class Sensei_Class_Teacher_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		$this->factory = new Sensei_Factory();
-	}//end setup()
+	}
 
 	/**
 	 *
@@ -40,21 +40,21 @@ class Sensei_Class_Teacher_Test extends WP_UnitTestCase {
 		$lessons = get_posts( 'post_type=course' );
 		foreach ( $lessons as $index => $lesson ) {
 			wp_delete_post( $lesson->ID, true );
-		}// end for each
+		}
 
 		// remove all lessons
 		$lessons = get_posts( 'post_type=lesson' );
 		foreach ( $lessons as $index => $lesson ) {
 			wp_delete_post( $lesson->ID, true );
-		}// end for each
+		}
 
 		// remove all quizzes
 		$quizzes = get_posts( 'post_type=quiz' );
 		foreach ( $quizzes as $index => $quiz ) {
 			wp_delete_post( $quiz->ID, true );
-		}// end for each
+		}
 
-	}//end tearDown()
+	}
 
 	/**
 	 * Testing the quiz class to make sure it is loaded
@@ -64,7 +64,7 @@ class Sensei_Class_Teacher_Test extends WP_UnitTestCase {
 		// test if the global sensei quiz class is loaded
 		$this->assertTrue( isset( Sensei()->teacher ), 'Sensei Modules class is not loaded' );
 
-	} // end testClassInstance
+	}
 
 	/**
 	 * Testing Sensei_Teacher::update_course_modules_author
@@ -149,7 +149,7 @@ class Sensei_Class_Teacher_Test extends WP_UnitTestCase {
 		$message                           = 'A new admin term with slug {adminID}-slug should not have been created. The admin term should not be duplicated when passed back to admin';
 		$this->assertFalse( strpos( $admin_term_after_multiple_updates[0]->slug, (string) $administrator->ID ), $message );
 
-	} // end test author change
+	}
 
 	/**
 	 * Testing Sensei_Teacher::update_course_modules_author
@@ -221,7 +221,7 @@ class Sensei_Class_Teacher_Test extends WP_UnitTestCase {
 			$this->assertEquals( $expected_module_2_slug, $term_after_update[0]->slug, 'Lesson module was not updated, ID: ' . $lesson_id );
 		}
 
-	}//end testUpdateCourseModulesAuthorChangeLessons()
+	}
 
 	public function testUpdateLessonTeacher() {
 		// setup assertions
@@ -385,4 +385,4 @@ class Sensei_Class_Teacher_Test extends WP_UnitTestCase {
 
 	}
 
-} // end class
+}

--- a/tests/unit-tests/test-class-utils.php
+++ b/tests/unit-tests/test-class-utils.php
@@ -24,7 +24,7 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		// remove this action so that no emails are sent during this test
 		remove_all_actions( 'sensei_user_course_start' );
 
-	}//end setup()
+	}
 
 	public function tearDown() {
 		parent::tearDown();
@@ -38,7 +38,7 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		// setup the test
 		// test if the global sensei quiz class is loaded
 		$this->assertTrue( class_exists( 'WooThemes_Sensei_Utils' ), 'Sensei Utils class constant is not loaded' );
-	} // end testClassInstance
+	}
 
 	/**
 	 * This tests Woothemes_Sensei_Utils::update_user_data
@@ -99,7 +99,7 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		// is the data saved still intact
 		$this->assertEquals( $test_array, $retrieved_array, 'The saved and retrieved data does not match' );
 
-	}//end testUpdateUserData()
+	}
 
 	/**
 	 * This tests Woothemes_Sensei_Utils::get_user_data
@@ -152,7 +152,7 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		// doest this function return the data that was saved?
 		$this->assertEquals( $test_array, $retrieved_value, 'This function does not retrieve the data that was saved' );
 
-	}//end testGetUserData()
+	}
 
 	/**
 	 * This tests Woothemes_Sensei_Utils::delete_user_data
@@ -205,7 +205,7 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		$this->assertTrue( $deleted, 'The user data should have been deleted, but was not' );
 		$this->assertEmpty( $retrieved_value, 'After deleting the user data should return false' );
 
-	}//end testDeleteUserData()
+	}
 
 	/**
 	 * This tests Woothemes_Sensei_Utils::round
@@ -217,7 +217,7 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		$this->assertTrue( doubleval( 2.13 ) == WooThemes_Sensei_Utils::round( 2.1256, 2 ), '2.1256 rounded with 2 precision should be 2.12' );
 		$this->assertTrue( 3 == WooThemes_Sensei_Utils::round( 2.5, 0 ), '2.5 rounded with 0 precision should be 3' );
 
-	}//end testRound()
+	}
 
 	/**
 	 * Test the array zip utility function
@@ -236,4 +236,4 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $array_zipped );
 	}
 
-}//end class
+}

--- a/widgets/class-sensei-category-courses-widget.php
+++ b/widgets/class-sensei-category-courses-widget.php
@@ -47,7 +47,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 		/* Create the widget. */
 		parent::__construct( $this->widget_idbase, $this->widget_title, $widget_ops, $control_ops );
 
-	} // End __construct()
+	}
 
 	/**
 	 * Display the widget on the frontend.
@@ -81,7 +81,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 
 		if ( 0 < intval( $instance['course_category'] ) ) {
 			$this->load_component( $instance );
-		} // End If Statement
+		}
 
 		// Add actions for plugins/themes to hook onto.
 		do_action( $this->widget_cssclass . '_bottom' );
@@ -89,7 +89,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 		/* After widget (defined by themes). */
 		echo wp_kses_post( $after_widget );
 
-	} // End widget()
+	}
 
 	/**
 	 * Method to update the settings from the form() method.
@@ -112,7 +112,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 		$instance['limit'] = strip_tags( $new_instance['limit'] );
 
 		return $instance;
-	} // End update()
+	}
 
 	/**
 	 * The form on the widget control in the widget administration area.
@@ -164,7 +164,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 		</p>
 
 		<?php
-	} // End form()
+	}
 
 	/**
 	 * Load the output.
@@ -224,7 +224,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 							</a>
 						</span>
 						<br />
-					<?php } // End If Statement ?>
+					<?php }?>
 					<span class="course-lesson-count">
 						<?php
 						// translators: Placeholder %d is the lesson count.
@@ -237,9 +237,9 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 					do_action( 'sensei_course_meta_inside_after', $post_id );
 					?>
 				</li>
-			<?php } // End For Loop ?>
+			<?php }?>
 			</ul>
 			<?php
-		} // End If Statement
-	} // End load_component()
-} // End Class
+		}
+	}
+}

--- a/widgets/class-sensei-category-courses-widget.php
+++ b/widgets/class-sensei-category-courses-widget.php
@@ -224,7 +224,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 							</a>
 						</span>
 						<br />
-					<?php }?>
+					<?php } ?>
 					<span class="course-lesson-count">
 						<?php
 						// translators: Placeholder %d is the lesson count.
@@ -237,7 +237,7 @@ class Sensei_Category_Courses_Widget extends WP_Widget {
 					do_action( 'sensei_course_meta_inside_after', $post_id );
 					?>
 				</li>
-			<?php }?>
+			<?php } ?>
 			</ul>
 			<?php
 		}

--- a/widgets/class-sensei-course-categories-widget.php
+++ b/widgets/class-sensei-course-categories-widget.php
@@ -46,7 +46,7 @@ class Sensei_Course_Categories_Widget extends WP_Widget {
 
 		/* Create the widget. */
 		parent::__construct( $this->widget_idbase, $this->widget_title, $widget_ops, $control_ops );
-	} // End __construct()
+	}
 
 	/**
 	 * Display the widget on the frontend.
@@ -86,7 +86,7 @@ class Sensei_Course_Categories_Widget extends WP_Widget {
 		/* After widget (defined by themes). */
 		echo wp_kses_post( $after_widget );
 
-	} // End widget()
+	}
 
 	/**
 	 * Method to update the settings from the form() method.
@@ -110,7 +110,7 @@ class Sensei_Course_Categories_Widget extends WP_Widget {
 		$instance['hierarchical'] = $new_instance['hierarchical'];
 
 		return $instance;
-	} // End update()
+	}
 
 	/**
 	 * The form on the widget control in the widget administration area.
@@ -155,7 +155,7 @@ class Sensei_Course_Categories_Widget extends WP_Widget {
 			<label for="<?php echo esc_attr( $this->get_field_id( 'hierarchical' ) ); ?>"><?php esc_html_e( 'Show hierarchy', 'sensei-lms' ); ?></label>
 		</p>
 		<?php
-	} // End form()
+	}
 
 	/**
 	 * Load the output.
@@ -179,9 +179,9 @@ class Sensei_Course_Categories_Widget extends WP_Widget {
 		);
 		if ( 0 < $limit ) {
 			$cat_args['number'] = $limit;
-		} // End If Statement
+		}
 		echo '<ul>';
 			wp_list_categories( apply_filters( 'widget_course_categories_args', $cat_args ) );
 		echo '</ul>';
-	} // End load_component()
-} // End Class
+	}
+}

--- a/widgets/class-sensei-course-component-widget.php
+++ b/widgets/class-sensei-course-component-widget.php
@@ -309,7 +309,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 							</a>
 						</span>
 						<br />
-					<?php }?>
+					<?php } ?>
 
 					<span class="course-lesson-count">
 						<?php

--- a/widgets/class-sensei-course-component-widget.php
+++ b/widgets/class-sensei-course-component-widget.php
@@ -67,7 +67,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 
 		/* Create the widget. */
 		parent::__construct( $this->widget_idbase, $this->widget_title, $widget_ops, $control_ops );
-	} // End __construct()
+	}
 
 	/**
 	 * Display the widget on the frontend.
@@ -118,7 +118,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 
 		add_filter( 'pre_get_posts', 'sensei_course_archive_filter', 10, 1 );
 
-	} // End widget()
+	}
 
 	/**
 	 * Method to update the settings from the form() method.
@@ -141,7 +141,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 		$instance['limit'] = esc_attr( $new_instance['limit'] );
 
 		return $instance;
-	} // End update()
+	}
 
 	/**
 	 * The form on the widget control in the widget administration area.
@@ -185,7 +185,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 		</p>
 
 		<?php
-	} // End form()
+	}
 
 	/**
 	 * Load the desired component, if a method is available for it.
@@ -234,7 +234,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 
 		$this->display_courses( $courses );
 
-	} // End load_component()
+	}
 
 
 	/**
@@ -309,7 +309,7 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 							</a>
 						</span>
 						<br />
-					<?php } // End If Statement ?>
+					<?php }?>
 
 					<span class="course-lesson-count">
 						<?php
@@ -328,14 +328,14 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 				</li>
 
 				<?php
-			} // End For Loop
+			}
 
 			if ( 'activecourses' == esc_attr( $this->instance['component'] ) || 'completedcourses' == esc_attr( $this->instance['component'] ) ) {
 				$my_account_page_id = intval( Sensei()->settings->settings['my_course_page'] );
 				echo '<li class="my-account fix"><a href="' . esc_url( get_permalink( $my_account_page_id ) ) . '">'
 					 . esc_html__( 'My Courses', 'sensei-lms' )
 					 . '<span class="meta-nav"></span></a></li>';
-			} // End If Statement
+			}
 
 			?>
 		</ul>
@@ -437,4 +437,4 @@ class Sensei_Course_Component_Widget extends WP_Widget {
 		return get_posts( $query_args );
 
 	}
-} // End Class
+}

--- a/widgets/class-sensei-lesson-component-widget.php
+++ b/widgets/class-sensei-lesson-component-widget.php
@@ -50,7 +50,7 @@ class Sensei_Lesson_Component_Widget extends WP_Widget {
 
 		/* Create the widget. */
 		parent::__construct( $this->widget_idbase, $this->widget_title, $widget_ops, $control_ops );
-	} // End __construct()
+	}
 
 	/**
 	 * Display the widget on the frontend.
@@ -94,9 +94,9 @@ class Sensei_Lesson_Component_Widget extends WP_Widget {
 
 			/* After widget (defined by themes). */
 			echo wp_kses_post( $after_widget );
-		} // End If Statement
+		}
 
-	} // End widget()
+	}
 
 	/**
 	 * Method to update the settings from the form() method.
@@ -119,7 +119,7 @@ class Sensei_Lesson_Component_Widget extends WP_Widget {
 		$instance['limit'] = esc_attr( $new_instance['limit'] );
 
 		return $instance;
-	} // End update()
+	}
 
 	/**
 	 * The form on the widget control in the widget administration area.
@@ -163,7 +163,7 @@ class Sensei_Lesson_Component_Widget extends WP_Widget {
 		</p>
 
 		<?php
-	} // End form()
+	}
 
 	/**
 	 * Load the desired component, if a method is available for it.
@@ -212,7 +212,7 @@ class Sensei_Lesson_Component_Widget extends WP_Widget {
 							</a>
 						</span>
 						<br />
-					<?php } // End If Statement ?>
+					<?php }?>
 					<?php if ( 0 < $lesson_course_id ) { ?>
 						<span class="lesson-course">
 							<?php
@@ -228,10 +228,10 @@ class Sensei_Lesson_Component_Widget extends WP_Widget {
 					<?php } ?>
 					<br />
 				</li>
-			<?php } // End For Loop ?>
+			<?php }?>
 			<?php echo '<li class="my-account fix"><a class="button" href="' . esc_url( get_post_type_archive_link( 'lesson' ) ) . '">' . esc_html__( 'More Lessons', 'sensei-lms' ) . '</a></li>'; ?>
 		</ul>
 			<?php
-		} // End If Statement
-	} // End load_component()
-} // End Class
+		}
+	}
+}

--- a/widgets/class-sensei-lesson-component-widget.php
+++ b/widgets/class-sensei-lesson-component-widget.php
@@ -212,7 +212,7 @@ class Sensei_Lesson_Component_Widget extends WP_Widget {
 							</a>
 						</span>
 						<br />
-					<?php }?>
+					<?php } ?>
 					<?php if ( 0 < $lesson_course_id ) { ?>
 						<span class="lesson-course">
 							<?php
@@ -228,7 +228,7 @@ class Sensei_Lesson_Component_Widget extends WP_Widget {
 					<?php } ?>
 					<br />
 				</li>
-			<?php }?>
+			<?php } ?>
 			<?php echo '<li class="my-account fix"><a class="button" href="' . esc_url( get_post_type_archive_link( 'lesson' ) ) . '">' . esc_html__( 'More Lessons', 'sensei-lms' ) . '</a></li>'; ?>
 		</ul>
 			<?php


### PR DESCRIPTION
### Changes proposed in this Pull Request

I removed the `// End ...` comments after code blocks as I think that they have no purpose and are bad practice. Let me know if you think that there is a usage for them and that we should keep them. 

I basically removed code using this regexp `  *//[/ ]*[Ee]nd [^?>]+`. If we agree that these comments should be removed I can do this in other plugins too.

### Testing instructions

* Do a smoke test and observe that no page is broken.