### PR TITLE
Return data from add students endpoint

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-course-students-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-students-controller.php
@@ -74,17 +74,20 @@ class Sensei_REST_API_Course_Students_Controller extends \WP_REST_Controller {
 		$params      = $request->get_params();
 		$student_ids = $params['student_ids'];
 		$course_ids  = $params['course_ids'];
+
+		$result = [];
 		foreach ( $student_ids as $user_id ) {
-			$user = new WP_User( $user_id );
+			$user               = new WP_User( $user_id );
+			$result[ $user_id ] = false;
 			if ( $user->exists() ) {
 				foreach ( $course_ids as $course_id ) {
-					$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
-					$course_enrolment->enrol( $user_id );
+					$course_enrolment                 = Sensei_Course_Enrolment::get_course_instance( $course_id );
+					$result[ $user_id ][ $course_id ] = $course_enrolment->enrol( $user_id );
 				}
 			}
 		}
 
-		return new WP_REST_Response( null, WP_HTTP::OK );
+		return new WP_REST_Response( $result, WP_HTTP::OK );
 	}
 
 	/**

--- a/tests/framework/trait-sensei-rest-api-test-helpers.php
+++ b/tests/framework/trait-sensei-rest-api-test-helpers.php
@@ -36,10 +36,26 @@ trait Sensei_REST_API_Test_Helpers {
 	 *
 	 * @return array Associative array containing the status and error code.
 	 */
-	public function getResponseAndStatusCode( WP_REST_Response $response ) {
+	public function getResponseAndStatusCode( WP_REST_Response $response ): array {
 		return [
 			'status_code' => $response->get_status(),
 			'error_code'  => $response->get_data()['code'] ?? null,
+		];
+	}
+
+	/**
+	 * Get response status code and data
+	 *
+	 * @since 4.4.0
+	 *
+	 * @param WP_REST_Response $response Response object.
+	 *
+	 * @return array Array containing the status code and data.
+	 */
+	public function getResponseStatusAndData( WP_REST_Response $response ): array {
+		return [
+			'status_code' => $response->get_status(),
+			'data'        => $response->get_data(),
 		];
 	}
 }

--- a/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-students-controller.php
+++ b/tests/unit-tests/rest-api/test-class-sensei-rest-api-course-students-controller.php
@@ -48,8 +48,8 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 
 	public function testAddUsersToCourses_RequestGiven_ReturnsSuccessfulResponse() {
 		/* Arrange. */
-		$student_ids = $this->factory->user->create_many( 2 );
-		$course_ids  = $this->factory->course->create_many( 2 );
+		$student_id = $this->factory->user->create();
+		$course_id  = $this->factory->course->create();
 
 		$this->login_as_admin();
 
@@ -59,15 +59,23 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$request->set_body(
 			wp_json_encode(
 				[
-					'student_ids' => $student_ids,
-					'course_ids'  => $course_ids,
+					'student_ids' => [ $student_id ],
+					'course_ids'  => [ $course_id ],
 				]
 			)
 		);
 		$response = $this->server->dispatch( $request );
 
 		/* Assert. */
-		$this->assertSame( 200, $response->get_status() );
+		$expected = [
+			'status_code' => 200,
+			'data'        => [
+				$student_id => [
+					$course_id => true,
+				],
+			],
+		];
+		$this->assertSame( $expected, $this->getResponseStatusAndData( $response ) );
 	}
 
 	public function testAddUsersToCourses_RequestGiven_EnrolsUserForCourse() {
@@ -115,7 +123,13 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 		$response = $this->server->dispatch( $request );
 
 		/* Assert. */
-		$this->assertSame( 200, $response->get_status() );
+		$expected = [
+			'status_code' => 200,
+			'data'        => [
+				999 => false,
+			],
+		];
+		$this->assertSame( $expected, $this->getResponseStatusAndData( $response ) );
 	}
 
 	public function testAddUsersToCourses_UserWithInsufficientPermissions_ReturnsForbiddenResponse() {
@@ -260,11 +274,14 @@ class Sensei_REST_API_Course_Students_Controller_Test extends WP_Test_REST_TestC
 
 		/* Assert. */
 		$expected = [
-			$user_id => [
-				$course_id => true,
+			'status_code' => 200,
+			'data'        => [
+				$user_id => [
+					$course_id => true,
+				],
+				'999'    => false,
 			],
-			'999'    => false,
 		];
-		$this->assertEquals( $expected, $response->get_data() );
+		$this->assertEquals( $expected, $this->getResponseStatusAndData( $response ) );
 	}
 }


### PR DESCRIPTION
Fixes part of #4959

> On the frontend we are using the lib apiFetch to make requests to our endpoints, this library requires that all endpoints should return a json response and currently this endpoint is not returning it.

### Changes proposed in this Pull Request

* Return data from add students endpoint.

### Testing instructions
* Get WP REST nonce (make sure you're logged in): http://devwp.local/wp-admin/admin-ajax.php?action=rest-nonce (replace devwp.local with your domain)
* Copy Cookie name and value
* Execute in terminal (replace WPNONCE, COOKIE-NAME & COOKIE-VALUE, USER_ID, COURSE_ID with actual values):
```
curl -X "POST" "http://devwp.local/?rest_route=%2Fsensei-internal%2Fv1%2Fcourse-users%2Fbatch&_wpnonce=WPNONCE" \
     -H 'Cookie: COOKIE-NAME=COOKIE-VALUE' \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "user_ids": USER_ID,
  "course_ids": COURSE_ID
}'
```

### Example Response
```
HTTP/1.1 200 OK
Server: nginx/1.16.0
Date: Fri, 15 Apr 2022 10:12:07 GMT
Content-Type: application/json; charset=UTF-8
Transfer-Encoding: chunked
Connection: close
Vary: Accept-Encoding
Vary: Accept-Encoding
X-Powered-By: PHP/7.4.1
X-Robots-Tag: noindex
Link: <http://devwp.local/wp-json/>; rel="https://api.w.org/"
X-Content-Type-Options: nosniff
Access-Control-Expose-Headers: X-WP-Total, X-WP-TotalPages, Link
Access-Control-Allow-Headers: Authorization, X-WP-Nonce, Content-Disposition, Content-MD5, Content-Type
Expires: Wed, 11 Jan 1984 05:00:00 GMT
Cache-Control: no-cache, must-revalidate, max-age=0
X-WP-Nonce: WPNONCE_HERE
Allow: POST, PUT, PATCH, DELETE

{"1":{"8":true}}
```