### PR TITLE
Change add student to course box in student per course page

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -299,6 +299,29 @@
 		}
 	}
 	.sensei-learners-extra {
+		.add-student-form-container.student-search-empty {
+			.select2-selection:before {
+				position: absolute;
+				font-family: dashicons;
+				content: "\f179";
+				font-size: 200%;
+				z-index: 1;
+				top: 0;
+				color: #9b9b9b;
+				padding: 1px 0px 0px 5px;
+				height: 100%;
+				display:flex;
+				flex-direction:row;
+				align-items: center;
+				justify-content: center;
+			}
+			.select2-search__field {
+				padding-left: 2.2em;
+			}
+		}
+		.select2-selection__rendered li {
+			margin-bottom: 0px;
+		}
 		.postbox {
 			padding: 1em 0px 0px 1em;
 			h2 {
@@ -311,6 +334,7 @@
 		.button-primary[disabled] {
 			background-color: #037ABAFF !important;
 			color: #66AFD6FF !important;
+			border-color: #66AFD6FF !important;
 		}
 	}
 }

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -299,6 +299,21 @@
 			}
 		}
 	}
+	.sensei-learners-extra {
+		.postbox {
+			padding: 1em 0px 0px 1em;
+			h2 {
+				padding: 0px !important;
+			}
+			.inside {
+				padding: 0px;
+			}
+		}
+		.button-primary[disabled] {
+			background-color: #037ABAFF !important;
+			color: #66AFD6FF !important;
+		}
+	}
 }
 
 .enrolment-helper {

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -299,8 +299,8 @@
 		}
 	}
 	.sensei-learners-extra {
-		.add-student-form-container.student-search-empty {
-			.select2-selection:before {
+		.add-student-form-container {
+			&.student-search-empty .select2-selection:before {
 				position: absolute;
 				font-family: dashicons;
 				content: "\f179";
@@ -315,6 +315,9 @@
 				align-items: center;
 				justify-content: center;
 			}
+			label {
+				display: block;
+			}
 			.select2-search__field {
 				padding-left: 2.2em;
 			}
@@ -324,17 +327,17 @@
 		}
 		.postbox {
 			padding: 1em 0px 0px 1em;
-			h2 {
-				padding: 0px !important;
+			h2#add-student-to-course-header {
+				padding: 0px;
 			}
 			.inside {
 				padding: 0px;
 			}
 		}
-		.button-primary[disabled] {
-			background-color: #037ABAFF !important;
-			color: #66AFD6FF !important;
-			border-color: #66AFD6FF !important;
+		#add_learner_submit[disabled] {
+			background-color: #037ABA !important;
+			color: #66AFD6 !important;
+			border-color: #037ABA !important;
 		}
 	}
 }

--- a/assets/js/learners-general.js
+++ b/assets/js/learners-general.js
@@ -235,7 +235,11 @@ jQuery( document ).ready( function ( $ ) {
 		}
 	} );
 
