### PR TITLE
Add unit tests for better coverage

### DIFF
--- a/tests/unit-tests/test-class-sensei-customizer.php
+++ b/tests/unit-tests/test-class-sensei-customizer.php
@@ -232,4 +232,12 @@ class Sensei_Customizer_Test extends WP_UnitTestCase {
 
 		self::assertSame( $expected, $actual );
 	}
+
+	public function testEnqueueCustomizerHelper_Constructed_AddsAction() {
+		$this->customizer->enqueue_customizer_helper();
+
+		$actual = has_action( 'wp_print_footer_scripts', [ $this->customizer, 'output_customizer_helper' ] );
+
+		self::assertSame( 10, $actual );
+	}
 }

--- a/tests/unit-tests/test-class-sensei-customizer.php
+++ b/tests/unit-tests/test-class-sensei-customizer.php
@@ -18,6 +18,22 @@ class Sensei_Customizer_Test extends WP_UnitTestCase {
 		$this->customizer = null;
 	}
 
+	public function testConstruct_Constructed_AddsActions() {
+		$actual = [
+			'customize_register'     => has_action( 'customize_register', array( $this->customizer, 'add_customizer_settings' ) ),
+			'customize_preview_init' => has_action( 'customize_preview_init', array( $this->customizer, 'enqueue_customizer_helper' ) ),
+			'wp_head'                => has_action( 'wp_head', array( $this->customizer, 'output_custom_settings' ) ),
+		];
+
+		$expected = [
+			'customize_register'     => 10,
+			'customize_preview_init' => 10,
+			'wp_head'                => 10,
+		];
+
+		self::assertSame( $expected, $actual );
+	}
+
 	public function testAddCustomizerSettings_CustomizeManagerGiven_AddsSectionToCustomizeManager() {
 		$customize_manager = new WP_Customize_Manager();
 
@@ -87,7 +103,7 @@ class Sensei_Customizer_Test extends WP_UnitTestCase {
 				],
 			],
 			'sensei-course-theme-foreground-color' => [
-				'sensei-course-theme-primary-color',
+				'sensei-course-theme-foreground-color',
 				[
 					'default'   => '#1e1e1e',
 					'transport' => 'postMessage',
@@ -95,5 +111,125 @@ class Sensei_Customizer_Test extends WP_UnitTestCase {
 				],
 			],
 		];
