### PR TITLE
Fix learner management alignment

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -238,6 +238,9 @@
 
 .sensei-learners-wrap  {
 	table .user_status  {
+		span {
+			padding: 0 10px;
+		}
 		.in-progress::before, .graded::before, .not-started::before  {
 			font-family: FontAwesomeSensei;
 			font-size: 14px;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It just fixes the learner management alignment.

### Testing instructions

* Enrol some users on a course.
* Go to the Learner Management, access the course Manage Learners, and make sure the status column is well aligned.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Before:
<img width="1255" alt="Screen Shot 2021-10-06 at 16 47 58" src="https://user-images.githubusercontent.com/876340/136272935-50997c34-4ebb-4596-9d68-d45d17758cf0.png">

After:
<img width="1258" alt="Screen Shot 2021-10-06 at 16 44 50" src="https://user-images.githubusercontent.com/876340/136272849-636d8d47-e2c6-44df-9822-20d70686476f.png">
