### PR TITLE
Fix deprecated warnings on the students report screen

### DIFF
--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -47,25 +47,33 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 			return $this->columns;
 		}
 
+		$total_completed_courses = 0;
+		$total_courses_started   = 0;
+		$total_average_grade     = 0;
+
 		$user_ids = $this->get_all_item_ids();
-		// Get total value for Courses Completed column in users table.
-		$course_args_completed   = array(
-			'user_id' => $user_ids,
-			'type'    => 'sensei_course_status',
-			'status'  => 'complete',
-		);
-		$total_completed_courses = Sensei_Utils::sensei_check_for_activity( $course_args_completed );
+		if ( $user_ids ) {
+			// Get total value for Courses Completed column in users table.
+			$total_completed_courses = Sensei_Utils::sensei_check_for_activity(
+				[
+					'user_id' => $user_ids,
+					'type'    => 'sensei_course_status',
+					'status'  => 'complete',
+				]
+			);
 
-		// Get the number of the courses that users have started.
-		$course_args_started   = array(
-			'user_id' => $user_ids,
-			'type'    => 'sensei_course_status',
-			'status'  => 'any',
-		);
-		$total_courses_started = Sensei_Utils::sensei_check_for_activity( $course_args_started );
+			// Get the number of the courses that users have started.
+			$total_courses_started = Sensei_Utils::sensei_check_for_activity(
+				[
+					'user_id' => $user_ids,
+					'type'    => 'sensei_course_status',
+					'status'  => 'any',
+				]
+			);
 
-		// Get total average students grade.
-		$total_average_grade = $this->reports_overview_service_students->get_graded_lessons_average_grade( $user_ids );
+			// Get total average students grade.
+			$total_average_grade = $this->reports_overview_service_students->get_graded_lessons_average_grade( $user_ids );
+		}
 
 		$columns = array(
 			// translators: Placeholder value is total count of students.

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-students.php
@@ -77,16 +77,16 @@ class Sensei_Reports_Overview_List_Table_Students extends Sensei_Reports_Overvie
 
 		$columns = array(
 			// translators: Placeholder value is total count of students.
-			'title'             => sprintf( __( 'Student (%d)', 'sensei-lms' ), esc_html( count( $user_ids ) ) ),
+			'title'             => sprintf( __( 'Student (%d)', 'sensei-lms' ), count( $user_ids ) ),
 			'email'             => __( 'Email', 'sensei-lms' ),
 			'date_registered'   => __( 'Date Registered', 'sensei-lms' ),
 			'last_activity'     => __( 'Last Activity', 'sensei-lms' ),
 			// translators: Placeholder value is all active courses.
-			'active_courses'    => sprintf( __( 'Active Courses (%d)', 'sensei-lms' ), esc_html( $total_courses_started - $total_completed_courses ) ),
+			'active_courses'    => sprintf( __( 'Active Courses (%d)', 'sensei-lms' ), $total_courses_started - $total_completed_courses ),
 			// translators: Placeholder value is all completed courses.
-			'completed_courses' => sprintf( __( 'Completed Courses (%d)', 'sensei-lms' ), esc_html( $total_completed_courses ) ),
+			'completed_courses' => sprintf( __( 'Completed Courses (%d)', 'sensei-lms' ), $total_completed_courses ),
 			// translators: Placeholder value is graded average value.
-			'average_grade'     => sprintf( __( 'Average Grade (%d%%)', 'sensei-lms' ), esc_html( $total_average_grade ) ),
+			'average_grade'     => sprintf( __( 'Average Grade (%d%%)', 'sensei-lms' ), $total_average_grade ),
 		);
 
 		// Backwards compatible filter name, moving forward should have single filter name.


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Fixes two deprecated warnings showing on the students report screen when there are no students on the list.
* Cleans up some excessive escaping.

### Testing instructions

* Make sure your PHP `errors_reporting` setting is turned on for deprecated warnings.
* Go to Sensei LMS -> Reports -> Students.
* Use the filters so you don't see any students.
* Make sure you see no deprecated warnings.
