### PR TITLE
Update menu structure

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -76,27 +76,28 @@ $sensei-notice-icon-width: 30px;
 	font-style: normal;
 }
 
-/*  Sensei icon */
-body #toplevel_page_sensei div.wp-menu-image:before {
-	font-family: 'sensei' !important;
-	content: "\f101";
+/* Sensei LMS menu */
+body #menu-posts-course {
+	div.wp-menu-image:before {
+		font-family: 'sensei';
+		content: "\f101";
+	}
+
+	ul li a {
+		&[href="post-new.php?post_type=course"] {
+			display: none;
+		}
+
+		&[href="edit.php?post_type=course&page=sensei_learners"],
+		&[href="edit.php?post_type=course&page=sensei_analysis"] {
+			border-top: solid 1px;
+			margin-top: 10px;
+			padding-top: 10px;
+		}
+	}
 }
 
-/* Lessons Icon */
-body #menu-posts-lesson div.wp-menu-image:before {
-	content: '\f163' !important;
-}
-
-/* Course Icon */
-body #menu-posts-course div.wp-menu-image:before {
-	content: '\f331' !important;
-}
-
-/* Questions Icon */
-body #menu-posts-question div.wp-menu-image:before {
-	content: '\f223' !important;
-}
-
+/* Dashboard At a Glance */
 #dashboard_right_now a.course-count:before,
 #dashboard_right_now span.course-count:before {
 	content: '\f331';
@@ -110,17 +111,6 @@ body #menu-posts-question div.wp-menu-image:before {
 #dashboard_right_now a.question-count:before,
 #dashboard_right_now span.question-count:before {
 	content: '\f223';
