### PR TITLE
Fix performance for My Courses shortcode.

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -268,7 +268,7 @@ class Sensei_Course {
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
-		return $course_enrolment->is_enrolled( $user_id );
+		return $course_enrolment->is_enrolled( $user_id, false );
 	}
 
 	/**

--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -268,7 +268,7 @@ class Sensei_Course {
 
 		$course_enrolment = Sensei_Course_Enrolment::get_course_instance( $course_id );
 
-		return $course_enrolment->is_enrolled( $user_id, false );
+		return $course_enrolment->is_enrolled( $user_id );
 	}
 
 	/**

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -377,6 +377,8 @@ class Sensei_Learner {
 			'order'       => $order,
 			'orderby'     => $orderby,
 			'tax_query'   => [], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Just empty to set array.
+			'lazy_load_term_meta' => false,
+			'cache_results' => false,
 		];
 
 		$query_args   = array_merge( $default_args, $base_query_args );

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -585,7 +585,7 @@ class Sensei_Learner {
 	/**
 	 * Get all users.
 	 *
-	 * @param array $args
+	 * @param array $args Arguments.
 	 *
 	 * @deprecated 3.0.0
 	 *

--- a/includes/class-sensei-learner.php
+++ b/includes/class-sensei-learner.php
@@ -373,12 +373,12 @@ class Sensei_Learner {
 		}
 
 		$default_args = [
-			'post_status' => 'publish',
-			'order'       => $order,
-			'orderby'     => $orderby,
-			'tax_query'   => [], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Just empty to set array.
+			'post_status'         => 'publish',
+			'order'               => $order,
+			'orderby'             => $orderby,
+			'tax_query'           => [], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query -- Just empty to set array.
 			'lazy_load_term_meta' => false,
-			'cache_results' => false,
+			'cache_results'       => false,
 		];
 
 		$query_args   = array_merge( $default_args, $base_query_args );

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -546,7 +546,6 @@ class Sensei_Course_Enrolment {
 
 		if ( $result ) {
 			$this->removed_learners = $removed_learners;
-
 			return true;
 		}
 

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -214,7 +214,7 @@ class Sensei_Course_Enrolment {
 		// We are retrieving the associated object_ids from the term and not the other way around (has_term) for performance reasons.
 		$object_ids = get_objects_in_term( $term->term_id, Sensei_PostTypes::LEARNER_TAXONOMY_NAME );
 
-		return in_array( $this->course_id, $object_ids, true );
+		return in_array( (string) $this->course_id, $object_ids, true );
 	}
 
 	/**

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -211,7 +211,10 @@ class Sensei_Course_Enrolment {
 	private function has_stored_enrolment( $user_id ) {
 		$term = Sensei_Learner::get_learner_term( $user_id );
 
-		return has_term( $term->term_id, Sensei_PostTypes::LEARNER_TAXONOMY_NAME, $this->course_id );
+		// We are retrieving the associated object_ids from the term and not the other way around (has_term) for performance reasons.
+		$object_ids = get_objects_in_term( $term->term_id, Sensei_PostTypes::LEARNER_TAXONOMY_NAME );
+
+		return in_array( $this->course_id, $object_ids, true );
 	}
 
 	/**
@@ -225,6 +228,13 @@ class Sensei_Course_Enrolment {
 	 */
 	public function save_enrolment( $user_id, $is_enrolled ) {
 		$term = Sensei_Learner::get_learner_term( $user_id );
+
+		$is_enrolled_current = $this->has_stored_enrolment( $user_id );
+
+		// Nothing has changed.
+		if ( $is_enrolled_current === $is_enrolled ) {
+			return true;
+		}
 
 		if ( ! $is_enrolled ) {
 			$result = true === wp_remove_object_terms( $this->course_id, [ intval( $term->term_id ) ], Sensei_PostTypes::LEARNER_TAXONOMY_NAME );
@@ -373,7 +383,7 @@ class Sensei_Course_Enrolment {
 	 * Get a enrolment provider's state for a user.
 	 *
 	 * @param Sensei_Course_Enrolment_Provider_Interface $provider Provider object.
-	 * @param int                                        $user_id User ID.
+	 * @param int                                        $user_id  User ID.
 	 *
 	 * @return Sensei_Enrolment_Provider_State
 	 * @throws Exception When learner term could not be created.
@@ -536,6 +546,7 @@ class Sensei_Course_Enrolment {
 
 		if ( $result ) {
 			$this->removed_learners = $removed_learners;
+
 			return true;
 		}
 

--- a/includes/enrolment/class-sensei-course-enrolment.php
+++ b/includes/enrolment/class-sensei-course-enrolment.php
@@ -226,13 +226,6 @@ class Sensei_Course_Enrolment {
 	public function save_enrolment( $user_id, $is_enrolled ) {
 		$term = Sensei_Learner::get_learner_term( $user_id );
 
-		$is_enrolled_current = has_term( $term->term_id, Sensei_PostTypes::LEARNER_TAXONOMY_NAME, $this->course_id );
-
-		// Nothing has changed.
-		if ( $is_enrolled_current === $is_enrolled ) {
-			return true;
-		}
-
 		if ( ! $is_enrolled ) {
 			$result = true === wp_remove_object_terms( $this->course_id, [ intval( $term->term_id ) ], Sensei_PostTypes::LEARNER_TAXONOMY_NAME );
 		} else {


### PR DESCRIPTION
Fixes #5247

### Changes proposed in this Pull Request
* Tweak the query arguments for courses to avoid querying the full list of users associated to the course when not needed.
* Reimplemented the `has_stored_enrolment` method for the same reason.
* More details in the P2 post: p6rkRX-3Kn-p2

### Testing instructions
* Test that everything is working as expected after this change.
* Test that My Courses page loads faster.
  * In order to reproduce this you will need to have many users registered in your local site... I did it by using All In One Migration plugin from wpcourses to my local site, but I spent multiple hours with this).

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
#### BEFORE
<img width="1727" alt="image" src="https://user-images.githubusercontent.com/799065/176167107-41c7f2a7-8ebd-4e96-9995-eb77f2173b67.png">

#### AFTER
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/799065/176166897-b24ba01c-25d3-47ed-ad9a-3746d781100f.png">