### PR TITLE
Fix the URL for the "Manage students" link

### DIFF
--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -691,7 +691,6 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 							add_query_arg(
 								array(
 									'post_type' => $this->menu_post_type,
-									'post_type' => $this->post_type,
 									'page'      => $this->page_slug,
 									'lesson_id' => $item->ID,
 									'course_id' => $this->course_id,


### PR DESCRIPTION
Fixes #4787

### Changes proposed in this Pull Request

* Remove the usage of non-existing property that resulted in omitting of the `post_type` parameter in the link.

### Testing instructions

* Go to Student Management.
* Click Manage students.
* Click Lessons.
* Click Manage students again.
* No errors. You can see the list of students for the lesson.

### Screenshot / Video

https://user-images.githubusercontent.com/329356/153217926-324267c9-d58b-4509-812b-43af8e572f74.mp4


