### PR TITLE
Make the lesson prerequisite metabox dropdown show lessons from the selected course

### DIFF
--- a/assets/js/admin/lesson-edit.js
+++ b/assets/js/admin/lesson-edit.js
@@ -19,9 +19,7 @@ domReady( () => {
 
 	const prerequisiteOptionElements = jQuery( '#lesson-prerequisite-options' );
 	if ( prerequisiteOptionElements.length > 0 ) {
-		prerequisiteOptionElements.select2( {
-			width: 'resolve',
-		} );
+		prerequisiteOptionElements.select2( { width: 'resolve' } );
 	}
 
 	const courseOptionElements = jQuery( '#lesson-course-options' );
@@ -33,4 +31,33 @@ domReady( () => {
 	if ( moduleOptionElements.length > 0 ) {
 		moduleOptionElements.select2( { width: 'resolve' } );
 	}
+
+	// Refresh the prerequisite meta box when the course changes in order to get the relevant prerequisites.
+	jQuery( '#lesson-course-options' ).on( 'change', function () {
+		const lessonId = jQuery( '#post_ID' ).val();
+		const courseId = jQuery( this ).val();
+
+		jQuery.get(
+			ajaxurl,
+			{
+				action: 'get_prerequisite_meta_box_content',
+				lesson_id: lessonId,
+				course_id: courseId,
+				security:
+					window.sensei_lesson_metadata
+						.get_prerequisite_meta_box_content_nonce,
+			},
+			function ( response ) {
+				if ( '' !== response ) {
+					// Replace the meta box and re-initialize select2.
+					jQuery( '> .inside', '#lesson-prerequisite' ).html(
+						response
+					);
+					jQuery( '#lesson-prerequisite-options' ).select2( {
+						width: 'resolve',
+					} );
+				}
+			}
+		);
+	} );
 } );

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1143,12 +1143,12 @@ class Sensei_Course {
 	 *
 	 * @access public
 	 *
-	 * @param int    $course_id   (default: 0)
-	 * @param string $post_status (default: 'publish')
-	 * @param string $fields      (default: 'all'). WP only allows 3 types, but we will limit it to only 'ids' or 'all'
-	 * @param array  $query_args  Base arguments for the WP query.
+	 * @param int          $course_id   (default: 0).         The course id.
+	 * @param string|array $post_status (default: 'publish'). The post status.
+	 * @param string       $fields      (default: 'all').     WP only allows 3 types, but we will limit it to only 'ids' or 'all'.
+	 * @param array        $query_args  Base arguments for the WP query.
 	 *
-	 * @return array{ type WP_Post }  $posts_array
+	 * @return WP_Post[]
 	 */
 	public function course_lessons( $course_id = 0, $post_status = 'publish', $fields = 'all', $query_args = [] ) {
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1737,8 +1737,8 @@ class Sensei_Core_Modules {
 	 * Find the lesson in the given course that doesn't belong
 	 * to any of the courses modules
 	 *
-	 * @param int    $course_id    The course id.
-	 * @param string $post_status  The status of the lessons.
+	 * @param int          $course_id    The course id.
+	 * @param string|array $post_status  The status of the lessons.
 	 *
 	 * @return array $non_module_lessons
 	 */

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -507,4 +507,42 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		Sensei_Quiz::submit_answers_for_grading( [], [], $lesson_id, $user_id );
 		$this->assertTrue( Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id ) );
 	}
+
+	/**
+	 * Ensure that when getting the lesson prerequisites, they are filtered based on the lesson's course.
+	 * The prerequisites should be lessons linked to that course.
+	 *
+	 * @covers Sensei_Lesson::get_prerequisites
+	 */
+	public function testLessonsAssignedToACourseShouldHavePrerequisitesFromThatCourse() {
+		/* Arrange */
+		$course_with_lessons = $this->factory->get_course_with_lessons(
+			[
+				'lesson_count'   => 3,
+				'question_count' => 0,
+			]
+		);
+
+		// Populate the database with an additional course and lessons.
+		$this->factory->get_course_with_lessons(
+			[
+				'lesson_count'   => 3,
+				'question_count' => 0,
+			]
+		);
+
+		$lesson_id       = $course_with_lessons['lesson_ids'][0];
+		$lesson_instance = new Sensei_Lesson();
+		$method          = new ReflectionMethod( $lesson_instance, 'get_prerequisites' );
+		$method->setAccessible( true );
+
+		/* Act */
+		$prerequisites = $method->invoke( $lesson_instance, $lesson_id, $course_with_lessons['course_id'] );
+
+		/* Assert */
+		$this->assertCount(
+			2, // Excluding the original lesson from the count.
+			$prerequisites
+		);
+	}
 }


### PR DESCRIPTION
Fixes #2826 and closes #2852

### Changes proposed in this Pull Request

* In the lesson prerequisite metabox, present only prerequisites that are related to the selected/current course.
* The prerequisites should be sorted by modules.

### Future

* Maybe add a prerequisites filter, so users can control the behavior?

### Testing instructions

* Populate your database with 2 courses with multiple lessons and modules.
* Go to the edit screen of a lesson.
* Make sure the prerequisite dropdown only contains lessons for the currently selected course.
* Make sure the prerequisite dropdown is sorted by module.
* Make sure the lesson itself is not included in that dropdown.
* Change the lesson course.
* Make sure the prerequisite dropdown contains lessons from that course.
* Select no course.
* Make sure you see a "No lessons exist yet" message in place of the prerequisite dropdown.

### Screenshot

![Screen Capture on 2021-11-05 at 13-54-25](https://user-images.githubusercontent.com/1612178/140506873-7453fe17-cbdf-42ac-a489-c9d27ad106b0.gif)