### PR TITLE
Refactor editor wizard variable names

### DIFF
--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -18,13 +18,14 @@ import '../../shared/data/api-fetch-preloaded-once';
  * Editor wizard modal component.
  */
 const EditorWizardModal = () => {
-	const dataState = useState( {} );
+	const wizardDataState = useState( {} );
 	const { editPost, savePost } = useDispatch( editorStore );
 
 	const [ open, setDone ] = useWizardOpenState();
 	const steps = useEditorWizardSteps();
+
 	const setDefaultPattern = useSetDefaultPattern( {
-		'sensei-content-description': dataState[ 0 ].courseDescription,
+		'sensei-content-description': wizardDataState[ 0 ].description,
 	} );
 
 	const onWizardCompletion = () => {
@@ -48,7 +49,7 @@ const EditorWizardModal = () => {
 			>
 				<Wizard
 					steps={ steps }
-					dataState={ dataState }
+					wizardDataState={ wizardDataState }
 					onCompletion={ onWizardCompletion }
 					skipWizard={ skipWizard }
 				/>

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -20,12 +20,13 @@ import '../../shared/data/api-fetch-preloaded-once';
 const EditorWizardModal = () => {
 	const wizardDataState = useState( {} );
 	const { editPost, savePost } = useDispatch( editorStore );
+	const wizardData = wizardDataState[ 0 ];
 
 	const [ open, setDone ] = useWizardOpenState();
 	const steps = useEditorWizardSteps();
 
 	const setDefaultPattern = useSetDefaultPattern( {
-		'sensei-content-description': wizardDataState[ 0 ].description,
+		'sensei-content-description': wizardData.description,
 	} );
 
 	const onWizardCompletion = () => {

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -51,14 +51,14 @@ const CourseDetailsStep = ( { wizardData, setWizardData } ) => {
 					<LimitedTextControl
 						className="sensei-editor-wizard-step__form-control"
 						label={ __( 'Course Title', 'sensei-lms' ) }
-						value={ wizardData.courseTitle ?? '' }
+						value={ wizardData.title ?? '' }
 						onChange={ updateCourseTitle }
 						maxLength={ 40 }
 					/>
 					<LimitedTextControl
 						className="sensei-editor-wizard-step__form-control"
 						label={ __( 'Course Description', 'sensei-lms' ) }
-						value={ wizardData.courseDescription ?? '' }
+						value={ wizardData.description ?? '' }
 						onChange={ updateCourseDescription }
 						maxLength={ 350 }
 						multiline={ true }

--- a/assets/admin/editor-wizard/steps/course-details-step.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.js
@@ -16,21 +16,21 @@ import detailsStepImage from '../../../images/details-step.png';
  * Initial step for course creation wizard.
  *
  * @param {Object}   props
- * @param {Object}   props.data
- * @param {Function} props.setData
+ * @param {Object}   props.wizardData    Wizard data.
+ * @param {Function} props.setWizardData Wizard data setter.
  */
-const CourseDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
+const CourseDetailsStep = ( { wizardData, setWizardData } ) => {
 	const { editPost } = useDispatch( editorStore );
 
 	const updateCourseTitle = ( title ) => {
-		setWizardData( { ...wizardData, courseTitle: title } );
+		setWizardData( { ...wizardData, title } );
 		editPost( { title } );
 	};
 
 	const updateCourseDescription = ( description ) => {
 		setWizardData( {
 			...wizardData,
-			courseDescription: description,
+			description,
 		} );
 		editPost( { excerpt: description } );
 	};

--- a/assets/admin/editor-wizard/steps/course-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/course-details-step.test.js
@@ -33,7 +33,7 @@ describe( '<CourseDetailsStep />', () => {
 		useDispatch.mockReturnValue( { editPost: editPostMock } );
 
 		const { queryByLabelText } = render(
-			<CourseDetailsStep data={ {} } setData={ () => {} } />
+			<CourseDetailsStep wizardData={ {} } setWizardData={ () => {} } />
 		);
 
 		expect( queryByLabelText( 'Course Title' ) ).toBeTruthy();
@@ -48,14 +48,17 @@ describe( '<CourseDetailsStep />', () => {
 		useDispatch.mockReturnValue( { editPost: editPostMock } );
 
 		const { queryByLabelText } = render(
-			<CourseDetailsStep data={ {} } setData={ setDataMock } />
+			<CourseDetailsStep
+				wizardData={ {} }
+				setWizardData={ setDataMock }
+			/>
 		);
 		fireEvent.change( queryByLabelText( 'Course Title' ), {
 			target: { value: NEW_TITLE },
 		} );
 
 		expect( editPostMock ).toBeCalledWith( { title: NEW_TITLE } );
-		expect( setDataMock ).toBeCalledWith( { courseTitle: NEW_TITLE } );
+		expect( setDataMock ).toBeCalledWith( { title: NEW_TITLE } );
 	} );
 
 	it( 'Updates course description in data and as post excerpt when changed.', () => {
@@ -65,7 +68,10 @@ describe( '<CourseDetailsStep />', () => {
 		useDispatch.mockReturnValue( { editPost: editPostMock } );
 
 		const { queryByLabelText } = render(
-			<CourseDetailsStep data={ {} } setData={ setDataMock } />
+			<CourseDetailsStep
+				wizardData={ {} }
+				setWizardData={ setDataMock }
+			/>
 		);
 		fireEvent.change( queryByLabelText( 'Course Description' ), {
 			target: { value: NEW_DESCRIPTION },
@@ -73,7 +79,7 @@ describe( '<CourseDetailsStep />', () => {
 
 		expect( editPostMock ).toBeCalledWith( { excerpt: NEW_DESCRIPTION } );
 		expect( setDataMock ).toBeCalledWith( {
-			courseDescription: NEW_DESCRIPTION,
+			description: NEW_DESCRIPTION,
 		} );
 	} );
 } );

--- a/assets/admin/editor-wizard/steps/course-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/course-patterns-step.js
@@ -12,21 +12,21 @@ import PatternsStep from './patterns-step';
 /**
  * Course patterns step.
  *
- * @param {Object} props      Component props.
- * @param {Object} props.data Wizard data.
+ * @param {Object} props            Component props.
+ * @param {Object} props.wizardData Wizard data.
  */
-const CoursePatternsStep = ( { data, ...props } ) => {
+const CoursePatternsStep = ( { wizardData, ...props } ) => {
 	const { user } = useSelect( ( select ) => ( {
 		user: select( 'core' ).getCurrentUser(),
 	} ) );
 	const replaces = {};
 
-	if ( data.courseTitle ) {
-		replaces[ 'sensei-content-title' ] = data.courseTitle;
+	if ( wizardData.title ) {
+		replaces[ 'sensei-content-title' ] = wizardData.title;
 	}
 
-	if ( data.courseDescription ) {
-		replaces[ 'sensei-content-description' ] = data.courseDescription;
+	if ( wizardData.description ) {
+		replaces[ 'sensei-content-description' ] = wizardData.description;
 	}
 
 	if ( user.name ) {

--- a/assets/admin/editor-wizard/steps/lesson-details-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.js
@@ -16,10 +16,10 @@ import detailsStepImage from '../../../images/details-step.png';
  * Initial step for lesson creation wizard.
  *
  * @param {Object}   props
- * @param {Object}   props.data
- * @param {Function} props.setData
+ * @param {Object}   props.wizardData    Wizard data.
+ * @param {Function} props.setWizardData Wizard data setter.
  */
-const LessonDetailsStep = ( { data: wizardData, setData: setWizardData } ) => {
+const LessonDetailsStep = ( { wizardData, setWizardData } ) => {
 	const [ lessonTitle, updateLessonTitle ] = useLessonTitle(
 		wizardData,
 		setWizardData
@@ -82,16 +82,16 @@ LessonDetailsStep.Actions = ( { goToNextStep } ) => {
  */
 const useLessonTitle = ( wizardData, setWizardData ) => {
 	const { editPost } = useDispatch( editorStore );
-	const { title } = useSelect( ( select ) => ( {
-		title: select( editorStore )?.getEditedPostAttribute( 'title' ),
+	const { postTitle } = useSelect( ( select ) => ( {
+		postTitle: select( editorStore )?.getEditedPostAttribute( 'title' ),
 	} ) );
-	const updateLessonTitle = ( newTitle ) => {
-		setWizardData( { ...wizardData, lessonTitle: newTitle } );
+	const updateLessonTitle = ( title ) => {
+		setWizardData( { ...wizardData, title } );
 		editPost( {
-			title: newTitle,
+			title,
 		} );
 	};
-	return [ wizardData.lessonTitle ?? title, updateLessonTitle ];
+	return [ wizardData.title ?? postTitle, updateLessonTitle ];
 };
 
 export default LessonDetailsStep;

--- a/assets/admin/editor-wizard/steps/lesson-details-step.test.js
+++ b/assets/admin/editor-wizard/steps/lesson-details-step.test.js
@@ -35,10 +35,10 @@ describe( '<LessonDetailsStep />', () => {
 	it( 'Renders title input field and not calls savePost initially.', () => {
 		const editPostMock = jest.fn();
 		useDispatch.mockReturnValue( { editPost: editPostMock } );
-		useSelect.mockReturnValue( { title: ANY_LESSON_TITLE } );
+		useSelect.mockReturnValue( { postTitle: ANY_LESSON_TITLE } );
 
 		const { queryByLabelText } = render(
-			<LessonDetailsStep data={ {} } setData={ () => {} } />
+			<LessonDetailsStep wizardData={ {} } setWizardData={ () => {} } />
 		);
 
 		expect( queryByLabelText( 'Lesson Title' ) ).toBeTruthy();
@@ -50,26 +50,29 @@ describe( '<LessonDetailsStep />', () => {
 		const setDataMock = jest.fn();
 		const NEW_TITLE = 'Some new title';
 		useDispatch.mockReturnValue( { editPost: editPostMock } );
-		useSelect.mockReturnValue( { title: ANY_LESSON_TITLE } );
+		useSelect.mockReturnValue( { postTitle: ANY_LESSON_TITLE } );
 
 		const { queryByLabelText } = render(
-			<LessonDetailsStep data={ {} } setData={ setDataMock } />
+			<LessonDetailsStep
+				wizardData={ {} }
+				setWizardData={ setDataMock }
+			/>
 		);
 		fireEvent.change( queryByLabelText( 'Lesson Title' ), {
 			target: { value: NEW_TITLE },
 		} );
 
 		expect( editPostMock ).toBeCalledWith( { title: NEW_TITLE } );
-		expect( setDataMock ).toBeCalledWith( { lessonTitle: NEW_TITLE } );
+		expect( setDataMock ).toBeCalledWith( { title: NEW_TITLE } );
 	} );
 
 	it( 'Renders post title in title field initially.', () => {
 		const editPostMock = jest.fn();
 		useDispatch.mockReturnValue( { editPost: editPostMock } );
-		useSelect.mockReturnValue( { title: ANY_LESSON_TITLE } );
+		useSelect.mockReturnValue( { postTitle: ANY_LESSON_TITLE } );
 
 		const { queryByLabelText } = render(
-			<LessonDetailsStep data={ {} } setData={ () => {} } />
+			<LessonDetailsStep wizardData={ {} } setWizardData={ () => {} } />
 		);
 
 		expect( queryByLabelText( 'Lesson Title' ) ).toBeTruthy();

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -15,10 +15,10 @@ import { EXTENSIONS_STORE } from '../../../extensions/store';
 /**
  * Lesson patterns step.
  *
- * @param {Object} props      Component props.
- * @param {Object} props.data Wizard data.
+ * @param {Object} props            Component props.
+ * @param {Object} props.wizardData Wizard data.
  */
-const LessonPatternsStep = ( { data, ...props } ) => {
+const LessonPatternsStep = ( { wizardData, ...props } ) => {
 	const { senseiProExtension } = useSelect(
 		( select ) => ( {
 			senseiProExtension: select(
@@ -30,8 +30,8 @@ const LessonPatternsStep = ( { data, ...props } ) => {
 
 	const replaces = {};
 
-	if ( data.lessonTitle ) {
-		replaces[ 'sensei-content-title' ] = data.lessonTitle;
+	if ( wizardData.title ) {
+		replaces[ 'sensei-content-title' ] = wizardData.title;
 	}
 
 	const isSenseiProActivated =

--- a/assets/admin/editor-wizard/wizard.js
+++ b/assets/admin/editor-wizard/wizard.js
@@ -46,7 +46,6 @@ const Wizard = ( { steps, wizardDataState, onCompletion, skipWizard } ) => {
 				{ CurrentStep.Actions && (
 					<div className="sensei-editor-wizard__actions">
 						<CurrentStep.Actions
-							wizardData={ wizardData }
 							goToNextStep={ goToNextStep }
 							skipWizard={ skipWizard }
 						/>

--- a/assets/admin/editor-wizard/wizard.js
+++ b/assets/admin/editor-wizard/wizard.js
@@ -8,20 +8,20 @@ import { __, sprintf } from '@wordpress/i18n';
  * Wizard component.
  *
  * @param {Object}   props
- * @param {Array}    props.steps        Array with the steps that will be rendered.
- * @param {Array}    props.dataState    Data and data setter.
- * @param {Function} props.onCompletion Callback to call when wizard is completed.
- * @param {Function} props.skipWizard   Function to skip wizard.
+ * @param {Array}    props.steps           Array with the steps that will be rendered.
+ * @param {Array}    props.wizardDataState Wizard Data and wizard data setter.
+ * @param {Function} props.onCompletion    Callback to call when wizard is completed.
+ * @param {Function} props.skipWizard      Function to skip wizard.
  */
-const Wizard = ( { steps, dataState, onCompletion, skipWizard } ) => {
+const Wizard = ( { steps, wizardDataState, onCompletion, skipWizard } ) => {
 	const [ currentStepNumber, setCurrentStepNumber ] = useState( 0 );
-	const [ data, setData ] = dataState;
+	const [ wizardData, setWizardData ] = wizardDataState;
 
 	const goToNextStep = () => {
 		if ( currentStepNumber + 1 < steps.length ) {
 			setCurrentStepNumber( currentStepNumber + 1 );
 		} else {
-			onCompletion( data );
+			onCompletion( wizardData );
 		}
 	};
 
@@ -30,8 +30,8 @@ const Wizard = ( { steps, dataState, onCompletion, skipWizard } ) => {
 	return (
 		<div className="sensei-editor-wizard">
 			<CurrentStep
-				data={ data }
-				setData={ setData }
+				wizardData={ wizardData }
+				setWizardData={ setWizardData }
 				onCompletion={ onCompletion }
 			/>
 			<div className="sensei-editor-wizard__footer">
@@ -46,7 +46,7 @@ const Wizard = ( { steps, dataState, onCompletion, skipWizard } ) => {
 				{ CurrentStep.Actions && (
 					<div className="sensei-editor-wizard__actions">
 						<CurrentStep.Actions
-							data={ data }
+							wizardData={ wizardData }
 							goToNextStep={ goToNextStep }
 							skipWizard={ skipWizard }
 						/>

--- a/assets/admin/editor-wizard/wizard.test.js
+++ b/assets/admin/editor-wizard/wizard.test.js
@@ -21,7 +21,7 @@ describe( '<Wizard />', () => {
 		};
 
 		const { queryByText } = render(
-			<Wizard steps={ [ DummyStep ] } dataState={ [] } />
+			<Wizard steps={ [ DummyStep ] } wizardDataState={ [] } />
 		);
 
 		expect( queryByText( SOME_DUMMY_CONTENT ) ).toBeTruthy();
@@ -34,7 +34,10 @@ describe( '<Wizard />', () => {
 			return SOME_DUMMY_CONTENT;
 		};
 		const { queryByText } = render(
-			<Wizard steps={ [ DummyStepWithoutActions ] } dataState={ [] } />
+			<Wizard
+				steps={ [ DummyStepWithoutActions ] }
+				wizardDataState={ [] }
+			/>
 		);
 
 		expect( queryByText( SOME_DUMMY_CONTENT ) ).toBeTruthy();
@@ -54,7 +57,10 @@ describe( '<Wizard />', () => {
 		};
 
 		const { queryByText } = render(
-			<Wizard steps={ [ FirstStep, SecondStep ] } dataState={ [] } />
+			<Wizard
+				steps={ [ FirstStep, SecondStep ] }
+				wizardDataState={ [] }
+			/>
 		);
 
 		expect( queryByText( 'FIRST_STEP_CONTENT' ) ).toBeTruthy();
@@ -78,7 +84,7 @@ describe( '<Wizard />', () => {
 		const { queryByText } = render(
 			<Wizard
 				steps={ [ SingleStep ] }
-				dataState={ [] }
+				wizardDataState={ [] }
 				onCompletion={ onCompletionCallback }
 			/>
 		);


### PR DESCRIPTION
This PR is a cherry-pick of the commits pushed to #5263, but without the part related to updating the lesson title only when the editor wizard is closed.

### Changes proposed in this Pull Request

* Change reference from `data` to `wizardData`;
* Use `title` instead of `courseTitle`/`lessonTitle`, and `description` instead of `courseDescription`;

### Testing instructions

- Maybe verify if everything is still working?
