### PR TITLE
Add grid view to Learner Courses block and update list view

### DIFF
--- a/assets/blocks/learner-courses-block/learner-courses-edit.js
+++ b/assets/blocks/learner-courses-block/learner-courses-edit.js
@@ -129,53 +129,59 @@ const LearnerCoursesEdit = ( {
 				key={ index }
 			>
 				<section className="entry">
-					{ options.courseCategoryEnabled && (
-						<small className="wp-block-sensei-lms-learner-courses__courses-list__category">
-							{ __( 'Category Name', 'sensei-lms' ) }
-						</small>
-					) }
-					<h3 className="wp-block-sensei-lms-learner-courses__courses-list__title">
-						{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-						<a href="#">{ __( 'Course Title', 'sensei-lms' ) }</a>
-					</h3>
 					{ options.featuredImageEnabled && (
 						<FeaturedImagePlaceholder />
 					) }
 
-					{ completed && (
-						<div className="wp-block-sensei-lms-learner-courses__courses-list__badge__wrapper">
-							<em className="wp-block-sensei-lms-learner-courses__courses-list__badge">
-								{ __( 'Completed', 'sensei-lms' ) }
-							</em>
-						</div>
-					) }
+					<div className="wp-block-sensei-lms-learner-courses__courses-list__details">
+						<h3 className="wp-block-sensei-lms-learner-courses__courses-list__title">
+							{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+							<a href="#">
+								{ __( 'Course Title', 'sensei-lms' ) }
+							</a>
+						</h3>
 
-					{ options.courseDescriptionEnabled && (
-						<p className="wp-block-sensei-lms-learner-courses__courses-list__description">
-							{ __(
-								'This is a preview of the course description…',
-								'sensei-lms'
-							) }
-						</p>
-					) }
-					{ options.progressBarEnabled && (
-						<CourseProgress
-							lessonsCount={ 3 }
-							completedCount={ completed ? 3 : 1 }
-							hidePercentage
-						/>
-					) }
-					{ completed && (
-						<div className="sensei-results-links wp-block-buttons is-content-justification-right">
-							<div className="wp-block-button">
-								{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-								<a className="wp-block-button__link" href="#">
-									{ __( 'View Results', 'sensei-lms' ) }
-								</a>
+						{ options.courseCategoryEnabled && (
+							<span className="wp-block-sensei-lms-learner-courses__courses-list__category">
+								{ __( 'Category Name', 'sensei-lms' ) }
+							</span>
+						) }
+
+						{ options.courseDescriptionEnabled && (
+							<p className="wp-block-sensei-lms-learner-courses__courses-list__description">
+								{ __(
+									'This is a preview of the course description…',
+									'sensei-lms'
+								) }
+							</p>
+						) }
+
+						{ options.progressBarEnabled && (
+							<CourseProgress
+								lessonsCount={ 3 }
+								completedCount={ completed ? 3 : 1 }
+								wrapperAttributes={ {
+									className:
+										'wp-block-sensei-lms-course-progress',
+								} }
+								hidePercentage
+							/>
+						) }
+
+						{ completed && (
+							<div className="sensei-results-links wp-block-buttons">
+								<div className="wp-block-button">
+									{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+									<a
+										className="wp-block-button__link"
+										href="#"
+									>
+										{ __( 'View Results', 'sensei-lms' ) }
+									</a>
+								</div>
 							</div>
-						</div>
-					) }
-					<div className="clearfix" />
+						) }
+					</div>
 				</section>
 			</li>
 		);
@@ -213,7 +219,7 @@ const LearnerCoursesEdit = ( {
 				<ul
 					className={ classnames(
 						'wp-block-sensei-lms-learner-courses__courses-list',
-						`--is-${ options.layoutView }-view`
+						`wp-block-sensei-lms-learner-courses__courses-list--is-${ options.layoutView }-view`
 					) }
 				>
 					{ Array.from( { length: 2 } ).map( coursesPlaceholderMap ) }

--- a/assets/blocks/learner-courses-block/learner-courses-editor.scss
+++ b/assets/blocks/learner-courses-block/learner-courses-editor.scss
@@ -3,19 +3,63 @@
 $block: '.wp-block-sensei-lms-learner-courses';
 $courses-list: '#{$block}__courses-list';
 
-
 .editor-styles-wrapper #{$courses-list} {
+	list-style: none;
+	padding: 0;
+	margin: 0;
 
 	&__featured-image {
 		display: flex;
 		align-items: center;
 		justify-content: center;
-		width: 100px;
-		height: 100px;
-		flex-shrink: 0;
 		background-color: #C3C4C7;
-		background-size: cover;
-		background-position: 50% 50%;
 		fill: #FFF;
+	}
+
+	&__title {
+		&,
+		.editor-styles-wrapper .wp-block & {
+			margin: 0;
+		}
+
+		.has-primary-color & a {
+			color: var(--sensei-primary-color, inherit);
+		}
+	}
+
+	&__description {
+		margin: 0;
+	}
+
+	.wp-block-sensei-lms-course-progress {
+		margin-top: 10px;
+	}
+
+	.sensei-results-links {
+		margin-top: auto; // Push button to bottom of card.
+		padding-top: 20px;
+
+		.wp-block-button {
+			margin: 0;
+		}
+
+		.wp-block-button__link {
+			border-radius: inherit;
+			line-height: normal;
+		}
+	}
+}
+
+/* List view */
+.editor-styles-wrapper #{$courses-list}--is-list-view {
+	#{$courses-list}__featured-image {
+		width: 150px;
+	}
+}
+
+/* Grid view */
+.editor-styles-wrapper #{$courses-list}--is-grid-view {
+	#{$courses-list}__featured-image {
+		height: 200px;
 	}
 }

--- a/assets/blocks/learner-courses-block/learner-courses-editor.scss
+++ b/assets/blocks/learner-courses-block/learner-courses-editor.scss
@@ -46,6 +46,7 @@ $courses-list: '#{$block}__courses-list';
 		.wp-block-button__link {
 			border-radius: inherit;
 			line-height: normal;
+			text-decoration: none;
 		}
 	}
 }

