### PR TITLE
Add mobile layout for learning mode

### DIFF
--- a/assets/course-theme/adminbar-layout.js
+++ b/assets/course-theme/adminbar-layout.js
@@ -1,0 +1,29 @@
+/**
+ * Track how much space the WordPress admin bar takes up at the top of the screen.
+ * Updates a CSS variable with the value.
+ */
+const trackAdminbarOffset = () => {
+	const adminbar = document.querySelector( '#wpadminbar' );
+	if ( ! adminbar ) {
+		return;
+	}
+
+	updateAdminbarOffset();
+	// eslint-disable-next-line @wordpress/no-global-event-listener
+	window.addEventListener( 'scroll', updateAdminbarOffset, {
+		capture: false,
+		passive: true,
+	} );
+
+	function updateAdminbarOffset() {
+		const { top, height } = adminbar.getBoundingClientRect();
+		const offset = Math.max( 0, height + top );
+		document.documentElement.style.setProperty(
+			'--sensei-wpadminbar-offset',
+			offset + 'px'
+		);
+	}
+};
+
+// eslint-disable-next-line @wordpress/no-global-event-listener
+window.addEventListener( 'DOMContentLoaded', trackAdminbarOffset );

--- a/assets/course-theme/course-theme.js
+++ b/assets/course-theme/course-theme.js
@@ -1,10 +1,19 @@
 /**
  * Internal dependencies
  */
+import './scroll-direction';
+import './adminbar-layout';
 import { toggleFocusMode } from './focus-mode';
 
 if ( ! window.sensei ) {
 	window.sensei = {};
 }
 
-window.sensei.courseTheme = { toggleFocusMode };
+/**
+ * Show or hide the sidebar in mobile mode.
+ */
+const toggleSidebar = () => {
+	document.body.classList.toggle( 'sensei-course-theme--sidebar-open' );
+};
+
+window.sensei.courseTheme = { toggleFocusMode, toggleSidebar };

--- a/assets/course-theme/scroll-direction.js
+++ b/assets/course-theme/scroll-direction.js
@@ -1,0 +1,36 @@
+let lastScrollTop = 0;
+
+const SCROLL_CLASS = 'scroll';
+
+/**
+ * Detect if a scroll movement is upward or downward.
+ */
+const detectScrollDirection = () => {
+	const { scrollTop, scrollHeight, clientHeight } = document.documentElement;
+	const delta = scrollTop - lastScrollTop;
+	lastScrollTop = Math.max( 0, scrollTop );
+	setScrollDirection( delta );
+
+	const atBottom = scrollHeight - scrollTop - clientHeight < 100;
+
+	document.body.classList.toggle( `${ SCROLL_CLASS }-bottom`, atBottom );
+};
+
+/**
+ * Set the `scroll-up` or `scroll-down` class on the body based on scroll direction.
+ *
+ * @param {number} delta Scroll movement.
+ */
+const setScrollDirection = ( delta ) => {
+	const [ direction, opposite ] =
+		delta < 0 ? [ 'up', 'down' ] : [ 'down', 'up' ];
+
+	document.body.classList.remove( `${ SCROLL_CLASS }-${ opposite }` );
+	document.body.classList.add( `${ SCROLL_CLASS }-${ direction }` );
+};
+
+// eslint-disable-next-line @wordpress/no-global-event-listener
+window.addEventListener( 'scroll', detectScrollDirection, {
+	capture: false,
+	passive: true,
+} );

--- a/assets/css/sensei-course-theme.scss
+++ b/assets/css/sensei-course-theme.scss
@@ -12,3 +12,4 @@
 @import 'sensei-course-theme/lesson-actions';
 @import 'sensei-course-theme/header';
 @import 'sensei-course-theme/focus-mode';
