### PR TITLE
Show incomplete questions info mesage on the quiz preview

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1616,7 +1616,7 @@ class Sensei_Quiz {
 	}
 
 	/**
-	 * Is password required
+	 * Is password required.
 	 *
 	 * @param int $lesson_id Lesson ID.
 	 *
@@ -1636,7 +1636,7 @@ class Sensei_Quiz {
 	}
 
 	/**
-	 * Will maybe delete the quiz
+	 * Will maybe delete the quiz.
 	 *
 	 * @since 1.9.5
 	 *

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1451,6 +1451,18 @@ class Sensei_Quiz {
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped above.
 		echo $message;
+
+		// show incomplete questions info message if there are incomplete questions and is preview.
+		if ( is_preview() ) {
+			$lesson_id          = Sensei()->quiz->get_lesson_id( $quiz_id );
+			$all_questions      = Sensei()->quiz->get_questions( Sensei()->lesson->lesson_quizzes( $lesson_id ) );
+			$filtered_questions = Sensei()->quiz->get_questions( Sensei()->lesson->lesson_quizzes( $lesson_id ), 'any', 'meta_value_num title', 'ASC', true );
+
+			if ( count( $all_questions ) !== count( $filtered_questions ) ) {
+				Sensei()->notices->add_notice( __( 'One or more questions in this lesson are incomplete. Incomplete questions are only displayed in preview mode and will not be displayed to students.', 'sensei-lms' ), 'info', 'incomplete-keys-messages' );
+				Sensei()->notices->maybe_print_notices();
+			}
+		}
 	}
 
 	/**
@@ -1543,7 +1555,7 @@ class Sensei_Quiz {
 	 */
 	public static function get_user_quiz_grade( $lesson_id, $user_id ) {
 
-		// get the quiz grade
+		// get the quiz grade.
 		$user_lesson_status = Sensei_Utils::user_lesson_status( $lesson_id, $user_id );
 		$user_quiz_grade    = 0;
 		if ( isset( $user_lesson_status->comment_ID ) ) {
@@ -1570,7 +1582,7 @@ class Sensei_Quiz {
 		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
 
 		$reset_allowed = get_post_meta( $quiz_id, '_enable_quiz_reset', true );
-		// backwards compatibility
+		// backwards compatibility.
 		if ( 'on' == $reset_allowed ) {
 			$reset_allowed = 1;
 		}
@@ -1604,7 +1616,9 @@ class Sensei_Quiz {
 	}
 
 	/**
-	 * @param $lesson_id
+	 * Is password required
+	 *
+	 * @param int $lesson_id Lesson ID.
 	 *
 	 * @return bool
 	 */
@@ -1613,7 +1627,7 @@ class Sensei_Quiz {
 		$quiz_id = Sensei()->lesson->lesson_quizzes( $lesson_id );
 
 		$reset_allowed = get_post_meta( $quiz_id, '_pass_required', true );
-		// backwards compatibility
+		// backwards compatibility.
 		if ( 'on' == $reset_allowed ) {
 			$reset_allowed = 1;
 		}
@@ -1622,9 +1636,11 @@ class Sensei_Quiz {
 	}
 
 	/**
+	 * Will maybe delete the quiz
+	 *
 	 * @since 1.9.5
 	 *
-	 * @param integer $post_id of the post being permanently deleted
+	 * @param integer $post_id of the post being permanently deleted.
 	 */
 	public function maybe_delete_quiz( $post_id ) {
 
@@ -1644,8 +1660,8 @@ class Sensei_Quiz {
 	 * Also, remove any question_ids not part of
 	 * the question set for this lesson quiz
 	 *
-	 * @param $post_global
-	 * @param $quiz_id
+	 * @param array $post_global Post global data.
+	 * @param int   $quiz_id Quiz ID.
 	 * @return array
 	 */
 	private function merge_quiz_answers_with_questions_asked( $post_global, $quiz_id ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -100645,9 +100645,9 @@
       }
     },
     "ws": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.3.tgz",
-      "integrity": "sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"


### PR DESCRIPTION
### About this PR
- In previous PR we introduced changes that will filter out incomplete questions for the user, they will be visible only if it is a preview 
- This PR will display a message if it is a preview that will inform the user that questions will not be displayed when it isn't a preview

### Changes proposed in this Pull Request
- When displaying other user quiz messages, add a notice about incomplete messages

#### Why did I add them this way (I'm not a huge fan of it, but this is the best I've come up with)
- Adding then in ```sensei_user_quiz_status_message``` is not possible since only a single message is returned from it and this message would either override another message that was supposed to be displayed or not shown
- Adding it on the frontend messages, I didn't see a place there where it would be appropriate
- Sending notice in ```getQuestions``` function is not a good place since then the message is displayed two times, doesn't matter that the key is unique. 

### For discussion
- I have issues when testing to get ```is_preview()``` to be true since we can open Lesson in Preview mode but when we click on View Quiz we get redirection that doesn't preview mode anymore. 
- I will create a separate PR to try to understand how to redirect in preview so that if we open lesson/course when going to the lesson and get to quiz they are also in preview

### Testing instructions
- As noted in the section above (for discussion) I had to do all the testing with switching is_preview() with **true** 
- Create a lesson with a quiz that has some incomplete questions go to the quiz and you will see the message box above it

![image](https://user-images.githubusercontent.com/7208249/147765393-48558eae-eaef-43db-9763-3de6ebfc56c9.png)

