### PR TITLE
Return wp_nonce_field result instead of output it immediately

### DIFF
--- a/includes/blocks/class-sensei-block-contact-teacher.php
+++ b/includes/blocks/class-sensei-block-contact-teacher.php
@@ -100,7 +100,7 @@ class Sensei_Block_Contact_Teacher {
 	private function teacher_contact_form( $post ) {
 
 		$nonce         = wp_nonce_field( \Sensei_Messages::NONCE_ACTION_NAME, \Sensei_Messages::NONCE_FIELD_NAME, true, false );
-		$wp_rest_nonce = wp_nonce_field( 'wp_rest' );
+		$wp_rest_nonce = wp_nonce_field( 'wp_rest', '_wpnonce', true, false );
 
 		return '
 			<form name="contact-teacher" action="" method="post" class="sensei-contact-teacher-form" onsubmit="sensei.submitContactTeacher(event)">


### PR DESCRIPTION
Fixes #4640 

### Changes proposed in this Pull Request

1. Enable debug logs.
2. Open any existing course with a Contact teacher block in the editor.
3. Look at logs: no warnings are expected.
4. Run PHP unit tests: no excessive output expected.