### PR TITLE
Reports: Replace `Date Registered` column with `Last Activity`

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -74,7 +74,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$columns = array(
 					'title'             => __( 'Student', 'sensei-lms' ),
 					'email'             => __( 'Email', 'sensei-lms' ),
-					'registered'        => __( 'Date Registered', 'sensei-lms' ),
+					'last_activity'     => __( 'Last Activity', 'sensei-lms' ),
 					'active_courses'    => __( 'Active Courses', 'sensei-lms' ),
 					'completed_courses' => __( 'Completed Courses', 'sensei-lms' ),
 					'average_grade'     => __( 'Average Grade', 'sensei-lms' ),
@@ -121,7 +121,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$columns = array(
 					'title'             => array( 'user_login', false ),
 					'email'             => array( 'user_email', false ),
-					'registered'        => array( 'registered', false ),
 					'active_courses'    => array( 'active_courses', false ),
 					'completed_courses' => array( 'completed_courses', false ),
 					'average_grade'     => array( 'average_grade', false ),
@@ -465,6 +464,33 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					$user_average_grade = Sensei_Utils::quotient_as_absolute_rounded_number( $grade_total, $grade_count, 2 );
 				}
 
+				// Get the last lesson activity.
+				$last_activity_comment = Sensei_Utils::sensei_check_for_activity(
+					array(
+						'number'  => 1,
+						'user_id' => $item->ID,
+						'type'    => 'sensei_lesson_status',
+					),
+					true
+				);
+
+				$last_activity = null;
+				if ( $last_activity_comment ) {
+					if ( $this->csv_output ) {
+						$last_activity = $last_activity_comment->comment_date;
+					} else {
+						$last_activity = sprintf(
+							'<abbr title="%s">%s</abbr>',
+							$last_activity_comment->comment_date,
+							sprintf(
+								/* translators: Time difference between two dates. %s: Number of seconds/minutes/etc. */
+								esc_html__( '%s ago', 'sensei-lms' ),
+								human_time_diff( strtotime( $last_activity_comment->comment_date_gmt ) )
+							)
+						);
+					}
+				}
+
 				$user_email = $item->user_email;
 
 				// Output the users data
@@ -487,7 +513,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					array(
 						'title'             => $user_name,
 						'email'             => $user_email,
-						'registered'        => $item->user_registered,
+						'last_activity'     => $last_activity,
 						'active_courses'    => ( $user_courses_started - $user_courses_ended ),
 						'completed_courses' => $user_courses_ended,
 						'average_grade'     => $user_average_grade,
@@ -585,7 +611,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		}
 
 		// This stops the full meta data of each user being loaded
-		$args['fields'] = array( 'ID', 'user_login', 'user_email', 'user_registered', 'display_name' );
+		$args['fields'] = array( 'ID', 'user_login', 'user_email', 'display_name' );
 
 		/**
 		 * Filter the WP_User_Query arguments

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -662,7 +662,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				'number'  => 1,
 				'user_id' => $user_id,
 				'type'    => 'sensei_lesson_status',
-				'status'  => [ 'complete', 'passed', 'ungraded', 'failed' ],
+				'status'  => [ 'complete', 'passed', 'graded' ],
 			),
 			true
 		);

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -648,12 +648,13 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 	/**
 	 * Get the last user activity date.
-	 * It is based on the date on which the last lesson was submitted (completed).
+	 * It is based on the date on which the last lesson was completed.
 	 *
 	 * @since 4.2.0
 	 *
-	 * @param  int $user_id
-	 * @return string
+	 * @param int $user_id The user ID.
+	 *
+	 * @return string The last activity date or 'N/A' if there is none.
 	 */
 	private function get_last_activity( int $user_id ): string {
 		$last_activity_comment = Sensei_Utils::sensei_check_for_activity(
@@ -667,7 +668,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		);
 
 		if ( ! $last_activity_comment ) {
-			return '';
+			return 'N/A';
 		}
 
 		// Return the full date when doing CSV export.

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -477,11 +477,11 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$last_activity = null;
 				if ( $last_activity_comment ) {
 					if ( $this->csv_output ) {
-						$last_activity = $last_activity_comment->comment_date;
+						$last_activity = $last_activity_comment->comment_date_gmt;
 					} else {
 						$last_activity = sprintf(
 							'<abbr title="%s">%s</abbr>',
-							$last_activity_comment->comment_date,
+							$last_activity_comment->comment_date_gmt,
 							sprintf(
 								/* translators: Time difference between two dates. %s: Number of seconds/minutes/etc. */
 								esc_html__( '%s ago', 'sensei-lms' ),

--- a/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
@@ -44,7 +44,8 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 		Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
 
 		/* Assert. */
-		$this->assertEmpty(
+		$this->assertEquals(
+			'N/A',
 			$method->invoke( $instance, $user_id ),
 			'The last activity should not take into account lessons that are in progress.'
 		);
@@ -92,9 +93,9 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 	 */
 	public function lessonCompleteStatuses(): array {
 		return [
+			[ 'complete' ],
 			[ 'passed' ],
-			[ 'ungraded' ],
-			[ 'failed' ],
+			[ 'graded' ],
 		];
 	}
 

--- a/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
@@ -46,7 +46,6 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 			]
 		);
 
-
 		$instance = new Sensei_Analysis_Overview_List_Table();
 		$method   = new ReflectionMethod( $instance, 'get_last_activity' );
 		$method->setAccessible( true );

--- a/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
@@ -24,26 +24,15 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests the last activity logic.
+	 * Tests that the last activity is ignoring "in-progress" lessons.
 	 *
 	 * @covers Sensei_Admin::get_last_activity
 	 */
-	public function testGetLastActivity() {
+	public function testGetLastActivityShouldIgnoreInProgressLessons() {
 		/* Arrange. */
-		$user_id  = $this->factory->user->create();
-		$lesson_1 = $this->factory->lesson->create(
-			[
-				'meta_input' => [
-					'_lesson_course' => $this->factory->course->create(),
-				],
-			]
-		);
-		$lesson_2 = $this->factory->lesson->create(
-			[
-				'meta_input' => [
-					'_lesson_course' => $this->factory->course->create(),
-				],
-			]
+		$user_id   = $this->factory->user->create();
+		$lesson_id = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $this->factory->course->create() ] ]
 		);
 
 		$instance = new Sensei_Analysis_Overview_List_Table();
@@ -52,63 +41,87 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 
 		/* Act. */
 		// Start lesson 1 (status: in-progress).
-		$lesson_1_activity_comment_id = Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id );
+		Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
 
 		/* Assert. */
 		$this->assertEmpty(
 			$method->invoke( $instance, $user_id ),
-			'The last activity should not take into account activities that are in progress.'
+			'The last activity should not take into account lessons that are in progress.'
+		);
+	}
+
+	/**
+	 * Tests that the last activity is based on "completed" lessons.
+	 *
+	 * @covers Sensei_Admin::get_last_activity
+	 * @dataProvider lessonCompleteStatuses
+	 */
+	public function testGetLastActivityShouldBeBasedOnCompletedLessons( $lesson_complete_status ) {
+		/* Arrange. */
+		$user_id   = $this->factory->user->create();
+		$lesson_id = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $this->factory->course->create() ] ]
 		);
 
+		$instance = new Sensei_Analysis_Overview_List_Table();
+		$method   = new ReflectionMethod( $instance, 'get_last_activity' );
+		$method->setAccessible( true );
+
 		/* Act. */
-		// Simulate quiz submission.
+		$lesson_activity_comment_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id );
+
+		// Update the lesson status.
 		wp_update_comment(
 			[
-				'comment_ID'       => $lesson_1_activity_comment_id,
-				'comment_approved' => 'ungraded',
+				'comment_ID'       => $lesson_activity_comment_id,
+				'comment_approved' => $lesson_complete_status,
 			]
 		);
 
 		/* Assert. */
 		$this->assertNotEmpty(
 			$method->invoke( $instance, $user_id ),
-			'The last activity should take into account activities with status "ungraded".'
+			'The last activity should take into account lessons with status "' . $lesson_complete_status . '".'
 		);
