### PR TITLE
Fix url encoding of timezone for reports

### DIFF
--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
@@ -346,7 +346,7 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 				'course_filter'          => $this->get_course_filter_value(),
 				'start_date'             => $this->get_start_date_filter_value(),
 				'end_date'               => $this->get_end_date_filter_value(),
-				'timezone'               => $this->get_timezone(),
+				'timezone'               => rawurlencode( $this->get_timezone() ),
 				's'                      => $this->get_search_value(),
 			),
 			admin_url( 'edit.php' )


### PR DESCRIPTION
A user reported in #5378071-z that their user export CSV was causing a fatal error.  This was happening because if a site had the timezone set to UTC, we were not properly encoding the `+` sign in the timezone in the URL, so the report failed.

### Changes proposed in this Pull Request

- Add a `rawurlencode` to the timezone string so that the report can work

### Testing instructions

* Check this PR out
* Go to Settings > General and set your timezone to UTC +0
* Go to Sensei > Reports
* Click on "Export all rows (CSV)"  to make sure it works
