### PR TITLE
Redirect logged-out user to the course after login when clicking on Take Course button in the Course page

### DIFF
--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -130,8 +130,11 @@ class Sensei_Block_Take_Course {
 	private function render_with_login( $content ) {
 		$target = sensei_user_registration_url();
 
+		$course_url = add_query_arg( 'take_course_sign_in', '1', get_permalink() );
+
 		return ( '
 			<form method="GET" action="' . esc_url( $target ) . '">
+			<input type="hidden" name="redirect_to" value="' . esc_url_raw( $course_url ) . '" />
 			' . $content . '
 			</form>
 			' );


### PR DESCRIPTION
Fixes #4780

### Changes proposed in this Pull Request

* Similar to the behavior we have in the Learning Mode lesson notifications, when a logged-out user clicks on "Take Course", we send them to the login, then after the login, we redirect them to the course where they clicked on "Take Course"

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course.
* Logged-out, access the course page.
* Click on Take Course button.
* Login, and make sure you're redirected to the course page with the button "Start course".

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/153291944-71f842e9-978c-4dd6-ac1e-9cac415b5df2.mov

