### PR TITLE
Add indicator on Grading menu that displays number of ungraded quizzes

### DIFF
--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -456,7 +456,8 @@ class Sensei_Grading {
 		}
 		$query .= ' GROUP BY comment_approved';
 
-		$counts = wp_cache_get( $cache_key, 'counts' );
+		// $counts = wp_cache_get( $cache_key, 'counts' );
+		$counts = false;
 		if ( false === $counts ) {
 			$sql     = $wpdb->prepare( $query, $type );
 			$results = (array) $wpdb->get_results( $sql, ARRAY_A );
@@ -465,7 +466,7 @@ class Sensei_Grading {
 			foreach ( $results as $row ) {
 				$counts[ $row['comment_approved'] ] = $row['total'];
 			}
-			wp_cache_set( $cache_key, $counts, 'counts' );
+			// wp_cache_set( $cache_key, $counts, 'counts' );
 		}
 
 		if ( ! isset( $counts['graded'] ) ) {

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -65,7 +65,7 @@ class Sensei_Grading {
 			$indicator_html = ' <span class="awaiting-mod">' . esc_html( $grading_counts['ungraded'] ) . '</span>';
 		}
 
-		// if ( current_user_can( 'manage_sensei_grades' ) ) {
+		if ( current_user_can( 'manage_sensei_grades' ) ) {
 			add_submenu_page(
 				'edit.php?post_type=course',
 				__( 'Grading', 'sensei-lms' ),
@@ -74,7 +74,7 @@ class Sensei_Grading {
 				$this->page_slug,
 				array( $this, 'grading_page' )
 			);
-		// }
+		}
 	}
 
 	/**

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -65,7 +65,7 @@ class Sensei_Grading {
 			$indicator_html = ' <span class="awaiting-mod">' . esc_html( $grading_counts['ungraded'] ) . '</span>';
 		}
 
-		if ( current_user_can( 'manage_sensei_grades' ) ) {
+		// if ( current_user_can( 'manage_sensei_grades' ) ) {
 			add_submenu_page(
 				'edit.php?post_type=course',
 				__( 'Grading', 'sensei-lms' ),
@@ -74,7 +74,7 @@ class Sensei_Grading {
 				$this->page_slug,
 				array( $this, 'grading_page' )
 			);
-		}
+		// }
 	}
 
 	/**

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -52,24 +52,29 @@ class Sensei_Grading {
 	}
 
 	/**
-	 * grading_admin_menu function.
+	 * Add the Grading menu.
 	 *
 	 * @since  1.3.0
 	 * @access public
-	 * @return void
 	 */
 	public function grading_admin_menu() {
+		$indicator_html = '';
+		$grading_counts = Sensei()->grading->count_statuses( apply_filters( 'sensei_grading_count_statues', [ 'type' => 'lesson' ] ) );
+
+		if ( $grading_counts['ungraded'] > 0 ) {
+			$indicator_html = ' <span class="awaiting-mod">' . esc_html( $grading_counts['ungraded'] ) . '</span>';
+		}
+
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
 			add_submenu_page(
 				'edit.php?post_type=course',
 				__( 'Grading', 'sensei-lms' ),
-				__( 'Grading', 'sensei-lms' ),
+				__( 'Grading', 'sensei-lms' ) . $indicator_html,
 				'manage_sensei_grades',
 				$this->page_slug,
 				array( $this, 'grading_page' )
 			);
 		}
-
 	}
 
 	/**

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -456,7 +456,7 @@ class Sensei_Grading {
 		}
 		$query .= ' GROUP BY comment_approved';
 
-		// $counts = wp_cache_get( $cache_key, 'counts' );
+		$counts = wp_cache_get( $cache_key, 'counts' );
 		$counts = false;
 		if ( false === $counts ) {
 			$sql     = $wpdb->prepare( $query, $type );
@@ -466,7 +466,7 @@ class Sensei_Grading {
 			foreach ( $results as $row ) {
 				$counts[ $row['comment_approved'] ] = $row['total'];
 			}
-			// wp_cache_set( $cache_key, $counts, 'counts' );
+			wp_cache_set( $cache_key, $counts, 'counts' );
 		}
 
 		if ( ! isset( $counts['graded'] ) ) {

--- a/tests/unit-tests/admin/test-class-sensei-extensions.php
+++ b/tests/unit-tests/admin/test-class-sensei-extensions.php
@@ -11,6 +11,13 @@
 class Sensei_Extensions_Test extends WP_UnitTestCase {
 	use Sensei_Test_Login_Helpers;
 
+	public function tearDown() {
+		parent::tearDown();
+
+		global $submenu;
+		unset( $submenu['edit.php?post_type=course'] );
+	}
+
 	/**
 	 * Testing the Sensei Extensions class to make sure it is loaded.
 	 */

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -32,44 +32,6 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that ungraded quiz count is displayed in the Grading menu.
-	 *
-	 * @covers Sensei_Grading::grading_admin_menu
-	 */
-	public function testGradingAdminMenuTitleWithIndicator() {
-		$user_id    = $this->factory->user->create();
-		$course_id  = $this->factory->course->create();
-		$lesson_ids = $this->factory->lesson->create_many( 5 );
-
-		foreach ( $lesson_ids as $lesson_id ) {
-			add_post_meta( $lesson_id, '_lesson_course', $course_id );
-		}
-
-		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[0], 'passed' );
-		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[1], 'ungraded' );
-		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[2], 'failed' );
-		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[3], 'ungraded' );
-		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[4], 'graded' );
-
-		$this->login_as_admin();
-
-		Sensei()->grading->grading_admin_menu();
-
-		global $submenu;
-
-		$grading_menu = '';
-
-		foreach ( $submenu['edit.php?post_type=course'] as $submenu_item ) {
-			if ( in_array( 'Grading', $submenu_item, true ) ) {
-				$grading_menu = $submenu_item;
-				break;
-			}
-		}
-
-		$this->assertEquals( 'Grading <span class="awaiting-mod">2</span>', $grading_menu, 'Should count 2 available updates' );
-	}
-
-	/**
 	 * Tests that ungraded quiz count is not displayed in the Grading menu.
 	 *
 	 * @covers Sensei_Grading::grading_admin_menu
@@ -105,6 +67,44 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		}
 
 		$this->assertEquals( 'Grading', $grading_menu[0], 'Should not have indicator when there are no ungraded quizzes' );
+	}
+
+	/**
+	 * Tests that ungraded quiz count is displayed in the Grading menu.
+	 *
+	 * @covers Sensei_Grading::grading_admin_menu
+	 */
+	public function testGradingAdminMenuTitleWithIndicator() {
+		$user_id    = $this->factory->user->create();
+		$course_id  = $this->factory->course->create();
+		$lesson_ids = $this->factory->lesson->create_many( 5 );
+
+		foreach ( $lesson_ids as $lesson_id ) {
+			add_post_meta( $lesson_id, '_lesson_course', $course_id );
+		}
+
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[0], 'passed' );
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[1], 'ungraded' );
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[2], 'failed' );
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[3], 'ungraded' );
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[4], 'graded' );
+
+		$this->login_as_admin();
+
+		Sensei()->grading->grading_admin_menu();
+
+		global $submenu;
+
+		$grading_menu = '';
+
+		foreach ( $submenu['edit.php?post_type=course'] as $submenu_item ) {
+			if ( in_array( 'Grading', $submenu_item, true ) ) {
+				$grading_menu = $submenu_item;
+				break;
+			}
+		}
+
+		$this->assertEquals( 'Grading <span class="awaiting-mod">2</span>', $grading_menu[0], 'Should count 2 available updates' );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -56,9 +56,9 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 
 		global $submenu;
 
