### PR TITLE
Update title only when the editor wizard is closed

### DIFF
--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -31,6 +31,8 @@ const EditorWizardModal = () => {
 		setDone( true );
 		editPost( {
 			meta: { _new_post: false },
+			excerpt: dataState[ 0 ].courseDescription,
+			title: dataState[ 0 ].courseTitle ?? dataState[ 0 ].lessonTitle,
 		} );
 		savePost();
 	};

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -24,17 +24,17 @@ const EditorWizardModal = () => {
 	const [ open, setDone ] = useWizardOpenState();
 	const steps = useEditorWizardSteps();
 	const setDefaultPattern = useSetDefaultPattern( {
-		'sensei-content-description': dataState[ 0 ].courseDescription,
+		'sensei-content-description': dataState[ 0 ].description,
 	} );
 
 	const onWizardCompletion = () => {
 		setDone( true );
 		const newPostData = {
 			meta: { _new_post: false },
-			title: dataState[ 0 ].courseTitle ?? dataState[ 0 ].lessonTitle,
+			title: dataState[ 0 ].title,
 		};
-		if ( dataState[ 0 ].courseDescription ) {
-			newPostData.excerpt = dataState[ 0 ].courseDescription;
+		if ( dataState[ 0 ].description ) {
+			newPostData.excerpt = dataState[ 0 ].description;
 		}
 		editPost( newPostData );
 		savePost();

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -20,21 +20,22 @@ import '../../shared/data/api-fetch-preloaded-once';
 const EditorWizardModal = () => {
 	const wizardDataState = useState( {} );
 	const { editPost, savePost } = useDispatch( editorStore );
+	const wizardData = wizardDataState[ 0 ];
 
 	const [ open, setDone ] = useWizardOpenState();
 	const steps = useEditorWizardSteps();
 	const setDefaultPattern = useSetDefaultPattern( {
-		'sensei-content-description': wizardDataState[ 0 ].description,
+		'sensei-content-description': wizardData.description,
 	} );
 
 	const onWizardCompletion = () => {
 		setDone( true );
 		const newPostData = {
 			meta: { _new_post: false },
-			title: wizardDataState[ 0 ].title,
+			title: wizardData.title,
 		};
-		if ( wizardDataState[ 0 ].description ) {
-			newPostData.excerpt = wizardDataState[ 0 ].description;
+		if ( wizardData.description ) {
+			newPostData.excerpt = wizardData.description;
 		}
 		editPost( newPostData );
 		savePost();

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -18,23 +18,23 @@ import '../../shared/data/api-fetch-preloaded-once';
  * Editor wizard modal component.
  */
 const EditorWizardModal = () => {
-	const dataState = useState( {} );
+	const wizardDataState = useState( {} );
 	const { editPost, savePost } = useDispatch( editorStore );
 
 	const [ open, setDone ] = useWizardOpenState();
 	const steps = useEditorWizardSteps();
 	const setDefaultPattern = useSetDefaultPattern( {
-		'sensei-content-description': dataState[ 0 ].description,
+		'sensei-content-description': wizardDataState[ 0 ].description,
 	} );
 
 	const onWizardCompletion = () => {
 		setDone( true );
 		const newPostData = {
 			meta: { _new_post: false },
-			title: dataState[ 0 ].title,
+			title: wizardDataState[ 0 ].title,
 		};
-		if ( dataState[ 0 ].description ) {
-			newPostData.excerpt = dataState[ 0 ].description;
+		if ( wizardDataState[ 0 ].description ) {
+			newPostData.excerpt = wizardDataState[ 0 ].description;
 		}
 		editPost( newPostData );
 		savePost();
@@ -53,7 +53,7 @@ const EditorWizardModal = () => {
 			>
 				<Wizard
 					steps={ steps }
-					dataState={ dataState }
+					wizardDataState={ wizardDataState }
 					onCompletion={ onWizardCompletion }
 					skipWizard={ skipWizard }
 				/>

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -29,11 +29,14 @@ const EditorWizardModal = () => {
 
 	const onWizardCompletion = () => {
 		setDone( true );
-		editPost( {
+		const newPostData = {
 			meta: { _new_post: false },
-			excerpt: dataState[ 0 ].courseDescription,
 			title: dataState[ 0 ].courseTitle ?? dataState[ 0 ].lessonTitle,
-		} );
+		};
+		if ( dataState[ 0 ].courseDescription ) {
+			newPostData.excerpt = dataState[ 0 ].courseDescription;
+		}
+		editPost( newPostData );
 		savePost();
 	};
 

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -19,13 +19,13 @@ import detailsStepImage from '../../../images/details-step.png';
  */
 const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 	const updateCourseTitle = ( title ) => {
-		setWizardData( { ...wizardData, courseTitle: title } );
+		setWizardData( { ...wizardData, title } );
 	};
 
 	const updateCourseDescription = ( description ) => {
 		setWizardData( {
 			...wizardData,
-			courseDescription: description,
+			description,
 		} );
 	};
 
@@ -45,14 +45,14 @@ const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 					<LimitedTextControl
 						className="sensei-editor-wizard-step__form-control"
 						label={ __( 'Course Title', 'sensei-lms' ) }
-						value={ wizardData.courseTitle ?? '' }
+						value={ wizardData.title ?? '' }
 						onChange={ updateCourseTitle }
 						maxLength={ 40 }
 					/>
 					<LimitedTextControl
 						className="sensei-editor-wizard-step__form-control"
 						label={ __( 'Course Description', 'sensei-lms' ) }
-						value={ wizardData.courseDescription ?? '' }
+						value={ wizardData.description ?? '' }
 						onChange={ updateCourseDescription }
 						maxLength={ 350 }
 						multiline={ true }

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -14,10 +14,10 @@ import detailsStepImage from '../../../images/details-step.png';
  * Initial step for course creation wizard.
  *
  * @param {Object}   props
- * @param {Object}   props.data
- * @param {Function} props.setData
+ * @param {Object}   props.wizardData    Wizard data.
+ * @param {Function} props.setWizardData Wizard data setter.
  */
-const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
+const CourseDetailsStep = ( { wizardData, setWizardData } ) => {
 	const updateCourseTitle = ( title ) => {
 		setWizardData( { ...wizardData, title } );
 	};

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -3,8 +3,6 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/components';
-import { store as editorStore } from '@wordpress/editor';
-import { useDispatch } from '@wordpress/data';
 
 /**
  * Internal dependencies
@@ -20,11 +18,8 @@ import detailsStepImage from '../../../images/details-step.png';
  * @param {Function} props.setData
  */
 const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
-	const { editPost } = useDispatch( editorStore );
-
 	const updateCourseTitle = ( title ) => {
 		setWizardData( { ...wizardData, courseTitle: title } );
-		editPost( { title } );
 	};
 
 	const updateCourseDescription = ( description ) => {
@@ -32,7 +27,6 @@ const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
 			...wizardData,
 			courseDescription: description,
 		} );
-		editPost( { excerpt: description } );
 	};
 
 	return (

--- a/assets/admin/editor-wizard/steps/course-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.test.js
@@ -41,11 +41,9 @@ describe( '<CourseDetailsStep />', () => {
 		expect( editPostMock ).toBeCalledTimes( 0 );
 	} );
 
-	it( 'Updates course title in data and as post title when changed.', () => {
-		const editPostMock = jest.fn();
+	it( 'Updates course title in data when changed.', () => {
 		const setDataMock = jest.fn();
 		const NEW_TITLE = 'Some new title';
-		useDispatch.mockReturnValue( { editPost: editPostMock } );
 
 		const { queryByLabelText } = render(
 			<CourseDetailsStep data={ {} } setData={ setDataMock } />
@@ -54,15 +52,12 @@ describe( '<CourseDetailsStep />', () => {
 			target: { value: NEW_TITLE },
 		} );
 
-		expect( editPostMock ).toBeCalledWith( { title: NEW_TITLE } );
 		expect( setDataMock ).toBeCalledWith( { courseTitle: NEW_TITLE } );
 	} );
 
-	it( 'Updates course description in data and as post excerpt when changed.', () => {
-		const editPostMock = jest.fn();
+	it( 'Updates course description in data when changed.', () => {
 		const setDataMock = jest.fn();
 		const NEW_DESCRIPTION = 'Some new description';
-		useDispatch.mockReturnValue( { editPost: editPostMock } );
 
 		const { queryByLabelText } = render(
 			<CourseDetailsStep data={ {} } setData={ setDataMock } />
@@ -71,7 +66,6 @@ describe( '<CourseDetailsStep />', () => {
 			target: { value: NEW_DESCRIPTION },
 		} );
 
-		expect( editPostMock ).toBeCalledWith( { excerpt: NEW_DESCRIPTION } );
 		expect( setDataMock ).toBeCalledWith( {
 			courseDescription: NEW_DESCRIPTION,
 		} );

--- a/assets/admin/editor-wizard/steps/course-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.test.js
@@ -52,7 +52,7 @@ describe( '<CourseDetailsStep />', () => {
 			target: { value: NEW_TITLE },
 		} );
 
-		expect( setDataMock ).toBeCalledWith( { courseTitle: NEW_TITLE } );
+		expect( setDataMock ).toBeCalledWith( { title: NEW_TITLE } );
 	} );
 
 	it( 'Updates course description in data when changed.', () => {
@@ -67,7 +67,7 @@ describe( '<CourseDetailsStep />', () => {
 		} );
 
 		expect( setDataMock ).toBeCalledWith( {
-			courseDescription: NEW_DESCRIPTION,
+			description: NEW_DESCRIPTION,
 		} );
 	} );
 } );

--- a/assets/admin/editor-wizard/steps/course-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.test.js
@@ -33,7 +33,7 @@ describe( '<CourseDetailsStep />', () => {
 		useDispatch.mockReturnValue( { editPost: editPostMock } );
 
 		const { queryByLabelText } = render(
-			<CourseDetailsStep data={ {} } setData={ () => {} } />
+			<CourseDetailsStep wizardData={ {} } setWizardData={ () => {} } />
 		);
 
 		expect( queryByLabelText( 'Course Title' ) ).toBeTruthy();
@@ -46,7 +46,10 @@ describe( '<CourseDetailsStep />', () => {
 		const NEW_TITLE = 'Some new title';
 
 		const { queryByLabelText } = render(
-			<CourseDetailsStep data={ {} } setData={ setDataMock } />
+			<CourseDetailsStep
+				wizardData={ {} }
+				setWizardData={ setDataMock }
+			/>
 		);
 		fireEvent.change( queryByLabelText( 'Course Title' ), {
 			target: { value: NEW_TITLE },
@@ -60,7 +63,10 @@ describe( '<CourseDetailsStep />', () => {
 		const NEW_DESCRIPTION = 'Some new description';
 
 		const { queryByLabelText } = render(
-			<CourseDetailsStep data={ {} } setData={ setDataMock } />
+			<CourseDetailsStep
+				wizardData={ {} }
+				setWizardData={ setDataMock }
+			/>
 		);
 		fireEvent.change( queryByLabelText( 'Course Description' ), {
 			target: { value: NEW_DESCRIPTION },

--- a/assets/admin/editor-wizard/steps/course-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/course-patterns-step.js
@@ -12,21 +12,21 @@ import PatternsStep from './patterns-step';
 /**
  * Course patterns step.
  *
- * @param {Object} props      Component props.
- * @param {Object} props.data Wizard data.
+ * @param {Object} props            Component props.
+ * @param {Object} props.wizardData Wizard data.
  */
-const CoursePatternsStep = ( { data, ...props } ) => {
+const CoursePatternsStep = ( { wizardData, ...props } ) => {
 	const { user } = useSelect( ( select ) => ( {
 		user: select( 'core' ).getCurrentUser(),
 	} ) );
 	const replaces = {};
 
-	if ( data.title ) {
-		replaces[ 'sensei-content-title' ] = data.title;
+	if ( wizardData.title ) {
+		replaces[ 'sensei-content-title' ] = wizardData.title;
 	}
 
-	if ( data.description ) {
-		replaces[ 'sensei-content-description' ] = data.description;
+	if ( wizardData.description ) {
+		replaces[ 'sensei-content-description' ] = wizardData.description;
 	}
 
 	if ( user.name ) {

--- a/assets/admin/editor-wizard/steps/course-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/course-patterns-step.js
@@ -21,12 +21,12 @@ const CoursePatternsStep = ( { data, ...props } ) => {
 	} ) );
 	const replaces = {};
 
-	if ( data.courseTitle ) {
-		replaces[ 'sensei-content-title' ] = data.courseTitle;
+	if ( data.title ) {
+		replaces[ 'sensei-content-title' ] = data.title;
 	}
 
-	if ( data.courseDescription ) {
-		replaces[ 'sensei-content-description' ] = data.courseDescription;
+	if ( data.description ) {
+		replaces[ 'sensei-content-description' ] = data.description;
 	}
 
 	if ( user.name ) {

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { Button } from '@wordpress/components';
 
@@ -81,15 +81,11 @@ LessonDetailsStep.Actions = ( { goToNextStep } ) => {
  * @param {Function} setWizardData Function to update the wizard data.
  */
 const useLessonTitle = ( wizardData, setWizardData ) => {
-	const { editPost } = useDispatch( editorStore );
 	const { title } = useSelect( ( select ) => ( {
 		title: select( editorStore )?.getEditedPostAttribute( 'title' ),
 	} ) );
 	const updateLessonTitle = ( newTitle ) => {
 		setWizardData( { ...wizardData, lessonTitle: newTitle } );
-		editPost( {
-			title: newTitle,
-		} );
 	};
 	return [ wizardData.lessonTitle ?? title, updateLessonTitle ];
 };

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -81,13 +81,13 @@ LessonDetailsStep.Actions = ( { goToNextStep } ) => {
  * @param {Function} setWizardData Function to update the wizard data.
  */
 const useLessonTitle = ( wizardData, setWizardData ) => {
-	const { title } = useSelect( ( select ) => ( {
-		title: select( editorStore )?.getEditedPostAttribute( 'title' ),
+	const { postTitle } = useSelect( ( select ) => ( {
+		postTitle: select( editorStore )?.getEditedPostAttribute( 'title' ),
 	} ) );
-	const updateLessonTitle = ( newTitle ) => {
-		setWizardData( { ...wizardData, lessonTitle: newTitle } );
+	const updateLessonTitle = ( title ) => {
+		setWizardData( { ...wizardData, title } );
 	};
-	return [ wizardData.lessonTitle ?? title, updateLessonTitle ];
+	return [ wizardData.title ?? postTitle, updateLessonTitle ];
 };
 
 export default LessonDetailsStep;

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -16,10 +16,10 @@ import detailsStepImage from '../../../images/details-step.png';
  * Initial step for lesson creation wizard.
  *
  * @param {Object}   props
- * @param {Object}   props.data
- * @param {Function} props.setData
+ * @param {Object}   props.wizardData    Wizard data.
+ * @param {Function} props.setWizardData Wizard data setter.
  */
-const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
+const LessonDetailsStep = ( { wizardData, setWizardData } ) => {
 	const [ lessonTitle, updateLessonTitle ] = useLessonTitle(
 		wizardData,
 		setWizardData

--- a/assets/admin/editor-wizard/steps/lesson-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.test.js
@@ -45,11 +45,9 @@ describe( '<LessonDetailsStep />', () => {
 		expect( editPostMock ).toBeCalledTimes( 0 );
 	} );
 
-	it( 'Updates lesson title in data and as title post when changed.', () => {
-		const editPostMock = jest.fn();
+	it( 'Updates lesson title in data when changed.', () => {
 		const setDataMock = jest.fn();
 		const NEW_TITLE = 'Some new title';
-		useDispatch.mockReturnValue( { editPost: editPostMock } );
 		useSelect.mockReturnValue( { title: ANY_LESSON_TITLE } );
 
 		const { queryByLabelText } = render(
@@ -59,7 +57,6 @@ describe( '<LessonDetailsStep />', () => {
 			target: { value: NEW_TITLE },
 		} );
 
-		expect( editPostMock ).toBeCalledWith( { title: NEW_TITLE } );
 		expect( setDataMock ).toBeCalledWith( { lessonTitle: NEW_TITLE } );
 	} );
 

--- a/assets/admin/editor-wizard/steps/lesson-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.test.js
@@ -35,7 +35,7 @@ describe( '<LessonDetailsStep />', () => {
 	it( 'Renders title input field and not calls savePost initially.', () => {
 		const editPostMock = jest.fn();
 		useDispatch.mockReturnValue( { editPost: editPostMock } );
-		useSelect.mockReturnValue( { title: ANY_LESSON_TITLE } );
+		useSelect.mockReturnValue( { postTitle: ANY_LESSON_TITLE } );
 
 		const { queryByLabelText } = render(
 			<LessonDetailsStep data={ {} } setData={ () => {} } />
@@ -48,7 +48,7 @@ describe( '<LessonDetailsStep />', () => {
 	it( 'Updates lesson title in data when changed.', () => {
 		const setDataMock = jest.fn();
 		const NEW_TITLE = 'Some new title';
-		useSelect.mockReturnValue( { title: ANY_LESSON_TITLE } );
+		useSelect.mockReturnValue( { postTitle: ANY_LESSON_TITLE } );
 
 		const { queryByLabelText } = render(
 			<LessonDetailsStep data={ {} } setData={ setDataMock } />
@@ -57,13 +57,13 @@ describe( '<LessonDetailsStep />', () => {
 			target: { value: NEW_TITLE },
 		} );
 
-		expect( setDataMock ).toBeCalledWith( { lessonTitle: NEW_TITLE } );
+		expect( setDataMock ).toBeCalledWith( { title: NEW_TITLE } );
 	} );
 
 	it( 'Renders post title in title field initially.', () => {
 		const editPostMock = jest.fn();
 		useDispatch.mockReturnValue( { editPost: editPostMock } );
-		useSelect.mockReturnValue( { title: ANY_LESSON_TITLE } );
+		useSelect.mockReturnValue( { postTitle: ANY_LESSON_TITLE } );
 
 		const { queryByLabelText } = render(
 			<LessonDetailsStep data={ {} } setData={ () => {} } />

--- a/assets/admin/editor-wizard/steps/lesson-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.test.js
@@ -38,7 +38,7 @@ describe( '<LessonDetailsStep />', () => {
 		useSelect.mockReturnValue( { postTitle: ANY_LESSON_TITLE } );
 
 		const { queryByLabelText } = render(
-			<LessonDetailsStep data={ {} } setData={ () => {} } />
+			<LessonDetailsStep wizardData={ {} } setWizardData={ () => {} } />
 		);
 
 		expect( queryByLabelText( 'Lesson Title' ) ).toBeTruthy();
@@ -51,7 +51,10 @@ describe( '<LessonDetailsStep />', () => {
 		useSelect.mockReturnValue( { postTitle: ANY_LESSON_TITLE } );
 
 		const { queryByLabelText } = render(
-			<LessonDetailsStep data={ {} } setData={ setDataMock } />
+			<LessonDetailsStep
+				wizardData={ {} }
+				setWizardData={ setDataMock }
+			/>
 		);
 		fireEvent.change( queryByLabelText( 'Lesson Title' ), {
 			target: { value: NEW_TITLE },
@@ -66,7 +69,7 @@ describe( '<LessonDetailsStep />', () => {
 		useSelect.mockReturnValue( { postTitle: ANY_LESSON_TITLE } );
 
 		const { queryByLabelText } = render(
-			<LessonDetailsStep data={ {} } setData={ () => {} } />
+			<LessonDetailsStep wizardData={ {} } setWizardData={ () => {} } />
 		);
 
 		expect( queryByLabelText( 'Lesson Title' ) ).toBeTruthy();

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -15,10 +15,10 @@ import { EXTENSIONS_STORE } from '../../../extensions/store';
 /**
  * Lesson patterns step.
  *
- * @param {Object} props      Component props.
- * @param {Object} props.data Wizard data.
+ * @param {Object} props            Component props.
+ * @param {Object} props.wizardData Wizard data.
  */
-const LessonPatternsStep = ( { data, ...props } ) => {
+const LessonPatternsStep = ( { wizardData, ...props } ) => {
 	const { senseiProExtension } = useSelect(
 		( select ) => ( {
 			senseiProExtension: select(
@@ -30,8 +30,8 @@ const LessonPatternsStep = ( { data, ...props } ) => {
 
 	const replaces = {};
 
-	if ( data.title ) {
-		replaces[ 'sensei-content-title' ] = data.title;
+	if ( wizardData.title ) {
+		replaces[ 'sensei-content-title' ] = wizardData.title;
 	}
 
 	const isSenseiProActivated =

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -30,8 +30,8 @@ const LessonPatternsStep = ( { data, ...props } ) => {
 
 	const replaces = {};
 
-	if ( data.lessonTitle ) {
-		replaces[ 'sensei-content-title' ] = data.lessonTitle;
+	if ( data.title ) {
+		replaces[ 'sensei-content-title' ] = data.title;
 	}
 
 	const isSenseiProActivated =

--- a/assets/admin/editor-wizard/wizard.js
+++ b/assets/admin/editor-wizard/wizard.js
@@ -46,7 +46,6 @@ const Wizard = ( { steps, wizardDataState, onCompletion, skipWizard } ) => {
 				{ CurrentStep.Actions && (
 					<div className="sensei-editor-wizard__actions">
 						<CurrentStep.Actions
-							wizardData={ wizardData }
 							goToNextStep={ goToNextStep }
 							skipWizard={ skipWizard }
 						/>

--- a/assets/admin/editor-wizard/wizard.js
+++ b/assets/admin/editor-wizard/wizard.js
@@ -8,20 +8,20 @@ import { __, sprintf } from '@wordpress/i18n';
  * Wizard component.
  *
  * @param {Object}   props
- * @param {Array}    props.steps        Array with the steps that will be rendered.
- * @param {Array}    props.dataState    Data and data setter.
- * @param {Function} props.onCompletion Callback to call when wizard is completed.
- * @param {Function} props.skipWizard   Function to skip wizard.
+ * @param {Array}    props.steps           Array with the steps that will be rendered.
+ * @param {Array}    props.wizardDataState Wizard Data and wizard data setter.
+ * @param {Function} props.onCompletion    Callback to call when wizard is completed.
+ * @param {Function} props.skipWizard      Function to skip wizard.
  */
-const Wizard = ( { steps, dataState, onCompletion, skipWizard } ) => {
+const Wizard = ( { steps, wizardDataState, onCompletion, skipWizard } ) => {
 	const [ currentStepNumber, setCurrentStepNumber ] = useState( 0 );
-	const [ data, setData ] = dataState;
+	const [ wizardData, setWizardData ] = wizardDataState;
 
 	const goToNextStep = () => {
 		if ( currentStepNumber + 1 < steps.length ) {
 			setCurrentStepNumber( currentStepNumber + 1 );
 		} else {
-			onCompletion( data );
+			onCompletion( wizardData );
 		}
 	};
 
@@ -30,8 +30,8 @@ const Wizard = ( { steps, dataState, onCompletion, skipWizard } ) => {
 	return (
 		<div className="sensei-editor-wizard">
 			<CurrentStep
-				data={ data }
-				setData={ setData }
+				wizardData={ wizardData }
+				setWizardData={ setWizardData }
 				onCompletion={ onCompletion }
 			/>
 			<div className="sensei-editor-wizard__footer">
@@ -46,7 +46,7 @@ const Wizard = ( { steps, dataState, onCompletion, skipWizard } ) => {
 				{ CurrentStep.Actions && (
 					<div className="sensei-editor-wizard__actions">
 						<CurrentStep.Actions
-							data={ data }
+							wizardData={ wizardData }
 							goToNextStep={ goToNextStep }
 							skipWizard={ skipWizard }
 						/>

--- a/assets/admin/editor-wizard/wizard.test.js
+++ b/assets/admin/editor-wizard/wizard.test.js
@@ -21,7 +21,7 @@ describe( '<Wizard />', () => {
 		};
 
 		const { queryByText } = render(
-			<Wizard steps={ [ DummyStep ] } dataState={ [] } />
+			<Wizard steps={ [ DummyStep ] } wizardDataState={ [] } />
 		);
 
 		expect( queryByText( SOME_DUMMY_CONTENT ) ).toBeTruthy();
@@ -34,7 +34,10 @@ describe( '<Wizard />', () => {
 			return SOME_DUMMY_CONTENT;
 		};
 		const { queryByText } = render(
-			<Wizard steps={ [ DummyStepWithoutActions ] } dataState={ [] } />
+			<Wizard
+				steps={ [ DummyStepWithoutActions ] }
+				wizardDataState={ [] }
+			/>
 		);
 
 		expect( queryByText( SOME_DUMMY_CONTENT ) ).toBeTruthy();
@@ -54,7 +57,10 @@ describe( '<Wizard />', () => {
 		};
 
 		const { queryByText } = render(
-			<Wizard steps={ [ FirstStep, SecondStep ] } dataState={ [] } />
+			<Wizard
+				steps={ [ FirstStep, SecondStep ] }
+				wizardDataState={ [] }
+			/>
 		);
 
 		expect( queryByText( 'FIRST_STEP_CONTENT' ) ).toBeTruthy();
@@ -78,7 +84,7 @@ describe( '<Wizard />', () => {
 		const { queryByText } = render(
 			<Wizard
 				steps={ [ SingleStep ] }
-				dataState={ [] }
+				wizardDataState={ [] }
 				onCompletion={ onCompletionCallback }
 			/>
 		);


### PR DESCRIPTION
Fixes #5240

### Changes proposed in this Pull Request

* Update title only when the editor wizard is closed, instead of updating it on real time;
* Change reference from `data` to `wizardData`; 
* Use `title` instead of `courseTitle`/`lessonTitle`, and `description` instead of `courseDescription`;

### Testing instructions

1. Create a new course, edit the title and the description and guarantee that nothing updates in the background;
2. a) Close the editor wizard, and verify that the title, description and excerpt appear correctly in the correct places;
2. b) Select a pattern and again verify that the title, description and excerpt appear correctly in the correct places;

In the same sense:

1. Create a new lesson, edit the title and guarantee that nothing updates in the background;
2. a) Close the editor wizard, and verify that the title appear correctly in the correct place;
2. b) Select a pattern and again verify that the title appear correctly in the correct place;

