### PR TITLE
Add the video embed from legacy meta box to learning mode

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -386,12 +386,14 @@ class Sensei_Lesson {
 		}
 		$html .= '</select></p>' . "\n";
 
-		$html .= '<p><label for="lesson_video_embed">' . esc_html__( 'Video Embed Code', 'sensei-lms' ) . ':</label><br/>' . "\n";
-		$html .= '<textarea rows="5" cols="50" name="lesson_video_embed" tabindex="6" id="course-video-embed">';
+		if ( ! empty( trim( $lesson_video_embed ) ) ) {
+			$html .= '<p><label for="lesson_video_embed">' . esc_html__( 'Video Embed Code', 'sensei-lms' ) . ':</label><br/>' . "\n";
+			$html .= '<textarea rows="5" cols="50" name="lesson_video_embed" tabindex="6" id="course-video-embed">';
 
-		$html .= $lesson_video_embed . '</textarea></p>' . "\n";
+			$html .= $lesson_video_embed . '</textarea></p>' . "\n";
 
-		$html .= '<p>' . esc_html__( 'Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above.', 'sensei-lms' ) . '</p>';
+			$html .= '<p>' . esc_html__( 'Paste the embed code for your video (e.g. YouTube, Vimeo etc.) in the box above.', 'sensei-lms' ) . '</p>';
+		}
 
 		echo wp_kses(
 			$html,

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -386,7 +386,8 @@ class Sensei_Lesson {
 		}
 		$html .= '</select></p>' . "\n";
 
-		if ( ! empty( trim( $lesson_video_embed ) ) ) {
+		// Show legacy embed video only when it's filled or when using classic editor.
+		if ( ! empty( trim( $lesson_video_embed ) ) || ! get_current_screen()->is_block_editor() ) {
 			$html .= '<p><label for="lesson_video_embed">' . esc_html__( 'Video Embed Code', 'sensei-lms' ) . ':</label><br/>' . "\n";
 			$html .= '<textarea rows="5" cols="50" name="lesson_video_embed" tabindex="6" id="course-video-embed">';
 


### PR DESCRIPTION
Part of #4761

### Changes proposed in this Pull Request

* It loads the video from the legacy embed video meta box when using learning mode.
* It also removes the video embed meta box if it's empty in that lesson, so we start deprecating it in favor of the video block.
  * If the user is using the classic editor, the video embed meta box continues there.
* If a user have lessons that they already migrated the videos to block, and they don't want the video embed from the legacy meta box, it can disable with this snippet:
```php
add_action( 'sensei_loaded', function() {
    remove_filter( 'the_content', [ Sensei_Course_Theme::instance(), 'add_lesson_video_to_content' ], 80 );
} );
```

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Checkout `master`.
* Create a course with learning mode enabled.
* Add a lesson, and add a video through the embed meta box (you need to remove the "Lesson Properties" block in order to see the meta box).
* Checkout this branch.
* Make sure the video shows up in the lesson.
* In the WP Admin > Sensei LMS > Settings > Courses, play with the setting "Enable theme styles", and make sure it works in both cases.
* Make sure it doesn't have any effect when learning mode is disabled.
* Clear the video embed field, save, and refresh the page. Make sure that the field disappeared.
* Activate the [Classic Editor](https://wordpress.org/plugins/classic-editor/), and make sure the field is back.