### PR TITLE
Fix random order for new questions with multiple choice

### DIFF
--- a/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
@@ -13,14 +13,21 @@ import { __ } from '@wordpress/i18n';
  * @param {Function} props.setOptions          Sets the options.
  */
 const QuestionMultipleChoiceSettings = ( {
-	options: { randomOrder = true },
+	options: { randomOrder },
 	setOptions,
-} ) => (
-	<CheckboxControl
-		label={ __( 'Random Order', 'sensei-lms' ) }
-		checked={ randomOrder }
-		onChange={ ( value ) => setOptions( { randomOrder: value } ) }
-	/>
-);
+} ) => {
+	// randomOrder is a specific option for the multiple choice question.
+	// We can't add it to the block.json as it applies for all blocks.
+	if ( undefined === randomOrder ) {
+		setOptions( { randomOrder: true } );
+	}
+	return (
+		<CheckboxControl
+			label={ __( 'Random Order', 'sensei-lms' ) }
+			checked={ randomOrder }
+			onChange={ ( value ) => setOptions( { randomOrder: value } ) }
+		/>
+	);
+};
 
 export default QuestionMultipleChoiceSettings;


### PR DESCRIPTION
Fixes #4287

### Changes proposed in this Pull Request

* Remove the default value for the `randomOrder` option
* Set `randomOrder` to true if the option is not presented

### Testing instructions

* Create a new lesson with a quiz
* Insert a Multiple Choice question and set the answer choices
* Observe that Random Order is enabled by default in block settings
* View quiz
* Reload the page a few times and see that the order changes
