### PR TITLE
Update grading screen with answer feedback changes

### DIFF
--- a/assets/js/grading-general.js
+++ b/assets/js/grading-general.js
@@ -63,6 +63,27 @@ jQuery( document ).ready( function ( $ ) {
 		}
 	};
 
+	jQuery.fn.updateFeedback = function () {
+		jQuery( '.question_box' ).each( function () {
+			var question_id = jQuery( this ).find( '.question_id' ).val();
+			var question_grade = parseInt(
+				jQuery( this )
+					.find( '#question_' + question_id + '_grade' )
+					.val()
+			);
+
+			var correctFeedback = jQuery( this ).find(
+				'.answer-feedback-correct'
+			);
+			var incorrectFeedback = jQuery( this ).find(
+				'.answer-feedback-incorrect'
+			);
+
+			correctFeedback.toggle( 0 < question_grade );
+			incorrectFeedback.toggle( ! question_grade );
+		} );
+	};
+
 	/**
 	 * Automatically grades questions where possible
 	 * @return void
@@ -175,6 +196,7 @@ jQuery( document ).ready( function ( $ ) {
 		} );
 
 		$.fn.calculateTotalGrade();
+		$.fn.updateFeedback();
 	};
 
 	/**
@@ -193,6 +215,7 @@ jQuery( document ).ready( function ( $ ) {
 			.removeClass( 'ungraded' );
 		jQuery( '.question-grade' ).val( '0' );
 		jQuery.fn.calculateTotalGrade();
+		jQuery.fn.updateFeedback();
 	};
 
 	jQuery.fn.getQueryVariable = function ( variable ) {
@@ -314,6 +337,7 @@ jQuery( document ).ready( function ( $ ) {
 				.val( 0 );
 		}
 		jQuery.fn.calculateTotalGrade();
+		jQuery.fn.updateFeedback();
 	} );
 
 	/**
@@ -363,6 +387,7 @@ jQuery( document ).ready( function ( $ ) {
 			).attr( 'checked', false );
 		}
 		jQuery.fn.calculateTotalGrade();
+		jQuery.fn.updateFeedback();
 	} );
 
 	/**
@@ -399,6 +424,10 @@ jQuery( document ).ready( function ( $ ) {
 			jQuery.fn.autoGrade();
 		}
 	);
+
+	if ( jQuery( '.sensei-grading-main' ).length ) {
+		jQuery.fn.updateFeedback();
+	}
 
 	/***************************************************************************************************
 	 * 	4 - Load Select2 Dropdowns.

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -134,10 +134,10 @@ class Sensei_Grading_User_Quiz {
 
 				$type = Sensei()->question->get_question_type( $question_id );
 
-				$custom_feedback    = Sensei()->quiz->get_user_answers_feedback( $lesson_id, $user_id );
-				$custom_feedback    = $custom_feedback[ $question_id ] ?? "";
-				$correct_feedback   = Sensei_Quiz::get_correct_answer_feedback( $question_id );
-				$incorrect_feedback = Sensei_Quiz::get_incorrect_answer_feedback( $question_id );
+				$custom_feedback       = Sensei()->quiz->get_user_answers_feedback( $lesson_id, $user_id );
+				$custom_feedback       = $custom_feedback[ $question_id ] ?? '';
+				$correct_feedback      = Sensei_Quiz::get_correct_answer_feedback( $question_id );
+				$incorrect_feedback    = Sensei_Quiz::get_incorrect_answer_feedback( $question_id );
 				$question_answer_notes = Sensei()->quiz->get_user_question_feedback( $lesson_id, $question_id, $user_id );
 
 				if ( ! $correct_feedback && ! $incorrect_feedback ) {

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -145,7 +145,7 @@ class Sensei_Grading_User_Quiz {
 				}
 
 				$question_grade_total = Sensei()->question->get_question_grade( $question_id );
-				$quiz_grade_total     += $question_grade_total;
+				$quiz_grade_total    += $question_grade_total;
 
 				$right_answer        = get_post_meta( $question_id, '_question_right_answer', true );
 				$user_answer_content = Sensei()->quiz->get_user_question_answer( $lesson_id, $question_id, $user_id );

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -134,10 +134,18 @@ class Sensei_Grading_User_Quiz {
 
 				$type = Sensei()->question->get_question_type( $question_id );
 
+				$custom_feedback    = Sensei()->quiz->get_user_answers_feedback( $lesson_id, $user_id );
+				$custom_feedback    = $custom_feedback[ $question_id ] ?? "";
+				$correct_feedback   = Sensei_Quiz::get_correct_answer_feedback( $question_id );
+				$incorrect_feedback = Sensei_Quiz::get_incorrect_answer_feedback( $question_id );
 				$question_answer_notes = Sensei()->quiz->get_user_question_feedback( $lesson_id, $question_id, $user_id );
 
+				if ( ! $correct_feedback && ! $incorrect_feedback ) {
+					$custom_feedback = $question_answer_notes;
+				}
+
 				$question_grade_total = Sensei()->question->get_question_grade( $question_id );
-				$quiz_grade_total    += $question_grade_total;
+				$quiz_grade_total     += $question_grade_total;
 
 				$right_answer        = get_post_meta( $question_id, '_question_right_answer', true );
 				$user_answer_content = Sensei()->quiz->get_user_question_answer( $lesson_id, $question_id, $user_id );
@@ -276,7 +284,7 @@ class Sensei_Grading_User_Quiz {
 						<h4><?php echo wp_kses_post( apply_filters( 'sensei_question_title', $question->post_title ) ); ?></h4>
 						<?php
 						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped before core filter applied.
-						echo apply_filters( 'the_content', wp_kses_post( $question->post_content ) );
+						echo Sensei_Question::get_the_question_description( $question_id );
 						?>
 						<p class="user-answer">
 						<?php
@@ -313,7 +321,9 @@ class Sensei_Grading_User_Quiz {
 						</div>
 						<div class="answer-notes">
 							<h5><?php esc_html_e( 'Answer Feedback', 'sensei-lms' ); ?></h5>
-							<textarea class="correct-answer" name="questions_feedback[<?php echo esc_attr( $question_id ); ?>]" placeholder="<?php esc_attr_e( 'Add feedback here...', 'sensei-lms' ); ?>"><?php echo esc_html( $question_answer_notes ); ?></textarea>
+							<div class="answer-feedback-correct"><?php echo wp_kses_post( $correct_feedback ); ?></div>
+							<div class="answer-feedback-incorrect"><?php echo wp_kses_post( $incorrect_feedback ); ?></div>
+							<textarea class="correct-answer" name="questions_feedback[<?php echo esc_attr( $question_id ); ?>]" placeholder="<?php esc_attr_e( 'Add custom feedback here...', 'sensei-lms' ); ?>"><?php echo esc_html( $custom_feedback ); ?></textarea>
 						</div>
 					</div>
 				</div>

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1151,7 +1151,7 @@ class Sensei_Quiz {
 	/**
 	 * Get a top-level inner block.
 	 *
-	 * @param int $question_id
+	 * @param int    $question_id
 	 * @param string $block_name
 	 *
 	 * @return array|null


### PR DESCRIPTION
Part of #4336 

### Changes proposed in this Pull Request

* Show the contents of correct/incorrect answer feedback block in the grading screen
* Fix rendering the question description block

### Testing instructions

* Update feedback for a quiz question in the block editor using the new correct/incorrect answer feedback blocks (see #4354 )
* Take the quiz with a learner
* Grade the quiz in WP-admin > Grading > [Grade] button for the learner
* Make sure the correct/incorrect feedback is displayed when marking the question as correct/incorrect
* Add a custom feedback text: make sure the learner sees this instead of the original

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![QuickTime movie](https://user-images.githubusercontent.com/176949/142232885-fca86724-740f-4e1f-8fac-20dbdc0e6778.gif)


