### PR TITLE
Fix quiz saving

### DIFF
--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -42,6 +42,10 @@ export function useQuizStructure( { clientId } ) {
 	useEffect( () => {
 		setBlock( clientId );
 		loadStructure();
+
+		return () => {
+			setBlock( null );
+		};
 	}, [ setBlock, loadStructure, clientId ] );
 }
 

--- a/assets/blocks/quiz/quiz-store.js
+++ b/assets/blocks/quiz/quiz-store.js
@@ -92,7 +92,10 @@ registerStructureStore( {
 	 * Checks if quiz block exists.
 	 */
 	blockExists() {
-		return !! select( QUIZ_STORE ).getBlock();
+		const clientId = select( QUIZ_STORE ).getBlock();
+		const block = select( 'core/block-editor' ).getBlock( clientId );
+
+		return !! block;
 	},
 
 	/**


### PR DESCRIPTION
It fixes another issue related to this fix: https://github.com/Automattic/sensei/pull/5322. Thank you @alexsanford for the catch!

### Changes proposed in this Pull Request

* To see details of the previous solution, check the [PR](https://github.com/Automattic/sensei/pull/5322
).
  * To check if the quiz block exists, we were checking the `select( QUIZ_STORE ).getBlock()`, but once the block is loaded (in a thumbnail or in the editor), it will set this value, and it won't be cleared anymore.
  * This PR adds a clear to that value.
  * And to avoid other edge cases, we improved to code in the `blockExists` function. Basically that `getBlock` selector just returns the clientId of the block. Now we're checking if the clientId really exists in the editor.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
1. Create a new Lesson in a Course.
2. Navigate to the patterns step in the wizard, and close it.
3. Add a Quiz block.
4. Add some questions to the quiz.
5. Open the network in your browser console.
6. Publish the lesson (should not be published yet).
7. Make sure `https://.../wp-json/sensei-internal/v1/lesson-quiz/{ID}?context=edit&_locale=user` was called.
8. Go to the quiz in the frontend and make sure it contains the added questions.