### PR TITLE
Add images to extensions page

### DIFF
--- a/assets/extensions/all-extensions.js
+++ b/assets/extensions/all-extensions.js
@@ -21,17 +21,6 @@ const extensionsSkeleton = [
 			{
 				key: 'sensei-wc-paid-courses',
 				extensionSlug: 'sensei-wc-paid-courses',
-				itemProps: {
-					className: 'special-class',
-					style: { background: 'red' },
-				},
-				wrapperProps: {
-					className: 'special',
-					style: { color: 'white' },
-				},
-				cardProps: {
-					htmlProps: { style: { background: 'blue' } },
-				},
 			},
 			{
 				key: 'sensei-content-drip',
@@ -41,6 +30,8 @@ const extensionsSkeleton = [
 				key: 'sensei-advanced-quizzes',
 				cardProps: {
 					title: 'Advanced Quizzes',
+					image:
+						'https://senseilms.com/wp-content/uploads/2019/05/Quizzes.png',
 					excerpt:
 						'Take your lesson quizzes to the next level with additional question types, quiz timer, answer feedback, and more.',
 					badgeLabel: 'Coming soon',
@@ -74,12 +65,8 @@ const extensionsSkeleton = [
 		title: 'Course Creation',
 		items: [
 			{
-				key: 'sensei-course-participants',
-				extensionSlug: 'sensei-course-participants',
-			},
-			{
-				key: 'sensei-course-progress',
-				extensionSlug: 'sensei-course-progress',
+				key: 'sensei-post-to-course',
+				extensionSlug: 'sensei-post-to-course',
 			},
 			{
 				key: 'sensei-media-attachments',
@@ -98,12 +85,8 @@ const extensionsSkeleton = [
 				extensionSlug: 'sensei-certificates',
 			},
 			{
-				key: 'sensei-share-your-grade',
-				extensionSlug: 'sensei-share-your-grade',
-			},
-			{
-				key: 'sensei-post-to-course',
-				extensionSlug: 'sensei-post-to-course',
+				key: 'sensei-course-progress',
+				extensionSlug: 'sensei-course-progress',
 			},
 		],
 	},

--- a/assets/extensions/card.js
+++ b/assets/extensions/card.js
@@ -21,6 +21,7 @@ import ExtensionActions from './extension-actions';
  * @param {string}   props.excerpt     Card excerpt (extension excerpt will be used as fallback).
  * @param {string}   props.badgeLabel  Badge label (will check extension update if it's not defined).
  * @param {Object[]} props.customLinks Array with custom links containing the link props.
+ * @param {string}   props.image       Card image.
  * @param {Object}   props.extension   Extension object.
  * @param {Object}   props.htmlProps   Wrapper extra props.
  */
@@ -29,39 +30,52 @@ const Card = ( {
 	excerpt,
 	badgeLabel,
 	customLinks,
+	image,
 	extension,
 	htmlProps,
-} ) => (
-	<article
-		{ ...htmlProps }
-		className={ classnames(
-			'sensei-extensions__card',
-			htmlProps?.className
-		) }
-	>
-		<header className="sensei-extensions__card__header">
-			<h3 className="sensei-extensions__card__title">
-				{ title || extension.title }
-			</h3>
-			{ ( badgeLabel || extension?.[ 'has_update' ] ) && (
-				<small className="sensei-extensions__card__new-badge">
-					{ badgeLabel || __( 'New version', 'sensei-lms' ) }
-				</small>
+} ) => {
+	const backgroundImage =
+		( image && `url(${ image })` ) ||
+		( extension?.image && `url(${ extension.image })` );
+	return (
+		<article
+			{ ...htmlProps }
+			className={ classnames(
+				'sensei-extensions__card',
+				htmlProps?.className
 			) }
-		</header>
-		<div className="sensei-extensions__card__content">
-			<p className="sensei-extensions__card__description">
-				{ excerpt || extension.excerpt }
-			</p>
-
-			{ ( extension || customLinks ) && (
-				<ExtensionActions
-					extension={ extension }
-					customLinks={ customLinks }
-				/>
-			) }
-		</div>
-	</article>
-);
+		>
+			<div
+				className="sensei-extensions__card__image"
+				style={ {
+					backgroundImage,
+				} }
+			/>
+			<div className="sensei-extensions__card__content">
+				<header className="sensei-extensions__card__header">
+					<h3 className="sensei-extensions__card__title">
+						{ title || extension.title }
+					</h3>
+					{ ( badgeLabel || extension?.[ 'has_update' ] ) && (
+						<small className="sensei-extensions__card__new-badge">
+							{ badgeLabel || __( 'New version', 'sensei-lms' ) }
+						</small>
+					) }
+				</header>
+				<div className="sensei-extensions__card__body">
+					<p className="sensei-extensions__card__description">
+						{ excerpt || extension.excerpt }
+					</p>
+					{ ( extension || customLinks ) && (
+						<ExtensionActions
+							extension={ extension }
+							customLinks={ customLinks }
+						/>
+					) }
+				</div>
+			</div>
+		</article>
+	);
+};
 
 export default Card;

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -6,7 +6,7 @@ $wordpress-break: 961px;
 @mixin white-box( $r: 2px ) {
 	border-radius: $r;
 	background-color: $white;
-	box-shadow: 0 0 0 1px #DCDCDE;
+	box-shadow: 0 0 0 1px $gray-5;
 }
 
 @mixin col-width($w) {
@@ -21,6 +21,8 @@ $wordpress-break: 961px;
 	@media (min-width: 783px) {
 		margin-right: 20px;
 	}
+
+	color: $gray-100;
 }
 
 .sensei-extensions {
@@ -130,7 +132,7 @@ $wordpress-break: 961px;
 		align-items: center;
 		font-size: 14px;
 		font-weight: 500;
-		color: #000;
+		color: inherit;
 
 		svg {
 			width: 24px;
@@ -233,7 +235,7 @@ $wordpress-break: 961px;
 			margin: 0;
 
 			&:not(:last-child) {
-				border-bottom: solid 1px #DCDCDE;
+				border-bottom: solid 1px $gray-5;
 			}
 		}
 	}
@@ -407,7 +409,7 @@ $wordpress-break: 961px;
 			padding: 0 10px;
 			margin-left: 10px;
 			font-size: 13px;
-			color: #000;
+			color: inherit;
 		}
 
 		&__button-icon {

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -3,8 +3,8 @@
 
 $wordpress-break: 961px;
 
-@mixin white-box {
-	border-radius: 2px;
+@mixin white-box( $r: 2px ) {
+	border-radius: $r;
 	background-color: $white;
 	box-shadow: 0 0 0 1px #DCDCDE;
 }
@@ -46,7 +46,7 @@ $wordpress-break: 961px;
 			margin: 0 0 17px;
 		}
 
-		&__content {
+		&__body {
 			flex: 1;
 		}
 	}
@@ -204,11 +204,24 @@ $wordpress-break: 961px;
 			}
 		}
 
+		.sensei-extensions__card {
+			flex-direction: column;
+			border-radius: 8px;
+			&__image {
+				border-radius: 8px 8px 0 0;
+			}
+		}
+
 		.sensei-extensions__card-wrapper {
 			height: 100%;
 			box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.16);
 			border-radius: 8px;
 		}
+
+		&__card-wrapper, .sensei-extensions__card {
+			height: 100%;
+		}
+
 	}
 
 	&__small-list,
@@ -222,6 +235,21 @@ $wordpress-break: 961px;
 			&:not(:last-child) {
 				border-bottom: solid 1px #DCDCDE;
 			}
+		}
+	}
+
+	&__small-list {
+		.sensei-extensions__card__image {
+			display: none;
+		}
+	}
+
+	&__large-list {
+		&__item:first-child .sensei-extensions__card__image {
+			border-radius: 2px 0 0 0;
+		}
+		&__item:last-child .sensei-extensions__card__image {
+			border-radius: 0 0 0 2px;
 		}
 	}
 
