### PR TITLE
Add extensions preload on editor wizard

### DIFF
--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -17,6 +17,7 @@ import CoursePatternsStep from './steps/course-patterns-step';
 import LessonDetailsStep from './steps/lesson-details-step';
 import LessonPatternsStep from './steps/lesson-patterns-step';
 import { EXTENSIONS_STORE } from '../../extensions/store';
+import '../../shared/data/api-fetch-preloaded-once';
 
 /**
  * A React Hook to observe if a modal is open based on the body class.

--- a/includes/admin/class-sensei-editor-wizard.php
+++ b/includes/admin/class-sensei-editor-wizard.php
@@ -86,6 +86,9 @@ class Sensei_Editor_Wizard {
 		if ( $is_new_post && in_array( $post_type, $post_types, true ) ) {
 			Sensei()->assets->enqueue( 'sensei-editor-wizard-script', 'admin/editor-wizard/index.js' );
 			Sensei()->assets->enqueue( 'sensei-editor-wizard-style', 'admin/editor-wizard/style.css' );
+
+			// Preload extensions (needed to identify if Sensei Pro is installed, and extension details).
+			Sensei()->assets->preload_data( [ '/sensei-internal/v1/sensei-extensions?type=plugin' ] );
 		}
 	}
 }


### PR DESCRIPTION
Fixes #5182

### Changes proposed in this Pull Request

* It preloads the extensions data in order to avoid the upsell step flashing (it depends on the extensions fetch to identify if Sensei Pro is installed).

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Open the course editor, and make sure the modal is open with "Step 1 of 3" from the first time it's opened (without changing from "Step 1 of 2" to "Step 1 of 3").