### PR TITLE
Fix menu highlighting for Grading pages

### DIFF
--- a/includes/class-sensei-grading-main.php
+++ b/includes/class-sensei-grading-main.php
@@ -260,11 +260,12 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		$quiz_id   = Sensei()->lesson->lesson_quizzes( $item->comment_post_ID, 'any' );
 		$quiz_link = add_query_arg(
 			array(
-				'page'    => $this->page_slug,
-				'user'    => $item->user_id,
-				'quiz_id' => $quiz_id,
+				'post_type' => 'course',
+				'page'      => $this->page_slug,
+				'user'      => $item->user_id,
+				'quiz_id'   => $quiz_id,
 			),
-			admin_url( 'admin.php' )
+			admin_url( 'edit.php' )
 		);
 
 		$grade_link = '';
@@ -287,10 +288,11 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 			$course_title = '<a href="' . esc_url(
 				add_query_arg(
 					array(
+						'post_type' => 'course',
 						'page'      => $this->page_slug,
 						'course_id' => $course_id,
 					),
-					admin_url( 'admin.php' )
+					admin_url( 'edit.php' )
 				)
 			) . '">' . esc_html( get_the_title( $course_id ) ) . '</a>';
 		}
@@ -298,10 +300,11 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		$lesson_title = '<a href="' . esc_url(
 			add_query_arg(
 				array(
+					'post_type' => 'course',
 					'page'      => $this->page_slug,
 					'lesson_id' => $item->comment_post_ID,
 				),
-				admin_url( 'admin.php' )
+				admin_url( 'edit.php' )
 			)
 		) . '">' . esc_html( get_the_title( $item->comment_post_ID ) ) . '</a>';
 
@@ -311,10 +314,11 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 				'title'       => '<strong><a class="row-title" href="' . esc_url(
 					add_query_arg(
 						array(
-							'page'    => $this->page_slug,
-							'user_id' => $item->user_id,
+							'post_type' => 'course',
+							'page'      => $this->page_slug,
+							'user_id'   => $item->user_id,
 						),
-						admin_url( 'admin.php' )
+						admin_url( 'edit.php' )
 					)
 				) . '">' . esc_html( $title ) . '</a></strong>',
 				'course'      => $course_title,
@@ -417,7 +421,8 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 			'type' => 'lesson',
 		);
 		$query_args = array(
-			'page' => $this->page_slug,
+			'post_type' => 'course',
+			'page'      => $this->page_slug,
 		);
 		if ( $this->course_id ) {
 			$query_args['course_id'] = $this->course_id;
@@ -474,10 +479,34 @@ class Sensei_Grading_Main extends Sensei_List_Table {
 		$inprogress_args['view'] = 'in-progress';
 
 		$format              = '<a class="%s" href="%s">%s <span class="count">(%s)</span></a>';
-		$menu['all']         = sprintf( $format, $all_class, esc_url( add_query_arg( $all_args, admin_url( 'admin.php' ) ) ), __( 'All', 'sensei-lms' ), number_format( (int) $all_lessons_count ) );
-		$menu['ungraded']    = sprintf( $format, $ungraded_class, esc_url( add_query_arg( $ungraded_args, admin_url( 'admin.php' ) ) ), __( 'Ungraded', 'sensei-lms' ), number_format( (int) $ungraded_lessons_count ) );
-		$menu['graded']      = sprintf( $format, $graded_class, esc_url( add_query_arg( $graded_args, admin_url( 'admin.php' ) ) ), __( 'Graded', 'sensei-lms' ), number_format( (int) $graded_lessons_count ) );
-		$menu['in-progress'] = sprintf( $format, $inprogress_class, esc_url( add_query_arg( $inprogress_args, admin_url( 'admin.php' ) ) ), __( 'In Progress', 'sensei-lms' ), number_format( (int) $inprogress_lessons_count ) );
+		$menu['all']         = sprintf(
+			$format,
+			$all_class,
+			esc_url( add_query_arg( $all_args, admin_url( 'edit.php' ) ) ),
+			__( 'All', 'sensei-lms' ),
+			number_format( (int) $all_lessons_count )
+		);
+		$menu['ungraded']    = sprintf(
+			$format,
+			$ungraded_class,
+			esc_url( add_query_arg( $ungraded_args, admin_url( 'edit.php' ) ) ),
+			__( 'Ungraded', 'sensei-lms' ),
+			number_format( (int) $ungraded_lessons_count )
+		);
+		$menu['graded']      = sprintf(
+			$format,
+			$graded_class,
+			esc_url( add_query_arg( $graded_args, admin_url( 'edit.php' ) ) ),
+			__( 'Graded', 'sensei-lms' ),
+			number_format( (int) $graded_lessons_count )
+		);
+		$menu['in-progress'] = sprintf(
+			$format,
+			$inprogress_class,
+			esc_url( add_query_arg( $inprogress_args, admin_url( 'edit.php' ) ) ),
+			__( 'In Progress', 'sensei-lms' ),
+			number_format( (int) $inprogress_lessons_count )
+		);
 
 		$menu = apply_filters( 'sensei_grading_sub_menu', $menu );
 		if ( ! empty( $menu ) ) {

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -353,19 +353,21 @@ class Sensei_Grading {
 			$course_id = get_post_meta( $lesson_id, '_lesson_course', true );
 			$url       = add_query_arg(
 				array(
+					'post_type' => 'course',
 					'page'      => $this->page_slug,
 					'course_id' => $course_id,
 				),
-				admin_url( 'admin.php' )
+				admin_url( 'edit.php' )
 			);
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), esc_html( get_the_title( $course_id ) ) );
 
 			$url    = add_query_arg(
 				array(
+					'post_type' => 'course',
 					'page'      => $this->page_slug,
 					'lesson_id' => $lesson_id,
 				),
-				admin_url( 'admin.php' )
+				admin_url( 'edit.php' )
 			);
 			$title .= sprintf( '&nbsp;&nbsp;<span class="lesson-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), esc_html( get_the_title( $lesson_id ) ) );
 		}
@@ -778,12 +780,13 @@ class Sensei_Grading {
 					'sensei_ajax_redirect_url',
 					add_query_arg(
 						array(
+							'post_type' => 'course',
 							'page'      => $this->page_slug,
 							'lesson_id' => $lesson_id,
 							'course_id' => $course_id,
 							'view'      => $grading_view,
 						),
-						admin_url( 'admin.php' )
+						admin_url( 'edit.php' )
 					)
 				)
 			);
@@ -814,12 +817,13 @@ class Sensei_Grading {
 					'sensei_ajax_redirect_url',
 					add_query_arg(
 						array(
+							'post_type' => 'course',
 							'page'      => $this->page_slug,
 							'lesson_id' => $lesson_id,
 							'course_id' => $course_id,
 							'view'      => $grading_view,
 						),
-						admin_url( 'admin.php' )
+						admin_url( 'edit.php' )
 					)
 				)
 			);


### PR DESCRIPTION
### Changes proposed in this Pull Request
Ensure the _Grading_ menu stays highlighted while filtering and drilling down.

### Testing instructions
Ensure the _Grading_ menu stays highlighted for each of the following actions:
- Clicking the _All_, _Ungraded_, _Graded_ and _In Progress_ filters.
- Selecting a course and lesson from the drop-downs.
- Clicking the _Reset filter_ button.
- Searching by user.
- Clicking on a student, course or lesson in the table.
- Clicking the _Grade quiz_ or _Review grade_ button.