### PR TITLE
Update courses page navigation

### DIFF
--- a/assets/css/admin-custom.css
+++ b/assets/css/admin-custom.css
@@ -140,6 +140,7 @@ div.question_boolean_fields { margin-bottom: 10px; }
 .sensei-custom-navigation .sensei-custom-navigation__main .sensei-custom-navigation__main__title h1 {
 	color: #1E1E1E;
 	font-size: 20px;
+	padding: 0;
 }
 
 .sensei-custom-navigation .sensei-custom-navigation__main__tabbar {

--- a/assets/css/admin-custom.css
+++ b/assets/css/admin-custom.css
@@ -121,31 +121,30 @@ div.question_boolean_fields { margin-bottom: 10px; }
 /**
  * Sensei custom navigation
  */
-#sensei-custom-navigation {
+.sensei-custom-navigation {
 	display: flex;
 	flex-direction: row;
 	align-items: center;
 	color: #000000;
 	margin-bottom: 20px;
-
 }
 
-#sensei-custom-navigation .title h1 {
+.sensei-custom-navigation .sensei-custom-navigation__title h1 {
 	color: #1E1E1E;
 	font-size: 20px;
 	margin-right: 25px;
 }
 
-#sensei-custom-navigation .navigation a {
+.sensei-custom-navigation .sensei-custom-navigation__navbar a {
 	margin-left: 0;
 	margin-right: 20px;
 }
 
-#sensei-custom-navigation .navigation a.page-title-action {
+.sensei-custom-navigation .sensei-custom-navigation__navbar a.page-title-action {
 	top: auto;
 }
 
-#sensei-custom-navigation .navigation a.sensei-custom-navigation__nav-tag {
+.sensei-custom-navigation .sensei-custom-navigation__navbar a.sensei-custom-navigation__navbar__navtab {
 	margin-right: 25px;
 	color: #1E1E1E;
 	text-decoration: none;
@@ -153,11 +152,11 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	padding-bottom:  14px;
 }
 
-#sensei-custom-navigation .navigation a.sensei-custom-navigation__nav-tag.active {
+.sensei-custom-navigation .sensei-custom-navigation__navbar a.sensei-custom-navigation__navbar__navtab.active {
 	font-weight: 500;
 	border-bottom: 4px solid #007CBA;
 }
 
-#sensei-custom-navigation .navigation a.sensei-custom-navigation__nav-tag:hover {
+.sensei-custom-navigation .sensei-custom-navigation__navbar a.sensei-custom-navigation__navbar__navtab:hover {
 	border-bottom: 4px solid #1E1E1E;
 }

--- a/assets/css/admin-custom.css
+++ b/assets/css/admin-custom.css
@@ -123,7 +123,7 @@ div.question_boolean_fields { margin-bottom: 10px; }
  */
 .sensei-custom-navigation {
 	display: flex;
-	flex-direction: column;
+	flex-flow: row wrap;
 	align-items: flex-start;
 	gap: 20px;
 	margin: 20px auto;

--- a/assets/css/admin-custom.css
+++ b/assets/css/admin-custom.css
@@ -123,48 +123,59 @@ div.question_boolean_fields { margin-bottom: 10px; }
  */
 .sensei-custom-navigation {
 	display: flex;
-	flex-flow: row wrap;
+	flex-direction: column;
 	align-items: flex-start;
-	color: #000000;
-	margin-bottom: 20px;
+	gap: 20px;
+	margin: 20px auto;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__title h1 {
-	color: #1E1E1E;
-	font-size: 20px;
-	margin-right: 25px;
-}
-
-.sensei-custom-navigation .sensei-custom-navigation__navbar {
+.sensei-custom-navigation .sensei-custom-navigation__main {
 	display: flex;
 	flex-flow: row wrap;
 	align-items: center;
 	justify-content: flex-start;
+	gap: 40px;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__navbar a {
-	margin-left: 0;
-	margin-right: 20px;
+.sensei-custom-navigation .sensei-custom-navigation__main .sensei-custom-navigation__main__title h1 {
+	color: #1E1E1E;
+	font-size: 20px;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__navbar a.page-title-action {
-	top: auto;
+.sensei-custom-navigation .sensei-custom-navigation__main__tabbar {
+	display: flex;
+	flex-flow: row wrap;
+	align-items: center;
+	justify-content: flex-start;
+	gap: 20px;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__navbar a.sensei-custom-navigation__navbar__navtab {
-	margin-right: 25px;
+.sensei-custom-navigation .sensei-custom-navigation__main__tabbar a.sensei-custom-navigation__main__tabbar__tab {
 	color: #1E1E1E;
 	text-decoration: none;
 	font-size: 14px;
-	padding-bottom:  10px;
+	padding-bottom:  2px;
 	border-bottom: 4px solid transparent;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__navbar a.sensei-custom-navigation__navbar__navtab.active {
+.sensei-custom-navigation .sensei-custom-navigation__main__tabbar a.sensei-custom-navigation__main__tabbar__tab.active {
 	font-weight: 500;
 	border-bottom: 4px solid #007CBA;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__navbar a.sensei-custom-navigation__navbar__navtab:hover {
+.sensei-custom-navigation .sensei-custom-navigation__main__tabbar a.sensei-custom-navigation__main__tabbar__tab:hover {
 	border-bottom: 4px solid #1E1E1E;
+}
+
+.sensei-custom-navigation .sensei-custom-navigation__additional {
+	display: flex;
+	flex-flow: row wrap;
+	align-items: baseline;
+	justify-content: flex-start;
+	gap: 20px;
+}
+
+.sensei-custom-navigation .sensei-custom-navigation__additional a.page-title-action {
+	margin-left: 0;
+	top: auto;
 }

--- a/assets/css/admin-custom.css
+++ b/assets/css/admin-custom.css
@@ -117,3 +117,47 @@ div.question_boolean_fields { margin-bottom: 10px; }
 .sensei-dismissible-link {
     text-decoration: none;
 }
+
+/**
+ * Sensei custom navigation
+ */
+#sensei-custom-navigation {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	color: #000000;
+	margin-bottom: 20px;
+
+}
+
+#sensei-custom-navigation .title h1 {
+	color: #1E1E1E;
+	font-size: 20px;
+	margin-right: 25px;
+}
+
+#sensei-custom-navigation .navigation a {
+	margin-left: 0;
+	margin-right: 20px;
+}
+
+#sensei-custom-navigation .navigation a.page-title-action {
+	top: auto;
+}
+
+#sensei-custom-navigation .navigation a.sensei-custom-navigation__nav-tag {
+	margin-right: 25px;
+	color: #1E1E1E;
+	text-decoration: none;
+	font-size: 14px;
+	padding-bottom:  14px;
+}
+
+#sensei-custom-navigation .navigation a.sensei-custom-navigation__nav-tag.active {
+	font-weight: 500;
+	border-bottom: 4px solid #007CBA;
+}
+
+#sensei-custom-navigation .navigation a.sensei-custom-navigation__nav-tag:hover {
+	border-bottom: 4px solid #1E1E1E;
+}

--- a/assets/css/admin-custom.css
+++ b/assets/css/admin-custom.css
@@ -123,24 +123,18 @@ div.question_boolean_fields { margin-bottom: 10px; }
  */
 .sensei-custom-navigation {
 	display: flex;
-	flex-flow: row wrap;
+	flex-flow: column wrap;
 	align-items: flex-start;
 	gap: 20px;
 	margin: 20px auto;
 }
 
-.sensei-custom-navigation__main {
+.sensei-custom-navigation__heading {
 	display: flex;
 	flex-flow: row wrap;
-	align-items: center;
+	align-items: baseline;
 	justify-content: flex-start;
-	gap: 40px;
-}
-
-.sensei-custom-navigation__main__title h1 {
-	color: #1E1E1E;
-	font-size: 20px;
-	padding: 0;
+	gap: 10px;
 }
 
 .sensei-custom-navigation__tabbar {
@@ -168,15 +162,22 @@ a.sensei-custom-navigation__tab:hover {
 	border-bottom: 4px solid #1E1E1E;
 }
 
-.sensei-custom-navigation__additional {
+.sensei-custom-navigation__links {
 	display: flex;
 	flex-flow: row wrap;
 	align-items: baseline;
 	justify-content: flex-start;
-	gap: 20px;
+	gap: 10px;
+}
+.sensei-custom-navigation__links a {
+	position: relative;
+	top: -3px;
 }
 
-.sensei-custom-navigation__additional a.page-title-action {
+.sensei-custom-navigation__links a.page-title-action,
+.sensei-custom-navigation__links a.page-title-action:active,
+.sensei-custom-navigation__links a.page-title-action:hover,
+.sensei-custom-navigation__links a.page-title-action:visited,
+.sensei-custom-navigation__links a.page-title-action:focus {
 	margin-left: 0;
-	top: auto;
 }

--- a/assets/css/admin-custom.css
+++ b/assets/css/admin-custom.css
@@ -129,7 +129,7 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	margin: 20px auto;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__main {
+.sensei-custom-navigation__main {
 	display: flex;
 	flex-flow: row wrap;
 	align-items: center;
@@ -137,13 +137,13 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	gap: 40px;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__main .sensei-custom-navigation__main__title h1 {
+.sensei-custom-navigation__main__title h1 {
 	color: #1E1E1E;
 	font-size: 20px;
 	padding: 0;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__main__tabbar {
+.sensei-custom-navigation__tabbar {
 	display: flex;
 	flex-flow: row wrap;
 	align-items: center;
@@ -151,7 +151,7 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	gap: 20px;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__main__tabbar a.sensei-custom-navigation__main__tabbar__tab {
+a.sensei-custom-navigation__tab {
 	color: #1E1E1E;
 	text-decoration: none;
 	font-size: 14px;
@@ -159,16 +159,16 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	border-bottom: 4px solid transparent;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__main__tabbar a.sensei-custom-navigation__main__tabbar__tab.active {
+a.sensei-custom-navigation__tab.active {
 	font-weight: 500;
 	border-bottom: 4px solid #007CBA;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__main__tabbar a.sensei-custom-navigation__main__tabbar__tab:hover {
+a.sensei-custom-navigation__tab:hover {
 	border-bottom: 4px solid #1E1E1E;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__additional {
+.sensei-custom-navigation__additional {
 	display: flex;
 	flex-flow: row wrap;
 	align-items: baseline;
@@ -176,7 +176,7 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	gap: 20px;
 }
 
-.sensei-custom-navigation .sensei-custom-navigation__additional a.page-title-action {
+.sensei-custom-navigation__additional a.page-title-action {
 	margin-left: 0;
 	top: auto;
 }

--- a/assets/css/admin-custom.css
+++ b/assets/css/admin-custom.css
@@ -123,8 +123,8 @@ div.question_boolean_fields { margin-bottom: 10px; }
  */
 .sensei-custom-navigation {
 	display: flex;
-	flex-direction: row;
-	align-items: center;
+	flex-flow: row wrap;
+	align-items: flex-start;
 	color: #000000;
 	margin-bottom: 20px;
 }
@@ -133,6 +133,13 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	color: #1E1E1E;
 	font-size: 20px;
 	margin-right: 25px;
+}
+
+.sensei-custom-navigation .sensei-custom-navigation__navbar {
+	display: flex;
+	flex-flow: row wrap;
+	align-items: center;
+	justify-content: flex-start;
 }
 
 .sensei-custom-navigation .sensei-custom-navigation__navbar a {
@@ -149,7 +156,8 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	color: #1E1E1E;
 	text-decoration: none;
 	font-size: 14px;
-	padding-bottom:  14px;
+	padding-bottom:  10px;
+	border-bottom: 4px solid transparent;
 }
 
 .sensei-custom-navigation .sensei-custom-navigation__navbar a.sensei-custom-navigation__navbar__navtab.active {

--- a/assets/js/admin/custom-navigation.js
+++ b/assets/js/admin/custom-navigation.js
@@ -9,8 +9,15 @@
 	document
 		.querySelector( '#wpbody-content > .wrap' )
 		.prepend( customNavigation );
-	document.querySelector( '.wrap > h1.wp-heading-inline' ).style.display =
-		'none';
-	document.querySelector( '.wrap > a.page-title-action' ).style.display =
-		'none';
+
+	const title = document.querySelector( '.wrap > h1.wp-heading-inline' );
+	if ( title ) {
+		title.style.display = 'none';
+	}
+	const newCourseButton = document.querySelector(
+		'.wrap > a.page-title-action'
+	);
+	if ( newCourseButton ) {
+		newCourseButton.style.display = 'none';
+	}
 } )();

--- a/assets/js/admin/custom-navigation.js
+++ b/assets/js/admin/custom-navigation.js
@@ -6,14 +6,17 @@
 		return;
 	}
 
+	// Move the custom navigation to the top of the page.
 	document
 		.querySelector( '#wpbody-content > .wrap' )
 		.prepend( customNavigation );
 
+	// Find the default heading and hide it.
 	const title = document.querySelector( '.wrap > h1.wp-heading-inline' );
 	if ( title ) {
 		title.style.display = 'none';
 	}
+	// Find the default "Add New" button and hide it.
 	const newCourseButton = document.querySelector(
 		'.wrap > a.page-title-action'
 	);

--- a/assets/js/admin/custom-navigation.js
+++ b/assets/js/admin/custom-navigation.js
@@ -1,0 +1,16 @@
+( () => {
+	const customNavigation = document.querySelector(
+		'#sensei-custom-navigation'
+	);
+	if ( ! customNavigation ) {
+		return;
+	}
+
+	document
+		.querySelector( '#wpbody-content > .wrap' )
+		.prepend( customNavigation );
+	document.querySelector( '.wrap > h1.wp-heading-inline' ).style.display =
+		'none';
+	document.querySelector( '.wrap > a.page-title-action' ).style.display =
+		'none';
+} )();

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -11,9 +11,10 @@ jQuery( document ).ready( function ( $ ) {
 				.addClass( 'section-heading' );
 		} );
 
-	// Only show the General settings.
+	// General settings is the default slug.
 	var selectedSettingsSlug = 'default-settings';
 
+	// Set the selected settings slug and tab if it was provided in the URL.
 	if ( window.location.hash && window.location.hash.length > 1 ) {
 		selectedSettingsSlug = window.location.hash.replace( '#', '' );
 		jQuery( '#woothemes-sensei .subsubsub a.tab' ).each( function () {

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -12,13 +12,25 @@ jQuery( document ).ready( function ( $ ) {
 		} );
 
 	// Only show the General settings.
-	var defaultSettingsSlug = 'default-settings';
+	var selectedSettingsSlug = 'default-settings';
+
+	if ( window.location.hash && window.location.hash.length > 1 ) {
+		selectedSettingsSlug = window.location.hash.replace( '#', '' );
+		jQuery( '#woothemes-sensei .subsubsub a.tab' ).each( function () {
+			if ( jQuery( this ).attr( 'href' ) === window.location.hash ) {
+				jQuery( this ).addClass( 'current' );
+			} else {
+				jQuery( this ).removeClass( 'current' );
+			}
+		} );
+	}
+
 	$( '#woothemes-sensei section' ).each( function () {
-		if ( this.id !== defaultSettingsSlug ) {
+		if ( this.id !== selectedSettingsSlug ) {
 			$( this ).hide();
 		}
 	} );
-	sensei_log_event( 'settings_view', { view: defaultSettingsSlug } );
+	sensei_log_event( 'settings_view', { view: selectedSettingsSlug } );
 
 	jQuery( '#woothemes-sensei .subsubsub a.tab' ).click( function () {
 		// Move the "current" CSS class.

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -37,6 +37,7 @@ class Sensei_Admin {
 
 		// register admin scripts
 		add_action( 'admin_enqueue_scripts', array( $this, 'register_scripts' ) );
+		add_action( 'admin_menu', array( $this, 'add_course_order' ) );
 		add_action( 'menu_order', array( $this, 'admin_menu_order' ) );
 		add_action( 'admin_head', array( $this, 'admin_menu_highlight' ) );
 		add_action( 'admin_init', array( $this, 'sensei_add_custom_menu_items' ) );
@@ -111,6 +112,23 @@ class Sensei_Admin {
 
 		add_submenu_page( 'edit.php?post_type=course', __( 'Order Courses', 'sensei-lms' ), __( 'Order Courses', 'sensei-lms' ), 'manage_sensei', $this->course_order_page_slug, array( $this, 'course_order_screen' ) );
 		add_submenu_page( 'edit.php?post_type=lesson', __( 'Order Lessons', 'sensei-lms' ), __( 'Order Lessons', 'sensei-lms' ), 'edit_published_lessons', $this->lesson_order_page_slug, array( $this, 'lesson_order_screen' ) );
+	}
+
+	/**
+	 * Add Course order page to admin panel.
+	 *
+	 * @since  1.9.0
+	 * @return void
+	 */
+	public function add_course_order() {
+		add_submenu_page(
+			null, // Hide in menu.
+			__( 'Order Courses', 'sensei-lms' ),
+			__( 'Order Courses', 'sensei-lms' ),
+			'manage_sensei',
+			$this->course_order_page_slug,
+			array( $this, 'course_order_screen' )
+		);
 	}
 
 	/**

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -117,8 +117,7 @@ class Sensei_Admin {
 	/**
 	 * Add Course order page to admin panel.
 	 *
-	 * @since  1.9.0
-	 * @return void
+	 * @since  4.0.0
 	 */
 	public function add_course_order() {
 		add_submenu_page(

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -345,8 +345,12 @@ class Sensei_Admin {
 		Sensei()->assets->enqueue( 'sensei-message-menu-fix', 'js/admin/message-menu-fix.js', [ 'jquery' ], true );
 
 		// Event logging.
-
 		Sensei()->assets->enqueue( 'sensei-event-logging', 'js/admin/event-logging.js', [ 'jquery' ], true );
+
+		// Sensei custom navigation.
+		if ( $screen && ( in_array( $screen->id, [ 'edit-course', 'edit-course-category' ], true ) ) ) {
+			Sensei()->assets->enqueue( 'sensei-admin-custom-navigation', 'js/admin/custom-navigation.js', [], true );
+		}
 
 		wp_localize_script( 'sensei-event-logging', 'sensei_event_logging', [ 'enabled' => Sensei_Usage_Tracking::get_instance()->get_tracking_enabled() ] );
 	}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -191,13 +191,13 @@ class Sensei_Course {
 	 * @param WP_Screen $screen
 	 */
 	private function display_courses_navigation( WP_Screen $screen ) {
-		$html  = '<div id="sensei-custom-navigation">';
-		$html .= '<div class="title">';
+		$html  = '<div id="sensei-custom-navigation" class="sensei-custom-navigation">';
+		$html .= '<div class="sensei-custom-navigation__title">';
 		$html .= '<h1>' . __( 'Courses', 'sensei-lms' ) . '</h1>';
 		$html .= '</div>';
-		$html .= '<div class="navigation">';
-		$html .= '<a class="sensei-custom-navigation__nav-tag ' . ( '' === $screen->taxonomy ? 'active' : '' ) . '" href="' . esc_url( admin_url( 'edit.php?post_type=course' ) ) . '">' . __( 'All Courses', 'sensei-lms' ) . '</a>';
-		$html .= '<a class="sensei-custom-navigation__nav-tag ' . ( 'course-category' === $screen->taxonomy ? 'active' : '' ) . '" href="' . esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ) . '">' . __( 'Course Categories', 'sensei-lms' ) . '</a>';
+		$html .= '<div class="sensei-custom-navigation__navbar">';
+		$html .= '<a class="sensei-custom-navigation__navbar__navtab ' . ( '' === $screen->taxonomy ? 'active' : '' ) . '" href="' . esc_url( admin_url( 'edit.php?post_type=course' ) ) . '">' . __( 'All Courses', 'sensei-lms' ) . '</a>';
+		$html .= '<a class="sensei-custom-navigation__navbar__navtab ' . ( 'course-category' === $screen->taxonomy ? 'active' : '' ) . '" href="' . esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ) . '">' . __( 'Course Categories', 'sensei-lms' ) . '</a>';
 		$html .= '<a class="page-title-action" href="' . esc_url( admin_url( 'post-new.php?post_type=course' ) ) . '">' . __( 'New course', 'sensei-lms' ) . '</a>';
 		$html .= '<a href="' . esc_url( admin_url( 'edit.php?post_type=course&page=course-order' ) ) . '">' . __( 'Order courses', 'sensei-lms' ) . '</a>';
 		$html .= '<a href="' . esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#course-settings' ) ) . '">' . __( 'Course settings', 'sensei-lms' ) . '</a>';

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -155,7 +155,7 @@ class Sensei_Course {
 	 * Highlight the menu item for the course pages.
 	 *
 	 * @since 4.0.0
-	 * @access private*
+	 * @access private
 	 *
 	 * @param string $submenu_file
 	 *

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -225,7 +225,6 @@ class Sensei_Course {
 			return;
 		}
 
-		Sensei()->assets->enqueue( 'sensei-admin-custom-navigation', 'js/admin/custom-navigation.js', [], true );
 		if ( 'course' === $screen->id ) {
 			Sensei()->assets->enqueue( 'sensei-admin-course-edit', 'js/admin/course-edit.js', [ 'jquery', 'sensei-core-select2' ], true );
 		}

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -195,12 +195,16 @@ class Sensei_Course {
 	private function display_courses_navigation( WP_Screen $screen ) {
 		?>
 		<div id="sensei-custom-navigation" class="sensei-custom-navigation">
-			<div class="sensei-custom-navigation__title">
-				<h1><?php esc_html_e( 'Courses', 'sensei-lms' ); ?></h1>
+			<div class="sensei-custom-navigation__main">
+				<div class="sensei-custom-navigation__main__title">
+					<h1><?php esc_html_e( 'Courses', 'sensei-lms' ); ?></h1>
+				</div>
+				<div class="sensei-custom-navigation__main__tabbar">
+					<a class="sensei-custom-navigation__main__tabbar__tab <?php echo '' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=course' ) ); ?>"><?php esc_html_e( 'All Courses', 'sensei-lms' ); ?></a>
+					<a class="sensei-custom-navigation__main__tabbar__tab <?php echo 'course-category' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ); ?>"><?php esc_html_e( 'Course Categories', 'sensei-lms' ); ?></a>
+				</div>
 			</div>
-			<div class="sensei-custom-navigation__navbar">
-				<a class="sensei-custom-navigation__navbar__navtab <?php echo '' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=course' ) ); ?>"><?php esc_html_e( 'All Courses', 'sensei-lms' ); ?></a>
-				<a class="sensei-custom-navigation__navbar__navtab <?php echo 'course-category' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ); ?>"><?php esc_html_e( 'Course Categories', 'sensei-lms' ); ?></a>
+			<div class="sensei-custom-navigation__additional">
 				<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=course' ) ); ?>"><?php esc_html_e( 'New course', 'sensei-lms' ); ?></a>
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=course-order' ) ); ?>"><?php esc_html_e( 'Order courses', 'sensei-lms' ); ?></a>
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#course-settings' ) ); ?>"><?php esc_html_e( 'Course settings', 'sensei-lms' ); ?></a>

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -148,7 +148,7 @@ class Sensei_Course {
 
 		// Add custom navigation.
 		add_action( 'in_admin_header', [ $this, 'add_custom_navigation' ] );
-		add_action( 'submenu_file', [ $this, 'highlight_menu_item' ] );
+		add_filter( 'submenu_file', [ $this, 'highlight_menu_item' ] );
 	}
 
 	/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -200,9 +200,9 @@ class Sensei_Course {
 					<h1><?php esc_html_e( 'Courses', 'sensei-lms' ); ?></h1>
 				</div>
 				<div class="sensei-custom-navigation__links">
-					<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=course' ) ); ?>"><?php esc_html_e( 'New course', 'sensei-lms' ); ?></a>
-					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=course-order' ) ); ?>"><?php esc_html_e( 'Order courses', 'sensei-lms' ); ?></a>
-					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#course-settings' ) ); ?>"><?php esc_html_e( 'Course settings', 'sensei-lms' ); ?></a>
+					<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=course' ) ); ?>"><?php esc_html_e( 'New Course', 'sensei-lms' ); ?></a>
+					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=course-order' ) ); ?>"><?php esc_html_e( 'Order Courses', 'sensei-lms' ); ?></a>
+					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#course-settings' ) ); ?>"><?php esc_html_e( 'Course Settings', 'sensei-lms' ); ?></a>
 				</div>
 			</div>
 			<div class="sensei-custom-navigation__tabbar">

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -157,7 +157,7 @@ class Sensei_Course {
 	 * @since 4.0.0
 	 * @access private*
 	 *
-	 * @param $submenu_file
+	 * @param string $submenu_file
 	 *
 	 * @return string
 	 */
@@ -199,8 +199,8 @@ class Sensei_Course {
 				<h1><?php esc_html_e( 'Courses', 'sensei-lms' ); ?></h1>
 			</div>
 			<div class="sensei-custom-navigation__navbar">
-				<a class="sensei-custom-navigation__navbar__navtab <?php echo $screen->taxonomy === '' ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=course' ) ); ?>"><?php esc_html_e( 'All Courses', 'sensei-lms' ); ?></a>
-				<a class="sensei-custom-navigation__navbar__navtab <?php echo $screen->taxonomy === 'course-category' ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ); ?>"><?php esc_html_e( 'Course Categories', 'sensei-lms' ); ?></a>
+				<a class="sensei-custom-navigation__navbar__navtab <?php echo '' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=course' ) ); ?>"><?php esc_html_e( 'All Courses', 'sensei-lms' ); ?></a>
+				<a class="sensei-custom-navigation__navbar__navtab <?php echo 'course-category' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ); ?>"><?php esc_html_e( 'Course Categories', 'sensei-lms' ); ?></a>
 				<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=course' ) ); ?>"><?php esc_html_e( 'New course', 'sensei-lms' ); ?></a>
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=course-order' ) ); ?>"><?php esc_html_e( 'Order courses', 'sensei-lms' ); ?></a>
 				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#course-settings' ) ); ?>"><?php esc_html_e( 'Course settings', 'sensei-lms' ); ?></a>

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -157,7 +157,7 @@ class Sensei_Course {
 	 * @since 4.0.0
 	 * @access private
 	 *
-	 * @param string $submenu_file
+	 * @param string $submenu_file The submenu file points to the certain item of the submenu.
 	 *
 	 * @return string
 	 */
@@ -190,7 +190,7 @@ class Sensei_Course {
 	/**
 	 * Display the courses' navigation.
 	 *
-	 * @param WP_Screen $screen
+	 * @param WP_Screen $screen WordPress current screen object.
 	 */
 	private function display_courses_navigation( WP_Screen $screen ) {
 		?>

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -195,19 +195,19 @@ class Sensei_Course {
 	private function display_courses_navigation( WP_Screen $screen ) {
 		?>
 		<div id="sensei-custom-navigation" class="sensei-custom-navigation">
-			<div class="sensei-custom-navigation__main">
+			<div class="sensei-custom-navigation__heading">
 				<div class="sensei-custom-navigation__title">
 					<h1><?php esc_html_e( 'Courses', 'sensei-lms' ); ?></h1>
 				</div>
-				<div class="sensei-custom-navigation__tabbar">
-					<a class="sensei-custom-navigation__tab <?php echo '' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=course' ) ); ?>"><?php esc_html_e( 'All Courses', 'sensei-lms' ); ?></a>
-					<a class="sensei-custom-navigation__tab <?php echo 'course-category' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ); ?>"><?php esc_html_e( 'Course Categories', 'sensei-lms' ); ?></a>
+				<div class="sensei-custom-navigation__links">
+					<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=course' ) ); ?>"><?php esc_html_e( 'New course', 'sensei-lms' ); ?></a>
+					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=course-order' ) ); ?>"><?php esc_html_e( 'Order courses', 'sensei-lms' ); ?></a>
+					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#course-settings' ) ); ?>"><?php esc_html_e( 'Course settings', 'sensei-lms' ); ?></a>
 				</div>
 			</div>
-			<div class="sensei-custom-navigation__additional">
-				<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=course' ) ); ?>"><?php esc_html_e( 'New course', 'sensei-lms' ); ?></a>
-				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=course-order' ) ); ?>"><?php esc_html_e( 'Order courses', 'sensei-lms' ); ?></a>
-				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#course-settings' ) ); ?>"><?php esc_html_e( 'Course settings', 'sensei-lms' ); ?></a>
+			<div class="sensei-custom-navigation__tabbar">
+				<a class="sensei-custom-navigation__tab <?php echo '' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=course' ) ); ?>"><?php esc_html_e( 'All Courses', 'sensei-lms' ); ?></a>
+				<a class="sensei-custom-navigation__tab <?php echo 'course-category' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ); ?>"><?php esc_html_e( 'Course Categories', 'sensei-lms' ); ?></a>
 			</div>
 		</div>
 		<?php

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -196,12 +196,12 @@ class Sensei_Course {
 		?>
 		<div id="sensei-custom-navigation" class="sensei-custom-navigation">
 			<div class="sensei-custom-navigation__main">
-				<div class="sensei-custom-navigation__main__title">
+				<div class="sensei-custom-navigation__title">
 					<h1><?php esc_html_e( 'Courses', 'sensei-lms' ); ?></h1>
 				</div>
-				<div class="sensei-custom-navigation__main__tabbar">
-					<a class="sensei-custom-navigation__main__tabbar__tab <?php echo '' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=course' ) ); ?>"><?php esc_html_e( 'All Courses', 'sensei-lms' ); ?></a>
-					<a class="sensei-custom-navigation__main__tabbar__tab <?php echo 'course-category' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ); ?>"><?php esc_html_e( 'Course Categories', 'sensei-lms' ); ?></a>
+				<div class="sensei-custom-navigation__tabbar">
+					<a class="sensei-custom-navigation__tab <?php echo '' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=course' ) ); ?>"><?php esc_html_e( 'All Courses', 'sensei-lms' ); ?></a>
+					<a class="sensei-custom-navigation__tab <?php echo 'course-category' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ); ?>"><?php esc_html_e( 'Course Categories', 'sensei-lms' ); ?></a>
 				</div>
 			</div>
 			<div class="sensei-custom-navigation__additional">

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -146,7 +146,7 @@ class Sensei_Course {
 		add_action( 'template_redirect', [ $this, 'setup_single_course_page' ] );
 		add_action( 'sensei_loaded', [ $this, 'add_legacy_course_hooks' ] );
 
-		// Add custom navigation
+		// Add custom navigation.
 		add_action( 'in_admin_header', [ $this, 'add_custom_navigation' ] );
 		add_action( 'parent_file', [ $this, 'highlight_menu_item' ] );
 	}
@@ -154,7 +154,7 @@ class Sensei_Course {
 	/**
 	 * Highlight the menu item for the course pages.
 	 *
-	 * @param $file
+	 * @param string $file
 	 *
 	 * @return string
 	 */
@@ -162,7 +162,8 @@ class Sensei_Course {
 		global $submenu_file;
 		$screen = get_current_screen();
 
-		if ( $screen && in_array( $screen->id, [ 'edit-course', 'edit-course-category', 'course_page_course-order' ] ) ) {
+		if ( $screen && in_array( $screen->id, [ 'edit-course', 'edit-course-category', 'course_page_course-order' ], true ) ) {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			$submenu_file = 'edit.php?post_type=course';
 		}
 
@@ -179,7 +180,7 @@ class Sensei_Course {
 		if ( ! $screen ) {
 			return;
 		}
-		if ( in_array( $screen->id, [ 'edit-course', 'edit-course-category'] ) ) {
+		if ( in_array( $screen->id, [ 'edit-course', 'edit-course-category' ], true ) ) {
 			$this->display_courses_navigation( $screen );
 		}
 	}
@@ -190,20 +191,20 @@ class Sensei_Course {
 	 * @param WP_Screen $screen
 	 */
 	private function display_courses_navigation( WP_Screen $screen ) {
-		?>
-		<div id="sensei-custom-navigation">
-			<div class="title">
-				<h1><?php echo __( 'Courses', 'sensei-lms' ); ?></h1>
-			</div>
-			<div class="navigation">
-				<a class="sensei-custom-navigation__nav-tag <?php echo $screen->taxonomy === '' ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=course' ) ); ?>"><?php echo __( 'All Courses', 'sensei-lms' ); ?></a>
-				<a class="sensei-custom-navigation__nav-tag <?php echo $screen->taxonomy === 'course-category' ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ); ?>"><?php echo __( 'Course Categories', 'sensei-lms' ); ?></a>
-				<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=course' ) ); ?>"><?php echo __( 'New course', 'sensei-lms' ); ?></a>
-				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=course-order' ) ); ?>"><?php echo __( 'Order courses', 'sensei-lms' ); ?></a>
-				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#course-settings' ) ); ?>"><?php echo __( 'Course settings', 'sensei-lms' ); ?></a>
-			</div>
-		</div>
-		<?php
+		$html  = '<div id="sensei-custom-navigation">';
+		$html .= '<div class="title">';
+		$html .= '<h1>' . __( 'Courses', 'sensei-lms' ) . '</h1>';
+		$html .= '</div>';
+		$html .= '<div class="navigation">';
+		$html .= '<a class="sensei-custom-navigation__nav-tag ' . ( '' === $screen->taxonomy ? 'active' : '' ) . '" href="' . esc_url( admin_url( 'edit.php?post_type=course' ) ) . '">' . __( 'All Courses', 'sensei-lms' ) . '</a>';
+		$html .= '<a class="sensei-custom-navigation__nav-tag ' . ( 'course-category' === $screen->taxonomy ? 'active' : '' ) . '" href="' . esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ) . '">' . __( 'Course Categories', 'sensei-lms' ) . '</a>';
+		$html .= '<a class="page-title-action" href="' . esc_url( admin_url( 'post-new.php?post_type=course' ) ) . '">' . __( 'New course', 'sensei-lms' ) . '</a>';
+		$html .= '<a href="' . esc_url( admin_url( 'edit.php?post_type=course&page=course-order' ) ) . '">' . __( 'Order courses', 'sensei-lms' ) . '</a>';
+		$html .= '<a href="' . esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#course-settings' ) ) . '">' . __( 'Course settings', 'sensei-lms' ) . '</a>';
+		$html .= '</div>';
+		$html .= '</div>';
+
+		echo wp_kses( $html, wp_kses_allowed_html( 'post' ) );
 	}
 
 	/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -148,32 +148,34 @@ class Sensei_Course {
 
 		// Add custom navigation.
 		add_action( 'in_admin_header', [ $this, 'add_custom_navigation' ] );
-		add_action( 'parent_file', [ $this, 'highlight_menu_item' ] );
+		add_action( 'submenu_file', [ $this, 'highlight_menu_item' ] );
 	}
 
 	/**
 	 * Highlight the menu item for the course pages.
 	 *
-	 * @param string $file
+	 * @since 4.0.0
+	 * @access private*
+	 *
+	 * @param $submenu_file
 	 *
 	 * @return string
 	 */
-	public function highlight_menu_item( $file ) {
-		global $submenu_file;
+	public function highlight_menu_item( $submenu_file ) {
 		$screen = get_current_screen();
 
 		if ( $screen && in_array( $screen->id, [ 'edit-course', 'edit-course-category', 'course_page_course-order' ], true ) ) {
-			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			$submenu_file = 'edit.php?post_type=course';
 		}
 
-		return $file;
+		return $submenu_file;
 	}
 
 	/**
 	 * Add custom navigation to the admin pages.
 	 *
-	 * @since 1.9.0
+	 * @since 4.0.0
+	 * @access private
 	 */
 	public function add_custom_navigation() {
 		$screen = get_current_screen();

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -193,20 +193,20 @@ class Sensei_Course {
 	 * @param WP_Screen $screen
 	 */
 	private function display_courses_navigation( WP_Screen $screen ) {
-		$html  = '<div id="sensei-custom-navigation" class="sensei-custom-navigation">';
-		$html .= '<div class="sensei-custom-navigation__title">';
-		$html .= '<h1>' . __( 'Courses', 'sensei-lms' ) . '</h1>';
-		$html .= '</div>';
-		$html .= '<div class="sensei-custom-navigation__navbar">';
-		$html .= '<a class="sensei-custom-navigation__navbar__navtab ' . ( '' === $screen->taxonomy ? 'active' : '' ) . '" href="' . esc_url( admin_url( 'edit.php?post_type=course' ) ) . '">' . __( 'All Courses', 'sensei-lms' ) . '</a>';
-		$html .= '<a class="sensei-custom-navigation__navbar__navtab ' . ( 'course-category' === $screen->taxonomy ? 'active' : '' ) . '" href="' . esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ) . '">' . __( 'Course Categories', 'sensei-lms' ) . '</a>';
-		$html .= '<a class="page-title-action" href="' . esc_url( admin_url( 'post-new.php?post_type=course' ) ) . '">' . __( 'New course', 'sensei-lms' ) . '</a>';
-		$html .= '<a href="' . esc_url( admin_url( 'edit.php?post_type=course&page=course-order' ) ) . '">' . __( 'Order courses', 'sensei-lms' ) . '</a>';
-		$html .= '<a href="' . esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#course-settings' ) ) . '">' . __( 'Course settings', 'sensei-lms' ) . '</a>';
-		$html .= '</div>';
-		$html .= '</div>';
-
-		echo wp_kses( $html, wp_kses_allowed_html( 'post' ) );
+		?>
+		<div id="sensei-custom-navigation" class="sensei-custom-navigation">
+			<div class="sensei-custom-navigation__title">
+				<h1><?php esc_html_e( 'Courses', 'sensei-lms' ); ?></h1>
+			</div>
+			<div class="sensei-custom-navigation__navbar">
+				<a class="sensei-custom-navigation__navbar__navtab <?php echo $screen->taxonomy === '' ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=course' ) ); ?>"><?php esc_html_e( 'All Courses', 'sensei-lms' ); ?></a>
+				<a class="sensei-custom-navigation__navbar__navtab <?php echo $screen->taxonomy === 'course-category' ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=course-category&post_type=course' ) ); ?>"><?php esc_html_e( 'Course Categories', 'sensei-lms' ); ?></a>
+				<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=course' ) ); ?>"><?php esc_html_e( 'New course', 'sensei-lms' ); ?></a>
+				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=course-order' ) ); ?>"><?php esc_html_e( 'Order courses', 'sensei-lms' ); ?></a>
+				<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#course-settings' ) ); ?>"><?php esc_html_e( 'Course settings', 'sensei-lms' ); ?></a>
+			</div>
+		</div>
+		<?php
 	}
 
 	/**

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,6 +24,7 @@ const files = [
 	'js/admin/lesson-edit.js',
 	'js/admin/ordering.js',
 	'js/admin/sensei-notice-dismiss.js',
+	'js/admin/custom-navigation.js',
 	'js/frontend/course-archive.js',
 	'js/frontend/course-video/video-blocks-extension.js',
 	'js/grading-general.js',


### PR DESCRIPTION
Part of #4529 

### Changes proposed in this Pull Request

* Add the custom menu to the courses page.
* Re-add Order courses page.
* Allow open particular tab of Sensei settings.

### Testing instructions
* Open courses admin page.
* Observe custom navigation.
* Click all the links and make sure the "Courses" menu item is active in the sidebar.
* Try to resize the window to look at changes in the navigation.

### Screenshot / Video
<img width="2005" alt="CleanShot 2022-01-26 at 15 59 26@2x" src="https://user-images.githubusercontent.com/329356/151167491-e4a9c864-8966-4d26-91e3-1f290235a2f9.png">
<img width="935" alt="CleanShot 2022-01-26 at 16 00 09@2x" src="https://user-images.githubusercontent.com/329356/151167502-33ae4b57-2e14-4c53-b6ab-777718def9f9.png">
<img width="520" alt="CleanShot 2022-01-26 at 16 00 26@2x" src="https://user-images.githubusercontent.com/329356/151167508-ef278c19-14a5-4aa2-b8fd-a43b7eb8c825.png">
<img width="376" alt="CleanShot 2022-01-26 at 16 00 46@2x" src="https://user-images.githubusercontent.com/329356/151167518-32b8b24b-d574-42ed-9142-4f950a25c747.png">

