### PR TITLE
Add course results block

### DIFF
--- a/assets/blocks/course-results-block/block.json
+++ b/assets/blocks/course-results-block/block.json
@@ -31,6 +31,18 @@
 		},
 		"customBorderColor": {
 			"type": "string"
+		},
+		"borderColorValue": {
+			"type": "string"
+		},
+		"defaultMainColor": {
+			"type": "string"
+		},
+		"defaultTextColor": {
+			"type": "string"
+		},
+		"defaultBorderColor": {
+			"type": "string"
 		}
 	}
 }

--- a/assets/blocks/course-results-block/block.json
+++ b/assets/blocks/course-results-block/block.json
@@ -1,0 +1,36 @@
+{
+	"name": "sensei-lms/course-results",
+	"category": "sensei-lms",
+	"supports": {
+		"html": false,
+		"multiple": false,
+		"defaultStylePicker": false
+	},
+	"attributes": {
+		"id": {
+			"type": "integer"
+		},
+		"moduleBorder": {
+			"type": "boolean",
+			"default": true
+		},
+		"mainColor": {
+			"type": "string"
+		},
+		"textColor": {
+			"type": "string"
+		},
+		"borderColor": {
+			"type": "string"
+		},
+		"customMainColor": {
+			"type": "string"
+		},
+		"customTextColor": {
+			"type": "string"
+		},
+		"customBorderColor": {
+			"type": "string"
+		}
+	}
+}

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -26,26 +26,20 @@ import { sprintf, __ } from '@wordpress/i18n';
  * @param {Object} props              Component props.
  * @param {Array}  props.lessonNumber The lesson number to use in the sample title.
  */
-const SampleLesson = ( props ) => {
-	const { lessonNumber } = props;
-
-	const lessonName = sprintf(
-		/* translators: Mock lesson number. */
-		__( 'Lesson %s', 'sensei-lms' ),
-		lessonNumber
-	);
-
-	return (
-		<div className="wp-block-sensei-lms-course-results__lesson">
-			<span className="wp-block-sensei-lms-course-results__lesson__title">
-				{ lessonName }
-			</span>
-			<span className="wp-block-sensei-lms-course-results__lesson__score">
-				xx%
-			</span>
-		</div>
-	);
-};
+const SampleLesson = ( { lessonNumber } ) => (
+	<div className="wp-block-sensei-lms-course-results__lesson">
+		<span className="wp-block-sensei-lms-course-results__lesson__title">
+			{ sprintf(
+				/* translators: Mock lesson number. */
+				__( 'Lesson %s', 'sensei-lms' ),
+				lessonNumber
+			) }
+		</span>
+		<span className="wp-block-sensei-lms-course-results__lesson__score">
+			xx%
+		</span>
+	</div>
+);
 
 /**
  * Sample module component.
@@ -56,34 +50,27 @@ const SampleLesson = ( props ) => {
  * @param {string}  props.style         The style selected for the results block.
  * @param {boolean} props.moduleBorder  If modules have borders.
  */
-const SampleModule = ( props ) => {
-	const { moduleName, lessonNumbers, style, moduleBorder } = props;
+const SampleModule = ( { moduleName, lessonNumbers, style, moduleBorder } ) => (
+	<section
+		className={ classnames( 'wp-block-sensei-lms-course-results__module', {
+			'wp-block-sensei-lms-course-results__module__bordered': moduleBorder,
+		} ) }
+	>
+		<header className="wp-block-sensei-lms-course-results__module__header">
+			<h2 className="wp-block-sensei-lms-course-results__module__title">
+				{ moduleName }
+			</h2>
+		</header>
 
-	return (
-		<section
-			className={ classnames(
-				'wp-block-sensei-lms-course-results__module',
-				{
-					'wp-block-sensei-lms-course-results__module__bordered': moduleBorder,
-				}
-			) }
-		>
-			<header className="wp-block-sensei-lms-course-results__module__header">
-				<h2 className="wp-block-sensei-lms-course-results__module__title">
-					{ moduleName }
-				</h2>
-			</header>
+		{ 'minimal' === style && (
+			<div className="wp-block-sensei-lms-course-results__module__separator" />
+		) }
 
-			{ 'minimal' === style && (
-				<div className="wp-block-sensei-lms-course-results__module__separator" />
-			) }
-
-			{ lessonNumbers.map( ( lessonNumber, index ) => (
-				<SampleLesson key={ index } lessonNumber={ lessonNumber } />
-			) ) }
-		</section>
-	);
-};
+		{ lessonNumbers.map( ( lessonNumber, index ) => (
+			<SampleLesson key={ index } lessonNumber={ lessonNumber } />
+		) ) }
+	</section>
+);
 
 /**
  * Edit course results block component.

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -12,7 +12,6 @@ import {
 	withDefaultColor,
 	withDefaultBlockStyle,
 } from '../../shared/blocks/settings';
-import { useCallback } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
 
@@ -20,6 +19,56 @@ import { sprintf, __ } from '@wordpress/i18n';
  * External dependencies
  */
 import classnames from 'classnames';
