### PR TITLE
Fix lesson blocks notice when Learning Mode is enabled

### DIFF
--- a/assets/js/admin/blocks-toggling-control.js
+++ b/assets/js/admin/blocks-toggling-control.js
@@ -119,8 +119,9 @@ export const startBlocksTogglingControl = ( postType ) => {
 	 */
 	const toggleLegacyOrBlocksNotice = () => {
 		const withSenseiBlocks = hasSenseiBlocks();
+		const courseThemeEnabled = window?.sensei?.courseThemeEnabled;
 
-		if ( withSenseiBlocks ) {
+		if ( withSenseiBlocks || courseThemeEnabled ) {
 			removeNotice( 'sensei-using-template' );
 		} else {
 			createWarningNotice(

--- a/assets/js/admin/blocks-toggling-control.js
+++ b/assets/js/admin/blocks-toggling-control.js
@@ -70,9 +70,6 @@ export const startBlocksTogglingControl = ( postType ) => {
 				toggleLegacyOrBlocksNotice();
 			}
 		},
-		onSave: () => {
-			toggleLegacyOrBlocksNotice();
-		},
 	} );
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes the notice in the lessons which says if the lesson will be displayed with blocks or custom templates. Now, when Learning Mode is enabled, we don't show the notice: `It looks like this course page doesn't have any Sensei blocks. This means that content will be handled by custom templates.`

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course with Learning mode enabled and add a lesson.
* In the lesson, remove all Sensei blocks, and make sure you don't see the notice about the "custom templates".
* Disable the learning mode in the course, remove all Sensei blocks again, and make sure you see the "custom templates" notice.

### Context

p1652852650889649/1652822680.825379-slack-C07418EJ0