### PR TITLE
Set course excerpt and load lesson title.

### DIFF
--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -32,6 +32,7 @@ const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 			...wizardData,
 			courseDescription: description,
 		} );
+		editPost( { excerpt: description } );
 	};
 
 	return (

--- a/assets/admin/editor-wizard/steps/course-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.test.js
@@ -40,7 +40,7 @@ describe( '<CourseDetailsStep />', () => {
 		expect( editPostMock ).toBeCalledTimes( 0 );
 	} );
 
-	it( 'Updates course title in data and as title post when changed.', () => {
+	it( 'Updates course title in data and as post title when changed.', () => {
 		const editPostMock = jest.fn();
 		const setDataMock = jest.fn();
 		const NEW_TITLE = 'Some new title';
@@ -57,7 +57,7 @@ describe( '<CourseDetailsStep />', () => {
 		expect( setDataMock ).toBeCalledWith( { courseTitle: NEW_TITLE } );
 	} );
 
-	it( 'Updates course description in data when changed.', () => {
+	it( 'Updates course description in data and as post excerpt when changed.', () => {
 		const editPostMock = jest.fn();
 		const setDataMock = jest.fn();
 		const NEW_DESCRIPTION = 'Some new description';
@@ -70,7 +70,7 @@ describe( '<CourseDetailsStep />', () => {
 			target: { value: NEW_DESCRIPTION },
 		} );
 
-		expect( editPostMock ).toBeCalledTimes( 0 );
+		expect( editPostMock ).toBeCalledWith( { excerpt: NEW_DESCRIPTION } );
 		expect( setDataMock ).toBeCalledWith( {
 			courseDescription: NEW_DESCRIPTION,
 		} );

--- a/assets/admin/editor-wizard/steps/course-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.test.js
@@ -15,6 +15,7 @@ import { useDispatch } from '@wordpress/data';
 import CourseDetailsStep from './course-details-step';
 
 jest.mock( '@wordpress/data' );
+jest.mock( '@wordpress/editor' );
 
 const ANY_PLUGIN_URL = 'https://some-url/';
 

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -20,7 +20,7 @@ import detailsStepImage from '../../../images/details-step.png';
  * @param {Function} props.setData
  */
 const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
-	const [ postTitle, updateLessonTitle ] = useLessonTitle(
+	const [ lessonTitle, updateLessonTitle ] = useLessonTitle(
 		wizardData,
 		setWizardData
 	);
@@ -40,7 +40,7 @@ const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 				<div className="sensei-editor-wizard-step__form">
 					<LimitedTextControl
 						label={ __( 'Lesson Title', 'sensei-lms' ) }
-						value={ wizardData.lessonTitle ?? postTitle }
+						value={ lessonTitle }
 						onChange={ updateLessonTitle }
 						maxLength={ 40 }
 					/>
@@ -90,7 +90,7 @@ const useLessonTitle = ( wizardData, setWizardData ) => {
 			title: newTitle,
 		} );
 	};
-	return [ title, updateLessonTitle ];
+	return [ wizardData.lessonTitle ?? title, updateLessonTitle ];
 };
 
 export default LessonDetailsStep;

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -20,15 +20,10 @@ import detailsStepImage from '../../../images/details-step.png';
  * @param {Function} props.setData
  */
 const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
-	const { editPost } = useDispatch( editorStore );
-	const postTitle = usePostTitle();
-
-	const updateLessonTitle = ( title ) => {
-		setWizardData( { ...wizardData, lessonTitle: title } );
-		editPost( {
-			title,
-		} );
-	};
+	const [ postTitle, updateLessonTitle ] = useLessonTitle(
+		wizardData,
+		setWizardData
+	);
 
 	return (
 		<div className="sensei-editor-wizard-modal__columns">
@@ -81,13 +76,21 @@ LessonDetailsStep.Actions = ( { goToNextStep } ) => {
 /**
  * Load the post title from the Editor Store.
  *
- * @return {string} The post title from the editor.
+ * @param {Object}   wizardData    The wizard data.
+ * @param {Function} setWizardData Function to update the wizard data.
  */
-const usePostTitle = () => {
+const useLessonTitle = ( wizardData, setWizardData ) => {
+	const { editPost } = useDispatch( editorStore );
 	const { title } = useSelect( ( select ) => ( {
 		title: select( editorStore )?.getEditedPostAttribute( 'title' ),
 	} ) );
-	return title;
+	const updateLessonTitle = ( newTitle ) => {
+		setWizardData( { ...wizardData, lessonTitle: newTitle } );
+		editPost( {
+			title: newTitle,
+		} );
+	};
+	return [ title, updateLessonTitle ];
 };
 
 export default LessonDetailsStep;

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { Button } from '@wordpress/components';
 
@@ -21,6 +21,7 @@ import detailsStepImage from '../../../images/details-step.png';
  */
 const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 	const { editPost } = useDispatch( editorStore );
+	const postTitle = usePostTitle();
 
 	const updateLessonTitle = ( title ) => {
 		setWizardData( { ...wizardData, lessonTitle: title } );
@@ -44,7 +45,7 @@ const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 				<div className="sensei-editor-wizard-step__form">
 					<LimitedTextControl
 						label={ __( 'Lesson Title', 'sensei-lms' ) }
-						value={ wizardData.lessonTitle ?? '' }
+						value={ wizardData.lessonTitle ?? postTitle }
 						onChange={ updateLessonTitle }
 						maxLength={ 40 }
 					/>
@@ -64,12 +65,29 @@ const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 	);
 };
 
+/**
+ * Actions for the LessonDetailsStep.
+ *
+ * @param {Function} goToNextStep Invoke to go to the next step.
+ */
 LessonDetailsStep.Actions = ( { goToNextStep } ) => {
 	return (
 		<Button isPrimary onClick={ goToNextStep }>
 			{ __( 'Continue', 'sensei-lms' ) }
 		</Button>
 	);
+};
+
+/**
+ * Load the post title from the Editor Store.
+ *
+ * @return {string} The post title from the editor.
+ */
+const usePostTitle = () => {
+	const { title } = useSelect( ( select ) => ( {
+		title: select( editorStore )?.getEditedPostAttribute( 'title' ),
+	} ) );
+	return title;
 };
 
 export default LessonDetailsStep;

--- a/assets/admin/editor-wizard/steps/lesson-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.test.js
@@ -7,7 +7,7 @@ import '@testing-library/jest-dom';
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useDispatch, useSelect } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -17,6 +17,7 @@ import LessonDetailsStep from './lesson-details-step';
 jest.mock( '@wordpress/data' );
 
 const ANY_PLUGIN_URL = 'https://some-url/';
+const ANY_LESSON_TITLE = 'Any lesson title.';
 
 describe( '<LessonDetailsStep />', () => {
 	beforeAll( () => {
@@ -27,9 +28,13 @@ describe( '<LessonDetailsStep />', () => {
 			},
 		} );
 	} );
+	afterEach( () => {
+		jest.resetAllMocks();
+	} );
 	it( 'Renders title input field and not calls savePost initially.', () => {
 		const editPostMock = jest.fn();
 		useDispatch.mockReturnValue( { editPost: editPostMock } );
+		useSelect.mockReturnValue( { title: ANY_LESSON_TITLE } );
 
 		const { queryByLabelText } = render(
 			<LessonDetailsStep data={ {} } setData={ () => {} } />
@@ -44,6 +49,7 @@ describe( '<LessonDetailsStep />', () => {
 		const setDataMock = jest.fn();
 		const NEW_TITLE = 'Some new title';
 		useDispatch.mockReturnValue( { editPost: editPostMock } );
+		useSelect.mockReturnValue( { title: ANY_LESSON_TITLE } );
 
 		const { queryByLabelText } = render(
 			<LessonDetailsStep data={ {} } setData={ setDataMock } />
@@ -54,6 +60,21 @@ describe( '<LessonDetailsStep />', () => {
 
 		expect( editPostMock ).toBeCalledWith( { title: NEW_TITLE } );
 		expect( setDataMock ).toBeCalledWith( { lessonTitle: NEW_TITLE } );
+	} );
+
+	it( 'Renders post title in title field initially.', () => {
+		const editPostMock = jest.fn();
+		useDispatch.mockReturnValue( { editPost: editPostMock } );
+		useSelect.mockReturnValue( { title: ANY_LESSON_TITLE } );
+
+		const { queryByLabelText } = render(
+			<LessonDetailsStep data={ {} } setData={ () => {} } />
+		);
+
+		expect( queryByLabelText( 'Lesson Title' ) ).toBeTruthy();
+		expect( queryByLabelText( 'Lesson Title' ) ).toHaveDisplayValue(
+			ANY_LESSON_TITLE
+		);
 	} );
 } );
 

--- a/assets/admin/editor-wizard/steps/lesson-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.test.js
@@ -15,6 +15,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import LessonDetailsStep from './lesson-details-step';
 
 jest.mock( '@wordpress/data' );
+jest.mock( '@wordpress/editor' );
 
 const ANY_PLUGIN_URL = 'https://some-url/';
 const ANY_LESSON_TITLE = 'Any lesson title.';


### PR DESCRIPTION
Fixes #5213

### Changes proposed in this Pull Request
* Persist Course description in the post excerpt.
* Load Lesson title from post title if available.
* Fix tests. 

### Testing instructions
* Create a Course and set a description using the Wizard.
* Choose a pattern with a courses outline (or the default one).
* Check that the description is added as the excerpt (right sidebar).
* The course outline should have some Lessons named "Lesson 1", "Lesson 2"... in draft status.
* Go to edit one of the lessons and you should see the wizard.
* The title "Lesson 1/2/3" should appear in the title field prefilled. 

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
<img width="1528" alt="image" src="https://user-images.githubusercontent.com/799065/171859608-136bc4b3-7d9e-4848-b104-7dcc2b9547d4.png">
<img width="1184" alt="image" src="https://user-images.githubusercontent.com/799065/171859717-e0705163-48d5-4e3a-b15e-e30298987251.png">


## Some context / explanations
In the original ticket #5213 the proposal was to remove the `wizardData` and replace it with the editorStore as the single source of truth.
I implement it that way and it was working, but when fixing the tests I realised that we were coupling everything to the editorStore structure. Currently that would work but I was afraid we needed some field in the future to be used in the patterns that do not fit in the Post entity. In fact using the excerpt for the description already looks like a little questionable to me.

We can discuss on that and I can work over it again if somebody finds a good reason for that :) 