### PR TITLE
Fix patterns styles for TwentyTwenty One

### DIFF
--- a/assets/blocks/button/button-edit.js
+++ b/assets/blocks/button/button-edit.js
@@ -38,7 +38,7 @@ const ButtonEdit = ( props ) => {
 					value={ text }
 					onChange={ ( value ) => setAttributes( { text: value } ) }
 					{ ...buttonProps }
-					tagName="a"
+					tagName="div"
 					identifier="text"
 					withoutInteractiveFormatting={ true }
 				/>

--- a/includes/block-patterns/course/templates/long-sales-page.php
+++ b/includes/block-patterns/course/templates/long-sales-page.php
@@ -10,8 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaType":"image","mediaWidth":58,"mediaSizeSlug":"full","verticalAlignment":"center","imageFill":false,"style":{"color":{"background":"#121c1c"},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"textColor":"background"} -->
-<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile is-vertically-aligned-center has-background-color has-text-color has-background has-link-color" style="background-color:#121c1c;grid-template-columns:auto 58%"><figure class="wp-block-media-text__media"><img src="<?php echo esc_url( Sensei()->assets->get_image( 'patterns-long-sales-01.jpg' ) ); ?>" alt="" /></figure><div class="wp-block-media-text__content"><!-- wp:group {"style":{"spacing":{"padding":{"top":"2em","right":"2em","bottom":"2em","left":"2em"}},"elements":{"link":{"color":{"text":"#fffdc7"}}}},"layout":{"inherit":false}} -->
+<!-- wp:media-text {"align":"full","mediaPosition":"right","mediaType":"image","mediaWidth":58,"mediaSizeSlug":"full","verticalAlignment":"center","imageFill":false,"style":{"color":{"background":"#121c1c","text":"#ffffff"},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}}} -->
+<div class="wp-block-media-text alignfull has-media-on-the-right is-stacked-on-mobile is-vertically-aligned-center has-text-color has-background has-link-color" style="background-color:#121c1c;color:#ffffff;grid-template-columns:auto 58%"><figure class="wp-block-media-text__media"><img src="<?php echo esc_url( Sensei()->assets->get_image( 'patterns-long-sales-01.jpg' ) ); ?>" alt=""/></figure><div class="wp-block-media-text__content"><!-- wp:group {"style":{"spacing":{"padding":{"top":"2em","right":"2em","bottom":"2em","left":"2em"}},"elements":{"link":{"color":{"text":"#fffdc7"}}}},"layout":{"inherit":false}} -->
 <div class="wp-block-group has-link-color" style="padding-top:2em;padding-right:2em;padding-bottom:2em;padding-left:2em"><!-- wp:heading {"level":1,"style":{"typography":{"fontWeight":"700","fontSize":"48px","lineHeight":"1.15"}}} -->
 <h1 style="font-size:48px;font-weight:700;line-height:1.15"><strong><?php esc_html_e( 'Deep dive into portrait photography', 'sensei-lms' ); ?></strong></h1>
 <!-- /wp:heading -->
@@ -74,8 +74,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dlarge, 8rem)","bottom":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dlarge, 8rem)"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"color":{"background":"#121c1c"}},"textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-text-color has-background has-link-color" style="background-color:#121c1c;padding-top:var(--wp--custom--spacing--large, 8rem);padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:heading -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dlarge, 8rem)","bottom":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dlarge, 8rem)"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"color":{"background":"#121c1c","text":"#ffffff"}},"layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-text-color has-background has-link-color" style="background-color:#121c1c;color:#ffffff;padding-top:var(--wp--custom--spacing--large, 8rem);padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:heading -->
 <h2><?php esc_html_e( 'What you will learn to master', 'sensei-lms' ); ?></h2>
 <!-- /wp:heading -->
 
