### PR TITLE
Add "Last Activity" column to Courses report

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -281,7 +281,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		switch ( $this->type ) {
 			case 'courses':
 				// Last Activity.
-				$last_activity_date = 'N/A';
+				$last_activity_date = __( 'N/A', 'sensei-lms' );
 				$lessons            = Sensei()->course->course_lessons( $item->ID, 'any', 'ids' );
 
 				if ( 0 < count( $lessons ) ) {
@@ -522,7 +522,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$last_activity = Sensei_Utils::sensei_check_for_activity( $args, true );
 
 		if ( ! $last_activity ) {
-			return 'N/A';
+			return __( 'N/A', 'sensei-lms' );
 		}
 
 		// Return the full date when doing a CSV export.

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -281,11 +281,12 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		switch ( $this->type ) {
 			case 'courses':
 				// Last Activity.
-				$last_activity_date = $this->get_last_activity_date(
-					array(
-						'post__in' => Sensei()->course->course_lessons( $item->ID, 'any', 'ids' ),
-					)
-				);
+				$last_activity_date = 'N/A';
+				$lessons            = Sensei()->course->course_lessons( $item->ID, 'any', 'ids' );
+
+				if ( 0 < count( $lessons ) ) {
+					$last_activity_date = $this->get_last_activity_date( array( 'post__in' => $lessons ) );
+				}
 
 				// Get Course Completions
 				$course_args        = array(

--- a/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
@@ -41,7 +41,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 	 *
 	 * @return string[][]
 	 */
-	public function lessonUncompleteStatuses(): array {
+	public function lessonIncompleteStatuses(): array {
 		return [
 			[ 'in-progress' ],
 			[ 'ungraded' ],
@@ -52,10 +52,10 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that the last activity is ignoring uncompleted lessons.
 	 *
-	 * @covers Sensei_Admin::get_last_activity
-	 * @dataProvider lessonUncompleteStatuses
+	 * @covers Sensei_Admin::get_last_activity_date
+	 * @dataProvider lessonIncompleteStatuses
 	 */
-	public function testGetLastActivityShouldIgnoreUncompleteLessons( $lesson_uncomplete_status ) {
+	public function testGetLastActivityShouldIgnoreIncompleteLessons( $lesson_incomplete_status ) {
 		/* Arrange. */
 		$user_id   = $this->factory->user->create();
 		$lesson_id = $this->factory->lesson->create(
@@ -63,7 +63,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 		);
 
 		$instance = new Sensei_Analysis_Overview_List_Table();
-		$method   = new ReflectionMethod( $instance, 'get_last_activity' );
+		$method   = new ReflectionMethod( $instance, 'get_last_activity_date' );
 		$method->setAccessible( true );
 
 		/* Act. */
@@ -72,14 +72,14 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 		wp_update_comment(
 			[
 				'comment_ID'       => $lesson_activity_comment_id,
-				'comment_approved' => $lesson_uncomplete_status,
+				'comment_approved' => $lesson_incomplete_status,
 			]
 		);
 
 		/* Assert. */
 		$this->assertEquals(
 			'N/A',
-			$method->invoke( $instance, $user_id ),
+			$method->invoke( $instance, array( 'user_id' => $user_id ) ),
 			'The last activity should not take into account lessons that are in progress.'
 		);
 	}
@@ -87,7 +87,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that the last activity is based on "completed" lessons.
 	 *
-	 * @covers Sensei_Admin::get_last_activity
+	 * @covers Sensei_Admin::get_last_activity_date
 	 * @dataProvider lessonCompleteStatuses
 	 */
 	public function testGetLastActivityShouldBeBasedOnCompletedLessons( $lesson_complete_status ) {
@@ -98,7 +98,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 		);
 
 		$instance = new Sensei_Analysis_Overview_List_Table();
-		$method   = new ReflectionMethod( $instance, 'get_last_activity' );
+		$method   = new ReflectionMethod( $instance, 'get_last_activity_date' );
 		$method->setAccessible( true );
 
 		/* Act. */
@@ -113,7 +113,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertStringEndsWith(
 			'ago',
-			$method->invoke( $instance, $user_id ),
+			$method->invoke( $instance, array( 'user_id' => $user_id ) ),
 			'The last activity should take into account lessons with status "' . $lesson_complete_status . '".'
 		);
 	}
@@ -121,7 +121,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that the last activity should be the more recent one.
 	 *
-	 * @covers Sensei_Admin::get_last_activity
+	 * @covers Sensei_Admin::get_last_activity_date
 	 */
 	public function testGetLastActivityShouldReturnTheMoreRecentActivity() {
 		/* Arrange. */
@@ -135,7 +135,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 		);
 
 		$instance = new Sensei_Analysis_Overview_List_Table();
-		$method   = new ReflectionMethod( $instance, 'get_last_activity' );
+		$method   = new ReflectionMethod( $instance, 'get_last_activity_date' );
 		$method->setAccessible( true );
 
 		/* Act. */
@@ -162,7 +162,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertEquals(
 			'2 days ago',
-			$method->invoke( $instance, $user_id ),
+			$method->invoke( $instance, array( 'user_id' => $user_id ) ),
 			'The last activity should be the more recent activity.'
 		);
 
@@ -179,7 +179,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertEquals(
 			'1 day ago',
-			$method->invoke( $instance, $user_id ),
+			$method->invoke( $instance, array( 'user_id' => $user_id ) ),
 			'The last activity should be the more recent activity.'
 		);
 	}
@@ -187,7 +187,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 	/**
 	 * Tests that the last activity date format is human-readable when less than a week.
 	 *
-	 * @covers Sensei_Admin::get_last_activity
+	 * @covers Sensei_Admin::get_last_activity_date
 	 */
 	public function testGetLastActivityShouldUseHumanReadableTimeFormatIfLessThanAWeek() {
 		/* Arrange. */
@@ -197,7 +197,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 		);
 
 		$instance = new Sensei_Analysis_Overview_List_Table();
-		$method   = new ReflectionMethod( $instance, 'get_last_activity' );
+		$method   = new ReflectionMethod( $instance, 'get_last_activity_date' );
 		$method->setAccessible( true );
 
 		/* Act. */
@@ -218,7 +218,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 				$lesson_activity_timestamp,
 				new DateTimeZone( 'GMT' )
 			),
-			$method->invoke( $instance, $user_id ),
+			$method->invoke( $instance, array( 'user_id' => $user_id ) ),
 			'The last activity date format or timezone is invalid.'
 		);
 
@@ -235,7 +235,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$this->assertEquals(
 			'1 day ago',
-			$method->invoke( $instance, $user_id ),
+			$method->invoke( $instance, array( 'user_id' => $user_id ) ),
 			'The last activity date format should be in human-readable form.'
 		);
 	}


### PR DESCRIPTION
Part of #4834.

### Changes proposed in this Pull Request
- Adds a _Last Activity_ column to the Courses report, which is the date on which the last lesson was marked complete in a given course by any student.
- This column shows a human readable date (e.g. "1 hour ago"), or the full date after 6 days of inactivity. 
- For the full date, it's displayed in the format specified in _Settings_ > _General_ > _Date Format_.

### Testing instructions
- Create 2 courses with at least 1 lesson in each.
- Complete one of the lessons in one of the courses.
- Check that the _Last Activity_ column of the Courses report displays an appropriate "... ago" value for the course containing the lesson you just completed.
- Check that the _Last Activity_ column displays "N/A" for the other course.
- If you have other courses with lessons that were completed more than 6 days ago, verify that the full date is displayed.
- Change the value of _Settings_ > _General_ > _Date Format_ and ensure the _Last Activity_ date is displayed in the selected format.
- Ensure the column can be sorted.