### PR TITLE
Add panel for Course Access Period

### DIFF
--- a/assets/blocks/course-expiration/expiry-meta-fields.js
+++ b/assets/blocks/course-expiration/expiry-meta-fields.js
@@ -1,0 +1,3 @@
+export const EXPIRY_TYPE = '_course_expiry_type';
+export const EXPIRY_LENGTH = '_course_expiry_length';
+export const EXPIRY_PERIOD = '_course_expiry_period';

--- a/assets/blocks/course-expiration/expiry-period.js
+++ b/assets/blocks/course-expiration/expiry-period.js
@@ -1,0 +1,3 @@
+export const MONTH = 'month';
+export const WEEK = 'week';
+export const DAY = 'day';

--- a/assets/blocks/course-expiration/expiry-types.js
+++ b/assets/blocks/course-expiration/expiry-types.js
@@ -1,0 +1,2 @@
+export const NO_EXPIRATION = 'no-expiration';
+export const EXPIRES_AFTER = 'expires-after';

--- a/assets/blocks/course-expiration/index.js
+++ b/assets/blocks/course-expiration/index.js
@@ -1,0 +1,16 @@
+/**
+ * WordPress dependencies
+ */
+import { registerPlugin } from '@wordpress/plugins';
+
+/**
+ * Internal dependencies
+ */
+import SettingsPanel from './settings-panel';
+
+if ( window.sensei_feature_flag_course_expiration ) {
+	registerPlugin( 'plugin-document-setting-panel-demo', {
+		render: SettingsPanel,
+		icon: 'clock',
+	} );
+}

--- a/assets/blocks/course-expiration/index.js
+++ b/assets/blocks/course-expiration/index.js
@@ -8,7 +8,7 @@ import { registerPlugin } from '@wordpress/plugins';
  */
 import SettingsPanel from './settings-panel';
 
