### PR TITLE
Update View Results button link

### DIFF
--- a/includes/blocks/class-sensei-block-view-results.php
+++ b/includes/blocks/class-sensei-block-view-results.php
@@ -48,11 +48,9 @@ class Sensei_Block_View_Results {
 			return '';
 		}
 
-		$results_link = esc_url( Sensei()->course_results->get_permalink( get_the_ID() ) );
-
 		return preg_replace(
 			'/<a(.*)>/',
-			'<a href="' . $results_link . '" $1>',
+			'<a href="' . esc_url( Sensei_Course::get_view_results_link( get_the_ID() ) ) . '" $1>',
 			$content,
 			1
 		);

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2800,10 +2800,14 @@ class Sensei_Course {
 		 * Filter the course completed page URL.
 		 *
 		 * @since 3.13.0
+		 * @hook sensei_course_completed_page_url
 		 *
-		 * @param string $url Course completed page URL.
+		 * @param {string} $url       Course completed page URL.
+		 * @param {int}    $course_id ID of the course that was completed.
+		 *
+		 * @return {string} Course completed page URL.
 		 */
-		return apply_filters( 'sensei_course_completed_page_url', $url );
+		return apply_filters( 'sensei_course_completed_page_url', $url, $course_id );
 	}
 
 	/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1706,18 +1706,19 @@ class Sensei_Course {
 
 				if ( $manage ) {
 					$has_quizzes = Sensei()->course->course_quizzes( $course_item->ID, true );
+
 					// Output only if there is content to display
 					if ( has_filter( 'sensei_results_links' ) || $has_quizzes ) {
-
 						$complete_html .= '<p class="sensei-results-links">';
 						$results_link   = '';
-						if ( $has_quizzes ) {
 
+						if ( $has_quizzes ) {
 							$results_link = '<a class="button view-results" href="'
-								. esc_url( Sensei()->course_results->get_permalink( $course_item->ID ) )
+								. esc_url( self::get_view_results_link( $course_item->ID ) )
 								. '">' . esc_html__( 'View Results', 'sensei-lms' )
 								. '</a>';
 						}
+
 						/**
 						 * Filter documented in Sensei_Course::the_course_action_buttons
 						 */
@@ -2435,7 +2436,7 @@ class Sensei_Course {
 			$results_link = '';
 
 			if ( $has_quizzes ) {
-				$results_link = '<a class="button view-results" href="' . esc_url( Sensei()->course_results->get_permalink( $course->ID ) ) . '">' .
+				$results_link = '<a class="button view-results" href="' . esc_url( self::get_view_results_link( $course->ID ) ) . '">' .
 					esc_html__( 'View Results', 'sensei-lms' ) . '</a>';
 			}
 
@@ -2780,6 +2781,50 @@ class Sensei_Course {
 	}
 
 	/**
+	 * Get the link to the course completed page.
+	 *
+	 * @since 3.13.0
+	 * @param int $course_id Course ID to append to URL.
+	 *
+	 * @return string The URL or empty string if page is not set or does not exist.
+	 */
+	public static function get_course_completed_page_url( $course_id = 0 ) {
+		$page_id = isset( Sensei()->settings->settings['course_completed_page'] ) ? intval( Sensei()->settings->settings['course_completed_page'] ) : 0;
+		$url     = $page_id ? get_permalink( $page_id ) : '';
+
+		if ( $url && 0 < $course_id ) {
+			$url = add_query_arg( 'course_id', $course_id, $url );
+		}
+
+		/**
+		 * Filter the course completed page URL.
+		 *
+		 * @since 3.13.0
+		 *
+		 * @param string $url Course completed page URL.
+		 */
+		return apply_filters( 'sensei_course_completed_page_url', $url );
+	}
+
+	/**
+	 * Get the link for the View Results button.
+	 *
+	 * @since 3.13.0
+	 * @param int $course_id Course ID.
+	 *
+	 * @return string The URL for the View Results button.
+	 */
+	public static function get_view_results_link( $course_id ) {
+		$url = self::get_course_completed_page_url( $course_id );
+
+		if ( ! $url ) {
+			$url = Sensei()->course_results->get_permalink( $course_id );
+		}
+
+		return $url;
+	}
+
+	/**
 	 * Output the headers on the course archive page
 	 *
 	 * @since 1.9.0
@@ -3067,9 +3112,11 @@ class Sensei_Course {
 					<p class="sensei-results-links">
 						<?php
 						$results_link = '';
+
 						if ( $has_quizzes ) {
-							$results_link = '<a class="view-results" href="' . esc_url( Sensei()->course_results->get_permalink( $post->ID ) ) . '">' . esc_html__( 'View Results', 'sensei-lms' ) . '</a>';
+							$results_link = '<a class="view-results" href="' . esc_url( self::get_view_results_link( $post->ID ) ) . '">' . esc_html__( 'View Results', 'sensei-lms' ) . '</a>';
 						}
+
 						/**
 						 * Filter documented in Sensei_Course::the_course_action_buttons
 						 */

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2788,13 +2788,10 @@ class Sensei_Course {
 	 *
 	 * @return string The URL or empty string if page is not set or does not exist.
 	 */
-	public static function get_course_completed_page_url( $course_id = 0 ) {
+	public static function get_course_completed_page_url( $course_id ) {
 		$page_id = isset( Sensei()->settings->settings['course_completed_page'] ) ? intval( Sensei()->settings->settings['course_completed_page'] ) : 0;
 		$url     = $page_id ? get_permalink( $page_id ) : '';
-
-		if ( $url && 0 < $course_id ) {
-			$url = add_query_arg( 'course_id', $course_id, $url );
-		}
+		$url     = $url && 0 < $course_id ? add_query_arg( 'course_id', $course_id, $url ) : '';
 
 		/**
 		 * Filter the course completed page URL.

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -789,15 +789,10 @@ class Sensei_Frontend {
 			return;
 		}
 
-		if ( ! isset( Sensei()->settings->settings['course_completed_page'] ) ) {
-			return;
-		}
-
-		$page_id = intval( Sensei()->settings->settings['course_completed_page'] );
-		$url     = get_permalink( $page_id );
+		$url = Sensei_Course::get_course_completed_page_url( $course_id );
 
 		if ( $url ) {
-			wp_safe_redirect( esc_url_raw( add_query_arg( 'course_id', $course_id, $url ) ) );
+			wp_safe_redirect( esc_url_raw( $url ) );
 			exit;
 		}
 	}

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -402,27 +402,6 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	/**
 	 * Test that the course completed page URL is returned.
 	 *
-	 * @covers Sensei_Course::get_course_completed_page_url
-	 */
-	public function testGetCourseCompletedPageUrl() {
-		$course_id = $this->factory->course->create();
-		$page_id   = $this->factory->post->create(
-			[
-				'post_type'  => 'page',
-				'post_title' => 'Course Completed',
-			]
-		);
-		Sensei()->settings->set( 'course_completed_page', $page_id );
-
-		$expected = "http://example.org/?page_id={$page_id}";
-		$actual   = Sensei_Course::get_course_completed_page_url();
-
-		$this->assertEquals( $expected, $actual );
-	}
-
-	/**
-	 * Test that the course completed page URL is returned.
-	 *
 	 * @covers Sensei_Course::get_view_results_link
 	 * @covers Sensei_Course::get_course_completed_page_url
 	 */

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -47,7 +47,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * This tests Sensei_Courses::get_all_course
+	 * This tests Sensei_Courses::get_all_courses
 	 *
 	 * @since 1.8.0
 	 */
@@ -397,5 +397,67 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		$this->manuallyEnrolStudentInCourse( $user_id, $course_id );
 
 		$this->assertTrue( $course_instance->can_access_course_content( $course_id, $user_id ), 'Standard users who are enrolled should have access to course content' );
+	}
+
+	/**
+	 * Test that the course completed page URL is returned.
+	 *
+	 * @covers Sensei_Course::get_course_completed_page_url
+	 */
+	public function testGetCourseCompletedPageUrl() {
+		$course_id = $this->factory->course->create();
+		$page_id   = $this->factory->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Course Completed',
+			]
+		);
+		Sensei()->settings->set( 'course_completed_page', $page_id );
+
+		$expected = "http://example.org/?page_id={$page_id}";
+		$actual   = Sensei_Course::get_course_completed_page_url();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Test that the course completed page URL is returned.
+	 *
+	 * @covers Sensei_Course::get_view_results_link
+	 * @covers Sensei_Course::get_course_completed_page_url
+	 */
+	public function testGetViewResultsLinkCourseCompletedPage() {
+		$course_id = $this->factory->course->create();
+		$page_id   = $this->factory->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Course Completed',
+			]
+		);
+		Sensei()->settings->set( 'course_completed_page', $page_id );
+
+		$expected = "http://example.org/?page_id={$page_id}&course_id={$course_id}";
+		$actual   = Sensei_Course::get_view_results_link( $course_id );
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 * Test that the course results page URL is returned.
+	 *
+	 * @covers Sensei_Course::get_view_results_link
+	 * @covers Sensei_Course::get_course_completed_page_url
+	 */
+	public function testGetViewResultsLinkCourseResultsPage() {
+		$course_id = $this->factory->course->create(
+			[
+				'post_name' => 'a-course',
+			]
+		);
+
+		$expected = 'http://example.org/?course_results=a-course';
+		$actual   = Sensei_Course::get_view_results_link( $course_id );
+
+		$this->assertEquals( $expected, $actual );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

Updates the _View Results_ button to go to the _Course Completed_ page if applicable, or the existing course results page if not.

This affects the button in the following places:

- _My Courses_ page (_Learner Courses_ block or when using the `[sensei_user_courses]` shortcode)
- Single course page (_View Results_ block or when using the legacy template)
- Learner profile page

### Testing instructions

* Add `define( 'SENSEI_FEATURE_FLAG_COURSE_COMPLETED_PAGE', true );` to `wp-config.php`.
* Ensure you've set the _Course Completed Page_ setting.
* Create a course containing a quiz and complete the course.
* Add the _Learner Courses_ block to the _My Courses_ page. Browse to it on the front end and ensure the _View Results_ button goes to the _Course Completed_ page.
* Remove all blocks from the _My Courses_ page and add the `[sensei_user_courses]` shortcode. Browse to it on the front end and ensure the _View Results_ button goes to the _Course Completed_ page.
* Add the _View Results_ block to the single course page. Browse to it on the front end and ensure the _View Results_ button goes to the _Course Completed_ page.
* Remove all blocks from the single course page so that the template is used. Browse to it on the front end and ensure the _View Results_ button goes to the _Course Completed_ page.
* Go to the learner profile page (`/learner/<username>`) and click the _Completed Courses_ tab. Ensure the _View Results_ button goes to the _Course Completed_ page.
* Clear the _Course Completed Page_ setting.
* Repeat the above steps but this time, check to ensure that the _View Results_ button goes to the old course results page.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_course_completed_page_url` - Filter the course completed page URL.