### PR TITLE
Add icon href filter

### DIFF
--- a/includes/class-sensei-assets.php
+++ b/includes/class-sensei-assets.php
@@ -280,7 +280,21 @@ class Sensei_Assets {
 	private function get_icon_href( string $name ) : string {
 		$sprite_file = $this->plugin_url . 'assets/dist/icons/sensei-sprite.svg?v=' . $this->version;
 
-		return "{$sprite_file}#sensei-sprite-{$name}";
+		/**
+		 * Filters the icon href for the svg.
+		 *
+		 * @since x.x.x
+		 * @hook sensei_icon_href
+		 *
+		 * @param {string} $icon_href   The icon href.
+		 * @param {string} $sprite_file The sprite file URL.
+		 * @param {string} $name        The icon name.
+		 *
+		 * @return {string} The icon href.
+		 */
+		$icon_href = apply_filters( 'sensei_icon_href', "{$sprite_file}#sensei-sprite-{$name}", $sprite_file, $name );
+
+		return $icon_href;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It introduces a new filter to filter Sensei icons href.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Add a filter to update your icons URL, like this:
  ```php
      add_filter( 'sensei_icon_href', function( $href ) {
  	return str_replace( 'dev', 'filtered', $href );
  } );
  ```
* Access a course with learning mode, and check the icons href in the sidebar to make sure it was filtered.
  <img width="784" alt="Screen Shot 2022-04-26 at 10 47 35" src="https://user-images.githubusercontent.com/876340/165314534-aea0e193-2917-470c-984a-631ac232fc45.png">

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_icon_href` filter - It filters the Sensei icons href.
  ```
   * @param {string} $icon_href   The icon href.
   * @param {string} $sprite_file The sprite file URL.
   * @param {string} $name        The icon name.
   *
   * @return {string} The icon href.
  ```

### Context

p6rkRX-3kJ-p2