### PR TITLE
Add hidden Import & Export submenus

### DIFF
--- a/includes/data-port/class-sensei-export.php
+++ b/includes/data-port/class-sensei-export.php
@@ -25,8 +25,9 @@ class Sensei_Export {
 	 * Sensei_Export constructor.
 	 */
 	public function __construct() {
-
 		$this->page_slug = 'sensei_export';
+
+		add_action( 'admin_menu', [ $this, 'admin_menu' ], 40 );
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 		if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
@@ -50,15 +51,11 @@ class Sensei_Export {
 
 	/**
 	 * Register an export submenu.
-	 *
-	 * @deprecated 4.0.0
 	 */
 	public function admin_menu() {
-		_deprecated_function( __METHOD__, '4.0.0' );
-
 		if ( current_user_can( 'manage_sensei' ) ) {
 			add_submenu_page(
-				'sensei',
+				'options.php',
 				__( 'Export Content', 'sensei-lms' ),
 				__( 'Export', 'sensei-lms' ),
 				'manage_sensei',

--- a/includes/data-port/class-sensei-import.php
+++ b/includes/data-port/class-sensei-import.php
@@ -27,6 +27,8 @@ class Sensei_Import {
 	public function __construct() {
 		$this->page_slug = 'sensei_import';
 
+		add_action( 'admin_menu', [ $this, 'admin_menu' ], 40 );
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 		if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
 
@@ -49,15 +51,11 @@ class Sensei_Import {
 
 	/**
 	 * Register an import submenu.
-	 *
-	 * @deprecated 4.0.0
 	 */
 	public function admin_menu() {
-		_deprecated_function( __METHOD__, '4.0.0' );
-
 		if ( current_user_can( 'manage_sensei' ) ) {
 			add_submenu_page(
-				'sensei',
+				'options.php',
 				__( 'Import Content', 'sensei-lms' ),
 				__( 'Import', 'sensei-lms' ),
 				'manage_sensei',


### PR DESCRIPTION
### Changes proposed in this Pull Request
This PR adds the Import and Export submenus back so that they can be linked to, but it hides them from the menu in the same way we do for the [Setup Wizard menu](https://github.com/Automattic/sensei/blob/master/includes/admin/class-sensei-setup-wizard.php#L116).

### Testing instructions
* Ensure _Import_ and _Export_ don't appear in the sidebar menu.
* Go to _Courses_ and click the _Help_ tab in the top right.
* Click the _Setup wizard_ button.
* Step through the wizard until you get to the last step.
* Click the _Import content_ button.
* Ensure you are taken to the _Import Content_ page.