### PR TITLE
Fix PHP notices when exporting the courses or lessons reports

### DIFF
--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -259,6 +259,8 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$this->search = $search;
 
 		$args = array(
+			'number'  => '-1',
+			'offset'  => 0,
 			'orderby' => $orderby,
 			'order'   => $order,
 		);
@@ -595,11 +597,9 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 			'post_status'      => array( 'publish', 'private' ),
 			'suppress_filters' => 0,
 		);
+
 		if ( $this->search ) {
 			$lessons_args['s'] = $this->search;
-		}
-		if ( $this->csv_output ) {
-			$lessons_args['posts_per_page'] = '-1';
 		}
 
 		// Using WP_Query as get_posts() doesn't support 'found_posts'

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -174,6 +174,8 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		$this->search = $search;
 
 		$args = array(
+			'number'  => '-1',
+			'offset'  => 0,
 			'orderby' => $orderby,
 			'order'   => $order,
 		);

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -229,6 +229,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		}
 
 		$args = array(
+			'number'  => -1,
+			'offset'  => 0,
 			'orderby' => $orderby,
 			'order'   => $order,
 		);
@@ -567,10 +569,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			'suppress_filters' => 0,
 		);
 
-		if ( $this->csv_output ) {
-			$course_args['posts_per_page'] = '-1';
-		}
-
 		if ( isset( $args['search'] ) ) {
 			$course_args['s'] = $args['search'];
 		}
@@ -601,10 +599,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			'order'            => $args['order'],
 			'suppress_filters' => 0,
 		);
-
-		if ( $this->csv_output ) {
-			$lessons_args['posts_per_page'] = '-1';
-		}
 
 		if ( isset( $args['search'] ) ) {
 			$lessons_args['s'] = $args['search'];


### PR DESCRIPTION
Fixes #4885

### Changes proposed in this Pull Request

* Pass all required key-value pairs in arguments for `get_lessons` and `get_courses`.

### Testing instructions

1. Go to `Sensei LMS -> Reports`.
2. Click on the `Courses` link or on the `Lessons` link.
3. Click the Export all rows (CSV) button.
4. No notices expected in logs.
5. Click on the specific course on `Courses` overview page.
6. Click the Export all rows (CSV) button.
7. No notices expected in logs.