### PR TITLE
Implement prev & next lesson buttons block.

### DIFF
--- a/assets/css/sensei-course-theme.scss
+++ b/assets/css/sensei-course-theme.scss
@@ -1,0 +1,1 @@
+@import './sensei-course-theme/prev-next-lesson';

--- a/assets/css/sensei-course-theme/prev-next-lesson.scss
+++ b/assets/css/sensei-course-theme/prev-next-lesson.scss
@@ -1,0 +1,31 @@
+.sensei-course-theme-prev-next-lesson-container {
+	display: flex;
+	flex-direction: row;
+	justify-content: flex-start;
+	align-items: center;
+}
+
+.sensei-course-theme-prev-next-lesson-a {
+	font-size: 14px;
+	line-height: 17px;
+	color: #000;
+	&:nth-child(2) {
+		margin-left: 27px;
+	}
+	&:hover {
+		text-decoration: underline;
+	}
+	svg {
+		height: 11px;
+	}
+	&__prev {
+		svg {
+			margin-right: 14px;
+		}
+	}
+	&__next {
+		svg {
+			margin-left: 14px;
+		}
+	}
+}

--- a/includes/blocks/course-theme/class-course-theme.php
+++ b/includes/blocks/course-theme/class-course-theme.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * File containing the class Sensei_CT_Blocks.
+ *
+ * @package sensei
+ */
+
+namespace Sensei\Blocks;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use \Sensei_Blocks_Initializer;
+use \Sensei\Blocks\Course_Theme\Prev_Lesson;
+use \Sensei\Blocks\Course_Theme\Next_Lesson;
+use \Sensei\Blocks\Course_Theme\Prev_Next_Lesson;
+
+/**
+ * Class Sensei_Course_Theme_Blocks
+ */
+class Course_Theme extends Sensei_Blocks_Initializer {
+	/**
+	 * Sensei_Blocks constructor.
+	 */
+	public function __construct() {
+		parent::__construct( [ 'lesson' ] );
+	}
+
+	/**
+	 * Enqueue frontend and editor assets.
+	 *
+	 * @access private
+	 */
+	public function enqueue_block_assets() {
+		Sensei()->assets->enqueue( 'sensei-course-theme', 'css/sensei-course-theme.css' );
+	}
+
+	/**
+	 * Enqueue editor assets.
+	 *
+	 * @access private
+	 */
+	public function enqueue_block_editor_assets() {
+	}
+
+	/**
+	 * Initializes the blocks.
+	 */
+	public function initialize_blocks() {
+		$prev = new Prev_Lesson();
+		$next = new Next_Lesson();
+		new Prev_Next_Lesson( $prev, $next );
+	}
+}

--- a/includes/blocks/course-theme/class-next-lesson.php
+++ b/includes/blocks/course-theme/class-next-lesson.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * File containing the Next_Lesson class.
+ *
+ * @package sensei
+ * @since
+ */
+
+namespace Sensei\Blocks\Course_Theme;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use \Sensei_Blocks;
+
+/**
+ * Class Next_Lesson is responsible for rendering the 'Next Lesson >' blocks.
+ */
+class Next_Lesson {
+
+	/**
+	 * The right chevron icon.
+	 *
+	 * @var string
+	 */
+	public static $icon = '<svg viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<path d="M0.999999 1.00002L6 6.50002L1 12" stroke="#1E1E1E" stroke-width="1.5"/>
+						   </svg>';
+
+	/**
+	 * Next_Lesson constructor.
+	 */
+	public function __construct() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/course-theme-next-lesson',
+			[
+				'render_callback' => [ $this, 'render' ],
+			]
+		);
+	}
+
+	/**
+	 * Renders the block.
+	 *
+	 * @param array $attributes The block attributes.
+	 *
+	 * @access private
+	 *
+	 * @return string The block HTML.
+	 */
+	public function render( array $attributes = [] ) : string {
+		$lesson = get_post();
+
+		if ( empty( $lesson ) ) {
+			return '';
+		}
+
+		$urls = sensei_get_prev_next_lessons( $lesson->ID );
+
+		if ( empty( $urls['next']['url'] ) ) {
+			return '';
+		}
+		$url  = esc_url( $urls['next']['url'] );
+		$text = $attributes['text'] ?? __( 'Next Lesson', 'sensei-lms' );
+		$text = wp_kses_post( $text );
+		$icon = self::$icon;
+
+		return ( "
+			<a class='sensei-course-theme-prev-next-lesson-a sensei-course-theme-prev-next-lesson-a__next' href='{$url}'>
+				<span class='sensei-course-theme-prev-next-lesson-text sensei-course-theme-prev-next-lesson-text__next'>
+					{$text}
+				</span>
+				{$icon}
+			</a>
+		" );
+	}
+
+
+}

