### PR TITLE
Hide the export button when there is no data

### DIFF
--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
@@ -288,6 +288,9 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 	 * Output for table footer
 	 */
 	public function data_table_footer() {
+		if ( $this->total_items < 1 ) {
+			return;
+		}
 		switch ( $this->type ) {
 			case 'courses':
 				$report = 'courses-overview';

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
@@ -108,8 +108,8 @@ class Sensei_Reports_Overview_List_Table_Abstract_Test extends WP_UnitTestCase {
 			->getMockForAbstractClass();
 
 		$data_provider
-			->method('get_last_total_items')
-			->willReturn(1);
+			->method( 'get_last_total_items' )
+			->willReturn( 1 );
 
 		/* Act. */
 		ob_start();
@@ -122,17 +122,16 @@ class Sensei_Reports_Overview_List_Table_Abstract_Test extends WP_UnitTestCase {
 		self::assertSame( $expected, $actual, 'The export button should be displayed' );
 	}
 
-	public function testTableFooter_WhenCalledWithNoData_NotDisplayTheExportButton()
-	{
+	public function testTableFooter_WhenCalledWithNoData_NotDisplayTheExportButton() {
 		/* Arrange. */
-		$data_provider = $this->createMock(Sensei_Reports_Overview_Data_Provider_Interface::class);
-		$list_table    = $this->getMockBuilder(Sensei_Reports_Overview_List_Table_Abstract::class)
-			->setConstructorArgs(['a', $data_provider])
+		$data_provider = $this->createMock( Sensei_Reports_Overview_Data_Provider_Interface::class );
+		$list_table    = $this->getMockBuilder( Sensei_Reports_Overview_List_Table_Abstract::class )
+			->setConstructorArgs( [ 'a', $data_provider ] )
 			->getMockForAbstractClass();
 
 		$data_provider
-			->method('get_last_total_items')
-			->willReturn(0);
+			->method( 'get_last_total_items' )
+			->willReturn( 0 );
 
 		/* Act. */
 		ob_start();
@@ -141,6 +140,6 @@ class Sensei_Reports_Overview_List_Table_Abstract_Test extends WP_UnitTestCase {
 
 		/* Assert. */
 		$expected = '';
-		self::assertSame($expected, $actual, 'The export button should not be displayed');
+		self::assertSame( $expected, $actual, 'The export button should not be displayed' );
 	}
 }

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
@@ -89,7 +89,7 @@ class Sensei_Reports_Overview_List_Table_Abstract_Test extends WP_UnitTestCase {
 		self::assertSame( $expected, $actual );
 	}
 
-	public function testTableFooter_WhenCalled_GeneratesProperHtmlFoFooter() {
+	public function testTableFooter_WhenCalled_DisplayTheExportButton() {
 		/* Arrange. */
 		$nonce = wp_create_nonce( 'sensei_csv_download' );
 		$_GET  = [
@@ -107,13 +107,40 @@ class Sensei_Reports_Overview_List_Table_Abstract_Test extends WP_UnitTestCase {
 			->setConstructorArgs( [ 'a', $data_provider ] )
 			->getMockForAbstractClass();
 
+		$data_provider
+			->method('get_last_total_items')
+			->willReturn(1);
+
+		/* Act. */
+		ob_start();
+		$list_table->prepare_items();
+		$list_table->data_table_footer();
+		$actual = ob_get_clean();
+
+		/* Assert. */
+		$expected = '<a class="button button-primary" href="http://example.org/wp-admin/edit.php?page=sensei_reports&#038;view=a&#038;sensei_report_download=user-overview&#038;post_type=course&#038;orderby=id&#038;order=asc&#038;course_filter=1&#038;start_date=2022-03-01&#038;end_date=2022-03-01&#038;s=course+5&#038;_sdl_nonce=' . $nonce . '">Export all rows (CSV)</a>';
+		self::assertSame( $expected, $actual, 'The export button should be displayed' );
+	}
+
+	public function testTableFooter_WhenCalledWithNoData_NotDisplayTheExportButton()
+	{
+		/* Arrange. */
+		$data_provider = $this->createMock(Sensei_Reports_Overview_Data_Provider_Interface::class);
+		$list_table    = $this->getMockBuilder(Sensei_Reports_Overview_List_Table_Abstract::class)
+			->setConstructorArgs(['a', $data_provider])
+			->getMockForAbstractClass();
+
+		$data_provider
+			->method('get_last_total_items')
+			->willReturn(0);
+
 		/* Act. */
 		ob_start();
 		$list_table->data_table_footer();
 		$actual = ob_get_clean();
 
 		/* Assert. */
-		$expected = '<a class="button button-primary" href="http://example.org/wp-admin/edit.php?page=sensei_reports&#038;view=a&#038;sensei_report_download=user-overview&#038;post_type=course&#038;orderby=id&#038;order=asc&#038;course_filter=1&#038;start_date=2022-03-01&#038;end_date=2022-03-01&#038;s=course+5&#038;_sdl_nonce=' . $nonce . '">Export all rows (CSV)</a>';
-		self::assertSame( $expected, $actual, 'Html for footer was not generated properly' );
+		$expected = '';
+		self::assertSame($expected, $actual, 'The export button should not be displayed');
 	}
 }


### PR DESCRIPTION
Fixes #4989
### Changes proposed in this Pull Request
* It hides the export button when there is not students

### Testing instructions

Hide the Export Button
* Go to Reports
* Set the Last Activity Start Date to a future date to hide all students.
* Check if the export button is not displayed

Show the Export Button
* Go to Reports
* Set the Date filters to dates you have students.
* Click the Filter button
* Check if the export button is displayed

