### PR TITLE
Fix reports date filters not accounting for the user timezone

### DIFF
--- a/assets/js/admin/reports.js
+++ b/assets/js/admin/reports.js
@@ -7,4 +7,11 @@ domReady( () => {
 	jQuery( '.sensei-date-picker' ).datepicker( {
 		dateFormat: 'yy-mm-dd',
 	} );
+
+	const timezone = Intl?.DateTimeFormat()?.resolvedOptions()?.timeZone;
+	if ( timezone ) {
+		jQuery( '.sensei-analysis__top-filters input[name="timezone"]' ).val(
+			timezone
+		);
+	}
 } );

--- a/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
+++ b/includes/reports/helper/class-sensei-reports-helper-date-range-trait.php
@@ -28,18 +28,23 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	}
 
 	/**
-	 * Get the start date filter value including the time.
+	 * Get the start date filter value including the time in UTC.
 	 *
 	 * @return string The start date including the time or empty string if none.
 	 */
 	protected function get_start_date_and_time(): string {
-		$start_date = DateTime::createFromFormat( 'Y-m-d', $this->get_start_date_filter_value() );
+		$start_date = DateTime::createFromFormat(
+			'Y-m-d',
+			$this->get_start_date_filter_value(),
+			new DateTimeZone( $this->get_timezone() )
+		);
 
 		if ( ! $start_date ) {
 			return '';
 		}
 
 		$start_date->setTime( 0, 0, 0 );
+		$start_date->setTimezone( new DateTimeZone( 'UTC' ) );
 
 		return $start_date->format( 'Y-m-d H:i:s' );
 	}
@@ -57,19 +62,40 @@ trait Sensei_Reports_Helper_Date_Range_Trait {
 	}
 
 	/**
-	 * Get the end date filter value including the time.
+	 * Get the end date filter value including the time in UTC.
 	 *
 	 * @return string The end date including the time or empty string if none.
 	 */
 	protected function get_end_date_and_time(): string {
-		$end_date = DateTime::createFromFormat( 'Y-m-d', $this->get_end_date_filter_value() );
+		$end_date = DateTime::createFromFormat(
+			'Y-m-d',
+			$this->get_end_date_filter_value(),
+			new DateTimeZone( $this->get_timezone() )
+		);
 
 		if ( ! $end_date ) {
 			return '';
 		}
 
 		$end_date->setTime( 23, 59, 59 );
+		$end_date->setTimezone( new DateTimeZone( 'UTC' ) );
 
 		return $end_date->format( 'Y-m-d H:i:s' );
+	}
+
+	/**
+	 * Get the user's timezone. If not available, returns the site's timezone.
+	 *
+	 * @return string The timezone string.
+	 */
+	protected function get_timezone(): string {
+		// phpcs:ignore WordPress.Security -- The timezone is sanitized by DateTime.
+		$user_timezone = $_GET['timezone'] ?? '';
+
+		if ( $user_timezone ) {
+			return $user_timezone;
+		}
+
+		return wp_timezone_string();
 	}
 }

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
@@ -221,7 +221,9 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 	public function output_top_filters() {
 		?>
 		<form class="sensei-analysis__top-filters">
-			<?php Sensei_Utils::output_query_params_as_inputs( [ 'course_filter', 'start_date', 'end_date', 's' ] ); ?>
+			<?php Sensei_Utils::output_query_params_as_inputs( [ 'course_filter', 'start_date', 'end_date', 's', 'timezone' ] ); ?>
+
+			<input type="hidden" name="timezone">
 
 			<?php if ( 'lessons' === $this->type ) : ?>
 				<label for="sensei-course-filter">
@@ -319,6 +321,7 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 				'course_filter'          => $this->get_course_filter_value(),
 				'start_date'             => $this->get_start_date_filter_value(),
 				'end_date'               => $this->get_end_date_filter_value(),
+				'timezone'               => $this->get_timezone(),
 				's'                      => $this->get_search_value(),
 			),
 			admin_url( 'edit.php' )

--- a/tests/unit-tests/reports/helper/test-class-sensei-reports-helper-date-range-trait.php
+++ b/tests/unit-tests/reports/helper/test-class-sensei-reports-helper-date-range-trait.php
@@ -1,0 +1,29 @@
+<?php
+
+class Sensei_Reports_Helper_Date_Range_Trait_Test extends WP_UnitTestCase {
+	use Sensei_Reports_Helper_Date_Range_Trait;
+
+	public function testGetTimezone_WhenCalledWithUserTimezoneSet_ReturnsTheUserTimezone() {
+		$_GET['timezone'] = 'UTC';
+
+		$this->assertEquals( 'UTC', $this->get_timezone() );
+	}
+
+	public function testGetTimezone_WhenCalledWithNotUserTimezoneSet_ReturnsTheSiteTimezone() {
+		$this->assertEquals( '+00:00', $this->get_timezone() );
+	}
+
+	public function testGetStartDateAndTime_WhenCalledWithUserTimezoneSet_ReturnsTheDateTimeInUTC() {
+		$_GET['start_date'] = '2022-01-02';
+		$_GET['timezone']   = '+02:00';
+
+		$this->assertEquals( '2022-01-01 22:00:00', $this->get_start_date_and_time() );
+	}
+
+	public function testGetEndDateAndTime_WhenCalledWithUserTimezoneSet_ReturnsTheDateTimeInUTC() {
+		$_GET['end_date'] = '2022-01-02';
+		$_GET['timezone'] = '+02:00';
+
+		$this->assertEquals( '2022-01-02 21:59:59', $this->get_end_date_and_time() );
+	}
+}

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-abstract.php
@@ -98,6 +98,7 @@ class Sensei_Reports_Overview_List_Table_Abstract_Test extends WP_UnitTestCase {
 			'orderby'       => 'id  ',
 			'start_date'    => '2022-03-01',
 			'end_date'      => '2022-03-01',
+			'timezone'      => 'UTC',
 			'course_filter' => 1,
 			'_wpnonce'      => $nonce,
 
@@ -118,7 +119,7 @@ class Sensei_Reports_Overview_List_Table_Abstract_Test extends WP_UnitTestCase {
 		$actual = ob_get_clean();
 
 		/* Assert. */
-		$expected = '<a class="button button-primary" href="http://example.org/wp-admin/edit.php?page=sensei_reports&#038;view=a&#038;sensei_report_download=user-overview&#038;post_type=course&#038;orderby=id&#038;order=asc&#038;course_filter=1&#038;start_date=2022-03-01&#038;end_date=2022-03-01&#038;s=course+5&#038;_sdl_nonce=' . $nonce . '">Export all rows (CSV)</a>';
+		$expected = '<a class="button button-primary" href="http://example.org/wp-admin/edit.php?page=sensei_reports&#038;view=a&#038;sensei_report_download=user-overview&#038;post_type=course&#038;orderby=id&#038;order=asc&#038;course_filter=1&#038;start_date=2022-03-01&#038;end_date=2022-03-01&#038;timezone=UTC&#038;s=course+5&#038;_sdl_nonce=' . $nonce . '">Export all rows (CSV)</a>';
 		self::assertSame( $expected, $actual, 'The export button should be displayed' );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Apply the user's timezone when using the last activity date filters.

### Testing instructions

* Set your timezone to +3 for example.
* Set your time to 01:00.
* Complete a lesson for a course. Note: In the database, the course's last activity date will be stored in UTC (yesterday at 22:00)
* Go to Sensei LMS -> Reports -> Courses.
* Set the last activity start and end dates to your current date and submit the filter.
* Make sure there is a `timezone` query param in the URL with your timezone.
* You should see the course in the list.
