### PR TITLE
Avoid using GLOB_BRACE so Sensei can run even successfully in non-GNU operating systems

### DIFF
--- a/includes/admin/class-sensei-status.php
+++ b/includes/admin/class-sensei-status.php
@@ -210,7 +210,7 @@ class Sensei_Status {
 
 		$template_dir = Sensei()->plugin_path . 'templates/';
 		$files        = glob( $template_dir . '*.php' );
-		$files       += glob( $template_dir . '**/*.php' );
+		$files        = array_merge( $files, glob( $template_dir . '**/*.php' ) );
 
 		foreach ( $files as $template_path ) {
 			$template               = substr( $template_path, strlen( $template_dir ) );

--- a/includes/admin/class-sensei-status.php
+++ b/includes/admin/class-sensei-status.php
@@ -209,7 +209,8 @@ class Sensei_Status {
 		$templates = [];
 
 		$template_dir = Sensei()->plugin_path . 'templates/';
-		$files        = glob( $template_dir . '{*.php,**/*.php}', GLOB_BRACE );
+		$files        = glob( $template_dir . '*.php' );
+		$files       += glob( $template_dir . '**/*.php' );
 
 		foreach ( $files as $template_path ) {
 			$template               = substr( $template_path, strlen( $template_dir ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* This PR allows the class `Sensei_Status` to avoid using `GLOB_BRACE`, using instead two `glob` calls to have equivalent access; 

### Testing instructions

1. Run the unit tests, and verify that nothing breaks nor that we have warnings about non-defined constants on the tests;
2. Maybe create a [theme override](https://senseilms.com/documentation/theming/) to check if the code still works;

### Context

I'm using a Docker Container to run PHP Unit Tests, and that docker container is based on [Alpine Linux](https://www.alpinelinux.org/), which uses `musl` instead of `glibc` and, because of that, doesn't support `GLOB_BRACE` defined. Because of that, PHP fails to find the constant `GLOB_BRACE` defined, and emits a warning while running the unit tests because of that. This PR fixes that issue.


