### PR TITLE
Add workflow to report commit status with link to download the plugin build

### DIFF
--- a/.github/workflows/report-build.yml
+++ b/.github/workflows/report-build.yml
@@ -1,0 +1,24 @@
+name: Report Plugin Build
+
+on:
+    workflow_run:
+        workflows: ["Plugin Build"]
+        types: 
+          - completed
+
+jobs:
+    report-build:
+        name: Report Plugin Build
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - name: Publish commit status with the link to download the plugin 
+              id: plugin_artifact
+              uses: fjorgemota/github-action-report-artifact@v0
+              with:
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
+                  artifact-name: sensei-lms-${{ github.event.workflow_run.head_sha }}
+                  report-on: commit_status
+                  context: Plugin Build Download
+                  message: Click on "Details" to download the plugin zip file
+                  


### PR DESCRIPTION
Will need to be complemented by an additional PR, to build the plugin, but need to add this first so Github can run this workflow appropriately.

In the meantime, it shouldn't run until the new PR is sent, so it should be safe to merge.

This PR is a follow-up to the PR #4731. I'll send a new PR later to complement this one.

### Changes proposed in this Pull Request

* Add workflow that will be run after a workflow called "Plugin build", and which will get the artifact list of that plugin build and report the link to download that plugin build as a commit status, using the action https://github.com/fjorgemota/github-action-report-artifact ;
  * Should allow reporting the commit status in a similar way to this PR: https://github.com/fjorgemota/sensei/pull/1;

### Testing instructions

Unfortunately, there's no easy way to test this PR yet, as this workflow needs to be in the main branch of the repository so Github can run it. However, I'm sending this PR mostly to check things like the message used, and things like that... :smiley: 
