### PR TITLE
Improve the students export performance

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -594,7 +594,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	/**
 	 * Format the last activity date to a more readable form.
 	 *
-	 * @since 4.2.0
+	 * @since 4.3.0
 	 *
 	 * @param string $date The last activity date.
 	 *
@@ -1100,7 +1100,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	/**
 	 * Add the `last_activity` field to the user query.
 	 *
-	 * @since  4.2.0
+	 * @since  4.3.0
 	 * @access private
 	 *
 	 * @param WP_User_Query $query The user query.


### PR DESCRIPTION
Related, but not a fix for #4669

### Changes proposed in this Pull Request

This change improves performance when exporting a big number of students by 15%~20%.
To make this possible, I'm reusing the last activity query field instead of querying the comments for each student.
The code is already covered by the existing tests.

### Testing instructions

* Go to Sensei LMS -> Reports -> Students.
* Click the Export button.
* The export should work as before.