-		$this->assertEquals( 'Grading', $submenu['edit.php?post_type=course'][0][0], 'Should not have indicator when there are no ungraded quizzes' );
+		$this->assertEquals( 'Grading', end( $submenu['edit.php?post_type=course'] )[0], 'Should not have indicator when there are no ungraded quizzes' );
 
-		// Clean up the menu.
+		// Clean up the submenu.
 		unset( $submenu['edit.php?post_type=course'] );
 	}
 
@@ -87,9 +87,9 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 
 		global $submenu;
 
-		$this->assertEquals( 'Grading <span class="awaiting-mod">2</span>', $submenu['edit.php?post_type=course'][0][0], 'Should count 2 available updates' );
+		$this->assertEquals( 'Grading <span class="awaiting-mod">2</span>', end( $submenu['edit.php?post_type=course'] )[0], 'Should display 2 ungraded quizzes' );
 
-		// Clean up the menu.
+		// Clean up the submenu.
 		unset( $submenu['edit.php?post_type=course'] );
 	}
 

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -79,15 +79,24 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		$course_id  = $this->factory->course->create();
 		$lesson_ids = $this->factory->lesson->create_many( 5 );
 
+		print_r( 'USER ID ' . $user_id, true );
+		print_r( 'COURSE ID ' . $course_id, true );
+
 		foreach ( $lesson_ids as $lesson_id ) {
-			add_post_meta( $lesson_id, '_lesson_course', $course_id );
+			add_post_meta( $lesson_id, '_lesson_course', $course_id, true );
+			print_r( 'LESSON ID ' . $lesson_id );
 		}
 
