### PR TITLE
Fix CSV importing on PHP 8

### DIFF
--- a/includes/data-port/class-sensei-import-csv-reader.php
+++ b/includes/data-port/class-sensei-import-csv-reader.php
@@ -149,8 +149,8 @@ class Sensei_Import_CSV_Reader {
 			$second_line         = $this->file->current();
 			$second_line_columns = count( $second_line );
 
-			// SplFileObject->current() returns [ 0 => null ] on empty lines, or false, on PHP 8.
-			if ( false === $second_line || ( 1 === $second_line_columns && empty( $second_line[0] ) ) ) {
+			// SplFileObject->current() returns [ 0 => null ] on empty lines.
+			if ( 1 === $second_line_columns && empty( $second_line[0] ) ) {
 				$this->file->next();
 				continue;
 			}
@@ -199,8 +199,8 @@ class Sensei_Import_CSV_Reader {
 
 			$indexed_line = $this->file->current();
 
-			// SplFileObject->current() returns [ 0 => null ] on empty lines, or false, in PHP 8.
-			if ( false !== $indexed_line && ( 1 < count( $indexed_line ) || ( 1 === count( $indexed_line ) && ! empty( $indexed_line[0] ) ) ) ) {
+			// SplFileObject->current() returns [ 0 => null ] on empty lines.
+			if ( 1 < count( $indexed_line ) || ( 1 === count( $indexed_line ) && ! empty( $indexed_line[0] ) ) ) {
 
 				if ( count( $indexed_line ) !== count( $columns ) ) {
 					$lines[] = new WP_Error(

--- a/includes/data-port/class-sensei-import-csv-reader.php
+++ b/includes/data-port/class-sensei-import-csv-reader.php
@@ -59,14 +59,21 @@ class Sensei_Import_CSV_Reader {
 	 */
 	public function __construct( $csv_file, $completed_lines = 0, $lines_per_batch = 30 ) {
 		$this->file = new SplFileObject( $csv_file );
-		$this->file->seek( PHP_INT_MAX );
-
-		// In PHP 8.0+ the SplFileObject::key() method works differently,
-		// so the total lines should be calculated before setting the CSV flag.
-		$this->total_lines = $this->file->key();
-
-		$this->file->setFlags( SplFileObject::READ_CSV );
+		// SplFileObject::READ_AHEAD is absolutely required for iterator_count to work, otherwise it blocks in an
+		// internal infinite loop. See: https://bugs.php.net/bug.php?id=63616 - this bug is totally avoided by using
+		// SplFileObject::READ_AHEAD.
+		$this->file->setFlags( SplFileObject::READ_CSV | SplFileObject::READ_AHEAD );
 		$this->detect_delimiter();
+
+		// In PHP 8.0+ SplFileObject::key() doesn't work in the same way as the SplFileObject::key() in PHP 7.x,
+		// so we need to use iterator_count instead to count the total number of lines in the file.
+		// Also note that, as iterator_count calls SplFileObject::rewind() on $this->file, we need to subtract 1 to
+		// ignore the header line and have the same result as SplFileObject::key() in PHP 7.0.
+		$this->total_lines = iterator_count( $this->file ) - 1;
+
+		// After computing the total number of lines in the file, we reset the flags to remove the
+		// SplFileObject:READ_AHEAD, which breaks our code.
+		$this->file->setFlags( SplFileObject::READ_CSV );
 
 		$this->completed_lines = $completed_lines;
 		$this->is_completed    = $this->completed_lines >= $this->total_lines;

--- a/includes/data-port/class-sensei-import-csv-reader.php
+++ b/includes/data-port/class-sensei-import-csv-reader.php
@@ -142,8 +142,8 @@ class Sensei_Import_CSV_Reader {
 			$second_line         = $this->file->current();
 			$second_line_columns = count( $second_line );
 
-			// SplFileObject->current() returns [ 0 => null ] on empty lines.
-			if ( 1 === $second_line_columns && empty( $second_line[0] ) ) {
+			// SplFileObject->current() returns [ 0 => null ] on empty lines, or false, on PHP 8.
+			if ( false === $second_line || ( 1 === $second_line_columns && empty( $second_line[0] ) ) ) {
 				$this->file->next();
 				continue;
 			}
@@ -192,8 +192,8 @@ class Sensei_Import_CSV_Reader {
 
 			$indexed_line = $this->file->current();
 
-			// SplFileObject->current() returns [ 0 => null ] on empty lines.
-			if ( 1 < count( $indexed_line ) || ( 1 === count( $indexed_line ) && ! empty( $indexed_line[0] ) ) ) {
+			// SplFileObject->current() returns [ 0 => null ] on empty lines, or false, in PHP 8.
+			if ( false !== $indexed_line && ( 1 < count( $indexed_line ) || ( 1 === count( $indexed_line ) && ! empty( $indexed_line[0] ) ) ) ) {
 
 				if ( count( $indexed_line ) !== count( $columns ) ) {
 					$lines[] = new WP_Error(


### PR DESCRIPTION
Previously, CSV importing on PHP 8 failed because the uploaded file was always detected as being empty. However, after #4770, this was "fixed", but the line count computed was way too big compared to the real number of lines inside the file. This fixes the total line count computed by using `iterator_count()` to count the number of lines inside the file.

Fixes #4725

### Changes proposed in this Pull Request

* Use a different way of computing the total line count, by using `iterator_count()` instead of `SplFileObject::key()`;

### Testing instructions

* Install Sensei;
* On the final page of the Setup Wizard (which you can see via the URL `/wp-admin/admin.php?page=sensei_setup_wizard&step=ready`), with the title "You're ready to start creating online courses!", click on the "Install a Sample course" button;
*  The file should be imported successfully;