### PR TITLE
Use AbortController to cancel fetch requests for unmounted components

### DIFF
--- a/assets/admin/students/hooks/use-abort-controller/index.js
+++ b/assets/admin/students/hooks/use-abort-controller/index.js
@@ -23,5 +23,5 @@ export default function useAbortController() {
 		getAbortController,
 	] );
 
-	return getSignal;
+	return { getSignal };
 }

--- a/assets/admin/students/hooks/use-abort-controller/index.test.js
+++ b/assets/admin/students/hooks/use-abort-controller/index.test.js
@@ -1,0 +1,25 @@
+/**
+ * Internal dependencies
+ */
+import useAbortController from '.';
+
+/**
+ * External dependencies
+ */
+import { cleanup, renderHook } from '@testing-library/react-hooks';
+
+describe( 'useAbortController', () => {
+	it( 'Should return signal to be used on async operations', () => {
+		const { result } = renderHook( () => useAbortController() );
+		expect( result.current.getSignal() ).toEqual(
+			new AbortController().signal
+		);
+	} );
+
+	it( 'Should abort async operations on component unmount', () => {
+		const { result } = renderHook( () => useAbortController() );
+		const signal = result.current.getSignal();
+		cleanup();
+		expect( signal.aborted ).toBe( true );
+	} );
+} );

