### PR TITLE
Add Ordering promo question type

### DIFF
--- a/assets/blocks/quiz/ordering-promo/index.js
+++ b/assets/blocks/quiz/ordering-promo/index.js
@@ -32,10 +32,11 @@ function addPromoLink( children, option ) {
 	if ( option.value !== 'ordering' ) {
 		return children;
 	}
+
 	return (
 		<div className="sensei-lms-question-block__type-selector__option__container--disabled">
 			<strong> { option.title }</strong>
-			<div className="sensei-lms-question-block__type-selector__option__description--disabled">
+			<div className="sensei-lms-question-block__type-selector__option__description sensei-lms-question-block__type-selector__option__description--disabled">
 				{ option.description }
 			</div>
 			<ExternalLink href={ PROMO_LINK }>

--- a/assets/blocks/quiz/ordering-promo/index.js
+++ b/assets/blocks/quiz/ordering-promo/index.js
@@ -3,60 +3,50 @@
  */
 import { __ } from '@wordpress/i18n';
 import { addFilter } from '@wordpress/hooks';
+import { ExternalLink } from '@wordpress/components';
 
-/**
- * @typedef QuestionType
- *
- * @property {string}   title          Question type name.
- * @property {string}   description    Question type description.
- * @property {Function} edit           Editor component.
- * @property {Function} save           Renderer component.
- * @property {Function} renderMenuItem Renders the question type in the toolbars' menu.
- */
-/**
- * Question type definitions.
- *
- * @type {Object.<string, QuestionType>}
- */
-const questionTypes = {
-	ordering: {
+const PROMO_LINK =
+	'https://senseilms.com/pricing/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=quiz_ordering_question_type';
+
+function addOrderingPromoOption( options ) {
+	options.push( {
 		title: __( 'Ordering', 'sensei-lms' ),
 		description: __(
 			'Place the answers in the correct order.',
 			'sensei-lms'
 		),
-		edit: null,
-		view: null,
-		settings: [],
-		renderMenuItem: () => (
-			<div>
-				<strong> { __( 'Ordering', 'sensei-lms' ) }</strong>
-				<div className="sensei-lms-question-block__type-selector__option__description">
-					{ __(
-						'Place the answers in the correct order.',
-						'sensei-lms'
-					) }
-				</div>
-				<div>
-					<a href="https://senseilms.com/pricing/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=quiz_ordering_question_type">
-						{ __( 'Upgrade to Sensei Pro', 'sensei-lms' ) }
-					</a>
-				</div>
-			</div>
-		),
+		label: __( 'Ordering', 'sensei-lms' ),
+		value: 'ordering',
 		disabled: true,
-	},
-};
-
-function addOrderingQuestionType( existingQuestionTypes ) {
-	return {
-		...existingQuestionTypes,
-		...questionTypes,
-	};
+	} );
+	return options;
 }
 
 addFilter(
-	'sensei-lms.Question.questionTypes',
-	'sensei-lms/ordering-question-type',
-	addOrderingQuestionType
+	'senseiQuestionTypeToolbarOptions',
+	'sensei-lms/ordering-promo',
+	addOrderingPromoOption
+);
+
+function addPromoLink( children, option ) {
+	if ( option.value !== 'ordering' ) {
+		return children;
+	}
+	return (
+		<div className="sensei-lms-question-block__type-selector__option__container--disabled">
+			<strong> { option.title }</strong>
+			<div className="sensei-lms-question-block__type-selector__option__description--disabled">
+				{ option.description }
+			</div>
+			<ExternalLink href={ PROMO_LINK }>
+				{ __( 'Upgrade to Sensei Pro', 'sensei-lms' ) }
+			</ExternalLink>
+		</div>
+	);
+}
+
+addFilter(
+	'senseiQuestionTypeToolbarOptionChildren',
+	'sensei-lms/ordering-promo',
+	addPromoLink
 );

--- a/assets/blocks/quiz/ordering-promo/index.js
+++ b/assets/blocks/quiz/ordering-promo/index.js
@@ -1,0 +1,62 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { addFilter } from '@wordpress/hooks';
+
+/**
+ * @typedef QuestionType
+ *
+ * @property {string}   title          Question type name.
+ * @property {string}   description    Question type description.
+ * @property {Function} edit           Editor component.
+ * @property {Function} save           Renderer component.
+ * @property {Function} renderMenuItem Renders the question type in the toolbars' menu.
+ */
+/**
+ * Question type definitions.
+ *
+ * @type {Object.<string, QuestionType>}
+ */
+const questionTypes = {
+	ordering: {
+		title: __( 'Ordering', 'sensei-lms' ),
+		description: __(
+			'Place the answers in the correct order.',
+			'sensei-lms'
+		),
+		edit: null,
+		view: null,
+		settings: [],
+		renderMenuItem: () => (
+			<div>
+				<strong> { __( 'Ordering', 'sensei-lms' ) }</strong>
+				<div className="sensei-lms-question-block__type-selector__option__description">
+					{ __(
+						'Place the answers in the correct order.',
+						'sensei-lms'
+					) }
+				</div>
+				<div>
+					<a href="https://senseilms.com/pricing/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=quiz_ordering_question_type">
+						{ __( 'Upgrade to Sensei Pro', 'sensei-lms' ) }
+					</a>
+				</div>
+			</div>
+		),
+		disabled: true,
+	},
+};
+
+function addOrderingQuestionType( existingQuestionTypes ) {
+	return {
+		...existingQuestionTypes,
+		...questionTypes,
+	};
+}
+
+addFilter(
+	'sensei-lms.Question.questionTypes',
+	'sensei-lms/ordering-question-type',
+	addOrderingQuestionType
+);

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -53,10 +53,20 @@ $block: '.sensei-lms-question-block';
 			padding: 12px;
 		}
 
+		&__option__container--disabled {
+			strong {
+				opacity: 0.4;
+			}
+		}
+
 		&__option__description {
 			color: #757575;
 			font-size: 90%;
 			margin-top: 3px;
+
+			&--disabled {
+				opacity: 0.4;
+			}
 		}
 	}
 

--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -57,6 +57,11 @@ $block: '.sensei-lms-question-block';
 			strong {
 				opacity: 0.4;
 			}
+
+			a {
+				display: inline-block;
+				margin-top: 3px;
+			}
 		}
 
 		&__option__description {

--- a/assets/blocks/quiz/question-block/question-type-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-type-toolbar.js
@@ -67,7 +67,7 @@ export const QuestionTypeToolbar = ( { value, onSelect } ) => {
 					 *
 					 * @param {JSX.Element} children Menu element children.
 					 * @param {Object}      option   The question type option.
-					 * @return {JSX.Element} Whether to hide the access period.
+					 * @return {JSX.Element} Retuns the filtered children for the menu item.
 					 */
 					children = applyFilters(
 						'senseiQuestionTypeToolbarOptionChildren',

--- a/assets/blocks/quiz/question-block/question-type-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-type-toolbar.js
@@ -21,7 +21,6 @@ let options = Object.entries( types ).map( ( [ value, settings ] ) => ( {
  *
  * @since 4.1.0
  *
- * @hook senseiQuestionTypeOptions
  * @param {Array} options The available question type options.
  * @return {Array} The filtered question type options.
  */
@@ -66,7 +65,6 @@ export const QuestionTypeToolbar = ( { value, onSelect } ) => {
 					 *
 					 * @since 4.1.0
 					 *
-					 * @hook senseiQuestionTypeToolbarOptionChildren
 					 * @param {JSX.Element} children Menu element children.
 					 * @param {Object}      option   The question type option.
 					 * @return {JSX.Element} Whether to hide the access period.

--- a/assets/blocks/quiz/question-block/question-type-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-type-toolbar.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Toolbar } from '@wordpress/components';
+import { applyFilters } from '@wordpress/hooks';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -10,12 +11,21 @@ import { __ } from '@wordpress/i18n';
 import ToolbarDropdown from '../../editor-components/toolbar-dropdown';
 import types from '../answer-blocks';
 
-const options = Object.entries( types ).map( ( [ value, settings ] ) => ( {
+let options = Object.entries( types ).map( ( [ value, settings ] ) => ( {
 	...settings,
 	label: settings.title,
 	value,
 } ) );
-
+/**
+ * Filters the available question type options.
+ *
+ * @since 4.1.0
+ *
+ * @hook senseiQuestionTypeOptions
+ * @param {Array} options The available question type options.
+ * @return {Array} The filtered question type options.
+ */
+options = applyFilters( 'senseiQuestionTypeToolbarOptions', options );
 /**
  * Question type selector toolbar control.
  *
@@ -43,21 +53,32 @@ export const QuestionTypeToolbar = ( { value, onSelect } ) => {
 					),
 				} }
 				getMenuItemProps={ ( option ) => {
-					const props = {};
-
-					if ( option.renderMenuItem ) {
-						props.children = option.renderMenuItem();
-					} else {
-						props.children = (
-							<div>
-								<strong> { option.title }</strong>
-								<div className="sensei-lms-question-block__type-selector__option__description">
-									{ option.description }
-								</div>
+					let children = (
+						<div>
+							<strong> { option.title }</strong>
+							<div className="sensei-lms-question-block__type-selector__option__description">
+								{ option.description }
 							</div>
-						);
-					}
+						</div>
+					);
+					/**
+					 * Filters the children of the menu item.
+					 *
+					 * @since 4.1.0
+					 *
+					 * @hook senseiQuestionTypeToolbarOptionChildren
+					 * @param {JSX.Element} children Menu element children.
+					 * @param {Object}      option   The question type option.
+					 * @return {JSX.Element} Whether to hide the access period.
+					 */
+					children = applyFilters(
+						'senseiQuestionTypeToolbarOptionChildren',
+						children,
+						option
+					);
 
+					const props = {};
+					props.children = children;
 					if ( option.disabled ) {
 						props.onClick = () => {};
 					}

--- a/assets/blocks/quiz/question-block/question-type-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-type-toolbar.js
@@ -42,16 +42,28 @@ export const QuestionTypeToolbar = ( { value, onSelect } ) => {
 						<b>{ selectedOption?.title }</b>
 					),
 				} }
-				getMenuItemProps={ ( option ) => ( {
-					children: (
-						<div>
-							<strong> { option.title }</strong>
-							<div className="sensei-lms-question-block__type-selector__option__description">
-								{ option.description }
+				getMenuItemProps={ ( option ) => {
+					const props = {};
+
+					if ( option.renderMenuItem ) {
+						props.children = option.renderMenuItem();
+					} else {
+						props.children = (
+							<div>
+								<strong> { option.title }</strong>
+								<div className="sensei-lms-question-block__type-selector__option__description">
+									{ option.description }
+								</div>
 							</div>
-						</div>
-					),
-				} ) }
+						);
+					}
+
+					if ( option.disabled ) {
+						props.onClick = () => {};
+					}
+
+					return props;
+				} }
 			/>
 		</Toolbar>
 	);

--- a/includes/blocks/class-sensei-quiz-blocks.php
+++ b/includes/blocks/class-sensei-quiz-blocks.php
@@ -40,7 +40,7 @@ class Sensei_Quiz_Blocks extends Sensei_Blocks_Initializer {
 		 * @hook  sensei_quiz_ordering_question_type_hide
 		 * @since 4.1.0
 		 *
-		 * @param  {bool} $hide_content_drip Whether to hide the ordering question type promo.
+		 * @param  {bool} $ordering_question_type_hide Whether to hide the ordering question type promo.
 		 * @return {bool} Whether to hide the ordering question type promo.
 		 */
 		$ordering_question_type_hide = apply_filters( 'sensei_quiz_ordering_question_type_hide', false );

--- a/includes/blocks/class-sensei-quiz-blocks.php
+++ b/includes/blocks/class-sensei-quiz-blocks.php
@@ -34,6 +34,15 @@ class Sensei_Quiz_Blocks extends Sensei_Blocks_Initializer {
 		Sensei()->assets->enqueue( 'sensei-quiz-blocks', 'blocks/quiz/index.js', [], true );
 		Sensei()->assets->enqueue( 'sensei-quiz-blocks-editor', 'blocks/quiz/quiz.editor.css', [ 'sensei-shared-blocks-editor-style', 'sensei-editor-components-style' ] );
 
+		/**
+		 * Filters the quiz ordering type promo toggle.
+		 *
+		 * @hook  sensei_quiz_ordering_question_type_hide
+		 * @since 4.1.0
+		 *
+		 * @param  {bool} $hide_content_drip Whether to hide the ordering question type promo.
+		 * @return {bool} Whether to hide the ordering question type promo.
+		 */
 		$ordering_question_type_hide = apply_filters( 'sensei_quiz_ordering_question_type_hide', false );
 		if ( ! $ordering_question_type_hide ) {
 			Sensei()->assets->enqueue( 'sensei-quiz-blocks-ordering-promo', 'blocks/quiz/ordering-promo/index.js', [], false );

--- a/includes/blocks/class-sensei-quiz-blocks.php
+++ b/includes/blocks/class-sensei-quiz-blocks.php
@@ -34,6 +34,11 @@ class Sensei_Quiz_Blocks extends Sensei_Blocks_Initializer {
 		Sensei()->assets->enqueue( 'sensei-quiz-blocks', 'blocks/quiz/index.js', [], true );
 		Sensei()->assets->enqueue( 'sensei-quiz-blocks-editor', 'blocks/quiz/quiz.editor.css', [ 'sensei-shared-blocks-editor-style', 'sensei-editor-components-style' ] );
 
+		$ordering_question_type_hide = apply_filters( 'sensei_quiz_ordering_question_type_hide', false );
+		if ( ! $ordering_question_type_hide ) {
+			Sensei()->assets->enqueue( 'sensei-quiz-blocks-ordering-promo', 'blocks/quiz/ordering-promo/index.js', [], false );
+		}
+
 		wp_localize_script( 'sensei-quiz-blocks', 'sensei_quiz_blocks', [ 'category_question_enabled' => Sensei()->feature_flags->is_enabled( 'block_editor_enable_category_questions' ) ] );
 
 		global $post;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,6 +56,7 @@ const files = [
 	'blocks/single-lesson.js',
 	'blocks/single-lesson-style-editor.scss',
 	'blocks/quiz/index.js',
+	'blocks/quiz/ordering-promo/index.js',
 	'blocks/quiz/quiz.editor.scss',
 	'blocks/shared.js',
 	'blocks/shared-style.scss',


### PR DESCRIPTION
Fixes #4756

### Changes proposed in this Pull Request

* Add Ordering question type promo.

### Testing instructions

* Create a lesson
* Add a quiz block
* Add a question 
* Open the question type dropdown

### New/Updated Hooks

* `sensei_quiz_ordering_question_type_hide` - Filters the quiz ordering type promo toggle.
* `senseiQuestionTypeToolbarOptions` - Filters the available question type options.
* `senseiQuestionTypeToolbarOptionChildren` - Filters the children of the menu item.

### Screenshot / Video
<img width="696" alt="CleanShot 2022-02-16 at 18 32 44@2x" src="https://user-images.githubusercontent.com/329356/154298775-c3341cc2-a447-4bed-819c-5f2e7f7dbcc3.png">

