### PR TITLE
Fix comments pagination on lesson page

### DIFF
--- a/includes/renderers/class-sensei-renderer-single-post.php
+++ b/includes/renderers/class-sensei-renderer-single-post.php
@@ -120,7 +120,7 @@ class Sensei_Renderer_Single_Post implements Sensei_Renderer_Interface {
 	 * Create the posts query.
 	 */
 	private function setup_post_query() {
-		global $page;
+		global $page, $cpage;
 
 		if ( empty( $this->post_id ) ) {
 			return;
@@ -130,6 +130,7 @@ class Sensei_Renderer_Single_Post implements Sensei_Renderer_Interface {
 			'p'         => $this->post_id,
 			'post_type' => get_post_type( $this->post_id ),
 			'page'      => $page,
+			'cpage'     => $cpage,
 		);
 
 		$this->post_query = new WP_Query( $args );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes an issue with comments pagination on unsupported themes.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Setup comments pagination on WP-admin > Settings > Discussion.
* Create a course with a lesson.
* As a student, add some comments to that lesson to create pagination.
* Navigate between the comment pages, and make sure it works properly.