### PR TITLE
Add/videopress extension

### DIFF
--- a/assets/js/frontend/course-video/video-blocks-extension.js
+++ b/assets/js/frontend/course-video/video-blocks-extension.js
@@ -139,6 +139,46 @@
 		)
 		.forEach( initVimeoPlayer );
 
+	const initVideoPressPlayer = ( iframe ) => {
+		iframe.addEventListener( 'load', () => {
+			// eslint-disable-next-line @wordpress/no-global-event-listener
+			window.addEventListener(
+				'message',
+				( event ) => {
+					if ( event.source !== iframe.contentWindow ) {
+						return;
+					}
+					if ( event.data.event === 'ended' ) {
+						onEnded();
+					}
+				},
+				false
+			);
+
+			// eslint-disable-next-line @wordpress/no-global-event-listener
+			document.addEventListener(
+				'visibilitychange',
+				() => {
+					if ( document.hidden ) {
+						iframe.contentWindow.postMessage(
+							{
+								event: 'videopress_action_pause',
+							},
+							'*'
+						);
+					}
+				},
+				false
+			);
+		} );
+	};
+
+	document
+		.querySelectorAll(
+			'.sensei-course-video-container.videopress-extension iframe'
+		)
+		.forEach( initVideoPressPlayer );
+
 	if ( courseVideoRequired ) {
 		disableCompleteLessonButton();
 	}

--- a/includes/course-video/blocks/class-sensei-course-video-blocks-videopress-extension.php
+++ b/includes/course-video/blocks/class-sensei-course-video-blocks-videopress-extension.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * File containing the Sensei_Course_Video_Blocks_VideoPress_Extension class.
+ *
+ * @package sensei-lms
+ * @since 4.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Extends standard Embed block with VideoPress specific functionality for video course progression
+ *
+ * @since 4.0.0
+ */
+class Sensei_Course_Video_Blocks_VideoPress_Extension extends Sensei_Course_Video_Blocks_Embed_Extension {
+	/**
+	 * Instance of class.
+	 *
+	 * @var self
+	 */
+	private static $instance;
+
+	/**
+	 * Returns an instance of the class.
+	 *
+	 * @return static
+	 */
+	public static function instance() {
+		if ( self::$instance ) {
+			return self::$instance;
+		}
+
+		self::$instance = new static();
+		return self::$instance;
+	}
+
+	/**
+	 * Sensei_Course_Video_Blocks_VideoPress_Extension constructor.
+	 */
+	private function __construct() {
+	}
+
+	/**
+	 * Check if the URL is a VideoPress URL.
+	 *
+	 * @param string $url
+	 *
+	 * @return bool
+	 */
+	protected function is_supported( string $url ): bool {
+		$host = wp_parse_url( $url, PHP_URL_HOST );
+
+		return strpos( $host, 'videopress.com' ) !== false || strpos( $host, 'video.wordpress.com' ) !== false;
+	}
+
+	/**
+	 * Returns the class name for the extension.
+	 *
+	 * @return string
+	 */
+	protected function get_extension_class_name(): string {
+		return 'videopress-extension';
+	}
+}

--- a/includes/course-video/blocks/class-sensei-course-video-blocks-youtube-extension.php
+++ b/includes/course-video/blocks/class-sensei-course-video-blocks-youtube-extension.php
@@ -38,7 +38,7 @@ class Sensei_Course_Video_Blocks_Youtube_Extension extends Sensei_Course_Video_B
 	}
 
 	/**
-	 * Sensei_Youtube_Extension constructor.
+	 * Sensei_Course_Video_Blocks_Youtube_Extension constructor.
 	 */
 	private function __construct() {
 	}