+		// TODO: Problem is either with data setup. Maybe caching?
+		// Update sensei_lesson_status
+		// SELECT comment_approved, COUNT( * ) AS total FROM {$wpdb->comments} WHERE comment_type = 'sensei_lesson_status' GROUP BY comment_approved
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[0], 'passed' );
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[1], 'ungraded' );
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[2], 'failed' );
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[3], 'ungraded' );
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[4], 'graded' );
+
+		print_r( Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] ), true );
 
 		$this->login_as_admin();
 
@@ -104,6 +113,18 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 			}
 		}
 
+				//Real data (
+	//     [0] => Grading <span class="awaiting-mod">1</span>
+	//     [1] => manage_sensei_grades
+	//     [2] => sensei_grading
+	//     [3] => Grading
+	// )
+
+		// --- Expected
+		// +++ Actual
+		// @@ @@
+		// -'Grading <span class="awaiting-mod">2</span>'
+		// +'Grading'
 		$this->assertEquals( 'Grading <span class="awaiting-mod">2</span>', $grading_menu[0], 'Should count 2 available updates' );
 	}
 

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -89,9 +89,6 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[3], 'ungraded' );
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[4], 'graded' );
 
-		$this->expectOutputString('');
-		print_r( Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] ), true );
-
 		$this->login_as_admin();
 
 		Sensei()->grading->grading_admin_menu();
@@ -106,6 +103,8 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 				break;
 			}
 		}
+
+		$this->assertArrayHasKey( 'foo', Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] ) );
 
 				//Real data (
 	//     [0] => Grading <span class="awaiting-mod">1</span>

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -84,19 +84,15 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 
 		foreach ( $lesson_ids as $lesson_id ) {
 			add_post_meta( $lesson_id, '_lesson_course', $course_id, true );
-			print_r( 'LESSON ID ' . $lesson_id );
 		}
 
-		// TODO: Problem is either with data setup. Maybe caching?
-		// Update sensei_lesson_status
-		// SELECT comment_approved, COUNT( * ) AS total FROM {$wpdb->comments} WHERE comment_type = 'sensei_lesson_status' GROUP BY comment_approved
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[0], 'passed' );
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[1], 'ungraded' );
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[2], 'failed' );
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[3], 'ungraded' );
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[4], 'graded' );
 
