### PR TITLE
Add a button in questions which opens quiz settings

### DIFF
--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -6,6 +6,7 @@ import { select, useDispatch } from '@wordpress/data';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { __, _n, sprintf } from '@wordpress/i18n';
+import { ToolbarGroup, ToolbarButton } from '@wordpress/components';
 /**
  * External dependencies
  */
@@ -41,6 +42,7 @@ import QuestionView from './question-view';
 import QuestionSettings from './question-settings';
 import { QuestionTypeToolbar } from './question-type-toolbar';
 import SingleQuestion from './single-question';
+import { useQuizSettings } from './question-quiz-settings';
 
 /**
  * Format the question grade as `X points`.
@@ -98,6 +100,8 @@ const QuestionEdit = ( props ) => {
 			{ questionNumber }.
 		</h2>
 	);
+
+	const { onOpenQuizSettings } = useQuizSettings( clientId );
 
 	const isInvalid =
 		props.meta.showValidationErrors && props.meta.validationErrors?.length;
@@ -219,6 +223,14 @@ const QuestionEdit = ( props ) => {
 							} )
 						}
 					/>
+					<ToolbarGroup>
+						<ToolbarButton
+							label={ __( 'Quiz Settings', 'sensei-lms' ) }
+							onClick={ onOpenQuizSettings }
+						>
+							{ __( 'Quiz Settings', 'sensei-lms' ) }
+						</ToolbarButton>
+					</ToolbarGroup>
 				</>
 			</BlockControls>
 			<QuestionSettings controls={ AnswerBlock?.settings } { ...props } />

--- a/assets/blocks/quiz/question-block/question-quiz-settings.js
+++ b/assets/blocks/quiz/question-block/question-quiz-settings.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect, useDispatch } from '@wordpress/data';
+
+/**
+ * Returns a method which opens the quiz settings.
+ *
+ * @param {string} clientId The question's clientId.
+ *
+ * @return {Function} A function which opens the quiz settings.
+ */
+export const useQuizSettings = ( clientId ) => {
+	const { openGeneralSidebar } = useDispatch( 'core/edit-post' );
+	const { selectBlock } = useDispatch( 'core/block-editor' );
+	const { parents } = useSelect(
+		( select ) => ( {
+			parents: select( 'core/block-editor' ).getBlockParentsByBlockName(
+				clientId,
+				'sensei-lms/quiz'
+			),
+		} ),
+		[]
+	);
+
+	let onOpenQuizSettings = () => {};
+
+	if ( parents.length > 0 ) {
+		onOpenQuizSettings = () => {
+			selectBlock( parents[ 0 ] );
+			openGeneralSidebar( 'edit-post/block' );
+		};
+	}
+
+	return { onOpenQuizSettings };
+};


### PR DESCRIPTION
There were some complaints that the quiz settings are not easy to find. For this reason I added a button in the question toolbar which selects the quiz block and opens the sidebar settings.

### Changes proposed in this Pull Request


![settings](https://user-images.githubusercontent.com/53191348/137150642-08bc4ef9-9790-45d6-a6bb-8a8a5f926a9c.gif)

* Adds a button in questions which opens the quiz settings.
* As Gutenberg requires the block to be selected in order for it's settings to open, the button also deselects the question and selects the quiz. This appears to be a bit disrupting
* I considered also adding a link in the question settings in the sidebar but decided against it as it will make it a bit harder to find and having both seems like an overkill.

### Testing instructions
* Open the quiz editor and select a question.
* Click the newly introduced 'Quiz Settings' button and observe that the quiz block is selected and it's settings are opened.