### PR TITLE
Add custom navigation to Questions menu item

### DIFF
--- a/assets/js/admin/custom-navigation.js
+++ b/assets/js/admin/custom-navigation.js
@@ -17,10 +17,10 @@
 		title.style.display = 'none';
 	}
 	// Find the default "Add New" button and hide it.
-	const newCourseButton = document.querySelector(
+	const addNewButton = document.querySelector(
 		'.wrap > a.page-title-action'
 	);
-	if ( newCourseButton ) {
-		newCourseButton.style.display = 'none';
+	if ( addNewButton ) {
+		addNewButton.style.display = 'none';
 	}
 } )();

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1430,7 +1430,7 @@ class Sensei_Admin {
 	}
 
 	/**
-	 * Display Lesson Order screen
+	 * Dsplay Lesson Order screen
 	 *
 	 * @return void
 	 */
@@ -1466,7 +1466,7 @@ class Sensei_Admin {
 			$courses = get_posts( $args );
 
 			$html .= '<form action="' . esc_url( admin_url( 'edit.php' ) ) . '" method="get">' . "\n";
-			$html .= '<input type="hidden" name="post_type" value="course" />' . "\n";
+			$html .= '<input type="hidden" name="post_type" value="lesson" />' . "\n";
 			$html .= '<input type="hidden" name="page" value="lesson-order" />' . "\n";
 			$html .= '<select id="lesson-order-course" name="course_id">' . "\n";
 			$html .= '<option value="">' . esc_html__( 'Select a course', 'sensei-lms' ) . '</option>' . "\n";

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -368,7 +368,7 @@ class Sensei_Admin {
 		Sensei()->assets->enqueue( 'sensei-event-logging', 'js/admin/event-logging.js', [ 'jquery' ], true );
 
 		// Sensei custom navigation.
-		if ( $screen && ( in_array( $screen->id, [ 'edit-course', 'edit-course-category', 'edit-lesson', 'edit-lesson-tag' ], true ) ) ) {
+		if ( $screen && ( in_array( $screen->id, [ 'edit-course', 'edit-course-category', 'edit-lesson', 'edit-lesson-tag', 'edit-question', 'edit-question-category' ], true ) ) ) {
 			Sensei()->assets->enqueue( 'sensei-admin-custom-navigation', 'js/admin/custom-navigation.js', [], true );
 		}
 

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1466,7 +1466,7 @@ class Sensei_Admin {
 			$courses = get_posts( $args );
 
 			$html .= '<form action="' . esc_url( admin_url( 'edit.php' ) ) . '" method="get">' . "\n";
-			$html .= '<input type="hidden" name="post_type" value="lesson" />' . "\n";
+			$html .= '<input type="hidden" name="post_type" value="course" />' . "\n";
 			$html .= '<input type="hidden" name="page" value="lesson-order" />' . "\n";
 			$html .= '<select id="lesson-order-course" name="course_id">' . "\n";
 			$html .= '<option value="">' . esc_html__( 'Select a course', 'sensei-lms' ) . '</option>' . "\n";

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -207,7 +207,7 @@ class Sensei_Lesson {
 			</div>
 			<div class="sensei-custom-navigation__tabbar">
 				<a class="sensei-custom-navigation__tab <?php echo '' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=lesson' ) ); ?>"><?php esc_html_e( 'All Lessons', 'sensei-lms' ); ?></a>
-				<a class="sensei-custom-navigation__tab <?php echo 'lesson-tag' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=lesson-tag&post_type=lesson' ) ); ?>"><?php esc_html_e( 'Lesson Tags', 'sensei-lms' ); ?></a>
+				<a class="sensei-custom-navigation__tab <?php echo 'lesson-tag' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=lesson-tag&post_type=course' ) ); ?>"><?php esc_html_e( 'Lesson Tags', 'sensei-lms' ); ?></a>
 			</div>
 		</div>
 		<?php

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -100,7 +100,7 @@ class Sensei_Question {
 			</div>
 			<div class="sensei-custom-navigation__tabbar">
 				<a class="sensei-custom-navigation__tab <?php echo '' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=question' ) ); ?>"><?php esc_html_e( 'All Questions', 'sensei-lms' ); ?></a>
-				<a class="sensei-custom-navigation__tab <?php echo 'question-category' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=question-category&post_type=question' ) ); ?>"><?php esc_html_e( 'Question Categories', 'sensei-lms' ); ?></a>
+				<a class="sensei-custom-navigation__tab <?php echo 'question-category' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=question-category&post_type=course' ) ); ?>"><?php esc_html_e( 'Question Categories', 'sensei-lms' ); ?></a>
 			</div>
 		</div>
 		<?php

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -37,9 +37,72 @@ class Sensei_Question {
 			add_filter( 'request', array( $this, 'filter_actions' ) );
 
 			add_action( 'save_post_question', array( $this, 'save_question' ), 10, 1 );
+
+			// Add custom navigation.
+			add_action( 'in_admin_header', [ $this, 'add_custom_navigation' ] );
+			add_filter( 'submenu_file', [ $this, 'highlight_menu_item' ] );
 		}
 
 		add_action( 'sensei_question_initial_publish', [ $this, 'log_initial_publish_event' ] );
+	}
+
+	/**
+	 * Add custom navigation to the admin pages.
+	 *
+	 * @since 4.0.0
+	 * @access private
+	 */
+	public function add_custom_navigation() {
+		$screen = get_current_screen();
+		if ( ! $screen ) {
+			return;
+		}
+		if ( in_array( $screen->id, [ 'edit-question', 'edit-question-category' ], true ) ) {
+			$this->display_question_navigation( $screen );
+		}
+	}
+
+	/**
+	 * Highlight the menu item for the question pages.
+	 *
+	 * @param string | null $submenu_file The submenu file points to the certain item of the submenu.
+	 *
+	 * @return string | null
+	 * @since 4.0.0
+	 * @access private
+	 */
+	public function highlight_menu_item( ?string $submenu_file ) {
+		$screen = get_current_screen();
+
+		if ( $screen && in_array( $screen->id, [ 'edit-lesson', 'edit-question-category' ], true ) ) {
+			$submenu_file = 'edit.php?post_type=question';
+		}
+
+		return $submenu_file;
+	}
+
+	/**
+	 * Display the lessons' navigation.
+	 *
+	 * @param WP_Screen $screen
+	 */
+	private function display_question_navigation( WP_Screen $screen ) {
+		?>
+		<div id="sensei-custom-navigation" class="sensei-custom-navigation">
+			<div class="sensei-custom-navigation__heading">
+				<div class="sensei-custom-navigation__title">
+					<h1><?php esc_html_e( 'Questions ', 'sensei-lms' ); ?></h1>
+				</div>
+				<div class="sensei-custom-navigation__links">
+					<a class="page-title-action" href="<?php echo esc_url( admin_url( 'post-new.php?post_type=question' ) ); ?>"><?php esc_html_e( 'New Question', 'sensei-lms' ); ?></a>
+				</div>
+			</div>
+			<div class="sensei-custom-navigation__tabbar">
+				<a class="sensei-custom-navigation__tab <?php echo '' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit.php?post_type=question' ) ); ?>"><?php esc_html_e( 'All Questions', 'sensei-lms' ); ?></a>
+				<a class="sensei-custom-navigation__tab <?php echo 'question-category' === $screen->taxonomy ? 'active' : ''; ?>" href="<?php echo esc_url( admin_url( 'edit-tags.php?taxonomy=question-category&post_type=question' ) ); ?>"><?php esc_html_e( 'Question Categories', 'sensei-lms' ); ?></a>
+			</div>
+		</div>
+		<?php
 	}
 
 	public function question_types() {

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -65,13 +65,14 @@ class Sensei_Question {
 	/**
 	 * Highlight the menu item for the question pages.
 	 *
-	 * @param string | null $submenu_file The submenu file points to the certain item of the submenu.
-	 *
-	 * @return string | null
 	 * @since 4.0.0
 	 * @access private
+	 *
+	 * @param string $submenu_file The submenu file points to the certain item of the submenu.
+	 *
+	 * @return string
 	 */
-	public function highlight_menu_item( ?string $submenu_file ) {
+	public function highlight_menu_item( $submenu_file ) {
 		$screen = get_current_screen();
 
 		if ( $screen && in_array( $screen->id, [ 'edit-lesson', 'edit-question-category' ], true ) ) {


### PR DESCRIPTION
Relates #4530

### Changes proposed in this Pull Request
* Add a tab for All Questions that displays the default view.
* Add a tab for Question Categories that loads the question categories page inline, rather than redirecting to Question Categories.

### Testing instructions
* Go to the Questions menu item in the Sensei menu
* You should see this outlook of the menu on the page 
![image](https://user-images.githubusercontent.com/7208249/151340069-d8c49c23-1526-4364-97ba-386968898f46.png)

* **The first two items are tabs** and when clicking them you should see the following two views

| All questions | Questions Categories  | Questions Categories menu item |
| -- | -- | -- |
| ![image](https://user-images.githubusercontent.com/7208249/151340111-0d10494a-5927-410d-9ae6-89e742221514.png) | ![image](https://user-images.githubusercontent.com/7208249/151340164-af7a0e9f-fbb4-4e92-8eaa-005463d8b3d0.png) | ![image](https://user-images.githubusercontent.com/7208249/151340234-b1834548-bba8-4dde-bcd6-cbe5e98bf23e.png) |

### New/Updated Hooks

Adding custom navigation to the Lessons page
add_action( 'in_admin_header', [ $this, 'add_custom_navigation' ] );

Highlighting menu items
add_filter( 'submenu_file', [ $this, 'highlight_menu_item' ] );
