### PR TITLE
Reload student management page after bulk action

### DIFF
--- a/assets/admin/students/student-bulk-action-button/index.js
+++ b/assets/admin/students/student-bulk-action-button/index.js
@@ -18,7 +18,12 @@ export const StudentBulkActionButton = () => {
 	const [ isModalOpen, setIsModalOpen ] = useState( false );
 	const [ studentIds, setStudentIds ] = useState( [] );
 	const [ studentName, setStudentName ] = useState( '' );
-	const closeModal = () => setIsModalOpen( false );
+	const closeModal = ( needsReload ) => {
+		if ( needsReload ) {
+			window.location.reload();
+		}
+		setIsModalOpen( false );
+	};
 	const setActionValue = ( selectedValue ) => {
 		switch ( selectedValue ) {
 			case 'enrol_restore_enrolment':


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/4959

### Changes proposed in this Pull Request

- Reloads the student management page after bulk actions are performed

### Testing instructions

- Create a few students
- Create a few courses
- Go to student management page
- Select one or more students
- Select a bulk action from the top left dropdown
- Click the "Select Courses" button that opens the course selection modal
- Select one or more courses in the modal
- Click the button at the modal's bottom right to perform the action
- The student management page should reload

### Screenshot / Video


https://user-images.githubusercontent.com/6820724/165153674-c4add42e-d50d-413a-996d-81f2ceee6f5c.mov

