### PR TITLE
Fix bulk-edit for Lessons

### DIFF
--- a/assets/js/admin/lesson-bulk-edit.js
+++ b/assets/js/admin/lesson-bulk-edit.js
@@ -9,16 +9,9 @@ jQuery( function ( $ ) {
 
 		// get the selected post ids that are being edited
 		var postIds = new Array();
-		$bulk_row
-			.find( '#bulk-titles' )
-			.children()
-			.each( function () {
-				postIds.push(
-					$( this )
-						.attr( 'id' )
-						.replace( /^(ttle)/i, '' )
-				);
-			} );
+		$bulk_row.find( '#bulk-titles-list button' ).each( function () {
+			postIds.push( $( this ).attr( 'id' ).replace( /^(_)/i, '' ) );
+		} );
 
 		// get the data:
 


### PR DESCRIPTION
Fixes #5334

### Changes proposed in this Pull Request

Right now when you try to Bulk Edit lessons, the `postIds` are not passed to the AJAX request, so no changes are made.  What's happening is that the wrong elements are used in jQuery, so the Ids don't get passed along.  In this change, I'm changing the target to the `button` element which contains the id in the `_{id}` format, and then using the `replace` to get rid of the underscore before the ID there.   I'm not sure why it was replacing `ttle`  before or if that's used elsewhere - couldn't find any mentions of that in the code.

### Testing instructions

* Go to Sensei LMS -> Lessons
* Select 2 or more Lesson checkboxes
* Select "Edit" from the "Bulk Actions" dropdown
* Click "Apply"
* Change the Course, Complexity, Pass required, Pass percentage, and quiz reset button
* Check to make sure the changes worked

### Screenshot / Video
![bulk-edit-lessons](https://user-images.githubusercontent.com/3220162/178352403-239dc054-a97a-4ec1-8284-02f0b1c626d4.gif)

