### PR TITLE
Move `window.sensei.pluginUrl` definition.

### DIFF
--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -42,7 +42,7 @@ class Sensei_Admin {
 		add_action( 'menu_order', array( $this, 'admin_menu_order' ) );
 		add_action( 'admin_head', array( $this, 'admin_menu_highlight' ) );
 		add_action( 'admin_init', array( $this, 'sensei_add_custom_menu_items' ) );
-		add_action( 'admin_print_scripts', array($this, 'sensei_set_plugin_url'));
+		add_action( 'admin_print_scripts', array( $this, 'sensei_set_plugin_url' ) );
 
 		// Duplicate lesson & courses
 		add_filter( 'post_row_actions', array( $this, 'duplicate_action_link' ), 10, 2 );
@@ -2014,7 +2014,7 @@ class Sensei_Admin {
 	/**
 	 * Set `window.sensei.pluginUrl` to be used from javascript.
 	 *
-	 * @since x.x.x
+	 * @since  x.x.x
 	 * @access private
 	 */
 	public function sensei_set_plugin_url() {
@@ -2024,11 +2024,11 @@ class Sensei_Admin {
 			return;
 		}
 
-		if ( in_array( $screen->id, [ 'course', 'lesson' ] ) ) {
+		if ( in_array( $screen->id, [ 'course', 'lesson' ], true ) ) {
 			?>
 			<script>
 				window.sensei = window.sensei || {};
-				window.sensei.pluginUrl = '<? echo Sensei()->plugin_url; ?>';
+				window.sensei.pluginUrl = '<?php echo Sensei()->plugin_url; ?>';
 			</script>
 			<?php
 		}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -42,6 +42,7 @@ class Sensei_Admin {
 		add_action( 'menu_order', array( $this, 'admin_menu_order' ) );
 		add_action( 'admin_head', array( $this, 'admin_menu_highlight' ) );
 		add_action( 'admin_init', array( $this, 'sensei_add_custom_menu_items' ) );
+		add_action( 'admin_print_scripts', array($this, 'sensei_set_plugin_url'));
 
 		// Duplicate lesson & courses
 		add_filter( 'post_row_actions', array( $this, 'duplicate_action_link' ), 10, 2 );
@@ -2008,6 +2009,22 @@ class Sensei_Admin {
 
 		sensei_log_event( $event_name, $properties );
 		// phpcs:enable WordPress.Security.NonceVerification
+	}
+
+	public function sensei_set_plugin_url() {
+
+		$screen = get_current_screen();
+		if ( ! $screen ) {
+			return;
+		}
+
+		if ( in_array( $screen->id, array( 'course', 'lesson' ) ) ) {
+			?>
+<script>
+	window.sensei = window.sensei || {}; window.sensei.pluginUrl = '<? echo Sensei()->plugin_url; ?>';
+</script>
+			<?php
+		}
 	}
 
 }

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -2028,7 +2028,7 @@ class Sensei_Admin {
 			?>
 			<script>
 				window.sensei = window.sensei || {};
-				window.sensei.pluginUrl = '<?php echo Sensei()->plugin_url; ?>';
+				window.sensei.pluginUrl = '<?php echo esc_url( Sensei()->plugin_url ); ?>';
 			</script>
 			<?php
 		}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -2018,11 +2018,12 @@ class Sensei_Admin {
 			return;
 		}
 
-		if ( in_array( $screen->id, array( 'course', 'lesson' ) ) ) {
+		if ( in_array( $screen->id, [ 'course', 'lesson' ] ) ) {
 			?>
-<script>
-	window.sensei = window.sensei || {}; window.sensei.pluginUrl = '<? echo Sensei()->plugin_url; ?>';
-</script>
+			<script>
+				window.sensei = window.sensei || {};
+				window.sensei.pluginUrl = '<? echo Sensei()->plugin_url; ?>';
+			</script>
 			<?php
 		}
 	}

--- a/includes/class-sensei-admin.php
+++ b/includes/class-sensei-admin.php
@@ -2011,6 +2011,12 @@ class Sensei_Admin {
 		// phpcs:enable WordPress.Security.NonceVerification
 	}
 
+	/**
+	 * Set `window.sensei.pluginUrl` to be used from javascript.
+	 *
+	 * @since x.x.x
+	 * @access private
+	 */
 	public function sensei_set_plugin_url() {
 
 		$screen = get_current_screen();

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -231,7 +231,6 @@ class Sensei_Course {
 			Sensei()->assets->enqueue( 'sensei-admin-course-edit', 'js/admin/course-edit.js', [ 'jquery', 'sensei-core-select2' ], true );
 			Sensei()->assets->enqueue( 'sensei-admin-course-edit-styles', 'css/course-editor.css' );
 
-			wp_add_inline_script( 'sensei-admin-course-edit', "window.sensei = window.sensei || {}; window.sensei.pluginUrl = '" . Sensei()->plugin_url . "';", 'before' );
 			$settings_json = wp_json_encode( \Sensei()->settings->get_settings() );
 			wp_add_inline_script(
 				'sensei-admin-course-edit',


### PR DESCRIPTION
Fixes #5189

### Changes proposed in this Pull Request
* Move where the `window.sensei.pluginUrl` attribute was being defined so that it can be used also from lesson page.

### Testing instructions
* Checkout to branch.
* Go to `Sensei LMS > Lessons > Create lesson` check that wizard appears.
* Go to `Sensei LMS > Courses > Create course` check that wizard appears.
* Go to `Sensei LMS > Courses > Create course` create a lesson using the Course Outline and saving. Click on "Edit lesson". Check that wizard appears.
* Check that the JS code setting `window.sensei.pluginUrl` is not appearing in other unnecessary pages.

### Screenshot / Video
<img width="1724" alt="image" src="https://user-images.githubusercontent.com/799065/170451013-7afe50a2-909b-4876-8119-65fda7870364.png">
<img width="1723" alt="image" src="https://user-images.githubusercontent.com/799065/170451073-bf95079d-c385-4093-8dca-99cddad95ef2.png">
