### PR TITLE
Add total grade and course title to Course Results block

### DIFF
--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -57,9 +57,9 @@ const SampleModule = ( { moduleName, lessonNumbers, style, moduleBorder } ) => (
 		} ) }
 	>
 		<header className="wp-block-sensei-lms-course-results__module__header">
-			<h2 className="wp-block-sensei-lms-course-results__module__title">
+			<h3 className="wp-block-sensei-lms-course-results__module__title">
 				{ moduleName }
-			</h2>
+			</h3>
 		</header>
 
 		{ 'minimal' === style && (
@@ -130,9 +130,12 @@ const CourseResultsEdit = ( props ) => {
 						{ __( 'Your Total Grade', 'sensei-lms' ) }
 					</span>
 					<span className="wp-block-sensei-lms-course-results__grade__score">
-						xx%
+						XX%
 					</span>
 				</div>
+				<h2 className="wp-block-sensei-lms-course-results__title">
+					{ __( 'Course Title', 'sensei-lms' ) }
+				</h2>
 				<SampleModule
 					moduleName={ __( 'Module A', 'sensei-lms' ) }
 					lessonNumbers={ [ 1, 2, 3 ] }

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -125,15 +125,13 @@ const CourseResultsEdit = ( props ) => {
 		<>
 			<CourseResultsSettings { ...props } />
 			<section className={ className } style={ styleVars }>
-				<div className="wp-block-sensei-lms-course-results__gradeWrapper">
-					<div className="wp-block-sensei-lms-course-results__grade">
-						<div className="wp-block-sensei-lms-course-results__grade__preface">
-							{ __( 'Your Total Grade', 'sensei-lms' ) }
-						</div>
-						<div className="wp-block-sensei-lms-course-results__grade__score">
-							xx%
-						</div>
-					</div>
+				<div className="wp-block-sensei-lms-course-results__grade">
+					<span className="wp-block-sensei-lms-course-results__grade__label">
+						{ __( 'Your Total Grade', 'sensei-lms' ) }
+					</span>
+					<span className="wp-block-sensei-lms-course-results__grade__score">
+						xx%
+					</span>
 				</div>
 				<SampleModule
 					moduleName={ __( 'Module A', 'sensei-lms' ) }

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -2,6 +2,28 @@ $dark-gray: #1a1d20;
 $spacing: 16px;
 
 .wp-block-sensei-lms-course-results {
+	&__grade {
+		margin: auto 0;
+		text-align: center;
+		width: 100%;
+
+		&__label {
+			font-size: 1.1em;
+		}
+
+		&__score {
+			display: block;
+			font-size: 2em;
+			font-weight: bold;
+			line-height: normal;
+		}
+	}
+
+	&__title {
+		margin: 1em 0 0.5em;
+		text-align: center;
+	}
+
 	&__module {
 		margin: 1em 0;
 
@@ -61,26 +83,6 @@ $spacing: 16px;
 			margin: 0 $spacing;
 			flex-shrink: 0;
 			opacity: 0.9;
-		}
-	}
-
-	&__gradeWrapper {
-		display: flex;
-		align-items: center;
-	}
-
-	&__grade {
-		text-align: center;
-		display: inline-block;
-		margin: $spacing auto;
-		padding: $spacing;
-
-		&__preface {
-			font-size: 1.1em;
-		}
-
-		&__score {
-			font-size: 1.5em;
 		}
 	}
 }

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -1,7 +1,8 @@
 $dark-gray: #1a1d20;
 $spacing: 16px;
 
-.wp-block-sensei-lms-course-results {
+.wp-block-sensei-lms-course-results,
+.editor-styles-wrapper .wp-block-sensei-lms-course-results {
 	&__grade {
 		margin: auto 0;
 		text-align: center;
@@ -21,6 +22,7 @@ $spacing: 16px;
 
 	&__title {
 		margin: 1em 0 0.5em;
+		padding: 0;
 		text-align: center;
 	}
 

--- a/assets/css/pages-frontend.scss
+++ b/assets/css/pages-frontend.scss
@@ -1,9 +1,13 @@
 /**
  * Course Completed Page
  */
-.course-completed .entry-title {
-	height: 0;
-	margin: 0;
-	padding: 0;
-	visibility: hidden;
+.course-completed {
+	&.singular .entry-header,
+	.entry-title {
+		border: 0;
+		height: 0;
+		margin: 0;
+		padding: 0;
+		visibility: hidden;
+	}
 }

--- a/assets/css/pages-frontend.scss
+++ b/assets/css/pages-frontend.scss
@@ -1,0 +1,9 @@
+/**
+ * Course Completed Page
+ */
+.course-completed .entry-title {
+	height: 0;
+	margin: 0;
+	padding: 0;
+	visibility: hidden;
+}

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -125,6 +125,13 @@ class Sensei_Course_Results_Block {
 		return implode( $content );
 	}
 
+	/**
+	 * Render the course title.
+	 *
+	 * @param int $course_id Course ID.
+	 *
+	 * @return string HTML for the course title.
+	 */
 	private function render_course_title( $course_id ) {
 		$content      = [];
 		$course_title = $course_id ? get_the_title( $course_id ) : '';
@@ -143,6 +150,7 @@ class Sensei_Course_Results_Block {
 	 *
 	 * @param array $item       The course structure item.
 	 * @param array $attributes The block attributes.
+	 *
 	 * @return string
 	 */
 	private function render_module( $item, $attributes ) {

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -174,9 +174,9 @@ class Sensei_Course_Results_Block {
 
 		$section_content[] = '<section ' . $this->get_module_html_attributes( $class_name, $attributes ) . '>';
 		$section_content[] = '<header ' . Sensei_Block_Helpers::render_style_attributes( [ 'wp-block-sensei-lms-course-results__module__header' ], $module_header_css ) . '>';
-		$section_content[] = '<h2 class="wp-block-sensei-lms-course-results__module__title">';
+		$section_content[] = '<h3 class="wp-block-sensei-lms-course-results__module__title">';
 		$section_content[] = esc_html( $item['title'] );
-		$section_content[] = '</h2>';
+		$section_content[] = '</h3>';
 		$section_content[] = '</header>';
 
 		if ( $is_minimal_style ) {

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -44,7 +44,7 @@ class Sensei_Course_Results_Block {
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/course-results',
 			[
-				'render_callback' => [ $this, 'render_course_results_block' ],
+				'render_callback' => [ $this, 'render_block' ],
 			],
 			Sensei()->assets->src_path( 'blocks/course-results-block' )
 		);
@@ -59,7 +59,7 @@ class Sensei_Course_Results_Block {
 	 *
 	 * @return string Block HTML.
 	 */
-	public function render_course_results_block( $attributes ) {
+	public function render_block( $attributes ) {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only used safely if the user completed course.
 		$course_id = isset( $_GET['course_id'] ) ? (int) $_GET['course_id'] : false;
 
@@ -80,7 +80,8 @@ class Sensei_Course_Results_Block {
 		$structure       = Sensei_Course_Structure::instance( $course_id )->get( 'view' );
 		$block_content   = [];
 		$block_content[] = '<section class="wp-block-sensei-lms-course-results sensei-block-wrapper">';
-		$block_content[] = $this->render_total_score( $course_id );
+		$block_content[] = $this->render_total_grade( $course_id );
+		$block_content[] = $this->render_course_title( $course_id );
 
 		foreach ( $structure as $item ) {
 			if ( 'module' === $item['type'] ) {
@@ -99,16 +100,42 @@ class Sensei_Course_Results_Block {
 	}
 
 	/**
-	 * Get the total score.
+	 * Render the total grade.
 	 *
-	 * @todo Needs to be implemented. This should only show if there is at least one quiz and all quizzes are graded.
+	 * @param int $course_id Course ID.
 	 *
-	 * @param int $course_id The course ID.
-	 *
-	 * @return string
+	 * @return string HTML for the total grade.
 	 */
-	private function render_total_score( $course_id ) {
-		return '';
+	private function render_total_grade( $course_id ) {
+		// Course does not have a quiz.
+		if ( ! Sensei()->course->course_quizzes( $course_id, true ) ) {
+			return '';
+		}
+
+		$content   = [];
+		$content[] = '<div class="wp-block-sensei-lms-course-results__grade">';
+		$content[] = '<span class="wp-block-sensei-lms-course-results__grade__label">';
+		$content[] = __( 'Your Total Grade', 'sensei-lms' );
+		$content[] = '</span>';
+		$content[] = '<span class="wp-block-sensei-lms-course-results__grade__score">';
+		$content[] = Sensei_Utils::sensei_course_user_grade( $course_id, get_current_user_id() ) . '%';
+		$content[] = '</span>';
+		$content[] = '</div>';
+
+		return implode( $content );
+	}
+
+	private function render_course_title( $course_id ) {
+		$content      = [];
+		$course_title = $course_id ? get_the_title( $course_id ) : '';
+
+		if ( $course_title ) {
+			$content[] = '<h2 class="wp-block-sensei-lms-course-results__title">';
+			$content[] = $course_title;
+			$content[] = '</h2>';
+		}
+
+		return implode( $content );
 	}
 
 	/**

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -161,20 +161,17 @@ class Sensei_Frontend {
 	 * @return void
 	 */
 	public function enqueue_styles() {
+		Sensei()->assets->enqueue( 'pages-frontend', 'css/pages-frontend.css' );
 
 		$disable_styles = Sensei_Utils::get_setting_as_flag( 'styles_disable', 'sensei_disable_styles' );
 
 		if ( ! $disable_styles ) {
-
 			Sensei()->assets->enqueue( Sensei()->token . '-frontend', 'css/frontend.css', [], 'screen' );
 
 			// Allow additional stylesheets to be loaded.
 			do_action( 'sensei_additional_styles' );
-
 		}
-
 	}
-
 
 	/**
 	 * Get template part.

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1268,12 +1268,18 @@ class Sensei_Main {
 	public function body_class( $classes ) {
 		if ( is_sensei() ) {
 			$classes[] = 'sensei';
-
 			$post_type = get_post_type();
+
 			if ( ! empty( $post_type ) ) {
 				$classes[] = $post_type;
 			}
+
+			// Add class to Course Completed page.
+			if ( get_the_ID() === intval( Sensei()->settings->settings['course_completed_page'] ) ) {
+				$classes[] = 'course-completed';
+			}
 		}
+
 		return $classes;
 	}
 

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -29,8 +29,8 @@ function is_sensei() {
 	) {
 		$is_sensei = true;
 	} elseif ( is_object( $post ) && ! is_wp_error( $post ) ) {
-		$course_page_id     = intval( Sensei()->settings->settings['course_page'] );
-		$my_courses_page_id = intval( Sensei()->settings->settings['my_course_page'] );
+		$course_page_id           = intval( Sensei()->settings->settings['course_page'] );
+		$my_courses_page_id       = intval( Sensei()->settings->settings['my_course_page'] );
 		$course_completed_page_id = intval( Sensei()->settings->settings['course_completed_page'] );
 
 		if ( in_array( $post->ID, array( $course_page_id, $my_courses_page_id ) )

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -31,6 +31,8 @@ function is_sensei() {
 	} elseif ( is_object( $post ) && ! is_wp_error( $post ) ) {
 		$course_page_id     = intval( Sensei()->settings->settings['course_page'] );
 		$my_courses_page_id = intval( Sensei()->settings->settings['my_course_page'] );
+		$course_completed_page_id = intval( Sensei()->settings->settings['course_completed_page'] );
+
 		if ( in_array( $post->ID, array( $course_page_id, $my_courses_page_id ) )
 			|| Sensei_Utils::is_learner_profile_page()
 			|| Sensei_Utils::is_course_results_page()

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -33,7 +33,7 @@ function is_sensei() {
 		$my_courses_page_id       = intval( Sensei()->settings->settings['my_course_page'] );
 		$course_completed_page_id = intval( Sensei()->settings->settings['course_completed_page'] );
 
-		if ( in_array( $post->ID, array( $course_page_id, $my_courses_page_id ) )
+		if ( in_array( $post->ID, array( $course_page_id, $my_courses_page_id, $course_completed_page_id ) )
 			|| Sensei_Utils::is_learner_profile_page()
 			|| Sensei_Utils::is_course_results_page()
 			|| Sensei_Utils::is_teacher_archive_page()

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -67,6 +67,7 @@ const files = [
 	'css/jquery-ui.css',
 	'css/modules-admin.css',
 	'css/modules-frontend.scss',
+	'css/pages-frontend.scss',
 	'css/ranges.css',
 	'css/settings.scss',
 	'css/meta-box-quiz-editor.scss',


### PR DESCRIPTION
### Changes proposed in this Pull Request

- Adds the total grade to the front end of the course results block, and the course title to both the editor and the front end.
- Hides the page title on the _Course Completed_ page. This only works on themes that are using the `entry-title` class on that element (e.g. not Aardvark).

### Testing instructions

- Add `define( 'SENSEI_FEATURE_FLAG_COURSE_COMPLETED_PAGE', true );` to `wp-config.php`.
- Add the Course Results block to the Course Completed page.
- Ensure "Course Title" appears above the lesson list.
- View the Course Completed page on the front end for a completed course with quizzes (append `?course_id=<completed_course_id>` to browse to it directly).
- Ensure both the course title and grade are correct, and that the page title is hidden. To check the grade, you can compare the total grade on the old course results page (`/course/other-lessons/results/`) to the one in the course results block.
- Complete a course without a quiz and browse to its corresponding Course Completed page.
- Ensure the course title appears but that the total grade does not.
- Repeat the above on some of Sensei's top themes and ensure it looks good.

The block styles don't appear to be working correctly on the front end, but I'll address that in a separate PR.

### Screenshots
![Screen Shot 2021-08-05 at 11 20 52 AM](https://user-images.githubusercontent.com/1190420/128375951-419b1808-d8c5-4ebb-8f17-e5791935dcc1.jpg)

![Screen Shot 2021-08-05 at 11 21 42 AM](https://user-images.githubusercontent.com/1190420/128376044-f24c16a2-eafb-495c-89c3-5f52cdf56585.jpg)