### PR TITLE
Fix Sensei screen IDs

### DIFF
--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -229,7 +229,7 @@ class Sensei_Setup_Wizard {
 	private function should_current_page_display_wizard() {
 		$screen = get_current_screen();
 
-		if ( false !== strpos( $screen->id, 'sensei-lms_page_sensei' ) ) {
+		if ( false !== strpos( $screen->id, 'course_page_sensei' ) ) {
 			return true;
 		}
 

--- a/includes/class-sensei-teacher.php
+++ b/includes/class-sensei-teacher.php
@@ -731,7 +731,7 @@ class Sensei_Teacher {
 		// check if we're on the grading screen
 		$screen = get_current_screen();
 
-		if ( empty( $screen ) || 'sensei-lms_page_sensei_grading' != $screen->id ) {
+		if ( empty( $screen ) || 'course_page_sensei_grading' != $screen->id ) {
 			return $comments;
 		}
 

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -506,7 +506,7 @@ class Sensei_Course_Enrolment_Manager {
 	 */
 	public function add_wcpc_1_notice() {
 		$screen        = get_current_screen();
-		$valid_screens = [ 'dashboard', 'plugins', 'plugins-network', 'sensei-lms_page_sensei_learners' ];
+		$valid_screens = [ 'dashboard', 'plugins', 'plugins-network', 'course_page_sensei_learners' ];
 
 		if ( ! current_user_can( 'activate_plugins' ) || ! in_array( $screen->id, $valid_screens, true ) ) {
 			return;

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -120,7 +120,7 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin_id );
 
-		set_current_screen( 'sensei-lms_page_sensei_test' );
+		set_current_screen( 'course_page_sensei_test' );
 		update_option( \Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
 
 		ob_start();


### PR DESCRIPTION
In [this PR](https://github.com/Automattic/sensei/pull/4618), when the Sensei menu was updated, our screen IDs were also changed. Specifically, they were previously prefixed by `sensei-lms_page_` and in that PR the prefix was changed to `course_page_`. However, not every screen ID check across the codebase was updated based on this change. The PR attempts to fix that.

Adding @Automattic/nexus as reviewers to ensure there isn't anything I'm doing here that interferes with the intention of the original PR.

### Changes proposed in this Pull Request

* Update check for Grading page when filtering.
* Update check for pages that should suggest the Setup Wizard.
* Update check for pages where the WCPC notice should display.

### Testing instructions

There are three features that were broken. I tested two of them, and the third one is probably not crucial for testing.

#### Grading Page

There is an obscure feature in the Grading page where if an Administrator also has the role of Teacher, they should not see the quizzes to be graded by other teachers, but only quizzes for their own courses.

- Create an `admin` user and a `teacher` user.
- Grant the `admin` user the role of `teacher` along with their `admin` role
  - Note: you can use a plugin [such as this one](https://wordpress.org/plugins/hm-multiple-roles/) to grant multiple roles. This is a feature built into WordPress, but doesn't have a UI by default.
  - Note: I wasn't able to set the role for my logged-in `admin` user. I needed to create a second admin.
- Create two courses, each with at least one Lesson with a Quiz. Turn auto-grading OFF.
- Set the "Teacher" for the two courses to the two new users.
- Log in as a student, start both courses, and take both quizzed.
- Log in as the `admin` and go to "Sensei LMS > Grading". Ensure that you ONLY see the quiz submission for that admin user's course.

#### Sensei Wizard Notice

- In the database, set the option `sensei_suggest_setup_wizard` to `1`.
- Open any Sensei page.
- Ensure that there is a notice for the Setup Wizard.

#### WCPC 1.x notice

This notice is for compatibility with an old version of WCPC. If someone is still using this old version (which is unlikely at this point), they will still see the notice on several non-Sensei pages. To save time, I didn't bother testing this one.