### PR TITLE
Remove the reports totals sidebar

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -93,9 +93,6 @@
 	&.course-profile  {
 		margin-left: 0;
 	}
-	.sensei-analysis-sidebar {
-		min-width: 281px;
-	}
 	.sensei-analysis-main {
 		flex: 1;
 		.tablenav {

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -605,10 +605,13 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	/**
 	 * Sets the stats boxes to render
 	 *
-	 * @since  1.2.0
-	 * @return array $stats_to_render of stats boxes and values
+	 * @since      1.2.0
+	 * @deprecated 4.2.0
+	 * @return     array $stats_to_render of stats boxes and values
 	 */
 	public function stats_boxes() {
+
+		_deprecated_function( __METHOD__, '4.2.0' );
 
 		// Get the data required
 		$user_count          = count_users();

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -190,15 +190,6 @@ class Sensei_Analysis {
 
 		?>
 		<div id="poststuff" class="sensei-analysis-wrap">
-			<div class="sensei-analysis-sidebar">
-				<?php
-				do_action( 'sensei_analysis_before_stats_boxes' );
-				foreach ( $sensei_analysis_overview->stats_boxes() as $key => $value ) {
-					$this->render_stats_box( esc_html( $key ), esc_html( $value ) );
-				}
-				do_action( 'sensei_analysis_after_stats_boxes' );
-				?>
-			</div>
 			<div class="sensei-analysis-main">
 				<?php $sensei_analysis_overview->display(); ?>
 			</div>
@@ -373,14 +364,18 @@ class Sensei_Analysis {
 	}
 
 	/**
-	 * render_stats_box outputs stats boxes
+	 * Outputs stats boxes.
 	 *
-	 * @since  1.2.0
-	 * @param  $title string title of stat
-	 * @param  $data string stats data
-	 * @return void
+	 * @since      1.2.0
+	 * @deprecated 4.2.0
+	 * @param      string $title Title of stat.
+	 * @param      string $data  Stats data.
+	 * @return     void
 	 */
 	public function render_stats_box( $title, $data ) {
+
+		_deprecated_function( __METHOD__, '4.2.0' );
+
 		?>
 		<div class="postbox">
 			<h2><span><?php echo esc_html( $title ); ?></span></h2>


### PR DESCRIPTION
Part of #4836

### Changes proposed in this Pull Request

This PR removes the totals sidebar on the Reports/Analysis screen.

### Testing instructions

* Go to Sensei LMS -> Analysis (not Reports yet)
* Check that the totals sidebar is not there and there are no errors on all sub-screens.

### Removed Hooks

* `sensei_analysis_before_stats_boxes` - Action removed along with the Reports sidebar.
* `sensei_analysis_after_stats_boxes` - Action removed along with the Reports sidebar.

### Deprecated Code

* `Sensei_Analysis::render_stats_box` - No replacement.
* `Sensei_Analysis_Overview_List_Table::stats_boxes` - No replacement.

