### PR TITLE
Move bulk actions below table on smaller screens

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -334,6 +334,11 @@
 .sensei-learners-main {
 	.tablenav {
 		&.top {
+			@media screen and (max-width: 782px) {
+				.sensei-student-bulk-actions__wrapper {
+					display: none;
+				}
+			}
 			.tablenav-pages {
 				margin: 0 0 5px 0;
 			}
@@ -568,7 +573,12 @@
 
 	@media screen and (max-width: 1400px) {
 		&__filters {
-			display: flex;
+			flex-direction: column-reverse;
+		}
+	}
+
+	@media screen and (max-width: 782px) {
+		&__filters {
 			flex-direction: column;
 		}
 	}
@@ -594,7 +604,7 @@
 	margin-right: 0px;
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 782px) {
 	.sensei-student-bulk-actions__container .select2 {
 		margin-top: 6px;
 		width: 190px !important;

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -62,15 +62,6 @@
 		background: #f5f5f5;
 		@include border_radius(10px);
 	}
-	@media screen and (max-width: 782px) {
-		.tablenav {
-			&.top {
-				p.search-box {
-					bottom: -90px;
-				}
-			}
-		}
-	}
 	.extra-content {
 		margin-top: 1em;
 	}
@@ -297,6 +288,16 @@
 			&:before {
 				content: "\f10c";
 			}
+		}
+	}
+	@media screen and (min-width: 1140px) {
+		.search-box {
+			margin-left: 10px;
+		}
+	}
+	@media screen and (min-width: 783px) {
+		.search-box {
+			margin-bottom: 10px;
 		}
 	}
 }
@@ -559,30 +560,16 @@
 	}
 }
 
-.sensei-learners-wrap .search-box {
-	margin-left: 10px;
-}
-
 .sensei-student-bulk-actions {
 	&__filters {
 		display: flex;
 		flex-direction: row;
 	}
 
-	&__filters > div {
-		margin-right: 10px;
-	}
-
 	@media screen and (max-width: 1400px) {
 		&__filters {
 			display: flex;
-			flex-direction: column-reverse;
-		}
-	}
-
-	@media screen and (max-width: 1400px) and (min-width: 1100px) {
-		&__container {
-			width: 60%;
+			flex-direction: column;
 		}
 	}
 

--- a/assets/js/learners-general.js
+++ b/assets/js/learners-general.js
@@ -274,7 +274,28 @@ jQuery( document ).ready( function ( $ ) {
 			},
 		},
 	} ); // end select2
-
+	// For mobile devices (below 783px) put the filters and bulk actions below the table, else keep above.
+	let $bulkActionContainer = $(
+			'.tablenav.top > .sensei-student-bulk-actions__wrapper'
+		).first(),
+		$tableBottomActionContainer = $( '.tablenav.bottom > .tablenav-pages' ),
+		$tableTopActionContainer = $( '.tablenav.top > .tablenav-pages' ),
+		$themeContainer = $( '#woothemes-sensei' ),
+		placeElementsBasedOnScreenSize = () => {
+			let width = $( window ).width();
+			let $targetContainer =
+				width < 783
+					? $tableBottomActionContainer
+					: $tableTopActionContainer;
+			let themeDivPosition = width < 783 ? 'inherit' : '';
+			if ( $targetContainer.has( $bulkActionContainer ).length ) {
+				return;
+			}
+			$targetContainer.before( $bulkActionContainer );
+			$themeContainer.css( { position: themeDivPosition } );
+		};
+	placeElementsBasedOnScreenSize();
+	$( window ).resize( placeElementsBasedOnScreenSize );
 	/***************************************************************************************************
 	 * 	3 - Load Select2 Dropdowns.
 	 ***************************************************************************************************/

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -367,7 +367,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 					<?php $this->render_bulk_actions_form( $courses ); ?>
 				</div>
 				<div class="sensei-student-bulk-actions__filters">
