### PR TITLE
Add warning if future php requirements isn't met

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -25,7 +25,7 @@ jobs:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
               with:
-                  php-version: '7.0'
+                  php-version: '7.2'
                   tools: composer
                   coverage: none
 
@@ -56,13 +56,13 @@ jobs:
             matrix:
                 wp: ['latest']
                 wpmu: [0]
-                php: ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0']
+                php: ['7.2', '7.3', '7.4', '8.0']
                 include:
-                    - php: 7.0
+                    - php: 7.2
                       wp: 5.7
-                    - php: 7.0
+                    - php: 7.2
                       wp: 5.8
-                    - php: 7.0
+                    - php: 7.2
                       wp: latest
                       wpmu: 1
                     - wp: nightly

--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
 		"optimize-autoloader": true,
 		"sort-packages": true,
 		"platform": {
-			"php": "7.0.33"
+			"php": "7.2"
 		},
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b94a56af8d9757de4a42e4a8807d9d5a",
+    "content-hash": "4c159ecd47fd9e982ad9fd9a53c45adb",
     "packages": [],
     "packages-dev": [
         {
@@ -2257,7 +2257,7 @@
         "php": "^7 || ^8"
     },
     "platform-overrides": {
-        "php": "7.0.33"
+        "php": "7.2"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/includes/class-sensei-dependency-checker.php
+++ b/includes/class-sensei-dependency-checker.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 2.0.0
  */
 class Sensei_Dependency_Checker {
-	const MINIMUM_PHP_VERSION = '7.0';
+	const MINIMUM_PHP_VERSION = '7.2';
 
 	/**
 	 * Checks for our PHP version requirement.

--- a/includes/class-sensei-dependency-checker.php
+++ b/includes/class-sensei-dependency-checker.php
@@ -17,32 +17,70 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 2.0.0
  */
 class Sensei_Dependency_Checker {
-	const MINIMUM_PHP_VERSION = '7.2';
+	const MINIMUM_PHP_VERSION        = '7.0';
+	const FUTURE_MINIMUM_PHP_VERSION = '7.2';
 
 	/**
 	 * Checks for our PHP version requirement.
 	 *
 	 * @return bool
 	 */
-	public static function check_php() {
-		return version_compare( phpversion(), self::MINIMUM_PHP_VERSION, '>=' );
+	public static function check_php_requirement() {
+		return self::verify_php( self::MINIMUM_PHP_VERSION );
 	}
 
 	/**
-	 * Adds notice in WP Admin that minimum version of PHP is not met.
+	 * Checks for our future PHP version requirement.
+	 *
+	 * @return bool
+	 */
+	public static function check_future_php_requirement() {
+		return self::verify_php( self::FUTURE_MINIMUM_PHP_VERSION );
+	}
+
+	/**
+	 * Checks for our PHP version requirement.
+	 *
+	 * @return bool
+	 */
+	private static function verify_php( $version ) {
+		return version_compare( phpversion(), $version, '>=' );
+	}
+
+	/**
+	 * Adds error in WP Admin that minimum version of PHP is not met.
+	 *
+	 * @access private
+	 */
+	public static function add_php_error() {
+		// translators: %1$s is version of PHP that Sensei requires; %2$s is the version of PHP WordPress is running on.
+		$message = sprintf( __( '<strong>Sensei LMS</strong> requires a minimum PHP version of %1$s, but you are running %2$s.', 'sensei-lms' ), self::MINIMUM_PHP_VERSION, phpversion() );
+		self::show_php_notice( $message );
+	}
+
+	/**
+	 * Adds warning in WP Admin that the future minimum version of PHP is not met.
 	 *
 	 * @access private
 	 */
 	public static function add_php_notice() {
+		// translators: %1$s is version of PHP that Sensei is going to require in the future; %2$s is the version of PHP WordPress is running on.
+		$message = sprintf( __( '<strong>Sensei LMS</strong> will require, in the next release, a minimum PHP version of %1$s, but you are running %2$s.', 'sensei-lms' ), self::FUTURE_MINIMUM_PHP_VERSION, phpversion() );
+		self::show_php_notice( $message );
+	}
+
+	/**
+	 * Verify if the user can see a PHP compatibility error and then shows the message if appropriate.
+	 *
+	 * @param string $message The message to show
+	 */
+	private static function show_php_notice( $message ) {
 		$screen        = get_current_screen();
 		$valid_screens = array( 'dashboard', 'plugins' );
 
 		if ( ! current_user_can( 'activate_plugins' ) || ! in_array( $screen->id, $valid_screens, true ) ) {
 			return;
 		}
-
-		// translators: %1$s is version of PHP that Sensei requires; %2$s is the version of PHP WordPress is running on.
-		$message = sprintf( __( '<strong>Sensei LMS</strong> requires a minimum PHP version of %1$s, but you are running %2$s.', 'sensei-lms' ), self::MINIMUM_PHP_VERSION, phpversion() );
 
 		echo '<div class="error"><p>';
 		echo wp_kses( $message, array( 'strong' => array() ) );

--- a/includes/class-sensei-dependency-checker.php
+++ b/includes/class-sensei-dependency-checker.php
@@ -41,6 +41,7 @@ class Sensei_Dependency_Checker {
 	/**
 	 * Checks for our PHP version requirement.
 	 *
+	 * @param string $version The PHP requirement to check against.
 	 * @return bool
 	 */
 	private static function verify_php( $version ) {
@@ -72,7 +73,7 @@ class Sensei_Dependency_Checker {
 	/**
 	 * Verify if the user can see a PHP compatibility error and then shows the message if appropriate.
 	 *
-	 * @param string $message The message to show
+	 * @param string $message The message to show.
 	 */
 	private static function show_php_notice( $message ) {
 		$screen        = get_current_screen();

--- a/includes/class-sensei-dependency-checker.php
+++ b/includes/class-sensei-dependency-checker.php
@@ -48,22 +48,22 @@ class Sensei_Dependency_Checker {
 	}
 
 	/**
-	 * Adds error in WP Admin that minimum version of PHP is not met.
+	 * Adds error in WP Admin that the current PHP version doesn't met the current minimum supported version of PHP.
 	 *
 	 * @access private
 	 */
-	public static function add_php_error() {
+	public static function add_php_version_notice() {
 		// translators: %1$s is version of PHP that Sensei requires; %2$s is the version of PHP WordPress is running on.
 		$message = sprintf( __( '<strong>Sensei LMS</strong> requires a minimum PHP version of %1$s, but you are running %2$s.', 'sensei-lms' ), self::MINIMUM_PHP_VERSION, phpversion() );
 		self::show_php_notice( $message );
 	}
 
 	/**
-	 * Adds warning in WP Admin that the future minimum version of PHP is not met.
+	 * Adds warning in WP Admin that the current PHP version doesn't met the future supported minimum version of PHP.
 	 *
 	 * @access private
 	 */
-	public static function add_php_notice() {
+	public static function add_future_php_version_notice() {
 		// translators: %1$s is version of PHP that Sensei is going to require in the future; %2$s is the version of PHP WordPress is running on.
 		$message = sprintf( __( '<strong>Sensei LMS</strong> will require, in the next release, a minimum PHP version of %1$s, but you are running %2$s.', 'sensei-lms' ), self::FUTURE_MINIMUM_PHP_VERSION, phpversion() );
 		self::show_php_notice( $message );

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -73,13 +73,13 @@ if ( class_exists( 'Sensei_Main' ) ) {
 
 require_once dirname( __FILE__ ) . '/includes/class-sensei-dependency-checker.php';
 if ( ! Sensei_Dependency_Checker::check_php_requirement() ) {
-	add_action( 'admin_notices', array( 'Sensei_Dependency_Checker', 'add_php_error' ) );
+	add_action( 'admin_notices', array( 'Sensei_Dependency_Checker', 'add_php_version_notice' ) );
 	return;
 }
 
 
 if ( ! Sensei_Dependency_Checker::check_future_php_requirement() ) {
-	add_action( 'admin_notices', array( 'Sensei_Dependency_Checker', 'add_php_notice' ) );
+	add_action( 'admin_notices', array( 'Sensei_Dependency_Checker', 'add_future_php_version_notice' ) );
 }
 
 if ( ! Sensei_Dependency_Checker::check_assets() ) {

--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -72,9 +72,14 @@ if ( class_exists( 'Sensei_Main' ) ) {
 }
 
 require_once dirname( __FILE__ ) . '/includes/class-sensei-dependency-checker.php';
-if ( ! Sensei_Dependency_Checker::check_php() ) {
-	add_action( 'admin_notices', array( 'Sensei_Dependency_Checker', 'add_php_notice' ) );
+if ( ! Sensei_Dependency_Checker::check_php_requirement() ) {
+	add_action( 'admin_notices', array( 'Sensei_Dependency_Checker', 'add_php_error' ) );
 	return;
+}
+
+
+if ( ! Sensei_Dependency_Checker::check_future_php_requirement() ) {
+	add_action( 'admin_notices', array( 'Sensei_Dependency_Checker', 'add_php_notice' ) );
 }
 
 if ( ! Sensei_Dependency_Checker::check_assets() ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Shows an error when the user is using a PHP version older than 7.2; (but allows the plugins to still work)
* Still shows an error when the user is using a PHP version older than 7.0; (and doesn't allow the plugin to work)
* Updates test matrix to not test PHP versions < 7.2;


### Testing instructions

* Verify the message that is shown when the user is using PHP 7.0; (and if the plugin still works successfully)
* Verify the message that is shown when the user is using PHP 7.2 or higher; (and if the plugin still works successfully)

### Context

p6rkRX-3mw-p2