+	}
+
+	/**
+	 * Lesson statuses that mark the lesson as completed.
+	 *
+	 * @return string[][]
+	 */
+	public function lessonCompleteStatuses(): array {
+		return [
+			[ 'passed' ],
+			[ 'ungraded' ],
+			[ 'failed' ],
+		];
+	}
+
+	/**
+	 * Tests that the last activity should be the more recent one.
+	 *
+	 * @covers Sensei_Admin::get_last_activity
+	 */
+	public function testGetLastActivityShouldReturnTheMoreRecentActivity() {
+		/* Arrange. */
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+		$lesson_1  = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$lesson_2  = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+
+		$instance = new Sensei_Analysis_Overview_List_Table();
+		$method   = new ReflectionMethod( $instance, 'get_last_activity' );
+		$method->setAccessible( true );
 
 		/* Act. */
-		// Simulate passing a quiz.
-		wp_update_comment(
-			[
-				'comment_ID'       => $lesson_1_activity_comment_id,
-				'comment_approved' => 'passed',
-			]
-		);
-
-		/* Assert. */
-		$this->assertNotEmpty(
-			$method->invoke( $instance, $user_id ),
-			'The last activity should take into account activities with status "passed".'
-		);
-
-		/* Act. */
-		// Simulate failing a quiz.
-		wp_update_comment(
-			[
-				'comment_ID'       => $lesson_1_activity_comment_id,
-				'comment_approved' => 'failed',
-			]
-		);
-
-		/* Assert. */
-		$this->assertNotEmpty(
-			$method->invoke( $instance, $user_id ),
-			'The last activity should take into account activities with status "failed".'
-		);
-
-		/* Act. */
-		// Complete lesson 1 and update its date.
+		// Complete lesson 1 and update its activity date.
 		$lesson_1_activity_comment_id = Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id, true );
