### PR TITLE
Fix conflict with Block Visibility plugin

### DIFF
--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -189,17 +189,15 @@ class Sensei_Blocks {
 	 *
 	 * @return string Block HTML.
 	 */
-	public static function update_button_block_url( $block_content, $block, $class_name, $url ): string {
+	public static function update_button_block_url( $block_content, $block, $class_name, $url ) {
 		if (
 			! isset( $block['blockName'] )
 			|| 'core/button' !== $block['blockName']
 			|| ! isset( $block['attrs']['className'] )
 			|| false === strpos( $block['attrs']['className'], $class_name )
+			|| ! $url
+			|| empty( $block_content )
 		) {
-			return $block_content;
-		}
-
-		if ( ! $url ) {
 			return $block_content;
 		}
 

--- a/includes/blocks/class-sensei-course-completed-actions-block.php
+++ b/includes/blocks/class-sensei-course-completed-actions-block.php
@@ -32,7 +32,7 @@ class Sensei_Course_Completed_Actions_Block {
 	 *
 	 * @return string Block HTML.
 	 */
-	public function update_more_courses_button_url( $block_content, $block ): string {
+	public function update_more_courses_button_url( $block_content, $block ) {
 		return Sensei_Blocks::update_button_block_url(
 			$block_content,
 			$block,


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes a conflict with the Block Visibility plugin.
* Based on the WP code, the error is in the Block Visibility plugin, but I think the changes don't make harm to Sensei code.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Setup an env with the Course Completed page (if you submit the first step of Setup Wizard, it will be configured).
* Install the Block Visibility plugin (https://www.blockvisibilitywp.com).
* Go the Course Completed page editor.
* Select the Find More Courses block and change its visibility to Hide. 
  <img width="1114" alt="Screen Shot 2021-09-21 at 11 51 14" src="https://user-images.githubusercontent.com/876340/134194045-cd422bb5-f708-4689-b3ac-081e981759cb.png">
* Complete a course.
* Make sure the page renders properly without errors.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### Context

* p1632197979006100-slack-C6GGX896G