-}
-
-/* Sensei Menu */
-#toplevel_page_sensei li.wp-first-item {
-	display: none;
-}
-
-/* Course Menu Icons */
-li.menu-icon-lesson .wp-menu-image img,
-li.menu-icon-course .wp-menu-image img {
-	display: none;
 }
 
 .edit-php.post-type-quiz .add-new-h2 {

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -55,12 +55,12 @@ class Sensei_Admin_Notices {
 		'edit-question-type',
 		'edit-question-category',
 		'edit-lesson-tag',
-		'sensei-lms_page_sensei_analysis',
-		'sensei-lms_page_sensei_learners',
-		'sensei-lms_page_sensei-settings',
-		'sensei-lms_page_sensei_grading',
-		'sensei-lms_page_sensei-extensions',
-		'sensei-lms_page_sensei-tools',
+		'course_page_sensei_analysis',
+		'course_page_sensei_learners',
+		'course_page_sensei-settings',
+		'course_page_sensei_grading',
+		'course_page_sensei-extensions',
+		'course_page_sensei-tools',
 		'lesson_page_lesson-order',
 	];
 

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -39,7 +39,6 @@ final class Sensei_Extensions {
 	 */
 	public function init() {
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin_assets' ) );
-		add_action( 'admin_menu', array( $this, 'add_admin_menu_item' ), 60 );
 	}
 
 	/**
@@ -51,7 +50,7 @@ final class Sensei_Extensions {
 	public function enqueue_admin_assets() {
 		$screen = get_current_screen();
 
-		if ( in_array( $screen->id, [ 'sensei-lms_page_sensei-extensions' ], true ) ) {
+		if ( in_array( $screen->id, [ 'course_page_sensei-extensions' ], true ) ) {
 			Sensei()->assets->enqueue( 'sensei-extensions', 'extensions/index.js', [], true );
 			Sensei()->assets->enqueue( 'sensei-extensions-style', 'extensions/extensions.css', [ 'sensei-wp-components' ] );
 			Sensei()->assets->preload_data( [ '/sensei-internal/v1/sensei-extensions?type=plugin' ] );
@@ -271,6 +270,7 @@ final class Sensei_Extensions {
 	 * Adds the menu item for the Extensions page.
 	 *
 	 * @since  2.0.0
+	 *
 	 * @access private
 	 */
 	public function add_admin_menu_item() {
@@ -282,7 +282,7 @@ final class Sensei_Extensions {
 		}
 
 		add_submenu_page(
-			'sensei',
+			'edit.php?post_type=course',
 			__( 'Sensei LMS Extensions', 'sensei-lms' ),
 			__( 'Extensions', 'sensei-lms' ) . $updates_html,
 			'install_plugins',

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -70,7 +70,7 @@ class Sensei_Learner_Management {
 		// Admin functions.
 		if ( is_admin() ) {
 			add_filter( 'set-screen-option', array( $this, 'set_learner_management_screen_option' ), 20, 3 );
-			add_action( 'admin_menu', array( $this, 'learners_admin_menu' ), 30 );
+
 			add_action( 'learners_wrapper_container', array( $this, 'wrapper_container' ) );
 
 			if ( isset( $_GET['page'] ) && ( ( $this->page_slug === $_GET['page'] ) || ( 'sensei_learner_admin' === $_GET['page'] ) ) ) {
@@ -103,10 +103,17 @@ class Sensei_Learner_Management {
 	 */
 	public function learners_admin_menu() {
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
-			$learners_page = add_submenu_page( 'sensei', $this->name, $this->name, 'manage_sensei_grades', $this->page_slug, array( $this, 'learners_page' ) );
+			$learners_page = add_submenu_page(
+				'edit.php?post_type=course',
+				$this->name,
+				$this->name,
+				'manage_sensei_grades',
+				$this->page_slug,
+				array( $this, 'learners_page' )
+			);
+
 			add_action( "load-$learners_page", array( $this, 'load_screen_options_when_on_bulk_actions' ) );
 		}
-
 	}
 
 	/**

--- a/includes/admin/class-sensei-tools.php
+++ b/includes/admin/class-sensei-tools.php
@@ -57,7 +57,6 @@ class Sensei_Tools {
 	 * @since 3.7.0
 	 */
 	public function init() {
-		add_action( 'admin_menu', [ $this, 'add_menu_pages' ], 90 );
 		add_filter( 'sensei_learners_main_column_data', [ Sensei_Tool_Enrolment_Debug::class, 'add_debug_action' ], 10, 3 );
 	}
 
@@ -101,9 +100,18 @@ class Sensei_Tools {
 	 * Adds admin menu pages.
 	 */
 	public function add_menu_pages() {
-		$title = esc_html__( 'Tools', 'sensei-lms' );
-		add_submenu_page( 'sensei', $title, $title, 'manage_sensei', 'sensei-tools', [ $this, 'output' ] );
-		add_action( 'load-sensei-lms_page_sensei-tools', [ $this, 'process' ] );
+		$title       = esc_html__( 'Tools', 'sensei-lms' );
+
+		add_submenu_page(
+			'edit.php?post_type=course',
+			$title,
+			$title,
+			'manage_sensei',
+			'sensei-tools',
+			[ $this, 'output' ]
+		);
+
+		add_action( 'load-course_page_sensei-tools', [ $this, 'process' ] );
 	}
 
 	/**
@@ -219,7 +227,7 @@ class Sensei_Tools {
 	 * @return string
 	 */
 	public function get_tools_url() {
-		return admin_url( 'admin.php?page=sensei-tools' );
+		return admin_url( 'edit.php?post_type=course&page=sensei-tools' );
 	}
 
 	/**

--- a/includes/admin/class-sensei-tools.php
+++ b/includes/admin/class-sensei-tools.php
@@ -100,7 +100,7 @@ class Sensei_Tools {
 	 * Adds admin menu pages.
 	 */
 	public function add_menu_pages() {
-		$title       = esc_html__( 'Tools', 'sensei-lms' );
+		$title = esc_html__( 'Tools', 'sensei-lms' );
 
 		add_submenu_page(
 			'edit.php?post_type=course',

--- a/includes/admin/views/html-admin-page-tools-header.php
+++ b/includes/admin/views/html-admin-page-tools-header.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		esc_html_e( 'Tools', 'sensei-lms' );
 
 		if ( ! empty( $tool ) ) {
-			$back_url = admin_url( 'admin.php?page=sensei-tools' );
+			$back_url = Sensei_Tools::instance()->get_tools_url();
 			?>
 			<a href="<?php echo esc_url( $back_url ); ?>" class="button"><?php echo esc_html__( 'All Tools', 'sensei-lms' ); ?></a>
 			<?php
@@ -45,4 +45,3 @@ if ( ! defined( 'ABSPATH' ) ) {
 		echo wp_kses_post( $message['message'] );
 		echo '</p></div>';
 	}
-

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -37,11 +37,8 @@ class Sensei_Admin {
 
 		// register admin scripts
 		add_action( 'admin_enqueue_scripts', array( $this, 'register_scripts' ) );
-
-		add_action( 'admin_menu', array( $this, 'admin_menu' ), 10 );
 		add_action( 'menu_order', array( $this, 'admin_menu_order' ) );
 		add_action( 'admin_head', array( $this, 'admin_menu_highlight' ) );
-		add_action( 'admin_init', array( $this, 'page_redirect' ) );
 		add_action( 'admin_init', array( $this, 'sensei_add_custom_menu_items' ) );
 
 		// Duplicate lesson & courses
@@ -89,9 +86,13 @@ class Sensei_Admin {
 	 * Add items to admin menu
 	 *
 	 * @since  1.4.0
+	 * @deprecated 4.0.0
+	 *
 	 * @return void
 	 */
 	public function admin_menu() {
+		_deprecated_function( __METHOD__, '4.0.0' );
+
 		global $menu;
 		$menu_cap = '';
 		if ( current_user_can( 'manage_sensei' ) ) {
@@ -187,9 +188,13 @@ class Sensei_Admin {
 	 * Redirect Sensei menu item to Analysis page
 	 *
 	 * @since  1.4.0
+	 * @deprecated 4.0.0
+	 *
 	 * @return void
 	 */
 	public function page_redirect() {
+		_deprecated_function( __METHOD__, '4.0.0' );
+
 		if ( isset( $_GET['page'] ) && $_GET['page'] == 'sensei' ) {
 			wp_safe_redirect( 'admin.php?page=sensei_analysis' );
 			exit;

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -29,12 +29,10 @@ class Sensei_Analysis {
 
 		// Admin functions
 		if ( is_admin() ) {
-			add_action( 'admin_menu', array( $this, 'analysis_admin_menu' ), 10 );
 			add_action( 'analysis_wrapper_container', array( $this, 'wrapper_container' ) );
+
 			if ( isset( $_GET['page'] ) && ( $_GET['page'] == $this->page_slug ) ) {
-
 				add_action( 'admin_print_styles', array( $this, 'enqueue_styles' ) );
-
 			}
 
 			add_action( 'admin_init', array( $this, 'report_download_page' ) );
@@ -53,9 +51,15 @@ class Sensei_Analysis {
 	 */
 	public function analysis_admin_menu() {
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
-			add_submenu_page( 'sensei', __( 'Analysis', 'sensei-lms' ), __( 'Analysis', 'sensei-lms' ), 'manage_sensei_grades', 'sensei_analysis', array( $this, 'analysis_page' ) );
+			add_submenu_page(
+				'edit.php?post_type=course',
+				__( 'Analysis', 'sensei-lms' ),
+				__( 'Analysis', 'sensei-lms' ),
+				'manage_sensei_grades',
+				'sensei_analysis',
+				array( $this, 'analysis_page' )
+			);
 		}
-
 	}
 
 	/**

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -33,15 +33,14 @@ class Sensei_Grading {
 
 		// Admin functions
 		if ( is_admin() ) {
-			add_action( 'admin_menu', array( $this, 'grading_admin_menu' ), 20 );
 			add_action( 'grading_wrapper_container', array( $this, 'wrapper_container' ) );
+
 			if ( isset( $_GET['page'] ) && ( $_GET['page'] == $this->page_slug ) ) {
 				add_action( 'admin_print_scripts', array( $this, 'enqueue_scripts' ) );
 				add_action( 'admin_print_styles', array( $this, 'enqueue_styles' ) );
 			}
 
 			add_action( 'admin_init', array( $this, 'admin_process_grading_submission' ) );
-
 			add_action( 'admin_notices', array( $this, 'add_grading_notices' ) );
 		}
 
@@ -61,7 +60,14 @@ class Sensei_Grading {
 	 */
 	public function grading_admin_menu() {
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
-			add_submenu_page( 'sensei', __( 'Grading', 'sensei-lms' ), __( 'Grading', 'sensei-lms' ), 'manage_sensei_grades', $this->page_slug, array( $this, 'grading_page' ) );
+			add_submenu_page(
+				'edit.php?post_type=course',
+				__( 'Grading', 'sensei-lms' ),
+				__( 'Grading', 'sensei-lms' ),
+				'manage_sensei_grades',
+				$this->page_slug,
+				array( $this, 'grading_page' )
+			);
 		}
 
 	}

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -40,8 +40,6 @@ class Sensei_Messages {
 		$this->post_type   = 'sensei_message';
 		$this->meta_fields = array( 'sender', 'receiver' );
 
-		// Add Messages page to admin menu
-		add_action( 'admin_menu', array( $this, 'add_menu_item' ), 40 );
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_box' ), 10, 2 );
 		add_action( 'admin_menu', array( $this, 'remove_meta_box' ) );
 
@@ -122,9 +120,15 @@ class Sensei_Messages {
 	}
 
 	public function add_menu_item() {
-
 		if ( ! isset( Sensei()->settings->settings['messages_disable'] ) || ! Sensei()->settings->settings['messages_disable'] ) {
-			add_submenu_page( 'sensei', __( 'Messages', 'sensei-lms' ), __( 'Messages', 'sensei-lms' ), 'edit_courses', 'edit.php?post_type=sensei_message' );
+
+			add_submenu_page(
+				'edit.php?post_type=course',
+				__( 'Messages', 'sensei-lms' ),
+				__( 'Messages', 'sensei-lms' ),
+				'edit_courses',
+				'edit.php?post_type=sensei_message'
+			);
 		}
 	}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -46,8 +46,6 @@ class Sensei_Core_Modules {
 		add_action( 'sensei_user_lesson_reset', array( $this, 'save_lesson_module_progress' ), 10, 2 );
 		add_action( 'wp', array( $this, 'save_module_progress' ), 10 );
 
-		// Handle module ordering
-		add_action( 'admin_menu', array( $this, 'register_modules_admin_menu_items' ), 30 );
 		add_action( 'admin_post_order_modules', array( $this, 'handle_order_modules' ) );
 		add_filter( 'manage_course_posts_columns', array( $this, 'course_columns' ), 11, 1 );
 		add_action( 'manage_course_posts_custom_column', array( $this, 'course_column_content' ), 11, 2 );
@@ -1059,10 +1057,13 @@ class Sensei_Core_Modules {
 	 * Register admin screen for ordering modules
 	 *
 	 * @since 1.8.0
+	 * @deprecated 4.0.0
 	 *
 	 * @return void
 	 */
 	public function register_modules_admin_menu_items() {
+		_deprecated_function( __METHOD__, '4.0.0' );
+
 		// add the modules link under the Course main menu
 		add_submenu_page( 'edit.php?post_type=course', __( 'Modules', 'sensei-lms' ), __( 'Modules', 'sensei-lms' ), 'manage_categories', 'edit-tags.php?taxonomy=module', '' );
 

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -752,8 +752,6 @@ class Sensei_PostTypes {
 	 * Setup the singular, plural and menu label names for the post types.
 	 *
 	 * @since  1.0.0
-	 * @param Sensei_Main $sensei Sensei object.
-	 *
 	 */
 	private function setup_post_type_labels_base() {
 		$this->labels = array(

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -66,6 +66,7 @@ class Sensei_PostTypes {
 		$this->token  = 'woothemes-sensei-posttypes';
 
 		$this->setup_post_type_labels_base();
+
 		add_action( 'init', array( $this, 'setup_course_post_type' ), 100 );
 		add_action( 'init', array( $this, 'setup_lesson_post_type' ), 100 );
 		add_action( 'init', array( $this, 'setup_quiz_post_type' ), 100 );
@@ -109,6 +110,9 @@ class Sensei_PostTypes {
 
 		// Add 'Edit Quiz' link to admin bar
 		add_action( 'admin_bar_menu', array( $this, 'quiz_admin_bar_menu' ), 81 );
+
+		// Add Sensei LMS submenus.
+		add_action( 'admin_menu', array( $this, 'add_submenus' ) );
 
 		$this->setup_initial_publish_action();
 
@@ -306,7 +310,7 @@ class Sensei_PostTypes {
 			'public'                => true,
 			'publicly_queryable'    => true,
 			'show_ui'               => true,
-			'show_in_menu'          => true,
+			'show_in_menu'          => false,
 			'query_var'             => true,
 			'rewrite'               => array(
 				'slug'       => esc_attr( apply_filters( 'sensei_lesson_slug', _x( 'lesson', 'post type single slug', 'sensei-lms' ) ) ),
@@ -402,7 +406,7 @@ class Sensei_PostTypes {
 			'public'                => false,
 			'publicly_queryable'    => true,
 			'show_ui'               => true,
-			'show_in_menu'          => true,
+			'show_in_menu'          => false,
 			'show_in_nav_menus'     => false,
 			'query_var'             => true,
 			'exclude_from_search'   => true,
@@ -486,7 +490,7 @@ class Sensei_PostTypes {
 				'public'                => true,
 				'publicly_queryable'    => true,
 				'show_ui'               => true,
-				'show_in_menu'          => 'admin.php?page=sensei',
+				'show_in_menu'          => false,
 				'show_in_nav_menus'     => true,
 				'query_var'             => true,
 				'exclude_from_search'   => true,
@@ -564,6 +568,7 @@ class Sensei_PostTypes {
 			'labels'            => $labels,
 			'show_in_rest'      => true,
 			'show_ui'           => true,
+			'show_in_menu'      => false,
 			'query_var'         => true,
 			'show_in_nav_menus' => true,
 			'capabilities'      => array(
@@ -747,7 +752,8 @@ class Sensei_PostTypes {
 	 * Setup the singular, plural and menu label names for the post types.
 	 *
 	 * @since  1.0.0
-	 * @return void
+	 * @param Sensei_Main $sensei Sensei object.
+	 *
 	 */
 	private function setup_post_type_labels_base() {
 		$this->labels = array(
@@ -760,7 +766,7 @@ class Sensei_PostTypes {
 		$this->labels['course']            = array(
 			'singular' => __( 'Course', 'sensei-lms' ),
 			'plural'   => __( 'Courses', 'sensei-lms' ),
-			'menu'     => __( 'Courses', 'sensei-lms' ),
+			'menu'     => __( 'Sensei LMS', 'sensei-lms' ),
 		);
 		$this->labels['lesson']            = array(
 			'singular' => __( 'Lesson', 'sensei-lms' ),
@@ -814,7 +820,7 @@ class Sensei_PostTypes {
 			// translators: Placeholder is the singular post type label.
 			'new_item'           => sprintf( __( 'New %s', 'sensei-lms' ), $singular ),
 			// translators: Placeholder is the plural post type label.
-			'all_items'          => sprintf( __( 'All %s', 'sensei-lms' ), $plural ),
+			'all_items'          => $plural,
 			// translators: Placeholder is the singular post type label.
 			'view_item'          => sprintf( __( 'View %s', 'sensei-lms' ), $singular ),
 			// translators: Placeholder is the plural post type label.
@@ -1008,6 +1014,48 @@ class Sensei_PostTypes {
 				);
 			}
 		}
+	}
+
+	/**
+	 * Add submenus under "Sensei LMS" main menu.
+	 *
+	 * @since 4.0.0
+	 */
+	public function add_submenus() {
+		add_submenu_page(
+			'edit.php?post_type=course',
+			__( 'Modules', 'sensei-lms' ),
+			__( 'Modules', 'sensei-lms' ),
+			'manage_categories',
+			'edit-tags.php?taxonomy=module'
+		);
+
+		add_submenu_page(
+			'edit.php?post_type=course',
+			__( 'Lessons', 'sensei-lms' ),
+			__( 'Lessons', 'sensei-lms' ),
+			'edit_lessons',
+			'edit.php?post_type=lesson'
+		);
+
+		add_submenu_page(
+			'edit.php?post_type=course',
+			__( 'Questions', 'sensei-lms' ),
+			__( 'Questions', 'sensei-lms' ),
+			'edit_questions',
+			'edit.php?post_type=question'
+		);
+
+		Sensei()->learners->learners_admin_menu();
+		Sensei()->grading->grading_admin_menu();
+
+		$sensei_messages = new Sensei_Messages();
+		$sensei_messages->add_menu_item();
+
+		Sensei()->analysis->analysis_admin_menu();
+		Sensei()->settings->register_settings_screen();
+		Sensei_Tools::instance()->add_menu_pages();
+		Sensei_Extensions::instance()->add_admin_menu_item();
 	}
 
 	/**

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -59,14 +59,10 @@ class Sensei_Settings_API {
 	 *
 	 * @access public
 	 * @since  1.0.0
-	 * @return void
 	 */
 	public function register_hook_listener() {
-
-		add_action( 'admin_menu', array( $this, 'register_settings_screen' ), 60 );
 		add_action( 'admin_init', array( $this, 'settings_fields' ) );
 		add_action( 'init', array( $this, 'general_init' ), 5 );
-
 	}
 
 	/**

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -87,13 +87,17 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 *
 	 * @access public
 	 * @since  1.0.0
-	 * @return void
 	 */
 	public function register_settings_screen() {
-
 		$this->settings_version = Sensei()->version; // Use the global plugin version on this settings screen.
-		$hook                   = add_submenu_page( 'sensei', $this->name, $this->menu_label, 'manage_sensei', $this->page_slug, array( $this, 'settings_screen' ) );
-		$this->hook             = $hook;
+		$this->hook             = add_submenu_page(
+			'edit.php?post_type=course',
+			$this->name,
+			$this->menu_label,
+			'manage_sensei',
+			$this->page_slug,
+			array( $this, 'settings_screen' )
+		);
 
 		if ( isset( $_GET['page'] ) && ( $_GET['page'] == $this->page_slug ) ) {
 			add_action( 'admin_notices', array( $this, 'settings_errors' ) );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -428,7 +428,7 @@ class Sensei_Main {
 		// Differentiate between administration and frontend logic.
 		if ( is_admin() ) {
 			// Load Admin Class
-			$this->admin = new Sensei_Admin( $this->main_plugin_file_name );
+			$this->admin = new Sensei_Admin();
 
 			// Load Analysis Reports
 			$this->analysis = new Sensei_Analysis( $this->main_plugin_file_name );

--- a/includes/data-port/class-sensei-export.php
+++ b/includes/data-port/class-sensei-export.php
@@ -28,8 +28,6 @@ class Sensei_Export {
 
 		$this->page_slug = 'sensei_export';
 
-		add_action( 'admin_menu', [ $this, 'admin_menu' ], 40 );
-
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 		if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
 
@@ -52,8 +50,12 @@ class Sensei_Export {
 
 	/**
 	 * Register an export submenu.
+	 *
+	 * @deprecated 4.0.0
 	 */
 	public function admin_menu() {
+		_deprecated_function( __METHOD__, '4.0.0' );
+
 		if ( current_user_can( 'manage_sensei' ) ) {
 			add_submenu_page(
 				'sensei',

--- a/includes/data-port/class-sensei-import.php
+++ b/includes/data-port/class-sensei-import.php
@@ -25,10 +25,7 @@ class Sensei_Import {
 	 * Sensei_Import constructor.
 	 */
 	public function __construct() {
-
 		$this->page_slug = 'sensei_import';
-
-		add_action( 'admin_menu', [ $this, 'admin_menu' ], 40 );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 		if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
@@ -52,8 +49,12 @@ class Sensei_Import {
 
 	/**
 	 * Register an import submenu.
+	 *
+	 * @deprecated 4.0.0
 	 */
 	public function admin_menu() {
+		_deprecated_function( __METHOD__, '4.0.0' );
+
 		if ( current_user_can( 'manage_sensei' ) ) {
 			add_submenu_page(
 				'sensei',

--- a/tests/unit-tests/admin/test-class-sensei-extensions.php
+++ b/tests/unit-tests/admin/test-class-sensei-extensions.php
@@ -76,7 +76,7 @@ class Sensei_Extensions_Test extends WP_UnitTestCase {
 		global $submenu;
 
 		$this->assertTrue(
-			in_array( 'Extensions <span class="awaiting-mod">2</span>', end( $submenu['sensei'] ), true ),
+			in_array( 'Extensions <span class="awaiting-mod">2</span>', end( $submenu['edit.php?post_type=course'] ), true ),
 			'Should count 2 available updates'
 		);
 	}
@@ -115,7 +115,7 @@ class Sensei_Extensions_Test extends WP_UnitTestCase {
 		global $submenu;
 
 		$this->assertTrue(
-			in_array( 'Extensions', end( $submenu['sensei'] ), true ),
+			in_array( 'Extensions', end( $submenu['edit.php?post_type=course'] ), true ),
 			'Should not have counter when there is no available update'
 		);
 	}


### PR DESCRIPTION
Fixes #4528.

### Changes proposed in this Pull Request
Use a single menu with submenus for organizing Sensei's pages. This PR changes some of the URLs for some of the menu items (i.e. the non-custom post type, non-taxonomy slugs). Just something to be aware of as we use the changes from this PR, in case I've missed updating a reference somewhere.

### Testing instructions
- Ensure all of Sensei's pages are contained under the _Sensei LMS_ menu as per the issue.
- Click through all menu items and ensure they load.

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* `Sensei_Admin::admin_menu`- No replacement.
* `Sensei_Admin::page_redirect` - No replacement.
* `Sensei_Core_Modules::register_modules_admin_menu_items` - No replacement.
* `Sensei_Export::admin_menu` - No replacement.
* `Sensei_Import::admin_menu` - No replacement.

### Screenshot / Video
![Screen Shot 2022-01-11 at 10 45 03 AM](https://user-images.githubusercontent.com/1190420/148974546-890685a6-13c9-4196-8a95-48a1eecdd441.jpg)