### PR TITLE
Fix svg mock in JS tests

### DIFF
--- a/tests/__mocks__/svg.js
+++ b/tests/__mocks__/svg.js
@@ -1,2 +1,8 @@
-export default 'SvgrURL';
-export const ReactComponent = 'div';
+import React from 'react';
+
+const SvgrMock = React.forwardRef( ( props, ref ) => (
+	<span ref={ ref } { ...props } />
+) );
+
+export const ReactComponent = SvgrMock;
+export default SvgrMock;


### PR DESCRIPTION
Based on https://github.com/Automattic/sensei/pull/5264

### Changes proposed in this Pull Request

* It fixes a warning in JS tests related to the SVG mock.
  * Idea got from https://github.com/gregberge/svgr/issues/83#issuecomment-575038115

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Run `npm run test-js -- course-upgrade-step`
* Make sure you don't see the warnings: `Warning: <SvgrURL /> is using incorrect casing. Use PascalCase for React components, or lowercase for HTML elements.`