### PR TITLE
Fix custom URL slug for course results link

### DIFF
--- a/includes/class-sensei-course-results.php
+++ b/includes/class-sensei-course-results.php
@@ -46,7 +46,7 @@ class Sensei_Course_Results {
 	 * @return void
 	 */
 	public function setup_permastruct() {
-		// Setup learner profile URL base.
+		// Setup course results URL base.
 		$this->courses_url_base = apply_filters( 'sensei_course_slug', _x( 'course', 'post type single url slug', 'sensei-lms' ) );
 
 		// Setup permalinks structure.


### PR DESCRIPTION
Fixes #4284

Other plugins and themes might want to change the URL base through the `sensei_course_slug` filter.

Moving initialization of the `courses_url_base` property to `Sensei_Course_Results::setup_permastruct()` makes it possible.

### Changes proposed in this Pull Request

* Move initialization of the `courses_url_base` property to `Sensei_Course_Results::setup_permastruct()`

### Testing instructions

* Go to functions.php in custom theme (or in custom plugin).
* Add filter for Course slug: add_filter( 'sensei_course_slug', function($slug){ return 'test'; } );
* Unset the "Course Completed Page" in Sensei LMS settings.
* Save WordPress's permalink settings.
* Go to "My Courses" page in frontend for learner with at least one completed course with a quiz.
* "View Results" buttons use the custom URL slug (`test` in our case).
