### PR TITLE
Add course theme notice

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -45,6 +45,7 @@ $sensei-notice-icon-width: 30px;
 	}
 
 	&__heading {
+		margin: 5px 0;
 		font-weight: bold;
 	}
 

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -11,7 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Class that handles showing the notices from SenseiLMS.com.
+ * Class that handles showing admin notices.
+ * It also includes notices coming from SenseiLMS.com.
  *
  * @access private
  *
@@ -131,6 +132,16 @@ class Sensei_Admin_Notices {
 		if ( ! $notices || ! is_array( $notices ) ) {
 			$notices = [];
 		}
+
+		/**
+		 * Filters the admin notices.
+		 *
+		 * @hook sensei_admin_notices
+		 *
+		 * @param {array} $notices The admin notices.
+		 * @return {array} The admin notices.
+		 */
+		$notices = apply_filters( 'sensei_admin_notices', $notices );
 
 		return $notices;
 	}

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -174,6 +174,10 @@ class Sensei_Admin_Notices {
 		<div class="notice sensei-notice is-dismissible" data-dismiss-action="sensei_dismiss_notice" data-dismiss-notice="<?php echo esc_attr( $notice_id ); ?>"
 				data-dismiss-nonce="<?php echo esc_attr( wp_create_nonce( self::DISMISS_NOTICE_NONCE_ACTION ) ); ?>">
 			<?php
+			if ( ! empty( $notice['icon'] ) ) {
+				// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic parts escaped in the function.
+				echo Sensei()->assets->get_icon( $notice['icon'], 'sensei-notice__icon' );
+			}
 			echo '<div class="sensei-notice__wrapper">';
 			echo '<div class="sensei-notice__content">';
 			if ( ! empty( $notice['heading'] ) ) {

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -175,12 +175,12 @@ class Sensei_Admin_Notices {
 				data-dismiss-nonce="<?php echo esc_attr( wp_create_nonce( self::DISMISS_NOTICE_NONCE_ACTION ) ); ?>">
 			<?php
 			echo '<div class="sensei-notice__wrapper">';
+			echo '<div class="sensei-notice__content">';
 			if ( ! empty( $notice['heading'] ) ) {
 				echo '<div class="sensei-notice__heading">';
 				echo wp_kses( $notice['heading'], self::ALLOWED_HTML );
 				echo '</div>';
 			}
-			echo '<div class="sensei-notice__content">';
 			echo wp_kses( $notice['message'], self::ALLOWED_HTML );
 			echo '</div>';
 			echo '</div>';

--- a/includes/admin/class-sensei-wccom-connect-notice.php
+++ b/includes/admin/class-sensei-wccom-connect-notice.php
@@ -87,7 +87,7 @@ class Sensei_WCCOM_Connect_Notice {
 		<div id="sensei-lms-wccom-connect-notice" class="notice sensei-notice is-dismissible" data-dismiss-action="sensei_dismiss_wccom_connect_notice"
 				data-dismiss-nonce="<?php echo esc_attr( wp_create_nonce( self::DISMISS_NOTICE_NONCE_ACTION ) ); ?>">
 			<?php
-				// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Function returning svg only.
+				// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic parts escaped in the function.
 				echo Sensei()->assets->get_icon( 'sensei', 'sensei-notice__icon' );
 			?>
 			<div class='sensei-notice__wrapper'>

--- a/includes/admin/class-sensei-wcpc-prompt.php
+++ b/includes/admin/class-sensei-wcpc-prompt.php
@@ -49,7 +49,7 @@ class Sensei_WCPC_Prompt {
 		<div class="notice sensei-notice is-dismissible" data-dismiss-action="sensei_dismiss_wcpc_prompt"
 			data-dismiss-nonce="<?php echo esc_attr( wp_create_nonce( self::DISMISS_PROMPT_NONCE_ACTION ) ); ?>">
 			<?php
-				// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Function returning svg only.
+				// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic parts escaped in the function.
 				echo Sensei()->assets->get_icon( 'sensei', 'sensei-notice__icon' );
 			?>
 			<div class='sensei-notice__wrapper'>

--- a/includes/class-sensei-assets.php
+++ b/includes/class-sensei-assets.php
@@ -287,6 +287,6 @@ class Sensei_Assets {
 	public function get_icon( string $name, string $class_names = '' ) : string {
 		$href = $this->get_icon_href( $name );
 
-		return '<svg class="' . $class_names . '"><use xlink:href="' . $href . '"></use></svg>';
+		return '<svg class="' . esc_attr( $class_names ) . '"><use xlink:href="' . esc_url( $href ) . '"></use></svg>';
 	}
 }

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -76,6 +76,7 @@ class Sensei_Course_Theme_Option {
 		add_action( 'template_redirect', [ $this, 'ensure_learning_mode_url_prefix' ] );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Lesson::instance(), 'init' ] );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Quiz::instance(), 'init' ] );
+		add_filter( 'sensei_admin_notices', [ $this, 'add_course_theme_notice' ] );
 	}
 
 	/**
@@ -160,6 +161,38 @@ class Sensei_Course_Theme_Option {
 		$theme = get_post_meta( $course_id, self::THEME_POST_META_NAME, true );
 
 		return self::SENSEI_THEME === $theme;
+	}
+
+	/**
+	 * Adds a course theme notice.
+	 *
+	 * @access private
+	 *
+	 * @param array $notices Notices list.
+	 *
+	 * @return array Notices including the course theme notice.
+	 */
+	public function add_course_theme_notice( array $notices ) {
+		$notices['sensei-course-theme'] = [
+			'icon'       => 'sensei',
+			'heading'    => __( 'Sensei’s new learning mode is here', 'sensei-lms' ),
+			'message'    => __( 'Give your students an intuitive and distraction-free learning experience.', 'sensei-lms' ),
+			'actions'    => [
+				[
+					'label'  => __( 'Learn more', 'sensei-lms' ),
+					'url'    => 'https://senseilms.com/wordpress-course-theme',
+					'target' => '_blank',
+				],
+			],
+			'conditions' => [
+				[
+					'type'    => 'screens',
+					'screens' => [ 'sensei*' ],
+				],
+			],
+		];
+
+		return $notices;
 	}
 
 	/**

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -174,6 +174,7 @@ class Sensei_Course_Theme_Option {
 	 */
 	public function add_course_theme_notice( array $notices ) {
 		$notices['sensei-course-theme'] = [
+			'type'       => 'user',
 			'icon'       => 'sensei',
 			'heading'    => __( 'Sensei’s new learning mode is here', 'sensei-lms' ),
 			'message'    => __( 'Give your students an intuitive and distraction-free learning experience.', 'sensei-lms' ),

--- a/templates/course-theme/lesson-quiz-notice.php
+++ b/templates/course-theme/lesson-quiz-notice.php
@@ -57,7 +57,7 @@ if ( ! function_exists( 'sensei_lesson_quiz_notice_actions_map' ) ) {
 				<a href="<?php echo esc_url( $action['url'] ); ?>" class="sensei-course-theme-lesson-quiz-notice__action sensei-course-theme__button is-<?php echo esc_attr( $action['style'] ); ?>">
 					<?php echo wp_kses_post( $action['label'] ); ?>
 					<?php
-						// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Function returning svg only.
+						// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic parts escaped in the function.
 						echo Sensei()->assets->get_icon( 'chevron-right', 'sensei-course-theme-lesson-quiz-notice__link-chevron' );
 					?>
 				</a>

--- a/templates/course-theme/locked-lesson-notice.php
+++ b/templates/course-theme/locked-lesson-notice.php
@@ -26,7 +26,7 @@ if ( ! function_exists( 'sensei_locked_lesson_notices_map' ) ) {
 				<?php if ( ! empty( $notice['icon'] ) ) { ?>
 				<div class="sensei-course-theme-locked-lesson-notice__icon">
 					<?php
-					// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Function returning svg only.
+					// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped -- Dynamic parts escaped in the function.
 					echo Sensei()->assets->get_icon( $notice['icon'] );
 					?>
 				</div>


### PR DESCRIPTION
Part of #4386

### Changes proposed in this Pull Request

* It expands the `Sensei_Course_Theme_Option`, adding a filter to support local notices.
* It adds a course theme notice to the Sensei pages on wp-admin.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Access a Sensei page on wp-admin, and make sure a Course Theme notice is displayed.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_admin_notices` - It filters the `$notices` to be displayed on wp-admin.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1141" alt="Screen Shot 2022-01-11 at 16 10 08" src="https://user-images.githubusercontent.com/876340/149006102-6f029058-7bae-41d7-8917-cea8a5adb22d.png">
