### PR TITLE
Add extensions request preload

### DIFF
--- a/assets/extensions/store.js
+++ b/assets/extensions/store.js
@@ -14,6 +14,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { createReducerFromActionMap } from '../shared/data/store-helpers';
+import '../shared/data/api-fetch-preloaded-once';
 
 /**
  * Extension statuses.

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -53,6 +53,8 @@ final class Sensei_Extensions {
 		if ( in_array( $screen->id, [ 'sensei-lms_page_sensei-extensions' ], true ) ) {
 			Sensei()->assets->enqueue( 'sensei-extensions', 'extensions/index.js', [], true );
 			Sensei()->assets->enqueue( 'sensei-extensions-style', 'extensions/extensions.css', [ 'sensei-wp-components' ] );
+
+			Sensei()->assets->preload_data( [ '/sensei-internal/v1/sensei-extensions?type=plugin' ] );
 		}
 	}
 

--- a/includes/rest-api/class-sensei-rest-api-extensions-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-extensions-controller.php
@@ -311,7 +311,7 @@ class Sensei_REST_API_Extensions_Controller extends WP_REST_Controller {
 			function ( $plugin ) use ( $wccom_connected ) {
 				$plugin->price      = html_entity_decode( $plugin->price );
 				$plugin->image      = $plugin->image_large ?? 'https://senseilms.com/wp-content/uploads/2021/04/' . $plugin->product_slug . '.png';
-				$plugin->can_update = ! $plugin->wccom_product_id || ( $wccom_connected && ! $plugin->wccom_expired );
+				$plugin->can_update = empty( $plugin->wccom_product_id ) || ( $wccom_connected && ! $plugin->wccom_expired );
 				return $plugin;
 			},
 			$plugins


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds the extensions preload.
* It's still fetching the `layout` endpoint, but it was unified to the same extensions request in https://github.com/Automattic/sensei/pull/4214.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Go to wp-admin > Sensei LMS > Extensions
* Check the network tab in your devtools to confirm that `/wp-json/sensei-internal/v1/sensei-extensions?type=plugin` is not requested.