### PR TITLE
Restrict the order lessons menu to teachers, authors, and above

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -109,7 +109,7 @@ class Sensei_Admin {
 		}
 
 		add_submenu_page( 'edit.php?post_type=course', __( 'Order Courses', 'sensei-lms' ), __( 'Order Courses', 'sensei-lms' ), 'manage_sensei', $this->course_order_page_slug, array( $this, 'course_order_screen' ) );
-		add_submenu_page( 'edit.php?post_type=lesson', __( 'Order Lessons', 'sensei-lms' ), __( 'Order Lessons', 'sensei-lms' ), 'manage_sensei_grades', $this->lesson_order_page_slug, array( $this, 'lesson_order_screen' ) );
+		add_submenu_page( 'edit.php?post_type=lesson', __( 'Order Lessons', 'sensei-lms' ), __( 'Order Lessons', 'sensei-lms' ), 'edit_published_lessons', $this->lesson_order_page_slug, array( $this, 'lesson_order_screen' ) );
 	}
 
 	/**
@@ -1359,7 +1359,7 @@ class Sensei_Admin {
 	 */
 	public function handle_order_lessons() {
 		check_admin_referer( 'order_lessons' );
-		if ( ! current_user_can( 'manage_sensei_grades' ) ) {
+		if ( ! current_user_can( 'edit_published_lessons' ) ) {
 			wp_die( esc_html__( 'Insufficient permissions', 'sensei-lms' ) );
 		}
 

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -109,7 +109,7 @@ class Sensei_Admin {
 		}
 
 		add_submenu_page( 'edit.php?post_type=course', __( 'Order Courses', 'sensei-lms' ), __( 'Order Courses', 'sensei-lms' ), 'manage_sensei', $this->course_order_page_slug, array( $this, 'course_order_screen' ) );
-		add_submenu_page( 'edit.php?post_type=lesson', __( 'Order Lessons', 'sensei-lms' ), __( 'Order Lessons', 'sensei-lms' ), 'edit_lessons', $this->lesson_order_page_slug, array( $this, 'lesson_order_screen' ) );
+		add_submenu_page( 'edit.php?post_type=lesson', __( 'Order Lessons', 'sensei-lms' ), __( 'Order Lessons', 'sensei-lms' ), 'manage_sensei_grades', $this->lesson_order_page_slug, array( $this, 'lesson_order_screen' ) );
 	}
 
 	/**

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1359,6 +1359,9 @@ class Sensei_Admin {
 	 */
 	public function handle_order_lessons() {
 		check_admin_referer( 'order_lessons' );
+		if ( ! current_user_can( 'manage_sensei_grades') ) {
+			wp_die( esc_html__( 'Insufficient permissions', 'sensei-lms' ) );
+		}
 
 		$ordered = null;
 		if ( isset( $_POST['lesson-order'] ) ) {

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1359,7 +1359,7 @@ class Sensei_Admin {
 	 */
 	public function handle_order_lessons() {
 		check_admin_referer( 'order_lessons' );
-		if ( ! current_user_can( 'manage_sensei_grades') ) {
+		if ( ! current_user_can( 'manage_sensei_grades' ) ) {
 			wp_die( esc_html__( 'Insufficient permissions', 'sensei-lms' ) );
 		}
 


### PR DESCRIPTION
Fixes #3376

### Changes proposed in this Pull Request

* Changes the `Order Lessons` capability from `edit_lessons` to `manage_sensei_grades`
* Adds a capability check for `manage_sensei_grades` in the `handle_order_lessons` function

**Disclaimer**:  I'm not 100% sure that `manage_sensei_grades` is the right capability, but here's my reasoning:
1. I thought it made sense for Editors, Teachers, and Administrators to be able to Order Lessons
2. I also thought that Subscribers, Contributors, and Authors should not be able to Order Lessons
3. This capability seemed to fit all those requirements.
4. I could be wrong as I'm not that familiar with Sensei 😃 

### Testing instructions

* Check this PR out
* Create a user with the roles of Contributor, Author, or Subscriber
* Confirm you can't navigate to the Order Lessons screen

<img width="427" alt="Screen Shot 2021-11-24 at 2 52 59 PM" src="https://user-images.githubusercontent.com/3220162/143322805-4e2c3625-d99a-475f-8e95-3cc47e9a0877.png">