### PR TITLE
Order lessons between modules

### DIFF
--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -65,6 +65,7 @@ div.question_boolean_fields { margin-bottom: 10px; }
     vertical-align: top;
 }
 .sortable-lesson-list {
+    min-height: 38px;
     border: 1px solid #e5e5e5;
     -webkit-box-shadow: 0 1px 1px rgba(0,0,0,.04);
     box-shadow: 0 1px 1px rgba(0,0,0,.04);

--- a/assets/js/admin/ordering.js
+++ b/assets/js/admin/ordering.js
@@ -1,10 +1,18 @@
 jQuery( document ).ready( function ( $ ) {
+	const $lessonList = $( '.sortable-lesson-list' );
+	const $courseList = $( '.sortable-course-list' );
+
+	$lessonList.sortable( {
+		connectWith: '.sortable-lesson-list',
+	} );
+
+	$courseList.sortable();
+
 	$( '#lesson-order-course' ).select2( { width: 'resolve' } );
-	$( '.sortable-course-list, .sortable-lesson-list' ).sortable();
 	$( '.sortable-tab-list' ).disableSelection();
 
 	/* Order Courses */
-	$( '.sortable-course-list' ).bind( 'sortstop', function () {
+	$courseList.bind( 'sortstop', function () {
 		var orderString = '';
 
 		$( this )
@@ -21,25 +29,11 @@ jQuery( document ).ready( function ( $ ) {
 	} );
 
 	/* Order Lessons */
-	$( '.sortable-lesson-list' ).bind( 'sortstop', function () {
-		var orderString = '';
-		var module_id = $( this ).attr( 'data-module-id' );
-		var order_input = 'lesson-order';
+	$lessonList.bind( 'sortstop', ( event, ui ) => {
+		const $listItem = $( ui.item[ 0 ] );
+		const $destinationList = $listItem.parent();
+		const moduleId = $destinationList.data( 'module-id' );
 
-		if ( 0 != module_id ) {
-			order_input = 'lesson-order-module-' + module_id;
-		}
-
-		$( this )
-			.find( '.lesson' )
-			.each( function ( i ) {
-				if ( i > 0 ) {
-					orderString += ',';
-				}
-
-				orderString += $( this ).find( 'span' ).attr( 'rel' );
-			} );
-
-		$( 'input[name="' + order_input + '"]' ).val( orderString );
+		$listItem.find( 'input' ).val( moduleId );
 	} );
 } );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1438,7 +1438,7 @@ class Sensei_Admin {
 			_doing_it_wrong(
 				'handle_order_lessons',
 				'The handle_order_lessons AJAX call should be a POST request with parameters "course_id" and "lessons".',
-				'4.0.1'
+				'4.1.0'
 			);
 
 			wp_die();
@@ -1533,18 +1533,19 @@ class Sensei_Admin {
 				if ( $course_id > 0 ) {
 					$course_structure = $this->get_course_structure( $course_id );
 					$modules          = $this->get_course_structure( $course_structure, 'module' );
+					$has_lessons      = false;
 
+					// Form start.
 					$html .= '<form id="editgrouping" method="post" action="'
 						. esc_url( admin_url( 'admin-post.php' ) ) . '" class="validate">' . "\n";
 
-					$has_lessons = false;
-
 					foreach ( $modules as $module ) {
-						if ( count( $module['lessons'] ) > 0 ) {
-							$has_lessons = true;
+						// Modules.
+						$html .= '<h3>' . esc_html( $module['title'] ) . '</h3>' . "\n";
+						$html .= '<ul class="sortable-lesson-list" data-module-id="' . esc_attr( $module['id'] ) . '">' . "\n";
 
-							$html .= '<h3>' . esc_html( $module['title'] ) . '</h3>' . "\n";
-							$html .= '<ul class="sortable-lesson-list" data-module-id="' . esc_attr( $module['id'] ) . '">' . "\n";
+						if ( $module['lessons'] ) {
+							$has_lessons = true;
 
 							foreach ( $module['lessons'] as $lesson ) {
 								$html .= '<li class="lesson">';
@@ -1552,16 +1553,16 @@ class Sensei_Admin {
 								$html .= '<input type="hidden" name="lessons[' . intval( $lesson['id'] ) . '][module]" value="' . intval( $module['id'] ) . '">';
 								$html .= '</li>' . "\n";
 							}
-
-							$html .= '</ul>' . "\n";
 						}
+
+						$html .= '</ul>' . "\n";
 					}
 
-					// Other Lessons
 					$other_lessons = $this->get_course_structure( $course_structure, 'lesson' );
-					if ( 0 < count( $other_lessons ) ) {
-						$has_lessons = true;
+					$has_lessons   = $has_lessons || $other_lessons;
 
+					if ( $has_lessons ) {
+						// Other Lessons (lessons not related to a module).
 						$html .= '<h3>' . esc_html__( 'Other Lessons', 'sensei-lms' ) . '</h3>' . "\n";
 						$html .= '<ul class="sortable-lesson-list" data-module-id="0">' . "\n";
 
@@ -1570,19 +1571,17 @@ class Sensei_Admin {
 							$html .= '<input type="hidden" name="lessons[' . intval( $other_lesson['id'] ) . '][module]" value="">';
 							$html .= '</li>' . "\n";
 						}
+
 						$html .= '</ul>' . "\n";
-					}
 
-					if ( ! $has_lessons ) {
-						$html .= '<p><em>' . esc_html__( 'There are no lessons in this course.', 'sensei-lms' ) . '</em></p>';
-					}
-
-					if ( $has_lessons ) {
+						// Form end.
 						$html .= '<input type="hidden" name="action" value="order_lessons" />' . "\n";
 						$html .= wp_nonce_field( 'order_lessons', '_wpnonce', true, false ) . "\n";
 						$html .= '<input type="hidden" name="course_id" value="' . esc_attr( $course_id ) . '" />' . "\n";
 						$html .= '<input type="submit" class="button-primary" value="' . esc_attr__( 'Save lesson order', 'sensei-lms' ) . '" />' . "\n";
 						$html .= '</form>';
+					} else {
+						$html .= '<p><em>' . esc_html__( 'There are no lessons in this course.', 'sensei-lms' ) . '</em></p>';
 					}
 				}
 			}
@@ -1692,7 +1691,7 @@ class Sensei_Admin {
 	/**
 	 * Sync the course lessons with a list of IDs.
 	 *
-	 * @since 4.0.1
+	 * @since 4.1.0
 	 *
 	 * @param array $lesson_ids {
 	 *     Arguments that accompany the lesson ids.

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -1431,13 +1431,32 @@ class Sensei_Admin {
 			wp_die( esc_html__( 'Insufficient permissions', 'sensei-lms' ) );
 		}
 
-		$course_id = isset( $_POST['course_id'] ) ? (int) $_POST['course_id'] : null;
-		$ordered   = null;
+		if (
+			empty( $_POST['course_id'] )
+			|| empty( $_POST['lessons'] )
+		) {
+			_doing_it_wrong(
+				'handle_order_lessons',
+				'The handle_order_lessons AJAX call should be a POST request with parameters "course_id" and "lessons".',
+				'4.0.1'
+			);
 
-		if ( isset( $_POST['lesson-order'] ) ) {
-			$lesson_order = sanitize_text_field( wp_unslash( $_POST['lesson-order'] ) );
-			$ordered      = $this->save_lesson_order( $lesson_order, $course_id );
+			wp_die();
 		}
+
+		$lessons_order = [];
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput -- The input is sanitized by hand.
+		foreach ( $_POST['lessons'] as $lesson_id => $lesson_data ) {
+			$lessons_order[ (int) $lesson_id ] = [
+				'module' => (int) $lesson_data['module'],
+			];
+		}
+
+		$course_id = (int) $_POST['course_id'];
+		$ordered   = $this->sync_lesson_order(
+			$lessons_order,
+			$course_id
+		);
 
 		wp_safe_redirect(
 			esc_url_raw(
@@ -1528,12 +1547,13 @@ class Sensei_Admin {
 							$html .= '<ul class="sortable-lesson-list" data-module-id="' . esc_attr( $module['id'] ) . '">' . "\n";
 
 							foreach ( $module['lessons'] as $lesson ) {
-								$html .= '<li class="lesson"><span rel="' . esc_attr( $lesson['id'] ) . '" style="width: 100%;"> ' . esc_html( $lesson['title'] ) . '</span></li>' . "\n";
+								$html .= '<li class="lesson">';
+								$html .= '<span rel="' . esc_attr( $lesson['id'] ) . '" style="width: 100%;"> ' . esc_html( $lesson['title'] ) . '</span>';
+								$html .= '<input type="hidden" name="lessons[' . intval( $lesson['id'] ) . '][module]" value="' . intval( $module['id'] ) . '">';
+								$html .= '</li>' . "\n";
 							}
 
 							$html .= '</ul>' . "\n";
-
-							$html .= '<input type="hidden" name="lesson-order-module-' . esc_attr( $module['id'] ) . '" value="" />' . "\n";
 						}
 					}
 
@@ -1546,7 +1566,9 @@ class Sensei_Admin {
 						$html .= '<ul class="sortable-lesson-list" data-module-id="0">' . "\n";
 
 						foreach ( $other_lessons as $other_lesson ) {
-							$html .= '<li class="lesson"><span rel="' . esc_attr( $other_lesson['id'] ) . '" style="width: 100%;"> ' . esc_html( $other_lesson['title'] ) . '</span></li>' . "\n";
+							$html .= '<li class="lesson"><span rel="' . esc_attr( $other_lesson['id'] ) . '" style="width: 100%;"> ' . esc_html( $other_lesson['title'] ) . '</span>';
+							$html .= '<input type="hidden" name="lessons[' . intval( $other_lesson['id'] ) . '][module]" value="">';
+							$html .= '</li>' . "\n";
 						}
 						$html .= '</ul>' . "\n";
 					}
@@ -1558,7 +1580,6 @@ class Sensei_Admin {
 					if ( $has_lessons ) {
 						$html .= '<input type="hidden" name="action" value="order_lessons" />' . "\n";
 						$html .= wp_nonce_field( 'order_lessons', '_wpnonce', true, false ) . "\n";
-						$html .= '<input type="hidden" name="lesson-order" value="" />' . "\n";
 						$html .= '<input type="hidden" name="course_id" value="' . esc_attr( $course_id ) . '" />' . "\n";
 						$html .= '<input type="submit" class="button-primary" value="' . esc_attr__( 'Save lesson order', 'sensei-lms' ) . '" />' . "\n";
 						$html .= '</form>';
@@ -1666,6 +1687,67 @@ class Sensei_Admin {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Sync the course lessons with a list of IDs.
+	 *
+	 * @since 4.0.1
+	 *
+	 * @param array $lesson_ids {
+	 *     Arguments that accompany the lesson ids.
+	 *
+	 *     @type int $module The module ID of the lesson.
+	 * }
+	 * @param int   $course_id
+	 *
+	 * @return bool
+	 */
+	private function sync_lesson_order( array $lesson_ids, int $course_id ): bool {
+
+		remove_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70 );
+		$original_course_structure = $this->get_course_structure( $course_id );
+		add_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70, 3 );
+
+		$lessons = [];
+		$modules = [];
+
+		// Extract the lessons from the course structure in preparation for the re-ordering.
+		foreach ( $original_course_structure as $item ) {
+			if ( 'module' === $item['type'] ) {
+				foreach ( $item['lessons'] as $lesson ) {
+					$lessons[ $lesson['id'] ] = $lesson;
+				}
+
+				$item['lessons']        = [];
+				$modules[ $item['id'] ] = $item;
+			} elseif ( 'lesson' === $item['type'] ) {
+				$lessons[ $item['id'] ] = $item;
+			}
+		}
+
+		// Map the lessons to the modules.
+		foreach ( $lesson_ids as $lesson_id => $lesson_data ) {
+			$module_id = (int) $lesson_data['module'];
+			if ( $module_id ) {
+				$modules[ $module_id ]['lessons'][] = $lessons[ $lesson_id ];
+			}
+		}
+
+		$reordered_course_structure = array_values( $modules );
+
+		// Map the lessons that don't belong to a module.
+		foreach ( $lesson_ids as $lesson_id => $lesson_data ) {
+			if ( ! $lesson_data['module'] ) {
+				$reordered_course_structure[] = $lessons[ $lesson_id ];
+			}
+		}
+
+		// Save the new course structure.
+		$saved = Sensei_Course_Structure::instance( $course_id )
+			->save( $reordered_course_structure );
+
+		return true === $saved;
 	}
 
 	/**

--- a/tests/unit-tests/test-class-admin.php
+++ b/tests/unit-tests/test-class-admin.php
@@ -182,6 +182,169 @@ class Sensei_Class_Admin_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Ensure the lessons could be moved and unassigned from modules.
+	 *
+	 * @covers Sensei_Admin::sync_lesson_order
+	 */
+	public function testShouldMoveLessonsBetweenModulesAndUnassignModules() {
+		/* Arrange. */
+		$setup             = $this->setupSyncLessonOrderEnv();
+		$sync_lesson_order = $setup['sync_lesson_order'];
+
+		$course_id = $setup['course_id'];
+		$lesson_1  = $setup['lessons'][0];
+		$lesson_2  = $setup['lessons'][1];
+		$module_1  = $setup['modules'][0];
+		$module_2  = $setup['modules'][1];
+
+		/* Act. */
+		$lessons_to_sync = [
+			$lesson_1 => [ 'module' => $module_1 ],
+			$lesson_2 => [ 'module' => $module_2 ],
+		];
+
+		$sync_lesson_order( $lessons_to_sync, $course_id );
+
+		/* Assert. */
+		$this->assertTrue( has_term( $module_1, Sensei()->modules->taxonomy, $lesson_1 ) );
+		$this->assertTrue( has_term( $module_2, Sensei()->modules->taxonomy, $lesson_2 ) );
+
+		/* Act. */
+		// Move lesson 2 to module 1.
+		$lessons_to_sync = [
+			$lesson_1 => [ 'module' => $module_1 ],
+			$lesson_2 => [ 'module' => $module_1 ],
+		];
+
+		$sync_lesson_order( $lessons_to_sync, $course_id );
+
+		/* Assert. */
+		$this->assertTrue( has_term( $module_1, Sensei()->modules->taxonomy, $lesson_1 ) );
+		$this->assertTrue( has_term( $module_1, Sensei()->modules->taxonomy, $lesson_2 ) );
+		$this->assertFalse( has_term( $module_2, Sensei()->modules->taxonomy, $lesson_2 ) );
+
+		/* Act. */
+		// Unassign the module from lesson 2.
+		$lessons_to_sync = [
+			$lesson_1 => [ 'module' => $module_1 ],
+			$lesson_2 => [ 'module' => null ],
+		];
+
+		$sync_lesson_order( $lessons_to_sync, $course_id );
+
+		/* Assert. */
+		$this->assertTrue( has_term( $module_1, Sensei()->modules->taxonomy, $lesson_1 ) );
+		$this->assertFalse( has_term( $module_1, Sensei()->modules->taxonomy, $lesson_2 ) );
+		$this->assertFalse( has_term( $module_2, Sensei()->modules->taxonomy, $lesson_2 ) );
+	}
+
+	/**
+	 * Ensure the lessons order is updated.
+	 *
+	 * @covers Sensei_Admin::sync_lesson_order
+	 */
+	public function testShouldUpdateTheOrderOfLessons() {
+		/* Arrange. */
+		$setup             = $this->setupSyncLessonOrderEnv();
+		$sync_lesson_order = $setup['sync_lesson_order'];
+
+		$course_id = $setup['course_id'];
+		$lesson_1  = $setup['lessons'][0];
+		$lesson_2  = $setup['lessons'][1];
+		$lesson_3  = $setup['lessons'][2];
+		$module_1  = $setup['modules'][0];
+		$module_2  = $setup['modules'][1];
+
+		/* Act. */
+		$lessons_to_sync = [
+			$lesson_1 => [ 'module' => $module_1 ],
+			$lesson_2 => [ 'module' => $module_2 ],
+			$lesson_3 => [ 'module' => null ],
+		];
+
+		$sync_lesson_order( $lessons_to_sync, $course_id );
+
+		/* Assert. */
+		$this->assertEquals( '0', get_post_meta( $lesson_1, '_order_module_' . $module_1, true ) );
+		$this->assertEquals( '0', get_post_meta( $lesson_2, '_order_module_' . $module_2, true ) );
+
+		/* Act. */
+		// Move the lesson 2 to module 1 and make it first.
+		$lessons_to_sync = [
+			$lesson_2 => [ 'module' => $module_1 ],
+			$lesson_1 => [ 'module' => $module_1 ],
+			$lesson_3 => [ 'module' => null ],
+		];
+
+		$sync_lesson_order( $lessons_to_sync, $course_id );
+
+		/* Assert. */
+		$this->assertEquals( '0', get_post_meta( $lesson_2, '_order_module_' . $module_1, true ) );
+		$this->assertEquals( '1', get_post_meta( $lesson_1, '_order_module_' . $module_1, true ) );
+
+		/* Act. */
+		// Have 2 unassigned lessons.
+		$lessons_to_sync = [
+			$lesson_1 => [ 'module' => $module_1 ],
+			$lesson_2 => [ 'module' => null ],
+			$lesson_3 => [ 'module' => null ],
+		];
+
+		$sync_lesson_order( $lessons_to_sync, $course_id );
+
+		/* Assert. */
+		$no_module_lessons_order = explode( ',', get_post_meta( $course_id, '_lesson_order', true ) );
+		$this->assertEquals( [ $lesson_2, $lesson_3 ], $no_module_lessons_order );
+
+		/* Act. */
+		// Reorder the unassigned lessons.
+		$lessons_to_sync = [
+			$lesson_1 => [ 'module' => $module_1 ],
+			$lesson_3 => [ 'module' => null ],
+			$lesson_2 => [ 'module' => null ],
+		];
+
+		$sync_lesson_order( $lessons_to_sync, $course_id );
+
+		/* Assert. */
+		$no_module_lessons_order = explode( ',', get_post_meta( $course_id, '_lesson_order', true ) );
+		$this->assertEquals( [ $lesson_3, $lesson_2 ], $no_module_lessons_order );
+	}
+
+	/**
+	 * Setup method for Sensei_Admin::sync_lesson_order.
+	 *
+	 * @return array
+	 */
+	private function setupSyncLessonOrderEnv() {
+		$course_id = $this->factory->course->create( [ 'post_author' => 1 ] );
+		$modules   = $this->factory->module->create_many( 2 );
+		$lessons   = $this->factory->lesson->create_many(
+			3,
+			[
+				'meta_input' => [
+					'_lesson_course' => $course_id,
+				],
+			]
+		);
+
+		wp_set_object_terms( $course_id, $modules, Sensei()->modules->taxonomy );
+
+		$admin  = new Sensei_Admin();
+		$method = new ReflectionMethod( $admin, 'sync_lesson_order' );
+		$method->setAccessible( true );
+
+		return [
+			'course_id'         => $course_id,
+			'lessons'           => $lessons,
+			'modules'           => $modules,
+			'sync_lesson_order' => function( $lessons_to_sync, $course_id ) use ( $admin, $method ) {
+				return $method->invoke( $admin, $lessons_to_sync, $course_id );
+			},
+		];
+	}
+
+	/**
 	 * Setup function for duplicate course.
 	 *
 	 * This function mocks the redirect method, create and set the user, create a course


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Make it possible for lessons to be ordered between course modules.

### Testing instructions

* Make a course with multiple modules and lessons. Have some lessons that are not assigned to a module.
* Go to Lessons -> Order Lessons, and select your course.
* Move lessons between modules and save.
* Move lessons out of modules and save.
* Make sure the order is preserved.
* Double check if the order is reflected in the course.

### Screenshot / Video

https://user-images.githubusercontent.com/1612178/151981218-0f3514af-4aca-4b8c-b91d-083c01945432.mp4


