### PR TITLE
Fix complete lesson form in the quiz page

### DIFF
--- a/includes/blocks/course-theme/class-lesson-actions.php
+++ b/includes/blocks/course-theme/class-lesson-actions.php
@@ -45,7 +45,8 @@ class Lesson_Actions {
 		$disabled_attribute = $is_disabled ? 'disabled' : '';
 
 		$nonce     = wp_nonce_field( 'woothemes_sensei_complete_lesson_noonce', 'woothemes_sensei_complete_lesson_noonce', false, false );
-		$permalink = esc_url( get_permalink() );
+		$lesson_id = Sensei_Utils::get_current_lesson();
+		$permalink = esc_url( get_permalink( $lesson_id ) );
 		$text      = esc_html( __( 'Complete lesson', 'sensei-lms' ) );
 
 		return ( '


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix an issue when a student is on the quiz results page and click on "Complete lesson". Previously, it was just refreshing the page because the `form action` wasn't correct for this context. Now it really completes the lesson.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create a course with a lesson and a quiz (not pass required).
* Enable the Course Theme (course editor sidebar).
* Answer the quiz, on the quiz results page, make sure that clicking on "Complete lesson" works properly.