### PR TITLE
Return 404 if course not found and 403 for permission issues and update tests

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-course-progress-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-progress-controller.php
@@ -91,15 +91,25 @@ class Sensei_REST_API_Course_Progress_Controller extends \WP_REST_Controller {
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
-	 * @return bool
+	 * @return boolean|WP_Error
 	 */
-	public function batch_delete_items_permissions_check( WP_REST_Request $request ): bool {
+	public function batch_delete_items_permissions_check( WP_REST_Request $request ) {
 		$params          = $request->get_params();
 		$course_ids      = $params['course_ids'];
 		$edit_course_cap = get_post_type_object( 'course' )->cap->edit_post;
 		foreach ( $course_ids as $course_id ) {
 			$course = get_post( absint( $course_id ) );
-			if ( empty( $course ) || 'course' !== $course->post_type || ! current_user_can( $edit_course_cap, $course_id ) ) {
+			if ( empty( $course ) || 'course' !== $course->post_type ) {
+				return new WP_Error(
+					'sensei_course_student_batch_action_missing_course',
+					__( 'Course not found.', 'sensei-lms' ),
+					[
+						'status'    => 404,
+						'course_id' => $course_id,
+					]
+				);
+			}
+			if ( ! current_user_can( $edit_course_cap, $course_id ) ) {
 				return false;
 			}
 		}

--- a/includes/rest-api/class-sensei-rest-api-course-students-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-students-controller.php
@@ -119,15 +119,25 @@ class Sensei_REST_API_Course_Students_Controller extends \WP_REST_Controller {
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 *
-	 * @return bool
+	 * @return boolean|WP_Error
 	 */
-	public function batch_operation_permissions_check( WP_REST_Request $request ): bool {
+	public function batch_operation_permissions_check( WP_REST_Request $request ) {
 		$params          = $request->get_params();
 		$course_ids      = $params['course_ids'];
 		$edit_course_cap = get_post_type_object( 'course' )->cap->edit_post;
 		foreach ( $course_ids as $course_id ) {
 			$course = get_post( absint( $course_id ) );
-			if ( empty( $course ) || 'course' !== $course->post_type || ! current_user_can( $edit_course_cap, $course_id ) ) {
+			if ( empty( $course ) || 'course' !== $course->post_type ) {
+				return new WP_Error(
+					'sensei_course_student_batch_action_missing_course',
+					__( 'Course not found.', 'sensei-lms' ),
+					[
+						'status'    => 404,
+						'course_id' => $course_id,
+					]
+				);
+			}
+			if ( ! current_user_can( $edit_course_cap, $course_id ) ) {
 				return false;
 			}
 		}

--- a/tests/framework/trait-sensei-rest-api-test-helpers.php
+++ b/tests/framework/trait-sensei-rest-api-test-helpers.php
@@ -26,4 +26,20 @@ trait Sensei_REST_API_Test_Helpers {
 	public function assertMeetsSchema( $schema, $result ) {
 		$this->assertTrue( true === rest_validate_value_from_schema( $result, $schema ), 'Result does not match schema' );
 	}
+
+	/**
+	 * Get response code and status.
+	 *
+	 * @since 4.4.0
+	 *
+	 * @param WP_REST_Response $response Request response object.
+	 *
+	 * @return array Associative array containing the status and error code.
+	 */
+	public function getResponseAndStatusCode( WP_REST_Response $response ) {
+		return [
+			'status_code' => $response->get_status(),
+			'error_code'  => $response->get_data()['code'] ?? null,
+		];
+	}
 }

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-progress-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-progress-controller.php
@@ -8,6 +8,7 @@
 class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestCase {
 	use Sensei_Test_Login_Helpers;
 	use Sensei_Course_Enrolment_Test_Helpers;
+	use Sensei_REST_API_Test_Helpers;
 	/**
 	 * A server instance that we use in tests to dispatch requests.
 	 *
@@ -242,10 +243,14 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		$response = $this->server->dispatch( $request );
 
 		/* Assert. */
-		self::assertSame( 404, $response->get_status() );
+		$expected = [
+			'status_code' => 404,
+			'error_code'  => 'sensei_course_student_batch_action_missing_course',
+		];
+		self::assertSame( $expected, $this->getResponseAndStatusCode( $response ) );
 	}
 
-	public function testDeleteCourseProgress_PostInsteadOfCourseGiven_ReturnsForbiddenResponse() {
+	public function testDeleteCourseProgress_PostInsteadOfCourseGiven_ReturnsNotFoundResponse() {
 		/* Arrange. */
 		$post_id    = $this->factory->post->create();
 		$student_id = $this->factory->user->create();
@@ -266,6 +271,10 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		$response = $this->server->dispatch( $request );
 
 		/* Assert. */
-		self::assertSame( 404, $response->get_status() );
+		$expected = [
+			'status_code' => 404,
+			'error_code'  => 'sensei_course_student_batch_action_missing_course',
+		];
+		self::assertSame( $expected, $this->getResponseAndStatusCode( $response ) );
 	}
 }

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-progress-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-progress-controller.php
@@ -180,6 +180,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 	public function testDeleteCourseProgress_UserWithInsufficientPermissions_ReturnsForbiddenResponse() {
 		/* Arrange. */
 		$this->login_as_student();
+		$course_id = $this->factory->course->create();
 
 		/* Act. */
 		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
@@ -188,7 +189,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 			wp_json_encode(
 				[
 					'student_ids' => [ 1 ],
-					'course_ids'  => [ 2 ],
+					'course_ids'  => [ $course_id ],
 				]
 			)
 		);
@@ -221,7 +222,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		self::assertSame( 200, $response->get_status() );
 	}
 
-	public function testDeleteCourseProgress_CourseNotFound_ReturnsForbiddenResponse() {
+	public function testDeleteCourseProgress_CourseNotFound_ReturnsCourseNotFoundResponse() {
 		/* Arrange. */
 		$student_id = $this->factory->user->create();
 
@@ -241,7 +242,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		$response = $this->server->dispatch( $request );
 
 		/* Assert. */
-		self::assertSame( 403, $response->get_status() );
+		self::assertSame( 404, $response->get_status() );
 	}
 
 	public function testDeleteCourseProgress_PostInsteadOfCourseGiven_ReturnsForbiddenResponse() {
@@ -265,6 +266,6 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		$response = $this->server->dispatch( $request );
 
 		/* Assert. */
-		self::assertSame( 403, $response->get_status() );
+		self::assertSame( 404, $response->get_status() );
 	}
 }

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-students-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-students-controller.php
@@ -8,6 +8,7 @@
 class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestCase {
 	use Sensei_Test_Login_Helpers;
 	use Sensei_Course_Enrolment_Test_Helpers;
+	use Sensei_REST_API_Test_Helpers;
 	/**
 	 * A server instance that we use in tests to dispatch requests.
 	 *
@@ -161,7 +162,11 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$response = $this->server->dispatch( $request );
 
 		/* Assert. */
-		$this->assertSame( 404, $response->get_status() );
+		$expected = [
+			'status_code' => 404,
+			'error_code'  => 'sensei_course_student_batch_action_missing_course',
+		];
+		$this->assertSame( $expected, $this->getResponseAndStatusCode( $response ) );
 	}
 
 	public function testRemoveUsersFromCoursesApi_AfterApiExecution_StudentsAreActuallyRemoved() {
@@ -224,7 +229,11 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$response = $this->server->dispatch( $request );
 
 		/* Assert. */
-		$this->assertSame( 404, $response->get_status() );
+		$expected = [
+			'status_code' => 404,
+			'error_code'  => 'sensei_course_student_batch_action_missing_course',
+		];
+		$this->assertSame( $expected, $this->getResponseAndStatusCode( $response ) );
 	}
 
 	public function testRemoveUsersFromCoursesApi_IfAnyStudentDoesNotExist_ReturnsFalseForThatStudentAndTrueForOthers() {

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-students-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-students-controller.php
@@ -141,7 +141,7 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$this->assertSame( 403, $response->get_status() );
 	}
 
-	public function testAddUsersToCourses_CourseNotFoundGiven_ReturnsForbiddenResponse() {
+	public function testAddUsersToCourses_CourseNotFoundGiven_ReturnsCourseNotFoundResponse() {
 		/* Arrange. */
 		$student_id = $this->factory->user->create();
 
@@ -161,7 +161,7 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$response = $this->server->dispatch( $request );
 
 		/* Assert. */
-		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 404, $response->get_status() );
 	}
 
 	public function testRemoveUsersFromCoursesApi_AfterApiExecution_StudentsAreActuallyRemoved() {
@@ -205,9 +205,10 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$this->assertEquals( 0, $enrolled_course_count );
 	}
 
-	public function testRemoveUsersFromCoursesApi_IfCourseDoesNotExist_ReturnsUnauthorizedResponse() {
+	public function testRemoveUsersFromCoursesApi_IfPostFoundInsteadOfCourse_ReturnsCourseNotFound() {
 		/* Arrange. */
 		$this->login_as_admin();
+		$post_id = $this->factory->post->create();
 
 		/* Act. */
 		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-students/batch' );
@@ -216,14 +217,14 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 			wp_json_encode(
 				[
 					'student_ids' => [ 1 ],
-					'course_ids'  => [ 999 ],
+					'course_ids'  => [ $post_id ],
 				]
 			)
 		);
 		$response = $this->server->dispatch( $request );
 
 		/* Assert. */
-		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 404, $response->get_status() );
 	}
 
 	public function testRemoveUsersFromCoursesApi_IfAnyStudentDoesNotExist_ReturnsFalseForThatStudentAndTrueForOthers() {


### PR DESCRIPTION
Related to https://github.com/Automattic/sensei/issues/4959

### Changes proposed in this Pull Request

Previously we were returning a 403 from the course bulk actions API if the user did not have permission to edit the course or if the course was not found. Now we'll send a 404 if the course is not found.

### Testing instructions

- Create a few courses
- Create a few students
- Create a few normal posts
- Add some students to a few courses using this API https://github.com/Automattic/sensei/pull/4968
- Try hitting the API with post ids or post ids mixed with course ids
- Try hitting the API with random ids which do not match with any course or post
- Try hitting the API without nonce and cookies
- Try the same for this API as well https://github.com/Automattic/sensei/pull/4976
- Observe that you receive 403s and 404s properly

Here's a sample request exported from vscode's thunder client. You can import this to your client and change the URL, Cookie, Nonce, Course Ids and Student Ids to check easily
[thunder-collection_Sensei.json.zip](https://github.com/Automattic/sensei/files/8465144/thunder-collection_Sensei.json.zip)

