### PR TITLE
Update @wordpress/element and react version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,9 +35,7 @@
         "classnames": "2.3.1",
         "interpolate-components": "1.1.1",
         "lodash": "4.17.21",
-        "react": "17.0.2",
         "react-animate-height": "2.0.23",
-        "react-dom": "17.0.2",
         "terser-webpack-plugin": "5.3.1",
         "uuid": "3.3.2",
         "whatwg-fetch": "3.6.2"
@@ -82,12 +80,15 @@
         "postcss-color-function": "4.1.0",
         "prettier": "npm:wp-prettier@2.0.5",
         "puppeteer-core": "npm:puppeteer-core@8.0.0",
+        "react": "17.0.2",
+        "react-dom": "17.0.2",
         "svg-spritemap-webpack-plugin": "4.4.0",
         "webpack": "5.64.4",
         "wp-hookdoc": "0.2.0"
       },
       "engines": {
-        "npm": ">=8"
+        "node": "^16.14.0",
+        "npm": "^8.9.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -40787,26 +40788,34 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/abbrev": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ansi-regex": {
       "version": "2.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/aproba": {
       "version": "1.2.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/are-we-there-yet": {
       "version": "1.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
@@ -40814,13 +40823,17 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/balanced-match": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/brace-expansion": {
       "version": "1.1.11",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -40828,57 +40841,75 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/chownr": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/code-point-at": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/concat-map": {
       "version": "0.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/console-control-strings": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/core-util-is": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/debug": {
       "version": "3.2.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/deep-extend": {
       "version": "0.6.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/delegates": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/detect-libc": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
+      "optional": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -40888,21 +40919,27 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/fs-minipass": {
       "version": "1.2.7",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.6.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/fs.realpath": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/gauge": {
       "version": "2.7.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -40916,8 +40953,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/glob": {
       "version": "7.1.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -40935,13 +40974,17 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/has-unicode": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/iconv-lite": {
       "version": "0.4.24",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -40951,16 +40994,20 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ignore-walk": {
       "version": "3.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minimatch": "^3.0.4"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/inflight": {
       "version": "1.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -40968,21 +41015,27 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/inherits": {
       "version": "2.0.4",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ini": {
       "version": "1.3.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": "*"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/is-fullwidth-code-point": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "number-is-nan": "^1.0.0"
       },
@@ -40992,13 +41045,17 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/isarray": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minimatch": {
       "version": "3.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -41008,13 +41065,17 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minimist": {
       "version": "1.2.5",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minipass": {
       "version": "2.9.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -41022,8 +41083,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/minizlib": {
       "version": "1.3.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^2.9.0"
       }
@@ -41031,8 +41094,10 @@
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/mkdirp": {
       "version": "0.5.3",
       "deprecated": "Legacy versions of mkdirp are no longer supported. Please update to mkdirp 1.x. (Note that the API surface has changed to use Promises in 1.x.)",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minimist": "^1.2.5"
       },
@@ -41042,13 +41107,17 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/ms": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/needle": {
       "version": "2.3.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -41063,8 +41132,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/node-pre-gyp": {
       "version": "0.14.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -41083,8 +41154,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/nopt": {
       "version": "4.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "abbrev": "1",
         "osenv": "^0.1.4"
@@ -41095,21 +41168,27 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npm-bundled": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "npm-normalize-package-bin": "^1.0.1"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npm-normalize-package-bin": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npm-packlist": {
       "version": "1.4.8",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -41118,8 +41197,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/npmlog": {
       "version": "4.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -41129,48 +41210,60 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/number-is-nan": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/object-assign": {
       "version": "4.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/once": {
       "version": "1.4.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/os-homedir": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/os-tmpdir": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/osenv": {
       "version": "0.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "os-homedir": "^1.0.0",
         "os-tmpdir": "^1.0.0"
@@ -41178,21 +41271,27 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/path-is-absolute": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/process-nextick-args": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/rc": {
       "version": "1.2.8",
+      "dev": true,
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -41205,8 +41304,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/readable-stream": {
       "version": "2.3.7",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -41219,8 +41320,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/rimraf": {
       "version": "2.7.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -41230,49 +41333,65 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/safe-buffer": {
       "version": "5.1.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/sax": {
       "version": "1.2.4",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/semver": {
       "version": "5.7.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/set-blocking": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/signal-exit": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/string_decoder": {
       "version": "1.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/string-width": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -41284,8 +41403,10 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/strip-ansi": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "ansi-regex": "^2.0.0"
       },
@@ -41295,16 +41416,20 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/strip-json-comments": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/tar": {
       "version": "4.4.13",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -41320,26 +41445,34 @@
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/wide-align": {
       "version": "1.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "string-width": "^1.0.2 || 2"
       }
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/wrappy": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-haste-map/node_modules/fsevents/node_modules/yallist": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/jest-jasmine2": {
       "version": "24.9.0",
@@ -91217,19 +91350,27 @@
           "dependencies": {
             "abbrev": {
               "version": "1.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "ansi-regex": {
               "version": "2.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "are-we-there-yet": {
               "version": "1.1.5",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "delegates": "^1.0.0",
                 "readable-stream": "^2.0.6"
@@ -91237,11 +91378,15 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -91249,57 +91394,81 @@
             },
             "chownr": {
               "version": "1.1.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "debug": {
               "version": "3.2.6",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ms": "^2.1.1"
               }
             },
             "deep-extend": {
               "version": "0.6.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "delegates": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "detect-libc": {
               "version": "1.0.3",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "fs-minipass": {
               "version": "1.2.7",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minipass": "^2.6.0"
               }
             },
             "fs.realpath": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "gauge": {
               "version": "2.7.4",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "aproba": "^1.0.3",
                 "console-control-strings": "^1.0.0",
@@ -91314,6 +91483,8 @@
             "glob": {
               "version": "7.1.6",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "fs.realpath": "^1.0.0",
                 "inflight": "^1.0.4",
@@ -91325,11 +91496,15 @@
             },
             "has-unicode": {
               "version": "2.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "iconv-lite": {
               "version": "0.4.24",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "safer-buffer": ">= 2.1.2 < 3"
               }
@@ -91337,6 +91512,8 @@
             "ignore-walk": {
               "version": "3.0.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minimatch": "^3.0.4"
               }
@@ -91344,6 +91521,8 @@
             "inflight": {
               "version": "1.0.6",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "once": "^1.3.0",
                 "wrappy": "1"
@@ -91351,37 +91530,51 @@
             },
             "inherits": {
               "version": "2.0.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
             },
             "isarray": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "1.2.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -91390,6 +91583,8 @@
             "minizlib": {
               "version": "1.3.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minipass": "^2.9.0"
               }
@@ -91397,17 +91592,23 @@
             "mkdirp": {
               "version": "0.5.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "^1.2.5"
               }
             },
             "ms": {
               "version": "2.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "needle": {
               "version": "2.3.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "debug": "^3.2.6",
                 "iconv-lite": "^0.4.4",
@@ -91417,6 +91618,8 @@
             "node-pre-gyp": {
               "version": "0.14.0",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "detect-libc": "^1.0.2",
                 "mkdirp": "^0.5.1",
@@ -91433,6 +91636,8 @@
             "nopt": {
               "version": "4.0.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "abbrev": "1",
                 "osenv": "^0.1.4"
@@ -91441,17 +91646,23 @@
             "npm-bundled": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "npm-normalize-package-bin": "^1.0.1"
               }
             },
             "npm-normalize-package-bin": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "npm-packlist": {
               "version": "1.4.8",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ignore-walk": "^3.0.1",
                 "npm-bundled": "^1.0.1",
@@ -91461,6 +91672,8 @@
             "npmlog": {
               "version": "4.1.2",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "are-we-there-yet": "~1.1.2",
                 "console-control-strings": "~1.1.0",
@@ -91470,30 +91683,42 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
             },
             "os-homedir": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "os-tmpdir": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "osenv": {
               "version": "0.1.5",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "os-homedir": "^1.0.0",
                 "os-tmpdir": "^1.0.0"
@@ -91501,15 +91726,21 @@
             },
             "path-is-absolute": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "process-nextick-args": {
               "version": "2.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "rc": {
               "version": "1.2.8",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "deep-extend": "^0.6.0",
                 "ini": "~1.3.0",
@@ -91520,6 +91751,8 @@
             "readable-stream": {
               "version": "2.3.7",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -91533,37 +91766,53 @@
             "rimraf": {
               "version": "2.7.1",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "glob": "^7.1.3"
               }
             },
             "safe-buffer": {
               "version": "5.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "sax": {
               "version": "1.2.4",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "semver": {
               "version": "5.7.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "set-blocking": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "signal-exit": {
               "version": "3.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "string_decoder": {
               "version": "1.1.1",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -91571,6 +91820,8 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -91580,17 +91831,23 @@
             "strip-ansi": {
               "version": "3.0.1",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
             },
             "strip-json-comments": {
               "version": "2.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "tar": {
               "version": "4.4.13",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "chownr": "^1.1.1",
                 "fs-minipass": "^1.2.5",
@@ -91603,22 +91860,30 @@
             },
             "util-deprecate": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "wide-align": {
               "version": "1.1.3",
               "bundled": true,
+              "dev": true,
+              "optional": true,
               "requires": {
                 "string-width": "^1.0.2 || 2"
               }
             },
             "wrappy": {
               "version": "1.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.1.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true,
+              "optional": true
             }
           }
         }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "url": "https://github.com/Automattic/sensei/issues"
   },
   "engines": {
-    "npm": ">=8"
+    "npm": "^8.9.0",
+    "node": "^16.14.0"
   },
   "overrides": {
       "react": "$react",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,6 @@
     "npm": "^8.9.0",
     "node": "^16.14.0"
   },
-  "overrides": {
-      "react": "$react",
-      "react-dom": "$react-dom",
-      "@wordpress/element": "$@wordpress/element"
-  },
   "dependencies": {
     "@wordpress/api-fetch": "3.22.0",
     "@wordpress/base-styles": "1.9.0",
@@ -51,12 +46,15 @@
     "classnames": "2.3.1",
     "interpolate-components": "1.1.1",
     "lodash": "4.17.21",
-    "react": "17.0.2",
     "react-animate-height": "2.0.23",
-    "react-dom": "17.0.2",
     "terser-webpack-plugin": "5.3.1",
     "uuid": "3.3.2",
     "whatwg-fetch": "3.6.2"
+  },
+  "overrides": {
+      "react": "17.0.2",
+      "react-dom": "17.0.2",
+      "@wordpress/element": "$@wordpress/element"
   },
   "devDependencies": {
     "@automattic/calypso-build": "10.0.0",
@@ -98,6 +96,8 @@
     "postcss-color-function": "4.1.0",
     "prettier": "npm:wp-prettier@2.0.5",
     "puppeteer-core": "npm:puppeteer-core@8.0.0",
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
     "svg-spritemap-webpack-plugin": "4.4.0",
     "webpack": "5.64.4",
     "wp-hookdoc": "0.2.0"

--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
   "engines": {
     "npm": ">=8"
   },
+  "overrides": {
+      "react": "$react",
+      "react-dom": "$react-dom",
+      "@wordpress/element": "$@wordpress/element"
+  },
   "dependencies": {
     "@wordpress/api-fetch": "3.22.0",
     "@wordpress/base-styles": "1.9.0",
@@ -31,7 +36,7 @@
     "@wordpress/dom-ready": "2.11.0",
     "@wordpress/edit-post": "3.27.0",
     "@wordpress/editor": "9.26.0",
-    "@wordpress/element": "2.16.0",
+    "@wordpress/element": "4.6.0",
     "@wordpress/escape-html": "1.9.0",
     "@wordpress/hooks": "2.9.0",
     "@wordpress/html-entities": "3.7.0",
@@ -45,7 +50,9 @@
     "classnames": "2.3.1",
     "interpolate-components": "1.1.1",
     "lodash": "4.17.21",
+    "react": "17.0.2",
     "react-animate-height": "2.0.23",
+    "react-dom": "17.0.2",
     "terser-webpack-plugin": "5.3.1",
     "uuid": "3.3.2",
     "whatwg-fetch": "3.6.2"
@@ -90,8 +97,6 @@
     "postcss-color-function": "4.1.0",
     "prettier": "npm:wp-prettier@2.0.5",
     "puppeteer-core": "npm:puppeteer-core@8.0.0",
-    "react": "16.11.0",
-    "react-test-renderer": "17.0.2",
     "svg-spritemap-webpack-plugin": "4.4.0",
     "webpack": "5.64.4",
     "wp-hookdoc": "0.2.0"


### PR DESCRIPTION
Resolvers part of #5108 

### Changes proposed in this Pull Request
*  This PR updates the packages:
- @wordpress/element
- react
- react-dom
* Use the npm overrides resolution to make sure we are really using the correct versions.
* Set the npm version engine to `8.9.0`



### Testing instructions
* Delete the node_modules folder
* Update the npm version to `8.9.0`
* Run npm install
* Run all js-tests
* Run the application (npm run start) and navigate through the react features (students modal, setup-wizard, course-creation).
No visual change is expected

