### PR TITLE
Change video api scripts to be more generic

### DIFF
--- a/assets/js/frontend/course-video/youtube-extension.js
+++ b/assets/js/frontend/course-video/youtube-extension.js
@@ -51,13 +51,7 @@ export const initYouTubeExtension = () => {
 	init();
 };
 
-// onYouTubeIframeAPIReady is called by YouTube iframe API when it is ready.
-const previousYouTubeIframeAPIReady =
-	window.onYouTubeIframeAPIReady !== undefined
-		? window.onYouTubeIframeAPIReady
-		: () => {};
-window.onYouTubeIframeAPIReady = () => {
+window.senseiYouTubeIframeAPIReady.then( () => {
 	youtubeIframeReady = true;
 	init();
-	previousYouTubeIframeAPIReady();
-};
+} );

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -83,8 +83,23 @@ class Sensei_Blocks {
 		Sensei()->assets->register( 'sensei-blocks-frontend', 'blocks/frontend.js', [], true );
 		Sensei()->assets->register( 'sensei-theme-blocks', 'css/sensei-theme-blocks.css' );
 
-		wp_register_script( 'sensei-youtube-iframe-api', 'https://www.youtube.com/iframe_api', [], 'unversioned', true );
+		wp_register_script( 'sensei-youtube-iframe-api', 'https://www.youtube.com/iframe_api', [], 'unversioned', false );
 		wp_register_script( 'sensei-vimeo-iframe-api', 'https://player.vimeo.com/api/player.js', [], 'unversioned', false );
+
+		wp_add_inline_script(
+			'sensei-youtube-iframe-api',
+			'window.senseiYouTubeIframeAPIReady = new Promise( ( resolve ) => {
+				const previousYouTubeIframeAPIReady =
+					window.onYouTubeIframeAPIReady !== undefined
+						? window.onYouTubeIframeAPIReady
+						: () => {};
+				window.onYouTubeIframeAPIReady = () => {
+					resolve();
+					previousYouTubeIframeAPIReady();
+				};
+			} )',
+			'before'
+		);
 	}
 
 	/**

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -85,6 +85,7 @@ class Sensei_Blocks {
 
 		wp_register_script( 'sensei-youtube-iframe-api', 'https://www.youtube.com/iframe_api', [], 'unversioned', false );
 		wp_register_script( 'sensei-vimeo-iframe-api', 'https://player.vimeo.com/api/player.js', [], 'unversioned', false );
+		wp_register_script( 'sensei-video-embed-apis', false, [ 'sensei-youtube-iframe-api', 'sensei-vimeo-iframe-api' ], 'unversioned', false );
 	}
 
 	/**

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -85,7 +85,9 @@ class Sensei_Blocks {
 
 		wp_register_script( 'sensei-youtube-iframe-api', 'https://www.youtube.com/iframe_api', [], 'unversioned', false );
 		wp_register_script( 'sensei-vimeo-iframe-api', 'https://player.vimeo.com/api/player.js', [], 'unversioned', false );
-		wp_register_script( 'sensei-video-embed-apis', false, [ 'sensei-youtube-iframe-api', 'sensei-vimeo-iframe-api' ], 'unversioned', false );
+
+		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion,WordPress.WP.EnqueuedResourceParameters.NotInFooter -- It's just joining some scripts.
+		wp_register_script( 'sensei-video-embed-apis', false, [ 'sensei-youtube-iframe-api', 'sensei-vimeo-iframe-api' ] );
 	}
 
 	/**

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -83,11 +83,8 @@ class Sensei_Blocks {
 		Sensei()->assets->register( 'sensei-blocks-frontend', 'blocks/frontend.js', [], true );
 		Sensei()->assets->register( 'sensei-theme-blocks', 'css/sensei-theme-blocks.css' );
 
-		wp_register_script( 'sensei-youtube-iframe-api', 'https://www.youtube.com/iframe_api', [], 'unversioned', false );
+		wp_register_script( 'sensei-youtube-iframe-api', 'https://www.youtube.com/iframe_api', [], 'unversioned', true );
 		wp_register_script( 'sensei-vimeo-iframe-api', 'https://player.vimeo.com/api/player.js', [], 'unversioned', false );
-
-		// phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion,WordPress.WP.EnqueuedResourceParameters.NotInFooter -- It's just joining some scripts.
-		wp_register_script( 'sensei-video-embed-apis', false, [ 'sensei-youtube-iframe-api', 'sensei-vimeo-iframe-api' ] );
 	}
 
 	/**

--- a/includes/blocks/class-sensei-blocks.php
+++ b/includes/blocks/class-sensei-blocks.php
@@ -82,6 +82,9 @@ class Sensei_Blocks {
 
 		Sensei()->assets->register( 'sensei-blocks-frontend', 'blocks/frontend.js', [], true );
 		Sensei()->assets->register( 'sensei-theme-blocks', 'css/sensei-theme-blocks.css' );
+
+		wp_register_script( 'sensei-youtube-iframe-api', 'https://www.youtube.com/iframe_api', [], 'unversioned', false );
+		wp_register_script( 'sensei-vimeo-iframe-api', 'https://player.vimeo.com/api/player.js', [], 'unversioned', false );
 	}
 
 	/**
@@ -154,7 +157,7 @@ class Sensei_Blocks {
 	/**
 	 * Check if the current post has any Sensei blocks.
 	 *
-	 * @param int|WP_Post|null $post
+	 * @param int|WP_Post|null $post Post.
 	 *
 	 * @return bool
 	 */

