### PR TITLE
Improve performance of fetching filtered lessons

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -599,16 +599,16 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		if ( ! $course_id ) {
 			return [];
 		}
-
-		$lessons_args = array(
+		// Fetching the lesson ids beforehand because joining both postmeta and comment + commentmeta makes WP_Query very slow.
+		$course_lessons = Sensei()->course->course_lessons( $course_id, 'any', 'ids' );
+		$lessons_args   = array(
 			'post_type'        => 'lesson',
 			'post_status'      => array( 'publish', 'private' ),
 			'posts_per_page'   => $args['number'],
 			'offset'           => $args['offset'],
 			'orderby'          => $args['orderby'],
 			'order'            => $args['order'],
-			'meta_key'         => '_lesson_course', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Applying the course filter.
-			'meta_value'       => $course_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Applying the course filter.
+			'post__in'         => $course_lessons,
 			'suppress_filters' => 0,
 		);
 
@@ -937,13 +937,14 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	public function add_days_to_complete_to_lessons_query( $clauses ) {
 		global $wpdb;
 
-		$clauses['fields'] .= ", sum( CEILING( timestampdiff( second, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ), {$wpdb->comments}.comment_date ) / (24 * 60 * 60) )) as days_to_complete";
-		$clauses['join']   .= " LEFT JOIN {$wpdb->comments} ON {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID";
-		$clauses['join']   .= " AND {$wpdb->comments}.comment_type IN ('sensei_lesson_status')";
-		$clauses['join']   .= " AND {$wpdb->comments}.comment_approved IN ( 'complete', 'graded', 'passed', 'failed' )";
-		$clauses['join']   .= " AND {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID";
-		$clauses['join']   .= " LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id";
-		$clauses['join']   .= " AND {$wpdb->commentmeta}.meta_key = 'start'";
+		$clauses['fields'] .= ", (SELECT SUM( CEILING( TIMESTAMPDIFF( second, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ), {$wpdb->comments}.comment_date ) / (24 * 60 * 60) )) as days_to_complete";
+		$clauses['fields'] .= " FROM {$wpdb->comments}";
+		$clauses['fields'] .= " INNER JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id";
+		$clauses['fields'] .= " WHERE {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID";
+		$clauses['fields'] .= " AND {$wpdb->comments}.comment_type IN ('sensei_lesson_status')";
+		$clauses['fields'] .= " AND {$wpdb->comments}.comment_approved IN ( 'complete', 'graded', 'passed', 'failed' )";
+		$clauses['fields'] .= " AND {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID";
+		$clauses['fields'] .= " AND {$wpdb->commentmeta}.meta_key = 'start') as days_to_complete";
 
 		return $clauses;
 	}


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/4833

### Changes proposed in this Pull Request

For filtering lessons with courses, we were joining the post table with post_meta, for getting days to complete for each lesson, we were joining with comment and comment_meta. This much joining was making the query slow for a large set of data. In my test DB with 3 courses, 300 lessons each, and 350000 total lesson completions per course, it was taking over 7 seconds to fetch lessons for a single course after filtering. Now after the improvement, it is close to 1.2 seconds for that similar case. 

### Testing instructions

* Add a few courses
* Add lessons to those courses
* Create a few students and complete those lessons
* Go to Reports->Lessons
* Filter the lessons using the Course dropdown on the top left of the table
* Check the values for each row

As this ticket is related mostly to performance, the best way to test will be to have a big set of data, switch to the feature/reports branch and browse the lessons page, switch the branch to this one, check the same page again.
