### PR TITLE
Do not auto-add Quiz blocks on the lessons anymore

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-lessons-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lessons-controller.php
@@ -126,7 +126,7 @@ class Sensei_REST_API_Lessons_Controller extends WP_REST_Posts_Controller {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		if ( 'edit' === $context && isset( $prepared['content']['raw'] ) ) {
 			$post = get_post();
-			if ( ! has_block( 'sensei-lms/quiz' ) ) {
+			if ( Sensei()->lesson::lesson_quiz_has_questions( $post->ID ) && ! has_block( 'sensei-lms/quiz' ) ) {
 				$prepared['content']['raw'] .= serialize_block(
 					[
 						'blockName'    => 'sensei-lms/quiz',


### PR DESCRIPTION
Fixes #5138

### Changes proposed in this Pull Request

* It doesn't re-add the quiz block as default behavior anymore (basically, it reverts [this PR](https://github.com/Automattic/sensei/pull/4420), since now we'll have patterns with the quiz, and it'll be probably more intuitive to find).
* It'll just add the quiz automatically if the user is coming from a legacy lesson with questions already added.
* Based on the [issue discussion](https://github.com/Automattic/sensei/issues/5138), for now, I kept the quiz in the default template (if we close the wizard or choose the default pattern). Maybe we could re-think it when working on the [patterns issue](https://github.com/Automattic/sensei/issues/5136), depending on the types of patterns we'll have. cc @Luchadores @burtrw 
  * If we wanna remove it, we can do it by removing https://github.com/Automattic/sensei/blob/version/4.4.2/includes/blocks/class-sensei-lesson-blocks.php#L108-L110, and probably we can also remove the logic related to the `isPostTemplate`.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
1. Create a course with a lesson.
2. Remove the quiz block from the lesson.
3. Refresh the editor, and make sure the lesson continues without the quiz block.
4. Activate the "Classic Editor" plugin.
5. Create a course with 2 lessons. One with a quiz with questions and another without a quiz.
6. Deactivate the "Classic Editor" plugin.
7. Edit both lessons. Ensure the quiz block is automatically added only in the lesson with the quiz.