### PR TITLE
Refresh the module selection after changing the course

### DIFF
--- a/assets/js/admin/blocks-toggling-control.js
+++ b/assets/js/admin/blocks-toggling-control.js
@@ -42,7 +42,6 @@ const blockEditorSelector = select( 'core/block-editor' );
 const coreEditorSelector = select( 'core/editor' );
 const editPostSelector = select( 'core/edit-post' );
 const editPostDispatcher = dispatch( 'core/edit-post' );
-const { createWarningNotice, removeNotice } = dispatch( 'core/notices' );
 
 /**
  * Start blocks toggling control.
@@ -56,6 +55,8 @@ export const startBlocksTogglingControl = ( postType ) => {
 	if ( ! blockEditorSelector ) {
 		return;
 	}
+
+	const { createWarningNotice, removeNotice } = dispatch( 'core/notices' );
 
 	let initialWithSenseiBlocks; // Whether initial state has Sensei Blocks.
 	let previousWithSenseiBlocks; // Whether previous state has Sensei Blocks.

--- a/assets/js/admin/lesson-edit.js
+++ b/assets/js/admin/lesson-edit.js
@@ -34,7 +34,7 @@ domReady( () => {
 
 	// Refresh the prerequisite meta box when the course changes in order to get the relevant prerequisites.
 	jQuery( '#lesson-course-options' ).on( 'change', function () {
-		const lessonId = jQuery( '#post_ID' ).val();
+		const lessonId = wp.data.select( 'core/editor' ).getCurrentPostId();
 		const courseId = jQuery( this ).val();
 
 		jQuery.get(

--- a/assets/js/admin/lesson-edit.js
+++ b/assets/js/admin/lesson-edit.js
@@ -34,7 +34,10 @@ domReady( () => {
 
 	// Refresh the prerequisite meta box when the course changes in order to get the relevant prerequisites.
 	jQuery( '#lesson-course-options' ).on( 'change', function () {
-		const lessonId = wp.data.select( 'core/editor' ).getCurrentPostId();
+		// Try to get the lesson ID from the wp data store. If not present, fallback to getting it from the DOM.
+		const lessonId =
+			wp.data.select( 'core/editor' )?.getCurrentPostId() ||
+			jQuery( '#post_ID' ).val();
 		const courseId = jQuery( this ).val();
 
 		jQuery.get(

--- a/assets/js/modules-admin.js
+++ b/assets/js/modules-admin.js
@@ -202,36 +202,28 @@ jQuery( document ).ready( function () {
 		} );
 	}
 
-	// Get Course modules (if any) on course select change
-	var $courseSelect = jQuery( '#lesson-course-options' ),
-		$lessonModuleMetaboxSelectContainer = jQuery(
-			'div#lesson-module-metabox-select'
-		);
+	// Refresh the modules meta box on course select change.
+	jQuery( '#lesson-course-options' ).on( 'change', function () {
+		const lessonId = jQuery( '#post_ID' ).val();
+		const courseId = jQuery( this ).val();
 
-	$courseSelect.on( 'change', function () {
-		if ( ! window.modulesAdmin.getCourseModulesNonce ) {
-			// console.log( 'missing modulesAdmin.getCourseModulesNonce' );
-			return;
-		}
-		var courseId = $courseSelect.val(),
-			data = {
-				security: window.modulesAdmin.getCourseModulesNonce,
-				action: 'sensei_get_course_modules',
+		jQuery.get(
+			ajaxurl,
+			{
+				action: 'sensei_get_lesson_module_metabox',
+				lesson_id: lessonId,
 				course_id: courseId,
-			};
-		if ( ! data.course_id ) {
-			// console.log( 'missing data.course_id' );
-			return;
-		}
-
-		jQuery.post( ajaxurl, data, function ( response ) {
-			if ( true === response.success ) {
-				var content = response.data.content;
-				$lessonModuleMetaboxSelectContainer.html( content );
-				jQuery( 'select#lesson-module-options' ).select2( {
-					width: 'resolve',
-				} );
+				security: window.modulesAdmin.getLessonModuleMetaBoxNonce,
+			},
+			function ( response ) {
+				if ( '' !== response ) {
+					// Replace the meta box and re-initialize select2.
+					jQuery( '> .inside', '#module_select' ).html( response );
+					jQuery( '#lesson-module-options' ).select2( {
+						width: 'resolve',
+					} );
+				}
 			}
-		} );
+		);
 	} );
 } );

--- a/assets/js/modules-admin.js
+++ b/assets/js/modules-admin.js
@@ -204,7 +204,10 @@ jQuery( document ).ready( function () {
 
 	// Refresh the modules meta box on course select change.
 	jQuery( '#lesson-course-options' ).on( 'change', function () {
-		const lessonId = wp.data.select( 'core/editor' ).getCurrentPostId();
+		// Try to get the lesson ID from the wp data store. If not present, fallback to getting it from the DOM.
+		const lessonId =
+			wp.data.select( 'core/editor' )?.getCurrentPostId() ||
+			jQuery( '#post_ID' ).val();
 		const courseId = jQuery( this ).val();
 
 		jQuery.get(

--- a/assets/js/modules-admin.js
+++ b/assets/js/modules-admin.js
@@ -204,7 +204,7 @@ jQuery( document ).ready( function () {
 
 	// Refresh the modules meta box on course select change.
 	jQuery( '#lesson-course-options' ).on( 'change', function () {
-		const lessonId = jQuery( '#post_ID' ).val();
+		const lessonId = wp.data.select( 'core/editor' ).getCurrentPostId();
 		const courseId = jQuery( this ).val();
 
 		jQuery.get(

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -211,12 +211,12 @@ class Sensei_Core_Modules {
 	/**
 	 * Renders the lesson module select input.
 	 *
-	 * @param int|null $course_id
-	 * @param int|null $current_module_id
+	 * @param int|null $course_id         The course post ID.
+	 * @param int|null $current_module_id The currently selected module post ID.
 	 *
-	 * @return string
+	 * @return string The lesson module select HTML.
 	 */
