### PR TITLE
Add Prettier plugin JSDoc

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,7 +13,10 @@ trim_trailing_whitespace = true
 [*.{md,txt,json,yml}]
 trim_trailing_whitespace = false
 
-[*.{json,yml}]
-insert_final_newline = false
+[*.{json}]
 indent_size = 2
 tab_width = 2
+
+[*.{json,yml}]
+insert_final_newline = false
+indent_style = space

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,25 +1,25 @@
 name: Build Hook Docs
 
 on:
- push:
-   branches:
-    - master
+    push:
+        branches:
+            - master
 
 jobs:
-  hookdocs:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js 10
-      uses: actions/setup-node@v2
-      with:
-        node-version: '10.x'
-    - name: npm install, and build docs
-      run: |
-        npm install
-        npm run build:docs
-    - name: Deploy to GH Pages
-      uses: maxheld83/ghpages@v0.3.0
-      env:
-        BUILD_DIR: 'hookdocs/'
-        GH_PAT: ${{ secrets.GH_PAT }}
+    hookdocs:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Use Node.js 10
+              uses: actions/setup-node@v2
+              with:
+                  node-version: '10.x'
+            - name: npm install, and build docs
+              run: |
+                  npm install
+                  npm run build:docs
+            - name: Deploy to GH Pages
+              uses: maxheld83/ghpages@v0.3.0
+              env:
+                  BUILD_DIR: 'hookdocs/'
+                  GH_PAT: ${{ secrets.GH_PAT }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,49 +1,47 @@
 name: E2E
 
-on:
-  pull_request
+on: pull_request
 
 jobs:
-  test:
-    name: E2E Tests
-    runs-on: ubuntu-16.04
-    strategy:
-      fail-fast: false
-      max-parallel: 10
-      matrix:
-        wp: [ '5.6.2' ]
-        php: [ '7.4' ]
-    env:
-      WP_VERSION: ${{ matrix.wp }}
-      PHP_VERSION: ${{ matrix.php }}
-      E2E_SLACKBOT_USER: 'Sensei e2e Reporter'
-      E2E_CHANNEL_NAME: '${{ secrets.E2E_CHANNEL_NAME }}'
-      E2E_SLACK_TOKEN: '${{ secrets.E2E_SLACK_TOKEN }}'
-    steps:
-      # clone the repository
-      - uses: actions/checkout@v2
-      # enable dependencies caching
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: mysql
-          coverage: none
-      # run CI checks
-      - name: Install JS dependencies
-        run: npm ci
-      - name: Build assets
-        run: npm run build:assets
-      - name: Set up Docker
-        run: npm run e2e-docker:up
-      - name: Run tests
-        run: npm run test:e2e
-      - name: Clean up
-        if: ${{ always() }}
-        run: npm run e2e-docker:down && echo "In case of E2E test failures, screenshots can be found in the slack channel `#evergreen-github`"
-        
+    test:
+        name: E2E Tests
+        runs-on: ubuntu-16.04
+        strategy:
+            fail-fast: false
+            max-parallel: 10
+            matrix:
+                wp: ['5.6.2']
+                php: ['7.4']
+        env:
+            WP_VERSION: ${{ matrix.wp }}
+            PHP_VERSION: ${{ matrix.php }}
+            E2E_SLACKBOT_USER: 'Sensei e2e Reporter'
+            E2E_CHANNEL_NAME: '${{ secrets.E2E_CHANNEL_NAME }}'
+            E2E_SLACK_TOKEN: '${{ secrets.E2E_SLACK_TOKEN }}'
+        steps:
+            # clone the repository
+            - uses: actions/checkout@v2
+            # enable dependencies caching
+            - uses: actions/cache@v2
+              with:
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: mysql
+                  coverage: none
+            # run CI checks
+            - name: Install JS dependencies
+              run: npm ci
+            - name: Build assets
+              run: npm run build:assets
+            - name: Set up Docker
+              run: npm run e2e-docker:up
+            - name: Run tests
+              run: npm run test:e2e
+            - name: Clean up
+              if: ${{ always() }}
+              run: npm run e2e-docker:down && echo "In case of E2E test failures, screenshots can be found in the slack channel `#evergreen-github`"

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -1,40 +1,39 @@
 name: JS Linting and Tests
 
-on:
-  pull_request
+on: pull_request
 
 jobs:
-  lint:
-    name:    JS Linting
-    runs-on: ubuntu-16.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm/
-          key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
-      - uses: actions/cache@v2
-        with:
-          path: node_modules/
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
-      - name: Install JS dependencies
-        run: npm ci
-      - name: Lint JS
-        run: npm run lint-js
+    lint:
+        name: JS Linting
+        runs-on: ubuntu-16.04
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/cache@v2
+              with:
+                  path: ~/.npm/
+                  key: ${{ runner.os }}-npm-${{ hashFiles('package-lock.json') }}
+            - uses: actions/cache@v2
+              with:
+                  path: node_modules/
+                  key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+            - name: Install JS dependencies
+              run: npm ci
+            - name: Lint JS
+              run: npm run lint-js
 
-  test:
-    name:    JS Testing
-    runs-on: ubuntu-16.04
-    steps:
-      # clone the repository
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-node-
-      - name: Install JS dependencies
-        run: npm ci
-      - name: Test JS
-        run: npm run test-js
+    test:
+        name: JS Testing
+        runs-on: ubuntu-16.04
+        steps:
+            # clone the repository
+            - uses: actions/checkout@v2
+            - uses: actions/cache@v2
+              with:
+                  path: ~/.npm
+                  key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+                  restore-keys: |
+                      ${{ runner.os }}-node-
+            - name: Install JS dependencies
+              run: npm ci
+            - name: Test JS
+              run: npm run test-js

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,86 +1,85 @@
 name: PHP Linting and Tests
 
-on:
-  pull_request
+on: pull_request
 
 jobs:
-  lint:
-    name:    PHP Linting
-    runs-on: ubuntu-16.04
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/composer/
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v2
-        with:
-          path: vendor/
-          key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.3'
-          tools:       composer
-          coverage:    none
-      - name: Set up branches
-        run: git checkout -b master refs/remotes/origin/master && git checkout -
-      - name: Install PHP dependencies
-        run: composer self-update --1 && composer install --no-ansi --no-interaction --prefer-dist --no-progress
-      - name: Check for new issues
-        run: ./scripts/linter-ci
-      - name: Check for escaping
-        run: ./vendor/bin/phpcs -s --sniffs=WordPress.WP.I18n,Generic.PHP.Syntax,WordPress.Security.EscapeOutput .
-      - name: Check for nonces
-        run: ./vendor/bin/phpcs -sn --sniffs=WordPress.Security.NonceVerification .
-      - name: Check WPCOM rules
-        run: ./vendor/bin/phpcs -sn --standard=./wpcom-phpcs.xml .
-  test:
-    name: PHP Unit Tests
-    runs-on: ubuntu-16.04
-    strategy:
-      fail-fast: false
-      max-parallel: 10
-      matrix:
-        wp: [ 'latest' ]
-        wpmu: [ 0 ]
-        php: [ '7.2', '7.3', '7.4' ]
-        include:
-          - php: 7.3
-            wp: 5.4
-          - php: 7.3
-            wp: 5.5
-          - php: 7.3
-            wp: latest
-            wpmu: 1
-    env:
-      WP_VERSION: ${{ matrix.wp }}
-      WP_MULTISITE: ${{ matrix.wpmu }}
-      PHP_VERSION: ${{ matrix.php }}
-    steps:
-      # clone the repository
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: ~/.cache/composer/
-          key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
-      - uses: actions/cache@v2
-        with:
-          path: vendor/
-          key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: mysql
-          tools: composer
-          coverage: none
-      # run CI checks
-      - name: Start mysql service
-        run: sudo /etc/init.d/mysql start
-      - name: Install PHP dependencies
-        run: composer install --no-ansi --no-interaction --prefer-dist --no-progress
-      - name: Setup test environment
-        run: bash ./tests/bin/install-wp-tests.sh wordpress_test root root localhost $WP_VERSION
-      - name: Run tests
-        run: ./vendor/bin/phpunit
+    lint:
+        name: PHP Linting
+        runs-on: ubuntu-16.04
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+            - uses: actions/cache@v2
+              with:
+                  path: ~/.cache/composer/
+                  key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+            - uses: actions/cache@v2
+              with:
+                  path: vendor/
+                  key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '7.3'
+                  tools: composer
+                  coverage: none
+            - name: Set up branches
+              run: git checkout -b master refs/remotes/origin/master && git checkout -
+            - name: Install PHP dependencies
+              run: composer self-update --1 && composer install --no-ansi --no-interaction --prefer-dist --no-progress
+            - name: Check for new issues
+              run: ./scripts/linter-ci
+            - name: Check for escaping
+              run: ./vendor/bin/phpcs -s --sniffs=WordPress.WP.I18n,Generic.PHP.Syntax,WordPress.Security.EscapeOutput .
+            - name: Check for nonces
+              run: ./vendor/bin/phpcs -sn --sniffs=WordPress.Security.NonceVerification .
+            - name: Check WPCOM rules
+              run: ./vendor/bin/phpcs -sn --standard=./wpcom-phpcs.xml .
+    test:
+        name: PHP Unit Tests
+        runs-on: ubuntu-16.04
+        strategy:
+            fail-fast: false
+            max-parallel: 10
+            matrix:
+                wp: ['latest']
+                wpmu: [0]
+                php: ['7.2', '7.3', '7.4']
+                include:
+                    - php: 7.3
+                      wp: 5.4
+                    - php: 7.3
+                      wp: 5.5
+                    - php: 7.3
+                      wp: latest
+                      wpmu: 1
+        env:
+            WP_VERSION: ${{ matrix.wp }}
+            WP_MULTISITE: ${{ matrix.wpmu }}
+            PHP_VERSION: ${{ matrix.php }}
+        steps:
+            # clone the repository
+            - uses: actions/checkout@v2
+            - uses: actions/cache@v2
+              with:
+                  path: ~/.cache/composer/
+                  key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
+            - uses: actions/cache@v2
+              with:
+                  path: vendor/
+                  key: ${{ runner.os }}-vendor-${{ hashFiles('composer.lock') }}
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  extensions: mysql
+                  tools: composer
+                  coverage: none
+            # run CI checks
+            - name: Start mysql service
+              run: sudo /etc/init.d/mysql start
+            - name: Install PHP dependencies
+              run: composer install --no-ansi --no-interaction --prefer-dist --no-progress
+            - name: Setup test environment
+              run: bash ./tests/bin/install-wp-tests.sh wordpress_test root root localhost $WP_VERSION
+            - name: Run tests
+              run: ./vendor/bin/phpunit

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+assets/dist
+vendor
+*.min.js

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,3 +1,4 @@
 module.exports = {
 	...require( '@wordpress/prettier-config' ),
+	plugins: [ './scripts/prettier/jsdoc' ],
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,4 @@
 module.exports = {
 	...require( '@wordpress/prettier-config' ),
-	plugins: [ './scripts/prettier/jsdoc' ],
+	plugins: [ './scripts/prettier/prettier-plugin-jsdoc' ],
 };

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,21 +1,21 @@
 filter:
-  excluded_paths:
-  - tests/*
+    excluded_paths:
+        - tests/*
 
 checks:
-  php:
-    variable_existence: false
-    verify_access_scope_valid: false
-    verify_argument_usable_as_reference: false
-    verify_property_names: false
-    no_global_keyword: false
-    psr2_switch_declaration: false
-    psr2_control_structure_declaration: false
-    psr2_class_declaration: false
-    one_class_per_file: false
-    no_exit: false
-    avoid_superglobals: false
-    avoid_closing_tag: false
+    php:
+        variable_existence: false
+        verify_access_scope_valid: false
+        verify_argument_usable_as_reference: false
+        verify_property_names: false
+        no_global_keyword: false
+        psr2_switch_declaration: false
+        psr2_control_structure_declaration: false
+        psr2_class_declaration: false
+        one_class_per_file: false
+        no_exit: false
+        avoid_superglobals: false
+        avoid_closing_tag: false
 
 tools:
-  sensiolabs_security_checker: true
+    sensiolabs_security_checker: true

--- a/assets/js/admin/meta-box-quiz-editor.js
+++ b/assets/js/admin/meta-box-quiz-editor.js
@@ -342,7 +342,7 @@ jQuery( document ).ready( function () {
 	/**
 	 * Upload media file to questions
 	 *
-	 * @param object button Button that was clicked
+	 * @param {object} button Button that was clicked
 	 * @return void
 	 *
 	 * @since  1.5.0

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,17 +1,16 @@
 version: '3.3'
 
 services:
+    wordpress-www:
+        build:
+            context: ../../../tests/e2e/docker/wordpress
+            args:
+                WP_VERSION: '${WP_VERSION:-latest}'
+        volumes:
+            # This path is relative to the first config file
+            # which is in node_modules/@woocommerce/e2e/env
+            - '../../../:/var/www/html/wp-content/plugins/sensei'
 
-  wordpress-www:
-    build:
-      context: ../../../tests/e2e/docker/wordpress
-      args:
-        WP_VERSION: "${WP_VERSION:-latest}"
-    volumes:
-      # This path is relative to the first config file
-      # which is in node_modules/@woocommerce/e2e/env
-      - "../../../:/var/www/html/wp-content/plugins/sensei"
-
-  wordpress-cli:
-    volumes:
-      - "../../../:/var/www/html/wp-content/plugins/sensei"
+    wordpress-cli:
+        volumes:
+            - '../../../:/var/www/html/wp-content/plugins/sensei'

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "i18n:js": "npx babel --config-file ./babel.makepot.js -o ./lang/tmp-babel.log assets --ignore \"**/*.test.js\",\"./assets/dist\",\"./assets/vendor\",\"./build\"",
     "i18n:php": "wp i18n make-pot --merge=lang/tmp-sensei-lms-js.pot --skip-js --exclude=build --headers='{\"Last-Translator\":null,\"Language-Team\":null,\"Report-Msgid-Bugs-To\":\"https://wordpress.org/support/plugin/sensei-lms\"}' . lang/sensei-lms.pot",
     "i18n:build": "npm run build:assets && npm run i18n:clean && npm run i18n:js && npm run i18n:php && node ./scripts/pot-dist-references.js && npm run i18n:clean",
-    "format-js": "wp-scripts format",
+    "format": "wp-scripts format",
     "lint-css": "wp-scripts lint-style **/*.scss",
     "lint-css:fix": "npm run lint-css -- --fix",
     "lint-js": "wp-scripts lint-js --ext js,jsx assets",
@@ -118,7 +118,7 @@
       "npm run lint-pkg-json"
     ],
     "*.{js,jsx}": [
-      "npm run format-js",
+      "npm run format",
       "wp-scripts lint-js"
     ],
     "*.php": [

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "i18n:js": "npx babel --config-file ./babel.makepot.js -o ./lang/tmp-babel.log assets --ignore \"**/*.test.js\",\"./assets/dist\",\"./assets/vendor\",\"./build\"",
     "i18n:php": "wp i18n make-pot --merge=lang/tmp-sensei-lms-js.pot --skip-js --exclude=build --headers='{\"Last-Translator\":null,\"Language-Team\":null,\"Report-Msgid-Bugs-To\":\"https://wordpress.org/support/plugin/sensei-lms\"}' . lang/sensei-lms.pot",
     "i18n:build": "npm run build:assets && npm run i18n:clean && npm run i18n:js && npm run i18n:php && node ./scripts/pot-dist-references.js && npm run i18n:clean",
-    "format-js": "wp-scripts format-js",
+    "format-js": "wp-scripts format",
     "lint-css": "wp-scripts lint-style **/*.scss",
     "lint-css:fix": "npm run lint-css -- --fix",
     "lint-js": "wp-scripts lint-js --ext js,jsx assets",

--- a/scripts/prettier/jsdoc.js
+++ b/scripts/prettier/jsdoc.js
@@ -1,0 +1,72 @@
+const prettier = require( 'prettier' );
+const parserBabel = require( 'prettier/parser-babel' );
+const parserFlow = require( 'prettier/parser-flow' );
+const { parseComment } = require( '@es-joy/jsdoccomment' );
+
+// In the future this function should ideally be migrated to `comment-parser` dependency.
+const alignTransform = require( 'eslint-plugin-jsdoc/dist/alignTransform' );
+const {
+	stringify,
+	transforms: { flow },
+} = require( 'comment-parser' );
+
+const jsdocPrettierPlugin = {
+	languages: prettier
+		.getSupportInfo()
+		.languages.filter( ( { name } ) =>
+			[ 'JavaScript', 'JSX' ].includes( name )
+		),
+	parsers: {
+		get babel() {
+			return getParserWithJSDoc( parserBabel.parsers.babel );
+		},
+		get flow() {
+			return getParserWithJSDoc( parserFlow.parsers.flow );
+		},
+	},
+};
+
+const getParserWithJSDoc = ( parser ) => ( {
+	...parser,
+	parse: ( text, parsers, options ) => {
+		const ast = parser.parse( text, parsers, options );
+
+		ast.comments.forEach( ( comment ) => {
+			if ( 'CommentBlock' !== comment.type && 'Block' !== comment.type ) {
+				return;
+			}
+
+			if (
+				! comment.value.match( /\n/ ) ||
+				! comment.value.match( /^\*/ ) ||
+				comment.value.match( /^\*\*/ )
+			) {
+				return;
+			}
+
+			const indent = ''.padStart( comment.start, '\t' ); // Indentation fixed as tabs for now.
+			const parsed = parseComment( comment, indent );
+
+			const transform = flow(
+				// If it's converted to a dynamic plugin sometime, this configuration should be an option.
+				alignTransform( {
+					indent,
+					tags: [ 'param', 'arg', 'argument', 'property', 'prop' ],
+					preserveMainDescriptionPostDelimiter: true,
+				} )
+			);
+
+			const transformedJsdoc = transform( parsed );
+			const formatted = stringify( transformedJsdoc )
+				.trimStart()
+				.replace( /^\/\*/, '' )
+				.replace( /\*\/$/, '' );
+
+			comment.value = formatted;
+		} );
+
+		return ast;
+	},
+} );
+
+module.exports = jsdocPrettierPlugin;

--- a/scripts/prettier/prettier-plugin-jsdoc.js
+++ b/scripts/prettier/prettier-plugin-jsdoc.js
@@ -10,7 +10,7 @@ const {
 	transforms: { flow },
 } = require( 'comment-parser' );
 
-const jsdocPrettierPlugin = {
+const prettierPluginJsdoc = {
 	languages: prettier
 		.getSupportInfo()
 		.languages.filter( ( { name } ) =>
@@ -69,4 +69,4 @@ const getParserWithJSDoc = ( parser ) => ( {
 	},
 } );
 
-module.exports = jsdocPrettierPlugin;
+module.exports = prettierPluginJsdoc;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It introduces a plugin for prettier to align JSDoc automatically. It matches the eslint rules.
* It also fixes YAML files based on Gutenberg format. The [format script started prettifying it](https://github.com/renatho/gutenberg/commit/06fd22e0f5922db0cd4ca1ae87b31887817a2f0b).

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Change a JSDoc to be misaligned, and run `npm run format`.
* Make sure it's now aligned.
* You can also [set up your editor](https://prettier.io/docs/en/editors.html) to run it automatically on file save as the video in this PR.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/125121450-55a7ad80-e0ca-11eb-8c9d-0a7e4aa13c5c.mov

