### PR TITLE
Fix unexpected style on the body

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -61,7 +61,7 @@ a.sensei-certificate-link {
 }
 
 /* Courses */
-.course,
+.course:not(body),
 .course-container,
 .course-container .course {
   @include clearfix();


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes an issue reported in https://wordpress.org/support/topic/blank-space-on-course-page/ (p1656924227897299-slack-C02P7FHLVR9)
* The issue is that the course page contains a weird border at the bottom. It's a very old class, and I'm not sure about all the purposes of that. One of them is a border in the course page list. But it seems it's a mistake to apply it to the body. So because I'm not sure about all of the purposes, I just added a `:not(body)`.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course and open it in the frontend.
* Make sure you don't see a border at the bottom of the `body`.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

The unexpected border that appears only in the course pages:

<img width="1392" alt="Screen Shot 2022-07-04 at 11 13 40" src="https://user-images.githubusercontent.com/876340/177172258-478f30f2-b80d-4897-a38b-26c1549d04c5.png">
