### PR TITLE
Fix learning mode with localized post type slugs

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -86,6 +86,7 @@ class Sensei_Data_Cleaner {
 		'widget_sensei_category_courses',
 		'sensei_dismiss_wcpc_prompt',
 		'sensei-cancelled-wccom-connect-dismissed',
+		'sensei_course_theme_query_var_flushed',
 	);
 
 	/**

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -165,8 +165,6 @@ class Sensei_Course_Theme {
 	 */
 	public function maybe_flush_rewrite_rules() {
 
-		delete_option( 'sensei_course_theme_query_var_flushed' );
-
 		if ( '2' !== get_option( 'sensei_course_theme_query_var_flushed' ) ) {
 			flush_rewrite_rules( false );
 		}

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -194,7 +194,6 @@ class Sensei_Course_Theme {
 
 	}
 
-
 	/**
 	 * Get course theme name.
 	 *
@@ -345,7 +344,7 @@ class Sensei_Course_Theme {
 		$course_id   = get_post_meta( $lesson->ID, '_lesson_course', true );
 		$preview_url = '/?p=' . $lesson->ID;
 		if ( ! Sensei_Course_Theme_Option::has_sensei_theme_enabled( $course_id ) ) {
-			$preview_url .= '&learn=1&' . self::PREVIEW_QUERY_VAR . '=' . $course_id;
+			$preview_url .= '&' . self::QUERY_VAR . '=1&' . self::PREVIEW_QUERY_VAR . '=' . $course_id;
 		}
 		return '/wp-admin/customize.php?autofocus[section]=sensei-course-theme&url=' . rawurlencode( $preview_url );
 	}
@@ -385,7 +384,7 @@ class Sensei_Course_Theme {
 			array(
 				'id'    => 'site-editor',
 				'title' => __( 'Edit Site', 'sensei-lms' ),
-				'href'  => admin_url( 'site-editor.php?learn=1&postType=wp_template&postId=' . self::THEME_NAME . '//' . get_post_type() ),
+				'href'  => admin_url( 'site-editor.php?' . self::QUERY_VAR . '=1&postType=wp_template&postId=' . self::THEME_NAME . '//' . get_post_type() ),
 			)
 		);
 	}

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -167,8 +167,8 @@ class Sensei_Course_Theme {
 
 		if ( '2' !== get_option( 'sensei_course_theme_query_var_flushed' ) ) {
 			flush_rewrite_rules( false );
+			update_option( 'sensei_course_theme_query_var_flushed', '2' );
 		}
-		update_option( 'sensei_course_theme_query_var_flushed', '2' );
 	}
 
 


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Change rewrite rules for learning mode: register one for each post type, and use their slug from register_post_type, which could be translated or filtered.

### Testing instructions

* Change the lesson slug: `add_filter( 'sensei_lesson_slug', function() { return 'nossel'; } );`
* Alternatively, change the site language, and [translate the `lesson` entry with the comment **post type single slug**](https://user-images.githubusercontent.com/176949/152237991-aa943fc8-cf28-4d97-8b63-326d0fe2fa06.png)
* Open a lesson in learning mode. 
* It should work, with the filtered/translated URL

