### PR TITLE
Fix svg mock for JS tests

### DIFF
--- a/tests/__mocks__/svg.js
+++ b/tests/__mocks__/svg.js
@@ -1,8 +1,4 @@
-import React from 'react';
-
-const SvgrMock = React.forwardRef( ( props, ref ) => (
-	<span ref={ ref } { ...props } />
-) );
+const SvgrMock = ( props ) => <span { ...props } />;
 
 export const ReactComponent = SvgrMock;
 export default SvgrMock;


### PR DESCRIPTION
Based on https://github.com/Automattic/sensei/pull/5264

### Changes proposed in this Pull Request

* https://github.com/Automattic/sensei/pull/5265 fixed some warnings, but it seems it introduced other tests issues. This PR fixes it.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Run `npm run test-js`, and make sure it passes.