### PR TITLE
Fix outline and quiz appenders on 5.9

### DIFF
--- a/assets/blocks/course-outline/outline-block/outline.scss
+++ b/assets/blocks/course-outline/outline-block/outline.scss
@@ -27,4 +27,10 @@
 			}
 		}
 	}
+
+	.block-list-appender.wp-block {
+		position: static;
+		margin-top: 0;
+		margin-bottom: 28px;
+	}
 }

--- a/assets/shared/components/text-appender/index.js
+++ b/assets/shared/components/text-appender/index.js
@@ -23,6 +23,10 @@ const TextAppender = ( { controls, text, label } ) => {
 				} }
 				label={ label }
 				controls={ controls }
+				popoverProps={ {
+					position: 'bottom center',
+				} }
+				menuProps={ { className: 'sensei-lms-text-appender__menu' } }
 			/>
 			<p
 				className="sensei-lms-text-appender__placeholder"

--- a/assets/shared/components/text-appender/style.scss
+++ b/assets/shared/components/text-appender/style.scss
@@ -1,6 +1,11 @@
 .sensei-lms-text-appender {
-
 	text-align: center;
+	height: unset !important;
+	line-height: 1 !important;
+
+	.block-editor-inserter__toggle {
+		display: block !important;
+	}
 
 	.editor-styles-wrapper &__placeholder {
 		opacity: 0.62;
@@ -8,7 +13,12 @@
 		line-height: 1;
 
 		&::after {
+			margin-top: 6px;
 			content: attr(data-placeholder);
 		}
+	}
+
+	&__menu .components-dropdown-menu__menu-item {
+		min-width: 175px;
 	}
 }


### PR DESCRIPTION
Fixes #4795

WordPress 5.9 changed the block appender rendering (to be absolute in the bottom right corner), which broke our custom appender in the course outline and the quiz blocks.

### Changes proposed in this Pull Request

* Update styling for `TextAppender` component

### Testing instructions

* On WordPress 5.9
* Open a course page, select the outline block
* "Add Module or Lesson" on the bottom should be visible and functioning
--
* Open a lesson page, select the quiz block
* "Add New or Existing Question" on the bottom should be visible and functioning

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="631" alt="image" src="https://user-images.githubusercontent.com/176949/154334012-c930a665-e4ea-409e-8ed8-60e35767703a.png">

