### PR TITLE
Improve focus mode toggle button

### DIFF
--- a/assets/course-theme/blocks/blocks.js
+++ b/assets/course-theme/blocks/blocks.js
@@ -9,6 +9,7 @@ import { useBlockProps } from '@wordpress/block-editor';
  */
 import ChevronLeft from '../../icons/chevron-left.svg';
 import ChevronRight from '../../icons/chevron-right.svg';
+import DoubleChevronRight from '../../icons/double-chevron-right.svg';
 import MenuIcon from '../../icons/menu.svg';
 import CorseNavigationBlock from './course-navigation';
 
@@ -115,7 +116,11 @@ const blocks = [
 		title: __( 'Focus Mode Toggle', 'sensei-lms' ),
 		name: 'sensei-lms/focus-mode-toggle',
 		edit() {
-			return <div>{ __( 'Collapse', 'sensei-lms' ) }</div>;
+			return (
+				<div className="sensei-course-theme__focus-mode-toggle">
+					<DoubleChevronRight className="sensei-course-theme__focus-mode-toggle-icon" />
+				</div>
+			);
 		},
 	},
 

--- a/assets/css/sensei-course-theme/focus-mode.scss
+++ b/assets/css/sensei-course-theme/focus-mode.scss
@@ -4,12 +4,30 @@ $base: '.sensei-course-theme';
 	.sensei-course-theme__focus-mode-toggle {
 		padding: 4px;
 		border: none;
-		background-color: transparent;
+		background-color: var(--bg-color);
 
 		.sensei-course-theme__focus-mode-toggle-icon {
 			width: 10px;
 			height: 10px;
-			transform: rotate(270deg);
+		}
+	}
+
+	body:not(.sensei-course-theme--focus-mode, .editor-styles-wrapper) {
+		.sensei-course-theme__focus-mode-toggle {
+			position: absolute;
+			left: 0;
+			bottom: -34px; // Button height width the padding.
+			text-align: left;
+
+			// Match sidebar spacing.
+			width: calc( var( --sidebar-width ) - 18px );
+			padding-left: 24px;
+			padding-top: 9px;
+			padding-bottom: 9px;
+		}
+
+		.sensei-course-theme__focus-mode-toggle-icon {
+			transform: rotate(180deg);
 		}
 	}
 

--- a/assets/css/sensei-course-theme/focus-mode.scss
+++ b/assets/css/sensei-course-theme/focus-mode.scss
@@ -5,14 +5,17 @@ $base: '.sensei-course-theme';
 		padding: 4px;
 		border: none;
 		background-color: var(--bg-color);
+		cursor: pointer;
 
 		.sensei-course-theme__focus-mode-toggle-icon {
 			width: 10px;
 			height: 10px;
+			transform: rotate(180deg);
 		}
 	}
 
-	body:not(.sensei-course-theme--focus-mode, .editor-styles-wrapper) {
+	// Toogle in the header and without focus mode.
+	body:not(.sensei-course-theme--focus-mode, .editor-styles-wrapper) .sensei-course-theme__header__left {
 		.sensei-course-theme__focus-mode-toggle {
 			position: absolute;
 			left: 0;
@@ -24,10 +27,6 @@ $base: '.sensei-course-theme';
 			padding-left: 24px;
 			padding-top: 9px;
 			padding-bottom: 9px;
-		}
-
-		.sensei-course-theme__focus-mode-toggle-icon {
-			transform: rotate(180deg);
 		}
 	}
 
@@ -65,9 +64,22 @@ $base: '.sensei-course-theme';
 			}
 			&__focus-mode-toggle {
 				.sensei-course-theme__focus-mode-toggle-icon {
-					transform: rotate(90deg);
+					transform: rotate(0);
 				}
 			}
+		}
+
+		// Toogle in the header.
+		.sensei-course-theme__header__left .sensei-course-theme__focus-mode-toggle {
+			.sensei-course-theme__focus-mode-toggle-icon {
+				transform: rotate(90deg);
+			}
+		}
+
+		// Toggle in the sidebar.
+		.sensei-course-theme__sidebar .sensei-course-theme__focus-mode-toggle {
+			position: absolute;
+			left: 405px;
 		}
 	}
 }

--- a/assets/css/sensei-course-theme/focus-mode.scss
+++ b/assets/css/sensei-course-theme/focus-mode.scss
@@ -19,7 +19,7 @@ $base: '.sensei-course-theme';
 		.sensei-course-theme__focus-mode-toggle {
 			position: absolute;
 			left: 0;
-			bottom: -34px; // Button height width the padding.
+			bottom: -34px; // Button height with the padding.
 			text-align: left;
 
 			// Match sidebar spacing.

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -61,7 +61,10 @@ body {
 
 		@media screen and (min-width: $breakpoint ) {
 			&--hidden {
-				visibility: hidden;
+				.sensei-course-theme__sidebar__footer,
+				.sensei-course-theme__sidebar__content .wp-block-group__inner-container > *:not(.sensei-course-theme__focus-mode-toggle) {
+					visibility: hidden;
+				}
 			}
 		}
 

--- a/assets/icons/double-chevron-right.svg
+++ b/assets/icons/double-chevron-right.svg
@@ -1,4 +1,4 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 	<path fill-rule="evenodd" clip-rule="evenodd" d="M13.1476 23.8755L24.0002 11.9377L13.1476 -0.000159764L10.9409 2.0059L19.9698 11.9377L10.9409 21.8694L13.1476 23.8755Z" fill="currentColor"/>
 	<path fill-rule="evenodd" clip-rule="evenodd" d="M3.20666 23.8755L14.0593 11.9377L3.20666 -0.000159764L0.999998 2.0059L10.0289 11.9377L1 21.8694L3.20666 23.8755Z" fill="currentColor"/>
 </svg>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It improves the way how we display the focus mode toggle button.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course with learning mode enabled.
* Test the focus mode toggle button, and make sure it works properly (as admin and as student - without the admin bar).
* Open the template editor.
* Move the toggle button to different places, like the sidebar and the content. Make sure it works properly in any place.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/151614924-2b25513f-aadb-4ee0-8ca2-1d19e641c806.mov

### Context

p1643391050250149-slack-C02KZBEJ30D