### PR TITLE
Remove Course Theme feature flag checks

### DIFF
--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -75,12 +75,10 @@ domReady( () => {
 /**
  * Plugins
  */
-if ( window.senseiCourseThemeFeatureFlagEnabled ) {
-	registerPlugin( 'sensei-course-theme-plugin', {
-		render: CourseTheme,
-		icon: null,
-	} );
-}
+registerPlugin( 'sensei-course-theme-plugin', {
+	render: CourseTheme,
+	icon: null,
+} );
 registerPlugin( 'sensei-course-video-progression-plugin', {
 	render: CourseVideoSidebar,
 	icon: null,

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -43,10 +43,8 @@ class Sensei_Blocks {
 
 	/**
 	 * Sensei_Blocks constructor.
-	 *
-	 * @param Sensei_Main $sensei Sensei instance.
 	 */
-	public function __construct( Sensei_Main $sensei ) {
+	public function __construct() {
 		// Skip if Gutenberg is not available.
 		if ( ! function_exists( 'register_block_type' ) ) {
 			return;

--- a/includes/class-sensei-customizer.php
+++ b/includes/class-sensei-customizer.php
@@ -20,11 +20,8 @@ class Sensei_Customizer {
 
 	/**
 	 * Sensei_Customizer constructor.
-	 *
-	 * @param Sensei_Main $sensei Main Sensei instance.
 	 */
-	public function __construct( Sensei_Main $sensei ) {
-
+	public function __construct() {
 		$this->colors = [
 			'sensei-course-theme-primary-color'    => [
 				'label'   => __( 'Primary Color', 'sensei-lms' ),
@@ -40,14 +37,9 @@ class Sensei_Customizer {
 			],
 		];
 
-		if ( ! $sensei->feature_flags->is_enabled( 'course_theme' ) ) {
-			return;
-		}
-
 		add_action( 'customize_register', [ $this, 'add_customizer_settings' ] );
 		add_action( 'customize_preview_init', [ $this, 'enqueue_customizer_helper' ] );
 		add_action( 'wp_head', [ $this, 'output_custom_settings' ] );
-
 	}
 
 	/**

--- a/includes/class-sensei-feature-flags.php
+++ b/includes/class-sensei-feature-flags.php
@@ -54,7 +54,6 @@ class Sensei_Feature_Flags {
 			'sensei_default_feature_flag_settings',
 			[
 				'enrolment_provider_tooltip' => false,
-				'course_theme'               => false,
 			]
 		);
 	}

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -304,7 +304,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		// Course Settings.
 		$fields['sensei_learning_mode_all'] = array(
 			'name'        => __( 'Learning mode', 'sensei-lms' ),
-			'description' => __( 'Enable this mode for your courses to show an immersive and dedicated view for the course, lessons, and quiz.*', 'sensei-lms' ),
+			'description' => __( 'Enable this mode for your courses to show an immersive and dedicated view for the course, lessons, and quizzes.', 'sensei-lms' ),
 			'form'        => 'render_learning_mode_setting',
 			'type'        => 'checkbox',
 			'default'     => false,
@@ -870,7 +870,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 			</div>
 			<br />
 			<p class="sensei-settings-learning-mode__description">
-				<?php esc_html_e( 'Enable this mode for your courses to show an immersive and dedicated view for the course, lessons, and quizzes.*', 'sensei-lms' ); ?>
+				<?php echo esc_html( $args['data']['description'] ); ?>
 			</p>
 			<?php if ( $customize_url ) { ?>
 			<br />

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -302,17 +302,14 @@ class Sensei_Settings extends Sensei_Settings_API {
 		);
 
 		// Course Settings.
-
-		if ( Sensei()->feature_flags->is_enabled( 'course_theme' ) ) {
-			$fields['sensei_learning_mode_all'] = array(
-				'name'        => __( 'Learning mode', 'sensei-lms' ),
-				'description' => __( 'Enable this mode for your courses to show an immersive and dedicated view for the course, lessons, and quiz.*', 'sensei-lms' ),
-				'form'        => 'render_learning_mode_setting',
-				'type'        => 'checkbox',
-				'default'     => false,
-				'section'     => 'course-settings',
-			);
-		}
+		$fields['sensei_learning_mode_all'] = array(
+			'name'        => __( 'Learning mode', 'sensei-lms' ),
+			'description' => __( 'Enable this mode for your courses to show an immersive and dedicated view for the course, lessons, and quiz.*', 'sensei-lms' ),
+			'form'        => 'render_learning_mode_setting',
+			'type'        => 'checkbox',
+			'default'     => false,
+			'section'     => 'course-settings',
+		);
 
 		$fields['course_completion'] = array(
 			'name'        => __( 'Courses are complete:', 'sensei-lms' ),

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -27,41 +27,37 @@ class Sensei_Usage_Tracking_Data {
 		$question_type_count = self::get_question_type_count();
 		$quiz_stats          = self::get_quiz_stats();
 		$usage_data          = array(
-			'courses'                 => wp_count_posts( 'course' )->publish,
-			'course_active'           => self::get_course_active_count(),
-			'course_completed'        => self::get_course_completed_count(),
-			'course_completion_rate'  => self::get_course_completion_rate(),
-			'course_videos'           => self::get_course_videos_count(),
-			'course_no_notifications' => self::get_course_no_notifications_count(),
-			'course_prereqs'          => self::get_course_prereqs_count(),
-			'course_featured'         => self::get_course_featured_count(),
-			'enrolments'              => self::get_course_enrolments(),
-			'enrolment_first'         => self::get_first_course_enrolment(),
-			'enrolment_last'          => self::get_last_course_enrolment(),
-			'enrolment_calculated'    => self::get_is_enrolment_calculated() ? 1 : 0,
-			'learners'                => self::get_learner_count(),
-			'lessons'                 => wp_count_posts( 'lesson' )->publish,
-			'lesson_modules'          => self::get_lesson_module_count(),
-			'lesson_prereqs'          => self::get_lesson_prerequisite_count(),
-			'lesson_previews'         => self::get_lesson_preview_count(),
-			'lesson_length'           => self::get_lesson_has_length_count(),
-			'lesson_complexity'       => self::get_lesson_with_complexity_count(),
-			'lesson_videos'           => self::get_lesson_with_video_count(),
-			'messages'                => wp_count_posts( 'sensei_message' )->publish,
-			'modules'                 => wp_count_terms( 'module' ),
-			'modules_max'             => self::get_max_module_count(),
-			'modules_min'             => self::get_min_module_count(),
-			'questions'               => wp_count_posts( 'question' )->publish,
-			'question_media'          => self::get_question_media_count(),
-			'question_random_order'   => self::get_question_random_order_count(),
-			'teachers'                => self::get_teacher_count(),
+			'courses'                       => wp_count_posts( 'course' )->publish,
+			'course_active'                 => self::get_course_active_count(),
+			'course_completed'              => self::get_course_completed_count(),
+			'course_completion_rate'        => self::get_course_completion_rate(),
+			'course_videos'                 => self::get_course_videos_count(),
+			'course_no_notifications'       => self::get_course_no_notifications_count(),
+			'course_prereqs'                => self::get_course_prereqs_count(),
+			'course_featured'               => self::get_course_featured_count(),
+			'enrolments'                    => self::get_course_enrolments(),
+			'enrolment_first'               => self::get_first_course_enrolment(),
+			'enrolment_last'                => self::get_last_course_enrolment(),
+			'enrolment_calculated'          => self::get_is_enrolment_calculated() ? 1 : 0,
+			'learners'                      => self::get_learner_count(),
+			'lessons'                       => wp_count_posts( 'lesson' )->publish,
+			'lesson_modules'                => self::get_lesson_module_count(),
+			'lesson_prereqs'                => self::get_lesson_prerequisite_count(),
+			'lesson_previews'               => self::get_lesson_preview_count(),
+			'lesson_length'                 => self::get_lesson_has_length_count(),
+			'lesson_complexity'             => self::get_lesson_with_complexity_count(),
+			'lesson_videos'                 => self::get_lesson_with_video_count(),
+			'messages'                      => wp_count_posts( 'sensei_message' )->publish,
+			'modules'                       => wp_count_terms( 'module' ),
+			'modules_max'                   => self::get_max_module_count(),
+			'modules_min'                   => self::get_min_module_count(),
+			'questions'                     => wp_count_posts( 'question' )->publish,
+			'question_media'                => self::get_question_media_count(),
+			'question_random_order'         => self::get_question_random_order_count(),
+			'teachers'                      => self::get_teacher_count(),
+			'courses_using_course_theme'    => self::get_courses_using_course_theme_count(),
+			'course_theme_enabled_globally' => self::get_is_course_theme_enabled_globally() ? 1 : 0,
 		);
-
-		if ( Sensei()->feature_flags->is_enabled( 'course_theme' ) ) {
-			// After removing the feature flag, remember to move this to the $usage_data variable assignment.
-			$usage_data['courses_using_course_theme']    = self::get_courses_using_course_theme_count();
-			$usage_data['course_theme_enabled_globally'] = self::get_is_course_theme_enabled_globally() ? 1 : 0;
-		}
 
 		return array_merge( $question_type_count, $usage_data, $quiz_stats );
 	}

--- a/includes/class-sensei-usage-tracking-data.php
+++ b/includes/class-sensei-usage-tracking-data.php
@@ -949,7 +949,7 @@ class Sensei_Usage_Tracking_Data {
 	 * @return bool
 	 */
 	private static function get_is_course_theme_enabled_globally() {
-		return (bool) Sensei()->settings->settings['sensei_learning_mode_all'];
+		return (bool) \Sensei()->settings->get( 'sensei_learning_mode_all' );
 	}
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -409,17 +409,17 @@ class Sensei_Main {
 		// data will be sent.
 		$this->usage_tracking->schedule_tracking_task();
 
-		$this->blocks = new Sensei_Blocks( $this );
+		$this->blocks = new Sensei_Blocks();
 
 		Sensei_Learner::instance()->init();
 		Sensei_Course_Enrolment_Manager::instance()->init();
 		$this->enrolment_scheduler = Sensei_Enrolment_Job_Scheduler::instance();
 		$this->enrolment_scheduler->init();
 		Sensei_Data_Port_Manager::instance()->init();
-		Sensei_Course_Theme_Option::instance()->init( $this );
-		Sensei_Course_Theme::instance()->init( $this );
-		Sensei_Course_Theme_Editor::instance()->init( $this );
-		new Sensei_Customizer( $this );
+		Sensei_Course_Theme_Option::instance()->init();
+		Sensei_Course_Theme::instance()->init();
+		Sensei_Course_Theme_Editor::instance()->init();
+		new Sensei_Customizer();
 
 		// Setup Wizard.
 		$this->setup_wizard = Sensei_Setup_Wizard::instance();

--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -58,15 +58,8 @@ class Sensei_Course_Theme_Editor {
 
 	/**
 	 * Initializes the Course Theme Editor.
-	 *
-	 * @param Sensei_Main $sensei Sensei object.
 	 */
-	public function init( $sensei ) {
-
-		if ( ! $sensei->feature_flags->is_enabled( 'course_theme' ) ) {
-			return;
-		}
-
+	public function init() {
 		add_action( 'admin_init', [ $this, 'maybe_add_site_editor_hooks' ] );
 		add_action( 'rest_api_init', [ $this, 'maybe_add_site_editor_hooks' ] );
 

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -142,7 +142,7 @@ class Sensei_Course_Theme_Option {
 	public static function has_sensei_theme_enabled( int $course_id ) {
 		$theme              = get_post_meta( $course_id, self::THEME_POST_META_NAME, true );
 		$enabled_for_course = self::SENSEI_THEME === $theme;
-		$enabled_globally   = (bool) \Sensei()->settings->settings['sensei_learning_mode_all'];
+		$enabled_globally   = (bool) \Sensei()->settings->get( 'sensei_learning_mode_all' );
 
 		/**
 		 * Filters if a course has learning mode enabled.

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -58,17 +58,8 @@ class Sensei_Course_Theme_Option {
 
 	/**
 	 * Initializes the Course Theme.
-	 *
-	 * @param Sensei_Main $sensei Sensei object.
 	 */
-	public function init( $sensei ) {
-		add_action( 'admin_enqueue_scripts', [ $this, 'add_feature_flag_inline_script' ] );
-
-		if ( ! $sensei->feature_flags->is_enabled( 'course_theme' ) ) {
-			// As soon this feature flag check is removed, the `$sensei` argument can also be removed.
-			return;
-		}
-
+	public function init() {
 		// Init blocks.
 		new \Sensei\Blocks\Course_Theme();
 
@@ -76,20 +67,6 @@ class Sensei_Course_Theme_Option {
 		add_action( 'template_redirect', [ $this, 'ensure_learning_mode_url_prefix' ] );
 		add_filter( 'show_admin_bar', [ $this, 'show_admin_bar_only_for_editors' ] );
 		add_filter( 'sensei_admin_notices', [ $this, 'add_course_theme_notice' ] );
-	}
-
-	/**
-	 * Add feature flag inline script.
-	 *
-	 * @access private
-	 */
-	public function add_feature_flag_inline_script() {
-		$screen  = get_current_screen();
-		$enabled = Sensei()->feature_flags->is_enabled( 'course_theme' ) ? 'true' : 'false';
-
-		if ( 'course' === $screen->id ) {
-			wp_add_inline_script( 'sensei-admin-course-edit', 'window.senseiCourseThemeFeatureFlagEnabled = ' . $enabled, 'before' );
-		}
 	}
 
 	/**

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -61,16 +61,8 @@ class Sensei_Course_Theme {
 
 	/**
 	 * Initializes the Course Theme.
-	 *
-	 * @param Sensei_Main $sensei Sensei object.
 	 */
-	public function init( $sensei ) {
-
-		if ( ! $sensei->feature_flags->is_enabled( 'course_theme' ) ) {
-			// As soon this feature flag check is removed, the `$sensei` argument can also be removed.
-			return;
-		}
-
+	public function init() {
 		add_action( 'setup_theme', [ $this, 'add_rewrite_rules' ], 10 );
 		add_action( 'setup_theme', [ $this, 'maybe_override_theme' ], 20 );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Lesson::instance(), 'init' ] );

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -139,7 +139,5 @@ class Sensei_Unit_Tests_Bootstrap {
 	}
 }
 
-define( 'SENSEI_FEATURE_FLAG_COURSE_THEME', true );
-
 Sensei_Unit_Tests_Bootstrap::instance();
 

--- a/tests/unit-tests/test-class-sensei-usage-tracking-data.php
+++ b/tests/unit-tests/test-class-sensei-usage-tracking-data.php
@@ -15,8 +15,6 @@ class Sensei_Usage_Tracking_Data_Test extends WP_UnitTestCase {
 	public function setUp() {
 		parent::setUp();
 
-		tests_add_filter( 'sensei_feature_flag_course_theme', '__return_true' );
-
 		$this->factory = new Sensei_Factory();
 		self::resetCourseEnrolmentManager();
 	}


### PR DESCRIPTION
Fixes #4488

### Changes proposed in this Pull Request

* It removes the Course Theme feature flag checks, and makes it enabled by default.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* If you have, remove the `course-theme` feature flag activation.
* Create a new course with learning mode enabled. And make sure the following features continue working properly.
  * Customize it through customizer.
  * Customize it through FSE.
  * Enable it for all courses through Sensei settings.