### PR TITLE
Add missing quiz translations

### DIFF
--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -126,7 +126,10 @@ const QuizSettings = ( {
 						<>
 							<PanelRow>
 								<RangeControl
-									label={ 'Passing Grade (%)' }
+									label={ __(
+										'Passing Grade (%)',
+										'sensei-lms'
+									) }
 									value={ quizPassmark }
 									onChange={ createChangeHandler(
 										'quizPassmark'

--- a/assets/js/grading-general.js
+++ b/assets/js/grading-general.js
@@ -1,3 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
 jQuery( document ).ready( function ( $ ) {
 	/***************************************************************************************************
 	 * 	1 - Helper Functions.
@@ -56,10 +61,10 @@ jQuery( document ).ready( function ( $ ) {
 
 		if ( total_questions == total_graded_questions ) {
 			jQuery( '#all_questions_graded' ).val( 'yes' );
-			jQuery( '.grade-button' ).val( 'Grade' );
+			jQuery( '.grade-button' ).val( __( 'Grade', 'sensei-lms' ) );
 		} else {
 			jQuery( '#all_questions_graded' ).val( 'no' );
-			jQuery( '.grade-button' ).val( 'Save' );
+			jQuery( '.grade-button' ).val( __( 'Save', 'sensei-lms' ) );
 		}
 	};
 

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -108,9 +108,9 @@ class Sensei_Grading_User_Quiz {
 				<span class="total_grade_total"><?php echo esc_html( $user_quiz_grade_total ); ?></span> / <span class="quiz_grade_total"><?php echo esc_html( $quiz_grade_total ); ?></span> (<span class="total_grade_percent"><?php echo esc_html( $quiz_grade ); ?></span>%)
 			</div>
 			<div class="buttons">
-				<input type="submit" value="<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>" class="grade-button button-primary" title="Saves grades as currently marked on this page" />
-				<input type="button" value="<?php esc_attr_e( 'Auto grade', 'sensei-lms' ); ?>" class="autograde-button button-secondary" title="Where possible, automatically grades questions that have not yet been graded" />
-				<input type="button" value="<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>" class="reset-button button-link button-link-delete" title="Resets all questions to ungraded and total grade to 0" />
+				<input type="submit" value="<?php esc_attr_e( 'Save', 'sensei-lms' ); ?>" class="grade-button button-primary" title="<?php esc_attr_e( 'Saves grades as currently marked on this page', 'sensei-lms' ); ?>" />
+				<input type="button" value="<?php esc_attr_e( 'Auto grade', 'sensei-lms' ); ?>" class="autograde-button button-secondary" title="<?php esc_attr_e( 'Where possible, automatically grades questions that have not yet been graded', 'sensei-lms' ); ?>" />
+				<input type="button" value="<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>" class="reset-button button-link button-link-delete" title="<?php esc_attr_e( 'Resets all questions to ungraded and total grade to 0', 'sensei-lms' ); ?>" />
 			</div>
 			<div class="clear"></div><br/>
 			<?php


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Wrap a few string in quiz grading in `__()` calls

### Testing instructions

* Generate pot file
* Translate the new strings. _In Loco, press sync if there was an existing translation so the new ones show up_
* Open Grading > Grade/Review a students answers
* Check the translated string showing:
    * The primary Save/Grade button is updating with the localized string when clicking reset and auto grade.
    * The labels hovering over these buttons show the localized string


<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="759" alt="image" src="https://user-images.githubusercontent.com/176949/153009365-611471e9-b2f5-4dc6-9c17-099334499fbe.png">
