### PR TITLE
Add editor wizard usage tracking

### DIFF
--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -60,10 +60,7 @@ const EditorWizardModal = () => {
 					steps={ steps }
 					wizardDataState={ wizardDataState }
 					onCompletion={ onWizardCompletion }
-					skipWizard={ () => {
-						skipWizard();
-						logEvent( 'editor_wizard_start_with_default_layout' );
-					} }
+					skipWizard={ skipWizard }
 				/>
 			</Modal>
 		)

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { Modal } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
@@ -19,8 +19,14 @@ import '../../shared/data/api-fetch-preloaded-once';
  */
 const EditorWizardModal = () => {
 	const wizardDataState = useState( {} );
-	const { editPost, savePost } = useDispatch( editorStore );
 	const wizardData = wizardDataState[ 0 ];
+	const { editPost, savePost } = useDispatch( editorStore );
+	const { postType } = useSelect(
+		( select ) => ( {
+			postType: select( editorStore ).getCurrentPostType(),
+		} ),
+		[]
+	);
 
 	const [ open, setDone ] = useWizardOpenState();
 	const steps = useEditorWizardSteps();
@@ -46,13 +52,26 @@ const EditorWizardModal = () => {
 		open && (
 			<Modal
 				className="sensei-editor-wizard-modal"
-				onRequestClose={ skipWizard }
+				onRequestClose={ () => {
+					skipWizard();
+					window.sensei_log_event( 'editor_wizard_close_modal', {
+						postType,
+					} );
+				} }
 			>
 				<Wizard
 					steps={ steps }
 					wizardDataState={ wizardDataState }
 					onCompletion={ onWizardCompletion }
-					skipWizard={ skipWizard }
+					skipWizard={ () => {
+						skipWizard();
+						window.sensei_log_event(
+							'editor_wizard_choose_default_pattern',
+							{
+								postType,
+							}
+						);
+					} }
 				/>
 			</Modal>
 		)

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -66,7 +66,7 @@ const EditorWizardModal = () => {
 					skipWizard={ () => {
 						skipWizard();
 						window.sensei_log_event(
-							'editor_wizard_choose_default_pattern',
+							'editor_wizard_start_with_default_layout',
 							{
 								post_type: postType,
 							}

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { Modal } from '@wordpress/components';
 import { useState } from '@wordpress/element';
 import { store as editorStore } from '@wordpress/editor';
@@ -11,7 +11,11 @@ import { store as editorStore } from '@wordpress/editor';
  */
 import Wizard from './wizard';
 import useEditorWizardSteps from './use-editor-wizard-steps';
-import { useWizardOpenState, useSetDefaultPattern } from './helpers';
+import {
+	useWizardOpenState,
+	useSetDefaultPattern,
+	useLogEvent,
+} from './helpers';
 import '../../shared/data/api-fetch-preloaded-once';
 
 /**
@@ -21,12 +25,7 @@ const EditorWizardModal = () => {
 	const wizardDataState = useState( {} );
 	const wizardData = wizardDataState[ 0 ];
 	const { editPost, savePost } = useDispatch( editorStore );
-	const { postType } = useSelect(
-		( select ) => ( {
-			postType: select( editorStore ).getCurrentPostType(),
-		} ),
-		[]
-	);
+	const logEvent = useLogEvent();
 
 	const [ open, setDone ] = useWizardOpenState();
 	const steps = useEditorWizardSteps();
@@ -54,9 +53,7 @@ const EditorWizardModal = () => {
 				className="sensei-editor-wizard-modal"
 				onRequestClose={ () => {
 					skipWizard();
-					window.sensei_log_event( 'editor_wizard_close_modal', {
-						post_type: postType,
-					} );
+					logEvent( 'editor_wizard_close_modal' );
 				} }
 			>
 				<Wizard
@@ -65,12 +62,7 @@ const EditorWizardModal = () => {
 					onCompletion={ onWizardCompletion }
 					skipWizard={ () => {
 						skipWizard();
-						window.sensei_log_event(
-							'editor_wizard_start_with_default_layout',
-							{
-								post_type: postType,
-							}
-						);
+						logEvent( 'editor_wizard_start_with_default_layout' );
 					} }
 				/>
 			</Modal>

--- a/assets/admin/editor-wizard/editor-wizard-modal.js
+++ b/assets/admin/editor-wizard/editor-wizard-modal.js
@@ -55,7 +55,7 @@ const EditorWizardModal = () => {
 				onRequestClose={ () => {
 					skipWizard();
 					window.sensei_log_event( 'editor_wizard_close_modal', {
-						postType,
+						post_type: postType,
 					} );
 				} }
 			>
@@ -68,7 +68,7 @@ const EditorWizardModal = () => {
 						window.sensei_log_event(
 							'editor_wizard_choose_default_pattern',
 							{
-								postType,
+								post_type: postType,
 							}
 						);
 					} }

--- a/assets/admin/editor-wizard/helpers.js
+++ b/assets/admin/editor-wizard/helpers.js
@@ -4,6 +4,7 @@
 import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useLayoutEffect, useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
+import { store as editorStore } from '@wordpress/editor';
 
 /**
  * Update blocks content, replacing the placeholders with a content.
@@ -125,5 +126,26 @@ export const useSetDefaultPattern = ( replaces ) => {
 
 		const replacedBlocks = replacePlaceholders( pattern.blocks, replaces );
 		resetBlocks( replacedBlocks );
+	};
+};
+
+/**
+ * Hook to log event with the current post type.
+ *
+ * @return {Function} Log event function.
+ */
+export const useLogEvent = () => {
+	const { postType } = useSelect(
+		( select ) => ( {
+			postType: select( editorStore ).getCurrentPostType(),
+		} ),
+		[]
+	);
+
+	return ( eventName, eventProperties ) => {
+		window.sensei_log_event( eventName, {
+			post_type: postType,
+			...eventProperties,
+		} );
 	};
 };

--- a/assets/admin/editor-wizard/patterns-list.js
+++ b/assets/admin/editor-wizard/patterns-list.js
@@ -59,7 +59,7 @@ const PatternsList = ( { onChoose } ) => {
 							role="option"
 							tabIndex={ 0 }
 							{ ...accessibleClick( () => {
-								onChoose( blocks );
+								onChoose( blocks, name );
 							} ) }
 						>
 							<div className="sensei-patterns-list__item-preview">

--- a/assets/admin/editor-wizard/steps/patterns-step.js
+++ b/assets/admin/editor-wizard/steps/patterns-step.js
@@ -56,11 +56,22 @@ const PatternsStep = ( { title, replaces, onCompletion } ) => {
  * @param {Object}   props            Compoent props.
  * @param {Function} props.skipWizard Skip wizard function.
  */
-PatternsStep.Actions = ( { skipWizard } ) => (
-	<Button isTertiary onClick={ skipWizard }>
-		{ __( 'Start with default layout', 'sensei-lms' ) }
-	</Button>
-);
+const PatternsStepActions = ( { skipWizard } ) => {
+	const logEvent = useLogEvent();
+
+	return (
+		<Button
+			isTertiary
+			onClick={ () => {
+				skipWizard();
+				logEvent( 'editor_wizard_start_with_default_layout' );
+			} }
+		>
+			{ __( 'Start with default layout', 'sensei-lms' ) }
+		</Button>
+	);
+};
+PatternsStep.Actions = PatternsStepActions;
 
 /**
  * Component to fill the Patterns Upsell section

--- a/assets/admin/editor-wizard/steps/patterns-step.js
+++ b/assets/admin/editor-wizard/steps/patterns-step.js
@@ -58,15 +58,13 @@ const PatternsStep = ( { title, replaces, onCompletion } ) => {
  */
 const PatternsStepActions = ( { skipWizard } ) => {
 	const logEvent = useLogEvent();
+	const clickHandler = () => {
+		skipWizard();
+		logEvent( 'editor_wizard_start_with_default_layout' );
+	};
 
 	return (
-		<Button
-			isTertiary
-			onClick={ () => {
-				skipWizard();
-				logEvent( 'editor_wizard_start_with_default_layout' );
-			} }
-		>
+		<Button isTertiary onClick={ clickHandler }>
 			{ __( 'Start with default layout', 'sensei-lms' ) }
 		</Button>
 	);

--- a/assets/admin/editor-wizard/steps/patterns-step.js
+++ b/assets/admin/editor-wizard/steps/patterns-step.js
@@ -42,7 +42,7 @@ const PatternsStep = ( { title, replaces, onCompletion } ) => {
 		onCompletion();
 
 		window.sensei_log_event( 'editor_wizard_choose_pattern', {
-			postType,
+			post_type: postType,
 			name,
 		} );
 	};

--- a/assets/admin/editor-wizard/steps/patterns-step.js
+++ b/assets/admin/editor-wizard/steps/patterns-step.js
@@ -3,14 +3,14 @@
  */
 import { Button, createSlotFill } from '@wordpress/components';
 import { store as editorStore } from '@wordpress/editor';
-import { useSelect, useDispatch } from '@wordpress/data';
+import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
  * Internal dependencies
  */
 import PatternsList from '../patterns-list';
-import { replacePlaceholders } from '../helpers';
+import { replacePlaceholders, useLogEvent } from '../helpers';
 
 const { Fill, Slot } = createSlotFill( 'Patterns Upsell' );
 
@@ -26,12 +26,7 @@ const { Fill, Slot } = createSlotFill( 'Patterns Upsell' );
  */
 const PatternsStep = ( { title, replaces, onCompletion } ) => {
 	const { resetEditorBlocks } = useDispatch( editorStore );
-	const { postType } = useSelect(
-		( select ) => ( {
-			postType: select( editorStore ).getCurrentPostType(),
-		} ),
-		[]
-	);
+	const logEvent = useLogEvent();
 
 	const onChoose = ( blocks, name ) => {
 		const newBlocks = replaces
@@ -41,10 +36,7 @@ const PatternsStep = ( { title, replaces, onCompletion } ) => {
 		resetEditorBlocks( newBlocks );
 		onCompletion();
 
-		window.sensei_log_event( 'editor_wizard_choose_pattern', {
-			post_type: postType,
-			name,
-		} );
+		logEvent( 'editor_wizard_choose_pattern', { name } );
 	};
 
 	return (

--- a/assets/admin/editor-wizard/steps/patterns-step.js
+++ b/assets/admin/editor-wizard/steps/patterns-step.js
@@ -3,7 +3,7 @@
  */
 import { Button, createSlotFill } from '@wordpress/components';
 import { store as editorStore } from '@wordpress/editor';
-import { useDispatch } from '@wordpress/data';
+import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -26,14 +26,25 @@ const { Fill, Slot } = createSlotFill( 'Patterns Upsell' );
  */
 const PatternsStep = ( { title, replaces, onCompletion } ) => {
 	const { resetEditorBlocks } = useDispatch( editorStore );
+	const { postType } = useSelect(
+		( select ) => ( {
+			postType: select( editorStore ).getCurrentPostType(),
+		} ),
+		[]
+	);
 
-	const onChoose = ( blocks ) => {
+	const onChoose = ( blocks, name ) => {
 		const newBlocks = replaces
 			? replacePlaceholders( blocks, replaces )
 			: blocks;
 
 		resetEditorBlocks( newBlocks );
 		onCompletion();
+
+		window.sensei_log_event( 'editor_wizard_choose_pattern', {
+			postType,
+			name,
+		} );
 	};
 
 	return (

--- a/assets/admin/editor-wizard/wizard.js
+++ b/assets/admin/editor-wizard/wizard.js
@@ -24,10 +24,12 @@ const Wizard = ( { steps, wizardDataState, onCompletion, skipWizard } ) => {
 	const logEvent = useLogEvent();
 
 	const goToNextStep = () => {
-		if ( currentStepNumber + 1 < steps.length ) {
-			setCurrentStepNumber( currentStepNumber + 1 );
+		const nextStepNumber = currentStepNumber + 1;
+
+		if ( nextStepNumber < steps.length ) {
+			setCurrentStepNumber( nextStepNumber );
 			logEvent( 'editor_wizard_navigate_to_next_step', {
-				navigated_to: steps[ currentStepNumber + 1 ].name,
+				navigated_to: steps[ nextStepNumber ].name,
 			} );
 		} else {
 			onCompletion( wizardData );

--- a/assets/admin/editor-wizard/wizard.js
+++ b/assets/admin/editor-wizard/wizard.js
@@ -5,6 +5,11 @@ import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 /**
+ * Internal dependencies
+ */
+import { useLogEvent } from './helpers';
+
+/**
  * Wizard component.
  *
  * @param {Object}   props
@@ -16,10 +21,14 @@ import { __, sprintf } from '@wordpress/i18n';
 const Wizard = ( { steps, wizardDataState, onCompletion, skipWizard } ) => {
 	const [ currentStepNumber, setCurrentStepNumber ] = useState( 0 );
 	const [ wizardData, setWizardData ] = wizardDataState;
+	const logEvent = useLogEvent();
 
 	const goToNextStep = () => {
 		if ( currentStepNumber + 1 < steps.length ) {
 			setCurrentStepNumber( currentStepNumber + 1 );
+			logEvent( 'editor_wizard_navigate_to_next_step', {
+				navigated_to: steps[ currentStepNumber + 1 ].name,
+			} );
 		} else {
 			onCompletion( wizardData );
 		}

--- a/assets/admin/editor-wizard/wizard.test.js
+++ b/assets/admin/editor-wizard/wizard.test.js
@@ -5,13 +5,26 @@ import { fireEvent, render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 /**
+ * WordPress dependencies
+ */
+import { useSelect } from '@wordpress/data';
+
+/**
  * Internal dependencies
  */
 import Wizard from './wizard';
 
 const SOME_DUMMY_CONTENT = 'SOME_DUMMY_CONTENT';
 const SOME_DUMMY_ACTIONS = 'SOME_DUMMY_ACTIONS';
+
+jest.mock( '@wordpress/data' );
+
 describe( '<Wizard />', () => {
+	beforeEach( () => {
+		useSelect.mockReturnValue( {} );
+		window.sensei_log_event = () => {};
+	} );
+
 	it( 'Wizard renders first step content and actions by default.', () => {
 		const DummyStep = () => {
 			return SOME_DUMMY_CONTENT;


### PR DESCRIPTION
Fixes #5252

### Changes proposed in this Pull Request

* It adds usage tracking to the editor wizard.

---

#### Event
`sensei_editor_wizard_choose_pattern` - When a pattern is chosen in the wizard.

#### Properties
- `post_type` (valid values: _course_, _lesson_)
- `name` (Name of the chosen pattern)

---

#### Event
`sensei_editor_wizard_start_with_default_layout` - When the "default" button is used.

#### Properties
- `post_type` (valid values: _course_, _lesson_)

---

#### Event
`sensei_editor_wizard_close_modal` - When the wizard is closed using the "x" button, ESC, or clicking outside.

#### Properties
- `post_type` (valid values: _course_, _lesson_)

---

#### Event
`sensei_editor_wizard_navigate_to_next_step` - When the user navigates to the next step.

#### Properties
- `post_type` (valid values: _course_, _lesson_)
- `navigated_to` (Step name that the user navigated to)

---

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create new courses and lessons, and make sure the mentioned ☝️ events are logged.
  * To test it you can use: https://github.com/automattic/event-monitor
  * And or a filter to also log it. Here's what I use:
  ```php
	add_filter( 'pre_http_request', function( $preempt, $r, $url ) {
		$event_monitor_url = 'http://host.docker.internal:8888/pixel/';
		$host              = parse_url( $url, PHP_URL_HOST );
		$path              = parse_url( $url, PHP_URL_PATH );
		if ( 'pixel.wp.com' === $host && '/t.gif' === $path ) {
			error_log( 'Logging Tracks event:' );
			error_log( $url );
			
			$http    = _wp_http_get_object();
			$new_url = $event_monitor_url . '?' . parse_url( $url, PHP_URL_QUERY );

			error_log( $new_url );

			return $http->request( $new_url, $r );
		}
		return $preempt;
	}, 10, 3 );
  ```