### PR TITLE
Add REST API endpoint to reset progress for students on courses

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-course-progress-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-progress-controller.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * File containing Sensei_REST_API_Course_Progress_Controller class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly.
+}
+
+/**
+ * Course Progress REST API Controller
+ *
+ * @since x.x.x
+ */
+class Sensei_REST_API_Course_Progress_Controller extends \WP_REST_Controller {
+
+	/**
+	 * Routes namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace;
+
+	/**
+	 * Routes prefix.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'course-progress';
+
+	/**
+	 * Sensei_REST_API_Course_Structure_Controller constructor.
+	 *
+	 * @param string $namespace Routes namespace.
+	 */
+	public function __construct( $namespace ) {
+		$this->namespace = $namespace;
+	}
+
+	/**
+	 * Register the REST API endpoints for Course Structure.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/batch',
+			[
+				[
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => [ $this, 'batch_delete_items' ],
+					'permission_callback' => [ $this, 'batch_delete_items_permissions_check' ],
+					'args'                => $this->get_args_schema(),
+				],
+			]
+		);
+	}
+
+	/**
+	 * Reset progress for students on courses.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function batch_delete_items( WP_REST_Request $request ) {
+		$params      = $request->get_params();
+		$student_ids = $params['student_ids'];
+		$course_ids  = $params['course_ids'];
+		foreach ( $student_ids as $student_id ) {
+			$user = new WP_User( $student_id );
+			if ( $user->exists() ) {
+				foreach ( $course_ids as $course_id ) {
+					if ( Sensei_Utils::has_started_course( $course_id, $student_id ) ) {
+						Sensei_Utils::reset_course_for_user( $course_id, $student_id );
+					}
+				}
+			}
+		}
+
+		return new WP_REST_Response( null, WP_HTTP::OK );
+	}
+
+	/**
+	 * Check if the current user can reset progress.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 *
+	 * @return bool
+	 */
+	public function batch_delete_items_permissions_check( WP_REST_Request $request ): bool {
+		$params          = $request->get_params();
+		$course_ids      = $params['course_ids'];
+		$edit_course_cap = get_post_type_object( 'course' )->cap->edit_post;
+		foreach ( $course_ids as $course_id ) {
+			$course = get_post( absint( $course_id ) );
+			if ( empty( $course ) || ! current_user_can( $edit_course_cap, $course_id ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Schema definition for endpoint arguments.
+	 *
+	 * @return array[]
+	 */
+	public function get_args_schema(): array {
+		return [
+			'course_ids'  => [
+				'description' => 'Course Ids to perform the action on.',
+				'type'        => 'array',
+				'minItems'    => 1,
+				'uniqueItems' => true,
+				'items'       => [
+					'type' => 'integer',
+				],
+				'required'    => true,
+			],
+			'student_ids' => [
+				'description' => 'Student Ids to perform the action on',
+				'type'        => 'array',
+				'minItems'    => 1,
+				'uniqueItems' => true,
+				'items'       => [
+					'type' => 'integer',
+				],
+				'required'    => true,
+			],
+		];
+	}
+}

--- a/includes/rest-api/class-sensei-rest-api-course-students-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-students-controller.php
@@ -31,7 +31,7 @@ class Sensei_REST_API_Course_Students_Controller extends \WP_REST_Controller {
 	protected $rest_base = 'course-students';
 
 	/**
-	 * Sensei_REST_API_Course_Structure_Controller constructor.
+	 * Sensei_REST_API_Course_Students_Controller constructor.
 	 *
 	 * @param string $namespace Routes namespace.
 	 */

--- a/includes/rest-api/class-sensei-rest-api-internal.php
+++ b/includes/rest-api/class-sensei-rest-api-internal.php
@@ -53,6 +53,7 @@ class Sensei_REST_API_Internal {
 			new Sensei_REST_API_Extensions_Controller( $this->namespace ),
 			new Sensei_REST_API_Send_Message_Controller( $this->namespace ),
 			new Sensei_REST_API_Course_Students_Controller( $this->namespace ),
+			new Sensei_REST_API_Course_Progress_Controller( $this->namespace ),
 		];
 
 		foreach ( $this->controllers as $controller ) {

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-progress-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-progress-controller.php
@@ -1,0 +1,179 @@
+<?php
+
+/**
+ * Sensei REST API Course Progress Controller Unit Tests.
+ *
+ * @covers Sensei_REST_API_Course_Progress_Controller
+ */
+class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestCase {
+	use Sensei_Test_Login_Helpers;
+	use Sensei_Course_Enrolment_Test_Helpers;
+	/**
+	 * A server instance that we use in tests to dispatch requests.
+	 *
+	 * @var WP_REST_Server $server
+	 */
+	protected $server;
+
+	/**
+	 * Sensei post factory.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	/**
+	 * Test specific setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		do_action( 'rest_api_init' );
+
+		$this->factory = new Sensei_Factory();
+
+		self::resetEnrolmentProviders();
+		$this->prepareEnrolmentManager();
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		$this->factory->tearDown();
+	}
+
+	public function testDeleteCourseProgress_RequestGiven_ReturnsSuccessfulResponse() {
+		/* Arrange. */
+		$course_id  = $this->factory->course->create();
+		$lesson1_id = $this->factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$lesson2_id = $this->factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$student_id = $this->factory->user->create();
+
+		Sensei_Utils::user_start_course( $student_id, $course_id );
+		Sensei_Utils::update_lesson_status( $student_id, $lesson1_id, 'complete' );
+		Sensei_Utils::user_start_lesson( $student_id, $lesson2_id );
+
+		$this->login_as_admin();
+
+		/* Act. */
+		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				[
+					'student_ids' => [ $student_id ],
+					'course_ids'  => [ $course_id ],
+				]
+			)
+		);
+		ob_start();
+		$response = $this->server->dispatch( $request );
+		ob_end_clean(); // suppress output from \Sensei_Quiz::reset_user_lesson_data().
+
+		/* Assert. */
+		self::assertEquals( 200, $response->get_status() );
+	}
+
+	public function testDeleteCourseProgress_RequestGiven_ProgressReseted() {
+		/* Arrange. */
+		$course_id  = $this->factory->course->create();
+		$lesson1_id = $this->factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$lesson2_id = $this->factory->lesson->create( [ 'meta_input' => [ '_lesson_course' => $course_id ] ] );
+		$student_id = $this->factory->user->create();
+
+		Sensei_Utils::user_start_course( $student_id, $course_id );
+		Sensei_Utils::update_lesson_status( $student_id, $lesson1_id, 'complete' );
+		Sensei_Utils::user_start_lesson( $student_id, $lesson2_id );
+
+		$this->login_as_admin();
+
+		/* Act. */
+		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				[
+					'student_ids' => [ $student_id ],
+					'course_ids'  => [ $course_id ],
+				]
+			)
+		);
+		ob_start();
+		$this->server->dispatch( $request );
+		ob_end_clean(); // suppress output from \Sensei_Quiz::reset_user_lesson_data().
+
+		/* Assert. */
+		self::assertFalse( false, Sensei_Course::is_user_enrolled( $student_id, $course_id ) );
+	}
+
+	public function testDeleteCourseProgress_UserWithInsufficientPermissions_ReturnsForbiddenResponse() {
+		/* Arrange. */
+		$this->login_as_student();
+
+		/* Act. */
+		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				[
+					'student_ids' => [ 1 ],
+					'course_ids'  => [ 2 ],
+				]
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		/* Assert. */
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	public function testDeleteCourseProgress_UserNotFound_ReturnsSuccessfulResponse() {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+
+		$this->login_as_admin();
+
+		/* Act. */
+		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				[
+					'student_ids' => [ 999 ],
+					'course_ids'  => [ $course_id ],
+				]
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		/* Assert. */
+		self::assertSame( 200, $response->get_status() );
+	}
+
+	public function testDeleteCourseProgress_CourseNotFound_ReturnsForbiddenResponse() {
+		/* Arrange. */
+		$student_id = $this->factory->user->create();
+
+		$this->login_as_admin();
+
+		/* Act. */
+		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				[
+					'student_ids' => [ $student_id ],
+					'course_ids'  => [ 999 ],
+				]
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		/* Assert. */
+		self::assertSame( 403, $response->get_status() );
+	}
+
+}


### PR DESCRIPTION
Fixes part of #4959 

### Changes proposed in this Pull Request

* Add REST API endpoint to reset progress for students on courses.

### Testing instructions

* Get WP REST nonce (make sure you're logged in): http://devwp.local/wp-admin/admin-ajax.php?action=rest-nonce (replace devwp.local with your domain)
* Copy Cookie name and value
* Execute in terminal (replace WPNONCE, COOKIE-NAME & COOKIE-VALUE, USER_ID, COURSE_ID with actual values):
  ```
  curl -X "DELETE" "http://devwp.local/?rest_route=%2Fsensei-internal%2Fv1%2Fcourse-progress%2Fbatch&_wpnonce=WPNONCE" \
       -H 'Cookie: COOKIE-NAME=COOKIE-VALUE' \
       -H 'Content-Type: application/json; charset=utf-8' \
       -d $'{
    "student_ids": USER_ID,
    "course_ids": COURSE_ID
  }'
  ```
* Make sure you get status code 200 and your user has no progress on the course (but user is enrolled to the course).