@@ -202,8 +202,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- /wp:media-text --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"6rem","bottom":"4rem"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:6rem;padding-bottom:4rem"><!-- wp:columns {"align":"wide"} -->
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"6rem","bottom":"4rem"}},"color":{"background":"#000000","text":"#ffffff"}},"layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-text-color has-background has-link-color" style="background-color:#000000;color:#ffffff;padding-top:6rem;padding-bottom:4rem"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:heading {"fontSize":"x-large"} -->
 <h2 class="has-x-large-font-size" id="extended-trailer"><?php esc_html_e( 'Jeff at work', 'sensei-lms' ); ?></h2>
@@ -247,8 +247,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:group {"backgroundColor":"foreground","textColor":"background","layout":{"inherit":false}} -->
-<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background"><!-- wp:spacer {"height":16} -->
+<!-- wp:group {"style":{"color":{"text":"#ffffff","background":"#000000"}},"layout":{"inherit":false}} -->
+<div class="wp-block-group has-text-color has-background" style="background-color:#000000;color:#ffffff"><!-- wp:spacer {"height":16} -->
 <div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 

--- a/includes/block-patterns/course/templates/long-sales-page.php
+++ b/includes/block-patterns/course/templates/long-sales-page.php
@@ -74,8 +74,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dlarge, 8rem)","bottom":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dlarge, 8rem)"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"color":{"background":"#121c1c","text":"#ffffff"}},"layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-text-color has-background has-link-color" style="background-color:#121c1c;color:#ffffff;padding-top:var(--wp--custom--spacing--large, 8rem);padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:heading -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"120px","top":"120px","right":"90px","left":"90px"}},"color":{"background":"#121c1c","text":"#ffffff"}},"layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-text-color has-background" style="background-color:#121c1c;color:#ffffff;padding-top:120px;padding-right:90px;padding-bottom:120px;padding-left:90px"><!-- wp:heading -->
 <h2><?php esc_html_e( 'What you will learn to master', 'sensei-lms' ); ?></h2>
 <!-- /wp:heading -->
 
@@ -84,8 +84,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- /wp:spacer -->
 
 <!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull"><!-- wp:separator {"opacity":"css","backgroundColor":"background","className":"alignwide is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-background-color has-css-opacity has-background-background-color has-background alignwide is-style-wide"/>
