### PR TITLE
Refresh page after performing modal action

### DIFF
--- a/assets/admin/students/student-action-menu/index.js
+++ b/assets/admin/students/student-action-menu/index.js
@@ -17,7 +17,7 @@ import StudentModal from '../student-modal';
 export const StudentActionMenu = () => {
 	const [ action, setAction ] = useState( '' );
 	const [ isModalOpen, setModalOpen ] = useState( false );
-	const closeModal = ( { needsReload } ) => {
+	const closeModal = ( needsReload ) => {
 		if ( needsReload ) {
 			window.location.reload();
 		}

--- a/assets/admin/students/student-action-menu/index.js
+++ b/assets/admin/students/student-action-menu/index.js
@@ -17,7 +17,12 @@ import StudentModal from '../student-modal';
 export const StudentActionMenu = () => {
 	const [ action, setAction ] = useState( '' );
 	const [ isModalOpen, setModalOpen ] = useState( false );
-	const closeModal = () => setModalOpen( false );
+	const closeModal = ( { needsReload } ) => {
+		if ( needsReload ) {
+			window.location.reload();
+		}
+		setModalOpen( false );
+	};
 
 	const controls = [
 		{

--- a/assets/admin/students/student-modal/index.js
+++ b/assets/admin/students/student-modal/index.js
@@ -80,7 +80,7 @@ export const StudentModal = ( { action, onClose } ) => {
 		<Modal
 			className="sensei-student-modal"
 			title={ __( 'Choose Course', 'sensei-lms' ) }
-			onRequestClose={ ( args ) => onClose( { ...args, needsReload } ) }
+			onRequestClose={ () => onClose( needsReload ) }
 		>
 			<p>{ description }</p>
 

--- a/assets/admin/students/student-modal/index.js
+++ b/assets/admin/students/student-modal/index.js
@@ -11,14 +11,27 @@ import { __ } from '@wordpress/i18n';
 import CourseList from './course-list';
 import InputControl from '../../../blocks/editor-components/input-control';
 
+let needsReload = false;
+
 const AddButton = (
-	<Button className="sensei-student-modal__action--add" variant="primary">
+	<Button
+		className="sensei-student-modal__action--add"
+		variant="primary"
+		onClick={ () => {
+			needsReload = true;
+		} }
+	>
 		{ __( 'Add to Course', 'sensei-lms' ) }
 	</Button>
 );
 
 const RemoveButton = (
-	<Button className="sensei-student-modal__action--remove">
+	<Button
+		className="sensei-student-modal__action--remove"
+		onClick={ () => {
+			needsReload = true;
+		} }
+	>
 		{ __( 'Remove from Course', 'sensei-lms' ) }
 	</Button>
 );
@@ -67,7 +80,7 @@ export const StudentModal = ( { action, onClose } ) => {
 		<Modal
 			className="sensei-student-modal"
 			title={ __( 'Choose Course', 'sensei-lms' ) }
-			onRequestClose={ onClose }
+			onRequestClose={ ( args ) => onClose( { ...args, needsReload } ) }
 		>
 			<p>{ description }</p>
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/4959

### Changes proposed in this Pull Request

After performing any action from the modal, like adding students to courses, or removing them, we need to reflect that in the student management page. The change in this PR allows reloading the page.

It doesn't reload the page on closing the modal every time, it lets internal action choose whether to reload or not. For example, in the case of adding students to courses, we can choose to reload the page only if the request is successful.

### Testing instructions

- Add a few courses
- Add a few students
- Go to students management page in admin panel
- Open the action modal by clicking the action menu and choosing an option from the right of students row
- Close the modal without doing anything
- Observe that the page wasn't reloaded
- Open the modal again and click on the action button on the modal bottom right
- Close the modal again
- Observe that it gets refreshed this time

### Screenshot / Video

https://user-images.githubusercontent.com/6820724/162432056-19ff46e8-e4d3-4b04-b2bd-fd0a841df3c7.mov
