### PR TITLE
Some preparation to reuse question components

### DIFF
--- a/assets/blocks/quiz/answer-blocks/index.js
+++ b/assets/blocks/quiz/answer-blocks/index.js
@@ -159,6 +159,11 @@ const availableCoreSettings = {
 };
 
 /**
+ * Question types before the filter being applied.
+ */
+export const unfilteredQuestionTypes = questionTypes;
+
+/**
  * Filters the quiz editor question types in order to support custom ones.
  *
  * @param {Object}   questionTypes             The question types.

--- a/assets/blocks/quiz/question-block/question-edit.js
+++ b/assets/blocks/quiz/question-block/question-edit.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { BlockControls, InnerBlocks } from '@wordpress/block-editor';
@@ -6,15 +11,11 @@ import { select, useDispatch } from '@wordpress/data';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { compose } from '@wordpress/compose';
 import { __, _n, sprintf } from '@wordpress/i18n';
-/**
- * External dependencies
- */
-import classnames from 'classnames';
+import { applyFilters } from '@wordpress/hooks';
 
 /**
  * Internal dependencies
  */
-
 import { withBlockValidation } from '../../../shared/blocks/block-validation';
 import {
 	answerFeedbackCorrectBlock,
@@ -41,6 +42,27 @@ import QuestionView from './question-view';
 import QuestionSettings from './question-settings';
 import { QuestionTypeToolbar } from './question-type-toolbar';
 import SingleQuestion from './single-question';
+
+let questionOptions = Object.entries( types ).map(
+	( [ value, settings ] ) => ( {
+		...settings,
+		label: settings.title,
+		value,
+	} )
+);
+
+/**
+ * Filters the available question type options.
+ *
+ * @since 4.1.0
+ *
+ * @param {Array} options The available question type options.
+ * @return {Array} The filtered question type options.
+ */
+questionOptions = applyFilters(
+	'senseiQuestionTypeToolbarOptions',
+	questionOptions
+);
 
 /**
  * Format the question grade as `X points`.
@@ -202,6 +224,7 @@ const QuestionEdit = ( props ) => {
 						onSelect={ ( nextValue ) =>
 							setAttributes( { type: nextValue } )
 						}
+						options={ questionOptions }
 					/>
 					<QuestionGradeToolbar
 						value={ options.grade }

--- a/assets/blocks/quiz/question-block/question-type-toolbar.js
+++ b/assets/blocks/quiz/question-block/question-type-toolbar.js
@@ -9,30 +9,16 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import ToolbarDropdown from '../../editor-components/toolbar-dropdown';
-import types from '../answer-blocks';
 
-let options = Object.entries( types ).map( ( [ value, settings ] ) => ( {
-	...settings,
-	label: settings.title,
-	value,
-} ) );
-/**
- * Filters the available question type options.
- *
- * @since 4.1.0
- *
- * @param {Array} options The available question type options.
- * @return {Array} The filtered question type options.
- */
-options = applyFilters( 'senseiQuestionTypeToolbarOptions', options );
 /**
  * Question type selector toolbar control.
  *
  * @param {Object}   props
  * @param {string}   props.value    Selected type.
  * @param {Function} props.onSelect Selection callback.
+ * @param {Array}    props.options  Question options.
  */
-export const QuestionTypeToolbar = ( { value, onSelect } ) => {
+export const QuestionTypeToolbar = ( { value, onSelect, options } ) => {
 	return (
 		<Toolbar className="sensei-lms-question-block__type-selector__toolbar">
 			<ToolbarDropdown


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It's a preparation to use question components on Interactive Blocks.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course with a Quiz.
* Add some questions of different types, use the question toolbar, and make sure everything works properly as previously.