### PR TITLE
Casting `lesson_length` value to integer in the backend.

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -813,6 +813,12 @@ class Sensei_Lesson {
 			return;
 		}
 
+		// Parse the value for `lesson_length` field as integer.
+		if ( 'lesson_length' === $post_key ) {
+			// phpcs:ignore WordPress.Security.NonceVerification
+			$new_meta_value = isset( $_POST[ $post_key ] ) ? intval( $_POST[ $post_key ] ) : '';
+		}
+
 		// update field with the new value
 		if ( -1 != $new_meta_value ) {
 			return update_post_meta( $post_id, $meta_key, $new_meta_value );


### PR DESCRIPTION
As discussed in #2764 and given it is already fixed in the frontend when
using the Lesson Properties block we are doing the simplest fix.

Fixes #2764

### Changes proposed in this Pull Request

* Casting the `lesson_length` meta property to an integer using `intval`.

### Testing instructions

* Create a new Lesson or edit an existing one.
* Make sure the Lesson Properties block is not present in the block editor.
* At the bottom the Lesson Properties meta box should appear.
* Add a value with decimals there, for example `10.5`.
* Save/publish and do a full refresh to see the value persisted for the Lesson Length property.
* For the previous example (`10.5`) it should read `10`.

### Screenshot / Video
![Kapture 2021-12-10 at 14 34 37](https://user-images.githubusercontent.com/799065/145582502-b8a37379-210a-4c57-9ce4-bf8b2cdd9552.gif)
