### PR TITLE
Fix widgets editor style for Sensei theme blocks

### DIFF
--- a/assets/course-theme/blocks/course-navigation.js
+++ b/assets/course-theme/blocks/course-navigation.js
@@ -79,17 +79,17 @@ const Module = ( { title, lessons } ) => (
 	<section className="sensei-lms-course-navigation-module sensei-collapsible">
 		<header className="sensei-lms-course-navigation-module__header">
 			<div className="sensei-collapsible__toggle">
-				<h2 className="sensei-lms-course-navigation-module__title">
+				<div className="sensei-lms-course-navigation-module__title">
 					{ title }
-				</h2>
+				</div>
 				<ChevronUp className="sensei-lms-course-navigation-module__collapsible-icon" />
 			</div>
 		</header>
-		<div className="sensei-lms-course-navigation-module__lessons sensei-collapsible__content">
+		<ol className="sensei-lms-course-navigation-module__lessons sensei-collapsible__content">
 			{ lessons.map( ( lesson ) => (
 				<Lesson { ...lesson } key={ lesson.title } />
 			) ) }
-		</div>
+		</ol>
 		<div className="sensei-lms-course-navigation-module__summary">
 			{ __( '2 lessons, 0 quizzes', 'sensei-lms' ) }
 		</div>
@@ -107,7 +107,7 @@ const Module = ( { title, lessons } ) => (
 const Lesson = ( { title, quiz, status } ) => {
 	const StatusIcon = ICONS[ status ];
 	return (
-		<div
+		<li
 			className={ `sensei-lms-course-navigation-lesson status-${ status }` }
 		>
 			<span className="sensei-lms-course-navigation-lesson__link">
@@ -121,7 +121,7 @@ const Lesson = ( { title, quiz, status } ) => {
 					{ __( 'Quiz', 'sensei-lms' ) }
 				</span>
 			) }
-		</div>
+		</li>
 	);
 };
 

--- a/assets/css/learning-mode.scss
+++ b/assets/css/learning-mode.scss
@@ -4,6 +4,7 @@
 @import 'sensei-course-theme/buttons';
 @import 'sensei-course-theme/quiz';
 @import 'sensei-course-theme/notices';
+@import 'sensei-theme-blocks';
 @import 'sensei-course-theme/course-progress-bar';
 @import 'sensei-course-theme/lesson-complete-transition';
 @import 'sensei-course-theme/contact-teacher';

--- a/assets/css/learning-mode.scss
+++ b/assets/css/learning-mode.scss
@@ -4,7 +4,6 @@
 @import 'sensei-course-theme/buttons';
 @import 'sensei-course-theme/quiz';
 @import 'sensei-course-theme/notices';
-@import 'sensei-theme-blocks';
 @import 'sensei-course-theme/course-progress-bar';
 @import 'sensei-course-theme/lesson-complete-transition';
 @import 'sensei-course-theme/contact-teacher';

--- a/assets/css/sensei-course-theme/course-navigation.scss
+++ b/assets/css/sensei-course-theme/course-navigation.scss
@@ -1,6 +1,7 @@
 @import '../../shared/styles/collapsible-content';
 
 
+.editor-styles-wrapper .sensei-lms-course-navigation,
 .sensei-lms-course-navigation {
 	&__modules, &__lessons, &-module__lessons {
 		&, li {

--- a/assets/css/sensei-theme-blocks.scss
+++ b/assets/css/sensei-theme-blocks.scss
@@ -1,6 +1,13 @@
 @mixin text-gray() {
 	opacity: 0.7;
 }
+
+// It's a hack to allow including this file in the editor canvas.
+// See https://github.com/WordPress/gutenberg/blob/e54a9ec2f97e28db3293628e921e40e81cfe5f76/packages/block-editor/src/components/iframe/index.js#L47.
+.wp-block-hack-to-include-css-in-canvas {
+	background: transparent;
+}
+
 @import 'sensei-course-theme/modal';
 @import 'sensei-course-theme/prev-next-lesson';
 @import 'sensei-course-theme/course-navigation';

--- a/assets/css/sensei-theme-blocks.scss
+++ b/assets/css/sensei-theme-blocks.scss
@@ -2,12 +2,6 @@
 	opacity: 0.7;
 }
 
-// It's a hack to allow including this file in the editor canvas.
-// See https://github.com/WordPress/gutenberg/blob/e54a9ec2f97e28db3293628e921e40e81cfe5f76/packages/block-editor/src/components/iframe/index.js#L47.
-.wp-block-hack-to-include-css-in-canvas {
-	background: transparent;
-}
-
 @import 'sensei-course-theme/modal';
 @import 'sensei-course-theme/prev-next-lesson';
 @import 'sensei-course-theme/course-navigation';

--- a/includes/blocks/class-sensei-blocks-initializer.php
+++ b/includes/blocks/class-sensei-blocks-initializer.php
@@ -53,8 +53,14 @@ abstract class Sensei_Blocks_Initializer {
 		if ( is_admin() ) {
 			$screen = get_current_screen();
 
+			if ( empty( $screen ) ) {
+				return;
+			}
+
+			$is_editor = $screen->is_block_editor || in_array( $screen->id, [ 'widgets', 'site-editor' ], true );
+
 			// Init blocks.
-			if ( null === $screen || ! $screen->is_block_editor || ! $this->is_post_type_included( $screen->post_type ) ) {
+			if ( ! $is_editor || ! $this->is_post_type_included( $screen->post_type ) ) {
 				return;
 			}
 		} elseif ( ! $this->is_post_type_included( get_post_type() ) ) {

--- a/includes/blocks/class-sensei-blocks-initializer.php
+++ b/includes/blocks/class-sensei-blocks-initializer.php
@@ -57,7 +57,7 @@ abstract class Sensei_Blocks_Initializer {
 				return;
 			}
 
-			$is_editor = $screen->is_block_editor || in_array( $screen->id, [ 'widgets', 'site-editor' ], true );
+			$is_editor = $screen->is_block_editor || in_array( $screen->id, [ 'widgets', 'site-editor', 'appearance_page_gutenberg-edit-site' ], true );
 
 			// Init blocks.
 			if ( ! $is_editor || ! $this->is_post_type_included( $screen->post_type ) ) {

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -81,7 +81,7 @@ class Sensei_Blocks {
 		Sensei()->assets->register( 'sensei-editor-components-style', 'blocks/editor-components/editor-components-style.css' );
 
 		Sensei()->assets->register( 'sensei-blocks-frontend', 'blocks/frontend.js', [], true );
-		Sensei()->assets->register( 'sensei-theme-blocks', 'css/sensei-theme-blocks.css', [] );
+		Sensei()->assets->register( 'sensei-theme-blocks', 'css/sensei-theme-blocks.css' );
 	}
 
 	/**

--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -169,8 +169,8 @@ class Sensei_Course_Theme_Editor {
 	 */
 	public function add_editor_styles() {
 
-		add_editor_style( Sensei()->assets->asset_url( 'css/sensei-course-theme.css' ) );
-		add_editor_style( Sensei()->assets->asset_url( 'css/sensei-course-theme.editor.css' ) );
+		add_editor_style( Sensei()->assets->asset_url( 'css/learning-mode.css' ) );
+		add_editor_style( Sensei()->assets->asset_url( 'css/learning-mode.editor.css' ) );
 		add_editor_style( Sensei()->assets->asset_url( 'css/frontend.css' ) );
 
 	}

--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -153,13 +153,18 @@ class Sensei_Course_Theme_Editor {
 
 		if ( $this->lesson_has_course_theme() || $this->is_site_editor() ) {
 			Sensei()->assets->enqueue( Sensei_Course_Theme::THEME_NAME . '-blocks', 'course-theme/blocks/blocks.js', [ 'sensei-shared-blocks' ] );
-			Sensei()->assets->enqueue_style( 'sensei-theme-blocks' );
 			Sensei()->assets->enqueue_style( 'sensei-shared-blocks-editor-style' );
 			Sensei_Course_Theme::instance()->enqueue_fonts();
 
 			if ( Sensei_Course_Theme_Option::should_override_theme() ) {
 				Sensei()->assets->enqueue( Sensei_Course_Theme::THEME_NAME . '-editor', 'course-theme/course-theme.editor.js' );
 			}
+		}
+
+		$screen = get_current_screen();
+
+		if ( ! empty( $screen ) && 'widgets' === $screen->id ) {
+			Sensei()->assets->enqueue_style( 'sensei-theme-blocks' );
 		}
 	}
 

--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -160,12 +160,6 @@ class Sensei_Course_Theme_Editor {
 				Sensei()->assets->enqueue( Sensei_Course_Theme::THEME_NAME . '-editor', 'course-theme/course-theme.editor.js' );
 			}
 		}
-
-		$screen = get_current_screen();
-
-		if ( ! empty( $screen ) && 'widgets' === $screen->id ) {
-			Sensei()->assets->enqueue_style( 'sensei-theme-blocks' );
-		}
 	}
 
 	/**

--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -153,6 +153,7 @@ class Sensei_Course_Theme_Editor {
 
 		if ( $this->lesson_has_course_theme() || $this->is_site_editor() ) {
 			Sensei()->assets->enqueue( Sensei_Course_Theme::THEME_NAME . '-blocks', 'course-theme/blocks/blocks.js', [ 'sensei-shared-blocks' ] );
+			Sensei()->assets->enqueue_style( 'sensei-theme-blocks' );
 			Sensei()->assets->enqueue_style( 'sensei-shared-blocks-editor-style' );
 			Sensei_Course_Theme::instance()->enqueue_fonts();
 


### PR DESCRIPTION
Fixes #4777
Based on #4775

### Changes proposed in this Pull Request

* It fixes the widgets editor styles for the Sensei blocks.
  * Basically, the solution was to include the `sensei-theme-blocks` along with the JS part, and remove these styles from the `learning-mode` bundle.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Edit the course theme template in the template Editor, edit the template in the lesson page, add it as widget, and make sure every place loads the styles properly.
* Also, create a course with learning mode, and make sure it works properly in the frontend.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="1022" alt="Screen Shot 2022-02-11 at 12 41 39" src="https://user-images.githubusercontent.com/876340/153622720-3f2fc12a-9101-4196-bbbd-c9de44cd6576.png">
