### PR TITLE
Add is_array check to avoid warnings

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2239,7 +2239,7 @@ class Sensei_Core_Modules {
 	 */
 	public function append_teacher_name_to_module( $terms, $taxonomies, $args ) {
 		// only for admin users ont he module taxonomy
-		if ( empty( $terms ) || ! current_user_can( 'manage_options' ) || ! in_array( 'module', $taxonomies ) || ! is_admin() ) {
+		if ( empty( $terms ) || ! is_array( $taxonomies ) || ! current_user_can( 'manage_options' ) || ! in_array( 'module', $taxonomies ) || ! is_admin() ) {
 			return $terms;
 		}
 


### PR DESCRIPTION
The following warning was reported:
```
Message: in_array() expects parameter 2 to be array, null given
Location: wp-content/plugins/woothemes-sensei/plugins/sensei-lms/includes/class-sensei-modules.php:2236
in_array()
wp-content/plugins/woothemes-sensei/plugins/sensei-lms/includes/class-sensei-modules.php:2236
Sensei_Core_Modules->append_teacher_name_to_module()
wp-includes/class-wp-hook.php:305
apply_filters('get_terms')
wp-includes/taxonomy.php:1297
get_terms()
wp-content/plugins/woocommerce-smart-coupons/includes/class-wc-sc-coupons-by-taxonomy.php:468
WC_SC_Coupons_By_Taxonomy->get_terms_grouped_by_taxonomy()
wp-content/plugins/woocommerce-smart-coupons/includes/class-wc-sc-coupons-by-taxonomy.php:93
WC_SC_Coupons_By_Taxonomy->usage_restriction()
wp-includes/class-wp-hook.php:303
do_action('woocommerce_coupon_options_usage_restriction')
wp-content/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php:282
WC_Meta_Box_Coupon_Data::output()
wp-admin/includes/template.php:1395
do_meta_boxes()
wp-admin/edit-form-advanced.php:688
```

### Changes proposed in this Pull Request

* This fixes the above warning.

### Testing instructions

* Login with a user which has the teacher role.
* Try creating a course with modules.
* Login with an admin user and visit modules page.
* Observe that the teacher name is appended to the module.
* Ensure that no warnings are logged.