### PR TITLE
Update navigation for the Students per course page

### DIFF
--- a/assets/css/admin-custom.scss
+++ b/assets/css/admin-custom.scss
@@ -141,6 +141,13 @@ div.question_boolean_fields { margin-bottom: 10px; }
 	}
 }
 
+.sensei-students__subheading {
+	a {
+		color: $text_primary;
+		text-decoration: none;
+	}
+}
+
 .sensei-students__call-to-action {
 	display: flex;
 	flex-flow: column;

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -377,7 +377,7 @@ class Sensei_Learner_Management {
 					'post_type' => $this->menu_post_type,
 					'page'      => $this->page_slug,
 					'course_id' => $course_id,
-					'view'      => 'learners',
+					'view'      => 'lessons',
 				),
 				admin_url( 'edit.php' )
 			);

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -391,21 +391,15 @@ class Sensei_Learner_Management {
 			);
 		}
 
-		$title = '';
+		$title_parts = [];
 		if ( 0 < $course_id ) {
-			$title .= get_the_title( $course_id );
+			$title_parts[] = get_the_title( $course_id );
 		}
-
-		if ( 0 < $lesson_id ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-
-			if ( ! empty( $title ) ) {
-				$title .= ': ';
-			}
-			$title .= get_the_title( $lesson_id );
+		if ( 0 < $lesson_id ) {
+			$title_parts[] = get_the_title( $lesson_id );
 		}
-
 		$back_link = '<a href="' . esc_url( $back_url ) . '">←</a> ';
-		$title     = $back_link . $title;
+		$title     = $back_link . implode( ': ', $title_parts );
 		?>
 			<h2 class="sensei-students__subheading">
 				<?php

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -368,10 +368,11 @@ class Sensei_Learner_Management {
 	 * @since  1.6.0
 	 */
 	public function learners_default_nav() {
-		$title = $this->name;
-		if ( isset( $_GET['course_id'] ) ) {
-			$course_id = intval( $_GET['course_id'] );
-			$url       = add_query_arg(
+		$course_id = (int) sanitize_text_field( wp_unslash( $_GET['course_id'] ?? 0 ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$lesson_id = (int) sanitize_text_field( wp_unslash( $_GET['lesson_id'] ?? 0 ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		if ( 0 < $course_id && 0 < $lesson_id ) {
+			$back_url = add_query_arg(
 				array(
 					'post_type' => $this->menu_post_type,
 					'page'      => $this->page_slug,
@@ -380,14 +381,33 @@ class Sensei_Learner_Management {
 				),
 				admin_url( 'edit.php' )
 			);
-			$title    .= sprintf( '&nbsp;&nbsp;<span class="course-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), get_the_title( $course_id ) );
+		} else {
+			$back_url = add_query_arg(
+				[
+					'post_type' => 'course',
+					'page'      => 'sensei_learners',
+				],
+				admin_url( 'edit.php' )
+			);
 		}
-		if ( isset( $_GET['lesson_id'] ) ) {
-			$lesson_id = intval( $_GET['lesson_id'] );
-			$title    .= '&nbsp;&nbsp;<span class="lesson-title">&gt;&nbsp;&nbsp;' . get_the_title( intval( $lesson_id ) ) . '</span>';
+
+		$title = '';
+		if ( 0 < $course_id ) {
+			$title .= get_the_title( $course_id );
 		}
+
+		if ( 0 < $lesson_id ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+			if ( ! empty( $title ) ) {
+				$title .= ': ';
+			}
+			$title .= get_the_title( $lesson_id );
+		}
+
+		$back_link = '<a href="' . esc_url( $back_url ) . '">←</a> ';
+		$title     = $back_link . $title;
 		?>
-			<h1>
+			<h2 class="sensei-students__subheading">
 				<?php
 				echo wp_kses(
 					apply_filters( 'sensei_learners_nav_title', $title ),
@@ -401,8 +421,7 @@ class Sensei_Learner_Management {
 					)
 				);
 				?>
-				| <a href="<?php echo esc_attr( $this->bulk_actions_controller->get_url() ); ?>"><?php echo esc_html( $this->bulk_actions_controller->get_name() ); ?></a></h1>
-			</h1>
+			</h2>
 		<?php
 	}
 

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -1076,23 +1076,6 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 			$menu['lessons'] = $this->lessons_link();
 
-		} elseif ( $this->course_id && $this->lesson_id ) {
-
-			$query_args = array(
-				'post_type' => $this->menu_post_type,
-				'page'      => $this->page_slug,
-				'course_id' => $this->course_id,
-				'view'      => 'lessons',
-			);
-
-			$course = get_the_title( $this->course_id );
-
-			$menu['back'] = '<a href="'
-				. esc_url( add_query_arg( $query_args, admin_url( 'edit.php' ) ) )
-				. '"><em>&larr; '
-				// translators: Placeholder is the Course title.
-				. esc_html( sprintf( __( 'Back to %s', 'sensei-lms' ), $course ) )
-				. '</em></a>';
 		}
 
 		$menu = apply_filters( 'sensei_learners_sub_menu', $menu );


### PR DESCRIPTION
Fixes part of #4957

### Changes proposed in this Pull Request

* Update subheading and navigation for the Students per course page

### Testing instructions

* Go to `Students`.
* Click on a course in the `Course Progress` column.
* Look at navigation above the table list (subheading).
* Try to go back by clicking on the left arrow.
* Again click on a course, then click on Lessons link above list table.
* Click "Manage Students" for a lesson.
* Look at navigation. You should see course name, colons, lesson name in the subheading and a link to a course on the left arrow.
* Try to go back.

### Screenshot / Video

https://user-images.githubusercontent.com/329356/163282399-e677849f-1985-482c-a7a0-3b3bea2cfdfb.mp4


