### PR TITLE
Reorganize quiz pagination settings

### DIFF
--- a/assets/blocks/quiz/question-block/question-settings.js
+++ b/assets/blocks/quiz/question-block/question-settings.js
@@ -31,7 +31,7 @@ const QuestionSettings = ( {
 	return (
 		<InspectorControls>
 			<PanelBody
-				title={ __( 'Question Settings', 'sensei-lms' ) }
+				title={ __( 'Question settings', 'sensei-lms' ) }
 				initialOpen={ true }
 			>
 				{ [ QuestionGradeSettings, ...controls ].map(

--- a/assets/blocks/quiz/quiz-block/pagination-settings.js
+++ b/assets/blocks/quiz/quiz-block/pagination-settings.js
@@ -74,7 +74,7 @@ const QuestionsControl = ( { settings, onChange, ...props } ) => {
 				}
 				{ ...props }
 			/>
-			<div>{ __( 'per page', 'sensei-lms' ) }</div>
+			<span>{ __( 'per page', 'sensei-lms' ) }</span>
 		</>
 	);
 };
@@ -104,49 +104,39 @@ export const PaginationSidebarSettings = ( {
 	return (
 		<>
 			<PanelBody
-				className="sensei-lms-quiz-block-styling"
-				title={ __( 'Quiz styling', 'sensei-lms' ) }
+				title={ __( 'Pagination', 'sensei-lms' ) }
 				initialOpen={ true }
 			>
-				<p>
-					{ __(
-						'Adjust how your quiz is displayed to your learners.',
-						'sensei-lms'
-					) }
-				</p>
-				<PanelRow className="sensei-lms-quiz-block-panel">
-					<h2 className="sensei-lms-quiz-block-panel__row">
-						{ __( 'Pagination', 'sensei-lms' ) }
-					</h2>
-					<div className="sensei-lms-quiz-block-panel__row">
-						<SelectControl
-							label={ __( 'Pagination', 'sensei-lms' ) }
-							hideLabelFromVision
-							value={ paginationNumber === null ? SINGLE : MULTI }
-							options={ paginationOptions }
-							onChange={ onDropdownChange(
-								settings,
-								onChange,
-								questionCount
-							) }
-						/>
-					</div>
-					{ paginationNumber !== null && (
-						<div className="sensei-lms-quiz-block-panel__row sensei-lms-quiz-block-panel__questions">
-							<QuestionsControl
-								settings={ settings }
-								onChange={ onChange }
-								questionCount={ questionCount }
-							/>
-						</div>
-					) }
+				<PanelRow className="sensei-lms-quiz-block__pagination">
+					<SelectControl
+						label={ __( 'Pagination', 'sensei-lms' ) }
+						hideLabelFromVision
+						value={ paginationNumber === null ? SINGLE : MULTI }
+						options={ paginationOptions }
+						onChange={ onDropdownChange(
+							settings,
+							onChange,
+							questionCount
+						) }
+					/>
 				</PanelRow>
-				<PanelRow className="sensei-lms-quiz-block-panel">
-					<h2 className="sensei-lms-quiz-block-panel__row">
-						{ __( 'Progress Bar', 'sensei-lms' ) }
-					</h2>
+				{ paginationNumber !== null && (
+					<PanelRow className="sensei-lms-quiz-block__question-count">
+						<QuestionsControl
+							settings={ settings }
+							onChange={ onChange }
+							questionCount={ questionCount }
+						/>
+					</PanelRow>
+				) }
+			</PanelBody>
+
+			<PanelBody
+				title={ __( 'Progress bar settings', 'sensei-lms' ) }
+				initialOpen={ true }
+			>
+				<PanelRow>
 					<ToggleControl
-						className="sensei-lms-quiz-block-panel__row"
 						checked={ showProgressBar }
 						label={ __( 'Show Progress Bar', 'sensei-lms' ) }
 						value={ progressBarRadius }
@@ -157,36 +147,37 @@ export const PaginationSidebarSettings = ( {
 							} )
 						}
 					/>
-					<div className="sensei-lms-quiz-block-panel__row sensei-lms-quiz-block-panel__progress-bar">
-						<NumberControl
-							label={ __( 'Radius', 'sensei-lms' ) }
-							min={ 1 }
-							step={ 1 }
-							suffix={ __( 'PX', 'sensei-lms' ) }
-							value={ progressBarRadius }
-							onChange={ ( value ) =>
-								onChange( {
-									...settings,
-									progressBarRadius: value,
-								} )
-							}
-						/>
-						<NumberControl
-							label={ __( 'Height', 'sensei-lms' ) }
-							min={ 1 }
-							step={ 1 }
-							suffix={ __( 'PX', 'sensei-lms' ) }
-							value={ progressBarHeight }
-							onChange={ ( value ) =>
-								onChange( {
-									...settings,
-									progressBarHeight: value,
-								} )
-							}
-						/>
-					</div>
+				</PanelRow>
+				<PanelRow className="sensei-lms-quiz-block__progress-bar">
+					<NumberControl
+						label={ __( 'Radius', 'sensei-lms' ) }
+						min={ 1 }
+						step={ 1 }
+						suffix={ __( 'PX', 'sensei-lms' ) }
+						value={ progressBarRadius }
+						onChange={ ( value ) =>
+							onChange( {
+								...settings,
+								progressBarRadius: value,
+							} )
+						}
+					/>
+					<NumberControl
+						label={ __( 'Height', 'sensei-lms' ) }
+						min={ 1 }
+						step={ 1 }
+						suffix={ __( 'PX', 'sensei-lms' ) }
+						value={ progressBarHeight }
+						onChange={ ( value ) =>
+							onChange( {
+								...settings,
+								progressBarHeight: value,
+							} )
+						}
+					/>
 				</PanelRow>
 			</PanelBody>
+
 			<PanelColorSettings
 				title={ __( 'Color settings', 'sensei-lms' ) }
 				initialOpen={ false }
@@ -254,7 +245,7 @@ export const PaginationToolbarSettings = ( {
 				/>
 			</Toolbar>
 			{ paginationNumber !== null && (
-				<ToolbarGroup className="sensei-lms-quiz-block-toolbar__group">
+				<ToolbarGroup className="sensei-lms-quiz-block__toolbar-group">
 					<QuestionsControl
 						settings={ settings }
 						onChange={ onChange }

--- a/assets/blocks/quiz/quiz-block/pagination-settings.js
+++ b/assets/blocks/quiz/quiz-block/pagination-settings.js
@@ -138,7 +138,7 @@ export const PaginationSidebarSettings = ( {
 
 			<PanelBody
 				title={ __( 'Progress bar settings', 'sensei-lms' ) }
-				initialOpen={ true }
+				initialOpen={ false }
 			>
 				<PanelRow>
 					<ToggleControl

--- a/assets/blocks/quiz/quiz-block/pagination-settings.js
+++ b/assets/blocks/quiz/quiz-block/pagination-settings.js
@@ -10,7 +10,7 @@ import {
 	Toolbar,
 	ToolbarGroup,
 } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -64,7 +64,12 @@ const QuestionsControl = ( { settings, onChange, ...props } ) => {
 				min={ 1 }
 				step={ 1 }
 				hideLabelFromVision
-				suffix={ __( 'Questions', 'sensei-lms' ) }
+				suffix={ _n(
+					'question',
+					'questions',
+					paginationNumber,
+					'sensei-lms'
+				) }
 				value={ paginationNumber }
 				onChange={ ( value ) =>
 					onChange( {

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -87,7 +87,7 @@ const QuizSettings = ( {
 		<>
 			<InspectorControls>
 				<PanelBody
-					title={ __( 'Quiz Settings', 'sensei-lms' ) }
+					title={ __( 'Quiz settings', 'sensei-lms' ) }
 					initialOpen={ true }
 				>
 					<PanelRow>

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -70,51 +70,25 @@ $gray-400: #ccc;
 			}
 		}
 	}
-}
 
-.sensei-lms-quiz-block-styling .sensei-lms-quiz-block-panel {
-	flex-wrap: wrap;
-
-	h2 {
-		font-size: calc( #{$default-font-size} + 1px );
-		font-weight: normal;
-	}
-
-	&__row {
-		flex-basis: 100%;
-		margin-right: 1em;
-	}
-
-	.components-base-control {
-		margin-bottom: 1em;
-	}
-
-	&__questions {
-		display: flex;
+	/* Settings */
+	&__question-count,
+	&__progress-bar {
 		align-items: baseline;
+		justify-content: flex-start;
 
 		.components-base-control {
-			flex-basis: 62%;
+			margin-bottom: 0;
 			margin-right: 1em;
 		}
-
-		p {
-			flex-basis: 30%;
-		}
 	}
 
-	&__progress-bar {
-		display: flex;
-		justify-content: space-between;
-
-		.components-base-control {
-			flex-basis: 48%;
-		}
+	&__question-count {
+		margin-bottom: 12px;
 	}
-}
 
-.sensei-lms-quiz-block-toolbar {
-	&__group {
+	/* Toolbar */
+	&__toolbar-group {
 		align-items: center;
 		padding: 0 1em;
 		width: 17em;
@@ -131,7 +105,6 @@ $gray-400: #ccc;
 }
 
 .sensei-lms-block-validation-notice {
-
 	display: inline-block;
 	margin: 4px 0;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Renames the Quiz block settings panel from "Quiz Settings"  to "Quiz settings" and the Question block settings panel from "Question Settings" to "Question settings", to better match the case that is used in our other blocks.
* Separates _Quiz styling_ into separate panels - _Pagination_ and _Progress bar settings_.
* Uses the singular or plural form of the word "question" based on the actual question count.
* Collapses the _Progress bar settings_ by default.

### Testing instructions
* Add the Quiz block to a lesson.
* Confirm that the settings panels were renamed as per the above.
* For the Quiz block, check that there is a _Pagination_ panel (default open) and a _Progress bar settings_ panel (default closed).
* Resize the browser and / or view the settings on mobile and ensure they look good.
* Play with the "per page" setting and ensure that "question" or "questions" appears in the field depending on if the value is 1 or > 1.

### Screenshot / Video

#### Before
![Screen Shot 2021-12-09 at 4 16 50 PM](https://user-images.githubusercontent.com/1190420/145476981-2dc19cda-831d-45ff-8301-e74a9280a580.jpg)

#### After
![Screen Shot 2021-12-09 at 4 17 18 PM](https://user-images.githubusercontent.com/1190420/145477025-0e78cf6c-cfa4-499c-b531-ab9af2a87864.jpg)