### PR TITLE
Add build/test JS files to the list of files that can use devDependencies

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,7 +17,15 @@ module.exports = {
 		'import/no-extraneous-dependencies': [
 			'error',
 			{
-				devDependencies: [ '**/*.test.js', 'webpack.config.js' ],
+				devDependencies: [
+					'**/*.test.js',
+					'scripts/**/*.js',
+					'tests/**/*.js',
+					'webpack.config.js',
+					'postcss.config.js',
+					'jest.setup.js',
+					'jest.config.js',
+				],
 				peerDependencies: false,
 				optionalDependencies: false,
 				bundledDependencies: false,


### PR DESCRIPTION
This is a complement for #4820, where I finally add some missing files to the list of files that can use packages in the `devDependencies` list, as checked by the rule `import/no-extraneous-dependencies`.

### Changes proposed in this Pull Request

* Includes some files to the list of files that can use `devDependencies`, as checked by the rule `import/no-extraneous-dependencies`;

### Testing instructions

* Download the branch folder, and run `./node_modules/.bin/wp-scripts lint-js --ext js,jsx` on the project folder;
* Verify that none of the errors is related to the  `import/no-extraneous-dependencies` rule;