### PR TITLE
Display the student FullName on the reports

### DIFF
--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -642,7 +642,7 @@ class Sensei_Analysis {
 			);
 			$user_name = Sensei_Learner::get_full_name( $user_id );
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', $url, $user_name );
-			$title    .= sprintf( '&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), $user_data->display_name );
+			$title    .= sprintf( '&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), $user_name );
 		}
 		if ( isset( $_GET['course_id'] ) ) {
 			$course_id = intval( $_GET['course_id'] );

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -215,8 +215,8 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	/**
 	 * Format user name.
 	 *
-	 * @param int $user_id user's id.
-	 * @param int $use_link Indicate if it should wrap the user_name with a link.
+	 * @param int  $user_id user's id.
+	 * @param bool $use_link Indicate if it should wrap the user_name with a link.
 	 *
 	 * @return string Formatted user name to the HTML table.
 	 */

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -147,27 +147,17 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 		}
 
 		$user_email = $item->user_email;
+		$user_name  = Sensei_Learner::get_full_name( $item->ID );
 
 		// Output the users data.
-		if ( $this->csv_output ) {
-			$user_name = Sensei_Learner::get_full_name( $item->ID );
-		} else {
-			$url                 = add_query_arg(
-				array(
-					'page'      => $this->page_slug,
-					'user_id'   => $item->ID,
-					'post_type' => $this->post_type,
-				),
-				admin_url( 'edit.php' )
-			);
-			$user_name           = '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . esc_html( $item->display_name ) . '</a></strong>';
+		if ( ! $this->csv_output ) {
 			$user_average_grade .= '%';
 		}
 
 		$column_data = apply_filters(
 			'sensei_analysis_overview_column_data',
 			array(
-				'title'             => $user_name,
+				'title'             => $this->csv_output ? $user_name : $this->format_user_name( $item->ID, $user_name ),
 				'email'             => $user_email,
 				'date_registered'   => $this->format_date_registered( $item->user_registered ),
 				'last_activity'     => $item->last_activity_date ? $this->format_last_activity_date( $item->last_activity_date ) : __( 'N/A', 'sensei-lms' ),
@@ -221,5 +211,26 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 		$date     = new DateTime( $date, $timezone );
 
 		return wp_date( get_option( 'date_format' ), $date->getTimestamp(), $timezone );
+	}
+
+	/**
+	 * Format user name.
+	 *
+	 * @param int $user_id user's id.
+	 * @param int $user_name user's name.
+	 *
+	 * @return string Formatted user name to the HTML table.
+	 */
+	private function format_user_name( $user_id, $user_name ) {
+		$url = add_query_arg(
+			array(
+				'page'      => $this->page_slug,
+				'user_id'   => $user_id,
+				'post_type' => $this->post_type,
+			),
+			admin_url( 'edit.php' )
+		);
+
+		return '<strong><a class="row-title" href="' . esc_url( $url ) . '">' . esc_html( $user_name ) . '</a></strong>';
 	}
 }

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -147,7 +147,6 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 		}
 
 		$user_email = $item->user_email;
-		$user_name  = Sensei_Learner::get_full_name( $item->ID );
 
 		// Output the users data.
 		if ( ! $this->csv_output ) {
@@ -157,7 +156,7 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 		$column_data = apply_filters(
 			'sensei_analysis_overview_column_data',
 			array(
-				'title'             => $this->csv_output ? $user_name : $this->format_user_name( $item->ID, $user_name ),
+				'title'             => $this->format_user_name( $item->ID, $this->csv_output ),
 				'email'             => $user_email,
 				'date_registered'   => $this->format_date_registered( $item->user_registered ),
 				'last_activity'     => $item->last_activity_date ? $this->format_last_activity_date( $item->last_activity_date ) : __( 'N/A', 'sensei-lms' ),
@@ -217,11 +216,18 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	 * Format user name.
 	 *
 	 * @param int $user_id user's id.
-	 * @param int $user_name user's name.
+	 * @param int $use_link Indicate if it should wrap the user_name with a link.
 	 *
 	 * @return string Formatted user name to the HTML table.
 	 */
-	private function format_user_name( $user_id, $user_name ) {
+	private function format_user_name( $user_id, $use_link ) {
+
+		$user_name = Sensei_Learner::get_full_name( $user_id );
+
+		if ( ! $use_link ) {
+			return $user_name;
+		}
+
 		$url = add_query_arg(
 			array(
 				'page'      => $this->page_slug,

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -213,7 +213,7 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	}
 
 	/**
-	 * Format user name wrapping or not with a link
+	 * Format user name wrapping or not with a link.
 	 *
 	 * @param int  $user_id user's id.
 	 * @param bool $use_raw_name Indicate if it should return the wrap the name with the student link.

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -213,18 +213,18 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 	}
 
 	/**
-	 * Format user name.
+	 * Format user name wrapping or not with a link
 	 *
 	 * @param int  $user_id user's id.
-	 * @param bool $use_link Indicate if it should wrap the user_name with a link.
+	 * @param bool $use_raw_name Indicate if it should return the wrap the name with the student link.
 	 *
-	 * @return string Formatted user name to the HTML table.
+	 * @return string Return the student full name (first_name+last_name) optionally wrapped by a link
 	 */
-	private function format_user_name( $user_id, $use_link ) {
+	private function format_user_name( $user_id, $use_raw_name ) {
 
 		$user_name = Sensei_Learner::get_full_name( $user_id );
 
-		if ( ! $use_link ) {
+		if ( $use_raw_name ) {
 			return $user_name;
 		}
 


### PR DESCRIPTION
Fixes #4992

### Changes proposed in this Pull Request
* Display the student's Full name on the reports' pages

### Testing instructions
* Create a setting for the First Name and the Last Name
* Enroll the created user in a Course
* Go the Reports > Students 
* Check if the student's First and Last names are displayed, instead of the display_name.
