### PR TITLE
Update learning mode banner copy

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -192,7 +192,7 @@ class Sensei_Course_Theme_Option {
 		$notices['sensei-course-theme'] = [
 			'type'       => 'user',
 			'icon'       => 'sensei',
-			'heading'    => __( 'Sensei’s new learning mode is here', 'sensei-lms' ),
+			'heading'    => __( 'Sensei’s new Learning Mode is here!', 'sensei-lms' ),
 			'message'    => __( 'Give your students an intuitive and distraction-free learning experience.', 'sensei-lms' ),
 			'actions'    => [
 				[


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It updates the Learning Mode banner copy to: _"Sensei’s new Learning Mode is here!"_

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* In the database, remove the `sensei-dismissed-notices` user meta from your user (or you can create another admin user).
* Access `WP Admin > Sensei LMS > Courses`, and make sure you see the notice with the new text.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1458" alt="Screen Shot 2022-01-31 at 18 29 44" src="https://user-images.githubusercontent.com/876340/151876205-1828d91e-e6b3-4abc-836e-daa2f52da6f7.png">