### PR TITLE
Add sensei_duplicate_post_args filter

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -731,7 +731,7 @@ class Sensei_Admin {
 		 * post. This may be a Course, Lesson, or Quiz.
 		 *
 		 * @hook  sensei_duplicate_post_args
-		 * @since 3.10.1
+		 * @since 3.11.0
 		 *
 		 * @param {array}   $new_post The arguments for duplicating the post.
 		 * @param {WP_Post} $post     The original post being duplicated.

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -702,7 +702,7 @@ class Sensei_Admin {
 			}
 		}
 
-		$new_post['post_title']       .= empty( $suffix ) ? __( '(Duplicate)', 'sensei-lms' ) : $suffix;
+		$new_post['post_title']       .= $suffix;
 		$new_post['post_date']         = current_time( 'mysql' );
 		$new_post['post_date_gmt']     = get_gmt_from_date( $new_post['post_date'] );
 		$new_post['post_modified']     = $new_post['post_date'];

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -726,6 +726,20 @@ class Sensei_Admin {
 		// As per wp_update_post() we need to escape the data from the db.
 		$new_post = wp_slash( $new_post );
 
+		/**
+		 * Filter arguments for `wp_insert_post` when duplicating a Sensei
+		 * post. This may be a Course, Lesson, or Quiz.
+		 *
+		 * @hook  sensei_duplicate_post_args
+		 * @since 3.10.1
+		 *
+		 * @param {array}   $new_post The arguments for duplicating the post.
+		 * @param {WP_Post} $post     The original post being duplicated.
+		 *
+		 * @return {array}  The new arguments to be handed to `wp_insert_post`.
+		 */
+		$new_post = apply_filters( 'sensei_duplicate_post_args', $new_post, $post );
+
 		$new_post_id = wp_insert_post( $new_post );
 
 		if ( ! is_wp_error( $new_post_id ) ) {


### PR DESCRIPTION
Fixes #4165

### Changes proposed in this Pull Request

- Add `sensei_duplicate_post_args` filter for customizing the arguments to `wp_insert_post` when duplicating a Sensei post. This may be a Course, Lesson, or Quiz.
- Remove default `(Duplicate)` suffix from the title of duplicated posts.

_Note that if the `3.10.1` milestone is merged into the `3.11` milestone, we will need to update the doc on this new hook._

### Testing instructions

- Add the following snippet:

```php
add_filter( 'sensei_duplicate_post_args', function( $new_post, $post ) {
	if ( ! in_array( get_post_type( $post ), [ 'lesson', 'course' ], true ) ) {
		return $new_post;
	}

	$new_post['post_status'] = 'publish';
	
	return $new_post;
}, 10, 2 );
```

- Duplicate a Course using the "Duplicate (with lessons)" link on the "All courses" page.
- Ensure that the duplicated Course and all of the duplicated Lessons are published (not draft) and the titles are not suffixed with the `(Duplicate)` text.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

- `sensei_duplicate_post_args`: Filter arguments for `wp_insert_post` when duplicating a Sensei post. This may be a Course, Lesson, or Quiz.
