### PR TITLE
Allow clearing the reports last activity date filter

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1099,9 +1099,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$default = gmdate( 'Y-m-d', strtotime( '-30 days' ) );
 
 		// phpcs:ignore WordPress.Security -- The date is sanitized by DateTime.
-		$start_date = $_GET['start_date'] ?? '';
+		$start_date = $_GET['start_date'] ?? $default;
 
-		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : $default;
+		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-overview-list-table.php
@@ -524,6 +524,16 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 		$method->setAccessible( true );
 
 		/* Act. */
+		$start_date = $method->invoke( $instance );
+
+		/* Assert. */
+		$this->assertEquals(
+			gmdate( 'Y-m-d', strtotime( '-30 days' ) ),
+			$start_date,
+			'The start date should default to 30 days ago.'
+		);
+
+		/* Act. */
 		$_GET = [
 			'start_date' => '2022-03-01',
 		];
@@ -546,9 +556,23 @@ class Sensei_Analysis_Overview_List_Table_Test extends WP_UnitTestCase {
 
 		/* Assert. */
 		$this->assertEquals(
-			gmdate( 'Y-m-d', strtotime( '-30 days' ) ),
+			'',
 			$start_date,
-			'The start date should default to 30 days ago.'
+			'The start date should be empty when the "start_date" query param is empty.'
+		);
+
+		/* Act. */
+		$_GET = [
+			'start_date' => 'invalid-date',
+		];
+
+		$start_date = $method->invoke( $instance );
+
+		/* Assert. */
+		$this->assertEquals(
+			'',
+			$start_date,
+			'The start date should be empty when the "start_date" query param date is invalid.'
 		);
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

With this change, you are able to remove the last activity start date and see all students/courses.

### Testing instructions

* Go to Sensei LMS -> Reports -> Students.
* The last activity start date filter should be set to 30 days ago.
* Clear the start date input and click the "Filter" button.
* The last activity filter should not be applied and the input should be empty.
* Repeat the process for Sensei LMS -> Reports -> Courses.
