### PR TITLE
Fix students admin area

### DIFF
--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -322,7 +322,15 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 			<option value="0"><?php echo esc_html( $select_label ); ?></option>
 			<?php
 			foreach ( $courses as $course ) {
-				echo '<option value="' . esc_attr( $course->ID ) . '"' . selected( $course->ID, $selected_course, false ) . '>' . esc_html( $course->post_title ) . '</option>';
+				$option_label = __( '(no title)', 'sensei-lms' );
+
+				if ( empty( $course->post_title ) ) {
+					$option_label = $option_label . ' ID: ' . $course->ID;
+				} else {
+					$option_label = $course->post_title;
+				}
+
+				echo '<option value="' . esc_attr( $course->ID ) . '"' . selected( $course->ID, $selected_course, false ) . '>' . esc_html( $option_label ) . '</option>';
 			}
 			?>
 		</select>

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -322,13 +322,9 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 			<option value="0"><?php echo esc_html( $select_label ); ?></option>
 			<?php
 			foreach ( $courses as $course ) {
-				$option_label = __( '(no title)', 'sensei-lms' );
-
-				if ( empty( $course->post_title ) ) {
-					$option_label = $option_label . ' ID: ' . $course->ID;
-				} else {
-					$option_label = $course->post_title;
-				}
+				$option_label = empty( $course->post_title )
+					? __( '(no title)', 'sensei-lms' ) . ' ID: ' . $course->ID
+					: $course->post_title;
 
 				echo '<option value="' . esc_attr( $course->ID ) . '"' . selected( $course->ID, $selected_course, false ) . '>' . esc_html( $option_label ) . '</option>';
 			}

--- a/includes/class-sensei-db-query-learners.php
+++ b/includes/class-sensei-db-query-learners.php
@@ -45,7 +45,28 @@ class Sensei_Db_Query_Learners {
 			$user_query_args['number'] = -1;
 
 			$user_query        = new WP_User_Query( $user_query_args );
-			$matching_user_ids = array_map( 'absint', $user_query->get_results() );
+			$matching_user_ids = $user_query->get_results();
+		}
+
+		if ( ! empty( $this->filter_by_course_id ) ) {
+			$eq = ( 'inc' === $this->filter_type ) ? '=' : '!=';
+
+			$sql = "
+				SELECT
+					`cf`.`user_id`
+				FROM `{$wpdb->comments}` AS `cf`
+					WHERE `cf`.`comment_type` = 'sensei_course_status'
+					AND `cf`.comment_post_ID {$eq} {$this->filter_by_course_id}
+					AND `cf`.comment_approved IS NOT NULL";
+
+			$results  = $wpdb->get_results( $sql );
+			$user_ids = wp_list_pluck( $results, 'user_id' );
+
+			if ( ! empty( $matching_user_ids ) ) {
+				$matching_user_ids = array_intersect( $user_ids, $matching_user_ids );
+			} else {
+				$matching_user_ids = $user_ids;
+			}
 		}
 
 		/*
@@ -61,22 +82,12 @@ class Sensei_Db_Query_Learners {
 				0 AS 'course_count'
 			FROM `{$wpdb->users}` AS `u`";
 
-		if ( ! empty( $this->filter_by_course_id ) ) {
-			$eq = ( 'inc' === $this->filter_type ) ? '=' : '!=';
-
-			$sql .= "
-				INNER JOIN `{$wpdb->comments}` AS `cf`
-					ON `u`.`ID` = `cf`.`user_id`
-					AND `cf`.`comment_type` = 'sensei_course_status'
-					AND `cf`.comment_post_ID {$eq} {$this->filter_by_course_id}
-					AND `cf`.comment_approved IS NOT NULL";
-		}
-
 		$sql .= ' WHERE 1=1';
 
 		if ( null !== $matching_user_ids ) {
-			$user_id_in = empty( $matching_user_ids ) ? 'false' : implode( ',', $matching_user_ids );
-			$sql       .= " AND u.ID IN ({$user_id_in})";
+			$matching_user_ids = array_map( 'absint', $matching_user_ids );
+			$user_id_in        = empty( $matching_user_ids ) ? 'false' : implode( ',', $matching_user_ids );
+			$sql              .= " AND u.ID IN ({$user_id_in})";
 		}
 
 		$sql .= ' GROUP BY `u`.`ID`';

--- a/includes/class-sensei-db-query-learners.php
+++ b/includes/class-sensei-db-query-learners.php
@@ -59,7 +59,7 @@ class Sensei_Db_Query_Learners {
 					AND `cf`.comment_post_ID {$eq} {$this->filter_by_course_id}
 					AND `cf`.comment_approved IS NOT NULL";
 
-			$results  = $wpdb->get_results( $sql );
+			$results  = $wpdb->get_results( $sql ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery
 			$user_ids = wp_list_pluck( $results, 'user_id' );
 
 			if ( ! empty( $matching_user_ids ) ) {

--- a/includes/class-sensei-db-query-learners.php
+++ b/includes/class-sensei-db-query-learners.php
@@ -109,6 +109,10 @@ class Sensei_Db_Query_Learners {
 	private function get_last_activity_date_by_users( $user_ids ) {
 		global $wpdb;
 
+		if ( empty( $user_ids ) ) {
+			return [];
+		}
+
 		$in_placeholders = implode( ', ', array_fill( 0, count( $user_ids ), '%s' ) );
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.DirectDatabaseQuery.DirectQuery


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes some issues in the Students admin area.
  * **Issue 1:** The Filter By Course field was listing courses with no title as an empty text. (_`<option></option>`_)
  * **Issue 2:** SQL error when filtering by courses with no students.
  * **Issue 3:** We need to avoid Inner Joins with the user table in order to support environments where the user table is in different place.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
**Issue 1:**
* Create some courses with no title.
* Access WP Admin > Sensei LMS > Students.
* Check the Filter By Course select, and make sure the courses without title contains a text _"(no title) ID: XXX"_.

**Issue 2:**
* Filter by a course with no students, and make sure no PHP errors are logged.

**Issue 3:** 
* Search for students using the "Search Students" form in the top right, and make sure it works properly.

### Context

p6rkRX-3N9-p2