### PR TITLE
Fix prev & next styles.

### DIFF
--- a/assets/css/sensei-course-theme/prev-next-lesson.scss
+++ b/assets/css/sensei-course-theme/prev-next-lesson.scss
@@ -7,13 +7,17 @@
 	}
 
     &-a {
+		padding: 12px 5px;
+		display: flex;
+		align-items: center;
 		span {
+			display: block;
 			font-size: 14px;
 			line-height: 17px;
 			color: inherit;
-			padding: 12px 5px;
 			text-decoration: none;
 		}
+
 		&:hover span {
 			color: var(--primary-color);
 		}
@@ -38,14 +42,17 @@
 
 		&__prev {
 			svg {
-				margin-right: 4px;
+				margin-right: 14px;
+				width: 5px;
+				height: 11px;
 			}
 		}
 
 		&__next {
 			svg {
-				margin-left: 4px;
-				margin-bottom: -1px;
+				margin-left: 14px;
+				width: 5px;
+				height: 11px;
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #

### Changes proposed in this Pull Request

* Fixes broken styles for course-theme header. The main cause of the issue was that the prev & next svg icons had no specific size set for them. Not sure why it worked before and stopped working later. 🤷‍♂️

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course-theme', '__return_true' );`
* Confirm the header looks as expected.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

#### Before

<img width="1289" alt="before" src="https://user-images.githubusercontent.com/2578542/145182390-f78c30c7-5b89-4c01-a121-59812b7ab337.png">

#### After

<img width="1288" alt="after" src="https://user-images.githubusercontent.com/2578542/145182419-c2a5c0d2-7e8e-4ef9-8646-c7e14a5372eb.png">
