### PR TITLE
Add phpcs check for missing function param comment

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -66,7 +66,6 @@
 		<exclude-pattern>tests/</exclude-pattern>
 		<exclude name="Squiz.Commenting.LongConditionClosingComment" />
 		<exclude name="Squiz.Commenting.PostStatementComment" />
-		<exclude name="Squiz.Commenting.FunctionComment.MissingParamComment" />
 		<exclude-pattern>tests/*</exclude-pattern>
 	</rule>
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

We tend to forget param comments, so this PR will add a phpcs check for that.

### Testing instructions

* Write a method/function with a param.
* Add a docblock for that param without a comment.
* Run `phpcs` and make sure it's upset about the missing comment.
