### PR TITLE
Moving `option-toggle` css to shared `question.scss`.

### DIFF
--- a/assets/blocks/quiz/question-block/question-block.editor.scss
+++ b/assets/blocks/quiz/question-block/question-block.editor.scss
@@ -1,6 +1,5 @@
 $block: '.sensei-lms-question-block';
 
-@import '../answer-blocks/option-toggle';
 @import './question';
 @import './question-grade-toolbar';
 @import '../../../shared/styles/wp-colors';

--- a/assets/blocks/quiz/question-block/question.scss
+++ b/assets/blocks/quiz/question-block/question.scss
@@ -1,3 +1,4 @@
+@import '../answer-blocks/option-toggle';
 
 /**
  * Sensei question and question block styles shared between frontend and editor.


### PR DESCRIPTION
We are going to start using the OptionToggle component in the frontend as well as the editor.

We need then to move the scss from the editor-only to the common `question.scss` file.

Fixes partially: 879-gh-Automattic/sensei-pro

### Changes proposed in this Pull Request

* Move `option-toggle.scss` to the shared `question.scss` file.

### Testing instructions
* Checkout to this branch and run the build.
* Check that OptionToggle (used in the quiz editor) still works.