### PR TITLE
Add quiz progress notice on Lesson page

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -59,7 +59,7 @@ class Sensei_Course_Theme_Lesson {
 	 */
 	private function maybe_add_quiz_results_notice() {
 		$lesson_id = \Sensei_Utils::get_current_lesson();
-		$user_id   = wp_get_current_user()->ID;
+		$user_id   = get_current_user_id();
 
 		if ( empty( $lesson_id ) || empty( $user_id ) ) {
 			return;

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -114,6 +114,10 @@ class Sensei_Course_Theme_Option {
 			$url = Sensei_Course_Theme::instance()->get_theme_redirect_url( $url );
 		}
 
+		if ( ! empty( $_SERVER['QUERY_STRING'] ) ) {
+			$url = esc_url_raw( wp_unslash( $url . '?' . $_SERVER['QUERY_STRING'] ) );
+		}
+
 		wp_safe_redirect( $url );
 
 		/**

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -34,6 +34,38 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Testing quiz progress notice.
+	 */
+	public function testQuizProgressNotice() {
+		$lesson_id = $this->factory->get_lesson_with_quiz_and_questions(); // It creates a quiz with 3 questions.
+		$lesson    = get_post( $lesson_id );
+		$quiz_id   = Sensei()->lesson->lesson_quizzes( $lesson_id );
+		$questions = Sensei()->lesson->lesson_quiz_questions( $quiz_id );
+
+		$this->login_as_student();
+		$GLOBALS['post'] = $lesson;
+
+		$user_id = get_current_user_id();
+
+		Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
+
+		// Create the sample data to save.
+		$user_quiz_answers = [
+			$questions[0]->ID => '0',
+			$questions[1]->ID => 'false',
+			$questions[2]->ID => '',
+		];
+		$lesson_data_saved = Sensei()->quiz->save_user_answers( $user_quiz_answers, array(), $lesson_id, $user_id );
+
+		\Sensei_Course_Theme_Lesson::instance()->init();
+
+		$html = \Sensei_Context_Notices::instance( 'course_theme_lesson_quiz' )->get_notices_html( 'course-theme/lesson-quiz-notice.php' );
+
+		$this->assertContains( 'Lesson quiz in progress', $html, 'Should return quiz progress notice' );
+		$this->assertContains( '2 of 3', $html, 'Should return quiz progress notice' );
+	}
+
+	/**
 	 * Testing quiz ungraded notice.
 	 */
 	public function testQuizUngradedNotice() {


### PR DESCRIPTION
Fixes #4581

### Changes proposed in this Pull Request

* It introduces a notice on the lesson page when the quiz is saved and in progress.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create a course with a lesson and a quiz. Add some questions to the quiz.
* As a student, go to the quiz, answer some questions, and save it (it needs to be done with learning mode enabled because it's not fixed for learning mode yet).
* Enable the learning mode (course editor sidebar).
* Visit the lesson page, and make sure you see the notice with the quiz progress, and a link to the quiz.
* Now, in the quiz settings, set a pagination.
* Check that the "Continue quiz" link from the notice goes to the page with the first unanswered question.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="935" alt="Screen Shot 2022-01-14 at 10 37 54" src="https://user-images.githubusercontent.com/876340/149524093-5227c3a0-f44b-419e-85d4-d79e0af4d447.png">
