### PR TITLE
Fix add student to course not visible if sensei pro/content drip is enabled

### DIFF
--- a/assets/css/settings.scss
+++ b/assets/css/settings.scss
@@ -421,6 +421,7 @@
 		width: 2.2em;
 	}
 	.tablenav {
+		height: auto;
 		&.top {
 			@media screen and (max-width: 782px) {
 				.sensei-student-bulk-actions__wrapper {


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/5110

### Changes proposed in this Pull Request

- The content drip form was positioning itself over the student adding form while rendering. So the users could not see it. That issue is fixed with css.

### Testing instructions

- Have the Sensei Pro plugin enabled.
- Have a student that is enrolled in a course.
- Go to Sensei LMS -> Students and click on the enrolled course.
- Make sure you can see both the content drip and the student adding form

### Screenshot / Video

<img width="1292" alt="image" src="https://user-images.githubusercontent.com/6820724/169389169-f858b932-e3d2-4895-bec5-8a88f6a900cc.png">
