### PR TITLE
Fix filter overlap on student courses page on mobile

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -338,6 +338,11 @@
 			}
 		}
 	}
+	@media screen and (max-width: 782px) and (min-width: 480px) {
+		.tablenav.bottom .displaying-num {
+			position: inherit;
+		}
+	}
 }
 
 .sensei-grading-main  {

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -338,13 +338,22 @@
 			}
 		}
 	}
+
 	@media screen and (max-width: 782px) and (min-width: 480px) {
 		.tablenav.bottom .displaying-num {
-			position: inherit;
+			position: relative;
+			top: -20px;
+			display: block;
+			text-align: right;
+		}
+	}
+
+	@media screen and (max-width: 480px) {
+		.tablenav.bottom .displaying-num {
+			top: -20px;
 		}
 	}
 }
-
 .sensei-grading-main  {
 	.question_box {
 		@include clearfix();

--- a/includes/admin/class-sensei-learners-main.php
+++ b/includes/admin/class-sensei-learners-main.php
@@ -138,8 +138,7 @@ class Sensei_Learners_Main extends Sensei_List_Table {
 
 		// Actions.
 		add_action( 'sensei_before_list_table', array( $this, 'data_table_header' ) );
-		add_action( 'sensei_learners_extra', array( $this, 'add_learners_box' ) );
-
+		add_action( 'sensei_after_list_table', array( $this, 'add_learners_box' ) );
 		add_filter( 'sensei_list_table_search_button_text', array( $this, 'search_button' ) );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

### Issue: 
- On mobile view student courses page there was an overlap between search students and Add courses additional content
<img width="566" alt="image" src="https://user-images.githubusercontent.com/7208249/164078673-edda39de-0ea9-4dcb-9c56-611dbca11974.png">
 
### How it is fixed: 
- Used add after table hook since it handles better

### Testing instructions
- Open any student courses page go to the bottom in desktop view it should look like this: 
<img width="1039" alt="image" src="https://user-images.githubusercontent.com/7208249/164078902-3c07cae3-ec4e-4d86-9d62-62f1aeaca55d.png">
- On tablet view: 
<img width="748" alt="image" src="https://user-images.githubusercontent.com/7208249/164078956-325fd2fb-c4b6-429f-8ca2-20b9f15c85c5.png">
- On mobile view: 
<img width="471" alt="image" src="https://user-images.githubusercontent.com/7208249/164079032-81b2f3ab-f5d0-4e91-88dd-0be3d8195e5f.png">
