### PR TITLE
Show pagination progress bar in lesson edit view

### DIFF
--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -18,6 +18,7 @@ import QuestionsModal from './questions-modal';
 import QuizSettings from './quiz-settings';
 import { useUpdateQuizHasQuestionsMeta } from './use-update-quiz-has-questions-meta';
 import { isQuestionEmpty } from '../data';
+import QuizProgressBarEdit from './quiz-progress-bar-edit';
 
 const ALLOWED_BLOCKS = [
 	'sensei-lms/quiz-question',
@@ -62,6 +63,9 @@ const QuizEdit = ( props ) => {
 		),
 		[ clientId ]
 	);
+	const pagination = props?.attributes?.options?.pagination;
+	const showPaginationProgressBar =
+		pagination?.paginationNumber && pagination?.showProgressBar;
 
 	return (
 		<>
@@ -69,6 +73,9 @@ const QuizEdit = ( props ) => {
 			<div className="sensei-lms-quiz-block__separator">
 				<span>{ __( 'Lesson Quiz', 'sensei-lms' ) }</span>
 			</div>
+			{ showPaginationProgressBar && (
+				<QuizProgressBarEdit pagination={ pagination } />
+			) }
 			<InnerBlocks
 				allowedBlocks={ ALLOWED_BLOCKS }
 				templateInsertUpdatesSelection={ false }

--- a/assets/blocks/quiz/quiz-block/quiz-progress-bar-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-progress-bar-edit.js
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import ProgressBar from '../../../shared/blocks/progress-bar';
+
+/**
+ * Progress bar in lesson edit view.
+ *
+ * @param {Object} props
+ */
+const QuizProgressBarEdit = ( props ) => {
+	const { pagination } = props;
+	const barAttributes = {
+		style: {
+			...( pagination?.progressBarColor && {
+				backgroundColor: pagination.progressBarColor,
+			} ),
+		},
+	};
+
+	const barWrapperAttributes = {
+		style: {
+			...( pagination?.progressBarBackground && {
+				backgroundColor: pagination.progressBarBackground,
+			} ),
+			...( pagination?.progressBarHeight && {
+				height: pagination.progressBarHeight,
+			} ),
+			...( pagination?.progressBarRadius && {
+				borderRadius: pagination.progressBarRadius,
+			} ),
+		},
+	};
+	return (
+		<ProgressBar
+			lessonsCount={ 10 }
+			completedCount={ 2 }
+			barAttributes={ barAttributes }
+			barWrapperAttributes={ barWrapperAttributes }
+		/>
+	);
+};
+
+export default QuizProgressBarEdit;

--- a/assets/blocks/quiz/quiz-block/quiz-progress-bar-edit.test.js
+++ b/assets/blocks/quiz/quiz-block/quiz-progress-bar-edit.test.js
@@ -1,0 +1,42 @@
+import { render } from '@testing-library/react';
+import QuizProgressBarEdit from './quiz-progress-bar-edit';
+import ProgressBar from '../../../shared/blocks/progress-bar';
+
+describe( 'Testing Quiz Progress Bar Edit', () => {
+	it( 'Test ProgressBar is rendered with expected properties', () => {
+		const pagination = {
+			progressBarColor: 'black',
+			progressBarBackground: 'white',
+			progressBarRadius: 6,
+			progressBarHeight: 12,
+		};
+		const barAttributes = {
+			style: {
+				backgroundColor: 'black',
+			},
+		};
+
+		const barWrapperAttributes = {
+			style: {
+				backgroundColor: 'white',
+				height: 12,
+				borderRadius: 6,
+			},
+		};
+
+		const quizProgressBarEditTest = render(
+			<QuizProgressBarEdit pagination={ pagination } />
+		);
+		const progressBar = render(
+			<ProgressBar
+				lessonsCount={ 10 }
+				completedCount={ 2 }
+				barAttributes={ barAttributes }
+				barWrapperAttributes={ barWrapperAttributes }
+			/>
+		);
+		expect( progressBar.baseElement ).toEqual(
+			quizProgressBarEditTest.baseElement
+		);
+	} );
+} );


### PR DESCRIPTION
Relates #4542

### Changes proposed in this Pull Request
Specifications from conversation with @donnapep 
>When I enable the Show progress bar setting and set Pagination to Multi-Page, I was expecting to see the progress bar displayed in the lesson editor inside the Quiz block. And then when I change either of those settings, the progress bar would be removed from the editor. So it would work similarly in the editor as it does on the front-end. This way the user can see what effect changing the setting has on the page without having to preview it each time.

### Testing instructions
1. Open Lesson edit view and enable pagination + turn no show progress bar you should see progress bar above the questions
| Lesson Edit View | Settings View | 
| -- | -- | 
| 
![image](https://user-images.githubusercontent.com/7208249/149271058-a5cd07a0-45f2-4c69-9466-01ac583c3eea.png) |  ![image](https://user-images.githubusercontent.com/7208249/149271092-f2505339-1bae-4632-b4db-fbf34b1f29f3.png) |