+<div class="wp-block-group alignfull"><!-- wp:separator {"style":{"color":{"background":"#ffffff40"}},"className":"alignwide is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background alignwide is-style-wide" style="background-color:#ffffff40;color:#ffffff40"/>
 <!-- /wp:separator -->
 
 <!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
@@ -106,8 +106,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:separator {"opacity":"css","backgroundColor":"background","className":"alignwide is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-background-color has-css-opacity has-background-background-color has-background alignwide is-style-wide"/>
+<!-- wp:separator {"style":{"color":{"background":"#ffffff40"}},"className":"alignwide is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background alignwide is-style-wide" style="background-color:#ffffff40;color:#ffffff40"/>
 <!-- /wp:separator -->
 
 <!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
@@ -128,8 +128,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:separator {"opacity":"css","backgroundColor":"background","className":"alignwide is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-background-color has-css-opacity has-background-background-color has-background alignwide is-style-wide"/>
+<!-- wp:separator {"style":{"color":{"background":"#ffffff40"}},"className":"alignwide is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background alignwide is-style-wide" style="background-color:#ffffff40;color:#ffffff40"/>
 <!-- /wp:separator -->
 
 <!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
@@ -150,8 +150,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:separator {"opacity":"css","backgroundColor":"background","className":"alignwide is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-background-color has-css-opacity has-background-background-color has-background alignwide is-style-wide"/>
+<!-- wp:separator {"style":{"color":{"background":"#ffffff40"}},"className":"alignwide is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background alignwide is-style-wide" style="background-color:#ffffff40;color:#ffffff40"/>
 <!-- /wp:separator -->
 
 <!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
@@ -172,8 +172,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 
-<!-- wp:separator {"opacity":"css","backgroundColor":"background","className":"alignwide is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-background-color has-css-opacity has-background-background-color has-background alignwide is-style-wide"/>
+<!-- wp:separator {"style":{"color":{"background":"#ffffff40"}},"className":"alignwide is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-alpha-channel-opacity has-background alignwide is-style-wide" style="background-color:#ffffff40;color:#ffffff40"/>
 <!-- /wp:separator --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group -->
@@ -202,8 +202,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- /wp:media-text --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"6rem","bottom":"4rem"}},"color":{"background":"#000000","text":"#ffffff"}},"layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-text-color has-background has-link-color" style="background-color:#000000;color:#ffffff;padding-top:6rem;padding-bottom:4rem"><!-- wp:columns {"align":"wide"} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"6rem","bottom":"4rem","right":"90px","left":"90px"}},"color":{"background":"#000000","text":"#ffffff"}},"layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-text-color has-background" style="background-color:#000000;color:#ffffff;padding-top:6rem;padding-right:90px;padding-bottom:4rem;padding-left:90px"><!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:heading {"fontSize":"x-large"} -->
 <h2 class="has-x-large-font-size" id="extended-trailer"><?php esc_html_e( 'Jeff at work', 'sensei-lms' ); ?></h2>
@@ -247,8 +247,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:group {"style":{"color":{"text":"#ffffff","background":"#000000"}},"layout":{"inherit":false}} -->
-<div class="wp-block-group has-text-color has-background" style="background-color:#000000;color:#ffffff"><!-- wp:spacer {"height":16} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"90px","bottom":"20px","left":"90px"}},"color":{"background":"#000000","text":"#ffffff"}},"layout":{"inherit":false}} -->
+<div class="wp-block-group has-text-color has-background" style="background-color:#000000;color:#ffffff;padding-top:20px;padding-right:90px;padding-bottom:20px;padding-left:90px"><!-- wp:spacer {"height":16} -->
 <div style="height:16px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 

--- a/includes/block-patterns/course/templates/video-hero.php
+++ b/includes/block-patterns/course/templates/video-hero.php
@@ -184,8 +184,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link has-text-color has-background" style="background-color:#ffffff;color:#000000"><?php esc_html_e( 'Take Course', 'sensei-lms' ); ?></button></div>
 <!-- /wp:sensei-lms/button-take-course -->
 
-<!-- wp:sensei-lms/button-contact-teacher -->
-<div class="wp-block-sensei-lms-button-contact-teacher is-style-outline wp-block-sensei-button wp-block-button has-text-align-left"><a class="wp-block-button__link"><?php esc_html_e( 'Contact Teacher', 'sensei-lms' ); ?></a></div>
+<!-- wp:sensei-lms/button-contact-teacher {"style":{"color":{"text":"#ffffff"}}} -->
+<div class="wp-block-sensei-lms-button-contact-teacher is-style-outline wp-block-sensei-button wp-block-button has-text-align-left"><a class="wp-block-button__link has-text-color" style="color:#ffffff"><?php esc_html_e( 'Contact Teacher', 'sensei-lms' ); ?></a></div>
 <!-- /wp:sensei-lms/button-contact-teacher --></div>
 <!-- /wp:group -->
 

