### PR TITLE
Fix edge case where the quiz status doesn't exist

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-quiz.php
+++ b/includes/course-theme/class-sensei-course-theme-quiz.php
@@ -58,23 +58,24 @@ class Sensei_Course_Theme_Quiz {
 	 */
 	private function maybe_add_quiz_results_notice() {
 		$lesson_id = Sensei_Utils::get_current_lesson();
-		$quiz_id   = \Sensei()->lesson->lesson_quizzes( $lesson_id );
+		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
 		$user_id   = get_current_user_id();
 
 		if ( empty( $user_id ) ) {
 			return;
 		}
 
-		$quiz_status = Sensei_Utils::user_lesson_status( $lesson_id, $user_id )->comment_approved;
+		$user_lesson_status = Sensei_Utils::user_lesson_status( $lesson_id, $user_id );
 
 		// If quiz is not submitted, then nothing else to do.
-		if ( ! \Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id ) ) {
+		if ( ! Sensei()->lesson->is_quiz_submitted( $lesson_id, $user_id ) || empty( $user_lesson_status ) ) {
 			return;
 		}
 
 		// Prepare title.
-		$grade = Sensei_Quiz::get_user_quiz_grade( $lesson_id, $user_id );
-		$title = sprintf(
+		$quiz_status = $user_lesson_status->comment_approved;
+		$grade       = Sensei_Quiz::get_user_quiz_grade( $lesson_id, $user_id );
+		$title       = sprintf(
 			// translators: The placeholder is the quiz grade.
 			__( 'Your Grade: %1$s%%', 'sensei-lms' ),
 			$grade
@@ -136,7 +137,7 @@ class Sensei_Course_Theme_Quiz {
 	 */
 	private static function render_contact_teacher() {
 		$link  = '<a href="#" class="sensei-course-theme__button is-link">' . __( 'Contact teacher', 'sensei-lms' ) . '</a>';
-		$block = new \Sensei_Block_Contact_Teacher();
+		$block = new Sensei_Block_Contact_Teacher();
 		return $block->render_contact_teacher_block( null, $link );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix edge case where the quiz status doesn't exist.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`.
* In the course editor sidebar, select Sensei Theme as the Course Theme.
* Create a course with a quiz.
* Get the quiz link and copy it.
* Reset the progress (It can be done through Student Management)
* Navigate directly to the quiz link (without any previous lesson status because it was reset).
* See the logs, after reproducing the instructions, and make sure no errors are logged.