### PR TITLE
Fix quiz question number on learning mode

### DIFF
--- a/includes/blocks/course-theme/class-quiz-content.php
+++ b/includes/blocks/course-theme/class-quiz-content.php
@@ -62,7 +62,10 @@ class Quiz_Content {
 		while ( sensei_quiz_has_questions() ) {
 			sensei_setup_the_question();
 			?>
-			<li class="sensei-quiz-question <?php sensei_the_question_class(); ?>">
+			<li
+				class="sensei-quiz-question <?php sensei_the_question_class(); ?>"
+				value="<?php echo esc_attr( sensei_get_the_question_number() ); ?>"
+			>
 				<?php
 				do_action( 'sensei_quiz_question_inside_before', sensei_get_the_question_id() );
 				sensei_the_question_content();


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes quiz question number on learning mode when the quiz is paginated like it was done in this commit: https://github.com/Automattic/sensei/commit/3a2a29a271a6e99bda849dda19af66069965ad06

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course that contains a paginated quiz.
* Enable the learning mode.
* Go to another page.
* Make sure the question number (in the left of the question text) is correct and not always "1".

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1286" alt="Screen Shot 2022-01-24 at 16 57 14" src="https://user-images.githubusercontent.com/876340/150855734-16a1b0da-30ba-4ed1-81fc-39d0c9b24a43.png">
