### PR TITLE
Add namespace support for autoloader bundle

### DIFF
--- a/includes/blocks/class-course-theme-blocks.php
+++ b/includes/blocks/class-course-theme-blocks.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the class Sensei_CT_Blocks.
+ * File containing the class Sensei_Course_Theme_Blocks.
  *
  * @package sensei
  */
@@ -15,11 +15,12 @@ use \Sensei_Blocks_Initializer;
 use \Sensei\Blocks\Course_Theme\Prev_Lesson;
 use \Sensei\Blocks\Course_Theme\Next_Lesson;
 use \Sensei\Blocks\Course_Theme\Prev_Next_Lesson;
+use \Sensei\Blocks\Course_Theme\Course_Title;
 
 /**
  * Class Sensei_Course_Theme_Blocks
  */
-class Course_Theme extends Sensei_Blocks_Initializer {
+class Course_Theme_Blocks extends Sensei_Blocks_Initializer {
 	/**
 	 * Sensei_Blocks constructor.
 	 */
@@ -51,5 +52,6 @@ class Course_Theme extends Sensei_Blocks_Initializer {
 		$prev = new Prev_Lesson();
 		$next = new Next_Lesson();
 		new Prev_Next_Lesson( $prev, $next );
+		new Course_Title();
 	}
 }

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -71,6 +71,7 @@ class Sensei_Autoloader {
 			new Sensei_Autoloader_Bundle( 'data-port/export-tasks' ),
 			new Sensei_Autoloader_Bundle( 'data-port/models' ),
 			new Sensei_Autoloader_Bundle( 'blocks' ),
+			new Sensei_Autoloader_Bundle( 'blocks/course-theme' ),
 		);
 
 		// Add Sensei custom auto loader.
@@ -197,14 +198,6 @@ class Sensei_Autoloader {
 			* WPML
 			*/
 			'Sensei_WPML'                                 => 'wpml/class-sensei-wpml.php',
-
-			/**
-			 * Course Theme
-			 */
-			'Sensei\Blocks\Course_Theme'                  => 'blocks/course-theme/class-course-theme.php',
-			'Sensei\Blocks\Course_Theme\Prev_Next_Lesson' => 'blocks/course-theme/class-prev-next-lesson.php',
-			'Sensei\Blocks\Course_Theme\Prev_Lesson'      => 'blocks/course-theme/class-prev-lesson.php',
-			'Sensei\Blocks\Course_Theme\Next_Lesson'      => 'blocks/course-theme/class-next-lesson.php',
 		);
 	}
 

--- a/includes/class-sensei-course-theme.php
+++ b/includes/class-sensei-course-theme.php
@@ -59,7 +59,7 @@ class Sensei_Course_Theme {
 		}
 
 		// Init blocks.
-		new \Sensei\Blocks\Course_Theme();
+		new \Sensei\Blocks\Course_Theme_Blocks();
 
 		add_action( 'init', [ $this, 'register_post_meta' ] );
 		add_action( 'template_redirect', [ $this, 'maybe_use_sensei_theme_template' ] );


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Let the autoloader match files to namespaced classnames if the namespace matches the current bundle directory
* Use it for the course theme classes

### Testing instructions

* Check that entire plugin is not broken
* Check that course theme blocks work