--- a/includes/blocks/course-theme/class-prev-lesson.php
+++ b/includes/blocks/course-theme/class-prev-lesson.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * File containing the Prev_Lesson class.
+ *
+ * @package sensei
+ * @since
+ */
+
+namespace Sensei\Blocks\Course_Theme;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use \Sensei_Blocks;
+
+/**
+ * Class Prev_Lesson is responsible for rendering the '< Prev Lesson | Next Lesson >' blocks.
+ */
+class Prev_Lesson {
+
+	/**
+	 * The left chevron icon.
+	 *
+	 * @var string
+	 */
+	public static $icon = '<svg viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+							<path d="M7 1.00002L2 6.50002L7 12" stroke="#1E1E1E" stroke-width="1.5"/>
+						   </svg>';
+
+	/**
+	 * Prev_Lesson constructor.
+	 */
+	public function __construct() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/course-theme-prev-lesson',
+			[
+				'render_callback' => [ $this, 'render' ],
+			]
+		);
+	}
+
+	/**
+	 * Renders the block.
+	 *
+	 * @param array $attributes The block attributes.
+	 *
+	 * @access private
+	 *
+	 * @return string The block HTML.
+	 */
+	public function render( array $attributes = [] ) : string {
+		$lesson = get_post();
+
+		if ( empty( $lesson ) ) {
+			return '';
+		}
+
+		$urls = sensei_get_prev_next_lessons( $lesson->ID );
+
+		if ( empty( $urls['previous']['url'] ) ) {
+			return '';
+		}
+		$url  = esc_url( $urls['previous']['url'] );
+		$text = $attributes['text'] ?? __( 'Previous Lesson', 'sensei-lms' );
+		$text = wp_kses_post( $text );
+		$icon = self::$icon;
+
+		return ( "
+			<a class='sensei-course-theme-prev-next-lesson-a sensei-course-theme-prev-next-lesson-a__prev' href='{$url}'>
+				{$icon}
+				<span class='sensei-course-theme-prev-next-lesson-text sensei-course-theme-prev-next-lesson-text__prev'>
+					{$text}
+				</span>
+			</a>
+		" );
+	}
+}

