### PR TITLE
Get the activities ordered by date using asc order

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -114,13 +114,6 @@ class Sensei_Utils {
 			$args['count'] = true;
 		}
 
-		// Are we only retrieving a single entry, or not care about the order...
-		if ( isset( $args['count'] ) || isset( $args['post_id'] ) ) {
-			// ...then we don't need to ask the db to order the results, this overrides WP default behaviour
-			$args['order']   = false;
-			$args['orderby'] = false;
-		}
-
 		// A user ID of 0 is in valid, so shortcut this
 		if ( isset( $args['user_id'] ) && 0 == intval( $args['user_id'] ) ) {
 			_deprecated_argument( __FUNCTION__, '1.0', esc_html__( 'At no point should user_id be equal to 0.', 'sensei-lms' ) );


### PR DESCRIPTION
Previously the code was doing an optimization, avoiding the database to order the activities data in certain scenarios, but it was preventing us to get the newest activity.

It is related to issue #4913 

### Changes proposed in this Pull Request

* Assume that we always need to get the activities ordered by the newest one. 

### Testing instructions


Steps to Reproduce
1. Complete a lesson as 2 different students on 2 different dates. You may need to manipulate the database directly if you don't already have such data.
2. Go to Sensei LMS > Reports > Lessons and filter by the course.
3. Inspect the Last Activity column for that lesson.
4. The Last Activity column should display the newest date.

Extra comment:
This method is pretty old, holds multiple responsibilities (return comments, return count) and it used in a lot of other places. Maybe we could think about splitting it into small pieces.

