### PR TITLE
Add editor wizard responsive style and tweak some styles

### DIFF
--- a/assets/admin/editor-wizard/patterns-list.scss
+++ b/assets/admin/editor-wizard/patterns-list.scss
@@ -1,6 +1,8 @@
 .sensei-patterns-list {
-	column-count: 2;
-	column-gap: 24px;
+	@media ( min-width: 600px ) {
+		column-count: 2;
+		column-gap: 24px;
+	}
 
 	&__item {
 		break-inside: avoid-column;

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -37,7 +37,9 @@ const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 	return (
 		<div className="sensei-editor-wizard-modal__columns">
 			<div className="sensei-editor-wizard-modal__content">
-				<h1>{ __( 'Create your course', 'sensei-lms' ) }</h1>
+				<h1 className="sensei-editor-wizard-modal__title">
+					{ __( 'Create your course', 'sensei-lms' ) }
+				</h1>
 				<div className="sensei-editor-wizard-step__description">
 					{ __(
 						'Keep your Course Title short as it will get displayed in different places around your website. You can easily change both later.',

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -78,11 +78,9 @@ const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 
 CourseDetailsStep.Actions = ( { goToNextStep } ) => {
 	return (
-		<div>
-			<Button isPrimary onClick={ goToNextStep }>
-				{ __( 'Continue', 'sensei-lms' ) }
-			</Button>
-		</div>
+		<Button isPrimary onClick={ goToNextStep }>
+			{ __( 'Continue', 'sensei-lms' ) }
+		</Button>
 	);
 };
 

--- a/assets/admin/editor-wizard/steps/course-upgrade-step.js
+++ b/assets/admin/editor-wizard/steps/course-upgrade-step.js
@@ -94,7 +94,7 @@ CourseUpgradeStep.Actions = ( { goToNextStep } ) => {
 		goToNextStep();
 	};
 	return (
-		<div>
+		<>
 			<Button
 				isTertiary
 				onClick={ goToNextStep }
@@ -110,7 +110,7 @@ CourseUpgradeStep.Actions = ( { goToNextStep } ) => {
 			>
 				{ __( 'Get Sensei Pro', 'sensei-lms' ) }
 			</Button>
-		</div>
+		</>
 	);
 };
 

--- a/assets/admin/editor-wizard/steps/course-upgrade-step.js
+++ b/assets/admin/editor-wizard/steps/course-upgrade-step.js
@@ -27,7 +27,9 @@ const CourseUpgradeStep = () => {
 	return (
 		<div className="sensei-editor-wizard-modal__columns">
 			<div className="sensei-editor-wizard-modal__content">
-				<h1>{ __( 'Sell with Sensei Pro', 'sensei-lms' ) }</h1>
+				<h1 className="sensei-editor-wizard-modal__title">
+					{ __( 'Sell with Sensei Pro', 'sensei-lms' ) }
+				</h1>
 				<p>
 					{ __(
 						'Do you want to sell this course? This requires Sensei Pro which also unlocks many useful features.',

--- a/assets/admin/editor-wizard/steps/course-upgrade-step.js
+++ b/assets/admin/editor-wizard/steps/course-upgrade-step.js
@@ -36,16 +36,16 @@ const CourseUpgradeStep = () => {
 						'sensei-lms'
 					) }
 				</p>
-				<h1 className="sensei-editor-wizard-modal-upsell__price">
+				<strong className="sensei-editor-wizard-modal-upsell__price">
 					{ sprintf(
 						// translators: placeholder is the price.
 						__( '%s USD', 'sensei-lms' ),
 						senseiProExtension.price.replace( '.00', '' )
 					) }
-				</h1>
-				<p className="sensei-editor-wizard-modal-upsell__price-detail">
+				</strong>
+				<span className="sensei-editor-wizard-modal-upsell__price-detail">
 					{ __( 'per year, 1 site', 'sensei-lms' ) }
-				</p>
+				</span>
 				<ul className="sensei-editor-wizard-modal-upsell__features">
 					<li className="sensei-editor-wizard-modal-upsell__feature-item">
 						{ __( 'WooCommerce integration', 'sensei-lms' ) }

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -66,11 +66,9 @@ const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 
 LessonDetailsStep.Actions = ( { goToNextStep } ) => {
 	return (
-		<div>
-			<Button isPrimary onClick={ goToNextStep }>
-				{ __( 'Continue', 'sensei-lms' ) }
-			</Button>
-		</div>
+		<Button isPrimary onClick={ goToNextStep }>
+			{ __( 'Continue', 'sensei-lms' ) }
+		</Button>
 	);
 };
 

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -32,7 +32,9 @@ const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 	return (
 		<div className="sensei-editor-wizard-modal__columns">
 			<div className="sensei-editor-wizard-modal__content">
-				<h1>{ __( 'Create your lesson', 'sensei-lms' ) }</h1>
+				<h1 className="sensei-editor-wizard-modal__title">
+					{ __( 'Create your lesson', 'sensei-lms' ) }
+				</h1>
 				<div className="sensei-editor-wizard-step__description">
 					{ __(
 						'It is best to keep your Lesson Title short because it will show in your course outline and navigation. You can easily change both later.',

--- a/assets/admin/editor-wizard/steps/patterns-step.js
+++ b/assets/admin/editor-wizard/steps/patterns-step.js
@@ -80,11 +80,9 @@ const PatternsStep = ( { title, replaces, onCompletion } ) => {
  * @param {Function} props.skipWizard Skip wizard function.
  */
 PatternsStep.Actions = ( { skipWizard } ) => (
-	<div>
-		<Button isTertiary onClick={ skipWizard }>
-			{ __( 'Start with default layout', 'sensei-lms' ) }
-		</Button>
-	</div>
+	<Button isTertiary onClick={ skipWizard }>
+		{ __( 'Start with default layout', 'sensei-lms' ) }
+	</Button>
 );
 
 export default PatternsStep;

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -161,7 +161,7 @@
 	&__form {
 		& label {
 			font-weight: bold;
-			margin-top: 30px;
+			margin-top: 20px;
 		}
 	}
 }

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -70,6 +70,10 @@
 
 	&__content {
 		margin: 30px;
+
+		h1 {
+			margin-top: 0;
+		}
 	}
 
 	&__illustration {

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -9,8 +9,9 @@
 		width: 100%;
 		background: #ffffff;
 		display: flex;
-		flex-direction: row;
+		flex-wrap: wrap;
 		align-items: center;
+		gap: 12px;
 		border-top: 1px solid rgba(30, 30, 30, 0.12);
 		padding: 18px;
 
@@ -25,8 +26,9 @@
 
 	&__actions {
 		display: flex;
+		flex: 1;
+		justify-content: end;
 		gap: 12px;
-		margin-left: auto;
 	}
 }
 

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -28,6 +28,7 @@
 	@media ( min-width: 600px ) { // Media query needed for WP 5.8 compatibility.
 		width: 800px;
 	}
+
 	& .components-modal__content {
 		padding: 0;
 		margin-top: 0;
@@ -54,13 +55,22 @@
 		}
 	}
 
+	&__title {
+		margin-top: 0;
+	}
+
 	&__sticky-title {
 		position: sticky;
 		top: 0;
 		z-index: 1;
-		margin: -30px 0 0;
-		padding: 30px 0 18px;
+		margin: -24px 0 0;
+		padding: 24px 0 18px;
 		background: #ffffff;
+
+		@media ( min-width: 600px ) {
+			padding-top: 30px;
+			margin-top: -30px;
+		}
 	}
 
 	&__columns {
@@ -71,10 +81,10 @@
 	}
 
 	&__content {
-		margin: 30px;
+		margin: 24px 18px 18px;
 
-		h1 {
-			margin-top: 0;
+		@media ( min-width: 600px ) {
+			margin: 30px;
 		}
 	}
 

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -64,8 +64,10 @@
 	}
 
 	&__columns {
-		display: grid;
-		grid-template-columns: 50% 50%;
+		@media ( min-width: 600px ) {
+			display: grid;
+			grid-template-columns: 50% 50%;
+		}
 	}
 
 	&__content {
@@ -77,10 +79,14 @@
 	}
 
 	&__illustration {
-		background: #43af99;
-		display: flex;
-		justify-content: right;
-		align-items: center;
+		display: none;
+
+		@media ( min-width: 600px ) {
+			background: #43af99;
+			display: flex;
+			justify-content: right;
+			align-items: center;
+		}
 	}
 
 	&__illustration-image {

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -25,6 +25,8 @@
 }
 
 .sensei-editor-wizard-modal {
+	color: #1e1e1e;
+
 	@media ( min-width: 600px ) { // Media query needed for WP 5.8 compatibility.
 		width: 800px;
 	}
@@ -53,6 +55,11 @@
 			margin: 8px 8px 0 0;
 			position: static;
 		}
+	}
+
+	&__title,
+	&__sticky-title {
+		color: inherit;
 	}
 
 	&__title {

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -12,7 +12,11 @@
 		flex-direction: row;
 		align-items: center;
 		border-top: 1px solid rgba(30, 30, 30, 0.12);
-		padding: 18px 30px;
+		padding: 18px;
+
+		@media ( min-width: 600px ) {
+			padding: 18px 30px;
+		}
 	}
 
 	&__progress {
@@ -20,6 +24,8 @@
 	}
 
 	&__actions {
+		display: flex;
+		gap: 12px;
 		margin-left: auto;
 	}
 }
@@ -148,11 +154,6 @@
 			width: 1.3em;
 			color: #00998b;
 		}
-	}
-
-	&__button {
-		margin-left: 12px;
-		padding: 18px 30px;
 	}
 }
 

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -106,10 +106,18 @@
 
 .sensei-editor-wizard-modal-upsell {
 	&__price {
-		font-size: 28px;
+		display: block;
+		margin-bottom: 8px;
+		line-height: 1.2;
+		font-size: 32px;
+
+		@media ( min-width: 600px ) {
+			font-size: 36px;
+		}
 	}
 
 	&__price-detail {
+		display: block;
 		font-size: 11px;
 		color: #787C82;
 		margin-top: -10px;


### PR DESCRIPTION
Fixes #5180

### Changes proposed in this Pull Request

* It tweaks some styles of the editor wizard, and improves the responsive styles.
* Since we were considering it a low priority issue, I just didn't change the step counter to the top of the page in smaller screens because it would demand some lines of code harder to maintain. For this case, I just allowed the flexbox to break the line when there isn't enough space.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Navigate through the Course Wizard and Lesson Wizard using a big screen and a small screen, and make sure everything looks well.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Big screen:

https://user-images.githubusercontent.com/876340/171053034-059225c4-5020-4829-93d4-fcbba6145729.mov

Small screen:

https://user-images.githubusercontent.com/876340/171053256-366a18e2-5f33-4d64-9804-eb1303082883.mov

