### PR TITLE
Add student action menu to Student Management page

### DIFF
--- a/assets/admin/students/student-action-menu/index.js
+++ b/assets/admin/students/student-action-menu/index.js
@@ -1,0 +1,48 @@
+/**
+ * WordPress dependencies
+ */
+import { DropdownMenu } from '@wordpress/components';
+import { render } from '@wordpress/element';
+import { moreVertical } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Student action menu.
+ *
+ * @param {Object} props
+ * @param {string} props.courseId Course ID.
+ */
+const StudentActionMenu = ( { courseId } ) => {
+	// eslint-disable-next-line no-console
+	console.log( courseId );
+
+	return (
+		<DropdownMenu
+			icon={ moreVertical }
+			label={ __( 'Select an action', 'sensei-lms' ) }
+			controls={ [
+				{
+					title: __( 'Add to Course', 'sensei-lms' ),
+					onClick: () => {},
+				},
+				{
+					title: __( 'Remove from Course', 'sensei-lms' ),
+					onClick: () => {},
+				},
+				{
+					title: __( 'Grading', 'sensei-lms' ),
+					onClick: () => {},
+				},
+			] }
+		/>
+	);
+};
+
+Array.from( document.getElementsByClassName( 'student-action-menu' ) ).forEach(
+	( actionMenu ) => {
+		render(
+			<StudentActionMenu courseId={ actionMenu.dataset.courseId } />,
+			actionMenu
+		);
+	}
+);

--- a/assets/admin/students/student-action-menu/index.js
+++ b/assets/admin/students/student-action-menu/index.js
@@ -8,14 +8,8 @@ import { __ } from '@wordpress/i18n';
 
 /**
  * Student action menu.
- *
- * @param {Object} props
- * @param {string} props.courseId Course ID.
  */
-const StudentActionMenu = ( { courseId } ) => {
-	// eslint-disable-next-line no-console
-	console.log( courseId );
-
+export const StudentActionMenu = () => {
 	return (
 		<DropdownMenu
 			icon={ moreVertical }

--- a/assets/admin/students/student-action-menu/index.test.js
+++ b/assets/admin/students/student-action-menu/index.test.js
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { fireEvent, render } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import { DOWN } from '@wordpress/keycodes';
+
+/**
+ * Internal dependencies
+ */
+import { StudentActionMenu } from './index';
+
+describe( '<StudentActionMenu />', () => {
+	it( 'Should display the default options', () => {
+		const {
+			container: { firstChild: dropdownMenuContainer },
+			getByText,
+		} = render( <StudentActionMenu courseId="123" /> );
+		const button = dropdownMenuContainer.querySelector(
+			'.components-dropdown-menu__toggle'
+		);
+
+		// Open the dropdown menu.
+		button.focus();
+		fireEvent.keyDown( button, {
+			keyCode: DOWN,
+			preventDefault: () => {},
+		} );
+
+		expect( getByText( 'Add to Course' ) ).toBeTruthy();
+		expect( getByText( 'Remove from Course' ) ).toBeTruthy();
+		expect( getByText( 'Grading' ) ).toBeTruthy();
+	} );
+} );

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -177,6 +177,7 @@ class Sensei_Learner_Management {
 		);
 
 		Sensei()->assets->enqueue( 'sensei-stop-double-submission', 'js/stop-double-submission.js', [], true );
+		Sensei()->assets->enqueue( 'sensei-student-action-menu', 'admin/students/student-action-menu/index.js', [], true );
 
 		wp_localize_script(
 			'sensei-learners-general',
@@ -213,9 +214,10 @@ class Sensei_Learner_Management {
 	 * @since 1.6.0
 	 */
 	public function enqueue_styles() {
-
-		Sensei()->assets->enqueue( 'sensei-jquery-ui', 'css/jquery-ui.css' );
-
+		// JQuery UI doesn't actually require sensei-wp-components, but the StudentActionMenu component does.
+		// Since StudentActionMenu doesn't currently have its own CSS file, I'm adding the dependency here
+		// as a workaround.
+		Sensei()->assets->enqueue( 'sensei-jquery-ui', 'css/jquery-ui.css', [ 'sensei-wp-components' ] );
 	}
 
 	/**

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -756,7 +756,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 						'num_learners' => esc_html( $course_learners ),
 						'updated'      => esc_html( $item->post_modified ),
 						'actions'      =>
-							'<div class="student-action-menu" data-course-id="' . esc_attr( $item->ID ) . '"></div>'
+							'<div class="student-action-menu" data-course-id="' . esc_attr( $item->ID ) . '"></div>',
 					),
 					$item
 				);

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -755,17 +755,8 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 							'</strong>',
 						'num_learners' => esc_html( $course_learners ),
 						'updated'      => esc_html( $item->post_modified ),
-						'actions'      => '<a class="button" href="' . esc_url(
-							add_query_arg(
-								array(
-									'post_type' => $this->menu_post_type,
-									'page'      => $this->page_slug,
-									'course_id' => $item->ID,
-									'view'      => 'learners',
-								),
-								admin_url( 'edit.php' )
-							)
-						) . '">' . esc_html__( 'Manage students', 'sensei-lms' ) . '</a> ' . $grading_action,
+						'actions'      =>
+							'<div class="student-action-menu" data-course-id="' . esc_attr( $item->ID ) . '"></div>'
 					),
 					$item
 				);

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -71,6 +71,7 @@ const files = [
 	'blocks/frontend.js',
 	'admin/exit-survey/index.js',
 	'admin/exit-survey/exit-survey.scss',
+	'admin/students/student-action-menu/index.js',
 	'css/tools.scss',
 	'css/enrolment-debug.scss',
 	'css/frontend.scss',


### PR DESCRIPTION
### Changes proposed in this Pull Request
This PR tries using the `DropdownMenu` component from the `@wordpress/components` package on the _Student Management_ page. It passes in `courseId` as a prop, which is logged to the console for demonstration purposes. This would obviously need to change later on to be a `userId` prop. We can take over this PR when it comes time to hook up the menu.

_Note:_ This PR is not meant to be merged as-is. We can use it to implement the action menu though once the other dependencies are ready.

### Testing instructions
- Execute `npm run build`.
- Go to _Student Management_.
- Try out the action menu. Currently it does nothing.

### Screenshots
![Screen Shot 2022-03-27 at 6 49 33 AM](https://user-images.githubusercontent.com/1190420/160277962-7e3b867a-66f9-4e66-b973-30881fc4d538.jpg)