### PR TITLE
Add totals to Courses report

### DIFF
--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -460,7 +460,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 					);
 					$lesson_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_completions', $lesson_args, $item ) );
 
-					$lesson_average_grade = __( 'n/a', 'sensei-lms' );
+					$lesson_average_grade = __( 'N/A', 'sensei-lms' );
 
 					if ( false != Sensei_Lesson::lesson_quiz_has_questions( $item->ID ) ) {
 						// Get Percent Complete

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -59,10 +59,20 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		switch ( $this->type ) {
 			case 'courses':
-				$columns = array(
+				$completions = Sensei_Utils::sensei_check_for_activity(
+					array(
+						'type'   => 'sensei_course_status',
+						'status' => 'complete',
+					)
+				);
+				$columns     = array(
 					'title'           => __( 'Course', 'sensei-lms' ),
 					'last_activity'   => __( 'Last Activity', 'sensei-lms' ),
-					'completions'     => __( 'Completed', 'sensei-lms' ),
+					'completions'     => sprintf(
+						// translators: Placeholder value is the number of completed courses.
+						__( 'Completed (%d)', 'sensei-lms' ),
+						esc_html( $completions )
+					),
 					'average_percent' => sprintf(
 						// translators: Placeholder value is the average grade of all courses.
 						__( 'Average Grade (%d%%)', 'sensei-lms' ),

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -265,14 +265,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			$args['search'] = esc_html( $_GET['s'] );
 		}
 
-		// Start the csv with the column headings
-		$column_headers = array();
-		$columns        = $this->get_columns();
-		foreach ( $columns as $key => $title ) {
-			$column_headers[] = $title;
-		}
-		$data[] = $column_headers;
-
 		switch ( $this->type ) {
 			case 'courses':
 				$this->items = $this->get_courses( $args );
@@ -287,6 +279,16 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$this->items = $this->get_learners( $args );
 				break;
 		}
+
+		// Start the CSV with the column headings.
+		$column_headers = array();
+		$columns        = $this->get_columns();
+
+		foreach ( $columns as $key => $title ) {
+			$column_headers[] = $title;
+		}
+
+		$data[] = $column_headers;
 
 		// Process each row.
 		foreach ( $this->items as $item ) {

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -78,7 +78,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						__( 'Average Grade (%s%%)', 'sensei-lms' ),
 						esc_html( ceil( Sensei()->grading->get_courses_average_grade() ) )
 					),
-          'days_to_completion' => __( 'Days to Completion', 'sensei-lms' ),
+					'days_to_completion' => __( 'Days to Completion', 'sensei-lms' ),
 				);
 				break;
 
@@ -342,8 +342,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						$average_grade = Sensei_Utils::quotient_as_absolute_rounded_number( $percent_total, $percent_count, 2 ) . '%';
 					}
 				}
-        
-        // Properties `count_of_completions` and `days_to_completion` where added to items in
+
+				// Properties `count_of_completions` and `days_to_completion` where added to items in
 				// `Sensei_Analysis_Overview_List_Table::add_days_to_completion_to_courses_queries`.
 				// We made it due to improve performance of the report. Don't try to access these properties outside.
 				$average_completion_days = $item->count_of_completions > 0 ? ceil( $item->days_to_completion / $item->count_of_completions ) : __( 'N/A', 'sensei-lms' );

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -65,8 +65,12 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						'status' => 'complete',
 					)
 				);