-		print_r( 'STATUSES ' . Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] ) );
+		print_r( 'STATUSES ' . Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] ), true );
 
 		$this->login_as_admin();
 

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -1,6 +1,8 @@
 <?php
 
 class Sensei_Class_Grading_Test extends WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+
 	/**
 	 * setup function
 	 *

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -57,6 +57,8 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 
 		global $submenu;
 
+		print_r( $submenu, true );
+
 		$this->assertTrue(
 			in_array( 'Grading <span class="awaiting-mod">2</span>', $submenu['edit.php?post_type=course'][20], true ),
 			'Should count 2 available updates'

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -57,10 +57,17 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 
 		global $submenu;
 
-		print_r( $submenu, true );
+		$grading_menu = '';
+
+		foreach ( $submenu['edit.php?post_type=course'] as $submenu_item ) {
+			if ( in_array( 'Grading', $submenu_item ) ) {
+				$grading_menu = $submenu_item;
+				break;
+			}
+		}
 
 		$this->assertTrue(
-			in_array( 'Grading <span class="awaiting-mod">2</span>', $submenu['edit.php?post_type=course'][20], true ),
+			in_array( 'Grading <span class="awaiting-mod">2</span>', $grading_menu, true ),
 			'Should count 2 available updates'
 		);
 	}

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -79,9 +79,6 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		$course_id  = $this->factory->course->create();
 		$lesson_ids = $this->factory->lesson->create_many( 5 );
 
-		print_r( 'USER ID ' . $user_id);
-		print_r( 'COURSE ID ' . $course_id );
-
 		foreach ( $lesson_ids as $lesson_id ) {
 			add_post_meta( $lesson_id, '_lesson_course', $course_id, true );
 		}
@@ -92,7 +89,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[3], 'ungraded' );
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[4], 'graded' );
 
-		print_r( 'STATUSES ' . Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] ), true );
+		print_r( Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] ), true );
 
 		$this->login_as_admin();
 

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -37,7 +37,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	public function testGradingAdminMenuTitleWithIndicator() {
 		$user_id    = $this->factory->user->create();
 		$course_id  = $this->factory->course->create();
-		$lesson_ids = $this->lesson->create_many( 5 );
+		$lesson_ids = $this->factory->lesson->create_many( 5 );
 
 		foreach ( $lesson_ids as $lesson_id ) {
 			add_post_meta( $lesson_id, '_lesson_course', $course_id );

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -79,8 +79,8 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		$course_id  = $this->factory->course->create();
 		$lesson_ids = $this->factory->lesson->create_many( 5 );
 
-		print_r( 'USER ID ' . $user_id, true );
-		print_r( 'COURSE ID ' . $course_id, true );
+		print_r( 'USER ID ' . $user_id);
+		print_r( 'COURSE ID ' . $course_id );
 
 		foreach ( $lesson_ids as $lesson_id ) {
 			add_post_meta( $lesson_id, '_lesson_course', $course_id, true );
@@ -96,7 +96,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[3], 'ungraded' );
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[4], 'graded' );
 
-		print_r( Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] ), true );
+		print_r( 'STATUSES ' . Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] ) );
 
 		$this->login_as_admin();
 

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -53,7 +53,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 
 		$this->login_as_admin();
 
-		Sensei_Grading::instance()->grading_admin_menu();
+		Sensei()->grading->grading_admin_menu();
 
 		global $submenu;
 

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -60,7 +60,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		$grading_menu = '';
 
 		foreach ( $submenu['edit.php?post_type=course'] as $submenu_item ) {
-			if ( in_array( 'Grading', $submenu_item ) ) {
+			if ( in_array( 'Grading', $submenu_item, true ) ) {
 				$grading_menu = $submenu_item;
 				break;
 			}

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -66,10 +66,45 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 			}
 		}
 
-		$this->assertTrue(
-			in_array( 'Grading <span class="awaiting-mod">2</span>', $grading_menu, true ),
-			'Should count 2 available updates'
-		);
+		$this->assertEquals( 'Grading <span class="awaiting-mod">2</span>', $grading_menu, 'Should count 2 available updates' );
+	}
+
+	/**
+	 * Tests that ungraded quiz count is not displayed in the Grading menu.
+	 *
+	 * @covers Sensei_Grading::grading_admin_menu
+	 */
+	public function testGradingAdminMenuTitleWithoutIndicator() {
+		$user_id    = $this->factory->user->create();
+		$course_id  = $this->factory->course->create();
+		$lesson_ids = $this->factory->lesson->create_many( 5 );
+
+		foreach ( $lesson_ids as $lesson_id ) {
+			add_post_meta( $lesson_id, '_lesson_course', $course_id );
+		}
+
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[0], 'passed' );
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[1], 'in-progress' );
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[2], 'failed' );
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[3], 'complete' );
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[4], 'graded' );
+
+		$this->login_as_admin();
+
+		Sensei()->grading->grading_admin_menu();
+
+		global $submenu;
+
+		$grading_menu = '';
+
+		foreach ( $submenu['edit.php?post_type=course'] as $submenu_item ) {
+			if ( in_array( 'Grading', $submenu_item, true ) ) {
+				$grading_menu = $submenu_item;
+				break;
+			}
+		}
+
+		$this->assertEquals( 'Grading', $grading_menu[0], 'Should not have indicator when there are no ungraded quizzes' );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -32,7 +32,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that ungraded quiz count is not displayed in the Grading menu.
+	 * Tests that the ungraded quiz count is not displayed in the Grading menu.
 	 *
 	 * @covers Sensei_Grading::grading_admin_menu
 	 */
