### PR TITLE
Fix various course theme styling issues

### DIFF
--- a/assets/css/sensei-course-theme/blockbase-ponyfill.scss
+++ b/assets/css/sensei-course-theme/blockbase-ponyfill.scss
@@ -13,7 +13,7 @@ body {
 }
 
 pre {
-	overflow: scroll;
+	overflow: auto;
 }
 
 button {
@@ -32,6 +32,11 @@ button {
 	margin-left: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
 	margin-right: calc(-1 * var(--wp--custom--gap--horizontal)) !important;
 	width: unset;
+	max-width: unset;
+}
+
+.wp-site-blocks .alignwide {
+	max-width: var(--wp--custom--layout--wide-size);
 }
 
 .wp-site-blocks .alignfull.wp-block-template-part, .wp-site-blocks .alignfull.wp-block-columns, .wp-site-blocks .alignfull.wp-block-group {

--- a/assets/css/sensei-course-theme/content.scss
+++ b/assets/css/sensei-course-theme/content.scss
@@ -19,6 +19,11 @@ input, textarea {
 	font-size: inherit;
 }
 
+::selection {
+	background-color: var(--primary-color);
+	color: var(--primary-contrast-color);
+}
+
 .sensei-course-theme {
 	&__main-content {
 		> * {

--- a/assets/css/sensei-course-theme/content.scss
+++ b/assets/css/sensei-course-theme/content.scss
@@ -1,4 +1,5 @@
 @import './blockbase-ponyfill';
+@import './global-styles';
 
 body {
 	--wp--custom--form--color--background: var(--bg-color);
@@ -8,7 +9,10 @@ body {
 	--wp--custom--form--border--radius: 2px;
 	--wp--custom--form--color--text: inherit;
 	--wp--custom--form--padding: 6px 8px;
+}
 
+a {
+	color: var(--primary-color);
 }
 
 input, textarea {
@@ -17,24 +21,32 @@ input, textarea {
 
 .sensei-course-theme {
 	&__main-content {
-
 		> * {
-			max-width: 900px;
+			max-width: var(--wp--custom--layout--content-size);
 			margin-left: auto;
 			margin-right: auto;
 		}
 
-		.alignfull {
-			margin-left: calc( -1 * var(--content-padding));
-			margin-right: calc( -1 * var(--content-padding));
+		.entry-content {
 			max-width: unset;
-			width: auto;
-		}
-
-		img {
-			max-width: 100%;
-			height: auto;
 		}
 	}
 }
+
+.entry-content {
+	--wp--custom--gap--horizontal: var(--content-padding);
+	--wp--custom--gap--vertical: 12px;
+
+	> * {
+		max-width: var(--wp--custom--layout--content-size);
+		margin-left: auto;
+		margin-right: auto;
+	}
+
+	img {
+		max-width: 100%;
+		height: auto;
+	}
+}
+
 

--- a/assets/css/sensei-course-theme/global-styles.scss
+++ b/assets/css/sensei-course-theme/global-styles.scss
@@ -1,0 +1,460 @@
+body {
+	--wp--preset--font-size--small: 16px;
+	--wp--preset--font-size--medium: 24px;
+	--wp--preset--font-size--large: 28px;
+	--wp--preset--font-size--x-large: 42px;
+	--wp--preset--font-size--normal: 18px;
+	--wp--preset--font-size--huge: 32px;
+	--wp--preset--font-family--body-font: "Source Serif Pro", serif;
+	--wp--preset--font-family--heading-font: "Source Serif Pro", serif;
+	--wp--preset--font-family--ui-font: Inter, sans-serif;
+	--wp--custom--separator--margin: var(--wp--custom--gap--vertical) auto;
+	--wp--custom--color--foreground: var(--wp--preset--color--foreground);
+	--wp--custom--color--background: var(--wp--preset--color--background);
+	--wp--custom--color--primary: var(--wp--preset--color--primary);
+	--wp--custom--color--border: var(--wp--preset--color--border);
+	--wp--custom--body--typography--line-height: 1.6;
+	--wp--custom--layout--content-size: 900px;
+	--wp--custom--layout--wide-size: 1100px;
+
+}
+
+body {
+	margin: 0;
+}
+
+body {
+	font-family: var(--wp--preset--font-family--body-font);
+	font-size: var(--wp--preset--font-size--normal);
+	line-height: var(--wp--custom--body--typography--line-height);
+}
+
+.wp-site-blocks > .alignleft {
+	float: left;
+	margin-right: 2em;
+}
+
+.wp-site-blocks > .alignright {
+	float: right;
+	margin-left: 2em;
+}
+
+.wp-site-blocks > .aligncenter {
+	justify-content: center;
+	margin-left: auto;
+	margin-right: auto;
+}
+
+h1 {
+	font-family: var(--wp--preset--font-family--heading-font);
+	font-size: 48px;
+	font-weight: var(--wp--custom--heading--typography--font-weight);
+	line-height: var(--wp--custom--heading--typography--line-height);
+	margin-top: var(--wp--custom--gap--vertical);
+	margin-bottom: var(--wp--custom--gap--vertical);
+}
+
+h2 {
+	font-family: var(--wp--preset--font-family--heading-font);
+	font-size: var(--wp--preset--font-size--huge);
+	font-weight: var(--wp--custom--heading--typography--font-weight);
+	line-height: var(--wp--custom--heading--typography--line-height);
+	margin-top: var(--wp--custom--gap--vertical);
+	margin-bottom: var(--wp--custom--gap--vertical);
+}
+
+h3 {
+	font-family: var(--wp--preset--font-family--heading-font);
+	font-size: var(--wp--preset--font-size--large);
+	font-weight: var(--wp--custom--heading--typography--font-weight);
+	line-height: var(--wp--custom--heading--typography--line-height);
+	margin-top: var(--wp--custom--gap--vertical);
+	margin-bottom: var(--wp--custom--gap--vertical);
+}
+
+h4 {
+	font-family: var(--wp--preset--font-family--heading-font);
+	font-size: var(--wp--preset--font-size--medium);
+	font-weight: var(--wp--custom--heading--typography--font-weight);
+	line-height: var(--wp--custom--heading--typography--line-height);
+	margin-top: var(--wp--custom--gap--vertical);
+	margin-bottom: var(--wp--custom--gap--vertical);
+}
+
+h5 {
+	font-family: var(--wp--preset--font-family--heading-font);
+	font-size: var(--wp--preset--font-size--normal);
+	font-weight: var(--wp--custom--heading--typography--font-weight);
+	line-height: var(--wp--custom--heading--typography--line-height);
+	margin-top: var(--wp--custom--gap--vertical);
+	margin-bottom: var(--wp--custom--gap--vertical);
+}
+
+h6 {
+	font-family: var(--wp--preset--font-family--heading-font);
+	font-size: var(--wp--preset--font-size--small);
+	font-weight: var(--wp--custom--heading--typography--font-weight);
+	line-height: var(--wp--custom--heading--typography--line-height);
+	margin-top: var(--wp--custom--gap--vertical);
+	margin-bottom: var(--wp--custom--gap--vertical);
+}
+
+.wp-block-button__link {
+	background-color: var(--wp--custom--button--color--background);
+	border-radius: var(--wp--custom--button--border--radius);
+	color: var(--wp--custom--button--color--text);
+	font-family: var(--wp--preset--font-family--body-font);
+	font-size: var(--wp--custom--button--typography--font-size);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	line-height: var(--wp--custom--button--typography--line-height);
+}
+
+.wp-block-code > code {
+	border-radius: 2px;
+	background: var(--border-color);
+	color: inherit;
+	border: none;
+	font-family: monospace;
+	padding-top: var(--wp--custom--gap--vertical);
+	padding-right: var(--wp--custom--gap--horizontal);
+	padding-bottom: var(--wp--custom--gap--vertical);
+	padding-left: var(--wp--custom--gap--horizontal);
+}
+
+.wp-block-gallery {
+	margin-bottom: var(--wp--custom--gap--vertical);
+}
+
+.wp-block-navigation {
+	font-size: var(--wp--preset--font-size--normal);
+}
+
+.wp-block-post-title {
+	font-family: var(--wp--preset--font-family--heading-font);
+	font-size: var(--wp--preset--font-size--large);
+	line-height: var(--wp--custom--heading--typography--line-height);
+	margin-bottom: 0;
+}
+
+.wp-block-post-date {
+	color: var(--wp--custom--color--foreground);
+	font-size: var(--wp--preset--font-size--small);
+}
+
+.wp-block-pullquote {
+	border-width: 1px 0;
+	border-style: solid;
+	font-size: var(--wp--preset--font-size--large);
+	font-style: italic;
+	padding-top: var(--wp--custom--gap--horizontal);
+	padding-right: var(--wp--custom--gap--horizontal);
+	padding-bottom: var(--wp--custom--gap--horizontal);
+	padding-left: var(--wp--custom--gap--horizontal);
+}
+
+.wp-block-search {
+	font-size: var(--wp--custom--button--typography--font-size);
+	line-height: var(--wp--custom--body--typography--line-height);
+}
+
+.wp-block-separator {
+	border-color: currentColor;
+	border-width: 0 0 1px 0;
+	border-style: solid;
+	color: var(--wp--custom--color--foreground);
+}
+
+.wp-block-quote {
+	border-color: var(--wp--custom--color--primary);
+	border-width: 0 0 0 1px;
+	border-style: solid;
+	font-size: var(--wp--preset--font-size--normal);
+	font-style: normal;
+	padding-left: var(--wp--custom--gap--horizontal);
+}
+
+.wp-block-site-tagline {
+	font-size: var(--wp--custom--font-sizes--tiny);
+}
+
+.wp-block-site-title {
+	font-size: var(--wp--preset--font-size--normal);
+	font-weight: 700;
+	text-decoration: none;
+}
+
+.has-black-color {
+	color: var(--wp--preset--color--black) !important;
+}
+
+.has-cyan-bluish-gray-color {
+	color: var(--wp--preset--color--cyan-bluish-gray) !important;
+}
+
+.has-white-color {
+	color: var(--wp--preset--color--white) !important;
+}
+
+.has-pale-pink-color {
+	color: var(--wp--preset--color--pale-pink) !important;
+}
+
+.has-vivid-red-color {
+	color: var(--wp--preset--color--vivid-red) !important;
+}
+
+.has-luminous-vivid-orange-color {
+	color: var(--wp--preset--color--luminous-vivid-orange) !important;
+}
+
+.has-luminous-vivid-amber-color {
+	color: var(--wp--preset--color--luminous-vivid-amber) !important;
+}
+
+.has-light-green-cyan-color {
+	color: var(--wp--preset--color--light-green-cyan) !important;
+}
+
+.has-vivid-green-cyan-color {
+	color: var(--wp--preset--color--vivid-green-cyan) !important;
+}
+
+.has-pale-cyan-blue-color {
+	color: var(--wp--preset--color--pale-cyan-blue) !important;
+}
+
+.has-vivid-cyan-blue-color {
+	color: var(--wp--preset--color--vivid-cyan-blue) !important;
+}
+
+.has-vivid-purple-color {
+	color: var(--wp--preset--color--vivid-purple) !important;
+}
+
+.has-primary-color {
+	color: var(--wp--preset--color--primary) !important;
+}
+
+.has-border-color {
+	color: var(--wp--preset--color--border) !important;
+}
+
+.has-foreground-color {
+	color: var(--wp--preset--color--foreground) !important;
+}
+
+.has-background-color {
+	color: var(--wp--preset--color--background) !important;
+}
+
+.has-black-background-color {
+	background-color: var(--wp--preset--color--black) !important;
+}
+
+.has-cyan-bluish-gray-background-color {
+	background-color: var(--wp--preset--color--cyan-bluish-gray) !important;
+}
+
+.has-white-background-color {
+	background-color: var(--wp--preset--color--white) !important;
+}
+
+.has-pale-pink-background-color {
+	background-color: var(--wp--preset--color--pale-pink) !important;
+}
+
+.has-vivid-red-background-color {
+	background-color: var(--wp--preset--color--vivid-red) !important;
+}
+
+.has-luminous-vivid-orange-background-color {
+	background-color: var(--wp--preset--color--luminous-vivid-orange) !important;
+}
+
+.has-luminous-vivid-amber-background-color {
+	background-color: var(--wp--preset--color--luminous-vivid-amber) !important;
+}
+
+.has-light-green-cyan-background-color {
+	background-color: var(--wp--preset--color--light-green-cyan) !important;
+}
+
+.has-vivid-green-cyan-background-color {
+	background-color: var(--wp--preset--color--vivid-green-cyan) !important;
+}
+
+.has-pale-cyan-blue-background-color {
+	background-color: var(--wp--preset--color--pale-cyan-blue) !important;
+}
+
+.has-vivid-cyan-blue-background-color {
+	background-color: var(--wp--preset--color--vivid-cyan-blue) !important;
+}
+
+.has-vivid-purple-background-color {
+	background-color: var(--wp--preset--color--vivid-purple) !important;
+}
+
+.has-primary-background-color {
+	background-color: var(--wp--preset--color--primary) !important;
+}
+
+.has-border-background-color {
+	background-color: var(--wp--preset--color--border) !important;
+}
+
+.has-foreground-background-color {
+	background-color: var(--wp--preset--color--foreground) !important;
+}
+
+.has-background-background-color {
+	background-color: var(--wp--preset--color--background) !important;
+}
+
+.has-black-border-color {
+	border-color: var(--wp--preset--color--black) !important;
+}
+
+.has-cyan-bluish-gray-border-color {
+	border-color: var(--wp--preset--color--cyan-bluish-gray) !important;
+}
+
+.has-white-border-color {
+	border-color: var(--wp--preset--color--white) !important;
+}
+
+.has-pale-pink-border-color {
+	border-color: var(--wp--preset--color--pale-pink) !important;
+}
+
+.has-vivid-red-border-color {
+	border-color: var(--wp--preset--color--vivid-red) !important;
+}
+
+.has-luminous-vivid-orange-border-color {
+	border-color: var(--wp--preset--color--luminous-vivid-orange) !important;
+}
+
+.has-luminous-vivid-amber-border-color {
+	border-color: var(--wp--preset--color--luminous-vivid-amber) !important;
+}
+
+.has-light-green-cyan-border-color {
+	border-color: var(--wp--preset--color--light-green-cyan) !important;
+}
+
+.has-vivid-green-cyan-border-color {
+	border-color: var(--wp--preset--color--vivid-green-cyan) !important;
+}
+
+.has-pale-cyan-blue-border-color {
+	border-color: var(--wp--preset--color--pale-cyan-blue) !important;
+}
+
+.has-vivid-cyan-blue-border-color {
+	border-color: var(--wp--preset--color--vivid-cyan-blue) !important;
+}
+
+.has-vivid-purple-border-color {
+	border-color: var(--wp--preset--color--vivid-purple) !important;
+}
+
+.has-primary-border-color {
+	border-color: var(--wp--preset--color--primary) !important;
+}
+
+.has-border-border-color {
+	border-color: var(--wp--preset--color--border) !important;
+}
+
+.has-foreground-border-color {
+	border-color: var(--wp--preset--color--foreground) !important;
+}
+
+.has-background-border-color {
+	border-color: var(--wp--preset--color--background) !important;
+}
+
+.has-vivid-cyan-blue-to-vivid-purple-gradient-background {
+	background: var(--wp--preset--gradient--vivid-cyan-blue-to-vivid-purple) !important;
+}
+
+.has-light-green-cyan-to-vivid-green-cyan-gradient-background {
+	background: var(--wp--preset--gradient--light-green-cyan-to-vivid-green-cyan) !important;
+}
+
+.has-luminous-vivid-amber-to-luminous-vivid-orange-gradient-background {
+	background: var(--wp--preset--gradient--luminous-vivid-amber-to-luminous-vivid-orange) !important;
+}
+
+.has-luminous-vivid-orange-to-vivid-red-gradient-background {
+	background: var(--wp--preset--gradient--luminous-vivid-orange-to-vivid-red) !important;
+}
+
+.has-very-light-gray-to-cyan-bluish-gray-gradient-background {
+	background: var(--wp--preset--gradient--very-light-gray-to-cyan-bluish-gray) !important;
+}
+
+.has-cool-to-warm-spectrum-gradient-background {
+	background: var(--wp--preset--gradient--cool-to-warm-spectrum) !important;
+}
+
+.has-blush-light-purple-gradient-background {
+	background: var(--wp--preset--gradient--blush-light-purple) !important;
+}
+
+.has-blush-bordeaux-gradient-background {
+	background: var(--wp--preset--gradient--blush-bordeaux) !important;
+}
+
+.has-luminous-dusk-gradient-background {
+	background: var(--wp--preset--gradient--luminous-dusk) !important;
+}
+
+.has-pale-ocean-gradient-background {
+	background: var(--wp--preset--gradient--pale-ocean) !important;
+}
+
+.has-electric-grass-gradient-background {
+	background: var(--wp--preset--gradient--electric-grass) !important;
+}
+
+.has-midnight-gradient-background {
+	background: var(--wp--preset--gradient--midnight) !important;
+}
+
+.has-small-font-size {
+	font-size: var(--wp--preset--font-size--small) !important;
+}
+
+.has-medium-font-size {
+	font-size: var(--wp--preset--font-size--medium) !important;
+}
+
+.has-large-font-size {
+	font-size: var(--wp--preset--font-size--large) !important;
+}
+
+.has-x-large-font-size {
+	font-size: var(--wp--preset--font-size--x-large) !important;
+}
+
+.has-normal-font-size {
+	font-size: var(--wp--preset--font-size--normal) !important;
+}
+
+.has-huge-font-size {
+	font-size: var(--wp--preset--font-size--huge) !important;
+}
+
+.has-body-font-font-family {
+	font-family: var(--wp--preset--font-family--body-font) !important;
+}
+
+.has-heading-font-font-family {
+	font-family: var(--wp--preset--font-family--heading-font) !important;
+}
+
+.has-ui-font-font-family {
+	font-family: var(--wp--preset--font-family--ui-font) !important;
+}

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -10,6 +10,23 @@ body {
 	background-color: var(--bg-color);
 }
 
+.sensei-course-theme__frame {
+
+	.wp-block-group__inner-container {
+		display: inherit;
+		flex: 1;
+		align-items: inherit;
+		justify-content: inherit;
+		flex-wrap: inherit;
+		flex-direction: inherit;
+		gap: inherit;
+	}
+
+	.sensei-block-wrapper {
+		margin: 0;
+	}
+}
+
 .sensei-course-theme {
 
 	@at-root body.admin-bar {
@@ -54,10 +71,12 @@ body {
 			flex: 1;
 		}
 		&__footer {
+			gap: 12px;
 			display: flex;
 			flex-direction: column;
 			align-items: center;
-			gap: 12px;
+			padding: 12px;
+
 		}
 	}
 
@@ -97,4 +116,5 @@ body {
 		flex: 0 0 auto!important;
 
 	}
+
 }

--- a/assets/css/sensei-course-theme/notices.scss
+++ b/assets/css/sensei-course-theme/notices.scss
@@ -94,9 +94,6 @@
 		list-style: none;
 		margin: 18px 0 0;
 		padding: 0;
-
-		> li:not(:last-child) {
-			margin-right: 12px;
-		}
+		gap: 12px;
 	}
 }

--- a/assets/css/sensei-course-theme/quiz.scss
+++ b/assets/css/sensei-course-theme/quiz.scss
@@ -21,22 +21,16 @@ $tablet-breakpoint: 768px;
 	}
 
 	&__header, &__footer {
-		display: flex;
-		align-items: center;
-		justify-content: space-between;
 		padding: 24px;
-		gap: 24px;
 
 		margin: 0 auto;
 		max-width: 1200px;
 
-		.wp-block-group__inner-container {
-			display: flex;
-			flex: 1;
-			align-items: center;
-			justify-content: space-between;
-			gap: 24px;
-		}
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 24px;
+
 	}
 
 	&__header {

--- a/includes/blocks/course-theme/class-course-content.php
+++ b/includes/blocks/course-theme/class-course-content.php
@@ -41,14 +41,24 @@ class Course_Content {
 	public function render_content() {
 		$type = get_post_type();
 
+		$content = '';
+
 		switch ( $type ) {
 			case 'quiz':
-				return Quiz_Content::render_quiz();
+				$content = Quiz_Content::render_quiz();
+				break;
 			case 'lesson':
-				return $this->render_lesson_content();
+				$content = $this->render_lesson_content();
+				break;
 		}
 
-		return '';
+		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );
+
+		return (
+			'<div ' . $wrapper_attributes . '>' .
+			$content .
+			'</div>'
+		);
 
 	}
 

--- a/includes/blocks/course-theme/class-quiz-actions.php
+++ b/includes/blocks/course-theme/class-quiz-actions.php
@@ -46,7 +46,7 @@ class Quiz_Actions {
 		}
 
 		global $sensei_question_loop;
-		$pagination_enabled = $sensei_question_loop['total_pages'] > 1;
+		$pagination_enabled = $sensei_question_loop && $sensei_question_loop['total_pages'] > 1;
 
 		// Get quiz actions. Either actions with pagination
 		// or only action if pagination is not enabled.

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1415,7 +1415,7 @@ class Sensei_Quiz {
 
 			// Check for a quiz grade.
 			$quiz_grade = get_comment_meta( $lesson_status->comment_ID, 'grade', true );
-			if ( $quiz_grade ) {
+			if ( '' !== $quiz_grade ) {
 				return true;
 			}
 		}

--- a/themes/sensei-course-theme/functions.php
+++ b/themes/sensei-course-theme/functions.php
@@ -92,8 +92,8 @@ function enqueue_scripts() {
 	$font_families = [ 'family=Source+Serif+Pro:ital,wght@0,200;0,300;0,400;0,600;0,700;0,900;1,200;1,300;1,400;1,600;1,700;1,900' ];
 
 	$fonts_url = esc_url_raw( 'https://fonts.googleapis.com/css2?' . implode( '&', array_unique( $font_families ) ) . '&display=swap' );
-	$version   = md5( $fonts_url );
 
-	wp_enqueue_style( 'sensei-course-theme-fonts', $fonts_url, [], $version );
+	//phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- External resource.
+	wp_enqueue_style( 'sensei-course-theme-fonts', $fonts_url, [], null );
 
 }

--- a/themes/sensei-course-theme/templates/lesson.html
+++ b/themes/sensei-course-theme/templates/lesson.html
@@ -37,6 +37,7 @@
         <!-- /wp:group -->
         <!-- wp:group {"className":"sensei-course-theme__sidebar__footer"} -->
         <div class="wp-block-group sensei-course-theme__sidebar__footer">
+            <!-- wp:sensei-lms/button-contact-teacher /-->
             <!-- wp:sensei-lms/exit-course /-->
         </div>
         <!-- /wp:group -->


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Fix content fonts not applying for older versions and non-block themes
* Add global styles CSS that would be generated on 5.9 from theme.json, to support all versions
* Fix a few UI layout issues
* Fix a few content block styling issues
* Fix quiz actions showing when quiz is graded to `0`
* Add back Contact Teacher block to sidebar


### Testing instructions

* Open a lesson with rich content in learning mode. Marvel at its beauty.
* Check out styles and fonts in Wordpress 5.7 and 5.8 too

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1591" alt="image" src="https://user-images.githubusercontent.com/176949/150617762-07e16cf3-c04c-480b-b827-2a4bc6e74044.png">