-				$columns     = array(
-					'title'           => __( 'Course', 'sensei-lms' ),
+				$columns           = array(
+					'title'           => sprintf(
+						// translators: Placeholder value is the number of courses.
+						__( 'Course (%d)', 'sensei-lms' ),
+						esc_html( $this->total_items )
+					),
 					'last_activity'   => __( 'Last Activity', 'sensei-lms' ),
 					'completions'     => sprintf(
 						// translators: Placeholder value is the number of completed courses.

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -59,7 +59,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		switch ( $this->type ) {
 			case 'courses':
-				$completions = Sensei_Utils::sensei_check_for_activity(
+				$total_completions = Sensei_Utils::sensei_check_for_activity(
 					array(
 						'type'   => 'sensei_course_status',
 						'status' => 'complete',
@@ -71,7 +71,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'completions'     => sprintf(
 						// translators: Placeholder value is the number of completed courses.
 						__( 'Completed (%d)', 'sensei-lms' ),
-						esc_html( $completions )
+						esc_html( $total_completions )
 					),
 					'average_percent' => sprintf(
 						// translators: Placeholder value is the average grade of all courses.

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -60,7 +60,11 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'title'           => __( 'Course', 'sensei-lms' ),
 					'last_activity'   => __( 'Last Activity', 'sensei-lms' ),
 					'completions'     => __( 'Completed', 'sensei-lms' ),
-					'average_percent' => __( 'Average Grade', 'sensei-lms' ),
+					'average_percent' => sprintf(
+						// translators: Placeholder value is the average grade of all courses.
+						__( 'Average Grade (%d%%)', 'sensei-lms' ),
+						esc_html( Sensei()->grading->get_courses_average_grade() )
+					),
 				);
 				break;
 

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -62,18 +62,18 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					)
 				);
 				$columns           = array(
-					'title'           => sprintf(
+					'title'              => sprintf(
 						// translators: Placeholder value is the number of courses.
 						__( 'Course (%d)', 'sensei-lms' ),
 						esc_html( $this->total_items )
 					),
-					'last_activity'   => __( 'Last Activity', 'sensei-lms' ),
-					'completions'     => sprintf(
+					'last_activity'      => __( 'Last Activity', 'sensei-lms' ),
+					'completions'        => sprintf(
 						// translators: Placeholder value is the number of completed courses.
 						__( 'Completed (%d)', 'sensei-lms' ),
 						esc_html( $total_completions )
 					),
-					'average_percent' => sprintf(
+					'average_percent'    => sprintf(
 						// translators: Placeholder value is the average grade of all courses.
 						__( 'Average Grade (%s%%)', 'sensei-lms' ),
 						esc_html( ceil( Sensei()->grading->get_courses_average_grade() ) )
@@ -361,13 +361,13 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						admin_url( 'edit.php' )
 					);
 
-					$course_title            = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . apply_filters( 'the_title', $item->post_title, $item->ID ) . '</a></strong>';
+					$course_title = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . apply_filters( 'the_title', $item->post_title, $item->ID ) . '</a></strong>';
 				}
 
 				$column_data = apply_filters(
 					'sensei_analysis_overview_column_data',
 					array(
-						'title'.             => $course_title,
+						'title'              => $course_title,
 						'last_activity'      => $last_activity_date,
 						'completions'        => $course_completions,
 						'average_percent'    => $average_grade,

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -53,6 +53,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @return array $columns, the array of columns to use with the table
 	 */
 	function get_columns() {
+		if ( $this->columns ) {
+			return $this->columns;
+		}
 
 		switch ( $this->type ) {
 			case 'courses':
@@ -90,10 +93,14 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				);
 				break;
 		}
+
 		// Backwards compatible filter name, moving forward should have single filter name
 		$columns = apply_filters( 'sensei_analysis_overview_' . $this->type . '_columns', $columns, $this );
 		$columns = apply_filters( 'sensei_analysis_overview_columns', $columns, $this );
-		return $columns;
+
+		$this->columns = $columns;
+
+		return $this->columns;
 	}
 
 	/**

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -20,6 +20,13 @@ class Sensei_Grading {
 	public $page_slug;
 
 	/**
+	 * Average grade of all courses.
+	 *
+	 * @var int
+	 */
+	private $courses_average_grade;
+
+	/**
 	 * Constructor
 	 *
 	 * @since  1.3.0
@@ -1211,6 +1218,10 @@ class Sensei_Grading {
 	 * @return double Average grade of all courses.
 	 */
 	public function get_courses_average_grade() {
+		if ( isset( $this->courses_average_grade ) ) {
+			return $this->courses_average_grade;
+		}
+
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
@@ -1225,7 +1236,9 @@ class Sensei_Grading {
 			return 0;
 		}
 
-		return $result->grade_total / $result->grade_count;
+		$this->courses_average_grade = $result->grade_total / $result->grade_count;
+
+		return $this->courses_average_grade;
 	}
 }
 

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -1191,7 +1191,7 @@ class Sensei_Grading {
 
 		$lesson_ids = Sensei()->course->course_lessons( $course_id, 'any', 'ids' );
 
-		if ( ! $lesson_ids) {
+		if ( ! $lesson_ids ) {
 			return 0;
 		}
 
@@ -1222,11 +1222,11 @@ class Sensei_Grading {
 		/**
 		 * The subquery calculates the average grade per course, and the outer query then calculates the
 		 * average grade of all courses. To be included in the calculation, a lesson must:
-		 * 	Have a status of 'graded', 'passed' or 'failed'.
-		 * 	Have grade data.
-		 * 	Be associated with a course.
-		 * 	Have quiz questions (checking for the existence of '_quiz_has_questions' meta is sufficient;
-		 * 	if it exists its value will be 1).
+		 *   Have a status of 'graded', 'passed' or 'failed'.
+		 *   Have grade data.
+		 *   Be associated with a course.
+		 *   Have quiz questions (checking for the existence of '_quiz_has_questions' meta is sufficient;
+		 *   if it exists its value will be 1).
 		 */
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
 		$result = $wpdb->get_row(

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -20,13 +20,6 @@ class Sensei_Grading {
 	public $page_slug;
 
 	/**
-	 * Average grade of all courses.
-	 *
-	 * @var double
-	 */
-	private $courses_average_grade;
-
-	/**
 	 * Constructor
 	 *
 	 * @since  1.3.0
@@ -1218,10 +1211,6 @@ class Sensei_Grading {
 	 * @return double Average grade of all courses.
 	 */
 	public function get_courses_average_grade() {
-		if ( isset( $this->courses_average_grade ) ) {
-			return $this->courses_average_grade;
-		}
-
 		global $wpdb;
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
@@ -1236,9 +1225,7 @@ class Sensei_Grading {
 			return 0;
 		}
 
-		$this->courses_average_grade = $result->grade_total / $result->grade_count;
-
-		return $this->courses_average_grade;
+		return $result->grade_total / $result->grade_count;
 	}
 }
 

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -1221,7 +1221,7 @@ class Sensei_Grading {
 			WHERE c.comment_type = 'sensei_course_status' AND cm.meta_key = 'percent'"
 		);
 
-		if ( 0 === $result->grade_count ) {
+		if ( '0' === $result->grade_count ) {
 			return 0;
 		}
 

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -1203,6 +1203,30 @@ class Sensei_Grading {
 
 	}
 
+	/**
+	 * Get the average grade of all courses.
+	 *
+	 * @since 4.2.0
+	 *
+	 * @return double Average grade of all courses.
+	 */
+	public function get_courses_average_grade() {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+		$result = $wpdb->get_row(
+			"SELECT SUM(cm.meta_value) AS grade_total, COUNT(*) as grade_count
+			FROM {$wpdb->comments} c
+			INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
+			WHERE c.comment_type = 'sensei_course_status' AND cm.meta_key = 'percent'"
+		);
+
+		if ( 0 === $result->grade_count ) {
+			return 0;
+		}
+
+		return $result->grade_total / $result->grade_count;
+	}
 }
 
 /**

--- a/includes/class-sensei-grading.php
+++ b/includes/class-sensei-grading.php
@@ -22,7 +22,7 @@ class Sensei_Grading {
 	/**
 	 * Average grade of all courses.
 	 *
-	 * @var int
+	 * @var double
 	 */
 	private $courses_average_grade;
 

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -186,6 +186,33 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that courses average grade is calculated correctly when there are no grades.
+	 *
+	 * @covers Sensei_Grading::get_courses_average_grade
+	 */
+	public function testGetCoursesAverageGradeNoGrades() {
+		$this->assertEquals( 0, Sensei()->grading->get_courses_average_grade() );
+	}
+
+	/**
+	 * Test that courses average grade is calculated correctly when there are grades.
+	 *
+	 * @covers Sensei_Grading::get_courses_average_grade
+	 */
+	public function testGetCoursesAverageGradeHasGrades() {
+		$grade      = 50;
+		$course_ids = $this->factory->course->create_many( 4 );
+
+		foreach ( $course_ids as $course_id ) {
+			$comment_id = $this->factory->comment->create( array( 'comment_type' => 'sensei_course_status' ) );
+			add_comment_meta( $comment_id, 'percent', $grade );
+			$grade += 10;
+		}
+
+		$this->assertEquals( 65, Sensei()->grading->get_courses_average_grade() );
+	}
+
+	/**
 	 * Get a test question.
 	 *
 	 * @param string $question_type

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -186,30 +186,224 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that courses average grade is calculated correctly when some lessons are ungraded or in-progress.
+	 *
+	 * @covers Sensei_Grading::get_courses_average_grade
+	 */
+	public function testGetCoursesAverageGradeLessonStatus() {
+		$course_id  = $this->factory->course->create();
+		$lesson_ids = $this->factory->lesson->create_many( 3,
+			[
+				'meta_input' => [
+					'_lesson_course'      => $course_id,
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+		$user_ids   = $this->factory->user->create_many( 2 );
+
+		// Start each student in each lesson.
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[0], $user_ids[0], 'failed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[0], $user_ids[1], 'graded' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[1], $user_ids[0], 'graded' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[1], $user_ids[1], 'passed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[2], $user_ids[0], 'ungraded' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[2], $user_ids[1], 'in-progress' );
+
+		// Assign a grade to each lesson for each student.
+		$this->assignGrade( $comment_ids[0], '10' );
+		$this->assignGrade( $comment_ids[1], '50' );
+		$this->assignGrade( $comment_ids[2], '100' );
+		$this->assignGrade( $comment_ids[3], '95' );
+		$this->assignGrade( $comment_ids[4], '40' );
+		$this->assignGrade( $comment_ids[5], '' );
+
+		$this->assertEquals( ( 10 + 50 + 100 + 95 ) / 4, Sensei()->grading->get_courses_average_grade() );
+	}
+
+	/**
 	 * Test that courses average grade is calculated correctly when there are no grades.
 	 *
 	 * @covers Sensei_Grading::get_courses_average_grade
 	 */
 	public function testGetCoursesAverageGradeNoGrades() {
+		$course_id  = $this->factory->course->create();
+		$lesson_ids = $this->factory->lesson->create_many( 3,
+			[
+				'meta_input' => [
+					'_lesson_course'      => $course_id,
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+		$user_ids   = $this->factory->user->create_many( 2 );
+
+		// Start each student in each lesson.
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[0], $user_ids[0], 'failed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[0], $user_ids[1], 'graded' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[1], $user_ids[0], 'passed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[1], $user_ids[1], 'failed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[2], $user_ids[0], 'graded' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[2], $user_ids[1], 'passed' );
+
 		$this->assertEquals( 0, Sensei()->grading->get_courses_average_grade() );
 	}
 
 	/**
-	 * Test that courses average grade is calculated correctly when there are grades.
+	 * Test that courses average grade is calculated correctly when some lessons have no course.
 	 *
 	 * @covers Sensei_Grading::get_courses_average_grade
 	 */
-	public function testGetCoursesAverageGradeHasGrades() {
-		$grade      = 50;
-		$course_ids = $this->factory->course->create_many( 4 );
+	public function testGetCoursesAverageGradeNoCourse() {
+		$course_id  = $this->factory->course->create();
+		$lesson_ids = $this->factory->lesson->create_many( 3,
+			[
+				'meta_input' => [
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+		$user_ids   = $this->factory->user->create_many( 2 );
 
-		foreach ( $course_ids as $course_id ) {
-			$comment_id = $this->factory->comment->create( array( 'comment_type' => 'sensei_course_status' ) );
-			add_comment_meta( $comment_id, 'percent', $grade );
-			$grade += 10;
-		}
+		// Assign course to some lessons.
+		add_post_meta( $lesson_ids[0], '_lesson_course', '' );
+		add_post_meta( $lesson_ids[2], '_lesson_course', $course_id );
 
-		$this->assertEquals( 65, Sensei()->grading->get_courses_average_grade() );
+		// Start each student in each lesson.
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[0], $user_ids[0], 'failed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[0], $user_ids[1], 'graded' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[1], $user_ids[0], 'passed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[1], $user_ids[1], 'failed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[2], $user_ids[0], 'graded' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[2], $user_ids[1], 'passed' );
+
+		// Assign a grade to each lesson for each student.
+		$this->assignGrade( $comment_ids[0], '10' );
+		$this->assignGrade( $comment_ids[1], '50' );
+		$this->assignGrade( $comment_ids[2], '100' );
+		$this->assignGrade( $comment_ids[3], '35' );
+		$this->assignGrade( $comment_ids[4], '70' );
+		$this->assignGrade( $comment_ids[5], '85' );
+
+		$this->assertEquals( ( 70 + 85 ) / 2, Sensei()->grading->get_courses_average_grade() );
+	}
+
+	/**
+	 * Test that courses average grade is calculated correctly when some lessons have no quiz.
+	 *
+	 * @covers Sensei_Grading::get_courses_average_grade
+	 */
+	public function testGetCoursesAverageGradeNoQuiz() {
+		$course_id  = $this->factory->course->create();
+		$lesson_ids = $this->factory->lesson->create_many( 3,
+			[
+				'meta_input' => [
+					'_lesson_course' => $course_id,
+				],
+			]
+		);
+		$user_ids   = $this->factory->user->create_many( 2 );
+
+		// Set some lessons to have a quiz.
+		add_post_meta( $lesson_ids[1], '_quiz_has_questions', 1 );
+		add_post_meta( $lesson_ids[2], '_quiz_has_questions', 1 );
+
+		// Start each student in each lesson.
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[0], $user_ids[0], 'failed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[0], $user_ids[1], 'graded' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[1], $user_ids[0], 'passed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[1], $user_ids[1], 'failed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[2], $user_ids[0], 'graded' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[2], $user_ids[1], 'passed' );
+
+		// Assign a grade to each lesson for each student.
+		$this->assignGrade( $comment_ids[0], '10' );
+		$this->assignGrade( $comment_ids[1], '50' );
+		$this->assignGrade( $comment_ids[2], '100' );
+		$this->assignGrade( $comment_ids[3], '35' );
+		$this->assignGrade( $comment_ids[4], '70' );
+		$this->assignGrade( $comment_ids[5], '85' );
+
+		$this->assertEquals( ( 100 + 35 + 70 + 85 ) / 4, Sensei()->grading->get_courses_average_grade() );
+	}
+
+	/**
+	 * Test that courses average grade is calculated correctly when there are multiple courses.
+	 *
+	 * @covers Sensei_Grading::get_courses_average_grade
+	 */
+	public function testGetCoursesAverageGradeMultipleCourses() {
+		$course_ids = $this->factory->course->create_many( 2 );
+		$lesson_ids = $this->factory->lesson->create_many( 3,
+			[
+				'meta_input' => [
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+		$user_ids   = $this->factory->user->create_many( 2 );
+
+		// Assign different courses to lessons.
+		add_post_meta( $lesson_ids[0], '_lesson_course', $course_ids[0] );
+		add_post_meta( $lesson_ids[1], '_lesson_course', $course_ids[0] );
+		add_post_meta( $lesson_ids[2], '_lesson_course', $course_ids[1] );
+
+		// Start each student in each lesson.
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[0], $user_ids[0], 'failed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[0], $user_ids[1], 'graded' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[1], $user_ids[0], 'passed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[1], $user_ids[1], 'failed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[2], $user_ids[0], 'graded' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[2], $user_ids[1], 'passed' );
+
+		// Assign a grade to each lesson for each student.
+		$this->assignGrade( $comment_ids[0], '10' );
+		$this->assignGrade( $comment_ids[1], '50' );
+		$this->assignGrade( $comment_ids[2], '100' );
+		$this->assignGrade( $comment_ids[3], '35' );
+		$this->assignGrade( $comment_ids[4], '70' );
+		$this->assignGrade( $comment_ids[5], '85' );
+
+		$first_course_average = ( 10 + 50 + 100 + 35 ) / 4;
+		$second_course_average = ( 70 + 85 ) / 2;
+
+		$this->assertEquals( ( $first_course_average + $second_course_average ) / count( $course_ids ), Sensei()->grading->get_courses_average_grade() );
+	}
+
+	/**
+	 * Test that courses average grade is calculated correctly when all conditions are met.
+	 *
+	 * @covers Sensei_Grading::get_courses_average_grade
+	 */
+	public function testGetCoursesAverageGrade() {
+		$course_id  = $this->factory->course->create();
+		$lesson_ids = $this->factory->lesson->create_many( 3,
+			[
+				'meta_input' => [
+					'_lesson_course'      => $course_id,
+					'_quiz_has_questions' => 1,
+				],
+			]
+		);
+		$user_ids   = $this->factory->user->create_many( 2 );
+
+		// Start each student in each lesson.
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[0], $user_ids[0], 'failed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[0], $user_ids[1], 'graded' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[1], $user_ids[0], 'passed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[1], $user_ids[1], 'failed' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[2], $user_ids[0], 'graded' );
+		$comment_ids[] = $this->startStudentInLesson( $lesson_ids[2], $user_ids[1], 'passed' );
+
+		// Assign a grade to each lesson for each student.
+		$this->assignGrade( $comment_ids[0], '10' );
+		$this->assignGrade( $comment_ids[1], '50' );
+		$this->assignGrade( $comment_ids[2], '100' );
+		$this->assignGrade( $comment_ids[3], '35' );
+		$this->assignGrade( $comment_ids[4], '70' );
+		$this->assignGrade( $comment_ids[5], '85' );
+
+		$this->assertEquals( ( 10 + 50 + 100 + 35 + 70 + 85 ) / 6, Sensei()->grading->get_courses_average_grade() );
 	}
 
 	/**
@@ -226,5 +420,34 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		$question['quiz_id']     = $quiz_id;
 		$question['post_author'] = get_post( $quiz_id )->post_author;
 		return Sensei()->lesson->lesson_save_question( $question );
+	}
+
+	/**
+	 * Add lesson status for a given student.
+	 *
+	 * @param int    $lesson_id Lesson ID.
+	 * @param int    $user_id   User ID.
+	 * @param string $status    Lesson status.
+	 * @return int Comment ID.
+	 */
+	private function startStudentInLesson( $lesson_id, $user_id, $status) {
+		return $this->factory->comment->create(
+			[
+				'comment_type'     => 'sensei_lesson_status',
+				'comment_approved' => $status,
+				'comment_post_ID'  => $lesson_id,
+				'user_id'          => $user_id,
+			]
+		);
+	}
+
+	/**
+	 * Assign a grade.
+	 *
+	 * @param int    $comment_id Comment ID.
+	 * @param string $grade      Grade.
+	 */
+	private function assignGrade( $comment_id, $grade ) {
+		add_comment_meta( $comment_id, 'grade', $grade );
 	}
 }

--- a/tests/unit-tests/test-class-grading.php
+++ b/tests/unit-tests/test-class-grading.php
@@ -4,7 +4,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	use Sensei_Test_Login_Helpers;
 
 	/**
-	 * setup function
+	 * Setup function
 	 *
 	 * This function sets up the lessons, quizes and their questions. This function runs before
 	 * every single test in this class
@@ -192,7 +192,8 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	 */
 	public function testGetCoursesAverageGradeLessonStatus() {
 		$course_id  = $this->factory->course->create();
-		$lesson_ids = $this->factory->lesson->create_many( 3,
+		$lesson_ids = $this->factory->lesson->create_many(
+			3,
 			[
 				'meta_input' => [
 					'_lesson_course'      => $course_id,
@@ -228,7 +229,8 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	 */
 	public function testGetCoursesAverageGradeNoGrades() {
 		$course_id  = $this->factory->course->create();
-		$lesson_ids = $this->factory->lesson->create_many( 3,
+		$lesson_ids = $this->factory->lesson->create_many(
+			3,
 			[
 				'meta_input' => [
 					'_lesson_course'      => $course_id,
@@ -256,7 +258,8 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	 */
 	public function testGetCoursesAverageGradeNoCourse() {
 		$course_id  = $this->factory->course->create();
-		$lesson_ids = $this->factory->lesson->create_many( 3,
+		$lesson_ids = $this->factory->lesson->create_many(
+			3,
 			[
 				'meta_input' => [
 					'_quiz_has_questions' => 1,
@@ -295,7 +298,8 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	 */
 	public function testGetCoursesAverageGradeNoQuiz() {
 		$course_id  = $this->factory->course->create();
-		$lesson_ids = $this->factory->lesson->create_many( 3,
+		$lesson_ids = $this->factory->lesson->create_many(
+			3,
 			[
 				'meta_input' => [
 					'_lesson_course' => $course_id,
@@ -334,7 +338,8 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	 */
 	public function testGetCoursesAverageGradeMultipleCourses() {
 		$course_ids = $this->factory->course->create_many( 2 );
-		$lesson_ids = $this->factory->lesson->create_many( 3,
+		$lesson_ids = $this->factory->lesson->create_many(
+			3,
 			[
 				'meta_input' => [
 					'_quiz_has_questions' => 1,
@@ -364,7 +369,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 		$this->assignGrade( $comment_ids[4], '70' );
 		$this->assignGrade( $comment_ids[5], '85' );
 
-		$first_course_average = ( 10 + 50 + 100 + 35 ) / 4;
+		$first_course_average  = ( 10 + 50 + 100 + 35 ) / 4;
 		$second_course_average = ( 70 + 85 ) / 2;
 
 		$this->assertEquals( ( $first_course_average + $second_course_average ) / count( $course_ids ), Sensei()->grading->get_courses_average_grade() );
@@ -377,7 +382,8 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	 */
 	public function testGetCoursesAverageGrade() {
 		$course_id  = $this->factory->course->create();
-		$lesson_ids = $this->factory->lesson->create_many( 3,
+		$lesson_ids = $this->factory->lesson->create_many(
+			3,
 			[
 				'meta_input' => [
 					'_lesson_course'      => $course_id,
@@ -430,7 +436,7 @@ class Sensei_Class_Grading_Test extends WP_UnitTestCase {
 	 * @param string $status    Lesson status.
 	 * @return int Comment ID.
 	 */
-	private function startStudentInLesson( $lesson_id, $user_id, $status) {
+	private function startStudentInLesson( $lesson_id, $user_id, $status ) {
 		return $this->factory->comment->create(
 			[
 				'comment_type'     => 'sensei_lesson_status',


### PR DESCRIPTION
Partial fix for #4834.

### Changes proposed in this Pull Request
Adds totals to the _Course_, _Completed_ and _Average Grade_ column headers of the Courses report.

### Testing instructions
* Add several courses with lessons that have quizzes.
* Take and grade the quizzes.
* Complete the courses.
* For the Courses report, check that the _Course_, _Completed_ and _Average Grade_ column headers display the correct totals. (Note that 0% entries for _Average Grade_ can be ignored as they are not included in the total average.)
* Trash and/or change the status to _Draft_ for one or more courses.
* Ensure that the _Course_ column header total is updated and correct.
* In _Student Management_, reset the progress of one or more students who completed a course.
* Ensure that the _Completed_ and _Average Grade_ column header totals are updated and correct.