### PR TITLE
Add a database seed WP-CLI command

### DIFF
--- a/includes/class-sensei-cli.php
+++ b/includes/class-sensei-cli.php
@@ -3,7 +3,6 @@
  * Enables the Sensei WP-CLI commands.
  *
  * @package sensei
- * @version 4.2.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -11,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * CLI class.
  *
- * @since 4.2.0
+ * @since 4.3.0
  */
 class Sensei_CLI {
 	/**

--- a/includes/class-sensei-cli.php
+++ b/includes/class-sensei-cli.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Enables the Sensei WP-CLI commands.
+ *
+ * @package sensei
+ * @version 4.2.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * CLI class.
+ *
+ * @since 4.2.0
+ */
+class Sensei_CLI {
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		$this->load();
+		$this->register();
+	}
+
+	/**
+	 * Load the command files.
+	 */
+	private function load() {
+		require_once dirname( __FILE__ ) . '/cli/class-sensei-db-seed-command.php';
+	}
+
+	/**
+	 * Register the CLI commands.
+	 */
+	private function register() {
+		WP_CLI::add_command( 'sensei db seed', Sensei_DB_Seed_Command::class );
+	}
+}

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -276,6 +276,7 @@ class Sensei_Main {
 		add_action( 'init', array( $this, 'load_localisation' ), 0 );
 
 		$this->initialize_global_objects();
+		$this->initialize_cli();
 	}
 
 	/**
@@ -455,6 +456,19 @@ class Sensei_Main {
 		$this->Sensei_WPML = new Sensei_WPML();
 
 		$this->rest_api_internal = new Sensei_REST_API_Internal();
+	}
+
+	/**
+	 * Load the WP-CLI commands.
+	 *
+	 * @since 4.2.0
+	 */
+	private function initialize_cli() {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			require_once $this->resolve_path( 'includes/class-sensei-cli.php' );
+
+			new Sensei_CLI();
+		}
 	}
 
 	/**

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -461,7 +461,7 @@ class Sensei_Main {
 	/**
 	 * Load the WP-CLI commands.
 	 *
-	 * @since 4.2.0
+	 * @since 4.3.0
 	 */
 	private function initialize_cli() {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/includes/cli/class-sensei-db-seed-command.php
+++ b/includes/cli/class-sensei-db-seed-command.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * WP-CLI command that helps with seeding the database.
  *
- * @since 4.2.0
+ * @since 4.3.0
  */
 class Sensei_DB_Seed_Command {
 	/**

--- a/includes/cli/class-sensei-db-seed-command.php
+++ b/includes/cli/class-sensei-db-seed-command.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Sensei_DB_Seed_Command class file.
+ *
+ * @package sensei
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WP-CLI command that helps with seeding the database.
+ *
+ * @since 4.2.0
+ */
+class Sensei_DB_Seed_Command {
+	/**
+	 * The timestamp at which the timer has started.
+	 *
+	 * @var float $timer_start
+	 */
+	private $timer_start;
+
+	/**
+	 * Seed the database.
+	 *
+	 * ## OPTIONS
+	 *
+	 * --users=<user_count>
+	 * : The number of users to be inserted.
+	 *
+	 * --courses=<course_count>
+	 * : The number of courses to be inserted.
+	 *
+	 * --lessons=<lesson_count>
+	 * : The number of lessons per course.
+	 *
+	 * @when after_wp_load
+	 *
+	 * @param array $args       Command arguments.
+	 * @param array $assoc_args Command arguments with names.
+	 */
+	public function __invoke( array $args = [], array $assoc_args = [] ) {
+		$this->start_timer();
+
+		$target_user_count   = (int) $assoc_args['users'];
+		$target_course_count = (int) $assoc_args['courses'];
+		$lessons_per_course  = (int) $assoc_args['lessons'];
+
+		// Disable some hooks that get in the way.
+		remove_action( 'sensei_course_status_updated', array( Sensei()->frontend, 'redirect_to_course_completed_page' ), 1000 );
+
+		// Queries.
+		$users_query = new WP_User_Query(
+			[
+				'number'      => 1, // We need only the total count.
+				'count_total' => true,
+				'fields'      => 'ids',
+				'meta_key'    => '_seeded', // phpcs:ignore WordPress.DB.SlowDBQuery -- Filter seeded users only.
+			]
+		);
+
+		$course_query = new WP_Query(
+			[
+				'posts_per_page' => -1,
+				'post_type'      => 'course',
+				'post_status'    => 'publish',
+				'fields'         => 'ids',
+				'meta_key'       => '_seeded', // phpcs:ignore WordPress.DB.SlowDBQuery -- Filter seeded courses only.
+			]
+		);
+
+		// Counters.
+		$total_user_count    = $users_query->get_total();
+		$total_course_count  = $course_query->found_posts;
+		$seeded_user_count   = 0;
+		$seeded_course_count = 0;
+
+		// Insert the courses and lessons.
+		while ( $total_course_count < $target_course_count ) {
+			$total_course_count++;
+			$seeded_course_count++;
+
+			$course_title = "Course $total_course_count";
+			$course_id    = wp_insert_post(
+				[
+					'post_title'  => $course_title,
+					'post_type'   => 'course',
+					'post_status' => 'publish',
+					'meta_input'  => [
+						'_seeded' => true,
+					],
+				]
+			);
+
+			$this->log( "Inserted '$course_title' ($course_id)." );
+
+			for ( $current_lesson_count = 1; $current_lesson_count <= $lessons_per_course; $current_lesson_count++ ) {
+				$lesson_title = "Lesson $current_lesson_count in course $total_course_count";
+				$lesson_id    = wp_insert_post(
+					[
+						'post_title'  => $lesson_title,
+						'post_type'   => 'lesson',
+						'post_status' => 'publish',
+						'meta_input'  => [
+							'_lesson_course' => $course_id,
+							'_seeded'        => true,
+						],
+					]
+				);
+
+				$this->log( "Inserted '$lesson_title' ($lesson_id)." );
+			}
+		}
+
+		// Fetch the courses after inserting them. We need this in case the seeder is re-run.
+		$course_ids = $course_query->get_posts();
+
+		// Insert and enroll the users.
+		while ( $total_user_count < $target_user_count ) {
+			$total_user_count++;
+			$seeded_user_count++;
+
+			$user_login = "user_$total_user_count";
+			$user_id    = wp_insert_user(
+				[
+					'user_login' => $user_login,
+					'user_email' => "$user_login@example.com",
+					'meta_input' => [
+						'_seeded' => true,
+					],
+				]
+			);
+
+			$this->log( "Inserted '$user_login' ($user_id)." );
+
+			// Enroll.
+			foreach ( $course_ids as $course_id ) {
+				$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
+				$course_enrolment->enrol( $user_id );
+				Sensei_Utils::force_complete_user_course( $user_id, $course_id );
+			}
+
+			// Avoid memory issues due to cache.
+			wp_cache_flush();
+
+			$this->log( "Enrolled '$user_login' ($user_id)." );
+		}
+
+		WP_CLI::success(
+			"
+Seeded users: $seeded_user_count ($total_user_count total)
+Seeded courses: $seeded_course_count ($total_course_count total)
+Execution time: {$this->get_execution_time()}
+"
+		);
+	}
+
+	/**
+	 * Output the log message prefixed by a datetime.
+	 *
+	 * @param string $message The logged message.
+	 */
+	private function log( string $message ) {
+		$date = wp_date( 'Y-m-d H:i:s' );
+
+		WP_CLI::log( "[$date] $message" );
+	}
+
+	/**
+	 * Start the timer.
+	 */
+	private function start_timer() {
+		$this->timer_start = microtime( true );
+	}
+
+	/**
+	 * Return the execution time.
+	 *
+	 * @return string The execution time.
+	 */
+	private function get_execution_time(): string {
+		$now            = microtime( true );
+		$execution_time = gmdate( 'H:i:s', $now - $this->timer_start );
+
+		return $execution_time;
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add a database seed WP-CLI command. ✨ 

### Testing instructions

* Make a fresh WordPress instance with a new database.
* Install and activate the Sensei plugin.
* Open the terminal in the main WordPress directory and run `wp sensei db seed --users=10 --courses=2 --lessons=5`
* Keep in mind that enrollment is slow when using too many courses/lessons and it gets progressively slower when adding more entries. Enrolling 100 users in 10 courses with 5 lessons takes 2 minutes... My suggestion would be to enroll the users in 2 courses with 5 lessons which is a bit more realistic and it takes 20 seconds for 100 users.

### Screenshot

<img width="516" alt="Screenshot on 2022-03-07 at 18-02-52" src="https://user-images.githubusercontent.com/1612178/157071175-a30d42b1-31a8-4f97-9bc9-912eef6ea364.png">

