### PR TITLE
Allow expansion of manual enrollments.

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -185,24 +185,6 @@
 				@include border_radius(3px);
 				white-space: nowrap;
 			}
-			.ungraded  {
-				background: darken($bg_light, 5%);
-			}
-			.in-progress  {
-				background: #ffffe0;
-			}
-			.graded  {
-				background: #52a8e8;
-				color: #fff;
-			}
-			.passed  {
-				background: $success;
-				color: #fff;
-			}
-			.failed  {
-				background: #ed6c6c;
-				color: #fff;
-			}
 		}
 
 		.enrolment_status  {
@@ -224,6 +206,58 @@
 		.row-actions {
 			a {
 				cursor: pointer;
+			}
+		}
+	}
+}
+
+.sensei-grading-wrap  {
+	table  {
+		.user_status  {
+			.ungraded  {
+				background: darken($bg_light, 5%);
+			}
+			.in-progress  {
+				background: #ffffe0;
+			}
+			.graded  {
+				background: #52a8e8;
+				color: #fff;
+			}
+			.passed  {
+				background: $success;
+				color: #fff;
+			}
+			.failed  {
+				background: #ed6c6c;
+				color: #fff;
+			}
+		}
+	}
+}
+
+.sensei-learners-wrap  {
+	table .user_status  {
+		.in-progress::before, .graded::before, .not-started::before  {
+			font-family: FontAwesomeSensei;
+			font-size: 14px;
+			margin-right: 5px;
+		}
+		.in-progress  {
+			&:before {
+				content: "\f042";
+				display:inline-block;
+				transform: rotate(90deg);
+			}
+		}
+		.graded  {
+			&:before {
+				content: "\f058";
+			}
+		}
+		.not-started {
+			&:before {
+				content: "\f10c";
 			}
 		}
 	}

--- a/assets/js/learners-general.js
+++ b/assets/js/learners-general.js
@@ -12,8 +12,19 @@ jQuery( document ).ready( function ( $ ) {
 		return this.length > 0;
 	};
 
-	jQuery( '.edit-start-date-date-picker' ).datepicker( {
-		dateFormat: 'yy-mm-dd',
+	jQuery( '.edit-date-date-picker' ).datepicker( {
+		// The space and colon characters are added to allow users typing a datetime manually.
+		dateFormat: 'yy-mm-dd :',
+		onSelect: function ( newDate ) {
+			let oldDate = $( this ).attr( 'value' ).split( ' ' );
+			newDate = newDate.substring( 0, newDate.length - 2 );
+
+			if ( oldDate[ 1 ] ) {
+				newDate = newDate + ' ' + oldDate[ 1 ];
+			}
+
+			$( this ).val( newDate );
+		},
 	} );
 
 	/***************************************************************************************************
@@ -60,29 +71,37 @@ jQuery( document ).ready( function ( $ ) {
 	} );
 
 	$( '.edit-start-date-submit' ).click( function () {
-		var $this = $( this );
-		var new_date = $this.prev( '.edit-start-date-date-picker' ).val();
-		var user_id = $this.attr( 'data-user-id' );
-		var post_id = $this.attr( 'data-post-id' );
-		var post_type = $this.attr( 'data-post-type' );
-		var comment_id = $this.attr( 'data-comment-id' );
-		var dataToPost = '';
+		let $this = $( this );
+		let userId = $this.attr( 'data-user-id' );
+		let postId = $this.attr( 'data-post-id' );
+		let postType = $this.attr( 'data-post-type' );
+		let commentId = $this.attr( 'data-comment-id' );
+		let newDates = {};
+
+		$this
+			.parents( 'tr' )
+			.find( '.edit-date-date-picker' )
+			.each( ( index, element ) => {
+				newDates[ element.getAttribute( 'data-name' ) ] = element.value;
+			} );
 
 		if (
-			! user_id ||
-			! post_id ||
-			! post_type ||
-			! new_date ||
-			! comment_id
+			! userId ||
+			! postId ||
+			! postType ||
+			! commentId ||
+			Object.keys( newDates ).length === 0
 		) {
 			return;
 		}
 
-		dataToPost += 'user_id=' + user_id;
-		dataToPost += '&post_id=' + post_id;
-		dataToPost += '&post_type=' + post_type;
-		dataToPost += '&new_date=' + new_date;
-		dataToPost += '&comment_id=' + comment_id;
+		let dataToPost = {
+			user_id: userId,
+			post_id: postId,
+			post_type: postType,
+			comment_id: commentId,
+			new_dates: newDates,
+		};
 
 		$.post(
 			ajaxurl,

--- a/assets/js/learners-general.js
+++ b/assets/js/learners-general.js
@@ -17,7 +17,10 @@ jQuery( document ).ready( function ( $ ) {
 		dateFormat: 'yy-mm-dd :',
 		onSelect: function ( newDate ) {
 			let oldDate = $( this ).attr( 'value' ).split( ' ' );
-			newDate = newDate.substring( 0, newDate.length - 2 );
+
+			if ( newDate.indexOf( ' :' ) > -1 ) {
+				newDate = newDate.substring( 0, newDate.length - 2 );
+			}
 
 			if ( oldDate[ 1 ] ) {
 				newDate = newDate + ' ' + oldDate[ 1 ];

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -450,7 +450,19 @@ class Sensei_Learner_Management {
 			exit( '' );
 		}
 
-		$updated = update_comment_meta( $comment_id, 'start', $mysql_date, $date_started );
+		$updated = (bool) update_comment_meta( $comment_id, 'start', $mysql_date, $date_started );
+
+		/**
+		 * Filter sensei_learners_default_columns
+		 *
+		 * Filters the columns that are displayed in learner management
+		 *
+		 * @param {array}   $columns              The default columns.
+		 * @param {object}  $sensei_learners_main Sensei_Learners_Main instance.
+		 *
+		 * @return {array} The modified default columns
+		 */
+		$updated = apply_filters( 'sensei_learners_learner_updated', $updated, $post_id, $comment_id );
 
 		if ( false === $updated ) {
 			exit( '' );

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -695,9 +695,7 @@ class Sensei_Learner_Management {
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
 		foreach ( $user_ids as $user_id ) {
-			$result = false;
-
-			$course_enrolment->enrol( $user_id );
+			$result = $course_enrolment->enrol( $user_id );
 
 			switch ( $post_type ) {
 				case 'course':

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -389,18 +389,26 @@ class Sensei_Learner_Management {
 	public function edit_date_started() {
 		check_ajax_referer( 'edit_date_nonce', 'security' );
 
-		$data        = sanitize_text_field( $_POST['data'] );
-		$action_data = array();
-		parse_str( $data, $action_data );
+		if ( ! empty( $_POST['data']['post_id'] ) && is_numeric( $_POST['data']['post_id'] ) ) {
+			$post_id = (int) sanitize_key( $_POST['data']['post_id'] );
+		} else {
+			exit( '' );
+		}
 
-		$post = get_post( intval( $action_data['post_id'] ) );
+		$post = get_post( $post_id );
 
 		if ( empty( $post ) || ! is_a( $post, 'WP_Post' ) ) {
 			exit( '' );
 		}
 
-		$comment_id = isset( $action_data['comment_id'] ) ? absint( $action_data['comment_id'] ) : 0;
-		$comment    = get_comment( intval( $action_data['comment_id'] ) );
+		if ( ! empty( $_POST['data']['comment_id'] ) && is_numeric( $_POST['data']['comment_id'] ) ) {
+			$comment_id = (int) sanitize_key( $_POST['data']['comment_id'] );
+		} else {
+			exit( '' );
+		}
+
+		$comment = get_comment( $comment_id );
+
 		if ( empty( $comment ) ) {
 			exit( '' );
 		}
@@ -408,7 +416,7 @@ class Sensei_Learner_Management {
 		// validate we can edit date.
 		$may_edit_date = false;
 
-		if ( current_user_can( 'manage_sensei' ) || get_current_user_id() === intval( $post->post_author ) ) {
+		if ( current_user_can( 'manage_sensei' ) || get_current_user_id() === (int) $post->post_author ) {
 			$may_edit_date = true;
 		}
 
@@ -416,19 +424,24 @@ class Sensei_Learner_Management {
 			exit( '' );
 		}
 
-		$date_started = get_comment_meta( $comment_id, 'start', true );
-		$date_string  = esc_html( $action_data['new_date'] );
+		if ( ! empty( $_POST['data']['new_dates']['start-date'] ) ) {
+			$date_string = sanitize_text_field( wp_unslash( $_POST['data']['new_dates']['start-date'] ) );
+		} else {
+			exit( '' );
+		}
 
 		if ( empty( $date_string ) ) {
 			exit( '' );
 		}
+
+		$date_started = get_comment_meta( $comment_id, 'start', true );
 
 		$expected_date_format = 'Y-m-d H:i:s';
 		if ( false === strpos( $date_string, ' ' ) ) {
 			$expected_date_format = 'Y-m-d';
 		}
 
-		$date = DateTime::createFromFormat( $expected_date_format, $date_string );
+		$date = DateTimeImmutable::createFromFormat( $expected_date_format, $date_string );
 		if ( false === $date ) {
 			exit( '' );
 		}

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -453,14 +453,15 @@ class Sensei_Learner_Management {
 		$updated = (bool) update_comment_meta( $comment_id, 'start', $mysql_date, $date_started );
 
 		/**
-		 * Filter sensei_learners_default_columns
+		 * Filter sensei_learners_learner_updated
 		 *
-		 * Filters the columns that are displayed in learner management
+		 * This filter should return false if there was no update in the learner row.
 		 *
-		 * @param {array}   $columns              The default columns.
-		 * @param {object}  $sensei_learners_main Sensei_Learners_Main instance.
+		 * @param {bool} $updated    A flag indicating if there was an update in the learner row.
+		 * @param {int}  $post_id    Lesson or course id.
+		 * @param {int}  $comment_id The comment id which tracks the progress of the learner.
 		 *
-		 * @return {array} The modified default columns
+		 * @return {bool} False if there were no updates.
 		 */
 		$updated = apply_filters( 'sensei_learners_learner_updated', $updated, $post_id, $comment_id );
 

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -692,15 +692,12 @@ class Sensei_Learner_Management {
 			return $result;
 		}
 
-		$enrolment_manager         = Sensei_Course_Enrolment_Manager::instance();
-		$manual_enrolment_provider = $enrolment_manager->get_manual_enrolment_provider();
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
 		foreach ( $user_ids as $user_id ) {
 			$result = false;
 
-			if ( $manual_enrolment_provider instanceof Sensei_Course_Manual_Enrolment_Provider ) {
-				$result = $manual_enrolment_provider->enrol_learner( $user_id, $course_id );
-			}
+			$course_enrolment->enrol( $user_id );
 
 			switch ( $post_type ) {
 				case 'course':

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -201,6 +201,16 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			);
 		}
 
+		/**
+		 * Filter sensei_learners_default_columns
+		 *
+		 * Filters the columns that are displayed in learner management
+		 *
+		 * @param {array}   $columns The default columns.
+		 * @param {object}  $this       Sensei_Learners_Main instance.
+		 *
+		 * @return {array} The modified default columns
+		 */
 		$columns = apply_filters( 'sensei_learners_default_columns', $columns, $this );
 		return $columns;
 	}
@@ -560,17 +570,19 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				 * This filter runs on the learner management screen for a specific course.
 				 * It provides the learner row column details.
 				 *
-				 * @param array   $columns {
-				 *   @type string   $title             Learner name.
-				 *   @type string   $date_started      Course start date.
-				 *   @type string   $date_completed    Course completion date (if completed).
-				 *   @type string   $course_status     Course status (e.g. completed, started etc).
-				 *   @type string   $enrolment_status  Enrolment status.
-				 *   @type html     $action_buttons    Actions that can be taken for this learner.
+				 * @param {array}   $columns {
+				 *   @type {string}   $title             Learner name.
+				 *   @type {string}   $date_started      Course start date.
+				 *   @type {string}   $date_completed    Course completion date (if completed).
+				 *   @type {string}   $course_status     Course status (e.g. completed, started etc).
+				 *   @type {string}   $enrolment_status  Enrolment status.
+				 *   @type {string}   $action_buttons    Actions that can be taken for this learner.
 				 * }
-				 * @param object  $item       Current WP_Comment item.
-				 * @param int     $post_id    Course ID.
-				 * @param string  $post_type  Post type.
+				 * @param {object}  $item       Current WP_Comment item.
+				 * @param {int}     $post_id    Course ID.
+				 * @param {string}  $post_type  Post type.
+				 *
+				 * @return {array} The modified columns
 				 */
 				$column_data = apply_filters(
 					'sensei_learners_main_column_data',
@@ -1279,6 +1291,15 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		$all_providers   = Sensei_Course_Enrolment_Manager::instance()->get_all_enrolment_providers();
 
 		return $manual_provider instanceof Sensei_Course_Manual_Enrolment_Provider && count( $all_providers ) > 1;
+	}
+
+	/**
+	 * Get the current view.
+	 *
+	 * @return string
+	 */
+	public function get_view() : string {
+		return $this->view;
 	}
 }
 

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -165,10 +165,10 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			case 'learners':
 				$columns = array(
 					'title'            => __( 'Learner', 'sensei-lms' ),
+					'enrolment_status' => __( 'Enrollment', 'sensei-lms' ),
+					'user_status'      => __( 'Status', 'sensei-lms' ),
 					'date_started'     => __( 'Date Started', 'sensei-lms' ),
 					'date_completed'   => __( 'Date Completed', 'sensei-lms' ),
-					'user_status'      => __( 'Status', 'sensei-lms' ),
-					'enrolment_status' => __( 'Enrollment', 'sensei-lms' ),
 				);
 				break;
 
@@ -359,13 +359,13 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 				if ( $this->lesson_id ) {
 
-					$post_id     = intval( $this->lesson_id );
+					$post_id     = $this->lesson_id;
 					$object_type = __( 'lesson', 'sensei-lms' );
 					$post_type   = 'lesson';
 
 				} elseif ( $this->course_id ) {
 
-					$post_id     = intval( $this->course_id );
+					$post_id     = $this->course_id;
 					$object_type = __( 'course', 'sensei-lms' );
 					$post_type   = 'course';
 
@@ -380,11 +380,17 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 				} else {
 
-					$progress_status_html =
-						'<span class="in-progress">' .
+					if ( 'course' === $post_type && 0 === Sensei_Utils::user_started_lesson_count( $post_id, $user_activity->user_id ) ) {
+						$progress_status_html =
+							'<span class="not-started">' .
+							esc_html__( 'Not Started', 'sensei-lms' ) .
+							'</span>';
+					} else {
+						$progress_status_html =
+							'<span class="in-progress">' .
 							esc_html__( 'In Progress', 'sensei-lms' ) .
-						'</span>';
-
+							'</span>';
+					}
 				}
 
 				$is_user_enrolled  = Sensei_Course::is_user_enrolled( $this->course_id, $user_activity->user_id );

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -206,8 +206,8 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		 *
 		 * Filters the columns that are displayed in learner management
 		 *
-		 * @param {array}   $columns The default columns.
-		 * @param {object}  $this       Sensei_Learners_Main instance.
+		 * @param {array}   $columns              The default columns.
+		 * @param {object}  $sensei_learners_main Sensei_Learners_Main instance.
 		 *
 		 * @return {array} The modified default columns
 		 */

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -459,7 +459,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$title = Sensei_Learner::get_full_name( $user_activity->user_id );
 				// translators: Placeholder is the full name of the learner.
 				$a_title              = sprintf( esc_html__( 'Edit &#8220;%s&#8221;', 'sensei-lms' ), esc_html( $title ) );
-				$edit_start_date_form = $this->get_edit_start_date_form( $user_activity, $post_id, $post_type, $object_type );
+				$edit_start_date_form = $this->get_edit_start_date_form( $user_activity, $post_id, $post_type );
 
 				$actions     = [];
 				$row_actions = [];
@@ -564,6 +564,9 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 					$actions[] = $edit_start_date_form;
 				}
 
+				$date_started = get_comment_meta( $user_activity->comment_ID, 'start', true );
+				$date_input   = '<input class="edit-date-date-picker" data-name="start-date" type="text" value="' . esc_attr( $date_started ) . '">';
+
 				/**
 				 * Filter sensei_learners_main_column_data
 				 *
@@ -596,7 +599,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 							'<div class="row-actions">' .
 								implode( ' | ', $row_actions ) .
 							'</div>',
-						'date_started'     => get_comment_meta( $user_activity->comment_ID, 'start', true ),
+						'date_started'     => $date_input,
 						'date_completed'   => ( 'complete' === $user_activity->comment_approved ) ? $user_activity->comment_date : '',
 						'user_status'      => $progress_status_html,
 						'enrolment_status' => $enrolment_status_html,
@@ -626,9 +629,10 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 							'class' => array(),
 						),
 						'input' => array(
-							'class' => array(),
-							'type'  => array(),
-							'value' => array(),
+							'class'     => array(),
+							'type'      => array(),
+							'value'     => array(),
+							'data-name' => array(),
 						),
 					)
 				);
@@ -759,7 +763,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$escaped_column_data = Sensei_Wp_Kses::wp_kses_array( $column_data );
 
 				break;
-		} // switch
+		}
 
 		return $escaped_column_data;
 	}
@@ -770,19 +774,15 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	 * @param WP_Comment $user_activity The sensei user activity.
 	 * @param integer    $post_id       The post id.
 	 * @param string     $post_type     The post type (lesson or course).
-	 * @param string     $object_type   The object type.
 	 *
 	 * @return string The form.
 	 */
-	private function get_edit_start_date_form( $user_activity, $post_id, $post_type, $object_type ) {
-		$comment_id   = $user_activity->comment_ID;
-		$date_started = get_comment_meta( $comment_id, 'start', true );
-		$form         = '<form class="edit-start-date">';
-		$form        .= '<input class="edit-start-date-date-picker" type="text" value="' . esc_attr( $date_started ) . '">';
-		$form        .= '<a class="edit-start-date-submit button" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '" data-comment-id="' . esc_attr( $comment_id ) . '">' . sprintf( esc_html__( 'Edit Start Date', 'sensei-lms' ), esc_html( $object_type ) ) . '</a>';
-		$form        .= '</form>';
+	private function get_edit_start_date_form( $user_activity, $post_id, $post_type ) : string {
+		$submit_button_text = __( 'Update Learner', 'sensei-lms' );
 
-		return $form;
+		return '<form class="edit-start-date">
+				<a class="edit-start-date-submit button" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '" data-comment-id="' . esc_attr( $user_activity->comment_ID ) . '">' . esc_html( $submit_button_text ) . '</a>
+			</form>';
 	}
 
 	/**

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1715,7 +1715,7 @@ class Sensei_Utils {
 	/**
 	 * Get the number of lessons of a course that a user started.
 	 *
-	 * @since  3.13.2
+	 * @since  3.13.3
 	 *
 	 * @param int $course_id The course id.
 	 * @param int $user_id   The user id.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1713,6 +1713,32 @@ class Sensei_Utils {
 	}
 
 	/**
+	 * Get the number of lessons of a course that a user started.
+	 *
+	 * @since  3.13.2
+	 *
+	 * @param int $course_id The course id.
+	 * @param int $user_id   The user id.
+	 *
+	 * @return int Lesson count.
+	 */
+	public static function user_started_lesson_count( int $course_id, int $user_id ) : int {
+		$lessons = Sensei()->course->course_lessons( $course_id, 'publish', 'ids' );
+
+		if ( empty( $lessons ) ) {
+			return 0;
+		}
+
+		$activity_args = array(
+			'post__in' => $lessons,
+			'user_id'  => $user_id,
+			'type'     => 'sensei_lesson_status',
+		);
+
+		return self::sensei_check_for_activity( $activity_args );
+	}
+
+	/**
 	 * Check if a user has completed a lesson or not
 	 *
 	 * @uses  Sensei()

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -593,7 +593,7 @@ class Sensei_Course_Enrolment {
 		 * @param int $course_id Course that the user will be enrolled to.
 		 * @param int $user_id   User ID.
 		 */
-		do_action( 'sensei_enrol_user', $this->course_id, $user_id );
+		do_action( 'sensei_admin_enrol_user', $this->course_id, $user_id );
 
 		// If user is removed, just restore.
 		if ( $this->is_learner_removed( $user_id ) ) {

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -588,7 +588,7 @@ class Sensei_Course_Enrolment {
 		/**
 		 * Notify when a user should be enrolled to the course.
 		 *
-		 * @since 3.13.2
+		 * @since 3.13.3
 		 *
 		 * @param int $course_id Course that the user will be enrolled to.
 		 * @param int $user_id   User ID.

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -584,6 +584,17 @@ class Sensei_Course_Enrolment {
 	 * @return boolean If user is enrolled.
 	 */
 	public function enrol( $user_id ) {
+
+		/**
+		 * Notify when a user should be enrolled to the course.
+		 *
+		 * @since 3.13.2
+		 *
+		 * @param int $course_id Course that the user will be enrolled to.
+		 * @param int $user_id   User ID.
+		 */
+		do_action( 'sensei_enrol_user', $this->course_id, $user_id );
+
 		// If user is removed, just restore.
 		if ( $this->is_learner_removed( $user_id ) ) {
 			$this->restore_learner( $user_id );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Updates the looks of 'Add Learner to Course' box in learner management. More specifically:
    * The title is moved on top 
    * The checkbox is moved on top of the submit button
    * The 'Learner will also be added to the course...' message which appear in lesson management screen was not moved and it will still appear below the button.
![Screenshot 2021-09-21 at 19 22 20](https://user-images.githubusercontent.com/53191348/134211454-b08d902f-0547-4951-961f-146ebf7cfbde.png)
* Made a fix on how the box works. More specifically previously if a user was removed from the course and then added with this box, he would not be enrolled to the course. This now works.
* Added two new hooks. The first allows the controls on the box to be expanded and the second triggers an action when a manual enrolment happens.

### Testing instructions
* Open the learner management screen and ensure that the box looks nice.
* Try manually enrolling a removed user using this box and ensure that it works as it should.

### New/Updated Hooks

* `sensei_admin_enrol_user` Notify when a user is manually enrolled to the course.
* `sensei_learners_learner_updated` Filter when a learner row is updated in learner management.