### PR TITLE
Fix quiz notice error when lesson is completed

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -1274,10 +1274,11 @@ class Sensei_Question {
 
 				$count++;
 				$question_option = array();
+				$is_quiz_graded  = isset( $question_data['user_quiz_grade'] );
 
-				if ( ( $question_data['lesson_completed'] && $question_data['user_quiz_grade'] != '' )
-					|| ( $question_data['lesson_completed'] && ! $question_data['reset_quiz_allowed'] && $question_data['user_quiz_grade'] != '' )
-					|| ( 'auto' == $question_data['quiz_grade_type'] && ! $question_data['reset_quiz_allowed'] && ! empty( $question_data['user_quiz_grade'] ) ) ) {
+				if ( ( $question_data['lesson_completed'] && $is_quiz_graded )
+					|| ( $question_data['lesson_completed'] && ! $question_data['reset_quiz_allowed'] && $is_quiz_graded )
+					|| ( 'auto' === $question_data['quiz_grade_type'] && ! $question_data['reset_quiz_allowed'] && $is_quiz_graded ) ) {
 
 					$user_correct = false;
 


### PR DESCRIPTION
Partial fix for #5351

### Changes proposed in this Pull Request

This change fixes a PHP notice error on the quiz page.

### Testing instructions

* Make a course with a lesson and a quiz with multiple-choice questions.
* Take the course and complete the lesson without going through the quiz.
* Go back to the lesson and view the quiz.
* There should be no PHP notices.
* The quiz should be working as before.