### PR TITLE
Make the quiz buttons consistent

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -422,46 +422,6 @@ a.sensei-certificate-link {
 		}
 	}
 
-	.sensei-quiz-pagination__actions {
-		display: flex;
-		order: 1;
-
-		@media only screen and (min-width: $tablet-breakpoint) {
-			order: 0;
-		}
-	}
-
-	.sensei-quiz-pagination__action {
-		display: inline-flex;
-
-		&:not(:first-child) {
-			margin-left: 0.5em;
-			padding-left: 0.5em;
-			border-left: 2px solid;
-		}
-
-		button {
-			@include button-link;
-		}
-	}
-
-	.sensei-quiz-pagination__nav {
-		display: flex;
-		align-items: center;
-
-		@media only screen and (min-width: $tablet-breakpoint) {
-			margin-left: auto;
-		}
-
-		.wp-block-buttons {
-			gap: 0.5em;
-
-			.wp-block-button {
-				margin: 0;
-			}
-		}
-	}
-
 	.sensei-quiz-pagination__prev-button {
 		&:before  {
 			@include iconbefore();
@@ -478,6 +438,54 @@ a.sensei-certificate-link {
 		}
 	}
 }
+
+/**
+ * Quiz Actions
+ */
+#sensei-quiz-actions {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	gap: 1.5em;
+
+	@media only screen and (min-width: $tablet-breakpoint) {
+		flex-direction: row;
+		margin-left: auto;
+	}
+
+	.sensei-quiz-action {
+		margin: 0;
+	}
+
+	.sensei-quiz-actions-primary {
+		display: flex;
+		gap: 0.5em;
+	}
+
+	.sensei-quiz-actions-secondary {
+		display: flex;
+		order: 1;
+
+		@media only screen and (min-width: $tablet-breakpoint) {
+			order: 0;
+		}
+
+		.sensei-quiz-action {
+			display: flex;
+
+			&:not(:first-child) {
+				margin-left: 0.5em;
+				padding-left: 0.5em;
+				border-left: 2px solid;
+			}
+
+			button {
+				@include button-link;
+			}
+		}
+	}
+}
+
 
 .quiz:not(.quiz-blocks), .lesson {
   button.quiz-submit  {

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1672,16 +1672,6 @@ class Sensei_Quiz {
 			<?php endif ?>
 
 			<div class="sensei-quiz-actions-secondary">
-				<?php if ( ! $is_quiz_completed ) : ?>
-					<div class="sensei-quiz-action">
-						<button type="submit" name="quiz_save" class="sensei-stop-double-submission">
-							<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>
-						</button>
-
-						<input type="hidden" name="woothemes_sensei_save_quiz_nonce" id="woothemes_sensei_save_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
-					</div>
-				<?php endif ?>
-
 				<?php if ( $is_reset_allowed ) : ?>
 					<div class="sensei-quiz-action">
 						<button type="submit" name="quiz_reset" class="sensei-stop-double-submission">
@@ -1689,6 +1679,16 @@ class Sensei_Quiz {
 						</button>
 
 						<input type="hidden" name="woothemes_sensei_reset_quiz_nonce" id="woothemes_sensei_reset_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' ) ); ?>" />
+					</div>
+				<?php endif ?>
+
+				<?php if ( ! $is_quiz_completed ) : ?>
+					<div class="sensei-quiz-action">
+						<button type="submit" name="quiz_save" class="sensei-stop-double-submission">
+							<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>
+						</button>
+
+						<input type="hidden" name="woothemes_sensei_save_quiz_nonce" id="woothemes_sensei_save_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
 					</div>
 				<?php endif ?>
 			</div>

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1674,7 +1674,7 @@ class Sensei_Quiz {
 			<div class="sensei-quiz-actions-secondary">
 				<?php if ( $is_reset_allowed ) : ?>
 					<div class="sensei-quiz-action">
-						<button type="submit" name="quiz_reset" class="sensei-stop-double-submission">
+						<button type="submit" name="quiz_reset" class="quiz-submit reset sensei-stop-double-submission">
 							<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>
 						</button>
 
@@ -1684,7 +1684,7 @@ class Sensei_Quiz {
 
 				<?php if ( ! $is_quiz_completed ) : ?>
 					<div class="sensei-quiz-action">
-						<button type="submit" name="quiz_save" class="sensei-stop-double-submission">
+						<button type="submit" name="quiz_save" class="quiz-submit save sensei-stop-double-submission">
 							<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>
 						</button>
 

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1658,34 +1658,40 @@ class Sensei_Quiz {
 		wp_enqueue_script( 'sensei-stop-double-submission' );
 		?>
 
-		<div class="wp-block-buttons">
+		<div id="sensei-quiz-actions">
 			<?php if ( ! $is_quiz_completed ) : ?>
-				<div class="wp-block-button">
-					<button type="submit" name="quiz_complete" class="wp-block-button__link button quiz-submit complete sensei-stop-double-submission">
-						<?php esc_attr_e( 'Complete Quiz', 'sensei-lms' ); ?>
-					</button>
+				<div class="sensei-quiz-actions-primary wp-block-buttons">
+					<div class="sensei-quiz-action wp-block-button">
+						<button type="submit" name="quiz_complete" class="wp-block-button__link button quiz-submit complete sensei-stop-double-submission">
+							<?php esc_attr_e( 'Complete', 'sensei-lms' ); ?>
+						</button>
 
-					<input type="hidden" name="woothemes_sensei_complete_quiz_nonce" id="woothemes_sensei_complete_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_quiz_nonce' ) ); ?>" />
-				</div>
-
-				<div class="wp-block-button is-style-outline">
-					<button type="submit" name="quiz_save" class="wp-block-button__link button quiz-submit save sensei-stop-double-submission">
-						<?php esc_attr_e( 'Save Quiz', 'sensei-lms' ); ?>
-					</button>
-
-					<input type="hidden" name="woothemes_sensei_save_quiz_nonce" id="woothemes_sensei_save_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
+						<input type="hidden" name="woothemes_sensei_complete_quiz_nonce" id="woothemes_sensei_complete_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_complete_quiz_nonce' ) ); ?>" />
+					</div>
 				</div>
 			<?php endif ?>
 
-			<?php if ( $is_reset_allowed ) : ?>
-				<div class="wp-block-button is-style-outline">
-					<button type="submit" name="quiz_reset" class="wp-block-button__link button quiz-submit reset sensei-stop-double-submission">
-						<?php esc_attr_e( 'Reset Quiz', 'sensei-lms' ); ?>
-					</button>
+			<div class="sensei-quiz-actions-secondary">
+				<?php if ( ! $is_quiz_completed ) : ?>
+					<div class="sensei-quiz-action">
+						<button type="submit" name="quiz_save" class="sensei-stop-double-submission">
+							<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>
+						</button>
 
-					<input type="hidden" name="woothemes_sensei_reset_quiz_nonce" id="woothemes_sensei_reset_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' ) ); ?>" />
-				</div>
-			<?php endif ?>
+						<input type="hidden" name="woothemes_sensei_save_quiz_nonce" id="woothemes_sensei_save_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
+					</div>
+				<?php endif ?>
+
+				<?php if ( $is_reset_allowed ) : ?>
+					<div class="sensei-quiz-action">
+						<button type="submit" name="quiz_reset" class="sensei-stop-double-submission">
+							<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>
+						</button>
+
+						<input type="hidden" name="woothemes_sensei_reset_quiz_nonce" id="woothemes_sensei_reset_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' ) ); ?>" />
+					</div>
+				<?php endif ?>
+			</div>
 		</div>
 		<?php
 

--- a/templates/single-quiz/pagination.php
+++ b/templates/single-quiz/pagination.php
@@ -63,7 +63,7 @@ $sensei_has_actions       = $sensei_is_reset_allowed || ! $sensei_is_quiz_comple
 			<div class="sensei-quiz-actions-secondary">
 				<?php if ( $sensei_is_reset_allowed ) : ?>
 					<div class="sensei-quiz-action">
-						<button type="submit" name="quiz_reset" class="sensei-stop-double-submission">
+						<button type="submit" name="quiz_reset" class="quiz-submit reset sensei-stop-double-submission">
 							<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>
 						</button>
 
@@ -73,7 +73,7 @@ $sensei_has_actions       = $sensei_is_reset_allowed || ! $sensei_is_quiz_comple
 
 				<?php if ( ! $sensei_is_quiz_completed ) : ?>
 					<div class="sensei-quiz-action">
-						<button type="submit" name="quiz_save" class="sensei-stop-double-submission">
+						<button type="submit" name="quiz_save" class="quiz-submit save sensei-stop-double-submission">
 							<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>
 						</button>
 

--- a/templates/single-quiz/pagination.php
+++ b/templates/single-quiz/pagination.php
@@ -58,34 +58,34 @@ $sensei_has_actions       = $sensei_is_reset_allowed || ! $sensei_is_quiz_comple
 		?>
 	</div>
 
-	<?php if ( $sensei_is_quiz_available && $sensei_has_actions ) : ?>
-		<div class="sensei-quiz-pagination__actions">
-			<?php if ( $sensei_is_reset_allowed ) : ?>
-				<div class="sensei-quiz-pagination__action">
-					<button type="submit" name="quiz_reset" class="sensei-stop-double-submission">
-						<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>
-					</button>
+	<div id="sensei-quiz-actions">
+		<?php if ( $sensei_is_quiz_available && $sensei_has_actions ) : ?>
+			<div class="sensei-quiz-actions-secondary">
+				<?php if ( $sensei_is_reset_allowed ) : ?>
+					<div class="sensei-quiz-action">
+						<button type="submit" name="quiz_reset" class="sensei-stop-double-submission">
+							<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>
+						</button>
 
-					<input type="hidden" name="woothemes_sensei_reset_quiz_nonce" id="woothemes_sensei_reset_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' ) ); ?>" />
-				</div>
-			<?php endif ?>
+						<input type="hidden" name="woothemes_sensei_reset_quiz_nonce" id="woothemes_sensei_reset_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_reset_quiz_nonce' ) ); ?>" />
+					</div>
+				<?php endif ?>
 
-			<?php if ( ! $sensei_is_quiz_completed ) : ?>
-				<div class="sensei-quiz-pagination__action">
-					<button type="submit" name="quiz_save" class="sensei-stop-double-submission">
-						<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>
-					</button>
+				<?php if ( ! $sensei_is_quiz_completed ) : ?>
+					<div class="sensei-quiz-action">
+						<button type="submit" name="quiz_save" class="sensei-stop-double-submission">
+							<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>
+						</button>
 
-					<input type="hidden" name="woothemes_sensei_save_quiz_nonce" id="woothemes_sensei_save_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
-				</div>
-			<?php endif ?>
-		</div>
-	<?php endif ?>
+						<input type="hidden" name="woothemes_sensei_save_quiz_nonce" id="woothemes_sensei_save_quiz_nonce" value="<?php echo esc_attr( wp_create_nonce( 'woothemes_sensei_save_quiz_nonce' ) ); ?>" />
+					</div>
+				<?php endif ?>
+			</div>
+		<?php endif ?>
 
-	<div class="sensei-quiz-pagination__nav">
-		<div class="wp-block-buttons">
+		<div class="sensei-quiz-actions-primary wp-block-buttons">
 			<?php if ( $sensei_question_loop['current_page'] > 1 ) : ?>
-				<div class="wp-block-button is-style-outline">
+				<div class="sensei-quiz-action wp-block-button is-style-outline">
 					<button
 						type="submit"
 						name="quiz_target_page"
@@ -98,7 +98,7 @@ $sensei_has_actions       = $sensei_is_reset_allowed || ! $sensei_is_quiz_comple
 			<?php endif ?>
 
 			<?php if ( $sensei_question_loop['current_page'] < $sensei_question_loop['total_pages'] ) : ?>
-				<div class="wp-block-button">
+				<div class="sensei-quiz-action wp-block-button">
 					<button
 						type="submit"
 						name="quiz_target_page"
@@ -109,7 +109,7 @@ $sensei_has_actions       = $sensei_is_reset_allowed || ! $sensei_is_quiz_comple
 					</button>
 				</div>
 			<?php elseif ( $sensei_is_quiz_available && ! $sensei_is_quiz_completed ) : ?>
-				<div class="wp-block-button">
+				<div class="sensei-quiz-action wp-block-button">
 					<button type="submit" name="quiz_complete" class="wp-block-button__link button quiz-submit complete sensei-stop-double-submission">
 						<?php esc_attr_e( 'Complete', 'sensei-lms' ); ?>
 					</button>


### PR DESCRIPTION
Fixes #4540

### Changes proposed in this Pull Request

This PR will unify the look of the non-paginated quiz buttons and the paginated ones.

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_quiz_pagination', '__return_true' );`
* Make a quiz with multiple questions.
* Enable the pagination by updating the quiz pagination settings.
* Check if the buttons look good on desktop and mobile.
* Disable the pagination.
* Check if the buttons look the same as the ones displayed in the paginated quiz.
* Make sure the buttons look consistent on all the popular themes.

### Screenshot

Pagination enabled:
<img width="623" alt="Screenshot on 2022-01-04 at 23-43-15" src="https://user-images.githubusercontent.com/1612178/148127845-198b54ae-1c15-475f-8804-e773c3df9c1c.png">

Pagination disabled:
<img width="634" alt="Screenshot on 2022-01-04 at 23-43-59" src="https://user-images.githubusercontent.com/1612178/148127850-2608b5e1-999c-4a40-a1cb-87ff77b224e2.png">

