### PR TITLE
Fix "Select courses" button shown as enabled momentarily on load

### DIFF
--- a/assets/admin/students/student-bulk-action-button/index.js
+++ b/assets/admin/students/student-bulk-action-button/index.js
@@ -12,8 +12,11 @@ import StudentModal from '../student-modal';
 
 /**
  *  Student bulk action button.
+ *
+ * @param {Object}  props
+ * @param {boolean} props.isDisabled Set button's initial state to be disabled or enabled, defaults to disabled.
  */
-export const StudentBulkActionButton = () => {
+export const StudentBulkActionButton = ( { isDisabled = true } = {} ) => {
 	const [ action, setAction ] = useState( 'add' );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ studentIds, setStudentIds ] = useState( [] );
@@ -73,6 +76,7 @@ export const StudentBulkActionButton = () => {
 		<>
 			<Button
 				className="button button-primary sensei-student-bulk-actions__button"
+				disabled={ isDisabled }
 				id="sensei-bulk-learner-actions-modal-toggle"
 				onClick={ openModal }
 			>

--- a/assets/admin/students/student-bulk-action-button/index.js
+++ b/assets/admin/students/student-bulk-action-button/index.js
@@ -46,12 +46,12 @@ export const StudentBulkActionButton = ( { isDisabled = true } ) => {
 		setButtonDisabled( ! ( args.detail && args.detail.enable ) );
 	};
 	useEffect( () => {
-		document.addEventListener(
+		global.addEventListener(
 			'enableDisableCourseSelectionToggle',
 			buttonEnableDisableEventHandler
 		);
 		return () => {
-			document.removeEventListener(
+			global.removeEventListener(
 				'enableDisableCourseSelectionToggle',
 				buttonEnableDisableEventHandler
 			);

--- a/assets/admin/students/student-bulk-action-button/index.js
+++ b/assets/admin/students/student-bulk-action-button/index.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { Button } from '@wordpress/components';
-import { render, useState } from '@wordpress/element';
+import { render, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -21,6 +21,7 @@ export const StudentBulkActionButton = ( { isDisabled = true } = {} ) => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ studentIds, setStudentIds ] = useState( [] );
 	const [ studentName, setStudentName ] = useState( '' );
+	const [ buttonDisabled, setButtonDisabled ] = useState( isDisabled );
 	const closeModal = () => setIsModalOpen( false );
 	const setActionValue = ( selectedValue ) => {
 		switch ( selectedValue ) {
@@ -36,7 +37,21 @@ export const StudentBulkActionButton = ( { isDisabled = true } = {} ) => {
 			default:
 		}
 	};
-
+	const buttonEnableDisableEventHandler = ( args ) => {
+		setButtonDisabled( ! ( args.detail && args.detail.enable ) );
+	};
+	useEffect( () => {
+		document.addEventListener(
+			'enableDisableCourseSelectionToggle',
+			buttonEnableDisableEventHandler
+		);
+		return () => {
+			document.removeEventListener(
+				'enableDisableCourseSelectionToggle',
+				buttonEnableDisableEventHandler
+			);
+		};
+	}, [] );
 	const openModal = () => {
 		const hiddenSenseiBulkAction = document.getElementById(
 			'bulk-action-selector-top'
@@ -76,7 +91,7 @@ export const StudentBulkActionButton = ( { isDisabled = true } = {} ) => {
 		<>
 			<Button
 				className="button button-primary sensei-student-bulk-actions__button"
-				disabled={ isDisabled }
+				disabled={ buttonDisabled }
 				id="sensei-bulk-learner-actions-modal-toggle"
 				onClick={ openModal }
 			>

--- a/assets/admin/students/student-bulk-action-button/index.js
+++ b/assets/admin/students/student-bulk-action-button/index.js
@@ -16,7 +16,7 @@ import StudentModal from '../student-modal';
  * @param {Object}  props
  * @param {boolean} props.isDisabled Set button's initial state to be disabled or enabled, defaults to disabled.
  */
-export const StudentBulkActionButton = ( { isDisabled = true } = {} ) => {
+export const StudentBulkActionButton = ( { isDisabled = true } ) => {
 	const [ action, setAction ] = useState( 'add' );
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ studentIds, setStudentIds ] = useState( [] );
@@ -116,7 +116,7 @@ export const StudentBulkActionButton = ( { isDisabled = true } = {} ) => {
 };
 
 Array.from(
-	document.getElementsByClassName( 'sensei-student-bulk-actions__button' )
+	document.querySelectorAll( 'div.sensei-student-bulk-actions__button' )
 ).forEach( ( button ) => {
 	render( <StudentBulkActionButton />, button );
 } );

--- a/assets/admin/students/student-bulk-action-button/index.test.js
+++ b/assets/admin/students/student-bulk-action-button/index.test.js
@@ -29,13 +29,20 @@ describe( '<StudentBulkActionButton />', () => {
 			.query( { per_page: 100 } )
 			.reply( 200, courses );
 	} );
+	it( 'Select courses button is disabled by default on render', () => {
+		render( <StudentBulkActionButton /> );
+		const button = screen.getByRole( 'button', {
+			id: 'sensei-bulk-learner-actions-modal-toggle',
+		} );
+		expect( button ).toBeDisabled();
+	} );
 	it( 'Student modal is rendered with action to add students on button click when add option is selected', () => {
 		setupSelector( [
 			{ value: 'enrol_restore_enrolment', selected: true },
 			{ value: 'remove_progress' },
 			{ value: 'remove_enrolment' },
 		] );
-		render( <StudentBulkActionButton /> );
+		render( <StudentBulkActionButton isDisabled={ false } /> );
 
 		// Click Select Courses button to open modal.
 		const button = screen.getByRole( 'button', {
@@ -57,7 +64,7 @@ describe( '<StudentBulkActionButton />', () => {
 			{ value: 'remove_progress', selected: true },
 			{ value: 'remove_enrolment' },
 		] );
-		render( <StudentBulkActionButton /> );
+		render( <StudentBulkActionButton isDisabled={ false } /> );
 
 		// Click Select Courses button to open modal.
 		const button = screen.getByRole( 'button', {
@@ -81,7 +88,7 @@ describe( '<StudentBulkActionButton />', () => {
 			{ value: 'remove_progress' },
 			{ value: 'remove_enrolment', selected: true },
 		] );
-		render( <StudentBulkActionButton /> );
+		render( <StudentBulkActionButton isDisabled={ false } /> );
 
 		// Click Select Courses button to open modal.
 		const button = screen.getByRole( 'button', {

--- a/assets/admin/students/student-bulk-action-button/index.test.js
+++ b/assets/admin/students/student-bulk-action-button/index.test.js
@@ -29,10 +29,10 @@ describe( '<StudentBulkActionButton />', () => {
 			.query( { per_page: 100 } )
 			.reply( 200, courses );
 	} );
-	it( 'Select courses button is disabled by default on render', () => {
+	it( 'Should be disabled by default on render', () => {
 		render( <StudentBulkActionButton /> );
 		const button = screen.getByRole( 'button', {
-			id: 'sensei-bulk-learner-actions-modal-toggle',
+			name: 'Select Courses',
 		} );
 		expect( button ).toBeDisabled();
 	} );

--- a/assets/js/learners-bulk-actions.js
+++ b/assets/js/learners-bulk-actions.js
@@ -160,14 +160,15 @@ jQuery( document ).ready( function () {
 			var validator = bulkUserActions.validator(),
 				bulkActionValidationResult = validator.validateBulkAction(),
 				selectedUserIdsValidationResult = validator.validateSelectedUserIds();
-			if (
-				bulkActionValidationResult.isValid &&
-				selectedUserIdsValidationResult.isValid
-			) {
-				$modalToggle.removeAttr( 'disabled' );
-			} else {
-				$modalToggle.attr( 'disabled', true );
-			}
+			document.dispatchEvent(
+				new CustomEvent( 'enableDisableCourseSelectionToggle', {
+					detail: {
+						enable:
+							bulkActionValidationResult.isValid &&
+							selectedUserIdsValidationResult.isValid,
+					},
+				} )
+			);
 			$hiddenSelectedUserIdsField.val(
 				JSON.stringify( bulkUserActions.getUserIds() )
 			);

--- a/assets/js/learners-bulk-actions.js
+++ b/assets/js/learners-bulk-actions.js
@@ -160,7 +160,7 @@ jQuery( document ).ready( function () {
 			var validator = bulkUserActions.validator(),
 				bulkActionValidationResult = validator.validateBulkAction(),
 				selectedUserIdsValidationResult = validator.validateSelectedUserIds();
-			document.dispatchEvent(
+			global.dispatchEvent(
 				new CustomEvent( 'enableDisableCourseSelectionToggle', {
 					detail: {
 						enable:

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -372,7 +372,9 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 							)
 						);
 						?>
-						<div class="sensei-student-bulk-actions__button"></div>
+						<div class="sensei-student-bulk-actions__button">
+							<button type="button" class="button components-button button-primary sensei-student-bulk-actions__button" disabled><?php echo esc_html__( 'Select Courses', 'sensei-lms' ); ?></button>
+						</div>
 					</div>
 					<form action="" method="get">
 						<div class="alignleft actions">


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/4959

On the student management page, the "Select Courses" button used to stay enabled for a very short while on load before getting disabled. Changed it to be disabled by default.

In the code, we are changing the enable and disable state via react button props instead of jquery reference.

### Testing instructions

- Create a few students
- Create a few courses
- Go to student management page
- Do hard and soft reloads
- Make sure the "Select Courses" loads in a disabled state
- Select a few students and select a bulk action
- Make sure the button becomes enabled
- Deselect the bulk action or students
- Make sure the button gets disabled