### PR TITLE
Make default lesson names translatable in the default course pattern

### DIFF
--- a/includes/block-patterns/course/templates/course-default.php
+++ b/includes/block-patterns/course/templates/course-default.php
@@ -21,9 +21,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 <!-- wp:sensei-lms/course-progress /-->
 
 <!-- wp:sensei-lms/course-outline -->
-<!-- wp:sensei-lms/course-outline-lesson {"title":"Lesson 1"} /-->
+<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Lesson 1', 'sensei-lms' ); ?>"} /-->
 
-<!-- wp:sensei-lms/course-outline-lesson {"title":"Lesson 2"} /-->
+<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Lesson 2', 'sensei-lms' ); ?>"} /-->
 
-<!-- wp:sensei-lms/course-outline-lesson {"title":"Lesson 3"} /-->
+<!-- wp:sensei-lms/course-outline-lesson {"title":"<?php esc_html_e( 'Lesson 3', 'sensei-lms' ); ?>"} /-->
 <!-- /wp:sensei-lms/course-outline -->


### PR DESCRIPTION
### Changes proposed in this Pull Request

Make default lesson names (Lesson 1, Lesson 2, Lesson 3) in the default course pattern translatable.

### Testing instructions

Create a new course. Ensure the lessons have the correct names.