### PR TITLE
Course Theme sidebar UX improvements

### DIFF
--- a/assets/css/sensei-course-theme/focus-mode.scss
+++ b/assets/css/sensei-course-theme/focus-mode.scss
@@ -7,8 +7,18 @@ $base: '.sensei-course-theme';
 	top: 8px;
 	padding: 4px;
 	white-space: nowrap;
+	display: flex;
+	flex-direction: row-reverse;
+	align-items: center;
+	gap: 12px;
 	&__disable {
 		display: none;
+	}
+
+	.sensei-course-theme__focus-mode-toggle-icon {
+		width: 10px;
+		height: 10px;
+		transform: rotate(180deg);
 	}
 }
 @media screen and (min-width: 782px) {
@@ -56,11 +66,15 @@ $base: '.sensei-course-theme';
 		}
 		&__focus-mode-toggle {
 			left: 420px;
+			flex-direction: row;
 			&__enable {
 				display: none;
 			}
 			&__disable {
 				display: revert;
+			}
+			.sensei-course-theme__focus-mode-toggle-icon {
+				transform: none;
 			}
 		}
 	}

--- a/assets/icons/double-chevron-right.svg
+++ b/assets/icons/double-chevron-right.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+	<path fill-rule="evenodd" clip-rule="evenodd" d="M13.1476 23.8755L24.0002 11.9377L13.1476 -0.000159764L10.9409 2.0059L19.9698 11.9377L10.9409 21.8694L13.1476 23.8755Z" fill="currentColor"/>
+	<path fill-rule="evenodd" clip-rule="evenodd" d="M3.20666 23.8755L14.0593 11.9377L3.20666 -0.000159764L0.999998 2.0059L10.0289 11.9377L1 21.8694L3.20666 23.8755Z" fill="currentColor"/>
+</svg>

--- a/includes/blocks/class-sensei-course-navigation-block.php
+++ b/includes/blocks/class-sensei-course-navigation-block.php
@@ -174,7 +174,9 @@ class Sensei_Course_Navigation_Block {
 		$summary_lessons = _n( '%d lesson', '%d lessons', $lesson_count, 'sensei-lms' );
 		// Translators: placeholder is number of quizzes.
 		$summary_quizzes = _n( '%d quiz', '%d quizzes', $quiz_count, 'sensei-lms' );
-		$summary         = sprintf( $summary_lessons . ', ' . $summary_quizzes, $lesson_count, $quiz_count );
+		$summary         = 0 === $quiz_count
+			? sprintf( $summary_lessons, $lesson_count )
+			: sprintf( $summary_lessons . ', ' . $summary_quizzes, $lesson_count, $quiz_count );
 
 		$classes   = [ 'sensei-lms-course-navigation-module sensei-collapsible' ];
 		$collapsed = '';

--- a/includes/blocks/course-theme/class-focus-mode.php
+++ b/includes/blocks/course-theme/class-focus-mode.php
@@ -51,6 +51,7 @@ class Focus_Mode {
 			'<button class="sensei-course-theme__focus-mode-toggle" %1s onclick="window.sensei.courseTheme.toggleFocusMode()">
 				<span class="sensei-course-theme__focus-mode-toggle__enable">%2s</span>
 				<span class="sensei-course-theme__focus-mode-toggle__disable">%3s</span>
+				' . Sensei()->assets->get_icon( 'double-chevron-right', 'sensei-course-theme__focus-mode-toggle-icon' ) . '
 			</button>',
 			$wrapper_attributes,
 			$label_enable,

--- a/themes/sensei-course-theme/single.php
+++ b/themes/sensei-course-theme/single.php
@@ -54,7 +54,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 		<!-- wp:sensei-lms/sidebar-footer -->
 		<div class="sensei-course-theme__sidebar__footer">
-			<!-- wp:sensei-lms/button-contact-teacher /-->
 			<a href="/">Exit Course</a>
 		</div>
 		<!-- /wp:sensei-lms/sidebar-footer -->


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It adds some UX improvements to the sidebar.
  * Icon to the expand/collapse button.
  * Show quiz counter in the sidebar only when it's greater than 0.
  * Removes Contact Teacher from the sidebar. Users will be able to add it later through FSE.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create a course with 2 modules - One containing quizzes and other not.
* Access the frontend, and make sure the module quiz counter only shows up for the module that contains quizzes.
* Also, make sure the expand/collapse buttons from the sidebar contain a new icon (a double chevron).
* Also, make sure the contact teacher button doesn't appear in the sidebar anymore.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="309" alt="Screen Shot 2022-01-11 at 10 42 57" src="https://user-images.githubusercontent.com/876340/148953626-b416b907-a791-44bf-9e8e-ed8519fe54b3.png">

### Context

pbFul3-Ed-p2