### PR TITLE
Fix menu highlighting for Student Management pages

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -30,24 +30,35 @@ class Sensei_Learner_Management {
 	 * @var string $name
 	 */
 	public $name;
+
 	/**
 	 * Main plugin file name.
 	 *
 	 * @var string $file
 	 */
 	public $file;
+
 	/**
 	 * Menu slug name.
 	 *
 	 * @var string $page_slug
 	 */
 	public $page_slug;
+
+	/**
+	 * Post type that the Student Management menu is associated with.
+	 *
+	 * @var string $menu_post_type
+	 */
+	public $menu_post_type;
+
 	/**
 	 * Reference to the class responsible for Bulk Learner Actions.
 	 *
 	 * @var Sensei_Learners_Admin_Bulk_Actions_Controller $bulk_actions_controller
 	 */
 	public $bulk_actions_controller;
+
 	/**
 	 * Per page screen option ID.
 	 *
@@ -63,9 +74,10 @@ class Sensei_Learner_Management {
 	 * @param string $file Main plugin file name.
 	 */
 	public function __construct( $file ) {
-		$this->name      = __( 'Student Management', 'sensei-lms' );
-		$this->file      = $file;
-		$this->page_slug = 'sensei_learners';
+		$this->name           = __( 'Student Management', 'sensei-lms' );
+		$this->file           = $file;
+		$this->page_slug      = 'sensei_learners';
+		$this->menu_post_type = 'course';
 
 		// Admin functions.
 		if ( is_admin() ) {
@@ -330,11 +342,12 @@ class Sensei_Learner_Management {
 			$course_id = intval( $_GET['course_id'] );
 			$url       = add_query_arg(
 				array(
+					'post_type' => $this->menu_post_type,
 					'page'      => $this->page_slug,
 					'course_id' => $course_id,
 					'view'      => 'learners',
 				),
-				admin_url( 'admin.php' )
+				admin_url( 'edit.php' )
 			);
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 		}
@@ -379,10 +392,11 @@ class Sensei_Learner_Management {
 			'sensei_ajax_redirect_url',
 			add_query_arg(
 				array(
+					'post_type' => $this->menu_post_type,
 					'page'       => $this->page_slug,
 					'course_cat' => $course_cat,
 				),
-				admin_url( 'admin.php' )
+				admin_url( 'edit.php' )
 			)
 		);
 
@@ -755,8 +769,9 @@ class Sensei_Learner_Management {
 
 		// Set redirect URL after adding user to course/lesson.
 		$query_args = array(
-			'page' => $this->page_slug,
-			'view' => 'learners',
+			'post_type' => $this->menu_post_type,
+			'page'      => $this->page_slug,
+			'view'      => 'learners',
 		);
 
 		if ( $course_id ) {
@@ -777,7 +792,7 @@ class Sensei_Learner_Management {
 			$query_args['message'] .= '_multiple';
 		}
 
-		$redirect_url = apply_filters( 'sensei_learners_add_learner_redirect_url', add_query_arg( $query_args, admin_url( 'admin.php' ) ) );
+		$redirect_url = apply_filters( 'sensei_learners_add_learner_redirect_url', add_query_arg( $query_args, admin_url( 'edit.php' ) ) );
 
 		wp_safe_redirect( esc_url_raw( $redirect_url ) );
 		exit;
@@ -859,7 +874,13 @@ class Sensei_Learner_Management {
 	 * @return string URL query string.
 	 */
 	public function get_url() {
-		return add_query_arg( array( 'page' => $this->page_slug ), admin_url( 'admin.php' ) );
+		return add_query_arg(
+			array(
+				'post_type' => $this->menu_post_type,
+				'page'      => $this->page_slug
+			),
+			admin_url( 'edit.php' )
+		);
 	}
 
 	/**

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -392,7 +392,7 @@ class Sensei_Learner_Management {
 			'sensei_ajax_redirect_url',
 			add_query_arg(
 				array(
-					'post_type' => $this->menu_post_type,
+					'post_type'  => $this->menu_post_type,
 					'page'       => $this->page_slug,
 					'course_cat' => $course_cat,
 				),

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -877,7 +877,7 @@ class Sensei_Learner_Management {
 		return add_query_arg(
 			array(
 				'post_type' => $this->menu_post_type,
-				'page'      => $this->page_slug
+				'page'      => $this->page_slug,
 			),
 			admin_url( 'edit.php' )
 		);

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -37,6 +37,13 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	private $page_slug;
 
 	/**
+	 * Post type that the Student Management menu is associated with.
+	 *
+	 * @var string $menu_post_type
+	 */
+	private $menu_post_type;
+
+	/**
 	 * The page view.
 	 *
 	 * @var string
@@ -111,6 +118,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	public function __construct( $management ) {
 		$this->name               = __( 'Bulk Student Actions', 'sensei-lms' );
 		$this->page_slug          = $management->page_slug;
+		$this->menu_post_type     = 'course';
 		$this->view               = 'sensei_learner_admin';
 		$this->learner_management = $management;
 
@@ -137,11 +145,12 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	public function redirect_to_learner_admin_index( $result ) {
 		$url = add_query_arg(
 			array(
-				'page'    => $this->get_page_slug(),
-				'view'    => $this->get_view(),
-				'message' => $result,
+				'post_type' => $this->menu_post_type,
+				'page'      => $this->get_page_slug(),
+				'view'      => $this->get_view(),
+				'message'   => $result,
 			),
-			admin_url( 'admin.php' )
+			admin_url( 'edit.php' )
 		);
 		wp_safe_redirect( $url );
 		exit;
@@ -155,10 +164,11 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	public function get_url() {
 		return add_query_arg(
 			[
-				'page' => $this->get_page_slug(),
-				'view' => $this->get_view(),
+				'post_type' => $this->menu_post_type,
+				'page'      => $this->get_page_slug(),
+				'view'      => $this->get_view(),
 			],
-			admin_url( 'admin.php' )
+			admin_url( 'edit.php' )
 		);
 	}
 
@@ -171,11 +181,12 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	public function get_learner_management_course_url( $course_id ) {
 		return add_query_arg(
 			[
+				'post_type' => $this->menu_post_type,
 				'page'      => 'sensei_learners',
 				'course_id' => absint( $course_id ),
 				'view'      => 'learners',
 			],
-			admin_url( 'admin.php' )
+			admin_url( 'edit.php' )
 		);
 	}
 

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -22,6 +22,13 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	private $page_slug;
 
 	/**
+	 * Post type that the Student Management menu is associated with.
+	 *
+	 * @var string $menu_post_type
+	 */
+	private $menu_post_type;
+
+	/**
 	 * The page name.
 	 *
 	 * @var string
@@ -59,6 +66,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		$this->controller         = $controller;
 		$this->name               = $controller->get_name();
 		$this->page_slug          = $controller->get_page_slug();
+		$this->menu_post_type     = 'course';
 		$this->query_args         = $this->parse_query_args();
 		$this->learner_management = $learner_management;
 		$this->page_slug          = 'sensei_learner_admin';
@@ -501,9 +509,10 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 			$filter_type_input = sanitize_text_field( wp_unslash( $_GET['filter_type'] ) );
 			$filter_type       = in_array( $filter_type_input, array( 'inc', 'exc' ), true ) ? $filter_type_input : 'inc';
 		}
-		$page = $this->page_slug;
-		$view = $this->controller->get_view();
-		$args = compact( 'page', 'view', 'per_page', 'offset', 'orderby', 'order', 'search', 'filter_by_course_id', 'filter_type' );
+		$page      = $this->page_slug;
+		$post_type = $this->menu_post_type;
+		$view      = $this->controller->get_view();
+		$args      = compact( 'page', 'post_type', 'view', 'per_page', 'offset', 'orderby', 'order', 'search', 'filter_by_course_id', 'filter_type' );
 
 		return $args;
 	}

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -50,6 +50,13 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	private $page_slug;
 
 	/**
+	 * Post type that the Student Management menu is associated with.
+	 *
+	 * @var string $menu_post_type
+	 */
+	private $menu_post_type;
+
+	/**
 	 * The enrollment status of the learners.
 	 *
 	 * @var string
@@ -123,7 +130,8 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			$this->view = 'learners';
 		}
 
-		$this->page_slug = 'sensei_learners';
+		$this->page_slug      = 'sensei_learners';
+		$this->menu_post_type = 'course';
 
 		// Load Parent token into constructor.
 		parent::__construct( 'learners_main' );
@@ -474,6 +482,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 						$withdraw_action_url = wp_nonce_url(
 							add_query_arg(
 								array(
+									'post_type'        => $this->menu_post_type,
 									'page'             => 'sensei_learners',
 									'view'             => 'learners',
 									'learner_action'   => 'withdraw',
@@ -481,7 +490,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 									'user_id'          => $user_activity->user_id,
 									'enrolment_status' => $this->enrolment_status,
 								),
-								admin_url( 'admin.php' )
+								admin_url( 'edit.php' )
 							),
 							'sensei-learner-action-withdraw'
 						);
@@ -515,6 +524,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 						$enrol_action_url = wp_nonce_url(
 							add_query_arg(
 								array(
+									'post_type'        => $this->menu_post_type,
 									'page'             => 'sensei_learners',
 									'view'             => 'learners',
 									'learner_action'   => $enrol_data_action,
@@ -522,7 +532,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 									'user_id'          => $user_activity->user_id,
 									'enrolment_status' => $this->enrolment_status,
 								),
-								admin_url( 'admin.php' )
+								admin_url( 'edit.php' )
 							),
 							'sensei-learner-action-' . $enrol_data_action
 						);
@@ -656,11 +666,12 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 					$grading_action = ' <a class="button" href="' . esc_url(
 						add_query_arg(
 							array(
+								'post_type' => $this->menu_post_type,
 								'page'      => 'sensei_grading',
 								'lesson_id' => $item->ID,
 								'course_id' => $this->course_id,
 							),
-							admin_url( 'admin.php' )
+							admin_url( 'edit.php' )
 						)
 					) . '">' . esc_html__( 'Grading', 'sensei-lms' ) . '</a>';
 				}
@@ -679,12 +690,14 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 						'actions'      => '<a class="button" href="' . esc_url(
 							add_query_arg(
 								array(
+									'post_type' => $this->menu_post_type,
+									'post_type' => $this->post_type,
 									'page'      => $this->page_slug,
 									'lesson_id' => $item->ID,
 									'course_id' => $this->course_id,
 									'view'      => 'learners',
 								),
-								admin_url( 'admin.php' )
+								admin_url( 'edit.php' )
 							)
 						) . '">' . esc_html__( 'Manage students', 'sensei-lms' ) . '</a> ' . $grading_action,
 					),
@@ -714,10 +727,11 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 				$grading_action = ' <a class="button" href="' . esc_url(
 					add_query_arg(
 						array(
+							'post_type' => $this->menu_post_type,
 							'page'      => 'sensei_grading',
 							'course_id' => $item->ID,
 						),
-						admin_url( 'admin.php' )
+						admin_url( 'edit.php' )
 					)
 				) . '">' . esc_html__( 'Grading', 'sensei-lms' ) . '</a>';
 
@@ -729,11 +743,12 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 								'<a class="row-title" href="' . esc_url(
 									add_query_arg(
 										array(
+											'post_type' => $this->menu_post_type,
 											'page'      => 'sensei_learners',
 											'course_id' => $item->ID,
 											'view'      => 'learners',
 										),
-										admin_url( 'admin.php' )
+										admin_url( 'edit.php' )
 									)
 								) . '" title="' . esc_attr( $a_title ) . '">' .
 									esc_html( $title ) .
@@ -744,11 +759,12 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 						'actions'      => '<a class="button" href="' . esc_url(
 							add_query_arg(
 								array(
+									'post_type' => $this->menu_post_type,
 									'page'      => $this->page_slug,
 									'course_id' => $item->ID,
 									'view'      => 'learners',
 								),
-								admin_url( 'admin.php' )
+								admin_url( 'edit.php' )
 							)
 						) . '">' . esc_html__( 'Manage students', 'sensei-lms' ) . '</a> ' . $grading_action,
 					),
@@ -1073,6 +1089,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		} elseif ( $this->course_id && $this->lesson_id ) {
 
 			$query_args = array(
+				'post_type' => $this->menu_post_type,
 				'page'      => $this->page_slug,
 				'course_id' => $this->course_id,
 				'view'      => 'lessons',
@@ -1081,7 +1098,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			$course = get_the_title( $this->course_id );
 
 			$menu['back'] = '<a href="'
-				. esc_url( add_query_arg( $query_args, admin_url( 'admin.php' ) ) )
+				. esc_url( add_query_arg( $query_args, admin_url( 'edit.php' ) ) )
 				. '"><em>&larr; '
 				// translators: Placeholder is the Course title.
 				. esc_html( sprintf( __( 'Back to %s', 'sensei-lms' ), $course ) )
@@ -1109,6 +1126,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	 */
 	private function learners_link( $enrolment_status ) {
 		$query_args = array(
+			'post_type'        => $this->menu_post_type,
 			'page'             => $this->page_slug,
 			'course_id'        => $this->course_id,
 			'view'             => 'learners',
@@ -1116,7 +1134,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		);
 
 		$is_selected = 'learners' === $this->view && $enrolment_status === $this->enrolment_status;
-		$url         = add_query_arg( $query_args, admin_url( 'admin.php' ) );
+		$url         = add_query_arg( $query_args, admin_url( 'edit.php' ) );
 		$link_title  = false;
 
 		switch ( $enrolment_status ) {
@@ -1148,12 +1166,13 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 	 */
 	private function lessons_link() {
 		$query_args = array(
+			'post_type' => $this->menu_post_type,
 			'page'      => $this->page_slug,
 			'course_id' => $this->course_id,
 			'view'      => 'lessons',
 		);
 
-		$url = add_query_arg( $query_args, admin_url( 'admin.php' ) );
+		$url = add_query_arg( $query_args, admin_url( 'edit.php' ) );
 
 		return '<a ' . ( 'lessons' === $this->view ? 'class="current"' : '' ) . ' href="' . esc_url( $url ) . '">' . esc_html__( 'Lessons', 'sensei-lms' ) . '</a>';
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request
Ensure the _Student Management_ menu stays highlighted while filtering and drilling down.

### Testing instructions
- Click through all areas of _Student Management_ and ensure the menu stays highlighted.
- Test _Bulk Student Actions_ as well.