### PR TITLE
Improve sensei theme check to use existing function

### DIFF
--- a/includes/class-sensei-course-theme.php
+++ b/includes/class-sensei-course-theme.php
@@ -89,14 +89,13 @@ class Sensei_Course_Theme {
 			return;
 		}
 
-		if ( get_post_type() === 'quiz' ) {
-			$lesson_id = Sensei()->quiz->get_lesson_id( get_the_ID() );
-		} else {
-			$lesson_id = get_the_ID();
+		$course_id = \Sensei_Utils::get_current_course();
+
+		if ( null === $course_id ) {
+			return;
 		}
 
-		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
-		$theme     = get_post_meta( $course_id, self::THEME_POST_META_NAME, true );
+		$theme = get_post_meta( $course_id, self::THEME_POST_META_NAME, true );
 
 		if ( self::SENSEI_THEME !== $theme ) {
 			return;


### PR DESCRIPTION
This is just a small refactor to use an existing function to get the current course ID.

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create a course with a lesson and a quiz.
* Select the "Sensei Theme" as the "Course Theme" (sidebar).
* Go to lesson and quiz in the frontend, and make sure it loads the new template.