### PR TITLE
Configure NPM to throws an error when the env is using a wrong npm version

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,14 +9,12 @@ jobs:
     hookdocs:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - name: Use Node.js 10
-              uses: actions/setup-node@v2
-              with:
-                  node-version: '10.x'
+            - uses: actions/checkout@v3
+            - name: Updates the npm version
+              run: npm install -g npm@8.9.0
             - name: npm install, and build docs
               run: |
-                  npm install
+                  npm ci
                   npm run build:docs
             - name: Deploy to GH Pages
               uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,12 +7,12 @@ jobs:
         name: Plugin Build
         runs-on: ubuntu-18.04
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - name: Get npm cache directory
               id: npm-cache
               run: |
                   echo "::set-output name=dir::$(npm config get cache)"
-            - uses: actions/cache@v2
+            - uses: actions/cache@v3
               with:
                   path: ${{ steps.npm-cache.outputs.dir }}
                   key: ${{ runner.os }}-node-${{ hashFiles('package-lock.json') }}
@@ -26,7 +26,11 @@ jobs:
             - name: Get composer cache directory
               id: composer-cache
               run: echo "::set-output name=dir::$(composer config cache-files-dir)"
-            - uses: actions/cache@v2
+
+            - name: Updates the npm version
+              run: npm install -g npm@8.9.0
+
+            - uses: actions/cache@v3
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -24,11 +24,6 @@ jobs:
             - name: Updates the CI npm
               run: npm install -g npm@8.9.0
 
-            - name: Use specific NodeJS version
-              uses: actions/setup-node@v3
-              with:
-                  node-version: '16'
-
             - name: Install dependencies
               run: npm ci
 

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -21,6 +21,9 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v3
 
+            - name: Updates the CI npm
+              run: npm install -g npm@8.9.0
+
             - name: Use specific NodeJS version
               uses: actions/setup-node@v3
               with:

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -21,7 +21,7 @@ jobs:
             - name: Checkout code
               uses: actions/checkout@v3
 
-            - name: Updates the CI npm
+            - name: Updates the npm version
               run: npm install -g npm@8.9.0
 
             - name: Install dependencies

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -32,7 +32,7 @@ jobs:
             # clone the repository
             - uses: actions/checkout@v3
 
-            - name: Updates the CI npm
+            - name: Updates the npm version
               run: npm install -g npm@8.9.0
 
             - uses: actions/cache@v3

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -31,6 +31,10 @@ jobs:
         steps:
             # clone the repository
             - uses: actions/checkout@v3
+
+            - name: Updates the CI npm
+              run: npm install -g npm@8.9.0
+
             - uses: actions/cache@v3
               with:
                   path: ~/.npm

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -8,6 +8,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
+
+            - name: Updates the CI npm
+              run: npm install -g npm@8.9.0
+
             - uses: actions/cache@v3
               with:
                   path: ~/.npm/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 save-exact = true
+engine-strict = true


### PR DESCRIPTION
### Changes proposed in this Pull Request
* It configures the npm to throw an error when an incorrect npm or node version is used.

More details on https://docs.npmjs.com/cli/v8/using-npm/config#engine-strict.

### Testing instructions
Install an older npm version `npm install -g npm@8.5.0` 
Run `npm install` 

Check if the npm throws this error:

```
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: sensei-lms@4.4.0
npm ERR! notsup Not compatible with your version of node/npm: sensei-lms@4.4.0
npm ERR! notsup Required: {"npm":"^8.9.0","node":"^16.14.0"}
npm ERR! notsup Actual:   {"npm":"8.5.0","node":"v16.14.2"}
```
Install the expected npm version `npm install -g npm@8.9.0` 
Run `npm install`
Check if the installations happened correctly.

