### PR TITLE
Remove `learn` query parameter from the preview url.

### DIFF
--- a/assets/js/admin/course-theme/course-theme-sidebar.js
+++ b/assets/js/admin/course-theme/course-theme-sidebar.js
@@ -73,7 +73,7 @@ const usePreviewAndCustomizerLinks = () => {
 		) {
 			previewUrl = `/?p=${ firstLesson.id }`;
 		} else {
-			previewUrl = `/?p=${ firstLesson.id }&learn=1&${ SENSEI_PREVIEW_QUERY }=${ currentPost.id }`;
+			previewUrl = `/?p=${ firstLesson.id }&${ SENSEI_PREVIEW_QUERY }=${ currentPost.id }`;
 		}
 
 		if ( firstLesson.draft ) {

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -98,7 +98,7 @@ class Sensei_Course_Theme {
 	/**
 	 * Add the URL prefix the theme is active under.
 	 *
-	 * @param string $path
+	 * @param string $path Optional path to prefix.
 	 *
 	 * @return string|void
 	 */
@@ -294,7 +294,7 @@ class Sensei_Course_Theme {
 	 *
 	 * @access private
 	 *
-	 * @param string[] $classes
+	 * @param string[] $classes The html classess to be added.
 	 *
 	 * @return string[] $classes
 	 */
@@ -397,7 +397,7 @@ class Sensei_Course_Theme {
 		$course_id   = get_post_meta( $lesson->ID, '_lesson_course', true );
 		$preview_url = '/?p=' . $lesson->ID;
 		if ( ! Sensei_Course_Theme_Option::has_learning_mode_enabled( $course_id ) ) {
-			$preview_url .= '&' . self::QUERY_VAR . '=1&' . self::PREVIEW_QUERY_VAR . '=' . $course_id;
+			$preview_url .= '&' . self::PREVIEW_QUERY_VAR . '=' . $course_id;
 		}
 		return '/wp-admin/customize.php?autofocus[section]=sensei-course-theme&url=' . rawurlencode( $preview_url );
 	}
@@ -423,7 +423,7 @@ class Sensei_Course_Theme {
 	 *
 	 * @access private
 	 *
-	 * @param WP_Admin_Bar $wp_admin_bar
+	 * @param WP_Admin_Bar $wp_admin_bar The WordPress Admin Bar object.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
Fixes #4892 

### Changes proposed in this Pull Request

* Removes the `learn` query param from the preview url. The new Learning Mode logic seems to not like it.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Open Course editor in WP admin.
* Make sure the Course has at least one lesson in it.
* Make sure the Learning Mode is __disabled__ for this course and save.
* Under the Learning Mode setting, click on the "Preview" link and confirm it shows the preview of the course in Learning Mode.
* Under the Learning Mode setting, click on the "Customize" link and confirm it allows the customization of the course in Learning Mode.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

#### Before

https://user-images.githubusercontent.com/2578542/156573589-5ab875c4-d193-4813-86c7-1f86988e96a8.mp4

#### After

https://user-images.githubusercontent.com/2578542/156573635-02d9aa4c-776e-4167-b503-c2fd8dc767c7.mp4