### PR TITLE
Report courses add Average Progress table

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -514,7 +514,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	/**
 	 * Calculate average lesson progress per student for course.
 	 *
-	 * @since 4.2.0
+	 * @since 4.3.0
 	 *
 	 * @param int $course_id Id of the course for which average progress is calculated.
 	 *

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -389,24 +389,20 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$total_lessons  = count( $course_lessons );
 
 				// Get all completed lessons.
-				$completed_count        = 0;
-					$lesson_args        = array(
-						'post__in' => $course_lessons,
-						'type'     => 'sensei_lesson_status',
-						'status'   => array( 'graded', 'ungraded', 'passed', 'failed', 'complete' ),
-						'count'    => true,
-					);
-					$lesson_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_lesson_completions', $lesson_args, $item ) );
-					if ( $lesson_completions ) {
-						$completed_count += (int) $lesson_completions;
-					}
+				$lesson_args        = array(
+					'post__in' => $course_lessons,
+					'type'     => 'sensei_lesson_status',
+					'status'   => array( 'graded', 'ungraded', 'passed', 'failed', 'complete' ),
+					'count'    => true,
+				);
+				$completed_count = (int) Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_lesson_completions', $lesson_args, $item ) );
 
-					// Calculate avergae progress.
-					if ( $course_students_count && $total_lessons ) {
-						// Average course progress is calculated based on lessons completed for the course
-						// divided by the total possible lessons completed.
-						$average_course_progress = $completed_count / ( $course_students_count * $total_lessons ) * 100;
-					}
+				// Calculate average progress.
+				if ( $course_students_count && $total_lessons ) {
+					// Average course progress is calculated based on lessons completed for the course
+					// divided by the total possible lessons completed.
+					$average_course_progress = $completed_count / ( $course_students_count * $total_lessons ) * 100;
+				}
 					$column_data = apply_filters(
 						'sensei_analysis_overview_column_data',
 						array(

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -396,12 +396,15 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'count'    => true,
 				);
 				$completed_count = (int) Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_lesson_completions', $lesson_args, $item ) );
-
 				// Calculate average progress.
+				$average_course_progress =  __( 'N/A', 'sensei-lms' );
 				if ( $course_students_count && $total_lessons ) {
 					// Average course progress is calculated based on lessons completed for the course
 					// divided by the total possible lessons completed.
-					$average_course_progress = $completed_count / ( $course_students_count * $total_lessons ) * 100;
+					$average_course_progress_value = $completed_count / ( $course_students_count * $total_lessons ) * 100;
+					$average_course_progress = esc_html(
+						sprintf( '%d%%', $average_course_progress_value )
+					);
 				}
 					$column_data = apply_filters(
 						'sensei_analysis_overview_column_data',
@@ -409,9 +412,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 							'title'              => $course_title,
 							'last_activity'      => $last_activity_date,
 							'completions'        => $course_completions,
-							'average_progress'   => esc_html(
-								sprintf( '%d%%', $average_course_progress )
-							),
+							'average_progress'   => $average_course_progress,
 							'average_grade'      => $average_grade,
 							'days_to_completion' => $average_completion_days,
 						),

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -397,7 +397,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						'status'  => array( 'graded', 'ungraded', 'passed', 'failed', 'complete' ),
 						'count'   => true,
 					);
-					$lesson_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_lesson_completions', $lesson_args, $item ) );
+					$lesson_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_lesson_completions', $lesson_args, $item ) );
 					if ( $lesson_completions ) {
 						$completed_count += (int) $lesson_completions;
 					}
@@ -416,7 +416,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 						'last_activity'      => $last_activity_date,
 						'completions'        => $course_completions,
 						'average_progress'   => esc_html(
-						/* translators: Progress value. */
 							sprintf( '%d%%', $average_course_progress )
 						),
 						'average_grade'      => $average_grade,

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -554,7 +554,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			// divided by the total possible lessons completed.
 			$average_course_progress_value = $completed_count / ( $course_students_count * $total_lessons ) * 100;
 			$average_course_progress       = esc_html(
-				sprintf( '%d%%', $average_course_progress_value )
+				sprintf( '%d%%', ceil( $average_course_progress_value ) )
 			);
 		}
 		return $average_course_progress;

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -376,7 +376,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$course_args           = array(
 					'post_id' => $item->ID,
 					'type'    => 'sensei_course_status',
-					'status'  => 'any',
+					'status'  => array( 'in-progress', 'complete' ),
 				);
 				$course_students_count = Sensei_Utils::sensei_check_for_activity( $course_args );
 
