### PR TITLE
Update color customization

### DIFF
--- a/assets/blocks/contact-teacher-block/contact-teacher.scss
+++ b/assets/blocks/contact-teacher-block/contact-teacher.scss
@@ -12,7 +12,8 @@
 		border: 1px solid #757575;
 		border-radius: 2px;
 		padding: 10px;
-		background-color: #fff;
+		background-color: inherit;
+		color: inherit;
 		margin-bottom: 20px;
 		width: 355px;
 	}
@@ -41,7 +42,7 @@ a.sensei-contact-teacher-close {
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	color: #1E1E1E;
+	color: inherit;
 	svg {
 		width: 14px;
 		height: 14px;

--- a/assets/css/notices.scss
+++ b/assets/css/notices.scss
@@ -3,5 +3,5 @@
 	border: solid 1px #DCDCDE;
 	margin-bottom: 21px;
 	padding: 17px 26px;
-	color: #000;
+	color: #1E1E1E;
 }

--- a/assets/css/sensei-course-theme.scss
+++ b/assets/css/sensei-course-theme.scss
@@ -5,10 +5,10 @@
 @import 'sensei-course-theme/buttons';
 @import 'sensei-course-theme/notices';
 @import 'sensei-course-theme/quiz';
+@import 'sensei-course-theme/modal';
 
 @import 'sensei-course-theme/prev-next-lesson';
 @import 'sensei-course-theme/course-navigation';
-@import 'sensei-course-theme/quiz-back-to-lesson';
 @import 'sensei-course-theme/course-progress-bar';
 @import 'sensei-course-theme/lesson-complete-transition';
 @import 'sensei-course-theme/lesson-actions';

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -1,4 +1,8 @@
 
+@mixin text-gray() {
+	opacity: 0.7;
+}
+
 body {
 	--primary-color: var(--sensei-course-theme-primary-color, var(--wp--custom--color--primary, #30968B));
 	--bg-color: var(--sensei-course-theme-background-color, var(--wp--custom--color--background-color, #FFFFFF));

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -1,11 +1,13 @@
 
 body {
-	--primary-color: var(--sensei-course-theme-primary-color, var(--wp--preset--color--primary, #30968B));
-	--primary-contrast-color: var(--wp--preset--color--primary-contrast-color, #FFFFFF);
-	--gray: var(--wp--preset--color--gray, #787C82);
-	--border-color: var(--wp--preset--color--border, #CCCCCC);
-	--bg-color: var(--wp--preset--color--background, #FFFFFF);
-	--text-color: var(--wp--preset--color--foreground, #000);
+	--primary-color: var(--sensei-course-theme-primary-color, var(--wp--custom--color--primary, #30968B));
+	--bg-color: var(--sensei-course-theme-background-color, var(--wp--custom--color--background-color, #FFFFFF));
+	--primary-contrast-color: var(--bg-color);
+	--text-color: var(--sensei-course-theme-foreground-color, var(--wp--custom--color--foreground-color, #1E1E1E));
+	--border-color: rgba(125, 125, 125, 0.3);
+
+	background-color: var(--bg-color);
+	color: var(--text-color);
 }
 
 .sensei-course-theme__frame {

--- a/assets/css/sensei-course-theme/blockbase-ponyfill.scss
+++ b/assets/css/sensei-course-theme/blockbase-ponyfill.scss
@@ -16,6 +16,10 @@ pre {
 	overflow: scroll;
 }
 
+button {
+	color: inherit;
+}
+
 /**
  * These are default block editor widths in case the theme doesn't provide them.
  */

--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -15,6 +15,8 @@
 	cursor: pointer;
 	text-align: center;
 	background: transparent;
+	border: none;
+	padding: 0;
 
 	&.is-primary,
 	&.is-secondary,

--- a/assets/css/sensei-course-theme/contact-teacher.scss
+++ b/assets/css/sensei-course-theme/contact-teacher.scss
@@ -33,23 +33,22 @@
 	}
 }
 
-.sensei-contact-teacher-success {
-	font-family: 'Inter', sans-serif;
-	display: block;
-	position: absolute;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	left: 0;
-	padding-top: 30px;
-	background-color: #fff;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	flex-direction: column;
-	z-index: -1;
-	opacity: 0;
-	transition: opacity 100ms ease-out;
+	.sensei-contact-teacher-success {
+		font-family: 'Inter', sans-serif;
+		display: block;
+		position: absolute;
+		top: 0;
+		right: 0;
+		bottom: 0;
+		left: 0;
+		padding-top: 30px;
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		flex-direction: column;
+		z-index: -1;
+		opacity: 0;
+		transition: opacity 100ms ease-out;
 
 	svg {
 		width: 42px;
@@ -58,22 +57,25 @@
 		color: var(--primary-color);
 	}
 
-	p {
-		font-weight: 500;
-		font-size: 24px;
-		line-height: 32px;
-		color: #1E1E1E;
-		width: 235px;
-		max-width: 100%;
-		text-align: center;
+		p {
+			font-weight: 500;
+			font-size: 24px;
+			line-height: 32px;
+			width: 235px;
+			max-width: 100%;
+			text-align: center;
+		}
 	}
-}
 
 .sensei-contact-teacher-form {
-	&.is-success {
-		.sensei-contact-teacher-success {
-			z-index: 1;
-			opacity: 1;
+	textarea {
+
+		}
+		&.is-success {
+			.sensei-contact-teacher-success {
+				z-index: 1;
+				opacity: 1;
+
 		}
 	}
 }

--- a/assets/css/sensei-course-theme/contact-teacher.scss
+++ b/assets/css/sensei-course-theme/contact-teacher.scss
@@ -34,7 +34,7 @@
 }
 
 	.sensei-contact-teacher-success {
-		font-family: 'Inter', sans-serif;
+		font-family: inherit;
 		display: block;
 		position: absolute;
 		top: 0;
@@ -49,13 +49,14 @@
 		z-index: -1;
 		opacity: 0;
 		transition: opacity 100ms ease-out;
+		background: var(--bg-color);
 
-	svg {
-		width: 42px;
-		height: 42px;
-		margin-bottom: 20px;
-		color: var(--primary-color);
-	}
+		svg {
+			width: 42px;
+			height: 42px;
+			margin-bottom: 20px;
+			color: var(--primary-color);
+		}
 
 		p {
 			font-weight: 500;

--- a/assets/css/sensei-course-theme/course-navigation.scss
+++ b/assets/css/sensei-course-theme/course-navigation.scss
@@ -3,7 +3,7 @@
 .sensei-lms-course-navigation {
 
 	&__modules + &__lessons {
-		border-top: 1px dotted #ccc;
+		border-top: 1px dotted var(--border-color);
 		margin-top: 6px;
 		padding-top: 6px;
 	}
@@ -42,11 +42,12 @@
 		font-size: 18px;
 		line-height: 22px;
 		text-align: left;
+		margin: 0;
 	}
 
 	&__summary {
 		font-size: 13px;
-		color: var(--gray);
+		@include text-gray;
 		visibility: hidden;
 		overflow: hidden;
 		max-height: 0;
@@ -83,7 +84,7 @@
 		padding-left: 6px;
 		margin-top: 1px; // Needed to compensate the font-size difference.
 		font-size: 13px;
-		color: var(--gray);
+		@include text-gray;
 	}
 
 	&__status {
@@ -95,7 +96,7 @@
 
 	&.status-locked,
 	&.status-not-started &__status {
-		color: var(--gray);
+		@include text-gray;
 	}
 
 	&.current-lesson &__title {

--- a/assets/css/sensei-course-theme/course-progress-bar.scss
+++ b/assets/css/sensei-course-theme/course-progress-bar.scss
@@ -1,6 +1,6 @@
 .sensei-course-theme-course-progress-bar {
 	height: 10px;
-	background-color: #DCDCDE;
+	background-color: var(--border-color);
 }
 
 .sensei-course-theme-course-progress-bar-inner {

--- a/assets/css/sensei-course-theme/header.scss
+++ b/assets/css/sensei-course-theme/header.scss
@@ -18,7 +18,7 @@
 	}
 
 	.sensei-course-theme-course-progress {
-		color: var(--gray);
+		@include text-gray;
 
 	}
 }

--- a/assets/css/sensei-course-theme/lesson-complete-transition.scss
+++ b/assets/css/sensei-course-theme/lesson-complete-transition.scss
@@ -13,7 +13,7 @@
 	flex-direction: column;
 	justify-content: center;
 	align-items: center;
-	background-color: #FFF;
+	background-color: var(--bg-color);
 
 	&__text {
 		margin: 25px 0;

--- a/assets/css/sensei-course-theme/lesson-module.scss
+++ b/assets/css/sensei-course-theme/lesson-module.scss
@@ -1,6 +1,5 @@
 .sensei-course-theme-lesson-module {
 	font-family: 'Inter', sans-serif;
-	color: #000000;
 	font-size: 14px;
 	line-height: 1.2;
 	font-weight: 400;

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -18,7 +18,7 @@
 	}
 
 	.sensei-course-theme {
-		--content-padding: 12px;
+		--content-padding: 18px;
 		--header-height: 60px;
 
 		&--sidebar-open {

--- a/assets/css/sensei-course-theme/modal.scss
+++ b/assets/css/sensei-course-theme/modal.scss
@@ -1,0 +1,8 @@
+[data-sensei-modal] [data-sensei-modal-content] {
+	background: var(--bg-color);
+	color: inherit;
+	border-color: var(--border-color);
+	textarea {
+		color: inherit;
+	}
+}

--- a/assets/css/sensei-course-theme/notices.scss
+++ b/assets/css/sensei-course-theme/notices.scss
@@ -1,5 +1,11 @@
 @import '../notices';
 
+.sensei-lms-notice {
+	background-color: rgba(125, 125, 125, 0.08);
+	border-color: var(--border-color);
+	color: inherit;
+}
+
 .sensei-course-theme-lesson-quiz-notice {
 	display: flex;
 	justify-content: space-between;

--- a/assets/css/sensei-course-theme/quiz-back-to-lesson.scss
+++ b/assets/css/sensei-course-theme/quiz-back-to-lesson.scss
@@ -1,6 +1,0 @@
-.sensei-lms-quiz-back-to-lesson {
-	font-family: var(--font-family);
-	font-size: 14px;
-	text-decoration: none;
-	color: var(--gray);
-}

--- a/assets/css/sensei-course-theme/quiz.scss
+++ b/assets/css/sensei-course-theme/quiz.scss
@@ -27,7 +27,7 @@
 	&__header {
 		position: sticky;
 		top: var(--top-offset);
-		background-color: #fff;
+		background-color: var(--bg-color);
 		z-index: 100;
 
 		.wp-block-post-title {
@@ -70,4 +70,10 @@
 
 		}
 	}
+}
+
+.sensei-lms-quiz-back-to-lesson {
+	font-family: var(--font-family);
+	font-size: 14px;
+	text-decoration: none;
 }

--- a/assets/css/sensei-course-theme/quiz.scss
+++ b/assets/css/sensei-course-theme/quiz.scss
@@ -56,9 +56,8 @@
 			left: 0;
 			right: 0;
 			z-index: 100;
-			background-color: #fff;
-			border-top: 1px solid #F6F7F7;
-			box-shadow: 2px 10px 30px 5px rgba(#E2E4E7, 0.5);
+			background-color: var(--bg-color);
+			box-shadow: 2px 10px 30px 5px rgba(0,0,0, 0.1);
 		}
 
 		&__left {

--- a/assets/icons/menu.svg
+++ b/assets/icons/menu.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
-    <path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z" />
+    <path d="M5 5v1.5h14V5H5zm0 7.8h14v-1.5H5v1.5zM5 19h14v-1.5H5V19z" fill="currentColor" />
 </svg>

--- a/assets/js/admin/course-theme/course-theme-sidebar.js
+++ b/assets/js/admin/course-theme/course-theme-sidebar.js
@@ -79,7 +79,7 @@ const usePreviewAndCustomizerLinks = () => {
 
 	let customizerUrl = '';
 	if ( previewUrl ) {
-		customizerUrl = `/wp-admin/customize.php?autofocus[section]=Sensei_Course_Theme_Option&url=${ encodeURIComponent(
+		customizerUrl = `/wp-admin/customize.php?autofocus[section]=sensei-course-theme&url=${ encodeURIComponent(
 			previewUrl
 		) }`;
 	}

--- a/includes/class-sensei-customizer.php
+++ b/includes/class-sensei-customizer.php
@@ -3,7 +3,7 @@
  * Sensei_Customizer class.
  *
  * @package sensei-lms
- * @since 4.0.0
+ * @since   4.0.0
  */
 
 /**
@@ -12,16 +12,11 @@
 class Sensei_Customizer {
 
 	/**
-	 * Sensei course theme primary color.
-	 */
-	const COURSE_THEME_PRIMARY_COLOR = 'sensei-course-theme-primary-color';
-
-	/**
-	 * Settings to output as CSS variables.
+	 * Configurable colors.
 	 *
-	 * @var string[] Variable names.
+	 * @var array[]
 	 */
-	public $css_variables = [ self::COURSE_THEME_PRIMARY_COLOR ];
+	private $colors;
 
 	/**
 	 * Sensei_Customizer constructor.
@@ -29,6 +24,21 @@ class Sensei_Customizer {
 	 * @param Sensei_Main $sensei Main Sensei instance.
 	 */
 	public function __construct( Sensei_Main $sensei ) {
+
+		$this->colors = [
+			'sensei-course-theme-primary-color'    => [
+				'label'   => __( 'Primary Color', 'sensei-lms' ),
+				'default' => '#1E1E1E',
+			],
+			'sensei-course-theme-background-color' => [
+				'label'   => __( 'Background Color', 'sensei-lms' ),
+				'default' => '#FFFFFF',
+			],
+			'sensei-course-theme-foreground-color' => [
+				'label'   => __( 'Text Color', 'sensei-lms' ),
+				'default' => '#1E1E1E',
+			],
+		];
 
 		if ( ! $sensei->feature_flags->is_enabled( 'course_theme' ) ) {
 			return;
@@ -47,44 +57,41 @@ class Sensei_Customizer {
 	 */
 	public function add_customizer_settings( WP_Customize_Manager $wp_customize ) {
 
-		$wp_customize->add_panel(
-			'sensei',
+		$wp_customize->add_section(
+			'sensei-course-theme',
 			[
 				'priority'       => 40,
 				'capability'     => 'manage_sensei',
 				'theme_supports' => '',
-				'title'          => __( 'Sensei LMS', 'sensei-lms' ),
+				'title'          => __( 'Learning Mode (Sensei LMS)', 'sensei-lms' ),
 			]
 		);
 
-		$wp_customize->add_section(
-			'Sensei_Course_Theme_Option',
-			[
-				'title'    => __( 'Course Theme', 'sensei-lms' ),
-				'priority' => 30,
-				'panel'    => 'sensei',
-			]
-		);
+		foreach ( $this->colors as $variable => $settings ) {
 
-		$wp_customize->add_setting(
-			self::COURSE_THEME_PRIMARY_COLOR,
-			[
-				'default'   => '#1E1E1E',
-				'transport' => 'postMessage',
-			]
-		);
+			$wp_customize->add_setting(
+				$variable,
+				[
+					'default'   => $settings['default'],
+					'transport' => 'postMessage',
+					'type'      => 'option',
+				]
+			);
 
-		$wp_customize->add_control(
-			new WP_Customize_Color_Control(
-				$wp_customize,
-				self::COURSE_THEME_PRIMARY_COLOR,
-				array(
-					'label'    => __( 'Primary Color', 'sensei-lms' ),
-					'section'  => 'Sensei_Course_Theme_Option',
-					'settings' => self::COURSE_THEME_PRIMARY_COLOR,
+			$wp_customize->add_control(
+				new WP_Customize_Color_Control(
+					$wp_customize,
+					$variable,
+					array(
+						'label'       => $settings['label'],
+						'section'     => 'sensei-course-theme',
+						'settings'    => $variable,
+						'description' => $settings['description'] ?? null,
+
+					)
 				)
-			)
-		);
+			);
+		}
 
 	}
 
@@ -104,8 +111,8 @@ class Sensei_Customizer {
 
 		$css = '';
 
-		foreach ( $this->css_variables as $variable ) {
-			$value = get_theme_mod( $variable );
+		foreach ( $this->colors as $variable => $settings ) {
+			$value = get_option( $variable );
 			if ( $value ) {
 				$css .= sprintf( "--%s: %s;\n", $variable, ( $value ) );
 			}
@@ -128,7 +135,7 @@ class Sensei_Customizer {
 		?>
 		<script type="text/javascript">
 			<?php
-			foreach ( $this->css_variables as $variable ) {
+			foreach ( $this->colors as $variable => $settings ) {
 				?>
 			wp.customize( '<?php echo esc_js( $variable ); ?>', ( setting ) => {
 				setting.bind( ( value ) => {

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -304,7 +304,7 @@ class Sensei_Course_Theme {
 		if ( ! Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id ) ) {
 			$preview_url .= '&learn=1&' . self::PREVIEW_QUERY_VAR . '=' . $course_id;
 		}
-		return '/wp-admin/customize.php?autofocus[section]=Sensei_Course_Theme_Option&url=' . rawurlencode( $preview_url );
+		return '/wp-admin/customize.php?autofocus[section]=sensei-course-theme&url=' . rawurlencode( $preview_url );
 	}
 
 	/**

--- a/themes/sensei-course-theme/theme.json
+++ b/themes/sensei-course-theme/theme.json
@@ -181,7 +181,6 @@
 			},
 			"core/post-date": {
 				"color": {
-					"link": "var(--wp--custom--color--foreground)",
 					"text": "var(--wp--custom--color--foreground)"
 				},
 				"typography": {
@@ -250,10 +249,6 @@
 					"textDecoration": "none"
 				}
 			}
-		},
-		"color": {
-			"background": "var(--wp--custom--color--background)",
-			"text": "var(--wp--custom--color--foreground)"
 		},
 		"elements": {
 			"h1": {
@@ -338,11 +333,6 @@
 						"top": "var(--wp--custom--gap--vertical)",
 						"bottom": "var(--wp--custom--gap--vertical)"
 					}
-				}
-			},
-			"link": {
-				"color": {
-					"text": "var(--wp--custom--color--primary)"
 				}
 			}
 		},


### PR DESCRIPTION
Fixes #4589 

I did not add the parts from Blockbase that saves values from the Customizer into the user's FSE Global Styles settings to keep things simple. This means Customizer settings will override changes made in Global Styles. We plan to push users to use the Customizer for now as Global Styles is still a bit unrefined.

### Changes proposed in this Pull Request

* Make the customizer work with the override theme
* Add Background and Text color
* Update CSS to use customizer colors
* Replace hard-coded colors in CSS, fix a few things
* Use opacity for greys and borders, so they work with any background (dark or light)

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Open up a lesson in learning mode
* Click Customize, change colors. See them change.
* Publish changes and close customizer. Check that the colors are still there.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/176949/150037477-27c8207e-eb24-47db-9c8e-ac26a70bbd96.mov



