### PR TITLE
Add quiz button color settings

### DIFF
--- a/assets/blocks/quiz/quiz-block/block.json
+++ b/assets/blocks/quiz/quiz-block/block.json
@@ -21,6 +21,8 @@
         "failedShowAnswerFeedback": false,
         "failedShowCorrectAnswers": false,
         "failedIndicateIncorrect": false,
+        "buttonTextColor": null,
+        "buttonBackgroundColor": null,
         "pagination": {}
       }
     },

--- a/assets/blocks/quiz/quiz-block/pagination-settings.js
+++ b/assets/blocks/quiz/quiz-block/pagination-settings.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { ContrastChecker, PanelColorSettings } from '@wordpress/block-editor';
 import {
 	PanelBody,
 	PanelRow,
@@ -32,28 +31,20 @@ const paginationOptions = [
 	},
 ];
 
-const onDropdownChange = ( settings, onChange ) => ( value ) => {
-	if ( value === MULTI ) {
-		onChange( {
-			...settings,
-			paginationNumber: 1,
-		} );
-	} else {
-		onChange( {
-			...settings,
-			paginationNumber: null,
-		} );
-	}
+const onDropdownChange = ( updatePagination ) => ( value ) => {
+	updatePagination( {
+		paginationNumber: value === MULTI ? 1 : null,
+	} );
 };
 
 /**
  * A component which contains a NumberControl and the 'per page' accompanying text.
  *
- * @param {Object}   props          Component props.
- * @param {Object}   props.settings Pagination settings object.
- * @param {Function} props.onChange Callback called when a setting changed.
+ * @param {Object}   props                  Component props.
+ * @param {Object}   props.settings         Pagination settings object.
+ * @param {Function} props.updatePagination Update pagination options function.
  */
-const QuestionsControl = ( { settings, onChange, ...props } ) => {
+const QuestionsControl = ( { settings, updatePagination, ...props } ) => {
 	const { paginationNumber } = settings;
 
 	return (
@@ -71,10 +62,7 @@ const QuestionsControl = ( { settings, onChange, ...props } ) => {
 				) }
 				value={ paginationNumber }
 				onChange={ ( value ) =>
-					onChange( {
-						...settings,
-						paginationNumber: value,
-					} )
+					updatePagination( { paginationNumber: value } )
 				}
 				{ ...props }
 			/>
@@ -86,18 +74,16 @@ const QuestionsControl = ( { settings, onChange, ...props } ) => {
 /**
  * Quiz sidebar settings.
  *
- * @param {Object}   props          Component props.
- * @param {Object}   props.settings Pagination settings object.
- * @param {Function} props.onChange Callback called when a setting changed.
+ * @param {Object}   props                  Component props.
+ * @param {Object}   props.settings         Pagination settings object.
+ * @param {Function} props.updatePagination Update pagination options function.
  */
-export const PaginationSidebarSettings = ( { settings, onChange } ) => {
+export const PaginationSidebarSettings = ( { settings, updatePagination } ) => {
 	const {
 		paginationNumber,
 		showProgressBar,
 		progressBarRadius,
 		progressBarHeight,
-		progressBarColor,
-		progressBarBackground,
 	} = settings;
 
 	return (
@@ -112,14 +98,14 @@ export const PaginationSidebarSettings = ( { settings, onChange } ) => {
 						hideLabelFromVision
 						value={ paginationNumber === null ? SINGLE : MULTI }
 						options={ paginationOptions }
-						onChange={ onDropdownChange( settings, onChange ) }
+						onChange={ onDropdownChange( updatePagination ) }
 					/>
 				</PanelRow>
 				{ paginationNumber !== null && (
 					<PanelRow className="sensei-lms-quiz-block__question-count">
 						<QuestionsControl
 							settings={ settings }
-							onChange={ onChange }
+							updatePagination={ updatePagination }
 						/>
 					</PanelRow>
 				) }
@@ -134,8 +120,7 @@ export const PaginationSidebarSettings = ( { settings, onChange } ) => {
 								) }
 								value={ progressBarRadius }
 								onChange={ ( value ) =>
-									onChange( {
-										...settings,
+									updatePagination( {
 										showProgressBar: value,
 									} )
 								}
@@ -149,8 +134,7 @@ export const PaginationSidebarSettings = ( { settings, onChange } ) => {
 								suffix={ __( 'PX', 'sensei-lms' ) }
 								value={ progressBarRadius }
 								onChange={ ( value ) =>
-									onChange( {
-										...settings,
+									updatePagination( {
 										progressBarRadius: value,
 									} )
 								}
@@ -162,8 +146,7 @@ export const PaginationSidebarSettings = ( { settings, onChange } ) => {
 								suffix={ __( 'PX', 'sensei-lms' ) }
 								value={ progressBarHeight }
 								onChange={ ( value ) =>
-									onChange( {
-										...settings,
+									updatePagination( {
 										progressBarHeight: value,
 									} )
 								}
@@ -172,39 +155,6 @@ export const PaginationSidebarSettings = ( { settings, onChange } ) => {
 					</>
 				) }
 			</PanelBody>
-			<PanelColorSettings
-				title={ __( 'Color settings', 'sensei-lms' ) }
-				initialOpen={ false }
-				colorSettings={ [
-					{
-						value: progressBarColor,
-						onChange: ( value ) =>
-							onChange( {
-								...settings,
-								progressBarColor: value,
-							} ),
-						label: __( 'Progress bar color', 'sensei-lms' ),
-					},
-					{
-						value: progressBarBackground,
-						onChange: ( value ) =>
-							onChange( {
-								...settings,
-								progressBarBackground: value,
-							} ),
-						label: __(
-							'Progress bar background color',
-							'sensei-lms'
-						),
-					},
-				] }
-			>
-				<ContrastChecker
-					textColor={ progressBarColor }
-					backgroundColor={ progressBarBackground }
-					isLargeText={ false }
-				/>
-			</PanelColorSettings>
 		</>
 	);
 };
@@ -212,11 +162,11 @@ export const PaginationSidebarSettings = ( { settings, onChange } ) => {
 /**
  * Quiz toolbar settings.
  *
- * @param {Object}   props          Component props.
- * @param {Object}   props.settings Pagination settings object.
- * @param {Function} props.onChange Callback called when a setting changed.
+ * @param {Object}   props                  Component props.
+ * @param {Object}   props.settings         Pagination settings object.
+ * @param {Function} props.updatePagination Update pagination options function.
  */
-export const PaginationToolbarSettings = ( { settings, onChange } ) => {
+export const PaginationToolbarSettings = ( { settings, updatePagination } ) => {
 	const { paginationNumber } = settings;
 
 	return (
@@ -226,14 +176,14 @@ export const PaginationToolbarSettings = ( { settings, onChange } ) => {
 					options={ paginationOptions }
 					optionsLabel={ __( 'Quiz pagination', 'sensei-lms' ) }
 					value={ paginationNumber === null ? SINGLE : MULTI }
-					onChange={ onDropdownChange( settings, onChange ) }
+					onChange={ onDropdownChange( updatePagination ) }
 				/>
 			</Toolbar>
 			{ paginationNumber !== null && (
 				<ToolbarGroup className="sensei-lms-quiz-block__toolbar-group">
 					<QuestionsControl
 						settings={ settings }
-						onChange={ onChange }
+						updatePagination={ updatePagination }
 					/>
 				</ToolbarGroup>
 			) }

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -3,7 +3,11 @@
 /**
  * WordPress dependencies
  */
-import { BlockControls, InspectorControls } from '@wordpress/block-editor';
+import {
+	BlockControls,
+	InspectorControls,
+	PanelColorSettings,
+} from '@wordpress/block-editor';
 import {
 	Button,
 	PanelBody,
@@ -57,6 +61,15 @@ const QuizSettings = ( {
 
 	const createChangeHandler = ( optionKey ) => ( value ) =>
 		setAttributes( { options: { ...options, [ optionKey ]: value } } );
+
+	// Update the pagination options function used for block settings.
+	const updatePagination = ( updatedPagination ) =>
+		setAttributes( {
+			options: {
+				...options,
+				pagination: { ...pagination, ...updatedPagination },
+			},
+		} );
 
 	const openQuizSettings = useOpenQuizSettings( clientId );
 
@@ -226,13 +239,36 @@ const QuizSettings = ( {
 				</PanelBody>
 				<PaginationSidebarSettings
 					settings={ pagination }
-					onChange={ createChangeHandler( 'pagination' ) }
+					updatePagination={ updatePagination }
+				/>
+				<PanelColorSettings
+					title={ __( 'Color settings', 'sensei-lms' ) }
+					initialOpen={ false }
+					colorSettings={ [
+						{
+							value: pagination.progressBarColor,
+							onChange: ( value ) =>
+								updatePagination( { progressBarColor: value } ),
+							label: __( 'Progress bar color', 'sensei-lms' ),
+						},
+						{
+							value: pagination.progressBarBackground,
+							onChange: ( value ) =>
+								updatePagination( {
+									progressBarBackground: value,
+								} ),
+							label: __(
+								'Progress bar background color',
+								'sensei-lms'
+							),
+						},
+					] }
 				/>
 			</InspectorControls>
 			<BlockControls>
 				<PaginationToolbarSettings
 					settings={ pagination }
-					onChange={ createChangeHandler( 'pagination' ) }
+					onChange={ updatePagination }
 				/>
 			</BlockControls>
 		</>

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -56,6 +56,8 @@ const QuizSettings = ( {
 		failedShowAnswerFeedback,
 		failedShowCorrectAnswers,
 		failedIndicateIncorrect,
+		buttonTextColor,
+		buttonBackgroundColor,
 		pagination,
 	} = options;
 
@@ -246,6 +248,21 @@ const QuizSettings = ( {
 					initialOpen={ false }
 					colorSettings={ [
 						{
+							value: buttonTextColor,
+							onChange: createChangeHandler( 'buttonTextColor' ),
+							label: __( 'Button text color', 'sensei-lms' ),
+						},
+						{
+							value: buttonBackgroundColor,
+							onChange: createChangeHandler(
+								'buttonBackgroundColor'
+							),
+							label: __(
+								'Button background color',
+								'sensei-lms'
+							),
+						},
+						{
 							value: pagination.progressBarColor,
 							onChange: ( value ) =>
 								updatePagination( { progressBarColor: value } ),
@@ -268,7 +285,7 @@ const QuizSettings = ( {
 			<BlockControls>
 				<PaginationToolbarSettings
 					settings={ pagination }
-					onChange={ updatePagination }
+					updatePagination={ updatePagination }
 				/>
 			</BlockControls>
 		</>

--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -248,12 +248,12 @@ const QuizSettings = ( {
 					initialOpen={ false }
 					colorSettings={ [
 						{
-							value: buttonTextColor,
+							value: buttonTextColor || undefined,
 							onChange: createChangeHandler( 'buttonTextColor' ),
 							label: __( 'Button text color', 'sensei-lms' ),
 						},
 						{
-							value: buttonBackgroundColor,
+							value: buttonBackgroundColor || undefined,
 							onChange: createChangeHandler(
 								'buttonBackgroundColor'
 							),
@@ -263,13 +263,14 @@ const QuizSettings = ( {
 							),
 						},
 						{
-							value: pagination.progressBarColor,
+							value: pagination.progressBarColor || undefined,
 							onChange: ( value ) =>
 								updatePagination( { progressBarColor: value } ),
 							label: __( 'Progress bar color', 'sensei-lms' ),
 						},
 						{
-							value: pagination.progressBarBackground,
+							value:
+								pagination.progressBarBackground || undefined,
 							onChange: ( value ) =>
 								updatePagination( {
 									progressBarBackground: value,

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1696,6 +1696,8 @@ class Sensei_Quiz {
 			return;
 		}
 
+		$button_inline_styles = self::get_button_inline_styles();
+
 		wp_enqueue_script( 'sensei-stop-double-submission' );
 		?>
 
@@ -1703,7 +1705,12 @@ class Sensei_Quiz {
 			<?php if ( ! $is_quiz_completed ) : ?>
 				<div class="sensei-quiz-actions-primary wp-block-buttons">
 					<div class="sensei-quiz-action wp-block-button">
-						<button type="submit" name="quiz_complete" class="wp-block-button__link button quiz-submit complete sensei-stop-double-submission">
+						<button
+							type="submit"
+							name="quiz_complete"
+							class="wp-block-button__link button quiz-submit complete sensei-stop-double-submission"
+							style="<?php echo esc_attr( $button_inline_styles ); ?>"
+						>
 							<?php esc_attr_e( 'Complete', 'sensei-lms' ); ?>
 						</button>
 
@@ -1735,6 +1742,36 @@ class Sensei_Quiz {
 			</div>
 		</div>
 		<?php
+
+	}
+
+	/**
+	 * Get the quiz button inline styles.
+	 *
+	 * @since 3.15.0
+	 *
+	 * @param int|null $quiz_id (Optional) The quiz post ID. Defaults to the current post ID.
+	 *
+	 * @return string
+	 */
+	public static function get_button_inline_styles( int $quiz_id = null ): string {
+
+		$quiz_id = $quiz_id ? $quiz_id : get_the_ID();
+
+		$button_text_color       = get_post_meta( $quiz_id, '_button_text_color', true );
+		$button_background_color = get_post_meta( $quiz_id, '_button_background_color', true );
+
+		$styles = [];
+
+		if ( $button_text_color ) {
+			$styles[] = sprintf( 'color: %s', $button_text_color );
+		}
+
+		if ( $button_background_color ) {
+			$styles[] = sprintf( 'background-color: %s', $button_background_color );
+		}
+
+		return implode( '; ', $styles );
 
 	}
 

--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -291,6 +291,9 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 			}
 		}
 
+		$meta_input['_button_text_color']       = $quiz_options['button_text_color'] ?? null;
+		$meta_input['_button_background_color'] = $quiz_options['button_background_color'] ?? null;
+
 		if ( isset( $quiz_options['pagination'] ) ) {
 			$meta_input['_pagination'] = wp_json_encode( $quiz_options['pagination'] );
 		}
@@ -381,6 +384,8 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 				'failed_indicate_incorrect'   => empty( $post_meta['_failed_indicate_incorrect'][0] ) ? $failed_feedback_default : 'yes' === $post_meta['_failed_indicate_incorrect'][0],
 				'failed_show_correct_answers' => empty( $post_meta['_failed_show_correct_answers'][0] ) ? $failed_feedback_default : 'yes' === $post_meta['_failed_show_correct_answers'][0],
 				'failed_show_answer_feedback' => empty( $post_meta['_failed_show_answer_feedback'][0] ) ? $failed_feedback_default : 'yes' === $post_meta['_failed_show_answer_feedback'][0],
+				'button_text_color'           => ! empty( $post_meta['_button_text_color'][0] ) ? $post_meta['_button_text_color'][0] : null,
+				'button_background_color'     => ! empty( $post_meta['_button_background_color'][0] ) ? $post_meta['_button_background_color'][0] : null,
 				'pagination'                  => $pagination,
 			],
 			'questions'     => $this->get_quiz_questions( $quiz ),
@@ -483,6 +488,16 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 						'failed_show_answer_feedback' => [
 							'type'        => [ 'boolean', 'null' ],
 							'description' => 'Show answer feedback text',
+							'default'     => null,
+						],
+						'button_text_color'           => [
+							'type'        => [ 'string', 'null' ],
+							'description' => 'Button text color',
+							'default'     => null,
+						],
+						'button_background_color'     => [
+							'type'        => [ 'string', 'null' ],
+							'description' => 'Button background color',
 							'default'     => null,
 						],
 						'pagination'                  => [

--- a/templates/single-quiz/pagination.php
+++ b/templates/single-quiz/pagination.php
@@ -86,7 +86,7 @@ $sensei_button_inline_styles = Sensei_Quiz::get_button_inline_styles();
 
 		<div class="sensei-quiz-actions-primary wp-block-buttons">
 			<?php if ( $sensei_question_loop['current_page'] > 1 ) : ?>
-				<div class="sensei-quiz-action wp-block-button is-style-outline">
+				<div class="sensei-quiz-action wp-block-button">
 					<button
 						type="submit"
 						name="quiz_target_page"

--- a/templates/single-quiz/pagination.php
+++ b/templates/single-quiz/pagination.php
@@ -14,10 +14,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $sensei_question_loop;
 
-$sensei_is_quiz_available = Sensei_Quiz::is_quiz_available();
-$sensei_is_quiz_completed = Sensei_Quiz::is_quiz_completed();
-$sensei_is_reset_allowed  = Sensei_Quiz::is_reset_allowed( Sensei()->quiz->get_lesson_id() );
-$sensei_has_actions       = $sensei_is_reset_allowed || ! $sensei_is_quiz_completed;
+$sensei_is_quiz_available    = Sensei_Quiz::is_quiz_available();
+$sensei_is_quiz_completed    = Sensei_Quiz::is_quiz_completed();
+$sensei_is_reset_allowed     = Sensei_Quiz::is_reset_allowed( Sensei()->quiz->get_lesson_id() );
+$sensei_has_actions          = $sensei_is_reset_allowed || ! $sensei_is_quiz_completed;
+$sensei_button_inline_styles = Sensei_Quiz::get_button_inline_styles();
 
 ?>
 
@@ -91,6 +92,7 @@ $sensei_has_actions       = $sensei_is_reset_allowed || ! $sensei_is_quiz_comple
 						name="quiz_target_page"
 						value="<?php echo esc_attr( add_query_arg( 'quiz-page', $sensei_question_loop['current_page'] - 1 ) ); ?>"
 						class="wp-block-button__link button sensei-stop-double-submission sensei-quiz-pagination__prev-button"
+						style="<?php echo esc_attr( $sensei_button_inline_styles ); ?>"
 					>
 						<?php esc_attr_e( 'Previous', 'sensei-lms' ); ?>
 					</button>
@@ -104,13 +106,19 @@ $sensei_has_actions       = $sensei_is_reset_allowed || ! $sensei_is_quiz_comple
 						name="quiz_target_page"
 						value="<?php echo esc_attr( add_query_arg( 'quiz-page', $sensei_question_loop['current_page'] + 1 ) ); ?>"
 						class="wp-block-button__link button sensei-stop-double-submission sensei-quiz-pagination__next-button"
+						style="<?php echo esc_attr( $sensei_button_inline_styles ); ?>"
 					>
 						<?php esc_attr_e( 'Next', 'sensei-lms' ); ?>
 					</button>
 				</div>
 			<?php elseif ( $sensei_is_quiz_available && ! $sensei_is_quiz_completed ) : ?>
 				<div class="sensei-quiz-action wp-block-button">
-					<button type="submit" name="quiz_complete" class="wp-block-button__link button quiz-submit complete sensei-stop-double-submission">
+					<button
+						type="submit"
+						name="quiz_complete"
+						class="wp-block-button__link button quiz-submit complete sensei-stop-double-submission"
+						style="<?php echo esc_attr( $sensei_button_inline_styles ); ?>"
+					>
 						<?php esc_attr_e( 'Complete', 'sensei-lms' ); ?>
 					</button>
 

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-lesson-quiz-controller.php
@@ -184,6 +184,8 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 				'_failed_indicate_incorrect'   => 'yes',
 				'_failed_show_answer_feedback' => 'yes',
 				'_failed_show_correct_answers' => 'no',
+				'_button_text_color'           => '#ffffff',
+				'_button_background_color'     => '#000000',
 			],
 		];
 		list( $lesson_id ) = $this->create_lesson_with_quiz( $quiz_args );
@@ -199,6 +201,8 @@ class Sensei_REST_API_Lesson_Quiz_Controller_Tests extends WP_Test_REST_TestCase
 		$this->assertTrue( $response_data['options']['failed_indicate_incorrect'] );
 		$this->assertTrue( $response_data['options']['failed_show_answer_feedback'] );
 		$this->assertFalse( $response_data['options']['failed_show_correct_answers'] );
+		$this->assertEquals( '#ffffff', $response_data['options']['button_text_color'] );
+		$this->assertEquals( '#000000', $response_data['options']['button_background_color'] );
 
 		$another_quiz_args = [
 			'meta_input' => [


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add quiz block button color settings.
* Move the pagination progress bar color settings code to the quiz block.

### Testing instructions

* Go to the quiz block settings.
* Go to the "Color settings" section.
* Pick button colors.
* Make sure the colors are used in the frontend.
* Unselect the colors.
* Make sure the buttons are back in their default state.

### Screenshot / Video

Quiz block color settings:
<img width="277" alt="Screenshot on 2022-01-13 at 17-11-06" src="https://user-images.githubusercontent.com/1612178/149356172-b5f6d82e-9fa7-414a-a605-9639ada9b978.png">

Without pagination:
<img width="609" alt="Screenshot on 2022-01-13 at 17-11-42" src="https://user-images.githubusercontent.com/1612178/149356395-bb6df1e4-d4fd-4a24-9570-68870638837b.png">

With pagination:
<img width="617" alt="Screenshot on 2022-01-13 at 17-12-28" src="https://user-images.githubusercontent.com/1612178/149356402-2fff3d22-f179-49e8-a4a3-5f483eb29e75.png">

