### PR TITLE
Update the view of Student management -> course progress column

### DIFF
--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -221,3 +221,17 @@ a.sensei-custom-navigation__info {
 .sensei-custom-navigation__links a.page-title-action:focus {
 	margin-left: 0;
 }
+
+.learner-overview-course-item {
+	display: block;
+	&.course-complete {
+		&:before {
+			font-family: dashicons;
+			content: "\f15e";
+			font-size: 170%;
+			vertical-align: bottom;
+			margin-right: 10px;
+			color: #7e7e7e;
+		}
+	}
+}

--- a/assets/js/learners-bulk-actions.js
+++ b/assets/js/learners-bulk-actions.js
@@ -209,10 +209,10 @@ jQuery( document ).ready( function () {
 			evt.preventDefault();
 			evt.stopPropagation();
 			var $elem = $( this ),
-				overviewDiv = $elem.siblings(
+				$overviewDiv = $elem.siblings(
 					'.learner-course-overview-detail'
 				);
-			overviewDiv.slideDown( 'slow' );
+			$overviewDiv.slideDown( 'slow' );
 			$( this ).slideUp( 'slow' );
 		} );
 

--- a/assets/js/learners-bulk-actions.js
+++ b/assets/js/learners-bulk-actions.js
@@ -209,16 +209,11 @@ jQuery( document ).ready( function () {
 			evt.preventDefault();
 			evt.stopPropagation();
 			var $elem = $( this ),
-				$overviewDiv = $elem
-					.siblings( '.learner-course-overview-detail' )
-					.first();
-
-			$learnerCourseOverviewDetail.filter( ':visible' ).slideUp( 'slow' );
-			if ( $overviewDiv.is( ':hidden' ) ) {
-				$overviewDiv.slideDown( 'slow' );
-			} else {
-				$overviewDiv.slideUp( 'slow' );
-			}
+				overviewDiv = $elem.siblings(
+					'.learner-course-overview-detail'
+				);
+			overviewDiv.slideDown( 'slow' );
+			$( this ).slideUp( 'slow' );
 		} );
 
 		$actionSelector.on( 'change', function () {

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -408,7 +408,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 			$courses            = explode( ',', $courses );
 			$courses_total      = count( $courses );
 			$courses_completed  = 0;
-			$visible_count      = 1;
+			$visible_count      = 3;
 			$completed_courses  = [];
 			$incomplete_courses = [];
 			foreach ( $courses as $i => $course_id ) {


### PR DESCRIPTION
Completes a part of https://github.com/Automattic/sensei/issues/4959

### Changes proposed in this Pull Request

In progress and Completed courses where being show as list of buttons in the Course Progress column in student management page. Changed that to show courses as URLs. To indicate completed courses, added a check sign on the left of the completed courses. Sorted the course list so that the In progress courses come on top followed by the completed courses. Only the first 3 are always shown by default, the rest can be made visible by clicking a '+n more' button if there are more than 3 courses.

### Testing instructions

- Add a few courses
- Add a few students
- Enrol students in courses, enroll some to more than three courses, some to equal, some to less than three
- Complete a few courses with some students, leave some courses incomplete
- Go to SenseiLMS->Students
- See if the course progress column has expected data
- Try expanding the course list with more button
- Check the order of the courses, check if the tick mark appears

### Screenshot / Video
![Screen Shot 2022-04-12 at 3 16 15 AM](https://user-images.githubusercontent.com/6820724/162834938-c208735f-18e3-439f-b351-6e8612a8379c.png)
