### PR TITLE
Add totals to reports->lessons column headers

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1139,7 +1139,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed'), CEILING( TIMESTAMPDIFF( second, STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) / (24 * 60 * 60) ), 0)) days_to_complete_sum
 			FROM $wpdb->comments lesson_students
 			LEFT JOIN $wpdb->commentmeta lesson_start ON lesson_start.comment_id = lesson_students.comment_id
-			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN (%1s)",
+			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN (%1s)", // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 				'%Y-%m-%d %H:%i:%s',
 				$lesson_ids
 			)
@@ -1150,7 +1150,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				"SELECT COUNT(DISTINCT({$wpdb->term_taxonomy}.term_id)) FROM {$wpdb->term_relationships}
 			LEFT JOIN {$wpdb->term_taxonomy} ON {$wpdb->term_taxonomy}.`term_taxonomy_id` = {$wpdb->term_relationships}.`term_taxonomy_id`
 			WHERE {$wpdb->term_taxonomy}.`taxonomy` = 'module'
-			AND object_id IN (%1s)",
+			AND object_id IN (%1s)",  // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
 				$lesson_ids
 			)
 		);

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1114,21 +1114,11 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 */
 	private function get_totals_for_lesson_report_column_headers( int $course_id ) {
 		global $wpdb;
-		$lesson_count = 0;
-		$lessons_args = array(
-			'post_type'      => 'lesson',
-			'post_status'    => array( 'publish', 'private' ),
-			'posts_per_page' => -1,
-			'meta_key'       => '_lesson_course', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Applying the course filter.
-			'meta_value'     => $course_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Applying the course filter.
-			'fields'         => 'ids',
-			'no_found_rows'  => true,
-		);
-		$query        = new WP_Query( $lessons_args );
+		$lessons      = Sensei()->course->course_lessons( $course_id, array( 'publish', 'private' ), 'ids' );
 		$lesson_ids   = '0';
-		if ( $query->have_posts() ) {
-			$lesson_count = count( $query->posts );
-			$lesson_ids   = implode( ',', $query->posts );
+		$lesson_count = count( $lessons );
+		if ( 0 < $lesson_count ) {
+			$lesson_ids = implode( ',', $lessons );
 		};
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
 		$lesson_completion_info = $wpdb->get_row(

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -111,7 +111,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$column_value_map['title']              = $total_counts->lesson_count;
 				$column_value_map['lesson_module']      = $total_counts->unique_module_count;
 				$column_value_map['students']           = $total_counts->unique_student_count;
-				$column_value_map['completions']        = $total_counts->lesson_completed_count > 0 ? $total_counts->lesson_completed_count : 0;
+				$column_value_map['completions']        = $total_counts->lesson_completed_count > 0 && $total_counts->lesson_count > 0
+					? ceil( $total_counts->lesson_completed_count / $total_counts->lesson_count )
+					: 0;
 				$column_value_map['days_to_completion'] = $total_counts->lesson_completed_count > 0
 					? ceil( $total_counts->days_to_complete_sum / $total_counts->lesson_completed_count )
 					: __( 'N/A', 'sensei-lms' );

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1081,34 +1081,54 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 *
 	 * @param int $course_id Course Id to filter lessons with.
 	 *
-	 * @return object Row containing the totals for column header.
+	 * @return object Object containing the required totals for column header.
 	 */
 	private function get_totals_for_lesson_report_column_headers( int $course_id ) {
 		global $wpdb;
-		$clean_course_id = esc_sql( $course_id );
+		$lesson_count = 0;
+		$lessons_args = array(
+			'post_type'      => 'lesson',
+			'post_status'    => array( 'publish', 'private' ),
+			'posts_per_page' => -1,
+			'meta_key'       => '_lesson_course', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Applying the course filter.
+			'meta_value'     => $course_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Applying the course filter.
+			'fields'         => 'ids',
+			'no_found_rows'  => true,
+		);
+		$query        = new WP_Query( $lessons_args );
+		$lesson_ids   = '0';
+		if ( $query->have_posts() ) {
+			$lesson_count = count( $query->posts );
+			$lesson_ids   = implode( ',', $query->posts );
+		};
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		return $wpdb->get_row(
+		$lesson_completion_info = $wpdb->get_row(
 			$wpdb->prepare(
-				"SELECT COUNT(DISTINCT(lessons.id)) lesson_count, COUNT(DISTINCT(lesson_taxonomy.term_id)) unique_module_count
-			, COUNT(DISTINCT(lesson_students.user_id)) unique_student_count
+				"SELECT COUNT(DISTINCT(lesson_students.user_id)) unique_student_count
 			, COUNT(DISTINCT(lesson_students.comment_id)) lesson_start_count
 			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed'), 1, 0)) lesson_completed_count
 			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed'), CEILING( TIMESTAMPDIFF( second, STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) / (24 * 60 * 60) ), 0)) days_to_complete_sum
-			FROM $wpdb->posts lessons
-			LEFT JOIN $wpdb->postmeta lessons_meta ON lessons.id = lessons_meta.post_id
-			AND lessons_meta.meta_key = '_lesson_course'
-			LEFT JOIN $wpdb->term_relationships lesson_term ON lessons.id = lesson_term.object_id
-			LEFT JOIN $wpdb->term_taxonomy lesson_taxonomy ON lesson_term.term_taxonomy_id = lesson_taxonomy.term_taxonomy_id
-			AND lesson_taxonomy.taxonomy = 'module'
-			LEFT JOIN $wpdb->comments lesson_students ON lesson_students.comment_post_id = lessons.id
-			AND lesson_students.comment_type = 'sensei_lesson_status'
+			FROM $wpdb->comments lesson_students
 			LEFT JOIN $wpdb->commentmeta lesson_start ON lesson_start.comment_id = lesson_students.comment_id
-			AND lesson_start.meta_key = 'start'
-			WHERE lessons.post_type = 'lesson' AND lessons.post_status IN ('publish','private') AND lessons_meta.meta_value = %d",
+			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN (%1s)",
 				'%Y-%m-%d %H:%i:%s',
-				$clean_course_id
+				$lesson_ids
 			)
 		);
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
+		$modules_count = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(DISTINCT({$wpdb->term_taxonomy}.term_id)) FROM {$wpdb->term_relationships}
+			LEFT JOIN {$wpdb->term_taxonomy} ON {$wpdb->term_taxonomy}.`term_taxonomy_id` = {$wpdb->term_relationships}.`term_taxonomy_id`
+			WHERE {$wpdb->term_taxonomy}.`taxonomy` = 'module'
+			AND object_id IN (%1s)",
+				$lesson_ids
+			)
+		);
+
+		$lesson_completion_info->lesson_count        = $lesson_count;
+		$lesson_completion_info->unique_module_count = $modules_count;
+		return $lesson_completion_info;
 	}
 }
 

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1233,8 +1233,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			$wpdb->prepare(
 				"SELECT COUNT(DISTINCT(lesson_students.user_id)) unique_student_count
 			, COUNT(lesson_students.comment_id) lesson_start_count
-			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed'), 1, 0)) lesson_completed_count
-			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed'), CEILING( TIMESTAMPDIFF( second, STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) / (24 * 60 * 60) ), 0)) days_to_complete_sum
+			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed', 'ungraded' ), 1, 0)) lesson_completed_count
+			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed', 'ungraded' ), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
 			FROM $wpdb->comments lesson_students
 			LEFT JOIN $wpdb->commentmeta lesson_start ON lesson_start.comment_id = lesson_students.comment_id
 			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN (%1s)", // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1120,11 +1120,16 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		if ( 0 < $lesson_count ) {
 			$lesson_ids = implode( ',', $lessons );
 		};
+
+		$default_args  = array(
+			'fields' => 'ids',
+		);
+		$modules_count = count( wp_get_object_terms( $lessons, 'module', $default_args ) );
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$lesson_completion_info = $wpdb->get_row(
+		$lesson_completion_info                      = $wpdb->get_row(
 			$wpdb->prepare(
 				"SELECT COUNT(DISTINCT(lesson_students.user_id)) unique_student_count
-			, COUNT(DISTINCT(lesson_students.comment_id)) lesson_start_count
+			, COUNT(lesson_students.comment_id) lesson_start_count
 			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed'), 1, 0)) lesson_completed_count
 			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed'), CEILING( TIMESTAMPDIFF( second, STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) / (24 * 60 * 60) ), 0)) days_to_complete_sum
 			FROM $wpdb->comments lesson_students
@@ -1134,17 +1139,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$lesson_ids
 			)
 		);
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$modules_count = $wpdb->get_var(
-			$wpdb->prepare(
-				"SELECT COUNT(DISTINCT({$wpdb->term_taxonomy}.term_id)) FROM {$wpdb->term_relationships}
-			LEFT JOIN {$wpdb->term_taxonomy} ON {$wpdb->term_taxonomy}.`term_taxonomy_id` = {$wpdb->term_relationships}.`term_taxonomy_id`
-			WHERE {$wpdb->term_taxonomy}.`taxonomy` = 'module'
-			AND object_id IN (%1s)",  // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
-				$lesson_ids
-			)
-		);
-
 		$lesson_completion_info->lesson_count        = $lesson_count;
 		$lesson_completion_info->unique_module_count = $modules_count;
 		return $lesson_completion_info;

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -120,7 +120,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		}
 		foreach ( $column_value_map as $key => $value ) {
 			if ( key_exists( $key, $columns ) ) {
-				$columns[ $key ] = "{$columns[ $key ]} ({$value})";
+				$columns[ $key ] = $columns[ $key ] . ' (' . esc_html( $value ) . ')';
 			}
 		}
 		return $columns;
@@ -956,7 +956,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 *
 	 * @return object Row containing the totals for column header.
 	 */
-	public function get_totals_for_lesson_report_column_headers( int $course_id ) {
+	private function get_totals_for_lesson_report_column_headers( int $course_id ) {
 		global $wpdb;
 
 		$clean_course_id                = esc_sql( $course_id );
@@ -965,8 +965,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$comment_query_piece['select'] .= ', COUNT(DISTINCT(lesson_taxonomy.term_id)) unique_module_count';
 		$comment_query_piece['select'] .= ', COUNT(DISTINCT(lesson_students.user_id)) unique_student_count';
 		$comment_query_piece['select'] .= ', COUNT(DISTINCT(lesson_students.comment_id)) lesson_start_count';
-		$comment_query_piece['select'] .= ", SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','completed'), 1, 0)) lesson_completed_count";
-		$comment_query_piece['select'] .= ", SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','completed'), CEILING( timestampdiff( second, STR_TO_DATE( lesson_start.meta_value, '%Y-%m-%d %H:%i:%s' ), lesson_students.comment_date ) / (24 * 60 * 60) ), 0)) days_to_complete_sum";
+		$comment_query_piece['select'] .= ", SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','completed','failed'), 1, 0)) lesson_completed_count";
+		$comment_query_piece['select'] .= ", SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','completed','failed'), CEILING( timestampdiff( second, STR_TO_DATE( lesson_start.meta_value, '%Y-%m-%d %H:%i:%s' ), lesson_students.comment_date ) / (24 * 60 * 60) ), 0)) days_to_complete_sum";
 		$comment_query_piece['from']    = " from {$wpdb->posts} lessons";
 		$comment_query_piece['join']    = " left join {$wpdb->postmeta} lessons_meta on lessons.id = lessons_meta.post_id";
 		$comment_query_piece['join']   .= " AND lessons_meta.meta_key = '_lesson_course'";

--- a/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
@@ -623,9 +623,10 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 			wp_update_comment(
 				[
 					'comment_ID'   => $lesson_activity_comment_id,
-					'comment_date' => gmdate( 'Y-m-d H:i:s', strtotime( ( $days_count++ ) . ' days' ) ),
+					'comment_date' => gmdate( 'Y-m-d H:i:s', strtotime( ( $days_count * 24 ) - 6 . ' hours' ) ),
 				]
 			);
+			$days_count++;
 		}
 
 		/* ACT */

--- a/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
@@ -893,7 +893,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 			'last_activity'      => 'Last Activity',
 			'completions'        => 'Completed (1)',
 			'completion_rate'    => 'Completion Rate (100%)',
-			'days_to_completion' => 'Days to Completion (8)',
+			'days_to_completion' => 'Days to Completion (9)',
 		];
 		self::assertSame( $expected, $actual, 'The expected column headers for lessons table in overview report does not match the actual output' );
 	}

