### PR TITLE
Update header on the Students page and add a doc link

### DIFF
--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -153,20 +153,17 @@ div.question_boolean_fields { margin-bottom: 10px; }
 }
 
 .sensei-custom-navigation__heading {
-	display: flex;
-	flex-flow: row wrap;
-	align-items: baseline;
-	justify-content: flex-start;
-	gap: 10px;
-}
+	&, &-with-info {
+		display: flex;
+		flex-flow: row wrap;
+		align-items: baseline;
+		justify-content: flex-start;
+		gap: 10px;
+	}
 
-.sensei-custom-navigation__heading-with-info {
-	display: flex;
-	flex-flow: row wrap;
-	align-items: baseline;
-	justify-content: flex-start;
-	gap: 10px;
-	width: 100%;
+	&-with-info {
+		width: 100%;
+	}
 }
 
 .sensei-custom-navigation__separator {

--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -149,7 +149,7 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	flex-flow: column wrap;
 	align-items: flex-start;
 	gap: 20px;
-	margin: 20px auto;
+	margin: 30px auto 20px;
 }
 
 .sensei-custom-navigation__heading {
@@ -158,6 +158,19 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	align-items: baseline;
 	justify-content: flex-start;
 	gap: 10px;
+}
+
+.sensei-custom-navigation__heading-with-info {
+	display: flex;
+	flex-flow: row wrap;
+	align-items: baseline;
+	justify-content: flex-start;
+	gap: 10px;
+	width: 100%;
+}
+
+.sensei-custom-navigation__separator {
+	flex: 1;
 }
 
 .sensei-custom-navigation__tabbar {

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -105,7 +105,50 @@ class Sensei_Learner_Management {
 			add_action( 'wp_ajax_remove_user_from_post', array( $this, 'remove_user_from_post' ) );
 			add_action( 'wp_ajax_reset_user_post', array( $this, 'reset_user_post' ) );
 			add_action( 'wp_ajax_sensei_json_search_users', array( $this, 'json_search_users' ) );
+
+			// Add custom navigation.
+			add_action( 'in_admin_header', [ $this, 'add_custom_navigation' ] );
 		}
+	}
+
+
+	/**
+	 * Add custom navigation to the admin pages.
+	 *
+	 * @since 4.0.0
+	 * @access private
+	 */
+	public function add_custom_navigation() {
+		$screen = get_current_screen();
+		if ( ! $screen ) {
+			return;
+		}
+
+		if ( in_array( $screen->id, [ 'course_page_sensei_learners' ], true ) && ( 'term' !== $screen->base ) ) {
+			$this->display_courses_navigation( $screen );
+		}
+	}
+
+	/**
+	 * Display the courses' navigation.
+	 *
+	 * @param WP_Screen $screen WordPress current screen object.
+	 */
+	private function display_courses_navigation( WP_Screen $screen ) {
+		?>
+		<div id="sensei-custom-navigation" class="sensei-custom-navigation">
+			<div class="sensei-custom-navigation__heading">
+				<div class="sensei-custom-navigation__title">
+					<h1><?php esc_html_e( 'Students', 'sensei-lms' ); ?></h1>
+				</div>
+				<div class="sensei-custom-navigation__links">
+					<a class="sensei-custom-navigation__info" target="_blank" href="https://senseilms.com/documentation/reports/?utm_source=plugin_sensei&utm_medium=docs&utm_campaign=reports">
+						<?php echo esc_html__( 'Guide To Using Reports', 'sensei-lms' ); ?>
+					</a>
+				</div>
+			</div>
+		</div>
+		<?php
 	}
 
 	/**

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -142,8 +142,8 @@ class Sensei_Learner_Management {
 					<h1><?php esc_html_e( 'Students', 'sensei-lms' ); ?></h1>
 				</div>
 				<div class="sensei-custom-navigation__separator"></div>
-				<a class="sensei-custom-navigation__info" target="_blank" href="https://senseilms.com/documentation/reports/?utm_source=plugin_sensei&utm_medium=docs&utm_campaign=reports">
-					<?php echo esc_html__( 'Guide To Using Reports', 'sensei-lms' ); ?>
+				<a class="sensei-custom-navigation__info" target="_blank" href="https://senseilms.com/documentation/?utm_source=plugin_sensei&utm_medium=docs&utm_campaign=student-management">
+					<?php echo esc_html__( 'Guide To Student Management', 'sensei-lms' ); ?>
 				</a>
 			</div>
 		</div>

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -137,15 +137,14 @@ class Sensei_Learner_Management {
 	private function display_courses_navigation( WP_Screen $screen ) {
 		?>
 		<div id="sensei-custom-navigation" class="sensei-custom-navigation">
-			<div class="sensei-custom-navigation__heading">
+			<div class="sensei-custom-navigation__heading-with-info">
 				<div class="sensei-custom-navigation__title">
 					<h1><?php esc_html_e( 'Students', 'sensei-lms' ); ?></h1>
 				</div>
-				<div class="sensei-custom-navigation__links">
-					<a class="sensei-custom-navigation__info" target="_blank" href="https://senseilms.com/documentation/reports/?utm_source=plugin_sensei&utm_medium=docs&utm_campaign=reports">
-						<?php echo esc_html__( 'Guide To Using Reports', 'sensei-lms' ); ?>
-					</a>
-				</div>
+				<div class="sensei-custom-navigation__separator"></div>
+				<a class="sensei-custom-navigation__info" target="_blank" href="https://senseilms.com/documentation/reports/?utm_source=plugin_sensei&utm_medium=docs&utm_campaign=reports">
+					<?php echo esc_html__( 'Guide To Using Reports', 'sensei-lms' ); ?>
+				</a>
 			</div>
 		</div>
 		<?php

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -125,7 +125,7 @@ class Sensei_Learner_Management {
 		}
 
 		if ( in_array( $screen->id, [ 'course_page_sensei_learners' ], true ) && ( 'term' !== $screen->base ) ) {
-			$this->display_courses_navigation( $screen );
+			$this->display_students_navigation( $screen );
 		}
 	}
 
@@ -134,7 +134,7 @@ class Sensei_Learner_Management {
 	 *
 	 * @param WP_Screen $screen WordPress current screen object.
 	 */
