### PR TITLE
Fix single page blocks script loading on the front-end

### DIFF
--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -38,7 +38,6 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	public function enqueue_block_assets() {
 
 		Sensei()->assets->disable_frontend_styles();
-		Sensei()->assets->enqueue( 'sensei-single-page-blocks', 'blocks/single-page.js', [], true );
 		Sensei()->assets->enqueue(
 			'sensei-single-page-blocks-style',
 			'blocks/single-page-style.css'
@@ -51,6 +50,7 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	 * @access private
 	 */
 	public function enqueue_block_editor_assets() {
+		Sensei()->assets->enqueue( 'sensei-single-page-blocks', 'blocks/single-page.js', [], true );
 		Sensei()->assets->enqueue(
 			'sensei-single-page-blocks-editor-style',
 			'blocks/single-page-style-editor.css'


### PR DESCRIPTION
Fixes #4335

The course completed page is showing warnings in the JS console.

```
The block "sensei-lms/course-results" is registered with an invalid category "sensei-lms".
```

This is due to a blocks script loading on the front-end. Changing the script to load only on the editor fixes the issue.

### Changes proposed in this Pull Request

* Load the `blocks/single-page.js` script only on the editor and not on the front-end.

### Testing instructions

* Go to the "Course Completed" page on the front-end.
* Make sure there are no warnings in the browser's console.
* Open the "Course Completed" page in the editor.
* Make sure all blocks are loading as expected.