### PR TITLE
Add days to completion total for courses

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -81,7 +81,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'days_to_completion' => sprintf(
 						// translators: Placeholder value is average days to completion.
 						__( 'Days to Completion (%d)', 'sensei-lms' ),
-						Sensei()->course->get_average_days_to_completion_total()
+						ceil( Sensei()->course->get_days_to_completion_total() )
 					),
 				);
 				break;

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -64,7 +64,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'days_to_completion' => sprintf(
 						// translators: Placeholder value is average days to completion.
 						__( 'Days to Completion (%d)', 'sensei-lms' ),
-						$this->get_days_to_completion_total_for_courses()
+						Sensei()->course->get_average_days_to_completion_total()
 					),
 				);
 				break;
@@ -917,32 +917,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$clauses['groupby'] .= " {$wpdb->posts}.ID";
 
 		return $clauses;
-	}
-
-	/**
-	 * Get average days to completion for all courses.
-	 *
-	 * @since 4.2.0
-	 * @access private
-	 *
-	 * @return int Average days to completion, rounded to the highest integer.
-	 */
-	public function get_days_to_completion_total_for_courses() {
-		global $wpdb;
-
-		$query = "
-			SELECT SUM( ABS( DATEDIFF( {$wpdb->comments}.comment_date, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ) ) ) + 1 ) / COUNT({$wpdb->commentmeta}.comment_id) AS average_days_to_completion
-			FROM {$wpdb->comments}
-			LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id
-				AND {$wpdb->commentmeta}.meta_key = 'start'
-			WHERE {$wpdb->comments}.comment_type IN ('sensei_course_status')
-				AND {$wpdb->comments}.comment_approved IN ( 'complete' )
-		";
-
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$average_days_to_completion = $wpdb->get_var( $query );
-
-		return (int) ceil( $average_days_to_completion );
 	}
 }
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3899,8 +3899,8 @@ class Sensei_Course {
 			FROM {$wpdb->comments}
 			LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id
 				AND {$wpdb->commentmeta}.meta_key = 'start'
-			WHERE {$wpdb->comments}.comment_type IN ('sensei_course_status')
-				AND {$wpdb->comments}.comment_approved IN ( 'complete' )
+			WHERE {$wpdb->comments}.comment_type = 'sensei_course_status'
+				AND {$wpdb->comments}.comment_approved = 'complete'
 		";
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3895,18 +3895,22 @@ class Sensei_Course {
 		global $wpdb;
 
 		$query = "
-			SELECT SUM( ABS( DATEDIFF( {$wpdb->comments}.comment_date, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ) ) ) + 1 ) / COUNT({$wpdb->commentmeta}.comment_id) AS average_days_to_completion
-			FROM {$wpdb->comments}
-			LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id
-				AND {$wpdb->commentmeta}.meta_key = 'start'
-			WHERE {$wpdb->comments}.comment_type = 'sensei_course_status'
-				AND {$wpdb->comments}.comment_approved = 'complete'
+			SELECT CEIL( SUM( agregated.average_days_to_completion ) / COUNT( agregated.average_days_to_completion ) ) AS average_days_to_completion
+			FROM (
+				SELECT CEIL( SUM( ABS( DATEDIFF( {$wpdb->comments}.comment_date, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ) ) ) + 1 ) / COUNT({$wpdb->commentmeta}.comment_id) ) AS average_days_to_completion
+				FROM {$wpdb->comments}
+				LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id
+					AND {$wpdb->commentmeta}.meta_key = 'start'
+				WHERE {$wpdb->comments}.comment_type = 'sensei_course_status'
+					AND {$wpdb->comments}.comment_approved = 'complete'
+				GROUP BY {$wpdb->comments}.comment_post_ID
+			) AS agregated
 		";
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
 		$average_days_to_completion = $wpdb->get_var( $query );
 
-		return (int) ceil( $average_days_to_completion );
+		return (int) $average_days_to_completion;
 	}
 }
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3889,28 +3889,28 @@ class Sensei_Course {
 	 * @since 4.2.0
 	 * @access private
 	 *
-	 * @return int Average days to completion, rounded to the highest integer.
+	 * @return int Total days to completion, rounded to the highest integer.
 	 */
-	public function get_average_days_to_completion_total() {
+	public function get_days_to_completion_total() {
 		global $wpdb;
 
 		$query = "
-			SELECT CEIL( SUM( agregated.average_days_to_completion ) / COUNT( agregated.average_days_to_completion ) ) AS average_days_to_completion
+			SELECT SUM( aggregated.days_to_completion )
 			FROM (
-				SELECT CEIL( SUM( ABS( DATEDIFF( {$wpdb->comments}.comment_date, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ) ) ) + 1 ) / COUNT({$wpdb->commentmeta}.comment_id) ) AS average_days_to_completion
+				SELECT CEIL( SUM( ABS( DATEDIFF( {$wpdb->comments}.comment_date, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ) ) ) + 1 ) / COUNT({$wpdb->commentmeta}.comment_id) ) AS days_to_completion
 				FROM {$wpdb->comments}
 				LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id
 					AND {$wpdb->commentmeta}.meta_key = 'start'
 				WHERE {$wpdb->comments}.comment_type = 'sensei_course_status'
 					AND {$wpdb->comments}.comment_approved = 'complete'
 				GROUP BY {$wpdb->comments}.comment_post_ID
-			) AS agregated
+			) AS aggregated
 		";
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$average_days_to_completion = $wpdb->get_var( $query );
+		$days_to_completion = $wpdb->get_var( $query );
 
-		return (int) $average_days_to_completion;
+		return (int) $days_to_completion;
 	}
 }
 

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3882,6 +3882,32 @@ class Sensei_Course {
 		return $url;
 
 	}