--- a/assets/blocks/learner-courses-block/learner-courses-settings.js
+++ b/assets/blocks/learner-courses-block/learner-courses-settings.js
@@ -32,16 +32,16 @@ import { CourseProgressSettings } from '../../shared/blocks/course-progress';
 const LearnerCoursesSettings = ( { options, setOptions } ) => {
 	const courseSettingsTogglers = [
 		{
-			optionKey: 'courseDescriptionEnabled',
-			label: __( 'Description', 'sensei-lms' ),
-		},
-		{
 			optionKey: 'featuredImageEnabled',
 			label: __( 'Featured image', 'sensei-lms' ),
 		},
 		{
 			optionKey: 'courseCategoryEnabled',
 			label: __( 'Category', 'sensei-lms' ),
+		},
+		{
+			optionKey: 'courseDescriptionEnabled',
+			label: __( 'Description', 'sensei-lms' ),
 		},
 		{
 			optionKey: 'progressBarEnabled',

--- a/assets/blocks/learner-courses-block/learner-courses-settings.js
+++ b/assets/blocks/learner-courses-block/learner-courses-settings.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import {
-	// BlockControls,
+	BlockControls,
 	InspectorControls,
 	PanelColorSettings,
 } from '@wordpress/block-editor';
@@ -10,11 +10,11 @@ import {
 	PanelBody,
 	PanelRow,
 	ToggleControl,
-	// ToolbarGroup,
-	// ToolbarButton,
-	// SelectControl,
+	ToolbarGroup,
+	ToolbarButton,
+	SelectControl,
 } from '@wordpress/components';
-// import { grid, list } from '@wordpress/icons';
+import { grid, list } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -49,18 +49,18 @@ const LearnerCoursesSettings = ( { options, setOptions } ) => {
 		},
 	];
 
-	// const layoutViewTogglers = [
-	// 	{
-	// 		view: 'list',
-	// 		label: __( 'List view', 'sensei-lms' ),
-	// 		icon: list,
-	// 	},
-	// 	{
-	// 		view: 'grid',
-	// 		label: __( 'Grid view', 'sensei-lms' ),
-	// 		icon: grid,
-	// 	},
-	// ];
+	const layoutViewTogglers = [
+		{
+			view: 'list',
+			label: __( 'List view', 'sensei-lms' ),
+			icon: list,
+		},
+		{
+			view: 'grid',
+			label: __( 'Grid view', 'sensei-lms' ),
+			icon: grid,
+		},
+	];
 
 	const colorSettings = [
 		{
@@ -96,26 +96,28 @@ const LearnerCoursesSettings = ( { options, setOptions } ) => {
 						</PanelRow>
 					) ) }
 				</PanelBody>
-				{ /* <PanelBody
-					title={ __( 'Styling', 'sensei-lms' ) }
-					initialOpen={ true }
-				>
-					<PanelRow>
-						<SelectControl
-							label={ __( 'Layout', 'sensei-lms' ) }
-							options={ layoutViewTogglers.map(
-								( { view, label } ) => ( {
-									value: view,
-									label,
-								} )
-							) }
-							value={ options.layoutView }
-							onChange={ ( value ) => {
-								setOptions( { layoutView: value } );
-							} }
-						/>
-					</PanelRow>
-				</PanelBody> */ }
+				{
+					<PanelBody
+						title={ __( 'Styling', 'sensei-lms' ) }
+						initialOpen={ true }
+					>
+						<PanelRow>
+							<SelectControl
+								label={ __( 'Layout', 'sensei-lms' ) }
+								options={ layoutViewTogglers.map(
+									( { view, label } ) => ( {
+										value: view,
+										label,
+									} )
+								) }
+								value={ options.layoutView }
+								onChange={ ( value ) => {
+									setOptions( { layoutView: value } );
+								} }
+							/>
+						</PanelRow>
+					</PanelBody>
+				}
 				{ options.progressBarEnabled && (
 					<CourseProgressSettings
 						borderRadius={ options.progressBarBorderRadius }
@@ -145,22 +147,24 @@ const LearnerCoursesSettings = ( { options, setOptions } ) => {
 					) }
 				/>
 			</InspectorControls>
-			{ /* <BlockControls>
-				<ToolbarGroup>
-					{ layoutViewTogglers.map( ( { view, label, icon } ) => (
-						<ToolbarButton
-							key={ view }
-							extraProps={ { 'data-testid': view } }
-							isActive={ view === options.layoutView }
-							icon={ icon }
-							label={ label }
-							onClick={ () => {
-								setOptions( { layoutView: view } );
-							} }
-						/>
-					) ) }
-				</ToolbarGroup>
-			</BlockControls> */ }
+			{
+				<BlockControls>
+					<ToolbarGroup>
+						{ layoutViewTogglers.map( ( { view, label, icon } ) => (
+							<ToolbarButton
+								key={ view }
+								extraProps={ { 'data-testid': view } }
+								isActive={ view === options.layoutView }
+								icon={ icon }
+								label={ label }
+								onClick={ () => {
+									setOptions( { layoutView: view } );
+								} }
+							/>
+						) ) }
+					</ToolbarGroup>
+				</BlockControls>
+			}
 		</>
 	);
 };

--- a/assets/blocks/learner-courses-block/learner-courses-settings.test.js
+++ b/assets/blocks/learner-courses-block/learner-courses-settings.test.js
@@ -31,7 +31,7 @@ describe( '<LearnerCoursesSettings />', () => {
 			queryByLabelText,
 			queryAllByLabelText,
 			queryByText,
-			// queryByTestId,
+			queryByTestId,
 		} = render(
 			<LearnerCoursesSettings
 				options={ options }
@@ -55,10 +55,10 @@ describe( '<LearnerCoursesSettings />', () => {
 			options.progressBarEnabled
 		);
 
-		// expect( queryByTestId( 'list' ) ).not.toHaveClass( 'is-pressed' );
-		// expect( queryByTestId( 'grid' ) ).toHaveClass( 'is-pressed' );
+		expect( queryByTestId( 'list' ) ).not.toHaveClass( 'is-pressed' );
+		expect( queryByTestId( 'grid' ) ).toHaveClass( 'is-pressed' );
 
-		// expect( queryByLabelText( 'Layout' ).value ).toEqual( 'grid' );
+		expect( queryByLabelText( 'Layout' ).value ).toEqual( 'grid' );
 
 		// Open progress bar settings.
 		fireEvent.click( queryByText( 'Progress bar settings' ) );
@@ -87,7 +87,7 @@ describe( '<LearnerCoursesSettings />', () => {
 			queryByLabelText,
 			queryAllByLabelText,
 			queryByText,
-			// queryByTestId,
+			queryByTestId,
 		} = render(
 			<LearnerCoursesSettings
 				options={ options }
@@ -115,15 +115,15 @@ describe( '<LearnerCoursesSettings />', () => {
 			progressBarEnabled: false,
 		} );
 
-		// fireEvent.click( queryByTestId( 'list' ) );
-		// expect( setOptionsMock ).toBeCalledWith( {
-		// 	layoutView: 'list',
-		// } );
+		fireEvent.click( queryByTestId( 'list' ) );
+		expect( setOptionsMock ).toBeCalledWith( {
+			layoutView: 'list',
+		} );
 
-		// fireEvent.click( queryByTestId( 'grid' ) );
-		// expect( setOptionsMock ).toBeCalledWith( {
-		// 	layoutView: 'grid',
-		// } );
+		fireEvent.click( queryByTestId( 'grid' ) );
+		expect( setOptionsMock ).toBeCalledWith( {
+			layoutView: 'grid',
+		} );
 
 		// Open progress bar settings.
 		fireEvent.click( queryByText( 'Progress bar settings' ) );

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -4,20 +4,10 @@ $block: '.wp-block-sensei-lms-learner-courses';
 $courses-list: '#{$block}__courses-list';
 
 /* Spacing defaults */
-
 .sensei .entry-content {
 	section {
 		padding: 0;
 	}
-}
-
-.sensei-block-wrapper {
-	margin-top: 28px;
-	margin-bottom: 28px;
-}
-
-.clearfix {
-	clear: both;
 }
 
 .sensei-pagination {
@@ -29,8 +19,7 @@ $courses-list: '#{$block}__courses-list';
 	}
 }
 
-/* Learner courses styles */
-
+/* Filters */
 .editor-styles-wrapper #{$block}__filter,
 #user-course-status-toggle {
 	display: flex;
@@ -74,138 +63,150 @@ $courses-list: '#{$block}__courses-list';
 	}
 }
 
+/* Course list */
 #{$courses-list},
 .editor-styles-wrapper #{$courses-list} {
-	list-style: none;
-	padding: 0;
-	margin: 0;
-
-	&__item {
-		margin: 0;
-		padding: 0;
-
-		.sensei-block-wrapper {
-			display: none;
-		}
-	}
-
-	&__featured-image {
-		float: left;
-		margin: 0 24px 12px 0;
-	}
-
 	&__category {
 		font-size: 70%;
 		text-transform: uppercase;
 	}
-
-	&__title {
-		&, .editor-styles-wrapper .wp-block & {
-			margin: 0 0 16px;
-		}
-
-		.has-primary-color & a {
-			color: var(--sensei-primary-color, inherit);
-		}
-	}
-
-	&__badge {
-		&__wrapper {
-			margin: 16px 0;
-		}
-		display: inline-block;
-		padding: 2px 8px;
-		color: var(--sensei-accent-color, inherit);
-		border: 1px solid currentColor;
-		border-radius: 4px;
-		font-size: 70%;
-		text-transform: uppercase;
-		font-style: normal;
-	}
-
-	&__description {
-		margin: 9px 0 18px;
-	}
 }
 
-
-#{$block} {
-
-	.course,
-	.course-container {
+/* List and grid view
+   Use #sensei-user-courses selector to override some theme styles (Divi). */
+#{$block} #sensei-user-courses {
+	.course-container,
+	.course {
 		margin: 0;
 		padding: 0;
 		list-style: none;
 
-		.entry {
-			margin: 24px 0;
-		}
-		.thumbnail {
-			margin-bottom: 6px;
-		}
-
+		// Progress bar
 		.sensei-block-wrapper {
-			clear: both;
-			margin: 16px 0;
-		}
-
-		.course-excerpt:empty {
-			padding-top: 28px;
+			margin-top: 10px;
 		}
 	}
 
 	.course {
-		border-bottom: 1px solid #e2e2e2;
-		clear: both;
-
-		.course-title {
-			margin: 0 0 16px;
-		}
-	}
-
-	.sensei-results-links {
-		display: flex;
-		align-items: center;
-		justify-content: flex-end;
-		margin-right: -12px;
-		clear: both;
-
-		.entry-content & {
-			margin-bottom: 0;
-
+		.course-title,
+		.course-excerpt {
+			margin: 0;
 		}
 
-		flex-wrap: wrap;
+		.entry-actions {
+			margin-top: auto; // Push buttons to bottom of card.
+			padding-top: 20px;
 
-		&, .entry-content & {
-			* {
-				margin: 6px 12px;
+			.button,
+			.course-complete,
+			.course-delete {
+				border: 0;
+				display: inline-block;
+				line-height: normal;
+				padding: 10px 20px;
+			}
+		}
+
+		form {
+			display: flex;
+			flex-wrap: wrap;
+			gap: 5px;
+		}
+
+		.sensei-results-links {
+			.button:not(:first-child) {
+				margin-left: 5px;
 			}
 		}
 	}
 
+	.sensei-results-links {
+		margin: 0;
+	}
 }
 
-#{$courses-list}.--is-grid-view, #{$block}--is-grid-view .course-container {
-	@media (min-width: 920px) {
-		display: flex;
-		flex-flow: row wrap;
-		margin: 0 -7px;
+/* List view - Editor and front end */
+.editor-styles-wrapper #{$courses-list}--is-list-view,
+#{$block}--is-list-view #sensei-user-courses .course-container {
+	margin: 2rem 0;
+	overflow: auto;
+}
 
-		#{$courses-list}__item, .course {
-			display: block;
-			flex: 1 0 calc(50% - 22px);
-			margin: 0 11px;
+.editor-styles-wrapper #{$courses-list}--is-list-view,
+#{$block}--is-list-view #sensei-user-courses {
+	.course {
+		border-bottom: 1px solid #e2e2e2;
+		padding-bottom: 2rem;
+
+		&:not(:first-child) {
+			padding-top: 2rem;
+		}
+
+		.entry {
+			display: flex;
+		}
+
+		img {
+			width: 150px;
+			height: 100%;
+			object-fit: cover;
+		}
+
+		#{$courses-list}__details {
+			display: flex;
+			flex-direction: column;
+			flex: 2;
+
+			&:not(:only-child) {
+				margin-left: 15px;
+			}
 		}
 	}
 }
 
-.sensei-course-progress {
+/* Grid view - Editor and front end */
+.editor-styles-wrapper #{$courses-list}--is-grid-view,
+#{$block}--is-grid-view #sensei-user-courses .course-container {
+	display: grid;
+	gap: 2rem;
+	grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+	padding: 2rem 0;
 
-	&__heading {
-		clear: both;
+	.course {
+		display: flex;
+		border: 0;
+		box-shadow: 0 1px 10px 0 rgb(25, 30, 35);
+
+		.course-content,
+		.entry,
+		#{$courses-list}__details {
+			display: flex;
+			flex-direction: column;
+			flex: 1;
+		}
+
+		#{$courses-list}__details {
+			padding: 10px;
+		}
+
+		.entry-actions {
+			margin-top: auto; // Push buttons to bottom of card.
+			padding-top: 20px;
+		}
 	}
+}
 
+/* Grid view - Front end */
+#{$block}--is-grid-view .course-content {
+	img {
+		height: 200px;
+		width: 100%;
+		object-fit: cover;
+	}
+}
+
+/* Progress bar */
+.sensei-course-progress {
 	&__bar {
 		height: var(--sensei-progress-bar-height, 14px);
 		border-radius: var(--sensei-progress-bar-border-radius, 10px);
@@ -218,13 +219,16 @@ $courses-list: '#{$block}__courses-list';
 	}
 }
 
+/* Colors */
 #{$block}.has-sensei-primary-color {
-
-	.course-title a, #{$courses-list}__title a, a {
+	a {
 		color: var(--sensei-primary-color, inherit);
 	}
 
-	.wp-block-button__link, .button {
+	.button,
+	.course-complete,
+	.course-delete,
+	.wp-block-button__link {
 		background-color: var(--sensei-primary-color, inherit);
 		color: #fff;
 	}

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -169,7 +169,7 @@ $courses-list: '#{$block}__courses-list';
 #{$block}--is-grid-view #sensei-user-courses .course-container {
 	display: grid;
 	gap: 2rem;
-	grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+	grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
 	padding: 2rem 0;
 
 	.course {

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -104,6 +104,7 @@ $courses-list: '#{$block}__courses-list';
 				display: inline-block;
 				line-height: normal;
 				padding: 10px 20px;
+				text-decoration: none;
 			}
 		}
 

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -112,6 +112,7 @@ $courses-list: '#{$block}__courses-list';
 			display: flex;
 			flex-wrap: wrap;
 			gap: 5px;
+			margin: 0;
 		}
 
 		.sensei-results-links {
@@ -150,6 +151,7 @@ $courses-list: '#{$block}__courses-list';
 		img {
 			width: 150px;
 			height: 100%;
+			margin: 0;
 			object-fit: cover;
 		}
 
@@ -202,6 +204,7 @@ $courses-list: '#{$block}__courses-list';
 	img {
 		height: 200px;
 		width: 100%;
+		margin: 0;
 		object-fit: cover;
 	}
 }