--- a/includes/course-video/class-sensei-course-video-settings.php
+++ b/includes/course-video/class-sensei-course-video-settings.php
@@ -81,12 +81,10 @@ class Sensei_Course_Video_Settings {
 			return;
 		}
 
-		wp_register_script( 'sensei-course-video-youtube-iframe-api', 'https://www.youtube.com/iframe_api', [], 'unversioned', true );
-		wp_register_script( 'sensei-course-video-vimeo-iframe-api', 'https://player.vimeo.com/api/player.js', [], 'unversioned', true );
 		Sensei()->assets->register(
 			'sensei-course-video-blocks-extension',
 			'js/frontend/course-video/video-blocks-extension.js',
-			[ 'sensei-course-video-youtube-iframe-api', 'sensei-course-video-vimeo-iframe-api' ],
+			[ 'sensei-youtube-iframe-api', 'sensei-vimeo-iframe-api' ],
 			true
 		);
 

--- a/includes/course-video/class-sensei-course-video-settings.php
+++ b/includes/course-video/class-sensei-course-video-settings.php
@@ -84,7 +84,7 @@ class Sensei_Course_Video_Settings {
 		Sensei()->assets->register(
 			'sensei-course-video-blocks-extension',
 			'js/frontend/course-video/video-blocks-extension.js',
-			[ 'sensei-youtube-iframe-api', 'sensei-vimeo-iframe-api' ],
+			[ 'sensei-video-embed-apis' ],
 			true
 		);
 

--- a/includes/course-video/class-sensei-course-video-settings.php
+++ b/includes/course-video/class-sensei-course-video-settings.php
@@ -84,7 +84,7 @@ class Sensei_Course_Video_Settings {
 		Sensei()->assets->register(
 			'sensei-course-video-blocks-extension',
 			'js/frontend/course-video/video-blocks-extension.js',
-			[ 'sensei-video-embed-apis' ],
+			[ 'sensei-youtube-iframe-api', 'sensei-vimeo-iframe-api' ],
 			true
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It just updates the way that the video API scripts are registered, in order to be more generic for reuse. It will be used in a new feature in Sensei Pro.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a course.
* Check the options in the "Video" panel in the sidebar.
* Add a lesson.
* Add a video (YouTube or Vimeo) to the lesson.
* Make sure the video settings continue working (like pausing the video when changing the tab, and completing the lesson when watching the whole video).