### PR TITLE
Add docs for feature flags

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,13 @@ Fixes #
 
 ### Testing instructions
 
+<!--
+If the functionality of this PR is behind a feature flag, please include the
+following testing step, using the correct name for the feature flag. (If you
+aren't sure, just ignore this step)
+
+* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
+-->
 *
 
 <!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -2,7 +2,19 @@
 
 /**
  * Class Sensei_Feature_Flags
- * Check for enabled experimental features by running a filter for each feature, overriden by defines
+ *
+ * Check for enabled experimental features by running a filter for each
+ * feature, overriden by defines. A feature flag can be enabled either by
+ * defining a constant, or adding a filter.
+ *
+ * Example - the feature flag `my_experimental_feature` may be enabled in the
+ * following ways:
+ *
+ * // Defining a constant:
+ * `define( 'SENSEI_FEATURE_FLAG_MY_EXPERIMENTAL_FEATURE', true );`
+ *
+ * // Adding a filter:
+ * `add_filter( 'sensei_feature_flag_my_experimental_feature', '__return_true' );`
  *
  * @package Core
  */


### PR DESCRIPTION
### Changes proposed in this Pull Request

I've been tripped up a couple of times by PR's that require a feature flag but don't mention it in the testing instructions. Generally it's because it was set up in a previous PR which I didn't test, so I didn't have the feature flag set up at that point.

To facilitate testing with feature flags (and since we've been using them more often), I've added a bit of documentation in the code on how to enable them, and an optional testing step in our PR template to specify the feature flag that needs to be enabled for testing.

One concern is that this adds extra noise or confusion to the PR template, especially for new contributors who may not know what feature flags are. Any thoughts?
