### PR TITLE
Add activity date filters to the students report screen

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -119,6 +119,10 @@
 		&__top-filters {
 			float: left;
 			margin-bottom: 14px;
+
+			.sensei-date-picker {
+				max-width: 100px;
+			}
 		}
 
 		&__no-items-message--highlighted {

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -118,6 +118,9 @@
 	.sensei-analysis {
 		&__top-filters {
 			float: left;
+			display: flex;
+			align-items: center;
+			gap: 4px;
 			margin-bottom: 14px;
 
 			.sensei-date-picker {

--- a/assets/js/admin/reports.js
+++ b/assets/js/admin/reports.js
@@ -4,7 +4,7 @@
 import domReady from '@wordpress/dom-ready';
 
 domReady( () => {
-	jQuery( '.sensei-analysis__top-filters' ).on( 'change', ( event ) => {
-		event.currentTarget.submit();
+	jQuery( '.sensei-date-picker' ).datepicker( {
+		dateFormat: 'yy-mm-dd',
 	} );
 } );

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -765,7 +765,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 			<?php if ( 'users' === $this->type ) : ?>
 				<label for="sensei-start-date-filter">
-					<?php esc_html_e( 'Start date', 'sensei-lms' ); ?>:
+					<?php esc_html_e( 'Last Activity', 'sensei-lms' ); ?>:
 				</label>
 
 				<input
@@ -774,12 +774,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					name="start_date"
 					type="text"
 					autocomplete="off"
+					placeholder="<?php echo esc_attr( __( 'Start Date', 'sensei-lms' ) ); ?>"
 					value="<?php echo esc_attr( $this->get_start_date_filter_value() ); ?>"
 				/>
-
-				<label for="sensei-end-date-filter">
-					<?php esc_html_e( 'End date', 'sensei-lms' ); ?>:
-				</label>
 
 				<input
 					class="sensei-date-picker"
@@ -787,6 +784,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					name="end_date"
 					type="text"
 					autocomplete="off"
+					placeholder="<?php echo esc_attr( __( 'End Date', 'sensei-lms' ) ); ?>"
 					value="<?php echo esc_attr( $this->get_end_date_filter_value() ); ?>"
 				/>
 			<?php endif ?>

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -773,6 +773,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					id="sensei-start-date-filter"
 					name="start_date"
 					type="text"
+					autocomplete="off"
 					value="<?php echo esc_attr( $this->get_start_date_filter_value() ); ?>"
 				/>
 
@@ -785,6 +786,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					id="sensei-end-date-filter"
 					name="end_date"
 					type="text"
+					autocomplete="off" 
 					value="<?php echo esc_attr( $this->get_end_date_filter_value() ); ?>"
 				/>
 			<?php endif ?>

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -650,9 +650,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		 */
 		$args = apply_filters( 'sensei_analysis_overview_filter_users', $args );
 
-		add_action( 'pre_user_query', [ $this, 'filter_users_by_last_activity'] );
+		add_action( 'pre_user_query', [ $this, 'filter_users_by_last_activity' ] );
 		$wp_user_search = new WP_User_Query( $args );
-		remove_action( 'pre_user_query', [ $this, 'filter_users_by_last_activity'] );
+		remove_action( 'pre_user_query', [ $this, 'filter_users_by_last_activity' ] );
 
 		$learners          = $wp_user_search->get_results();
 		$this->total_items = $wp_user_search->get_total();
@@ -786,7 +786,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					id="sensei-end-date-filter"
 					name="end_date"
 					type="text"
-					autocomplete="off" 
+					autocomplete="off"
 					value="<?php echo esc_attr( $this->get_end_date_filter_value() ); ?>"
 				/>
 			<?php endif ?>

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -993,7 +993,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			WHERE {$wpdb->comments}.user_id = {$wpdb->users}.ID
 			AND {$wpdb->comments}.comment_approved IN ('complete', 'passed', 'graded')
 			AND {$wpdb->comments}.comment_type = 'sensei_lesson_status'
-			ORDER BY wp_comments.comment_date_gmt DESC
+			ORDER BY {$wpdb->comments}.comment_date_gmt DESC
 			LIMIT 1
 		)";
 

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -37,12 +37,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		parent::__construct( 'analysis_overview' );
 
 		// Actions.
-		if ( 'lessons' === $this->type ) {
-			add_action( 'sensei_before_list_table', array( $this, 'output_lessons_top_filters' ) );
-		}
-
+		add_action( 'sensei_before_list_table', array( $this, 'output_top_filters' ) );
 		add_action( 'sensei_after_list_table', array( $this, 'data_table_footer' ) );
-
 		add_filter( 'sensei_list_table_search_button_text', array( $this, 'search_button' ) );
 	}
 
@@ -740,21 +736,56 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	}
 
 	/**
-	 * Output the lessons top filter form.
+	 * Output top filter form.
 	 *
 	 * @since  4.2.0
 	 * @access private
 	 */
-	public function output_lessons_top_filters() {
+	public function output_top_filters() {
+
+		if ( ! in_array( $this->type, [ 'lessons', 'users' ], true ) ) {
+			return;
+		}
+
 		?>
 		<form class="sensei-analysis__top-filters">
-			<?php Sensei_Utils::output_query_params_as_inputs( [ 'course_filter', 's' ] ); ?>
+			<?php Sensei_Utils::output_query_params_as_inputs( [ 'course_filter', 'start_date', 'end_date', 's' ] ); ?>
 
-			<label for="sensei-course-filter">
-				<?php esc_html_e( 'Course', 'sensei-lms' ); ?>:
-			</label>
+			<?php if ( 'lessons' === $this->type ) : ?>
+				<label for="sensei-course-filter">
+					<?php esc_html_e( 'Course', 'sensei-lms' ); ?>:
+				</label>
 
-			<?php $this->output_course_select_input(); ?>
+				<?php $this->output_course_select_input(); ?>
+			<?php endif ?>
+
+			<?php if ( 'users' === $this->type ) : ?>
+				<label for="sensei-start-date-filter">
+					<?php esc_html_e( 'Start date', 'sensei-lms' ); ?>:
+				</label>
+
+				<input
+					class="sensei-date-picker"
+					id="sensei-start-date-filter"
+					name="start_date"
+					type="text"
+					value="<?php echo esc_attr( $this->get_start_date_filter_value() ); ?>"
+				/>
+
+				<label for="sensei-end-date-filter">
+					<?php esc_html_e( 'End date', 'sensei-lms' ); ?>:
+				</label>
+
+				<input
+					class="sensei-date-picker"
+					id="sensei-end-date-filter"
+					name="end_date"
+					type="text"
+					value="<?php echo esc_attr( $this->get_end_date_filter_value() ); ?>"
+				/>
+			<?php endif ?>
+
+			<?php submit_button( __( 'Filter', 'sensei-lms' ), '', '', false ); ?>
 		</form>
 		<?php
 	}
@@ -926,6 +957,30 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	private function get_course_filter_value(): int {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for filtering.
 		return isset( $_GET['course_filter'] ) ? (int) $_GET['course_filter'] : 0;
+	}
+
+	/**
+	 * Get the start date filter value.
+	 *
+	 * @return string The start date.
+	 */
+	private function get_start_date_filter_value(): string {
+		// phpcs:ignore WordPress.Security -- The date is sanitized at a later stage.
+		$start_date = $_GET['start_date'] ?? '';
+
+		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
+	}
+
+	/**
+	 * Get the end date filter value.
+	 *
+	 * @return string The end date.
+	 */
+	private function get_end_date_filter_value(): string {
+		// phpcs:ignore WordPress.Security -- The date is sanitized at a later stage.
+		$end_date = $_GET['end_date'] ?? '';
+
+		return DateTime::createFromFormat( 'Y-m-d', $end_date ) ? $end_date : '';
 	}
 
 }

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1028,10 +1028,12 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @return string The start date.
 	 */
 	private function get_start_date_filter_value(): string {
+		$default = gmdate( 'Y-m-d', strtotime( '-30 days' ) );
+
 		// phpcs:ignore WordPress.Security -- The date is sanitized at a later stage.
 		$start_date = $_GET['start_date'] ?? '';
 
-		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
+		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : $default;
 	}
 
 	/**

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -198,7 +198,7 @@ class Sensei_Analysis {
 	 */
 	public function enqueue_scripts() {
 
-		Sensei()->assets->enqueue( 'sensei-reports', 'js/admin/reports.js', [ 'jquery' ] );
+		Sensei()->assets->enqueue( 'sensei-reports', 'js/admin/reports.js', [ 'jquery', 'jquery-ui-datepicker' ] );
 
 	}
 
@@ -213,6 +213,7 @@ class Sensei_Analysis {
 	public function enqueue_styles() {
 
 		Sensei()->assets->enqueue( 'sensei-settings-api', 'css/settings.css' );
+		Sensei()->assets->enqueue( 'sensei-jquery-ui', 'css/jquery-ui.css' );
 
 	}
 


### PR DESCRIPTION
Part of #4833

### Changes proposed in this Pull Request

* Add "start date" and "end date" filters to the students report screen.

### Testing instructions

* Have multiple users that have course "last activity" on different days.
* Go to Sensei LMS -> Reports -> Students.
* Make sure the start date is set to 30 days ago by default.
* Play around with the start/end date filters and make sure both filters are working.
* Try to do an export while using the filters.
* Make sure the search is working.

### Screenshot

<img width="1286" alt="Screenshot on 2022-03-11 at 03-35-01" src="https://user-images.githubusercontent.com/1612178/157784941-9e9f3de8-8762-43c5-af45-4c502fca3814.png">

