### PR TITLE
Add conditional content block to lessons

### DIFF
--- a/assets/blocks/shared.js
+++ b/assets/blocks/shared.js
@@ -9,13 +9,15 @@ import { subscribe, select } from '@wordpress/data';
  */
 import registerSenseiBlocks from './register-sensei-blocks';
 import ContactTeacherBlock from './contact-teacher-block';
+import ConditionalContentBlock from './conditional-content-block';
 
 // Post types where blocks should be loaded. Or null if it should be loaded for any post type.
 const BLOCKS_PER_POST_TYPE = {
 	'sensei-lms/button-contact-teacher': [ 'course', 'lesson' ],
+	'sensei-lms/conditional-content': [ 'course', 'lesson' ],
 };
 
-registerSenseiBlocks( [ ContactTeacherBlock ] );
+registerSenseiBlocks( [ ContactTeacherBlock, ConditionalContentBlock ] );
 
 let postType = null;
 

--- a/assets/blocks/single-course.js
+++ b/assets/blocks/single-course.js
@@ -5,7 +5,6 @@ import registerSenseiBlocks from './register-sensei-blocks';
 import TakeCourseBlock from './take-course-block';
 import CourseProgressBlock from './course-progress-block';
 import { OutlineBlock, LessonBlock, ModuleBlock } from './course-outline';
-import ConditionalContentBlock from './conditional-content-block';
 import ViewResults from './view-results-block';
 
 registerSenseiBlocks( [
@@ -14,6 +13,5 @@ registerSenseiBlocks( [
 	LessonBlock,
 	TakeCourseBlock,
 	CourseProgressBlock,
-	ConditionalContentBlock,
 	ViewResults,
 ] );

--- a/includes/blocks/class-sensei-lesson-blocks.php
+++ b/includes/blocks/class-sensei-lesson-blocks.php
@@ -122,6 +122,8 @@ class Sensei_Lesson_Blocks extends Sensei_Blocks_Initializer {
 		 */
 		$post_type_object->template = apply_filters( 'sensei_lesson_block_template', $block_template, $post_type_object->template ?? [] );
 
+		new Sensei_Conditional_Content_Block();
+
 		if ( ! Sensei()->lesson->has_sensei_blocks() ) {
 			return;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Enable the conditional content block in lessons

### Testing instructions

* Add the block to a lesson with some content, set to Enrolled, set the lesson to be a preview
* Open the lesson as a guest student. Content in the block should be hidden.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="949" alt="image" src="https://user-images.githubusercontent.com/176949/155024738-92a15ef1-aa40-4073-9ee4-f89ffa56e42e.png">
