### PR TITLE
Fix 404 for draft lesson preview when Learning Mode is enabled.

### DIFF
--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -94,7 +94,7 @@ class Sensei_Course_Theme {
 	 */
 	public function get_theme_redirect_url( $path = '' ) {
 
-		if ( '' === get_option( 'permalink_structure' ) ) {
+		if ( '' === get_option( 'permalink_structure' ) || get_query_var( 'preview' ) ) {
 			return home_url( add_query_arg( [ self::QUERY_VAR => 1 ], $path ) );
 		}
 
@@ -263,12 +263,6 @@ class Sensei_Course_Theme {
 	public static function is_preview_mode( $course_id ) {
 		// Do not allow sensei preview if not an administrator.
 		if ( ! current_user_can( 'manage_sensei' ) ) {
-			return false;
-		}
-
-		// Do not allow sensei preview if it is not a course related page.
-		$course_id = intval( \Sensei_Utils::get_current_course() );
-		if ( ! $course_id ) {
 			return false;
 		}
 


### PR DESCRIPTION
Fixes #4636 

To enable Learning Mode we modify the url to have a `learn` variable. If the site is configured to have custom permalink structure, then we prepend the url path with `/learn/`. Else, if the site urls are not customized, then we simply append `?learn=1` query variable.

However, no matter if the site permalink structure is set to have a custom structure, the post preview links are always plain. And we should always treat preview links as if they are plain links.

### Changes proposed in this Pull Request

* Besides checking if the site is configured to have a customized permalink structure, we also check if the url has a `preview` query variable to decide how we should add the `learn` variable into the url to enable the Learning Mode.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create course with draft lessons in it.
* Enable Learning Mode for that course.
* Go to one of the draft lesson's editor and preview the draft lesson.
* Confirm that it shows the draft lesson in Learning Mode.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video


https://user-images.githubusercontent.com/2578542/149920356-6db38f4f-5210-484c-adbf-a7c1f830bc1f.mp4


