### PR TITLE
Create 3 default lessons on the Course Outline Block

### DIFF
--- a/assets/blocks/course-outline/outline-block/outline-edit.js
+++ b/assets/blocks/course-outline/outline-block/outline-edit.js
@@ -7,9 +7,7 @@ import {
 } from '@wordpress/block-editor';
 import { compose } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { store as editorStore } from '@wordpress/editor';
 import { createContext, useCallback, useEffect } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
@@ -54,10 +52,9 @@ const OutlineEdit = ( props ) => {
 
 	const { setBlocks } = useBlocksCreator( clientId );
 
-	const { isEmpty, isPostNew } = useSelect(
+	const { isEmpty } = useSelect(
 		( select ) => ( {
 			isEmpty: ! select( blockEditorStore ).getBlocks( clientId ).length,
-			isPostNew: select( editorStore ).isEditedPostNew(),
 		} ),
 		[ clientId ]
 	);
@@ -68,18 +65,6 @@ const OutlineEdit = ( props ) => {
 		() => <OutlineAppender clientId={ clientId } />,
 		[ clientId ]
 	);
-
-	useEffect( () => {
-		if ( ! isPostNew ) {
-			// Only add the lessons if the post is new
-			return;
-		}
-		setBlocks( [
-			{ type: 'lesson', title: __( 'Lesson 1', 'sensei-lms' ) },
-			{ type: 'lesson', title: __( 'Lesson 2', 'sensei-lms' ) },
-			{ type: 'lesson', title: __( 'Lesson 3', 'sensei-lms' ) },
-		] );
-	}, [ isPostNew, setBlocks ] );
 
 	return isEmpty ? (
 		<OutlinePlaceholder

--- a/includes/blocks/class-sensei-course-blocks.php
+++ b/includes/blocks/class-sensei-course-blocks.php
@@ -67,7 +67,30 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 			[ 'sensei-lms/button-take-course' ],
 			[ 'sensei-lms/button-contact-teacher' ],
 			[ 'sensei-lms/course-progress' ],
-			[ 'sensei-lms/course-outline' ],
+			[
+				'sensei-lms/course-outline',
+				[],
+				[
+					[
+						'sensei-lms/course-outline-lesson',
+						[
+							'title' => __( 'Lesson 1', 'sensei-lms' ),
+						],
+					],
+					[
+						'sensei-lms/course-outline-lesson',
+						[
+							'title' => __( 'Lesson 2', 'sensei-lms' ),
+						],
+					],
+					[
+						'sensei-lms/course-outline-lesson',
+						[
+							'title' => __( 'Lesson 3', 'sensei-lms' ),
+						],
+					],
+				],
+			],
 		];
 
 		/**
@@ -133,7 +156,7 @@ class Sensei_Course_Blocks extends Sensei_Blocks_Initializer {
 	 *
 	 * @access private
 	 *
-	 * @param bool $enabled
+	 * @param bool $enabled The current value passed from the filter.
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
Fixes #5142

### Changes proposed in this Pull Request

* Change Course Outline block behavior to add three lessons (Lesson 1, Lesson 2 and Lesson 3) to the course by default, but only when the post is new;

### Testing instructions

1. Switch to this branch and run `npm start` (or install the plugin build on this PR on some WordPress installation);
3. Create a new course;
4. Verify that 3 lessons (Lesson 1, Lesson 2 and Lesson 3) appear on the course outline by default;
5. Verify that if you save the course, the lessons will be saved too;
6. Verify that if you delete some the lessons (or add new ones), the lessons are persisted correctly; (e.g the system doesn't replace the modified lesson list for the default lesson list)
7. Verify that if you delete all the lessons, the Course Outline Placeholder will appear;
8. Verify that, in a scenario where you save the course after deleting all the lessons, if you refresh the page, the three default lessons ARE NOT restored;

## Screenshots

![Screenshot of the course outline block with titles in each lesson used as placeholder](https://user-images.githubusercontent.com/529864/170593361-b91c731a-01e7-4783-af13-36f39605b812.png)

### Note

I'm not 100% sure if this PR covers all the behaviors that we are expecting from issue #5142, but I 100% feel like this is a good starting point to start experimenting and working on that issue.