### PR TITLE
Add a filter for students on a course by Date Started

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -109,13 +109,12 @@
 		flex: 1;
 		.tablenav {
 			.tablenav-pages {
-				line-height: 25px;
 				margin-right: 20px;
 			}
 		}
 	}
 
-	.sensei-analysis {
+	.sensei-analysis, .sensei-analysis-course {
 		&__top-filters {
 			float: left;
 			display: flex;
@@ -132,6 +131,43 @@
 			margin: 50px 0;
 			text-align: center;
 			font-size: 14px;
+		}
+	}
+
+	.sensei-analysis-course {
+		&__table-header {
+			float: left;
+		}
+
+		&__submenu {
+				list-style: none;
+				margin: 0;
+				padding: 0;
+				font-size: 13px;
+				color: #646970;
+
+			 a {
+				line-height: 2;
+				padding: .2em;
+				text-decoration: none;
+			}
+
+			a.current {
+				color: #000000;
+				font-weight: 600;
+				border: none;
+			}
+
+			li {
+				display: inline-block;
+				margin: 0;
+				padding: 0;
+				white-space: nowrap;
+			}
+		}
+
+		&__top-filters {
+			margin: 5px 0 7px;
 		}
 	}
 }

--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -12,11 +12,48 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 
+	use Sensei_Reports_Helper_Date_Range_Trait;
+
+	/**
+	 * User ID.
+	 *
+	 * @var int
+	 */
 	public $user_id;
+
+	/**
+	 * Course ID.
+	 *
+	 * @var int
+	 */
 	public $course_id;
+
+	/**
+	 * Total number of lessons.
+	 *
+	 * @var int
+	 */
 	public $total_lessons;
+
+	/**
+	 * User IDs.
+	 *
+	 * @var array
+	 */
 	public $user_ids;
+
+	/**
+	 * Page slug.
+	 *
+	 * @var string
+	 */
 	public $page_slug;
