### PR TITLE
Minor tweaks to quiz and video settings

### DIFF
--- a/assets/blocks/quiz/quiz-block/pagination-settings.js
+++ b/assets/blocks/quiz/quiz-block/pagination-settings.js
@@ -27,7 +27,7 @@ const paginationOptions = [
 		value: SINGLE,
 	},
 	{
-		label: __( 'Multi-Page', 'sensei-lms' ),
+		label: __( 'Multi-page', 'sensei-lms' ),
 		value: MULTI,
 	},
 ];

--- a/assets/blocks/quiz/quiz-block/pagination-settings.js
+++ b/assets/blocks/quiz/quiz-block/pagination-settings.js
@@ -106,7 +106,7 @@ export const PaginationSidebarSettings = ( { settings, onChange } ) => {
 				title={ __( 'Pagination', 'sensei-lms' ) }
 				initialOpen={ true }
 			>
-				<PanelRow className="sensei-lms-quiz-block__pagination">
+				<PanelRow className="sensei-lms-quiz-block-settings__pagination">
 					<SelectControl
 						label={ __( 'Pagination', 'sensei-lms' ) }
 						hideLabelFromVision
@@ -116,7 +116,7 @@ export const PaginationSidebarSettings = ( { settings, onChange } ) => {
 					/>
 				</PanelRow>
 				{ paginationNumber !== null && (
-					<PanelRow className="sensei-lms-quiz-block__question-count">
+					<PanelRow className="sensei-lms-quiz-block-settings__question-count">
 						<QuestionsControl
 							settings={ settings }
 							onChange={ onChange }
@@ -141,7 +141,7 @@ export const PaginationSidebarSettings = ( { settings, onChange } ) => {
 								}
 							/>
 						</PanelRow>
-						<PanelRow className="sensei-lms-quiz-block__progress-bar">
+						<PanelRow className="sensei-lms-quiz-block-settings__progress-bar">
 							<NumberControl
 								label={ __( 'Radius', 'sensei-lms' ) }
 								min={ 1 }

--- a/assets/blocks/quiz/quiz.editor.scss
+++ b/assets/blocks/quiz/quiz.editor.scss
@@ -32,6 +32,24 @@ $gray-400: #ccc;
 	}
 }
 
+/* Block Settings */
+.sensei-lms-quiz-block-settings {
+	&__question-count,
+	&__progress-bar {
+		align-items: baseline;
+		justify-content: flex-start;
+
+		.components-base-control {
+			margin-bottom: 0;
+			margin-right: 1em;
+		}
+	}
+
+	&__question-count {
+		margin-bottom: 12px;
+	}
+}
+
 .sensei-lms-quiz-block {
 	&__separator {
 		position: relative;
@@ -88,21 +106,6 @@ $gray-400: #ccc;
 				box-shadow: none;
 			}
 		}
-	}
-
-	&__question-count,
-	&__progress-bar {
-		align-items: baseline;
-		justify-content: flex-start;
-
-		.components-base-control {
-			margin-bottom: 0;
-			margin-right: 1em;
-		}
-	}
-
-	&__question-count {
-		margin-bottom: 12px;
 	}
 
 	/* Toolbar */

--- a/assets/js/admin/course-video-sidebar.js
+++ b/assets/js/admin/course-video-sidebar.js
@@ -30,7 +30,7 @@ const CourseVideoSidebar = () => {
 			title={ __( 'Video', 'sensei-lms' ) }
 		>
 			<ToggleControl
-				label={ __( 'Autocomplete lesson', 'sensei-lms' ) }
+				label={ __( 'Autocomplete Lesson', 'sensei-lms' ) }
 				checked={ autocomplete }
 				onChange={ setAutocomplete }
 				help={ __( 'Complete lesson when video ends.', 'sensei-lms' ) }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Updates the CSS class names in the pagination settings so they don't conflict with CSS class names used by the block itself.
* Updates the case used in the quiz and video settings to match what we're doing elsewhere.

### Testing instructions

Ensure the quiz and video settings appear as in the following screenshots:

![Screen Shot 2022-01-14 at 4 39 38 PM](https://user-images.githubusercontent.com/1190420/149588847-ba84687d-c6df-4c18-ae30-c753b9d808f9.jpg)

![Screen Shot 2022-01-14 at 4 40 41 PM](https://user-images.githubusercontent.com/1190420/149588930-ad8e8547-433a-474b-8274-e35aadf94135.jpg)
