### PR TITLE
Fix learning mode notices in preview lessons

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -263,10 +263,12 @@ class Sensei_Course_Theme_Lesson {
 
 			$notice_text  = __( 'Please register or sign in to access the course content.', 'sensei-lms' );
 			$notice_title = __( 'You don\'t have access to this lesson', 'sensei-lms' );
+			$notice_icon  = 'lock';
 
 			if ( Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
 				$notice_text  = __( 'Register or sign in to take this lesson.', 'sensei-lms' );
 				$notice_title = __( 'This is a preview lesson', 'sensei-lms' );
+				$notice_icon  = 'eye';
 			}
 
 			$notices->add_notice(
@@ -274,7 +276,7 @@ class Sensei_Course_Theme_Lesson {
 				$notice_text,
 				$notice_title,
 				$actions,
-				'lock'
+				$notice_icon
 			);
 
 			return;
@@ -292,10 +294,12 @@ class Sensei_Course_Theme_Lesson {
 
 		$notice_text  = __( 'Please register for this course to access the content.', 'sensei-lms' );
 		$notice_title = __( 'You don\'t have access to this lesson', 'sensei-lms' );
+		$notice_icon  = 'lock';
 
 		if ( Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
 			$notice_text  = __( 'Register for this course to take this lesson.', 'sensei-lms' );
 			$notice_title = __( 'This is a preview lesson', 'sensei-lms' );
+			$notice_icon  = 'eye';
 		}
 
 		$notices->add_notice(
@@ -303,7 +307,7 @@ class Sensei_Course_Theme_Lesson {
 			$notice_text,
 			$notice_title,
 			$actions,
-			'lock'
+			$notice_icon
 		);
 	}
 }

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -221,16 +221,19 @@ class Sensei_Course_Theme_Lesson {
 			return;
 		}
 
-		$notices = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' );
+		$notices      = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' );
+		$notice_key   = 'locked_lesson';
+		$notice_title = __( 'You don\'t have access to this lesson', 'sensei-lms' );
+		$notice_icon  = 'lock';
 
 		// Course prerequisite notice.
 		if ( ! Sensei_Course::is_prerequisite_complete( $course_id ) ) {
 			$notices->add_notice(
-				'locked_lesson',
+				$notice_key,
 				Sensei()->course::get_course_prerequisite_message( $course_id ),
-				__( 'You don\'t have access to this lesson', 'sensei-lms' ),
+				$notice_title,
 				[],
-				'lock'
+				$notice_icon
 			);
 
 			return;
@@ -261,9 +264,7 @@ class Sensei_Course_Theme_Lesson {
 				],
 			];
 
-			$notice_text  = __( 'Please register or sign in to access the course content.', 'sensei-lms' );
-			$notice_title = __( 'You don\'t have access to this lesson', 'sensei-lms' );
-			$notice_icon  = 'lock';
+			$notice_text = __( 'Please register or sign in to access the course content.', 'sensei-lms' );
 
 			if ( Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
 				$notice_text  = __( 'Register or sign in to take this lesson.', 'sensei-lms' );
@@ -272,7 +273,7 @@ class Sensei_Course_Theme_Lesson {
 			}
 
 			$notices->add_notice(
-				'locked_lesson',
+				$notice_key,
 				$notice_text,
 				$notice_title,
 				$actions,
@@ -292,9 +293,7 @@ class Sensei_Course_Theme_Lesson {
 			</form>',
 		];
 
-		$notice_text  = __( 'Please register for this course to access the content.', 'sensei-lms' );
-		$notice_title = __( 'You don\'t have access to this lesson', 'sensei-lms' );
-		$notice_icon  = 'lock';
+		$notice_text = __( 'Please register for this course to access the content.', 'sensei-lms' );
 
 		if ( Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
 			$notice_text  = __( 'Register for this course to take this lesson.', 'sensei-lms' );
@@ -303,7 +302,7 @@ class Sensei_Course_Theme_Lesson {
 		}
 
 		$notices->add_notice(
-			'locked_lesson',
+			$notice_key,
 			$notice_text,
 			$notice_title,
 			$actions,

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -261,10 +261,18 @@ class Sensei_Course_Theme_Lesson {
 				],
 			];
 
+			$notice_text  = __( 'Please register or sign in to access the course content.', 'sensei-lms' );
+			$notice_title = __( 'You don\'t have access to this lesson', 'sensei-lms' );
+
+			if ( Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
+				$notice_text  = __( 'Register or sign in to take this lesson.', 'sensei-lms' );
+				$notice_title = __( 'This is a preview lesson', 'sensei-lms' );
+			}
+
 			$notices->add_notice(
 				'locked_lesson',
-				__( 'Please register or sign in to access the course content.', 'sensei-lms' ),
-				__( 'You don\'t have access to this lesson', 'sensei-lms' ),
+				$notice_text,
+				$notice_title,
 				$actions,
 				'lock'
 			);
@@ -282,10 +290,18 @@ class Sensei_Course_Theme_Lesson {
 			</form>',
 		];
 
+		$notice_text  = __( 'Please register for this course to access the content.', 'sensei-lms' );
+		$notice_title = __( 'You don\'t have access to this lesson', 'sensei-lms' );
+
+		if ( Sensei_Utils::is_preview_lesson( $lesson_id ) ) {
+			$notice_text  = __( 'Register for this course to take this lesson.', 'sensei-lms' );
+			$notice_title = __( 'This is a preview lesson', 'sensei-lms' );
+		}
+
 		$notices->add_notice(
 			'locked_lesson',
-			__( 'Please register for this course to access the content.', 'sensei-lms' ),
-			__( 'You don\'t have access to this lesson', 'sensei-lms' ),
+			$notice_text,
+			$notice_title,
 			$actions,
 			'lock'
 		);

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -232,6 +232,27 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Testing logged out preview notice.
+	 */
+	public function testLoggedOutPreviewNotice() {
+		$lesson          = $this->factory->lesson->create_and_get(
+			[
+				'meta_input' => [
+					'_lesson_preview' => 'preview',
+				],
+			]
+		);
+		$GLOBALS['post'] = $lesson;
+
+		wp_logout();
+		\Sensei_Course_Theme_Lesson::instance()->init();
+
+		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
+
+		$this->assertContains( 'Register or sign in to take this lesson.', $html, 'Should return logged out preview notice' );
+	}
+
+	/**
 	 * Testing not enrolled notice.
 	 */
 	public function testNotEnrolledNotice() {
@@ -244,6 +265,27 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
 
 		$this->assertContains( 'Please register for this course to access the content.', $html, 'Should return not enrolled notice' );
+	}
+
+	/**
+	 * Testing not enrolled preview notice.
+	 */
+	public function testNotEnrolledPreviewNotice() {
+		$lesson          = $this->factory->lesson->create_and_get(
+			[
+				'meta_input' => [
+					'_lesson_preview' => 'preview',
+				],
+			]
+		);
+		$GLOBALS['post'] = $lesson;
+
+		$this->login_as_student();
+		\Sensei_Course_Theme_Lesson::instance()->init();
+
+		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
+
+		$this->assertContains( 'Register for this course to take this lesson.', $html, 'Should return not enrolled preview notice' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/4764

### Changes proposed in this Pull Request

* It fixes the learning mode notices in preview lessons.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course with Learning Mode enabled.
* Add a lesson with preview (_"Preview"_ panel in the lesson editor sidebar).
* Access the lesson logged out, and make sure you see a specific message for logged out users saying that it's a preview.
* Access the lesson logged in as a not enrolled student, and make sure you see a specific message for not enrolled users saying that it's a preview.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="928" alt="Screen Shot 2022-02-08 at 16 59 41" src="https://user-images.githubusercontent.com/876340/153066099-0553a793-0310-443a-9552-a1d2ae866aa1.png">

<img width="930" alt="Screen Shot 2022-02-08 at 16 59 57" src="https://user-images.githubusercontent.com/876340/153066117-ad8335d7-4a5d-4f1c-a5d6-402397087d75.png">

