### PR TITLE
Show prerequisite notice as priority notice for logged out users

### DIFF
--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -78,9 +78,9 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Testing prerequisite notice.
+	 * Testing lesson prerequisite notice.
 	 */
-	public function testPrerequisiteNotice() {
+	public function testLessonPrerequisiteNotice() {
 		$course_id           = $this->factory->course->create();
 		$prerequisite_lesson = $this->factory->lesson->create_and_get();
 		$lesson              = $this->factory->lesson->create_and_get(
@@ -103,9 +103,9 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Testing ungraded prerequisite notice.
+	 * Testing ungraded lesson prerequisite notice.
 	 */
-	public function testUngradedPrerequisiteNotice() {
+	public function testUngradedLessonPrerequisiteNotice() {
 		$course_id           = $this->factory->course->create();
 		$prerequisite_lesson = $this->create_lesson_with_submitted_answers();
 		$lesson              = $this->factory->lesson->create_and_get(
@@ -125,6 +125,35 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
 
 		$this->assertRegExp( '/You will be able to view this lesson once the .* are completed and graded./', $html, 'Should return ungraded prerequisite notice' );
+	}
+
+	/**
+	 * Testing course prerequisite notice.
+	 */
+	public function testCoursePrerequisiteNotice() {
+		$prerequisite_course_id = $this->factory->course->create();
+		$course_id              = $this->factory->course->create(
+			[
+				'meta_input' => [
+					'_course_prerequisite' => $prerequisite_course_id,
+				],
+			]
+		);
+		$lesson                 = $this->factory->lesson->create_and_get(
+			[
+				'meta_input' => [
+					'_lesson_course' => $course_id,
+				],
+			]
+		);
+		$GLOBALS['post']        = $lesson;
+
+		$this->login_as_student();
+		\Sensei_Course_Theme_Lesson::instance()->init();
+
+		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
+
+		$this->assertRegExp( '/You must first complete .* before taking this course./', $html, 'Should return course prerequisite notice' );
 	}
 
 	/**


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/4445

### Changes proposed in this Pull Request

* As discussed in 709-gh-Automattic/sensei-wc-paid-courses#discussion_r768409035, it shows a prerequisite notice as a priority notice even for logged-out users.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create 2 courses with lessons.
* Make one course a prerequisite of the other.
* Select the "Sensei Theme" as the "Course Theme" (sidebar) in the course that contains a prerequisite.
* Logged-out, access a lesson of the course with a prerequisite course, and make sure you see a notice with a link to the prerequisite course.
* Logged-in, make sure you see the same notice.
* Complete the prerequisite course, and make sure you see the notice to take the course.