### PR TITLE
Fix course completed date does not update when having one lesson

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1777,16 +1777,12 @@ class Sensei_Utils {
 		$comment_id = false;
 		if ( ! empty( $status ) ) {
 			$args = array(
-				'user_id'   => $user_id,
-				'post_id'   => $course_id,
-				'status'    => $status,
-				'type'      => 'sensei_course_status', /* FIELD SIZE 20 */
-				'action'    => 'update', // Update the existing status...
-				'keep_time' => true, // ...but don't change the existing timestamp
+				'user_id' => $user_id,
+				'post_id' => $course_id,
+				'status'  => $status,
+				'type'    => 'sensei_course_status', /* FIELD SIZE 20 */
+				'action'  => 'update', // Update the existing status...
 			);
-			if ( 'in-progress' == $status ) {
-				unset( $args['keep_time'] ); // Keep updating what's happened
-			}
 
 			$comment_id = self::sensei_log_activity( $args );
 			if ( $comment_id && ! empty( $metadata ) ) {


### PR DESCRIPTION
Fixes #4537

### Changes proposed in this Pull Request

Fixes the course completed date not updating when the course has only one lesson.

### Testing instructions

* Create a course with one lesson.
* Complete the lesson.
* Go to Sensei LMS -> Student Management -> Your course
* Make sure "Date Completed" is correct and not the same as "Date started".