--- a/includes/blocks/class-sensei-learner-courses-block.php
+++ b/includes/blocks/class-sensei-learner-courses-block.php
@@ -51,11 +51,7 @@ class Sensei_Learner_Courses_Block {
 		);
 
 		if ( isset( $attributes['options']['layoutView'] ) ) {
-			if ( 'grid' === $attributes['options']['layoutView'] ) {
-				$class .= ' wp-block-sensei-lms-learner-courses--is-grid-view';
-			} elseif ( 'list' === $attributes['options']['layoutView'] ) {
-				$class .= ' wp-block-sensei-lms-learner-courses--is-list-view';
-			}
+			$class .= ' wp-block-sensei-lms-learner-courses--is-' . $attributes['options']['layoutView'] . '-view';
 		}
 
 		return '<div class="wp-block-sensei-lms-learner-courses ' . $class . ' " style="' . esc_attr( $style ) . '">' . $shortcode->render() . '</div>';

--- a/includes/blocks/class-sensei-learner-courses-block.php
+++ b/includes/blocks/class-sensei-learner-courses-block.php
@@ -50,8 +50,12 @@ class Sensei_Learner_Courses_Block {
 			]
 		);
 
-		if ( isset( $attributes['options']['layoutView'] ) && 'grid' === $attributes['options']['layoutView'] ) {
-			$class .= ' wp-block-sensei-lms-learner-courses--is-grid-view';
+		if ( isset( $attributes['options']['layoutView'] ) ) {
+			if ( 'grid' === $attributes['options']['layoutView'] ) {
+				$class .= ' wp-block-sensei-lms-learner-courses--is-grid-view';
+			} elseif ( 'list' === $attributes['options']['layoutView'] ) {
+				$class .= ' wp-block-sensei-lms-learner-courses--is-list-view';
+			}
 		}
 
 		return '<div class="wp-block-sensei-lms-learner-courses ' . $class . ' " style="' . esc_attr( $style ) . '">' . $shortcode->render() . '</div>';

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -366,6 +366,9 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		add_filter( 'sensei_course_loop_content_class', array( $this, 'course_status_class_tagging' ), 20, 2 );
 
 		if ( $this->is_block ) {
+			// Remove default WordPress theme hook that overrides Sensei styles.
+			remove_filter( 'wp_get_attachment_image_attributes', 'twenty_twenty_one_get_attachment_image_attributes', 10 );
+
 			remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'the_course_meta' ) );
 			remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'course_image' ), 30 );
 

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -366,17 +366,17 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		add_filter( 'sensei_course_loop_content_class', array( $this, 'course_status_class_tagging' ), 20, 2 );
 
 		if ( $this->is_block ) {
-
 			remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'the_course_meta' ) );
