### PR TITLE
Remove sortable from columns that can't be sorted

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -30,7 +30,7 @@ jobs:
                   coverage: none
 
             - name: Set up branches
-              run: git checkout -b master refs/remotes/origin/master && git checkout -
+              run: git checkout -b master refs/remotes/origin/trunk && git checkout -
 
             - name: Install PHP dependencies
               run: composer self-update --1 && composer install --no-ansi --no-interaction --prefer-dist --no-progress

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1205,7 +1205,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * Order query based on the custom field.
 	 *
 	 * @since  4.3.0
-	 * @access public
+	 * @access private
 	 *
 	 * @param array  $args Arguments Old orderby arguments.
 	 * @param object $query Query.

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -190,14 +190,14 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		switch ( $this->type ) {
 			case 'courses':
 				$columns = array(
-					'title'              => array( 'title', false ),
-					'completions'        => array( 'count_of_completions', false ),
+					'title'       => array( 'title', false ),
+					'completions' => array( 'count_of_completions', false ),
 				);
 				break;
 
 			case 'lessons':
 				$columns = array(
-					'title'              => array( 'title', false ),
+					'title' => array( 'title', false ),
 				);
 				break;
 
@@ -1187,9 +1187,9 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @since  4.3.0
 	 * @access public
 	 *
-	 * @param $query The user query.
+	 * @param WP_User_Query $query The user query.
 	 */
-	public function add_orderby_custom_field_to_query( $query ) {
+	public function add_orderby_custom_field_to_query( WP_User_Query $query ) {
 		global $wpdb;
 		if ( ! isset( $query->query_vars['orderby'] ) || ! isset( $query->query_vars['order'] ) ) {
 			return '';
@@ -1211,9 +1211,6 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @param object $query Query.
 	 */
 	public function add_orderby_custom_field_to_non_user_query( $args, $query ) {
-		if ( ! isset( $query->query_vars['orderby'] ) || ! isset( $query->query_vars['order'] ) ) {
-			return '';
-		}
 		return sprintf(
 			'%s %s',
 			esc_sql( $query->query_vars['orderby'] ),

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1209,10 +1209,12 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @param object $query Query.
 	 */
 	public function add_orderby_custom_field_to_non_user_query( $args, $query ) {
-		return sprintf(
-			'%s %s',
-			esc_sql( $query->query_vars['orderby'] ),
-			esc_sql( $query->query_vars['order'] )
+		global $wpdb;
+
+		return $wpdb->prepare(
+			'%1s %1s', // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder -- not needed.
+			$query->query_vars['orderby'],
+			$query->query_vars['order']
 		);
 	}
 

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -190,15 +190,14 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		switch ( $this->type ) {
 			case 'courses':
 				$columns = array(
-					'title' => array( 'title', false ),
+					'title'              => array( 'title', false ),
+					'completions'        => array( 'count_of_completions', false ),
 				);
 				break;
 
 			case 'lessons':
 				$columns = array(
-					'title'       => array( 'title', false ),
-					'students'    => array( 'students', false ),
-					'completions' => array( 'completions', false ),
+					'title'              => array( 'title', false ),
 				);
 				break;
 
@@ -708,7 +707,11 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		add_filter( 'posts_clauses', [ $this, 'filter_courses_by_last_activity' ] );
 		add_filter( 'posts_clauses', [ $this, 'add_days_to_completion_to_courses_queries' ] );
+		if ( isset( $args['orderby'] ) && ( 'count_of_completions' === $args['orderby'] ) ) {
+			add_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_non_user_query' ), 10, 2 );
+		}
 		$courses_query = new WP_Query( apply_filters( 'sensei_analysis_overview_filter_courses', $course_args ) );
+		remove_filter( 'posts_orderby', array( $this, 'add_orderby_custom_field_to_non_user_query' ), 10, 2 );
 		remove_filter( 'posts_clauses', [ $this, 'filter_courses_by_last_activity' ] );
 		remove_filter( 'posts_clauses', [ $this, 'add_days_to_completion_to_courses_queries' ] );
 
@@ -749,6 +752,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		if ( isset( $args['search'] ) ) {
 			$lessons_args['s'] = $args['search'];
 		}
+
 		add_filter( 'posts_clauses', [ $this, 'add_days_to_complete_to_lessons_query' ] );
 		// Using WP_Query as get_posts() doesn't support 'found_posts'.
 		$lessons_query = new WP_Query( apply_filters( 'sensei_analysis_overview_filter_lessons', $lessons_args ) );
@@ -1183,15 +1187,35 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @since  4.3.0
 	 * @access public
 	 *
-	 * @param WP_User_Query $query The user query.
+	 * @param $query The user query.
 	 */
-	public function add_orderby_custom_field_to_query( WP_User_Query $query ) {
+	public function add_orderby_custom_field_to_query( $query ) {
 		global $wpdb;
 		if ( ! isset( $query->query_vars['orderby'] ) || ! isset( $query->query_vars['order'] ) ) {
 			return '';
 		}
 		$query->query_orderby = sprintf(
 			'ORDER BY %s %s',
+			esc_sql( $query->query_vars['orderby'] ),
+			esc_sql( $query->query_vars['order'] )
+		);
+	}
+
+	/**
+	 * Order query based on the custom field.
+	 *
+	 * @since  4.3.0
+	 * @access public
+	 *
+	 * @param array  $args Arguments Old orderby arguments.
+	 * @param object $query Query.
+	 */
+	public function add_orderby_custom_field_to_non_user_query( $args, $query ) {
+		if ( ! isset( $query->query_vars['orderby'] ) || ! isset( $query->query_vars['order'] ) ) {
+			return '';
+		}
+		return sprintf(
+			'%s %s',
 			esc_sql( $query->query_vars['orderby'] ),
 			esc_sql( $query->query_vars['order'] )
 		);


### PR DESCRIPTION
Fixes : https://trello.com/c/mM8i6xY6/171-audit-reports-columns-and-remove-header-links-from-any-columns-that-dont-sort-properly

### Changes proposed in this Pull Request
**Added sortable options:** 
- Students: Completions (we compute this value and not receive from DB)

**Removed sortable options:** 
- Lessons:  Students (There is not more columns), Completions  (we compute this value and not receive from DB)

### Testing instructions
1. Open reports
2. Go to Lessons
3. Make sure they sort properly based on the title
4. Make sure no other column is sortable except Title
5. Go to courses
6. Make sure they sort properly based on the title
7. Make sure they sort properly based on completions 
8. Make sure no other column is sortable except Title and Completions


