### PR TITLE
Add the ability to search courses in the modal

### DIFF
--- a/assets/admin/students/student-modal/course-list-fetch.test.js
+++ b/assets/admin/students/student-modal/course-list-fetch.test.js
@@ -1,0 +1,48 @@
+/**
+ * External dependencies
+ */
+import { render, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import { CourseList } from './course-list';
+import httpClient from '../../lib/http-client';
+
+jest.mock( '../../lib/http-client' );
+
+describe( 'CourseList fetch', () => {
+	beforeEach( () => {
+		httpClient.mockImplementation( () => Promise.resolve( [] ) );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'Should append a search param to the URL', async () => {
+		render( <CourseList searchQuery="abc123" /> );
+
+		await waitFor(
+			() =>
+				expect( httpClient ).toHaveBeenCalledWith( {
+					path: '/wp/v2/courses?per_page=100&search=abc123',
+					method: 'GET',
+				} ),
+			{ timeout: 450 }
+		);
+	} );
+
+	it( 'Should NOT append a search param to the URL', async () => {
+		render( <CourseList searchQuery="" /> );
+
+		await waitFor(
+			() =>
+				expect( httpClient ).toHaveBeenCalledWith( {
+					path: '/wp/v2/courses?per_page=100',
+					method: 'GET',
+				} ),
+			{ timeout: 450 }
+		);
+	} );
+} );

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -105,32 +105,6 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 	);
 
 	// Fetch the courses.
-	useEffect( () => {
-		fetchCourses( searchQuery );
-
-		httpClient( {
-			path: '/wp/v2/courses?per_page=100' +
-				( searchQuery ? `&search=${ searchQuery }` : '' ),
-			method: 'GET',
-		} )
-			.then( ( result ) => {
-				if ( isMounted.current ) {
-					setCourses( result );
-				}
-			} )
-			.catch( () => {
-				if ( isMounted.current ) {
-					setIsFetching( false );
-				}
-			} )
-			.finally( () => {
-				if ( isMounted.current ) {
-					setIsFetching( false );
-				}
-			} );
-		return () => ( isMounted.current = false );
-	}, [ fetchCourses, searchQuery ] );
-
 	const fetchCourses = useCallback(
 		debounce( ( query ) => {
 			setIsFetching( true );
@@ -142,7 +116,7 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 			} )
 				.then( ( result ) => {
 					if ( isMounted.current ) {
-						setCourses( result.data );
+						setCourses( result );
 					}
 				} )
 				.catch( () => {
@@ -158,6 +132,12 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 		}, 400 ),
 		[]
 	);
+
+	useEffect( () => {
+		fetchCourses( searchQuery );
+
+		return () => ( isMounted.current = false );
+	}, [ fetchCourses, searchQuery ] );
 
 	return (
 		<>

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -24,6 +24,24 @@ import httpClient from '../../lib/http-client';
  */
 
 /**
+ * Loading course list component.
+ */
+const LoadingCourseList = () => (
+	<li className="sensei-student-modal__course-list--loading">
+		<Spinner />
+	</li>
+);
+
+/**
+ * Empty course list component.
+ */
+const EmptyCourseList = () => (
+	<li className="sensei-student-modal__course-list--empty">
+		{ __( 'No courses found.', 'sensei-lms' ) }
+	</li>
+);
+
+/**
  * Course item.
  *
  * @param {Object}        props
@@ -141,31 +159,26 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 		[]
 	);
 
-	if ( isFetching ) {
-		return (
-			<div className="sensei-student-modal__course-list--loading">
-				<Spinner />
-			</div>
-		);
-	}
-
-	if ( 0 === courses.length ) {
-		return <p>{ __( 'No courses found.', 'sensei-lms' ) }</p>;
-	}
-
 	return (
 		<>
 			<span className="sensei-student-modal__course-list__header">
 				{ __( 'Your Courses', 'sensei-lms' ) }
 			</span>
 			<ul className="sensei-student-modal__course-list">
-				{ courses.map( ( course ) => (
-					<CourseItem
-						key={ course.id }
-						course={ course }
-						onChange={ selectCourse }
-					/>
-				) ) }
+				{ isFetching && <LoadingCourseList /> }
+
+				{ ! isFetching && 0 === courses.length && <EmptyCourseList /> }
+
+				{ ! isFetching &&
+					0 < courses.length &&
+					courses.map( ( course ) => (
+						<CourseItem
+							key={ course.id }
+							course={ course }
+							onChange={ selectCourse }
+						/>
+					) )
+				}
 			</ul>
 		</>
 	);

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -85,7 +85,7 @@ const CourseItem = ( { course, onChange } ) => {
  *
  * @param {Object}                  props
  * @param {string}                  props.searchQuery Course to search for.
- * @param {onCourseSelectionChange} props.onChange Event triggered when a course is selected or unselected
+ * @param {onCourseSelectionChange} props.onChange    Event triggered when a course is selected or unselected
  */
 export const CourseList = ( { searchQuery, onChange } ) => {
 	const [ isFetching, setIsFetching ] = useState( true );
@@ -110,8 +110,9 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 			setIsFetching( true );
 
 			httpClient( {
-				url: '/wp-json/wp/v2/courses?per_page=100' +
-					( searchQuery ? `&search=${ searchQuery }` : '' ),
+				path:
+					'/wp/v2/courses?per_page=100' +
+					( query ? `&search=${ query }` : '' ),
 				method: 'GET',
 			} )
 				.then( ( result ) => {
@@ -157,8 +158,7 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 							course={ course }
 							onChange={ selectCourse }
 						/>
-					) )
-				}
+					) ) }
 			</ul>
 		</>
 	);

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -91,7 +91,6 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 	const [ isFetching, setIsFetching ] = useState( true );
 	const [ courses, setCourses ] = useState( [] );
 	const selectedCourses = useRef( [] );