+
+	/**
+	 * Selected view.
+	 *
+	 * @var string
+	 */
 	public $view = 'lesson';
 
 	/**
@@ -29,11 +66,14 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	/**
 	 * Constructor
 	 *
+	 * @param int $course_id Course ID.
+	 * @param int $user_id User ID.
+	 *
 	 * @since  1.2.0
 	 */
 	public function __construct( $course_id = 0, $user_id = 0 ) {
-		$this->course_id = intval( $course_id );
-		$this->user_id   = intval( $user_id );
+		$this->course_id = (int) $course_id;
+		$this->user_id   = (int) $user_id;
 		$this->page_slug = Sensei_Analysis::PAGE_SLUG;
 
 		if ( isset( $_GET['view'] ) && in_array( $_GET['view'], array( 'user', 'lesson' ) ) ) {
@@ -788,66 +828,6 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		}
 
 		return $text;
-	}
-
-	/**
-	 * Get the start date filter value.
-	 *
-	 * @return string The start date.
-	 */
-	private function get_start_date_filter_value(): string {
-		$default = gmdate( 'Y-m-d', strtotime( '-30 days' ) );
-
-		// phpcs:ignore WordPress.Security -- The date is sanitized by DateTime.
-		$start_date = $_GET['start_date'] ?? $default;
-
-		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
-	}
-
-	/**
-	 * Get the start date filter value including the time.
-	 *
-	 * @return string The start date including the time or empty string if none.
-	 */
-	protected function get_start_date_and_time(): string {
-		$start_date = DateTime::createFromFormat( 'Y-m-d', $this->get_start_date_filter_value() );
-
-		if ( ! $start_date ) {
-			return '';
-		}
-
-		$start_date->setTime( 0, 0, 0 );
-
-		return $start_date->format( 'Y-m-d H:i:s' );
-	}
-
-	/**
-	 * Get the end date filter value.
-	 *
-	 * @return string The end date or empty string if none.
-	 */
-	private function get_end_date_filter_value(): string {
-		// phpcs:ignore WordPress.Security -- The date is sanitized by DateTime.
-		$end_date = $_GET['end_date'] ?? '';
-
-		return DateTime::createFromFormat( 'Y-m-d', $end_date ) ? $end_date : '';
-	}
-
-	/**
-	 * Get the end date filter value including the time.
-	 *
-	 * @return string The end date including the time or empty string if none.
-	 */
-	protected function get_end_date_and_time(): string {
-		$end_date = DateTime::createFromFormat( 'Y-m-d', $this->get_end_date_filter_value() );
-
-		if ( ! $end_date ) {
-			return '';
-		}
-
-		$end_date->setTime( 23, 59, 59 );
-
-		return $end_date->format( 'Y-m-d H:i:s' );
 	}
 
 	/**

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -74,6 +74,7 @@ class Sensei_Autoloader {
 			new Sensei_Autoloader_Bundle( 'course-theme' ),
 			new Sensei_Autoloader_Bundle( 'course-video' ),
 			new Sensei_Autoloader_Bundle( 'course-video/blocks' ),
+			new Sensei_Autoloader_Bundle( 'reports/helper' ),
 			new Sensei_Autoloader_Bundle( 'reports/overview/data-provider' ),
 			new Sensei_Autoloader_Bundle( 'reports/overview/list-table' ),
 		);

--- a/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
+++ b/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * File containing the Sensei_Reports_Helper_Date_Range_Trait trait.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * This trait contains shared methods related to date range params handling.
+ */
+trait Sensei_Reports_Helper_Date_Range_Trait {
+	/**
+	 * Get the start date filter value.
+	 *
+	 * @return string The start date.
+	 */
+	protected function get_start_date_filter_value(): string {
+		$default = gmdate( 'Y-m-d', strtotime( '-30 days' ) );
+
+		// phpcs:ignore WordPress.Security -- The date is sanitized by DateTime.
+		$start_date = $_GET['start_date'] ?? $default;
+
+		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
+	}
+
+	/**
+	 * Get the start date filter value including the time.
+	 *
+	 * @return string The start date including the time or empty string if none.
+	 */
+	protected function get_start_date_and_time(): string {
+		$start_date = DateTime::createFromFormat( 'Y-m-d', $this->get_start_date_filter_value() );
+
+		if ( ! $start_date ) {
+			return '';
+		}
+
+		$start_date->setTime( 0, 0, 0 );
+
+		return $start_date->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * Get the end date filter value.
+	 *
+	 * @return string The end date or empty string if none.
+	 */
+	protected function get_end_date_filter_value(): string {
+		// phpcs:ignore WordPress.Security -- The date is sanitized by DateTime.
+		$end_date = $_GET['end_date'] ?? '';
+
+		return DateTime::createFromFormat( 'Y-m-d', $end_date ) ? $end_date : '';
+	}
+
+	/**
+	 * Get the end date filter value including the time.
+	 *
+	 * @return string The end date including the time or empty string if none.
+	 */
+	protected function get_end_date_and_time(): string {
+		$end_date = DateTime::createFromFormat( 'Y-m-d', $this->get_end_date_filter_value() );
+
+		if ( ! $end_date ) {
+			return '';
+		}
+
+		$end_date->setTime( 23, 59, 59 );
+
+		return $end_date->format( 'Y-m-d H:i:s' );
+	}
+}

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
@@ -16,6 +16,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_Table {
 
+	use Sensei_Reports_Helper_Date_Range_Trait;
+
 	/**
 	 * Reports page slug.
 	 *
@@ -356,66 +358,6 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 	private function get_order_value(): string {
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for filtering.
 		return isset( $_GET['order'] ) ? sanitize_key( wp_unslash( $_GET['order'] ) ) : 'ASC';
-	}
-
-	/**
-	 * Get the start date filter value.
-	 *
-	 * @return string The start date.
-	 */
-	private function get_start_date_filter_value(): string {
-		$default = gmdate( 'Y-m-d', strtotime( '-30 days' ) );
-
-		// phpcs:ignore WordPress.Security -- The date is sanitized by DateTime.
-		$start_date = $_GET['start_date'] ?? $default;
-
-		return DateTime::createFromFormat( 'Y-m-d', $start_date ) ? $start_date : '';
-	}
-
-	/**
-	 * Get the start date filter value including the time.
-	 *
-	 * @return string The start date including the time or empty string if none.
-	 */
-	protected function get_start_date_and_time(): string {
-		$start_date = DateTime::createFromFormat( 'Y-m-d', $this->get_start_date_filter_value() );
-
-		if ( ! $start_date ) {
-			return '';
-		}
-
-		$start_date->setTime( 0, 0, 0 );
-
-		return $start_date->format( 'Y-m-d H:i:s' );
-	}
-
-	/**
-	 * Get the end date filter value.
-	 *
-	 * @return string The end date or empty string if none.
-	 */
-	private function get_end_date_filter_value(): string {
-		// phpcs:ignore WordPress.Security -- The date is sanitized by DateTime.
-		$end_date = $_GET['end_date'] ?? '';
-
-		return DateTime::createFromFormat( 'Y-m-d', $end_date ) ? $end_date : '';
-	}
-
-	/**
-	 * Get the end date filter value including the time.
-	 *
-	 * @return string The end date including the time or empty string if none.
-	 */
-	protected function get_end_date_and_time(): string {
-		$end_date = DateTime::createFromFormat( 'Y-m-d', $this->get_end_date_filter_value() );
-
-		if ( ! $end_date ) {
-			return '';
-		}
-
-		$end_date->setTime( 23, 59, 59 );
-
-		return $end_date->format( 'Y-m-d H:i:s' );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
@@ -67,6 +67,7 @@ class Sensei_Analysis_Course_List_Table_Test extends WP_UnitTestCase {
 			$user2_id,
 			$user3_id,
 		];
+		sort( $expected );
 		self::assertSame( $expected, $this->export_items( $table->items ) );
 	}
 
@@ -106,6 +107,7 @@ class Sensei_Analysis_Course_List_Table_Test extends WP_UnitTestCase {
 			$user3_id,
 			$user4_id,
 		];
+		sort( $expected );
 		self::assertSame( $expected, $this->export_items( $table->items ) );
 	}
 
@@ -114,6 +116,7 @@ class Sensei_Analysis_Course_List_Table_Test extends WP_UnitTestCase {
 		foreach ( $items as $item ) {
 			$ret[] = (int) $item->user_id;
 		}
+		sort( $ret );
 		return $ret;
 	}
 }

