### PR TITLE
Check video embed code duplication by css class.

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -847,7 +847,7 @@ class Sensei_Frontend {
 
 			if ( '' != $lesson_video_embed ) {
 				?>
-				<div class="video <?php echo esc_attr(self::VIDEO_EMBED_CLASS); ?>"><?php echo wp_kses( $lesson_video_embed, $this->allowed_html ); ?></div>
+				<div class="video <?php echo esc_attr( self::VIDEO_EMBED_CLASS ); ?>"><?php echo wp_kses( $lesson_video_embed, $this->allowed_html ); ?></div>
 				<?php
 			}
 		}

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -847,7 +847,7 @@ class Sensei_Frontend {
 
 			if ( '' != $lesson_video_embed ) {
 				?>
-				<div class="video <?php echo self::VIDEO_EMBED_CLASS; ?>"><?php echo wp_kses( $lesson_video_embed, $this->allowed_html ); ?></div>
+				<div class="video <?php echo esc_attr(self::VIDEO_EMBED_CLASS); ?>"><?php echo wp_kses( $lesson_video_embed, $this->allowed_html ); ?></div>
 				<?php
 			}
 		}

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -42,6 +42,8 @@ class Sensei_Frontend {
 	 */
 	public $allowed_html;
 
+	const VIDEO_EMBED_CLASS = 'sensei-video-embed';
+
 	/**
 	 * Constructor.
 	 *
@@ -845,7 +847,7 @@ class Sensei_Frontend {
 
 			if ( '' != $lesson_video_embed ) {
 				?>
-				<div class="video"><?php echo wp_kses( $lesson_video_embed, $this->allowed_html ); ?></div>
+				<div class="video <?php echo self::VIDEO_EMBED_CLASS; ?>"><?php echo wp_kses( $lesson_video_embed, $this->allowed_html ); ?></div>
 				<?php
 			}
 		}

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -490,7 +490,7 @@ class Sensei_Course_Theme {
 
 		// Checks if video is already added in the content to avoid it duplicated when `the_content`
 		// filter is called more than once.
-		if ( ! empty( $video ) && false === strpos( $content, $video ) ) {
+		if ( ! empty( $video ) && false === strpos( $content, Sensei_Frontend::VIDEO_EMBED_CLASS ) ) {
 			return $video . $content;
 		}
 

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme.php
@@ -17,6 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Course_Theme_Test extends WP_UnitTestCase {
 
 	use Sensei_Test_Login_Helpers;
+	use Sensei_Course_Enrolment_Test_Helpers;
 	use Sensei_Course_Enrolment_Manual_Test_Helpers;
 
 	/**
@@ -40,6 +41,7 @@ class Sensei_Course_Theme_Test extends WP_UnitTestCase {
 		parent::setup();
 		$this->factory  = new Sensei_Factory();
 		$this->instance = Sensei_Course_Theme::instance();
+		$this->prepareEnrolmentManager();
 	}
 
 	/**

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme.php
@@ -17,6 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 class Sensei_Course_Theme_Test extends WP_UnitTestCase {
 
 	use Sensei_Test_Login_Helpers;
+	use Sensei_Course_Enrolment_Manual_Test_Helpers;
 
 	/**
 	 * Sensei Factory helper class - useful to create objects for testing.
@@ -79,5 +80,34 @@ class Sensei_Course_Theme_Test extends WP_UnitTestCase {
 		$_GET[ Sensei_Course_Theme::PREVIEW_QUERY_VAR ] = (string) $another_course->ID;
 		$allowed                                        = Sensei_Course_Theme::is_preview_mode( $course->ID );
 		$this->assertFalse( $allowed, 'Should not allow preview if preview query id is not current course page.' );
+	}
+
+	public function testAddLessonVideoToContentAddsOnlyOnceEvenIfCalledMultipleTimes() {
+		$course_info = $this->factory->get_course_with_lessons();
+		$course_id   = $course_info['course_id'];
+		$lesson_id   = array_pop( $course_info['lesson_ids'] );
+		$lesson      = get_post( $lesson_id );
+
+		// Setup globals.
+		$GLOBALS['post']                = $lesson;
+		$GLOBALS['wp_query']->post      = $lesson;
+		$GLOBALS['wp_query']->is_single = true;
+
+		// Set video embed.
+		update_post_meta( $lesson_id, '_lesson_video_embed', 'VIDEO_EMBED_CODE' );
+
+		// Enable Learning Mode (course theme).
+		update_post_meta( $course_id, Sensei_Course_Theme_Option::THEME_POST_META_NAME, Sensei_Course_Theme_Option::SENSEI_THEME );
+
+		// Enrol student in course.
+		$user_id = $this->login_as_student()->get_user_by_role( 'subscriber' );
+		$this->manuallyEnrolStudentInCourse( $user_id, $course_id );
+
+		$input = 'THE LESSON CONTENT';
+		// Call method two times.
+		$output = $this->instance->add_lesson_video_to_content( $input );
+		$output = $this->instance->add_lesson_video_to_content( $output );
+		// Expect only one video embed class.
+		$this->assertEquals( 1, substr_count( $output, Sensei_Frontend::VIDEO_EMBED_CLASS ) );
 	}
 }


### PR DESCRIPTION
Fixes #5313

### Changes proposed in this Pull Request
* Add a new css class to the video embed wrapper div.
* Check for the css class instead of the whole embed code to avoid duplications when `the_content` is called multiple times.

### Testing instructions
* Enable Learning Mode.
* Create a lesson and include a video embed (using the legacy setting) containing an iframe. For example: `<iframe src="https://player.vimeo.com/video/300279023?h=f4d3811cbb" width="1080" height="608" frameborder="0" allowfullscreen></iframe>`.
* View the lesson and check that the video is shown only once.
* For the issue to happen `the_content` filter must be colled more than once. This happens when using the Divi Builder or in some cases with some SEO plugins.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
#### BEFORE
<img width="892" alt="image" src="https://user-images.githubusercontent.com/799065/176655689-9b660ae6-f2a1-434d-9532-c6ca2443d5d5.png">

#### AFTER
<img width="918" alt="image" src="https://user-images.githubusercontent.com/799065/176655890-796076f4-d40f-4d9c-bf5e-6fb4960d217c.png">


