### PR TITLE
Update menu structure

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -77,6 +77,7 @@ $sensei-notice-icon-width: 30px;
 }
 
 /*  Sensei icon */
+/* Delete when 'menu_restructure' feature flag is removed - START */
 body #toplevel_page_sensei div.wp-menu-image:before {
 	font-family: 'sensei' !important;
 	content: "\f101";
@@ -89,14 +90,16 @@ body #menu-posts-lesson div.wp-menu-image:before {
 
 /* Course Icon */
 body #menu-posts-course div.wp-menu-image:before {
-	content: '\f331' !important;
+	content: '\f331';
 }
 
 /* Questions Icon */
 body #menu-posts-question div.wp-menu-image:before {
 	content: '\f223' !important;
 }
+/* Delete when 'menu_restructure' feature flag is removed - END */
 
+/* Dashboard At a Glance */
 #dashboard_right_now a.course-count:before,
 #dashboard_right_now span.course-count:before {
 	content: '\f331';
@@ -112,6 +115,7 @@ body #menu-posts-question div.wp-menu-image:before {
 	content: '\f223';
 }
 
+/* Delete when 'menu_restructure' feature flag is removed - START */
 /* Sensei Menu */
 #toplevel_page_sensei li.wp-first-item {
 	display: none;
@@ -122,6 +126,7 @@ li.menu-icon-lesson .wp-menu-image img,
 li.menu-icon-course .wp-menu-image img {
 	display: none;
 }
+/* Delete when 'menu_restructure' feature flag is removed - END */
 
 .edit-php.post-type-quiz .add-new-h2 {
 	display: none;

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -1,0 +1,24 @@
+/* Sensei LMS menu */
+body #menu-posts-course {
+	div.wp-menu-image:before {
+		font-family: 'sensei';
+		content: "\f101";
+	}
+
+	ul li a {
+		&[href="post-new.php?post_type=course"] {
+			display: none;
+		}
+
+		&[href="edit.php?post_type=question"],
+		&[href="edit.php?post_type=sensei_message"] {
+			padding-bottom: 10px;
+		}
+
+		&[href="edit.php?post_type=course&page=sensei_learners"],
+		&[href="edit.php?post_type=course&page=sensei_analysis"] {
+			border-top: solid 1px;
+			padding-top: 10px;
+		}
+	}
+}

--- a/assets/css/menu.scss
+++ b/assets/css/menu.scss
@@ -10,14 +10,10 @@ body #menu-posts-course {
 			display: none;
 		}
 
