### PR TITLE
Change lesson pattern with quiz

### DIFF
--- a/includes/block-patterns/lesson/templates/default-with-quiz.php
+++ b/includes/block-patterns/lesson/templates/default-with-quiz.php
@@ -14,8 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 <p></p>
 <!-- /wp:paragraph -->
 
-<!-- wp:sensei-lms/quiz {"options":{"passRequired":false,"quizPassmark":0,"autoGrade":false,"allowRetakes":false,"showQuestions":null,"randomQuestionOrder":false,"failedIndicateIncorrect":true,"failedShowCorrectAnswers":true,"failedShowAnswerFeedback":true,"buttonTextColor":null,"buttonBackgroundColor":null,"pagination":{"paginationNumber":null,"showProgressBar":false,"progressBarRadius":6,"progressBarHeight":12,"progressBarColor":null,"progressBarBackground":null},"enableQuizTimer":"1","timerValue":300},"isPostTemplate":true} /-->
-
 <!-- wp:sensei-lms/lesson-actions -->
 <div class="wp-block-sensei-lms-lesson-actions"><div class="sensei-buttons-container"><!-- wp:sensei-lms/button-view-quiz {"inContainer":true} -->
 		<div class="wp-block-sensei-lms-button-view-quiz is-style-default sensei-buttons-container__button-block wp-block-sensei-lms-button-view-quiz__wrapper"><div class="wp-block-sensei-lms-button-view-quiz is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link"><?php esc_html_e( 'View Quiz', 'sensei-lms' ); ?></button></div></div>
@@ -33,3 +31,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="wp-block-sensei-lms-button-reset-lesson is-style-outline sensei-buttons-container__button-block wp-block-sensei-lms-button-reset-lesson__wrapper"><div class="wp-block-sensei-lms-button-reset-lesson is-style-outline wp-block-sensei-button wp-block-button has-text-align-left"><button class="wp-block-button__link sensei-stop-double-submission"><?php esc_html_e( 'Reset Lesson', 'sensei-lms' ); ?></button></div></div>
 		<!-- /wp:sensei-lms/button-reset-lesson --></div></div>
 <!-- /wp:sensei-lms/lesson-actions -->
+
+<!-- wp:sensei-lms/quiz {"options":{"passRequired":false,"quizPassmark":0,"autoGrade":false,"allowRetakes":false,"showQuestions":null,"randomQuestionOrder":false,"failedIndicateIncorrect":true,"failedShowCorrectAnswers":true,"failedShowAnswerFeedback":true,"buttonTextColor":null,"buttonBackgroundColor":null,"pagination":{"paginationNumber":null,"showProgressBar":false,"progressBarRadius":6,"progressBarHeight":12,"progressBarColor":null,"progressBarBackground":null},"enableQuizTimer":"1","timerValue":300},"isPostTemplate":true} /-->


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It moves the Quiz block to the bottom of the Lesson pattern.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Add a new lesson.
* Navigate through the wizard, and choose the "Default Lesson with Quiz" pattern.
* Make sure the quiz is the last block.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot

<img width="732" alt="Screen Shot 2022-06-13 at 14 11 35" src="https://user-images.githubusercontent.com/876340/173408440-5e9737be-4dca-46a9-a2d3-a52a25ca5704.png">
