### PR TITLE
Display average total for Days to Completion in Courses report header

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -87,7 +87,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 					'days_to_completion' => sprintf(
 						// translators: Placeholder value is average days to completion.
 						__( 'Days to Completion (%d)', 'sensei-lms' ),
-						ceil( Sensei()->course->get_days_to_completion_total() )
+						ceil( Sensei()->course->get_average_days_to_completion() )
 					),
 				);
 				break;

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3889,9 +3889,9 @@ class Sensei_Course {
 	 * @since 4.2.0
 	 * @access private
 	 *
-	 * @return float Total days to completion, rounded to the highest integer.
+	 * @return float Average days to completion, rounded to the highest integer.
 	 */
-	public function get_days_to_completion_total() {
+	public function get_average_days_to_completion() {
 		global $wpdb;
 
 		$query = "

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -3889,13 +3889,13 @@ class Sensei_Course {
 	 * @since 4.2.0
 	 * @access private
 	 *
-	 * @return int Total days to completion, rounded to the highest integer.
+	 * @return float Total days to completion, rounded to the highest integer.
 	 */
 	public function get_days_to_completion_total() {
 		global $wpdb;
 
 		$query = "
-			SELECT SUM( aggregated.days_to_completion )
+			SELECT AVG( aggregated.days_to_completion )
 			FROM (
 				SELECT CEIL( SUM( ABS( DATEDIFF( {$wpdb->comments}.comment_date, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ) ) ) + 1 ) / COUNT({$wpdb->commentmeta}.comment_id) ) AS days_to_completion
 				FROM {$wpdb->comments}
@@ -3908,9 +3908,7 @@ class Sensei_Course {
 		";
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
-		$days_to_completion = $wpdb->get_var( $query );
-
-		return (int) $days_to_completion;
+		return (float) $wpdb->get_var( $query );
 	}
 }
 

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
@@ -81,7 +81,7 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 			'days_to_completion' => sprintf(
 			// translators: Placeholder value is average days to completion.
 				__( 'Days to Completion (%d)', 'sensei-lms' ),
-				ceil( $this->course->get_days_to_completion_total() )
+				ceil( $this->course->get_average_days_to_completion() )
 			),
 		);
 

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
@@ -51,7 +51,7 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		$grading->method( 'get_courses_average_grade' )->willReturn( 2 );
 
 		$course = $this->createMock( Sensei_Course::class );
-		$course->method( 'get_days_to_completion_total' )->willReturn( 3 );
+		$course->method( 'get_days_to_completion_total' )->willReturn( 2.2 );
 
 		$list_table              = new Sensei_Reports_Overview_List_Table_Courses(
 			$grading,
@@ -87,7 +87,7 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		$grading->method( 'get_courses_average_grade' )->willReturn( 2 );
 
 		$course = $this->createMock( Sensei_Course::class );
-		$course->method( 'get_days_to_completion_total' )->willReturn( 3 );
+		$course->method( 'get_days_to_completion_total' )->willReturn( 3.0 );
 
 		$list_table              = new Sensei_Reports_Overview_List_Table_Courses(
 			$grading,

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
@@ -51,7 +51,7 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		$grading->method( 'get_courses_average_grade' )->willReturn( 2 );
 
 		$course = $this->createMock( Sensei_Course::class );
-		$course->method( 'get_days_to_completion_total' )->willReturn( 2.2 );
+		$course->method( 'get_average_days_to_completion' )->willReturn( 2.2 );
 
 		$list_table              = new Sensei_Reports_Overview_List_Table_Courses(
 			$grading,
@@ -87,7 +87,7 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 		$grading->method( 'get_courses_average_grade' )->willReturn( 2 );
 
 		$course = $this->createMock( Sensei_Course::class );
-		$course->method( 'get_days_to_completion_total' )->willReturn( 3.0 );
+		$course->method( 'get_average_days_to_completion' )->willReturn( 3.0 );
 
 		$list_table              = new Sensei_Reports_Overview_List_Table_Courses(
 			$grading,

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -590,7 +590,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		// 2022-01-30 00:00:00 - 2022-01-01 00:00:01 + 1 = 30 days.
 		// As these completions are for the single course:
 		// ceil(7 + 10 + 30/ 3)  = 16 days.
-		self::assertSame( 16, $actual );
+		self::assertSame( 16.0, $actual );
 	}
 
 	public function testGetAverageDaysToCompletionTotalWhenMoreThanOneCourseExistReturnsMatchingValue() {
@@ -630,13 +630,13 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 
 		// Average for the first course: (1 + 1) / 2 = 1.
 		// Average for the second course: 4 / 1 = 4.
-		// Total: 1 + 4 = 5.
-		self::assertSame( 5, $actual );
+		// Total: (1 + 4) / 2 = 2.5.
+		self::assertSame( 2.5, $actual );
 	}
 
 	public function testGetAverageDaysToCompletionTotalWithoutCompletionsReturnsZero() {
 		$actual = Sensei()->course->get_days_to_completion_total();
 
-		self::assertSame( 0, $actual );
+		self::assertSame( 0.0, $actual );
 	}
 }

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -550,7 +550,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		);
 	}
 
-	public function testGetAverageDaysToCompletionTotalWhenOneCourseExistsReturnsMatchingValue() {
+	public function testGetAverageDaysToCompletionWhenOneCourseExistsReturnsMatchingValue() {
 		$user1_id  = $this->factory->user->create();
 		$user2_id  = $this->factory->user->create();
 		$user3_id  = $this->factory->user->create();
@@ -583,7 +583,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		);
 		update_comment_meta( $comment3_id, 'start', '2022-01-01 00:00:01' );
 
-		$actual = Sensei()->course->get_days_to_completion_total();
+		$actual = Sensei()->course->get_average_days_to_completion();
 
 		// 2022-01-07 00:00:00 - 2022-01-01 00:00:01 + 1 = 7 days.
 		// 2022-01-10 00:00:00 - 2022-01-01 00:00:01 + 1 = 10 days.
@@ -593,7 +593,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		self::assertSame( 16.0, $actual );
 	}
 
-	public function testGetAverageDaysToCompletionTotalWhenMoreThanOneCourseExistReturnsMatchingValue() {
+	public function testGetAverageDaysToCompletionWhenMoreThanOneCourseExistReturnsMatchingValue() {
 		$user1_id   = $this->factory->user->create();
 		$user2_id   = $this->factory->user->create();
 		$course1_id = $this->factory->course->create();
@@ -626,7 +626,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		);
 		update_comment_meta( $comment3_id, 'start', '2022-03-09 00:22:34' );
 
-		$actual = Sensei()->course->get_days_to_completion_total();
+		$actual = Sensei()->course->get_average_days_to_completion();
 
 		// Average for the first course: (1 + 1) / 2 = 1.
 		// Average for the second course: 4 / 1 = 4.
@@ -634,8 +634,8 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 		self::assertSame( 2.5, $actual );
 	}
 
-	public function testGetAverageDaysToCompletionTotalWithoutCompletionsReturnsZero() {
-		$actual = Sensei()->course->get_days_to_completion_total();
+	public function testGetAverageDaysToCompletionWithoutCompletionsReturnsZero() {
+		$actual = Sensei()->course->get_average_days_to_completion();
 
 		self::assertSame( 0.0, $actual );
 	}


### PR DESCRIPTION
Fixes #4990

Lessons report is also mentioned in the issue. However, [it calculates average already](https://github.com/Automattic/sensei/blob/1efd19363f1e4ad6c433c5fea27a13470bdf1f74/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php#L88-L88).

### Changes proposed in this Pull Request

* Display average Days to Completion instead of sum on Courses tab of Reports

### Testing instructions

* Add a few courses and students, enrol courses for those students.
* Set different start dates for students for the courses to have different values.
* Check the Courses tab in Reports and make sure you get expected `Days to Completion` there.

### Screenshot / Video
<img width="1238" alt="CleanShot 2022-05-05 at 00 09 26@2x" src="https://user-images.githubusercontent.com/329356/166817665-8f810c10-55a2-4cff-8429-5a777578cb19.png">

