### PR TITLE
Fix addEventListener when no element is found

### DIFF
--- a/assets/js/admin/course-edit.js
+++ b/assets/js/admin/course-edit.js
@@ -62,7 +62,7 @@ domReady( () => {
 	// Log when the "Add Lesson" link is clicked.
 	document
 		.querySelector( 'a.add-course-lesson' )
-		.addEventListener(
+		?.addEventListener(
 			'click',
 			trackLinkClickCallback( 'course_add_lesson_click' )
 		);
@@ -70,7 +70,7 @@ domReady( () => {
 	// Log when the "Edit Lesson" link is clicked.
 	document
 		.querySelector( 'a.edit-lesson-action' )
-		.addEventListener(
+		?.addEventListener(
 			'click',
 			trackLinkClickCallback( 'course_edit_lesson_click' )
 		);


### PR DESCRIPTION
Fixes error reported in https://github.com/Automattic/sensei/pull/4819#discussion_r812178420

### Changes proposed in this Pull Request

* It handles the case when no elements are found with the selector before attaching the event.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a new course, and make sure you don't see errors in the console.