### PR TITLE
Fix courses and lessons last activity date not showing in reports

### DIFF
--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-courses.php
@@ -202,7 +202,7 @@ class Sensei_Reports_Overview_List_Table_Courses extends Sensei_Reports_Overview
 			'sensei_analysis_overview_column_data',
 			array(
 				'title'              => $course_title,
-				'last_activity'      => $item->last_activity_date ? $this->format_last_activity_date( $item->last_activity_date ) : __( 'N/A', 'sensei-lms' ),
+				'last_activity'      => $item->last_activity_date ? Sensei_Utils::format_last_activity_date( $item->last_activity_date ) : __( 'N/A', 'sensei-lms' ),
 				'completions'        => $course_completions,
 				'average_progress'   => $average_course_progress,
 				'average_percent'    => $average_grade,

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -165,7 +165,7 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 				'title'              => $lesson_title,
 				'lesson_module'      => $this->get_row_module( $item->ID ),
 				'students'           => $lesson_students,
-				'last_activity'      => $item->last_activity_date ? $this->format_last_activity_date( $item->last_activity_date ) : __( 'N/A', 'sensei-lms' ),
+				'last_activity'      => $item->last_activity_date ? Sensei_Utils::format_last_activity_date( $item->last_activity_date ) : __( 'N/A', 'sensei-lms' ),
 				'completions'        => $lesson_completions,
 				'completion_rate'    => $this->get_completion_rate( $lesson_completions, $lesson_students ),
 				'days_to_completion' => $average_completion_days,


### PR DESCRIPTION
### Changes proposed in this Pull Request

Last activity date for courses and lessons didn't render after merging. Fixed that.

### Testing instructions

- Go to Reports -> Courses
- Make sure the last activity date appears in the table
- Go to Reports -> Lessons, select a course
- Make sure the last activity date appears in the table
### Screenshot / Video
Before
<img width="1392" alt="Screen Shot 2022-05-14 at 2 26 06 AM" src="https://user-images.githubusercontent.com/6820724/168387575-07325246-0de5-4eff-b21e-794573e1c660.png">
After
<img width="1392" alt="image" src="https://user-images.githubusercontent.com/6820724/168387819-3b2e0c99-342a-4118-84b6-1320b78619e7.png">
