### PR TITLE
Set post type in the module link for selecting proper menu item

### DIFF
--- a/assets/js/admin/event-logging.js
+++ b/assets/js/admin/event-logging.js
@@ -13,7 +13,9 @@ const adminTracking = [
 		eventName: 'courses_view',
 	},
 	{
-		selector: selector + 'a[href="edit-tags.php?taxonomy=module"]',
+		selector:
+			selector +
+			'a[href="edit-tags.php?taxonomy=module&post_type=course"]',
 		eventName: 'modules_view',
 	},
 	{

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -208,7 +208,7 @@ class Sensei_Admin {
 
 		} elseif ( $screen->base == 'edit-tags' && $taxonomy == 'module' ) {
 
-			$submenu_file = 'edit-tags.php?taxonomy=module';
+			$submenu_file = 'edit-tags.php?taxonomy=module&post_type=course';
 			$parent_file  = 'edit.php?post_type=course';
 
 		} elseif ( in_array( $screen->id, array( 'sensei_message', 'edit-sensei_message' ) ) ) {

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -123,7 +123,7 @@ class Sensei_Core_Modules {
 	public function highlight_menu_item( $submenu_file ) {
 		$screen = get_current_screen();
 		if ( $screen && in_array( $screen->id, [ 'edit-module', 'course_page_module-order' ], true ) ) {
-			$submenu_file = 'edit-tags.php?taxonomy=module';
+			$submenu_file = 'edit-tags.php?taxonomy=module&post_type=course';
 		}
 
 		return $submenu_file;
@@ -1127,7 +1127,7 @@ class Sensei_Core_Modules {
 		_deprecated_function( __METHOD__, '4.0.0' );
 
 		// add the modules link under the Course main menu
-		add_submenu_page( 'edit.php?post_type=course', __( 'Modules', 'sensei-lms' ), __( 'Modules', 'sensei-lms' ), 'manage_categories', 'edit-tags.php?taxonomy=module', '' );
+		add_submenu_page( 'edit.php?post_type=course', __( 'Modules', 'sensei-lms' ), __( 'Modules', 'sensei-lms' ), 'manage_categories', 'edit-tags.php?taxonomy=module&post_type=course', '' );
 
 		// Register new admin page for module ordering.
 		add_submenu_page( 'edit.php?post_type=course', __( 'Order Modules', 'sensei-lms' ), __( 'Order Modules', 'sensei-lms' ), 'edit_lessons', $this->order_page_slug, array( $this, 'module_order_screen' ) );

--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -1059,7 +1059,7 @@ class Sensei_PostTypes {
 			__( 'Modules', 'sensei-lms' ),
 			__( 'Modules', 'sensei-lms' ),
 			'manage_categories',
-			'edit-tags.php?taxonomy=module'
+			'edit-tags.php?taxonomy=module&post_type=course'
 		);
 
 		add_submenu_page(


### PR DESCRIPTION
Fixes #5116 

### Changes proposed in this Pull Request

* Set post type in the module link for selecting proper menu item

### Testing instructions

* Go to 'Sensei LMS -> Modules'
* Add a module.
* Click on the module you just created to open it in the editor.
* Make sure Modules submenu is selected

### Screenshot / Video
<img width="1402" alt="CleanShot 2022-05-12 at 21 45 42@2x" src="https://user-images.githubusercontent.com/329356/168146986-056c4f18-47af-4f1b-9dcd-0d8c211edda0.png">

