### PR TITLE
Fix wrong data for column in exported csv in Reports->Lessons

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -351,7 +351,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		// Process each row.
 		foreach ( $this->items as $item ) {
-			$data[] = $this->get_row_data( $item );
+			$data[] = array_replace( $columns, $this->get_row_data( $item ) );
 		}
 
 		return $data;

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
@@ -175,11 +175,11 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 			$column_headers[] = $title;
 		}
 
-		$data[] = $column_headers;
-
+		$data[]                   = $column_headers;
+		$columns_keys_assoc_array = array_fill_keys( array_keys( $columns ), '' );
 		// Process each row.
 		foreach ( $this->items as $item ) {
-			$data[] = array_replace( $columns, $this->get_row_data( $item ) );
+			$data[] = array_replace( $columns_keys_assoc_array, $this->get_row_data( $item ) );
 		}
 
 		return $data;

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
@@ -179,7 +179,7 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 
 		// Process each row.
 		foreach ( $this->items as $item ) {
-			$data[] = $this->get_row_data( $item );
+			$data[] = array_replace( $columns, $this->get_row_data( $item ) );
 		}
 
 		return $data;

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
@@ -74,7 +74,7 @@ class Sensei_Reports_Overview_List_Table_Abstract_Test extends WP_UnitTestCase {
 					[ $post2, [ 'c' => 3 ] ],
 				]
 			);
-		$list_table->columns = [ 'd', 'e', 'f' ];
+		$list_table->columns = array_flip( [ 'd', 'e', 'f' ] );
 
 		/* Act. */
 		$actual = $list_table->generate_report();

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
@@ -74,7 +74,8 @@ class Sensei_Reports_Overview_List_Table_Abstract_Test extends WP_UnitTestCase {
 					[ $post2, [ 'c' => 3 ] ],
 				]
 			);
-		$list_table->columns = array_flip( [ 'd', 'e', 'f' ] );
+		$list_table->columns       = array_combine( [ 'd', 'e', 'f' ], [ 'd', 'e', 'f' ] );
+		$columns_with_empty_values = array_fill_keys( array_keys( $list_table->columns ), '' );
 
 		/* Act. */
 		$actual = $list_table->generate_report();
@@ -82,8 +83,8 @@ class Sensei_Reports_Overview_List_Table_Abstract_Test extends WP_UnitTestCase {
 		/* Assert. */
 		$expected = [
 			[ 'd', 'e', 'f' ],
-			[ 'b' => 2 ],
-			[ 'c' => 3 ],
+			array_merge( $columns_with_empty_values, [ 'b' => 2 ] ),
+			array_merge( $columns_with_empty_values, [ 'c' => 3 ] ),
 		];
 		self::assertSame( $expected, $actual );
 	}


### PR DESCRIPTION
Fixes the issue mentioned here https://github.com/Automattic/sensei/pull/4964#pullrequestreview-924205973

### Changes proposed in this Pull Request

The column data was not sorted according to the column headers. So when 'module' column was added in the headers, the data was not being sorted, so the module column appeared after the title column, but the data for the module column was in the last column in each row. So it resulted in all columns except the title showing wrong data (1 right circular shift except the title). Here we're sorting the data as per column headers to make them appear in the same order.

### Testing instructions

1. Create a few lessons
2. Export CSV
3.  See if all data appears according to their column name

### Screenshot / Video
Before - (Notice that the students column is showing a date, also the rest of the columns)
![image](https://user-images.githubusercontent.com/6820724/161245390-d6282669-90b5-42ea-8a4c-7dffaa09eba9.png)

After-
![image](https://user-images.githubusercontent.com/6820724/161245612-5c44541d-9dcd-4779-a681-3181c7e0cb17.png)
