### PR TITLE
Fix legacy or blocks notice

### DIFF
--- a/assets/js/admin/post-edit.js
+++ b/assets/js/admin/post-edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { select, dispatch } from '@wordpress/data';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 
 // Legacy metaboxes toggle control.
 ( () => {
@@ -33,6 +33,7 @@ import { __, sprintf } from '@wordpress/i18n';
 
 	// WordPress data.
 	const blockEditorSelector = select( 'core/block-editor' );
+	const coreEditorSelector = select( 'core/editor' );
 	const editPostSelector = select( 'core/edit-post' );
 	const editPostDispatcher = dispatch( 'core/edit-post' );
 	const { createWarningNotice, removeNotice } = dispatch( 'core/notices' );
@@ -60,7 +61,9 @@ import { __, sprintf } from '@wordpress/i18n';
 			}
 		);
 
-		toggleLegacyOrBlocksNotice( postType, action );
+		if ( coreEditorSelector.isEditedPostDirty() ) {
+			toggleLegacyOrBlocksNotice( postType, action );
+		}
 
 		// Prevent submit course modules.
 		document


### PR DESCRIPTION
Related to https://github.com/Automattic/sensei/issues/4242

### Changes proposed in this Pull Request

* It fixes the legacy or blocks notice to not show up when loading the editor with a single Sensei block.

### Testing instructions

* Create a course with a single Sensei block.
* Refresh the page, and make sure you don't see the warning related to the editor containing or not Sensei blocks.
* Now, remove the block and make sure you see a message that the page doesn't contain any Sensei block.
* Add the block again, and make sure you see a message that the page contains Sensei blocks.