--- a/assets/admin/students/student-modal/course-list-fetch.test.js
+++ b/assets/admin/students/student-modal/course-list-fetch.test.js
@@ -48,7 +48,7 @@ describe( 'CourseList fetch', () => {
 				expect( httpClient ).toHaveBeenCalledWith( {
 					path: '/wp/v2/courses?per_page=100',
 					method: 'GET',
-					signal: { aborted: false },
+					signal: new AbortController().signal,
 				} ),
 			{ timeout: 450 }
 		);

--- a/assets/admin/students/student-modal/course-list-fetch.test.js
+++ b/assets/admin/students/student-modal/course-list-fetch.test.js
@@ -8,8 +8,14 @@ import { render, waitFor } from '@testing-library/react';
  */
 import { CourseList } from './course-list';
 import httpClient from '../../lib/http-client';
+import useAbortController from './use-abort-controller';
 
 jest.mock( '../../lib/http-client' );
+jest.mock( './use-abort-controller' );
+
+useAbortController.mockImplementation( () => {
+	return jest.fn().mockReturnValue( { aborted: false } );
+} );
 
 describe( 'CourseList fetch', () => {
 	beforeEach( () => {
@@ -28,6 +34,7 @@ describe( 'CourseList fetch', () => {
 				expect( httpClient ).toHaveBeenCalledWith( {
 					path: '/wp/v2/courses?per_page=100&search=abc123',
 					method: 'GET',
+					signal: { aborted: false },
 				} ),
 			{ timeout: 450 }
 		);
@@ -41,6 +48,7 @@ describe( 'CourseList fetch', () => {
 				expect( httpClient ).toHaveBeenCalledWith( {
 					path: '/wp/v2/courses?per_page=100',
 					method: 'GET',
+					signal: { aborted: false },
 				} ),
 			{ timeout: 450 }
 		);

--- a/assets/admin/students/student-modal/course-list-fetch.test.js
+++ b/assets/admin/students/student-modal/course-list-fetch.test.js
@@ -8,14 +8,8 @@ import { render, waitFor } from '@testing-library/react';
  */
 import { CourseList } from './course-list';
 import httpClient from '../../lib/http-client';
-import useAbortController from './use-abort-controller';
 
 jest.mock( '../../lib/http-client' );
-jest.mock( './use-abort-controller' );
-
-useAbortController.mockImplementation( () => {
-	return jest.fn().mockReturnValue( { aborted: false } );
-} );
 
 describe( 'CourseList fetch', () => {
 	beforeEach( () => {
@@ -34,7 +28,7 @@ describe( 'CourseList fetch', () => {
 				expect( httpClient ).toHaveBeenCalledWith( {
 					path: '/wp/v2/courses?per_page=100&search=abc123',
 					method: 'GET',
-					signal: { aborted: false },
+					signal: new AbortController().signal,
 				} ),
 			{ timeout: 450 }
 		);

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -54,9 +54,13 @@ const EmptyCourseList = () => (
 const CourseItem = ( { course, checked = false, onChange } ) => {
 	const courseId = course?.id;
 	const title = decodeEntities( course?.title?.rendered );
+	const [ isChecked, setIsChecked ] = useState( checked );
 
 	const onSelectCourse = useCallback(
-		( isSelected ) => onChange( { isSelected, course } ),
+		( isSelected ) => {
+			setIsChecked( isSelected );
+			onChange( { isSelected, course } );
+		},
 		[ course, onChange ]
 	);
 
@@ -68,7 +72,7 @@ const CourseItem = ( { course, checked = false, onChange } ) => {
 			<CheckboxControl
 				id={ `course-${ courseId }` }
 				title={ title }
-				checked={ checked }
+				checked={ isChecked }
 				onChange={ onSelectCourse }
 			/>
 			<label htmlFor={ `course-${ courseId }` } title={ title }>

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -15,6 +15,7 @@ import { debounce } from 'lodash';
  * Internal dependencies
  */
 import httpClient from '../../lib/http-client';
+import useAbortController from './use-abort-controller';
 
 /**
  * Callback for select or unselect courseItem
@@ -95,6 +96,7 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 	const [ isFetching, setIsFetching ] = useState( true );
 	const [ courses, setCourses ] = useState( [] );
 	const selectedCourses = useRef( [] );
+	const getSignal = useAbortController();
 
 	const selectCourse = useCallback(
 		( { isSelected, course } ) => {
@@ -117,15 +119,14 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 					'/wp/v2/courses?per_page=100' +
 					( query ? `&search=${ query }` : '' ),
 				method: 'GET',
+				signal: getSignal(),
 			} )
-				.then( ( result ) => {
-					setCourses( result );
-				} )
-				.catch( () => {
-					setIsFetching( false );
-				} )
+				.then( ( result ) => setCourses( result ) )
+				.catch( () => {} )
 				.finally( () => {
-					setIsFetching( false );
+					if ( ! getSignal().aborted ) {
+						setIsFetching( false );
+					}
 				} );
 		}, 400 ),
 		[]

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -15,7 +15,7 @@ import { debounce } from 'lodash';
  * Internal dependencies
  */
 import httpClient from '../../lib/http-client';
-import useAbortController from './use-abort-controller';
+import useAbortController from '../hooks/use-abort-controller';
 
 /**
  * Callback for select or unselect courseItem
@@ -100,7 +100,7 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 	const [ isFetching, setIsFetching ] = useState( true );
 	const [ courses, setCourses ] = useState( [] );
 	const selectedCourses = useRef( [] );
-	const getSignal = useAbortController();
+	const { getSignal } = useAbortController();
 
 	const selectCourse = useCallback(
 		( { isSelected, course } ) => {

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -126,7 +126,9 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 				signal: getSignal(),
 			} )
 				.then( ( result ) => setCourses( result ) )
-				.catch( () => {} )
+				.catch( ( error ) => {
+					console.log( error ); // eslint-disable-line no-console
+				} )
 				.finally( () => {
 					if ( ! getSignal().aborted ) {
 						setIsFetching( false );

--- a/assets/admin/students/student-modal/course-list.js
+++ b/assets/admin/students/student-modal/course-list.js
@@ -51,7 +51,7 @@ const EmptyCourseList = () => (
  * @param {boolean}       props.checked  Checkbox state
  * @param {onChangeEvent} props.onChange Event triggered when the a course is select/unselected
  */
-const CourseItem = ( { course, checked, onChange } ) => {
+const CourseItem = ( { course, checked = false, onChange } ) => {
 	const courseId = course?.id;
 	const title = decodeEntities( course?.title?.rendered );
 
@@ -153,9 +153,12 @@ export const CourseList = ( { searchQuery, onChange } ) => {
 							key={ course.id }
 							course={ course }
 							onChange={ selectCourse }
-							checked={ selectedCourses.current.find(
-								( { id } ) => id === course.id
-							) }
+							checked={
+								selectedCourses.current.length > 0 &&
+								selectedCourses.current.find(
+									( { id } ) => id === course.id
+								)
+							}
 						/>
 					) ) }
 			</ul>

--- a/assets/admin/students/student-modal/use-abort-controller.js
+++ b/assets/admin/students/student-modal/use-abort-controller.js
@@ -1,0 +1,27 @@
+/**
+ * WordPress dependencies
+ */
+import { useCallback, useEffect, useRef } from '@wordpress/element';
+
+// Solution borrowed from https://gist.github.com/kentcdodds/b36572b6e9227207e6c71fd80e63f3b4.
+export default function useAbortController() {
+	const abortControllerRef = useRef();
+
+	const getAbortController = useCallback( () => {
+		if ( ! abortControllerRef.current ) {
+			abortControllerRef.current = new AbortController();
+		}
+
+		return abortControllerRef.current;
+	}, [] );
+
+	useEffect( () => {
+		return () => getAbortController().abort();
+	}, [ getAbortController ] );
+
+	const getSignal = useCallback( () => getAbortController().signal, [
+		getAbortController,
+	] );
+
+	return getSignal;
+}


### PR DESCRIPTION
Fixes the following React warnings and errors when the tests were run:
- `Can't perform a React state update on an unmounted component.`
- `A component is changing an uncontrolled input of type checkbox to be controlled.`

### Changes proposed in this Pull Request
I borrowed and integrated [this solution](https://gist.github.com/kentcdodds/b36572b6e9227207e6c71fd80e63f3b4) to handle the warning. It successfully eliminates the warning and also solves the underlying issue.

### Testing instructions
Ensure that you don't see the above warning / error on the JS tests (they fail for another reason 😅 ).