### PR TITLE
Making `single-line` answer block component reusable.

### DIFF
--- a/assets/blocks/quiz/answer-blocks/single-line.js
+++ b/assets/blocks/quiz/answer-blocks/single-line.js
@@ -6,8 +6,8 @@ import { __ } from '@wordpress/i18n';
 /**
  * Question block single-line answer component.
  *
- * @param {Object} prop
- * @param {Object} prop.children
+ * @param {Object} props
+ * @param {Object} props.children
  */
 const SingleLineAnswer = ( { children } ) => {
 	return (

--- a/assets/blocks/quiz/answer-blocks/single-line.js
+++ b/assets/blocks/quiz/answer-blocks/single-line.js
@@ -5,14 +5,19 @@ import { __ } from '@wordpress/i18n';
 
 /**
  * Question block single-line answer component.
+ *
+ * @param {Object} prop
+ * @param {Object} prop.children
  */
-const SingleLineAnswer = () => {
+const SingleLineAnswer = ( { children } ) => {
 	return (
 		<div className="sensei-lms-question-block__answer sensei-lms-question-block__answer--single-line">
 			<small className="sensei-lms-question-block__input-label">
 				{ __( 'Answer:', 'sensei-lms' ) }
 			</small>
-			<div className="sensei-lms-question-block__text-input-placeholder" />
+			<div className="sensei-lms-question-block__text-input-placeholder">
+				{ children }
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
Fixes partially [#883](883-gh-Automattic/sensei-pro)

### Changes proposed in this Pull Request
* Make single-line editor component to accept contents for the placeholder as children.

### Testing instructions
* Checkout to the branch.
* See that single-line question block can be added to the quizz as previously (correct answer can not be edited and only a placeholder for user input is shown).

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
<img width="735" alt="image" src="https://user-images.githubusercontent.com/799065/163140801-af5d8df9-a658-4ba3-bf9f-20e1e759658f.png">
