### PR TITLE
Fix legacy quiz styles in learning mode

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -491,7 +491,7 @@ div.sensei-quiz-actions {
 }
 
 
-.quiz:not(.quiz-blocks), .lesson {
+.quiz:not(.quiz-blocks):not(.sensei-course-theme), .lesson {
   button.quiz-submit {
     &.complete {
       background: $success;
@@ -1059,7 +1059,7 @@ section.entry span.course-lesson-progress { margin-left: 10px; }
   }
 }
 
-.course-container, .course, .lesson, .quiz:not(.quiz-blocks)  {
+.course-container, .course, .lesson, .quiz:not(.quiz-blocks):not(.sensei-course-theme)  {
   a.button, a.button:visited,
   a.comment-reply-link,
   #commentform #submit,

--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -509,7 +509,7 @@ div.sensei-quiz-actions {
   }
 }
 
-.quiz-blocks {
+.quiz-blocks:not(.sensei-course-theme) {
   .wp-block-buttons {
     display: flex;
     flex-direction: row;

--- a/assets/css/sensei-course-theme/buttons.scss
+++ b/assets/css/sensei-course-theme/buttons.scss
@@ -19,6 +19,7 @@
 		font-size: inherit;
 		background-color: inherit !important;
 		color: inherit !important;
+		text-transform: unset;
 		&:hover {
 			background-color: inherit !important;
 			color: inherit !important;


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Fix legacy quiz styles appearing in learning mode
* Fix uppercase button theme styles leaking

### Testing instructions

* In a course with learning mode, create a lesson with no Sensei blocks, except for a quiz
* Add quiz questions, take quiz with student
* See _before_ screenshot not happening

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

|  <img width="274" alt="image" src="https://user-images.githubusercontent.com/176949/155006804-3e43f9cb-2606-4cc6-b2b1-b51a50c04bc6.png">  |  →   | <img width="276" alt="image" src="https://user-images.githubusercontent.com/176949/155006733-6f1963ad-e088-4f42-89a5-9b82123e56f2.png">   |
|---|---|---|

