### PR TITLE
Fix an error on the admin lessons screen

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2597,7 +2597,7 @@ class Sensei_Lesson {
 
 		// Make sure other sensei columns stay directly behind the new columns.
 		$other_sensei_columns = [
-			'module',
+			'modules',
 		];
 		foreach ( $other_sensei_columns as $column_key ) {
 			if ( isset( $defaults[ $column_key ] ) ) {

--- a/includes/class-sensei-modules.php
+++ b/includes/class-sensei-modules.php
@@ -1407,7 +1407,9 @@ class Sensei_Core_Modules {
 	 * @return array          Modified columns.
 	 */
 	public function add_lesson_columns( $columns = array() ) {
-		$columns['module'] = __( 'Module', 'sensei-lms' );
+		// The lesson module column id should not be equal to "module".
+		// @see https://core.trac.wordpress.org/ticket/56185.
+		$columns['modules'] = __( 'Module', 'sensei-lms' );
 
 		return $columns;
 	}
@@ -1422,7 +1424,7 @@ class Sensei_Core_Modules {
 	 * @param  integer $lesson_id The lesson ID.
 	 */
 	public function add_lesson_column_content( $column = '', $lesson_id = 0 ) {
-		if ( 'module' === $column ) {
+		if ( 'modules' === $column ) {
 			$modules = wp_get_post_terms( $lesson_id, $this->taxonomy );
 			$module  = $modules && is_array( $modules ) ? $modules[0] : null;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR fixes a Javascript error that was generated on the lessons screen in the admin panel.

The error is related to the module column which had an id="module" that caused WordPress core to throw an error. More info about this (unconfirmed) bug could be found here: https://core.trac.wordpress.org/ticket/56185.

This also fixes the lessons Quick Edit action bug reported in p6rkRX-3NM-p2#comment-4324.

### Testing instructions

* Go to Sensei LMS -> Lessons.
* Open the browser console and make sure there are no errors.
* Make sure the Quick Edit action works.
* Make sure the module column works as expected.

### Screenshot / Video

![image](https://user-images.githubusercontent.com/1612178/178085728-793b8801-58ec-470b-a015-d49cbacad7fe.png)