+	}
+
+	/**
+	 * Test that customizer adds controls to the customizer manager.
+	 *
+	 * @param string $setting_id Setting identifier.
+	 * @param array $expected Expected setting value.
+	 *
+	 * @dataProvider providerAddCustomizerSettings_CustomizeManagerGiven_AddsControlToCustomizeManager
+	 */
+	public function testAddCustomizerSettings_CustomizeManagerGiven_AddsControlToCustomizeManager( $setting_id, $expected ) {
+		$customize_manager = new WP_Customize_Manager();
+
+		$this->customizer->add_customizer_settings( $customize_manager );
+		$control = $customize_manager->get_control( $setting_id );
+
+		self::assertSame( $expected, $this->exportControl( $control ) );
+	}
+
+	public function exportControl( WP_Customize_Control $control ): array {
+		return [
+			'label'   => $control->label,
+			'section' => $control->section,
+			'type'    => $control->type,
+		];
+	}
+
+	public function providerAddCustomizerSettings_CustomizeManagerGiven_AddsControlToCustomizeManager(): array {
+		return [
+			'sensei-course-theme-primary-color'    => [
+				'sensei-course-theme-primary-color',
+				[
+					'label'   => 'Primary Color',
+					'section' => 'sensei-course-theme',
+					'type'    => 'color',
+				],
+			],
+			'sensei-course-theme-background-color' => [
+				'sensei-course-theme-background-color',
+				[
+					'label'   => 'Background Color',
+					'section' => 'sensei-course-theme',
+					'type'    => 'color',
+				],
+			],
+			'sensei-course-theme-foreground-color' => [
+				'sensei-course-theme-foreground-color',
+				[
+					'label'   => 'Text Color',
+					'section' => 'sensei-course-theme',
+					'type'    => 'color',
+				],
+			],
+		];
+	}
+
+	public function testOutputCustomSettings_DefaultValuesSet_OutputsCustomSettings() {
+		add_option( 'sensei-course-theme-primary-color', '#1e1e1e' );
+		add_option( 'sensei-course-theme-background-color', '#ffffff' );
+		add_option( 'sensei-course-theme-foreground-color', '#1e1e1e' );
+
+		ob_start();
+		$this->customizer->output_custom_settings();
+		$actual = ob_get_clean();
+
+		$expected = '		<style>
+			:root {
+						}
+		</style>
+		';
+
+		self::assertSame( $expected, $actual );
+	}
+
+	public function testOutputCustomSettings_CustomValuesSet_OutputsCustomSettings() {
+		add_option( 'sensei-course-theme-primary-color', 'a' );
+		add_option( 'sensei-course-theme-background-color', 'b' );
+		add_option( 'sensei-course-theme-foreground-color', 'c' );
+
+		ob_start();
+		$this->customizer->output_custom_settings();
+		$actual = ob_get_clean();
+
+		$expected = '		<style>
+			:root {
+			--sensei-course-theme-primary-color: a;
+--sensei-course-theme-background-color: b;
+--sensei-course-theme-foreground-color: c;
+			}
+		</style>
+		';
+
+		self::assertSame( $expected, $actual );
+	}
+
+	public function testOutputCustomizerHelper_Constructed_OutputsCustomizerHelper() {
+		ob_start();
+		$this->customizer->output_customizer_helper();
+		$actual = ob_get_clean();
+
+		$expected = '		<script type="text/javascript">
+						wp.customize( \'sensei-course-theme-primary-color\', ( setting ) => {
+				setting.bind( ( value ) => {
+					document.documentElement.style.setProperty( \'--sensei-course-theme-primary-color\', value )
+				} );
+			} );
+							wp.customize( \'sensei-course-theme-background-color\', ( setting ) => {
+				setting.bind( ( value ) => {
+					document.documentElement.style.setProperty( \'--sensei-course-theme-background-color\', value )
+				} );
+			} );
+							wp.customize( \'sensei-course-theme-foreground-color\', ( setting ) => {
+				setting.bind( ( value ) => {
+					document.documentElement.style.setProperty( \'--sensei-course-theme-foreground-color\', value )
+				} );
+			} );
+						</script>
+		';
+
+		self::assertSame( $expected, $actual );
 	}
 }

--- a/tests/unit-tests/test-class-sensei-customizer.php
+++ b/tests/unit-tests/test-class-sensei-customizer.php
@@ -50,4 +50,58 @@ class Sensei_Customizer_Test extends WP_UnitTestCase {
 			'title'          => $section->title,
 		];
 	}
+
+	/**
+	 * Test that customizer adds settings to the customizer manager.
+	 *
+	 * @param string $setting_id Setting identifier.
+	 * @param array $expected Expected setting value.
+	 *
+	 * @dataProvider providerAddCustomizerSettings_CustomizeManagerGiven_AddsSettingToCustomizeManager
+	 */
+	public function testAddCustomizerSettings_CustomizeManagerGiven_AddsSettingToCustomizeManager( $setting_id, $expected ) {
+		$customize_manager = new WP_Customize_Manager();
+
+		$this->customizer->add_customizer_settings( $customize_manager );
+		$setting = $customize_manager->get_setting( $setting_id );
+
+		self::assertSame( $expected, $this->exportSetting( $setting ) );
+	}
+
+	public function exportSetting( WP_Customize_Setting $setting ): array {
+		return [
+			'default'   => $setting->default,
+			'transport' => $setting->transport,
+			'type'      => $setting->type,
+		];
+	}
+
+	public function providerAddCustomizerSettings_CustomizeManagerGiven_AddsSettingToCustomizeManager(): array {
+		return [
+			'sensei-course-theme-primary-color'    => [
+				'sensei-course-theme-primary-color',
+				[
+					'default'   => '#1e1e1e',
+					'transport' => 'postMessage',
+					'type'      => 'option',
+				],
+			],
+			'sensei-course-theme-background-color' => [
+				'sensei-course-theme-background-color',
+				[
+					'default'   => '#ffffff',
+					'transport' => 'postMessage',
+					'type'      => 'option',
+				],
+			],
+			'sensei-course-theme-foreground-color' => [
+				'sensei-course-theme-primary-color',
+				[
+					'default'   => '#1e1e1e',
+					'transport' => 'postMessage',
+					'type'      => 'option',
+				],
+			],
+		];
+	}
 }

