### PR TITLE
Add support to "import" images directly in js

### DIFF
--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -7,6 +7,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import LimitedTextControl from '../../../blocks/editor-components/limited-text-control';
+import senseiProUpsell from '../../../images/sensei-pro-upsell.png';
 
 /**
  * Initial step for course creation wizard.
@@ -49,10 +50,7 @@ const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 			</div>
 			<div className="sensei-editor-wizard-modal__illustration">
 				<img
-					src={
-						window.sensei.pluginUrl +
-						'assets/dist/images/sensei-pro-upsell.png'
-					}
+					src={ window.sensei.pluginUrl + senseiProUpsell }
 					alt="PENDING TO IMPLEMENT, BUT HERE TO SHOW IT WORKING"
 					className="sensei-editor-wizard-modal__illustration-image"
 				/>

--- a/assets/admin/editor-wizard/steps/course-upgrade-step.js
+++ b/assets/admin/editor-wizard/steps/course-upgrade-step.js
@@ -9,6 +9,7 @@ import { useSelect } from '@wordpress/data';
  * Internal dependencies
  */
 import { EXTENSIONS_STORE } from '../../../extensions/store';
+import senseiProUpsell from '../../../images/sensei-pro-upsell.png';
 
 /**
  * Upgrade step during course creation wizard.
@@ -69,10 +70,7 @@ const CourseUpgradeStep = () => {
 			</div>
 			<div className="sensei-editor-wizard-modal__illustration">
 				<img
-					src={
-						window.sensei.pluginUrl +
-						'assets/dist/images/sensei-pro-upsell.png'
-					}
+					src={ window.sensei.pluginUrl + senseiProUpsell }
 					alt={ __(
 						'Illustration of a course listing with the pricing defined and with the button "Purchase Button"',
 						'sensei-lms'

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -1,4 +1,9 @@
 /**
+ * Internal dependencies
+ */
+import senseiProUpsell from '../../../images/sensei-pro-upsell.png';
+
+/**
  * Initial step for course creation wizard.
  */
 const LessonDetailsStep = () => {
@@ -11,10 +16,7 @@ const LessonDetailsStep = () => {
 			</div>
 			<div className="sensei-editor-wizard-modal__illustration">
 				<img
-					src={
-						window.sensei.pluginUrl +
-						'assets/dist/images/sensei-pro-upsell.png'
-					}
+					src={ window.sensei.pluginUrl + senseiProUpsell }
 					alt="PENDING TO IMPLEMENT, BUT HERE TO SHOW IT WORKING"
 					className="sensei-editor-wizard-modal__illustration-image"
 				/>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -117,16 +117,31 @@ const baseDist = 'assets/dist/';
 
 function getWebpackConfig( env, argv ) {
 	const webpackConfig = getBaseWebpackConfig( { ...env, WP: true }, argv );
+	const styleSheetFiles = /\.(sc|sa|c)ss$/i;
+	const scriptFiles = /\.[jt]sx?$/i;
+
 	webpackConfig.module.rules[ 3 ].generator.publicPath = '../';
 
 	// Handle SVG images only in CSS files.
-	webpackConfig.module.rules[ 3 ].test = /\.(?:gif|jpg|jpeg|png)$/i;
+	webpackConfig.module.rules[ 3 ].test = /\.(?:gif|jpg|jpeg|png|woff|woff2|eot|ttf|otf|svg)$/i;
+	webpackConfig.module.rules[ 3 ].issuer = styleSheetFiles;
+
+	// Handle only images in JS files
 	webpackConfig.module.rules = [
 		...webpackConfig.module.rules,
 		{
-			...webpackConfig.module.rules[ 3 ],
-			issuer: /\.(sc|sa|c)ss$/,
+			test: /\.(?:gif|jpg|jpeg|png)$/i,
+			issuer: scriptFiles,
+			type: 'asset/resource',
+			generator: {
+				filename: '[path][name]-[contenthash][ext]',
+				publicPath: 'assets/dist/',
+			},
+		},
+		{
 			test: /\.svg$/,
+			issuer: scriptFiles,
+			use: [ '@svgr/webpack' ],
 		},
 	];
 
@@ -152,24 +167,6 @@ function getWebpackConfig( env, argv ) {
 		devtool:
 			process.env.SOURCEMAP ||
 			( isDevelopment ? 'eval-source-map' : false ),
-		module: {
-			rules: [
-				...webpackConfig.module.rules,
-				{
-					test: /\.(?:gif|jpg|jpeg|png|woff|woff2|eot|ttf|otf)$/i,
-					type: 'asset/resource',
-					generator: {
-						filename: '[path][name]-[contenthash][ext]',
-						publicPath: '../',
-					},
-				},
-				{
-					test: /\.svg$/,
-					issuer: /\.[jt]sx?$/,
-					use: [ '@svgr/webpack' ],
-				},
-			],
-		},
 		plugins: [
 			...webpackConfig.plugins,
 			new GenerateChunksMapPlugin( {


### PR DESCRIPTION
### Changes proposed in this Pull Request

- Edit Webpack config to allow us to import JS images directly in JS, only needing to append `window.sensei.pluginUrl` as a prefix, while allowing the references to assets in CSS/SCSS/SASS to still work;

### Testing instructions

- Switch to this branch;
- Verify if the icons still load in WP-Admin;
- Verify if the image in the Editor Wizard still load correctly;
- Verify if other assets (like fonts, for instance) still work successfully too;