### PR TITLE
Allow only before or after text on the gap question

### DIFF
--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -67,15 +67,15 @@ const questionTypes = {
 				'sensei-lms'
 			),
 			noRightAnswerWhitespace: __(
-				'The value of the right answer can not be whitespace character.',
+				'The value of the right answer can not be blank space.',
 				'sensei-lms'
 			),
 			noWrongAnswer: __(
-				'Add a wrong answer to this question. Value can not be whitespace character.',
+				'Add a wrong answer to this question. Value can not be blank space.',
 				'sensei-lms'
 			),
 			noWrongAnswerWhitespace: __(
-				'The value of the wrong answer can not be whitespace character.',
+				'The value of the wrong answer can not be blank space.',
 				'sensei-lms'
 			),
 		},
@@ -111,15 +111,15 @@ const questionTypes = {
 		messages: {
 			noGap: __( 'Add a right answer to this question.', 'sensei-lms' ),
 			noGapWhitespace: __(
-				'The value of a right answer can not be whitespace character.',
+				'The value of a right answer can not be blank space.',
 				'sensei-lms'
 			),
 			noBeforeAndNoAfter: __(
-				'Add text before or after the gap. Value can not be whitespace character.',
+				'Add text before or after the gap. Value can not be blank space.',
 				'sensei-lms'
 			),
 			noBeforeAndNoAfterWhitespace: __(
-				'Value of the text before or after the gap can not be whitespace character.',
+				'Value of the text before or after the gap can not be blank space.',
 				'sensei-lms'
 			),
 		},

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -85,14 +85,15 @@ const questionTypes = {
 		validate: ( { before, after, gap } = {} ) => {
 			return {
 				noGap: ! gap?.length,
-				noBefore: ! before,
-				noAfter: ! after,
+				noBeforeAndNoAfter: ! before && ! after,
 			};
 		},
 		messages: {
 			noGap: __( 'Add a right answer to this question.', 'sensei-lms' ),
-			noBefore: __( 'Add text before and after the gap.', 'sensei-lms' ),
-			noAfter: __( 'Add text before and after the gap.', 'sensei-lms' ),
+			noBeforeAndNoAfter: __(
+				'Add text before or after the gap.',
+				'sensei-lms'
+			),
 		},
 	},
 	'single-line': {

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -44,22 +44,26 @@ const questionTypes = {
 		feedback: true,
 		validate: ( { answers = [] } = {} ) => {
 			return {
-				noAnswers: answers.filter( ( a ) => a.label ).length < 2,
-				noRightAnswer: ! answers.some( ( a ) => a.correct ),
-				noWrongAnswer: ! answers.some( ( a ) => ! a.correct ),
+				noAnswers: answers.filter( ( a ) => a.label.trim() ).length < 2,
+				noRightAnswer: ! answers.some(
+					( a ) => a.correct && a.label.trim()
+				),
+				noWrongAnswer: ! answers.some(
+					( a ) => ! a.correct && a.label.trim()
+				),
 			};
 		},
 		messages: {
 			noAnswers: __(
-				'Add at least one right and one wrong answer.',
+				'Add at least one right and one wrong answer. Value can not be whitespace character.',
 				'sensei-lms'
 			),
 			noRightAnswer: __(
-				'Add a right answer to this question.',
+				'Add a right answer to this question. Value can not be whitespace character.',
 				'sensei-lms'
 			),
 			noWrongAnswer: __(
-				'Add a wrong answer to this question.',
+				'Add a wrong answer to this question. Value can not be whitespace character.',
 				'sensei-lms'
 			),
 		},
@@ -84,14 +88,17 @@ const questionTypes = {
 		settings: [],
 		validate: ( { before, after, gap } = {} ) => {
 			return {
-				noGap: ! gap?.length,
-				noBeforeAndNoAfter: ! before && ! after,
+				noGap: ! gap?.filter( ( val ) => val.trim() !== '' ).length,
+				noBeforeAndNoAfter: ! before?.trim() && ! after?.trim(),
 			};
 		},
 		messages: {
-			noGap: __( 'Add a right answer to this question.', 'sensei-lms' ),
+			noGap: __(
+				'Add a right answer to this question. Value can not be whitespace character.',
+				'sensei-lms'
+			),
 			noBeforeAndNoAfter: __(
-				'Add text before or after the gap.',
+				'Add text before or after the gap. Value can not be whitespace character.',
 				'sensei-lms'
 			),
 		},

--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -44,26 +44,38 @@ const questionTypes = {
 		feedback: true,
 		validate: ( { answers = [] } = {} ) => {
 			return {
-				noAnswers: answers.filter( ( a ) => a.label.trim() ).length < 2,
-				noRightAnswer: ! answers.some(
+				noAnswers: answers.filter( ( a ) => a.label ).length < 2,
+				noRightAnswer: ! answers.some( ( a ) => a.correct && a.label ),
+				noRightAnswerWhitespace: ! answers.some(
 					( a ) => a.correct && a.label.trim()
 				),
 				noWrongAnswer: ! answers.some(
+					( a ) => ! a.correct && a.label
+				),
+				noWrongAnswerWhitespace: ! answers.some(
 					( a ) => ! a.correct && a.label.trim()
 				),
 			};
 		},
 		messages: {
 			noAnswers: __(
-				'Add at least one right and one wrong answer. Value can not be whitespace character.',
+				'Add at least one right and one wrong answer.',
 				'sensei-lms'
 			),
 			noRightAnswer: __(
-				'Add a right answer to this question. Value can not be whitespace character.',
+				'Add a right answer to this question.',
+				'sensei-lms'
+			),
+			noRightAnswerWhitespace: __(
+				'The value of the right answer can not be whitespace character.',
 				'sensei-lms'
 			),
 			noWrongAnswer: __(
 				'Add a wrong answer to this question. Value can not be whitespace character.',
+				'sensei-lms'
+			),
+			noWrongAnswerWhitespace: __(
+				'The value of the wrong answer can not be whitespace character.',
 				'sensei-lms'
 			),
 		},
@@ -88,17 +100,26 @@ const questionTypes = {
 		settings: [],
 		validate: ( { before, after, gap } = {} ) => {
 			return {
-				noGap: ! gap?.filter( ( val ) => val.trim() !== '' ).length,
-				noBeforeAndNoAfter: ! before?.trim() && ! after?.trim(),
+				noGap: ! gap?.filter( ( val ) => val !== '' ).length,
+				noGapWhitespace: ! gap?.filter( ( val ) => val.trim() !== '' )
+					.length,
+				noBeforeAndNoAfter: ! before && ! after,
+				noBeforeAndNoAfterWhitespace:
+					! before?.trim() && ! after?.trim(),
 			};
 		},
 		messages: {
-			noGap: __(
-				'Add a right answer to this question. Value can not be whitespace character.',
+			noGap: __( 'Add a right answer to this question.', 'sensei-lms' ),
+			noGapWhitespace: __(
+				'The value of a right answer can not be whitespace character.',
 				'sensei-lms'
 			),
 			noBeforeAndNoAfter: __(
 				'Add text before or after the gap. Value can not be whitespace character.',
+				'sensei-lms'
+			),
+			noBeforeAndNoAfterWhitespace: __(
+				'Value of the text before or after the gap can not be whitespace character.',
 				'sensei-lms'
 			),
 		},


### PR DESCRIPTION
Fixes #3549

### Changes proposed in this Pull Request
- The issue was reported that Gap question without the before/after text can be created. This was not an issue but intended behavior
- In this PR another issue was addressed: currently, validation check that both before and after texts for the gap messages have to be present. In the discussion with @donnapep we have decided to change this in a way to allow to have either before or after the text (or both) because we found it a valid use-case.  

### Additional notes 
- These types of errors are not always displayed to the user, for example, if you load the page for the first time they will be displayed on the sidebar and not under the block  

### Testing instructions

1. Create a Gap question without the text you can see the error message: _Add a right answer to this question._ 

![image](https://user-images.githubusercontent.com/7208249/146005685-2fc16321-05c1-4b8f-acb0-78aa96e08077.png)

![image](https://user-images.githubusercontent.com/7208249/146005788-7366e1b8-debb-4042-aeba-b30b18a95cac.png)

2. Add text in the gap but don't add before/after text, message visible: _Add text before or after the gap._


![image](https://user-images.githubusercontent.com/7208249/146005908-17ab9421-f865-492e-8b6a-0d90a02b58f2.png)
![image](https://user-images.githubusercontent.com/7208249/146005920-4ac9d79a-439f-4f41-9833-47132452fda3.png)

3. Add before or after text: No message should be displayed  

![image](https://user-images.githubusercontent.com/7208249/146006034-4d58c41e-7386-49b6-9b9f-70d9d832506b.png)
![image](https://user-images.githubusercontent.com/7208249/146006080-157c0e83-9d35-49ad-83d5-103895fcd0a6.png)
