### PR TITLE
Avoid switching from an uncontrolled to a controlled element

### DIFF
--- a/assets/blocks/quiz/answer-blocks/multiple-choice.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * External dependencies
@@ -42,8 +42,16 @@ const MultipleChoiceAnswer = ( props ) => {
 	const { setAttributes, hasSelected } = props;
 
 	let {
-		attributes: { answers = [] },
+		attributes: { answers = [], options = {} },
 	} = props;
+
+	// randomOrder is a specific option for the multiple choice question.
+	// We can't add it to the block.json as it applies for all blocks
+	useEffect( () => {
+		if ( undefined === options.randomOrder ) {
+			setAttributes( { options: { ...options, randomOrder: true } } );
+		}
+	}, [ options, setAttributes ] );
 
 	if ( 0 === answers.length ) {
 		answers = DEFAULT_ANSWERS;

--- a/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
+++ b/assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js
@@ -3,7 +3,6 @@
  */
 import { CheckboxControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
-import { useEffect } from '@wordpress/element';
 
 /**
  * Question block settings for multiple choice questions.
@@ -17,14 +16,6 @@ const QuestionMultipleChoiceSettings = ( {
 	options: { randomOrder },
 	setOptions,
 } ) => {
-	// randomOrder is a specific option for the multiple choice question.
-	// We can't add it to the block.json as it applies for all blocks.
-	useEffect( () => {
-		if ( undefined === randomOrder ) {
-			setOptions( { randomOrder: true } );
-		}
-	}, [ randomOrder, setOptions ] );
-
 	return (
 		<CheckboxControl
 			label={ __( 'Random Order', 'sensei-lms' ) }


### PR DESCRIPTION
Fixes #4287

While fixing an issue with random order in #4356, I introduced a case when the randomOrder option is undefined, resulting in an uncontrolled form element. At the same time, we set a new value for this option and got a warning about switching from an uncontrolled to a controlled element.

The purpose of this pull request is to fix behavior and eliminate warnings.

### Changes proposed in this Pull Request

* Use useEffect to avoid changes in the rendering scope.
* Set default value to avoid switching from an uncontrolled to a controlled element.

### Testing instructions

* Create a new lesson with a quiz
* Open the developer console
* Insert a Multiple Choice question
* There must be no warnings in the console

### Screenshot / Video
Here is an example of warnings in the console:
<img width="1799" alt="Warnings in the console" src="https://user-images.githubusercontent.com/329356/138250134-86684bd0-aa2f-496e-aa3c-5935c91ef488.png">

