### PR TITLE
WP_User_Query can't be called with 'who' parameter in WP versions >= 5.9.0

### DIFF
--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -291,11 +291,13 @@ class Sensei_Teacher {
 	 * @return array $users user id array
 	 */
 	public function get_teachers_and_authors() {
+		global $wp_version;
 
+		$authors_field     = version_compare( $wp_version, '5.9.0', '>=' ) ? 'capability' : 'who';
 		$author_query_args = array(
-			'blog_id' => $GLOBALS['blog_id'],
-			'fields'  => 'any',
-			'who'     => 'authors',
+			'blog_id'      => $GLOBALS['blog_id'],
+			'fields'       => 'any',
+			$authors_field => 'authors',
 		);
 
 		$authors = get_users( $author_query_args );


### PR DESCRIPTION
Fixes #4505

###About the issue 
- In new WP version, version that it >= 5.9.0  ```'who'``` parameter is deprecated for WP_User_Query function and ```'capability'``` parameter should be used instead.
- We have to make sure that error is not present in any version


## Testing instructions
### Steps to reproduce (copied from the issue)
1. Open course page while using 5.8.2 WP version
2. Make sure there isn't anything in debug.log
3. Install and activate the WordPress Beta Tester plugin.
4. Go to Tools > Beta Testing and then Bleeding Edge > Beta/RC Only.
5. Go to Dashboard > Updates and click the button to install 5.9-beta1.
6. Go to Courses and select an existing course.
7. Make sure there isn't anything in debug.log

