### PR TITLE
Add days to completion column for courses on the Reports overview page

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -332,7 +332,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						'title'              => $course_title,
 						'completions'        => $course_completions,
 						'average_percent'    => $course_average_percent,
-						'days_to_completion' => $days_to_completion ?? __( 'n/a', 'sensei-lms' ),
+						'days_to_completion' => $days_to_completion ?? __( 'N/A', 'sensei-lms' ),
 					),
 					$item,
 					$this
@@ -361,7 +361,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$course_id    = get_post_meta( $item->ID, '_lesson_course', true );
 				$course_title = $course_id ? get_the_title( $course_id ) : '';
 
-				$lesson_average_grade = __( 'n/a', 'sensei-lms' );
+				$lesson_average_grade = __( 'N/A', 'sensei-lms' );
 				if ( false != Sensei_Lesson::lesson_quiz_has_questions( $item->ID ) ) {
 					// Get Percent Complete
 					$grade_args = array(
@@ -404,7 +404,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						);
 						$course_title = '<a href="' . esc_url( $url ) . '">' . esc_html( $course_title ) . '</a>';
 					} else {
-						$course_title = __( 'n/a', 'sensei-lms' );
+						$course_title = __( 'N/A', 'sensei-lms' );
 					}
 					if ( is_numeric( $lesson_average_grade ) ) {
 						$lesson_average_grade .= '%';

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -322,7 +322,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				}
 
 				$days_to_completion = $this->get_course_days_to_completion( $item );
-				$days_to_completion = Sensei_Utils::as_absolute_rounded_number( $days_to_completion, 2 );
+				if ( null !== $days_to_completion ) {
+					$days_to_completion = Sensei_Utils::as_absolute_rounded_number( $days_to_completion, 2 );
+				}
 
 				$column_data = apply_filters(
 					'sensei_analysis_overview_column_data',

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -823,7 +823,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			'type'    => 'sensei_course_status',
 			'status'  => 'complete',
 		);
-		$user_courses_ended = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_user_courses_ended', $course_args, $item ), true );
+		$user_courses_ended = Sensei_Utils::sensei_check_for_activity( $course_args, true );
 		if ( ! is_array( $user_courses_ended ) ) {
 			$user_courses_ended = array( $user_courses_ended );
 		}


### PR DESCRIPTION
Fixes part of #4834

### Changes proposed in this Pull Request

* Add Days To Completion column (for Courses). It shows how many days it took for a student to complete a course. Courses with a single lesson won't be calculated because of [an issue with saving completion time](https://github.com/Automattic/sensei/issues/4537). We also skip unfinished courses. We round numbers to the upper limit and then calculate an average.

### Testing instructions
1. Create a course with two or more lessons.
2. Enroll the course and complete lessons.
3. Go to `Sensei LMS -> Reports -> Courses`. Look at the last column (Days To Completion) for your course.
4. Most probably you'll see the number 1. To get other values:
  - Enroll the course with a different user and complete all the lessons in the course
  - Change start meta for the `sensei_course_status` comment or comment_date for that comment (the latest sounds easier, so here is an example query: 
  `UPDATE wp_comments SET comment_date = '2022-03-05 10:41:28' WHERE comment_ID = '12';`
  - To find the comment you can use this query:
  `SELECT comment_ID FROM wp_comments WHERE comment_type = 'sensei_course_status' AND comment_approved = 'complete' AND comment_post_ID = '123'; -- 123 stands for your course ID`