-		$lesson_1_activity_timestamp  = strtotime( '-7 days' );
+		$lesson_1_activity_timestamp  = strtotime( '-3 days' );
 		wp_update_comment(
 			[
 				'comment_ID'   => $lesson_1_activity_comment_id,
@@ -116,21 +129,9 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 			]
 		);
 
-		/* Assert. */
-		$this->assertEquals(
-			wp_date(
-				get_option( 'date_format' ),
-				$lesson_1_activity_timestamp,
-				new DateTimeZone( 'GMT' )
-			),
-			$method->invoke( $instance, $user_id ),
-			'The last activity date format or timezone is invalid.'
-		);
-
-		/* Act. */
-		// Complete lesson 2 and update its date.
+		// Complete lesson 2 and update its activity date.
 		$lesson_2_activity_comment_id = Sensei_Utils::sensei_start_lesson( $lesson_2, $user_id, true );
-		$lesson_2_activity_timestamp  = strtotime( '-1 day' );
+		$lesson_2_activity_timestamp  = strtotime( '-2 day' );
 		wp_update_comment(
 			[
 				'comment_ID'   => $lesson_2_activity_comment_id,
@@ -140,10 +141,82 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 
 		/* Assert. */
 		$this->assertEquals(
-			'1 day ago',
+			'2 days ago',
 			$method->invoke( $instance, $user_id ),
-			'The last activity should be the more recent activity or the date format is invalid and should be in human-readable form.'
+			'The last activity should be the more recent activity.'
 		);
 
+		/* Act. */
+		// Update lesson 1 activity date.
+		$lesson_1_activity_timestamp = strtotime( '-1 days' );
+		wp_update_comment(
+			[
+				'comment_ID'   => $lesson_1_activity_comment_id,
+				'comment_date' => gmdate( 'Y-m-d H:i:s', $lesson_1_activity_timestamp ),
+			]
+		);
+
+		/* Assert. */
+		$this->assertEquals(
+			'1 day ago',
+			$method->invoke( $instance, $user_id ),
+			'The last activity should be the more recent activity.'
+		);
+	}
+
+	/**
+	 * Tests that the last activity date format is human-readable when less than a week.
+	 *
+	 * @covers Sensei_Admin::get_last_activity
+	 */
+	public function testGetLastActivityShouldUseHumanReadableTimeFormatIfLessThanAWeek() {
+		/* Arrange. */
+		$user_id   = $this->factory->user->create();
+		$lesson_id = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $this->factory->course->create() ] ]
+		);
+
+		$instance = new Sensei_Analysis_Overview_List_Table();
+		$method   = new ReflectionMethod( $instance, 'get_last_activity' );
+		$method->setAccessible( true );
+
+		/* Act. */
+		// Complete lesson and update its activity date.
+		$lesson_activity_comment_id = Sensei_Utils::sensei_start_lesson( $lesson_id, $user_id, true );
+		$lesson_activity_timestamp  = strtotime( '-7 days' );
+		wp_update_comment(
+			[
+				'comment_ID'   => $lesson_activity_comment_id,
+				'comment_date' => gmdate( 'Y-m-d H:i:s', $lesson_activity_timestamp ),
+			]
+		);
+
+		/* Assert. */
+		$this->assertEquals(
+			wp_date(
+				get_option( 'date_format' ),
+				$lesson_activity_timestamp,
+				new DateTimeZone( 'GMT' )
+			),
+			$method->invoke( $instance, $user_id ),
+			'The last activity date format or timezone is invalid.'
+		);
+
+		/* Act. */
+		// Update the lesson's activity date.
+		$lesson_activity_timestamp = strtotime( '-1 day' );
+		wp_update_comment(
+			[
+				'comment_ID'   => $lesson_activity_comment_id,
+				'comment_date' => gmdate( 'Y-m-d H:i:s', $lesson_activity_timestamp ),
+			]
+		);
+
+		/* Assert. */
+		$this->assertEquals(
+			'1 day ago',
+			$method->invoke( $instance, $user_id ),
+			'The last activity date format should be in human-readable form.'
+		);
 	}
 }

