### PR TITLE
Handle connecting to WooCommerce.com from Extensions page

### DIFF
--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -13,6 +13,7 @@ import { useSenseiColorTheme } from '../react-hooks/use-sensei-color-theme';
 import Header from './header';
 import Tabs from './tabs';
 import UpdateNotification from './update-notification';
+import WCCOMConnection from './update-notification/wccom-connection';
 import QueryStringRouter, { Route } from '../shared/query-string-router';
 import AllExtensions from './all-extensions';
 import FilteredExtensions from './filtered-extensions';
@@ -22,10 +23,12 @@ import { Grid, Col } from './grid';
 const Main = () => {
 	useSenseiColorTheme();
 
-	const { extensions, layout, error } = useSelect( ( select ) => {
+	const { extensions, connected, layout, error } = useSelect( ( select ) => {
 		const store = select( EXTENSIONS_STORE );
+
 		return {
 			extensions: store.getExtensions(),
+			connected: store.getConnectionStatus(),
 			layout: store.getLayout(),
 			error: store.getError(),
 		};
@@ -44,6 +47,12 @@ const Main = () => {
 	);
 	const installedExtensions = extensions.filter(
 		( extension ) => extension.is_installed
+	);
+	const wooExtensions = extensions.filter(
+		( extension ) => extension.wccom_product_id
+	);
+	const nonWooExtensions = extensions.filter(
+		( extension ) => ! extension.wccom_product_id
 	);
 
 	const tabs = [
@@ -81,7 +90,13 @@ const Main = () => {
 						) }
 					</Col>
 
-					<UpdateNotification extensions={ extensions } />
+					{ ! connected && (
+						<WCCOMConnection extensions={ wooExtensions } />
+					) }
+
+					<UpdateNotification
+						extensions={ connected ? extensions : nonWooExtensions }
+					/>
 					{ tabs.map( ( tab ) => (
 						<Route key={ tab.id } route={ tab.id }>
 							{ tab.content }

--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -96,7 +96,7 @@ const actions = {
 		return {
 			type: 'SET_CONNECTION_STATUS',
 			connected,
-		}
+		};
 	},
 
 	/**

--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -42,6 +42,7 @@ const DEFAULT_STATE = {
 	 * or mapped based in a key list).
 	 */
 	entities: { extensions: {} },
+	connected: false,
 	layout: [],
 	queue: [],
 	wccom: {},
@@ -85,6 +86,17 @@ const actions = {
 			entities,
 		};
 	},
+
+	/**
+	 * Sets the WC.com connection status.
+	 *
+	 * @param {Object} connected Whether the site is connected to WC.com.
+	 */
+	setConnectionStatus( connected ) {
+		return {
+			type: 'SET_CONNECTION_STATUS',
+			connected,
+		}
 
 	/**
 	 * Install extensions.
@@ -281,6 +293,7 @@ const selectors = {
 			.getExtensions( args )
 			.filter( ( extension ) => status === extension.status ),
 	getEntities: ( { entities }, entity ) => entities[ entity ],
+	getConnectionStatus: ( { connected } ) => connected,
 	getLayout: ( { layout } ) => layout,
 	getNextProcess: ( { queue } ) => queue[ 0 ] || null,
 	getWccomData: ( { wccom } ) => wccom,
@@ -307,6 +320,7 @@ const resolvers = {
 		yield actions.setExtensions(
 			response.extensions.map( ( extension ) => extension.product_slug )
 		);
+		yield actions.setConnectionStatus( response.wccom_connected );
 	},
 };
 
@@ -335,6 +349,10 @@ const reducer = {
 				{}
 			),
 		},
+	} ),
+	SET_CONNECTION_STATUS: ( { connected }, state ) => ( {
+		...state,
+		connected,
 	} ),
 	SET_LAYOUT: ( { layout }, state ) => ( {
 		...state,

--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -97,6 +97,7 @@ const actions = {
 			type: 'SET_CONNECTION_STATUS',
 			connected,
 		}
+	},
 
 	/**
 	 * Install extensions.

--- a/assets/extensions/update-notification/index.js
+++ b/assets/extensions/update-notification/index.js
@@ -9,7 +9,7 @@ import { Icon } from '@wordpress/components';
  */
 import Single from './single';
 import Multiple from './multiple';
-import UpdateAvailableLabel from './update-available-label';
+import UpdateAvailable from './update-available';
 import { Col } from '../grid';
 import updateIcon from '../../icons/update-icon';
 import ExtensionActions from '../extension-actions';
@@ -69,10 +69,8 @@ const UpdateNotification = ( { extensions } ) => {
 				role="alert"
 				className="sensei-extensions__update-notification"
 			>
-				<small className="sensei-extensions__update-badge">
-					<Icon icon={ updateIcon } />
-					<UpdateAvailableLabel updatesCount={ updatesCount } />
-				</small>
+				<UpdateAvailable updatesCount={ updatesCount } />
+
 				{ 1 === updatesCount ? (
 					<Single extension={ extensionsWithUpdate[ 0 ] } />
 				) : (

--- a/assets/extensions/update-notification/index.js
+++ b/assets/extensions/update-notification/index.js
@@ -1,8 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { __, _n, sprintf } from '@wordpress/i18n';
-import { Icon } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -12,7 +11,6 @@ import Multiple from './multiple';
 import UpdateAvailable from './update-available';
 import { Col } from '../grid';
 import updateIcon from '../../icons/update-icon';
-import ExtensionActions from '../extension-actions';
 import { useDispatch } from '@wordpress/data';
 import { EXTENSIONS_STORE, isLoadingStatus } from '../store';
 
@@ -28,12 +26,11 @@ const UpdateNotification = ( { extensions } ) => {
 	);
 
 	const updatesCount = extensionsWithUpdate.length;
+	const { updateExtensions } = useDispatch( EXTENSIONS_STORE );
 
 	if ( 0 === updatesCount ) {
 		return null;
 	}
-
-	const { updateExtensions } = useDispatch( EXTENSIONS_STORE );
 
 	const inProgress = extensionsWithUpdate.some( ( extension ) =>
 		isLoadingStatus( extension.status )

--- a/assets/extensions/update-notification/multiple.js
+++ b/assets/extensions/update-notification/multiple.js
@@ -4,82 +4,41 @@
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
- * Internal dependencies
- */
-import ExtensionActions from '../extension-actions';
-import { useDispatch } from '@wordpress/data';
-import { EXTENSIONS_STORE, isLoadingStatus } from '../store';
-import updateIcon from '../../icons/update-icon';
-
-/**
  * Multiple update notification.
  *
  * @param {Object} props            Component props.
  * @param {Array}  props.extensions Extensions with update.
+ * @param {Array}  props.actions    Actions that can be taken.
  */
-const Multiple = ( { extensions } ) => {
-	const { updateExtensions } = useDispatch( EXTENSIONS_STORE );
+const Multiple = ( { extensions, actions } ) => (
+	<>
+		<ul className="sensei-extensions__update-notification__list">
+			{ extensions.map( ( extension ) => (
+				<li
+					key={ extension.product_slug }
+					className="sensei-extensions__update-notification__list__item"
+				>
+					{ extension.title }{ ' ' }
+					{ extension.changelog_url && (
+						<a
+							href={ extension.changelog_url }
+							className="sensei-extensions__update-notification__version-link"
+							target="_blank"
+							rel="noreferrer external"
+						>
+							{ sprintf(
+								// translators: placeholder is the version number.
+								__( 'version %s', 'sensei-lms' ),
+								extension.version
+							) }
+						</a>
+					) }
+				</li>
+			) ) }
+		</ul>
 
-	const inProgress = extensions.some( ( extension ) =>
-		isLoadingStatus( extension.status )
-	);
-
-	let actionProps = {
-		key: 'update-button',
-		onClick: () => {
-			updateExtensions(
-				extensions.map( ( extension ) => extension.product_slug )
-			);
-		},
-	};
-
-	if ( inProgress ) {
-		actionProps = {
-			children: __( 'Updating…', 'sensei-lms' ),
-			className: 'sensei-extensions__rotating-icon',
-			icon: updateIcon,
-			disabled: true,
-			...actionProps,
-		};
-	} else {
-		actionProps = {
-			children: __( 'Update all', 'sensei-lms' ),
-			...actionProps,
-		};
-	}
-
-	const actions = [ actionProps ];
-
-	return (
-		<>
-			<ul className="sensei-extensions__update-notification__list">
-				{ extensions.map( ( extension ) => (
-					<li
-						key={ extension.product_slug }
-						className="sensei-extensions__update-notification__list__item"
-					>
-						{ extension.title }{ ' ' }
-						{ extension.changelog_url && (
-							<a
-								href={ extension.changelog_url }
-								className="sensei-extensions__update-notification__version-link"
-								target="_blank"
-								rel="noreferrer external"
-							>
-								{ sprintf(
-									// translators: placeholder is the version number.
-									__( 'version %s', 'sensei-lms' ),
-									extension.version
-								) }
-							</a>
-						) }
-					</li>
-				) ) }
-			</ul>
-
-			<ExtensionActions actions={ actions } />
-		</>
-	);
-};
+		<ExtensionActions actions={ actions } />
+	</>
+);
 
 export default Multiple;

--- a/assets/extensions/update-notification/multiple.js
+++ b/assets/extensions/update-notification/multiple.js
@@ -4,6 +4,11 @@
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import ExtensionActions from '../extension-actions';
+
+/**
  * Multiple update notification.
  *
  * @param {Object} props            Component props.

--- a/assets/extensions/update-notification/update-available-label.js
+++ b/assets/extensions/update-notification/update-available-label.js
@@ -1,0 +1,29 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _n, sprintf } from '@wordpress/i18n';
+
+/**
+ * Update available label component.
+ *
+ * @param {Object} props              Component props.
+ * @param {number} props.updatesCount Number of extension updates.
+ */
+const updateAvailableLabel = ( { updatesCount } ) => (
+	<>
+		{ 1 === updatesCount
+			? __( 'Update available', 'sensei-lms' )
+			: sprintf(
+					// translators: placeholder is number of updates available.
+					_n(
+						'%d update available',
+						'%d updates available',
+						updatesCount,
+						'sensei-lms'
+					),
+					updatesCount
+			  ) }
+	</>
+);
+
+export default updateAvailableLabel;

--- a/assets/extensions/update-notification/update-available.js
+++ b/assets/extensions/update-notification/update-available.js
@@ -4,13 +4,20 @@
 import { __, _n, sprintf } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import { UpdateIcon } from '../../icons';
+
+/**
  * Update available label component.
  *
  * @param {Object} props              Component props.
  * @param {number} props.updatesCount Number of extension updates.
  */
-const updateAvailableLabel = ( { updatesCount } ) => (
-	<>
+const UpdateAvailable = ( { updatesCount } ) => (
+	<small className="sensei-extensions__update-badge">
+		<UpdateIcon />
+
 		{ 1 === updatesCount
 			? __( 'Update available', 'sensei-lms' )
 			: sprintf(
@@ -23,7 +30,7 @@ const updateAvailableLabel = ( { updatesCount } ) => (
 					),
 					updatesCount
 			  ) }
-	</>
+	</small>
 );
 
-export default updateAvailableLabel;
+export default UpdateAvailable;

--- a/assets/extensions/update-notification/update-available.js
+++ b/assets/extensions/update-notification/update-available.js
@@ -2,11 +2,12 @@
  * WordPress dependencies
  */
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
 
 /**
  * Internal dependencies
  */
-import { UpdateIcon } from '../../icons';
+import updateIcon from '../../icons/update-icon';
 
 /**
  * Update available label component.
@@ -16,7 +17,7 @@ import { UpdateIcon } from '../../icons';
  */
 const UpdateAvailable = ( { updatesCount } ) => (
 	<small className="sensei-extensions__update-badge">
-		<UpdateIcon />
+		<Icon icon={ updateIcon } />
 
 		{ 1 === updatesCount
 			? __( 'Update available', 'sensei-lms' )

--- a/assets/extensions/update-notification/wccom-connection.js
+++ b/assets/extensions/update-notification/wccom-connection.js
@@ -32,7 +32,7 @@ const WCCOMConnection = ( { extensions } ) => {
 	const actions = [
 		{
 			key: 'connect',
-			children: __( 'Connect', 'sensei-lms' ),
+			children: __( 'Connect account', 'sensei-lms' ),
 			href: window.sensei_extensions?.connectUrl,
 		},
 	];
@@ -50,7 +50,7 @@ const WCCOMConnection = ( { extensions } ) => {
 
 				<h3 className="sensei-extensions__update-notification__title">
 					{ __(
-						'Connect your site to WooCommerce.com to update.',
+						'Connect your site to your WooCommerce.com account to update.',
 						'sensei-lms'
 					) }
 				</h3>

--- a/assets/extensions/update-notification/wccom-connection.js
+++ b/assets/extensions/update-notification/wccom-connection.js
@@ -7,9 +7,8 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import Multiple from './multiple';
-import UpdateAvailableLabel from './update-available-label';
+import UpdateAvailable from './update-available';
 import { Col } from '../grid';
-import { UpdateIcon } from '../../icons';
 import ExtensionActions from '../extension-actions';
 
 /**
@@ -43,10 +42,7 @@ const WCCOMConnection = ( { extensions } ) => {
 				role="alert"
 				className="sensei-extensions__update-notification"
 			>
-				<small className="sensei-extensions__update-badge">
-					<UpdateIcon />
-					<UpdateAvailableLabel updatesCount={ updatesCount } />
-				</small>
+				<UpdateAvailable updatesCount={ updatesCount } />
 
 				<h3 className="sensei-extensions__update-notification__title">
 					{ __(

--- a/assets/extensions/update-notification/wccom-connection.js
+++ b/assets/extensions/update-notification/wccom-connection.js
@@ -1,0 +1,88 @@
+/**
+ * WordPress dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import Multiple from './multiple';
+import UpdateAvailableLabel from './update-available-label';
+import { Col } from '../grid';
+import { UpdateIcon } from '../../icons';
+import ExtensionActions from '../extension-actions';
+
+/**
+ * WooCommerce.com connection component.
+ *
+ * @param {Object} props            Component props.
+ * @param {Array}  props.extensions Extensions list.
+ */
+const WCCOMConnection = ( { extensions } ) => {
+	const extensionsWithUpdate = extensions.filter(
+		( extension ) => extension.has_update
+	);
+
+	const updatesCount = extensionsWithUpdate.length;
+
+	if ( 0 === updatesCount ) {
+		return null;
+	}
+
+	const actions = [
+		{
+			key: 'connect',
+			children: __( 'Connect', 'sensei-lms' ),
+			href: window.sensei_extensions?.connectUrl,
+		},
+	];
+
+	return (
+		<Col as="section" className="sensei-extensions__section" cols={ 12 }>
+			<div
+				role="alert"
+				className="sensei-extensions__update-notification"
+			>
+				<small className="sensei-extensions__update-badge">
+					<UpdateIcon />
+					<UpdateAvailableLabel updatesCount={ updatesCount } />
+				</small>
+
+				<h3 className="sensei-extensions__update-notification__title">
+					{ __(
+						'Connect your site to WooCommerce.com to update.',
+						'sensei-lms'
+					) }
+				</h3>
+
+				{ 1 === updatesCount ? (
+					<>
+						<div className="sensei-extensions__update-notification__description">
+							<span>{ extensionsWithUpdate[ 0 ].title } </span>
+							<a
+								href={ extensionsWithUpdate[ 0 ].link }
+								className="sensei-extensions__update-notification__version-link"
+								target="_blank"
+								rel="noreferrer external"
+							>
+								{ sprintf(
+									// translators: placeholder is the version number.
+									__( 'version %s', 'sensei-lms' ),
+									extensionsWithUpdate[ 0 ].version
+								) }
+							</a>
+						</div>
+						<ExtensionActions actions={ actions } />
+					</>
+				) : (
+					<Multiple
+						extensions={ extensionsWithUpdate }
+						actions={ actions }
+					/>
+				) }
+			</div>
+		</Col>
+	);
+};
+
+export default WCCOMConnection;

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -50,11 +50,27 @@ final class Sensei_Extensions {
 	 */
 	public function enqueue_admin_assets() {
 		$screen = get_current_screen();
+
 		if ( in_array( $screen->id, [ 'sensei-lms_page_sensei-extensions' ], true ) ) {
 			Sensei()->assets->enqueue( 'sensei-extensions', 'extensions/index.js', [], true );
 			Sensei()->assets->enqueue( 'sensei-extensions-style', 'extensions/extensions.css', [ 'sensei-wp-components' ] );
-
 			Sensei()->assets->preload_data( [ '/sensei-internal/v1/sensei-extensions?type=plugin' ] );
+
+			wp_localize_script(
+				'sensei-extensions',
+				'sensei_extensions',
+				[
+					'connectUrl' => add_query_arg(
+						array(
+							'page'              => 'wc-addons',
+							'section'           => 'helper',
+							'wc-helper-connect' => 1,
+							'wc-helper-nonce'   => wp_create_nonce( 'connect' ),
+						),
+						admin_url( 'admin.php' )
+					),
+				]
+			);
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
Display a connection notice if there are updates waiting that are delivered via WooCommerce.com, but the site has not been connected yet.

### Testing instructions
This PR was refactored in https://github.com/Automattic/sensei/pull/4215, so might be best to test against that PR.

- Disconnect your WooCommerce.com account.
- Install an old version of WooCommerce Paid Courses.
- Go to the Extensions page and ensure the following notice is displayed:

![no-connection-single](https://user-images.githubusercontent.com/1190420/116913318-51b56600-ac17-11eb-90d2-fe4aed1e4c95.jpg)
- Install an old version of Content Drip.
- Go to the Extensions page and ensure the following notice is displayed:

![no-connection-multiple](https://user-images.githubusercontent.com/1190420/116913365-642f9f80-ac17-11eb-8d65-45001e835805.jpg)
- Click the _Connect_ button and ensure you are taken through the WooCommerce connection flow.
- Once connected, revisit the Extensions page and ensure the updates are now displayed as part of the _Update all_ notice.