### PR TITLE
Add course type to analysis links

### DIFF
--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -321,8 +321,9 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 							'page'      => $this->page_slug,
 							'user_id'   => $item->user_id,
 							'course_id' => $this->course_id,
+							'post_type' => 'course',
 						),
-						admin_url( 'admin.php' )
+						admin_url( 'edit.php' )
 					);
 
 					$user_name = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . esc_html( $user_name ) . '</a></strong>';
@@ -404,8 +405,9 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 							array(
 								'page'      => $this->page_slug,
 								'lesson_id' => $item->ID,
+								'post_type' => 'course',
 							),
-							admin_url( 'admin.php' )
+							admin_url( 'edit.php' )
 						);
 						$lesson_title = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . apply_filters( 'the_title', $item->post_title, $item->ID ) . '</a></strong>';
 
@@ -473,8 +475,9 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 							array(
 								'page'      => $this->page_slug,
 								'lesson_id' => $item->ID,
+								'post_type' => 'course',
 							),
-							admin_url( 'admin.php' )
+							admin_url( 'edit.php' )
 						);
 						$lesson_title = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . apply_filters( 'the_title', $item->post_title, $item->ID ) . '</a></strong>';
 
@@ -634,9 +637,10 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$url_args     = array(
 			'page'      => $this->page_slug,
 			'course_id' => $this->course_id,
+			'post_type' => 'course',
 		);
-		$learners_url = add_query_arg( array_merge( $url_args, array( 'view' => 'user' ) ), admin_url( 'admin.php' ) );
-		$lessons_url  = add_query_arg( array_merge( $url_args, array( 'view' => 'lesson' ) ), admin_url( 'admin.php' ) );
+		$learners_url = add_query_arg( array_merge( $url_args, array( 'view' => 'user' ) ), admin_url( 'edit.php' ) );
+		$lessons_url  = add_query_arg( array_merge( $url_args, array( 'view' => 'lesson' ) ), admin_url( 'edit.php' ) );
 
 		$learners_class = $lessons_class = '';
 
@@ -686,11 +690,12 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 			'course_id'              => $this->course_id,
 			'view'                   => $this->view,
 			'sensei_report_download' => $report,
+			'post_type'              => 'course',
 		);
 		if ( $this->user_id ) {
 			$url_args['user_id'] = $this->user_id;
 		}
-		$url = add_query_arg( $url_args, admin_url( 'admin.php' ) );
+		$url = add_query_arg( $url_args, admin_url( 'edit.php' ) );
 		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download', '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
 	}
 

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -17,6 +17,12 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	public $user_ids;
 	public $view      = 'lesson';
 	public $page_slug = 'sensei_analysis';
