### PR TITLE
Fix sorting for students reports table

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1181,19 +1181,17 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * Order query based on the custom field.
 	 *
 	 * @since  4.3.0
-	 * @access public
+	 * @access private
 	 *
 	 * @param WP_User_Query $query The user query.
 	 */
 	public function add_orderby_custom_field_to_query( WP_User_Query $query ) {
 		global $wpdb;
-		if ( ! isset( $query->query_vars['orderby'] ) || ! isset( $query->query_vars['order'] ) ) {
-			return '';
-		}
-		$query->query_orderby = sprintf(
-			'ORDER BY %s %s',
-			esc_sql( $query->query_vars['orderby'] ),
-			esc_sql( $query->query_vars['order'] )
+
+		$query->query_orderby = $wpdb->prepare(
+			'ORDER BY %1s %1s', // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder -- not needed.
+			$query->query_vars['orderby'],
+			$query->query_vars['order']
 		);
 	}
 

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -205,11 +205,10 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			case 'users':
 			default:
 				$columns = array(
-					'title'             => array( 'user_login', false ),
-					'email'             => array( 'user_email', false ),
-					'active_courses'    => array( 'active_courses', false ),
-					'completed_courses' => array( 'completed_courses', false ),
-					'average_grade'     => array( 'average_grade', false ),
+					'title'           => array( 'display_name', false ),
+					'email'           => array( 'user_email', false ),
+					'date_registered' => array( 'user_registered', false ),
+					'last_activity'   => array( 'last_activity_date', false ),
 				);
 				break;
 		}
@@ -229,9 +228,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// Handle orderby.
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
-				$orderby = esc_html( $_GET['orderby'] );
-			}
+			$orderby = esc_html( $_GET['orderby'] );
 		}
 
 		// Handle order.
@@ -301,9 +298,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		// Handle orderby
 		$orderby = '';
 		if ( ! empty( $_GET['orderby'] ) ) {
-			if ( array_key_exists( esc_html( $_GET['orderby'] ), $this->get_sortable_columns() ) ) {
-				$orderby = esc_html( $_GET['orderby'] );
-			}
+			$orderby = esc_html( $_GET['orderby'] );
 		}
 
 		// Handle order
@@ -789,7 +784,13 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		add_action( 'pre_user_query', [ $this, 'add_last_activity_to_user_query' ] );
 		add_action( 'pre_user_query', [ $this, 'filter_users_by_last_activity' ] );
+
+		if ( isset( $args['orderby'] ) && 'last_activity_date' === $args['orderby'] ) {
+			add_action( 'pre_user_query', [ $this, 'add_orderby_custom_field_to_query' ] );
+		}
+
 		$wp_user_search = new WP_User_Query( $args );
+		remove_action( 'pre_user_query', [ $this, 'add_orderby_custom_field_to_query' ] );
 		remove_action( 'pre_user_query', [ $this, 'add_last_activity_to_user_query' ] );
 		remove_action( 'pre_user_query', [ $this, 'filter_users_by_last_activity' ] );
 
@@ -797,7 +798,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		$this->total_items = $wp_user_search->get_total();
 
 		return $learners;
-
 	}
 
 	/**
@@ -1174,8 +1174,27 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			WHERE {$wpdb->comments}.user_id = {$wpdb->users}.ID
 			AND {$wpdb->comments}.comment_approved IN ('complete', 'passed', 'graded')
 			AND {$wpdb->comments}.comment_type = 'sensei_lesson_status'
-			ORDER BY {$wpdb->comments}.comment_date_gmt DESC
 		) AS last_activity_date";
+	}
+
+	/**
+	 * Order query based on the custom field.
+	 *
+	 * @since  4.3.0
+	 * @access public
+	 *
+	 * @param WP_User_Query $query The user query.
+	 */
+	public function add_orderby_custom_field_to_query( WP_User_Query $query ) {
+		global $wpdb;
+		if ( ! isset( $query->query_vars['orderby'] ) || ! isset( $query->query_vars['order'] ) ) {
+			return '';
+		}
+		$query->query_orderby = sprintf(
+			'ORDER BY %s %s',
+			esc_sql( $query->query_vars['orderby'] ),
+			esc_sql( $query->query_vars['order'] )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #4833

### Changes proposed in this Pull Request
1. Fixing old sortable columns: 
**Name**
 What and why was it not sorted well? 
 it was sorted based on the **user_login** and in the table, **display_name** is shown in the title column.
**Email** 
This was not working at all and it was because of this check: [this](https://github.com/Automattic/sensei/compare/update/fix_sorting_for_students_column?expand=1#diff-6ce1dc075c4832d5bf050e621bcfecbab91d97504e8bc565f4f476b1ea2f654dL232)
it was checking based on the key and the key is always internal value for the column name and not the value in the database that we need to order by. 

2. New sortable columns:
**Date created** 
- This was string forward since the value is the value from the DB

**Last Activity**
- This is the field that was added with filters. I've added a somewhat generic solution to appending query with new order items. 

### Testing instructions
- Try sorting the columns by these 4 sortable columns: 

| Title | Email | Date created | Last Activity |
| -- | -- | -- | -- |
|  <img width="1347" alt="image" src="https://user-images.githubusercontent.com/7208249/160189637-1ccc2194-bf17-4be1-b13c-98dfbccf93d6.png"> |  <img width="1335" alt="image" src="https://user-images.githubusercontent.com/7208249/160189661-fb6c4bad-b86c-4d3b-b1e6-9def02642c51.png"> |  <img width="1350" alt="image" src="https://user-images.githubusercontent.com/7208249/160189686-0a6954a1-f398-44b8-81c8-8167423afadc.png"> |  <img width="1346" alt="image" src="https://user-images.githubusercontent.com/7208249/160189708-47743922-ffd2-4c7e-964e-b2996a52df80.png"> | 