-		&[href="edit.php?post_type=question"],
-		&[href="edit.php?post_type=sensei_message"] {
-			padding-bottom: 10px;
-		}
-
 		&[href="edit.php?post_type=course&page=sensei_learners"],
 		&[href="edit.php?post_type=course&page=sensei_analysis"] {
 			border-top: solid 1px;
+			margin-top: 10px;
 			padding-top: 10px;
 		}
 	}

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -55,12 +55,20 @@ class Sensei_Admin_Notices {
 		'edit-question-type',
 		'edit-question-category',
 		'edit-lesson-tag',
+		'course_page_sensei_analysis',
+		'course_page_sensei_learners',
+		'course_page_sensei-settings',
+		'course_page_sensei_grading',
+		'course_page_sensei-extensions',
+		'course_page_sensei-tools',
+		// START - Delete when 'menu_restructure' feature flag is removed.
 		'sensei-lms_page_sensei_analysis',
 		'sensei-lms_page_sensei_learners',
 		'sensei-lms_page_sensei-settings',
 		'sensei-lms_page_sensei_grading',
 		'sensei-lms_page_sensei-extensions',
 		'sensei-lms_page_sensei-tools',
+		// END - Delete when 'menu_restructure' feature flag is removed.
 		'lesson_page_lesson-order',
 	];
 

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -55,7 +55,7 @@ final class Sensei_Extensions {
 	 * @access private
 	 */
 	public function enqueue_admin_assets() {
-		$screen = get_current_screen();
+		$screen               = get_current_screen();
 		$extensions_screen_id = Sensei()->feature_flags->is_enabled( 'menu_restructure' ) ?
 			'course_page_sensei-extensions' :
 			'sensei-lms_page_sensei-extensions';
@@ -286,7 +286,7 @@ final class Sensei_Extensions {
 	public function add_admin_menu_item() {
 		$updates_html = '';
 		$updates      = $this->get_has_update_count();
-		$parent_slug = Sensei()->feature_flags->is_enabled( 'menu_restructure' ) ?
+		$parent_slug  = Sensei()->feature_flags->is_enabled( 'menu_restructure' ) ?
 			'edit.php?post_type=course' :
 			'sensei';
 

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -60,7 +60,7 @@ class Sensei_Learner_Management {
 	 *
 	 * @since  1.6.0
 	 *
-	 * @param string $file Main plugin file name.
+	 * @param string      $file Main plugin file name.
 	 * @param Sensei_Main $sensei Sensei object.
 	 */
 	public function __construct( $file, $sensei ) {

--- a/includes/admin/views/html-admin-page-tools-header.php
+++ b/includes/admin/views/html-admin-page-tools-header.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		esc_html_e( 'Tools', 'sensei-lms' );
 
 		if ( ! empty( $tool ) ) {
-			$back_url = admin_url( 'admin.php?page=sensei-tools' );
+			$back_url = Sensei_Tools::instance()->get_tools_url();
 			?>
 			<a href="<?php echo esc_url( $back_url ); ?>" class="button"><?php echo esc_html__( 'All Tools', 'sensei-lms' ); ?></a>
 			<?php

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -21,15 +21,20 @@ class Sensei_Analysis {
 	 *
 	 * @since  1.0.0
 	 * @param string $file
+	 * @param Sensei_Main $sensei Sensei object.
 	 */
-	public function __construct( $file ) {
+	public function __construct( $file, $sensei ) {
 		$this->name      = __( 'Analysis', 'sensei-lms' );
 		$this->file      = $file;
 		$this->page_slug = 'sensei_analysis';
 
 		// Admin functions
 		if ( is_admin() ) {
-			add_action( 'admin_menu', array( $this, 'analysis_admin_menu' ), 10 );
+			if ( ! $sensei->feature_flags->is_enabled( 'menu_restructure' ) ) {
+				// As soon this feature flag check is removed, the `$sensei` argument can also be removed.
+				add_action( 'admin_menu', array( $this, 'analysis_admin_menu' ), 10 );
+			}
+
 			add_action( 'analysis_wrapper_container', array( $this, 'wrapper_container' ) );
 			if ( isset( $_GET['page'] ) && ( $_GET['page'] == $this->page_slug ) ) {
 
@@ -53,9 +58,19 @@ class Sensei_Analysis {
 	 */
 	public function analysis_admin_menu() {
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
-			add_submenu_page( 'sensei', __( 'Analysis', 'sensei-lms' ), __( 'Analysis', 'sensei-lms' ), 'manage_sensei_grades', 'sensei_analysis', array( $this, 'analysis_page' ) );
-		}
+			$parent_slug = Sensei()->feature_flags->is_enabled( 'menu_restructure' ) ?
+				'edit.php?post_type=course' :
+				'sensei';
 
+			add_submenu_page(
+				$parent_slug,
+				__( 'Analysis', 'sensei-lms' ),
+				__( 'Analysis', 'sensei-lms' ),
+				'manage_sensei_grades',
+				'sensei_analysis',
+				array( $this, 'analysis_page' )
+			);
+		}
 	}
 
 	/**

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -20,7 +20,7 @@ class Sensei_Analysis {
 	 * Constructor
 	 *
 	 * @since  1.0.0
-	 * @param string $file
+	 * @param string      $file
 	 * @param Sensei_Main $sensei Sensei object.
 	 */
 	public function __construct( $file, $sensei ) {

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -349,7 +349,8 @@ class Sensei_Data_Cleaner {
 	 * @access private
 	 */
 	private static function cleanup_pages() {
-		$settings = new Sensei_Settings();
+		// Delete parameter when 'menu_restructure' feature flag is removed.
+		$settings = new Sensei_Settings( Sensei() );
 
 		// Trash the Course Archive page.
 		$course_archive_page_id = $settings->get( 'course_page' );

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -57,6 +57,7 @@ class Sensei_Feature_Flags {
 				'course_theme'                   => false,
 				'quiz_pagination'                => false,
 				'video_based_course_progression' => false,
+				'menu_restructure'               => true,
 			]
 		);
 	}

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -57,7 +57,7 @@ class Sensei_Feature_Flags {
 				'course_theme'                   => false,
 				'quiz_pagination'                => false,
 				'video_based_course_progression' => false,
-				'menu_restructure'               => true,
+				'menu_restructure'               => false,
 			]
 		);
 	}

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -25,15 +25,20 @@ class Sensei_Grading {
 	 * @since  1.3.0
 	 *
 	 * @param $file
+	 * @param Sensei_Main $sensei Sensei object.
 	 */
-	public function __construct( $file ) {
+	public function __construct( $file, $sensei ) {
 		$this->name      = __( 'Grading', 'sensei-lms' );
 		$this->file      = $file;
 		$this->page_slug = 'sensei_grading';
 
 		// Admin functions
 		if ( is_admin() ) {
-			add_action( 'admin_menu', array( $this, 'grading_admin_menu' ), 20 );
+			if ( ! $sensei->feature_flags->is_enabled( 'menu_restructure' ) ) {
+				// As soon this feature flag check is removed, the `$sensei` argument can also be removed.
+				add_action( 'admin_menu', array( $this, 'grading_admin_menu' ), 20 );
+			}
+
 			add_action( 'grading_wrapper_container', array( $this, 'wrapper_container' ) );
 			if ( isset( $_GET['page'] ) && ( $_GET['page'] == $this->page_slug ) ) {
 				add_action( 'admin_print_scripts', array( $this, 'enqueue_scripts' ) );
@@ -61,7 +66,18 @@ class Sensei_Grading {
 	 */
 	public function grading_admin_menu() {
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
-			add_submenu_page( 'sensei', __( 'Grading', 'sensei-lms' ), __( 'Grading', 'sensei-lms' ), 'manage_sensei_grades', $this->page_slug, array( $this, 'grading_page' ) );
+			$parent_slug = Sensei()->feature_flags->is_enabled( 'menu_restructure' ) ?
+				'edit.php?post_type=course' :
+				'sensei';
+
+			add_submenu_page(
+				$parent_slug,
+				__( 'Grading', 'sensei-lms' ),
+				__( 'Grading', 'sensei-lms' ),
+				'manage_sensei_grades',
+				$this->page_slug,
+				array( $this, 'grading_page' )
+			);
 		}
 
 	}

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -34,14 +34,20 @@ class Sensei_Messages {
 	 * Constructor.
 	 *
 	 * @since  1.6.0
+	 *
+	 * @param Sensei_Main $sensei Sensei object.
 	 */
-	public function __construct() {
+	public function __construct( $sensei ) {
 		$this->token       = 'messages';
 		$this->post_type   = 'sensei_message';
 		$this->meta_fields = array( 'sender', 'receiver' );
 
-		// Add Messages page to admin menu
-		add_action( 'admin_menu', array( $this, 'add_menu_item' ), 40 );
+		// Add Messages page to admin menu.
+		if ( ! $sensei->feature_flags->is_enabled( 'menu_restructure' ) ) {
+			// As soon this feature flag check is removed, the `$sensei` argument can also be removed.
+			add_action( 'admin_menu', array( $this, 'add_menu_item' ), 40 );
+		}
+
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_box' ), 10, 2 );
 		add_action( 'admin_menu', array( $this, 'remove_meta_box' ) );
 
@@ -122,9 +128,18 @@ class Sensei_Messages {
 	}
 
 	public function add_menu_item() {
-
 		if ( ! isset( Sensei()->settings->settings['messages_disable'] ) || ! Sensei()->settings->settings['messages_disable'] ) {
-			add_submenu_page( 'sensei', __( 'Messages', 'sensei-lms' ), __( 'Messages', 'sensei-lms' ), 'edit_courses', 'edit.php?post_type=sensei_message' );
+			$parent_slug = Sensei()->feature_flags->is_enabled( 'menu_restructure' ) ?
+				'edit.php?post_type=course' :
+				'sensei';
+
+			add_submenu_page(
+				$parent_slug,
+				__( 'Messages', 'sensei-lms' ),
+				__( 'Messages', 'sensei-lms' ),
+				'edit_courses',
+				'edit.php?post_type=sensei_message'
+			);
 		}
 	}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -20,7 +20,7 @@ class Sensei_Core_Modules {
 	private $order_page_slug;
 	public $taxonomy;
 
-	public function __construct( $file ) {
+	public function __construct( $file, $sensei ) {
 		$this->file            = $file;
 		$this->taxonomy        = 'module';
 		$this->order_page_slug = 'module-order';
@@ -47,7 +47,10 @@ class Sensei_Core_Modules {
 		add_action( 'wp', array( $this, 'save_module_progress' ), 10 );
 
 		// Handle module ordering
-		add_action( 'admin_menu', array( $this, 'register_modules_admin_menu_items' ), 30 );
+		if ( ! $sensei->feature_flags->is_enabled( 'menu_restructure' ) ) {
+			add_action( 'admin_menu', array( $this, 'register_modules_admin_menu_items' ), 30 );
+		}
+
 		add_action( 'admin_post_order_modules', array( $this, 'handle_order_modules' ) );
 		add_filter( 'manage_course_posts_columns', array( $this, 'course_columns' ), 11, 1 );
 		add_action( 'manage_course_posts_custom_column', array( $this, 'course_column_content' ), 11, 2 );
@@ -1059,10 +1062,15 @@ class Sensei_Core_Modules {
 	 * Register admin screen for ordering modules
 	 *
 	 * @since 1.8.0
+	 * @deprecated 4.0.0
 	 *
 	 * @return void
 	 */
 	public function register_modules_admin_menu_items() {
+		if ( Sensei()->feature_flags->is_enabled( 'menu_restructure' ) ) {
+			_deprecated_function( __METHOD__, '4.0.0' );
+		}
+
 		// add the modules link under the Course main menu
 		add_submenu_page( 'edit.php?post_type=course', __( 'Modules', 'sensei-lms' ), __( 'Modules', 'sensei-lms' ), 'manage_categories', 'edit-tags.php?taxonomy=module', '' );
 

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -130,7 +130,9 @@ class Sensei_PostTypes {
 	 * Dynamically loads post type objects for meta boxes on backend
 	 *
 	 * @access public
-	 * @param array $posttypes (default: array())
+	 * @param array       $posttypes (default: array())
+	 * @param Sensei_Main $sensei Sensei object.
+	 *
 	 * @return void
 	 */
 	public function load_posttype_objects( $posttypes = array(), $sensei ) {
@@ -766,7 +768,6 @@ class Sensei_PostTypes {
 	 *
 	 * @since  1.0.0
 	 * @param Sensei_Main $sensei Sensei object.
-	 *
 	 */
 	private function setup_post_type_labels_base( $sensei ) {
 		$this->labels = array(
@@ -1062,7 +1063,6 @@ class Sensei_PostTypes {
 		Sensei()->learners->learners_admin_menu();
 		Sensei()->grading->grading_admin_menu();
 
-		// Messages
 		$sensei_messages = new Sensei_Messages( Sensei() );
 		$sensei_messages->add_menu_item();
 

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -92,7 +92,9 @@ class Sensei_PostTypes {
 			'question' => 'Question',
 			'messages' => 'Messages',
 		);
-		$this->load_posttype_objects( $default_post_types );
+
+		// As soon as the 'menu_restructure' feature flag is removed, the `$sensei` argument can also be removed.
+		$this->load_posttype_objects( $default_post_types, $sensei );
 		$this->set_role_cap_defaults( $default_post_types );
 
 		// Admin functions
@@ -131,13 +133,19 @@ class Sensei_PostTypes {
 	 * @param array $posttypes (default: array())
 	 * @return void
 	 */
-	public function load_posttype_objects( $posttypes = array() ) {
+	public function load_posttype_objects( $posttypes = array(), $sensei ) {
 
 		foreach ( $posttypes as $posttype_token => $posttype_name ) {
 
 			// Load the files
-			$class_name                   = 'Sensei_' . $posttype_name;
-			$this->$posttype_token        = new $class_name();
+			$class_name = 'Sensei_' . $posttype_name;
+
+			if ( 'Sensei_Messages' === $class_name ) {
+				$this->$posttype_token = new $class_name( $sensei );
+			} else {
+				$this->$posttype_token = new $class_name();
+			}
+
 			$this->$posttype_token->token = $posttype_token;
 
 		}
@@ -1054,13 +1062,9 @@ class Sensei_PostTypes {
 		Sensei()->learners->learners_admin_menu();
 		Sensei()->grading->grading_admin_menu();
 
-		add_submenu_page(
-			'edit.php?post_type=course',
-			__( 'Messages', 'sensei-lms' ),
-			__( 'Messages', 'sensei-lms' ),
-			'edit_questions',
-			'edit.php?post_type=sensei_message'
-		);
+		// Messages
+		$sensei_messages = new Sensei_Messages( Sensei() );
+		$sensei_messages->add_menu_item();
 
 		Sensei()->analysis->analysis_admin_menu();
 		Sensei()->settings->register_settings_screen();

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -59,11 +59,17 @@ class Sensei_Settings_API {
 	 *
 	 * @access public
 	 * @since  1.0.0
+	 *
+	 * @param Sensei_Main $sensei Sensei object.
+	 *
 	 * @return void
 	 */
-	public function register_hook_listener() {
+	public function register_hook_listener( $sensei ) {
+		if ( ! $sensei->feature_flags->is_enabled( 'menu_restructure' ) ) {
+			// As soon this feature flag check is removed, the `$sensei` argument can also be removed.
+			add_action( 'admin_menu', array( $this, 'register_settings_screen' ), 60 );
+		}
 
-		add_action( 'admin_menu', array( $this, 'register_settings_screen' ), 60 );
 		add_action( 'admin_init', array( $this, 'settings_fields' ) );
 		add_action( 'init', array( $this, 'general_init' ), 5 );
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -20,8 +20,10 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 *
 	 * @access public
 	 * @since 1.0.0
+	 *
+	 * @param Sensei_Main $sensei Sensei object.
 	 */
-	public function __construct() {
+	public function __construct( $sensei ) {
 		parent::__construct(); // Required in extended classes.
 
 		add_action( 'init', array( __CLASS__, 'flush_rewrite_rules' ) );
@@ -36,7 +38,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		}
 
-		$this->register_hook_listener();
+		$this->register_hook_listener( $sensei );
 		$this->get_settings();
 
 		// Log when settings are updated by the user.
@@ -90,10 +92,20 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 * @return void
 	 */
 	public function register_settings_screen() {
-
 		$this->settings_version = Sensei()->version; // Use the global plugin version on this settings screen.
-		$hook                   = add_submenu_page( 'sensei', $this->name, $this->menu_label, 'manage_sensei', $this->page_slug, array( $this, 'settings_screen' ) );
-		$this->hook             = $hook;
+
+		$parent_slug = Sensei()->feature_flags->is_enabled( 'menu_restructure' ) ?
+			'edit.php?post_type=course' :
+			'sensei';
+
+		$this->hook = add_submenu_page(
+			$parent_slug,
+			$this->name,
+			$this->menu_label,
+			'manage_sensei',
+			$this->page_slug,
+			array( $this, 'settings_screen' )
+		);
 
 		if ( isset( $_GET['page'] ) && ( $_GET['page'] == $this->page_slug ) ) {
 			add_action( 'admin_notices', array( $this, 'settings_errors' ) );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -355,21 +355,21 @@ class Sensei_Main {
 	 * @since 1.9.0
 	 */
 	public function initialize_global_objects() {
+		// Feature flags.
+		$this->feature_flags = new Sensei_Feature_Flags();
+
 		// Setup settings.
-		$this->settings = new Sensei_Settings();
+		$this->settings = new Sensei_Settings( $this );
 
 		// Asset loading.
 		$this->assets = new Sensei_Assets( $this->plugin_url, $this->plugin_path, $this->version );
-
-		// Feature flags.
-		$this->feature_flags = new Sensei_Feature_Flags();
 
 		// Load the shortcode loader into memory, so as to listen to all for
 		// all shortcodes on the front end.
 		$this->shortcode_loader = new Sensei_Shortcode_Loader();
 
 		// Setup post types.
-		$this->post_types = new Sensei_PostTypes();
+		$this->post_types = new Sensei_PostTypes( $this );
 
 		// Load Course Results Class.
 		$this->course_results = new Sensei_Course_Results();
@@ -396,7 +396,7 @@ class Sensei_Main {
 		$this->load_modules_class();
 
 		// Load Learner Management Functionality.
-		$this->learners = new Sensei_Learner_Management( $this->main_plugin_file_name );
+		$this->learners = new Sensei_Learner_Management( $this->main_plugin_file_name, $this );
 
 		$this->view_helper = new Sensei_View_Helper();
 
@@ -428,10 +428,10 @@ class Sensei_Main {
 		// Differentiate between administration and frontend logic.
 		if ( is_admin() ) {
 			// Load Admin Class
-			$this->admin = new Sensei_Admin( $this->main_plugin_file_name );
+			$this->admin = new Sensei_Admin( $this );
 
 			// Load Analysis Reports
-			$this->analysis = new Sensei_Analysis( $this->main_plugin_file_name );
+			$this->analysis = new Sensei_Analysis( $this->main_plugin_file_name, $this );
 
 			new Sensei_Import();
 			new Sensei_Export();
@@ -454,7 +454,7 @@ class Sensei_Main {
 		$this->notices = new Sensei_Notices();
 
 		// Load Grading Functionality
-		$this->grading = new Sensei_Grading( $this->main_plugin_file_name );
+		$this->grading = new Sensei_Grading( $this->main_plugin_file_name, $this );
 
 		// Load Email Class
 		$this->emails = new Sensei_Emails( $this->main_plugin_file_name );
@@ -1340,7 +1340,7 @@ class Sensei_Main {
 		if ( ! class_exists( 'Sensei_Modules' ) && 'Sensei_Modules' !== $class ) {
 			// Load the modules class.
 			require_once dirname( __FILE__ ) . '/class-sensei-modules.php';
-			$this->modules = new Sensei_Core_Modules( $this->main_plugin_file_name );
+			$this->modules = new Sensei_Core_Modules( $this->main_plugin_file_name, $this );
 
 		} else {
 			// fallback for people still using the modules extension.

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -433,8 +433,8 @@ class Sensei_Main {
 			// Load Analysis Reports
 			$this->analysis = new Sensei_Analysis( $this->main_plugin_file_name, $this );
 
-			new Sensei_Import();
-			new Sensei_Export();
+			new Sensei_Import( $this );
+			new Sensei_Export( $this );
 			new Sensei_Exit_Survey();
 			new Sensei_WCPC_Prompt();
 			new Sensei_WCCOM_Connect_Notice();

--- a/includes/data-port/class-sensei-export.php
+++ b/includes/data-port/class-sensei-export.php
@@ -23,12 +23,17 @@ class Sensei_Export {
 
 	/**
 	 * Sensei_Export constructor.
+	 *
+	 * @param Sensei_Main $sensei Sensei object.
 	 */
-	public function __construct() {
+	public function __construct( $sensei ) {
 
 		$this->page_slug = 'sensei_export';
 
-		add_action( 'admin_menu', [ $this, 'admin_menu' ], 40 );
+		if ( ! $sensei->feature_flags->is_enabled( 'menu_restructure' ) ) {
+			// As soon this feature flag check is removed, the `$sensei` argument can also be removed.
+			add_action( 'admin_menu', [ $this, 'admin_menu' ], 40 );
+		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 		if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
@@ -52,8 +57,14 @@ class Sensei_Export {
 
 	/**
 	 * Register an export submenu.
+	 *
+	 * @deprecated 4.0.0
 	 */
 	public function admin_menu() {
+		if ( Sensei()->feature_flags->is_enabled( 'menu_restructure' ) ) {
+			_deprecated_function( __METHOD__, '4.0.0' );
+		}
+
 		if ( current_user_can( 'manage_sensei' ) ) {
 			add_submenu_page(
 				'sensei',

--- a/includes/data-port/class-sensei-import.php
+++ b/includes/data-port/class-sensei-import.php
@@ -23,12 +23,17 @@ class Sensei_Import {
 
 	/**
 	 * Sensei_Import constructor.
+	 *
+	 * @param Sensei_Main $sensei Sensei object.
 	 */
-	public function __construct() {
+	public function __construct( $sensei ) {
 
 		$this->page_slug = 'sensei_import';
 
-		add_action( 'admin_menu', [ $this, 'admin_menu' ], 40 );
+		if ( ! $sensei->feature_flags->is_enabled( 'menu_restructure' ) ) {
+			// As soon this feature flag check is removed, the `$sensei` argument can also be removed.
+			add_action( 'admin_menu', [ $this, 'admin_menu' ], 40 );
+		}
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 		if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
@@ -52,8 +57,14 @@ class Sensei_Import {
 
 	/**
 	 * Register an import submenu.
+	 *
+	 * @deprecated 4.0.0
 	 */
 	public function admin_menu() {
+		if ( Sensei()->feature_flags->is_enabled( 'menu_restructure' ) ) {
+			_deprecated_function( __METHOD__, '4.0.0' );
+		}
+
 		if ( current_user_can( 'manage_sensei' ) ) {
 			add_submenu_page(
 				'sensei',

--- a/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-courses.php
+++ b/tests/unit-tests/data-port/export-tasks/test-class-sensei-export-courses.php
@@ -32,7 +32,7 @@ class Sensei_Export_Courses_Tests extends WP_UnitTestCase {
 		parent::setUp();
 
 		if ( ! isset( Sensei()->admin ) ) {
-			Sensei()->admin = new Sensei_Admin();
+			Sensei()->admin = new Sensei_Admin( Sensei() );
 		}
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -192,7 +192,8 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 	 */
 	private function duplicate_course_with_lessons_setup( $qty_lessons ) {
 		// Mock the safe_redirect method
-		Sensei()->admin = $this->getMockBuilder( 'WooThemes_Sensei_Admin' )
+		Sensei()->admin = $this->getMockBuilder( Sensei_Admin::class )
+			->setConstructorArgs( [ Sensei() ] )
 			->setMethods( [ 'safe_redirect' ] )
 			->getMock();
 

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -10,7 +10,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setup();
 
-		Sensei()->grading = new WooThemes_Sensei_Grading( '' );
+		Sensei()->grading = new WooThemes_Sensei_Grading( '', Sensei() );
 		$this->factory    = new Sensei_Factory();
 	}
 

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -15,7 +15,7 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		parent::setUp();
 
 		if ( ! isset( Sensei()->admin ) ) {
-			Sensei()->admin = new Sensei_Admin();
+			Sensei()->admin = new Sensei_Admin( Sensei() );
 		}
 
 		$this->factory = new Sensei_Factory();

--- a/tests/unit-tests/test-class-sensei-learners-admin-bulk-actions-controller.php
+++ b/tests/unit-tests/test-class-sensei-learners-admin-bulk-actions-controller.php
@@ -19,7 +19,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller_Test extends WP_UnitTestCase
 		$this->factory = new Sensei_Factory();
 
 		$this->controller = $this->getMockBuilder( Sensei_Learners_Admin_Bulk_Actions_Controller::class )
-			->setConstructorArgs( [ new Sensei_Learner_Management( '' ) ] )
+			->setConstructorArgs( [ new Sensei_Learner_Management( '', Sensei() ) ] )
 			->setMethods( [ 'check_nonce', 'is_current_page', 'redirect_to_learner_admin_index' ] )
 			->getMock();
 

--- a/tests/unit-tests/test-class-sensei-messages.php
+++ b/tests/unit-tests/test-class-sensei-messages.php
@@ -35,7 +35,7 @@ class Sensei_Messages_Test extends WP_UnitTestCase {
 	public function testUserMessagesCapCheckNonMessage() {
 		$this->login_as_teacher();
 
-		$instance  = new Sensei_Messages();
+		$instance  = new Sensei_Messages( Sensei() );
 		$course_id = $this->factory->course->create();
 
 		$this->assertEquals( [], $instance->user_messages_cap_check( [], [ 'read' ], [ 'read_post', get_current_user_id(), $course_id ] ) );
@@ -52,7 +52,7 @@ class Sensei_Messages_Test extends WP_UnitTestCase {
 		$this->login_as_student();
 		$student_id = get_current_user_id();
 
-		$instance   = new Sensei_Messages();
+		$instance   = new Sensei_Messages( Sensei() );
 		$message_id = $this->factory->message->create(
 			[
 				'meta_input' => [
@@ -79,7 +79,7 @@ class Sensei_Messages_Test extends WP_UnitTestCase {
 		$this->login_as_student();
 		$student_id = get_current_user_id();
 
-		$instance   = new Sensei_Messages();
+		$instance   = new Sensei_Messages( Sensei() );
 		$message_id = $this->factory->message->create(
 			[
 				'meta_input' => [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,6 +66,7 @@ const files = [
 	'css/admin-custom.css',
 	'css/extensions.scss',
 	'css/global.scss',
+	'css/menu.scss',
 	'css/jquery-ui.css',
 	'css/modules-admin.css',
 	'css/modules-frontend.scss',


### PR DESCRIPTION
Fixes #4528.

### Changes proposed in this Pull Request
Use a single menu with submenus for organizing Sensei's pages. This feature is behind a `menu_restructure` flag.

### Testing instructions
- Set `menu_restructure` to `true` in `includes/sensei-feature-flags`.
- Ensure all of Sensei's pages are contained under the _Sensei LMS_ menu as per the issue.
- Click through all menu items and ensure they load.
- Set `menu_restructure` to `false` in `includes/sensei-feature-flags`.
- Ensure Sensei's menu structure reverts back to how it looks in the current version.
- Click through all menu items and ensure they load.

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* `Sensei_Admin::admin_menu`- No replacement.
* `Sensei_Admin::page_redirect` - No replacement.
* `Sensei_Core_Modules::register_modules_admin_menu_items` - No replacement.
* `Sensei_Export::admin_menu` - No replacement.
* `Sensei_Import::admin_menu` - No replacement.

### Screenshot / Video
![Screen Shot 2022-01-11 at 10 45 03 AM](https://user-images.githubusercontent.com/1190420/148974546-890685a6-13c9-4196-8a95-48a1eecdd441.jpg)