### PR TITLE
Add Last activity for Lessons

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -66,6 +66,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'title'         => __( 'Lesson', 'sensei-lms' ),
 					'course'        => __( 'Course', 'sensei-lms' ),
 					'students'      => __( 'Students', 'sensei-lms' ),
+					'last_activity' => __( 'Last Activity', 'sensei-lms' ),
 					'completions'   => __( 'Completed', 'sensei-lms' ),
 					'average_grade' => __( 'Average Grade', 'sensei-lms' ),
 				);
@@ -112,6 +113,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'title'         => array( 'title', false ),
 					'course'        => array( 'course', false ),
 					'students'      => array( 'students', false ),
+					'last_activity' => array( 'last_activity', false ),
 					'completions'   => array( 'completions', false ),
 					'average_grade' => array( 'average_grade', false ),
 				);
@@ -343,6 +345,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				break;
 
 			case 'lessons':
+				// Last Activity.
+				$last_activity_date = $this->get_last_activity_date( array( 'post__in' => array( $item->ID ) ) );
+
 				// Get Learners (i.e. those who have started)
 				$lesson_args     = array(
 					'post_id' => $item->ID,
@@ -419,6 +424,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						'title'         => $lesson_title,
 						'course'        => $course_title,
 						'students'      => $lesson_students,
+						'last_activity' => $last_activity_date,
 						'completions'   => $lesson_completions,
 						'average_grade' => $lesson_average_grade,
 					),

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -345,9 +345,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				break;
 
 			case 'lessons':
-				// Last Activity.
-				$last_activity_date = $this->get_last_activity_date( array( 'post__in' => array( $item->ID ) ) );
-
 				// Get Learners (i.e. those who have started)
 				$lesson_args     = array(
 					'post_id' => $item->ID,
@@ -424,7 +421,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						'title'         => $lesson_title,
 						'course'        => $course_title,
 						'students'      => $lesson_students,
-						'last_activity' => $last_activity_date,
+						'last_activity' => $this->get_last_activity_date( array( 'post_id' => $item->ID ) ),
 						'completions'   => $lesson_completions,
 						'average_grade' => $lesson_average_grade,
 					),

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -102,7 +102,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			case 'courses':
 				$columns = array(
 					'title'           => array( 'title', false ),
-					'last_activity'   => array( 'last_activity', false ),
 					'completions'     => array( 'completions', false ),
 					'average_percent' => array( 'average_percent', false ),
 				);
@@ -113,7 +112,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'title'         => array( 'title', false ),
 					'course'        => array( 'course', false ),
 					'students'      => array( 'students', false ),
-					'last_activity' => array( 'last_activity', false ),
 					'completions'   => array( 'completions', false ),
 					'average_grade' => array( 'average_grade', false ),
 				);


### PR DESCRIPTION
Fixes part of #4835

### Changes proposed in this Pull Request

* Add Last Activity column on the Lessons overview page in Reports

### Testing instructions

* Add a course with a few lessons.
* Take a course and complete the first lesson.
* Check reports: there should be a date for the completed lessons and "N/A" for incomplete lessons.
* Complete all lessons and check that there is a correct date in the Last Activity column for these lessons.

### Screenshot / Video
<img width="1702" alt="CleanShot 2022-03-03 at 16 57 48@2x" src="https://user-images.githubusercontent.com/329356/156579373-c8d7dcad-eca7-498d-b72c-342a452d4f79.png">

