### PR TITLE
Add filters and actions to support quiz timer

### DIFF
--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -9,6 +9,7 @@ import { camelCase, snakeCase, omit, keyBy } from 'lodash';
 import { dispatch, select, useDispatch } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
@@ -45,7 +46,19 @@ export function useQuizStructure( { clientId } ) {
 	}, [ setBlock, loadStructure, clientId ] );
 }
 
-registerStructureStore( {
+/**
+ * Filters the quiz structure store to allow modifications on the interactions with the lesson-quiz REST API.
+ *
+ * @param {string}   opts.storeName          Name of quiz store.
+ * @param {Function} opts.getEndpoint        REST API endpoint.
+ * @param {Function} opts.saveError          Handler for displaying save errors.
+ * @param {Function} opts.fetchError         Handler for displaying fetch errors.
+ * @param {Function} opts.clearError         Handler for clearing errors.
+ * @param {Function} opts.updateBlock        Update block with given structure.
+ * @param {Function} opts.readBlock          Extract structure from block.
+ * @param {Function} opts.setServerStructure Set the server structure which is used to track differences.
+ */
+const quizStructureStore = applyFilters( 'sensei-lms.quizStructureStore', {
 	storeName: QUIZ_STORE,
 	*getEndpoint() {
 		const lessonId = yield select( 'core/editor' ).getCurrentPostId();
@@ -197,3 +210,5 @@ registerStructureStore( {
 		};
 	},
 } );
+
+registerStructureStore( quizStructureStore );

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -230,6 +230,16 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 
 		Sensei()->quiz->set_questions( $quiz_id, array_filter( $question_ids ) );
 
+		/**
+		 * Fire action when a the lesson-quiz controller updates the data of the quiz.
+		 *
+		 * @hook sensei_rest_api_lesson_quiz_update
+		 *
+		 * @param {WP_Post} $lesson         The lesson.
+		 * @param {array}   $request_params The request parameters.
+		 */
+		do_action( 'sensei_rest_api_lesson_quiz_update', $lesson, $json_params );
+
 		$response = new WP_REST_Response();
 		$response->set_data( $this->get_quiz_data( get_post( $quiz_id ), $lesson ) );
 
@@ -382,7 +392,17 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 			$quiz_data['options']['pagination'] = $json_array;
 		}
 
-		return $quiz_data;
+		/**
+		 * Filters the response of lesson-quiz requests.
+		 *
+		 * @hook sensei_rest_api_lesson_quiz_response
+		 *
+		 * @param {array}   $quiz_data The response data.
+		 * @param {WP_Post} $quiz      The quiz post.default interval.
+		 *
+		 * @return {array} $quiz_data The modified response data.
+		 */
+		return apply_filters( 'sensei_rest_api_lesson_quiz_response', $quiz_data, $quiz );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Added two new filters in the lesson-quiz endpoint to be able to expand it with more data.
* Added a filter for quiz structure store in order to be able to expand the quiz editor.

### Testing instructions
Just make sure that nothing breaks and that the filters make sense and are well documented.

### New/Updated Hooks

* `sensei-lms.quizStructureStore` filters the quiz structure store to allow modifications on the interactions with the lesson-quiz endpoint.
* `sensei_rest_api_lesson_quiz_update` is an action which is triggered when quiz data are updated through the REST endpoint
* `sensei_rest_api_lesson_quiz_response` filters the response for the lesson-quiz endpoint.

