### PR TITLE
Add dummy argument to bypass server caching

### DIFF
--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -377,7 +377,7 @@ class Sensei_Quiz {
 
 		// Redirect to the start of the quiz.
 		wp_safe_redirect(
-			remove_query_arg( 'quiz-page' )
+			add_query_arg( [ 'bypass_server_cache' => uniqid() ], remove_query_arg( 'quiz-page' ) )
 		);
 		exit;
 
@@ -426,7 +426,7 @@ class Sensei_Quiz {
 
 		// Redirect to the start of the quiz.
 		wp_safe_redirect(
-			remove_query_arg( 'quiz-page' )
+			add_query_arg( [ 'bypass_server_cache' => uniqid() ], remove_query_arg( 'quiz-page' ) )
 		);
 		exit;
 
@@ -491,7 +491,7 @@ class Sensei_Quiz {
 
 		// Redirect to the target page.
 		wp_safe_redirect(
-			wp_unslash( $_POST['quiz_target_page'] )
+			add_query_arg( [ 'bypass_server_cache' => uniqid() ], sanitize_text_field( wp_unslash( $_POST['quiz_target_page'] ) ) )
 		);
 		exit;
 


### PR DESCRIPTION
There was an issue reported in our quiz that sometimes, a completed quiz would display as not completed or a quiz that has been reset would appear as completed. This is caused by server caching. More info can be found [here](p1654779757463229-slack-C02P7FHLVR9).

This is probably something that shouldn't be handled in Sensei, however I can see this issue be raised again so it might be worth it to implement a fix if it isn't to complicated.

### Changes proposed in this Pull Request

* A new argument was added to the redirects in the quiz pages with a value created by `uniqid`. This will cause a cache miss and force the server to load the page with the correct content.

### Testing instructions
- Open a quiz and complete it.
- Observe that after you click complete, a `bypass_server_cache` argument appears in the url.
- Reset the quiz and observe the same argument again.
- Add quiz pagination and observe that the argument appears in next,previous and pagination links.
- Ensure that the fix works with learning mode enabled.