### PR TITLE
Fix quiz buttons styles

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -442,7 +442,7 @@ a.sensei-certificate-link {
 /**
  * Quiz Actions
  */
-.sensei-quiz-actions {
+div.sensei-quiz-actions {
 	display: flex;
 	flex-direction: column;
 	align-items: center;


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes the button styles conflict with Twenty Twenty-One theme after we changed it from ID to class.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Check the buttons "Reset" and "Save" in the quiz, and make sure they don't have a background like the screenshot.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="307" alt="Screen Shot 2022-01-24 at 11 31 49" src="https://user-images.githubusercontent.com/876340/150833587-9a62d238-ad67-4c0b-8cee-d68a3b90f6b9.png">