### PR TITLE
Disable PHP 8 unit testing

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -44,7 +44,7 @@ jobs:
             matrix:
                 wp: ['latest']
                 wpmu: [0]
-                php: ['7.3', '7.4', '8.0']
+                php: ['7.3', '7.4']
                 include:
                     - php: 7.4
                       wp: 5.6
@@ -79,14 +79,6 @@ jobs:
               run: sudo /etc/init.d/mysql start
             - name: Install PHP dependencies
               run: composer install --no-ansi --no-interaction --prefer-dist --no-progress --ignore-platform-reqs
-            - name: Add PHP8 Compatibility
-              run: |
-                  if [ "$(php -r "echo version_compare(PHP_VERSION,'8.0','>=');")" ]; then
-                      curl -L https://github.com/woocommerce/phpunit/archive/add-compatibility-with-php8-to-phpunit-7.zip -o /tmp/phpunit-7.5-fork.zip
-                      unzip -d /tmp/phpunit-7.5-fork /tmp/phpunit-7.5-fork.zip
-                      composer config repositories.0 '{"type": "path", "url": "/tmp/phpunit-7.5-fork/phpunit-add-compatibility-with-php8-to-phpunit-7", "options": {"symlink": false}}'
-                      composer require --dev -W phpunit/phpunit:@dev --ignore-platform-reqs
-                  fi
             - name: Setup test environment
               run: bash ./tests/bin/install-wp-tests.sh wordpress_test root root localhost $WP_VERSION
             - name: Run tests


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Temporarily revert PHP 8.0 test runs until they work. Work tracking proper support: #4605

### Testing instructions

* CI 👀 
