### PR TITLE
Implement sensei-lms/course-theme-complete-lesson block.

### DIFF
--- a/assets/css/sensei-course-theme/complete-lesson.scss
+++ b/assets/css/sensei-course-theme/complete-lesson.scss
@@ -1,0 +1,42 @@
+.sensei-course-theme-complete-lesson-form {
+	padding: 0;
+	margin: 0;
+}
+.sensei-course-theme-complete-lesson {
+	font-size: 14px;
+	line-height: 17px;
+	font-weight: 700;
+	padding: 11px 18px;
+	background-color: transparent;
+	border: 1px solid #000;
+	border-radius: 2px;
+	background-color: #fff;
+	&:hover {
+		border: 1px solid #000;
+		background-color: #f9f9f9;
+	}
+}
+.sensei-course-theme-completed-lesson {
+	display: inline-block;
+}
+.sensei-course-theme-completed-lesson-inner {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	padding: 11px 18px;
+	background-color: #fff;
+	border: 1px solid #000;
+	border-radius: 2px;
+
+	span {
+		font-size: 14px;
+		line-height: 17px;
+		font-weight: 700;
+		margin-left: 6px;
+		color: #000;
+	}
+
+	svg {
+		width: 17px;
+	}
+}

--- a/assets/css/sensei-course-theme/complete-lesson.scss
+++ b/assets/css/sensei-course-theme/complete-lesson.scss
@@ -2,41 +2,29 @@
 	padding: 0;
 	margin: 0;
 }
