### PR TITLE
Hide incomplete questions from the frontend (Preview) 

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3454,7 +3454,9 @@ class Sensei_Lesson {
 			}
 		}
 
-		$questions = Sensei()->quiz->get_questions( $quiz_id, $post_status, $orderby, $order );
+		// Filter out questions that are incomplete on the frontend.
+		$filter_incomplete_questions = true;
+		$questions                   = Sensei()->quiz->get_questions( $quiz_id, $post_status, $orderby, $order, $filter_incomplete_questions );
 
 		// Set the questions array that will be manipulated within this function.
 		$questions_array = $questions;

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1661,7 +1661,7 @@ class Sensei_Quiz {
 	}
 
 	/**
-	 * Get all the questions of a quiz or get all complete questions if filtering flag is true.
+	 * Get all the questions of a quiz or get all complete questions if filtering flag is true and is not preview.
 	 *
 	 * @param int    $quiz_id The quiz id.
 	 * @param string $post_status Question post status.
@@ -1695,7 +1695,11 @@ class Sensei_Quiz {
 		$questions_query = new WP_Query( $question_query_args );
 
 		$posts = $questions_query->posts;
-		return $filter_incomplete_questions ? $this->filter_out_incomplete_questions( $posts ) : $posts;
+
+		if ( is_preview() || ! $filter_incomplete_questions ) {
+			return $posts;
+		}
+		return $this->filter_out_incomplete_questions( $posts );
 	}
 
 	/**

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1663,11 +1663,11 @@ class Sensei_Quiz {
 	/**
 	 * Get all the questions of a quiz.
 	 *
-	 * @param int    $quiz_id     The quiz id.
+	 * @param int    $quiz_id The quiz id.
 	 * @param string $post_status Question post status.
-	 * @param string $orderby     Question order by.
-	 * @param string $order       Question order.
-	 *
+	 * @param string $orderby Question order by.
+	 * @param string $order Question order.
+	 * @param bool   $filter_incomplete_questions
 	 * @return WP_Post[]
 	 */
 	public function get_questions( $quiz_id, $post_status = 'any', $orderby = 'meta_value_num title', $order = 'ASC', $filter_incomplete_questions = false ) : array {
@@ -1730,6 +1730,7 @@ class Sensei_Quiz {
 	private function is_multiple_choice_question_complete( int $question_id ): bool {
 		$right_answers = get_post_meta( $question_id, '_question_right_answer', true );
 		$wrong_answers = get_post_meta( $question_id, '_question_wrong_answers', true );
+
 		// Multiple choice question is incomplete if there isn't at least one right and one wrong answer.
 		if ( ! is_array( $right_answers ) || count( $right_answers ) < 1 || ! is_array( $wrong_answers ) || count( $wrong_answers ) < 1 ) {
 			return false;

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1661,7 +1661,7 @@ class Sensei_Quiz {
 	}
 
 	/**
-	 * Get all the questions of a quiz.
+	 * Get all the questions of a quiz or get all complete questions if filtering flag is true.
 	 *
 	 * @param int    $quiz_id The quiz id.
 	 * @param string $post_status Question post status.
@@ -1699,7 +1699,7 @@ class Sensei_Quiz {
 	}
 
 	/**
-	 * Get all the questions of a quiz.
+	 * Filter out incomplete questions.
 	 *
 	 * @param array $questions  All questions.
 	 *

--- a/tests/framework/factories/class-wp-unittest-factory-for-question.php
+++ b/tests/framework/factories/class-wp-unittest-factory-for-question.php
@@ -67,11 +67,9 @@ class WP_UnitTest_Factory_For_Question extends WP_UnitTest_Factory_For_Post_Sens
 			$test_question_data['add_question_right_answer_singleline'] = '';
 
 		} elseif ( 'gap-fill' === $type ) {
-
-			$test_question_data['add_question_right_answer_gapfill_pre']  = '';
-			$test_question_data['add_question_right_answer_gapfill_gap']  = '';
-			$test_question_data['add_question_right_answer_gapfill_post'] = '';
-
+			$test_question_data['add_question_right_answer_gapfill_pre']  = 'Text pre';
+			$test_question_data['add_question_right_answer_gapfill_gap']  = 'Answer text';
+			$test_question_data['add_question_right_answer_gapfill_post'] = 'Text after';
 		} elseif ( 'multi-line' === $type ) {
 
 			$test_question_data['add_question_right_answer_multiline'] = '';

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -128,6 +128,66 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$this->assertCount( 6, $questions_not_filtered );
 		$this->assertCount( 0, $questions_filtered );
 	}
+
+	/**
+	 * Testing Woothemes_Sensei()->quiz->get_questions.
+	 */
+	public function testGetQuestionsFiltersIncompleteQuestionsMultipleChoice() {
+		$lesson_id = $this->factory->lesson->create();
+		$quiz_id   = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
+
+		$this->factory->question->create_many(
+			2,
+			[
+				'quiz_id'                => $quiz_id,
+				'question_type'          => 'multiple-choice',
+				'question_right_answers' => [],
+				'question_wrong_answers' => [],
+			]
+		);
+		$this->factory->question->create_many(
+			2,
+			[
+				'quiz_id'       => $quiz_id,
+				'question_type' => 'multiple-choice',
+			]
+		);
+		$questions_filtered     = Sensei()->quiz->get_questions( $quiz_id, 'any', 'meta_value_num title', 'ASC', true );
+		$questions_not_filtered = Sensei()->quiz->get_questions( $quiz_id );
+		$this->assertCount( 4, $questions_not_filtered );
+		$this->assertCount( 2, $questions_filtered );
+	}
+
+	/**
+	 * Testing Woothemes_Sensei()->quiz->get_questions.
+	 */
+	public function testGetQuestionsFiltersIncompleteQuestionsFillGap() {
+		$lesson_id = $this->factory->lesson->create();
+		$quiz_id   = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
+		$this->factory->question->create_many(
+			2,
+			[
+				'quiz_id'                                => $quiz_id,
+				'question_type'                          => 'gap-fill',
+				'add_question_right_answer_gapfill_pre'  => '',
+				'add_question_right_answer_gapfill_gap'  => '',
+				'add_question_right_answer_gapfill_post' => '',
+			]
+		);
+		$this->factory->question->create_many(
+			2,
+			[
+				'quiz_id'       => $quiz_id,
+				'question_type' => 'gap-fill',
+			]
+		);
+
+		$questions_filtered     = Sensei()->quiz->get_questions( $quiz_id, 'any', 'meta_value_num title', 'ASC', true );
+		$questions_not_filtered = Sensei()->quiz->get_questions( $quiz_id );
+		$this->assertCount( 4, $questions_not_filtered );
+		$this->assertCount( 2, $questions_filtered );
+	}
+
 	/**
 	 * This test Woothemes_Sensei()->quiz->save_user_answers.
 	 */

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -65,7 +65,69 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$this->assertTrue( isset( Sensei()->quiz ), 'Sensei quiz class is not loaded' );
 
 	}
+	/**
+	 * Testing Woothemes_Sensei()->quiz->get_questions.
+	 */
+	public function testGetQuestionsFiltersIncompleteQuestionsEmptyValues() {
+		$lesson_id = $this->factory->lesson->create();
+		$quiz_id   = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
 
+		$this->factory->question->create_many(
+			3,
+			[
+				'quiz_id'                => $quiz_id,
+				'question_type'          => 'multiple-choice',
+				'question_right_answers' => [],
+				'question_wrong_answers' => [],
+			]
+		);
+		$this->factory->question->create_many(
+			3,
+			[
+				'quiz_id'                                => $quiz_id,
+				'question_type'                          => 'gap-fill',
+				'add_question_right_answer_gapfill_pre'  => '',
+				'add_question_right_answer_gapfill_gap'  => '',
+				'add_question_right_answer_gapfill_post' => '',
+			]
+		);
+		$questions_filtered     = Sensei()->quiz->get_questions( $quiz_id, 'any', 'meta_value_num title', 'ASC', true );
+		$questions_not_filtered = Sensei()->quiz->get_questions( $quiz_id );
+		$this->assertCount( 6, $questions_not_filtered );
+		$this->assertCount( 0, $questions_filtered );
+	}
+
+	/**
+	 * Testing Woothemes_Sensei()->quiz->get_questions.
+	 */
+	public function testGetQuestionsFiltersIncompleteQuestionsWhitespaceValues() {
+		$lesson_id = $this->factory->lesson->create();
+		$quiz_id   = $this->factory->maybe_create_quiz_for_lesson( $lesson_id );
+
+		$this->factory->question->create_many(
+			3,
+			[
+				'quiz_id'                => $quiz_id,
+				'question_type'          => 'multiple-choice',
+				'question_right_answers' => [ ' ', ' ', ' ' ],
+				'question_wrong_answers' => [ ' ' ],
+			]
+		);
+		$this->factory->question->create_many(
+			3,
+			[
+				'quiz_id'                                => $quiz_id,
+				'question_type'                          => 'gap-fill',
+				'add_question_right_answer_gapfill_pre'  => ' ',
+				'add_question_right_answer_gapfill_gap'  => ' ',
+				'add_question_right_answer_gapfill_post' => ' ',
+			]
+		);
+		$questions_filtered     = Sensei()->quiz->get_questions( $quiz_id, 'any', 'meta_value_num title', 'ASC', true );
+		$questions_not_filtered = Sensei()->quiz->get_questions( $quiz_id );
+		$this->assertCount( 6, $questions_not_filtered );
+		$this->assertCount( 0, $questions_filtered );
+	}
 	/**
 	 * This test Woothemes_Sensei()->quiz->save_user_answers.
 	 */


### PR DESCRIPTION
### Motivation behind this PR
**What is an incomplete question**
- Multiple choice question that 
-- Doesn't have at least one right AND wrong answer
-- Doesn't have at least one right AND wrong answer that are not whitespace characters

- Gap-fill question that: 
-- Doesn't have at least text before or text after
-- Doesn't have correct answer text
--  Doesn't have at least text before or text after that are not whitespace characters
--  Doesn't have correct answer text that is not whitespace characters

**What is the motivation**
We do not forbid a saving question that is incomplete, but with this PR we want to hide it from the user in the preview. The question however needs to be present in the Edit view.

**For discussion**
This will introduce the change that will affect current users and already existing lessons. Potentially this could produce some unexpected behavior for our customers that have some incomplete questions that they are using. How do we want to communicate this?

### Changes proposed in this Pull Request

- Add a new flag to SenseiQiuz-> get_questions() to indicate that we want to filter out incomplete questions
- Why do we want a flag? We want to filter questions only when they are fetched for the front end. If we don't do that and filter them every time, this breaks the edit view because there is this two check:
https://github.com/Automattic/sensei/blob/master/assets/shared/structure/structure-store.js#L181
https://github.com/Automattic/sensei/blob/master/assets/shared/structure/structure-store.js#L191
and they would return true every time someone clicks an update: 
You can read more in this thread: 
https://a8c.slack.com/archives/C8QJAM52B/p1640086619001200 
- Implement filtering for multiple-choice and fill-gap questions 
- Write tests for qet_questions() method 
- Fix factory method for gap-fill questions (was not setting proper data by default)

### Testing instructions
1. Open lesson view 
2. Create a Multiple Choice question without answers
3. Create a Multiple Choice question with only wrong/right answer 
4. Create a Multiple Choice question with whitespace as an answer 
5. Create a Multiple Choice question with one right one wrong answer (this is complete one)
6. Create a Gap Fill question without the correct answer 
7. Create a Gap Fill question without before or after the text 
8. Create a Gap Fill question without the correct answer of whitespace value 
9. Create a Gap Fill question without the before or after the text of whitespace value 
10. Create a Gap Fill question without the text before and right answer (this is complete one)
11. Update the lesson
12. Go to Lesson Preview 
13. View quiz
14. You should see only 2 questions (number 5 and number 10)

