### PR TITLE
Add/course theme progress counter

### DIFF
--- a/assets/images/chevron-left.svg
+++ b/assets/images/chevron-left.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path d="M7 1.00002L2 6.50002L7 12" stroke="#1E1E1E" stroke-width="1.5"/>
+</svg>

--- a/assets/images/chevron-left.svg
+++ b/assets/images/chevron-left.svg
@@ -1,3 +1,3 @@
 <svg viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<path d="M7 1.00002L2 6.50002L7 12" stroke="#1E1E1E" stroke-width="1.5"/>
+	<path d="M7 1.00002L2 6.50002L7 12" stroke="currentColor" stroke-width="1.5"/>
 </svg>

--- a/assets/images/chevron-right.svg
+++ b/assets/images/chevron-right.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path d="M0.999999 1.00002L6 6.50002L1 12" stroke="#1E1E1E" stroke-width="1.5"/>
+</svg>

--- a/assets/images/chevron-right.svg
+++ b/assets/images/chevron-right.svg
@@ -1,3 +1,3 @@
 <svg viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<path d="M0.999999 1.00002L6 6.50002L1 12" stroke="#1E1E1E" stroke-width="1.5"/>
+	<path d="M0.999999 1.00002L6 6.50002L1 12" stroke="currentColor" stroke-width="1.5"/>
 </svg>

--- a/includes/blocks/class-sensei-course-progress-block.php
+++ b/includes/blocks/class-sensei-course-progress-block.php
@@ -51,9 +51,11 @@ class Sensei_Course_Progress_Block {
 			return '';
 		}
 
