### PR TITLE
Move focus toggle to the sidebar

### DIFF
--- a/assets/css/sensei-course-theme/focus-mode.scss
+++ b/assets/css/sensei-course-theme/focus-mode.scss
@@ -19,19 +19,20 @@ $base: '.sensei-course-theme';
 		}
 	}
 
-	// Toogle in the header and without focus mode.
-	body:not(.sensei-course-theme--focus-mode, .editor-styles-wrapper) .sensei-course-theme__header__left {
-		.sensei-course-theme__focus-mode-toggle {
-			position: absolute;
-			left: 0;
-			top: var(--header-height);
-			text-align: left;
+	body:not(.sensei-course-theme--focus-mode) {
 
-			// Match sidebar spacing.
-			width: calc( var( --sidebar-width ) - 18px );
-			padding-left: 24px;
-			padding-top: 9px;
-			padding-bottom: 9px;
+		// Toogle in the header and without focus mode.
+		.sensei-course-theme__header__left .sensei-course-theme__focus-mode-toggle {
+			transform: rotate(90deg)
+		}
+
+		// Toggle in the sidebar and without focus mode.
+		.sensei-course-theme__sidebar .sensei-course-theme__focus-mode-toggle {
+			display: flex;
+			justify-content: flex-end;
+			width: 100%;
+			box-sizing: border-box;
+			padding-right: 6px;
 		}
 	}
 

--- a/themes/sensei-course-theme/templates/lesson.html
+++ b/themes/sensei-course-theme/templates/lesson.html
@@ -4,7 +4,6 @@
     <div class="wp-block-columns sensei-course-theme__header__container is-not-stacked-on-mobile">
         <!-- wp:column {"className":"sensei-course-theme__header__left"} -->
         <div class="wp-block-column sensei-course-theme__header__left">
-            <!-- wp:sensei-lms/focus-mode-toggle /-->
             <!-- wp:site-logo { "width": 50 } /-->
             <!-- wp:sensei-lms/course-title /-->
             <!-- wp:sensei-lms/course-theme-course-progress-counter /-->
@@ -32,6 +31,7 @@
     <div class="wp-block-column sensei-course-theme__sidebar sensei-course-theme__frame" style="flex-basis:300px">
         <!-- wp:group {"className":"sensei-course-theme__sidebar__content"} -->
         <div class="wp-block-group sensei-course-theme__sidebar__content">
+            <!-- wp:sensei-lms/focus-mode-toggle /-->
             <!-- wp:sensei-lms/course-navigation /-->
         </div>
         <!-- /wp:group -->


### PR DESCRIPTION
Fixes #4875

### Changes proposed in this Pull Request

- Moves the focus mode toggle in the sidebar.
- When the user places the toggle in the header, it stays there in every case.
- The toggle does not use absolute positioning anymore which caused it to overlap other elements.

![expensify](https://user-images.githubusercontent.com/53191348/159763563-b5d39e21-9804-4b89-a513-d45c540e7d98.gif)

### Testing instructions
- Open a course that has the learning mode enabled.
- Try out the toggle and ensure that it works ok.
- Open the site editor and try placing the toggle in various places, especially the header.
- Ensure that it works as expected.