### PR TITLE
PHP 8 fixes

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,83 +3,93 @@ name: PHP Linting and Tests
 on: pull_request
 
 jobs:
-  lint:
-    name:    PHP Linting
-    runs-on: ubuntu-16.04
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/composer/
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v2
-        with:
-          path: vendor/
-          key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          tools:       composer
-          coverage:    none
-      - name: Set up branches
-        run: git checkout -b master refs/remotes/origin/master && git checkout -
-      - name: Install PHP dependencies
-        run: composer self-update --1 && composer install --no-ansi --no-interaction --prefer-dist --no-progress
-      - name: Check for new issues
-        run: ./scripts/linter-ci
-      - name: Check for escaping
-        run: ./vendor/bin/phpcs -s --sniffs=WordPress.WP.I18n,Generic.PHP.Syntax,WordPress.Security.EscapeOutput .
-      - name: Check for nonces
-        run: ./vendor/bin/phpcs -sn --sniffs=WordPress.Security.NonceVerification .
-      - name: Check WPCOM rules
-        run: ./vendor/bin/phpcs -sn --standard=./wpcom-phpcs.xml .
-  test:
-    name: PHP Unit Tests
-    runs-on: ubuntu-16.04
-    strategy:
-      fail-fast: false
-      max-parallel: 10
-      matrix:
-        wp: [ 'latest' ]
-        wpmu: [ 0 ]
-        php: [ '7.3', '7.4', '8.0 ]
-        include:
-          - php: 7.4
-            wp: 5.4
-          - php: 7.4
-            wp: 5.5
-          - php: 7.4
-            wp: latest
-            wpmu: 1
-    env:
-      WP_VERSION: ${{ matrix.wp }}
-      WP_MULTISITE: ${{ matrix.wpmu }}
-      PHP_VERSION: ${{ matrix.php }}
-    steps:
-      # clone the repository
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/composer/
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v2
-        with:
-          path: vendor/
-          key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: mysql
-          tools: composer
-          coverage: none
-      # run CI checks
-      - name: Start mysql service
-        run: sudo /etc/init.d/mysql start
-      - name: Install PHP dependencies
-        run: composer install --no-ansi --no-interaction --prefer-dist --no-progress
-      - name: Setup test environment
-        run: bash ./tests/bin/install-wp-tests.sh wordpress_test root root localhost $WP_VERSION
-      - name: Run tests
-        run: ./vendor/bin/phpunit
+    lint:
+        name: PHP Linting
+        runs-on: ubuntu-16.04
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+            - uses: actions/cache@v2
+              with:
+                  path: ~/.cache/composer/
+                  key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+            - uses: actions/cache@v2
+              with:
+                  path: vendor/
+                  key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '7.4'
+                  tools: composer
+                  coverage: none
+            - name: Set up branches
+              run: git checkout -b master refs/remotes/origin/master && git checkout -
+            - name: Install PHP dependencies
+              run: composer self-update --1 && composer install --no-ansi --no-interaction --prefer-dist --no-progress
+            - name: Check for new issues
+              run: ./scripts/linter-ci
+            - name: Check for escaping
+              run: ./vendor/bin/phpcs -s --sniffs=WordPress.WP.I18n,Generic.PHP.Syntax,WordPress.Security.EscapeOutput .
+            - name: Check for nonces
+              run: ./vendor/bin/phpcs -sn --sniffs=WordPress.Security.NonceVerification .
+            - name: Check WPCOM rules
+              run: ./vendor/bin/phpcs -sn --standard=./wpcom-phpcs.xml .
+    test:
+        name: PHP Unit Tests
+        runs-on: ubuntu-16.04
+        strategy:
+            fail-fast: false
+            max-parallel: 10
+            matrix:
+                wp: ['latest']
+                wpmu: [0]
+                php: ['7.3', '7.4', '8.0']
+                include:
+                    - php: 7.4
+                      wp: 5.4
+                    - php: 7.4
+                      wp: 5.5
+                    - php: 7.4
+                      wp: latest
+                      wpmu: 1
+        env:
+            WP_VERSION: ${{ matrix.wp }}
+            WP_MULTISITE: ${{ matrix.wpmu }}
+            PHP_VERSION: ${{ matrix.php }}
+        steps:
+            # clone the repository
+            - uses: actions/checkout@v2
+            - uses: actions/cache@v2
+              with:
+                  path: ~/.cache/composer/
+                  key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+            - uses: actions/cache@v2
+              with:
+                  path: vendor/
+                  key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: mysql
+                  tools: composer
+                  coverage: none
+            # run CI checks
+            - name: Start mysql service
+              run: sudo /etc/init.d/mysql start
+            - name: Install PHP dependencies
+              run: composer install --no-ansi --no-interaction --prefer-dist --no-progress --ignore-platform-reqs
+            - name: Add PHP8 Compatibility
+              run: |
+                  if [ "$(php -r "echo version_compare(PHP_VERSION,'8.0','>=');")" ]; then
+                      curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
+                      unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
+                      rm ./vendor/bin/phpunit
+                      composer bin phpunit config --unset platform
+                      composer bin phpunit config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
+                      composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
+                  fi
+            - name: Setup test environment
+              run: bash ./tests/bin/install-wp-tests.sh wordpress_test root root localhost $WP_VERSION
+            - name: Run tests
+              run: ./vendor/bin/phpunit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,83 +3,83 @@ name: PHP Linting and Tests
 on: pull_request
 
 jobs:
-    lint:
-        name: PHP Linting
-        runs-on: ubuntu-16.04
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                  fetch-depth: 0
-            - uses: actions/cache@v2
-              with:
-                  path: ~/.cache/composer/
-                  key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-            - uses: actions/cache@v2
-              with:
-                  path: vendor/
-                  key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
-            - uses: shivammathur/setup-php@v2
-              with:
-                  php-version: '7.3'
-                  tools: composer
-                  coverage: none
-            - name: Set up branches
-              run: git checkout -b master refs/remotes/origin/master && git checkout -
-            - name: Install PHP dependencies
-              run: composer self-update --1 && composer install --no-ansi --no-interaction --prefer-dist --no-progress
-            - name: Check for new issues
-              run: ./scripts/linter-ci
-            - name: Check for escaping
-              run: ./vendor/bin/phpcs -s --sniffs=WordPress.WP.I18n,Generic.PHP.Syntax,WordPress.Security.EscapeOutput .
-            - name: Check for nonces
-              run: ./vendor/bin/phpcs -sn --sniffs=WordPress.Security.NonceVerification .
-            - name: Check WPCOM rules
-              run: ./vendor/bin/phpcs -sn --standard=./wpcom-phpcs.xml .
-    test:
-        name: PHP Unit Tests
-        runs-on: ubuntu-16.04
-        strategy:
-            fail-fast: false
-            max-parallel: 10
-            matrix:
-                wp: ['latest']
-                wpmu: [0]
-                php: ['7.2', '7.3', '7.4']
-                include:
-                    - php: 7.3
-                      wp: 5.4
-                    - php: 7.3
-                      wp: 5.5
-                    - php: 7.3
-                      wp: latest
-                      wpmu: 1
-        env:
-            WP_VERSION: ${{ matrix.wp }}
-            WP_MULTISITE: ${{ matrix.wpmu }}
-            PHP_VERSION: ${{ matrix.php }}
-        steps:
-            # clone the repository
-            - uses: actions/checkout@v2
-            - uses: actions/cache@v2
-              with:
-                  path: ~/.cache/composer/
-                  key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-            - uses: actions/cache@v2
-              with:
-                  path: vendor/
-                  key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
-            - uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php }}
-                  extensions: mysql
-                  tools: composer
-                  coverage: none
-            # run CI checks
-            - name: Start mysql service
-              run: sudo /etc/init.d/mysql start
-            - name: Install PHP dependencies
-              run: composer install --no-ansi --no-interaction --prefer-dist --no-progress
-            - name: Setup test environment
-              run: bash ./tests/bin/install-wp-tests.sh wordpress_test root root localhost $WP_VERSION
-            - name: Run tests
-              run: ./vendor/bin/phpunit
+  lint:
+    name:    PHP Linting
+    runs-on: ubuntu-16.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/composer/
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+      - uses: actions/cache@v2
+        with:
+          path: vendor/
+          key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools:       composer
+          coverage:    none
+      - name: Set up branches
+        run: git checkout -b master refs/remotes/origin/master && git checkout -
+      - name: Install PHP dependencies
+        run: composer self-update --1 && composer install --no-ansi --no-interaction --prefer-dist --no-progress
+      - name: Check for new issues
+        run: ./scripts/linter-ci
+      - name: Check for escaping
+        run: ./vendor/bin/phpcs -s --sniffs=WordPress.WP.I18n,Generic.PHP.Syntax,WordPress.Security.EscapeOutput .
+      - name: Check for nonces
+        run: ./vendor/bin/phpcs -sn --sniffs=WordPress.Security.NonceVerification .
+      - name: Check WPCOM rules
+        run: ./vendor/bin/phpcs -sn --standard=./wpcom-phpcs.xml .
+  test:
+    name: PHP Unit Tests
+    runs-on: ubuntu-16.04
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        wp: [ 'latest' ]
+        wpmu: [ 0 ]
+        php: [ '7.3', '7.4', '8.0 ]
+        include:
+          - php: 7.4
+            wp: 5.4
+          - php: 7.4
+            wp: 5.5
+          - php: 7.4
+            wp: latest
+            wpmu: 1
+    env:
+      WP_VERSION: ${{ matrix.wp }}
+      WP_MULTISITE: ${{ matrix.wpmu }}
+      PHP_VERSION: ${{ matrix.php }}
+    steps:
+      # clone the repository
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/composer/
+          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+      - uses: actions/cache@v2
+        with:
+          path: vendor/
+          key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mysql
+          tools: composer
+          coverage: none
+      # run CI checks
+      - name: Start mysql service
+        run: sudo /etc/init.d/mysql start
+      - name: Install PHP dependencies
+        run: composer install --no-ansi --no-interaction --prefer-dist --no-progress
+      - name: Setup test environment
+        run: bash ./tests/bin/install-wp-tests.sh wordpress_test root root localhost $WP_VERSION
+      - name: Run tests
+        run: ./vendor/bin/phpunit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -84,10 +84,8 @@ jobs:
                   if [ "$(php -r "echo version_compare(PHP_VERSION,'8.0','>=');")" ]; then
                       curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
                       unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
-                      rm ./vendor/bin/phpunit
-                      composer bin phpunit config --unset platform
-                      composer bin phpunit config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
-                      composer bin phpunit require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
+                      composer config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
+                      composer require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
                   fi
             - name: Setup test environment
               run: bash ./tests/bin/install-wp-tests.sh wordpress_test root root localhost $WP_VERSION

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "automattic/sensei-lms",
 	"description": "A learning management plugin for WordPress, which provides the smoothest platform for helping you teach anything.",
 	"require-dev": {
-		"php": "^5.4 || ^7",
+		"php": "^5.4 || ^7 || ^8",
 		"phpunit/phpunit": "7.5.20",
 		"dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
 		"phpcompatibility/phpcompatibility-wp": "2.1.1",

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
 		"squizlabs/php_codesniffer": "3.6.0",
 		"wp-coding-standards/wpcs": "2.3.0",
 		"sirbrillig/phpcs-variable-analysis": "2.11.0",
-		"sirbrillig/phpcs-no-get-current-user": "1.1.0",
-		"bamarni/composer-bin-plugin": "^1.4"
+		"sirbrillig/phpcs-no-get-current-user": "1.1.0"
 	},
 	"prefer-stable": true,
 	"archive": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
 		"squizlabs/php_codesniffer": "3.6.0",
 		"wp-coding-standards/wpcs": "2.3.0",
 		"sirbrillig/phpcs-variable-analysis": "2.11.0",
-		"sirbrillig/phpcs-no-get-current-user": "1.1.0"
+		"sirbrillig/phpcs-no-get-current-user": "1.1.0",
+		"bamarni/composer-bin-plugin": "^1.4"
 	},
 	"prefer-stable": true,
 	"archive": {

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 		"phpunit/phpunit": "7.5.20",
 		"dealerdirect/phpcodesniffer-composer-installer": "0.7.1",
 		"phpcompatibility/phpcompatibility-wp": "2.1.1",
-		"squizlabs/php_codesniffer": "3.5.8",
+		"squizlabs/php_codesniffer": "3.6.0",
 		"wp-coding-standards/wpcs": "2.3.0",
 		"sirbrillig/phpcs-variable-analysis": "2.11.0",
 		"sirbrillig/phpcs-no-get-current-user": "1.1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,55 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "995ae9a50705d34d0aee0f884a294e5b",
+    "content-hash": "6ec11888db3941ded05baa6e88a54c89",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "bamarni/composer-bin-plugin",
+            "version": "1.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/bamarni/composer-bin-plugin.git",
+                "reference": "9329fb0fbe29e0e1b2db8f4639a193e4f5406225"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/9329fb0fbe29e0e1b2db8f4639a193e4f5406225",
+                "reference": "9329fb0fbe29e0e1b2db8f4639a193e4f5406225",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": "^5.5.9 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0 || ^2.0",
+                "symfony/console": "^2.5 || ^3.0 || ^4.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Bamarni\\Composer\\Bin\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Bamarni\\Composer\\Bin\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "No conflicts for your bin dependencies",
+            "keywords": [
+                "composer",
+                "conflict",
+                "dependency",
+                "executable",
+                "isolation",
+                "tool"
+            ],
+            "time": "2020-05-03T08:27:20+00:00"
+        },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b66c636e09783ff0f60272450e7a0cc",
+    "content-hash": "6b93cabe3283ce856ba1933e902d4c66",
     "packages": [],
     "packages-dev": [
         {
@@ -602,16 +602,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.12.2",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "245710e971a030f42e08f4912863805570f23d39"
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/245710e971a030f42e08f4912863805570f23d39",
-                "reference": "245710e971a030f42e08f4912863805570f23d39",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
                 "shasum": ""
             },
             "require": {
@@ -661,7 +661,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-12-19T10:15:11+00:00"
+            "time": "2021-03-17T13:42:18+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1731,16 +1731,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.8",
+            "version": "3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4"
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/9d583721a7157ee997f235f327de038e7ea6dac4",
-                "reference": "9d583721a7157ee997f235f327de038e7ea6dac4",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
@@ -1778,20 +1778,20 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-10-23T02:01:07+00:00"
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -1803,7 +1803,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -1854,7 +1854,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -1904,30 +1904,35 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.9.1",
+            "version": "1.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozarts/assert.git",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
-                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/6964c76c7804814a842473e0c8fd15bab0f18e25",
+                "reference": "6964c76c7804814a842473e0c8fd15bab0f18e25",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0 || ^8.0",
+                "php": "^7.2 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
                 "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<3.9.1"
+                "vimeo/psalm": "<4.6.1 || 4.6.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
+                "phpunit/phpunit": "^8.5.13"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.10-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -1949,7 +1954,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-07-08T17:02:28+00:00"
+            "time": "2021-03-09T10:59:23+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b93cabe3283ce856ba1933e902d4c66",
+    "content-hash": "995ae9a50705d34d0aee0f884a294e5b",
     "packages": [],
     "packages-dev": [
         {
@@ -2010,7 +2010,7 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": {
-        "php": "^5.4 || ^7"
+        "php": "^5.4 || ^7 || ^8"
     },
     "plugin-api-version": "1.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,55 +4,9 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6ec11888db3941ded05baa6e88a54c89",
+    "content-hash": "995ae9a50705d34d0aee0f884a294e5b",
     "packages": [],
     "packages-dev": [
-        {
-            "name": "bamarni/composer-bin-plugin",
-            "version": "1.4.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/bamarni/composer-bin-plugin.git",
-                "reference": "9329fb0fbe29e0e1b2db8f4639a193e4f5406225"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/bamarni/composer-bin-plugin/zipball/9329fb0fbe29e0e1b2db8f4639a193e4f5406225",
-                "reference": "9329fb0fbe29e0e1b2db8f4639a193e4f5406225",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": "^5.5.9 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "composer/composer": "^1.0 || ^2.0",
-                "symfony/console": "^2.5 || ^3.0 || ^4.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Bamarni\\Composer\\Bin\\Plugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Bamarni\\Composer\\Bin\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "No conflicts for your bin dependencies",
-            "keywords": [
-                "composer",
-                "conflict",
-                "dependency",
-                "executable",
-                "isolation",
-                "tool"
-            ],
-            "time": "2020-05-03T08:27:20+00:00"
-        },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
             "version": "v0.7.1",

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -354,6 +354,8 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				// in this case the item passed in is actually the users activity on course of lesson.
 				$user_activity = $item;
 				$post_id       = false;
+				$post_type     = false;
+				$object_type   = false;
 
 				if ( $this->lesson_id ) {
 
@@ -1102,6 +1104,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 		$is_selected = 'learners' === $this->view && $enrolment_status === $this->enrolment_status;
 		$url         = add_query_arg( $query_args, admin_url( 'admin.php' ) );
+		$link_title  = false;
 
 		switch ( $enrolment_status ) {
 			case 'enrolled':
@@ -1116,6 +1119,10 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			case 'all':
 				$link_title = esc_html__( 'All Learners', 'sensei-lms' );
 				break;
+		}
+
+		if ( ! $link_title ) {
+			return '';
 		}
 
 		return '<a ' . ( $is_selected ? 'class="current"' : '' ) . ' href="' . esc_url( $url ) . '">' . $link_title . '</a>';
@@ -1208,7 +1215,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 						submit_button( sprintf( __( 'Add to \'%1$s\'', 'sensei-lms' ), $post_title ), 'primary', 'add_learner_submit', false, array() );
 						?>
 					</p>
-					<?php if ( 'lesson' === $form_post_type ) { ?>
+					<?php if ( 'lesson' === $form_post_type && isset( $course_title ) ) { ?>
 						<p><span class="description">
 							<?php
 							// translators: Placeholder is the course title.

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1199,6 +1199,7 @@ class Sensei_Admin {
 	public function handle_order_courses() {
 		check_admin_referer( 'order_courses' );
 
+		$ordered = null;
 		if ( isset( $_POST['course-order'] ) && 0 < strlen( $_POST['course-order'] ) ) {
 			$ordered = $this->save_course_order( esc_attr( $_POST['course-order'] ) );
 		}
@@ -1355,6 +1356,7 @@ class Sensei_Admin {
 	public function handle_order_lessons() {
 		check_admin_referer( 'order_lessons' );
 
+		$ordered = null;
 		if ( isset( $_POST['lesson-order'] ) ) {
 			$ordered = $this->save_lesson_order( esc_attr( $_POST['lesson-order'] ), esc_attr( $_POST['course_id'] ) );
 		}

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -200,6 +200,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		$user_start_date = get_comment_meta( $item->comment_ID, 'start', true );
 		$user_end_date   = $item->comment_date;
 
+		$grade = null;
 		if ( 'complete' == $item->comment_approved ) {
 			$status = __( 'Completed', 'sensei-lms' );
 			$grade  = __( 'No Grade', 'sensei-lms' );

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -829,7 +829,7 @@ class Sensei_Grading {
 		if (
 			$page
 			&& $message
-			&& $this->page_slug == $page
+			&& $this->page_slug === $page
 			&& 'graded' === $message
 		) {
 			?>

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -823,7 +823,7 @@ class Sensei_Grading {
 	}
 
 	public function add_grading_notices() {
-		$page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : false;
+		$page    = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : false;
 		$message = isset( $_GET['message'] ) ? sanitize_text_field( wp_unslash( $_GET['message'] ) ) : false;
 
 		if (
@@ -834,7 +834,7 @@ class Sensei_Grading {
 		) {
 			?>
 			<div class="grading-notice updated">
-				<p><?php echo __( 'Quiz Graded Successfully!', 'sensei-lms' ); ?></p>
+				<p><?php echo esc_html__( 'Quiz Graded Successfully!', 'sensei-lms' ); ?></p>
 			</div>
 			<?php
 		}

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -823,16 +823,18 @@ class Sensei_Grading {
 	}
 
 	public function add_grading_notices() {
-		if ( isset( $_GET['page'] ) && $this->page_slug == $_GET['page'] && isset( $_GET['message'] ) && $_GET['message'] ) {
-			if ( 'graded' == $_GET['message'] ) {
-				$msg = array(
-					'updated',
-					__( 'Quiz Graded Successfully!', 'sensei-lms' ),
-				);
-			}
+		$page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : false;
+		$message = isset( $_GET['message'] ) ? sanitize_text_field( wp_unslash( $_GET['message'] ) ) : false;
+
+		if (
+			$page
+			&& $message
+			&& $this->page_slug == $page
+			&& 'graded' === $message
+		) {
 			?>
-			<div class="grading-notice <?php echo esc_attr( $msg[0] ); ?>">
-				<p><?php echo esc_html( $msg[1] ); ?></p>
+			<div class="grading-notice updated">
+				<p><?php echo __( 'Quiz Graded Successfully!', 'sensei-lms' ); ?></p>
 			</div>
 			<?php
 		}

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -661,13 +661,13 @@ class Sensei_Question {
 				$output .= self::question_media_kses( $question_media_link );
 				$output .= '<dl>';
 
-			if ( $question_media_title ) {
+			if ( ! empty( $question_media_title ) ) {
 
 				$output .= '<dt>' . wp_kses_post( $question_media_title ) . '</dt>';
 
 			}
 
-			if ( $question_media_description ) {
+			if ( ! empty( $question_media_description ) ) {
 
 				$output .= '<dd>' . wp_kses_post( $question_media_description ) . '</dd>';
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -201,7 +201,7 @@ class Sensei_Quiz {
 	 *
 	 * @return false or int $answers_saved
 	 */
-	public static function save_user_answers( $quiz_answers, $files = array(), $lesson_id, $user_id = 0 ) {
+	public static function save_user_answers( $quiz_answers, $files = array(), $lesson_id = 0, $user_id = 0 ) {
 
 		if ( ! ( $user_id > 0 ) ) {
 			$user_id = get_current_user_id();
@@ -601,7 +601,7 @@ class Sensei_Quiz {
 	 *
 	 * @return bool $answers_submitted
 	 */
-	public static function submit_answers_for_grading( $quiz_answers, $files = array(), $lesson_id, $user_id = 0 ) {
+	public static function submit_answers_for_grading( $quiz_answers, $files = array(), $lesson_id = 0, $user_id = 0 ) {
 
 		$answers_submitted = false;
 

--- a/includes/data-port/class-sensei-import-job.php
+++ b/includes/data-port/class-sensei-import-job.php
@@ -295,13 +295,16 @@ class Sensei_Import_Job extends Sensei_Data_Port_Job {
 			return false;
 		}
 
-		$real_mime = false;
-
 		// Validate file.
 		if ( extension_loaded( 'fileinfo' ) ) {
 			$finfo     = finfo_open( FILEINFO_MIME_TYPE );
 			$real_mime = finfo_file( $finfo, $file );
 			finfo_close( $finfo );
+
+			// Some versions of PHP 8 return `application/csv` instead of `text/csv`.
+			if ( in_array( 'text/csv', $allowed, true ) ) {
+				$allowed[] = 'application/csv';
+			}
 
 			// When importing a CSV with HTML content, it can be interpreted as `text/html`.
 			$allowed_with_html = array_merge( $allowed, [ 'text/html' ] );

--- a/includes/data-port/export-tasks/class-sensei-export-task.php
+++ b/includes/data-port/export-tasks/class-sensei-export-task.php
@@ -104,12 +104,18 @@ abstract class Sensei_Export_Task
 
 	/**
 	 * Run export task.
+	 *
+	 * @throws Exception Caught exception when empty file is passed in tests.
 	 */
 	public function run() {
 		$posts = $this->query->posts;
 		$job   = $this->get_job();
 
 		try {
+			if ( empty( $this->file ) ) {
+				throw new Exception( 'Missing output file' );
+			}
+
 			$output_file = new SplFileObject( $this->file, 'a' );
 		} catch ( Exception $e ) {
 			$this->is_aborted = true;

--- a/includes/shortcodes/class-sensei-shortcode-loader.php
+++ b/includes/shortcodes/class-sensei-shortcode-loader.php
@@ -134,12 +134,12 @@ class Sensei_Shortcode_Loader {
 	 *
 	 * @return string
 	 */
-	public function render_shortcode( $attributes = '', $content = '', $code ) {
+	public function render_shortcode( $attributes = '', $content = '', $code = false ) {
 		global $wp_query;
 
 		// only respond if the shortcode that we've added shortcode
 		// classes for.
-		if ( ! isset( $this->shortcode_classes[ $code ] ) ) {
+		if ( ! $code || ! isset( $this->shortcode_classes[ $code ] ) ) {
 			return '';
 		}
 

--- a/tests/framework/factories/class-sensei-factory.php
+++ b/tests/framework/factories/class-sensei-factory.php
@@ -500,7 +500,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 	 *
 	 * @throws Exception 'Generate questions needs a valid lesson ID.' if the ID passed in is not a valid lesson
 	 */
-	protected function attach_lessons_questions( $number = 10, $lesson_id, $question_args = array(), $quiz_args = array(), $reuse_questions = true ) {
+	protected function attach_lessons_questions( $number = 10, $lesson_id = 0, $question_args = array(), $quiz_args = array(), $reuse_questions = true ) {
 
 		if ( empty( $lesson_id ) || ! intval( $lesson_id ) > 0
 			 || ! get_post( $lesson_id ) || 'lesson' != get_post_type( $lesson_id ) ) {
@@ -563,7 +563,7 @@ class Sensei_Factory extends WP_UnitTest_Factory {
 	 * @return int[]
 	 * @throws Exception
 	 */
-	protected function attach_lessons_multiple_questions( $number = 10, $lesson_id, $multiple_question_args = array(), $quiz_args = array() ) {
+	protected function attach_lessons_multiple_questions( $number = 10, $lesson_id = 0, $multiple_question_args = array(), $quiz_args = array() ) {
 		if ( empty( $lesson_id ) || ! intval( $lesson_id ) > 0
 			 || ! get_post( $lesson_id ) || 'lesson' != get_post_type( $lesson_id ) ) {
 			throw new Exception( 'Generate questions needs a valid lesson ID.' );

--- a/widgets/class-sensei-course-categories-widget.php
+++ b/widgets/class-sensei-course-categories-widget.php
@@ -100,14 +100,14 @@ class Sensei_Course_Categories_Widget extends WP_Widget {
 		$instance = $old_instance;
 
 		/* Strip tags for title and name to remove HTML (important for text inputs). */
-		$instance['title'] = strip_tags( $new_instance['title'] );
+		$instance['title'] = strip_tags( $new_instance['title'] ?? '' );
 
 		/* The select box is returning a text value, so we escape it. */
-		$instance['limit'] = esc_attr( $new_instance['limit'] );
+		$instance['limit'] = (int) $new_instance['limit'] ?? 3;
 
 		/* The check box is returning a boolean value. */
-		$instance['count']        = $new_instance['count'];
-		$instance['hierarchical'] = $new_instance['hierarchical'];
+		$instance['count']        = $new_instance['count'] ?? 0;
+		$instance['hierarchical'] = $new_instance['hierarchical'] ?? 0;
 
 		return $instance;
 	}


### PR DESCRIPTION
Fixes #3773

Changes for PHP 8:
- Bump PHP version in CI.
- Fixes PHPUnit for PHP 8 by using WooCommerce's updated version. We can drop this when [WordPress core bumps its PHPUnit version](https://core.trac.wordpress.org/ticket/46149).
- Fixes issue with course category widget.
- Fixes issues with warning showing for methods that have required parameters after optional parameters.

Other cleanup:
- Fixes some issues with possibly unset variables. I don't think most of these were causing issues.

Post merge tasks:
- [ ] Update branch rules for new CI jobs.