### PR TITLE
Guarantee that the link will stay as white after visiting it

### DIFF
--- a/assets/admin/editor-wizard/style.scss
+++ b/assets/admin/editor-wizard/style.scss
@@ -169,6 +169,9 @@
 			color: #fff;
 			text-decoration: none;
 		}
+		&:visited {
+			color: #fff;
+		}
 	}
 }
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add a `:visited` rule to keep the link "Learn More" in the upsell for the Paid Lesson Patterns as white;

### Testing instructions

1. Create a new lesson;
2. In the editor wizard, click "Continue" to go to the lesson patterns step;
3. Click on "Learn More" and verify that it opens a new tab with the Sensei's pricing page;
4. Coming back to the editor wizard, verify that the link "Learn More" stays in the white color;

### Screenshot / Video

**Before this change:**
![Before this change - with the "Learn more" link being blue after the visit](https://user-images.githubusercontent.com/529864/174127633-29958cbd-da21-4f9b-876f-5f01eab11be6.png)

**After this change:**

![After this change - with the "Learn More" link in white color even after the visit](https://user-images.githubusercontent.com/529864/174127745-cc9ea725-dae9-4286-94ff-79c9232b5cb6.png)
