### PR TITLE
Fix lesson ordering

### DIFF
--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -61,7 +61,7 @@ class Sensei_Admin_Notices {
 		'course_page_sensei_grading',
 		'course_page_sensei-extensions',
 		'course_page_sensei-tools',
-		'lesson_page_lesson-order',
+		'course_page_lesson-order',
 	];
 
 	const OTHER_ALLOWED_SCREEN_IDS = [

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -254,7 +254,7 @@ class Sensei_Setup_Wizard {
 			'course_page_module-order',
 			'edit-lesson',
 			'edit-lesson-tag',
-			'lesson_page_lesson-order',
+			'course_page_lesson-order',
 			'edit-question',
 			'question',
 			'edit-question-category',

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -369,7 +369,7 @@ class Sensei_Admin {
 		Sensei()->assets->register( 'sensei-chosen-ajax', '../vendor/chosen/ajax-chosen.jquery.min.js', [ 'jquery', 'sensei-chosen' ], true );
 
 		// Load ordering script on Order Courses and Order Lessons pages.
-		if ( in_array( $screen->id, [ 'course_page_course-order', 'lesson_page_lesson-order' ], true ) ) {
+		if ( in_array( $screen->id, [ 'course_page_course-order', 'course_page_lesson-order' ], true ) ) {
 			Sensei()->assets->enqueue( 'sensei-ordering', 'js/admin/ordering.js', [ 'jquery', 'jquery-ui-sortable', 'sensei-core-select2' ], true );
 		}
 

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1426,7 +1426,7 @@ class Sensei_Admin {
 			wp_die( esc_html__( 'Insufficient permissions', 'sensei-lms' ) );
 		}
 
-		$course_id = (int) $_POST['course_id'] ?? null;
+		$course_id = isset( $_POST['course_id'] ) ? (int) $_POST['course_id'] : null;
 		$ordered   = null;
 
 		if ( isset( $_POST['lesson-order'] ) ) {

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1426,24 +1426,28 @@ class Sensei_Admin {
 			wp_die( esc_html__( 'Insufficient permissions', 'sensei-lms' ) );
 		}
 
-		$ordered = null;
+		$course_id = (int) $_POST['course_id'] ?? null;
+		$ordered   = null;
+
 		if ( isset( $_POST['lesson-order'] ) ) {
-			$ordered = $this->save_lesson_order( esc_attr( $_POST['lesson-order'] ), esc_attr( $_POST['course_id'] ) );
+			$lesson_order = sanitize_text_field( wp_unslash( $_POST['lesson-order'] ) );
+			$ordered      = $this->save_lesson_order( $lesson_order, $course_id );
 		}
 
-		wp_redirect(
+		wp_safe_redirect(
 			esc_url_raw(
 				add_query_arg(
 					array(
-						'post_type' => 'lesson',
+						'post_type' => 'course',
 						'page'      => $this->lesson_order_page_slug,
 						'ordered'   => $ordered,
-						'course_id' => $_POST['course_id'],
+						'course_id' => $course_id,
 					),
 					admin_url( 'edit.php' )
 				)
 			)
 		);
+		exit;
 	}
 
 	/**

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -1469,7 +1469,7 @@ class Sensei_Teacher {
 			'edit-course',
 			'edit-question',
 			'course_page_course-order',
-			'lesson_page_lesson-order',
+			'course_page_lesson-order',
 		);
 
 		if ( in_array( $screen->id, $limit_screens ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request
Fixes lessons not being able to be reordered.

### Testing instructions
- Go to the _Order Lessons_ page.
- Select a course.
- Reorder the lessons.
- Click _Save lesson order_. 