### PR TITLE
Change the layout of the posts filter form

### DIFF
--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -149,6 +149,10 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	align-items: flex-start;
 	gap: 20px;
 	margin: 20px auto;
+
+	~ .subtitle {
+		padding-left: 0;
+	}
 }
 
 .sensei-custom-navigation__heading {

--- a/assets/css/posts-filter.scss
+++ b/assets/css/posts-filter.scss
@@ -1,0 +1,40 @@
+/**
+ * Variables
+ */
+$tablet-breakpoint: 783px;
+
+/**
+ * Posts filter form
+ */
+@media only screen and (min-width: $tablet-breakpoint) {
+	.tablenav.top {
+		padding-top: 0;
+		margin: 0;
+		height: auto;
+
+		> * {
+			margin-top: 1em;
+		}
+
+		.search-box {
+			margin-left: 2em;
+		}
+
+		.actions:not(.bulkactions) {
+			padding-right: 0;
+			float: right;
+
+			#post-query-submit {
+				margin-right: 0;
+			}
+		}
+
+		.tablenav-pages {
+			margin-bottom: 1em;
+			clear: both;
+		}
+	}
+}
+
+
+

--- a/assets/css/posts-filter.scss
+++ b/assets/css/posts-filter.scss
@@ -8,8 +8,8 @@ $tablet-breakpoint: 783px;
  */
 @media only screen and (min-width: $tablet-breakpoint) {
 	.tablenav.top {
-		padding-top: 0;
-		margin: 0;
+		padding: 0;
+		margin: 0 0 1em 0;
 		height: auto;
 
 		> * {
@@ -30,7 +30,7 @@ $tablet-breakpoint: 783px;
 		}
 
 		.tablenav-pages {
-			margin-bottom: 1em;
+			margin-bottom: 0;
 			clear: both;
 		}
 	}

--- a/assets/js/admin/posts-filter.js
+++ b/assets/js/admin/posts-filter.js
@@ -11,4 +11,10 @@ domReady( () => {
 		'.tablenav.top',
 		$postsFilterForm
 	);
+
+	// Auto-submit the form when changing the filters.
+	jQuery(
+		'.actions:not(.bulkactions) :input',
+		$postsFilterForm
+	).on( 'change', ( event ) => $postsFilterForm.trigger( 'submit' ) );
 } );

--- a/assets/js/admin/posts-filter.js
+++ b/assets/js/admin/posts-filter.js
@@ -1,0 +1,14 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+domReady( () => {
+	const $postsFilterForm = jQuery( '#posts-filter' );
+
+	// Move the search box next to the other actions for easier styling.
+	jQuery( '.search-box', $postsFilterForm ).prependTo(
+		'.tablenav.top',
+		$postsFilterForm
+	);
+} );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -321,6 +321,11 @@ class Sensei_Admin {
 
 		}
 
+		// Posts filter form.
+		if ( $this->screen_has_posts_filter() ) {
+			Sensei()->assets->enqueue( 'sensei-admin-posts-filter', 'css/posts-filter.css', [], 'screen' );
+		}
+
 	}
 
 
@@ -366,15 +371,40 @@ class Sensei_Admin {
 
 		// Event logging.
 		Sensei()->assets->enqueue( 'sensei-event-logging', 'js/admin/event-logging.js', [ 'jquery' ], true );
+		wp_localize_script( 'sensei-event-logging', 'sensei_event_logging', [ 'enabled' => Sensei_Usage_Tracking::get_instance()->get_tracking_enabled() ] );
 
 		// Sensei custom navigation.
 		if ( $screen && ( in_array( $screen->id, [ 'edit-course', 'edit-course-category', 'edit-lesson', 'edit-lesson-tag', 'edit-question', 'edit-question-category' ], true ) ) ) {
 			Sensei()->assets->enqueue( 'sensei-admin-custom-navigation', 'js/admin/custom-navigation.js', [], true );
 		}
 
-		wp_localize_script( 'sensei-event-logging', 'sensei_event_logging', [ 'enabled' => Sensei_Usage_Tracking::get_instance()->get_tracking_enabled() ] );
+		// Posts filter form.
+		if ( $this->screen_has_posts_filter() ) {
+			Sensei()->assets->enqueue( 'sensei-admin-posts-filter', 'js/admin/posts-filter.js', [ 'jquery' ], true );
+		}
+
 	}
 
+	/**
+	 * Check if the current screen has the posts filter form.
+	 *
+	 * @since 4.0.0
+	 *
+	 * @return bool
+	 */
+	private function screen_has_posts_filter(): bool {
+		$screen = get_current_screen();
+
+		if ( ! $screen ) {
+			return false;
+		}
+
+		return in_array(
+			$screen->id,
+			[ 'edit-course', 'edit-lesson', 'edit-question', 'edit-sensei_message' ],
+			true
+		);
+	}
 
 	/**
 	 * admin_install_notice function.

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -77,6 +77,8 @@ const files = [
 	'css/meta-box-quiz-editor.scss',
 	'css/sensei-course-theme.scss',
 	'course-theme/course-theme.js',
+	'css/posts-filter.scss',
+	'js/admin/posts-filter.js',
 ];
 
 function getName( filename ) {


### PR DESCRIPTION
Part of #4529

### Changes proposed in this Pull Request

* Updates the posts filter form layout on all Sensei post types.
* Auto-submit the form on filter change.

### Testing instructions

* Open the listing screen of one of Sensei's post types.
* Make sure the filters are positioned to the right.
* Check how the layout looks if there is pagination.
* Do a search (with and without results) and see how that looks.
* Check if everything looks good on mobile.
* Double check if there are no other broken screens.

### Screenshots

With pagination:
<img width="1330" alt="Screenshot on 2022-01-28 at 17-54-14" src="https://user-images.githubusercontent.com/1612178/151579291-f89dc7a3-69c5-4b4c-9e7b-fd6c5f8c1ada.png">

Without pagination and including the search results text:
<img width="1329" alt="Screenshot on 2022-01-28 at 17-56-08" src="https://user-images.githubusercontent.com/1612178/151579318-40ac0925-1692-4dca-8e98-032df6a36ab2.png">

Tablet:
<img width="942" alt="Screenshot on 2022-01-28 at 17-55-00" src="https://user-images.githubusercontent.com/1612178/151579357-bb0b626d-753a-49c2-8d84-38e3f6fdc51b.png">

Mobile:
<img width="724" alt="Screenshot on 2022-01-28 at 18-18-02" src="https://user-images.githubusercontent.com/1612178/151582824-b31c3f20-cf5c-4b2b-a2ff-807046b642b2.png">
<img width="722" alt="Screenshot on 2022-01-28 at 18-17-12" src="https://user-images.githubusercontent.com/1612178/151582719-3d0598b5-5915-4e50-8dec-66d90b39d485.png">


