### PR TITLE
Sensei Theme: Adding redirection to first lesson after course enrolment.

### DIFF
--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -839,7 +839,7 @@ class Sensei_Course_Structure {
 	/**
 	 * Get first incomplete lesson ID or `false` if there is none.
 	 *
-	 * @return mixed|false
+	 * @return int|false
 	 */
 	public function get_first_incomplete_lesson_id() {
 		list( $lesson_ids, ) = $this->flatten_structure( $this->get() );

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -828,10 +828,27 @@ class Sensei_Course_Structure {
 						return 1;
 					}
 
-					return false === $b_position || $a_position < $b_position ? -1 : 1;
+					return false === $b_position || $a_position < $b_position ? - 1 : 1;
 				}
 			);
 		}
+
 		return $structure;
+	}
+
+	/**
+	 * Get first incomplete lesson ID or `false` if there is none.
+	 *
+	 * @return mixed|false
+	 */
+	public function get_first_incomplete_lesson_id() {
+		list( $lesson_ids, ) = $this->flatten_structure( $this->get() );
+		foreach ( $lesson_ids as $lesson_id ) {
+			if ( ! Sensei_Utils::user_completed_lesson( $lesson_id ) ) {
+				return $lesson_id;
+			}
+		}
+
+		return false;
 	}
 }

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -132,6 +132,9 @@ class Sensei_Course {
 		// ensure the course category page respects the manual order set for courses
 		add_filter( 'pre_get_posts', array( __CLASS__, 'alter_course_category_order' ), 10, 1 );
 
+		// filter the redirect url after enrolment
+		add_filter( 'sensei_start_course_redirect_url', array( __CLASS__, 'alter_redirect_url_after_enrolment' ), 10, 2 );
+
 		// Allow course archive to be setup as the home page
 		if ( (int) get_option( 'page_on_front' ) > 0 ) {
 			add_action( 'pre_get_posts', array( $this, 'allow_course_archive_on_front_page' ), 9, 1 );
@@ -3885,6 +3888,28 @@ class Sensei_Course {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Alters the redirect url after a user enrols to a course.
+	 *
+	 * @param String  $url  Default redirect url.
+	 * @param WP_Post $post Post object for course.
+	 *
+	 * @return String
+	 */
+	public static function alter_redirect_url_after_enrolment( $url, $post ) {
+
+		$course_id = $post->ID;
+		if ( Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id ) ) {
+			$lessons = Sensei()->course->course_lessons( $course_id );
+			if ( count( $lessons ) > 0 ) {
+				$url = get_permalink( $lessons[0]->ID );
+			}
+		}
+
+		return $url;
+
 	}
 }
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3901,10 +3901,10 @@ class Sensei_Course {
 	public static function alter_redirect_url_after_enrolment( $url, $post ) {
 
 		$course_id = $post->ID;
-		if ( Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id ) ) {
-			$lessons = Sensei()->course->course_lessons( $course_id );
-			if ( count( $lessons ) > 0 ) {
-				$url = get_permalink( $lessons[0]->ID );
+		if ( Sensei_Course_Theme_Option::instance()->has_sensei_theme_enabled( $course_id ) ) {
+			$first_incomplete_lesson_id = Sensei_Course_Structure::instance( $course_id )->get_first_incomplete_lesson_id();
+			if ( false !== $first_incomplete_lesson_id ) {
+				$url = get_permalink( $first_incomplete_lesson_id );
 			}
 		}
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -132,7 +132,7 @@ class Sensei_Course {
 		// ensure the course category page respects the manual order set for courses
 		add_filter( 'pre_get_posts', array( __CLASS__, 'alter_course_category_order' ), 10, 1 );
 
-		// filter the redirect url after enrolment
+		// Filter the redirect url after enrolment.
 		add_filter( 'sensei_start_course_redirect_url', array( __CLASS__, 'alter_redirect_url_after_enrolment' ), 10, 2 );
 
 		// Allow course archive to be setup as the home page

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -137,7 +137,7 @@ class Sensei_Course_Theme_Option {
 	 *
 	 * @return bool
 	 */
-	public static function has_sensei_theme_enabled( $course_id ) {
+	public function has_sensei_theme_enabled( int $course_id ) {
 
 		$theme = get_post_meta( $course_id, self::THEME_POST_META_NAME, true );
 

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -123,13 +123,25 @@ class Sensei_Course_Theme_Option {
 			return false;
 		}
 
-		$theme = get_post_meta( $course_id, self::THEME_POST_META_NAME, true );
-
-		if ( self::SENSEI_THEME !== $theme ) {
+		if ( ! self::has_sensei_theme_enabled( $course_id ) ) {
 			return false;
 		}
 
 		return true;
+	}
+
+	/**
+	 * Check if the given course has the Sensei Theme enabled or not.
+	 *
+	 * @param int $course_id Course ID.
+	 *
+	 * @return bool
+	 */
+	public static function has_sensei_theme_enabled( $course_id ) {
+
+		$theme = get_post_meta( $course_id, self::THEME_POST_META_NAME, true );
+
+		return self::SENSEI_THEME === $theme;
 	}
 
 	/**

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-option.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-option.php
@@ -16,9 +16,23 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 
-	private Sensei_Factory $factory;
-	private Sensei_Course_Theme_Option $instance;
+	/**
+	 * Sensei Factory helper class - useful to create objects for testing.
+	 *
+	 * @var Sensei_Factory
+	 */
+	private $factory;
 
+	/**
+	 * Instance of `Sensei_Course_Theme_Option` under test.
+	 *
+	 * @var Sensei_Course_Theme_Option
+	 */
+	private $instance;
+
+	/**
+	 * Setup method. Run first on every test execution.
+	 */
 	public function setup() {
 		parent::setup();
 		$this->factory  = new Sensei_Factory();
@@ -32,6 +46,9 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 		$this->assertTrue( class_exists( 'Sensei_Course_Theme_Option' ), 'Sensei Course Theme class should exist' );
 	}
 
+	/**
+	 * Ensure `has_sensei_theme_enabled` returns false by default.
+	 */
 	public function testHasSenseiThemeEnabledReturnsFalseByDefault() {
 		$course_id = $this->factory->course->create();
 
@@ -40,6 +57,9 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 		$this->assertFalse( $output, 'By default the `has_sensei_theme_enabled` method must return false.' );
 	}
 
+	/**
+	 * Ensure `has_sensei_theme_enabled` returns false if WordPress theme is enabled.
+	 */
 	public function testHasSenseiThemeEnabledReturnsFalseWhenUsingWordpressTheme() {
 		$course_id = $this->factory->course->create();
 		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::WORDPRESS_THEME );
@@ -49,6 +69,9 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 		$this->assertFalse( $output, '`has_sensei_theme_enabled` method must return false when WordPress theme is enabled.' );
 	}
 
+	/**
+	 * Ensure `has_sensei_theme_enabled` returns true if Sensei theme is enabled.
+	 */
 	public function testHasSenseiThemeEnabledReturnsTrueWhenUsingSenseiTheme() {
 		$course_id = $this->factory->course->create();
 		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-option.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-option.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * This file contains the Sensei_Course_Theme_Option_Test class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Tests for Sensei_Course_Theme_Option class.
+ *
+ * @group course-theme
+ */
+class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
+
+	private Sensei_Factory $factory;
+	private Sensei_Course_Theme_Option $instance;
+
+	public function setup() {
+		parent::setup();
+		$this->factory  = new Sensei_Factory();
+		$this->instance = Sensei_Course_Theme_Option::instance();
+	}
+
+	/**
+	 * Testing the Sensei_Course_Theme_Option class to make sure it is loaded.
+	 */
+	public function testClassInstance() {
+		$this->assertTrue( class_exists( 'Sensei_Course_Theme_Option' ), 'Sensei Course Theme class should exist' );
+	}
+
+	public function testHasSenseiThemeEnabledReturnsFalseByDefault() {
+		$course_id = $this->factory->course->create();
+
+		$output = $this->instance->has_sensei_theme_enabled( $course_id );
+
+		$this->assertFalse( $output, 'By default the `has_sensei_theme_enabled` method must return false.' );
+	}
+
+	public function testHasSenseiThemeEnabledReturnsFalseWhenUsingWordpressTheme() {
+		$course_id = $this->factory->course->create();
+		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::WORDPRESS_THEME );
+
+		$output = $this->instance->has_sensei_theme_enabled( $course_id );
+
+		$this->assertFalse( $output, '`has_sensei_theme_enabled` method must return false when WordPress theme is enabled.' );
+	}
+
+	public function testHasSenseiThemeEnabledReturnsTrueWhenUsingSenseiTheme() {
+		$course_id = $this->factory->course->create();
+		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
+
+		$output = $this->instance->has_sensei_theme_enabled( $course_id );
+
+		$this->assertTrue( $output, '`has_sensei_theme_enabled` method must return true when Sensei theme is enabled.' );
+	}
+}

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -1539,7 +1539,7 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 					[
 						'type'  => 'lesson',
 						'title' => 'Lesson A',
-						'id'    => $lesson_ids[0]
+						'id'    => $lesson_ids[0],
 					],
 				],
 			],
@@ -1551,7 +1551,7 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 					[
 						'type'  => 'lesson',
 						'title' => 'Lesson B',
-						'id'    => $lesson_ids[1]
+						'id'    => $lesson_ids[1],
 					],
 				],
 			],


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Using the filter `sensei_start_course_redirect_url` to override the redirection url after enrolling if Sensei Theme is enabled for the given course.
* Created `Sensei_Course_Theme::has_sensei_theme_enabled` method to check if a course has the Sensei Theme enabled or not.

### Special considerations
- Change only applies to Sensei Theme courses.
- If no lessons available the redirection override will not work — user will be redirected to the course page.
- Only published lessons are taken into account.

### Testing instructions
* Enable the feature flag: `add_filter( 'sensei_feature_flag_sensei_theme', '__return_true' );`
* Enable Sensei Theme for a course with the sidebar option in the course editor.
* Login with a unenrolled user (or unenroll her from the Learner Management section)
* Go to the Course view and click on the "Take course" button.
* You should land in the first lesson.
* Repeating the action for a course without the "Sensei Theme" will make the user land in the same course page.


### Screenshot / Video
![Kapture 2021-12-02 at 12 08 13](https://user-images.githubusercontent.com/799065/144411138-23430a6e-a494-4db4-ac12-11b26d1f5a23.gif)
