### PR TITLE
Add usage tracking for Sensei LMS submenus

### DIFF
--- a/assets/js/admin/event-logging.js
+++ b/assets/js/admin/event-logging.js
@@ -5,6 +5,10 @@
 const selector = '#menu-posts-course ';
 const adminTracking = [
 	{
+		selector: selector + '.wp-menu-name',
+		eventName: 'courses_view',
+	},
+	{
 		selector: selector + 'a[href="edit.php?post_type=course"]',
 		eventName: 'courses_view',
 	},

--- a/assets/js/admin/event-logging.js
+++ b/assets/js/admin/event-logging.js
@@ -1,14 +1,51 @@
-// Used to add tracking to WP core elements, where we can't add custom code.
+/**
+ * Used to add tracking to WP core elements, where we can't add custom code.
+ * Settings and Extensions submenus are logged elsewhere.
+ */
+const selector = '#menu-posts-course ';
 const adminTracking = [
 	{
-		selector:
-			'#toplevel_page_sensei a[href="admin.php?page=sensei_import"]',
-		eventName: 'import_click',
+		selector: selector + 'a[href="edit.php?post_type=course"]',
+		eventName: 'courses_view',
+	},
+	{
+		selector: selector + 'a[href="edit-tags.php?taxonomy=module"]',
+		eventName: 'modules_view',
+	},
+	{
+		selector: selector + 'a[href="edit.php?post_type=lesson"]',
+		eventName: 'lessons_view',
+	},
+	{
+		selector: selector + 'a[href="edit.php?post_type=question"]',
+		eventName: 'questions_view',
 	},
 	{
 		selector:
-			'#toplevel_page_sensei a[href="admin.php?page=sensei_export"]',
-		eventName: 'export_click',
+			selector +
+			'a[href="edit.php?post_type=course&page=sensei_learners"]',
+		eventName: 'student_management_view',
+	},
+	{
+		selector:
+			selector +
+			'a[href="edit.php?post_type=course&page=sensei_grading"]',
+		eventName: 'grading_view',
+	},
+	{
+		selector: selector + 'a[href="edit.php?post_type=sensei_message"]',
+		eventName: 'messages_view',
+	},
+	{
+		selector:
+			selector +
+			'a[href="edit.php?post_type=course&page=sensei_analysis"]',
+		eventName: 'analysis_view',
+	},
+	{
+		selector:
+			selector + 'a[href="edit.php?post_type=course&page=sensei-tools"]',
+		eventName: 'tools_view',
 	},
 ];
 


### PR DESCRIPTION
Fixes #4674.

### Changes proposed in this Pull Request
Adds event tracking when any of the _Sensei LMS_ submenus are clicked.

### Testing instructions
- Select the _Enable usage tracking_ setting in _Sensei LMS_ > _Settings_ > _General_.
- Click on each of the submenus under the _Sensei LMS_ main menu.
- Wait about 15 minutes.
- Check that each of the events were logged in Tracks:
  - [sensei_courses_view](https://mc.a8c.com/tracks/live/?eventname=sensei_courses_view&user=&useragent=)
  - [sensei_modules_view](https://mc.a8c.com/tracks/live/?eventname=sensei_modules_view&user=&useragent=)
  - [sensei_lessons_view](https://mc.a8c.com/tracks/live/?eventname=sensei_lessons_view&user=&useragent=)
  - [sensei_questions_view](https://mc.a8c.com/tracks/live/?eventname=sensei_questions_view&user=&useragent=)
  - [sensei_student_management_view](https://mc.a8c.com/tracks/live/?eventname=sensei_student_management_view&user=&useragent=)
  - [sensei_grading_view](https://mc.a8c.com/tracks/live/?eventname=sensei_grading_view&user=&useragent=)
  - [sensei_messages_view](https://mc.a8c.com/tracks/live/?eventname=sensei_messages_view&user=&useragent=)
  - [sensei_analysis_view](https://mc.a8c.com/tracks/live/?eventname=sensei_analysis_view&user=&useragent=)
  - [sensei_tools_view](https://mc.a8c.com/tracks/live/?eventname=sensei_tools_view&user=&useragent=)
- Deselect the _Enable usage tracking_ setting in _Sensei LMS_ > _Settings_ > _General_ (so we're not logging a bunch of test data).

Note that `sensei_settings_view` and `sensei_extensions_view` are also being logged, but are unaffected by this PR.