### PR TITLE
Move the Course Completed page to Trash when uninstalling the plugin

### DIFF
--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -363,6 +363,12 @@ class Sensei_Data_Cleaner {
 		if ( $my_courses_page_id ) {
 			wp_trash_post( $my_courses_page_id );
 		}
+
+		// Trash the Course Completed page.
+		$course_completed_page_id = $settings->get( 'course_completed_page' );
+		if ( $course_completed_page_id ) {
+			wp_trash_post( $course_completed_page_id );
+		}
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-data-cleaner.php
+++ b/tests/unit-tests/test-class-sensei-data-cleaner.php
@@ -16,6 +16,7 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 	private $regular_page_ids;
 	private $course_archive_page_id;
 	private $my_courses_page_id;
+	private $course_completed_page_id;
 
 	// Taxonomies.
 	private $modules;
@@ -205,6 +206,15 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 		);
 		Sensei()->settings->set( 'my_course_page', $this->my_courses_page_id );
 
+		// Create the Course Completed page.
+		$this->course_completed_page_id = $this->factory->post->create(
+			array(
+				'post_type'  => 'page',
+				'post_title' => 'Course Completed',
+			)
+		);
+		Sensei()->settings->set( 'course_completed_page', $this->course_completed_page_id );
+
 		// Refresh the Sensei settings in memory.
 		Sensei()->settings->get_settings();
 	}
@@ -316,6 +326,7 @@ class Sensei_Data_Cleaner_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 'trash', get_post_status( $this->course_archive_page_id ), 'Course Archive page should be trashed' );
 		$this->assertEquals( 'trash', get_post_status( $this->my_courses_page_id ), 'My Courses page should be trashed' );
+		$this->assertEquals( 'trash', get_post_status( $this->course_completed_page_id ), 'Course Completed page should be trashed' );
 
 		foreach ( $this->regular_page_ids as $page_id ) {
 			$this->assertNotEquals( 'trash', get_post_status( $page_id ), 'Regular page should not be trashed' );


### PR DESCRIPTION
Fixes #4710

### Changes proposed in this Pull Request

* Move Course Completed page to Trash when uninstalling the plugin;
* Change tests to verify if the Course Completed page is being moved to Trash when running the uninstaller's methods;

### Testing instructions

* Setup Sensei LMS with all the pages (course archive, my courses and course completed) published and correctly configured at Sensei;
* Go to Sensei LMS > Settings;
* Check Delete data on uninstall;
* Deactivate Sensei LMS;
* Delete Sensei LMS; (PS: make sure to backup the repository before this step!)
* Verify if all the pages are indeed moved to Trash;

