### PR TITLE
Fix/learning mode a11y

### DIFF
--- a/assets/blocks/frontend.js
+++ b/assets/blocks/frontend.js
@@ -35,7 +35,6 @@ domReady( () => {
 		}
 
 		let originalHeight = content.offsetHeight + 'px';
-		const originalDisplay = content.style.display;
 
 		if ( content.classList.contains( 'collapsed' ) ) {
 			const transition = content.style.transition;
@@ -60,7 +59,7 @@ domReady( () => {
 				// Browser needs to render the element first and
 				// change it's height later in order to animate the transition.
 				window.requestAnimationFrame( () => {
-					content.style.display = originalDisplay;
+					content.style.display = '';
 					window.requestAnimationFrame( () => {
 						content.style.maxHeight = originalHeight;
 					} );

--- a/assets/blocks/frontend.js
+++ b/assets/blocks/frontend.js
@@ -8,6 +8,13 @@ import domReady from '@wordpress/dom-ready';
  */
 import '../js/sensei-modal';
 
+/**
+ * The collapse/expand transition duration in milliseconds.
+ *
+ * @constant {number}
+ */
+const TRANSITION_DURATION = 350;
+
 domReady( () => {
 	if (
 		0 === document.querySelectorAll( '.sensei-collapsible__toggle' ).length
@@ -28,6 +35,7 @@ domReady( () => {
 		}
 
 		let originalHeight = content.offsetHeight + 'px';
+		const originalDisplay = content.style.display;
 
 		if ( content.classList.contains( 'collapsed' ) ) {
 			const transition = content.style.transition;
@@ -36,19 +44,34 @@ domReady( () => {
 			originalHeight = content.offsetHeight + 'px';
 			content.style.maxHeight = 0;
 			content.style.transition = transition;
+			content.style.display = 'none';
 		} else {
 			content.style.maxHeight = originalHeight;
 		}
 
+		let transitionTimeoutId = null;
 		toggleButton.addEventListener( 'click', ( e ) => {
 			e.preventDefault();
 			toggleButton.classList.toggle( 'collapsed' );
 			const collapsed = content.classList.toggle( 'collapsed' );
 
+			clearTimeout( transitionTimeoutId );
 			if ( ! collapsed ) {
-				content.style.maxHeight = originalHeight;
+				window.requestAnimationFrame( () => {
+					content.style.display = originalDisplay;
+					window.requestAnimationFrame( () => {
+						content.style.maxHeight = originalHeight;
+					} );
+				} );
 			} else {
 				content.style.maxHeight = '0px';
+
+				// At the end of the collapse animation, we set the content
+				// display to "none", so the elements inside the content do not
+				// get focus when user navigates by tabbing through buttons and links.
+				transitionTimeoutId = setTimeout( () => {
+					content.style.display = 'none';
+				}, TRANSITION_DURATION );
 			}
 		} );
 	} );

--- a/assets/blocks/frontend.js
+++ b/assets/blocks/frontend.js
@@ -8,13 +8,6 @@ import domReady from '@wordpress/dom-ready';
  */
 import '../js/sensei-modal';
 
-/**
- * The collapse/expand transition duration in milliseconds.
- *
- * @constant {number}
- */
-const TRANSITION_DURATION = 350;
-
 domReady( () => {
 	if (
 		0 === document.querySelectorAll( '.sensei-collapsible__toggle' ).length
@@ -48,13 +41,11 @@ domReady( () => {
 			content.style.maxHeight = originalHeight;
 		}
 
-		let transitionTimeoutId = null;
 		toggleButton.addEventListener( 'click', ( e ) => {
 			e.preventDefault();
 			toggleButton.classList.toggle( 'collapsed' );
 			const collapsed = content.classList.toggle( 'collapsed' );
 
-			clearTimeout( transitionTimeoutId );
 			if ( ! collapsed ) {
 				// Browser needs to render the element first and
 				// change it's height later in order to animate the transition.
@@ -66,13 +57,12 @@ domReady( () => {
 				} );
 			} else {
 				content.style.maxHeight = '0px';
+			}
+		} );
 
-				// At the end of the collapse animation, we set the content
-				// display to "none", so the elements inside the content do not
-				// get focus when user navigates by tabbing through buttons and links.
-				transitionTimeoutId = setTimeout( () => {
-					content.style.display = 'none';
-				}, TRANSITION_DURATION );
+		content.addEventListener( 'transitionend', () => {
+			if ( content.classList.contains( 'collapsed' ) ) {
+				content.style.display = 'none';
 			}
 		} );
 	} );

--- a/assets/blocks/frontend.js
+++ b/assets/blocks/frontend.js
@@ -34,6 +34,7 @@ domReady( () => {
 			content.style.transition = 'unset';
 			content.style.maxHeight = 'unset';
 			originalHeight = content.offsetHeight + 'px';
+			content.style.visibility = 'hidden';
 			content.style.maxHeight = 0;
 			content.style.transition = transition;
 		} else {

--- a/assets/blocks/frontend.js
+++ b/assets/blocks/frontend.js
@@ -46,15 +46,18 @@ domReady( () => {
 			const collapsed = content.classList.toggle( 'collapsed' );
 
 			if ( ! collapsed ) {
-				content.style.visibility = 'visible';
+				content.style.visibility = '';
 				content.style.maxHeight = originalHeight;
 			} else {
 				content.style.maxHeight = '0px';
 			}
 		} );
 
-		content.addEventListener( 'transitionend', () => {
-			if ( content.classList.contains( 'collapsed' ) ) {
+		content.addEventListener( 'transitionend', ( e ) => {
+			if (
+				'max-height' === e.propertyName &&
+				content.classList.contains( 'collapsed' )
+			) {
 				content.style.visibility = 'hidden';
 			}
 		} );

--- a/assets/blocks/frontend.js
+++ b/assets/blocks/frontend.js
@@ -57,6 +57,8 @@ domReady( () => {
 
 			clearTimeout( transitionTimeoutId );
 			if ( ! collapsed ) {
+				// Browser needs to render the element first and
+				// change it's height later in order to animate the transition.
 				window.requestAnimationFrame( () => {
 					content.style.display = originalDisplay;
 					window.requestAnimationFrame( () => {

--- a/assets/blocks/frontend.js
+++ b/assets/blocks/frontend.js
@@ -36,7 +36,6 @@ domReady( () => {
 			originalHeight = content.offsetHeight + 'px';
 			content.style.maxHeight = 0;
 			content.style.transition = transition;
-			content.style.display = 'none';
 		} else {
 			content.style.maxHeight = originalHeight;
 		}
@@ -47,14 +46,8 @@ domReady( () => {
 			const collapsed = content.classList.toggle( 'collapsed' );
 
 			if ( ! collapsed ) {
-				// Browser needs to render the element first and
-				// change it's height later in order to animate the transition.
-				window.requestAnimationFrame( () => {
-					content.style.display = '';
-					window.requestAnimationFrame( () => {
-						content.style.maxHeight = originalHeight;
-					} );
-				} );
+				content.style.visibility = 'visible';
+				content.style.maxHeight = originalHeight;
 			} else {
 				content.style.maxHeight = '0px';
 			}
@@ -62,7 +55,7 @@ domReady( () => {
 
 		content.addEventListener( 'transitionend', () => {
 			if ( content.classList.contains( 'collapsed' ) ) {
-				content.style.display = 'none';
+				content.style.visibility = 'hidden';
 			}
 		} );
 	} );

--- a/assets/course-theme/contact-teacher.js
+++ b/assets/course-theme/contact-teacher.js
@@ -30,7 +30,7 @@ export function submitContactTeacher( ev ) {
 	const submitButton = form.querySelector(
 		'button.sensei-contact-teacher-form__submit'
 	);
-	const closeButton = document.querySelector(
+	const closeButton = form.parentElement.querySelector(
 		'.sensei-contact-teacher-close'
 	);
 	submitButton.classList.add( 'sensei-course-theme__button', 'is-busy' );

--- a/assets/course-theme/contact-teacher.js
+++ b/assets/course-theme/contact-teacher.js
@@ -27,10 +27,14 @@ export function submitContactTeacher( ev ) {
 	ev.preventDefault();
 
 	const form = ev.target;
-	const submitButton = ev.target.querySelector(
+	const submitButton = form.querySelector(
 		'button.sensei-contact-teacher-form__submit'
 	);
+	const closeButton = document.querySelector(
+		'.sensei-contact-teacher-close'
+	);
 	submitButton.classList.add( 'sensei-course-theme__button', 'is-busy' );
+	submitButton.disabled = true;
 
 	const fieldNames = [
 		'sensei_message_teacher_nonce',
@@ -57,6 +61,7 @@ export function submitContactTeacher( ev ) {
 		} )
 		.then( () => {
 			form.classList.add( 'is-success' );
+			closeButton.focus();
 		} )
 		.catch( () => {
 			// TODO: Show submit failed message.

--- a/assets/course-theme/contact-teacher.js
+++ b/assets/course-theme/contact-teacher.js
@@ -31,7 +31,6 @@ export function submitContactTeacher( ev ) {
 		'button.sensei-contact-teacher-form__submit'
 	);
 	submitButton.classList.add( 'sensei-course-theme__button', 'is-busy' );
-	submitButton.disabled = true;
 
 	const fieldNames = [
 		'sensei_message_teacher_nonce',

--- a/assets/course-theme/focus-mode.js
+++ b/assets/course-theme/focus-mode.js
@@ -24,7 +24,7 @@ const restoreFocusModeState = () => {
 	try {
 		const wasActive = JSON.parse( savedState );
 		if ( 'boolean' === typeof wasActive ) {
-			toggleFocusMode( wasActive );
+			toggleFocusMode( wasActive, true );
 		}
 	} catch ( e ) {}
 };
@@ -33,17 +33,21 @@ const restoreFocusModeState = () => {
  * Toggle focus mode.
  *
  * @param {boolean?} on
+ * @param {boolean?} restore Whether restoring.
  */
-const toggleFocusMode = ( on ) => {
+const toggleFocusMode = ( on, restore ) => {
 	const { classList } = document.body;
 
+	const courseNavigation = document.querySelector(
+		'.sensei-lms-course-navigation'
+	);
 	const isActive = classList.contains( FOCUS_MODE_CLASS );
 	const next = 'undefined' === typeof on ? ! isActive : on;
 
 	if ( ! next ) {
-		document.querySelector(
-			'.sensei-lms-course-navigation'
-		).style.visibility = '';
+		courseNavigation.style.visibility = '';
+	} else if ( restore ) {
+		courseNavigation.style.visibility = 'hidden';
 	}
 
 	classList.toggle( FOCUS_MODE_CLASS, next );

--- a/assets/course-theme/focus-mode.js
+++ b/assets/course-theme/focus-mode.js
@@ -38,8 +38,14 @@ const toggleFocusMode = ( on ) => {
 	const { classList } = document.body;
 
 	const isActive = classList.contains( FOCUS_MODE_CLASS );
-
 	const next = 'undefined' === typeof on ? ! isActive : on;
+
+	if ( ! next ) {
+		document.querySelector(
+			'.sensei-lms-course-navigation'
+		).style.visibility = '';
+	}
+
 	classList.toggle( FOCUS_MODE_CLASS, next );
 	window.sessionStorage.setItem( FOCUS_MODE_CLASS, JSON.stringify( next ) );
 };
@@ -47,6 +53,19 @@ const toggleFocusMode = ( on ) => {
 // eslint-disable-next-line @wordpress/no-global-event-listener
 window.addEventListener( 'DOMContentLoaded', () => {
 	initFocusMode();
+
+	document
+		.querySelector( '.sensei-course-theme__sidebar' )
+		.addEventListener( 'transitionend', ( e ) => {
+			if (
+				'left' === e.propertyName &&
+				document.body.classList.contains( FOCUS_MODE_CLASS )
+			) {
+				document.querySelector(
+					'.sensei-lms-course-navigation'
+				).style.visibility = 'hidden';
+			}
+		} );
 } );
 
 export { toggleFocusMode };

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -4,7 +4,7 @@
 }
 
 body {
-	--primary-color: var(--sensei-course-theme-primary-color, var(--wp--custom--color--primary, #30968B));
+	--primary-color: var(--sensei-course-theme-primary-color, var(--wp--custom--color--primary, #307771));
 	--bg-color: var(--sensei-course-theme-background-color, var(--wp--custom--color--background-color, #FFFFFF));
 	--primary-contrast-color: var(--bg-color);
 	--text-color: var(--sensei-course-theme-foreground-color, var(--wp--custom--color--foreground-color, #1E1E1E));

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -40,11 +40,8 @@ body {
 	line-height: 1.5;
 	letter-spacing: normal;
 
-<<<<<<< HEAD
 	* {
 		font-family: 'Inter', sans-serif;
 	}
 
-=======
->>>>>>> 5adea823c (Apply focus outline styles to all buttons and links.)
 }

--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -40,8 +40,11 @@ body {
 	line-height: 1.5;
 	letter-spacing: normal;
 
+<<<<<<< HEAD
 	* {
 		font-family: 'Inter', sans-serif;
 	}
 
+=======
+>>>>>>> 5adea823c (Apply focus outline styles to all buttons and links.)
 }

--- a/assets/css/sensei-course-theme/blockbase-ponyfill.scss
+++ b/assets/css/sensei-course-theme/blockbase-ponyfill.scss
@@ -203,7 +203,7 @@ a:hover, a:focus {
 }
 
 a:not(.ab-item):not(.screen-reader-shortcut):active, a:not(.ab-item):not(.screen-reader-shortcut):focus {
-	outline: 1px dotted currentColor;
+	outline: 1px dashed var(--primary-color);
 	text-decoration: none;
 }
 
@@ -252,14 +252,14 @@ input[type="color"]:focus,
 textarea:focus {
 	border-color: var(--custom--form--color--border);
 	color: var(--wp--custom--form--color--text);
-	outline: 1px dotted currentColor;
+	outline: 1px dashed var(--primary-color);
 	outline-offset: 2px;
 }
 
 input[type="checkbox"]:focus,
 input[type="submit"]:focus,
 button:focus {
-	outline: 1px dotted currentColor;
+	outline: 1px dashed var(--primary-color);
 	outline-offset: 2px;
 }
 
@@ -733,7 +733,7 @@ p.has-drop-cap:not(:focus):first-letter {
 }
 
 .wp-block-post-comments form .comment-form-cookies-consent input[type="checkbox"]:focus + ::before {
-	outline: 1px dotted currentColor;
+	outline: 1px dashed var(--primary-color);
 	outline-offset: 2px;
 }
 

--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -1,3 +1,10 @@
+.sensei-course-theme__frame {
+	a, button {
+		&:focus {
+			outline: dashed 1px var(--primary-color);
+		}
+	}
+}
 
 .wp-block-button .wp-block-button__link {
 	all: unset;
@@ -27,6 +34,19 @@
 		font-weight: 700;
 		text-decoration: none;
 		border-radius: 2px;
+	}
+
+	&.wp-block-button {
+		padding: 0;
+		.wp-block-button__link {
+			padding: 8px 11px;
+			display: block;
+			&:focus {
+				outline: dashed 1px var(--primary-color);
+				margin: -1px;
+				padding: 9px 12px;
+			}
+		}
 	}
 
 	&.is-primary,

--- a/assets/css/sensei-course-theme/contact-teacher.scss
+++ b/assets/css/sensei-course-theme/contact-teacher.scss
@@ -37,10 +37,10 @@
 		font-family: inherit;
 		display: block;
 		position: absolute;
-		top: 0;
-		right: 0;
-		bottom: 0;
-		left: 0;
+		top: -5px;
+		right: -5px;
+		bottom: -5px;
+		left: -5px;
 		padding-top: 30px;
 		display: flex;
 		justify-content: center;

--- a/assets/css/sensei-course-theme/course-navigation.scss
+++ b/assets/css/sensei-course-theme/course-navigation.scss
@@ -65,7 +65,7 @@
 
 .sensei-lms-course-navigation-lesson {
 	display: flex;
-	padding: 10px 0;
+	padding: 10px 1px;
 
 	&__link {
 		flex: 1;

--- a/assets/css/sensei-course-theme/header.scss
+++ b/assets/css/sensei-course-theme/header.scss
@@ -3,7 +3,7 @@
 		a:not(:hover) {
 			color: currentColor;
 		}
-		padding: 1px;
+		padding: 1px 2px;
 		font-size: 24px;
 		font-weight: 600;
 		overflow: hidden;

--- a/assets/css/sensei-course-theme/header.scss
+++ b/assets/css/sensei-course-theme/header.scss
@@ -3,6 +3,7 @@
 		a:not(:hover) {
 			color: currentColor;
 		}
+		padding: 1px;
 		font-size: 24px;
 		font-weight: 600;
 		overflow: hidden;

--- a/assets/js/sensei-modal.js
+++ b/assets/js/sensei-modal.js
@@ -1,3 +1,5 @@
+/* eslint @wordpress/no-global-active-element: 0 -- Not relevant out of React.  */
+
 /**
  * Internal dependencies
  */
@@ -27,6 +29,8 @@ import { querySelectorAncestor } from '../shared/helpers/DOM';
  * ```
  */
 
+let lastActiveElement = document.activeElement;
+
 /**
  * Opens the modal
  * @param {MouseEvent} ev The click event.
@@ -55,19 +59,25 @@ const openModal = ( ev ) => {
 	} );
 
 	// Open the modal.
-	setTimeout(
-		() => {
+	// Make sure the elements are opened only after they are painted by
+	// the browser first. Otherwise the transition effects do not work.
+	window.requestAnimationFrame( () =>
+		window.requestAnimationFrame( () => {
 			modalElementCopy.setAttribute( 'data-sensei-modal-is-open', '' );
 			document.body.dispatchEvent(
 				new CustomEvent( 'sensei-modal-open', {
 					detail: modalElementCopy,
 				} )
 			);
-		},
-
-		// Make sure the elements are opened only after they are painted by
-		// the browser first. Otherwise the transition effects do not work.
-		20
+			lastActiveElement = document.activeElement;
+			const content = modalElementCopy.querySelector(
+				'[data-sensei-modal-content]'
+			);
+			if ( content ) {
+				content.tabIndex = 0;
+				content.focus();
+			}
+		} )
 	);
 };
 
@@ -86,6 +96,7 @@ const closeModal = ( ev ) => {
 					detail: modalElement,
 				} )
 			);
+			lastActiveElement?.focus();
 		} );
 };
 

--- a/assets/js/sensei-modal.js
+++ b/assets/js/sensei-modal.js
@@ -29,6 +29,11 @@ import { querySelectorAncestor } from '../shared/helpers/DOM';
  * ```
  */
 
+/**
+ * The last focused element in the document.
+ *
+ * @type {Element}
+ */
 let lastActiveElement = document.activeElement;
 
 /**
@@ -123,3 +128,13 @@ function attachModalEvents() {
 // Init modal when the DOM is fully ready.
 // eslint-disable-next-line @wordpress/no-global-event-listener
 window.addEventListener( 'load', attachModalEvents );
+
+/**
+ * Support for closing the Modal on Esc key.
+ */
+// eslint-disable-next-line @wordpress/no-global-event-listener
+document.addEventListener( 'keydown', ( ev ) => {
+	if ( [ 'Esc', 'Escape' ].includes( ev.key ) ) {
+		closeModal();
+	}
+} );

--- a/includes/blocks/class-sensei-block-contact-teacher.php
+++ b/includes/blocks/class-sensei-block-contact-teacher.php
@@ -77,13 +77,14 @@ class Sensei_Block_Contact_Teacher {
 		$contact_form_open = isset( $_GET['contact'] ) && ! ( isset( $_GET['send'] ) && 'complete' === $_GET['send'] );
 
 		$contact_form = $this->teacher_contact_form( $post );
+		$text_close   = __( 'Close', 'sensei-lms' );
 
 		return '<div id="private_message" class="sensei-block-wrapper sensei-collapsible" data-sensei-modal ' . ( $contact_form_open ? 'data-sensei-modal-is-open' : '' ) . '>
 				' . ( $this->add_button_attributes( $content, $contact_form_link ) ) . '
-				<a href="' . $post_link . '" data-sensei-modal-overlay></a>
+				<a href="' . $post_link . '" data-sensei-modal-overlay aria-label="' . $text_close . '"></a>
 				<div data-sensei-modal-content>
 					' . $contact_form . '
-					<a class="sensei-contact-teacher-close" href="' . $post_link . '" data-sensei-modal-close>
+					<a class="sensei-contact-teacher-close" href="' . $post_link . '" data-sensei-modal-close title="' . $text_close . '">
 						' . \Sensei()->assets->get_icon( 'close' ) . '
 					</a>
 				</div>

--- a/includes/blocks/course-theme/class-next-lesson.php
+++ b/includes/blocks/course-theme/class-next-lesson.php
@@ -58,7 +58,7 @@ class Next_Lesson {
 		$icon = \Sensei()->assets->get_icon( 'chevron-right' );
 
 		return ( "
-			<a class='sensei-course-theme-prev-next-lesson-a sensei-course-theme-prev-next-lesson-a__next' href='{$url}'>
+			<a class='sensei-course-theme-prev-next-lesson-a sensei-course-theme-prev-next-lesson-a__next' href='{$url}' aria-label='{$text}'>
 				<span class='sensei-course-theme-prev-next-lesson-text sensei-course-theme-prev-next-lesson-text__next'>
 					{$text}
 				</span>

--- a/includes/blocks/course-theme/class-prev-lesson.php
+++ b/includes/blocks/course-theme/class-prev-lesson.php
@@ -58,7 +58,7 @@ class Prev_Lesson {
 		$icon = \Sensei()->assets->get_icon( 'chevron-left' );
 
 		return ( "
-			<a class='sensei-course-theme-prev-next-lesson-a sensei-course-theme-prev-next-lesson-a__prev' href='{$url}'>
+			<a class='sensei-course-theme-prev-next-lesson-a sensei-course-theme-prev-next-lesson-a__prev' href='{$url}' aria-label='{$text}'>
 				{$icon}
 				<span class='sensei-course-theme-prev-next-lesson-text sensei-course-theme-prev-next-lesson-text__prev'>
 					{$text}


### PR DESCRIPTION
Fixes #4608

### Changes proposed in this Pull Request

* Hides the collapsed content with `display: none;` css rule. This prevents the elements inside the collapsed content to capture focus when user navigates via tab key.
  * ⚠️ Didn't have time to do the same for sidebar closing/opening. The issue is that the "Collapse/Expand" button is located inside the sidebar content and if we set display `none` to sidebar then the buttons is also not visible. Didn't want to make too much change to the Learning Mode template when we're close to freezing the code.
* Adds title/aria-label to some actionable elements that does not have textual representation.
* Adds a little CSS to clearly outline the elements in focus.
* Adds support for sensei-modal to jump element focus onto the modal when it's opened and when the modal is closed, jumps back to the last element that was on focus before modal opening.
  * ⚠️ We also need to support retaining the focus inside the model while it is open. Currently when a person tabs through all the elements inside the modal it does not cycle back to first element inside the modal but instead focuses the next element outside the modal content. Didn't have time to dig into this.
* Adds support for close on `Escape` key for sensei-modal.
* Updates the default `--primary-color` to meet the a11y contrast ration requirement.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Enable the feature flag: `add_filter( 'sensei_feature_flag_course_theme', '__return_true' );`
* Enable Learning Mode to a Course and create a lesson with quiz (with pagination) and with contact teacher block inside the lesson content.
* Visit this lesson page and using only keyboard:
  * confirm that you can navigate through the actionable elements (buttons and links).
  * confirm that you can see clearly when the elements are in focus.
  * confirm that you can navigate through course navigation without the focus being lost inside the collapsed modules.
  * confirm that you can open the contact teacher modal, write a message, send the message and then close it.
  * confirm that after closing the contact teacher modal the "Contact Teacher" button gets it's focus back.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Navigating without a mouse!

https://user-images.githubusercontent.com/2578542/150535140-5da50099-b6c7-4480-ba98-ffb811de864a.mp4

#### Lesson Page Before
<img width="840" alt="lesson-before" src="https://user-images.githubusercontent.com/2578542/150535255-df066f0c-33b5-451d-9045-5fc0e08e5ae7.png">

#### Lesson Page After
<img width="905" alt="lesson-after" src="https://user-images.githubusercontent.com/2578542/150535300-534e9b83-2989-42bb-8940-89b1c3d53077.png">

#### Quiz Page Before
<img width="905" alt="quiz-before" src="https://user-images.githubusercontent.com/2578542/150535337-d25f7794-5f8e-4b7f-a34f-2e816f0cf88f.png">

#### Quiz Page After
<img width="905" alt="quiz-after" src="https://user-images.githubusercontent.com/2578542/150535382-80ce36e8-217a-4bcf-9fb0-779fd350ed4b.png">

