### PR TITLE
Fix the "import" docs link

### DIFF
--- a/assets/data-port/import/upload/upload-page.js
+++ b/assets/data-port/import/upload/upload-page.js
@@ -38,7 +38,7 @@ export const UploadPage = ( { state, isReady, submitStartImport } ) => {
 								// eslint-disable-next-line jsx-a11y/anchor-has-content
 								<a
 									className="link__color-secondary"
-									href="https://senseilms.com/lesson/import/"
+									href="https://senseilms.com/documentation/import/"
 									target="_blank"
 									type="external"
 									rel="noopener noreferrer"

--- a/sample-data/lessons.csv
+++ b/sample-data/lessons.csv
@@ -289,7 +289,7 @@ Id,Lesson,Slug,Description,Excerpt,Status,Module,Prerequisite,Preview,Tags,Image
 <!-- /wp:sensei-lms/button-contact-teacher -->
 
 <!-- wp:paragraph -->
-<p>Sensei LMS has native functionality that enables you to export courses, lessons and questions. This means you can export course data from a staging site, for example, and then <a href=""https://senseilms.com/lesson/import/"" data-type=""lesson"" data-id=""3473"">import</a> it into your live site.</p>
+<p>Sensei LMS has native functionality that enables you to export courses, lessons and questions. This means you can export course data from a staging site, for example, and then <a href=""https://senseilms.com/documentation/import/"" data-type=""lesson"" data-id=""3473"">import</a> it into your live site.</p>
 <!-- /wp:paragraph -->
 
 <!-- wp:list {""ordered"":true} -->


### PR DESCRIPTION
Fixes #5200

### Changes proposed in this Pull Request

Fixes the link that points to the import docs.

### Testing instructions

* Go to Sensei LMS -> Tools -> Import Content.
* Make sure the documentation link is pointing to https://senseilms.com/documentation/import/.
