### PR TITLE
Fix learning mode styles

### DIFF
--- a/assets/css/sensei-course-theme/base.scss
+++ b/assets/css/sensei-course-theme/base.scss
@@ -21,7 +21,7 @@ body {
 	--wp--style--block-gap: 0px;
 
 	a {
-		color: var(--text-color);
+		color: inherit;
 		text-decoration: none;
 	}
 

--- a/assets/css/sensei-course-theme/course-progress-bar.scss
+++ b/assets/css/sensei-course-theme/course-progress-bar.scss
@@ -1,6 +1,7 @@
 .sensei-course-theme-course-progress-bar {
 	height: var(--header-progress-bar-height);
 	background-color: var(--border-color);
+	margin: 0 !important;
 }
 
 .sensei-course-theme-course-progress-bar-inner {

--- a/assets/css/sensei-course-theme/course-progress-bar.scss
+++ b/assets/css/sensei-course-theme/course-progress-bar.scss
@@ -1,5 +1,5 @@
 .sensei-course-theme-course-progress-bar {
-	height: 10px;
+	height: var(--header-progress-bar-height);
 	background-color: var(--border-color);
 }
 

--- a/assets/css/sensei-course-theme/focus-mode.scss
+++ b/assets/css/sensei-course-theme/focus-mode.scss
@@ -4,7 +4,7 @@ $base: '.sensei-course-theme';
 	.sensei-course-theme__focus-mode-toggle {
 		padding: 4px;
 		border: none;
-		background-color: var(--bg-color) !important;
+		background-color: unset !important;
 		cursor: pointer;
 		color: inherit !important;
 		line-height: 10px;

--- a/assets/css/sensei-course-theme/focus-mode.scss
+++ b/assets/css/sensei-course-theme/focus-mode.scss
@@ -65,6 +65,10 @@ $base: '.sensei-course-theme';
 				left: -400px;
 				overflow: visible;
 			}
+			&__main-content ~ .sensei-course-theme__sidebar {
+				left: unset;
+				right: -400px;
+			}
 			&__main-content {
 				margin-left: 0 !important;
 			}

--- a/assets/css/sensei-course-theme/header.scss
+++ b/assets/css/sensei-course-theme/header.scss
@@ -2,7 +2,7 @@
 	.wp-block-sensei-lms-course-title {
 		padding: 1px 2px;
 		margin: 0;
-		font-size: 24px;
+		font-size: 18px;
 		font-weight: 600;
 		overflow: hidden;
 		white-space: nowrap;

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -76,6 +76,7 @@ body.sensei-course-theme {
 		overscroll-behavior: contain;
 		display: flex;
 		flex-direction: column;
+		scrollbar-gutter: stable both-edges;
 
 		@media screen and (min-width: $breakpoint ) {
 			&--hidden {

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -129,7 +129,7 @@ body.sensei-course-theme {
 			flex-wrap: nowrap;
 			padding: 0 24px;
 			margin: 0 !important;
-			gap: 24px;
+			gap: 24px!important;
 			height: calc(var(--header-height) - 10px);
 		}
 

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -89,8 +89,7 @@ body.sensei-course-theme {
 
 		&__content, &__footer {
 			margin: 0 !important;
-			padding: 24px;
-			padding-right: 16px;
+			padding: 12px;
 			padding-bottom: 12px;
 		}
 

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -116,9 +116,17 @@ body.sensei-course-theme {
 		}
 	}
 
+	&__main-content ~ &__sidebar {
+		left: unset;
+		right: 0;
+		border-right: unset;
+		border-left: 1px solid var(--border-color);
+
+	}
+
 	&__main-content {
 		padding: 32px 0;
-		margin-left: var(--sidebar-width) !important;
+		margin-right: var(--sidebar-width) !important;
 
 		// A Divi fix since it doesn't load Gutenberg block library styles.
 		@at-root {
@@ -126,6 +134,10 @@ body.sensei-course-theme {
 				flex: 1;
 			}
 		}
+	}
+
+	&__sidebar ~ &__main-content {
+		margin-left: var(--sidebar-width) !important;
 	}
 
 	&__header {

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -137,6 +137,7 @@ body.sensei-course-theme {
 	}
 
 	&__sidebar ~ &__main-content {
+		margin-right: unset ! important;
 		margin-left: var(--sidebar-width) !important;
 	}
 

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -67,6 +67,10 @@ body.sensei-course-theme {
 		z-index: 100;
 	}
 
+	&__columns {
+		margin-top: var(--header-height) !important;
+	}
+
 	&__sidebar {
 		position: fixed;
 		top: var(--full-header-height);

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -1,5 +1,6 @@
 :root {
-	--header-height: 75px;
+	--header-height: 65px;
+	--header-progress-bar-height: 4px;
 	--sidebar-width: 300px;
 	--content-padding: 32px;
 }
@@ -58,7 +59,9 @@ body.sensei-course-theme {
 
 	&__header {
 		margin: 0;
-		position: sticky;
+		position: fixed;
+		left: 0;
+		right: 0;
 		top: var(--top-offset);
 		background-color: var(--bg-color);
 		z-index: 100;
@@ -130,7 +133,7 @@ body.sensei-course-theme {
 			padding: 0 24px;
 			margin: 0 !important;
 			gap: 24px!important;
-			height: calc(var(--header-height) - 10px);
+			height: calc(var(--header-height) - var(--header-progress-bar-height));
 		}
 
 		&__left {

--- a/assets/css/sensei-course-theme/lesson-module.scss
+++ b/assets/css/sensei-course-theme/lesson-module.scss
@@ -4,8 +4,8 @@
 	line-height: 1.2;
 	font-weight: 400;
 	text-transform: uppercase;
-	margin-top: 10px;
-	margin-bottom: 10px;
+	margin-top: 10px !important;
+	margin-bottom: 10px !important;
 	font-style: normal;
 	display: block;
 }

--- a/assets/css/sensei-course-theme/mobile.scss
+++ b/assets/css/sensei-course-theme/mobile.scss
@@ -24,7 +24,7 @@
 
 			.sensei-course-theme__header__container {
 				padding-bottom: var(--header-open-height);
-
+				height: var(--header-height);
 			}
 
 			.sensei-course-theme-course-progress-bar {
@@ -35,7 +35,15 @@
 				display: block;
 				position: absolute;
 				left: 24px;
-				bottom: 22px;
+				top: calc( var(--header-height) - 36px);
+			}
+			.sensei-course-theme-course-progress-bar {
+				height: 8px;
+				position: absolute;
+				top: calc( var(--header-height) - 12px);
+				margin: 0;
+				left: 24px;
+				right: 24px;
 			}
 		}
 
@@ -75,9 +83,10 @@
 				font-size: 14px;
 			}
 
-			.sensei-course-theme-course-progress-bar {
-				height: 10px;
-			}
+		}
+
+		&__sidebar__content {
+			padding: 24px;
 		}
 
 		&__sidebar-toggle {
@@ -87,7 +96,7 @@
 			background: none;
 			border: none;
 			padding: 0;
-			color: var(--text-color);
+			color: inherit;
 
 			svg {
 				width: 24px;


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Fix a few spacing issues around learning mode
* Fix sidebar jumping when scrollbar is shown/hidden
* Adjust design based on latest iteration
* Improve support for dark header/sidebar

### Testing instructions

* Open a lesson in learning mode. Check that sidebar, header UI looks right on desktop on mobile.
* Edit the template, change background and text colors of the sidebar and header blocks. Check that colors are respected and nothing is out of place.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

![image](https://user-images.githubusercontent.com/176949/184649711-bdd524bf-b328-44b0-bab6-df23ceab8209.png)


