### PR TITLE
Fix only first row exporting for some reports

### DIFF
--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -259,7 +259,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		$this->search = $search;
 
 		$args = array(
-			'number'  => '-1',
+			'number'  => '',
 			'offset'  => 0,
 			'orderby' => $orderby,
 			'order'   => $order,

--- a/includes/class-sensei-analysis-lesson-list-table.php
+++ b/includes/class-sensei-analysis-lesson-list-table.php
@@ -174,7 +174,7 @@ class Sensei_Analysis_Lesson_List_Table extends Sensei_List_Table {
 		$this->search = $search;
 
 		$args = array(
-			'number'  => '-1',
+			'number'  => '',
 			'offset'  => 0,
 			'orderby' => $orderby,
 			'order'   => $order,


### PR DESCRIPTION
### Changes proposed in this Pull Request
In order to fetch all rows, the `number` parameter should be empty to indicate no limit, and not -1.

### Testing instructions
- In the Courses report, click on a course that has several students enrolled in it.
- Click on "Students taking this course".
- Export the data and ensure all students are exported.
- In the Lessons report, find a course that contains a lesson that several students have started.
- Click on the lesson name.
- Export the data and ensure all students are exported.