### PR TITLE
Add error handling to Students modal

### DIFF
--- a/assets/admin/students/student-modal/index.js
+++ b/assets/admin/students/student-modal/index.js
@@ -1,9 +1,9 @@
 /**
  * WordPress dependencies
  */
-import { Button, Modal, Spinner } from '@wordpress/components';
+import { Button, Modal, Notice, Spinner } from '@wordpress/components';
 import { search } from '@wordpress/icons';
-import { __ } from '@wordpress/i18n';
+import { __, _n } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -24,6 +24,13 @@ const POSSIBLE_ACTIONS = {
 			'sensei-lms'
 		),
 		buttonLabel: __( 'Add to Course', 'sensei-lms' ),
+		errorMessage: ( students ) =>
+			_n(
+				'Unable to add student. Please try again.',
+				'Unable to add students. Please try again.',
+				students.length,
+				'sensei-lms'
+			),
 		sendAction: ( students, courses ) =>
 			httpClient( {
 				restRoute: '/sensei-internal/v1/course-students/batch',
@@ -38,6 +45,13 @@ const POSSIBLE_ACTIONS = {
 			'sensei-lms'
 		),
 		buttonLabel: __( 'Remove from Course', 'sensei-lms' ),
+		errorMessage: ( students ) =>
+			_n(
+				'Unable to remove student. Please try again.',
+				'Unable to remove students. Please try again.',
+				students.length,
+				'sensei-lms'
+			),
 		sendAction: ( students, courses ) =>
 			httpClient( {
 				restRoute: '/sensei-internal/v1/course-students/batch',
@@ -52,6 +66,13 @@ const POSSIBLE_ACTIONS = {
 			'sensei-lms'
 		),
 		buttonLabel: __( 'Reset or Remove Progress', 'sensei-lms' ),
+		errorMessage: ( students ) =>
+			_n(
+				'Unable to reset or remove progress for this student. Please try again.',
+				'Unable to reset or remove progress for these students. Please try again.',
+				students.length,
+				'sensei-lms'
+			),
 		sendAction: ( students, courses ) =>
 			httpClient( {
 				restRoute: '/sensei-internal/v1/course-progress/batch',
@@ -75,12 +96,13 @@ export const StudentModal = ( { action, onClose, students } ) => {
 	const {
 		description,
 		buttonLabel,
+		errorMessage,
 		sendAction,
 		isDestructive,
 	} = POSSIBLE_ACTIONS[ action ];
 	const [ selectedCourses, setCourses ] = useState( [] );
 	const [ isSending, setIsSending ] = useState( false );
-	const [ hasError, setError ] = useState( false );
+	const [ error, setError ] = useState( false );
 	const isMounted = useRef( true );
 
 	useEffect( () => {
@@ -89,6 +111,7 @@ export const StudentModal = ( { action, onClose, students } ) => {
 
 	const send = useCallback( async () => {
 		setIsSending( true );
+
 		try {
 			await sendAction(
 				students,
@@ -116,12 +139,22 @@ export const StudentModal = ( { action, onClose, students } ) => {
 				iconRight={ search }
 			/>
 
-			{ hasError && <h1>Sorry, something went wrong</h1> }
 			<CourseList
 				onChange={ ( courses ) => {
 					setCourses( courses );
 				} }
 			/>
+
+			{ error && (
+				<Notice
+					status="error"
+					isDismissible={ false }
+					className="sensei-student-modal__notice"
+				>
+					{ errorMessage( students ) }
+				</Notice>
+			) }
+
 			<div className="sensei-student-modal__action">
 				<Button
 					className={ `sensei-student-modal__action` }

--- a/assets/admin/students/student-modal/index.test.js
+++ b/assets/admin/students/student-modal/index.test.js
@@ -26,7 +26,13 @@ const courses = [
 const students = [ 1, 2, 3 ];
 
 describe( '<StudentModal />', () => {
-	const { getByText, findByText, findByRole, findByLabelText } = screen;
+	const {
+		getByText,
+		findAllByText,
+		findByText,
+		findByRole,
+		findByLabelText,
+	} = screen;
 
 	const courseOptionAt = async ( index ) =>
 		findByLabelText( courses.at( index ).title.rendered );
@@ -42,6 +48,7 @@ describe( '<StudentModal />', () => {
 			.query( { per_page: 100, _locale: 'user' } )
 			.reply( 200, courses );
 	} );
+
 	afterAll( () => nock.cleanAll() );
 
 	it( 'Should display a list of courses', async () => {
@@ -103,7 +110,7 @@ describe( '<StudentModal />', () => {
 			} );
 		} );
 
-		describe( 'when there is a failure to add the students to the courses', () => {
+		describe( 'When there is a failure to add the students to the courses', () => {
 			beforeEach( async () => {
 				nock( 'http://localhost' )
 					.post( '/' )
@@ -117,12 +124,6 @@ describe( '<StudentModal />', () => {
 				fireEvent.click( await courseOptionAt( 0 ) );
 
 				fireEvent.click( await buttonByLabel( 'Add to Course' ) );
-			} );
-
-			it( 'Should display an error message', async () => {
-				expect(
-					await findByText( 'Sorry, something went wrong' )
-				).toBeInTheDocument();
 			} );
 
 			it( 'Should enable the action button', async () => {
@@ -159,7 +160,7 @@ describe( '<StudentModal />', () => {
 			).toBeInTheDocument();
 		} );
 
-		it( 'Should remove the selected students to the selected course', async () => {
+		it( 'Should remove the selected students from the selected course', async () => {
 			nock( 'http://localhost/' )
 				.post( '/', {
 					student_ids: students,
@@ -179,33 +180,6 @@ describe( '<StudentModal />', () => {
 
 			await waitFor( () => {
 				expect( onClose ).toHaveBeenCalledWith( true );
-			} );
-		} );
-
-		describe( 'when there is a failure to remove the students from the courses', () => {
-			beforeEach( async () => {
-				nock( 'http://localhost' )
-					.post( '/', {
-						student_ids: students,
-						course_ids: [ courses.at( 0 ).id ],
-					} )
-					.query( {
-						rest_route: '/sensei-internal/v1/course-students/batch',
-						_locale: 'user',
-					} )
-					.matchHeader( 'x-http-method-override', 'DELETE' )
-					.once()
-					.reply( 500, { status: 'error' } );
-
-				fireEvent.click( await courseOptionAt( 0 ) );
-
-				fireEvent.click( await buttonByLabel( 'Remove from Course' ) );
-			} );
-
-			it( 'Should display an error message', async () => {
-				expect(
-					await findByText( 'Sorry, something went wrong' )
-				).toBeInTheDocument();
 			} );
 		} );
 	} );
@@ -260,9 +234,138 @@ describe( '<StudentModal />', () => {
 				expect( onClose ).toHaveBeenCalledWith( true );
 			} );
 		} );
+	} );
 
-		describe( 'when there is a failure to reset the students progress', () => {
-			beforeEach( async () => {
+	describe( 'Errors', () => {
+		describe( 'Single student', () => {
+			beforeAll( () => {
+				// Add to course
+				nock( 'http://localhost' )
+					.post( '/', {
+						student_ids: [ students[ 0 ] ],
+						course_ids: [ courses.at( 0 ).id ],
+					} )
+					.query( {
+						rest_route: '/sensei-internal/v1/course-students/batch',
+						_locale: 'user',
+					} )
+					.once()
+					.reply( 200, { status: 'ok' } );
+
+				// Remove from course
+				nock( 'http://localhost/' )
+					.post( '/', {
+						student_ids: [ students[ 0 ] ],
+						course_ids: [ courses.at( 0 ).id ],
+					} )
+					.query( {
+						rest_route: '/sensei-internal/v1/course-students/batch',
+						_locale: 'user',
+					} )
+					.matchHeader( 'x-http-method-override', 'DELETE' )
+					.once()
+					.reply( 200, { status: 'ok' } );
+
+				// Reset or remove progress
+				nock( 'http://localhost' )
+					.post( '/', {
+						student_ids: [ students[ 0 ] ],
+						course_ids: [ courses.at( 0 ).id ],
+					} )
+					.query( {
+						rest_route: '/sensei-internal/v1/course-progress/batch',
+						_locale: 'user',
+					} )
+					.matchHeader( 'x-http-method-override', 'DELETE' )
+					.once()
+					.reply( 500, { status: 'error' } );
+			} );
+
+			it( 'Should display an error message when adding a student to a course', async () => {
+				render(
+					<StudentModal action="add" students={ [ students[ 0 ] ] } />
+				);
+
+				fireEvent.click( await courseOptionAt( 0 ) );
+				fireEvent.click( await buttonByLabel( 'Add to Course' ) );
+
+				expect(
+					await findAllByText(
+						'Unable to add student. Please try again.'
+					)
+				).toHaveLength( 2 ); // ARIA + notice
+			} );
+
+			it( 'Should display an error message when removing a student from a course', async () => {
+				render(
+					<StudentModal
+						action="remove"
+						students={ [ students[ 0 ] ] }
+					/>
+				);
+
+				fireEvent.click( await courseOptionAt( 0 ) );
+				fireEvent.click( await buttonByLabel( 'Remove from Course' ) );
+
+				expect(
+					await findAllByText(
+						'Unable to remove student. Please try again.'
+					)
+				).toHaveLength( 2 ); // ARIA + notice
+			} );
+
+			it( 'Should display an error message when resetting progress for a single student', async () => {
+				render(
+					<StudentModal
+						action="reset-progress"
+						students={ [ students[ 0 ] ] }
+					/>
+				);
+
+				fireEvent.click( await courseOptionAt( 0 ) );
+				fireEvent.click(
+					await buttonByLabel( 'Reset or Remove Progress' )
+				);
+
+				expect(
+					// In addition to the notice, there is an ARIA element that has this text.
+					await findAllByText(
+						'Unable to reset or remove progress for this student. Please try again.'
+					)
+				).toHaveLength( 2 ); // ARIA + notice
+			} );
+		} );
+
+		describe( 'Multiple students', () => {
+			beforeAll( () => {
+				// Add to course
+				nock( 'http://localhost' )
+					.post( '/', {
+						student_ids: students,
+						course_ids: [ courses.at( 0 ).id ],
+					} )
+					.query( {
+						rest_route: '/sensei-internal/v1/course-students/batch',
+						_locale: 'user',
+					} )
+					.once()
+					.reply( 200, { status: 'ok' } );
+
+				// Remove from course
+				nock( 'http://localhost/' )
+					.post( '/', {
+						student_ids: students,
+						course_ids: [ courses.at( 0 ).id ],
+					} )
+					.query( {
+						rest_route: '/sensei-internal/v1/course-students/batch',
+						_locale: 'user',
+					} )
+					.matchHeader( 'x-http-method-override', 'DELETE' )
+					.once()
+					.reply( 200, { status: 'ok' } );
+
+				// Reset or remove progress
 				nock( 'http://localhost' )
 					.post( '/', {
 						student_ids: students,
@@ -275,17 +378,54 @@ describe( '<StudentModal />', () => {
 					.matchHeader( 'x-http-method-override', 'DELETE' )
 					.once()
 					.reply( 500, { status: 'error' } );
+			} );
+
+			it( 'Should display an error message when adding multiple students to a course', async () => {
+				render( <StudentModal action="add" students={ students } /> );
+
+				fireEvent.click( await courseOptionAt( 0 ) );
+				fireEvent.click( await buttonByLabel( 'Add to Course' ) );
+
+				expect(
+					await findAllByText(
+						'Unable to add students. Please try again.'
+					)
+				).toHaveLength( 2 ); // ARIA + notice
+			} );
+
+			it( 'Should display an error message when removing multiple students from a course', async () => {
+				render(
+					<StudentModal action="remove" students={ students } />
+				);
+
+				fireEvent.click( await courseOptionAt( 0 ) );
+				fireEvent.click( await buttonByLabel( 'Remove from Course' ) );
+
+				expect(
+					await findAllByText(
+						'Unable to remove students. Please try again.'
+					)
+				).toHaveLength( 2 ); // ARIA + notice
+			} );
+
+			it( 'Should display an error message when resetting progress for multiple students', async () => {
+				render(
+					<StudentModal
+						action="reset-progress"
+						students={ students }
+					/>
+				);
 
 				fireEvent.click( await courseOptionAt( 0 ) );
 				fireEvent.click(
 					await buttonByLabel( 'Reset or Remove Progress' )
 				);
-			} );
 
-			it( 'Should display an error message', async () => {
 				expect(
-					await findByText( 'Sorry, something went wrong' )
-				).toBeInTheDocument();
+					await findAllByText(
+						'Unable to reset or remove progress for these students. Please try again.'
+					)
+				).toHaveLength( 2 ); // ARIA + notice
 			} );
 		} );
 	} );

--- a/assets/admin/students/student-modal/student-modal.scss
+++ b/assets/admin/students/student-modal/student-modal.scss
@@ -42,6 +42,10 @@
 		}
 	}
 
+	&__notice {
+		margin: 0;
+	}
+
 	&__action {
 		display: flex;
 		justify-content: flex-end;


### PR DESCRIPTION
### Changes proposed in this Pull Request
Adds an error message if something goes wrong with adding, removing, or resetting progress.

### Testing instructions
To force errors to happen, I changed the following lines to return `404` instead of `WP_HTTP::OK`:
-  https://github.com/Automattic/sensei/blob/feature/student-management/includes/rest-api/class-sensei-rest-api-course-progress-controller.php#L86
- https://github.com/Automattic/sensei/blob/feature/student-management/includes/rest-api/class-sensei-rest-api-course-students-controller.php#L90
- https://github.com/Automattic/sensei/blob/feature/student-management/includes/rest-api/class-sensei-rest-api-course-students-controller.php#L117

Then:
- Select _Add to Course_ from the dropdown, select a course, and click the _Add to Course_ button.
- Ensure the message "Unable to add student. Please try again." is displayed.
- Close the modal.
- Select _Remove from Course_ from the dropdown, select a course, and click the _Remove from Course_ button.
- Ensure the message "Unable to remove student. Please try again." is displayed.
- Close the modal.
- Select _Reset or Remove Progress_ from the dropdown, select a course, and click the _Reset or Remove Progress_ button.
- Ensure the message "Unable to reset or remove progress for this student. Please try again." is displayed.
- Close the modal.

### Screenshot / Video
#### Add

![Screen Shot 2022-04-20 at 11 52 50 AM](https://user-images.githubusercontent.com/1190420/164273679-238a2297-2e85-4ba2-82f6-7fa990801dd4.jpg)

#### Remove

![Screen Shot 2022-04-20 at 11 52 36 AM](https://user-images.githubusercontent.com/1190420/164273711-86de3e5b-9d3e-40fd-ad97-acb62ec26355.jpg)

#### Reset or Remove Progress

![Screen Shot 2022-04-20 at 11 53 01 AM](https://user-images.githubusercontent.com/1190420/164273742-a175349f-56a1-4211-a5d9-635cc0a33824.jpg)