### PR TITLE
Fix lesson quick edit and bulk edit for quiz settings

### DIFF
--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -125,6 +125,18 @@ div.question_boolean_fields { margin-bottom: 10px; }
     text-decoration: none;
 }
 
+.sensei-edit-field-set .sensei-quiz-settings {
+	display: flex;
+	width: 40%;
+	flex-wrap: wrap;
+	margin-bottom: 0.3em;
+}
+
+.sensei-edit-field-set .sensei-quiz-settings .title {
+	flex-basis: 90%;
+	flex-shrink: 0;
+}
+
 .wp-list-table {
 	.sensei-wp-list-table-link {
 		display: block;

--- a/assets/js/admin/lesson-bulk-edit.js
+++ b/assets/js/admin/lesson-bulk-edit.js
@@ -76,7 +76,6 @@ jQuery( function ( $ ) {
 				sensei_edit_pass_required: newPassRequired,
 				sensei_edit_pass_percentage: newPassPercentage,
 				sensei_edit_enable_quiz_reset: newEnableQuizReset,
-				// other values not originally included
 				sensei_edit_show_questions: newShowQuestions,
 				sensei_edit_random_question_order: newRandomQuestionOrder,
 				sensei_edit_quiz_grade_type: newQuizGradeType,

--- a/assets/js/admin/lesson-bulk-edit.js
+++ b/assets/js/admin/lesson-bulk-edit.js
@@ -45,6 +45,21 @@ jQuery( function ( $ ) {
 			.find( '#sensei-edit-enable-quiz-reset' )
 			.val();
 
+		// Quiz number of questions to show
+		var newShowQuestions = $bulk_row
+			.find( '#sensei-edit-show-questions' )
+			.val();
+
+		// Quiz Random Question Order
+		var newRandomQuestionOrder = $bulk_row
+			.find( '#sensei-edit-random-question-order' )
+			.val();
+
+		// Quiz Grade Type
+		var newQuizGradeType = $bulk_row
+			.find( '#sensei-edit-quiz-grade-type' )
+			.val();
+
 		// save the data
 		$.ajax( {
 			url: ajaxurl, // this is a variable that WordPress has already defined for us
@@ -61,6 +76,10 @@ jQuery( function ( $ ) {
 				sensei_edit_pass_required: newPassRequired,
 				sensei_edit_pass_percentage: newPassPercentage,
 				sensei_edit_enable_quiz_reset: newEnableQuizReset,
+				// other values not originally included
+				sensei_edit_show_questions: newShowQuestions,
+				sensei_edit_random_question_order: newRandomQuestionOrder,
+				sensei_edit_quiz_grade_type: newQuizGradeType,
 
 				// post ids to apply the changes to
 				post_ids: postIds,

--- a/assets/js/admin/lesson-quick-edit.js
+++ b/assets/js/admin/lesson-quick-edit.js
@@ -21,7 +21,7 @@
 			var senseiFieldValues = window[ 'sensei_quick_edit_' + postId ];
 
 			//load the relod function on the save button click
-			editRow.find( 'a.save' ).on( 'click', function () {
+			editRow.find( '.save' ).on( 'click', function () {
 				location.reload();
 			} );
 
@@ -71,6 +71,37 @@
 					'"] ',
 				editRow
 			).attr( 'selected', true );
+
+			if ( 'auto' === senseiFieldValues.quiz_grade_type ) {
+				senseiFieldValues.quiz_grade_type = 1;
+			} else {
+				senseiFieldValues.quiz_grade_type = 0;
+			}
+			$(
+				':input[name="quiz_grade_type"] option[value="' +
+					senseiFieldValues.quiz_grade_type +
+					'"] ',
+				editRow
+			).attr( 'selected', true );
+
+			if (
+				'yes' == senseiFieldValues.random_question_order ||
+				'1' == senseiFieldValues.random_question_order
+			) {
+				senseiFieldValues.random_question_order = 1;
+			} else {
+				senseiFieldValues.random_question_order = 0;
+			}
+			$(
+				':input[name="random_question_order"] option[value="' +
+					senseiFieldValues.random_question_order +
+					'"] ',
+				editRow
+			).attr( 'selected', true );
+
+			$( ':input[name="show_questions"]', editRow ).val(
+				senseiFieldValues.show_questions
+			);
 		}
 	};
 } )( jQuery );

--- a/assets/js/admin/lesson-quick-edit.js
+++ b/assets/js/admin/lesson-quick-edit.js
@@ -22,46 +22,19 @@
 
 			//on the save button click, set senseiFieldValues to the values user entered in the form fields
 			editRow.find( '.save' ).on( 'click', function () {
-				senseiFieldValues.lesson_course = $(
-					'#sensei-edit-lesson-course'
-				).val();
-				senseiFieldValues.lesson_complexity = $(
-					'#sensei-edit-lesson-complexity'
-				).val();
-				senseiFieldValues.pass_required = $(
-					'#sensei-edit-lesson-pass-required'
-				).val();
-				senseiFieldValues.quiz_passmark = $(
-					'#sensei-edit-quiz-pass-percentage'
-				).val();
-				senseiFieldValues.enable_quiz_reset = $(
-					'#sensei-edit-enable-quiz-reset'
-				).val();
-				senseiFieldValues.show_questions = $(
-					'#sensei-edit-show-questions'
-				).val();
-				senseiFieldValues.random_question_order = $(
-					'#sensei-edit-random-question-order'
-				).val();
-				senseiFieldValues.quiz_grade_type = $(
-					'#sensei-edit-quiz-grade-type'
-				).val();
+				const $inputs = $( '.sensei-quiz-settings :input', editRow );
+
+				$inputs.each( function () {
+					const inputName = $( this ).attr( 'name' );
+					const inputValue = $( this ).val();
+
+					senseiFieldValues[ inputName ] = inputValue;
+				} );
 			} );
 
 			// populate the data
 			//data is localized in sensei_quick_edit object
-			$(
-				':input[name="lesson_course"] option[value="' +
-					senseiFieldValues.lesson_course +
-					'"] ',
-				editRow
-			).attr( 'selected', true );
-			$(
-				':input[name="lesson_complexity"] option[value="' +
-					senseiFieldValues.lesson_complexity +
-					'"] ',
-				editRow
-			).attr( 'selected', true );
+
 			if (
 				'on' == senseiFieldValues.pass_required ||
 				'1' == senseiFieldValues.pass_required
@@ -70,15 +43,6 @@
 			} else {
 				senseiFieldValues.pass_required = 0;
 			}
-			$(
-				':input[name="pass_required"] option[value="' +
-					senseiFieldValues.pass_required +
-					'"] ',
-				editRow
-			).attr( 'selected', true );
-			$( ':input[name="quiz_passmark"]', editRow ).val(
-				senseiFieldValues.quiz_passmark
-			);
 
 			if (
 				'on' == senseiFieldValues.enable_quiz_reset ||
@@ -88,12 +52,6 @@
 			} else {
 				senseiFieldValues.enable_quiz_reset = 0;
 			}
-			$(
-				':input[name="enable_quiz_reset"] option[value="' +
-					senseiFieldValues.enable_quiz_reset +
-					'"] ',
-				editRow
-			).attr( 'selected', true );
 
 			if (
 				'auto' === senseiFieldValues.quiz_grade_type ||
@@ -103,12 +61,6 @@
 			} else {
 				senseiFieldValues.quiz_grade_type = 0;
 			}
-			$(
-				':input[name="quiz_grade_type"] option[value="' +
-					senseiFieldValues.quiz_grade_type +
-					'"] ',
-				editRow
-			).attr( 'selected', true );
 
 			if (
 				'yes' == senseiFieldValues.random_question_order ||
@@ -118,16 +70,24 @@
 			} else {
 				senseiFieldValues.random_question_order = 0;
 			}
-			$(
-				':input[name="random_question_order"] option[value="' +
-					senseiFieldValues.random_question_order +
-					'"] ',
-				editRow
-			).attr( 'selected', true );
 
-			$( ':input[name="show_questions"]', editRow ).val(
-				senseiFieldValues.show_questions
-			);
+			for ( const [ key, value ] of Object.entries(
+				senseiFieldValues
+			) ) {
+				var elem = $( ':input[name="' + key + '"]', editRow );
+				if ( elem.prop( 'nodeName' ) == 'INPUT' ) {
+					elem.val( parseInt( value ) );
+				} else {
+					$(
+						':input[name="' +
+							key +
+							'"] option[value="' +
+							value +
+							'"] ',
+						editRow
+					).attr( 'selected', true );
+				}
+			}
 		}
 	};
 } )( jQuery );

--- a/assets/js/admin/lesson-quick-edit.js
+++ b/assets/js/admin/lesson-quick-edit.js
@@ -22,7 +22,7 @@
 
 			//load the relod function on the save button click
 			editRow.find( '.save' ).on( 'click', function () {
-				location.reload();
+				setTimeout( () => location.reload(), 2000 );
 			} );
 
 			// populate the data

--- a/assets/js/admin/lesson-quick-edit.js
+++ b/assets/js/admin/lesson-quick-edit.js
@@ -20,9 +20,32 @@
 			var editRow = $( '#edit-' + postId );
 			var senseiFieldValues = window[ 'sensei_quick_edit_' + postId ];
 
-			//load the relod function on the save button click
+			//on the save button click, set senseiFieldValues to the values user entered in the form fields
 			editRow.find( '.save' ).on( 'click', function () {
-				setTimeout( () => location.reload(), 2000 );
+				senseiFieldValues.lesson_course = $(
+					'#sensei-edit-lesson-course'
+				).val();
+				senseiFieldValues.lesson_complexity = $(
+					'#sensei-edit-lesson-complexity'
+				).val();
+				senseiFieldValues.pass_required = $(
+					'#sensei-edit-lesson-pass-required'
+				).val();
+				senseiFieldValues.quiz_passmark = $(
+					'#sensei-edit-quiz-pass-percentage'
+				).val();
+				senseiFieldValues.enable_quiz_reset = $(
+					'#sensei-edit-enable-quiz-reset'
+				).val();
+				senseiFieldValues.show_questions = $(
+					'#sensei-edit-show-questions'
+				).val();
+				senseiFieldValues.random_question_order = $(
+					'#sensei-edit-random-question-order'
+				).val();
+				senseiFieldValues.quiz_grade_type = $(
+					'#sensei-edit-quiz-grade-type'
+				).val();
 			} );
 
 			// populate the data
@@ -72,7 +95,10 @@
 				editRow
 			).attr( 'selected', true );
 
-			if ( 'auto' === senseiFieldValues.quiz_grade_type ) {
+			if (
+				'auto' === senseiFieldValues.quiz_grade_type ||
+				'1' === senseiFieldValues.quiz_grade_type
+			) {
 				senseiFieldValues.quiz_grade_type = 1;
 			} else {
 				senseiFieldValues.quiz_grade_type = 0;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -5126,7 +5126,7 @@ class Sensei_Lesson {
 	 * Saves the quiz post meta settings
 	 *
 	 * @param int|null $lesson_id
-	 * @param string $new_settings
+	 * @param string   $new_settings
 	 */
 	private function save_quiz_settings( $lesson_id, array $new_settings ) {
 
@@ -5135,7 +5135,7 @@ class Sensei_Lesson {
 		if ( isset( $quiz_id ) && 0 < intval( $quiz_id ) ) {
 
 			// update pass required.
-			if ( - 1 != $new_settings['pass_required'] ) {
+			if ( - 1 !== $new_settings['pass_required'] ) {
 
 				$checked = $new_settings['pass_required'] ? 'on' : 'off';
 				update_post_meta( $quiz_id, '_pass_required', $checked );
@@ -5150,7 +5150,7 @@ class Sensei_Lesson {
 			}
 
 			// update enable quiz reset.
-			if ( - 1 != $new_settings['enable_quiz_reset'] ) {
+			if ( - 1 !== $new_settings['enable_quiz_reset'] ) {
 
 				$checked = $new_settings['enable_quiz_reset'] ? 'on' : '';
 				update_post_meta( $quiz_id, '_enable_quiz_reset', $checked );
@@ -5159,7 +5159,7 @@ class Sensei_Lesson {
 			}
 
 			// update random question order.
-			if ( - 1 != $new_settings['random_question_order'] ) {
+			if ( - 1 !== $new_settings['random_question_order'] ) {
 
 				$checked = $new_settings['random_question_order'] ? 'yes' : 'no';
 				update_post_meta( $quiz_id, '_random_question_order', $checked );
@@ -5167,7 +5167,7 @@ class Sensei_Lesson {
 			}
 
 			// update quiz grade type.
-			if ( - 1 != $new_settings['quiz_grade_type'] ) {
+			if ( - 1 !== $new_settings['quiz_grade_type'] ) {
 
 				$checked = $new_settings['quiz_grade_type'] ? 'auto' : 'manual';
 				update_post_meta( $quiz_id, '_quiz_grade_type', $checked );

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4130,8 +4130,7 @@ class Sensei_Lesson {
 	function save_all_lessons_edit_fields() {
 
 		// verify all the data before attempting to save
-		if ( ! isset( $_POST['security'] ) || ! check_ajax_referer( 'bulk-edit-lessons', 'security' )
-			 || empty( $_POST['post_ids'] ) || ! is_array( $_POST['post_ids'] ) ) {
+		if ( ! isset( $_POST['security'] ) || ! check_ajax_referer( 'bulk-edit-lessons', 'security' ) || empty( $_POST['post_ids'] ) || ! is_array( $_POST['post_ids'] ) ) {
 			die();
 		}
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4141,11 +4141,10 @@ class Sensei_Lesson {
 		$new_pass_required     = sanitize_text_field( $_POST['sensei_edit_pass_required'] );
 		$new_pass_percentage   = sanitize_text_field( $_POST['sensei_edit_pass_percentage'] );
 		$new_enable_quiz_reset = sanitize_text_field( $_POST['sensei_edit_enable_quiz_reset'] );
-		// add the 3 other quiz settings
 		$show_questions        = sanitize_text_field( $_POST['sensei_edit_show_questions'] );
 		$random_question_order = sanitize_text_field( $_POST['sensei_edit_random_question_order'] );
 		$quiz_grade_type       = sanitize_text_field( $_POST['sensei_edit_quiz_grade_type'] );
-		// store the values for all selected posts
+		// store the values for all selected posts.
 		foreach ( $_POST['post_ids'] as $lesson_id ) {
 
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -671,13 +671,13 @@ class Sensei_Lesson {
 			}
 		}
 
-		$new_pass_required     = sanitize_text_field( $_POST['pass_required'] );
-		$new_pass_percentage   = sanitize_text_field( $_POST['quiz_passmark'] );
-		$new_enable_quiz_reset = sanitize_text_field( $_POST['enable_quiz_reset'] );
+		$new_pass_required     = isset( $_POST['pass_required'] ) ? sanitize_text_field( $_POST['pass_required'] ) : '-1';
+		$new_pass_percentage   = isset( $_POST['quiz_passmark'] ) ? sanitize_text_field( $_POST['quiz_passmark'] ) : '-1';
+		$new_enable_quiz_reset = isset( $_POST['enable_quiz_reset'] ) ? sanitize_text_field( $_POST['enable_quiz_reset'] ) : '-1';
 		// add 3 other quiz settings
-		$show_questions        = sanitize_text_field( $_POST['show_questions'] );
-		$random_question_order = sanitize_text_field( $_POST['random_question_order'] );
-		$quiz_grade_type       = sanitize_text_field( $_POST['quiz_grade_type'] );
+		$show_questions        = isset( $_POST['show_questions'] ) ? sanitize_text_field( $_POST['show_questions'] ) : '-1';
+		$random_question_order = isset( $_POST['random_question_order'] ) ? sanitize_text_field( $_POST['random_question_order'] ) : '-1';
+		$quiz_grade_type       = isset( $_POST['quiz_grade_type'] ) ? sanitize_text_field( $_POST['quiz_grade_type'] ) : '-1';
 
 		$this->save_quiz_settings( $post_id, $new_pass_required, $new_pass_percentage, $new_enable_quiz_reset, $random_question_order, $quiz_grade_type, $show_questions );
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4146,15 +4146,14 @@ class Sensei_Lesson {
 		// store the values for all selected posts.
 		foreach ( $_POST['post_ids'] as $lesson_id ) {
 
-
 			// do not save the items if the value is -1 as this
 			// means it was not changed
 			// update lesson course
-			if ( - 1 != $new_course ) {
+			if ( - 1 !== $new_course ) {
 				update_post_meta( $lesson_id, '_lesson_course', $new_course );
 			}
 			// update lesson complexity
-			if ( -1 != $new_complexity ) {
+			if ( -1 !== $new_complexity ) {
 				update_post_meta( $lesson_id, '_lesson_complexity', $new_complexity );
 			}
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -636,7 +636,7 @@ class Sensei_Lesson {
 	public function meta_box_save( $post_id ) {
 
 		// Verify the nonce before proceeding.
-		if ( ( get_post_type( $post_id ) != $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( $_POST[ 'woo_' . $this->token . '_nonce' ], 'sensei-save-post-meta' ) ) {
+		if ( ( get_post_type( $post_id ) !== $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( $_POST[ 'woo_' . $this->token . '_nonce' ], 'sensei-save-post-meta' ) ) {
 			return $post_id;
 		}
 		// Get the post type object.
@@ -671,13 +671,12 @@ class Sensei_Lesson {
 			}
 		}
 
-		$new_pass_required     = isset( $_POST['pass_required'] ) ? sanitize_text_field( $_POST['pass_required'] ) : '-1';
-		$new_pass_percentage   = isset( $_POST['quiz_passmark'] ) ? sanitize_text_field( $_POST['quiz_passmark'] ) : '-1';
-		$new_enable_quiz_reset = isset( $_POST['enable_quiz_reset'] ) ? sanitize_text_field( $_POST['enable_quiz_reset'] ) : '-1';
-		// add 3 other quiz settings
-		$show_questions        = isset( $_POST['show_questions'] ) ? sanitize_text_field( $_POST['show_questions'] ) : '-1';
-		$random_question_order = isset( $_POST['random_question_order'] ) ? sanitize_text_field( $_POST['random_question_order'] ) : '-1';
-		$quiz_grade_type       = isset( $_POST['quiz_grade_type'] ) ? sanitize_text_field( $_POST['quiz_grade_type'] ) : '-1';
+		$new_pass_required     = isset( $_POST['pass_required'] ) ? sanitize_text_field( wp_unslash( $_POST['pass_required'] ) ) : '-1';
+		$new_pass_percentage   = isset( $_POST['quiz_passmark'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_passmark'] ) ) : '-1';
+		$new_enable_quiz_reset = isset( $_POST['enable_quiz_reset'] ) ? sanitize_text_field( wp_unslash( $_POST['enable_quiz_reset'] ) ) : '-1';
+		$show_questions        = isset( $_POST['show_questions'] ) ? sanitize_text_field( wp_unslash( $_POST['show_questions'] ) ) : '-1';
+		$random_question_order = isset( $_POST['random_question_order'] ) ? sanitize_text_field( wp_unslash( $_POST['random_question_order'] ) ) : '-1';
+		$quiz_grade_type       = isset( $_POST['quiz_grade_type'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_grade_type'] ) ) : '-1';
 
 		$this->save_quiz_settings( $post_id, $new_pass_required, $new_pass_percentage, $new_enable_quiz_reset, $random_question_order, $quiz_grade_type, $show_questions );
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -674,10 +674,14 @@ class Sensei_Lesson {
 		$new_pass_required     = sanitize_text_field( $_POST['pass_required'] );
 		$new_pass_percentage   = sanitize_text_field( $_POST['quiz_passmark'] );
 		$new_enable_quiz_reset = sanitize_text_field( $_POST['enable_quiz_reset'] );
+		// add 3 other quiz settings
+		$show_questions        = sanitize_text_field( $_POST['show_questions'] );
+		$random_question_order = sanitize_text_field( $_POST['random_question_order'] );
+		$quiz_grade_type       = sanitize_text_field( $_POST['quiz_grade_type'] );
 
-		$this->save_quiz_settings( $post_id, $new_pass_required, $new_pass_percentage, $new_enable_quiz_reset );
+		$this->save_quiz_settings( $post_id, $new_pass_required, $new_pass_percentage, $new_enable_quiz_reset, $random_question_order, $quiz_grade_type, $show_questions );
 
-		return  $post_id;
+		return $post_id;
 
 	}
 
@@ -3961,57 +3965,103 @@ class Sensei_Lesson {
 
 					?>
 
-					<h4><?php esc_html_e( 'Quiz Settings', 'sensei-lms' ); ?> </h4>
+				<h4><?php esc_html_e( 'Quiz Settings', 'sensei-lms' ); ?> </h4>
 
-					<?php
+				<?php
 
-					//
-					// Lesson require pass to complete
-					//
-					$pass_required_options = array(
-						'-1' => $no_change_text,
-						'0'  => esc_html__( 'No', 'sensei-lms' ),
-						'1'  => esc_html__( 'Yes', 'sensei-lms' ),
-					);
+				//
+				// Lesson require pass to complete
+				//
+				$pass_required_options = array(
+					'-1' => $no_change_text,
+					'0'  => esc_html__( 'No', 'sensei-lms' ),
+					'1'  => esc_html__( 'Yes', 'sensei-lms' ),
+				);
 
-					$pass_required_select_attributes = array(
-						'name'  => 'pass_required',
-						'id'    => 'sensei-edit-lesson-pass-required',
-						'class' => ' ',
-					);
-					$require_pass_field              = Sensei_Utils::generate_drop_down( '-1', $pass_required_options, $pass_required_select_attributes, false );
+				$pass_required_select_attributes = array(
+					'name'  => 'pass_required',
+					'id'    => 'sensei-edit-lesson-pass-required',
+					'class' => ' ',
+				);
+				$require_pass_field              = Sensei_Utils::generate_drop_down( '-1', $pass_required_options, $pass_required_select_attributes, false );
 
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in called method.
-					echo $this->generate_all_lessons_edit_field( esc_html__( 'Pass required', 'sensei-lms' ), $require_pass_field );
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in called method.
+				echo $this->generate_all_lessons_edit_field( esc_html__( 'Pass required', 'sensei-lms' ), $require_pass_field );
 
-					//
-					// Quiz pass percentage
-					//
-					$quiz_pass_percentage_field = '<input name="quiz_passmark" id="sensei-edit-quiz-pass-percentage" type="number" />';
+				//
+				// Quiz pass percentage
+				//
+				$quiz_pass_percentage_field = '<input name="quiz_passmark" id="sensei-edit-quiz-pass-percentage" type="number" />';
 
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in called method.
-					echo $this->generate_all_lessons_edit_field( esc_html__( 'Pass Percentage', 'sensei-lms' ), $quiz_pass_percentage_field );
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in called method.
+				echo $this->generate_all_lessons_edit_field( esc_html__( 'Pass Percentage', 'sensei-lms' ), $quiz_pass_percentage_field );
 
-					//
-					// Enable quiz reset button
-					//
-					$quiz_reset_select__options   = array(
-						'-1' => $no_change_text,
-						'0'  => esc_html__( 'No', 'sensei-lms' ),
-						'1'  => esc_html__( 'Yes', 'sensei-lms' ),
-					);
-					$quiz_reset_name_id           = 'sensei-edit-enable-quiz-reset';
-					$quiz_reset_select_attributes = array(
-						'name'  => 'enable_quiz_reset',
-						'id'    => $quiz_reset_name_id,
-						'class' => ' ',
-					);
-					$quiz_reset_field             = Sensei_Utils::generate_drop_down( '-1', $quiz_reset_select__options, $quiz_reset_select_attributes, false );
+				//
+				// Enable quiz reset button
+				//
+				$quiz_reset_select__options   = array(
+					'-1' => $no_change_text,
+					'0'  => esc_html__( 'No', 'sensei-lms' ),
+					'1'  => esc_html__( 'Yes', 'sensei-lms' ),
+				);
+				$quiz_reset_name_id           = 'sensei-edit-enable-quiz-reset';
+				$quiz_reset_select_attributes = array(
+					'name'  => 'enable_quiz_reset',
+					'id'    => $quiz_reset_name_id,
+					'class' => ' ',
+				);
+				$quiz_reset_field             = Sensei_Utils::generate_drop_down( '-1', $quiz_reset_select__options, $quiz_reset_select_attributes, false );
 
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in called method.
-					echo $this->generate_all_lessons_edit_field( esc_html__( 'Enable quiz reset button', 'sensei-lms' ), $quiz_reset_field );
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in called method.
+				echo $this->generate_all_lessons_edit_field( esc_html__( 'Enable quiz reset button', 'sensei-lms' ), $quiz_reset_field );
 
-					?>
+				//
+				// Number of questions to show
+				//
+				$show_questions_field = '<input name="show_questions" id="sensei-edit-show-questions" type="number" />';
+
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in called method.
+				echo $this->generate_all_lessons_edit_field( esc_html__( 'Number of questions to show', 'sensei-lms' ), $show_questions_field );
+
+				//
+				// Randomise question order
+				//
+				$random_question_order_options = array(
+					'-1' => $no_change_text,
+					'0'  => esc_html__( 'No', 'sensei-lms' ),
+					'1'  => esc_html__( 'Yes', 'sensei-lms' ),
+				);
+
+				$random_question_order_select_attributes = array(
+					'name'  => 'random_question_order',
+					'id'    => 'sensei-edit-random-question-order',
+					'class' => ' ',
+				);
+				$random_question_order_field             = Sensei_Utils::generate_drop_down( '-1', $random_question_order_options, $random_question_order_select_attributes, false );
+
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in called method.
+				echo $this->generate_all_lessons_edit_field( esc_html__( 'Randomise question order', 'sensei-lms' ), $random_question_order_field );
+
+				//
+				// Grade quiz automatically
+				//
+				$grade_quiz_automatically_options = array(
+					'-1' => $no_change_text,
+					'0'  => esc_html__( 'No', 'sensei-lms' ),
+					'1'  => esc_html__( 'Yes', 'sensei-lms' ),
+				);
+
+				$grade_quiz_automatically_select_attributes = array(
+					'name'  => 'quiz_grade_type',
+					'id'    => 'sensei-edit-quiz-grade-type',
+					'class' => ' ',
+				);
+				$grade_quiz_automatically_field             = Sensei_Utils::generate_drop_down( '-1', $grade_quiz_automatically_options, $grade_quiz_automatically_select_attributes, false );
+
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in called method.
+				echo $this->generate_all_lessons_edit_field( esc_html__( 'Grade quiz automatically', 'sensei-lms' ), $grade_quiz_automatically_field );
+
+				?>
 			</div>
 		</fieldset>
 		<?php
@@ -4030,12 +4080,13 @@ class Sensei_Lesson {
 	 */
 	public function generate_all_lessons_edit_field( $title, $field ) {
 
-		$html  = '';
-		$html  = '<div class="inline-edit-group" >';
+		$html = '';
+		$html = '<div class="inline-edit-group" >';
 		$html .= '<span class="title">' . esc_html( $title ) . '</span> ';
 		$html .= '<span class="input-text-wrap">';
 		$html .= $field;
 		$html .= '</span>';
+
 		$html .= '</div>';
 
 		return wp_kses(
@@ -4072,7 +4123,7 @@ class Sensei_Lesson {
 
 		// verify all the data before attempting to save
 		if ( ! isset( $_POST['security'] ) || ! check_ajax_referer( 'bulk-edit-lessons', 'security' )
-			|| empty( $_POST['post_ids'] ) || ! is_array( $_POST['post_ids'] ) ) {
+			 || empty( $_POST['post_ids'] ) || ! is_array( $_POST['post_ids'] ) ) {
 			die();
 		}
 
@@ -4082,6 +4133,10 @@ class Sensei_Lesson {
 		$new_pass_required     = sanitize_text_field( $_POST['sensei_edit_pass_required'] );
 		$new_pass_percentage   = sanitize_text_field( $_POST['sensei_edit_pass_percentage'] );
 		$new_enable_quiz_reset = sanitize_text_field( $_POST['sensei_edit_enable_quiz_reset'] );
+		// add the 3 other quiz settings
+		$show_questions        = sanitize_text_field( $_POST['sensei_edit_show_questions'] );
+		$random_question_order = sanitize_text_field( $_POST['sensei_edit_random_question_order'] );
+		$quiz_grade_type       = sanitize_text_field( $_POST['sensei_edit_quiz_grade_type'] );
 		// store the values for all selected posts
 		foreach ( $_POST['post_ids'] as $lesson_id ) {
 
@@ -4089,7 +4144,7 @@ class Sensei_Lesson {
 			// do not save the items if the value is -1 as this
 			// means it was not changed
 			// update lesson course
-			if ( -1 != $new_course ) {
+			if ( - 1 != $new_course ) {
 				update_post_meta( $lesson_id, '_lesson_course', $new_course );
 			}
 			// update lesson complexity
@@ -4097,7 +4152,7 @@ class Sensei_Lesson {
 				update_post_meta( $lesson_id, '_lesson_complexity', $new_complexity );
 			}
 
-			$this->save_quiz_settings( $lesson_id, $new_pass_required, $new_pass_percentage, $new_enable_quiz_reset );
+			$this->save_quiz_settings( $lesson_id, $new_pass_required, $new_pass_percentage, $new_enable_quiz_reset, $random_question_order, $quiz_grade_type, $show_questions );
 
 		}
 
@@ -5058,7 +5113,7 @@ class Sensei_Lesson {
 	 * @param          $new_pass_percentage
 	 * @param string   $new_enable_quiz_reset
 	 */
-	private function save_quiz_settings( ?int $lesson_id, string $new_pass_required, $new_pass_percentage, string $new_enable_quiz_reset ): void {
+	private function save_quiz_settings( ?int $lesson_id, string $new_pass_required, $new_pass_percentage, string $new_enable_quiz_reset, string $random_question_order, string $quiz_grade_type, $show_questions ): void {
 
 		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
 
@@ -5066,7 +5121,7 @@ class Sensei_Lesson {
 		if ( isset( $quiz_id ) && 0 < intval( $quiz_id ) ) {
 
 			// update pass required
-			if ( -1 != $new_pass_required ) {
+			if ( - 1 != $new_pass_required ) {
 
 				$checked = $new_pass_required ? 'on' : 'off';
 				update_post_meta( $quiz_id, '_pass_required', $checked );
@@ -5083,11 +5138,34 @@ class Sensei_Lesson {
 			//
 			// update enable quiz reset
 			//
-			if ( -1 != $new_enable_quiz_reset ) {
+			if ( - 1 != $new_enable_quiz_reset ) {
 
 				$checked = $new_enable_quiz_reset ? 'on' : '';
 				update_post_meta( $quiz_id, '_enable_quiz_reset', $checked );
 				unset( $checked );
+
+			}
+
+			// update random question order
+			if ( - 1 != $random_question_order ) {
+
+				$checked = $random_question_order ? 'yes' : 'no';
+				update_post_meta( $quiz_id, '_random_question_order', $checked );
+				unset( $checked );
+			}
+
+			// update quiz grade type
+			if ( - 1 != $quiz_grade_type ) {
+
+				$checked = $quiz_grade_type ? 'auto' : 'manual';
+				update_post_meta( $quiz_id, '_quiz_grade_type', $checked );
+				unset( $checked );
+			}
+
+			// update number of questions to show
+			if ( ! empty( $show_questions ) && is_numeric( $show_questions ) ) {
+
+				update_post_meta( $quiz_id, '_show_questions', $show_questions );
 
 			}
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4014,17 +4014,17 @@ class Sensei_Lesson {
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in called method.
 				echo $this->generate_all_lessons_edit_field( esc_html__( 'Enable quiz reset button', 'sensei-lms' ), $quiz_reset_field );
 
-				//
-				// Number of questions to show
-				//
+				/*
+				/* Number of questions to show
+				*/
 				$show_questions_field = '<input name="show_questions" id="sensei-edit-show-questions" type="number" />';
 
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in called method.
 				echo $this->generate_all_lessons_edit_field( esc_html__( 'Number of questions to show', 'sensei-lms' ), $show_questions_field );
 
-				//
-				// Randomise question order
-				//
+				/*
+				/* Randomise question order
+				*/
 				$random_question_order_options = array(
 					'-1' => $no_change_text,
 					'0'  => esc_html__( 'No', 'sensei-lms' ),
@@ -4041,9 +4041,9 @@ class Sensei_Lesson {
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in called method.
 				echo $this->generate_all_lessons_edit_field( esc_html__( 'Randomise question order', 'sensei-lms' ), $random_question_order_field );
 
-				//
-				// Grade quiz automatically
-				//
+				/*
+				/* Grade quiz automatically
+				*/
 				$grade_quiz_automatically_options = array(
 					'-1' => $no_change_text,
 					'0'  => esc_html__( 'No', 'sensei-lms' ),

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -678,7 +678,16 @@ class Sensei_Lesson {
 		$random_question_order = isset( $_POST['random_question_order'] ) ? sanitize_text_field( wp_unslash( $_POST['random_question_order'] ) ) : '-1';
 		$quiz_grade_type       = isset( $_POST['quiz_grade_type'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_grade_type'] ) ) : '-1';
 
-		$this->save_quiz_settings( $post_id, $new_pass_required, $new_pass_percentage, $new_enable_quiz_reset, $random_question_order, $quiz_grade_type, $show_questions );
+		$new_settings = array(
+			'pass_required'         => $new_pass_required,
+			'pass_percentage'       => $new_pass_percentage,
+			'enable_quiz_reset'     => $new_enable_quiz_reset,
+			'show_questions'        => $show_questions,
+			'random_question_order' => $random_question_order,
+			'quiz_grade_type'       => $quiz_grade_type,
+		);
+
+		$this->save_quiz_settings( $post_id, $new_settings );
 
 		return $post_id;
 
@@ -4151,7 +4160,16 @@ class Sensei_Lesson {
 				update_post_meta( $lesson_id, '_lesson_complexity', $new_complexity );
 			}
 
-			$this->save_quiz_settings( $lesson_id, $new_pass_required, $new_pass_percentage, $new_enable_quiz_reset, $random_question_order, $quiz_grade_type, $show_questions );
+			$new_settings = array(
+				'pass_required'         => $new_pass_required,
+				'pass_percentage'       => $new_pass_percentage,
+				'enable_quiz_reset'     => $new_enable_quiz_reset,
+				'show_questions'        => $show_questions,
+				'random_question_order' => $random_question_order,
+				'quiz_grade_type'       => $quiz_grade_type,
+			);
+
+			$this->save_quiz_settings( $lesson_id, $new_settings );
 
 		}
 
@@ -5111,63 +5129,58 @@ class Sensei_Lesson {
 	 * Saves the quiz post meta settings
 	 *
 	 * @param int|null $lesson_id
-	 * @param string $new_pass_required
-	 * @param int $new_pass_percentage
-	 * @param string $new_enable_quiz_reset
-	 * @param string $random_question_order
-	 * @param string $quiz_grade_type
-	 * @param int $show_questions
+	 * @param string $new_settings
 	 */
-	private function save_quiz_settings( ?int $lesson_id, string $new_pass_required, int $new_pass_percentage, string $new_enable_quiz_reset, string $random_question_order, string $quiz_grade_type, int $show_questions ): void {
+	private function save_quiz_settings( ?int $lesson_id, array $new_settings ): void {
 
 		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
 
 		if ( isset( $quiz_id ) && 0 < intval( $quiz_id ) ) {
 
 			// update pass required.
-			if ( - 1 != $new_pass_required ) {
+			if ( - 1 != $new_settings['pass_required'] ) {
 
-				$checked = $new_pass_required ? 'on' : 'off';
+				$checked = $new_settings['pass_required'] ? 'on' : 'off';
 				update_post_meta( $quiz_id, '_pass_required', $checked );
 				unset( $checked );
 			}
 
 			// update pass percentage.
-			if ( ! empty( $new_pass_percentage ) && is_numeric( $new_pass_percentage ) ) {
+			if ( ! empty( $new_settings['pass_percentage'] ) && is_numeric( $new_settings['pass_percentage'] ) ) {
 
-				update_post_meta( $quiz_id, '_quiz_passmark', $new_pass_percentage );
+				update_post_meta( $quiz_id, '_quiz_passmark', $new_settings['pass_percentage'] );
 
 			}
 
 			// update enable quiz reset.
-			if ( - 1 != $new_enable_quiz_reset ) {
+			if ( - 1 != $new_settings['enable_quiz_reset'] ) {
 
-				$checked = $new_enable_quiz_reset ? 'on' : '';
+				$checked = $new_settings['enable_quiz_reset'] ? 'on' : '';
 				update_post_meta( $quiz_id, '_enable_quiz_reset', $checked );
 				unset( $checked );
 
 			}
 
 			// update random question order.
-			if ( - 1 != $random_question_order ) {
+			if ( - 1 != $new_settings['random_question_order'] ) {
 
-				$checked = $random_question_order ? 'yes' : 'no';
+				$checked = $new_settings['random_question_order'] ? 'yes' : 'no';
 				update_post_meta( $quiz_id, '_random_question_order', $checked );
 				unset( $checked );
 			}
 
 			// update quiz grade type.
-			if ( - 1 != $quiz_grade_type ) {
+			if ( - 1 != $new_settings['quiz_grade_type'] ) {
 
-				$checked = $quiz_grade_type ? 'auto' : 'manual';
+				$checked = $new_settings['quiz_grade_type'] ? 'auto' : 'manual';
 				update_post_meta( $quiz_id, '_quiz_grade_type', $checked );
 				unset( $checked );
 			}
 
 			// update number of questions to show.
-			if ( ! empty( $show_questions ) ) {
+			if ( ! empty( $new_settings['show_questions'] ) ) {
 
-				update_post_meta( $quiz_id, '_show_questions', $show_questions );
+				update_post_meta( $quiz_id, '_show_questions', $new_settings['show_questions'] );
 
 			}
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -5125,8 +5125,8 @@ class Sensei_Lesson {
 	 *
 	 * Saves the quiz post meta settings
 	 *
-	 * @param int|null $lesson_id
-	 * @param array    $new_settings
+	 * @param int|null $lesson_id ID if the lesson.
+	 * @param array    $new_settings New settings to be saved.
 	 */
 	private function save_quiz_settings( $lesson_id, array $new_settings ) {
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4135,14 +4135,14 @@ class Sensei_Lesson {
 		}
 
 		// get our variables
-		$new_course            = sanitize_text_field( $_POST['sensei_edit_lesson_course'] );
-		$new_complexity        = sanitize_text_field( $_POST['sensei_edit_complexity'] );
-		$new_pass_required     = sanitize_text_field( $_POST['sensei_edit_pass_required'] );
-		$new_pass_percentage   = sanitize_text_field( $_POST['sensei_edit_pass_percentage'] );
-		$new_enable_quiz_reset = sanitize_text_field( $_POST['sensei_edit_enable_quiz_reset'] );
-		$show_questions        = sanitize_text_field( $_POST['sensei_edit_show_questions'] );
-		$random_question_order = sanitize_text_field( $_POST['sensei_edit_random_question_order'] );
-		$quiz_grade_type       = sanitize_text_field( $_POST['sensei_edit_quiz_grade_type'] );
+		$new_course            = isset( $_POST['sensei_edit_lesson_course'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_lesson_course'] ) ) : '';
+		$new_complexity        = isset( $_POST['sensei_edit_complexity'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_complexity'] ) ) : '';
+		$new_pass_required     = isset( $_POST['sensei_edit_complexity'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_complexity'] ) ) : '';
+		$new_pass_percentage   = isset( $_POST['sensei_edit_pass_percentage'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_pass_percentage'] ) ) : '';
+		$new_enable_quiz_reset = isset( $_POST['sensei_edit_enable_quiz_reset'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_enable_quiz_reset'] ) ) : '';
+		$show_questions        = isset( $_POST['sensei_edit_show_questions'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_show_questions'] ) ) : '';
+		$random_question_order = isset( $_POST['sensei_edit_random_question_order'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_random_question_order'] ) ) : '';
+		$quiz_grade_type       = isset( $_POST['sensei_edit_quiz_grade_type'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_quiz_grade_type'] ) ) : '';
 		// store the values for all selected posts.
 		foreach ( $_POST['post_ids'] as $lesson_id ) {
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3973,7 +3973,7 @@ class Sensei_Lesson {
 
 					?>
 
-				<h4><?php esc_html_e( 'Quiz Settings', 'sensei-lms' ); ?> </h4>
+					<h4><?php esc_html_e( 'Quiz Settings', 'sensei-lms' ); ?> </h4>
 
 				<?php
 
@@ -4089,7 +4089,7 @@ class Sensei_Lesson {
 	public function generate_all_lessons_edit_field( $title, $field ) {
 
 		$html  = '';
-		$html  = '<div class="inline-edit-group quiz-settings" >';
+		$html  = '<div class="inline-edit-group sensei-quiz-settings" >';
 		$html .= '<span class="title">' . esc_html( $title ) . '</span> ';
 		$html .= '<span class="input-text-wrap">';
 		$html .= $field;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -5126,7 +5126,7 @@ class Sensei_Lesson {
 	 * Saves the quiz post meta settings
 	 *
 	 * @param int|null $lesson_id
-	 * @param string   $new_settings
+	 * @param array    $new_settings
 	 */
 	private function save_quiz_settings( $lesson_id, array $new_settings ) {
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4079,8 +4079,8 @@ class Sensei_Lesson {
 	 */
 	public function generate_all_lessons_edit_field( $title, $field ) {
 
-		$html = '';
-		$html = '<div class="inline-edit-group" >';
+		$html  = '';
+		$html  = '<div class="inline-edit-group quiz-settings" >';
 		$html .= '<span class="title">' . esc_html( $title ) . '</span> ';
 		$html .= '<span class="input-text-wrap">';
 		$html .= $field;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4137,7 +4137,7 @@ class Sensei_Lesson {
 		// get our variables
 		$new_course            = isset( $_POST['sensei_edit_lesson_course'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_lesson_course'] ) ) : '';
 		$new_complexity        = isset( $_POST['sensei_edit_complexity'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_complexity'] ) ) : '';
-		$new_pass_required     = isset( $_POST['sensei_edit_complexity'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_complexity'] ) ) : '';
+		$new_pass_required     = isset( $_POST['sensei_edit_pass_required'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_pass_required'] ) ) : '';
 		$new_pass_percentage   = isset( $_POST['sensei_edit_pass_percentage'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_pass_percentage'] ) ) : '';
 		$new_enable_quiz_reset = isset( $_POST['sensei_edit_enable_quiz_reset'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_enable_quiz_reset'] ) ) : '';
 		$show_questions        = isset( $_POST['sensei_edit_show_questions'] ) ? sanitize_text_field( wp_unslash( $_POST['sensei_edit_show_questions'] ) ) : '';

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -5107,19 +5107,24 @@ class Sensei_Lesson {
 	}
 
 	/**
+	 *
+	 * Saves the quiz post meta settings
+	 *
 	 * @param int|null $lesson_id
-	 * @param string   $new_pass_required
-	 * @param          $new_pass_percentage
-	 * @param string   $new_enable_quiz_reset
+	 * @param string $new_pass_required
+	 * @param int $new_pass_percentage
+	 * @param string $new_enable_quiz_reset
+	 * @param string $random_question_order
+	 * @param string $quiz_grade_type
+	 * @param int $show_questions
 	 */
-	private function save_quiz_settings( ?int $lesson_id, string $new_pass_required, $new_pass_percentage, string $new_enable_quiz_reset, string $random_question_order, string $quiz_grade_type, $show_questions ): void {
+	private function save_quiz_settings( ?int $lesson_id, string $new_pass_required, int $new_pass_percentage, string $new_enable_quiz_reset, string $random_question_order, string $quiz_grade_type, int $show_questions ): void {
 
 		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
 
-		// Quiz Related settings
 		if ( isset( $quiz_id ) && 0 < intval( $quiz_id ) ) {
 
-			// update pass required
+			// update pass required.
 			if ( - 1 != $new_pass_required ) {
 
 				$checked = $new_pass_required ? 'on' : 'off';
@@ -5127,16 +5132,14 @@ class Sensei_Lesson {
 				unset( $checked );
 			}
 
-			// update pass percentage
+			// update pass percentage.
 			if ( ! empty( $new_pass_percentage ) && is_numeric( $new_pass_percentage ) ) {
 
 				update_post_meta( $quiz_id, '_quiz_passmark', $new_pass_percentage );
 
 			}
 
-			//
-			// update enable quiz reset
-			//
+			// update enable quiz reset.
 			if ( - 1 != $new_enable_quiz_reset ) {
 
 				$checked = $new_enable_quiz_reset ? 'on' : '';
@@ -5145,7 +5148,7 @@ class Sensei_Lesson {
 
 			}
 
-			// update random question order
+			// update random question order.
 			if ( - 1 != $random_question_order ) {
 
 				$checked = $random_question_order ? 'yes' : 'no';
@@ -5153,7 +5156,7 @@ class Sensei_Lesson {
 				unset( $checked );
 			}
 
-			// update quiz grade type
+			// update quiz grade type.
 			if ( - 1 != $quiz_grade_type ) {
 
 				$checked = $quiz_grade_type ? 'auto' : 'manual';
@@ -5161,8 +5164,8 @@ class Sensei_Lesson {
 				unset( $checked );
 			}
 
-			// update number of questions to show
-			if ( ! empty( $show_questions ) && is_numeric( $show_questions ) ) {
+			// update number of questions to show.
+			if ( ! empty( $show_questions ) ) {
 
 				update_post_meta( $quiz_id, '_show_questions', $show_questions );
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -670,6 +670,15 @@ class Sensei_Lesson {
 
 			}
 		}
+
+		$new_pass_required     = sanitize_text_field( $_POST['pass_required'] );
+		$new_pass_percentage   = sanitize_text_field( $_POST['quiz_passmark'] );
+		$new_enable_quiz_reset = sanitize_text_field( $_POST['enable_quiz_reset'] );
+
+		$this->save_quiz_settings( $post_id, $new_pass_required, $new_pass_percentage, $new_enable_quiz_reset );
+
+		return  $post_id;
+
 	}
 
 	/**
@@ -4076,8 +4085,6 @@ class Sensei_Lesson {
 		// store the values for all selected posts
 		foreach ( $_POST['post_ids'] as $lesson_id ) {
 
-			// get the quiz id needed for the quiz meta
-			$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
 
 			// do not save the items if the value is -1 as this
 			// means it was not changed
@@ -4090,35 +4097,8 @@ class Sensei_Lesson {
 				update_post_meta( $lesson_id, '_lesson_complexity', $new_complexity );
 			}
 
-			// Quiz Related settings
-			if ( isset( $quiz_id ) && 0 < intval( $quiz_id ) ) {
+			$this->save_quiz_settings( $lesson_id, $new_pass_required, $new_pass_percentage, $new_enable_quiz_reset );
 
-				// update pass required
-				if ( -1 != $new_pass_required ) {
-
-					$checked = $new_pass_required ? 'on' : '';
-					update_post_meta( $quiz_id, '_pass_required', $checked );
-					unset( $checked );
-				}
-
-				// update pass percentage
-				if ( ! empty( $new_pass_percentage ) && is_numeric( $new_pass_percentage ) ) {
-
-						update_post_meta( $quiz_id, '_quiz_passmark', $new_pass_percentage );
-
-				}
-
-				//
-				// update enable quiz reset
-				//
-				if ( -1 != $new_enable_quiz_reset ) {
-
-					$checked = $new_enable_quiz_reset ? 'on' : '';
-					update_post_meta( $quiz_id, '_enable_quiz_reset', $checked );
-					unset( $checked );
-
-				}
-			}
 		}
 
 		die();
@@ -5070,6 +5050,47 @@ class Sensei_Lesson {
 		}
 
 		return false;
+	}
+
+	/**
+	 * @param int|null $lesson_id
+	 * @param string   $new_pass_required
+	 * @param          $new_pass_percentage
+	 * @param string   $new_enable_quiz_reset
+	 */
+	private function save_quiz_settings( ?int $lesson_id, string $new_pass_required, $new_pass_percentage, string $new_enable_quiz_reset ): void {
+
+		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+
+		// Quiz Related settings
+		if ( isset( $quiz_id ) && 0 < intval( $quiz_id ) ) {
+
+			// update pass required
+			if ( -1 != $new_pass_required ) {
+
+				$checked = $new_pass_required ? 'on' : 'off';
+				update_post_meta( $quiz_id, '_pass_required', $checked );
+				unset( $checked );
+			}
+
+			// update pass percentage
+			if ( ! empty( $new_pass_percentage ) && is_numeric( $new_pass_percentage ) ) {
+
+				update_post_meta( $quiz_id, '_quiz_passmark', $new_pass_percentage );
+
+			}
+
+			//
+			// update enable quiz reset
+			//
+			if ( -1 != $new_enable_quiz_reset ) {
+
+				$checked = $new_enable_quiz_reset ? 'on' : '';
+				update_post_meta( $quiz_id, '_enable_quiz_reset', $checked );
+				unset( $checked );
+
+			}
+		}
 	}
 }
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -5130,7 +5130,7 @@ class Sensei_Lesson {
 	 * @param int|null $lesson_id
 	 * @param string $new_settings
 	 */
-	private function save_quiz_settings( ?int $lesson_id, array $new_settings ): void {
+	private function save_quiz_settings( $lesson_id, array $new_settings ) {
 
 		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -28,7 +28,16 @@ class Sensei_Quiz {
 	public function __construct( $file = __FILE__ ) {
 		$this->file        = $file;
 		$this->token       = 'quiz';
-		$this->meta_fields = array( 'quiz_passmark', 'quiz_lesson', 'quiz_type', 'quiz_grade_type', 'pass_required', 'enable_quiz_reset' );
+		$this->meta_fields = array(
+			'quiz_passmark',
+			'quiz_lesson',
+			'quiz_type',
+			'quiz_grade_type',
+			'pass_required',
+			'enable_quiz_reset',
+			'show_questions',
+			'random_question_order',
+		);
 		add_action( 'save_post', array( $this, 'update_after_lesson_change' ) );
 
 		// Redirect if the lesson is protected.


### PR DESCRIPTION
Fixes #3382 #4117 

### Changes proposed in this Pull Request

* Add 3 post meta fields to bulk and quick edit fields in the lesson admin page: `show_questions`, `random_question_order`, `quiz_grade_type`
* Save persist these post meta fields to the database when save or update button is clicked.

### Testing instructions

* Create a lesson.
* On the Lessons page, hover over the lesson and click Quick Edit.
* Set a value for Pass required, Pass Percentage and Enable quiz reset button.
* Click Update.
* Select the lesson and view the quiz settings.
* You should see the updated settings