### PR TITLE
Fix video, embed width

### DIFF
--- a/assets/css/sensei-course-theme/content.scss
+++ b/assets/css/sensei-course-theme/content.scss
@@ -96,6 +96,13 @@ body {
 		max-width: 100%;
 		height: auto;
 	}
+
+	embed,
+	iframe,
+	object {
+		max-width: 100%;
+	}
+
 }
 
 


### PR DESCRIPTION
Fixes #4871

### Changes proposed in this Pull Request

* Add CSS to limit max-width for videos and other embeds

### Testing instructions
- Add a Vimeo embed as **Lesson Video** to a lesson. (Remove all Sensei blocks from the lesson for the metabox to show up, then paste the code into Lesson Information > Video Embed Code)
- Save, view the lesson and resize to a small screen
- Video width should resize to screen width

Sample embed code:
```
<iframe src="https://player.vimeo.com/video/682661192?h=645fe74a58" width="640" height="384" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen></iframe>
<p><a href="https://vimeo.com/682661192">Lighting Tests</a> from <a href="https://vimeo.com/tomnicoll">Tom Nicoll</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
``` 