+	/**
+	 * The post type under which is the page registered.
+	 *
+	 * @var string
+	 */
+	private $post_type = 'course';
 
 	/**
 	 * Constructor
@@ -321,7 +327,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 							'page'      => $this->page_slug,
 							'user_id'   => $item->user_id,
 							'course_id' => $this->course_id,
-							'post_type' => 'course',
+							'post_type' => $this->post_type,
 						),
 						admin_url( 'edit.php' )
 					);
@@ -405,7 +411,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 							array(
 								'page'      => $this->page_slug,
 								'lesson_id' => $item->ID,
-								'post_type' => 'course',
+								'post_type' => $this->post_type,
 							),
 							admin_url( 'edit.php' )
 						);
@@ -475,7 +481,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 							array(
 								'page'      => $this->page_slug,
 								'lesson_id' => $item->ID,
-								'post_type' => 'course',
+								'post_type' => $this->post_type,
 							),
 							admin_url( 'edit.php' )
 						);
@@ -637,7 +643,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$url_args     = array(
 			'page'      => $this->page_slug,
 			'course_id' => $this->course_id,
-			'post_type' => 'course',
+			'post_type' => $this->post_type,
 		);
 		$learners_url = add_query_arg( array_merge( $url_args, array( 'view' => 'user' ) ), admin_url( 'edit.php' ) );
 		$lessons_url  = add_query_arg( array_merge( $url_args, array( 'view' => 'lesson' ) ), admin_url( 'edit.php' ) );
@@ -690,7 +696,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 			'course_id'              => $this->course_id,
 			'view'                   => $this->view,
 			'sensei_report_download' => $report,
-			'post_type'              => 'course',
+			'post_type'              => $this->post_type,
 		);
 		if ( $this->user_id ) {
 			$url_args['user_id'] = $this->user_id;

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -15,6 +15,12 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 	public $lesson_id;
 	public $course_id;
 	public $page_slug = 'sensei_analysis';
+	/**
+	 * The post type under which is the page registered.
+	 *
+	 * @var string
+	 */
+	private $post_type = 'course';
 
 	/**
 	 * Constructor
@@ -229,7 +235,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 					'page'      => $this->page_slug,
 					'user_id'   => $item->user_id,
 					'course_id' => $this->course_id,
-					'post_type' => 'course',
+					'post_type' => $this->post_type,
 				),
 				admin_url( 'edit.php' )
 			);
@@ -358,7 +364,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 				'page'                   => $this->page_slug,
 				'lesson_id'              => $this->lesson_id,
 				'sensei_report_download' => $report,
-				'post_type'              => 'course',
+				'post_type'              => $this->post_type,
 			),
 			admin_url( 'edit.php' )
 		);

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -229,8 +229,9 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 					'page'      => $this->page_slug,
 					'user_id'   => $item->user_id,
 					'course_id' => $this->course_id,
+					'post_type' => 'course',
 				),
-				admin_url( 'admin.php' )
+				admin_url( 'edit.php' )
 			);
 
 			$user_name = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . esc_html( $user_name ) . '</a></strong>';
@@ -357,8 +358,9 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 				'page'                   => $this->page_slug,
 				'lesson_id'              => $this->lesson_id,
 				'sensei_report_download' => $report,
+				'post_type'              => 'course',
 			),
-			admin_url( 'admin.php' )
+			admin_url( 'edit.php' )
 		);
 		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download', '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
 	}

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -14,6 +14,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	public $type;
 	public $page_slug = 'sensei_analysis';
+	/**
+	 * The post type under which is the page registered.
+	 *
+	 * @var string
+	 */
+	private $post_type = 'course';
 
 	/**
 	 * Constructor
@@ -317,7 +323,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						array(
 							'page'      => $this->page_slug,
 							'course_id' => $item->ID,
-							'post_type' => 'course',
+							'post_type' => $this->post_type,
 						),
 						admin_url( 'edit.php' )
 					);
@@ -388,7 +394,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						array(
 							'page'      => $this->page_slug,
 							'lesson_id' => $item->ID,
-							'post_type' => 'course',
+							'post_type' => $this->post_type,
 						),
 						admin_url( 'edit.php' )
 					);
@@ -399,7 +405,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 							array(
 								'page'      => $this->page_slug,
 								'course_id' => $course_id,
-								'post_type' => 'course',
+								'post_type' => $this->post_type,
 							),
 							admin_url( 'edit.php' )
 						);
@@ -469,7 +475,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						array(
 							'page'      => $this->page_slug,
 							'user_id'   => $item->ID,
-							'post_type' => 'course',
+							'post_type' => $this->post_type,
 						),
 						admin_url( 'edit.php' )
 					);
@@ -509,7 +515,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 */
 	private function get_courses( $args ) {
 		$course_args = array(
-			'post_type'        => 'course',
+			'post_type'        => $this->post_type,
 			'post_status'      => array( 'publish', 'private' ),
 			'posts_per_page'   => $args['number'],
 			'offset'           => $args['offset'],
@@ -669,7 +675,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		$query_args     = array(
 			'page'      => $this->page_slug,
-			'post_type' => 'course',
+			'post_type' => $this->post_type,
 		);
 		$learners_class = $courses_class = $lessons_class = '';
 		switch ( $this->type ) {
@@ -731,7 +737,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				'page'                   => $this->page_slug,
 				'view'                   => $this->type,
 				'sensei_report_download' => $report,
-				'post_type'              => 'course',
+				'post_type'              => $this->post_type,
 			),
 			admin_url( 'edit.php' )
 		);

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -317,8 +317,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						array(
 							'page'      => $this->page_slug,
 							'course_id' => $item->ID,
+							'post_type' => 'course',
 						),
-						admin_url( 'admin.php' )
+						admin_url( 'edit.php' )
 					);
 
 					$course_title            = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . apply_filters( 'the_title', $item->post_title, $item->ID ) . '</a></strong>';
