### PR TITLE
Remove unquoted complex placeholders

### DIFF
--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1178,13 +1178,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @param WP_User_Query $query The user query.
 	 */
 	public function add_orderby_custom_field_to_query( WP_User_Query $query ) {
-		global $wpdb;
-
-		$query->query_orderby = $wpdb->prepare(
-			'ORDER BY %1s %1s', // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder -- not needed.
-			$query->query_vars['orderby'],
-			$query->query_vars['order']
-		);
+		$query->query_orderby = 'ORDER BY ' . $query->query_vars['orderby'] . ' ' . $query->query_vars['order'];
 	}
 
 	/**
@@ -1197,13 +1191,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 	 * @param object $query Query.
 	 */
 	public function add_orderby_custom_field_to_non_user_query( $args, $query ) {
-		global $wpdb;
-
-		return $wpdb->prepare(
-			'%1s %1s', // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder -- not needed.
-			$query->query_vars['orderby'],
-			$query->query_vars['order']
-		);
+		return $query->query_vars['orderby'] . ' ' . $query->query_vars['order'];
 	}
 
 	/**
@@ -1374,9 +1362,8 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed', 'ungraded' ), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
 			FROM $wpdb->comments lesson_students
 			LEFT JOIN $wpdb->commentmeta lesson_start ON lesson_start.comment_id = lesson_students.comment_id
-			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN (%1s)", // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
-				'%Y-%m-%d %H:%i:%s',
-				$lesson_ids
+			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( " . implode( ',', $lesson_ids ) . ' )', // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				'%Y-%m-%d %H:%i:%s'
 			)
 		);
 		$lesson_completion_info->lesson_count        = $lesson_count;

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1362,7 +1362,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed', 'ungraded' ), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
 			FROM $wpdb->comments lesson_students
 			LEFT JOIN $wpdb->commentmeta lesson_start ON lesson_start.comment_id = lesson_students.comment_id
-			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( " . implode( ',', $lesson_ids ) . ' )', // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( " . $lesson_ids . ' )', // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 				'%Y-%m-%d %H:%i:%s'
 			)
 		);

--- a/includes/class-sensei-analysis-overview-list-table.php
+++ b/includes/class-sensei-analysis-overview-list-table.php
@@ -1362,7 +1362,7 @@ class Sensei_Analysis_Overview_List_Table extends Sensei_List_Table {
 			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed', 'ungraded' ), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
 			FROM $wpdb->comments lesson_students
 			LEFT JOIN $wpdb->commentmeta lesson_start ON lesson_start.comment_id = lesson_students.comment_id
-			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( " . $lesson_ids . ' )', // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( $lesson_ids )", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				'%Y-%m-%d %H:%i:%s'
 			)
 		);

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-courses.php
@@ -93,13 +93,7 @@ class Sensei_Reports_Overview_Data_Provider_Courses implements Sensei_Reports_Ov
 	 * @param object $query Query.
 	 */
 	public function add_orderby_custom_field_to_query( $args, $query ) {
-		global $wpdb;
-
-		return $wpdb->prepare(
-			'%1s %1s', // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder -- not needed.
-			$query->query_vars['orderby'],
-			$query->query_vars['order']
-		);
+		return $query->query_vars['orderby'] . ' ' . $query->query_vars['order'];
 	}
 
 	/**

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
@@ -117,11 +117,7 @@ class Sensei_Reports_Overview_Data_Provider_Students implements Sensei_Reports_O
 	public function add_orderby_custom_field_to_user_query( WP_User_Query $query ) {
 		global $wpdb;
 
-		$query->query_orderby = $wpdb->prepare(
-			'ORDER BY %1s %1s', // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder -- not needed.
-			$query->query_vars['orderby'],
-			$query->query_vars['order']
-		);
+		$query->query_orderby = 'ORDER BY ' . $query->query_vars['orderby'] . ' ' . $query->query_vars['order'];
 	}
 
 	/**

--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
@@ -115,8 +115,6 @@ class Sensei_Reports_Overview_Data_Provider_Students implements Sensei_Reports_O
 	 * @param WP_User_Query $query The user query.
 	 */
 	public function add_orderby_custom_field_to_user_query( WP_User_Query $query ) {
-		global $wpdb;
-
 		$query->query_orderby = 'ORDER BY ' . $query->query_vars['orderby'] . ' ' . $query->query_vars['order'];
 	}
 

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -287,9 +287,8 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed', 'ungraded' ), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
 			FROM $wpdb->comments lesson_students
 			LEFT JOIN $wpdb->commentmeta lesson_start ON lesson_start.comment_id = lesson_students.comment_id
