### PR TITLE
Improve admin notice button alignment

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -51,6 +51,7 @@ $sensei-notice-icon-width: 30px;
 
 	&__actions {
 		margin: 0.5em 0 0.5em auto;
+		align-self: center;
 
 		.button {
 			padding: 3px 12px;
@@ -58,7 +59,7 @@ $sensei-notice-icon-width: 30px;
 	}
 
 	.notice-dismiss {
-		margin: 0.5em 0 0 auto;
+		align-self: center;
 		padding: 0;
 		position: static;
 	}


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Align buttons and dismiss icon to the center in Sensei-branded admin notices

### Testing instructions

* Open a fresh site that has Learner Mode notice
* View a Sensei pages like Courses on WP-Admin

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

### Before
<img width="1116" alt="image" src="https://user-images.githubusercontent.com/176949/151803461-d304a002-cbd4-4eea-903b-866210b4847d.png">

### After
<img width="1113" alt="image" src="https://user-images.githubusercontent.com/176949/151803362-02b54b18-7b7a-4213-82cf-1fad9af3f8bd.png">

