### PR TITLE
Fix the Plugin URI on the plugin header of the project

### DIFF
--- a/sensei-lms.php
+++ b/sensei-lms.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * Plugin Name: Sensei LMS
- * Plugin URI: https://woocommerce.com/products/sensei/
+ * Plugin URI: https://senseilms.com/
  * Description: Share your knowledge, grow your network, and strengthen your brand by launching an online course.
  * Version: 4.5.1
  * Author: Automattic


### PR DESCRIPTION
Fix small detail [found here](https://github.com/Automattic/sensei/pull/5286#discussion_r901954055). 

### Changes proposed in this Pull Request

* Change the Plugin URI of the project to point to https://senseilms.com/

### Testing instructions

1. Install the plugin with a build based on this branch of the project;
2. Verify that, on the plugin page, the "Visit plugin site" link points to https://senseilms.com/ instead of https://woocommerce.com/products/sensei/