### PR TITLE
Fix quiz answer notes issues

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -796,8 +796,8 @@ class Sensei_Question {
 		 */
 		$show_correct_answers = apply_filters( 'sensei_question_show_answers', $show_correct_answers, $question_id, $quiz_id, $lesson_id, get_current_user_id() );
 
-		$answer_grade   = Sensei()->quiz->get_user_question_grade( $lesson_id, $question_id, get_current_user_id() );
-		$answer_correct = is_int( $answer_grade ) && $answer_grade > 0;
+		$answer_grade   = (int) Sensei()->quiz->get_user_question_grade( $lesson_id, $question_id, get_current_user_id() );
+		$answer_correct = $answer_grade > 0;
 
 		$answer_notes_classname = '';
 		$answer_feedback_title  = '';

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -882,6 +882,8 @@ class Sensei_Question {
 		 */
 		$correct_answer = apply_filters( 'sensei_question_answer_message_correct_answer', $correct_answer, $lesson_id, $question_id, get_current_user_id(), $answer_correct );
 
+		$has_answer_notes = $answer_notes && wp_strip_all_tags( $answer_notes );
+
 		?>
 		<div class="sensei-lms-question__answer-feedback <?php echo esc_attr( $answer_notes_classname ); ?>">
 			<?php if ( $indicate_incorrect ) { ?>
@@ -894,7 +896,7 @@ class Sensei_Question {
 					<?php } ?>
 				</div>
 			<?php } ?>
-			<?php if ( $answer_notes || $correct_answer ) { ?>
+			<?php if ( $has_answer_notes || $correct_answer ) { ?>
 				<div class="sensei-lms-question__answer-feedback__content">
 					<?php if ( $correct_answer ) { ?>
 						<div class="sensei-lms-question__answer-feedback__correct-answer">
@@ -902,7 +904,7 @@ class Sensei_Question {
 							<strong><?php echo wp_kses_post( $correct_answer ); ?></strong>
 						</div>
 					<?php } ?>
-					<?php if ( $answer_notes && wp_strip_all_tags( $answer_notes ) ) { ?>
+					<?php if ( $has_answer_notes ) { ?>
 						<div class="sensei-lms-question__answer-feedback__answer-notes">
 							<?php echo wp_kses_post( $answer_notes ); ?>
 						</div>


### PR DESCRIPTION
Fixes #4466

### Changes proposed in this Pull Request

* Fix answer feedback container displaying for empty paragraphs
* Fix auto-graded failed question's grade not displaying as '0'

### Testing instructions

* See #4466

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="961" alt="image" src="https://user-images.githubusercontent.com/176949/151059365-5d87dc94-0fea-424a-8698-7badf198e53c.png">
