### PR TITLE
Fix block spacing when using course theme in the editor

### DIFF
--- a/assets/css/sensei-course-theme/editor.scss
+++ b/assets/css/sensei-course-theme/editor.scss
@@ -1,3 +1,8 @@
+body {
+	padding: 8px;
+	--wp--custom--gap--baseline: 0.5em;
+}
+
 .wp-block {
 	max-width: 900px;
 	margin-left: auto;


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Set up variable controlling spacing between blocks
* Set padding on wrapper for small-screen readability

### Testing instructions

- Edit a lesson with Learning Mode enabled. Check that paragraph and other blocks have space between them, same as on the frontend.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

### Before
<img width="597" alt="image" src="https://user-images.githubusercontent.com/176949/151842765-2cef8869-43c8-436a-b3ad-258dabcd67db.png">

### After

<img width="582" alt="image" src="https://user-images.githubusercontent.com/176949/151842824-ff771291-e76f-41c4-a361-10109615e16a.png">

