### PR TITLE
Fix redirect & pagination issues

### DIFF
--- a/assets/css/sensei-course-theme/lesson-actions.scss
+++ b/assets/css/sensei-course-theme/lesson-actions.scss
@@ -10,3 +10,14 @@
 		margin: 0;
 	}
 }
+
+.sensei-course-theme__post-pagination {
+	margin-top: 36px;
+	margin-bottom: 36px;
+
+	display: flex;
+	align-items: flex-start;
+	flex-wrap: wrap;
+	gap: 12px;
+
+}

--- a/includes/blocks/course-theme/class-course-theme-blocks.php
+++ b/includes/blocks/course-theme/class-course-theme-blocks.php
@@ -62,7 +62,7 @@ class Course_Theme_Blocks extends Sensei_Blocks_Initializer {
 		new Blocks\Quiz_Back_To_Lesson();
 		new Blocks\Sidebar_Toggle_Button();
 		new Blocks\Quiz_Actions();
-		new Blocks\Pagination();
+		new Blocks\Page_Actions();
 		new \Sensei_Block_Quiz_Progress();
 	}
 }

--- a/includes/blocks/course-theme/class-page-actions.php
+++ b/includes/blocks/course-theme/class-page-actions.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * File containing the Pagination class.
+ * File containing the Page_Actions class.
  *
  * @package sensei
  * @since   4.0.0
@@ -17,7 +17,7 @@ use \Sensei_Blocks;
 /**
  * Display lesson or quiz pagination.
  */
-class Pagination {
+class Page_Actions {
 	/**
 	 * Exit_Course constructor.
 	 */
@@ -58,6 +58,12 @@ class Pagination {
 	 */
 	private function render_post_pagination() {
 
-		return wp_link_pages( [ 'echo' => false ] );
+		return wp_link_pages(
+			[
+				'echo'   => false,
+				'before' => '<div class="wp-block-sensei-lms-page-actions sensei-course-theme__post-pagination">',
+				'after'  => '</div>',
+			]
+		);
 	}
 }

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -229,7 +229,7 @@ class Sensei_Autoloader {
 			'Sensei\Blocks\Course_Theme\Sidebar_Toggle_Button' => 'blocks/course-theme/class-sidebar-toggle-button.php',
 			'Sensei\Blocks\Course_Theme\Quiz_Graded'       => 'blocks/course-theme/class-quiz-graded.php',
 			'Sensei\Blocks\Course_Theme\Quiz_Actions'      => 'blocks/course-theme/class-quiz-actions.php',
-			'Sensei\Blocks\Course_Theme\Pagination'        => 'blocks/course-theme/class-pagination.php',
+			'Sensei\Blocks\Course_Theme\Page_Actions'      => 'blocks/course-theme/class-page-actions.php',
 		);
 	}
 

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -87,6 +87,9 @@ class Sensei_Course_Theme_Option {
 		if ( $should_use_theme ) {
 			$url = str_replace( trailingslashit( home_url() ), '', $url );
 			$url = Sensei_Course_Theme::instance()->get_theme_redirect_url( $url );
+		} else {
+			$prefix = Sensei_Course_Theme::instance()->get_theme_redirect_url( '' );
+			$url    = str_replace( $prefix, trailingslashit( home_url() ), $url );
 		}
 
 		if ( ! empty( $_SERVER['QUERY_STRING'] ) ) {


### PR DESCRIPTION
#4686 broke the redirect from `/learn` to normal view when learning mode is off.

### Changes proposed in this Pull Request

* Fix redirection
* Rename page actions class and file too
* Clean up and style the pagination links a bit

### Testing instructions

* Enable theme style support, or disable learning mode for a course
* Visit `/learn/lesson/lesson-title` for a lesson in the course
* It should redirect to the lesson correctly
-- 
* Check that pages in a multi-page lesson can still be accessed
