### PR TITLE
Fix teacher name getting appended and duplicated in module title in course edit

### DIFF
--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -103,6 +103,7 @@ export const extractStructure = ( blocks ) => {
 		module: ( block ) => ( {
 			description: block.attributes.description,
 			lessons: extractStructure( block.innerBlocks ),
+			teacher: block.attributes.teacher,
 		} ),
 		lesson: ( block ) => ( {
 			draft: block.attributes.draft,

--- a/assets/blocks/course-outline/module-block/block.json
+++ b/assets/blocks/course-outline/module-block/block.json
@@ -19,6 +19,10 @@
       "type": "string",
       "default": ""
     },
+    "teacher": {
+      "type": "string",
+      "default": ""
+    },
     "mainColor": {
       "type": "string"
     },

--- a/assets/blocks/course-outline/module-block/module-edit.js
+++ b/assets/blocks/course-outline/module-block/module-edit.js
@@ -52,7 +52,13 @@ export const ModuleEdit = ( props ) => {
 	const {
 		clientId,
 		className,
-		attributes: { title, description, borderedSelected, borderColorValue },
+		attributes: {
+			title,
+			description,
+			borderedSelected,
+			borderColorValue,
+			teacher,
+		},
 		mainColor,
 		defaultMainColor,
 		textColor,
@@ -158,6 +164,7 @@ export const ModuleEdit = ( props ) => {
 							onChange={ updateName }
 						/>
 					</h2>
+					{ teacher && <span>({ teacher })</span> }
 					<ModuleStatus clientId={ clientId } />
 					{ collapsibleModules && (
 						<button

--- a/assets/blocks/course-outline/module-block/module-edit.js
+++ b/assets/blocks/course-outline/module-block/module-edit.js
@@ -164,7 +164,9 @@ export const ModuleEdit = ( props ) => {
 							onChange={ updateName }
 						/>
 					</h2>
-					{ teacher && <span>({ teacher })</span> }
+					{ teacher && (
+						<span className="teacher-name">({ teacher })</span>
+					) }
 					<ModuleStatus clientId={ clientId } />
 					{ collapsibleModules && (
 						<button

--- a/assets/blocks/course-outline/module-block/module-edit.test.js
+++ b/assets/blocks/course-outline/module-block/module-edit.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 
 /**
  * WordPress dependencies
@@ -76,5 +76,34 @@ describe( '<ModuleEdit />', () => {
 		} );
 
 		expect( setAttributesMock ).toBeCalledWith( { description: 'Test' } );
+	} );
+
+	it( 'Should not display the teacher name section if no or empty name is provided', () => {
+		render(
+			<ModuleEdit
+				className={ '' }
+				attributes={ { title: '', description: '', lessons: [] } }
+			/>
+		);
+
+		expect( screen.queryByText( '(', { exact: false } ) ).toBeFalsy();
+	} );
+
+	it( 'Should display the teacher name section in parentheses if name is provided', () => {
+		render(
+			<ModuleEdit
+				className={ '' }
+				attributes={ {
+					title: '',
+					description: '',
+					lessons: [],
+					teacher: 'teacher1',
+				} }
+			/>
+		);
+
+		expect( screen.getByText( '(', { exact: false } ).textContent ).toEqual(
+			'(teacher1)'
+		);
 	} );
 } );

--- a/assets/blocks/course-outline/module-block/module.scss
+++ b/assets/blocks/course-outline/module-block/module.scss
@@ -29,6 +29,10 @@ $block: '.wp-block-sensei-lms-course-outline-module';
 		font-weight: bold;
 		display: flex;
 		align-items: center;
+		.teacher-name {
+			padding-left: 1em;
+			font-size: 0.8em;
+		}
 	}
 
 	#{$block}__title {

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -61,8 +61,9 @@ class Sensei_Course_Structure {
 	 * @see Sensei_Course_Structure::prepare_lesson()
 	 * @see Sensei_Course_Structure::prepare_module()
 	 *
-	 * @param string  $context  Context that structure is being retrieved for. Possible values: edit, view.
-	 * @param boolean $no_cache Avoid query cache.
+	 * @param string  $context           Context that structure is being retrieved for. Possible values: edit, view.
+	 * @param boolean $no_cache          Avoid query cache.
+	 * @param boolean $is_admin_override Override is_admin if is_admin returns false.
 	 *
 	 * @return array {
 	 *     An array which has course structure information.
@@ -71,7 +72,7 @@ class Sensei_Course_Structure {
 	 *                 and prepare_module().
 	 * }
 	 */
-	public function get( $context = 'view', $no_cache = false ) {
+	public function get( $context = 'view', $no_cache = false, $is_admin_override = false ) {
 		if ( $no_cache ) {
 			add_filter( 'posts_where', [ $this, 'filter_no_cache_where' ] );
 		}
@@ -84,10 +85,16 @@ class Sensei_Course_Structure {
 		$post_status            = $published_lessons_only ? self::PUBLISHED_POST_STATUSES : 'any';
 		$no_module_lessons      = wp_list_pluck( Sensei()->modules->get_none_module_lessons( $this->course_id, $post_status ), 'ID' );
 
-		$modules = $this->get_modules();
-		foreach ( $modules as $module_term ) {
-			$module = $this->prepare_module( $module_term, $post_status );
+		$add_teacher_name_property = 'edit' === $context && current_user_can( 'manage_options' ) && ( is_admin() || $is_admin_override );
 
+		$add_teacher_name_property && remove_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70 );
+
+		$modules = $this->get_modules();
+
+		$add_teacher_name_property && $context && add_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70, 3 );
+
+		foreach ( $modules as $module_term ) {
+			$module = $this->prepare_module( $module_term, $post_status, $add_teacher_name_property );
 			if ( ! empty( $module['lessons'] ) || 'edit' === $context ) {
 				$structure[] = $module;
 			}
@@ -129,8 +136,9 @@ class Sensei_Course_Structure {
 	 *
 	 * @see Sensei_Course_Structure::prepare_lesson()
 	 *
-	 * @param WP_Term      $module_term        Module term.
-	 * @param array|string $lesson_post_status Lesson post status(es).
+	 * @param WP_Term      $module_term               Module term.
+	 * @param array|string $lesson_post_status        Lesson post status(es).
+	 * @param boolean      $add_teacher_name_property Teacher's name will be added to the module as a property.
 	 *
 	 * @return array {
 	 *     An array which has module information.
@@ -138,19 +146,27 @@ class Sensei_Course_Structure {
 	 *     @type string $type        The type of the array which is 'module'.
 	 *     @type int    $id          The module term id.
 	 *     @type string $title       The module name.
+	 *     @type string $teacher     Name of the teacher of this module, gets populated only in admin panel for admins and if the teacher is not admin.
 	 *     @type string $description The module description.
 	 *     @type array  $lessons     An array of the module lessons. See Sensei_Course_Structure::prepare_lesson().
 	 * }
 	 */
-	private function prepare_module( WP_Term $module_term, $lesson_post_status ) : array {
+	private function prepare_module( WP_Term $module_term, $lesson_post_status, $add_teacher_name_property ) : array {
 		$lessons = $this->get_module_lessons( $module_term->term_id, $lesson_post_status );
-		$module  = [
+
+		$module = [
 			'type'        => 'module',
 			'id'          => $module_term->term_id,
 			'title'       => $module_term->name,
 			'description' => $module_term->description,
+			'teacher'     => '',
 			'lessons'     => [],
 		];
+
+		if ( $add_teacher_name_property ) {
+			$author            = Sensei_Core_Modules::get_term_author( $module_term->slug );
+			$module['teacher'] = user_can( $author, 'manage_options' ) ? '' : $author->display_name;
+		}
 
 		foreach ( $lessons as $lesson ) {
 			$module['lessons'][] = $this->prepare_lesson( $lesson );

--- a/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
@@ -141,6 +141,7 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 		$context = 'view';
 		if ( 'edit' === $request['context'] && $this->can_current_user_edit_course( $course->ID ) ) {
 			$context = 'edit';
+			remove_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70 );
 		}
 
 		$response = new WP_REST_Response();
@@ -189,7 +190,7 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 		}
 
 		$response = new WP_REST_Response();
-		$response->set_data( $course_structure->get( 'edit', wp_using_ext_object_cache(), true ) );
+		$response->set_data( $course_structure->get( 'edit', wp_using_ext_object_cache() ) );
 
 		return $response;
 	}

--- a/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-course-structure-controller.php
@@ -189,7 +189,7 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 		}
 
 		$response = new WP_REST_Response();
-		$response->set_data( $course_structure->get( 'edit', wp_using_ext_object_cache() ) );
+		$response->set_data( $course_structure->get( 'edit', wp_using_ext_object_cache(), true ) );
 
 		return $response;
 	}
@@ -197,7 +197,7 @@ class Sensei_REST_API_Course_Structure_Controller extends \WP_REST_Controller {
 	/**
 	 * Get the course object.
 	 *
-	 * @param int $course_id
+	 * @param int $course_id Id of the course.
 	 *
 	 * @return WP_Post|null
 	 */

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -1698,8 +1698,9 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		$course_structure = Sensei_Course_Structure::instance( $course_id );
 
 		/* Act */
-		$edit_output = $course_structure->get( 'edit' );
 		$view_output = $course_structure->get();
+		remove_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70 );
+		$edit_output = $course_structure->get( 'edit' );
 
 		/* Assert */
 		//Added multiple assertions to cut db setup time for tests.
@@ -1709,7 +1710,7 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 		$this->assertNotContains( 'teacher1', $edit_output[0]['title'] );
 
 		//For view mode.
-		$this->assertEmpty( $view_output[0]['teacher'] );
+		$this->assertEquals( 'teacher1', $view_output[0]['teacher'] );
 		$this->assertContains( 'teacher1', $view_output[0]['title'] );
 
 		// Reset $current_screen. This is needed for WordPress <= 5.8.


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/4703

### Changes proposed in this Pull Request

On the course edit block page, teacher's name was shown as appended to the module title. Upon saving, the teacher's name got actually saved appended to the module title.

Teacher's name is now shown and processed separately from the text area so that it does not get saved with the title.

### Testing instructions

- Make a user with the "teacher" role.
- Go to the "Add new course" screen.
- Add a module with a lesson.
- Save the post and refresh the page.
- Assign the course to the teacher user.
- Update and refresh to make sure the teacher's name is added to the module.
- Add another lesson.
- Save the post and refresh the page.
- Make sure the teacher's name is not duplicated

### Screenshot / Video
<img width="971" alt="image" src="https://user-images.githubusercontent.com/6820724/168076164-4d8ef8fc-9142-446c-b1e5-7abab5393f26.png">
