### PR TITLE
Provide "Save and edit lesson" button from Course Outline

### DIFF
--- a/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
@@ -8,7 +8,7 @@ import {
 	Toolbar,
 	ToolbarItem,
 } from '@wordpress/components';
-import { dispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -37,10 +37,11 @@ export const EditLessonLink = ( { lessonId } ) => (
 /**
  * Toolbar section for the link to edit a lesson.
  *
- * @param {Object} props          Component props.
- * @param {number} props.lessonId The lesson ID.
+ * @param {Object} props             Component props.
+ * @param {number} props.lessonId    The lesson ID.
+ * @param {number} props.lessonTitle The lesson title.
  */
-const LessonEditToolbar = ( { lessonId } ) => {
+const LessonEditToolbar = ( { lessonId, lessonTitle } ) => {
 	// Determine whether we are currently saving.
 	const { isSavingPost, isSavingMetaBoxes, isSavingStructure } = useSelect(
 		( select ) => ( {
@@ -50,14 +51,17 @@ const LessonEditToolbar = ( { lessonId } ) => {
 		} )
 	);
 
+	// Function to trigger saving the post.
+	const { savePost } = useDispatch( 'core/editor' );
+
+	// If we don't have an ID or a title yet, don't render anything.
+	if ( ! lessonId && ! lessonTitle ) {
+		return null;
+	}
+
 	// Component for the "Save and edit lesson" button.
 	const savePostLink = (
-		<ToolbarItem
-			as={ Button }
-			onClick={ () => {
-				dispatch( 'core/editor' ).savePost();
-			} }
-		>
+		<ToolbarItem as={ Button } onClick={ savePost }>
 			{ __( 'Save to edit lesson', 'sensei-lms' ) }
 		</ToolbarItem>
 	);

--- a/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
@@ -9,6 +9,8 @@ import {
 	ToolbarItem,
 } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editPostStore } from '@wordpress/edit-post';
+import { store as editorStore } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -45,14 +47,14 @@ const LessonEditToolbar = ( { lessonId, lessonTitle } ) => {
 	// Determine whether we are currently saving.
 	const { isSavingPost, isSavingMetaBoxes, isSavingStructure } = useSelect(
 		( select ) => ( {
-			isSavingPost: select( 'core/editor' ).isSavingPost(),
-			isSavingMetaBoxes: select( 'core/edit-post' ).isSavingMetaBoxes(),
+			isSavingPost: select( editorStore ).isSavingPost(),
+			isSavingMetaBoxes: select( editPostStore ).isSavingMetaBoxes(),
 			isSavingStructure: select( COURSE_STORE ).getIsSavingStructure(),
 		} )
 	);
 
 	// Function to trigger saving the post.
-	const { savePost } = useDispatch( 'core/editor' );
+	const { savePost } = useDispatch( editorStore );
 
 	// If we don't have an ID or a title yet, don't render anything.
 	if ( ! lessonId && ! lessonTitle ) {

--- a/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
@@ -58,7 +58,7 @@ const LessonEditToolbar = ( { lessonId } ) => {
 				dispatch( 'core/editor' ).savePost();
 			} }
 		>
-			{ __( 'Save and edit lesson', 'sensei-lms' ) }
+			{ __( 'Save to edit lesson', 'sensei-lms' ) }
 		</ToolbarItem>
 	);
 

--- a/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
@@ -9,7 +9,6 @@ import {
 	ToolbarItem,
 } from '@wordpress/components';
 import { dispatch, useSelect } from '@wordpress/data';
-import { useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -51,23 +50,11 @@ const LessonEditToolbar = ( { lessonId } ) => {
 		} )
 	);
 
-	// Should we open the lesson in a new tab after save?
-	const [ shouldEditLesson, setShouldEditLesson ] = useState( false );
-
-	// Open the lesson in a new tab if needed.
-	useEffect( () => {
-		if ( shouldEditLesson && lessonId ) {
-			setShouldEditLesson( false );
-			window.open( getLessonURL( lessonId ), '_blank' );
-		}
-	}, [ shouldEditLesson, lessonId, isSavingStructure ] );
-
 	// Component for the "Save and edit lesson" button.
 	const savePostLink = (
 		<ToolbarItem
 			as={ Button }
 			onClick={ () => {
-				setShouldEditLesson( true );
 				dispatch( 'core/editor' ).savePost();
 			} }
 		>

--- a/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-edit-toolbar.js
@@ -1,0 +1,91 @@
+/**
+ * WordPress dependencies
+ */
+import {
+	Button,
+	ExternalLink,
+	Spinner,
+	Toolbar,
+	ToolbarItem,
+} from '@wordpress/components';
+import { dispatch, useSelect } from '@wordpress/data';
+import { useEffect, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { COURSE_STORE } from '../course-outline-store';
+
+const getLessonURL = ( lessonId ) => `post.php?post=${ lessonId }&action=edit`;
+
+/**
+ * Link to edit the Lesson in a new tab.
+ *
+ * @param {Object} props          Component props.
+ * @param {number} props.lessonId The lesson ID.
+ */
+export const EditLessonLink = ( { lessonId } ) => (
+	<ExternalLink
+		href={ getLessonURL( lessonId ) }
+		target="lesson"
+		className="wp-block-sensei-lms-course-outline-lesson__edit"
+	>
+		{ __( 'Edit lesson', 'sensei-lms' ) }
+	</ExternalLink>
+);
+
+/**
+ * Toolbar section for the link to edit a lesson.
+ *
+ * @param {Object} props          Component props.
+ * @param {number} props.lessonId The lesson ID.
+ */
+const LessonEditToolbar = ( { lessonId } ) => {
+	// Determine whether we are currently saving.
+	const { isSavingPost, isSavingMetaBoxes, isSavingStructure } = useSelect(
+		( select ) => ( {
+			isSavingPost: select( 'core/editor' ).isSavingPost(),
+			isSavingMetaBoxes: select( 'core/edit-post' ).isSavingMetaBoxes(),
+			isSavingStructure: select( COURSE_STORE ).getIsSavingStructure(),
+		} )
+	);
+
+	// Should we open the lesson in a new tab after save?
+	const [ shouldEditLesson, setShouldEditLesson ] = useState( false );
+
+	// Open the lesson in a new tab if needed.
+	useEffect( () => {
+		if ( shouldEditLesson && lessonId ) {
+			setShouldEditLesson( false );
+			window.open( getLessonURL( lessonId ), '_blank' );
+		}
+	}, [ shouldEditLesson, lessonId, isSavingStructure ] );
+
+	// Component for the "Save and edit lesson" button.
+	const savePostLink = (
+		<ToolbarItem
+			as={ Button }
+			onClick={ () => {
+				setShouldEditLesson( true );
+				dispatch( 'core/editor' ).savePost();
+			} }
+		>
+			{ __( 'Save and edit lesson', 'sensei-lms' ) }
+		</ToolbarItem>
+	);
+
+	// Spinner.
+	const savingPostIndicator = <ToolbarItem as={ Spinner } />;
+
+	let toolbarItem = savePostLink;
+	if ( lessonId ) {
+		toolbarItem = <EditLessonLink lessonId={ lessonId } />;
+	} else if ( isSavingPost || isSavingStructure || isSavingMetaBoxes ) {
+		toolbarItem = savingPostIndicator;
+	}
+
+	return <Toolbar className="components-button">{ toolbarItem }</Toolbar>;
+};
+
+export default LessonEditToolbar;

--- a/assets/blocks/course-outline/lesson-block/lesson-settings.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-settings.js
@@ -71,7 +71,7 @@ const LessonSettings = ( {
 				</PanelBody>
 			</InspectorControls>
 			<BlockControls>
-				<LessonEditToolbar lessonId={ id } />
+				<LessonEditToolbar lessonId={ id } lessonTitle={ title } />
 			</BlockControls>
 		</>
 	);

--- a/assets/blocks/course-outline/lesson-block/lesson-settings.js
+++ b/assets/blocks/course-outline/lesson-block/lesson-settings.js
@@ -2,12 +2,7 @@
  * WordPress dependencies
  */
 import { InspectorControls, BlockControls } from '@wordpress/block-editor';
-import {
-	ExternalLink,
-	FontSizePicker,
-	PanelBody,
-	Toolbar,
-} from '@wordpress/components';
+import { FontSizePicker, PanelBody } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
@@ -16,6 +11,7 @@ import { __ } from '@wordpress/i18n';
  */
 import { Status } from '../status-preview';
 import { StatusControl } from '../status-preview/status-control';
+import LessonEditToolbar, { EditLessonLink } from './lesson-edit-toolbar';
 
 /**
  * Inspector controls for lesson block.
@@ -39,22 +35,12 @@ const LessonSettings = ( {
 		select( 'core/block-editor' ).getSettings()
 	);
 
-	const editLessonLink = (
-		<ExternalLink
-			href={ `post.php?post=${ id }&action=edit` }
-			target="lesson"
-			className="wp-block-sensei-lms-course-outline-lesson__edit"
-		>
-			{ __( 'Edit lesson', 'sensei-lms' ) }
-		</ExternalLink>
-	);
-
 	return (
 		<>
 			<InspectorControls>
 				{ id && (
 					<PanelBody title={ __( 'Lesson', 'sensei-lms' ) }>
-						<h2>{ editLessonLink }</h2>
+						<h2>{ <EditLessonLink lessonId={ id } /> }</h2>
 						<p>
 							{ __(
 								'Edit details such as lesson content, prerequisite, quiz settings and more.',
@@ -85,11 +71,7 @@ const LessonSettings = ( {
 				</PanelBody>
 			</InspectorControls>
 			<BlockControls>
-				{ id && (
-					<Toolbar className="components-button">
-						{ editLessonLink }
-					</Toolbar>
-				) }
+				<LessonEditToolbar lessonId={ id } />
 			</BlockControls>
 		</>
 	);


### PR DESCRIPTION
Fixes #5143 

### Changes proposed in this Pull Request

* Add "Save and edit lesson" button to the Lesson block within a Course Outline.
* When clicked, the Course is saved and the "Edit Lesson" link appears in the toolbar.
* [Maybe] Automatically open the Lesson in a new tab after save.

### Note

I originally added functionality for automatically opening the Lesson in a new tab after the save is complete. However, I removed it in https://github.com/Automattic/sensei/commit/7ee779ec7b939bec2fa1e989870e210239c3bb34 for a few reasons:

- Some browsers will likely block this, as it is trying to "open a pop-up" from JS.
- I wasn't sure how to best deal with error handling. It seems like if there was an error, and then a later API request completed successfully, this could open a new tab at unexpected times.
- It seems like just changing the "Save and edit lesson" button to the "Edit lesson" link after save might be a good enough UX, but would like feedback on this (cc @burtrw @Luchadores )
- I would also appreciate design input on the button text, the spinner, and the overall behaviour.

If you would like to see how it worked, just revert that commit and you should be able to test.

### Testing instructions

* Create a new Course.
* Add a few Lessons using the Course Outline block.
* Before saving, click on one of the Lessons. In the Toolbar, click on "Save and edit lesson".
* Notice that the Course saves and the "Edit lesson" link appears.
* Repeat the above steps in an existing Course with Lessons; add a new Lesson and ensure the new button behaves as expected.

### Screenshot / Video

https://user-images.githubusercontent.com/842193/169550794-33be5e37-4b5e-46b1-adb5-388cf0c0dce0.mov


