### PR TITLE
Fix lesson compatibility issue with Divi

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-compat.php
+++ b/includes/course-theme/class-sensei-course-theme-compat.php
@@ -77,6 +77,14 @@ class Sensei_Course_Theme_Compat {
 	 * @return string The wrapper template path.
 	 */
 	public function get_wrapper_template( $template ) {
+		// Fix compatibility issue with Divi builder.
+		if (
+			class_exists( 'ET_GB_Block_Layout' )
+			&& method_exists( 'ET_GB_Block_Layout', 'is_layout_block_preview' )
+			&& ET_GB_Block_Layout::is_layout_block_preview()
+		) {
+			return $template;
+		}
 
 		if ( ! preg_match( '/template-canvas.php$/', $template ) ) {
 			return Sensei_Course_Theme::instance()->get_course_theme_root() . '/index.php';
@@ -127,7 +135,7 @@ class Sensei_Course_Theme_Compat {
 	/**
 	 * Get custom logo from the original theme's customize settings if it was not found already.
 	 *
-	 * @param string $custom_logo
+	 * @param string $custom_logo Custom logo.
 	 *
 	 * @return string
 	 */


### PR DESCRIPTION
Fixes #5067

### Changes proposed in this Pull Request

* Fixes Lesson compatibility issue with Divi when Learning Mode is enabled.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
1. Enable Divi Builder on Course and Lesson post types (Divi > Theme Options > Builder).
2. Create a new Course with Learning Mode enabled, and a new Lesson within that Course. Use the default editor for both.
3. Add some blocks to the top of the Lesson.
4. Add a "Divi Layout" block. Create a new layout in the builder.
5. In the Lesson editor, make sure the layout is displayed as expected (without duplicating all the editor content).
6. Setup an env with WP 5.8, repeat the steps, and make sure you can edit the lessons properly, and they look well in the frontend.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="842" alt="Screen Shot 2022-04-28 at 19 16 07" src="https://user-images.githubusercontent.com/876340/165856726-6e5e55c6-daf2-443c-809a-2920b6f9d953.png">