--- a/tests/unit-tests/test-class-sensei-customizer.php
+++ b/tests/unit-tests/test-class-sensei-customizer.php
@@ -1,0 +1,53 @@
+<?php
+require_once ABSPATH . WPINC . '/class-wp-customize-manager.php';
+
+class Sensei_Customizer_Test extends WP_UnitTestCase {
+
+	private $customizer;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		$bootstrap = Sensei_Unit_Tests_Bootstrap::instance();
+
+		//      $bootstrap->
+
+	}
+
+	public function setUp() {
+		parent::setUp();
+		$this->customizer = new Sensei_Customizer();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		remove_action( 'customize_register', array( $this->customizer, 'add_customizer_settings' ) );
+		remove_action( 'customize_preview_init', array( $this->customizer, 'enqueue_customizer_helper' ) );
+		remove_action( 'wp_head', array( $this->customizer, 'output_custom_settings' ) );
+		$this->customizer = null;
+	}
+
+	public function testAddCustomizerSettings_CustomizeManagerGiven_AddsSectionToCustomizeManager() {
+		$customize_manager = new WP_Customize_Manager();
+
+		$this->customizer->add_customizer_settings( $customize_manager );
+		$section = $customize_manager->get_section( 'sensei-course-theme' );
+
+		$expected = [
+			'priority'       => 40,
+			'capability'     => 'manage_sensei',
+			'theme_supports' => '',
+			'title'          => 'Learning Mode (Sensei LMS)',
+		];
+		self::assertSame( $expected, $this->exportSection( $section ) );
+
+	}
+
+	private function exportSection( WP_Customize_Section $section ): array {
+		return [
+			'priority'       => $section->priority,
+			'capability'     => $section->capability,
+			'theme_supports' => $section->theme_supports,
+			'title'          => $section->title,
+		];
+	}
+}

