### PR TITLE
Update `sensei_default_feature_flag_settings` filter to be called later

### DIFF
--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -20,13 +20,37 @@
  */
 class Sensei_Feature_Flags {
 
-	private $default_feature_settings;
-
+	/**
+	 * Feature flags.
+	 *
+	 * @var array
+	 */
 	private $feature_flags;
 
+	/**
+	 * Sensei_Feature_Flags constructor.
+	 */
 	public function __construct() {
-		$this->feature_flags            = array();
-		$this->default_feature_settings = (array) apply_filters(
+		$this->feature_flags = [];
+	}
+
+	/**
+	 * Get default feature settings.
+	 *
+	 * @return array Default feature settings.
+	 */
+	private function get_default_feature_settings() {
+		/**
+		 * Filters the default feature flag settings.
+		 *
+		 * @since 3.13.2
+		 * @hook sensei_default_feature_flag_settings
+		 *
+		 * @param {array} $default_feature_flag_settings Default feature flag settings.
+		 *
+		 * @return {array} Default feature flag settings.
+		 */
+		return apply_filters(
 			'sensei_default_feature_flag_settings',
 			[
 				'rest_api_v1'                  => false,
@@ -37,21 +61,24 @@ class Sensei_Feature_Flags {
 	}
 
 	/**
-	 * checks if a feature is enabled
+	 * Checks if a feature is enabled.
 	 *
-	 * @param $feature
+	 * @param string $feature
+	 *
 	 * @return bool
 	 */
 	public function is_enabled( $feature ) {
-		$feature = trim( strtolower( $feature ) );
-		if ( ! isset( $this->default_feature_settings[ $feature ] ) ) {
+		$feature                  = trim( strtolower( $feature ) );
+		$default_feature_settings = $this->get_default_feature_settings();
+
+		if ( ! isset( $default_feature_settings[ $feature ] ) ) {
 			return false;
 		}
 
 		$full_feature_name = 'sensei_feature_flag_' . $feature;
 		if ( ! isset( $this->feature_flags[ $feature ] ) ) {
 			$feature_define                  = strtoupper( $full_feature_name );
-			$value                           = defined( $feature_define ) ? (bool) constant( $feature_define ) : $this->default_feature_settings[ $feature ];
+			$value                           = defined( $feature_define ) ? (bool) constant( $feature_define ) : $default_feature_settings[ $feature ];
 			$this->feature_flags[ $feature ] = $value;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It refactors the `Sensei_Feature_Flags` class, so we can hook the filter `sensei_default_feature_flag_settings` through other plugins. Previously, this hook was being called in the class instantiation, regardless of any hook, so we were depending on the order of the plugins loading to filter that.
* I considered create the `default_feature_settings` attribute based on a WP hook, but I decided to go with the current solution (use the filter on the `is_enabled`, so we can use the filter at different times).

### New/Updated Hooks

* `sensei_default_feature_flag_settings` - The hook continues the same, just being called in a different moment - when calling the `Sensei_Feature_Flags::is_enabled` instead of on the class constructor.