### PR TITLE
Update learner courses priorities

### DIFF
--- a/assets/css/pages-frontend.scss
+++ b/assets/css/pages-frontend.scss
@@ -1,3 +1,5 @@
+@import 'fontawesome';
+
 /**
  * Course Completed Page
  */

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1427,6 +1427,17 @@ class Sensei_Course {
 	}
 
 	/**
+	 * Has results links check.
+	 *
+	 * @param int $course_id Course ID.
+	 *
+	 * @return boolean
+	 */
+	private static function has_results_links( $course_id ) {
+		return ! empty( apply_filters( 'sensei_results_links', '', $course_id ) );
+	}
+
+	/**
 	 * load_user_courses_content generates HTML for user's active & completed courses
 	 *
 	 * This function also ouputs the html so no need to echo the content.
@@ -1708,7 +1719,7 @@ class Sensei_Course {
 					$has_quizzes = Sensei()->course->course_quizzes( $course_item->ID, true );
 
 					// Output only if there is content to display
-					if ( has_filter( 'sensei_results_links' ) || $has_quizzes ) {
+					if ( self::has_results_links( $course_item->ID ) || $has_quizzes ) {
 						$complete_html .= '<p class="sensei-results-links">';
 						$results_link   = '';
 
@@ -2391,7 +2402,7 @@ class Sensei_Course {
 
 		$has_quizzes = Sensei()->course->course_quizzes( $course->ID, true );
 
-		if ( has_filter( 'sensei_results_links' ) || $has_quizzes ) {
+		if ( self::has_results_links( $course->ID ) || $has_quizzes ) {
 			$has_results_button = true;
 		}
 
@@ -3134,7 +3145,7 @@ class Sensei_Course {
 				<div class="status completed"><?php esc_html_e( 'Completed', 'sensei-lms' ); ?></div>
 				<?php
 				$has_quizzes = Sensei()->course->course_quizzes( $course_id, true );
-				if ( has_filter( 'sensei_results_links' ) || $has_quizzes ) {
+				if ( self::has_results_links( $course_id ) || $has_quizzes ) {
 					?>
 					<p class="sensei-results-links">
 						<?php

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1434,7 +1434,7 @@ class Sensei_Course {
 	 * @return boolean
 	 */
 	private static function has_results_links( $course_id ) {
-		return ! empty( apply_filters( 'sensei_results_links', '', $course_id ) );
+		return has_filter( 'sensei_results_links' ) && ! empty( apply_filters( 'sensei_results_links', '', $course_id ) );
 	}
 
 	/**

--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -408,12 +408,12 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 			}
 
 			if ( $this->options['progressBarEnabled'] ) {
-				add_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_progress' ) );
+				add_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_progress' ), 20 );
 			}
 		}
 
-		add_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_buttons' ) );
-		$this->is_block && add_action( 'sensei_course_content_inside_after', array( $this, 'add_course_details_wrapper_end' ) );
+		add_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_buttons' ), 30 );
+		$this->is_block && add_action( 'sensei_course_content_inside_after', array( $this, 'add_course_details_wrapper_end' ), 40 );
 	}
 
 	/**
@@ -425,8 +425,8 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 
 		// Remove all hooks after the output is generated.
 		remove_action( 'sensei_course_content_inside_before', array( $this, 'course_category' ), 3 );
-		remove_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_progress' ) );
-		remove_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_buttons' ) );
+		remove_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_progress' ), 20 );
+		remove_action( 'sensei_course_content_inside_after', array( $this, 'attach_course_buttons' ), 30 );
 		remove_filter( 'sensei_course_loop_content_class', array( $this, 'course_status_class_tagging' ), 20 );
 		remove_action( 'sensei_loop_course_before', array( $this, 'course_toggle_actions' ) );
 		remove_filter( 'get_the_excerpt', '__return_false' );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It introduces priorities do some hooks in the learner courses, so we can introduce content in different parts.
* It also fixes the results links check. Previously it was returning true without adding anything when Certificates was active, because it registers the filter, but decides if something will be added inside the function (which makes sense).
* It also introduces the `fontawesome` to frontend pages. See https://github.com/Automattic/sensei/pull/4322#discussion_r718785480

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Just make sure My Courses, Learner profile, and legacy single course page continue working properly, listing the correct buttons when appropriate (View Results, Certificates).