### PR TITLE
Fix question description losing blocks

### DIFF
--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -132,16 +132,19 @@ const QuestionEdit = ( props ) => {
 		]
 	);
 
-	const template = [
-		[ questionDescriptionBlock.name, {} ],
-		[ questionAnswersBlock.name, {} ],
-		...( canHaveFeedback
-			? [
-					[ answerFeedbackCorrectBlock.name, {} ],
-					[ answerFeedbackIncorrectBlock.name, {} ],
-			  ]
-			: [] ),
-	];
+	const template = useMemo(
+		() => [
+			[ questionDescriptionBlock.name, {} ],
+			[ questionAnswersBlock.name, {} ],
+			...( canHaveFeedback
+				? [
+						[ answerFeedbackCorrectBlock.name, {} ],
+						[ answerFeedbackIncorrectBlock.name, {} ],
+				  ]
+				: [] ),
+		],
+		[ canHaveFeedback ]
+	);
 
 	if ( ! editable ) {
 		return (

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -133,21 +133,7 @@ const QuestionEdit = ( props ) => {
 	);
 
 	const template = [
-		[
-			questionDescriptionBlock.name,
-			{},
-			[
-				[
-					'core/paragraph',
-					{
-						placeholder: __(
-							'Add question description or type / to choose a block.',
-							'sensei-lms'
-						),
-					},
-				],
-			],
-		],
+		[ questionDescriptionBlock.name, {} ],
 		[ questionAnswersBlock.name, {} ],
 		...( canHaveFeedback
 			? [

--- a/assets/blocks/quiz/question-description-block/question-description.js
+++ b/assets/blocks/quiz/question-description-block/question-description.js
@@ -28,7 +28,7 @@ const QuestionDescription = () => {
 						'core/paragraph',
 						{
 							placeholder: __(
-								'Question Description',
+								'Add question description or type / to choose a block.',
 								'sensei-lms'
 							),
 						},


### PR DESCRIPTION
Fixes #4694, fixes #4769, fixes #4554

### Changes proposed in this Pull Request

* Fix question description content being forced to one paragraph block

### Testing instructions

* Create or edit a question (on its own or in a quiz)
* Add multiple paragraph. Save and reload. They should still be there
* Add an image or other content instead of the default paragraph. Save and reload. Should still be there

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="723" alt="image" src="https://user-images.githubusercontent.com/176949/152860235-e054f3b0-dd3c-45c6-b35a-a85437a1fba0.png">
