### PR TITLE
Add Customizer panel with setting for primary color

### DIFF
--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -1,7 +1,7 @@
 .sensei-course-theme__frame {
 
-	--primary-color: var(--theme-color, #30968B);
-	
+	--primary-color: var(--sensei-course-theme-primary-color, #30968B);
+
 	a:hover, a:hover * {
 		color: var(--primary-color);
 		fill: var(--primary-color);

--- a/includes/class-sensei-customizer.php
+++ b/includes/class-sensei-customizer.php
@@ -1,0 +1,132 @@
+<?php
+
+/**
+ * Add customizer settings.
+ */
+class Sensei_Customizer {
+
+	/**
+	 * Sensei course theme primary color.
+	 */
+	const COURSE_THEME_PRIMARY_COLOR = 'sensei-course-theme-primary-color';
+
+	/**
+	 * Settings to output as CSS variables.
+	 *
+	 * @var string[] Variable names.
+	 */
+	public $css_variables = [ self::COURSE_THEME_PRIMARY_COLOR ];
+
+	/**
+	 * Sensei_Customizer constructor.
+	 */
+	public function __construct() {
+
+		add_action( 'customize_register', [ $this, 'add_customizer_settings' ] );
+		add_action( 'customize_preview_init', [ $this, 'enqueue_customizer_helper' ] );
+		add_action( 'wp_head', [ $this, 'output_custom_settings' ] );
+
+	}
+
+	/**
+	 * Add Sensei section and settings to Customizer.
+	 *
+	 * @param WP_Customize_Manager $wp_customize
+	 */
+	public function add_customizer_settings( WP_Customize_Manager $wp_customize ) {
+
+		$wp_customize->add_panel(
+			'sensei',
+			[
+				'priority'       => 40,
+				'capability'     => 'manage_sensei',
+				'theme_supports' => '',
+				'title'          => __( 'Sensei LMS', 'sensei-lms' ),
+			]
+		);
+
+		$wp_customize->add_section(
+			'sensei_course_theme',
+			[
+				'title'    => __( 'Course Theme', 'sensei-lms' ),
+				'priority' => 30,
+				'panel'    => 'sensei',
+			]
+		);
+
+		$wp_customize->add_setting(
+			self::COURSE_THEME_PRIMARY_COLOR,
+			[
+				'default'   => '#1E1E1E',
+				'transport' => 'postMessage',
+			]
+		);
+
+		$wp_customize->add_control(
+			new WP_Customize_Color_Control(
+				$wp_customize,
+				self::COURSE_THEME_PRIMARY_COLOR,
+				array(
+					'label'    => __( 'Primary Color', 'sensei-lms' ),
+					'section'  => 'sensei_course_theme',
+					'settings' => self::COURSE_THEME_PRIMARY_COLOR,
+				)
+			)
+		);
+
+	}
+
+	/**
+	 * Add helper script to the footer when customizer preview is active.
+	 *
+	 * @hooked customize_preview_init
+	 */
+	public function enqueue_customizer_helper() {
+		add_action( 'wp_print_footer_scripts', [ $this, 'output_customizer_helper' ] );
+	}
+
+	/**
+	 * Output custom settings as CSS variables.
+	 */
+	public function output_custom_settings() {
+
+		$css = '';
+
+		foreach ( $this->css_variables as $variable ) {
+			$value = get_theme_mod( $variable );
+			if ( $value ) {
+				$css .= sprintf( "--%s: %s;\n", $variable, ( $value ) );
+			}
+		}
+
+		?>
+		<style>
+			:root {
+			<?php echo esc_html( $css ); ?>
+			}
+		</style>
+		<?php
+	}
+
+	/**
+	 * Helper script to instantly update the CSS variables when previewing customizer settings.
+	 */
+	public function output_customizer_helper() {
+
+		?>
+		<script type="text/javascript">
+			<?php
+			foreach ( $this->css_variables as $variable ) {
+				?>
+			wp.customize( '<?php echo esc_js( $variable ); ?>', ( setting ) => {
+				setting.bind( ( value ) => {
+					document.documentElement.style.setProperty( '--<?php echo esc_js( $variable ); ?>', value )
+				} );
+			} );
+				<?php
+			}
+			?>
+		</script>
+		<?php
+	}
+}

--- a/includes/class-sensei-customizer.php
+++ b/includes/class-sensei-customizer.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Sensei_Customizer class.
+ *
+ * @package sensei-lms
+ * @since 4.0.0
+ */
 
 /**
  * Add customizer settings.

--- a/includes/class-sensei-customizer.php
+++ b/includes/class-sensei-customizer.php
@@ -25,8 +25,14 @@ class Sensei_Customizer {
 
 	/**
 	 * Sensei_Customizer constructor.
+	 *
+	 * @param Sensei_Main $sensei Main Sensei instance.
 	 */
-	public function __construct() {
+	public function __construct( Sensei_Main $sensei ) {
+
+		if ( ! $sensei->feature_flags->is_enabled( 'course_theme' ) ) {
+			return;
+		}
 
 		add_action( 'customize_register', [ $this, 'add_customizer_settings' ] );
 		add_action( 'customize_preview_init', [ $this, 'enqueue_customizer_helper' ] );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -417,6 +417,7 @@ class Sensei_Main {
 		$this->enrolment_scheduler->init();
 		Sensei_Data_Port_Manager::instance()->init();
 		Sensei_Course_Theme::instance()->init( $this );
+		new Sensei_Customizer();
 
 		// Setup Wizard.
 		$this->setup_wizard = Sensei_Setup_Wizard::instance();

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -417,7 +417,7 @@ class Sensei_Main {
 		$this->enrolment_scheduler->init();
 		Sensei_Data_Port_Manager::instance()->init();
 		Sensei_Course_Theme::instance()->init( $this );
-		new Sensei_Customizer();
+		new Sensei_Customizer( $this );
 
 		// Setup Wizard.
 		$this->setup_wizard = Sensei_Setup_Wizard::instance();


### PR DESCRIPTION
Fixes #4385 

### Changes proposed in this Pull Request

* Add `Sensei_Customizer` class to set up Wordpress theme customizer settings
* Add `Sensei LMS` panel with a `Course Theme` section
* Add primary color setting

### Testing instructions

* Enable the feature flag `sensei_feature_flag_course_theme`
* View a course lesson that has course theme enabled, as an admin
* Open `Customize` from the wp admin bar at the top of the page
* Change the color in Sensei LMS > Course Theme > Primary color
* Check that the color is updating on the page
* Publish the change
* Check that the color is being used

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="619" alt="image" src="https://user-images.githubusercontent.com/176949/143144569-600a783c-5ea3-46e4-adf9-87044035af54.png">

