### PR TITLE
Fix "Days to Completion" and "Module" columns are swapped when exporting lessons

### DIFF
--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -83,7 +83,6 @@ class Sensei_Core_Modules {
 
 		// Add 'Modules' columns to Analysis tables
 		add_filter( 'sensei_analysis_overview_columns', array( $this, 'analysis_overview_column_title' ), 10, 2 );
-		add_filter( 'sensei_analysis_overview_column_data', array( $this, 'analysis_overview_column_data' ), 10, 3 );
 		add_filter( 'sensei_analysis_course_columns', array( $this, 'analysis_course_column_title' ), 10, 2 );
 		add_filter( 'sensei_analysis_course_column_data', array( $this, 'analysis_course_column_data' ), 10, 3 );
 
@@ -1577,12 +1576,16 @@ class Sensei_Core_Modules {
 	 * Data for 'Module' column Analysis Lesson Overview table
 	 *
 	 * @since 1.8.0
+	 * @deprecated x.x.x
 	 *
 	 * @param  array   $columns Table column data
 	 * @param  WP_Post $lesson
 	 * @return array              Updated column data
 	 */
 	public function analysis_overview_column_data( $columns, $lesson ) {
+
+		_deprecated_function( __METHOD__, 'x.x.x' );
+
 		if ( isset( $_GET['view'] ) && 'lessons' == $_GET['view'] ) {
 			$lesson_module      = '';
 			$lesson_module_list = wp_get_post_terms( $lesson->ID, $this->taxonomy );

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1576,7 +1576,7 @@ class Sensei_Core_Modules {
 	 * Data for 'Module' column Analysis Lesson Overview table
 	 *
 	 * @since 1.8.0
-	 * @deprecated x.x.x
+	 * @deprecated 4.3.0
 	 *
 	 * @param  array   $columns Table column data
 	 * @param  WP_Post $lesson
@@ -1584,7 +1584,7 @@ class Sensei_Core_Modules {
 	 */
 	public function analysis_overview_column_data( $columns, $lesson ) {
 
-		_deprecated_function( __METHOD__, 'x.x.x' );
+		_deprecated_function( __METHOD__, '4.3.0' );
 
 		if ( isset( $_GET['view'] ) && 'lessons' == $_GET['view'] ) {
 			$lesson_module      = '';

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -196,12 +196,12 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 
 		foreach ( $modules_terms as $term ) {
 			if ( $this->csv_output ) {
-				$module = $term->name;
+				$module = esc_html( $term->name );
 			} else {
 				$module = sprintf(
 					'<a href="%s">%s</a>',
-					admin_url( 'edit-tags.php?action=edit&taxonomy=module&tag_ID=' . $term->term_id ),
-					$term->name
+					esc_url( admin_url( 'edit-tags.php?action=edit&taxonomy=module&tag_ID=' . $term->term_id ) ),
+					esc_html( $term->name )
 				);
 			}
 

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -157,12 +157,13 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 			);
 			// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound
 			$lesson_title = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . apply_filters( 'the_title', $item->post_title, $item->ID ) . '</a></strong>';
-
 		}
+
 		$column_data = apply_filters(
 			'sensei_analysis_overview_column_data',
 			array(
 				'title'              => $lesson_title,
+				'lesson_module'      => $this->get_row_module( $item->ID ),
 				'students'           => $lesson_students,
 				'last_activity'      => $this->get_last_activity_date( array( 'post_id' => $item->ID ) ),
 				'completions'        => $lesson_completions,
@@ -181,6 +182,35 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 
 		return $escaped_column_data;
 	}
+
+	/**
+	 * Get the module data for a row.
+	 *
+	 * @param int $lesson_id The lesson post ID.
+	 *
+	 * @return string
+	 */
+	private function get_row_module( int $lesson_id ): string {
+		$module        = '';
+		$modules_terms = wp_get_post_terms( $lesson_id, 'module' );
+
+		foreach ( $modules_terms as $term ) {
+			if ( $this->csv_output ) {
+				$module = $term->name;
+			} else {
+				$module = sprintf(
+					'<a href="%s">%s</a>',
+					admin_url( 'edit-tags.php?action=edit&taxonomy=module&tag_ID=' . $term->term_id ),
+					$term->name
+				);
+			}
+
+			break;
+		}
+
+		return $module;
+	}
+
 	/**
 	 * Get completion rate for a lesson.
 	 *


### PR DESCRIPTION
Fixes #4977

### Changes proposed in this Pull Request

This PR fixes the "Days to Completion" and "Module" columns. They are swapped when doing a lessons export from the reports screen.
This also removes the module links from the CSV export. 

### Testing instructions

* Go to Sensei LMS -> Reports -> Lessons.
* Select a course with lessons that belong to modules.
* Click "Export all rows" and open the CSV.
* The "Days to Completion" and "Module" columns should be correct.
* There should be no module links.

### Deprecated

* `Sensei_Core_Modules::analysis_overview_column_data`

### Screenshot / Video
<img width="761" alt="Screenshot on 2022-04-02 at 00-00-36" src="https://user-images.githubusercontent.com/1612178/161340647-a76c5464-f116-45f9-bac3-ad136d0b48b5.png">

