### PR TITLE
Add site logo block fallback

### DIFF
--- a/includes/blocks/course-theme/class-site-logo.php
+++ b/includes/blocks/course-theme/class-site-logo.php
@@ -12,8 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-use \Sensei_Blocks;
-
 /**
  * Display the site logo, linking to the course page.
  */
@@ -23,14 +21,15 @@ class Site_Logo {
 	 * Site_Logo constructor.
 	 */
 	public function __construct() {
-		Sensei_Blocks::register_sensei_block(
-			'sensei-lms/site-logo',
-			[
-				'render_callback' => [ $this, 'render' ],
-			]
-		);
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'core/site-logo' ) ) {
+			register_block_type(
+				'core/site-logo',
+				[
+					'render_callback' => [ $this, 'render_site_logo' ],
+				]
+			);
+		}
 	}
-
 
 	/**
 	 * Renders the block.
@@ -41,7 +40,8 @@ class Site_Logo {
 	 *
 	 * @return string The block HTML.
 	 */
-	public function render( array $attributes = [] ): string {
+	public function render_site_logo( array $attributes ): string {
+
 		$course_id      = \Sensei_Utils::get_current_course();
 		$custom_logo_id = get_theme_mod( 'custom_logo' );
 

--- a/includes/blocks/course-theme/class-site-logo.php
+++ b/includes/blocks/course-theme/class-site-logo.php
@@ -42,20 +42,6 @@ class Site_Logo {
 	 */
 	public function render_site_logo( array $attributes ): string {
 
-		$course_id      = \Sensei_Utils::get_current_course();
-		$custom_logo_id = get_theme_mod( 'custom_logo' );
-
-		if ( ! $course_id || ! $custom_logo_id ) {
-			return '';
-		}
-
-		$logo = wp_get_attachment_image( $custom_logo_id, 'medium', false );
-
-		$wrapper_attributes = '';
-		if ( function_exists( 'get_block_wrapper_attributes' ) ) {
-			$wrapper_attributes = get_block_wrapper_attributes( $attributes );
-		}
-
-		return sprintf( '<a href="%1$s" %2$s>%3$s</a>', get_the_permalink( $course_id ), $wrapper_attributes, $logo );
+		return get_custom_logo();
 	}
 }

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -41,6 +41,13 @@ class Sensei_Course_Theme {
 	private static $instance;
 
 	/**
+	 * Active theme on the site before override.
+	 *
+	 * @var string
+	 */
+	private $original_theme;
+
+	/**
 	 * Sensei_Course_Theme constructor. Prevents other instances from being created outside of `self::instance()`.
 	 */
 	private function __construct() {
@@ -128,6 +135,8 @@ class Sensei_Course_Theme {
 	 * Load a bundled theme for the request.
 	 */
 	public function override_theme() {
+
+		$this->original_theme = get_stylesheet();
 
 		add_filter( 'theme_root', [ $this, 'get_plugin_themes_root' ] );
 		add_filter( 'pre_option_stylesheet_root', [ $this, 'get_plugin_themes_root' ] );
@@ -339,6 +348,15 @@ class Sensei_Course_Theme {
 				'href'  => admin_url( 'site-editor.php?learn=1&postType=wp_template&postId=' . self::THEME_NAME . '//' . get_post_type() ),
 			)
 		);
+	}
+
+	/**
+	 * Get the original active site theme.
+	 *
+	 * @return mixed
+	 */
+	public function get_original_theme() {
+		return $this->original_theme;
 	}
 
 }

--- a/themes/sensei-course-theme/compat.php
+++ b/themes/sensei-course-theme/compat.php
@@ -20,6 +20,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 function init() {
 	add_filter( 'template_include', '\Sensei\Themes\Sensei_Course_Theme\Compat\get_wrapper_template' );
+	add_filter( 'theme_mod_custom_logo', '\Sensei\Themes\Sensei_Course_Theme\Compat\theme_mod_custom_logo', 60 );
+
+
 }
 
 /**
@@ -91,3 +94,28 @@ function get_the_block_template_html( $template_content ) {
 	return '<div class="wp-site-blocks">' . $content . '</div>';
 
 }
+
+/**
+ * Get custom logo from the original theme's customize settings if it was not found already.
+ *
+ * @param string $custom_logo
+ *
+ * @return string
+ */
+function theme_mod_custom_logo( $custom_logo ) {
+
+	if ( $custom_logo ) {
+		return $custom_logo;
+	}
+
+	$theme_mods = get_option( 'theme_mods_' . \Sensei_Course_Theme::instance()->get_original_theme() );
+
+	if ( ! empty( $theme_mods['custom_logo'] ) ) {
+		return $theme_mods['custom_logo'];
+	}
+
+	return $custom_logo;
+
+}
+
+

--- a/themes/sensei-course-theme/compat.php
+++ b/themes/sensei-course-theme/compat.php
@@ -22,7 +22,6 @@ function init() {
 	add_filter( 'template_include', '\Sensei\Themes\Sensei_Course_Theme\Compat\get_wrapper_template' );
 	add_filter( 'theme_mod_custom_logo', '\Sensei\Themes\Sensei_Course_Theme\Compat\theme_mod_custom_logo', 60 );
 
-
 }
 
 /**

--- a/themes/sensei-course-theme/functions.php
+++ b/themes/sensei-course-theme/functions.php
@@ -29,6 +29,7 @@ function setup_theme() {
 	add_theme_support( 'responsive-embeds' );
 	add_theme_support( 'post-thumbnails' );
 	add_theme_support( 'block-nav-menus' );
+	add_theme_support( 'custom-logo' );
 	add_theme_support( 'html5', array( 'comment-list', 'comment-form', 'search-form', 'gallery', 'caption', 'style', 'script' ) );
 
 	Compat\init();


### PR DESCRIPTION
Fixes #4584 

### Changes proposed in this Pull Request

* Add renderer for `core/site-logo` if it doesn't exists (pre-5.8)
* Fix loading the site logo set for the original theme when overriding with the course theme
  * Since 5.8, the logo is stored in a 'site-logo' logo option instead of a theme_mod, so it persists across themes

### Testing instructions

* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Open a site with Wordpress 5.7. Make sure a site logo is set in customizer
* Open a lesson in learning mode. Check that logo is there

