### PR TITLE
Filter providers before checking if they handle enrolment on the frontend

### DIFF
--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -225,7 +225,7 @@ class Sensei_Course_Enrolment_Manager {
 		/**
 		 * Filter providers that can handle frontend enrolment.
 		 *
-		 * This filter is used to prevent frontend enrolment when a non-manual provider handles enrolment.
+		 * It is used to filter providers that can affect enrolment on the frontend.
 		 *
 		 * @since $$next-version$$
 		 *

--- a/includes/enrolment/class-sensei-course-enrolment-manager.php
+++ b/includes/enrolment/class-sensei-course-enrolment-manager.php
@@ -222,6 +222,17 @@ class Sensei_Course_Enrolment_Manager {
 
 		unset( $all_providers[ Sensei_Course_Manual_Enrolment_Provider::instance()->get_id() ] );
 
+		/**
+		 * Filter providers that can handle frontend enrolment.
+		 *
+		 * This filter is used to prevent frontend enrolment when a non-manual provider handles enrolment.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param Sensei_Course_Enrolment_Provider_Interface[] $providers List of enrolment providers instances.
+		 */
+		$all_providers = apply_filters( 'sensei_course_enrolment_providers_prevent_manual_enrol', $all_providers );
+
 		foreach ( $all_providers as $provider ) {
 			if ( $provider->handles_enrolment( $course_id ) ) {
 				// One of the other providers handles enrolment. Prevent enrolment on the frontend form.


### PR DESCRIPTION
The idea here is to allow having providers that don't affect enrolment on the frontend.

### Changes proposed in this Pull Request

* Filter providers before checking if they handle enrolment on the frontend

### New/Updated Hooks

* `sensei_course_enrolment_providers_prevent_manual_enrol` - Filter providers that can handle frontend enrolment.