### PR TITLE
Update/add totals to students column in students

### DIFF
--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -101,7 +101,11 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	public function get_columns() {
 		$columns = array(
 			'cb'                 => '<label class="screen-reader-text" for="cb-select-all-1">Select All</label><input id="cb-select-all-1" type="checkbox">',
-			'learner'            => __( 'Student', 'sensei-lms' ),
+			'learner'            => sprintf(
+				// translators: placeholder is the total number of students.
+				__( 'Students (%d)', 'sensei-lms' ),
+				esc_html( $this->total_items )
+			),
 			'email'              => __( 'Email', 'sensei-lms' ),
 			'progress'           => __( 'Course Progress', 'sensei-lms' ),
 			'last_activity_date' => __( 'Last Activity', 'sensei-lms' ),


### PR DESCRIPTION
Relates #4958

### Changes proposed in this Pull Request
* Change Student -> Students like it is in the designs 
<img width="287" alt="image" src="https://user-images.githubusercontent.com/7208249/163190223-7ddd1899-b2f9-43a2-aadc-6d1f15e3ff44.png">

### Testing instructions
- Open Students page check there is total next to the Students column title like in the image underneath: 
<img width="287" alt="image" src="https://user-images.githubusercontent.com/7208249/163190274-1a9f1975-1675-4b21-8234-433c086c2b9c.png">
- The number should be the same as the number above the table
