### PR TITLE
Fix teachers can see all courses on some screens

### DIFF
--- a/includes/admin/class-sensei-admin-notices.php
+++ b/includes/admin/class-sensei-admin-notices.php
@@ -56,7 +56,7 @@ class Sensei_Admin_Notices {
 		'edit-question-type',
 		'edit-question-category',
 		'edit-lesson-tag',
-		'course_page_sensei_reports',
+		'course_page_' . Sensei_Analysis::PAGE_SLUG,
 		'course_page_sensei_learners',
 		'course_page_sensei-settings',
 		'course_page_sensei_grading',

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -579,7 +579,7 @@ class Sensei_Teacher {
 		$sensei_post_types = array( 'course', 'lesson', 'question' );
 
 		// exit early for the following conditions
-		$limit_screen_ids = array( 'sensei-lms_page_sensei_analysis', 'course_page_module-order' );
+		$limit_screen_ids = array( 'course_page_' . Sensei_Analysis::PAGE_SLUG, 'course_page_module-order' );
 
 		if ( ! $this->is_admin_teacher() || empty( $screen ) || ! in_array( $screen->id, $limit_screen_ids )
 			|| ! in_array( $query->query['post_type'], $sensei_post_types ) ) {
@@ -687,9 +687,9 @@ class Sensei_Teacher {
 			return $query;
 		}
 		switch ( $screen->id ) {
-			case 'sensei-lms_page_sensei_grading':
-			case 'sensei-lms_page_sensei_analysis':
-			case 'sensei-lms_page_sensei_learners':
+			case 'course_page_sensei_grading':
+			case 'course_page_' . Sensei_Analysis::PAGE_SLUG:
+			case 'course_page_sensei_learners':
 			case 'lesson':
 			case 'course':
 			case 'question':


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR prevents the teachers from seeing all courses on the Reports, Student Management, and Grading (filters only) screens.

### Testing instructions

* With a teacher user, make a course with a lesson, and a quiz.
* With another user, make a course with a lesson, and a quiz.
* Enroll a user in both courses and submit the quiz.
* Login as the teacher.
* Go to Sensei LMS -> Student Management.
* Make sure you see only your course.
* Go to Sensei LMS -> Grading.
* Make sure you can filter only by your course.
* Go to Sensei LMS -> Reports.
* Make sure you can see only your course and lessons.
