### PR TITLE
Fix the quiz block not rendering

### DIFF
--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -261,14 +261,14 @@ const QuizSettings = ( {
 							),
 						},
 						{
-							value: pagination.progressBarColor || undefined,
+							value: pagination?.progressBarColor || undefined,
 							onChange: ( value ) =>
 								updatePagination( { progressBarColor: value } ),
 							label: __( 'Progress bar color', 'sensei-lms' ),
 						},
 						{
 							value:
-								pagination.progressBarBackground || undefined,
+								pagination?.progressBarBackground || undefined,
 							onChange: ( value ) =>
 								updatePagination( {
 									progressBarBackground: value,


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This fixes the quiz block generating an error when the block has no pagination settings.

### Testing instructions

* Make a quiz with a few questions on version 3.14.0.
* Switch to this branch.
* Make sure the quiz block is rendering and there are no errors in the console.
* Make sure all the quiz pagination settings are working.