### PR TITLE
Add blocks template to completed course page

### DIFF
--- a/assets/blocks/course-results-block/course-results.scss
+++ b/assets/blocks/course-results-block/course-results.scss
@@ -8,6 +8,9 @@ $block: '.wp-block-sensei-lms-course-results';
 		#{$block}__module-header:not(.has-background) {
 			background-color: $dark-gray;
 		}
+		#{$block}__module-header:not(.has-text-color) {
+			color: #FFF;
+		}
 	}
 
 	&__grade {

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -114,18 +114,16 @@ class Sensei_Setup_Wizard_Pages {
 
 		$blocks[] = serialize_block(
 			[
-				'blockName'    => 'sensei-lms/course-results',
-				'innerContent' => [],
+				'blockName'    => 'core/buttons',
+				'innerContent' => [ '<div class="wp-block-buttons"><!-- wp:button {"className":"more-courses"} --><div class="wp-block-button more-courses"><a class="wp-block-button__link">' . __( 'Find More Courses', 'sensei-lms' ) . '</a></div><!-- /wp:button --></div>' ],
 				'attrs'        => [],
 			]
 		);
 
-		$find_my_courses_label = __( 'Find More Courses', 'sensei-lms' );
-
 		$blocks[] = serialize_block(
 			[
-				'blockName'    => 'core/buttons',
-				'innerContent' => [ '<div class="wp-block-buttons"><!-- wp:button {"className":"more-courses"} --><div class="wp-block-button more-courses"><a class="wp-block-button__link">Find More Courses</a></div><!-- /wp:button --></div>' ],
+				'blockName'    => 'sensei-lms/course-results',
+				'innerContent' => [],
 				'attrs'        => [],
 			]
 		);

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -107,7 +107,7 @@ class Sensei_Setup_Wizard_Pages {
 		$blocks[] = serialize_block(
 			[
 				'blockName'    => 'core/paragraph',
-				'innerContent' => [ '<p class="has-text-align-center has-large-font-size">' . __( 'Congratulations on completing the course! 🥳', 'sensei-lms' ) . '</p>' ],
+				'innerContent' => [ '<p class="has-text-align-center has-large-font-size">' . __( 'Congratulations on completing this course! 🥳', 'sensei-lms' ) . '</p>' ],
 				'attrs'        => [
 					'align'    => 'center',
 					'fontSize' => 'large',

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -65,7 +65,7 @@ class Sensei_Setup_Wizard_Pages {
 		Sensei()->settings->set( 'my_course_page', $new_my_course_page_id );
 
 		// Course Completion Page.
-		$new_course_completed_page_id = $this->create_page( esc_sql( _x( 'course-completed', 'page_slug', 'sensei-lms' ) ), __( 'Course Completed', 'sensei-lms' ) );
+		$new_course_completed_page_id = $this->create_page( esc_sql( _x( 'course-completed', 'page_slug', 'sensei-lms' ) ), __( 'Course Completed', 'sensei-lms' ), $this->get_course_completed_page_content() );
 		Sensei()->settings->set( 'course_completed_page', $new_course_completed_page_id );
 
 		Sensei()->initiate_rewrite_rules_flush();
@@ -90,6 +90,42 @@ class Sensei_Setup_Wizard_Pages {
 			[
 				'blockName'    => 'sensei-lms/learner-courses',
 				'innerContent' => [],
+				'attrs'        => [],
+			]
+		);
+
+		return implode( $blocks );
+	}
+
+	/**
+	 * Get the block content for course completed.
+	 *
+	 * @return string
+	 */
+	private function get_course_completed_page_content() {
+		$blocks   = [];
+		$blocks[] = serialize_block(
+			[
+				'blockName'    => 'core/paragraph',
+				'innerContent' => [ '<p class="has-text-align-center">' . __( 'Congratulations on completing the course!', 'sensei-lms' ) . '</p>' ],
+				'attrs'        => [ 'align' => 'center' ],
+			]
+		);
+
+		$blocks[] = serialize_block(
+			[
+				'blockName'    => 'sensei-lms/course-results',
+				'innerContent' => [],
+				'attrs'        => [],
+			]
+		);
+
+		$find_my_courses_label = __( 'Find More Courses', 'sensei-lms' );
+
+		$blocks[] = serialize_block(
+			[
+				'blockName'    => 'core/buttons',
+				'innerContent' => [ '<div class="wp-block-buttons"><!-- wp:button {"className":"more-courses"} --><div class="wp-block-button more-courses"><a class="wp-block-button__link">Find More Courses</a></div><!-- /wp:button --></div>' ],
 				'attrs'        => [],
 			]
 		);

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -107,16 +107,19 @@ class Sensei_Setup_Wizard_Pages {
 		$blocks[] = serialize_block(
 			[
 				'blockName'    => 'core/paragraph',
-				'innerContent' => [ '<p class="has-text-align-center">' . __( 'Congratulations on completing the course! 🥳', 'sensei-lms' ) . '</p>' ],
-				'attrs'        => [ 'align' => 'center' ],
+				'innerContent' => [ '<p class="has-text-align-center has-large-font-size">' . __( 'Congratulations on completing the course! 🥳', 'sensei-lms' ) . '</p>' ],
+				'attrs'        => [
+					'align'    => 'center',
+					'fontSize' => 'large',
+				],
 			]
 		);
 
 		$blocks[] = serialize_block(
 			[
 				'blockName'    => 'core/buttons',
-				'innerContent' => [ '<div class="wp-block-buttons"><!-- wp:button {"className":"more-courses"} --><div class="wp-block-button more-courses"><a class="wp-block-button__link">' . __( 'Find More Courses', 'sensei-lms' ) . '</a></div><!-- /wp:button --></div>' ],
-				'attrs'        => [],
+				'innerContent' => [ '<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"className":"more-courses"} --><div class="wp-block-button more-courses"><a class="wp-block-button__link">' . __( 'Find More Courses', 'sensei-lms' ) . '</a></div><!-- /wp:button --></div>' ],
+				'attrs'        => [ 'contentJustification' => 'center' ],
 			]
 		);
 

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -107,7 +107,7 @@ class Sensei_Setup_Wizard_Pages {
 		$blocks[] = serialize_block(
 			[
 				'blockName'    => 'core/paragraph',
-				'innerContent' => [ '<p class="has-text-align-center">' . __( 'Congratulations on completing the course!', 'sensei-lms' ) . '</p>' ],
+				'innerContent' => [ '<p class="has-text-align-center">' . __( 'Congratulations on completing the course! 🥳', 'sensei-lms' ) . '</p>' ],
 				'attrs'        => [ 'align' => 'center' ],
 			]
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It adds a default blocks template to the completed course page, when created through Setup Wizard.

### Testing instructions

* Remove the Course Completed page, if you already have it.
* Go through the Sensei Setup Wizard and post the welcome step. `/wp-admin/admin.php?page=sensei_setup_wizard`
* Make sure the Course Completed page was created.
* Also make sure it has default colors in the frontend.
* Go to the page editor, save it, and make sure now it has the correct colors in the frontend.