### PR TITLE
Add modal to add or remove a student from a course

### DIFF
--- a/assets/admin/students/student-action-menu/index.js
+++ b/assets/admin/students/student-action-menu/index.js
@@ -2,40 +2,67 @@
  * WordPress dependencies
  */
 import { DropdownMenu } from '@wordpress/components';
-import { render } from '@wordpress/element';
+import { render, useState } from '@wordpress/element';
 import { moreVertical } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import StudentModal from '../student-modal';
 
 /**
  * Student action menu.
  */
 export const StudentActionMenu = () => {
+	const [ action, setAction ] = useState( '' );
+	const [ isModalOpen, setModalOpen ] = useState( false );
+	const closeModal = () => setModalOpen( false );
+
+	const controls = [
+		{
+			title: __( 'Add to Course', 'sensei-lms' ),
+			onClick: () => addToCourse(),
+		},
+		{
+			title: __( 'Remove from Course', 'sensei-lms' ),
+			onClick: () => removeFromCourse(),
+		},
+		{
+			title: __( 'Grading', 'sensei-lms' ),
+			onClick: () => {},
+		},
+	];
+
+	const addToCourse = () => {
+		setAction( 'add' );
+		setModalOpen( true );
+	};
+
+	const removeFromCourse = () => {
+		setAction( 'remove' );
+		setModalOpen( true );
+	};
+
 	return (
-		<DropdownMenu
-			icon={ moreVertical }
-			label={ __( 'Select an action', 'sensei-lms' ) }
-			controls={ [
-				{
-					title: __( 'Add to Course', 'sensei-lms' ),
-					onClick: () => {},
-				},
-				{
-					title: __( 'Remove from Course', 'sensei-lms' ),
-					onClick: () => {},
-				},
-				{
-					title: __( 'Grading', 'sensei-lms' ),
-					onClick: () => {},
-				},
-			] }
-		/>
+		<>
+			<DropdownMenu
+				icon={ moreVertical }
+				label={ __( 'Select an action', 'sensei-lms' ) }
+				controls={ controls }
+			/>
+
+			{ isModalOpen && (
+				<StudentModal action={ action } onClose={ closeModal } />
+			) }
+		</>
 	);
 };
 
 Array.from( document.getElementsByClassName( 'student-action-menu' ) ).forEach(
 	( actionMenu ) => {
 		render(
-			<StudentActionMenu courseId={ actionMenu.dataset.courseId } />,
+			<StudentActionMenu courseId={ actionMenu?.dataset?.courseId } />,
 			actionMenu
 		);
 	}

--- a/assets/admin/students/student-action-menu/index.js
+++ b/assets/admin/students/student-action-menu/index.js
@@ -62,7 +62,7 @@ export const StudentActionMenu = () => {
 Array.from( document.getElementsByClassName( 'student-action-menu' ) ).forEach(
 	( actionMenu ) => {
 		render(
-			<StudentActionMenu courseId={ actionMenu?.dataset?.courseId } />,
+			<StudentActionMenu userId={ actionMenu?.dataset?.userId } />,
 			actionMenu
 		);
 	}

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Course list.
+ */
+const CourseList = () => {
+	return (
+		<ul className="sensei-course-list">
+			<li className="sensei-course-list__item--empty">
+				<p>{ __( 'No courses found.', 'sensei-lms' ) }</p>
+			</li>
+		</ul>
+	);
+};
+
+export default CourseList;

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -6,6 +6,23 @@ import { CheckboxControl, Spinner } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
+const courseItems = ( course ) => {
+	const courseId = course?.id;
+	const title = course?.title?.rendered;
+
+	return (
+		<li
+			className="sensei-student-modal__course-list__item"
+			key={ courseId }
+		>
+			<CheckboxControl id={ `course-${ courseId }` } title={ title } />
+			<label htmlFor={ `course-${ courseId }` } title={ title }>
+				{ title }
+			</label>
+		</li>
+	);
+};
+
 /**
  * Course list.
  */
@@ -41,33 +58,13 @@ export const CourseList = () => {
 		return <p>{ __( 'No courses found.', 'sensei-lms' ) }</p>;
 	}
 
-	const coursesMap = ( course ) => {
-		const courseId = course?.id;
-		const title = course?.title?.rendered;
-
-		return (
-			<li
-				className="sensei-student-modal__course-list__item"
-				key={ courseId }
-			>
-				<CheckboxControl
-					id={ `course-${ courseId }` }
-					title={ title }
-				/>
-				<label htmlFor={ `course-${ courseId }` } title={ title }>
-					{ title }
-				</label>
-			</li>
-		);
-	};
-
 	return (
 		<>
 			<span className="sensei-student-modal__course-list__header">
 				{ __( 'Your Courses', 'sensei-lms' ) }
 			</span>
 			<ul className="sensei-student-modal__course-list">
-				{ courses.map( coursesMap ) }
+				{ courses.map( courseItems ) }
 			</ul>
 		</>
 	);

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -62,6 +62,9 @@ const CourseList = () => {
 
 	return (
 		<>
+			<span className="sensei-course-list__header">
+				{ __( 'Your Courses', 'sensei-lms' ) }
+			</span>
 			<ul className="sensei-course-list">
 				{ courses.map( coursesMap ) }
 			</ul>

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -1,18 +1,71 @@
 /**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
+import { CheckboxControl, Spinner } from '@wordpress/components';
+import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Course list.
  */
 const CourseList = () => {
+	const [ isFetching, setIsFetching ] = useState( true );
+	const [ courses, setCourses ] = useState( [] );
+
+	// Fetch the courses.
+	useEffect( () => {
+		setIsFetching( true );
+
+		apiFetch( {
+			path: '/wp/v2/courses?per_page=100',
+			method: 'GET',
+		} )
+			.then( ( result ) => {
+				setCourses( result );
+			} )
+			.finally( () => {
+				setIsFetching( false );
+			} );
+	}, [] );
+
+	if ( isFetching ) {
+		return (
+			<div className="sensei-course-list--loading">
+				<Spinner />
+			</div>
+		);
+	}
+
+	if ( 0 === courses.length ) {
+		return <p>{ __( 'No courses found.', 'sensei-lms' ) }</p>;
+	}
+
+	const coursesMap = ( course ) => {
+		const courseId = course?.id;
+		const title = course?.title?.rendered;
+
+		return (
+			<>
+				<li className="sensei-course-list__item" key={ courseId }>
+					<CheckboxControl
+						id={ `course-${ courseId }` }
+						title={ title }
+					/>
+					<label htmlFor={ `course-${ courseId }` } title={ title }>
+						{ title }
+					</label>
+				</li>
+			</>
+		);
+	};
+
 	return (
-		<ul className="sensei-course-list">
-			<li className="sensei-course-list__item--empty">
-				<p>{ __( 'No courses found.', 'sensei-lms' ) }</p>
-			</li>
-		</ul>
+		<>
+			<ul className="sensei-course-list">
+				{ courses.map( coursesMap ) }
+			</ul>
+		</>
 	);
 };
 

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -31,7 +31,7 @@ const CourseList = () => {
 
 	if ( isFetching ) {
 		return (
-			<div className="sensei-course-list--loading">
+			<div className="sensei-student-modal__course-list--loading">
 				<Spinner />
 			</div>
 		);
@@ -47,7 +47,10 @@ const CourseList = () => {
 
 		return (
 			<>
-				<li className="sensei-course-list__item" key={ courseId }>
+				<li
+					className="sensei-student-modal__course-list__item"
+					key={ courseId }
+				>
 					<CheckboxControl
 						id={ `course-${ courseId }` }
 						title={ title }
@@ -62,10 +65,10 @@ const CourseList = () => {
 
 	return (
 		<>
-			<span className="sensei-course-list__header">
+			<span className="sensei-student-modal__course-list__header">
 				{ __( 'Your Courses', 'sensei-lms' ) }
 			</span>
-			<ul className="sensei-course-list">
+			<ul className="sensei-student-modal__course-list">
 				{ courses.map( coursesMap ) }
 			</ul>
 		</>

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
 /**
  * Course list.
  */
-const CourseList = () => {
+export const CourseList = () => {
 	const [ isFetching, setIsFetching ] = useState( true );
 	const [ courses, setCourses ] = useState( [] );
 
@@ -46,20 +46,18 @@ const CourseList = () => {
 		const title = course?.title?.rendered;
 
 		return (
-			<>
-				<li
-					className="sensei-student-modal__course-list__item"
-					key={ courseId }
-				>
-					<CheckboxControl
-						id={ `course-${ courseId }` }
-						title={ title }
-					/>
-					<label htmlFor={ `course-${ courseId }` } title={ title }>
-						{ title }
-					</label>
-				</li>
-			</>
+			<li
+				className="sensei-student-modal__course-list__item"
+				key={ courseId }
+			>
+				<CheckboxControl
+					id={ `course-${ courseId }` }
+					title={ title }
+				/>
+				<label htmlFor={ `course-${ courseId }` } title={ title }>
+					{ title }
+				</label>
+			</li>
 		);
 	};
 

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -6,7 +6,12 @@ import { CheckboxControl, Spinner } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
-const courseItems = ( course ) => {
+/**
+ * Course item.
+ *
+ * @param {Object} course Course.
+ */
+const CourseItem = ( course ) => {
 	const courseId = course?.id;
 	const title = course?.title?.rendered;
 
@@ -64,7 +69,7 @@ export const CourseList = () => {
 				{ __( 'Your Courses', 'sensei-lms' ) }
 			</span>
 			<ul className="sensei-student-modal__course-list">
-				{ courses.map( courseItems ) }
+				{ courses.map( CourseItem ) }
 			</ul>
 		</>
 	);

--- a/assets/admin/students/student-modal/course-list.test.js
+++ b/assets/admin/students/student-modal/course-list.test.js
@@ -13,26 +13,37 @@ import apiFetch from '@wordpress/api-fetch';
  */
 import { CourseList } from './course-list';
 
-const coursePromise = Promise.resolve( [
-	{
-		id: 1,
-		title: { rendered: 'My Course' },
-	},
-	{
-		id: 2,
-		title: { rendered: 'Another Course' },
-	},
-] );
-
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
-apiFetch.mockImplementation( () => coursePromise );
 
 describe( '<CourseList />', () => {
 	it( 'Should display courses in the list', async () => {
+		const coursePromise = Promise.resolve( [
+			{
+				id: 1,
+				title: { rendered: 'My Course' },
+			},
+			{
+				id: 2,
+				title: { rendered: 'Another Course' },
+			},
+		] );
+		apiFetch.mockImplementation( () => coursePromise );
+
 		await act( async () => {
 			render( <CourseList /> );
 		} );
 
-		expect( screen.getAllByRole( 'listitem' ).length ).toBe( 2 );
+		expect( screen.getByLabelText( 'My Course' ) ).toBeTruthy();
+		expect( screen.getByLabelText( 'Another Course' ) ).toBeTruthy();
+	} );
+
+	it( 'Should show a message when there are no courses', async () => {
+		apiFetch.mockImplementation( () => Promise.resolve( [] ) );
+
+		await act( async () => {
+			render( <CourseList /> );
+		} );
+
+		expect( screen.getByText( 'No courses found.' ) ).toBeTruthy();
 	} );
 } );

--- a/assets/admin/students/student-modal/course-list.test.js
+++ b/assets/admin/students/student-modal/course-list.test.js
@@ -1,0 +1,38 @@
+/**
+ * External dependencies
+ */
+import { act, render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { CourseList } from './course-list';
+
+const coursePromise = Promise.resolve( [
+	{
+		id: 1,
+		title: { rendered: 'My Course' },
+	},
+	{
+		id: 2,
+		title: { rendered: 'Another Course' },
+	},
+] );
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+apiFetch.mockImplementation( () => coursePromise );
+
+describe( '<CourseList />', () => {
+	it( 'Should display courses in the list', async () => {
+		await act( async () => {
+			render( <CourseList /> );
+		} );
+
+		expect( screen.getAllByRole( 'listitem' ).length ).toBe( 2 );
+	} );
+} );

--- a/assets/admin/students/student-modal/index.js
+++ b/assets/admin/students/student-modal/index.js
@@ -18,7 +18,7 @@ import InputControl from '../../../blocks/editor-components/input-control';
  * @param {Object}   props.action  Action that is being performed.
  * @param {Function} props.onClose Close callback.
  */
-const StudentModal = ( { action, onClose } ) => {
+export const StudentModal = ( { action, onClose } ) => {
 	const addDescription = __(
 		'Select the course(s) you would like to add students to:',
 		'sensei-lms'
@@ -30,7 +30,7 @@ const StudentModal = ( { action, onClose } ) => {
 	);
 
 	const addButton = (
-		<Button isPrimary className="sensei-student-modal__action--add">
+		<Button className="sensei-student-modal__action--add" variant="primary">
 			{ __( 'Add to Course', 'sensei-lms' ) }
 		</Button>
 	);

--- a/assets/admin/students/student-modal/index.js
+++ b/assets/admin/students/student-modal/index.js
@@ -52,9 +52,6 @@ const StudentModal = ( { action, onClose } ) => {
 				placeholder={ __( 'Search courses', 'sensei-lms' ) }
 				iconRight={ search }
 			/>
-			<span className="sensei-student-modal__header">
-				{ __( 'Your Courses', 'sensei-lms' ) }
-			</span>
 			<CourseList />
 			<div className="sensei-student-modal__action">
 				{ 'add' === action ? addButton : removeButton }

--- a/assets/admin/students/student-modal/index.js
+++ b/assets/admin/students/student-modal/index.js
@@ -1,0 +1,66 @@
+/**
+ * WordPress dependencies
+ */
+import { Button, Modal } from '@wordpress/components';
+import { search } from '@wordpress/icons';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import CourseList from './course-list';
+import InputControl from '../../../blocks/editor-components/input-control';
+
+/**
+ * Questions modal content.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.action  Action that is being performed.
+ * @param {Function} props.onClose Close callback.
+ */
+const StudentModal = ( { action, onClose } ) => {
+	const addDescription = __(
+		'Select the course(s) you would like to add students to:',
+		'sensei-lms'
+	);
+
+	const removeDescription = __(
+		'Select the course(s) you would like to remove students from:',
+		'sensei-lms'
+	);
+
+	const addButton = (
+		<Button isPrimary className="sensei-student-modal__action--add">
+			{ __( 'Add to Course', 'sensei-lms' ) }
+		</Button>
+	);
+
+	const removeButton = (
+		<Button className="sensei-student-modal__action--remove">
+			{ __( 'Remove from Course', 'sensei-lms' ) }
+		</Button>
+	);
+
+	return (
+		<Modal
+			className="sensei-student-modal"
+			title={ __( 'Choose Course', 'sensei-lms' ) }
+			onRequestClose={ onClose }
+		>
+			<p>{ 'add' === action ? addDescription : removeDescription }</p>
+			<InputControl
+				placeholder={ __( 'Search courses', 'sensei-lms' ) }
+				iconRight={ search }
+			/>
+			<span className="sensei-student-modal__header">
+				{ __( 'Your Courses', 'sensei-lms' ) }
+			</span>
+			<CourseList />
+			<div className="sensei-student-modal__action">
+				{ 'add' === action ? addButton : removeButton }
+			</div>
+		</Modal>
+	);
+};
+
+export default StudentModal;

--- a/assets/admin/students/student-modal/index.test.js
+++ b/assets/admin/students/student-modal/index.test.js
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { act, render, screen } from '@testing-library/react';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import { StudentModal } from './index';
+
+const coursePromise = Promise.resolve( [
+	{
+		id: 1,
+		title: { rendered: 'My Course' },
+	},
+] );
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+apiFetch.mockImplementation( () => coursePromise );
+
+describe( '<StudentModal />', () => {
+	it( 'Should display the "Add to Course" button when adding a course', async () => {
+		await act( async () => {
+			render( <StudentModal action="add" /> );
+		} );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Add to Course' } )
+		).toBeTruthy();
+	} );
+
+	it( 'Should display the "Remove from Course" button when removing a course', async () => {
+		await act( async () => {
+			render( <StudentModal action="remove" /> );
+		} );
+
+		expect(
+			screen.getByRole( 'button', { name: 'Remove from Course' } )
+		).toBeTruthy();
+	} );
+} );

--- a/assets/admin/students/student-modal/student-modal.scss
+++ b/assets/admin/students/student-modal/student-modal.scss
@@ -1,0 +1,29 @@
+@import '../../../shared/styles/wp-colors';
+
+.sensei-student-modal {
+	width: 455px;
+
+	&__header {
+		display: block;
+		margin-top: 30px;
+	}
+
+	.sensei-course-list {
+		border: 1px solid #8c8f94;
+	}
+
+	.sensei-course-list__item--empty {
+		margin: 0;
+		padding: 10px;
+	}
+
+	.sensei-student-modal__action {
+		display: flex;
+		justify-content: flex-end;
+		margin-top: 40px;
+
+		&--remove {
+			color: $alert-red;
+		}
+	}
+}

--- a/assets/admin/students/student-modal/student-modal.scss
+++ b/assets/admin/students/student-modal/student-modal.scss
@@ -1,40 +1,47 @@
 @import '../../../shared/styles/wp-colors';
 
 .sensei-student-modal {
-	width: 455px;
+	max-width: 697px;
+	width: 100%;
 
-	&__header {
-		display: block;
-		margin-top: 30px;
-	}
-
-	.sensei-course-list {
+	&__course-list {
 		border: 1px solid #8c8f94;
-	}
+		height: calc(100vh - 340px);
+		overflow: auto;
 
-	.sensei-course-list__item--empty {
-		margin: 0;
-		padding: 10px;
-	}
-
-	.sensei-course-list__item {
-		margin: 0;
-		padding: 15px 25px;
-
-		.components-base-control {
-			display: inline-block;
+		@media (min-width: 600px) {
+			height: 300px;
 		}
 
-		.components-base-control__field {
+		&--loading {
+			text-align: center;
+			padding: 20px;
+		}
+
+		&__header {
+			display: block;
+			margin-top: 30px;
+		}
+
+		&__item {
 			margin: 0;
-		}
+			padding: 15px 25px;
 
-		&:nth-child(odd) {
-			background-color: #f6f7f7;
+			.components-base-control {
+				display: inline-block;
+			}
+
+			.components-base-control__field {
+				margin: 0;
+			}
+
+			&:nth-child(odd) {
+				background-color: #f6f7f7;
+			}
 		}
 	}
 
-	.sensei-student-modal__action {
+	&__action {
 		display: flex;
 		justify-content: flex-end;
 		margin-top: 40px;

--- a/assets/admin/students/student-modal/student-modal.scss
+++ b/assets/admin/students/student-modal/student-modal.scss
@@ -17,6 +17,23 @@
 		padding: 10px;
 	}
 
+	.sensei-course-list__item {
+		margin: 0;
+		padding: 15px 25px;
+
+		.components-base-control {
+			display: inline-block;
+		}
+
+		.components-base-control__field {
+			margin: 0;
+		}
+
+		&:nth-child(odd) {
+			background-color: #f6f7f7;
+		}
+	}
+
 	.sensei-student-modal__action {
 		display: flex;
 		justify-content: flex-end;

--- a/assets/admin/students/student-modal/student-modal.scss
+++ b/assets/admin/students/student-modal/student-modal.scss
@@ -6,11 +6,12 @@
 
 	&__course-list {
 		border: 1px solid #8c8f94;
-		height: calc(100vh - 340px);
+		height: auto;
+		max-height: calc(100vh - 340px);
 		overflow: auto;
 
 		@media (min-width: 600px) {
-			height: 300px;
+			max-height: 300px;
 		}
 
 		&--loading {

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -179,6 +179,7 @@ class Sensei_Learner_Management {
 
 		Sensei()->assets->enqueue( 'sensei-stop-double-submission', 'js/stop-double-submission.js', [], true );
 		Sensei()->assets->enqueue( 'sensei-student-action-menu', 'admin/students/student-action-menu/index.js', [], true );
+		Sensei()->assets->enqueue( 'sensei-student-modal', 'admin/students/student-modal/index.js', [], true );
 
 		wp_localize_script(
 			'sensei-learners-general',
@@ -215,10 +216,12 @@ class Sensei_Learner_Management {
 	 * @since 1.6.0
 	 */
 	public function enqueue_styles() {
-		// JQuery UI doesn't actually require sensei-wp-components, but the StudentActionMenu component does.
-		// Since StudentActionMenu doesn't currently have its own CSS file, I'm adding the dependency here
-		// as a workaround.
-		Sensei()->assets->enqueue( 'sensei-jquery-ui', 'css/jquery-ui.css', [ 'sensei-wp-components' ] );
+		Sensei()->assets->enqueue( 'sensei-jquery-ui', 'css/jquery-ui.css' );
+		Sensei()->assets->enqueue(
+			'sensei-student-modal-style',
+			'admin/students/student-modal/student-modal.css',
+			[ 'sensei-wp-components', 'sensei-editor-components-style' ]
+		);
 	}
 
 	/**

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -104,6 +104,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 			'learner'  => __( 'Student', 'sensei-lms' ),
 			'email'    => __( 'Email', 'sensei-lms' ),
 			'progress' => __( 'Course Progress', 'sensei-lms' ),
+			'actions'  => '',
 		);
 
 		return apply_filters( 'sensei_learners_admin_default_columns', $columns, $this );
@@ -158,6 +159,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 				'learner'    => esc_html__( 'No results found', 'sensei-lms' ),
 				'progress'   => '',
 				'enrolments' => '',
+				'actions'    => '',
 			);
 		} else {
 			$learner  = $item;
@@ -167,6 +169,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 				'learner'  => $this->get_learner_html( $learner ),
 				'email'    => $learner->user_email,
 				'progress' => $courses,
+				'actions'    => '<div class="student-action-menu" data-user-id="' . esc_attr( $learner->user_id ) . '"></div>',
 			);
 		}
 

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -169,7 +169,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 				'learner'  => $this->get_learner_html( $learner ),
 				'email'    => $learner->user_email,
 				'progress' => $courses,
-				'actions'    => '<div class="student-action-menu" data-user-id="' . esc_attr( $learner->user_id ) . '"></div>',
+				'actions'  => '<div class="student-action-menu" data-user-id="' . esc_attr( $learner->user_id ) . '"></div>',
 			);
 		}
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,6 +72,7 @@ const files = [
 	'admin/exit-survey/index.js',
 	'admin/exit-survey/exit-survey.scss',
 	'admin/students/student-action-menu/index.js',
+	'admin/students/student-modal/student-modal.scss',
 	'css/tools.scss',
 	'css/enrolment-debug.scss',
 	'css/frontend.scss',


### PR DESCRIPTION
Partial fix for #4959.

### Changes proposed in this Pull Request

Adds a modal that opens when _Add to Course_ or _Remove from Course_ is clicked in the actions dropdown.

### Testing instructions

1. Go to Students.
2. Select a row and click the _Add to Course_ option in the dropdown menu.
3. Ensure courses are displayed and that the _Add to Course_ button is displayed.
4. Click off the modal to close it.
5. Select a row and click the _Remove from Course_ option in the dropdown menu.
6. Ensure courses are displayed and that the _Remove from Course_ button is displayed.
7. Move all your courses to the trash.
8. Go to Students.
9. Repeat step 2.
10. Ensure _No courses found._ message is displayed.
11. Check that the modal looks good on mobile. (The mobile view of the table is very broken and will be addressed by a separate card.)

Note: Searching courses or clicking the buttons do nothing.

### Screenshot / Video
![Screen Shot 2022-04-06 at 10 23 40 AM](https://user-images.githubusercontent.com/1190420/161997359-74e45691-adf8-4ce2-ae5a-6372bbca6993.jpg)

![Screen Shot 2022-04-06 at 10 24 57 AM](https://user-images.githubusercontent.com/1190420/161997621-c04c7db4-af57-436f-a5c2-d85da4663ccc.jpg)