### PR TITLE
Renamed learner -> student in all user-facing occurrences

### DIFF
--- a/assets/blocks/course-completed-actions/index.js
+++ b/assets/blocks/course-completed-actions/index.js
@@ -15,7 +15,7 @@ export const registerCourseCompletedActionsBlock = () => {
 		name: 'sensei-lms/course-completed-actions',
 		title: __( 'Course Completed Actions', 'sensei-lms' ),
 		description: __(
-			'Prompt learners to take action after completing a course.',
+			'Prompt students to take action after completing a course.',
 			'sensei-lms'
 		),
 		category: 'sensei-lms',
@@ -42,7 +42,7 @@ export const registerCourseCompletedActionsBlock = () => {
 		name: 'sensei-lms/more-courses-button',
 		title: __( 'Find More Courses', 'sensei-lms' ),
 		description: __(
-			'Prompt learners to find more courses.',
+			'Prompt students to find more courses.',
 			'sensei-lms'
 		),
 		keywords: [

--- a/assets/blocks/course-outline/status-preview/status-control/index.js
+++ b/assets/blocks/course-outline/status-preview/status-control/index.js
@@ -43,7 +43,7 @@ export const StatusControl = ( {
 		<RadioControl
 			className="wp-block-sensei-lms-course-outline-status-control"
 			help={ __(
-				'Preview a status. The actual status that the learner sees is determined by their progress in the course.',
+				'Preview a status. The actual status that the student sees is determined by their progress in the course.',
 				'sensei-lms'
 			) }
 			{ ...props }

--- a/assets/blocks/course-results-block/index.js
+++ b/assets/blocks/course-results-block/index.js
@@ -13,7 +13,7 @@ import edit from './course-results-edit';
 export default {
 	title: __( 'Course Results', 'sensei-lms' ),
 	description: __(
-		'Show course results to learners on the course completion page.',
+		'Show course results to students on the course completion page.',
 		'sensei-lms'
 	),
 	keywords: [

--- a/assets/blocks/learner-courses-block/index.js
+++ b/assets/blocks/learner-courses-block/index.js
@@ -11,19 +11,19 @@ import metadata from './block.json';
 import { LearnerCoursesIcon as icon } from '../../icons';
 
 export default {
-	title: __( 'Learner Courses', 'sensei-lms' ),
+	title: __( 'Student Courses', 'sensei-lms' ),
 	description: __(
-		'Manage what learners see on their dashboard. This block is only displayed to logged in learners.',
+		'Manage what students see on their dashboard. This block is only displayed to logged in students.',
 		'sensei-lms'
 	),
 	keywords: [
-		__( 'Learner Courses', 'sensei-lms' ),
+		__( 'Student Courses', 'sensei-lms' ),
 		__( 'My Courses', 'sensei-lms' ),
 		__( 'Dashboard', 'sensei-lms' ),
 		__( 'Courses', 'sensei-lms' ),
 		__( 'Enrolled', 'sensei-lms' ),
 		__( 'Student', 'sensei-lms' ),
-		__( 'Learner', 'sensei-lms' ),
+		__( 'Student', 'sensei-lms' ),
 	],
 	example: {},
 	icon,

--- a/assets/blocks/learner-courses-block/index.js
+++ b/assets/blocks/learner-courses-block/index.js
@@ -22,7 +22,7 @@ export default {
 		__( 'Dashboard', 'sensei-lms' ),
 		__( 'Courses', 'sensei-lms' ),
 		__( 'Enrolled', 'sensei-lms' ),
-		__( 'Student', 'sensei-lms' ),
+		__( 'Learner', 'sensei-lms' ),
 		__( 'Student', 'sensei-lms' ),
 	],
 	example: {},

--- a/assets/blocks/learner-messages-button-block/index.js
+++ b/assets/blocks/learner-messages-button-block/index.js
@@ -23,10 +23,10 @@ export default createButtonBlockType( {
 	settings: {
 		name: 'sensei-lms/button-learner-messages',
 		description: __(
-			'Enable a learner to view their messages. This block is only displayed if the learner is logged in and private messaging is enabled.',
+			'Enable a student to view their messages. This block is only displayed if the student is logged in and private messaging is enabled.',
 			'sensei-lms'
 		),
-		title: __( 'Learner Messages Button', 'sensei-lms' ),
+		title: __( 'Student Messages Button', 'sensei-lms' ),
 		attributes,
 		styles: [
 			BlockStyles.Fill,

--- a/assets/blocks/learner-messages-button-block/messages-disabled-notice.js
+++ b/assets/blocks/learner-messages-button-block/messages-disabled-notice.js
@@ -31,7 +31,7 @@ const MessagesDisabledNotice = ( { children, attributes: { isPreview } } ) => {
 		if ( '1' === window.sensei_messages.disabled ) {
 			createWarningNotice(
 				__(
-					'You have added the "Learner Messages Button" block to your editor, but messages are disabled in your settings.',
+					'You have added the "Student Messages Button" block to your editor, but messages are disabled in your settings.',
 					'sensei-lms'
 				),
 				{

--- a/assets/blocks/lesson-actions/complete-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/complete-lesson-block/index.js
@@ -17,7 +17,7 @@ export default createButtonBlockType( {
 		parent: [ 'sensei-lms/lesson-actions' ],
 		title: __( 'Complete Lesson', 'sensei-lms' ),
 		description: __(
-			'Enable a learner to mark the lesson as complete. This block is only displayed if the lesson has no quiz or the quiz is optional.',
+			'Enable a student to mark the lesson as complete. This block is only displayed if the lesson has no quiz or the quiz is optional.',
 			'sensei-lms'
 		),
 		keywords: [

--- a/assets/blocks/lesson-actions/lesson-actions-block/index.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/index.js
@@ -14,7 +14,7 @@ import icon from '../../../icons/buttons-icon';
 export default {
 	title: __( 'Lesson Actions', 'sensei-lms' ),
 	description: __(
-		'Enable a learner to perform specific actions for a lesson.',
+		'Enable a student to perform specific actions for a lesson.',
 		'sensei-lms'
 	),
 	keywords: [

--- a/assets/blocks/lesson-actions/next-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/next-lesson-block/index.js
@@ -17,7 +17,7 @@ export default createButtonBlockType( {
 		title: __( 'Next Lesson', 'sensei-lms' ),
 		parent: [ 'sensei-lms/lesson-actions' ],
 		description: __(
-			'Enable a learner to move to the next lesson. This block is only displayed if the current lesson has been completed.',
+			'Enable a student to move to the next lesson. This block is only displayed if the current lesson has been completed.',
 			'sensei-lms'
 		),
 		keywords: [

--- a/assets/blocks/lesson-actions/reset-lesson-block/index.js
+++ b/assets/blocks/lesson-actions/reset-lesson-block/index.js
@@ -17,7 +17,7 @@ export default createButtonBlockType( {
 		title: __( 'Reset Lesson', 'sensei-lms' ),
 		parent: [ 'sensei-lms/lesson-actions' ],
 		description: __(
-			'Enable a learner to reset their progress. This block is only displayed if the lesson is completed and has no quiz, or the quiz is completed and retakes are enabled.',
+			'Enable a student to reset their progress. This block is only displayed if the lesson is completed and has no quiz, or the quiz is completed and retakes are enabled.',
 			'sensei-lms'
 		),
 		keywords: [

--- a/assets/blocks/lesson-actions/view-quiz-block/index.js
+++ b/assets/blocks/lesson-actions/view-quiz-block/index.js
@@ -16,7 +16,7 @@ export default createButtonBlockType( {
 		name: 'sensei-lms/button-view-quiz',
 		title: __( 'View Quiz', 'sensei-lms' ),
 		parent: [ 'sensei-lms/lesson-actions' ],
-		description: __( 'Enable a learner to view the quiz.', 'sensei-lms' ),
+		description: __( 'Enable a student to view the quiz.', 'sensei-lms' ),
 		keywords: [
 			__( 'Quiz', 'sensei-lms' ),
 			__( 'Lesson', 'sensei-lms' ),

--- a/assets/blocks/quiz/question-block/single-question.js
+++ b/assets/blocks/quiz/question-block/single-question.js
@@ -70,7 +70,7 @@ const SingleQuestion = ( props ) => {
 				{ notice }
 				<p>
 					{ __(
-						"Incomplete questions added to a quiz won't be displayed to the learner.",
+						"Incomplete questions added to a quiz won't be displayed to the student.",
 						'sensei-lms'
 					) }
 				</p>

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -117,13 +117,13 @@ const QuizSettings = ( {
 										id="sensei-lms-quiz-block-failed-feedback-options"
 										className="sensei-lms-subsection-control"
 										help={ __(
-											'What learners see when reviewing their quiz after grading.',
+											'What students see when reviewing their quiz after grading.',
 											'sensei-lms'
 										) }
 									>
 										<h3>
 											{ __(
-												'If learner does not pass quiz',
+												'If student does not pass quiz',
 												'sensei-lms'
 											) }
 										</h3>

--- a/assets/blocks/quiz/quiz-block/quiz-validation.js
+++ b/assets/blocks/quiz/quiz-block/quiz-validation.js
@@ -118,7 +118,7 @@ const QuizValidationResult = ( { clientId, setMeta } ) => {
 				{ notice }
 				<p>
 					{ __(
-						"Incomplete questions won't be displayed to the learner when taking the quiz.",
+						"Incomplete questions won't be displayed to the student when taking the quiz.",
 						'sensei-lms'
 					) }
 				</p>

--- a/assets/blocks/view-results-block/index.js
+++ b/assets/blocks/view-results-block/index.js
@@ -16,7 +16,7 @@ export default createButtonBlockType( {
 	settings: {
 		name: 'sensei-lms/button-view-results',
 		description: __(
-			'Enable a learner to view their course results.',
+			'Enable a student to view their course results.',
 			'sensei-lms'
 		),
 		title: __( 'View Results', 'sensei-lms' ),

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -63,7 +63,7 @@ class Sensei_Learner_Management {
 	 * @param string $file Main plugin file name.
 	 */
 	public function __construct( $file ) {
-		$this->name      = __( 'Learner Management', 'sensei-lms' );
+		$this->name      = __( 'Student Management', 'sensei-lms' );
 		$this->file      = $file;
 		$this->page_slug = 'sensei_learners';
 
@@ -131,7 +131,7 @@ class Sensei_Learner_Management {
 		if ( isset( $this->bulk_actions_controller ) && $this->bulk_actions_controller->is_current_page() ) {
 
 			$args = array(
-				'label'   => __( 'Learners per page', 'sensei-lms' ),
+				'label'   => __( 'Students per page', 'sensei-lms' ),
 				'default' => 20,
 				'option'  => self::SENSEI_LEARNER_MANAGEMENT_PER_PAGE,
 			);
@@ -168,19 +168,19 @@ class Sensei_Learner_Management {
 		);
 
 		$data = array(
-			'remove_generic_confirm'     => __( 'Are you sure you want to remove this learner?', 'sensei-lms' ),
-			'remove_from_lesson_confirm' => __( 'Are you sure you want to remove the learner from this lesson?', 'sensei-lms' ),
-			'remove_from_course_confirm' => __( 'Are you sure you want to remove this learner\'s enrollment in the course?', 'sensei-lms' ),
-			'enrol_in_course_confirm'    => __( 'Are you sure you want to enroll the learner in this course?', 'sensei-lms' ),
-			'restore_enrollment_confirm' => __( 'Are you sure you want to restore the learner enrollment in this course?', 'sensei-lms' ),
-			'reset_lesson_confirm'       => __( 'Are you sure you want to reset the progress of this learner for this lesson?', 'sensei-lms' ),
-			'reset_course_confirm'       => __( 'Are you sure you want to reset the progress of this learner for this course?', 'sensei-lms' ),
-			'remove_progress_confirm'    => __( 'Are you sure you want to remove the progress of this learner for this course?', 'sensei-lms' ),
+			'remove_generic_confirm'     => __( 'Are you sure you want to remove this student?', 'sensei-lms' ),
+			'remove_from_lesson_confirm' => __( 'Are you sure you want to remove the student from this lesson?', 'sensei-lms' ),
+			'remove_from_course_confirm' => __( 'Are you sure you want to remove this student\'s enrollment in the course?', 'sensei-lms' ),
+			'enrol_in_course_confirm'    => __( 'Are you sure you want to enroll the student in this course?', 'sensei-lms' ),
+			'restore_enrollment_confirm' => __( 'Are you sure you want to restore the student enrollment in this course?', 'sensei-lms' ),
+			'reset_lesson_confirm'       => __( 'Are you sure you want to reset the progress of this student for this lesson?', 'sensei-lms' ),
+			'reset_course_confirm'       => __( 'Are you sure you want to reset the progress of this student for this course?', 'sensei-lms' ),
+			'remove_progress_confirm'    => __( 'Are you sure you want to remove the progress of this student for this course?', 'sensei-lms' ),
 			'modify_user_post_nonce'     => wp_create_nonce( 'modify_user_post_nonce' ),
 			'search_users_nonce'         => wp_create_nonce( 'search-users' ),
 			'edit_date_nonce'            => wp_create_nonce( 'edit_date_nonce' ),
 			'course_category_nonce'      => wp_create_nonce( 'course_category_nonce' ),
-			'selectplaceholder'          => __( 'Select learners to manually enroll...', 'sensei-lms' ),
+			'selectplaceholder'          => __( 'Select students to manually enroll...', 'sensei-lms' ),
 		);
 
 		wp_localize_script( 'sensei-learners-general', 'woo_learners_general_data', $data );
@@ -789,50 +789,50 @@ class Sensei_Learner_Management {
 				case 'error_enrol':
 					$notice = [
 						'error',
-						__( 'An error occurred while enrolling the learner.', 'sensei-lms' ),
+						__( 'An error occurred while enrolling the student.', 'sensei-lms' ),
 					];
 					break;
 				case 'error_restore_enrollment':
 					$notice = [
 						'error',
-						__( 'An error occurred while restoring learner enrollment.', 'sensei-lms' ),
+						__( 'An error occurred while restoring student enrollment.', 'sensei-lms' ),
 					];
 					break;
 				case 'error_enrol_multiple':
 					$notice = [
 						'error',
-						__( 'An error occurred while enrolling the learners.', 'sensei-lms' ),
+						__( 'An error occurred while enrolling the students.', 'sensei-lms' ),
 					];
 					break;
 				case 'error_withdraw':
 					$notice = [
 						'error',
-						__( 'An error occurred removing the learner\'s enrollment.', 'sensei-lms' ),
+						__( 'An error occurred removing the student\'s enrollment.', 'sensei-lms' ),
 					];
 					break;
 				case 'success_withdraw':
 					$notice = [
 						'updated',
-						__( 'Learner\'s enrollment has been removed.', 'sensei-lms' ),
+						__( 'Student\'s enrollment has been removed.', 'sensei-lms' ),
 					];
 					break;
 				case 'success_enrol':
 					$notice = [
 						'updated',
-						__( 'Learner has been enrolled.', 'sensei-lms' ),
+						__( 'Student has been enrolled.', 'sensei-lms' ),
 					];
 					break;
 				case 'success_restore_enrollment':
 					$notice = [
 						'updated',
-						__( 'Learner enrollment has been restored.', 'sensei-lms' ),
+						__( 'Student enrollment has been restored.', 'sensei-lms' ),
 					];
 					break;
 				case 'success_bulk':
 				case 'success_enrol_multiple':
 					$notice = [
 						'updated',
-						__( 'Learners have been enrolled.', 'sensei-lms' ),
+						__( 'Student have been enrolled.', 'sensei-lms' ),
 					];
 					break;
 			}

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -99,7 +99,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 		_deprecated_function( __METHOD__, '3.0.0' );
 
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
-			add_submenu_page( 'sensei', __( 'Learner Admin', 'sensei-lms' ), __( 'Learner Admin', 'sensei-lms' ), 'manage_sensei_grades', 'sensei_learner_admin', array( $this, 'learner_admin_page' ) );
+			add_submenu_page( 'sensei', __( 'Student Admin', 'sensei-lms' ), __( 'Student Admin', 'sensei-lms' ), 'manage_sensei_grades', 'sensei_learner_admin', array( $this, 'learner_admin_page' ) );
 		}
 	}
 
@@ -109,7 +109,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	 * @param Sensei_Learner_Management $management The learner managemnt object.
 	 */
 	public function __construct( $management ) {
-		$this->name               = __( 'Bulk Learner Actions', 'sensei-lms' );
+		$this->name               = __( 'Bulk Student Actions', 'sensei-lms' );
 		$this->page_slug          = $management->page_slug;
 		$this->view               = 'sensei_learner_admin';
 		$this->learner_management = $management;
@@ -402,7 +402,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 				break;
 			case 'action-success':
 				$msg_class = 'notice notice-success';
-				$msg       = __( 'Bulk learner action succeeded', 'sensei-lms' );
+				$msg       = __( 'Bulk student action succeeded', 'sensei-lms' );
 				break;
 		}
 

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -93,7 +93,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	public function get_columns() {
 		$columns = array(
 			'cb'         => '<label class="screen-reader-text" for="cb-select-all-1">Select All</label><input id="cb-select-all-1" type="checkbox">',
-			'learner'    => __( 'Learner', 'sensei-lms' ),
+			'learner'    => __( 'Student', 'sensei-lms' ),
 			'progress'   => __( 'Course Progress', 'sensei-lms' ),
 			'enrolments' => __( 'Enrollments', 'sensei-lms' ),
 		);
@@ -248,7 +248,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	 * @see WP_List_Table
 	 */
 	public function no_items() {
-		$text = __( 'No learners found.', 'sensei-lms' );
+		$text = __( 'No students found.', 'sensei-lms' );
 		echo wp_kses_post( apply_filters( 'sensei_learners_no_items_text', $text ) );
 	}
 
@@ -306,7 +306,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	private function render_bulk_action_select_box() {
 		$rendered     =
 			'<select name="sensei_bulk_action_select" id="bulk-action-selector-top">' .
-			'<option value="">' . esc_html__( 'Bulk Learner Actions', 'sensei-lms' ) . '</option>';
+			'<option value="">' . esc_html__( 'Bulk Student Actions', 'sensei-lms' ) . '</option>';
 		$bulk_actions = $this->controller->get_known_bulk_actions();
 
 		foreach ( $bulk_actions as $value => $translation ) {
@@ -372,7 +372,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	 * Returns the search button text.
 	 */
 	public function search_button() {
-		return __( 'Search Learners', 'sensei-lms' );
+		return __( 'Search Students', 'sensei-lms' );
 	}
 
 	/**

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -164,7 +164,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		switch ( $this->view ) {
 			case 'learners':
 				$columns = array(
-					'title'            => __( 'Learner', 'sensei-lms' ),
+					'title'            => __( 'Student', 'sensei-lms' ),
 					'enrolment_status' => __( 'Enrollment', 'sensei-lms' ),
 					'user_status'      => __( 'Status', 'sensei-lms' ),
 					'date_started'     => __( 'Date Started', 'sensei-lms' ),
@@ -175,7 +175,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			case 'lessons':
 				$columns = array(
 					'title'        => __( 'Lesson', 'sensei-lms' ),
-					'num_learners' => __( '# Learners', 'sensei-lms' ),
+					'num_learners' => __( '# Students', 'sensei-lms' ),
 					'updated'      => __( 'Last Updated', 'sensei-lms' ),
 				);
 				break;
@@ -184,7 +184,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			default:
 				$columns = array(
 					'title'        => __( 'Course', 'sensei-lms' ),
-					'num_learners' => __( '# Learners', 'sensei-lms' ),
+					'num_learners' => __( '# Students', 'sensei-lms' ),
 					'updated'      => __( 'Last Updated', 'sensei-lms' ),
 				);
 				break;
@@ -686,7 +686,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 								),
 								admin_url( 'admin.php' )
 							)
-						) . '">' . esc_html__( 'Manage learners', 'sensei-lms' ) . '</a> ' . $grading_action,
+						) . '">' . esc_html__( 'Manage students', 'sensei-lms' ) . '</a> ' . $grading_action,
 					),
 					$item,
 					$this->course_id
@@ -750,7 +750,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 								),
 								admin_url( 'admin.php' )
 							)
-						) . '">' . esc_html__( 'Manage learners', 'sensei-lms' ) . '</a> ' . $grading_action,
+						) . '">' . esc_html__( 'Manage students', 'sensei-lms' ) . '</a> ' . $grading_action,
 					),
 					$item
 				);
@@ -773,7 +773,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	 * @return string The form.
 	 */
 	private function get_edit_start_date_form( $user_activity, $post_id, $post_type ) : string {
-		$submit_button_text = __( 'Update Learner', 'sensei-lms' );
+		$submit_button_text = __( 'Update Student', 'sensei-lms' );
 
 		return '<form class="edit-start-date">
 				<a class="edit-start-date-submit button" data-user-id="' . esc_attr( $user_activity->user_id ) . '" data-post-id="' . esc_attr( $post_id ) . '" data-post-type="' . esc_attr( $post_type ) . '" data-comment-id="' . esc_attr( $user_activity->comment_ID ) . '">' . esc_html( $submit_button_text ) . '</a>
@@ -1001,7 +1001,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	public function no_items() {
 		switch ( $this->view ) {
 			case 'learners':
-				$text = __( 'No learners found.', 'sensei-lms' );
+				$text = __( 'No students found.', 'sensei-lms' );
 				break;
 
 			case 'lessons':
@@ -1121,16 +1121,16 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 		switch ( $enrolment_status ) {
 			case 'enrolled':
-				$link_title = esc_html__( 'Enrolled Learners', 'sensei-lms' );
+				$link_title = esc_html__( 'Enrolled Students', 'sensei-lms' );
 				break;
 			case 'unenrolled':
-				$link_title = esc_html__( 'Unenrolled Learners', 'sensei-lms' );
+				$link_title = esc_html__( 'Unenrolled Students', 'sensei-lms' );
 				break;
 			case 'manual':
-				$link_title = esc_html__( 'Manually Enrolled Learners', 'sensei-lms' );
+				$link_title = esc_html__( 'Manually Enrolled Students', 'sensei-lms' );
 				break;
 			case 'all':
-				$link_title = esc_html__( 'All Learners', 'sensei-lms' );
+				$link_title = esc_html__( 'All Students', 'sensei-lms' );
 				break;
 		}
 
@@ -1206,7 +1206,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			<h2 class="postbox-title">
 				<?php
 				// translators: Placeholder is the post type.
-				printf( esc_html__( 'Add Learner to %1$s', 'sensei-lms' ), esc_html( $post_type ) );
+				printf( esc_html__( 'Add Student to %1$s', 'sensei-lms' ), esc_html( $post_type ) );
 				?>
 			</h2>
 			<div class="inside">
@@ -1215,9 +1215,9 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 						<select name="add_user_id[]" id="add_learner_search" multiple="multiple" style="min-width:300px;">
 						</select>
 						<?php if ( 'lesson' === $form_post_type ) { ?>
-							<label for="add_complete_lesson"><input type="checkbox" id="add_complete_lesson" name="add_complete_lesson"  value="yes" /> <?php esc_html_e( 'Complete lesson for learner', 'sensei-lms' ); ?></label>
+							<label for="add_complete_lesson"><input type="checkbox" id="add_complete_lesson" name="add_complete_lesson"  value="yes" /> <?php esc_html_e( 'Complete lesson for student', 'sensei-lms' ); ?></label>
 						<?php } elseif ( 'course' === $form_post_type ) { ?>
-							<label for="add_complete_course"><input type="checkbox" id="add_complete_course" name="add_complete_course"  value="yes" /> <?php esc_html_e( 'Complete course for learner', 'sensei-lms' ); ?></label>
+							<label for="add_complete_course"><input type="checkbox" id="add_complete_course" name="add_complete_course"  value="yes" /> <?php esc_html_e( 'Complete course for student', 'sensei-lms' ); ?></label>
 						<?php } ?>
 						<br/>
 						<span class="description"><?php esc_html_e( 'Search for a user by typing their name or username.', 'sensei-lms' ); ?></span>
@@ -1232,7 +1232,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 						<p><span class="description">
 							<?php
 							// translators: Placeholder is the course title.
-							printf( esc_html__( 'Learner will also be added to the course \'%1$s\' if they are not already taking it.', 'sensei-lms' ), esc_html( $course_title ) );
+							printf( esc_html__( 'Student will also be added to the course \'%1$s\' if they are not already taking it.', 'sensei-lms' ), esc_html( $course_title ) );
 							?>
 						</span></p>
 					<?php } ?>
@@ -1260,7 +1260,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 		switch ( $this->view ) {
 			case 'learners':
-				$text = __( 'Search Learners', 'sensei-lms' );
+				$text = __( 'Search Students', 'sensei-lms' );
 				break;
 
 			case 'lessons':
@@ -1276,7 +1276,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	}
 
 	/**
-	 * Helper method which calculates if the 'Manually Enrolled Learners' filter should be displayed.
+	 * Helper method which calculates if the 'Manually Enrolled Students' filter should be displayed.
 	 *
 	 * @return bool
 	 * @throws Exception If the providers weren't initialized yet.

--- a/includes/admin/class-sensei-status.php
+++ b/includes/admin/class-sensei-status.php
@@ -172,7 +172,7 @@ class Sensei_Status {
 		}
 
 		return [
-			'label' => __( 'Learner calculation job', 'sensei-lms' ),
+			'label' => __( 'Student calculation job', 'sensei-lms' ),
 			'value' => $status,
 		];
 	}
@@ -276,9 +276,9 @@ class Sensei_Status {
 	 * @return array
 	 */
 	public function test_enrolment_cache_warmed() {
-		$description = __( 'Sensei LMS attempts to calculate whether learners are enrolled in all courses ahead of time to speed up loading.', 'sensei-lms' );
+		$description = __( 'Sensei LMS attempts to calculate whether students are enrolled in all courses ahead of time to speed up loading.', 'sensei-lms' );
 		$result      = [
-			'label'       => __( 'Learner enrollment has been calculated', 'sensei-lms' ),
+			'label'       => __( 'Student enrollment has been calculated', 'sensei-lms' ),
 			'status'      => 'good',
 			'badge'       => [
 				'label' => __( 'Sensei LMS', 'sensei-lms' ),
@@ -292,7 +292,7 @@ class Sensei_Status {
 		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
 		if ( get_option( Sensei_Enrolment_Job_Scheduler::CALCULATION_VERSION_OPTION_NAME ) !== $enrolment_manager->get_enrolment_calculation_version() ) {
 			$result['status'] = 'recommended';
-			$result['label']  = __( 'Learner enrollment has not been calculated', 'sensei-lms' );
+			$result['label']  = __( 'Student enrollment has not been calculated', 'sensei-lms' );
 			$description     .= ' ' . __( 'This could be in progress. Until this process is complete, some pages may load more slowly.', 'sensei-lms' );
 		}
 

--- a/includes/admin/tools/class-sensei-tool-enrolment-debug.php
+++ b/includes/admin/tools/class-sensei-tool-enrolment-debug.php
@@ -49,7 +49,7 @@ class Sensei_Tool_Enrolment_Debug implements Sensei_Tool_Interface, Sensei_Tool_
 	 * @return string
 	 */
 	public function get_description() {
-		return __( 'Check what the enrollment status is between a course and learner.', 'sensei-lms' );
+		return __( 'Check what the enrollment status is between a course and student.', 'sensei-lms' );
 	}
 
 	/**

--- a/includes/admin/tools/views/html-enrolment-debug.php
+++ b/includes/admin/tools/views/html-enrolment-debug.php
@@ -64,7 +64,7 @@ $allowed_debug_html = [
 				echo ' <a href="' . esc_url( $edit_course_url ) . '" class="button">' . esc_html__( 'Edit Course', 'sensei-lms' ) . '</a>';
 
 				$manage_learners_url = admin_url( sprintf( 'admin.php?page=sensei_learners&course_id=%d&view=learners', $results['course_id'] ) );
-				echo ' <a href="' . esc_url( $manage_learners_url ) . '" class="button">' . esc_html__( 'Manage Learners', 'sensei-lms' ) . '</a>';
+				echo ' <a href="' . esc_url( $manage_learners_url ) . '" class="button">' . esc_html__( 'Manage Students', 'sensei-lms' ) . '</a>';
 				?>
 			</div>
 		</td>
@@ -84,7 +84,7 @@ $allowed_debug_html = [
 
 				if ( $results['is_removed'] ) {
 					echo '<div class="info info-neutral">';
-					echo esc_html__( 'Learner manually removed', 'sensei-lms' );
+					echo esc_html__( 'Student manually removed', 'sensei-lms' );
 					echo '</div>';
 				}
 			}
@@ -174,11 +174,11 @@ $allowed_debug_html = [
 							echo '</div>';
 						} elseif ( $provider['is_enrolled'] ) {
 							echo '<div class="tag">';
-							echo esc_html__( 'Enrolls Learner', 'sensei-lms' );
+							echo esc_html__( 'Enrolls Student', 'sensei-lms' );
 							echo '</div>';
 						} else {
 							echo '<div class="tag">';
-							echo esc_html__( 'Does Not Enroll Learner', 'sensei-lms' );
+							echo esc_html__( 'Does Not Enroll Student', 'sensei-lms' );
 							echo '</div>';
 						}
 						?>

--- a/includes/blocks/class-sensei-course-outline-course-block.php
+++ b/includes/blocks/class-sensei-course-outline-course-block.php
@@ -59,7 +59,7 @@ class Sensei_Course_Outline_Course_Block {
 		$css        = Sensei_Block_Helpers::build_styles( $attributes );
 
 		if ( ! empty( $attributes['preview_drafts'] ) ) {
-			Sensei()->notices->add_notice( __( 'One or more lessons in this course are not published. Unpublished lessons and empty modules are only displayed in preview mode and will not be displayed to learners.', 'sensei-lms' ), 'info', 'sensei-course-outline-drafts' );
+			Sensei()->notices->add_notice( __( 'One or more lessons in this course are not published. Unpublished lessons and empty modules are only displayed in preview mode and will not be displayed to students.', 'sensei-lms' ), 'info', 'sensei-course-outline-drafts' );
 		}
 
 		$icons = $this->render_svg_icon_library();

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -58,7 +58,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		switch ( $this->view ) {
 			case 'user':
 				$columns = array(
-					'title'       => __( 'Learner', 'sensei-lms' ),
+					'title'       => __( 'Student', 'sensei-lms' ),
 					'started'     => __( 'Date Started', 'sensei-lms' ),
 					'completed'   => __( 'Date Completed', 'sensei-lms' ),
 					'user_status' => __( 'Status', 'sensei-lms' ),
@@ -82,7 +82,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 
 					$columns = array(
 						'title'         => __( 'Lesson', 'sensei-lms' ),
-						'num_learners'  => __( 'Learners', 'sensei-lms' ),
+						'num_learners'  => __( 'Students', 'sensei-lms' ),
 						'completions'   => __( 'Completed', 'sensei-lms' ),
 						'average_grade' => __( 'Average Grade', 'sensei-lms' ),
 					);
@@ -606,7 +606,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	public function no_items() {
 		switch ( $this->view ) {
 			case 'user':
-				$text = __( 'No learners found.', 'sensei-lms' );
+				$text = __( 'No students found.', 'sensei-lms' );
 				break;
 
 			case 'lesson':
@@ -625,9 +625,9 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	 */
 	public function data_table_header() {
 		if ( $this->user_id ) {
-			$learners_text = __( 'Other Learners taking this Course', 'sensei-lms' );
+			$learners_text = __( 'Other Students taking this Course', 'sensei-lms' );
 		} else {
-			$learners_text = __( 'Learners taking this Course', 'sensei-lms' );
+			$learners_text = __( 'Students taking this Course', 'sensei-lms' );
 		}
 		$lessons_text = __( 'Lessons in this Course', 'sensei-lms' );
 
@@ -703,7 +703,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	public function search_button( $text = '' ) {
 		switch ( $this->view ) {
 			case 'user':
-				$text = __( 'Search Learners', 'sensei-lms' );
+				$text = __( 'Search Students', 'sensei-lms' );
 				break;
 
 			case 'lesson':

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -43,7 +43,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 	 */
 	function get_columns() {
 		$columns = array(
-			'title'     => __( 'Learner', 'sensei-lms' ),
+			'title'     => __( 'Student', 'sensei-lms' ),
 			'started'   => __( 'Date Started', 'sensei-lms' ),
 			'completed' => __( 'Date Completed', 'sensei-lms' ),
 			'status'    => __( 'Status', 'sensei-lms' ),
@@ -330,7 +330,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 	 * @return void
 	 */
 	public function no_items() {
-		esc_html_e( 'No learners found.', 'sensei-lms' );
+		esc_html_e( 'No students found.', 'sensei-lms' );
 	}
 
 	/**
@@ -340,7 +340,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 	 * @return void
 	 */
 	public function data_table_header() {
-		echo '<strong>' . esc_html__( 'Learners taking this Lesson', 'sensei-lms' ) . '</strong>';
+		echo '<strong>' . esc_html__( 'Students taking this Lesson', 'sensei-lms' ) . '</strong>';
 	}
 
 	/**
@@ -371,7 +371,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 	 */
 	public function search_button( $text = '' ) {
 
-		$text = __( 'Search Learners', 'sensei-lms' );
+		$text = __( 'Search Students', 'sensei-lms' );
 
 		return $text;
 

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -46,7 +46,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			case 'courses':
 				$columns = array(
 					'title'           => __( 'Course', 'sensei-lms' ),
-					'students'        => __( 'Learners', 'sensei-lms' ),
+					'students'        => __( 'Students', 'sensei-lms' ),
 					'lessons'         => __( 'Lessons', 'sensei-lms' ),
 					'completions'     => __( 'Completed', 'sensei-lms' ),
 					'average_percent' => __( 'Average Percentage', 'sensei-lms' ),
@@ -57,7 +57,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$columns = array(
 					'title'         => __( 'Lesson', 'sensei-lms' ),
 					'course'        => __( 'Course', 'sensei-lms' ),
-					'students'      => __( 'Learners', 'sensei-lms' ),
+					'students'      => __( 'Students', 'sensei-lms' ),
 					'completions'   => __( 'Completed', 'sensei-lms' ),
 					'average_grade' => __( 'Average Grade', 'sensei-lms' ),
 				);
@@ -66,7 +66,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			case 'users':
 			default:
 				$columns = array(
-					'title'             => __( 'Learner', 'sensei-lms' ),
+					'title'             => __( 'Student', 'sensei-lms' ),
 					'email'             => __( 'Email', 'sensei-lms' ),
 					'registered'        => __( 'Date Registered', 'sensei-lms' ),
 					'active_courses'    => __( 'Active Courses', 'sensei-lms' ),
@@ -629,8 +629,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$stats_to_render = array(
 			__( 'Total Courses', 'sensei-lms' )           => $total_courses,
 			__( 'Total Lessons', 'sensei-lms' )           => $total_lessons,
-			__( 'Total Learners', 'sensei-lms' )          => $user_count,
-			__( 'Average Courses per Learner', 'sensei-lms' ) => $average_courses_per_learner,
+			__( 'Total Students', 'sensei-lms' )          => $user_count,
+			__( 'Average Courses per Student', 'sensei-lms' ) => $average_courses_per_learner,
 			__( 'Average Grade', 'sensei-lms' )           => $total_average_grade . '%',
 			__( 'Total Completed Courses', 'sensei-lms' ) => $total_courses_ended,
 		);
@@ -685,7 +685,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$lesson_args['view']  = 'lessons';
 		$courses_args['view'] = 'courses';
 
-		$menu['learners'] = '<a class="' . esc_attr( $learners_class ) . '" href="' . esc_url( add_query_arg( $learner_args, admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'Learners', 'sensei-lms' ) . '</a>';
+		$menu['learners'] = '<a class="' . esc_attr( $learners_class ) . '" href="' . esc_url( add_query_arg( $learner_args, admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'Students', 'sensei-lms' ) . '</a>';
 		$menu['courses']  = '<a class="' . esc_attr( $courses_class ) . '" href="' . esc_url( add_query_arg( $courses_args, admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'Courses', 'sensei-lms' ) . '</a>';
 		$menu['lessons']  = '<a class="' . esc_attr( $lessons_class ) . '" href="' . esc_url( add_query_arg( $lesson_args, admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'Lessons', 'sensei-lms' ) . '</a>';
 
@@ -750,7 +750,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 			case 'users':
 			default:
-				$text = __( 'Search Learners', 'sensei-lms' );
+				$text = __( 'Search Students', 'sensei-lms' );
 				break;
 		}
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1786,8 +1786,8 @@ class Sensei_Course {
 			$no_active_message   = __( 'You have no active courses.', 'sensei-lms' );
 			$no_complete_message = __( 'You have not completed any courses yet.', 'sensei-lms' );
 		} else {
-			$no_active_message   = __( 'This learner has no active courses.', 'sensei-lms' );
-			$no_complete_message = __( 'This learner has not completed any courses yet.', 'sensei-lms' );
+			$no_active_message   = __( 'This student has no active courses.', 'sensei-lms' );
+			$no_complete_message = __( 'This student has not completed any courses yet.', 'sensei-lms' );
 		}
 
 		ob_start();

--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -60,7 +60,7 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 	 */
 	function get_columns() {
 		$columns = array(
-			'title'       => __( 'Learner', 'sensei-lms' ),
+			'title'       => __( 'Student', 'sensei-lms' ),
 			'course'      => __( 'Course', 'sensei-lms' ),
 			'lesson'      => __( 'Lesson', 'sensei-lms' ),
 			'updated'     => __( 'Updated', 'sensei-lms' ),

--- a/includes/class-sensei-learner-profiles.php
+++ b/includes/class-sensei-learner-profiles.php
@@ -25,7 +25,7 @@ class Sensei_Learner_Profiles {
 	public function __construct() {
 
 		// Setup learner profile URL base
-		$this->profile_url_base = apply_filters( 'sensei_learner_profiles_url_base', __( 'learner', 'sensei-lms' ) );
+		$this->profile_url_base = apply_filters( 'sensei_learner_profiles_url_base', __( 'student', 'sensei-lms' ) );
 
 		// Setup permalink structure for learner profiles
 		add_action( 'init', array( $this, 'setup_permastruct' ) );

--- a/includes/class-sensei-learner-profiles.php
+++ b/includes/class-sensei-learner-profiles.php
@@ -25,7 +25,7 @@ class Sensei_Learner_Profiles {
 	public function __construct() {
 
 		// Setup learner profile URL base
-		$this->profile_url_base = apply_filters( 'sensei_learner_profiles_url_base', __( 'student', 'sensei-lms' ) );
+		$this->profile_url_base = apply_filters( 'sensei_learner_profiles_url_base', __( 'learner', 'sensei-lms' ) );
 
 		// Setup permalink structure for learner profiles
 		add_action( 'init', array( $this, 'setup_permastruct' ) );

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -376,7 +376,7 @@ class Sensei_Learner {
 
 			if ( empty( self::$learner_terms[ $user_id ] ) || self::$learner_terms[ $user_id ] instanceof WP_Error ) {
 				unset( self::$learner_terms[ $user_id ] );
-				throw new Exception( esc_html__( 'Learner term could not be created for user.', 'sensei-lms' ) );
+				throw new Exception( esc_html__( 'Student term could not be created for user.', 'sensei-lms' ) );
 			}
 		}
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -1934,7 +1934,7 @@ class Sensei_Lesson {
 					}
 						$html .= '<label>' . esc_html__( 'Upload notes:', 'sensei-lms' ) . '</label> ';
 						$html .= '<textarea id="' . esc_attr( $wrong_field_id ) . '" name="add_question_wrong_answer_fileupload" rows="4" cols="40" class="widefat">' . esc_textarea( $wrong_answer ) . '</textarea>';
-						$html .= '<p class="question-field-helper-text">' . esc_html__( 'Displayed to the learner to describe what to upload.', 'sensei-lms' ) . '</p>';
+						$html .= '<p class="question-field-helper-text">' . esc_html__( 'Displayed to the student to describe what to upload.', 'sensei-lms' ) . '</p>';
 
 						// Guides for grading
 						$html .= '<label>' . esc_html__( 'Grading Notes:', 'sensei-lms' ) . '</label> ';

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -133,7 +133,7 @@ class Sensei_Messages {
 			array(
 				'id'          => 'sender',
 				'label'       => __( 'Message sent by:', 'sensei-lms' ),
-				'description' => __( 'The username of the learner who sent this message.', 'sensei-lms' ),
+				'description' => __( 'The username of the student who sent this message.', 'sensei-lms' ),
 				'type'        => 'plain-text',
 				'default'     => get_post_meta( $post->ID, '_sender', true ),
 			),

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -505,7 +505,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		);
 
 		// Learner Profile settings
-		$profile_url_base    = apply_filters( 'sensei_learner_profiles_url_base', __( 'student', 'sensei-lms' ) );
+		$profile_url_base    = apply_filters( 'sensei_learner_profiles_url_base', __( 'learner', 'sensei-lms' ) );
 		$profile_url_example = trailingslashit( get_home_url() ) . $profile_url_base . '/%username%';
 
 		$fields['learner_profile_enable'] = array(

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -154,8 +154,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 		);
 
 		$sections['learner-profile-settings'] = array(
-			'name'        => __( 'Learner Profiles', 'sensei-lms' ),
-			'description' => __( 'Settings for public Learner Profiles.', 'sensei-lms' ),
+			'name'        => __( 'Student Profiles', 'sensei-lms' ),
+			'description' => __( 'Settings for public Student Profiles.', 'sensei-lms' ),
 		);
 
 		$this->sections = apply_filters( 'sensei_settings_tabs', $sections );
@@ -217,7 +217,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['messages_disable'] = array(
 			'name'        => __( 'Disable Private Messages', 'sensei-lms' ),
-			'description' => __( 'Disable the private message functions between learners and teachers.', 'sensei-lms' ),
+			'description' => __( 'Disable the private message functions between students and teachers.', 'sensei-lms' ),
 			'type'        => 'checkbox',
 			'default'     => false,
 			'section'     => 'default-settings',
@@ -245,7 +245,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		$fields['course_completed_page'] = array(
 			'name'        => __( 'Course Completed Page', 'sensei-lms' ),
-			'description' => __( 'The page that is displayed after a learner completes a course.', 'sensei-lms' ),
+			'description' => __( 'The page that is displayed after a student completes a course.', 'sensei-lms' ),
 			'type'        => 'select',
 			'default'     => get_option( 'woothemes-sensei_course_completed_page_id', 0 ),
 			'section'     => 'default-settings',
@@ -420,7 +420,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		// Lesson Settings
 		$fields['lesson_comments'] = array(
 			'name'        => __( 'Allow Comments for Lessons', 'sensei-lms' ),
-			'description' => __( 'This will allow learners to post comments on the single Lesson page, only learner who have access to the Lesson will be allowed to comment.', 'sensei-lms' ),
+			'description' => __( 'This will allow students to post comments on the single Lesson page, only student who have access to the Lesson will be allowed to comment.', 'sensei-lms' ),
 			'type'        => 'checkbox',
 			'default'     => true,
 			'section'     => 'lesson-settings',
@@ -505,21 +505,21 @@ class Sensei_Settings extends Sensei_Settings_API {
 		);
 
 		// Learner Profile settings
-		$profile_url_base    = apply_filters( 'sensei_learner_profiles_url_base', __( 'learner', 'sensei-lms' ) );
+		$profile_url_base    = apply_filters( 'sensei_learner_profiles_url_base', __( 'student', 'sensei-lms' ) );
 		$profile_url_example = trailingslashit( get_home_url() ) . $profile_url_base . '/%username%';
 
 		$fields['learner_profile_enable'] = array(
-			'name'        => __( 'Public learner profiles', 'sensei-lms' ),
+			'name'        => __( 'Public student profiles', 'sensei-lms' ),
 			// translators: Placeholder is a profile URL example.
-			'description' => sprintf( __( 'Enable public learner profiles that will be accessible to everyone. Profile URL format: %s', 'sensei-lms' ), $profile_url_example ),
+			'description' => sprintf( __( 'Enable public student profiles that will be accessible to everyone. Profile URL format: %s', 'sensei-lms' ), $profile_url_example ),
 			'type'        => 'checkbox',
 			'default'     => true,
 			'section'     => 'learner-profile-settings',
 		);
 
 		$fields['learner_profile_show_courses'] = array(
-			'name'        => __( 'Show learner\'s courses', 'sensei-lms' ),
-			'description' => __( 'Display the learner\'s active and completed courses on their profile.', 'sensei-lms' ),
+			'name'        => __( 'Show student\'s courses', 'sensei-lms' ),
+			'description' => __( 'Display the student\'s active and completed courses on their profile.', 'sensei-lms' ),
 			'type'        => 'checkbox',
 			'default'     => true,
 			'section'     => 'learner-profile-settings',
@@ -532,11 +532,11 @@ class Sensei_Settings extends Sensei_Settings_API {
 		);
 
 		$teacher_email_options = array(
-			'teacher-started-course'   => __( 'A learner starts their course', 'sensei-lms' ),
-			'teacher-completed-course' => __( 'A learner completes their course', 'sensei-lms' ),
-			'teacher-completed-lesson' => __( 'A learner completes a lesson', 'sensei-lms' ),
-			'teacher-quiz-submitted'   => __( 'A learner submits a quiz for grading', 'sensei-lms' ),
-			'teacher-new-message'      => __( 'A learner sends a private message to a teacher', 'sensei-lms' ),
+			'teacher-started-course'   => __( 'A student starts their course', 'sensei-lms' ),
+			'teacher-completed-course' => __( 'A student completes their course', 'sensei-lms' ),
+			'teacher-completed-lesson' => __( 'A student completes a lesson', 'sensei-lms' ),
+			'teacher-quiz-submitted'   => __( 'A student submits a quiz for grading', 'sensei-lms' ),
+			'teacher-new-message'      => __( 'A student sends a private message to a teacher', 'sensei-lms' ),
 		);
 
 		$global_email_options = array(
@@ -544,8 +544,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 		);
 
 		$fields['email_learners'] = array(
-			'name'        => __( 'Emails Sent to Learners', 'sensei-lms' ),
-			'description' => __( 'Select the notifications that will be sent to learners.', 'sensei-lms' ),
+			'name'        => __( 'Emails Sent to Students', 'sensei-lms' ),
+			'description' => __( 'Select the notifications that will be sent to students.', 'sensei-lms' ),
 			'type'        => 'multicheck',
 			'options'     => $learner_email_options,
 			'defaults'    => array( 'learner-graded-quiz', 'learner-completed-course' ),

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -512,7 +512,7 @@ class Sensei_Course_Enrolment_Manager {
 			return;
 		}
 
-		$message = __( '<strong>Sensei LMS</strong> has detected an incompatible version of WooCommerce Paid Courses. Learners will not be able to access their courses until it is upgraded to version 2.0.0 or greater.', 'sensei-lms' );
+		$message = __( '<strong>Sensei LMS</strong> has detected an incompatible version of WooCommerce Paid Courses. Students will not be able to access their courses until it is upgraded to version 2.0.0 or greater.', 'sensei-lms' );
 
 		echo '<div class="error"><p>';
 		echo wp_kses( $message, [ 'strong' => [] ] );

--- a/includes/enrolment/class-sensei-course-manual-enrolment-provider.php
+++ b/includes/enrolment/class-sensei-course-manual-enrolment-provider.php
@@ -257,18 +257,18 @@ class Sensei_Course_Manual_Enrolment_Provider
 		$legacy_migration_status = $provider_state->get_stored_value( self::DATA_KEY_LEGACY_MIGRATION );
 
 		if ( null === $legacy_migration_status ) {
-			$messages[] = __( 'Learner manual enrollment <strong>was not migrated</strong> from a legacy version of Sensei LMS.', 'sensei-lms' );
+			$messages[] = __( 'Student manual enrollment <strong>was not migrated</strong> from a legacy version of Sensei LMS.', 'sensei-lms' );
 
 			if ( false !== get_option( 'sensei_enrolment_legacy' ) ) {
-				$messages[] = __( 'Learner <strong>did not have</strong> course progress at the time of manual enrollment migration.', 'sensei-lms' );
+				$messages[] = __( 'Student <strong>did not have</strong> course progress at the time of manual enrollment migration.', 'sensei-lms' );
 			}
 		} else {
-			$messages[] = __( 'Learner <strong>did have</strong> course progress at the time of manual enrollment migration.', 'sensei-lms' );
+			$messages[] = __( 'Student <strong>did have</strong> course progress at the time of manual enrollment migration.', 'sensei-lms' );
 
 			if ( false === $legacy_migration_status ) {
-				$messages[] = __( 'Manual enrollment <strong>was not provided</strong> to the learner on legacy migration.', 'sensei-lms' );
+				$messages[] = __( 'Manual enrollment <strong>was not provided</strong> to the student on legacy migration.', 'sensei-lms' );
 			} else {
-				$messages[] = __( 'Manual enrollment <strong>was provided</strong> to the learner on legacy migration.', 'sensei-lms' );
+				$messages[] = __( 'Manual enrollment <strong>was provided</strong> to the student on legacy migration.', 'sensei-lms' );
 			}
 		}
 

--- a/lang/sensei-lms.pot
+++ b/lang/sensei-lms.pot
@@ -1,2764 +1,24 @@
 # Copyright (C) 2021 Automattic
-# This file is distributed under the same license as the Sensei LMS plugin.
+# This file is distributed under the GPL version 2 or later - http://www.gnu.org/licenses/old-licenses/gpl-2.0.html.
 msgid ""
 msgstr ""
 "Project-Id-Version: Sensei LMS 3.14.0\n"
-"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/sensei-lms\n"
-"Last-Translator: \n"
-"Language-Team: \n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/sensei\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=utf-8\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2021-11-24T19:22:36+00:00\n"
+"POT-Creation-Date: 2021-12-03T12:38:59+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"X-Generator: WP-CLI 2.4.0\n"
+"X-Generator: WP-CLI 2.5.0\n"
 "X-Domain: sensei-lms\n"
 
-#: assets/admin/exit-survey/form.js:63
-#: assets/dist/admin/exit-survey/index.js:1
-msgid "Quick Feedback"
-msgstr ""
-
-#: assets/admin/exit-survey/form.js:65
-#: assets/dist/admin/exit-survey/index.js:1
-msgid ""
-"If you have a moment, please let us know why you are deactivating so that "
-"we can work to improve our product."
-msgstr ""
-
-#: assets/admin/exit-survey/form.js:80
-#: assets/dist/admin/exit-survey/index.js:1
-msgid "Submit Feedback"
-msgstr ""
-
-#: assets/admin/exit-survey/form.js:87
-#: assets/dist/admin/exit-survey/index.js:1
-msgid "Skip Feedback"
-msgstr ""
-
-#: assets/admin/exit-survey/reasons.js:12
-#: assets/dist/admin/exit-survey/index.js:1
-msgid "I no longer need the plugin"
-msgstr ""
-
-#: assets/admin/exit-survey/reasons.js:16
-#: assets/dist/admin/exit-survey/index.js:1
-msgid "The plugin isn't working"
-msgstr ""
-
-#: assets/admin/exit-survey/reasons.js:17
-#: assets/dist/admin/exit-survey/index.js:1
-msgid "What isn't working properly?"
-msgstr ""
-
-#: assets/admin/exit-survey/reasons.js:21
-#: assets/dist/admin/exit-survey/index.js:1
-msgid "I'm looking for different functionality"
-msgstr ""
-
-#: assets/admin/exit-survey/reasons.js:22
-#: assets/dist/admin/exit-survey/index.js:1
-msgid "What functionality is missing?"
-msgstr ""
-
-#: assets/admin/exit-survey/reasons.js:26
-#: assets/dist/admin/exit-survey/index.js:1
-msgid "I found a better plugin"
-msgstr ""
-
-#: assets/admin/exit-survey/reasons.js:27
-#: assets/dist/admin/exit-survey/index.js:1
-msgid "What's the name of the plugin?"
-msgstr ""
-
-#: assets/admin/exit-survey/reasons.js:31
-#: assets/dist/admin/exit-survey/index.js:1
-msgid "It's a temporary deactivation"
-msgstr ""
-
-#: assets/admin/exit-survey/reasons.js:36
-#: assets/dist/admin/exit-survey/index.js:1
-msgid "Why are you deactivating?"
-msgstr ""
-
-#: assets/blocks/button/button-edit.js:36
-#: assets/dist/blocks/shared.js:1
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-lesson.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Add text…"
-msgstr ""
-
-#: assets/blocks/button/button-settings.js:24
-#: assets/blocks/course-outline/module-block/module-settings.js:18
-#: assets/dist/blocks/shared.js:1
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-lesson.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Border settings"
-msgstr ""
-
-#: assets/blocks/button/button-settings.js:28
-#: assets/shared/blocks/course-progress/course-progress-settings.js:39
-#: assets/dist/blocks/shared.js:1
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-lesson.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Border radius"
-msgstr ""
-
-#: assets/blocks/button/button-settings.js:55
-#: assets/dist/blocks/shared.js:1
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-lesson.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Change button alignment"
-msgstr ""
-
-#: assets/blocks/button/color-hooks.js:43
-#: assets/blocks/course-outline/lesson-block/lesson-edit.js:124
-#: assets/dist/blocks/shared.js:1
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-lesson.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Background color"
-msgstr ""
-
-#: assets/blocks/button/color-hooks.js:47
-#: assets/blocks/course-outline/lesson-block/lesson-edit.js:128
-#: assets/blocks/course-outline/module-block/module-edit.js:217
-#: assets/blocks/course-progress-block/course-progress-edit.js:118
-#: assets/dist/blocks/shared.js:1
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-lesson.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Text color"
-msgstr ""
-
-#: assets/blocks/button/index.js:28
-#: assets/dist/blocks/shared.js:1
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-lesson.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Fill"
-msgstr ""
-
-#: assets/blocks/button/index.js:32
-#: assets/blocks/course-outline/outline-block/index.js:21
-#: assets/dist/blocks/shared.js:1
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-lesson.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Outline"
-msgstr ""
-
-#: assets/blocks/button/index.js:36
-#: assets/dist/blocks/shared.js:1
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-lesson.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Link"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/conditional-content-edit.js:21
-#: assets/blocks/conditional-content-block/index.js:22
-#: assets/blocks/learner-courses-block/index.js:24
-#: includes/admin/class-sensei-learners-main.php:445
-#: includes/admin/tools/views/html-enrolment-debug.php:78
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Enrolled"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/conditional-content-edit.js:22
-#: assets/blocks/conditional-content-block/index.js:27
-#: includes/admin/class-sensei-learners-main.php:448
-#: includes/admin/tools/views/html-enrolment-debug.php:82
-#: assets/dist/blocks/single-course.js:1
-msgid "Not Enrolled"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/conditional-content-edit.js:23
-#: includes/admin/class-sensei-setup-wizard-pages.php:68
-#: assets/dist/blocks/single-course.js:1
-msgid "Course Completed"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/conditional-content-settings.js:106
-#: assets/dist/blocks/single-course.js:1
-msgid "Remove condition"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/conditional-content-settings.js:89
-#: assets/dist/blocks/single-course.js:1
-msgid "Visible when"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/index.js:16
-#: assets/dist/blocks/single-course.js:1
-msgid "Conditional Content"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/index.js:17
-#: assets/dist/blocks/single-course.js:1
-msgid "Content inside this block will be shown to the selected subgroup of users."
-msgstr ""
-
-#: assets/blocks/conditional-content-block/index.js:23
-#: assets/dist/blocks/single-course.js:1
-msgid "Content"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/index.js:24
-#: assets/blocks/quiz/question-block/question-view.js:56
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Locked"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/index.js:25
-#: assets/dist/blocks/single-course.js:1
-msgid "Private"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/index.js:26
-#: assets/blocks/course-completed-actions/index.js:24
-#: assets/blocks/course-outline/status-preview/status-control/index.js:18
-#: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-settings.js:44
-#: assets/data-port/import/done/done-page.js:91
-#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:409
-#: includes/admin/class-sensei-learners-main.php:386
-#: includes/admin/tools/class-sensei-tool-enrolment-debug.php:217
-#: includes/blocks/class-sensei-course-outline-module-block.php:135
-#: includes/class-sensei-analysis-course-list-table.php:86
-#: includes/class-sensei-analysis-course-list-table.php:302
-#: includes/class-sensei-analysis-course-list-table.php:370
-#: includes/class-sensei-analysis-lesson-list-table.php:205
-#: includes/class-sensei-analysis-overview-list-table.php:51
-#: includes/class-sensei-analysis-overview-list-table.php:61
-#: includes/class-sensei-analysis-user-profile-list-table.php:206
-#: includes/class-sensei-course.php:3145
-#: includes/class-sensei-grading-main.php:238
-#: includes/class-sensei-modules.php:772
-#: includes/shortcodes/class-sensei-shortcode-user-courses.php:570
-#: includes/template-functions.php:654
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-page.js:1
-#: assets/dist/blocks/single-lesson.js:1
-#: assets/dist/data-port/import.js:1
-msgid "Completed"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/index.js:28
-#: assets/dist/blocks/single-course.js:1
-msgid "Restrict"
-msgstr ""
-
-#: assets/blocks/conditional-content-block/index.js:29
-#: assets/dist/blocks/single-course.js:1
-msgid "Access"
-msgstr ""
-
-#: assets/blocks/contact-teacher-block/index.js:18
-#: assets/dist/blocks/shared.js:1
-msgid ""
-"Enable a registered user to contact the teacher. This block is only "
-"displayed if the user is logged in and private messaging is enabled."
-msgstr ""
-
-#: assets/blocks/contact-teacher-block/index.js:25
-#: includes/class-sensei-messages.php:253
-#: assets/dist/blocks/shared.js:1
-msgid "Contact Teacher"
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:16
-#: assets/dist/blocks/single-page.js:1
-msgid "Course Completed Actions"
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:17
-#: assets/dist/blocks/single-page.js:1
-msgid "Prompt learners to take action after completing a course."
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:23
-#: assets/blocks/course-outline/lesson-block/index.js:17
-#: assets/blocks/course-outline/outline-block/index.js:18
-#: assets/blocks/course-progress-block/index.js:22
-#: assets/blocks/course-results-block/index.js:20
-#: assets/blocks/take-course-block/index.js:28
-#: includes/admin/class-sensei-learners-main.php:186
-#: includes/admin/class-sensei-learners-main.php:1190
-#: includes/admin/tools/views/html-enrolment-debug-form.php:55
-#: includes/admin/tools/views/html-enrolment-debug.php:53
-#: includes/admin/tools/views/html-recalculate-course-enrolment-form.php:25
-#: includes/class-sensei-analysis-overview-list-table.php:48
-#: includes/class-sensei-analysis-overview-list-table.php:59
-#: includes/class-sensei-analysis-user-profile-list-table.php:45
-#: includes/class-sensei-grading-main.php:64
-#: includes/class-sensei-lesson.php:201
-#: includes/class-sensei-posttypes.php:761
-#: assets/dist/blocks/single-page.js:1
-#: assets/dist/blocks/single-course.js:1
-msgid "Course"
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:25
-#: assets/blocks/lesson-actions/lesson-actions-block/index.js:22
-#: assets/dist/blocks/single-page.js:1
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Actions"
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:26
-#: assets/blocks/lesson-actions/lesson-actions-block/index.js:23
-#: assets/dist/blocks/single-page.js:1
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Buttons"
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:28
-#: assets/dist/blocks/single-page.js:1
-msgid "View Certificate"
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:43
-#: includes/admin/class-sensei-setup-wizard-pages.php:151
-#: assets/dist/blocks/single-page.js:1
-msgid "Find More Courses"
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:44
-#: assets/dist/blocks/single-page.js:1
-msgid "Prompt learners to find more courses."
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:49
-#: assets/blocks/learner-courses-block/index.js:23
-#: assets/shared/helpers/labels.js:7
-#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:387
-#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:407
-#: includes/admin/class-sensei-setup-wizard-pages.php:60
-#: includes/class-sensei-admin.php:1628
-#: includes/class-sensei-analysis-overview-list-table.php:689
-#: includes/class-sensei-analysis-user-profile-list-table.php:327
-#: includes/class-sensei-course.php:2896
-#: includes/class-sensei-posttypes.php:762
-#: includes/class-sensei-posttypes.php:763
-#: includes/class-sensei-settings.php:142
-#: includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php:55
-#: assets/dist/blocks/single-page.js:1
-#: assets/dist/data-port/export.js:1
-#: assets/dist/data-port/import.js:1
-msgid "Courses"
-msgstr ""
-
-#: assets/blocks/course-completed-actions/index.js:50
-#: assets/dist/blocks/single-page.js:1
-msgid "Archive"
-msgstr ""
-
-#: assets/blocks/course-outline/course-outline-store.js:66
-#: assets/dist/blocks/single-course.js:1
-#. Error message.
-msgid "Course modules and lessons could not be updated. %s"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/index.js:15
-#: assets/dist/blocks/single-course.js:1
-msgid "Where your course content lives."
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/index.js:17
-#: assets/blocks/course-outline/lesson-block/lesson-settings.js:56
-#: assets/blocks/course-outline/module-block/index.js:35
-#: assets/blocks/course-outline/outline-block/index.js:50
-#: assets/blocks/course-outline/outline-block/outline-appender.js:29
-#: assets/blocks/lesson-actions/complete-lesson-block/index.js:26
-#: assets/blocks/lesson-actions/lesson-actions-block/index.js:21
-#: assets/blocks/lesson-actions/next-lesson-block/index.js:26
-#: assets/blocks/lesson-actions/reset-lesson-block/index.js:28
-#: assets/blocks/lesson-actions/view-quiz-block/index.js:22
-#: includes/admin/class-sensei-learners-main.php:177
-#: includes/admin/class-sensei-learners-main.php:1195
-#: includes/class-sensei-analysis-course-list-table.php:74
-#: includes/class-sensei-analysis-course-list-table.php:84
-#: includes/class-sensei-analysis-overview-list-table.php:58
-#: includes/class-sensei-course.php:2962
-#: includes/class-sensei-grading-main.php:65
-#: includes/class-sensei-posttypes.php:766
-#: templates/course-results/lessons.php:37
-#: templates/single-course/modules.php:100
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Lesson"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/index.js:21
-#: assets/dist/blocks/single-course.js:1
-msgid "Start learning"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/lesson-edit.js:103
-#: includes/blocks/class-sensei-course-outline-lesson-block.php:41
-#: includes/class-sensei-frontend.php:1237
-#: includes/class-sensei-lesson.php:207
-#: assets/dist/blocks/single-course.js:1
-msgid "Preview"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/lesson-edit.js:61
-#: assets/dist/blocks/single-course.js:1
-msgid "Unsaved"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/lesson-edit.js:63
-#: assets/dist/blocks/single-course.js:1
-msgid "Draft"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/lesson-edit.js:93
-#: assets/dist/blocks/single-course.js:1
-msgid "Add Lesson"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/lesson-settings.js:48
-#: assets/dist/blocks/single-course.js:1
-msgid "Edit lesson"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/lesson-settings.js:59
-#: assets/dist/blocks/single-course.js:1
-msgid "Edit details such as lesson content, prerequisite, quiz settings and more."
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/lesson-settings.js:66
-#: assets/dist/blocks/single-course.js:1
-msgid "Typography"
-msgstr ""
-
-#: assets/blocks/course-outline/lesson-block/lesson-settings.js:76
-#: assets/blocks/course-outline/module-block/module-status.js:72
-#: includes/admin/class-sensei-learners-main.php:169
-#: includes/class-sensei-analysis-course-list-table.php:64
-#: includes/class-sensei-analysis-course-list-table.php:77
-#: includes/class-sensei-analysis-lesson-list-table.php:49
-#: includes/class-sensei-analysis-user-profile-list-table.php:48
-#: includes/class-sensei-grading-main.php:67
-#: assets/dist/blocks/single-course.js:1
-msgid "Status"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/index.js:17
-#: assets/dist/blocks/single-course.js:1
-msgid "Group related lessons together."
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/index.js:20
-#: assets/dist/blocks/single-course.js:1
-msgid "Course Module"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/index.js:21
-#: assets/dist/blocks/single-course.js:1
-msgid "Group"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/index.js:22
-#: assets/blocks/course-outline/module-block/module-edit.js:198
-#: assets/blocks/course-outline/outline-block/index.js:19
-#: assets/blocks/course-results-block/index.js:21
-#: assets/shared/helpers/labels.js:8
-#: includes/admin/class-sensei-learners-main.php:1158
-#: includes/blocks/class-sensei-course-outline-module-block.php:98
-#: includes/class-sensei-admin.php:1629
-#: includes/class-sensei-analysis-overview-list-table.php:50
-#: includes/class-sensei-analysis-overview-list-table.php:690
-#: includes/class-sensei-course.php:2962
-#: includes/class-sensei-modules.php:1270
-#: includes/class-sensei-posttypes.php:767
-#: includes/class-sensei-posttypes.php:768
-#: includes/class-sensei-settings.php:147
-#: templates/course-results/lessons.php:39
-#: templates/single-course/modules.php:102
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-page.js:1
-#: assets/dist/data-port/export.js:1
-#: assets/dist/data-port/import.js:1
-msgid "Lessons"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/index.js:28
-#: assets/blocks/course-outline/outline-block/index.js:43
-#: assets/blocks/course-outline/outline-block/outline-appender.js:42
-#: includes/class-sensei-modules.php:126
-#: includes/class-sensei-modules.php:1330
-#: includes/class-sensei-modules.php:1379
-#: includes/class-sensei-modules.php:1780
-#: assets/dist/blocks/single-course.js:1
-msgid "Module"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/index.js:29
-#: assets/blocks/course-outline/outline-block/index.js:44
-#: assets/dist/blocks/single-course.js:1
-msgid "About Module"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/index.js:46
-#: assets/blocks/course-outline/outline-block/index.js:27
-#: assets/blocks/course-results-block/index.js:29
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Filled"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/index.js:51
-#: assets/blocks/course-outline/outline-block/index.js:32
-#: assets/blocks/course-results-block/index.js:34
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Minimal"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/module-edit.js:157
-#: assets/dist/blocks/single-course.js:1
-msgid "Module name"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/module-edit.js:174
-#: includes/blocks/class-sensei-course-outline-module-block.php:91
-#: assets/dist/blocks/single-course.js:1
-msgid "Toggle module content"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/module-edit.js:189
-#: includes/rest-api/class-sensei-rest-api-course-structure-controller.php:286
-#: assets/dist/blocks/single-course.js:1
-msgid "Module description"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/module-edit.js:215
-#: assets/dist/blocks/single-course.js:1
-msgid "Main color"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/module-edit.js:220
-#: assets/dist/blocks/single-course.js:1
-msgid "Border color"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/module-settings.js:24
-#: assets/blocks/course-outline/outline-block/outline-settings.js:43
-#: assets/blocks/course-results-block/course-results-settings.js:30
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Border"
-msgstr ""
-
-#: assets/blocks/course-outline/module-block/module-settings.js:25
-#: assets/dist/blocks/single-course.js:1
-msgid "Toggle to enable the border."
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/index.js:15
-#: assets/blocks/course-outline/outline-block/outline-placeholder.js:21
-#: assets/dist/blocks/single-course.js:1
-msgid "Course Outline"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/index.js:16
-#: assets/dist/blocks/single-course.js:1
-msgid "Manage your Sensei LMS course outline."
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/index.js:20
-#: assets/blocks/course-outline/outline-block/outline-settings.js:26
-#: assets/blocks/course-results-block/course-results-settings.js:22
-#: assets/blocks/course-results-block/index.js:22
-#: includes/class-sensei-modules.php:1039
-#: includes/class-sensei-modules.php:1627
-#: includes/class-sensei-modules.php:1779
-#: includes/class-sensei-modules.php:1790
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Modules"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/index.js:22
-#: assets/dist/blocks/single-course.js:1
-msgid "Structure"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/index.js:61
-#: assets/dist/blocks/single-course.js:1
-msgid "First Lesson"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/index.js:70
-#: assets/dist/blocks/single-course.js:1
-msgid "Second Lesson"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/outline-appender.js:34
-#: includes/class-sensei-posttypes.php:907
-#: assets/dist/blocks/single-course.js:1
-msgid "Lesson name"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/outline-appender.js:54
-#: assets/dist/blocks/single-course.js:1
-msgid "Add Module or Lesson"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/outline-placeholder.js:23
-#: assets/dist/blocks/single-course.js:1
-msgid ""
-"Build and display a course outline. A course is made up of modules "
-"(optional) and lessons. You can use modules to group related lessons "
-"together."
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/outline-placeholder.js:33
-#: assets/dist/blocks/single-course.js:1
-msgid "Create a module"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/outline-placeholder.js:40
-#: assets/dist/blocks/single-course.js:1
-msgid "Create a lesson"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/outline-settings.js:34
-#: assets/dist/blocks/single-course.js:1
-msgid "Collapsible modules"
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/outline-settings.js:35
-#: assets/dist/blocks/single-course.js:1
-msgid "Modules can be collapsed or expanded."
-msgstr ""
-
-#: assets/blocks/course-outline/outline-block/outline-settings.js:44
-#: assets/blocks/course-results-block/course-results-settings.js:31
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Toggle the border for all modules."
-msgstr ""
-
-#: assets/blocks/course-outline/status-preview/status-control/index.js:16
-#: includes/admin/class-sensei-learners-main.php:394
-#: assets/dist/blocks/single-course.js:1
-msgid "Not Started"
-msgstr ""
-
-#: assets/blocks/course-outline/status-preview/status-control/index.js:17
-#: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-settings.js:40
-#: includes/admin/class-sensei-learner-management.php:166
-#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:387
-#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:407
-#: includes/admin/class-sensei-learners-main.php:399
-#: includes/admin/tools/class-sensei-tool-enrolment-debug.php:214
-#: includes/blocks/class-sensei-course-outline-module-block.php:132
-#: includes/class-sensei-analysis-course-list-table.php:307
-#: includes/class-sensei-analysis-course-list-table.php:394
-#: includes/class-sensei-analysis-lesson-list-table.php:219
-#: includes/class-sensei-analysis-user-profile-list-table.php:213
-#: includes/class-sensei-course.php:3169
-#: includes/class-sensei-grading-main.php:253
-#: includes/class-sensei-grading-main.php:480
-#: includes/class-sensei-lesson.php:4086
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-lesson.js:1
-msgid "In Progress"
-msgstr ""
-
-#: assets/blocks/course-outline/status-preview/status-control/index.js:45
-#: assets/dist/blocks/single-course.js:1
-msgid ""
-"Preview a status. The actual status that the learner sees is determined by "
-"their progress in the course."
-msgstr ""
-
-#: assets/blocks/course-progress-block/course-progress-edit.js:110
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:158
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Progress bar color"
-msgstr ""
-
-#: assets/blocks/course-progress-block/course-progress-edit.js:114
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:167
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Progress bar background color"
-msgstr ""
-
-#: assets/blocks/course-progress-block/index.js:14
-#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:97
-#: assets/dist/blocks/single-course.js:1
-msgid "Course Progress"
-msgstr ""
-
-#: assets/blocks/course-progress-block/index.js:15
-#: assets/dist/blocks/single-course.js:1
-msgid ""
-"Display the user's progress in the course. This block is only displayed if "
-"the user is enrolled."
-msgstr ""
-
-#: assets/blocks/course-progress-block/index.js:20
-#: assets/blocks/lesson-actions/reset-lesson-block/index.js:27
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Progress"
-msgstr ""
-
-#: assets/blocks/course-progress-block/index.js:21
-#: assets/dist/blocks/single-course.js:1
-msgid "Bar"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:138
-#: includes/blocks/class-sensei-course-results-block.php:131
-#: assets/dist/blocks/single-page.js:1
-msgid "Your Total Grade"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:145
-#: assets/blocks/learner-courses-block/learner-courses-edit.js:140
-#: assets/dist/blocks/single-page.js:1
-msgid "Course Title"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:148
-#: assets/dist/blocks/single-page.js:1
-msgid "Module A"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:154
-#: assets/dist/blocks/single-page.js:1
-msgid "Module B"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:160
-#: assets/dist/blocks/single-page.js:1
-msgid "Module C"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:175
-#: assets/dist/blocks/single-page.js:1
-msgid "Module color"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:179
-#: assets/dist/blocks/single-page.js:1
-msgid "Module text color"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:183
-#: assets/dist/blocks/single-page.js:1
-msgid "Module border color"
-msgstr ""
-
-#: assets/blocks/course-results-block/course-results-edit.js:36
-#: assets/dist/blocks/single-page.js:1
-#. Mock lesson number.
-msgid "Lesson %s"
-msgstr ""
-
-#: assets/blocks/course-results-block/index.js:14
-#: assets/dist/blocks/single-page.js:1
-msgid "Course Results"
-msgstr ""
-
-#: assets/blocks/course-results-block/index.js:15
-#: assets/dist/blocks/single-page.js:1
-msgid "Show course results to learners on the course completion page."
-msgstr ""
-
-#: assets/blocks/course-results-block/index.js:23
-#: assets/dist/blocks/single-page.js:1
-msgid "Results"
-msgstr ""
-
-#: assets/blocks/course-results-block/index.js:24
-#: assets/dist/blocks/single-page.js:1
-msgid "Completion"
-msgstr ""
-
-#: assets/blocks/editor-components/number-control/index.js:77
-#: assets/blocks/lesson-actions/lesson-actions-block/index.js:26
-#: assets/blocks/lesson-actions/reset-lesson-block/index.js:24
-#: includes/class-sensei-grading-user-quiz.php:113
-#: includes/class-sensei-grading-user-quiz.php:353
-#: assets/dist/blocks/quiz/index.js:1
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Reset"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/index.js:15
-#: assets/dist/blocks/single-page.js:1
-msgid ""
-"Manage what learners see on their dashboard. This block is only displayed "
-"to logged in learners."
-msgstr ""
-
-#: assets/blocks/learner-courses-block/index.js:20
-#: assets/dist/blocks/single-page.js:1
-msgid "Learner Courses"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/index.js:21
-#: includes/admin/class-sensei-setup-wizard-pages.php:64
-#: includes/class-sensei-admin.php:1630
-#: widgets/class-sensei-course-component-widget.php:336
-#: assets/dist/blocks/single-page.js:1
-msgid "My Courses"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/index.js:22
-#: assets/dist/blocks/single-page.js:1
-msgid "Dashboard"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/index.js:25
-#: assets/dist/blocks/single-page.js:1
-msgid "Student"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/index.js:26
-#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:96
-#: includes/admin/class-sensei-learners-main.php:167
-#: includes/class-sensei-analysis-course-list-table.php:61
-#: includes/class-sensei-analysis-lesson-list-table.php:46
-#: includes/class-sensei-analysis-overview-list-table.php:69
-#: includes/class-sensei-grading-main.php:63
-#: assets/dist/blocks/single-page.js:1
-msgid "Learner"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-edit.js:103
-#: includes/class-sensei-analysis-overview-list-table.php:72
-#: includes/class-sensei-course.php:1810
-#: assets/dist/blocks/single-page.js:1
-msgid "Active Courses"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-edit.js:107
-#: includes/class-sensei-analysis-overview-list-table.php:73
-#: includes/class-sensei-course.php:1811
-#: assets/dist/blocks/single-page.js:1
-msgid "Completed Courses"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-edit.js:146
-#: assets/dist/blocks/single-page.js:1
-msgid "Category Name"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-edit.js:152
-#: assets/dist/blocks/single-page.js:1
-msgid "This is a preview of the course description…"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-edit.js:179
-#: assets/blocks/view-results-block/index.js:25
-#: includes/class-sensei-course.php:1729
-#: includes/class-sensei-course.php:2451
-#: includes/class-sensei-course.php:3155
-#: assets/dist/blocks/single-page.js:1
-#: assets/dist/blocks/single-course.js:1
-msgid "View Results"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-edit.js:99
-#: assets/dist/blocks/single-page.js:1
-msgid "All Courses"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-settings.js:101
-#: assets/dist/blocks/single-page.js:1
-msgid "Styling"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-settings.js:106
-#: assets/dist/blocks/single-page.js:1
-msgid "Layout"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-settings.js:138
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:148
-#: assets/shared/blocks/settings.js:60
-#: assets/dist/blocks/single-page.js:1
-#: assets/dist/blocks/quiz/index.js:1
-#: assets/dist/blocks/shared.js:1
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Color settings"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-settings.js:36
-#: assets/dist/blocks/single-page.js:1
-msgid "Featured image"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-settings.js:40
-#: assets/blocks/quiz/category-question-block/category-question-settings.js:112
-#: assets/blocks/quiz/quiz-block/questions-modal/filter.js:56
-#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:148
-#: includes/class-sensei-lesson.php:1386
-#: includes/class-sensei-lesson.php:1394
-#: assets/dist/blocks/single-page.js:1
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Category"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-settings.js:44
-#: assets/blocks/quiz/question-description-block/index.js:19
-#: assets/setup-wizard/purpose/index.js:143
-#: assets/dist/blocks/single-page.js:1
-#: assets/dist/blocks/quiz/index.js:1
-#: assets/dist/setup-wizard/index.js:1
-msgid "Description"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-settings.js:48
-#: assets/dist/blocks/single-page.js:1
-msgid "Progress bar"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-settings.js:55
-#: assets/dist/blocks/single-page.js:1
-msgid "List view"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-settings.js:60
-#: assets/dist/blocks/single-page.js:1
-msgid "Grid view"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-settings.js:68
-#: assets/dist/blocks/single-page.js:1
-msgid "Primary color"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-settings.js:73
-#: assets/dist/blocks/single-page.js:1
-msgid "Accent color"
-msgstr ""
-
-#: assets/blocks/learner-courses-block/learner-courses-settings.js:82
-#: assets/dist/blocks/single-page.js:1
-msgid "Course settings"
-msgstr ""
-
-#: assets/blocks/learner-messages-button-block/index.js:14
-#: includes/blocks/class-sensei-learner-messages-button-block.php:76
-#: includes/class-sensei-admin.php:1632
-#: includes/class-sensei-course.php:1801
-#: includes/class-sensei-messages.php:836
-#: includes/class-sensei-messages.php:927
-#: assets/dist/blocks/single-page.js:1
-msgid "My Messages"
-msgstr ""
-
-#: assets/blocks/learner-messages-button-block/index.js:25
-#: assets/dist/blocks/single-page.js:1
-msgid ""
-"Enable a learner to view their messages. This block is only displayed if "
-"the learner is logged in and private messaging is enabled."
-msgstr ""
-
-#: assets/blocks/learner-messages-button-block/index.js:29
-#: assets/dist/blocks/single-page.js:1
-msgid "Learner Messages Button"
-msgstr ""
-
-#: assets/blocks/learner-messages-button-block/messages-disabled-notice.js:33
-#: assets/dist/blocks/single-page.js:1
-msgid ""
-"You have added the \"Learner Messages Button\" block to your editor, but "
-"messages are disabled in your settings."
-msgstr ""
-
-#: assets/blocks/learner-messages-button-block/messages-disabled-notice.js:42
-#: assets/dist/blocks/single-page.js:1
-msgid "Go to disabled messages setting"
-msgstr ""
-
-#: assets/blocks/lesson-actions/complete-lesson-block/index.js:19
-#: assets/dist/blocks/single-lesson.js:1
-msgid ""
-"Enable a learner to mark the lesson as complete. This block is only "
-"displayed if the lesson has no quiz or the quiz is optional."
-msgstr ""
-
-#: assets/blocks/lesson-actions/complete-lesson-block/index.js:24
-#: assets/blocks/lesson-actions/lesson-actions-block/index.js:24
-#: includes/admin/class-sensei-status.php:171
-#: includes/class-sensei-lesson.php:4082
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Complete"
-msgstr ""
-
-#: assets/blocks/lesson-actions/complete-lesson-block/index.js:25
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Finish"
-msgstr ""
-
-#: assets/blocks/lesson-actions/complete-lesson-block/index.js:27
-#: assets/blocks/lesson-actions/next-lesson-block/index.js:27
-#: assets/blocks/lesson-actions/reset-lesson-block/index.js:29
-#: assets/blocks/lesson-actions/view-quiz-block/index.js:23
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Button"
-msgstr ""
-
-#: assets/blocks/lesson-actions/complete-lesson-block/index.js:31
-#: includes/class-sensei-frontend.php:976
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Complete Lesson"
-msgstr ""
-
-#: assets/blocks/lesson-actions/lesson-actions-block/index.js:15
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Lesson Actions"
-msgstr ""
-
-#: assets/blocks/lesson-actions/lesson-actions-block/index.js:16
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Enable a learner to perform specific actions for a lesson."
-msgstr ""
-
-#: assets/blocks/lesson-actions/lesson-actions-block/index.js:25
-#: assets/blocks/lesson-actions/next-lesson-block/index.js:24
-#: includes/class-sensei-course.php:1663
-#: includes/class-sensei-course.php:1775
-#: includes/class-sensei-lesson.php:1418
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Next"
-msgstr ""
-
-#: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js:54
-#: assets/blocks/lesson-actions/reset-lesson-block/index.js:33
-#: includes/class-sensei-frontend.php:1010
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Reset Lesson"
-msgstr ""
-
-#: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-settings.js:48
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Preview lesson state"
-msgstr ""
-
-#: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-settings.js:55
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Additional Actions"
-msgstr ""
-
-#: assets/blocks/lesson-actions/next-lesson-block/index.js:19
-#: assets/dist/blocks/single-lesson.js:1
-msgid ""
-"Enable a learner to move to the next lesson. This block is only displayed "
-"if the current lesson has been completed."
-msgstr ""
-
-#: assets/blocks/lesson-actions/next-lesson-block/index.js:25
-#: assets/data-port/export/export-select-content-page.js:59
-#: assets/data-port/import/upload/upload-page.js:72
-#: assets/setup-wizard/features/features-selection.js:100
-#: assets/setup-wizard/features/installation-feedback.js:103
-#: assets/setup-wizard/purpose/index.js:164
-#: assets/setup-wizard/welcome/index.js:67
-#: assets/setup-wizard/welcome/usage-modal.js:81
-#: assets/dist/blocks/single-lesson.js:1
-#: assets/dist/data-port/export.js:1
-#: assets/dist/data-port/import.js:1
-#: assets/dist/setup-wizard/index.js:1
-msgid "Continue"
-msgstr ""
-
-#: assets/blocks/lesson-actions/next-lesson-block/index.js:31
-#: includes/blocks/course-theme/class-next-lesson.php:65
-#: includes/class-sensei-utils.php:1309
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Next Lesson"
-msgstr ""
-
-#: assets/blocks/lesson-actions/reset-lesson-block/index.js:19
-#: assets/dist/blocks/single-lesson.js:1
-msgid ""
-"Enable a learner to reset their progress. This block is only displayed if "
-"the lesson is completed and has no quiz, or the quiz is completed and "
-"retakes are enabled."
-msgstr ""
-
-#: assets/blocks/lesson-actions/reset-lesson-block/index.js:25
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Restart"
-msgstr ""
-
-#: assets/blocks/lesson-actions/reset-lesson-block/index.js:26
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Revert"
-msgstr ""
-
-#: assets/blocks/lesson-actions/view-quiz-block/index.js:19
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Enable a learner to view the quiz."
-msgstr ""
-
-#: assets/blocks/lesson-actions/view-quiz-block/index.js:21
-#: assets/blocks/quiz/quiz-block/index.js:19
-#: includes/class-sensei-posttypes.php:771
-#: assets/dist/blocks/single-lesson.js:1
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Quiz"
-msgstr ""
-
-#: assets/blocks/lesson-actions/view-quiz-block/index.js:27
-#: assets/dist/blocks/single-lesson.js:1
-msgid "View Quiz"
-msgstr ""
-
-#: assets/blocks/lesson-properties/constants.js:13
-#: includes/class-sensei-lesson.php:3195
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Easy"
-msgstr ""
-
-#: assets/blocks/lesson-properties/constants.js:17
-#: includes/class-sensei-lesson.php:3196
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Standard"
-msgstr ""
-
-#: assets/blocks/lesson-properties/constants.js:21
-#: includes/class-sensei-lesson.php:3197
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Hard"
-msgstr ""
-
-#: assets/blocks/lesson-properties/constants.js:9
-#: includes/admin/class-sensei-learner-management.php:643
-#: includes/class-sensei-course.php:349
-#: includes/class-sensei-course.php:758
-#: includes/class-sensei-lesson.php:254
-#: includes/class-sensei-lesson.php:331
-#: includes/class-sensei-lesson.php:1308
-#: includes/class-sensei-modules.php:218
-#: includes/class-sensei-utils.php:2270
-#: assets/dist/blocks/single-lesson.js:1
-msgid "None"
-msgstr ""
-
-#: assets/blocks/lesson-properties/index.js:15
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Add lesson properties such as length and difficulty."
-msgstr ""
-
-#: assets/blocks/lesson-properties/index.js:20
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Metadata"
-msgstr ""
-
-#: assets/blocks/lesson-properties/index.js:21
-#: assets/blocks/lesson-properties/lesson-properties-edit.js:68
-#: includes/blocks/class-sensei-lesson-properties-block.php:51
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Length"
-msgstr ""
-
-#: assets/blocks/lesson-properties/index.js:22
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Complexity"
-msgstr ""
-
-#: assets/blocks/lesson-properties/index.js:23
-#: assets/blocks/lesson-properties/lesson-properties-edit.js:90
-#: includes/blocks/class-sensei-lesson-properties-block.php:68
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Difficulty"
-msgstr ""
-
-#: assets/blocks/lesson-properties/index.js:24
-#: includes/class-sensei-lesson.php:210
-#: includes/class-sensei-lesson.php:3699
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Lesson Information"
-msgstr ""
-
-#: assets/blocks/lesson-properties/index.js:25
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Lesson Properties"
-msgstr ""
-
-#: assets/blocks/lesson-properties/lesson-properties-edit.js:29
-#: assets/dist/blocks/single-lesson.js:1
-msgid "Properties"
-msgstr ""
-
-#: assets/blocks/lesson-properties/lesson-properties-edit.js:72
-#: assets/dist/blocks/single-lesson.js:1
-msgid "minute"
-msgid_plural "minutes"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/blocks/quiz/answer-blocks/file-upload.js:13
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Browse…"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/gap-fill.js:41
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Text before the gap"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/gap-fill.js:64
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Add right answers. Separate with commas or the Enter key."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/gap-fill.js:74
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Text after the gap"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:100
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Short answer to an open-ended question."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:109
-#: includes/class-sensei-grading-user-quiz.php:193
-#: includes/class-sensei-lesson.php:1119
-#: includes/class-sensei-question.php:51
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Multi Line"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:110
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Long answer to an open-ended question."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:119
-#: includes/class-sensei-grading-user-quiz.php:201
-#: includes/class-sensei-lesson.php:1119
-#: includes/class-sensei-question.php:52
-#: assets/dist/blocks/quiz/index.js:1
-msgid "File Upload"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:120
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Upload a file or document."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:39
-#: includes/class-sensei-grading-user-quiz.php:152
-#: includes/class-sensei-grading-user-quiz.php:163
-#: includes/class-sensei-lesson.php:1119
-#: includes/class-sensei-question.php:47
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Multiple Choice"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:40
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Select from a list of options."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:53
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Add at least one right and one wrong answer."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:61
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Add a wrong answer to this question."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:68
-#: includes/class-sensei-grading-user-quiz.php:157
-#: includes/class-sensei-lesson.php:1119
-#: includes/class-sensei-question.php:48
-#: assets/dist/blocks/quiz/index.js:1
-msgid "True/False"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:69
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Select whether a statement is true or false."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:79
-#: includes/class-sensei-grading-user-quiz.php:167
-#: includes/class-sensei-lesson.php:1119
-#: includes/class-sensei-question.php:49
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Gap Fill"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:80
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Fill in the blank."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:93
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Add a right answer to this question."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:95
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Add text before and after the gap."
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/index.js:99
-#: includes/class-sensei-grading-user-quiz.php:197
-#: includes/class-sensei-lesson.php:1119
-#: includes/class-sensei-question.php:50
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Single Line"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/multi-line.js:13
-#: assets/blocks/quiz/answer-blocks/single-line.js:13
-#: templates/single-quiz/question-type-single-line.php:28
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Answer:"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js:54
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Add Answer"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js:70
-#: assets/blocks/quiz/answer-blocks/true-false.js:53
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Right"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js:71
-#: assets/blocks/quiz/answer-blocks/true-false.js:54
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Wrong"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/true-false.js:73
-#: includes/class-sensei-lesson.php:1776
-#: includes/class-sensei-question.php:1371
-#: templates/single-quiz/question-type-boolean.php:85
-#: assets/dist/blocks/quiz/index.js:1
-msgid "True"
-msgstr ""
-
-#: assets/blocks/quiz/answer-blocks/true-false.js:74
-#: includes/class-sensei-lesson.php:1777
-#: includes/class-sensei-question.php:1373
-#: templates/single-quiz/question-type-boolean.php:89
-#: assets/dist/blocks/quiz/index.js:1
-msgid "False"
-msgstr ""
-
-#: assets/blocks/quiz/answer-feedback-block/answer-feedback-toggle.js:37
-#: includes/class-sensei-grading-user-quiz.php:323
-#: includes/class-sensei-lesson.php:1919
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Answer Feedback"
-msgstr ""
-
-#: assets/blocks/quiz/answer-feedback-block/answer-feedback-toggle.js:45
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Show feedback to students after they submit the quiz."
-msgstr ""
-
-#: assets/blocks/quiz/answer-feedback-block/answer-feedback.js:17
-#: includes/class-sensei-question.php:804
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Correct"
-msgstr ""
-
-#: assets/blocks/quiz/answer-feedback-block/answer-feedback.js:18
-#: assets/dist/blocks/quiz/index.js:1
-msgid ""
-"Enter feedback to be displayed if a student gets this answer right. Type / "
-"to choose a block."
-msgstr ""
-
-#: assets/blocks/quiz/answer-feedback-block/answer-feedback.js:24
-#: includes/class-sensei-question.php:807
-#: includes/class-sensei-question.php:998
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Incorrect"
-msgstr ""
-
-#: assets/blocks/quiz/answer-feedback-block/answer-feedback.js:25
-#: assets/dist/blocks/quiz/index.js:1
-msgid ""
-"Enter feedback to be displayed if a student gets this answer wrong. Type / "
-"to choose a block."
-msgstr ""
-
-#: assets/blocks/quiz/answer-feedback-block/index.js:32
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Correct Answer Feedback"
-msgstr ""
-
-#: assets/blocks/quiz/answer-feedback-block/index.js:34
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Display correct answer feedback."
-msgstr ""
-
-#: assets/blocks/quiz/answer-feedback-block/index.js:45
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Incorrect Answer Feedback"
-msgstr ""
-
-#: assets/blocks/quiz/answer-feedback-block/index.js:47
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Display incorrect answer feedback."
-msgstr ""
-
-#: assets/blocks/quiz/category-question-block/category-question-edit.js:75
-#: assets/blocks/quiz/category-question-block/index.js:19
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Category Question"
-msgstr ""
-
-#: assets/blocks/quiz/category-question-block/category-question-edit.js:82
-#: assets/dist/blocks/quiz/index.js:1
-#. placeholder is number of questions to show from category.
-msgid "%d question"
-msgid_plural "%d questions"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/blocks/quiz/category-question-block/category-question-settings.js:101
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Category Question Settings"
-msgstr ""
-
-#: assets/blocks/quiz/category-question-block/category-question-settings.js:106
-#: assets/dist/blocks/quiz/index.js:1
-msgid "No question categories exist."
-msgstr ""
-
-#: assets/blocks/quiz/category-question-block/category-question-settings.js:134
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:88
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:190
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Number of Questions"
-msgstr ""
-
-#: assets/blocks/quiz/category-question-block/category-question-settings.js:149
-#: assets/dist/blocks/quiz/index.js:1
-#. The underlying error message.
-msgid "An error occurred while retrieving questions: %s"
-msgstr ""
-
-#: assets/blocks/quiz/category-question-block/category-question-settings.js:166
-#: assets/dist/blocks/quiz/index.js:1
-#. Placeholder is number of questions in category.
-msgid "The selected category has %d question."
-msgid_plural "The selected category has %d questions."
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/blocks/quiz/category-question-block/index.js:22
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Pull questions from a question category."
-msgstr ""
-
-#: assets/blocks/quiz/category-question-block/index.js:25
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Example Category"
-msgstr ""
-
-#: assets/blocks/quiz/category-question-block/index.js:31
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Assign a category to this question."
-msgstr ""
-
-#: assets/blocks/quiz/question-answers-block/index.js:19
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Answers"
-msgstr ""
-
-#: assets/blocks/quiz/question-answers-block/index.js:21
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Question Answers."
-msgstr ""
-
-#: assets/blocks/quiz/question-block/index.js:20
-#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:146
-#: includes/class-sensei-lesson.php:897
-#: includes/class-sensei-lesson.php:906
-#: includes/class-sensei-lesson.php:1384
-#: includes/class-sensei-lesson.php:1392
-#: includes/class-sensei-posttypes.php:776
-#: includes/class-sensei-question.php:143
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Question"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/index.js:23
-#: assets/dist/blocks/quiz/index.js:1
-msgid "The building block of all quizzes."
-msgstr ""
-
-#: assets/blocks/quiz/question-block/index.js:25
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Example Quiz Question"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/index.js:31
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Add a title to this question."
-msgstr ""
-
-#: assets/blocks/quiz/question-block/question-block-helpers.js:19
-#: assets/dist/blocks/quiz/index.js:1
-msgid ""
-"Any updates made to this question will also update it in any other quiz "
-"that includes it."
-msgstr ""
-
-#: assets/blocks/quiz/question-block/question-block-helpers.js:24
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Shared Question"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/question-edit.js:143
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Add question description or type / to choose a block."
-msgstr ""
-
-#: assets/blocks/quiz/question-block/question-edit.js:181
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Question Title"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/question-edit.js:53
-#: assets/dist/blocks/quiz/index.js:1
-#. placeholder is the grade for the questions.
-msgid "%d point"
-msgid_plural "%d points"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/blocks/quiz/question-block/question-grade-control.js:28
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Point"
-msgid_plural "Points"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/blocks/quiz/question-block/question-settings.js:34
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Question Settings"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/question-type-toolbar.js:35
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Question Type"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/question-view.js:62
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Question Details"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/question-view.js:66
-#: assets/dist/blocks/quiz/index.js:1
-msgid "You are not allowed to edit this question."
-msgstr ""
-
-#: assets/blocks/quiz/question-block/settings/question-grade-settings.js:28
-#: includes/class-sensei-analysis-course-list-table.php:78
-#: includes/class-sensei-analysis-lesson-list-table.php:50
-#: includes/class-sensei-grading-main.php:68
-#: includes/class-sensei-lesson.php:898
-#: includes/class-sensei-lesson.php:907
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Grade"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js:20
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Grading Notes"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js:23
-#: includes/class-sensei-lesson.php:1819
-#: includes/class-sensei-lesson.php:1832
-#: includes/class-sensei-lesson.php:1856
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Displayed to the teacher when grading the question."
-msgstr ""
-
-#: assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js:20
-#: includes/class-sensei-lesson.php:1182
-#: includes/class-sensei-lesson.php:1322
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Random Order"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/single-question.js:51
-#: assets/blocks/quiz/quiz-block/quiz-validation.js:34
-#: assets/dist/blocks/quiz/index.js:1
-msgid "View issues"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/single-question.js:58
-#: assets/dist/blocks/quiz/index.js:1
-msgid "This question is incomplete."
-msgstr ""
-
-#: assets/blocks/quiz/question-block/single-question.js:66
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Validation"
-msgstr ""
-
-#: assets/blocks/quiz/question-block/single-question.js:72
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Incomplete questions added to a quiz won't be displayed to the learner."
-msgstr ""
-
-#: assets/blocks/quiz/question-description-block/index.js:22
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Question Description."
-msgstr ""
-
-#: assets/blocks/quiz/question-description-block/question-description.js:30
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Question Description"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/index.js:21
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Evaluate progress and strengthen understanding of course concepts."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/index.js:26
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Exam"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/index.js:27
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:92
-#: assets/blocks/quiz/quiz-block/questions-modal/index.js:45
-#: assets/shared/helpers/labels.js:9
-#: includes/class-sensei-posttypes.php:777
-#: includes/class-sensei-posttypes.php:778
-#: assets/dist/blocks/quiz/index.js:1
-#: assets/dist/data-port/export.js:1
-#: assets/dist/data-port/import.js:1
-msgid "Questions"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/index.js:28
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Test"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/index.js:29
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Assessment"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/index.js:30
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Evaluation"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/index.js:40
-#: assets/dist/blocks/quiz/index.js:1
-msgid "First Example Question"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/index.js:46
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Second Example Question"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:101
-#: assets/dist/blocks/quiz/index.js:1
-msgid "per page"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:106
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Progress Bar"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:111
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Show Progress Bar"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:119
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Radius"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:132
-#: assets/shared/blocks/course-progress/course-progress-settings.js:50
-#: assets/dist/blocks/quiz/index.js:1
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Height"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:135
-#: assets/dist/blocks/quiz/index.js:1
-msgid "PX"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:42
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Quiz styling"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:46
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Adjust how your quiz is displayed to your learners."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:57
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Pagination"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:63
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Single page"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/pagination-settings.js:67
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Multi-Page"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/questions-modal/actions.js:43
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Add Selected"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/questions-modal/actions.js:46
-#: assets/dist/blocks/quiz/index.js:1
-#. Number of selected questions.
-msgid "Add Selected (%s)"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/questions-modal/actions.js:55
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Clear Selected"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/questions-modal/filter.js:45
-#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:147
-#: includes/class-sensei-lesson.php:899
-#: includes/class-sensei-lesson.php:908
-#: includes/class-sensei-lesson.php:1385
-#: includes/class-sensei-lesson.php:1393
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Type"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/questions-modal/filter.js:86
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Search questions"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/questions-modal/index.js:54
-#: assets/dist/blocks/quiz/index.js:1
-msgid ""
-"Unable to add the selected question(s). Please make sure you are still "
-"logged in and try again."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:138
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Toggle all visible questions selection."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:156
-#: assets/dist/blocks/quiz/index.js:1
-msgid "No questions found."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-appender.js:39
-#: includes/class-sensei-lesson.php:1267
-#: assets/dist/blocks/quiz/index.js:1
-msgid "New Question"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-appender.js:44
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Category Question(s)"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-appender.js:49
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Existing Question(s)"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-appender.js:55
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Add new or existing question(s)"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-edit.js:70
-#: assets/blocks/quiz/quiz-block/quiz-validation.js:114
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Lesson Quiz"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:113
-#: assets/dist/blocks/quiz/index.js:1
-msgid "What learners see when reviewing their quiz after grading."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:119
-#: assets/dist/blocks/quiz/index.js:1
-msgid "If learner does not pass quiz"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:130
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Indicate which questions are incorrect."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:140
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Show correct answers."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:150
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Show “Answer Feedback” text."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:164
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Auto Grade"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:165
-#: assets/dist/blocks/quiz/index.js:1
-msgid ""
-"Automatically grade Multiple Choice, True/False and Gap Fill questions that "
-"have a non-zero point value."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:175
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Allow Retakes"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:184
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Random Question Order"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:191
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Display a random selection of questions."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:201
-#: assets/extensions/main.js:75
-#: includes/admin/views/html-admin-page-extensions-categories.php:33
-#: includes/class-sensei-course.php:2698
-#: includes/class-sensei-grading-main.php:477
-#: includes/class-sensei-lesson.php:1359
-#: includes/class-sensei-lesson.php:2150
-#: includes/shortcodes/class-sensei-shortcode-user-courses.php:568
-#: assets/dist/blocks/quiz/index.js:1
-#: assets/dist/extensions/index.js:1
-msgid "All"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:84
-#: includes/class-sensei-lesson.php:3749
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Quiz Settings"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-settings.js:91
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Pass Required"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-validation.js:120
-#: assets/dist/blocks/quiz/index.js:1
-msgid "Incomplete questions won't be displayed to the learner when taking the quiz."
-msgstr ""
-
-#: assets/blocks/quiz/quiz-block/quiz-validation.js:42
-#: assets/dist/blocks/quiz/index.js:1
-#. placeholder is the numer of incomplete questions.
-msgid "There is %d incomplete question in your lesson quiz."
-msgid_plural "There are %d incomplete questions in your lesson quiz."
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/blocks/quiz/quiz-store.js:149
-#: assets/dist/blocks/quiz/index.js:1
-#. Error message.
-msgid "Quiz settings and questions could not be loaded. %s"
-msgstr ""
-
-#: assets/blocks/quiz/quiz-store.js:168
-#: assets/dist/blocks/quiz/index.js:1
-#. Error message.
-msgid "Quiz settings and questions could not be updated. %s"
-msgstr ""
-
-#: assets/blocks/take-course-block/index.js:17
-#: assets/dist/blocks/single-course.js:1
-msgid "Course Signup"
-msgstr ""
-
-#: assets/blocks/take-course-block/index.js:18
-#: assets/dist/blocks/single-course.js:1
-msgid ""
-"Enable a registered user to start the course. This block is only displayed "
-"if the user is not already enrolled."
-msgstr ""
-
-#: assets/blocks/take-course-block/index.js:23
-#: assets/dist/blocks/single-course.js:1
-msgid "Start"
-msgstr ""
-
-#: assets/blocks/take-course-block/index.js:24
-#: assets/dist/blocks/single-course.js:1
-msgid "Sign up"
-msgstr ""
-
-#: assets/blocks/take-course-block/index.js:25
-#: assets/dist/blocks/single-course.js:1
-msgid "Signup"
-msgstr ""
-
-#: assets/blocks/take-course-block/index.js:26
-#: assets/dist/blocks/single-course.js:1
-msgid "Enrol"
-msgstr ""
-
-#: assets/blocks/take-course-block/index.js:27
-#: includes/admin/class-sensei-learners-main.php:504
-#: assets/dist/blocks/single-course.js:1
-msgid "Enroll"
-msgstr ""
-
-#: assets/blocks/take-course-block/index.js:29
-#: assets/dist/blocks/single-course.js:1
-msgid "Take course"
-msgstr ""
-
-#: assets/blocks/take-course-block/index.js:33
-#: assets/dist/blocks/single-course.js:1
-msgid "Take Course"
-msgstr ""
-
-#: assets/blocks/view-results-block/index.js:18
-#: assets/dist/blocks/single-course.js:1
-msgid "Enable a learner to view their course results."
-msgstr ""
-
-#: assets/data-port/export/export-page.js:32
-#: assets/dist/data-port/export.js:1
-msgid "Export content to a CSV file"
-msgstr ""
-
-#: assets/data-port/export/export-page.js:35
-#: assets/dist/data-port/export.js:1
-msgid ""
-"This tool enables you to export courses, lessons, and questions to CSV "
-"files. These files are bundled together and downloaded to your computer in "
-".zip format."
-msgstr ""
-
-#: assets/data-port/export/export-progress-page.js:57
-#: includes/class-sensei-lesson.php:1205
-#: assets/dist/data-port/export.js:1
-msgid "Cancel"
-msgstr ""
-
-#: assets/data-port/export/export-progress-page.js:67
-#: assets/dist/data-port/export.js:1
-msgid "The following file was exported:"
-msgid_plural "The following files were exported:"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/data-port/export/export-progress-page.js:96
-#: assets/dist/data-port/export.js:1
-msgid "Export More Content"
-msgstr ""
-
-#: assets/data-port/export/export-select-content-page.js:32
-#: assets/dist/data-port/export.js:1
-msgid "Which type of content would you like to export?"
-msgstr ""
-
-#: assets/data-port/import.js:42
-#: assets/setup-wizard/index.js:58
-#: assets/dist/data-port/import.js:1
-#: assets/dist/setup-wizard/index.js:1
-msgid "An error has occurred while fetching the data. Please try again later!"
-msgstr ""
-
-#: assets/data-port/import.js:47
-#: assets/setup-wizard/index.js:63
-#: assets/dist/data-port/import.js:1
-#: assets/dist/setup-wizard/index.js:1
-msgid "Error details:"
-msgstr ""
-
-#: assets/data-port/import/done/done-page.js:107
-#: assets/dist/data-port/import.js:1
-msgid "No content was imported."
-msgstr ""
-
-#: assets/data-port/import/done/done-page.js:113
-#: assets/dist/data-port/import.js:1
-msgid "Import More Content"
-msgstr ""
-
-#: assets/data-port/import/done/done-page.js:38
-#: includes/class-sensei-analysis-course-list-table.php:385
-#: includes/class-sensei-analysis-lesson-list-table.php:214
-#: includes/class-sensei-grading-main.php:247
-#: assets/dist/data-port/import.js:1
-msgid "Failed"
-msgstr ""
-
-#: assets/data-port/import/done/done-page.js:40
-#: assets/dist/data-port/import.js:1
-msgid ""
-"The following content was not imported. Please make the necessary "
-"corrections to the import file and try again."
-msgstr ""
-
-#: assets/data-port/import/done/done-page.js:54
-#: assets/dist/data-port/import.js:1
-msgid "Partial"
-msgstr ""
-
-#: assets/data-port/import/done/done-page.js:56
-#: assets/dist/data-port/import.js:1
-msgid ""
-"The following content was partially imported. The import process "
-"encountered some issues that you can resolve manually by clicking the link "
-"and making the necessary adjustments."
-msgstr ""
-
-#: assets/data-port/import/done/done-page.js:72
-#: assets/dist/data-port/import.js:1
-msgid "Fetching log details…"
-msgstr ""
-
-#: assets/data-port/import/done/done-page.js:78
-#: assets/dist/data-port/import.js:1
-msgid "Failed to load import log."
-msgstr ""
-
-#: assets/data-port/import/done/done-page.js:81
-#: assets/setup-wizard/features/installation-feedback.js:85
-#: assets/dist/data-port/import.js:1
-#: assets/dist/setup-wizard/index.js:1
-msgid "Retry"
-msgstr ""
-
-#: assets/data-port/import/done/done-page.js:95
-#: assets/dist/data-port/import.js:1
-msgid "The following content was imported:"
-msgstr ""
-
-#: assets/data-port/import/done/import-log.js:47
-#: assets/dist/data-port/import.js:1
-msgid "File"
-msgstr ""
-
-#: assets/data-port/import/done/import-log.js:49
-#: assets/dist/data-port/import.js:1
-msgid "Title"
-msgstr ""
-
-#: assets/data-port/import/done/import-log.js:50
-#: assets/dist/data-port/import.js:1
-msgid "Line #"
-msgstr ""
-
-#: assets/data-port/import/done/import-success-results.js:15
-#: includes/admin/class-sensei-learners-main.php:377
-#: includes/class-sensei-lesson.php:4321
-#: includes/class-sensei-modules.php:859
-#: includes/class-sensei-utils.php:1359
-#: includes/class-sensei.php:823
-#: includes/class-sensei.php:862
-#: includes/class-sensei.php:922
-#: includes/class-sensei.php:936
-#: assets/dist/data-port/import.js:1
-msgid "course"
-msgid_plural "courses"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/data-port/import/done/import-success-results.js:16
-#: includes/admin/class-sensei-learners-main.php:371
-#: includes/class-sensei.php:906
-#: assets/dist/data-port/import.js:1
-msgid "lesson"
-msgid_plural "lessons"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/data-port/import/done/import-success-results.js:17
-#: assets/dist/data-port/import.js:1
-msgid "question"
-msgid_plural "questions"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/data-port/import/import-progress/import-progress-page.js:26
-#: assets/dist/data-port/import.js:1
-msgid "Importing"
-msgstr ""
-
-#: assets/data-port/import/import-progress/import-progress-page.js:28
-#: assets/dist/data-port/import.js:1
-msgid "Your content is now being imported…"
-msgstr ""
-
-#: assets/data-port/import/levels.js:13
-#: assets/dist/data-port/import.js:1
-msgid "Lessons CSV File"
-msgstr ""
-
-#: assets/data-port/import/levels.js:17
-#: assets/dist/data-port/import.js:1
-msgid "Questions CSV File"
-msgstr ""
-
-#: assets/data-port/import/levels.js:9
-#: assets/dist/data-port/import.js:1
-msgid "Courses CSV File"
-msgstr ""
-
-#: assets/data-port/import/steps.js:17
-#: assets/dist/data-port/import.js:1
-msgid "Upload CSV Files"
-msgstr ""
-
-#: assets/data-port/import/steps.js:22
-#: includes/data-port/class-sensei-import.php:61
-#: assets/dist/data-port/import.js:1
-msgid "Import"
-msgstr ""
-
-#: assets/data-port/import/steps.js:27
-#: assets/dist/data-port/import.js:1
-msgid "Done"
-msgstr ""
-
-#: assets/data-port/import/upload-level/upload-level.js:139
-#: assets/dist/data-port/import.js:1
-msgid "Uploading…"
-msgstr ""
-
-#: assets/data-port/import/upload-level/upload-level.js:140
-#: assets/dist/data-port/import.js:1
-msgid "Upload"
-msgstr ""
-
-#: assets/data-port/import/upload-level/upload-level.js:41
-#: assets/dist/data-port/import.js:1
-msgid "Only CSV files are supported."
-msgstr ""
-
-#: assets/data-port/import/upload-level/upload-level.js:97
-#: assets/dist/data-port/import.js:1
-msgid "Delete File"
-msgstr ""
-
-#: assets/data-port/import/upload/upload-page.js:29
-#: assets/dist/data-port/import.js:1
-msgid "Import content from a CSV file"
-msgstr ""
-
-#: assets/data-port/import/upload/upload-page.js:32
-#: assets/dist/data-port/import.js:1
-msgid ""
-"This tool enables you to import courses, lessons, and questions from a CSV "
-"file. Please review the {{link}}documentation{{/link}} to learn more about "
-"the expected file structure."
-msgstr ""
-
-#: assets/data-port/import/upload/upload-page.js:56
-#: assets/dist/data-port/import.js:1
-msgid "Choose one or more CSV files to upload from your computer."
-msgstr ""
-
-#: assets/extensions/card.js:62
-#: assets/dist/extensions/index.js:1
-msgid "New version"
-msgstr ""
-
-#: assets/extensions/extension-actions.js:131
-#: assets/dist/extensions/index.js:1
-msgid "More details"
-msgstr ""
-
-#: assets/extensions/extension-actions.js:67
-#: assets/dist/extensions/index.js:1
-msgid "In progress…"
-msgstr ""
-
-#: assets/extensions/extension-actions.js:75
-#: includes/class-sensei-lesson.php:1206
-#: assets/dist/extensions/index.js:1
-msgid "Update"
-msgstr ""
-
-#: assets/extensions/extension-actions.js:82
-#: assets/extensions/main.js:87
-#: assets/setup-wizard/data/normalizer.js:25
-#: assets/dist/extensions/index.js:1
-#: assets/dist/setup-wizard/index.js:1
-msgid "Installed"
-msgstr ""
-
-#: assets/extensions/extension-actions.js:91
-#: assets/extensions/main.js:81
-#: assets/setup-wizard/data/normalizer.js:29
-#: includes/admin/views/html-admin-page-extensions-results.php:38
-#: assets/dist/extensions/index.js:1
-#: assets/dist/setup-wizard/index.js:1
-msgid "Free"
-msgstr ""
-
-#: assets/extensions/extension-actions.js:94
-#: assets/dist/extensions/index.js:1
-msgid "Install"
-msgstr ""
-
-#: assets/extensions/header.js:9
-#: includes/admin/class-sensei-extensions.php:286
-#: includes/admin/views/html-admin-page-extensions.php:13
-#: assets/dist/extensions/index.js:1
-msgid "Sensei LMS Extensions"
-msgstr ""
-
-#: assets/extensions/main.js:56
-#: assets/dist/extensions/index.js:1
-msgid "No extensions found."
-msgstr ""
-
-#: assets/extensions/store.js:151
-#: assets/dist/extensions/index.js:1
-msgid "Update completed successfully!"
-msgstr ""
-
-#: assets/extensions/store.js:156
-#: assets/dist/extensions/index.js:1
-#. Placeholder is the underlying error message.
-msgid "There was an error while updating the plugin: %1$s"
-msgstr ""
-
-#: assets/extensions/store.js:162
-#: assets/dist/extensions/index.js:1
-msgid "Installation completed successfully!"
-msgstr ""
-
-#: assets/extensions/store.js:167
-#: assets/dist/extensions/index.js:1
-#. Placeholder is the underlying error message.
-msgid "There was an error while installing the plugin: %1$s"
-msgstr ""
-
-#: assets/extensions/update-notification/index.js:52
-#: assets/dist/extensions/index.js:1
-msgid "Updating…"
-msgstr ""
-
-#: assets/extensions/update-notification/index.js:60
-#: assets/dist/extensions/index.js:1
-msgid "Update all"
-msgstr ""
-
-#: assets/extensions/update-notification/multiple.js:36
-#: assets/extensions/update-notification/woocommerce-notice.js:112
-#: assets/dist/extensions/index.js:1
-#. placeholder is the version number.
-msgid "version %s"
-msgstr ""
-
-#: assets/extensions/update-notification/update-available.js:23
-#: assets/dist/extensions/index.js:1
-msgid "Update available"
-msgstr ""
-
-#: assets/extensions/update-notification/update-available.js:26
-#: assets/dist/extensions/index.js:1
-#. placeholder is number of updates available.
-msgid "%d update available"
-msgid_plural "%d updates available"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/extensions/update-notification/woocommerce-notice.js:39
-#: assets/dist/extensions/index.js:1
-msgid ""
-"Your site needs to be connected to your WooCommerce.com account before this "
-"extension can be updated."
-msgid_plural ""
-"Your site needs to be connected to your WooCommerce.com account before "
-"these extensions can be updated."
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/extensions/update-notification/woocommerce-notice.js:48
-#: includes/admin/class-sensei-wccom-connect-notice.php:101
-#: assets/dist/extensions/index.js:1
-msgid "Connect account"
-msgstr ""
-
-#: assets/extensions/update-notification/woocommerce-notice.js:55
-#: assets/dist/extensions/index.js:1
-msgid "WooCommerce needs to be installed before this extension can be updated."
-msgid_plural "WooCommerce needs to be installed before these extensions can be updated."
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/extensions/update-notification/woocommerce-notice.js:64
-#: assets/dist/extensions/index.js:1
-msgid "Install WooCommerce"
-msgstr ""
-
-#: assets/extensions/update-notification/woocommerce-notice.js:71
-#: assets/dist/extensions/index.js:1
-msgid "WooCommerce needs to be activated before this extension can be updated."
-msgid_plural "WooCommerce needs to be activated before these extensions can be updated."
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/extensions/update-notification/woocommerce-notice.js:80
-#: assets/dist/extensions/index.js:1
-msgid "Activate WooCommerce"
-msgstr ""
-
-#: assets/js/admin/blocks-toggling-control.js:152
-#: assets/setup-wizard/features/feature-description.js:35
-#: assets/dist/js/admin/course-edit.js:1
-#: assets/dist/js/admin/lesson-edit.js:1
-#: assets/dist/setup-wizard/index.js:1
-msgid "Learn more"
-msgstr ""
-
-#: assets/js/admin/blocks-toggling-control.js:163
-#: assets/dist/js/admin/course-edit.js:1
-#: assets/dist/js/admin/lesson-edit.js:1
-msgid ""
-"You've just added your first Sensei block. This will change how your course "
-"page appears. Be sure to preview your page before saving changes."
-msgstr ""
-
-#: assets/js/admin/blocks-toggling-control.js:178
-#: assets/dist/js/admin/course-edit.js:1
-#: assets/dist/js/admin/lesson-edit.js:1
-msgid ""
-"Are you sure you want to remove all Sensei blocks? This will change how "
-"your course page appears. Be sure to preview your page before saving "
-"changes."
-msgstr ""
-
-#: assets/js/admin/course-theme-sidebar.js:37
-#: assets/dist/js/admin/course-edit.js:1
-msgid "Course Theme"
-msgstr ""
-
-#: assets/js/admin/course-theme-sidebar.js:40
-#: assets/dist/js/admin/course-edit.js:1
-msgid ""
-"This does not change the theme of your site. It only applies to logged in "
-"users when viewing the course."
-msgstr ""
-
-#: assets/js/admin/course-theme-sidebar.js:46
-#: assets/dist/js/admin/course-edit.js:1
-msgid "Theme"
-msgstr ""
-
-#: assets/js/admin/course-theme-sidebar.js:51
-#: assets/dist/js/admin/course-edit.js:1
-msgid "Sensei Theme"
-msgstr ""
-
-#: assets/js/admin/course-theme-sidebar.js:55
-#: assets/dist/js/admin/course-edit.js:1
-msgid "WordPress Theme"
-msgstr ""
-
-#: assets/setup-wizard/data/normalizer.js:28
-#: assets/dist/setup-wizard/index.js:1
-msgid "per year"
-msgstr ""
-
-#: assets/setup-wizard/features/confirmation-modal.js:40
-#: assets/dist/setup-wizard/index.js:1
-msgid "Would you like to install the following features now?"
-msgstr ""
-
-#: assets/setup-wizard/features/confirmation-modal.js:61
-#: assets/dist/setup-wizard/index.js:1
-msgid ""
-"You won't have access to this functionality until the extensions have been "
-"installed."
-msgstr ""
-
-#: assets/setup-wizard/features/confirmation-modal.js:69
-#: assets/dist/setup-wizard/index.js:1
-msgid ""
-"WooCommerce.com will open in a new tab so that you can complete the "
-"purchase process."
-msgstr ""
-
-#: assets/setup-wizard/features/confirmation-modal.js:87
-#: assets/dist/setup-wizard/index.js:1
-msgid "I'll do it later"
-msgstr ""
-
-#: assets/setup-wizard/features/confirmation-modal.js:96
-#: assets/dist/setup-wizard/index.js:1
-msgid "Install now"
-msgstr ""
-
-#: assets/setup-wizard/features/feature-description-utils.js:31
-#: assets/dist/setup-wizard/index.js:1
-msgid " and "
-msgstr ""
-
-#: assets/setup-wizard/features/feature-description-utils.js:35
-#: assets/dist/setup-wizard/index.js:1
-#. Placeholder is the plugin titles.
-msgid "* WooCommerce is required to receive updates for %1$s."
-msgstr ""
-
-#: assets/setup-wizard/features/feature-status.js:25
-#: assets/dist/setup-wizard/index.js:1
-msgid "Installing plugin"
-msgstr ""
-
-#: assets/setup-wizard/features/feature-status.js:32
-#: assets/dist/setup-wizard/index.js:1
-msgid "Error installing plugin"
-msgstr ""
-
-#: assets/setup-wizard/features/feature-status.js:40
-#: assets/dist/setup-wizard/index.js:1
-msgid "Plugin installed"
-msgstr ""
-
-#: assets/setup-wizard/features/feature-status.js:47
-#: assets/dist/setup-wizard/index.js:1
-msgid "Purchasing plugin"
-msgstr ""
-
-#: assets/setup-wizard/features/features-selection.js:58
-#: assets/dist/setup-wizard/index.js:1
-msgid "No features found."
-msgstr ""
-
-#: assets/setup-wizard/features/index.js:204
-#: assets/dist/setup-wizard/index.js:1
-msgid "Enhance your online courses with these optional features."
-msgstr ""
-
-#: assets/setup-wizard/features/installation-feedback.js:135
-#: assets/dist/setup-wizard/index.js:1
-msgid "Retry?"
-msgstr ""
-
-#: assets/setup-wizard/features/installation-feedback.js:67
-#: assets/dist/setup-wizard/index.js:1
-msgid "Installing…"
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:119
-#: assets/dist/setup-wizard/index.js:1
-msgid "What is your primary purpose for offering online courses?"
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:124
-#: assets/dist/setup-wizard/index.js:1
-msgid "Choose any that apply"
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:24
-#: assets/dist/setup-wizard/index.js:1
-msgid "Share your knowledge"
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:25
-#: assets/dist/setup-wizard/index.js:1
-msgid "You are a hobbyist interested in sharing your knowledge."
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:32
-#: assets/dist/setup-wizard/index.js:1
-msgid "Generate income"
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:33
-#: assets/dist/setup-wizard/index.js:1
-msgid "You would like to generate additional income for yourself or your business."
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:40
-#: assets/dist/setup-wizard/index.js:1
-msgid "Promote your business"
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:41
-#: assets/dist/setup-wizard/index.js:1
-msgid "You own a business and would like to use online courses to promote it."
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:48
-#: assets/dist/setup-wizard/index.js:1
-msgid "Provide certification training"
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:49
-#: assets/dist/setup-wizard/index.js:1
-msgid "You want to help people become certified professionals."
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:56
-#: assets/dist/setup-wizard/index.js:1
-msgid "Train employees"
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:57
-#: assets/dist/setup-wizard/index.js:1
-msgid "You work at a company that regularly trains new or existing employees."
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:64
-#: assets/dist/setup-wizard/index.js:1
-msgid "Educate students"
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:65
-#: assets/dist/setup-wizard/index.js:1
-msgid "You are an educator who would like to create an online classroom."
-msgstr ""
-
-#: assets/setup-wizard/purpose/index.js:72
-#: assets/dist/setup-wizard/index.js:1
-msgid "Other"
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:103
-#: assets/dist/setup-wizard/index.js:1
-msgid "Import content"
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:116
-#: assets/dist/setup-wizard/index.js:1
-msgid "Install the {{em}}Getting Started with Sensei LMS{{/em}} course."
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:134
-#: assets/dist/setup-wizard/index.js:1
-msgid "Install a sample course"
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:142
-#: assets/dist/setup-wizard/index.js:1
-msgid "The sample course could not be imported. Please try again."
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:154
-#: assets/dist/setup-wizard/index.js:1
-msgid ""
-"Visit SenseiLMS.com to learn how to {{link}}create your first "
-"course.{{/link}}"
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:186
-#: assets/dist/setup-wizard/index.js:1
-msgid "Exit to Courses"
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:41
-#: assets/dist/setup-wizard/index.js:1
-msgid "You're ready to start creating online courses!"
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:50
-#: assets/dist/setup-wizard/index.js:1
-msgid "Join our mailing list"
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:52
-#: includes/email-signup/template.php:25
-#: assets/dist/setup-wizard/index.js:1
-msgid ""
-"We're here for you — get tips, product updates, and inspiration straight to "
-"your mailbox."
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:60
-#: assets/dist/setup-wizard/index.js:1
-msgid "What's next?"
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:64
-#: assets/dist/setup-wizard/index.js:1
-msgid "Create some courses"
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:68
-#: assets/dist/setup-wizard/index.js:1
-msgid "You're ready to create online courses."
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:81
-#: assets/dist/setup-wizard/index.js:1
-msgid "Create a course"
-msgstr ""
-
-#: assets/setup-wizard/ready/index.js:90
-#: assets/dist/setup-wizard/index.js:1
-msgid "Transfer existing content to your site — just import a CSV file."
-msgstr ""
-
-#: assets/setup-wizard/ready/mailinglist-signup-form.js:56
-#: includes/email-signup/template.php:58
-#: assets/dist/setup-wizard/index.js:1
-msgid "Yes, please!"
-msgstr ""
-
-#: assets/setup-wizard/steps.js:18
-#: assets/dist/setup-wizard/index.js:1
-msgid "Welcome"
-msgstr ""
-
-#: assets/setup-wizard/steps.js:23
-#: assets/dist/setup-wizard/index.js:1
-msgid "Purpose"
-msgstr ""
-
-#: assets/setup-wizard/steps.js:28
-#: assets/dist/setup-wizard/index.js:1
-msgid "Features"
-msgstr ""
-
-#: assets/setup-wizard/steps.js:33
-#: assets/dist/setup-wizard/index.js:1
-msgid "Ready"
-msgstr ""
-
-#: assets/setup-wizard/welcome/index.js:46
-#: assets/dist/setup-wizard/index.js:1
-msgid "Welcome to Sensei LMS!"
-msgstr ""
-
-#: assets/setup-wizard/welcome/index.js:51
-#: assets/dist/setup-wizard/index.js:1
-msgid "Thank you for choosing Sensei LMS!"
-msgstr ""
-
-#: assets/setup-wizard/welcome/index.js:57
-#: assets/dist/setup-wizard/index.js:1
-msgid ""
-"This setup wizard will help you get started creating online courses more "
-"quickly. It is optional and should take only a few minutes."
-msgstr ""
-
-#: assets/setup-wizard/welcome/index.js:77
-#: assets/dist/setup-wizard/index.js:1
-msgid "Not right now"
-msgstr ""
-
-#: assets/setup-wizard/welcome/usage-modal.js:32
-#: assets/dist/setup-wizard/index.js:1
-msgid ""
-"Get improved features and faster fixes by sharing non-sensitive data via "
-"{{link}}usage tracking{{/link}} that shows us how Sensei LMS is used. No "
-"personal data is tracked or stored."
-msgstr ""
-
-#: assets/setup-wizard/welcome/usage-modal.js:57
-#: assets/dist/setup-wizard/index.js:1
-msgid "Build a Better Sensei LMS"
-msgstr ""
-
-#: assets/setup-wizard/welcome/usage-modal.js:69
-#: assets/dist/setup-wizard/index.js:1
-msgid "Yes, count me in!"
-msgstr ""
-
-#: assets/shared/blocks/course-progress/course-progress-settings.js:33
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-page.js:1
-msgid "Progress bar settings"
-msgstr ""
-
-#: assets/shared/blocks/course-progress/course-progress.js:56
-#: includes/blocks/class-sensei-course-progress-block.php:82
-#: includes/class-sensei-course.php:1551
-#: includes/class-sensei-course.php:1701
-#: includes/class-sensei-course.php:2287
-#: includes/class-sensei-frontend.php:1059
-#: includes/shortcodes/class-sensei-legacy-shortcodes.php:422
-#: widgets/class-sensei-category-courses-widget.php:231
-#: widgets/class-sensei-course-component-widget.php:317
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-page.js:1
-#. placeholder is number of lessons in the course.
-#. translators: Placeholder %d is the lesson count.
-msgid "%d Lesson"
-msgid_plural "%d Lessons"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/shared/blocks/course-progress/course-progress.js:73
-#: assets/dist/blocks/single-course.js:1
-#: assets/dist/blocks/single-page.js:1
-#. placeholder is number of completed lessons in the course.
-msgid "%d Completed"
-msgid_plural "%d Completed"
-msgstr[0] ""
-msgstr[1] ""
-
-#: assets/shared/helpers/labels.js:13
-#: assets/dist/data-port/export.js:1
-#: assets/dist/data-port/import.js:1
-msgid "Error"
-msgstr ""
-
-#: assets/shared/helpers/labels.js:14
-#: assets/dist/data-port/export.js:1
-#: assets/dist/data-port/import.js:1
-msgid "Warning"
-msgstr ""
-
+#. Plugin Name of the plugin
 #: includes/admin/class-sensei-status.php:63
 #: includes/admin/class-sensei-status.php:284
-#: includes/blocks/class-sensei-blocks.php:112
-#. Plugin Name of the plugin
+#: includes/blocks/class-sensei-blocks.php:114
+#: includes/class-sensei-customizer.php:56
 msgid "Sensei LMS"
 msgstr ""
 
@@ -2767,9 +27,7 @@ msgid "https://woocommerce.com/products/sensei/"
 msgstr ""
 
 #. Description of the plugin
-msgid ""
-"Share your knowledge, grow your network, and strengthen your brand by "
-"launching an online course."
+msgid "Share your knowledge, grow your network, and strengthen your brand by launching an online course."
 msgstr ""
 
 #. Author of the plugin
@@ -2780,95 +38,134 @@ msgstr ""
 msgid "https://automattic.com"
 msgstr ""
 
+#: includes/admin/class-sensei-extensions.php:286
+#: includes/admin/views/html-admin-page-extensions.php:13
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/header.js:9
+msgid "Sensei LMS Extensions"
+msgstr ""
+
 #: includes/admin/class-sensei-extensions.php:287
 msgid "Extensions"
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:66
-msgid "Learner Management"
+msgid "Student Management"
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:134
-msgid "Learners per page"
+msgid "Students per page"
+msgstr ""
+
+#: includes/admin/class-sensei-learner-management.php:166
+#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:387
+#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:407
+#: includes/admin/class-sensei-learners-main.php:399
+#: includes/admin/tools/class-sensei-tool-enrolment-debug.php:214
+#: includes/blocks/class-sensei-course-outline-module-block.php:132
+#: includes/class-sensei-analysis-course-list-table.php:307
+#: includes/class-sensei-analysis-course-list-table.php:394
+#: includes/class-sensei-analysis-lesson-list-table.php:219
+#: includes/class-sensei-analysis-user-profile-list-table.php:213
+#: includes/class-sensei-course.php:3201
+#: includes/class-sensei-grading-main.php:253
+#: includes/class-sensei-grading-main.php:480
+#: includes/class-sensei-lesson.php:4212
+#: assets/blocks/course-outline/status-preview/status-control/index.js:17
+#: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-settings.js:40
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+msgid "In Progress"
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:171
-msgid "Are you sure you want to remove this learner?"
+msgid "Are you sure you want to remove this student?"
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:172
-msgid "Are you sure you want to remove the learner from this lesson?"
+msgid "Are you sure you want to remove the student from this lesson?"
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:173
-msgid "Are you sure you want to remove this learner's enrollment in the course?"
+msgid "Are you sure you want to remove this student's enrollment in the course?"
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:174
-msgid "Are you sure you want to enroll the learner in this course?"
+msgid "Are you sure you want to enroll the student in this course?"
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:175
-msgid "Are you sure you want to restore the learner enrollment in this course?"
+msgid "Are you sure you want to restore the student enrollment in this course?"
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:176
-msgid "Are you sure you want to reset the progress of this learner for this lesson?"
+msgid "Are you sure you want to reset the progress of this student for this lesson?"
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:177
-msgid "Are you sure you want to reset the progress of this learner for this course?"
+msgid "Are you sure you want to reset the progress of this student for this course?"
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:178
-msgid ""
-"Are you sure you want to remove the progress of this learner for this "
-"course?"
+msgid "Are you sure you want to remove the progress of this student for this course?"
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:183
-msgid "Select learners to manually enroll..."
+msgid "Select students to manually enroll..."
+msgstr ""
+
+#: includes/admin/class-sensei-learner-management.php:643
+#: includes/class-sensei-course.php:349
+#: includes/class-sensei-course.php:758
+#: includes/class-sensei-lesson.php:257
+#: includes/class-sensei-lesson.php:345
+#: includes/class-sensei-lesson.php:1383
+#: includes/class-sensei-modules.php:218
+#: includes/class-sensei-utils.php:2270
+#: assets/blocks/lesson-properties/constants.js:9
+#: assets/dist/blocks/single-lesson.js:1
+msgid "None"
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:792
-msgid "An error occurred while enrolling the learner."
+msgid "An error occurred while enrolling the student."
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:798
-msgid "An error occurred while restoring learner enrollment."
+msgid "An error occurred while restoring student enrollment."
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:804
-msgid "An error occurred while enrolling the learners."
+msgid "An error occurred while enrolling the students."
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:810
-msgid "An error occurred removing the learner's enrollment."
+msgid "An error occurred removing the student's enrollment."
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:816
-msgid "Learner's enrollment has been removed."
+msgid "Student's enrollment has been removed."
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:822
-msgid "Learner has been enrolled."
+msgid "Student has been enrolled."
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:828
-msgid "Learner enrollment has been restored."
+msgid "Student enrollment has been restored."
 msgstr ""
 
 #: includes/admin/class-sensei-learner-management.php:835
-msgid "Learners have been enrolled."
+msgid "Student have been enrolled."
 msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-controller.php:102
-msgid "Learner Admin"
+msgid "Student Admin"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-controller.php:112
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:309
-msgid "Bulk Learner Actions"
+msgid "Bulk Student Actions"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-controller.php:118
@@ -2918,7 +215,25 @@ msgid "Invalid Course"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-controller.php:405
-msgid "Bulk learner action succeeded"
+msgid "Bulk student action succeeded"
+msgstr ""
+
+#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:96
+#: includes/admin/class-sensei-learners-main.php:167
+#: includes/class-sensei-analysis-course-list-table.php:61
+#: includes/class-sensei-analysis-lesson-list-table.php:46
+#: includes/class-sensei-analysis-overview-list-table.php:69
+#: includes/class-sensei-grading-main.php:63
+#: assets/blocks/learner-courses-block/index.js:25
+#: assets/blocks/learner-courses-block/index.js:26
+#: assets/dist/blocks/single-page.js:1
+msgid "Student"
+msgstr ""
+
+#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:97
+#: assets/blocks/course-progress-block/index.js:14
+#: assets/dist/blocks/single-course.js:6
+msgid "Course Progress"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:98
@@ -2930,12 +245,12 @@ msgstr ""
 msgid "No results found"
 msgstr ""
 
+#. translators: Placeholder is the full name of the learner.
+#. translators: Placeholder is the item title.
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:223
 #: includes/admin/class-sensei-learners-main.php:459
 #: includes/admin/class-sensei-learners-main.php:652
 #: includes/admin/class-sensei-learners-main.php:712
-#. translators: Placeholder is the full name of the learner.
-#. translators: Placeholder is the item title.
 msgid "Edit &#8220;%s&#8221;"
 msgstr ""
 
@@ -2943,7 +258,7 @@ msgstr ""
 #: includes/admin/class-sensei-learners-main.php:1004
 #: includes/class-sensei-analysis-course-list-table.php:609
 #: includes/class-sensei-analysis-lesson-list-table.php:333
-msgid "No learners found."
+msgid "No students found."
 msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:288
@@ -2963,7 +278,7 @@ msgid "Filter By Course"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:363
-#: includes/class-sensei-lesson.php:1376
+#: includes/class-sensei-lesson.php:1451
 msgid "Filter"
 msgstr ""
 
@@ -2972,7 +287,55 @@ msgstr ""
 #: includes/class-sensei-analysis-course-list-table.php:706
 #: includes/class-sensei-analysis-lesson-list-table.php:374
 #: includes/class-sensei-analysis-overview-list-table.php:753
-msgid "Search Learners"
+msgid "Search Students"
+msgstr ""
+
+#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:387
+#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:407
+#: includes/admin/class-sensei-setup-wizard-pages.php:60
+#: includes/class-sensei-admin.php:1636
+#: includes/class-sensei-analysis-overview-list-table.php:689
+#: includes/class-sensei-analysis-user-profile-list-table.php:327
+#: includes/class-sensei-course.php:2928
+#: includes/class-sensei-posttypes.php:762
+#: includes/class-sensei-posttypes.php:763
+#: includes/class-sensei-settings.php:142
+#: includes/unsupported-theme-handlers/class-sensei-unsupported-theme-handler-course-archive.php:55
+#: assets/blocks/course-completed-actions/index.js:49
+#: assets/blocks/learner-courses-block/index.js:23
+#: assets/dist/blocks/single-page.js:1
+#: assets/dist/data-port/export.js:1
+#: assets/dist/data-port/import.js:1
+#: assets/shared/helpers/labels.js:7
+msgid "Courses"
+msgstr ""
+
+#: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:409
+#: includes/admin/class-sensei-learners-main.php:386
+#: includes/admin/tools/class-sensei-tool-enrolment-debug.php:217
+#: includes/blocks/class-sensei-course-outline-module-block.php:135
+#: includes/class-sensei-analysis-course-list-table.php:86
+#: includes/class-sensei-analysis-course-list-table.php:302
+#: includes/class-sensei-analysis-course-list-table.php:370
+#: includes/class-sensei-analysis-lesson-list-table.php:205
+#: includes/class-sensei-analysis-overview-list-table.php:51
+#: includes/class-sensei-analysis-overview-list-table.php:61
+#: includes/class-sensei-analysis-user-profile-list-table.php:206
+#: includes/class-sensei-course.php:3177
+#: includes/class-sensei-grading-main.php:238
+#: includes/class-sensei-modules.php:772
+#: includes/shortcodes/class-sensei-shortcode-user-courses.php:570
+#: includes/template-functions.php:654
+#: assets/blocks/conditional-content-block/index.js:26
+#: assets/blocks/course-completed-actions/index.js:24
+#: assets/blocks/course-outline/status-preview/status-control/index.js:18
+#: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-settings.js:44
+#: assets/data-port/import/done/done-page.js:91
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/blocks/single-page.js:1
+#: assets/dist/data-port/import.js:1
+msgid "Completed"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-view.php:412
@@ -2993,6 +356,18 @@ msgstr ""
 msgid "Enrollment"
 msgstr ""
 
+#: includes/admin/class-sensei-learners-main.php:169
+#: includes/class-sensei-analysis-course-list-table.php:64
+#: includes/class-sensei-analysis-course-list-table.php:77
+#: includes/class-sensei-analysis-lesson-list-table.php:49
+#: includes/class-sensei-analysis-user-profile-list-table.php:48
+#: includes/class-sensei-grading-main.php:67
+#: assets/blocks/course-outline/lesson-block/lesson-settings.js:76
+#: assets/blocks/course-outline/module-block/module-status.js:72
+#: assets/dist/blocks/single-course.js:6
+msgid "Status"
+msgstr ""
+
 #: includes/admin/class-sensei-learners-main.php:170
 #: includes/class-sensei-analysis-course-list-table.php:62
 #: includes/class-sensei-analysis-course-list-table.php:75
@@ -3009,9 +384,35 @@ msgstr ""
 msgid "Date Completed"
 msgstr ""
 
+#: includes/admin/class-sensei-learners-main.php:177
+#: includes/admin/class-sensei-learners-main.php:1195
+#: includes/class-sensei-analysis-course-list-table.php:74
+#: includes/class-sensei-analysis-course-list-table.php:84
+#: includes/class-sensei-analysis-overview-list-table.php:58
+#: includes/class-sensei-course.php:2994
+#: includes/class-sensei-grading-main.php:65
+#: includes/class-sensei-posttypes.php:766
+#: templates/course-results/lessons.php:37
+#: templates/single-course/modules.php:100
+#: assets/blocks/course-outline/lesson-block/index.js:14
+#: assets/blocks/course-outline/lesson-block/index.js:17
+#: assets/blocks/course-outline/lesson-block/lesson-settings.js:56
+#: assets/blocks/course-outline/module-block/index.js:35
+#: assets/blocks/course-outline/outline-block/index.js:50
+#: assets/blocks/course-outline/outline-block/outline-appender.js:29
+#: assets/blocks/lesson-actions/complete-lesson-block/index.js:26
+#: assets/blocks/lesson-actions/lesson-actions-block/index.js:21
+#: assets/blocks/lesson-actions/next-lesson-block/index.js:26
+#: assets/blocks/lesson-actions/reset-lesson-block/index.js:28
+#: assets/blocks/lesson-actions/view-quiz-block/index.js:22
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Lesson"
+msgstr ""
+
 #: includes/admin/class-sensei-learners-main.php:178
 #: includes/admin/class-sensei-learners-main.php:187
-msgid "# Learners"
+msgid "# Students"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:179
@@ -3019,13 +420,89 @@ msgstr ""
 msgid "Last Updated"
 msgstr ""
 
+#: includes/admin/class-sensei-learners-main.php:186
+#: includes/admin/class-sensei-learners-main.php:1190
+#: includes/admin/tools/views/html-enrolment-debug-form.php:55
+#: includes/admin/tools/views/html-enrolment-debug.php:53
+#: includes/admin/tools/views/html-recalculate-course-enrolment-form.php:25
+#: includes/class-sensei-analysis-overview-list-table.php:48
+#: includes/class-sensei-analysis-overview-list-table.php:59
+#: includes/class-sensei-analysis-user-profile-list-table.php:45
+#: includes/class-sensei-grading-main.php:64
+#: includes/class-sensei-lesson.php:204
+#: includes/class-sensei-posttypes.php:761
+#: assets/blocks/course-completed-actions/index.js:23
+#: assets/blocks/course-outline/lesson-block/index.js:17
+#: assets/blocks/course-outline/outline-block/index.js:18
+#: assets/blocks/course-progress-block/index.js:22
+#: assets/blocks/course-results-block/index.js:20
+#: assets/blocks/take-course-block/index.js:28
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-page.js:1
+msgid "Course"
+msgstr ""
+
+#: includes/admin/class-sensei-learners-main.php:371
+#: includes/class-sensei.php:907
+#: assets/data-port/import/done/import-success-results.js:16
+#: assets/dist/data-port/import.js:1
+msgid "lesson"
+msgid_plural "lessons"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin/class-sensei-learners-main.php:377
+#: includes/class-sensei-lesson.php:4447
+#: includes/class-sensei-modules.php:859
+#: includes/class-sensei-utils.php:1359
+#: includes/class-sensei.php:824
+#: includes/class-sensei.php:863
+#: includes/class-sensei.php:923
+#: includes/class-sensei.php:937
+#: assets/data-port/import/done/import-success-results.js:15
+#: assets/dist/data-port/import.js:1
+msgid "course"
+msgid_plural "courses"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/admin/class-sensei-learners-main.php:394
+#: assets/blocks/course-outline/status-preview/status-control/index.js:16
+#: assets/dist/blocks/single-course.js:6
+msgid "Not Started"
+msgstr ""
+
 #: includes/admin/class-sensei-learners-main.php:440
 msgid "No enrollment data was found."
+msgstr ""
+
+#: includes/admin/class-sensei-learners-main.php:445
+#: includes/admin/tools/views/html-enrolment-debug.php:78
+#: assets/blocks/conditional-content-block/conditional-content-edit.js:21
+#: assets/blocks/conditional-content-block/index.js:22
+#: assets/blocks/learner-courses-block/index.js:24
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-page.js:1
+msgid "Enrolled"
+msgstr ""
+
+#: includes/admin/class-sensei-learners-main.php:448
+#: includes/admin/tools/views/html-enrolment-debug.php:82
+#: assets/blocks/conditional-content-block/conditional-content-edit.js:22
+#: assets/blocks/conditional-content-block/index.js:27
+#: assets/dist/blocks/single-course.js:6
+msgid "Not Enrolled"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:499
 #: includes/admin/class-sensei-learners-main.php:549
 msgid "Reset Progress"
+msgstr ""
+
+#: includes/admin/class-sensei-learners-main.php:504
+#: assets/blocks/take-course-block/index.js:27
+#: assets/dist/blocks/single-course.js:6
+msgid "Enroll"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:510
@@ -3046,11 +523,11 @@ msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:689
 #: includes/admin/class-sensei-learners-main.php:753
-msgid "Manage learners"
+msgid "Manage students"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:776
-msgid "Update Learner"
+msgid "Update Student"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:1008
@@ -3064,7 +541,7 @@ msgid "No courses found."
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:1045
-#: includes/class-sensei-course.php:3396
+#: includes/class-sensei-course.php:3428
 msgid "Course Category"
 msgstr ""
 
@@ -3073,54 +550,76 @@ msgstr ""
 msgid "All Course Categories"
 msgstr ""
 
-#: includes/admin/class-sensei-learners-main.php:1087
 #. translators: Placeholder is the Course title.
+#: includes/admin/class-sensei-learners-main.php:1087
 msgid "Back to %s"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:1124
-msgid "Enrolled Learners"
+msgid "Enrolled Students"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:1127
-msgid "Unenrolled Learners"
+msgid "Unenrolled Students"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:1130
-msgid "Manually Enrolled Learners"
+msgid "Manually Enrolled Students"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:1133
-msgid "All Learners"
+msgid "All Students"
 msgstr ""
 
-#: includes/admin/class-sensei-learners-main.php:1209
+#: includes/admin/class-sensei-learners-main.php:1158
+#: includes/blocks/class-sensei-course-outline-module-block.php:98
+#: includes/class-sensei-admin.php:1637
+#: includes/class-sensei-analysis-overview-list-table.php:50
+#: includes/class-sensei-analysis-overview-list-table.php:690
+#: includes/class-sensei-course.php:2994
+#: includes/class-sensei-modules.php:1270
+#: includes/class-sensei-posttypes.php:767
+#: includes/class-sensei-posttypes.php:768
+#: includes/class-sensei-settings.php:147
+#: templates/course-results/lessons.php:39
+#: templates/single-course/modules.php:102
+#: assets/blocks/course-outline/module-block/index.js:22
+#: assets/blocks/course-outline/module-block/module-edit.js:198
+#: assets/blocks/course-outline/outline-block/index.js:19
+#: assets/blocks/course-results-block/index.js:21
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-page.js:1
+#: assets/dist/data-port/export.js:1
+#: assets/dist/data-port/import.js:1
+#: assets/shared/helpers/labels.js:8
+msgid "Lessons"
+msgstr ""
+
 #. translators: Placeholder is the post type.
-msgid "Add Learner to %1$s"
+#: includes/admin/class-sensei-learners-main.php:1209
+msgid "Add Student to %1$s"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:1218
-msgid "Complete lesson for learner"
+msgid "Complete lesson for student"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:1220
-msgid "Complete course for learner"
+msgid "Complete course for student"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:1223
 msgid "Search for a user by typing their name or username."
 msgstr ""
 
-#: includes/admin/class-sensei-learners-main.php:1228
 #. translators: Placeholder is the post title.
+#: includes/admin/class-sensei-learners-main.php:1228
 msgid "Add to '%1$s'"
 msgstr ""
 
-#: includes/admin/class-sensei-learners-main.php:1235
 #. translators: Placeholder is the course title.
-msgid ""
-"Learner will also be added to the course '%1$s' if they are not already "
-"taking it."
+#: includes/admin/class-sensei-learners-main.php:1235
+msgid "Student will also be added to the course '%1$s' if they are not already taking it."
 msgstr ""
 
 #: includes/admin/class-sensei-learners-main.php:1267
@@ -3135,18 +634,55 @@ msgstr ""
 msgid "Search Courses"
 msgstr ""
 
-#: includes/admin/class-sensei-plugins-installation.php:351
 #. translators: Placeholder %1$s is the plugin title, %2$s is the error message.
+#: includes/admin/class-sensei-plugins-installation.php:351
 msgid "%1$s could not be installed (%2$s)."
 msgstr ""
 
-#: includes/admin/class-sensei-plugins-installation.php:370
 #. translators: Placeholder %1$s is the plugin title, %2$s is the error message.
+#: includes/admin/class-sensei-plugins-installation.php:370
 msgid "%1$s is installed but could not be activated (%2$s)."
+msgstr ""
+
+#: includes/admin/class-sensei-setup-wizard-pages.php:60
+msgctxt "page_slug"
+msgid "courses-overview"
+msgstr ""
+
+#: includes/admin/class-sensei-setup-wizard-pages.php:64
+msgctxt "page_slug"
+msgid "my-courses"
+msgstr ""
+
+#: includes/admin/class-sensei-setup-wizard-pages.php:64
+#: includes/class-sensei-admin.php:1638
+#: widgets/class-sensei-course-component-widget.php:336
+#: assets/blocks/learner-courses-block/index.js:21
+#: assets/dist/blocks/single-page.js:1
+msgid "My Courses"
+msgstr ""
+
+#: includes/admin/class-sensei-setup-wizard-pages.php:68
+msgctxt "page_slug"
+msgid "course-completed"
+msgstr ""
+
+#: includes/admin/class-sensei-setup-wizard-pages.php:68
+#: assets/blocks/conditional-content-block/conditional-content-edit.js:23
+#: assets/dist/blocks/single-course.js:6
+msgid "Course Completed"
 msgstr ""
 
 #: includes/admin/class-sensei-setup-wizard-pages.php:135
 msgid "Congratulations on completing this course! 🥳"
+msgstr ""
+
+#: includes/admin/class-sensei-setup-wizard-pages.php:151
+#: assets/blocks/course-completed-actions/index.js:11
+#: assets/blocks/course-completed-actions/index.js:27
+#: assets/blocks/course-completed-actions/index.js:43
+#: assets/dist/blocks/single-page.js:1
+msgid "Find More Courses"
 msgstr ""
 
 #: includes/admin/class-sensei-setup-wizard.php:117
@@ -3155,9 +691,7 @@ msgid "Sensei LMS - Setup Wizard"
 msgstr ""
 
 #: includes/admin/class-sensei-setup-wizard.php:289
-msgid ""
-"<strong>Welcome to Sensei LMS</strong> &#8211; You're almost ready to start "
-"creating online courses!"
+msgid "<strong>Welcome to Sensei LMS</strong> &#8211; You're almost ready to start creating online courses!"
 msgstr ""
 
 #: includes/admin/class-sensei-setup-wizard.php:295
@@ -3186,9 +720,7 @@ msgid "Setup Wizard"
 msgstr ""
 
 #: includes/admin/class-sensei-setup-wizard.php:387
-msgid ""
-"If you need to access the setup wizard again, please click on the button "
-"below."
+msgid "If you need to access the setup wizard again, please click on the button below."
 msgstr ""
 
 #: includes/admin/class-sensei-status.php:87
@@ -3207,8 +739,8 @@ msgstr ""
 msgid "Not applicable"
 msgstr ""
 
-#: includes/admin/class-sensei-status.php:115
 #. translators: Placeholder is datetime for when the instance was upgraded.
+#: includes/admin/class-sensei-status.php:115
 msgid "Yes, updated Sensei LMS from a pre-3.0 version at %s"
 msgstr ""
 
@@ -3220,13 +752,13 @@ msgstr ""
 msgid "No template overrides"
 msgstr ""
 
-#: includes/admin/class-sensei-status.php:140
 #. translators: First placeholder is Sensei LMS' template version and the second placeholder is the theme's version.
+#: includes/admin/class-sensei-status.php:140
 msgid "Mismatch (plugin v%1$s; theme v%2$s)"
 msgstr ""
 
-#: includes/admin/class-sensei-status.php:143
 #. translators: Placeholder is the version of the template.
+#: includes/admin/class-sensei-status.php:143
 msgid "Match (v%s)"
 msgstr ""
 
@@ -3242,8 +774,16 @@ msgstr ""
 msgid "Pending"
 msgstr ""
 
+#: includes/admin/class-sensei-status.php:171
+#: includes/class-sensei-lesson.php:4208
+#: assets/blocks/lesson-actions/complete-lesson-block/index.js:24
+#: assets/blocks/lesson-actions/lesson-actions-block/index.js:24
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Complete"
+msgstr ""
+
 #: includes/admin/class-sensei-status.php:175
-msgid "Learner calculation job"
+msgid "Student calculation job"
 msgstr ""
 
 #: includes/admin/class-sensei-status.php:266
@@ -3251,23 +791,19 @@ msgid "Enrollment status cached"
 msgstr ""
 
 #: includes/admin/class-sensei-status.php:279
-msgid ""
-"Sensei LMS attempts to calculate whether learners are enrolled in all "
-"courses ahead of time to speed up loading."
+msgid "Sensei LMS attempts to calculate whether students are enrolled in all courses ahead of time to speed up loading."
 msgstr ""
 
 #: includes/admin/class-sensei-status.php:281
-msgid "Learner enrollment has been calculated"
+msgid "Student enrollment has been calculated"
 msgstr ""
 
 #: includes/admin/class-sensei-status.php:295
-msgid "Learner enrollment has not been calculated"
+msgid "Student enrollment has not been calculated"
 msgstr ""
 
 #: includes/admin/class-sensei-status.php:296
-msgid ""
-"This could be in progress. Until this process is complete, some pages may "
-"load more slowly."
+msgid "This could be in progress. Until this process is complete, some pages may load more slowly."
 msgstr ""
 
 #: includes/admin/class-sensei-tools.php:104
@@ -3284,17 +820,21 @@ msgid "There was a problem validating your request. Please try again."
 msgstr ""
 
 #: includes/admin/class-sensei-wccom-connect-notice.php:93
-msgid ""
-"Get notified about new features and updates by connecting your "
-"WooCommerce.com account."
+msgid "Get notified about new features and updates by connecting your WooCommerce.com account."
+msgstr ""
+
+#: includes/admin/class-sensei-wccom-connect-notice.php:101
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/update-notification/woocommerce-notice.js:48
+msgid "Connect account"
 msgstr ""
 
 #: includes/admin/class-sensei-wcpc-prompt.php:46
 msgid "WooCommerce Paid Courses extension"
 msgstr ""
 
-#: includes/admin/class-sensei-wcpc-prompt.php:57
 #. translators: Placeholder is the learn more link.
+#: includes/admin/class-sensei-wcpc-prompt.php:57
 msgid "Monetize and sell your courses by installing the %s."
 msgstr ""
 
@@ -3307,7 +847,7 @@ msgid "Debug Course Enrollment"
 msgstr ""
 
 #: includes/admin/tools/class-sensei-tool-enrolment-debug.php:52
-msgid "Check what the enrollment status is between a course and learner."
+msgid "Check what the enrollment status is between a course and student."
 msgstr ""
 
 #: includes/admin/tools/class-sensei-tool-enrolment-debug.php:139
@@ -3351,13 +891,13 @@ msgstr ""
 msgid "Fix module slugs that do not match the module name."
 msgstr ""
 
-#: includes/admin/tools/class-sensei-tool-module-slugs-mismatch.php:124
 #. translators: %1$s is the IDs of the updated terms.
+#: includes/admin/tools/class-sensei-tool-module-slugs-mismatch.php:124
 msgid "Module slugs were updated in the terms with IDs: %1$s."
 msgstr ""
 
-#: includes/admin/tools/class-sensei-tool-module-slugs-mismatch.php:132
 #. translators: %1$s is terms with error on update.
+#: includes/admin/tools/class-sensei-tool-module-slugs-mismatch.php:132
 msgid "Errors happened while updating slugs for the terms with IDs: %1$s."
 msgstr ""
 
@@ -3370,9 +910,7 @@ msgid "Recalculate Course Enrollment"
 msgstr ""
 
 #: includes/admin/tools/class-sensei-tool-recalculate-course-enrolment.php:45
-msgid ""
-"Invalidate the cached enrollment and trigger recalculation for all users in "
-"a specific course."
+msgid "Invalidate the cached enrollment and trigger recalculation for all users in a specific course."
 msgstr ""
 
 #: includes/admin/tools/class-sensei-tool-recalculate-course-enrolment.php:99
@@ -3384,9 +922,7 @@ msgid "Recalculate Enrollments"
 msgstr ""
 
 #: includes/admin/tools/class-sensei-tool-recalculate-enrolment.php:43
-msgid ""
-"Invalidate the cached enrollment and trigger recalculation for all users "
-"and courses."
+msgid "Invalidate the cached enrollment and trigger recalculation for all users and courses."
 msgstr ""
 
 #: includes/admin/tools/class-sensei-tool-recalculate-enrolment.php:53
@@ -3398,9 +934,7 @@ msgid "Remove Deleted User Data"
 msgstr ""
 
 #: includes/admin/tools/class-sensei-tool-remove-deleted-user-data.php:43
-msgid ""
-"Removes course, lesson, and quiz progress for deleted users. This should "
-"have been done automatically since Sensei LMS v3.0."
+msgid "Removes course, lesson, and quiz progress for deleted users. This should have been done automatically since Sensei LMS v3.0."
 msgstr ""
 
 #: includes/admin/tools/class-sensei-tool-remove-deleted-user-data.php:60
@@ -3448,13 +982,12 @@ msgid "View Course"
 msgstr ""
 
 #: includes/admin/tools/views/html-enrolment-debug.php:64
-#: includes/class-sensei-lesson.php:186
+#: includes/class-sensei-lesson.php:189
 msgid "Edit Course"
 msgstr ""
 
 #: includes/admin/tools/views/html-enrolment-debug.php:67
-#: includes/class-sensei-course.php:679
-msgid "Manage Learners"
+msgid "Manage Students"
 msgstr ""
 
 #: includes/admin/tools/views/html-enrolment-debug.php:73
@@ -3462,20 +995,20 @@ msgid "Enrollment status"
 msgstr ""
 
 #: includes/admin/tools/views/html-enrolment-debug.php:87
-msgid "Learner manually removed"
+msgid "Student manually removed"
 msgstr ""
 
 #: includes/admin/tools/views/html-enrolment-debug.php:95
 msgid "Course progress status"
 msgstr ""
 
-#: includes/admin/tools/views/html-enrolment-debug.php:106
 #. translators: %s placeholder is datetime progress was started.
+#: includes/admin/tools/views/html-enrolment-debug.php:106
 msgid "Started on %s"
 msgstr ""
 
-#: includes/admin/tools/views/html-enrolment-debug.php:112
 #. translators: %s placeholder is datetime progress was started.
+#: includes/admin/tools/views/html-enrolment-debug.php:112
 msgid "Last activity on %s"
 msgstr ""
 
@@ -3495,8 +1028,8 @@ msgstr ""
 msgid "Does Not Match Calculated Enrollment"
 msgstr ""
 
-#: includes/admin/tools/views/html-enrolment-debug.php:140
 #. translators: %s placeholder is datetime results were last calculated.
+#: includes/admin/tools/views/html-enrolment-debug.php:140
 msgid "Last calculated on %s"
 msgstr ""
 
@@ -3509,11 +1042,11 @@ msgid "Does Not Handle Course"
 msgstr ""
 
 #: includes/admin/tools/views/html-enrolment-debug.php:177
-msgid "Enrolls Learner"
+msgid "Enrolls Student"
 msgstr ""
 
 #: includes/admin/tools/views/html-enrolment-debug.php:181
-msgid "Does Not Enroll Learner"
+msgid "Does Not Enroll Student"
 msgstr ""
 
 #: includes/admin/tools/views/html-enrolment-debug.php:190
@@ -3548,12 +1081,33 @@ msgstr ""
 msgid "Trigger Course Enrollment Recalculation"
 msgstr ""
 
+#: includes/admin/views/html-admin-page-extensions-categories.php:33
+#: includes/class-sensei-course.php:2730
+#: includes/class-sensei-grading-main.php:477
+#: includes/class-sensei-lesson.php:1434
+#: includes/class-sensei-lesson.php:2225
+#: includes/shortcodes/class-sensei-shortcode-user-courses.php:568
+#: assets/dist/blocks/quiz/index.js:6
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/main.js:75
+msgid "All"
+msgstr ""
+
 #: includes/admin/views/html-admin-page-extensions-messages.php:23
 msgid "More Information &rarr;"
 msgstr ""
 
 #: includes/admin/views/html-admin-page-extensions-results.php:17
 msgid "No extensions were found."
+msgstr ""
+
+#: includes/admin/views/html-admin-page-extensions-results.php:38
+#: assets/dist/extensions/index.js:1
+#: assets/dist/setup-wizard/index.js:6
+#: assets/extensions/extension-actions.js:91
+#: assets/extensions/main.js:81
+#: assets/setup-wizard/data/normalizer.js:29
+msgid "Free"
 msgstr ""
 
 #: includes/admin/views/html-admin-page-extensions-results.php:45
@@ -3596,43 +1150,157 @@ msgstr ""
 msgid "Send Message"
 msgstr ""
 
+#. Translators: placeholder is number of lessons.
+#: includes/blocks/class-sensei-course-navigation-block.php:150
+msgid "%d lesson"
+msgid_plural "%d lessons"
+msgstr[0] ""
+msgstr[1] ""
+
+#. Translators: placeholder is number of quizzes.
+#: includes/blocks/class-sensei-course-navigation-block.php:152
+msgid "%d quiz"
+msgid_plural "%d quizzes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: includes/blocks/class-sensei-course-navigation-block.php:163
+#: includes/blocks/class-sensei-course-outline-module-block.php:91
+#: assets/blocks/course-outline/module-block/module-edit.js:174
+#: assets/dist/blocks/single-course.js:6
+msgid "Toggle module content"
+msgstr ""
+
+#: includes/blocks/class-sensei-course-navigation-block.php:207
+#: includes/class-sensei-posttypes.php:771
+#: assets/blocks/lesson-actions/view-quiz-block/index.js:21
+#: assets/blocks/quiz/quiz-block/index.js:19
+#: assets/dist/blocks/quiz/index.js:6
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Quiz"
+msgstr ""
+
 #: includes/blocks/class-sensei-course-outline-course-block.php:54
 msgid "There is no published content in this course yet."
 msgstr ""
 
 #: includes/blocks/class-sensei-course-outline-course-block.php:62
-msgid ""
-"One or more lessons in this course are not published. Unpublished lessons "
-"and empty modules are only displayed in preview mode and will not be "
-"displayed to learners."
+msgid "One or more lessons in this course are not published. Unpublished lessons and empty modules are only displayed in preview mode and will not be displayed to students."
+msgstr ""
+
+#: includes/blocks/class-sensei-course-outline-lesson-block.php:41
+#: includes/class-sensei-frontend.php:1237
+#: includes/class-sensei-lesson.php:210
+#: assets/blocks/course-outline/lesson-block/lesson-edit.js:103
+#: assets/dist/blocks/single-course.js:6
+msgid "Preview"
 msgstr ""
 
 #: includes/blocks/class-sensei-course-outline-lesson-block.php:46
 msgid "(Draft)"
 msgstr ""
 
-#: includes/blocks/class-sensei-course-progress-block.php:85
+#. translators: Placeholder %d is the lesson count.
+#. translators: placeholder is number of lessons in the course.
+#: includes/blocks/class-sensei-course-progress-block.php:84
+#: includes/class-sensei-course.php:1551
+#: includes/class-sensei-course.php:1701
+#: includes/class-sensei-course.php:2319
+#: includes/class-sensei-frontend.php:1059
+#: includes/shortcodes/class-sensei-legacy-shortcodes.php:422
+#: widgets/class-sensei-category-courses-widget.php:231
+#: widgets/class-sensei-course-component-widget.php:317
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-page.js:1
+#: assets/shared/blocks/course-progress/course-progress.js:56
+msgid "%d Lesson"
+msgid_plural "%d Lessons"
+msgstr[0] ""
+msgstr[1] ""
+
 #. translators: Placeholders are the number and percentage of completed lessons.
+#: includes/blocks/class-sensei-course-progress-block.php:87
 msgid "%1$d completed (%2$s)"
+msgstr ""
+
+#: includes/blocks/class-sensei-course-results-block.php:131
+#: assets/blocks/course-results-block/course-results-edit.js:138
+#: assets/dist/blocks/single-page.js:1
+msgid "Your Total Grade"
+msgstr ""
+
+#: includes/blocks/class-sensei-learner-messages-button-block.php:76
+#: includes/class-sensei-admin.php:1640
+#: includes/class-sensei-course.php:1801
+#: includes/class-sensei-messages.php:836
+#: includes/class-sensei-messages.php:927
+#: assets/blocks/learner-messages-button-block/index.js:14
+#: assets/dist/blocks/single-page.js:1
+msgid "My Messages"
 msgstr ""
 
 #: includes/blocks/class-sensei-lesson-blocks.php:84
 msgid "Write lesson content..."
 msgstr ""
 
-#: includes/blocks/class-sensei-lesson-properties-block.php:53
+#: includes/blocks/class-sensei-lesson-properties-block.php:51
+#: assets/blocks/lesson-properties/index.js:21
+#: assets/blocks/lesson-properties/lesson-properties-edit.js:32
+#: assets/blocks/lesson-properties/lesson-properties-edit.js:68
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Length"
+msgstr ""
+
 #. translators: placeholder is lesson length in minutes.
+#: includes/blocks/class-sensei-lesson-properties-block.php:53
 msgid "%d minute"
 msgid_plural "%d minutes"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/blocks/course-theme/class-prev-lesson.php:65
+#: includes/blocks/class-sensei-lesson-properties-block.php:68
+#: assets/blocks/lesson-properties/index.js:23
+#: assets/blocks/lesson-properties/lesson-properties-edit.js:48
+#: assets/blocks/lesson-properties/lesson-properties-edit.js:90
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Difficulty"
+msgstr ""
+
+#: includes/blocks/course-theme/class-complete-lesson.php:83
+msgid "Complete lesson"
+msgstr ""
+
+#. translators: Placeholder %1$d is the completed lessons count, %2$d is the total lessons count and %3$d is the percentage of completed lessons.
+#: includes/blocks/course-theme/class-course-progress-counter.php:49
+msgid "%1$d of %2$d lessons complete (%3$d%%)"
+msgstr ""
+
+#: includes/blocks/course-theme/class-focus-mode.php:47
+msgid "Collapse"
+msgstr ""
+
+#: includes/blocks/course-theme/class-focus-mode.php:48
+msgid "Expand"
+msgstr ""
+
+#: includes/blocks/course-theme/class-next-lesson.php:56
+#: includes/class-sensei-utils.php:1309
+#: assets/blocks/lesson-actions/next-lesson-block/index.js:17
+#: assets/blocks/lesson-actions/next-lesson-block/index.js:31
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Next Lesson"
+msgstr ""
+
+#: includes/blocks/course-theme/class-prev-lesson.php:56
 msgid "Previous Lesson"
 msgstr ""
 
 #: includes/blocks/course-theme/class-quiz-back-to-lesson.php:54
 msgid "Back to lesson"
+msgstr ""
+
+#: includes/blocks/course-theme/class-quiz-button.php:61
+msgid "Take quiz"
 msgstr ""
 
 #: includes/class-sensei-admin.php:111
@@ -3641,14 +1309,12 @@ msgid "Order Courses"
 msgstr ""
 
 #: includes/class-sensei-admin.php:112
-#: includes/class-sensei-admin.php:1392
+#: includes/class-sensei-admin.php:1395
 msgid "Order Lessons"
 msgstr ""
 
 #: includes/class-sensei-admin.php:377
-msgid ""
-"This will duplicate the lesson quiz and all of its questions. Are you sure "
-"you want to do this?"
+msgid "This will duplicate the lesson quiz and all of its questions. Are you sure you want to do this?"
 msgstr ""
 
 #: includes/class-sensei-admin.php:378
@@ -3661,9 +1327,7 @@ msgid "Duplicate"
 msgstr ""
 
 #: includes/class-sensei-admin.php:382
-msgid ""
-"This will duplicate the course lessons along with all of their quizzes and "
-"questions. Are you sure you want to do this?"
+msgid "This will duplicate the course lessons along with all of their quizzes and questions. Are you sure you want to do this?"
 msgstr ""
 
 #: includes/class-sensei-admin.php:383
@@ -3678,8 +1342,8 @@ msgstr ""
 msgid "Duplicate (with lessons)"
 msgstr ""
 
-#: includes/class-sensei-admin.php:463
 #. translators: Placeholder is the post type string.
+#: includes/class-sensei-admin.php:463
 msgid "Please supply a %1$s ID."
 msgstr ""
 
@@ -3688,6 +1352,7 @@ msgid "Invalid post type. Can duplicate only lessons and courses"
 msgstr ""
 
 #: includes/class-sensei-admin.php:489
+#: includes/class-sensei-admin.php:1363
 msgid "Insufficient permissions"
 msgstr ""
 
@@ -3703,75 +1368,71 @@ msgstr ""
 msgid "Save course order"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1400
+#: includes/class-sensei-admin.php:1403
 msgid "The lesson order has been saved."
 msgstr ""
 
-#: includes/class-sensei-admin.php:1418
+#: includes/class-sensei-admin.php:1426
 #: includes/class-sensei-grading-main.php:385
 #: includes/class-sensei-grading.php:508
 #: includes/class-sensei-modules.php:1102
 msgid "Select a course"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1429
+#: includes/class-sensei-admin.php:1437
 #: includes/class-sensei-modules.php:1115
 msgid "Select"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1465
-#: includes/class-sensei-course.php:2957
+#: includes/class-sensei-admin.php:1473
+#: includes/class-sensei-course.php:2989
 #: templates/course-results/lessons.php:122
 msgid "Other Lessons"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1475
+#: includes/class-sensei-admin.php:1483
 msgid "There are no lessons in this course."
 msgstr ""
 
-#: includes/class-sensei-admin.php:1483
+#: includes/class-sensei-admin.php:1491
 msgid "Save lesson order"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1631
+#: includes/class-sensei-admin.php:1639
 msgid "My Profile"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1633
+#: includes/class-sensei-admin.php:1641
 #: includes/class-sensei-frontend.php:384
 #: templates/user/login-form.php:25
 #: templates/user/login-form.php:67
 msgid "Login"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1633
+#: includes/class-sensei-admin.php:1641
 #: includes/class-sensei-frontend.php:382
 msgid "Logout"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1666
+#: includes/class-sensei-admin.php:1674
 msgid "Add to Menu"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1739
+#: includes/class-sensei-admin.php:1747
 msgid "Settings > General"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1740
+#: includes/class-sensei-admin.php:1748
 msgid "add a new Administrator"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1741
+#: includes/class-sensei-admin.php:1749
 msgid "existing Administrator"
 msgstr ""
 
-#: includes/class-sensei-admin.php:1752
 #. translators: The %s placeholders are as follows: - A link to the General Settings page with the translated text "Settings > General". - A link to add an admin user with the translated text "add a new Administrator". - The current admin email address from the Settings. - A link to view the existing admin users, with the translated text "existing Administrator".
-msgid ""
-"To prevent issues with Sensei LMS module names, your Email Address in %1$s "
-"should also belong to an Administrator user. You can either %2$s with the "
-"email address %3$s, or change that email address to match the email of an "
-"%4$s."
+#: includes/class-sensei-admin.php:1760
+msgid "To prevent issues with Sensei LMS module names, your Email Address in %1$s should also belong to an Administrator user. You can either %2$s with the email address %3$s, or change that email address to match the email of an %4$s."
 msgstr ""
 
 #: includes/class-sensei-analysis-course-list-table.php:65
@@ -3779,11 +1440,21 @@ msgstr ""
 msgid "Percent Complete"
 msgstr ""
 
+#: includes/class-sensei-analysis-course-list-table.php:78
+#: includes/class-sensei-analysis-lesson-list-table.php:50
+#: includes/class-sensei-grading-main.php:68
+#: includes/class-sensei-lesson.php:973
+#: includes/class-sensei-lesson.php:982
+#: assets/blocks/quiz/question-block/settings/question-grade-settings.js:28
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Grade"
+msgstr ""
+
 #: includes/class-sensei-analysis-course-list-table.php:85
 #: includes/class-sensei-analysis-overview-list-table.php:49
 #: includes/class-sensei-analysis-overview-list-table.php:60
 #: includes/class-sensei-analysis-overview-list-table.php:688
-msgid "Learners"
+msgid "Students"
 msgstr ""
 
 #: includes/class-sensei-analysis-course-list-table.php:87
@@ -3816,6 +1487,14 @@ msgstr ""
 msgid "Passed"
 msgstr ""
 
+#: includes/class-sensei-analysis-course-list-table.php:385
+#: includes/class-sensei-analysis-lesson-list-table.php:214
+#: includes/class-sensei-grading-main.php:247
+#: assets/data-port/import/done/done-page.js:38
+#: assets/dist/data-port/import.js:1
+msgid "Failed"
+msgstr ""
+
 #: includes/class-sensei-analysis-course-list-table.php:390
 #: includes/class-sensei-analysis-lesson-list-table.php:217
 #: includes/class-sensei-grading-main.php:250
@@ -3830,11 +1509,11 @@ msgid "n/a"
 msgstr ""
 
 #: includes/class-sensei-analysis-course-list-table.php:628
-msgid "Other Learners taking this Course"
+msgid "Other Students taking this Course"
 msgstr ""
 
 #: includes/class-sensei-analysis-course-list-table.php:630
-msgid "Learners taking this Course"
+msgid "Students taking this Course"
 msgstr ""
 
 #: includes/class-sensei-analysis-course-list-table.php:632
@@ -3849,7 +1528,7 @@ msgid "Export all rows (CSV)"
 msgstr ""
 
 #: includes/class-sensei-analysis-lesson-list-table.php:343
-msgid "Learners taking this Lesson"
+msgid "Students taking this Lesson"
 msgstr ""
 
 #: includes/class-sensei-analysis-overview-list-table.php:52
@@ -3864,6 +1543,20 @@ msgstr ""
 msgid "Date Registered"
 msgstr ""
 
+#: includes/class-sensei-analysis-overview-list-table.php:72
+#: includes/class-sensei-course.php:1810
+#: assets/blocks/learner-courses-block/learner-courses-edit.js:103
+#: assets/dist/blocks/single-page.js:1
+msgid "Active Courses"
+msgstr ""
+
+#: includes/class-sensei-analysis-overview-list-table.php:73
+#: includes/class-sensei-course.php:1811
+#: assets/blocks/learner-courses-block/learner-courses-edit.js:107
+#: assets/dist/blocks/single-page.js:1
+msgid "Completed Courses"
+msgstr ""
+
 #: includes/class-sensei-analysis-overview-list-table.php:630
 msgid "Total Courses"
 msgstr ""
@@ -3873,19 +1566,19 @@ msgid "Total Lessons"
 msgstr ""
 
 #: includes/class-sensei-analysis-overview-list-table.php:632
-msgid "Total Learners"
+msgid "Total Students"
 msgstr ""
 
 #: includes/class-sensei-analysis-overview-list-table.php:633
-msgid "Average Courses per Learner"
+msgid "Average Courses per Student"
 msgstr ""
 
 #: includes/class-sensei-analysis-overview-list-table.php:635
 msgid "Total Completed Courses"
 msgstr ""
 
-#: includes/class-sensei-analysis-overview-list-table.php:654
 #. translators: Placeholders %1$s and %3$s are opening and closing <em> tages, %2$s is the view type.
+#: includes/class-sensei-analysis-overview-list-table.php:654
 msgid "%1$sNo %2$s found%3$s"
 msgstr ""
 
@@ -3903,14 +1596,17 @@ msgstr ""
 msgid "Invalid user"
 msgstr ""
 
+#: includes/class-sensei-course-results.php:50
+msgctxt "post type single url slug"
+msgid "course"
+msgstr ""
+
 #: includes/class-sensei-course-results.php:68
 msgid "Course Results: "
 msgstr ""
 
 #: includes/class-sensei-course-structure.php:642
-msgid ""
-"Individual lesson or modules cannot appear multiple times in the same "
-"course."
+msgid "Individual lesson or modules cannot appear multiple times in the same course."
 msgstr ""
 
 #: includes/class-sensei-course-structure.php:649
@@ -3921,8 +1617,8 @@ msgstr ""
 msgid "Each item must be an array."
 msgstr ""
 
-#: includes/class-sensei-course-structure.php:703
 #. translators: Placeholder is ID for module.
+#: includes/class-sensei-course-structure.php:703
 msgid "Module with id \"%d\" was not found"
 msgstr ""
 
@@ -3930,8 +1626,8 @@ msgstr ""
 msgid "Module lessons array can only contain lessons."
 msgstr ""
 
-#: includes/class-sensei-course-structure.php:735
 #. translators: Placeholder is ID for lesson.
+#: includes/class-sensei-course-structure.php:735
 msgid "Lesson with id \"%d\" was not found"
 msgstr ""
 
@@ -3984,27 +1680,25 @@ msgid "Feature this course"
 msgstr ""
 
 #: includes/class-sensei-course.php:436
-#: includes/class-sensei-lesson.php:260
+#: includes/class-sensei-lesson.php:263
 msgid "Video Embed Code"
 msgstr ""
 
 #: includes/class-sensei-course.php:441
-#: includes/class-sensei-lesson.php:265
-msgid ""
-"Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box "
-"above."
+#: includes/class-sensei-lesson.php:268
+msgid "Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above."
 msgstr ""
 
-#: includes/class-sensei-course.php:607
-#: includes/class-sensei-course.php:746
-#: includes/class-sensei-lesson.php:2402
-#: includes/class-sensei-lesson.php:2410
-#: includes/class-sensei-posttypes.php:813
 #. translators: Placeholder is the Lesson title.
 #. translators: Placeholder is the title of the course prerequisite.
 #. translators: Placeholder is the course title.
 #. translators: Placeholder is the title of the prerequisite lesson.
 #. translators: Placeholder is the singular post type label.
+#: includes/class-sensei-course.php:607
+#: includes/class-sensei-course.php:746
+#: includes/class-sensei-lesson.php:2485
+#: includes/class-sensei-lesson.php:2493
+#: includes/class-sensei-posttypes.php:813
 msgid "Edit %s"
 msgstr ""
 
@@ -4028,20 +1722,35 @@ msgstr ""
 msgid "+ Add Another Lesson"
 msgstr ""
 
+#: includes/class-sensei-course.php:679
+msgid "Manage Learners"
+msgstr ""
+
 #: includes/class-sensei-course.php:680
 msgid "Manage Grading"
 msgstr ""
 
+#: includes/class-sensei-course.php:695
+msgctxt "column name"
+msgid "Course Title"
+msgstr ""
+
+#: includes/class-sensei-course.php:696
+msgctxt "column name"
+msgid "Pre-requisite Course"
+msgstr ""
+
+#: includes/class-sensei-course.php:697
+msgctxt "column name"
+msgid "Category"
+msgstr ""
+
 #: includes/class-sensei-course.php:880
-msgid ""
-"Querying with argument `$type` having a value of `freecourses` is "
-"deprecated."
+msgid "Querying with argument `$type` having a value of `freecourses` is deprecated."
 msgstr ""
 
 #: includes/class-sensei-course.php:904
-msgid ""
-"Querying with argument `$type` having a value of `paidcourses` is "
-"deprecated."
+msgid "Querying with argument `$type` having a value of `paidcourses` is deprecated."
 msgstr ""
 
 #: includes/class-sensei-course.php:1530
@@ -4049,37 +1758,57 @@ msgstr ""
 msgid "by "
 msgstr ""
 
+#. translators: Placeholder is a comma-separated list of the Course categories.
 #: includes/class-sensei-course.php:1558
 #: includes/class-sensei-course.php:1708
-#: includes/class-sensei-course.php:2293
+#: includes/class-sensei-course.php:2325
 #: includes/class-sensei-frontend.php:1068
 #: includes/shortcodes/class-sensei-legacy-shortcodes.php:430
-#. translators: Placeholder is a comma-separated list of the Course categories.
 msgid "in %s"
 msgstr ""
 
-#: includes/class-sensei-course.php:1564
-#: includes/class-sensei-course.php:2304
 #. translators: Placeholders are the counts for lessons completed and total lessons, respectively.
+#: includes/class-sensei-course.php:1564
+#: includes/class-sensei-course.php:2336
 msgid "%1$d of %2$d lessons completed"
 msgstr ""
 
 #: includes/class-sensei-course.php:1591
-#: includes/class-sensei-course.php:2432
+#: includes/class-sensei-course.php:2464
 #: includes/class-sensei-frontend.php:813
 msgid "Mark as Complete"
 msgstr ""
 
 #: includes/class-sensei-course.php:1623
-#: includes/class-sensei-course.php:2442
+#: includes/class-sensei-course.php:2474
 #: includes/class-sensei-frontend.php:855
 msgid "Delete Course"
 msgstr ""
 
 #: includes/class-sensei-course.php:1648
 #: includes/class-sensei-course.php:1760
-#: includes/class-sensei-lesson.php:1418
+#: includes/class-sensei-lesson.php:1493
 msgid "Previous"
+msgstr ""
+
+#: includes/class-sensei-course.php:1663
+#: includes/class-sensei-course.php:1775
+#: includes/class-sensei-lesson.php:1493
+#: assets/blocks/lesson-actions/lesson-actions-block/index.js:25
+#: assets/blocks/lesson-actions/next-lesson-block/index.js:24
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Next"
+msgstr ""
+
+#: includes/class-sensei-course.php:1729
+#: includes/class-sensei-course.php:2483
+#: includes/class-sensei-course.php:3187
+#: assets/blocks/learner-courses-block/learner-courses-edit.js:179
+#: assets/blocks/view-results-block/index.js:22
+#: assets/blocks/view-results-block/index.js:25
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-page.js:1
+msgid "View Results"
 msgstr ""
 
 #: includes/class-sensei-course.php:1783
@@ -4094,11 +1823,11 @@ msgid "You have not completed any courses yet."
 msgstr ""
 
 #: includes/class-sensei-course.php:1786
-msgid "This learner has no active courses."
+msgid "This student has no active courses."
 msgstr ""
 
 #: includes/class-sensei-course.php:1787
-msgid "This learner has not completed any courses yet."
+msgid "This student has not completed any courses yet."
 msgstr ""
 
 #: includes/class-sensei-course.php:1800
@@ -4112,124 +1841,129 @@ msgstr ""
 msgid "Start a Course!"
 msgstr ""
 
-#: includes/class-sensei-course.php:1996
 #. translators: Placeholders are the counts for lessons completed and total lessons, respectively.
+#: includes/class-sensei-course.php:1996
 msgid "Currently completed %1$s lesson of %2$s in total"
 msgid_plural "Currently completed %1$s lessons of %2$s in total"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/class-sensei-course.php:2187
+#: includes/class-sensei-course.php:2219
 msgid "Disable notifications on this course?"
 msgstr ""
 
-#: includes/class-sensei-course.php:2235
+#: includes/class-sensei-course.php:2267
 #: includes/class-sensei-frontend.php:1090
 #: includes/shortcodes/class-sensei-legacy-shortcodes.php:452
 msgid "Preview this course"
 msgstr ""
 
-#: includes/class-sensei-course.php:2240
-#: includes/shortcodes/class-sensei-legacy-shortcodes.php:449
 #. translators: Placeholder is the number of preview lessons.
+#: includes/class-sensei-course.php:2272
+#: includes/shortcodes/class-sensei-legacy-shortcodes.php:449
 msgid "(%d preview lessons)"
 msgstr ""
 
-#: includes/class-sensei-course.php:2265
 #. translators: %1$s is the author posts URL, %2$s and %3$s are the author name.
+#: includes/class-sensei-course.php:2297
 msgid "by <a href=\"%1$s\" title=\"%2$s\">%3$s</a>"
 msgstr ""
 
-#: includes/class-sensei-course.php:2639
+#: includes/class-sensei-course.php:2671
 msgid "Sort by newest first"
 msgstr ""
 
-#: includes/class-sensei-course.php:2640
+#: includes/class-sensei-course.php:2672
 msgid "Sort by title A-Z"
 msgstr ""
 
-#: includes/class-sensei-course.php:2703
+#: includes/class-sensei-course.php:2735
 msgid "Featured"
 msgstr ""
 
-#: includes/class-sensei-course.php:2876
 #. translators: Placeholders are the taxonomy name and the term name, respectively.
+#: includes/class-sensei-course.php:2908
 msgid "%1$s Archives: %2$s"
 msgstr ""
 
-#: includes/class-sensei-course.php:2884
+#: includes/class-sensei-course.php:2916
 #: includes/shortcodes/class-sensei-legacy-shortcodes.php:160
 #: widgets/class-sensei-course-component-widget.php:48
 msgid "New Courses"
 msgstr ""
 
-#: includes/class-sensei-course.php:2887
+#: includes/class-sensei-course.php:2919
 #: includes/shortcodes/class-sensei-legacy-shortcodes.php:132
 #: widgets/class-sensei-course-component-widget.php:49
 msgid "Featured Courses"
 msgstr ""
 
-#: includes/class-sensei-course.php:2890
+#: includes/class-sensei-course.php:2922
 #: includes/shortcodes/class-sensei-legacy-shortcodes.php:146
 msgid "Free Courses"
 msgstr ""
 
-#: includes/class-sensei-course.php:2893
+#: includes/class-sensei-course.php:2925
 #: includes/shortcodes/class-sensei-legacy-shortcodes.php:117
 msgid "Paid Courses"
 msgstr ""
 
-#: includes/class-sensei-course.php:3258
 #. translators: Placeholders are an opening and closing <a> tag linking to the login URL.
+#: includes/class-sensei-course.php:3290
 msgid "or %1$slog in%2$s to view this course."
 msgstr ""
 
-#: includes/class-sensei-course.php:3299
+#: includes/class-sensei-course.php:3331
 #: includes/class-sensei-frontend.php:1161
 #: includes/class-sensei-frontend.php:1191
 #: includes/class-sensei-templates.php:457
 msgid "Register"
 msgstr ""
 
-#: includes/class-sensei-course.php:3392
+#: includes/class-sensei-course.php:3424
 #: widgets/class-sensei-category-courses-widget.php:145
 msgid "Course Category:"
 msgstr ""
 
-#: includes/class-sensei-course.php:3596
-#: includes/class-sensei-lesson.php:4371
 #. translators: Placeholder $1$s is the course title.
 #. translators: Placeholder is the lesson prerequisite title.
+#: includes/class-sensei-course.php:3628
+#: includes/class-sensei-lesson.php:4497
 msgid "You must first complete: %1$s"
 msgstr ""
 
-#: includes/class-sensei-course.php:3603
 #. translators: Placeholder $1$s is the course title.
+#: includes/class-sensei-course.php:3635
 msgid "You must first complete %1$s before taking this course."
 msgstr ""
 
-#: includes/class-sensei-dependency-checker.php:45
+#: includes/class-sensei-customizer.php:63
+#: assets/dist/js/admin/course-edit.js:1
+#: assets/js/admin/course-theme-sidebar.js:37
+msgid "Course Theme"
+msgstr ""
+
+#: includes/class-sensei-customizer.php:82
+msgid "Primary Color"
+msgstr ""
+
 #. translators: %1$s is version of PHP that Sensei requires; %2$s is the version of PHP WordPress is running on.
-msgid ""
-"<strong>Sensei LMS</strong> requires a minimum PHP version of %1$s, but you "
-"are running %2$s."
+#: includes/class-sensei-dependency-checker.php:45
+msgid "<strong>Sensei LMS</strong> requires a minimum PHP version of %1$s, but you are running %2$s."
 msgstr ""
 
 #: includes/class-sensei-dependency-checker.php:58
 msgid "Learn more about updating PHP"
 msgstr ""
 
-#: includes/class-sensei-dependency-checker.php:60
 #. translators: accessibility text
+#: includes/class-sensei-dependency-checker.php:60
 msgid "(opens in a new tab)"
 msgstr ""
 
-#: includes/class-sensei-dependency-checker.php:89
 #. translators: 1: is a link to a support document. 2: closing link
-msgid ""
-"Your installation of Sensei LMS is incomplete. If you installed Sensei LMS "
-"from GitHub, %1$splease refer to this document%2$s to set up your "
-"development environment."
+#: includes/class-sensei-dependency-checker.php:89
+msgid "Your installation of Sensei LMS is incomplete. If you installed Sensei LMS from GitHub, %1$splease refer to this document%2$s to set up your development environment."
 msgstr ""
 
 #: includes/class-sensei-frontend.php:597
@@ -4245,13 +1979,13 @@ msgstr ""
 msgid "Back to the lesson"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:648
 #. translators: Placeholder is a comma-separated list of links to the tags.
+#: includes/class-sensei-frontend.php:648
 msgid "Lesson tags: %1$s"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:683
 #. translators: Placeholder is the filtered tag name.
+#: includes/class-sensei-frontend.php:683
 msgid "Lesson tag: %1$s"
 msgstr ""
 
@@ -4260,14 +1994,29 @@ msgstr ""
 msgid "Lesson Reset Successfully."
 msgstr ""
 
-#: includes/class-sensei-frontend.php:843
 #. translators: Placeholder is the Course title.
+#: includes/class-sensei-frontend.php:843
 msgid "%1$s marked as complete."
 msgstr ""
 
-#: includes/class-sensei-frontend.php:866
 #. translators: Placeholder is the Course title.
+#: includes/class-sensei-frontend.php:866
 msgid "%1$s deleted."
+msgstr ""
+
+#: includes/class-sensei-frontend.php:976
+#: assets/blocks/lesson-actions/complete-lesson-block/index.js:18
+#: assets/blocks/lesson-actions/complete-lesson-block/index.js:31
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Complete Lesson"
+msgstr ""
+
+#: includes/class-sensei-frontend.php:1010
+#: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js:54
+#: assets/blocks/lesson-actions/reset-lesson-block/index.js:17
+#: assets/blocks/lesson-actions/reset-lesson-block/index.js:33
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Reset Lesson"
 msgstr ""
 
 #: includes/class-sensei-frontend.php:1052
@@ -4279,8 +2028,8 @@ msgstr ""
 msgid "by"
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1088
 #. translators: Placeholder is the number of free lessons in the course.
+#: includes/class-sensei-frontend.php:1088
 msgid "You can access %d of this course's lessons for free"
 msgstr ""
 
@@ -4306,15 +2055,15 @@ msgstr ""
 msgid "Anti-spam"
 msgstr ""
 
+#. translators: Placeholder is a link to the Course permalink.
 #: includes/class-sensei-frontend.php:1222
 #: widgets/class-sensei-lesson-component-widget.php:222
-#. translators: Placeholder is a link to the Course permalink.
 msgid "Part of: %s"
 msgstr ""
 
+#. translators: Placeholder is a link to the Course permalink.
 #: includes/class-sensei-frontend.php:1223
 #: widgets/class-sensei-lesson-component-widget.php:223
-#. translators: Placeholder is a link to the Course permalink.
 msgid "View course"
 msgstr ""
 
@@ -4323,15 +2072,11 @@ msgid "<strong>ERROR</strong>: Please enter a username."
 msgstr ""
 
 #: includes/class-sensei-frontend.php:1633
-msgid ""
-"<strong>ERROR</strong>: This username is invalid because it uses illegal "
-"characters. Please enter a valid username."
+msgid "<strong>ERROR</strong>: This username is invalid because it uses illegal characters. Please enter a valid username."
 msgstr ""
 
 #: includes/class-sensei-frontend.php:1635
-msgid ""
-"<strong>ERROR</strong>: This username is already registered. Please choose "
-"another one."
+msgid "<strong>ERROR</strong>: This username is already registered. Please choose another one."
 msgstr ""
 
 #: includes/class-sensei-frontend.php:1647
@@ -4343,20 +2088,16 @@ msgid "<strong>ERROR</strong>: The email address isn&#8217;t correct."
 msgstr ""
 
 #: includes/class-sensei-frontend.php:1651
-msgid ""
-"<strong>ERROR</strong>: This email is already registered, please choose "
-"another one."
+msgid "<strong>ERROR</strong>: This email is already registered, please choose another one."
 msgstr ""
 
 #: includes/class-sensei-frontend.php:1663
 msgid "<strong>ERROR</strong>: The password field is empty."
 msgstr ""
 
-#: includes/class-sensei-frontend.php:1671
 #. translators: Placeholder is the admin email address.
-msgid ""
-"<strong>ERROR</strong>: Couldn&#8217;t register you&hellip; please contact "
-"the <a href=\"mailto:%s\">webmaster</a> !"
+#: includes/class-sensei-frontend.php:1671
+msgid "<strong>ERROR</strong>: Couldn&#8217;t register you&hellip; please contact the <a href=\"mailto:%s\">webmaster</a> !"
 msgstr ""
 
 #: includes/class-sensei-frontend.php:1707
@@ -4394,8 +2135,8 @@ msgstr ""
 
 #: includes/class-sensei-grading-user-quiz.php:107
 #: includes/class-sensei-grading-user-quiz.php:347
-#: includes/class-sensei-lesson.php:1175
-#: includes/class-sensei-lesson.php:1317
+#: includes/class-sensei-lesson.php:1250
+#: includes/class-sensei-lesson.php:1392
 msgid "Grade:"
 msgstr ""
 
@@ -4409,19 +2150,85 @@ msgstr ""
 msgid "Auto grade"
 msgstr ""
 
+#: includes/class-sensei-grading-user-quiz.php:113
+#: includes/class-sensei-grading-user-quiz.php:353
+#: assets/blocks/editor-components/number-control/index.js:77
+#: assets/blocks/lesson-actions/lesson-actions-block/index.js:26
+#: assets/blocks/lesson-actions/reset-lesson-block/index.js:24
+#: assets/dist/blocks/quiz/index.js:6
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Reset"
+msgstr ""
+
+#: includes/class-sensei-grading-user-quiz.php:152
+#: includes/class-sensei-grading-user-quiz.php:163
+#: includes/class-sensei-lesson.php:1194
+#: includes/class-sensei-question.php:47
+#: assets/blocks/quiz/answer-blocks/index.js:39
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Multiple Choice"
+msgstr ""
+
+#: includes/class-sensei-grading-user-quiz.php:157
+#: includes/class-sensei-lesson.php:1194
+#: includes/class-sensei-question.php:48
+#: assets/blocks/quiz/answer-blocks/index.js:68
+#: assets/dist/blocks/quiz/index.js:6
+msgid "True/False"
+msgstr ""
+
+#: includes/class-sensei-grading-user-quiz.php:167
+#: includes/class-sensei-lesson.php:1194
+#: includes/class-sensei-question.php:49
+#: assets/blocks/quiz/answer-blocks/index.js:79
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Gap Fill"
+msgstr ""
+
+#: includes/class-sensei-grading-user-quiz.php:193
+#: includes/class-sensei-lesson.php:1194
+#: includes/class-sensei-question.php:51
+#: assets/blocks/quiz/answer-blocks/index.js:109
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Multi Line"
+msgstr ""
+
+#: includes/class-sensei-grading-user-quiz.php:197
+#: includes/class-sensei-lesson.php:1194
+#: includes/class-sensei-question.php:50
+#: assets/blocks/quiz/answer-blocks/index.js:99
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Single Line"
+msgstr ""
+
+#: includes/class-sensei-grading-user-quiz.php:201
+#: includes/class-sensei-lesson.php:1194
+#: includes/class-sensei-question.php:52
+#: assets/blocks/quiz/answer-blocks/index.js:119
+#: assets/dist/blocks/quiz/index.js:6
+msgid "File Upload"
+msgstr ""
+
+#. translators: Placeholder %1$s is a link to the submitted file.
 #: includes/class-sensei-grading-user-quiz.php:214
 #: templates/single-quiz/question-type-file-upload.php:41
-#. translators: Placeholder %1$s is a link to the submitted file.
 msgid "Submitted file: %1$s"
 msgstr ""
 
-#: includes/class-sensei-grading-user-quiz.php:237
 #. translators: Placeholder is the question number.
+#: includes/class-sensei-grading-user-quiz.php:237
 msgid "Question %d: "
 msgstr ""
 
 #: includes/class-sensei-grading-user-quiz.php:307
 msgid "Correct answer"
+msgstr ""
+
+#: includes/class-sensei-grading-user-quiz.php:323
+#: includes/class-sensei-lesson.php:1994
+#: assets/blocks/quiz/answer-feedback-block/answer-feedback-toggle.js:37
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Answer Feedback"
 msgstr ""
 
 #: includes/class-sensei-grading-user-quiz.php:326
@@ -4443,434 +2250,544 @@ msgstr ""
 
 #: includes/class-sensei-learner-profiles.php:28
 #: includes/class-sensei-settings.php:508
-msgid "learner"
+msgid "student"
 msgstr ""
 
-#: includes/class-sensei-learner-profiles.php:96
-#: includes/class-sensei-learner-profiles.php:172
 #. translators: Placeholder is the full name of the learner.
 #. translators: Placeholder is the first name or the display name of the user.
+#: includes/class-sensei-learner-profiles.php:96
+#: includes/class-sensei-learner-profiles.php:172
 msgid "Courses %s is taking"
 msgstr ""
 
 #: includes/class-sensei-learner.php:379
-msgid "Learner term could not be created for user."
+msgid "Student term could not be created for user."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:58
 #. translators: %1$s is a link to the quiz documentation, %2$s is a link to a support article about the WordPress editor.
-msgid ""
-"*Note that this functionality has been moved to the <a href=\"%1$s\">quiz "
-"block</a> and will not be supported going forward. Please consider "
-"switching to the <a href=\"%2$s\">block editor</a>.</em>"
+#: includes/class-sensei-lesson.php:58
+msgid "*Note that this functionality has been moved to the <a href=\"%1$s\">quiz block</a> and will not be supported going forward. Please consider switching to the <a href=\"%2$s\">block editor</a>.</em>"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:204
+#: includes/class-sensei-lesson.php:207
 msgid "Prerequisite"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:214
-msgid "Quiz Settings*"
+#: includes/class-sensei-lesson.php:213
+#: includes/class-sensei-lesson.php:3825
+#: assets/blocks/lesson-properties/index.js:24
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Lesson Information"
 msgstr ""
 
 #: includes/class-sensei-lesson.php:217
+msgid "Quiz Settings*"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:220
 msgid "Quiz Questions*"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:249
+#: includes/class-sensei-lesson.php:252
 msgid "Lesson Length in minutes"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:252
-#: includes/class-sensei-lesson.php:3745
+#: includes/class-sensei-lesson.php:255
+#: includes/class-sensei-lesson.php:3871
 msgid "Lesson Complexity"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:337
+#: includes/class-sensei-lesson.php:352
 msgid "No lessons exist yet. Please add some first."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:385
+#: includes/class-sensei-lesson.php:460
 msgid "Allow this lesson to be viewed without login"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:841
+#: includes/class-sensei-lesson.php:916
 msgid "Once you have saved your lesson you will be able to add questions."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:879
+#: includes/class-sensei-lesson.php:954
 msgid "Please save your lesson in order to add questions to your quiz."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:900
-#: includes/class-sensei-lesson.php:909
+#: includes/class-sensei-lesson.php:972
+#: includes/class-sensei-lesson.php:981
+#: includes/class-sensei-lesson.php:1459
+#: includes/class-sensei-lesson.php:1467
+#: includes/class-sensei-posttypes.php:776
+#: includes/class-sensei-question.php:143
+#: assets/blocks/quiz/question-block/index.js:20
+#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:146
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Question"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:974
+#: includes/class-sensei-lesson.php:983
+#: includes/class-sensei-lesson.php:1460
+#: includes/class-sensei-lesson.php:1468
+#: assets/blocks/quiz/quiz-block/questions-modal/filter.js:45
+#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:147
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Type"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:975
+#: includes/class-sensei-lesson.php:984
 msgid "Action"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:919
+#: includes/class-sensei-lesson.php:994
 msgid "There are no Questions for this Quiz yet. Please add some below."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1069
-#: includes/class-sensei-lesson.php:1328
-#: includes/class-sensei-lesson.php:2253
+#: includes/class-sensei-lesson.php:1144
+#: includes/class-sensei-lesson.php:1403
+#: includes/class-sensei-lesson.php:2336
 msgid "Add file"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1096
-#: includes/class-sensei-lesson.php:2254
+#: includes/class-sensei-lesson.php:1171
+#: includes/class-sensei-lesson.php:2337
 msgid "Change file"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1123
+#: includes/class-sensei-lesson.php:1198
 msgid "Edit Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1123
+#: includes/class-sensei-lesson.php:1198
 msgid "Edit"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1123
-#: includes/class-sensei-lesson.php:1125
+#: includes/class-sensei-lesson.php:1198
+#: includes/class-sensei-lesson.php:1200
 msgid "Remove Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1123
-#: includes/class-sensei-lesson.php:1125
-#: includes/class-sensei-lesson.php:1142
+#: includes/class-sensei-lesson.php:1198
+#: includes/class-sensei-lesson.php:1200
+#: includes/class-sensei-lesson.php:1217
 msgid "Remove"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1125
+#: includes/class-sensei-lesson.php:1200
 msgid "You are not the question owner, so you cannot edit it."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1136
 #. translators: Placeholder is the question category name.
+#: includes/class-sensei-lesson.php:1211
 msgid "Selected from '%1$s' "
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1142
+#: includes/class-sensei-lesson.php:1217
 msgid "Remove Question(s)"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1163
-#: includes/class-sensei-lesson.php:1286
+#: includes/class-sensei-lesson.php:1238
+#: includes/class-sensei-lesson.php:1361
 msgid "Question:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1169
-#: includes/class-sensei-lesson.php:1291
+#: includes/class-sensei-lesson.php:1244
+#: includes/class-sensei-lesson.php:1366
 msgid "Description:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1188
-#: includes/class-sensei-lesson.php:1327
+#: includes/class-sensei-lesson.php:1257
+#: includes/class-sensei-lesson.php:1397
+#: assets/blocks/quiz/question-block/settings/question-multiple-choice-settings.js:20
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Random Order"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:1263
+#: includes/class-sensei-lesson.php:1402
 msgid "Media:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1189
-#: includes/class-sensei-lesson.php:1328
+#: includes/class-sensei-lesson.php:1264
+#: includes/class-sensei-lesson.php:1403
 msgid "Add file to question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1189
-#: includes/class-sensei-lesson.php:1328
+#: includes/class-sensei-lesson.php:1264
+#: includes/class-sensei-lesson.php:1403
 msgid "Add to question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1190
-#: includes/class-sensei-lesson.php:1329
+#: includes/class-sensei-lesson.php:1265
+#: includes/class-sensei-lesson.php:1404
 msgid "Delete file"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1206
+#: includes/class-sensei-lesson.php:1280
+#: assets/data-port/export/export-progress-page.js:57
+#: assets/dist/data-port/export.js:1
+msgid "Cancel"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:1281
 msgid "Update Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1268
+#: includes/class-sensei-lesson.php:1281
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/extension-actions.js:75
+msgid "Update"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:1342
+#: assets/blocks/quiz/quiz-block/quiz-appender.js:39
+#: assets/dist/blocks/quiz/index.js:6
+msgid "New Question"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:1343
 msgid "Existing Questions"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1270
+#: includes/class-sensei-lesson.php:1345
 msgid "Category Questions"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1279
 #. translators: Placeholders are an opening and closing <a> tag linking to the question bank.
-msgid ""
-"Add a new question to this quiz - your question will also be added to the "
-"%1$squestion bank%2$s."
+#: includes/class-sensei-lesson.php:1354
+msgid "Add a new question to this quiz - your question will also be added to the %1$squestion bank%2$s."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1296
+#: includes/class-sensei-lesson.php:1371
 msgid "Question Type:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1306
+#: includes/class-sensei-lesson.php:1381
 msgid "Question Category:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1344
+#: includes/class-sensei-lesson.php:1419
 msgid "Add Question"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1355
 #. translators: Placeholders are an opening and closing <a> tag linking to the question bank.
+#: includes/class-sensei-lesson.php:1430
 msgid "Add an existing question to this quiz from the %1$squestion bank%2$s."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1360
+#: includes/class-sensei-lesson.php:1435
 msgid "Unused"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1361
+#: includes/class-sensei-lesson.php:1436
 msgid "Used"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1364
+#: includes/class-sensei-lesson.php:1439
 msgid "All Types"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1370
+#: includes/class-sensei-lesson.php:1445
 msgid "All Categories"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1375
+#: includes/class-sensei-lesson.php:1450
 msgid "Search"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1422
+#: includes/class-sensei-lesson.php:1461
+#: includes/class-sensei-lesson.php:1469
+#: assets/blocks/learner-courses-block/learner-courses-settings.js:40
+#: assets/blocks/quiz/category-question-block/category-question-settings.js:112
+#: assets/blocks/quiz/quiz-block/questions-modal/filter.js:56
+#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:148
+#: assets/dist/blocks/quiz/index.js:6
+#: assets/dist/blocks/single-page.js:1
+msgid "Category"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:1497
 msgid "Add Selected Question(s)"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1431
 #. translators: Placeholders are an opening and closing <a> tag linking to the question categories page.
-msgid ""
-"Add any number of questions from a specified category. Edit your question "
-"categories %1$shere%2$s."
+#: includes/class-sensei-lesson.php:1506
+msgid "Add any number of questions from a specified category. Edit your question categories %1$shere%2$s."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1434
+#: includes/class-sensei-lesson.php:1509
 msgid "Select a Question Category"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1440
+#: includes/class-sensei-lesson.php:1515
 msgid "Number of questions:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1442
+#: includes/class-sensei-lesson.php:1517
 msgid "Add Question(s)"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1655
+#: includes/class-sensei-lesson.php:1730
 msgid "There are no questions matching your search."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1710
-#: includes/class-sensei-lesson.php:2251
+#: includes/class-sensei-lesson.php:1785
+#: includes/class-sensei-lesson.php:2334
 msgid "Right:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1732
-#: includes/class-sensei-lesson.php:2252
+#: includes/class-sensei-lesson.php:1807
+#: includes/class-sensei-lesson.php:2335
 msgid "Wrong:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1760
+#: includes/class-sensei-lesson.php:1835
 msgid "Add right answer"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1761
+#: includes/class-sensei-lesson.php:1836
 msgid "Add wrong answer"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1799
+#: includes/class-sensei-lesson.php:1851
+#: includes/class-sensei-question.php:1374
+#: templates/single-quiz/question-type-boolean.php:85
+#: assets/blocks/quiz/answer-blocks/true-false.js:27
+#: assets/blocks/quiz/answer-blocks/true-false.js:73
+#: assets/dist/blocks/quiz/index.js:6
+msgid "True"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:1852
+#: includes/class-sensei-question.php:1376
+#: templates/single-quiz/question-type-boolean.php:89
+#: assets/blocks/quiz/answer-blocks/true-false.js:28
+#: assets/blocks/quiz/answer-blocks/true-false.js:74
+#: assets/dist/blocks/quiz/index.js:6
+msgid "False"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:1874
 msgid "Text before the gap:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1801
+#: includes/class-sensei-lesson.php:1876
 msgid "Gap:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1803
+#: includes/class-sensei-lesson.php:1878
 msgid "Text after the gap:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1805
+#: includes/class-sensei-lesson.php:1880
 msgid "Preview:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1817
-#: includes/class-sensei-lesson.php:1830
-#: includes/class-sensei-lesson.php:1854
+#: includes/class-sensei-lesson.php:1892
+#: includes/class-sensei-lesson.php:1905
+#: includes/class-sensei-lesson.php:1929
 msgid "Grading Notes:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1849
+#: includes/class-sensei-lesson.php:1894
+#: includes/class-sensei-lesson.php:1907
+#: includes/class-sensei-lesson.php:1931
+#: assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js:23
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Displayed to the teacher when grading the question."
+msgstr ""
+
+#: includes/class-sensei-lesson.php:1924
 msgid "Upload notes:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1851
-msgid "Displayed to the learner to describe what to upload."
+#: includes/class-sensei-lesson.php:1926
+msgid "Displayed to the student to describe what to upload."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:1918
-msgid ""
-"This feedback will be automatically displayed to the student once they have "
-"completed the quiz."
+#: includes/class-sensei-lesson.php:1993
+msgid "This feedback will be automatically displayed to the student once they have completed the quiz."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2036
-msgid ""
-"There is no quiz for this lesson yet - please add one in the 'Quiz "
-"Questions' box."
+#: includes/class-sensei-lesson.php:2111
+msgid "There is no quiz for this lesson yet - please add one in the 'Quiz Questions' box."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2127
+#: includes/class-sensei-lesson.php:2202
 msgid "Pass required to complete lesson"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2128
+#: includes/class-sensei-lesson.php:2203
 msgid "The passmark must be achieved before the lesson is complete."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2135
+#: includes/class-sensei-lesson.php:2210
 msgid "Quiz passmark percentage"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2146
+#: includes/class-sensei-lesson.php:2221
 msgid "Number of questions to show"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2147
-msgid ""
-"Show a random selection of questions from this quiz each time a student "
-"views it."
+#: includes/class-sensei-lesson.php:2222
+msgid "Show a random selection of questions from this quiz each time a student views it."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2156
+#: includes/class-sensei-lesson.php:2231
 msgid "Randomise question order"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2164
+#: includes/class-sensei-lesson.php:2239
 msgid "Grade quiz automatically"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2165
-msgid ""
-"Grades quiz and displays answer explanation immediately after completion. "
-"Only applicable if quiz is limited to Multiple Choice, True/False and Gap "
-"Fill questions. Questions that have a grade of zero are skipped during "
-"autograding."
+#: includes/class-sensei-lesson.php:2240
+msgid "Grades quiz and displays answer explanation immediately after completion. Only applicable if quiz is limited to Multiple Choice, True/False and Gap Fill questions. Questions that have a grade of zero are skipped during autograding."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2172
+#: includes/class-sensei-lesson.php:2247
 msgid "Allow user to retake the quiz"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2173
+#: includes/class-sensei-lesson.php:2248
 msgid "Enables the quiz reset button."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2255
+#: includes/class-sensei-lesson.php:2338
 msgid "Are you sure you want to remove this question?"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2256
+#: includes/class-sensei-lesson.php:2339
 msgid "Are you sure you want to remove these questions?"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2257
-msgid ""
-"You have selected more questions than this category contains - please "
-"reduce the number of questions that you are adding."
+#: includes/class-sensei-lesson.php:2340
+msgid "You have selected more questions than this category contains - please reduce the number of questions that you are adding."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2588
-#: includes/rest-api/class-sensei-rest-api-question-helpers-trait.php:109
+#: includes/class-sensei-lesson.php:2440
+msgctxt "column name"
+msgid "Lesson Title"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:2441
+msgctxt "column name"
+msgid "Course"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:2442
+msgctxt "column name"
+msgid "Pre-requisite Lesson"
+msgstr ""
+
 #. translators: Placeholders are the question number and the question category name.
+#: includes/class-sensei-lesson.php:2671
+#: includes/rest-api/class-sensei-rest-api-question-helpers-trait.php:109
 msgid "%1$s Question(s) from %2$s"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3707
+#: includes/class-sensei-lesson.php:3278
+#: assets/blocks/lesson-properties/constants.js:13
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Easy"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:3279
+#: assets/blocks/lesson-properties/constants.js:17
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Standard"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:3280
+#: assets/blocks/lesson-properties/constants.js:21
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Hard"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:3833
 msgid "No Change"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3729
+#: includes/class-sensei-lesson.php:3855
 msgid "Lesson Course"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3758
-#: includes/class-sensei-lesson.php:3785
+#: includes/class-sensei-lesson.php:3875
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Quiz Settings"
+msgstr ""
+
+#: includes/class-sensei-lesson.php:3884
+#: includes/class-sensei-lesson.php:3911
 msgid "No"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3759
-#: includes/class-sensei-lesson.php:3786
+#: includes/class-sensei-lesson.php:3885
+#: includes/class-sensei-lesson.php:3912
 msgid "Yes"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3770
+#: includes/class-sensei-lesson.php:3896
 msgid "Pass required"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3778
+#: includes/class-sensei-lesson.php:3904
 msgid "Pass Percentage"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:3797
+#: includes/class-sensei-lesson.php:3923
 msgid "Enable quiz reset button"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4042
+#. translators: Placeholder is the lesson title.
+#: includes/class-sensei-lesson.php:4168
 #: templates/course-results/lessons.php:91
 #: templates/course-results/lessons.php:148
-#. translators: Placeholder is the lesson title.
 msgid "Start %s"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4065
+#: includes/class-sensei-lesson.php:4191
 msgid "Length:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4065
+#: includes/class-sensei-lesson.php:4191
 msgid "minutes"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4071
+#: includes/class-sensei-lesson.php:4197
 msgid "Author:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4076
+#: includes/class-sensei-lesson.php:4202
 msgid "Complexity:"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4320
+#. translators: Placeholders are an opening and closing <a> tag linking to the course permalink.
+#: includes/class-sensei-lesson.php:4446
 #: includes/class-sensei-modules.php:858
 #: includes/class-sensei-utils.php:1269
 #: includes/class-sensei-utils.php:1358
-#. translators: Placeholders are an opening and closing <a> tag linking to the course permalink.
 msgid "Sign Up"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4325
-#: includes/class-sensei.php:878
 #. translators: The placeholder %1$s is a link to the Course.
+#: includes/class-sensei-lesson.php:4451
+#: includes/class-sensei.php:879
 msgid "Please sign up for the %1$s before starting the lesson."
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4376
 #. translators: Placeholder is the link to the prerequisite lesson.
+#: includes/class-sensei-lesson.php:4502
 msgid "You must first complete %1$s before viewing this Lesson"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4396
+#: includes/class-sensei-lesson.php:4522
 msgid "Lessons Archive"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:4505
-#: includes/class-sensei-lesson.php:4507
+#: includes/class-sensei-lesson.php:4631
+#: includes/class-sensei-lesson.php:4633
 msgid "View the Lesson Quiz"
 msgstr ""
 
@@ -4901,7 +2818,7 @@ msgid "Message sent by:"
 msgstr ""
 
 #: includes/class-sensei-messages.php:136
-msgid "The username of the learner who sent this message."
+msgid "The username of the student who sent this message."
 msgstr ""
 
 #: includes/class-sensei-messages.php:142
@@ -4944,6 +2861,13 @@ msgstr ""
 msgid "Contact Course Teacher"
 msgstr ""
 
+#: includes/class-sensei-messages.php:253
+#: assets/blocks/contact-teacher-block/index.js:22
+#: assets/blocks/contact-teacher-block/index.js:25
+#: assets/dist/blocks/shared.js:1
+msgid "Contact Teacher"
+msgstr ""
+
 #: includes/class-sensei-messages.php:513
 msgid "You need a higher level of permission."
 msgstr ""
@@ -4960,35 +2884,44 @@ msgstr ""
 msgid "Please log in to view your messages."
 msgstr ""
 
+#. translators: Placeholders are the sender's display name and the date, respectively.
 #: includes/class-sensei-messages.php:769
 #: includes/class-sensei-messages.php:903
-#. translators: Placeholders are the sender's display name and the date, respectively.
 msgid "Sent by %1$s on %2$s."
 msgstr ""
 
-#: includes/class-sensei-messages.php:794
-#: includes/class-sensei-messages.php:880
 #. translators: Placeholder is a link to post, with the post's title as the link text.
 #. translators: Placeholder is the post title.
+#: includes/class-sensei-messages.php:794
+#: includes/class-sensei-messages.php:880
 msgid "Re: %1$s"
+msgstr ""
+
+#: includes/class-sensei-modules.php:126
+#: includes/class-sensei-modules.php:1330
+#: includes/class-sensei-modules.php:1379
+#: includes/class-sensei-modules.php:1780
+#: assets/blocks/course-outline/module-block/index.js:16
+#: assets/blocks/course-outline/module-block/index.js:19
+#: assets/blocks/course-outline/module-block/index.js:28
+#: assets/blocks/course-outline/outline-block/index.js:43
+#: assets/blocks/course-outline/outline-block/outline-appender.js:42
+#: assets/dist/blocks/single-course.js:6
+msgid "Module"
 msgstr ""
 
 #: includes/class-sensei-modules.php:132
 msgid "Course Modules"
 msgstr ""
 
-#: includes/class-sensei-modules.php:159
 #. translators: The placeholders are opening and closing <em> tags.
-msgid ""
-"No modules are available for this lesson yet. %1$sPlease select a course "
-"first.%2$s"
+#: includes/class-sensei-modules.php:159
+msgid "No modules are available for this lesson yet. %1$sPlease select a course first.%2$s"
 msgstr ""
 
-#: includes/class-sensei-modules.php:234
 #. translators: The placeholders are as follows: %1$s - <em> %2$s - </em> %3$s - Opening <a> tag to link to the Course URL. %4$s - </a>
-msgid ""
-"No modules are available for this lesson yet. %1$sPlease add some to "
-"%3$sthe course%4$s.%2$s"
+#: includes/class-sensei-modules.php:234
+msgid "No modules are available for this lesson yet. %1$sPlease add some to %3$sthe course%4$s.%2$s"
 msgstr ""
 
 #: includes/class-sensei-modules.php:351
@@ -5017,9 +2950,22 @@ msgstr ""
 msgid "In progress"
 msgstr ""
 
-#: includes/class-sensei-modules.php:863
 #. translators: Placeholder is a link to the Course.
+#: includes/class-sensei-modules.php:863
 msgid "Please sign up for the %1$s before starting the module."
+msgstr ""
+
+#: includes/class-sensei-modules.php:1039
+#: includes/class-sensei-modules.php:1627
+#: includes/class-sensei-modules.php:1779
+#: includes/class-sensei-modules.php:1790
+#: assets/blocks/course-outline/outline-block/index.js:20
+#: assets/blocks/course-outline/outline-block/outline-settings.js:26
+#: assets/blocks/course-results-block/course-results-settings.js:22
+#: assets/blocks/course-results-block/index.js:22
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-page.js:1
+msgid "Modules"
 msgstr ""
 
 #: includes/class-sensei-modules.php:1042
@@ -5095,13 +3041,53 @@ msgstr ""
 msgid "&larr; Back to Modules"
 msgstr ""
 
-#: includes/class-sensei-modules.php:2014
 #. translators: %s: add new taxonomy label
+#: includes/class-sensei-modules.php:2014
 msgid "+ %s"
 msgstr ""
 
 #: includes/class-sensei-posttypes.php:160
 msgid "Error: Feed does not exist"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:206
+msgctxt "post type single url base"
+msgid "course"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:312
+msgctxt "post type single slug"
+msgid "lesson"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:363
+msgctxt "post type single slug"
+msgid "quiz"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:410
+msgctxt "post type single slug"
+msgid "question"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:458
+msgctxt "post type single slug"
+msgid "multiple_question"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:494
+msgctxt "post type single slug"
+msgid "messages"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:546
+msgctxt "taxonomy general name"
+msgid "Course Categories"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:547
+msgctxt "taxonomy singular name"
+msgid "Course Category"
 msgstr ""
 
 #: includes/class-sensei-posttypes.php:548
@@ -5144,6 +3130,21 @@ msgstr ""
 msgid "&larr; Back to Course Categories"
 msgstr ""
 
+#: includes/class-sensei-posttypes.php:575
+msgctxt "taxonomy archive slug"
+msgid "course-category"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:592
+msgctxt "taxonomy general name"
+msgid "Quiz Types"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:593
+msgctxt "taxonomy singular name"
+msgid "Quiz Type"
+msgstr ""
+
 #: includes/class-sensei-posttypes.php:594
 msgid "Search Quiz Types"
 msgstr ""
@@ -5180,6 +3181,21 @@ msgstr ""
 msgid "Quiz Types"
 msgstr ""
 
+#: includes/class-sensei-posttypes.php:613
+msgctxt "taxonomy archive slug"
+msgid "quiz-type"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:629
+msgctxt "taxonomy general name"
+msgid "Question Types"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:630
+msgctxt "taxonomy singular name"
+msgid "Question Type"
+msgstr ""
+
 #: includes/class-sensei-posttypes.php:631
 msgid "Search Question Types"
 msgstr ""
@@ -5214,6 +3230,21 @@ msgstr ""
 
 #: includes/class-sensei-posttypes.php:639
 msgid "Question Types"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:652
+msgctxt "taxonomy archive slug"
+msgid "question-type"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:667
+msgctxt "taxonomy general name"
+msgid "Question Categories"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:668
+msgctxt "taxonomy singular name"
+msgid "Question Category"
 msgstr ""
 
 #: includes/class-sensei-posttypes.php:669
@@ -5260,6 +3291,21 @@ msgstr ""
 msgid "&larr; Back to Question Categories"
 msgstr ""
 
+#: includes/class-sensei-posttypes.php:697
+msgctxt "taxonomy archive slug"
+msgid "question-category"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:712
+msgctxt "taxonomy general name"
+msgid "Lesson Tags"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:713
+msgctxt "taxonomy singular name"
+msgid "Lesson Tag"
+msgstr ""
+
 #: includes/class-sensei-posttypes.php:714
 msgid "Search Lesson Tags"
 msgstr ""
@@ -5304,11 +3350,28 @@ msgstr ""
 msgid "&larr; Back to Lesson Tags"
 msgstr ""
 
+#: includes/class-sensei-posttypes.php:740
+msgctxt "taxonomy archive slug"
+msgid "lesson-tag"
+msgstr ""
+
 #: includes/class-sensei-posttypes.php:772
 #: includes/class-sensei-posttypes.php:773
 #: includes/class-sensei-question.php:157
 #: includes/class-sensei-question.php:160
 msgid "Quizzes"
+msgstr ""
+
+#: includes/class-sensei-posttypes.php:777
+#: includes/class-sensei-posttypes.php:778
+#: assets/blocks/quiz/quiz-block/index.js:27
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:67
+#: assets/blocks/quiz/quiz-block/questions-modal/index.js:45
+#: assets/dist/blocks/quiz/index.js:6
+#: assets/dist/data-port/export.js:1
+#: assets/dist/data-port/import.js:1
+#: assets/shared/helpers/labels.js:9
+msgid "Questions"
 msgstr ""
 
 #: includes/class-sensei-posttypes.php:781
@@ -5328,48 +3391,48 @@ msgstr ""
 msgid "Add New"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:811
 #. translators: Placeholder is the singular post type label.
+#: includes/class-sensei-posttypes.php:811
 msgid "Add New %s"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:815
 #. translators: Placeholder is the singular post type label.
+#: includes/class-sensei-posttypes.php:815
 msgid "New %s"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:817
 #. translators: Placeholder is the plural post type label.
+#: includes/class-sensei-posttypes.php:817
 msgid "All %s"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:819
 #. translators: Placeholder is the singular post type label.
+#: includes/class-sensei-posttypes.php:819
 msgid "View %s"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:821
 #. translators: Placeholder is the plural post type label.
+#: includes/class-sensei-posttypes.php:821
 msgid "Search %s"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:823
 #. translators: Placeholder is the lower-case plural post type label.
+#: includes/class-sensei-posttypes.php:823
 msgid "No %s found"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:825
 #. translators: Placeholder is the lower-case plural post type label.
+#: includes/class-sensei-posttypes.php:825
 msgid "No %s found in Trash"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:866
 #. translators: Placeholders are the singular label for the post type and the post's permalink, respectively.
+#: includes/class-sensei-posttypes.php:866
 msgid "%1$s updated. %2$sView %1$s%3$s."
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:867
 #. translators: Placeholders are the singular label for the post type and the post's permalink, respectively.
+#: includes/class-sensei-posttypes.php:867
 msgid "Custom field updated."
 msgstr ""
 
@@ -5377,43 +3440,43 @@ msgstr ""
 msgid "Custom field deleted."
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:870
 #. translators: Placeholder is the singular label for the post type.
+#: includes/class-sensei-posttypes.php:870
 msgid "%1$s updated."
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:872
 #. translators: Placeholders are the singular label for the post type and the post's revision, respectively.
+#: includes/class-sensei-posttypes.php:872
 msgid "%1$s restored to revision from %2$s."
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:874
 #. translators: Placeholders are the singular label for the post type and the post's permalink, respectively.
+#: includes/class-sensei-posttypes.php:874
 msgid "%1$s published. %2$sView %1$s%3$s."
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:876
 #. translators: Placeholder is the singular label for the post type.
+#: includes/class-sensei-posttypes.php:876
 msgid "%1$s saved."
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:878
 #. translators: Placeholders are the singular label for the post type and the post's preview link, respectively.
+#: includes/class-sensei-posttypes.php:878
 msgid "%1$s submitted. %2$sPreview %1$s%3$s."
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:887
 #. translators: Placeholders are as follows (in order): - The singular label for the post type. - The formatted post date. - The opening tag for the post's permalink. - The closing tag for the post's permalink.
+#: includes/class-sensei-posttypes.php:887
 msgid "%1$s scheduled for: %2$s. %3$sPreview %4$s%5$s."
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:887
 #. translators: Placeholders are as follows (in order): - The singular label for the post type. - The formatted post date. - The opening tag for the post's permalink. - The closing tag for the post's permalink.
+#: includes/class-sensei-posttypes.php:887
 msgid "M j, Y @ G:i"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:889
 #. translators: Placeholders are the singular label for the post type and the post's preview link, respectively.
+#: includes/class-sensei-posttypes.php:889
 msgid "%1$s draft updated. %2$sPreview %3$s%4$s."
 msgstr ""
 
@@ -5421,8 +3484,29 @@ msgstr ""
 msgid "Course name"
 msgstr ""
 
-#: includes/class-sensei-question.php:249
+#: includes/class-sensei-posttypes.php:907
+#: assets/blocks/course-outline/outline-block/outline-appender.js:34
+#: assets/dist/blocks/single-course.js:6
+msgid "Lesson name"
+msgstr ""
+
+#: includes/class-sensei-question.php:78
+msgctxt "column name"
+msgid "Question"
+msgstr ""
+
+#: includes/class-sensei-question.php:79
+msgctxt "column name"
+msgid "Type"
+msgstr ""
+
+#: includes/class-sensei-question.php:80
+msgctxt "column name"
+msgid "Categories"
+msgstr ""
+
 #. translators: Placeholders are an opening and closing <em> tag.
+#: includes/class-sensei-question.php:249
 msgid "%1$sThis question does not appear in any quizzes yet.%2$s"
 msgstr ""
 
@@ -5434,6 +3518,19 @@ msgstr ""
 msgid "All categories"
 msgstr ""
 
+#: includes/class-sensei-question.php:804
+#: assets/blocks/quiz/answer-feedback-block/answer-feedback.js:17
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Correct"
+msgstr ""
+
+#: includes/class-sensei-question.php:807
+#: includes/class-sensei-question.php:998
+#: assets/blocks/quiz/answer-feedback-block/answer-feedback.js:24
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Incorrect"
+msgstr ""
+
 #: includes/class-sensei-question.php:897
 msgid "Right Answer:"
 msgstr ""
@@ -5442,13 +3539,13 @@ msgstr ""
 msgid "Incorrect - Right Answer:"
 msgstr ""
 
-#: includes/class-sensei-question.php:1010
 #. translators: Placeholder is the question grade.
+#: includes/class-sensei-question.php:1010
 msgid "Grade: %d"
 msgstr ""
 
-#: includes/class-sensei-question.php:1149
 #. translators: Placeholder are the upload size and the measurement (e.g. 5 MB).
+#: includes/class-sensei-question.php:1149
 msgid "Maximum upload file size: %s"
 msgstr ""
 
@@ -5456,20 +3553,20 @@ msgstr ""
 msgid "Quiz Saved Successfully."
 msgstr ""
 
-#: includes/class-sensei-quiz.php:1259
 #. translators: Placeholder is the quiz name with any instance of the word "quiz" removed.
+#: includes/class-sensei-quiz.php:1259
 msgid "%s Quiz"
 msgstr ""
 
-#: includes/class-sensei-quiz.php:1418
+#: includes/class-sensei-quiz.php:1448
 msgid "Complete Quiz"
 msgstr ""
 
-#: includes/class-sensei-quiz.php:1423
+#: includes/class-sensei-quiz.php:1453
 msgid "Save Quiz"
 msgstr ""
 
-#: includes/class-sensei-quiz.php:1432
+#: includes/class-sensei-quiz.php:1462
 msgid "Reset Quiz"
 msgstr ""
 
@@ -5481,13 +3578,13 @@ msgstr ""
 msgid "Override init_fields() in your class."
 msgstr ""
 
-#: includes/class-sensei-settings-api.php:969
 #. translators: Placeholder is the field name.
+#: includes/class-sensei-settings-api.php:969
 msgid "%s is a required field"
 msgstr ""
 
-#: includes/class-sensei-settings-api.php:988
 #. translators: Placeholder is the name of the settings page.
+#: includes/class-sensei-settings-api.php:988
 msgid "%s updated"
 msgstr ""
 
@@ -5524,11 +3621,11 @@ msgid "Settings for email notifications sent from your site."
 msgstr ""
 
 #: includes/class-sensei-settings.php:157
-msgid "Learner Profiles"
+msgid "Student Profiles"
 msgstr ""
 
 #: includes/class-sensei-settings.php:158
-msgid "Settings for public Learner Profiles."
+msgid "Settings for public Student Profiles."
 msgstr ""
 
 #: includes/class-sensei-settings.php:198
@@ -5572,7 +3669,7 @@ msgid "Disable Private Messages"
 msgstr ""
 
 #: includes/class-sensei-settings.php:220
-msgid "Disable the private message functions between learners and teachers."
+msgid "Disable the private message functions between students and teachers."
 msgstr ""
 
 #: includes/class-sensei-settings.php:227
@@ -5580,9 +3677,7 @@ msgid "Course Archive Page"
 msgstr ""
 
 #: includes/class-sensei-settings.php:228
-msgid ""
-"The page to use to display courses. If you leave this blank the default "
-"custom post type archive will apply."
+msgid "The page to use to display courses. If you leave this blank the default custom post type archive will apply."
 msgstr ""
 
 #: includes/class-sensei-settings.php:237
@@ -5590,9 +3685,7 @@ msgid "My Courses Page"
 msgstr ""
 
 #: includes/class-sensei-settings.php:238
-msgid ""
-"The page to use to display the courses that a user is currently taking as "
-"well as the courses a user has complete."
+msgid "The page to use to display the courses that a user is currently taking as well as the courses a user has complete."
 msgstr ""
 
 #: includes/class-sensei-settings.php:247
@@ -5600,7 +3693,7 @@ msgid "Course Completed Page"
 msgstr ""
 
 #: includes/class-sensei-settings.php:248
-msgid "The page that is displayed after a learner completes a course."
+msgid "The page that is displayed after a student completes a course."
 msgstr ""
 
 #: includes/class-sensei-settings.php:257
@@ -5608,9 +3701,7 @@ msgid "Use placeholder images"
 msgstr ""
 
 #: includes/class-sensei-settings.php:258
-msgid ""
-"Output a placeholder image when no featured image has been specified for "
-"Courses and Lessons."
+msgid "Output a placeholder image when no featured image has been specified for Courses and Lessons."
 msgstr ""
 
 #: includes/class-sensei-settings.php:265
@@ -5618,9 +3709,7 @@ msgid "Disable Sensei LMS Styles"
 msgstr ""
 
 #: includes/class-sensei-settings.php:266
-msgid ""
-"Prevent the frontend stylesheets from loading. This will remove the default "
-"styles for all Sensei LMS elements."
+msgid "Prevent the frontend stylesheets from loading. This will remove the default styles for all Sensei LMS elements."
 msgstr ""
 
 #: includes/class-sensei-settings.php:272
@@ -5636,9 +3725,7 @@ msgid "Disable Sensei LMS Javascript"
 msgstr ""
 
 #: includes/class-sensei-settings.php:282
-msgid ""
-"Prevent the frontend javascript from loading. This affects the progress "
-"bars and the My Courses tabs."
+msgid "Prevent the frontend javascript from loading. This affects the progress bars and the My Courses tabs."
 msgstr ""
 
 #: includes/class-sensei-settings.php:289
@@ -5646,9 +3733,7 @@ msgid "Disable HTML security"
 msgstr ""
 
 #: includes/class-sensei-settings.php:290
-msgid ""
-"Allow any HTML tags in the Video Embed field. Warning: Enabling this may "
-"leave your site more vulnerable to XSS attacks"
+msgid "Allow any HTML tags in the Video Embed field. Warning: Enabling this may leave your site more vulnerable to XSS attacks"
 msgstr ""
 
 #: includes/class-sensei-settings.php:297
@@ -5656,9 +3741,7 @@ msgid "Delete data on uninstall"
 msgstr ""
 
 #: includes/class-sensei-settings.php:298
-msgid ""
-"Delete Sensei LMS data when the plugin is deleted. Once removed, this data "
-"cannot be restored."
+msgid "Delete Sensei LMS data when the plugin is deleted. Once removed, this data cannot be restored."
 msgstr ""
 
 #: includes/class-sensei-settings.php:306
@@ -5713,14 +3796,12 @@ msgstr ""
 msgid "Image Hard Crop - Archive"
 msgstr ""
 
+#. translators: Placeholders are an opening and closing <a> tag linking to the documentation page.
 #: includes/class-sensei-settings.php:362
 #: includes/class-sensei-settings.php:397
 #: includes/class-sensei-settings.php:466
 #: includes/class-sensei-settings.php:501
-#. translators: Placeholders are an opening and closing <a> tag linking to the documentation page.
-msgid ""
-"After changing this setting, you may need to %1$sregenerate your "
-"thumbnails%2$s."
+msgid "After changing this setting, you may need to %1$sregenerate your thumbnails%2$s."
 msgstr ""
 
 #: includes/class-sensei-settings.php:369
@@ -5767,9 +3848,7 @@ msgid "More link text"
 msgstr ""
 
 #: includes/class-sensei-settings.php:413
-msgid ""
-"The text that will be displayed on the Course Archive for the more courses "
-"link."
+msgid "The text that will be displayed on the Course Archive for the more courses link."
 msgstr ""
 
 #: includes/class-sensei-settings.php:415
@@ -5781,9 +3860,7 @@ msgid "Allow Comments for Lessons"
 msgstr ""
 
 #: includes/class-sensei-settings.php:423
-msgid ""
-"This will allow learners to post comments on the single Lesson page, only "
-"learner who have access to the Lesson will be allowed to comment."
+msgid "This will allow students to post comments on the single Lesson page, only student who have access to the Lesson will be allowed to comment."
 msgstr ""
 
 #: includes/class-sensei-settings.php:430
@@ -5807,9 +3884,7 @@ msgid "Image Width - Course Lessons"
 msgstr ""
 
 #: includes/class-sensei-settings.php:447
-msgid ""
-"The width in pixels of the featured image for the Lessons on the Course "
-"Single page."
+msgid "The width in pixels of the featured image for the Lessons on the Course Single page."
 msgstr ""
 
 #: includes/class-sensei-settings.php:455
@@ -5817,9 +3892,7 @@ msgid "Image Height - Course Lessons"
 msgstr ""
 
 #: includes/class-sensei-settings.php:456
-msgid ""
-"The height in pixels of the featured image for the Lessons on the Course "
-"Single page."
+msgid "The height in pixels of the featured image for the Lessons on the Course Single page."
 msgstr ""
 
 #: includes/class-sensei-settings.php:464
@@ -5843,22 +3916,20 @@ msgid "The height in pixels of the featured image for the Lessons single post pa
 msgstr ""
 
 #: includes/class-sensei-settings.php:512
-msgid "Public learner profiles"
+msgid "Public student profiles"
 msgstr ""
 
-#: includes/class-sensei-settings.php:514
 #. translators: Placeholder is a profile URL example.
-msgid ""
-"Enable public learner profiles that will be accessible to everyone. Profile "
-"URL format: %s"
+#: includes/class-sensei-settings.php:514
+msgid "Enable public student profiles that will be accessible to everyone. Profile URL format: %s"
 msgstr ""
 
 #: includes/class-sensei-settings.php:521
-msgid "Show learner's courses"
+msgid "Show student's courses"
 msgstr ""
 
 #: includes/class-sensei-settings.php:522
-msgid "Display the learner's active and completed courses on their profile."
+msgid "Display the student's active and completed courses on their profile."
 msgstr ""
 
 #: includes/class-sensei-settings.php:530
@@ -5870,23 +3941,23 @@ msgid "They complete a course"
 msgstr ""
 
 #: includes/class-sensei-settings.php:535
-msgid "A learner starts their course"
+msgid "A student starts their course"
 msgstr ""
 
 #: includes/class-sensei-settings.php:536
-msgid "A learner completes their course"
+msgid "A student completes their course"
 msgstr ""
 
 #: includes/class-sensei-settings.php:537
-msgid "A learner completes a lesson"
+msgid "A student completes a lesson"
 msgstr ""
 
 #: includes/class-sensei-settings.php:538
-msgid "A learner submits a quiz for grading"
+msgid "A student submits a quiz for grading"
 msgstr ""
 
 #: includes/class-sensei-settings.php:539
-msgid "A learner sends a private message to a teacher"
+msgid "A student sends a private message to a teacher"
 msgstr ""
 
 #: includes/class-sensei-settings.php:543
@@ -5894,11 +3965,11 @@ msgid "They receive a reply to their private message"
 msgstr ""
 
 #: includes/class-sensei-settings.php:547
-msgid "Emails Sent to Learners"
+msgid "Emails Sent to Students"
 msgstr ""
 
 #: includes/class-sensei-settings.php:548
-msgid "Select the notifications that will be sent to learners."
+msgid "Select the notifications that will be sent to students."
 msgstr ""
 
 #: includes/class-sensei-settings.php:556
@@ -5937,11 +4008,9 @@ msgstr ""
 msgid "Header Image"
 msgstr ""
 
-#: includes/class-sensei-settings.php:594
 #. translators: Placeholders are opening and closing <a> tags linking to the media uploader.
-msgid ""
-"Enter a URL to an image you want to show in the email's header. Upload your "
-"image using the %1$smedia uploader%2$s."
+#: includes/class-sensei-settings.php:594
+msgid "Enter a URL to an image you want to show in the email's header. Upload your image using the %1$smedia uploader%2$s."
 msgstr ""
 
 #: includes/class-sensei-settings.php:602
@@ -5952,9 +4021,9 @@ msgstr ""
 msgid "The text to appear in the footer of Sensei LMS emails."
 msgstr ""
 
+#. translators: Placeholder is the blog name.
 #: includes/class-sensei-settings.php:606
 #: templates/emails/footer.php:26
-#. translators: Placeholder is the blog name.
 msgid "%1$s - Powered by Sensei LMS"
 msgstr ""
 
@@ -5962,8 +4031,8 @@ msgstr ""
 msgid "Base Colour"
 msgstr ""
 
-#: includes/class-sensei-settings.php:614
 #. translators: Placeholders are opening and closing <code> tags.
+#: includes/class-sensei-settings.php:614
 msgid "The base colour for Sensei LMS email templates. Default %1$s#557da1%2$s."
 msgstr ""
 
@@ -5971,33 +4040,27 @@ msgstr ""
 msgid "Background Colour"
 msgstr ""
 
-#: includes/class-sensei-settings.php:624
 #. translators: Placeholders are opening and closing <code> tags.
-msgid ""
-"The background colour for Sensei LMS email templates. Default "
-"%1$s#f5f5f5%2$s."
+#: includes/class-sensei-settings.php:624
+msgid "The background colour for Sensei LMS email templates. Default %1$s#f5f5f5%2$s."
 msgstr ""
 
 #: includes/class-sensei-settings.php:632
 msgid "Body Background Colour"
 msgstr ""
 
-#: includes/class-sensei-settings.php:634
 #. translators: Placeholders are opening and closing <code> tags.
-msgid ""
-"The main body background colour for Sensei LMS email templates. Default "
-"%1$s#fdfdfd%2$s."
+#: includes/class-sensei-settings.php:634
+msgid "The main body background colour for Sensei LMS email templates. Default %1$s#fdfdfd%2$s."
 msgstr ""
 
 #: includes/class-sensei-settings.php:642
 msgid "Body Text Colour"
 msgstr ""
 
-#: includes/class-sensei-settings.php:644
 #. translators: Placeholders are opening and closing <code> tags.
-msgid ""
-"The main body text colour for Sensei LMS email templates. Default "
-"%1$s#505050%2$s."
+#: includes/class-sensei-settings.php:644
+msgid "The main body text colour for Sensei LMS email templates. Default %1$s#505050%2$s."
 msgstr ""
 
 #: includes/class-sensei-settings.php:711
@@ -6022,29 +4085,23 @@ msgstr ""
 msgid "Show all teachers"
 msgstr ""
 
-#: includes/class-sensei-teacher.php:1634
 #. translators: Placeholder is the author name.
+#: includes/class-sensei-teacher.php:1634
 msgid "All courses by %s"
 msgstr ""
 
-#: includes/class-sensei-usage-tracking.php:91
 #. translators: The href tag contains the URL for the page telling users what data Sensei tracks.
-msgid ""
-"We'd love if you helped us make Sensei LMS better by allowing us to collect "
-"<a href=\"%s\" target=\"_blank\">usage tracking data</a>. No sensitive "
-"information is collected, and you can opt out at any time."
+#: includes/class-sensei-usage-tracking.php:91
+msgid "We'd love if you helped us make Sensei LMS better by allowing us to collect <a href=\"%s\" target=\"_blank\">usage tracking data</a>. No sensitive information is collected, and you can opt out at any time."
 msgstr ""
 
 #: includes/class-sensei-usage-tracking.php:150
 msgid "Enable usage tracking"
 msgstr ""
 
-#: includes/class-sensei-usage-tracking.php:156
 #. translators: The href tag contains the URL for the page telling users what data Sensei tracks.
-msgid ""
-"Help us make Sensei LMS better by allowing us to collect <a href=\"%s\" "
-"target=\"_blank\">usage tracking data</a>. No sensitive information is "
-"collected."
+#: includes/class-sensei-usage-tracking.php:156
+msgid "Help us make Sensei LMS better by allowing us to collect <a href=\"%s\" target=\"_blank\">usage tracking data</a>. No sensitive information is collected."
 msgstr ""
 
 #: includes/class-sensei-utils.php:68
@@ -6056,13 +4113,13 @@ msgstr ""
 msgid "You have not started this course yet."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1195
 #. translators: Placeholder is the user's grade.
+#: includes/class-sensei-utils.php:1195
 msgid "You have passed this course with a grade of %1$d%%."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1200
 #. translators: Placeholders are the required grade and the actual grade, respectively.
+#: includes/class-sensei-utils.php:1200
 msgid "You require %1$d%% to pass this course. Your grade is %2$s%%."
 msgstr ""
 
@@ -6070,8 +4127,8 @@ msgstr ""
 msgid "You have not taken this lesson's quiz yet"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1269
 #. translators: Placeholders are an opening and closing <a> tag linking to the course permalink.
+#: includes/class-sensei-utils.php:1269
 msgid "Please sign up for %1$sthe course%2$s before taking this quiz"
 msgstr ""
 
@@ -6087,52 +4144,48 @@ msgstr ""
 msgid "Congratulations! You have completed this lesson."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1295
 #. translators: Placeholder is the quiz grade.
+#: includes/class-sensei-utils.php:1295
 msgid "Congratulations! You have passed this lesson's quiz achieving %s%%"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1298
 #. translators: Placeholder is the quiz grade.
+#: includes/class-sensei-utils.php:1298
 msgid "Congratulations! You have passed this quiz achieving %s%%"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1321
 #. translators: Placeholders are an opening and closing <a> tag linking to the quiz permalink.
-msgid ""
-"You have completed this lesson's quiz and it will be graded soon. %1$sView "
-"the lesson quiz%2$s"
+#: includes/class-sensei-utils.php:1321
+msgid "You have completed this lesson's quiz and it will be graded soon. %1$sView the lesson quiz%2$s"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1324
 #. translators: Placeholder is the quiz passmark.
-msgid ""
-"You have completed this quiz and it will be graded soon. You require %1$s%% "
-"to pass."
+#: includes/class-sensei-utils.php:1324
+msgid "You have completed this quiz and it will be graded soon. You require %1$s%% to pass."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1333
 #. translators: Placeholders are the quiz passmark and the learner's grade, respectively.
+#: includes/class-sensei-utils.php:1333
 msgid "You require %1$d%% to pass this lesson's quiz. Your grade is %2$s%%"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1336
 #. translators: Placeholders are the quiz passmark and the learner's grade, respectively.
+#: includes/class-sensei-utils.php:1336
 msgid "You require %1$d%% to pass this quiz. Your grade is %2$s%%"
 msgstr ""
 
-#: includes/class-sensei-utils.php:1348
 #. translators: Placeholder is the quiz passmark.
+#: includes/class-sensei-utils.php:1348
 msgid "You require %1$d%% to pass this lesson's quiz."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1351
 #. translators: Placeholder is the quiz passmark.
+#: includes/class-sensei-utils.php:1351
 msgid "You require %1$d%% to pass this quiz."
 msgstr ""
 
-#: includes/class-sensei-utils.php:1363
 #. translators: Placeholder is a link to the course permalink.
+#: includes/class-sensei-utils.php:1363
 msgid "Please sign up for the %1$s before taking this quiz."
 msgstr ""
 
@@ -6140,8 +4193,8 @@ msgstr ""
 msgid "View the lesson quiz"
 msgstr ""
 
-#: includes/class-sensei-view-helper.php:66
 #. translators: number of points.
+#: includes/class-sensei-view-helper.php:66
 msgid "Points: %s"
 msgstr ""
 
@@ -6150,61 +4203,88 @@ msgstr ""
 msgid "Cheatin&#8217; huh?"
 msgstr ""
 
-#: includes/class-sensei.php:826
 #. translators: The placeholder %s is a link to the course.
+#: includes/class-sensei.php:827
 msgid "Please complete the previous %1$s before taking this course."
 msgstr ""
 
-#: includes/class-sensei.php:831
 #. translators: The placeholders are the opening and closing tags for a link to log in.
+#: includes/class-sensei.php:832
 msgid "Or %1$s login %2$s to access your purchased courses"
 msgstr ""
 
-#: includes/class-sensei.php:861
-#: includes/class-sensei.php:905
-#: includes/class-sensei.php:921
-#: includes/class-sensei.php:935
+#: includes/class-sensei.php:862
+#: includes/class-sensei.php:906
+#: includes/class-sensei.php:922
+#: includes/class-sensei.php:936
 msgid "Restricted Access"
 msgstr ""
 
-#: includes/class-sensei.php:867
 #. translators: The placeholder %1$s is a link to the Course.
+#: includes/class-sensei.php:868
 msgid "This is a preview lesson. Please purchase the %1$s to access all lessons."
 msgstr ""
 
-#: includes/class-sensei.php:870
 #. translators: The placeholder %1$s is a link to the Course.
+#: includes/class-sensei.php:871
 msgid "Please purchase the %1$s before starting this Lesson."
 msgstr ""
 
-#: includes/class-sensei.php:875
 #. translators: The placeholder %1$s is a link to the Course.
+#: includes/class-sensei.php:876
 msgid "This is a preview lesson. Please sign up for the %1$s to access all lessons."
 msgstr ""
 
-#: includes/class-sensei.php:908
 #. translators: The placeholder %1$s is a link to the Lesson.
+#: includes/class-sensei.php:909
 msgid "Please complete the previous %1$s before taking this Quiz."
 msgstr ""
 
-#: includes/class-sensei.php:926
 #. translators: The placeholder %1$s is a link to the Course.
+#: includes/class-sensei.php:927
 msgid "Please purchase the %1$s before starting this Quiz."
 msgstr ""
 
-#: includes/class-sensei.php:929
 #. translators: The placeholder %1$s is a link to the Course.
+#: includes/class-sensei.php:930
 msgid "Please sign up for the %1$s before starting this Quiz."
 msgstr ""
 
-#: includes/class-sensei.php:938
 #. translators: The placeholder %1$s is a link to the Course.
+#: includes/class-sensei.php:939
 msgid "Please sign up for the %1$s before taking this Quiz."
 msgstr ""
 
-#: includes/class-sensei.php:1430
 #. translators: Docs as in Documentation
+#: includes/class-sensei.php:1431
 msgid "Docs"
+msgstr ""
+
+#: includes/class-sensei.php:1449
+msgctxt "plugin action link"
+msgid "Configure"
+msgstr ""
+
+#: includes/course-theme/class-sensei-course-theme-lesson.php:90
+msgid "Awaiting grade"
+msgstr ""
+
+#. translators: Placeholders are the required grade and the actual grade, respectively.
+#: includes/course-theme/class-sensei-course-theme-lesson.php:93
+msgid "You require %1$s%% to pass this course. Your grade is %2$s%%."
+msgstr ""
+
+#. translators: Placeholder is the quiz grade.
+#: includes/course-theme/class-sensei-course-theme-lesson.php:96
+msgid "Your Grade %s%%"
+msgstr ""
+
+#: includes/course-theme/class-sensei-course-theme-lesson.php:102
+msgid "View quiz"
+msgstr ""
+
+#: includes/course-theme/class-sensei-course-theme-lesson.php:108
+msgid "Quiz completed"
 msgstr ""
 
 #: includes/data-port/class-sensei-data-port-job.php:504
@@ -6217,8 +4297,8 @@ msgstr ""
 msgid "Error saving file."
 msgstr ""
 
-#: includes/data-port/class-sensei-data-port-job.php:722
 #. translators: Placeholder is ID of entry in source file.
+#: includes/data-port/class-sensei-data-port-job.php:722
 msgid "ID: %s"
 msgstr ""
 
@@ -6234,18 +4314,18 @@ msgstr ""
 msgid "Attachment insertion failed."
 msgstr ""
 
-#: includes/data-port/class-sensei-data-port-utilities.php:241
 #. translators: Placeholder is list of file extensions.
+#: includes/data-port/class-sensei-data-port-utilities.php:241
 msgid "File type is not supported. Must be one of the following: %s."
 msgstr ""
 
-#: includes/data-port/class-sensei-data-port-utilities.php:522
 #. translators: Placeholder is the term which errored.
+#: includes/data-port/class-sensei-data-port-utilities.php:522
 msgid "Module does not exist: %s."
 msgstr ""
 
-#: includes/data-port/class-sensei-data-port-utilities.php:532
 #. translators: First placeholder is the term which errored, second is the course id.
+#: includes/data-port/class-sensei-data-port-utilities.php:532
 msgid "Module %1$s is not part of course %2$s."
 msgstr ""
 
@@ -6257,11 +4337,9 @@ msgstr ""
 msgid "Export"
 msgstr ""
 
-#: includes/data-port/class-sensei-import-block-migrator.php:149
 #. translators: The %1$d is the lesson id and the %2$s the lesson title.
-msgid ""
-"Lesson with id %1$d and title %2$s which is referenced in course outline "
-"block not found."
+#: includes/data-port/class-sensei-import-block-migrator.php:149
+msgid "Lesson with id %1$d and title %2$s which is referenced in course outline block not found."
 msgstr ""
 
 #: includes/data-port/class-sensei-import-block-migrator.php:174
@@ -6281,15 +4359,15 @@ msgstr ""
 msgid "Uploaded file was not a valid CSV."
 msgstr ""
 
-#: includes/data-port/class-sensei-import-csv-reader.php:351
 #. translators: Placeholder is list of columns that are missing.
+#: includes/data-port/class-sensei-import-csv-reader.php:351
 msgid "Source file is missing the required column: %s"
 msgid_plural "Source file is missing the required columns: %s"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/data-port/class-sensei-import-csv-reader.php:369
 #. translators: Placeholder is list of columns that are unknown.
+#: includes/data-port/class-sensei-import-csv-reader.php:369
 msgid "The following column is unknown: %s"
 msgid_plural "The following columns are unknown: %s"
 msgstr[0] ""
@@ -6303,8 +4381,8 @@ msgstr ""
 msgid "No `--user` argument was provided. Do you want to create posts as a guest?"
 msgstr ""
 
-#: includes/data-port/class-sensei-import-job-cli.php:109
 #. translators: Placeholder %1$s is the name of the file; %2$s is the path provided.
+#: includes/data-port/class-sensei-import-job-cli.php:109
 msgid "File provided for \"%1$s\" (%1$s) was not found"
 msgstr ""
 
@@ -6312,8 +4390,8 @@ msgstr ""
 msgid "No file arguments were provided."
 msgstr ""
 
-#: includes/data-port/class-sensei-import-job-cli.php:142
 #. translators: Placeholder %1$s is the name of the file; %2$s is the path provided; %3$s is the validation error.
+#: includes/data-port/class-sensei-import-job-cli.php:142
 msgid "File provided for \"%1$s\" (%2$s) was not not valid. Error: %3$s"
 msgstr ""
 
@@ -6321,34 +4399,38 @@ msgstr ""
 msgid "Import Content"
 msgstr ""
 
-#: includes/data-port/export-tasks/class-sensei-export-task.php:132
+#: includes/data-port/class-sensei-import.php:61
+#: assets/data-port/import/steps.js:22
+#: assets/dist/data-port/import.js:1
+msgid "Import"
+msgstr ""
+
 #. translators: Placeholder is the content file being exported.
+#: includes/data-port/export-tasks/class-sensei-export-task.php:132
 msgid "Error exporting the %s file."
 msgstr ""
 
-#: includes/data-port/import-tasks/class-sensei-import-associations.php:139
 #. translators: Placeholder is the reference to a lesson which did not exist.
+#: includes/data-port/import-tasks/class-sensei-import-associations.php:139
 msgid "Lesson does not exist: %s."
 msgstr ""
 
-#: includes/data-port/import-tasks/class-sensei-import-associations.php:155
 #. translators: Placeholder is the lesson reference (e.g. "id:44").
+#: includes/data-port/import-tasks/class-sensei-import-associations.php:155
 msgid "The lesson \"%s\" can only be associated with one course at a time."
 msgstr ""
 
-#: includes/data-port/import-tasks/class-sensei-import-associations.php:280
 #. translators: Placeholder is reference to module.
-msgid ""
-"Unable to set the lesson module to \"%s\" because it does not have a course "
-"associated with it."
+#: includes/data-port/import-tasks/class-sensei-import-associations.php:280
+msgid "Unable to set the lesson module to \"%s\" because it does not have a course associated with it."
 msgstr ""
 
 #: includes/data-port/import-tasks/class-sensei-import-file-process-task.php:262
 msgid "A required field is missing or one of the fields is malformed. Line skipped."
 msgstr ""
 
-#: includes/data-port/import-tasks/class-sensei-import-prerequisite-trait.php:43
 #. translators: Placeholder is reference to another post.
+#: includes/data-port/import-tasks/class-sensei-import-prerequisite-trait.php:43
 msgid "Unable to set the prerequisite to \"%s\""
 msgstr ""
 
@@ -6357,24 +4439,20 @@ msgid "Unable to set the prerequisite to the same entry"
 msgstr ""
 
 #: includes/data-port/models/class-sensei-import-course-model.php:49
-msgid ""
-"The user with the supplied username has a different email. Teacher email "
-"will be ignored."
+msgid "The user with the supplied username has a different email. Teacher email will be ignored."
 msgstr ""
 
 #: includes/data-port/models/class-sensei-import-course-model.php:60
-msgid ""
-"Teacher Username is empty. Course teacher is set to the currently logged in "
-"user."
+msgid "Teacher Username is empty. Course teacher is set to the currently logged in user."
 msgstr ""
 
 #: includes/data-port/models/class-sensei-import-course-model.php:86
 msgid "Course creation failed."
 msgstr ""
 
+#. translators: Placeholder is comma separated list of terms that failed to save.
 #: includes/data-port/models/class-sensei-import-course-model.php:252
 #: includes/data-port/models/class-sensei-import-lesson-model.php:411
-#. translators: Placeholder is comma separated list of terms that failed to save.
 msgid "The following terms failed to save: %s"
 msgstr ""
 
@@ -6390,8 +4468,8 @@ msgstr ""
 msgid "Number of Questions must be greater than or equal to 1."
 msgstr ""
 
-#: includes/data-port/models/class-sensei-import-lesson-model.php:198
 #. translators: Placeholder is the question post ID which errored.
+#: includes/data-port/models/class-sensei-import-lesson-model.php:198
 msgid "Question does not exist: %s."
 msgstr ""
 
@@ -6403,23 +4481,23 @@ msgstr ""
 msgid "Length must be greater than or equal to 1."
 msgstr ""
 
-#: includes/data-port/models/class-sensei-import-model.php:160
 #. translators: Placeholder is the column name.
+#: includes/data-port/models/class-sensei-import-model.php:160
 msgid "%s must be a whole number."
 msgstr ""
 
-#: includes/data-port/models/class-sensei-import-model.php:179
 #. translators: Placeholder is the column name.
+#: includes/data-port/models/class-sensei-import-model.php:179
 msgid "%s must be a number."
 msgstr ""
 
-#: includes/data-port/models/class-sensei-import-model.php:199
 #. translators: Placeholder %1$s is the column name. %2$s is the accepted values.
+#: includes/data-port/models/class-sensei-import-model.php:199
 msgid "%1$s must be one of the following: %2$s."
 msgstr ""
 
-#: includes/data-port/models/class-sensei-import-model.php:220
 #. translators: Placeholder is the column name.
+#: includes/data-port/models/class-sensei-import-model.php:220
 msgid "%s contains invalid characters."
 msgstr ""
 
@@ -6431,13 +4509,18 @@ msgstr ""
 msgid "Question insertion failed."
 msgstr ""
 
-#: includes/data-port/models/class-sensei-import-question-model.php:138
 #. translators: First placeholder is name of field, second placeholder is error returned.
+#: includes/data-port/models/class-sensei-import-question-model.php:138
 msgid "Meta field \"%1$s\" is invalid: %2$s"
 msgstr ""
 
 #: includes/email-signup/template.php:23
 msgid "Join Sensei LMS's Mailing List!"
+msgstr ""
+
+#: includes/email-signup/template.php:25
+#: assets/dist/setup-wizard/index.js:6
+msgid "We're here for you — get tips, product updates, and inspiration straight to your mailbox."
 msgstr ""
 
 #: includes/email-signup/template.php:31
@@ -6448,26 +4531,28 @@ msgstr ""
 msgid "Enter your email address"
 msgstr ""
 
-#: includes/email-signup/template.php:45
 #. translators: placeholder is the URL to MailChimp's Legal page.
-msgid ""
-"We use Mailchimp as our marketing platform. By clicking below to subscribe, "
-"you acknowledge that your information will be transferred to Mailchimp for "
-"processing. <a href=\"%s\" target=\"_blank\">Learn more about Mailchimp's "
-"privacy practices here.</a>"
+#: includes/email-signup/template.php:45
+msgid "We use Mailchimp as our marketing platform. By clicking below to subscribe, you acknowledge that your information will be transferred to Mailchimp for processing. <a href=\"%s\" target=\"_blank\">Learn more about Mailchimp's privacy practices here.</a>"
 msgstr ""
 
 #: includes/email-signup/template.php:57
 msgid "Not Now"
 msgstr ""
 
-#: includes/emails/class-sensei-email-learner-completed-course.php:63
+#: includes/email-signup/template.php:58
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/ready/mailinglist-signup-form.js:56
+msgid "Yes, please!"
+msgstr ""
+
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-learner-completed-course.php:63
 msgid "[%1$s] You have completed a course"
 msgstr ""
 
-#: includes/emails/class-sensei-email-learner-completed-course.php:64
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-learner-completed-course.php:64
 msgid "You have completed a course"
 msgstr ""
 
@@ -6483,53 +4568,53 @@ msgstr ""
 msgid "failed"
 msgstr ""
 
-#: includes/emails/class-sensei-email-learner-graded-quiz.php:65
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-learner-graded-quiz.php:65
 msgid "[%1$s] Your quiz has been graded"
 msgstr ""
 
-#: includes/emails/class-sensei-email-learner-graded-quiz.php:66
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-learner-graded-quiz.php:66
 msgid "Your quiz has been graded"
 msgstr ""
 
-#: includes/emails/class-sensei-email-learner-graded-quiz.php:79
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-learner-graded-quiz.php:79
 msgid "[%1$s] You have completed a quiz"
 msgstr ""
 
-#: includes/emails/class-sensei-email-learner-graded-quiz.php:80
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-learner-graded-quiz.php:80
 msgid "You have completed a quiz"
 msgstr ""
 
-#: includes/emails/class-sensei-email-new-message-reply.php:97
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-new-message-reply.php:97
 msgid "[%1$s] You have a new message"
 msgstr ""
 
-#: includes/emails/class-sensei-email-new-message-reply.php:98
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-new-message-reply.php:98
 msgid "You have received a reply to your private message"
 msgstr ""
 
-#: includes/emails/class-sensei-email-teacher-completed-course.php:64
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-teacher-completed-course.php:64
 msgid "[%1$s] Your student has completed a course"
 msgstr ""
 
-#: includes/emails/class-sensei-email-teacher-completed-course.php:65
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-teacher-completed-course.php:65
 msgid "Your student has completed a course"
 msgstr ""
 
-#: includes/emails/class-sensei-email-teacher-completed-lesson.php:34
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-teacher-completed-lesson.php:34
 msgid "[%1$s] Your student has completed a lesson"
 msgstr ""
 
-#: includes/emails/class-sensei-email-teacher-completed-lesson.php:35
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-teacher-completed-lesson.php:35
 msgid "Your student has completed a lesson"
 msgstr ""
 
@@ -6541,41 +4626,38 @@ msgstr ""
 msgid "New course assigned to you"
 msgstr ""
 
-#: includes/emails/class-sensei-email-teacher-new-message.php:60
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-teacher-new-message.php:60
 msgid "[%1$s] You have received a new private message"
 msgstr ""
 
-#: includes/emails/class-sensei-email-teacher-new-message.php:61
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-teacher-new-message.php:61
 msgid "Your student has sent you a private message"
 msgstr ""
 
-#: includes/emails/class-sensei-email-teacher-quiz-submitted.php:66
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-teacher-quiz-submitted.php:66
 msgid "[%1$s] Your student has submitted a quiz for grading"
 msgstr ""
 
-#: includes/emails/class-sensei-email-teacher-quiz-submitted.php:67
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-teacher-quiz-submitted.php:67
 msgid "Your student has submitted a quiz for grading"
 msgstr ""
 
-#: includes/emails/class-sensei-email-teacher-started-course.php:59
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-teacher-started-course.php:59
 msgid "[%1$s] Your student has started a course"
 msgstr ""
 
-#: includes/emails/class-sensei-email-teacher-started-course.php:60
 #. translators: Placeholder is the blog name.
+#: includes/emails/class-sensei-email-teacher-started-course.php:60
 msgid "Your student has started a course"
 msgstr ""
 
 #: includes/enrolment/class-sensei-course-enrolment-manager.php:515
-msgid ""
-"<strong>Sensei LMS</strong> has detected an incompatible version of "
-"WooCommerce Paid Courses. Learners will not be able to access their courses "
-"until it is upgraded to version 2.0.0 or greater."
+msgid "<strong>Sensei LMS</strong> has detected an incompatible version of WooCommerce Paid Courses. Students will not be able to access their courses until it is upgraded to version 2.0.0 or greater."
 msgstr ""
 
 #: includes/enrolment/class-sensei-course-manual-enrolment-provider.php:62
@@ -6584,37 +4666,27 @@ msgstr ""
 
 #: includes/enrolment/class-sensei-course-manual-enrolment-provider.php:260
 #: tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php:191
-msgid ""
-"Learner manual enrollment <strong>was not migrated</strong> from a legacy "
-"version of Sensei LMS."
+msgid "Student manual enrollment <strong>was not migrated</strong> from a legacy version of Sensei LMS."
 msgstr ""
 
 #: includes/enrolment/class-sensei-course-manual-enrolment-provider.php:263
-msgid ""
-"Learner <strong>did not have</strong> course progress at the time of manual "
-"enrollment migration."
+msgid "Student <strong>did not have</strong> course progress at the time of manual enrollment migration."
 msgstr ""
 
 #: includes/enrolment/class-sensei-course-manual-enrolment-provider.php:266
 #: tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php:213
 #: tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php:236
-msgid ""
-"Learner <strong>did have</strong> course progress at the time of manual "
-"enrollment migration."
+msgid "Student <strong>did have</strong> course progress at the time of manual enrollment migration."
 msgstr ""
 
 #: includes/enrolment/class-sensei-course-manual-enrolment-provider.php:269
 #: tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php:214
-msgid ""
-"Manual enrollment <strong>was not provided</strong> to the learner on "
-"legacy migration."
+msgid "Manual enrollment <strong>was not provided</strong> to the student on legacy migration."
 msgstr ""
 
 #: includes/enrolment/class-sensei-course-manual-enrolment-provider.php:271
 #: tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php:237
-msgid ""
-"Manual enrollment <strong>was provided</strong> to the learner on legacy "
-"migration."
+msgid "Manual enrollment <strong>was provided</strong> to the student on legacy migration."
 msgstr ""
 
 #: includes/rest-api/class-sensei-rest-api-course-structure-controller.php:87
@@ -6648,6 +4720,12 @@ msgstr ""
 
 #: includes/rest-api/class-sensei-rest-api-course-structure-controller.php:282
 msgid "Module title"
+msgstr ""
+
+#: includes/rest-api/class-sensei-rest-api-course-structure-controller.php:286
+#: assets/blocks/course-outline/module-block/module-edit.js:189
+#: assets/dist/blocks/single-course.js:6
+msgid "Module description"
 msgstr ""
 
 #: includes/rest-api/class-sensei-rest-api-course-structure-controller.php:290
@@ -6735,8 +4813,8 @@ msgstr ""
 msgid "No plugins to update found."
 msgstr ""
 
-#: includes/rest-api/class-sensei-rest-api-extensions-controller.php:318
 #. translators: Placeholder is the name of the plugin that failed.
+#: includes/rest-api/class-sensei-rest-api-extensions-controller.php:318
 msgid "Failed to update plugin %s"
 msgstr ""
 
@@ -6762,9 +4840,7 @@ msgid "Missing a temporary folder to store the uploaded file."
 msgstr ""
 
 #: includes/rest-api/class-sensei-rest-api-import-controller.php:209
-msgid ""
-"Failed to write the uploaded file to disk. Please contact your host to fix "
-"a possible permissions issue."
+msgid "Failed to write the uploaded file to disk. Please contact your host to fix a possible permissions issue."
 msgstr ""
 
 #: includes/rest-api/class-sensei-rest-api-import-controller.php:213
@@ -6787,8 +4863,8 @@ msgstr ""
 msgid "Job file could not be deleted."
 msgstr ""
 
-#: includes/rest-api/class-sensei-rest-api-import-controller.php:340
 #. translators: %1$s placeholder is object type; %2$s is result descriptor (success, error).
+#: includes/rest-api/class-sensei-rest-api-import-controller.php:340
 msgid "Number of %1$s items with %2$s result"
 msgstr ""
 
@@ -6886,47 +4962,42 @@ msgstr ""
 msgid "Other free-text purpose."
 msgstr ""
 
-#: includes/sensei-functions.php:238
 #. translators: Placeholders are the hook tag and the version which it was deprecated, respectively.
+#: includes/sensei-functions.php:238
 msgid "SENSEI: The hook '%1$s', has been deprecated since '%2$s'."
 msgstr ""
 
-#: includes/sensei-functions.php:243
 #. translators: Placeholder is the alternative action name.
+#: includes/sensei-functions.php:243
 msgid "Please use '%s' instead."
 msgstr ""
 
-#: includes/shortcodes/class-sensei-legacy-shortcodes.php:44
 #. translators: %s is the name of the shortcode.
+#: includes/shortcodes/class-sensei-legacy-shortcodes.php:44
 msgid "Shortcode `[%s]`"
 msgstr ""
 
-#: includes/shortcodes/class-sensei-legacy-shortcodes.php:47
 #. translators: %1$s is the name of the shortcode; %2$s is page URL with shortcode; %3$s is URL for shortcode documentation.
-msgid ""
-"The shortcode `[%1$s]` (used on: %2$s) has been deprecated since Sensei "
-"v1.9.0. Check %3$s for alternatives."
+#: includes/shortcodes/class-sensei-legacy-shortcodes.php:47
+msgid "The shortcode `[%1$s]` (used on: %2$s) has been deprecated since Sensei v1.9.0. Check %3$s for alternatives."
 msgstr ""
 
-#: includes/shortcodes/class-sensei-legacy-shortcodes.php:71
 #. translators: %1$s is the name of the shortcode; %2$s is the link to Sensei documentation.
-msgid ""
-"The Sensei LMS shortcode <strong>[%1$s]</strong> has been deprecated and "
-"will soon be removed. Check <a href=\"%2$s\" rel=\"noopener\">Sensei LMS "
-"documentation</a> for alternatives. Only site editors will see this notice."
+#: includes/shortcodes/class-sensei-legacy-shortcodes.php:71
+msgid "The Sensei LMS shortcode <strong>[%1$s]</strong> has been deprecated and will soon be removed. Check <a href=\"%2$s\" rel=\"noopener\">Sensei LMS documentation</a> for alternatives. Only site editors will see this notice."
 msgstr ""
 
 #: includes/shortcodes/class-sensei-shortcode-course-categories.php:96
 msgid "No course categories found."
 msgstr ""
 
-#: includes/shortcodes/class-sensei-shortcode-course-page.php:57
 #. translators: Placeholder is the example shortcode text.
+#: includes/shortcodes/class-sensei-shortcode-course-page.php:57
 msgid "Please supply a course ID for the shortcode: %s"
 msgstr ""
 
-#: includes/shortcodes/class-sensei-shortcode-course-page.php:68
 #. translators: Placeholders are the shortcode name and the error message.
+#: includes/shortcodes/class-sensei-shortcode-course-page.php:68
 msgid "Error rendering %1$s shortcode - %2$s"
 msgstr ""
 
@@ -6984,13 +5055,13 @@ msgstr ""
 msgid "You can review and publish the new course here:  "
 msgstr ""
 
-#: templates/emails/learner-completed-course.php:34
 #. translators: Placeholder is the translated text for "passed" or "failed".
+#: templates/emails/learner-completed-course.php:34
 msgid "You have completed and %1$s the course"
 msgstr ""
 
-#: templates/emails/learner-graded-quiz.php:34
 #. translators: Placeholder is the translated text for "passed" or "failed".
+#: templates/emails/learner-graded-quiz.php:34
 msgid "You %1$s the lesson"
 msgstr ""
 
@@ -6998,23 +5069,23 @@ msgstr ""
 msgid "with a grade of"
 msgstr ""
 
-#: templates/emails/learner-graded-quiz.php:47
 #. translators: Placeholder is the passmark as a percentage.
+#: templates/emails/learner-graded-quiz.php:47
 msgid "The pass mark is %1$s"
 msgstr ""
 
-#: templates/emails/learner-graded-quiz.php:56
 #. translators: Placeholders are an opening and closing <a> tag linking to the quiz permalink.
+#: templates/emails/learner-graded-quiz.php:56
 msgid "You can review your grade and your answers %1$shere%2$s."
 msgstr ""
 
-#: templates/emails/new-message-reply.php:36
 #. translators: Placeholder is the post type (e.g. course or lesson)
+#: templates/emails/new-message-reply.php:36
 msgid "has replied to your private message regarding the %1$s"
 msgstr ""
 
-#: templates/emails/new-message-reply.php:51
 #. translators: Placeholder is an opening an closing <a> tag linking to the comment.
+#: templates/emails/new-message-reply.php:51
 msgid "You can view the message and reply %1$shere%2$s."
 msgstr ""
 
@@ -7026,24 +5097,24 @@ msgstr ""
 msgid "Your student"
 msgstr ""
 
-#: templates/emails/teacher-completed-course.php:38
 #. translators: Placeholder is the translated text for "passed" or "failed".
+#: templates/emails/teacher-completed-course.php:38
 msgid "has completed and %1$s the course"
 msgstr ""
 
+#. translators: Placeholders are an opening and closing <a> tag linking to the course's learners page in wp-admin.
 #: templates/emails/teacher-completed-course.php:49
 #: templates/emails/teacher-started-course.php:42
-#. translators: Placeholders are an opening and closing <a> tag linking to the course's learners page in wp-admin.
-msgid "Manage this course's learners %1$shere%2$s."
+msgid "Manage this course's students %1$shere%2$s."
 msgstr ""
 
 #: templates/emails/teacher-completed-lesson.php:35
 msgid "has completed the lesson"
 msgstr ""
 
-#: templates/emails/teacher-completed-lesson.php:44
 #. translators: Placeholders are an opening and closing <a> tag linking to the lesson's learners page.
-msgid "Manage this lesson's learners %1$shere%2$s."
+#: templates/emails/teacher-completed-lesson.php:44
+msgid "Manage this lesson's students %1$shere%2$s."
 msgstr ""
 
 #: templates/emails/teacher-new-course-assignment.php:36
@@ -7054,13 +5125,13 @@ msgstr ""
 msgid "You can edit the assigned course here: "
 msgstr ""
 
-#: templates/emails/teacher-new-message.php:38
 #. translators: Placeholder is the post type (e.g. course or lesson).
+#: templates/emails/teacher-new-message.php:38
 msgid "has sent you a private message regarding the %1$s"
 msgstr ""
 
-#: templates/emails/teacher-new-message.php:53
 #. translators: Placeholders are an opening and closing <a> tag linking to the Message permalink.
+#: templates/emails/teacher-new-message.php:53
 msgid "You can reply to this message %1$shere%2$s."
 msgstr ""
 
@@ -7072,8 +5143,8 @@ msgstr ""
 msgid "for grading."
 msgstr ""
 
-#: templates/emails/teacher-quiz-submitted.php:48
 #. translators: Placeholders are an opening and closing <a> tag linking to the grading page for the quiz.
+#: templates/emails/teacher-quiz-submitted.php:48
 msgid "You can grade this quiz %1$shere%2$s."
 msgstr ""
 
@@ -7091,6 +5162,13 @@ msgstr ""
 
 #: templates/single-quiz/question-type-file-upload.php:51
 msgid "Uploading a new file will replace your existing one:"
+msgstr ""
+
+#: templates/single-quiz/question-type-single-line.php:28
+#: assets/blocks/quiz/answer-blocks/multi-line.js:13
+#: assets/blocks/quiz/answer-blocks/single-line.js:13
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Answer:"
 msgstr ""
 
 #: templates/teacher-archive.php:35
@@ -7154,9 +5232,7 @@ msgid "Show hierarchy"
 msgstr ""
 
 #: widgets/class-sensei-course-component-widget.php:30
-msgid ""
-"This widget will output a list of Courses - New, Featured, Free, Paid, "
-"Active, Completed."
+msgid "This widget will output a list of Courses - New, Featured, Free, Paid, Active, Completed."
 msgstr ""
 
 #: widgets/class-sensei-course-component-widget.php:32
@@ -7208,177 +5284,1932 @@ msgstr ""
 msgid "More Lessons"
 msgstr ""
 
-#: includes/admin/class-sensei-setup-wizard-pages.php:60
-msgctxt "page_slug"
-msgid "courses-overview"
+#: assets/admin/exit-survey/form.js:63
+#: assets/dist/admin/exit-survey/index.js:1
+msgid "Quick Feedback"
 msgstr ""
 
-#: includes/admin/class-sensei-setup-wizard-pages.php:64
-msgctxt "page_slug"
-msgid "my-courses"
+#: assets/admin/exit-survey/form.js:65
+#: assets/dist/admin/exit-survey/index.js:1
+msgid "If you have a moment, please let us know why you are deactivating so that we can work to improve our product."
 msgstr ""
 
-#: includes/admin/class-sensei-setup-wizard-pages.php:68
-msgctxt "page_slug"
-msgid "course-completed"
+#: assets/admin/exit-survey/form.js:80
+#: assets/dist/admin/exit-survey/index.js:1
+msgid "Submit Feedback"
 msgstr ""
 
-#: includes/class-sensei-course-results.php:50
-msgctxt "post type single url slug"
-msgid "course"
+#: assets/admin/exit-survey/form.js:87
+#: assets/dist/admin/exit-survey/index.js:1
+msgid "Skip Feedback"
 msgstr ""
 
-#: includes/class-sensei-course.php:695
-msgctxt "column name"
+#: assets/admin/exit-survey/reasons.js:12
+#: assets/dist/admin/exit-survey/index.js:1
+msgid "I no longer need the plugin"
+msgstr ""
+
+#: assets/admin/exit-survey/reasons.js:16
+#: assets/dist/admin/exit-survey/index.js:1
+msgid "The plugin isn't working"
+msgstr ""
+
+#: assets/admin/exit-survey/reasons.js:17
+#: assets/dist/admin/exit-survey/index.js:1
+msgid "What isn't working properly?"
+msgstr ""
+
+#: assets/admin/exit-survey/reasons.js:21
+#: assets/dist/admin/exit-survey/index.js:1
+msgid "I'm looking for different functionality"
+msgstr ""
+
+#: assets/admin/exit-survey/reasons.js:22
+#: assets/dist/admin/exit-survey/index.js:1
+msgid "What functionality is missing?"
+msgstr ""
+
+#: assets/admin/exit-survey/reasons.js:26
+#: assets/dist/admin/exit-survey/index.js:1
+msgid "I found a better plugin"
+msgstr ""
+
+#: assets/admin/exit-survey/reasons.js:27
+#: assets/dist/admin/exit-survey/index.js:1
+msgid "What's the name of the plugin?"
+msgstr ""
+
+#: assets/admin/exit-survey/reasons.js:31
+#: assets/dist/admin/exit-survey/index.js:1
+msgid "It's a temporary deactivation"
+msgstr ""
+
+#: assets/admin/exit-survey/reasons.js:36
+#: assets/dist/admin/exit-survey/index.js:1
+msgid "Why are you deactivating?"
+msgstr ""
+
+#: assets/blocks/button/button-edit.js:36
+#: assets/dist/blocks/shared.js:1
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/blocks/single-page.js:1
+msgid "Add text…"
+msgstr ""
+
+#: assets/blocks/button/button-settings.js:24
+#: assets/blocks/course-outline/module-block/module-settings.js:18
+#: assets/dist/blocks/shared.js:1
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/blocks/single-page.js:1
+msgid "Border settings"
+msgstr ""
+
+#: assets/blocks/button/button-settings.js:28
+#: assets/dist/blocks/shared.js:1
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/blocks/single-page.js:1
+#: assets/shared/blocks/course-progress/course-progress-settings.js:39
+msgid "Border radius"
+msgstr ""
+
+#: assets/blocks/button/button-settings.js:55
+#: assets/dist/blocks/shared.js:1
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/blocks/single-page.js:1
+msgid "Change button alignment"
+msgstr ""
+
+#: assets/blocks/button/color-hooks.js:43
+#: assets/blocks/course-outline/lesson-block/lesson-edit.js:124
+#: assets/dist/blocks/shared.js:1
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/blocks/single-page.js:1
+msgid "Background color"
+msgstr ""
+
+#: assets/blocks/button/color-hooks.js:47
+#: assets/blocks/course-outline/lesson-block/lesson-edit.js:128
+#: assets/blocks/course-outline/module-block/module-edit.js:217
+#: assets/blocks/course-progress-block/course-progress-edit.js:118
+#: assets/dist/blocks/shared.js:1
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/blocks/single-page.js:1
+msgid "Text color"
+msgstr ""
+
+#: assets/blocks/button/index.js:28
+#: assets/dist/blocks/shared.js:1
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/blocks/single-page.js:1
+msgid "Fill"
+msgstr ""
+
+#: assets/blocks/button/index.js:32
+#: assets/blocks/course-outline/outline-block/index.js:21
+#: assets/dist/blocks/shared.js:1
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/blocks/single-page.js:1
+msgid "Outline"
+msgstr ""
+
+#: assets/blocks/button/index.js:36
+#: assets/dist/blocks/shared.js:1
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/blocks/single-page.js:1
+msgid "Link"
+msgstr ""
+
+#: assets/blocks/conditional-content-block/conditional-content-settings.js:89
+#: assets/dist/blocks/single-course.js:6
+msgid "Visible when"
+msgstr ""
+
+#: assets/blocks/conditional-content-block/conditional-content-settings.js:106
+#: assets/dist/blocks/single-course.js:6
+msgid "Remove condition"
+msgstr ""
+
+#: assets/blocks/conditional-content-block/index.js:16
+#: assets/dist/blocks/single-course.js:6
+msgid "Conditional Content"
+msgstr ""
+
+#: assets/blocks/conditional-content-block/index.js:17
+#: assets/dist/blocks/single-course.js:6
+msgid "Content inside this block will be shown to the selected subgroup of users."
+msgstr ""
+
+#: assets/blocks/conditional-content-block/index.js:23
+#: assets/dist/blocks/single-course.js:6
+msgid "Content"
+msgstr ""
+
+#: assets/blocks/conditional-content-block/index.js:24
+#: assets/blocks/quiz/question-block/question-view.js:56
+#: assets/dist/blocks/quiz/index.js:6
+#: assets/dist/blocks/single-course.js:6
+msgid "Locked"
+msgstr ""
+
+#: assets/blocks/conditional-content-block/index.js:25
+#: assets/dist/blocks/single-course.js:6
+msgid "Private"
+msgstr ""
+
+#: assets/blocks/conditional-content-block/index.js:28
+#: assets/dist/blocks/single-course.js:6
+msgid "Restrict"
+msgstr ""
+
+#: assets/blocks/conditional-content-block/index.js:29
+#: assets/dist/blocks/single-course.js:6
+msgid "Access"
+msgstr ""
+
+#: assets/blocks/contact-teacher-block/index.js:18
+#: assets/dist/blocks/shared.js:1
+msgid "Enable a registered user to contact the teacher. This block is only displayed if the user is logged in and private messaging is enabled."
+msgstr ""
+
+#: assets/blocks/course-completed-actions/index.js:16
+#: assets/dist/blocks/single-page.js:1
+msgid "Course Completed Actions"
+msgstr ""
+
+#: assets/blocks/course-completed-actions/index.js:17
+#: assets/dist/blocks/single-page.js:1
+msgid "Prompt students to take action after completing a course."
+msgstr ""
+
+#: assets/blocks/course-completed-actions/index.js:25
+#: assets/blocks/lesson-actions/lesson-actions-block/index.js:22
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/blocks/single-page.js:1
+msgid "Actions"
+msgstr ""
+
+#: assets/blocks/course-completed-actions/index.js:26
+#: assets/blocks/lesson-actions/lesson-actions-block/index.js:23
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/blocks/single-page.js:1
+msgid "Buttons"
+msgstr ""
+
+#: assets/blocks/course-completed-actions/index.js:28
+#: assets/dist/blocks/single-page.js:1
+msgid "View Certificate"
+msgstr ""
+
+#: assets/blocks/course-completed-actions/index.js:44
+#: assets/dist/blocks/single-page.js:1
+msgid "Prompt students to find more courses."
+msgstr ""
+
+#: assets/blocks/course-completed-actions/index.js:50
+#: assets/dist/blocks/single-page.js:1
+msgid "Archive"
+msgstr ""
+
+#. translators: Error message.
+#: assets/blocks/course-outline/course-outline-store.js:66
+#: assets/dist/blocks/single-course.js:6
+msgid "Course modules and lessons could not be updated. %s"
+msgstr ""
+
+#: assets/blocks/course-outline/lesson-block/index.js:15
+#: assets/dist/blocks/single-course.js:6
+msgid "Where your course content lives."
+msgstr ""
+
+#: assets/blocks/course-outline/lesson-block/index.js:21
+#: assets/dist/blocks/single-course.js:6
+msgid "Start learning"
+msgstr ""
+
+#: assets/blocks/course-outline/lesson-block/lesson-edit.js:61
+#: assets/dist/blocks/single-course.js:6
+msgid "Unsaved"
+msgstr ""
+
+#: assets/blocks/course-outline/lesson-block/lesson-edit.js:63
+#: assets/dist/blocks/single-course.js:6
+msgid "Draft"
+msgstr ""
+
+#: assets/blocks/course-outline/lesson-block/lesson-edit.js:93
+#: assets/dist/blocks/single-course.js:6
+msgid "Add Lesson"
+msgstr ""
+
+#: assets/blocks/course-outline/lesson-block/lesson-settings.js:48
+#: assets/dist/blocks/single-course.js:6
+msgid "Edit lesson"
+msgstr ""
+
+#: assets/blocks/course-outline/lesson-block/lesson-settings.js:59
+#: assets/dist/blocks/single-course.js:6
+msgid "Edit details such as lesson content, prerequisite, quiz settings and more."
+msgstr ""
+
+#: assets/blocks/course-outline/lesson-block/lesson-settings.js:66
+#: assets/dist/blocks/single-course.js:6
+msgid "Typography"
+msgstr ""
+
+#: assets/blocks/course-outline/module-block/index.js:17
+#: assets/dist/blocks/single-course.js:6
+msgid "Group related lessons together."
+msgstr ""
+
+#: assets/blocks/course-outline/module-block/index.js:20
+#: assets/dist/blocks/single-course.js:6
+msgid "Course Module"
+msgstr ""
+
+#: assets/blocks/course-outline/module-block/index.js:21
+#: assets/dist/blocks/single-course.js:6
+msgid "Group"
+msgstr ""
+
+#: assets/blocks/course-outline/module-block/index.js:29
+#: assets/blocks/course-outline/outline-block/index.js:44
+#: assets/dist/blocks/single-course.js:6
+msgid "About Module"
+msgstr ""
+
+#: assets/blocks/course-outline/module-block/index.js:46
+#: assets/blocks/course-outline/outline-block/index.js:27
+#: assets/blocks/course-results-block/index.js:29
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-page.js:1
+msgid "Filled"
+msgstr ""
+
+#: assets/blocks/course-outline/module-block/index.js:51
+#: assets/blocks/course-outline/outline-block/index.js:32
+#: assets/blocks/course-results-block/index.js:34
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-page.js:1
+msgid "Minimal"
+msgstr ""
+
+#: assets/blocks/course-outline/module-block/module-edit.js:157
+#: assets/dist/blocks/single-course.js:6
+msgid "Module name"
+msgstr ""
+
+#: assets/blocks/course-outline/module-block/module-edit.js:215
+#: assets/dist/blocks/single-course.js:6
+msgid "Main color"
+msgstr ""
+
+#: assets/blocks/course-outline/module-block/module-edit.js:220
+#: assets/dist/blocks/single-course.js:6
+msgid "Border color"
+msgstr ""
+
+#: assets/blocks/course-outline/module-block/module-settings.js:24
+#: assets/blocks/course-outline/outline-block/outline-settings.js:43
+#: assets/blocks/course-results-block/course-results-settings.js:30
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-page.js:1
+msgid "Border"
+msgstr ""
+
+#: assets/blocks/course-outline/module-block/module-settings.js:25
+#: assets/dist/blocks/single-course.js:6
+msgid "Toggle to enable the border."
+msgstr ""
+
+#: assets/blocks/course-outline/outline-block/index.js:15
+#: assets/blocks/course-outline/outline-block/outline-placeholder.js:21
+#: assets/dist/blocks/single-course.js:6
+msgid "Course Outline"
+msgstr ""
+
+#: assets/blocks/course-outline/outline-block/index.js:16
+#: assets/dist/blocks/single-course.js:6
+msgid "Manage your Sensei LMS course outline."
+msgstr ""
+
+#: assets/blocks/course-outline/outline-block/index.js:22
+#: assets/dist/blocks/single-course.js:6
+msgid "Structure"
+msgstr ""
+
+#: assets/blocks/course-outline/outline-block/index.js:61
+#: assets/dist/blocks/single-course.js:6
+msgid "First Lesson"
+msgstr ""
+
+#: assets/blocks/course-outline/outline-block/index.js:70
+#: assets/dist/blocks/single-course.js:6
+msgid "Second Lesson"
+msgstr ""
+
+#: assets/blocks/course-outline/outline-block/outline-appender.js:54
+#: assets/dist/blocks/single-course.js:6
+msgid "Add Module or Lesson"
+msgstr ""
+
+#: assets/blocks/course-outline/outline-block/outline-placeholder.js:23
+#: assets/dist/blocks/single-course.js:6
+msgid "Build and display a course outline. A course is made up of modules (optional) and lessons. You can use modules to group related lessons together."
+msgstr ""
+
+#: assets/blocks/course-outline/outline-block/outline-placeholder.js:33
+#: assets/dist/blocks/single-course.js:6
+msgid "Create a module"
+msgstr ""
+
+#: assets/blocks/course-outline/outline-block/outline-placeholder.js:40
+#: assets/dist/blocks/single-course.js:6
+msgid "Create a lesson"
+msgstr ""
+
+#: assets/blocks/course-outline/outline-block/outline-settings.js:34
+#: assets/dist/blocks/single-course.js:6
+msgid "Collapsible modules"
+msgstr ""
+
+#: assets/blocks/course-outline/outline-block/outline-settings.js:35
+#: assets/dist/blocks/single-course.js:6
+msgid "Modules can be collapsed or expanded."
+msgstr ""
+
+#: assets/blocks/course-outline/outline-block/outline-settings.js:44
+#: assets/blocks/course-results-block/course-results-settings.js:31
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-page.js:1
+msgid "Toggle the border for all modules."
+msgstr ""
+
+#: assets/blocks/course-outline/status-preview/status-control/index.js:45
+#: assets/dist/blocks/single-course.js:6
+msgid "Preview a status. The actual status that the student sees is determined by their progress in the course."
+msgstr ""
+
+#: assets/blocks/course-progress-block/course-progress-edit.js:110
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:201
+#: assets/dist/blocks/quiz/index.js:6
+#: assets/dist/blocks/single-course.js:6
+msgid "Progress bar color"
+msgstr ""
+
+#: assets/blocks/course-progress-block/course-progress-edit.js:114
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:210
+#: assets/dist/blocks/quiz/index.js:6
+#: assets/dist/blocks/single-course.js:6
+msgid "Progress bar background color"
+msgstr ""
+
+#: assets/blocks/course-progress-block/index.js:15
+#: assets/dist/blocks/single-course.js:6
+msgid "Display the user's progress in the course. This block is only displayed if the user is enrolled."
+msgstr ""
+
+#: assets/blocks/course-progress-block/index.js:20
+#: assets/blocks/lesson-actions/reset-lesson-block/index.js:27
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Progress"
+msgstr ""
+
+#: assets/blocks/course-progress-block/index.js:21
+#: assets/dist/blocks/single-course.js:6
+msgid "Bar"
+msgstr ""
+
+#. translators: Mock lesson number.
+#: assets/blocks/course-results-block/course-results-edit.js:36
+#: assets/dist/blocks/single-page.js:1
+msgid "Lesson %s"
+msgstr ""
+
+#: assets/blocks/course-results-block/course-results-edit.js:145
+#: assets/blocks/learner-courses-block/learner-courses-edit.js:140
+#: assets/dist/blocks/single-page.js:1
 msgid "Course Title"
 msgstr ""
 
-#: includes/class-sensei-course.php:696
-msgctxt "column name"
-msgid "Pre-requisite Course"
+#: assets/blocks/course-results-block/course-results-edit.js:148
+#: assets/dist/blocks/single-page.js:1
+msgid "Module A"
 msgstr ""
 
-#: includes/class-sensei-course.php:697
-msgctxt "column name"
-msgid "Category"
+#: assets/blocks/course-results-block/course-results-edit.js:154
+#: assets/dist/blocks/single-page.js:1
+msgid "Module B"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2357
-msgctxt "column name"
-msgid "Lesson Title"
+#: assets/blocks/course-results-block/course-results-edit.js:160
+#: assets/dist/blocks/single-page.js:1
+msgid "Module C"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2358
-msgctxt "column name"
-msgid "Course"
+#: assets/blocks/course-results-block/course-results-edit.js:175
+#: assets/dist/blocks/single-page.js:1
+msgid "Module color"
 msgstr ""
 
-#: includes/class-sensei-lesson.php:2359
-msgctxt "column name"
-msgid "Pre-requisite Lesson"
+#: assets/blocks/course-results-block/course-results-edit.js:179
+#: assets/dist/blocks/single-page.js:1
+msgid "Module text color"
 msgstr ""
 
-#: includes/class-sensei-question.php:78
-msgctxt "column name"
-msgid "Question"
+#: assets/blocks/course-results-block/course-results-edit.js:183
+#: assets/dist/blocks/single-page.js:1
+msgid "Module border color"
 msgstr ""
 
-#: includes/class-sensei-question.php:79
-msgctxt "column name"
-msgid "Type"
+#: assets/blocks/course-results-block/index.js:14
+#: assets/dist/blocks/single-page.js:1
+msgid "Course Results"
 msgstr ""
 
-#: includes/class-sensei-question.php:80
-msgctxt "column name"
-msgid "Categories"
+#: assets/blocks/course-results-block/index.js:15
+#: assets/dist/blocks/single-page.js:1
+msgid "Show course results to students on the course completion page."
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:206
-msgctxt "post type single url base"
-msgid "course"
+#: assets/blocks/course-results-block/index.js:23
+#: assets/dist/blocks/single-page.js:1
+msgid "Results"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:312
-msgctxt "post type single slug"
-msgid "lesson"
+#: assets/blocks/course-results-block/index.js:24
+#: assets/dist/blocks/single-page.js:1
+msgid "Completion"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:363
-msgctxt "post type single slug"
-msgid "quiz"
+#: assets/blocks/learner-courses-block/index.js:14
+#: assets/blocks/learner-courses-block/index.js:20
+#: assets/dist/blocks/single-page.js:1
+msgid "Student Courses"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:410
-msgctxt "post type single slug"
-msgid "question"
+#: assets/blocks/learner-courses-block/index.js:15
+#: assets/dist/blocks/single-page.js:1
+msgid "Manage what students see on their dashboard. This block is only displayed to logged in students."
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:458
-msgctxt "post type single slug"
-msgid "multiple_question"
+#: assets/blocks/learner-courses-block/index.js:22
+#: assets/dist/blocks/single-page.js:1
+msgid "Dashboard"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:494
-msgctxt "post type single slug"
-msgid "messages"
+#: assets/blocks/learner-courses-block/learner-courses-edit.js:99
+#: assets/dist/blocks/single-page.js:1
+msgid "All Courses"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:546
-msgctxt "taxonomy general name"
-msgid "Course Categories"
+#: assets/blocks/learner-courses-block/learner-courses-edit.js:146
+#: assets/dist/blocks/single-page.js:1
+msgid "Category Name"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:592
-msgctxt "taxonomy general name"
-msgid "Quiz Types"
+#: assets/blocks/learner-courses-block/learner-courses-edit.js:152
+#: assets/dist/blocks/single-page.js:1
+msgid "This is a preview of the course description…"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:629
-msgctxt "taxonomy general name"
-msgid "Question Types"
+#: assets/blocks/learner-courses-block/learner-courses-settings.js:36
+#: assets/dist/blocks/single-page.js:1
+msgid "Featured image"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:667
-msgctxt "taxonomy general name"
-msgid "Question Categories"
+#: assets/blocks/learner-courses-block/learner-courses-settings.js:44
+#: assets/blocks/quiz/question-description-block/index.js:19
+#: assets/dist/blocks/quiz/index.js:6
+#: assets/dist/blocks/single-page.js:1
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:143
+msgid "Description"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:712
-msgctxt "taxonomy general name"
-msgid "Lesson Tags"
+#: assets/blocks/learner-courses-block/learner-courses-settings.js:48
+#: assets/dist/blocks/single-page.js:1
+msgid "Progress bar"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:547
-msgctxt "taxonomy singular name"
-msgid "Course Category"
+#: assets/blocks/learner-courses-block/learner-courses-settings.js:55
+#: assets/dist/blocks/single-page.js:1
+msgid "List view"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:593
-msgctxt "taxonomy singular name"
-msgid "Quiz Type"
+#: assets/blocks/learner-courses-block/learner-courses-settings.js:60
+#: assets/dist/blocks/single-page.js:1
+msgid "Grid view"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:630
-msgctxt "taxonomy singular name"
+#: assets/blocks/learner-courses-block/learner-courses-settings.js:68
+#: assets/dist/blocks/single-page.js:1
+msgid "Primary color"
+msgstr ""
+
+#: assets/blocks/learner-courses-block/learner-courses-settings.js:73
+#: assets/dist/blocks/single-page.js:1
+msgid "Accent color"
+msgstr ""
+
+#: assets/blocks/learner-courses-block/learner-courses-settings.js:82
+#: assets/dist/blocks/single-page.js:1
+msgid "Course settings"
+msgstr ""
+
+#: assets/blocks/learner-courses-block/learner-courses-settings.js:101
+#: assets/dist/blocks/single-page.js:1
+msgid "Styling"
+msgstr ""
+
+#: assets/blocks/learner-courses-block/learner-courses-settings.js:106
+#: assets/dist/blocks/single-page.js:1
+msgid "Layout"
+msgstr ""
+
+#: assets/blocks/learner-courses-block/learner-courses-settings.js:138
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:191
+#: assets/dist/blocks/quiz/index.js:6
+#: assets/dist/blocks/shared.js:1
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/blocks/single-page.js:1
+#: assets/shared/blocks/settings.js:60
+msgid "Color settings"
+msgstr ""
+
+#: assets/blocks/learner-messages-button-block/index.js:25
+#: assets/dist/blocks/single-page.js:1
+msgid "Enable a student to view their messages. This block is only displayed if the student is logged in and private messaging is enabled."
+msgstr ""
+
+#: assets/blocks/learner-messages-button-block/index.js:29
+#: assets/dist/blocks/single-page.js:1
+msgid "Student Messages Button"
+msgstr ""
+
+#: assets/blocks/learner-messages-button-block/messages-disabled-notice.js:33
+#: assets/dist/blocks/single-page.js:1
+msgid "You have added the \"Student Messages Button\" block to your editor, but messages are disabled in your settings."
+msgstr ""
+
+#: assets/blocks/learner-messages-button-block/messages-disabled-notice.js:42
+#: assets/dist/blocks/single-page.js:1
+msgid "Go to disabled messages setting"
+msgstr ""
+
+#: assets/blocks/lesson-actions/complete-lesson-block/index.js:19
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Enable a student to mark the lesson as complete. This block is only displayed if the lesson has no quiz or the quiz is optional."
+msgstr ""
+
+#: assets/blocks/lesson-actions/complete-lesson-block/index.js:25
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Finish"
+msgstr ""
+
+#: assets/blocks/lesson-actions/complete-lesson-block/index.js:27
+#: assets/blocks/lesson-actions/next-lesson-block/index.js:27
+#: assets/blocks/lesson-actions/reset-lesson-block/index.js:29
+#: assets/blocks/lesson-actions/view-quiz-block/index.js:23
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Button"
+msgstr ""
+
+#: assets/blocks/lesson-actions/lesson-actions-block/index.js:15
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Lesson Actions"
+msgstr ""
+
+#: assets/blocks/lesson-actions/lesson-actions-block/index.js:16
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Enable a student to perform specific actions for a lesson."
+msgstr ""
+
+#: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-settings.js:48
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Preview lesson state"
+msgstr ""
+
+#: assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-settings.js:55
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Additional Actions"
+msgstr ""
+
+#: assets/blocks/lesson-actions/next-lesson-block/index.js:19
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Enable a student to move to the next lesson. This block is only displayed if the current lesson has been completed."
+msgstr ""
+
+#: assets/blocks/lesson-actions/next-lesson-block/index.js:25
+#: assets/data-port/export/export-select-content-page.js:59
+#: assets/data-port/import/upload/upload-page.js:72
+#: assets/dist/blocks/single-lesson.js:1
+#: assets/dist/data-port/export.js:1
+#: assets/dist/data-port/import.js:1
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/features-selection.js:100
+#: assets/setup-wizard/features/installation-feedback.js:92
+#: assets/setup-wizard/features/installation-feedback.js:103
+#: assets/setup-wizard/purpose/index.js:164
+#: assets/setup-wizard/welcome/index.js:67
+#: assets/setup-wizard/welcome/usage-modal.js:81
+msgid "Continue"
+msgstr ""
+
+#: assets/blocks/lesson-actions/reset-lesson-block/index.js:19
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Enable a student to reset their progress. This block is only displayed if the lesson is completed and has no quiz, or the quiz is completed and retakes are enabled."
+msgstr ""
+
+#: assets/blocks/lesson-actions/reset-lesson-block/index.js:25
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Restart"
+msgstr ""
+
+#: assets/blocks/lesson-actions/reset-lesson-block/index.js:26
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Revert"
+msgstr ""
+
+#: assets/blocks/lesson-actions/view-quiz-block/index.js:17
+#: assets/blocks/lesson-actions/view-quiz-block/index.js:27
+#: assets/dist/blocks/single-lesson.js:1
+msgid "View Quiz"
+msgstr ""
+
+#: assets/blocks/lesson-actions/view-quiz-block/index.js:19
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Enable a student to view the quiz."
+msgstr ""
+
+#: assets/blocks/lesson-properties/index.js:14
+#: assets/blocks/lesson-properties/index.js:25
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Lesson Properties"
+msgstr ""
+
+#: assets/blocks/lesson-properties/index.js:15
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Add lesson properties such as length and difficulty."
+msgstr ""
+
+#: assets/blocks/lesson-properties/index.js:20
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Metadata"
+msgstr ""
+
+#: assets/blocks/lesson-properties/index.js:22
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Complexity"
+msgstr ""
+
+#: assets/blocks/lesson-properties/lesson-properties-edit.js:29
+#: assets/dist/blocks/single-lesson.js:1
+msgid "Properties"
+msgstr ""
+
+#: assets/blocks/lesson-properties/lesson-properties-edit.js:39
+#: assets/blocks/lesson-properties/lesson-properties-edit.js:72
+#: assets/dist/blocks/single-lesson.js:1
+msgid "minute"
+msgid_plural "minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/blocks/quiz/answer-blocks/file-upload.js:13
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Browse…"
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/gap-fill.js:41
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Text before the gap"
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/gap-fill.js:64
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Add right answers. Separate with commas or the Enter key."
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/gap-fill.js:74
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Text after the gap"
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/index.js:40
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Select from a list of options."
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/index.js:53
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Add at least one right and one wrong answer."
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/index.js:57
+#: assets/blocks/quiz/answer-blocks/index.js:93
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Add a right answer to this question."
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/index.js:61
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Add a wrong answer to this question."
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/index.js:69
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Select whether a statement is true or false."
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/index.js:80
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Fill in the blank."
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/index.js:94
+#: assets/blocks/quiz/answer-blocks/index.js:95
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Add text before and after the gap."
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/index.js:100
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Short answer to an open-ended question."
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/index.js:110
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Long answer to an open-ended question."
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/index.js:120
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Upload a file or document."
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js:54
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Add Answer"
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js:70
+#: assets/blocks/quiz/answer-blocks/true-false.js:53
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Right"
+msgstr ""
+
+#: assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js:71
+#: assets/blocks/quiz/answer-blocks/true-false.js:54
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Wrong"
+msgstr ""
+
+#: assets/blocks/quiz/answer-feedback-block/answer-feedback-toggle.js:45
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Show feedback to students after they submit the quiz."
+msgstr ""
+
+#: assets/blocks/quiz/answer-feedback-block/answer-feedback.js:18
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Enter feedback to be displayed if a student gets this answer right. Type / to choose a block."
+msgstr ""
+
+#: assets/blocks/quiz/answer-feedback-block/answer-feedback.js:25
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Enter feedback to be displayed if a student gets this answer wrong. Type / to choose a block."
+msgstr ""
+
+#: assets/blocks/quiz/answer-feedback-block/index.js:32
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Correct Answer Feedback"
+msgstr ""
+
+#: assets/blocks/quiz/answer-feedback-block/index.js:34
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Display correct answer feedback."
+msgstr ""
+
+#: assets/blocks/quiz/answer-feedback-block/index.js:45
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Incorrect Answer Feedback"
+msgstr ""
+
+#: assets/blocks/quiz/answer-feedback-block/index.js:47
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Display incorrect answer feedback."
+msgstr ""
+
+#: assets/blocks/quiz/category-question-block/category-question-edit.js:75
+#: assets/blocks/quiz/category-question-block/index.js:19
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Category Question"
+msgstr ""
+
+#. translators: placeholder is number of questions to show from category.
+#: assets/blocks/quiz/category-question-block/category-question-edit.js:82
+#: assets/dist/blocks/quiz/index.js:6
+msgid "%d question"
+msgid_plural "%d questions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/blocks/quiz/category-question-block/category-question-settings.js:101
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Category Question Settings"
+msgstr ""
+
+#: assets/blocks/quiz/category-question-block/category-question-settings.js:106
+#: assets/dist/blocks/quiz/index.js:6
+msgid "No question categories exist."
+msgstr ""
+
+#: assets/blocks/quiz/category-question-block/category-question-settings.js:134
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:63
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Number of Questions"
+msgstr ""
+
+#. translators: The underlying error message.
+#: assets/blocks/quiz/category-question-block/category-question-settings.js:149
+#: assets/dist/blocks/quiz/index.js:6
+msgid "An error occurred while retrieving questions: %s"
+msgstr ""
+
+#. translators: Placeholder is number of questions in category.
+#: assets/blocks/quiz/category-question-block/category-question-settings.js:166
+#: assets/dist/blocks/quiz/index.js:6
+msgid "The selected category has %d question."
+msgid_plural "The selected category has %d questions."
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/blocks/quiz/category-question-block/index.js:22
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Pull questions from a question category."
+msgstr ""
+
+#: assets/blocks/quiz/category-question-block/index.js:25
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Example Category"
+msgstr ""
+
+#: assets/blocks/quiz/category-question-block/index.js:31
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Assign a category to this question."
+msgstr ""
+
+#: assets/blocks/quiz/question-answers-block/index.js:19
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Answers"
+msgstr ""
+
+#: assets/blocks/quiz/question-answers-block/index.js:21
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Question Answers."
+msgstr ""
+
+#: assets/blocks/quiz/question-block/index.js:23
+#: assets/dist/blocks/quiz/index.js:6
+msgid "The building block of all quizzes."
+msgstr ""
+
+#: assets/blocks/quiz/question-block/index.js:25
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Example Quiz Question"
+msgstr ""
+
+#: assets/blocks/quiz/question-block/index.js:31
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Add a title to this question."
+msgstr ""
+
+#: assets/blocks/quiz/question-block/question-block-helpers.js:19
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Any updates made to this question will also update it in any other quiz that includes it."
+msgstr ""
+
+#: assets/blocks/quiz/question-block/question-block-helpers.js:24
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Shared Question"
+msgstr ""
+
+#: assets/blocks/quiz/question-block/question-settings.js:34
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Question Settings"
+msgstr ""
+
+#: assets/blocks/quiz/question-block/question-type-toolbar.js:31
+#: assets/blocks/quiz/question-block/question-type-toolbar.js:35
+#: assets/dist/blocks/quiz/index.js:6
 msgid "Question Type"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:668
-msgctxt "taxonomy singular name"
-msgid "Question Category"
+#: assets/blocks/quiz/question-block/question-view.js:62
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Question Details"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:713
-msgctxt "taxonomy singular name"
-msgid "Lesson Tag"
+#: assets/blocks/quiz/question-block/question-view.js:66
+#: assets/dist/blocks/quiz/index.js:6
+msgid "You are not allowed to edit this question."
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:575
-msgctxt "taxonomy archive slug"
-msgid "course-category"
+#: assets/blocks/quiz/question-block/settings/question-grading-notes-settings.js:20
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Grading Notes"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:613
-msgctxt "taxonomy archive slug"
-msgid "quiz-type"
+#: assets/blocks/quiz/question-block/single-question.js:51
+#: assets/blocks/quiz/quiz-block/quiz-validation.js:34
+#: assets/dist/blocks/quiz/index.js:6
+msgid "View issues"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:652
-msgctxt "taxonomy archive slug"
-msgid "question-type"
+#: assets/blocks/quiz/question-block/single-question.js:58
+#: assets/dist/blocks/quiz/index.js:6
+msgid "This question is incomplete."
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:697
-msgctxt "taxonomy archive slug"
-msgid "question-category"
+#: assets/blocks/quiz/question-block/single-question.js:66
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Validation"
 msgstr ""
 
-#: includes/class-sensei-posttypes.php:740
-msgctxt "taxonomy archive slug"
-msgid "lesson-tag"
+#: assets/blocks/quiz/question-block/single-question.js:72
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Incomplete questions added to a quiz won't be displayed to the student."
 msgstr ""
 
-#: includes/class-sensei.php:1448
-msgctxt "plugin action link"
-msgid "Configure"
+#: assets/blocks/quiz/question-description-block/index.js:22
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Question Description."
+msgstr ""
+
+#: assets/blocks/quiz/question-description-block/question-description.js:30
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Question Description"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/index.js:21
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Evaluate progress and strengthen understanding of course concepts."
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/index.js:26
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Exam"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/index.js:28
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Test"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/index.js:29
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Assessment"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/index.js:30
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Evaluation"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/index.js:40
+#: assets/dist/blocks/quiz/index.js:6
+msgid "First Example Question"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/index.js:46
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Second Example Question"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:26
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Single page"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:30
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Multi-Page"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:77
+#: assets/dist/blocks/quiz/index.js:6
+msgid "per page"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:108
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Quiz styling"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:112
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Adjust how your quiz is displayed to your students."
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:119
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:123
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Pagination"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:146
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Progress Bar"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:151
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Show Progress Bar"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:162
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Radius"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:165
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:178
+#: assets/dist/blocks/quiz/index.js:6
+msgid "PX"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:175
+#: assets/dist/blocks/quiz/index.js:6
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-page.js:1
+#: assets/shared/blocks/course-progress/course-progress-settings.js:50
+msgid "Height"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/pagination-settings.js:247
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Quiz pagination"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/questions-modal/actions.js:43
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Add Selected"
+msgstr ""
+
+#. translators: Number of selected questions.
+#: assets/blocks/quiz/quiz-block/questions-modal/actions.js:46
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Add Selected (%s)"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/questions-modal/actions.js:55
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Clear Selected"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/questions-modal/filter.js:86
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Search questions"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/questions-modal/index.js:54
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Unable to add the selected question(s). Please make sure you are still logged in and try again."
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:138
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Toggle all visible questions selection."
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/questions-modal/questions.js:156
+#: assets/dist/blocks/quiz/index.js:6
+msgid "No questions found."
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/quiz-appender.js:44
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Category Question(s)"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/quiz-appender.js:49
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Existing Question(s)"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/quiz-appender.js:55
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Add new or existing question(s)"
+msgstr ""
+
+#: assets/blocks/quiz/quiz-block/quiz-edit.js:70
+#: assets/blocks/quiz/quiz-block/quiz-validation.js:114
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Lesson Quiz"
+msgstr ""
+
+#. Translators: placeholder is the numer of incomplete questions.
+#: assets/blocks/quiz/quiz-block/quiz-validation.js:42
+#: assets/dist/blocks/quiz/index.js:6
+msgid "There is %d incomplete question in this lesson's quiz."
+msgid_plural "There are %d incomplete questions in this lesson's quiz."
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/blocks/quiz/quiz-block/quiz-validation.js:120
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Incomplete questions won't be displayed to the student when taking the quiz."
+msgstr ""
+
+#. translators: Error message.
+#: assets/blocks/quiz/quiz-store.js:139
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Quiz settings and questions could not be loaded. %s"
+msgstr ""
+
+#. translators: Error message.
+#: assets/blocks/quiz/quiz-store.js:158
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Quiz settings and questions could not be updated. %s"
+msgstr ""
+
+#: assets/blocks/take-course-block/index.js:17
+#: assets/dist/blocks/single-course.js:6
+msgid "Course Signup"
+msgstr ""
+
+#: assets/blocks/take-course-block/index.js:18
+#: assets/dist/blocks/single-course.js:6
+msgid "Enable a registered user to start the course. This block is only displayed if the user is not already enrolled."
+msgstr ""
+
+#: assets/blocks/take-course-block/index.js:23
+#: assets/dist/blocks/single-course.js:6
+msgid "Start"
+msgstr ""
+
+#: assets/blocks/take-course-block/index.js:24
+#: assets/dist/blocks/single-course.js:6
+msgid "Sign up"
+msgstr ""
+
+#: assets/blocks/take-course-block/index.js:25
+#: assets/dist/blocks/single-course.js:6
+msgid "Signup"
+msgstr ""
+
+#: assets/blocks/take-course-block/index.js:26
+#: assets/dist/blocks/single-course.js:6
+msgid "Enrol"
+msgstr ""
+
+#: assets/blocks/take-course-block/index.js:29
+#: assets/dist/blocks/single-course.js:6
+msgid "Take course"
+msgstr ""
+
+#: assets/blocks/take-course-block/index.js:33
+#: assets/dist/blocks/single-course.js:6
+msgid "Take Course"
+msgstr ""
+
+#: assets/blocks/view-results-block/index.js:18
+#: assets/dist/blocks/single-course.js:6
+msgid "Enable a student to view their course results."
+msgstr ""
+
+#: assets/data-port/export/export-page.js:32
+#: assets/dist/data-port/export.js:1
+msgid "Export content to a CSV file"
+msgstr ""
+
+#: assets/data-port/export/export-progress-page.js:96
+#: assets/dist/data-port/export.js:1
+msgid "Export More Content"
+msgstr ""
+
+#: assets/data-port/export/export-select-content-page.js:32
+#: assets/dist/data-port/export.js:1
+msgid "Which type of content would you like to export?"
+msgstr ""
+
+#: assets/data-port/import.js:42
+#: assets/dist/data-port/import.js:1
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/index.js:58
+msgid "An error has occurred while fetching the data. Please try again later!"
+msgstr ""
+
+#: assets/data-port/import.js:47
+#: assets/dist/data-port/import.js:1
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/index.js:63
+msgid "Error details:"
+msgstr ""
+
+#: assets/data-port/import/done/done-page.js:40
+#: assets/dist/data-port/import.js:1
+msgid "The following content was not imported. Please make the necessary corrections to the import file and try again."
+msgstr ""
+
+#: assets/data-port/import/done/done-page.js:54
+#: assets/dist/data-port/import.js:1
+msgid "Partial"
+msgstr ""
+
+#: assets/data-port/import/done/done-page.js:56
+#: assets/dist/data-port/import.js:1
+msgid "The following content was partially imported. The import process encountered some issues that you can resolve manually by clicking the link and making the necessary adjustments."
+msgstr ""
+
+#: assets/data-port/import/done/done-page.js:72
+#: assets/dist/data-port/import.js:1
+msgid "Fetching log details…"
+msgstr ""
+
+#: assets/data-port/import/done/done-page.js:78
+#: assets/dist/data-port/import.js:1
+msgid "Failed to load import log."
+msgstr ""
+
+#: assets/data-port/import/done/done-page.js:81
+#: assets/dist/data-port/import.js:1
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/installation-feedback.js:85
+msgid "Retry"
+msgstr ""
+
+#: assets/data-port/import/done/done-page.js:95
+#: assets/dist/data-port/import.js:1
+msgid "The following content was imported:"
+msgstr ""
+
+#: assets/data-port/import/done/done-page.js:107
+#: assets/dist/data-port/import.js:1
+msgid "No content was imported."
+msgstr ""
+
+#: assets/data-port/import/done/done-page.js:113
+#: assets/dist/data-port/import.js:1
+msgid "Import More Content"
+msgstr ""
+
+#: assets/data-port/import/done/import-log.js:47
+#: assets/dist/data-port/import.js:1
+msgid "File"
+msgstr ""
+
+#: assets/data-port/import/done/import-log.js:49
+#: assets/dist/data-port/import.js:1
+msgid "Title"
+msgstr ""
+
+#: assets/data-port/import/done/import-log.js:50
+#: assets/dist/data-port/import.js:1
+msgid "Line #"
+msgstr ""
+
+#: assets/data-port/import/done/import-success-results.js:17
+#: assets/dist/data-port/import.js:1
+msgid "question"
+msgid_plural "questions"
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/data-port/import/import-progress/import-progress-page.js:26
+#: assets/dist/data-port/import.js:1
+msgid "Importing"
+msgstr ""
+
+#: assets/data-port/import/import-progress/import-progress-page.js:28
+#: assets/dist/data-port/import.js:1
+msgid "Your content is now being imported…"
+msgstr ""
+
+#: assets/data-port/import/levels.js:9
+#: assets/dist/data-port/import.js:1
+msgid "Courses CSV File"
+msgstr ""
+
+#: assets/data-port/import/levels.js:13
+#: assets/dist/data-port/import.js:1
+msgid "Lessons CSV File"
+msgstr ""
+
+#: assets/data-port/import/levels.js:17
+#: assets/dist/data-port/import.js:1
+msgid "Questions CSV File"
+msgstr ""
+
+#: assets/data-port/import/steps.js:17
+#: assets/dist/data-port/import.js:1
+msgid "Upload CSV Files"
+msgstr ""
+
+#: assets/data-port/import/steps.js:27
+#: assets/dist/data-port/import.js:1
+msgid "Done"
+msgstr ""
+
+#: assets/data-port/import/upload-level/upload-level.js:41
+#: assets/dist/data-port/import.js:1
+msgid "Only CSV files are supported."
+msgstr ""
+
+#: assets/data-port/import/upload-level/upload-level.js:97
+#: assets/dist/data-port/import.js:1
+msgid "Delete File"
+msgstr ""
+
+#: assets/data-port/import/upload-level/upload-level.js:139
+#: assets/dist/data-port/import.js:1
+msgid "Uploading…"
+msgstr ""
+
+#: assets/data-port/import/upload-level/upload-level.js:140
+#: assets/dist/data-port/import.js:1
+msgid "Upload"
+msgstr ""
+
+#: assets/data-port/import/upload/upload-page.js:29
+#: assets/dist/data-port/import.js:1
+msgid "Import content from a CSV file"
+msgstr ""
+
+#: assets/data-port/import/upload/upload-page.js:32
+#: assets/dist/data-port/import.js:1
+msgid "This tool enables you to import courses, lessons, and questions from a CSV file. Please review the {{link}}documentation{{/link}} to learn more about the expected file structure."
+msgstr ""
+
+#: assets/data-port/import/upload/upload-page.js:56
+#: assets/dist/data-port/import.js:1
+msgid "Choose one or more CSV files to upload from your computer."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "%d point"
+msgid_plural "%d points"
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Add question description or type / to choose a block."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Question Title"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Pass Required"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "What students see when reviewing their quiz after grading."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "If student does not pass quiz"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Indicate which questions are incorrect."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Show correct answers."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Show “Answer Feedback” text."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Auto Grade"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Automatically grade Multiple Choice, True/False and Gap Fill questions that have a non-zero point value."
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Allow Retakes"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Random Question Order"
+msgstr ""
+
+#: assets/dist/blocks/quiz/index.js:6
+msgid "Display a random selection of questions."
+msgstr ""
+
+#. translators: placeholder is number of completed lessons in the course.
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-page.js:1
+#: assets/shared/blocks/course-progress/course-progress.js:73
+msgid "%d Completed"
+msgid_plural "%d Completed"
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/dist/blocks/single-course.js:6
+#: assets/dist/blocks/single-page.js:1
+#: assets/shared/blocks/course-progress/course-progress-settings.js:33
+msgid "Progress bar settings"
+msgstr ""
+
+#: assets/dist/data-port/export.js:1
+msgid "This tool enables you to export courses, lessons, and questions to CSV files. These files are bundled together and downloaded to your computer in .zip format."
+msgstr ""
+
+#: assets/dist/data-port/export.js:1
+#: assets/dist/data-port/import.js:1
+#: assets/shared/helpers/labels.js:13
+msgid "Error"
+msgstr ""
+
+#: assets/dist/data-port/export.js:1
+#: assets/dist/data-port/import.js:1
+#: assets/shared/helpers/labels.js:14
+msgid "Warning"
+msgstr ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/store.js:151
+msgid "Update completed successfully!"
+msgstr ""
+
+#. translators: Placeholder is the underlying error message.
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/store.js:156
+msgid "There was an error while updating the plugin: %1$s"
+msgstr ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/store.js:162
+msgid "Installation completed successfully!"
+msgstr ""
+
+#. translators: Placeholder is the underlying error message.
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/store.js:167
+msgid "There was an error while installing the plugin: %1$s"
+msgstr ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/extension-actions.js:67
+msgid "In progress…"
+msgstr ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/dist/setup-wizard/index.js:6
+#: assets/extensions/extension-actions.js:82
+#: assets/extensions/main.js:87
+#: assets/setup-wizard/data/normalizer.js:25
+msgid "Installed"
+msgstr ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/extension-actions.js:94
+msgid "Install"
+msgstr ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/extension-actions.js:131
+msgid "More details"
+msgstr ""
+
+#. translators: placeholder is the version number.
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/update-notification/multiple.js:36
+#: assets/extensions/update-notification/woocommerce-notice.js:112
+msgid "version %s"
+msgstr ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/update-notification/update-available.js:23
+msgid "Update available"
+msgstr ""
+
+#. translators: placeholder is number of updates available.
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/update-notification/update-available.js:26
+msgid "%d update available"
+msgid_plural "%d updates available"
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/update-notification/index.js:52
+msgid "Updating…"
+msgstr ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/update-notification/index.js:60
+msgid "Update all"
+msgstr ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/update-notification/woocommerce-notice.js:39
+msgid "Your site needs to be connected to your WooCommerce.com account before this extension can be updated."
+msgid_plural "Your site needs to be connected to your WooCommerce.com account before these extensions can be updated."
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/update-notification/woocommerce-notice.js:71
+msgid "WooCommerce needs to be activated before this extension can be updated."
+msgid_plural "WooCommerce needs to be activated before these extensions can be updated."
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/update-notification/woocommerce-notice.js:80
+msgid "Activate WooCommerce"
+msgstr ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/update-notification/woocommerce-notice.js:55
+msgid "WooCommerce needs to be installed before this extension can be updated."
+msgid_plural "WooCommerce needs to be installed before these extensions can be updated."
+msgstr[0] ""
+msgstr[1] ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/update-notification/woocommerce-notice.js:64
+msgid "Install WooCommerce"
+msgstr ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/card.js:62
+msgid "New version"
+msgstr ""
+
+#: assets/dist/extensions/index.js:1
+#: assets/extensions/main.js:56
+msgid "No extensions found."
+msgstr ""
+
+#: assets/dist/js/admin/course-edit.js:1
+#: assets/js/admin/course-theme-sidebar.js:40
+msgid "This does not change the theme of your site. It only applies to logged in users when viewing the course."
+msgstr ""
+
+#: assets/dist/js/admin/course-edit.js:1
+#: assets/js/admin/course-theme-sidebar.js:46
+msgid "Theme"
+msgstr ""
+
+#: assets/dist/js/admin/course-edit.js:1
+#: assets/js/admin/course-theme-sidebar.js:51
+msgid "Sensei Theme"
+msgstr ""
+
+#: assets/dist/js/admin/course-edit.js:1
+#: assets/js/admin/course-theme-sidebar.js:55
+msgid "WordPress Theme"
+msgstr ""
+
+#: assets/dist/js/admin/course-edit.js:1
+#: assets/dist/js/admin/lesson-edit.js:1
+#: assets/dist/setup-wizard/index.js:6
+#: assets/js/admin/blocks-toggling-control.js:152
+#: assets/setup-wizard/features/feature-description.js:35
+msgid "Learn more"
+msgstr ""
+
+#: assets/dist/js/admin/course-edit.js:1
+#: assets/dist/js/admin/lesson-edit.js:1
+#: assets/js/admin/blocks-toggling-control.js:163
+msgid "You've just added your first Sensei block. This will change how your course page appears. Be sure to preview your page before saving changes."
+msgstr ""
+
+#: assets/dist/js/admin/course-edit.js:1
+#: assets/dist/js/admin/lesson-edit.js:1
+#: assets/js/admin/blocks-toggling-control.js:178
+msgid "Are you sure you want to remove all Sensei blocks? This will change how your course page appears. Be sure to preview your page before saving changes."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/feature-status.js:25
+msgid "Installing plugin"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/feature-status.js:32
+msgid "Error installing plugin"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/feature-status.js:40
+msgid "Plugin installed"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/feature-status.js:47
+msgid "Purchasing plugin"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/data/normalizer.js:28
+msgid "per year"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+msgid "Get improved features and faster fixes by sharing non-sensitive data via {{link}}usage tracking{{/link}} that shows us how Sensei LMS is used. No personal data is tracked or stored."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/welcome/usage-modal.js:57
+msgid "Build a Better Sensei LMS"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/welcome/usage-modal.js:69
+msgid "Yes, count me in!"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:24
+msgid "Share your knowledge"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:25
+msgid "You are a hobbyist interested in sharing your knowledge."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:32
+msgid "Generate income"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:33
+msgid "You would like to generate additional income for yourself or your business."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:40
+msgid "Promote your business"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:41
+msgid "You own a business and would like to use online courses to promote it."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:48
+msgid "Provide certification training"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:49
+msgid "You want to help people become certified professionals."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:56
+msgid "Train employees"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:57
+msgid "You work at a company that regularly trains new or existing employees."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:64
+msgid "Educate students"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:65
+msgid "You are an educator who would like to create an online classroom."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:72
+msgid "Other"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/feature-description-utils.js:31
+msgid " and "
+msgstr ""
+
+#. translators: Placeholder is the plugin titles.
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/feature-description-utils.js:35
+msgid "* WooCommerce is required to receive updates for %1$s."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/confirmation-modal.js:40
+msgid "Would you like to install the following features now?"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/confirmation-modal.js:61
+msgid "You won't have access to this functionality until the extensions have been installed."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/confirmation-modal.js:69
+msgid "WooCommerce.com will open in a new tab so that you can complete the purchase process."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/confirmation-modal.js:87
+msgid "I'll do it later"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/confirmation-modal.js:96
+msgid "Install now"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/installation-feedback.js:67
+msgid "Installing…"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/installation-feedback.js:135
+msgid "Retry?"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/features-selection.js:58
+msgid "No features found."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/features/index.js:204
+msgid "Enhance your online courses with these optional features."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/welcome/index.js:46
+msgid "Welcome to Sensei LMS!"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/welcome/index.js:51
+msgid "Thank you for choosing Sensei LMS!"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/welcome/index.js:57
+msgid "This setup wizard will help you get started creating online courses more quickly. It is optional and should take only a few minutes."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/welcome/index.js:77
+msgid "Not right now"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/steps.js:18
+msgid "Welcome"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:119
+msgid "What is your primary purpose for offering online courses?"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/purpose/index.js:124
+msgid "Choose any that apply"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/steps.js:23
+msgid "Purpose"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/steps.js:28
+msgid "Features"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+msgid "You're ready to start creating online courses!"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+msgid "Join our mailing list"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+msgid "What's next?"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/ready/index.js:64
+msgid "Create some courses"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+msgid "You're ready to create online courses."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/ready/index.js:81
+msgid "Create a course"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/ready/index.js:89
+#: assets/setup-wizard/ready/index.js:103
+msgid "Import content"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/ready/index.js:90
+msgid "Transfer existing content to your site — just import a CSV file."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/ready/index.js:111
+#: assets/setup-wizard/ready/index.js:134
+msgid "Install a sample course"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/ready/index.js:116
+msgid "Install the {{em}}Getting Started with Sensei LMS{{/em}} course."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/ready/index.js:142
+msgid "The sample course could not be imported. Please try again."
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/ready/index.js:154
+msgid "Visit SenseiLMS.com to learn how to {{link}}create your first course.{{/link}}"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/ready/index.js:186
+msgid "Exit to Courses"
+msgstr ""
+
+#: assets/dist/setup-wizard/index.js:6
+#: assets/setup-wizard/steps.js:33
+msgid "Ready"
 msgstr ""

--- a/templates/emails/teacher-completed-course.php
+++ b/templates/emails/teacher-completed-course.php
@@ -46,7 +46,7 @@ printf( esc_html__( 'has completed and %1$s the course', 'sensei-lms' ), esc_htm
 <p style="<?php echo esc_attr( $small ); ?>">
 <?php
 // translators: Placeholders are an opening and closing <a> tag linking to the course's learners page in wp-admin.
-printf( esc_html__( 'Manage this course\'s learners %1$shere%2$s.', 'sensei-lms' ), '<a href="' . esc_url( admin_url( 'admin.php?page=sensei_learners&view=learners&course_id=' . $course_id ) ) . '">', '</a>' );
+printf( esc_html__( 'Manage this course\'s students %1$shere%2$s.', 'sensei-lms' ), '<a href="' . esc_url( admin_url( 'admin.php?page=sensei_learners&view=learners&course_id=' . $course_id ) ) . '">', '</a>' );
 ?>
 </p>
 

--- a/templates/emails/teacher-completed-lesson.php
+++ b/templates/emails/teacher-completed-lesson.php
@@ -41,7 +41,7 @@ $large = 'text-align: center !important;font-size: 350% !important;line-height: 
 <p style="<?php echo esc_attr( $small ); ?>">
 <?php
 // translators: Placeholders are an opening and closing <a> tag linking to the lesson's learners page.
-printf( esc_html__( 'Manage this lesson\'s learners %1$shere%2$s.', 'sensei-lms' ), '<a href="' . esc_url( admin_url( 'admin.php?page=sensei_learners&view=learners&lesson_id=' . $lesson_id ) ) . '">', '</a>' );
+printf( esc_html__( 'Manage this lesson\'s students %1$shere%2$s.', 'sensei-lms' ), '<a href="' . esc_url( admin_url( 'admin.php?page=sensei_learners&view=learners&lesson_id=' . $lesson_id ) ) . '">', '</a>' );
 ?>
 </p>
 

--- a/templates/emails/teacher-started-course.php
+++ b/templates/emails/teacher-started-course.php
@@ -39,7 +39,7 @@ $large = 'text-align: center !important;font-size: 350% !important;line-height: 
 <p style="<?php echo esc_attr( $small ); ?>">
 <?php
 // translators: Placeholders are an opening and closing <a> tag linking to the course's learners page in wp-admin.
-printf( esc_html__( 'Manage this course\'s learners %1$shere%2$s.', 'sensei-lms' ), '<a href="' . esc_url( admin_url( 'admin.php?page=sensei_learners&view=learners&course_id=' . $course_id ) ) . '">', '</a>' );
+printf( esc_html__( 'Manage this course\'s students %1$shere%2$s.', 'sensei-lms' ), '<a href="' . esc_url( admin_url( 'admin.php?page=sensei_learners&view=learners&course_id=' . $course_id ) ) . '">', '</a>' );
 ?>
 </p>
 

--- a/tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php
+++ b/tests/unit-tests/enrolment/test-class-sensei-course-manual-enrolment-provider.php
@@ -188,7 +188,7 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 
 		$debug          = $provider->debug( $student_id, $course_id );
 		$expected_debug = [
-			__( 'Learner manual enrollment <strong>was not migrated</strong> from a legacy version of Sensei LMS.', 'sensei-lms' ),
+			__( 'Student manual enrollment <strong>was not migrated</strong> from a legacy version of Sensei LMS.', 'sensei-lms' ),
 		];
 
 		$this->assertEquals( $expected_debug, $debug );
@@ -210,8 +210,8 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 
 		$debug          = $provider->debug( $student_id, $course_id );
 		$expected_debug = [
-			__( 'Learner <strong>did have</strong> course progress at the time of manual enrollment migration.', 'sensei-lms' ),
-			__( 'Manual enrollment <strong>was not provided</strong> to the learner on legacy migration.', 'sensei-lms' ),
+			__( 'Student <strong>did have</strong> course progress at the time of manual enrollment migration.', 'sensei-lms' ),
+			__( 'Manual enrollment <strong>was not provided</strong> to the student on legacy migration.', 'sensei-lms' ),
 		];
 
 		$this->assertEquals( $expected_debug, $debug );
@@ -233,8 +233,8 @@ class Sensei_Course_Manual_Enrolment_Provider_Test extends WP_UnitTestCase {
 
 		$debug          = $provider->debug( $student_id, $course_id );
 		$expected_debug = [
-			__( 'Learner <strong>did have</strong> course progress at the time of manual enrollment migration.', 'sensei-lms' ),
-			__( 'Manual enrollment <strong>was provided</strong> to the learner on legacy migration.', 'sensei-lms' ),
+			__( 'Student <strong>did have</strong> course progress at the time of manual enrollment migration.', 'sensei-lms' ),
+			__( 'Manual enrollment <strong>was provided</strong> to the student on legacy migration.', 'sensei-lms' ),
 		];
 
 		$this->assertEquals( $expected_debug, $debug );

--- a/tests/unit-tests/test-class-sensei-learners-main.php
+++ b/tests/unit-tests/test-class-sensei-learners-main.php
@@ -83,10 +83,10 @@ class Sensei_Learners_Main_Test extends WP_UnitTestCase {
 
 	public function enrolmentFilterTestCases() {
 		return [
-			'All learners'               => [ 'all', 9 ],
-			'Enrolled learners'          => [ 'enrolled', 6 ],
-			'Unenrolled learners'        => [ 'unenrolled', 3 ],
-			'Manually enrolled learners' => [ 'manual', 2 ],
+			'All students'               => [ 'all', 9 ],
+			'Enrolled students'          => [ 'enrolled', 6 ],
+			'Unenrolled students'        => [ 'unenrolled', 3 ],
+			'Manually enrolled students' => [ 'manual', 2 ],
 		];
 	}
 }


### PR DESCRIPTION
Fixes #4451
Trello: https://trello.com/c/NQx3rfMI/17-replace-all-instances-of-learner-with-student

## Changes proposed in this Pull Request

- Replaced learner -> student in all of the strings that are visible to the user
## Why I didn't change it in the code: 
- If it is going to be done it needs to be done in separate PR, not to make this one 2complicated 
- Public functions and block names CAN't be renamed without some bigger changes
- It will leave the codebase in half-state

## How I did it 
- I used .pot file to find all the user-facing occurrences
- Pot was easy to search and also includes files + lines where this occurrence happened
- After I replaced occurrences in the code I re-installed it and regenerated pot file

## Testing instructions
1. Go to the pot file -> see there aren't any msg that include **learner** **learners**
2. Start wp-admin with sensei plugin locally and go trough setting, see if there is any **learner**  left

