### PR TITLE
Add method to return the set of course ids for a given array of lesson ids

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3865,7 +3865,7 @@ class Sensei_Lesson {
 			foreach ( $results as $result ) {
 				$courses_by_lesson[ $result->lesson_id ] = $result->course_id;
 			}
-			wp_cache_set( $cache_key, $courses_by_lesson, $cache_group );
+			wp_cache_set( $cache_key, $courses_by_lesson, $cache_group, 60 );
 		}
 		return $courses_by_lesson;
 	}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3834,6 +3834,15 @@ class Sensei_Lesson {
 	public function get_course_ids( $lesson_ids ) {
 		global $wpdb;
 
+		asort( $lesson_ids );
+
+		$cache_key     = 'lesson/get-course-ids/' . implode( ',', $lesson_ids );
+		$cache_group   = 'sensei';
+		$cached_result = wp_cache_get( $cache_key, $cache_group );
+		if ( false !== $cached_result ) {
+			return $cached_result;
+		}
+
 		$courses_by_lesson = array_fill_keys( $lesson_ids, false );
 
 		$placeholders = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
@@ -3854,9 +3863,8 @@ class Sensei_Lesson {
 				$courses_by_lesson[ $result->lesson_id ] = $result->course_id;
 			}
 		}
-
+		wp_cache_set( $cache_key, $courses_by_lesson, $cache_group );
 		return $courses_by_lesson;
-
 	}
 
 	/**

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3834,7 +3834,7 @@ class Sensei_Lesson {
 	public function get_course_ids( $lesson_ids ) {
 		global $wpdb;
 
-		asort( $lesson_ids );
+		sort( $lesson_ids, SORT_NUMERIC );
 
 		$cache_key     = 'lesson/get-course-ids/' . implode( ',', $lesson_ids );
 		$cache_group   = 'sensei';
@@ -3842,10 +3842,8 @@ class Sensei_Lesson {
 		if ( false !== $cached_result ) {
 			return $cached_result;
 		}
-
 		$courses_by_lesson = array_fill_keys( $lesson_ids, false );
-
-		$placeholders = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
+		$placeholders      = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
 
 		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 		$query = $wpdb->prepare(

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3866,7 +3866,9 @@ class Sensei_Lesson {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
 		$results = $wpdb->get_results( $query );
 		if ( is_array( $results ) ) {
-			$courses_by_lesson = wp_list_pluck($results, 'course_id', 'lesson_id');
+			foreach ( $results as $result ) {
+				$courses_by_lesson[ $result->lesson_id ] = $result->course_id;
+			}
 			wp_cache_set( $cache_key, $courses_by_lesson, $cache_group, 60 );
 		}
 		return $courses_by_lesson;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3834,6 +3834,10 @@ class Sensei_Lesson {
 	public function get_course_ids( $lesson_ids ) {
 		global $wpdb;
 
+		if ( empty( $lesson_ids ) ) {
+			return [];
+		}
+
 		sort( $lesson_ids, SORT_NUMERIC );
 		$lesson_ids = array_unique( $lesson_ids, SORT_NUMERIC );
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3865,8 +3865,8 @@ class Sensei_Lesson {
 			foreach ( $results as $result ) {
 				$courses_by_lesson[ $result->lesson_id ] = $result->course_id;
 			}
+			wp_cache_set( $cache_key, $courses_by_lesson, $cache_group );
 		}
-		wp_cache_set( $cache_key, $courses_by_lesson, $cache_group );
 		return $courses_by_lesson;
 	}
 

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3866,8 +3866,7 @@ class Sensei_Lesson {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
 		$results = $wpdb->get_results( $query );
 		if ( is_array( $results ) ) {
-			$results_courses_by_lesson = wp_list_pluck( $results, 'course_id', 'lesson_id' );
-			$courses_by_lesson = array_merge( $courses_by_lesson, $results_courses_by_lesson );
+			$courses_by_lesson = wp_list_pluck($results, 'course_id', 'lesson_id');
 			wp_cache_set( $cache_key, $courses_by_lesson, $cache_group, 60 );
 		}
 		return $courses_by_lesson;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3846,7 +3846,9 @@ class Sensei_Lesson {
 		$courses_by_lesson = array_fill_keys( $lesson_ids, false );
 
 		$placeholders = implode( ', ', array_fill( 0, count( $lesson_ids ), '%d' ) );
-		$query        = $wpdb->prepare(
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$query = $wpdb->prepare(
 			"
 				SELECT lesson.ID AS lesson_id, course.ID AS course_id FROM {$wpdb->posts} lesson
 					INNER JOIN {$wpdb->postmeta} AS lesson_meta ON lesson_meta.post_id=lesson.ID AND lesson_meta.meta_key='_lesson_course'
@@ -3856,7 +3858,9 @@ class Sensei_Lesson {
 		",
 			$lesson_ids
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared,WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
 		$results = $wpdb->get_results( $query );
 		if ( is_array( $results ) ) {
 			foreach ( $results as $result ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3834,6 +3834,7 @@ class Sensei_Lesson {
 	public function get_course_ids( $lesson_ids ) {
 		global $wpdb;
 
+		$lesson_ids = array_unique( $lesson_ids );
 		sort( $lesson_ids, SORT_NUMERIC );
 
 		$cache_key     = 'lesson/get-course-ids/' . md5( implode( ',', $lesson_ids ) );

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3862,7 +3862,8 @@ class Sensei_Lesson {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
 		$results = $wpdb->get_results( $query );
 		if ( is_array( $results ) ) {
-			$courses_by_lesson = wp_list_pluck($results, 'course_id', 'lesson_id');
+			$results_courses_by_lesson = wp_list_pluck( $results, 'course_id', 'lesson_id' );
+			$courses_by_lesson = array_merge( $courses_by_lesson, $results_courses_by_lesson );
 			wp_cache_set( $cache_key, $courses_by_lesson, $cache_group, 60 );
 		}
 		return $courses_by_lesson;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3834,8 +3834,8 @@ class Sensei_Lesson {
 	public function get_course_ids( $lesson_ids ) {
 		global $wpdb;
 
-		$lesson_ids = array_unique( $lesson_ids );
 		sort( $lesson_ids, SORT_NUMERIC );
+		$lesson_ids = array_unique( $lesson_ids, SORT_NUMERIC );
 
 		$cache_key     = 'lesson/get-course-ids/' . md5( implode( ',', $lesson_ids ) );
 		$cache_group   = 'sensei';

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3836,7 +3836,7 @@ class Sensei_Lesson {
 
 		sort( $lesson_ids, SORT_NUMERIC );
 
-		$cache_key     = 'lesson/get-course-ids/' . implode( ',', $lesson_ids );
+		$cache_key     = 'lesson/get-course-ids/' . md5( implode( ',', $lesson_ids ) );
 		$cache_group   = 'sensei';
 		$cached_result = wp_cache_get( $cache_key, $cache_group );
 		if ( false !== $cached_result ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3862,9 +3862,7 @@ class Sensei_Lesson {
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery,WordPress.DB.PreparedSQL.NotPrepared
 		$results = $wpdb->get_results( $query );
 		if ( is_array( $results ) ) {
-			foreach ( $results as $result ) {
-				$courses_by_lesson[ $result->lesson_id ] = $result->course_id;
-			}
+			$courses_by_lesson = wp_list_pluck($results, 'course_id', 'lesson_id');
 			wp_cache_set( $cache_key, $courses_by_lesson, $cache_group, 60 );
 		}
 		return $courses_by_lesson;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3838,7 +3838,7 @@ class Sensei_Lesson {
 		$lesson_ids = array_unique( $lesson_ids, SORT_NUMERIC );
 
 		$cache_key     = 'lesson/get-course-ids/' . md5( implode( ',', $lesson_ids ) );
-		$cache_group   = 'sensei';
+		$cache_group   = 'sensei/temporary';
 		$cached_result = wp_cache_get( $cache_key, $cache_group );
 		if ( false !== $cached_result ) {
 			return $cached_result;

--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -275,6 +275,7 @@ class Sensei_Main {
 		$this->load_plugin_textdomain();
 		add_action( 'init', array( $this, 'load_localisation' ), 0 );
 
+		$this->initialize_cache_groups();
 		$this->initialize_global_objects();
 		$this->initialize_cli();
 	}
@@ -338,6 +339,15 @@ class Sensei_Main {
 	 */
 	public function __wakeup() {
 		_doing_it_wrong( __FUNCTION__, esc_html__( 'Cheatin&#8217; huh?', 'sensei-lms' ), '1.8' );
+	}
+
+	/**
+	 * Initialize the cache groups used in Sensei
+	 *
+	 * @since $$next-version$$
+	 */
+	protected function initialize_cache_groups() {
+		wp_cache_add_non_persistent_groups( 'sensei/temporary' );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -110,23 +110,15 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_id' ),
 			'The lesson class method `get_course_id` does not exist '
 		);
