### PR TITLE
Rename "Student Management" to "Students"

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -74,7 +74,7 @@ class Sensei_Learner_Management {
 	 * @param string $file Main plugin file name.
 	 */
 	public function __construct( $file ) {
-		$this->name           = __( 'Student Management', 'sensei-lms' );
+		$this->name           = __( 'Students', 'sensei-lms' );
 		$this->file           = $file;
 		$this->page_slug      = 'sensei_learners';
 		$this->menu_post_type = 'course';


### PR DESCRIPTION
Related to the issue #4958
### Changes proposed in this Pull Request
Rename the admin/"Students Management" page to Students on the menu and title.

### Testing instructions
- Open the admin page
- Check if the menu and the page title were renamed as this screenshot https://d.pr/QKkmca




