### PR TITLE
Lessons page submenu items

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1466,7 +1466,6 @@ class Sensei_Admin {
 			$courses = get_posts( $args );
 
 			$html .= '<form action="' . esc_url( admin_url( 'edit.php' ) ) . '" method="get">' . "\n";
-			$html .= '<input type="hidden" name="post_type" value="course" />' . "\n";
 			$html .= '<input type="hidden" name="page" value="lesson-order" />' . "\n";
 			$html .= '<select id="lesson-order-course" name="course_id">' . "\n";
 			$html .= '<option value="">' . esc_html__( 'Select a course', 'sensei-lms' ) . '</option>' . "\n";

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1466,6 +1466,7 @@ class Sensei_Admin {
 			$courses = get_posts( $args );
 
 			$html .= '<form action="' . esc_url( admin_url( 'edit.php' ) ) . '" method="get">' . "\n";
+			$html .= '<input type="hidden" name="post_type" value="course" />' . "\n";
 			$html .= '<input type="hidden" name="page" value="lesson-order" />' . "\n";
 			$html .= '<select id="lesson-order-course" name="course_id">' . "\n";
 			$html .= '<option value="">' . esc_html__( 'Select a course', 'sensei-lms' ) . '</option>' . "\n";

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1462,7 +1462,7 @@ class Sensei_Admin {
 			$courses = get_posts( $args );
 
 			$html .= '<form action="' . esc_url( admin_url( 'edit.php' ) ) . '" method="get">' . "\n";
-			$html .= '<input type="hidden" name="post_type" value="lesson" />' . "\n";
+			$html .= '<input type="hidden" name="post_type" value="course" />' . "\n";
 			$html .= '<input type="hidden" name="page" value="lesson-order" />' . "\n";
 			$html .= '<select id="lesson-order-course" name="course_id">' . "\n";
 			$html .= '<option value="">' . esc_html__( 'Select a course', 'sensei-lms' ) . '</option>' . "\n";

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -38,6 +38,7 @@ class Sensei_Admin {
 		// register admin scripts
 		add_action( 'admin_enqueue_scripts', array( $this, 'register_scripts' ) );
 		add_action( 'admin_menu', array( $this, 'add_course_order' ) );
+		add_action( 'admin_menu', array( $this, 'add_lesson_order' ) );
 		add_action( 'menu_order', array( $this, 'admin_menu_order' ) );
 		add_action( 'admin_head', array( $this, 'admin_menu_highlight' ) );
 		add_action( 'admin_init', array( $this, 'sensei_add_custom_menu_items' ) );
@@ -131,6 +132,22 @@ class Sensei_Admin {
 	}
 
 	/**
+	 * Add Lesson order page to admin panel.
+	 *
+	 * @since  4.0.0
+	 */
+	public function add_lesson_order() {
+		add_submenu_page(
+			null,
+			__( 'Order Lessons', 'sensei-lms' ),
+			__( 'Order Lessons', 'sensei-lms' ),
+			'manage_sensei',
+			$this->lesson_order_page_slug,
+			array( $this, 'lesson_order_screen' )
+		);
+	}
+
+	/**
 	 * [admin_menu_order description]
 	 *
 	 * @since  1.4.0
@@ -198,6 +215,7 @@ class Sensei_Admin {
 			$parent_file  = 'sensei';
 
 		}
+
 		// phpcs:enable WordPress.WP.GlobalVariablesOverride.Prohibited
 	}
 
@@ -348,9 +366,7 @@ class Sensei_Admin {
 		Sensei()->assets->enqueue( 'sensei-event-logging', 'js/admin/event-logging.js', [ 'jquery' ], true );
 
 		// Sensei custom navigation.
-		if ( $screen && ( in_array( $screen->id, [ 'edit-course', 'edit-course-category' ], true ) ) ) {
-			Sensei()->assets->enqueue( 'sensei-admin-custom-navigation', 'js/admin/custom-navigation.js', [], true );
-		}
+		Sensei()->assets->enqueue( 'sensei-admin-custom-navigation', 'js/admin/custom-navigation.js', [], true );
 
 		wp_localize_script( 'sensei-event-logging', 'sensei_event_logging', [ 'enabled' => Sensei_Usage_Tracking::get_instance()->get_tracking_enabled() ] );
 	}
@@ -1410,7 +1426,7 @@ class Sensei_Admin {
 	}
 
 	/**
-	 * Dsplay Lesson Order screen
+	 * Display Lesson Order screen
 	 *
 	 * @return void
 	 */

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -369,7 +369,7 @@ class Sensei_Admin {
 
 		// Sensei custom navigation.
 		if ( $screen && ( in_array( $screen->id, [ 'edit-course', 'edit-course-category', 'edit-lesson', 'edit-lesson-tag' ], true ) ) ) {
-			Sensei()->assets->enqueue('sensei-admin-custom-navigation', 'js/admin/custom-navigation.js', [], true);
+			Sensei()->assets->enqueue( 'sensei-admin-custom-navigation', 'js/admin/custom-navigation.js', [], true );
 		}
 
 		wp_localize_script( 'sensei-event-logging', 'sensei_event_logging', [ 'enabled' => Sensei_Usage_Tracking::get_instance()->get_tracking_enabled() ] );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -119,6 +119,7 @@ class Sensei_Admin {
 	 * Add Course order page to admin panel.
 	 *
 	 * @since  4.0.0
+	 * @access private
 	 */
 	public function add_course_order() {
 		add_submenu_page(
@@ -135,13 +136,14 @@ class Sensei_Admin {
 	 * Add Lesson order page to admin panel.
 	 *
 	 * @since  4.0.0
+	 * @access private
 	 */
 	public function add_lesson_order() {
 		add_submenu_page(
 			null,
 			__( 'Order Lessons', 'sensei-lms' ),
 			__( 'Order Lessons', 'sensei-lms' ),
-			'manage_sensei',
+			'edit_published_lessons',
 			$this->lesson_order_page_slug,
 			array( $this, 'lesson_order_screen' )
 		);
@@ -366,7 +368,9 @@ class Sensei_Admin {
 		Sensei()->assets->enqueue( 'sensei-event-logging', 'js/admin/event-logging.js', [ 'jquery' ], true );
 
 		// Sensei custom navigation.
-		Sensei()->assets->enqueue( 'sensei-admin-custom-navigation', 'js/admin/custom-navigation.js', [], true );
+		if ( $screen && ( in_array( $screen->id, [ 'edit-course', 'edit-course-category', 'edit-lesson', 'edit-lesson-tag' ], true ) ) ) {
+			Sensei()->assets->enqueue('sensei-admin-custom-navigation', 'js/admin/custom-navigation.js', [], true);
+		}
 
 		wp_localize_script( 'sensei-event-logging', 'sensei_event_logging', [ 'enabled' => Sensei_Usage_Tracking::get_instance()->get_tracking_enabled() ] );
 	}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -142,9 +142,76 @@ class Sensei_Lesson {
 			add_action( 'wp', array( __CLASS__, 'maybe_start_lesson' ) );
 		}
 
+		// Add custom navigation.
+		add_action( 'in_admin_header', [ $this, 'add_custom_navigation' ] );
+		add_filter( 'submenu_file', [ $this, 'highlight_menu_item' ] );
+
 		// Log event on the initial publish for a lesson.
 		add_action( 'sensei_lesson_initial_publish', [ $this, 'log_initial_publish_event' ] );
 	}
+
+	/**
+	 * Add custom navigation to the admin pages.
+	 *
+	 * @since 4.0.0
+	 * @access private
+	 */
+	public function add_custom_navigation() {
+		$screen = get_current_screen();
+		if ( ! $screen ) {
+			return;
+		}
+		if ( in_array( $screen->id, [ 'edit-lesson', 'edit-lesson-tag' ], true ) ) {
+			$this->display_lessons_navigation( $screen );
+		}
+	}
+
+	/**
+	 * Highlight the menu item for the lessons pages.
+	 *
+	 * @param string | null $submenu_file The submenu file points to the certain item of the submenu.
+	 *
+	 * @return string | null
+	 * @since 4.0.0
+	 * @access private
+	 */
+	public function highlight_menu_item( ?string $submenu_file ) {
+		$screen = get_current_screen();
+
+		if ( $screen && in_array( $screen->id, [ 'edit-lesson', 'edit-lesson-tag', 'course_page_lesson-order' ], true ) ) {
+			$submenu_file = 'edit.php?post_type=lesson';
+		}
+
+		return $submenu_file;
+	}
+
+
+	/**
+	 * Display the lessons' navigation.
+	 *
+	 * @param WP_Screen $screen
+	 */
+	private function display_lessons_navigation( WP_Screen $screen ) {
+		?>
+		<div id="sensei-custom-navigation" class="sensei-custom-navigation">
+			<div class="sensei-custom-navigation__heading">
+				<div class="sensei-custom-navigation__title">
+					<h1><?php esc_html_e( 'Lessons', 'sensei-lms' ); ?></h1>
+				</div>
+				<div class="sensei-custom-navigation__links">
+					<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=lesson' ) ); ?>"><?php esc_html_e( 'New lesson', 'sensei-lms' ); ?></a>
+					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=lesson-order' ) ); ?>"><?php esc_html_e( 'Order lessons', 'sensei-lms' ); ?></a>
+					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#lesson-settings' ) ); ?>"><?php esc_html_e( 'Lesson settings', 'sensei-lms' ); ?></a>
+				</div>
+			</div>
+			<div class="sensei-custom-navigation__tabbar">
+				<a class="sensei-custom-navigation__tab <?php echo '' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=lesson' ) ); ?>"><?php esc_html_e( 'All Lessons', 'sensei-lms' ); ?></a>
+				<a class="sensei-custom-navigation__tab <?php echo 'lesson-tag' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=lesson-tag&post_type=lesson' ) ); ?>"><?php esc_html_e( 'Lesson Tags', 'sensei-lms' ); ?></a>
+			</div>
+		</div>
+		<?php
+	}
+
 
 	/**
 	 * Adds a link for editing the lesson's course if it belongs to a course.
@@ -180,7 +247,8 @@ class Sensei_Lesson {
 			return;
 		}
 
-		$url = admin_url( "post.php?post=$course_id&action=edit" ); ?>
+		$url = admin_url( "post.php?post=$course_id&action=edit" );
+		?>
 
 		<script>
 			jQuery(function () {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -169,13 +169,14 @@ class Sensei_Lesson {
 	/**
 	 * Highlight the menu item for the lessons pages.
 	 *
-	 * @param string | null $submenu_file The submenu file points to the certain item of the submenu.
-	 *
-	 * @return string | null
 	 * @since 4.0.0
 	 * @access private
+	 *
+	 * @param string $submenu_file The submenu file points to the certain item of the submenu.
+	 *
+	 * @return string
 	 */
-	public function highlight_menu_item( ?string $submenu_file ) {
+	public function highlight_menu_item( $submenu_file ) {
 		$screen = get_current_screen();
 
 		if ( $screen && in_array( $screen->id, [ 'edit-lesson', 'edit-lesson-tag', 'course_page_lesson-order' ], true ) ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -200,9 +200,9 @@ class Sensei_Lesson {
 					<h1><?php esc_html_e( 'Lessons', 'sensei-lms' ); ?></h1>
 				</div>
 				<div class="sensei-custom-navigation__links">
-					<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=lesson' ) ); ?>"><?php esc_html_e( 'New lesson', 'sensei-lms' ); ?></a>
-					<a href="<?php echo esc_url( admin_url( 'edit.php?page=lesson-order' ) ); ?>"><?php esc_html_e( 'Order lessons', 'sensei-lms' ); ?></a>
-					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#lesson-settings' ) ); ?>"><?php esc_html_e( 'Lesson settings', 'sensei-lms' ); ?></a>
+					<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=lesson' ) ); ?>"><?php esc_html_e( 'New Lesson', 'sensei-lms' ); ?></a>
+					<a href="<?php echo esc_url( admin_url( 'edit.php?page=lesson-order' ) ); ?>"><?php esc_html_e( 'Order Lessons', 'sensei-lms' ); ?></a>
+					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#lesson-settings' ) ); ?>"><?php esc_html_e( 'Lesson Settings', 'sensei-lms' ); ?></a>
 				</div>
 			</div>
 			<div class="sensei-custom-navigation__tabbar">

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -201,7 +201,7 @@ class Sensei_Lesson {
 				</div>
 				<div class="sensei-custom-navigation__links">
 					<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=lesson' ) ); ?>"><?php esc_html_e( 'New Lesson', 'sensei-lms' ); ?></a>
-					<a href="<?php echo esc_url( admin_url( 'edit.php?page=lesson-order' ) ); ?>"><?php esc_html_e( 'Order Lessons', 'sensei-lms' ); ?></a>
+					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=lesson-order' ) ); ?>"><?php esc_html_e( 'Order Lessons', 'sensei-lms' ); ?></a>
 					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#lesson-settings' ) ); ?>"><?php esc_html_e( 'Lesson Settings', 'sensei-lms' ); ?></a>
 				</div>
 			</div>

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -201,7 +201,7 @@ class Sensei_Lesson {
 				</div>
 				<div class="sensei-custom-navigation__links">
 					<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=lesson' ) ); ?>"><?php esc_html_e( 'New lesson', 'sensei-lms' ); ?></a>
-					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=lesson-order' ) ); ?>"><?php esc_html_e( 'Order lessons', 'sensei-lms' ); ?></a>
+					<a href="<?php echo esc_url( admin_url( 'edit.php?page=lesson-order' ) ); ?>"><?php esc_html_e( 'Order lessons', 'sensei-lms' ); ?></a>
 					<a href="<?php echo esc_url( admin_url( 'edit.php?post_type=course&page=sensei-settings#lesson-settings' ) ); ?>"><?php esc_html_e( 'Lesson settings', 'sensei-lms' ); ?></a>
 				</div>
 			</div>


### PR DESCRIPTION
Relates #4530

### Changes proposed in this Pull Request
* Add a tab for All Lessons that displays the default view.
* Add a tab for Lesson Tags that goes to the Lesson Tags page.
* Add an Order lessons link that goes to the Order Lessons page.
* Add a Lesson settings link that goes to the Lessons tab of Sensei LMS Settings.

### Testing instructions
* Go to the Lessons menu item in the Sensei menu 
* You should see this outlook of the menu
![image](https://user-images.githubusercontent.com/7208249/151337005-0b045d4c-6c13-4326-9187-ff20624b09da.png)
* **The first two items are tabs** and when clicking them you should see the following two views

| All lessons | Lesson tags | Lesson tag menu item |
| -- | -- | -- |
| ![image](https://user-images.githubusercontent.com/7208249/151337128-5d65330d-1547-47b2-adcc-c8858ef205f9.png) | ![image](https://user-images.githubusercontent.com/7208249/151337187-ac7290c1-e747-4df4-aeb0-3ee47038a8d9.png) | ![image](https://user-images.githubusercontent.com/7208249/151337298-fdfcb0d3-273f-48b7-a74a-cf393280f512.png) |


* Clicking New Lesson should redirect you to Lesson Creation view
![image](https://user-images.githubusercontent.com/7208249/151120365-101144eb-f092-47e0-8a93-dde89c26cb66.png)

* Clicking Order Lessons should lead you to 
![image](https://user-images.githubusercontent.com/7208249/151337436-87274e55-f5fc-48c3-9987-fa6447b0b509.png)
* Clicking Lesson Settings should lead you to 
![image](https://user-images.githubusercontent.com/7208249/151337487-15311383-9272-4317-b4d5-3149f2b0e021.png)

### New/Updated Hooks
Adding new Submenu item for Order Lessons so that that can be displayed in the Order Lessons tab
* add_action( 'admin_menu', array( $this, 'add_lesson_order' ) );

Adding custom navigation to the Lessons page 
* add_action( 'in_admin_header', [ $this, 'add_custom_navigation' ] );

Highlighting menu items 
*add_filter( 'submenu_file', [ $this, 'highlight_menu_item' ] );