### PR TITLE
Change answer feedback copies for Standalone Questions.

### DIFF
--- a/assets/blocks/quiz/answer-feedback-block/answer-feedback-toggle.js
+++ b/assets/blocks/quiz/answer-feedback-block/answer-feedback-toggle.js
@@ -43,7 +43,7 @@ export const AnswerFeedbackToggle = () => {
 
 			<div className="sensei-lms-question-block__answer-feedback-toggle__help">
 				{ __(
-					'Show feedback to students after they submit the quiz.',
+					'Show feedback once the question is answered.',
 					'sensei-lms'
 				) }
 			</div>

--- a/assets/blocks/quiz/answer-feedback-block/answer-feedback.js
+++ b/assets/blocks/quiz/answer-feedback-block/answer-feedback.js
@@ -16,14 +16,14 @@ const config = {
 	correct: {
 		title: __( 'Correct', 'sensei-lms' ),
 		placeholder: __(
-			'Enter feedback to be displayed if a student gets this answer right. Type / to choose a block.',
+			'Show a message when the question is answered correctly. Type / to choose a block.',
 			'sensei-lms'
 		),
 	},
 	incorrect: {
 		title: __( 'Incorrect', 'sensei-lms' ),
 		placeholder: __(
-			'Enter feedback to be displayed if a student gets this answer wrong. Type / to choose a block.',
+			'Show a message when the question is answered incorrectly. Type / to choose a block.',
 			'sensei-lms'
 		),
 	},


### PR DESCRIPTION
Changing copies so that they do not make any reference to students or
quiz. That way can be used by Standalone Questions without any
ambiguity.

Fixes #5047

### Changes proposed in this Pull Request

* Change copies for answer feedback in the editor to not make any reference to Students nor Quizzes.

### Testing instructions
* Checkout to the branch.
* Add any question as Standalone o in a Quiz.
* Check that the texts are the expected ones (reference #5047)

### Screenshot / Video
<img width="707" alt="image" src="https://user-images.githubusercontent.com/799065/164749864-17f3b408-da79-4337-b4e6-57b657f3aab9.png">
