### PR TITLE
Fix lesson course metabox request infinite loop

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lesson-quiz-controller.php
@@ -357,7 +357,7 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 		$allow_retakes           = ! empty( $post_meta['_enable_quiz_reset'][0] ) && 'on' === $post_meta['_enable_quiz_reset'][0];
 		$failed_feedback_default = ! $allow_retakes;
 
-		$pagination = [
+		$pagination_defaults = [
 			'pagination_number'       => null,
 			'show_progress_bar'       => false,
 			'progress_bar_radius'     => 6,
@@ -366,8 +366,11 @@ class Sensei_REST_API_Lesson_Quiz_Controller extends \WP_REST_Controller {
 			'progress_bar_background' => null,
 		];
 
-		if ( ! empty( $post_meta['_pagination'][0] ) ) {
-			$pagination = json_decode( $post_meta['_pagination'][0], true ) ?? $pagination;
+		if ( empty( $post_meta['_pagination'][0] ) ) {
+			$pagination = $pagination_defaults;
+		} else {
+			$pagination = json_decode( $post_meta['_pagination'][0], true );
+			$pagination = $pagination ? $pagination : $pagination_defaults;
 		}
 
 		$quiz_data = [


### PR DESCRIPTION
### Changes proposed in this Pull Request

* The lesson course metabox goes into a request infinite loop after a new lesson is saved. This PR fixes that. The issue was related to the pagination settings not being populated.

### Testing instructions

* In the admin panel, create a new lesson post.
* Click the "publish" button.
* Check your devtools and make sure there are no looping requests in the networking tab.
* Change a few pagination settings and make sure they are saved as expected.