### PR TITLE
Fix module order not preserved after teacher update

### DIFF
--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -431,7 +431,7 @@ class Sensei_Course_Structure {
 	 *
 	 * @param array $module_order Module order to save.
 	 */
-	private function save_module_order( array $module_order ) {
+	public function save_module_order( array $module_order ) {
 		$current_module_order_raw = get_post_meta( $this->course_id, '_module_order', true );
 		$current_module_order     = $current_module_order_raw ? array_map( 'intval', $current_module_order_raw ) : [];
 

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -408,16 +408,17 @@ class Sensei_Teacher {
 		}
 
 		remove_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70 );
-		$terms_selected_on_course = wp_get_object_terms( $course_id, 'module' );
+		$modules = Sensei()->modules->get_course_modules( $course_id );
 		add_filter( 'get_terms', array( Sensei()->modules, 'append_teacher_name_to_module' ), 70, 3 );
 
-		if ( empty( $terms_selected_on_course ) ) {
+		if ( empty( $modules ) ) {
 			return;
 		}
 
-		$lessons = Sensei()->course->course_lessons( $course_id, null );
+		$lessons      = Sensei()->course->course_lessons( $course_id, null );
+		$module_order = [];
 
-		foreach ( $terms_selected_on_course as $term ) {
+		foreach ( $modules as $term ) {
 			$term_author = Sensei_Core_Modules::get_term_author( $term->slug );
 
 			if ( ! $term_author || intval( $new_teacher_id ) !== intval( $term_author->ID ) ) {
@@ -460,7 +461,8 @@ class Sensei_Teacher {
 					continue;
 				}
 
-				$term_id = $new_term['term_id'];
+				$term_id        = $new_term['term_id'];
+				$module_order[] = $term_id;
 
 				// Set the terms selected on the course.
 				wp_set_object_terms( $course_id, $term_id, 'module', true );
@@ -495,6 +497,8 @@ class Sensei_Teacher {
 				Sensei()->modules->remove_if_unused( $term->term_id );
 			}
 		}
+
+		Sensei_Course_Structure::instance( $course_id )->save_module_order( $module_order );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-teacher.php
+++ b/tests/unit-tests/test-class-teacher.php
@@ -67,6 +67,57 @@ class Sensei_Class_Teacher_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test if the module order is updated after the teacher has changed.
+	 */
+	public function testUpdateCourseModules_TeacherUpdated_UpdatesTheModuleOrder() {
+		/* Arrange. */
+		$user_id   = $this->factory->user->create();
+		$course_id = $this->factory->course->create();
+
+		$structure_source = [
+			[
+				'type'    => 'module',
+				'title'   => 'Module A',
+				'lessons' => [
+					[
+						'type'  => 'lesson',
+						'title' => 'Lesson A',
+					],
+				],
+			],
+			[
+				'type'    => 'module',
+				'title'   => 'Module B',
+				'lessons' => [
+					[
+						'type'  => 'lesson',
+						'title' => 'Lesson B',
+					],
+				],
+			],
+		];
+
+		$course_structure = Sensei_Course_Structure::instance( $course_id );
+		$course_structure->save( $structure_source );
+
+		/* Act. */
+		Sensei_Teacher::update_course_modules_author( $course_id, $user_id );
+
+		/* Assert. */
+		$new_module_order = Sensei()->modules->get_course_module_order( $course_id );
+		$new_structure    = $course_structure->get( 'edit' );
+
+		$expected_module_order = [];
+		foreach ( $new_structure as $item ) {
+			if ( 'module' === $item['type'] ) {
+				$expected_module_order[] = $item['id'];
+			}
+		}
+
+		$this->assertEquals( $expected_module_order, $new_module_order );
+	}
+
+	/**
 	 * Testing Sensei_Teacher::update_course_modules_author
 	 * This test focus on changing module author
 	 *


### PR DESCRIPTION
Fixes #2140

### Changes proposed in this Pull Request

This fixes a case where the module order is not preserved after the course teacher is updated.

### Testing instructions

* Have a course with 3 modules each with a lesson.
* From the course edit page, reorder the modules and save the course.
* Do a browser refresh on the edit page.
* Change the course teacher to some other user.
* Do a browser refresh on the edit page.
* Make sure the module order is the same.