-		$course_ids = $this->factory->course->create_many( 3 );
-		$lesson_ids = $this->factory->lesson->create_many( 9 );
-		foreach ( $lesson_ids as $lesson_index => $lesson_id ) {
-			$course_index = $lesson_index % count( $course_ids );
-			$course_id    = $course_ids[ $course_index ];
-			update_post_meta( $lesson_id, '_lesson_course', $course_id );
-		}
-		foreach ( $lesson_ids as $lesson_index => $lesson_id ) {
-			$expected_course_index = $lesson_index % count( $course_ids );
-			$expected_course_id    = $course_ids[ $expected_course_index ];
-			$course_id             = Sensei()->lesson->get_course_id( $lesson_id );
-			$this->assertEquals(
-				$expected_course_id,
-				$course_id,
-				"Lesson with ID {$lesson_id} has course ID {$course_id}, expected {$expected_course_id}"
-			);
-		}
+		$expected_course_id = $this->factory->course->create();
+		$lesson_id          = $this->factory->lesson->create();
+		update_post_meta( $lesson_id, '_lesson_course', $expected_course_id );
+		$course_id = Sensei()->lesson->get_course_id( $lesson_id );
+		$this->assertEquals(
+			$expected_course_id,
+			$course_id,
+			"Lesson {$lesson_id} has course ID {$course_id}, expected {$expected_course_id}"
+		);
 	}
 
 	/**

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -100,6 +100,11 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 
 	}
 
+	/**
+	 * Verify if the method get_course_id returns the expected course ID
+	 *
+	 * @covers Sensei_Lesson::get_course_id
+	 */
 	public function testGetCourseId() {
 		$this->assertTrue(
 			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_id' ),
@@ -124,6 +129,11 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		}
 	}
 
