### PR TITLE
Do not show "View results" in course summary if course is not complet…

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2435,7 +2435,7 @@ class Sensei_Course {
 
 			$results_link = '';
 
-			if ( $has_quizzes ) {
+			if ( $has_quizzes && Sensei_Utils::user_completed_course( $course, wp_get_current_user()->ID ) ) {
 				$results_link = '<a class="button view-results" href="' . esc_url( self::get_view_results_link( $course->ID ) ) . '">' .
 					esc_html__( 'View Results', 'sensei-lms' ) . '</a>';
 			}


### PR DESCRIPTION
Fixes #3998

### Changes proposed in this Pull Request

- Show the "View results" for a course only if the user has completed it.
- The issue above also reports about the message in Course Results page that states "You have passed this course with grade of 0%", even if user has not completed a single lesson. However it is related to the old Course Results page, which is deprecated in favor of "Course Results" block that could be used anywhere the user desires. Now a teacher has control over what kind of message and in which conditions it is shown.

### Testing instructions

- Install the version of Sensei from [this branch](https://github.com/Automattic/sensei/tree/fix/course-progress-alert) and install the sample course that comes with it.
- Publish the sample course.
- Visit the sample course page and enroll to the course by pressing "Take Course".
- Visit "My Courses" page and confirm that course summary does not have a "View results" button when 0 lessons of the course is completed.
- Complete several lessons from the course.
- Visit "My Courses" page and confirm that course summary does not have a "View results" button when some lessons of the course is completed.
- Complete all the lessons from the course.
- Visit "My Courses" page and confirm that course summary does have "View results" button when all the lessons of the course is completed.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

- n/a

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

- n/a

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

#### Before

<img width="835" alt="before-1" src="https://user-images.githubusercontent.com/2578542/135973349-ecb10496-aea1-4b4c-88fe-f98f46f70679.png">

<img width="829" alt="before-2" src="https://user-images.githubusercontent.com/2578542/135973367-77f41c84-1f28-42a4-b788-ce9752b855d0.png">

#### After

<img width="832" alt="after-1" src="https://user-images.githubusercontent.com/2578542/135973406-a55c0273-a40f-45d3-8009-ed9a80b290f7.png">

<img width="833" alt="after-2" src="https://user-images.githubusercontent.com/2578542/135973414-52db3fe3-6f3c-4d7d-b761-87f64edf1850.png">

<img width="829" alt="after-3" src="https://user-images.githubusercontent.com/2578542/135973421-276b59a5-39b2-4bd0-81b3-44463602926c.png">
