### PR TITLE
Fix Course Outline styles on pattern thumbnails

### DIFF
--- a/assets/blocks/course-outline/course-outline-editor.scss
+++ b/assets/blocks/course-outline/course-outline-editor.scss
@@ -1,4 +1,5 @@
 $dark-gray: #1a1d20;
+body,
 .block-editor {
 	.wp-block-sensei-lms-course-outline {
 		padding: 0 1em;
@@ -22,7 +23,7 @@ $dark-gray: #1a1d20;
 		}
 	}
 
-	.wp-block-sensei-lms-course-outline-lesson {
+	.wp-block-sensei-lms-course-outline-lesson .wp-block-sensei-lms-course-outline-lesson {
 
 		&__input {
 			margin: 20px 16px;

--- a/assets/blocks/course-outline/course-outline-editor.scss
+++ b/assets/blocks/course-outline/course-outline-editor.scss
@@ -28,6 +28,12 @@ body,
 		&__input {
 			margin: 20px 16px;
 			background: none;
+
+			@at-root {
+				.block-editor-block-preview__content-iframe & {
+					height: 29px !important; // Force height in the thumbnails - issue with `react-autosize-textarea`.
+				}
+			}
 		}
 
 		&__post-status {


### PR DESCRIPTION
Fixes #5250

### Changes proposed in this Pull Request

* It fixes the Course Outline styles on pattern thumbnails.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a new course.
* In the wizard, navigate to the patterns step.
* Check that the Course Outline appears correctly in the thumbnails.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="883" alt="Screen Shot 2022-06-10 at 17 13 56" src="https://user-images.githubusercontent.com/876340/173145264-d3c99a94-a669-4cb2-89ae-acfb683ad6bd.png">

Notice that a part of the pattern is not appearing. It's because it doesn't crop the pattern 100% correctly. It also happens in other patterns:

<img width="1071" alt="Screen Shot 2022-06-10 at 17 14 54" src="https://user-images.githubusercontent.com/876340/173145318-38b62cf0-92d8-4662-a54e-756accd2f29e.png">
