### PR TITLE
Tweak Course pattern Lesson titles

### DIFF
--- a/includes/block-patterns/course/templates/long-sales-page.php
+++ b/includes/block-patterns/course/templates/long-sales-page.php
@@ -259,13 +259,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- wp:sensei-lms/course-progress /-->
 
 <!-- wp:sensei-lms/course-outline -->
-<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Lighting for portraiture', 'sensei-lms' ); ?>"} /-->
+<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Lesson 1', 'sensei-lms' ); ?>"} /-->
 
-<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Three-point lighting', 'sensei-lms' ); ?>"} /-->
+<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Lesson 2', 'sensei-lms' ); ?>"} /-->
 
-<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Key light', 'sensei-lms' ); ?>"} /-->
-
-<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Fill light', 'sensei-lms' ); ?>"} /-->
+<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Lesson 3', 'sensei-lms' ); ?>"} /-->
 <!-- /wp:sensei-lms/course-outline -->
 
 <!-- wp:sensei-lms/button-take-course {"textColor":"background"} -->

--- a/includes/block-patterns/course/templates/video-hero.php
+++ b/includes/block-patterns/course/templates/video-hero.php
@@ -166,13 +166,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- wp:sensei-lms/course-progress /-->
 
 <!-- wp:sensei-lms/course-outline -->
-<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Introduction', 'sensei-lms' ); ?>"} /-->
+<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Lesson 1', 'sensei-lms' ); ?>"} /-->
 
-<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( "Meeting Doug's network", 'sensei-lms' ); ?>"} /-->
+<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Lesson 2', 'sensei-lms' ); ?>"} /-->
 
-<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Start your journey', 'sensei-lms' ); ?>"} /-->
-
-<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'From script to film', 'sensei-lms' ); ?>"} /-->
+<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Lesson 3', 'sensei-lms' ); ?>"} /-->
 <!-- /wp:sensei-lms/course-outline -->
 
 <!-- wp:spacer {"height":8} -->


### PR DESCRIPTION
Fixes #5239 

### Changes proposed in this Pull Request

Change the Lesson titles to "Lesson 1", "Lesson 2", "Lesson 3" within Course patterns.

### Testing instructions

Create a new course. Choose a pattern from the last page of the wizard. Ensure that the Lessons added to the Course Outline have the above titles.
