### PR TITLE
Update quiz status and title on lesson update

### DIFF
--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -122,7 +122,11 @@ registerStructureStore( {
 			'id'
 		);
 
+		const lesson = select( 'core/editor' ).getCurrentPost();
+
 		return {
+			lesson_status: lesson?.status,
+			lesson_title: lesson?.title,
 			options,
 			questions: questionBlockAttributes.map( ( question ) =>
 				// Avoid overriding non-editable question.

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -231,7 +231,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 		Sensei()->quiz->set_questions( $quiz_id, array_filter( $question_ids ) );
 
 		$response = new WP_REST_Response();
-		$response->set_data( $this->get_quiz_data( get_post( $quiz_id ) ) );
+		$response->set_data( $this->get_quiz_data( get_post( $quiz_id ), $lesson ) );
 
 		return $response;
 	}
@@ -328,7 +328,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 		}
 
 		$response = new WP_REST_Response();
-		$response->set_data( $this->get_quiz_data( get_post( $quiz ) ) );
+		$response->set_data( $this->get_quiz_data( get_post( $quiz ), $lesson ) );
 
 		return $response;
 	}
@@ -336,18 +336,19 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 	/**
 	 * Helper method which retrieves quiz options.
 	 *
-	 * @param WP_Post $quiz
+	 * @param WP_Post $quiz   The quiz post.
+	 * @param WP_Post $lesson The lesson post.
 	 *
 	 * @return array
 	 */
-	private function get_quiz_data( WP_Post $quiz ): array {
+	private function get_quiz_data( WP_Post $quiz, WP_Post $lesson ) : array {
 		$post_meta = get_post_meta( $quiz->ID );
 
 		$allow_retakes           = ! empty( $post_meta['_enable_quiz_reset'][0] ) && 'on' === $post_meta['_enable_quiz_reset'][0];
 		$failed_feedback_default = ! $allow_retakes;
 
 		$quiz_data = [
-			'options'   => [
+			'options'       => [
 				'pass_required'               => ! empty( $post_meta['_pass_required'][0] ) && 'on' === $post_meta['_pass_required'][0],
 				'quiz_passmark'               => empty( $post_meta['_quiz_passmark'][0] ) ? 0 : (int) $post_meta['_quiz_passmark'][0],
 				'auto_grade'                  => ! empty( $post_meta['_quiz_grade_type'][0] ) && 'auto' === $post_meta['_quiz_grade_type'][0],
@@ -358,7 +359,9 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 				'failed_show_correct_answers' => empty( $post_meta['_failed_show_correct_answers'][0] ) ? $failed_feedback_default : 'yes' === $post_meta['_failed_show_correct_answers'][0],
 				'failed_show_answer_feedback' => empty( $post_meta['_failed_show_answer_feedback'][0] ) ? $failed_feedback_default : 'yes' === $post_meta['_failed_show_answer_feedback'][0],
 			],
-			'questions' => $this->get_quiz_questions( $quiz ),
+			'questions'     => $this->get_quiz_questions( $quiz ),
+			'lesson_title'  => $lesson->post_title,
+			'lesson_status' => $lesson->post_status,
 		];
 
 		$quiz_data['options']['pagination'] = [
@@ -417,7 +420,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 		$schema = [
 			'type'       => 'object',
 			'properties' => [
-				'options'   => [
+				'options'       => [
 					'type'       => 'object',
 					'required'   => true,
 					'properties' => [
@@ -468,10 +471,18 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 						],
 					],
 				],
-				'questions' => [
+				'questions'     => [
 					'type'     => 'array',
 					'required' => true,
 					'items'    => $this->get_single_question_schema(),
+				],
+				'lesson_title'  => [
+					'type'        => 'string',
+					'description' => 'The lesson title',
+				],
+				'lesson_status' => [
+					'type'        => 'string',
+					'description' => 'The lesson status',
 				],
 			],
 		];


### PR DESCRIPTION
Fixes #4353

### Changes proposed in this Pull Request

* The lesson status and lesson title was not included in the quiz structure. This way the quiz was not update when one of these values changed.
* This change updates the quiz structure store to include these two fields.

### Testing instructions
* Update the lesson status of a lesson with a quiz.
* Observe that the quiz status is changed to be the same with the lesson status.
* Update the lesson title and observe that the quiz title is updated too.