### PR TITLE
Fix learning mode redirection.

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -73,7 +73,7 @@ class Sensei_Course_Theme_Option {
 		new \Sensei\Blocks\Course_Theme();
 
 		add_action( 'init', [ $this, 'register_post_meta' ] );
-		add_action( 'template_redirect', [ $this, 'maybe_redirect_to_correct_mode' ] );
+		add_action( 'template_redirect', [ $this, 'ensure_learning_mode_url_prefix' ] );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Lesson::instance(), 'init' ] );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Quiz::instance(), 'init' ] );
 	}
@@ -93,11 +93,12 @@ class Sensei_Course_Theme_Option {
 	}
 
 	/**
-	 * Redirect to the correct mode if needed.
+	 * Ensure the learning mode prefix is set if required or removed
+	 * if not allowed.
 	 *
 	 * @access private
 	 */
-	public function maybe_redirect_to_correct_mode() {
+	public function ensure_learning_mode_url_prefix() {
 		if (
 			is_admin() ||
 			( Sensei_Course_Theme::instance()->is_active() && $this->should_use_sensei_theme() ) ||


### PR DESCRIPTION
Fixes #4541 

### Changes proposed in this Pull Request

* Exit immediately after wp_safe_redirect to avoid unwanted hooks from running.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)


-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* For testing unwanted lesson hooks:
  * Hook into any action and/or hook that might run during the lesson page visit.
  * Turn on Learning Mode.
  * Visit the lesson page and confirm that no lesson related hooks did run.
* For testing blank lesson page.
  * Turn on the Learning Mode.
  * Visit the lesson page.
  * In a separate tab/window, visit the course page editor and turn off the Learning mode.
  * Refresh the lesson page and confirm it renders in normal mode without problems.