### PR TITLE
Implement the quiz pagination frontend

### DIFF
--- a/assets/css/_mixins.scss
+++ b/assets/css/_mixins.scss
@@ -35,7 +35,6 @@ $fontpath:          'includes/fonts/';
     font-weight: normal;
     line-height: 1em;
     width:1em;
-    text-align: right;
 }
 
 @mixin iconbefore()

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -391,12 +391,12 @@ a.sensei-certificate-link {
 		margin-bottom: 0;
 	}
 
-	ul {
+	ul.page-numbers {
 		display: flex;
 		gap: 0.5em;
-		list-style: none;
+		list-style: none !important;
 		margin: 0;
-		padding: 0;
+		padding: 0 !important;
 
 		li, span {
 			margin: 0;
@@ -436,7 +436,7 @@ a.sensei-certificate-link {
 		border-left: 2px solid;
 	}
 
-	button {
+	button[type="submit"] {
 		margin: 0;
 		padding: 0;
 		border: 0;
@@ -445,6 +445,7 @@ a.sensei-certificate-link {
 		text-decoration: underline;
 		text-transform: none;
 		font-weight: normal;
+		cursor: pointer;
 
 		&:hover {
 			color: inherit;

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -6,6 +6,7 @@
 /**
  * Variables
  */
+$tablet-breakpoint: 768px;
 
 /**
  * Functions
@@ -377,7 +378,7 @@ a.sensei-certificate-link {
 	gap: 1.5em;
 	margin: 1.618em 0;
 
-	@media only screen and (min-width: 768px) {
+	@media only screen and (min-width: $tablet-breakpoint) {
 		flex-direction: row;
 	}
 
@@ -386,7 +387,7 @@ a.sensei-certificate-link {
 		gap: 0.5em;
 		margin-bottom: 1em;
 
-		@media only screen and (min-width: 768px) {
+		@media only screen and (min-width: $tablet-breakpoint) {
 			margin-bottom: 0;
 		}
 
@@ -408,7 +409,7 @@ a.sensei-certificate-link {
 		display: flex;
 		order: 1;
 
-		@media only screen and (min-width: 768px) {
+		@media only screen and (min-width: $tablet-breakpoint) {
 			order: 0;
 		}
 	}
@@ -445,7 +446,7 @@ a.sensei-certificate-link {
 		display: flex;
 		align-items: center;
 
-		@media only screen and (min-width: 768px) {
+		@media only screen and (min-width: $tablet-breakpoint) {
 			margin-left: auto;
 		}
 
@@ -1144,7 +1145,7 @@ section.entry span.course-lesson-progress { margin-left: 10px; }
   }
 
 /* RESPOND */
-@media only screen and (min-width: 768px)  {
+@media only screen and (min-width: $tablet-breakpoint)  {
   #main .course  {
     .course-meta  {
       .course-start  {

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -456,6 +456,22 @@ a.sensei-certificate-link {
 	}
 }
 
+.sensei-quiz-pagination__prev-button {
+	&:before  {
+		@include iconbefore();
+		content: '\f104';
+		margin-right: 0.25em;
+	}
+}
+
+.sensei-quiz-pagination__next-button {
+	&:after  {
+		@include iconafter();
+		content: '\f105';
+		margin-left: 0.25em;
+	}
+}
+
 .quiz:not(.quiz-blocks), .lesson {
   button.quiz-submit  {
     &.complete  {

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -370,6 +370,88 @@ a.sensei-certificate-link {
   }
 }
 
+.sensei-quiz-pagination {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 1.5em;
+	margin: 1.618em 0;
+
+	@media (max-width: 667px) {
+		flex-direction: column;
+	}
+}
+
+.sensei-quiz-pagination__list {
+	flex-grow: 1;
+	gap: 0.5em;
+
+	@media (max-width: 667px) {
+		margin-bottom: 1em;
+	}
+
+	ul {
+		display: flex;
+		gap: 0.5em;
+		list-style: none;
+		margin: 0;
+		padding: 0;
+
+		li, span {
+			margin: 0;
+			padding: 0;
+		}
+	}
+}
+
+.sensei-quiz-pagination__actions {
+	display: flex;
+
+	@media (max-width: 667px) {
+		order: 1;
+	}
+}
+
+.sensei-quiz-pagination__nav {
+	display: flex;
+	align-items: center;
+
+	.wp-block-buttons {
+		gap: 0.5em;
+
+		.wp-block-button {
+			margin: 0;
+		}
+	}
+}
+
+.sensei-quiz-pagination__button-link {
+	display: inline-flex;
+
+	&:not(:first-child) {
+		margin-left: 0.5em;
+		padding-left: 0.5em;
+		border-left: 2px solid;
+	}
+
+	button {
+		margin: 0;
+		padding: 0;
+		border: 0;
+		color: inherit;
+		background-color: transparent;
+		text-decoration: underline;
+		text-transform: none;
+		font-weight: normal;
+
+		&:hover {
+			color: inherit;
+			background-color: transparent;
+			text-decoration: none;
+		}
+	}
+}
+
 .quiz:not(.quiz-blocks), .lesson {
   button.quiz-submit  {
     &.complete  {

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -440,8 +440,8 @@ a.sensei-certificate-link {
 		margin: 0;
 		padding: 0;
 		border: 0;
-		color: inherit;
-		background-color: transparent;
+		color: inherit !important;
+		background-color: transparent !important;
 		text-decoration: underline;
 		text-transform: none;
 		font-weight: normal;

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -417,7 +417,10 @@ a.sensei-certificate-link {
 .sensei-quiz-pagination__nav {
 	display: flex;
 	align-items: center;
-	margin-left: auto;
+
+	@media only screen and (min-width: 768px) {
+		margin-left: auto;
+	}
 
 	.wp-block-buttons {
 		gap: 0.5em;

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -417,6 +417,7 @@ a.sensei-certificate-link {
 .sensei-quiz-pagination__nav {
 	display: flex;
 	align-items: center;
+	margin-left: auto;
 
 	.wp-block-buttons {
 		gap: 0.5em;

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -370,7 +370,7 @@ a.sensei-certificate-link {
   }
 }
 
-.sensei-quiz-pagination {
+#sensei-quiz-pagination {
 	display: flex;
 	flex-flow: column wrap;
 	align-items: center;
@@ -380,98 +380,98 @@ a.sensei-certificate-link {
 	@media only screen and (min-width: 768px) {
 		flex-direction: row;
 	}
-}
 
-.sensei-quiz-pagination__list {
-	flex-grow: 1;
-	gap: 0.5em;
-	margin-bottom: 1em;
-
-	@media only screen and (min-width: 768px) {
-		margin-bottom: 0;
-	}
-
-	ul.page-numbers {
-		display: flex;
+	.sensei-quiz-pagination__list {
+		flex-grow: 1;
 		gap: 0.5em;
-		list-style: none !important;
-		margin: 0;
-		padding: 0 !important;
+		margin-bottom: 1em;
 
-		li, span {
+		@media only screen and (min-width: 768px) {
+			margin-bottom: 0;
+		}
+
+		ul.page-numbers {
+			display: flex;
+			gap: 0.5em;
 			margin: 0;
 			padding: 0;
+			list-style: none;
+
+			li, span {
+				margin: 0;
+				padding: 0;
+			}
 		}
 	}
-}
 
-.sensei-quiz-pagination__actions {
-	display: flex;
-	order: 1;
+	.sensei-quiz-pagination__actions {
+		display: flex;
+		order: 1;
 
-	@media only screen and (min-width: 768px) {
-		order: 0;
-	}
-}
-
-.sensei-quiz-pagination__nav {
-	display: flex;
-	align-items: center;
-
-	@media only screen and (min-width: 768px) {
-		margin-left: auto;
+		@media only screen and (min-width: 768px) {
+			order: 0;
+		}
 	}
 
-	.wp-block-buttons {
-		gap: 0.5em;
+	.sensei-quiz-pagination__action {
+		display: inline-flex;
 
-		.wp-block-button {
+		&:not(:first-child) {
+			margin-left: 0.5em;
+			padding-left: 0.5em;
+			border-left: 2px solid;
+		}
+
+		button {
 			margin: 0;
-		}
-	}
-}
-
-.sensei-quiz-pagination__button-link {
-	display: inline-flex;
-
-	&:not(:first-child) {
-		margin-left: 0.5em;
-		padding-left: 0.5em;
-		border-left: 2px solid;
-	}
-
-	button[type="submit"] {
-		margin: 0;
-		padding: 0;
-		border: 0;
-		color: inherit !important;
-		background-color: transparent !important;
-		text-decoration: underline;
-		text-transform: none;
-		font-weight: normal;
-		cursor: pointer;
-
-		&:hover {
+			padding: 0;
+			border: 0;
 			color: inherit;
 			background-color: transparent;
-			text-decoration: none;
+			text-decoration: underline;
+			text-transform: none;
+			font-weight: normal;
+			cursor: pointer;
+
+			&:hover {
+				color: inherit;
+				background-color: transparent;
+				text-decoration: none;
+			}
 		}
 	}
-}
 
-.sensei-quiz-pagination__prev-button {
-	&:before  {
-		@include iconbefore();
-		content: '\f104';
-		margin-right: 0.25em;
+	.sensei-quiz-pagination__nav {
+		display: flex;
+		align-items: center;
+
+		@media only screen and (min-width: 768px) {
+			margin-left: auto;
+		}
+
+		.wp-block-buttons {
+			gap: 0.5em;
+
+			.wp-block-button {
+				margin: 0;
+			}
+		}
 	}
-}
 
-.sensei-quiz-pagination__next-button {
-	&:after  {
-		@include iconafter();
-		content: '\f105';
-		margin-left: 0.25em;
+	.sensei-quiz-pagination__prev-button {
+		&:before  {
+			@include iconbefore();
+			content: '\f104';
+			margin-right: 0.25em;
+		}
+	}
+
+	.sensei-quiz-pagination__next-button {
+		&:after  {
+			@include iconafter();
+			content: '\f105';
+			margin-left: 0.25em;
+		}
 	}
 }
 

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -372,22 +372,23 @@ a.sensei-certificate-link {
 
 .sensei-quiz-pagination {
 	display: flex;
-	flex-wrap: wrap;
+	flex-flow: column wrap;
 	align-items: center;
 	gap: 1.5em;
 	margin: 1.618em 0;
 
-	@media (max-width: 667px) {
-		flex-direction: column;
+	@media only screen and (min-width: 768px) {
+		flex-direction: row;
 	}
 }
 
 .sensei-quiz-pagination__list {
 	flex-grow: 1;
 	gap: 0.5em;
+	margin-bottom: 1em;
 
-	@media (max-width: 667px) {
-		margin-bottom: 1em;
+	@media only screen and (min-width: 768px) {
+		margin-bottom: 0;
 	}
 
 	ul {
@@ -406,9 +407,10 @@ a.sensei-certificate-link {
 
 .sensei-quiz-pagination__actions {
 	display: flex;
+	order: 1;
 
-	@media (max-width: 667px) {
-		order: 1;
+	@media only screen and (min-width: 768px) {
+		order: 0;
 	}
 }
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1241,7 +1241,7 @@ class Sensei_Quiz {
 	 *
 	 * @return bool
 	 */
-	private static function can_take_quiz( int $quiz_id = null, int $user_id = null ): bool {
+	public static function can_take_quiz( int $quiz_id = null, int $user_id = null ): bool {
 
 		$quiz_id = $quiz_id ? $quiz_id : get_the_ID();
 		$user_id = $user_id ? $user_id : get_current_user_id();
@@ -1473,12 +1473,7 @@ class Sensei_Quiz {
 		remove_action( 'sensei_single_quiz_questions_after', array( 'Sensei_Quiz', 'action_buttons' ), 10 );
 
 		// Load the pagination template.
-		Sensei_Templates::get_template(
-			'single-quiz/pagination.php',
-			[
-				'can_take_quiz' => self::can_take_quiz(),
-			]
-		);
+		Sensei_Templates::get_template( 'single-quiz/pagination.php' );
 
 	}
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1344,15 +1344,10 @@ class Sensei_Quiz {
 		$sensei_question_loop['total_pages']    = 1;
 
 		$quiz_id             = get_the_ID();
-		$pagination_settings = [];
-
-		// Paginate the questions only if the user is taking the quiz.
-		if ( self::can_take_quiz( $quiz_id ) ) {
-			$pagination_settings = json_decode(
-				get_post_meta( $quiz_id, '_pagination', true ),
-				true
-			);
-		}
+		$pagination_settings = json_decode(
+			get_post_meta( $quiz_id, '_pagination', true ),
+			true
+		);
 
 		if ( ! empty( $pagination_settings['pagination_number'] ) ) {
 			$sensei_question_loop['posts_per_page'] = (int) $pagination_settings['pagination_number'];
@@ -1478,7 +1473,12 @@ class Sensei_Quiz {
 		remove_action( 'sensei_single_quiz_questions_after', array( 'Sensei_Quiz', 'action_buttons' ), 10 );
 
 		// Load the pagination template.
-		Sensei_Templates::get_template( 'single-quiz/pagination.php' );
+		Sensei_Templates::get_template(
+			'single-quiz/pagination.php',
+			[
+				'can_take_quiz' => self::can_take_quiz(),
+			]
+		);
 
 	}
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1285,6 +1285,7 @@ class Sensei_Quiz {
 		$sensei_question_loop['questions']      = [];
 		$sensei_question_loop['posts_per_page'] = -1;
 		$sensei_question_loop['current_page']   = 1;
+		$sensei_question_loop['total_pages']    = 1;
 
 		// Get the pagination settings and populate the loop object.
 		$pagination = json_decode(
@@ -1308,16 +1309,22 @@ class Sensei_Quiz {
 			return;
 		}
 
+		$sensei_question_loop['total'] = count( $all_questions );
+
 		// Paginate the questions.
 		if ( $sensei_question_loop['posts_per_page'] > 0 ) {
-			$offset              = $sensei_question_loop['posts_per_page'] * ( $sensei_question_loop['current_page'] - 1 );
-			$paginated_questions = array_slice( $all_questions, $offset, $sensei_question_loop['posts_per_page'] );
+			$offset         = $sensei_question_loop['posts_per_page'] * ( $sensei_question_loop['current_page'] - 1 );
+			$loop_questions = array_slice( $all_questions, $offset, $sensei_question_loop['posts_per_page'] );
+
+			// Calculate the number of pages.
+			$sensei_question_loop['total_pages'] = (int) ceil(
+				$sensei_question_loop['total'] / $sensei_question_loop['posts_per_page']
+			);
 		} else {
-			$paginated_questions = $all_questions;
+			$loop_questions = $all_questions;
 		}
 
-		$sensei_question_loop['total']     = count( $all_questions );
-		$sensei_question_loop['questions'] = $paginated_questions;
+		$sensei_question_loop['questions'] = $loop_questions;
 		$sensei_question_loop['quiz_id']   = get_the_ID();
 	}
 
@@ -1340,6 +1347,7 @@ class Sensei_Quiz {
 		$sensei_question_loop['quiz_id']        = '';
 		$sensei_question_loop['posts_per_page'] = -1;
 		$sensei_question_loop['current_page']   = 1;
+		$sensei_question_loop['total_pages']    = 1;
 
 	}
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1269,18 +1269,18 @@ class Sensei_Quiz {
 
 		// Check the lesson status.
 		$lesson_status = Sensei_Utils::user_lesson_status( $lesson_id, $user_id );
-		if ( $lesson_status && 'ungraded' === $lesson_status->comment_approved ) {
-			return false;
-		}
+		if ( $lesson_status ) {
+			$lesson_status = is_array( $lesson_status ) ? $lesson_status[0] : $lesson_status;
 
-		$lesson_status_comment_id = is_array( $lesson_status )
-			? $lesson_status[0]->comment_ID
-			: $lesson_status->comment_ID;
+			if ( 'ungraded' === $lesson_status->comment_approved ) {
+				return false;
+			}
 
-		// Check for a quiz grade.
-		$quiz_grade = get_comment_meta( $lesson_status_comment_id, 'grade', true );
-		if ( $quiz_grade ) {
-			return false;
+			// Check for a quiz grade.
+			$quiz_grade = get_comment_meta( $lesson_status->comment_ID, 'grade', true );
+			if ( $quiz_grade ) {
+				return false;
+			}
 		}
 
 		return true;

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1356,12 +1356,12 @@ class Sensei_Quiz {
 
 		if ( ! empty( $pagination_settings['pagination_number'] ) ) {
 			$sensei_question_loop['posts_per_page'] = (int) $pagination_settings['pagination_number'];
-		}
 
-		// phpcs:ignore WordPress.Security.NonceVerification -- Argument is used for pagination in the frontend.
-		if ( ! empty( $_GET['quiz-page'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification
-			$sensei_question_loop['current_page'] = max( 1, (int) $_GET['quiz-page'] );
+			// phpcs:ignore WordPress.Security.NonceVerification -- Argument is used for pagination in the frontend.
+			if ( ! empty( $_GET['quiz-page'] ) ) {
+				// phpcs:ignore WordPress.Security.NonceVerification
+				$sensei_question_loop['current_page'] = max( 1, (int) $_GET['quiz-page'] );
+			}
 		}
 
 		// Fetch the questions.

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1241,7 +1241,7 @@ class Sensei_Quiz {
 	 *
 	 * @return bool
 	 */
-	public function can_take_quiz( int $quiz_id = null, int $user_id = null ): bool {
+	private static function can_take_quiz( int $quiz_id = null, int $user_id = null ): bool {
 
 		$quiz_id = $quiz_id ? $quiz_id : get_the_ID();
 		$user_id = $user_id ? $user_id : get_current_user_id();
@@ -1347,7 +1347,7 @@ class Sensei_Quiz {
 		$pagination_settings = [];
 
 		// Paginate the questions only if the user is taking the quiz.
-		if ( Sensei()->quiz->can_take_quiz( $quiz_id ) ) {
+		if ( self::can_take_quiz( $quiz_id ) ) {
 			$pagination_settings = json_decode(
 				get_post_meta( $quiz_id, '_pagination', true ),
 				true
@@ -1493,7 +1493,7 @@ class Sensei_Quiz {
 		$quiz_id   = get_the_ID();
 		$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_id );
 
-		$can_take_quiz  = Sensei()->quiz->can_take_quiz( $quiz_id );
+		$can_take_quiz  = self::can_take_quiz( $quiz_id );
 		$can_reset_quiz = self::is_reset_allowed( $lesson_id );
 
 		if ( ! $can_take_quiz && ! $can_reset_quiz ) {

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -142,6 +142,10 @@ add_filter( 'sensei_get_question_template_data', array( 'Sensei_Question', 'mult
 add_filter( 'sensei_get_question_template_data', array( 'Sensei_Question', 'gap_fill_load_question_data' ), 10, 3 );
 add_filter( 'sensei_get_question_template_data', array( 'Sensei_Question', 'file_upload_load_question_data' ), 10, 3 );
 
+// @since 3.15.0
+// Add the quiz pagination.
+add_action( 'sensei_single_quiz_questions_after', array( 'Sensei_Quiz', 'the_quiz_pagination' ), 9, 0 );
+
 // @since 1.9.0
 // deprecate the quiz button action
 add_action( 'sensei_single_quiz_questions_after', array( 'Sensei_Quiz', 'action_buttons' ), 10, 0 );

--- a/includes/template-functions.php
+++ b/includes/template-functions.php
@@ -859,6 +859,43 @@ function sensei_get_the_question_id() {
 
 }
 
+/**
+ * Return the number of the current question within the quiz question loop.
+ *
+ * @since 3.15.0
+ *
+ * @return int
+ */
+function sensei_get_the_question_number() {
+
+	global $sensei_question_loop;
+
+	$question_number = ( $sensei_question_loop['current_page'] - 1 )
+		* $sensei_question_loop['posts_per_page']
+		+ $sensei_question_loop['current']
+		+ 1;
+
+	/**
+	 * Filters the number of the current question within the quiz question loop.
+	 *
+	 * @hook  sensei_the_question_number
+	 * @since 3.15.0
+	 *
+	 * @param {int} $question_number The question number.
+	 * @param {int} $question_id     The question ID.
+	 * @param {int} $quiz_id         The quiz ID.
+	 *
+	 * @return {int}
+	 */
+	return apply_filters(
+		'sensei_the_question_number',
+		$question_number,
+		$sensei_question_loop['current_question']->ID,
+		$sensei_question_loop['quiz_id']
+	);
+
+}
+
 /************************
  *
  * Single Lesson Functions

--- a/templates/single-quiz.php
+++ b/templates/single-quiz.php
@@ -57,7 +57,10 @@ do_action( 'sensei_single_quiz_content_inside_before', get_the_ID() );
 					sensei_setup_the_question();
 					?>
 
-					<li class="<?php sensei_the_question_class(); ?>">
+					<li
+						class="<?php sensei_the_question_class(); ?>"
+						value="<?php echo esc_attr( sensei_get_the_question_number() ); ?>"
+					>
 
 						<?php
 

--- a/templates/single-quiz.php
+++ b/templates/single-quiz.php
@@ -7,7 +7,7 @@
  * @author      Automattic
  * @package     Sensei
  * @category    Templates
- * @version     3.6.0
+ * @version     3.15.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/single-quiz/pagination.php
+++ b/templates/single-quiz/pagination.php
@@ -73,9 +73,9 @@ global $sensei_question_loop;
 				<div class="wp-block-button is-style-outline">
 					<a
 						href="<?php echo esc_attr( add_query_arg( 'quiz-page', $sensei_question_loop['current_page'] - 1 ) ); ?>"
-						class="wp-block-button__link button"
+						class="wp-block-button__link button sensei-quiz-pagination__prev-button"
 					>
-						<?php esc_attr_e( '&lt; Previous', 'sensei-lms' ); ?>
+						<?php esc_attr_e( 'Previous', 'sensei-lms' ); ?>
 					</a>
 				</div>
 			<?php endif ?>
@@ -92,9 +92,9 @@ global $sensei_question_loop;
 				<div class="wp-block-button">
 					<a
 						href="<?php echo esc_attr( add_query_arg( 'quiz-page', $sensei_question_loop['current_page'] + 1 ) ); ?>"
-						class="wp-block-button__link button"
+						class="wp-block-button__link button sensei-quiz-pagination__next-button"
 					>
-						<?php esc_attr_e( 'Next &gt;', 'sensei-lms' ); ?>
+						<?php esc_attr_e( 'Next', 'sensei-lms' ); ?>
 					</a>
 				</div>
 			<?php endif ?>

--- a/templates/single-quiz/pagination.php
+++ b/templates/single-quiz/pagination.php
@@ -75,7 +75,7 @@ global $sensei_question_loop;
 						href="<?php echo esc_attr( add_query_arg( 'quiz-page', $sensei_question_loop['current_page'] - 1 ) ); ?>"
 						class="wp-block-button__link button"
 					>
-						<?php esc_attr_e( '&lt; Prev', 'sensei-lms' ); ?>
+						<?php esc_attr_e( '&lt; Previous', 'sensei-lms' ); ?>
 					</a>
 				</div>
 			<?php endif ?>

--- a/templates/single-quiz/pagination.php
+++ b/templates/single-quiz/pagination.php
@@ -24,8 +24,8 @@ global $sensei_question_loop;
 			/**
 			 * Filters the quiz questions paginate links arguments.
 			 *
-			 * @see https://developer.wordpress.org/reference/functions/paginate_links/
-			 * @hook sensei_add_comment_indexes
+			 * @see   https://developer.wordpress.org/reference/functions/paginate_links/
+			 * @hook  sensei_quiz_pagination_args
 			 * @since 3.15.0
 			 *
 			 * @param {array} $args The pagination arguments.

--- a/templates/single-quiz/pagination.php
+++ b/templates/single-quiz/pagination.php
@@ -50,7 +50,7 @@ global $sensei_question_loop;
 	<div class="sensei-quiz-pagination__actions">
 		<?php if ( Sensei_Quiz::is_reset_allowed( Sensei()->quiz->get_lesson_id( get_the_ID() ) ) ) : ?>
 			<div class="sensei-quiz-pagination__button-link">
-				<button type="submit" name="quiz_reset" class="sensei-stop-double-submission has-background has-text-color">
+				<button type="submit" name="quiz_reset" class="sensei-stop-double-submission">
 					<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>
 				</button>
 
@@ -59,7 +59,7 @@ global $sensei_question_loop;
 		<?php endif ?>
 
 		<div class="sensei-quiz-pagination__button-link">
-			<button type="submit" name="quiz_save" class="sensei-stop-double-submission has-background has-text-color">
+			<button type="submit" name="quiz_save" class="sensei-stop-double-submission">
 				<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>
 			</button>
 

--- a/templates/single-quiz/pagination.php
+++ b/templates/single-quiz/pagination.php
@@ -47,25 +47,27 @@ global $sensei_question_loop;
 		?>
 	</div>
 
-	<div class="sensei-quiz-pagination__actions">
-		<?php if ( Sensei_Quiz::is_reset_allowed( Sensei()->quiz->get_lesson_id( get_the_ID() ) ) ) : ?>
+	<?php if ( $can_take_quiz ) : ?>
+		<div class="sensei-quiz-pagination__actions">
+			<?php if ( Sensei_Quiz::is_reset_allowed( Sensei()->quiz->get_lesson_id( get_the_ID() ) ) ) : ?>
+				<div class="sensei-quiz-pagination__action">
+					<button type="submit" name="quiz_reset" class="sensei-stop-double-submission">
+						<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>
+					</button>
+
+					<input type="hidden" name="woothemes_sensei_reset_quiz_nonce" id="woothemes_sensei_reset_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' ) ); ?>" />
+				</div>
+			<?php endif ?>
+
 			<div class="sensei-quiz-pagination__action">
-				<button type="submit" name="quiz_reset" class="sensei-stop-double-submission">
-					<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>
+				<button type="submit" name="quiz_save" class="sensei-stop-double-submission">
+					<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>
 				</button>
 
-				<input type="hidden" name="woothemes_sensei_reset_quiz_nonce" id="woothemes_sensei_reset_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' ) ); ?>" />
+				<input type="hidden" name="woothemes_sensei_save_quiz_nonce" id="woothemes_sensei_save_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
 			</div>
-		<?php endif ?>
-
-		<div class="sensei-quiz-pagination__action">
-			<button type="submit" name="quiz_save" class="sensei-stop-double-submission">
-				<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>
-			</button>
-
-			<input type="hidden" name="woothemes_sensei_save_quiz_nonce" id="woothemes_sensei_save_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
 		</div>
-	</div>
+	<?php endif ?>
 
 	<div class="sensei-quiz-pagination__nav">
 		<div class="wp-block-buttons">
@@ -80,15 +82,7 @@ global $sensei_question_loop;
 				</div>
 			<?php endif ?>
 
-			<?php if ( $sensei_question_loop['current_page'] === $sensei_question_loop['total_pages'] ) : ?>
-				<div class="wp-block-button">
-					<button type="submit" name="quiz_complete" class="wp-block-button__link button quiz-submit complete sensei-stop-double-submission">
-						<?php esc_attr_e( 'Complete', 'sensei-lms' ); ?>
-					</button>
-
-					<input type="hidden" name="woothemes_sensei_complete_quiz_nonce" id="woothemes_sensei_complete_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_quiz_nonce' ) ); ?>" />
-				</div>
-			<?php else : ?>
+			<?php if ( $sensei_question_loop['current_page'] < $sensei_question_loop['total_pages'] ) : ?>
 				<div class="wp-block-button">
 					<a
 						href="<?php echo esc_attr( add_query_arg( 'quiz-page', $sensei_question_loop['current_page'] + 1 ) ); ?>"
@@ -96,6 +90,14 @@ global $sensei_question_loop;
 					>
 						<?php esc_attr_e( 'Next', 'sensei-lms' ); ?>
 					</a>
+				</div>
+			<?php elseif ( $can_take_quiz ) : ?>
+				<div class="wp-block-button">
+					<button type="submit" name="quiz_complete" class="wp-block-button__link button quiz-submit complete sensei-stop-double-submission">
+						<?php esc_attr_e( 'Complete', 'sensei-lms' ); ?>
+					</button>
+
+					<input type="hidden" name="woothemes_sensei_complete_quiz_nonce" id="woothemes_sensei_complete_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_quiz_nonce' ) ); ?>" />
 				</div>
 			<?php endif ?>
 		</div>

--- a/templates/single-quiz/pagination.php
+++ b/templates/single-quiz/pagination.php
@@ -16,7 +16,7 @@ global $sensei_question_loop;
 
 ?>
 
-<div class="sensei-quiz-pagination">
+<div id="sensei-quiz-pagination">
 	<div class="sensei-quiz-pagination__list">
 		<?php
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- No need to escape the pagination links.
@@ -49,7 +49,7 @@ global $sensei_question_loop;
 
 	<div class="sensei-quiz-pagination__actions">
 		<?php if ( Sensei_Quiz::is_reset_allowed( Sensei()->quiz->get_lesson_id( get_the_ID() ) ) ) : ?>
-			<div class="sensei-quiz-pagination__button-link">
+			<div class="sensei-quiz-pagination__action">
 				<button type="submit" name="quiz_reset" class="sensei-stop-double-submission">
 					<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>
 				</button>
@@ -58,7 +58,7 @@ global $sensei_question_loop;
 			</div>
 		<?php endif ?>
 
-		<div class="sensei-quiz-pagination__button-link">
+		<div class="sensei-quiz-pagination__action">
 			<button type="submit" name="quiz_save" class="sensei-stop-double-submission">
 				<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>
 			</button>

--- a/templates/single-quiz/pagination.php
+++ b/templates/single-quiz/pagination.php
@@ -22,13 +22,15 @@ global $sensei_question_loop;
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- No need to escape the pagination links.
 		echo paginate_links(
 			/**
-			 * Filters the quiz questions paginate links args.
+			 * Filters the quiz questions paginate links arguments.
 			 *
 			 * @see https://developer.wordpress.org/reference/functions/paginate_links/
-			 *
+			 * @hook sensei_add_comment_indexes
 			 * @since 3.15.0
 			 *
-			 * @param array $args The pagination arguments.
+			 * @param {array} $args The pagination arguments.
+			 *
+			 * @return {array}
 			 */
 			apply_filters(
 				'sensei_quiz_pagination_args',

--- a/templates/single-quiz/pagination.php
+++ b/templates/single-quiz/pagination.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * The template for displaying the quiz pagination.
+ *
+ * @author   Automattic
+ * @package  Sensei
+ * @category Templates
+ * @version  3.15.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+global $sensei_question_loop;
+
+?>
+
+<div class="sensei-quiz-pagination">
+	<div class="sensei-quiz-pagination__list">
+		<?php
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- No need to escape the pagination links.
+		echo paginate_links(
+			/**
+			 * Filters the quiz questions paginate links args.
+			 *
+			 * @see https://developer.wordpress.org/reference/functions/paginate_links/
+			 *
+			 * @since 3.15.0
+			 *
+			 * @param array $args The pagination arguments.
+			 */
+			apply_filters(
+				'sensei_quiz_pagination_args',
+				[
+					'total'     => $sensei_question_loop['total_pages'],
+					'current'   => $sensei_question_loop['current_page'],
+					'format'    => '?quiz-page=%#%',
+					'type'      => 'list',
+					'mid_size'  => 1,
+					'prev_next' => false,
+				]
+			)
+		);
+		?>
+	</div>
+
+	<div class="sensei-quiz-pagination__actions">
+		<?php if ( Sensei_Quiz::is_reset_allowed( Sensei()->quiz->get_lesson_id( get_the_ID() ) ) ) : ?>
+			<div class="sensei-quiz-pagination__button-link">
+				<button type="submit" name="quiz_reset" class="sensei-stop-double-submission has-background has-text-color">
+					<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>
+				</button>
+
+				<input type="hidden" name="woothemes_sensei_reset_quiz_nonce" id="woothemes_sensei_reset_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' ) ); ?>" />
+			</div>
+		<?php endif ?>
+
+		<div class="sensei-quiz-pagination__button-link">
+			<button type="submit" name="quiz_save" class="sensei-stop-double-submission has-background has-text-color">
+				<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>
+			</button>
+
+			<input type="hidden" name="woothemes_sensei_save_quiz_nonce" id="woothemes_sensei_save_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
+		</div>
+	</div>
+
+	<div class="sensei-quiz-pagination__nav">
+		<div class="wp-block-buttons">
+			<?php if ( $sensei_question_loop['current_page'] > 1 ) : ?>
+				<div class="wp-block-button is-style-outline">
+					<a
+						href="<?php echo esc_attr( add_query_arg( 'quiz-page', $sensei_question_loop['current_page'] - 1 ) ); ?>"
+						class="wp-block-button__link button"
+					>
+						<?php esc_attr_e( '&lt; Prev', 'sensei-lms' ); ?>
+					</a>
+				</div>
+			<?php endif ?>
+
+			<?php if ( $sensei_question_loop['current_page'] === $sensei_question_loop['total_pages'] ) : ?>
+				<div class="wp-block-button">
+					<button type="submit" name="quiz_complete" class="wp-block-button__link button quiz-submit complete sensei-stop-double-submission">
+						<?php esc_attr_e( 'Complete', 'sensei-lms' ); ?>
+					</button>
+
+					<input type="hidden" name="woothemes_sensei_complete_quiz_nonce" id="woothemes_sensei_complete_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_quiz_nonce' ) ); ?>" />
+				</div>
+			<?php else : ?>
+				<div class="wp-block-button">
+					<a
+						href="<?php echo esc_attr( add_query_arg( 'quiz-page', $sensei_question_loop['current_page'] + 1 ) ); ?>"
+						class="wp-block-button__link button"
+					>
+						<?php esc_attr_e( 'Next &gt;', 'sensei-lms' ); ?>
+					</a>
+				</div>
+			<?php endif ?>
+		</div>
+	</div>
+</div>

--- a/templates/single-quiz/pagination.php
+++ b/templates/single-quiz/pagination.php
@@ -14,6 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $sensei_question_loop;
 
+$sensei_can_take_quiz = Sensei_Quiz::can_take_quiz();
+
 ?>
 
 <div id="sensei-quiz-pagination">
@@ -47,7 +49,7 @@ global $sensei_question_loop;
 		?>
 	</div>
 
-	<?php if ( $can_take_quiz ) : ?>
+	<?php if ( $sensei_can_take_quiz ) : ?>
 		<div class="sensei-quiz-pagination__actions">
 			<?php if ( Sensei_Quiz::is_reset_allowed( Sensei()->quiz->get_lesson_id( get_the_ID() ) ) ) : ?>
 				<div class="sensei-quiz-pagination__action">
@@ -91,7 +93,7 @@ global $sensei_question_loop;
 						<?php esc_attr_e( 'Next', 'sensei-lms' ); ?>
 					</a>
 				</div>
-			<?php elseif ( $can_take_quiz ) : ?>
+			<?php elseif ( $sensei_can_take_quiz ) : ?>
 				<div class="wp-block-button">
 					<button type="submit" name="quiz_complete" class="wp-block-button__link button quiz-submit complete sensei-stop-double-submission">
 						<?php esc_attr_e( 'Complete', 'sensei-lms' ); ?>

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1278,7 +1278,8 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 			->method( 'can_take_quiz' )
 			->will( $this->returnValue( true ) );
 
-		Sensei()->quiz = $sensei_quiz_mock;
+		$sensei_quiz_instance = Sensei()->quiz;
+		Sensei()->quiz        = $sensei_quiz_mock;
 
 		/* Act */
 		Sensei_Quiz::start_quiz_questions_loop();
@@ -1288,6 +1289,9 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$this->assertEquals( 5, $sensei_question_loop['total_pages'], 'The loop `total_pages` should be calculated properly`.' );
 		$this->assertCount( 2, $sensei_question_loop['questions'], 'The loop questions count should be equal to the questions per page.' );
 		$this->assertEquals( 10, $sensei_question_loop['total'], 'The loop total questions count should be equal to the total questions count of the quiz.' );
+
+		/* Reset */
+		Sensei()->quiz = $sensei_quiz_instance;
 	}
 
 	/**

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1315,13 +1315,10 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'passed' );
 
-		$method = new ReflectionMethod( Sensei_Quiz::class, 'can_take_quiz' );
-		$method->setAccessible( true );
-
 		/* Assert */
-		$this->assertFalse( $method->invoke( Sensei()->quiz, $quiz_id, $user_id ), 'Users not enrolled in a course, should not be able to take the quiz.' );
+		$this->assertFalse( Sensei_Quiz::can_take_quiz( $quiz_id, $user_id ), 'Users not enrolled in a course, should not be able to take the quiz.' );
 		$course_enrolment->enrol( $user_id );
-		$this->assertTrue( $method->invoke( Sensei()->quiz, $quiz_id, $user_id ), 'Users enrolled in a course, should be able to take the quiz.' );
+		$this->assertTrue( Sensei_Quiz::can_take_quiz( $quiz_id, $user_id ), 'Users enrolled in a course, should be able to take the quiz.' );
 	}
 
 	/**
@@ -1350,13 +1347,10 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'passed' );
 
-		$method = new ReflectionMethod( Sensei_Quiz::class, 'can_take_quiz' );
-		$method->setAccessible( true );
-
 		/* Assert */
-		$this->assertFalse( $method->invoke( Sensei()->quiz, $quiz_id, $user_id ), 'Should not be able to take the quiz if there is a uncompleted prerequisite lesson.' );
+		$this->assertFalse( Sensei_Quiz::can_take_quiz( $quiz_id, $user_id ), 'Should not be able to take the quiz if there is a uncompleted prerequisite lesson.' );
 		Sensei_Utils::update_lesson_status( $user_id, $prerequisite_lesson_id, 'complete' );
-		$this->assertTrue( $method->invoke( Sensei()->quiz, $quiz_id, $user_id ), 'Should be able to take the quiz if the prerequisite lesson is completed.' );
+		$this->assertTrue( Sensei_Quiz::can_take_quiz( $quiz_id, $user_id ), 'Should be able to take the quiz if the prerequisite lesson is completed.' );
 	}
 
 	/**
@@ -1382,13 +1376,10 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'passed' );
 
-		$method = new ReflectionMethod( Sensei_Quiz::class, 'can_take_quiz' );
-		$method->setAccessible( true );
-
 		/* Assert */
-		$this->assertTrue( $method->invoke( Sensei()->quiz, $quiz_id, $user_id ), 'Should be able to take the quiz if the lesson status is not ungraded.' );
+		$this->assertTrue( Sensei_Quiz::can_take_quiz( $quiz_id, $user_id ), 'Should be able to take the quiz if the lesson status is not ungraded.' );
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_id, 'ungraded' );
-		$this->assertFalse( $method->invoke( Sensei()->quiz, $quiz_id, $user_id ), 'Should not be able to take the quiz if the lesson status is ungraded.' );
+		$this->assertFalse( Sensei_Quiz::can_take_quiz( $quiz_id, $user_id ), 'Should not be able to take the quiz if the lesson status is ungraded.' );
 	}
 
 }

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1270,6 +1270,16 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 			wp_json_encode( [ 'pagination_number' => 2 ] )
 		);
 
+		$sensei_quiz_mock = $this->getMockBuilder( Sensei_Quiz::class )
+			->setMethods( [ 'can_take_quiz' ] )
+			->getMock();
+
+		$sensei_quiz_mock
+			->method( 'can_take_quiz' )
+			->will( $this->returnValue( true ) );
+
+		Sensei()->quiz = $sensei_quiz_mock;
+
 		/* Act */
 		Sensei_Quiz::start_quiz_questions_loop();
 

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1275,6 +1275,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 		/* Assert */
 		$this->assertEquals( 2, $sensei_question_loop['posts_per_page'], 'The loop `posts_per_page` should be the same as the number defined in the quiz pagination setting.' );
+		$this->assertEquals( 5, $sensei_question_loop['total_pages'], 'The loop `total_pages` should be calculated properly`.' );
 		$this->assertCount( 2, $sensei_question_loop['questions'], 'The loop questions count should be equal to the questions per page.' );
 		$this->assertEquals( 10, $sensei_question_loop['total'], 'The loop total questions count should be equal to the total questions count of the quiz.' );
 	}


### PR DESCRIPTION
Fixes #4480 

### Changes proposed in this Pull Request

This PR adds the quiz pagination frontend UI and refactors some of the default quiz action buttons code. It does not implement the session needed for the quiz form submission to work properly, so no need to test that.

### Testing instructions

* Enable the quiz pagination feature:
```php
add_filter( 'sensei_feature_flag_quiz_pagination', '__return_true' );
```
* Make a new course with a lesson.
* Make a quiz with multiple questions (>=8).
* Enable the pagination by updating the quiz pagination settings (see #4387).
* Enroll in the course.
* Open the quiz in the frontend.
* Don't use the save/reset/complete buttons. They will be fixed when the quiz session is implemented (#4392).
* Make sure the question listing is paginated.
* Make sure the numeric pagination and the next/prev buttons work.
* Check if the question numbers are correct.
* Edit the quiz and enable the `Allow Retakes` setting and make sure the `Reset` button is present in the frontend.
* Make sure you see the `Complete` button on the last page.
* Make sure you have at least 8 pages and go to page 4 to see the full width of the numeric pagination.
* Make sure the pagination looks good on the more popular WP themes.
* Make sure the pagination looks good on mobile.
* Make sure the question listing is paginated even if not enrolled in the course.
* Make the quiz pagination per page number bigger than the questions count and make sure the pagination UI is not loading. You should see the default action buttons instead.
* Disable the quiz pagination and make sure the default quiz action buttons work as expected.

### New Hooks

* `sensei_quiz_pagination_args` - Filters the quiz questions paginate links args.
* `sensei_the_question_number` - Filters the number of the current question within the quiz question loop.

### Changed Templates

* `single-quiz.php` - Explicitly provide the question number.

### Screenshots

Desktop:
<img width="662" alt="Screenshot on 2021-12-14 at 15-51-34" src="https://user-images.githubusercontent.com/1612178/146012162-f395e4b4-6905-459d-b75a-15996d744036.png">
<img width="851" alt="Screenshot on 2021-12-14 at 15-54-04" src="https://user-images.githubusercontent.com/1612178/146012191-d13eb774-096f-4bf8-8f11-51869ce8487a.png">


Mobile:
<img width="353" alt="Screenshot on 2021-12-14 at 15-55-39" src="https://user-images.githubusercontent.com/1612178/146012217-562b23d1-bfc7-4c00-a019-4aab2799706b.png">
<img width="341" alt="Screenshot on 2021-12-14 at 15-54-47" src="https://user-images.githubusercontent.com/1612178/146012235-c9cf39d4-2402-43ef-a2b5-2f4e5cecc42a.png">

