### PR TITLE
Tweak link style in lesson quiz notice 

### DIFF
--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -48,6 +48,10 @@
 	&.is-link {
 		font-weight: 600;
 		text-decoration: underline;
+
+		&:hover {
+			color: var(--primary-color);
+		}
 	}
 
 	&[aria-disabled="true"],

--- a/assets/css/sensei-course-theme/notices.scss
+++ b/assets/css/sensei-course-theme/notices.scss
@@ -36,6 +36,16 @@
 			margin-right: 12px;
 		}
 	}
+
+	&__action {
+		display: flex;
+		align-items: center;
+	}
+
+	&__link-chevron {
+		width: 24px;
+		height: 24px;
+	}
 }
 
 .sensei-course-theme-locked-lesson-notice {

--- a/templates/course-theme/lesson-quiz-notice.php
+++ b/templates/course-theme/lesson-quiz-notice.php
@@ -54,8 +54,12 @@ if ( ! function_exists( 'sensei_lesson_quiz_notice_actions_map' ) ) {
 				echo wp_kses_post( $action );
 			} else {
 				?>
-				<a href="<?php echo esc_url( $action['url'] ); ?>" class="sensei-course-theme__button is-<?php echo esc_attr( $action['style'] ); ?>">
+				<a href="<?php echo esc_url( $action['url'] ); ?>" class="sensei-course-theme-lesson-quiz-notice__action sensei-course-theme__button is-<?php echo esc_attr( $action['style'] ); ?>">
 					<?php echo wp_kses_post( $action['label'] ); ?>
+					<?php
+						// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Function returning svg only.
+						echo Sensei()->assets->get_icon( 'chevron-right', 'sensei-course-theme-lesson-quiz-notice__link-chevron' );
+					?>
 				</a>
 				<?php
 			}


### PR DESCRIPTION
Based on https://github.com/Automattic/sensei/pull/4538

### Changes proposed in this Pull Request

* It tweaks the link style in lesson quiz notice.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create a course and select Sensei Course Theme (course editor sidebar).
* Add a lesson with a quiz.
* Complete the quiz, and access the lesson page.
* Make sure the link in the notice is like the screenshot.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="932" alt="Screen Shot 2021-12-28 at 11 04 56" src="https://user-images.githubusercontent.com/876340/147574560-2de355a7-7de6-45de-8d5f-3f748f03efeb.png">
