### PR TITLE
Course Results block tweaks

### DIFF
--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -50,16 +50,20 @@ const SampleLesson = ( { lessonNumber } ) => (
  *
  * @param {Object}  props              Component props.
  * @param {string}  props.moduleName   The name of the module.
- * @param {string}  props.style        The style selected for the results block.
  * @param {boolean} props.moduleBorder If modules have borders.
+ * @param {string}  props.headerStyles The module header styles.
+ * @param {string}  props.style        The style selected for the results block.
  */
-const SampleModule = ( { moduleName, style, moduleBorder } ) => (
+const SampleModule = ( { moduleName, moduleBorder, headerStyles, style } ) => (
 	<section
 		className={ classnames( 'wp-block-sensei-lms-course-results__module', {
 			'wp-block-sensei-lms-course-results__module__bordered': moduleBorder,
 		} ) }
 	>
-		<header className="wp-block-sensei-lms-course-results__module__header">
+		<header
+			className="wp-block-sensei-lms-course-results__module__header"
+			style={ headerStyles }
+		>
 			<h3 className="wp-block-sensei-lms-course-results__module__title">
 				{ moduleName }
 			</h3>
@@ -144,16 +148,19 @@ const CourseResultsEdit = ( props ) => {
 				<SampleModule
 					moduleName={ __( 'Module A', 'sensei-lms' ) }
 					moduleBorder={ moduleBorder }
+					headerStyles={ headerStyles }
 					style={ style }
 				/>
 				<SampleModule
 					moduleName={ __( 'Module B', 'sensei-lms' ) }
 					moduleBorder={ moduleBorder }
+					headerStyles={ headerStyles }
 					style={ style }
 				/>
 				<SampleModule
 					moduleName={ __( 'Module C', 'sensei-lms' ) }
 					moduleBorder={ moduleBorder }
+					headerStyles={ headerStyles }
 					style={ style }
 				/>
 			</section>

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -31,7 +31,7 @@ const SampleLesson = ( { lessonNumber } ) => (
 		{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
 		<a
 			href="#"
-			className="wp-block-sensei-lms-course-results__lesson__title"
+			className="wp-block-sensei-lms-course-results__lesson-title"
 		>
 			{ sprintf(
 				/* translators: Mock lesson number. */
@@ -39,7 +39,7 @@ const SampleLesson = ( { lessonNumber } ) => (
 				lessonNumber
 			) }
 		</a>
-		<span className="wp-block-sensei-lms-course-results__lesson__score">
+		<span className="wp-block-sensei-lms-course-results__lesson-score">
 			xx%
 		</span>
 	</li>
@@ -57,14 +57,14 @@ const SampleLesson = ( { lessonNumber } ) => (
 const SampleModule = ( { moduleName, moduleBorder, headerStyles, style } ) => (
 	<section
 		className={ classnames( 'wp-block-sensei-lms-course-results__module', {
-			'wp-block-sensei-lms-course-results__module__bordered': moduleBorder,
+			'wp-block-sensei-lms-course-results__module--has-border': moduleBorder,
 		} ) }
 	>
 		<header
-			className="wp-block-sensei-lms-course-results__module__header"
+			className="wp-block-sensei-lms-course-results__module-header"
 			style={ headerStyles }
 		>
-			<h3 className="wp-block-sensei-lms-course-results__module__title">
+			<h3 className="wp-block-sensei-lms-course-results__module-title">
 				{ moduleName }
 			</h3>
 		</header>
@@ -135,14 +135,14 @@ const CourseResultsEdit = ( props ) => {
 			<CourseResultsSettings { ...props } />
 			<section className={ className } style={ styleVars }>
 				<div className="wp-block-sensei-lms-course-results__grade">
-					<span className="wp-block-sensei-lms-course-results__grade__label">
+					<span className="wp-block-sensei-lms-course-results__grade-label">
 						{ __( 'Your Total Grade', 'sensei-lms' ) }
 					</span>
-					<span className="wp-block-sensei-lms-course-results__grade__score">
+					<span className="wp-block-sensei-lms-course-results__grade-score">
 						XX%
 					</span>
 				</div>
-				<h2 className="wp-block-sensei-lms-course-results__title">
+				<h2 className="wp-block-sensei-lms-course-results__course-title">
 					{ __( 'Course Title', 'sensei-lms' ) }
 				</h2>
 				<SampleModule

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -27,7 +27,7 @@ import { sprintf, __ } from '@wordpress/i18n';
  * @param {Array}  props.lessonNumber The lesson number to use in the sample title.
  */
 const SampleLesson = ( { lessonNumber } ) => (
-	<div className="wp-block-sensei-lms-course-results__lesson">
+	<li className="wp-block-sensei-lms-course-results__lesson">
 		<span className="wp-block-sensei-lms-course-results__lesson__title">
 			{ sprintf(
 				/* translators: Mock lesson number. */
@@ -38,7 +38,7 @@ const SampleLesson = ( { lessonNumber } ) => (
 		<span className="wp-block-sensei-lms-course-results__lesson__score">
 			xx%
 		</span>
-	</div>
+	</li>
 );
 
 /**
@@ -65,9 +65,11 @@ const SampleModule = ( { moduleName, style, moduleBorder } ) => (
 			<div className="wp-block-sensei-lms-course-results__module__separator" />
 		) }
 
-		{ [ 1, 2 ].map( ( lessonNumber, index ) => (
-			<SampleLesson key={ index } lessonNumber={ lessonNumber } />
-		) ) }
+		<ul className="wp-block-sensei-lms-course-results__lessons">
+			{ [ 1, 2 ].map( ( lessonNumber, index ) => (
+				<SampleLesson key={ index } lessonNumber={ lessonNumber } />
+			) ) }
+		</ul>
 	</section>
 );
 

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -44,13 +44,12 @@ const SampleLesson = ( { lessonNumber } ) => (
 /**
  * Sample module component.
  *
- * @param {Object}  props               Component props.
- * @param {string}  props.moduleName    The name of the module.
- * @param {Array}   props.lessonNumbers The lesson numbers to include in the sample module.
- * @param {string}  props.style         The style selected for the results block.
- * @param {boolean} props.moduleBorder  If modules have borders.
+ * @param {Object}  props              Component props.
+ * @param {string}  props.moduleName   The name of the module.
+ * @param {string}  props.style        The style selected for the results block.
+ * @param {boolean} props.moduleBorder If modules have borders.
  */
-const SampleModule = ( { moduleName, lessonNumbers, style, moduleBorder } ) => (
+const SampleModule = ( { moduleName, style, moduleBorder } ) => (
 	<section
 		className={ classnames( 'wp-block-sensei-lms-course-results__module', {
 			'wp-block-sensei-lms-course-results__module__bordered': moduleBorder,
@@ -66,7 +65,7 @@ const SampleModule = ( { moduleName, lessonNumbers, style, moduleBorder } ) => (
 			<div className="wp-block-sensei-lms-course-results__module__separator" />
 		) }
 
-		{ lessonNumbers.map( ( lessonNumber, index ) => (
+		{ [ 1, 2 ].map( ( lessonNumber, index ) => (
 			<SampleLesson key={ index } lessonNumber={ lessonNumber } />
 		) ) }
 	</section>
@@ -138,19 +137,16 @@ const CourseResultsEdit = ( props ) => {
 				</h2>
 				<SampleModule
 					moduleName={ __( 'Module A', 'sensei-lms' ) }
-					lessonNumbers={ [ 1, 2, 3 ] }
 					moduleBorder={ moduleBorder }
 					style={ style }
 				/>
 				<SampleModule
 					moduleName={ __( 'Module B', 'sensei-lms' ) }
-					lessonNumbers={ [ 4, 5, 6 ] }
 					moduleBorder={ moduleBorder }
 					style={ style }
 				/>
 				<SampleModule
 					moduleName={ __( 'Module C', 'sensei-lms' ) }
-					lessonNumbers={ [ 7, 8 ] }
 					moduleBorder={ moduleBorder }
 					style={ style }
 				/>

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -29,19 +29,18 @@ import { sprintf, __ } from '@wordpress/i18n';
 const SampleLesson = ( { lessonNumber } ) => (
 	<li className="wp-block-sensei-lms-course-results__lesson">
 		{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
-		<a
-			href="#"
-			className="wp-block-sensei-lms-course-results__lesson-title"
-		>
-			{ sprintf(
-				/* translators: Mock lesson number. */
-				__( 'Lesson %s', 'sensei-lms' ),
-				lessonNumber
-			) }
+		<a href="#" className="wp-block-sensei-lms-course-results__lesson-link">
+			<span className="wp-block-sensei-lms-course-results__lesson-title">
+				{ sprintf(
+					/* translators: Mock lesson number. */
+					__( 'Lesson %s', 'sensei-lms' ),
+					lessonNumber
+				) }
+			</span>
+			<span className="wp-block-sensei-lms-course-results__lesson-score">
+				xx%
+			</span>
 		</a>
-		<span className="wp-block-sensei-lms-course-results__lesson-score">
-			xx%
-		</span>
 	</li>
 );
 

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -70,7 +70,7 @@ const SampleModule = ( { moduleName, moduleBorder, headerStyles, style } ) => (
 		</header>
 
 		{ 'minimal' === style && (
-			<div className="wp-block-sensei-lms-course-results__module__separator" />
+			<div className="wp-block-sensei-lms-course-results__separator" />
 		) }
 
 		<ul className="wp-block-sensei-lms-course-results__lessons">

--- a/assets/blocks/course-results-block/course-results-edit.js
+++ b/assets/blocks/course-results-block/course-results-edit.js
@@ -28,13 +28,17 @@ import { sprintf, __ } from '@wordpress/i18n';
  */
 const SampleLesson = ( { lessonNumber } ) => (
 	<li className="wp-block-sensei-lms-course-results__lesson">
-		<span className="wp-block-sensei-lms-course-results__lesson__title">
+		{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+		<a
+			href="#"
+			className="wp-block-sensei-lms-course-results__lesson__title"
+		>
 			{ sprintf(
 				/* translators: Mock lesson number. */
 				__( 'Lesson %s', 'sensei-lms' ),
 				lessonNumber
 			) }
-		</span>
+		</a>
 		<span className="wp-block-sensei-lms-course-results__lesson__score">
 			xx%
 		</span>

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -80,6 +80,10 @@ $block: '.wp-block-sensei-lms-course-results';
 		margin: 0;
 		padding: 0;
 
+		&--has-other #{$block}__lesson {
+			border-bottom: 1px solid $dark-gray;
+		}
+
 		#{$block}__lesson {
 			align-items: center;
 			display: flex;

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -1,8 +1,9 @@
 $dark-gray: #1a1d20;
 $spacing: 16px;
+$block: '.wp-block-sensei-lms-course-results';
 
-.wp-block-sensei-lms-course-results,
-.editor-styles-wrapper .wp-block-sensei-lms-course-results {
+#{$block},
+.editor-styles-wrapper #{$block} {
 	&__grade {
 		margin: auto 0;
 		text-align: center;
@@ -55,7 +56,7 @@ $spacing: 16px;
 		}
 
 		&__title,
-		.wp-block-sensei-lms-course-results &__title {
+		#{$block} &__title {
 			font-size: 1.1em;
 			font-weight: inherit;
 			flex: 1;
@@ -68,23 +69,29 @@ $spacing: 16px;
 		}
 	}
 
-	&__lesson {
-		display: flex;
-		align-items: center;
-		margin: 1px 0;
-		position: relative;
+	&__lessons {
+		list-style: none;
+		margin: 0;
+		padding: 0;
 
-		&__title {
-			flex: 1;
-			padding: $spacing;
-		}
+		#{$block}__lesson {
+			display: flex;
+			align-items: center;
+			margin: 1px 0;
+			position: relative;
 
-		&__score {
-			display: inline-block;
-			flex: 0 0 40px;
-			margin: 0 $spacing;
-			flex-shrink: 0;
-			opacity: 0.9;
+			&__title {
+				flex: 1;
+				padding: $spacing;
+			}
+
+			&__score {
+				display: inline-block;
+				flex: 0 0 40px;
+				margin: 0 $spacing;
+				flex-shrink: 0;
+				opacity: 0.9;
+			}
 		}
 	}
 }

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -72,6 +72,7 @@ $block: '.wp-block-sensei-lms-course-results';
 		}
 	}
 
+	#left-area &__lessons,
 	&__lessons {
 		list-style: none;
 		margin: 0;

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -55,8 +55,6 @@ $block: '.wp-block-sensei-lms-course-results';
 		&-header {
 			padding: $spacing;
 			font-weight: bold;
-			display: flex;
-			align-items: center;
 			background: var( --sensei-module-header-bg-color );
 			color: var( --sensei-module-header-text-color );
 		}
@@ -65,7 +63,6 @@ $block: '.wp-block-sensei-lms-course-results';
 		#{$block} &-title {
 			font-size: 1.1em;
 			font-weight: inherit;
-			flex: 1;
 			margin: 0;
 			color: inherit;
 			&::before,
@@ -85,15 +82,18 @@ $block: '.wp-block-sensei-lms-course-results';
 		}
 
 		#{$block}__lesson {
-			align-items: center;
-			display: flex;
 			margin: 1px 0;
 			position: relative;
+
+			#{$block}__lesson-link {
+				align-items: center;
+				display: flex;
+				text-decoration: none;
+			}
 
 			&-title {
 				flex: 1;
 				padding: $spacing;
-				text-decoration: none;
 			}
 
 			&-score {

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -5,7 +5,7 @@ $block: '.wp-block-sensei-lms-course-results';
 #{$block},
 .editor-styles-wrapper #{$block} {
 	&.is-style-default {
-		#{$block}__module__header:not(.has-background) {
+		#{$block}__module-header:not(.has-background) {
 			background-color: $dark-gray;
 		}
 	}
@@ -15,11 +15,11 @@ $block: '.wp-block-sensei-lms-course-results';
 		text-align: center;
 		width: 100%;
 
-		&__label {
+		&-label {
 			font-size: 1.1em;
 		}
 
-		&__score {
+		&-score {
 			display: block;
 			font-size: 2em;
 			font-weight: bold;
@@ -27,7 +27,7 @@ $block: '.wp-block-sensei-lms-course-results';
 		}
 	}
 
-	&__title {
+	&__course-title {
 		margin: 1em 0 0.5em;
 		padding: 0;
 		text-align: center;
@@ -48,7 +48,11 @@ $block: '.wp-block-sensei-lms-course-results';
 	&__module {
 		margin: 1em 0;
 
-		&__header {
+		&--has-border {
+			border: 1px solid var( --sensei-module-border-color, $dark-gray );
+		}
+
+		&-header {
 			padding: $spacing;
 			font-weight: bold;
 			display: flex;
@@ -57,12 +61,8 @@ $block: '.wp-block-sensei-lms-course-results';
 			color: var( --sensei-module-header-text-color );
 		}
 
-		&__bordered {
-			border: 1px solid var( --sensei-module-border-color, $dark-gray );
-		}
-
-		&__title,
-		#{$block} &__title {
+		&-title,
+		#{$block} &-title {
 			font-size: 1.1em;
 			font-weight: inherit;
 			flex: 1;
@@ -86,13 +86,13 @@ $block: '.wp-block-sensei-lms-course-results';
 			margin: 1px 0;
 			position: relative;
 
-			&__title {
+			&-title {
 				flex: 1;
 				padding: $spacing;
 				text-decoration: none;
 			}
 
-			&__score {
+			&-score {
 				display: inline-block;
 				flex: 0 0 40px;
 				margin: 0 $spacing;

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -72,7 +72,7 @@ $block: '.wp-block-sensei-lms-course-results';
 		}
 	}
 
-	#left-area &__lessons,
+	#left-area &__lessons, // Divi
 	&__lessons {
 		list-style: none;
 		margin: 0;

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -75,14 +75,15 @@ $block: '.wp-block-sensei-lms-course-results';
 		padding: 0;
 
 		#{$block}__lesson {
-			display: flex;
 			align-items: center;
+			display: flex;
 			margin: 1px 0;
 			position: relative;
 
 			&__title {
 				flex: 1;
 				padding: $spacing;
+				text-decoration: none;
 			}
 
 			&__score {

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -4,6 +4,12 @@ $block: '.wp-block-sensei-lms-course-results';
 
 #{$block},
 .editor-styles-wrapper #{$block} {
+	&.is-style-default {
+		#{$block}__module__header:not(.has-background) {
+			background-color: $dark-gray;
+		}
+	}
+
 	&__grade {
 		margin: auto 0;
 		text-align: center;

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -77,6 +77,10 @@ $block: '.wp-block-sensei-lms-course-results';
 		margin: 0;
 		padding: 0;
 
+		&--has-other {
+			margin-bottom: 1em;
+		}
+
 		&--has-other #{$block}__lesson {
 			border-bottom: 1px solid $dark-gray;
 		}

--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -33,6 +33,18 @@ $block: '.wp-block-sensei-lms-course-results';
 		text-align: center;
 	}
 
+	&__separator {
+		display: block;
+		border: none;
+		height: 4px;
+		margin-left: 4px;
+		margin-right: 4px;
+		background-color: var(
+			--sensei-module-header-separator-color,
+			$dark-gray
+		);
+	}
+
 	&__module {
 		margin: 1em 0;
 
@@ -47,18 +59,6 @@ $block: '.wp-block-sensei-lms-course-results';
 
 		&__bordered {
 			border: 1px solid var( --sensei-module-border-color, $dark-gray );
-		}
-
-		&__separator {
-			display: block;
-			border: none;
-			height: 4px;
-			margin-left: 4px;
-			margin-right: 4px;
-			background-color: var(
-				--sensei-module-header-separator-color,
-				$dark-gray
-			);
 		}
 
 		&__title,

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -275,9 +275,9 @@ class Sensei_Course_Results_Block {
 	private function render_lesson( $item ) {
 		$section_content   = [];
 		$section_content[] = '<li class="wp-block-sensei-lms-course-results__lesson">';
-		$section_content[] = '<span class="wp-block-sensei-lms-course-results__lesson__title">';
+		$section_content[] = '<a class="wp-block-sensei-lms-course-results__lesson__title" href="' . esc_url( get_permalink( $item['id'] ) ) . '">';
 		$section_content[] = esc_html( $item['title'] );
-		$section_content[] = '</span>';
+		$section_content[] = '</a>';
 
 		$grade = $this->get_lesson_grade( $item['id'] );
 		if ( null !== $grade ) {

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -96,15 +96,13 @@ class Sensei_Course_Results_Block {
 		// Render other lessons.
 		if ( $has_other_lessons ) {
 			$block_content[] = '<ul class="wp-block-sensei-lms-course-results__lessons wp-block-sensei-lms-course-results__lessons--has-other">';
-		}
 
-		foreach ( $structure as $item ) {
-			if ( 'lesson' === $item['type'] ) {
-				$block_content[] = $this->render_lesson( $item );
+			foreach ( $structure as $item ) {
+				if ( 'lesson' === $item['type'] ) {
+					$block_content[] = $this->render_lesson( $item );
+				}
 			}
-		}
 
-		if ( $has_other_lessons ) {
 			$block_content[] = '</ul>';
 		}
 

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -286,9 +286,10 @@ class Sensei_Course_Results_Block {
 	private function render_lesson( $item ) {
 		$section_content   = [];
 		$section_content[] = '<li class="wp-block-sensei-lms-course-results__lesson">';
-		$section_content[] = '<a class="wp-block-sensei-lms-course-results__lesson-title" href="' . esc_url( get_permalink( $item['id'] ) ) . '">';
+		$section_content[] = '<a href="' . esc_url( get_permalink( $item['id'] ) ) . '" class="wp-block-sensei-lms-course-results__lesson-link">';
+		$section_content[] = '<span class="wp-block-sensei-lms-course-results__lesson-title">';
 		$section_content[] = esc_html( $item['title'] );
-		$section_content[] = '</a>';
+		$section_content[] = '</span>';
 
 		$grade = $this->get_lesson_grade( $item['id'] );
 		if ( null !== $grade ) {
@@ -297,6 +298,7 @@ class Sensei_Course_Results_Block {
 			$section_content[] = '</span>';
 		}
 
+		$section_content[] = '</a>';
 		$section_content[] = '</li>';
 
 		return implode( $section_content );

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -95,7 +95,7 @@ class Sensei_Course_Results_Block {
 
 		// Render other lessons.
 		if ( $has_other_lessons ) {
-			$block_content[] = '<ul class="wp-block-sensei-lms-course-results__lessons">';
+			$block_content[] = '<ul class="wp-block-sensei-lms-course-results__lessons wp-block-sensei-lms-course-results__lessons--has-other">';
 		}
 
 		foreach ( $structure as $item ) {
@@ -161,18 +161,11 @@ class Sensei_Course_Results_Block {
 		}
 
 		// Render separator for courses that don't have any modules.
-		$type_counts   = array_count_values( array_column( $structure, 'type' ) );
-		$has_modules   = array_key_exists( 'module', $type_counts ) && 0 < $type_counts['module'];
-		$separator_css = Sensei_Block_Helpers::build_styles(
-			$attributes,
-			[
-				'mainColor'   => 'background-color',
-				'borderColor' => null,
-			]
-		);
+		$type_counts = array_count_values( array_column( $structure, 'type' ) );
+		$has_modules = array_key_exists( 'module', $type_counts ) && 0 < $type_counts['module'];
 
 		if ( ! $has_modules ) {
-			$content[] = '<div ' . Sensei_Block_Helpers::render_style_attributes( 'wp-block-sensei-lms-course-results__separator', $separator_css ) . '></div>';
+			$content[] = '<div class="wp-block-sensei-lms-course-results__separator"></div>';
 		}
 
 		return implode( $content );

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -130,10 +130,10 @@ class Sensei_Course_Results_Block {
 
 		$content   = [];
 		$content[] = '<div class="wp-block-sensei-lms-course-results__grade">';
-		$content[] = '<span class="wp-block-sensei-lms-course-results__grade__label">';
+		$content[] = '<span class="wp-block-sensei-lms-course-results__grade-label">';
 		$content[] = __( 'Your Total Grade', 'sensei-lms' );
 		$content[] = '</span>';
-		$content[] = '<span class="wp-block-sensei-lms-course-results__grade__score">';
+		$content[] = '<span class="wp-block-sensei-lms-course-results__grade-score">';
 		$content[] = Sensei_Utils::sensei_course_user_grade( $course_id, get_current_user_id() ) . '%';
 		$content[] = '</span>';
 		$content[] = '</div>';
@@ -155,7 +155,7 @@ class Sensei_Course_Results_Block {
 		$course_title = $course_id ? get_the_title( $course_id ) : '';
 
 		if ( $course_title ) {
-			$content[] = '<h2 class="wp-block-sensei-lms-course-results__title">';
+			$content[] = '<h2 class="wp-block-sensei-lms-course-results__course-title">';
 			$content[] = $course_title;
 			$content[] = '</h2>';
 		}
@@ -214,8 +214,8 @@ class Sensei_Course_Results_Block {
 		}
 
 		$section_content[] = '<section ' . $this->get_module_html_attributes( $class_name, $attributes ) . '>';
-		$section_content[] = '<header ' . Sensei_Block_Helpers::render_style_attributes( [ 'wp-block-sensei-lms-course-results__module__header' ], $module_header_css ) . '>';
-		$section_content[] = '<h3 class="wp-block-sensei-lms-course-results__module__title">';
+		$section_content[] = '<header ' . Sensei_Block_Helpers::render_style_attributes( [ 'wp-block-sensei-lms-course-results__module-header' ], $module_header_css ) . '>';
+		$section_content[] = '<h3 class="wp-block-sensei-lms-course-results__module-title">';
 		$section_content[] = esc_html( $item['title'] );
 		$section_content[] = '</h3>';
 		$section_content[] = '</header>';
@@ -269,7 +269,7 @@ class Sensei_Course_Results_Block {
 		);
 
 		if ( ! empty( $attributes['moduleBorder'] ) ) {
-			$class_names[] = 'wp-block-sensei-lms-course-results__module__bordered';
+			$class_names[] = 'wp-block-sensei-lms-course-results__module--has-border';
 
 			if ( ! empty( $attributes['borderColorValue'] ) ) {
 				$inline_styles[] = sprintf( 'border-color: %s;', $attributes['borderColorValue'] );
@@ -293,13 +293,13 @@ class Sensei_Course_Results_Block {
 	private function render_lesson( $item ) {
 		$section_content   = [];
 		$section_content[] = '<li class="wp-block-sensei-lms-course-results__lesson">';
-		$section_content[] = '<a class="wp-block-sensei-lms-course-results__lesson__title" href="' . esc_url( get_permalink( $item['id'] ) ) . '">';
+		$section_content[] = '<a class="wp-block-sensei-lms-course-results__lesson-title" href="' . esc_url( get_permalink( $item['id'] ) ) . '">';
 		$section_content[] = esc_html( $item['title'] );
 		$section_content[] = '</a>';
 
 		$grade = $this->get_lesson_grade( $item['id'] );
 		if ( null !== $grade ) {
-			$section_content[] = '<span class="wp-block-sensei-lms-course-results__lesson__score">';
+			$section_content[] = '<span class="wp-block-sensei-lms-course-results__lesson-score">';
 			$section_content[] = $grade . '%';
 			$section_content[] = '</span>';
 		}

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -226,13 +226,11 @@ class Sensei_Course_Results_Block {
 
 		if ( 0 < count( $item['lessons'] ) ) {
 			$section_content[] = '<ul class="wp-block-sensei-lms-course-results__lessons">';
-		}
 
-		foreach ( $item['lessons'] as $lesson ) {
-			$section_content[] = $this->render_lesson( $lesson );
-		}
+			foreach ( $item['lessons'] as $lesson ) {
+				$section_content[] = $this->render_lesson( $lesson );
+			}
 
-		if ( 0 < count( $item['lessons'] ) ) {
 			$section_content[] = '</ul>';
 		}
 

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -79,8 +79,7 @@ class Sensei_Course_Results_Block {
 
 		$class_name        = Sensei_Block_Helpers::block_class_with_default_style( $attributes, [] );
 		$structure         = Sensei_Course_Structure::instance( $course_id )->get( 'view' );
-		$other_lessons     = array_count_values( array_column( $structure, 'type' ) );
-		$has_other_lessons = array_key_exists( 'lesson', $other_lessons ) && 0 < $other_lessons['lesson'];
+		$has_other_lessons = $this->course_structure_has_type( $structure, 'lesson' );
 		$block_content     = [];
 		$block_content[]   = '<section class="wp-block-sensei-lms-course-results sensei-block-wrapper ' . $class_name . '">';
 		$block_content[]   = $this->render_total_grade( $course_id );
@@ -159,8 +158,7 @@ class Sensei_Course_Results_Block {
 		}
 
 		// Render separator for courses that don't have any modules.
-		$type_counts = array_count_values( array_column( $structure, 'type' ) );
-		$has_modules = array_key_exists( 'module', $type_counts ) && 0 < $type_counts['module'];
+		$has_modules = $this->course_structure_has_type( $structure, 'module' );
 
 		if ( ! $has_modules ) {
 			$content[] = '<div class="wp-block-sensei-lms-course-results__separator"></div>';
@@ -333,4 +331,17 @@ class Sensei_Course_Results_Block {
 		return $grade;
 	}
 
+	/**
+	 * Check whether the course structure contains an item of the specified type.
+	 *
+	 * @param array  $structure  Course structure information.
+	 * @param string $type       Type to check (module, lesson).
+	 *
+	 * @return bool Whether an item of the specified type exists in the course structure.
+	 */
+	private function course_structure_has_type( $structure, $type ) {
+		$type_counts = array_count_values( array_column( $structure, 'type' ) );
+
+		return array_key_exists( $type, $type_counts ) && 0 < $type_counts[ $type ];
+	}
 }

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -77,11 +77,12 @@ class Sensei_Course_Results_Block {
 			return $this->block_content;
 		}
 
+		$class_name        = Sensei_Block_Helpers::block_class_with_default_style( $attributes, [] );
 		$structure         = Sensei_Course_Structure::instance( $course_id )->get( 'view' );
 		$other_lessons     = array_count_values( array_column( $structure, 'type' ) );
 		$has_other_lessons = array_key_exists( 'lesson', $other_lessons ) && 0 < $other_lessons['lesson'];
 		$block_content     = [];
-		$block_content[]   = '<section class="wp-block-sensei-lms-course-results sensei-block-wrapper">';
+		$block_content[]   = '<section class="wp-block-sensei-lms-course-results sensei-block-wrapper' . $class_name . '">';
 		$block_content[]   = $this->render_total_grade( $course_id );
 		$block_content[]   = $this->render_course_title( $course_id );
 
@@ -241,7 +242,7 @@ class Sensei_Course_Results_Block {
 	 * @return string The html attributes.
 	 */
 	private function get_module_html_attributes( $class_name, $attributes ) : string {
-		$class_names   = [ 'wp-block-sensei-lms-course-results__module', $class_name ];
+		$class_names   = [ 'wp-block-sensei-lms-course-results__module' ];
 		$inline_styles = [];
 		$css           = Sensei_Block_Helpers::build_styles(
 			$attributes,

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -82,9 +82,9 @@ class Sensei_Course_Results_Block {
 		$other_lessons     = array_count_values( array_column( $structure, 'type' ) );
 		$has_other_lessons = array_key_exists( 'lesson', $other_lessons ) && 0 < $other_lessons['lesson'];
 		$block_content     = [];
-		$block_content[]   = '<section class="wp-block-sensei-lms-course-results sensei-block-wrapper' . $class_name . '">';
+		$block_content[]   = '<section class="wp-block-sensei-lms-course-results sensei-block-wrapper ' . $class_name . '">';
 		$block_content[]   = $this->render_total_grade( $course_id );
-		$block_content[]   = $this->render_course_title( $course_id );
+		$block_content[]   = $this->render_course_title( $course_id, $structure, $attributes );
 
 		// Render modules and associated lessons.
 		foreach ( $structure as $item ) {
@@ -144,11 +144,13 @@ class Sensei_Course_Results_Block {
 	/**
 	 * Render the course title.
 	 *
-	 * @param int $course_id Course ID.
+	 * @param int   $course_id  Course ID.
+	 * @param array $structure  Course structure information.
+	 * @param array $attributes The block attributes.
 	 *
 	 * @return string HTML for the course title.
 	 */
-	private function render_course_title( $course_id ) {
+	private function render_course_title( $course_id, $structure, $attributes ) {
 		$content      = [];
 		$course_title = $course_id ? get_the_title( $course_id ) : '';
 
@@ -156,6 +158,21 @@ class Sensei_Course_Results_Block {
 			$content[] = '<h2 class="wp-block-sensei-lms-course-results__title">';
 			$content[] = $course_title;
 			$content[] = '</h2>';
+		}
+
+		// Render separator for courses that don't have any modules.
+		$type_counts   = array_count_values( array_column( $structure, 'type' ) );
+		$has_modules   = array_key_exists( 'module', $type_counts ) && 0 < $type_counts['module'];
+		$separator_css = Sensei_Block_Helpers::build_styles(
+			$attributes,
+			[
+				'mainColor'   => 'background-color',
+				'borderColor' => null,
+			]
+		);
+
+		if ( ! $has_modules ) {
+			$content[] = '<div ' . Sensei_Block_Helpers::render_style_attributes( 'wp-block-sensei-lms-course-results__separator', $separator_css ) . '></div>';
 		}
 
 		return implode( $content );
@@ -212,7 +229,7 @@ class Sensei_Course_Results_Block {
 				]
 			);
 
-			$section_content[] = '<div ' . Sensei_Block_Helpers::render_style_attributes( 'wp-block-sensei-lms-course-results__module__separator', $header_border_css ) . '></div>';
+			$section_content[] = '<div ' . Sensei_Block_Helpers::render_style_attributes( 'wp-block-sensei-lms-course-results__separator', $header_border_css ) . '></div>';
 
 		}
 

--- a/includes/blocks/class-sensei-course-results-block.php
+++ b/includes/blocks/class-sensei-course-results-block.php
@@ -77,21 +77,36 @@ class Sensei_Course_Results_Block {
 			return $this->block_content;
 		}
 
-		$structure       = Sensei_Course_Structure::instance( $course_id )->get( 'view' );
-		$block_content   = [];
-		$block_content[] = '<section class="wp-block-sensei-lms-course-results sensei-block-wrapper">';
-		$block_content[] = $this->render_total_grade( $course_id );
-		$block_content[] = $this->render_course_title( $course_id );
+		$structure         = Sensei_Course_Structure::instance( $course_id )->get( 'view' );
+		$other_lessons     = array_count_values( array_column( $structure, 'type' ) );
+		$has_other_lessons = array_key_exists( 'lesson', $other_lessons ) && 0 < $other_lessons['lesson'];
+		$block_content     = [];
+		$block_content[]   = '<section class="wp-block-sensei-lms-course-results sensei-block-wrapper">';
+		$block_content[]   = $this->render_total_grade( $course_id );
+		$block_content[]   = $this->render_course_title( $course_id );
 
+		// Render modules and associated lessons.
 		foreach ( $structure as $item ) {
 			if ( 'module' === $item['type'] ) {
 				$block_content[] = $this->render_module( $item, $attributes );
 			}
+		}
 
+		// Render other lessons.
+		if ( $has_other_lessons ) {
+			$block_content[] = '<ul class="wp-block-sensei-lms-course-results__lessons">';
+		}
+
+		foreach ( $structure as $item ) {
 			if ( 'lesson' === $item['type'] ) {
 				$block_content[] = $this->render_lesson( $item );
 			}
 		}
+
+		if ( $has_other_lessons ) {
+			$block_content[] = '</ul>';
+		}
+
 		$block_content[] = '</section>';
 
 		$this->block_content = implode( $block_content );
@@ -200,8 +215,16 @@ class Sensei_Course_Results_Block {
 
 		}
 
+		if ( 0 < count( $item['lessons'] ) ) {
+			$section_content[] = '<ul class="wp-block-sensei-lms-course-results__lessons">';
+		}
+
 		foreach ( $item['lessons'] as $lesson ) {
 			$section_content[] = $this->render_lesson( $lesson );
+		}
+
+		if ( 0 < count( $item['lessons'] ) ) {
+			$section_content[] = '</ul>';
 		}
 
 		$section_content[] = '</section>';
@@ -251,7 +274,7 @@ class Sensei_Course_Results_Block {
 	 */
 	private function render_lesson( $item ) {
 		$section_content   = [];
-		$section_content[] = '<div class="wp-block-sensei-lms-course-results__lesson">';
+		$section_content[] = '<li class="wp-block-sensei-lms-course-results__lesson">';
 		$section_content[] = '<span class="wp-block-sensei-lms-course-results__lesson__title">';
 		$section_content[] = esc_html( $item['title'] );
 		$section_content[] = '</span>';
@@ -263,7 +286,7 @@ class Sensei_Course_Results_Block {
 			$section_content[] = '</span>';
 		}
 
-		$section_content[] = '</div>';
+		$section_content[] = '</li>';
 
 		return implode( $section_content );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Show 2 lessons per module in editor.
* Lessons now use semantic markup (i.e. a list).
* Clicking on a lesson will take you to it.
* Fixed issues with color settings.
* Added a separator below the course title and between lessons for courses with no modules.
* Switched to using BEM class names.

### Testing instructions
* Add the Course Results block to the Course Completed page.
* Ensure 2 lessons are displayed per module in the editor.
* Browse to the page on the front end (append a `course_id` query parameter for a completed course).
* Click on a lesson and ensure you're taken to the correct page.
* Test different variations of the styles and color settings and ensure they work in the front end and back end.
* For courses without any modules, check that a separator appears below the course title and between the lessons. Note that because the color settings are only applicable to modules, they will not have any affect on courses that don't have modules. Same goes for the styles and border.

### Screenshot / Video
_Course with No Modules on Twenty Twenty One_

![Screen Shot 2021-08-11 at 11 35 07 AM](https://user-images.githubusercontent.com/1190420/129059290-a5a9e3c7-94e5-4788-82a3-f4f8a069c3d3.jpg)