### PR TITLE
Adding "by default" sort order to Courses archive page.

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -127,9 +127,7 @@ class Sensei_Course {
 		add_filter( 'pre_get_posts', array( __CLASS__, 'course_archive_featured_filter' ), 10, 1 );
 
 		// Handle the ordering for the courses archive page.
-		if ( is_post_type_archive( 'course' ) ) {
-			add_filter( 'pre_get_posts', array( __CLASS__, 'course_archive_set_order_by' ), 10, 1 );
-		}
+		add_filter( 'pre_get_posts', array( __CLASS__, 'course_archive_set_order_by' ), 10, 1 );
 
 		// ensure the course category page respects the manual order set for courses
 		add_filter( 'pre_get_posts', array( __CLASS__, 'alter_course_category_order' ), 10, 1 );
@@ -2796,6 +2794,11 @@ class Sensei_Course {
 	 * @return WP_Query $query
 	 */
 	public static function course_archive_set_order_by( $query ) {
+
+		// Applies only to Course archive page.
+		if ( ! $query->is_post_type_archive( 'course' ) ) {
+			return;
+		}
 
 		// Default sort order depends on custom course order being set or not.
 		$orderby = 'date';

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2671,7 +2671,7 @@ class Sensei_Course {
 		$course_order_by_options = apply_filters(
 			'sensei_archive_course_order_by_options',
 			array(
-				'default' => __( 'Sort by default', 'sensei-lms' ),
+				'default' => __( 'Default sort', 'sensei-lms' ),
 				'newness' => __( 'Sort by newest first', 'sensei-lms' ),
 				'title'   => __( 'Sort by title A-Z', 'sensei-lms' ),
 			)

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2796,7 +2796,7 @@ class Sensei_Course {
 	public static function course_archive_order_by_title( $query ) {
 
 		if ( isset( $_REQUEST['course-orderby'] ) && 'title' === sanitize_text_field( wp_unslash( $_REQUEST['course-orderby'] ) )
-			 && 'course' === $query->get( 'post_type' ) && $query->is_main_query() ) {
+			&& 'course' === $query->get( 'post_type' ) && $query->is_main_query() ) {
 			// Setup the order by title for this query.
 			$query->set( 'orderby', 'title' );
 			$query->set( 'order', 'ASC' );

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -126,8 +126,10 @@ class Sensei_Course {
 		// filter the course query when featured filter is applied
 		add_filter( 'pre_get_posts', array( __CLASS__, 'course_archive_featured_filter' ), 10, 1 );
 
-		// handle the order by title post submission.
-		add_filter( 'pre_get_posts', array( __CLASS__, 'course_archive_set_order_by' ), 10, 1 );
+		// Handle the ordering for the courses archive page.
+		if ( is_post_type_archive( 'course' ) ) {
+			add_filter( 'pre_get_posts', array( __CLASS__, 'course_archive_set_order_by' ), 10, 1 );
+		}
 
 		// ensure the course category page respects the manual order set for courses
 		add_filter( 'pre_get_posts', array( __CLASS__, 'alter_course_category_order' ), 10, 1 );
@@ -2655,7 +2657,7 @@ class Sensei_Course {
 	public static function course_archive_sorting( $query ) {
 
 		// don't show on category pages and other pages
-		if ( ! is_archive( 'course ' ) || is_tax( 'course-category' ) ) {
+		if ( ! is_post_type_archive( 'course' ) || is_tax( 'course-category' ) ) {
 			return;
 		}
 
@@ -2785,9 +2787,9 @@ class Sensei_Course {
 	}
 
 	/**
-	 * Set the sorting options based on the query parameter and configuration.
+	 * Set the sorting options based on the query parameter and configuration in the Courses archive page.
 	 *
-	 * Hooked into pre_get_posts
+	 * Hooked into pre_get_posts for the courses archive only.
 	 *
 	 * @since 1.9.0
 	 * @param WP_Query $query
@@ -2795,7 +2797,7 @@ class Sensei_Course {
 	 */
 	public static function course_archive_set_order_by( $query ) {
 
-		// Default sort order depends on course order being set or not.
+		// Default sort order depends on custom course order being set or not.
 		$orderby = 'date';
 		$order   = 'DESC';
 		if ( ! empty( get_option( 'sensei_course_order', '' ) ) ) {

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2809,7 +2809,7 @@ class Sensei_Course {
 		}
 
 		if ( isset( $_REQUEST['course-orderby'] ) ) {
-			$request_orderby = sanitize_text_field( $_REQUEST['course-orderby'] );
+			$request_orderby = sanitize_text_field( wp_unslash( $_REQUEST['course-orderby'] ) );
 			switch ( $request_orderby ) {
 				case 'title':
 					$orderby = 'title';

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2785,13 +2785,34 @@ class Sensei_Course {
 	}
 
 	/**
+	 * If the course order drop down is changed.
+	 * In versions previous to 3.14.1 this method was hooked into pre_get_posts.
+	 *
+	 * @since      1.9.0
+	 * @deprecated 3.14.1
+	 * @param WP_Query $query WordPress query.
+	 * @return WP_Query
+	 */
+	public static function course_archive_order_by_title( $query ) {
+
+		if ( isset( $_REQUEST['course-orderby'] ) && 'title' === sanitize_text_field( wp_unslash( $_REQUEST['course-orderby'] ) )
+			 && 'course' === $query->get( 'post_type' ) && $query->is_main_query() ) {
+			// Setup the order by title for this query.
+			$query->set( 'orderby', 'title' );
+			$query->set( 'order', 'ASC' );
+		}
+
+		return $query;
+	}
+
+	/**
 	 * Set the sorting options based on the query parameter and configuration in the Courses archive page.
 	 *
 	 * Hooked into pre_get_posts.
 	 *
-	 * @since 1.9.0
-	 * @param WP_Query $query
-	 * @return WP_Query $query
+	 * @since 3.14.1
+	 * @param WP_Query $query WordPress query.
+	 * @return WP_Query
 	 */
 	public static function course_archive_set_order_by( $query ) {
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2787,7 +2787,7 @@ class Sensei_Course {
 	/**
 	 * Set the sorting options based on the query parameter and configuration in the Courses archive page.
 	 *
-	 * Hooked into pre_get_posts for the courses archive only.
+	 * Hooked into pre_get_posts.
 	 *
 	 * @since 1.9.0
 	 * @param WP_Query $query
@@ -3490,8 +3490,8 @@ class Sensei_Course {
 		return array(
 			'post_type'        => 'course',
 			'posts_per_page'   => 1000,
-			'orderby'          => 'menu_order',
-			'order'            => 'ASC',
+			'orderby'          => 'date',
+			'order'            => 'DESC',
 			'suppress_filters' => 0,
 		);
 	}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2809,7 +2809,7 @@ class Sensei_Course {
 		}
 
 		if ( isset( $_REQUEST['course-orderby'] ) ) {
-			$request_orderby = $_REQUEST['course-orderby'];
+			$request_orderby = sanitize_text_field( $_REQUEST['course-orderby'] );
 			switch ( $request_orderby ) {
 				case 'title':
 					$orderby = 'title';

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2829,7 +2829,9 @@ class Sensei_Course {
 			$order   = 'ASC';
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( isset( $_REQUEST['course-orderby'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification
 			$request_orderby = sanitize_text_field( wp_unslash( $_REQUEST['course-orderby'] ) );
 			switch ( $request_orderby ) {
 				case 'title':

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2794,6 +2794,7 @@ class Sensei_Course {
 	 * @return WP_Query
 	 */
 	public static function course_archive_order_by_title( $query ) {
+		_deprecated_function( __METHOD__, '3.15.0' );
 
 		if ( isset( $_REQUEST['course-orderby'] ) && 'title' === sanitize_text_field( wp_unslash( $_REQUEST['course-orderby'] ) )
 			&& 'course' === $query->get( 'post_type' ) && $query->is_main_query() ) {

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -2786,10 +2786,10 @@ class Sensei_Course {
 
 	/**
 	 * If the course order drop down is changed.
-	 * In versions previous to 3.14.1 this method was hooked into pre_get_posts.
+	 * In versions previous to 3.15.0 this method was hooked into pre_get_posts.
 	 *
 	 * @since      1.9.0
-	 * @deprecated 3.14.1
+	 * @deprecated 3.15.0
 	 * @param WP_Query $query WordPress query.
 	 * @return WP_Query
 	 */
@@ -2810,7 +2810,7 @@ class Sensei_Course {
 	 *
 	 * Hooked into pre_get_posts.
 	 *
-	 * @since 3.14.1
+	 * @since 3.15.0
 	 * @param WP_Query $query WordPress query.
 	 * @return WP_Query
 	 */

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -466,6 +466,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	 * @dataProvider data_testCourseArchiveOrderSetOrderBy
 	 */
 	public function testCourseArchiveOrderSetOrderBy( $request_parameters, $course_order_option, $expected_order_by, $expected_order ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$original_request_object = $_REQUEST;
 		$_REQUEST                = $request_parameters;
 		$wp_query                = $this->createMock( 'WP_Query' );


### PR DESCRIPTION
As reported by #2401 there was no way for the Courses page to display the courses in the order specified in the administration panel.
Now a new option "Sort by default" will appear in the dropdown for that.
This option will be used by default if a custom order is specified. If this is not the case default option will behave like previously — ordering by newest first.

Fixes #2401

### Changes proposed in this Pull Request
* Adding new "Sort by default" option in the sorting dropdown in the Courses page.
* This option will order by the custom order if specified in the admin panel or by newest first (which was the behaviour until now).

### Testing instructions
* Go to `/courses-overview` and check that the sorting options work as defined.
* Go to the administration panel `Courses > Order courses` and change the order.
* Check now that the new "By default" dropdown option is the one used by default and shows the courses in the same order as defined in the previous step.

### Deprecated
- Function `Sensei_Course::course_archive_order_by_title` removed.

### Screenshot / Video
![Kapture 2021-12-14 at 15 39 49](https://user-images.githubusercontent.com/799065/146019623-d0c3bd7f-4c74-42cc-92bd-d993c2c75ee6.gif)