+			remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'course_image' ), 30 );
 
-			if ( ! $this->options['featuredImageEnabled'] ) {
-				remove_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'course_image' ), 30 );
+			if ( $this->options['featuredImageEnabled'] ) {
+				add_action( 'sensei_course_content_inside_before', array( Sensei()->course, 'course_image' ), 1 );
 			}
 
-			add_action( 'sensei_course_content_inside_before', array( $this, 'course_completed_badge' ), 40 );
+			add_action( 'sensei_course_content_inside_before', array( $this, 'add_course_details_wrapper_start' ), 2 );
 
 			if ( $this->options['courseCategoryEnabled'] ) {
-				add_action( 'sensei_course_content_inside_before', array( $this, 'course_category' ), 3 );
+				add_action( 'sensei_course_content_inside_before', array( $this, 'course_category' ), 6 );
 			}
 
 			if ( ! $this->options['courseDescriptionEnabled'] ) {
@@ -389,6 +389,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		}
 
 		add_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_buttons' ) );
+		$this->is_block && add_action( 'sensei_course_content_inside_after', array( $this, 'add_course_details_wrapper_end' ) );
 	}
 
 	/**
@@ -400,7 +401,6 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 		// Remove all hooks after the output is generated.
 		remove_action( 'sensei_course_content_inside_before', array( $this, 'course_category' ), 3 );
-		remove_action( 'sensei_course_content_inside_before', array( $this, 'course_completed_badge' ), 40 );
 		remove_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_progress' ) );
 		remove_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_buttons' ) );
 		remove_filter( 'sensei_course_loop_content_class', array( $this, 'course_status_class_tagging' ), 20 );
@@ -448,31 +448,29 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	}
 
 	/**
-	 * Add Completed badge to completed courses.
-	 *
-	 * @param int|WP_Post $course
-	 */
-	public function course_completed_badge( $course ) {
-		if ( Sensei_Utils::user_completed_course( $course, get_current_user_id() ) ) {
-			echo '<div class="wp-block-sensei-lms-learner-courses__courses-list__badge__wrapper">
-						<em class="wp-block-sensei-lms-learner-courses__courses-list__badge">
-							' . esc_html__( 'Completed', 'sensei-lms' ) . '
-						</em>
-					</div>';
-		}
-	}
-
-	/**
 	 * Display course categories.
 	 *
 	 * @param int|WP_Post $course
 	 */
 	public function course_category( $course ) {
 		$category_output = get_the_term_list( $course, 'course-category', '', ', ', '' );
-		echo '<div class="wp-block-sensei-lms-learner-courses__courses-list__category">
-						' . wp_kses_post( $category_output ) . '
-					</div>';
+		echo '<span class="wp-block-sensei-lms-learner-courses__courses-list__category">
+					' . wp_kses_post( $category_output ) . '
+				</span>';
+	}
 
