### PR TITLE
Display ungraded quizzes for student when "Grading" menu item selected

### DIFF
--- a/assets/admin/students/student-action-menu/index.js
+++ b/assets/admin/students/student-action-menu/index.js
@@ -13,8 +13,11 @@ import StudentModal from '../student-modal';
 
 /**
  * Student action menu.
+ *
+ * @param {Object} props          Component props.
+ * @param {string} props.userName Student's user name.
  */
-export const StudentActionMenu = () => {
+export const StudentActionMenu = ( { userName } ) => {
 	const [ action, setAction ] = useState( '' );
 	const [ isModalOpen, setModalOpen ] = useState( false );
 	const closeModal = () => setModalOpen( false );
@@ -30,7 +33,11 @@ export const StudentActionMenu = () => {
 		},
 		{
 			title: __( 'Grading', 'sensei-lms' ),
-			onClick: () => {},
+			onClick: () =>
+				window.open(
+					`edit.php?post_type=course&page=sensei_grading&view=ungraded&s=${ userName }`,
+					'_self'
+				),
 		},
 	];
 
@@ -62,7 +69,10 @@ export const StudentActionMenu = () => {
 Array.from( document.getElementsByClassName( 'student-action-menu' ) ).forEach(
 	( actionMenu ) => {
 		render(
-			<StudentActionMenu userId={ actionMenu?.dataset?.userId } />,
+			<StudentActionMenu
+				userId={ actionMenu?.dataset?.userId }
+				userName={ actionMenu?.dataset?.userName }
+			/>,
 			actionMenu
 		);
 	}

--- a/assets/admin/students/student-action-menu/index.test.js
+++ b/assets/admin/students/student-action-menu/index.test.js
@@ -1,11 +1,12 @@
 /**
  * External dependencies
  */
-import { fireEvent, render } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
  */
+import apiFetch from '@wordpress/api-fetch';
 import { DOWN } from '@wordpress/keycodes';
 
 /**
@@ -13,25 +14,79 @@ import { DOWN } from '@wordpress/keycodes';
  */
 import { StudentActionMenu } from './index';
 
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
 describe( '<StudentActionMenu />', () => {
-	it( 'Should display the default options', () => {
-		const {
-			container: { firstChild: dropdownMenuContainer },
-			getByText,
-		} = render( <StudentActionMenu courseId="123" /> );
-		const button = dropdownMenuContainer.querySelector(
-			'.components-dropdown-menu__toggle'
-		);
+	it( 'Should display modal when "Add to Course" is selected', async () => {
+		apiFetch.mockImplementation( () => Promise.resolve( [] ) );
+		render( <StudentActionMenu /> );
 
 		// Open the dropdown menu.
+		const button = screen.getByRole( 'button' );
+
 		button.focus();
 		fireEvent.keyDown( button, {
 			keyCode: DOWN,
 			preventDefault: () => {},
 		} );
 
-		expect( getByText( 'Add to Course' ) ).toBeTruthy();
-		expect( getByText( 'Remove from Course' ) ).toBeTruthy();
-		expect( getByText( 'Grading' ) ).toBeTruthy();
+		// Click the "Add to Course" menu item.
+		const menuItem = screen.getByText( 'Add to Course' );
+
+		await act( async () => {
+			fireEvent.click( menuItem );
+		} );
+
+		expect( screen.getByRole( 'dialog' ) ).toBeTruthy();
+	} );
+
+	it( 'Should display modal when "Remove from Course" is selected', async () => {
+		apiFetch.mockImplementation( () => Promise.resolve( [] ) );
+		render( <StudentActionMenu /> );
+
+		// Open the dropdown menu.
+		const button = screen.getByRole( 'button' );
+
+		button.focus();
+		fireEvent.keyDown( button, {
+			keyCode: DOWN,
+			preventDefault: () => {},
+		} );
+
+		// Click the "Remove from Course" menu item.
+		const menuItem = screen.getByText( 'Remove from Course' );
+
+		await act( async () => {
+			fireEvent.click( menuItem );
+		} );
+
+		expect( screen.getByRole( 'dialog' ) ).toBeTruthy();
+	} );
+
+	it( "Should display student's ungraded quizzes when Grading menu item is selected", () => {
+		render( <StudentActionMenu userName="mary" /> );
+
+		// Open the dropdown menu.
+		const button = screen.getByRole( 'button' );
+
+		button.focus();
+		fireEvent.keyDown( button, {
+			keyCode: DOWN,
+			preventDefault: () => {},
+		} );
+
+		// Click the "Grading" menu item.
+		const menuItem = screen.getByText( 'Grading' );
+		const windowSpy = jest.spyOn( window, 'open' );
+
+		windowSpy.mockImplementation( () => null );
+		fireEvent.click( menuItem );
+
+		expect( windowSpy ).toBeCalledWith(
+			'edit.php?post_type=course&page=sensei_grading&view=ungraded&s=mary',
+			'_self'
+		);
+
+		windowSpy.mockRestore();
 	} );
 } );

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -169,7 +169,8 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 				'learner'  => $this->get_learner_html( $learner ),
 				'email'    => $learner->user_email,
 				'progress' => $courses,
-				'actions'  => '<div class="student-action-menu" data-user-id="' . esc_attr( $learner->user_id ) . '"></div>',
+				'actions'  => '<div class="student-action-menu" data-user-id="' . esc_attr( $learner->user_id ) .
+					'" data-user-name="' . esc_attr( $learner->user_login ) . '"></div>',
 			);
 		}
 

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -177,7 +177,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 				'email'              => $learner->user_email,
 				'progress'           => $courses,
 				'last_activity_date' => $last_activity_date,
-				'actions'  => '<div class="student-action-menu" data-user-id="' . esc_attr( $learner->user_id ) .
+				'actions'            => '<div class="student-action-menu" data-user-id="' . esc_attr( $learner->user_id ) .
 					'" data-user-name="' . esc_attr( $learner->user_login ) . '"></div>',
 			);
 		}


### PR DESCRIPTION
Partial fix for #4959.

### Changes proposed in this Pull Request
This PR hooks up the _Grading_ menu item to display ungraded quizzes for the student when selected (the other menu items are already hooked up). It also adds some tests for each menu item.

### Testing instructions
- Go to Students.
- Open the action menu for a student and select the _Grading_ option.
- Ensure the _Grading_ page opens, and is filtered to show ungraded quizzes for the selected student.