### PR TITLE
Fix incorrect menu being highlighted on Lessons page

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -75,7 +75,7 @@ class Sensei_Question {
 	public function highlight_menu_item( $submenu_file ) {
 		$screen = get_current_screen();
 
-		if ( $screen && in_array( $screen->id, [ 'edit-lesson', 'edit-question-category' ], true ) ) {
+		if ( $screen && 'edit-question-category' === $screen->id ) {
 			$submenu_file = 'edit.php?post_type=question';
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
Fix _Questions_ menu being highlighted instead of _Lessons_ when viewing lessons.

### Testing instructions
- Click on _Sensei LMS_ > _Lessons_.
- Ensure the _Lessons_ menu is highlighted.
- Click on _Lesson Tags_.
- Ensure the _Lessons_ menu is highlighted.
- Click on _Questions_.
- Ensure the _Questions_ menu is highlighted.
- Click on _Question Categories_.
- Ensure the _Questions_ menu is highlighted.