### PR TITLE
Redirect the quiz if the lesson is password protected

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -31,6 +31,9 @@ class Sensei_Quiz {
 		$this->meta_fields = array( 'quiz_passmark', 'quiz_lesson', 'quiz_type', 'quiz_grade_type', 'pass_required', 'enable_quiz_reset' );
 		add_action( 'save_post', array( $this, 'update_after_lesson_change' ) );
 
+		// Redirect if the lesson is protected.
+		add_action( 'template_redirect', array( $this, 'redirect_if_lesson_is_protected' ) );
+
 		// Listen for a page change.
 		add_action( 'template_redirect', array( $this, 'page_change_listener' ) );
 
@@ -427,6 +430,25 @@ class Sensei_Quiz {
 		);
 		exit;
 
+	}
+
+	/**
+	 * Redirect back to the lesson if the lesson is password protected.
+	 *
+	 * @since  x.x.x
+	 * @access private
+	 */
+	public function redirect_if_lesson_is_protected() {
+		if ( ! is_singular( 'quiz' ) ) {
+			return;
+		}
+
+		$lesson_id = $this->get_lesson_id();
+
+		if ( post_password_required( $lesson_id ) ) {
+			wp_safe_redirect( get_permalink( $lesson_id ) );
+			exit;
+		}
 	}
 
 	/**

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -1504,4 +1504,50 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$this->assertTrue( Sensei_Quiz::is_quiz_completed( $quiz_id, $user_id ), 'The quiz should be considered completed if the lesson status is ungraded.' );
 	}
 
+	public function testRedirectIfLessonIsProtected_ProtectedLessonGiven_RedirectsToLesson() {
+		/* Arrange. */
+		$lesson_id = $this->factory->lesson->create( [ 'post_password' => 123 ] );
+		$quiz_id   = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
+
+		$halt_redirect = function( $location, $status ) {
+			throw new \Exception(
+				wp_json_encode(
+					[
+						'location' => $location,
+						'status'   => $status,
+					]
+				)
+			);
+		};
+
+		$this->go_to( get_permalink( $quiz_id ) );
+
+		/* Act. */
+		add_filter( 'wp_redirect', $halt_redirect, 1, 2 );
+		try {
+			Sensei()->quiz->redirect_if_lesson_is_protected();
+		} catch ( \Exception $e ) {
+			$redirect = json_decode( $e->getMessage(), true );
+		}
+		remove_filter( 'wp_redirect', $halt_redirect, 1, 2 );
+
+		/* Assert. */
+		$this->assertEquals( 302, $redirect['status'] );
+		$this->assertEquals( get_permalink( $lesson_id ), $redirect['location'] );
+	}
+
+	public function testRedirectIfLessonIsProtected_NoProtectedLessonGiven_DoesNotRedirectsToLesson() {
+		/* Arrange. */
+		$lesson_id = $this->factory->lesson->create();
+		$quiz_id   = $this->factory->quiz->create( [ 'post_parent' => $lesson_id ] );
+
+		$this->go_to( get_permalink( $quiz_id ) );
+
+		/* Act. */
+		$result = Sensei()->quiz->redirect_if_lesson_is_protected();
+
+		/* Assert. */
+		$this->assertNull( $result );
+	}
+
 }


### PR DESCRIPTION
Related to #1854

### Changes proposed in this Pull Request

If the lesson is password protected it makes sense for the quiz to be as well. This change redirects the quiz back to the lesson if the password is not provided.

### Testing instructions

* Have a password protected lesson with a quiz.
* Go to yourwebsite.com/lesson/your-lesson/ and make sure it's password protected.
* Go to yourwebsite.com/quiz/your-lesson/ and make sure it redirects back to the lesson.
* Fill in the password and make sure both pages are accessible.
* Make sure the quiz submission works.
* Make sure all works in learning mode as well.