-	private function display_courses_navigation( WP_Screen $screen ) {
+	private function display_students_navigation( WP_Screen $screen ) {
 		?>
 		<div id="sensei-custom-navigation" class="sensei-custom-navigation">
 			<div class="sensei-custom-navigation__heading-with-info">

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -130,7 +130,7 @@ class Sensei_Learner_Management {
 	}
 
 	/**
-	 * Display the courses' navigation.
+	 * Display the Students' page navigation.
 	 *
 	 * @param WP_Screen $screen WordPress current screen object.
 	 */

--- a/includes/admin/views/html-admin-page-students-main.php
+++ b/includes/admin/views/html-admin-page-students-main.php
@@ -24,7 +24,6 @@ do_action( 'sensei_learner_admin_before_container' );
 <div id="woothemes-sensei" class="wrap woothemes-sensei">
 	<?php
 	do_action( 'sensei_learner_admin_wrapper_container', 'top' );
-	$sensei_list_table->output_headers();
 	?>
 
 	<div id="poststuff" class="sensei-learners-wrap">

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -328,12 +328,12 @@ class Sensei_Admin {
 	private function are_custom_admin_styles_allowed( $post_type, $hook_suffix, $screen ) {
 		$allowed_post_types      = apply_filters( 'sensei_scripts_allowed_post_types', array( 'lesson', 'course', 'question' ) );
 		$allowed_post_type_pages = apply_filters( 'sensei_scripts_allowed_post_type_pages', array( 'edit.php', 'post-new.php', 'post.php', 'edit-tags.php' ) );
-		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', Sensei_Analysis::PAGE_SLUG, 'sensei_learners', 'sensei_updates', 'sensei-settings', $this->lesson_order_page_slug, $this->course_order_page_slug ) );
+		$allowed_pages           = apply_filters( 'sensei_scripts_allowed_pages', array( 'sensei_grading', Sensei_Analysis::PAGE_SLUG, 'sensei_learners', 'sensei_updates', 'sensei-settings', 'sensei_learners', $this->lesson_order_page_slug, $this->course_order_page_slug ) );
 		$module_pages_screen_ids = [ 'edit-module' ];
 
 		$is_allowed_type           = isset( $post_type ) && in_array( $post_type, $allowed_post_types, true );
 		$is_allowed_post_type_page = isset( $hook_suffix ) && in_array( $hook_suffix, $allowed_post_type_pages, true );
-		$is_allowed_page           = isset( $_GET['page'] ) && in_array( $_GET['page'], $allowed_pages, true );
+		$is_allowed_page           = isset( $_GET['page'] ) && in_array( $_GET['page'], $allowed_pages, true ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		$is_modules_page           = $screen && in_array( $screen->id, $module_pages_screen_ids, true );
 
 		return ( $is_allowed_type && $is_allowed_post_type_page ) || $is_allowed_page || $is_modules_page;
@@ -397,7 +397,17 @@ class Sensei_Admin {
 	 * @return bool
 	 */
 	private function has_custom_navigation( $screen ) {
-		$screens_with_custom_navigation = [ 'edit-course', 'edit-course-category', 'edit-module', 'edit-lesson', 'edit-lesson-tag', 'edit-question', 'edit-question-category', 'course_page_' . Sensei_Analysis::PAGE_SLUG ];
+		$screens_with_custom_navigation = [
+			'edit-course',
+			'edit-course-category',
+			'edit-module',
+			'edit-lesson',
+			'edit-lesson-tag',
+			'edit-question',
+			'edit-question-category',
+			'course_page_' . Sensei_Analysis::PAGE_SLUG,
+			'course_page_sensei_learners',
+		];
 
 		return $screen
 			&& ( in_array( $screen->id, $screens_with_custom_navigation, true ) )


### PR DESCRIPTION
Fixes part of #4958

### Changes proposed in this Pull Request

* Add custom navigation with a doc link to Sensei website.

### Testing instructions

- Go to `Sensei LMS -> Students`
- Look at heading of the page.

### Screenshot / Video

<img width="1440" alt="CleanShot 2022-04-08 at 16 50 14@2x" src="https://user-images.githubusercontent.com/329356/162450163-25e57328-af52-4780-8e19-92ef30d5e84a.png">

<img width="689" alt="CleanShot 2022-04-08 at 16 50 54@2x" src="https://user-images.githubusercontent.com/329356/162450138-983c0a08-83c4-450b-98bc-1fde7924564f.png">

<img width="500" alt="CleanShot 2022-04-08 at 16 51 49@2x" src="https://user-images.githubusercontent.com/329356/162450094-56f7b586-cf33-4e15-a66c-904acb27077f.png">

I had to increase `margin-top` up to 30px to have doc link in the proper place:
<img width="1280" alt="CleanShot 2022-04-08 at 16 39 08@2x" src="https://user-images.githubusercontent.com/329356/162450263-c7d89995-d683-4fce-9cb0-72cf807444b0.png">


Otherwise, it looked this way:
<img width="1280" alt="CleanShot 2022-04-08 at 16 38 55@2x" src="https://user-images.githubusercontent.com/329356/162450276-2c62f475-14e8-4d23-a4fc-69687163db1c.png">


