### PR TITLE
Update the link and text for CTA on the extensions page

### DIFF
--- a/assets/extensions/featured-product-sensei-pro.js
+++ b/assets/extensions/featured-product-sensei-pro.js
@@ -43,7 +43,10 @@ const FeaturedProductSenseiPro = () => {
 				__( 'Schedule ‘drip’ content', 'sensei-lms' ),
 				__( 'Set expiration date of courses', 'sensei-lms' ),
 				__( 'Advanced quiz features', 'sensei-lms' ),
-				__( 'Interactive learning blocks (coming soon)', 'sensei-lms' ),
+				__(
+					'Flashcard, image hotspot, and tasklist blocks',
+					'sensei-lms'
+				),
 				__( 'Premium support', 'sensei-lms' ),
 			] }
 			image={ senseiProExtension.image_large }

--- a/assets/extensions/featured-product-sensei-pro.js
+++ b/assets/extensions/featured-product-sensei-pro.js
@@ -53,10 +53,8 @@ const FeaturedProductSenseiPro = () => {
 				__( '%s USD / year (1 site)', 'sensei-lms' ),
 				senseiProExtension.price
 			) }
-			buttonLink={ sprintf(
-				'https://senseilms.com/checkout?add-to-cart=%d&utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=extensions_header',
-				senseiProExtension.wccom_product_id
-			) }
+			buttonLink="https://senseilms.com/pricing/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=extensions_header"
+			buttonTitle={ __( 'Learn More', 'sensei-lms' ) }
 		/>
 	);
 };

--- a/assets/extensions/featured-product.js
+++ b/assets/extensions/featured-product.js
@@ -20,6 +20,7 @@ import { __, sprintf } from '@wordpress/i18n';
  * @param {string}   props.image         Product image.
  * @param {string}   props.price         Product price.
  * @param {string}   props.buttonLink    CTA button link.
+ * @param {string}   props.buttonTitle   CTA button title.
  * @param {Object}   props.htmlProps     Wrapper extra props.
  */
 const FeaturedProduct = ( props ) => {
@@ -32,6 +33,7 @@ const FeaturedProduct = ( props ) => {
 		image,
 		price,
 		buttonLink,
+		buttonTitle,
 		htmlProps,
 	} = props;
 
@@ -108,7 +110,7 @@ const FeaturedProduct = ( props ) => {
 							'is-large'
 						) }
 					>
-						{ getProductText }
+						{ buttonTitle }
 					</a>
 				</div>
 			</section>


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update the link to pricing.
* Change text from "Get Sensei Pro" to "Learn More".

### Testing instructions

* Go to `Sensei LMS -> Extensions`
* Make sure you see "Learn More" button for the featured product and the link is `https://senseilms.com/pricing/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=extensions_header`.

### Screenshot / Video
![CleanShot 2022-05-18 at 18 23 22@2x](https://user-images.githubusercontent.com/329356/169081544-875384e3-d2ab-4b3d-9892-656cd1cc9656.png)

