### PR TITLE
Revert "Add hidden Import & Export submenus"

### DIFF
--- a/includes/data-port/class-sensei-export.php
+++ b/includes/data-port/class-sensei-export.php
@@ -25,9 +25,8 @@ class Sensei_Export {
 	 * Sensei_Export constructor.
 	 */
 	public function __construct() {
-		$this->page_slug = 'sensei_export';
 
-		add_action( 'admin_menu', [ $this, 'admin_menu' ], 40 );
+		$this->page_slug = 'sensei_export';
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 		if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
@@ -51,11 +50,15 @@ class Sensei_Export {
 
 	/**
 	 * Register an export submenu.
+	 *
+	 * @deprecated 4.0.0
 	 */
 	public function admin_menu() {
+		_deprecated_function( __METHOD__, '4.0.0' );
+
 		if ( current_user_can( 'manage_sensei' ) ) {
 			add_submenu_page(
-				'options.php',
+				'sensei',
 				__( 'Export Content', 'sensei-lms' ),
 				__( 'Export', 'sensei-lms' ),
 				'manage_sensei',

--- a/includes/data-port/class-sensei-import.php
+++ b/includes/data-port/class-sensei-import.php
@@ -27,8 +27,6 @@ class Sensei_Import {
 	public function __construct() {
 		$this->page_slug = 'sensei_import';
 
-		add_action( 'admin_menu', [ $this, 'admin_menu' ], 40 );
-
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 		if ( isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug ) ) {
 
@@ -51,11 +49,15 @@ class Sensei_Import {
 
 	/**
 	 * Register an import submenu.
+	 *
+	 * @deprecated 4.0.0
 	 */
 	public function admin_menu() {
+		_deprecated_function( __METHOD__, '4.0.0' );
+
 		if ( current_user_can( 'manage_sensei' ) ) {
 			add_submenu_page(
-				'options.php',
+				'sensei',
 				__( 'Import Content', 'sensei-lms' ),
 				__( 'Import', 'sensei-lms' ),
 				'manage_sensei',


### PR DESCRIPTION
Reverts Automattic/sensei#4675. In #4634, the Import / Export functionality is going to be accessible from the _Tools_ menu, so there's no need to add them as hidden submenus.