+@import 'sensei-course-theme/mobile';

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -2,8 +2,8 @@ $default-primary-color: #30968B;
 $default-primary-contrast-color: #FFFFFF;
 
 :root {
-	--primary-color: var(--sensei-course-theme-primary-color, #{$default-primary-color});
-	--primary-contrast-color: var(--sensei-course-theme-button-text-color, #{$default-primary-contrast-color});
+	--primary-color: var(--sensei-course-theme-primary-color, $default-primary-color);
+	--primary-contrast-color: var(--sensei-course-theme-button-text-color, $default-primary-contrast-color);
 	--gray: #787C82;
 }
 

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -2,8 +2,8 @@ $default-primary-color: #30968B;
 $default-primary-contrast-color: #FFFFFF;
 
 :root {
-	--primary-color: var(--sensei-course-theme-primary-color, $default-primary-color);
-	--primary-contrast-color: var(--sensei-course-theme-button-text-color, $default-primary-contrast-color);
+	--primary-color: var(--sensei-course-theme-primary-color, #{$default-primary-color});
+	--primary-contrast-color: var(--sensei-course-theme-button-text-color, #{$default-primary-contrast-color});
 	--gray: #787C82;
 }
 

--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -2,6 +2,7 @@
 	&__button {
 		display: inline-block;
 		font-size: 14px;
+		text-align: center;
 
 		&.is-primary,
 		&.is-secondary {

--- a/assets/css/sensei-course-theme/contact-teacher.scss
+++ b/assets/css/sensei-course-theme/contact-teacher.scss
@@ -6,8 +6,8 @@ body.sensei-course-theme {
 
 	.sensei-contact-teacher-form__submit {
 		padding: 10px 20px;
-		background-color: var(--sensei-course-theme-primary-color, #{$default-primary-color});
-		color: var(--sensei-course-theme-button-text-color, #{$default-primary-contrast-color});
+		background-color: var(--sensei-course-theme-primary-color, $default-primary-color);
+		color: var(--sensei-course-theme-button-text-color, $default-primary-contrast-color);
 		font-weight: 700;
 		font-size: 14px;
 		&.is-busy {

--- a/assets/css/sensei-course-theme/contact-teacher.scss
+++ b/assets/css/sensei-course-theme/contact-teacher.scss
@@ -6,8 +6,8 @@ body.sensei-course-theme {
 
 	.sensei-contact-teacher-form__submit {
 		padding: 10px 20px;
-		background-color: var(--sensei-course-theme-primary-color, $default-primary-color);
-		color: var(--sensei-course-theme-button-text-color, $default-primary-contrast-color);
+		background-color: var(--sensei-course-theme-primary-color, #{$default-primary-color});
+		color: var(--sensei-course-theme-button-text-color, #{$default-primary-contrast-color});
 		font-weight: 700;
 		font-size: 14px;
 		&.is-busy {

--- a/assets/css/sensei-course-theme/course-progress-bar.scss
+++ b/assets/css/sensei-course-theme/course-progress-bar.scss
@@ -1,6 +1,5 @@
 .sensei-course-theme-course-progress-bar {
 	height: 10px;
-	width: 100%;
 	background-color: #DCDCDE;
 }
 

--- a/assets/css/sensei-course-theme/focus-mode.scss
+++ b/assets/css/sensei-course-theme/focus-mode.scss
@@ -10,8 +10,10 @@ $base: '.sensei-course-theme';
 		display: none;
 	}
 }
-.sensei-course-theme__sidebar {
-	padding-top: 32px;
+@media screen and (min-width: 782px) {
+	.sensei-course-theme__sidebar {
+		padding-top: 32px;
+	}
 }
 
 .sensei-course-theme--focus-mode {

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -55,7 +55,7 @@
 	}
 
 	&__main-content {
-		padding: --content-padding;
+		padding: var(--content-padding);
 		margin-left: var(--sidebar-width) !important;
 
 		> * {

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -70,4 +70,8 @@
 			flex: 0 0 auto;
 		}
 	}
+
+	&__actions {
+		flex: 0 0 auto!important;
+	}
 }

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -60,20 +60,13 @@
 			display: flex;
 			align-items: center;
 			gap: 24px;
+			flex: 1 0 auto;
 		}
 
-		&__right {
+		&__navigation {
 			display: flex;
 			align-items: center;
 			gap: 24px;
-		}
-
-		&__container:not(.is-not-stacked-on-mobile) > &__left {
-			flex: 1;
-		}
-
-		&__container:not(.is-not-stacked-on-mobile) > &__right {
-
 			flex: 0 0 auto;
 		}
 	}

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -29,9 +29,28 @@
 		left: 0;
 		width: var(--sidebar-width);
 		border-right: 1px solid #ccc;
-		padding: 24px;
-		padding-right: 16px;
 		background-color: #fff;
+
+		display: flex;
+		flex-direction: column;
+
+		&__content, &__footer {
+			padding: 24px;
+			padding-right: 16px;
+			padding-bottom: 12px;
+		}
+
+		&__content {
+			flex: 1;
+			overflow: auto;
+			overscroll-behavior: contain;
+		}
+		&__footer {
+			display: flex;
+			flex-direction: column;
+			align-items: center;
+			gap: 12px;
+		}
 	}
 
 	&__main-content {
@@ -73,5 +92,6 @@
 
 	&__actions {
 		flex: 0 0 auto!important;
+
 	}
 }

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -65,7 +65,7 @@
 				flex-wrap: wrap;
 				height: 30px;
 			}
-			&__right {
+			&__navigation {
 				gap: 12px;
 				height: 30px;
 			}
@@ -84,13 +84,9 @@
 		}
 
 		&__sidebar-toggle {
+			display: block;
 			font-size: 24px;
-			&:hover {
-				transform: rotate(180deg);
-			}
-			.sidebar-open & {
-				transform: rotate(360deg);
-			}
+			margin-top: -5px;
 		}
 
 		&__sidebar {

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -110,8 +110,8 @@
 		}
 
 		&__main-content {
-			margin-left: 0 !important;
 			flex: 1 !important;
+			margin: 12px !important;
 			padding-bottom: 82px;
 			position: relative;
 		}

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -85,8 +85,15 @@
 
 		&__sidebar-toggle {
 			display: block;
-			font-size: 24px;
-			margin-top: -5px;
+			width: 24px;
+			height: 24px;
+			svg {
+				width: 24px;
+				height: 24px;
+			}
+			&:hover {
+				fill: var(--primary-color);
+			}
 		}
 
 		&__sidebar {

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -5,7 +5,7 @@
 
 @media screen and (max-width: 782px) {
 
-	body.admin-bar  {
+	body.admin-bar {
 		--top-offset: 46px;
 	}
 
@@ -19,10 +19,12 @@
 
 		&--sidebar-open {
 			--header-height: 90px;
+
 			.sensei-course-theme__header__container {
 				padding-bottom: var(--header-open-height);
 
 			}
+
 			.sensei-course-theme-course-progress-bar {
 				margin: 0 24px;
 			}
@@ -56,6 +58,7 @@
 				flex-wrap: wrap;
 				height: 30px;
 			}
+
 			&__navigation {
 				gap: 12px;
 				height: 30px;
@@ -66,9 +69,11 @@
 					max-height: 30px;
 				}
 			}
+
 			.wp-block-sensei-lms-course-title {
 				font-size: 14px;
 			}
+
 			.sensei-course-theme-course-progress-bar {
 				height: 10px;
 			}
@@ -78,10 +83,12 @@
 			display: block;
 			width: 24px;
 			height: 24px;
+
 			svg {
 				width: 24px;
 				height: 24px;
 			}
+
 			&:hover {
 				fill: var(--primary-color);
 			}
@@ -96,13 +103,14 @@
 			transition: all 300ms;
 
 		}
+
 		&:not(&--sidebar-open) &__sidebar {
 			bottom: 100vh;
 			top: -100vh;
 		}
 
 		&__main-content {
-			margin-left: 0!important;
+			margin-left: 0 !important;
 			flex: 1 !important;
 			padding-bottom: 82px;
 			position: relative;
@@ -116,25 +124,27 @@
 			background: #fff;
 			box-shadow: 0px 3px 30px rgba(25, 30, 35, 0.2);
 			transition: bottom 800ms ease-in;
+
 			.sensei-course-theme-lesson-actions {
 				padding: 24px;
 				display: flex;
 				gap: 24px;
+
 				> * {
 					flex: 1;
 				}
+
 				button {
 					width: 100%;
 				}
 			}
 		}
+
 		&--sidebar-open &__actions {
 			transition: bottom 300ms 0ms;
 			bottom: -30vh;
 		}
-		&:not(&--sidebar-open) &__actions {
 
-		}
 		&.scroll-down &__actions {
 			transition-delay: 200ms;
 			bottom: -100px;
@@ -143,15 +153,11 @@
 		&.scroll-bottom &__actions {
 			bottom: 0;
 		}
-		&.scroll-bottom &__main-content {
-
-
-		}
 	}
 }
 
 @media screen and (max-width: 600px) {
-	body.admin-bar  {
+	body.admin-bar {
 		--top-offset: 0px;
 	}
 	.sensei-course-theme {

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -5,31 +5,24 @@
 
 @media screen and (max-width: 782px) {
 
-	@at-root body.admin-bar  {
-		--top-offset: 0px;
+	body.admin-bar  {
+		--top-offset: 46px;
 	}
 
 	.sensei-course-theme__focus-mode-toggle {
 		display: none;
 	}
 
-
 	.sensei-course-theme {
 
 		--header-height: 60px;
 
-		&.sidebar-open {
+		&--sidebar-open {
 			--header-height: 90px;
 			.sensei-course-theme__header__container {
 				padding-bottom: var(--header-open-height);
 
 			}
-
-			.sensei-course-theme__sidebar {
-
-
-			}
-
 			.sensei-course-theme-course-progress-bar {
 				margin: 0 24px;
 			}
@@ -43,8 +36,6 @@
 		}
 
 		&__header {
-
-			top: 0;
 
 			&__container {
 				align-items: flex-start;
@@ -102,15 +93,19 @@
 			left: 0;
 			right: 0;
 			width: unset;
-			overflow: auto;
-			body:not(.sidebar-open) & {
-				bottom: 100vh;
-				top: -100vh;
-			}
+			transition: all 300ms;
+
 		}
+		&:not(&--sidebar-open) &__sidebar {
+			bottom: 100vh;
+			top: -100vh;
+		}
+
 		&__main-content {
 			margin-left: 0!important;
 			flex: 1 !important;
+			padding-bottom: 82px;
+			position: relative;
 		}
 
 		&__actions {
@@ -119,9 +114,10 @@
 			left: 0;
 			right: 0;
 			background: #fff;
-			padding: 24px;
 			box-shadow: 0px 3px 30px rgba(25, 30, 35, 0.2);
+			transition: bottom 800ms ease-in;
 			.sensei-course-theme-lesson-actions {
+				padding: 24px;
 				display: flex;
 				gap: 24px;
 				> * {
@@ -132,8 +128,35 @@
 				}
 			}
 		}
-		&.sidebar-open &__actions {
+		&--sidebar-open &__actions {
 			bottom: -30vh;
+		}
+		&:not(&--sidebar-open) &__actions {
+
+		}
+		&.scroll-down &__actions {
+			transition-delay: 200ms;
+			bottom: -100px;
+		}
+
+		&.scroll-bottom &__actions {
+			bottom: 0;
+		}
+		&.scroll-bottom &__main-content {
+
+
+		}
+	}
+}
+
+@media screen and (max-width: 600px) {
+	body.admin-bar  {
+		--top-offset: 0px;
+	}
+	.sensei-course-theme {
+		&--sidebar-open &__sidebar {
+			transition: all 400ms, padding-top 0ms 0ms;
+			padding-top: calc(24px + var(--sensei-wpadminbar-offset, 0px));
 		}
 	}
 }

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -14,7 +14,7 @@
 	}
 
 	.sensei-course-theme {
-
+		--content-padding: 12px;
 		--header-height: 60px;
 
 		&--sidebar-open {
@@ -111,7 +111,8 @@
 
 		&__main-content {
 			flex: 1 !important;
-			margin: 12px !important;
+			margin-left: 0!important;
+
 			padding-bottom: 82px;
 			position: relative;
 		}

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -1,0 +1,136 @@
+
+.sensei-course-theme__sidebar-toggle {
+	display: none;
+}
+
+@media screen and (max-width: 782px) {
+
+	@at-root body.admin-bar  {
+		--top-offset: 0px;
+	}
+
+	.sensei-course-theme__focus-mode-toggle {
+		display: none;
+	}
+
+
+	.sensei-course-theme {
+
+		--header-height: 60px;
+
+		&.sidebar-open {
+			--header-height: 90px;
+			.sensei-course-theme__header__container {
+				padding-bottom: var(--header-open-height);
+
+			}
+
+			.sensei-course-theme__sidebar {
+
+
+			}
+
+			.sensei-course-theme-course-progress-bar {
+				margin: 0 24px;
+			}
+
+			.sensei-course-theme__header .sensei-course-theme-course-progress {
+				display: block;
+				position: absolute;
+				left: 24px;
+				bottom: 22px;
+			}
+		}
+
+		&__header {
+
+			top: 0;
+
+			&__container {
+				align-items: flex-start;
+				padding-top: 12px;
+				overflow: hidden;
+			}
+
+			.sensei-course-theme-course-progress, .sensei-course-theme-prev-next-lesson-text {
+				display: none;
+			}
+
+			.sensei-course-theme-prev-next-lesson-a {
+				padding: 2px;
+			}
+
+			&__left {
+				gap: 12px;
+				flex-wrap: wrap;
+				height: 30px;
+			}
+			&__right {
+				gap: 12px;
+				height: 30px;
+			}
+
+			.wp-block-sensei-lms-site-logo {
+				&, img {
+					max-height: 30px;
+				}
+			}
+			.wp-block-sensei-lms-course-title {
+				font-size: 14px;
+			}
+			.sensei-course-theme-course-progress-bar {
+				height: 10px;
+			}
+		}
+
+		&__sidebar-toggle {
+			font-size: 24px;
+			&:hover {
+				transform: rotate(180deg);
+			}
+			.sidebar-open & {
+				transform: rotate(360deg);
+			}
+		}
+
+		&__sidebar {
+			z-index: 90;
+			background: #FFFFFF;
+			left: 0;
+			right: 0;
+			width: unset;
+			overflow: auto;
+			body:not(.sidebar-open) & {
+				bottom: 100vh;
+				top: -100vh;
+			}
+		}
+		&__main-content {
+			margin-left: 0!important;
+			flex: 1 !important;
+		}
+
+		&__actions {
+			position: fixed;
+			bottom: 0;
+			left: 0;
+			right: 0;
+			background: #fff;
+			padding: 24px;
+			box-shadow: 0px 3px 30px rgba(25, 30, 35, 0.2);
+			.sensei-course-theme-lesson-actions {
+				display: flex;
+				gap: 24px;
+				> * {
+					flex: 1;
+				}
+				button {
+					width: 100%;
+				}
+			}
+		}
+		&.sidebar-open &__actions {
+			bottom: -30vh;
+		}
+	}
+}

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -129,6 +129,7 @@
 			}
 		}
 		&--sidebar-open &__actions {
+			transition: bottom 300ms 0ms;
 			bottom: -30vh;
 		}
 		&:not(&--sidebar-open) &__actions {

--- a/assets/css/sensei-course-theme/prev-next-lesson.scss
+++ b/assets/css/sensei-course-theme/prev-next-lesson.scss
@@ -40,19 +40,10 @@
 			}
 		}
 
-		&__prev {
+		&__prev, &__next {
 			svg {
-				margin-right: 14px;
-				width: 5px;
-				height: 11px;
-			}
-		}
-
-		&__next {
-			svg {
-				margin-left: 14px;
-				width: 5px;
-				height: 11px;
+				width: 24px;
+				height: 24px;
 			}
 		}
 	}

--- a/assets/css/sensei-course-theme/resets.scss
+++ b/assets/css/sensei-course-theme/resets.scss
@@ -1,17 +1,17 @@
+
 .sensei-course-theme__frame {
 
-	// Reset browser styles.
+	* {
+		all: unset;
+		display: revert;
+		box-sizing: border-box;
+	}
 
 	@at-root body {
 		margin: 0;
 	}
 	@at-root * {
 		box-sizing: border-box;
-	}
-
-	* {
-		all: unset;
-		display: revert;
 	}
 
 	.screen-reader-text {

--- a/assets/images/chevron-left.svg
+++ b/assets/images/chevron-left.svg
@@ -1,3 +1,3 @@
-<svg viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<path d="M7 1.00002L2 6.50002L7 12" stroke="currentColor" stroke-width="1.5"/>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path d="M14 7.00002L9 12.5L14 18" stroke="currentColor" stroke-width="1.5"/>
 </svg>

--- a/assets/images/chevron-right.svg
+++ b/assets/images/chevron-right.svg
@@ -1,3 +1,3 @@
-<svg viewBox="0 0 8 13" fill="none" xmlns="http://www.w3.org/2000/svg">
-	<path d="M0.999999 1.00002L6 6.50002L1 12" stroke="currentColor" stroke-width="1.5"/>
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path d="M10 7.00002L15 12.5L10 18" stroke="currentColor" stroke-width="1.5"/>
 </svg>

--- a/assets/images/menu.svg
+++ b/assets/images/menu.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z" />
+</svg>

--- a/includes/blocks/course-theme/class-course-theme.php
+++ b/includes/blocks/course-theme/class-course-theme.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 use Sensei\Blocks\Course_Theme\Course_Title;
 use Sensei\Blocks\Course_Theme\Focus_Mode;
+use Sensei\Blocks\Course_Theme\Sidebar_Toggle_Button;
 use Sensei\Blocks\Course_Theme\Site_Logo;
 use \Sensei_Blocks_Initializer;
 use \Sensei_Course_Theme_Option;
@@ -67,6 +68,7 @@ class Course_Theme extends Sensei_Blocks_Initializer {
 		new Site_Logo();
 		new Notices();
 		new Focus_Mode();
+		new Sidebar_Toggle_Button();
 		if ( 'lesson' === get_post_type() ) {
 			new Prev_Lesson();
 			new Next_Lesson();

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -112,22 +112,22 @@ class Lesson_Actions {
 		// Quiz button.
 		if ( ! empty( $quiz_permalink ) && ! Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id ) ) {
 			$take_quiz_button = $this->render_take_quiz( $quiz_permalink, $has_incomplete_prerequisite );
-			$actions[]        = '<li>' . $take_quiz_button . '</li>';
+			$actions[]        = $take_quiz_button;
 		}
 
 		// Complete button.
 		if ( ! $is_pass_required ) {
 			$complete_button_class  = isset( $take_quiz_button ) ? 'is-secondary' : 'is-primary';
 			$complete_lesson_button = $this->render_complete_lesson( $complete_button_class, $has_incomplete_prerequisite );
-			$actions[]              = '<li>' . $complete_lesson_button . '</li>';
+			$actions[]              = $complete_lesson_button;
 		}
 
 		if ( empty( $actions ) ) {
 			return '';
 		}
 
-		return '<ul class="sensei-course-theme-lesson-actions">
+		return '<div class="sensei-course-theme-lesson-actions">
 			' . implode( '', $actions ) . '
-		</ul>';
+		</div>';
 	}
 }

--- a/includes/blocks/course-theme/class-next-lesson.php
+++ b/includes/blocks/course-theme/class-next-lesson.php
@@ -53,7 +53,7 @@ class Next_Lesson {
 			return '';
 		}
 		$url  = esc_url( $urls['next']['url'] );
-		$text = $attributes['text'] ?? __( 'Next Lesson', 'sensei-lms' );
+		$text = $attributes['text'] ?? __( 'Next', 'sensei-lms' );
 		$text = wp_kses_post( $text );
 		$icon = \Sensei()->assets->get_icon( 'chevron-right' );
 

--- a/includes/blocks/course-theme/class-prev-lesson.php
+++ b/includes/blocks/course-theme/class-prev-lesson.php
@@ -53,7 +53,7 @@ class Prev_Lesson {
 			return '';
 		}
 		$url  = esc_url( $urls['previous']['url'] );
-		$text = $attributes['text'] ?? __( 'Previous Lesson', 'sensei-lms' );
+		$text = $attributes['text'] ?? __( 'Previous', 'sensei-lms' );
 		$text = wp_kses_post( $text );
 		$icon = \Sensei()->assets->get_icon( 'chevron-left' );
 

--- a/includes/blocks/course-theme/class-sidebar-toggle-button.php
+++ b/includes/blocks/course-theme/class-sidebar-toggle-button.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * File containing the Sidebar_Toggle_Button class.
+ *
+ * @package sensei
+ * @since 3.13.4
+ */
+
+namespace Sensei\Blocks\Course_Theme;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use \Sensei_Blocks;
+
+/**
+ * Class Sidebar_Toggle_Button the back to lesson block in the quiz.
+ */
+class Sidebar_Toggle_Button {
+	/**
+	 * Quiz_Back_To_Lesson constructor.
+	 */
+	public function __construct() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/sidebar-toggle-button',
+			[
+				'render_callback' => [ $this, 'render' ],
+			]
+		);
+	}
+
+	/**
+	 * Renders the block.
+	 *
+	 * @param array $attributes The block attributes.
+	 *
+	 * @access private
+	 *
+	 * @return string The block HTML.
+	 */
+	public function render( array $attributes = [] ) : string {
+		$icon = \Sensei()->assets->get_icon( 'menu' );
+		$label = __('Toggle course navigation', 'sensei-lms');
+		return "<button class='sensei-course-theme__sidebar-toggle' onclick=\"sensei.courseTheme.toggleSidebar()\" title='{$label}'>{$icon}</button>";
+	}
+}

--- a/includes/blocks/course-theme/class-sidebar-toggle-button.php
+++ b/includes/blocks/course-theme/class-sidebar-toggle-button.php
@@ -15,11 +15,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 use \Sensei_Blocks;
 
 /**
- * Class Sidebar_Toggle_Button the back to lesson block in the quiz.
+ * A button to toggle the sidebar in mobile view.
  */
 class Sidebar_Toggle_Button {
 	/**
-	 * Quiz_Back_To_Lesson constructor.
+	 * Sidebar_Toggle_Button constructor.
 	 */
 	public function __construct() {
 		Sensei_Blocks::register_sensei_block(
@@ -42,6 +42,6 @@ class Sidebar_Toggle_Button {
 	public function render( array $attributes = [] ) : string {
 		$icon  = \Sensei()->assets->get_icon( 'menu' );
 		$label = __( 'Toggle course navigation', 'sensei-lms' );
-		return "<button class='sensei-course-theme__sidebar-toggle' onclick=\"sensei.courseTheme.toggleSidebar()\" title='{$label}'>{$icon}</button>";
+		return "<button class='sensei-course-theme__sidebar-toggle' onclick='sensei.courseTheme.toggleSidebar()' title='{$label}'>{$icon}</button>";
 	}
 }

--- a/includes/blocks/course-theme/class-sidebar-toggle-button.php
+++ b/includes/blocks/course-theme/class-sidebar-toggle-button.php
@@ -40,8 +40,8 @@ class Sidebar_Toggle_Button {
 	 * @return string The block HTML.
 	 */
 	public function render( array $attributes = [] ) : string {
-		$icon = \Sensei()->assets->get_icon( 'menu' );
-		$label = __('Toggle course navigation', 'sensei-lms');
+		$icon  = \Sensei()->assets->get_icon( 'menu' );
+		$label = __( 'Toggle course navigation', 'sensei-lms' );
 		return "<button class='sensei-course-theme__sidebar-toggle' onclick=\"sensei.courseTheme.toggleSidebar()\" title='{$label}'>{$icon}</button>";
 	}
 }

--- a/includes/class-sensei-assets.php
+++ b/includes/class-sensei-assets.php
@@ -289,7 +289,7 @@ class Sensei_Assets {
 						'width'   => true,
 						'height'  => true,
 						'fill'    => true,
-						'viewBox' => true,
+						'viewbox' => true,
 						'xmlns'   => true,
 					],
 					'path'   => [

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -214,6 +214,7 @@ class Sensei_Autoloader {
 			'Sensei\Blocks\Course_Theme\Quiz_Back_To_Lesson' => 'blocks/course-theme/class-quiz-back-to-lesson.php',
 			'Sensei\Blocks\Course_Theme\Course_Progress_Counter' => 'blocks/course-theme/class-course-progress-counter.php',
 			'Sensei\Blocks\Course_Theme\Course_Progress_Bar' => 'blocks/course-theme/class-course-progress-bar.php',
+			'Sensei\Blocks\Course_Theme\Sidebar_Toggle_Button' => 'blocks/course-theme/class-sidebar-toggle-button.php',
 		);
 	}
 

--- a/themes/sensei-course-theme/single.php
+++ b/themes/sensei-course-theme/single.php
@@ -22,10 +22,15 @@
 		<!-- /wp:column -->
 		<!-- wp:column {"className":"sensei-course-theme__header__navigation"} -->
 		<div class="sensei-course-theme__header__navigation">
+			<button class="sensei-course-theme__sidebar-toggle" onclick="document.body.classList.toggle('sidebar-open')">🍔</button>
 			<!-- wp:sensei-lms/course-theme-prev-next-lesson -->
 			<!-- wp:sensei-lms/course-theme-prev-lesson {"inContainer":true} /-->
 			<!-- wp:sensei-lms/course-theme-next-lesson {"inContainer":true} /-->
 			<!-- /wp:sensei-lms/course-theme-prev-next-lesson -->
+		</div>
+		<!-- /wp:column -->
+		<!-- wp:column {"className":"sensei-course-theme__actions"} -->
+		<div class="sensei-course-theme__actions">
 			<!-- wp:sensei-lms/course-theme-lesson-actions /-->
 		</div>
 		<!-- /wp:column -->

--- a/themes/sensei-course-theme/single.php
+++ b/themes/sensei-course-theme/single.php
@@ -22,11 +22,11 @@
 		<!-- /wp:column -->
 		<!-- wp:column {"className":"sensei-course-theme__header__navigation"} -->
 		<div class="sensei-course-theme__header__navigation">
-			<button class="sensei-course-theme__sidebar-toggle" onclick="document.body.classList.toggle('sidebar-open')">🍔</button>
 			<!-- wp:sensei-lms/course-theme-prev-next-lesson -->
 			<!-- wp:sensei-lms/course-theme-prev-lesson {"inContainer":true} /-->
 			<!-- wp:sensei-lms/course-theme-next-lesson {"inContainer":true} /-->
 			<!-- /wp:sensei-lms/course-theme-prev-next-lesson -->
+			<!-- wp:sensei-lms/sidebar-toggle-button /-->
 		</div>
 		<!-- /wp:column -->
 		<!-- wp:column {"className":"sensei-course-theme__actions"} -->

--- a/themes/sensei-course-theme/single.php
+++ b/themes/sensei-course-theme/single.php
@@ -43,10 +43,17 @@
 <div class="sensei-course-theme__columns">
 	<!-- wp:column {"width":"300px","className":"sensei-course-theme__sidebar"} -->
 	<div class="sensei-course-theme__sidebar sensei-course-theme__frame" style="flex-basis:300px">
-		<!-- wp:sensei-lms/sidebar-toggle /-->
-
-		<!-- wp:sensei-lms/focus-mode-toggle /-->
-		<!-- wp:sensei-lms/course-navigation /-->
+		<!-- wp:sensei-lms/sidebar-content -->
+		<div class="sensei-course-theme__sidebar__content">
+			<!-- wp:sensei-lms/focus-mode-toggle /-->
+			<!-- wp:sensei-lms/course-navigation /-->
+		</div>
+		<!-- wp:sensei-lms/sidebar-footer -->
+		<div class="sensei-course-theme__sidebar__footer">
+			<button class="sensei-course-theme__button is-secondary">Contact Teacher</button>
+			<a href="/">Exit Course</a>
+		</div>
+		<!-- /wp:sensei-lms/sidebar-footer -->
 	</div>
 	<!-- /wp:column -->
 

--- a/themes/sensei-course-theme/single.php
+++ b/themes/sensei-course-theme/single.php
@@ -12,16 +12,16 @@
 <!-- wp:sensei-lms/container {"className":"sensei-course-theme__header"} -->
 <div class="wp-block-sensei-lms-container sensei-course-theme__header sensei-course-theme__frame">
 	<!-- wp:columns {"className":"sensei-course-theme__header"} -->
-	<div class="wp-block-columns sensei-course-theme__header__container">
+	<div class="sensei-course-theme__header__container">
 		<!-- wp:column {"className":"sensei-course-theme__header__left"} -->
-		<div class="wp-block-column sensei-course-theme__header__left">
+		<div class="sensei-course-theme__header__left">
 			<!-- wp:sensei-lms/site-logo /-->
 			<!-- wp:sensei-lms/course-title /-->
 			<!-- wp:sensei-lms/course-theme-course-progress-counter /-->
 		</div>
 		<!-- /wp:column -->
-		<!-- wp:column {"className":"sensei-course-theme__header__right"} -->
-		<div class="wp-block-column sensei-course-theme__header__right">
+		<!-- wp:column {"className":"sensei-course-theme__header__navigation"} -->
+		<div class="sensei-course-theme__header__navigation">
 			<!-- wp:sensei-lms/course-theme-prev-next-lesson -->
 			<!-- wp:sensei-lms/course-theme-prev-lesson {"inContainer":true} /-->
 			<!-- wp:sensei-lms/course-theme-next-lesson {"inContainer":true} /-->
@@ -35,16 +35,18 @@
 </div>
 <!-- /wp:sensei-lms/container -->
 <!-- wp:columns {"className":"sensei-course-theme__columns"} -->
-<div class="wp-block-columns sensei-course-theme__columns">
+<div class="sensei-course-theme__columns">
 	<!-- wp:column {"width":"300px","className":"sensei-course-theme__sidebar"} -->
-	<div class="wp-block-column sensei-course-theme__sidebar sensei-course-theme__frame" style="flex-basis:300px">
+	<div class="sensei-course-theme__sidebar sensei-course-theme__frame" style="flex-basis:300px">
+		<!-- wp:sensei-lms/sidebar-toggle /-->
+
 		<!-- wp:sensei-lms/focus-mode-toggle /-->
 		<!-- wp:sensei-lms/course-navigation /-->
 	</div>
 	<!-- /wp:column -->
 
 	<!-- wp:column {"width":"","className":"sensei-course-theme__main-content"} -->
-	<div class="wp-block-column sensei-course-theme__main-content">
+	<div class="sensei-course-theme__main-content">
 		<!-- wp:post-title /-->
 
 		<!-- wp:sensei-lms/course-theme-notices /-->


### PR DESCRIPTION
Fixes #4484 


### Changes proposed in this Pull Request
- Add mobile/responsive layout to course theme:
- Make sidebar a toggle-able menu
- Move lesson actions to sticky bottom footer, hidden when scrolling
- Adjust sizes & spacing a bit

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Take out mobile phone
* Open lesson of a course with course theme enabled
* Browse around the course. Make sure sidebar and action buttons are showing correctly


<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img src="https://user-images.githubusercontent.com/176949/145651748-bb2ef915-4fe8-4823-ba6e-1ea402a03e4f.gif" width=240 />

