### PR TITLE
Remove int hint

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -139,7 +139,7 @@ class Sensei_Course_Theme_Option {
 	 *
 	 * @return bool
 	 */
-	public static function has_sensei_theme_enabled( int $course_id ) {
+	public static function has_sensei_theme_enabled( $course_id ) {
 		$theme              = get_post_meta( $course_id, self::THEME_POST_META_NAME, true );
 		$enabled_for_course = self::SENSEI_THEME === $theme;
 		$enabled_globally   = (bool) \Sensei()->settings->get( 'sensei_learning_mode_all' );


### PR DESCRIPTION
Fixes https://wordpress.org/support/topic/fatal-error-4064/

### Changes proposed in this Pull Request

* Remove a type hint that leads to an error when the ID is string. 
  * The course ID here could be an empty string/false if there is no course for the lesson, and generally IDs are just a wild west in WordPress. Though the error wasn't happening for me even in that case

### Testing instructions

* Not sure how can it happen in the wild. I guess add a string like `"broken"` to a lesson's `_lesson_course` meta?
* Run PHP 8 
