### PR TITLE
Add lesson notices filters

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -4442,7 +4442,7 @@ class Sensei_Lesson {
 	}
 
 	/**
-	 * Outputs the lessons course signup lingk
+	 * Outputs the lessons course signup link.
 	 *
 	 * This hook runs inside the single lesson page.
 	 *
@@ -4469,7 +4469,7 @@ class Sensei_Lesson {
 		 * @return {bool} Whether to show the course sign up notice.
 		 */
 		if ( apply_filters( 'sensei_lesson_show_course_signup_notice', $show_course_signup_notice, $course_id ) ) {
-			$course_link  = '<a href="' . esc_url( get_permalink( $course_id ) ) . '" title="' . esc_attr__( 'Sign Up', 'sensei-lms' ) . '">';
+			$course_link  = '<a href="' . esc_url( Sensei()->lesson->get_take_course_url( $course_id ) ) . '" title="' . esc_attr__( 'Sign Up', 'sensei-lms' ) . '">';
 			$course_link .= esc_html__( 'course', 'sensei-lms' );
 			$course_link .= '</a>';
 
@@ -4503,6 +4503,34 @@ class Sensei_Lesson {
 			Sensei()->notices->add_notice( $message, $notice_level );
 		}
 
+	}
+
+	/**
+	 * Get take course URL.
+	 *
+	 * @param int $course_id Course ID.
+	 *
+	 * @return string Take course URL.
+	 */
+	public function get_take_course_url( $course_id ) {
+		/**
+		 * Filter the take course URL displayed in lessons.
+		 * Notice that in Learning Mode, when user is logged-in, it will not use this
+		 * filter and directly enroll the user in the course.
+		 *
+		 * @since x.x.x
+		 * @hook sensei_lesson_take_course_url
+		 *
+		 * @param {string} $take_course_url Take course URL.
+		 * @param {int}    $course_id       Course ID.
+		 *
+		 * @return {string} Returns filtered take course URL.
+		 */
+		return apply_filters(
+			'sensei_lesson_take_course_url',
+			get_permalink( $course_id ),
+			$course_id
+		);
 	}
 
 	/**

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -250,7 +250,7 @@ class Sensei_Course_Theme_Lesson {
 			$actions = [
 				[
 					'label' => __( 'Take course', 'sensei-lms' ),
-					'url'   => $this->get_logged_out_take_course_url( $course_id ),
+					'url'   => Sensei()->lesson->get_take_course_url( $course_id ),
 					'style' => 'primary',
 				],
 				[
@@ -303,32 +303,6 @@ class Sensei_Course_Theme_Lesson {
 			$notice_title,
 			$actions,
 			$notice_icon
-		);
-	}
-
-	/**
-	 * Get take course URL when student is not enrolled.
-	 *
-	 * @param int $course_id Course ID.
-	 *
-	 * @return string Take course URL
-	 */
-	private function get_logged_out_take_course_url( $course_id ) {
-		/**
-		 * Filter the take course URL when student is not enrolled.
-		 *
-		 * @since x.x.x
-		 * @hook sensei_learning_mode_logged_out_take_course_url
-		 *
-		 * @param {string} $take_course_url Take course URL.
-		 * @param {int}    $course_id       Course ID.
-		 *
-		 * @return {string} Returns filtered take course URL.
-		 */
-		return apply_filters(
-			'sensei_learning_mode_logged_out_take_course_url',
-			get_permalink( $course_id ),
-			$course_id
 		);
 	}
 }

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -250,7 +250,7 @@ class Sensei_Course_Theme_Lesson {
 			$actions = [
 				[
 					'label' => __( 'Take course', 'sensei-lms' ),
-					'url'   => get_permalink( $course_id ),
+					'url'   => $this->get_logged_out_take_course_url( $course_id ),
 					'style' => 'primary',
 				],
 				[
@@ -303,6 +303,32 @@ class Sensei_Course_Theme_Lesson {
 			$notice_title,
 			$actions,
 			$notice_icon
+		);
+	}
+
+	/**
+	 * Get take course URL when student is not enrolled.
+	 *
+	 * @param int $course_id Course ID.
+	 *
+	 * @return string Take course URL
+	 */
+	private function get_logged_out_take_course_url( $course_id ) {
+		/**
+		 * Filter the take course URL when student is not enrolled.
+		 *
+		 * @since x.x.x
+		 * @hook sensei_learning_mode_logged_out_take_course_url
+		 *
+		 * @param {string} $take_course_url Take course URL.
+		 * @param {int}    $course_id       Course ID.
+		 *
+		 * @return {string} Returns filtered take course URL.
+		 */
+		return apply_filters(
+			'sensei_learning_mode_logged_out_take_course_url',
+			get_permalink( $course_id ),
+			$course_id
 		);
 	}
 }

--- a/includes/sensei-functions.php
+++ b/includes/sensei-functions.php
@@ -305,7 +305,18 @@ function sensei_user_registration_url( bool $return_wp_registration_url = true, 
 		$registration_url = add_query_arg( 'redirect_to', $redirect, $registration_url );
 	}
 
-	return $registration_url;
+	/**
+	 * Filter the registration URL.
+	 *
+	 * @since x.x.x
+	 * @hook sensei_registration_url
+	 *
+	 * @param {string} $registration_url Registration URL.
+	 * @param {string} $redirect         Redirect url after registration.
+	 *
+	 * @return {string} Returns filtered registration URL.
+	 */
+	return apply_filters( 'sensei_registration_url', $registration_url, $redirect );
 }
 
 /**
@@ -323,25 +334,33 @@ function sensei_user_registration_url( bool $return_wp_registration_url = true, 
  * @return string The login url.
  */
 function sensei_user_login_url( string $redirect = '' ) {
-
+	$login_url          = '';
 	$my_courses_page_id = intval( Sensei()->settings->get( 'my_course_page' ) );
 	$page               = get_post( $my_courses_page_id );
 
 	if ( $my_courses_page_id && isset( $page->ID ) && 'page' == get_post_type( $page->ID ) ) {
-
 		$my_courses_url = get_permalink( $page->ID );
 		if ( ! empty( $redirect ) ) {
 			$my_courses_url = add_query_arg( 'redirect_to', $redirect, $my_courses_url );
 		}
 
-		return $my_courses_url;
-
+		$login_url = $my_courses_url;
 	} else {
-
-		return wp_login_url( $redirect );
-
+		$login_url = wp_login_url( $redirect );
 	}
 
+	/**
+	 * Filter the login URL.
+	 *
+	 * @since x.x.x
+	 * @hook sensei_login_url
+	 *
+	 * @param {string} $login_url Login URL.
+	 * @param {string} $redirect  Redirect url after login.
+	 *
+	 * @return {string} Returns filtered login URL.
+	 */
+	return apply_filters( 'sensei_login_url', $login_url, $redirect );
 }
 
 /**


### PR DESCRIPTION
Part of #5068

### Changes proposed in this Pull Request

* It adds some filters allowing to customize links used in lesson notices (login, registration and take course).
  * It was implemented as filters only because our Learning Mode block is a generic block for any type of notices.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Add the following filters to your site:
  ```php
  add_filter(
  	'sensei_lesson_take_course_url',
  	function( $take_course_url, $course_id ) {
  		return 'http://lesson-take-course.com?' . $course_id;
  	},
  	10,
  	2
  );
  
  add_filter(
  	'sensei_registration_url',
  	function( $registration_url, $redirect ) {
  		return 'http://registration.com?' . $redirect;
  	},
  	10,
  	2
  );
  
  add_filter(
  	'sensei_login_url',
  	function( $registration_url, $redirect ) {
  		return 'http://login.com?' . $redirect;
  	},
  	10,
  	2
  );
  ```
* Create a course with lessons, and Learning Mode enabled.
  * In WP admin > Settings > General, enable the setting "Anyone can register".
  * Logged-out, access a lesson from the created course.
  * Make sure the "Take course" button was filtered to "lesson take" URL, and "Sign in" to "registration" URL.
  * In WP admin > Settings > General, disable the setting "Anyone can register".
  * Make sure not the "Sign in" link is filtered to "login" URL, and take course continues with the "lesson take" URL.
  * Log-in, access the lesson, and make sure that clicking on "Take course" will automatically enroll the user.
* Create a course with lessons, and Learning Mode disabled.
  * Access a lesson from the created course logged-out and logged-in. Make sure in both situations you see the notice linking to the "lesson take" URL.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

* `sensei_lesson_take_course_url` - Filter the take course URL displayed in lessons. Notice that in Learning Mode, when user is logged-in, it will not use this filter and directly enroll the user in the course.
* `sensei_registration_url` - Filter the registration URL.
* `sensei_login_url` - Filter the login URL.