### PR TITLE
Add ESLint rules to recommend arrow functions and yoda conditions

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -51,6 +51,7 @@ module.exports = {
 		],
 		'prefer-arrow-callback': [ 'warn', { allowNamedFunctions: false } ],
 		'func-style': [ 'warn', 'expression', { allowArrowFunctions: true } ],
+		yoda: [ 'warn', 'always' ],
 		'jsdoc/require-yields': 'off',
 		'jsdoc/tag-lines': 'off',
 		'react-hooks/exhaustive-deps': 'warn',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,9 +40,20 @@ module.exports = {
 				preserveMainDescriptionPostDelimiter: true,
 			},
 		],
+		'prefer-arrow-functions/prefer-arrow-functions': [
+			'warn',
+			{
+				classPropertiesAllowed: false,
+				disallowPrototype: false,
+				returnStyle: 'implicit',
+				singleReturnOnly: false,
+			},
+		],
+		'prefer-arrow-callback': [ 'warn', { allowNamedFunctions: false } ],
+		'func-style': [ 'warn', 'expression', { allowArrowFunctions: true } ],
 		'jsdoc/require-yields': 'off',
 		'jsdoc/tag-lines': 'off',
 		'react-hooks/exhaustive-deps': 'warn',
 	},
-	plugins: [ 'jest' ],
+	plugins: [ 'jest', 'prefer-arrow-functions' ],
 };

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
     "whatwg-fetch": "3.6.2"
   },
   "overrides": {
-      "react": "17.0.2",
-      "react-dom": "17.0.2",
-      "@wordpress/element": "$@wordpress/element"
+    "react": "17.0.2",
+    "react-dom": "17.0.2",
+    "@wordpress/element": "$@wordpress/element"
   },
   "devDependencies": {
     "@automattic/calypso-build": "10.0.0",
@@ -88,6 +88,7 @@
     "eslint": "7.30.0",
     "eslint-config-prettier": "8.1.0",
     "eslint-plugin-jsdoc": "35.4.1",
+    "eslint-plugin-prefer-arrow-functions": "3.1.4",
     "expect-puppeteer": "4.4.0",
     "gettext-parser": "4.0.4",
     "husky": "6.0.0",


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add an ESLint plugin to always remind us to use arrow functions and arrow callbacks, in the form of warnings;
* Add an ESLint rule to recommend `yoda` conditions. Slack discussion about this here: p1653582444832239-slack-C8QJAM52B

### Testing instructions

* Switch to this branch;
* Run `npm install`;
* Run `npm run lint-js` and check if there are a bunch of warnings related to the arrow functions;

### Notes

I didn't run ESLint with the `--fix` parameter because there's a big number of changes that this might cause, which may incur into way more testing than originally planned. Also, considering that the github check shouldn't break with the quantity of warnings, I think that's a valid solution.