### PR TITLE
Fix JavaScript Error on the grading page

### DIFF
--- a/assets/js/grading-general.js
+++ b/assets/js/grading-general.js
@@ -120,8 +120,8 @@ jQuery( document ).ready( function ( $ ) {
 					correct_answer = $this.find( '.correct-answer' ).html();
 				}
 
-				user_answer = $.trim( user_answer );
-				correct_answer = $.trim( correct_answer );
+				user_answer = user_answer.trim();
+				correct_answer = correct_answer.trim();
 
 				// Auto-grading
 				if ( $this.hasClass( 'auto-grade' ) ) {

--- a/assets/js/grading-general.js
+++ b/assets/js/grading-general.js
@@ -204,6 +204,9 @@ jQuery( document ).ready( function ( $ ) {
 		$.fn.updateFeedback();
 	};
 
+	// Calculate total grade on page load to make sure everything is set up correctly
+	jQuery.fn.autoGrade();
+
 	/**
 	 * Resets all graded questions.
 	 */

--- a/includes/class-sensei-grading-user-quiz.php
+++ b/includes/class-sensei-grading-user-quiz.php
@@ -383,12 +383,6 @@ class Sensei_Grading_User_Quiz {
 				<input type="button" value="<?php esc_attr_e( 'Reset', 'sensei-lms' ); ?>" class="reset-button button-link button-link-delete" title="Resets all questions to ungraded and total grade to 0" />
 			</div>
 			<div class="clear"></div>
-			<script type="text/javascript">
-				jQuery( window ).on( 'load', function() {
-					// Calculate total grade on page load to make sure everything is set up correctly
-					jQuery.fn.autoGrade();
-				});
-			</script>
 		</form>
 		<?php
 	}


### PR DESCRIPTION
Fixes #4715 

### Changes proposed in this Pull Request

* Move the call to the function `jQuery.fn.autoGrade();` to inside the script that defines it so the function is always defined when that function is called; (instead of depending on the loading of the script)
* Also fixes a small warning that jQuery Migrate was emitting about a deprecated jQuery function;

### Testing instructions

* Add a multiple choice question to a quiz.
* Take the quiz as a student.
* Find the quiz and click the Grade quiz button.
* Repeat that process a few times to guarantee that no error is happening;