--- a/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * Tests for Sensei_Analysis_Overview_List_Table class.
+ */
+class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
+
+	/**
+	 * Set up before each test.
+	 */
+	public function setup() {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		$this->factory->tearDown();
+	}
+
+	/**
+	 * Tests the last activity logic.
+	 *
+	 * @covers Sensei_Admin::get_last_activity
+	 */
+	public function testGetLastActivity() {
+		/* Arrange. */
+		$user_id  = $this->factory->user->create();
+		$lesson_1 = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course' => $this->factory->course->create(),
+				],
+			]
+		);
+		$lesson_2 = $this->factory->lesson->create(
+			[
+				'meta_input' => [
+					'_lesson_course' => $this->factory->course->create(),
+				],
+			]
+		);
+
+
+		$instance = new Sensei_Analysis_Overview_List_Table();
+		$method   = new ReflectionMethod( $instance, 'get_last_activity' );
+		$method->setAccessible( true );
+
+		/* Act. */
+		// Start lesson 1 (status: in-progress).
+		$lesson_1_activity_comment_id = Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id );
+
+		/* Assert. */
+		$this->assertEmpty(
+			$method->invoke( $instance, $user_id ),
+			'The last activity should not take into account activities that are in progress.'
+		);
+
+		/* Act. */
+		// Simulate quiz submission.
+		wp_update_comment(
+			[
+				'comment_ID'       => $lesson_1_activity_comment_id,
+				'comment_approved' => 'ungraded',
+			]
+		);
+
+		/* Assert. */
+		$this->assertNotEmpty(
+			$method->invoke( $instance, $user_id ),
+			'The last activity should take into account activities with status "ungraded".'
+		);
+
+		/* Act. */
+		// Simulate passing a quiz.
+		wp_update_comment(
+			[
+				'comment_ID'       => $lesson_1_activity_comment_id,
+				'comment_approved' => 'passed',
+			]
+		);
+
+		/* Assert. */
+		$this->assertNotEmpty(
+			$method->invoke( $instance, $user_id ),
+			'The last activity should take into account activities with status "passed".'
+		);
+
+		/* Act. */
+		// Simulate failing a quiz.
+		wp_update_comment(
+			[
+				'comment_ID'       => $lesson_1_activity_comment_id,
+				'comment_approved' => 'failed',
+			]
+		);
+
+		/* Assert. */
+		$this->assertNotEmpty(
+			$method->invoke( $instance, $user_id ),
+			'The last activity should take into account activities with status "failed".'
+		);
+
+		/* Act. */
+		// Complete lesson 1 and update its date.
+		$lesson_1_activity_comment_id = Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id, true );
+		$lesson_1_activity_timestamp  = strtotime( '-7 days' );
+		wp_update_comment(
+			[
+				'comment_ID'   => $lesson_1_activity_comment_id,
+				'comment_date' => gmdate( 'Y-m-d H:i:s', $lesson_1_activity_timestamp ),
+			]
+		);
+
+		/* Assert. */
+		$this->assertEquals(
+			wp_date(
+				get_option( 'date_format' ),
+				$lesson_1_activity_timestamp,
+				new DateTimeZone( 'GMT' )
+			),
+			$method->invoke( $instance, $user_id ),
+			'The last activity date format or timezone is invalid.'
+		);
+
+		/* Act. */
+		// Complete lesson 2 and update its date.
+		$lesson_2_activity_comment_id = Sensei_Utils::sensei_start_lesson( $lesson_2, $user_id, true );
+		$lesson_2_activity_timestamp  = strtotime( '-1 day' );
+		wp_update_comment(
+			[
+				'comment_ID'   => $lesson_2_activity_comment_id,
+				'comment_date' => gmdate( 'Y-m-d H:i:s', $lesson_2_activity_timestamp ),
+			]
+		);
+
+		/* Assert. */
+		$this->assertEquals(
+			'1 day ago',
+			$method->invoke( $instance, $user_id ),
+			'The last activity should be the more recent activity or the date format is invalid and should be in human-readable form.'
+		);
+
+	}
+}

--- a/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
@@ -111,7 +111,8 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 		);
 
 		/* Assert. */
-		$this->assertNotEmpty(
+		$this->assertStringEndsWith(
+			'ago',
 			$method->invoke( $instance, $user_id ),
 			'The last activity should take into account lessons with status "' . $lesson_complete_status . '".'
 		);


### PR DESCRIPTION
Part of #4833

### Changes proposed in this Pull Request

This PR replaces the "date registered" column in the students report with "last activity". The last activity date is based on lesson activities (lesson status change).

### Testing instructions

* Create two new courses with lessons.
* Go to the first course and mark a lesson as complete.
* Go to Sensei LMS -> Analysis.
* Make sure the last activity date and date diff for the first course is correct.
* Make sure the last activity is empty for the second course.
* Export the data to CSV and make sure it's correct.
