### PR TITLE
Add enrolment notice if course is unpublished

### DIFF
--- a/includes/blocks/class-sensei-course-outline-course-block.php
+++ b/includes/blocks/class-sensei-course-outline-course-block.php
@@ -65,6 +65,9 @@ class Sensei_Course_Outline_Course_Block {
 		if ( ! empty( $attributes['preview_drafts'] ) ) {
 			Sensei()->notices->add_notice( __( 'One or more lessons in this course are not published. Unpublished lessons and empty modules are only displayed in preview mode and will not be displayed to students.', 'sensei-lms' ), 'info', 'sensei-course-outline-drafts' );
 		}
+		if ( isset( $_GET['draftcourse'] ) && 'true' === $_GET['draftcourse'] ) {
+			Sensei()->notices->add_notice( __( 'Cannot register for an unpublished course.  Please publish the course first.', 'sensei-lms' ), 'info', 'sensei-course-outline-drafts' );
+		}
 
 		return '
 			<section ' . Sensei_Block_Helpers::render_style_attributes( [ 'wp-block-sensei-lms-course-outline', 'sensei-block-wrapper', $class_name ], $css ) . '>

--- a/includes/blocks/class-sensei-course-outline-course-block.php
+++ b/includes/blocks/class-sensei-course-outline-course-block.php
@@ -65,6 +65,7 @@ class Sensei_Course_Outline_Course_Block {
 		if ( ! empty( $attributes['preview_drafts'] ) ) {
 			Sensei()->notices->add_notice( __( 'One or more lessons in this course are not published. Unpublished lessons and empty modules are only displayed in preview mode and will not be displayed to students.', 'sensei-lms' ), 'info', 'sensei-course-outline-drafts' );
 		}
+		// phpcs:ignore WordPress.Security.NonceVerification
 		if ( isset( $_GET['draftcourse'] ) && 'true' === $_GET['draftcourse'] ) {
 			Sensei()->notices->add_notice( __( 'Cannot register for an unpublished course.  Please publish the course first.', 'sensei-lms' ), 'info', 'sensei-course-outline-drafts' );
 		}

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1220,7 +1220,7 @@ class Sensei_Frontend {
 				$redirect_url = apply_filters( 'sensei_start_course_redirect_url', get_permalink( $post->ID ), $post );
 
 				if ( 'publish' !== get_post_status( $post ) ) {
-					wp_safe_redirect( $redirect_url . '&draftcourse=true' );
+					wp_safe_redirect( add_query_arg( 'draftcourse', 'true', $redirect_url ) );
 					exit();
 				}
 				if ( false !== $redirect_url ) {

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1220,7 +1220,7 @@ class Sensei_Frontend {
 				$redirect_url = apply_filters( 'sensei_start_course_redirect_url', get_permalink( $post->ID ), $post );
 
 				if ( 'publish' !== get_post_status( $post ) ) {
-					wp_safe_redirect( $redirect_url . "&draftcourse=true" );
+					wp_safe_redirect( $redirect_url . '&draftcourse=true' );
 					exit();
 				}
 				if ( false !== $redirect_url ) {

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1219,6 +1219,10 @@ class Sensei_Frontend {
 				 */
 				$redirect_url = apply_filters( 'sensei_start_course_redirect_url', get_permalink( $post->ID ), $post );
 
+				if ( 'publish' !== get_post_status( $post ) ) {
+					wp_safe_redirect( $redirect_url . "&draftcourse=true" );
+					exit();
+				}
 				if ( false !== $redirect_url ) {
 					?>
 


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/5340

### Changes proposed in this Pull Request

* When you try to press the `Take Course` button on an unpublished course, the `course_start` action now checks if the post doesn't have the `publish` status and if so, it will display a warning that says `Cannot register for an unpublished course.  Please publish the course first.`

### Testing instructions
1. Create a new course
2. Set it to Draft
3. Go to preview the course
4. Try pressing "Take Course"

### Screenshot / Video
![take-course-preview](https://user-images.githubusercontent.com/3220162/178166587-f3da68de-0182-40fd-bde8-4b3a55d40509.gif)

**Question**:  Does it make sense for this to be an `info` notice or would `alert` be better?