### PR TITLE
Extends `OptionToggle` to be used with input

### DIFF
--- a/assets/blocks/quiz/answer-blocks/option-toggle.js
+++ b/assets/blocks/quiz/answer-blocks/option-toggle.js
@@ -8,6 +8,15 @@ import classnames from 'classnames';
  */
 import { check } from '@wordpress/icons';
 
+/**
+ * Toggle component using divs.
+ *
+ * @param {Object}  props            Component props.
+ * @param {string}  props.className  Class name for the wrapper.
+ * @param {boolean} props.isChecked  Whether it's checked.
+ * @param {boolean} props.isCheckbox Whether it's a checkbox.
+ * @param {Object}  props.children   Component children.
+ */
 export const OptionToggle = ( {
 	className,
 	isChecked,
@@ -28,8 +37,24 @@ export const OptionToggle = ( {
 				{ 'is-checked': isChecked, 'is-checkbox': isCheckbox }
 			) }
 		>
-			{ isChecked && isCheckbox && check }
+			{ isCheckbox && check }
 		</div>
 		{ children }
 	</div>
+);
+
+/**
+ * Toggle component using input.
+ *
+ * @param {Object} props      Component props.
+ * @param {string} props.type Input toggle type (`checkbox` or `radio`).
+ */
+export const InputToggle = ( props ) => (
+	<>
+		<input
+			className="sensei-lms-question-block__option-toggle-input"
+			{ ...props }
+		/>
+		<OptionToggle isCheckbox={ props.type === 'checkbox' } />
+	</>
 );

--- a/assets/blocks/quiz/answer-blocks/option-toggle.scss
+++ b/assets/blocks/quiz/answer-blocks/option-toggle.scss
@@ -1,8 +1,8 @@
-
 .sensei-lms-question-block__option-toggle {
 	color: inherit;
 	display: inline-flex;
 	align-items: center;
+
 	.edit-post-visual-editor & {
 		font-family: inherit;
 		font-size: inherit;
@@ -23,10 +23,10 @@
 		width: 26px;
 		height: 26px;
 		border-radius: 50%;
-		box-shadow: inset 0 0 0 1.5px currentColor;
+		box-sizing: border-box;
+		border: solid 1.5px currentColor;
 		position: relative;
 		align-items: center;
-
 
 		&:after {
 			position: absolute;
@@ -41,10 +41,6 @@
 			border-radius: 50%;
 		}
 
-		&.is-checked:after {
-			background: currentColor;
-		}
-
 		&.is-checkbox {
 			border-radius: 4px;
 			display: flex;
@@ -52,6 +48,7 @@
 			justify-content: center;
 
 			svg {
+				display: none;
 				width: 20px;
 				height: 20px;
 				fill: currentColor;
@@ -61,5 +58,44 @@
 				content: none;
 			}
 		}
+	}
+
+	&-input {
+		position: absolute;
+		z-index: 1;
+		opacity: 0;
+		width: 26px;
+		height: 26px;
+		margin: 0;
+		padding: 0;
+		cursor: pointer;
+	}
+
+	// Checked state.
+	&__control.is-checked,
+	&-input:checked + & &__control {
+		svg {
+			display: revert;
+		}
+
+		&::after {
+			background: currentColor;
+		}
+	}
+
+	&-input:disabled {
+		cursor: not-allowed;
+
+		& + .sensei-lms-question-block__option-toggle {
+			opacity: 0.3;
+		}
+	}
+
+	&-input:focus-visible + & &__control {
+		$box-shadow: 0 0 0 1.5px;
+
+		// Default styles for Firefox and Chrome.
+		box-shadow: $box-shadow Highlight;
+		box-shadow: $box-shadow -webkit-focus-ring-color;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It creates a new component called `InputToggle`, extending `OptionToggle`. The difference is that it uses `input`.
* For now, I just extended the `OptionToggle` and implemented it in the same context to avoid bigger changes. In the future, we can separate it.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a lesson with a quiz, including multiple-choice questions with radio and checkboxes (when it has more than one correct answer), and make sure it continues working properly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="399" alt="Screen Shot 2022-04-08 at 16 10 13" src="https://user-images.githubusercontent.com/876340/162508777-3e47eccb-4bcf-421a-bc33-e6a7d8a735d7.png">
