### PR TITLE
Add some Paid Course Upsell tests

### DIFF
--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { Modal } from '@wordpress/components';
 import { useEffect, useLayoutEffect, useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
@@ -11,13 +11,8 @@ import { store as editorStore } from '@wordpress/editor';
  * Internal dependencies
  */
 import Wizard from './wizard';
-import CourseDetailsStep from './steps/course-details-step';
-import CourseUpgradeStep from './steps/course-upgrade-step';
-import CoursePatternsStep from './steps/course-patterns-step';
-import LessonDetailsStep from './steps/lesson-details-step';
-import LessonPatternsStep from './steps/lesson-patterns-step';
-import { EXTENSIONS_STORE } from '../../extensions/store';
 import '../../shared/data/api-fetch-preloaded-once';
+import useEditorWizardSteps from './use-editor-wizard-steps';
 
 /**
  * A React Hook to observe if a modal is open based on the body class.
@@ -84,6 +79,7 @@ const EditorWizardModal = () => {
 	const [ open, setDone ] = useWizardOpenState();
 	const { synchronizeTemplate } = useDispatch( blockEditorStore );
 	const { editPost } = useDispatch( editorStore );
+	const steps = useEditorWizardSteps();
 
 	const closeModal = () => {
 		setDone( true );
@@ -92,29 +88,6 @@ const EditorWizardModal = () => {
 			meta: { _new_post: false },
 		} );
 	};
-
-	// Choose steps by post type.
-	const stepsByPostType = {
-		course: [ CourseDetailsStep, CourseUpgradeStep, CoursePatternsStep ],
-		lesson: [ LessonDetailsStep, LessonPatternsStep ],
-	};
-	const { postType, senseiProExtension } = useSelect(
-		( select ) => ( {
-			postType: select( editorStore )?.getCurrentPostType(),
-			senseiProExtension: select(
-				EXTENSIONS_STORE
-			).getSenseiProExtension(),
-		} ),
-		[]
-	);
-
-	if ( ! senseiProExtension || senseiProExtension.is_installed === true ) {
-		stepsByPostType.course = stepsByPostType.course.filter(
-			( step ) => step !== CourseUpgradeStep
-		);
-	}
-
-	const steps = stepsByPostType[ postType ];
 
 	// eslint-disable-next-line no-unused-vars
 	const onWizardCompletion = ( wizardData ) => {

--- a/assets/admin/editor-wizard/steps/course-upgrade-step.test.js
+++ b/assets/admin/editor-wizard/steps/course-upgrade-step.test.js
@@ -1,0 +1,56 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * Internal dependencies
+ */
+import CourseUpgradeStep from './course-upgrade-step';
+
+jest.mock( '@wordpress/data' );
+
+const DUMMY_ROUNDED_PRICE_WITH_CENTS = '$130.00';
+const DUMMY_ROUNDED_PRICE = '$130';
+const DUMMY_PRICE_WITH_CENTS = '$123.50';
+const DUMMY_PRICE_SUFFIX = ' USD';
+
+describe( '<CourseUpgradeStep />', () => {
+	beforeAll( () => {
+		window.sensei = { pluginUrl: '' };
+	} );
+
+	it( 'Should return a component including the price rounded', () => {
+		useSelect.mockReturnValue( {
+			postType: 'course',
+			senseiProExtension: {
+				is_installed: false,
+				price: DUMMY_ROUNDED_PRICE_WITH_CENTS,
+			},
+		} );
+		const { queryByText } = render( <CourseUpgradeStep /> );
+		expect(
+			queryByText( DUMMY_ROUNDED_PRICE + DUMMY_PRICE_SUFFIX )
+		).toBeTruthy();
+	} );
+
+	it( 'Should return a component including the price with cents', () => {
+		useSelect.mockReturnValue( {
+			postType: 'course',
+			senseiProExtension: {
+				is_installed: false,
+				price: DUMMY_PRICE_WITH_CENTS,
+			},
+		} );
+		const { queryByText } = render( <CourseUpgradeStep /> );
+		expect(
+			queryByText( DUMMY_PRICE_WITH_CENTS + DUMMY_PRICE_SUFFIX )
+		).toBeTruthy();
+	} );
+} );

--- a/assets/admin/editor-wizard/use-editor-wizard-steps.js
+++ b/assets/admin/editor-wizard/use-editor-wizard-steps.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+import { store as editorStore } from '@wordpress/editor/build/store';
+
+/**
+ * Internal dependencies
+ */
+import CourseDetailsStep from './steps/course-details-step';
+import CourseUpgradeStep from './steps/course-upgrade-step';
+import CoursePatternsStep from './steps/course-patterns-step';
+import LessonDetailsStep from './steps/lesson-details-step';
+import LessonPatternsStep from './steps/lesson-patterns-step';
+import { EXTENSIONS_STORE } from '../../extensions/store';
+
+const useEditorWizardSteps = () => {
+	const stepsByPostType = {
+		course: [ CourseDetailsStep, CourseUpgradeStep, CoursePatternsStep ],
+		lesson: [ LessonDetailsStep, LessonPatternsStep ],
+	};
+	const { postType, senseiProExtension } = useSelect(
+		( select ) => ( {
+			postType: select( editorStore )?.getCurrentPostType(),
+			senseiProExtension: select(
+				EXTENSIONS_STORE
+			).getSenseiProExtension(),
+		} ),
+		[]
+	);
+
+	if ( ! senseiProExtension || senseiProExtension.is_installed === true ) {
+		stepsByPostType.course = stepsByPostType.course.filter(
+			( step ) => step !== CourseUpgradeStep
+		);
+	}
+
+	return stepsByPostType[ postType ];
+};
+
+export default useEditorWizardSteps;

--- a/assets/admin/editor-wizard/use-editor-wizard-steps.js
+++ b/assets/admin/editor-wizard/use-editor-wizard-steps.js
@@ -18,7 +18,7 @@ import { EXTENSIONS_STORE } from '../../extensions/store';
  * Returns the list of components (representing steps) for the Editor Wizard according to the post type and if
  * Sensei Pro is installed or not.
  *
- * @return {Array} The list of components to show to the user
+ * @return {Array} The list of components to show to the user.
  */
 const useEditorWizardSteps = () => {
 	const stepsByPostType = {

--- a/assets/admin/editor-wizard/use-editor-wizard-steps.js
+++ b/assets/admin/editor-wizard/use-editor-wizard-steps.js
@@ -16,7 +16,7 @@ import { EXTENSIONS_STORE } from '../../extensions/store';
 
 /**
  * Returns the list of components (representing steps) for the Editor Wizard according to the post type and if
- * Sensei Pro is installed or not
+ * Sensei Pro is installed or not.
  *
  * @return {Array} The list of components to show to the user
  */

--- a/assets/admin/editor-wizard/use-editor-wizard-steps.js
+++ b/assets/admin/editor-wizard/use-editor-wizard-steps.js
@@ -14,6 +14,12 @@ import LessonDetailsStep from './steps/lesson-details-step';
 import LessonPatternsStep from './steps/lesson-patterns-step';
 import { EXTENSIONS_STORE } from '../../extensions/store';
 
+/**
+ * Returns the list of components (representing steps) for the Editor Wizard according to the post type and to if
+ * Sensei Pro is installed or not
+ *
+ * @return {Array} The list of components to show to the user
+ */
 const useEditorWizardSteps = () => {
 	const stepsByPostType = {
 		course: [ CourseDetailsStep, CourseUpgradeStep, CoursePatternsStep ],

--- a/assets/admin/editor-wizard/use-editor-wizard-steps.js
+++ b/assets/admin/editor-wizard/use-editor-wizard-steps.js
@@ -15,7 +15,7 @@ import LessonPatternsStep from './steps/lesson-patterns-step';
 import { EXTENSIONS_STORE } from '../../extensions/store';
 
 /**
- * Returns the list of components (representing steps) for the Editor Wizard according to the post type and to if
+ * Returns the list of components (representing steps) for the Editor Wizard according to the post type and if
  * Sensei Pro is installed or not
  *
  * @return {Array} The list of components to show to the user

--- a/assets/admin/editor-wizard/use-editor-wizard-steps.test.js
+++ b/assets/admin/editor-wizard/use-editor-wizard-steps.test.js
@@ -1,0 +1,47 @@
+/**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
+ * Internal dependencies
+ */
+import useEditorWizardSteps from './use-editor-wizard-steps';
+import CourseDetailsStep from './steps/course-details-step';
+import CourseUpgradeStep from './steps/course-upgrade-step';
+import CoursePatternsStep from './steps/course-patterns-step';
+import LessonDetailsStep from './steps/lesson-details-step';
+import LessonPatternsStep from './steps/lesson-patterns-step';
+
+jest.mock( '@wordpress/data' );
+
+describe( 'useEditorWizardSteps()', () => {
+	it( 'Should have all the course steps when the post type is course and Sensei Pro is not installed', () => {
+		useSelect.mockReturnValue( {
+			postType: 'course',
+			senseiProExtension: { is_installed: false },
+		} );
+		const steps = useEditorWizardSteps();
+		expect( steps ).toEqual( [
+			CourseDetailsStep,
+			CourseUpgradeStep,
+			CoursePatternsStep,
+		] );
+	} );
+	it( 'Should have all the course steps when the post type is course and Sensei Pro is installed', () => {
+		useSelect.mockReturnValue( {
+			postType: 'course',
+			senseiProExtension: { is_installed: true },
+		} );
+		const steps = useEditorWizardSteps();
+		expect( steps ).toEqual( [ CourseDetailsStep, CoursePatternsStep ] );
+	} );
+	it( 'Should have all the lesson steps when the post type is lesson', () => {
+		useSelect.mockReturnValue( {
+			postType: 'lesson',
+			senseiProExtension: { is_installed: false },
+		} );
+		const steps = useEditorWizardSteps();
+		expect( steps ).toEqual( [ LessonDetailsStep, LessonPatternsStep ] );
+	} );
+} );

--- a/assets/admin/editor-wizard/use-editor-wizard-steps.test.js
+++ b/assets/admin/editor-wizard/use-editor-wizard-steps.test.js
@@ -28,7 +28,15 @@ describe( 'useEditorWizardSteps()', () => {
 			CoursePatternsStep,
 		] );
 	} );
-	it( 'Should have all the course steps when the post type is course and Sensei Pro is installed', () => {
+	it( 'Should not have the course upgrade step when the post type is course and the Sensei Pro extension is not found', () => {
+		useSelect.mockReturnValue( {
+			postType: 'course',
+			senseiProExtension: undefined,
+		} );
+		const steps = useEditorWizardSteps();
+		expect( steps ).toEqual( [ CourseDetailsStep, CoursePatternsStep ] );
+	} );
+	it( 'Should not have the course upgrade step when the post type is course and the Sensei Pro is installed', () => {
 		useSelect.mockReturnValue( {
 			postType: 'course',
 			senseiProExtension: { is_installed: true },

--- a/jest.config.js
+++ b/jest.config.js
@@ -16,5 +16,6 @@ module.exports = {
 	],
 	moduleNameMapper: {
 		'\\.svg$': '<rootDir>/tests/__mocks__/svg.js',
+		'\\.(gif|jpg|jpeg|png)$': '<rootDir>/tests/__mocks__/image.js',
 	},
 };

--- a/tests/__mocks__/image.js
+++ b/tests/__mocks__/image.js
@@ -1,0 +1,1 @@
+export default 'Image URL';


### PR DESCRIPTION
Fixes #5183

### Changes proposed in this Pull Request

* Add some tests to the Paid Course Upsell, verifying the logic behind the editor wizard steps algorithm and also if the price is shown correctly on the CourseUpgradeStep;
* Also refactor the steps decision logic to remove it from the EditorWizardModal component, and into its own hook, so it's easier to test while also simplifying a little bit the EditorWizardModal component;

### Testing instructions

- Switch to this branch;
- Run `npm install` (if you haven't run it yet);
- Run `npm run test-js` and verify that the tests still pass successfully;