### PR TITLE
Add course navigation base class

### DIFF
--- a/includes/class-sensei-course-navigation.php
+++ b/includes/class-sensei-course-navigation.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * File containing Sensei_Course_Navigation class.
+ *
+ * @package sensei-lms
+ * @since 3.16.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Sensei_Course_Navigation class.
+ *
+ * @since 3.16.0
+ */
+class Sensei_Course_Navigation {
+	/**
+	 * Instance of class.
+	 *
+	 * @var self
+	 */
+	private static $instance;
+
+	/**
+	 * Sensei_Course_Navigation constructor. Prevents other instances from being created outside of `self::instance()`.
+	 */
+	private function __construct() {}
+
+	/**
+	 * Fetches an instance of the class.
+	 *
+	 * @return self
+	 */
+	public static function instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Initializes the Course Navigation.
+	 */
+	public function init() {}
+}

--- a/includes/class-sensei-course-navigation.php
+++ b/includes/class-sensei-course-navigation.php
@@ -43,6 +43,13 @@ class Sensei_Course_Navigation {
 
 	/**
 	 * Initializes the Course Navigation.
+	 *
+	 * @param Sensei_Main $sensei Sensei object.
 	 */
-	public function init() {}
+	public function init( $sensei ) {
+		if ( ! $sensei->feature_flags->is_enabled( 'course_navigation' ) ) {
+			// As soon this feature flag check is removed, the `$sensei` argument can also be removed.
+			return;
+		}
+	}
 }

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -54,6 +54,7 @@ class Sensei_Feature_Flags {
 			'sensei_default_feature_flag_settings',
 			[
 				'enrolment_provider_tooltip' => false,
+				'course_navigation'          => false,
 			]
 		);
 	}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -416,7 +416,7 @@ class Sensei_Main {
 		$this->enrolment_scheduler = Sensei_Enrolment_Job_Scheduler::instance();
 		$this->enrolment_scheduler->init();
 		Sensei_Data_Port_Manager::instance()->init();
-		Sensei_Course_Navigation::instance()->init();
+		Sensei_Course_Navigation::instance()->init( $this );
 
 		// Setup Wizard.
 		$this->setup_wizard = Sensei_Setup_Wizard::instance();

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -416,6 +416,7 @@ class Sensei_Main {
 		$this->enrolment_scheduler = Sensei_Enrolment_Job_Scheduler::instance();
 		$this->enrolment_scheduler->init();
 		Sensei_Data_Port_Manager::instance()->init();
+		Sensei_Course_Navigation::instance()->init();
 
 		// Setup Wizard.
 		$this->setup_wizard = Sensei_Setup_Wizard::instance();

--- a/tests/unit-tests/test-class-sensei-course-navigation.php
+++ b/tests/unit-tests/test-class-sensei-course-navigation.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file contains the Sensei_Course_Navigation_Test class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tests for Sensei_Course_Navigation_Test class.
+ *
+ * @group course-navigation
+ */
+class Sensei_Course_Navigation_Test extends WP_UnitTestCase {
+	/**
+	 * Testing the Course Navigation class to make sure it is loaded.
+	 */
+	public function testClassInstance() {
+		$this->assertTrue( class_exists( 'Sensei_Course_Navigation' ), 'Sensei Course Navigation class should exist' );
+	}
+}


### PR DESCRIPTION
Fixes #4366

### Changes proposed in this Pull Request

* It introduces the basic class for the Course Navigation.
* It also introduces a feature flag check to initialize the class. You can activate it with the constant `define( 'SENSEI_FEATURE_FLAG_COURSE_NAVIGATION', true );`

### Testing instructions

* Just make sure the tests are passing (there's a check to confirm if the class exists).