### PR TITLE
Fix style of the setup confirmation wizard

### DIFF
--- a/assets/setup-wizard/style.scss
+++ b/assets/setup-wizard/style.scss
@@ -234,10 +234,15 @@
 			border-bottom: 0;
 		}
 
+		.components-modal__content {
+			margin-top: 0;
+		}
+
 		.components-modal__header {
 			padding: 25px 0;
 			margin: 0;
 			height: auto;
+			position: sticky;
 
 			.components-modal__header-heading {
 				font-size: 20px;
@@ -245,7 +250,7 @@
 		}
 
 		.sensei-list {
-			margin-top: 0;
+			margin-bottom: 13px;
 		}
 
 		.sensei-list__item {


### PR DESCRIPTION
Fixes #5272

### Changes proposed in this Pull Request

* Edit setup confirmation wizard styles to integrate better with the styles of the updated components provided by WordPress;

### Testing instructions

1. On a WordPress installation with this code, preferably without any of the free Sensei LMS extensions installed (like Sensei LMS Certificates, Sensei LMS Post to Course Creator, or even Sensei LMS Media Attachments), visit the URL `/wp-admin/admin.php?page=sensei_setup_wizard&step=features`;
2. On that page, make sure that all the checkboxes are checked, and click "Continue";
3. Verify that the modal looks good (or similar to what we had before merging the feature branch related to the course/lesson wizard);

It might be worth to take a look at the other modals too, to see if anything else was affected.

### Screenshot / Video

**Screenshot of the confirmation wizard BEFORE merging our feature branch related to the course/lesson wizard**:

![Screenshot of the confirmation wizard BEFORE merging our feature branch related to the course/lesson wizard](https://user-images.githubusercontent.com/529864/173711340-382762c8-bb40-41dc-9722-6cf34ae20838.png)

**Screenshot of the same confirmation wizard, but now with the code from this PR**:

![Screenshot of the same confirmation wizard, but now with the code from this PR](https://user-images.githubusercontent.com/529864/173711405-8e8c81d2-306c-4064-85cc-ab32fea4ffef.png)

### Notes 

I tried to make this PR as simple as possible and very focused on the setup confirmation wizard. LMK if I need to make additional adjustments on the design or anything else.