### PR TITLE
Lessons: Report return empty array when no lessons in course

### DIFF
--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
@@ -50,7 +50,11 @@ class Sensei_Reports_Overview_Data_Provider_Lessons implements Sensei_Reports_Ov
 		}
 		// Fetching the lesson ids beforehand because joining both postmeta and comment + commentmeta makes WP_Query very slow.
 		$course_lessons = $this->course->course_lessons( $filters['course_id'], 'any', 'ids' );
-		$lessons_args   = array(
+		if ( empty( $course_lessons ) ) {
+			return [];
+		}
+
+		$lessons_args = array(
 			'post_type'        => 'lesson',
 			'post_status'      => array( 'publish', 'private' ),
 			'posts_per_page'   => $filters['number'],

--- a/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-lessons.php
+++ b/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-lessons.php
@@ -64,4 +64,41 @@ class Sensei_Reports_Overview_Data_Provider_Lessons_Test extends WP_UnitTestCase
 			'The lessons should be filtered by course.'
 		);
 	}
+
+	/**
+	 * Tests that get items returns no lessons when course doesn't have lessons.
+	 *
+	 * @covers Sensei_Reports_Overview_Data_Provider_Lessons::get_items
+	 */
+	public function testGetItems_returns_no_lessons_if_course_does_not_have_lessons() {
+		// Create 2 courses.
+		$course_id_1 = $this->factory->course->create();
+		$course_id_2 = $this->factory->course->create();
+
+		// Add lessons to second course.
+		$course_lesson_ids = $this->factory->lesson->create_many( 2, [ 'meta_input' => [ '_lesson_course' => $course_id_2 ] ] );
+
+		// Fill the database with other lessons from other courses.
+		$this->factory->lesson->create_many( 2, [ 'meta_input' => [ '_lesson_course' => $this->factory->course->create() ] ] );
+
+		$instance = new Sensei_Reports_Overview_Data_Provider_Lessons( Sensei()->course );
+
+		// Get items for first course.
+		$query_args = [
+			'number'    => -1,
+			'offset'    => 0,
+			'orderby'   => '',
+			'order'     => 'ASC',
+			'course_id' => $course_id_1,
+		];
+
+		$course_lesson_posts = $instance->get_items( $query_args );
+
+		/* Assert. */
+		$this->assertEquals(
+			[],
+			$course_lesson_posts,
+			'No lesson was returned from get items.'
+		);
+	}
 }


### PR DESCRIPTION
Fixes #5089

### Changes proposed in this Pull Request

- Early return if there are no courses_lessons 
- When the empty array is passed to the **post__in** the argument is ignored so all the lessons were returned

### Testing instructions
- Add couple of courses some of them with lessons and one without
- Go to Sensei LMS -> Reports 
- Select lessons tab
- Select course WITHOUT the courses
- The table should be empty 
