### PR TITLE
Update Learner Courses block styles

### DIFF
--- a/assets/blocks/learner-courses-block/learner-courses-editor.scss
+++ b/assets/blocks/learner-courses-block/learner-courses-editor.scss
@@ -1,3 +1,4 @@
+@import 'learner-courses-mixins';
 @import '../../shared/blocks/course-progress/course-progress-settings';
 
 $block: '.wp-block-sensei-lms-learner-courses';
@@ -36,8 +37,7 @@ $courses-list: '#{$block}__courses-list';
 	}
 
 	.sensei-results-links {
-		margin-top: auto; // Push button to bottom of card.
-		padding-top: 20px;
+		@include buttons-wrapper;
 
 		.wp-block-button {
 			margin: 0;

--- a/assets/blocks/learner-courses-block/learner-courses-editor.scss
+++ b/assets/blocks/learner-courses-block/learner-courses-editor.scss
@@ -28,7 +28,7 @@ $courses-list: '#{$block}__courses-list';
 	}
 
 	&__description {
-		margin: 0;
+		margin: 16px 0 16px;
 	}
 
 	.wp-block-sensei-lms-course-progress {

--- a/assets/blocks/learner-courses-block/learner-courses-mixins.scss
+++ b/assets/blocks/learner-courses-block/learner-courses-mixins.scss
@@ -1,0 +1,4 @@
+@mixin buttons-wrapper {
+	margin-top: auto; // Push buttons to bottom of card.
+	padding-top: 30px;
+}

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -178,7 +178,7 @@ $courses-list: '#{$block}__courses-list';
 	.course {
 		display: flex;
 		border: 0;
-		box-shadow: 0 1px 10px 0 rgb(25, 30, 35);
+		box-shadow: 0 1px 10px 0 rgba(25, 30, 35, 0.15);
 
 		.course-content,
 		.entry,

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -1,3 +1,4 @@
+@import 'learner-courses-mixins';
 @import '../../shared/blocks/course-progress/course-progress';
 
 $block: '.wp-block-sensei-lms-learner-courses';
@@ -98,8 +99,7 @@ $courses-list: '#{$block}__courses-list';
 		}
 
 		.entry-actions {
-			margin-top: auto; // Push buttons to bottom of card.
-			padding-top: 20px;
+			@include buttons-wrapper;
 
 			.button,
 			.course-complete,
@@ -197,8 +197,7 @@ $courses-list: '#{$block}__courses-list';
 		}
 
 		.entry-actions {
-			margin-top: auto; // Push buttons to bottom of card.
-			padding-top: 20px;
+			@include buttons-wrapper;
 		}
 	}
 }

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -93,6 +93,10 @@ $courses-list: '#{$block}__courses-list';
 			margin: 0;
 		}
 
+		.course-excerpt {
+			margin: 16px 0 16px;
+		}
+
 		.entry-actions {
 			margin-top: auto; // Push buttons to bottom of card.
 			padding-top: 20px;

--- a/templates/content-course.php
+++ b/templates/content-course.php
@@ -9,7 +9,7 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     1.12.2
+ * @version     3.13.1
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -50,11 +50,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 			do_action( 'sensei_course_content_inside_before', get_the_ID() );
 			?>
 
+			<?php if ( get_the_excerpt() ) : ?>
+
 			<p class="course-excerpt">
 
 				<?php echo wp_kses_post( get_the_excerpt() ); ?>
 
 			</p>
+
+			<?php endif; ?>
 
 			<?php
 			/**


### PR DESCRIPTION
Fixes #4277.

### Changes proposed in this Pull Request

For the Learner Courses block:
* Change opacity of card box shadow to 15%.
* Adjust the top and bottom padding around the excerpt to 16px.
* Increase the spacing between the progress bar and the buttons to 30px.

### Testing instructions

View the Learner Courses block in the editor and on the front end and ensure the above tweaks are applied. Check both grid view and list view.

### Changed Templates
- `content-course.php` - Don't add HTML for the course excerpt if it's empty.

### Screenshots
![Screen Shot 2021-08-23 at 4 09 24 PM](https://user-images.githubusercontent.com/1190420/130512636-bb4eee9a-9798-40a0-9abc-783fcccf4a36.jpg)