### PR TITLE
Removing ID attribute to prevent duplication.

### DIFF
--- a/includes/shortcodes/class-sensei-shortcode-user-courses.php
+++ b/includes/shortcodes/class-sensei-shortcode-user-courses.php
@@ -551,7 +551,7 @@ class Sensei_Shortcode_User_Courses implements Sensei_Shortcode_Interface {
 				$css_class = $key === $this->status ? 'active' : 'inactive';
 				$url       = add_query_arg( self::MY_COURSES_STATUS_FILTER, $key, $base_url );
 				?>
-				<a id="sensei-user-courses-all-action" href="<?php echo esc_url( $url ); ?>" class="<?php echo esc_attr( $css_class ); ?>"><?php echo esc_html( $option ); ?></a>
+				<a href="<?php echo esc_url( $url ); ?>" class="<?php echo esc_attr( $css_class ); ?>"><?php echo esc_html( $option ); ?></a>
 			<?php } ?>
 		</section>
 


### PR DESCRIPTION
Currently the IDs were not being used so we can remove them. Another alternative would be to compose the ID with the `$key`.

Fixes #2716

### Changes proposed in this Pull Request

* Removing `id` attribute for the links in the toggle menu rendered by the shortcode `[sensei_user_courses]`.

### Testing instructions
* Go to My Courses page (or any other using the `[sensei_user_courses]` shortcode).
* Run an HTML verification tool or check that the `sensei-user-courses-all-action` id is not duplicated.

### Screenshot / Video
![image](https://user-images.githubusercontent.com/799065/145588836-3c8853ad-d3f7-49f0-920b-544eec92e321.png)
