### PR TITLE
Add filters to extend learner courses page

### DIFF
--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -117,7 +117,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 			if ( isset( $_GET[ self::MY_COURSES_STATUS_FILTER ] ) ) {
 				$course_filter_by_status = sanitize_text_field( $_GET[ self::MY_COURSES_STATUS_FILTER ] );
 
-				if ( ! empty( $course_filter_by_status ) && in_array( $course_filter_by_status, array( 'all', 'active', 'complete' ), true ) ) {
+				if ( ! empty( $course_filter_by_status ) && in_array( $course_filter_by_status, array_keys( $this->get_filter_options() ), true ) ) {
 					$attributes['status'] = $course_filter_by_status;
 				}
 			}
@@ -516,14 +516,10 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		 */
 		$should_display_course_toggles = (bool) apply_filters( 'sensei_shortcode_user_courses_display_course_toggle_actions', true );
 		if ( false === $should_display_course_toggles ) {
-			   return;
+			return;
 		}
 
-		$active_filter_options = array(
-			'all'      => __( 'All Courses', 'sensei-lms' ),
-			'active'   => __( 'Active Courses', 'sensei-lms' ),
-			'complete' => __( 'Completed Courses', 'sensei-lms' ),
-		);
+		$active_filter_options = $this->get_filter_options();
 
 		$base_url = get_page_link( $this->page_id );
 		?>
@@ -541,6 +537,18 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		<?php
 	}
 
+	/**
+	 * Get the filter options.
+	 *
+	 * @return array The filter options.
+	 */
+	private function get_filter_options() {
+		return [
+			'all'      => __( 'All', 'sensei-lms' ),
+			'active'   => __( 'Active', 'sensei-lms' ),
+			'complete' => __( 'Completed', 'sensei-lms' ),
+		];
+	}
 
 	/**
 	 * Load the javascript for the toggle functionality

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -211,7 +211,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 		);
 
 		/**
-		 * Filters the the query which fetches the user courses.
+		 * Filters the query which fetches the user courses.
 		 *
 		 * @since 3.13.2
 		 * @hook sensei_user_courses_query

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -543,11 +543,23 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 	 * @return array The filter options.
 	 */
 	private function get_filter_options() {
-		return [
+		$filter_options = [
 			'all'      => __( 'All', 'sensei-lms' ),
 			'active'   => __( 'Active', 'sensei-lms' ),
 			'complete' => __( 'Completed', 'sensei-lms' ),
 		];
+
+		/**
+		 * Filters the the user courses filter options.
+		 *
+		 * @since 3.13.2
+		 * @hook sensei_user_courses_filter_options
+		 *
+		 * @param {array} $filter_options The filter options.
+		 *
+		 * @return {array} The filter options.
+		 */
+		return apply_filters( 'sensei_user_courses_filter_options', $filter_options );
 	}
 
 	/**

--- a/tests/unit-tests/blocks/test-class-sensei-block-learner-courses.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-learner-courses.php
@@ -45,9 +45,9 @@ class Sensei_Block_Learner_Courses_Test extends WP_UnitTestCase {
 
 		$result = do_blocks( $post_content );
 
-		$this->assertContains( 'All Courses', $result );
-		$this->assertContains( 'Active Courses', $result );
-		$this->assertContains( 'Completed Courses', $result );
+		$this->assertContains( 'All', $result );
+		$this->assertContains( 'Active', $result );
+		$this->assertContains( 'Completed', $result );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Introduces filters to extend the learner courses page.
* It also renames the tabs removing the "Courses" word.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a page with the shortcode `[sensei_user_courses]`.
* Create another page with the block "Learner Courses".
* Access them in the frontend, and make sure it continues working as previously.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_user_courses_query` - Filters the the query which fetches the user courses. So it's possible to introduce tabs with new content.
* `sensei_user_courses_filter_options` - Filters the the user courses filter options (tabs).