### PR TITLE
Remove the warning in the learning mode

### DIFF
--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
@@ -67,7 +67,7 @@ const LessonActionsEdit = ( props ) => {
 		: 'not-allowed';
 
 	if ( courseThemeEnabled ) {
-		return <></>;
+		return null;
 	}
 
 	// Filter inner blocks based on the settings.

--- a/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
+++ b/assets/blocks/lesson-actions/lesson-actions-block/lesson-actions-edit.js
@@ -6,7 +6,6 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies
  */
-import { Notice } from '@wordpress/components';
 import { InnerBlocks } from '@wordpress/block-editor';
 import { __ } from '@wordpress/i18n';
 
@@ -68,18 +67,7 @@ const LessonActionsEdit = ( props ) => {
 		: 'not-allowed';
 
 	if ( courseThemeEnabled ) {
-		return (
-			<Notice
-				status="warning"
-				isDismissible={ false }
-				className="wp-block-sensei-lms-lesson-actions__notice"
-			>
-				{ __(
-					'Lesson Actions block is not displayed when Learning Mode is enabled.',
-					'sensei-lms'
-				) }
-			</Notice>
-		);
+		return <></>;
 	}
 
 	// Filter inner blocks based on the settings.


### PR DESCRIPTION
In Learning mode we can't display action buttons and we used to show the warning in the editor. However, it might be confusing and we decided to hide the warning.

### Changes proposed in this Pull Request

* Remove warning about action buttons in Learning mode

### Testing instructions

* Create a course, turn on the learning mode for it
* Create a lesson in the course.
* Go to the lesson editor.
* You shouldn't see notification "Lesson Actions block is not displayed when Learning Mode is enabled." on the top.

