### PR TITLE
Hide Lesson Actions block when learning mode is enabled

### DIFF
--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
@@ -6,6 +6,7 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
+import { Notice } from '@wordpress/components';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
@@ -22,6 +23,8 @@ import {
 	INNER_BLOCKS_TEMPLATE,
 	IN_PROGRESS_PREVIEW,
 } from './constants';
+
+const courseThemeEnabled = window?.sensei?.courseThemeEnabled || false;
 
 /**
  * Edit lesson actions block component.
@@ -63,6 +66,21 @@ const LessonActionsEdit = ( props ) => {
 	const completeLessonAllowedClass = completeLessonAllowed
 		? 'allowed'
 		: 'not-allowed';
+
+	if ( courseThemeEnabled ) {
+		return (
+			<Notice
+				status="warning"
+				isDismissible={ false }
+				className="wp-block-sensei-lms-lesson-actions__notice"
+			>
+				{ __(
+					'Lesson Actions block is not displayed when Learning Mode is enabled.',
+					'sensei-lms'
+				) }
+			</Notice>
+		);
+	}
 
 	// Filter inner blocks based on the settings.
 	const filteredInnerBlocksTemplate = INNER_BLOCKS_TEMPLATE.filter(

--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-editor.scss
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-editor.scss
@@ -20,4 +20,7 @@
 			display: none;
 		}
 	}
+	&__notice {
+		margin: 0;
+	}
 }

--- a/includes/blocks/class-sensei-lesson-actions-block.php
+++ b/includes/blocks/class-sensei-lesson-actions-block.php
@@ -43,7 +43,12 @@ class Sensei_Lesson_Actions_Block {
 			return '';
 		}
 
-		if ( ! Sensei_Lesson::should_show_lesson_actions( $lesson->ID ) ) {
+		$course_id = Sensei()->lesson->get_course_id( $lesson->ID );
+
+		if (
+			Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id )
+			|| ! Sensei_Lesson::should_show_lesson_actions( $lesson->ID )
+		) {
 			return '';
 		}
 

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -49,6 +49,18 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 			true
 		);
 
+		$course_id = Sensei_Utils::get_current_course();
+		if ( ! empty( $course_id ) ) {
+			wp_add_inline_script(
+				'sensei-single-lesson-blocks',
+				sprintf(
+					'window.sensei = window.sensei || {}; window.sensei.courseThemeEnabled = %s;',
+					Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id ) ? 'true' : 'false'
+				),
+				'before'
+			);
+		}
+
 		Sensei()->assets->enqueue(
 			'sensei-single-lesson-blocks-editor-style',
 			'blocks/single-lesson-style-editor.css',

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -71,7 +71,7 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		// Notice that for new Lessons, the `lesson_id` will return `0` (post query string not set).
 		// It means the following check will return `false`. It's expected and works well because
 		// new lessons don't have associated courses yet.
-		$sensei_theme_enabled = Sensei_Course_Theme_Option::instance()->has_sensei_theme_enabled( $course_id );
+		$sensei_theme_enabled = Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id );
 
 		if ( $sensei_theme_enabled ) {
 			$block_template = [

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3941,7 +3941,7 @@ class Sensei_Course {
 	public static function alter_redirect_url_after_enrolment( $url, $post ) {
 
 		$course_id = $post->ID;
-		if ( Sensei_Course_Theme_Option::instance()->has_sensei_theme_enabled( $course_id ) ) {
+		if ( Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id ) ) {
 			$first_incomplete_lesson_id = Sensei_Course_Structure::instance( $course_id )->get_first_incomplete_lesson_id();
 			if ( false !== $first_incomplete_lesson_id ) {
 				$url = get_permalink( $first_incomplete_lesson_id );

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-option.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-option.php
@@ -24,19 +24,11 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 	private $factory;
 
 	/**
-	 * Instance of `Sensei_Course_Theme_Option` under test.
-	 *
-	 * @var Sensei_Course_Theme_Option
-	 */
-	private $instance;
-
-	/**
 	 * Setup method. Run first on every test execution.
 	 */
 	public function setup() {
 		parent::setup();
-		$this->factory  = new Sensei_Factory();
-		$this->instance = Sensei_Course_Theme_Option::instance();
+		$this->factory = new Sensei_Factory();
 	}
 
 	/**
@@ -60,7 +52,7 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 	public function testHasSenseiThemeEnabledReturnsFalseByDefault() {
 		$course_id = $this->factory->course->create();
 
-		$output = $this->instance->has_sensei_theme_enabled( $course_id );
+		$output = Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id );
 
 		$this->assertFalse( $output, 'By default the `has_sensei_theme_enabled` method must return false.' );
 	}
@@ -72,7 +64,7 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 		$course_id = $this->factory->course->create();
 		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::WORDPRESS_THEME );
 
-		$output = $this->instance->has_sensei_theme_enabled( $course_id );
+		$output = Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id );
 
 		$this->assertFalse( $output, '`has_sensei_theme_enabled` method must return false when WordPress theme is enabled.' );
 	}
@@ -84,7 +76,7 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 		$course_id = $this->factory->course->create();
 		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
 
-		$output = $this->instance->has_sensei_theme_enabled( $course_id );
+		$output = Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id );
 
 		$this->assertTrue( $output, '`has_sensei_theme_enabled` method must return true when Sensei theme is enabled.' );
 	}
@@ -95,7 +87,7 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 	public function testSenseiThemeGloballyOffAndCourseNull() {
 		\Sensei()->settings->set( 'sensei_learning_mode_all', false );
 		$course_id = $this->factory->course->create();
-		$output    = $this->instance->has_sensei_theme_enabled( $course_id );
+		$output    = Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id );
 		$this->assertFalse( $output, '`has_sensei_theme_enabled` method must return false when Sensei theme is globally off and for course null.' );
 	}
 
@@ -106,7 +98,7 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 		\Sensei()->settings->set( 'sensei_learning_mode_all', false );
 		$course_id = $this->factory->course->create();
 		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::WORDPRESS_THEME );
-		$output = $this->instance->has_sensei_theme_enabled( $course_id );
+		$output = Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id );
 		$this->assertFalse( $output, '`has_sensei_theme_enabled` method must return false when Sensei theme is globally off and for course off.' );
 	}
 
@@ -117,7 +109,7 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 		\Sensei()->settings->set( 'sensei_learning_mode_all', false );
 		$course_id = $this->factory->course->create();
 		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
-		$output = $this->instance->has_sensei_theme_enabled( $course_id );
+		$output = Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id );
 		$this->assertTrue( $output, '`has_sensei_theme_enabled` method must return false when Sensei theme is globally off and for course on.' );
 	}
 
@@ -127,7 +119,7 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 	public function testSenseiThemeGloballyOnAndCourseNull() {
 		\Sensei()->settings->set( 'sensei_learning_mode_all', true );
 		$course_id = $this->factory->course->create();
-		$output    = $this->instance->has_sensei_theme_enabled( $course_id );
+		$output    = Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id );
 		$this->assertTrue( $output, '`has_sensei_theme_enabled` method must return true when Sensei theme is globally on and for course null.' );
 	}
 
@@ -138,7 +130,7 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 		\Sensei()->settings->set( 'sensei_learning_mode_all', true );
 		$course_id = $this->factory->course->create();
 		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::WORDPRESS_THEME );
-		$output = $this->instance->has_sensei_theme_enabled( $course_id );
+		$output = Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id );
 		$this->assertTrue( $output, '`has_sensei_theme_enabled` method must return true when Sensei theme is globally on and for course off.' );
 	}
 
@@ -149,7 +141,7 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 		\Sensei()->settings->set( 'sensei_learning_mode_all', true );
 		$course_id = $this->factory->course->create();
 		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
-		$output = $this->instance->has_sensei_theme_enabled( $course_id );
+		$output = Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id );
 		$this->assertTrue( $output, '`has_sensei_theme_enabled` method must return true when Sensei theme is globally on and for course on.' );
 	}
 
@@ -161,7 +153,7 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 		$course_id = $this->factory->course->create();
 		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::WORDPRESS_THEME );
 		add_filter( 'sensei_course_learning_mode_enabled', '__return_true' );
-		$output = $this->instance->has_sensei_theme_enabled( $course_id );
+		$output = Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id );
 		$this->assertTrue( $output, '`has_sensei_theme_enabled` method must return true when Sensei theme is globally off for course off and via filter on.' );
 	}
 }


### PR DESCRIPTION
Fixes #4622

### Changes proposed in this Pull Request

* The Lesson Actions block will display a notice in the frontend saying that the block is not displayed when learning mode is enabled.
* The Lesson Actions block is not displayed in the frontend when the Learning Mode is enabled.
* At some point `has_sensei_theme_enabled` was changed to static method, so it also fixes some places where it was being called in a wrong way.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create a course with Learning Mode enabled, and another one with Learning Mode disabled.
* Add at least one lesson to each course.
* Check that adding a Lesson Actions block to the lessons displays a notice only when Learning Mode is enabled.
* Access the lessons as a student, and make sure you only see the Lesson Actions block when Learning Mode is disabled.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Lesson editor in a course with Learning Mode **disabled**:

<img width="1272" alt="Screen Shot 2022-01-18 at 14 00 23" src="https://user-images.githubusercontent.com/876340/149989359-b4f6a328-52dc-47a7-a222-5f03b2689d28.png">

Lesson editor in a course with Learning Mode **enabled**:

<img width="1299" alt="Screen Shot 2022-01-18 at 14 00 08" src="https://user-images.githubusercontent.com/876340/149989377-f169c63f-11f3-47ec-a622-de9013266af8.png">

