### PR TITLE
Tweak Lesson blocks template when associated with a course with Learning Mode enabled.

### DIFF
--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -76,15 +76,30 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 
 		$post_type_object = get_post_type_object( 'lesson' );
 
-		$block_template = [
-			[ 'sensei-lms/lesson-properties' ],
-			[ 'sensei-lms/button-contact-teacher' ],
-			[
-				'core/paragraph',
-				[ 'placeholder' => __( 'Write lesson content...', 'sensei-lms' ) ],
-			],
-			[ 'sensei-lms/lesson-actions' ],
-		];
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$lesson_id            = isset( $_GET['post'] ) ? intval( $_GET['post'] ) : 0;
+		$course_id            = Sensei()->lesson->get_course_id( $lesson_id );
+		$sensei_theme_enabled = Sensei_Course_Theme_Option::instance()->has_sensei_theme_enabled( $course_id );
+
+		if ( $sensei_theme_enabled ) {
+			$block_template = [
+				[ 'sensei-lms/lesson-properties' ],
+				[
+					'core/paragraph',
+					[ 'placeholder' => __( 'Write lesson content...', 'sensei-lms' ) ],
+				],
+			];
+		} else {
+			$block_template = [
+				[ 'sensei-lms/lesson-properties' ],
+				[ 'sensei-lms/button-contact-teacher' ],
+				[
+					'core/paragraph',
+					[ 'placeholder' => __( 'Write lesson content...', 'sensei-lms' ) ],
+				],
+				[ 'sensei-lms/lesson-actions' ],
+			];
+		}
 
 		if ( Sensei()->quiz->is_block_based_editor_enabled() ) {
 			$block_template[] = [ 'sensei-lms/quiz', [ 'isPostTemplate' => true ] ];

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -77,8 +77,12 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		$post_type_object = get_post_type_object( 'lesson' );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$lesson_id            = isset( $_GET['post'] ) ? intval( $_GET['post'] ) : 0;
-		$course_id            = Sensei()->lesson->get_course_id( $lesson_id );
+		$lesson_id = isset( $_GET['post'] ) ? intval( $_GET['post'] ) : 0; // WP query is not ready yet.
+		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
+
+		// Notice that for new Lessons, the `lesson_id` will return `0` (post query string not set).
+		// It means the following check will return `false`. It's expected and works well because
+		// new lessons don't have associated courses yet.
 		$sensei_theme_enabled = Sensei_Course_Theme_Option::instance()->has_sensei_theme_enabled( $course_id );
 
 		if ( $sensei_theme_enabled ) {

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -125,7 +125,7 @@ class Sensei_Course_Theme_Option {
 			return false;
 		}
 
-		if ( ! self::has_sensei_theme_enabled( $course_id ) ) {
+		if ( ! $this->has_sensei_theme_enabled( $course_id ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
PR based on https://github.com/Automattic/sensei/pull/4557

Based on [this conversation](https://github.com/Automattic/sensei/pull/4539#issuecomment-999174987), it tweaks the lesson blocks template based on the course Learning Mode.

### Changes proposed in this Pull Request

* When creating lessons through the Course Outline, in a course with Learning Mode on, it uses a different blocks template:
  * Lesson properties.
  * "Write lesson content..." paragraph.
  * Quiz.
* Notice that it's the only scenario where we can identify if the course is associated with a course with the Learning Mode enabled. And after saving the lesson, we can't tweak the template anymore.

cc @sruj09 to check if it makes sense.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create a course and enable the Learning Mode (course editor sidebar).
* Create a lesson through the Course Outline.
* Make sure it just contains the lesson properties, the paragraph, and the quiz block.
* Disable the Learning Mode.
* Create a new lesson through the Course Outline, and make sure it also contains all the lesson blocks, like the lesson actions.
* Create a new lesson through the WP-admin > Lessons > Add new, and make sure the lesson contains all the lesson blocks.