### PR TITLE
Add indicator to Grading menu that displays the number of ungraded quizzes

### DIFF
--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -59,7 +59,7 @@ class Sensei_Grading {
 	 */
 	public function grading_admin_menu() {
 		$indicator_html = '';
-		$grading_counts = Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] ) );
+		$grading_counts = Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] );
 
 		if ( intval( $grading_counts['ungraded'] ) > 0 ) {
 			$indicator_html = ' <span class="awaiting-mod">' . esc_html( $grading_counts['ungraded'] ) . '</span>';

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -52,24 +52,29 @@ class Sensei_Grading {
 	}
 
 	/**
-	 * grading_admin_menu function.
+	 * Add the Grading submenu.
 	 *
 	 * @since  1.3.0
 	 * @access public
-	 * @return void
 	 */
 	public function grading_admin_menu() {
+		$indicator_html = '';
+		$grading_counts = Sensei()->grading->count_statuses( apply_filters( 'sensei_grading_count_statues', [ 'type' => 'lesson' ] ) );
+
+		if ( $grading_counts['ungraded'] > 0 ) {
+			$indicator_html = ' <span class="awaiting-mod">' . esc_html( $grading_counts['ungraded'] ) . '</span>';
+		}
+
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
 			add_submenu_page(
 				'edit.php?post_type=course',
 				__( 'Grading', 'sensei-lms' ),
-				__( 'Grading', 'sensei-lms' ),
+				__( 'Grading', 'sensei-lms' ) . $indicator_html,
 				'manage_sensei_grades',
 				$this->page_slug,
 				array( $this, 'grading_page' )
 			);
 		}
-
 	}
 
 	/**

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -59,7 +59,7 @@ class Sensei_Grading {
 	 */
 	public function grading_admin_menu() {
 		$indicator_html = '';
-		$grading_counts = Sensei()->grading->count_statuses( apply_filters( 'sensei_grading_count_statues', [ 'type' => 'lesson' ] ) );
+		$grading_counts = Sensei()->grading->count_statuses( [ 'type' => 'lesson' ] ) );
 
 		if ( intval( $grading_counts['ungraded'] ) > 0 ) {
 			$indicator_html = ' <span class="awaiting-mod">' . esc_html( $grading_counts['ungraded'] ) . '</span>';

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -61,7 +61,7 @@ class Sensei_Grading {
 		$indicator_html = '';
 		$grading_counts = Sensei()->grading->count_statuses( apply_filters( 'sensei_grading_count_statues', [ 'type' => 'lesson' ] ) );
 
-		if ( $grading_counts['ungraded'] > 0 ) {
+		if ( intval( $grading_counts['ungraded'] ) > 0 ) {
 			$indicator_html = ' <span class="awaiting-mod">' . esc_html( $grading_counts['ungraded'] ) . '</span>';
 		}
 

--- a/tests/unit-tests/admin/test-class-sensei-extensions.php
+++ b/tests/unit-tests/admin/test-class-sensei-extensions.php
@@ -11,6 +11,13 @@
 class Sensei_Extensions_Test extends WP_UnitTestCase {
 	use Sensei_Test_Login_Helpers;
 
+	public function tearDown() {
+		parent::tearDown();
+
+		global $submenu;
+		unset( $submenu['edit.php?post_type=course'] );
+	}
+
 	/**
 	 * Testing the Sensei Extensions class to make sure it is loaded.
 	 */


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adds an indicator to the _Grading_ menu when there are ungraded quizzes.

### Testing instructions

- Add a few quiz questions to a few lessons.
- Ensure the _Auto Grade_ quiz setting is disabled.
- As a student, take the quizzes.
- Ensure the correct number of ungraded quizzes is displayed in the _Grading_ submenu.
- Grade all the ungraded quizzes.
- Ensure the grading indicator is removed.

### Screenshot / Video
![Screen Shot 2022-01-24 at 8 52 38 AM](https://user-images.githubusercontent.com/1190420/150795194-1bccf9bd-402d-4bd0-8d2c-0c5e7d27fb04.jpg)