### PR TITLE
Rename the `Select Courses` button to `Select Action`

### DIFF
--- a/assets/admin/students/student-bulk-action-button/index.js
+++ b/assets/admin/students/student-bulk-action-button/index.js
@@ -81,7 +81,7 @@ export const StudentBulkActionButton = () => {
 				id="sensei-bulk-learner-actions-modal-toggle"
 				onClick={ openModal }
 			>
-				{ __( 'Select Courses', 'sensei-lms' ) }
+				{ __( 'Select Action', 'sensei-lms' ) }
 			</Button>
 			<input type="hidden" id="bulk-action-user-ids" />
 			{ isModalOpen && (

--- a/assets/admin/students/student-bulk-action-button/index.test.js
+++ b/assets/admin/students/student-bulk-action-button/index.test.js
@@ -8,6 +8,13 @@ import { render, screen } from '@testing-library/react';
 import { StudentBulkActionButton } from './index';
 import nock from 'nock';
 
+/**
+ *  Create a custom screen selector that ignores text inside html tags like hello <strong> world</strong>
+ *
+ * @param {string} value Text value to be searched without tags. E.g. "Hello Word".
+ * @return {Function} custom selector can be used by screen.getByText to match text with inline html.
+ */
+
 const ignoreInlineTags = ( value ) => ( _, node ) => {
 	const hasText = ( n ) => n.textContent === value;
 	const nodeHasText = hasText( node );

--- a/assets/admin/students/student-bulk-action-button/index.test.js
+++ b/assets/admin/students/student-bulk-action-button/index.test.js
@@ -8,6 +8,16 @@ import { render, screen } from '@testing-library/react';
 import { StudentBulkActionButton } from './index';
 import nock from 'nock';
 
+const ignoreInlineTags = ( value ) => ( _, node ) => {
+	const hasText = ( n ) => n.textContent === value;
+	const nodeHasText = hasText( node );
+	const childrenDontHaveText = Array.from( node.children ).every(
+		( child ) => ! hasText( child )
+	);
+
+	return nodeHasText && childrenDontHaveText;
+};
+
 let spy;
 const courses = [
 	{
@@ -22,6 +32,11 @@ beforeAll( () => {
 	spy = jest.spyOn( document, 'getElementById' );
 } );
 describe( '<StudentBulkActionButton />', () => {
+	const selectActionButton = () =>
+		screen.getByRole( 'button', {
+			name: 'Select Action',
+		} );
+
 	beforeAll( () => {
 		nock( NOCK_HOST_URL )
 			.persist()
@@ -29,7 +44,8 @@ describe( '<StudentBulkActionButton />', () => {
 			.query( { per_page: 100 } )
 			.reply( 200, courses );
 	} );
-	it( 'Student modal is rendered with action to add students on button click when add option is selected', () => {
+
+	it( 'Should render the `Add to course` modal', () => {
 		setupSelector( [
 			{ value: 'enrol_restore_enrolment', selected: true },
 			{ value: 'remove_progress' },
@@ -37,21 +53,17 @@ describe( '<StudentBulkActionButton />', () => {
 		] );
 		render( <StudentBulkActionButton /> );
 
-		// Click Select Courses button to open modal.
-		const button = screen.getByRole( 'button', {
-			id: 'sensei-bulk-learner-actions-modal-toggle',
-		} );
-		button.click();
+		selectActionButton().click();
 		expect(
-			screen.getByText( 'Select the course(s) you would like to add', {
-				exact: false,
-			} ).textContent
-		).toEqual(
-			'Select the course(s) you would like to add 3 students to:'
-		);
+			screen.getByText(
+				ignoreInlineTags(
+					'Select the course(s) you would like to add 3 students to:'
+				)
+			)
+		).toBeInTheDocument();
 	} );
 
-	it( 'Student modal is rendered with action to remove progress on button click when remove progress is selected', () => {
+	it( 'Should render the `Reset or Remove Progress` modal', () => {
 		setupSelector( [
 			{ value: 'enrol_restore_enrolment' },
 			{ value: 'remove_progress', selected: true },
@@ -59,23 +71,17 @@ describe( '<StudentBulkActionButton />', () => {
 		] );
 		render( <StudentBulkActionButton /> );
 
-		// Click Select Courses button to open modal.
-		const button = screen.getByRole( 'button', {
-			id: 'sensei-bulk-learner-actions-modal-toggle',
-		} );
-		button.click();
+		selectActionButton().click();
+
 		expect(
 			screen.getByText(
-				'Select the course(s) you would like to reset or remove progress from for ',
-				{
-					exact: false,
-				}
-			).textContent
-		).toEqual(
-			'Select the course(s) you would like to reset or remove progress from for 3 students:'
-		);
+				ignoreInlineTags(
+					'Select the course(s) you would like to reset or remove progress from for 3 students:'
+				)
+			)
+		).toBeInTheDocument();
 	} );
-	it( 'Student modal is rendered with action to remove students on button click when remove from course is selected', () => {
+	it( 'Should render the `Remove from Course` modal', () => {
 		setupSelector( [
 			{ value: 'enrol_restore_enrolment' },
 			{ value: 'remove_progress' },
@@ -83,21 +89,14 @@ describe( '<StudentBulkActionButton />', () => {
 		] );
 		render( <StudentBulkActionButton /> );
 
-		// Click Select Courses button to open modal.
-		const button = screen.getByRole( 'button', {
-			id: 'sensei-bulk-learner-actions-modal-toggle',
-		} );
-		button.click();
+		selectActionButton().click();
 		expect(
 			screen.getByText(
-				'Select the course(s) you would like to remove ',
-				{
-					exact: false,
-				}
-			).textContent
-		).toEqual(
-			'Select the course(s) you would like to remove 3 students from:'
-		);
+				ignoreInlineTags(
+					'Select the course(s) you would like to remove 3 students from:'
+				)
+			)
+		).toBeInTheDocument();
 	} );
 } );
 


### PR DESCRIPTION
Resolves part of #4959


### Changes proposed in this Pull Request
*  Rename the Select Course Button to Select Action


### Screenshot / Video
<img width="1307" alt="Screen Shot 2022-04-27 at 16 06 23" src="https://user-images.githubusercontent.com/38718/165601120-bd2fa708-8e8d-48d7-884d-1ef22bc4d014.png">

### Extra notes
Layout adjustments related to this button were covered on the PR #5072 
