### PR TITLE
Update module button to have the collapsible action

### DIFF
--- a/assets/css/sensei-course-theme/course-navigation.scss
+++ b/assets/css/sensei-course-theme/course-navigation.scss
@@ -11,42 +11,33 @@
 }
 
 .sensei-lms-course-navigation-module {
-	&__header {
+	.sensei-collapsible__toggle {
 		display: flex;
 		align-items: flex-start;
+		width: 100%;
 		margin: 12px 0;
 
-		.sensei-collapsible__toggle {
-			&:hover {
-				color: var(--primary-color);
-			}
-			svg {
-				fill: currentColor;
-				width: 24px;
-				height: 24px;
-			}
+		&:hover {
+			color: var(--primary-color);
+			text-decoration: underline;
+		}
 
-			&.collapsed {
-				transform: rotate(180deg);
-			}
-
+		.sensei-lms-course-navigation-module__collapsible-icon {
+			width: 24px;
 			height: 24px;
+		}
+
+		&.collapsed .sensei-lms-course-navigation-module__collapsible-icon {
+			transform: rotate(180deg);
 		}
 	}
 
 	&__title {
 		flex: 1;
-
-		a {
-			color: var(--primary-color);
-			font-weight: 600;
-			font-size: 18px;
-			line-height: 22px;
-
-			&:hover {
-				text-decoration: underline;
-			}
-		}
+		color: var(--primary-color);
+		font-weight: 600;
+		font-size: 18px;
+		line-height: 22px;
 	}
 
 	&__summary {

--- a/includes/blocks/class-sensei-course-navigation-block.php
+++ b/includes/blocks/class-sensei-course-navigation-block.php
@@ -182,19 +182,15 @@ class Sensei_Course_Navigation_Block {
 			$collapsed = 'collapsed';
 		}
 
-		$collapse_toggle = '<button type="button" class="sensei-lms-course-navigation__arrow sensei-collapsible__toggle ' . $collapsed . '">
-				' . Sensei()->assets->get_icon( 'chevron-up' ) . '
-				<span class="screen-reader-text">' . esc_html__( 'Toggle module content', 'sensei-lms' ) . '</span>
-			</button>';
-
 		return '
 			<section ' . Sensei_Block_Helpers::render_style_attributes( $classes, [] ) . '>
 				<header class="sensei-lms-course-navigation-module__header">
-					<h2 class="sensei-lms-course-navigation-module__title">
-						<a href="' . esc_url( $module_url ) . '">' . $title . '</a>
-					</h2>
-					' . $collapse_toggle .
-			'</header>
+					<button type="button" class="sensei-collapsible__toggle ' . $collapsed . '">
+						<h2 class="sensei-lms-course-navigation-module__title">' . $title . '</h2>
+						' . Sensei()->assets->get_icon( 'chevron-up', 'sensei-lms-course-navigation-module__collapsible-icon' ) . '
+						<span class="screen-reader-text">' . esc_html__( 'Toggle module content', 'sensei-lms' ) . '</span>
+					</button>
+				</header>
 				<div class="sensei-lms-course-navigation-module__lessons sensei-collapsible__content ' . $collapsed . '">
 					' . $lessons_html . '
 				</div>


### PR DESCRIPTION
Fixes #4593

### Changes proposed in this Pull Request

* Until we don't implement https://github.com/Automattic/sensei/issues/4551, the modules in the sidebar expand/collapse the lessons.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`.
* Create a course with modules.
* Enable the learning mode on the course editor sidebar.
* Access a lesson as a student.
* Make sure the modules link on the sidebar expands and collapses the lessons.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/149010508-ccced1ae-ed1c-4b19-a67b-e3c454b00bc3.mov