+	/**
+	 * Add an opening wrapper element around the course details.
+	 */
+	public function add_course_details_wrapper_start() {
+		echo '<div class="wp-block-sensei-lms-learner-courses__courses-list__details">';
+	}
+
+	/**
+	 * Add a closing wrapper element around the course details.
+	 */
+	public function add_course_details_wrapper_end() {
+		echo '</div>';
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request
- Adds a grid view to the Learner Courses block and tweaks the layout for the list view.
- Removes the _Completed_ badge when a course has been completed. The progress bar already indicates this.
- The block no longer relies on the _Image Width - Archive_ and _Image Height - Archive_ settings except for loading placeholder images when no featured image is specified (in the future, we could see about using a plugin-provided image asset instead). Rather, the medium-sized thumbnail is loaded, and CSS is used to size the image as appropriate.
- Grid view will wrap columns into rows when there’s not enough space to accommodate a ~300px~ 280px minimum width card. If there's only enough room for one card, it will expand to fill the remaining space.

### Testing instructions
- Enable the certificates extension and complete a course to get the certificate (in order to see the _View Certificate_ button).
- In Sensei LMS > Settings > Courses, set _Courses are complete_ to _At any time (by clicking the 'Complete Course' button)_ (in order to see the _Complete Course_ button).
- Add the Learner Courses block to a page.
- Check to ensure the block looks good in both list view and grid view.
- Toggle the various course settings and ensure the block continues to look good.
- View the page at different resolutions and ensure the UI looks decent.
- View the page on different themes to ensure nothing breaks (I tested on Divi and Astra).
- View a page with the `sensei_user_courses` shortcode and ensure that looks as it did prior to this change.

### Screenshots
#### List View
![list-view](https://user-images.githubusercontent.com/1190420/125116075-2d17b780-e0ba-11eb-9cb1-507bb95675fb.jpg)

#### Grid View
![grid-view](https://user-images.githubusercontent.com/1190420/125116104-36a11f80-e0ba-11eb-8e5f-e6f282c23324.jpg)