### PR TITLE
Fix lesson pattern styles

### DIFF
--- a/includes/block-patterns/lesson/templates/zoom-meeting.php
+++ b/includes/block-patterns/lesson/templates/zoom-meeting.php
@@ -10,8 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 ?>
-<!-- wp:group {"align":"wide","backgroundColor":"tertiary"} -->
-<div class="wp-block-group alignwide has-tertiary-background-color has-background"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
+<!-- wp:group {"align":"wide","style":{"color":{"background":"#f6f6f6"}}} -->
+<div class="wp-block-group alignwide has-background" style="background-color:#f6f6f6"><!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
 	<div class="wp-block-columns alignwide are-vertically-aligned-center"><!-- wp:column {"verticalAlignment":"center"} -->
 		<div class="wp-block-column is-vertically-aligned-center"><!-- wp:paragraph {"style":{"typography":{"lineHeight":"2"}}} -->
 			<p style="line-height:2"><strong><?php esc_html_e( 'Date:', 'sensei-lms' ); ?></strong><br><?php echo esc_html( wp_date( 'F jS, Y' ) ); ?></p>

--- a/includes/block-patterns/lesson/templates/zoom-meeting.php
+++ b/includes/block-patterns/lesson/templates/zoom-meeting.php
@@ -34,6 +34,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<!-- /wp:columns --></div>
 <!-- /wp:group -->
 
+<!-- wp:spacer {"height":24} -->
+<div style="height:24px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
 <!-- wp:paragraph -->
 <p><strong><?php esc_html_e( 'Agenda:', 'sensei-lms' ); ?></strong></p>
 <!-- /wp:paragraph -->


### PR DESCRIPTION
Part of https://github.com/Automattic/sensei/issues/5218

### Changes proposed in this Pull Request

* It fixes the lesson pattern styles for different themes.
  * This is much simpler than the Course Patterns since it doesn't have many styles applied, but I didn't generate snapshots for this case because it's much more patterns.

There's a specific case that I tried to fix, but I wasn't able to do it with a safe approach, so I didn't change anything. For the Discussion pattern, we have a comments block. This block has a submit button that is getting blue from Sensei styles. I didn't find a way to ignore that styles for this block, and I think it can have many side-effects if we just remove it or try to make it more specific for some scenarios. Ideas here are welcome.

<img width="696" alt="Screen Shot 2022-06-13 at 19 47 43" src="https://user-images.githubusercontent.com/876340/173460008-7c7802f1-d0f8-48fc-a379-7a92476487b8.png">


### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Run the patterns against different themes, and make sure it looks acceptable.