### PR TITLE
Fix invalid type issue when questions options empty

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1185,11 +1185,12 @@ class Sensei_Question {
 			}
 
 			// Merge right and wrong answers
+			$merged_options = [];
 			if ( is_array( $question_data['question_right_answer'] ) ) {
 
 				$merged_options = array_merge( $question_data['question_wrong_answers'], $question_data['question_right_answer'] );
 
-			} else {
+			} elseif ( is_array( $question_data['question_wrong_answers'] ) ) {
 
 				array_push( $question_data['question_wrong_answers'], $question_data['question_right_answer'] );
 				$merged_options = $question_data['question_wrong_answers'];

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1126,7 +1126,7 @@ class Sensei_Question {
 			$answer_media_filename = '';
 
 			$question_helptext = '';
-			if ( isset( $question_data['question_wrong_answers'][0] ) ) {
+			if ( is_array( $question_data['question_wrong_answers'] ) && isset( $question_data['question_wrong_answers'][0] ) ) {
 
 				$question_helptext = $question_data['question_wrong_answers'][0];
 
@@ -1185,12 +1185,14 @@ class Sensei_Question {
 			}
 
 			// Merge right and wrong answers
-			$merged_options = [];
+			if ( ! is_array( $question_data['question_wrong_answers'] ) ) {
+				$question_data['question_wrong_answers'] = [];
+			}
 			if ( is_array( $question_data['question_right_answer'] ) ) {
 
 				$merged_options = array_merge( $question_data['question_wrong_answers'], $question_data['question_right_answer'] );
 
-			} elseif ( is_array( $question_data['question_wrong_answers'] ) ) {
+			} else {
 
 				array_push( $question_data['question_wrong_answers'], $question_data['question_right_answer'] );
 				$merged_options = $question_data['question_wrong_answers'];


### PR DESCRIPTION
Fixes #4468
### What caused the issue? 

- $question_data['question_wrong_answers'] was not an array but an empty string so $merged_options (answers) were not an array and we were trying to iterate to is

### Changes proposed in this Pull Request

- Set $merged_options (answers)  to an empty array and then check if $question_data['question_wrong_answers'] is an array before setting $merged_options to ist's value

### Testing instructions

**1.  Create a quiz question with radio buttons but without answers**
![image](https://user-images.githubusercontent.com/7208249/144219891-6a02ec34-8d65-46c9-9ed9-7ca64ac2f014.png)
**2. Preview the quiz**
![image](https://user-images.githubusercontent.com/7208249/144220105-37b5596e-c9b8-4e5d-b114-7ca746562ea8.png)
3. **No _debug.login_** {$yoursitename}/app/public/wp-content 