### PR TITLE
Update navigation on Reports page

### DIFF
--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -166,6 +166,12 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	align-items: center;
 	justify-content: flex-start;
 	gap: 20px;
+	width: 100%;
+	padding-right: 20px;
+
+	&__separator {
+		flex: 1;
+	}
 }
 
 a.sensei-custom-navigation__tab {
@@ -183,6 +189,17 @@ a.sensei-custom-navigation__tab.active {
 
 a.sensei-custom-navigation__tab:hover {
 	border-bottom: 4px solid #1E1E1E;
+}
+
+.sensei-custom-navigation__info {
+	display: flex;
+	gap: 5px;
+	align-items: flex-end;
+
+	a {
+		text-decoration: none;
+		font-size: 14px;
+	}
 }
 
 .sensei-custom-navigation__links {

--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -169,7 +169,7 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	width: 100%;
 	padding-right: 20px;
 
-	&__separator {
+	&-separator {
 		flex: 1;
 	}
 }

--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -191,14 +191,14 @@ a.sensei-custom-navigation__tab:hover {
 	border-bottom: 4px solid #1E1E1E;
 }
 
-.sensei-custom-navigation__info {
-	display: flex;
-	gap: 5px;
-	align-items: flex-end;
+a.sensei-custom-navigation__info {
+	text-decoration: none;
+	font-size: 14px;
 
-	a {
-		text-decoration: none;
-		font-size: 14px;
+	&:after {
+		content: url(../icons/external-link.svg);
+		margin-left: 5px;
+		vertical-align: text-top;
 	}
 }
 

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -397,7 +397,7 @@ class Sensei_Admin {
 	 * @return bool
 	 */
 	private function has_custom_navigation( $screen ) {
-		$screens_with_custom_navigation = [ 'edit-course', 'edit-course-category', 'edit-module', 'edit-lesson', 'edit-lesson-tag', 'edit-question', 'edit-question-category', 'course_page_sensei_analysis' ];
+		$screens_with_custom_navigation = [ 'edit-course', 'edit-course-category', 'edit-module', 'edit-lesson', 'edit-lesson-tag', 'edit-question', 'edit-question-category', 'course_page_' . Sensei_Analysis::PAGE_SLUG ];
 
 		return $screen
 			&& ( in_array( $screen->id, $screens_with_custom_navigation, true ) )

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -373,8 +373,8 @@ class Sensei_Admin {
 			Sensei()->assets->enqueue( 'sensei-ordering', 'js/admin/ordering.js', [ 'jquery', 'jquery-ui-sortable', 'sensei-core-select2' ], true );
 		}
 
-		// load edit module scripts
-		if ( 'edit-module' == $screen->id ) {
+		// Load edit module scripts.
+		if ( 'edit-module' === $screen->id ) {
 			wp_enqueue_script( 'sensei-chosen-ajax' );
 		}
 
@@ -383,18 +383,25 @@ class Sensei_Admin {
 		// Event logging.
 		Sensei()->assets->enqueue( 'sensei-event-logging', 'js/admin/event-logging.js', [ 'jquery' ], true );
 
-		// Sensei custom navigation.
-		$screens_with_custom_navigation = [ 'edit-course', 'edit-course-category', 'edit-module', 'edit-lesson', 'edit-lesson-tag', 'edit-question', 'edit-question-category' ];
-
-		if (
-			$screen
-			&& ( in_array( $screen->id, $screens_with_custom_navigation, true ) )
-			&& ( 'term' !== $screen->base )
-		) {
+		if ( $this->has_custom_navigation( $screen ) ) {
 			Sensei()->assets->enqueue( 'sensei-admin-custom-navigation', 'js/admin/custom-navigation.js', [], true );
 		}
 
 		wp_localize_script( 'sensei-event-logging', 'sensei_event_logging', [ 'enabled' => Sensei_Usage_Tracking::get_instance()->get_tracking_enabled() ] );
+	}
+
+	/**
+	 * Check if the current screen has a custom navigation.
+	 *
+	 * @param WP_Screen|null $screen The current screen.
+	 * @return bool
+	 */
+	private function has_custom_navigation( $screen ) {
+		$screens_with_custom_navigation = [ 'edit-course', 'edit-course-category', 'edit-module', 'edit-lesson', 'edit-lesson-tag', 'edit-question', 'edit-question-category', 'course_page_sensei_analysis' ];
+
+		return $screen
+			&& ( in_array( $screen->id, $screens_with_custom_navigation, true ) )
+			&& ( 'term' !== $screen->base );
 	}
 
 

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -34,7 +34,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		parent::__construct( 'analysis_overview' );
 
 		// Actions
-		add_action( 'sensei_before_list_table', array( $this, 'data_table_header' ) );
 		add_action( 'sensei_after_list_table', array( $this, 'data_table_footer' ) );
 
 		add_filter( 'sensei_list_table_search_button_text', array( $this, 'search_button' ) );
@@ -671,9 +670,12 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * Output for table heading
 	 *
 	 * @since  1.2.0
+	 * @deprecated 4.2.0
 	 * @return void
 	 */
 	public function data_table_header() {
+		_deprecated_function( __METHOD__, '4.2.0' );
+
 		$menu = array();
 
 		$query_args     = array(

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -142,7 +142,7 @@ class Sensei_Analysis {
 			</div>
 			<div class="sensei-custom-navigation__tabbar">
 				<?php echo wp_kses( implode( '', $menu ), wp_kses_allowed_html( 'post' ) ); ?>
-				<div class="sensei-custom-navigation__tabbar__separator"></div>
+				<div class="sensei-custom-navigation__tabbar-separator"></div>
 				<a class="sensei-custom-navigation__info" target="_blank" href="https://senseilms.com/docs">
 					<?php echo esc_html__( 'Guide To Using Reports', 'sensei-lms' ); ?>
 				</a>

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -143,7 +143,9 @@ class Sensei_Analysis {
 			<div class="sensei-custom-navigation__tabbar">
 				<?php echo wp_kses( implode( '', $menu ), wp_kses_allowed_html( 'post' ) ); ?>
 				<div class="sensei-custom-navigation__tabbar__separator"></div>
-				<a class="sensei-custom-navigation__info" href="https://senseilms.com/docs">Guide To Using Reports</a>
+				<a class="sensei-custom-navigation__info" target="_blank" href="https://senseilms.com/docs">
+					<?php echo esc_html__( 'Guide To Using Reports', 'sensei-lms' ); ?>
+				</a>
 				<div></div>
 			</div>
 		</div>

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -45,9 +45,75 @@ class Sensei_Analysis {
 			add_action( 'admin_init', array( $this, 'report_download_page' ) );
 
 			add_filter( 'user_search_columns', array( $this, 'user_search_columns_filter' ), 10, 3 );
+
+			// Add custom navigation.
+			add_action( 'in_admin_header', [ $this, 'add_custom_navigation' ] );
 		}
 	}
 
+	/**
+	 * Add custom navigation to the admin pages.
+	 *
+	 * @since 4.0.0
+	 * @access private
+	 */
+	public function add_custom_navigation() {
+		// phpcs:ignore WordPress.Security.NonceVerification -- No action, nonce is not required.
+		$is_reports_page = isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug );
+
+		if ( ! $is_reports_page ) {
+			return;
+		}
+
+		$this->display_reports_navigation();
+	}
+
+	/**
+	 * Display the Reports navigation.
+	 */
+	private function display_reports_navigation() {
+		// phpcs:ignore
+		$type = isset( $_GET['view'] ) ? esc_html( $_GET['view'] ) : false;
+
+		$reports            = array(
+			'learners' => __( 'Students', 'sensei-lms' ),
+			'courses'  => __( 'Courses', 'sensei-lms' ),
+			'lessons'  => __( 'Lessons', 'sensei-lms' ),
+		);
+		$current_report_key = isset( $reports[ $type ] ) ? $type : 'learners';
+
+		$link_template = '<div><a href="%s" class="sensei-custom-navigation__tab %s">%s</a></div>';
+		$menu          = array();
+		foreach ( $reports as $key => $title ) {
+			$class_name   = $current_report_key === $key ? 'active' : '';
+			$query_args   = array(
+				'page'      => $this->page_slug,
+				'post_type' => $this->post_type,
+				'view'      => $key,
+			);
+			$menu[ $key ] = sprintf( $link_template, esc_url( add_query_arg( $query_args, admin_url( 'edit.php' ) ) ), $class_name, $title );
+		}
+		$menu = apply_filters( 'sensei_analysis_sub_menu', $menu );
+
+		?>
+		<div id="sensei-custom-navigation" class="sensei-custom-navigation">
+			<div class="sensei-custom-navigation__heading">
+				<div class="sensei-custom-navigation__title">
+					<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $this->name ) ); ?></h1>
+				</div>
+			</div>
+			<div class="sensei-custom-navigation__tabbar">
+				<?php echo wp_kses( implode( '', $menu ), wp_kses_allowed_html( 'post' ) ); ?>
+				<div class="sensei-custom-navigation__tabbar__separator"></div>
+				<div class="sensei-custom-navigation__info">
+					<a href="https://senseilms.com/docs">Guide To Using Reports</a>
+					<span class="dashicons dashicons-external"></span>
+				</div>
+				<div></div>
+			</div>
+		</div>
+		<?php
+	}
 
 	/**
 	 * analysis_admin_menu function.
@@ -185,7 +251,6 @@ class Sensei_Analysis {
 		do_action( 'analysis_before_container' );
 		do_action( 'analysis_wrapper_container', 'top' );
 
-		$this->analysis_default_nav();
 		do_action( 'sensei_analysis_after_headers' );
 
 		?>
@@ -217,7 +282,6 @@ class Sensei_Analysis {
 		do_action( 'analysis_before_container' );
 		do_action( 'analysis_wrapper_container', 'top' );
 
-		$this->analysis_user_profile_nav();
 		do_action( 'sensei_analysis_after_headers' );
 
 		?>
@@ -249,7 +313,6 @@ class Sensei_Analysis {
 		do_action( 'analysis_before_container' );
 		do_action( 'analysis_wrapper_container', 'top' );
 
-		$this->analysis_course_nav();
 		do_action( 'sensei_analysis_after_headers' );
 
 		?>
@@ -282,7 +345,6 @@ class Sensei_Analysis {
 		do_action( 'analysis_before_container' );
 		do_action( 'analysis_wrapper_container', 'top' );
 
-		$this->analysis_user_course_nav();
 		do_action( 'sensei_analysis_after_headers' );
 
 		?>
@@ -314,7 +376,6 @@ class Sensei_Analysis {
 		do_action( 'analysis_before_container' );
 		do_action( 'analysis_wrapper_container', 'top' );
 
-		$this->analysis_course_users_nav();
 		do_action( 'sensei_analysis_after_headers' );
 
 		?>
@@ -346,7 +407,6 @@ class Sensei_Analysis {
 		do_action( 'analysis_before_container' );
 		do_action( 'analysis_wrapper_container', 'top' );
 
-		$this->analysis_lesson_users_nav();
 		do_action( 'sensei_analysis_after_headers' );
 
 		?>
@@ -428,10 +488,11 @@ class Sensei_Analysis {
 	 * Default nav area for Analysis, overview of Learners, Courses and Lessons
 	 *
 	 * @since  1.2.0
+	 * @deprecated 4.2.0
 	 * @return void
 	 */
 	public function analysis_default_nav() {
-
+		_deprecated_function( __METHOD__, '4.2.0' );
 		$title = $this->name;
 		?>
 			<h1>
@@ -444,10 +505,11 @@ class Sensei_Analysis {
 	 * Nav area for Analysis of a specific User profile
 	 *
 	 * @since  1.2.0
+	 * @deprecated 4.2.0
 	 * @return void
 	 */
 	public function analysis_user_profile_nav() {
-
+		_deprecated_function( __METHOD__, '4.2.0' );
 		$analysis_args = array(
 			'page'      => $this->page_slug,
 			'post_type' => $this->post_type,
@@ -478,10 +540,11 @@ class Sensei_Analysis {
 	 * Nav area for Analysis of a specific Course and its Lessons, specific to a User
 	 *
 	 * @since  1.2.0
+	 * @deprecated 4.2.0
 	 * @return void
 	 */
 	public function analysis_user_course_nav() {
-
+		_deprecated_function( __METHOD__, '4.2.0' );
 		$analysis_args = array(
 			'page'      => $this->page_slug,
 			'post_type' => $this->post_type,
@@ -523,10 +586,11 @@ class Sensei_Analysis {
 	 * Nav area for Analysis of a specific Course and displaying its Lessons
 	 *
 	 * @since  1.2.0
+	 * @deprecated 4.2.0
 	 * @return void
 	 */
 	public function analysis_course_nav() {
-
+		_deprecated_function( __METHOD__, '4.2.0' );
 		$analysis_args = array(
 			'page'      => $this->page_slug,
 			'post_type' => $this->post_type,
@@ -553,10 +617,11 @@ class Sensei_Analysis {
 	 * Nav area for Analysis of a specific Course displaying its Users
 	 *
 	 * @since  1.2.0
+	 * @deprecated 4.2.0
 	 * @return void
 	 */
 	public function analysis_course_users_nav() {
-
+		_deprecated_function( __METHOD__, '4.2.0' );
 		$analysis_args = array(
 			'page'      => $this->page_slug,
 			'post_type' => $this->post_type,
@@ -583,10 +648,11 @@ class Sensei_Analysis {
 	 * Nav area for Analysis of a specific Lesson displaying its Users
 	 *
 	 * @since  1.2.0
+	 * @deprecated 4.2.0
 	 * @return void
 	 */
 	public function analysis_lesson_users_nav() {
-
+		_deprecated_function( __METHOD__, '4.2.0' );
 		$analysis_args = array(
 			'page'      => $this->page_slug,
 			'post_type' => $this->post_type,

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -92,7 +92,7 @@ class Sensei_Analysis {
 	 */
 	public function add_custom_navigation() {
 		// phpcs:ignore WordPress.Security.NonceVerification -- No action, nonce is not required.
-		$is_reports_page = isset( $_GET['page'] ) && ( $_GET['page'] === $this->page_slug );
+		$is_reports_page = isset( $_GET['page'] ) && ( $_GET['page'] === self::PAGE_SLUG );
 
 		if ( ! $is_reports_page ) {
 			return;
@@ -125,7 +125,7 @@ class Sensei_Analysis {
 		foreach ( $reports as $key => $title ) {
 			$class_name   = $current_report_key === $key ? 'active' : '';
 			$query_args   = array(
-				'page'      => $this->page_slug,
+				'page'      => self::PAGE_SLUG,
 				'post_type' => $this->post_type,
 				'view'      => $key,
 			);

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -54,7 +54,7 @@ class Sensei_Analysis {
 	/**
 	 * Add custom navigation to the admin pages.
 	 *
-	 * @since 4.0.0
+	 * @since 4.2.0
 	 * @access private
 	 */
 	public function add_custom_navigation() {

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -114,11 +114,11 @@ class Sensei_Analysis {
 		$type = isset( $_GET['view'] ) ? esc_html( $_GET['view'] ) : false;
 
 		$reports            = array(
-			'learners' => __( 'Students', 'sensei-lms' ),
+			'students' => __( 'Students', 'sensei-lms' ),
 			'courses'  => __( 'Courses', 'sensei-lms' ),
 			'lessons'  => __( 'Lessons', 'sensei-lms' ),
 		);
-		$current_report_key = isset( $reports[ $type ] ) ? $type : 'learners';
+		$current_report_key = isset( $reports[ $type ] ) ? $type : 'students';
 
 		$link_template = '<div><a href="%s" class="sensei-custom-navigation__tab %s">%s</a></div>';
 		$menu          = array();

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -282,6 +282,7 @@ class Sensei_Analysis {
 		do_action( 'analysis_before_container' );
 		do_action( 'analysis_wrapper_container', 'top' );
 
+		$this->analysis_user_profile_nav();
 		do_action( 'sensei_analysis_after_headers' );
 
 		?>
@@ -313,6 +314,7 @@ class Sensei_Analysis {
 		do_action( 'analysis_before_container' );
 		do_action( 'analysis_wrapper_container', 'top' );
 
+		$this->analysis_course_nav();
 		do_action( 'sensei_analysis_after_headers' );
 
 		?>
@@ -345,6 +347,7 @@ class Sensei_Analysis {
 		do_action( 'analysis_before_container' );
 		do_action( 'analysis_wrapper_container', 'top' );
 
+		$this->analysis_user_course_nav();
 		do_action( 'sensei_analysis_after_headers' );
 
 		?>
@@ -376,6 +379,7 @@ class Sensei_Analysis {
 		do_action( 'analysis_before_container' );
 		do_action( 'analysis_wrapper_container', 'top' );
 
+		$this->analysis_course_users_nav();
 		do_action( 'sensei_analysis_after_headers' );
 
 		?>
@@ -407,6 +411,7 @@ class Sensei_Analysis {
 		do_action( 'analysis_before_container' );
 		do_action( 'analysis_wrapper_container', 'top' );
 
+		$this->analysis_lesson_users_nav();
 		do_action( 'sensei_analysis_after_headers' );
 
 		?>
@@ -505,11 +510,10 @@ class Sensei_Analysis {
 	 * Nav area for Analysis of a specific User profile
 	 *
 	 * @since  1.2.0
-	 * @deprecated 4.2.0
 	 * @return void
 	 */
 	public function analysis_user_profile_nav() {
-		_deprecated_function( __METHOD__, '4.2.0' );
+
 		$analysis_args = array(
 			'page'      => $this->page_slug,
 			'post_type' => $this->post_type,
@@ -540,11 +544,10 @@ class Sensei_Analysis {
 	 * Nav area for Analysis of a specific Course and its Lessons, specific to a User
 	 *
 	 * @since  1.2.0
-	 * @deprecated 4.2.0
 	 * @return void
 	 */
 	public function analysis_user_course_nav() {
-		_deprecated_function( __METHOD__, '4.2.0' );
+
 		$analysis_args = array(
 			'page'      => $this->page_slug,
 			'post_type' => $this->post_type,
@@ -586,11 +589,10 @@ class Sensei_Analysis {
 	 * Nav area for Analysis of a specific Course and displaying its Lessons
 	 *
 	 * @since  1.2.0
-	 * @deprecated 4.2.0
 	 * @return void
 	 */
 	public function analysis_course_nav() {
-		_deprecated_function( __METHOD__, '4.2.0' );
+
 		$analysis_args = array(
 			'page'      => $this->page_slug,
 			'post_type' => $this->post_type,
@@ -617,11 +619,10 @@ class Sensei_Analysis {
 	 * Nav area for Analysis of a specific Course displaying its Users
 	 *
 	 * @since  1.2.0
-	 * @deprecated 4.2.0
 	 * @return void
 	 */
 	public function analysis_course_users_nav() {
-		_deprecated_function( __METHOD__, '4.2.0' );
+
 		$analysis_args = array(
 			'page'      => $this->page_slug,
 			'post_type' => $this->post_type,
@@ -648,11 +649,10 @@ class Sensei_Analysis {
 	 * Nav area for Analysis of a specific Lesson displaying its Users
 	 *
 	 * @since  1.2.0
-	 * @deprecated 4.2.0
 	 * @return void
 	 */
 	public function analysis_lesson_users_nav() {
-		_deprecated_function( __METHOD__, '4.2.0' );
+
 		$analysis_args = array(
 			'page'      => $this->page_slug,
 			'post_type' => $this->post_type,

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -110,10 +110,7 @@ class Sensei_Analysis {
 			<div class="sensei-custom-navigation__tabbar">
 				<?php echo wp_kses( implode( '', $menu ), wp_kses_allowed_html( 'post' ) ); ?>
 				<div class="sensei-custom-navigation__tabbar__separator"></div>
-				<div class="sensei-custom-navigation__info">
-					<a href="https://senseilms.com/docs">Guide To Using Reports</a>
-					<span class="dashicons dashicons-external"></span>
-				</div>
+				<a class="sensei-custom-navigation__info" href="https://senseilms.com/docs">Guide To Using Reports</a>
 				<div></div>
 			</div>
 		</div>

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -92,7 +92,7 @@ class Sensei_Analysis {
 	 */
 	public function add_custom_navigation() {
 		// phpcs:ignore WordPress.Security.NonceVerification -- No action, nonce is not required.
-		$is_reports_page = isset( $_GET['page'] ) && ( $_GET['page'] === self::PAGE_SLUG );
+		$is_reports_page = isset( $_GET['page'] ) && ( self::PAGE_SLUG === $_GET['page'] );
 
 		if ( ! $is_reports_page ) {
 			return;

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -135,16 +135,20 @@ class Sensei_Analysis {
 		 * Filter the Reports navigation menu items.
 		 *
 		 * @since 4.2.0
+		 * @hook sensei_analysis_sub_menu
 		 *
-		 * @param array $menu The menu items.
+		 * @param {array} $menu The menu items.
+		 * @return {array} Returns filtered menu items.
 		 */
 		$menu = apply_filters( 'sensei_analysis_sub_menu', $menu );
 		/**
 		 * Filter the Reports page title.
 		 *
 		 * @since 4.2.0
+		 * @hook sensei_analysis_nav_title
 		 *
-		 * @param string $title The page title.
+		 * @param {string} $title The page title.
+		 * @return {string} Returns filtered page title.
 		 */
 		$data = apply_filters( 'sensei_analysis_nav_title', $this->name );
 		?>

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -131,13 +131,27 @@ class Sensei_Analysis {
 			);
 			$menu[ $key ] = sprintf( $link_template, esc_url( add_query_arg( $query_args, admin_url( 'edit.php' ) ) ), $class_name, $title );
 		}
+		/**
+		 * Filter the Reports navigation menu items.
+		 *
+		 * @since 4.2.0
+		 *
+		 * @param array $menu The menu items.
+		 */
 		$menu = apply_filters( 'sensei_analysis_sub_menu', $menu );
-
+		/**
+		 * Filter the Reports page title.
+		 *
+		 * @since 4.2.0
+		 *
+		 * @param string $title The page title.
+		 */
+		$data = apply_filters( 'sensei_analysis_nav_title', $this->name );
 		?>
 		<div id="sensei-custom-navigation" class="sensei-custom-navigation">
 			<div class="sensei-custom-navigation__heading">
 				<div class="sensei-custom-navigation__title">
-					<h1><?php echo wp_kses_post( apply_filters( 'sensei_analysis_nav_title', $this->name ) ); ?></h1>
+					<h1><?php echo wp_kses_post( $data ); ?></h1>
 				</div>
 			</div>
 			<div class="sensei-custom-navigation__tabbar">

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -65,6 +65,11 @@ class Sensei_Analysis {
 			return;
 		}
 
+		// phpcs:ignore WordPress.Security.NonceVerification -- No action, nonce is not required.
+		if ( isset( $_GET['course_id'] ) || isset( $_GET['lesson_id'] ) || isset( $_GET['user_id'] ) ) {
+			return;
+		}
+
 		$this->display_reports_navigation();
 	}
 


### PR DESCRIPTION
Fixes part of #4836

### Changes proposed in this Pull Request

* Add custom navigation to Reports pages.

### Testing instructions

* Go to `/wp-admin` -> `Sensei LMS` -> `Reports`
* Check the header.
* Follow navigation links and make sure you can see the updated navigation on all Reports pages.

### New/Updated Hooks

* `sensei_analysis_sub_menu` - Filters custom navigation menu.

### Deprecated Code

* `Sensei_Analysis_Overview_List_Table::data_table_header`
* `Sensei_Analysis::analysis_default_nav`

### Screenshot / Video
<img width="1703" alt="CleanShot 2022-03-01 at 13 14 39@2x" src="https://user-images.githubusercontent.com/329356/156151015-8c5ae672-b885-40d8-9bbe-9b685d7d5b7d.png">
<img width="282" alt="CleanShot 2022-03-01 at 13 14 57@2x" src="https://user-images.githubusercontent.com/329356/156151033-f5971b89-047e-4fd9-bba8-cdafba53ea77.png">

