### PR TITLE
Add filters to show enrollment actions and view results block

### DIFF
--- a/includes/blocks/class-sensei-block-view-results.php
+++ b/includes/blocks/class-sensei-block-view-results.php
@@ -44,7 +44,25 @@ class Sensei_Block_View_Results {
 	 * @return string The HTML of the block.
 	 */
 	public function render( $attributes, $content ): string {
-		if ( ! Sensei()->course::is_user_enrolled( get_the_ID() ) ) {
+		/**
+		 * Whether render the view results block.
+		 *
+		 * @since 3.13.2
+		 *
+		 * @param {boolean} $render     Whether render the view results block.
+		 * @param {array}   $attributes Block attributes.
+		 * @param {string}  $content    Block HTML.
+		 *
+		 * @return {boolean} Whether render the view results block.
+		 */
+		$render = apply_filters(
+			'sensei_render_view_results_block',
+			Sensei()->course::is_user_enrolled( get_the_ID() ),
+			$attributes,
+			$content
+		);
+
+		if ( ! $render ) {
 			return '';
 		}
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3100,8 +3100,11 @@ class Sensei_Course {
 		<?php
 
 		// Check if course is completed.
-		$user_course_status = Sensei_Utils::user_course_status( $course_id, $user_id );
-		$completed_course   = Sensei_Utils::user_completed_course( $user_course_status );
+		$completed_course = false;
+		if ( ! empty( $user_id ) ) {
+			$user_course_status = Sensei_Utils::user_course_status( $course_id, $user_id );
+			$completed_course   = Sensei_Utils::user_completed_course( $user_course_status );
+		}
 
 		/**
 		 * Display course enrollment actions.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3092,22 +3092,45 @@ class Sensei_Course {
 			return;
 		}
 
+		$course_id = $post->ID;
+		$user_id   = $current_user->ID;
+
 		?>
 		<section class="course-meta course-enrolment">
 		<?php
-		$is_user_taking_course = self::is_user_enrolled( $post->ID, $current_user->ID );
 
-		// If user is taking course, display progress.
-		if ( $is_user_taking_course ) {
-			// Check if course is completed
-			$user_course_status = Sensei_Utils::user_course_status( $post->ID, $current_user->ID );
-			$completed_course   = Sensei_Utils::user_completed_course( $user_course_status );
+		// Check if course is completed.
+		$user_course_status = Sensei_Utils::user_course_status( $course_id, $user_id );
+		$completed_course   = Sensei_Utils::user_completed_course( $user_course_status );
+
+		/**
+		 * Display course enrollment actions.
+		 *
+		 * @since 3.13.2
+		 *
+		 * @param {boolean} $display_actions  Whether display the actions.
+		 * @param {int}     $course_id        Course ID.
+		 * @param {int}     $user_id          User ID.
+		 * @param {boolean} $completed_course Whether user completed the course.
+		 *
+		 * @return {boolean} Whether display course enrollment actions.
+		 */
+		$display_actions = apply_filters(
+			'sensei_display_course_enrollment_actions',
+			self::is_user_enrolled( $course_id, $user_id ),
+			$course_id,
+			$user_id,
+			$completed_course
+		);
+
+		if ( $display_actions ) {
+
 			// Success message
 			if ( $completed_course ) {
 				?>
 				<div class="status completed"><?php esc_html_e( 'Completed', 'sensei-lms' ); ?></div>
 				<?php
-				$has_quizzes = Sensei()->course->course_quizzes( $post->ID, true );
+				$has_quizzes = Sensei()->course->course_quizzes( $course_id, true );
 				if ( has_filter( 'sensei_results_links' ) || $has_quizzes ) {
 					?>
 					<p class="sensei-results-links">
@@ -3115,13 +3138,13 @@ class Sensei_Course {
 						$results_link = '';
 
 						if ( $has_quizzes ) {
-							$results_link = '<a class="view-results" href="' . esc_url( self::get_view_results_link( $post->ID ) ) . '">' . esc_html__( 'View Results', 'sensei-lms' ) . '</a>';
+							$results_link = '<a class="view-results" href="' . esc_url( self::get_view_results_link( $course_id ) ) . '">' . esc_html__( 'View Results', 'sensei-lms' ) . '</a>';
 						}
 
 						/**
 						 * Filter documented in Sensei_Course::the_course_action_buttons
 						 */
-						$results_link = apply_filters( 'sensei_results_links', $results_link, $post->ID );
+						$results_link = apply_filters( 'sensei_results_links', $results_link, $course_id );
 						echo wp_kses_post( $results_link );
 						?>
 						</p>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR introduces 2 new filters to show or not the enrollment actions (legacy template) and view results block.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a legacy course and a course including the View Results block.
* Check them in different conditions (enrolled, not enrolled, completed), and make sure it continues working as previously.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_render_view_results_block` - Filter to render or not the view results block.
* `sensei_display_course_enrollment_actions` - Filter to display or not the course enrolment actions.