@@ -240,19 +268,21 @@ $wordpress-break: 961px;
 
 	@media (min-width: $wordpress-break) {
 		&__large-list {
-			.sensei-extensions__card__content {
-				display: flex;
+			.sensei-extensions__card {
+			}
+			.sensei-extensions__card__body {
+
+			}
+			.sensei-extensions__card__image {
 			}
 			.sensei-extensions__card__description {
-				flex: 1;
+
 			}
 			.sensei-extensions__extension-actions {
-				padding-left: 20px;
-				flex-shrink: 0;
-				flex-direction: row-reverse;
+
 			}
 			.sensei-extensions__extension-actions__details-link {
-				margin-right: 10px;
+
 			}
 		}
 	}
@@ -277,14 +307,22 @@ $wordpress-break: 961px;
 		}
 
 		.sensei-extensions__card-wrapper {
-			@include white-box;
+			@include white-box(2px);
 			height: 100%
+		}
+
+		.sensei-extensions__card {
+			flex-direction: column;
+			&__image {
+				border-radius: 2px 2px 0 0;
+			}
 		}
 	}
 
 	&__card {
-		padding: 25px;
-		background-color: $white;
+		display: flex;
+		align-items: stretch;
+		height: 100%;
 
 		&__header {
 			display: flex;
@@ -292,10 +330,37 @@ $wordpress-break: 961px;
 			margin-bottom: 10px;
 		}
 
+		&__content {
+			padding: 25px;
+			display: flex;
+			flex-direction: column;
+			min-height: 170px;
+			flex: 1;
+		}
+
+		&__body {
+			flex: 1;
+			display: flex;
+			flex-direction: column;
+		}
+
 		&__title {
 			margin: 0;
 			font-size: 16px;
 			font-weight: bold;
+			color: inherit;
+		}
+
+		&__price {
+			margin-bottom: 10px;
+			font-size: 16px;
+		}
+
+		&__image {
+			background-color: $gray-0;
+			background-size: cover;
+			background-position: center center;
+			flex: 0 0 220px;
 		}
 
 		&__new-badge {
@@ -317,6 +382,7 @@ $wordpress-break: 961px;
 		&__description {
 			margin: 0 0 10px;
 			font-size: 14px;
+			flex: 1;
 		}
 	}
 

--- a/includes/rest-api/class-sensei-rest-api-extensions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-extensions-controller.php
@@ -136,6 +136,7 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 		$mapped_plugins = array_map(
 			function( $plugin ) {
 				$plugin->price = html_entity_decode( $plugin->price );
+				$plugin->image = 'https://senseilms.com/wp-content/uploads/2019/05/' . $plugin->product_slug . '.png';
 
 				return $plugin;
 			},


### PR DESCRIPTION
Depends on #4197 

### Changes proposed in this Pull Request

* Add support for displaying extension images in cards in various layouts
  — Image is on top on featured & grid cards, on the left side for large lists, and no image for small lists
* Update card layout: set cards in the same row to the same height, align card action buttons to bottom
* Update large lists to left-aligned action buttons


### Testing instructions

* 


<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![image](https://user-images.githubusercontent.com/176949/116155320-3d8ad980-a6ea-11eb-9701-4b46d425558d.png)

