### PR TITLE
Grading display filter for custom question types

### DIFF
--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -218,7 +218,7 @@ class Sensei_Grading_User_Quiz {
 				/**
 				 * Other question type filters.
 				 *
-				 * adds a filter that other question types can hook into before display on the admin grading page.
+				 * Adds a filter that other question types can hook into before display on the admin grading page.
 				 *
 				 * @since
 				 *

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -215,6 +215,26 @@ class Sensei_Grading_User_Quiz {
 						break;
 				}
 
+				/**
+				 * Other question type filters.
+				 *
+				 * adds a filter that other question types can hook into before display on the admin grading page.
+				 *
+				 * @since
+				 *
+				 * @param null
+				 * @param string $type
+				 * @param int $question_id
+				 */
+				$possibly_new_args = apply_filters( 'sensei_grading_display_quiz_question', null, $type, $question_id );
+
+				if( null !== $possibly_new_args && 0 < count( $possibly_new_args ) ) {
+					$type_name           = $possibly_new_args['type_name'];
+					$right_answer        = $possibly_new_args['right_answer'];
+					$user_answer_content = $possibly_new_args['user_answer_content'];
+					$grade_type          = $possibly_new_args['grade_type'];
+				}
+
 				$quiz_grade_type = get_post_meta( $this->quiz_id, '_quiz_grade_type', true );
 
 				// Don't auto-grade if "Grade quiz automatically" isn't selected in Quiz Settings,

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -229,10 +229,10 @@ class Sensei_Grading_User_Quiz {
 				$possibly_new_args = apply_filters( 'sensei_grading_display_quiz_question', null, $type, $question_id );
 
 				if( null !== $possibly_new_args && 0 < count( $possibly_new_args ) ) {
-					$type_name           = $possibly_new_args['type_name'];
-					$right_answer        = $possibly_new_args['right_answer'];
-					$user_answer_content = $possibly_new_args['user_answer_content'];
-					$grade_type          = $possibly_new_args['grade_type'];
+					$type_name           = $possibly_new_args['type_name'] ?? $type_name;
+					$right_answer        = $possibly_new_args['right_answer'] ?? $right_answer;
+					$user_answer_content = $possibly_new_args['user_answer_content'] ?? $user_answer_content;
+					$grade_type          = $possibly_new_args['grade_type'] ?? $grade_type;
 				}
 
 				$quiz_grade_type = get_post_meta( $this->quiz_id, '_quiz_grade_type', true );

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -228,7 +228,7 @@ class Sensei_Grading_User_Quiz {
 				 */
 				$possibly_new_args = apply_filters( 'sensei_grading_display_quiz_question', null, $type, $question_id );
 
-				if( null !== $possibly_new_args && 0 < count( $possibly_new_args ) ) {
+				if ( null !== $possibly_new_args && 0 < count( $possibly_new_args ) ) {
 					$type_name           = $possibly_new_args['type_name'] ?? $type_name;
 					$right_answer        = $possibly_new_args['right_answer'] ?? $right_answer;
 					$user_answer_content = $possibly_new_args['user_answer_content'] ?? $user_answer_content;

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -216,7 +216,6 @@ class Sensei_Grading_User_Quiz {
 				}
 
 				/**
-				 * Filter quiz right answer and user answer content for grading page display.
 				 * Filters the various values which are displayed in the grading admin page for each quiz question.
 				 * The expected values are type_name, right_answer, user_answer_content and grade_type
 				 *
@@ -224,11 +223,7 @@ class Sensei_Grading_User_Quiz {
 				 *
 				 * @hook sensei_grading_display_quiz_question
 				 *
-				 * @param {null}   $display_values
-				 * @param {string} $type
-				 * @param {int}    $question_id
-				 *
-				 * @return {array|null} {
+				 * @param {array|null}   $display_values {
 				 *     Optional. An array of arguments or null.
 				 *
 				 *     @type {string}       $type_name           The question type.
@@ -236,6 +231,10 @@ class Sensei_Grading_User_Quiz {
 				 *     @type {string|array} $user_answer_content The user supplied answer to the quiz.
 				 *     @type {string}       $grade_type          Auto or manual grading.
 				 * }
+				 * @param {string} $type
+				 * @param {int}    $question_id
+				 *
+				 * @return {array|null}
 				 */
 				$possibly_new_args = apply_filters( 'sensei_grading_display_quiz_question', null, $type, $question_id, $right_answer, $user_answer_content );
 

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -216,15 +216,26 @@ class Sensei_Grading_User_Quiz {
 				}
 
 				/**
-				 * Other question type filters.
+				 * Filter quiz right answer and user answer content for grading page display.
+				 * Filters the various values which are displayed in the grading admin page for each quiz question.
+				 * The expected values are type_name, right_answer, user_answer_content and grade_type
 				 *
-				 * Adds a filter that other question types can hook into before display on the admin grading page.
+				 * @since 4.0.0
 				 *
-				 * @since
+				 * @hook sensei_grading_display_quiz_question
 				 *
-				 * @param null
-				 * @param string $type
-				 * @param int $question_id
+				 * @param {null}   $display_values
+				 * @param {string} $type
+				 * @param {int}    $question_id
+				 *
+				 * @return {array|null} {
+				 *     Optional. An array of arguments or null.
+				 *
+				 *     @type {string}       $type_name           The question type.
+				 *     @type {string|array} $right_answer        The right answer to the quiz.
+				 *     @type {string|array} $user_answer_content The user supplied answer to the quiz.
+				 *     @type {string}       $grade_type          Auto or manual grading.
+				 * }
 				 */
 				$possibly_new_args = apply_filters( 'sensei_grading_display_quiz_question', null, $type, $question_id, $right_answer, $user_answer_content );
 

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -226,10 +226,10 @@ class Sensei_Grading_User_Quiz {
 				 * @param {array|null}   $display_values {
 				 *     Optional. An array of arguments or null.
 				 *
-				 *     @type {string}       $type_name           The question type.
-				 *     @type {string|array} $right_answer        The right answer to the quiz.
-				 *     @type {string|array} $user_answer_content The user supplied answer to the quiz.
-				 *     @type {string}       $grade_type          Auto or manual grading.
+				 *     @key {string}       $type_name           The question type.
+				 *     @key {string|array} $right_answer        The right answer to the quiz.
+				 *     @key {string|array} $user_answer_content The user supplied answer to the quiz.
+				 *     @key {string}       $grade_type          Auto or manual grading.
 				 * }
 				 * @param {string} $type
 				 * @param {int}    $question_id

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -226,7 +226,7 @@ class Sensei_Grading_User_Quiz {
 				 * @param string $type
 				 * @param int $question_id
 				 */
-				$possibly_new_args = apply_filters( 'sensei_grading_display_quiz_question', null, $type, $question_id );
+				$possibly_new_args = apply_filters( 'sensei_grading_display_quiz_question', null, $type, $question_id, $right_answer, $user_answer_content );
 
 				if ( null !== $possibly_new_args && 0 < count( $possibly_new_args ) ) {
 					$type_name           = $possibly_new_args['type_name'] ?? $type_name;


### PR DESCRIPTION

Extensions that use a custom question type can hook into this filter to modify what gets displayed on the admin grading page.

### Changes proposed in this Pull Request

* add a filter: `sensei_grading_display_quiz_question` that fires when a question is about to be displayed on the grading page along with learner supplied answer. 
* The filter accepts a null value and the question ID and returns an array of the values, most importantly, the learner's answer and the correct answer, to display in the admin grading page. 
* If modified, the returned array should have some or all of the following keys: `type_name`, `right_answer`, `user_answer_content`, `grade_type`. If any of the keys are missing, the computed value in the calling scope is used instead.

### Testing instructions

* Hook into the filter and add a callback: `add_filter( 'sensei_grading_display_quiz_question', 'callback' );`. This callback should expect a null value, question type and the question ID as arguments.
* Return an array that contains some or all of the following keys: `type_name`, `right_answer`, `user_answer_content`, `grade_type`.
* Take a quiz on the frontend.
* Go to the grading page on admin, the displayed data for that particular quiz should be what is returned in the callback.

### New Hooks
* `sensei_grading_display_quiz_question`: Filters the various values which are displayed in the grading admin page for each quiz question.