### PR TITLE
Improve performance on course ordering

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1326,18 +1326,22 @@ class Sensei_Admin {
 	}
 
 	public function save_course_order( $order_string = '' ) {
+		global $wpdb;
 		$order = array();
 
 		$i = 1;
 		foreach ( explode( ',', $order_string ) as $course_id ) {
 			if ( $course_id ) {
-				$order[]     = $course_id;
-				$update_args = array(
-					'ID'         => absint( $course_id ),
-					'menu_order' => $i,
-				);
+				$order[] = $course_id;
 
-				wp_update_post( $update_args );
+				// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+				$wpdb->query(
+					$wpdb->prepare(
+						"UPDATE $wpdb->posts SET menu_order = %d WHERE ID = %d",
+						$i,
+						absint( $course_id )
+					)
+				);
 
 				++$i;
 			}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It improves performance on the Course Ordering.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create some courses.
* Go to WP-admin > Courses > Order Courses.
* Order the courses, refresh the page, and make sure it was properly re-ordered.