### PR TITLE
Fix PHP linter throws an error when the project folder has spaces

### DIFF
--- a/scripts/linter-new-php
+++ b/scripts/linter-new-php
@@ -8,7 +8,7 @@ created=`git log --diff-filter=A --follow --format=%at -- "$1" | tail -1`
 if [[ $created > 1577833200 ]] ;
 then
     echo "Linting $1"
-    ./vendor/bin/phpcs -q $1
+    ./vendor/bin/phpcs -q "$1"
 else
   echo "Skipping linting for $1"
   exit 0


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Wrap the path argument with quotes in the PHP linter bash script.

### Testing instructions

* Move the git repository to a folder that contains a space in its name. (ex: `/home/user/Local Sites/sensei`)
* Make a change to a .php file.
* Add the file to git with `git add .`.
* Run `git status` to make sure the file was added.
* Run `git commit`.
* Ensure there are no errors generated by `linter-new-php`.

### Screenshot / Video
<img width="975" alt="Markup 2021-11-03 at 13 07 42" src="https://user-images.githubusercontent.com/1612178/140050206-da85ab18-d6a1-4a73-b5f4-b92ac4f09949.png">

