### PR TITLE
Add clock notice type

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -882,6 +882,12 @@ section.entry span.course-lesson-progress { margin-left: 10px; }
         content: '\f0f6';
       }
     }
+    &.clock {
+      background:#eee;
+      &:before {
+        content: '\f017';
+      }
+    }
     &.normal {
       background:#eee; padding:9px 15px;
     }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,8 +15,8 @@
 	<exclude-pattern type="relative">^tmp/*</exclude-pattern>
 
 	<!-- Configs -->
-	<config name="minimum_supported_wp_version" value="4.9" />
-	<config name="testVersion" value="7.0-"/>
+	<config name="minimum_supported_wp_version" value="5.6" />
+	<config name="testVersion" value="7.3-"/>
 
 	<!-- Rules -->
 	<rule ref="PHPCompatibilityWP"/>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds a notice which has a grey background and a clock icon
![Screenshot 2021-09-10 at 15 45 04](https://user-images.githubusercontent.com/53191348/132855302-7ff259f7-ff00-4cd8-b65a-eb4b5f783f00.png)


### Testing instructions
* You can use [this PR](662-gh-Automattic/sensei-wc-paid-courses) to test how the notice looks.