### PR TITLE
Fix notice of blocks state (have or not Sensei blocks) in dynamic lesson

### DIFF
--- a/assets/js/admin/blocks-toggling-control.js
+++ b/assets/js/admin/blocks-toggling-control.js
@@ -57,47 +57,47 @@ export const startBlocksTogglingControl = ( postType ) => {
 		return;
 	}
 
-	let initialSenseiBlocksCount;
-	let previousSenseiBlocksCount;
+	let initialWithSenseiBlocks; // Whether initial state has Sensei Blocks.
+	let previousWithSenseiBlocks; // Whether previous state has Sensei Blocks.
 	let lastBlocks;
 
 	editorLifecycle( {
 		subscribeListener: () => {
-			const newBlocks = select( 'core/editor' ).getBlocks();
+			const newBlocks = coreEditorSelector.getBlocks();
 
 			// Check if blocks were changed.
 			if ( newBlocks !== lastBlocks ) {
 				lastBlocks = newBlocks;
 				toggleLegacyMetaboxes();
 
-				previousSenseiBlocksCount = getSenseiBlocksCount();
+				previousWithSenseiBlocks = hasSenseiBlocks();
 
-				if ( undefined !== initialSenseiBlocksCount ) {
+				if ( undefined !== initialWithSenseiBlocks ) {
 					toggleLegacyOrBlocksNotice();
 				}
 			}
 		},
 		onSetDirty: () => {
-			// Set initial blocks count.
+			// Set initial blocks state.
 			if (
 				coreEditorSelector.isEditedPostDirty() &&
-				undefined === initialSenseiBlocksCount
+				undefined === initialWithSenseiBlocks
 			) {
-				initialSenseiBlocksCount = previousSenseiBlocksCount;
+				initialWithSenseiBlocks = previousWithSenseiBlocks;
 			}
 		},
 		onSave: () => {
-			// Update initial blocks on post save.
-			initialSenseiBlocksCount = getSenseiBlocksCount();
+			// Update initial blocks state on save.
+			initialWithSenseiBlocks = hasSenseiBlocks();
 			toggleLegacyOrBlocksNotice();
 		},
 	} );
 
 	/**
-	 * Get Sensei blocks count.
+	 * Check whether it has Sensei blocks.
 	 */
-	const getSenseiBlocksCount = () =>
-		getBlocksCount( Object.values( SENSEI_BLOCKS[ postType ] ) );
+	const hasSenseiBlocks = () =>
+		hasSomeBlocks( Object.values( SENSEI_BLOCKS[ postType ] ) );
 
 	/**
 	 * Toggle metaboxes if a replacement block is present or not.
@@ -105,7 +105,7 @@ export const startBlocksTogglingControl = ( postType ) => {
 	const toggleLegacyMetaboxes = () => {
 		Object.entries( metaboxReplacements[ postType ] ).forEach(
 			( [ metaboxName, blockDeps ] ) => {
-				const enable = getBlocksCount( blockDeps ) === 0;
+				const enable = ! hasSomeBlocks( blockDeps );
 				if (
 					enable !==
 					editPostSelector.isEditorPanelEnabled( metaboxName )
@@ -139,9 +139,7 @@ export const startBlocksTogglingControl = ( postType ) => {
 	 * will start using the legacy template or the blocks.
 	 */
 	const toggleLegacyOrBlocksNotice = () => {
-		const senseiBlocksCount = getBlocksCount(
-			Object.values( SENSEI_BLOCKS[ postType ] )
-		);
+		const withSenseiBlocks = hasSenseiBlocks();
 
 		const noticeOptions = {
 			isDismissible: true,
@@ -154,10 +152,10 @@ export const startBlocksTogglingControl = ( postType ) => {
 			],
 		};
 
-		if ( senseiBlocksCount > 0 ) {
+		if ( withSenseiBlocks ) {
 			removeNotice( 'sensei-using-template' );
 
-			if ( initialSenseiBlocksCount === 0 ) {
+			if ( ! initialWithSenseiBlocks ) {
 				const message = __(
 					"You've just added your first Sensei block. This will change how your course page appears. Be sure to preview your page before saving changes.",
 					'sensei-lms'
@@ -169,10 +167,10 @@ export const startBlocksTogglingControl = ( postType ) => {
 			} else {
 				removeNotice( 'sensei-using-blocks' );
 			}
-		} else if ( senseiBlocksCount === 0 ) {
+		} else if ( ! withSenseiBlocks ) {
 			removeNotice( 'sensei-using-blocks' );
 
-			if ( initialSenseiBlocksCount > 0 ) {
+			if ( initialWithSenseiBlocks ) {
 				const message = __(
 					'Are you sure you want to remove all Sensei blocks? This will change how your course page appears. Be sure to preview your page before saving changes.',
 					'sensei-lms'
@@ -188,16 +186,15 @@ export const startBlocksTogglingControl = ( postType ) => {
 	};
 
 	/**
-	 * Get blocks count.
+	 * Check whether it has at least one block.
 	 *
-	 * @param {string[]} blocks Blocks to count.
+	 * @param {string[]} blocks Blocks to check.
 	 *
-	 * @return {number} Number of blocks found.
+	 * @return {boolean} Whether it has at least one block.
 	 */
-	const getBlocksCount = ( blocks ) =>
-		blocks.reduce(
-			( sum, blockName ) =>
-				sum + blockEditorSelector.getGlobalBlockCount( blockName ),
-			0
+	const hasSomeBlocks = ( blocks ) =>
+		blocks.some(
+			( blockName ) =>
+				blockEditorSelector.getGlobalBlockCount( blockName ) > 0
 		);
 };

--- a/assets/js/admin/blocks-toggling-control.js
+++ b/assets/js/admin/blocks-toggling-control.js
@@ -171,7 +171,7 @@ export const startBlocksTogglingControl = ( postType ) => {
 			} else {
 				removeNotice( 'sensei-using-blocks' );
 			}
-		} else if ( ! withSenseiBlocks ) {
+		} else {
 			removeNotice( 'sensei-using-blocks' );
 
 			if ( initialWithSenseiBlocks ) {

--- a/assets/js/admin/blocks-toggling-control.js
+++ b/assets/js/admin/blocks-toggling-control.js
@@ -83,7 +83,11 @@ export const startBlocksTogglingControl = ( postType ) => {
 				coreEditorSelector.isEditedPostDirty() &&
 				undefined === initialWithSenseiBlocks
 			) {
-				initialWithSenseiBlocks = previousWithSenseiBlocks;
+				// If it will fill the template (needs_template is true),
+				// we consider that it has Sensei blocks initially.
+				initialWithSenseiBlocks =
+					coreEditorSelector.getCurrentPostAttribute( 'meta' )
+						?._needs_template || previousWithSenseiBlocks;
 			}
 		},
 		onSave: () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* I noticed https://github.com/Automattic/sensei/pull/4276 wasn't working properly for lessons created through the course outline. It happens because we create the template dynamically in this case (similar to a user adding blocks to an empty post). So it was showing the message _"You've just added your first Sensei block"_.
* Basically, the approach was changing the code to test if it has Sensei blocks (boolean), instead of counting them (we weren't using the information just to check whether it had blocks). And then we consider it has Sensei blocks initially when we know it will populate the blocks dynamically.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course.
* Add a lesson.
* Select the lesson block and click on "Edit lesson".

Also, make sure the original behavior continues working properly.

#### Part 1: Notice

* Create a course with the Outline block.
* Refresh the page, and make sure you don't see the warning message (yellow warning on the top of the editor) related to the editor containing or not Sensei blocks.
* Now, remove the block and make sure you see a message that the page doesn't contain any Sensei block.
* Add the block again, and make sure you don't see the message anymore.
* Remove the block (you should see the message again), and save the post. The message should disappear (resetting the state to compare).
* Add the block again and you should see the message that the page contains Sensei blocks.

#### Part 2: Metaboxes

* In a course with the outline block, you should not see the legacy metaboxes (lessons, modules and video).
* Test it adding/removing the block and make sure it updates in real-time.
* Also, try to refresh the editor with/without the block, and make sure it starts with the correct state (showing or not the metaboxes).