### PR TITLE
Fix student name appearing twice on student report title

### DIFF
--- a/includes/class-sensei-analysis.php
+++ b/includes/class-sensei-analysis.php
@@ -641,7 +641,6 @@ class Sensei_Analysis {
 				admin_url( 'edit.php' )
 			);
 			$user_name = Sensei_Learner::get_full_name( $user_id );
-			$title    .= sprintf( '&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', $url, $user_name );
 			$title    .= sprintf( '&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;<a href="%s">%s</a></span>', esc_url( $url ), $user_name );
 		}
 		if ( isset( $_GET['course_id'] ) ) {

--- a/tests/unit-tests/test-class-sensei-analysis.php
+++ b/tests/unit-tests/test-class-sensei-analysis.php
@@ -6,6 +6,8 @@
  * @covers Sensei_Analysis
  */
 class Sensei_Analysis_Test extends WP_UnitTestCase {
+	use Sensei_Test_Login_Helpers;
+
 	private static $initial_hook_suffix;
 
 	public static function setUpBeforeClass() {
@@ -57,5 +59,21 @@ class Sensei_Analysis_Test extends WP_UnitTestCase {
 				'Sensei_Analysis_Lesson_List_Table',
 			],
 		];
+	}
+
+	public function testAnalysisUserCourseNav_WhenCalled_GeneratesProperHtml() {
+		/* Arrange */
+		$this->login_as_admin();
+		$analysis        = new Sensei_Analysis( 'a' );
+		$_GET['user_id'] = 1;
+
+		/* Act */
+		ob_start();
+		$analysis->analysis_user_course_nav();
+		$actual = trim( ob_get_clean() );
+
+		/* Assert */
+		$expected = '<h1><a href="http://example.org/wp-admin/edit.php?page=sensei_reports&#038;post_type=course">Reports</a>&nbsp;&nbsp;<span class="user-title">&gt;&nbsp;&nbsp;<a href="http://example.org/wp-admin/edit.php?page=sensei_reports&#038;user_id=1&#038;post_type=course">admin</a></span></h1>';
+		$this->assertEquals( $expected, $actual );
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/5103

### Changes proposed in this Pull Request

In Reports->Students->(Click on a student from the list)->(Click on a course from the list), removed the extra student name URL from the navigation title on the top of the table.

### Testing instructions

- Go to Reports -> Students
- Click on a student
- Click on a course
- Make sure the title on the table shows the student name just once

### Screenshot / Video
<img width="730" alt="Screen Shot 2022-05-10 at 4 21 52 PM" src="https://user-images.githubusercontent.com/6820724/167607623-915dba50-88a5-43a6-b4aa-d19680bfe530.png">
