### PR TITLE
Fix lesson not getting assigned to module if course teacher has teacher role

### DIFF
--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -104,6 +104,7 @@ export const extractStructure = ( blocks ) => {
 			description: block.attributes.description,
 			lessons: extractStructure( block.innerBlocks ),
 			teacher: block.attributes.teacher,
+			slug: block.attributes.slug,
 		} ),
 		lesson: ( block ) => ( {
 			draft: block.attributes.draft,

--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -104,7 +104,7 @@ export const extractStructure = ( blocks ) => {
 			description: block.attributes.description,
 			lessons: extractStructure( block.innerBlocks ),
 			teacher: block.attributes.teacher,
-			slug: block.attributes.slug,
+			lastTitle: block.attributes.lastTitle,
 		} ),
 		lesson: ( block ) => ( {
 			draft: block.attributes.draft,

--- a/assets/blocks/course-outline/module-block/block.json
+++ b/assets/blocks/course-outline/module-block/block.json
@@ -23,6 +23,10 @@
       "type": "string",
       "default": ""
     },
+    "slug": {
+      "type": "string",
+      "default": ""
+    },
     "mainColor": {
       "type": "string"
     },

--- a/assets/blocks/course-outline/module-block/block.json
+++ b/assets/blocks/course-outline/module-block/block.json
@@ -23,7 +23,7 @@
       "type": "string",
       "default": ""
     },
-    "slug": {
+    "lastTitle": {
       "type": "string",
       "default": ""
     },

--- a/assets/shared/structure/structure-store.test.js
+++ b/assets/shared/structure/structure-store.test.js
@@ -22,10 +22,24 @@ describe( 'Structure store', () => {
 			updateBlock: jest.fn(),
 			readBlock: jest.fn(),
 		};
-
 		( { unsubscribe } = registerStructureStore( store ) );
-		registerStore( 'core/editor', mockEditorStore );
-
+		const storesForRegister = {
+			'core/editor': mockEditorStore,
+			'core/edit-post': {
+				reducer: () => {},
+				selectors: {
+					isSavingMetaBoxes: jest
+						.fn()
+						.mockReturnValueOnce( true )
+						.mockReturnValueOnce( true )
+						.mockReturnValueOnce( true )
+						.mockReturnValueOnce( false ),
+				},
+			},
+		};
+		for ( const key in storesForRegister ) {
+			registerStore( key, storesForRegister[ key ] );
+		}
 		apiFetch.mockClear();
 		store.getEndpoint.mockImplementation( function* () {
 			return 'test-api/1';

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -138,6 +138,7 @@ class Sensei_Course_Structure {
 	 *     @type int    $id          The module term id.
 	 *     @type string $title       The module name.
 	 *     @type string $teacher     Name of the teacher of this module, gets populated only in admin panel for admins and if the teacher is not admin.
+	 *     @type string $lastTitle   Used in the block editor for unchanged title state reference.
 	 *     @type string $description The module description.
 	 *     @type array  $lessons     An array of the module lessons. See Sensei_Course_Structure::prepare_lesson().
 	 * }
@@ -152,7 +153,7 @@ class Sensei_Course_Structure {
 			'title'       => $module_term->name,
 			'description' => $module_term->description,
 			'teacher'     => user_can( $author, 'manage_options' ) ? '' : $author->display_name,
-			'slug'        => $module_term->slug,
+			'lastTitle'   => $module_term->name,
 			'lessons'     => [],
 		];
 
@@ -700,12 +701,13 @@ class Sensei_Course_Structure {
 		if ( 'module' === $raw_item['type'] ) {
 			if ( $item['id'] ) {
 				$term = get_term( $item['id'], 'module' );
-				if ( ! $term && $raw_item['slug'] ) {
-					$new_slug = $this->get_module_slug( $raw_item['title'] );
-					$term     = $this->get_module_for_teacher_by_slug( $raw_item['slug'], [ $new_slug ] );
-					if ( $term ) {
-						$item['id'] = $term->term_id;
-					}
+				// Because term may get deleted in some cases during the process of changing the course teacher
+				// which takes place before saving structure.
+				if ( ! $term && $raw_item['lastTitle'] ) {
+					// During the teacher changing process of courses, modules are created or fetched using the
+					// existing title, not the one that is sent in the course structure save process.
+					$term       = $this->get_existing_module( $raw_item['lastTitle'] );
+					$item['id'] = $term;
 				}
 				if ( ! $term || is_wp_error( $term ) ) {
 					return new WP_Error(
@@ -861,40 +863,5 @@ class Sensei_Course_Structure {
 		}
 
 		return false;
-	}
-
-	/**
-	 * Get module for teacher by slug.
-	 *
-	 * @since x.x.x
-	 *
-	 * @param string $slug             The probable slug.
-	 * @param array  $additional_slugs Additional slugs to search with.
-	 *
-	 * @return WP_Term|null The found term or null.
-	 */
-	private function get_module_for_teacher_by_slug( string $slug, array $additional_slugs = [] ) {
-		$search_slugs  = [] + $additional_slugs ?? [];
-		$user_id       = get_post( $this->course_id )->post_author;
-		$is_admin_user = user_can( $user_id, 'manage_options' );
-		$split_slug    = explode( '-', $slug );
-
-		array_shift( $split_slug );
-
-		if ( ! $is_admin_user ) {
-			$search_slugs[] = $user_id . '-' . $slug;
-			$search_slugs[] = $user_id . '-' . implode( '-', $split_slug );
-		} elseif ( count( $split_slug ) > 0 ) {
-			$search_slugs[] = implode( '-', $split_slug );
-		}
-
-		foreach ( $search_slugs as $search_slug ) {
-			$search_term = get_term_by( 'slug', $search_slug, 'module' );
-
-			if ( $search_term && ! is_wp_error( $search_term ) ) {
-				return $search_term;
-			}
-		}
-		return null;
 	}
 }

--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -152,6 +152,7 @@ class Sensei_Course_Structure {
 			'title'       => $module_term->name,
 			'description' => $module_term->description,
 			'teacher'     => user_can( $author, 'manage_options' ) ? '' : $author->display_name,
+			'slug'        => $module_term->slug,
 			'lessons'     => [],
 		];
 

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -415,7 +415,7 @@ class Sensei_Teacher {
 			return;
 		}
 
-		$lessons = Sensei()->course->course_lessons( $course_id );
+		$lessons = Sensei()->course->course_lessons( $course_id, null );
 
 		foreach ( $terms_selected_on_course as $term ) {
 			$term_author = Sensei_Core_Modules::get_term_author( $term->slug );


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/4704

### Changes proposed in this Pull Request

In the block editor for editing courses, the course structure and course meta fields (like 'teacher') were being saved parallelly while saving the course. Changing course teacher removes modules from courses and creates new ones and sometimes the old modules are even deleted during this process. So, the structure saving call and the teacher re-assigning call sometimes collide and that was the main cause for the issue. Now it is handled in a way that the structure saving will happen only after meta are saved.

If the user wants to edit the course blocks after changing teacher, or they already have changes in the blocks and then change the teacher and update the course, the previous slug is being used to handle the issue where the module is deleted and the system can't find it using the ID. We could keep the teacher selection dropdown or the module editor disabled for a more sure shot way, but this way the user doesn't get blocked while creating/editing a course and can keep working, felt that is a good experience for the user.

Also while reassigning lessons to modules while editing, draft lessons were not being considered. That case is also handled.

### Testing instructions

- Create a couple of users with the role 'Teacher'
- Go to SenseiLMS->Courses
- Design a new course with multiple modules containing multiple lesson blocks
- Change the course teacher from admin user to a teacher user
- Try saving it. Refresh and make sure the structure isn't broken
- Go back to the course list and select the same course for editing
- Change course teacher to another teacher user
- Make sure it doesn't break
- Try different user change combo and module/lesson structure changes combo

### Screenshot / Video

https://user-images.githubusercontent.com/6820724/169018750-86aad79c-2261-47fe-9f21-a71a468dfe69.mp4

