### PR TITLE
Fix icons in the upgrade step

### DIFF
--- a/assets/admin/editor-wizard/steps/course-upgrade-step.js
+++ b/assets/admin/editor-wizard/steps/course-upgrade-step.js
@@ -10,6 +10,7 @@ import { useSelect } from '@wordpress/data';
  */
 import { EXTENSIONS_STORE } from '../../../extensions/store';
 import senseiProUpsellImage from '../../../images/sensei-pro-upsell.png';
+import CheckIcon from '../../../icons/checked.svg';
 
 /**
  * Upgrade step during course creation wizard.
@@ -47,27 +48,27 @@ const CourseUpgradeStep = () => {
 					{ __( 'per year, 1 site', 'sensei-lms' ) }
 				</span>
 				<ul className="sensei-editor-wizard-modal-upsell__features">
-					<li className="sensei-editor-wizard-modal-upsell__feature-item">
+					<FeatureItem>
 						{ __( 'WooCommerce integration', 'sensei-lms' ) }
-					</li>
-					<li className="sensei-editor-wizard-modal-upsell__feature-item">
+					</FeatureItem>
+					<FeatureItem>
 						{ __( "Schedule 'drip' content", 'sensei-lms' ) }
-					</li>
-					<li className="sensei-editor-wizard-modal-upsell__feature-item">
+					</FeatureItem>
+					<FeatureItem>
 						{ __( 'Set expiration date of courses', 'sensei-lms' ) }
-					</li>
-					<li className="sensei-editor-wizard-modal-upsell__feature-item">
+					</FeatureItem>
+					<FeatureItem>
 						{ __( 'Quiz timer', 'sensei-lms' ) }
-					</li>
-					<li className="sensei-editor-wizard-modal-upsell__feature-item">
+					</FeatureItem>
+					<FeatureItem>
 						{ __(
 							'Flashcards, Image Hotspots, and Checklists',
 							'sensei-lms'
 						) }
-					</li>
-					<li className="sensei-editor-wizard-modal-upsell__feature-item">
+					</FeatureItem>
+					<FeatureItem>
 						{ __( '1 year of updates & support', 'sensei-lms' ) }
-					</li>
+					</FeatureItem>
 				</ul>
 			</div>
 			<div className="sensei-editor-wizard-modal__illustration">
@@ -83,6 +84,13 @@ const CourseUpgradeStep = () => {
 		</div>
 	);
 };
+
+const FeatureItem = ( { children } ) => (
+	<li className="sensei-editor-wizard-modal-upsell__feature-item">
+		<CheckIcon className="sensei-editor-wizard-modal-upsell__feature-item-icon" />
+		{ children }
+	</li>
+);
 
 CourseUpgradeStep.Actions = ( { goToNextStep } ) => {
 	const upgrade = () => {

--- a/assets/admin/editor-wizard/steps/course-upgrade-step.js
+++ b/assets/admin/editor-wizard/steps/course-upgrade-step.js
@@ -85,6 +85,12 @@ const CourseUpgradeStep = () => {
 	);
 };
 
+/**
+ * Item of the feature list in the Upgrade Step
+ *
+ * @param {Object} props          Component Props
+ * @param {string} props.children Text to be included after the feature item icon
+ */
 const FeatureItem = ( { children } ) => (
 	<li className="sensei-editor-wizard-modal-upsell__feature-item">
 		<CheckIcon className="sensei-editor-wizard-modal-upsell__feature-item-icon" />

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -135,7 +135,7 @@
 		padding: 0 0 20px 24px;
 		margin: 0;
 		display: flex;
-		align-content: center;
+		align-items: center;
 	}
 
 	&__feature-item-icon {

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -142,6 +142,7 @@
 		width: 24px;
 		height: 24px;
 		margin-left: -24px;
+		margin-right: 6px;
 		color: #00998b;
 	}
 }

--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -134,15 +134,15 @@
 	&__feature-item {
 		padding: 0 0 20px 24px;
 		margin: 0;
+		display: flex;
+		align-content: center;
+	}
 
-		&::before {
-			content: "\f00c";
-			font-family: FontAwesomeSensei, FontAwesome;
-			display: inline-block;
-			margin-left: -24px;
-			width: 24px;
-			color: #00998b;
-		}
+	&__feature-item-icon {
+		width: 24px;
+		height: 24px;
+		margin-left: -24px;
+		color: #00998b;
 	}
 }
 


### PR DESCRIPTION
Fixes #5231

### Changes proposed in this Pull Request

* Change the icons used in the features list shown in the upgrade step;

### Testing instructions

1. Create a new course on a WordPress installation WITHOUT Sensei Pro;
2. Click "Continue" to advance to the upgrade step;
3. Verify if the icons now match the design in the Figma NyhJy9d7SwvDoIAXecN7eH-fi-1262%3A9084

### Screenshot / Video

![Screenshot of the Upgrade Step with the icons fixed](https://user-images.githubusercontent.com/529864/172727015-f8dac49f-5d05-4070-a927-d7e52b2512d8.png)
