### PR TITLE
Fix JSON named exports

### DIFF
--- a/assets/js/admin/course-theme/course-theme-sidebar.js
+++ b/assets/js/admin/course-theme/course-theme-sidebar.js
@@ -15,10 +15,14 @@ import {
 	WORDPRESS_THEME,
 	SENSEI_PREVIEW_QUERY,
 } from './constants';
-import { name as courseOutlineBlockName } from '../../../blocks/course-outline/outline-block/block.json';
-import { name as courseModuleBlockName } from '../../../blocks/course-outline/module-block/block.json';
-import { name as courseLessonBlockName } from '../../../blocks/course-outline/lesson-block/block.json';
+import courseOutlineBlock from '../../../blocks/course-outline/outline-block/block.json';
+import courseModuleBlock from '../../../blocks/course-outline/module-block/block.json';
+import courseLessonBlock from '../../../blocks/course-outline/lesson-block/block.json';
 import { getFirstBlockByName } from '../../../blocks/course-outline/data';
+
+const courseOutlineBlockName = courseOutlineBlock.name;
+const courseModuleBlockName = courseModuleBlock.name;
+const courseLessonBlockName = courseLessonBlock.name;
 
 const canPreview = ( block ) =>
 	block.name === courseLessonBlockName && block.attributes.id;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes a warning in Webpack build because named exports are [deprecated](https://webpack.js.org/blog/2020-10-10-webpack-5-release/#json-modules) for [JSON](https://webpack.js.org/migrate/5/#using-named-exports-from-json-modules) in Webpack 5.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Run `npm run build`, and make sure the warnings don't appear anymore.
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Go to the course sidebar editor.
* Test the preview and customizer link, and make sure it continues working properly.

### Screenshots

The warnings:
<img width="789" alt="Screen Shot 2022-01-19 at 19 47 23" src="https://user-images.githubusercontent.com/876340/150231260-612880f1-b16b-4005-9179-d066e17bb612.png">
