### PR TITLE
Fix incorrect i18n extraction from js files

### DIFF
--- a/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
+++ b/assets/blocks/quiz/answer-blocks/multiple-choice-answer-option.js
@@ -66,9 +66,8 @@ const MultipleChoiceAnswerOption = ( props ) => {
 						className="sensei-lms-question-block__answer--multiple-choice__toggle"
 						onClick={ toggleCorrect }
 					>
-						{ correct
-							? __( 'Right', 'sensei-lms' )
-							: __( 'Wrong', 'sensei-lms' ) }
+						{ correct && __( 'Right', 'sensei-lms' ) }
+						{ ! correct && __( 'Wrong', 'sensei-lms' ) }
 					</Button>
 				</div>
 			) }

--- a/assets/blocks/quiz/answer-blocks/true-false.js
+++ b/assets/blocks/quiz/answer-blocks/true-false.js
@@ -49,9 +49,10 @@ const TrueFalseAnswer = ( {
 									} )
 								}
 							>
-								{ correct === value
-									? __( 'Right', 'sensei-lms' )
-									: __( 'Wrong', 'sensei-lms' ) }
+								{ correct === value &&
+									__( 'Right', 'sensei-lms' ) }
+								{ correct !== value &&
+									__( 'Wrong', 'sensei-lms' ) }
 							</Button>
 						</div>
 					) }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "interpolate-components": "1.1.1",
     "lodash": "4.17.21",
     "react-animate-height": "2.0.23",
+    "terser-webpack-plugin": "5.3.1",
     "uuid": "3.3.2"
   },
   "devDependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,12 @@ const { fromPairs } = require( 'lodash' );
 const CopyPlugin = require( 'copy-webpack-plugin' );
 const SVGSpritemapPlugin = require( 'svg-spritemap-webpack-plugin' );
 const getBaseWebpackConfig = require( '@automattic/calypso-build/webpack.config.js' );
+const TerserPlugin = require( 'terser-webpack-plugin' );
+
+/**
+ * I18n methods that should not be mangled by the compiler process
+ */
+const I18N_METHODS = [ '__', '_n', '_nx', '_x' ];
 
 /**
  * Internal dependencies
@@ -124,6 +130,18 @@ function getWebpackConfig( env, argv ) {
 		entry: mapFilesToEntries( files ),
 		output: {
 			path: path.resolve( '.', baseDist ),
+		},
+		optimization: {
+			concatenateModules: false,
+			minimizer: [
+				new TerserPlugin( {
+					extractComments: false,
+					terserOptions: {
+						mangle: { reserved: I18N_METHODS },
+						format: { comments: true },
+					},
+				} ),
+			],
 		},
 		devtool:
 			process.env.SOURCEMAP ||


### PR DESCRIPTION
Fixes #4832 

### Summary
Currently, the internationalization process is:

> Build the application > upload to our plugins repository > translate.wordpress.org scans the *assets/DIST* folder looking for i18n calls ( E.g. `__(`,  `_n(`, etc...) to extract the keys and generate a *.pot* file.

The pot file is published on `translate.wordpress.org` to enable the volunteers to translate it.

During our JS building process, our webpack was configured to mangle the function names to reduce the bundle size, but it was replacing our `__("Some string to be translated")`  to  `EE("Some string to be translated"` that breaks ou i18n scanning process.


### Changes proposed in this Pull Request
* [Configure webpack to not mangle i18n methods](https://github.com/Automattic/sensei/commit/f822251a83bcd3d92a20f4794f3081c1807face9)
  Currently, the mangling process is breaking our i18n because it is transforming the calls `__(` to `EE(` and the final code is analyzed by a `wp make-pot` that looks for `__(` calls.


* [Remove ternary that breaks the i18n scan](https://github.com/Automattic/sensei/commit/c84dfc00377da023b8e04801484aa698f38c10af) 
The i18n is not supporting the final code generated when we use ternaries + i18n calls. The generate is something like __( x=== y ? 'Right' : 'WRONG', 'sensei-lms') but the i18n scan is looking for __('STRING'), so it fails to get the strings.



### Testing instructions


#### Checking the pot file:

1. Comment the following lines:
https://github.com/Automattic/sensei/blob/c84dfc00377da023b8e04801484aa698f38c10af/webpack.config.js#L134-L145

2. Run:
` npm run build && wp i18n make-pot assets/dist/  lang/sensei-unfixed.pot --domain=sensei-lms`

3. Uncomment the commented lines

4. Run:
`npm run build && wp i18n make-pot assets/dist/  lang/sensei-unfixed.pot --domain=sensei-lms`

5. Compare both files using some diff tool.


#### Checking the translations: 

1. Run 2 times `npm run build && wp i18n make-pot .  lang/sensei-fixed.pot --domain=sensei-lms `
2. Install the sensei-lms plugin from the local zip file.
3. Install `Loco Language` plugins
4. Go to Loco Translate > Plugins > Sensei-LMS > Advanced and fill the `Template file` field with  the value `lang/sensei-fixed.pot` and save the Config.
5. Change the WP language to Español
6.  Go to Loco Translate > Plugins > Sensei-LMS > Español
7. Click `Sincronizar` https://d.pr/i/qsAgdT
8. Click `Guardar`
9. Click `Añadir" > lección` on wordpress topbar.
10. Check if the text are equal to https://d.pr/i/wUbs7T

# Screenshot
https://d.pr/i/wUbs7T

NOTE:
The Loco language plugin is only required until we publish this version.