### PR TITLE
Handle extensions fetch error

### DIFF
--- a/assets/extensions/main.js
+++ b/assets/extensions/main.js
@@ -24,10 +24,19 @@ import { Grid, Col } from './grid';
 const Main = () => {
 	useSenseiColorTheme();
 
-	const { extensions, connected, layout, error } = useSelect( ( select ) => {
+	const {
+		extensions,
+		connected,
+		layout,
+		isExtensionsLoading,
+		error,
+	} = useSelect( ( select ) => {
 		const store = select( EXTENSIONS_STORE );
 
 		return {
+			isExtensionsLoading: ! store.hasFinishedResolution(
+				'getExtensions'
+			),
 			extensions: store.getExtensions(),
 			connected: store.getConnectionStatus(),
 			layout: store.getLayout(),
@@ -35,12 +44,16 @@ const Main = () => {
 		};
 	} );
 
-	if ( 0 === extensions.length || 0 === layout.length ) {
+	if ( isExtensionsLoading ) {
 		return (
 			<div className="sensei-extensions__loader">
 				<Spinner />
 			</div>
 		);
+	}
+
+	if ( 0 === extensions.length || 0 === layout.length ) {
+		return <div>{ __( 'No extensions found.', 'sensei-lms' ) }</div>;
 	}
 
 	const freeExtensions = extensions.filter(

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -140,6 +140,10 @@ final class Sensei_Extensions {
 			}
 		}
 
+		if ( empty( $extensions ) ) {
+			return [];
+		}
+
 		if ( 'plugin' === $type ) {
 			return $this->add_installed_extensions_properties( $extensions );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It handles errors when fetching extensions from senseilms.com.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Simulate an error while fetching the extensions.
* Make sure the extensions page opens properly and you don't see any error in the logs.