### PR TITLE
Add locked lesson free course notices

### DIFF
--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -1,9 +1,10 @@
-.sensei-course-theme__frame {
-
+.sensei-course-theme {
 	--primary-color: var(--sensei-course-theme-primary-color, #30968B);
 	--primary-contrast-color: var(--sensei-course-theme-button-text-color, #FFFFFF);
 	--gray: #787C82;
+}
 
+.sensei-course-theme__frame {
 	a:hover, a:hover * {
 		color: var(--primary-color);
 		fill: var(--primary-color);
@@ -20,4 +21,3 @@
 	line-height: 1.5;
 	letter-spacing: normal;
 }
-

--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -2,6 +2,7 @@
 	&__button {
 		display: inline-block;
 		font-size: 14px;
+		cursor: pointer;
 
 		&.is-primary,
 		&.is-secondary {

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -128,7 +128,7 @@ class Sensei_Block_Take_Course {
 	 * @return string
 	 */
 	private function render_with_login( $content ) {
-		$target = sensei_user_registration_url() ?? wp_registration_url();
+		$target = sensei_user_registration_url();
 
 		return ( '
 			<form method="GET" action="' . esc_url( $target ) . '">

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -118,8 +118,7 @@ class Sensei_Block_Take_Course {
 	 * @return string
 	 */
 	private function render_with_login( $content ) {
-		$sensei_registration_link = sensei_user_registration_url();
-		$target                   = ! empty( $sensei_registration_link ) ? $sensei_registration_link : wp_registration_url();
+		$target = sensei_user_registration_url() ?? wp_registration_url();
 
 		return ( '
 			<form method="GET" action="' . esc_url( $target ) . '">

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -55,6 +55,16 @@ class Sensei_Block_Take_Course {
 				Sensei()->notices->add_notice( Sensei()->course::get_course_prerequisite_message( $course_id ), 'info', 'sensei-take-course-prerequisite' );
 				$html = $this->render_disabled( $content );
 			} else {
+				// Replace button label in case it's coming from a sign in with redirect to take course.
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No action based on input.
+				if ( isset( $_GET['take_course_sign_in'] ) ) {
+					$content = preg_replace(
+						'/(.*)<button(.*)>(.*)<\/button>(.*)/',
+						'$1<button$2>' . __( 'Start course', 'sensei-lms' ) . '</button>$4',
+						$content,
+						1
+					);
+				}
 				$html = $this->render_with_start_course_form( $course_id, $content );
 			}
 		} elseif ( ! is_user_logged_in() ) {

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -118,24 +118,8 @@ class Sensei_Block_Take_Course {
 	 * @return string
 	 */
 	private function render_with_login( $content ) {
-
-		/**
-		 * Filter to force Sensei to output the default WordPress user
-		 * registration link.
-		 *
-		 * @param bool $wp_register_link default false
-		 *
-		 * @since 1.9.0
-		 */
-		$wp_register_link = apply_filters( 'sensei_use_wp_register_link', false );
-
-		$settings = Sensei()->settings->get_settings();
-		if ( ! empty( $settings['my_course_page'] ) && ! $wp_register_link ) {
-			$my_courses_url = get_permalink( intval( $settings['my_course_page'] ) );
-			$target         = esc_url( $my_courses_url );
-		} else {
-			$target = wp_registration_url();
-		}
+		$sensei_registration_link = sensei_user_registration_url();
+		$target                   = ! empty( $sensei_registration_link ) ? $sensei_registration_link : wp_registration_url();
 
 		return ( '
 			<form method="GET" action="' . esc_url( $target ) . '">

--- a/includes/class-sensei-context-notices.php
+++ b/includes/class-sensei-context-notices.php
@@ -70,7 +70,8 @@ class Sensei_Context_Notices {
 	 * @param string $text    Notice text.
 	 * @param string $title   Notice title.
 	 * @param array  $actions {
-	 *     Actions to display inside the notice.
+	 *     Actions to display inside the notice. It can contains strings with custom actions,
+	 *     or arrays with the following properties.
 	 *
 	 *     @type string $label Action label.
 	 *     @type string $url   Action URL.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3305,7 +3305,7 @@ class Sensei_Course {
 					return;
 				}
 
-				$my_courses_url = sensei_user_registration_url();
+				$my_courses_url = sensei_user_registration_url( false );
 
 				if ( ! empty( $my_courses_url ) ) {
 					echo '<div class="status register"><a href="' . esc_url( $my_courses_url ) . '">' .

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3294,25 +3294,6 @@ class Sensei_Course {
 
 				self::add_course_access_permission_message( $notice );
 
-				$my_courses_page_id = '';
-
-				/**
-				 * Filter to force Sensei to output the default WordPress user
-				 * registration link.
-				 *
-				 * @since 1.9.0
-				 * @param bool $wp_register_link default false
-				 */
-				$wp_register_link = apply_filters( 'sensei_use_wp_register_link', false );
-
-				$settings = Sensei()->settings->get_settings();
-				if ( isset( $settings['my_course_page'] )
-					&& 0 < intval( $settings['my_course_page'] ) ) {
-
-					$my_courses_page_id = $settings['my_course_page'];
-
-				}
-
 				if (
 					! (bool) apply_filters_deprecated(
 						'sensei_user_can_register_for_course',
@@ -3323,14 +3304,14 @@ class Sensei_Course {
 				) {
 					return;
 				}
-				// If a My Courses page was set in Settings, and 'sensei_use_wp_register_link'
-				// is false, link to My Courses. If not, link to default WordPress registration page.
-				if ( ! empty( $my_courses_page_id ) && $my_courses_page_id && ! $wp_register_link ) {
-						$my_courses_url = get_permalink( $my_courses_page_id );
-						echo '<div class="status register"><a href="' . esc_url( $my_courses_url ) . '">' .
-							esc_html__( 'Register', 'sensei-lms' ) . '</a></div>';
+
+				$my_courses_url = sensei_user_registration_url();
+
+				if ( ! empty( $my_courses_url ) ) {
+					echo '<div class="status register"><a href="' . esc_url( $my_courses_url ) . '">' .
+						esc_html__( 'Register', 'sensei-lms' ) . '</a></div>';
 				} else {
-						wp_register( '<div class="status register">', '</div>' );
+					wp_register( '<div class="status register">', '</div>' );
 				}
 			}
 		}

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1557,7 +1557,7 @@ class Sensei_Frontend {
 					wp_redirect( esc_url_raw( add_query_arg( 'login', 'failed', $referrer ) ) );
 					exit;
 				} else { // on login success.
-					$redirect_to = $_REQUEST['redirect_to'] ?? remove_query_arg( 'login', $referrer );
+					$redirect_to = isset( $_REQUEST['redirect_to'] ) ? esc_url_raw( wp_unslash( $_REQUEST['redirect_to'] ) ) : remove_query_arg( 'login', $referrer );
 
 					/**
 					 * Change the redirect url programatically.
@@ -1695,7 +1695,7 @@ class Sensei_Frontend {
 			$redirect = esc_url( home_url( $wp->request ) );
 		}
 
-		$redirect_to = $_REQUEST['redirect_to'] ?? $redirect;
+		$redirect_to = isset( $_REQUEST['redirect_to'] ) ? esc_url_raw( wp_unslash( $_REQUEST['redirect_to'] ) ) : $redirect;
 
 		wp_redirect( apply_filters( 'sensei_registration_redirect', $redirect_to ) );
 		exit;

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1152,15 +1152,12 @@ class Sensei_Frontend {
 			<?php
 			if ( get_option( 'users_can_register' ) ) {
 
-				// get current url.
-				$action_url = get_permalink();
-
 				?>
 
 				<div class="col-2">
 					<h2><?php esc_html_e( 'Register', 'sensei-lms' ); ?></h2>
 
-					<form method="post" class="register"  action="<?php echo esc_url( $action_url ); ?>" >
+					<form method="post" class="register">
 
 						<?php do_action( 'sensei_register_form_start' ); ?>
 
@@ -1560,16 +1557,29 @@ class Sensei_Frontend {
 					wp_redirect( esc_url_raw( add_query_arg( 'login', 'failed', $referrer ) ) );
 					exit;
 				} else { // on login success.
+					$redirect_to = $_REQUEST['redirect_to'] ?? remove_query_arg( 'login', $referrer );
 
 					/**
-					* Change the redirect url programatically.
-					*
-					* @since 1.6.1
-					*
-					* @param string $referrer the page where the current url wheresensei login form was posted from.
-					*/
+					 * Change the redirect url programatically.
+					 *
+					 * @since 1.6.1
+					 * @deprecated 3.15.0 Use `sensei_login_success_redirect_url` instead.
+					 *
+					 * @param string $referrer the page where the current url wheresensei login form was posted from.
+					 */
+					$success_redirect_url = apply_filters_deprecated( 'sesei_login_success_redirect_url', [ $redirect_to ], 'sensei_login_success_redirect_url', 'Use `sensei_login_success_redirect_url` instead' );
 
-					$success_redirect_url = apply_filters( 'sesei_login_success_redirect_url', remove_query_arg( 'login', $referrer ) );
+					/**
+					 * Change the redirect url programatically.
+					 *
+					 * @hook sensei_login_success_redirect_url
+					 * @since 3.15.0
+					 *
+					 * @param {string} $referrer The page where the current url wheresensei login form was posted from.
+					 *
+					 * @return {string} The redirect URL if login is successful.
+					 */
+					$success_redirect_url = apply_filters( 'sensei_login_success_redirect_url', $success_redirect_url );
 
 					wp_redirect( esc_url_raw( $success_redirect_url ) );
 					exit;
@@ -1685,7 +1695,9 @@ class Sensei_Frontend {
 			$redirect = esc_url( home_url( $wp->request ) );
 		}
 
-		wp_redirect( apply_filters( 'sensei_registration_redirect', $redirect ) );
+		$redirect_to = $_REQUEST['redirect_to'] ?? $redirect;
+
+		wp_redirect( apply_filters( 'sensei_registration_redirect', $redirect_to ) );
 		exit;
 
 	}

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -1504,10 +1504,10 @@ class Sensei_Teacher {
 		if ( user_can( $user, 'edit_courses' ) ) {
 
 			// phpcs:ignore WordPress.Security.NonceVerification -- We are not making any changes based on this.
-			if ( isset( $_POST['redirect_to'] ) ) {
+			if ( isset( $_REQUEST['redirect_to'] ) ) {
 
 				// phpcs:ignore WordPress.Security.NonceVerification -- We are not making any changes based on this.
-				wp_safe_redirect( $_POST['redirect_to'], 303 );
+				wp_safe_redirect( wp_unslash( $_REQUEST['redirect_to'] ), 303 );
 
 				exit;
 

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -156,13 +156,15 @@ class Sensei_Course_Theme_Lesson {
 	 * @return void
 	 */
 	private function maybe_add_not_enrolled_notice() {
-		$lesson_id = \Sensei_Utils::get_current_lesson();
-		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
-		$notices   = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' );
-		$actions   = [
+		$lesson_id        = \Sensei_Utils::get_current_lesson();
+		$course_id        = Sensei()->lesson->get_course_id( $lesson_id );
+		$notices          = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' );
+		$registration_url = sensei_user_registration_url() ?? wp_registration_url();
+		$registration_url = add_query_arg( 'redirect_to', get_permalink(), $registration_url );
+		$actions          = [
 			[
 				'label' => __( 'Take course', 'sensei-lms' ),
-				'url'   => '',
+				'url'   => $registration_url,
 				'style' => 'primary',
 			],
 		];
@@ -170,7 +172,7 @@ class Sensei_Course_Theme_Lesson {
 		if ( ! is_user_logged_in() ) {
 			$actions[] = [
 				'label' => __( 'Sign in', 'sensei-lms' ),
-				'url'   => sensei_user_registration_url(),
+				'url'   => $registration_url,
 				'style' => 'secondary',
 			];
 

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -51,6 +51,7 @@ class Sensei_Course_Theme_Lesson {
 
 		$this->maybe_add_quiz_results_notice();
 		$this->maybe_add_prerequisite_notice();
+		$this->maybe_add_not_enrolled_notice();
 	}
 
 	/**
@@ -146,6 +147,52 @@ class Sensei_Course_Theme_Lesson {
 
 			$notices = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' );
 			$notices->add_notice( 'locked_lesson', $text, __( 'You don\'t have access to this lesson', 'sensei-lms' ), [], 'lock' );
+		}
+	}
+
+	/**
+	 * Maybe add not enrolled notice.
+	 *
+	 * @return void
+	 */
+	private function maybe_add_not_enrolled_notice() {
+		$lesson_id = \Sensei_Utils::get_current_lesson();
+		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
+		$notices   = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' );
+		$actions   = [
+			[
+				'label' => __( 'Take course', 'sensei-lms' ),
+				'url'   => '',
+				'style' => 'primary',
+			],
+		];
+
+		if ( ! is_user_logged_in() ) {
+			$actions[] = [
+				'label' => __( 'Sign in', 'sensei-lms' ),
+				'url'   => sensei_user_registration_url(),
+				'style' => 'secondary',
+			];
+
+			$notices->add_notice(
+				'locked_lesson',
+				__( 'Please register or sign in to access the course content.', 'sensei-lms' ),
+				__( 'You don\'t have access to this lesson', 'sensei-lms' ),
+				$actions,
+				'lock'
+			);
+
+			return;
+		}
+
+		if ( ! Sensei_Course::is_user_enrolled( $course_id ) ) {
+			$notices->add_notice(
+				'locked_lesson',
+				__( 'Please register for this course to access the content.', 'sensei-lms' ),
+				__( 'You don\'t have access to this lesson', 'sensei-lms' ),
+				$actions,
+				'lock'
+			);
 		}
 	}
 }

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -156,24 +156,31 @@ class Sensei_Course_Theme_Lesson {
 	 * @return void
 	 */
 	private function maybe_add_not_enrolled_notice() {
-		$lesson_id        = \Sensei_Utils::get_current_lesson();
-		$course_id        = Sensei()->lesson->get_course_id( $lesson_id );
-		$notices          = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' );
-		$registration_url = sensei_user_registration_url() ?? wp_registration_url();
-		$registration_url = add_query_arg( 'redirect_to', get_permalink(), $registration_url );
+		$lesson_id                = \Sensei_Utils::get_current_lesson();
+		$course_id                = Sensei()->lesson->get_course_id( $lesson_id );
+		$notices                  = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' );
+		$registration_url         = sensei_user_registration_url() ?? wp_registration_url();
+		$sign_in_url              = add_query_arg( 'redirect_to', get_permalink(), $registration_url );
+		$take_course_redirect_url = add_query_arg( 'take_course_sign_in', '1', get_permalink( $course_id ) );
+		$take_course_url          = add_query_arg( 'redirect_to', $take_course_redirect_url, $registration_url );
 
 		if ( ! is_user_logged_in() ) {
 			$actions = [
 				[
-					'label' => __( 'Sign in', 'sensei-lms' ),
-					'url'   => $registration_url,
+					'label' => __( 'Take course', 'sensei-lms' ),
+					'url'   => $take_course_url,
 					'style' => 'primary',
+				],
+				[
+					'label' => __( 'Sign in', 'sensei-lms' ),
+					'url'   => $sign_in_url,
+					'style' => 'secondary',
 				],
 			];
 
 			$notices->add_notice(
 				'locked_lesson',
-				__( 'Please sign in to access the course content.', 'sensei-lms' ),
+				__( 'Please register or sign in to access the course content.', 'sensei-lms' ),
 				__( 'You don\'t have access to this lesson', 'sensei-lms' ),
 				$actions,
 				'lock'

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -156,15 +156,21 @@ class Sensei_Course_Theme_Lesson {
 	 * @return void
 	 */
 	private function maybe_add_not_enrolled_notice() {
-		$lesson_id                = \Sensei_Utils::get_current_lesson();
-		$course_id                = Sensei()->lesson->get_course_id( $lesson_id );
-		$notices                  = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' );
-		$registration_url         = sensei_user_registration_url() ?? wp_registration_url();
-		$sign_in_url              = add_query_arg( 'redirect_to', get_permalink(), $registration_url );
-		$take_course_redirect_url = add_query_arg( 'take_course_sign_in', '1', get_permalink( $course_id ) );
-		$take_course_url          = add_query_arg( 'redirect_to', $take_course_redirect_url, $registration_url );
+		$lesson_id = \Sensei_Utils::get_current_lesson();
+		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
+		$notices   = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' );
 
 		if ( ! is_user_logged_in() ) {
+			$user_can_register = get_option( 'users_can_register' );
+
+			// Take course URL.
+			$course_url      = add_query_arg( 'take_course_sign_in', '1', get_permalink( $course_id ) );
+			$take_course_url = $user_can_register ? sensei_user_registration_url( true, $course_url ) : sensei_user_login_url( $course_url );
+
+			// Sign in URL.
+			$current_link = get_permalink();
+			$sign_in_url  = $user_can_register ? sensei_user_registration_url( true, $current_link ) : sensei_user_login_url( $current_link );
+
 			$actions = [
 				[
 					'label' => __( 'Take course', 'sensei-lms' ),

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -161,24 +161,19 @@ class Sensei_Course_Theme_Lesson {
 		$notices          = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' );
 		$registration_url = sensei_user_registration_url() ?? wp_registration_url();
 		$registration_url = add_query_arg( 'redirect_to', get_permalink(), $registration_url );
-		$actions          = [
-			[
-				'label' => __( 'Take course', 'sensei-lms' ),
-				'url'   => $registration_url,
-				'style' => 'primary',
-			],
-		];
 
 		if ( ! is_user_logged_in() ) {
-			$actions[] = [
-				'label' => __( 'Sign in', 'sensei-lms' ),
-				'url'   => $registration_url,
-				'style' => 'secondary',
+			$actions = [
+				[
+					'label' => __( 'Sign in', 'sensei-lms' ),
+					'url'   => $registration_url,
+					'style' => 'primary',
+				],
 			];
 
 			$notices->add_notice(
 				'locked_lesson',
-				__( 'Please register or sign in to access the course content.', 'sensei-lms' ),
+				__( 'Please sign in to access the course content.', 'sensei-lms' ),
 				__( 'You don\'t have access to this lesson', 'sensei-lms' ),
 				$actions,
 				'lock'
@@ -188,6 +183,15 @@ class Sensei_Course_Theme_Lesson {
 		}
 
 		if ( ! Sensei_Course::is_user_enrolled( $course_id ) ) {
+			$nonce   = wp_nonce_field( 'woothemes_sensei_start_course_noonce', 'woothemes_sensei_start_course_noonce', false, false );
+			$actions = [
+				'<form method="POST" action="' . esc_url( get_permalink( $course_id ) ) . '">
+					<input type="hidden" name="course_start" value="1" />
+					' . $nonce . '
+					<button type="submit" class="sensei-course-theme__button is-primary">' . esc_html__( 'Take course', 'sensei-lms' ) . '</button>
+				</form>',
+			];
+
 			$notices->add_notice(
 				'locked_lesson',
 				__( 'Please register for this course to access the content.', 'sensei-lms' ),

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -116,8 +116,14 @@ class Sensei_Course_Theme_Lesson {
 	 * Maybe add lesson prerequisite notice.
 	 */
 	private function maybe_add_prerequisite_notice() {
+		$lesson_id = \Sensei_Utils::get_current_lesson();
+		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
+
+		if ( ! Sensei_Course::is_user_enrolled( $course_id ) ) {
+			return;
+		}
+
 		$user_id             = get_current_user_id();
-		$lesson_id           = \Sensei_Utils::get_current_lesson();
 		$lesson_prerequisite = \Sensei_Lesson::find_first_prerequisite_lesson( $lesson_id, $user_id );
 
 		if ( $lesson_prerequisite > 0 ) {

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -50,7 +50,7 @@ class Sensei_Course_Theme_Lesson {
 		}
 
 		$this->maybe_add_quiz_results_notice();
-		$this->maybe_add_prerequisite_notice();
+		$this->maybe_add_lesson_prerequisite_notice();
 		$this->maybe_add_not_enrolled_notice();
 	}
 
@@ -116,7 +116,7 @@ class Sensei_Course_Theme_Lesson {
 	/**
 	 * Maybe add lesson prerequisite notice.
 	 */
-	private function maybe_add_prerequisite_notice() {
+	private function maybe_add_lesson_prerequisite_notice() {
 		$lesson_id = \Sensei_Utils::get_current_lesson();
 		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
 
@@ -190,22 +190,32 @@ class Sensei_Course_Theme_Lesson {
 		}
 
 		if ( ! Sensei_Course::is_user_enrolled( $course_id ) ) {
-			$nonce   = wp_nonce_field( 'woothemes_sensei_start_course_noonce', 'woothemes_sensei_start_course_noonce', false, false );
-			$actions = [
-				'<form method="POST" action="' . esc_url( get_permalink( $course_id ) ) . '">
-					<input type="hidden" name="course_start" value="1" />
-					' . $nonce . '
-					<button type="submit" class="sensei-course-theme__button is-primary">' . esc_html__( 'Take course', 'sensei-lms' ) . '</button>
-				</form>',
-			];
+			if ( ! Sensei_Course::is_prerequisite_complete( $course_id ) ) {
+				$notices->add_notice(
+					'locked_lesson',
+					Sensei()->course::get_course_prerequisite_message( $course_id ),
+					__( 'You don\'t have access to this lesson', 'sensei-lms' ),
+					[],
+					'lock'
+				);
+			} else {
+				$nonce   = wp_nonce_field( 'woothemes_sensei_start_course_noonce', 'woothemes_sensei_start_course_noonce', false, false );
+				$actions = [
+					'<form method="POST" action="' . esc_url( get_permalink( $course_id ) ) . '">
+						<input type="hidden" name="course_start" value="1" />
+						' . $nonce . '
+						<button type="submit" class="sensei-course-theme__button is-primary">' . esc_html__( 'Take course', 'sensei-lms' ) . '</button>
+					</form>',
+				];
 
-			$notices->add_notice(
-				'locked_lesson',
-				__( 'Please register for this course to access the content.', 'sensei-lms' ),
-				__( 'You don\'t have access to this lesson', 'sensei-lms' ),
-				$actions,
-				'lock'
-			);
+				$notices->add_notice(
+					'locked_lesson',
+					__( 'Please register for this course to access the content.', 'sensei-lms' ),
+					__( 'You don\'t have access to this lesson', 'sensei-lms' ),
+					$actions,
+					'lock'
+				);
+			}
 		}
 	}
 }

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -267,13 +267,18 @@ function sensei_is_a_course( $post ) {
 }
 
 /**
- * Get registration link.
+ * Get registration url.
  *
  * @since 3.15.0
  *
- * @return string|null The registration link of NULL for wp registration.
+ * @param bool   $return_wp_registration_url Whether return the url if it should use the WP registration url.
+ * @param string $redirect                   Redirect url after registration.
+ *
+ * @return string|null The registration url.
+ *                     If wp registration is the return case and $return_wp_registration_url is
+ *                     true, it returns the url, otherwise it returns null.
  */
-function sensei_user_registration_url() {
+function sensei_user_registration_url( bool $return_wp_registration_url = true, string $redirect = '' ) {
 	/**
 	 * Filter to force Sensei to output the default WordPress user
 	 * registration link.
@@ -283,15 +288,24 @@ function sensei_user_registration_url() {
 	 * @since 1.9.0
 	 */
 	$wp_register_link = apply_filters( 'sensei_use_wp_register_link', false );
+	$registration_url = '';
 	$settings         = Sensei()->settings->get_settings();
 
 	if ( empty( $settings['my_course_page'] ) || $wp_register_link ) {
-		return null;
+		if ( ! $return_wp_registration_url ) {
+			return null;
+		}
+
+		$registration_url = wp_registration_url();
+	} else {
+		$registration_url = get_permalink( intval( $settings['my_course_page'] ) );
 	}
 
-	$my_courses_url = get_permalink( intval( $settings['my_course_page'] ) );
+	if ( ! empty( $redirect ) ) {
+		$registration_url = add_query_arg( 'redirect_to', $redirect, $registration_url );
+	}
 
-	return esc_url( $my_courses_url );
+	return $registration_url;
 }
 
 /**
@@ -302,19 +316,29 @@ function sensei_user_registration_url() {
  * or the wp-login link.
  *
  * @since 1.9.0
+ * @since 3.15.0 Introduce redirect param.
+ *
+ * @param string $redirect Redirect url after login.
+ *
+ * @return string The login url.
  */
-function sensei_user_login_url() {
+function sensei_user_login_url( string $redirect = '' ) {
 
 	$my_courses_page_id = intval( Sensei()->settings->get( 'my_course_page' ) );
 	$page               = get_post( $my_courses_page_id );
 
 	if ( $my_courses_page_id && isset( $page->ID ) && 'page' == get_post_type( $page->ID ) ) {
 
-		return get_permalink( $page->ID );
+		$my_courses_url = get_permalink( $page->ID );
+		if ( ! empty( $redirect ) ) {
+			$my_courses_url = add_query_arg( 'redirect_to', $redirect, $my_courses_url );
+		}
+
+		return $my_courses_url;
 
 	} else {
 
-		return wp_login_url();
+		return wp_login_url( $redirect );
 
 	}
 

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -267,6 +267,34 @@ function sensei_is_a_course( $post ) {
 }
 
 /**
+ * Get registration link.
+ *
+ * @since 3.15.0
+ *
+ * @return string|false The registration link of false for wp registration.
+ */
+function sensei_user_registration_url() {
+	/**
+	 * Filter to force Sensei to output the default WordPress user
+	 * registration link.
+	 *
+	 * @param bool $wp_register_link default false
+	 *
+	 * @since 1.9.0
+	 */
+	$wp_register_link = apply_filters( 'sensei_use_wp_register_link', false );
+	$settings         = Sensei()->settings->get_settings();
+
+	if ( empty( $settings['my_course_page'] ) || $wp_register_link ) {
+		return false;
+	}
+
+	$my_courses_url = get_permalink( intval( $settings['my_course_page'] ) );
+
+	return esc_url( $my_courses_url );
+}
+
+/**
  * Determine the login link
  * on the frontend.
  *

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -271,7 +271,7 @@ function sensei_is_a_course( $post ) {
  *
  * @since 3.15.0
  *
- * @return string|false The registration link of false for wp registration.
+ * @return string|null The registration link of NULL for wp registration.
  */
 function sensei_user_registration_url() {
 	/**
@@ -286,7 +286,7 @@ function sensei_user_registration_url() {
 	$settings         = Sensei()->settings->get_settings();
 
 	if ( empty( $settings['my_course_page'] ) || $wp_register_link ) {
-		return false;
+		return null;
 	}
 
 	$my_courses_url = get_permalink( intval( $settings['my_course_page'] ) );

--- a/templates/course-theme/lesson-quiz-notice.php
+++ b/templates/course-theme/lesson-quiz-notice.php
@@ -51,24 +51,7 @@ if ( ! function_exists( 'sensei_lesson_quiz_notice_actions_map' ) ) {
 		<li>
 			<?php
 			if ( ! is_array( $action ) ) {
-				echo wp_kses(
-					$action,
-					array_merge(
-						wp_kses_allowed_html( 'post' ),
-						[
-							'form'  => [
-								'method' => [],
-								'action' => [],
-							],
-							'input' => [
-								'class' => [],
-								'name'  => [],
-								'type'  => [],
-								'value' => [],
-							],
-						]
-					)
-				);
+				echo wp_kses_post( $action );
 			} else {
 				?>
 				<a href="<?php echo esc_url( $action['url'] ); ?>" class="sensei-course-theme__button is-<?php echo esc_attr( $action['style'] ); ?>">

--- a/templates/course-theme/lesson-quiz-notice.php
+++ b/templates/course-theme/lesson-quiz-notice.php
@@ -49,7 +49,7 @@ if ( ! function_exists( 'sensei_lesson_quiz_notice_actions_map' ) ) {
 	function sensei_lesson_quiz_notice_actions_map( $action ) {
 		?>
 		<li>
-			<a href="<?php echo esc_url( $action['url'] ); ?>" class="button is-<?php echo esc_attr( $action['style'] ); ?>">
+			<a href="<?php echo esc_url( $action['url'] ); ?>" class="sensei-course-theme__button is-<?php echo esc_attr( $action['style'] ); ?>">
 				<?php echo wp_kses_post( $action['label'] ); ?>
 			</a>
 		</li>

--- a/templates/course-theme/lesson-quiz-notice.php
+++ b/templates/course-theme/lesson-quiz-notice.php
@@ -51,7 +51,24 @@ if ( ! function_exists( 'sensei_lesson_quiz_notice_actions_map' ) ) {
 		<li>
 			<?php
 			if ( ! is_array( $action ) ) {
-				echo wp_kses_post( $action );
+				echo wp_kses(
+					$action,
+					array_merge(
+						wp_kses_allowed_html( 'post' ),
+						[
+							'form'  => [
+								'method' => [],
+								'action' => [],
+							],
+							'input' => [
+								'class' => [],
+								'name'  => [],
+								'type'  => [],
+								'value' => [],
+							],
+						]
+					)
+				);
 			} else {
 				?>
 				<a href="<?php echo esc_url( $action['url'] ); ?>" class="sensei-course-theme__button is-<?php echo esc_attr( $action['style'] ); ?>">

--- a/templates/course-theme/lesson-quiz-notice.php
+++ b/templates/course-theme/lesson-quiz-notice.php
@@ -44,7 +44,7 @@ if ( ! function_exists( 'sensei_lesson_quiz_notice_actions_map' ) ) {
 	/**
 	 * Notice actions map to echo the actions.
 	 *
-	 * @param array $action
+	 * @param array|string $action
 	 */
 	function sensei_lesson_quiz_notice_actions_map( $action ) {
 		?>

--- a/templates/course-theme/lesson-quiz-notice.php
+++ b/templates/course-theme/lesson-quiz-notice.php
@@ -49,9 +49,17 @@ if ( ! function_exists( 'sensei_lesson_quiz_notice_actions_map' ) ) {
 	function sensei_lesson_quiz_notice_actions_map( $action ) {
 		?>
 		<li>
-			<a href="<?php echo esc_url( $action['url'] ); ?>" class="sensei-course-theme__button is-<?php echo esc_attr( $action['style'] ); ?>">
-				<?php echo wp_kses_post( $action['label'] ); ?>
-			</a>
+			<?php
+			if ( ! is_array( $action ) ) {
+				echo wp_kses_post( $action );
+			} else {
+				?>
+				<a href="<?php echo esc_url( $action['url'] ); ?>" class="sensei-course-theme__button is-<?php echo esc_attr( $action['style'] ); ?>">
+					<?php echo wp_kses_post( $action['label'] ); ?>
+				</a>
+				<?php
+			}
+			?>
 		</li>
 		<?php
 	}

--- a/templates/course-theme/locked-lesson-notice.php
+++ b/templates/course-theme/locked-lesson-notice.php
@@ -57,7 +57,7 @@ if ( ! function_exists( 'sensei_locked_lesson_notice_actions_map' ) ) {
 	function sensei_locked_lesson_notice_actions_map( $action ) {
 		?>
 		<li>
-			<a href="<?php echo esc_url( $action['url'] ); ?>" class="button is-<?php echo esc_attr( $action['style'] ); ?>">
+			<a href="<?php echo esc_url( $action['url'] ); ?>" class="sensei-course-theme__button is-<?php echo esc_attr( $action['style'] ); ?>">
 				<?php echo wp_kses_post( $action['label'] ); ?>
 			</a>
 		</li>

--- a/templates/course-theme/locked-lesson-notice.php
+++ b/templates/course-theme/locked-lesson-notice.php
@@ -59,7 +59,25 @@ if ( ! function_exists( 'sensei_locked_lesson_notice_actions_map' ) ) {
 		<li>
 			<?php
 			if ( ! is_array( $action ) ) {
-				echo wp_kses_post( $action );
+				echo wp_kses(
+					$action,
+					array_merge(
+						wp_kses_allowed_html( 'post' ),
+						[
+							'form'  => [
+								'method' => [],
+								'action' => [],
+							],
+							'input' => [
+								'class' => [],
+								'name'  => [],
+								'id'    => [],
+								'type'  => [],
+								'value' => [],
+							],
+						]
+					)
+				);
 			} else {
 				?>
 				<a href="<?php echo esc_url( $action['url'] ); ?>" class="sensei-course-theme__button is-<?php echo esc_attr( $action['style'] ); ?>">

--- a/templates/course-theme/locked-lesson-notice.php
+++ b/templates/course-theme/locked-lesson-notice.php
@@ -52,14 +52,22 @@ if ( ! function_exists( 'sensei_locked_lesson_notice_actions_map' ) ) {
 	/**
 	 * Notice actions map to echo the actions.
 	 *
-	 * @param array $action
+	 * @param array|string $action
 	 */
 	function sensei_locked_lesson_notice_actions_map( $action ) {
 		?>
 		<li>
-			<a href="<?php echo esc_url( $action['url'] ); ?>" class="sensei-course-theme__button is-<?php echo esc_attr( $action['style'] ); ?>">
-				<?php echo wp_kses_post( $action['label'] ); ?>
-			</a>
+			<?php
+			if ( ! is_array( $action ) ) {
+				echo wp_kses_post( $action );
+			} else {
+				?>
+				<a href="<?php echo esc_url( $action['url'] ); ?>" class="sensei-course-theme__button is-<?php echo esc_attr( $action['style'] ); ?>">
+					<?php echo wp_kses_post( $action['label'] ); ?>
+				</a>
+				<?php
+			}
+			?>
 		</li>
 		<?php
 	}

--- a/tests/unit-tests/test-class-sensei-context-notices.php
+++ b/tests/unit-tests/test-class-sensei-context-notices.php
@@ -27,6 +27,7 @@ class Sensei_Context_Notices_Test extends WP_UnitTestCase {
 				'url'   => 'http://action',
 				'style' => 'link',
 			],
+			'Custom action',
 		];
 		$notices->add_notice( 'key', 'Text', 'Title', $actions );
 
@@ -35,6 +36,7 @@ class Sensei_Context_Notices_Test extends WP_UnitTestCase {
 		$this->assertContains( 'Text', $html );
 		$this->assertContains( 'Title', $html );
 		$this->assertContains( 'Action label', $html );
+		$this->assertContains( 'Custom action', $html );
 	}
 
 	/**

--- a/tests/unit-tests/test-sensei-functions.php
+++ b/tests/unit-tests/test-sensei-functions.php
@@ -69,6 +69,7 @@ class Sensei_Functions_Test extends WP_UnitTestCase {
 	 * @since 3.15.0
 	 */
 	public function testSenseiUserRegistrationUrl() {
+		Sensei()->settings->set( 'my_course_page', false );
 		$this->assertFalse(
 			sensei_user_registration_url(),
 			'Should return false when My Course page is not set'

--- a/tests/unit-tests/test-sensei-functions.php
+++ b/tests/unit-tests/test-sensei-functions.php
@@ -69,10 +69,19 @@ class Sensei_Functions_Test extends WP_UnitTestCase {
 	 * @since 3.15.0
 	 */
 	public function testSenseiUserRegistrationUrl() {
+		$wp_registration_url = wp_registration_url();
+
 		Sensei()->settings->set( 'my_course_page', false );
-		$this->assertNull(
+
+		$this->assertEquals(
+			$wp_registration_url,
 			sensei_user_registration_url(),
-			'Should return NULL when My Course page is not set'
+			'Should return WP registration URL when My Course page is not set'
+		);
+
+		$this->assertNull(
+			sensei_user_registration_url( false ),
+			'Should return NULL when My Course page is not set and `$return_wp_registration_url` is `false`'
 		);
 
 		$my_courses_page_id = $this->factory->post->create(
@@ -92,7 +101,8 @@ class Sensei_Functions_Test extends WP_UnitTestCase {
 
 		tests_add_filter( 'sensei_use_wp_register_link', '__return_true' );
 
-		$this->assertNull(
+		$this->assertEquals(
+			$wp_registration_url,
 			sensei_user_registration_url(),
 			'Should return NULL when filter is set to use wp registration link'
 		);

--- a/tests/unit-tests/test-sensei-functions.php
+++ b/tests/unit-tests/test-sensei-functions.php
@@ -70,9 +70,9 @@ class Sensei_Functions_Test extends WP_UnitTestCase {
 	 */
 	public function testSenseiUserRegistrationUrl() {
 		Sensei()->settings->set( 'my_course_page', false );
-		$this->assertFalse(
+		$this->assertNull(
 			sensei_user_registration_url(),
-			'Should return false when My Course page is not set'
+			'Should return NULL when My Course page is not set'
 		);
 
 		$my_courses_page_id = $this->factory->post->create(
@@ -92,9 +92,9 @@ class Sensei_Functions_Test extends WP_UnitTestCase {
 
 		tests_add_filter( 'sensei_use_wp_register_link', '__return_true' );
 
-		$this->assertFalse(
+		$this->assertNull(
 			sensei_user_registration_url(),
-			'Should return false when filter is set to use wp registration link'
+			'Should return NULL when filter is set to use wp registration link'
 		);
 	}
 

--- a/tests/unit-tests/test-sensei-functions.php
+++ b/tests/unit-tests/test-sensei-functions.php
@@ -64,6 +64,40 @@ class Sensei_Functions_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test user registration URL.
+	 *
+	 * @since 3.15.0
+	 */
+	public function testSenseiUserRegistrationUrl() {
+		$this->assertFalse(
+			sensei_user_registration_url(),
+			'Should return false when My Course page is not set'
+		);
+
+		$my_courses_page_id = $this->factory->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'My Courses',
+				'post_name'  => 'my-courses',
+			]
+		);
+		Sensei()->settings->set( 'my_course_page', $my_courses_page_id );
+
+		$this->assertEquals(
+			get_permalink( $my_courses_page_id ),
+			sensei_user_registration_url(),
+			'Should get the my courses page permalink as registration page'
+		);
+
+		tests_add_filter( 'sensei_use_wp_register_link', '__return_true' );
+
+		$this->assertFalse(
+			sensei_user_registration_url(),
+			'Should return false when filter is set to use wp registration link'
+		);
+	}
+
+	/**
 	 * Filter for setting theme to Twenty Sixteen.
 	 *
 	 * @since 1.12.0


### PR DESCRIPTION
Part of #4445

### Changes proposed in this Pull Request

* It introduces notices  (logged out and not enrolled students) in the lesson pages for free courses.
* It also contains some redirects logic if the user is logged out.
  * If they click on "Sign in", they log in, then they will be redirected to the same page they were.
  * If they click on "Take course", they log in, then they will be redirected to the course page, with the button "Start course" instead of "Take course" (or any other name they used).
* Notice that the redirects after login may not work if users are using a custom login/registration page. It's was implemented using `redirect_to` query string, which is the same used by WP core login.
* It also refactors some code to use the new `sensei_user_registration_url` function.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create a course.
* Add at least one lesson.
* Select the "Sensei Theme" as the "Course Theme" (sidebar).
* Logged out, access a lesson page, and make sure you see a notice with "Take course" and "Sign in" buttons.
* Using the Sign in button, make sure you're redirected back to the lesson page you were.
* Using the Take course button, make sure you're redirected to the course with a button "Start course" instead of "Take course" (just the label was replaced for that redirect case).
* Now, logged in as a student, try to access a lesson page, and make sure you see a notice with the "Take course" button only.
* Make sure that by clicking on that button, you get enrolled in the course. When https://github.com/Automattic/sensei/pull/4496 is completed, the user will be redirected to the first lesson after the enrollment.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_login_success_redirect_url` - The old `sesei_login_success_redirect_url` renamed.

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* `sesei_login_success_redirect_url` - Deprecated because the typo in the filter name.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/145272704-40b977d8-71e1-4011-82f9-6439125be868.mov

On 0:13, notice that it will redirect to the first lesson after https://github.com/Automattic/sensei/pull/4496 is completed.

#### Another case, in a course with course prerequisite.

<img width="940" alt="Screen Shot 2021-12-08 at 16 27 08" src="https://user-images.githubusercontent.com/876340/145272783-6159274e-9189-4823-b311-906819158e6b.png">