### PR TITLE
$taxonomies can be null, don't always treat it as an array

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2120,7 +2120,7 @@ class Sensei_Core_Modules {
 	public function filter_module_terms( $terms, $taxonomies, $args ) {
 
 		// dont limit for admins and other taxonomies. This should also only apply to admin
-		if ( current_user_can( 'manage_options' ) || ! in_array( 'module', $taxonomies ) || ! is_admin() ) {
+		if ( current_user_can( 'manage_options' ) || ! $taxonomies || ! in_array( 'module', $taxonomies ) || ! is_admin() ) {
 			return $terms;
 		}
 


### PR DESCRIPTION
The second parameter to the `get_terms` filter can be null, causing a PHP Warning.

```
E_WARNING: in_array() expects parameter 2 to be array, null given in wp-content/plugins/sensei-lms/includes/class-sensei-modules.php:2123
```

This can be triggered by a query such as `get_terms( [ 'term_taxonomy_id' => ?? ] );` as done by Jetpack Sync during the `jetpack_sync_cron` cron event.

See https://core.trac.wordpress.org/ticket/54222

### Changes proposed in this Pull Request

* Check `$taxonomies` is a truthy value. 

### Testing instructions

* Monitor PHP Warnings during Jetpack Sync.

### Screenshot / Video