+
+	/**
+	 * Get average days to completion for all courses.
+	 *
+	 * @since 4.2.0
+	 * @access private
+	 *
+	 * @return int Average days to completion, rounded to the highest integer.
+	 */
+	public function get_average_days_to_completion_total() {
+		global $wpdb;
+
+		$query = "
+			SELECT SUM( ABS( DATEDIFF( {$wpdb->comments}.comment_date, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ) ) ) + 1 ) / COUNT({$wpdb->commentmeta}.comment_id) AS average_days_to_completion
+			FROM {$wpdb->comments}
+			LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id
+				AND {$wpdb->commentmeta}.meta_key = 'start'
+			WHERE {$wpdb->comments}.comment_type IN ('sensei_course_status')
+				AND {$wpdb->comments}.comment_approved IN ( 'complete' )
+		";
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+		$average_days_to_completion = $wpdb->get_var( $query );
+
+		return (int) ceil( $average_days_to_completion );
+	}
 }
 
 /**

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -583,12 +583,13 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		);
 		update_comment_meta( $comment3_id, 'start', '2022-01-01 00:00:01' );
 
-		$actual = Sensei()->course->get_average_days_to_completion_total();
+		$actual = Sensei()->course->get_days_to_completion_total();
 
 		// 2022-01-07 00:00:00 - 2022-01-01 00:00:01 + 1 = 7 days.
 		// 2022-01-10 00:00:00 - 2022-01-01 00:00:01 + 1 = 10 days.
 		// 2022-01-30 00:00:00 - 2022-01-01 00:00:01 + 1 = 30 days.
-		// ceil( ( 7 + 10 + 30 ) / 3 ) = 16 days.
+		// As these completions are for the single course:
+		// ceil(7 + 10 + 30/ 3)  = 16 days.
 		self::assertSame( 16, $actual );
 	}
 
@@ -625,17 +626,16 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		);
 		update_comment_meta( $comment3_id, 'start', '2022-03-09 00:22:34' );
 
-		$actual = Sensei()->course->get_average_days_to_completion_total();
+		$actual = Sensei()->course->get_days_to_completion_total();
 
 		// Average for the first course: (1 + 1) / 2 = 1.
 		// Average for the second course: 4 / 1 = 4.
-		// Overall average: ( 1 + 4 ) / 2 = 2.5.
-		// ceil( 2.5 ) = 3.
-		self::assertSame( 3, $actual );
+		// Total: 1 + 4 = 5.
+		self::assertSame( 5, $actual );
 	}
 
 	public function testGetAverageDaysToCompletionTotalWithoutCompletionsReturnsZero() {
-		$actual = Sensei()->course->get_average_days_to_completion_total();
+		$actual = Sensei()->course->get_days_to_completion_total();
 
 		self::assertSame( 0, $actual );
 	}

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -633,4 +633,10 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		// ceil( 2.5 ) = 3.
 		self::assertSame( 3, $actual );
 	}
+
+	public function testGetAverageDaysToCompletionTotalWithoutCompletionsReturnsZero() {
+		$actual = Sensei()->course->get_average_days_to_completion_total();
+
+		self::assertSame( 0, $actual );
+	}
 }

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -549,4 +549,46 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 			'Order set and default option selected'      => array( array( 'course-orderby' => 'default' ), 'anything', 'menu_order', 'ASC' ),
 		);
 	}
+
+	public function testGetAverageDaysToCompletionTotalReturnsMatchingValue() {
+		$user1_id  = $this->factory->user->create();
+		$user2_id  = $this->factory->user->create();
+		$user3_id  = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+
+		$comment1_id = Sensei_Utils::update_course_status( $user1_id, $course_id, 'complete' );
+		wp_update_comment(
+			[
+				'comment_ID'   => $comment1_id,
+				'comment_date' => '2022-01-07 00:00:00',
+			]
+		);
+		update_comment_meta( $comment1_id, 'start', '2022-01-01 00:00:01' );
+
+		$comment2_id = Sensei_Utils::update_course_status( $user2_id, $course_id, 'complete' );
+		wp_update_comment(
+			[
+				'comment_ID'   => $comment2_id,
+				'comment_date' => '2022-01-10 00:00:00',
+			]
+		);
+		update_comment_meta( $comment2_id, 'start', '2022-01-01 00:00:01' );
+
+		$comment3_id = Sensei_Utils::update_course_status( $user3_id, $course_id, 'complete' );
+		wp_update_comment(
+			[
+				'comment_ID'   => $comment3_id,
+				'comment_date' => '2022-01-30 00:00:00',
+			]
+		);
+		update_comment_meta( $comment3_id, 'start', '2022-01-01 00:00:01' );
+
+		$actual = Sensei()->course->get_average_days_to_completion_total();
+
+		// 2022-01-07 00:00:00 - 2022-01-01 00:00:01 + 1 = 7 days.
+		// 2022-01-10 00:00:00 - 2022-01-01 00:00:01 + 1 = 10 days.
+		// 2022-01-30 00:00:00 - 2022-01-01 00:00:01 + 1 = 30 days.
+		// ceil( ( 7 + 10 + 30 ) / 3 ) = 16 days.
+		self::assertSame( 16, $actual );
+	}
 }


### PR DESCRIPTION
Fixes part of #4834

### Changes proposed in this Pull Request

* Add total for Days to Completion column in Courses.
* **Tests: TBD**

### Testing instructions

* Add courses and a few users.
* Complete courses with each user.
* Set different start dates for students in these courses (`Sensei LMS -> Student Management`).
* Check Days to Completion in table header.
