### PR TITLE
Add complete lesson attributes

### DIFF
--- a/assets/course-theme/complete-lesson-button.js
+++ b/assets/course-theme/complete-lesson-button.js
@@ -10,10 +10,10 @@ import { __ } from '@wordpress/i18n';
 export const initCompleteLessonTransition = () => {
 	domReady( () => {
 		const completeForms = document.querySelectorAll(
-			'[data-id="complete-lesson-form"], .lesson_button_form'
+			'[data-id="complete-lesson-form"]'
 		);
 		const completeButtons = document.querySelectorAll(
-			'[data-id="complete-lesson-button"], .wp-block-sensei-lms-button-complete-lesson button'
+			'[data-id="complete-lesson-button"]'
 		);
 		const progressBars = document.querySelectorAll(
 			'.sensei-course-theme-course-progress-bar-inner'
@@ -67,15 +67,6 @@ export const initCompleteLessonTransition = () => {
 		 */
 		const onFormSubmit = ( e ) => {
 			const form = e.target;
-
-			// Skip if the form is not for complete lesson (Reset lesson block, for example).
-			if (
-				! form.querySelector(
-					'input[name="quiz_action"][value="lesson-complete"]'
-				)
-			) {
-				return;
-			}
 
 			delayFormSubmit( e, form );
 			runProgressBarAnimation();

--- a/includes/blocks/class-sensei-complete-lesson-block.php
+++ b/includes/blocks/class-sensei-complete-lesson-block.php
@@ -82,8 +82,15 @@ class Sensei_Complete_Lesson_Block {
 			);
 		}
 
+		$content = preg_replace(
+			'/<(button|a)/',
+			'<$1 data-id="complete-lesson-button"',
+			$content,
+			1
+		);
+
 		return '
-		<form class="lesson_button_form" method="POST" action="' . $permalink . '">
+		<form class="lesson_button_form" data-id="complete-lesson-form" method="POST" action="' . $permalink . '">
 			' . $nonce . '
 			<input type="hidden" name="quiz_action" value="lesson-complete" />
 			' . $content . '

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -963,18 +963,19 @@ class Sensei_Frontend {
 			?>
 			<form class="lesson_button_form" data-id="complete-lesson-form" method="POST" action="<?php echo esc_url( get_permalink() ); ?>">
 				<input type="hidden"
-					   name="woothemes_sensei_complete_lesson_noonce"
-					   id="woothemes_sensei_complete_lesson_noonce"
-					   value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_lesson_noonce' ) ); ?>"
+					name="woothemes_sensei_complete_lesson_noonce"
+					id="woothemes_sensei_complete_lesson_noonce"
+					value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_lesson_noonce' ) ); ?>"
 				/>
 
 				<input type="hidden" name="quiz_action" value="lesson-complete" />
 
 				<input type="submit"
-					   name="quiz_complete"
-					   class="quiz-submit complete sensei-stop-double-submission"
-					   data-id="complete-lesson-button"
-					   value="<?php esc_attr_e( 'Complete Lesson', 'sensei-lms' ); ?>"/>
+					name="quiz_complete"
+					class="quiz-submit complete sensei-stop-double-submission"
+					data-id="complete-lesson-button"
+					value="<?php esc_attr_e( 'Complete Lesson', 'sensei-lms' ); ?>"
+				/>
 
 			</form>
 			<?php

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -961,7 +961,7 @@ class Sensei_Frontend {
 			wp_enqueue_script( 'sensei-stop-double-submission' );
 
 			?>
-			<form class="lesson_button_form" method="POST" action="<?php echo esc_url( get_permalink() ); ?>">
+			<form class="lesson_button_form" data-id="complete-lesson-form" method="POST" action="<?php echo esc_url( get_permalink() ); ?>">
 				<input type="hidden"
 					   name="woothemes_sensei_complete_lesson_noonce"
 					   id="woothemes_sensei_complete_lesson_noonce"
@@ -973,6 +973,7 @@ class Sensei_Frontend {
 				<input type="submit"
 					   name="quiz_complete"
 					   class="quiz-submit complete sensei-stop-double-submission"
+					   data-id="complete-lesson-button"
 					   value="<?php esc_attr_e( 'Complete Lesson', 'sensei-lms' ); ?>"/>
 
 			</form>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Based on [this comment](https://github.com/Automattic/sensei/pull/4539#discussion_r773661216), and [this](https://github.com/Automattic/sensei/pull/4546#pullrequestreview-838833100), I thought that it would be good to add data attributes to all places that we can have the complete lesson buttons. So we can handle better with these scripts.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create a course with lessons.
* Enable the Course Theme (course editor sidebar).
* Complete the lessons as a student through the Complete Lesson button block in the content, and the Complete Lesson button in the top bar, and make sure you see the transition feedback (message and progress bar animation).