### PR TITLE
Fix grade message with decimals

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1292,10 +1292,10 @@ class Sensei_Utils {
 				elseif ( ! empty( $quiz_grade ) && abs( $quiz_grade ) >= 0 ) {
 					if ( $is_lesson ) {
 						// translators: Placeholder is the quiz grade.
-						$message = sprintf( __( 'Congratulations! You have passed this lesson\'s quiz achieving %s%%', 'sensei-lms' ), self::round( $quiz_grade ) );
+						$message = sprintf( __( 'Congratulations! You have passed this lesson\'s quiz achieving %s%%', 'sensei-lms' ), self::round( $quiz_grade, 2 ) );
 					} else {
 						// translators: Placeholder is the quiz grade.
-						$message = sprintf( __( 'Congratulations! You have passed this quiz achieving %s%%', 'sensei-lms' ), self::round( $quiz_grade ) );
+						$message = sprintf( __( 'Congratulations! You have passed this quiz achieving %s%%', 'sensei-lms' ), self::round( $quiz_grade, 2 ) );
 					}
 				}
 
@@ -1321,7 +1321,7 @@ class Sensei_Utils {
 						$message = sprintf( __( 'You have completed this lesson\'s quiz and it will be graded soon. %1$sView the lesson quiz%2$s', 'sensei-lms' ), '<a href="' . esc_url( get_permalink( $quiz_id ) ) . '" title="' . esc_attr( get_the_title( $quiz_id ) ) . '">', '</a>' );
 					} else {
 						// translators: Placeholder is the quiz passmark.
-						$message = sprintf( __( 'You have completed this quiz and it will be graded soon. You require %1$s%% to pass.', 'sensei-lms' ), self::round( $quiz_passmark ) );
+						$message = sprintf( __( 'You have completed this quiz and it will be graded soon. You require %1$s%% to pass.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
 					}
 				}
 				// Lesson status must be "failed"
@@ -1330,10 +1330,10 @@ class Sensei_Utils {
 					$box_class = 'alert';
 					if ( $is_lesson ) {
 						// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
-						$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark ), self::round( $quiz_grade ) );
+						$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
 					} else {
 						// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
-						$message = sprintf( __( 'You require %1$d%% to pass this quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark ), self::round( $quiz_grade ) );
+						$message = sprintf( __( 'You require %1$d%% to pass this quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
 					}
 				}
 				// Lesson/Quiz requires a pass
@@ -1345,10 +1345,10 @@ class Sensei_Utils {
 						$message = '';
 					} elseif ( $is_lesson ) {
 						// translators: Placeholder is the quiz passmark.
-						$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz.', 'sensei-lms' ), self::round( $quiz_passmark ) );
+						$message = sprintf( __( 'You require %1$d%% to pass this lesson\'s quiz.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
 					} else {
 						// translators: Placeholder is the quiz passmark.
-						$message = sprintf( __( 'You require %1$d%% to pass this quiz.', 'sensei-lms' ), self::round( $quiz_passmark ) );
+						$message = sprintf( __( 'You require %1$d%% to pass this quiz.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
 					}
 				}
 			}

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -76,26 +76,19 @@ class Sensei_Course_Theme_Lesson {
 		}
 
 		$user_lesson_status = \Sensei_Utils::user_lesson_status( $lesson_id, $user_id );
-		$user_grade         = 0;
-
-		if ( $user_lesson_status ) {
-			if ( isset( $user_lesson_status->comment_ID ) ) {
-				$grade = get_comment_meta( $user_lesson_status->comment_ID, 'grade', true );
-				if ( ! empty( $grade ) ) {
-					$user_grade = \Sensei_Utils::round( $grade );
-				}
-			}
-		}
+		$user_grade         = Sensei_Quiz::get_user_quiz_grade( $lesson_id, $user_id );
+		$user_grade         = Sensei_Utils::round( $user_grade, 2 );
 
 		$quiz_id       = Sensei()->lesson->lesson_quizzes( $lesson_id );
-		$quiz_passmark = absint( get_post_meta( $quiz_id, '_quiz_passmark', true ) );
+		$quiz_passmark = get_post_meta( $quiz_id, '_quiz_passmark', true );
+		$quiz_passmark = Sensei_Utils::round( $quiz_passmark, 2 );
 		$pass_required = get_post_meta( $quiz_id, '_pass_required', true );
 
 		if ( 'ungraded' === $user_lesson_status->comment_approved ) {
 			$text = __( 'Awaiting grade', 'sensei-lms' );
 		} elseif ( 'failed' === $user_lesson_status->comment_approved ) {
 			// translators: Placeholders are the required grade and the actual grade, respectively.
-			$text = sprintf( __( 'You require %1$s%% to pass this course. Your grade is %2$s%%.', 'sensei-lms' ), '<strong>' . $quiz_passmark . '</strong>', '<strong>' . $user_grade . '</strong>' );
+			$text = sprintf( __( 'You require %1$s%% to pass this lesson\'s quiz. Your grade is %2$s%%.', 'sensei-lms' ), '<strong>' . $quiz_passmark . '</strong>', '<strong>' . $user_grade . '</strong>' );
 		} else {
 			// translators: Placeholder is the quiz grade.
 			$text = sprintf( __( 'Your Grade %s%%', 'sensei-lms' ), '<strong class="sensei-course-theme-lesson-quiz-notice__grade">' . $user_grade . '</strong>' );

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -75,23 +75,22 @@ class Sensei_Course_Theme_Lesson {
 			return;
 		}
 
-		$user_lesson_status = \Sensei_Utils::user_lesson_status( $lesson_id, $user_id );
-		$user_grade         = Sensei_Quiz::get_user_quiz_grade( $lesson_id, $user_id );
-		$user_grade         = Sensei_Utils::round( $user_grade, 2 );
+		$lesson_status    = \Sensei_Utils::user_lesson_status( $lesson_id, $user_id );
+		$grade            = Sensei_Quiz::get_user_quiz_grade( $lesson_id, $user_id );
+		$grade_rounded    = Sensei_Utils::round( $grade, 2 );
+		$quiz_id          = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		$passmark         = get_post_meta( $quiz_id, '_quiz_passmark', true );
+		$passmark_rounded = Sensei_Utils::round( $passmark, 2 );
+		$pass_required    = get_post_meta( $quiz_id, '_pass_required', true );
 
-		$quiz_id       = Sensei()->lesson->lesson_quizzes( $lesson_id );
-		$quiz_passmark = get_post_meta( $quiz_id, '_quiz_passmark', true );
-		$quiz_passmark = Sensei_Utils::round( $quiz_passmark, 2 );
-		$pass_required = get_post_meta( $quiz_id, '_pass_required', true );
-
-		if ( 'ungraded' === $user_lesson_status->comment_approved ) {
+		if ( 'ungraded' === $lesson_status->comment_approved ) {
 			$text = __( 'Awaiting grade', 'sensei-lms' );
-		} elseif ( 'failed' === $user_lesson_status->comment_approved ) {
+		} elseif ( 'failed' === $lesson_status->comment_approved ) {
 			// translators: Placeholders are the required grade and the actual grade, respectively.
-			$text = sprintf( __( 'You require %1$s%% to pass this lesson\'s quiz. Your grade is %2$s%%.', 'sensei-lms' ), '<strong>' . $quiz_passmark . '</strong>', '<strong>' . $user_grade . '</strong>' );
+			$text = sprintf( __( 'You require %1$s%% to pass this lesson\'s quiz. Your grade is %2$s%%.', 'sensei-lms' ), '<strong>' . $passmark_rounded . '</strong>', '<strong>' . $grade_rounded . '</strong>' );
 		} else {
 			// translators: Placeholder is the quiz grade.
-			$text = sprintf( __( 'Your Grade %s%%', 'sensei-lms' ), '<strong class="sensei-course-theme-lesson-quiz-notice__grade">' . $user_grade . '</strong>' );
+			$text = sprintf( __( 'Your Grade %s%%', 'sensei-lms' ), '<strong class="sensei-course-theme-lesson-quiz-notice__grade">' . $grade_rounded . '</strong>' );
 		}
 
 		$notices = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' );
@@ -121,7 +120,7 @@ class Sensei_Course_Theme_Lesson {
 		$lesson_prerequisite = \Sensei_Lesson::find_first_prerequisite_lesson( $lesson_id, $user_id );
 
 		if ( $lesson_prerequisite > 0 ) {
-			$user_lesson_status = \Sensei_Utils::user_lesson_status( $lesson_prerequisite, $user_id );
+			$lesson_status = \Sensei_Utils::user_lesson_status( $lesson_prerequisite, $user_id );
 
 			$prerequisite_lesson_link = '<a href="'
 				. esc_url( get_permalink( $lesson_prerequisite ) )
@@ -132,7 +131,7 @@ class Sensei_Course_Theme_Lesson {
 				. esc_html__( 'prerequisites', 'sensei-lms' )
 				. '</a>';
 
-			$text = ! empty( $user_lesson_status ) && 'ungraded' === $user_lesson_status->comment_approved
+			$text = ! empty( $lesson_status ) && 'ungraded' === $lesson_status->comment_approved
 				// translators: Placeholder is the link to the prerequisite lesson.
 				? sprintf( esc_html__( 'You will be able to view this lesson once the %1$s are completed and graded.', 'sensei-lms' ), $prerequisite_lesson_link )
 				// translators: Placeholder is the link to the prerequisite lesson.

--- a/includes/course-theme/class-sensei-course-theme-quiz.php
+++ b/includes/course-theme/class-sensei-course-theme-quiz.php
@@ -65,38 +65,37 @@ class Sensei_Course_Theme_Quiz {
 			return;
 		}
 
-		$user_lesson_status = Sensei_Utils::user_lesson_status( $lesson_id, $user_id );
+		$lesson_status = Sensei_Utils::user_lesson_status( $lesson_id, $user_id );
 
 		// If quiz is not submitted, then nothing else to do.
-		if ( ! Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id ) || empty( $user_lesson_status ) ) {
+		if ( ! Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id ) || empty( $lesson_status ) ) {
 			return;
 		}
 
 		// Prepare title.
-		$quiz_status = $user_lesson_status->comment_approved;
-		$grade       = Sensei_Quiz::get_user_quiz_grade( $lesson_id, $user_id );
-		$grade       = Sensei_Utils::round( $grade, 2 );
-		$title       = sprintf(
+		$grade         = Sensei_Quiz::get_user_quiz_grade( $lesson_id, $user_id );
+		$grade_rounded = Sensei_Utils::round( $grade, 2 );
+		$title         = sprintf(
 			// translators: The placeholder is the quiz grade.
 			__( 'Your Grade: %1$s%%', 'sensei-lms' ),
-			$grade
+			$grade_rounded
 		);
-		if ( 'ungraded' === $quiz_status ) {
+		if ( 'ungraded' === $lesson_status->comment_approved ) {
 			$title = __( 'Awaiting grade', 'sensei-lms' );
 		}
 
 		// Prepare message.
 		$text = __( "You've passed the quiz and can continue to the next lesson.", 'sensei-lms' );
-		if ( 'ungraded' === $quiz_status ) {
+		if ( 'ungraded' === $lesson_status->comment_approved ) {
 			$text = __( 'Your answers have been submitted and your teacher will grade this quiz shortly.', 'sensei-lms' );
-		} elseif ( 'failed' === $quiz_status ) {
-			$passmark = get_post_meta( $quiz_id, '_quiz_passmark', true );
-			$passmark = Sensei_Utils::round( $passmark, 2 );
-			$text     = sprintf(
+		} elseif ( 'failed' === $lesson_status->comment_approved ) {
+			$passmark         = get_post_meta( $quiz_id, '_quiz_passmark', true );
+			$passmark_rounded = Sensei_Utils::round( $passmark, 2 );
+			$text             = sprintf(
 				// translators: The first placeholder is the minimum grade required, and the second placeholder is the actual grade.
 				__( 'You require %1$s%% to pass this quiz. Your grade is %2$s%%.', 'sensei-lms' ),
-				$passmark,
-				$grade
+				$passmark_rounded,
+				$grade_rounded
 			);
 		}
 

--- a/includes/course-theme/class-sensei-course-theme-quiz.php
+++ b/includes/course-theme/class-sensei-course-theme-quiz.php
@@ -75,6 +75,7 @@ class Sensei_Course_Theme_Quiz {
 		// Prepare title.
 		$quiz_status = $user_lesson_status->comment_approved;
 		$grade       = Sensei_Quiz::get_user_quiz_grade( $lesson_id, $user_id );
+		$grade       = Sensei_Utils::round( $grade, 2 );
 		$title       = sprintf(
 			// translators: The placeholder is the quiz grade.
 			__( 'Your Grade: %1$s%%', 'sensei-lms' ),
@@ -89,7 +90,8 @@ class Sensei_Course_Theme_Quiz {
 		if ( 'ungraded' === $quiz_status ) {
 			$text = __( 'Your answers have been submitted and your teacher will grade this quiz shortly.', 'sensei-lms' );
 		} elseif ( 'failed' === $quiz_status ) {
-			$passmark = absint( get_post_meta( $quiz_id, '_quiz_passmark', true ), 2 );
+			$passmark = get_post_meta( $quiz_id, '_quiz_passmark', true );
+			$passmark = Sensei_Utils::round( $passmark, 2 );
 			$text     = sprintf(
 				// translators: The first placeholder is the minimum grade required, and the second placeholder is the actual grade.
 				__( 'You require %1$s%% to pass this quiz. Your grade is %2$s%%.', 'sensei-lms' ),

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -59,7 +59,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 
 		$html = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' );
 
-		$this->assertContains( 'You require <strong>80</strong>% to pass this course. Your grade is <strong>0</strong>%.', $html, 'Should return quiz failed notice' );
+		$this->assertContains( 'You require <strong>80</strong>% to pass this lesson\'s quiz. Your grade is <strong>0</strong>%.', $html, 'Should return quiz failed notice' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #3530 and reported on https://wordpress.org/support/topic/required-passing-grade-does-not-align-with-percentage-grade-in-grading/

### Changes proposed in this Pull Request

* Show the decimals in the grade messages (lesson and quiz page).
* Basically, no we display 2 decimals when needed, avoiding case with messages like:
  > "You require 67% to pass this quiz. Your grade is 67%".

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course with a lesson and a quiz, and set it to autograde, pass required, and passing grade "67".
* Includes 3 questions.
* As a student, answer the quiz with 2 correct questions.
* Make sure you see the message like (in the quiz and in the lesson page):
  > "You require 67% to pass this quiz. Your grade is 66.67%"
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* In the course editor sidebar, set the course theme to Sensei Theme.
* Reset the progress, or access the course with another student.
* Repeat the tests, and make sure you see the correct messages in the Course Theme too.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Failed in the lesson page:

<img width="1292" alt="Screen Shot 2022-01-07 at 18 10 20" src="https://user-images.githubusercontent.com/876340/148609177-5de6e3ff-b3d3-4ff9-9a70-b604d4fc78f9.png">

Failed in the quiz page:

<img width="1289" alt="Screen Shot 2022-01-07 at 18 10 26" src="https://user-images.githubusercontent.com/876340/148609186-eb37f1d8-6145-4b3f-b0ad-2bdf1adae245.png">

Failed in the Course Theme lesson page:

<img width="936" alt="Screen Shot 2022-01-07 at 18 11 25" src="https://user-images.githubusercontent.com/876340/148609194-9516d65e-2b78-43ff-9df4-701b6c81d876.png">

Failed in the Course Theme quiz page:

<img width="939" alt="Screen Shot 2022-01-07 at 18 11 36" src="https://user-images.githubusercontent.com/876340/148609214-5364d411-a837-4fd2-8050-a26c8738e30f.png">

Passed in the lesson page:

<img width="1293" alt="Screen Shot 2022-01-07 at 18 13 07" src="https://user-images.githubusercontent.com/876340/148609285-d00fc4e5-6221-41d4-a58d-5c6a51c214ad.png">

Passed in the quiz page:

<img width="1281" alt="Screen Shot 2022-01-07 at 18 13 18" src="https://user-images.githubusercontent.com/876340/148609323-7194c84a-73b9-43d1-b5f9-93fa1b35a26e.png">

Passed in the Course Theme lesson page:

<img width="935" alt="Screen Shot 2022-01-07 at 18 14 02" src="https://user-images.githubusercontent.com/876340/148609337-201f48b4-b15e-4601-a677-825d13a2505a.png">

Passed in the Course Theme quiz page:

<img width="940" alt="Screen Shot 2022-01-07 at 18 14 08" src="https://user-images.githubusercontent.com/876340/148609347-a80eaa21-3356-43ae-8e06-fffd82cd7e2d.png">

With a number that don't need decimals (1 correct of 2):

<img width="945" alt="Screen Shot 2022-01-07 at 18 15 27" src="https://user-images.githubusercontent.com/876340/148609395-03221a09-4325-4131-a46d-10ef48b7f770.png">

