### PR TITLE
Update Take course button from lesson notices to redirect to course

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -240,10 +240,6 @@ class Sensei_Course_Theme_Lesson {
 		if ( ! is_user_logged_in() ) {
 			$user_can_register = get_option( 'users_can_register' );
 
-			// Take course URL.
-			$course_url      = add_query_arg( 'take_course_sign_in', '1', get_permalink( $course_id ) );
-			$take_course_url = $user_can_register ? sensei_user_registration_url( true, $course_url ) : sensei_user_login_url( $course_url );
-
 			// Sign in URL.
 			$current_link = get_permalink();
 			$sign_in_url  = $user_can_register ? sensei_user_registration_url( true, $current_link ) : sensei_user_login_url( $current_link );
@@ -251,7 +247,7 @@ class Sensei_Course_Theme_Lesson {
 			$actions = [
 				[
 					'label' => __( 'Take course', 'sensei-lms' ),
-					'url'   => $take_course_url,
+					'url'   => get_permalink( $course_id ),
 					'style' => 'primary',
 				],
 				[


### PR DESCRIPTION
Fixes #4771

### Changes proposed in this Pull Request

* It updates the "Take course" button from lesson notices in Learning Mode to redirect to the course instead of sending the student to the login.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course with a lesson.
* Logged-out, access the lesson, and click on "Take course".
* Make sure you're redirected to the course page instead of the login page.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/153297110-78711764-0da4-440a-bc61-b25991544e61.mov


