### PR TITLE
Add course completion page

### DIFF
--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -65,8 +65,8 @@ class Sensei_Setup_Wizard_Pages {
 		Sensei()->settings->set( 'my_course_page', $new_my_course_page_id );
 
 		// Course Completion Page.
-		$new_course_completion_page_id = $this->create_page( esc_sql( _x( 'course-completion', 'page_slug', 'sensei-lms' ) ), __( 'Course Completion', 'sensei-lms' ) );
-		Sensei()->settings->set( 'course_completion_page', $new_course_completion_page_id );
+		$new_course_completed_page_id = $this->create_page( esc_sql( _x( 'course-completed', 'page_slug', 'sensei-lms' ) ), __( 'Course Completed', 'sensei-lms' ) );
+		Sensei()->settings->set( 'course_completed_page', $new_course_completed_page_id );
 
 		Sensei()->initiate_rewrite_rules_flush();
 	}

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -52,10 +52,7 @@ class Sensei_Setup_Wizard_Pages {
 	}
 
 	/**
-	 * Create Courses and My Courses pages.
-	 * Updates Sensei settings Course page nad My Courses options.
-	 *
-	 * @return void
+	 * Create Sensei pages and update settings.
 	 */
 	public function create_pages() {
 
@@ -66,6 +63,10 @@ class Sensei_Setup_Wizard_Pages {
 		// My Courses page.
 		$new_my_course_page_id = $this->create_page( esc_sql( _x( 'my-courses', 'page_slug', 'sensei-lms' ) ), __( 'My Courses', 'sensei-lms' ), $this->get_learner_courses_page_content() );
 		Sensei()->settings->set( 'my_course_page', $new_my_course_page_id );
+
+		// Course Completion Page.
+		$new_course_completion_page_id = $this->create_page( esc_sql( _x( 'course-completion', 'page_slug', 'sensei-lms' ) ), __( 'Course Completion', 'sensei-lms' ) );
+		Sensei()->settings->set( 'course_completion_page', $new_course_completion_page_id );
 
 		Sensei()->initiate_rewrite_rules_flush();
 	}

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -64,9 +64,11 @@ class Sensei_Setup_Wizard_Pages {
 		$new_my_course_page_id = $this->create_page( esc_sql( _x( 'my-courses', 'page_slug', 'sensei-lms' ) ), __( 'My Courses', 'sensei-lms' ), $this->get_learner_courses_page_content() );
 		Sensei()->settings->set( 'my_course_page', $new_my_course_page_id );
 
-		// Course Completion Page.
-		$new_course_completed_page_id = $this->create_page( esc_sql( _x( 'course-completed', 'page_slug', 'sensei-lms' ) ), __( 'Course Completed', 'sensei-lms' ) );
-		Sensei()->settings->set( 'course_completed_page', $new_course_completed_page_id );
+		if ( Sensei()->feature_flags->is_enabled( 'course_completed_page' ) ) {
+			// Course Completion Page.
+			$new_course_completed_page_id = $this->create_page( esc_sql( _x( 'course-completed', 'page_slug', 'sensei-lms' ) ), __( 'Course Completed', 'sensei-lms' ) );
+			Sensei()->settings->set( 'course_completed_page', $new_course_completed_page_id );
+		}
 
 		Sensei()->initiate_rewrite_rules_flush();
 	}

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -77,6 +77,7 @@ class Sensei_Data_Cleaner {
 		'sensei_courses_page_id',
 		'woothemes-sensei_courses_page_id',
 		'woothemes-sensei_user_dashboard_page_id',
+		'woothemes-sensei_course_completed_page_id',
 		'sensei-legacy-flags',
 		'sensei-scheduler-calculation-version',
 		'widget_sensei_course_component',

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -32,6 +32,7 @@ class Sensei_Feature_Flags {
 				'rest_api_v1'                  => false,
 				'rest_api_v1_skip_permissions' => false,
 				'enrolment_provider_tooltip'   => false,
+				'course_completed_page'        => false,
 			]
 		);
 	}

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -787,6 +787,10 @@ class Sensei_Frontend {
 			return;
 		}
 
