### PR TITLE
Use standard way of getting quiz ID on grading page

### DIFF
--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -263,7 +263,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		$title = Sensei_Learner::get_full_name( $item->user_id );
 
 		// QuizID to be deprecated
-		$quiz_id   = get_post_meta( $item->comment_post_ID, '_lesson_quiz', true );
+		$quiz_id   = Sensei()->lesson->lesson_quizzes( $item->comment_post_ID, 'any' );
 		$quiz_link = add_query_arg(
 			array(
 				'page'    => $this->page_slug,


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Between Sensei LMS 3.6 and 3.9 we weren't setting `_lesson_quiz` meta on lessons created with the course outline block. That was quasi-okay because the primary way of setting this link is with `post_parent` on the quiz. 
* The only place using this `_lesson_quiz` is in Grading. This switches out the method used in that area. This fixes the issue for lessons created during these versions.
* We could also remove all other update/add references to `_lesson_quiz`. What do you all think?

### Testing instructions
- Simulate the issue by creating a lesson with a quiz and then delete the `_lesson_quiz` post meta for the lesson.
- Take the quiz as a student.
- In Sensei LMS > Grading, check the `Grade quiz` button/link correctly sets the `quiz_id` argument.