### PR TITLE
Fix Edit Lesson link in admin bar

### DIFF
--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -311,6 +311,7 @@ class Sensei_PostTypes {
 			'publicly_queryable'    => true,
 			'show_ui'               => true,
 			'show_in_menu'          => false,
+			'show_in_admin_bar'     => true,
 			'query_var'             => true,
 			'rewrite'               => array(
 				'slug'       => esc_attr( apply_filters( 'sensei_lesson_slug', _x( 'lesson', 'post type single slug', 'sensei-lms' ) ) ),
@@ -360,6 +361,7 @@ class Sensei_PostTypes {
 			'publicly_queryable'  => true,
 			'show_ui'             => true,
 			'show_in_menu'        => false,
+			'show_in_admin_bar'   => true,
 			'show_in_nav_menus'   => false,
 			'query_var'           => true,
 			'exclude_from_search' => true,
@@ -407,6 +409,7 @@ class Sensei_PostTypes {
 			'publicly_queryable'    => true,
 			'show_ui'               => true,
 			'show_in_menu'          => false,
+			'show_in_admin_bar'     => true,
 			'show_in_nav_menus'     => false,
 			'query_var'             => true,
 			'exclude_from_search'   => true,


### PR DESCRIPTION
Fixes #4744 

### Changes proposed in this Pull Request

* Enable 'Edit Lesson' and similar links in the admin bar  

### Testing instructions

* Open a lesson in the frontend as admin. Check that the link is there in the admin bar

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="117" alt="image" src="https://user-images.githubusercontent.com/176949/152614169-c6b3bb8b-5fc5-46d1-b29a-436da1cfa300.png">
