### PR TITLE
Add quiz block in the lessons when the block is not there

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-lessons-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lessons-controller.php
@@ -124,7 +124,7 @@ class Sensei_REST_API_Lessons_Controller extends WP_REST_Posts_Controller {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		if ( 'edit' === $context && isset( $prepared['content']['raw'] ) ) {
 			$post = get_post();
-			if ( Sensei()->lesson::lesson_quiz_has_questions( $post->ID ) && ! has_block( 'sensei-lms/quiz' ) ) {
+			if ( ! has_block( 'sensei-lms/quiz' ) ) {
 				$prepared['content']['raw'] .= serialize_block(
 					[
 						'blockName'    => 'sensei-lms/quiz',


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Before this PR, when a lesson didn't have a quiz block, it was added only if the lesson had questions.
* With this change, it will add the quiz block in any scenario that it isn't there. The idea is that it should be always there since it's the way to handle quizzes.

See this PR for reference: https://github.com/Automattic/sensei/pull/4018

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* With the block based editor disabled (`add_filter( 'sensei_quiz_enable_block_based_editor', '__return_false' );`), create a 2 lessons. One with a quiz with questions and another without questions.
* Remove the filter to re-enable the block based quiz editor.
* Edit both lessons. Ensure the block is added.