@@ -384,7 +384,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$average_course_progress = 0;
 
 				// Get all course lessons.
-				$lessons        = Sensei()->course->course_lessons( $item->ID, 'any', 'ids' );
+				$lessons        = Sensei()->course->course_lessons( $item->ID, 'publish', 'ids' );
 				$course_lessons = is_array( $lessons ) ? $lessons : array( $lessons );
 				$total_lessons  = count( $course_lessons );
 

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -397,12 +397,12 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				);
 				$completed_count = (int) Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_lesson_completions', $lesson_args, $item ) );
 				// Calculate average progress.
-				$average_course_progress =  __( 'N/A', 'sensei-lms' );
+				$average_course_progress = __( 'N/A', 'sensei-lms' );
 				if ( $course_students_count && $total_lessons ) {
 					// Average course progress is calculated based on lessons completed for the course
 					// divided by the total possible lessons completed.
 					$average_course_progress_value = $completed_count / ( $course_students_count * $total_lessons ) * 100;
-					$average_course_progress = esc_html(
+					$average_course_progress       = esc_html(
 						sprintf( '%d%%', $average_course_progress_value )
 					);
 				}

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -389,41 +389,39 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$total_lessons  = count( $course_lessons );
 
 				// Get all completed lessons.
-				$completed_count = 0;
-				foreach ( $course_lessons as $lesson_id ) {
+				$completed_count        = 0;
 					$lesson_args        = array(
-						'post_id' => $lesson_id,
-						'type'    => 'sensei_lesson_status',
-						'status'  => array( 'graded', 'ungraded', 'passed', 'failed', 'complete' ),
-						'count'   => true,
+						'post__in' => $course_lessons,
+						'type'     => 'sensei_lesson_status',
+						'status'   => array( 'graded', 'ungraded', 'passed', 'failed', 'complete' ),
+						'count'    => true,
 					);
 					$lesson_completions = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_lesson_completions', $lesson_args, $item ) );
 					if ( $lesson_completions ) {
 						$completed_count += (int) $lesson_completions;
 					}
-				}
 
-				// Calculate avergae progress.
-				if ( $course_students_count && $total_lessons ) {
-					// Average course progress is calculated based on lessons completed for the course
-					// divided by the total possible lessons completed.
-					$average_course_progress = $completed_count / ( $course_students_count * $total_lessons ) * 100;
-				}
-				$column_data = apply_filters(
-					'sensei_analysis_overview_column_data',
-					array(
-						'title'              => $course_title,
-						'last_activity'      => $last_activity_date,
-						'completions'        => $course_completions,
-						'average_progress'   => esc_html(
-							sprintf( '%d%%', $average_course_progress )
+					// Calculate avergae progress.
+					if ( $course_students_count && $total_lessons ) {
+						// Average course progress is calculated based on lessons completed for the course
+						// divided by the total possible lessons completed.
+						$average_course_progress = $completed_count / ( $course_students_count * $total_lessons ) * 100;
+					}
+					$column_data = apply_filters(
+						'sensei_analysis_overview_column_data',
+						array(
+							'title'              => $course_title,
+							'last_activity'      => $last_activity_date,
+							'completions'        => $course_completions,
+							'average_progress'   => esc_html(
+								sprintf( '%d%%', $average_course_progress )
+							),
+							'average_grade'      => $average_grade,
+							'days_to_completion' => $average_completion_days,
 						),
-						'average_grade'      => $average_grade,
-						'days_to_completion' => $average_completion_days,
-					),
-					$item,
-					$this
-				);
+						$item,
+						$this
+					);
 				break;
 
 			case 'lessons':

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -131,11 +131,11 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		switch ( $this->type ) {
 			case 'courses':
 				$columns = array(
-					'title'              => array( 'title', false ),
-					'completions'        => array( 'completions', false ),
-					'average_progress'   => array( 'average_progress', false ),
-					'average_grade'      => array( 'average_grade', false ),
-					'days_to_completion' => array( 'days_to_completion', false ),
+					'title'           => array( 'title', false ),
+					'students'        => array( 'students', false ),
+					'lessons'         => array( 'lessons', false ),
+					'completions'     => array( 'completions', false ),
+					'average_percent' => array( 'average_percent', false ),
 				);
 				break;
 

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -131,11 +131,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		switch ( $this->type ) {
 			case 'courses':
 				$columns = array(
-					'title'           => array( 'title', false ),
-					'students'        => array( 'students', false ),
-					'lessons'         => array( 'lessons', false ),
-					'completions'     => array( 'completions', false ),
-					'average_percent' => array( 'average_percent', false ),
+					'title' => array( 'title', false ),
 				);
 				break;
 

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -378,7 +378,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'type'    => 'sensei_course_status',
 					'status'  => 'any',
 				);
-				$course_students_count = Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_learners', $course_args, $item ) );
+				$course_students_count = Sensei_Utils::sensei_check_for_activity( $course_args );
 
 				// Calculate average lesson progress per student for course.
 				$average_course_progress = 0;

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -554,7 +554,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			// divided by the total possible lessons completed.
 			$average_course_progress_value = $completed_count / ( $course_students_count * $total_lessons ) * 100;
 			$average_course_progress       = esc_html(
-				sprintf( '%d%%', ceil( $average_course_progress_value ) )
+				sprintf( '%d%%', round( $average_course_progress_value ) )
 			);
 		}
 		return $average_course_progress;

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -389,7 +389,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 				$total_lessons  = count( $course_lessons );
 
 				// Get all completed lessons.
-				$lesson_args        = array(
+				$lesson_args     = array(
 					'post__in' => $course_lessons,
 					'type'     => 'sensei_lesson_status',
 					'status'   => array( 'graded', 'ungraded', 'passed', 'failed', 'complete' ),

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -372,41 +372,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					$course_title = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . apply_filters( 'the_title', $item->post_title, $item->ID ) . '</a></strong>';
 				}
 
-				// Fetch learners in course.
-				$course_args           = array(
-					'post_id' => $item->ID,
-					'type'    => 'sensei_course_status',
-					'status'  => array( 'in-progress', 'complete' ),
-				);
-				$course_students_count = Sensei_Utils::sensei_check_for_activity( $course_args );
-
-				// Calculate average lesson progress per student for course.
-				$average_course_progress = 0;
-
-				// Get all course lessons.
-				$lessons        = Sensei()->course->course_lessons( $item->ID, 'publish', 'ids' );
-				$course_lessons = is_array( $lessons ) ? $lessons : array( $lessons );
-				$total_lessons  = count( $course_lessons );
-
-				// Get all completed lessons.
-				$lesson_args     = array(
-					'post__in' => $course_lessons,
-					'type'     => 'sensei_lesson_status',
-					'status'   => array( 'graded', 'ungraded', 'passed', 'failed', 'complete' ),
-					'count'    => true,
-				);
-				$completed_count = (int) Sensei_Utils::sensei_check_for_activity( apply_filters( 'sensei_analysis_course_lesson_completions', $lesson_args, $item ) );
-				// Calculate average progress.
-				$average_course_progress = __( 'N/A', 'sensei-lms' );
-				if ( $course_students_count && $total_lessons ) {
-					// Average course progress is calculated based on lessons completed for the course
-					// divided by the total possible lessons completed.
-					$average_course_progress_value = $completed_count / ( $course_students_count * $total_lessons ) * 100;
-					$average_course_progress       = esc_html(
-						sprintf( '%d%%', $average_course_progress_value )
-					);
-				}
-					$column_data = apply_filters(
+				$average_course_progress = $this->get_average_progress_for_courses_table( $item->ID );
+					$column_data         = apply_filters(
 						'sensei_analysis_overview_column_data',
 						array(
 							'title'              => $course_title,
@@ -546,6 +513,53 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		return $escaped_column_data;
 	}
+
+
+	/**
+	 * Calculate average lesson progress per student for course.
+	 *
+	 * @since 4.2.0
+	 *
+	 * @param int $course_id Id of the course for which average progress is calculated.
+	 *
+	 * @return string The average progress for the course, or N/A if none.
+	 */
+	private function get_average_progress_for_courses_table( $course_id ) {
+		// Fetch learners in course.
+		$course_args = array(
+			'post_id' => $course_id,
+			'type'    => 'sensei_course_status',
+			'status'  => array( 'in-progress', 'complete' ),
+		);
+
+		$course_students_count = Sensei_Utils::sensei_check_for_activity( $course_args );
+
+		// Get all course lessons.
+		$lessons        = Sensei()->course->course_lessons( $course_id, 'publish', 'ids' );
+		$course_lessons = is_array( $lessons ) ? $lessons : array( $lessons );
+		$total_lessons  = count( $course_lessons );
+
+		// Get all completed lessons.
+		$lesson_args     = array(
+			'post__in' => $course_lessons,
+			'type'     => 'sensei_lesson_status',
+			'status'   => array( 'graded', 'ungraded', 'passed', 'failed', 'complete' ),
+			'count'    => true,
+		);
+		$completed_count = (int) Sensei_Utils::sensei_check_for_activity( $lesson_args );
+		// Calculate average progress.
+		$average_course_progress = __( 'N/A', 'sensei-lms' );
+		if ( $course_students_count && $total_lessons ) {
+			// Average course progress is calculated based on lessons completed for the course
+			// divided by the total possible lessons completed.
+			$average_course_progress_value = $completed_count / ( $course_students_count * $total_lessons ) * 100;
+			$average_course_progress       = esc_html(
+				sprintf( '%d%%', $average_course_progress_value )
+			);
+		}
+		return $average_course_progress;
+	}
+
 
 	/**
 	 * Get the date on which the last lesson was marked complete.

--- a/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
@@ -873,13 +873,62 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 
 		// Enroll student 2 to the course and lessons, but don't complete the lessons.
 		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_2 );
-		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_2 );
+		Sensei_Utils::sensei_start_lesson( $lesson_2, $user_id_2 );
 
 		/* Assert. */
 		$this->assertEquals(
 			'50%',
 			$method->invoke( $instance, ( $course_id ) ),
 			'Find an average of lessons completed in the course for all the students.'
+		);
+	}
+
+	/**
+	 * Tests getting average progress value for the course based on the lessons completion.
+	 *
+	 * @covers Sensei_Analysis_Overview_List_Table::get_average_progress_for_courses_table
+	 */
+	public function testAverageProgressForCourseRoundupNumber() {
+		// Create a course
+		$course_id = $this->factory->course->create();
+
+		// Create 2 users
+		$user_id_1 = $this->factory->user->create();
+		$user_id_2 = $this->factory->user->create();
+
+		//Add 3 lessons to the course
+		$lesson_1 = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$lesson_2 = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$lesson_3 = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+
+		$instance = new Sensei_Analysis_Overview_List_Table();
+
+		// Get private method get_average_progress_for_courses_table
+		$method = new ReflectionMethod( $instance, 'get_average_progress_for_courses_table' );
+		$method->setAccessible( true );
+
+		// Complete lesson 1 and lesson 2 with user_1.
+		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_1, true );
+		Sensei_Utils::sensei_start_lesson( $lesson_2, $user_id_1 );
+		Sensei_Utils::sensei_start_lesson( $lesson_3, $user_id_1 );
+
+		// Enroll student 2 to the course and lessons, but don't complete the lessons.
+		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_2 );
+		Sensei_Utils::sensei_start_lesson( $lesson_2, $user_id_2 );
+		Sensei_Utils::sensei_start_lesson( $lesson_3, $user_id_2 );
+
+		// The value after calcuation should be 16.66%, but it should be rounded up to 17.
+		/* Assert. */
+		$this->assertEquals(
+			'17%',
+			$method->invoke( $instance, ( $course_id ) ),
+			'Find an average of lessons completed in the course for all the students round it up.'
 		);
 	}
 

--- a/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
@@ -839,6 +839,126 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 		/* Assert */
 		$this->assertEquals( $row_data['completion_rate'], $expected_output, "The 'Completion Rate' for {$enrolled_student_count} enrolled and {$completed_student_count} completed students should be {$expected_output}, got {$row_data['completion_rate']}" );
 	}
+
+	/**
+	 * Tests getting average progress value for the course based on the lessons completion.
+	 *
+	 * @covers Sensei_Analysis_Overview_List_Table::get_average_progress_for_courses_table
+	 */
+	public function testAverageProgressForCourse() {
+		// Create a course
+		$course_id = $this->factory->course->create();
+
+		// Create 2 users
+		$user_id_1 = $this->factory->user->create();
+		$user_id_2 = $this->factory->user->create();
+
+		//Add 2 lessons to the course
+		$lesson_1 = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$lesson_2 = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+
+		$instance = new Sensei_Analysis_Overview_List_Table();
+
+		// Get private method get_average_progress_for_courses_table
+		$method = new ReflectionMethod( $instance, 'get_average_progress_for_courses_table' );
+		$method->setAccessible( true );
+
+		// Complete lesson 1 and lesson 2 with user_1.
+		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_1, true );
+		Sensei_Utils::sensei_start_lesson( $lesson_2, $user_id_1, true );
+
+		// Enroll student 2 to the course and lessons, but don't complete the lessons.
+		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_2 );
+		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_2 );
+
+		/* Assert. */
+		$this->assertEquals(
+			'50%',
+			$method->invoke( $instance, ( $course_id ) ),
+			'Find an average of lessons completed in the course for all the students.'
+		);
+	}
+
+	/**
+	 * Tests getting average progress value N/A when no students in course.
+	 *
+	 * @covers Sensei_Analysis_Overview_List_Table::get_average_progress_for_courses_table
+	 */
+	public function testAverageProgressNAReturnedNoStudents() {
+		// Create a course
+		$course_id = $this->factory->course->create();
+
+		//Add 2 lessons to the course
+		$lesson_1 = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$lesson_2 = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+
+		$instance = new Sensei_Analysis_Overview_List_Table();
+
+		// Get private method get_average_progress_for_courses_table
+		$method = new ReflectionMethod( $instance, 'get_average_progress_for_courses_table' );
+		$method->setAccessible( true );
+
+		/* Assert. */
+		$this->assertEquals(
+			'N/A',
+			$method->invoke( $instance, ( $course_id ) ),
+			'N/A returned when there is no students enrolled in the course'
+		);
+	}
+
+	/**
+	 * Tests getting average progress 0% when students didn't complete any lesson.
+	 *
+	 * @covers Sensei_Analysis_Overview_List_Table::get_average_progress_for_courses_table
+	 */
+	public function testAverageProgressZeroReturned() {
+		// Create a course
+		$course_id = $this->factory->course->create();
+
+		// Create 2 users
+		$user_id_1 = $this->factory->user->create();
+		$user_id_2 = $this->factory->user->create();
+
+		//Add 2 lessons to the course
+		$lesson_1 = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+		$lesson_2 = $this->factory->lesson->create(
+			[ 'meta_input' => [ '_lesson_course' => $course_id ] ]
+		);
+
+		$instance = new Sensei_Analysis_Overview_List_Table();
+
+		// Get private method get_average_progress_for_courses_table
+		$method = new ReflectionMethod( $instance, 'get_average_progress_for_courses_table' );
+		$method->setAccessible( true );
+
+		// Complete lesson 1 and lesson 2 with user_1.
+		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_1 );
+		Sensei_Utils::sensei_start_lesson( $lesson_2, $user_id_1 );
+
+		// Enroll student 2 to the course and lessons, but don't complete the lessons.
+		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_2 );
+		Sensei_Utils::sensei_start_lesson( $lesson_1, $user_id_2 );
+
+		/* Assert. */
+		$this->assertEquals(
+			'0%',
+			$method->invoke( $instance, ( $course_id ) ),
+			'Progress is 0 when no student have completed no lessons.'
+		);
+
+	}
+
+
 	/**
 	 * Returns an associative array with parameters needed to run lesson completion test.
 	 *


### PR DESCRIPTION
Relates  #4834

### Changes proposed in this Pull Request
- Average Progress: Calculate the progress of students in the course, progress of how many lessons they have finished. 

### How it's implemented: 
- The average progress is calculated by dividing total completed lessons with max completed lessons (All students * all lessons) and multiplied by 100% to get a percentage. 

### Testing instructions
- Have at least one user with some completed lessons
- Go to page -> Reposts (Analysis) -> Courses
- New column should be there: 
<img width="1312" alt="image" src="https://user-images.githubusercontent.com/7208249/158596850-916c5a48-7fbb-4a43-a127-418d3ba44251.png">


### For discussion
- I first implemented it by extending the SQL query but it was making the query too slow.