+	/**
+	 * Verify if the method get_course_ids returns the same result as get_course_id
+	 *
+	 * @covers Sensei_Lesson::get_course_ids
+	 */
 	public function testGetCourseIds() {
 		$this->assertTrue(
 			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_ids' ),
@@ -155,7 +165,11 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		}
 	}
 
-
+	/**
+	 * Verify if the method getCourseIds is being cached properly
+	 *
+	 * @covers Sensei_Lesson::get_course_ids
+	 */
 	public function testGetCourseIdsCache() {
 		$this->assertTrue(
 			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_ids' ),

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -105,21 +105,52 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_id' ),
 			'The lesson class method `get_course_id` does not exist '
 		);
-		$course_ids = $this->factory->course->create_many( 2 );
-		$lesson_ids = $this->factory->lesson->create_many( 8 );
-		$to_check   = array();
+		$course_ids = $this->factory->course->create_many( 3 );
+		$lesson_ids = $this->factory->lesson->create_many( 9 );
+		$lesson_id_to_course_id   = array();
 		foreach ( $lesson_ids as $lesson_id ) {
 			$course_index           = array_rand( $course_ids );
 			$course_id              = $course_ids[ $course_index ];
-			$to_check[ $lesson_id ] = $course_id;
+			$lesson_id_to_course_id[ $lesson_id ] = $course_id;
 			update_post_meta( $lesson_id, '_lesson_course', $course_id );
 		}
-		foreach ( $to_check as $lesson_id => $expected_course_id ) {
+		foreach ( $lesson_id_to_course_id as $lesson_id => $expected_course_id ) {
 			$course_id = Sensei()->lesson->get_course_id( $lesson_id );
 			$this->assertEquals(
 				$expected_course_id,
 				$course_id,
 				"Lesson with ID {$lesson_id} has course ID {$course_id}, expected {$expected_course_id}"
+			);
+		}
+	}
+
+	public function testGetCourseIds() {
+		$this->assertTrue(
+			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_ids' ),
+			'The lesson class method `get_course_ids` does not exist '
+		);
+		$course_ids = $this->factory->course->create_many( 3 );
+		$lesson_ids = $this->factory->lesson->create_many( 9 );
+		$lesson_id_to_course_id   = array();
+		foreach ( $lesson_ids as $lesson_id ) {
+			$course_index           = array_rand( $course_ids );
+			$course_id              = $course_ids[ $course_index ];
+			$lesson_id_to_course_id[ $lesson_id ] = $course_id;
+			update_post_meta( $lesson_id, '_lesson_course', $course_id );
+		}
+		$courses_id = Sensei()->lesson->get_course_ids( $lesson_ids );
+		foreach ( $lesson_id_to_course_id as $lesson_id => $expected_course_id ) {
+			$course_id = $courses_id[ $lesson_id ];
+			$get_course_id_result = Sensei()->lesson->get_course_id( $lesson_id );
+			$this->assertEquals(
+				$expected_course_id,
+				$course_id,
+				"Lesson with ID {$lesson_id} has course ID {$course_id}, expected {$expected_course_id}"
+			);
+			$this->assertEquals(
+				$get_course_id_result,
+				$course_id,
+				"get_course_ids returned ID {$course_id} for lesson {$lesson_id}, but get_course_id returned {$get_course_id_result}"
 			);
 		}
 	}

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -56,10 +56,9 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 	 */
 	public function testIsPreRequisiteComplete() {
 
-		// does this function add_user_data exist?
 		$this->assertTrue(
 			method_exists( 'WooThemes_Sensei_Lesson', 'is_prerequisite_complete' ),
-			'The lesson class function `is_prerequisite_complete` does not exist '
+			'The lesson class method `is_prerequisite_complete` does not exist '
 		);
 
 		// falsy state
@@ -131,7 +130,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		}
 		$this->assertTrue(
 			method_exists( 'WooThemes_Sensei_Lesson', 'add_lesson_to_course_order' ),
-			'The lesson class function `add_lesson_to_course_order` does not exist '
+			'The lesson class method `add_lesson_to_course_order` does not exist '
 		);
 
 		$course_id = $this->factory->course->create();

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -155,6 +155,48 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		}
 	}
 
