### PR TITLE
Implement the quiz pagination backend

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1297,9 +1297,9 @@ class Sensei_Quiz {
 		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification -- Argument is used for pagination in the frontend.
-		if ( ! empty( $_GET['questions-page'] ) ) {
+		if ( ! empty( $_GET['quiz-page'] ) ) {
 			// phpcs:ignore WordPress.Security.NonceVerification
-			$sensei_question_loop['current_page'] = max( 1, (int) $_GET['questions-page'] );
+			$sensei_question_loop['current_page'] = max( 1, (int) $_GET['quiz-page'] );
 		}
 
 		// Fetch the questions.

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -770,11 +770,13 @@ function sensei_quiz_has_questions() {
 
 	global $sensei_question_loop;
 
-	if ( ! isset( $sensei_question_loop['total'] ) ) {
+	$questions_count = count( $sensei_question_loop['questions'] );
+
+	if ( 0 === $questions_count ) {
 		return false;
 	}
 
-	return $sensei_question_loop['current'] + 1 < $sensei_question_loop['total'];
+	return $sensei_question_loop['current'] + 1 < $questions_count;
 }
 
 /**

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1274,9 +1274,9 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		Sensei_Quiz::start_quiz_questions_loop();
 
 		/* Assert */
-		$this->assertEquals( 2, $sensei_question_loop['posts_per_page'] );
-		$this->assertCount( 2, $sensei_question_loop['questions'] );
-		$this->assertEquals( 10, $sensei_question_loop['total'] );
+		$this->assertEquals( 2, $sensei_question_loop['posts_per_page'], 'The loop `posts_per_page` should be the same as the number defined in the quiz pagination setting.' );
+		$this->assertCount( 2, $sensei_question_loop['questions'], 'The loop questions count should be equal to the questions per page.' );
+		$this->assertEquals( 10, $sensei_question_loop['total'], 'The loop total questions count should be equal to the total questions count of the quiz.' );
 	}
 
 }

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1248,6 +1248,35 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * Ensure that when the quiz pagination is enabled, that is reflected in the loop object.
+	 *
+	 * @covers Sensei_Quiz::start_quiz_questions_loop
+	 * @group  questions
+	 */
+	public function testQuizQuestionsLoopShouldPaginate() {
+		/* Arrange */
+		global $post, $sensei_question_loop;
 
+		$lesson_id = $this->factory->lesson->create();
+		$quiz_id   = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
+		$post      = get_post( $quiz_id );
+
+		$this->factory->question->create_many( 10, [ 'quiz_id' => $quiz_id ] );
+
+		update_post_meta(
+			$quiz_id,
+			'_pagination',
+			wp_json_encode( [ 'pagination_number' => 2 ] )
+		);
+
+		/* Act */
+		Sensei_Quiz::start_quiz_questions_loop();
+
+		/* Assert */
+		$this->assertEquals( 2, $sensei_question_loop['posts_per_page'] );
+		$this->assertCount( 2, $sensei_question_loop['questions'] );
+		$this->assertEquals( 10, $sensei_question_loop['total'] );
+	}
 
 }


### PR DESCRIPTION
Part of #4480

### Changes proposed in this Pull Request

* Add the backend needed to make the quiz pagination.

### Testing instructions

* Enable the quiz pagination feature:
```php
add_filter( 'sensei_feature_flag_quiz_pagination', '__return_true' );
```
* Make a quiz with multiple questions, also make sure to include a _Questions Category_ that has multiple questions in.
* Enable the pagination by updating the quiz pagination settings (see https://github.com/Automattic/sensei/issues/4387).
* Open the quiz in the frontend.
* Make sure the questions listing is paginated.
* Append `?questions-page=2` to the URL.
* Make sure you see the second page of the questions listing.
* Play around with the `questions-page` param and the pagination settings and make sure the results are correct.
* Make sure there are no issues if the quiz pagination settings are missing.