### PR TITLE
Fix exporting "students taking course" not affected by filters

### DIFF
--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -790,6 +790,7 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 
 		$course = get_post( $this->course_id );
 		$report = sanitize_title( $course->post_title ) . '-' . $this->view . 's-overview';
+
 		if ( $this->user_id ) {
 			$user_name = Sensei_Learner::get_full_name( $this->user_id );
 			$report    = sanitize_title( $user_name ) . '-' . $report;
@@ -801,11 +802,17 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 			'view'                   => $this->view,
 			'sensei_report_download' => $report,
 			'post_type'              => $this->post_type,
+			'start_date'             => $this->get_start_date_filter_value(),
+			'end_date'               => $this->get_end_date_filter_value(),
+			's'                      => $this->get_search_value(),
 		);
+
 		if ( $this->user_id ) {
 			$url_args['user_id'] = $this->user_id;
 		}
+
 		$url = add_query_arg( $url_args, admin_url( 'edit.php' ) );
+
 		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download', '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
 	}
 
@@ -871,6 +878,16 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 		];
 
 		return $args;
+	}
+
+	/**
+	 * Get the search value.
+	 *
+	 * @return string search param value.
+	 */
+	private function get_search_value(): string {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Arguments used for filtering.
+		return isset( $_GET['s'] ) ? sanitize_text_field( wp_unslash( $_GET['s'] ) ) : '';
 	}
 }
 

--- a/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
@@ -111,6 +111,40 @@ class Sensei_Analysis_Course_List_Table_Test extends WP_UnitTestCase {
 		self::assertSame( $expected, $this->export_items( $table->items ) );
 	}
 
+	public function testTableFooter_WhenCalled_DisplayTheExportButtonWithCorrectArgs() {
+		/* Arrange. */
+		$course = $this->factory->course->create_and_get();
+		$user   = $this->factory->user->create_and_get();
+		$nonce  = wp_create_nonce( 'sensei_csv_download' );
+
+		$_GET = [
+			's'          => 'course',
+			'start_date' => '2022-03-01',
+			'end_date'   => '2022-03-02',
+			'_wpnonce'   => $nonce,
+		];
+
+		$list_table = new Sensei_Analysis_Course_List_Table( $course->ID, $user->ID );
+
+		/* Act. */
+		ob_start();
+		$list_table->prepare_items();
+		$list_table->data_table_footer();
+		$actual = ob_get_clean();
+
+		/* Assert. */
+		$expected = sprintf(
+			'<a class="button button-primary" href="http://example.org/wp-admin/edit.php?page=sensei_reports&#038;course_id=%d&#038;view=lesson&#038;sensei_report_download=%s-%s-lessons-overview&#038;post_type=course&#038;start_date=2022-03-01&#038;end_date=2022-03-02&#038;s=course&#038;user_id=%d&#038;_sdl_nonce=%s">Export all rows (CSV)</a>',
+			$course->ID,
+			$user->user_nicename,
+			$course->post_name,
+			$user->ID,
+			$nonce
+		);
+
+		self::assertSame( $expected, $actual, 'The export button should be displayed with the correct args.' );
+	}
+
 	private function export_items( array $items ) {
 		$ret = [];
 		foreach ( $items as $item ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR fixes the CSV export not being affected by the filters in the "Students taking this Course" reports section.

### Testing instructions

* Have a few students that are taking the same course.
* Go to Sensei LMS -> Reports -> Courses -> [the course] -> Students taking this Course (tab)
* Filter the students using the "Date Started" filter and make sure you see only a fraction of the students (not all).
* Click the "Export all rows" button.
* Make sure the exported results are the same as what you see on the screen table.
* Repeat the above by using the "Search".