@@ -387,8 +388,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						array(
 							'page'      => $this->page_slug,
 							'lesson_id' => $item->ID,
+							'post_type' => 'course',
 						),
-						admin_url( 'admin.php' )
+						admin_url( 'edit.php' )
 					);
 					$lesson_title = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . apply_filters( 'the_title', $item->post_title, $item->ID ) . '</a></strong>';
 
@@ -397,8 +399,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 							array(
 								'page'      => $this->page_slug,
 								'course_id' => $course_id,
+								'post_type' => 'course',
 							),
-							admin_url( 'admin.php' )
+							admin_url( 'edit.php' )
 						);
 						$course_title = '<a href="' . esc_url( $url ) . '">' . esc_html( $course_title ) . '</a>';
 					} else {
@@ -464,10 +467,11 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				} else {
 					$url                 = add_query_arg(
 						array(
-							'page'    => $this->page_slug,
-							'user_id' => $item->ID,
+							'page'      => $this->page_slug,
+							'user_id'   => $item->ID,
+							'post_type' => 'course',
 						),
-						admin_url( 'admin.php' )
+						admin_url( 'edit.php' )
 					);
 					$user_name           = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . esc_html( $item->display_name ) . '</a></strong>';
 					$user_average_grade .= '%';
@@ -727,8 +731,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				'page'                   => $this->page_slug,
 				'view'                   => $this->type,
 				'sensei_report_download' => $report,
+				'post_type'              => 'course',
 			),
-			admin_url( 'admin.php' )
+			admin_url( 'edit.php' )
 		);
 		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download', '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
 	}

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -664,7 +664,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$menu = array();
 
 		$query_args     = array(
-			'page' => $this->page_slug,
+			'page'      => $this->page_slug,
 			'post_type' => 'course',
 		);
 		$learners_class = $courses_class = $lessons_class = '';

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -665,6 +665,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		$query_args     = array(
 			'page' => $this->page_slug,
+			'post_type' => 'course',
 		);
 		$learners_class = $courses_class = $lessons_class = '';
 		switch ( $this->type ) {
@@ -685,9 +686,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$lesson_args['view']  = 'lessons';
 		$courses_args['view'] = 'courses';
 
-		$menu['learners'] = '<a class="' . esc_attr( $learners_class ) . '" href="' . esc_url( add_query_arg( $learner_args, admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'Students', 'sensei-lms' ) . '</a>';
-		$menu['courses']  = '<a class="' . esc_attr( $courses_class ) . '" href="' . esc_url( add_query_arg( $courses_args, admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'Courses', 'sensei-lms' ) . '</a>';
-		$menu['lessons']  = '<a class="' . esc_attr( $lessons_class ) . '" href="' . esc_url( add_query_arg( $lesson_args, admin_url( 'admin.php' ) ) ) . '">' . esc_html__( 'Lessons', 'sensei-lms' ) . '</a>';
+		$menu['learners'] = '<a class="' . esc_attr( $learners_class ) . '" href="' . esc_url( add_query_arg( $learner_args, admin_url( 'edit.php' ) ) ) . '">' . esc_html__( 'Students', 'sensei-lms' ) . '</a>';
+		$menu['courses']  = '<a class="' . esc_attr( $courses_class ) . '" href="' . esc_url( add_query_arg( $courses_args, admin_url( 'edit.php' ) ) ) . '">' . esc_html__( 'Courses', 'sensei-lms' ) . '</a>';
+		$menu['lessons']  = '<a class="' . esc_attr( $lessons_class ) . '" href="' . esc_url( add_query_arg( $lesson_args, admin_url( 'edit.php' ) ) ) . '">' . esc_html__( 'Lessons', 'sensei-lms' ) . '</a>';
 
 		$menu = apply_filters( 'sensei_analysis_overview_sub_menu', $menu );
 		if ( ! empty( $menu ) ) {

--- a/includes/class-sensei-analysis-user-profile-list-table.php
+++ b/includes/class-sensei-analysis-user-profile-list-table.php
@@ -222,8 +222,9 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 					'page'      => $this->page_slug,
 					'user_id'   => $this->user_id,
 					'course_id' => $item->comment_post_ID,
+					'post_type' => 'course',
 				),
-				admin_url( 'admin.php' )
+				admin_url( 'edit.php' )
 			);
 
 			$course_title = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . esc_html( $course_title ) . '</a></strong>';
@@ -341,8 +342,9 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 				'page'                   => $this->page_slug,
 				'user_id'                => $this->user_id,
 				'sensei_report_download' => $report,
+				'post_type'              => 'course',
 			),
-			admin_url( 'admin.php' )
+			admin_url( 'edit.php' )
 		);
 		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download', '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
 	}

