### PR TITLE
Fix Lesson template when creating a new lesson through WP-admin menu

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-lessons-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lessons-controller.php
@@ -117,7 +117,9 @@ class Sensei_REST_API_Lessons_Controller extends WP_REST_Posts_Controller {
 	 * @return array Modified data object with additional fields.
 	 */
 	protected function add_additional_fields_to_object( $prepared, $request ) {
-		if ( ! Sensei()->quiz->is_block_based_editor_enabled() ) {
+		global $pagenow;
+
+		if ( ! Sensei()->quiz->is_block_based_editor_enabled() || 'post-new.php' === $pagenow ) {
 			return $prepared;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes Lesson template when creating a new lesson through WP-admin menu.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Go to wp-admin.
* Go to the menu Lessons > Add New.
* Make sure the lesson starts with the lesson template (Lesson properties, Contact teacher, Lesson actions, and Quiz).