### PR TITLE
Add upgrade nudge for access period

### DIFF
--- a/assets/css/course-editor.scss
+++ b/assets/css/course-editor.scss
@@ -92,3 +92,9 @@ $primary: #6FCFB2;
 		}
 	}
 }
+
+.sensei-course-access-period-promo {
+	&__holder {
+		opacity: 0.4;
+	}
+}

--- a/assets/js/admin/course-access-period-promo-sidebar.js
+++ b/assets/js/admin/course-access-period-promo-sidebar.js
@@ -1,0 +1,45 @@
+/**
+ * WordPress dependencies
+ */
+import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
+import { ExternalLink, SelectControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Course access period promo sidebar component.
+ */
+const CourseAccessPeriodPromoSidebar = () => {
+	return (
+		<PluginDocumentSettingPanel
+			name="sensei-course-access-period-promo"
+			title={ __( 'Access Period', 'sensei-lms' ) }
+		>
+			<div className="sensei-course-access-period-promo">
+				<p>
+					<ExternalLink href="https://senseilms.com/pricing/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=course_access_period">
+						{ __( 'Upgrade to Sensei Pro', 'sensei-lms' ) }
+					</ExternalLink>
+				</p>
+
+				<div className="sensei-course-access-period-promo__holder">
+					<p>
+						{ __(
+							'Set how long learners will have access to this course.',
+							'sensei-lms'
+						) }
+					</p>
+
+					<SelectControl
+						label={ __( 'Expiration', 'sensei-lms' ) }
+						options={ [
+							{ label: __( 'No expiration', 'sensei-lms' ) },
+							{ label: __( 'Expires after', 'sensei-lms' ) },
+						] }
+					/>
+				</div>
+			</div>
+		</PluginDocumentSettingPanel>
+	);
+};
+
+export default CourseAccessPeriodPromoSidebar;

--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { select, subscribe } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
+import { applyFilters } from '@wordpress/hooks';
 import domReady from '@wordpress/dom-ready';
 import { registerPlugin } from '@wordpress/plugins';
 
@@ -12,6 +12,7 @@ import { registerPlugin } from '@wordpress/plugins';
 import { startBlocksTogglingControl } from './blocks-toggling-control';
 import CourseTheme from './course-theme';
 import CourseVideoSidebar from './course-video-sidebar';
+import CourseAccessPeriodPromoSidebar from './course-access-period-promo-sidebar';
 
 ( () => {
 	const editPostSelector = select( 'core/edit-post' );
@@ -75,10 +76,28 @@ domReady( () => {
 /**
  * Plugins
  */
+
+/**
+ * Filters the course access period display.
+ *
+ * @since 4.1.0
+ *
+ * @hook senseiCourseAccessPeriodHide
+ * @param {boolean} $hideCourseAccessPeriod Whether to hide the access period.
+ * @return {boolean} Whether to hide the access period.
+ */
+if ( ! applyFilters( 'senseiCourseAccessPeriodHide', false ) ) {
+	registerPlugin( 'sensei-course-access-period-promo-plugin', {
+		render: CourseAccessPeriodPromoSidebar,
+		icon: null,
+	} );
+}
+
 registerPlugin( 'sensei-course-theme-plugin', {
 	render: CourseTheme,
 	icon: null,
 } );
+
 registerPlugin( 'sensei-course-video-progression-plugin', {
 	render: CourseVideoSidebar,
 	icon: null,

--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -82,8 +82,7 @@ domReady( () => {
  *
  * @since 4.1.0
  *
- * @hook senseiCourseAccessPeriodHide
- * @param {boolean} $hideCourseAccessPeriod Whether to hide the access period.
+ * @param {boolean} hideCourseAccessPeriod Whether to hide the access period.
  * @return {boolean} Whether to hide the access period.
  */
 if ( ! applyFilters( 'senseiCourseAccessPeriodHide', false ) ) {


### PR DESCRIPTION
Fixes #4798

### Changes proposed in this Pull Request

* Add access period promo section to the course edit screen.

### Testing instructions

* Go to the course edit screen.
* Make sure there is an "Access Period" panel in the sidebar.
* The link should point to the pricing page.
* Make sure the panel is collapsible.

### New Hooks

* `senseiCourseAccessPeriodHide` - Filters the course access period promo panel display.

### Screenshot / Video

<img width="278" alt="Screenshot on 2022-02-16 at 00-48-33" src="https://user-images.githubusercontent.com/1612178/154163045-996304eb-b4ab-48fb-a2d9-e40fb67d0558.png">

