### PR TITLE
Update appearance of the Students column content

### DIFF
--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -172,7 +172,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 				$last_activity_date = Sensei_Utils::format_last_activity_date( $item->last_activity_date );
 			}
 			$row_data = array(
-				'cb'                 => '<label class="screen-reader-text" for="cb-select-all-1">Select All</label><input type="checkbox" name="user_id" value="' . esc_attr( $learner->user_id ) . '" class="sensei_user_select_id">',
+				'cb'                 => '<label class="screen-reader-text">Select All</label><input type="checkbox" name="user_id" value="' . esc_attr( $learner->user_id ) . '" class="sensei_user_select_id">',
 				'learner'            => $this->get_learner_html( $learner ),
 				'email'              => $learner->user_email,
 				'progress'           => $courses,

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -236,14 +236,11 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	 * @return string The HTML.
 	 */
 	private function get_learner_html( $learner ) {
-		$login = $learner->user_login;
-		$title = Sensei_Learner::get_full_name( $learner->user_id );
+		$full_name = Sensei_Learner::get_full_name( $learner->user_id );
 		// translators: Placeholder is the full name of the learner.
-		$a_title = sprintf( esc_html__( 'Edit &#8220;%s&#8221;', 'sensei-lms' ), esc_html( $title ) );
-		$html    = '<strong><a class="row-title" href="' . esc_url( admin_url( 'user-edit.php?user_id=' . $learner->user_id ) ) . '" title="' . esc_attr( $a_title ) . '">' . esc_html( $login ) . '</a></strong>';
-		$html   .= ' <span>(<em>' . esc_html( $title ) . '</em>, ' . esc_html( $learner->user_email ) . ')</span>';
+		$a_title = sprintf( esc_html__( 'Edit &#8220;%s&#8221;', 'sensei-lms' ), esc_html( $full_name ) );
 
-		return $html;
+		return '<strong><a class="row-title" href="' . esc_url( admin_url( 'user-edit.php?user_id=' . $learner->user_id ) ) . '" title="' . esc_attr( $a_title ) . '">' . esc_html( $full_name ) . '</a></strong>';
 	}
 
 	/**

--- a/includes/class-sensei-list-table.php
+++ b/includes/class-sensei-list-table.php
@@ -213,41 +213,58 @@ class Sensei_List_Table extends WP_List_Table {
 	 */
 	function single_row( $item ) {
 		static $row_class = '';
-		$row_class        = ( $row_class == '' ? 'alternate' : '' );
+
+		$row_class   = ( $row_class == '' ? 'alternate' : '' );
+		$column_data = $this->get_row_data( $item );
 
 		echo '<tr class="' . esc_attr( $row_class ) . '">';
-
-		$column_data = $this->get_row_data( $item );
 
 		list( $columns, $hidden, $sortable, $primary ) = $this->get_column_info();
 
 		foreach ( $columns as $column_name => $column_display_name ) {
 			$classes = esc_attr( $column_name ) . ' column-' . esc_attr( $column_name );
+			$data    = '';
+			$style   = '';
+
 			if ( $primary === $column_name ) {
 				$classes .= ' column-primary';
+			} else if ( 'cb' === $column_name ) {
+				$classes .= ' check-column';
 			}
 
-			$style = '';
+			if ( 'cb' !== $column_name ) {
+				$data = 'data-colname="' . esc_attr( $column_display_name ) . '"';
+			}
+
 			if ( in_array( $column_name, $hidden ) ) {
-				$style = 'display:none;';
+				$style = 'style="display: none;"';
 			}
 
-			$data = 'data-colname="' . esc_attr( $column_display_name ) . '"';
-
-			$attributes = "class='$classes' $data style='$style'";
+			$attributes = "class='$classes' $data $style";
 
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $attributes escaped while preparation.
-			echo "<td $attributes>";
+			if ( 'cb' === $column_name ) {
+				// Checkbox element needs to be wrapped in a table header cell to have proper WordPress styles applied.
+				echo "<th $attributes>";
+			} else {
+				echo "<td $attributes>";
+			}
+
 			if ( isset( $column_data[ $column_name ] ) ) {
 				// $column_data is escaped in the individual get_row_data functions.
-
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in `get_row_data` method implementations.
 				echo $column_data[ $column_name ];
 			}
+
 			if ( $column_name === $primary ) {
 				echo '<button type="button" class="toggle-row"><span class="screen-reader-text">' . esc_html__( 'Show more details', 'sensei-lms' ) . '</span></button>';
 			}
-			echo '</td>';
+
+			if ( 'cb' === $column_name ) {
+				echo '</th>';
+			} else {
+				echo '</td>';
+			}
 		}
 
 		echo '</tr>';

--- a/includes/class-sensei-list-table.php
+++ b/includes/class-sensei-list-table.php
@@ -228,7 +228,7 @@ class Sensei_List_Table extends WP_List_Table {
 
 			if ( $primary === $column_name ) {
 				$classes .= ' column-primary';
-			} else if ( 'cb' === $column_name ) {
+			} elseif ( 'cb' === $column_name ) {
 				$classes .= ' check-column';
 			}
 
@@ -242,11 +242,12 @@ class Sensei_List_Table extends WP_List_Table {
 
 			$attributes = "class='$classes' $data $style";
 
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $attributes escaped while preparation.
 			if ( 'cb' === $column_name ) {
 				// Checkbox element needs to be wrapped in a table header cell to have proper WordPress styles applied.
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $attributes escaped when prepared.
 				echo "<th $attributes>";
 			} else {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $attributes escaped when prepared.
 				echo "<td $attributes>";
 			}
 


### PR DESCRIPTION
Fixes part of #4958

### Changes proposed in this Pull Request

* Display student's full name, without email

### Testing instructions

* Go to `Sensei LMS -> Students`
* Check Students column: you should see full name, otherwise the display name if full name is not specified.

### Screenshot / Video

<img width="1440" alt="CleanShot 2022-04-08 at 17 17 17@2x" src="https://user-images.githubusercontent.com/329356/162454436-dce97a28-e6dd-4d33-b2df-cac92fd3c327.png">