-	jQuery( 'select#add_learner_search' ).select2( {
+	let $learnerSearchSelect = jQuery( 'select#add_learner_search' );
+	let $learnerAddToCourseSubmitButton = jQuery(
+		"[name='add_learner_submit']"
+	).first();
+	$learnerSearchSelect.select2( {
 		minimumInputLength: 3,
 		placeholder: window.woo_learners_general_data.selectplaceholder,
 		width: '300px',
@@ -274,7 +278,12 @@ jQuery( document ).ready( function ( $ ) {
 			},
 		},
 	} ); // end select2
-
+	$learnerSearchSelect.on( 'change.select2', () => {
+		$learnerAddToCourseSubmitButton.prop(
+			'disabled',
+			$learnerSearchSelect.select2( 'data' ).length < 1
+		);
+	} );
 	/***************************************************************************************************
 	 * 	3 - Load Select2 Dropdowns.
 	 ***************************************************************************************************/

--- a/assets/js/learners-general.js
+++ b/assets/js/learners-general.js
@@ -239,11 +239,13 @@ jQuery( document ).ready( function ( $ ) {
 	let $learnerAddToCourseSubmitButton = jQuery(
 		"[name='add_learner_submit']"
 	).first();
+	let $learnerSearchboxFormContainer = jQuery(
+		'.sensei-learners-extra .add-student-form-container'
+	);
 	$learnerSearchSelect.select2( {
 		minimumInputLength: 3,
 		placeholder: window.woo_learners_general_data.selectplaceholder,
 		width: '300px',
-
 		ajax: {
 			// in wp-admin ajaxurl is supplied by WordPress and is available globaly
 			url: window.ajaxurl,
@@ -279,10 +281,16 @@ jQuery( document ).ready( function ( $ ) {
 		},
 	} ); // end select2
 	$learnerSearchSelect.on( 'change.select2', () => {
-		$learnerAddToCourseSubmitButton.prop(
-			'disabled',
-			$learnerSearchSelect.select2( 'data' ).length < 1
-		);
+		let isNoStudentSelected =
+			$learnerSearchSelect.select2( 'data' ).length < 1;
+		$learnerAddToCourseSubmitButton.prop( 'disabled', isNoStudentSelected );
+		if ( isNoStudentSelected ) {
+			$learnerSearchboxFormContainer.addClass( 'student-search-empty' );
+		} else {
+			$learnerSearchboxFormContainer.removeClass(
+				'student-search-empty'
+			);
+		}
 	} );
 	/***************************************************************************************************
 	 * 	3 - Load Select2 Dropdowns.

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -1161,7 +1161,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		}
 		?>
 		<div class="postbox">
-			<h2>
+			<h2 id="add-student-to-course-header">
 				<?php
 				// translators: Placeholder is the post type.
 				printf( esc_html__( 'Add Student to %1$s', 'sensei-lms' ), esc_html( $post_type ) );
@@ -1172,10 +1172,10 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 					<p class="add-student-form-container student-search-empty">
 						<select name="add_user_id[]" id="add_learner_search" multiple="multiple" style="min-width:300px;"></select>
 						<?php if ( 'lesson' === $form_post_type ) { ?>
-							<div><label for="add_complete_lesson"><input type="checkbox" id="add_complete_lesson" name="add_complete_lesson"  value="yes" /> <?php esc_html_e( 'Complete lesson for selected student(s)', 'sensei-lms' ); ?></label></div>
-					<?php } elseif ( 'course' === $form_post_type ) { ?>
-							<div><label for="add_complete_course"><input type="checkbox" id="add_complete_course" name="add_complete_course"  value="yes" /> <?php esc_html_e( 'Complete course for selected student(s)', 'sensei-lms' ); ?></label></div>
-					<?php } ?>
+							<label for="add_complete_lesson"><input type="checkbox" id="add_complete_lesson" name="add_complete_lesson"  value="yes" /> <?php esc_html_e( 'Complete lesson for selected student(s)', 'sensei-lms' ); ?></label>
+						<?php } elseif ( 'course' === $form_post_type ) { ?>
+							<label for="add_complete_course"><input type="checkbox" id="add_complete_course" name="add_complete_course"  value="yes" /> <?php esc_html_e( 'Complete course for selected student(s)', 'sensei-lms' ); ?></label>
+						<?php } ?>
 					</p>
 					<p>
 						<?php

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -1212,7 +1212,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 		}
 		?>
 		<div class="postbox">
-			<h2 class="postbox-title">
+			<h2>
 				<?php
 				// translators: Placeholder is the post type.
 				printf( esc_html__( 'Add Student to %1$s', 'sensei-lms' ), esc_html( $post_type ) );
@@ -1221,20 +1221,17 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			<div class="inside">
 				<form name="add_learner" action="" method="post">
 					<p>
-						<select name="add_user_id[]" id="add_learner_search" multiple="multiple" style="min-width:300px;">
-						</select>
+						<select name="add_user_id[]" id="add_learner_search" multiple="multiple" style="min-width:300px;"></select>
 						<?php if ( 'lesson' === $form_post_type ) { ?>
-							<label for="add_complete_lesson"><input type="checkbox" id="add_complete_lesson" name="add_complete_lesson"  value="yes" /> <?php esc_html_e( 'Complete lesson for student', 'sensei-lms' ); ?></label>
-						<?php } elseif ( 'course' === $form_post_type ) { ?>
-							<label for="add_complete_course"><input type="checkbox" id="add_complete_course" name="add_complete_course"  value="yes" /> <?php esc_html_e( 'Complete course for student', 'sensei-lms' ); ?></label>
-						<?php } ?>
-						<br/>
-						<span class="description"><?php esc_html_e( 'Search for a user by typing their name or username.', 'sensei-lms' ); ?></span>
+							<div><label for="add_complete_lesson"><input type="checkbox" id="add_complete_lesson" name="add_complete_lesson"  value="yes" /> <?php esc_html_e( 'Complete lesson for selected student(s)', 'sensei-lms' ); ?></label></div>
+					<?php } elseif ( 'course' === $form_post_type ) { ?>
+							<div><label for="add_complete_course"><input type="checkbox" id="add_complete_course" name="add_complete_course"  value="yes" /> <?php esc_html_e( 'Complete course for selected student(s)', 'sensei-lms' ); ?></label></div>
+					<?php } ?>
 					</p>
 					<p>
 						<?php
 						// translators: Placeholder is the post title.
-						submit_button( sprintf( __( 'Add to \'%1$s\'', 'sensei-lms' ), $post_title ), 'primary', 'add_learner_submit', false, array() );
+						submit_button( sprintf( __( 'Add to \'%1$s\'', 'sensei-lms' ), $post_title ), 'primary', 'add_learner_submit', false, array( 'disabled' => true ) );
 						?>
 					</p>
 					<?php if ( 'lesson' === $form_post_type && isset( $course_title ) ) { ?>

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -1169,7 +1169,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 			</h2>
 			<div class="inside">
 				<form name="add_learner" action="" method="post">
-					<p>
+					<p class="add-student-form-container student-search-empty">
 						<select name="add_user_id[]" id="add_learner_search" multiple="multiple" style="min-width:300px;"></select>
 						<?php if ( 'lesson' === $form_post_type ) { ?>
 							<div><label for="add_complete_lesson"><input type="checkbox" id="add_complete_lesson" name="add_complete_lesson"  value="yes" /> <?php esc_html_e( 'Complete lesson for selected student(s)', 'sensei-lms' ); ?></label></div>

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-lessons.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-lessons.php
@@ -99,7 +99,7 @@ class Sensei_Reports_Overview_List_Table_Lessons_Test extends WP_UnitTestCase {
 			wp_update_comment(
 				[
 					'comment_ID'   => $lesson_activity_comment_id,
-					'comment_date' => gmdate( 'Y-m-d H:i:s', strtotime( ( $days_count * 24 ) - 6 . ' hours' ) ),
+					'comment_date' => gmdate( 'Y-m-d H:i:s', strtotime( ( $days_count * 24 ) . ' hours' ) ),
 				]
 			);
 			$days_count++;


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/4957

### Changes proposed in this Pull Request

- Underline below header removed
- Completion checkbox is below the selector now
- The checkbox label is changed
- The submit button is now disabled if no student is selected
- The disabled button color is faded blue instead of the normal disabled color
- The spacing around the elements inside the box is uniform

### Testing instructions
- Create a few courses
- Create a few students
- Enroll some of those students to a few courses
- Go to SenseiLMS->Students
- Click on course from the 'Course Progress' column
- Check the "Add students to course" box at the bottom and make sure everything mentioned above is implemented and the functionality is not broken

### Screenshot / Video
No student selected -
![image](https://user-images.githubusercontent.com/6820724/163300380-94338599-5a67-40d1-ac47-452695d3397b.png)
One or more students selected -
![image](https://user-images.githubusercontent.com/6820724/163300737-0bfbcaad-2fdf-4b8f-b2d4-021983fd9192.png)
