### PR TITLE
Add styles for the disabled button in the lesson template

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -488,12 +488,19 @@ a.sensei-certificate-link {
 
 
 .quiz:not(.quiz-blocks), .lesson {
-  button.quiz-submit  {
-    &.complete  {
+  button.quiz-submit {
+    &.complete {
       background: $success;
     }
-    &.reset  {
+    &.reset {
       background: $error;
+    }
+  }
+  input.quiz-submit {
+    &:disabled {
+      pointer-events: none;
+      opacity: 0.5;
+      filter: grayscale(100%);
     }
   }
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add styles for the disabled state of the button in the lesson template

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_video_based_course_progression', '__return_true' );`
  The preferable place is inside `sensei-lms.php`, somewhere in the beginning.
* Run `npm start`
* Enable `Required` video setting for a course.
* Add a YouTube/Vimeo/Video block to the course lesson.
* Remove ALL Sensei blocks from this lesson.
* Enroll in the course.
* Open the lesson with the video.
* The complete lesson button should be disabled (grey, no changes of pointer when the mouse is over the button).
* Watch the video completely. The complete lesson button should become enabled.

### Screenshots
<img width="670" alt="CleanShot 2022-01-11 at 13 42 05@2x" src="https://user-images.githubusercontent.com/329356/148929875-49f2e4ca-309a-44c2-99f0-3ef2520d056a.png">

