### PR TITLE
Fix preview learning mode in a course with disabled learning mode

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -122,6 +122,8 @@ class Sensei_Course_Theme_Option {
 			return false;
 		}
 
+		$course_id = absint( $course_id );
+
 		if (
 			self::has_sensei_theme_enabled( $course_id ) ||
 			Sensei_Course_Theme::is_preview_mode( $course_id )


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes preview learning mode in a course with disabled learning mode.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course with lessons.
* Make sure the learning mode is disabled. Click on "Preview" in the sidebar next to the Learning mode toggle.
* Make sure you can preview the learning mode.