### PR TITLE
Add Divi fix when using Learning Mode

### DIFF
--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -113,6 +113,7 @@ body.sensei-course-theme {
 		padding: 32px 0;
 		margin-left: var(--sidebar-width) !important;
 
+		// A Divi fix since it doesn't load Gutenberg block library styles.
 		@at-root {
 			.et_pb_pagebuilder_layout & {
 				flex: 1;

--- a/assets/css/sensei-course-theme/layout.scss
+++ b/assets/css/sensei-course-theme/layout.scss
@@ -112,6 +112,12 @@ body.sensei-course-theme {
 	&__main-content {
 		padding: 32px 0;
 		margin-left: var(--sidebar-width) !important;
+
+		@at-root {
+			.et_pb_pagebuilder_layout & {
+				flex: 1;
+			}
+		}
 	}
 
 	&__header {


### PR DESCRIPTION
Fixes #5292

### Changes proposed in this Pull Request

* @aaronfc gave the idea to include a fix for [this issue](https://github.com/Automattic/sensei/issues/5292#issuecomment-1164614628) in our code since we support Divi and maybe it's something that Divi wouldn't fix easily. So we dug into the issue a little more to find a good permanent solution.

Divi contains this code to dequeue block library styles attached to the `wp_enqueue_scripts` action.

```php
    if ( ! function_exists( 'et_dequeue_block_css' ) ) :
        /**
        * If the option is enabled and the page is built with the Divi Builder,
        * dequeue the gutenberg block css file from the head.
        *
        * @since 4.10.0
        */
        function et_dequeue_block_css() {
            global $shortname;

            $post_id                 = get_the_id();
            $is_page_builder_used    = function_exists( 'et_pb_is_pagebuilder_used' ) ? et_pb_is_pagebuilder_used( $post_id ) : false;
            $defer_block_css_enabled = ( 'on' === et_get_option( $shortname . '_defer_block_css', 'on' ) );

            if ( $is_page_builder_used && $defer_block_css_enabled ) {
                wp_dequeue_style( 'wp-block-library' );
            }
        }
    endif;
```

They also have this code attached to the `body_class` filter.

```php
    // Add the page builder class.
    if ( et_pb_is_pagebuilder_used( get_the_ID() ) && ! ET_GB_Block_Layout::is_layout_block_preview() ) {
        $classes[] = 'et_pb_pagebuilder_layout';
    }
```

So we assume that it's safe to add our solution based on the `.et_pb_pagebuilder_layout`.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course with Learning Mode enabled.
* Make sure Divi builder is enabled for the Lessons in _"WP admin » DIVI » Theme options » Builder » Enable Divi Builder On Post Types » Lessons"_.
* Edit a lesson with Divi builder and save it.
* Check the lesson in the frontend, and make sure the content has a padding around.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

Before the fix:

<img width="1479" alt="Screen Shot 2022-06-24 at 11 08 42" src="https://user-images.githubusercontent.com/876340/175553051-14f89b79-1b58-472f-b09d-b2520ddda6c1.png">

After the fix:

<img width="1481" alt="Screen Shot 2022-06-24 at 11 08 51" src="https://user-images.githubusercontent.com/876340/175553113-ea7d2f1c-e739-47d1-8351-6ff1e47e56f2.png">
