### PR TITLE
Fix css for view-certificate button.

### DIFF
--- a/assets/css/frontend.scss
+++ b/assets/css/frontend.scss
@@ -42,7 +42,7 @@ a.view-results-link,
 a.sensei-certificate-link {
   display: inline-block;
   padding: .236em .857em;
-  background: $border_main;
+  background: $info;
   float: right;
   margin-left: .236em;
   padding: .382em 1em;


### PR DESCRIPTION
### Changes proposed in this Pull Request
* Change background colour from `$border_main` to `$info` for view sensei certificate button.

### Testing instructions
* Create a course and remove all the sensei blocks (for example: leave it empty).
* Assign a certificate template in the right sidebar (you need sensei-certificate installed).
* Enrol to the course and complete it.
* You should see a "View certificate" button that can be recognised easily.
* (If you don't see a button similar to the one in the below screenshot go to Sensei LMS > Settings and set the "My Courses" page to none).

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
#### BEFORE
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/799065/177349788-13c259b9-755a-4b74-b76d-3ca9ab8107e9.png">

#### AFTER
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/799065/177349684-27f9857c-1def-46a0-a007-288499ce95ff.png">
