### PR TITLE
Fix quiz settings link not centered on Astra

### DIFF
--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -90,13 +90,11 @@ const QuizSettings = ( {
 
 	return (
 		<>
-			<Button
-				className="sensei-lms-quiz-block__settings-link"
-				onClick={ openQuizSettings }
-				icon={ CogIcon }
-			>
-				{ __( 'Quiz settings', 'sensei-lms' ) }
-			</Button>
+			<div className="sensei-lms-quiz-block__settings-quick-nav">
+				<Button onClick={ openQuizSettings } icon={ CogIcon }>
+					{ __( 'Quiz settings', 'sensei-lms' ) }
+				</Button>
+			</div>
 			<InspectorControls>
 				<PanelBody
 					title={ __( 'Quiz settings', 'sensei-lms' ) }

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -72,13 +72,16 @@ $gray-400: #ccc;
 	}
 
 	/* Settings */
-	&__settings-link {
+	&__settings-quick-nav {
 		display: flex;
-		margin: 0 auto;
-		text-decoration: underline;
+		justify-content: center;
 
-		&:focus:not(:disabled) {
-			box-shadow: none;
+		button {
+			text-decoration: underline;
+
+			&:focus:not(:disabled) {
+				box-shadow: none;
+			}
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Center the quiz settings link (the new link that shows up below the quiz in edit mode) on the Astra theme.

### Testing instructions

* Switch to the Astra theme.
* Open the edit screen of a lesson.
* Make sure the "Quiz settings" link is centered.
