### PR TITLE
Add Video settings panel to the lesson sidebar

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -206,6 +206,9 @@ class Sensei_Lesson {
 		// Add Meta Box for Prerequisite Lesson
 		add_meta_box( 'lesson-prerequisite', esc_html__( 'Prerequisite', 'sensei-lms' ), array( $this, 'lesson_prerequisite_meta_box_content' ), $this->token, 'side', 'low' );
 
+		// Add Meta Box for Video-Course Progression settings
+		add_meta_box( 'lesson-video', esc_html__( 'Video', 'sensei-lms' ), array( $this, 'lesson_video_meta_box_content' ), $this->token, 'side', 'low' );
+
 		// Add Meta Box for Lesson Preview
 		add_meta_box( 'lesson-preview', esc_html__( 'Preview', 'sensei-lms' ), array( $this, 'lesson_preview_meta_box_content' ), $this->token, 'side', 'low' );
 
@@ -441,6 +444,21 @@ class Sensei_Lesson {
 		}
 
 		wp_die(); // This is required to terminate immediately and return a proper response.
+	}
+
+	/**
+	 * Display the Video settings panel for the lesson.
+	 *
+	 * @return void
+	 */
+	public function lesson_video_meta_box_content() {
+		$lesson_course = get_post_meta( get_the_ID(), '_lesson_course', true );
+		$edit_course_url = get_edit_post_link( $lesson_course );
+
+		$html  = '<p>' . esc_html__( 'Control how students progress through the course based on their interactions with lesson video.', 'sensei-lms' ) . '<p>';
+		$html .= '<p><a href="' . esc_attr( $edit_course_url ) . '">' . esc_html__( 'Customize', 'sensei-lms' ) . '</a>';
+
+		echo $html;
 	}
 
 	/**

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -234,6 +234,7 @@ class Sensei_Lesson {
 	/**
 	 * Add Meta Box for Video-Course Progression settings
 	 *
+	 * @access private
 	 * @param WP_Post $post
 	 */
 	public function add_video_meta_box( $post ) {
@@ -456,6 +457,8 @@ class Sensei_Lesson {
 
 	/**
 	 * Display the Video settings panel for the lesson.
+	 *
+	 * @access private
 	 */
 	public function lesson_video_meta_box_content() {
 		$html = '<p>' . esc_html__( 'Control how students progress through the course based on their interactions with lesson video.', 'sensei-lms' ) . '<p>';

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -69,6 +69,7 @@ class Sensei_Lesson {
 
 			// Metabox functions
 			add_action( 'admin_menu', array( $this, 'meta_box_setup' ), 20 );
+			add_action( 'add_meta_boxes_' . $this->token, array( $this, 'add_video_meta_box' ), 10, 1 );
 			add_action( 'save_post', array( $this, 'meta_box_save' ) );
 			add_action( 'save_post', array( $this, 'quiz_update' ) );
 			add_action( 'save_post', array( $this, 'add_lesson_to_course_order' ) );
@@ -206,9 +207,6 @@ class Sensei_Lesson {
 		// Add Meta Box for Prerequisite Lesson
 		add_meta_box( 'lesson-prerequisite', esc_html__( 'Prerequisite', 'sensei-lms' ), array( $this, 'lesson_prerequisite_meta_box_content' ), $this->token, 'side', 'low' );
 
-		// Add Meta Box for Video-Course Progression settings
-		add_meta_box( 'lesson-video', esc_html__( 'Video', 'sensei-lms' ), array( $this, 'lesson_video_meta_box_content' ), $this->token, 'side', 'low' );
-
 		// Add Meta Box for Lesson Preview
 		add_meta_box( 'lesson-preview', esc_html__( 'Preview', 'sensei-lms' ), array( $this, 'lesson_preview_meta_box_content' ), $this->token, 'side', 'low' );
 
@@ -232,6 +230,21 @@ class Sensei_Lesson {
 		// Add CSS.
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 
+	}
+
+	/**
+	 * Add Meta Box for Video-Course Progression settings
+	 *
+	 * @param WP_Post $post
+	 *
+	 * @return void
+	 */
+	public function add_video_meta_box( $post ) {
+		$lesson_course = get_post_meta( $post->ID, '_lesson_course', true );
+		if ( ! $lesson_course ) {
+			return;
+		}
+		add_meta_box( 'lesson-video', esc_html__( 'Video', 'sensei-lms' ), array( $this, 'lesson_video_meta_box_content' ), $this->token, 'side', 'low' );
 	}
 
 	/**
@@ -454,13 +467,9 @@ class Sensei_Lesson {
 	public function lesson_video_meta_box_content() {
 		$html = '<p>' . esc_html__( 'Control how students progress through the course based on their interactions with lesson video.', 'sensei-lms' ) . '<p>';
 
-		$lesson_course = get_post_meta( get_the_ID(), '_lesson_course', true );
-		if ( $lesson_course ) {
-			$edit_course_url = get_edit_post_link( $lesson_course );
-			$html           .= '<p><a href="' . esc_attr( $edit_course_url ) . '">' . esc_html__( 'Customize', 'sensei-lms' ) . '</a>';
-		} else {
-			$html .= '<p>' . esc_html__( 'Please attach the lesson to a course first.', 'sensei-lms' ) . '</p>';
-		}
+		$lesson_course   = get_post_meta( get_the_ID(), '_lesson_course', true );
+		$edit_course_url = get_edit_post_link( $lesson_course );
+		$html           .= '<p><a href="' . esc_attr( $edit_course_url ) . '">' . esc_html__( 'Customize', 'sensei-lms' ) . '</a>';
 		echo wp_kses( $html, wp_kses_allowed_html( 'post' ) );
 	}
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -229,7 +229,7 @@ class Sensei_Lesson {
 		// Add JS scripts
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 
-		// Add CSS
+		// Add CSS.
 		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_styles' ) );
 
 	}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -197,7 +197,6 @@ class Sensei_Lesson {
 	 * meta_box_setup function.
 	 *
 	 * @access public
-	 * @return void
 	 */
 	public function meta_box_setup() {
 
@@ -236,8 +235,6 @@ class Sensei_Lesson {
 	 * Add Meta Box for Video-Course Progression settings
 	 *
 	 * @param WP_Post $post
-	 *
-	 * @return void
 	 */
 	public function add_video_meta_box( $post ) {
 		$lesson_course = get_post_meta( $post->ID, '_lesson_course', true );
@@ -251,7 +248,6 @@ class Sensei_Lesson {
 	 * lesson_info_meta_box_content function.
 	 *
 	 * @access public
-	 * @return void
 	 */
 	public function lesson_info_meta_box_content() {
 		global $post;
@@ -325,7 +321,6 @@ class Sensei_Lesson {
 	 * lesson_prerequisite_meta_box_content function.
 	 *
 	 * @access public
-	 * @return void
 	 */
 	public function lesson_prerequisite_meta_box_content() {
 		global $post;
@@ -461,8 +456,6 @@ class Sensei_Lesson {
 
 	/**
 	 * Display the Video settings panel for the lesson.
-	 *
-	 * @return void
 	 */
 	public function lesson_video_meta_box_content() {
 		$html = '<p>' . esc_html__( 'Control how students progress through the course based on their interactions with lesson video.', 'sensei-lms' ) . '<p>';
@@ -477,7 +470,6 @@ class Sensei_Lesson {
 	 * lesson_preview_meta_box_content function.
 	 *
 	 * @access public
-	 * @return void
 	 */
 	public function lesson_preview_meta_box_content() {
 		global $post;
@@ -572,7 +564,6 @@ class Sensei_Lesson {
 	 *
 	 * @access public
 	 * @param int $lesson_id
-	 * @return void
 	 */
 	public function add_lesson_to_course_order( $lesson_id = 0 ) {
 		$lesson_id = intval( $lesson_id );
@@ -860,7 +851,6 @@ class Sensei_Lesson {
 	 * lesson_course_meta_box_content function.
 	 *
 	 * @access public
-	 * @return void
 	 */
 	public function lesson_course_meta_box_content() {
 		global $post;
@@ -2112,7 +2102,6 @@ class Sensei_Lesson {
 	 * lesson_quiz_meta_box_content function.
 	 *
 	 * @access public
-	 * @return void
 	 */
 	public function lesson_quiz_meta_box_content() {
 		global $post;
@@ -2130,8 +2119,6 @@ class Sensei_Lesson {
 
 	/**
 	 * Quiz settings metabox
-	 *
-	 * @return void
 	 */
 	public function lesson_quiz_settings_meta_box_content() {
 		global $post;
@@ -2308,7 +2295,6 @@ class Sensei_Lesson {
 	 * enqueue_scripts function.
 	 *
 	 * @access public
-	 * @return void
 	 */
 	public function enqueue_scripts( $hook ) {
 		global $post_type;
@@ -2406,7 +2392,6 @@ class Sensei_Lesson {
 	 *
 	 * @access private
 	 * @since  3.0.0
-	 * @return void
 	 */
 	private function enqueue_lesson_edit_scripts() {
 		// Load the quick edit screen script.
@@ -2420,7 +2405,6 @@ class Sensei_Lesson {
 	 *
 	 * @access public
 	 * @since  1.4.0
-	 * @return void
 	 */
 	public function enqueue_styles( $hook ) {
 		global  $post_type;
@@ -2512,7 +2496,6 @@ class Sensei_Lesson {
 	 * @since  1.0.0
 	 * @param  string $column_name
 	 * @param  int    $id
-	 * @return void
 	 */
 	public function add_column_data( $column_name, $id ) {
 		switch ( $column_name ) {
@@ -2545,7 +2528,6 @@ class Sensei_Lesson {
 	 *
 	 * @access public
 	 * @deprecated 2.2.0
-	 * @return void
 	 */
 	public function lesson_add_course() {
 		_deprecated_function( __METHOD__, '2.2.0' );
@@ -2611,7 +2593,6 @@ class Sensei_Lesson {
 	 * Updates a question.
 	 *
 	 * @access public
-	 * @return void
 	 */
 	public function lesson_update_question() {
 		// Add nonce security to the request.
@@ -3851,7 +3832,6 @@ class Sensei_Lesson {
 	 *
 	 * @param string $column_name
 	 * @param string $post_type
-	 * @return void
 	 */
 	public function all_lessons_edit_fields( $column_name, $post_type ) {
 
@@ -4021,7 +4001,6 @@ class Sensei_Lesson {
 	 * from the admin all lesson screen.
 	 *
 	 * @since 1.8.0
-	 * @return void
 	 */
 	function save_all_lessons_edit_fields() {
 
@@ -4098,7 +4077,6 @@ class Sensei_Lesson {
 	 * NOTE: this function runs for each row in the edit column
 	 *
 	 * @since 1.8.0
-	 * @return void
 	 */
 	public function set_quick_edit_admin_defaults( $column_name, $post_id ) {
 
@@ -4552,7 +4530,6 @@ class Sensei_Lesson {
 	 * Outputs the lesson archive header.
 	 *
 	 * @since  1.9.0
-	 * @return void
 	 */
 	public function the_archive_header() {
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -452,16 +452,16 @@ class Sensei_Lesson {
 	 * @return void
 	 */
 	public function lesson_video_meta_box_content() {
-		$html  = '<p>' . esc_html__( 'Control how students progress through the course based on their interactions with lesson video.', 'sensei-lms' ) . '<p>';
+		$html = '<p>' . esc_html__( 'Control how students progress through the course based on their interactions with lesson video.', 'sensei-lms' ) . '<p>';
 
 		$lesson_course = get_post_meta( get_the_ID(), '_lesson_course', true );
 		if ( $lesson_course ) {
 			$edit_course_url = get_edit_post_link( $lesson_course );
-			$html            .= '<p><a href="' . esc_attr( $edit_course_url ) . '">' . esc_html__( 'Customize', 'sensei-lms' ) . '</a>';
+			$html           .= '<p><a href="' . esc_attr( $edit_course_url ) . '">' . esc_html__( 'Customize', 'sensei-lms' ) . '</a>';
 		} else {
 			$html .= '<p>' . esc_html__( 'Please attach the lesson to a course first.', 'sensei-lms' ) . '</p>';
 		}
-		echo $html;
+		echo wp_kses( $html, wp_kses_allowed_html( 'post' ) );
 	}
 
 	/**

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -452,12 +452,15 @@ class Sensei_Lesson {
 	 * @return void
 	 */
 	public function lesson_video_meta_box_content() {
-		$lesson_course = get_post_meta( get_the_ID(), '_lesson_course', true );
-		$edit_course_url = get_edit_post_link( $lesson_course );
-
 		$html  = '<p>' . esc_html__( 'Control how students progress through the course based on their interactions with lesson video.', 'sensei-lms' ) . '<p>';
-		$html .= '<p><a href="' . esc_attr( $edit_course_url ) . '">' . esc_html__( 'Customize', 'sensei-lms' ) . '</a>';
 
+		$lesson_course = get_post_meta( get_the_ID(), '_lesson_course', true );
+		if ( $lesson_course ) {
+			$edit_course_url = get_edit_post_link( $lesson_course );
+			$html            .= '<p><a href="' . esc_attr( $edit_course_url ) . '">' . esc_html__( 'Customize', 'sensei-lms' ) . '</a>';
+		} else {
+			$html .= '<p>' . esc_html__( 'Please attach the lesson to a course first.', 'sensei-lms' ) . '</p>';
+		}
 		echo $html;
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds Video settings panel to the lesson sidebar

### Testing instructions
* Create a course.
* Add a lesson.
* Open the lesson in the editor and look at the sidebar, below Preview.
* Create a new lesson (not attached to a course).
* Open the new lesson: there should be no Video meta box in the sidebar.

### Screenshot / Video
<img width="284" alt="CleanShot 2022-01-13 at 20 20 20@2x" src="https://user-images.githubusercontent.com/329356/149378076-d52cb69e-e179-4fa5-b5d8-3d2177cb350c.png">



