### PR TITLE
Add extension update endpoint

### DIFF
--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -25,7 +25,7 @@ const Main = () => {
 			path: '/sensei-internal/v1/sensei-extensions?type=plugin',
 		} )
 			.then( ( result ) => {
-				setExtensions( result );
+				setExtensions( result.extensions || [] );
 			} )
 			.catch( () => setExtensions( [] ) );
 	}, [] );

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -119,19 +119,15 @@ final class Sensei_Extensions {
 
 		$installed_plugins = get_plugins();
 
-		$wccom_connected     = false;
 		$wccom_subscriptions = [];
 
 		if ( class_exists( 'WC_Helper_Options' ) ) {
-			$auth            = WC_Helper_Options::get( 'auth' );
-			$wccom_connected = ! empty( $auth['access_token'] );
-
 			$wccom_subscriptions = WC_Helper::get_subscriptions();
 		}
 
 		// Includes installed version, whether it has update and WC.com metadata.
 		$extensions = array_map(
-			function( $extension ) use ( $installed_plugins, $wccom_connected, $wccom_subscriptions ) {
+			function( $extension ) use ( $installed_plugins, $wccom_subscriptions ) {
 				$extension->is_installed = isset( $installed_plugins[ $extension->plugin_file ] );
 
 				if ( $extension->is_installed ) {
@@ -140,8 +136,6 @@ final class Sensei_Extensions {
 				}
 
 				if ( isset( $extension->wccom_product_id ) ) {
-					$extension->wccom_connected = $wccom_connected;
-
 					foreach ( $wccom_subscriptions as $wccom_subscription ) {
 						if ( (int) $extension->wccom_product_id === $wccom_subscription['product_id'] ) {
 							$extension->wccom_expired = $wccom_subscription['expired'];

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -119,14 +119,36 @@ final class Sensei_Extensions {
 
 		$installed_plugins = get_plugins();
 
-		// Includes installed version, and whether it has update.
+		$wccom_connected     = false;
+		$wccom_subscriptions = [];
+
+		if ( class_exists( 'WC_Helper_Options' ) ) {
+			$auth            = WC_Helper_Options::get( 'auth' );
+			$wccom_connected = ! empty( $auth['access_token'] );
+
+			$wccom_subscriptions = WC_Helper::get_subscriptions();
+		}
+
+		// Includes installed version, whether it has update and WC.com metadata.
 		$extensions = array_map(
-			function( $extension ) use ( $installed_plugins ) {
+			function( $extension ) use ( $installed_plugins, $wccom_connected, $wccom_subscriptions ) {
 				$extension->is_installed = isset( $installed_plugins[ $extension->plugin_file ] );
 
 				if ( $extension->is_installed ) {
 					$extension->installed_version = $installed_plugins[ $extension->plugin_file ]['Version'];
 					$extension->has_update        = isset( $extension->version ) && version_compare( $extension->version, $extension->installed_version, '>' );
+				}
+
+				if ( isset( $extension->wccom_product_id ) ) {
+					$extension->wccom_connected = $wccom_connected;
+
+					foreach ( $wccom_subscriptions as $wccom_subscription ) {
+						if ( (int) $extension->wccom_product_id === $wccom_subscription['product_id'] ) {
+							$extension->wccom_expired = $wccom_subscription['expired'];
+
+							break;
+						}
+					}
 				}
 
 				return $extension;

--- a/includes/rest-api/class-sensei-rest-api-extensions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-extensions-controller.php
@@ -286,8 +286,20 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 			$plugins
 		);
 
+		$wccom_connected = false;
+
+		if ( class_exists( 'WC_Helper_Options' ) ) {
+			$auth            = WC_Helper_Options::get( 'auth' );
+			$wccom_connected = ! empty( $auth['access_token'] );
+		}
+
 		$response = new WP_REST_Response();
-		$response->set_data( array_values( $mapped_plugins ) );
+		$response->set_data(
+			[
+				'extensions'      => array_values( $mapped_plugins ),
+				'wccom_connected' => $wccom_connected,
+			]
+		);
 
 		return $response;
 	}
@@ -299,77 +311,79 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 	 */
 	public function get_item_schema() : array {
 		return [
-			'type'  => 'array',
-			'items' => [
-				'type'       => 'object',
-				'properties' => [
-					'hash'             => [
-						'type'        => 'string',
-						'description' => 'Product ID.',
-					],
-					'title'            => [
-						'type'        => 'string',
-						'description' => 'Extension title.',
-					],
-					'image'            => [
-						'type'        => 'string',
-						'description' => 'Extension image.',
-					],
-					'excerpt'          => [
-						'type'        => 'string',
-						'description' => 'Extension excerpt',
-					],
-					'link'             => [
-						'type'        => 'string',
-						'description' => 'Extension link.',
-					],
-					'price'            => [
-						'type'        => 'string',
-						'description' => 'Extension price.',
-					],
-					'is_featured'      => [
-						'type'        => 'boolean',
-						'description' => 'Whether its a featured extension.',
-					],
-					'product_slug'     => [
-						'type'        => 'string',
-						'description' => 'Extension product slug.',
-					],
-					'hosted_location'  => [
-						'type'        => 'string',
-						'description' => 'Where the extension is hosted (dotorg or external)',
-					],
-					'type'             => [
-						'type'        => 'string',
-						'description' => 'Whether this is a plugin or a theme',
-					],
-					'plugin_file'      => [
-						'type'        => 'string',
-						'description' => 'Main plugin file.',
-					],
-					'version'          => [
-						'type'        => 'string',
-						'description' => 'Extension version.',
-					],
-					'wccom_product_id' => [
-						'type'        => 'string',
-						'description' => 'WooCommerce.com product ID.',
-					],
-					'is_installed'     => [
-						'type'        => 'boolean',
-						'description' => 'Whether the extension is installed.',
-					],
-					'has_update'       => [
-						'type'        => 'boolean',
-						'description' => 'Whether the extension has available updates.',
-					],
-					'wccom_connected'  => [
-						'type'        => 'boolean',
-						'description' => 'Whether the site is connected to WC.com.',
-					],
-					'wccom_expired'    => [
-						'type'        => 'boolean',
-						'description' => 'Whether the WC.com subscription is expired.',
+			'wccom_connected' => [
+				'type'        => 'boolean',
+				'description' => 'Whether the site is connected to WC.com.',
+			],
+			'extensions'      => [
+				'type'  => 'array',
+				'items' => [
+					'type'       => 'object',
+					'properties' => [
+						'hash'             => [
+							'type'        => 'string',
+							'description' => 'Product ID.',
+						],
+						'title'            => [
+							'type'        => 'string',
+							'description' => 'Extension title.',
+						],
+						'image'            => [
+							'type'        => 'string',
+							'description' => 'Extension image.',
+						],
+						'excerpt'          => [
+							'type'        => 'string',
+							'description' => 'Extension excerpt',
+						],
+						'link'             => [
+							'type'        => 'string',
+							'description' => 'Extension link.',
+						],
+						'price'            => [
+							'type'        => 'string',
+							'description' => 'Extension price.',
+						],
+						'is_featured'      => [
+							'type'        => 'boolean',
+							'description' => 'Whether its a featured extension.',
+						],
+						'product_slug'     => [
+							'type'        => 'string',
+							'description' => 'Extension product slug.',
+						],
+						'hosted_location'  => [
+							'type'        => 'string',
+							'description' => 'Where the extension is hosted (dotorg or external)',
+						],
+						'type'             => [
+							'type'        => 'string',
+							'description' => 'Whether this is a plugin or a theme',
+						],
+						'plugin_file'      => [
+							'type'        => 'string',
+							'description' => 'Main plugin file.',
+						],
+						'version'          => [
+							'type'        => 'string',
+							'description' => 'Extension version.',
+						],
+						'wccom_product_id' => [
+							'type'        => 'string',
+							'description' => 'WooCommerce.com product ID.',
+						],
+						'is_installed'     => [
+							'type'        => 'boolean',
+							'description' => 'Whether the extension is installed.',
+						],
+						'has_update'       => [
+							'type'        => 'boolean',
+							'description' => 'Whether the extension has available updates.',
+						],
+						'wccom_expired'    => [
+							'type'        => 'boolean',
+							'description' => 'Whether the WC.com subscription is expired.',
+						],
 					],
 				],
 			],

--- a/includes/rest-api/class-sensei-rest-api-extensions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-extensions-controller.php
@@ -165,11 +165,11 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 			}
 		);
 
-		return $this->create_plugins_response( $filtered_plugins );
+		return $this->create_extensions_response( $filtered_plugins );
 	}
 
 	/**
-	 * Update a single plugin.
+	 * Update an array of plugins.
 	 *
 	 * @access private
 	 *
@@ -217,7 +217,7 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 			return $error;
 		}
 
-		return $this->create_plugins_response( Sensei_Extensions::instance()->get_extensions( 'plugin' ) );
+		return $this->create_extensions_response( Sensei_Extensions::instance()->get_extensions( 'plugin' ) );
 	}
 
 	/**
@@ -276,7 +276,7 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 	 *
 	 * @return WP_REST_Response
 	 */
-	private function create_plugins_response( array $plugins ): WP_REST_Response {
+	private function create_extensions_response( array $plugins ): WP_REST_Response {
 		$mapped_plugins = array_map(
 			function ( $plugin ) {
 				$plugin->price = html_entity_decode( $plugin->price );

--- a/includes/rest-api/class-sensei-rest-api-extensions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-extensions-controller.php
@@ -84,6 +84,36 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 				'schema' => [ $this, 'get_item_schema' ],
 			]
 		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/update',
+			[
+				[
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => [ $this, 'update_extensions' ],
+					'permission_callback' => [ $this, 'can_user_manage_plugins' ],
+					'args'                => [
+						'plugins' => [
+							'type'              => 'array',
+							'required'          => true,
+							'sanitize_callback' => function( $param ) {
+								if ( ! is_array( $param ) ) {
+									$param = [ $param ];
+								}
+
+								return array_map(
+									function ( $plugin ) {
+										return sanitize_title( $plugin );
+									},
+									$param
+								);
+							},
+						],
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -94,7 +124,7 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 	 * @return bool|WP_Error Whether the user can manage extensions.
 	 */
 	public function can_user_manage_plugins( WP_REST_Request $request ) {
-		if ( ! current_user_can( 'activate_plugins' ) ) {
+		if ( ! current_user_can( 'activate_plugins' ) || ! current_user_can( 'update_plugins' ) ) {
 			return new WP_Error(
 				'rest_cannot_view_plugins',
 				__( 'Sorry, you are not allowed to manage plugins for this site.', 'sensei-lms' ),
@@ -108,13 +138,15 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 	/**
 	 * Returns the requested extensions.
 	 *
+	 * @access private
+	 *
 	 * @param WP_REST_Request $request The request.
 	 *
 	 * @return WP_REST_Response The response which contains the extensions.
 	 */
 	public function get_extensions( WP_REST_Request $request ) : WP_REST_Response {
 		$params  = $request->get_params();
-		$plugins = Sensei_Extensions::instance()->get_extensions( $params['type'] );
+		$plugins = Sensei_Extensions::instance()->get_extensions( $params['type'] ?? null );
 
 		$filtered_plugins = array_filter(
 			$plugins,
@@ -133,13 +165,125 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 			}
 		);
 
+		return $this->create_plugins_response( $filtered_plugins );
+	}
+
+	/**
+	 * Update a single plugin.
+	 *
+	 * @access private
+	 *
+	 * @param WP_REST_Request $request The request.
+	 *
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function update_extensions( WP_REST_Request $request ) {
+		$json_params    = $request->get_json_params();
+		$plugins_arg    = $json_params['plugins'];
+		$sensei_plugins = Sensei_Extensions::instance()->get_extensions( 'plugin' );
+
+		$plugins_to_update = array_filter(
+			$sensei_plugins,
+			function( $plugin ) use ( $plugins_arg ) {
+				return $plugin->is_installed && $plugin->has_update && in_array( $plugin->product_slug, $plugins_arg, true );
+			}
+		);
+
+		if ( empty( $plugins_to_update ) ) {
+			$response = new WP_REST_Response();
+			$response->set_data(
+				new WP_Error(
+					'sensei_extensions_no_plugins_to_update',
+					__( 'No plugins to update found.', 'sensei-lms' )
+				)
+			);
+			$response->set_status( 404 );
+
+			return $response;
+		}
+
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+		require_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+		WP_Filesystem();
+
+		$skin     = new WP_Ajax_Upgrader_Skin();
+		$upgrader = new Plugin_Upgrader( $skin );
+		$result   = $upgrader->bulk_upgrade( wp_list_pluck( $plugins_to_update, 'plugin_file' ) );
+
+		$error = $this->check_for_upgrade_error( $plugins_to_update, $result, $skin, $upgrader );
+
+		if ( is_wp_error( $error ) ) {
+			return $error;
+		}
+
+		return $this->create_plugins_response( Sensei_Extensions::instance()->get_extensions( 'plugin' ) );
+	}
+
+	/**
+	 * Check if the result of the upgrade has an error. Error handling has been copied from wp_ajax_update_plugin.
+	 *
+	 * @param array                 $plugins  Plugins which where upgraded.
+	 * @param array|WP_Error|false  $result   Result of the upgrade.
+	 * @param WP_Ajax_Upgrader_Skin $skin     Upgrader sking.
+	 * @param Plugin_Upgrader       $upgrader The upgrader.
+	 *
+	 * @return bool|WP_Error
+	 */
+	private function check_for_upgrade_error( array $plugins, $result, WP_Ajax_Upgrader_Skin $skin, Plugin_Upgrader $upgrader ) {
+		if ( is_wp_error( $skin->result ) ) {
+			return $skin->result;
+		}
+
+		if ( $skin->get_errors()->has_errors() ) {
+			return new WP_Error(
+				'sensei_extensions_plugin_update_failed',
+				$skin->get_error_messages()
+			);
+		}
+
+		if ( is_array( $result ) ) {
+			foreach ( $plugins as $plugin ) {
+				if ( empty( $result[ $plugin->plugin_file ] ) ) {
+					return new WP_Error(
+						'sensei_extensions_plugin_update_failed',
+						// translators: Placeholder is the name of the plugin that failed.
+						sprintf( __( 'Failed to update plugin %s', 'sensei-lms' ), $plugin->title )
+					);
+				}
+
+				if ( true === $result[ $plugin->plugin_file ] ) {
+					return new WP_Error(
+						'sensei_extensions_plugin_update_failed',
+						$upgrader->strings['up_to_date']
+					);
+				}
+			}
+		} else {
+			return new WP_Error(
+				'sensei_extensions_plugin_update_failed',
+				__( 'Plugin update failed.', 'sensei-lms' )
+			);
+		}
+
+		return false;
+	}
+
+	/**
+	 * Generate a REST response from an array of plugins.
+	 *
+	 * @param array $plugins The plugins.
+	 *
+	 * @return WP_REST_Response
+	 */
+	private function create_plugins_response( array $plugins ): WP_REST_Response {
 		$mapped_plugins = array_map(
-			function( $plugin ) {
+			function ( $plugin ) {
 				$plugin->price = html_entity_decode( $plugin->price );
 
 				return $plugin;
 			},
-			$filtered_plugins
+			$plugins
 		);
 
 		$response = new WP_REST_Response();
@@ -219,9 +363,16 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 						'type'        => 'boolean',
 						'description' => 'Whether the extension has available updates.',
 					],
+					'wccom_connected'  => [
+						'type'        => 'boolean',
+						'description' => 'Whether the site is connected to WC.com.',
+					],
+					'wccom_expired'    => [
+						'type'        => 'boolean',
+						'description' => 'Whether the WC.com subscription is expired.',
+					],
 				],
 			],
 		];
 	}
-
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds an endpoint which updates a list of plugins. The new endpoint is `sensei-internal/v1/sensei-extensions/update` and it accepts a single array argument, `plugins`.
* The update happens during a single request. This is the same approach the WP core is using. Alternatively we could do the update asychronously and do polling but I think that this approach is simpler.
* There is no integration with the frontend currently. I started working on this in #4202 but it is probably going to need refactoring to take into account dynamic content introduced in #4197.
* Plugins that are hosted in WC.com are not updated when the site is not connected to it.
* Two new fiels were added to the extenstions endpoint, `wccom_connected` and `wccom_expired`. These are meant to be used by functionality in future PRs

### Testing instructions
* The only way to test this ATM is to try the edpoint directly.
* You can simulate a plugin being outdated by modifying the version in the main plugin file.
* Then you can try a POST with arguments:
```
{
  "plugins": [ "sensei-content-drip", "sensei-wc-paid-courses" ]
}
```
* Observe that when the request is completed, that the plugins are updated.