### PR TITLE
Allow user re-enrolling even when removed

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1239,12 +1239,11 @@ class Sensei_Frontend {
 	public function manually_enrol_learner( $user_id, $course_id ) {
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
-		// If user is removed, just restore instead.
+		// If user is removed, just restore it.
 		if ( $course_enrolment->is_learner_removed( $user_id ) ) {
 			$course_enrolment->restore_learner( $user_id );
 		}
 
-		// If user isn't still enrolled, enroll manually.
 		$enrolment_manager         = Sensei_Course_Enrolment_Manager::instance();
 		$manual_enrolment_provider = $enrolment_manager->get_manual_enrolment_provider();
 

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1237,10 +1237,9 @@ class Sensei_Frontend {
 	 * @return bool True if successful.
 	 */
 	public function manually_enrol_learner( $user_id, $course_id ) {
-		$enrolment_manager = Sensei_Course_Enrolment_Manager::instance();
-		$manual_enrolment  = $enrolment_manager->get_manual_enrolment_provider();
+		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
-		return $manual_enrolment && $manual_enrolment->enrol_learner( $user_id, $course_id );
+		return $course_enrolment->enrol( $user_id );
 	}
 
 	/**

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1239,7 +1239,20 @@ class Sensei_Frontend {
 	public function manually_enrol_learner( $user_id, $course_id ) {
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
-		return $course_enrolment->enrol( $user_id );
+		// If user is removed, just restore instead.
+		if ( $course_enrolment->is_learner_removed( $user_id ) ) {
+			$course_enrolment->restore_learner( $user_id );
+		}
+
+		// If user isn't still enrolled, enroll manually.
+		$enrolment_manager         = Sensei_Course_Enrolment_Manager::instance();
+		$manual_enrolment_provider = $enrolment_manager->get_manual_enrolment_provider();
+
+		if ( ! ( $manual_enrolment_provider instanceof Sensei_Course_Manual_Enrolment_Provider ) ) {
+			return false;
+		}
+
+		return $manual_enrolment_provider->enrol_learner( $user_id, $course_id );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4574

### Changes proposed in this Pull Request

* The idea is to restore the learner if it's already removed just before calling  `Sensei_Course_Manual_Enrolment_Provider::enrol_learner`, so we can avoid surprises with that;

### Testing instructions

1. Block an enrolled user to a course by adding him to the sensei_removed_learners meta. This can happen naturally if the course is paid and the user is removed from the course in the admin.
2. If the course is paid, update the course to be a free course.
3. Try to enroll the blocked user by clicking ‘Take Course’ in the frontend.
4. Check that the enrollment was successful.

