### PR TITLE
Update "Course Completed Actions" variation

### DIFF
--- a/assets/blocks/course-completed-actions/index.js
+++ b/assets/blocks/course-completed-actions/index.js
@@ -30,6 +30,7 @@ export const registerCourseCompletedActionsBlock = () =>
 			],
 		] ),
 		attributes: {
+			contentJustification: 'center',
 			anchor: 'course-completed-actions',
 		},
 		isActive: ( blockAttributes, variationAttributes ) =>

--- a/assets/blocks/course-completed-actions/index.js
+++ b/assets/blocks/course-completed-actions/index.js
@@ -29,4 +29,9 @@ export const registerCourseCompletedActionsBlock = () =>
 				},
 			],
 		] ),
+		attributes: {
+			anchor: 'course-completed-actions',
+		},
+		isActive: ( blockAttributes, variationAttributes ) =>
+			blockAttributes.anchor === variationAttributes.anchor,
 	} );

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -140,7 +140,7 @@ class Sensei_Setup_Wizard_Pages {
 					],
 					[
 						'blockName'    => 'core/buttons',
-						'innerContent' => [ '<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"className":"more-courses"} --><div class="wp-block-button more-courses"><a class="wp-block-button__link">' . __( 'Find More Courses', 'sensei-lms' ) . '</a></div><!-- /wp:button --></div>' ],
+						'innerContent' => [ '<div class="wp-block-buttons is-content-justification-center" id="course-completed-actions"><!-- wp:button {"className":"more-courses"} --><div class="wp-block-button more-courses"><a class="wp-block-button__link">' . __( 'Find More Courses', 'sensei-lms' ) . '</a></div><!-- /wp:button --></div>' ],
 						'attrs'        => [
 							'contentJustification' => 'center',
 							'anchor'               => 'course-completed-actions',

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -77,24 +77,36 @@ class Sensei_Setup_Wizard_Pages {
 	 * @return string
 	 */
 	private function get_learner_courses_page_content() {
-		$blocks   = [];
-		$blocks[] = serialize_block(
-			[
-				'blockName'    => 'sensei-lms/button-learner-messages',
-				'innerContent' => [],
-				'attrs'        => [],
-			]
+		$blocks = serialize_blocks(
+			/**
+			 * Filter the learner courses page content when auto-creating it
+			 * through setup wizard.
+			 *
+			 * @hook  sensei_learner_courses_page_content
+			 * @since 3.13.1
+			 *
+			 * @param {array} $learner_courses_page_content Blocks array.
+			 *
+			 * @return {array} Blocks array.
+			 */
+			apply_filters(
+				'sensei_learner_courses_page_content',
+				[
+					[
+						'blockName'    => 'sensei-lms/button-learner-messages',
+						'innerContent' => [],
+						'attrs'        => [],
+					],
+					[
+						'blockName'    => 'sensei-lms/learner-courses',
+						'innerContent' => [],
+						'attrs'        => [],
+					],
+				]
+			)
 		);
 
-		$blocks[] = serialize_block(
-			[
-				'blockName'    => 'sensei-lms/learner-courses',
-				'innerContent' => [],
-				'attrs'        => [],
-			]
-		);
-
-		return implode( $blocks );
+		return $blocks;
 	}
 
 	/**
@@ -103,38 +115,47 @@ class Sensei_Setup_Wizard_Pages {
 	 * @return string
 	 */
 	private function get_course_completed_page_content() {
-		$blocks   = [];
-		$blocks[] = serialize_block(
-			[
-				'blockName'    => 'core/paragraph',
-				'innerContent' => [ '<p class="has-text-align-center has-large-font-size">' . __( 'Congratulations on completing this course! 🥳', 'sensei-lms' ) . '</p>' ],
-				'attrs'        => [
-					'align'    => 'center',
-					'fontSize' => 'large',
-				],
-			]
+		$blocks = serialize_blocks(
+			/**
+			 * Filter the course completed page content when auto-creating it
+			 * through setup wizard.
+			 *
+			 * @hook  sensei_course_completed_page_content
+			 * @since 3.13.1
+			 *
+			 * @param {array} $course_completed_page_content Blocks array.
+			 *
+			 * @return {array} Blocks array.
+			 */
+			apply_filters(
+				'sensei_course_completed_page_content',
+				[
+					[
+						'blockName'    => 'core/paragraph',
+						'innerContent' => [ '<p class="has-text-align-center has-large-font-size">' . __( 'Congratulations on completing this course! 🥳', 'sensei-lms' ) . '</p>' ],
+						'attrs'        => [
+							'align'    => 'center',
+							'fontSize' => 'large',
+						],
+					],
+					[
+						'blockName'    => 'core/buttons',
+						'innerContent' => [ '<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"className":"more-courses"} --><div class="wp-block-button more-courses"><a class="wp-block-button__link">' . __( 'Find More Courses', 'sensei-lms' ) . '</a></div><!-- /wp:button --></div>' ],
+						'attrs'        => [
+							'contentJustification' => 'center',
+							'anchor'               => 'course-completed-actions',
+						],
+					],
+					[
+						'blockName'    => 'sensei-lms/course-results',
+						'innerContent' => [],
+						'attrs'        => [],
+					],
+				]
+			)
 		);
 
-		$blocks[] = serialize_block(
-			[
-				'blockName'    => 'core/buttons',
-				'innerContent' => [ '<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"className":"more-courses"} --><div class="wp-block-button more-courses"><a class="wp-block-button__link">' . __( 'Find More Courses', 'sensei-lms' ) . '</a></div><!-- /wp:button --></div>' ],
-				'attrs'        => [
-					'contentJustification' => 'center',
-					'anchor'               => 'course-completed-actions',
-				],
-			]
-		);
-
-		$blocks[] = serialize_block(
-			[
-				'blockName'    => 'sensei-lms/course-results',
-				'innerContent' => [],
-				'attrs'        => [],
-			]
-		);
-
-		return implode( $blocks );
+		return $blocks;
 	}
 
 }

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -82,15 +82,15 @@ class Sensei_Setup_Wizard_Pages {
 			 * Filter the learner courses page content when auto-creating it
 			 * through setup wizard.
 			 *
-			 * @hook  sensei_learner_courses_page_content
+			 * @hook  sensei_default_learner_courses_page_content
 			 * @since 3.13.1
 			 *
-			 * @param {array} $learner_courses_page_content Blocks array.
+			 * @param {array} $blocks Blocks array.
 			 *
 			 * @return {array} Blocks array.
 			 */
 			apply_filters(
-				'sensei_learner_courses_page_content',
+				'sensei_default_learner_courses_page_content',
 				[
 					[
 						'blockName'    => 'sensei-lms/button-learner-messages',
@@ -120,15 +120,15 @@ class Sensei_Setup_Wizard_Pages {
 			 * Filter the course completed page content when auto-creating it
 			 * through setup wizard.
 			 *
-			 * @hook  sensei_course_completed_page_content
+			 * @hook  sensei_default_course_completed_page_content
 			 * @since 3.13.1
 			 *
-			 * @param {array} $course_completed_page_content Blocks array.
+			 * @param {array} $blocks Blocks array.
 			 *
 			 * @return {array} Blocks array.
 			 */
 			apply_filters(
-				'sensei_course_completed_page_content',
+				'sensei_default_course_completed_page_content',
 				[
 					[
 						'blockName'    => 'core/paragraph',

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -82,7 +82,7 @@ class Sensei_Setup_Wizard_Pages {
 			 * Filter the learner courses page content when auto-creating it
 			 * through setup wizard.
 			 *
-			 * @hook  sensei_default_learner_courses_page_content
+			 * @hook  sensei_default_learner_courses_page_template
 			 * @since 3.13.1
 			 *
 			 * @param {array} $blocks Blocks array.
@@ -90,7 +90,7 @@ class Sensei_Setup_Wizard_Pages {
 			 * @return {array} Blocks array.
 			 */
 			apply_filters(
-				'sensei_default_learner_courses_page_content',
+				'sensei_default_learner_courses_page_template',
 				[
 					[
 						'blockName'    => 'sensei-lms/button-learner-messages',
@@ -120,7 +120,7 @@ class Sensei_Setup_Wizard_Pages {
 			 * Filter the course completed page content when auto-creating it
 			 * through setup wizard.
 			 *
-			 * @hook  sensei_default_course_completed_page_content
+			 * @hook  sensei_default_course_completed_page_template
 			 * @since 3.13.1
 			 *
 			 * @param {array} $blocks Blocks array.
@@ -128,7 +128,7 @@ class Sensei_Setup_Wizard_Pages {
 			 * @return {array} Blocks array.
 			 */
 			apply_filters(
-				'sensei_default_course_completed_page_content',
+				'sensei_default_course_completed_page_template',
 				[
 					[
 						'blockName'    => 'core/paragraph',

--- a/includes/admin/class-sensei-setup-wizard-pages.php
+++ b/includes/admin/class-sensei-setup-wizard-pages.php
@@ -119,7 +119,10 @@ class Sensei_Setup_Wizard_Pages {
 			[
 				'blockName'    => 'core/buttons',
 				'innerContent' => [ '<div class="wp-block-buttons is-content-justification-center"><!-- wp:button {"className":"more-courses"} --><div class="wp-block-button more-courses"><a class="wp-block-button__link">' . __( 'Find More Courses', 'sensei-lms' ) . '</a></div><!-- /wp:button --></div>' ],
-				'attrs'        => [ 'contentJustification' => 'center' ],
+				'attrs'        => [
+					'contentJustification' => 'center',
+					'anchor'               => 'course-completed-actions',
+				],
 			]
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It adds an anchor attribute to the Course Completed Actions variation, so we can associate the variation (`isActive` method) to the block through that argument.
* It also adds 2 new filters to override the page content creation through Setup Wizard. It can be useful in case we want customize the default blocks from other plugins.
* And it adds the `contentJustification` attribute as `center` to the block variation.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Remove the My Courses and the Course Completed pages.
* Go to the setup wizard, and submit the "Welcome" step.
* Make sure the pages were created with the correct blocks.
* Go to the Course Completed page. Select the actions block, and make sure it's identified as _"Course Completed Actions"_ in the sidebar.
* Remove the block, and adds it again. Make sure it continues identified as _"Course Completed Actions"_.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_default_learner_courses_page_content` (arguments: `$blocks`) - Filter the learner course page content when auto-created through setup wizard.
* `sensei_default_course_completed_page_content` (arguments: `$blocks`) - Filter the course completed page content when auto-created through setup wizard.