### PR TITLE
Fetch last activity date with the main query

### DIFF
--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php
@@ -102,6 +102,7 @@ class Sensei_Reports_Overview_Data_Provider_Courses implements Sensei_Reports_Ov
 	/**
 	 * Add last activity date for each course.
 	 *
+	 * @since  x.x.x
 	 * @access private
 	 *
 	 * @param array $clauses Associative array of the clauses for the query.

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php
@@ -112,15 +112,15 @@ class Sensei_Reports_Overview_Data_Provider_Courses implements Sensei_Reports_Ov
 	public function add_last_activity_to_courses_query( array $clauses ): array {
 		global $wpdb;
 
-		$clauses['fields'] .= ', MAX(lacm.comment_date_gmt) AS last_activity_date';
-		$clauses['join']   .= "
-			LEFT JOIN {$wpdb->postmeta} lapm
-				ON  lapm.meta_key = '_lesson_course'
-				AND lapm.meta_value = {$wpdb->posts}.ID
-			LEFT JOIN {$wpdb->comments} lacm
-				ON lapm.post_id = lacm.comment_post_ID
+		$clauses['fields'] .= ", (
+			SELECT MAX(lacm.comment_date_gmt)
+			FROM {$wpdb->comments} lacm
+			JOIN {$wpdb->postmeta} lapm ON lapm.post_id = lacm.comment_post_ID
+			WHERE  lapm.meta_key = '_lesson_course'
 				AND lacm.comment_type = 'sensei_lesson_status'
 				AND lacm.comment_approved IN ('complete', 'passed', 'graded')
+				AND lapm.meta_value = {$wpdb->posts}.ID
+			) AS last_activity_date
 		";
 
 		return $clauses;

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
@@ -98,7 +98,7 @@ class Sensei_Reports_Overview_Data_Provider_Lessons implements Sensei_Reports_Ov
 	 *
 	 * @return array Modified associative array of the clauses for the query.
 	 */
-	public function add_days_to_complete_to_lessons_query( $clauses ) {
+	public function add_days_to_complete_to_lessons_query( array $clauses ): array {
 		global $wpdb;
 
 		$clauses['fields'] .= ", (SELECT SUM( ABS( DATEDIFF( STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ), {$wpdb->comments}.comment_date )) + 1 ) as days_to_complete";
@@ -122,7 +122,7 @@ class Sensei_Reports_Overview_Data_Provider_Lessons implements Sensei_Reports_Ov
 	 *
 	 * @return array Modified associative array of the clauses for the query.
 	 */
-	public function add_last_activity_to_lessons_query( $clauses ) {
+	public function add_last_activity_to_lessons_query( array $clauses ): array {
 		global $wpdb;
 
 		$clauses['fields'] .= ", (

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-lessons.php
@@ -70,8 +70,10 @@ class Sensei_Reports_Overview_Data_Provider_Lessons implements Sensei_Reports_Ov
 		}
 
 		add_filter( 'posts_clauses', [ $this, 'add_days_to_complete_to_lessons_query' ] );
+		add_filter( 'posts_clauses', [ $this, 'add_last_activity_to_lessons_query' ] );
 		// Using WP_Query as get_posts() doesn't support 'found_posts'.
 		$lessons_query = new WP_Query( apply_filters( 'sensei_analysis_overview_filter_lessons', $lessons_args ) );
+		remove_filter( 'posts_clauses', [ $this, 'add_last_activity_to_lessons_query' ] );
 		remove_filter( 'posts_clauses', [ $this, 'add_days_to_complete_to_lessons_query' ] );
 		$this->last_total_items = $lessons_query->found_posts;
 		return $lessons_query->posts;
@@ -106,6 +108,31 @@ class Sensei_Reports_Overview_Data_Provider_Lessons implements Sensei_Reports_Ov
 		$clauses['fields'] .= " AND {$wpdb->comments}.comment_type IN ('sensei_lesson_status')";
 		$clauses['fields'] .= " AND {$wpdb->comments}.comment_approved IN ( 'complete', 'graded', 'passed', 'failed', 'ungraded' )";
 		$clauses['fields'] .= " AND {$wpdb->commentmeta}.meta_key = 'start') as days_to_complete";
+
+		return $clauses;
+	}
+
+	/**
+	 * Add the `last_activity` field to the query.
+	 *
+	 * @since  x.x.x
+	 * @access private
+	 *
+	 * @param array $clauses Associative array of the clauses for the query.
+	 *
+	 * @return array Modified associative array of the clauses for the query.
+	 */
+	public function add_last_activity_to_lessons_query( $clauses ) {
+		global $wpdb;
+
+		$clauses['fields'] .= ", (
+			SELECT MAX({$wpdb->comments}.comment_date_gmt)
+			FROM {$wpdb->comments}
+			WHERE {$wpdb->comments}.comment_post_ID = {$wpdb->posts}.ID
+			AND {$wpdb->comments}.comment_approved IN ('complete', 'passed', 'graded')
+			AND {$wpdb->comments}.comment_type = 'sensei_lesson_status'
+			ORDER BY {$wpdb->comments}.comment_date_gmt DESC
+		) AS last_activity_date";
 
 		return $clauses;
 	}

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -165,7 +165,7 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 				'title'              => $lesson_title,
 				'lesson_module'      => $this->get_row_module( $item->ID ),
 				'students'           => $lesson_students,
-				'last_activity'      => $this->get_last_activity_date( array( 'post_id' => $item->ID ) ),
+				'last_activity'      => $item->last_activity_date ? $this->format_last_activity_date( $item->last_activity_date ) : __( 'N/A', 'sensei-lms' ),
 				'completions'        => $lesson_completions,
 				'completion_rate'    => $this->get_completion_rate( $lesson_completions, $lesson_students ),
 				'days_to_completion' => $average_completion_days,
@@ -286,48 +286,5 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 		$lesson_completion_info->lesson_count        = $lesson_count;
 		$lesson_completion_info->unique_module_count = $modules_count;
 		return $lesson_completion_info;
-	}
-	/**
-	 * Get the date on which the last lesson was marked complete.
-	 *
-	 * @since 4.3.0
-	 *
-	 * @param array $args Array of arguments to pass to comments query.
-	 *
-	 * @return string The last activity date, or N/A if none.
-	 */
-	protected function get_last_activity_date( array $args ): string {
-		$default_args  = array(
-			'number' => 1,
-			'type'   => 'sensei_lesson_status',
-			'status' => [ 'complete', 'passed', 'graded' ],
-		);
-		$args          = wp_parse_args( $args, $default_args );
-		$last_activity = Sensei_Utils::sensei_check_for_activity( $args, true );
-
-		if ( ! $last_activity ) {
-			return __( 'N/A', 'sensei-lms' );
-		}
-
-		// Return the full date when doing a CSV export.
-		if ( $this->csv_output ) {
-			return $last_activity->comment_date_gmt;
-		}
-
-		$timezone           = new DateTimeZone( 'GMT' );
-		$now                = new DateTime( 'now', $timezone );
-		$last_activity_date = new DateTime( $last_activity->comment_date_gmt, $timezone );
-		$diff_in_days       = $now->diff( $last_activity_date )->days;
-
-		// Show a human readable date if activity is within 6 days.
-		if ( $diff_in_days < 7 ) {
-			return sprintf(
-			/* translators: Time difference between two dates. %s: Number of seconds/minutes/etc. */
-				__( '%s ago', 'sensei-lms' ),
-				human_time_diff( strtotime( $last_activity->comment_date_gmt ) )
-			);
-		}
-
-		return wp_date( get_option( 'date_format' ), $last_activity_date->getTimestamp(), $timezone );
 	}
 }


