### PR TITLE
Update/average progress new branch

### DIFF
--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -190,6 +190,15 @@ class Sensei_Analysis {
 
 		?>
 		<div id="poststuff" class="sensei-analysis-wrap">
+			<div class="sensei-analysis-sidebar">
+				<?php
+				do_action( 'sensei_analysis_before_stats_boxes' );
+				foreach ( $sensei_analysis_overview->stats_boxes() as $key => $value ) {
+					$this->render_stats_box( esc_html( $key ), esc_html( $value ) );
+				}
+				do_action( 'sensei_analysis_after_stats_boxes' );
+				?>
+			</div>
 			<div class="sensei-analysis-main">
 				<?php $sensei_analysis_overview->display(); ?>
 			</div>
@@ -364,18 +373,14 @@ class Sensei_Analysis {
 	}
 
 	/**
-	 * Outputs stats boxes.
+	 * render_stats_box outputs stats boxes
 	 *
-	 * @since      1.2.0
-	 * @deprecated 4.2.0
-	 * @param      string $title Title of stat.
-	 * @param      string $data  Stats data.
-	 * @return     void
+	 * @since  1.2.0
+	 * @param  $title string title of stat
+	 * @param  $data string stats data
+	 * @return void
 	 */
 	public function render_stats_box( $title, $data ) {
-
-		_deprecated_function( __METHOD__, '4.2.0' );
-
 		?>
 		<div class="postbox">
 			<h2><span><?php echo esc_html( $title ); ?></span></h2>

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1358,43 +1358,29 @@ class Sensei_Course {
 	}
 
 	/**
-	 * Function to return count of lessons in coutse.
+	 * course_lesson_count function.
 	 *
 	 * @access public
-	 * @param  int $course_id Course id (default: 0).
+	 * @param  int $course_id (default: 0)
 	 * @return int
 	 */
 	public function course_lesson_count( $course_id = 0 ) {
-		$lessons_array = $this->course_lesson_ids( $course_id );
-
-		$count = count( $lessons_array );
-
-		return $count;
-	}
-
-	/**
-	 * Function to return ids of all lessons in course.
-	 *
-	 * @access public
-	 * @since 4.2.0
-	 *
-	 * @param  int $course_id Course id (default: 0).
-	 * @return int
-	 */
-	public function course_lesson_ids( $course_id = 0 ) {
 
 		$lesson_args   = array(
 			'post_type'        => 'lesson',
 			'posts_per_page'   => -1,
-			'meta_key'         => '_lesson_course', // phpcs:ignore Slow query ok.
-			'meta_value'       => $course_id, // phpcs:ignore Slow query ok.
+			'meta_key'         => '_lesson_course',
+			'meta_value'       => $course_id,
 			'post_status'      => 'publish',
 			'suppress_filters' => 0,
-			'fields'           => 'ids', // less data to retrieve.
+			'fields'           => 'ids', // less data to retrieve
 		);
 		$lessons_array = get_posts( $lesson_args );
 
-		return $lessons_array;
+		$count = count( $lessons_array );
+
+		return $count;
+
 	}
 
 	/**


### PR DESCRIPTION
Relates  #4834

### Changes proposed in this Pull Request
- Average Progress: Calculate the progress of each student in a given course (# lessons marked complete / # lessons in the course), and then determine the average of all of the progress. 

### Testing instructions
- Have at least one user with some completed lessons
- Go to page -> Reposts -> Courses
- New column should be there: 
<img width="1342" alt="image" src="https://user-images.githubusercontent.com/7208249/158592524-670556a4-e363-444b-90c0-7daba17a93e1.png">


### For discussion
- I did first used the approach to append SQL query, but that query was too slow. 