### PR TITLE
Rename Take Course block to Course Sign Up

### DIFF
--- a/assets/blocks/contact-teacher-block/index.js
+++ b/assets/blocks/contact-teacher-block/index.js
@@ -10,7 +10,7 @@ import { BlockStyles, createButtonBlockType } from '../button';
 import ToggleLegacyMetaboxesWrapper from '../toggle-legacy-metaboxes-wrapper';
 
 /**
- * Take course button block.
+ * Contact teacher button block.
  */
 export default createButtonBlockType( {
 	tagName: 'a',

--- a/assets/blocks/take-course-block/index.js
+++ b/assets/blocks/take-course-block/index.js
@@ -16,7 +16,7 @@ export default createButtonBlockType( {
 	EditWrapper: ToggleLegacyMetaboxesWrapper,
 	settings: {
 		name: 'sensei-lms/button-take-course',
-		title: __( 'Take Course', 'sensei-lms' ),
+		title: __( 'Course Sign Up', 'sensei-lms' ),
 		description: __(
 			'Enable a registered user to start the course. This block is only displayed if the user is not already enrolled.',
 			'sensei-lms'
@@ -27,6 +27,7 @@ export default createButtonBlockType( {
 			__( 'Enrol', 'sensei-lms' ),
 			__( 'Enroll', 'sensei-lms' ),
 			__( 'Course', 'sensei-lms' ),
+			__( 'Take course', 'sensei-lms' ),
 		],
 		attributes: {
 			text: {

--- a/assets/blocks/take-course-block/index.js
+++ b/assets/blocks/take-course-block/index.js
@@ -16,7 +16,7 @@ export default createButtonBlockType( {
 	EditWrapper: ToggleLegacyMetaboxesWrapper,
 	settings: {
 		name: 'sensei-lms/button-take-course',
-		title: __( 'Course Sign Up', 'sensei-lms' ),
+		title: __( 'Course Signup', 'sensei-lms' ),
 		description: __(
 			'Enable a registered user to start the course. This block is only displayed if the user is not already enrolled.',
 			'sensei-lms'
@@ -24,6 +24,7 @@ export default createButtonBlockType( {
 		keywords: [
 			__( 'Start', 'sensei-lms' ),
 			__( 'Sign up', 'sensei-lms' ),
+			__( 'Signup', 'sensei-lms' ),
 			__( 'Enrol', 'sensei-lms' ),
 			__( 'Enroll', 'sensei-lms' ),
 			__( 'Course', 'sensei-lms' ),


### PR DESCRIPTION
Fixes #4285

### Changes proposed in this Pull Request

* Rename Take Course block to Course Sign Up.

I was planning to also change the block name `'sensei-lms/button-take-course'`, but it seems it's not possible without breaking backward compatibility.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Go to the `master` branch.
* Create a course with the Take Course button.
* Go to this branch.
* Select the block, and make sure the name is _"Course Sign Up"_ now.
* Also make sure it continues working properly for courses with associated products.