### PR TITLE
Add `/themes` folder to the build package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
 			"!/lang",
 			"!/readme.txt",
 			"!/templates",
+			"!/themes",
 			"!/uninstall.php",
 			"!/widgets",
 			"!/sensei-lms.php",


### PR DESCRIPTION
### Changes proposed in this Pull Request

* After the build, the learning mode wasn't working properly. So I noticed the new `themes` folder wasn't included in the package. This PR just fixes it, including that folder in the build.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* To make it easier, change to `true` the course theme feature flag under `Sensei_Feature_Flags::get_default_feature_settings`.
* Build the package.
* Install in a fresh site.
* Create a course with Learning Mode active (course editor sidebar).
* Add at least a lesson.
* Access the lesson in the frontend, and make sure the learning mode loads properly.