--- a/includes/course-video/class-sensei-course-video-settings.php
+++ b/includes/course-video/class-sensei-course-video-settings.php
@@ -77,6 +77,7 @@ class Sensei_Course_Video_Settings {
 		Sensei_Course_Video_Blocks_Youtube_Extension::instance()->init();
 		Sensei_Course_Video_Blocks_Video_Extension::instance()->init();
 		Sensei_Course_Video_Blocks_Vimeo_Extension::instance()->init();
+		Sensei_Course_Video_Blocks_VideoPress_Extension::instance()->init();
 	}
 
 	/**

--- a/tests/unit-tests/course-video/blocks/test-class-sensei-course-video-blocks-videopress-extension.php
+++ b/tests/unit-tests/course-video/blocks/test-class-sensei-course-video-blocks-videopress-extension.php
@@ -1,0 +1,36 @@
+<?php
+
+class Test_Sensei_Course_Video_Blocks_VideoPress_Extension extends WP_UnitTestCase {
+	/**
+	 * Test if only VideoPress video embeds are wrapped in the block.
+	 *
+	 * @dataProvider provider_wraps_only_videopress_embeds
+	 */
+	public function test_wrap_only_videopress_embed( $iframe, $url, $expected ) {
+		$videopress_extension = Sensei_Course_Video_Blocks_VideoPress_Extension::instance();
+
+		$result = $videopress_extension->wrap_video( $iframe, $url );
+
+		self::assertSame( $expected, $result );
+	}
+
+	public function provider_wraps_only_videopress_embeds() {
+		return array(
+			'videopress.com'      => array(
+				'<iframe src="https://videopress.com/abc"></iframe>',
+				'https://videopress.com/v/abc',
+				'<div class=\'sensei-course-video-container videopress-extension\'><iframe src="https://videopress.com/abc"></iframe></div>',
+			),
+			'video.wordpress.com' => array(
+				'<iframe src="https://videopress.com/abc"></iframe>',
+				'https://video.wordpress.com/embed/video-id',
+				'<div class=\'sensei-course-video-container videopress-extension\'><iframe src="https://videopress.com/abc"></iframe></div>',
+			),
+			'youtube.com'         => array(
+				'<iframe src="https://www.youtube.com/embed/video-id"></iframe>',
+				'https://www.youtube.com/watch?v=video-id',
+				'<iframe src="https://www.youtube.com/embed/video-id"></iframe>',
+			),
+		);
+	}
+}

--- a/tests/unit-tests/course-video/blocks/test-class-sensei-course-video-blocks-vimeo-extension.php
+++ b/tests/unit-tests/course-video/blocks/test-class-sensei-course-video-blocks-vimeo-extension.php
@@ -7,8 +7,7 @@ class Test_Sensei_Course_Video_Blocks_Vimeo_Extension extends WP_UnitTestCase {
 	 * @dataProvider provider_wraps_only_vimeo_embeds
 	 */
 	public function test_wrap_only_vimeo_embed( $iframe, $url, $expected ) {
-		$settings        = $this->createMock( Sensei_Course_Video_Settings::class );
-		$vimeo_extension = Sensei_Course_Video_Blocks_Vimeo_Extension::instance( $settings );
+		$vimeo_extension = Sensei_Course_Video_Blocks_Vimeo_Extension::instance();
 
 		$result = $vimeo_extension->wrap_video( $iframe, $url );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Initialize event handlers for the VideoPress block to implement Video-course progression settings.
* I based this solution on [the YouTube implementation](https://github.com/Automattic/sensei/pull/4546) (so it is extremely similar).

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_video_based_course_progression', '__return_true' );`
  The preferable place is inside `sensei-lms.php`, somewhere in the beginning.
* Run `npm start`
* Enable all video settings for a course.
* Add a VideoPress block to the course lesson. (Ask me for a VideoPress video link if you need.)
* Enroll in the course.
* Open the lesson with the video.
* Watch the video completely and wait for the auto-submission of the form.
* Disable autocomplete setting and open the lesson again.
* Try to complete the lesson before you watched it completely. Shouldn't submit the form.
* Watch the video completely and wait for the auto-submission of the form. Should work. Also, the complete lesson button should become enabled.
* Test of auto-pause:
  * Start playing video.
  * Try to change tab/window.
  * Video should be paused.