### PR TITLE
CSV will contain only the searched items if exported after searching

### DIFF
--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
@@ -314,6 +314,7 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 				'course_filter'          => $this->get_course_filter_value(),
 				'start_date'             => $this->get_start_date_filter_value(),
 				'end_date'               => $this->get_end_date_filter_value(),
+				's'                      => $this->get_search_value(),
 			),
 			admin_url( 'edit.php' )
 		);
@@ -418,6 +419,15 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 		return $end_date->format( 'Y-m-d H:i:s' );
 	}
 
+	/**
+	 * Get the search value.
+	 *
+	 * @return string search param value.
+	 */
+	private function get_search_value(): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for filtering.
+		return isset( $_GET['s'] ) ? esc_attr( sanitize_text_field( wp_unslash( $_GET['s'] ) ) ) : '';
+	}
 	/**
 	 * Format the last activity date to a more readable form.
 	 *

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
@@ -88,4 +88,32 @@ class Sensei_Reports_Overview_List_Table_Abstract_Test extends WP_UnitTestCase {
 		];
 		self::assertSame( $expected, $actual );
 	}
+
+	public function testTableFooter_WhenCalled_GeneratesProperHtmlFoFooter() {
+		/* Arrange. */
+		$nonce = wp_create_nonce( 'sensei_csv_download' );
+		$_GET  = [
+			's'             => 'course 5',
+			'order'         => 'asc  ',
+			'orderby'       => 'id  ',
+			'start_date'    => '2022-03-01',
+			'end_date'      => '2022-03-01',
+			'course_filter' => 1,
+			'_wpnonce'      => $nonce,
+
+		];
+		$data_provider = $this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class );
+		$list_table    = $this->getMockBuilder( Sensei_Reports_Overview_List_Table_Abstract::class )
+			->setConstructorArgs( [ 'a', $data_provider ] )
+			->getMockForAbstractClass();
+
+		/* Act. */
+		ob_start();
+		$list_table->data_table_footer();
+		$actual = ob_get_clean();
+
+		/* Assert. */
+		$expected = '<a class="button button-primary" href="http://example.org/wp-admin/edit.php?page=sensei_reports&#038;view=a&#038;sensei_report_download=user-overview&#038;post_type=course&#038;orderby=id&#038;order=asc&#038;course_filter=1&#038;start_date=2022-03-01&#038;end_date=2022-03-01&#038;s=course+5&#038;_sdl_nonce=' . $nonce . '">Export all rows (CSV)</a>';
+		self::assertSame( $expected, $actual, 'Html for footer was not generated properly' );
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/4988

### Changes proposed in this Pull Request

* Tables in Reports weren't taking searched string into consideration when exported as CSV. It is fixed here. Also have added a test for the footer.

### Testing instructions
- Go to reports.
- Do a filter by date/course depending on what page are you on. The table will be populated now
- Do a search using the search box on top-right
- Make sure search worked
- Now export the csv for each report page
- Make sure that they contains only the items you searched for

### Screenshot / Video
![image](https://user-images.githubusercontent.com/6820724/165778906-08c82f3d-9586-4511-91a5-5589ff745e5b.png)
