### PR TITLE
Update extensions error message to be formatted

### DIFF
--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -5,6 +5,7 @@ import { Notice, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 import { EditorNotices } from '@wordpress/editor';
+import { RawHTML } from '@wordpress/element';
 
 /**
  * Internal dependencies
@@ -85,7 +86,7 @@ const Main = () => {
 						<Tabs tabs={ tabs } />
 						{ error !== null && (
 							<Notice status="error" isDismissible={ false }>
-								{ error }
+								<RawHTML>{ error }</RawHTML>
 							</Notice>
 						) }
 					</Col>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It formats the extensions page error message.

### Testing instructions

* Try to update a WC extension without a subscription related to that extension, or you can inject any other error through the code directly (could be in `Sensei_REST_API_Extensions_Controller`).

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1275" alt="Screen Shot 2021-05-10 at 16 38 06" src="https://user-images.githubusercontent.com/876340/117715302-73ca5d80-b1ae-11eb-81ec-098629a4055d.png">
