### PR TITLE
Add lesson actions and navigation to the bottom of the content, for screen reader only

### DIFF
--- a/assets/css/sensei-course-theme/lesson-actions.scss
+++ b/assets/css/sensei-course-theme/lesson-actions.scss
@@ -21,3 +21,8 @@
 	gap: 12px;
 
 }
+
+.sensei-course-theme__read-only-actions {
+	position: absolute;
+	left: -9999999px;
+}

--- a/assets/css/sensei-course-theme/lesson-actions.scss
+++ b/assets/css/sensei-course-theme/lesson-actions.scss
@@ -21,8 +21,3 @@
 	gap: 12px;
 
 }
-
-.sensei-course-theme__read-only-actions {
-	position: absolute;
-	left: -9999999px;
-}

--- a/includes/blocks/course-theme/class-page-actions.php
+++ b/includes/blocks/course-theme/class-page-actions.php
@@ -43,7 +43,7 @@ class Page_Actions {
 
 		switch ( get_post_type() ) {
 			case 'lesson':
-				return $this->render_post_pagination();
+				return $this->render_lesson_actions();
 			case 'quiz':
 				return do_blocks( '<!-- wp:sensei-lms/quiz-actions /-->' );
 		}
@@ -52,18 +52,27 @@ class Page_Actions {
 	}
 
 	/**
-	 * Render the WordPress post pagination.
+	 * Render the Lesson actions.
 	 *
 	 * @return string
 	 */
-	private function render_post_pagination() {
-
-		return wp_link_pages(
+	private function render_lesson_actions() {
+		// WordPress post pagination.
+		$actions = wp_link_pages(
 			[
 				'echo'   => false,
 				'before' => '<div class="wp-block-sensei-lms-page-actions sensei-course-theme__post-pagination">',
 				'after'  => '</div>',
 			]
 		);
+
+		// Prev and next navigation, and lesson actions.
+		$actions = $actions .
+			'<div class="sensei-course-theme__read-only-actions">' .
+				do_blocks( '<!-- wp:sensei-lms/course-theme-prev-next-lesson /-->' ) .
+				do_blocks( '<!-- wp:sensei-lms/course-theme-lesson-actions /-->' ) .
+			'</div>';
+
+		return $actions;
 	}
 }

--- a/includes/blocks/course-theme/class-page-actions.php
+++ b/includes/blocks/course-theme/class-page-actions.php
@@ -68,7 +68,7 @@ class Page_Actions {
 
 		// Prev and next navigation, and lesson actions.
 		$actions = $actions .
-			'<div class="sensei-course-theme__read-only-actions">' .
+			'<div class="screen-reader-text">' .
 				do_blocks( '<!-- wp:sensei-lms/course-theme-prev-next-lesson /-->' ) .
 				do_blocks( '<!-- wp:sensei-lms/course-theme-lesson-actions /-->' ) .
 			'</div>';


### PR DESCRIPTION
Fixes #4738

### Changes proposed in this Pull Request

* It adds the prev/next links and the lesson actions, like "take quiz" and "complete lesson" buttons, to the Page Actions block which is added by default to the bottom of the lesson content.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course with Learning Mode.
* Activate a screen reader.
* Navigate through the course, and make sure that after the content it reads the lesson actions (prev/next, complete lesson, take quiz).

### Considered alternatives

I thought about adding anchors to that parts but reading carefully [the comment from Alex](https://github.com/Automattic/sensei/issues/4742#issuecomment-1047271157), I think it wouldn't be nice because they wouldn't continue with the reference at the bottom of the lesson. So it seems duplication is the best approach here.