-	const isMounted = useRef( true );
 
 	const selectCourse = useCallback(
 		( { isSelected, course } ) => {
@@ -116,19 +115,13 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 				method: 'GET',
 			} )
 				.then( ( result ) => {
-					if ( isMounted.current ) {
-						setCourses( result );
-					}
+					setCourses( result );
 				} )
 				.catch( () => {
-					if ( isMounted.current ) {
-						setIsFetching( false );
-					}
+					setIsFetching( false );
 				} )
 				.finally( () => {
-					if ( isMounted.current ) {
-						setIsFetching( false );
-					}
+					setIsFetching( false );
 				} );
 		}, 400 ),
 		[]
@@ -136,8 +129,6 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 
 	useEffect( () => {
 		fetchCourses( searchQuery );
-
-		return () => ( isMounted.current = false );
 	}, [ fetchCourses, searchQuery ] );
 
 	return (

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -61,9 +61,10 @@ const CourseItem = ( { course, onChange } ) => {
  * Course list.
  *
  * @param {Object}                  props
+ * @param {string}                  props.searchQuery Course to search for.
  * @param {onCourseSelectionChange} props.onChange Event triggered when a course is selected or unselected
  */
-export const CourseList = ( { onChange } ) => {
+export const CourseList = ( { searchQuery, onChange } ) => {
 	const [ isFetching, setIsFetching ] = useState( true );
 	const [ courses, setCourses ] = useState( [] );
 	const selectedCourses = useRef( [] );
@@ -85,7 +86,8 @@ export const CourseList = ( { onChange } ) => {
 		setIsFetching( true );
 
 		httpClient( {
-			path: '/wp/v2/courses?per_page=100',
+			path: '/wp/v2/courses?per_page=100' +
+				( searchQuery ? `&search=${ searchQuery }` : '' ),
 			method: 'GET',
 		} )
 			.then( ( result ) => {
@@ -104,7 +106,7 @@ export const CourseList = ( { onChange } ) => {
 				}
 			} );
 		return () => ( isMounted.current = false );
-	}, [] );
+	}, [ searchQuery ] );
 
 	if ( isFetching ) {
 		return (

--- a/assets/admin/students/student-modal/course-list.test.js
+++ b/assets/admin/students/student-modal/course-list.test.js
@@ -24,8 +24,6 @@ const courses = [
 	},
 ];
 
-const timeoutValue = 500;
-
 describe( '<CourseList />', () => {
 	beforeAll( () => {
 		nock( 'http://localhost' )

--- a/assets/admin/students/student-modal/course-list.test.js
+++ b/assets/admin/students/student-modal/course-list.test.js
@@ -24,6 +24,8 @@ const courses = [
 	},
 ];
 
+const timeoutValue = 500;
+
 describe( '<CourseList />', () => {
 	beforeAll( () => {
 		nock( 'http://localhost' )
@@ -44,6 +46,7 @@ describe( '<CourseList />', () => {
 
 	it( 'Should call onChange with the selected courses when a course is selected', async () => {
 		const onChange = jest.fn();
+
 		render( <CourseList onChange={ onChange } /> );
 
 		fireEvent.click(
@@ -61,6 +64,7 @@ describe( '<CourseList />', () => {
 
 	it( 'Should remove unselected items when a course is selected and deselected', async () => {
 		const onChange = jest.fn();
+
 		render( <CourseList onChange={ onChange } /> );
 
 		fireEvent.click(

--- a/assets/admin/students/student-modal/index.js
+++ b/assets/admin/students/student-modal/index.js
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { Button, Modal, Spinner } from '@wordpress/components';
+import { useCallback, useRef, useState, useEffect } from '@wordpress/element';
 import { search } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 
@@ -15,7 +16,6 @@ import httpClient from '../../lib/http-client';
 /**
  * External dependencies
  */
-import { useCallback, useRef, useState, useEffect } from '@wordpress/element';
 
 const POSSIBLE_ACTIONS = {
 	add: {
@@ -103,6 +103,10 @@ export const StudentModal = ( { action, onClose, students } ) => {
 		}
 	}, [ sendAction, students, selectedCourses, onClose ] );
 
+	const [ searchQuery, setSearchQuery ] = useState( '' );
+
+	const searchCourses = ( value ) => setSearchQuery( value );
+
 	return (
 		<Modal
 			className="sensei-student-modal"
@@ -112,12 +116,16 @@ export const StudentModal = ( { action, onClose, students } ) => {
 			<p>{ description }</p>
 
 			<InputControl
-				placeholder={ __( 'Search courses', 'sensei-lms' ) }
 				iconRight={ search }
+				onChange={ searchCourses }
+				placeholder={ __( 'Search courses', 'sensei-lms' ) }
+				value={ searchQuery }
 			/>
 
 			{ hasError && <h1>Sorry, something went wrong</h1> }
+
 			<CourseList
+				searchQuery={ searchQuery }
 				onChange={ ( courses ) => {
 					setCourses( courses );
 				} }

--- a/assets/admin/students/student-modal/index.js
+++ b/assets/admin/students/student-modal/index.js
@@ -79,6 +79,7 @@ export const StudentModal = ( { action, onClose, students } ) => {
 		isDestructive,
 	} = POSSIBLE_ACTIONS[ action ];
 	const [ selectedCourses, setCourses ] = useState( [] );
+	const [ searchQuery, setSearchQuery ] = useState( '' );
 	const [ isSending, setIsSending ] = useState( false );
 	const [ hasError, setError ] = useState( false );
 	const isMounted = useRef( true );
@@ -102,8 +103,6 @@ export const StudentModal = ( { action, onClose, students } ) => {
 			}
 		}
 	}, [ sendAction, students, selectedCourses, onClose ] );
-
-	const [ searchQuery, setSearchQuery ] = useState( '' );
 
 	const searchCourses = ( value ) => setSearchQuery( value );
 

--- a/assets/admin/students/student-modal/student-modal.scss
+++ b/assets/admin/students/student-modal/student-modal.scss
@@ -6,7 +6,7 @@
 
 	&__course-list {
 		border: 1px solid #8c8f94;
-		height: auto;
+		height: 300px;
 		max-height: calc(100vh - 340px);
 		overflow: auto;
 
@@ -14,14 +14,15 @@
 			max-height: 300px;
 		}
 
-		&--loading {
-			text-align: center;
-			padding: 20px;
-		}
-
 		&__header {
 			display: block;
 			margin-top: 30px;
+		}
+
+		&--loading,
+		&--empty {
+			padding-top: 1em;
+			text-align: center;
 		}
 
 		&__item {


### PR DESCRIPTION
Partial fix for #4959.

### Changes proposed in this Pull Request
This PR adds the ability to search for specific courses in the modal.

### Testing instructions
- Open the modal on the Students page.
- The spinner should be displayed while courses are being searched.
- Open the Network > Fetch/XHR tab in DevTools.
- Enter some text to search for.
- Depending on how fast you type, you should not see an API call for every keystroke. The API is called 400ms after you stop typing.
- Ensure that the height of the course list (bordered area) remains fixed and is not jumpy when moving between the following states:
  - When the loading spinner is displayed
  - When courses are displayed
  - When no courses are found

### Screenshot / Video

__Loading__

![loading](https://user-images.githubusercontent.com/1190420/163210343-ce48c907-8475-45c6-8221-a59ea7fe2e13.jpg)

__No Courses__

![empty](https://user-images.githubusercontent.com/1190420/163210293-ee55f21a-5607-4cdf-a85b-b2639a59abf1.jpg)

__Course List__

![courses](https://user-images.githubusercontent.com/1190420/163210392-6ede85da-541f-49a4-aa7c-138b0a02730a.jpg)