-		$completed     = count( Sensei()->course->get_completed_lesson_ids( $course_id ) );
-		$total_lessons = count( Sensei()->course->course_lessons( $course_id ) );
-		$percentage    = Sensei_Utils::quotient_as_absolute_rounded_percentage( $completed, $total_lessons );
+		list(
+			'lessons_count'                => $total_lessons,
+			'completed_lessons_count'      => $completed,
+			'completed_lessons_percentage' => $percentage,
+		) = \Sensei()->course->get_progress_stats( $course_id );
 
 		$text_css           = Sensei_Block_Helpers::build_styles( $attributes );
 		$bar_background_css = Sensei_Block_Helpers::build_styles(

--- a/includes/blocks/course-theme/class-course-progress-counter.php
+++ b/includes/blocks/course-theme/class-course-progress-counter.php
@@ -38,17 +38,9 @@ class Course_Progress_Counter {
 	 * @return string The block HTML.
 	 */
 	public function render() : string {
-		$post   = get_post();
-		$course = $post;
-
-		if ( 'lesson' === $post->post_type ) {
-			$course_id = \Sensei()->lesson->get_course_id( $post->ID );
-			$course    = get_post( $course_id );
-		}
-
-		$stats = \Sensei()->course->get_progress_stats( $course->ID );
-
-		$output = sprintf(
+		$course_id = \Sensei_Utils::get_current_course();
+		$stats     = \Sensei()->course->get_progress_stats( $course_id );
+		$output    = sprintf(
 			/* translators: Placeholder %1$d is the completed lessons count, %2$d is the total lessons count and %3$d is the percentage of completed lessons. */
 			__( '%1$d of %2$d lessons complete (%3$d%%)', 'sensei-lms' ),
 			$stats['completed_lessons_count'],

--- a/includes/blocks/course-theme/class-course-progress-counter.php
+++ b/includes/blocks/course-theme/class-course-progress-counter.php
@@ -39,8 +39,12 @@ class Course_Progress_Counter {
 	 */
 	public function render() : string {
 		$course_id = \Sensei_Utils::get_current_course();
-		$stats     = \Sensei()->course->get_progress_stats( $course_id );
-		$output    = sprintf(
+		if ( ! $course_id ) {
+			return '';
+		}
+
+		$stats  = \Sensei()->course->get_progress_stats( $course_id );
+		$output = sprintf(
 			/* translators: Placeholder %1$d is the completed lessons count, %2$d is the total lessons count and %3$d is the percentage of completed lessons. */
 			__( '%1$d of %2$d lessons complete (%3$d%%)', 'sensei-lms' ),
 			$stats['completed_lessons_count'],

--- a/includes/blocks/course-theme/class-course-progress-counter.php
+++ b/includes/blocks/course-theme/class-course-progress-counter.php
@@ -46,16 +46,14 @@ class Course_Progress_Counter {
 			$course    = get_post( $course_id );
 		}
 
-		$lessons_count                = count( \Sensei()->course->course_lessons( $course->ID, null, 'ids' ) );
-		$completed_lessons_count      = count( \Sensei()->course->get_completed_lesson_ids( $course->ID ) );
-		$completed_lessons_percentage = \Sensei_Utils::quotient_as_absolute_rounded_percentage( $completed_lessons_count, $lessons_count, 2 );
+		$stats = \Sensei()->course->get_progress_stats( $course->ID );
 
 		$output = sprintf(
 			/* translators: Placeholder %1$d is the completed lessons count, %2$d is the total lessons count and %3$d is the percentage of completed lessons. */
 			__( '%1$d of %2$d lessons complete (%3$d%%)', 'sensei-lms' ),
-			$completed_lessons_count,
-			$lessons_count,
-			$completed_lessons_percentage
+			$stats['completed_lessons_count'],
+			$stats['lessons_count'],
+			$stats['completed_lessons_percentage']
 		);
 
 		return ( "

--- a/includes/blocks/course-theme/class-course-progress-counter.php
+++ b/includes/blocks/course-theme/class-course-progress-counter.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * File containing the Course_Progress class.
+ * File containing the Course_Progress_Counter class.
  *
  * @package sensei
- * @since
+ * @since 3.13.4
  */
 
 namespace Sensei\Blocks\Course_Theme;
@@ -15,11 +15,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 use \Sensei_Blocks;
 
 /**
- * Class Course_Progress is responsible for rendering the '< Prev Lesson | Next Lesson >' blocks.
+ * Class Course_Progress_Counter is responsible for rendering the '< Prev Lesson | Next Lesson >' blocks.
  */
 class Course_Progress_Counter {
 	/**
-	 * Course_Progress constructor.
+	 * Course_Progress_Counter constructor.
 	 */
 	public function __construct() {
 		Sensei_Blocks::register_sensei_block(

--- a/includes/blocks/course-theme/class-course-progress-counter.php
+++ b/includes/blocks/course-theme/class-course-progress-counter.php
@@ -23,7 +23,7 @@ class Course_Progress_Counter {
 	 */
 	public function __construct() {
 		Sensei_Blocks::register_sensei_block(
-			'sensei-lms/course-theme-course-progress',
+			'sensei-lms/course-theme-course-progress-counter',
 			[
 				'render_callback' => [ $this, 'render' ],
 			]

--- a/includes/blocks/course-theme/class-course-progress-counter.php
+++ b/includes/blocks/course-theme/class-course-progress-counter.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * File containing the Course_Progress class.
+ *
+ * @package sensei
+ * @since
+ */
+
+namespace Sensei\Blocks\Course_Theme;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use \Sensei_Blocks;
+
+/**
+ * Class Course_Progress is responsible for rendering the '< Prev Lesson | Next Lesson >' blocks.
+ */
+class Course_Progress_Counter {
+	/**
+	 * Course_Progress constructor.
+	 */
+	public function __construct() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/course-theme-course-progress',
+			[
+				'render_callback' => [ $this, 'render' ],
+			]
+		);
+	}
+
+	/**
+	 * Renders the block.
+	 *
+	 * @access private
+	 *
+	 * @return string The block HTML.
+	 */
+	public function render() : string {
+		$post   = get_post();
+		$course = $post;
+
+		if ( 'lesson' === $post->post_type ) {
+			$course_id = \Sensei()->lesson->get_course_id( $post->ID );
+			$course    = get_post( $course_id );
+		}
+
+		$lessons_count                = count( \Sensei()->course->course_lessons( $course->ID, null, 'ids' ) );
+		$completed_lessons_count      = count( \Sensei()->course->get_completed_lesson_ids( $course->ID ) );
+		$completed_lessons_percentage = \Sensei_Utils::quotient_as_absolute_rounded_percentage( $completed_lessons_count, $lessons_count, 2 );
+
+		$output = sprintf(
+			/* translators: Placeholder %1$d is the completed lessons count, %2$d is the total lessons count and %3$d is the percentage of completed lessons. */
+			__( '%1$d of %2$d lessons complete (%3$d%%)', 'sensei-lms' ),
+			$completed_lessons_count,
+			$lessons_count,
+			$completed_lessons_percentage
+		);
+
+		return ( "
+			<div class='sensei-course-theme-course-progress'>
+				{$output}
+			</div>
+		" );
+	}
+}

--- a/includes/blocks/course-theme/class-course-progress-counter.php
+++ b/includes/blocks/course-theme/class-course-progress-counter.php
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use \Sensei_Blocks;
 
 /**
- * Class Course_Progress_Counter is responsible for rendering the '< Prev Lesson | Next Lesson >' blocks.
+ * Class Course_Progress_Counter is responsible for rendering the '1 of 10 lessons complete (10%)' block.
  */
 class Course_Progress_Counter {
 	/**

--- a/includes/blocks/course-theme/class-course-theme.php
+++ b/includes/blocks/course-theme/class-course-theme.php
@@ -17,6 +17,7 @@ use \Sensei\Blocks\Course_Theme\Prev_Lesson;
 use \Sensei\Blocks\Course_Theme\Next_Lesson;
 use \Sensei\Blocks\Course_Theme\Prev_Next_Lesson;
 use \Sensei\Blocks\Course_Theme\Quiz_Back_To_Lesson;
+use \Sensei\Blocks\Course_Theme\Course_Progress_Counter;
 
 /**
  * Class Sensei_Course_Theme_Blocks
@@ -26,7 +27,7 @@ class Course_Theme extends Sensei_Blocks_Initializer {
 	 * Sensei_Blocks constructor.
 	 */
 	public function __construct() {
-		parent::__construct( [ 'lesson', 'quiz' ] );
+		parent::__construct( [ 'lesson', 'course', 'quiz' ] );
 	}
 
 	/**
@@ -57,11 +58,10 @@ class Course_Theme extends Sensei_Blocks_Initializer {
 	 */
 	public function initialize_blocks() {
 		if ( 'lesson' === get_post_type() ) {
-			$prev = new Prev_Lesson();
-			$next = new Next_Lesson();
-			new Prev_Next_Lesson( $prev, $next );
+			new Prev_Next_Lesson( new Prev_Lesson(), new Next_Lesson() );
 		} elseif ( 'quiz' === get_post_type() ) {
 			new Quiz_Back_To_Lesson();
 		}
+		new Course_Progress_Counter();
 	}
 }

--- a/includes/blocks/course-theme/class-course-theme.php
+++ b/includes/blocks/course-theme/class-course-theme.php
@@ -58,7 +58,9 @@ class Course_Theme extends Sensei_Blocks_Initializer {
 	 */
 	public function initialize_blocks() {
 		if ( 'lesson' === get_post_type() ) {
-			new Prev_Next_Lesson( new Prev_Lesson(), new Next_Lesson() );
+			new Prev_Lesson();
+			new Next_Lesson();
+			new Prev_Next_Lesson();
 		} elseif ( 'quiz' === get_post_type() ) {
 			new Quiz_Back_To_Lesson();
 		}

--- a/includes/blocks/course-theme/class-course-theme.php
+++ b/includes/blocks/course-theme/class-course-theme.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the class Sensei_CT_Blocks.
+ * File containing the class Course_Theme.
  *
  * @package sensei
  */
@@ -20,11 +20,11 @@ use \Sensei\Blocks\Course_Theme\Quiz_Back_To_Lesson;
 use \Sensei\Blocks\Course_Theme\Course_Progress_Counter;
 
 /**
- * Class Sensei_Course_Theme_Blocks
+ * Class Course_Theme
  */
 class Course_Theme extends Sensei_Blocks_Initializer {
 	/**
-	 * Sensei_Blocks constructor.
+	 * Course_Theme constructor.
 	 */
 	public function __construct() {
 		parent::__construct( [ 'lesson', 'course', 'quiz' ] );

--- a/includes/blocks/course-theme/class-next-lesson.php
+++ b/includes/blocks/course-theme/class-next-lesson.php
@@ -15,18 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 use \Sensei_Blocks;
 
 /**
- * Class Next_Lesson is responsible for rendering the 'Next Lesson >' blocks.
+ * Class Next_Lesson is responsible for rendering the 'Next Lesson >' block.
  */
 class Next_Lesson {
-
-	/**
-	 * The right chevron icon.
-	 *
-	 * @var string
-	 */
-	public static $icon = '<svg viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
-							<path d="M0.999999 1.00002L6 6.50002L1 12" stroke="#1E1E1E" stroke-width="1.5"/>
-						   </svg>';
 
 	/**
 	 * Next_Lesson constructor.
@@ -64,7 +55,7 @@ class Next_Lesson {
 		$url  = esc_url( $urls['next']['url'] );
 		$text = $attributes['text'] ?? __( 'Next Lesson', 'sensei-lms' );
 		$text = wp_kses_post( $text );
-		$icon = self::$icon;
+		$icon = \Sensei_Utils::icon( 'chevron-right' );
 
 		return ( "
 			<a class='sensei-course-theme-prev-next-lesson-a sensei-course-theme-prev-next-lesson-a__next' href='{$url}'>

--- a/includes/blocks/course-theme/class-next-lesson.php
+++ b/includes/blocks/course-theme/class-next-lesson.php
@@ -55,7 +55,7 @@ class Next_Lesson {
 		$url  = esc_url( $urls['next']['url'] );
 		$text = $attributes['text'] ?? __( 'Next Lesson', 'sensei-lms' );
 		$text = wp_kses_post( $text );
-		$icon = \Sensei_Utils::icon( 'chevron-right' );
+		$icon = \Sensei()->assets->get_icon( 'chevron-right' );
 
 		return ( "
 			<a class='sensei-course-theme-prev-next-lesson-a sensei-course-theme-prev-next-lesson-a__next' href='{$url}'>

--- a/includes/blocks/course-theme/class-prev-lesson.php
+++ b/includes/blocks/course-theme/class-prev-lesson.php
@@ -15,18 +15,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 use \Sensei_Blocks;
 
 /**
- * Class Prev_Lesson is responsible for rendering the '< Prev Lesson | Next Lesson >' blocks.
+ * Class Prev_Lesson is responsible for rendering the '< Prev Lesson' block.
  */
 class Prev_Lesson {
-
-	/**
-	 * The left chevron icon.
-	 *
-	 * @var string
-	 */
-	public static $icon = '<svg viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
-							<path d="M7 1.00002L2 6.50002L7 12" stroke="#1E1E1E" stroke-width="1.5"/>
-						   </svg>';
 
 	/**
 	 * Prev_Lesson constructor.
@@ -64,7 +55,7 @@ class Prev_Lesson {
 		$url  = esc_url( $urls['previous']['url'] );
 		$text = $attributes['text'] ?? __( 'Previous Lesson', 'sensei-lms' );
 		$text = wp_kses_post( $text );
-		$icon = self::$icon;
+		$icon = \Sensei_Utils::icon( 'chevron-left' );
 
 		return ( "
 			<a class='sensei-course-theme-prev-next-lesson-a sensei-course-theme-prev-next-lesson-a__prev' href='{$url}'>

--- a/includes/blocks/course-theme/class-prev-lesson.php
+++ b/includes/blocks/course-theme/class-prev-lesson.php
@@ -55,7 +55,7 @@ class Prev_Lesson {
 		$url  = esc_url( $urls['previous']['url'] );
 		$text = $attributes['text'] ?? __( 'Previous Lesson', 'sensei-lms' );
 		$text = wp_kses_post( $text );
-		$icon = \Sensei_Utils::icon( 'chevron-left' );
+		$icon = \Sensei()->assets->get_icon( 'chevron-left' );
 
 		return ( "
 			<a class='sensei-course-theme-prev-next-lesson-a sensei-course-theme-prev-next-lesson-a__prev' href='{$url}'>

--- a/includes/blocks/course-theme/class-prev-next-lesson.php
+++ b/includes/blocks/course-theme/class-prev-next-lesson.php
@@ -60,6 +60,11 @@ class Prev_Next_Lesson {
 	public function render() : string {
 		$prev = $this->prev->render();
 		$next = $this->next->render();
-		return "<div  class='sensei-course-theme-prev-next-lesson-container'>$prev $next</div>";
+		return ( "
+			<div class='sensei-course-theme-prev-next-lesson-container'>
+				{$prev}
+				{$next}
+			</div>
+		" );
 	}
 }

--- a/includes/blocks/course-theme/class-prev-next-lesson.php
+++ b/includes/blocks/course-theme/class-prev-next-lesson.php
@@ -3,7 +3,7 @@
  * File containing the Prev_Next_Lesson class.
  *
  * @package sensei
- * @since
+ * @since 3.13.4
  */
 
 namespace Sensei\Blocks\Course_Theme;
@@ -13,37 +13,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use \Sensei_Blocks;
-use \Sensei\Blocks\Course_Theme\Prev_Lesson;
-use \Sensei\Blocks\Course_Theme\Next_Lesson;
 
 /**
  * Class Prev_Next_Lesson is responsible for rendering the '< Prev Lesson | Next Lesson >' blocks.
  */
 class Prev_Next_Lesson {
-
-	/**
-	 * Reference to the previous lesson button block.
-	 *
-	 * @var Sensei_CT_Prev_Lesson_Block
-	 */
-	private $prev = null;
-
-	/**
-	 * Reference to the previous lesson button block.
-	 *
-	 * @var Sensei_CT_Next_Lesson_Block
-	 */
-	private $next = null;
-
 	/**
 	 * Prev_Next_Lesson constructor.
-	 *
-	 * @param Prev_Lesson $prev The previous lesson block.
-	 * @param Next_Lesson $next The next lesson block.
 	 */
-	public function __construct( Prev_Lesson $prev, Next_Lesson $next ) {
-		$this->prev = $prev;
-		$this->next = $next;
+	public function __construct() {
 		Sensei_Blocks::register_sensei_block(
 			'sensei-lms/course-theme-prev-next-lesson',
 			[

--- a/includes/blocks/course-theme/class-prev-next-lesson.php
+++ b/includes/blocks/course-theme/class-prev-next-lesson.php
@@ -55,15 +55,15 @@ class Prev_Next_Lesson {
 	/**
 	 * Renders the block.
 	 *
+	 * @param array  $attributes The attributes that were saved for this block.
+	 * @param string $content The content that is rendered by the inner blocks.
+	 *
 	 * @return string The block HTML.
 	 */
-	public function render() : string {
-		$prev = $this->prev->render();
-		$next = $this->next->render();
+	public function render( array $attributes, string $content ) : string {
 		return ( "
 			<div class='sensei-course-theme-prev-next-lesson-container'>
-				{$prev}
-				{$next}
+				{$content}
 			</div>
 		" );
 	}

--- a/includes/class-sensei-assets.php
+++ b/includes/class-sensei-assets.php
@@ -262,6 +262,8 @@ class Sensei_Assets {
 	 * Gets the contents of the icon file at assets/images/<name>.svg
 	 * for the given name. Or empty string if file not found.
 	 *
+	 * @since 3.13.4
+	 *
 	 * @param string $name The name of the icon file at "assets/images/<name>.svg".
 	 * @return string The icon markup.
 	 */
@@ -273,6 +275,7 @@ class Sensei_Assets {
 		// Read file inside try/catch in case the
 		// icon file is not there.
 		try {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local file usage.
 			$content = file_get_contents( $file );
 		} catch ( Exception $e ) {
 			$content = false;

--- a/includes/class-sensei-assets.php
+++ b/includes/class-sensei-assets.php
@@ -258,4 +258,30 @@ class Sensei_Assets {
 		add_filter( 'sensei_disable_styles', '__return_true' );
 	}
 
+	/**
+	 * Gets the contents of the icon file at assets/images/<name>.svg
+	 * for the given name. Or empty string if file not found.
+	 *
+	 * @param string $name The name of the icon file at "assets/images/<name>.svg".
+	 * @return string The icon markup.
+	 */
+	public function get_icon( string $name = '' ) {
+		$dir     = realpath( $this->plugin_path . './assets/images' );
+		$file    = "{$dir}/{$name}.svg";
+		$content = '';
+
+		// Read file inside try/catch in case the
+		// icon file is not there.
+		try {
+			$content = file_get_contents( $file );
+		} catch ( Exception $e ) {
+			$content = false;
+		}
+
+		if ( false !== $content ) {
+			return $content;
+		}
+
+		return '';
+	}
 }

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -206,6 +206,7 @@ class Sensei_Autoloader {
 			'Sensei\Blocks\Course_Theme\Prev_Lesson'      => 'blocks/course-theme/class-prev-lesson.php',
 			'Sensei\Blocks\Course_Theme\Next_Lesson'      => 'blocks/course-theme/class-next-lesson.php',
 			'Sensei\Blocks\Course_Theme\Quiz_Back_To_Lesson' => 'blocks/course-theme/class-quiz-back-to-lesson.php',
+			'Sensei\Blocks\Course_Theme\Course_Progress_Counter' => 'blocks/course-theme/class-course-progress-counter.php',
 		);
 	}
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2032,8 +2032,9 @@ class Sensei_Course {
 		 *              $stats['lessons_count'] The total number of lessons in the course.
 		 *              $stats['completed_lessons_count'] The total number of completed lessons of the course by the user.
 		 *              $stats['completed_lessons_percentage'] The completed lessons percentage relative to total number of lessons.
+		 * @param int   $course_id The id of the course.
 		 */
-		return apply_filters( 'sensei_course_progress_stats', $stats );
+		return apply_filters( 'sensei_course_progress_stats', $stats, $course_id );
 	}
 
 	/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2006,6 +2006,37 @@ class Sensei_Course {
 	}
 
 	/**
+	 * Returns a summary of course progress statistics in keyed array.
+	 *
+	 * @param int $course_id The id of the course.
+	 *
+	 * @return array $stats An array of progress stats.
+	 *               $stats['lessons_count'] The total number of lessons in the course.
+	 *               $stats['completed_lessons_count'] The total number of completed lessons of the course by the user.
+	 *               $stats['completed_lessons_percentage'] The completed lessons percentage relative to total number of lessons.
+	 */
+	public function get_progress_stats( int $course_id ): array {
+		$lessons_count           = count( \Sensei()->course->course_lessons( $course_id, null, 'ids' ) );
+		$completed_lessons_count = count( \Sensei()->course->get_completed_lesson_ids( $course_id ) );
+		$stats                   = [
+			'lessons_count'                => $lessons_count,
+			'completed_lessons_count'      => $completed_lessons_count,
+			'completed_lessons_percentage' => \Sensei_Utils::quotient_as_absolute_rounded_percentage( $completed_lessons_count, $lessons_count, 2 ),
+		];
+
+		/**
+		 * Filter the course progress stats.
+		 *
+		 * @since 3.14.4
+		 * @param array $stat An array of course progress stats.
+		 *              $stats['lessons_count'] The total number of lessons in the course.
+		 *              $stats['completed_lessons_count'] The total number of completed lessons of the course by the user.
+		 *              $stats['completed_lessons_percentage'] The completed lessons percentage relative to total number of lessons.
+		 */
+		return apply_filters( 'sensei_course_progress_stats', $stats );
+	}
+
+	/**
 	 * Output the course progress statement
 	 *
 	 * @param $course_id

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2714,6 +2714,34 @@ class Sensei_Utils {
 		return false;
 	}
 
+	/**
+	 * Gets the contents of the icon file at assets/images/<name>.svg
+	 * for the given name. Or empty string if file not found.
+	 *
+	 * @param string $name The name of the icon file at "assets/images/<name>.svg".
+	 * @return string The icon markup.
+	 */
+	public static function icon( string $name = '' ) {
+		$dir     = realpath( __DIR__ . '/../assets/images' );
+		$file    = "{$dir}/{$name}.svg";
+		$content = '';
+
+		// Read file inside try/catch in case the
+		// icon file is not there.
+		try {
+			ob_start();
+			include $file;
+			$content = ob_get_clean();
+		} catch ( Exception $e ) {
+			$content = false;
+		}
+
+		if ( false !== $content ) {
+			return $content;
+		}
+
+		return '';
+	}
 }
 
 /**

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2713,6 +2713,7 @@ class Sensei_Utils {
 		}
 		return false;
 	}
+
 }
 
 /**

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2713,35 +2713,6 @@ class Sensei_Utils {
 		}
 		return false;
 	}
-
-	/**
-	 * Gets the contents of the icon file at assets/images/<name>.svg
-	 * for the given name. Or empty string if file not found.
-	 *
-	 * @param string $name The name of the icon file at "assets/images/<name>.svg".
-	 * @return string The icon markup.
-	 */
-	public static function icon( string $name = '' ) {
-		$dir     = realpath( __DIR__ . '/../assets/images' );
-		$file    = "{$dir}/{$name}.svg";
-		$content = '';
-
-		// Read file inside try/catch in case the
-		// icon file is not there.
-		try {
-			ob_start();
-			include $file;
-			$content = ob_get_clean();
-		} catch ( Exception $e ) {
-			$content = false;
-		}
-
-		if ( false !== $content ) {
-			return $content;
-		}
-
-		return '';
-	}
 }
 
 /**

--- a/templates/course-theme/single-lesson.php
+++ b/templates/course-theme/single-lesson.php
@@ -22,7 +22,14 @@ if ( have_posts() ) {
 <!-- wp:group {"className":"sensei-course-theme__header"} -->
 <div class="wp-block-group sensei-course-theme__header">
 	<!-- wp:paragraph -->
-	<p>Header here</p>
+
+	<!-- wp:sensei-lms/course-theme-course-progress-counter /-->
+
+	<!-- wp:sensei-lms/course-theme-prev-next-lesson -->
+	<!-- wp:sensei-lms/course-theme-prev-lesson {"inContainer":true} /-->
+	<!-- wp:sensei-lms/course-theme-next-lesson {"inContainer":true} /-->
+	<!-- /wp:sensei-lms/course-theme-prev-next-lesson -->
+
 	<!-- /wp:paragraph -->
 </div>
 <!-- /wp:group -->


### PR DESCRIPTION
Fixes #4374 

### Changes proposed in this Pull Request

* Implements `sensei-lms/course-theme-course-progress-counter` block. 
* Implements a simple `\Sensei()->assets->get_icon( string $name = '' )` method for icon management. The method is a starting point that could expand to optimizations, like mentioned [here](https://github.com/Automattic/sensei/pull/4426#discussion_r752557682).

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)


-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Add `<!-- wp:sensei-lms/course-theme-course-progress-counter /-->` block in one of your courses or lessons.
* Visit the course page and confirm it correctly counts the completed lessons.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video


https://user-images.githubusercontent.com/2578542/142612530-75df7c43-f0f4-4fd0-beb7-54a5aa3c35db.mp4

