### PR TITLE
Show Add Students CTA when there are no students on the course

### DIFF
--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -141,6 +141,14 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	}
 }
 
+.sensei-students__call-to-action {
+	display: flex;
+	flex-flow: column;
+	margin: 20px auto;
+}
+.sensei-students__call-to-action div {
+	margin: 8px auto;
+}
 /**
  * Sensei custom navigation
  */

--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -145,10 +145,12 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	display: flex;
 	flex-flow: column;
 	margin: 20px auto;
+
+	div {
+		margin: 8px auto;
+	}
 }
-.sensei-students__call-to-action div {
-	margin: 8px auto;
-}
+
 /**
  * Sensei custom navigation
  */

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -267,7 +267,22 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	 * @see WP_List_Table
 	 */
 	public function no_items() {
-		$text = __( 'No students found.', 'sensei-lms' );
+		$course_id = (int) ( $this->query_args['filter_by_course_id'] ?? 0 );
+		if ( 0 === $course_id ) {
+			$text = __( 'No students found.', 'sensei-lms' );
+		} else {
+			$add_students_args = [
+				'post_type' => 'course',
+				'page'      => 'sensei_learners',
+				'course_id' => $course_id,
+				'view'      => 'learners',
+			];
+
+			$message = __( 'This course doesn\'t have any students yet, you can add them below.', 'sensei-lms' );
+			$button  = '<a class="button button-primary" href="' . esc_url( add_query_arg( $add_students_args, admin_url( 'edit.php' ) ) ) . '">' . __( 'Add Students', 'sensei-lms' ) . '</a>';
+			$text    = '<div class="sensei-students__call-to-action"><div>' . $message . '</div><div>' . $button . '</div></div>';
+		}
+
 		echo wp_kses_post( apply_filters( 'sensei_learners_no_items_text', $text ) );
 	}
 


### PR DESCRIPTION
Fixes part of #4958

### Changes proposed in this Pull Request

* Display Add Students button if a course is selected, but no students found.

### Testing instructions

* Create a new course.
* Go to `Students`.
* Select your new course in `Filter By Course` and apply filter.
* You see `Add Students` button.

### Screenshot / Video
<img width="1247" alt="CleanShot 2022-04-12 at 00 43 33@2x" src="https://user-images.githubusercontent.com/329356/162839857-37088fd9-6cf5-4578-a66a-8da73492f7ba.png">
<img width="758" alt="CleanShot 2022-04-12 at 00 44 16@2x" src="https://user-images.githubusercontent.com/329356/162839865-5140b5a2-03c2-4df5-92d8-0e05ba3fbd23.png">
<img width="479" alt="CleanShot 2022-04-12 at 00 44 25@2x" src="https://user-images.githubusercontent.com/329356/162839872-8b09dbdb-a433-4af7-a42f-94380bad4d46.png">

