### PR TITLE
Block quiz answers when the quiz is completed

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1129,11 +1129,11 @@ class Sensei_Question {
 	public static function get_template_data( $question_id, $quiz_id ) {
 
 		$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_id );
-		$user_id = get_current_user_id();
+		$user_id   = get_current_user_id();
 
 		$reset_allowed = get_post_meta( $quiz_id, '_enable_quiz_reset', true );
 		// backwards compatibility
-		if ( 'on' == $reset_allowed ) {
+		if ( 'on' === $reset_allowed ) {
 			$reset_allowed = 1;
 		}
 
@@ -1153,7 +1153,7 @@ class Sensei_Question {
 		$data['lesson_completed']       = Sensei_Utils::user_completed_lesson( $lesson_id, $user_id );
 		$data['quiz_grade_type']        = get_post_meta( $quiz_id, '_quiz_grade_type', true );
 		$data['reset_quiz_allowed']     = $reset_allowed;
-		$data['quiz_is_completed']      = Sensei_Quiz::is_quiz_completed($quiz_id, $user_id);
+		$data['quiz_is_completed']      = Sensei_Quiz::is_quiz_completed( $quiz_id, $user_id );
 
 		/**
 		 * Filter the question template data. This filter fires in

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1152,7 +1152,7 @@ class Sensei_Question {
 		$data['lesson_completed']       = Sensei_Utils::user_completed_lesson( $lesson_id, get_current_user_id() );
 		$data['quiz_grade_type']        = get_post_meta( $quiz_id, '_quiz_grade_type', true );
 		$data['reset_quiz_allowed']     = $reset_allowed;
-		$data['quiz_is_completed']      = Sensei()->quiz->is_completed( $quiz_id );
+		$data['quiz_is_completed']      = Sensei_Quiz::is_quiz_completed();
 
 		/**
 		 * Filter the question template data. This filter fires in

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1136,13 +1136,6 @@ class Sensei_Question {
 			$reset_allowed = 1;
 		}
 
-		// Check again that the lesson is complete
-		$user_lesson_end      = Sensei_Utils::user_completed_lesson( Sensei()->quiz->get_lesson_id( $quiz_id ), get_current_user_id() );
-		$user_lesson_complete = false;
-		if ( $user_lesson_end ) {
-			$user_lesson_complete = true;
-		}
-
 		// setup the question data
 		$data                           = [];
 		$data['ID']                     = $question_id;
@@ -1156,7 +1149,7 @@ class Sensei_Question {
 		$data['question_right_answer']  = get_post_meta( $question_id, '_question_right_answer', true );
 		$data['question_wrong_answers'] = get_post_meta( $question_id, '_question_wrong_answers', true );
 		$data['user_answer_entry']      = Sensei()->quiz->get_user_question_answer( $lesson_id, $question_id, get_current_user_id() );
-		$data['lesson_completed']       = Sensei_Utils::user_completed_course( $lesson_id, get_current_user_id() );
+		$data['lesson_completed']       = Sensei_Utils::user_completed_lesson( $lesson_id, get_current_user_id() );
 		$data['quiz_grade_type']        = get_post_meta( $quiz_id, '_quiz_grade_type', true );
 		$data['reset_quiz_allowed']     = $reset_allowed;
 		$data['lesson_complete']        = $user_lesson_complete;

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1129,6 +1129,7 @@ class Sensei_Question {
 	public static function get_template_data( $question_id, $quiz_id ) {
 
 		$lesson_id = Sensei()->quiz->get_lesson_id( $quiz_id );
+		$user_id = get_current_user_id();
 
 		$reset_allowed = get_post_meta( $quiz_id, '_enable_quiz_reset', true );
 		// backwards compatibility
@@ -1145,14 +1146,14 @@ class Sensei_Question {
 		$data['lesson_id']              = Sensei()->quiz->get_lesson_id( $quiz_id );
 		$data['type']                   = Sensei()->question->get_question_type( $question_id );
 		$data['question_grade']         = Sensei()->question->get_question_grade( $question_id );
-		$data['user_question_grade']    = Sensei()->quiz->get_user_question_grade( $lesson_id, $question_id, get_current_user_id() );
+		$data['user_question_grade']    = Sensei()->quiz->get_user_question_grade( $lesson_id, $question_id, $user_id );
 		$data['question_right_answer']  = get_post_meta( $question_id, '_question_right_answer', true );
 		$data['question_wrong_answers'] = get_post_meta( $question_id, '_question_wrong_answers', true );
-		$data['user_answer_entry']      = Sensei()->quiz->get_user_question_answer( $lesson_id, $question_id, get_current_user_id() );
-		$data['lesson_completed']       = Sensei_Utils::user_completed_lesson( $lesson_id, get_current_user_id() );
+		$data['user_answer_entry']      = Sensei()->quiz->get_user_question_answer( $lesson_id, $question_id, $user_id );
+		$data['lesson_completed']       = Sensei_Utils::user_completed_lesson( $lesson_id, $user_id );
 		$data['quiz_grade_type']        = get_post_meta( $quiz_id, '_quiz_grade_type', true );
 		$data['reset_quiz_allowed']     = $reset_allowed;
-		$data['quiz_is_completed']      = Sensei_Quiz::is_quiz_completed();
+		$data['quiz_is_completed']      = Sensei_Quiz::is_quiz_completed($quiz_id, $user_id);
 
 		/**
 		 * Filter the question template data. This filter fires in

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1152,7 +1152,7 @@ class Sensei_Question {
 		$data['lesson_completed']       = Sensei_Utils::user_completed_lesson( $lesson_id, get_current_user_id() );
 		$data['quiz_grade_type']        = get_post_meta( $quiz_id, '_quiz_grade_type', true );
 		$data['reset_quiz_allowed']     = $reset_allowed;
-		$data['lesson_complete']        = $user_lesson_complete;
+		$data['quiz_is_completed']      = Sensei()->quiz->is_completed( $quiz_id );
 
 		/**
 		 * Filter the question template data. This filter fires in
@@ -1281,7 +1281,6 @@ class Sensei_Question {
 
 					// For zero grade mark as 'correct' but add no classes
 					if ( 0 == $question_data['question_grade'] ) {
-
 						$user_correct = true;
 
 					} elseif ( $question_data['user_question_grade'] > 0 ) {

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1154,7 +1154,7 @@ class Sensei_Question {
 		$data['quiz_grade_type']        = get_post_meta( $quiz_id, '_quiz_grade_type', true );
 		$data['reset_quiz_allowed']     = $reset_allowed;
 		$data['quiz_is_completed']      = Sensei_Quiz::is_quiz_completed( $quiz_id, $user_id );
-
+		$data['lesson_complete']        = $data['lesson_completed'];
 		/**
 		 * Filter the question template data. This filter fires in
 		 * the get_template_data function.

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1155,6 +1155,7 @@ class Sensei_Question {
 		$data['reset_quiz_allowed']     = $reset_allowed;
 		$data['quiz_is_completed']      = Sensei_Quiz::is_quiz_completed( $quiz_id, $user_id );
 		$data['lesson_complete']        = $data['lesson_completed'];
+		
 		/**
 		 * Filter the question template data. This filter fires in
 		 * the get_template_data function.

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1155,7 +1155,7 @@ class Sensei_Question {
 		$data['reset_quiz_allowed']     = $reset_allowed;
 		$data['quiz_is_completed']      = Sensei_Quiz::is_quiz_completed( $quiz_id, $user_id );
 		$data['lesson_complete']        = $data['lesson_completed'];
-		
+
 		/**
 		 * Filter the question template data. This filter fires in
 		 * the get_template_data function.

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -955,20 +955,6 @@ class Sensei_Quiz {
 	}
 
 	/**
-	 * Check if the user has completed the quiz.
-	 *
-	 * @since 4.3.0
-	 *
-	 * @param int|null $quiz_id (Optional) The quiz post ID. Defaults to the current post ID.
-	 * @param int|null $user_id (Optional) The user ID. Defaults to the current user ID.
-	 *
-	 * @return bool
-	 */
-	public function is_completed( int $quiz_id = 0, int $user_id = 0 ): bool {
-		return self::is_quiz_completed( $quiz_id, $user_id );
-	}
-
-	/**
 	 * Retrieve the users quiz question grades
 	 *
 	 * This function gets all the grades for all the questions in the given lesson quiz for a specific user.

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -955,6 +955,20 @@ class Sensei_Quiz {
 	}
 
 	/**
+	 * Check if the user has completed the quiz.
+	 *
+	 * @since 4.3.0
+	 *
+	 * @param int|null $quiz_id (Optional) The quiz post ID. Defaults to the current post ID.
+	 * @param int|null $user_id (Optional) The user ID. Defaults to the current user ID.
+	 *
+	 * @return bool
+	 */
+	public function is_completed( int $quiz_id = 0, int $user_id = 0 ): bool {
+		return self::is_quiz_completed( $quiz_id, $user_id );
+	}
+
+	/**
 	 * Retrieve the users quiz question grades
 	 *
 	 * This function gets all the grades for all the questions in the given lesson quiz for a specific user.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1544,8 +1544,7 @@ class Sensei_Utils {
 	 * @param int   $user_id
 	 * @return boolean
 	 */
-	public static function user_completed_lesson( $lesson = 0, $user_id = 0 ) {
-
+	public static function user_completed_lesson( $lesson = 0, $user_id = 0 ): bool {
 		if ( $lesson ) {
 			$lesson_id = 0;
 			if ( is_object( $lesson ) ) {

--- a/templates/single-quiz/question-type-boolean.php
+++ b/templates/single-quiz/question-type-boolean.php
@@ -72,10 +72,7 @@ $boolean_options = array( 'true', 'false' );
 			   name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>"
 			   value="<?php echo esc_attr( $option_value ); ?>"
 			<?php echo checked( $question_data['user_answer_entry'], $option_value, false ); ?>
-			<?php
-			if ( ! is_user_logged_in() ) {
-				echo ' disabled'; }
-			?>
+			<?php echo $question_data['quiz_is_completed'] || ! is_user_logged_in() ? 'disabled' : ''; ?>
 		/>
 		<label for="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $option_value ); ?>">
 			<?php

--- a/templates/single-quiz/question-type-file-upload.php
+++ b/templates/single-quiz/question-type-file-upload.php
@@ -46,7 +46,7 @@ $question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(
 		?>
 
 	</p>
-	<?php if ( ! $question_data['lesson_complete'] ) { ?>
+	<?php if ( ! $question_data['quiz_is_completed'] ) { ?>
 
 		<aside class="reupload_notice"><?php esc_html_e( 'Uploading a new file will replace your existing one:', 'sensei-lms' ); ?></aside>
 
@@ -54,7 +54,7 @@ $question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(
 
 <?php } ?>
 
-<?php if ( ! $question_data['lesson_complete'] ) { ?>
+<?php if ( ! $question_data['quiz_is_completed'] ) { ?>
 
 	<input type="file" name="file_upload_<?php echo esc_attr( $question_data['ID'] ); ?>" />
 

--- a/templates/single-quiz/question-type-gap-fill.php
+++ b/templates/single-quiz/question-type-gap-fill.php
@@ -21,13 +21,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 $question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(), get_the_ID() );
 ?>
 
+
 <p class="gapfill-answer">
 	<span class="gapfill-answer-pre">
 		<?php echo wp_kses_post( apply_filters( 'sensei_answer_text', esc_html( $question_data['gapfill_pre'] ) ) ); ?>
 		<input type="text" id="<?php echo esc_attr( 'question_' . $question_data['ID'] ); ?>"
 			name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>"
 			value="<?php echo esc_attr( $question_data['user_answer_entry'] ); ?>"
-			class="gapfill-answer-gap" />
+			class="gapfill-answer-gap"
+			<?php echo $question_data['quiz_is_completed'] || ! is_user_logged_in() ? 'disabled' : ''; ?>
+		/>
 		<span class="gapfill-answer-post">
 			<?php echo wp_kses_post( apply_filters( 'sensei_answer_text', esc_html( $question_data['gapfill_post'] ) ) ); ?>
 		</span>

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -25,25 +25,21 @@ $question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(
 <?php
 $count = 0;
 foreach ( $question_data['answer_options'] as $option ) {
-
 	$count++;
 
 	?>
 
 	<li class="<?php echo esc_attr( $option['option_class'] ); ?>">
 		<input type="<?php echo esc_attr( $option['type'] ); ?>"
-			   id="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>"
-			   name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>[]"
-			   value="<?php echo esc_attr( $option['answer'] ); ?>" <?php echo esc_attr( $option['checked'] ); ?>
-				<?php echo is_user_logged_in() ? '' : ' disabled'; ?>
+			id="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>"
+			name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>[]"
+			value="<?php echo esc_attr( $option['answer'] ); ?>" <?php echo esc_attr( $option['checked'] ); ?>
+			<?php echo $question_data['quiz_is_completed'] || ! is_user_logged_in() ? 'disabled' : ''; ?>
 			/>
 
 		<label for="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>">
-
 			<?php echo wp_kses_post( apply_filters( 'sensei_answer_text', $option['answer'] ) ); ?>
-
 		</label>
-
 	</li>
 <?php } ?>
 

--- a/templates/single-quiz/question-type-single-line.php
+++ b/templates/single-quiz/question-type-single-line.php
@@ -29,7 +29,9 @@ $question_data = Sensei_Question::get_template_data( sensei_get_the_question_id(
 	</label>
 
 	<input type="text" id="<?php echo esc_attr( 'question_' . $question_data['ID'] ); ?>"
-		   name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>"
-		   value="<?php echo esc_attr( $question_data['user_answer_entry'] ); ?>" />
+		name="<?php echo esc_attr( 'sensei_question[' . $question_data['ID'] . ']' ); ?>"
+		value="<?php echo esc_attr( $question_data['user_answer_entry'] ); ?>"
+		<?php echo $question_data['quiz_is_completed'] || ! is_user_logged_in() ? 'disabled' : ''; ?>
+		/>
 
 </div>


### PR DESCRIPTION
Fixes #4889

### Changes proposed in this Pull Request

This PR is blocking almost all question types to be updated after the student submits its answer.

### Testing instructions
1. Create a course
2. Create a lesson
3. Configure a quiz using every question type (the multi-line type is still not supported, it will be covered on issue #4949).
4. Enroll in the create a course as a Student. 
5. Answer all questions with wrong answers.
6. Check the result page it is possible to edit the answers after the submission. 

