### PR TITLE
Update tests readme with information about svn

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -41,6 +41,8 @@ To install MySQL follow the instructions provided [here](https://dev.mysql.com/d
 
 To install the WP test suite you need to first run `composer install` and `npm install` in the top level directory. Then you need to use the `tests/bin/install-wp-tests.sh` script to install the WP test suite.
 
+`install-wp-tests.sh` script needs `svn` to be installed in order to create test files, you can do that by running `npm install svn`
+
 If you used Docker to create a database, you need to pass the database name and the user credentials from the previous step. You also need to skip creating a new database:
 
 `TMPDIR=/tmp ./tests/bin/install-wp-tests.sh <test_db_name> <test_user_name> <test_user_password> 127.0.0.1 latest true`

--- a/tests/README.md
+++ b/tests/README.md
@@ -41,7 +41,7 @@ To install MySQL follow the instructions provided [here](https://dev.mysql.com/d
 
 To install the WP test suite you need to first run `composer install` and `npm install` in the top level directory. Then you need to use the `tests/bin/install-wp-tests.sh` script to install the WP test suite.
 
-`install-wp-tests.sh` script needs `svn` to be installed in order to create test files, you can do that by running `npm install svn`
+`install-wp-tests.sh` script needs `svn` to be installed in order to create test files. You can find instructions for installing ``svn`` [here](https://subversion.apache.org/packages.html).
 
 If you used Docker to create a database, you need to pass the database name and the user credentials from the previous step. You also need to skip creating a new database:
 


### PR DESCRIPTION
### Fixes 
Not an issue

### Changes proposed in this Pull Request

- Update a test readme to include information that svn is needed to be installed in order for test files to be created

- When trying to initiate the tests for the first time there was a very generic and misleading error message, but what was actually happening was that test files were not created by the ```install-wp-tests.sh```

### Testing instructions
https://github.com/Automattic/sensei/tree/update/update_readme_tips_on_running_php_tests/tests#readme


### Screenshot / Video
![image](https://user-images.githubusercontent.com/7208249/144418272-b51acf63-9198-447e-987b-aa54506e2ade.png)

![image](https://user-images.githubusercontent.com/7208249/144418484-78fe81d2-125a-4004-a4d4-82d0635df63a.png)

