### PR TITLE
Remove console warnings produced by js unit tests

### DIFF
--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -108,32 +108,32 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 	);
 
 	// Fetch the courses.
-	const fetchCourses = useCallback(
-		debounce( ( query ) => {
-			setIsFetching( true );
+	const fetchCourses = debounce( ( query ) => {
+		setIsFetching( true );
 
-			httpClient( {
-				path:
-					'/wp/v2/courses?per_page=100' +
-					( query ? `&search=${ query }` : '' ),
-				method: 'GET',
+		httpClient( {
+			path:
+				'/wp/v2/courses?per_page=100' +
+				( query ? `&search=${ query }` : '' ),
+			method: 'GET',
+		} )
+			.then( ( result ) => {
+				setCourses( result );
 			} )
-				.then( ( result ) => {
-					setCourses( result );
-				} )
-				.catch( () => {
-					setIsFetching( false );
-				} )
-				.finally( () => {
-					setIsFetching( false );
-				} );
-		}, 400 ),
-		[]
-	); // eslint-disable-line react-hooks/exhaustive-deps
+			.catch( () => {
+				setIsFetching( false );
+			} )
+			.finally( () => {
+				setIsFetching( false );
+			} );
+	}, 400 );
 
 	useEffect( () => {
 		fetchCourses( searchQuery );
-	}, [ fetchCourses, searchQuery ] );
+		return () => {
+			fetchCourses.cancel();
+		};
+	}, [ searchQuery ] );
 
 	return (
 		<>

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -53,6 +53,7 @@ const EmptyCourseList = () => (
 const CourseItem = ( { course, checked, onChange } ) => {
 	const courseId = course?.id;
 	const title = decodeEntities( course?.title?.rendered );
+	const [ isChecked ] = useState( checked );
 
 	const onSelectCourse = useCallback(
 		( isSelected ) => onChange( { isSelected, course } ),
@@ -67,7 +68,7 @@ const CourseItem = ( { course, checked, onChange } ) => {
 			<CheckboxControl
 				id={ `course-${ courseId }` }
 				title={ title }
-				checked={ checked }
+				checked={ isChecked }
 				onChange={ onSelectCourse }
 			/>
 			<label htmlFor={ `course-${ courseId }` } title={ title }>


### PR DESCRIPTION
Fixes two test warnings generated while running the js unit tests

### Changes proposed in this Pull Request

- Removed the callback hook and cleared the denounce on unmount
- Changed the checkbox's checked value to be taken from a state variable

### Testing instructions

Unit Test -
- Pull the branch, run the tests, there shouldn't be any warning in the console

Single Action -
- Go to student management page
- Select the actions from the student list's action menu
- Make sure the modal works as before, the courses are fetched properly, can be selected and the search is working well on the modal

Bulk Action -
- Select multiple students using checkboxes on the left
- Select a bulk action from the dropdown on the top left
- Click on the "Select Courses" button
- Make sure the modal works as before