### PR TITLE
Change 'Manage Learners' to 'Manage Students' on the course management meta box

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -764,7 +764,7 @@ class Sensei_Course {
 			admin_url( 'edit.php' )
 		);
 
-		echo '<ul><li><a href=' . esc_url( $manage_url ) . '>' . esc_html__( 'Manage Learners', 'sensei-lms' ) . '</a></li>';
+		echo '<ul><li><a href=' . esc_url( $manage_url ) . '>' . esc_html__( 'Manage Students', 'sensei-lms' ) . '</a></li>';
 		echo '<li><a href=' . esc_url( $grading_url ) . '>' . esc_html__( 'Manage Grading', 'sensei-lms' ) . '</a></li></ul>';
 	}
 


### PR DESCRIPTION
Fixes #4945

### Changes proposed in this Pull Request

* Changed the text `Manage Learners` to `Manage Students`

### Testing instructions

* Go to a Course
* Look at the metabox "Course Management"
* Make sure it says "Manage Students"

### Screenshot / Video
<img width="374" alt="Screen Shot 2022-07-12 at 11 38 49 AM" src="https://user-images.githubusercontent.com/3220162/178569968-e4a70cba-140d-420b-98ff-3247116db8a5.png">

Does the `.pot` file get regenerated at release or should I be updating it with this PR?