### PR TITLE
Update documentation link URL for Student Management

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -142,7 +142,7 @@ class Sensei_Learner_Management {
 					<h1><?php esc_html_e( 'Students', 'sensei-lms' ); ?></h1>
 				</div>
 				<div class="sensei-custom-navigation__separator"></div>
-				<a class="sensei-custom-navigation__info" target="_blank" href="https://senseilms.com/documentation/?utm_source=plugin_sensei&utm_medium=docs&utm_campaign=student-management">
+				<a class="sensei-custom-navigation__info" target="_blank" href="https://senseilms.com/documentation/student-management?utm_source=plugin_sensei&utm_medium=docs&utm_campaign=student-management">
 					<?php echo esc_html__( 'Guide To Student Management', 'sensei-lms' ); ?>
 				</a>
 			</div>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update documentation link URL on Students pages

### Testing instructions

* Go to `Sensei LMS -> Students`
* Make sure you can see `Guide To Student Management`.
* Make sure it leads to https://senseilms.com/documentation/student-management?utm_source=plugin_sensei&utm_medium=docs&utm_campaign=student-management
* The page doesn't exist yet!