--- a/includes/blocks/course-theme/class-prev-next-lesson.php
+++ b/includes/blocks/course-theme/class-prev-next-lesson.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * File containing the Prev_Next_Lesson class.
+ *
+ * @package sensei
+ * @since
+ */
+
+namespace Sensei\Blocks\Course_Theme;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use \Sensei_Blocks;
+use \Sensei\Blocks\Course_Theme\Prev_Lesson;
+use \Sensei\Blocks\Course_Theme\Next_Lesson;
+
+/**
+ * Class Prev_Next_Lesson is responsible for rendering the '< Prev Lesson | Next Lesson >' blocks.
+ */
+class Prev_Next_Lesson {
+
+	/**
+	 * Reference to the previous lesson button block.
+	 *
+	 * @var Sensei_CT_Prev_Lesson_Block
+	 */
+	private $prev = null;
+
+	/**
+	 * Reference to the previous lesson button block.
+	 *
+	 * @var Sensei_CT_Next_Lesson_Block
+	 */
+	private $next = null;
+
+	/**
+	 * Prev_Next_Lesson constructor.
+	 *
+	 * @param Prev_Lesson $prev The previous lesson block.
+	 * @param Next_Lesson $next The next lesson block.
+	 */
+	public function __construct( Prev_Lesson $prev, Next_Lesson $next ) {
+		$this->prev = $prev;
+		$this->next = $next;
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/course-theme-prev-next-lesson',
+			[
+				'render_callback' => [ $this, 'render' ],
+			]
+		);
+	}
+
+	/**
+	 * Renders the block.
+	 *
+	 * @return string The block HTML.
+	 */
+	public function render() : string {
+		$prev = $this->prev->render();
+		$next = $this->next->render();
+		return "<div  class='sensei-course-theme-prev-next-lesson-container'>$prev $next</div>";
+	}
+}

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -91,88 +91,88 @@ class Sensei_Autoloader {
 			/**
 			 * Main Sensei class
 			 */
-			'Sensei_Main'                                => 'class-sensei.php',
+			'Sensei_Main'                                 => 'class-sensei.php',
 
 			/**
 			 * Emails
 			 */
-			'Sensei_Email_Learner_Completed_Course'      => 'emails/class-sensei-email-learner-completed-course.php',
-			'Sensei_Email_Learner_Graded_Quiz'           => 'emails/class-sensei-email-learner-graded-quiz.php',
-			'Sensei_Email_New_Message_Reply'             => 'emails/class-sensei-email-new-message-reply.php',
-			'Sensei_Email_Teacher_Completed_Course'      => 'emails/class-sensei-email-teacher-completed-course.php',
-			'Sensei_Email_Teacher_Completed_Lesson'      => 'emails/class-sensei-email-teacher-completed-lesson.php',
-			'Sensei_Email_Teacher_New_Course_Assignment' => 'emails/class-sensei-email-teacher-new-course-assignment.php',
-			'Sensei_Email_Teacher_New_Message'           => 'emails/class-sensei-email-teacher-new-message.php',
-			'Sensei_Email_Teacher_Quiz_Submitted'        => 'emails/class-sensei-email-teacher-quiz-submitted.php',
-			'Sensei_Email_Teacher_Started_Course'        => 'emails/class-sensei-email-teacher-started-course.php',
+			'Sensei_Email_Learner_Completed_Course'       => 'emails/class-sensei-email-learner-completed-course.php',
+			'Sensei_Email_Learner_Graded_Quiz'            => 'emails/class-sensei-email-learner-graded-quiz.php',
+			'Sensei_Email_New_Message_Reply'              => 'emails/class-sensei-email-new-message-reply.php',
+			'Sensei_Email_Teacher_Completed_Course'       => 'emails/class-sensei-email-teacher-completed-course.php',
+			'Sensei_Email_Teacher_Completed_Lesson'       => 'emails/class-sensei-email-teacher-completed-lesson.php',
+			'Sensei_Email_Teacher_New_Course_Assignment'  => 'emails/class-sensei-email-teacher-new-course-assignment.php',
+			'Sensei_Email_Teacher_New_Message'            => 'emails/class-sensei-email-teacher-new-message.php',
+			'Sensei_Email_Teacher_Quiz_Submitted'         => 'emails/class-sensei-email-teacher-quiz-submitted.php',
+			'Sensei_Email_Teacher_Started_Course'         => 'emails/class-sensei-email-teacher-started-course.php',
 
 			/**
 			 * Admin
 			 */
-			'Sensei_Learner_Management'                  => 'admin/class-sensei-learner-management.php',
-			'Sensei_Extensions'                          => 'admin/class-sensei-extensions.php',
-			'Sensei_Exit_Survey'                         => 'admin/class-sensei-exit-survey.php',
-			'Sensei_WCPC_Prompt'                         => 'admin/class-sensei-wcpc-prompt.php',
+			'Sensei_Learner_Management'                   => 'admin/class-sensei-learner-management.php',
+			'Sensei_Extensions'                           => 'admin/class-sensei-extensions.php',
+			'Sensei_Exit_Survey'                          => 'admin/class-sensei-exit-survey.php',
+			'Sensei_WCPC_Prompt'                          => 'admin/class-sensei-wcpc-prompt.php',
 			'Sensei_Learners_Admin_Bulk_Actions_Controller' => 'admin/class-sensei-learners-admin-bulk-actions-controller.php',
-			'Sensei_Learners_Admin_Bulk_Actions_View'    => 'admin/class-sensei-learners-admin-bulk-actions-view.php',
-			'Sensei_Learners_Main'                       => 'admin/class-sensei-learners-main.php',
-			'Sensei_Email_Signup_Form'                   => 'email-signup/class-sensei-email-signup-form.php', // @deprecated since 3.1.0
-			'Sensei_Setup_Wizard'                        => 'admin/class-sensei-setup-wizard.php',
-			'Sensei_Setup_Wizard_Pages'                  => 'admin/class-sensei-setup-wizard-pages.php',
-			'Sensei_Plugins_Installation'                => 'admin/class-sensei-plugins-installation.php',
-			'Sensei_Status'                              => 'admin/class-sensei-status.php',
-			'Sensei_WCCOM_Connect_Notice'                => 'admin/class-sensei-wccom-connect-notice.php',
-			'Sensei_Admin_Notices'                       => 'admin/class-sensei-admin-notices.php',
+			'Sensei_Learners_Admin_Bulk_Actions_View'     => 'admin/class-sensei-learners-admin-bulk-actions-view.php',
+			'Sensei_Learners_Main'                        => 'admin/class-sensei-learners-main.php',
+			'Sensei_Email_Signup_Form'                    => 'email-signup/class-sensei-email-signup-form.php', // @deprecated since 3.1.0
+			'Sensei_Setup_Wizard'                         => 'admin/class-sensei-setup-wizard.php',
+			'Sensei_Setup_Wizard_Pages'                   => 'admin/class-sensei-setup-wizard-pages.php',
+			'Sensei_Plugins_Installation'                 => 'admin/class-sensei-plugins-installation.php',
+			'Sensei_Status'                               => 'admin/class-sensei-status.php',
+			'Sensei_WCCOM_Connect_Notice'                 => 'admin/class-sensei-wccom-connect-notice.php',
+			'Sensei_Admin_Notices'                        => 'admin/class-sensei-admin-notices.php',
 
 			/**
 			 * Admin Tools
 			 */
-			'Sensei_Tools'                               => 'admin/class-sensei-tools.php',
-			'Sensei_Tool_Interface'                      => 'admin/tools/class-sensei-tool-interface.php',
-			'Sensei_Tool_Interactive_Interface'          => 'admin/tools/class-sensei-tool-interactive-interface.php',
-			'Sensei_Tool_Recalculate_Course_Enrolment'   => 'admin/tools/class-sensei-tool-recalculate-course-enrolment.php',
-			'Sensei_Tool_Recalculate_Enrolment'          => 'admin/tools/class-sensei-tool-recalculate-enrolment.php',
-			'Sensei_Tool_Ensure_Roles'                   => 'admin/tools/class-sensei-tool-ensure-roles.php',
-			'Sensei_Tool_Remove_Deleted_User_Data'       => 'admin/tools/class-sensei-tool-remove-deleted-user-data.php',
-			'Sensei_Tool_Module_Slugs_Mismatch'          => 'admin/tools/class-sensei-tool-module-slugs-mismatch.php',
-			'Sensei_Tool_Enrolment_Debug'                => 'admin/tools/class-sensei-tool-enrolment-debug.php',
+			'Sensei_Tools'                                => 'admin/class-sensei-tools.php',
+			'Sensei_Tool_Interface'                       => 'admin/tools/class-sensei-tool-interface.php',
+			'Sensei_Tool_Interactive_Interface'           => 'admin/tools/class-sensei-tool-interactive-interface.php',
+			'Sensei_Tool_Recalculate_Course_Enrolment'    => 'admin/tools/class-sensei-tool-recalculate-course-enrolment.php',
+			'Sensei_Tool_Recalculate_Enrolment'           => 'admin/tools/class-sensei-tool-recalculate-enrolment.php',
+			'Sensei_Tool_Ensure_Roles'                    => 'admin/tools/class-sensei-tool-ensure-roles.php',
+			'Sensei_Tool_Remove_Deleted_User_Data'        => 'admin/tools/class-sensei-tool-remove-deleted-user-data.php',
+			'Sensei_Tool_Module_Slugs_Mismatch'           => 'admin/tools/class-sensei-tool-module-slugs-mismatch.php',
+			'Sensei_Tool_Enrolment_Debug'                 => 'admin/tools/class-sensei-tool-enrolment-debug.php',
 
 			/**
 			 * Shortcodes
 			 */
-			'Sensei_Shortcode_Loader'                    => 'shortcodes/class-sensei-shortcode-loader.php',
-			'Sensei_Shortcode_Interface'                 => 'shortcodes/interface-sensei-shortcode.php',
-			'Sensei_Shortcode_Featured_Courses'          => 'shortcodes/class-sensei-shortcode-featured-courses.php',
-			'Sensei_Shortcode_User_Courses'              => 'shortcodes/class-sensei-shortcode-user-courses.php',
-			'Sensei_Shortcode_Courses'                   => 'shortcodes/class-sensei-shortcode-courses.php',
-			'Sensei_Shortcode_Teachers'                  => 'shortcodes/class-sensei-shortcode-teachers.php',
-			'Sensei_Shortcode_User_Messages'             => 'shortcodes/class-sensei-shortcode-user-messages.php',
-			'Sensei_Shortcode_Course_Page'               => 'shortcodes/class-sensei-shortcode-course-page.php',
-			'Sensei_Shortcode_Lesson_Page'               => 'shortcodes/class-sensei-shortcode-lesson-page.php',
-			'Sensei_Shortcode_Course_Categories'         => 'shortcodes/class-sensei-shortcode-course-categories.php',
-			'Sensei_Shortcode_Unpurchased_Courses'       => 'shortcodes/class-sensei-shortcode-unpurchased-courses.php',
-			'Sensei_Legacy_Shortcodes'                   => 'shortcodes/class-sensei-legacy-shortcodes.php',
+			'Sensei_Shortcode_Loader'                     => 'shortcodes/class-sensei-shortcode-loader.php',
+			'Sensei_Shortcode_Interface'                  => 'shortcodes/interface-sensei-shortcode.php',
+			'Sensei_Shortcode_Featured_Courses'           => 'shortcodes/class-sensei-shortcode-featured-courses.php',
+			'Sensei_Shortcode_User_Courses'               => 'shortcodes/class-sensei-shortcode-user-courses.php',
+			'Sensei_Shortcode_Courses'                    => 'shortcodes/class-sensei-shortcode-courses.php',
+			'Sensei_Shortcode_Teachers'                   => 'shortcodes/class-sensei-shortcode-teachers.php',
+			'Sensei_Shortcode_User_Messages'              => 'shortcodes/class-sensei-shortcode-user-messages.php',
+			'Sensei_Shortcode_Course_Page'                => 'shortcodes/class-sensei-shortcode-course-page.php',
+			'Sensei_Shortcode_Lesson_Page'                => 'shortcodes/class-sensei-shortcode-lesson-page.php',
+			'Sensei_Shortcode_Course_Categories'          => 'shortcodes/class-sensei-shortcode-course-categories.php',
+			'Sensei_Shortcode_Unpurchased_Courses'        => 'shortcodes/class-sensei-shortcode-unpurchased-courses.php',
+			'Sensei_Legacy_Shortcodes'                    => 'shortcodes/class-sensei-legacy-shortcodes.php',
 
 			/**
 			 * Renderers
 			 */
-			'Sensei_Renderer_Interface'                  => 'renderers/interface-sensei-renderer.php',
-			'Sensei_Renderer_Single_Post'                => 'renderers/class-sensei-renderer-single-post.php',
+			'Sensei_Renderer_Interface'                   => 'renderers/interface-sensei-renderer.php',
+			'Sensei_Renderer_Single_Post'                 => 'renderers/class-sensei-renderer-single-post.php',
 
 			/**
 			 * Update tasks.
 			 */
-			'Sensei_Update_Fix_Question_Author'          => 'update-tasks/class-sensei-update-fix-question-author.php',
+			'Sensei_Update_Fix_Question_Author'           => 'update-tasks/class-sensei-update-fix-question-author.php',
 			'Sensei_Update_Remove_Abandoned_Multiple_Question' => 'update-tasks/class-sensei-update-remove-abandoned-multiple-question.php',
 
 			/**
 			 * Unsupported theme handlers.
 			 */
-			'Sensei_Unsupported_Theme_Handler_Interface' => 'unsupported-theme-handlers/interface-sensei-unsupported-theme-handler.php',
+			'Sensei_Unsupported_Theme_Handler_Interface'  => 'unsupported-theme-handlers/interface-sensei-unsupported-theme-handler.php',
 			'Sensei_Unsupported_Theme_Handler_Page_Imitator' => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-page-imitator.php',
-			'Sensei_Unsupported_Theme_Handler_Utils'     => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-utils.php',
-			'Sensei_Unsupported_Theme_Handler_CPT'       => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php',
-			'Sensei_Unsupported_Theme_Handler_Module'    => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-module.php',
+			'Sensei_Unsupported_Theme_Handler_Utils'      => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-utils.php',
+			'Sensei_Unsupported_Theme_Handler_CPT'        => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-cpt.php',
+			'Sensei_Unsupported_Theme_Handler_Module'     => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-module.php',
 			'Sensei_Unsupported_Theme_Handler_Course_Results' => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-results.php',
 			'Sensei_Unsupported_Theme_Handler_Lesson_Tag_Archive' => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-lesson-tag-archive.php',
 			'Sensei_Unsupported_Theme_Handler_Teacher_Archive' => 'unsupported-theme-handlers/class-sensei-unsupported-theme-handler-teacher-archive.php',
@@ -183,23 +183,32 @@ class Sensei_Autoloader {
 			/**
 			 * Built in theme integration support
 			 */
-			'Sensei_Theme_Integration_Loader'            => 'theme-integrations/theme-integration-loader.php',
-			'Sensei__S'                                  => 'theme-integrations/underscores.php',
-			'Sensei_Twentyeleven'                        => 'theme-integrations/twentyeleven.php',
-			'Sensei_Twentytwelve'                        => 'theme-integrations/twentytwelve.php',
-			'Sensei_Twentythirteen'                      => 'theme-integrations/Twentythirteen.php',
-			'Sensei_Twentyfourteen'                      => 'theme-integrations/Twentyfourteen.php',
-			'Sensei_Twentyfifteen'                       => 'theme-integrations/Twentyfifteen.php',
-			'Sensei_Twentysixteen'                       => 'theme-integrations/Twentysixteen.php',
-			'Sensei_Storefront'                          => 'theme-integrations/Storefront.php',
+			'Sensei_Theme_Integration_Loader'             => 'theme-integrations/theme-integration-loader.php',
+			'Sensei__S'                                   => 'theme-integrations/underscores.php',
+			'Sensei_Twentyeleven'                         => 'theme-integrations/twentyeleven.php',
+			'Sensei_Twentytwelve'                         => 'theme-integrations/twentytwelve.php',
+			'Sensei_Twentythirteen'                       => 'theme-integrations/Twentythirteen.php',
+			'Sensei_Twentyfourteen'                       => 'theme-integrations/Twentyfourteen.php',
+			'Sensei_Twentyfifteen'                        => 'theme-integrations/Twentyfifteen.php',
+			'Sensei_Twentysixteen'                        => 'theme-integrations/Twentysixteen.php',
+			'Sensei_Storefront'                           => 'theme-integrations/Storefront.php',
 
 			/**
 			* WPML
 			*/
-			'Sensei_WPML'                                => 'wpml/class-sensei-wpml.php',
+			'Sensei_WPML'                                 => 'wpml/class-sensei-wpml.php',
 
+			/**
+			 * Course Theme
+			 */
+			'Sensei\Blocks\Course_Theme'                  => 'blocks/course-theme/class-course-theme.php',
+			'Sensei\Blocks\Course_Theme\Prev_Next_Lesson' => 'blocks/course-theme/class-prev-next-lesson.php',
+			'Sensei\Blocks\Course_Theme\Prev_Lesson'      => 'blocks/course-theme/class-prev-lesson.php',
+			'Sensei\Blocks\Course_Theme\Next_Lesson'      => 'blocks/course-theme/class-next-lesson.php',
 		);
 	}
+
+
 
 	/**
 	 * Autoload all sensei files as the class names are used.

--- a/includes/class-sensei-course-theme.php
+++ b/includes/class-sensei-course-theme.php
@@ -56,6 +56,9 @@ class Sensei_Course_Theme {
 			return;
 		}
 
+		// Init blocks.
+		new \Sensei\Blocks\Course_Theme();
+
 		add_action( 'init', [ $this, 'register_post_meta' ] );
 	}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,7 @@ const files = [
 	'css/ranges.css',
 	'css/settings.scss',
 	'css/meta-box-quiz-editor.scss',
+	'css/sensei-course-theme.scss',
 ];
 
 function getName( filename ) {


### PR DESCRIPTION
Fixes #4370 

### Changes proposed in this Pull Request

* Previous Lesson | Next Lesson buttons block for Course Theme.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Build the assets `npm run build:assets`.
* Create lesson(s) and add `<!-- wp:sensei-lms/course-theme-prev-next-lesson /-->` block into it via code editor and save the lesson.
* Visit the lesson page and confirm that both "Previous Lesson" and "Next Lesson" links work properly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/2578542/142196290-7b5e4135-311c-481b-9d59-5b7decf20456.mp4