--- a/includes/class-sensei-analysis-user-profile-list-table.php
+++ b/includes/class-sensei-analysis-user-profile-list-table.php
@@ -14,6 +14,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 	public $user_id;
 	public $page_slug = 'sensei_analysis';
+	/**
+	 * The post type under which is the page registered.
+	 *
+	 * @var string
+	 */
+	private $post_type = 'course';
 
 	/**
 	 * Constructor
@@ -222,7 +228,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 					'page'      => $this->page_slug,
 					'user_id'   => $this->user_id,
 					'course_id' => $item->comment_post_ID,
-					'post_type' => 'course',
+					'post_type' => $this->post_type,
 				),
 				admin_url( 'edit.php' )
 			);
@@ -342,7 +348,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 				'page'                   => $this->page_slug,
 				'user_id'                => $this->user_id,
 				'sensei_report_download' => $report,
-				'post_type'              => 'course',
+				'post_type'              => $this->post_type,
 			),
 			admin_url( 'edit.php' )
 		);

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -446,7 +446,7 @@ class Sensei_Analysis {
 	 */
 	public function analysis_user_profile_nav() {
 
-		$title = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( array( 'page' => $this->page_slug ), admin_url( 'admin.php' ) ) ), esc_html( $this->name ) );
+		$title = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( array( 'page' => $this->page_slug, 'post_type' => 'course' ), admin_url( 'edit.php' ) ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['user_id'] ) && 0 < intval( $_GET['user_id'] ) ) {
 
 			$user_id   = intval( $_GET['user_id'] );
@@ -455,8 +455,9 @@ class Sensei_Analysis {
 					array(
 						'page' => $this->page_slug,
 						'user' => $user_id,
+						'post_type' => 'course',
 					),
-					admin_url( 'admin.php' )
+					admin_url( 'edit.php' )
 				)
 			);
 			$user_name = Sensei_Learner::get_full_name( $user_id );
