### PR TITLE
Remove video based course progression feature flag

### DIFF
--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -81,9 +81,7 @@ if ( window.senseiCourseThemeFeatureFlagEnabled ) {
 		icon: null,
 	} );
 }
-if ( window.senseiVideoCourseProgressionFeatureFlagEnabled ) {
-	registerPlugin( 'sensei-course-video-progression-plugin', {
-		render: CourseVideoSidebar,
-		icon: null,
-	} );
-}
+registerPlugin( 'sensei-course-video-progression-plugin', {
+	render: CourseVideoSidebar,
+	icon: null,
+} );

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -53,9 +53,8 @@ class Sensei_Feature_Flags {
 		return apply_filters(
 			'sensei_default_feature_flag_settings',
 			[
-				'enrolment_provider_tooltip'     => false,
-				'course_theme'                   => false,
-				'video_based_course_progression' => false,
+				'enrolment_provider_tooltip' => false,
+				'course_theme'               => false,
 			]
 		);
 	}

--- a/includes/course-video/class-sensei-course-video-settings.php
+++ b/includes/course-video/class-sensei-course-video-settings.php
@@ -60,37 +60,14 @@ class Sensei_Course_Video_Settings {
 
 	/**
 	 * Initializes the Video-Based Course Progression.
-	 *
-	 * @param Sensei_Main $sensei Sensei object.
 	 */
-	public function init( $sensei ) {
-		add_action( 'admin_enqueue_scripts', [ $this, 'add_feature_flag_inline_script' ] );
-
-		if ( ! $sensei->feature_flags->is_enabled( 'video_based_course_progression' ) ) {
-			// As soon this feature flag check is removed, the `$sensei` argument can also be removed.
-			return;
-		}
-
+	public function init() {
 		add_action( 'init', [ $this, 'register_post_meta' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_frontend_scripts' ] );
 
 		Sensei_Course_Video_Blocks_Youtube_Extension::instance()->init();
 		Sensei_Course_Video_Blocks_Video_Extension::instance()->init();
 		Sensei_Course_Video_Blocks_Vimeo_Extension::instance()->init();
-	}
-
-	/**
-	 * Add feature flag inline script.
-	 *
-	 * @access private
-	 */
-	public function add_feature_flag_inline_script() {
-		$screen  = get_current_screen();
-		$enabled = Sensei()->feature_flags->is_enabled( 'video_based_course_progression' ) ? 'true' : 'false';
-
-		if ( 'course' === $screen->id ) {
-			wp_add_inline_script( 'sensei-admin-course-edit', 'window.senseiVideoCourseProgressionFeatureFlagEnabled = ' . $enabled, 'before' );
-		}
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Removes the video-based course progression feature flag.

### Testing instructions

* Make sure you don't have the feature flag enabled (code like this: `add_filter( 'sensei_feature_flag_video_based_course_progression', '__return_true' );`).
* Run `npm start`
* Open (or create) a course.
* Check if Video settings are presented in the sidebar.