### PR TITLE
Fix course complete emails not being sent

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -67,7 +67,7 @@ class Sensei_Frontend {
 		add_action( 'sensei_lesson_archive_lesson_title', array( $this, 'sensei_lesson_archive_lesson_title' ), 10 );
 		add_action( 'wp', array( $this, 'sensei_complete_lesson' ), 10 );
 		add_action( 'wp_head', array( $this, 'sensei_complete_course' ), 10 );
-		add_action( 'sensei_course_status_updated', array( $this, 'redirect_to_course_completed_page' ), 10, 3 );
+		add_action( 'sensei_course_status_updated', array( $this, 'redirect_to_course_completed_page' ), 1000, 3 );
 		add_action( 'sensei_frontend_messages', array( $this, 'sensei_frontend_messages' ) );
 		add_action( 'sensei_lesson_video', array( $this, 'sensei_lesson_video' ), 10, 1 );
 		add_action( 'sensei_complete_lesson_button', array( $this, 'sensei_complete_lesson_button' ) );


### PR DESCRIPTION
Currently, the emails generated by completing a course are not being sent.

This is caused by the [course completed page redirect action](https://github.com/Automattic/sensei/blob/master/includes/class-sensei-frontend.php#L70). It is terminating the execution before [other actions](https://github.com/Automattic/sensei/blob/master/includes/class-sensei-emails.php#L45-L46) have a chance to trigger.

### Changes proposed in this Pull Request

* Make the course completed page redirect action execute last. 

### Testing instructions

* In Sensei LMS > Settings > Email Notifications, ensure email notifications are enabled for both the teacher and the learner when a course is completed.
* Complete a course.
* Make sure the course completed emails are sent to both the teacher and the student.