+
+	public function testGetCourseIdsCache() {
+		$this->assertTrue(
+			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_ids' ),
+			'The lesson class method `get_course_ids` does not exist '
+		);
+		$course_ids             = $this->factory->course->create_many( 3 );
+		$lesson_ids             = $this->factory->lesson->create_many( 9 );
+		$lesson_id_to_course_id = array();
+		foreach ( $lesson_ids as $lesson_id ) {
+			$course_index                         = array_rand( $course_ids );
+			$course_id                            = $course_ids[ $course_index ];
+			$lesson_id_to_course_id[ $lesson_id ] = $course_id;
+			update_post_meta( $lesson_id, '_lesson_course', $course_id );
+		}
+		$courses_id = Sensei()->lesson->get_course_ids( $lesson_ids );
+		foreach ( $lesson_id_to_course_id as $lesson_id => $expected_course_id ) {
+			$course_id            = $courses_id[ $lesson_id ];
+			$get_course_id_result = Sensei()->lesson->get_course_id( $lesson_id );
+			$this->assertEquals(
+				$expected_course_id,
+				$course_id,
+				"Lesson with ID {$lesson_id} has course ID {$course_id}, expected {$expected_course_id}"
+			);
+			$this->assertEquals(
+				$get_course_id_result,
+				$course_id,
+				"get_course_ids returned ID {$course_id} for lesson {$lesson_id}, but get_course_id returned {$get_course_id_result}"
+			);
+		}
+		shuffle($lesson_ids);
+		$courses_id = Sensei()->lesson->get_course_ids( $lesson_ids );
+		foreach ( $lesson_id_to_course_id as $lesson_id => $expected_course_id ) {
+			$course_id            = $courses_id[ $lesson_id ];
+			$this->assertEquals(
+				$expected_course_id,
+				$course_id,
+				"Lesson with ID {$lesson_id} has course ID {$course_id}, expected {$expected_course_id}"
+			);
+		}
+	}
+
 	public function testAddLessonToCourseOrderHook() {
 		if ( ! isset( Sensei()->admin ) ) {
 			Sensei()->admin = new WooThemes_Sensei_Admin();

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -105,12 +105,12 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_id' ),
 			'The lesson class method `get_course_id` does not exist '
 		);
-		$course_ids = $this->factory->course->create_many( 3 );
-		$lesson_ids = $this->factory->lesson->create_many( 9 );
-		$lesson_id_to_course_id   = array();
+		$course_ids             = $this->factory->course->create_many( 3 );
+		$lesson_ids             = $this->factory->lesson->create_many( 9 );
+		$lesson_id_to_course_id = array();
 		foreach ( $lesson_ids as $lesson_id ) {
-			$course_index           = array_rand( $course_ids );
-			$course_id              = $course_ids[ $course_index ];
+			$course_index                         = array_rand( $course_ids );
+			$course_id                            = $course_ids[ $course_index ];
 			$lesson_id_to_course_id[ $lesson_id ] = $course_id;
 			update_post_meta( $lesson_id, '_lesson_course', $course_id );
 		}
@@ -129,18 +129,18 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_ids' ),
 			'The lesson class method `get_course_ids` does not exist '
 		);
