### PR TITLE
add course ID class to courses page and course and lesson ID classes …

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1267,15 +1267,15 @@ class Sensei_Main {
 
 				if ( 'lesson' === $post_type ) {
 					$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
-					$classes[] = 'courseid-' . $course_id;
+					$classes[] = 'course-id-' . $course_id;
 				}
 
 				if ( 'quiz' === $post_type ) {
 					$lesson_id = Sensei()->quiz->get_lesson_id( get_the_ID() );
-					$classes[] = 'lessonid-' . $lesson_id;
+					$classes[] = 'lesson-id-' . $lesson_id;
 
 					$course_id = Sensei()->lesson->get_course_id( $lesson_id );
-					$classes[] = 'courseid-' . $course_id;
+					$classes[] = 'course-id-' . $course_id;
 				}
 			}
 

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -1264,6 +1264,19 @@ class Sensei_Main {
 
 			if ( ! empty( $post_type ) ) {
 				$classes[] = $post_type;
+
+				if ( 'lesson' === $post_type ) {
+					$course_id = Sensei()->lesson->get_course_id( get_the_ID() );
+					$classes[] = 'courseid-' . $course_id;
+				}
+
+				if ( 'quiz' === $post_type ) {
+					$lesson_id = Sensei()->quiz->get_lesson_id( get_the_ID() );
+					$classes[] = 'lessonid-' . $lesson_id;
+
+					$course_id = Sensei()->lesson->get_course_id( $lesson_id );
+					$classes[] = 'courseid-' . $course_id;
+				}
 			}
 
 			// Add class to Course Completed page.


### PR DESCRIPTION
Add Course and Lesson ID to lesson and quiz pages' body tag

Fixes #3752

### Changes proposed in this Pull Request

* On the lesson page, add the course ID class to the body tag: `courseid-XX`
* On the quiz page, add the lesson ID and course ID class to the body tag: `lessonid-XX`, `courseid-XX`

### Testing instructions

* Navigate to a lesson page and inspect the HTML body tag, you should see a class with the format: `courseid-XX`
* Navigate to a quiz page and inspect the HTML body tag, you should see classes with the format: `lessonid-XX` and `courseid-XX`