### PR TITLE
Add new lesson report default view and course filter

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -84,15 +84,27 @@
 	display: flex;
 	gap: 20px;
 	flex-flow: row;
+
 	@media (max-width: 850px) {
 		flex-direction: column;
 	}
+
+	table  {
+		tr  {
+			td  {
+				padding: 10px 7px;
+			}
+		}
+	}
+
 	&.user-profile  {
 		margin-left: 0;
 	}
+
 	&.course-profile  {
 		margin-left: 0;
 	}
+
 	.sensei-analysis-main {
 		flex: 1;
 		.tablenav {
@@ -102,10 +114,16 @@
 			}
 		}
 	}
-	table  {
-		tr  {
-			td  {
-				padding: 10px 7px;
+
+	.sensei-analysis__inner-form {
+		margin: 50px 0;
+		text-align: center;
+
+		&__description {
+			margin-bottom: 20px;
+
+			p {
+				font-size: 14px;
 			}
 		}
 	}

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -115,14 +115,13 @@
 		}
 	}
 
-	.sensei-analysis__inner-form {
-		margin: 50px 0;
-		text-align: center;
-
-		&__description {
-			margin-bottom: 20px;
+	.sensei-analysis__filter-form {
+		&--inner {
+			margin: 50px 0;
+			text-align: center;
 
 			p {
+				margin-bottom: 20px;
 				font-size: 14px;
 			}
 		}

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -121,14 +121,10 @@
 			margin-bottom: 14px;
 		}
 
-		&__inner-filters {
+		&__no-items-message--highlighted {
 			margin: 50px 0;
 			text-align: center;
-
-			p {
-				margin-bottom: 20px;
-				font-size: 14px;
-			}
+			font-size: 14px;
 		}
 	}
 }

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -121,7 +121,7 @@
 			margin-bottom: 14px;
 		}
 
-		&__no-items-message--highlighted {
+		&__no-items-message {
 			margin: 50px 0;
 			text-align: center;
 			font-size: 14px;

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -115,8 +115,13 @@
 		}
 	}
 
-	.sensei-analysis__filter-form {
-		&--inner {
+	.sensei-analysis {
+		&__top-filters {
+			float: left;
+			margin-bottom: 14px;
+		}
+
+		&__inner-filters {
 			margin: 50px 0;
 			text-align: center;
 

--- a/assets/js/admin/reports.js
+++ b/assets/js/admin/reports.js
@@ -1,0 +1,10 @@
+/**
+ * WordPress dependencies
+ */
+import domReady from '@wordpress/dom-ready';
+
+domReady( () => {
+	jQuery( '.sensei-analysis__inner-form' ).on( 'change', ( event ) => {
+		event.currentTarget.submit();
+	} );
+} );

--- a/assets/js/admin/reports.js
+++ b/assets/js/admin/reports.js
@@ -4,7 +4,7 @@
 import domReady from '@wordpress/dom-ready';
 
 domReady( () => {
-	jQuery( '.sensei-analysis__inner-form' ).on( 'change', ( event ) => {
+	jQuery( '.sensei-analysis__filter-form' ).on( 'change', ( event ) => {
 		event.currentTarget.submit();
 	} );
 } );

--- a/assets/js/admin/reports.js
+++ b/assets/js/admin/reports.js
@@ -4,7 +4,9 @@
 import domReady from '@wordpress/dom-ready';
 
 domReady( () => {
-	jQuery( '.sensei-analysis__filter-form' ).on( 'change', ( event ) => {
+	jQuery(
+		'.sensei-analysis__top-filters, .sensei-analysis__inner-filters'
+	).on( 'change', ( event ) => {
 		event.currentTarget.submit();
 	} );
 } );

--- a/assets/js/admin/reports.js
+++ b/assets/js/admin/reports.js
@@ -4,9 +4,7 @@
 import domReady from '@wordpress/dom-ready';
 
 domReady( () => {
-	jQuery(
-		'.sensei-analysis__top-filters, .sensei-analysis__inner-filters'
-	).on( 'change', ( event ) => {
+	jQuery( '.sensei-analysis__top-filters' ).on( 'change', ( event ) => {
 		event.currentTarget.submit();
 	} );
 } );

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -748,7 +748,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	public function output_lessons_top_filters() {
 		?>
 		<form class="sensei-analysis__top-filters">
-			<?php $this->output_query_params_as_inputs(); ?>
+			<?php Sensei_Utils::output_query_params_as_inputs( [ 'course_filter', 's' ] ); ?>
 
 			<label for="sensei-course-filter">
 				<?php esc_html_e( 'Course', 'sensei-lms' ); ?>:
@@ -783,20 +783,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			<?php endforeach; ?>
 		</select>
 		<?php
-	}
-
-	/**
-	 * Output the current query params as hidden inputs.
-	 *
-	 * @since 4.2.0
-	 */
-	private function output_query_params_as_inputs() {
-		// phpcs:ignore WordPress.Security.NonceVerification -- Arguments are used for filtering.
-		foreach ( $_GET as $name => $value ) {
-			?>
-			<input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="<?php echo esc_attr( wp_unslash( $value ) ); ?>">
-			<?php
-		}
 	}
 
 	/**

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -862,6 +862,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				'view'                   => $this->type,
 				'sensei_report_download' => $report,
 				'post_type'              => $this->post_type,
+				'course_filter'          => $this->get_course_filter_value(),
 			),
 			admin_url( 'edit.php' )
 		);

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -716,11 +716,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @since  1.2.0
 	 */
 	public function no_items() {
-		$highlight = false;
 
 		if ( 'lessons' === $this->type && ! $this->get_course_filter_value() ) {
-			$message   = __( 'View your Lessons data by first selecting a course.', 'sensei-lms' );
-			$highlight = true;
+			$message = __( 'View your Lessons data by first selecting a course.', 'sensei-lms' );
 		} else {
 			if ( ! $this->type || 'users' === $this->type ) {
 				$type = __( 'students', 'sensei-lms' );
@@ -733,7 +731,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		}
 
 		?>
-		<div class="sensei-analysis__no-items-message <?php echo $highlight ? 'sensei-analysis__no-items-message--highlighted' : ''; ?>">
+		<div class="sensei-analysis__no-items-message">
 			<?php echo wp_kses_post( $message ); ?>
 		</div>
 		<?php

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -182,7 +182,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				break;
 
 			case 'lessons':
-				$this->items = $this->get_lessons( $args );
+				$this->items = $this->get_lessons( $args, $this->get_selected_course_id() );
 				break;
 
 			case 'users':
@@ -252,7 +252,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				break;
 
 			case 'lessons':
-				$this->items = $this->get_lessons( $args );
+				$this->items = $this->get_lessons( $args, $this->get_selected_course_id() );
 				break;
 
 			case 'users':
@@ -583,15 +583,21 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	}
 
 	/**
-	 * Return array of lessons
+	 * Return array of lessons.
 	 *
 	 * @since  1.7.0
 	 *
-	 * @param array $args Associative array for query.
+	 * @param array $args      The query arguments.
+	 * @param int   $course_id The selected course ID.
 	 *
-	 * @return array lessons
+	 * @return array Lesson posts or empty array if no course is selected.
 	 */
-	private function get_lessons( $args ) {
+	private function get_lessons( array $args, int $course_id ): array {
+
+		if ( ! $course_id ) {
+			return [];
+		}
+
 		$lessons_args = array(
 			'post_type'        => 'lesson',
 			'post_status'      => array( 'publish', 'private' ),
@@ -599,6 +605,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			'offset'           => $args['offset'],
 			'orderby'          => $args['orderby'],
 			'order'            => $args['order'],
+			'meta_key'         => '_lesson_course', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Applying the course filter.
+			'meta_value'       => $course_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Applying the course filter.
 			'suppress_filters' => 0,
 		);
 
@@ -845,6 +853,16 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$clauses['groupby'] .= " {$wpdb->posts}.ID";
 
 		return $clauses;
+	}
+
+	/**
+	 * Get the selected course ID.
+	 *
+	 * @return int The course ID or 0 if none is selected.
+	 */
+	private function get_selected_course_id() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for filtering.
+		return isset( $_GET['course_id'] ) ? (int) $_GET['course_id'] : 0;
 	}
 
 }

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -38,7 +38,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		// Actions.
 		if ( 'lessons' === $this->type ) {
-			add_action( 'sensei_before_list_table', array( $this, 'output_lessons_top_filter_form' ) );
+			add_action( 'sensei_before_list_table', array( $this, 'output_lessons_top_filters') );
 		}
 
 		add_action( 'sensei_after_list_table', array( $this, 'data_table_footer' ) );
@@ -717,7 +717,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 */
 	public function no_items() {
 		if ( 'lessons' === $this->type && ! $this->get_course_filter() ) {
-			$this->output_lessons_inner_filter_form();
+			$this->output_lessons_inner_filters();
 		} else {
 			if ( ! $this->type || 'users' === $this->type ) {
 				$type = __( 'students', 'sensei-lms' );
@@ -734,16 +734,16 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 *
 	 * @since  4.2.0
 	 */
-	public function output_lessons_top_filter_form() {
+	public function output_lessons_top_filters() {
 		?>
-		<form class="sensei-analysis__filter-form">
+		<form class="sensei-analysis__top-filters">
 			<?php $this->output_query_params_as_inputs(); ?>
 
 			<label for="sensei-course-filter">
 				<?php esc_html_e( 'Filter', 'sensei-lms' ); ?>:
 			</label>
 
-			<?php $this->output_course_filter_select(); ?>
+			<?php $this->output_course_select_input(); ?>
 		</form>
 		<?php
 	}
@@ -753,16 +753,16 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 *
 	 * @since 4.2.0
 	 */
-	private function output_lessons_inner_filter_form() {
+	private function output_lessons_inner_filters() {
 		?>
-		<form class="sensei-analysis__filter-form sensei-analysis__filter-form--inner">
+		<form class="sensei-analysis__inner-filters">
 			<?php $this->output_query_params_as_inputs(); ?>
 
 			<p>
 				<?php esc_html_e( 'View your Lessons data by first selecting a course.', 'sensei-lms' ); ?>
 			</p>
 
-			<?php $this->output_course_filter_select(); ?>
+			<?php $this->output_course_select_input(); ?>
 		</form>
 		<?php
 	}
@@ -772,7 +772,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 *
 	 * @since 4.2.0
 	 */
-	private function output_course_filter_select() {
+	private function output_course_select_input() {
 		$courses            = Sensei_Course::get_all_courses();
 		$selected_course_id = $this->get_course_filter();
 

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -716,17 +716,27 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @since  1.2.0
 	 */
 	public function no_items() {
+		$highlight = false;
+
 		if ( 'lessons' === $this->type && ! $this->get_course_filter_value() ) {
-			$this->output_lessons_inner_filters();
+			$message   = __( 'View your Lessons data by first selecting a course.', 'sensei-lms' );
+			$highlight = true;
 		} else {
 			if ( ! $this->type || 'users' === $this->type ) {
 				$type = __( 'students', 'sensei-lms' );
 			} else {
 				$type = $this->type;
 			}
+
 			// translators: Placeholders %1$s and %3$s are opening and closing <em> tags, %2$s is the view type.
-			echo wp_kses_post( sprintf( __( '%1$sNo %2$s found%3$s', 'sensei-lms' ), '<em>', $type, '</em>' ) );
+			$message = sprintf( __( '%1$sNo %2$s found%3$s', 'sensei-lms' ), '<em>', $type, '</em>' );
 		}
+
+		?>
+		<div class="sensei-analysis__no-items-message <?php echo $highlight ? 'sensei-analysis__no-items-message--highlighted' : ''; ?>">
+			<?php echo wp_kses_post( $message ); ?>
+		</div>
+		<?php
 	}
 
 	/**
@@ -741,27 +751,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			<?php $this->output_query_params_as_inputs(); ?>
 
 			<label for="sensei-course-filter">
-				<?php esc_html_e( 'Filter', 'sensei-lms' ); ?>:
+				<?php esc_html_e( 'Course', 'sensei-lms' ); ?>:
 			</label>
-
-			<?php $this->output_course_select_input(); ?>
-		</form>
-		<?php
-	}
-
-	/**
-	 * Output the lessons inner filter form.
-	 *
-	 * @since 4.2.0
-	 */
-	private function output_lessons_inner_filters() {
-		?>
-		<form class="sensei-analysis__inner-filters">
-			<?php $this->output_query_params_as_inputs(); ?>
-
-			<p>
-				<?php esc_html_e( 'View your Lessons data by first selecting a course.', 'sensei-lms' ); ?>
-			</p>
 
 			<?php $this->output_course_select_input(); ?>
 		</form>

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -928,14 +928,13 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	public function add_days_to_complete_to_lessons_query( $clauses ) {
 		global $wpdb;
 
-		$clauses['fields']  .= ", sum( CEILING( timestampdiff( second, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ), {$wpdb->comments}.comment_date ) / (24 * 60 * 60) )) as days_to_complete";
-		$clauses['join']    .= " LEFT JOIN {$wpdb->comments} ON {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID";
-		$clauses['join']    .= " AND {$wpdb->comments}.comment_type IN ('sensei_lesson_status')";
-		$clauses['join']    .= " AND {$wpdb->comments}.comment_approved IN ( 'complete', 'graded', 'passed', 'failed' )";
-		$clauses['join']    .= " AND {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID";
-		$clauses['join']    .= " LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id";
-		$clauses['join']    .= " AND {$wpdb->commentmeta}.meta_key = 'start'";
-		$clauses['groupby'] .= " {$wpdb->posts}.ID";
+		$clauses['fields'] .= ", sum( CEILING( timestampdiff( second, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ), {$wpdb->comments}.comment_date ) / (24 * 60 * 60) )) as days_to_complete";
+		$clauses['join']   .= " LEFT JOIN {$wpdb->comments} ON {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID";
+		$clauses['join']   .= " AND {$wpdb->comments}.comment_type IN ('sensei_lesson_status')";
+		$clauses['join']   .= " AND {$wpdb->comments}.comment_approved IN ( 'complete', 'graded', 'passed', 'failed' )";
+		$clauses['join']   .= " AND {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID";
+		$clauses['join']   .= " LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id";
+		$clauses['join']   .= " AND {$wpdb->commentmeta}.meta_key = 'start'";
 
 		return $clauses;
 	}

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -186,7 +186,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				break;
 
 			case 'lessons':
-				$this->items = $this->get_lessons( $args, $this->get_course_filter() );
+				$this->items = $this->get_lessons( $args, $this->get_course_filter_value() );
 				break;
 
 			case 'users':
@@ -256,7 +256,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				break;
 
 			case 'lessons':
-				$this->items = $this->get_lessons( $args, $this->get_course_filter() );
+				$this->items = $this->get_lessons( $args, $this->get_course_filter_value() );
 				break;
 
 			case 'users':
@@ -716,7 +716,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @since  1.2.0
 	 */
 	public function no_items() {
-		if ( 'lessons' === $this->type && ! $this->get_course_filter() ) {
+		if ( 'lessons' === $this->type && ! $this->get_course_filter_value() ) {
 			$this->output_lessons_inner_filters();
 		} else {
 			if ( ! $this->type || 'users' === $this->type ) {
@@ -733,6 +733,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * Output the lessons top filter form.
 	 *
 	 * @since  4.2.0
+	 * @access private
 	 */
 	public function output_lessons_top_filters() {
 		?>
@@ -774,7 +775,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 */
 	private function output_course_select_input() {
 		$courses            = Sensei_Course::get_all_courses();
-		$selected_course_id = $this->get_course_filter();
+		$selected_course_id = $this->get_course_filter_value();
 
 		?>
 		<select name="course_filter" id="sensei-course-filter">
@@ -944,7 +945,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 *
 	 * @return int The course ID or 0 if none is selected.
 	 */
-	private function get_course_filter(): int {
+	private function get_course_filter_value(): int {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for filtering.
 		return isset( $_GET['course_filter'] ) ? (int) $_GET['course_filter'] : 0;
 	}

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -38,7 +38,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		// Actions.
 		if ( 'lessons' === $this->type ) {
-			add_action( 'sensei_before_list_table', array( $this, 'output_lessons_top_filters') );
+			add_action( 'sensei_before_list_table', array( $this, 'output_lessons_top_filters' ) );
 		}
 
 		add_action( 'sensei_after_list_table', array( $this, 'data_table_footer' ) );

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -719,10 +719,10 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		if ( 'lessons' === $this->type && ! $this->get_course_filter() ) {
 			$this->output_lessons_inner_filter_form();
 		} else {
-			if ( ! $this->view || 'users' === $this->view ) {
-				$type = 'learners';
+			if ( ! $this->type || 'users' === $this->type ) {
+				$type = __( 'students', 'sensei-lms' );
 			} else {
-				$type = $this->view;
+				$type = $this->type;
 			}
 			// translators: Placeholders %1$s and %3$s are opening and closing <em> tags, %2$s is the view type.
 			echo wp_kses_post( sprintf( __( '%1$sNo %2$s found%3$s', 'sensei-lms' ), '<em>', $type, '</em>' ) );
@@ -775,6 +775,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	private function output_course_filter_select() {
 		$courses            = Sensei_Course::get_all_courses();
 		$selected_course_id = $this->get_course_filter();
+
 		?>
 		<select name="course_filter" id="sensei-course-filter">
 			<option>

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -55,6 +55,7 @@ class Sensei_Analysis {
 
 			// phpcs:ignore WordPress.Security.NonceVerification -- Arguments used for comparison.
 			if ( isset( $_GET['page'] ) && self::PAGE_SLUG === $_GET['page'] ) {
+				add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
 				add_action( 'admin_print_styles', array( $this, 'enqueue_styles' ) );
 			}
 
@@ -188,6 +189,17 @@ class Sensei_Analysis {
 				array( $this, 'analysis_page' )
 			);
 		}
+	}
+
+	/**
+	 * Enqueue JS scripts.
+	 *
+	 * @since 4.2.0
+	 */
+	public function enqueue_scripts() {
+
+		Sensei()->assets->enqueue( 'sensei-reports', 'js/admin/reports.js', [ 'jquery' ] );
+
 	}
 
 	/**

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -194,7 +194,8 @@ class Sensei_Analysis {
 	/**
 	 * Enqueue JS scripts.
 	 *
-	 * @since 4.2.0
+	 * @since  4.2.0
+	 * @access private
 	 */
 	public function enqueue_scripts() {
 

--- a/includes/class-sensei-list-table.php
+++ b/includes/class-sensei-list-table.php
@@ -123,19 +123,9 @@ class Sensei_List_Table extends WP_List_Table {
 		}
 		?><form method="get">
 			<?php
-			if ( isset( $_GET ) && count( $_GET ) > 0 ) {
-				foreach ( $_GET as $k => $v ) {
-					if ( 's' != $k ) {
-						?>
-
-						<input type="hidden" name="<?php echo esc_attr( $k ); ?>" value="<?php echo esc_attr( $v ); ?>" />
-
-						<?php
-					}
-				}
-			}
+			Sensei_Utils::output_query_params_as_inputs( [ 's' ] );
+			$this->search_box( apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users', 'sensei-lms' ) ), 'search_id' );
 			?>
-			<?php $this->search_box( apply_filters( 'sensei_list_table_search_button_text', __( 'Search Users', 'sensei-lms' ) ), 'search_id' ); ?>
 		</form>
 		<?php
 	}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2569,6 +2569,26 @@ class Sensei_Utils {
 		return false;
 	}
 
+	/**
+	 * Output the current query params as hidden inputs.
+	 *
+	 * @since 4.2.0
+	 *
+	 * @param array $excluded The query params that should be excluded.
+	 */
+	public static function output_query_params_as_inputs( array $excluded = [] ) {
+		// phpcs:ignore WordPress.Security.NonceVerification -- The nonce should be checked before calling this method.
+		foreach ( $_GET as $name => $value ) {
+			if ( in_array( $name, $excluded, true ) ) {
+				continue;
+			}
+
+			?>
+			<input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="<?php echo esc_attr( wp_unslash( $value ) ); ?>">
+			<?php
+		}
+	}
+
 }
 
 /**

--- a/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
@@ -280,4 +280,39 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 			'The last activity date format or timezone is invalid.'
 		);
 	}
+
+	/**
+	 * Tests that when getting the lessons they are filtered by course.
+	 *
+	 * @covers Sensei_Analysis_Overview_List_Table::get_lessons
+	 */
+	public function testGetLessonsByCourse() {
+		/* Arrange. */
+		$course_id         = $this->factory->course->create();
+		$course_lesson_ids = $this->factory->lesson->create_many( 2, [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+
+		// Fill the database with other lessons from other courses.
+		$this->factory->lesson->create_many( 2, [ 'meta_input' => [ '_lesson_course' => $this->factory->course->create() ] ] );
+
+		$instance = new Sensei_Analysis_Overview_List_Table();
+		$method   = new ReflectionMethod( $instance, 'get_lessons' );
+		$method->setAccessible( true );
+
+		/* Act. */
+		$query_args = [
+			'number'  => -1,
+			'offset'  => 0,
+			'orderby' => '',
+			'order'   => 'ASC',
+		];
+
+		$course_lesson_posts = $method->invoke( $instance, $query_args, $course_id );
+
+		/* Assert. */
+		$this->assertEquals(
+			$course_lesson_ids,
+			wp_list_pluck( $course_lesson_posts, 'ID' ),
+			'The lessons should be filtered by course.'
+		);
+	}
 }

--- a/tests/unit-tests/test-class-utils.php
+++ b/tests/unit-tests/test-class-utils.php
@@ -236,4 +236,26 @@ class Sensei_Class_Utils_Test extends WP_UnitTestCase {
 		$this->assertEquals( $expected, $array_zipped );
 	}
 
+	/**
+	 * Test that the query params inputs are correct.
+	 *
+	 * @covers Sensei_Utils::output_query_params_as_inputs
+	 */
+	public function testOutputQueryParamsAsInputs() {
+		/* Arrange. */
+		$_GET = [
+			'param_1' => 'value_1',
+			'param_2' => 'value_2',
+		];
+
+		/* Act. */
+		ob_start();
+		Sensei_Utils::output_query_params_as_inputs( [ 'param_2' ] );
+		$output = ob_get_clean();
+
+		/* Assert. */
+		$this->assertContains( '<input type="hidden" name="param_1" value="value_1">', $output, 'Output should contain the query param input with the correct value.' );
+		$this->assertNotContains( 'param_2', $output, 'Output should not contain the excluded query param input.' );
+	}
+
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ const files = [
 	'js/admin/ordering.js',
 	'js/admin/sensei-notice-dismiss.js',
 	'js/admin/custom-navigation.js',
+	'js/admin/reports.js',
 	'js/frontend/course-archive.js',
 	'js/frontend/course-video/video-blocks-extension.js',
 	'js/grading-general.js',


### PR DESCRIPTION
Part of #4835

### Changes proposed in this Pull Request

* Add lesson report top filter form that can filter by course.
* Show lesson report inner message when no course is selected.

### Testing instructions

* Have multiple courses with lessons.
* Go to Sensei LMS -> Analysis -> Lessons.
* Select a course from the top filter form.
* The lessons should be filtered for that course.
* Make sure the search form is also working.

### Screenshot / Video

<img width="1323" alt="Screenshot on 2022-03-05 at 02-19-33" src="https://user-images.githubusercontent.com/1612178/156858843-84350bea-e021-4371-9ea0-0bf39bdae661.png">