-	private function render_lesson_module_select_for_course( int $course_id = null, int $current_module_id = null ) {
+	private function render_lesson_module_select_for_course( int $course_id = null, int $current_module_id = null ): string {
 		// Get the available modules for this lesson's course.
 		$modules = $course_id ? $this->get_course_modules( $course_id ) : [];
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -93,6 +93,7 @@ class Sensei_Core_Modules {
 
 		// store new modules created on the course edit screen
 		add_action( 'wp_ajax_sensei_add_new_module_term', array( 'Sensei_Core_Modules', 'add_new_module_term' ) );
+		add_action( 'wp_ajax_sensei_get_course_modules', array( $this, 'ajax_get_course_modules' ) );
 		add_action( 'wp_ajax_sensei_get_lesson_module_metabox', array( $this, 'handle_get_lesson_module_metabox' ) );
 
 		// for non admin users, only show taxonomies that belong to them
@@ -2127,6 +2128,27 @@ class Sensei_Core_Modules {
 			)
 		);
 
+	}
+
+	/**
+	 * Get course modules
+	 *
+	 * @deprecated 3.15.0
+	 */
+	public function ajax_get_course_modules() {
+		_deprecated_function( __METHOD__, '3.15.0', 'Sensei_Core_Modules::handle_get_lesson_module_metabox' );
+
+		// Security check
+		check_ajax_referer( 'get-course-modules', 'security' );
+
+		$course_id = isset( $_POST['course_id'] ) ? absint( $_POST['course_id'] ) : null;
+		if ( null === $course_id ) {
+			wp_send_json_error( array( 'error' => 'invalid course id' ) );
+		}
+
+		$html_content = $this->render_lesson_module_select_for_course( $course_id );
+
+		wp_send_json_success( array( 'content' => $html_content ) );
 	}
 
 	/**

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -150,7 +150,7 @@ class Sensei_Core_Modules {
 	/**
 	 * Outputs the lesson module meta box HTML.
 	 *
-	 * @since 3.14.0
+	 * @since 3.15.0
 	 *
 	 * @param WP_Post $lesson_post The lesson post object.
 	 * @param int     $course_id   The course id.
@@ -210,6 +210,8 @@ class Sensei_Core_Modules {
 
 	/**
 	 * Renders the lesson module select input.
+	 *
+	 * @since 3.15.0
 	 *
 	 * @param int|null $course_id         The course post ID.
 	 * @param int|null $current_module_id The currently selected module post ID.
@@ -2153,6 +2155,8 @@ class Sensei_Core_Modules {
 
 	/**
 	 * Handles the lesson module meta box ajax request by outputting the box content HTML.
+	 *
+	 * @since 3.15.0
 	 */
 	public function handle_get_lesson_module_metabox() {
 		// Security check.


### PR DESCRIPTION
Fixes #3202

### Changes proposed in this Pull Request

* Refresh the module selection dropdown on the lesson edit screen after changing the course.

### Testing instructions

* Populate your database with a course with some modules and lessons and another course with only lessons (no modules).
* Go to the edit screen of a lesson.
* Select the course that has modules.
* Make sure the "module" metabox contains a dropdown with the course modules.
* Select the course that has no modules.
* Make sure the "module" metabox contains: `No modules are available for this lesson yet. Please add some to the course.`
* Select no course.
* Make sure the "module" metabox contains: `No modules are available for this lesson yet. Please select a course first.`
* Make sure the expected module value is stored in the database after updating the lesson.

### Deprecated Code
 * `Sensei_Core_Modules::ajax_get_course_modules` - in favour of
 `Sensei_Core_Modules::handle_get_lesson_module_metabox`

### Screenshot

![Screen Capture on 2021-11-15 at 21-21-45](https://user-images.githubusercontent.com/1612178/141841457-5efbbf73-9803-4e2f-a984-c96de1238c11.gif)