### PR TITLE
Fix phpunit config and add tests run with coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,9 @@ assets/dist
 build
 diffs
 hookdocs
-node_modules/*
+node_modules/
 tests/images/test-*
-vendor/*
+vendor/
 tests/e2e/screenshots
 /*.zip
+/coverage/

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "test": "npm run test-php && npm run test-js",
     "test-js": "wp-scripts test-unit-js",
     "test-php": "./vendor/bin/phpunit",
+    "test-php-coverage": "php -dxdebug.mode=coverage ./vendor/bin/phpunit --coverage-html=coverage",
     "e2e-docker:up": "npm explore @woocommerce/e2e-environment -- npm run docker:up",
     "e2e-docker:down": "npm explore @woocommerce/e2e-environment -- npm run docker:down",
     "test:e2e": "npm explore @woocommerce/e2e-environment -- npm run test:e2e",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -7,7 +7,6 @@
         convertNoticesToExceptions="true"
         convertWarningsToExceptions="true"
         verbose="true"
-        syntaxCheck="true"
 >
     <php>
         <server name='HTTP_HOST' value='http://localhost' />
@@ -22,14 +21,15 @@
         </testsuite>
     </testsuites>
     <filter>
-        <blacklist>
-            <directory suffix=".php">./tests/</directory>
-            <directory suffix=".php">./tmp/</directory>
-        </blacklist>
-    </filter>
-    <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
+            <directory suffix=".php">./includes/</directory>
+			<exclude>
+				<directory suffix=".php">./includes/3rd-party/</directory>
+				<directory suffix=".php">./includes/admin/tools/views/</directory>
+				<directory suffix=".php">./includes/admin/views/</directory>
+				<file>./includes/data-port/class-sensei-import-job-cli.php</file>
+				<file>./includes/email-signup/template.php</file>
+			</exclude>
         </whitelist>
     </filter>
     <!-- disable logging for speed purposes


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fix PHPUnit config (phpunit.xml).
* Add a command to package.json to run PHPUnit tests with a coverage report

### Testing instructions

* Check if you have Xdebug:
  ```
  % php -v | grep Xdebug
  ```
  In case Xdebug is installed you should see something like:
  ```
      with Xdebug v3.1.2, Copyright (c) 2002-2021, by Derick Rethans
  ```
* Run PHP tests with coverage:
  ```
  % npm run test-php-coverage
  ```
* When PHPUnit finished, run the following command (on macOS) to see the report:
  ```   
  % open coverage/index.html
  ```

### Screenshot / Video
![CleanShot 2022-03-15 at 01 12 02@2x](https://user-images.githubusercontent.com/329356/158270302-4d8adb55-184a-4cfb-a65f-568c288653c0.png)