@@ -52,25 +52,18 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[4], 'graded' );
 
 		$this->login_as_admin();
-
 		Sensei()->grading->grading_admin_menu();
 
 		global $submenu;
 
-		$grading_menu = '';
+		$this->assertEquals( 'Grading', $submenu['edit.php?post_type=course'][0][0], 'Should not have indicator when there are no ungraded quizzes' );
 
-		foreach ( $submenu['edit.php?post_type=course'] as $submenu_item ) {
-			if ( in_array( 'Grading', $submenu_item, true ) ) {
-				$grading_menu = $submenu_item;
-				break;
-			}
-		}
-
-		$this->assertEquals( 'Grading', $grading_menu[0], 'Should not have indicator when there are no ungraded quizzes' );
+		// Clean up the menu.
+		unset( $submenu['edit.php?post_type=course'] );
 	}
 
 	/**
-	 * Tests that ungraded quiz count is displayed in the Grading menu.
+	 * Tests that the ungraded quiz count is displayed in the Grading menu.
 	 *
 	 * @covers Sensei_Grading::grading_admin_menu
 	 */
@@ -90,35 +83,14 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[4], 'graded' );
 
 		$this->login_as_admin();
-
 		Sensei()->grading->grading_admin_menu();
 
 		global $submenu;
 
-		$grading_menu = '';
+		$this->assertEquals( 'Grading <span class="awaiting-mod">2</span>', $submenu['edit.php?post_type=course'][0][0], 'Should count 2 available updates' );
 
-		foreach ( $submenu['edit.php?post_type=course'] as $submenu_item ) {
-			if ( in_array( 'Grading', $submenu_item, true ) ) {
-				$grading_menu = $submenu_item;
-				break;
-			}
-		}
-
-		$this->assertArrayHasKey( 'foo', Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] ) );
-
-				//Real data (
-	//     [0] => Grading <span class="awaiting-mod">1</span>
-	//     [1] => manage_sensei_grades
-	//     [2] => sensei_grading
-	//     [3] => Grading
-	// )
-
-		// --- Expected
-		// +++ Actual
-		// @@ @@
-		// -'Grading <span class="awaiting-mod">2</span>'
-		// +'Grading'
-		$this->assertEquals( 'Grading <span class="awaiting-mod">2</span>', $grading_menu[0], 'Should count 2 available updates' );
+		// Clean up the menu.
+		unset( $submenu['edit.php?post_type=course'] );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -89,6 +89,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[3], 'ungraded' );
 		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[4], 'graded' );
 
+		$this->expectOutputString('');
 		print_r( Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] ), true );
 
 		$this->login_as_admin();

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -30,6 +30,38 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tests that ungraded quiz count is displayed in the Grading menu.
+	 *
+	 * @covers Sensei_Grading::grading_admin_menu
+	 */
+	public function testGradingAdminMenuTitleWithIndicator() {
+		$user_id    = $this->factory->user->create();
+		$course_id  = $this->factory->course->create();
+		$lesson_ids = $this->lesson->create_many( 5 );
+
+		foreach ( $lesson_ids as $lesson_id ) {
+			add_post_meta( $lesson_id, '_lesson_course', $course_id );
+		}
+
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[0], 'passed' );
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[1], 'ungraded' );
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[2], 'failed' );
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[3], 'ungraded' );
+		Sensei_Utils::update_lesson_status( $user_id, $lesson_ids[4], 'graded' );
+
+		$this->login_as_admin();
+
+		Sensei_Grading::instance()->grading_admin_menu();
+
+		global $submenu;
+
+		$this->assertTrue(
+			in_array( 'Grading <span class="awaiting-mod">2</span>', $submenu['edit.php?post_type=course'][20], true ),
+			'Should count 2 available updates'
+		);
+	}
+
+	/**
 	 * Data source for ::testGradeGapFillQuestionRegEx
 	 *
 	 * @return array


### PR DESCRIPTION
Fixes #

### Changes proposed in this Pull Request

*

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
*

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
