### PR TITLE
Fix editor wizard styles

### DIFF
--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -48,12 +48,14 @@ const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 				</p>
 				<div className="sensei-editor-wizard-step__form">
 					<LimitedTextControl
+						className="sensei-editor-wizard-step__form-control"
 						label={ __( 'Course Title', 'sensei-lms' ) }
 						value={ wizardData.courseTitle ?? '' }
 						onChange={ updateCourseTitle }
 						maxLength={ 40 }
 					/>
 					<LimitedTextControl
+						className="sensei-editor-wizard-step__form-control"
 						label={ __( 'Course Description', 'sensei-lms' ) }
 						value={ wizardData.courseDescription ?? '' }
 						onChange={ updateCourseDescription }

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -37,15 +37,15 @@ const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 	return (
 		<div className="sensei-editor-wizard-modal__columns">
 			<div className="sensei-editor-wizard-modal__content">
-				<h1 className="sensei-editor-wizard-modal__title">
+				<h1 className="sensei-editor-wizard-step__title">
 					{ __( 'Create your course', 'sensei-lms' ) }
 				</h1>
-				<div className="sensei-editor-wizard-step__description">
+				<p className="sensei-editor-wizard-step__description">
 					{ __(
 						'Keep your Course Title short as it will get displayed in different places around your website. You can easily change both later.',
 						'sensei-lms'
 					) }
-				</div>
+				</p>
 				<div className="sensei-editor-wizard-step__form">
 					<LimitedTextControl
 						label={ __( 'Course Title', 'sensei-lms' ) }

--- a/assets/admin/editor-wizard/steps/course-upgrade-step.js
+++ b/assets/admin/editor-wizard/steps/course-upgrade-step.js
@@ -27,10 +27,10 @@ const CourseUpgradeStep = () => {
 	return (
 		<div className="sensei-editor-wizard-modal__columns">
 			<div className="sensei-editor-wizard-modal__content">
-				<h1 className="sensei-editor-wizard-modal__title">
+				<h1 className="sensei-editor-wizard-step__title">
 					{ __( 'Sell with Sensei Pro', 'sensei-lms' ) }
 				</h1>
-				<p>
+				<p className="sensei-editor-wizard-step__description">
 					{ __(
 						'Do you want to sell this course? This requires Sensei Pro which also unlocks many useful features.',
 						'sensei-lms'

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -32,15 +32,15 @@ const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 	return (
 		<div className="sensei-editor-wizard-modal__columns">
 			<div className="sensei-editor-wizard-modal__content">
-				<h1 className="sensei-editor-wizard-modal__title">
+				<h1 className="sensei-editor-wizard-step__title">
 					{ __( 'Create your lesson', 'sensei-lms' ) }
 				</h1>
-				<div className="sensei-editor-wizard-step__description">
+				<p className="sensei-editor-wizard-step__description">
 					{ __(
 						'It is best to keep your Lesson Title short because it will show in your course outline and navigation. You can easily change both later.',
 						'sensei-lms'
 					) }
-				</div>
+				</p>
 				<div className="sensei-editor-wizard-step__form">
 					<LimitedTextControl
 						label={ __( 'Lesson Title', 'sensei-lms' ) }

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -43,6 +43,7 @@ const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 				</p>
 				<div className="sensei-editor-wizard-step__form">
 					<LimitedTextControl
+						className="sensei-editor-wizard-step__form-control"
 						label={ __( 'Lesson Title', 'sensei-lms' ) }
 						value={ wizardData.lessonTitle ?? '' }
 						onChange={ updateLessonTitle }

--- a/assets/admin/editor-wizard/steps/patterns-step.js
+++ b/assets/admin/editor-wizard/steps/patterns-step.js
@@ -65,7 +65,7 @@ const PatternsStep = ( { title, replaces, onCompletion } ) => {
 
 	return (
 		<div className="sensei-editor-wizard-modal__content">
-			<h1 className="sensei-editor-wizard-modal__sticky-title">
+			<h1 className="sensei-editor-wizard-step__sticky-title">
 				{ title }
 			</h1>
 			<PatternsList onChoose={ onChoose } />

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -108,8 +108,8 @@
 	&__price {
 		display: block;
 		margin-bottom: 8px;
-		line-height: 1.2;
-		font-size: 32px;
+		line-height: 1;
+		font-size: 36px;
 
 		@media ( min-width: 600px ) {
 			font-size: 36px;
@@ -118,27 +118,29 @@
 
 	&__price-detail {
 		display: block;
-		font-size: 11px;
+		font-size: 13px;
 		color: #787C82;
-		margin-top: -10px;
 		margin-bottom: 30px;
 	}
 
 	&__features {
 		list-style: none;
+		margin: 0;
 		padding: 0;
+		font-size: 14px;
 		font-weight: 700;
 	}
 
 	&__feature-item {
-		padding-left: 1.3em;
+		padding: 0 0 20px 24px;
+		margin: 0;
 
 		&::before {
 			content: "\f00c";
 			font-family: FontAwesomeSensei, FontAwesome;
 			display: inline-block;
-			margin-left: -1.3em;
-			width: 1.3em;
+			margin-left: -24px;
+			width: 24px;
 			color: #00998b;
 		}
 	}

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -39,6 +39,7 @@
 
 	@media ( min-width: 600px ) { // Media query needed for WP 5.8 compatibility.
 		width: 800px;
+		height: 670px;
 	}
 
 	& .components-modal__content {
@@ -115,6 +116,7 @@
 	}
 
 	&__content {
+		flex: 1;
 		padding: 24px 18px 18px;
 
 		@media ( min-width: 600px ) {

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -71,6 +71,7 @@
 
 	&__title,
 	&__sticky-title {
+		line-height: 1.1;
 		color: inherit;
 	}
 

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -112,7 +112,7 @@
 
 		@media ( min-width: 600px ) {
 			display: grid;
-			grid-template-columns: 50% 50%;
+			grid-template-columns: 52% 48%;
 		}
 	}
 
@@ -129,6 +129,7 @@
 		display: none;
 
 		@media ( min-width: 600px ) {
+			padding-top: 25px;
 			background: #43af99;
 			display: flex;
 			justify-content: right;
@@ -137,7 +138,7 @@
 	}
 
 	&__illustration-image {
-		height: 75%;
+		width: 84%;
 	}
 }
 

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -69,44 +69,6 @@
 		}
 	}
 
-	&__title,
-	&__sticky-title {
-		line-height: 1.1;
-		color: inherit;
-	}
-
-	&__title {
-		margin-top: 0;
-	}
-
-	&__sticky-title {
-		position: sticky;
-		top: 24px;
-		z-index: 1;
-		margin: 0;
-		padding-bottom: 18px;
-		background: #ffffff;
-
-		@media ( min-width: 600px ) {
-			top: 30px;
-		}
-
-		// White box above the title to hide content on scroll.
-		&::before {
-			content: '';
-			display: block;
-			width: 100%;
-			height: 24px;
-			position: absolute;
-			bottom: 100%;
-			background: #ffffff;
-
-			@media ( min-width: 600px ) {
-				height: 30px;
-			}
-		}
-	}
-
 	&__columns {
 		flex: 1;
 
@@ -183,6 +145,48 @@
 }
 
 .sensei-editor-wizard-step {
+	&__title,
+	&__sticky-title {
+		line-height: 1.1;
+		color: inherit;
+	}
+
+	&__title {
+		margin-top: 0;
+	}
+
+	&__sticky-title {
+		position: sticky;
+		top: 24px;
+		z-index: 1;
+		margin: 0;
+		padding-bottom: 18px;
+		background: #ffffff;
+
+		@media ( min-width: 600px ) {
+			top: 30px;
+		}
+
+		// White box above the title to hide content on scroll.
+		&::before {
+			content: '';
+			display: block;
+			width: 100%;
+			height: 24px;
+			position: absolute;
+			bottom: 100%;
+			background: #ffffff;
+
+			@media ( min-width: 600px ) {
+				height: 30px;
+			}
+		}
+	}
+
+	&__description {
+		margin: 0 0 4px;
+	}
+
 	&__form {
 		& label {
 			font-weight: bold;

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -184,13 +184,16 @@
 	}
 
 	&__description {
-		margin: 0 0 4px;
+		margin: 0 0 24px;
 	}
 
 	&__form {
 		& label {
 			font-weight: bold;
-			margin-top: 20px;
 		}
+	}
+
+	&__form-control {
+		margin-bottom: 32px;
 	}
 }

--- a/assets/blocks/editor-components/limited-text-control/index.js
+++ b/assets/blocks/editor-components/limited-text-control/index.js
@@ -28,6 +28,8 @@ const LimitedTextControl = ( {
 				value.length,
 				maxLength
 			) }
+			value={ value }
+			maxLength={ maxLength }
 			{ ...props }
 		/>
 	);

--- a/assets/blocks/editor-components/limited-text-control/index.js
+++ b/assets/blocks/editor-components/limited-text-control/index.js
@@ -7,19 +7,16 @@ import { __, sprintf } from '@wordpress/i18n';
 /**
  * Text control with input limited by a given maximum length.
  *
- * @param {Object}   props           Component properties.
- * @param {string}   props.label     Label for the field.
- * @param {string}   props.value     Value for the field.
- * @param {Function} props.onChange  Callback for when the value changes.
- * @param {number}   props.maxLength Maximum length for the field.
- * @param {boolean}  props.multiline Whether if multiline input (textarea) must be used or not.
+ * @param {Object}  props           Component properties.
+ * @param {string}  props.value     Value for the field.
+ * @param {number}  props.maxLength Maximum length for the field.
+ * @param {boolean} props.multiline Whether if multiline input (textarea) must be used or not.
  */
 const LimitedTextControl = ( {
-	label,
 	value,
-	onChange,
 	maxLength,
 	multiline = false,
+	...props
 } ) => {
 	const Control = multiline ? TextareaControl : TextControl;
 
@@ -31,10 +28,7 @@ const LimitedTextControl = ( {
 				value.length,
 				maxLength
 			) }
-			label={ label }
-			onChange={ onChange }
-			value={ value }
-			maxLength={ maxLength }
+			{ ...props }
 		/>
 	);
 };


### PR DESCRIPTION
Fixes #5217
Based on https://github.com/Automattic/sensei/pull/5206

### Changes proposed in this Pull Request

* It fixes some styles from the editor wizard to match the designs.
* Notice that only some spaces inside the form are not exactly the same, but very similar. I kept the styles from the original component.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Navigate through the setup wizard, and make sure it looks like the design.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/171664826-717ef372-d624-47ff-9372-ee407d1a1749.mov