-					<div>
+					<div class="alignleft actions bulkactions">
 						<?php
 						echo wp_kses(
 							$this->render_bulk_action_select_box(),
@@ -384,8 +384,8 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 						?>
 						<button type="submit" id="sensei-bulk-learner-actions-modal-toggle" class="button button-primary action" disabled><?php echo esc_html__( 'Select Courses', 'sensei-lms' ); ?></button>
 					</div>
-					<div class="alignleft">
-						<form action="" method="get">
+					<form action="" method="get">
+						<div class="alignleft actions">
 							<?php
 							foreach ( $this->query_args as $name => $value ) {
 								if ( 'filter_by_course_id' === $name || 'filter_type' === $name ) {
@@ -396,8 +396,8 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 							$this->courses_select( $courses, $selected_course, 'courses-select-filter', 'filter_by_course_id', __( 'Filter By Course', 'sensei-lms' ) );
 							?>
 							<button type="submit" id="filt" class="button action"><?php echo esc_html__( 'Filter', 'sensei-lms' ); ?></button>
-						</form>
-					</div>
+						</div>
+					</form>
 				</div>
 			</div>
 		</div>

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,6 @@ const baseConfig = require( '@wordpress/scripts/config/jest-unit.config.js' );
 
 module.exports = {
 	...baseConfig,
-	preset: null,
 	setupFilesAfterEnv: [ './jest.setup.js' ],
 	testPathIgnorePatterns: [
 		'/node_modules/',

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,7 @@ const baseConfig = require( '@wordpress/scripts/config/jest-unit.config.js' );
 
 module.exports = {
 	...baseConfig,
+	preset: null,
 	setupFilesAfterEnv: [ './jest.setup.js' ],
 	testPathIgnorePatterns: [
 		'/node_modules/',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,9 +2,11 @@
  * External dependencies
  */
 import MutationObserver from '@sheerun/mutationobserver-shim';
+import nock from 'nock';
 /**
  * WordPress dependencies
  */
 import '@wordpress/jest-preset-default/scripts/setup-globals';
 import '@testing-library/jest-dom';
 window.MutationObserver = MutationObserver;
+beforeAll( () => nock.cleanAll() );


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/4958

### Changes proposed in this Pull Request

For mobile view, the bulk actions and the filters are now rendered below the table. This makes the student management page conform with other similar pages in wp, like Wp Admin->Users->All Users. Also some custom CSS and markups conflicted with the default behavior (like Wp Admin -> Users -> All Users behavaes) of list tables with actions which were later fixed with more custom CSS. Some of those issues are addressed here.

The bulk and course selection section is moved using JS. It can also be done using CSS and duplicating these sections in the bottom. But that requires select2 dropdowns to have separate ids which requires changing multiple functions, also multiple select2 dropdowns for a single field needs be in sync. JS way requires less change.

### Testing instructions

- Create a few courses
- Create a few students
- Enrol a few students to those courese
- Go to Sensei LMS -> Students
- Try both filter and bulk action dropdowns and check if they work properly
- Try with different screen sizes, especially for standard desktop, tab and mobiles
- Make sure that the bulk action and filter dropdowns move below the table in mobile screens
- Check if the spacings are uniform and acceptable, above under and between the dropdowns, from top and bottom. Also check this for the search box and pagination navigators
- Check with and without pagination

### Screenshot / Video
Desktop
<img width="1343" alt="Screen Shot 2022-04-15 at 5 07 17 PM" src="https://user-images.githubusercontent.com/6820724/163650881-bb5e642b-71a0-4be2-8cc5-a5ee0e2d7ef7.png">
Tab
<img width="704" alt="Screen Shot 2022-04-15 at 5 06 06 PM" src="https://user-images.githubusercontent.com/6820724/163650904-132bcac4-13d5-47a0-a241-9a8102649ef7.png">
Mobile
<img width="435" alt="Screen Shot 2022-04-15 at 5 05 10 PM" src="https://user-images.githubusercontent.com/6820724/163650923-9b662246-be8d-4405-811d-ef933e865d6e.png">
Mobile - no item
<img width="435" alt="Screen Shot 2022-04-15 at 5 03 45 PM" src="https://user-images.githubusercontent.com/6820724/163650962-e3e52dc2-fa05-4f8d-bb9e-63ac49b57819.png">


