### PR TITLE
Use POST method method instead of DELETE

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-course-progress-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-progress-controller.php
@@ -45,10 +45,10 @@ class Sensei_REST_API_Course_Progress_Controller extends \WP_REST_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/batch',
+			$this->rest_base . '/batch/delete',
 			[
 				[
-					'methods'             => WP_REST_Server::DELETABLE,
+					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => [ $this, 'batch_delete_items' ],
 					'permission_callback' => [ $this, 'batch_delete_items_permissions_check' ],
 					'args'                => $this->get_args_schema(),

--- a/includes/rest-api/class-sensei-rest-api-course-students-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-students-controller.php
@@ -45,16 +45,23 @@ class Sensei_REST_API_Course_Students_Controller extends \WP_REST_Controller {
 	public function register_routes() {
 		register_rest_route(
 			$this->namespace,
-			$this->rest_base . '/batch',
+			$this->rest_base . '/batch/create',
 			[
 				[
-					'methods'             => WP_REST_Server::EDITABLE,
+					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => [ $this, 'batch_create_items' ],
 					'permission_callback' => [ $this, 'batch_operation_permissions_check' ],
 					'args'                => $this->get_args_schema(),
-				],
+				]
+			]
+		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/batch/delete',
+			[
 				[
-					'methods'             => WP_REST_Server::DELETABLE,
+					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => [ $this, 'batch_remove_items' ],
 					'permission_callback' => [ $this, 'batch_operation_permissions_check' ],
 					'args'                => $this->get_args_schema(),

--- a/includes/rest-api/class-sensei-rest-api-course-students-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-students-controller.php
@@ -52,7 +52,7 @@ class Sensei_REST_API_Course_Students_Controller extends \WP_REST_Controller {
 					'callback'            => [ $this, 'batch_create_items' ],
 					'permission_callback' => [ $this, 'batch_operation_permissions_check' ],
 					'args'                => $this->get_args_schema(),
-				]
+				],
 			]
 		);
 

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-progress-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-progress-controller.php
@@ -60,7 +60,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_admin();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-progress/batch/delete' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -92,7 +92,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_admin();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-progress/batch/delete' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -124,7 +124,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_admin();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-progress/batch/delete' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -155,7 +155,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_admin();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-progress/batch/delete' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -184,7 +184,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		$course_id = $this->factory->course->create();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-progress/batch/delete' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -207,7 +207,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_admin();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-progress/batch/delete' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -230,7 +230,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_admin();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-progress/batch/delete' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -258,7 +258,7 @@ class Sensei_REST_API_Course_Progress_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_admin();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-progress/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-progress/batch/delete' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-students-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-students-controller.php
@@ -54,7 +54,7 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_admin();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-students/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-students/batch/create' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -78,7 +78,7 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_admin();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-students/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-students/batch/create' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -102,7 +102,7 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_admin();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-students/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-students/batch/create' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -126,7 +126,7 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_student();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-students/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-students/batch/create' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -149,7 +149,7 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_admin();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-students/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-students/batch/create' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -186,7 +186,7 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_admin();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-students/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-students/batch/delete' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -216,7 +216,7 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$post_id = $this->factory->post->create();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-students/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-students/batch/delete' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(
@@ -246,7 +246,7 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$this->login_as_admin();
 
 		/* Act. */
-		$request = new WP_REST_Request( 'DELETE', '/sensei-internal/v1/course-students/batch' );
+		$request = new WP_REST_Request( 'POST', '/sensei-internal/v1/course-students/batch/delete' );
 		$request->set_header( 'content-type', 'application/json' );
 		$request->set_body(
 			wp_json_encode(


### PR DESCRIPTION
Sometimes DELETE method doesn't work, and the web server returns 405 error (method not allowed).

Fixes part of #4959

### Changes proposed in this Pull Request

* Use the POST method instead of DELETE.

### Testing instructions

* Get WP REST nonce (make sure you're logged in): http://devwp.local/wp-admin/admin-ajax.php?action=rest-nonce (replace devwp.local with your domain)
* Copy Cookie name and value
* Execute in terminal (replace WPNONCE, COOKIE-NAME & COOKIE-VALUE, USER_ID, COURSE_ID with actual values):
  ```
  # Reset course progress
  curl -X "POST" "http://devwp.local/?rest_route=%2Fsensei-internal%2Fv1%2Fcourse-progress%2Fbatch%2Fdelete&_wpnonce=WPNONCE" \
       -H 'Cookie: COOKIE-NAME=COOKIE-VALUE' \
       -H 'Content-Type: application/json; charset=utf-8' \
       -d $'{
    "student_ids": USER_ID,
    "course_ids": COURSE_ID
  }'

  # Add students
  curl -X "POST" "http://devwp.local/?rest_route=%2Fsensei-internal%2Fv1%2Fcourse-users%2Fbatch%2Fcreate&_wpnonce=WPNONCE" \
       -H 'Cookie: COOKIE-NAME=COOKIE-VALUE' \
       -H 'Content-Type: application/json; charset=utf-8' \
       -d $'{
    "user_ids": USER_ID,
    "course_ids": COURSE_ID
  }'

  # Remove students
  curl -X "POST" "http://devwp.local/?rest_route=%2Fsensei-internal%2Fv1%2Fcourse-students%2Fbatch%2Fdelete&_wpnonce=WPNONCE" \
       -H 'Cookie: COOKIE-NAME=COOKIE-VALUE' \
       -H 'Content-Type: application/json; charset=utf-8' \
       -d $'{
    "student_ids": USER_ID,
    "course_ids": COURSE_ID
  }'
  ```
