### PR TITLE
Add release checklist

### DIFF
--- a/.github/RELEASE-CHECKLIST.yml
+++ b/.github/RELEASE-CHECKLIST.yml
@@ -1,0 +1,9 @@
+paths:
+  "**":
+    - Check that the installed version is correct on the Plugins page.
+    - Create and publish a course, a module, and a lesson to the course.
+    - Enable the learning mode in the course.
+    - Log in with a user and complete the course.
+    - Visit Students in admin and observe that the user is displayed with the course completed.
+    - Disable learning mode in the course.
+    - Visit the course again to make sure that it displayed correctly.

--- a/.github/workflows/release-checklist.yml
+++ b/.github/workflows/release-checklist.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Checklist
-        uses: wyozi/contextual-qa-checklist-action@master
+        uses: automattic/contextual-qa-checklist-action@master
         with:
           gh-token: ${{ secrets.GITHUB_TOKEN }}
           input-file: .github/RELEASE-CHECKLIST.yml

--- a/.github/workflows/release-checklist.yml
+++ b/.github/workflows/release-checklist.yml
@@ -1,0 +1,25 @@
+name: Plugin Release Build
+
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - 'trunk'
+
+jobs:
+  checklist_job:
+    if: ${{ startsWith( github.head_ref, 'release/' ) }}
+    runs-on: ubuntu-latest
+    name: Sensei release checklist
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Checklist
+        uses: wyozi/contextual-qa-checklist-action@master
+        with:
+          gh-token: ${{ secrets.GITHUB_TOKEN }}
+          input-file: .github/RELEASE-CHECKLIST.yml
+          comment-header: 'Please perform the following tests with the built package in a new installation before publishing:'
+          comment-footer: '' 
+          show-paths: false


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Adds a test checklist to be executed before publishing a new release.

![Screenshot 2022-06-28 at 18 20 30](https://user-images.githubusercontent.com/53191348/176217427-83f2d143-2325-4361-b580-b64a889e158e.png)

### Testing instructions

* Observe that the checklist is added when a PR against trunk is raised.
* Not sure if this is testable in this repo, I tested it in a private clone of Sensei.