### PR TITLE
Update `package-lock.json`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37802,30 +37802,34 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -37833,15 +37837,17 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -37849,66 +37855,75 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -37918,24 +37933,27 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -37949,9 +37967,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -37969,15 +37988,17 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -37987,18 +38008,20 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -38006,24 +38029,27 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -38033,15 +38059,17 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -38051,15 +38079,17 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minimist": {
       "version": "1.2.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -38067,9 +38097,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
@@ -38077,9 +38108,10 @@
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.3",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -38089,15 +38121,17 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/needle": {
       "version": "2.3.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -38112,9 +38146,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -38133,9 +38168,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -38146,24 +38182,27 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.8",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -38172,9 +38211,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -38184,54 +38224,60 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -38239,24 +38285,27 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -38269,9 +38318,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.7",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -38284,9 +38334,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -38296,57 +38347,65 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -38358,9 +38417,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -38370,18 +38430,20 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -38397,30 +38459,34 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
-      "extraneous": true,
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/graceful-fs": {
       "version": "4.2.3",
@@ -88706,22 +88772,26 @@
             "abbrev": {
               "version": "1.1.1",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -88730,12 +88800,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -88744,32 +88816,38 @@
             "chownr": {
               "version": "1.1.4",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "debug": {
               "version": "3.2.6",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "^2.1.1"
               }
@@ -88777,22 +88855,26 @@
             "deep-extend": {
               "version": "0.6.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "delegates": {
               "version": "1.0.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "fs-minipass": {
               "version": "1.2.7",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minipass": "^2.6.0"
               }
@@ -88800,12 +88882,14 @@
             "fs.realpath": {
               "version": "1.0.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "gauge": {
               "version": "2.7.4",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -88820,7 +88904,8 @@
             "glob": {
               "version": "7.1.6",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -88833,12 +88918,14 @@
             "has-unicode": {
               "version": "2.0.1",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
               }
@@ -88846,7 +88933,8 @@
             "ignore-walk": {
               "version": "3.0.3",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minimatch": "^3.0.4"
               }
@@ -88854,7 +88942,8 @@
             "inflight": {
               "version": "1.0.6",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -88863,17 +88952,20 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -88881,12 +88973,14 @@
             "isarray": {
               "version": "1.0.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -88894,12 +88988,14 @@
             "minimist": {
               "version": "1.2.5",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -88908,7 +89004,8 @@
             "minizlib": {
               "version": "1.3.3",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minipass": "^2.9.0"
               }
@@ -88916,7 +89013,8 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
@@ -88924,12 +89022,14 @@
             "ms": {
               "version": "2.1.2",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "needle": {
               "version": "2.3.3",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "debug": "^3.2.6",
                 "iconv-lite": "^0.4.4",
@@ -88939,7 +89039,8 @@
             "node-pre-gyp": {
               "version": "0.14.0",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "detect-libc": "^1.0.2",
                 "mkdirp": "^0.5.1",
@@ -88956,7 +89057,8 @@
             "nopt": {
               "version": "4.0.3",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "abbrev": "1",
                 "osenv": "^0.1.4"
@@ -88965,7 +89067,8 @@
             "npm-bundled": {
               "version": "1.1.1",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "npm-normalize-package-bin": "^1.0.1"
               }
@@ -88973,12 +89076,14 @@
             "npm-normalize-package-bin": {
               "version": "1.0.1",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "npm-packlist": {
               "version": "1.4.8",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ignore-walk": "^3.0.1",
                 "npm-bundled": "^1.0.1",
@@ -88988,7 +89093,8 @@
             "npmlog": {
               "version": "4.1.2",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -88999,17 +89105,20 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "once": {
               "version": "1.4.0",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -89017,17 +89126,20 @@
             "os-homedir": {
               "version": "1.0.2",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "osenv": {
               "version": "0.1.5",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
@@ -89036,17 +89148,20 @@
             "path-is-absolute": {
               "version": "1.0.1",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.1",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "rc": {
               "version": "1.2.8",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -89057,7 +89172,8 @@
             "readable-stream": {
               "version": "2.3.7",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -89071,7 +89187,8 @@
             "rimraf": {
               "version": "2.7.1",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "glob": "^7.1.3"
               }
@@ -89079,37 +89196,44 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "sax": {
               "version": "1.2.4",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "semver": {
               "version": "5.7.1",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -89117,7 +89241,8 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -89127,7 +89252,8 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -89135,12 +89261,14 @@
             "strip-json-comments": {
               "version": "2.0.1",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "tar": {
               "version": "4.4.13",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "chownr": "^1.1.1",
                 "fs-minipass": "^1.2.5",
@@ -89154,12 +89282,14 @@
             "util-deprecate": {
               "version": "1.0.2",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
               "bundled": true,
-              "extraneous": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "string-width": "^1.0.2 || 2"
               }
@@ -89167,12 +89297,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "extraneous": true
+              "dev": true,
+              "optional": true
             }
           }
         },


### PR DESCRIPTION
### Changes proposed in this Pull Request

Deleting `node_modules` and running `npm install` with the latest npm version will rewrite the `package-lock.json`. This PR makes `package-lock.json` compatible with the latest npm version.  

### Testing instructions

* Delete `node_modules`.
* Run `npm install`.
* Make sure the `package-lock.json` is unchanged.