### PR TITLE
Make the bulk actions screen to be the main students page

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -276,72 +276,11 @@ class Sensei_Learner_Management {
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
 		if ( ! empty( $_GET['course_id'] ) ) {
-			$this->output_course_page();
+			require __DIR__ . '/views/html-admin-page-students-course.php';
 		} else {
-			$this->output_main_page();
+			require __DIR__ . '/views/html-admin-page-students-main.php';
 		}
 
-	}
-
-	/**
-	 * Display the students main page.
-	 *
-	 * @since x.x.x
-	 */
-	private function output_main_page() {
-		// Load Learners data.
-		$sensei_learners_main_view = new Sensei_Learners_Admin_Bulk_Actions_View( $this->bulk_actions_controller, $this );
-		$sensei_learners_main_view->prepare_items();
-
-		// Wrappers.
-		do_action( 'sensei_learner_admin_before_container' );
-		?>
-		<div id="woothemes-sensei" class="wrap woothemes-sensei">
-		<?php
-		do_action( 'sensei_learner_admin_wrapper_container', 'top' );
-		$sensei_learners_main_view->output_headers();
-		?>
-		<div id="poststuff" class="sensei-learners-wrap">
-			<div class="sensei-learners-main">
-				<?php $sensei_learners_main_view->display(); ?>
-			</div>
-			<div class="sensei-learners-extra">
-				<?php do_action( 'sensei_learner_admin_extra' ); ?>
-			</div>
-		</div>
-		<?php
-		do_action( 'sensei_learner_admin_wrapper_container', 'bottom' );
-		?>
-		</div>
-		<?php
-		do_action( 'sensei_learner_admin_after_container' );
-	}
-
-	/**
-	 * Display the course page.
-	 *
-	 * @since x.x.x
-	 */
-	private function output_course_page() {
-		$sensei_learners_main = new Sensei_Learners_Main();
-		$sensei_learners_main->prepare_items();
-
-		// Wrappers.
-		do_action( 'learners_before_container' );
-		do_action( 'learners_wrapper_container', 'top' );
-		$this->learners_headers();
-		?>
-		<div id="poststuff" class="sensei-learners-wrap">
-			<div class="sensei-learners-main">
-				<?php $sensei_learners_main->display(); ?>
-			</div>
-			<div class="sensei-learners-extra">
-				<?php do_action( 'sensei_learners_extra' ); ?>
-			</div>
-		</div>
-		<?php
-		do_action( 'learners_wrapper_container', 'bottom' );
-		do_action( 'learners_after_container' );
 	}
 
 	/**

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -327,8 +327,13 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 
 	/**
 	 * Display the learner bulk action page.
+	 *
+	 * @deprecated x.x.x
 	 */
 	public function learner_admin_page() {
+
+		_deprecated_function( __METHOD__, 'x.x.x', 'Sensei_Learner_Management::output_main_page' );
+
 		// Load Learners data.
 		$sensei_learners_main_view = new Sensei_Learners_Admin_Bulk_Actions_View( $this, $this->learner_management );
 		$sensei_learners_main_view->prepare_items();
@@ -362,7 +367,7 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 	 */
 	public function is_current_page() {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for comparison.
-		return isset( $_GET['page'], $_GET['view'] ) && ( $_GET['page'] === $this->page_slug ) && ( $_GET['view'] === $this->view );
+		return empty( $_GET['course_id'] ) && isset( $_GET['page'] ) && $_GET['page'] === $this->page_slug;
 	}
 
 	/**

--- a/includes/admin/views/html-admin-page-students-course.php
+++ b/includes/admin/views/html-admin-page-students-course.php
@@ -2,7 +2,7 @@
 /**
  * Students page course view.
  *
- * This view displays the students data filtered by course.
+ * This view displays the students data in a course context.
  *
  * @package sensei-lms
  * @since x.x.x

--- a/includes/admin/views/html-admin-page-students-course.php
+++ b/includes/admin/views/html-admin-page-students-course.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Students page course view.
+ *
+ * This view displays the students data filtered by course.
+ *
+ * @package sensei-lms
+ * @since x.x.x
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+$sensei_list_table = new Sensei_Learners_Main();
+$sensei_list_table->prepare_items();
+
+do_action( 'learners_before_container' );
+do_action( 'learners_wrapper_container', 'top' );
+
+Sensei()->learners->learners_headers();
+?>
+
+<div id="poststuff" class="sensei-learners-wrap">
+	<div class="sensei-learners-main">
+		<?php $sensei_list_table->display(); ?>
+	</div>
+	<div class="sensei-learners-extra">
+		<?php do_action( 'sensei_learners_extra' ); ?>
+	</div>
+</div>
+
+<?php
+do_action( 'learners_wrapper_container', 'bottom' );
+do_action( 'learners_after_container' );

--- a/includes/admin/views/html-admin-page-students-main.php
+++ b/includes/admin/views/html-admin-page-students-main.php
@@ -12,7 +12,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-$sensei_list_table = new Sensei_Learners_Admin_Bulk_Actions_View( $this->bulk_actions_controller, $this );
+$sensei_list_table = new Sensei_Learners_Admin_Bulk_Actions_View(
+	Sensei()->learners->bulk_actions_controller,
+	Sensei()->learners
+);
 $sensei_list_table->prepare_items();
 
 do_action( 'sensei_learner_admin_before_container' );

--- a/includes/admin/views/html-admin-page-students-main.php
+++ b/includes/admin/views/html-admin-page-students-main.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Students page main view.
+ *
+ * This view displays the students data and bulk actions dropdown.
+ *
+ * @package sensei-lms
+ * @since x.x.x
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+$sensei_list_table = new Sensei_Learners_Admin_Bulk_Actions_View( $this->bulk_actions_controller, $this );
+$sensei_list_table->prepare_items();
+
+do_action( 'sensei_learner_admin_before_container' );
+?>
+
+<div id="woothemes-sensei" class="wrap woothemes-sensei">
+	<?php
+	do_action( 'sensei_learner_admin_wrapper_container', 'top' );
+	$sensei_list_table->output_headers();
+	?>
+
+	<div id="poststuff" class="sensei-learners-wrap">
+		<div class="sensei-learners-main">
+			<?php $sensei_list_table->display(); ?>
+		</div>
+		<div class="sensei-learners-extra">
+			<?php do_action( 'sensei_learner_admin_extra' ); ?>
+		</div>
+	</div>
+
+	<?php do_action( 'sensei_learner_admin_wrapper_container', 'bottom' ); ?>
+</div>
+
+<?php
+do_action( 'sensei_learner_admin_after_container' );

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -139,7 +139,7 @@ class Sensei_Main {
 	public $teacher;
 
 	/**
-	 * @var Sensei_Learners
+	 * @var Sensei_Learner_Management
 	 */
 	public $learners;
 


### PR DESCRIPTION
Part of #4958

### Changes proposed in this Pull Request

This PR changes the default screen that is loaded on the Student Management menu. It now loads the Bulk Student Actions screen instead the select course screen.

### Testing instructions

* Have some students with a few completed courses.
* Go to Sensei LMS -> Student Management.
* The "Bulk Student Actions" screen should be loaded.
* Make sure the bulk actions are working like before.
* Make sure the course filter is working.
* Make sure you can access the course screen by clicking on a course from the "Course Progress" column.
* Make sure the course screen is working like before.

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

* `Sensei_Learners_Admin_Bulk_Actions_Controller::learner_admin_page` - Replaced by `Sensei_Learner_Management::output_main_page`.
