### PR TITLE
Integrate update endpoint

### DIFF
--- a/assets/extensions/all-extensions.js
+++ b/assets/extensions/all-extensions.js
@@ -2,21 +2,26 @@
  * External dependencies
  */
 import classnames from 'classnames';
-import { keyBy } from 'lodash';
+
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import Card from './card';
 import { Grid, Col } from './grid';
+import { EXTENSIONS_STORE } from './store';
 
 /**
  * Renders the sections based on the skeleton structure. It can also render subsections recursively.
  *
- * @param {Array}  layout           Layout skeleton.
- * @param {Object} extensionsBySlug Extensions by slug to be rendered.
+ * @param {Array}  layout     Layout skeleton.
+ * @param {Object} extensions Extensions by slug to be rendered.
  */
-const renderSections = ( layout, extensionsBySlug ) =>
+const renderSections = ( layout, extensions ) =>
 	layout.map( ( section ) => (
 		<Col
 			key={ section.key }
@@ -41,10 +46,7 @@ const renderSections = ( layout, extensionsBySlug ) =>
 
 			{ section.innerSections ? (
 				<Grid>
-					{ renderSections(
-						section.innerSections,
-						extensionsBySlug
-					) }
+					{ renderSections( section.innerSections, extensions ) }
 				</Grid>
 			) : (
 				<ul
@@ -78,7 +80,7 @@ const renderSections = ( layout, extensionsBySlug ) =>
 								>
 									<Card
 										{ ...( extensionSlug
-											? extensionsBySlug[ extensionSlug ]
+											? extensions[ extensionSlug ]
 											: {} ) }
 										{ ...cardProps }
 									/>
@@ -94,14 +96,15 @@ const renderSections = ( layout, extensionsBySlug ) =>
 /**
  * All extensions component.
  *
- * @param {Object} props            Component props.
- * @param {Array}  props.extensions All extensions.
- * @param {Array}  props.layout     Layout to render the extensions page.
+ * @param {Object} props        Component props.
+ * @param {Array}  props.layout Layout to render the extensions page.
  */
-const AllExtensions = ( { extensions, layout } ) => {
-	const extensionsBySlug = keyBy( extensions, 'product_slug' );
+const AllExtensions = ( { layout } ) => {
+	const { extensions } = useSelect( ( select ) => ( {
+		extensions: select( EXTENSIONS_STORE ).getEntities( 'extensions' ),
+	} ) );
 
-	return renderSections( layout, extensionsBySlug );
+	return renderSections( layout, extensions );
 };
 
 export default AllExtensions;

--- a/assets/extensions/card.js
+++ b/assets/extensions/card.js
@@ -11,7 +11,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import ExtensionActions, { getExtensionActions } from './extension-actions';
+import ExtensionActions, { useExtensionActions } from './extension-actions';
 
 /**
  * Extensions card component.
@@ -34,9 +34,10 @@ const Card = ( props ) => {
 		image,
 	} = props;
 
-	const actions = customActions || getExtensionActions( props );
-
+	const extensionActions = useExtensionActions( props );
+	const actions = customActions || extensionActions;
 	const backgroundImage = image && `url(${ image })`;
+
 	return (
 		<article
 			{ ...htmlProps }

--- a/assets/extensions/card.js
+++ b/assets/extensions/card.js
@@ -7,11 +7,13 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import ExtensionActions, { getExtensionActions } from './extension-actions';
+import { EXTENSIONS_STORE } from './store';
 
 /**
  * Extensions card component.
@@ -34,7 +36,12 @@ const Card = ( props ) => {
 		image,
 	} = props;
 
-	const actions = customActions || getExtensionActions( props );
+	const componentInProgress = useSelect( ( select ) =>
+		select( EXTENSIONS_STORE ).getComponentInProgress()
+	);
+
+	const actions =
+		customActions || getExtensionActions( props, componentInProgress );
 
 	const backgroundImage = image && `url(${ image })`;
 	return (

--- a/assets/extensions/card.js
+++ b/assets/extensions/card.js
@@ -7,13 +7,11 @@ import classnames from 'classnames';
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
  */
 import ExtensionActions, { getExtensionActions } from './extension-actions';
-import { EXTENSIONS_STORE } from './store';
 
 /**
  * Extensions card component.
@@ -36,12 +34,7 @@ const Card = ( props ) => {
 		image,
 	} = props;
 
-	const componentInProgress = useSelect( ( select ) =>
-		select( EXTENSIONS_STORE ).getComponentInProgress()
-	);
-
-	const actions =
-		customActions || getExtensionActions( props, componentInProgress );
+	const actions = customActions || getExtensionActions( props );
 
 	const backgroundImage = image && `url(${ image })`;
 	return (

--- a/assets/extensions/extension-actions.js
+++ b/assets/extensions/extension-actions.js
@@ -3,7 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
-import { dispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -45,13 +45,15 @@ const ExtensionActions = ( { actions } ) => (
 export default ExtensionActions;
 
 /**
- * Get extension actions array.
+ * Extension actions hook.
  *
  * @param {Object} extension Extension object.
  *
  * @return {Array|null} Array of actions, or null if it's not a valid extension.
  */
-export const getExtensionActions = ( extension ) => {
+export const useExtensionActions = ( extension ) => {
+	const { updateExtensions } = useDispatch( EXTENSIONS_STORE );
+
 	if ( ! extension.product_slug ) {
 		return null;
 	}
@@ -73,10 +75,7 @@ export const getExtensionActions = ( extension ) => {
 	} else if ( extension.canUpdate ) {
 		buttonLabel = __( 'Update', 'sensei-lms' );
 		buttonAction = () =>
-			dispatch( EXTENSIONS_STORE ).updateExtensions(
-				[ extension ],
-				extension.product_slug
-			);
+			updateExtensions( [ extension ], extension.product_slug );
 	} else if ( extension.is_installed ) {
 		buttonLabel = (
 			<>

--- a/assets/extensions/extension-actions.js
+++ b/assets/extensions/extension-actions.js
@@ -9,7 +9,7 @@ import { useDispatch } from '@wordpress/data';
  * Internal dependencies
  */
 import { checked } from '../icons/wordpress-icons';
-import { EXTENSIONS_STORE } from './store';
+import { EXTENSIONS_STORE, isLoadingStatus } from './store';
 import { UpdateIcon } from '../icons';
 
 /**
@@ -61,7 +61,7 @@ export const useExtensionActions = ( extension ) => {
 	let buttonLabel = '';
 	let buttonAction = () => {};
 
-	if ( 'in-progress' === extension.status ) {
+	if ( isLoadingStatus( extension.status ) ) {
 		buttonLabel = (
 			<>
 				<UpdateIcon
@@ -99,7 +99,7 @@ export const useExtensionActions = ( extension ) => {
 		{
 			key: 'main-button',
 			disabled:
-				'in-progress' === extension.status ||
+				isLoadingStatus( extension.status ) ||
 				( extension.is_installed && ! extension.canUpdate ),
 			children: buttonLabel,
 			onClick: buttonAction,

--- a/assets/extensions/extension-actions.js
+++ b/assets/extensions/extension-actions.js
@@ -53,18 +53,14 @@ export const useExtensionActions = ( extension ) => {
 		return null;
 	}
 
-	let actionProps = {
-		key: 'main-button',
-		disabled:
-			isLoadingStatus( extension.status ) ||
-			( extension.is_installed && ! extension.canUpdate ),
-	};
+	let actionProps = { key: 'main-button' };
 
 	if ( isLoadingStatus( extension.status ) ) {
 		actionProps = {
 			children: __( 'Updating…', 'sensei-lms' ),
 			className: 'sensei-extensions__rotating-icon',
 			icon: updateIcon,
+			disabled: true,
 			...actionProps,
 		};
 	} else if ( extension.canUpdate ) {
@@ -72,12 +68,14 @@ export const useExtensionActions = ( extension ) => {
 			children: __( 'Update', 'sensei-lms' ),
 			onClick: () =>
 				updateExtensions( [ extension ], extension.product_slug ),
+			disabled: ! extension.canUpdate,
 			...actionProps,
 		};
 	} else if ( extension.is_installed ) {
 		actionProps = {
 			children: __( 'Installed', 'sensei-lms' ),
 			icon: checked,
+			disabled: true,
 			...actionProps,
 		};
 	} else {

--- a/assets/extensions/extension-actions.js
+++ b/assets/extensions/extension-actions.js
@@ -59,9 +59,6 @@ export const getExtensionActions = ( extension, componentInProgress ) => {
 
 	let buttonLabel = '';
 	let buttonAction = () => {};
-	let buttonDisabled =
-		componentInProgress !== '' ||
-		( extension.is_installed && ! extension.canUpdate );
 
 	if ( componentInProgress === extension.product_slug ) {
 		buttonLabel = (
@@ -74,7 +71,6 @@ export const getExtensionActions = ( extension, componentInProgress ) => {
 				{ __( 'Updating…', 'sensei-lms' ) }
 			</>
 		);
-		buttonDisabled = true;
 	} else if ( extension.canUpdate ) {
 		buttonLabel = __( 'Update', 'sensei-lms' );
 		buttonAction = () =>
@@ -104,7 +100,9 @@ export const getExtensionActions = ( extension, componentInProgress ) => {
 	let buttons = [
 		{
 			key: 'main-button',
-			disabled: buttonDisabled,
+			disabled:
+				componentInProgress !== '' ||
+				( extension.is_installed && ! extension.canUpdate ),
 			children: buttonLabel,
 			onClick: buttonAction,
 		},

--- a/assets/extensions/extension-actions.js
+++ b/assets/extensions/extension-actions.js
@@ -53,36 +53,46 @@ export const useExtensionActions = ( extension ) => {
 		return null;
 	}
 
-	const mainButtonProps = {};
+	let actionProps = {
+		key: 'main-button',
+		disabled:
+			isLoadingStatus( extension.status ) ||
+			( extension.is_installed && ! extension.canUpdate ),
+	};
 
 	if ( isLoadingStatus( extension.status ) ) {
-		mainButtonProps.children = __( 'Updating…', 'sensei-lms' );
-		mainButtonProps.className = 'sensei-extensions__rotating-icon';
-		mainButtonProps.icon = updateIcon;
+		actionProps = {
+			children: __( 'Updating…', 'sensei-lms' ),
+			className: 'sensei-extensions__rotating-icon',
+			icon: updateIcon,
+			...actionProps,
+		};
 	} else if ( extension.canUpdate ) {
-		mainButtonProps.children = __( 'Update', 'sensei-lms' );
-		mainButtonProps.onClick = () =>
-			updateExtensions( [ extension ], extension.product_slug );
+		actionProps = {
+			children: __( 'Update', 'sensei-lms' ),
+			onClick: () =>
+				updateExtensions( [ extension ], extension.product_slug ),
+			...actionProps,
+		};
 	} else if ( extension.is_installed ) {
-		mainButtonProps.icon = checked;
-		mainButtonProps.children = __( 'Installed', 'sensei-lms' );
+		actionProps = {
+			children: __( 'Installed', 'sensei-lms' ),
+			icon: checked,
+			...actionProps,
+		};
 	} else {
-		mainButtonProps.children = `${ __( 'Install', 'sensei-lms' ) } - ${
+		const price =
 			extension.price !== '0'
 				? extension.price
-				: __( 'Free', 'sensei-lms' )
-		}`;
+				: __( 'Free', 'sensei-lms' );
+
+		actionProps = {
+			children: `${ __( 'Install', 'sensei-lms' ) } - ${ price }`,
+			...actionProps,
+		};
 	}
 
-	let buttons = [
-		{
-			key: 'main-button',
-			disabled:
-				isLoadingStatus( extension.status ) ||
-				( extension.is_installed && ! extension.canUpdate ),
-			...mainButtonProps,
-		},
-	];
+	let buttons = [ actionProps ];
 
 	if ( extension.link ) {
 		buttons = [

--- a/assets/extensions/extension-actions.js
+++ b/assets/extensions/extension-actions.js
@@ -2,8 +2,8 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Icon } from '@wordpress/icons';
 import { useDispatch } from '@wordpress/data';
+import { Button } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -20,25 +20,20 @@ import { UpdateIcon } from '../icons';
  */
 const ExtensionActions = ( { actions } ) => (
 	<ul className="sensei-extensions__extension-actions">
-		{ actions.map( ( { key, children, ...actionProps } ) => {
-			const ActionComponent = actionProps.href ? 'a' : 'button';
-
-			return (
-				<li
-					key={ key }
-					className="sensei-extensions__extension-actions__item"
+		{ actions.map( ( { key, children, ...actionProps } ) => (
+			<li
+				key={ key }
+				className="sensei-extensions__extension-actions__item"
+			>
+				<Button
+					isPrimary={ ! actionProps.href }
+					isLink={ !! actionProps.href }
+					{ ...actionProps }
 				>
-					<ActionComponent
-						className={
-							actionProps.className || 'button button-primary'
-						}
-						{ ...actionProps }
-					>
-						{ children }
-					</ActionComponent>
-				</li>
-			);
-		} ) }
+					{ children }
+				</Button>
+			</li>
+		) ) }
 	</ul>
 );
 
@@ -58,11 +53,10 @@ export const useExtensionActions = ( extension ) => {
 		return null;
 	}
 
-	let buttonLabel = '';
-	let buttonAction = () => {};
+	const mainButtonProps = {};
 
 	if ( isLoadingStatus( extension.status ) ) {
-		buttonLabel = (
+		mainButtonProps.children = (
 			<>
 				<UpdateIcon
 					width="20"
@@ -73,22 +67,14 @@ export const useExtensionActions = ( extension ) => {
 			</>
 		);
 	} else if ( extension.canUpdate ) {
-		buttonLabel = __( 'Update', 'sensei-lms' );
-		buttonAction = () =>
+		mainButtonProps.children = __( 'Update', 'sensei-lms' );
+		mainButtonProps.onClick = () =>
 			updateExtensions( [ extension ], extension.product_slug );
 	} else if ( extension.is_installed ) {
-		buttonLabel = (
-			<>
-				<Icon
-					className="sensei-extensions__extension-actions__button-icon"
-					icon={ checked }
-					size={ 14 }
-				/>{ ' ' }
-				{ __( 'Installed', 'sensei-lms' ) }
-			</>
-		);
+		mainButtonProps.icon = checked;
+		mainButtonProps.children = __( 'Installed', 'sensei-lms' );
 	} else {
-		buttonLabel = `${ __( 'Install', 'sensei-lms' ) } - ${
+		mainButtonProps.children = `${ __( 'Install', 'sensei-lms' ) } - ${
 			extension.price !== '0'
 				? extension.price
 				: __( 'Free', 'sensei-lms' )
@@ -101,8 +87,7 @@ export const useExtensionActions = ( extension ) => {
 			disabled:
 				isLoadingStatus( extension.status ) ||
 				( extension.is_installed && ! extension.canUpdate ),
-			children: buttonLabel,
-			onClick: buttonAction,
+			...mainButtonProps,
 		},
 	];
 

--- a/assets/extensions/extension-actions.js
+++ b/assets/extensions/extension-actions.js
@@ -10,7 +10,7 @@ import { Button } from '@wordpress/components';
  */
 import { checked } from '../icons/wordpress-icons';
 import { EXTENSIONS_STORE, isLoadingStatus } from './store';
-import { UpdateIcon } from '../icons';
+import updateIcon from '../icons/update-icon';
 
 /**
  * Extension actions component.
@@ -56,16 +56,9 @@ export const useExtensionActions = ( extension ) => {
 	const mainButtonProps = {};
 
 	if ( isLoadingStatus( extension.status ) ) {
-		mainButtonProps.children = (
-			<>
-				<UpdateIcon
-					width="20"
-					height="20"
-					className="sensei-extensions__rotating-icon sensei-extensions__extension-actions__button-icon"
-				/>
-				{ __( 'Updating…', 'sensei-lms' ) }
-			</>
-		);
+		mainButtonProps.children = __( 'Updating…', 'sensei-lms' );
+		mainButtonProps.className = 'sensei-extensions__rotating-icon';
+		mainButtonProps.icon = updateIcon;
 	} else if ( extension.canUpdate ) {
 		mainButtonProps.children = __( 'Update', 'sensei-lms' );
 		mainButtonProps.onClick = () =>

--- a/assets/extensions/extension-actions.js
+++ b/assets/extensions/extension-actions.js
@@ -47,12 +47,11 @@ export default ExtensionActions;
 /**
  * Get extension actions array.
  *
- * @param {Object} extension           Extension object.
- * @param {string} componentInProgress Which component has caused an update.
+ * @param {Object} extension Extension object.
  *
  * @return {Array|null} Array of actions, or null if it's not a valid extension.
  */
-export const getExtensionActions = ( extension, componentInProgress ) => {
+export const getExtensionActions = ( extension ) => {
 	if ( ! extension.product_slug ) {
 		return null;
 	}
@@ -60,7 +59,7 @@ export const getExtensionActions = ( extension, componentInProgress ) => {
 	let buttonLabel = '';
 	let buttonAction = () => {};
 
-	if ( componentInProgress === extension.product_slug ) {
+	if ( 'in-progress' === extension.status ) {
 		buttonLabel = (
 			<>
 				<UpdateIcon
@@ -101,7 +100,7 @@ export const getExtensionActions = ( extension, componentInProgress ) => {
 		{
 			key: 'main-button',
 			disabled:
-				componentInProgress !== '' ||
+				'in-progress' === extension.status ||
 				( extension.is_installed && ! extension.canUpdate ),
 			children: buttonLabel,
 			onClick: buttonAction,

--- a/assets/extensions/extension-actions.js
+++ b/assets/extensions/extension-actions.js
@@ -63,12 +63,12 @@ export const useExtensionActions = ( extension ) => {
 			disabled: true,
 			...actionProps,
 		};
-	} else if ( extension.canUpdate ) {
+	} else if ( extension.has_update ) {
 		actionProps = {
 			children: __( 'Update', 'sensei-lms' ),
 			onClick: () =>
 				updateExtensions( [ extension ], extension.product_slug ),
-			disabled: ! extension.canUpdate,
+			disabled: ! extension.can_update,
 			...actionProps,
 		};
 	} else if ( extension.is_installed ) {

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -439,4 +439,9 @@ $wordpress-break: 961px;
 			vertical-align: middle;
 		}
 	}
+
+	&__rotating-icon {
+		animation: rotation 2s infinite linear;
+		margin-right: 6px;
+	}
 }

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -41,429 +41,429 @@ $wordpress-break: 961px;
 			left: 175px;
 		}
 	}
-}
 
-.sensei-extensions {
-	.button-primary {
-		min-width: 112px;
-		min-height: 36px;
-	}
-
-	&__loader {
-		height: 80vh;
-		display: flex;
-		justify-content: center;
-		align-items: center;
-	}
-
-	&__section {
-		display: flex;
-		flex-direction: column;
-		width: 100%;
-		margin-bottom: 38px;
-
-		&--with-inner-sections {
-			margin-bottom: 0;
+	.sensei-extensions {
+		.components-button.is-primary {
+			min-width: 112px;
+			min-height: 36px;
 		}
 
-		&__title {
-			margin: 0 0 17px;
+		&__loader {
+			height: 80vh;
+			display: flex;
+			justify-content: center;
+			align-items: center;
 		}
 
-		&__description {
-			margin: 0 0 17px;
-		}
-
-		&__body {
-			flex: 1;
-		}
-	}
-
-	&__grid {
-		display: flex;
-		flex-wrap: wrap;
-		margin: 0 -9px;
-
-		&__col {
-			box-sizing: border-box;
+		&__section {
+			display: flex;
+			flex-direction: column;
 			width: 100%;
-			padding: 0 9px;
+			margin-bottom: 38px;
 
-			&.--col-12 {
-				@include col-width( 12 );
+			&--with-inner-sections {
+				margin-bottom: 0;
 			}
 
-			&.--col-11 {
-				@include col-width( 11 );
+			&__title {
+				margin: 0 0 17px;
 			}
 
-			&.--col-10 {
-				@include col-width( 10 );
+			&__description {
+				margin: 0 0 17px;
 			}
 
-			&.--col-9 {
-				@include col-width( 9 );
-			}
-
-			&.--col-8 {
-				@include col-width( 8 );
-			}
-
-			&.--col-7 {
-				@include col-width( 7 );
-			}
-
-			&.--col-6 {
-				@include col-width( 6 );
-			}
-
-			&.--col-5 {
-				@include col-width( 5 );
-			}
-
-			&.--col-4 {
-				@include col-width( 4 );
-			}
-
-			&.--col-3 {
-				@include col-width( 3 );
-			}
-
-			&.--col-2 {
-				@include col-width( 2 );
-			}
-
-			&.--col-1 {
-				@include col-width( 1 );
-			}
-		}
-	}
-
-	&__tabs {
-		float: none;
-
-		&__tab {
-			&:not(:last-child)::after {
-				content: '|';
+			&__body {
+				flex: 1;
 			}
 		}
 
-		&__count::before {
-			content: ' ';
-		}
-	}
+		&__grid {
+			display: flex;
+			flex-wrap: wrap;
+			margin: 0 -9px;
 
-	&__update-badge {
-		display: flex;
-		align-items: center;
-		font-size: 14px;
-		font-weight: 500;
-		color: inherit;
+			&__col {
+				box-sizing: border-box;
+				width: 100%;
+				padding: 0 9px;
 
-		svg {
-			width: 24px;
-			height: 24px;
-			margin-right: 5px;
-		}
-	}
+				&.--col-12 {
+					@include col-width( 12 );
+				}
 
-	&__update-notification {
-		@include white-box;
-		padding: 17px 50px;
-		border-left: solid 5px $primary;
+				&.--col-11 {
+					@include col-width( 11 );
+				}
 
-		.sensei-extensions__update-badge {
-			margin-left: -29px;
-		}
+				&.--col-10 {
+					@include col-width( 10 );
+				}
 
-		&__title {
-			margin: 10px 0;
-			font-size: 18px;
-		}
+				&.--col-9 {
+					@include col-width( 9 );
+				}
 
-		&__description {
-			margin: 0 0 30px;
-			font-size: 14px;
-		}
+				&.--col-8 {
+					@include col-width( 8 );
+				}
 
-		&__list {
-			margin: 10px 0 30px;
+				&.--col-7 {
+					@include col-width( 7 );
+				}
 
-			&__item {
-				margin: 0;
+				&.--col-6 {
+					@include col-width( 6 );
+				}
 
-				&::before {
-					content: "- "
+				&.--col-5 {
+					@include col-width( 5 );
+				}
+
+				&.--col-4 {
+					@include col-width( 4 );
+				}
+
+				&.--col-3 {
+					@include col-width( 3 );
+				}
+
+				&.--col-2 {
+					@include col-width( 2 );
+				}
+
+				&.--col-1 {
+					@include col-width( 1 );
 				}
 			}
 		}
 
-		&__version-link {
-			color: inherit;
-		}
-	}
+		&__tabs {
+			float: none;
 
-	&__featured-list {
-		@include white-box;
-		padding: 15px;
-		margin: 0;
+			&__tab {
+				&:not(:last-child)::after {
+					content: '|';
+				}
+			}
+
+			&__count::before {
+				content: ' ';
+			}
+		}
+
+		&__update-badge {
+			display: flex;
+			align-items: center;
+			font-size: 14px;
+			font-weight: 500;
+			color: inherit;
+
+			svg {
+				width: 24px;
+				height: 24px;
+				margin-right: 5px;
+			}
+		}
+
+		&__update-notification {
+			@include white-box;
+			padding: 17px 50px;
+			border-left: solid 5px $primary;
+
+			.sensei-extensions__update-badge {
+				margin-left: -29px;
+			}
+
+			&__title {
+				margin: 10px 0;
+				font-size: 18px;
+			}
+
+			&__description {
+				margin: 0 0 30px;
+				font-size: 14px;
+			}
+
+			&__list {
+				margin: 10px 0 30px;
+
+				&__item {
+					margin: 0;
+
+					&::before {
+						content: "- "
+					}
+				}
+			}
+
+			&__version-link {
+				color: inherit;
+			}
+		}
+
+		&__featured-list {
+			@include white-box;
+			padding: 15px;
+			margin: 0;
+
+			@media (min-width: $wordpress-break) {
+				display: flex;
+				flex-wrap: wrap;
+			}
+
+			@media (min-width: 1200px) {
+				padding: 50px 45px;
+			}
+
+			.sensei-extensions__list-item {
+				box-sizing: border-box;
+				padding: 10px;
+				margin: 0;
+
+				@media (min-width: $wordpress-break) {
+					@include col-width(6);
+					padding: 15px;
+				}
+
+				@media (min-width: 1200px) {
+					@include col-width(4);
+				}
+			}
+
+			.sensei-extensions__card {
+				border-radius: 8px;
+				flex-direction: column;
+
+				&__image {
+					border-radius: 8px 8px 0 0;
+				}
+			}
+
+			.sensei-extensions__card-wrapper {
+				height: 100%;
+				box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.16);
+				border-radius: 8px;
+			}
+
+			&__card-wrapper, .sensei-extensions__card {
+				height: 100%;
+			}
+
+		}
+
+		&__small-list,
+		&__large-list {
+			@include white-box;
+			margin: 0;
+
+			.sensei-extensions__list-item {
+				margin: 0;
+
+				&:not(:last-child) {
+					border-bottom: solid 1px $gray-5;
+				}
+			}
+		}
+
+		&__small-list {
+			.sensei-extensions__card__image {
+				display: none;
+			}
+		}
+
+		&__large-list {
+			&__item:first-child .sensei-extensions__card__image {
+				border-radius: 2px 2px 0 0;
+				@media (min-width: $wordpress-break) {
+					border-radius: 2px 0 0 0;
+				}
+			}
+			&__item:last-child .sensei-extensions__card__image {
+				@media (min-width: $wordpress-break) {
+					border-radius: 0 0 0 2px;
+				}
+			}
+			@media (max-width: $wordpress-break) {
+				.sensei-extensions__card {
+					flex-direction: column;
+				}
+			}
+		}
+
+		@media (min-width: $wordpress-break) and (max-width: 1100px) {
+			&__small-list {
+				.sensei-extensions__card__header {
+					display: block;
+				}
+				.sensei-extensions__card__new-badge {
+					display: block;
+					text-align: right;
+					padding-left: 0;
+				}
+			}
+		}
 
 		@media (min-width: $wordpress-break) {
-			display: flex;
-			flex-wrap: wrap;
-		}
+			&__large-list {
+				.sensei-extensions__card {
+				}
+				.sensei-extensions__card__body {
 
-		@media (min-width: 1200px) {
-			padding: 50px 45px;
-		}
+				}
+				.sensei-extensions__card__image {
+				}
+				.sensei-extensions__card__description {
 
-		.sensei-extensions__list-item {
-			box-sizing: border-box;
-			padding: 10px;
-			margin: 0;
+				}
+				.sensei-extensions__extension-actions {
 
-			@media (min-width: $wordpress-break) {
-				@include col-width(6);
-				padding: 15px;
-			}
+				}
+				.sensei-extensions__extension-actions__details-link {
 
-			@media (min-width: 1200px) {
-				@include col-width(4);
+				}
 			}
 		}
 
-		.sensei-extensions__card {
-			border-radius: 8px;
-			flex-direction: column;
+		&__grid-list {
+			padding: 0;
+			margin-bottom: -15px;
 
-			&__image {
-				border-radius: 8px 8px 0 0;
+			@extend .sensei-extensions__grid;
+
+			.sensei-extensions__list-item {
+				margin: 0 0 15px;
+
+				@extend .sensei-extensions__grid__col;
+
+				@media (min-width: $wordpress-break) {
+					@include col-width(6);
+				}
+
+				@media (min-width: 1200px) {
+					@include col-width(4);
+				}
 			}
-		}
 
-		.sensei-extensions__card-wrapper {
-			height: 100%;
-			box-shadow: 0px 8px 16px rgba(0, 0, 0, 0.16);
-			border-radius: 8px;
-		}
-
-		&__card-wrapper, .sensei-extensions__card {
-			height: 100%;
-		}
-
-	}
-
-	&__small-list,
-	&__large-list {
-		@include white-box;
-		margin: 0;
-
-		.sensei-extensions__list-item {
-			margin: 0;
-
-			&:not(:last-child) {
-				border-bottom: solid 1px $gray-5;
+			.sensei-extensions__card-wrapper {
+				@include white-box(2px);
+				height: 100%
 			}
-		}
-	}
 
-	&__small-list {
-		.sensei-extensions__card__image {
-			display: none;
-		}
-	}
-
-	&__large-list {
-		&__item:first-child .sensei-extensions__card__image {
-			border-radius: 2px 2px 0 0;
-			@media (min-width: $wordpress-break) {
-				border-radius: 2px 0 0 0;
-			}
-		}
-		&__item:last-child .sensei-extensions__card__image {
-			@media (min-width: $wordpress-break) {
-				border-radius: 0 0 0 2px;
-			}
-		}
-		@media (max-width: $wordpress-break) {
 			.sensei-extensions__card {
 				flex-direction: column;
-			}
-		}
-	}
-
-	@media (min-width: $wordpress-break) and (max-width: 1100px) {
-		&__small-list {
-			.sensei-extensions__card__header {
-				display: block;
-			}
-			.sensei-extensions__card__new-badge {
-				display: block;
-				text-align: right;
-				padding-left: 0;
-			}
-		}
-	}
-
-	@media (min-width: $wordpress-break) {
-		&__large-list {
-			.sensei-extensions__card {
-			}
-			.sensei-extensions__card__body {
-
-			}
-			.sensei-extensions__card__image {
-			}
-			.sensei-extensions__card__description {
-
-			}
-			.sensei-extensions__extension-actions {
-
-			}
-			.sensei-extensions__extension-actions__details-link {
-
-			}
-		}
-	}
-
-	&__grid-list {
-		padding: 0;
-		margin-bottom: -15px;
-
-		@extend .sensei-extensions__grid;
-
-		.sensei-extensions__list-item {
-			margin: 0 0 15px;
-
-			@extend .sensei-extensions__grid__col;
-
-			@media (min-width: $wordpress-break) {
-				@include col-width(6);
-			}
-
-			@media (min-width: 1200px) {
-				@include col-width(4);
+				&__image {
+					border-radius: 2px 2px 0 0;
+				}
 			}
 		}
 
-		.sensei-extensions__card-wrapper {
-			@include white-box(2px);
-			height: 100%
-		}
+		&__card {
+			display: flex;
+			align-items: stretch;
+			height: 100%;
 
-		.sensei-extensions__card {
-			flex-direction: column;
+			&__header {
+				display: flex;
+				justify-content: space-between;
+				margin-bottom: 10px;
+			}
+
+			&__content {
+				padding: 25px;
+				display: flex;
+				flex-direction: column;
+				flex: 1;
+
+				@media (min-width: $wordpress-break) {
+					min-height: 170px;
+				}
+			}
+
+			&__body {
+				flex: 1;
+				display: flex;
+				flex-direction: column;
+			}
+
+			&__title {
+				margin: 0;
+				font-size: 16px;
+				font-weight: bold;
+				color: inherit;
+			}
+
+			&__price {
+				margin-bottom: 10px;
+				font-size: 16px;
+			}
+
 			&__image {
-				border-radius: 2px 2px 0 0;
+				background-color: $gray-0;
+				background-size: cover;
+				background-position: center center;
+				flex: 0 0 220px;
+			}
+
+			&__new-badge {
+				padding-left: 10px;
+				font-size: 12px;
+				white-space: nowrap;
+
+				&::before {
+					content: "";
+					display: inline-block;
+					width: 8px;
+					height: 8px;
+					margin-right: 7px;
+					background-color: $primary;
+					border-radius: 50%;
+				}
+			}
+
+			&__description {
+				margin: 0 0 10px;
+				font-size: 14px;
+				flex: 1;
 			}
 		}
-	}
 
-	&__card {
-		display: flex;
-		align-items: stretch;
-		height: 100%;
-
-		&__header {
+		&__extension-actions {
 			display: flex;
-			justify-content: space-between;
-			margin-bottom: 10px;
-		}
-
-		&__content {
-			padding: 25px;
-			display: flex;
-			flex-direction: column;
-			flex: 1;
-
-			@media (min-width: $wordpress-break) {
-				min-height: 170px;
-			}
-		}
-
-		&__body {
-			flex: 1;
-			display: flex;
-			flex-direction: column;
-		}
-
-		&__title {
+			align-items: center;
 			margin: 0;
-			font-size: 16px;
-			font-weight: bold;
-			color: inherit;
-		}
+			padding: 0;
 
-		&__price {
-			margin-bottom: 10px;
-			font-size: 16px;
-		}
+			&__item {
+				margin: 0;
 
-		&__image {
-			background-color: $gray-0;
-			background-size: cover;
-			background-position: center center;
-			flex: 0 0 220px;
-		}
+				a.button {
+					display: inline-flex;
+					justify-content: center;
+					align-items: center;
+				}
+			}
 
-		&__new-badge {
-			padding-left: 10px;
-			font-size: 12px;
-			white-space: nowrap;
-
-			&::before {
-				content: "";
+			&__details-link {
 				display: inline-block;
-				width: 8px;
-				height: 8px;
-				margin-right: 7px;
-				background-color: $primary;
-				border-radius: 50%;
+				padding: 0 10px;
+				margin-left: 10px;
+				font-size: 13px;
+				color: inherit;
+			}
+
+			&__button-icon {
+				vertical-align: middle;
 			}
 		}
 
-		&__description {
-			margin: 0 0 10px;
-			font-size: 14px;
-			flex: 1;
-		}
-	}
-
-	&__extension-actions {
-		display: flex;
-		align-items: center;
-		margin: 0;
-		padding: 0;
-
-		&__item {
-			margin: 0;
-
-			a.button {
-				display: inline-flex;
-				justify-content: center;
-				align-items: center;
-			}
+		&__rotating-icon {
+			animation: rotation 2s infinite linear;
+			margin-right: 6px;
 		}
 
-		&__details-link {
-			display: inline-block;
-			padding: 0 10px;
-			margin-left: 10px;
-			font-size: 13px;
-			color: inherit;
+		.components-notice {
+			margin: 10px 0 0;
 		}
-
-		&__button-icon {
-			vertical-align: middle;
-		}
-	}
-
-	&__rotating-icon {
-		animation: rotation 2s infinite linear;
-		margin-right: 6px;
-	}
-
-	.components-notice {
-		margin: 10px 0 0;
 	}
 }

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -155,12 +155,7 @@ $wordpress-break: 961px;
 		border-left: solid 5px $primary;
 
 		.sensei-extensions__update-badge {
-			margin-left: -29px
-		}
-
-		.sensei-extensions__update-message {
-			margin: 0 -29px;
-			font-size: 14px;
+			margin-left: -29px;
 		}
 
 		&__title {

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -158,6 +158,11 @@ $wordpress-break: 961px;
 			margin-left: -29px
 		}
 
+		.sensei-extensions__update-message {
+			margin: 0 -29px;
+			font-size: 14px;
+		}
+
 		&__title {
 			margin: 10px 0;
 			font-size: 18px;

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -449,4 +449,8 @@ $wordpress-break: 961px;
 		animation: rotation 2s infinite linear;
 		margin-right: 6px;
 	}
+
+	.components-notice {
+		margin: 10px 0 0;
+	}
 }

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -451,15 +451,10 @@ $wordpress-break: 961px;
 				font-size: 13px;
 				color: inherit;
 			}
-
-			&__button-icon {
-				vertical-align: middle;
-			}
 		}
 
-		&__rotating-icon {
+		&__rotating-icon svg {
 			animation: rotation 2s infinite linear;
-			margin-right: 6px;
 		}
 
 		.components-notice {

--- a/assets/extensions/extensions.scss
+++ b/assets/extensions/extensions.scss
@@ -23,6 +23,24 @@ $wordpress-break: 961px;
 	}
 
 	color: $gray-100;
+
+	// Adjust the position of the notices
+	.components-editor-notices__snackbar {
+		position: fixed;
+		left: 0;
+		right: 0;
+		bottom: 40px;
+		padding-left: 16px;
+		padding-right: 16px;
+
+		@media (min-width: 783px) {
+			left: 50px;
+		}
+
+		@media (min-width: $wordpress-break) {
+			left: 175px;
+		}
+	}
 }
 
 .sensei-extensions {

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { Spinner } from '@wordpress/components';
+import { Notice, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
@@ -22,6 +22,9 @@ import { Grid, Col } from './grid';
 const Main = () => {
 	const extensions = useSelect( ( select ) =>
 		select( EXTENSIONS_STORE ).getExtensions()
+	);
+	const error = useSelect( ( select ) =>
+		select( EXTENSIONS_STORE ).getError()
 	);
 
 	const [ layout, setLayout ] = useState( false );
@@ -90,6 +93,11 @@ const Main = () => {
 				<Col className="sensei-extensions__section" cols={ 12 }>
 					<Header />
 					<Tabs tabs={ tabs } />
+					{ error !== null && (
+						<Notice status="error" isDismissible={ false }>
+							{ error }
+						</Notice>
+					) }
 				</Col>
 
 				<UpdateNotification extensions={ extensions } />

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -20,9 +20,9 @@ import { EXTENSIONS_STORE } from './store';
 import { Grid, Col } from './grid';
 
 const Main = () => {
-	const extensions = useSelect( ( select ) =>
-		select( EXTENSIONS_STORE ).getExtensions()
-	);
+	const { extensions } = useSelect( ( select ) => ( {
+		extensions: select( EXTENSIONS_STORE ).getExtensions(),
+	} ) );
 	const error = useSelect( ( select ) =>
 		select( EXTENSIONS_STORE ).getError()
 	);

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -22,15 +22,14 @@ import { Grid, Col } from './grid';
 const Main = () => {
 	useSenseiColorTheme();
 
-	const { extensions } = useSelect( ( select ) => ( {
-		extensions: select( EXTENSIONS_STORE ).getExtensions(),
-	} ) );
-	const { layout } = useSelect( ( select ) => ( {
-		layout: select( EXTENSIONS_STORE ).getLayout(),
-	} ) );
-	const error = useSelect( ( select ) =>
-		select( EXTENSIONS_STORE ).getError()
-	);
+	const { extensions, layout, error } = useSelect( ( select ) => {
+		const store = select( EXTENSIONS_STORE );
+		return {
+			extensions: store.getExtensions(),
+			layout: store.getLayout(),
+			error: store.getError(),
+		};
+	} );
 
 	if ( extensions.length === 0 || layout.length === 0 ) {
 		return (

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -9,6 +9,7 @@ import { EditorNotices } from '@wordpress/editor';
 /**
  * Internal dependencies
  */
+import { useSenseiColorTheme } from '../react-hooks/use-sensei-color-theme';
 import Header from './header';
 import Tabs from './tabs';
 import UpdateNotification from './update-notification';
@@ -19,6 +20,8 @@ import { EXTENSIONS_STORE } from './store';
 import { Grid, Col } from './grid';
 
 const Main = () => {
+	useSenseiColorTheme();
+
 	const { extensions } = useSelect( ( select ) => ( {
 		extensions: select( EXTENSIONS_STORE ).getExtensions(),
 	} ) );

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -4,8 +4,6 @@
 import { Notice, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
-import apiFetch from '@wordpress/api-fetch';
-import { useState, useEffect } from '@wordpress/element';
 import { EditorNotices } from '@wordpress/editor';
 
 /**
@@ -24,23 +22,14 @@ const Main = () => {
 	const { extensions } = useSelect( ( select ) => ( {
 		extensions: select( EXTENSIONS_STORE ).getExtensions(),
 	} ) );
+	const { layout } = useSelect( ( select ) => ( {
+		layout: select( EXTENSIONS_STORE ).getLayout(),
+	} ) );
 	const error = useSelect( ( select ) =>
 		select( EXTENSIONS_STORE ).getError()
 	);
 
-	const [ layout, setLayout ] = useState( false );
-
-	useEffect( () => {
-		apiFetch( {
-			path: '/sensei-internal/v1/sensei-extensions/layout',
-		} )
-			.then( ( result ) => {
-				setLayout( result.layout || [] );
-			} )
-			.catch( () => setLayout( [] ) );
-	}, [] );
-
-	if ( extensions.length === 0 || false === layout ) {
+	if ( extensions.length === 0 || layout.length === 0 ) {
 		return (
 			<div className="sensei-extensions__loader">
 				<Spinner />

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -1,10 +1,11 @@
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
-import { useState, useEffect } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { useSelect } from '@wordpress/data';
+import apiFetch from '@wordpress/api-fetch';
+import { useState, useEffect } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -15,20 +16,13 @@ import UpdateNotification from './update-notification';
 import QueryStringRouter, { Route } from '../shared/query-string-router';
 import AllExtensions from './all-extensions';
 import FilteredExtensions from './filtered-extensions';
+import { EXTENSIONS_STORE } from './store';
 import { Grid, Col } from './grid';
 
 const Main = () => {
-	const [ extensions, setExtensions ] = useState( false );
-
-	useEffect( () => {
-		apiFetch( {
-			path: '/sensei-internal/v1/sensei-extensions?type=plugin',
-		} )
-			.then( ( result ) => {
-				setExtensions( result.extensions || [] );
-			} )
-			.catch( () => setExtensions( [] ) );
-	}, [] );
+	const extensions = useSelect( ( select ) =>
+		select( EXTENSIONS_STORE ).getExtensions()
+	);
 
 	const [ layout, setLayout ] = useState( false );
 
@@ -42,7 +36,7 @@ const Main = () => {
 			.catch( () => setLayout( [] ) );
 	}, [] );
 
-	if ( false === extensions || false === layout ) {
+	if ( extensions.length === 0 || false === layout ) {
 		return (
 			<div className="sensei-extensions__loader">
 				<Spinner />

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -6,6 +6,7 @@ import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import { useState, useEffect } from '@wordpress/element';
+import { EditorNotices } from '@wordpress/editor';
 
 /**
  * Internal dependencies
@@ -78,26 +79,29 @@ const Main = () => {
 	];
 
 	return (
-		<Grid as="main" className="sensei-extensions">
-			<QueryStringRouter paramName="tab" defaultRoute="all">
-				<Col className="sensei-extensions__section" cols={ 12 }>
-					<Header />
-					<Tabs tabs={ tabs } />
-					{ error !== null && (
-						<Notice status="error" isDismissible={ false }>
-							{ error }
-						</Notice>
-					) }
-				</Col>
+		<>
+			<Grid as="main" className="sensei-extensions">
+				<QueryStringRouter paramName="tab" defaultRoute="all">
+					<Col className="sensei-extensions__section" cols={ 12 }>
+						<Header />
+						<Tabs tabs={ tabs } />
+						{ error !== null && (
+							<Notice status="error" isDismissible={ false }>
+								{ error }
+							</Notice>
+						) }
+					</Col>
 
-				<UpdateNotification extensions={ extensions } />
-				{ tabs.map( ( tab ) => (
-					<Route key={ tab.id } route={ tab.id }>
-						{ tab.content }
-					</Route>
-				) ) }
-			</QueryStringRouter>
-		</Grid>
+					<UpdateNotification extensions={ extensions } />
+					{ tabs.map( ( tab ) => (
+						<Route key={ tab.id } route={ tab.id }>
+							{ tab.content }
+						</Route>
+					) ) }
+				</QueryStringRouter>
+			</Grid>
+			<EditorNotices />
+		</>
 	);
 };
 

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -50,10 +50,6 @@ const Main = () => {
 	const freeExtensions = extensions.filter(
 		( extension ) => extension.price === '0'
 	);
-	// TODO: Specify which plugins are third party
-	const thirdPartyExtensions = extensions.filter(
-		( extension ) => extension.price === '0'
-	);
 	const installedExtensions = extensions.filter(
 		( extension ) => extension.is_installed
 	);
@@ -72,12 +68,6 @@ const Main = () => {
 			label: __( 'Free', 'sensei-lms' ),
 			count: freeExtensions.length,
 			content: <FilteredExtensions extensions={ freeExtensions } />,
-		},
-		{
-			id: 'third-party',
-			label: __( 'Third Party', 'sensei-lms' ),
-			count: thirdPartyExtensions.length,
-			content: <FilteredExtensions extensions={ thirdPartyExtensions } />,
 		},
 		{
 			id: 'installed',

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -51,9 +51,7 @@ const Main = () => {
 			id: 'all',
 			label: __( 'All', 'sensei-lms' ),
 			count: extensions.length,
-			content: (
-				<AllExtensions extensions={ extensions } layout={ layout } />
-			),
+			content: <AllExtensions layout={ layout } />,
 		},
 		{
 			id: 'free',

--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -31,7 +31,7 @@ const Main = () => {
 		};
 	} );
 
-	if ( extensions.length === 0 || layout.length === 0 ) {
+	if ( 0 === extensions.length || 0 === layout.length ) {
 		return (
 			<div className="sensei-extensions__loader">
 				<Spinner />

--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -117,14 +117,18 @@ const actions = {
 				}
 			);
 		} catch ( error ) {
+			const errorMessage = Object.keys( error.errors )
+				.map( ( key ) => error.errors[ key ].join( ' ' ) )
+				.join( ' ' );
+
 			yield actions.setError(
 				sprintf(
 					// translators: Placeholder is underlying error message.
 					__(
-						'There was an error while updating the plugin: %1$s.',
+						'There was an error while updating the plugin: %1$s',
 						'sensei-lms'
 					),
-					error.message
+					errorMessage
 				)
 			);
 		} finally {

--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -32,7 +32,8 @@ export const EXTENSIONS_STORE = 'sensei/extensions';
  * Default store state.
  */
 const DEFAULT_STATE = {
-	extensions: [],
+	// Extensions list to be mapped using the entities.
+	extensionsSlugs: [],
 	entities: { extensions: {} },
 	layout: [],
 	error: null,
@@ -196,8 +197,8 @@ const actions = {
  * Extension store selectors.
  */
 const selectors = {
-	getExtensions: ( { extensions, entities } ) =>
-		extensions.map( ( slug ) => entities.extensions[ slug ] ),
+	getExtensions: ( { extensionsSlugs, entities } ) =>
+		extensionsSlugs.map( ( slug ) => entities.extensions[ slug ] ),
 	getExtensionsByStatus: ( args, status ) =>
 		selectors
 			.getExtensions( args )
@@ -245,7 +246,7 @@ const reducer = {
 			// Update extension array (slugs).
 			newState = {
 				...newState,
-				extensions: [
+				extensionsSlugs: [
 					...extensions.map(
 						( extension ) => extension.product_slug
 					),

--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -6,7 +6,7 @@ import { keyBy } from 'lodash';
 /**
  * WordPress dependencies
  */
-import { registerStore } from '@wordpress/data';
+import { registerStore, dispatch } from '@wordpress/data';
 import { controls, apiFetch } from '@wordpress/data-controls';
 import { __, sprintf } from '@wordpress/i18n';
 
@@ -68,6 +68,14 @@ const actions = {
 					wccom_connected: response.wccom_connected,
 				},
 				true
+			);
+
+			dispatch( 'core/notices' ).createNotice(
+				'success',
+				__( 'Update completed succesfully!', 'sensei-lms' ),
+				{
+					type: 'snackbar',
+				}
 			);
 		} catch ( error ) {
 			yield actions.setError(

--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -256,7 +256,10 @@ const reducer = (
 			const extensionsWithStatus = { ...state.entities.extensions };
 
 			action.slugs.forEach( ( slug ) => {
-				extensionsWithStatus[ slug ].status = action.status;
+				extensionsWithStatus[ slug ] = {
+					...extensionsWithStatus[ slug ],
+					status: action.status,
+				};
 			} );
 
 			return {

--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -144,6 +144,19 @@ const actions = {
 	},
 
 	/**
+	 * Set the extensions layout.
+	 *
+	 * @param {Object} obj        Layout object.
+	 * @param {Array}  obj.layout Extensions layout.
+	 */
+	setLayout( { layout = [] } ) {
+		return {
+			type: 'SET_LAYOUT',
+			layout,
+		};
+	},
+
+	/**
 	 * Set the error message.
 	 *
 	 * @param {string} error The error.
@@ -166,6 +179,7 @@ const selectors = {
 		selectors
 			.getExtensions( args )
 			.filter( ( extension ) => status === extension.status ),
+	getLayout: ( { layout } ) => layout,
 	getError: ( { error } ) => error,
 };
 
@@ -183,6 +197,17 @@ const resolvers = {
 
 		return actions.setExtensions( response );
 	},
+
+	/**
+	 * Loads the extensions layout.
+	 */
+	*getLayout() {
+		const response = yield apiFetch( {
+			path: '/sensei-internal/v1/sensei-extensions/layout',
+		} );
+
+		return actions.setLayout( response );
+	},
 };
 
 /**
@@ -195,6 +220,7 @@ const reducer = (
 	state = {
 		extensions: [],
 		entities: { extensions: {} },
+		layout: [],
 		error: null,
 	},
 	action
@@ -239,6 +265,11 @@ const reducer = (
 					...state.entities,
 					extensions: extensionsWithStatus,
 				},
+			};
+		case 'SET_LAYOUT':
+			return {
+				...state,
+				layout: action.layout,
 			};
 		case 'SET_ERROR':
 			return {

--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -179,6 +179,7 @@ const selectors = {
 		selectors
 			.getExtensions( args )
 			.filter( ( extension ) => status === extension.status ),
+	getEntities: ( { entities }, entity ) => entities[ entity ],
 	getLayout: ( { layout } ) => layout,
 	getError: ( { error } ) => error,
 };

--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -35,15 +35,16 @@ const actions = {
 	/**
 	 * Updates the provided extensions.
 	 *
-	 * @param {Array} extensions The extensions to update.
+	 * @param {Array}  extensions The extensions to update.
+	 * @param {string} component  The component which started the update.
 	 */
-	*updateExtensions( extensions ) {
+	*updateExtensions( extensions, component ) {
 		const plugins = extensions.map(
 			( extension ) => extension.product_slug
 		);
 
 		try {
-			yield actions.setButtonsDisabled( true );
+			yield actions.setComponentInProgress( component );
 			const newExtensions = yield apiFetch( {
 				path: '/sensei-internal/v1/sensei-extensions/update',
 				method: 'POST',
@@ -51,21 +52,21 @@ const actions = {
 			} );
 
 			yield actions.setExtensions( newExtensions );
-			return actions.setButtonsDisabled( false );
+			return actions.setComponentInProgress( '' );
 		} catch ( error ) {
 			// TODO: Handle error
 		}
 	},
 
 	/**
-	 * Enable or disable the buttons globally.
+	 * Update the component that caused an update.
 	 *
-	 * @param {boolean} disabled Whether to disable or enable.
+	 * @param {string} componentInProgress The component.
 	 */
-	setButtonsDisabled( disabled ) {
+	setComponentInProgress( componentInProgress ) {
 		return {
-			type: 'SET_BUTTONS_DISABLED',
-			disabled,
+			type: 'SET_COMPONENT_IN_PROGRESS',
+			componentInProgress,
 		};
 	},
 };
@@ -75,7 +76,7 @@ const actions = {
  */
 const selectors = {
 	getExtensions: ( { extensions } ) => extensions,
-	getButtonsDisabled: ( { buttonsDisabled } ) => buttonsDisabled,
+	getComponentInProgress: ( { componentInProgress } ) => componentInProgress,
 };
 
 /**
@@ -109,7 +110,7 @@ const resolvers = {
 const reducer = (
 	state = {
 		extensions: [],
-		buttonsDisabled: false,
+		componentInProgress: '',
 	},
 	action
 ) => {
@@ -119,10 +120,10 @@ const reducer = (
 				...state,
 				extensions: [ ...action.extensions ],
 			};
-		case 'SET_BUTTONS_DISABLED':
+		case 'SET_COMPONENT_IN_PROGRESS':
 			return {
 				...state,
-				buttonsDisabled: action.disabled,
+				componentInProgress: action.componentInProgress,
 			};
 		default:
 			return state;

--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -1,0 +1,140 @@
+/**
+ * WordPress dependencies
+ */
+import { registerStore } from '@wordpress/data';
+import { controls, apiFetch } from '@wordpress/data-controls';
+
+/**
+ * Extension store actions.
+ */
+const actions = {
+	/**
+	 * Sets the extensions.
+	 *
+	 * @param {Array} extensions The new extensions.
+	 */
+	setExtensions( extensions ) {
+		const enrichedExtensions = extensions.map( ( extension ) => {
+			let canUpdate = false;
+			// If the extension is hosted in WC.com, check that the site is connected and the subscription is not expired.
+			if ( extension.has_update ) {
+				canUpdate =
+					! extension.wccom_product_id ||
+					( extension.wccom_connected && ! extension.wccom_expired );
+			}
+
+			return { ...extension, canUpdate };
+		} );
+
+		return {
+			type: 'SET_EXTENSIONS',
+			extensions: enrichedExtensions,
+		};
+	},
+
+	/**
+	 * Updates the provided extensions.
+	 *
+	 * @param {Array} extensions The extensions to update.
+	 */
+	*updateExtensions( extensions ) {
+		const plugins = extensions.map(
+			( extension ) => extension.product_slug
+		);
+
+		try {
+			yield actions.setButtonsDisabled( true );
+			const newExtensions = yield apiFetch( {
+				path: '/sensei-internal/v1/sensei-extensions/update',
+				method: 'POST',
+				data: { plugins },
+			} );
+
+			yield actions.setExtensions( newExtensions );
+			return actions.setButtonsDisabled( false );
+		} catch ( error ) {
+			// TODO: Handle error
+		}
+	},
+
+	/**
+	 * Enable or disable the buttons globally.
+	 *
+	 * @param {boolean} disabled Whether to disable or enable.
+	 */
+	setButtonsDisabled( disabled ) {
+		return {
+			type: 'SET_BUTTONS_DISABLED',
+			disabled,
+		};
+	},
+};
+
+/**
+ * Extension store selectors.
+ */
+const selectors = {
+	getExtensions: ( { extensions } ) => extensions,
+	getButtonsDisabled: ( { buttonsDisabled } ) => buttonsDisabled,
+};
+
+/**
+ * Extension store resolvers.
+ */
+const resolvers = {
+	/**
+	 * Loads the extensions during initialization.
+	 */
+	*getExtensions() {
+		let extensions = [];
+
+		try {
+			extensions = yield apiFetch( {
+				path: '/sensei-internal/v1/sensei-extensions?type=plugin',
+			} );
+		} catch ( error ) {
+			//TODO: Handle error
+		}
+
+		return actions.setExtensions( extensions );
+	},
+};
+
+/**
+ * Product store reducer.
+ *
+ * @param {Object} state  The store state.
+ * @param {Object} action The action to handle.
+ */
+const reducer = (
+	state = {
+		extensions: [],
+		buttonsDisabled: false,
+	},
+	action
+) => {
+	switch ( action.type ) {
+		case 'SET_EXTENSIONS':
+			return {
+				...state,
+				extensions: [ ...action.extensions ],
+			};
+		case 'SET_BUTTONS_DISABLED':
+			return {
+				...state,
+				buttonsDisabled: action.disabled,
+			};
+		default:
+			return state;
+	}
+};
+
+export const EXTENSIONS_STORE = 'sensei/extensions';
+
+registerStore( EXTENSIONS_STORE, {
+	reducer,
+	actions,
+	selectors,
+	resolvers,
+	controls,
+} );

--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -47,7 +47,7 @@ const DEFAULT_STATE = {
  * @return {string} Whether is a loading status.
  */
 export const isLoadingStatus = ( status ) =>
-	Object.values( STATUS ).includes( status );
+	[ STATUS.IN_PROGRESS, STATUS.IN_QUEUE ].includes( status );
 
 /**
  * Extension store actions.

--- a/assets/extensions/update-notification/index.js
+++ b/assets/extensions/update-notification/index.js
@@ -20,7 +20,7 @@ import updateIcon from '../../icons/update-icon';
  */
 const UpdateNotification = ( { extensions } ) => {
 	const extensionsWithUpdate = extensions.filter(
-		( extension ) => extension.canUpdate
+		( extension ) => extension.can_update && extension.has_update
 	);
 
 	const updatesCount = extensionsWithUpdate.length;

--- a/assets/extensions/update-notification/index.js
+++ b/assets/extensions/update-notification/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -9,7 +10,7 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import Single from './single';
 import Multiple from './multiple';
 import { Col } from '../grid';
-import { UpdateIcon } from '../../icons';
+import updateIcon from '../../icons/update-icon';
 
 /**
  * Update notification component.
@@ -49,7 +50,7 @@ const UpdateNotification = ( { extensions } ) => {
 				className="sensei-extensions__update-notification"
 			>
 				<small className="sensei-extensions__update-badge">
-					<UpdateIcon />
+					<Icon icon={ updateIcon } />
 					{ updateAvailableLabel }
 				</small>
 				{ 1 === updatesCount ? (

--- a/assets/extensions/update-notification/index.js
+++ b/assets/extensions/update-notification/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -18,6 +19,7 @@ import { UpdateIcon } from '../../icons';
  * @param {Array}  props.extensions Extensions list.
  */
 const UpdateNotification = ( { extensions } ) => {
+	const [ updateClicked, setUpdateClicked ] = useState( false );
 	const extensionsWithUpdate = extensions.filter(
 		( extension ) => extension.canUpdate
 	);
@@ -25,6 +27,28 @@ const UpdateNotification = ( { extensions } ) => {
 	const updatesCount = extensionsWithUpdate.length;
 
 	if ( 0 === updatesCount ) {
+		if ( updateClicked ) {
+			return (
+				<Col
+					as="section"
+					className="sensei-extensions__section"
+					cols={ 12 }
+				>
+					<div
+						role="alert"
+						className="sensei-extensions__update-notification"
+					>
+						<p className="sensei-extensions__update-message">
+							{ __(
+								'Update completed succesfully!',
+								'sensei-lms'
+							) }
+						</p>
+					</div>
+				</Col>
+			);
+		}
+
 		return null;
 	}
 
@@ -53,9 +77,15 @@ const UpdateNotification = ( { extensions } ) => {
 					{ updateAvailableLabel }
 				</small>
 				{ 1 === updatesCount ? (
-					<Single extension={ extensionsWithUpdate[ 0 ] } />
+					<Single
+						extension={ extensionsWithUpdate[ 0 ] }
+						onUpdate={ () => setUpdateClicked( true ) }
+					/>
 				) : (
-					<Multiple extensions={ extensionsWithUpdate } />
+					<Multiple
+						extensions={ extensionsWithUpdate }
+						onUpdate={ () => setUpdateClicked( true ) }
+					/>
 				) }
 			</div>
 		</Col>

--- a/assets/extensions/update-notification/index.js
+++ b/assets/extensions/update-notification/index.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -19,7 +18,6 @@ import { UpdateIcon } from '../../icons';
  * @param {Array}  props.extensions Extensions list.
  */
 const UpdateNotification = ( { extensions } ) => {
-	const [ updateClicked, setUpdateClicked ] = useState( false );
 	const extensionsWithUpdate = extensions.filter(
 		( extension ) => extension.canUpdate
 	);
@@ -27,28 +25,6 @@ const UpdateNotification = ( { extensions } ) => {
 	const updatesCount = extensionsWithUpdate.length;
 
 	if ( 0 === updatesCount ) {
-		if ( updateClicked ) {
-			return (
-				<Col
-					as="section"
-					className="sensei-extensions__section"
-					cols={ 12 }
-				>
-					<div
-						role="alert"
-						className="sensei-extensions__update-notification"
-					>
-						<p className="sensei-extensions__update-message">
-							{ __(
-								'Update completed succesfully!',
-								'sensei-lms'
-							) }
-						</p>
-					</div>
-				</Col>
-			);
-		}
-
 		return null;
 	}
 
@@ -77,15 +53,9 @@ const UpdateNotification = ( { extensions } ) => {
 					{ updateAvailableLabel }
 				</small>
 				{ 1 === updatesCount ? (
-					<Single
-						extension={ extensionsWithUpdate[ 0 ] }
-						onUpdate={ () => setUpdateClicked( true ) }
-					/>
+					<Single extension={ extensionsWithUpdate[ 0 ] } />
 				) : (
-					<Multiple
-						extensions={ extensionsWithUpdate }
-						onUpdate={ () => setUpdateClicked( true ) }
-					/>
+					<Multiple extensions={ extensionsWithUpdate } />
 				) }
 			</div>
 		</Col>

--- a/assets/extensions/update-notification/index.js
+++ b/assets/extensions/update-notification/index.js
@@ -19,7 +19,7 @@ import { UpdateIcon } from '../../icons';
  */
 const UpdateNotification = ( { extensions } ) => {
 	const extensionsWithUpdate = extensions.filter(
-		( extension ) => extension.has_update
+		( extension ) => extension.canInstall
 	);
 
 	const updatesCount = extensionsWithUpdate.length;

--- a/assets/extensions/update-notification/index.js
+++ b/assets/extensions/update-notification/index.js
@@ -19,7 +19,7 @@ import { UpdateIcon } from '../../icons';
  */
 const UpdateNotification = ( { extensions } ) => {
 	const extensionsWithUpdate = extensions.filter(
-		( extension ) => extension.canInstall
+		( extension ) => extension.canUpdate
 	);
 
 	const updatesCount = extensionsWithUpdate.length;

--- a/assets/extensions/update-notification/multiple.js
+++ b/assets/extensions/update-notification/multiple.js
@@ -7,45 +7,44 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import ExtensionActions from '../extension-actions';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { EXTENSIONS_STORE } from '../store';
 import { UpdateIcon } from '../../icons';
 
 /**
  * Multiple update notification.
  *
- * @param {Object}   props            Component props.
- * @param {Array}    props.extensions Extensions with update.
- * @param {Function} props.onUpdate   Callback to call when update is clicked.
+ * @param {Object} props            Component props.
+ * @param {Array}  props.extensions Extensions with update.
  */
-const Multiple = ( { extensions, onUpdate } ) => {
-	const componentInProgress = useSelect( ( select ) =>
-		select( EXTENSIONS_STORE ).getComponentInProgress()
-	);
+const Multiple = ( { extensions } ) => {
 	const { updateExtensions } = useDispatch( EXTENSIONS_STORE );
+
+	const inProgress = extensions.some(
+		( extension ) => 'in-progress' === extension.status
+	);
+
+	const children = inProgress ? (
+		<>
+			<UpdateIcon
+				width="20"
+				height="20"
+				className="sensei-extensions__rotating-icon sensei-extensions__extension-actions__button-icon"
+			/>
+			{ __( 'Updating…', 'sensei-lms' ) }
+		</>
+	) : (
+		__( 'Update all', 'sensei-lms' )
+	);
 
 	const action = {
 		key: 'update-button',
-		children: __( 'Update all', 'sensei-lms' ),
-		disabled: componentInProgress !== '',
+		children,
+		disabled: inProgress,
 		onClick: () => {
-			onUpdate();
-			updateExtensions( extensions, 'multiple-extension-notification' );
+			updateExtensions( extensions );
 		},
 	};
-
-	if ( componentInProgress === 'multiple-extension-notification' ) {
-		action.children = (
-			<>
-				<UpdateIcon
-					width="20"
-					height="20"
-					className="sensei-extensions__rotating-icon sensei-extensions__extension-actions__button-icon"
-				/>
-				{ __( 'Updating…', 'sensei-lms' ) }
-			</>
-		);
-	}
 
 	return (
 		<>

--- a/assets/extensions/update-notification/multiple.js
+++ b/assets/extensions/update-notification/multiple.js
@@ -37,14 +37,16 @@ const Multiple = ( { extensions } ) => {
 		__( 'Update all', 'sensei-lms' )
 	);
 
-	const action = {
-		key: 'update-button',
-		children,
-		disabled: inProgress,
-		onClick: () => {
-			updateExtensions( extensions );
+	const actions = [
+		{
+			key: 'update-button',
+			children,
+			disabled: inProgress,
+			onClick: () => {
+				updateExtensions( extensions );
+			},
 		},
-	};
+	];
 
 	return (
 		<>
@@ -71,7 +73,7 @@ const Multiple = ( { extensions } ) => {
 				) ) }
 			</ul>
 
-			<ExtensionActions actions={ [ action ] } />
+			<ExtensionActions actions={ actions } />
 		</>
 	);
 };

--- a/assets/extensions/update-notification/multiple.js
+++ b/assets/extensions/update-notification/multiple.js
@@ -8,7 +8,7 @@ import { __, sprintf } from '@wordpress/i18n';
  */
 import ExtensionActions from '../extension-actions';
 import { useDispatch } from '@wordpress/data';
-import { EXTENSIONS_STORE } from '../store';
+import { EXTENSIONS_STORE, isLoadingStatus } from '../store';
 import { UpdateIcon } from '../../icons';
 
 /**
@@ -20,8 +20,8 @@ import { UpdateIcon } from '../../icons';
 const Multiple = ( { extensions } ) => {
 	const { updateExtensions } = useDispatch( EXTENSIONS_STORE );
 
-	const inProgress = extensions.some(
-		( extension ) => 'in-progress' === extension.status
+	const inProgress = extensions.some( ( extension ) =>
+		isLoadingStatus( extension.status )
 	);
 
 	const children = inProgress ? (

--- a/assets/extensions/update-notification/multiple.js
+++ b/assets/extensions/update-notification/multiple.js
@@ -14,10 +14,11 @@ import { UpdateIcon } from '../../icons';
 /**
  * Multiple update notification.
  *
- * @param {Object} props            Component props.
- * @param {Array}  props.extensions Extensions with update.
+ * @param {Object}   props            Component props.
+ * @param {Array}    props.extensions Extensions with update.
+ * @param {Function} props.onUpdate   Callback to call when update is clicked.
  */
-const Multiple = ( { extensions } ) => {
+const Multiple = ( { extensions, onUpdate } ) => {
 	const componentInProgress = useSelect( ( select ) =>
 		select( EXTENSIONS_STORE ).getComponentInProgress()
 	);
@@ -28,6 +29,7 @@ const Multiple = ( { extensions } ) => {
 		children: __( 'Update all', 'sensei-lms' ),
 		disabled: componentInProgress !== '',
 		onClick: () => {
+			onUpdate();
 			updateExtensions( extensions, 'multiple-extension-notification' );
 		},
 	};

--- a/assets/extensions/update-notification/multiple.js
+++ b/assets/extensions/update-notification/multiple.js
@@ -26,7 +26,6 @@ const Multiple = ( { extensions } ) => {
 
 	let actionProps = {
 		key: 'update-button',
-		disabled: inProgress,
 		onClick: () => {
 			updateExtensions( extensions );
 		},
@@ -37,6 +36,7 @@ const Multiple = ( { extensions } ) => {
 			children: __( 'Updating…', 'sensei-lms' ),
 			className: 'sensei-extensions__rotating-icon',
 			icon: updateIcon,
+			disabled: true,
 			...actionProps,
 		};
 	} else {

--- a/assets/extensions/update-notification/multiple.js
+++ b/assets/extensions/update-notification/multiple.js
@@ -7,6 +7,9 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import ExtensionActions from '../extension-actions';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { EXTENSIONS_STORE } from '../store';
+import { UpdateIcon } from '../../icons';
 
 /**
  * Multiple update notification.
@@ -14,44 +17,62 @@ import ExtensionActions from '../extension-actions';
  * @param {Object} props            Component props.
  * @param {Array}  props.extensions Extensions with update.
  */
-const Multiple = ( { extensions } ) => (
-	<>
-		<ul className="sensei-extensions__update-notification__list">
-			{ extensions.map( ( extension ) => (
-				<li
-					key={ extension.product_slug }
-					className="sensei-extensions__update-notification__list__item"
-				>
-					{ extension.title }{ ' ' }
-					<a
-						href={ extension.link }
-						className="sensei-extensions__update-notification__version-link"
-						target="_blank"
-						rel="noreferrer external"
-					>
-						{ sprintf(
-							// translators: placeholder is the version number.
-							__( 'version %s', 'sensei-lms' ),
-							extension.version
-						) }
-					</a>
-				</li>
-			) ) }
-		</ul>
+const Multiple = ( { extensions } ) => {
+	const componentInProgress = useSelect( ( select ) =>
+		select( EXTENSIONS_STORE ).getComponentInProgress()
+	);
+	const { updateExtensions } = useDispatch( EXTENSIONS_STORE );
 
-		<ExtensionActions
-			actions={ [
-				{
-					key: 'update-button',
-					children: __( 'Update all', 'sensei-lms' ),
-					onClick: () => {
-						// eslint-disable-next-line no-console
-						console.log( 'TODO: Update all' );
-					},
-				},
-			] }
-		/>
-	</>
-);
+	const action = {
+		key: 'update-button',
+		children: __( 'Update all', 'sensei-lms' ),
+		disabled: componentInProgress !== '',
+		onClick: () => {
+			updateExtensions( extensions, 'multiple-extension-notification' );
+		},
+	};
+
+	if ( componentInProgress === 'multiple-extension-notification' ) {
+		action.children = (
+			<>
+				<UpdateIcon
+					width="20"
+					height="20"
+					className="sensei-extensions__rotating-icon sensei-extensions__extension-actions__button-icon"
+				/>
+				{ __( 'Updating…', 'sensei-lms' ) }
+			</>
+		);
+	}
+
+	return (
+		<>
+			<ul className="sensei-extensions__update-notification__list">
+				{ extensions.map( ( extension ) => (
+					<li
+						key={ extension.product_slug }
+						className="sensei-extensions__update-notification__list__item"
+					>
+						{ extension.title }{ ' ' }
+						<a
+							href={ extension.link }
+							className="sensei-extensions__update-notification__version-link"
+							target="_blank"
+							rel="noreferrer external"
+						>
+							{ sprintf(
+								// translators: placeholder is the version number.
+								__( 'version %s', 'sensei-lms' ),
+								extension.version
+							) }
+						</a>
+					</li>
+				) ) }
+			</ul>
+
+			<ExtensionActions actions={ [ action ] } />
+		</>
+	);
+};
 
 export default Multiple;

--- a/assets/extensions/update-notification/multiple.js
+++ b/assets/extensions/update-notification/multiple.js
@@ -24,7 +24,7 @@ const Multiple = ( { extensions } ) => {
 		isLoadingStatus( extension.status )
 	);
 
-	const actionProps = {
+	let actionProps = {
 		key: 'update-button',
 		disabled: inProgress,
 		onClick: () => {
@@ -33,11 +33,17 @@ const Multiple = ( { extensions } ) => {
 	};
 
 	if ( inProgress ) {
-		actionProps.children = __( 'Updating…', 'sensei-lms' );
-		actionProps.className = 'sensei-extensions__rotating-icon';
-		actionProps.icon = updateIcon;
+		actionProps = {
+			children: __( 'Updating…', 'sensei-lms' ),
+			className: 'sensei-extensions__rotating-icon',
+			icon: updateIcon,
+			...actionProps,
+		};
 	} else {
-		actionProps.children = __( 'Update all', 'sensei-lms' );
+		actionProps = {
+			children: __( 'Update all', 'sensei-lms' ),
+			...actionProps,
+		};
 	}
 
 	const actions = [ actionProps ];

--- a/assets/extensions/update-notification/multiple.js
+++ b/assets/extensions/update-notification/multiple.js
@@ -9,7 +9,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import ExtensionActions from '../extension-actions';
 import { useDispatch } from '@wordpress/data';
 import { EXTENSIONS_STORE, isLoadingStatus } from '../store';
-import { UpdateIcon } from '../../icons';
+import updateIcon from '../../icons/update-icon';
 
 /**
  * Multiple update notification.
@@ -24,29 +24,23 @@ const Multiple = ( { extensions } ) => {
 		isLoadingStatus( extension.status )
 	);
 
-	const children = inProgress ? (
-		<>
-			<UpdateIcon
-				width="20"
-				height="20"
-				className="sensei-extensions__rotating-icon sensei-extensions__extension-actions__button-icon"
-			/>
-			{ __( 'Updating…', 'sensei-lms' ) }
-		</>
-	) : (
-		__( 'Update all', 'sensei-lms' )
-	);
-
-	const actions = [
-		{
-			key: 'update-button',
-			children,
-			disabled: inProgress,
-			onClick: () => {
-				updateExtensions( extensions );
-			},
+	const actionProps = {
+		key: 'update-button',
+		disabled: inProgress,
+		onClick: () => {
+			updateExtensions( extensions );
 		},
-	];
+	};
+
+	if ( inProgress ) {
+		actionProps.children = __( 'Updating…', 'sensei-lms' );
+		actionProps.className = 'sensei-extensions__rotating-icon';
+		actionProps.icon = updateIcon;
+	} else {
+		actionProps.children = __( 'Update all', 'sensei-lms' );
+	}
+
+	const actions = [ actionProps ];
 
 	return (
 		<>

--- a/assets/extensions/update-notification/single.js
+++ b/assets/extensions/update-notification/single.js
@@ -2,6 +2,11 @@
  * Internal dependencies
  */
 import ExtensionActions, { getExtensionActions } from '../extension-actions';
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { EXTENSIONS_STORE } from '../store';
 
 /**
  * Single update notification.
@@ -9,16 +14,27 @@ import ExtensionActions, { getExtensionActions } from '../extension-actions';
  * @param {Object} props           Component props.
  * @param {Object} props.extension Extension with update.
  */
-const Single = ( { extension } ) => (
-	<>
-		<h3 className="sensei-extensions__update-notification__title">
-			{ extension.title }
-		</h3>
-		<p className="sensei-extensions__update-notification__description">
-			{ extension.excerpt }
-		</p>
-		<ExtensionActions actions={ getExtensionActions( extension ) } />
-	</>
-);
+const Single = ( { extension } ) => {
+	const componentInProgress = useSelect( ( select ) =>
+		select( EXTENSIONS_STORE ).getComponentInProgress()
+	);
+
+	return (
+		<>
+			<h3 className="sensei-extensions__update-notification__title">
+				{ extension.title }
+			</h3>
+			<p className="sensei-extensions__update-notification__description">
+				{ extension.excerpt }
+			</p>
+			<ExtensionActions
+				actions={ getExtensionActions(
+					extension,
+					componentInProgress
+				) }
+			/>
+		</>
+	);
+};
 
 export default Single;

--- a/assets/extensions/update-notification/single.js
+++ b/assets/extensions/update-notification/single.js
@@ -1,23 +1,69 @@
 /**
  * Internal dependencies
  */
-import ExtensionActions, { getExtensionActions } from '../extension-actions';
+import ExtensionActions from '../extension-actions';
 /**
  * WordPress dependencies
  */
-import { useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { EXTENSIONS_STORE } from '../store';
+import { UpdateIcon } from '../../icons';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Single update notification.
  *
- * @param {Object} props           Component props.
- * @param {Object} props.extension Extension with update.
+ * @param {Object}   props           Component props.
+ * @param {Object}   props.extension Extension with update.
+ * @param {Function} props.onUpdate  Callback to call when update is clicked.
  */
-const Single = ( { extension } ) => {
+const Single = ( { extension, onUpdate } ) => {
 	const componentInProgress = useSelect( ( select ) =>
 		select( EXTENSIONS_STORE ).getComponentInProgress()
 	);
+	const { updateExtensions } = useDispatch( EXTENSIONS_STORE );
+
+	let actions = [
+		{
+			key: 'update-button',
+			children: __( 'Update', 'sensei-lms' ),
+			disabled: componentInProgress !== '',
+			onClick: () => {
+				onUpdate();
+				updateExtensions(
+					[ extension ],
+					'single-extension-notification'
+				);
+			},
+		},
+	];
+
+	if ( componentInProgress === 'single-extension-notification' ) {
+		actions[ 0 ].children = (
+			<>
+				<UpdateIcon
+					width="20"
+					height="20"
+					className="sensei-extensions__rotating-icon sensei-extensions__extension-actions__button-icon"
+				/>
+				{ __( 'Updating…', 'sensei-lms' ) }
+			</>
+		);
+	}
+
+	if ( extension.link ) {
+		actions = [
+			...actions,
+			{
+				key: 'more-details',
+				href: extension.link,
+				className: 'sensei-extensions__extension-actions__details-link',
+				target: '_blank',
+				rel: 'noreferrer external',
+				children: __( 'More details', 'sensei-lms' ),
+			},
+		];
+	}
 
 	return (
 		<>
@@ -27,12 +73,7 @@ const Single = ( { extension } ) => {
 			<p className="sensei-extensions__update-notification__description">
 				{ extension.excerpt }
 			</p>
-			<ExtensionActions
-				actions={ getExtensionActions(
-					extension,
-					componentInProgress
-				) }
-			/>
+			<ExtensionActions actions={ actions } />
 		</>
 	);
 };

--- a/assets/extensions/update-notification/single.js
+++ b/assets/extensions/update-notification/single.js
@@ -1,70 +1,15 @@
 /**
  * Internal dependencies
  */
-import ExtensionActions from '../extension-actions';
-/**
- * WordPress dependencies
- */
-import { useDispatch, useSelect } from '@wordpress/data';
-import { EXTENSIONS_STORE } from '../store';
-import { UpdateIcon } from '../../icons';
-import { __ } from '@wordpress/i18n';
+import ExtensionActions, { getExtensionActions } from '../extension-actions';
 
 /**
  * Single update notification.
  *
- * @param {Object}   props           Component props.
- * @param {Object}   props.extension Extension with update.
- * @param {Function} props.onUpdate  Callback to call when update is clicked.
+ * @param {Object} props           Component props.
+ * @param {Object} props.extension Extension with update.
  */
-const Single = ( { extension, onUpdate } ) => {
-	const componentInProgress = useSelect( ( select ) =>
-		select( EXTENSIONS_STORE ).getComponentInProgress()
-	);
-	const { updateExtensions } = useDispatch( EXTENSIONS_STORE );
-
-	let actions = [
-		{
-			key: 'update-button',
-			children: __( 'Update', 'sensei-lms' ),
-			disabled: componentInProgress !== '',
-			onClick: () => {
-				onUpdate();
-				updateExtensions(
-					[ extension ],
-					'single-extension-notification'
-				);
-			},
-		},
-	];
-
-	if ( componentInProgress === 'single-extension-notification' ) {
-		actions[ 0 ].children = (
-			<>
-				<UpdateIcon
-					width="20"
-					height="20"
-					className="sensei-extensions__rotating-icon sensei-extensions__extension-actions__button-icon"
-				/>
-				{ __( 'Updating…', 'sensei-lms' ) }
-			</>
-		);
-	}
-
-	if ( extension.link ) {
-		actions = [
-			...actions,
-			{
-				key: 'more-details',
-				href: extension.link,
-				className: 'sensei-extensions__extension-actions__details-link',
-				target: '_blank',
-				rel: 'noreferrer external',
-				children: __( 'More details', 'sensei-lms' ),
-			},
-		];
-	}
-
+const Single = ( { extension } ) => {
 	return (
 		<>
 			<h3 className="sensei-extensions__update-notification__title">
@@ -73,7 +18,7 @@ const Single = ( { extension, onUpdate } ) => {
 			<p className="sensei-extensions__update-notification__description">
 				{ extension.excerpt }
 			</p>
-			<ExtensionActions actions={ actions } />
+			<ExtensionActions actions={ getExtensionActions( extension ) } />
 		</>
 	);
 };

--- a/assets/extensions/update-notification/single.js
+++ b/assets/extensions/update-notification/single.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import ExtensionActions, { getExtensionActions } from '../extension-actions';
+import ExtensionActions, { useExtensionActions } from '../extension-actions';
 
 /**
  * Single update notification.
@@ -10,6 +10,8 @@ import ExtensionActions, { getExtensionActions } from '../extension-actions';
  * @param {Object} props.extension Extension with update.
  */
 const Single = ( { extension } ) => {
+	const actions = useExtensionActions( extension );
+
 	return (
 		<>
 			<h3 className="sensei-extensions__update-notification__title">
@@ -18,7 +20,7 @@ const Single = ( { extension } ) => {
 			<p className="sensei-extensions__update-notification__description">
 				{ extension.excerpt }
 			</p>
-			<ExtensionActions actions={ getExtensionActions( extension ) } />
+			<ExtensionActions actions={ actions } />
 		</>
 	);
 };

--- a/assets/icons/index.js
+++ b/assets/icons/index.js
@@ -4,4 +4,3 @@ export { LessonIcon } from './lesson-icon';
 export { ModuleIcon } from './module-icon';
 export { ProgressIcon } from './progress-icon';
 export { SenseiIcon } from './sensei-icon';
-export { UpdateIcon } from './update-icon';

--- a/assets/icons/update-icon.js
+++ b/assets/icons/update-icon.js
@@ -3,8 +3,8 @@
  */
 import { Path, SVG } from '@wordpress/components';
 
-export const UpdateIcon = ( props ) => (
-	<SVG { ...props } xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+const updateIcon = (
+	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
 		<Path
 			fillRule="evenodd"
 			clipRule="evenodd"
@@ -19,3 +19,5 @@ export const UpdateIcon = ( props ) => (
 		/>
 	</SVG>
 );
+
+export default updateIcon;

--- a/assets/icons/wordpress-icons.js
+++ b/assets/icons/wordpress-icons.js
@@ -9,40 +9,31 @@ import { Path, SVG } from '@wordpress/components';
  */
 export const chevronRight = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path fill="currentColor" d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z" />
+		<Path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z" />
 	</SVG>
 );
 
 export const chevronUp = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path
-			fill="currentColor"
-			d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z"
-		/>
+		<Path d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z" />
 	</SVG>
 );
 
 export const checked = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path fill="currentColor" d="M9 18.6L3.5 13l1-1L9 16.4l9.5-9.9 1 1z" />
+		<Path d="M9 18.6L3.5 13l1-1L9 16.4l9.5-9.9 1 1z" />
 	</SVG>
 );
 
 export const button = (
 	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-		<Path
-			fill="currentColor"
-			d="M19 6.5H5c-1.1 0-2 .9-2 2v7c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7c0-1.1-.9-2-2-2zm.5 9c0 .3-.2.5-.5.5H5c-.3 0-.5-.2-.5-.5v-7c0-.3.2-.5.5-.5h14c.3 0 .5.2.5.5v7zM8 13h8v-1.5H8V13z"
-		/>
+		<Path d="M19 6.5H5c-1.1 0-2 .9-2 2v7c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7c0-1.1-.9-2-2-2zm.5 9c0 .3-.2.5-.5.5H5c-.3 0-.5-.2-.5-.5v-7c0-.3.2-.5.5-.5h14c.3 0 .5.2.5.5v7zM8 13h8v-1.5H8V13z" />
 	</SVG>
 );
 
 export const alert = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path fill="currentColor" d="M13 7h-2v6h2V7zM13 15h-2v2h2v-2z" />
-		<Path
-			fill="currentColor"
-			d="M12 4.75a7.25 7.25 0 100 14.5 7.25 7.25 0 000-14.5zM3.25 12a8.75 8.75 0 1117.5 0 8.75 8.75 0 01-17.5 0z"
-		/>
+		<Path d="M13 7h-2v6h2V7zM13 15h-2v2h2v-2z" />
+		<Path d="M12 4.75a7.25 7.25 0 100 14.5 7.25 7.25 0 000-14.5zM3.25 12a8.75 8.75 0 1117.5 0 8.75 8.75 0 01-17.5 0z" />
 	</SVG>
 );

--- a/assets/icons/wordpress-icons.js
+++ b/assets/icons/wordpress-icons.js
@@ -9,31 +9,40 @@ import { Path, SVG } from '@wordpress/components';
  */
 export const chevronRight = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z" />
+		<Path fill="currentColor" d="M10.6 6L9.4 7l4.6 5-4.6 5 1.2 1 5.4-6z" />
 	</SVG>
 );
 
 export const chevronUp = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z" />
+		<Path
+			fill="currentColor"
+			d="M6.5 12.4L12 8l5.5 4.4-.9 1.2L12 10l-4.5 3.6-1-1.2z"
+		/>
 	</SVG>
 );
 
 export const checked = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M9 18.6L3.5 13l1-1L9 16.4l9.5-9.9 1 1z" />
+		<Path fill="currentColor" d="M9 18.6L3.5 13l1-1L9 16.4l9.5-9.9 1 1z" />
 	</SVG>
 );
 
 export const button = (
 	<SVG viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-		<Path d="M19 6.5H5c-1.1 0-2 .9-2 2v7c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7c0-1.1-.9-2-2-2zm.5 9c0 .3-.2.5-.5.5H5c-.3 0-.5-.2-.5-.5v-7c0-.3.2-.5.5-.5h14c.3 0 .5.2.5.5v7zM8 13h8v-1.5H8V13z" />
+		<Path
+			fill="currentColor"
+			d="M19 6.5H5c-1.1 0-2 .9-2 2v7c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7c0-1.1-.9-2-2-2zm.5 9c0 .3-.2.5-.5.5H5c-.3 0-.5-.2-.5-.5v-7c0-.3.2-.5.5-.5h14c.3 0 .5.2.5.5v7zM8 13h8v-1.5H8V13z"
+		/>
 	</SVG>
 );
 
 export const alert = (
 	<SVG xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-		<Path d="M13 7h-2v6h2V7zM13 15h-2v2h2v-2z" />
-		<Path d="M12 4.75a7.25 7.25 0 100 14.5 7.25 7.25 0 000-14.5zM3.25 12a8.75 8.75 0 1117.5 0 8.75 8.75 0 01-17.5 0z" />
+		<Path fill="currentColor" d="M13 7h-2v6h2V7zM13 15h-2v2h2v-2z" />
+		<Path
+			fill="currentColor"
+			d="M12 4.75a7.25 7.25 0 100 14.5 7.25 7.25 0 000-14.5zM3.25 12a8.75 8.75 0 1117.5 0 8.75 8.75 0 01-17.5 0z"
+		/>
 	</SVG>
 );

--- a/assets/shared/styles/wp-components.scss
+++ b/assets/shared/styles/wp-components.scss
@@ -19,7 +19,7 @@ body.sensei-color {
 			color: #000;
 		}
 		&:disabled {
-			background-color: rgba(70, 200, 173, 0.7);
+			background-color: rgba($primary, 0.7);
 		}
 		&.is-busy {
 			background-size: 100px 100%;

--- a/assets/shared/styles/wp-components.scss
+++ b/assets/shared/styles/wp-components.scss
@@ -10,8 +10,24 @@
 
 body.sensei-color {
 
-	.components-button.is-primary.is-busy {
-		background-size: 100px 100%;
+	.components-button.is-primary {
+		&,
+		&:hover,
+		&:active,
+		&:focus,
+		&:disabled {
+			color: #000;
+		}
+		&:disabled {
+			background-color: rgba(70, 200, 173, 0.7);
+		}
+		&.is-busy {
+			background-size: 100px 100%;
+		}
+	}
+
+	.components-button {
+		justify-content: center;
 	}
 
 	a, .button-link, .components-button.is-link {

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -52,7 +52,7 @@ final class Sensei_Extensions {
 		$screen = get_current_screen();
 		if ( in_array( $screen->id, [ 'sensei-lms_page_sensei-extensions' ], true ) ) {
 			Sensei()->assets->enqueue( 'sensei-extensions', 'extensions/index.js', [], true );
-			Sensei()->assets->enqueue( 'sensei-extensions-style', 'extensions/extensions.css' );
+			Sensei()->assets->enqueue( 'sensei-extensions-style', 'extensions/extensions.css', [ 'sensei-wp-components' ] );
 		}
 	}
 

--- a/includes/rest-api/class-sensei-rest-api-extensions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-extensions-controller.php
@@ -300,21 +300,22 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	private function create_extensions_response( array $plugins, string $response_key = 'extensions' ): WP_REST_Response {
-		$mapped_plugins = array_map(
-			function ( $plugin ) {
-				$plugin->price = html_entity_decode( $plugin->price );
-				$plugin->image = $plugin->image_large ?? 'https://senseilms.com/wp-content/uploads/2021/04/' . $plugin->product_slug . '.png';
-				return $plugin;
-			},
-			$plugins
-		);
-
 		$wccom_connected = false;
 
 		if ( class_exists( 'WC_Helper_Options' ) ) {
 			$auth            = WC_Helper_Options::get( 'auth' );
 			$wccom_connected = ! empty( $auth['access_token'] );
 		}
+
+		$mapped_plugins = array_map(
+			function ( $plugin ) use ( $wccom_connected ) {
+				$plugin->price      = html_entity_decode( $plugin->price );
+				$plugin->image      = $plugin->image_large ?? 'https://senseilms.com/wp-content/uploads/2021/04/' . $plugin->product_slug . '.png';
+				$plugin->can_update = ! $plugin->wccom_product_id || ( $wccom_connected && ! $plugin->wccom_expired );
+				return $plugin;
+			},
+			$plugins
+		);
 
 		$response_json                  = [ 'wccom_connected' => $wccom_connected ];
 		$response_json[ $response_key ] = array_values( $mapped_plugins );

--- a/includes/rest-api/class-sensei-rest-api-extensions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-extensions-controller.php
@@ -230,7 +230,14 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 			return $error;
 		}
 
-		return $this->create_extensions_response( Sensei_Extensions::instance()->get_extensions( 'plugin' ) );
+		$updated_plugins = array_filter(
+			Sensei_Extensions::instance()->get_extensions( 'plugin' ),
+			function( $plugin ) use ( $plugins_arg ) {
+				return in_array( $plugin->product_slug, $plugins_arg, true );
+			}
+		);
+
+		return $this->create_extensions_response( $updated_plugins, 'completed' );
 	}
 
 	/**
@@ -285,11 +292,12 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 	/**
 	 * Generate a REST response from an array of plugins.
 	 *
-	 * @param array $plugins The plugins.
+	 * @param array  $plugins      The plugins.
+	 * @param string $response_key Response key for the extensions array.
 	 *
 	 * @return WP_REST_Response
 	 */
-	private function create_extensions_response( array $plugins ): WP_REST_Response {
+	private function create_extensions_response( array $plugins, string $response_key = 'extensions' ): WP_REST_Response {
 		$mapped_plugins = array_map(
 			function ( $plugin ) {
 				$plugin->price = html_entity_decode( $plugin->price );
@@ -306,13 +314,11 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 			$wccom_connected = ! empty( $auth['access_token'] );
 		}
 
+		$response_json                  = [ 'wccom_connected' => $wccom_connected ];
+		$response_json[ $response_key ] = array_values( $mapped_plugins );
+
 		$response = new WP_REST_Response();
-		$response->set_data(
-			[
-				'extensions'      => array_values( $mapped_plugins ),
-				'wccom_connected' => $wccom_connected,
-			]
-		);
+		$response->set_data( $response_json );
 
 		return $response;
 	}

--- a/includes/rest-api/class-sensei-rest-api-extensions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-extensions-controller.php
@@ -220,6 +220,8 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 
 		WP_Filesystem();
 
+		wp_update_plugins();
+
 		$skin     = new WP_Ajax_Upgrader_Skin();
 		$upgrader = new Plugin_Upgrader( $skin );
 		$result   = $upgrader->bulk_upgrade( wp_list_pluck( $plugins_to_update, 'plugin_file' ) );

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -10,11 +10,11 @@ module.exports = {
 			},
 			themes: {
 				'sensei-color': {
-					primary: '#32af7d',
-					secondary: '#32af7d',
-					toggle: '#32af7d',
-					button: '#32af7d',
-					outlines: '#32af7d',
+					primary: '#46c8ad',
+					secondary: '#46c8ad',
+					toggle: '#46c8ad',
+					button: '#46c8ad',
+					outlines: '#46c8ad',
 				},
 			},
 		} ),


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Intigrates the extensions page with the REST API.
* Only update is implemented with this PR. Install and possibly Renew will be handled by other PRs

### Testing instructions

* You can simulate a plugin being outdated by modifying the version in the main plugin file.
* When testing plugins that are hosted in WC.com, WooCommerce save the plugin information in a transient, which means that you might need to do a couple of refreshes for the update to work. Otherwise you will get an error saying that the plugin is already at the latest version.
* After modifying the plugin files, navigate to the extension page and either click the Update button in the notification, or in one of the plugins.
* Observe that the plugins are updated.