--- a/includes/block-patterns/course/templates/video-hero.php
+++ b/includes/block-patterns/course/templates/video-hero.php
@@ -10,10 +10,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dlarge, 8rem)","bottom":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dlarge, 8rem)"}},"elements":{"link":{"color":{"text":"var:preset|color|secondary"}}}},"backgroundColor":"foreground","textColor":"secondary"} -->
-<div class="wp-block-group alignfull has-secondary-color has-foreground-background-color has-text-color has-background has-link-color" style="padding-top:var(--wp--custom--spacing--large, 8rem);padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:group {"align":"full","layout":{"inherit":false}} -->
-<div class="wp-block-group alignfull"><!-- wp:heading {"level":1,"align":"wide","style":{"typography":{"fontSize":"clamp(3rem, 6vw, 4.5rem)"}},"textColor":"tertiary"} -->
-<h1 class="alignwide has-tertiary-color has-text-color" id="warble-a-film-about-hobbyist-bird-watchers-1" style="font-size:clamp(3rem, 6vw, 4.5rem)"><?php esc_html_e( 'Welcome to the Film Direction Course', 'sensei-lms' ); ?></h1>
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dlarge, 8rem)","bottom":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dlarge, 8rem)"}},"color":{"background":"#000000","text":"#ffffff"}}} -->
+<div class="wp-block-group alignfull has-text-color has-background" style="background-color:#000000;color:#ffffff;padding-top:var(--wp--custom--spacing--large, 8rem);padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:group {"align":"full","layout":{"inherit":false}} -->
+<div class="wp-block-group alignfull"><!-- wp:heading {"level":1,"align":"wide","style":{"typography":{"fontSize":"clamp(3rem, 6vw, 4.5rem)"}}} -->
+<h1 class="alignwide" style="font-size:clamp(3rem, 6vw, 4.5rem)"><?php esc_html_e( 'Welcome to the Film Direction Course', 'sensei-lms' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:spacer {"height":32} -->
@@ -24,8 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <figure class="wp-block-video alignwide"><video controls src="<?php echo esc_url( Sensei()->assets->get_image( 'patterns-video.mp4' ) ); ?>"></video></figure>
 <!-- /wp:video -->
 
-<!-- wp:columns {"align":"wide","textColor":"tertiary"} -->
-<div class="wp-block-columns alignwide has-tertiary-color has-text-color"><!-- wp:column {"width":"50%"} -->
+<!-- wp:columns {"align":"wide"} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"width":"50%"} -->
 <div class="wp-block-column" style="flex-basis:50%"><!-- wp:paragraph -->
 <p><strong>Doug Stilton</strong></p>
 <!-- /wp:paragraph --></div>
@@ -38,8 +38,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- /wp:column -->
 
 <!-- wp:column -->
-<div class="wp-block-column"><!-- wp:sensei-lms/button-take-course {"align":"right","backgroundColor":"tertiary","textColor":"foreground"} -->
-<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><button class="wp-block-button__link has-foreground-color has-tertiary-background-color has-text-color has-background"><?php esc_html_e( 'Take Course', 'sensei-lms' ); ?></button></div>
+<div class="wp-block-column"><!-- wp:sensei-lms/button-take-course {"align":"right","style":{"color":{"text":"#000000","background":"#ffffff"}}} -->
+<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><button class="wp-block-button__link has-text-color has-background" style="background-color:#ffffff;color:#000000"><?php esc_html_e( 'Take Course', 'sensei-lms' ); ?></button></div>
 <!-- /wp:sensei-lms/button-take-course --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns --></div>
@@ -150,8 +150,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:group {"backgroundColor":"foreground","textColor":"background"} -->
-<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background"><!-- wp:spacer {"height":24} -->
+<!-- wp:group {"style":{"color":{"text":"#ffffff","background":"#000000"}}} -->
+<div class="wp-block-group has-text-color has-background" style="background-color:#000000;color:#ffffff"><!-- wp:spacer {"height":24} -->
 <div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
@@ -180,8 +180,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- /wp:spacer -->
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:sensei-lms/button-take-course {"align":"left","backgroundColor":"background","textColor":"foreground"} -->
-<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link has-foreground-color has-background-background-color has-text-color has-background"><?php esc_html_e( 'Take Course', 'sensei-lms' ); ?></button></div>
+<div class="wp-block-group"><!-- wp:sensei-lms/button-take-course {"align":"left","style":{"color":{"text":"#000000","background":"#ffffff"}}} -->
+<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link has-text-color has-background" style="background-color:#ffffff;color:#000000"><?php esc_html_e( 'Take Course', 'sensei-lms' ); ?></button></div>
 <!-- /wp:sensei-lms/button-take-course -->
 
 <!-- wp:sensei-lms/button-contact-teacher -->

