### PR TITLE
Tweak wizard preview box sizing

### DIFF
--- a/assets/admin/editor-wizard/patterns-list.scss
+++ b/assets/admin/editor-wizard/patterns-list.scss
@@ -1,3 +1,7 @@
+$thumbnail-height: 235px;
+$preview-padding: 5px;
+$preview-max-height: $thumbnail-height - $preview-padding * 2;
+
 .sensei-patterns-list {
 	@media ( min-width: 600px ) {
 		column-count: 2;
@@ -6,7 +10,7 @@
 
 	&__item {
 		break-inside: avoid-column;
-		margin-bottom: 16px;
+		margin-bottom: 30px;
 		cursor: pointer;
 
 		&:last-child {
@@ -15,6 +19,18 @@
 
 		&-preview {
 			border: 1px solid #f0f0f0;
+			height: $thumbnail-height;
+			overflow: hidden;
+
+			display: flex;
+			justify-content: center;
+			align-items: center;
+			padding-top: $preview-padding;
+			padding-bottom: $preview-padding;
+
+			.block-editor-block-preview__container {
+				max-height: $preview-max-height;
+			}
 		}
 
 		&:hover &-preview,


### PR DESCRIPTION
### Changes proposed in this Pull Request

Add consistency to the sizing of the preview boxes, making it easier to visually parse.

Previews should be vertically centered within the box, unless they are too large in which case they should stick to the top and be cut off at the bottom.

### Testing instructions

View the Course and Lesson modals, go to the Patterns step, and ensure the boxes look consistent sizes and the vertical centering is working.

### Screenshots

**Lesson Patterns**

(Note that this screenshot doesn't include some of the styling improvements to the patterns themselves)

<img width="819" alt="Screen Shot 2022-06-09 at 17 04 19" src="https://user-images.githubusercontent.com/842193/172934485-c6ac081e-4c8d-418b-aae4-dae4f5fbc00a.png">

**Course Patterns**

cc @burtrw do we want these ones cut off as well? Or should this only happen for Lesson patterns?

<img width="815" alt="Screen Shot 2022-06-09 at 17 04 52" src="https://user-images.githubusercontent.com/842193/172934576-098067a3-0622-4ede-9ab7-dbf905e9c455.png">

