### PR TITLE
Fix spacing issues in filters on the Students page

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -656,6 +656,7 @@
 
 	&__bulk_actions_container {
 		display: flex;
+		margin-right: 22px;
 	}
 
 	&__bulk_actions_container &__button {

--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -372,6 +372,7 @@
 	border-width: 2px;
 }
 
+
 .sensei-learners-main {
 	.tablenav {
 		&.top {
@@ -646,11 +647,12 @@
 	}
 
 	&__button {
-		margin-left: 4px;
+		margin-left: 6px;
 	}
 	@media screen and (max-width: 782px) {
 		&__button {
 			margin-top: 6px;
+			margin-left: 4px;
 		}
 	}
 


### PR DESCRIPTION
Resolves part of #4959
### Changes proposed in this Pull Request

* Add a space between the bulk action button and the course filter
* Add space between the bulk action dropdown and the "Select courses" button (Following the WordPress standard space)

### Screenshot / Video
<img width="1564" alt="Screen Shot 2022-04-27 at 08 45 23" src="https://user-images.githubusercontent.com/38718/165511371-08526d51-3254-4406-a57c-714639771037.png">

<img width="1726" alt="Screen Shot 2022-04-28 at 10 03 34" src="https://user-images.githubusercontent.com/38718/165758354-7452436a-4326-4f05-a497-b9c8d66d58cc.png">





