### PR TITLE
Add sensei_user_course_end action before redirecting to completed page

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -721,6 +721,9 @@ class Sensei_Frontend {
 		$url = Sensei_Course::get_course_completed_page_url( $course_id );
 
 		if ( $url ) {
+
+			do_action( 'sensei_user_course_end', $user_id, $course_id );
+
 			wp_safe_redirect( esc_url_raw( $url ) );
 			exit;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request
This is a fix for[ issue 5288](https://github.com/Automattic/sensei/issues/5288).
Added the setting of `sensei_user_course_end` action before redirecting to the completed page.
Adding this will trigger further actions after completion of the course.

### Testing instructions

1. Go to Sensei LMS settings and add a Course Completed Page
2. Create a course
3. Add a test action with `die('Test')` that hooks into `sensei_user_course_end`
4. Complete the course as a user
5. Should see white screen and "Test" string