### PR TITLE
Add check so that Authors can only order their own lessons.

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1418,11 +1418,13 @@ class Sensei_Admin {
 			$html .= '<option value="">' . esc_html__( 'Select a course', 'sensei-lms' ) . '</option>' . "\n";
 
 			foreach ( $courses as $course ) {
-				$course_id = '';
-				if ( isset( $_GET['course_id'] ) ) {
-					$course_id = intval( $_GET['course_id'] );
+				if ( current_user_can( 'edit_others_posts') || get_current_user_id() == $course->post_author ) {
+					$course_id = '';
+					if ( isset( $_GET['course_id'] ) ) {
+						$course_id = intval( $_GET['course_id'] );
+					}
+					$html .= '<option value="' . esc_attr( intval( $course->ID ) ) . '" ' . selected( $course->ID, $course_id, false ) . '>' . esc_html( get_the_title( $course->ID ) ) . '</option>' . "\n";
 				}
-				$html .= '<option value="' . esc_attr( intval( $course->ID ) ) . '" ' . selected( $course->ID, $course_id, false ) . '>' . esc_html( get_the_title( $course->ID ) ) . '</option>' . "\n";
 			}
 
 			$html .= '</select>' . "\n";

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1418,7 +1418,7 @@ class Sensei_Admin {
 			$html .= '<option value="">' . esc_html__( 'Select a course', 'sensei-lms' ) . '</option>' . "\n";
 
 			foreach ( $courses as $course ) {
-				if ( current_user_can( 'edit_others_posts') || get_current_user_id() == $course->post_author ) {
+				if ( current_user_can( 'edit_others_posts' ) || get_current_user_id() === (int) $course->post_author ) {
 					$course_id = '';
 					if ( isset( $_GET['course_id'] ) ) {
 						$course_id = intval( $_GET['course_id'] );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1409,6 +1409,11 @@ class Sensei_Admin {
 				'order'          => 'ASC',
 			);
 
+			// Ensure that the user either has permission to edit other's courses or is the author of the course.
+			if ( ! current_user_can( 'edit_others_courses' ) ) {
+				$args['author'] = get_current_user_id();
+			}
+
 			$courses = get_posts( $args );
 
 			$html .= '<form action="' . esc_url( admin_url( 'edit.php' ) ) . '" method="get">' . "\n";
@@ -1418,13 +1423,11 @@ class Sensei_Admin {
 			$html .= '<option value="">' . esc_html__( 'Select a course', 'sensei-lms' ) . '</option>' . "\n";
 
 			foreach ( $courses as $course ) {
-				if ( current_user_can( 'edit_others_posts' ) || get_current_user_id() === (int) $course->post_author ) {
-					$course_id = '';
-					if ( isset( $_GET['course_id'] ) ) {
-						$course_id = intval( $_GET['course_id'] );
-					}
-					$html .= '<option value="' . esc_attr( intval( $course->ID ) ) . '" ' . selected( $course->ID, $course_id, false ) . '>' . esc_html( get_the_title( $course->ID ) ) . '</option>' . "\n";
+				$course_id = '';
+				if ( isset( $_GET['course_id'] ) ) {
+					$course_id = intval( $_GET['course_id'] );
 				}
+				$html .= '<option value="' . esc_attr( intval( $course->ID ) ) . '" ' . selected( $course->ID, $course_id, false ) . '>' . esc_html( get_the_title( $course->ID ) ) . '</option>' . "\n";
 			}
 
 			$html .= '</select>' . "\n";


### PR DESCRIPTION
Check if current user can edit other people's posts, or if the current user is the author of that post.

Fixes #4473

### Changes proposed in this Pull Request

* Adds a check to the Order Lessons screen so that you need to have the `edit_others_posts` capability ( Super Admins, Admins, or Editors), OR you need to be the Author of that Course to be able to reorder it.

### Testing instructions

1. Make a course with multiple lessons as User 1.
2. Make a user with the role Author - User 2.
3. Log in as the Author user.
4. Go to Lessons -> Order Lessons
5. From the dropdown you should not be able to see the course created by User 1.