--- a/tests/unit-tests/test-class-sensei-customizer.php
+++ b/tests/unit-tests/test-class-sensei-customizer.php
@@ -5,14 +5,6 @@ class Sensei_Customizer_Test extends WP_UnitTestCase {
 
 	private $customizer;
 
-	public static function setUpBeforeClass() {
-		parent::setUpBeforeClass();
-		$bootstrap = Sensei_Unit_Tests_Bootstrap::instance();
-
-		//      $bootstrap->
-
-	}
-
 	public function setUp() {
 		parent::setUp();
 		$this->customizer = new Sensei_Customizer();

--- a/tests/unit-tests/test-class-sensei-db-query-learners.php
+++ b/tests/unit-tests/test-class-sensei-db-query-learners.php
@@ -1,0 +1,165 @@
+<?php
+
+class Sensei_Db_Query_Learners_Test extends WP_UnitTestCase {
+	public function setUp() {
+		parent::setup();
+		$this->factory = new Sensei_Factory();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
+
+	public function testGetAll_EmptyArgsGiven_ReturnsMatchingResult() {
+		$user1_id = $this->factory->user->create( [ 'user_email' => 'user1@example.com' ] );
+		$user2_id = $this->factory->user->create( [ 'user_email' => 'user2@example.com' ] );
+		$user3_id = $this->factory->user->create( [ 'user_email' => 'user3@example.com' ] );
+
+		$course1_id = $this->factory->course->create();
+		$course2_id = $this->factory->course->create();
+
+		Sensei_Utils::update_course_status( $user1_id, $course1_id );
+		Sensei_Utils::update_course_status( $user1_id, $course2_id, 'complete' );
+		Sensei_Utils::update_course_status( $user2_id, $course1_id, 'complete' );
+		Sensei_Utils::update_course_status( $user3_id, $course2_id );
+
+		$query = new Sensei_Db_Query_Learners( [] );
+
+		$learners = $query->get_all();
+
+		$expected = [
+			[
+				'user_email'   => 'admin@example.org', // admin
+				'course_count' => '0',
+			],
+			[
+				'user_email'   => 'user1@example.com',
+				'course_count' => '2',
+			],
+			[
+				'user_email'   => 'user2@example.com',
+				'course_count' => '1',
+			],
+			[
+				'user_email'   => 'user3@example.com',
+				'course_count' => '1',
+			],
+		];
+
+		self::assertSame( $expected, $this->exportLearners( $learners ) );
+	}
+
+	public function testGetAll_CourseIdGiven_ReturnsMatchingResult() {
+		$user1_id = $this->factory->user->create( [ 'user_email' => 'user1@example.com' ] );
+		$user2_id = $this->factory->user->create( [ 'user_email' => 'user2@example.com' ] );
+		$user3_id = $this->factory->user->create( [ 'user_email' => 'user3@example.com' ] );
+
+		$course1_id = $this->factory->course->create();
+		$course2_id = $this->factory->course->create();
+
+		Sensei_Utils::update_course_status( $user1_id, $course1_id );
+		Sensei_Utils::update_course_status( $user1_id, $course2_id, 'complete' );
+		Sensei_Utils::update_course_status( $user2_id, $course1_id, 'complete' );
+		Sensei_Utils::update_course_status( $user3_id, $course2_id );
+
+		$args  = [
+			'filter_by_course_id' => $course1_id,
+		];
+		$query = new Sensei_Db_Query_Learners( $args );
+
+		$learners = $query->get_all();
+
+		$expected = [
+			[
+				'user_email'   => 'user1@example.com',
+				'course_count' => '2',
+			],
+			[
+				'user_email'   => 'user2@example.com',
+				'course_count' => '1',
+			],
+		];
+
+		self::assertSame( $expected, $this->exportLearners( $learners ) );
+	}
+
+	public function testGetAll_CourseIdAndPerPageGiven_ReturnsMatchingResult() {
+		$user1_id = $this->factory->user->create( [ 'user_email' => 'user1@example.com' ] );
+		$user2_id = $this->factory->user->create( [ 'user_email' => 'user2@example.com' ] );
+		$user3_id = $this->factory->user->create( [ 'user_email' => 'user3@example.com' ] );
+
+		$course1_id = $this->factory->course->create();
+		$course2_id = $this->factory->course->create();
+
+		Sensei_Utils::update_course_status( $user1_id, $course1_id );
+		Sensei_Utils::update_course_status( $user1_id, $course2_id, 'complete' );
+		Sensei_Utils::update_course_status( $user2_id, $course1_id, 'complete' );
+		Sensei_Utils::update_course_status( $user3_id, $course2_id );
+
+		$args  = [
+			'filter_by_course_id' => $course1_id,
+			'per_page'            => 1,
+		];
+		$query = new Sensei_Db_Query_Learners( $args );
+
+		$learners = $query->get_all();
+
+		$expected = [
+			[
+				'user_email'   => 'user1@example.com',
+				'course_count' => '2',
+			],
+		];
+
+		self::assertSame( $expected, $this->exportLearners( $learners ) );
+	}
+
+	public function testGetAll_CourseIdExcluded_ReturnsMatchingResult() {
+		$user1_id = $this->factory->user->create( [ 'user_email' => 'user1@example.com' ] );
+		$user2_id = $this->factory->user->create( [ 'user_email' => 'user2@example.com' ] );
+		$user3_id = $this->factory->user->create( [ 'user_email' => 'user3@example.com' ] );
+
+		$course1_id = $this->factory->course->create();
+		$course2_id = $this->factory->course->create();
+
+		Sensei_Utils::user_start_course( $user1_id, $course1_id );
+		Sensei_Utils::user_start_course( $user1_id, $course2_id, 'complete' );
+		Sensei_Utils::user_start_course( $user2_id, $course1_id, 'complete' );
+		Sensei_Utils::user_start_course( $user3_id, $course2_id );
+
+		$args  = [
+			'filter_by_course_id' => $course1_id,
+			'filter_type'         => 'exc',
+		];
+		$query = new Sensei_Db_Query_Learners( $args );
+
+		$learners = $query->get_all();
+
+		$expected = [
+			[
+				'user_email'   => 'user1@example.com',
+				'course_count' => '2',
+			],
+			[
+				'user_email'   => 'user3@example.com',
+				'course_count' => '1',
+			],
+		];
+
+		self::assertSame( $expected, $this->exportLearners( $learners ) );
+	}
+
+	private function exportLearners( array $learners ): array {
+		$ret = [];
+
+		foreach ( $learners as $learner ) {
+			$ret[] = [
+				'user_email'   => $learner->user_email,
+				'course_count' => $learner->course_count,
+			];
+		}
+
+		return $ret;
+	}
+}


### PR DESCRIPTION
I added tests for two classes. That took ~2 workdays and improved coverage on 0.33%.

### Changes proposed in this Pull Request

* Add tests for `Sensei_Customizer` and for `Sensei_Db_Query_Learners`. 

### Testing instructions

* Run `npm run test-php-coverage`
