### PR TITLE
Added completion rate column in Reports->Lessons

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -62,11 +62,12 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 			case 'lessons':
 				$columns = array(
-					'title'         => __( 'Lesson', 'sensei-lms' ),
-					'course'        => __( 'Course', 'sensei-lms' ),
-					'students'      => __( 'Students', 'sensei-lms' ),
-					'completions'   => __( 'Completed', 'sensei-lms' ),
-					'average_grade' => __( 'Average Grade', 'sensei-lms' ),
+					'title'           => __( 'Lesson', 'sensei-lms' ),
+					'course'          => __( 'Course', 'sensei-lms' ),
+					'students'        => __( 'Students', 'sensei-lms' ),
+					'completions'     => __( 'Completed', 'sensei-lms' ),
+					'completion_rate' => __( 'Completion Rate', 'sensei-lms' ),
+					'average_grade'   => __( 'Average Grade', 'sensei-lms' ),
 				);
 				break;
 
@@ -107,11 +108,12 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 			case 'lessons':
 				$columns = array(
-					'title'         => array( 'title', false ),
-					'course'        => array( 'course', false ),
-					'students'      => array( 'students', false ),
-					'completions'   => array( 'completions', false ),
-					'average_grade' => array( 'average_grade', false ),
+					'title'           => array( 'title', false ),
+					'course'          => array( 'course', false ),
+					'students'        => array( 'students', false ),
+					'completions'     => array( 'completions', false ),
+					'completion_rate' => array( 'completion_rate', false ),
+					'average_grade'   => array( 'average_grade', false ),
 				);
 				break;
 
@@ -405,11 +407,12 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$column_data = apply_filters(
 					'sensei_analysis_overview_column_data',
 					array(
-						'title'         => $lesson_title,
-						'course'        => $course_title,
-						'students'      => $lesson_students,
-						'completions'   => $lesson_completions,
-						'average_grade' => $lesson_average_grade,
+						'title'           => $lesson_title,
+						'course'          => $course_title,
+						'students'        => $lesson_students,
+						'completions'     => $lesson_completions,
+						'completion_rate' => $lesson_students > 0 ? round( ( $lesson_completions / $lesson_students ) * 100 ) . '%' : __( 'n/a', 'sensei-lms' ),
+						'average_grade'   => $lesson_average_grade,
 					),
 					$item,
 					$this


### PR DESCRIPTION
Relates [#4835](https://github.com/Automattic/sensei/issues/4835)

### Changes proposed in this Pull Request

Added 'Completion Rate' column for lessons. Calculated percentage by 'Number of students started the lesson / number of students who completed the lesson' formula. Rounded up the result.
 

### Testing instructions

1. Create a course and add a few lessons, publish them
2. Add some lessons without assigning them to any course
3. Enroll some students in those courses
4. From those student accounts, complete a few lessons, keep a few that you have only visited but did not complete, and leave a few totally unvisited
5. Keep count of what you did and check if the 'Completion Rate' is showing the correct value or not
### Screenshot / Video
![image](https://user-images.githubusercontent.com/6820724/156583849-14387ddd-4b4a-4039-a4f6-3cf7a278977e.png)
