### PR TITLE
Ensure the content filter for course content is re-added in Learning Mode

### DIFF
--- a/includes/blocks/course-theme/class-course-content.php
+++ b/includes/blocks/course-theme/class-course-content.php
@@ -56,7 +56,7 @@ class Course_Content {
 	 *
 	 * @access private
 	 *
-	 * @param string $content
+	 * @param string $content The content of the post.
 	 *
 	 * @return string HTML
 	 */
@@ -82,6 +82,8 @@ class Course_Content {
 		}
 
 		$wrapper_attributes = get_block_wrapper_attributes( array( 'class' => 'entry-content' ) );
+
+		add_filter( 'the_content', [ $this, 'render_content' ] );
 
 		return (
 			'<div ' . $wrapper_attributes . '>' .


### PR DESCRIPTION
Fixes https://github.com/Automattic/evergreen/issues/148

### Changes proposed in this Pull Request

When rendering course content in learning mode, ensure the `the_content` filter is re-added after being temporarily removed. Otherwise, if `the_content` is called early, the filter is removed and some content may not show up on the frontend.

### Testing instructions

One way to see this is by following the steps below. This is an incompatibility with a specific plugin, but it's possible that this could be showing up in other places as well.

- Install the "Rank Math SEO" plugin.
- Create a course with a lesson and a quiz. Enable Learning Mode.
- In Sensei Settings > Courses, ensure the setting "Enable theme styles" is checked and saved.
- Enrol in the course and view the quiz. Without the change from this PR, the quiz questions do not display (Rank Math SEO does something earlier which calls `the_content`). With this change, the quiz is rendered properly.