### PR TITLE
Learner Courses block styling issues

### DIFF
--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -193,7 +193,7 @@ $courses-list: '#{$block}__courses-list';
 		}
 
 		#{$courses-list}__details {
-			padding: 10px;
+			padding: 16px;
 		}
 
 		.entry-actions {

--- a/assets/blocks/learner-courses-block/learner-courses.scss
+++ b/assets/blocks/learner-courses-block/learner-courses.scss
@@ -112,17 +112,12 @@ $courses-list: '#{$block}__courses-list';
 			}
 		}
 
-		form {
+		form,
+		.sensei-results-links {
 			display: flex;
 			flex-wrap: wrap;
 			gap: 5px;
 			margin: 0;
-		}
-
-		.sensei-results-links {
-			.button:not(:first-child) {
-				margin-left: 5px;
-			}
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Adds 16px of padding around the cards in the Learner Courses block (as requested [here](https://github.com/Automattic/sensei/pull/4291#issuecomment-907444815)).
* Moves buttons to a new line if there is not enough space to display them side-by-side (as reported [here](https://github.com/Automattic/sensei/pull/4291#pullrequestreview-736591245)).

### Testing instructions
* Activate the Certificates extension.
* Test the Learner Courses block on multiple themes and ensure the _View Results_ and _View Certificate_ buttons stack when there is not enough space.

### Screenshot / Video
#### Twenty Twenty-One ####

_Before_

![Screen Shot 2021-09-02 at 4 01 01 PM](https://user-images.githubusercontent.com/1190420/131908448-e7c8d2e9-f453-49a7-8a8e-23aa4c3ebe05.jpg)

_After_

![Screen Shot 2021-09-02 at 3 57 35 PM](https://user-images.githubusercontent.com/1190420/131908072-3b091586-93ae-4963-a690-a9c89ccc3a42.jpg)