### PR TITLE
Add optional 'style' option for admin notices

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -63,6 +63,18 @@ $sensei-notice-icon-width: 30px;
 		padding: 0;
 		position: static;
 	}
+
+	&.sensei-notice-error {
+		border-left-color: $notice-error;
+	}
+
+	&.sensei-notice-warning {
+		border-left-color: $notice-warning;
+	}
+
+	&.sensei-notice-info {
+		border-left-color: $notice-info;
+	}
 }
 
 /*  Sensei Icon Font */

--- a/assets/shared/styles/_variables.scss
+++ b/assets/shared/styles/_variables.scss
@@ -24,6 +24,10 @@ $white: #ffffff;
 
 $alert-red: #d94f4f;
 
+$notice-error: #d63638;
+$notice-warning: #dba617;
+$notice-info: #72aee6;
+
 $gap-largest: 40px;
 $gap-larger: 36px;
 $gap-large: 24px;

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -168,10 +168,15 @@ class Sensei_Admin_Notices {
 			$notice['actions'] = [];
 		}
 
+		$notice_class = '';
+		if ( ! empty( $notice['style'] ) ) {
+			$notice_class = 'sensei-notice-' . $notice['style'];
+		}
+
 		wp_enqueue_script( 'sensei-dismiss-notices' );
 
 		?>
-		<div class="notice sensei-notice is-dismissible" data-dismiss-action="sensei_dismiss_notice" data-dismiss-notice="<?php echo esc_attr( $notice_id ); ?>"
+		<div class="notice sensei-notice <?php echo esc_attr( $notice_class ); ?> is-dismissible" data-dismiss-action="sensei_dismiss_notice" data-dismiss-notice="<?php echo esc_attr( $notice_id ); ?>"
 				data-dismiss-nonce="<?php echo esc_attr( wp_create_nonce( self::DISMISS_NOTICE_NONCE_ACTION ) ); ?>">
 			<?php
 			if ( ! empty( $notice['icon'] ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

Adds an option `style` option for admin notices, which sets the colour of the left border. Options are:

- error (red)
- warning (yellow)
- info (blue)

If no style is given, the default Sensei green is used. The red, yellow, and blue colours were taken from the WordPress notices.

Examples:

<img width="1424" alt="Screen Shot 2022-02-10 at 16 07 32" src="https://user-images.githubusercontent.com/842193/153488144-b40796f3-2fc3-405f-9bca-18ab572a6dc4.png">

Also see https://github.com/Automattic/sensei-wc-paid-courses/pull/784 for a real-world usage example.

### Testing instructions

Add the following code snippet. Open any Sensei page in WP Admin to see the notices.

```php
add_filter( 'sensei_admin_notices', function( $notices ) {
	$notices['test-default'] = [
		'type'       => 'user',
		'icon'       => 'sensei',
		'heading'    => 'Test Default Notice',
		'message'    => 'This is a default notice.',
	];
	
	$notices['test-error'] = [
		'type'       => 'user',
		'icon'       => 'sensei',
		'style'      => 'error',
		'heading'    => 'Test Error Notice',
		'message'    => 'This is an error notice.',
	];
	
	$notices['test-warning'] = [
		'type'       => 'user',
		'icon'       => 'sensei',
		'style'      => 'warning',
		'heading'    => 'Test Warning Notice',
		'message'    => 'This is a warning notice.',
	];
	
	$notices['test-info'] = [
		'type'       => 'user',
		'icon'       => 'sensei',
		'style'      => 'info',
		'heading'    => 'Test Info Notice',
		'message'    => 'This is an info notice.',
	];

	return $notices;
} );
```