### PR TITLE
Don't set minimum width for course progress bar on front end

### DIFF
--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -214,11 +214,11 @@ $courses-list: '#{$block}__courses-list';
 	&__bar {
 		height: var(--sensei-progress-bar-height, 14px);
 		border-radius: var(--sensei-progress-bar-border-radius, 10px);
+		overflow: hidden;
 
 		div {
 			background-color: currentColor;
 			background-color: var(--sensei-accent-color, currentColor);
-			border-radius: var(--sensei-progress-bar-border-radius, 10px);
 		}
 	}
 }

--- a/assets/shared/blocks/course-progress/course-progress.scss
+++ b/assets/shared/blocks/course-progress/course-progress.scss
@@ -14,10 +14,10 @@
 		height: 14px;
 		border-radius: 10px;
 		background-color: #E6E6E6;
+		overflow: hidden;
 
 		div {
 			height: 100%;
-			border-radius: 10px;
 			background-color: #0064B4;
 		}
 	}

--- a/includes/blocks/class-sensei-course-progress-block.php
+++ b/includes/blocks/class-sensei-course-progress-block.php
@@ -68,7 +68,7 @@ class Sensei_Course_Progress_Block {
 			]
 		);
 
-		$bar_css                    = Sensei_Block_Helpers::build_styles(
+		$bar_css = Sensei_Block_Helpers::build_styles(
 			$attributes,
 			[
 				'textColor' => null,
@@ -76,7 +76,8 @@ class Sensei_Course_Progress_Block {
 			],
 			[ 'borderRadius' => 'border-radius' ]
 		);
-		$bar_css['inline_styles'][] = 'width: ' . ( 3 > $percentage ? 3 : $percentage ) . '%';
+
+		$bar_css['inline_styles'][] = 'width: ' . $percentage . '%';
 
 		// translators: Placeholder %d is the lesson count.
 		$lessons_text = sprintf( _n( '%d Lesson', '%d Lessons', $total_lessons, 'sensei-lms' ), $total_lessons );

--- a/includes/blocks/class-sensei-course-progress-block.php
+++ b/includes/blocks/class-sensei-course-progress-block.php
@@ -73,8 +73,7 @@ class Sensei_Course_Progress_Block {
 			[
 				'textColor' => null,
 				'barColor'  => 'background-color',
-			],
-			[ 'borderRadius' => 'border-radius' ]
+			]
 		);
 
 		$bar_css['inline_styles'][] = 'width: ' . $percentage . '%';


### PR DESCRIPTION
Fixes #4181.

### Changes proposed in this Pull Request
As near as I can tell, the border radius isn't working in some circumstances because there is not enough room to fully render the corner. These circumstances are dependent on both the height and width of the bar. 

The simplest solution is to not set a default minimum width for the progress bar on the front end. A minimum width is still required in the editor in order to visualize any changes to the progress bar's colour.

### Testing instructions
1. Add the Learner Courses block to a page.
2. Set the border radius and height of the progress bar to their maximum values.
3. View the page and ensure that courses that have no completed lessons don't have any part of the progress bar filled in, and that there are no issues rendering the left side of the bar.
4. Add the Course Progress block to a course.
5. Repeat steps 2 and 3.

### Screenshot
![Screen Shot 2021-07-13 at 3 18 10 PM](https://user-images.githubusercontent.com/1190420/125512021-11b80319-6d25-4ce9-8062-cb6e36dfe15d.jpg)