### PR TITLE
Update the reports documentation link

### DIFF
--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -162,7 +162,7 @@ class Sensei_Analysis {
 			<div class="sensei-custom-navigation__tabbar">
 				<?php echo wp_kses( implode( '', $menu ), wp_kses_allowed_html( 'post' ) ); ?>
 				<div class="sensei-custom-navigation__tabbar-separator"></div>
-				<a class="sensei-custom-navigation__info" target="_blank" href="https://senseilms.com/docs">
+				<a class="sensei-custom-navigation__info" target="_blank" href="https://senseilms.com/documentation/reports/?utm_source=plugin_sensei&utm_medium=docs&utm_campaign=reports">
 					<?php echo esc_html__( 'Guide To Using Reports', 'sensei-lms' ); ?>
 				</a>
 				<div></div>


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR updates the documentation link on the reports screens.

### Testing instructions

* Go to Sensei LMS -> Reports.
* Make sure the documentation link (Guide To Using Reports) is updated on all overview screens to https://senseilms.com/documentation/reports/?utm_source=plugin_sensei&utm_medium=docs&utm_campaign=reports