-if ( window.sensei_feature_flag_course_expiration ) {
+if ( window.sensei_single_course_blocks.feature_flag_course_expiration ) {
 	registerPlugin( 'plugin-document-setting-panel-demo', {
 		render: SettingsPanel,
 		icon: 'clock',

--- a/assets/blocks/course-expiration/settings-panel.js
+++ b/assets/blocks/course-expiration/settings-panel.js
@@ -3,29 +3,66 @@
  */
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
 import { RadioControl, SelectControl } from '@wordpress/components';
+import { useEntityProp } from '@wordpress/core-data';
 
 /**
  * Internal dependencies
  */
+import {
+	EXPIRY_TYPE,
+	EXPIRY_LENGTH,
+	EXPIRY_PERIOD,
+} from './expiry-meta-fields';
 import { NO_EXPIRATION, EXPIRES_AFTER } from './expiry-types';
 import { MONTH, WEEK, DAY } from './expiry-period';
 import NumberControl from '../editor-components/number-control';
 
+/**
+ * A hook that provides a value from course meta and a setter for that value.
+ *
+ * @param {string} metaName     The name of the meta.
+ * @param {*}      defaultValue The default value of the meta.
+ * @return {Array} An array containing the value and the setter.
+ */
+const useCourseMeta = ( metaName, defaultValue ) => {
+	const [ meta, setMeta ] = useEntityProp( 'postType', 'course', 'meta' );
+
+	const value = meta[ metaName ];
+	const setter = ( newValue ) =>
+		setMeta( { ...meta, [ metaName ]: newValue } );
+
+	if ( ! value ) {
+		setter( defaultValue );
+	}
+
+	return [ value, setter ];
+};
+
 const SettingsPanel = () => {
-	const [ expiryType, setExpiryType ] = useState( NO_EXPIRATION );
-	const [ expiresAfterNumber, setExpiresAfterNumber ] = useState( 1 );
-	const [ expiresAfterPeriod, setExpiresAfterPeriod ] = useState( MONTH );
+	const [ expiryType, onExpiryTypeChange ] = useCourseMeta(
+		EXPIRY_TYPE,
+		NO_EXPIRATION
+	);
+
+	const [ expiryLength, onExpiryLengthChange ] = useCourseMeta(
+		EXPIRY_LENGTH,
+		1
+	);
+
+	const [ expiryPeriod, onExpiryPeriodChange ] = useCourseMeta(
+		EXPIRY_PERIOD,
+		MONTH
+	);
 
 	const expireAfterForm = (
 		<>
 			<NumberControl
-				value={ expiresAfterNumber }
-				onChange={ ( value ) => setExpiresAfterNumber( value ) }
+				value={ expiryLength }
+				onChange={ onExpiryLengthChange }
 			/>
 			<SelectControl
-				value={ expiresAfterPeriod }
+				value={ expiryPeriod }
 				options={ [
 					{
 						label: __( 'Month(s)', 'sensei-lms' ),
@@ -40,7 +77,7 @@ const SettingsPanel = () => {
 						value: DAY,
 					},
 				] }
-				onChange={ ( value ) => setExpiresAfterPeriod( value ) }
+				onChange={ onExpiryPeriodChange }
 			/>
 		</>
 	);
@@ -63,7 +100,7 @@ const SettingsPanel = () => {
 						value: EXPIRES_AFTER,
 					},
 				] }
-				onChange={ ( value ) => setExpiryType( value ) }
+				onChange={ onExpiryTypeChange }
 			/>
 
 			{ EXPIRES_AFTER === expiryType ? expireAfterForm : '' }

--- a/assets/blocks/course-expiration/settings-panel.js
+++ b/assets/blocks/course-expiration/settings-panel.js
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { __ } from '@wordpress/i18n';
+import { useState } from '@wordpress/element';
+import { RadioControl, SelectControl } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { NO_EXPIRATION, EXPIRES_AFTER } from './expiry-types';
+import { MONTH, WEEK, DAY } from './expiry-period';
+import NumberControl from '../editor-components/number-control';
+
+const SettingsPanel = () => {
+	const [ expiryType, setExpiryType ] = useState( NO_EXPIRATION );
+	const [ expiresAfterNumber, setExpiresAfterNumber ] = useState( 1 );
+	const [ expiresAfterPeriod, setExpiresAfterPeriod ] = useState( MONTH );
+
+	const expireAfterForm = (
+		<>
+			<NumberControl
+				value={ expiresAfterNumber }
+				onChange={ ( value ) => setExpiresAfterNumber( value ) }
+			/>
+			<SelectControl
+				value={ expiresAfterPeriod }
+				options={ [
+					{
+						label: __( 'Month(s)', 'sensei-lms' ),
+						value: MONTH,
+					},
+					{
+						label: __( 'Week(s)', 'sensei-lms' ),
+						value: WEEK,
+					},
+					{
+						label: __( 'Day(s)', 'sensei-lms' ),
+						value: DAY,
+					},
+				] }
+				onChange={ ( value ) => setExpiresAfterPeriod( value ) }
+			/>
+		</>
+	);
+
+	return (
+		<PluginDocumentSettingPanel
+			name="course-access-period"
+			title="Course Access Period"
+			className="course-access-period"
+		>
+			<RadioControl
+				selected={ expiryType }
+				options={ [
+					{
+						label: __( 'No Expiration', 'sensei-lms' ),
+						value: NO_EXPIRATION,
+					},
+					{
+						label: __( 'Expires after', 'sensei-lms' ),
+						value: EXPIRES_AFTER,
+					},
+				] }
+				onChange={ ( value ) => setExpiryType( value ) }
+			/>
+
+			{ EXPIRES_AFTER === expiryType ? expireAfterForm : '' }
+		</PluginDocumentSettingPanel>
+	);
+};
+
+export default SettingsPanel;

--- a/assets/blocks/single-course.js
+++ b/assets/blocks/single-course.js
@@ -7,6 +7,7 @@ import CourseProgressBlock from './course-progress-block';
 import { OutlineBlock, LessonBlock, ModuleBlock } from './course-outline';
 import ConditionalContentBlock from './conditional-content-block';
 import ViewResults from './view-results-block';
+import './course-expiration';
 
 registerSenseiBlocks( [
 	OutlineBlock,

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -126,6 +126,14 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 			Sensei()->assets->preload_data( [ sprintf( '/sensei-internal/v1/course-structure/%d?context=edit', $post->ID ) ] );
 		}
 
+		// Feature flag for Course Expiration.
+		wp_localize_script(
+			'sensei-single-course-blocks',
+			'sensei_single_course_blocks',
+			[
+				'feature_flag_course_expiration' => Sensei()->feature_flags->is_enabled( 'course_expiration' ),
+			]
+		);
 	}
 
 	/**

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -32,6 +32,7 @@ class Sensei_Feature_Flags {
 				'rest_api_v1'                  => false,
 				'rest_api_v1_skip_permissions' => false,
 				'enrolment_provider_tooltip'   => false,
+				'course_expiration'            => false,
 			]
 		);
 	}


### PR DESCRIPTION

### Changes proposed in this Pull Request

Add panel to set the "Course Access Period" in the sidebar of the Course Editor. The setting should save properly, but doesn't do anything yet.

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_expiration', '__return_true' );`
* Create a Course and open it in the block editor.
* Open the "Course Access Period" panel in the "Course" sidebar.
* Try various settings for the expiration. Ensure that it saves and reloads when the editor is refreshed.

### To-do

- [ ] Set up the REST API so the values persist.
- [ ] Tweak the CSS.
- [ ] Write some tests.