### PR TITLE
Fixing multiple pages due to Page Breaks in unsupported Sensei themes.

### DIFF
--- a/includes/renderers/class-sensei-renderer-single-post.php
+++ b/includes/renderers/class-sensei-renderer-single-post.php
@@ -120,6 +120,8 @@ class Sensei_Renderer_Single_Post implements Sensei_Renderer_Interface {
 	 * Create the posts query.
 	 */
 	private function setup_post_query() {
+		global $page;
+
 		if ( empty( $this->post_id ) ) {
 			return;
 		}
@@ -127,6 +129,7 @@ class Sensei_Renderer_Single_Post implements Sensei_Renderer_Interface {
 		$args = array(
 			'p'         => $this->post_id,
 			'post_type' => get_post_type( $this->post_id ),
+			'page'      => $page,
 		);
 
 		$this->post_query = new WP_Query( $args );


### PR DESCRIPTION
We are now taking into account the current `$page` variable in order to properly display the expected part of the content when rendering with an unsupported theme a multi-page course or lesson (adding Page Breaks).

Pagination will depend on how and where the actual theme displays it.

Fixes #3318

### Changes proposed in this Pull Request

* Now we are adding the global `$page` variable to the WP_Query when using an unsupported theme.

### Testing instructions
* Use an "unsupported theme" like Twenty Twenty-one.
* Edit or create a lesson (or course) and add at least a Page Break in the content.
* Go to the lesson (or course) and you should see the first part of the content.
* Locate the pagination (depending on the Theme might at the bottom of the page).
* Click on some page and check the content is properly displayed.

### Screenshot / Video
![Kapture 2021-12-13 at 12 52 34](https://user-images.githubusercontent.com/799065/145808023-df33feea-afef-486c-a181-a05434a5c574.gif)
