### PR TITLE
Fix different default option on boolean questions

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -313,6 +313,9 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 			case 'boolean':
 				if ( isset( $question['answer']['correct'] ) ) {
 					$meta['_question_right_answer'] = $question['answer']['correct'] ? 'true' : 'false';
+				} else {
+					// If the correct field isn't defined, then it's true by default.
+					$meta['_question_right_answer'] = 'true';
 				}
 				break;
 			case 'gap-fill':

--- a/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
+++ b/includes/rest-api/class-sensei-rest-api-question-helpers-trait.php
@@ -547,7 +547,8 @@ trait Sensei_REST_API_Question_Helpers_Trait {
 				$type_specific_properties = array_merge_recursive( $type_specific_properties, $this->get_multiple_choice_properties( $question ) );
 				break;
 			case 'boolean':
-				$type_specific_properties['answer']['correct'] = 'true' === get_post_meta( $question->ID, '_question_right_answer', true );
+				$right_answer                                  = get_post_meta( $question->ID, '_question_right_answer', true );
+				$type_specific_properties['answer']['correct'] = 'true' === $right_answer || '' === $right_answer;
 				break;
 			case 'gap-fill':
 				$type_specific_properties['answer'] = $this->get_gap_fill_properties( $question );


### PR DESCRIPTION
Originally, the "correct" answer changed to "false" because it wasn't "true", but "" (yeah, an empty string) instead.

This change makes the code consider an empty string the same as "true", so the consistency between the UI and the backend is maintained.

Fixes #4566

### Changes proposed in this Pull Request

* Make "" (the default value for the option) equivalent to "true" in the backend, so the default between the UI and the backend is maintained.

### Testing instructions

* Create a lesson;
* Add a question to it;
* Change it to "True/False", **without** clicking on any other buttons inside the question block;
* Hit the "update" button on the top of the WordPress interface;
* Check if the "right"/"wrong" choices are the same as before;