### PR TITLE
Rename Analysis to Reports

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -103,7 +103,7 @@ body #menu-posts-course {
 		}
 
 		&[href="edit.php?post_type=course&page=sensei_learners"],
-		&[href="edit.php?post_type=course&page=sensei_analysis"] {
+		&[href="edit.php?post_type=course&page=sensei_reports"] {
 			border-top: solid 1px;
 			margin-top: 10px;
 			padding-top: 10px;

--- a/assets/js/admin/event-logging.js
+++ b/assets/js/admin/event-logging.js
@@ -43,7 +43,7 @@ const adminTracking = [
 	{
 		selector:
 			selector +
-			'a[href="edit.php?post_type=course&page=sensei_analysis"]',
+			'a[href="edit.php?post_type=course&page=sensei_reports"]',
 		eventName: 'analysis_view',
 	},
 	{

--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -56,7 +56,7 @@ class Sensei_Admin_Notices {
 		'edit-question-type',
 		'edit-question-category',
 		'edit-lesson-tag',
-		'course_page_sensei_analysis',
+		'course_page_sensei_reports',
 		'course_page_sensei_learners',
 		'course_page_sensei-settings',
 		'course_page_sensei_grading',

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -328,7 +328,7 @@ class Sensei_Admin {
 	private function are_custom_admin_styles_allowed( $post_type, $hook_suffix, $screen ) {
 		$allowed_post_types      = apply_filters( 'sensei_scripts_allowed_post_types', array( 'lesson', 'course', 'question' ) );
 		$allowed_post_type_pages = apply_filters( 'sensei_scripts_allowed_post_type_pages', array( 'edit.php', 'post-new.php', 'post.php', 'edit-tags.php' ) );
-		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', Sensei()->analysis->page_slug, 'sensei_learners', 'sensei_updates', 'sensei-settings', $this->lesson_order_page_slug, $this->course_order_page_slug ) );
+		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', Sensei_Analysis::PAGE_SLUG, 'sensei_learners', 'sensei_updates', 'sensei-settings', $this->lesson_order_page_slug, $this->course_order_page_slug ) );
 		$module_pages_screen_ids = [ 'edit-module' ];
 
 		$is_allowed_type           = isset( $post_type ) && in_array( $post_type, $allowed_post_types, true );

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -232,7 +232,7 @@ class Sensei_Admin {
 		_deprecated_function( __METHOD__, '4.0.0' );
 
 		if ( isset( $_GET['page'] ) && $_GET['page'] == 'sensei' ) {
-			wp_safe_redirect( 'admin.php?page=sensei_analysis' );
+			wp_safe_redirect( 'admin.php?page=sensei_reports' );
 			exit;
 		}
 	}
@@ -328,7 +328,7 @@ class Sensei_Admin {
 	private function are_custom_admin_styles_allowed( $post_type, $hook_suffix, $screen ) {
 		$allowed_post_types      = apply_filters( 'sensei_scripts_allowed_post_types', array( 'lesson', 'course', 'question' ) );
 		$allowed_post_type_pages = apply_filters( 'sensei_scripts_allowed_post_type_pages', array( 'edit.php', 'post-new.php', 'post.php', 'edit-tags.php' ) );
-		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', 'sensei_analysis', 'sensei_learners', 'sensei_updates', 'sensei-settings', $this->lesson_order_page_slug, $this->course_order_page_slug ) );
+		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', Sensei()->analysis->page_slug, 'sensei_learners', 'sensei_updates', 'sensei-settings', $this->lesson_order_page_slug, $this->course_order_page_slug ) );
 		$module_pages_screen_ids = [ 'edit-module' ];
 
 		$is_allowed_type           = isset( $post_type ) && in_array( $post_type, $allowed_post_types, true );

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -11,12 +11,14 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.2.0
  */
 class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
+
 	public $user_id;
 	public $course_id;
 	public $total_lessons;
 	public $user_ids;
-	public $view      = 'lesson';
-	public $page_slug = 'sensei_analysis';
+	public $page_slug;
+	public $view = 'lesson';
+
 	/**
 	 * The post type under which is the page registered.
 	 *
@@ -32,6 +34,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	public function __construct( $course_id = 0, $user_id = 0 ) {
 		$this->course_id = intval( $course_id );
 		$this->user_id   = intval( $user_id );
+		$this->page_slug = Sensei()->analysis->page_slug;
 
 		if ( isset( $_GET['view'] ) && in_array( $_GET['view'], array( 'user', 'lesson' ) ) ) {
 			$this->view = $_GET['view'];

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -34,7 +34,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	public function __construct( $course_id = 0, $user_id = 0 ) {
 		$this->course_id = intval( $course_id );
 		$this->user_id   = intval( $user_id );
-		$this->page_slug = Sensei()->analysis->page_slug;
+		$this->page_slug = Sensei_Analysis::PAGE_SLUG;
 
 		if ( isset( $_GET['view'] ) && in_array( $_GET['view'], array( 'user', 'lesson' ) ) ) {
 			$this->view = $_GET['view'];

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -32,7 +32,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 	public function __construct( $lesson_id = 0 ) {
 		$this->lesson_id = intval( $lesson_id );
 		$this->course_id = intval( get_post_meta( $this->lesson_id, '_lesson_course', true ) );
-		$this->page_slug = Sensei()->analysis->page_slug;
+		$this->page_slug = Sensei_Analysis::PAGE_SLUG;
 
 		// Load Parent token into constructor
 		parent::__construct( 'analysis_lesson' );

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -12,9 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.2.0
  */
 class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
+
 	public $lesson_id;
 	public $course_id;
-	public $page_slug = 'sensei_analysis';
+	public $page_slug;
+
 	/**
 	 * The post type under which is the page registered.
 	 *
@@ -30,6 +32,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 	public function __construct( $lesson_id = 0 ) {
 		$this->lesson_id = intval( $lesson_id );
 		$this->course_id = intval( get_post_meta( $this->lesson_id, '_lesson_course', true ) );
+		$this->page_slug = Sensei()->analysis->page_slug;
 
 		// Load Parent token into constructor
 		parent::__construct( 'analysis_lesson' );

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -12,8 +12,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.2.0
  */
 class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
+
 	public $type;
-	public $page_slug = 'sensei_analysis';
+	public $page_slug;
+
 	/**
 	 * The post type under which is the page registered.
 	 *
@@ -28,7 +30,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @return  void
 	 */
 	public function __construct( $type = 'users' ) {
-		$this->type = in_array( $type, array( 'courses', 'lessons', 'users' ) ) ? $type : 'users';
+		$this->type      = in_array( $type, array( 'courses', 'lessons', 'users' ) ) ? $type : 'users';
+		$this->page_slug = Sensei()->analysis->page_slug;
 
 		// Load Parent token into constructor
 		parent::__construct( 'analysis_overview' );

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -31,7 +31,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 */
 	public function __construct( $type = 'users' ) {
 		$this->type      = in_array( $type, array( 'courses', 'lessons', 'users' ) ) ? $type : 'users';
-		$this->page_slug = Sensei()->analysis->page_slug;
+		$this->page_slug = Sensei_Analysis::PAGE_SLUG;
 
 		// Load Parent token into constructor
 		parent::__construct( 'analysis_overview' );

--- a/includes/class-sensei-analysis-user-profile-list-table.php
+++ b/includes/class-sensei-analysis-user-profile-list-table.php
@@ -12,8 +12,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 1.2.0
  */
 class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
+
 	public $user_id;
-	public $page_slug = 'sensei_analysis';
+	public $page_slug;
+
 	/**
 	 * The post type under which is the page registered.
 	 *
@@ -28,7 +30,8 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 	 * @return  void
 	 */
 	public function __construct( $user_id = 0 ) {
-		$this->user_id = intval( $user_id );
+		$this->user_id   = intval( $user_id );
+		$this->page_slug = Sensei()->analysis->page_slug;
 
 		// Load Parent token into constructor
 		parent::__construct( 'analysis_user_profile' );

--- a/includes/class-sensei-analysis-user-profile-list-table.php
+++ b/includes/class-sensei-analysis-user-profile-list-table.php
@@ -31,7 +31,7 @@ class Sensei_Analysis_User_Profile_List_Table extends Sensei_List_Table {
 	 */
 	public function __construct( $user_id = 0 ) {
 		$this->user_id   = intval( $user_id );
-		$this->page_slug = Sensei()->analysis->page_slug;
+		$this->page_slug = Sensei_Analysis::PAGE_SLUG;
 
 		// Load Parent token into constructor
 		parent::__construct( 'analysis_user_profile' );

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -29,7 +29,7 @@ class Sensei_Analysis {
 	 * @param string $file
 	 */
 	public function __construct( $file ) {
-		$this->name      = __( 'Analysis', 'sensei-lms' );
+		$this->name      = __( 'Reports', 'sensei-lms' );
 		$this->file      = $file;
 		$this->page_slug = 'sensei_analysis';
 		$this->post_type = 'course';
@@ -60,8 +60,8 @@ class Sensei_Analysis {
 		if ( current_user_can( 'manage_sensei_grades' ) ) {
 			add_submenu_page(
 				'edit.php?post_type=course',
-				__( 'Analysis', 'sensei-lms' ),
-				__( 'Analysis', 'sensei-lms' ),
+				$this->name,
+				$this->name,
 				'manage_sensei_grades',
 				'sensei_analysis',
 				array( $this, 'analysis_page' )

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -12,9 +12,24 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Analysis {
 
+	/**
+	 * The reports' page slug.
+	 */
+	const PAGE_SLUG = 'sensei_reports';
+
+	/**
+	 * The reports' page name (title).
+	 *
+	 * @var string
+	 */
 	public $name;
+
+	/**
+	 * Reference to the main plugin file name.
+	 *
+	 * @var string
+	 */
 	public $file;
-	public $page_slug;
 
 	/**
 	 * The post type under which is the page registered.
@@ -32,14 +47,14 @@ class Sensei_Analysis {
 	public function __construct( $file ) {
 		$this->name      = __( 'Reports', 'sensei-lms' );
 		$this->file      = $file;
-		$this->page_slug = 'sensei_reports';
 		$this->post_type = 'course';
 
-		// Admin functions
+		// Admin functions.
 		if ( is_admin() ) {
 			add_action( 'analysis_wrapper_container', array( $this, 'wrapper_container' ) );
 
-			if ( isset( $_GET['page'] ) && ( $_GET['page'] == $this->page_slug ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification -- Arguments used for comparison.
+			if ( isset( $_GET['page'] ) && self::PAGE_SLUG === $_GET['page'] ) {
 				add_action( 'admin_print_styles', array( $this, 'enqueue_styles' ) );
 			}
 
@@ -49,6 +64,22 @@ class Sensei_Analysis {
 		}
 	}
 
+	/**
+	 * Graceful fallback for deprecated properties.
+	 *
+	 * @since 4.2.0
+	 *
+	 * @param string $key The key to get.
+	 *
+	 * @return string|void
+	 */
+	public function __get( $key ) {
+		if ( 'page_slug' === $key ) {
+			_doing_it_wrong( 'Sensei_Analysis->page_slug', 'The "page_slug" property is deprecated. Use the Sensei_Analysis::PAGE_SLUG constant instead.', '4.2.0' );
+
+			return self::PAGE_SLUG;
+		}
+	}
 
 	/**
 	 * analysis_admin_menu function.
@@ -64,7 +95,7 @@ class Sensei_Analysis {
 				$this->name,
 				$this->name,
 				'manage_sensei_grades',
-				$this->page_slug,
+				self::PAGE_SLUG,
 				array( $this, 'analysis_page' )
 			);
 		}
@@ -455,7 +486,7 @@ class Sensei_Analysis {
 	public function analysis_user_profile_nav() {
 
 		$analysis_args = array(
-			'page'      => $this->page_slug,
+			'page'      => self::PAGE_SLUG,
 			'post_type' => $this->post_type,
 		);
 		$title         = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( $analysis_args, admin_url( 'edit.php' ) ) ), esc_html( $this->name ) );
@@ -464,7 +495,7 @@ class Sensei_Analysis {
 			$url       = esc_url(
 				add_query_arg(
 					array(
-						'page'      => $this->page_slug,
+						'page'      => self::PAGE_SLUG,
 						'user'      => $user_id,
 						'post_type' => $this->post_type,
 					),
@@ -489,7 +520,7 @@ class Sensei_Analysis {
 	public function analysis_user_course_nav() {
 
 		$analysis_args = array(
-			'page'      => $this->page_slug,
+			'page'      => self::PAGE_SLUG,
 			'post_type' => $this->post_type,
 		);
 		$title         = sprintf( '<a href="%s">%s</a>', esc_url( add_query_arg( $analysis_args, admin_url( 'edit.php' ) ) ), esc_html( $this->name ) );
@@ -498,7 +529,7 @@ class Sensei_Analysis {
 			$user_data = get_userdata( $user_id );
 			$url       = add_query_arg(
 				array(
-					'page'      => $this->page_slug,
+					'page'      => self::PAGE_SLUG,
 					'user_id'   => $user_id,
 					'post_type' => $this->post_type,
 				),
@@ -512,7 +543,7 @@ class Sensei_Analysis {
 			$course_id = intval( $_GET['course_id'] );
 			$url       = add_query_arg(
 				array(
-					'page'      => $this->page_slug,
+					'page'      => self::PAGE_SLUG,
 					'course_id' => $course_id,
 					'post_type' => $this->post_type,
 				),
@@ -534,7 +565,7 @@ class Sensei_Analysis {
 	public function analysis_course_nav() {
 
 		$analysis_args = array(
-			'page'      => $this->page_slug,
+			'page'      => self::PAGE_SLUG,
 			'post_type' => $this->post_type,
 		);
 		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'edit.php' ) ), esc_html( $this->name ) );
@@ -542,7 +573,7 @@ class Sensei_Analysis {
 			$course_id = intval( $_GET['course_id'] );
 			$url       = add_query_arg(
 				array(
-					'page'      => $this->page_slug,
+					'page'      => self::PAGE_SLUG,
 					'course_id' => $course_id,
 					'post_type' => $this->post_type,
 				),
@@ -564,7 +595,7 @@ class Sensei_Analysis {
 	public function analysis_course_users_nav() {
 
 		$analysis_args = array(
-			'page'      => $this->page_slug,
+			'page'      => self::PAGE_SLUG,
 			'post_type' => $this->post_type,
 		);
 		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'edit.php' ) ), esc_html( $this->name ) );
@@ -572,7 +603,7 @@ class Sensei_Analysis {
 			$course_id = intval( $_GET['course_id'] );
 			$url       = add_query_arg(
 				array(
-					'page'      => $this->page_slug,
+					'page'      => self::PAGE_SLUG,
 					'course_id' => $course_id,
 					'post_type' => $this->post_type,
 				),
@@ -594,7 +625,7 @@ class Sensei_Analysis {
 	public function analysis_lesson_users_nav() {
 
 		$analysis_args = array(
-			'page'      => $this->page_slug,
+			'page'      => self::PAGE_SLUG,
 			'post_type' => $this->post_type,
 		);
 		$title         = sprintf( '<a href="%s">%s</a>', add_query_arg( $analysis_args, admin_url( 'edit.php' ) ), esc_html( $this->name ) );
@@ -603,7 +634,7 @@ class Sensei_Analysis {
 			$course_id = intval( get_post_meta( $lesson_id, '_lesson_course', true ) );
 			$url       = add_query_arg(
 				array(
-					'page'      => $this->page_slug,
+					'page'      => self::PAGE_SLUG,
 					'course_id' => $course_id,
 					'post_type' => $this->post_type,
 				),
@@ -612,7 +643,7 @@ class Sensei_Analysis {
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
 			$url       = add_query_arg(
 				array(
-					'page'      => $this->page_slug,
+					'page'      => self::PAGE_SLUG,
 					'lesson_id' => $lesson_id,
 					'post_type' => $this->post_type,
 				),

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -15,6 +15,7 @@ class Sensei_Analysis {
 	public $name;
 	public $file;
 	public $page_slug;
+
 	/**
 	 * The post type under which is the page registered.
 	 *
@@ -31,7 +32,7 @@ class Sensei_Analysis {
 	public function __construct( $file ) {
 		$this->name      = __( 'Reports', 'sensei-lms' );
 		$this->file      = $file;
-		$this->page_slug = 'sensei_analysis';
+		$this->page_slug = 'sensei_reports';
 		$this->post_type = 'course';
 
 		// Admin functions
@@ -63,7 +64,7 @@ class Sensei_Analysis {
 				$this->name,
 				$this->name,
 				'manage_sensei_grades',
-				'sensei_analysis',
+				$this->page_slug,
 				array( $this, 'analysis_page' )
 			);
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2511,7 +2511,7 @@ class Sensei_Lesson {
 		 * @param {array} $allowed_pages Allowed pages.
 		 * @return {array} Allowed pages.
 		 */
-		$allowed_pages = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', 'sensei_analysis', 'sensei_learners', 'sensei_updates', 'sensei-settings' ) );
+		$allowed_pages = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', Sensei()->analysis->page_slug, 'sensei_learners', 'sensei_updates', 'sensei-settings' ) );
 
 		// Test for Write Panel Pages
 		if ( ( ( isset( $post_type ) && in_array( $post_type, $allowed_post_types ) ) && ( isset( $hook ) && in_array( $hook, $allowed_post_type_pages ) ) ) || ( isset( $_GET['page'] ) && in_array( $_GET['page'], $allowed_pages ) ) ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2511,7 +2511,7 @@ class Sensei_Lesson {
 		 * @param {array} $allowed_pages Allowed pages.
 		 * @return {array} Allowed pages.
 		 */
-		$allowed_pages = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', Sensei()->analysis->page_slug, 'sensei_learners', 'sensei_updates', 'sensei-settings' ) );
+		$allowed_pages = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', Sensei_Analysis::PAGE_SLUG, 'sensei_learners', 'sensei_updates', 'sensei-settings' ) );
 
 		// Test for Write Panel Pages
 		if ( ( ( isset( $post_type ) && in_array( $post_type, $allowed_post_types ) ) && ( isset( $hook ) && in_array( $hook, $allowed_post_type_pages ) ) ) || ( isset( $_GET['page'] ) && in_array( $_GET['page'], $allowed_pages ) ) ) {


### PR DESCRIPTION
Part of #4836

### Changes proposed in this Pull Request

This PR renames the "Analysis" menu and page to "Reports". Also changes the page slug/screen id.

### Testing instructions

* Click on the Sensei LMS menu.
* You should see "Reports", click on that.
* The page title should be "Reports".
* Go through the subpages. The title should still be "Reports".

### Deprecated Code

* `Sensei_Analysis->page_slug` - Use the `Sensei_Analysis::PAGE_SLUG` constant instead.