### PR TITLE
Fix course theme start lesson

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -139,7 +139,7 @@ class Sensei_Lesson {
 		} else {
 			// Frontend actions
 			// Starts lesson when the student visits for the first time and prerequisite courses have been met.
-			add_action( 'sensei_single_lesson_content_inside_before', array( __CLASS__, 'maybe_start_lesson' ) );
+			add_action( 'wp', array( __CLASS__, 'maybe_start_lesson' ) );
 		}
 
 		// Log event on the initial publish for a lesson.
@@ -4325,11 +4325,11 @@ class Sensei_Lesson {
 	 * @param int|string $user_id
 	 */
 	public static function maybe_start_lesson( $lesson_id = '', $user_id = '' ) {
-		if ( empty( $lesson_id ) ) {
+		if ( empty( $lesson_id ) || ! is_int( $lesson_id ) ) {
 			$lesson_id = get_the_ID();
 		}
 
-		if ( empty( $user_id ) ) {
+		if ( empty( $user_id ) || ! is_int( $user_id ) ) {
 			$user_id = get_current_user_id();
 		}
 


### PR DESCRIPTION
Fixes #4569

### Changes proposed in this Pull Request

* It fixes the issue that the lesson wouldn't start for a user when using Learning Mode.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create a course and select Sensei Course Theme (course editor sidebar).
* Add some lessons to the course.
* For this test, you should make the first access in a lesson directly through the final URL `/learn/lesson/lesson-slug/`.
* Make sure after the first access the lesson started - you can confirm it by checking the course lessons in wp-admin > Sensei LMS > Student Management.
* Repeat the test in a course without the learning mode enabled, and make sure it also continues working there.