### PR TITLE
Update Quiz title when parent Lesson title is updated. #4292

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -116,6 +116,7 @@ class Sensei_Quiz {
 			'ID'          => $quiz_id,
 			'post_author' => $new_lesson_author_id,
 			'post_name'   => $saved_lesson->post_name,
+			'post_title'  => $saved_lesson->post_title,
 		);
 
 		// Remove the action so that it doesn't fire again.


### PR DESCRIPTION
Fixes #4292 

### Changes proposed in this Pull Request

- Update the Quiz title when it's parent Lesson title is updated.

### Testing instructions

- Create a Lesson with a Quiz in it.
- Visit a Lesson page and click "View Quiz" button.
- Confirm that the title is the same as Lesson title plus `Quiz`. For example for Lesson `Module` the title for the Quiz is `Module Quiz`.
- Edit Lesson and rename the title.
- Go to the Lesson's quiz page and confirm the Quiz title has updated accordingly.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

- Updated `update_after_lesson_change` hook in `Sensei_Quiz` so that it syncs the Quiz title with Lesson title.

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

- n/a

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

#### Before

https://user-images.githubusercontent.com/2578542/135993004-b148edf9-d034-4f44-87fa-3da4d2b9f226.mp4

#### After

https://user-images.githubusercontent.com/2578542/135993039-04af3137-2e44-4ee1-95a3-eedc8e81a145.mp4
