### PR TITLE
Fix placeholder images for courses

### DIFF
--- a/includes/class-sensei-course.php
+++ b/includes/class-sensei-course.php
@@ -1116,7 +1116,7 @@ class Sensei_Course {
 					 * @param int    $width     Requested image width.
 					 * @param int    $height    Requested image height.
 					 */
-					$img_html         = apply_filters( 'sensei_course_placeholder_image_url', '<img src="http://placehold.it/' . $width . 'x' . $height . '" class="' . esc_attr( $classes ) . '" />', $course_id, $width, $height );
+					$img_html         = apply_filters( 'sensei_course_placeholder_image_url', '<img src="//via.placeholder.com/' . $width . 'x' . $height . '" class="' . esc_attr( $classes ) . '" />', $course_id, $width, $height );
 					$used_placeholder = true;
 
 				}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -3731,7 +3731,7 @@ class Sensei_Lesson {
 				 * @param {string} $html HTML for the lesson placeholder image.
 				 * @return {string} HTML for the lesson placeholder image.
 				 */
-				$img_element = apply_filters( 'sensei_lesson_placeholder_image_url', '<img src="http://placehold.it/' . esc_url( $width ) . 'x' . esc_url( $height ) . '" class="woo-image thumbnail alignleft" />' );
+				$img_element = apply_filters( 'sensei_lesson_placeholder_image_url', '<img src="//via.placeholder.com/' . esc_url( $width ) . 'x' . esc_url( $height ) . '" class="woo-image thumbnail alignleft" />' );
 
 			}
 		}


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/1723

### Changes proposed in this Pull Request

* Currently, there is a setting in Sensei > Settings for using placeholder images for courses that don't have images. 
`Use placeholder images | Output a placeholder image when no featured image has been specified for Courses and Lessons.`
However, we're using the old `placehold.it` urls which no longer work.    This PR changes it to use the new URLs as well as makes the links https/http agnostic.

### Testing instructions

* Use `placeholder images` from Sensei > Settings
* Create a course with no featured image
* Go to "Courses" (`courses-overview`) page
* Make sure you see the placeholder images

### Screenshot / Video
<img width="587" alt="Screen Shot 2022-07-12 at 2 49 59 PM" src="https://user-images.githubusercontent.com/3220162/178601579-c86856ab-3776-4939-84f5-644cdce9d84f.png">

