### PR TITLE
Try removal reason

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -472,7 +472,7 @@ class Sensei_Course_Enrolment {
 		}
 
 		$removed_learners[ $user_id ] = [
-			'date'   => time(),
+			'date'   => current_datetime()->getTimestamp(),
 			'reason' => $reason ?? self::REMOVAL_REASON_MANUAL,
 		];
 

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -510,6 +510,25 @@ class Sensei_Course_Enrolment {
 	}
 
 	/**
+	 * Get learner removal reason.
+	 *
+	 * @param int $user_id User ID.
+	 *
+	 * @return string|false Learner removal reason.
+	 *                      Or `false` if learner is not removed in the removed learners.
+	 *                      Default is self::REMOVAL_REASON_MANUAL if the reason is not set.
+	 */
+	public function get_learner_removal_reason( $user_id ) {
+		$removed_learners = $this->get_removed_learners();
+
+		if ( ! array_key_exists( $user_id, $removed_learners ) ) {
+			return false;
+		}
+
+		return $removed_learners[ $user_id ]['reason'] ?? self::REMOVAL_REASON_MANUAL;
+	}
+
+	/**
 	 * Get removed learners meta.
 	 *
 	 * @return array Removed learners array.


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This is a temporary solution to add the removal reason.
* We still need to discuss a little more what approach we'll use for that, but this would probably be the methods signature.
* Also, notice that we have the `withdraw` and the `remove_learner` methods. The `withdraw` uses the `remove_learner`, but before it tries to remove the user from the Manual provider. I'm also thinking to change this approach, and keep the user enrolled even in the manual provider, and call the remove_learner directly (that creates a meta with the removed learners - like a blacklist).

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
*

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
