### PR TITLE
Fix testLessonAssociatedPostsExported sporadical failures

### DIFF
--- a/includes/data-port/export-tasks/class-sensei-export-task.php
+++ b/includes/data-port/export-tasks/class-sensei-export-task.php
@@ -92,6 +92,7 @@ abstract class Sensei_Export_Task
 				'posts_per_page' => $this->batch_size,
 				'offset'         => $this->completed_posts,
 				'post_status'    => 'any',
+				'orderby'        => 'ID',
 			]
 		);
 

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-lessons.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-lessons.php
@@ -119,7 +119,7 @@ class Sensei_Export_Lessons_Tests extends WP_UnitTestCase {
 			[
 				'prerequisite' => 'id:' . $prerequisite_lesson->ID,
 			],
-			$result[0]
+			$result[1]
 		);
 	}
 


### PR DESCRIPTION
### Overview

Test testLessonAssociatedPostsExported would fail sporadically. The reason behind this was that exported posts were ordered by date which means that if the post was created in the same second, then sometimes the exported posts would have a different order. As we access the posts results array by index, the test would access the wrong post.

### Changes proposed in this Pull Request

* We now order exported posts by ID which will lead to a consistent ordering in every case.

### Testing instructions

* No observable changes.