### PR TITLE
Remove and rename columns from Courses report

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -52,8 +52,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			case 'courses':
 				$columns = array(
 					'title'           => __( 'Course', 'sensei-lms' ),
-					'students'        => __( 'Students', 'sensei-lms' ),
-					'lessons'         => __( 'Lessons', 'sensei-lms' ),
 					'completions'     => __( 'Completed', 'sensei-lms' ),
 					'average_percent' => __( 'Average Percentage', 'sensei-lms' ),
 				);
@@ -99,8 +97,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			case 'courses':
 				$columns = array(
 					'title'           => array( 'title', false ),
-					'students'        => array( 'students', false ),
-					'lessons'         => array( 'lessons', false ),
 					'completions'     => array( 'completions', false ),
 					'average_percent' => array( 'average_percent', false ),
 				);
@@ -280,14 +276,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		switch ( $this->type ) {
 			case 'courses':
-				// Get Learners (i.e. those who have started)
-				$course_args     = array(
-					'post_id' => $item->ID,
-					'type'    => 'sensei_course_status',
-					'status'  => 'any',
-				);
-				$course_students = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_learners', $course_args, $item ) );
-
 				// Get Course Completions
 				$course_args        = array(
 					'post_id' => $item->ID,
@@ -295,9 +283,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'status'  => 'complete',
 				);
 				$course_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_completions', $course_args, $item ) );
-
-				// Course Lessons
-				$course_lessons = Sensei()->lesson->lesson_count( array( 'publish', 'private' ), $item->ID );
 
 				// Get Percent Complete
 				$grade_args = array(
@@ -336,8 +321,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'sensei_analysis_overview_column_data',
 					array(
 						'title'           => $course_title,
-						'students'        => $course_students,
-						'lessons'         => $course_lessons,
 						'completions'     => $course_completions,
 						'average_percent' => $course_average_percent,
 					),

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -53,7 +53,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$columns = array(
 					'title'           => __( 'Course', 'sensei-lms' ),
 					'completions'     => __( 'Completed', 'sensei-lms' ),
-					'average_percent' => __( 'Average Percentage', 'sensei-lms' ),
+					'average_percent' => __( 'Average Grade', 'sensei-lms' ),
 				);
 				break;
 


### PR DESCRIPTION
Part of #4834.

### Changes proposed in this Pull Request
On the _Courses_ report:
- Remove the _Students_ and _Lessons_ columns.
- Rename the _Average Percentage_ column to _Average Grade_. I did not rename the underlying array key since this data is actually being pulled from a meta named "percent".

There are no unit tests since this is removing functionality.

### Testing instructions
Check that the only columns that exist on the _Courses_ report are _Course_, _Completed_ and _Average Grade_.