### PR TITLE
Add "New" badge to Learning Mode

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -127,3 +127,19 @@ li.menu-icon-course .wp-menu-image img {
 .edit-php.post-type-quiz .add-new-h2 {
 	display: none;
 }
+
+.sensei-badge {
+	display: inline-block;
+	padding: 0 5px;
+	border-radius: 9px;
+	font-size: 12px;
+
+	&--success {
+		background-color: #28a745;
+		color: #ffffff;
+	}
+
+	&--after-text {
+		margin-left: 5px;
+	}
+}

--- a/assets/js/admin/course-theme/course-theme-sidebar.js
+++ b/assets/js/admin/course-theme/course-theme-sidebar.js
@@ -103,7 +103,14 @@ const CourseThemeSidebar = () => {
 	return (
 		<PluginDocumentSettingPanel
 			name="sensei-course-theme"
-			title={ __( 'Course Styles', 'sensei-lms' ) }
+			title={
+				<>
+					{ __( 'Course Styles', 'sensei-lms' ) }
+					<span className="sensei-badge sensei-badge--success sensei-badge--after-text">
+						{ __( 'New!', 'sensei-lms' ) }
+					</span>
+				</>
+			}
 		>
 			{ globalLearningModeEnabled ? (
 				<p>

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -303,7 +303,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		// Course Settings.
 		$fields['sensei_learning_mode_all'] = array(
-			'name'        => __( 'Learning mode', 'sensei-lms' ),
+			'name'        => __( 'Learning mode', 'sensei-lms' ) . '<span class="sensei-badge sensei-badge--success sensei-badge--after-text">' . __( 'New!', 'sensei-lms' ) . '</span>',
 			'description' => __( 'Enable this mode for your courses to show an immersive and dedicated view for the course, lessons, and quizzes.', 'sensei-lms' ),
 			'form'        => 'render_learning_mode_setting',
 			'type'        => 'checkbox',


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It adds a "New" badge to the Learning Mode.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Go to the course editor sidebar, and make sure you see a "New" badge in the "Course Styles" panel.
* Go to the Sensei settings > Course tab, and make sure you see a "New" badge in the learning mode setting.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="983" alt="Screen Shot 2022-01-25 at 11 06 23" src="https://user-images.githubusercontent.com/876340/150993095-d8292e8a-f86c-47bf-b783-cc9d225a2866.png">

<img width="309" alt="Screen Shot 2022-01-25 at 11 06 11" src="https://user-images.githubusercontent.com/876340/150993111-ae56dcdd-e3b9-4eac-bf69-d0a53053f6b7.png">

