### PR TITLE
Fixes to the Upsell for Premium Lesson Patterns

### DIFF
--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -34,8 +34,8 @@ const LessonPatternsStep = ( { data, ...props } ) => {
 		replaces[ 'sensei-content-title' ] = data.lessonTitle;
 	}
 
-	const isSenseiProInstalled =
-		! senseiProExtension || senseiProExtension.is_installed === true;
+	const isSenseiProActivated =
+		! senseiProExtension || senseiProExtension.is_activated === true;
 
 	return (
 		<Fragment>
@@ -45,7 +45,7 @@ const LessonPatternsStep = ( { data, ...props } ) => {
 				{ ...props }
 			/>
 			<PatternsStep.UpsellFill>
-				{ isSenseiProInstalled ? null : <UpsellBlock /> }
+				{ isSenseiProActivated ? null : <UpsellBlock /> }
 			</PatternsStep.UpsellFill>
 		</Fragment>
 	);

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -59,14 +59,11 @@ const UpsellBlock = () => (
 		<LogoTreeIcon className="sensei-editor-wizard-patterns-upsell__logo" />
 		<div className="sensei-editor-wizard-patterns-upsell__text">
 			<b className="sensei-editor-wizard-patterns-upsell__title">
-				{ __(
-					'Want more lesson types, check out Sensei Pro.',
-					'sensei-lms'
-				) }
+				{ __( 'Want More Lesson Types?', 'sensei-lms' ) }
 			</b>
 			<br />
 			{ __(
-				'Flashcards, timed quizes, image hotspots, tasklists, and more.',
+				'Get flashcards, timed quizzes, image hotspots, and more with Sensei Pro.',
 				'sensei-lms'
 			) }{ ' ' }
 			<a
@@ -75,7 +72,7 @@ const UpsellBlock = () => (
 				rel="noreferrer external"
 				target="blank"
 			>
-				{ __( 'Learn more', 'sensei-lms' ) }
+				{ __( 'Learn more.', 'sensei-lms' ) }
 			</a>
 		</div>
 	</div>

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -73,6 +73,7 @@ const UpsellBlock = () => (
 				className="sensei-editor-wizard-patterns-upsell__link"
 				href="https://senseilms.com/pricing/?utm_source=plugin_sensei&utm_medium=upsell&utm_campaign=lesson_patterns_editor_wizard"
 				rel="noreferrer external"
+				target="blank"
 			>
 				{ __( 'Learn more', 'sensei-lms' ) }
 			</a>

--- a/assets/admin/editor-wizard/use-editor-wizard-steps.js
+++ b/assets/admin/editor-wizard/use-editor-wizard-steps.js
@@ -16,7 +16,7 @@ import { EXTENSIONS_STORE } from '../../extensions/store';
 
 /**
  * Returns the list of components (representing steps) for the Editor Wizard according to the post type and if
- * Sensei Pro is installed or not.
+ * Sensei Pro is activated or not.
  *
  * @return {Array} The list of components to show to the user.
  */
@@ -35,7 +35,7 @@ const useEditorWizardSteps = () => {
 		[]
 	);
 
-	if ( ! senseiProExtension || senseiProExtension.is_installed === true ) {
+	if ( ! senseiProExtension || senseiProExtension.is_activated === true ) {
 		stepsByPostType.course = stepsByPostType.course.filter(
 			( step ) => step !== CourseUpgradeStep
 		);

--- a/assets/admin/editor-wizard/use-editor-wizard-steps.test.js
+++ b/assets/admin/editor-wizard/use-editor-wizard-steps.test.js
@@ -36,10 +36,10 @@ describe( 'useEditorWizardSteps()', () => {
 		const steps = useEditorWizardSteps();
 		expect( steps ).toEqual( [ CourseDetailsStep, CoursePatternsStep ] );
 	} );
-	it( 'Should not have the course upgrade step when the post type is course and the Sensei Pro is installed', () => {
+	it( 'Should not have the course upgrade step when the post type is course and the Sensei Pro is activated', () => {
 		useSelect.mockReturnValue( {
 			postType: 'course',
-			senseiProExtension: { is_installed: true },
+			senseiProExtension: { is_activated: true },
 		} );
 		const steps = useEditorWizardSteps();
 		expect( steps ).toEqual( [ CourseDetailsStep, CoursePatternsStep ] );
@@ -47,7 +47,7 @@ describe( 'useEditorWizardSteps()', () => {
 	it( 'Should have all the lesson steps when the post type is lesson', () => {
 		useSelect.mockReturnValue( {
 			postType: 'lesson',
-			senseiProExtension: { is_installed: false },
+			senseiProExtension: { is_activated: false },
 		} );
 		const steps = useEditorWizardSteps();
 		expect( steps ).toEqual( [ LessonDetailsStep, LessonPatternsStep ] );

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -172,6 +172,7 @@ final class Sensei_Extensions {
 		$extensions = array_map(
 			function( $extension ) use ( $installed_plugins, $wccom_subscriptions ) {
 				$extension->is_installed = isset( $installed_plugins[ $extension->plugin_file ] );
+				$extension->is_activated = $extension->is_installed && is_plugin_active( $extension->plugin_file );
 
 				if ( $extension->is_installed ) {
 					$extension->installed_version = $installed_plugins[ $extension->plugin_file ]['Version'];

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard-api.php
@@ -405,6 +405,7 @@ class Sensei_Setup_Wizard_API_Test extends WP_Test_REST_TestCase {
 			'plugin_file'  => 'test/test.php',
 			'status'       => 'installing',
 			'is_installed' => false,
+			'is_activated' => false,
 		];
 		$sensei_extensions  = Sensei()->setup_wizard->get_sensei_extensions();
 

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -511,6 +511,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 				'status'       => 'installing',
 				'plugin_file'  => 'test/test.php',
 				'is_installed' => false,
+				'is_activated' => false,
 			],
 			(object) [
 				'product_slug' => 'slug-2',
@@ -518,17 +519,20 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 				'error'        => 'Error message',
 				'plugin_file'  => 'test/test.php',
 				'is_installed' => false,
+				'is_activated' => false,
 			],
 			(object) [
 				'product_slug' => 'slug-3',
 				'status'       => 'installed',
 				'plugin_file'  => 'test/test-installed.php',
 				'is_installed' => false,
+				'is_activated' => false,
 			],
 			(object) [
 				'product_slug' => 'slug-4',
 				'plugin_file'  => 'test/test.php',
 				'is_installed' => false,
+				'is_activated' => false,
 			],
 			get_transient( Sensei_Utils::WC_INFORMATION_TRANSIENT ),
 		];
@@ -565,6 +569,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 				'product_slug' => 'allowed',
 				'plugin_file'  => 'test/test.php',
 				'is_installed' => false,
+				'is_activated' => false,
 			],
 		];
 


### PR DESCRIPTION
Some fixes to the PR #5254

### Changes proposed in this Pull Request

* Open "Learn More" link in a new tab;
* Change CTA as [proposed here](https://github.com/Automattic/sensei/pull/5254#issuecomment-1152599583);
* Make the Upsells disappear only when Sensei Pro is installed AND activated;

### Testing instructions

In a WordPress installation with this code, and without Sensei Pro installed/activated: 

1. Create a new lesson, click on "Continue" in the editor wizard to go to the Lessons Patterns step;
2. Verify that the CTA on the upsell for Premium Lesson patterns changed according to [this comment](https://github.com/Automattic/sensei/pull/5254#issuecomment-1152599583);
3. Click on the "Learn More" link in the upsell, and check if it opens in a new tab;

Also, verify that both upsells (on the Course Wizard and on the Lesson Wizard) disappear when Sensei Pro is both installed AND activated.

### Screenshot / Video

![image](https://user-images.githubusercontent.com/529864/173128195-b2b37f3f-e2a9-42eb-b5ce-c54549a763c2.png)



