### PR TITLE
Move packages from devDependencies to dependencies (lint-js error)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
     "npm": ">=7"
   },
   "dependencies": {
+    "@automattic/calypso-build": "10.0.0",
     "@wordpress/api-fetch": "3.18.0",
     "@wordpress/base-styles": "1.9.0",
     "@wordpress/block-editor": "4.4.0",
-    "@wordpress/blocks": "6.21.0",
+    "@wordpress/blocks": "6.21.0", 
     "@wordpress/components": "9.4.1",
     "@wordpress/compose": "3.25.0",
     "@wordpress/core-data": "2.26.0",
@@ -41,13 +42,14 @@
     "@wordpress/token-list": "1.12.0",
     "@wordpress/url": "2.17.0",
     "classnames": "2.3.1",
+    "copy-webpack-plugin": "10.2.0",
     "interpolate-components": "1.1.1",
     "lodash": "4.17.21",
     "react-animate-height": "2.0.23",
+    "svg-spritemap-webpack-plugin": "4.4.0",
     "uuid": "3.3.2"
   },
   "devDependencies": {
-    "@automattic/calypso-build": "10.0.0",
     "@babel/cli": "7.13.14",
     "@babel/core": "7.13.14",
     "@babel/preset-env": "7.16.4",
@@ -71,7 +73,6 @@
     "@wordpress/prettier-config": "1.0.1",
     "@wordpress/scripts": "16.1.4",
     "comment-parser": "1.1.5",
-    "copy-webpack-plugin": "10.2.0",
     "cross-env": "7.0.2",
     "eslint": "7.30.0",
     "eslint-config-prettier": "8.1.0",
@@ -87,7 +88,6 @@
     "puppeteer-core": "npm:puppeteer-core@8.0.0",
     "react": "16.11.0",
     "react-test-renderer": "17.0.2",
-    "svg-spritemap-webpack-plugin": "4.4.0",
     "webpack": "5.64.4",
     "wp-hookdoc": "0.2.0"
   },


### PR DESCRIPTION
I disabled the husky pre-commit hook while [merging master into feature/upsells](https://github.com/Automattic/sensei/pull/4846) (log in the end of the description).
This pull request solves errors from that hook.

### Changes proposed in this Pull Request

* Move packages from devDependencies to dependencies

### Husky log
```
[STARTED] Preparing...
[SUCCESS] Preparing...
[STARTED] Hiding unstaged changes to partially staged files...
[SUCCESS] Hiding unstaged changes to partially staged files...
[STARTED] Running tasks...
[STARTED] Running tasks for package.json
[STARTED] Running tasks for *.{js,jsx}
[STARTED] Running tasks for *.php
[STARTED] npm run lint-pkg-json
[STARTED] npm run format
[STARTED] scripts/linter-new-php
[SUCCESS] npm run lint-pkg-json
[SUCCESS] Running tasks for package.json
[SUCCESS] npm run format
[STARTED] wp-scripts lint-js
[SUCCESS] scripts/linter-new-php
[SUCCESS] Running tasks for *.php
[FAILED] wp-scripts lint-js [FAILED]
[FAILED] wp-scripts lint-js [FAILED]
[SUCCESS] Running tasks...
[STARTED] Applying modifications...
[SKIPPED] Skipped because of errors from tasks.
[STARTED] Restoring unstaged changes to partially staged files...
[SKIPPED] Skipped because of errors from tasks.
[STARTED] Reverting to original state because of errors...
[SUCCESS] Reverting to original state because of errors...
[STARTED] Cleaning up...
[SUCCESS] Cleaning up...
✖ wp-scripts lint-js:
/Users/merkushin/Developer/sensei/webpack.config.js
  7:29  error  'copy-webpack-plugin' should be listed in the project's dependencies, not devDependencies           import/no-extraneous-dependencies
  8:37  error  'svg-spritemap-webpack-plugin' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
  9:39  error  '@automattic/calypso-build' should be listed in the project's dependencies, not devDependencies     import/no-extraneous-dependencies
✖ 3 problems (3 errors, 0 warnings)
husky - pre-commit hook exited with code 1 (error)
```