### PR TITLE
Completion lesson transitions

### DIFF
--- a/assets/course-theme/complete-lesson-button.js
+++ b/assets/course-theme/complete-lesson-button.js
@@ -4,6 +4,9 @@
 import domReady from '@wordpress/dom-ready';
 import { __ } from '@wordpress/i18n';
 
+/**
+ * Initializes complete lesson transition.
+ */
 export const initCompleteLessonTransition = () => {
 	domReady( () => {
 		const completeForms = document.querySelectorAll(
@@ -12,10 +15,16 @@ export const initCompleteLessonTransition = () => {
 		const completeButtons = document.querySelectorAll(
 			'[data-id="complete-lesson-button"], .wp-block-sensei-lms-button-complete-lesson button'
 		);
+		const progressBars = document.querySelectorAll(
+			'.sensei-course-theme-course-progress-bar-inner'
+		);
 		const mainContent = document.querySelector(
 			'.sensei-course-theme__main-content'
 		);
 
+		/**
+		 * Disable complete buttons.
+		 */
 		const disableButtons = () => {
 			completeButtons.forEach( ( button ) => {
 				button.setAttribute( 'disabled', 'disabled' );
@@ -23,37 +32,70 @@ export const initCompleteLessonTransition = () => {
 			} );
 		};
 
-		completeForms.forEach( ( form ) => {
-			form.addEventListener( 'submit', ( e ) => {
-				// Skip if the form is not for complete lesson (Reset lesson block, for example).
-				if (
-					! form.querySelector(
-						'input[name="quiz_action"][value="lesson-complete"]'
-					)
-				) {
-					return;
-				}
+		/**
+		 * Delay submit to show animations.
+		 *
+		 * @param {Object} e    The submit event.
+		 * @param {Object} form The form DOM node.
+		 */
+		const delayFormSubmit = ( e, form ) => {
+			e.preventDefault();
+			disableButtons();
 
-				e.preventDefault();
-				disableButtons();
+			setTimeout( () => {
+				form.submit();
+			}, 1000 );
+		};
 
-				setTimeout( () => {
-					form.submit();
-				}, 1000 );
+		/**
+		 * Run progress bar animation.
+		 */
+		const runProgressBarAnimation = () => {
+			progressBars.forEach( ( progressBar ) => {
+				const { completed, count } = progressBar.dataset;
 
-				mainContent.insertAdjacentHTML(
-					'beforebegin',
-					`<div class="sensei-course-theme-lesson-completion-notice">
-						<svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg" class="sensei-course-theme-lesson-completion-notice__icon">
-							<circle cx="35" cy="35" r="34.25" stroke="currentColor" stroke-width="1.5" />
-							<path d="M45.1909 25.2503L31.4692 43.7045L23.5125 37.7883" stroke="currentColor" stroke-width="2" />
-						</svg>
-						<p class="sensei-course-theme-lesson-completion-notice__text">
-							${ __( 'Lesson complete', 'sensei-lms' ) }
-						</p>
-					</div>`
-				);
+				// Percentage with one more completed.
+				const percentage = ( ( +completed + 1 ) / +count ) * 100;
+				progressBar.style.width = `${ percentage }%`;
 			} );
+		};
+
+		/**
+		 * Form submit handler.
+		 *
+		 * @param {Object} e The submit event.
+		 */
+		const onFormSubmit = ( e ) => {
+			const form = e.target;
+
+			// Skip if the form is not for complete lesson (Reset lesson block, for example).
+			if (
+				! form.querySelector(
+					'input[name="quiz_action"][value="lesson-complete"]'
+				)
+			) {
+				return;
+			}
+
+			delayFormSubmit( e, form );
+			runProgressBarAnimation();
+
+			mainContent.insertAdjacentHTML(
+				'beforebegin',
+				`<div class="sensei-course-theme-lesson-completion-notice">
+					<svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg" class="sensei-course-theme-lesson-completion-notice__icon">
+						<circle cx="35" cy="35" r="34.25" stroke="currentColor" stroke-width="1.5" />
+						<path d="M45.1909 25.2503L31.4692 43.7045L23.5125 37.7883" stroke="currentColor" stroke-width="2" />
+					</svg>
+					<p class="sensei-course-theme-lesson-completion-notice__text">
+						${ __( 'Lesson complete', 'sensei-lms' ) }
+					</p>
+				</div>`
+			);
+		};
+
+		completeForms.forEach( ( form ) => {
+			form.addEventListener( 'submit', onFormSubmit );
 		} );
 	} );
 };

--- a/assets/course-theme/complete-lesson-button.js
+++ b/assets/course-theme/complete-lesson-button.js
@@ -87,7 +87,7 @@ export const initCompleteLessonTransition = () => {
 						<circle cx="35" cy="35" r="34.25" stroke="currentColor" stroke-width="1.5" />
 						<path d="M45.1909 25.2503L31.4692 43.7045L23.5125 37.7883" stroke="currentColor" stroke-width="2" />
 					</svg>
-					<p class="sensei-course-theme-lesson-completion-notice__text">
+					<p role="alert" class="sensei-course-theme-lesson-completion-notice__text">
 						${ __( 'Lesson complete', 'sensei-lms' ) }
 					</p>
 				</div>`

--- a/assets/course-theme/complete-lesson-button.js
+++ b/assets/course-theme/complete-lesson-button.js
@@ -1,0 +1,59 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+import { __ } from '@wordpress/i18n';
+
+export const initCompleteLessonTransition = () => {
+	domReady( () => {
+		const completeForms = document.querySelectorAll(
+			'[data-id="complete-lesson-form"], .lesson_button_form'
+		);
+		const completeButtons = document.querySelectorAll(
+			'[data-id="complete-lesson-button"], .wp-block-sensei-lms-button-complete-lesson button'
+		);
+		const mainContent = document.querySelector(
+			'.sensei-course-theme__main-content'
+		);
+
+		const disableButtons = () => {
+			completeButtons.forEach( ( button ) => {
+				button.setAttribute( 'disabled', 'disabled' );
+				button.classList.add( 'is-busy' );
+			} );
+		};
+
+		completeForms.forEach( ( form ) => {
+			form.addEventListener( 'submit', ( e ) => {
+				// Skip if the form is not for complete lesson (Reset lesson block, for example).
+				if (
+					! form.querySelector(
+						'input[name="quiz_action"][value="lesson-complete"]'
+					)
+				) {
+					return;
+				}
+
+				e.preventDefault();
+				disableButtons();
+
+				setTimeout( () => {
+					form.submit();
+				}, 1000 );
+
+				mainContent.insertAdjacentHTML(
+					'beforebegin',
+					`<div class="sensei-course-theme-lesson-completion-notice">
+						<svg width="70" height="70" viewBox="0 0 70 70" fill="none" xmlns="http://www.w3.org/2000/svg" class="sensei-course-theme-lesson-completion-notice__icon">
+							<circle cx="35" cy="35" r="34.25" stroke="currentColor" stroke-width="1.5" />
+							<path d="M45.1909 25.2503L31.4692 43.7045L23.5125 37.7883" stroke="currentColor" stroke-width="2" />
+						</svg>
+						<p class="sensei-course-theme-lesson-completion-notice__text">
+							${ __( 'Lesson complete', 'sensei-lms' ) }
+						</p>
+					</div>`
+				);
+			} );
+		} );
+	} );
+};

--- a/assets/course-theme/course-theme.js
+++ b/assets/course-theme/course-theme.js
@@ -5,6 +5,7 @@ import './scroll-direction';
 import './adminbar-layout';
 import { toggleFocusMode } from './focus-mode';
 import { submitContactTeacher } from './contact-teacher';
+import { initCompleteLessonTransition } from './complete-lesson-button';
 
 if ( ! window.sensei ) {
 	window.sensei = {};
@@ -19,3 +20,5 @@ const toggleSidebar = () => {
 
 window.sensei.courseTheme = { toggleFocusMode, toggleSidebar };
 window.sensei.submitContactTeacher = submitContactTeacher;
+
+initCompleteLessonTransition();

--- a/assets/css/sensei-course-theme.scss
+++ b/assets/css/sensei-course-theme.scss
@@ -11,6 +11,7 @@
 @import 'sensei-course-theme/course-navigation';
 @import 'sensei-course-theme/quiz-back-to-lesson';
 @import 'sensei-course-theme/course-progress-bar';
+@import 'sensei-course-theme/lesson-complete-transition';
 @import 'sensei-course-theme/lesson-actions';
 @import 'sensei-course-theme/contact-teacher';
 @import 'sensei-course-theme/lesson-module';

--- a/assets/css/sensei-course-theme/focus-mode.scss
+++ b/assets/css/sensei-course-theme/focus-mode.scss
@@ -3,8 +3,9 @@ $base: '.sensei-course-theme';
 
 .sensei-course-theme__focus-mode-toggle {
 	position: absolute;
-	left: 24px;
-	top: 12px;
+	left: 20px;
+	top: 8px;
+	padding: 4px;
 	white-space: nowrap;
 	&__disable {
 		display: none;
@@ -17,6 +18,8 @@ $base: '.sensei-course-theme';
 }
 
 .sensei-course-theme--focus-mode {
+	--focus-header-height: 45px;
+
 	.sensei-course-theme {
 		&__header {
 			&__container {
@@ -53,8 +56,6 @@ $base: '.sensei-course-theme';
 		}
 		&__focus-mode-toggle {
 			left: 420px;
-			top: -28px;
-			padding: 4px;
 			&__enable {
 				display: none;
 			}

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -1,9 +1,10 @@
 .sensei-course-theme {
 
-	--header-height: 75px;
+	--header-height: var(--focus-header-height, 75px);
 	--sidebar-width: 300px;
 	--top-offset: 0px;
 	--content-padding: 32px;
+	--full-header-height: calc(var(--header-height) + var(--top-offset));
 
 	@at-root body.admin-bar {
 		--top-offset: 32px;
@@ -25,7 +26,7 @@
 
 	&__sidebar {
 		position: fixed;
-		top: calc(var(--header-height) + var(--top-offset));
+		top: var(--full-header-height);
 		bottom: 0;
 		left: 0;
 		width: var(--sidebar-width);

--- a/assets/css/sensei-course-theme/lesson-complete-transition.scss
+++ b/assets/css/sensei-course-theme/lesson-complete-transition.scss
@@ -1,0 +1,34 @@
+@keyframes sensei-course-theme-lesson-completion-notice-fadein {
+	from { opacity: 0; }
+	to { opacity: 1; }
+}
+
+.sensei-course-theme-lesson-completion-notice {
+	position: fixed;
+	height: calc(100vh - var(--full-header-height));
+	left: var(--sidebar-width);
+	right: 0;
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	background-color: #FFF;
+
+	&__text {
+		margin: 25px 0;
+		font-size: 30px;
+		font-weight: 700;
+	}
+
+	&__icon {
+		color: var(--primary-color);
+	}
+
+	.sensei-course-theme--focus-mode & {
+		left: 0;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		animation: sensei-course-theme-lesson-completion-notice-fadein 0.8s ease forwards;
+	}
+}

--- a/assets/css/sensei-course-theme/lesson-complete-transition.scss
+++ b/assets/css/sensei-course-theme/lesson-complete-transition.scss
@@ -5,6 +5,7 @@
 
 .sensei-course-theme-lesson-completion-notice {
 	position: fixed;
+	z-index: 1;
 	height: calc(100vh - var(--full-header-height));
 	left: var(--sidebar-width);
 	right: 0;

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -13,6 +13,10 @@
 		display: none;
 	}
 
+	.sensei-course-theme-lesson-completion-notice {
+		left: 0;
+	}
+
 	.sensei-course-theme {
 		--content-padding: 12px;
 		--header-height: 60px;

--- a/includes/blocks/class-sensei-course-progress-block.php
+++ b/includes/blocks/class-sensei-course-progress-block.php
@@ -51,11 +51,10 @@ class Sensei_Course_Progress_Block {
 			return '';
 		}
 
-		list(
-			'lessons_count'                => $total_lessons,
-			'completed_lessons_count'      => $completed,
-			'completed_lessons_percentage' => $percentage,
-		) = \Sensei()->course->get_progress_stats( $course_id );
+		$stats         = Sensei()->course->get_progress_stats( $course_id );
+		$total_lessons = $stats['lessons_count'];
+		$completed     = $stats['completed_lessons_count'];
+		$percentage    = $stats['completed_lessons_percentage'];
 
 		$text_css           = Sensei_Block_Helpers::build_styles( $attributes );
 		$bar_background_css = Sensei_Block_Helpers::build_styles(

--- a/includes/blocks/course-theme/class-course-progress-bar.php
+++ b/includes/blocks/course-theme/class-course-progress-bar.php
@@ -43,12 +43,13 @@ class Course_Progress_Bar {
 			return '';
 		}
 
-		list( 'completed_lessons_percentage' => $width ) = \Sensei()->course->get_progress_stats( $course_id );
+		$stats = \Sensei()->course->get_progress_stats( $course_id );
 
-		return ( "
-			<div class='sensei-course-theme-course-progress-bar'>
-				<div class='sensei-course-theme-course-progress-bar-inner' style='width: {$width}%;'></div>
-			</div>
-		" );
+		return sprintf(
+			'<div class="sensei-course-theme-course-progress-bar">
+				<div class="sensei-course-theme-course-progress-bar-inner" style="width: %f%%;"></div>
+			</div>',
+			$stats['completed_lessons_percentage']
+		);
 	}
 }

--- a/includes/blocks/course-theme/class-course-progress-bar.php
+++ b/includes/blocks/course-theme/class-course-progress-bar.php
@@ -43,13 +43,15 @@ class Course_Progress_Bar {
 			return '';
 		}
 
-		$stats = \Sensei()->course->get_progress_stats( $course_id );
+		$stats = Sensei()->course->get_progress_stats( $course_id );
 
 		return sprintf(
 			'<div class="sensei-course-theme-course-progress-bar">
-				<div class="sensei-course-theme-course-progress-bar-inner" style="width: %f%%;"></div>
+				<div class="sensei-course-theme-course-progress-bar-inner" style="width: %f%%;" data-completed="%d" data-count="%d"></div>
 			</div>',
-			$stats['completed_lessons_percentage']
+			$stats['completed_lessons_percentage'],
+			$stats['completed_lessons_count'],
+			$stats['lessons_count']
 		);
 	}
 }

--- a/includes/blocks/course-theme/class-course-progress-bar.php
+++ b/includes/blocks/course-theme/class-course-progress-bar.php
@@ -47,7 +47,7 @@ class Course_Progress_Bar {
 
 		return sprintf(
 			'<div class="sensei-course-theme-course-progress-bar">
-				<div class="sensei-course-theme-course-progress-bar-inner" style="width: %f%%;" data-completed="%d" data-count="%d"></div>
+				<div class="sensei-course-theme-course-progress-bar-inner" style="width: %s%%;" data-completed="%d" data-count="%d"></div>
 			</div>',
 			$stats['completed_lessons_percentage'],
 			$stats['completed_lessons_count'],

--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -49,10 +49,10 @@ class Lesson_Actions {
 		$text      = esc_html( __( 'Complete lesson', 'sensei-lms' ) );
 
 		return ( '
-			<form class="sensei-course-theme-lesson-actions__complete-lesson-form" method="POST" action="' . $permalink . '">
+			<form data-id="complete-lesson-form" class="sensei-course-theme-lesson-actions__complete-lesson-form" method="POST" action="' . $permalink . '">
 				' . $nonce . '
 				<input type="hidden" name="quiz_action" value="lesson-complete" />
-				<button type="submit" class="sensei-course-theme__button ' . $button_class . '" ' . $disabled_attribute . '>
+				<button type="submit" data-id="complete-lesson-button" class="sensei-course-theme__button ' . $button_class . '" ' . $disabled_attribute . '>
 					' . $text . '
 				</button>
 			</form>


### PR DESCRIPTION
Fixes #4481

### Changes proposed in this Pull Request

* It introduces a "Lesson complete" feedback with a delay in the completion submit.
* It also introduced an animation in the progress bar when completing a lesson.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create a course with lessons.
* Enable the Course Theme (course editor sidebar).
* Complete the lessons as a student, and make sure you see the transition feedback (message and progress bar animation).

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/146427704-6ae55303-5c29-4fe3-89c4-bc0e88a45d64.mov

cc @sruj09 