### PR TITLE
Add `Reset or Remove Progress` action item

### DIFF
--- a/assets/admin/students/student-action-menu/index.js
+++ b/assets/admin/students/student-action-menu/index.js
@@ -38,6 +38,10 @@ export const StudentActionMenu = ( { studentId, studentName } ) => {
 			onClick: () => removeFromCourse(),
 		},
 		{
+			title: __( 'Reset or Remove Progress', 'sensei-lms' ),
+			onClick: () => resetProgress(),
+		},
+		{
 			title: __( 'Grading', 'sensei-lms' ),
 			onClick: () =>
 				window.open(
@@ -54,6 +58,11 @@ export const StudentActionMenu = ( { studentId, studentName } ) => {
 
 	const removeFromCourse = () => {
 		setAction( 'remove' );
+		setModalOpen( true );
+	};
+
+	const resetProgress = () => {
+		setAction( 'reset-progress' );
 		setModalOpen( true );
 	};
 

--- a/assets/admin/students/student-action-menu/index.test.js
+++ b/assets/admin/students/student-action-menu/index.test.js
@@ -63,6 +63,29 @@ describe( '<StudentActionMenu />', () => {
 		expect( screen.getByRole( 'dialog' ) ).toBeTruthy();
 	} );
 
+	it( 'Should display modal when "Reset or Remove progress" is selected', async () => {
+		apiFetch.mockImplementation( () => Promise.resolve( [] ) );
+		render( <StudentActionMenu /> );
+
+		// Open the dropdown menu.
+		const button = screen.getByRole( 'button' );
+
+		button.focus();
+		fireEvent.keyDown( button, {
+			keyCode: DOWN,
+			preventDefault: () => {},
+		} );
+
+		// Click the "Reset or Remove Progress" menu item.
+		const menuItem = screen.getByText( 'Reset or Remove Progress' );
+
+		await act( async () => {
+			fireEvent.click( menuItem );
+		} );
+
+		expect( screen.getByRole( 'dialog' ) ).toBeTruthy();
+	} );
+
 	it( "Should display student's ungraded quizzes when Grading menu item is selected", () => {
 		render( <StudentActionMenu studentName="mary" /> );
 

--- a/assets/admin/students/student-action-menu/index.test.js
+++ b/assets/admin/students/student-action-menu/index.test.js
@@ -6,7 +6,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
+import httpClient from '../../lib/http-client';
 import { DOWN } from '@wordpress/keycodes';
 
 /**
@@ -14,11 +14,11 @@ import { DOWN } from '@wordpress/keycodes';
  */
 import { StudentActionMenu } from './index';
 
-jest.mock( '@wordpress/api-fetch' );
+jest.mock( '../../lib/http-client' );
 
 describe( '<StudentActionMenu />', () => {
 	it( 'Should display modal when "Add to Course" is selected', async () => {
-		apiFetch.mockImplementation( () => Promise.resolve( [] ) );
+		httpClient.mockImplementation( () => Promise.resolve( { data: [] } ) );
 		render( <StudentActionMenu /> );
 
 		// Open the dropdown menu.
@@ -41,7 +41,7 @@ describe( '<StudentActionMenu />', () => {
 	} );
 
 	it( 'Should display modal when "Remove from Course" is selected', async () => {
-		apiFetch.mockImplementation( () => Promise.resolve( [] ) );
+		httpClient.mockImplementation( () => Promise.resolve( { data: [] } ) );
 		render( <StudentActionMenu /> );
 
 		// Open the dropdown menu.
@@ -64,7 +64,7 @@ describe( '<StudentActionMenu />', () => {
 	} );
 
 	it( 'Should display modal when "Reset or Remove progress" is selected', async () => {
-		apiFetch.mockImplementation( () => Promise.resolve( [] ) );
+		httpClient.mockImplementation( () => Promise.resolve( { data: [] } ) );
 		render( <StudentActionMenu /> );
 
 		// Open the dropdown menu.

--- a/assets/admin/students/student-action-menu/index.test.js
+++ b/assets/admin/students/student-action-menu/index.test.js
@@ -6,19 +6,19 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 /**
  * WordPress dependencies
  */
-import httpClient from '../../lib/http-client';
 import { DOWN } from '@wordpress/keycodes';
 
 /**
  * Internal dependencies
  */
 import { StudentActionMenu } from './index';
+import httpClient from '../../lib/http-client';
 
 jest.mock( '../../lib/http-client' );
 
 describe( '<StudentActionMenu />', () => {
 	it( 'Should display modal when "Add to Course" is selected', async () => {
-		httpClient.mockImplementation( () => Promise.resolve( { data: [] } ) );
+		httpClient.mockImplementation( () => Promise.resolve( [] ) );
 		render( <StudentActionMenu /> );
 
 		// Open the dropdown menu.
@@ -41,7 +41,7 @@ describe( '<StudentActionMenu />', () => {
 	} );
 
 	it( 'Should display modal when "Remove from Course" is selected', async () => {
-		httpClient.mockImplementation( () => Promise.resolve( { data: [] } ) );
+		httpClient.mockImplementation( () => Promise.resolve( [] ) );
 		render( <StudentActionMenu /> );
 
 		// Open the dropdown menu.
@@ -64,7 +64,7 @@ describe( '<StudentActionMenu />', () => {
 	} );
 
 	it( 'Should display modal when "Reset or Remove progress" is selected', async () => {
-		httpClient.mockImplementation( () => Promise.resolve( { data: [] } ) );
+		httpClient.mockImplementation( () => Promise.resolve( [] ) );
 		render( <StudentActionMenu /> );
 
 		// Open the dropdown menu.

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,13 +2,14 @@
  * External dependencies
  */
 import MutationObserver from '@sheerun/mutationobserver-shim';
+import nock from 'nock';
+import 'whatwg-fetch';
+
 /**
  * WordPress dependencies
  */
 import '@wordpress/jest-preset-default/scripts/setup-globals';
 import '@testing-library/jest-dom';
-import 'whatwg-fetch';
-import nock from 'nock';
 
 window.MutationObserver = MutationObserver;
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,4 +13,4 @@ import '@testing-library/jest-dom';
 
 window.MutationObserver = MutationObserver;
 
-beforeEach( () => nock.cleanAll() );
+beforeAll( () => nock.cleanAll() );

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -13,4 +13,4 @@ import '@testing-library/jest-dom';
 
 window.MutationObserver = MutationObserver;
 
-beforeAll( () => nock.cleanAll() );
+beforeEach( () => nock.cleanAll() );


### PR DESCRIPTION
Related to #4959

### Changes proposed in this Pull Request

* it adds a `Remove or Reset Progress` item on the student action menu. 

### Testing instructions
* Go to the students' page
* Click on the 3 dots point
* Check if the menu item `Reset Or Remove progress` is available
* Click to open the modal
* Check if the modal is related to reset the progress
* Reset a student's progress, choosing a course and applying the reset.


### Screenshot / Video
<img width="293" alt="Screen Shot 2022-04-14 at 17 43 42" src="https://user-images.githubusercontent.com/38718/163472544-01258722-060b-4869-b44b-1d8eebb130f9.png">
<img width="697" alt="Screen Shot 2022-04-14 at 17 43 57" src="https://user-images.githubusercontent.com/38718/163472549-0c815beb-a82f-44d1-b052-577ab6563106.png">

