### PR TITLE
Rename Bulk actions

### DIFF
--- a/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-controller.php
@@ -130,8 +130,8 @@ class Sensei_Learners_Admin_Bulk_Actions_Controller {
 		$this->view               = 'sensei_learner_admin';
 
 		$this->known_bulk_actions = [
-			self::ENROL_RESTORE_ENROLMENT => __( 'Enroll / Restore Enrollment', 'sensei-lms' ),
-			self::REMOVE_ENROLMENT        => __( 'Remove Enrollment', 'sensei-lms' ),
+			self::ENROL_RESTORE_ENROLMENT => __( 'Add to Course', 'sensei-lms' ),
+			self::REMOVE_ENROLMENT        => __( 'Remove from Course', 'sensei-lms' ),
 			self::REMOVE_PROGRESS         => __( 'Reset or Remove Progress', 'sensei-lms' ),
 		];
 

--- a/lang/sensei-lms.pot
+++ b/lang/sensei-lms.pot
@@ -3420,12 +3420,12 @@ msgid "Bulk Student Actions"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-controller.php:126
-msgid "Enroll / Restore Enrollment"
+msgid "Add to Course"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-controller.php:127
 #: includes/admin/class-sensei-learners-main.php:501
-msgid "Remove Enrollment"
+msgid "Remove from Course"
 msgstr ""
 
 #: includes/admin/class-sensei-learners-admin-bulk-actions-controller.php:128


### PR DESCRIPTION
Resolves part of #4959

### Changes proposed in this Pull Request

* Rename the current bulk actions to follow 

### Testing instructions
* Open the students page
* Check on the first dropdown the names:
 -  `Add To Course` (instead of `Enroll / Restore Enrollment`)
 -  `Remove from Course` (instead of  'Remove Enrollment')
 - `Reset or Remove Progress` no changes.


### Screenshot / Video
<img width="618" alt="Screen Shot 2022-04-26 at 15 35 43" src="https://user-images.githubusercontent.com/38718/165368894-d6a65831-75e9-445f-9dac-c6a20b485b50.png">


