### PR TITLE
Add skeleton for wizard steps.

### DIFF
--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -105,9 +105,9 @@ const EditorWizardModal = () => {
 		closeModal();
 	};
 
-	const updateModalTitle = ( wizardData ) => {
-		if ( wizardData.modalTitle ) {
-			setModalTitle( wizardData.modalTitle );
+	const updateModalTitle = ( step ) => {
+		if ( step.Title !== undefined ) {
+			setModalTitle( step.Title );
 		}
 	};
 
@@ -120,8 +120,8 @@ const EditorWizardModal = () => {
 			>
 				<Wizard
 					steps={ steps }
+					onStepChange={ updateModalTitle }
 					onCompletion={ onWizardCompletion }
-					onChange={ updateModalTitle }
 				/>
 			</Modal>
 		) ) ||

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { select, useDispatch } from '@wordpress/data';
 import { Modal } from '@wordpress/components';
 import { useEffect, useLayoutEffect, useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -13,6 +13,8 @@ import Wizard from './wizard';
 import CourseDetailsStep from './steps/course-details-step';
 import UpgradeStep from './steps/upgrade-step';
 import CoursePatternsStep from './steps/course-patterns-step';
+import LessonDetailsStep from './steps/lesson-details-step';
+import LessonPatternsStep from './steps/lesson-patterns-step';
 
 /**
  * A React Hook to observe if a modal is open based on the body class.
@@ -88,8 +90,13 @@ const EditorWizardModal = () => {
 		} );
 	};
 
-	// TODO Implement different flows depending on post type 👇.
-	const steps = [ CourseDetailsStep, UpgradeStep, CoursePatternsStep ];
+	// Choose steps by post type.
+	const stepsByPostType = {
+		course: [ CourseDetailsStep, UpgradeStep, CoursePatternsStep ],
+		lesson: [ LessonDetailsStep, LessonPatternsStep ],
+	};
+	const postType = select( 'core/editor' )?.getCurrentPostType();
+	const steps = stepsByPostType[ postType ];
 
 	const onWizardCompletion = ( data ) => {
 		// TODO Implement actions when wizard is completed.

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { select, useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { Modal } from '@wordpress/components';
 import { useEffect, useLayoutEffect, useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -96,7 +96,9 @@ const EditorWizardModal = () => {
 		course: [ CourseDetailsStep, UpgradeStep, CoursePatternsStep ],
 		lesson: [ LessonDetailsStep, LessonPatternsStep ],
 	};
-	const postType = select( 'core/editor' )?.getCurrentPostType();
+	const { postType } = useSelect( ( select ) => ( {
+		postType: select( editorStore )?.getCurrentPostType(),
+	} ) );
 	const steps = stepsByPostType[ postType ];
 
 	// eslint-disable-next-line no-unused-vars

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -81,6 +81,7 @@ const EditorWizardModal = () => {
 	const [ open, setDone ] = useWizardOpenState();
 	const { synchronizeTemplate } = useDispatch( blockEditorStore );
 	const { editPost } = useDispatch( editorStore );
+	const [ modalTitle, setModalTitle ] = useState( '' );
 
 	const closeModal = () => {
 		setDone( true );
@@ -98,21 +99,29 @@ const EditorWizardModal = () => {
 	const postType = select( 'core/editor' )?.getCurrentPostType();
 	const steps = stepsByPostType[ postType ];
 
-	const onWizardCompletion = ( data ) => {
-		// TODO Implement actions when wizard is completed.
-
-		// eslint-disable-next-line no-console
-		console.log(
-			`Wizard completed with data: ${ JSON.stringify( data ) }`
-		);
-
+	// eslint-disable-next-line no-unused-vars
+	const onWizardCompletion = ( wizardData ) => {
+		// TODO Implement actions when wizard is completed
 		closeModal();
+	};
+
+	const updateModalTitle = ( wizardData ) => {
+		if (
+			wizardData.modalTitle !== undefined &&
+			wizardData.modalTitle !== modalTitle
+		) {
+			setModalTitle( wizardData.modalTitle );
+		}
 	};
 
 	return (
 		open && (
-			<Modal onRequestClose={ closeModal } title="I'm a modal!">
-				<Wizard steps={ steps } onCompletion={ onWizardCompletion } />
+			<Modal onRequestClose={ closeModal } title={ modalTitle }>
+				<Wizard
+					steps={ steps }
+					onCompletion={ onWizardCompletion }
+					onChange={ updateModalTitle }
+				/>
 			</Modal>
 		)
 	);

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -6,6 +6,13 @@ import { Modal } from '@wordpress/components';
 import { useEffect, useLayoutEffect, useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
+/**
+ * Internal dependencies
+ */
+import Wizard from './wizard';
+import CourseDetailsStep from './steps/course-details-step';
+import UpgradeStep from './steps/upgrade-step';
+import CoursePatternsStep from './steps/course-patterns-step';
 
 /**
  * A React Hook to observe if a modal is open based on the body class.
@@ -81,10 +88,24 @@ const EditorWizardModal = () => {
 		} );
 	};
 
+	// TODO Implement different flows depending on post type 👇.
+	const steps = [ CourseDetailsStep, UpgradeStep, CoursePatternsStep ];
+
+	const onWizardCompletion = ( data ) => {
+		// TODO Implement actions when wizard is completed.
+
+		// eslint-disable-next-line no-console
+		console.log(
+			`Wizard completed with data: ${ JSON.stringify( data ) }`
+		);
+
+		closeModal();
+	};
+
 	return (
 		open && (
 			<Modal onRequestClose={ closeModal } title="I'm a modal!">
-				Code me, please!
+				<Wizard steps={ steps } onCompletion={ onWizardCompletion } />
 			</Modal>
 		)
 	);

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -106,15 +106,13 @@ const EditorWizardModal = () => {
 	};
 
 	const updateModalTitle = ( wizardData ) => {
-		if (
-			wizardData.modalTitle
-		) {
+		if ( wizardData.modalTitle ) {
 			setModalTitle( wizardData.modalTitle );
 		}
 	};
 
 	return (
-		open && (
+		( open && steps && (
 			<Modal
 				className="sensei-editor-wizard-modal"
 				onRequestClose={ closeModal }
@@ -126,7 +124,8 @@ const EditorWizardModal = () => {
 					onChange={ updateModalTitle }
 				/>
 			</Modal>
-		)
+		) ) ||
+		null
 	);
 };
 

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -116,7 +116,11 @@ const EditorWizardModal = () => {
 
 	return (
 		open && (
-			<Modal onRequestClose={ closeModal } title={ modalTitle }>
+			<Modal
+				className="sensei-editor-wizard-modal"
+				onRequestClose={ closeModal }
+				title={ modalTitle }
+			>
 				<Wizard
 					steps={ steps }
 					onCompletion={ onWizardCompletion }

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -107,8 +107,7 @@ const EditorWizardModal = () => {
 
 	const updateModalTitle = ( wizardData ) => {
 		if (
-			wizardData.modalTitle !== undefined &&
-			wizardData.modalTitle !== modalTitle
+			wizardData.modalTitle
 		) {
 			setModalTitle( wizardData.modalTitle );
 		}

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -5,10 +5,10 @@
  * @param {Object}   props.data
  * @param {Function} props.setData
  */
-const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
+const CourseDetailsStep = ( { data, setData } ) => {
 	// Sample implementation updating title attribute.
 	const onTitleChange = ( event ) => {
-		setWizardData( { ...wizardData, title: event.target.value } );
+		setData( { ...data, title: event.target.value } );
 	};
 	return (
 		<div>

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { useEffect } from '@wordpress/element';
-
-/**
  * Initial step for course creation wizard.
  *
  * @param {Object}   props
@@ -11,11 +6,7 @@ import { useEffect } from '@wordpress/element';
  * @param {Function} props.setData
  */
 const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
-	// Update modal title.
-	useEffect( () => {
-		setWizardData( { ...wizardData, modalTitle: 'Course Details Step' } );
-	}, [] );
-
+	// TODO Implement this.
 	// Sample implementation updating newCourseTitle attribute.
 	const updateNewCourseTitle = ( event ) => {
 		setWizardData( { ...wizardData, newCourseTitle: event.target.value } );
@@ -30,6 +21,8 @@ const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 		</div>
 	);
 };
+
+CourseDetailsStep.Title = 'Course Details Step';
 
 CourseDetailsStep.Actions = ( { data, goToNextStep } ) => {
 	// Actions have access to the whole wizard data.

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -5,10 +5,10 @@
  * @param {Object}   props.data
  * @param {Function} props.setData
  */
-const CourseDetailsStep = ( { data, setData } ) => {
+const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 	// Sample implementation updating title attribute.
 	const onTitleChange = ( event ) => {
-		setData( { ...data, title: event.target.value } );
+		setWizardData( { ...wizardData, title: event.target.value } );
 	};
 	return (
 		<div>

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
  * Initial step for course creation wizard.
  *
  * @param {Object}   props
@@ -6,16 +11,20 @@
  * @param {Function} props.setData
  */
 const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
-	// Sample implementation updating title attribute.
-	const onTitleChange = ( event ) => {
-		setWizardData( { ...wizardData, title: event.target.value } );
+	// Update modal title.
+	useEffect( () => {
+		setWizardData( { ...wizardData, modalTitle: 'Course Details Step' } );
+	}, [] );
+
+	// Sample implementation updating newCourseTitle attribute.
+	const updateNewCourseTitle = ( event ) => {
+		setWizardData( { ...wizardData, newCourseTitle: event.target.value } );
 	};
 	return (
 		<div>
-			<div>Course Details Step</div>
 			<div>
 				<label htmlFor="course_title">Course title:</label>
-				<input id="course_title" onChange={ onTitleChange } />
+				<input id="course_title" onChange={ updateNewCourseTitle } />
 			</div>
 			<div>PENDING TO IMPLEMENT</div>
 		</div>
@@ -37,8 +46,7 @@ CourseDetailsStep.Actions = ( { data, goToNextStep } ) => {
 					aria-label="Funny eyes that will be removed later."
 				>
 					👀
-				</span>{ ' ' }
-				data
+				</span>
 			</button>
 			<button onClick={ goToNextStep }>Next</button>
 		</div>

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -1,0 +1,48 @@
+/**
+ * Initial step for course creation wizard.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.data
+ * @param {Function} props.setData
+ */
+const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
+	// Sample implementation updating title attribute.
+	const onTitleChange = ( event ) => {
+		setWizardData( { ...wizardData, title: event.target.value } );
+	};
+	return (
+		<div>
+			<div>Course Details Step</div>
+			<div>
+				<label htmlFor="course_title">Course title:</label>
+				<input id="course_title" onChange={ onTitleChange } />
+			</div>
+			<div>PENDING TO IMPLEMENT</div>
+		</div>
+	);
+};
+
+CourseDetailsStep.Actions = ( { data, goToNextStep } ) => {
+	// Actions have access to the whole wizard data.
+	const secondaryAction = () => {
+		// TODO Remove this.
+		// eslint-disable-next-line no-alert
+		window.alert( `Data ${ JSON.stringify( data ) }` );
+	};
+	return (
+		<div>
+			<button onClick={ secondaryAction }>
+				<span
+					role="img"
+					aria-label="Funny eyes that will be removed later."
+				>
+					👀
+				</span>{ ' ' }
+				data
+			</button>
+			<button onClick={ goToNextStep }>Next</button>
+		</div>
+	);
+};
+
+export default CourseDetailsStep;

--- a/assets/admin/editor-wizard/steps/course-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/course-patterns-step.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { useEffect } from '@wordpress/element';
-
-/**
  * Final step in course creation wizard choosing the actual course pattern to use.
  *
  * @param {Object}   props
@@ -18,11 +13,6 @@ const CoursePatternsStep = ( {
 	setData: setWizardData,
 	onCompletion,
 } ) => {
-	// Update modal title.
-	useEffect( () => {
-		setWizardData( { ...wizardData, modalTitle: 'Course Patterns Step' } );
-	}, [] );
-
 	// TODO Implement this.
 
 	// We can call `onCompletion` to complete the wizard after setting the correct pattern with `setData`.
@@ -34,6 +24,8 @@ const CoursePatternsStep = ( {
 		</div>
 	);
 };
+
+CoursePatternsStep.Title = 'Course Patterns Step';
 
 CoursePatternsStep.Actions = ( { goToNextStep } ) => {
 	// TODO Implement this.

--- a/assets/admin/editor-wizard/steps/course-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/course-patterns-step.js
@@ -1,0 +1,32 @@
+/**
+ * Final step in course creation wizard choosing the actual course pattern to use.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.data
+ * @param {Function} props.setData
+ * @param {Function} props.onCompletion
+ */
+// eslint-disable-next-line no-unused-vars
+const CoursePatternsStep = ( { data, setData, onCompletion } ) => {
+	// TODO Implement this.
+
+	// We can call `onCompletion` to complete the wizard after setting the correct pattern with `setData`.
+
+	return (
+		<div>
+			<div>Course Patterns Step</div>
+			<div>PENDING TO IMPLEMENT</div>
+		</div>
+	);
+};
+
+CoursePatternsStep.Actions = ( { goToNextStep } ) => {
+	// TODO Implement this.
+	return (
+		<div>
+			<button onClick={ goToNextStep }>Complete</button>
+		</div>
+	);
+};
+
+export default CoursePatternsStep;

--- a/assets/admin/editor-wizard/steps/course-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/course-patterns-step.js
@@ -15,6 +15,7 @@ const CoursePatternsStep = ( {
 	// TODO Implement this.
 
 	// We can call `onCompletion` to complete the wizard after setting the correct pattern with `setData`.
+	// We could replace `onCompletion` with the `goToNextStep` callback with a similar effect.
 
 	return (
 		<div>

--- a/assets/admin/editor-wizard/steps/course-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/course-patterns-step.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
  * Final step in course creation wizard choosing the actual course pattern to use.
  *
  * @param {Object}   props
@@ -6,12 +11,18 @@
  * @param {Function} props.setData
  * @param {Function} props.onCompletion
  */
+
 /* eslint-disable no-unused-vars */
 const CoursePatternsStep = ( {
 	data: wizardData,
 	setData: setWizardData,
 	onCompletion,
 } ) => {
+	// Update modal title.
+	useEffect( () => {
+		setWizardData( { ...wizardData, modalTitle: 'Course Patterns Step' } );
+	}, [] );
+
 	// TODO Implement this.
 
 	// We can call `onCompletion` to complete the wizard after setting the correct pattern with `setData`.
@@ -19,7 +30,6 @@ const CoursePatternsStep = ( {
 
 	return (
 		<div>
-			<div>Course Patterns Step</div>
 			<div>PENDING TO IMPLEMENT</div>
 		</div>
 	);

--- a/assets/admin/editor-wizard/steps/course-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/course-patterns-step.js
@@ -6,8 +6,12 @@
  * @param {Function} props.setData
  * @param {Function} props.onCompletion
  */
-// eslint-disable-next-line no-unused-vars
-const CoursePatternsStep = ( { data, setData, onCompletion } ) => {
+/* eslint-disable no-unused-vars */
+const CoursePatternsStep = ( {
+	data: wizardData,
+	setData: setWizardData,
+	onCompletion,
+} ) => {
 	// TODO Implement this.
 
 	// We can call `onCompletion` to complete the wizard after setting the correct pattern with `setData`.

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -1,0 +1,32 @@
+/**
+ * Initial step for course creation wizard.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.data
+ * @param {Function} props.setData
+ */
+const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
+	const onTitleChange = ( event ) => {
+		setWizardData( { ...wizardData, title: event.target.value } );
+	};
+	return (
+		<div>
+			<div>Course Details Step</div>
+			<div>
+				<label htmlFor="course_title">Course title:</label>
+				<input id="course_title" onChange={ onTitleChange } />
+			</div>
+			<div>PENDING TO IMPLEMENT</div>
+		</div>
+	);
+};
+
+LessonDetailsStep.Actions = ( { goToNextStep } ) => {
+	return (
+		<div>
+			<button onClick={ goToNextStep }>Next</button>
+		</div>
+	);
+};
+
+export default LessonDetailsStep;

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -11,7 +11,7 @@ const LessonDetailsStep = ( { data, setData } ) => {
 	};
 	return (
 		<div>
-			<div>Course Details Step</div>
+			<div>Lesson Details Step</div>
 			<div>
 				<label htmlFor="course_title">Course title:</label>
 				<input id="course_title" onChange={ onTitleChange } />

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
  * Initial step for course creation wizard.
  *
  * @param {Object}   props
@@ -6,16 +11,13 @@
  * @param {Function} props.setData
  */
 const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
-	const onTitleChange = ( event ) => {
-		setWizardData( { ...wizardData, title: event.target.value } );
-	};
+	// Update modal title.
+	useEffect( () => {
+		setWizardData( { ...wizardData, modalTitle: 'Lesson Details Step' } );
+	}, [] );
+
 	return (
 		<div>
-			<div>Lesson Details Step</div>
-			<div>
-				<label htmlFor="course_title">Course title:</label>
-				<input id="course_title" onChange={ onTitleChange } />
-			</div>
 			<div>PENDING TO IMPLEMENT</div>
 		</div>
 	);

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -1,27 +1,16 @@
 /**
- * WordPress dependencies
- */
-import { useEffect } from '@wordpress/element';
-
-/**
  * Initial step for course creation wizard.
- *
- * @param {Object}   props
- * @param {Object}   props.data
- * @param {Function} props.setData
  */
-const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
-	// Update modal title.
-	useEffect( () => {
-		setWizardData( { ...wizardData, modalTitle: 'Lesson Details Step' } );
-	}, [] );
-
+const LessonDetailsStep = () => {
+	// TODO Implement this.
 	return (
 		<div>
 			<div>PENDING TO IMPLEMENT</div>
 		</div>
 	);
 };
+
+LessonDetailsStep.Title = 'Lesson Details Step';
 
 LessonDetailsStep.Actions = ( { goToNextStep } ) => {
 	return (

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -5,9 +5,9 @@
  * @param {Object}   props.data
  * @param {Function} props.setData
  */
-const LessonDetailsStep = ( { data, setData } ) => {
+const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 	const onTitleChange = ( event ) => {
-		setData( { ...data, title: event.target.value } );
+		setWizardData( { ...wizardData, title: event.target.value } );
 	};
 	return (
 		<div>

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -5,9 +5,9 @@
  * @param {Object}   props.data
  * @param {Function} props.setData
  */
-const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
+const LessonDetailsStep = ( { data, setData } ) => {
 	const onTitleChange = ( event ) => {
-		setWizardData( { ...wizardData, title: event.target.value } );
+		setData( { ...data, title: event.target.value } );
 	};
 	return (
 		<div>

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -1,0 +1,32 @@
+/**
+ * Final step in lesson creation wizard choosing the actual lesson pattern to use.
+ *
+ * @param {Object}   props
+ * @param {Object}   props.data
+ * @param {Function} props.setData
+ * @param {Function} props.onCompletion
+ */
+// eslint-disable-next-line no-unused-vars
+const LessonPatternsStep = ( { data, setData, onCompletion } ) => {
+	// TODO Implement this.
+
+	// We can call `onCompletion` to complete the wizard after setting the correct pattern with `setData`.
+
+	return (
+		<div>
+			<div>Lesson Patterns Step</div>
+			<div>PENDING TO IMPLEMENT</div>
+		</div>
+	);
+};
+
+LessonPatternsStep.Actions = ( { goToNextStep } ) => {
+	// TODO Implement this.
+	return (
+		<div>
+			<button onClick={ goToNextStep }>Complete</button>
+		</div>
+	);
+};
+
+export default LessonPatternsStep;

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -1,9 +1,4 @@
 /**
- * WordPress dependencies
- */
-import { useEffect } from '@wordpress/element';
-
-/**
  * Final step in lesson creation wizard choosing the actual lesson pattern to use.
  *
  * @param {Object}   props
@@ -17,11 +12,6 @@ const LessonPatternsStep = ( {
 	setData: setWizardData,
 	onCompletion,
 } ) => {
-	// Update modal title.
-	useEffect( () => {
-		setWizardData( { ...wizardData, modalTitle: 'Lesson Patterns Step' } );
-	}, [] );
-
 	// TODO Implement this.
 
 	// We can call `onCompletion` to complete the wizard after setting the correct pattern with `setData`.
@@ -33,6 +23,8 @@ const LessonPatternsStep = ( {
 		</div>
 	);
 };
+
+LessonPatternsStep.Title = 'Lesson Patterns Step';
 
 LessonPatternsStep.Actions = ( { goToNextStep } ) => {
 	// TODO Implement this.

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -15,6 +15,7 @@ const LessonPatternsStep = ( {
 	// TODO Implement this.
 
 	// We can call `onCompletion` to complete the wizard after setting the correct pattern with `setData`.
+	// We could replace `onCompletion` with the `goToNextStep` callback with a similar effect.
 
 	return (
 		<div>

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -6,8 +6,12 @@
  * @param {Function} props.setData
  * @param {Function} props.onCompletion
  */
-// eslint-disable-next-line no-unused-vars
-const LessonPatternsStep = ( { data, setData, onCompletion } ) => {
+/* eslint-disable no-unused-vars */
+const LessonPatternsStep = ( {
+	data: wizardData,
+	setData: setWizardData,
+	onCompletion,
+} ) => {
 	// TODO Implement this.
 
 	// We can call `onCompletion` to complete the wizard after setting the correct pattern with `setData`.

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
  * Final step in lesson creation wizard choosing the actual lesson pattern to use.
  *
  * @param {Object}   props
@@ -12,6 +17,11 @@ const LessonPatternsStep = ( {
 	setData: setWizardData,
 	onCompletion,
 } ) => {
+	// Update modal title.
+	useEffect( () => {
+		setWizardData( { ...wizardData, modalTitle: 'Lesson Patterns Step' } );
+	}, [] );
+
 	// TODO Implement this.
 
 	// We can call `onCompletion` to complete the wizard after setting the correct pattern with `setData`.
@@ -19,7 +29,6 @@ const LessonPatternsStep = ( {
 
 	return (
 		<div>
-			<div>Lesson Patterns Step</div>
 			<div>PENDING TO IMPLEMENT</div>
 		</div>
 	);

--- a/assets/admin/editor-wizard/steps/upgrade-step.js
+++ b/assets/admin/editor-wizard/steps/upgrade-step.js
@@ -1,0 +1,28 @@
+/**
+ * Upgrade step during course creation wizard.
+ *
+ * @param {Object} props
+ */
+const UpgradeStep = ( {} ) => {
+	// TODO Implement this.
+	return (
+		<div>
+			<div>Upgrade Step</div>
+			<div>PENDING TO IMPLEMENT</div>
+		</div>
+	);
+};
+
+UpgradeStep.Actions = ( { goToNextStep } ) => {
+	// TODO Implement this.
+	return (
+		<div>
+			<button onClick={ goToNextStep }>Next</button>
+			<a href="https://senseilms.com" target="_blank" rel="noreferrer">
+				Upgrade
+			</a>
+		</div>
+	);
+};
+
+export default UpgradeStep;

--- a/assets/admin/editor-wizard/steps/upgrade-step.js
+++ b/assets/admin/editor-wizard/steps/upgrade-step.js
@@ -1,13 +1,23 @@
 /**
+ * WordPress dependencies
+ */
+import { useEffect } from '@wordpress/element';
+
+/**
  * Upgrade step during course creation wizard.
  *
- * @param {Object} props
+ * @param {Object}   props
+ * @param {Object}   props.data
+ * @param {Function} props.setData
  */
-const UpgradeStep = ( {} ) => {
+const UpgradeStep = ( { data: wizardData, setData: setWizardData } ) => {
+	// Update modal title.
+	useEffect( () => {
+		setWizardData( { ...wizardData, modalTitle: 'Upgrade Step' } );
+	}, [] );
 	// TODO Implement this.
 	return (
 		<div>
-			<div>Upgrade Step</div>
 			<div>PENDING TO IMPLEMENT</div>
 		</div>
 	);

--- a/assets/admin/editor-wizard/steps/upgrade-step.js
+++ b/assets/admin/editor-wizard/steps/upgrade-step.js
@@ -1,20 +1,7 @@
 /**
- * WordPress dependencies
- */
-import { useEffect } from '@wordpress/element';
-
-/**
  * Upgrade step during course creation wizard.
- *
- * @param {Object}   props
- * @param {Object}   props.data
- * @param {Function} props.setData
  */
-const UpgradeStep = ( { data: wizardData, setData: setWizardData } ) => {
-	// Update modal title.
-	useEffect( () => {
-		setWizardData( { ...wizardData, modalTitle: 'Upgrade Step' } );
-	}, [] );
+const UpgradeStep = () => {
 	// TODO Implement this.
 	return (
 		<div>
@@ -22,6 +9,8 @@ const UpgradeStep = ( { data: wizardData, setData: setWizardData } ) => {
 		</div>
 	);
 };
+
+UpgradeStep.Title = 'Upgrade Step';
 
 UpgradeStep.Actions = ( { goToNextStep } ) => {
 	// TODO Implement this.

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -1,15 +1,41 @@
 .sensei-editor-wizard {
+
+	width: 800px;
+
+	&__content {
+		margin: 30px;
+	}
+
 	&__footer {
 		display: flex;
 		flex-direction: row;
-		margin-top: 25px;
+		align-items: center;
+		border-top: 1px solid rgba(30, 30, 30, 0.12);
+		padding: 30px;
 	}
 
 	&__progress {
-		color: grey;
+		color: #787C82;
 	}
 
 	&__actions {
 		margin-left: auto;
+	}
+}
+
+.sensei-editor-wizard-modal {
+	& .components-modal__header {
+		border-bottom: 0;
+		padding: 30px;
+		height: auto;
+
+		& .components-modal__header-heading {
+			font-size: 32px;
+			line-height: 40px;
+			color: #1E1E1E;
+		}
+	}
+	& .components-modal__content {
+		padding: 0;
 	}
 }

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -1,15 +1,15 @@
 .sensei-editor-wizard {
-	& &__footer {
+	&__footer {
 		display: flex;
 		flex-direction: row;
 		margin-top: 25px;
 	}
 
-	& &__footer &__progress {
+	&__progress {
 		color: grey;
 	}
 
-	& &__footer &__actions {
+	&__actions {
 		margin-left: auto;
 	}
 }

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -1,0 +1,15 @@
+.sensei-editor-wizard {
+	& &__footer {
+		display: flex;
+		flex-direction: row;
+		margin-top: 25px;
+	}
+
+	& &__footer &__progress {
+		color: grey;
+	}
+
+	& &__footer &__actions {
+		margin-left: auto;
+	}
+}

--- a/assets/admin/editor-wizard/wizard.js
+++ b/assets/admin/editor-wizard/wizard.js
@@ -1,16 +1,17 @@
 /**
  * WordPress dependencies
  */
-import { useState } from '@wordpress/element';
+import { useEffect, useState } from '@wordpress/element';
 
 /**
  * Wizard component.
  *
  * @param {Object}   props
  * @param {Array}    props.steps        Array with the steps that will be rendered.
+ * @param {Function} props.onChange     Callback to call when wizard data changes.
  * @param {Function} props.onCompletion Callback to call when wizard is completed.
  */
-const Wizard = ( { steps, onCompletion } ) => {
+const Wizard = ( { steps, onChange, onCompletion } ) => {
 	const [ currentStepNumber, setCurrentStepNumber ] = useState( 0 );
 	const [ data, setData ] = useState( {} );
 
@@ -23,6 +24,11 @@ const Wizard = ( { steps, onCompletion } ) => {
 			onCompletion( data );
 		}
 	};
+
+	// Call onChange every time wizard data is changed.
+	useEffect( () => {
+		onChange( data );
+	}, [ data, onChange ] );
 
 	return (
 		<div className={ 'sensei-editor-wizard' }>

--- a/assets/admin/editor-wizard/wizard.js
+++ b/assets/admin/editor-wizard/wizard.js
@@ -15,7 +15,10 @@ const Wizard = ( { steps, onChange, onCompletion } ) => {
 	const [ currentStepNumber, setCurrentStepNumber ] = useState( 0 );
 	const [ data, setData ] = useState( {} );
 
-	const CurrentStep = steps[ currentStepNumber ];
+	// Call onChange every time wizard data is changed.
+	useEffect( () => {
+		onChange( data );
+	}, [ data, onChange ] );
 
 	const goToNextStep = () => {
 		if ( currentStepNumber + 1 < steps.length ) {
@@ -25,34 +28,34 @@ const Wizard = ( { steps, onChange, onCompletion } ) => {
 		}
 	};
 
-	// Call onChange every time wizard data is changed.
-	useEffect( () => {
-		onChange( data );
-	}, [ data, onChange ] );
+	const CurrentStep = steps[ currentStepNumber ];
 
 	return (
-		<div className={ 'sensei-editor-wizard' }>
-			<div className={ 'sensei-editor-wizard__content' }>
-				<CurrentStep
-					data={ data }
-					setData={ setData }
-					onCompletion={ onCompletion }
-				/>
-			</div>
-			<div className={ 'sensei-editor-wizard__footer' }>
-				<div className={ 'sensei-editor-wizard__progress' }>
-					Step { currentStepNumber + 1 } of { steps.length }
+		( CurrentStep && (
+			<div className={ 'sensei-editor-wizard' }>
+				<div className={ 'sensei-editor-wizard__content' }>
+					<CurrentStep
+						data={ data }
+						setData={ setData }
+						onCompletion={ onCompletion }
+					/>
 				</div>
-				{ CurrentStep.Actions && (
-					<div className={ 'sensei-editor-wizard__actions' }>
-						<CurrentStep.Actions
-							data={ data }
-							goToNextStep={ goToNextStep }
-						/>
+				<div className={ 'sensei-editor-wizard__footer' }>
+					<div className={ 'sensei-editor-wizard__progress' }>
+						Step { currentStepNumber + 1 } of { steps.length }
 					</div>
-				) }
+					{ CurrentStep.Actions && (
+						<div className={ 'sensei-editor-wizard__actions' }>
+							<CurrentStep.Actions
+								data={ data }
+								goToNextStep={ goToNextStep }
+							/>
+						</div>
+					) }
+				</div>
 			</div>
-		</div>
+		) ) ||
+		null
 	);
 };
 

--- a/assets/admin/editor-wizard/wizard.js
+++ b/assets/admin/editor-wizard/wizard.js
@@ -32,7 +32,7 @@ const Wizard = ( { steps, onChange, onCompletion } ) => {
 
 	return (
 		<div className={ 'sensei-editor-wizard' }>
-			<div className={ 'sensei-editor-wizard__body' }>
+			<div className={ 'sensei-editor-wizard__content' }>
 				<CurrentStep
 					data={ data }
 					setData={ setData }

--- a/assets/admin/editor-wizard/wizard.js
+++ b/assets/admin/editor-wizard/wizard.js
@@ -8,17 +8,12 @@ import { useEffect, useState } from '@wordpress/element';
  *
  * @param {Object}   props
  * @param {Array}    props.steps        Array with the steps that will be rendered.
- * @param {Function} props.onChange     Callback to call when wizard data changes.
+ * @param {Function} props.onStepChange Callback to call when wizard's step changes.
  * @param {Function} props.onCompletion Callback to call when wizard is completed.
  */
-const Wizard = ( { steps, onChange, onCompletion } ) => {
+const Wizard = ( { steps, onStepChange, onCompletion } ) => {
 	const [ currentStepNumber, setCurrentStepNumber ] = useState( 0 );
 	const [ data, setData ] = useState( {} );
-
-	// Call onChange every time wizard data is changed.
-	useEffect( () => {
-		onChange( data );
-	}, [ data, onChange ] );
 
 	const goToNextStep = () => {
 		if ( currentStepNumber + 1 < steps.length ) {
@@ -29,6 +24,11 @@ const Wizard = ( { steps, onChange, onCompletion } ) => {
 	};
 
 	const CurrentStep = steps[ currentStepNumber ];
+
+	// Call onChange every time wizard data is changed.
+	useEffect( () => {
+		onStepChange( CurrentStep );
+	}, [ CurrentStep, onStepChange ] );
 
 	return (
 		( CurrentStep && (

--- a/assets/admin/editor-wizard/wizard.js
+++ b/assets/admin/editor-wizard/wizard.js
@@ -35,7 +35,7 @@ const Wizard = ( { steps, onCompletion } ) => {
 			</div>
 			<div className={ 'sensei-editor-wizard__footer' }>
 				<div className={ 'sensei-editor-wizard__progress' }>
-					Step { currentStepNumber } of { steps.length }
+					Step { currentStepNumber + 1 } of { steps.length }
 				</div>
 				{ CurrentStep.Actions && (
 					<div className={ 'sensei-editor-wizard__actions' }>

--- a/assets/admin/editor-wizard/wizard.js
+++ b/assets/admin/editor-wizard/wizard.js
@@ -1,0 +1,53 @@
+/**
+ * WordPress dependencies
+ */
+import { useState } from '@wordpress/element';
+
+/**
+ * Wizard component.
+ *
+ * @param {Object}   props
+ * @param {Array}    props.steps        Array with the steps that will be rendered.
+ * @param {Function} props.onCompletion Callback to call when wizard is completed.
+ */
+const Wizard = ( { steps, onCompletion } ) => {
+	const [ currentStepNumber, setCurrentStepNumber ] = useState( 0 );
+	const [ data, setData ] = useState( {} );
+
+	const CurrentStep = steps[ currentStepNumber ];
+
+	const goToNextStep = () => {
+		if ( currentStepNumber + 1 < steps.length ) {
+			setCurrentStepNumber( currentStepNumber + 1 );
+		} else {
+			onCompletion( data );
+		}
+	};
+
+	return (
+		<div className={ 'sensei-editor-wizard' }>
+			<div className={ 'sensei-editor-wizard__body' }>
+				<CurrentStep
+					data={ data }
+					setData={ setData }
+					onCompletion={ onCompletion }
+				/>
+			</div>
+			<div className={ 'sensei-editor-wizard__footer' }>
+				<div className={ 'sensei-editor-wizard__progress' }>
+					Step { currentStepNumber } of { steps.length }
+				</div>
+				{ CurrentStep.Actions && (
+					<div className={ 'sensei-editor-wizard__actions' }>
+						<CurrentStep.Actions
+							data={ data }
+							goToNextStep={ goToNextStep }
+						/>
+					</div>
+				) }
+			</div>
+		</div>
+	);
+};
+
+export default Wizard;

--- a/assets/admin/editor-wizard/wizard.test.js
+++ b/assets/admin/editor-wizard/wizard.test.js
@@ -20,7 +20,9 @@ describe( '<Wizard />', () => {
 			return SOME_DUMMY_ACTIONS;
 		};
 
-		const { queryByText } = render( <Wizard steps={ [ DummyStep ] } /> );
+		const { queryByText } = render(
+			<Wizard steps={ [ DummyStep ] } onChange={ () => {} } />
+		);
 
 		expect( queryByText( SOME_DUMMY_CONTENT ) ).toBeTruthy();
 		expect( queryByText( SOME_DUMMY_ACTIONS ) ).toBeTruthy();
@@ -32,7 +34,10 @@ describe( '<Wizard />', () => {
 			return SOME_DUMMY_CONTENT;
 		};
 		const { queryByText } = render(
-			<Wizard steps={ [ DummyStepWithoutActions ] } />
+			<Wizard
+				steps={ [ DummyStepWithoutActions ] }
+				onChange={ () => {} }
+			/>
 		);
 
 		expect( queryByText( SOME_DUMMY_CONTENT ) ).toBeTruthy();
@@ -52,7 +57,7 @@ describe( '<Wizard />', () => {
 		};
 
 		const { queryByText } = render(
-			<Wizard steps={ [ FirstStep, SecondStep ] } />
+			<Wizard steps={ [ FirstStep, SecondStep ] } onChange={ () => {} } />
 		);
 
 		expect( queryByText( 'FIRST_STEP_CONTENT' ) ).toBeTruthy();
@@ -64,7 +69,7 @@ describe( '<Wizard />', () => {
 		expect( queryByText( 'Step 2 of 2' ) ).toBeTruthy();
 	} );
 
-	it( 'Wizard calls onCompletion callback after last step.', () => {
+	it( 'Wizard calls `onCompletion` callback after last step.', () => {
 		const SingleStep = () => {
 			return null;
 		};
@@ -76,10 +81,36 @@ describe( '<Wizard />', () => {
 		const { queryByText } = render(
 			<Wizard
 				steps={ [ SingleStep ] }
+				onChange={ () => {} }
 				onCompletion={ onCompletionCallback }
 			/>
 		);
 		fireEvent.click( queryByText( 'Next' ) );
 		expect( onCompletionCallback ).toBeCalled();
+	} );
+
+	it( 'Wizard calls `onChange` when wizard data is updated.', () => {
+		const onChangeMock = jest.fn();
+		const StepWithInput = ( {
+			data: wizardData,
+			setData: setWizardData,
+		} ) => {
+			return (
+				<input
+					value={ wizardData.value ?? '' }
+					onChange={ ( e ) => {
+						setWizardData( { value: e.target.value } );
+					} }
+				></input>
+			);
+		};
+
+		const { queryByRole } = render(
+			<Wizard steps={ [ StepWithInput ] } onChange={ onChangeMock } />
+		);
+		fireEvent.change( queryByRole( 'textbox' ), {
+			target: { value: 'TEST_DATA' },
+		} );
+		expect( onChangeMock ).toHaveBeenCalledWith( { value: 'TEST_DATA' } );
 	} );
 } );

--- a/assets/admin/editor-wizard/wizard.test.js
+++ b/assets/admin/editor-wizard/wizard.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 /**
@@ -24,6 +24,7 @@ describe( '<Wizard />', () => {
 
 		expect( queryByText( SOME_DUMMY_CONTENT ) ).toBeTruthy();
 		expect( queryByText( SOME_DUMMY_ACTIONS ) ).toBeTruthy();
+		expect( queryByText( 'Step 1 of 1' ) ).toBeTruthy();
 	} );
 
 	it( 'Wizard renders step without actions.', () => {
@@ -36,5 +37,49 @@ describe( '<Wizard />', () => {
 
 		expect( queryByText( SOME_DUMMY_CONTENT ) ).toBeTruthy();
 		expect( queryByText( SOME_DUMMY_ACTIONS ) ).toBeFalsy();
+		expect( queryByText( 'Step 1 of 1' ) ).toBeTruthy();
+	} );
+
+	it( 'Wizard navigates to next step.', () => {
+		const FirstStep = () => {
+			return 'FIRST_STEP_CONTENT';
+		};
+		FirstStep.Actions = ( { goToNextStep } ) => {
+			return <button onClick={ goToNextStep }>Next</button>;
+		};
+		const SecondStep = () => {
+			return 'SECOND_STEP_CONTENT';
+		};
+
+		const { queryByText } = render(
+			<Wizard steps={ [ FirstStep, SecondStep ] } />
+		);
+
+		expect( queryByText( 'FIRST_STEP_CONTENT' ) ).toBeTruthy();
+		expect( queryByText( 'Step 1 of 2' ) ).toBeTruthy();
+
+		fireEvent.click( queryByText( 'Next' ) );
+
+		expect( queryByText( 'SECOND_STEP_CONTENT' ) ).toBeTruthy();
+		expect( queryByText( 'Step 2 of 2' ) ).toBeTruthy();
+	} );
+
+	it( 'Wizard calls onCompletion callback after last step.', () => {
+		const SingleStep = () => {
+			return null;
+		};
+		SingleStep.Actions = ( { goToNextStep } ) => {
+			return <button onClick={ goToNextStep }>Next</button>;
+		};
+		const onCompletionCallback = jest.fn();
+
+		const { queryByText } = render(
+			<Wizard
+				steps={ [ SingleStep ] }
+				onCompletion={ onCompletionCallback }
+			/>
+		);
+		fireEvent.click( queryByText( 'Next' ) );
+		expect( onCompletionCallback ).toBeCalled();
 	} );
 } );

--- a/assets/admin/editor-wizard/wizard.test.js
+++ b/assets/admin/editor-wizard/wizard.test.js
@@ -8,7 +8,6 @@ import '@testing-library/jest-dom';
  * Internal dependencies
  */
 import Wizard from './wizard';
-import { expect } from '@playwright/test';
 
 const SOME_DUMMY_CONTENT = 'SOME_DUMMY_CONTENT';
 const SOME_DUMMY_ACTIONS = 'SOME_DUMMY_ACTIONS';
@@ -23,7 +22,7 @@ describe( '<Wizard />', () => {
 
 		const { queryByText } = render( <Wizard steps={ [ DummyStep ] } /> );
 
-		expect( queryByText( 'SOMETHING_NOT_EXISTING' ) ).toBeTruthy();
+		expect( queryByText( SOME_DUMMY_CONTENT ) ).toBeTruthy();
 		expect( queryByText( SOME_DUMMY_ACTIONS ) ).toBeTruthy();
 	} );
 

--- a/assets/admin/editor-wizard/wizard.test.js
+++ b/assets/admin/editor-wizard/wizard.test.js
@@ -1,0 +1,41 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * Internal dependencies
+ */
+import Wizard from './wizard';
+import { expect } from '@playwright/test';
+
+const SOME_DUMMY_CONTENT = 'SOME_DUMMY_CONTENT';
+const SOME_DUMMY_ACTIONS = 'SOME_DUMMY_ACTIONS';
+describe( '<Wizard />', () => {
+	it( 'Wizard renders first step content and actions by default.', () => {
+		const DummyStep = () => {
+			return SOME_DUMMY_CONTENT;
+		};
+		DummyStep.Actions = () => {
+			return SOME_DUMMY_ACTIONS;
+		};
+
+		const { queryByText } = render( <Wizard steps={ [ DummyStep ] } /> );
+
+		expect( queryByText( 'SOMETHING_NOT_EXISTING' ) ).toBeTruthy();
+		expect( queryByText( SOME_DUMMY_ACTIONS ) ).toBeTruthy();
+	} );
+
+	it( 'Wizard renders step without actions.', () => {
+		const DummyStepWithoutActions = () => {
+			return SOME_DUMMY_CONTENT;
+		};
+		const { queryByText } = render(
+			<Wizard steps={ [ DummyStepWithoutActions ] } />
+		);
+
+		expect( queryByText( SOME_DUMMY_CONTENT ) ).toBeTruthy();
+		expect( queryByText( SOME_DUMMY_ACTIONS ) ).toBeFalsy();
+	} );
+} );

--- a/assets/admin/editor-wizard/wizard.test.js
+++ b/assets/admin/editor-wizard/wizard.test.js
@@ -21,7 +21,7 @@ describe( '<Wizard />', () => {
 		};
 
 		const { queryByText } = render(
-			<Wizard steps={ [ DummyStep ] } onChange={ () => {} } />
+			<Wizard steps={ [ DummyStep ] } onStepChange={ () => {} } />
 		);
 
 		expect( queryByText( SOME_DUMMY_CONTENT ) ).toBeTruthy();
@@ -36,7 +36,7 @@ describe( '<Wizard />', () => {
 		const { queryByText } = render(
 			<Wizard
 				steps={ [ DummyStepWithoutActions ] }
-				onChange={ () => {} }
+				onStepChange={ () => {} }
 			/>
 		);
 
@@ -57,7 +57,10 @@ describe( '<Wizard />', () => {
 		};
 
 		const { queryByText } = render(
-			<Wizard steps={ [ FirstStep, SecondStep ] } onChange={ () => {} } />
+			<Wizard
+				steps={ [ FirstStep, SecondStep ] }
+				onStepChange={ () => {} }
+			/>
 		);
 
 		expect( queryByText( 'FIRST_STEP_CONTENT' ) ).toBeTruthy();
@@ -81,7 +84,7 @@ describe( '<Wizard />', () => {
 		const { queryByText } = render(
 			<Wizard
 				steps={ [ SingleStep ] }
-				onChange={ () => {} }
+				onStepChange={ () => {} }
 				onCompletion={ onCompletionCallback }
 			/>
 		);
@@ -89,28 +92,29 @@ describe( '<Wizard />', () => {
 		expect( onCompletionCallback ).toBeCalled();
 	} );
 
-	it( 'Wizard calls `onChange` when wizard data is updated.', () => {
-		const onChangeMock = jest.fn();
-		const StepWithInput = ( {
-			data: wizardData,
-			setData: setWizardData,
-		} ) => {
-			return (
-				<input
-					value={ wizardData.value ?? '' }
-					onChange={ ( e ) => {
-						setWizardData( { value: e.target.value } );
-					} }
-				></input>
-			);
+	it( 'Wizard calls `onStepChange` when wizard step is updated.', () => {
+		const onStepChangedMock = jest.fn();
+		const FirstStep = () => {
+			return 'FIRST_STEP_CONTENT';
+		};
+		FirstStep.Actions = ( { goToNextStep } ) => {
+			return <button onClick={ goToNextStep }>Next</button>;
+		};
+		const SecondStep = () => {
+			return 'SECOND_STEP_CONTENT';
 		};
 
-		const { queryByRole } = render(
-			<Wizard steps={ [ StepWithInput ] } onChange={ onChangeMock } />
+		const { queryByText } = render(
+			<Wizard
+				steps={ [ FirstStep, SecondStep ] }
+				onStepChange={ onStepChangedMock }
+			/>
 		);
-		fireEvent.change( queryByRole( 'textbox' ), {
-			target: { value: 'TEST_DATA' },
-		} );
-		expect( onChangeMock ).toHaveBeenCalledWith( { value: 'TEST_DATA' } );
+
+		expect( onStepChangedMock ).toHaveBeenLastCalledWith( FirstStep );
+
+		fireEvent.click( queryByText( 'Next' ) );
+
+		expect( onStepChangedMock ).toHaveBeenLastCalledWith( SecondStep );
 	} );
 } );


### PR DESCRIPTION
Fixes #5126

### Changes proposed in this Pull Request
* Created `Wizard` component that expects a `steps` attribute containing an ordered array of the different `Steps` that should be rendered.
* Some sample `Steps` have been added in order to test the different cases and flows we expect to support:
  * `course-details-step.js`: Has a sample input and way to persist data in the `Wizard`'s data. It has also a sample action that displays the contents of the `Wizard` data.
  * `upgrade-step.js`: Empty step with only two actions: next and go to some url.
  * `course-patterns-step.js`: Empty step with only a final action - `onCompletion` can be called when choosing the pattern at some point.
  * `lesson-details-step.js` and `lesson-patterns-step.js` are also empty steps that are not currently used. 

### Testing instructions
- Create a new Lesson or Course and you will be prompted with a sample **wizard for Course**.
- Play around with the actions.
- Check the code :)

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
https://user-images.githubusercontent.com/799065/169290375-2e84138d-aa37-4a16-a457-4dd1fb33f025.mp4

### Discussion / Context
- This is only a proposal for the basic structure for the Wizard.
- Tried by using `{children}` but couldn't figure out the best way to have different "actions" per step - if anyone wants to give it a try I will be pleased to learn how to do that!
- I expect this task to include some minor CSS for the modal, but specific details for each step will be handled in each steps task.
- I will look how to have different steps for different post types but I want to get fast feedback on the main structure. Will update the PR with that once I have it.

### TODO
- [x] Allow different steps depending on post type.
- [x] CSS for modal + wizard structure.
- [x] Update modal title? Maybe title can be part of each step.
- [x] Add tests for `wizard.js`.