### PR TITLE
Minor tweaks to copy on Extensions page

### DIFF
--- a/assets/extensions/all-extensions.js
+++ b/assets/extensions/all-extensions.js
@@ -37,7 +37,7 @@ const AllExtensions = ( { extensions } ) => {
 
 			<section className="sensei-extensions__section sensei-extensions__grid__col --col-8">
 				<h2 className="sensei-extensions__section__title">
-					{ __( 'Course creation', 'sensei-lms' ) }
+					{ __( 'Course Creation', 'sensei-lms' ) }
 				</h2>
 				<ul className="sensei-extensions__section__content sensei-extensions__large-list">
 					{ extensions.map( ( extension ) => (
@@ -53,7 +53,7 @@ const AllExtensions = ( { extensions } ) => {
 
 			<section className="sensei-extensions__section sensei-extensions__grid__col --col-4">
 				<h2 className="sensei-extensions__section__title">
-					{ __( 'Learner engagement', 'sensei-lms' ) }
+					{ __( 'Learner Engagement', 'sensei-lms' ) }
 				</h2>
 				<ul className="sensei-extensions__section__content sensei-extensions__small-list">
 					{ extensions.map( ( extension ) => (

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -63,7 +63,7 @@ const Main = () => {
 		},
 		{
 			id: 'third-party',
-			label: __( 'Third party', 'sensei-lms' ),
+			label: __( 'Third Party', 'sensei-lms' ),
 			count: thirdPartyExtensions.length,
 			content: <FilteredExtensions extensions={ thirdPartyExtensions } />,
 		},

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -322,7 +322,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['course_archive_image_enable'] = array(
 			'name'        => __( 'Course Archive Image', 'sensei-lms' ),
-			'description' => __( 'Output the Course Image on the Course Archive Page (does not apply when using blocks).', 'sensei-lms' ),
+			'description' => __( 'Output the Course Image on the Course Archive Page.', 'sensei-lms' ),
 			'type'        => 'checkbox',
 			'default'     => true,
 			'section'     => 'course-settings',


### PR DESCRIPTION
Minor tweaks to copy on the Extensions and Settings pages.

I removed the settings text that was added in #4184. Since the setting explicitly mentions the course archive page, and we don't technically have any blocks for the course archive page, adding it might cause more confusion. We also don't force new translations for this text by leaving it the same.

### Testing instructions
Check that the copy was updated on the Extensions and settings pages.