-		$course_ids = $this->factory->course->create_many( 3 );
-		$lesson_ids = $this->factory->lesson->create_many( 9 );
-		$lesson_id_to_course_id   = array();
+		$course_ids             = $this->factory->course->create_many( 3 );
+		$lesson_ids             = $this->factory->lesson->create_many( 9 );
+		$lesson_id_to_course_id = array();
 		foreach ( $lesson_ids as $lesson_id ) {
-			$course_index           = array_rand( $course_ids );
-			$course_id              = $course_ids[ $course_index ];
+			$course_index                         = array_rand( $course_ids );
+			$course_id                            = $course_ids[ $course_index ];
 			$lesson_id_to_course_id[ $lesson_id ] = $course_id;
 			update_post_meta( $lesson_id, '_lesson_course', $course_id );
 		}
 		$courses_id = Sensei()->lesson->get_course_ids( $lesson_ids );
 		foreach ( $lesson_id_to_course_id as $lesson_id => $expected_course_id ) {
-			$course_id = $courses_id[ $lesson_id ];
+			$course_id            = $courses_id[ $lesson_id ];
 			$get_course_id_result = Sensei()->lesson->get_course_id( $lesson_id );
 			$this->assertEquals(
 				$expected_course_id,

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -185,10 +185,10 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 				"get_course_ids returned ID {$course_id} for lesson {$lesson_id}, but get_course_id returned {$get_course_id_result}"
 			);
 		}
