### PR TITLE
Add woothemes-sensei detection to the extensions API

### DIFF
--- a/assets/admin/editor-wizard/helpers.js
+++ b/assets/admin/editor-wizard/helpers.js
@@ -5,6 +5,12 @@ import { useSelect, useDispatch } from '@wordpress/data';
 import { useEffect, useLayoutEffect, useState } from '@wordpress/element';
 import { store as blockEditorStore } from '@wordpress/block-editor';
 import { store as editorStore } from '@wordpress/editor';
+import { applyFilters } from '@wordpress/hooks';
+
+/**
+ * Internal dependencies
+ */
+import { EXTENSIONS_STORE } from '../../extensions/store';
 
 /**
  * Update blocks content, replacing the placeholders with a content.
@@ -148,4 +154,33 @@ export const useLogEvent = () => {
 			...eventProperties,
 		} );
 	};
+};
+
+/**
+ * Hook to check if Sensei Pro is enabled or not, and hide the editor wizard accordingly.
+ *
+ * @return {boolean} If the editor wizard upsell should be hidden or not.
+ */
+export const useHideEditorWizardUpsell = () => {
+	const { senseiProExtension } = useSelect(
+		( select ) => ( {
+			senseiProExtension: select(
+				EXTENSIONS_STORE
+			).getSenseiProExtension(),
+		} ),
+		[]
+	);
+
+	/**
+	 * Filters if the editor wizard upsells should show or not
+	 *
+	 * @since 4.1.0
+	 *
+	 * @param {boolean} hideEditorWizardUpsell Whether to hide the editor wizard upsells.
+	 * @return {boolean} Whether to hide the editor wizard upsells.
+	 */
+	return applyFilters(
+		'senseiEditorWizardUpsellHide',
+		! senseiProExtension || senseiProExtension.is_activated === true
+	);
 };

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -24,7 +24,7 @@ const LessonPatternsStep = ( { wizardData, ...props } ) => {
 		replaces[ 'sensei-content-title' ] = wizardData.title;
 	}
 
-	const isSenseiProActivated = useHideEditorWizardUpsell();
+	const shouldHideEditorWizardUpsell = useHideEditorWizardUpsell();
 
 	return (
 		<Fragment>
@@ -34,7 +34,7 @@ const LessonPatternsStep = ( { wizardData, ...props } ) => {
 				{ ...props }
 			/>
 			<PatternsStep.UpsellFill>
-				{ isSenseiProActivated ? null : <UpsellBlock /> }
+				{ shouldHideEditorWizardUpsell ? null : <UpsellBlock /> }
 			</PatternsStep.UpsellFill>
 		</Fragment>
 	);

--- a/assets/admin/editor-wizard/steps/lesson-patterns-step.js
+++ b/assets/admin/editor-wizard/steps/lesson-patterns-step.js
@@ -2,7 +2,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useSelect } from '@wordpress/data';
 import { Fragment } from '@wordpress/element';
 
 /**
@@ -10,7 +9,7 @@ import { Fragment } from '@wordpress/element';
  */
 import PatternsStep from './patterns-step';
 import LogoTreeIcon from '../../../icons/logo-tree.svg';
