### PR TITLE
Fix is_sensei() false positives

### DIFF
--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -33,8 +33,11 @@ function is_sensei() {
 		$my_courses_page_id       = intval( Sensei()->settings->settings['my_course_page'] );
 		$course_completed_page_id = intval( Sensei()->settings->settings['course_completed_page'] );
 
-		if ( in_array( $post->ID, array( $course_page_id, $my_courses_page_id, $course_completed_page_id ) )
-			|| Sensei_Utils::is_learner_profile_page()
+		if ( ! empty( $post->ID ) && in_array( $post->ID, [ $course_page_id, $my_courses_page_id, $course_completed_page_id ], true ) ) {
+			$is_sensei = true;
+		}
+
+		if ( Sensei_Utils::is_learner_profile_page()
 			|| Sensei_Utils::is_course_results_page()
 			|| Sensei_Utils::is_teacher_archive_page()
 			|| Sensei()->blocks->has_sensei_blocks()

--- a/tests/unit-tests/test-sensei-functions.php
+++ b/tests/unit-tests/test-sensei-functions.php
@@ -47,6 +47,22 @@ class Sensei_Functions_Test extends WP_UnitTestCase {
 		$this->assertTrue( sensei_does_theme_support_templates() );
 	}
 
+	public function testIsSenseiReturnsFalseWhenPostIdEmpty() {
+		global $post;
+
+		$post = $this->factory->post->create_and_get();
+		Sensei()->settings->settings['course_completed_page'] = $post->ID;
+
+		$post->ID = 0;
+		$this->assertFalse( is_sensei() );
+
+		$post->ID = '';
+		$this->assertFalse( is_sensei() );
+
+		$post->ID = Sensei()->settings->settings['course_completed_page'];
+		$this->assertTrue( is_sensei() );
+	}
+
 	/**
 	 * Filter for setting theme to Twenty Sixteen.
 	 *


### PR DESCRIPTION
Fixes #4341

There are cases where $post->ID might be 0 or an empty string. For these cases, if one of 'Course Archive Page', 'My Courses Page' or 'Course Completed Page' is not set, `is_sensei()` will return true.

### Changes proposed in this Pull Request

* Adds a check for $post->ID to not be empty. 
* It also changes the `in_array` check to be strict. Since we are comparing page ids, I can't imagine a scenario where a non strict comparison would be needed.

### Testing instructions
* Observe that the `sensei` class is still added in Sensei pages. For example  'Course Archive Page', 'My Courses Page',  'Course Completed Page' the learner profile page etc.