### PR TITLE
Add pagination sidebar settings

### DIFF
--- a/assets/blocks/editor-components/number-control/index.js
+++ b/assets/blocks/editor-components/number-control/index.js
@@ -12,16 +12,17 @@ import { __ } from '@wordpress/i18n';
 /**
  * Number control component.
  *
- * @param {Object}   props                    Component props.
- * @param {string}   [props.className]        Additional classnames for the input.
- * @param {string}   [props.id]               Component id used to connect label and input - required if label is set.
- * @param {string}   [props.label]            Input label.
- * @param {number}   [props.value]            Input value.
- * @param {string}   [props.help]             Help text.
- * @param {boolean}  [props.allowReset=false] Whether reset is allowed.
- * @param {string}   [props.resetLabel]       Reset button custom label.
- * @param {Function} props.onChange           Change function, which receives number as argument.
- * @param {string}   props.suffix             Input suffix.
+ * @param {Object}   props                     Component props.
+ * @param {string}   [props.className]         Additional classnames for the input.
+ * @param {string}   [props.id]                Component id used to connect label and input - required if label is set.
+ * @param {string}   [props.label]             Input label.
+ * @param {number}   [props.value]             Input value.
+ * @param {string}   [props.help]              Help text.
+ * @param {boolean}  [props.allowReset=false]  Whether reset is allowed.
+ * @param {string}   [props.resetLabel]        Reset button custom label.
+ * @param {Function} props.onChange            Change function, which receives number as argument.
+ * @param {string}   props.suffix              Input suffix.
+ * @param {boolean}  props.hideLabelFromVision Hides label.
  */
 const NumberControl = ( {
 	className,
@@ -33,6 +34,7 @@ const NumberControl = ( {
 	resetLabel,
 	onChange,
 	suffix,
+	hideLabelFromVision,
 	...props
 } ) => {
 	const setValue = ( e ) => {
@@ -40,7 +42,12 @@ const NumberControl = ( {
 	};
 
 	return (
-		<BaseControl id={ id } label={ label } help={ help }>
+		<BaseControl
+			id={ id }
+			label={ label }
+			help={ help }
+			hideLabelFromVision={ hideLabelFromVision }
+		>
 			<div className="sensei-number-control">
 				<div className="sensei-number-control__input-container">
 					<input

--- a/assets/blocks/quiz/quiz-block/block.json
+++ b/assets/blocks/quiz/quiz-block/block.json
@@ -11,7 +11,10 @@
     },
     "options": {
       "type": "object"
-		},
+    },
+    "paginationSettings": {
+      "type": "object"
+    },
     "isPostTemplate": {
       "type": "boolean",
       "default": false

--- a/assets/blocks/quiz/quiz-block/pagination-settings.js
+++ b/assets/blocks/quiz/quiz-block/pagination-settings.js
@@ -1,0 +1,168 @@
+/**
+ * WordPress dependencies
+ */
+import { ContrastChecker, PanelColorSettings } from '@wordpress/block-editor';
+import {
+	PanelBody,
+	PanelRow,
+	ToggleControl,
+	SelectControl,
+} from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import NumberControl from '../../editor-components/number-control';
+
+const SINGLE = 'single';
+const MULTI = 'multi';
+
+/**
+ * Quiz settings.
+ *
+ * @param {Object}   props          Block props.
+ * @param {Object}   props.settings Pagination settings object.
+ * @param {Function} props.onChange Callback called when a setting changed.
+ */
+const PaginationSettings = ( { settings, onChange } ) => {
+	const {
+		paginationNumber,
+		showProgressBar,
+		progressBarRadius,
+		progressBarHeight,
+		progressBarColor,
+		progressBarBackground,
+	} = settings;
+
+	return (
+		<>
+			<PanelBody
+				title={ __( 'Quiz front end', 'sensei-lms' ) }
+				initialOpen={ true }
+			>
+				<p>
+					{ __(
+						'Adjust how your quiz is displayed to your learners.',
+						'sensei-lms'
+					) }
+				</p>
+				<PanelRow className="sensei-lms-quiz-block-panel__row-title">
+					<h2>{ __( 'Pagination', 'sensei-lms' ) }</h2>
+					<SelectControl
+						label={ __( 'Pagination', 'sensei-lms' ) }
+						hideLabelFromVision
+						value={ paginationNumber !== null ? MULTI : SINGLE }
+						options={ [
+							{
+								label: __( 'Single page', 'sensei-lms' ),
+								value: SINGLE,
+							},
+							{
+								label: __( 'Multi page', 'sensei-lms' ),
+								value: MULTI,
+							},
+						] }
+						onChange={ ( value ) => {
+							if ( value === MULTI ) {
+								onChange( {
+									...settings,
+									paginationNumber: 1,
+								} );
+							} else {
+								onChange( {
+									...settings,
+									paginationNumber: null,
+								} );
+							}
+						} }
+					/>
+					<NumberControl
+						label={ __( 'Number of Questions', 'sensei-lms' ) }
+						min={ 1 }
+						step={ 1 }
+						hideLabelFromVision
+						suffix={ __( 'QNS', 'sensei-lms' ) }
+						value={ paginationNumber }
+						onChange={ ( value ) =>
+							onChange( { ...settings, paginationNumber: value } )
+						}
+					/>
+				</PanelRow>
+				<PanelRow className="sensei-lms-quiz-block-panel__row-title">
+					<h2>{ __( 'Progress Bar', 'sensei-lms' ) }</h2>
+					<ToggleControl
+						className="sensei-lms-quiz-block-panel__row-item"
+						checked={ showProgressBar }
+						label={ __( 'Show Progress Bar', 'sensei-lms' ) }
+						value={ progressBarRadius }
+						onChange={ ( value ) =>
+							onChange( { ...settings, showProgressBar: value } )
+						}
+					/>
+					<NumberControl
+						label={ __( 'Radius', 'sensei-lms' ) }
+						min={ 1 }
+						step={ 1 }
+						suffix={ __( 'PX', 'sensei-lms' ) }
+						value={ progressBarRadius }
+						onChange={ ( value ) =>
+							onChange( {
+								...settings,
+								progressBarRadius: value,
+							} )
+						}
+					/>
+					<NumberControl
+						label={ __( 'Height', 'sensei-lms' ) }
+						min={ 1 }
+						step={ 1 }
+						suffix={ __( 'PX', 'sensei-lms' ) }
+						value={ progressBarHeight }
+						onChange={ ( value ) =>
+							onChange( {
+								...settings,
+								progressBarHeight: value,
+							} )
+						}
+					/>
+				</PanelRow>
+			</PanelBody>
+			<PanelColorSettings
+				title={ __( 'Color settings', 'sensei-lms' ) }
+				initialOpen={ false }
+				colorSettings={ [
+					{
+						value: progressBarColor,
+						onChange: ( value ) =>
+							onChange( {
+								...settings,
+								progressBarColor: value,
+							} ),
+						label: __( 'Progress bar color', 'sensei-lms' ),
+					},
+					{
+						value: progressBarBackground,
+						onChange: ( value ) =>
+							onChange( {
+								...settings,
+								progressBarBackground: value,
+							} ),
+						label: __(
+							'Progress bar background color',
+							'sensei-lms'
+						),
+					},
+				] }
+			>
+				<ContrastChecker
+					textColor={ progressBarColor }
+					backgroundColor={ progressBarBackground }
+					isLargeText={ false }
+				/>
+			</PanelColorSettings>
+		</>
+	);
+};
+
+export default PaginationSettings;

--- a/assets/blocks/quiz/quiz-block/pagination-settings.js
+++ b/assets/blocks/quiz/quiz-block/pagination-settings.js
@@ -38,6 +38,7 @@ const PaginationSettings = ( { settings, onChange } ) => {
 	return (
 		<>
 			<PanelBody
+				className="sensei-lms-quiz-block-styling"
 				title={ __( 'Quiz styling', 'sensei-lms' ) }
 				initialOpen={ true }
 			>
@@ -47,52 +48,65 @@ const PaginationSettings = ( { settings, onChange } ) => {
 						'sensei-lms'
 					) }
 				</p>
-				<PanelRow className="sensei-lms-quiz-block-panel__row-title">
-					<h2>{ __( 'Pagination', 'sensei-lms' ) }</h2>
-					<SelectControl
-						label={ __( 'Pagination', 'sensei-lms' ) }
-						hideLabelFromVision
-						value={ paginationNumber !== null ? MULTI : SINGLE }
-						options={ [
-							{
-								label: __( 'Single page', 'sensei-lms' ),
-								value: SINGLE,
-							},
-							{
-								label: __( 'Multi-Page', 'sensei-lms' ),
-								value: MULTI,
-							},
-						] }
-						onChange={ ( value ) => {
-							if ( value === MULTI ) {
+				<PanelRow className="sensei-lms-quiz-block-panel">
+					<h2 className="sensei-lms-quiz-block-panel__row">
+						{ __( 'Pagination', 'sensei-lms' ) }
+					</h2>
+					<div className="sensei-lms-quiz-block-panel__row">
+						<SelectControl
+							label={ __( 'Pagination', 'sensei-lms' ) }
+							className="test"
+							hideLabelFromVision
+							value={ paginationNumber !== null ? MULTI : SINGLE }
+							options={ [
+								{
+									label: __( 'Single page', 'sensei-lms' ),
+									value: SINGLE,
+								},
+								{
+									label: __( 'Multi-Page', 'sensei-lms' ),
+									value: MULTI,
+								},
+							] }
+							onChange={ ( value ) => {
+								if ( value === MULTI ) {
+									onChange( {
+										...settings,
+										paginationNumber: 1,
+									} );
+								} else {
+									onChange( {
+										...settings,
+										paginationNumber: null,
+									} );
+								}
+							} }
+						/>
+					</div>
+					<div className="sensei-lms-quiz-block-panel__row sensei-lms-quiz-block-panel__questions">
+						<NumberControl
+							label={ __( 'Number of Questions', 'sensei-lms' ) }
+							min={ 1 }
+							step={ 1 }
+							hideLabelFromVision
+							suffix={ __( 'Questions', 'sensei-lms' ) }
+							value={ paginationNumber }
+							onChange={ ( value ) =>
 								onChange( {
 									...settings,
-									paginationNumber: 1,
-								} );
-							} else {
-								onChange( {
-									...settings,
-									paginationNumber: null,
-								} );
+									paginationNumber: value,
+								} )
 							}
-						} }
-					/>
-					<NumberControl
-						label={ __( 'Number of Questions', 'sensei-lms' ) }
-						min={ 1 }
-						step={ 1 }
-						hideLabelFromVision
-						suffix={ __( 'Questions', 'sensei-lms' ) }
-						value={ paginationNumber }
-						onChange={ ( value ) =>
-							onChange( { ...settings, paginationNumber: value } )
-						}
-					/>
+						/>
+						<p>{ __( 'per page', 'sensei-lms' ) }</p>
+					</div>
 				</PanelRow>
-				<PanelRow className="sensei-lms-quiz-block-panel__row-title">
-					<h2>{ __( 'Progress Bar', 'sensei-lms' ) }</h2>
+				<PanelRow className="sensei-lms-quiz-block-panel">
+					<h2 className="sensei-lms-quiz-block-panel__row">
+						{ __( 'Progress Bar', 'sensei-lms' ) }
+					</h2>
 					<ToggleControl
-						className="sensei-lms-quiz-block-panel__row-item"
+						className="sensei-lms-quiz-block-panel__row"
 						checked={ showProgressBar }
 						label={ __( 'Show Progress Bar', 'sensei-lms' ) }
 						value={ progressBarRadius }
@@ -100,32 +114,34 @@ const PaginationSettings = ( { settings, onChange } ) => {
 							onChange( { ...settings, showProgressBar: value } )
 						}
 					/>
-					<NumberControl
-						label={ __( 'Radius', 'sensei-lms' ) }
-						min={ 1 }
-						step={ 1 }
-						suffix={ __( 'PX', 'sensei-lms' ) }
-						value={ progressBarRadius }
-						onChange={ ( value ) =>
-							onChange( {
-								...settings,
-								progressBarRadius: value,
-							} )
-						}
-					/>
-					<NumberControl
-						label={ __( 'Height', 'sensei-lms' ) }
-						min={ 1 }
-						step={ 1 }
-						suffix={ __( 'PX', 'sensei-lms' ) }
-						value={ progressBarHeight }
-						onChange={ ( value ) =>
-							onChange( {
-								...settings,
-								progressBarHeight: value,
-							} )
-						}
-					/>
+					<div className="sensei-lms-quiz-block-panel__row sensei-lms-quiz-block-panel__progress-bar">
+						<NumberControl
+							label={ __( 'Radius', 'sensei-lms' ) }
+							min={ 1 }
+							step={ 1 }
+							suffix={ __( 'PX', 'sensei-lms' ) }
+							value={ progressBarRadius }
+							onChange={ ( value ) =>
+								onChange( {
+									...settings,
+									progressBarRadius: value,
+								} )
+							}
+						/>
+						<NumberControl
+							label={ __( 'Height', 'sensei-lms' ) }
+							min={ 1 }
+							step={ 1 }
+							suffix={ __( 'PX', 'sensei-lms' ) }
+							value={ progressBarHeight }
+							onChange={ ( value ) =>
+								onChange( {
+									...settings,
+									progressBarHeight: value,
+								} )
+							}
+						/>
+					</div>
 				</PanelRow>
 			</PanelBody>
 			<PanelColorSettings

--- a/assets/blocks/quiz/quiz-block/pagination-settings.js
+++ b/assets/blocks/quiz/quiz-block/pagination-settings.js
@@ -38,7 +38,7 @@ const PaginationSettings = ( { settings, onChange } ) => {
 	return (
 		<>
 			<PanelBody
-				title={ __( 'Quiz front end', 'sensei-lms' ) }
+				title={ __( 'Quiz styling', 'sensei-lms' ) }
 				initialOpen={ true }
 			>
 				<p>
@@ -59,7 +59,7 @@ const PaginationSettings = ( { settings, onChange } ) => {
 								value: SINGLE,
 							},
 							{
-								label: __( 'Multi page', 'sensei-lms' ),
+								label: __( 'Multi-Page', 'sensei-lms' ),
 								value: MULTI,
 							},
 						] }
@@ -82,7 +82,7 @@ const PaginationSettings = ( { settings, onChange } ) => {
 						min={ 1 }
 						step={ 1 }
 						hideLabelFromVision
-						suffix={ __( 'QNS', 'sensei-lms' ) }
+						suffix={ __( 'Questions', 'sensei-lms' ) }
 						value={ paginationNumber }
 						onChange={ ( value ) =>
 							onChange( { ...settings, paginationNumber: value } )

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -145,12 +145,14 @@ const QuizSettings = ( {
 					/>
 				</PanelRow>
 			</PanelBody>
-			<PaginationSettings
-				settings={ paginationSettings }
-				onChange={ ( newSettings ) =>
-					setAttributes( { paginationSettings: newSettings } )
-				}
-			/>
+			{ window.sensei_single_lesson_blocks.quiz_pagination_enabled && (
+				<PaginationSettings
+					settings={ paginationSettings }
+					onChange={ ( newSettings ) =>
+						setAttributes( { paginationSettings: newSettings } )
+					}
+				/>
+			) }
 		</InspectorControls>
 	);
 };

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -17,18 +17,20 @@ import { __ } from '@wordpress/i18n';
  */
 import NumberControl from '../../editor-components/number-control';
 import { isQuestionEmpty } from '../data';
+import PaginationSettings from './pagination-settings';
 
 /**
  * Quiz settings.
  *
- * @param {Object}   props                    Block props.
- * @param {Object}   props.attributes         Block attributes
- * @param {Object}   props.attributes.options Current setting options.
- * @param {Function} props.setAttributes      Set attributes function.
- * @param {string}   props.clientId           Block ID.
+ * @param {Object}   props                               Block props.
+ * @param {Object}   props.attributes                    Block attributes
+ * @param {Object}   props.attributes.options            Current setting options.
+ * @param {Function} props.setAttributes                 Set attributes function.
+ * @param {string}   props.clientId                      Block ID.
+ * @param {Object}   props.attributes.paginationSettings Pagination settings.
  */
 const QuizSettings = ( {
-	attributes: { options = {} },
+	attributes: { options = {}, paginationSettings = {} },
 	setAttributes,
 	clientId,
 } ) => {
@@ -143,6 +145,12 @@ const QuizSettings = ( {
 					/>
 				</PanelRow>
 			</PanelBody>
+			<PaginationSettings
+				settings={ paginationSettings }
+				onChange={ ( newSettings ) =>
+					setAttributes( { paginationSettings: newSettings } )
+				}
+			/>
 		</InspectorControls>
 	);
 };

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -145,7 +145,8 @@ const QuizSettings = ( {
 					/>
 				</PanelRow>
 			</PanelBody>
-			{ window.sensei_single_lesson_blocks.quiz_pagination_enabled && (
+			{ /* eslint-disable-next-line camelcase */ }
+			{ window.sensei_single_lesson_blocks?.quiz_pagination_enabled && (
 				<PaginationSettings
 					settings={ paginationSettings }
 					onChange={ ( newSettings ) =>

--- a/assets/blocks/quiz/quiz-block/quiz-settings.test.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.test.js
@@ -11,6 +11,7 @@ import QuizSettings from './quiz-settings';
 jest.mock( '@wordpress/block-editor', () => ( {
 	...jest.requireActual( '@wordpress/block-editor' ),
 	InspectorControls: ( { children } ) => children,
+	PanelColorSettings: () => null,
 } ) );
 
 jest.mock( '@wordpress/data', () => {

--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -71,6 +71,10 @@ registerStructureStore( {
 
 		yield dispatch( 'core/block-editor' ).updateBlockAttributes( clientId, {
 			options: normalizeAttributes( structure.options, camelCase ),
+			paginationSettings: normalizeAttributes(
+				structure.pagination,
+				camelCase
+			),
 		} );
 
 		if ( ! structure.questions?.length ) {
@@ -110,6 +114,11 @@ registerStructureStore( {
 			snakeCase
 		);
 
+		const pagination = normalizeAttributes(
+			quizBlock.attributes.paginationSettings,
+			snakeCase
+		);
+
 		const questionBlocks = select( 'core/block-editor' ).getBlocks(
 			clientId
 		);
@@ -129,6 +138,7 @@ registerStructureStore( {
 					? serverQuestionsById[ question.id ]
 					: omit( question, READ_ONLY_ATTRIBUTES )
 			),
+			pagination,
 		};
 	},
 

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -72,6 +72,28 @@ $gray-400: #ccc;
 	}
 }
 
+.sensei-lms-quiz-block-panel {
+	&__row-title {
+		flex-wrap: wrap;
+
+		h2 {
+			flex-basis: 100%;
+			font-size: calc( #{$default-font-size} + 1px );
+			font-weight: normal;
+		}
+
+		.components-base-control {
+			flex-basis: 48%;
+			margin-bottom: 8px;
+		}
+	}
+
+	&__row-item.components-base-control {
+		flex-basis: 100%;
+		margin-bottom: 12px;
+	}
+}
+
 .sensei-lms-block-validation-notice {
 
 	display: inline-block;

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -72,25 +72,44 @@ $gray-400: #ccc;
 	}
 }
 
-.sensei-lms-quiz-block-panel {
-	&__row-title {
-		flex-wrap: wrap;
+.sensei-lms-quiz-block-styling .sensei-lms-quiz-block-panel {
+	flex-wrap: wrap;
 
-		h2 {
-			flex-basis: 100%;
-			font-size: calc( #{$default-font-size} + 1px );
-			font-weight: normal;
-		}
+	h2 {
+		font-size: calc( #{$default-font-size} + 1px );
+		font-weight: normal;
+	}
+
+	&__row {
+		flex-basis: 100%;
+		margin-right: 1em;
+	}
+
+	.components-base-control {
+		margin-bottom: 1em;
+	}
+
+	&__questions {
+		display: flex;
+		align-items: baseline;
 
 		.components-base-control {
-			flex-basis: 48%;
-			margin-bottom: 8px;
+			flex-basis: 62%;
+			margin-right: 1em;
+		}
+
+		p {
+			flex-basis: 30%;
 		}
 	}
 
-	&__row-item.components-base-control {
-		flex-basis: 100%;
-		margin-bottom: 12px;
+	&__progress-bar {
+		display: flex;
+		justify-content: space-between;
+
+		.components-base-control {
+			flex-basis: 48%;
+		}
 	}
 }
 

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -54,6 +54,19 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 			[ 'sensei-shared-blocks-editor-style', 'sensei-editor-components-style' ]
 		);
 
+		wp_add_inline_script(
+			'sensei-single-lesson-blocks',
+			sprintf(
+				'window.sensei_single_lesson_blocks = %s',
+				wp_json_encode(
+					[
+						'quiz_pagination_enabled' => Sensei()->feature_flags->is_enabled( 'quiz_pagination' ),
+					]
+				)
+			),
+			'before'
+		);
+
 	}
 
 	/**

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -55,6 +55,7 @@ class Sensei_Feature_Flags {
 			[
 				'enrolment_provider_tooltip' => false,
 				'course_theme'               => false,
+				'quiz_pagination'            => false,
 			]
 		);
 	}

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -179,8 +179,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson->ID );
 		$is_new  = null === $quiz_id;
 
-		$json_params  = $request->get_json_params();
-		$quiz_options = $json_params['options'];
+		$json_params = $request->get_json_params();
 
 		$quiz_id = wp_insert_post(
 			[
@@ -190,7 +189,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 				'post_title'   => $lesson->post_title,
 				'post_type'    => 'quiz',
 				'post_parent'  => $lesson->ID,
-				'meta_input'   => $this->get_quiz_meta( $quiz_options, $lesson ),
+				'meta_input'   => $this->get_quiz_meta( $json_params, $lesson ),
 			]
 		);
 
@@ -240,13 +239,15 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 	/**
 	 * Helper method to translate input to quiz meta.
 	 *
-	 * @param array   $quiz_options The input coming from JSON data.
+	 * @param array   $json_params The input coming from JSON data.
 	 * @param WP_Post $lesson       The parent lesson.
 	 *
 	 * @return array The meta.
 	 */
-	private function get_quiz_meta( array $quiz_options, WP_Post $lesson ) : array {
+	private function get_quiz_meta( array $json_params, WP_Post $lesson ) : array {
 		$meta_input = [ '_quiz_lesson' => $lesson->ID ];
+
+		$quiz_options = $json_params['options'];
 
 		if ( isset( $quiz_options['pass_required'] ) ) {
 			$meta_input['_pass_required'] = true === $quiz_options['pass_required'] ? 'on' : '';
@@ -270,6 +271,10 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 
 		if ( isset( $quiz_options['random_question_order'] ) ) {
 			$meta_input['_random_question_order'] = true === $quiz_options['random_question_order'] ? 'yes' : 'no';
+		}
+
+		if ( isset( $json_params['pagination'] ) ) {
+			$meta_input['_pagination'] = wp_json_encode( $json_params['pagination'] );
 		}
 
 		return $meta_input;
@@ -329,8 +334,8 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 	 */
 	private function get_quiz_data( WP_Post $quiz ) : array {
 		$post_meta = get_post_meta( $quiz->ID );
-		return [
-			'options'   => [
+		$quiz_data = [
+			'options'    => [
 				'pass_required'         => ! empty( $post_meta['_pass_required'][0] ) && 'on' === $post_meta['_pass_required'][0],
 				'quiz_passmark'         => empty( $post_meta['_quiz_passmark'][0] ) ? 0 : (int) $post_meta['_quiz_passmark'][0],
 				'auto_grade'            => ! empty( $post_meta['_quiz_grade_type'][0] ) && 'auto' === $post_meta['_quiz_grade_type'][0],
@@ -338,8 +343,29 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 				'show_questions'        => empty( $post_meta['_show_questions'][0] ) ? null : (int) $post_meta['_show_questions'][0],
 				'random_question_order' => ! empty( $post_meta['_random_question_order'][0] ) && 'yes' === $post_meta['_random_question_order'][0],
 			],
-			'questions' => $this->get_quiz_questions( $quiz ),
+			'questions'  => $this->get_quiz_questions( $quiz ),
+			'pagination' => ! empty( $post_meta['_pagination'] ) ? $post_meta['_pagination'] : [],
 		];
+
+		$quiz_data['pagination'] = [
+			'pagination_number'       => null,
+			'show_progress_bar'       => false,
+			'progress_bar_radius'     => 5,
+			'progress_bar_height'     => 5,
+			'progress_bar_color'      => null,
+			'progress_bar_background' => null,
+		];
+
+		if ( empty( $post_meta['_pagination'][0] ) || ! is_string( $post_meta['_pagination'][0] ) ) {
+			return $quiz_data;
+		}
+
+		$json_array = json_decode( $post_meta['_pagination'][0], true );
+		if ( $json_array ) {
+			$quiz_data['pagination'] = $json_array;
+		}
+
+		return $quiz_data;
 	}
 
 	/**
@@ -420,6 +446,40 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 				],
 			],
 		];
+
+		if ( Sensei()->feature_flags->is_enabled( 'quiz_pagination' ) ) {
+			$schema['properties']['pagination'] = [
+				'type'       => 'object',
+				'required'   => true,
+				'properties' => [
+					'pagination_number'       => [
+						'type'        => 'integer',
+						'description' => 'Number of questions per page',
+						'default'     => null,
+					],
+					'show_progress_bar'       => [
+						'type'        => 'boolean',
+						'description' => 'Whether to show the progress bar in the frontend',
+						'default'     => false,
+					],
+					'progress_bar_radius'     => [
+						'type'        => 'integer',
+						'description' => 'Progress bar radius',
+						'default'     => 5,
+					],
+					'progress_bar_height'     => [
+						'type'        => 'integer',
+						'description' => 'Progress bar height',
+						'default'     => 5,
+					],
+					'progress_bar_background' => [
+						'type'        => 'string',
+						'description' => 'Progress bar background color',
+						'default'     => null,
+					],
+				],
+			];
+		}
 
 		return $schema;
 	}

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
@@ -766,6 +766,59 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 	}
 
 	/**
+	 * Tests updating quiz pagination settings.
+	 */
+	public function testUpdatingPaginationSettings() {
+		$this->login_as_teacher();
+
+		$lesson_id = $this->factory->lesson->create();
+
+		$body = [
+			'options'    => [],
+			'questions'  => [],
+			'pagination' => [
+				'pagination_number'       => 3,
+				'show_progress_bar'       => true,
+				'progress_bar_radius'     => 10,
+				'progress_bar_height'     => 10,
+				'progress_bar_color'      => '#ffffff',
+				'progress_bar_background' => '#eeeeee',
+			],
+		];
+
+		$this->send_post_request( $lesson_id, $body );
+
+		$pagination_meta = get_post_meta( Sensei()->lesson->lesson_quizzes( $lesson_id ), '_pagination', true );
+		$json_array      = json_decode( $pagination_meta, true );
+
+		$this->assertEquals( 3, $json_array['pagination_number'] );
+		$this->assertEquals( true, $json_array['show_progress_bar'] );
+		$this->assertEquals( 10, $json_array['progress_bar_radius'] );
+		$this->assertEquals( 10, $json_array['progress_bar_height'] );
+		$this->assertEquals( '#ffffff', $json_array['progress_bar_color'] );
+		$this->assertEquals( '#eeeeee', $json_array['progress_bar_background'] );
+	}
+
+	/**
+	 * Tests default values for quiz pagination settings.
+	 */
+	public function testPaginationSettingsDefaultValues() {
+		$this->login_as_teacher();
+
+		list( $lesson_id ) = $this->create_lesson_with_quiz();
+
+		$response_data       = $this->send_get_request( $lesson_id );
+		$pagination_settings = $response_data['pagination'];
+
+		$this->assertNull( $pagination_settings['pagination_number'] );
+		$this->assertFalse( $pagination_settings['show_progress_bar'] );
+		$this->assertEquals( 5, $pagination_settings['progress_bar_radius'] );
+		$this->assertEquals( 5, $pagination_settings['progress_bar_height'] );
+		$this->assertNull( $pagination_settings['progress_bar_color'] );
+		$this->assertNull( $pagination_settings['progress_bar_background'] );
+	}
+
+	/**
 	 * Tests that invalid question data are validated.
 	 */
 	public function testQuestionValidationFails() {


### PR DESCRIPTION
Fixes #4387 #4390

![Screenshot 2021-11-02 at 11 09 56](https://user-images.githubusercontent.com/53191348/139818145-8690e4b6-8f59-4313-8b28-01533c9b122b.png)

### Changes proposed in this Pull Request

* Adds sidebar settings for quiz pagination.

### Testing instructions

* As it is now, the changes are stored in the quiz meta but they are not used anywhere. For testing you can update the quiz and check `pagination` quiz meta to see if the correct JSON is stored.
* To try the settings you will need to add this snippet: `add_filter( 'sensei_feature_flag_quiz_pagination', '__return_true' );`