### PR TITLE
Fix lesson patterns placeholders

### DIFF
--- a/includes/block-patterns/lesson/templates/discussion-question.php
+++ b/includes/block-patterns/lesson/templates/discussion-question.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <!-- wp:group {"backgroundColor":"tertiary"} -->
-<div class="wp-block-group has-tertiary-background-color has-background"><!-- wp:paragraph {"placeholder":"<?php esc_html__( 'Write your discussion question topic or prompt here.', 'sensei-lms' ); ?>"} -->
+<div class="wp-block-group has-tertiary-background-color has-background"><!-- wp:paragraph {"placeholder":"<?php esc_html_e( 'Write your discussion question topic or prompt here.', 'sensei-lms' ); ?>"} -->
 <p></p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:group -->

--- a/includes/block-patterns/lesson/templates/video-lesson.php
+++ b/includes/block-patterns/lesson/templates/video-lesson.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <figure class="wp-block-video"></figure>
 <!-- /wp:video -->
 
-<!-- wp:paragraph {"placeholder":"<?php esc_html__( 'Include a transcript, link to a transcript, or a summary of the video.', 'sensei-lms' ); ?>"} -->
+<!-- wp:paragraph {"placeholder":"<?php esc_html_e( 'Include a transcript, link to a transcript, or a summary of the video.', 'sensei-lms' ); ?>"} -->
 <p></p>
 <!-- /wp:paragraph -->
 


### PR DESCRIPTION
It fixes the issues reported in https://github.com/Automattic/sensei/pull/5206#pullrequestreview-993104910

### Changes proposed in this Pull Request

* It fixes 2 lesson patterns placeholders.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Check the discussion question pattern and the video lesson pattern while creating a new lesson.
* Make sure they have the placeholders:
  * _"Write your discussion question topic or prompt here."_
  * _"Include a transcript, link to a transcript, or a summary of the video."_