### PR TITLE
Re-style answer feedback frontend

### DIFF
--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -35,8 +35,32 @@
 		flex: 1;
 	}
 
+	&__points {
+		font-weight: bold;
+	}
+
 	&__content {
 		padding: 12px $horizontal-padding;
+	}
+
+	&__correct-answer {
+		.highlight {
+			background: var(--color);
+			padding: 5px;
+			border-radius: 2px;
+		}
+	}
+
+	&__correct-answer + &__answer-notes {
+		border-top: 1px solid  var(--color);
+		margin-top: 12px;
+		padding-top: 12px;
+	}
+
+	&__answer-notes {
+		.entry-content & > *:last-child {
+			margin-bottom: 0;
+		}
 	}
 
 	&__icon:after {

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -1129,3 +1129,5 @@ body.tax-module #main .lesson-content .lesson-meta {
  * Imports
  */
 @import 'grid';
+
+@import '../blocks/quiz/question-block/question';

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -795,8 +795,8 @@ class Sensei_Question {
 		$answer_grade   = Sensei()->quiz->get_user_question_grade( $lesson_id, $question_id, get_current_user_id() );
 		$answer_correct = is_int( $answer_grade ) && $answer_grade > 0;
 
-		$answer_notes_classname = "";
-		$answer_feedback_title  = "";
+		$answer_notes_classname = '';
+		$answer_feedback_title  = '';
 
 		if ( $indicate_incorrect ) {
 			if ( $answer_correct ) {

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -894,7 +894,7 @@ class Sensei_Question {
 				<div class="sensei-lms-question__answer-feedback__content">
 					<?php if ( $correct_answer ) { ?>
 						<div class="sensei-lms-question__answer-feedback__correct-answer">
-							<?php echo __( 'Right Answer:', 'sensei-lms' ); ?>
+							<?php echo wp_kses_post( __( 'Right Answer:', 'sensei-lms' ) ); ?>
 							<strong><?php echo wp_kses_post( $correct_answer ); ?></strong>
 						</div>
 					<?php } ?>
@@ -915,7 +915,7 @@ class Sensei_Question {
 	/**
 	 * Answer feedback.
 	 *
-	 * @param $question_id
+	 * @param int $question_id Question ID.
 	 */
 	public static function answer_feedback_notes( $question_id ) {
 		self::the_answer_feedback( $question_id );

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -914,7 +914,9 @@ class Sensei_Question {
 
 	/**
 	 * Answer feedback.
+	 *
 	 * @deprecated 3.14.0 Renamed to the_answer_feedback
+	 *
 	 * @param int $question_id Question ID.
 	 */
 	public static function answer_feedback_notes( $question_id ) {

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -914,10 +914,11 @@ class Sensei_Question {
 
 	/**
 	 * Answer feedback.
-	 *
+	 * @deprecated 3.14.0 Renamed to the_answer_feedback
 	 * @param int $question_id Question ID.
 	 */
 	public static function answer_feedback_notes( $question_id ) {
+		_deprecated_function( __METHOD__, '3.14.0', 'Sensei_Question::the_answer_feedback' );
 		self::the_answer_feedback( $question_id );
 	}
 
@@ -930,10 +931,12 @@ class Sensei_Question {
 	 * Pseudo code for logic:  https://github.com/Automattic/sensei/issues/1422#issuecomment-214494263
 	 *
 	 * @since 1.9.0
-	 *
-	 * @deprecated 3.14 Moved into the_answer_feedback
+	 * @deprecated 3.14.0 Moved into the_answer_feedback
 	 */
 	public static function the_answer_result_indication() {
+
+		_deprecated_function( __METHOD__, '3.14.0', 'Sensei_Question::the_answer_feedback' );
+
 		global $sensei_question_loop;
 
 		$quiz_id            = $sensei_question_loop['quiz_id'];
@@ -974,12 +977,14 @@ class Sensei_Question {
 
 	/**
 	 * @since 1.9.5
-	 * @deprecated 3.14 Moved into the_answer_feedback
+	 * @deprecated 3.14.0 Moved into the_answer_feedback
 	 *
 	 * @param integer $lesson_id
 	 * @param integer $question_id
 	 */
 	public static function output_result_indication( $lesson_id, $question_id ) {
+
+		_deprecated_function( __METHOD__, '3.14.0', 'Sensei_Question::the_answer_feedback' );
 
 		$question_grade      = Sensei()->question->get_question_grade( $question_id );
 		$user_question_grade = Sensei()->quiz->get_user_question_grade( $lesson_id, $question_id, get_current_user_id() );

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -742,7 +742,6 @@ class Sensei_Question {
 	/**
 	 * This function can only be run withing the single quiz question loop
 	 *
-	 * @since 1.9.0
 	 * @param $question_id
 	 */
 	public static function answer_feedback_notes( $question_id ) {
@@ -771,57 +770,56 @@ class Sensei_Question {
 		// Check if answers must be shown
 		$show_answers = $quiz_graded && ( $succeeded || $failed_and_show_answers || Sensei_Quiz::is_enabled( $lesson_id, 'failed_show_answer_feedback' ) );
 
-		/**
-		 * Allow dynamic overriding of whether to show question answers or not
-		 *
-		 * @since 1.9.7
-		 * @hook sensei_question_show_answers
-		 *
-		 * @param {bool} $show_answers Whether to show the answer to the question.
-		 * @param {int}  $question_id  Question ID.
-		 * @param {int}  $quiz_id      Quiz ID.
-		 * @param {int}  $lesson_id    Lesson ID.
-		 * @param {int}  $user_id      User ID.
-		 * @return {bool} Whether to show the answer to the question.
-		 */
-		$show_answers = apply_filters( 'sensei_question_show_answers', $show_answers, $question_id, $quiz_id, $lesson_id, get_current_user_id() );
-
 		// Show answers if allowed
 		if ( $show_answers ) {
 			$answer_notes   = Sensei()->quiz->get_user_question_feedback( $lesson_id, $question_id, get_current_user_id() );
 			$answer_grade   = Sensei()->quiz->get_user_question_grade( $lesson_id, $question_id, get_current_user_id() );
 			$answer_correct = is_int( $answer_grade ) && $answer_grade > 0;
 
-			if ( $answer_notes ) {
-				if ( $answer_correct ) {
-					$answer_notes_classname = 'answer-feedback-correct';
-				} else {
-					$answer_notes_classname = 'answer-feedback-failed';
-				}
-				?>
 
-				<div class="sensei-message info info-special answer-feedback <?php echo esc_attr( $answer_notes_classname ); ?>">
+			if ( $answer_correct ) {
+				$answer_notes_classname = 'sensei-lms-question__answer-feedback--correct';
+				$answer_feedback_title = __('Correct', 'sensei-lms');
+			} else {
+				$answer_notes_classname = 'sensei-lms-question__answer-feedback--incorrect';
+				$answer_feedback_title = __('Incorrect', 'sensei-lms');
+			}
 
-					<?php
-						/**
-						 * Filter the answer feedback.
-						 *
-						 * @since 1.9.0
-						 * @hook sensei_question_answer_notes
-						 *
-						 * @param {bool|string} $answer_notes Answer notes.
-						 * @param {int}         $question_id  Question ID.
-						 * @param {int}         $lesson_id    Lesson ID.
-						 * @return {string} Answer notes.
-						 */
-						echo wp_kses_post( apply_filters( 'sensei_question_answer_notes', $answer_notes, $question_id, $lesson_id ) );
+			/**
+			 * Filter the answer feedback.
+			 *
+			 * @since 1.9.0
+			 * @hook sensei_question_answer_notes
+			 *
+			 * @param {bool|string} $answer_notes Answer notes.
+			 * @param {int}         $question_id  Question ID.
+			 * @param {int}         $lesson_id    Lesson ID.
+			 * @return {string} Answer notes.
+			 */
+			$answer_notes = apply_filters( 'sensei_question_answer_notes', $answer_notes, $question_id, $lesson_id );
 
-					?>
+			$question_grade = Sensei()->question->get_question_grade( $question_id );
 
+			$points = Sensei()->view_helper->format_question_points( $answer_grade . '/' . $question_grade );
+
+			?>
+
+			<div class="sensei-lms-question__answer-feedback <?php echo esc_attr( $answer_notes_classname ); ?>">
+				<div class="sensei-lms-question__answer-feedback__header">
+					<span class="sensei-lms-question__answer-feedback__icon"></span>
+					<span class="sensei-lms-question__answer-feedback__title"><?php echo wp_kses_post( $answer_feedback_title ); ?></span>
+					<span class="sensei-lms-question__answer-feedback__points"><?php echo wp_kses_post( $points ); ?></span>
 				</div>
 
-				<?php
-			}
+				<?php if( $answer_notes ) { ?>
+					<div class="sensei-lms-question__answer-feedback__content">
+						<?php echo wp_kses_post( $answer_notes ); ?>
+					</div>
+				<?php } ?>
+			</div>
+
+			<?php
+
 		}
 
 	}

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -959,7 +959,7 @@ class Sensei_Question {
 			$show_answers = true;
 		}
 
-		if ( ! $user_passed && Sensei_Quiz::is_disabled( $lesson_id, 'failed_indicate_incorrect' ) ) {
+		if ( ! $user_passed && ! Sensei_Quiz::get_option( $lesson_id, 'failed_indicate_incorrect', true ) ) {
 			$show_answers = false;
 		}
 
@@ -987,7 +987,7 @@ class Sensei_Question {
 		// Defaults
 		$answer_message = __( 'Incorrect - Right Answer:', 'sensei-lms' ) . ' ' . self::get_correct_answer( $question_id );
 
-		if ( Sensei_Quiz::is_disabled( $lesson_id, 'failed_show_correct_answers' ) ) {
+		if ( ! Sensei_Quiz::get_option( $lesson_id, 'failed_show_correct_answers', true ) ) {
 			$answer_message = __( 'Incorrect', 'sensei-lms' );
 		}
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1501,7 +1501,7 @@ class Sensei_Quiz {
 	public static function get_option( $lesson_id, $option, $default = null ) {
 
 		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
-		$option = get_post_meta( $quiz_id, '_' . $option, true );
+		$option  = get_post_meta( $quiz_id, '_' . $option, true );
 
 		if ( ! $option ) {
 			return $default;

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1533,11 +1533,17 @@ class Sensei_Quiz {
 	 *
 	 * @return mixed
 	 */
-	private static function get_option( $lesson_id, $option ) {
+	public static function get_option( $lesson_id, $option, $default = null ) {
 
 		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
 
-		return get_post_meta( $quiz_id, '_' . $option, true );
+		$option = get_post_meta( $quiz_id, '_' . $option, true );
+
+		if ( ! $option ) {
+			return $default;
+		}
+
+		else return 'yes' === $option;
 
 	}
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1512,60 +1512,6 @@ class Sensei_Quiz {
 	}
 
 	/**
-	 * Check if an option is explicitly enabled.
-	 *
-	 * @since 3.14.0
-	 *
-	 * @param int    $lesson_id Lesson ID.
-	 * @param string $option Option name.
-	 *
-	 * @return bool
-	 */
-	public static function is_enabled( $lesson_id, $option ) {
-
-		$value = self::get_option( $lesson_id, $option );
-
-		return 'yes' === $value;
-
-	}
-
-	/**
-	 * Check if an option is explicitly disabled.
-	 *
-	 * @since 3.14.0
-	 *
-	 * @param int    $lesson_id Lesson ID.
-	 * @param string $option Option name.
-	 *
-	 * @return bool
-	 */
-	public static function is_disabled( $lesson_id, $option ) {
-
-		$value = self::get_option( $lesson_id, $option );
-
-		return 'no' === $value;
-
-	}
-
-	/**
-	 * Get a quiz option's value.
-	 *
-	 * @since 3.14.0
-	 *
-	 * @param int    $lesson_id Lesson ID.
-	 * @param string $option Option name.
-	 *
-	 * @return mixed
-	 */
-	private static function get_option( $lesson_id, $option ) {
-
-		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
-
-		return get_post_meta( $quiz_id, '_' . $option, true );
-
-	}
-
-	/**
 	 * @param $lesson_id
 	 *
 	 * @return bool

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1529,21 +1529,21 @@ class Sensei_Quiz {
 	 * @since 3.14.0
 	 *
 	 * @param int    $lesson_id Lesson ID.
-	 * @param string $option Option name.
+	 * @param string $option    Option name.
+	 * @param mixed  $default   Default value to be returned if the option is unset.
 	 *
 	 * @return mixed
 	 */
 	public static function get_option( $lesson_id, $option, $default = null ) {
 
 		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
-
 		$option = get_post_meta( $quiz_id, '_' . $option, true );
 
 		if ( ! $option ) {
 			return $default;
+		} else {
+			return 'yes' === $option;
 		}
-
-		else return 'yes' === $option;
 
 	}
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1587,7 +1587,7 @@ class Sensei_Quiz {
 	 *
 	 * @return mixed
 	 */
-	public static function get_option( $lesson_id, $option ) {
+	private static function get_option( $lesson_id, $option ) {
 
 		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1542,6 +1542,60 @@ class Sensei_Quiz {
 	}
 
 	/**
+	 * Check if an option is explicitly enabled.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @param int    $lesson_id Lesson ID.
+	 * @param string $option Option name.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled( $lesson_id, $option ) {
+
+		$value = self::get_option( $lesson_id, $option );
+
+		return 'yes' === $value;
+
+	}
+
+	/**
+	 * Check if an option is explicitly disabled.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @param int    $lesson_id Lesson ID.
+	 * @param string $option Option name.
+	 *
+	 * @return bool
+	 */
+	public static function is_disabled( $lesson_id, $option ) {
+
+		$value = self::get_option( $lesson_id, $option );
+
+		return 'no' === $value;
+
+	}
+
+	/**
+	 * Get a quiz option's value.
+	 *
+	 * @since 3.14.0
+	 *
+	 * @param int    $lesson_id Lesson ID.
+	 * @param string $option Option name.
+	 *
+	 * @return bool
+	 */
+	public static function get_option( $lesson_id, $option ) {
+
+		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
+
+		return get_post_meta( $quiz_id, '_' . $option, true );
+
+	}
+
+	/**
 	 * @param $lesson_id
 	 *
 	 * @return bool

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1585,7 +1585,7 @@ class Sensei_Quiz {
 	 * @param int    $lesson_id Lesson ID.
 	 * @param string $option Option name.
 	 *
-	 * @return bool
+	 * @return mixed
 	 */
 	public static function get_option( $lesson_id, $option ) {
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1488,42 +1488,6 @@ class Sensei_Quiz {
 	}
 
 	/**
-	 * Check if an option is explicitly enabled.
-	 *
-	 * @since 3.14.0
-	 *
-	 * @param int    $lesson_id Lesson ID.
-	 * @param string $option Option name.
-	 *
-	 * @return bool
-	 */
-	public static function is_enabled( $lesson_id, $option ) {
-
-		$value = self::get_option( $lesson_id, $option );
-
-		return 'yes' === $value;
-
-	}
-
-	/**
-	 * Check if an option is explicitly disabled.
-	 *
-	 * @since 3.14.0
-	 *
-	 * @param int    $lesson_id Lesson ID.
-	 * @param string $option Option name.
-	 *
-	 * @return bool
-	 */
-	public static function is_disabled( $lesson_id, $option ) {
-
-		$value = self::get_option( $lesson_id, $option );
-
-		return 'no' === $value;
-
-	}
-
-	/**
 	 * Get a quiz option's value.
 	 *
 	 * @since 3.14.0

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -133,12 +133,8 @@ add_action( 'sensei_quiz_question_inside_before', array( 'Sensei_Question', 'the
 add_action( 'sensei_quiz_question_inside_before', array( 'Sensei_Question', 'the_question_hidden_fields' ), 40 );
 
 // @since 1.9.0
-// hook in incorrect / correct message below questions if the quiz has been graded
-add_action( 'sensei_quiz_question_inside_after', array( 'Sensei_Question', 'the_answer_result_indication' ) );
-
-// @since 1.9.0
 // add answer grading feedback at the bottom of the question
-add_action( 'sensei_quiz_question_inside_after', array( 'Sensei_Question', 'answer_feedback_notes' ) );
+add_action( 'sensei_quiz_question_inside_after', array( 'Sensei_Question', 'the_answer_feedback' ) );
 
 // @since 1.9.0
 // add extra question data for different quesiton types when get_question_template_data_is_called.

--- a/templates/single-quiz.php
+++ b/templates/single-quiz.php
@@ -84,7 +84,7 @@ do_action( 'sensei_single_quiz_content_inside_before', get_the_ID() );
 						/**
 						 * Action inside before the question content on single-quiz page
 						 *
-						 * @hooked Sensei_Question::answer_feedback_notes
+						 * @hooked Sensei_Question::the_answer_feedback
 						 *
 						 * @param string $the_question_id
 						 */


### PR DESCRIPTION
Fixes #4355 (answer section changes were scoped out)
Based on #4354

### Changes proposed in this Pull Request

* Group all the answer feedback into one notice:
<img width="666" alt="image" src="https://user-images.githubusercontent.com/176949/142235645-9666e8e1-248c-4614-90c0-5bc61e56d1d0.png">

### Testing instructions

* Create a quiz, turn off 'Pass required'
* Take a quiz with a learner, then grade their answers as a teacher
* Open the quiz page with the learner. Make sure the Grade, correct answer, feedback text are visible for each question
* Enable 'Pass required' and toggle the gradual answer feedback settings. See that only the turned on feedback is displayed.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_question_answer_message_grade` — filter the grade displayed in the answer feedback notice
* `sensei_question_answer_message_text` — deprected as part of `Sensei_Question::output_result_indication`
* `sensei_question_answer_message_css_class` — moved into `Sensei_Question::the_answer_feedback`


<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* `Sensei_Question::answer_feedback_notes` — renamed to `Sensei_Question::the_answer_feedback`
* `Sensei_Question::the_answer_result_indication` — now part of `Sensei_Question::the_answer_feedback`
* `Sensei_Question::output_result_indication` — now part of `Sensei_Question::the_answer_feedback`

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

#### Everything

<img width="666" alt="image" src="https://user-images.githubusercontent.com/176949/142235645-9666e8e1-248c-4614-90c0-5bc61e56d1d0.png">

#### Just 'Indicate which questions are incorrect.'

<img width="664" alt="image" src="https://user-images.githubusercontent.com/176949/142235666-633ece96-df2e-4f80-b7da-87eff1618c3d.png">

#### Just 'Show “Answer Feedback” text.'

<img width="684" alt="image" src="https://user-images.githubusercontent.com/176949/142237219-33e2f780-4c73-4569-8752-eb47a5a78204.png">

