### PR TITLE
Update students per course table column header and content

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -225,7 +225,6 @@
 		.enrolment_status  {
 			span  {
 				display: inline-block;
-				padding: 5px 10px;
 				@include border_radius(3px);
 				white-space: nowrap;
 			}

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -172,8 +172,8 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		switch ( $this->view ) {
 			case 'learners':
 				$columns = array(
-					'title'            => __( 'Student', 'sensei-lms' ),
-					'enrolment_status' => __( 'Enrollment', 'sensei-lms' ),
+					'title'            => __( 'Students', 'sensei-lms' ),
+					'enrolment_status' => __( 'Enrolled', 'sensei-lms' ),
 					'user_status'      => __( 'Status', 'sensei-lms' ),
 					'date_started'     => __( 'Date Started', 'sensei-lms' ),
 					'date_completed'   => __( 'Date Completed', 'sensei-lms' ),
@@ -387,54 +387,26 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 				}
 
-				if ( 'complete' === $user_activity->comment_approved || 'graded' === $user_activity->comment_approved || 'passed' === $user_activity->comment_approved ) {
-
-					$progress_status_html =
-						'<span class="graded">' .
-							esc_html__( 'Completed', 'sensei-lms' ) .
-						'</span>';
-
+				if ( in_array( $user_activity->comment_approved, [ 'complete', 'graded', 'passed' ], true ) ) {
+					$progress_status_html = esc_html__( 'Completed', 'sensei-lms' );
 				} else {
-
-					if ( 'course' === $post_type && 0 === Sensei_Utils::user_started_lesson_count( $post_id, $user_activity->user_id ) ) {
-						$progress_status_html =
-							'<span class="not-started">' .
-							esc_html__( 'Not Started', 'sensei-lms' ) .
-							'</span>';
-					} else {
-						$progress_status_html =
-							'<span class="in-progress">' .
-							esc_html__( 'In Progress', 'sensei-lms' ) .
-							'</span>';
-					}
+					$user_not_started     = 'course' === $post_type && 0 === Sensei_Utils::user_started_lesson_count( $post_id, $user_activity->user_id );
+					$progress_status_html = $user_not_started ? esc_html__( 'Not Started', 'sensei-lms' ) : esc_html__( 'In Progress', 'sensei-lms' );
 				}
 
-				$is_user_enrolled  = Sensei_Course::is_user_enrolled( $this->course_id, $user_activity->user_id );
-				$course_enrolment  = Sensei_Course_Enrolment::get_course_instance( $this->course_id );
-				$enrolment_results = $course_enrolment->get_enrolment_check_results( $user_activity->user_id );
-				$provider_results  = [];
-
-				if ( $enrolment_results ) {
-					$provider_results = $enrolment_results->get_provider_results();
-				}
-
+				$is_user_enrolled       = Sensei_Course::is_user_enrolled( $this->course_id, $user_activity->user_id );
+				$course_enrolment       = Sensei_Course_Enrolment::get_course_instance( $this->course_id );
+				$enrolment_results      = $course_enrolment->get_enrolment_check_results( $user_activity->user_id );
+				$provider_results       = $enrolment_results ? $enrolment_results->get_provider_results() : [];
 				$enrolment_tooltip_html = '';
 
 				if ( Sensei()->feature_flags->is_enabled( 'enrolment_provider_tooltip' ) ) {
 					if ( ! empty( $provider_results ) ) {
-						$enrolment_tooltip_html   = [];
-						$enrolment_tooltip_html[] = '<ul class="enrolment-helper">';
+						$enrolment_tooltip_html = [ '<ul class="enrolment-helper">' ];
 
 						foreach ( $provider_results as $id => $result ) {
-							$name = Sensei_Course_Enrolment_Manager::instance()->get_enrolment_provider_name_by_id( $id );
-							if ( ! $name ) {
-								$name = $id;
-							}
-
-							$item_class = 'does-not-provide-enrolment';
-							if ( $result ) {
-								$item_class = 'provides-enrolment';
-							}
+							$name       = Sensei_Course_Enrolment_Manager::instance()->get_enrolment_provider_name_by_id( $id ) ?? $id;
+							$item_class = $result ? 'provides-enrolment' : 'does-not-provide-enrolment';
 
 							$enrolment_tooltip_html[] =
 								'<li class="' . esc_attr( $item_class ) . '">' .
@@ -449,16 +421,10 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 					}
 				}
 
-				if ( $is_user_enrolled ) {
-					$enrolment_label             = __( 'Enrolled', 'sensei-lms' );
-					$enrolment_label_extra_class = 'enrolled';
-				} else {
-					$enrolment_label             = __( 'Not Enrolled', 'sensei-lms' );
-					$enrolment_label_extra_class = 'not-enrolled';
-				}
+				$enrolment_label = $is_user_enrolled ? __( 'Yes', 'sensei-lms' ) : __( 'No', 'sensei-lms' );
 
 				$enrolment_status_html =
-					'<span class="sensei-tooltip ' . esc_attr( $enrolment_label_extra_class ) . '" data-tooltip="' . esc_attr( htmlentities( $enrolment_tooltip_html ) ) . '">' .
+					'<span class="sensei-tooltip" data-tooltip="' . esc_attr( htmlentities( $enrolment_tooltip_html ) ) . '">' .
 						esc_html( $enrolment_label ) .
 					'</span>';
 

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -574,7 +574,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 								implode( ' | ', $row_actions ) .
 							'</div>',
 						'date_started'     => $date_input,
-						'date_completed'   => ( 'complete' === $user_activity->comment_approved ) ? $user_activity->comment_date : '',
+						'date_completed'   => ( 'complete' === $user_activity->comment_approved ) ? $user_activity->comment_date : '-',
 						'user_status'      => $progress_status_html,
 						'enrolment_status' => $enrolment_status_html,
 						'actions'          => implode( ' ', $actions ),

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-lessons.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-lessons.php
@@ -99,7 +99,7 @@ class Sensei_Reports_Overview_List_Table_Lessons_Test extends WP_UnitTestCase {
 			wp_update_comment(
 				[
 					'comment_ID'   => $lesson_activity_comment_id,
-					'comment_date' => gmdate( 'Y-m-d H:i:s', strtotime( ( $days_count * 24 ) - 6 . ' hours' ) ),
+					'comment_date' => gmdate( 'Y-m-d H:i:s', strtotime( ( $days_count * 24 ) . ' hours' ) ),
 				]
 			);
 			$days_count++;


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/4957

### Changes proposed in this Pull Request

In the student per course page, changed the column header student to students, enrollment to enrolled.
Changed the content of enrolled to Yes/No replacing the previous way of showing different statuses. Also removed the icon from the left of course status, fixed some padding for a better view on desktop and mobile. Also refactored some codes to simplify.

### Testing instructions

- Create a few courses
- Create a few students
- Enrol a few students in those courses
- Complete a few, leave a few enrolled but fully incomplete and partially complete, leave a few unenrolled.
- Go to SenseiLMS->Students. Select a course from the course progress column
- Check if the column headers and values are loading as expected for different courses and students
- Check the table on mobile as well

### Screenshot / Video
Desktop -
![image](https://user-images.githubusercontent.com/6820724/163158316-df4a8d0c-e32d-42ce-832b-83877e8e5c0a.png)
Mobile -
![image](https://user-images.githubusercontent.com/6820724/163158619-e5758838-3a44-4ffd-a6ae-709017033f28.png)