### PR TITLE
Add/course theme course progress bar

### DIFF
--- a/assets/css/sensei-course-theme/course-progress-bar.scss
+++ b/assets/css/sensei-course-theme/course-progress-bar.scss
@@ -1,0 +1,11 @@
+.sensei-course-theme-course-progress-bar {
+	height: 10px;
+	width: 100%;
+	background-color: #DCDCDE;
+;
+}
+
+.sensei-course-theme-course-progress-bar-inner {
+	height: 10px;
+	background-color: #43AF99;
+}

--- a/assets/css/sensei-course-theme/sensei-course-theme.scss
+++ b/assets/css/sensei-course-theme/sensei-course-theme.scss
@@ -2,6 +2,7 @@
 
 @import 'prev-next-lesson';
 @import 'quiz-back-to-lesson';
+@import 'course-progress-bar';
 
 .sensei-course-theme {
 

--- a/includes/blocks/course-theme/class-course-progress-bar.php
+++ b/includes/blocks/course-theme/class-course-progress-bar.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * File containing the Course_Progress_Bar class.
+ *
+ * @package sensei
+ * @since 3.13.4
+ */
+
+namespace Sensei\Blocks\Course_Theme;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use \Sensei_Blocks;
+
+/**
+ * Class Course_Progress_Bar is responsible for rendering the '[==========----------]' block.
+ */
+class Course_Progress_Bar {
+	/**
+	 * Course_Progress_Bar constructor.
+	 */
+	public function __construct() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/course-theme-course-progress-bar',
+			[
+				'render_callback' => [ $this, 'render' ],
+			]
+		);
+	}
+
+	/**
+	 * Renders the block.
+	 *
+	 * @access private
+	 *
+	 * @return string The block HTML.
+	 */
+	public function render() : string {
+		$course_id = \Sensei_Utils::get_current_course();
+		if ( ! $course_id ) {
+			return '';
+		}
+
+		list( 'completed_lessons_percentage' => $width ) = \Sensei()->course->get_progress_stats( $course_id );
+
+		return ( "
+			<div class='sensei-course-theme-course-progress-bar'>
+				<div class='sensei-course-theme-course-progress-bar-inner' style='width: {$width}%;'></div>
+			</div>
+		" );
+	}
+}

--- a/includes/blocks/course-theme/class-course-theme.php
+++ b/includes/blocks/course-theme/class-course-theme.php
@@ -18,6 +18,7 @@ use \Sensei\Blocks\Course_Theme\Next_Lesson;
 use \Sensei\Blocks\Course_Theme\Prev_Next_Lesson;
 use \Sensei\Blocks\Course_Theme\Quiz_Back_To_Lesson;
 use \Sensei\Blocks\Course_Theme\Course_Progress_Counter;
+use \Sensei\Blocks\Course_Theme\Course_Progress_Bar;
 
 /**
  * Class Course_Theme
@@ -65,5 +66,6 @@ class Course_Theme extends Sensei_Blocks_Initializer {
 			new Quiz_Back_To_Lesson();
 		}
 		new Course_Progress_Counter();
+		new Course_Progress_Bar();
 	}
 }

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -207,6 +207,7 @@ class Sensei_Autoloader {
 			'Sensei\Blocks\Course_Theme\Next_Lesson'      => 'blocks/course-theme/class-next-lesson.php',
 			'Sensei\Blocks\Course_Theme\Quiz_Back_To_Lesson' => 'blocks/course-theme/class-quiz-back-to-lesson.php',
 			'Sensei\Blocks\Course_Theme\Course_Progress_Counter' => 'blocks/course-theme/class-course-progress-counter.php',
+			'Sensei\Blocks\Course_Theme\Course_Progress_Bar' => 'blocks/course-theme/class-course-progress-bar.php',
 		);
 	}
 

--- a/templates/course-theme/single-lesson.php
+++ b/templates/course-theme/single-lesson.php
@@ -30,6 +30,8 @@ if ( have_posts() ) {
 	<!-- wp:sensei-lms/course-theme-next-lesson {"inContainer":true} /-->
 	<!-- /wp:sensei-lms/course-theme-prev-next-lesson -->
 
+	<!-- wp:sensei-lms/course-theme-course-progress-bar /-->
+
 	<!-- /wp:paragraph -->
 </div>
 <!-- /wp:group -->

--- a/tests/unit-tests/course-theme/test-class-course-progress-bar.php
+++ b/tests/unit-tests/course-theme/test-class-course-progress-bar.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * This file contains the Course_Progress_Bar_Test class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use \Sensei\Blocks\Course_Theme\Course_Progress_Bar;
+
+/**
+ * Tests for Course_Progress_Bar_Test class.
+ *
+ * @group course-theme
+ */
+class Course_Progress_Bar_Test extends WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+	/**
+	 * Setup function.
+	 */
+	public function setup() {
+		parent::setup();
+
+		$this->factory = new Sensei_Factory();
+	}
+
+	/**
+	 * Testing the Course Progress Bar class to make sure it is loaded.
+	 */
+	public function testClassInstance() {
+		$this->assertTrue( class_exists( '\Sensei\Blocks\Course_Theme\Course_Progress_Bar' ), '\Sensei\Blocks\Course_Theme\Course_Progress_Bar class should exist' );
+	}
+
+	/**
+	 * Tests that course progress bar width is correct.
+	 */
+	public function testProgressBarWidth() {
+		$course  = $this->factory->course->create_and_get();
+		$lesson1 = $this->factory->lesson->create_and_get();
+		add_post_meta( $lesson1->ID, '_lesson_course', $course->ID );
+		$lesson2 = $this->factory->lesson->create_and_get();
+		add_post_meta( $lesson2->ID, '_lesson_course', $course->ID );
+
+		$this->login_as_student();
+		$GLOBALS['post'] = $course;
+		$block           = new Course_Progress_Bar();
+
+		// check for 0% width
+		$this->assertContains( 'width: 0%', $block->render(), 'The course progress bar width should be 0%.' );
+
+		// check for 50% width
+		\Sensei_Utils::sensei_start_lesson( $lesson1->ID, get_current_user_id(), true );
+		$this->assertContains( 'width: 50%', $block->render(), 'The course progress bar width should be 50%.' );
+
+		// check for 100% width
+		\Sensei_Utils::sensei_start_lesson( $lesson2->ID, get_current_user_id(), true );
+		$this->assertContains( 'width: 100%', $block->render(), 'The course progress bar width should be 100%.' );
+	}
+
+	/**
+	 * Tests that course progress bar is empty if the post type is not applicable.
+	 */
+	public function testProgressBarEmpty() {
+		$this->login_as_student();
+		$random_post     = $this->factory->post->create_and_get();
+		$GLOBALS['post'] = $random_post;
+		$block           = new Course_Progress_Bar();
+
+		$this->assertEquals( '', $block->render(), 'The course progress bar should be empty.' );
+	}
+}


### PR DESCRIPTION
Fixes #4375 

### Changes proposed in this Pull Request

* Implements the `sensei-lms/course-theme-course-progress-bar` block.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Open up any lesson, quiz or course with course theme set to Sensei Theme and confirm there is a progress bar and it shows the correct percentage in progress.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video


https://user-images.githubusercontent.com/2578542/143035261-175df35d-691e-4909-b3f6-51efcdd6bc19.mp4

