### PR TITLE
Fix lint errors on legacy files

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -230,13 +230,17 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	public function prepare_items() {
 		// Handle orderby.
 		$orderby = '';
+		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['orderby'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 			$orderby = esc_html( $_GET['orderby'] );
 		}
 
 		// Handle order.
 		$order = 'ASC';
+		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['order'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification,WordPress.PHP.StrictComparisons.LooseComparison,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$order = ( 'ASC' == strtoupper( $_GET['order'] ) ) ? 'ASC' : 'DESC';
 		}
 
@@ -256,9 +260,11 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			'order'   => $order,
 		);
 
-		// Handle search
+		// Handle search.
+		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( isset( $_GET['s'] ) && ! empty( $_GET['s'] ) ) {
-			$args['search'] = esc_html( $_GET['s'] );
+			// phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$args['search'] = esc_html( wp_unslash( $_GET['s'] ) );
 		}
 
 		switch ( $this->type ) {
@@ -287,6 +293,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 		);
 	}
 
+	// phpcs:ignore Squiz.Commenting.FunctionComment.MissingParamTag
 	/**
 	 * Generate a csv report with different parameters, pagination, columns and table elements
 	 *
@@ -298,15 +305,19 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 
 		$this->csv_output = true;
 
-		// Handle orderby
+		// Handle orderby.
 		$orderby = '';
+		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( ! empty( $_GET['orderby'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$orderby = esc_html( $_GET['orderby'] );
 		}
 
-		// Handle order
+		// Handle order.
 		$order = 'ASC';
+		//phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( ! empty( $_GET['order'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification,WordPress.PHP.StrictComparisons.LooseComparison,WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$order = ( 'ASC' == strtoupper( $_GET['order'] ) ) ? 'ASC' : 'DESC';
 		}
 
@@ -317,8 +328,10 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			'order'   => $order,
 		);
 
-		// Handle search
+		// Handle search.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( isset( $_GET['s'] ) && ! empty( $_GET['s'] ) ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$args['search'] = esc_html( $_GET['s'] );
 		}
 

--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -289,7 +289,8 @@ class Sensei_Analysis {
 
 		$this->check_course_lesson( $course_id, $lesson_id, $user_id );
 
-		$type = isset( $_GET['view'] ) ? esc_html( $_GET['view'] ) : 'students';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$type = isset( $_GET['view'] ) ? sanitize_key( wp_unslash( $_GET['view'] ) ) : 'students';
 
 		if ( 0 < $lesson_id ) {
 			// Viewing a specific Lesson and all its Learners

--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -377,7 +377,11 @@ class Sensei_Messages {
 			return false;
 		}
 
-		$message_id = $this->save_new_message_post( $current_user->ID, $post->post_author, sanitize_text_field( $_POST['contact_message'] ), $post->ID );
+		$message = empty( $_POST['contact_message'] )
+			? ''
+			: sanitize_text_field( wp_unslash( $_POST['contact_message'] ) );
+
+		$message_id = $this->save_new_message_post( $current_user->ID, $post->post_author, $message, $post->ID );
 
 		if ( $message_id ) {
 			do_action( 'sensei_new_private_message', $message_id );


### PR DESCRIPTION
This PR branch was based on `version/4.3.0` tag.

### Changes proposed in this Pull Request

* This PR fixes some lint errors on legacy files in order to update Learnomattic.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Go to a course in the frontend, and send a message to a teacher.
* Reads the message in the wp-admin, and make sure the message is there and correct.
* Also, enroll some students to some courses, and make sure the reports work properly in the wp-admin > Sensei LMS > Reports.