### PR TITLE
Fix persistence of menu highlights

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -748,19 +748,21 @@ class Sensei_Course {
 
 		$manage_url  = add_query_arg(
 			array(
+				'post_type' => 'course',
 				'page'      => 'sensei_learners',
 				'course_id' => $post->ID,
 				'view'      => 'learners',
 			),
-			admin_url( 'admin.php' )
+			admin_url( 'edit.php' )
 		);
 		$grading_url = add_query_arg(
 			array(
+				'post_type' => 'course',
 				'page'      => 'sensei_grading',
 				'course_id' => $post->ID,
 				'view'      => 'learners',
 			),
-			admin_url( 'admin.php' )
+			admin_url( 'edit.php' )
 		);
 
 		echo '<ul><li><a href=' . esc_url( $manage_url ) . '>' . esc_html__( 'Manage Learners', 'sensei-lms' ) . '</a></li>';

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -125,20 +125,22 @@ class Sensei_Learner {
 
 		$manage_url = add_query_arg(
 			[
+				'post_type' => 'course',
 				'page'      => 'sensei_learners',
 				'view'      => 'learners',
 				'course_id' => $course_id,
 			],
-			admin_url( 'admin.php' )
+			admin_url( 'edit.php' )
 		);
 
 		$grade_url = add_query_arg(
 			[
+				'post_type' => 'course',
 				'page'      => 'sensei_grading',
 				'view'      => 'all',
 				'course_id' => $course_id,
 			],
-			admin_url( 'admin.php' )
+			admin_url( 'edit.php' )
 		);
 
 		?>


### PR DESCRIPTION
### Changes proposed in this Pull Request
Fixes a final few issues with some menu items not being highlighted.

### Testing instructions
- Edit a course.
- In the _Course Management_ meta box, click the _Manage Learners_ and _Manage Grading_ links.
- Ensure the appropriate menu item is highlighted.
- On the _Courses_ page, click the _Manage_ and _Grade_ buttons in the _Students_ column.
- Ensure the appropriate menu item is highlighted.