### PR TITLE
Fix styling of modal checkboxes and buttons

### DIFF
--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -132,7 +132,7 @@ export const CourseList = ( { onChange } ) => {
 						key={ course.id }
 						course={ course }
 						onChange={ selectCourse }
-						checked={ selectedCourses.current.some(
+						checked={ selectedCourses.current.find(
 							( { id } ) => id === course.id
 						) }
 					/>

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -151,9 +151,9 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 							key={ course.id }
 							course={ course }
 							onChange={ selectCourse }
-              checked={ selectedCourses.current.find(
-              	( { id } ) => id === course.id
-              ) }
+							checked={ selectedCourses.current.find(
+								( { id } ) => id === course.id
+							) }
 						/>
 					) ) }
 			</ul>

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -23,11 +23,13 @@ import httpClient from '../../lib/http-client';
  *
  * @param {Object}        props
  * @param {Object}        props.course   Course
+ * @param {boolean}       props.checked  Checkbox state
  * @param {onChangeEvent} props.onChange Event triggered when the a course is select/unselected
  */
-const CourseItem = ( { course, onChange } ) => {
+const CourseItem = ( { course, checked, onChange } ) => {
 	const courseId = course?.id;
 	const title = course?.title?.rendered;
+
 	const onSelectCourse = useCallback(
 		( isSelected ) => onChange( { isSelected, course } ),
 		[ course, onChange ]
@@ -41,6 +43,7 @@ const CourseItem = ( { course, onChange } ) => {
 			<CheckboxControl
 				id={ `course-${ courseId }` }
 				title={ title }
+				checked={ checked }
 				onChange={ onSelectCourse }
 			/>
 			<label htmlFor={ `course-${ courseId }` } title={ title }>
@@ -129,6 +132,9 @@ export const CourseList = ( { onChange } ) => {
 						key={ course.id }
 						course={ course }
 						onChange={ selectCourse }
+						checked={ selectedCourses.current.some(
+							( { id } ) => id === course.id
+						) }
 					/>
 				) ) }
 			</ul>

--- a/assets/admin/students/student-modal/student-modal.scss
+++ b/assets/admin/students/student-modal/student-modal.scss
@@ -47,8 +47,22 @@
 		justify-content: flex-end;
 		margin-top: 40px;
 
-		&.is-destructive:hover {
+		&.is-destructive {
 			color: $alert-red;
+			box-shadow: inset 0 0 0 1px $alert-red;
+
+			&:hover:not(:disabled) {
+				color: darken($alert-red, 20%);
+				box-shadow: inset 0 0 0 1px darken($alert-red, 20%);
+			}
+
+			&:focus:not(:disabled) {
+				color: var(--wp-admin-theme-color);
+			}
+
+			&:active:not(:disabled) {
+				background: $gray-400;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request
Fixes the styles of the _Remove from Course_ and _Reset or Remove Progress_ buttons by importing the applicable styles from https://github.com/WordPress/gutenberg/blob/trunk/packages/components/src/button/style.scss#L175.

The best solution would be to update the version of the `@wordpress/components` package as it's really old and we're way 
out-of-sync with WordPress, but when I tried it set off a whole dependency chain of other packages needing updates. We may want to consider prioritizing this when we're on janitorial, as it's only going to get more and more difficult to update.

Also addresses an issue where the checkmark was not displaying in the checkbox when selected.

### Testing instructions
Select _Remove from Course_ from the action menu, select a course, and ensure the checkbox and button look like this:

![Screen Shot 2022-04-21 at 7 24 29 PM](https://user-images.githubusercontent.com/1190420/164567018-14cf0bfc-b7ed-46ad-9eb5-ced078550200.jpg)

Do the same for _Reset or Remove Progress_:

![Screen Shot 2022-04-21 at 7 23 35 PM](https://user-images.githubusercontent.com/1190420/164566794-0cbeb7d4-ab40-4250-9eb5-540e72bf5c7a.jpg)