### PR TITLE
Only load Discussion pattern if the Comments Query Loop block is available

### DIFF
--- a/includes/block-patterns/class-sensei-block-patterns.php
+++ b/includes/block-patterns/class-sensei-block-patterns.php
@@ -81,7 +81,10 @@ class Sensei_Block_Patterns {
 				'files-to-download',
 			];
 
-			if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/comments-query-loop' ) ) {
+			if (
+				WP_Block_Type_Registry::get_instance()->is_registered( 'core/comments-query-loop' )
+				|| version_compare( get_bloginfo( 'version' ), '6.0', '>=' )
+			) {
 				$block_patterns[] = 'discussion-question';
 			}
 		}

--- a/includes/block-patterns/class-sensei-block-patterns.php
+++ b/includes/block-patterns/class-sensei-block-patterns.php
@@ -78,9 +78,12 @@ class Sensei_Block_Patterns {
 		} elseif ( 'lesson' === $post_type ) {
 			$block_patterns = [
 				'video-lesson',
-				'discussion-question',
 				'files-to-download',
 			];
+
+			if ( WP_Block_Type_Registry::get_instance()->is_registered( 'core/comments-query-loop' ) ) {
+				$block_patterns[] = 'discussion-question';
+			}
 		}
 
 		foreach ( $block_patterns as $block_pattern ) {


### PR DESCRIPTION
Fixes #5223

### Changes proposed in this Pull Request

Do not load the Discussion pattern if the Comments Query Loop block is unavailable.

### Testing instructions

**Install WordPress 5.8.4 (you may want to use the WP Downgrade plugin for this).**

- Add a new Lesson and walk through the wizard.
- Ensure that the "Discussion Question" pattern **is not** available in the wizard.
- Ensure that the "Discussion Question" pattern **is not** available in the inserter.

**Install the latest version of the Gutenberg plugin.**

- Add a new Lesson and walk through the wizard.
- Ensure that the "Discussion Question" pattern **is** available in the wizard.
- Ensure that the "Discussion Question" pattern **is** available in the inserter.

**Uninstall the Gutenberg plugin, and upgrade to WordPress 6.0 or newer.**

- Add a new Lesson and walk through the wizard.
- Ensure that the "Discussion Question" pattern **is** available in the wizard.
- Ensure that the "Discussion Question" pattern **is** available in the inserter.

### Note

This PR also changes the order of the Lesson patterns, so Discussion Question is at the bottom. Is this ok? Should we insert it in the list where it was before (in the middle) for design purposes?