### PR TITLE
Fix PHP Warning when exporting questions without wrong answers

### DIFF
--- a/includes/data-port/export-tasks/class-sensei-export-questions.php
+++ b/includes/data-port/export-tasks/class-sensei-export-questions.php
@@ -111,7 +111,7 @@ class Sensei_Export_Questions
 		switch ( $question_type ) {
 			case 'multiple-choice':
 				$answers_right = Sensei()->question->get_answers_by_id( (array) $meta['_question_right_answer'] );
-				$answers_wrong = Sensei()->question->get_answers_by_id( $meta['_question_wrong_answers'] );
+				$answers_wrong = Sensei()->question->get_answers_by_id( (array) $meta['_question_wrong_answers'] );
 
 				$answers_right = array_map(
 					function( $value ) {


### PR DESCRIPTION
This fixes the issue reported in #4688, which emitted a warning when exporting questions.

The technical details are here: When there's no wrong answer for a multiple-choice question, the `$meta['_question_wrong_answers']` will have an empty string, which isn't iterable by `foreach`. This is what causes the warning on the code. So by typecasting the value to an array, we can properly avoid the warning while maintaining the code functionality.

Fixes #4688

### Changes proposed in this Pull Request

* Type-cast the `$meta['_question_wrong_answers']` to an array, so fixing the warning when there are no wrong answers;

### Testing instructions

* Create some questions (possibly multiple-choice questions, but you may want to test with other questions too). Add some answers for some but not for others.
* Go to Tools.
* Click on Visit Tool in the Export Content row.
* Select Questions and click Continue.
* Check if there are no PHP warnings on the debug logs; 

The warning this change fix is this one:

 ```
[08-Feb-2022 20:10:09 UTC] PHP Warning:  Invalid argument supplied for foreach() in /var/www/html/wp-content/plugins/sensei/includes/class-sensei-question.php on line 1505
```

Which matches the warning that the original issue reported, [specially considering the changes on that file since when that issue was reported](https://github.com/Automattic/sensei/compare/f88f327ab139dc44ec1f036662886c087d3e7f91..master#diff-3486c06ef1c37a423c0b733774e415315237355acdc2c495352576daec34978d).

