### PR TITLE
Extend quiz settings inspector panel

### DIFF
--- a/assets/blocks/quiz/quiz-block/quiz-settings.js
+++ b/assets/blocks/quiz/quiz-block/quiz-settings.js
@@ -9,12 +9,13 @@ import {
 	PanelColorSettings,
 } from '@wordpress/block-editor';
 import {
+	BaseControl,
 	Button,
 	PanelBody,
 	PanelRow,
 	RangeControl,
+	Slot,
 	ToggleControl,
-	BaseControl,
 } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEffect } from '@wordpress/element';
@@ -239,6 +240,7 @@ const QuizSettings = ( {
 							onChange={ createChangeHandler( 'showQuestions' ) }
 						/>
 					</PanelRow>
+					<Slot name="SenseiQuizSettings" />
 				</PanelBody>
 				<PaginationSidebarSettings
 					settings={ pagination }


### PR DESCRIPTION
Make quiz settings on the inspector panel extendable by adding a named slot component

Fixes #

### Changes proposed in this Pull Request

* Added a `Slot` component to quiz settings block inspector. This makes it possible to extend (add more settings fields) from other plugins.

### Testing instructions

- No testing is required. Just make sure nothing is broken.