-			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN (%1s)", // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder
-				'%Y-%m-%d %H:%i:%s',
-				$lesson_ids
+			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( " . implode( ',', $lesson_ids ) . ' )', // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+				'%Y-%m-%d %H:%i:%s'
 			)
 		);
 		$lesson_completion_info->lesson_count        = $lesson_count;

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -287,7 +287,7 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed', 'ungraded' ), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
 			FROM $wpdb->comments lesson_students
 			LEFT JOIN $wpdb->commentmeta lesson_start ON lesson_start.comment_id = lesson_students.comment_id
-			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( " . implode( ',', $lesson_ids ) . ' )', // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( " . $lesson_ids . ' )', // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 				'%Y-%m-%d %H:%i:%s'
 			)
 		);

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-lessons.php
@@ -287,7 +287,7 @@ class Sensei_Reports_Overview_List_Table_Lessons extends Sensei_Reports_Overview
 			, SUM(IF(lesson_students.`comment_approved` IN ('graded','passed','complete','failed', 'ungraded' ), ABS( DATEDIFF( STR_TO_DATE( lesson_start.meta_value, %s ), lesson_students.comment_date ) ) + 1, 0)) days_to_complete_sum
 			FROM $wpdb->comments lesson_students
 			LEFT JOIN $wpdb->commentmeta lesson_start ON lesson_start.comment_id = lesson_students.comment_id
