### PR TITLE
Fix link styles in Learning Mode

### DIFF
--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -54,7 +54,7 @@
 	}
 
 	&.is-primary,
-	&.wp-block-button:not(.is-style-outline) {
+	&.wp-block-button:not(.is-style-outline, .is-style-link) {
 		background-color: var(--primary-color);
 		color: var(--primary-contrast-color);
 		&:hover {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes an issue with link styles when using Learning Mode.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course with Learning Mode enabled.
* Add at least one lesson.
* Add a Contact Teacher block to the lesson and change the button style to "Link".
* Check the button styles in the editor and in the frontend, and make sure it works properly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="806" alt="Screen Shot 2022-02-01 at 17 24 20" src="https://user-images.githubusercontent.com/876340/152045443-e9898b44-45b8-45c6-adce-717d973bcb86.png">