### PR TITLE
Add/course theme wide full support

### DIFF
--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -3,6 +3,7 @@
 	--header-height: 75px;
 	--sidebar-width: 300px;
 	--top-offset: 0px;
+	--content-padding: 32px;
 
 	@at-root body.admin-bar {
 		--top-offset: 32px;
@@ -35,13 +36,24 @@
 	}
 
 	&__main-content {
-		padding: 32px;
+		padding: --content-padding;
 		margin-left: var(--sidebar-width) !important;
 
 		> * {
 			max-width: 900px;
 			margin-left: auto;
 			margin-right: auto;
+		}
+
+		.alignfull {
+			margin-left: -(--content-padding);
+			margin-right: -(--content-padding);
+			max-width: 100%;
+		}
+
+		img {
+			max-width: 100%;
+			height: auto;
 		}
 	}
 


### PR DESCRIPTION
Fixes #4483 

### Changes proposed in this Pull Request

* Adds support for Gutenberg blocks' "Align Full" mode. The "Align Wide" mode is already working as expected.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course-theme', '__return_true' );`
* Create lesson content with "Align Left|Center|Right|Wide|Full" modes and confirm they are styled as expected on the Course Theme.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/2578542/145193121-3cbc8a52-db17-40f6-9316-b764e067f819.mp4