-.sensei-course-theme-complete-lesson {
+
+button.sensei-course-theme-complete-lesson {
+	box-sizing: border-box;
 	font-size: 14px;
 	line-height: 17px;
 	font-weight: 700;
 	padding: 11px 18px;
-	background-color: transparent;
-	border: 1px solid #000;
 	border-radius: 2px;
-	background-color: #fff;
-	&:hover {
-		border: 1px solid #000;
-		background-color: #f9f9f9;
-	}
-}
-.sensei-course-theme-completed-lesson {
-	display: inline-block;
-}
-.sensei-course-theme-completed-lesson-inner {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	padding: 11px 18px;
-	background-color: #fff;
-	border: 1px solid #000;
-	border-radius: 2px;
+	background-color: var(--primary-color);
+	color: var(--primary-contrast-color);
 
-	span {
-		font-size: 14px;
-		line-height: 17px;
-		font-weight: 700;
-		margin-left: 6px;
-		color: #000;
+	&:disabled {
+		background-color: var(--primary-color);
+		color: var(--primary-contrast-color);
+		cursor: not-allowed;
 	}
 
-	svg {
-		width: 17px;
+	&__secondary {
+		border: 1px solid var(--primary-color);
+		background-color: rgba(0, 0, 0, 0);
+		color: var(--primary-color);
+		&:hover {
+			background-color: rgba(0, 0, 0, 0.02);
+		}
 	}
 }

--- a/assets/css/sensei-course-theme/prev-next-lesson.scss
+++ b/assets/css/sensei-course-theme/prev-next-lesson.scss
@@ -7,12 +7,13 @@
 	}
 
     &-a {
-		span, &:hover span {
+		span {
 			font-size: 14px;
 			line-height: 17px;
 			color: #000;
 		}
 		&:hover span {
+			color: var(--primary-color);
 			text-decoration: underline;
 		}
 
@@ -20,12 +21,19 @@
 			margin-left: 27px;
 		}
 
-		svg, &:hover svg {
+		svg {
 			height: 11px;
 			path {
 				fill: transparent;
 				stroke: #000;
 				stroke-width: 1.5;
+			}
+		}
+
+		&:hover svg {
+			path {
+				fill: transparent;
+				stroke: var(--primary-color);
 			}
 		}
 

--- a/assets/css/sensei-course-theme/prev-next-lesson.scss
+++ b/assets/css/sensei-course-theme/prev-next-lesson.scss
@@ -1,31 +1,44 @@
-.sensei-course-theme-prev-next-lesson-container {
-	display: flex;
-	flex-direction: row;
-	justify-content: flex-start;
-	align-items: center;
-}
+.sensei-course-theme-prev-next-lesson {
+	&-container {
+		display: flex;
+		flex-direction: row;
+		justify-content: flex-start;
+		align-items: center;
+	}
 
-.sensei-course-theme-prev-next-lesson-a {
-	font-size: 14px;
-	line-height: 17px;
-	color: #000;
-	&:nth-child(2) {
-		margin-left: 27px;
-	}
-	&:hover {
-		text-decoration: underline;
-	}
-	svg {
-		height: 11px;
-	}
-	&__prev {
-		svg {
-			margin-right: 14px;
+    &-a {
+		span, &:hover span {
+			font-size: 14px;
+			line-height: 17px;
+			color: #000;
 		}
-	}
-	&__next {
-		svg {
-			margin-left: 14px;
+		&:hover span {
+			text-decoration: underline;
+		}
+
+		&:nth-child( 2 ) {
+			margin-left: 27px;
+		}
+
+		svg, &:hover svg {
+			height: 11px;
+			path {
+				fill: transparent;
+				stroke: #000;
+				stroke-width: 1.5;
+			}
+		}
+
+		&__prev {
+			svg {
+				margin-right: 14px;
+			}
+		}
+
+		&__next {
+			svg {
+				margin-left: 14px;
+			}
 		}
 	}
 }

--- a/assets/css/sensei-course-theme/sensei-course-theme.scss
+++ b/assets/css/sensei-course-theme/sensei-course-theme.scss
@@ -8,4 +8,5 @@
 @import './course-navigation';
 @import './quiz-back-to-lesson';
 @import './course-progress-bar';
+@import './complete-lesson';
 @import './header';

--- a/assets/images/check.svg
+++ b/assets/images/check.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+	<path stroke="#000" stroke-width="1.5" d="M9 18.6L3.5 13l1-1L9 16.4l9.5-9.9 1 1z" />
+</svg>

--- a/assets/images/check.svg
+++ b/assets/images/check.svg
@@ -1,3 +1,0 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-	<path stroke="#000" stroke-width="1.5" d="M9 18.6L3.5 13l1-1L9 16.4l9.5-9.9 1 1z" />
-</svg>

--- a/includes/blocks/course-theme/class-complete-lesson.php
+++ b/includes/blocks/course-theme/class-complete-lesson.php
@@ -82,14 +82,14 @@ class Complete_Lesson {
 		$permalink = esc_url( get_permalink() );
 		$text      = esc_html( __( 'Complete lesson', 'sensei-lms' ) );
 
-		return ( "
-			<form class='sensei-course-theme-complete-lesson-form' method='POST' action='{$permalink}'>
-				{$nonce}
-				<input type='hidden' name='quiz_action' value='lesson-complete' />
-				<button type='submit' class='sensei-course-theme-complete-lesson {$secondary}' {$disabled}>
-					{$text}
+		return ( '
+			<form class="sensei-course-theme-complete-lesson-form" method="POST" action="' . $permalink . '">
+				' . $nonce . '
+				<input type="hidden" name="quiz_action" value="lesson-complete" />
+				<button type="submit" class="sensei-course-theme-complete-lesson ' . $secondary . '" ' . $disabled . '>
+					' . $text . '
 				</button>
 			</form>
-		" );
+		' );
 	}
 }

--- a/includes/blocks/course-theme/class-complete-lesson.php
+++ b/includes/blocks/course-theme/class-complete-lesson.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * File containing the Complete_Lesson class.
+ *
+ * @package sensei
+ * @since
+ */
+
+namespace Sensei\Blocks\Course_Theme;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use \Sensei_Blocks;
+
+/**
+ * Class Complete_Lesson is responsible for rendering the 'Mark complete' block.
+ */
+class Complete_Lesson {
+
+	/**
+	 * Complete_Lesson constructor.
+	 */
+	public function __construct() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/course-theme-complete-lesson',
+			[
+				'render_callback' => [ $this, 'render' ],
+			]
+		);
+	}
+
+	/**
+	 * Renders the block.
+	 *
+	 * @access private
+	 *
+	 * @return string The block HTML.
+	 */
+	public function render() : string {
+		$post = get_post();
+
+		// Return empty if we can't get the post for some reason.
+		if ( empty( $post ) ) {
+			return '';
+		}
+
+		$course_id = Sensei()->lesson->get_course_id( $post->ID );
+
+		if (
+			// Return empty if it is not a lesson post.
+			'lesson' !== $post->post_type ||
+
+			// Return empty if user is not enrolled.
+			! \Sensei_Course::is_user_enrolled( $course_id ) ||
+
+			// Return empty if the lesson requires a quiz pass.
+			Sensei()->lesson->lesson_has_quiz_with_questions_and_pass_required( $post->ID )
+		) {
+			return '';
+		}
+
+		// Render "Completed" if user already completed the lesson.
+		if ( \Sensei_Utils::user_completed_lesson( $post->ID ) ) {
+			$text = esc_html( __( 'Completed', 'sensei-lms' ) );
+			$icon = \Sensei()->assets->get_icon( 'check' );
+
+			return ( "
+				<div class='sensei-course-theme-completed-lesson'>
+					<div class='sensei-course-theme-completed-lesson-inner'>
+						{$icon}<span>{$text}</span>
+					</div>
+				</div>
+			" );
+		}
+
+		// Render "Mark Complete" button.
+		$nonce     = wp_nonce_field( 'woothemes_sensei_complete_lesson_noonce', 'woothemes_sensei_complete_lesson_noonce', false, false );
+		$permalink = esc_url( get_permalink() );
+		$text      = esc_html( __( 'Mark complete', 'sensei-lms' ) );
+
+		return ( "
+			<form class='sensei-course-theme-complete-lesson-form' method='POST' action='{$permalink}'>
+				{$nonce}
+				<input type='hidden' name='quiz_action' value='lesson-complete' />
+				<button type='submit' class='sensei-course-theme-complete-lesson'>
+					{$text}
+				</button>
+			</form>
+		" );
+	}
+}

--- a/includes/blocks/course-theme/class-course-progress-counter.php
+++ b/includes/blocks/course-theme/class-course-progress-counter.php
@@ -3,7 +3,7 @@
  * File containing the Course_Progress_Counter class.
  *
  * @package sensei
- * @since 3.13.4
+ * @since 3.15.0
  */
 
 namespace Sensei\Blocks\Course_Theme;

--- a/includes/blocks/course-theme/class-course-theme.php
+++ b/includes/blocks/course-theme/class-course-theme.php
@@ -22,6 +22,7 @@ use \Sensei\Blocks\Course_Theme\Quiz_Back_To_Lesson;
 use \Sensei\Blocks\Course_Theme\Course_Progress_Counter;
 use \Sensei\Blocks\Course_Theme\Course_Progress_Bar;
 use \Sensei\Blocks\Course_Theme\Quiz_Button;
+use \Sensei\Blocks\Course_Theme\Complete_Lesson;
 
 /**
  * Class Course_Theme
@@ -70,6 +71,7 @@ class Course_Theme extends Sensei_Blocks_Initializer {
 			new Course_Progress_Counter();
 			new Course_Progress_Bar();
 			new Quiz_Button();
+			new Complete_lesson();
 		} elseif ( 'quiz' === get_post_type() ) {
 			new Quiz_Back_To_Lesson();
 		}

--- a/includes/blocks/course-theme/class-course-theme.php
+++ b/includes/blocks/course-theme/class-course-theme.php
@@ -73,6 +73,5 @@ class Course_Theme extends Sensei_Blocks_Initializer {
 		} elseif ( 'quiz' === get_post_type() ) {
 			new Quiz_Back_To_Lesson();
 		}
-
 	}
 }

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -211,6 +211,7 @@ class Sensei_Autoloader {
 			'Sensei\Blocks\Course_Theme\Quiz_Back_To_Lesson' => 'blocks/course-theme/class-quiz-back-to-lesson.php',
 			'Sensei\Blocks\Course_Theme\Course_Progress_Counter' => 'blocks/course-theme/class-course-progress-counter.php',
 			'Sensei\Blocks\Course_Theme\Course_Progress_Bar' => 'blocks/course-theme/class-course-progress-bar.php',
+			'Sensei\Blocks\Course_Theme\Complete_Lesson'  => 'blocks/course-theme/class-complete-lesson.php',
 		);
 	}
 

--- a/templates/course-theme/single-lesson.php
+++ b/templates/course-theme/single-lesson.php
@@ -32,7 +32,10 @@ if ( have_posts() ) {
 		<!-- /wp:column -->
 		<!-- wp:column {"className":"sensei-course-theme__header__right"} -->
 		<div class="wp-block-column sensei-course-theme__header__right">
-			<!-- wp:sensei-lms/course-theme-prev-next-lesson /-->
+			<!-- wp:sensei-lms/course-theme-prev-next-lesson -->
+			<!-- wp:sensei-lms/course-theme-prev-lesson {"inContainer":true} /-->
+			<!-- wp:sensei-lms/course-theme-next-lesson {"inContainer":true} /-->
+			<!-- /wp:sensei-lms/course-theme-prev-next-lesson -->
 			<!-- wp:sensei-lms/course-theme-complete-lesson /-->
 			<!-- wp:sensei-lms/course-theme-quiz-button /-->
 		</div>

--- a/tests/unit-tests/course-theme/test-class-complete-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-complete-lesson.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * This file contains the Complete_Lesson_Test class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use \Sensei\Blocks\Course_Theme\Complete_Lesson;
+
+/**
+ * Tests for Complete_Lesson_Test class.
+ *
+ * @group course-theme
+ */
+class Complete_Lesson_Test extends WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+	/**
+	 * Setup function.
+	 */
+	public function setup() {
+		parent::setup();
+
+		$this->factory = new Sensei_Factory();
+	}
+
+	/**
+	 * Testing the Complete_Lesson class to make sure it is loaded.
+	 */
+	public function testClassInstance() {
+		$this->assertTrue( class_exists( '\Sensei\Blocks\Course_Theme\Complete_Lesson' ), '\Sensei\Blocks\Course_Theme\Complete_Lesson class should exist' );
+	}
+
+	/**
+	 * Test complete lesson block when there is no post.
+	 */
+	public function testNoPost() {
+		$course = $this->factory->course->create_and_get();
+		$lesson = $this->factory->lesson->create_and_get();
+		add_post_meta( $lesson->ID, '_lesson_course', $course->ID );
+		$this->login_as_student();
+		\Sensei()->frontend->manually_enrol_learner( get_current_user_id(), $course->ID );
+
+		$GLOBALS['post'] = null;
+		$block           = new Complete_Lesson();
+
+		// Check for empty response.
+		$this->assertEquals( '', $block->render(), 'Should render empty string if there is no post.' );
+	}
+
+	/**
+	 * Test complete lesson block when the post is not lesson.
+	 */
+	public function testNotLesson() {
+		$course = $this->factory->course->create_and_get();
+		$lesson = $this->factory->lesson->create_and_get();
+		add_post_meta( $lesson->ID, '_lesson_course', $course->ID );
+		$this->login_as_student();
+		\Sensei()->frontend->manually_enrol_learner( get_current_user_id(), $course->ID );
+
+		$GLOBALS['post'] = $course;
+		$block           = new Complete_Lesson();
+
+		// Check for empty response.
+		$this->assertEquals( '', $block->render(), 'Should render empty string if the post is not a lesson.' );
+	}
+
+	/**
+	 * Test complete lesson block when the post is not lesson.
+	 */
+	public function testNotEnrolled() {
+		$course = $this->factory->course->create_and_get();
+		$lesson = $this->factory->lesson->create_and_get();
+		add_post_meta( $lesson->ID, '_lesson_course', $course->ID );
+		$this->login_as_student();
+
+		$GLOBALS['post'] = $lesson;
+		$block           = new Complete_Lesson();
+
+		// Check for empty response.
+		$this->assertEquals( '', $block->render(), 'Should render empty string if user is not enrolled.' );
+	}
+
+	/**
+	 * Test complete lesson block for a lesson with quiz that requires passing.
+	 */
+	public function testQuizPassRequired() {
+		$course      = $this->factory->course->create_and_get();
+		$lesson_args = [
+			'meta_input' => [
+				'_lesson_course'      => $course->ID,
+				'_quiz_has_questions' => 1,
+			],
+		];
+		$lesson      = $this->factory->lesson->create_and_get( $lesson_args );
+		$quiz_args   = [
+			'post_parent' => $lesson->ID,
+			'meta_input'  => [
+				'_pass_required' => 'on',
+			],
+		];
+		$this->factory->quiz->create( $quiz_args );
+		$this->login_as_student();
+		\Sensei()->frontend->manually_enrol_learner( get_current_user_id(), $course->ID );
+
+		$GLOBALS['post'] = $lesson;
+		$block           = new Complete_Lesson();
+
+		// Check for empty response.
+		$this->assertEquals( '', $block->render(), 'Should render empty string if the lesson has quiz with questions and requires passing.' );
+	}
+
+	/**
+	 * Test complete lesson block when user already completed the lesson.
+	 */
+	public function testAlreadyCompleted() {
+		$course = $this->factory->course->create_and_get();
+		$lesson = $this->factory->lesson->create_and_get();
+		add_post_meta( $lesson->ID, '_lesson_course', $course->ID );
+		$student = $this->login_as_student();
+		\Sensei()->frontend->manually_enrol_learner( get_current_user_id(), $course->ID );
+		\Sensei_Utils::sensei_start_lesson( $lesson->ID, get_current_user_id(), true );
+
+		$GLOBALS['post'] = $lesson;
+		$block           = new Complete_Lesson();
+
+		// Check for empty response.
+		$this->assertContains( 'Completed', $block->render(), 'Should render empty string if user is not enrolled.' );
+	}
+
+	/**
+	 * Test complete lesson block when lesson can be marked as complete.
+	 */
+	public function testBlock() {
+		$course = $this->factory->course->create_and_get();
+		$lesson = $this->factory->lesson->create_and_get();
+		add_post_meta( $lesson->ID, '_lesson_course', $course->ID );
+		$student = $this->login_as_student();
+		\Sensei()->frontend->manually_enrol_learner( get_current_user_id(), $course->ID );
+
+		$GLOBALS['post'] = $lesson;
+		$block           = new Complete_Lesson();
+
+		// Check for empty response.
+		$this->assertContains( 'Mark complete', $block->render(), 'Should render empty string if user is not enrolled.' );
+	}
+}


### PR DESCRIPTION
Fixes #4405 

### Changes proposed in this Pull Request

* Implements `sensei-lms/course-theme-complete-lesson` block.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course-theme', '__return_true' );`
* Confirm the "Mark complete" button is rendered as **primary** CTA for a lesson.
* Confirm the "Mark complete" button is rendered as **secondary** CTA for a lesson with quiz but not requiring to pass.
* Confirm the "Mark complete" button is rendered as **disabled** CTA for a lesson with a pre-requisite.
* Confirm the "Mark complete" button **is not** rendered if lesson has quiz that requires passing.
* Confirm the "Mark complete" button **is not** rendered if lesson is already completed by the user.
* Confirm the "Mark complete" button completes the lesson and navigates to the next one when clicked.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video


https://user-images.githubusercontent.com/2578542/143580260-9234069f-7092-4b5a-b26b-6701da0d2f4e.mp4