+		if ( ! isset( Sensei()->settings->settings['course_completed_page'] ) ) {
+			return;
+		}
+
 		$page_id = intval( Sensei()->settings->settings['course_completed_page'] );
 		$url     = get_permalink( $page_id );
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -67,6 +67,7 @@ class Sensei_Frontend {
 		add_action( 'sensei_lesson_archive_lesson_title', array( $this, 'sensei_lesson_archive_lesson_title' ), 10 );
 		add_action( 'wp', array( $this, 'sensei_complete_lesson' ), 10 );
 		add_action( 'wp_head', array( $this, 'sensei_complete_course' ), 10 );
+		add_action( 'sensei_course_status_updated', array( $this, 'redirect_to_course_completion_page' ) );
 		add_action( 'sensei_frontend_messages', array( $this, 'sensei_frontend_messages' ) );
 		add_action( 'sensei_lesson_video', array( $this, 'sensei_lesson_video' ), 10, 1 );
 		add_action( 'sensei_complete_lesson_button', array( $this, 'sensei_complete_lesson_button' ) );
@@ -769,6 +770,30 @@ class Sensei_Frontend {
 
 		if ( $redirect_url ) {
 			wp_safe_redirect( esc_url_raw( $redirect_url ) );
+			exit;
+		}
+	}
+
+	/**
+	 * Redirect to the course completion page, if applicable.
+	 *
+	 * @since 3.13.0
+	 * @access private
+	 *
+	 * @param string $status    Course status.
+	 * @param int    $user_id   User ID.
+	 * @param int    $course_id Course ID.
+	 */
+	public function redirect_to_course_completion_page( $status ) {
+		if ( 'complete' !== $status ) {
+			return;
+		}
+
+		$page_id = intval( Sensei()->settings->settings['course_completion_page'] );
+		$url     = get_permalink( $page_id );
+
+		if ( $url ) {
+			wp_safe_redirect( esc_url_raw( $url ) );
 			exit;
 		}
 	}

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -781,8 +781,6 @@ class Sensei_Frontend {
 	 * @access private
 	 *
 	 * @param string $status    Course status.
-	 * @param int    $user_id   User ID.
-	 * @param int    $course_id Course ID.
 	 */
 	public function redirect_to_course_completion_page( $status ) {
 		if ( 'complete' !== $status ) {

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -67,7 +67,7 @@ class Sensei_Frontend {
 		add_action( 'sensei_lesson_archive_lesson_title', array( $this, 'sensei_lesson_archive_lesson_title' ), 10 );
 		add_action( 'wp', array( $this, 'sensei_complete_lesson' ), 10 );
 		add_action( 'wp_head', array( $this, 'sensei_complete_course' ), 10 );
-		add_action( 'sensei_course_status_updated', array( $this, 'redirect_to_course_completion_page' ) );
+		add_action( 'sensei_course_status_updated', array( $this, 'redirect_to_course_completed_page' ) );
 		add_action( 'sensei_frontend_messages', array( $this, 'sensei_frontend_messages' ) );
 		add_action( 'sensei_lesson_video', array( $this, 'sensei_lesson_video' ), 10, 1 );
 		add_action( 'sensei_complete_lesson_button', array( $this, 'sensei_complete_lesson_button' ) );
@@ -775,19 +775,19 @@ class Sensei_Frontend {
 	}
 
 	/**
-	 * Redirect to the course completion page, if applicable.
+	 * Redirect to the course completed page, if applicable.
 	 *
 	 * @since 3.13.0
 	 * @access private
 	 *
 	 * @param string $status    Course status.
 	 */
-	public function redirect_to_course_completion_page( $status ) {
+	public function redirect_to_course_completed_page( $status ) {
 		if ( 'complete' !== $status ) {
 			return;
 		}
 
-		$page_id = intval( Sensei()->settings->settings['course_completion_page'] );
+		$page_id = intval( Sensei()->settings->settings['course_completed_page'] );
 		$url     = get_permalink( $page_id );
 
 		if ( $url ) {

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -35,7 +35,7 @@ class Sensei_Quiz {
 		add_action( 'template_redirect', array( $this, 'reset_button_click_listener' ) );
 
 		// Fire the complete quiz button submit for grading action.
-		add_action( 'sensei_single_quiz_content_inside_before', array( $this, 'user_quiz_submit_listener' ) );
+		add_action( 'template_redirect', array( $this, 'user_quiz_submit_listener' ) );
 
 		// Fire the save user answers quiz button click responder.
 		add_action( 'sensei_single_quiz_content_inside_before', array( $this, 'user_save_quiz_answers_listener' ) );

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -243,11 +243,11 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'options'     => $pages_array,
 		);
 
-		$fields['course_completion_page'] = array(
-			'name'        => __( 'Course Completion Page', 'sensei-lms' ),
+		$fields['course_completed_page'] = array(
+			'name'        => __( 'Course Completed Page', 'sensei-lms' ),
 			'description' => __( 'The page that is displayed after a learner completes a course.', 'sensei-lms' ),
 			'type'        => 'select',
-			'default'     => get_option( 'woothemes-sensei_course_completion_page_id', 0 ),
+			'default'     => get_option( 'woothemes-sensei_course_completed_page_id', 0 ),
 			'section'     => 'default-settings',
 			'required'    => 0,
 			'options'     => $pages_array,

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -243,15 +243,17 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'options'     => $pages_array,
 		);
 
-		$fields['course_completed_page'] = array(
-			'name'        => __( 'Course Completed Page', 'sensei-lms' ),
-			'description' => __( 'The page that is displayed after a learner completes a course.', 'sensei-lms' ),
-			'type'        => 'select',
-			'default'     => get_option( 'woothemes-sensei_course_completed_page_id', 0 ),
-			'section'     => 'default-settings',
-			'required'    => 0,
-			'options'     => $pages_array,
-		);
+		if ( Sensei()->feature_flags->is_enabled( 'course_completed_page' ) ) {
+			$fields['course_completed_page'] = array(
+				'name'        => __( 'Course Completed Page', 'sensei-lms' ),
+				'description' => __( 'The page that is displayed after a learner completes a course.', 'sensei-lms' ),
+				'type'        => 'select',
+				'default'     => get_option( 'woothemes-sensei_course_completed_page_id', 0 ),
+				'section'     => 'default-settings',
+				'required'    => 0,
+				'options'     => $pages_array,
+			);
+		}
 
 		$fields['placeholder_images_enable'] = array(
 			'name'        => __( 'Use placeholder images', 'sensei-lms' ),

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -243,6 +243,16 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'options'     => $pages_array,
 		);
 
+		$fields['course_completion_page'] = array(
+			'name'        => __( 'Course Completion Page', 'sensei-lms' ),
+			'description' => __( 'The page that is displayed after a learner completes a course.', 'sensei-lms' ),
+			'type'        => 'select',
+			'default'     => get_option( 'woothemes-sensei_course_completion_page_id', 0 ),
+			'section'     => 'default-settings',
+			'required'    => 0,
+			'options'     => $pages_array,
+		);
+
 		$fields['placeholder_images_enable'] = array(
 			'name'        => __( 'Use placeholder images', 'sensei-lms' ),
 			'description' => __( 'Output a placeholder image when no featured image has been specified for Courses and Lessons.', 'sensei-lms' ),

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
@@ -143,13 +143,13 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 
 		$this->request( 'POST', 'welcome', [ 'usage_tracking' => false ] );
 
-		$courses_page           = get_page_by_path( 'courses-overview' );
-		$my_courses_page        = get_page_by_path( 'my-courses' );
-		$course_completion_page = get_page_by_path( 'course-completion' );
+		$courses_page          = get_page_by_path( 'courses-overview' );
+		$my_courses_page       = get_page_by_path( 'my-courses' );
+		$course_completed_page = get_page_by_path( 'course-completed' );
 
 		$this->assertNotNull( $courses_page, 'Course archive page' );
 		$this->assertNotNull( $my_courses_page, 'My Courses page' );
-		$this->assertNotNull( $course_completion_page, 'Course completion page' );
+		$this->assertNotNull( $course_completed_page, 'Course completed page' );
 	}
 
 	/**

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
@@ -54,6 +54,8 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 
 		// Prevent requests.
 		add_filter( 'pre_http_request', '__return_empty_array' );
+
+		add_filter( 'sensei_feature_flag_course_completed_page', '__return_true' );
 	}
 
 	/**
@@ -67,6 +69,8 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 
 		// Restore Usage tracking option.
 		Sensei()->usage_tracking->set_tracking_enabled( true );
+
+		remove_filter( 'sensei_feature_flag_course_completed_page', '__return_true' );
 	}
 
 	/**

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
@@ -143,8 +143,8 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 
 		$this->request( 'POST', 'welcome', [ 'usage_tracking' => false ] );
 
-		$courses_page    = get_page_by_path( 'courses-overview' );
-		$my_courses_page = get_page_by_path( 'my-courses' );
+		$courses_page           = get_page_by_path( 'courses-overview' );
+		$my_courses_page        = get_page_by_path( 'my-courses' );
 		$course_completion_page = get_page_by_path( 'course-completion' );
 
 		$this->assertNotNull( $courses_page, 'Course archive page' );

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
@@ -145,9 +145,11 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 
 		$courses_page    = get_page_by_path( 'courses-overview' );
 		$my_courses_page = get_page_by_path( 'my-courses' );
+		$course_completion_page = get_page_by_path( 'course-completion' );
 
-		$this->assertNotNull( $courses_page );
-		$this->assertNotNull( $my_courses_page );
+		$this->assertNotNull( $courses_page, 'Course archive page' );
+		$this->assertNotNull( $my_courses_page, 'My Courses page' );
+		$this->assertNotNull( $course_completion_page, 'Course completion page' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds a new _Course Completion Page_ setting.
* Creates this page (currently blank) in the setup wizard.
* Redirects to this page when the course is complete.

~~Note that I did not add a feature flag for this as I think it will ship before course expiration. However, if that turns out not to be the case, I will eat crow and go back and add it.~~

### Testing instructions
1. Add `define( 'SENSEI_FEATURE_FLAG_COURSE_COMPLETED_PAGE', true );` to `wp-config.php`.
2. Step through the setup wizard.
3. Check that an empty page titled _Course Completion_ was created and that it's set as the value in the _Course Completion Page_ setting.
4. Register for a course and complete all lessons in order.
5. After clicking the _Complete Lesson_ button on the last lesson, you should be automatically taken to the Course Completion page.
6. Reset your course progress and complete all lessons, this time out of order.
7. After clicking the _Complete Lesson_ button on the last incomplete lesson, you should be automatically taken to the Course Completion page.
8. Add a quiz with a multiple choice question to one of the lessons and set it to auto-grade.
9. Complete the quiz as the last task for that course, and ensure you're taken to the Course Completion page.
10. Clear the _Course Completion Page_ setting.
11. Reset your course progress and complete all lessons.
12. After clicking the _Complete Lesson_ button on the last lesson, ensure you stay on the current page.