### PR TITLE
Add check to module teacher term filter

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -2524,6 +2524,10 @@ class Sensei_Core_Modules {
 				$term = get_term( $term, 'module' );
 			}
 
+			if ( ! $term instanceof WP_Term ) {
+				continue;
+			}
+
 			$author = self::get_term_author( $term->slug );
 
 			if ( ! user_can( $author, 'manage_options' ) && isset( $term->name ) ) {


### PR DESCRIPTION
Fixes #4365

### Changes proposed in this Pull Request

* Add a check to `Sensei_Core_Modules::append_teacher_name_to_module` to ignore non-`WP_Term` terms, as it does not work with them

### Testing instructions

From the issue:

> - Install current https://wordpress.org/plugins/wordpress-seo/ (17.4 or later)
> - Admin: edit any Course
> - Watch PHP error log
> - See Notice: Trying to get property 'slug' of non-object for every module term in the system
