### PR TITLE
Fix collapsible height with a loaded font

### DIFF
--- a/assets/blocks/frontend.js
+++ b/assets/blocks/frontend.js
@@ -1,14 +1,10 @@
 /**
- * WordPress dependencies
- */
-import domReady from '@wordpress/dom-ready';
-
-/**
  * Internal dependencies
  */
 import '../js/sensei-modal';
 
-domReady( () => {
+// eslint-disable-next-line @wordpress/no-global-event-listener
+window.addEventListener( 'load', () => {
 	if (
 		0 === document.querySelectorAll( '.sensei-collapsible__toggle' ).length
 	) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -128,7 +128,7 @@ function getWebpackConfig( env, argv ) {
 					test: /\.(?:gif|jpg|jpeg|png|woff|woff2|eot|ttf|otf)$/i,
 					type: 'asset/resource',
 					generator: {
-						filename: '[path][name]-[contenthash].[ext]',
+						filename: '[path][name]-[contenthash][ext]',
 						publicPath: '../',
 					},
 				},


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes an issue with the calculated height of collapsible elements. If a text element that can break the line is using a custom font, the text size can change after applying the font, which can impact the element height. So if the content loads before the font is ready, it can calculate a wrong initial height for the element.
* It also fixes the Webpack configuration, removing a double dot from the file extensions.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* It's easier to reproduce on Chrome, and with disabled cache (Network tab in developer tools).
* Create a course with texts similar to the snapshots, and refresh it sometimes.
* Make sure the content is not cropped.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="378" alt="Screen Shot 2022-01-24 at 15 53 51" src="https://user-images.githubusercontent.com/876340/150848985-50cda996-786f-48ea-b79b-e363cb11cd5a.png">

<img width="358" alt="Screen Shot 2022-01-24 at 15 53 35" src="https://user-images.githubusercontent.com/876340/150848974-d50f03da-e3fe-45e9-9762-0bf441a8aa0d.png">


