### PR TITLE
Omit className attribute from quiz structure sync

### DIFF
--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -13,7 +13,7 @@ import categoryQuestionBlock from './category-question-block';
 /**
  * External dependencies
  */
-import { mapKeys, mapValues, isObject } from 'lodash';
+import { mapKeys, mapValues, isObject, omit } from 'lodash';
 
 /**
  * Quiz settings and questions data.
@@ -119,12 +119,13 @@ function prepareQuestionBlock( attributes, innerBlocks ) {
  */
 export function parseQuestionBlocks( blocks ) {
 	const questions = blocks?.map( ( block ) => {
+		const attributes = omit( block.attributes, [ 'className' ] );
 		if ( block.attributes.type === 'category-question' ) {
-			return block.attributes;
+			return attributes;
 		}
 
 		return {
-			...block.attributes,
+			...attributes,
 			description: getBlockContent( block ),
 		};
 	} );


### PR DESCRIPTION
Fixes an infinite save loop when there are CSS classes added to a question block.

### Changes proposed in this Pull Request
* Omit `className` attribute from quiz structure syncronization

### Testing instructions
* Add a lesson with a quiz, create a question
* Save lesson
* Add CSS classes to the question block via settings > Advanced > Additional CSS class(es)
* Save
* Check that the post is not saved again and again infinitely

