### PR TITLE
Hide custom header when editing taxonomies

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -385,7 +385,12 @@ class Sensei_Admin {
 
 		// Sensei custom navigation.
 		$screens_with_custom_navigation = [ 'edit-course', 'edit-course-category', 'edit-module', 'edit-lesson', 'edit-lesson-tag', 'edit-question', 'edit-question-category' ];
-		if ( $screen && ( in_array( $screen->id, $screens_with_custom_navigation, true ) ) ) {
+
+		if (
+			$screen
+			&& ( in_array( $screen->id, $screens_with_custom_navigation, true ) )
+			&& ( 'term' !== $screen->base )
+		) {
 			Sensei()->assets->enqueue( 'sensei-admin-custom-navigation', 'js/admin/custom-navigation.js', [], true );
 		}
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -179,10 +179,12 @@ class Sensei_Course {
 	 */
 	public function add_custom_navigation() {
 		$screen = get_current_screen();
+
 		if ( ! $screen ) {
 			return;
 		}
-		if ( in_array( $screen->id, [ 'edit-course', 'edit-course-category' ], true ) ) {
+
+		if ( in_array( $screen->id, [ 'edit-course', 'edit-course-category' ], true ) && ( 'term' !== $screen->base ) ) {
 			$this->display_courses_navigation( $screen );
 		}
 	}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -158,10 +158,12 @@ class Sensei_Lesson {
 	 */
 	public function add_custom_navigation() {
 		$screen = get_current_screen();
+
 		if ( ! $screen ) {
 			return;
 		}
-		if ( in_array( $screen->id, [ 'edit-lesson', 'edit-lesson-tag' ], true ) ) {
+
+		if ( in_array( $screen->id, [ 'edit-lesson', 'edit-lesson-tag' ], true ) && ( 'term' !== $screen->base ) ) {
 			$this->display_lessons_navigation( $screen );
 		}
 	}

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -138,11 +138,12 @@ class Sensei_Core_Modules {
 	 */
 	public function add_custom_navigation() {
 		$screen = get_current_screen();
+
 		if ( ! $screen ) {
 			return;
 		}
 
-		if ( 'edit-module' === $screen->id ) {
+		if ( ( 'edit-module' === $screen->id ) && ( 'term' !== $screen->base ) ) {
 			$this->display_modules_navigation( $screen );
 		}
 	}

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -54,10 +54,12 @@ class Sensei_Question {
 	 */
 	public function add_custom_navigation() {
 		$screen = get_current_screen();
+
 		if ( ! $screen ) {
 			return;
 		}
-		if ( in_array( $screen->id, [ 'edit-question', 'edit-question-category' ], true ) ) {
+
+		if ( in_array( $screen->id, [ 'edit-question', 'edit-question-category' ], true ) && ( 'term' !== $screen->base ) ) {
 			$this->display_question_navigation( $screen );
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request
Remove the custom header from the following pages:
- Edit Course Category
- Edit Module
- Edit Lesson Tag
- Edit Question Category

### Testing instructions
- Navigate to Course Categories.
- Edit an existing category.
- Ensure the custom header is not visible.
- Repeat the above steps for modules, lesson tags and question categories.