-			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( " . $lesson_ids . ' )', // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			WHERE lesson_start.meta_key = 'start' AND lesson_students.comment_post_id IN ( $lesson_ids )", // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				'%Y-%m-%d %H:%i:%s'
 			)
 		);

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -106,27 +106,23 @@ class Sensei_Reports_Overview_Service_Courses {
 		 */
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
 		$result = $wpdb->get_row(
-		// phpcs:ignore
-			$wpdb->prepare(
-				"SELECT AVG(course_average) as courses_average
-			FROM (
-				SELECT AVG(cm.meta_value) as course_average
-				FROM {$wpdb->comments} c
-				INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
-				INNER JOIN {$wpdb->postmeta} course ON c.comment_post_ID = course.post_id
-				INNER JOIN {$wpdb->postmeta} has_questions ON c.comment_post_ID = has_questions.post_id
-				INNER JOIN {$wpdb->posts} p ON p.ID = course.meta_value
-				WHERE c.comment_type = 'sensei_lesson_status'
-					AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
-					AND cm.meta_key = 'grade'
-					AND course.meta_key = '_lesson_course'
-					AND course.meta_value <> ''
-					AND has_questions.meta_key = '_quiz_has_questions'
-				 AND course.meta_value IN (%1s) " // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder -- no need for quoting.
-				. ' GROUP BY course.meta_value
-			) averages_by_course',
-				implode( ',', $course_ids )
-			)
+			"SELECT AVG(course_average) as courses_average
+		FROM (
+			SELECT AVG(cm.meta_value) as course_average
+			FROM {$wpdb->comments} c
+			INNER JOIN {$wpdb->commentmeta} cm ON c.comment_ID = cm.comment_id
+			INNER JOIN {$wpdb->postmeta} course ON c.comment_post_ID = course.post_id
+			INNER JOIN {$wpdb->postmeta} has_questions ON c.comment_post_ID = has_questions.post_id
+			INNER JOIN {$wpdb->posts} p ON p.ID = course.meta_value
+			WHERE c.comment_type = 'sensei_lesson_status'
+				AND c.comment_approved IN ( 'graded', 'passed', 'failed' )
+				AND cm.meta_key = 'grade'
+				AND course.meta_key = '_lesson_course'
+				AND course.meta_value <> ''
+				AND has_questions.meta_key = '_quiz_has_questions'
+				AND course.meta_value IN ( " . implode( ',', $course_ids ) . ' ) ' // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			. ' GROUP BY course.meta_value
+		) averages_by_course'
 		);
 
 		return doubleval( $result->courses_average );
@@ -147,22 +143,19 @@ class Sensei_Reports_Overview_Service_Courses {
 		}
 		global $wpdb;
 
-		$query = $wpdb->prepare(
-			"
-			SELECT AVG( aggregated.days_to_completion )
-			FROM (
-				SELECT CEIL( SUM( ABS( DATEDIFF( {$wpdb->comments}.comment_date, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%%Y-%%m-%%d %%H:%%i:%%s' ) ) ) + 1 ) / COUNT({$wpdb->commentmeta}.comment_id) ) AS days_to_completion
-				FROM {$wpdb->comments}
-				LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id
-					AND {$wpdb->commentmeta}.meta_key = 'start'
-				WHERE {$wpdb->comments}.comment_type = 'sensei_course_status'
-					AND {$wpdb->comments}.comment_approved = 'complete'
-					AND {$wpdb->comments}.comment_post_ID IN (%1s)"  // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder -- no need for quoting.
-			. " GROUP BY {$wpdb->comments}.comment_post_ID
-			) AS aggregated
-		",
-			implode( ',', $course_ids )
-		);
+		$query = "
+		SELECT AVG( aggregated.days_to_completion )
+		FROM (
+			SELECT CEIL( SUM( ABS( DATEDIFF( {$wpdb->comments}.comment_date, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%%Y-%%m-%%d %%H:%%i:%%s' ) ) ) + 1 ) / COUNT({$wpdb->commentmeta}.comment_id) ) AS days_to_completion
+			FROM {$wpdb->comments}
+			LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id
+				AND {$wpdb->commentmeta}.meta_key = 'start'
+			WHERE {$wpdb->comments}.comment_type = 'sensei_course_status'
+				AND {$wpdb->comments}.comment_approved = 'complete'
+				AND {$wpdb->comments}.comment_post_ID IN ( " . implode( ',', $course_ids ) . ' )' // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		. " GROUP BY {$wpdb->comments}.comment_post_ID
+		) AS aggregated
+		";
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
 		return (float) $wpdb->get_var( $query );
@@ -209,15 +202,11 @@ class Sensei_Reports_Overview_Service_Courses {
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe direct sql.
 		return $wpdb->get_results(
-		// phpcs:ignore
-			$wpdb->prepare(
-				"SELECT pm.meta_value as course_id, GROUP_CONCAT(pm.post_id) as lessons
-				FROM {$wpdb->postmeta} pm
-				WHERE pm.meta_value IN (%1s)" // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder -- no need for quoting.
-				. " AND pm.meta_key = '_lesson_course'
-				GROUP BY pm.meta_value",
-				implode( ',', $course_ids )
-			),
+			"SELECT pm.meta_value as course_id, GROUP_CONCAT(pm.post_id) as lessons
+			FROM {$wpdb->postmeta} pm
+			WHERE pm.meta_value IN ( " . implode( ',', $course_ids ) . ' )'  // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			. " AND pm.meta_key = '_lesson_course'
+			GROUP BY pm.meta_value",
 			'OBJECT_K'
 		);
 	}
@@ -235,15 +224,12 @@ class Sensei_Reports_Overview_Service_Courses {
 		global $wpdb;
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Safe direct sql.
 		return $wpdb->get_results(
-			$wpdb->prepare(
-				"SELECT c.comment_post_ID as course_id, count(c.comment_post_ID) as students_count
-					FROM {$wpdb->comments} c
-					WHERE c.comment_post_ID IN (%1s)" // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder -- no quoting.
-				. " AND c.comment_type = 'sensei_course_status'
-					AND c.comment_approved IN ( 'in-progress', 'complete' )
-					GROUP BY c.comment_post_ID",
-				implode( ',', $course_ids )
-			),
+			"SELECT c.comment_post_ID as course_id, count(c.comment_post_ID) as students_count
+				FROM {$wpdb->comments} c
+				WHERE c.comment_post_ID IN ( " . implode( ',', $course_ids ) . ' )'  // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+			. " AND c.comment_type = 'sensei_course_status'
+				AND c.comment_approved IN ( 'in-progress', 'complete' )
+				GROUP BY c.comment_post_ID",
 			'OBJECT_K'
 		);
 	}

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-courses.php
@@ -146,7 +146,7 @@ class Sensei_Reports_Overview_Service_Courses {
 		$query = "
 		SELECT AVG( aggregated.days_to_completion )
 		FROM (
-			SELECT CEIL( SUM( ABS( DATEDIFF( {$wpdb->comments}.comment_date, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%%Y-%%m-%%d %%H:%%i:%%s' ) ) ) + 1 ) / COUNT({$wpdb->commentmeta}.comment_id) ) AS days_to_completion
+			SELECT CEIL( SUM( ABS( DATEDIFF( {$wpdb->comments}.comment_date, STR_TO_DATE( {$wpdb->commentmeta}.meta_value, '%Y-%m-%d %H:%i:%s' ) ) ) + 1 ) / COUNT({$wpdb->commentmeta}.comment_id) ) AS days_to_completion
 			FROM {$wpdb->comments}
 			LEFT JOIN {$wpdb->commentmeta} ON {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id
 				AND {$wpdb->commentmeta}.meta_key = 'start'

--- a/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
+++ b/includes/reports/overview/services/class-sensei-reports-overview-service-students.php
@@ -39,13 +39,10 @@ class Sensei_Reports_Overview_Service_Students {
 		// Fetching all the grades of all the lessons that are graded.
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Performance improvement.
 		$sum_result          = $wpdb->get_row(
-			$wpdb->prepare(
-				"SELECT SUM( {$wpdb->commentmeta}.meta_value ) AS grade_sum,COUNT( * ) as grade_count FROM {$wpdb->comments}
-             INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
-			 WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND ( {$wpdb->commentmeta}.meta_key = 'grade')
-			 AND {$wpdb->comments}.user_id IN (%1s)", // phpcs:ignore WordPress.DB.PreparedSQLPlaceholders.UnquotedComplexPlaceholder -- no need for quoting.
-				implode( ',', $user_ids )
-			)
+			"SELECT SUM( {$wpdb->commentmeta}.meta_value ) AS grade_sum,COUNT( * ) as grade_count FROM {$wpdb->comments}
+			INNER JOIN {$wpdb->commentmeta}  ON ( {$wpdb->comments}.comment_ID = {$wpdb->commentmeta}.comment_id )
+			WHERE {$wpdb->comments}.comment_type IN ('sensei_lesson_status') AND ( {$wpdb->commentmeta}.meta_key = 'grade')
+			AND {$wpdb->comments}.user_id IN ( " . implode( ',', $user_ids ) . ' )' // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		);
 		$average_grade_value = 0;
 		if ( ! $sum_result->grade_count || '0' === $sum_result->grade_count ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It removes unquoted complex placeholders.
* It replaces some cases of `ORDER BY` using `$wpdb->prepare` with string concatenation.
* It replaces some cases of queries with `array` using `$wpdb->prepare` with string concatenation with `implode`.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Navigate through the reports and the possible affected areas, and make sure it continues working properly.

### Context

p6rkRX-3N9-p2