### PR TITLE
Fix mobile view on Students page

### DIFF
--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -172,7 +172,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 				$last_activity_date = Sensei_Utils::format_last_activity_date( $item->last_activity_date );
 			}
 			$row_data = array(
-				'cb'                 => '<label class="screen-reader-text" for="cb-select-all-1">Select All</label><input type="checkbox" name="user_id" value="' . esc_attr( $learner->user_id ) . '" class="sensei_user_select_id">',
+				'cb'                 => '<label class="screen-reader-text">Select All</label><input type="checkbox" name="user_id" value="' . esc_attr( $learner->user_id ) . '" class="sensei_user_select_id">',
 				'learner'            => $this->get_learner_html( $learner ),
 				'email'              => $learner->user_email,
 				'progress'           => $courses,

--- a/includes/class-sensei-list-table.php
+++ b/includes/class-sensei-list-table.php
@@ -213,41 +213,58 @@ class Sensei_List_Table extends WP_List_Table {
 	 */
 	function single_row( $item ) {
 		static $row_class = '';
-		$row_class        = ( $row_class == '' ? 'alternate' : '' );
+
+		$row_class   = ( $row_class == '' ? 'alternate' : '' );
+		$column_data = $this->get_row_data( $item );
 
 		echo '<tr class="' . esc_attr( $row_class ) . '">';
-
-		$column_data = $this->get_row_data( $item );
 
 		list( $columns, $hidden, $sortable, $primary ) = $this->get_column_info();
 
 		foreach ( $columns as $column_name => $column_display_name ) {
 			$classes = esc_attr( $column_name ) . ' column-' . esc_attr( $column_name );
+			$data    = '';
+			$style   = '';
+
 			if ( $primary === $column_name ) {
 				$classes .= ' column-primary';
+			} else if ( 'cb' === $column_name ) {
+				$classes .= ' check-column';
 			}
 
-			$style = '';
+			if ( 'cb' !== $column_name ) {
+				$data = 'data-colname="' . esc_attr( $column_display_name ) . '"';
+			}
+
 			if ( in_array( $column_name, $hidden ) ) {
-				$style = 'display:none;';
+				$style = 'style="display: none;"';
 			}
 
-			$data = 'data-colname="' . esc_attr( $column_display_name ) . '"';
-
-			$attributes = "class='$classes' $data style='$style'";
+			$attributes = "class='$classes' $data $style";
 
 			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $attributes escaped while preparation.
-			echo "<td $attributes>";
+			if ( 'cb' === $column_name ) {
+				// Checkbox element needs to be wrapped in a table header cell to have proper WordPress styles applied.
+				echo "<th $attributes>";
+			} else {
+				echo "<td $attributes>";
+			}
+
 			if ( isset( $column_data[ $column_name ] ) ) {
 				// $column_data is escaped in the individual get_row_data functions.
-
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in `get_row_data` method implementations.
 				echo $column_data[ $column_name ];
 			}
+
 			if ( $column_name === $primary ) {
 				echo '<button type="button" class="toggle-row"><span class="screen-reader-text">' . esc_html__( 'Show more details', 'sensei-lms' ) . '</span></button>';
 			}
-			echo '</td>';
+
+			if ( 'cb' === $column_name ) {
+				echo '</th>';
+			} else {
+				echo '</td>';
+			}
 		}
 
 		echo '</tr>';

--- a/includes/class-sensei-list-table.php
+++ b/includes/class-sensei-list-table.php
@@ -228,7 +228,7 @@ class Sensei_List_Table extends WP_List_Table {
 
 			if ( $primary === $column_name ) {
 				$classes .= ' column-primary';
-			} else if ( 'cb' === $column_name ) {
+			} elseif ( 'cb' === $column_name ) {
 				$classes .= ' check-column';
 			}
 
@@ -242,11 +242,12 @@ class Sensei_List_Table extends WP_List_Table {
 
 			$attributes = "class='$classes' $data $style";
 
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $attributes escaped while preparation.
 			if ( 'cb' === $column_name ) {
 				// Checkbox element needs to be wrapped in a table header cell to have proper WordPress styles applied.
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $attributes escaped when prepared.
 				echo "<th $attributes>";
 			} else {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- $attributes escaped when prepared.
 				echo "<td $attributes>";
 			}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request
Fixes the mobile view on the Students page.

### Testing instructions
- Go to the Students page.
- Decrease the screen to mobile size.
- Click the arrow to expand a row.
- Ensure the UI looks similar to the _After_ screenshot below.

### Screenshot / Video
_Before_

![Screen Shot 2022-04-11 at 9 48 13 AM](https://user-images.githubusercontent.com/1190420/162753752-dd68002d-09b5-4124-9c70-5d2c8597cce5.jpg)

_After_

![Screen Shot 2022-04-11 at 9 44 31 AM](https://user-images.githubusercontent.com/1190420/162753321-32bf079c-3ae7-4388-8a5f-763dc51dc4d8.jpg)