--- a/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
@@ -892,6 +892,7 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 			'students'           => 'Students (3)',
 			'last_activity'      => 'Last Activity',
 			'completions'        => 'Completed (1)',
+			'completion_rate'    => 'Completion Rate (100%)',
 			'days_to_completion' => 'Days to Completion (8)',
 		];
 		self::assertSame( $expected, $actual, 'The expected column headers for lessons table in overview report does not match the actual output' );


### PR DESCRIPTION
Partial for [#4835](https://github.com/Automattic/sensei/issues/4835)

### Changes proposed in this Pull Request

Added totals to column headers in reports->lessons. Here

1. Lesson -> Unique lesson count
2. Module -> Unique module count
3. Students -> Unique students count
4. Completed -> How many times students have completed the lessons in the course in total
5. Days to Completion -> Ceiling value of the number of days taken by students on average to complete the lessons
6. Completion Rate -> (count of students completed lessons / count of students enrolled in lessons) * 100

A few things we've tried here,
- Changing the headers via filter, so not changing the strings directly
- If we want to make the header counts optional later, we can do it more easily
- get_columns was being called multiple times, our filter function removes itself after being called once and doesn't get executed in subsequent calls, so we don't need to check something and handle this case manually
- We're not using any global variables
- 'completion_rate' is not yet merged to the parent branch, but we have the total count for it handled here. Once it is merged, we won't need to change the code here.
- Kept a switch case so that if we decide to implement the other header count tickets the same way, we can do it here with minimal change and it will all be together

### Testing instructions
1. Create more than one courses
2. Add a few modules and lessons
3. Enroll a few students in those courses.
4. Start a few random lessons, complete some of them and leave others incomplete.
5. Check the count values in the headers

### Screenshot / Video
![image](https://user-images.githubusercontent.com/6820724/157870056-b7cfe627-0773-4c58-a360-6c18635e413a.png)