### PR TITLE
Disable the lesson archive

### DIFF
--- a/includes/class-sensei-posttypes.php
+++ b/includes/class-sensei-posttypes.php
@@ -352,7 +352,7 @@ class Sensei_PostTypes {
 			),
 			'map_meta_cap'          => true,
 			'capability_type'       => 'lesson',
-			'has_archive'           => true,
+			'has_archive'           => false,
 			'hierarchical'          => false,
 			'menu_position'         => 52,
 			'supports'              => $supports_array,


### PR DESCRIPTION
Fixes #4241

### Changes proposed in this Pull Request

This PR disables the lesson archive by default. The GH issue explains why this is needed.

### Testing instructions

* Refresh your permalinks.
* Check if the archive is disabled by visiting `yoursite.com/lesson`.

### Notes

If someone needs this feature, it could be enabled again with the following snippet:

```php
add_filter( 'sensei_register_post_type_lesson', function( $args ) {
	$args['has_archive'] = true;
	return $args;
} );
```