### PR TITLE
Load less User data for Teacher metabox

### DIFF
--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -263,7 +263,7 @@ class Sensei_Teacher {
 			<?php foreach ( $users as $user_data ) { ?>
 
 					<?php
-						$user_id = $user_data->id;
+						$user_id           = $user_data->id;
 						$user_display_name = $user_data->display_name;
 					?>
 					<option <?php selected( $current_author, $user_id, true ); ?> value="<?php echo esc_attr( $user_id ); ?>" >
@@ -329,7 +329,7 @@ class Sensei_Teacher {
 			[
 				'blog_id' => $GLOBALS['blog_id'],
 				'include' => $ids,
-				'fields' => $fields,
+				'fields'  => $fields,
 			]
 		);
 	}

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -319,7 +319,7 @@ class Sensei_Teacher {
 	 * @since 3.13.4
 	 * @access private
 	 *
-	 * @param  string|array $fields Fields to return from DB. Defaults to 'id'.
+	 * @param  string|array $fields Fields to return from DB. Defaults to 'ID'.
 	 * @return array
 	 */
 	private function get_teachers_and_authors_with_fields( $fields = 'ID' ) {

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -254,7 +254,7 @@ class Sensei_Teacher {
 		$current_author = $post->post_author;
 
 		// get the users authorised to author courses
-		$users = $this->get_teachers_and_authors_with_fields( [ 'id', 'display_name' ] );
+		$users = $this->get_teachers_and_authors_with_fields( [ 'ID', 'display_name' ] );
 
 		?>
 		<input type="hidden" name="post_author_override" value="<?php echo intval( $current_author ); ?>" />
@@ -263,7 +263,7 @@ class Sensei_Teacher {
 			<?php foreach ( $users as $user_data ) { ?>
 
 					<?php
-						$user_id           = $user_data->id;
+						$user_id           = $user_data->ID;
 						$user_display_name = $user_data->display_name;
 					?>
 					<option <?php selected( $current_author, $user_id, true ); ?> value="<?php echo esc_attr( $user_id ); ?>" >
@@ -322,7 +322,7 @@ class Sensei_Teacher {
 	 * @param  string|array $fields Fields to return from DB. Defaults to 'id'.
 	 * @return array
 	 */
-	private function get_teachers_and_authors_with_fields( $fields = 'id' ) {
+	private function get_teachers_and_authors_with_fields( $fields = 'ID' ) {
 		$ids = $this->get_teachers_and_authors();
 
 		return get_users(

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -254,19 +254,20 @@ class Sensei_Teacher {
 		$current_author = $post->post_author;
 
 		// get the users authorised to author courses
-		$users = $this->get_teachers_and_authors();
+		$users = $this->get_teachers_and_authors_with_fields( [ 'id', 'display_name' ] );
 
 		?>
 		<input type="hidden" name="post_author_override" value="<?php echo intval( $current_author ); ?>" />
 		<select name="sensei-course-teacher-author" class="sensei course teacher">
 
-			<?php foreach ( $users as $user_id ) { ?>
+			<?php foreach ( $users as $user_data ) { ?>
 
 					<?php
-						$user = get_user_by( 'id', $user_id );
+						$user_id = $user_data->id;
+						$user_display_name = $user_data->display_name;
 					?>
 					<option <?php selected( $current_author, $user_id, true ); ?> value="<?php echo esc_attr( $user_id ); ?>" >
-						<?php echo esc_html( $user->display_name ); ?>
+						<?php echo esc_html( $user_display_name ); ?>
 					</option>
 
 				<?php
@@ -309,6 +310,28 @@ class Sensei_Teacher {
 
 		return array_unique( array_merge( $teachers, $authors ) );
 
+	}
+
+	/**
+	 * Get list of users who can author courses, lessons, and quizzes.
+	 * Optionally specify the fields to return from the DB.
+	 *
+	 * @since 3.13.4
+	 * @access private
+	 *
+	 * @param  string|array $fields Fields to return from DB. Defaults to 'id'.
+	 * @return array
+	 */
+	private function get_teachers_and_authors_with_fields( $fields = 'id' ) {
+		$ids = $this->get_teachers_and_authors();
+
+		return get_users(
+			[
+				'blog_id' => $GLOBALS['blog_id'],
+				'include' => $ids,
+				'fields' => $fields,
+			]
+		);
 	}
 
 	/**

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -286,7 +286,7 @@ class Sensei_Teacher {
 	 * Get a list of users who can author courses, lessons and quizes.
 	 *
 	 * @since 1.8.0
-	 * @access public
+	 * @access private
 	 * @parameters
 	 * @return array $users user id array
 	 */


### PR DESCRIPTION
Fixes memory issue for sites with many users.

### Testing instructions

Load the Course editor. Try changing the Teacher to different users and ensure that it works. Try users with roles of `Author`, `Teacher`, and `admin`.