### PR TITLE
Hide admin bar for non editor users on learning mode pages.

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -74,7 +74,7 @@ class Sensei_Course_Theme_Option {
 
 		add_action( 'init', [ $this, 'register_post_meta' ] );
 		add_action( 'template_redirect', [ $this, 'ensure_learning_mode_url_prefix' ] );
-		add_filter( 'show_admin_bar', [ $this, 'hide_admin_bar_for_non_editors' ] );
+		add_filter( 'show_admin_bar', [ $this, 'show_admin_bar_only_for_editors' ] );
 		add_filter( 'sensei_admin_notices', [ $this, 'add_course_theme_notice' ] );
 	}
 

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -183,7 +183,7 @@ class Sensei_Course_Theme_Option {
 	}
 
 	/**
-	 * Filter to hide admin bar for non-editor users.
+	 * Filter to show admin bar only for editor users.
 	 *
 	 * @access private
 	 *
@@ -191,7 +191,7 @@ class Sensei_Course_Theme_Option {
 	 *
 	 * @return bool Whether show admin bar.
 	 */
-	public function hide_admin_bar_for_non_editors( $show_admin_bar ) {
+	public function show_admin_bar_only_for_editors( $show_admin_bar ) {
 		$lesson_id = Sensei_Utils::get_current_lesson();
 		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
 

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -74,6 +74,7 @@ class Sensei_Course_Theme_Option {
 
 		add_action( 'init', [ $this, 'register_post_meta' ] );
 		add_action( 'template_redirect', [ $this, 'ensure_learning_mode_url_prefix' ] );
+		add_filter( 'show_admin_bar', [ $this, 'hide_admin_bar_for_non_editors' ] );
 		add_filter( 'sensei_admin_notices', [ $this, 'add_course_theme_notice' ] );
 	}
 
@@ -179,6 +180,26 @@ class Sensei_Course_Theme_Option {
 		$enabled_via_filter = (bool) apply_filters( 'sensei_course_learning_mode_enabled', $enabled_for_course, $enabled_globally, $course_id );
 
 		return $enabled_for_course || $enabled_globally || $enabled_via_filter;
+	}
+
+	/**
+	 * Filter to hide admin bar for non-editor users.
+	 *
+	 * @access private
+	 *
+	 * @param bool $show_admin_bar Whether show admin bar.
+	 *
+	 * @return bool Whether show admin bar.
+	 */
+	public function hide_admin_bar_for_non_editors( $show_admin_bar ) {
+		$lesson_id = Sensei_Utils::get_current_lesson();
+		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
+
+		if ( self::has_sensei_theme_enabled( $course_id ) ) {
+			return current_user_can( get_post_type_object( 'lesson' )->cap->edit_post, $lesson_id );
+		}
+
+		return $show_admin_bar;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It hides the admin bar for non-editor users on learning mode pages.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Create a course with at least one lesson and with Learning Mode enabled (enable it through course editor sidebar).
* Access the lesson page using a student, and a user that can edit it.
* Make sure you only see the top bar when the user can edit it.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Student / Admin:

<img width="1155" alt="Screen Shot 2022-01-19 at 15 57 26" src="https://user-images.githubusercontent.com/876340/150196236-bbe84193-d5d8-4c24-af8b-87e67d8c5a2d.png">


### Context

p1642615343002600-slack-C02KZBEJ30D