### PR TITLE
Add `learn/` prefixed rewrite rule for module views

### DIFF
--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -77,6 +77,7 @@ class Sensei_Course_Theme {
 
 		add_action( 'setup_theme', [ $this, 'add_query_var' ], 1 );
 		add_action( 'registered_post_type', [ $this, 'add_post_type_rewrite_rules' ], 10, 2 );
+		add_action( 'registered_taxonomy', [ $this, 'add_taxonomy_rewrite_rules' ], 10, 3 );
 		add_action( 'shutdown', [ $this, 'maybe_flush_rewrite_rules' ] );
 		add_action( 'setup_theme', [ $this, 'maybe_override_theme' ], 2 );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Lesson::instance(), 'init' ] );
@@ -232,6 +233,23 @@ class Sensei_Course_Theme {
 		add_rewrite_rule( '^' . self::QUERY_VAR . '/' . $slug . '/([^/]+)(?:/([0-9]+))?\??(.*)', 'index.php?' . self::QUERY_VAR . '=1&' . $post_type . '=$matches[1]&page=$matches[2]&$matches[3]', 'top' );
 		add_rewrite_tag( '%' . self::QUERY_VAR . '%', '([^?]+)' );
 
+	}
+
+	/**
+	 * Add a route with a /learn prefix for using course theme for a taxonomy.
+	 *
+	 * @param string $taxonomy    Taxonomy slug.
+	 * @param array  $object_type Array of object types supported by the taxonomy.
+	 * @param array  $args        Arguments used to register the taxonomy.
+	 */
+	public function add_taxonomy_rewrite_rules( $taxonomy, $object_type, $args ) {
+		if ( ! in_array( $taxonomy, [ 'module' ], true ) ) {
+			return;
+		}
+
+		$slug = preg_quote( $args['rewrite']['slug'] ?? $taxonomy, '/' );
+
+		add_rewrite_rule( '^' . self::QUERY_VAR . '/' . $slug . '/([^/]+)(?:/([0-9]+))?\??(.*)', 'index.php?' . self::QUERY_VAR . '=1&' . $taxonomy . '=$matches[1]', 'top' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

Add a rewrite rule with the `learn/` prefix to registered `module` taxonomy, similar to how this is done for the registered lesson and quiz post types.

Without this rule, requests for `learn/module/` are seen as 404s and their permalink is guessed, often incorrectly.

I believe this fixes #5008.

### Testing instructions

With multiple lessons and modules setup...

**Before**:

```
curl -Ik https://example.test/modules/week-1/
```

Returns a 302 response with a location of `https://example.test/learn/modules/week-1/` and following that location

```
curl -Ik https://example.test/learn/modules/week-1/
```

Returns a 404 response.

**After**:

The same 302 location is returned, but

```
curl -Ik https://example.test/learn/modules/week-1/
```

Returns a correct 200 response.