### PR TITLE
Remove infinite loop on test execution

### DIFF
--- a/assets/shared/structure/structure-store.test.js
+++ b/assets/shared/structure/structure-store.test.js
@@ -55,16 +55,20 @@ describe( 'Structure store', () => {
 		expect( store.readBlock ).toHaveBeenCalled();
 	} );
 
-	it( 'Saves structure when post is being saved', function () {
-		store.readBlock.mockReturnValue( { structure: 'block' } );
-
+	it( 'Saves structure when post is being saved', () => {
+		const savePost = jest.spyOn( dispatch( 'core/editor' ), 'savePost' );
+		store.readBlock.mockReturnValue( 'new' );
+		apiFetch.mockReturnValue( 'new' );
 		dispatch( 'core/editor' ).savePost();
-
 		expect( apiFetch ).toHaveBeenCalledWith( {
 			method: 'POST',
 			path: '/sensei-internal/v1/test-api/1',
-			data: { structure: 'block' },
+			data: 'new',
 		} );
+
+		// Check if there is not an infinite loop.
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( savePost ).toHaveBeenCalledTimes( 1 );
 	} );
 
 	it( 'Re-saves post on change after structure save', () => {
@@ -72,10 +76,12 @@ describe( 'Structure store', () => {
 		store.readBlock
 			.mockReturnValueOnce( 'old' )
 			.mockReturnValueOnce( 'new' );
+
 		apiFetch.mockReturnValue( 'new' );
 
 		dispatch( 'core/editor' ).savePost();
 
 		expect( savePost ).toHaveBeenCalledTimes( 2 );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 	} );
 } );


### PR DESCRIPTION
Fixes an already existing issue detected during the #4959 development.

## Context
Currently, the blocks that implement the  `structured-store`, [are syncing the state of the block structure, automatically after the post is saved.](https://github.com/Automattic/sensei/blob/69afbaa10eb8b14fcc0e86ddd0904525fd089287/assets/shared/structure/structure-store.js#L254-L257), so the action `startPostSave` checks if the current state `state.editorStructure`  is `!=` of the state returned by the backend, (this diff is represented by the `hasUnsavedServerUpdates` state), calling the `saveStructure` [action again](https://github.com/Automattic/sensei/blob/69afbaa10eb8b14fcc0e86ddd0904525fd089287/assets/shared/structure/structure-store.js#L140-L142).


## Root Cause
The root cause of the ` Maximum call stack size exceeded` issue, was that the `save post` test was not configuring properly the result of the sync process, so the `structured-store` was always assuming that the internal state, defined by the `readBlock` [mock](https://github.com/Automattic/sensei/blob/69afbaa10eb8b14fcc0e86ddd0904525fd089287/assets/shared/structure/structure-store.js#L134), was always different of the result of the [apiFetch sync call](https://github.com/Automattic/sensei/blob/69afbaa10eb8b14fcc0e86ddd0904525fd089287/assets/shared/structure/structure-store.js#L76-L80). It was leading the code to an infinite unsynchronized state, generating a infinite loop. 

>savePost>`startPostSave`> InternalState!=ServerState>saveStructure>finishPostSave>savePost > ...Infinite loop.

This process is complete async, so it was not blocking the node execution but it was increasing the node stack size while the test suite was executing all tests, so when we run the tests our machines, the time to execute the test was not enough to throw the  `Maximum call stack size exceeded`, but our CI execute the tests slower, so it was causing issues.

## Solution
I just fixed the test setup to always ensure the sync process is happening properly and I add an assertion to check the number of times the `savePost` [method was called. ](https://github.com/Automattic/sensei/pull/5078/files#diff-cfac13c399bf68838488371681bab1376b96fab3b5625b6e085de43c02551777R71)


### Testing instructions

- Remove the apiFech [mock configuration ](https://github.com/Automattic/sensei/blob/69afbaa10eb8b14fcc0e86ddd0904525fd089287/assets/shared/structure/structure-store.test.js#L61)

- Run the ` npm run test-js assets/shared/structure/structure-store.test.js` 
- Check if the test output, it should be something similar to it:

```
● Structure store › Saves structure when post is being saved

    expect(jest.fn()).toHaveBeenCalledTimes(expected)

    Expected number of calls: 1
    Received number of calls: 38
```

- Enable again the apiFech mock configuration and check if the test is passing.
- Run all test and check if there is no warning  related to `Mtestsum call stack size exceeded`

