### PR TITLE
Fix color selector issue

### DIFF
--- a/assets/blocks/learner-courses-block/block.json
+++ b/assets/blocks/learner-courses-block/block.json
@@ -14,9 +14,7 @@
         "courseCategoryEnabled": false,
         "progressBarEnabled": true,
         "progressBarBorderRadius": 10,
-        "progressBarHeight": 14,
-        "primaryColor": null,
-        "accentColor": null
+        "progressBarHeight": 14
       }
     }
   }

--- a/assets/blocks/learner-courses-block/learner-courses-settings.js
+++ b/assets/blocks/learner-courses-block/learner-courses-settings.js
@@ -66,12 +66,12 @@ const LearnerCoursesSettings = ( { options, setOptions } ) => {
 		{
 			optionKey: 'primaryColor',
 			label: __( 'Primary color', 'sensei-lms' ),
-			value: options.primaryColor,
+			value: options.primaryColor || undefined,
 		},
 		{
 			optionKey: 'accentColor',
 			label: __( 'Accent color', 'sensei-lms' ),
-			value: options.accentColor,
+			value: options.accentColor || undefined,
 		},
 	];
 


### PR DESCRIPTION
Fixes #4278

### Changes proposed in this Pull Request

* It fixes an issue when selecting a custom color to the Learner Courses block.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Go to the `master` branch.
* Create a page with the _Learner Courses_ block.
* Go to this branch, and make sure the block continues working properly in the editor, and in the frontend.
* Select a custom color to the block (see #4278 video). And make sure it works properly.
* Repeat the process, re-creating the block in the `master` branch, but this time selecting a color (to make the selector work on `master` you need to click in "Clear" before using the color picker). Make sure the color persists during the branch change.