### PR DESCRIPTION
Fixes #4987

### Changes proposed in this Pull Request

* Fetch last_activity_date with the main query instead of fetching it separately in the loop

### Testing instructions

* Prepare a few courses and students. 
* Enrol courses for these students.
* Complete some lessons.
* Go to Sensei LMS -> Reports.
* Check Courses and Lessons tabs.
* Make sure you see correct Last Activity date for courses/lessons.

### Screenshot / Video

*Before Lessons*
<img width="1281" alt="CleanShot 2022-05-06 at 22 50 06@2x" src="https://user-images.githubusercontent.com/329356/167200003-93f41b23-e801-450d-8c52-9b08480ed524.png">


*After Lessons*
<img width="1279" alt="CleanShot 2022-05-06 at 22 53 50@2x" src="https://user-images.githubusercontent.com/329356/167200478-6649aa06-a813-4b10-9bf6-32b32b686a7c.png">


*Before Courses*
<img width="367" alt="CleanShot 2022-05-06 at 22 53 13@2x" src="https://user-images.githubusercontent.com/329356/167200545-3982a1b0-dfab-41e9-a37d-d44d716d2c48.png">
<img width="1277" alt="CleanShot 2022-05-06 at 22 53 32@2x" src="https://user-images.githubusercontent.com/329356/167200498-80913f42-5b34-4ccb-8cf0-e9dd541972f2.png">


*After Courses*
<img width="325" alt="CleanShot 2022-05-06 at 22 51 58@2x" src="https://user-images.githubusercontent.com/329356/167200563-148bd36f-fdec-4da0-b22c-2953ec6da88d.png">
<img width="1278" alt="CleanShot 2022-05-06 at 22 49 43@2x" src="https://user-images.githubusercontent.com/329356/167199985-3d3e6279-9703-491e-a97a-6debb894ad6a.png">

*After Some Changes*
https://github.com/Automattic/sensei/pull/5101/commits/a5baf08e1c401f5594404b22b009433665ed89ec
<img width="350" alt="CleanShot 2022-05-06 at 23 26 06@2x" src="https://user-images.githubusercontent.com/329356/167204704-cdbc95a9-e0f4-47b9-b5da-b668e225d259.png">

*After The Latest Changes*
https://github.com/Automattic/sensei/pull/5101/commits/1ad844930afec9b3e2d890e4d60c95e384b829e2
<img width="378" alt="CleanShot 2022-05-06 at 23 49 18@2x" src="https://user-images.githubusercontent.com/329356/167207475-65a08ee5-92a4-4776-9ab4-745ac47d743f.png">




## PROBLEM HERE

As you can see, in Courses, the new version takes more time for DB queries even though we have fewer queries.
~~I suppose that's because we join the same tables twice: to add a field and to filter by the last activity date~~. (But the join for adding the field is really ineffective.) Unfortunately, I didn't find an easy way to use the aggregated value in WHERE or add HAVING in WP_Query.
~~At the moment, I consider reverting changes for Courses.~~
At the moment, I get comparable results, so we can go on with current solution. But maybe you have any ideas on how to optimize/rewrite queries?

