### PR TITLE
Fix lesson video embed when using Yoast

### DIFF
--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -466,12 +466,14 @@ class Sensei_Course_Theme {
 			return $content;
 		}
 
-		remove_filter( 'the_content', [ $this, 'add_lesson_video_to_content' ], 80 );
-
 		ob_start();
 		Sensei()->frontend->sensei_lesson_video( get_the_ID() );
 		$video = ob_get_clean();
 
-		return $video . $content;
+		if ( ! empty( $video ) && false === strpos( $content, $video ) ) {
+			return $video . $content;
+		}
+
+		return $content;
 	}
 }

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -470,6 +470,8 @@ class Sensei_Course_Theme {
 		Sensei()->frontend->sensei_lesson_video( get_the_ID() );
 		$video = ob_get_clean();
 
+		// Checks if video is already added in the content to avoid it duplicated when `the_content`
+		// filter is called more than once.
 		if ( ! empty( $video ) && false === strpos( $content, $video ) ) {
 			return $video . $content;
 		}


### PR DESCRIPTION
Fixes #4966

### Changes proposed in this Pull Request

* Yoast uses [`wp_trim_excerpt`](https://developer.wordpress.org/reference/functions/wp_trim_excerpt/) which also calls the `the_content` filter, so our filter was being removed at that moment (before applying the change in the_content). I changed the approach that avoided to add duplicated videos to the content by checking if the embed string is already in the content.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->

I could just reproduce it in WP 5.7, which uses our custom `core/post-content`. For that, you need the Yoast in this version: https://github.com/Yoast/wordpress-seo/releases/tag/18.3-RC10

1. Create a course with a lesson using the block editor, and enable Learning Mode for that course;
2. Edit that lesson using the classic editor, and put a YouTube or Vimeo embed code in the "Video Embed Code:" field;
3. Now, install and activate Yoast SEO;
4. Finally, visit the public lesson page you just created;