--- a/includes/block-patterns/course/templates/video-hero.php
+++ b/includes/block-patterns/course/templates/video-hero.php
@@ -10,8 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dlarge, 8rem)","bottom":"var(\u002d\u002dwp\u002d\u002dcustom\u002d\u002dspacing\u002d\u002dlarge, 8rem)"}},"color":{"background":"#000000","text":"#ffffff"}}} -->
-<div class="wp-block-group alignfull has-text-color has-background" style="background-color:#000000;color:#ffffff;padding-top:var(--wp--custom--spacing--large, 8rem);padding-bottom:var(--wp--custom--spacing--large, 8rem)"><!-- wp:group {"align":"full","layout":{"inherit":false}} -->
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"120px","bottom":"120px","right":"90px","left":"90px"}},"color":{"text":"#ffffff","background":"#000000"}}} -->
+<div class="wp-block-group alignfull has-text-color has-background" style="background-color:#000000;color:#ffffff;padding-top:120px;padding-right:90px;padding-bottom:120px;padding-left:90px"><!-- wp:group {"align":"full","layout":{"inherit":false}} -->
 <div class="wp-block-group alignfull"><!-- wp:heading {"level":1,"align":"wide","style":{"typography":{"fontSize":"clamp(3rem, 6vw, 4.5rem)"}}} -->
 <h1 class="alignwide" style="font-size:clamp(3rem, 6vw, 4.5rem)"><?php esc_html_e( 'Welcome to the Film Direction Course', 'sensei-lms' ); ?></h1>
 <!-- /wp:heading -->
@@ -70,8 +70,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- /wp:group --></div>
 <!-- /wp:group -->
 
-<!-- wp:group {"align":"full","style":{"color":{"background":"#f8f4e4"}}} -->
-<div class="wp-block-group alignfull has-background" style="background-color:#f8f4e4"><!-- wp:spacer {"height":24} -->
+<!-- wp:group {"align":"full","style":{"color":{"background":"#f8f4e4"},"spacing":{"padding":{"top":"20px","left":"90px","right":"90px","bottom":"20px"}}}} -->
+<div class="wp-block-group alignfull has-background" style="background-color:#f8f4e4;padding-top:20px;padding-right:90px;padding-bottom:20px;padding-left:90px"><!-- wp:spacer {"height":24} -->
 <div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
@@ -150,8 +150,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:group {"style":{"color":{"text":"#ffffff","background":"#000000"}}} -->
-<div class="wp-block-group has-text-color has-background" style="background-color:#000000;color:#ffffff"><!-- wp:spacer {"height":24} -->
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"90px","bottom":"20px","left":"90px"}},"color":{"text":"#ffffff","background":"#000000"}}} -->
+<div class="wp-block-group has-text-color has-background" style="background-color:#000000;color:#ffffff;padding-top:20px;padding-right:90px;padding-bottom:20px;padding-left:90px"><!-- wp:spacer {"height":24} -->
 <div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 


### PR DESCRIPTION
Part of #5218
Based on https://github.com/Automattic/sensei/pull/5206

### Changes proposed in this Pull Request

* It fixes the pattern styles for TwentyTwenty One. Two main changes were needed for that:
  * In the editor, now we display the buttons as `div`. So it will work more similarly to the original Buttons block, getting the correct styles.
  * It changes some colors from the patterns to use custom colors instead of the theme color. The theme color can vary a lot from theme to theme, so I risk saying that it's not a good practice for patterns.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Activate the TwentyTwenty One theme.
* Create 2 courses with the different patterns.
* Make sure they work well in the editor and in the frontend.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/171732139-a9aecb51-edc7-423b-847d-8589d0118c50.mov