--- a/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
@@ -1,0 +1,119 @@
+<?php
+
+/**
+ * Sensei Analysis Course List Table Unit Test.
+ *
+ * @covers Sensei_Analysis_Course_List_Table
+ */
+class Sensei_Analysis_Course_List_Table_Test extends WP_UnitTestCase {
+	private static $initial_hook_suffix;
+
+	/**
+	 * Factory object.
+	 *
+	 * @var Sensei_Factory
+	 */
+	protected $factory;
+
+	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+		self::$initial_hook_suffix = $GLOBALS['hook_suffix'] ?? null;
+		$GLOBALS['hook_suffix']    = null;
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+		$GLOBALS['hook_suffix'] = self::$initial_hook_suffix;
+	}
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+	}
+
+	public function testPrepareItems_DateStartedFilterSet_SetsMatchingItems() {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+
+		$user1_id = $this->factory->user->create();
+		$user2_id = $this->factory->user->create();
+		$user3_id = $this->factory->user->create();
+		$user4_id = $this->factory->user->create();
+
+		$activity1_id = Sensei_Utils::start_user_on_course( $user1_id, $course_id );
+		$activity2_id = Sensei_Utils::start_user_on_course( $user2_id, $course_id );
+		$activity3_id = Sensei_Utils::start_user_on_course( $user3_id, $course_id );
+		$activity4_id = Sensei_Utils::start_user_on_course( $user4_id, $course_id );
+
+		update_comment_meta( $activity1_id, 'start', '2018-01-01' );
+		update_comment_meta( $activity2_id, 'start', '2018-01-02' );
+		update_comment_meta( $activity3_id, 'start', '2018-01-03' );
+		update_comment_meta( $activity4_id, 'start', '2018-01-04' );
+
+		$_GET['start_date'] = '2018-01-02';
+		$_GET['end_date']   = '2018-01-03';
+		$_GET['view']       = 'user';
+
+		/* Act. */
+		$table = new Sensei_Analysis_Course_List_Table( $course_id );
+		$table->prepare_items();
+
+		/* Assert. */
+		$expected = [
+			$user2_id,
+			$user3_id,
+		];
+		self::assertSame( $expected, $this->export_items( $table->items ) );
+	}
+
+	public function testPrepareItems_DefaultDateStartedFilterSet_SetsMatchingItems() {
+		/* Arrange. */
+		$course_id = $this->factory->course->create();
+
+		$user1_id = $this->factory->user->create();
+		$user2_id = $this->factory->user->create();
+		$user3_id = $this->factory->user->create();
+		$user4_id = $this->factory->user->create();
+
+		$activity1_id = Sensei_Utils::start_user_on_course( $user1_id, $course_id );
+		$activity2_id = Sensei_Utils::start_user_on_course( $user2_id, $course_id );
+		$activity3_id = Sensei_Utils::start_user_on_course( $user3_id, $course_id );
+		$activity4_id = Sensei_Utils::start_user_on_course( $user4_id, $course_id );
+
+		$more_than_30days_ago = new DateTime( '-31 day' );
+		$exactly_30days_ago   = new DateTime( '-30 day' );
+		$week_ago             = new DateTime( '-7 day' );
+		$today                = new DateTime( 'now' );
+
+		update_comment_meta( $activity1_id, 'start', $more_than_30days_ago->format( 'Y-m-d' ) );
+		update_comment_meta( $activity2_id, 'start', $exactly_30days_ago->format( 'Y-m-d' ) );
+		update_comment_meta( $activity3_id, 'start', $week_ago->format( 'Y-m-d' ) );
+		update_comment_meta( $activity4_id, 'start', $today->format( 'Y-m-d' ) );
+
+		$_GET['view'] = 'user';
+
+		/* Act. */
+		$table = new Sensei_Analysis_Course_List_Table( $course_id );
+		$table->prepare_items();
+
+		/* Assert. */
+		$expected = [
+			$user2_id,
+			$user3_id,
+			$user4_id,
+		];
+		self::assertSame( $expected, $this->export_items( $table->items ) );
+	}
+
+	private function export_items( array $items ) {
+		$ret = [];
+		foreach ( $items as $item ) {
+			$ret[] = (int) $item->user_id;
+		}
+		return $ret;
+	}
+}


