### PR TITLE
Fix quiz saving issue

### DIFF
--- a/assets/blocks/course-outline/course-outline-store.js
+++ b/assets/blocks/course-outline/course-outline-store.js
@@ -59,6 +59,9 @@ registerStructureStore( {
 			false
 		);
 	},
+	blockExists() {
+		return !! getEditorOutlineBlock();
+	},
 	readBlock: getEditorOutlineStructure,
 	*saveError( error ) {
 		const errorMessage = sprintf(

--- a/assets/blocks/quiz/data.js
+++ b/assets/blocks/quiz/data.js
@@ -130,6 +130,10 @@ export function parseQuestionBlocks( blocks ) {
 		};
 	} );
 
+	if ( 0 === questions.length ) {
+		return questions;
+	}
+
 	const lastQuestion = questions.pop();
 
 	if ( ! isQuestionEmpty( lastQuestion ) ) {

--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -118,29 +118,38 @@ registerStructureStore( {
 			snakeCase
 		);
 
+		const lesson = select( 'core/editor' ).getCurrentPost();
+		const serverStructure = select( QUIZ_STORE ).getServerStructure();
+
 		const questionBlocks = select( 'core/block-editor' ).getBlocks(
 			clientId
 		);
 
-		const questionBlockAttributes = parseQuestionBlocks( questionBlocks );
+		let questions = [];
 
-		const serverQuestionsById = keyBy(
-			select( QUIZ_STORE ).getServerStructure().questions,
-			'id'
-		);
+		if ( 0 < questionBlocks.length && serverStructure ) {
+			const questionBlockAttributes = parseQuestionBlocks(
+				questionBlocks
+			);
 
-		const lesson = select( 'core/editor' ).getCurrentPost();
+			const serverQuestionsById = keyBy(
+				serverStructure.questions,
+				'id'
+			);
+
+			questions = questionBlockAttributes.map( ( question ) =>
+				// Avoid overriding non-editable question.
+				false === question.editable
+					? serverQuestionsById[ question.id ]
+					: omit( question, READ_ONLY_ATTRIBUTES )
+			);
+		}
 
 		return {
 			lesson_status: lesson?.status,
 			lesson_title: lesson?.title,
 			options,
-			questions: questionBlockAttributes.map( ( question ) =>
-				// Avoid overriding non-editable question.
-				false === question.editable
-					? serverQuestionsById[ question.id ]
-					: omit( question, READ_ONLY_ATTRIBUTES )
-			),
+			questions,
 		};
 	},
 

--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -89,6 +89,13 @@ registerStructureStore( {
 	},
 
 	/**
+	 * Checks if quiz block exists.
+	 */
+	blockExists() {
+		return !! select( QUIZ_STORE ).getBlock();
+	},
+
+	/**
 	 * Parse question blocks and quiz settings from Quiz block.
 	 *
 	 * @throws {Object} Quiz structure.

--- a/assets/shared/structure/structure-store.js
+++ b/assets/shared/structure/structure-store.js
@@ -24,6 +24,7 @@ import '../data/api-fetch-preloaded-once';
  * @param {Function} opts.fetchError         Handler for displaying fetch errors.
  * @param {Function} opts.clearError         Handler for clearing errors.
  * @param {Function} opts.updateBlock        Update block with given structure.
+ * @param {Function} opts.blockExists        Check if block exists.
  * @param {Function} opts.readBlock          Extract structure from block.
  * @param {Function} opts.setServerStructure Set the server structure which is used to track differences.
  */
@@ -34,6 +35,7 @@ export function registerStructureStore( {
 	fetchError,
 	clearError,
 	updateBlock,
+	blockExists,
 	readBlock,
 	setServerStructure,
 	...store
@@ -237,6 +239,12 @@ export function registerStructureStore( {
 			if ( ! editor || ! editPostSelector ) {
 				return;
 			}
+
+			// Check if the block exists.
+			if ( ! blockExists() ) {
+				return;
+			}
+
 			const isSavingPost =
 				editor.isSavingPost() && ! editor.isAutosavingPost();
 			const isSavingStructure = select(

--- a/assets/shared/structure/structure-store.test.js
+++ b/assets/shared/structure/structure-store.test.js
@@ -21,6 +21,7 @@ describe( 'Structure store', () => {
 			getEndpoint: jest.fn(),
 			updateBlock: jest.fn(),
 			readBlock: jest.fn(),
+			blockExists: jest.fn().mockReturnValue( true ),
 		};
 		( { unsubscribe } = registerStructureStore( store ) );
 		const storesForRegister = {


### PR DESCRIPTION
Fixes #5317

### Changes proposed in this Pull Request

* It fixes an issue that happens when the Quiz block (or the Course Outline block for other context) are not in the page when the page loads. Thank you for working on that with me @aaronfc!
  * It started happening after we removed the Quiz block from the default lesson template.
  * Basically, a quiz store is registered when the quiz block is loaded in our bundle. And the store expected that after the post saving it would start saving the quiz structure, which is not true because the quiz block doesn't exist. It would cause the script to be stuck in [this conditional](https://github.com/Automattic/sensei/blob/version/4.5.1/assets/shared/structure/structure-store.js#L255-L271) because the post saving would complete, setting the `structureStartedSaving` to `true`, but it would never be set to false because the structure would never save. So we'd need to refresh the page with the quiz block in the page when we saving the post to make it work.
  * The change, basically adds an extra check if the block exists to run that whole logic, otherwise, it will skip it.

IMO, this is a little complex and we should try to make a bigger refactor at some point trying to simplify it. It's hard because we need some "hacks" to handle what we need to do with the features we have from WP, but maybe we could try to create some abstractions. One thing that we already have that could help a little is the `editorLifecycle` function (probably needs to be enhanced to support the [meta saving checks](https://github.com/Automattic/sensei/pull/5151) too).

I think we'll still have some edge cases with our current logic. But much more unlikely to happen (like adding/removing quiz block during the save moment). And it would probably be solvable as this current issue with a refresh in the page and a new post save.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
**Quiz block:**

1. Create a new Lesson.
2. Close the Lesson wizard.
3. Add a Quiz block.
4. Add some questions to the quiz.
5. Open the network in your browser console.
6. Publish the lesson (should not be published yet).
7. Make sure `https://.../wp-json/sensei-internal/v1/lesson-quiz/{ID}?context=edit&_locale=user` was called.
8. Go to the quiz in the frontend and make sure it contains the added questions.

**Course Outline block:**

1. Edit the `includes/block-patterns/course/templates/course-default.php` removing the [`wp:sensei-lms/course-outline` block (starting in the line 23)](https://github.com/Automattic/sensei/blob/version/4.5.1/includes/block-patterns/course/templates/course-default.php#L23-L29).
2. Create a new course.
3. Close the Course wizard.
4. Add the Course Outline block.
5. Add a lesson.
6. Open the network in your browser console.
7. Publish the course (should not be published yet).
8. Make sure `https://.../wp-json/sensei-internal/v1/course-structure/2422?context=edit&_locale=user` was called.
9. Go to the course in the frontend and make sure it contains the added lessons.

Try to reproduce other flows that you can think of creating a course and a lesson with quiz, and make sure it's created properly.