@@ -476,7 +477,7 @@ class Sensei_Analysis {
 	 */
 	public function analysis_user_course_nav() {
 
-		$title = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( array( 'page' => $this->page_slug ), admin_url( 'admin.php' ) ) ), esc_html( $this->name ) );
+		$title = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( array( 'page' => $this->page_slug, 'post_type' => 'course' ), admin_url( 'edit.php' ) ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['user_id'] ) && 0 < intval( $_GET['user_id'] ) ) {
 			$user_id   = intval( $_GET['user_id'] );
 			$user_data = get_userdata( $user_id );
@@ -484,8 +485,9 @@ class Sensei_Analysis {
 				array(
 					'page'    => $this->page_slug,
 					'user_id' => $user_id,
+					'post_type' => 'course',
 				),
-				admin_url( 'admin.php' )
+				admin_url( 'edit.php' )
 			);
 			$user_name = Sensei_Learner::get_full_name( $user_id );
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', $url, $user_name );
@@ -497,8 +499,9 @@ class Sensei_Analysis {
 				array(
 					'page'      => $this->page_slug,
 					'course_id' => $course_id,
+					'post_type' => 'course',
 				),
-				admin_url( 'admin.php' )
+				admin_url( 'edit.php' )
 			);
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
@@ -515,15 +518,16 @@ class Sensei_Analysis {
 	 */
 	public function analysis_course_nav() {
 
-		$title = sprintf( '<a href="%s">%s</a>', add_query_arg( array( 'page' => $this->page_slug ), admin_url( 'admin.php' ) ), esc_html( $this->name ) );
+		$title = sprintf( '<a href="%s">%s</a>', add_query_arg( array( 'page' => $this->page_slug, 'post_type' => 'course' ), admin_url( 'edit.php' ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['course_id'] ) ) {
 			$course_id = intval( $_GET['course_id'] );
 			$url       = add_query_arg(
 				array(
 					'page'      => $this->page_slug,
 					'course_id' => $course_id,
+					'post_type' => 'course',
 				),
-				admin_url( 'admin.php' )
+				admin_url( 'edit.php' )
 			);
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
@@ -540,15 +544,16 @@ class Sensei_Analysis {
 	 */
 	public function analysis_course_users_nav() {
 
-		$title = sprintf( '<a href="%s">%s</a>', add_query_arg( array( 'page' => $this->page_slug ), admin_url( 'admin.php' ) ), esc_html( $this->name ) );
+		$title = sprintf( '<a href="%s">%s</a>', add_query_arg( array( 'page' => $this->page_slug, 'post_type' => 'course' ), admin_url( 'edit.php' ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['course_id'] ) ) {
 			$course_id = intval( $_GET['course_id'] );
 			$url       = add_query_arg(
 				array(
 					'page'      => $this->page_slug,
 					'course_id' => $course_id,
+					'post_type' => 'course'
 				),
-				admin_url( 'admin.php' )
+				admin_url( 'edit.php' )
 			);
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
@@ -565,7 +570,7 @@ class Sensei_Analysis {
 	 */
 	public function analysis_lesson_users_nav() {
 
-		$title = sprintf( '<a href="%s">%s</a>', add_query_arg( array( 'page' => $this->page_slug ), admin_url( 'admin.php' ) ), esc_html( $this->name ) );
+		$title = sprintf( '<a href="%s">%s</a>', add_query_arg( array( 'page' => $this->page_slug, 'post_type' => 'course' ), admin_url( 'edit.php' ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['lesson_id'] ) ) {
 			$lesson_id = intval( $_GET['lesson_id'] );
 			$course_id = intval( get_post_meta( $lesson_id, '_lesson_course', true ) );
@@ -573,16 +578,18 @@ class Sensei_Analysis {
 				array(
 					'page'      => $this->page_slug,
 					'course_id' => $course_id,
+					'post_type' => 'course',
 				),
-				admin_url( 'admin.php' )
+				admin_url( 'edit.php' )
 			);
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 			$url       = add_query_arg(
 				array(
 					'page'      => $this->page_slug,
 					'lesson_id' => $lesson_id,
+					'post_type' => 'course',
 				),
-				admin_url( 'admin.php' )
+				admin_url( 'edit.php' )
 			);
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="lesson-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $lesson_id ) );
 		}

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -446,15 +446,18 @@ class Sensei_Analysis {
 	 */
 	public function analysis_user_profile_nav() {
 
-		$title = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( array( 'page' => $this->page_slug, 'post_type' => 'course' ), admin_url( 'edit.php' ) ) ), esc_html( $this->name ) );
+		$analysis_args = array(
+			'page'      => $this->page_slug,
+			'post_type' => 'course',
+		);
+		$title         = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( $analysis_args, admin_url( 'edit.php' ) ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['user_id'] ) && 0 < intval( $_GET['user_id'] ) ) {
-
 			$user_id   = intval( $_GET['user_id'] );
 			$url       = esc_url(
 				add_query_arg(
 					array(
-						'page' => $this->page_slug,
-						'user' => $user_id,
+						'page'      => $this->page_slug,
+						'user'      => $user_id,
 						'post_type' => 'course',
 					),
 					admin_url( 'edit.php' )
@@ -477,14 +480,18 @@ class Sensei_Analysis {
 	 */
 	public function analysis_user_course_nav() {
 
-		$title = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( array( 'page' => $this->page_slug, 'post_type' => 'course' ), admin_url( 'edit.php' ) ) ), esc_html( $this->name ) );
+		$analysis_args = array(
+			'page'      => $this->page_slug,
+			'post_type' => 'course',
+		);
+		$title         = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( $analysis_args, admin_url( 'edit.php' ) ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['user_id'] ) && 0 < intval( $_GET['user_id'] ) ) {
 			$user_id   = intval( $_GET['user_id'] );
 			$user_data = get_userdata( $user_id );
 			$url       = add_query_arg(
 				array(
-					'page'    => $this->page_slug,
-					'user_id' => $user_id,
+					'page'      => $this->page_slug,
+					'user_id'   => $user_id,
 					'post_type' => 'course',
 				),
 				admin_url( 'edit.php' )
@@ -518,7 +525,11 @@ class Sensei_Analysis {
 	 */
 	public function analysis_course_nav() {
 
-		$title = sprintf( '<a href="%s">%s</a>', add_query_arg( array( 'page' => $this->page_slug, 'post_type' => 'course' ), admin_url( 'edit.php' ) ), esc_html( $this->name ) );
+		$analysis_args = array(
+			'page'      => $this->page_slug,
+			'post_type' => 'course',
+		);
+		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'edit.php' ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['course_id'] ) ) {
 			$course_id = intval( $_GET['course_id'] );
 			$url       = add_query_arg(
@@ -544,14 +555,18 @@ class Sensei_Analysis {
 	 */
 	public function analysis_course_users_nav() {
 
-		$title = sprintf( '<a href="%s">%s</a>', add_query_arg( array( 'page' => $this->page_slug, 'post_type' => 'course' ), admin_url( 'edit.php' ) ), esc_html( $this->name ) );
+		$analysis_args = array(
+			'page'      => $this->page_slug,
+			'post_type' => 'course',
+		);
+		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'edit.php' ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['course_id'] ) ) {
 			$course_id = intval( $_GET['course_id'] );
 			$url       = add_query_arg(
 				array(
 					'page'      => $this->page_slug,
 					'course_id' => $course_id,
-					'post_type' => 'course'
+					'post_type' => 'course',
 				),
 				admin_url( 'edit.php' )
 			);
@@ -570,7 +585,11 @@ class Sensei_Analysis {
 	 */
 	public function analysis_lesson_users_nav() {
 
-		$title = sprintf( '<a href="%s">%s</a>', add_query_arg( array( 'page' => $this->page_slug, 'post_type' => 'course' ), admin_url( 'edit.php' ) ), esc_html( $this->name ) );
+		$analysis_args = array(
+			'page'      => $this->page_slug,
+			'post_type' => 'course',
+		);
+		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'edit.php' ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['lesson_id'] ) ) {
 			$lesson_id = intval( $_GET['lesson_id'] );
 			$course_id = intval( get_post_meta( $lesson_id, '_lesson_course', true ) );

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -15,6 +15,12 @@ class Sensei_Analysis {
 	public $name;
 	public $file;
 	public $page_slug;
+	/**
+	 * The post type under which is the page registered.
+	 *
+	 * @var string
+	 */
+	private $post_type;
 
 	/**
 	 * Constructor
@@ -26,6 +32,7 @@ class Sensei_Analysis {
 		$this->name      = __( 'Analysis', 'sensei-lms' );
 		$this->file      = $file;
 		$this->page_slug = 'sensei_analysis';
+		$this->post_type = 'course';
 
 		// Admin functions
 		if ( is_admin() ) {
@@ -448,7 +455,7 @@ class Sensei_Analysis {
 
 		$analysis_args = array(
 			'page'      => $this->page_slug,
-			'post_type' => 'course',
+			'post_type' => $this->post_type,
 		);
 		$title         = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( $analysis_args, admin_url( 'edit.php' ) ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['user_id'] ) && 0 < intval( $_GET['user_id'] ) ) {
@@ -458,7 +465,7 @@ class Sensei_Analysis {
 					array(
 						'page'      => $this->page_slug,
 						'user'      => $user_id,
-						'post_type' => 'course',
+						'post_type' => $this->post_type,
 					),
 					admin_url( 'edit.php' )
 				)
@@ -482,7 +489,7 @@ class Sensei_Analysis {
 
 		$analysis_args = array(
 			'page'      => $this->page_slug,
-			'post_type' => 'course',
+			'post_type' => $this->post_type,
 		);
 		$title         = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( $analysis_args, admin_url( 'edit.php' ) ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['user_id'] ) && 0 < intval( $_GET['user_id'] ) ) {
@@ -492,7 +499,7 @@ class Sensei_Analysis {
 				array(
 					'page'      => $this->page_slug,
 					'user_id'   => $user_id,
-					'post_type' => 'course',
+					'post_type' => $this->post_type,
 				),
 				admin_url( 'edit.php' )
 			);
@@ -506,7 +513,7 @@ class Sensei_Analysis {
 				array(
 					'page'      => $this->page_slug,
 					'course_id' => $course_id,
-					'post_type' => 'course',
+					'post_type' => $this->post_type,
 				),
 				admin_url( 'edit.php' )
 			);
@@ -527,7 +534,7 @@ class Sensei_Analysis {
 
 		$analysis_args = array(
 			'page'      => $this->page_slug,
-			'post_type' => 'course',
+			'post_type' => $this->post_type,
 		);
 		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'edit.php' ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['course_id'] ) ) {
@@ -536,7 +543,7 @@ class Sensei_Analysis {
 				array(
 					'page'      => $this->page_slug,
 					'course_id' => $course_id,
-					'post_type' => 'course',
+					'post_type' => $this->post_type,
 				),
 				admin_url( 'edit.php' )
 			);
@@ -557,7 +564,7 @@ class Sensei_Analysis {
 
 		$analysis_args = array(
 			'page'      => $this->page_slug,
-			'post_type' => 'course',
+			'post_type' => $this->post_type,
 		);
 		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'edit.php' ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['course_id'] ) ) {
@@ -566,7 +573,7 @@ class Sensei_Analysis {
 				array(
 					'page'      => $this->page_slug,
 					'course_id' => $course_id,
-					'post_type' => 'course',
+					'post_type' => $this->post_type,
 				),
 				admin_url( 'edit.php' )
 			);
@@ -587,7 +594,7 @@ class Sensei_Analysis {
 
 		$analysis_args = array(
 			'page'      => $this->page_slug,
-			'post_type' => 'course',
+			'post_type' => $this->post_type,
 		);
 		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'edit.php' ) ), esc_html( $this->name ) );
 		if ( isset( $_GET['lesson_id'] ) ) {
@@ -597,7 +604,7 @@ class Sensei_Analysis {
 				array(
 					'page'      => $this->page_slug,
 					'course_id' => $course_id,
-					'post_type' => 'course',
+					'post_type' => $this->post_type,
 				),
 				admin_url( 'edit.php' )
 			);
@@ -606,7 +613,7 @@ class Sensei_Analysis {
 				array(
 					'page'      => $this->page_slug,
 					'lesson_id' => $lesson_id,
-					'post_type' => 'course',
+					'post_type' => $this->post_type,
 				),
 				admin_url( 'edit.php' )
 			);


### PR DESCRIPTION
## Changes proposed in this Pull Request

* Add `post_type=course` to analysis page links.
* Change the base for the link from `admin.php` to `edit.php`. After adding the post type links stopped working at all until I changed the base. At the same time, the overview page had this base since the beginning.

### Testing instructions

* Open `Sensei LMS -> Analysis` page from the main menu.
* Change the current tab (Courses/Lessons/Students) above the table.
* Make sure "Analysis" is selected in the menu.

### Screenshot / Video

https://user-images.githubusercontent.com/329356/151789692-46edff4a-3f63-4144-8f55-738c57cca58d.mp4


