### PR TITLE
Fix hide export button when no results on "Students taking course" screen

### DIFF
--- a/includes/class-sensei-analysis-course-list-table.php
+++ b/includes/class-sensei-analysis-course-list-table.php
@@ -787,6 +787,9 @@ class Sensei_Analysis_Course_List_Table extends Sensei_List_Table {
 	 * @return void
 	 */
 	public function data_table_footer() {
+		if ( ! $this->total_items ) {
+			return;
+		}
 
 		$course = get_post( $this->course_id );
 		$report = sanitize_title( $course->post_title ) . '-' . $this->view . 's-overview';

--- a/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
@@ -140,9 +140,10 @@ class Sensei_Analysis_Course_List_Table_Test extends WP_UnitTestCase {
 
 		$list_table = new Sensei_Analysis_Course_List_Table( $course->ID, $user->ID );
 
+		$list_table->total_items = 1;
+
 		/* Act. */
 		ob_start();
-		$list_table->prepare_items();
 		$list_table->data_table_footer();
 		$actual = ob_get_clean();
 

--- a/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
+++ b/tests/unit-tests/test-class-sensei-analysis-course-list-table.php
@@ -111,6 +111,20 @@ class Sensei_Analysis_Course_List_Table_Test extends WP_UnitTestCase {
 		self::assertSame( $expected, $this->export_items( $table->items ) );
 	}
 
+	public function testTableFooter_WhenCalledWithNoData_NotDisplayTheExportButton() {
+		/* Arrange. */
+		$list_table = new Sensei_Analysis_Course_List_Table();
+
+		/* Act. */
+		ob_start();
+		$list_table->data_table_footer();
+		$actual = ob_get_clean();
+
+		/* Assert. */
+		$expected = '';
+		self::assertSame( $expected, $actual, 'The export button should not be displayed' );
+	}
+
 	private function export_items( array $items ) {
 		$ret = [];
 		foreach ( $items as $item ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Hides the export button when there are no results.

### Testing instructions

* Go to Sensei LMS -> Reports -> Courses -> [a course] -> Students taking this Course (tab)
* Use the filters so you don't see any results.
* There should be no "Export all rows" button.