### PR TITLE
Fix position of Single Student Actions menu

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -373,6 +373,16 @@
 }
 
 .sensei-learners-main {
+	.components-popover {
+		&:not( [data-y-axis='middle'] )[data-x-axis='left'] {
+			>.components-popover__content {
+				margin-right: -18px;
+			}
+		}
+	}
+	.column-actions {
+		width: 2.2em;
+	}
 	.tablenav {
 		&.top {
 			@media screen and (max-width: 782px) {


### PR DESCRIPTION
Resolves part of #4959


### Changes proposed in this Pull Request
*  Reduce space between the three dots menu and the table right border
*  Adjust the Student Action Menu position

### Screenshot / Video
<img width="1480" alt="Screen Shot 2022-04-27 at 09 49 14" src="https://user-images.githubusercontent.com/38718/165521683-439f05fb-f477-48f7-a7ad-79fa2d94dc1d.png">

