### PR TITLE
Hide progress bar for pagination in quiz editor if count of question is less than per page count

### DIFF
--- a/assets/blocks/quiz/quiz-block/quiz-edit.js
+++ b/assets/blocks/quiz/quiz-block/quiz-edit.js
@@ -19,6 +19,7 @@ import QuizSettings from './quiz-settings';
 import { useUpdateQuizHasQuestionsMeta } from './use-update-quiz-has-questions-meta';
 import { isQuestionEmpty } from '../data';
 import QuizProgressBarEdit from './quiz-progress-bar-edit';
+import { useSelect } from '@wordpress/data';
 
 const ALLOWED_BLOCKS = [
 	'sensei-lms/quiz-question',
@@ -52,6 +53,21 @@ const QuizEdit = ( props ) => {
 
 	const closeExistingQuestionsModal = () =>
 		setExistingQuestionsModalOpen( false );
+	const questionCount = useSelect(
+		( select ) =>
+			select( 'core/block-editor' )
+				.getBlock( clientId )
+				.innerBlocks.reduce( ( count, question ) => {
+					if ( isQuestionEmpty( question.attributes ) ) return count;
+					return (
+						count +
+						( question.attributes.type === 'category-question'
+							? question.attributes.options.number
+							: 1 )
+					);
+				}, 0 ),
+		[ clientId ]
+	);
 
 	/* Temporary solution. See https://github.com/WordPress/gutenberg/pull/29911 */
 	const AppenderComponent = useCallback(
@@ -65,7 +81,9 @@ const QuizEdit = ( props ) => {
 	);
 	const pagination = props?.attributes?.options?.pagination;
 	const showPaginationProgressBar =
-		pagination?.paginationNumber && pagination?.showProgressBar;
+		pagination?.paginationNumber &&
+		pagination?.showProgressBar &&
+		pagination.paginationNumber < questionCount;
 
 	return (
 		<>


### PR DESCRIPTION
Hide the progress bar shown in the lesson editor if the count of questions added in the editor is less than the count of questions set to be shown per page in pagination settings for that quiz

Fixes [#4631](https://github.com/Automattic/sensei/issues/4631)

### Changes proposed in this Pull Request
If pagination was set to multi-page and showing the progress bar was enabled in the settings for a lesson, it used to show the progress bar on top of the question editor. But as part of our idea is to make the editor look as similar as possible to what the user will see in the front end, we will now only show the progress bar when the valid question count is greater than the number of questions to be shown in a single page.

- If a question does not have any title, it won't be counted as a valid question. On the other hand, if a question is a category-type question, the count of the questions under that category will be taken into account instead of treating it as a single question. This way the progress bar behavior on the editor page stays similar to when it is shown in the frontend to a quiz taker.

### Testing instructions

1. Go to lessons editor
2.  Click on 'Quiz Settings' at the bottom
3. On the right sidebar, click on pagination drop-down and select multi-page
4. Enable 'Show progress bar'
5. Put a number in 'Questions per page' box above the drop-down
6. Now add questions to reach that number and see if the progress bar appears on top when you cross that number and disappears otherwise. Try removing some questions as well and observe the behavior.

Additionally:
- Try saving the questions and go out of the editor and get in again to check if the behavior holds even after reloading, with both more than and less than the 'Question per page' number of questions
- After adding a few questions, try increasing and decreasing the number you wrote in the "Quetions per page" field and see if it shows and hides the progress bar as expected
- Try enabling and disabling the 'Show progress bar' and see if the topbar is shown and hidden accordingly

### Screenshot / Video

https://user-images.githubusercontent.com/6820724/155510860-5f8186b8-9930-45f7-8a94-18e3666b51ec.mov

