### PR TITLE
Move Import and Export to the Tools page

### DIFF
--- a/assets/setup-wizard/ready/index.js
+++ b/assets/setup-wizard/ready/index.js
@@ -95,7 +95,7 @@ export const Ready = () => {
 										<Button
 											className="sensei-setup-wizard__button"
 											isSecondary
-											href="admin.php?page=sensei_import"
+											href="edit.php?post_type=course&page=sensei-tools&tool=import-content"
 											{ ...logLink(
 												'setup_wizard_ready_import'
 											) }

--- a/assets/setup-wizard/ready/index.test.js
+++ b/assets/setup-wizard/ready/index.test.js
@@ -80,7 +80,9 @@ describe( '<Ready />', () => {
 			queryByText( 'Import content', {
 				selector: 'a',
 			} ).getAttribute( 'href' )
-		).toEqual( 'admin.php?page=sensei_import' );
+		).toEqual(
+			'edit.php?post_type=course&page=sensei-tools&tool=import-content'
+		);
 	} );
 
 	it( 'Should have a create your first course link.', () => {

--- a/includes/admin/class-sensei-tools.php
+++ b/includes/admin/class-sensei-tools.php
@@ -69,6 +69,7 @@ class Sensei_Tools {
 		if ( ! $this->tools ) {
 			$tools   = [];
 			$tools[] = new Sensei_Tool_Import();
+			$tools[] = new Sensei_Tool_Export();
 			$tools[] = new Sensei_Tool_Recalculate_Enrolment();
 			$tools[] = new Sensei_Tool_Recalculate_Course_Enrolment();
 			$tools[] = new Sensei_Tool_Ensure_Roles();

--- a/includes/admin/class-sensei-tools.php
+++ b/includes/admin/class-sensei-tools.php
@@ -68,6 +68,7 @@ class Sensei_Tools {
 	public function get_tools() {
 		if ( ! $this->tools ) {
 			$tools   = [];
+			$tools[] = new Sensei_Tool_Import();
 			$tools[] = new Sensei_Tool_Recalculate_Enrolment();
 			$tools[] = new Sensei_Tool_Recalculate_Course_Enrolment();
 			$tools[] = new Sensei_Tool_Ensure_Roles();

--- a/includes/admin/tools/class-sensei-tool-export.php
+++ b/includes/admin/tools/class-sensei-tool-export.php
@@ -21,11 +21,7 @@ class Sensei_Tool_Export implements Sensei_Tool_Interface, Sensei_Tool_Interacti
 	 * Output tool view for interactive action methods.
 	 */
 	public function output() {
-		?>
-		<div id="sensei-export-page-wrapper" class="wrap">
-			<div id="sensei-export-page" class="sensei-export"></div>
-		</div>
-		<?php
+		include __DIR__ . '/views/html-export.php';
 	}
 
 	/**

--- a/includes/admin/tools/class-sensei-tool-export.php
+++ b/includes/admin/tools/class-sensei-tool-export.php
@@ -21,7 +21,11 @@ class Sensei_Tool_Export implements Sensei_Tool_Interface, Sensei_Tool_Interacti
 	 * Output tool view for interactive action methods.
 	 */
 	public function output() {
-		include __DIR__ . '/views/html-export.php';
+		?>
+		<div id="sensei-export-page-wrapper" class="wrap">
+			<div id="sensei-export-page" class="sensei-export"></div>
+		</div>
+		<?php
 	}
 
 	/**

--- a/includes/admin/tools/class-sensei-tool-export.php
+++ b/includes/admin/tools/class-sensei-tool-export.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * File containing Sensei_Tool_Export class.
+ *
+ * @package sensei-lms
+ * @since 4.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Sensei_Tool_Export class.
+ *
+ * @package sensei-lms
+ * @since 4.0.0
+ */
+class Sensei_Tool_Export implements Sensei_Tool_Interface, Sensei_Tool_Interactive_Interface {
+
+	public function output() {
+		include __DIR__ . '/views/html-export.php';
+	}
+
+	public function get_id() {
+		return 'export-content';
+	}
+
+	public function get_name() {
+		return __( 'Export Content', 'sensei-lms' );
+	}
+
+	public function get_description() {
+		return __( 'Export courses, lessons, and questions to a CSV file.', 'sensei-lms' );
+	}
+
+	public function process() {
+		add_action(
+			'admin_print_scripts',
+			function() {
+				Sensei()->assets->enqueue( 'sensei-export', 'data-port/export.js', [], true );
+				Sensei()->assets->preload_data( [ '/sensei-internal/v1/export/active' ] );
+			}
+		);
+
+		add_action(
+			'admin_print_styles',
+			function() {
+				Sensei()->assets->enqueue( 'sensei-export', 'data-port/style.css', [ 'sensei-wp-components' ] );
+			}
+		);
+	}
+
+	public function is_available() {
+		return true;
+	}
+}

--- a/includes/admin/tools/class-sensei-tool-export.php
+++ b/includes/admin/tools/class-sensei-tool-export.php
@@ -17,23 +17,43 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.0.0
  */
 class Sensei_Tool_Export implements Sensei_Tool_Interface, Sensei_Tool_Interactive_Interface {
-
+	/**
+	 * Output tool view for interactive action methods.
+	 */
 	public function output() {
 		include __DIR__ . '/views/html-export.php';
 	}
 
+	/**
+	 * Get the ID of the tool.
+	 *
+	 * @return string
+	 */
 	public function get_id() {
 		return 'export-content';
 	}
 
+	/**
+	 * Get the name of the tool.
+	 *
+	 * @return string
+	 */
 	public function get_name() {
 		return __( 'Export Content', 'sensei-lms' );
 	}
 
+	/**
+	 * Get the description of the tool.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( 'Export courses, lessons, and questions to a CSV file.', 'sensei-lms' );
 	}
 
+	/**
+	 * Run the tool.
+	 */
 	public function process() {
 		add_action(
 			'admin_print_scripts',
@@ -51,6 +71,11 @@ class Sensei_Tool_Export implements Sensei_Tool_Interface, Sensei_Tool_Interacti
 		);
 	}
 
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
 	public function is_available() {
 		return true;
 	}

--- a/includes/admin/tools/class-sensei-tool-import.php
+++ b/includes/admin/tools/class-sensei-tool-import.php
@@ -19,30 +19,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Tool_Import implements Sensei_Tool_Interface, Sensei_Tool_Interactive_Interface {
 
 	public function output() {
-		add_action(
-			'admin_print_scripts',
-			function() {
-				Sensei()->assets->enqueue( 'sensei-import', 'data-port/import.js', [], true );
-				Sensei()->assets->preload_data( [ '/sensei-internal/v1/import/active' ] );
-			}
-		);
-
-		add_action(
-			'admin_print_styles',
-			function() {
-				Sensei()->assets->enqueue( 'sensei-import', 'data-port/style.css', [ 'sensei-wp-components' ] );
-			}
-		);
-		?>
-		<div id="sensei-import-page-wrapper" class="wrap">
-			<h1>
-				<?php echo wp_kses_post( get_admin_page_title() ); ?>
-			</h1>
-			<div id="sensei-import-page" class="sensei-import">
-
-			</div>
-		</div>
-	<?php	}
+		include __DIR__ . '/views/html-import.php';
+	}
 
 	public function get_id() {
 		return 'import-content';
@@ -57,7 +35,20 @@ class Sensei_Tool_Import implements Sensei_Tool_Interface, Sensei_Tool_Interacti
 	}
 
 	public function process() {
-		// TODO: Implement process() method.
+		add_action(
+			'admin_print_scripts',
+			function() {
+				Sensei()->assets->enqueue( 'sensei-import', 'data-port/import.js', [], true );
+				Sensei()->assets->preload_data( [ '/sensei-internal/v1/import/active' ] );
+			}
+		);
+
+		add_action(
+			'admin_print_styles',
+			function() {
+				Sensei()->assets->enqueue( 'sensei-import', 'data-port/style.css', [ 'sensei-wp-components' ] );
+			}
+		);
 	}
 
 	public function is_available() {

--- a/includes/admin/tools/class-sensei-tool-import.php
+++ b/includes/admin/tools/class-sensei-tool-import.php
@@ -21,7 +21,11 @@ class Sensei_Tool_Import implements Sensei_Tool_Interface, Sensei_Tool_Interacti
 	 * Output tool view for interactive action methods.
 	 */
 	public function output() {
-		include __DIR__ . '/views/html-import.php';
+		?>
+		<div id="sensei-import-page-wrapper" class="wrap">
+			<div id="sensei-import-page" class="sensei-import"></div>
+		</div>
+		<?php
 	}
 
 	/**

--- a/includes/admin/tools/class-sensei-tool-import.php
+++ b/includes/admin/tools/class-sensei-tool-import.php
@@ -21,11 +21,7 @@ class Sensei_Tool_Import implements Sensei_Tool_Interface, Sensei_Tool_Interacti
 	 * Output tool view for interactive action methods.
 	 */
 	public function output() {
-		?>
-		<div id="sensei-import-page-wrapper" class="wrap">
-			<div id="sensei-import-page" class="sensei-import"></div>
-		</div>
-		<?php
+		include __DIR__ . '/views/html-import.php';
 	}
 
 	/**

--- a/includes/admin/tools/class-sensei-tool-import.php
+++ b/includes/admin/tools/class-sensei-tool-import.php
@@ -17,23 +17,43 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 4.0.0
  */
 class Sensei_Tool_Import implements Sensei_Tool_Interface, Sensei_Tool_Interactive_Interface {
-
+	/**
+	 * Output tool view for interactive action methods.
+	 */
 	public function output() {
 		include __DIR__ . '/views/html-import.php';
 	}
 
+	/**
+	 * Get the ID of the tool.
+	 *
+	 * @return string
+	 */
 	public function get_id() {
 		return 'import-content';
 	}
 
+	/**
+	 * Get the name of the tool.
+	 *
+	 * @return string
+	 */
 	public function get_name() {
 		return __( 'Import Content', 'sensei-lms' );
 	}
 
+	/**
+	 * Get the description of the tool.
+	 *
+	 * @return string
+	 */
 	public function get_description() {
 		return __( 'Import courses, lessons, and questions from a CSV file.', 'sensei-lms' );
 	}
 
+	/**
+	 * Run the tool.
+	 */
 	public function process() {
 		add_action(
 			'admin_print_scripts',
@@ -51,6 +71,11 @@ class Sensei_Tool_Import implements Sensei_Tool_Interface, Sensei_Tool_Interacti
 		);
 	}
 
+	/**
+	 * Is the tool currently available?
+	 *
+	 * @return bool True if tool is available.
+	 */
 	public function is_available() {
 		return true;
 	}

--- a/includes/admin/tools/class-sensei-tool-import.php
+++ b/includes/admin/tools/class-sensei-tool-import.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * File containing Sensei_Tool_Import class.
+ *
+ * @package sensei-lms
+ * @since 4.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Sensei_Tool_Import class.
+ *
+ * @package sensei-lms
+ * @since 4.0.0
+ */
+class Sensei_Tool_Import implements Sensei_Tool_Interface, Sensei_Tool_Interactive_Interface {
+
+	public function output() {
+		add_action(
+			'admin_print_scripts',
+			function() {
+				Sensei()->assets->enqueue( 'sensei-import', 'data-port/import.js', [], true );
+				Sensei()->assets->preload_data( [ '/sensei-internal/v1/import/active' ] );
+			}
+		);
+
+		add_action(
+			'admin_print_styles',
+			function() {
+				Sensei()->assets->enqueue( 'sensei-import', 'data-port/style.css', [ 'sensei-wp-components' ] );
+			}
+		);
+		?>
+		<div id="sensei-import-page-wrapper" class="wrap">
+			<h1>
+				<?php echo wp_kses_post( get_admin_page_title() ); ?>
+			</h1>
+			<div id="sensei-import-page" class="sensei-import">
+
+			</div>
+		</div>
+	<?php	}
+
+	public function get_id() {
+		return 'import-content';
+	}
+
+	public function get_name() {
+		return __( 'Import Content', 'sensei-lms' );
+	}
+
+	public function get_description() {
+		return __( 'Import courses, lessons, and questions from a CSV file.', 'sensei-lms' );
+	}
+
+	public function process() {
+		// TODO: Implement process() method.
+	}
+
+	public function is_available() {
+		return true;
+	}
+}

--- a/includes/admin/tools/views/html-export.php
+++ b/includes/admin/tools/views/html-export.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * File containing export tool view.
+ *
+ * @package sensei-lms
+ * @since 4.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+?>
+<div id="sensei-export-page-wrapper" class="wrap">
+	<div id="sensei-export-page" class="sensei-export"></div>
+</div>

--- a/includes/admin/tools/views/html-export.php
+++ b/includes/admin/tools/views/html-export.php
@@ -1,4 +1,0 @@
-<div id="sensei-export-page-wrapper" class="wrap">
-	<div id="sensei-export-page" class="sensei-export">
-	</div>
-</div>

--- a/includes/admin/tools/views/html-export.php
+++ b/includes/admin/tools/views/html-export.php
@@ -1,0 +1,4 @@
+<div id="sensei-export-page-wrapper" class="wrap">
+	<div id="sensei-export-page" class="sensei-export">
+	</div>
+</div>

--- a/includes/admin/tools/views/html-import.php
+++ b/includes/admin/tools/views/html-import.php
@@ -1,0 +1,16 @@
+<?php
+/**
+ * File containing import tool view.
+ *
+ * @package sensei-lms
+ * @since 4.0.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+?>
+<div id="sensei-import-page-wrapper" class="wrap">
+	<div id="sensei-import-page" class="sensei-import"></div>
+</div>

--- a/includes/admin/tools/views/html-import.php
+++ b/includes/admin/tools/views/html-import.php
@@ -1,0 +1,4 @@
+<div id="sensei-import-page-wrapper" class="wrap">
+	<div id="sensei-import-page" class="sensei-import">
+	</div>
+</div>

--- a/includes/admin/tools/views/html-import.php
+++ b/includes/admin/tools/views/html-import.php
@@ -1,4 +1,0 @@
-<div id="sensei-import-page-wrapper" class="wrap">
-	<div id="sensei-import-page" class="sensei-import">
-	</div>
-</div>

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -139,6 +139,7 @@ class Sensei_Autoloader {
 			'Sensei_Tool_Remove_Deleted_User_Data'        => 'admin/tools/class-sensei-tool-remove-deleted-user-data.php',
 			'Sensei_Tool_Module_Slugs_Mismatch'           => 'admin/tools/class-sensei-tool-module-slugs-mismatch.php',
 			'Sensei_Tool_Enrolment_Debug'                 => 'admin/tools/class-sensei-tool-enrolment-debug.php',
+			'Sensei_Tool_Import'                          => 'admin/tools/class-sensei-tool-import.php',
 
 			/**
 			 * Shortcodes

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -140,6 +140,7 @@ class Sensei_Autoloader {
 			'Sensei_Tool_Module_Slugs_Mismatch'           => 'admin/tools/class-sensei-tool-module-slugs-mismatch.php',
 			'Sensei_Tool_Enrolment_Debug'                 => 'admin/tools/class-sensei-tool-enrolment-debug.php',
 			'Sensei_Tool_Import'                          => 'admin/tools/class-sensei-tool-import.php',
+			'Sensei_Tool_Export'                          => 'admin/tools/class-sensei-tool-export.php',
 
 			/**
 			 * Shortcodes

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -236,7 +236,9 @@ describe( 'Setup Wizard', () => {
 			} );
 			await page.waitForNavigation();
 			await expect( page.url() ).toMatch(
-				adminUrl( 'admin.php?page=sensei_import' )
+				adminUrl(
+					'edit.php?post_type=course&page=sensei-tools&tool=import-content'
+				)
 			);
 		} );
 	} );


### PR DESCRIPTION
Fixes #4531 

### Changes proposed in this Pull Request

* Add Import and Export tools on the Tools page

### Testing instructions
* Add a course, lesson, questions
* Go to `Sensei LMS -> Tools`
* Click `Visit Tool` for `Export Content` and follow instructions.
* Go back to `Sensei LMS -> Tools`
* Click `Visit Tool` for `Import Content` and follow instructions.

### Screenshot / Video
<img width="1840" alt="CleanShot 2022-01-14 at 17 42 52@2x" src="https://user-images.githubusercontent.com/329356/149535090-33973f83-2f96-459b-b130-df83986908d4.png">
<img width="1829" alt="CleanShot 2022-01-14 at 17 50 27@2x" src="https://user-images.githubusercontent.com/329356/149535219-544b0f4d-cd37-4863-bb57-ef07a3158346.png">
<img width="1836" alt="CleanShot 2022-01-14 at 17 50 53@2x" src="https://user-images.githubusercontent.com/329356/149535231-3ac39f71-f0b0-4642-aef4-bf424d3111f2.png">

