### PR TITLE
Open links in new tab for WooCommerce & Content Drip settings promos

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -599,15 +599,17 @@
 	}
 
 	&__redirect-button {
+		align-items: center;
 		background-color: #6fcfb2;
 		border-color: #6fcfb2;
-		color: #000;
-		height: 36px;
-		width: 180px;
 		border-radius: 4px;
+		box-shadow: none;
+		color: #000;
 		display: flex;
+		height: 36px;
 		justify-content: center;
-		align-items: center;
+		outline: none;
+		width: 180px;
 	}
 
 	&__background-image {

--- a/includes/class-sensei-settings-api.php
+++ b/includes/class-sensei-settings-api.php
@@ -133,9 +133,19 @@ class Sensei_Settings_API {
 		?>
 		<div id="sensei-promo-banner" class="sensei-promo-banner">
 			<div class="sensei-promo-banner__background sensei-promo-banner__background-large sensei-promo-banner__background-medium">
-				<span class="sensei-promo-banner__header"><?php echo esc_html( $header ); ?></span>
-				<span class="sensei-promo-banner__body"><?php echo esc_html( $text ); ?> </span>
-				<a class="button button-primary sensei-promo-banner__redirect-button" href="<?php echo esc_url( $url ); ?>"><?php echo esc_html( $button_text ); ?></a>
+				<span class="sensei-promo-banner__header">
+					<?php echo esc_html( $header ); ?>
+				</span>
+				<span class="sensei-promo-banner__body">
+					<?php echo esc_html( $text ); ?>
+				</span>
+				<a
+					class="button button-primary sensei-promo-banner__redirect-button"
+					href="<?php echo esc_url( $url ); ?>"
+					target="_blank"
+				>
+					<?php echo esc_html( $button_text ); ?>
+				</a>
 			</div>
 			<div class="sensei-promo-banner__side-background">
 				<picture>


### PR DESCRIPTION
### Changes proposed in this Pull Request

- When the _Upgrade to Sensei Pro_ button is clicked, open the page in a new tab.
- Remove button styling for focus state.

### Testing instructions

- On the _WooCommerce_ tab of Sensei's settings, click the _Upgrade to Sensei Pro_ button and ensure the page opens in a new tab.
- Check that the button styling hasn't changed.
- Repeat the above steps for the _Content Drip_ tab of Sensei's settings.