-import { EXTENSIONS_STORE } from '../../../extensions/store';
+import { useHideEditorWizardUpsell } from '../helpers';
 
 /**
  * Lesson patterns step.
@@ -19,23 +18,13 @@ import { EXTENSIONS_STORE } from '../../../extensions/store';
  * @param {Object} props.wizardData Wizard data.
  */
 const LessonPatternsStep = ( { wizardData, ...props } ) => {
-	const { senseiProExtension } = useSelect(
-		( select ) => ( {
-			senseiProExtension: select(
-				EXTENSIONS_STORE
-			).getSenseiProExtension(),
-		} ),
-		[]
-	);
-
 	const replaces = {};
 
 	if ( wizardData.title ) {
 		replaces[ 'sensei-content-title' ] = wizardData.title;
 	}
 
-	const isSenseiProActivated =
-		! senseiProExtension || senseiProExtension.is_activated === true;
+	const isSenseiProActivated = useHideEditorWizardUpsell();
 
 	return (
 		<Fragment>

--- a/assets/admin/editor-wizard/use-editor-wizard-steps.js
+++ b/assets/admin/editor-wizard/use-editor-wizard-steps.js
@@ -32,9 +32,9 @@ const useEditorWizardSteps = () => {
 		[]
 	);
 
-	const isSenseiProActivated = useHideEditorWizardUpsell();
+	const shouldHideEditorWizardUpsell = useHideEditorWizardUpsell();
 
-	if ( isSenseiProActivated ) {
+	if ( shouldHideEditorWizardUpsell ) {
 		stepsByPostType.course = stepsByPostType.course.filter(
 			( step ) => step !== CourseUpgradeStep
 		);

--- a/assets/admin/editor-wizard/use-editor-wizard-steps.js
+++ b/assets/admin/editor-wizard/use-editor-wizard-steps.js
@@ -12,7 +12,7 @@ import CourseUpgradeStep from './steps/course-upgrade-step';
 import CoursePatternsStep from './steps/course-patterns-step';
 import LessonDetailsStep from './steps/lesson-details-step';
 import LessonPatternsStep from './steps/lesson-patterns-step';
-import { EXTENSIONS_STORE } from '../../extensions/store';
+import { useHideEditorWizardUpsell } from './helpers';
 
 /**
  * Returns the list of components (representing steps) for the Editor Wizard according to the post type and if
@@ -25,17 +25,16 @@ const useEditorWizardSteps = () => {
 		course: [ CourseDetailsStep, CourseUpgradeStep, CoursePatternsStep ],
 		lesson: [ LessonDetailsStep, LessonPatternsStep ],
 	};
-	const { postType, senseiProExtension } = useSelect(
+	const { postType } = useSelect(
 		( select ) => ( {
 			postType: select( editorStore )?.getCurrentPostType(),
-			senseiProExtension: select(
-				EXTENSIONS_STORE
-			).getSenseiProExtension(),
 		} ),
 		[]
 	);
 
-	if ( ! senseiProExtension || senseiProExtension.is_activated === true ) {
+	const isSenseiProActivated = useHideEditorWizardUpsell();
+
+	if ( isSenseiProActivated ) {
 		stepsByPostType.course = stepsByPostType.course.filter(
 			( step ) => step !== CourseUpgradeStep
 		);

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -168,29 +168,15 @@ final class Sensei_Extensions {
 			$wccom_subscriptions = WC_Helper::get_subscriptions();
 		}
 
-		$aliases = [
-			'sensei-pro/sensei-pro.php' => [
-				'woothemes-sensei/woothemes-sensei.php',
-			],
-		];
-
 		// Includes installed version, whether it has update and WC.com metadata.
 		$extensions = array_map(
-			function( $extension ) use ( $installed_plugins, $wccom_subscriptions, $aliases ) {
-				$plugin_file = $extension->plugin_file;
+			function( $extension ) use ( $installed_plugins, $wccom_subscriptions ) {
+				$extension->is_installed = isset( $installed_plugins[ $extension->plugin_file ] );
+				$extension->is_activated = $extension->is_installed && is_plugin_active( $extension->plugin_file );
 
-				$plugin_file_aliases   = array_key_exists( $plugin_file, $aliases ) ? $aliases[ $plugin_file ] : [];
-				$plugin_file_aliases[] = $plugin_file;
-
-				foreach ( $plugin_file_aliases as $extension_plugin_file ) {
-					$extension->is_installed = isset( $installed_plugins[ $extension_plugin_file ] );
-					$extension->is_activated = $extension->is_installed && is_plugin_active( $extension_plugin_file );
-
-					if ( $extension->is_installed ) {
-						$extension->installed_version = $installed_plugins[ $extension_plugin_file ]['Version'];
-						$extension->has_update        = $extension_plugin_file === $plugin_file && isset( $extension->version ) && version_compare( $extension->version, $extension->installed_version, '>' );
-						break;
-					}
+				if ( $extension->is_installed ) {
+					$extension->installed_version = $installed_plugins[ $extension->plugin_file ]['Version'];
+					$extension->has_update        = isset( $extension->version ) && version_compare( $extension->version, $extension->installed_version, '>' );
 				}
 
 				if ( isset( $extension->wccom_product_id ) ) {

--- a/includes/admin/class-sensei-extensions.php
+++ b/includes/admin/class-sensei-extensions.php
@@ -168,15 +168,29 @@ final class Sensei_Extensions {
 			$wccom_subscriptions = WC_Helper::get_subscriptions();
 		}
 
+		$aliases = [
+			'sensei-pro/sensei-pro.php' => [
+				'woothemes-sensei/woothemes-sensei.php',
+			],
+		];
+
 		// Includes installed version, whether it has update and WC.com metadata.
 		$extensions = array_map(
-			function( $extension ) use ( $installed_plugins, $wccom_subscriptions ) {
-				$extension->is_installed = isset( $installed_plugins[ $extension->plugin_file ] );
-				$extension->is_activated = $extension->is_installed && is_plugin_active( $extension->plugin_file );
+			function( $extension ) use ( $installed_plugins, $wccom_subscriptions, $aliases ) {
+				$plugin_file = $extension->plugin_file;
 
-				if ( $extension->is_installed ) {
-					$extension->installed_version = $installed_plugins[ $extension->plugin_file ]['Version'];
-					$extension->has_update        = isset( $extension->version ) && version_compare( $extension->version, $extension->installed_version, '>' );
+				$plugin_file_aliases   = array_key_exists( $plugin_file, $aliases ) ? $aliases[ $plugin_file ] : [];
+				$plugin_file_aliases[] = $plugin_file;
+
+				foreach ( $plugin_file_aliases as $extension_plugin_file ) {
+					$extension->is_installed = isset( $installed_plugins[ $extension_plugin_file ] );
+					$extension->is_activated = $extension->is_installed && is_plugin_active( $extension_plugin_file );
+
+					if ( $extension->is_installed ) {
+						$extension->installed_version = $installed_plugins[ $extension_plugin_file ]['Version'];
+						$extension->has_update        = $extension_plugin_file === $plugin_file && isset( $extension->version ) && version_compare( $extension->version, $extension->installed_version, '>' );
+						break;
+					}
 				}
 
 				if ( isset( $extension->wccom_product_id ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Use filters to decide when to show or not the editor wizard upsells;

### Testing instructions

1. Create a build of `woothemes-sensei` based on this branch;
2. Install in a clean WordPress installation;
3. Verify if the upsell to Sensei Pro doesn't appear more on the Sensei Extensions page `/wp-admin/edit.php?post_type=course&page=sensei-extensions`;
4. Verify if the upsells to Sensei Pro don't appear on the Editor Wizard anymore (both on the Course Wizard, which has a dedicated step just as a upsell for Sensei Pro, as well as for the Premium Lessons Patterns step)

I also recommend testing in another WordPress installation to check if both upsells don't appear when Sensei LMS (based on this branch) + Sensei Pro is installed and activated.