### PR TITLE
Remove excessive escaping of course titles on frontend

### DIFF
--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -3,6 +3,7 @@
  */
 import { CheckboxControl, Spinner } from '@wordpress/components';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -51,7 +52,7 @@ const EmptyCourseList = () => (
  */
 const CourseItem = ( { course, checked, onChange } ) => {
 	const courseId = course?.id;
-	const title = course?.title?.rendered;
+	const title = decodeEntities( course?.title?.rendered );
 
 	const onSelectCourse = useCallback(
 		( isSelected ) => onChange( { isSelected, course } ),

--- a/assets/admin/students/student-modal/course-list.test.js
+++ b/assets/admin/students/student-modal/course-list.test.js
@@ -79,7 +79,7 @@ describe( '<CourseList />', () => {
 		expect( onChange ).toHaveBeenLastCalledWith( [ courses.at( 1 ) ] );
 	} );
 
-	describe( 'when there is no course', () => {
+	describe( 'When there is no course', () => {
 		beforeEach( () => {
 			nock.cleanAll();
 			nock( NOCK_HOST_URL )
@@ -95,6 +95,27 @@ describe( '<CourseList />', () => {
 			expect(
 				await screen.findByText( 'No courses found.' )
 			).toBeTruthy();
+		} );
+	} );
+
+	describe( 'When there are HTML-Entities in course titles', () => {
+		beforeEach( () => {
+			nock.cleanAll();
+			nock( NOCK_HOST_URL )
+				.get( '/wp/v2/courses' )
+				.query( { per_page: 100, _locale: 'user' } )
+				.reply( 200, [
+					{
+						id: 1,
+						title: { rendered: 'Course&#8217;s' },
+					},
+				] );
+		} );
+
+		it( 'Should show the course title without HTML-Entities', async () => {
+			render( <CourseList /> );
+
+			expect( await screen.findByText( 'Course’s' ) ).toBeTruthy();
 		} );
 	} );
 } );

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@wordpress/element": "2.16.0",
     "@wordpress/escape-html": "1.9.0",
     "@wordpress/hooks": "2.9.0",
+    "@wordpress/html-entities": "3.7.0",
     "@wordpress/i18n": "3.14.0",
     "@wordpress/icons": "2.10.0",
     "@wordpress/keycodes": "2.19.2",


### PR DESCRIPTION
Fixes part of #4959

### Changes proposed in this Pull Request

* Remove excessive escaping of course titles on frontend

### Testing instructions

* Add a course with a single quote in the title
* Go to Students
* Select any bulk action or row action and open modal.
* Use search to see the course with the single quote.
* Make sure you don't see a code like `&#8217;` (or any other) in the title.

### Screenshot / Video
![CleanShot 2022-04-25 at 17 45 13@2x](https://user-images.githubusercontent.com/329356/165113469-57e3ea29-a200-4093-91db-d81572e03147.png)

