### PR TITLE
Add a 3-second delay before autocompleting the lesson

### DIFF
--- a/assets/js/frontend/course-video/video-blocks-extension.js
+++ b/assets/js/frontend/course-video/video-blocks-extension.js
@@ -33,7 +33,9 @@
 			'[data-id="complete-lesson-button"]'
 		);
 		if ( completeButton ) {
-			completeButton.click();
+			setTimeout( () => {
+				completeButton.click();
+			}, 3000 );
 		}
 	};
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add a 3-second delay before autocompleting the lesson

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_video_based_course_progression', '__return_true' );`
  The preferable place is inside `sensei-lms.php`, somewhere in the beginning.
* Run `npm start`
* Enable `Autocomplete lesson` video settings for a course.
* Add a YouTube/Vimeo/Video/VideoPress block to the course lesson.
* Enroll in the course.
* Open the lesson with the video.
* Watch the video completely and wait for 3 seconds for the auto-submission of the form:
    * It shouldn't be autocompleted immediately!