### PR TITLE
Fix structure ordering cache

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1581,7 +1581,7 @@ class Sensei_Admin {
 	}
 
 	/**
-	 * Get course structure.
+	 * Get or filter course structure for lesson ordering.
 	 *
 	 * @param int|array   $course_structure Structure array or course ID to get the structure.
 	 * @param null|string $type             Optional type to filter the content.
@@ -1591,7 +1591,7 @@ class Sensei_Admin {
 	private function get_course_structure( $course_structure = null, $type = null ) {
 		$course_structure = is_array( $course_structure )
 			? $course_structure
-			: Sensei_Course_Structure::instance( $course_structure )->get( 'edit' );
+			: Sensei_Course_Structure::instance( $course_structure )->get( 'edit', wp_using_ext_object_cache() );
 
 		if ( isset( $type ) ) {
 			$course_structure = array_filter(

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -119,7 +119,9 @@ class Sensei_Course_Structure {
 	 * @return string Where with extra condition to avoid cache.
 	 */
 	public function filter_no_cache_where( $where ) {
-		return $where . ' AND ' . time() . ' = ' . time();
+		$time = time();
+
+		return $where . ' AND ' . $time . ' = ' . $time;
 	}
 
 	/**

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -61,7 +61,8 @@ class Sensei_Course_Structure {
 	 * @see Sensei_Course_Structure::prepare_lesson()
 	 * @see Sensei_Course_Structure::prepare_module()
 	 *
-	 * @param string $context Context that structure is being retrieved for. Possible values: edit, view.
+	 * @param string  $context  Context that structure is being retrieved for. Possible values: edit, view.
+	 * @param boolean $no_cache Avoid query cache.
 	 *
 	 * @return array {
 	 *     An array which has course structure information.
@@ -70,7 +71,11 @@ class Sensei_Course_Structure {
 	 *                 and prepare_module().
 	 * }
 	 */
-	public function get( $context = 'view' ) {
+	public function get( $context = 'view', $no_cache = false ) {
+		if ( $no_cache ) {
+			add_filter( 'posts_where', [ $this, 'filter_no_cache_where' ] );
+		}
+
 		$context = in_array( $context, [ 'view', 'edit' ], true ) ? $context : 'view';
 
 		$structure = [];
@@ -97,7 +102,24 @@ class Sensei_Course_Structure {
 			$structure[] = $this->prepare_lesson( $lesson );
 		}
 
+		if ( $no_cache ) {
+			remove_filter( 'posts_where', [ $this, 'filter_no_cache_where' ] );
+		}
+
 		return $structure;
+	}
+
+	/**
+	 * Filter where adding an extra condition to avoid cache.
+	 *
+	 * @access private
+	 *
+	 * @param string $where Current where.
+	 *
+	 * @return string Where with extra condition to avoid cache.
+	 */
+	public function filter_no_cache_where( $where ) {
+		return $where . ' AND ' . time() . ' = ' . time();
 	}
 
 	/**

--- a/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
@@ -189,7 +189,7 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 		}
 
 		$response = new WP_REST_Response();
-		$response->set_data( $course_structure->get( 'edit' ) );
+		$response->set_data( $course_structure->get( 'edit', wp_using_ext_object_cache() ) );
 
 		return $response;
 	}


### PR DESCRIPTION
Fixes #3891

### Changes proposed in this Pull Request

* It fixes the issue related to cache when ordering the course structure.
  * Notice that it only happens when using `memcached` for object cache. With Redis, using the plugin _"Redis Object Cache"_ I couldn't reproduce the issue.
* The chosen strategy was to avoid cache in some specific cases while getting the structure for edit. It was done by adding a new conditional to the `WHERE` query. It seems the way that solves for any extension. My first option was trying to clear some cache objects, but in the plugin I used, for example, it had some specific names, so we couldn't clear it in a generic way for any object cache extension.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
You can configure your local env (2 first steps), or you can test it in Pressable or an Ephemeral site.

* Configure and start `memcached`.
* Configure the object cache in WordPress to use the `memcached`. I used the plugin [Docket Cache](https://wordpress.org/plugins/docket-cache/) for this.
* Create a course with modules and lessons (use lessons inside modules and lessons without modules to make sure all scenarios are working properly).
* Reorder the lessons, save the post, and make sure the lessons continue in the correct place (see the issue for more details).
* Go to WP admin > Lessons > Order Lessons.
* Select your course.
* Reorder the lessons, and make sure it works properly.