### PR TITLE
Consolidate course module columns

### DIFF
--- a/assets/css/admin-custom.css
+++ b/assets/css/admin-custom.css
@@ -109,6 +109,15 @@ div.question_boolean_fields { margin-bottom: 10px; }
     padding-left: 2em !important;
 }
 
+.post-type-course .wp-list-table .button-link {
+	color: #2C3338;
+	display: inline-block;
+}
+
+.post-type-course .wp-list-table .button-link:not(:first-child) {
+	margin-top: 2em;
+}
+
 .sensei-inline-edit-col{
     margin-bottom: 2em !important;
     padding-left: 0.5em;

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -698,15 +698,18 @@ class Sensei_Course {
 		$new_columns['title']               = _x( 'Course Title', 'column name', 'sensei-lms' );
 		$new_columns['course-prerequisite'] = _x( 'Pre-requisite Course', 'column name', 'sensei-lms' );
 		$new_columns['course-category']     = _x( 'Category', 'column name', 'sensei-lms' );
+
+		if ( isset( $defaults['modules'] ) ) {
+			$new_columns['modules'] = $defaults['modules'];
+		}
+
 		if ( isset( $defaults['date'] ) ) {
 			$new_columns['date'] = $defaults['date'];
 		}
 
 		// Make sure other sensei columns stay directly behind the new columns.
 		$other_sensei_columns = [
-			'taxonomy-module',
 			'teacher',
-			'module_order',
 		];
 		foreach ( $other_sensei_columns as $column_key ) {
 			if ( isset( $defaults[ $column_key ] ) ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2457,7 +2457,7 @@ class Sensei_Lesson {
 
 		// Make sure other sensei columns stay directly behind the new columns.
 		$other_sensei_columns = [
-			'taxonomy-module',
+			'module',
 		];
 		foreach ( $other_sensei_columns as $column_key ) {
 			if ( isset( $defaults[ $column_key ] ) ) {

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -51,8 +51,8 @@ class Sensei_Core_Modules {
 
 		add_filter( 'manage_course_posts_columns', array( $this, 'course_columns' ), 11, 1 );
 		add_action( 'manage_course_posts_custom_column', array( $this, 'course_column_content' ), 11, 2 );
-		add_filter( 'manage_lesson_posts_columns', array( $this, 'lesson_columns' ), 11, 1 );
-		add_action( 'manage_lesson_posts_custom_column', array( $this, 'lesson_column_content' ), 11, 2 );
+		add_filter( 'manage_lesson_posts_columns', array( $this, 'add_lesson_columns' ), 11, 1 );
+		add_action( 'manage_lesson_posts_custom_column', array( $this, 'add_lesson_column_content' ), 11, 2 );
 
 		// Ensure modules always show under courses
 		add_action( 'admin_menu', array( $this, 'remove_lessons_menu_model_taxonomy' ), 10 );
@@ -1287,12 +1287,13 @@ class Sensei_Core_Modules {
 	/**
 	 * Add custom columns to lesson list table.
 	 *
-	 * @since 4.0.0
+	 * @since  4.0.0
+	 * @access private
 	 *
 	 * @param  array $columns Existing columns.
 	 * @return array          Modified columns.
 	 */
-	public function lesson_columns( $columns = array() ) {
+	public function add_lesson_columns( $columns = array() ) {
 		$columns['module'] = __( 'Module', 'sensei-lms' );
 
 		return $columns;
@@ -1301,13 +1302,13 @@ class Sensei_Core_Modules {
 	/**
 	 * Load content in the lesson custom columns.
 	 *
-	 * @since 4.0.0
+	 * @since  4.0.0
+	 * @access private
 	 *
 	 * @param  string  $column    Current column name.
 	 * @param  integer $lesson_id The lesson ID.
-	 * @return void
 	 */
-	public function lesson_column_content( $column = '', $lesson_id = 0 ) {
+	public function add_lesson_column_content( $column = '', $lesson_id = 0 ) {
 		if ( 'module' === $column ) {
 			$modules = wp_get_post_terms( $lesson_id, $this->taxonomy );
 			$module  = $modules && is_array( $modules ) ? $modules[0] : null;

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -46,6 +46,7 @@ class Sensei_Core_Modules {
 		add_action( 'sensei_user_lesson_reset', array( $this, 'save_lesson_module_progress' ), 10, 2 );
 		add_action( 'wp', array( $this, 'save_module_progress' ), 10 );
 
+		add_action( 'admin_menu', array( $this, 'add_submenus' ) );
 		add_action( 'admin_post_order_modules', array( $this, 'handle_order_modules' ) );
 		add_filter( 'manage_course_posts_columns', array( $this, 'course_columns' ), 11, 1 );
 		add_action( 'manage_course_posts_custom_column', array( $this, 'course_column_content' ), 11, 2 );
@@ -1071,6 +1072,22 @@ class Sensei_Core_Modules {
 
 		// Register new admin page for module ordering.
 		add_submenu_page( 'edit.php?post_type=course', __( 'Order Modules', 'sensei-lms' ), __( 'Order Modules', 'sensei-lms' ), 'edit_lessons', $this->order_page_slug, array( $this, 'module_order_screen' ) );
+	}
+
+	/**
+	 * Add admin screens.
+	 *
+	 * @since 4.0.0
+	 */
+	public function add_submenus() {
+		add_submenu_page(
+			null, // Hide the submenu.
+			__( 'Order Modules', 'sensei-lms' ),
+			__( 'Order Modules', 'sensei-lms' ),
+			'edit_lessons',
+			$this->order_page_slug,
+			array( $this, 'module_order_screen' )
+		);
 	}
 
 	/**

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1068,7 +1068,7 @@ class Sensei_Core_Modules {
 
 		// Register an admin page for module ordering.
 		add_submenu_page(
-			null, // Hide the submenu.
+			'options.php',
 			__( 'Order Modules', 'sensei-lms' ),
 			__( 'Order Modules', 'sensei-lms' ),
 			'edit_lessons',
@@ -1100,7 +1100,7 @@ class Sensei_Core_Modules {
 						'ordered'   => $ordered,
 						'course_id' => $_POST['course_id'],
 					),
-					admin_url( 'edit.php' )
+					admin_url( 'options.php' )
 				)
 			)
 		);
@@ -1131,7 +1131,7 @@ class Sensei_Core_Modules {
 
 			$courses = Sensei()->course->get_all_courses();
 
-			$html .= '<form action="' . esc_url( admin_url( 'edit.php' ) ) . '" method="get">' . "\n";
+			$html .= '<form method="get">' . "\n";
 			$html .= '<input type="hidden" name="post_type" value="course" />' . "\n";
 			$html .= '<input type="hidden" name="page" value="' . esc_attr( $this->order_page_slug ) . '" />' . "\n";
 			$html .= '<select id="module-order-course" name="course_id">' . "\n";
@@ -1251,7 +1251,7 @@ class Sensei_Core_Modules {
 				// Output the edit modules order link.
 				echo sprintf(
 					'<a class="button-link" href="%s">%s</a>',
-					esc_url( admin_url( 'edit.php?post_type=course&page=module-order&course_id=' . intval( $course_id ) ) ),
+					esc_url( admin_url( 'options.php?post_type=course&page=module-order&course_id=' . intval( $course_id ) ) ),
 					esc_html__( 'Order modules', 'sensei-lms' )
 				);
 			}
@@ -1662,7 +1662,7 @@ class Sensei_Core_Modules {
 		 */
 		$script_on_pages_white_list = apply_filters(
 			'sensei_module_admin_script_page_white_lists',
-			array( 'course_page_module-order' )
+			array( 'admin_page_module-order' )
 		);
 
 		// Only load module scripts when adding, editing or ordering modules or editing course/lesson.

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1243,28 +1243,28 @@ class Sensei_Core_Modules {
 	 */
 	public function course_column_content( $column = '', $course_id = 0 ) {
 		if ( 'modules' === $column ) {
-			$modules = $this->get_course_modules( $course_id );
+			$modules      = $this->get_course_modules( $course_id );
+			$module_links = [];
 
-			if ( $modules ) {
-				$module_links = [];
-				foreach ( $modules as $module ) {
-					$module_links[] = sprintf(
-						'<a href="%s">%s</a>',
-						esc_url(
-							add_query_arg(
-								[
-									'post_type'     => 'course',
-									$this->taxonomy => $module->slug,
-								],
-								admin_url( 'edit.php' )
-							)
-						),
-						esc_html( $module->name )
-					);
-				}
+			foreach ( $modules as $module ) {
+				$module_links[] = sprintf(
+					'<a href="%s">%s</a>',
+					esc_url(
+						add_query_arg(
+							[
+								'post_type'     => 'course',
+								$this->taxonomy => $module->slug,
+							],
+							admin_url( 'edit.php' )
+						)
+					),
+					esc_html( $module->name )
+				);
+			}
 
-				echo implode( ', ', $module_links ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is escaped in the array.
+			echo implode( ', ', $module_links ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is escaped in the array.
 
+			if ( count( $modules ) > 1 ) {
 				// Output the edit modules order link.
 				echo sprintf(
 					'<a class="button-link" href="%s">%s</a>',

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1278,7 +1278,7 @@ class Sensei_Core_Modules {
 							admin_url( 'edit.php' )
 						)
 					),
-					esc_html__( 'Order modules', 'sensei-lms' )
+					esc_html__( 'Order Modules', 'sensei-lms' )
 				);
 			}
 		}

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -46,9 +46,7 @@ class Sensei_Core_Modules {
 		add_action( 'sensei_user_lesson_reset', array( $this, 'save_lesson_module_progress' ), 10, 2 );
 		add_action( 'wp', array( $this, 'save_module_progress' ), 10 );
 
-		add_action( 'admin_menu', array( $this, 'register_modules_admin_menu_items' ), 30 );
 		add_action( 'admin_post_order_modules', array( $this, 'handle_order_modules' ) );
-
 		add_filter( 'manage_course_posts_columns', array( $this, 'course_columns' ), 11, 1 );
 		add_action( 'manage_course_posts_custom_column', array( $this, 'course_column_content' ), 11, 2 );
 		add_filter( 'manage_lesson_posts_columns', array( $this, 'add_lesson_columns' ), 11, 1 );
@@ -1058,24 +1056,21 @@ class Sensei_Core_Modules {
 	}
 
 	/**
-	 * Register admin pages related to modules.
+	 * Register admin screen for ordering modules
 	 *
 	 * @since 1.8.0
+	 * @deprecated 4.0.0
 	 *
 	 * @return void
 	 */
 	public function register_modules_admin_menu_items() {
+		_deprecated_function( __METHOD__, '4.0.0' );
 
-		// Register an admin page for module ordering.
-		add_submenu_page(
-			null, // Hide the submenu.
-			__( 'Order Modules', 'sensei-lms' ),
-			__( 'Order Modules', 'sensei-lms' ),
-			'edit_lessons',
-			$this->order_page_slug,
-			array( $this, 'module_order_screen' )
-		);
+		// add the modules link under the Course main menu
+		add_submenu_page( 'edit.php?post_type=course', __( 'Modules', 'sensei-lms' ), __( 'Modules', 'sensei-lms' ), 'manage_categories', 'edit-tags.php?taxonomy=module', '' );
 
+		// Register new admin page for module ordering.
+		add_submenu_page( 'edit.php?post_type=course', __( 'Order Modules', 'sensei-lms' ), __( 'Order Modules', 'sensei-lms' ), 'edit_lessons', $this->order_page_slug, array( $this, 'module_order_screen' ) );
 	}
 
 	/**

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -46,7 +46,9 @@ class Sensei_Core_Modules {
 		add_action( 'sensei_user_lesson_reset', array( $this, 'save_lesson_module_progress' ), 10, 2 );
 		add_action( 'wp', array( $this, 'save_module_progress' ), 10 );
 
+		add_action( 'admin_menu', array( $this, 'register_modules_admin_menu_items' ), 30 );
 		add_action( 'admin_post_order_modules', array( $this, 'handle_order_modules' ) );
+
 		add_filter( 'manage_course_posts_columns', array( $this, 'course_columns' ), 11, 1 );
 		add_action( 'manage_course_posts_custom_column', array( $this, 'course_column_content' ), 11, 2 );
 		add_filter( 'manage_lesson_posts_columns', array( $this, 'lesson_columns' ), 11, 1 );
@@ -1056,21 +1058,24 @@ class Sensei_Core_Modules {
 	}
 
 	/**
-	 * Register admin screen for ordering modules
+	 * Register admin pages related to modules.
 	 *
 	 * @since 1.8.0
-	 * @deprecated 4.0.0
 	 *
 	 * @return void
 	 */
 	public function register_modules_admin_menu_items() {
-		_deprecated_function( __METHOD__, '4.0.0' );
 
-		// add the modules link under the Course main menu
-		add_submenu_page( 'edit.php?post_type=course', __( 'Modules', 'sensei-lms' ), __( 'Modules', 'sensei-lms' ), 'manage_categories', 'edit-tags.php?taxonomy=module', '' );
+		// Register an admin page for module ordering.
+		add_submenu_page(
+			null, // Hide the submenu.
+			__( 'Order Modules', 'sensei-lms' ),
+			__( 'Order Modules', 'sensei-lms' ),
+			'edit_lessons',
+			$this->order_page_slug,
+			array( $this, 'module_order_screen' )
+		);
 
-		// Register new admin page for module ordering.
-		add_submenu_page( 'edit.php?post_type=course', __( 'Order Modules', 'sensei-lms' ), __( 'Order Modules', 'sensei-lms' ), 'edit_lessons', $this->order_page_slug, array( $this, 'module_order_screen' ) );
 	}
 
 	/**

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1243,9 +1243,18 @@ class Sensei_Core_Modules {
 	 */
 	public function course_column_content( $column = '', $course_id = 0 ) {
 		if ( 'modules' === $column ) {
-			$module_links = $this->get_module_links( $course_id );
+			$modules = $this->get_course_modules( $course_id );
 
-			if ( $module_links ) {
+			if ( $modules ) {
+				$module_links = [];
+				foreach ( $modules as $module ) {
+					$module_links[] = sprintf(
+						'<a href="%s">%s</a>',
+						esc_attr( get_edit_term_link( $module->term_id ) ),
+						esc_html( $module->name )
+					);
+				}
+
 				echo implode( ', ', $module_links ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is escaped in the array.
 
 				// Output the edit modules order link.
@@ -1283,35 +1292,17 @@ class Sensei_Core_Modules {
 	 */
 	public function lesson_column_content( $column = '', $lesson_id = 0 ) {
 		if ( 'module' === $column ) {
-			$module_links = $this->get_module_links( $lesson_id );
+			$modules = wp_get_post_terms( $lesson_id, $this->taxonomy );
+			$module  = $modules && is_array( $modules ) ? $modules[0] : null;
 
-			echo implode( ', ', $module_links ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is escaped in the array.
-		}
-	}
-
-	/**
-	 * Get the links of all modules related to a post.
-	 *
-	 * @since 4.0.0
-	 *
-	 * @param  int $post_id
-	 * @return array
-	 */
-	private function get_module_links( int $post_id ): array {
-		$terms = get_the_terms( $post_id, $this->taxonomy );
-		$links = [];
-
-		if ( $terms ) {
-			foreach ( $terms as $term ) {
-				$links[] = sprintf(
+			if ( $module ) {
+				printf(
 					'<a href="%s">%s</a>',
-					esc_attr( get_edit_term_link( $term->term_id ) ),
-					esc_html( $term->name )
+					esc_attr( get_edit_term_link( $module->term_id ) ),
+					esc_html( $module->name )
 				);
 			}
 		}
-
-		return $links;
 	}
 
 	/**

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1250,7 +1250,15 @@ class Sensei_Core_Modules {
 				foreach ( $modules as $module ) {
 					$module_links[] = sprintf(
 						'<a href="%s">%s</a>',
-						esc_attr( get_edit_term_link( $module->term_id ) ),
+						esc_url(
+							add_query_arg(
+								[
+									'post_type'     => 'course',
+									$this->taxonomy => $module->slug,
+								],
+								admin_url( 'edit.php' )
+							)
+						),
 						esc_html( $module->name )
 					);
 				}
@@ -1260,7 +1268,16 @@ class Sensei_Core_Modules {
 				// Output the edit modules order link.
 				echo sprintf(
 					'<a class="button-link" href="%s">%s</a>',
-					esc_url( admin_url( 'edit.php?post_type=course&page=module-order&course_id=' . intval( $course_id ) ) ),
+					esc_url(
+						add_query_arg(
+							[
+								'post_type' => 'course',
+								'page'      => 'module-order',
+								'course_id' => $course_id,
+							],
+							admin_url( 'edit.php' )
+						)
+					),
 					esc_html__( 'Order modules', 'sensei-lms' )
 				);
 			}
@@ -1298,7 +1315,15 @@ class Sensei_Core_Modules {
 			if ( $module ) {
 				printf(
 					'<a href="%s">%s</a>',
-					esc_attr( get_edit_term_link( $module->term_id ) ),
+					esc_url(
+						add_query_arg(
+							[
+								'post_type'     => 'lesson',
+								$this->taxonomy => $module->slug,
+							],
+							admin_url( 'edit.php' )
+						)
+					),
 					esc_html( $module->name )
 				);
 			}

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1068,7 +1068,7 @@ class Sensei_Core_Modules {
 
 		// Register an admin page for module ordering.
 		add_submenu_page(
-			'options.php',
+			null, // Hide the submenu.
 			__( 'Order Modules', 'sensei-lms' ),
 			__( 'Order Modules', 'sensei-lms' ),
 			'edit_lessons',
@@ -1100,7 +1100,7 @@ class Sensei_Core_Modules {
 						'ordered'   => $ordered,
 						'course_id' => $_POST['course_id'],
 					),
-					admin_url( 'options.php' )
+					admin_url( 'edit.php' )
 				)
 			)
 		);
@@ -1131,7 +1131,7 @@ class Sensei_Core_Modules {
 
 			$courses = Sensei()->course->get_all_courses();
 
-			$html .= '<form method="get">' . "\n";
+			$html .= '<form action="' . esc_url( admin_url( 'edit.php' ) ) . '" method="get">' . "\n";
 			$html .= '<input type="hidden" name="post_type" value="course" />' . "\n";
 			$html .= '<input type="hidden" name="page" value="' . esc_attr( $this->order_page_slug ) . '" />' . "\n";
 			$html .= '<select id="module-order-course" name="course_id">' . "\n";
@@ -1260,7 +1260,7 @@ class Sensei_Core_Modules {
 				// Output the edit modules order link.
 				echo sprintf(
 					'<a class="button-link" href="%s">%s</a>',
-					esc_url( admin_url( 'options.php?post_type=course&page=module-order&course_id=' . intval( $course_id ) ) ),
+					esc_url( admin_url( 'edit.php?post_type=course&page=module-order&course_id=' . intval( $course_id ) ) ),
 					esc_html__( 'Order modules', 'sensei-lms' )
 				);
 			}
@@ -1653,7 +1653,7 @@ class Sensei_Core_Modules {
 		 */
 		$script_on_pages_white_list = apply_filters(
 			'sensei_module_admin_script_page_white_lists',
-			array( 'admin_page_module-order' )
+			array( 'course_page_module-order' )
 		);
 
 		// Only load module scripts when adding, editing or ordering modules or editing course/lesson.

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -49,6 +49,8 @@ class Sensei_Core_Modules {
 		add_action( 'admin_post_order_modules', array( $this, 'handle_order_modules' ) );
 		add_filter( 'manage_course_posts_columns', array( $this, 'course_columns' ), 11, 1 );
 		add_action( 'manage_course_posts_custom_column', array( $this, 'course_column_content' ), 11, 2 );
+		add_filter( 'manage_lesson_posts_columns', array( $this, 'lesson_columns' ), 11, 1 );
+		add_action( 'manage_lesson_posts_custom_column', array( $this, 'lesson_column_content' ), 11, 2 );
 
 		// Ensure modules always show under courses
 		add_action( 'admin_menu', array( $this, 'remove_lessons_menu_model_taxonomy' ), 10 );
@@ -1248,6 +1250,37 @@ class Sensei_Core_Modules {
 					esc_html__( 'Order modules', 'sensei-lms' )
 				);
 			}
+		}
+	}
+
+	/**
+	 * Add custom columns to lesson list table.
+	 *
+	 * @since 1.8.0
+	 *
+	 * @param  array $columns Existing columns.
+	 * @return array          Modified columns.
+	 */
+	public function lesson_columns( $columns = array() ) {
+		$columns['module'] = __( 'Module', 'sensei-lms' );
+
+		return $columns;
+	}
+
+	/**
+	 * Load content in the lesson custom columns.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @param  string  $column    Current column name.
+	 * @param  integer $lesson_id The lesson ID.
+	 * @return void
+	 */
+	public function lesson_column_content( $column = '', $lesson_id = 0 ) {
+		if ( 'module' === $column ) {
+			$module_links = $this->get_module_links( $lesson_id );
+
+			echo implode( ', ', $module_links ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output is escaped in the array.
 		}
 	}
 

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1256,7 +1256,7 @@ class Sensei_Core_Modules {
 	/**
 	 * Add custom columns to lesson list table.
 	 *
-	 * @since 1.8.0
+	 * @since 4.0.0
 	 *
 	 * @param  array $columns Existing columns.
 	 * @return array          Modified columns.
@@ -1285,7 +1285,7 @@ class Sensei_Core_Modules {
 	}
 
 	/**
-	 * Output the content of the course modules column.
+	 * Get the links of all modules related to a post.
 	 *
 	 * @since 4.0.0
 	 *
@@ -1293,7 +1293,7 @@ class Sensei_Core_Modules {
 	 * @return array
 	 */
 	private function get_module_links( int $post_id ): array {
-		$terms = get_the_terms( $post_id, 'module' );
+		$terms = get_the_terms( $post_id, $this->taxonomy );
 		$links = [];
 
 		if ( $terms ) {


### PR DESCRIPTION
Part of #4529

### Changes proposed in this Pull Request

* Merge the modules and modules order columns on the courses admin page.
* Style the consolidated column according to the new design.
* Fix the "Order modules" admin page not working.

### Testing instructions

* Create a course with multiple modules.
* Go to the courses admin page.
* Make sure there is a "Modules" column, that contains all the courses and the "Order modules" link.
* Make sure the links work.
* Go to the lessons admin page.
* Check if the "Module" column links are working.

### Screenshot / Video

<img width="1168" alt="Screenshot on 2022-01-17 at 23-26-00" src="https://user-images.githubusercontent.com/1612178/149838693-2f6cb6d7-ec57-4500-93d9-6f57a82b5a32.png">