-		shuffle($lesson_ids);
+		shuffle( $lesson_ids );
 		$courses_id = Sensei()->lesson->get_course_ids( $lesson_ids );
 		foreach ( $lesson_id_to_course_id as $lesson_id => $expected_course_id ) {
-			$course_id            = $courses_id[ $lesson_id ];
+			$course_id = $courses_id[ $lesson_id ];
 			$this->assertEquals(
 				$expected_course_id,
 				$course_id,

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -108,7 +108,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		$course_ids = $this->factory->course->create_many( 2 );
 		$lesson_ids = $this->factory->lesson->create_many( 8 );
 		$to_check   = array();
-		foreach ( $lesson_ids as $index => $lesson_id ) {
+		foreach ( $lesson_ids as $lesson_id ) {
 			$course_index           = array_rand( $course_ids );
 			$course_id              = $course_ids[ $course_index ];
 			$to_check[ $lesson_id ] = $course_id;

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -142,15 +142,14 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		);
 		$course_ids             = $this->factory->course->create_many( 3 );
 		$lesson_ids             = $this->factory->lesson->create_many( 9 );
-		$lesson_id_to_course_id = array();
 		foreach ( $lesson_ids as $lesson_id_index => $lesson_id ) {
 			$course_index                         = $lesson_id_index % count( $course_ids );
 			$course_id                            = $course_ids[ $course_index ];
-			$lesson_id_to_course_id[ $lesson_id ] = $course_id;
 			update_post_meta( $lesson_id, '_lesson_course', $course_id );
 		}
 		$courses_id = Sensei()->lesson->get_course_ids( $lesson_ids );
-		foreach ( $lesson_id_to_course_id as $lesson_id => $expected_course_id ) {
+		foreach ( $lesson_ids as  $lesson_id_index => $lesson_id ) {
+			$expected_course_id   = $lesson_id_index % count( $course_ids );
 			$course_id            = $courses_id[ $lesson_id ];
 			$get_course_id_result = Sensei()->lesson->get_course_id( $lesson_id );
 			$this->assertEquals(
@@ -166,7 +165,8 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		}
 		shuffle( $lesson_ids );
 		$courses_id = Sensei()->lesson->get_course_ids( $lesson_ids );
-		foreach ( $lesson_id_to_course_id as $lesson_id => $expected_course_id ) {
+		foreach ( $lesson_ids as  $lesson_id_index => $lesson_id )
+			$expected_course_id   = $lesson_id_index % count( $course_ids );
 			$course_id = $courses_id[ $lesson_id ];
 			$this->assertEquals(
 				$expected_course_id,

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -142,8 +142,8 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		$course_ids             = $this->factory->course->create_many( 3 );
 		$lesson_ids             = $this->factory->lesson->create_many( 9 );
 		$lesson_id_to_course_id = array();
-		foreach ( $lesson_ids as $lesson_id ) {
-			$course_index                         = array_rand( $course_ids );
+		foreach ( $lesson_ids as $lesson_id_index => $lesson_id ) {
+			$course_index                         = $lesson_id_index % count( $course_ids );
 			$course_id                            = $course_ids[ $course_index ];
 			$lesson_id_to_course_id[ $lesson_id ] = $course_id;
 			update_post_meta( $lesson_id, '_lesson_course', $course_id );
@@ -178,8 +178,8 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		$course_ids             = $this->factory->course->create_many( 3 );
 		$lesson_ids             = $this->factory->lesson->create_many( 9 );
 		$lesson_id_to_course_id = array();
-		foreach ( $lesson_ids as $lesson_id ) {
-			$course_index                         = array_rand( $course_ids );
+		foreach ( $lesson_ids as $lesson_id_index => $lesson_id ) {
+			$course_index                         = $lesson_id_index % count( $course_ids );
 			$course_id                            = $course_ids[ $course_index ];
 			$lesson_id_to_course_id[ $lesson_id ] = $course_id;
 			update_post_meta( $lesson_id, '_lesson_course', $course_id );

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -110,17 +110,16 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_id' ),
 			'The lesson class method `get_course_id` does not exist '
 		);
-		$course_ids             = $this->factory->course->create_many( 3 );
-		$lesson_ids             = $this->factory->lesson->create_many( 9 );
-		$lesson_id_to_course_id = array();
-		foreach ( $lesson_ids as $lesson_id ) {
-			$course_index                         = array_rand( $course_ids );
-			$course_id                            = $course_ids[ $course_index ];
-			$lesson_id_to_course_id[ $lesson_id ] = $course_id;
+		$course_ids = $this->factory->course->create_many( 3 );
+		$lesson_ids = $this->factory->lesson->create_many( 9 );
+		foreach ( $lesson_ids as $lesson_index => $lesson_id ) {
+			$course_index = $lesson_index % count( $course_ids );
+			$course_id    = $course_ids[ $course_index ];
 			update_post_meta( $lesson_id, '_lesson_course', $course_id );
 		}
-		foreach ( $lesson_id_to_course_id as $lesson_id => $expected_course_id ) {
-			$course_id = Sensei()->lesson->get_course_id( $lesson_id );
+		foreach ( $lesson_ids as $lesson_index => $lesson_id ) {
+			$expected_course_id = $lesson_index % count( $course_ids );
+			$course_id          = Sensei()->lesson->get_course_id( $lesson_id );
 			$this->assertEquals(
 				$expected_course_id,
 				$course_id,
@@ -140,11 +139,11 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_ids' ),
 			'The lesson class method `get_course_ids` does not exist '
 		);
-		$course_ids             = $this->factory->course->create_many( 3 );
-		$lesson_ids             = $this->factory->lesson->create_many( 9 );
+		$course_ids = $this->factory->course->create_many( 3 );
+		$lesson_ids = $this->factory->lesson->create_many( 9 );
 		foreach ( $lesson_ids as $lesson_id_index => $lesson_id ) {
-			$course_index                         = $lesson_id_index % count( $course_ids );
-			$course_id                            = $course_ids[ $course_index ];
+			$course_index = $lesson_id_index % count( $course_ids );
+			$course_id    = $course_ids[ $course_index ];
 			update_post_meta( $lesson_id, '_lesson_course', $course_id );
 		}
 		$courses_id = Sensei()->lesson->get_course_ids( $lesson_ids );
@@ -165,9 +164,9 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		}
 		shuffle( $lesson_ids );
 		$courses_id = Sensei()->lesson->get_course_ids( $lesson_ids );
-		foreach ( $lesson_ids as  $lesson_id_index => $lesson_id )
-			$expected_course_id   = $lesson_id_index % count( $course_ids );
-			$course_id = $courses_id[ $lesson_id ];
+		foreach ( $lesson_ids as  $lesson_id_index => $lesson_id ) {
+			$expected_course_id = $lesson_id_index % count( $course_ids );
+			$course_id          = $courses_id[ $lesson_id ];
 			$this->assertEquals(
 				$expected_course_id,
 				$course_id,

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -130,47 +130,12 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify if the method get_course_ids returns the same result as get_course_id.
+	 * Verify if the method get_course_ids returns the same result as get_course_id, while also verifying
+	 * if it is being cached properly.
 	 *
 	 * @covers Sensei_Lesson::get_course_ids
 	 */
 	public function testGetCourseIds() {
-		$this->assertTrue(
-			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_ids' ),
-			'The lesson class method `get_course_ids` does not exist '
-		);
-		$course_ids             = $this->factory->course->create_many( 3 );
-		$lesson_ids             = $this->factory->lesson->create_many( 9 );
-		$lesson_id_to_course_id = array();
-		foreach ( $lesson_ids as $lesson_id_index => $lesson_id ) {
-			$course_index                         = $lesson_id_index % count( $course_ids );
-			$course_id                            = $course_ids[ $course_index ];
-			$lesson_id_to_course_id[ $lesson_id ] = $course_id;
-			update_post_meta( $lesson_id, '_lesson_course', $course_id );
-		}
-		$courses_id = Sensei()->lesson->get_course_ids( $lesson_ids );
-		foreach ( $lesson_id_to_course_id as $lesson_id => $expected_course_id ) {
-			$course_id            = $courses_id[ $lesson_id ];
-			$get_course_id_result = Sensei()->lesson->get_course_id( $lesson_id );
-			$this->assertEquals(
-				$expected_course_id,
-				$course_id,
-				"Lesson with ID {$lesson_id} has course ID {$course_id}, expected {$expected_course_id}"
-			);
-			$this->assertEquals(
-				$get_course_id_result,
-				$course_id,
-				"get_course_ids returned ID {$course_id} for lesson {$lesson_id}, but get_course_id returned {$get_course_id_result}"
-			);
-		}
-	}
-
-	/**
-	 * Verify if the method getCourseIds is being cached properly.
-	 *
-	 * @covers Sensei_Lesson::get_course_ids
-	 */
-	public function testGetCourseIdsCache() {
 		$this->assertTrue(
 			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_ids' ),
 			'The lesson class method `get_course_ids` does not exist '

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -101,7 +101,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify if the method get_course_id returns the expected course ID
+	 * Verify if the method get_course_id returns the expected course ID.
 	 *
 	 * @covers Sensei_Lesson::get_course_id
 	 */
@@ -130,7 +130,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify if the method get_course_ids returns the same result as get_course_id
+	 * Verify if the method get_course_ids returns the same result as get_course_id.
 	 *
 	 * @covers Sensei_Lesson::get_course_ids
 	 */
@@ -166,7 +166,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify if the method getCourseIds is being cached properly
+	 * Verify if the method getCourseIds is being cached properly.
 	 *
 	 * @covers Sensei_Lesson::get_course_ids
 	 */

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -101,6 +101,30 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 
 	}
 
+	public function testGetCourseId() {
+		$this->assertTrue(
+			method_exists( 'WooThemes_Sensei_Lesson', 'get_course_id' ),
+			'The lesson class method `get_course_id` does not exist '
+		);
+		$course_ids = $this->factory->course->create_many( 2 );
+		$lesson_ids = $this->factory->lesson->create_many( 8 );
+		$to_check   = array();
+		foreach ( $lesson_ids as $index => $lesson_id ) {
+			$course_index           = array_rand( $course_ids );
+			$course_id              = $course_ids[ $course_index ];
+			$to_check[ $lesson_id ] = $course_id;
+			update_post_meta( $lesson_id, '_lesson_course', $course_id );
+		}
+		foreach ( $to_check as $lesson_id => $expected_course_id ) {
+			$course_id = Sensei()->lesson->get_course_id( $lesson_id );
+			$this->assertEquals(
+				$expected_course_id,
+				$course_id,
+				"Lesson with ID {$lesson_id} has course ID {$course_id}, expected {$expected_course_id}"
+			);
+		}
+	}
+
 	public function testAddLessonToCourseOrderHook() {
 		if ( ! isset( Sensei()->admin ) ) {
 			Sensei()->admin = new WooThemes_Sensei_Admin();

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -118,8 +118,9 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 			update_post_meta( $lesson_id, '_lesson_course', $course_id );
 		}
 		foreach ( $lesson_ids as $lesson_index => $lesson_id ) {
-			$expected_course_id = $lesson_index % count( $course_ids );
-			$course_id          = Sensei()->lesson->get_course_id( $lesson_id );
+			$expected_course_index = $lesson_index % count( $course_ids );
+			$expected_course_id    = $course_ids[ $expected_course_index ];
+			$course_id             = Sensei()->lesson->get_course_id( $lesson_id );
 			$this->assertEquals(
 				$expected_course_id,
 				$course_id,
@@ -146,11 +147,12 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 			$course_id    = $course_ids[ $course_index ];
 			update_post_meta( $lesson_id, '_lesson_course', $course_id );
 		}
-		$courses_id = Sensei()->lesson->get_course_ids( $lesson_ids );
+		$result_courses_id = Sensei()->lesson->get_course_ids( $lesson_ids );
 		foreach ( $lesson_ids as  $lesson_id_index => $lesson_id ) {
-			$expected_course_id   = $lesson_id_index % count( $course_ids );
-			$course_id            = $courses_id[ $lesson_id ];
-			$get_course_id_result = Sensei()->lesson->get_course_id( $lesson_id );
+			$expected_course_index = $lesson_id_index % count( $course_ids );
+			$expected_course_id    = $course_ids[ $expected_course_index ];
+			$course_id             = $result_courses_id[ $lesson_id ];
+			$get_course_id_result  = Sensei()->lesson->get_course_id( $lesson_id );
 			$this->assertEquals(
 				$expected_course_id,
 				$course_id,
@@ -162,11 +164,14 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 				"get_course_ids returned ID {$course_id} for lesson {$lesson_id}, but get_course_id returned {$get_course_id_result}"
 			);
 		}
-		shuffle( $lesson_ids );
-		$courses_id = Sensei()->lesson->get_course_ids( $lesson_ids );
+		$shuffled_lesson_ids = $lesson_ids;
+		shuffle( $shuffled_lesson_ids );
+		$cached_courses_id = Sensei()->lesson->get_course_ids( $shuffled_lesson_ids );
+		$this->assertEquals( $result_courses_id, $cached_courses_id );
 		foreach ( $lesson_ids as  $lesson_id_index => $lesson_id ) {
-			$expected_course_id = $lesson_id_index % count( $course_ids );
-			$course_id          = $courses_id[ $lesson_id ];
+			$expected_course_index = $lesson_id_index % count( $course_ids );
+			$expected_course_id    = $course_ids[ $expected_course_index ];
+			$course_id             = $cached_courses_id[ $lesson_id ];
 			$this->assertEquals(
 				$expected_course_id,
 				$course_id,


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds the method  `get_course_ids` to the class `Sensei_Lesson` to allow us to get, for a given array of lesson IDs, all course IDs for that array of lesson IDs;

### Testing instructions

1. Change to this branch and run unit tests;
2. Also, use the Testing Instructions on the PR 1357-gh-Automattic/sensei-pro to check if this PR is working as desired;

### Related

Related issue: 1080-gh-Automattic/sensei-pro