+
+const SampleLesson = ( props ) => {
+	const { lessonNumber } = props;
+
+	const lessonName = sprintf(
+		/* translators: Mock lesson number. */
+		__( 'Lesson %s', 'sensei-lms' ),
+		lessonNumber
+	);
+
+	return (
+		<div className="wp-block-sensei-lms-course-results__lesson">
+			<span className="wp-block-sensei-lms-course-results__lesson__title">
+				{ lessonName }
+			</span>
+			<span className="wp-block-sensei-lms-course-results__lesson__score">
+				xx%
+			</span>
+		</div>
+	);
+};
+
+const SampleModule = ( props ) => {
+	const { moduleName, lessonNumbers, style, moduleBorder } = props;
+
+	return (
+		<section
+			className={ classnames(
+				'wp-block-sensei-lms-course-results__module',
+				{
+					'wp-block-sensei-lms-course-results__module__bordered': moduleBorder,
+				}
+			) }
+		>
+			<header className="wp-block-sensei-lms-course-results__module__header">
+				<h2 className="wp-block-sensei-lms-course-results__module__title">
+					{ moduleName }
+				</h2>
+			</header>
+
+			{ 'minimal' === style && (
+				<div className="wp-block-sensei-lms-course-results__module__separator" />
+			) }
+
+			{ lessonNumbers.map( ( lessonNumber, index ) => (
+				<SampleLesson key={ index } lessonNumber={ lessonNumber } />
+			) ) }
+		</section>
+	);
+};
 
 /**
  * Edit course results block component.
@@ -49,58 +98,6 @@ const CourseResultsEdit = ( props ) => {
 
 	const styleRegex = /is-style-(\w+)/;
 	const style = className.match( styleRegex )?.[ 1 ];
-
-	// Minimal border element.
-	let minimalBorder;
-	if ( 'minimal' === style ) {
-		minimalBorder = (
-			<div className="wp-block-sensei-lms-course-results__module__separator" />
-		);
-	}
-
-	const renderSampleLesson = useCallback( ( lessonNumber ) => {
-		const lessonName = sprintf(
-			/* translators: Mock lesson number. */
-			__( 'Lesson %s', 'sensei-lms' ),
-			lessonNumber
-		);
-
-		return (
-			<div className="wp-block-sensei-lms-course-results__lesson">
-				<span className="wp-block-sensei-lms-course-results__lesson__title">
-					{ lessonName }
-				</span>
-				<span className="wp-block-sensei-lms-course-results__lesson__score">
-					xx%
-				</span>
-			</div>
-		);
-	}, [] );
-
-	const renderSampleModule = useCallback(
-		( moduleName, lessonNumbers ) => (
-			<section
-				className={ classnames(
-					'wp-block-sensei-lms-course-results__module',
-					{
-						'wp-block-sensei-lms-course-results__module__bordered': moduleBorder,
-					}
-				) }
-			>
-				<header className="wp-block-sensei-lms-course-results__module__header">
-					<h2 className="wp-block-sensei-lms-course-results__module__title">
-						{ moduleName }
-					</h2>
-				</header>
-				{ minimalBorder }
-
-				{ lessonNumbers.map( ( lessonNumber ) =>
-					renderSampleLesson( lessonNumber )
-				) }
-			</section>
-		),
-		[ moduleBorder, minimalBorder, renderSampleLesson ]
-	);
 
 	// Header styles.
 	const headerStyles = {
@@ -136,19 +133,24 @@ const CourseResultsEdit = ( props ) => {
 						</div>
 					</div>
 				</div>
-				{ renderSampleModule( __( 'Module A', 'sensei-lms' ), [
-					1,
-					2,
-					3,
-				] ) }
-				{ renderSampleModule( __( 'Module B', 'sensei-lms' ), [
-					4,
-					5,
-				] ) }
-				{ renderSampleModule( __( 'Module C', 'sensei-lms' ), [
-					6,
-					7,
-				] ) }
+				<SampleModule
+					moduleName={ __( 'Module A', 'sensei-lms' ) }
+					lessonNumbers={ [ 1, 2, 3 ] }
+					moduleBorder={ moduleBorder }
+					style={ style }
+				/>
+				<SampleModule
+					moduleName={ __( 'Module B', 'sensei-lms' ) }
+					lessonNumbers={ [ 4, 5, 6 ] }
+					moduleBorder={ moduleBorder }
+					style={ style }
+				/>
+				<SampleModule
+					moduleName={ __( 'Module C', 'sensei-lms' ) }
+					lessonNumbers={ [ 7, 8 ] }
+					moduleBorder={ moduleBorder }
+					style={ style }
+				/>
 			</section>
 		</>
 	);

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -20,6 +20,12 @@ import { sprintf, __ } from '@wordpress/i18n';
  */
 import classnames from 'classnames';
 
+/**
+ * Sample lesson component.
+ *
+ * @param {Object} props              Component props.
+ * @param {Array}  props.lessonNumber The lesson number to use in the sample title.
+ */
 const SampleLesson = ( props ) => {
 	const { lessonNumber } = props;
 
@@ -41,6 +47,15 @@ const SampleLesson = ( props ) => {
 	);
 };
 
+/**
+ * Sample module component.
+ *
+ * @param {Object}  props               Component props.
+ * @param {string}  props.moduleName    The name of the module.
+ * @param {Array}   props.lessonNumbers The lesson numbers to include in the sample module.
+ * @param {string}  props.style         The style selected for the results block.
+ * @param {boolean} props.moduleBorder  If modules have borders.
+ */
 const SampleModule = ( props ) => {
 	const { moduleName, lessonNumbers, style, moduleBorder } = props;
 

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -14,12 +14,12 @@ import {
 } from '../../shared/blocks/settings';
 import { useCallback } from '@wordpress/element';
 import { dispatch } from '@wordpress/data';
+import { sprintf, __ } from '@wordpress/i18n';
 
 /**
  * External dependencies
  */
 import classnames from 'classnames';
-import { sprintf, __ } from '@wordpress/i18n';
 
 /**
  * Edit course results block component.

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -24,18 +24,16 @@ import classnames from 'classnames';
 /**
  * Edit course results block component.
  *
- * @param {Object}   props                         Component props.
- * @param {string}   props.clientId                Block client ID.
- * @param {string}   props.className               Custom class name.
- * @param {Object}   props.mainColor               Header main color.
- * @param {Object}   props.textColor               Header text color.
- * @param {Object}   props.borderColor             Default border color.
- * @param {Object}   props.defaultMainColor        Default main color.
- * @param {Object}   props.defaultTextColor        Default text color.
- * @param {Object}   props.defaultBorderColor      Default border color.
- * @param {Object}   props.attributes              Block attributes.
- * @param {boolean}  props.attributes.moduleBorder True if a modules should have a border.
- * @param {Function} props.setAttributes           Block setAttributes callback.
+ * @param {Object}  props                         Component props.
+ * @param {string}  props.className               Custom class name.
+ * @param {Object}  props.defaultMainColor        Default main color.
+ * @param {Object}  props.defaultTextColor        Default text color.
+ * @param {Object}  props.defaultBorderColor      Default border color.
+ * @param {Object}  props.mainColor               Header main color.
+ * @param {Object}  props.textColor               Header text color.
+ * @param {Object}  props.borderColor             Default border color.
+ * @param {Object}  props.attributes              Block attributes.
+ * @param {boolean} props.attributes.moduleBorder True if a modules should have a border.
  */
 const CourseResultsEdit = ( props ) => {
 	const {
@@ -43,8 +41,8 @@ const CourseResultsEdit = ( props ) => {
 		defaultMainColor,
 		defaultTextColor,
 		defaultBorderColor,
-		textColor,
 		mainColor,
+		textColor,
 		borderColor,
 		attributes: { moduleBorder },
 	} = props;

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -1,0 +1,187 @@
+/**
+ * WordPress dependencies
+ */
+import { compose } from '@wordpress/compose';
+
+/**
+ * Internal dependencies
+ */
+import CourseResultsSettings from './course-results-settings';
+import {
+	withColorSettings,
+	withDefaultColor,
+	withDefaultBlockStyle,
+} from '../../shared/blocks/settings';
+import { useCallback } from '@wordpress/element';
+
+/**
+ * External dependencies
+ */
+import classnames from 'classnames';
+import { sprintf, __ } from '@wordpress/i18n';
+
+/**
+ * Edit course results block component.
+ *
+ * @param {Object}   props                         Component props.
+ * @param {string}   props.clientId                Block client ID.
+ * @param {string}   props.className               Custom class name.
+ * @param {Object}   props.mainColor               Header main color.
+ * @param {Object}   props.textColor               Header text color.
+ * @param {Object}   props.borderColor             Default border color.
+ * @param {Object}   props.defaultMainColor        Default main color.
+ * @param {Object}   props.defaultTextColor        Default text color.
+ * @param {Object}   props.defaultBorderColor      Default border color.
+ * @param {Object}   props.attributes              Block attributes.
+ * @param {boolean}  props.attributes.moduleBorder True if a modules should have a border.
+ * @param {Function} props.setAttributes           Block setAttributes callback.
+ */
+const CourseResultsEdit = ( props ) => {
+	const {
+		className,
+		defaultMainColor,
+		defaultTextColor,
+		defaultBorderColor,
+		textColor,
+		mainColor,
+		borderColor,
+		attributes: { moduleBorder },
+	} = props;
+
+	const styleRegex = /is-style-(\w+)/;
+	const style = className.match( styleRegex )?.[ 1 ];
+
+	// Minimal border element.
+	let minimalBorder;
+	if ( 'minimal' === style ) {
+		minimalBorder = (
+			<div className="wp-block-sensei-lms-course-results__module__separator" />
+		);
+	}
+
+	const renderSampleLesson = useCallback( ( lessonNumber ) => {
+		const lessonName = sprintf(
+			/* translators: Mock lesson number. */
+			__( 'Lesson %s', 'sensei-lms' ),
+			lessonNumber
+		);
+
+		return (
+			<div className="wp-block-sensei-lms-course-results__lesson">
+				<span className="wp-block-sensei-lms-course-results__lesson__title">
+					{ lessonName }
+				</span>
+				<span className="wp-block-sensei-lms-course-results__lesson__score">
+					xx%
+				</span>
+			</div>
+		);
+	}, [] );
+
+	const renderSampleModule = useCallback(
+		( moduleName, lessonNumbers ) => (
+			<section
+				className={ classnames(
+					'wp-block-sensei-lms-course-results__module',
+					{
+						'wp-block-sensei-lms-course-results__module__bordered': moduleBorder,
+					}
+				) }
+			>
+				<header className="wp-block-sensei-lms-course-results__module__header">
+					<h2 className="wp-block-sensei-lms-course-results__module__title">
+						{ moduleName }
+					</h2>
+				</header>
+				{ minimalBorder }
+
+				{ lessonNumbers.map( ( lessonNumber ) =>
+					renderSampleLesson( lessonNumber )
+				) }
+			</section>
+		),
+		[ moduleBorder, minimalBorder, renderSampleLesson ]
+	);
+
+	// Header styles.
+	const headerStyles = {
+		default: {
+			background: mainColor?.color || defaultMainColor?.color,
+			color: textColor?.color || defaultTextColor?.color,
+		},
+		minimal: {
+			color: textColor?.color,
+		},
+	}[ style ];
+
+	const styleVars = {
+		'--sensei-module-header-bg-color':
+			headerStyles?.background || 'inherit',
+		'--sensei-module-header-text-color': headerStyles?.color || 'inherit',
+		'--sensei-module-border-color':
+			borderColor?.color || defaultBorderColor?.color,
+	};
+
+	return (
+		<>
+			<CourseResultsSettings { ...props } />
+			<section className={ className } style={ styleVars }>
+				<div className="wp-block-sensei-lms-course-results__gradeWrapper">
+					<div className="wp-block-sensei-lms-course-results__grade">
+						<div className="wp-block-sensei-lms-course-results__grade__preface">
+							{ __( 'Your Total Grade', 'sensei-lms' ) }
+						</div>
+						<div className="wp-block-sensei-lms-course-results__grade__score">
+							xx%
+						</div>
+					</div>
+				</div>
+				{ renderSampleModule( __( 'Module A', 'sensei-lms' ), [
+					1,
+					2,
+					3,
+				] ) }
+				{ renderSampleModule( __( 'Module B', 'sensei-lms' ), [
+					4,
+					5,
+				] ) }
+				{ renderSampleModule( __( 'Module C', 'sensei-lms' ), [
+					6,
+					7,
+				] ) }
+			</section>
+		</>
+	);
+};
+
+export default compose(
+	withDefaultBlockStyle(),
+	withColorSettings( {
+		mainColor: {
+			style: 'background-color',
+			label: __( 'Module background color', 'sensei-lms' ),
+		},
+		textColor: {
+			style: 'color',
+			label: __( 'Module text color', 'sensei-lms' ),
+		},
+		borderColor: {
+			style: 'border-color',
+			label: __( 'Module border color', 'sensei-lms' ),
+		},
+	} ),
+	withDefaultColor( {
+		defaultMainColor: {
+			style: 'background-color',
+			probeKey: 'primaryColor',
+		},
+		defaultTextColor: {
+			style: 'color',
+			probeKey: 'primaryContrastColor',
+		},
+		defaultBorderColor: {
+			style: 'border-color',
+			probeKey: 'primaryColor',
+		},
+	} )
+)( CourseResultsEdit );

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -13,6 +13,7 @@ import {
 	withDefaultBlockStyle,
 } from '../../shared/blocks/settings';
 import { useCallback } from '@wordpress/element';
+import { dispatch } from '@wordpress/data';
 
 /**
  * External dependencies
@@ -118,6 +119,7 @@ const CourseResultsEdit = ( props ) => {
 		'--sensei-module-header-bg-color':
 			headerStyles?.background || 'inherit',
 		'--sensei-module-header-text-color': headerStyles?.color || 'inherit',
+		'--sensei-module-header-separator-color': mainColor?.color || 'inherit',
 		'--sensei-module-border-color':
 			borderColor?.color || defaultBorderColor?.color,
 	};
@@ -159,7 +161,7 @@ export default compose(
 	withColorSettings( {
 		mainColor: {
 			style: 'background-color',
-			label: __( 'Module background color', 'sensei-lms' ),
+			label: __( 'Module color', 'sensei-lms' ),
 		},
 		textColor: {
 			style: 'color',
@@ -168,6 +170,11 @@ export default compose(
 		borderColor: {
 			style: 'border-color',
 			label: __( 'Module border color', 'sensei-lms' ),
+			onChange: ( { clientId, colorValue } ) =>
+				dispatch( 'core/block-editor' ).updateBlockAttributes(
+					clientId,
+					{ borderColorValue: colorValue }
+				),
 		},
 	} ),
 	withDefaultColor( {

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { compose } from '@wordpress/compose';
@@ -14,11 +19,6 @@ import {
 } from '../../shared/blocks/settings';
 import { dispatch } from '@wordpress/data';
 import { sprintf, __ } from '@wordpress/i18n';
-
-/**
- * External dependencies
- */
-import classnames from 'classnames';
 
 /**
  * Sample lesson component.

--- a/assets/blocks/course-results-block/course-results-settings.js
+++ b/assets/blocks/course-results-block/course-results-settings.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InspectorControls } from '@wordpress/block-editor';
+import { PanelBody, ToggleControl } from '@wordpress/components';
+
+/**
+ * Inspector controls for course results block.
+ *
+ * @param {Object} props Block props.
+ */
+const CourseResultsSettings = ( props ) => {
+	const {
+		attributes: { moduleBorder },
+		setAttributes,
+	} = props;
+
+	return (
+		<InspectorControls>
+			<PanelBody
+				title={ __( 'Modules', 'sensei-lms' ) }
+				initialOpen={ true }
+			>
+				<ToggleControl
+					checked={ moduleBorder }
+					onChange={ ( newValue ) =>
+						setAttributes( { moduleBorder: newValue } )
+					}
+					label={ __( 'Border', 'sensei-lms' ) }
+					help={ __(
+						'Toggle the border for all modules.',
+						'sensei-lms'
+					) }
+				/>
+			</PanelBody>
+		</InspectorControls>
+	);
+};
+
+export default CourseResultsSettings;

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -1,5 +1,3 @@
-$moduleSelector: '.wp-block-sensei-lms-course-results-module';
-$lessonSelector: '.wp-block-sensei-lms-course-results-lesson';
 $dark-gray: #1a1d20;
 $spacing: 16px;
 

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -1,0 +1,85 @@
+$moduleSelector: '.wp-block-sensei-lms-course-results-module';
+$lessonSelector: '.wp-block-sensei-lms-course-results-lesson';
+$dark-gray: #1a1d20;
+$spacing: 16px;
+
+.wp-block-sensei-lms-course-results {
+	&__module {
+		margin: 1em 0;
+
+		&__header {
+			padding: $spacing;
+			font-weight: bold;
+			display: flex;
+			align-items: center;
+			background: var( --sensei-module-header-bg-color );
+			color: var( --sensei-module-header-text-color );
+		}
+
+		&__bordered {
+			border: 1px solid var( --sensei-module-border-color, $dark-gray );
+		}
+
+		&__separator {
+			display: block;
+			border: none;
+			height: 4px;
+			margin-left: 4px;
+			margin-right: 4px;
+			background-color: var( --sensei-module-border-color, $dark-gray );
+		}
+
+		&__title,
+		.wp-block-sensei-lms-course-results &__title {
+			font-size: 1.1em;
+			font-weight: inherit;
+			flex: 1;
+			margin: 0;
+			color: inherit;
+			&::before,
+			&::after {
+				content: none;
+			}
+		}
+	}
+
+	&__lesson {
+		display: flex;
+		align-items: center;
+		margin: 1px 0;
+		position: relative;
+
+		&__title {
+			flex: 1;
+			padding: $spacing;
+		}
+
+		&__score {
+			display: inline-block;
+			flex: 0 0 40px;
+			margin: 0 $spacing;
+			flex-shrink: 0;
+			opacity: 0.9;
+		}
+	}
+
+	&__gradeWrapper {
+		display: flex;
+		align-items: center;
+	}
+
+	&__grade {
+		text-align: center;
+		display: inline-block;
+		margin: $spacing auto;
+		padding: $spacing;
+
+		&__preface {
+			font-size: 1.1em;
+		}
+
+		&__score {
+			font-size: 1.5em;
+		}
+	}
+}

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -26,7 +26,10 @@ $spacing: 16px;
 			height: 4px;
 			margin-left: 4px;
 			margin-right: 4px;
-			background-color: var( --sensei-module-border-color, $dark-gray );
+			background-color: var(
+				--sensei-module-header-separator-color,
+				$dark-gray
+			);
 		}
 
 		&__title,

--- a/assets/blocks/course-results-block/index.js
+++ b/assets/blocks/course-results-block/index.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { CourseIcon as icon } from '../../icons';
+import metadata from './block.json';
+import edit from './course-results-edit';
+
+export default {
+	title: __( 'Course Results', 'sensei-lms' ),
+	description: __(
+		'Show course results to learners on the course completion page.',
+		'sensei-lms'
+	),
+	keywords: [
+		__( 'Course', 'sensei-lms' ),
+		__( 'Lessons', 'sensei-lms' ),
+		__( 'Modules', 'sensei-lms' ),
+		__( 'Results', 'sensei-lms' ),
+		__( 'Completion', 'sensei-lms' ),
+	],
+	styles: [
+		{
+			name: 'default',
+			label: __( 'Filled', 'sensei-lms' ),
+			isDefault: true,
+		},
+		{
+			name: 'minimal',
+			label: __( 'Minimal', 'sensei-lms' ),
+		},
+	],
+	example: {
+		attributes: {},
+	},
+	...metadata,
+	icon,
+	edit,
+};

--- a/assets/blocks/single-page-style.scss
+++ b/assets/blocks/single-page-style.scss
@@ -1,1 +1,2 @@
 @import './learner-courses-block/learner-courses';
+@import './course-results-block/course-results';

--- a/assets/blocks/single-page.js
+++ b/assets/blocks/single-page.js
@@ -4,5 +4,10 @@
 import registerSenseiBlocks from './register-sensei-blocks';
 import LearnerCoursesBlock from './learner-courses-block';
 import LearnerMessagesButtonBlock from './learner-messages-button-block';
+import CourseResultsBlock from './course-results-block';
 
-registerSenseiBlocks( [ LearnerCoursesBlock, LearnerMessagesButtonBlock ] );
+registerSenseiBlocks( [
+	LearnerCoursesBlock,
+	LearnerMessagesButtonBlock,
+	CourseResultsBlock,
+] );

--- a/assets/blocks/single-page.js
+++ b/assets/blocks/single-page.js
@@ -6,8 +6,9 @@ import LearnerCoursesBlock from './learner-courses-block';
 import LearnerMessagesButtonBlock from './learner-messages-button-block';
 import CourseResultsBlock from './course-results-block';
 
-registerSenseiBlocks( [
-	LearnerCoursesBlock,
-	LearnerMessagesButtonBlock,
-	CourseResultsBlock,
-] );
+const blocks = [ LearnerCoursesBlock, LearnerMessagesButtonBlock ];
+
+if ( window.sensei_single_page_blocks.course_completed_page_enabled ) {
+	blocks.push( CourseResultsBlock );
+}
+registerSenseiBlocks( blocks );

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -59,6 +59,7 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 		$this->contact_teacher = new Sensei_Block_Contact_Teacher();
 		$this->take_course     = new Sensei_Block_Take_Course();
 		new Sensei_Conditional_Content_Block();
+		new Sensei_Course_Results_Block();
 		new Sensei_Block_View_Results();
 
 		$post_type_object = get_post_type_object( 'course' );

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -59,7 +59,6 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 		$this->contact_teacher = new Sensei_Block_Contact_Teacher();
 		$this->take_course     = new Sensei_Block_Take_Course();
 		new Sensei_Conditional_Content_Block();
-		new Sensei_Course_Results_Block();
 		new Sensei_Block_View_Results();
 
 		$post_type_object = get_post_type_object( 'course' );

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -48,19 +48,8 @@ class Sensei_Course_Results_Block {
 			[
 				'render_callback' => [ $this, 'render_course_results_block' ],
 			],
-			Sensei()->assets->src_path( 'blocks/course-results' )
+			Sensei()->assets->src_path( 'blocks/course-results-block' )
 		);
-	}
-
-	/**
-	 * Check user permission for editing a course.
-	 *
-	 * @param int $course_id Course post ID.
-	 *
-	 * @return bool Whether the user can edit the course.
-	 */
-	private function can_current_user_edit_course( $course_id ) {
-		return current_user_can( get_post_type_object( 'course' )->cap->edit_post, $course_id );
 	}
 
 	/**
@@ -73,14 +62,203 @@ class Sensei_Course_Results_Block {
 	 * @return string Block HTML.
 	 */
 	public function render_course_results_block( $attributes ) {
+		$course_id = isset( $_GET['course_id'] ) ? (int) $_GET['course_id'] : false;
+
+		// Check that a course has been passed to the page this block is on and the user has completed that course.
+		if (
+			! $course_id
+			|| ! get_current_user_id()
+			|| 'course' !== get_post_type( $course_id )
+			|| ! Sensei_Utils::user_completed_course( $course_id, get_current_user_id() )
+		) {
+				return '';
+		}
+
 		if ( $this->block_content ) {
 			return $this->block_content;
 		}
-		$this->block_attributes['course'] = $attributes;
 
-		$this->block_content = 'Hey!';
+		$structure         = Sensei_Course_Structure::instance( $course_id )->get( 'view' );
+		$block_content     = [];
+		$section_content[] = '<section class="wp-block-sensei-lms-course-results sensei-block-wrapper">';
+		$block_content[]   = $this->render_total_score( $course_id );
+
+		foreach ( $structure as $item ) {
+			if ( 'module' === $item['type'] ) {
+				$block_content[] = $this->render_module( $item, $course_id, $attributes );
+			}
+
+			if ( 'lesson' === $item['type'] ) {
+				$block_content[] = $this->render_lesson( $item, $course_id );
+			}
+		}
+		$block_content[] = '</section>';
+
+		$this->block_content = implode( $block_content );
+
 		return $this->block_content;
+	}
 
+	/**
+	 * Get the total score.
+	 *
+	 * @todo Needs to be implemented. This should only show if there is at least one quiz and all quizzes are graded.
+	 *
+	 * @param int $course_id The course ID.
+	 *
+	 * @return string
+	 */
+	private function render_total_score( $course_id ) {
+		return '';
+	}
+
+	/**
+	 * Render a module in the course results block.
+	 *
+	 * @param array $item       The course structure item.
+	 * @param int   $course_id  The course ID.
+	 * @param array $attributes The block attributes.
+	 * @return string
+	 */
+	private function render_module( $item, $course_id, $attributes ) {
+		if ( empty( $item['lessons'] ) ) {
+			return '';
+		}
+
+		$section_content   = [];
+		$class_name        = Sensei_Block_Helpers::block_class_with_default_style( $attributes, [] );
+		$module_header_css = [];
+		$is_default_style  = false !== strpos( $class_name, 'is-style-default' );
+		$is_minimal_style  = false !== strpos( $class_name, 'is-style-minimal' );
+
+		// Only set header CSS whether it's the default style or the text color is set.
+		if (
+			$is_default_style
+			|| ! empty( $attributes['textColor'] )
+			|| ! empty( $attributes['customTextColor'] )
+		) {
+			$module_header_css = Sensei_Block_Helpers::build_styles(
+				$attributes,
+				[
+					'mainColor'       => $is_default_style ? 'background-color' : null,
+					'backgroundColor' => null,
+					'borderColor'     => null,
+				]
+			);
+		}
+
+		$section_content[] = '<section ' . $this->get_module_html_attributes( $class_name, $attributes ) . '>';
+		$section_content[] = '<header ' . Sensei_Block_Helpers::render_style_attributes( [ 'wp-block-sensei-lms-course-results__module__header' ], $module_header_css ) . '>';
+		$section_content[] = '<h2 class="wp-block-sensei-lms-course-results__module__title">';
+		$section_content[] = esc_html( $item['title'] );
+		$section_content[] = '</h2>';
+		$section_content[] = '</header>';
+
+		if ( $is_minimal_style ) {
+			$header_border_css = Sensei_Block_Helpers::build_styles(
+				$attributes,
+				[
+					'mainColor'   => 'background-color',
+					'borderColor' => null,
+				]
+			);
+
+			$section_content[] = '<div ' . Sensei_Block_Helpers::render_style_attributes( 'wp-block-sensei-lms-course-results__module__separator', $header_border_css ) . '></div>';
+
+		}
+
+		foreach ( $item['lessons'] as $lesson ) {
+			$section_content[] = $this->render_lesson( $lesson, $course_id );
+		}
+
+		$section_content[] = '</section>';
+
+		return implode( $section_content );
+	}
+
+	/**
+	 * Calculates the module section html attributes.
+	 *
+	 * @param string $class_name The block class name.
+	 * @param array  $attributes The outline attributes.
+	 *
+	 * @return string The html attributes.
+	 */
+	private function get_module_html_attributes( $class_name, $attributes ) : string {
+		$class_names   = [ 'wp-block-sensei-lms-course-results__module', $class_name ];
+		$inline_styles = [];
+		$css           = Sensei_Block_Helpers::build_styles(
+			$attributes,
+			[
+				'textColor' => null,
+			]
+		);
+
+		if ( ! empty( $attributes['moduleBorder'] ) ) {
+			$class_names[] = 'wp-block-sensei-lms-course-results__module__bordered';
+
+			if ( ! empty( $attributes['borderColorValue'] ) ) {
+				$inline_styles[] = sprintf( 'border-color: %s;', $attributes['borderColorValue'] );
+			}
+		}
+
+		return Sensei_Block_Helpers::render_style_attributes(
+			$class_names,
+			[
+				'css_classes'   => $css['css_classes'],
+				'inline_styles' => array_merge( $css['inline_styles'], $inline_styles ),
+			]
+		);
+	}
+
+	/**
+	 * Render a lesson in the course results block.
+	 */
+	private function render_lesson( $item, $course_id ) {
+		$section_content   = [];
+		$section_content[] = '<div class="wp-block-sensei-lms-course-results__lesson">';
+		$section_content[] = '<span class="wp-block-sensei-lms-course-results__lesson__title">';
+		$section_content[] = esc_html( $item['title'] );
+		$section_content[] = '</span>';
+
+		$grade = $this->get_lesson_grade( $item['id'] );
+		if ( null !== $grade ) {
+			$section_content[] = '<span class="wp-block-sensei-lms-course-results__lesson__score">';
+			$section_content[] = $grade . '%';
+			$section_content[] = '</span>';
+		}
+
+		$section_content[] = '</div>';
+
+		return implode( $section_content );
+	}
+
+	/**
+	 * Get the lesson grade.
+	 *
+	 * @param int $lesson_id
+	 *
+	 * @return string|null
+	 */
+	private function get_lesson_grade( $lesson_id ) {
+		$activity_args   = [
+			'post_id' => $lesson_id,
+			'user_id' => get_current_user_id(),
+			'type'    => 'sensei_lesson_status',
+			'status'  => [ 'graded', 'passed', 'failed' ],
+		];
+		$lesson_activity = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
+		if ( is_array( $lesson_activity ) ) {
+			$lesson_activity = $lesson_activity[0];
+		}
+
+		$grade = get_comment_meta( $lesson_activity->comment_ID, 'grade', true );
+
+		if ( null === $grade || '' === $grade ) {
+			return null;
+		}
+
+		return $grade;
 	}
 
 }

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * File containing the Sensei_Course_Results_Block class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Course_Results_Block
+ */
+class Sensei_Course_Results_Block {
+
+	/**
+	 * Rendered HTML output for the block.
+	 *
+	 * @var string
+	 */
+	private $block_content;
+
+	/**
+	 * Sensei_Course_Results_Block constructor.
+	 */
+	public function __construct() {
+		$this->register_blocks();
+	}
+
+	/**
+	 * Resets block content.
+	 *
+	 * @access private
+	 */
+	public function clear_block_content() {
+		$this->block_content = null;
+	}
+
+	/**
+	 * Register course results block.
+	 *
+	 * @access private
+	 */
+	public function register_blocks() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/course-results',
+			[
+				'render_callback' => [ $this, 'render_course_results_block' ],
+			],
+			Sensei()->assets->src_path( 'blocks/course-results' )
+		);
+	}
+
+	/**
+	 * Check user permission for editing a course.
+	 *
+	 * @param int $course_id Course post ID.
+	 *
+	 * @return bool Whether the user can edit the course.
+	 */
+	private function can_current_user_edit_course( $course_id ) {
+		return current_user_can( get_post_type_object( 'course' )->cap->edit_post, $course_id );
+	}
+
+	/**
+	 * Render Course Results block.
+	 *
+	 * @access private
+	 *
+	 * @param array $attributes Block attributes.
+	 *
+	 * @return string Block HTML.
+	 */
+	public function render_course_results_block( $attributes ) {
+		if ( $this->block_content ) {
+			return $this->block_content;
+		}
+		$this->block_attributes['course'] = $attributes;
+
+		$this->block_content = 'Hey!';
+		return $this->block_content;
+
+	}
+
+}

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -39,10 +39,8 @@ class Sensei_Course_Results_Block {
 
 	/**
 	 * Register course results block.
-	 *
-	 * @access private
 	 */
-	public function register_blocks() {
+	private function register_blocks() {
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/course-results',
 			[

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -248,6 +248,11 @@ class Sensei_Course_Results_Block {
 			'status'  => [ 'graded', 'passed', 'failed' ],
 		];
 		$lesson_activity = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
+
+		if ( empty( $lesson_activity ) ) {
+			return null;
+		}
+
 		if ( is_array( $lesson_activity ) ) {
 			$lesson_activity = $lesson_activity[0];
 		}

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -256,7 +256,7 @@ class Sensei_Course_Results_Block {
 
 		$grade = get_comment_meta( $lesson_activity->comment_ID, 'grade', true );
 
-		if ( null === $grade || '' === $grade ) {
+		if ( false === $grade || '' === $grade ) {
 			return null;
 		}
 

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -25,7 +25,7 @@ class Sensei_Course_Results_Block {
 	 * Sensei_Course_Results_Block constructor.
 	 */
 	public function __construct() {
-		$this->register_blocks();
+		$this->register_block();
 	}
 
 	/**
@@ -40,7 +40,7 @@ class Sensei_Course_Results_Block {
 	/**
 	 * Register course results block.
 	 */
-	private function register_blocks() {
+	private function register_block() {
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/course-results',
 			[

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -62,6 +62,7 @@ class Sensei_Course_Results_Block {
 	 * @return string Block HTML.
 	 */
 	public function render_course_results_block( $attributes ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only used safely if the user completed course.
 		$course_id = isset( $_GET['course_id'] ) ? (int) $_GET['course_id'] : false;
 
 		// Check that a course has been passed to the page this block is on and the user has completed that course.
@@ -78,18 +79,18 @@ class Sensei_Course_Results_Block {
 			return $this->block_content;
 		}
 
-		$structure         = Sensei_Course_Structure::instance( $course_id )->get( 'view' );
-		$block_content     = [];
-		$section_content[] = '<section class="wp-block-sensei-lms-course-results sensei-block-wrapper">';
-		$block_content[]   = $this->render_total_score( $course_id );
+		$structure       = Sensei_Course_Structure::instance( $course_id )->get( 'view' );
+		$block_content   = [];
+		$block_content[] = '<section class="wp-block-sensei-lms-course-results sensei-block-wrapper">';
+		$block_content[] = $this->render_total_score( $course_id );
 
 		foreach ( $structure as $item ) {
 			if ( 'module' === $item['type'] ) {
-				$block_content[] = $this->render_module( $item, $course_id, $attributes );
+				$block_content[] = $this->render_module( $item, $attributes );
 			}
 
 			if ( 'lesson' === $item['type'] ) {
-				$block_content[] = $this->render_lesson( $item, $course_id );
+				$block_content[] = $this->render_lesson( $item );
 			}
 		}
 		$block_content[] = '</section>';
@@ -116,11 +117,10 @@ class Sensei_Course_Results_Block {
 	 * Render a module in the course results block.
 	 *
 	 * @param array $item       The course structure item.
-	 * @param int   $course_id  The course ID.
 	 * @param array $attributes The block attributes.
 	 * @return string
 	 */
-	private function render_module( $item, $course_id, $attributes ) {
+	private function render_module( $item, $attributes ) {
 		if ( empty( $item['lessons'] ) ) {
 			return '';
 		}
@@ -168,7 +168,7 @@ class Sensei_Course_Results_Block {
 		}
 
 		foreach ( $item['lessons'] as $lesson ) {
-			$section_content[] = $this->render_lesson( $lesson, $course_id );
+			$section_content[] = $this->render_lesson( $lesson );
 		}
 
 		$section_content[] = '</section>';
@@ -213,8 +213,10 @@ class Sensei_Course_Results_Block {
 
 	/**
 	 * Render a lesson in the course results block.
+	 *
+	 * @param array $item The course structure item.
 	 */
-	private function render_lesson( $item, $course_id ) {
+	private function render_lesson( $item ) {
 		$section_content   = [];
 		$section_content[] = '<div class="wp-block-sensei-lms-course-results__lesson">';
 		$section_content[] = '<span class="wp-block-sensei-lms-course-results__lesson__title">';

--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -26,6 +26,7 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	public function initialize_blocks() {
 		new Sensei_Learner_Courses_Block();
 		new Sensei_Learner_Messages_Button_Block();
+		new Sensei_Course_Results_Block();
 	}
 
 	/**

--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -26,7 +26,10 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	public function initialize_blocks() {
 		new Sensei_Learner_Courses_Block();
 		new Sensei_Learner_Messages_Button_Block();
-		new Sensei_Course_Results_Block();
+
+		if ( Sensei()->feature_flags->is_enabled( 'course_completed_page' ) ) {
+			new Sensei_Course_Results_Block();
+		}
 	}
 
 	/**
@@ -41,6 +44,12 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 		Sensei()->assets->enqueue(
 			'sensei-single-page-blocks-style',
 			'blocks/single-page-style.css'
+		);
+
+		wp_localize_script(
+			'sensei-single-page-blocks',
+			'sensei_single_page_blocks',
+			[ 'course_completed_page_enabled' => Sensei()->feature_flags->is_enabled( 'course_completed_page' ) ]
 		);
 	}
 

--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -46,10 +46,17 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 			'blocks/single-page-style.css'
 		);
 
-		wp_localize_script(
+		wp_add_inline_script(
 			'sensei-single-page-blocks',
-			'sensei_single_page_blocks',
-			[ 'course_completed_page_enabled' => Sensei()->feature_flags->is_enabled( 'course_completed_page' ) ]
+			sprintf(
+				'window.sensei_single_page_blocks = %s',
+				wp_json_encode(
+					[
+						'course_completed_page_enabled' => Sensei()->feature_flags->is_enabled( 'course_completed_page' ),
+					]
+				)
+			),
+			'before'
 		);
 	}
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -67,7 +67,7 @@ class Sensei_Frontend {
 		add_action( 'sensei_lesson_archive_lesson_title', array( $this, 'sensei_lesson_archive_lesson_title' ), 10 );
 		add_action( 'wp', array( $this, 'sensei_complete_lesson' ), 10 );
 		add_action( 'wp_head', array( $this, 'sensei_complete_course' ), 10 );
-		add_action( 'sensei_course_status_updated', array( $this, 'redirect_to_course_completed_page' ) );
+		add_action( 'sensei_course_status_updated', array( $this, 'redirect_to_course_completed_page' ), 10, 3 );
 		add_action( 'sensei_frontend_messages', array( $this, 'sensei_frontend_messages' ) );
 		add_action( 'sensei_lesson_video', array( $this, 'sensei_lesson_video' ), 10, 1 );
 		add_action( 'sensei_complete_lesson_button', array( $this, 'sensei_complete_lesson_button' ) );
@@ -781,9 +781,11 @@ class Sensei_Frontend {
 	 * @access private
 	 *
 	 * @param string $status    Course status.
+	 * @param int    $user_id   The user ID (unused).
+	 * @param int    $course_id The course ID.
 	 */
-	public function redirect_to_course_completed_page( $status ) {
-		if ( 'complete' !== $status ) {
+	public function redirect_to_course_completed_page( $status, $user_id, $course_id ) {
+		if ( 'complete' !== $status || ! $course_id ) {
 			return;
 		}
 
@@ -795,7 +797,7 @@ class Sensei_Frontend {
 		$url     = get_permalink( $page_id );
 
 		if ( $url ) {
-			wp_safe_redirect( esc_url_raw( $url ) );
+			wp_safe_redirect( esc_url_raw( add_query_arg( 'course_id', $course_id, $url ) ) );
 			exit;
 		}
 	}


### PR DESCRIPTION
Fixes #4249

### Changes proposed in this Pull Request

* This adds the basic parts of the course results block behind the established feature flag (`course_completed_page`).
* Since all color settings need to be universal (this block isn't per-course), I tried to make them generic and put the in the block sidebar.
* It tries to follow a lot of what we did for the course outline block for frontend rendering. I diverged a tiny bit for the editor (using CSS variables) just because it simplified the code now that everything is one block vs outline -> lesson/module blocks.
* Note: This looks a bit funny on courses that don't have quizzes, especially not within modules where you could add a border (see screenshot). We might need to iterate a bit on the design for those. However, it'd be nice to get this in before I go on leave so it might need to happen in a new PR.

### Partially implemented
Although implemented in the editor, I did not implement the overall course grade. This PR was getting quite big and is something that might need some more thought (for example: you can complete a course before the last quiz is graded if not auto-graded and required, how does that factor into it?). If we don't get to it, it will be easy to remove from the editor preview.

### Testing instructions
* If you haven't already, add `define( 'SENSEI_FEATURE_FLAG_COURSE_COMPLETED_PAGE', true );` to `wp-config.php`.
* Create a completed course page with this block. Make sure the Completed Course setting is set to the new page.
* Have a course that has a mix of lessons and modules. Let some have auto-graded quizzes.
* Complete the course.
* Verify you are redirected to the completed course page with the `?course_id=ID` param and the structure appears correctly.
* Modify the styles of the block and refresh the completed course page. Ensure the editor and frontend match.

### Screenshots
<details>
  <summary>Click to expand and see screenshots!</summary>

<img width="1354" alt="Screen Shot 2021-07-29 at 5 01 25 PM" src="https://user-images.githubusercontent.com/68693/127525904-949a6e57-0af6-47c7-82a5-b7722145e6bd.png">

<img width="836" alt="Screen Shot 2021-07-29 at 4 51 36 PM" src="https://user-images.githubusercontent.com/68693/127524223-1e1171f3-273e-4b3d-a8dd-809a61bb193a.png">

<img width="806" alt="Screen Shot 2021-07-29 at 4 52 38 PM" src="https://user-images.githubusercontent.com/68693/127524401-101bc93c-5549-4c3a-99e9-7bfe1b6c187d.png">

<img width="829" alt="Screen Shot 2021-07-29 at 4 53 14 PM" src="https://user-images.githubusercontent.com/68693/127524544-b00c8ff0-b04e-44be-af6a-3fc67e2ac2a9.png">
<img width="845" alt="Screen Shot 2021-07-29 at 4 56 26 PM" src="https://user-images.githubusercontent.com/68693/127525015-cd8e9e6d-84d5-42db-8daa-6b2d7045ea53.png">
</details>