### PR TITLE
Optimize performance for reports->courses

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1045,7 +1045,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		}
 		// Fetch the lessons within the expected last activity range.
 		$lessons_query = "SELECT cm.comment_post_id lesson_id
-			FROM wp_comments cm
+			FROM {$wpdb->comments} cm
 			WHERE cm.comment_approved IN ('complete', 'passed', 'graded')
 			AND cm.comment_type = 'sensei_lesson_status'";
 		// Filter by start date.
@@ -1065,7 +1065,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		}
 		// Fetch the course IDs associated with those lessons.
 		$course_query      = "SELECT DISTINCT(pm.meta_value) course_id
-		FROM wp_postmeta pm JOIN ({$lessons_query}) ls
+		FROM {$wpdb->postmeta} pm JOIN ({$lessons_query}) ls
 		ON ls.lesson_id = pm.post_id
 		";
 		$clauses['where'] .= " AND {$wpdb->posts}.ID IN ({$course_query})";


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/4834

### Changes proposed in this Pull Request

While testing with a large set of data (3 courses, 300 lessons each, 1200 students enrolled per lesson), fetching courses was taking a long time, it was giving me a server timeout. So got the query that was generated from the log ran it directly on the db for fetching the courses, it took over 15 minutes, then I had to stop the query from executing. The days to completion and the last activity date filter joined together with the course fetching query was making it extremely slow, removing the days to completion part, the last activity filter was taking 12 seconds to complete alone.

We've updated the query so that the joining does not create a problem and executes faster. Now it takes only 1.8 seconds on average with the same data set.

### Testing instructions

1. Create a few courses 
2. Add a good number of lessons to those courses
3. Enroll a good number of students in those lessons and complete them.
4. Go to Reports -> Courses, filter with date range, check the performance