### PR DESCRIPTION
Fixes #5016 

### Changes proposed in this Pull Request

* Add a filter for students on a course by Date Started

### Testing instructions

* Add a course and a few students.
* Enrol the course for these students.
* Update "Date Started" for these students on the course (you can do it by going to Student Management and clicking on the corresponding course); set different dates for further experiments with filters. For example, set over 30 days ago for one of them, and 30 to 0 days ago for others.
* Go to Reports, click on Courses tab, click on the course.
* Click on "Students taking this Course".
* Try Date Started filter.
* Make sure you see students with Date Started in the filter date range.

### Screenshot / Video

*Default filter*
<img width="1438" alt="CleanShot 2022-04-29 at 00 43 17@2x" src="https://user-images.githubusercontent.com/329356/165851508-5da32629-f746-49c8-abc1-f3bb749ebe4f.png">

*Custom beginning of the range was set*
<img width="1437" alt="CleanShot 2022-04-29 at 00 43 59@2x" src="https://user-images.githubusercontent.com/329356/165851729-b05d606c-c4a2-4640-a2a9-ac31be99eeee.png">

*Custom beginning and end of the range were set*
<img width="1437" alt="CleanShot 2022-04-29 at 00 44 30@2x" src="https://user-images.githubusercontent.com/329356/165851833-75e8b7aa-52c6-4e3a-a2ed-aa38b0cce2d4.png">


