### PR TITLE
Use lastTitle to merge modules configurations after save an editing

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,9 +1,6 @@
 name: PHP Linting and Tests
 
-on:
-    pull_request:
-      paths:
-        - '**.php'
+on: pull_request
 
 jobs:
     lint:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,6 +1,9 @@
 name: PHP Linting and Tests
 
-on: pull_request
+on:
+    pull_request:
+      paths:
+        - '**.php'
 
 jobs:
     lint:

--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -79,13 +79,13 @@ export const syncStructureToBlocks = ( structure, blocks ) => {
  * @return {boolean}  Flag indicating if the block matches on the the strategies
  */
 
-const byStructureItem = ( block ) => ( courseStructureItem ) => {
-	const { name, attributes } = courseStructureItem;
+const byCourseData = ( courseData ) => ( block ) => {
+	const { name, attributes } = block;
 	const isTheCorrectBlockType = Object.keys( blockTypes ).includes( name );
 
-	const findById = () => !! attributes.id && block.id === attributes.id;
-	const findByTitle = () => attributes.title === block.title;
-	const findByLastTitle = () => attributes.title === block.lastTitle;
+	const findById = () => !! attributes.id && courseData.id === attributes.id;
+	const findByTitle = () => attributes.title === courseData.title;
+	const findByLastTitle = () => attributes.title === courseData.lastTitle;
 
 	if ( ! isTheCorrectBlockType ) {
 		return false;
@@ -103,16 +103,16 @@ const findInInnerBlocks = ( blocks, predicate ) =>
 /**
  * Find the block for a given lesson/module item.
  *
- * @param {Object[]}                                    blocks        Block.
- * @param {Array.<(CourseLessonData|CourseModuleData)>} structureItem Structure item.
+ * @param {Object[]}                                    blocks     Block.
+ * @param {Array.<(CourseLessonData|CourseModuleData)>} courseData Course item.
  * @return {Object} The block, if found.
  */
-const findBlock = ( blocks, structureItem ) => {
+const findBlock = ( blocks, courseData ) => {
 	const isLesson = ( value ) => value === 'lesson';
-	const found = blocks.find( byStructureItem( structureItem ) );
+	const found = blocks.find( byCourseData( courseData ) );
 
-	if ( ! found && isLesson( structureItem.type ) ) {
-		return findInInnerBlocks( blocks, byStructureItem( structureItem ) );
+	if ( ! found && isLesson( courseData.type ) ) {
+		return findInInnerBlocks( blocks, byCourseData( courseData ) );
 	}
 
 	return found;

--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -70,15 +70,12 @@ export const syncStructureToBlocks = ( structure, blocks ) => {
 		return block;
 	} );
 };
-
 /**
- * Predicate method to compare a block with a course structure item, using different strategies.
+ * Predicate builder method that return a predicate a block with a course structure item, using different strategies.
  *
- * @param {Object[]}                                    blocks        Block.
- * @param {Array.<(CourseLessonData|CourseModuleData)>} structureItem Structure item.
- * @return {boolean}  Flag indicating if the block matches on the the strategies
+ * @param {Object[]} courseData Course Lesson Data or Course Module Data..
+ * @return {Function} Predicate that match a block using course lesson data/course module data.
  */
-
 const byCourseData = ( courseData ) => ( block ) => {
 	const { name, attributes } = block;
 	const isTheCorrectBlockType = Object.keys( blockTypes ).includes( name );

--- a/assets/blocks/course-outline/data.js
+++ b/assets/blocks/course-outline/data.js
@@ -6,7 +6,7 @@
  */
 import { createBlock } from '@wordpress/blocks';
 import { select } from '@wordpress/data';
-import { invert } from 'lodash';
+import { curry, invert } from 'lodash';
 
 /**
  * Course structure data.
@@ -70,13 +70,15 @@ export const syncStructureToBlocks = ( structure, blocks ) => {
 		return block;
 	} );
 };
+
 /**
- * Predicate builder method that return a predicate a block with a course structure item, using different strategies.
+ * Check if the block is related to the current course structure CourseLessonData|CourseModuleData
  *
- * @param {Object[]} courseData Course Lesson Data or Course Module Data..
- * @return {Function} Predicate that match a block using course lesson data/course module data.
+ * @param {block}                             block      Gutenberg Block stored on the editor store
+ * @param {CourseLessonData|CourseModuleData} courseData Course Lesson Data or Course Module Data..
+ * @return {boolean} returns if the block matches with the data structure.
  */
-const byCourseData = ( courseData ) => ( block ) => {
+const byCourseData = curry( ( courseData, block ) => {
 	const { name, attributes } = block;
 	const isTheCorrectBlockType = Object.keys( blockTypes ).includes( name );
 
@@ -89,7 +91,7 @@ const byCourseData = ( courseData ) => ( block ) => {
 	}
 
 	return [ findById(), findByTitle(), findByLastTitle() ].includes( true );
-};
+} );
 
 const findInInnerBlocks = ( blocks, predicate ) =>
 	blocks.reduce(

--- a/assets/blocks/course-outline/data.test.js
+++ b/assets/blocks/course-outline/data.test.js
@@ -166,6 +166,172 @@ describe( 'syncStructureToBlocks', () => {
 			},
 		] );
 	} );
+
+	it( 'merges with existing blocks using the id', () => {
+		const blocks = [
+			createBlock( 'sensei-lms/course-outline-module', {
+				title: 'M1',
+				type: 'module',
+				description: 'Module 1',
+				id: 1,
+				style: { color: 'red' },
+			} ),
+		];
+
+		const changed = [
+			{
+				description: 'Module 1 description updated',
+				type: 'module',
+				title: 'M1 updated',
+				id: 1,
+			},
+		];
+
+		const newBlocks = syncStructureToBlocks( changed, blocks );
+
+		expect( newBlocks ).toEqual( [
+			{
+				clientId: blocks[ 0 ].clientId,
+				name: 'sensei-lms/course-outline-module',
+				attributes: {
+					title: 'M1 updated',
+					description: 'Module 1 description updated',
+					id: 1,
+					style: { color: 'red' },
+				},
+				innerBlocks: [],
+				isValid: true,
+			},
+		] );
+	} );
+
+	it( 'merges with existing blocks using the title when there is not id', () => {
+		const blocks = [
+			createBlock( 'sensei-lms/course-outline-module', {
+				title: 'M1',
+				type: 'module',
+				description: 'Module 1',
+				style: { color: 'red' },
+			} ),
+		];
+
+		const changed = [
+			{
+				description: 'Module 1 description updated',
+				type: 'module',
+				title: 'M1',
+				id: 2,
+			},
+		];
+
+		const newBlocks = syncStructureToBlocks( changed, blocks );
+
+		expect( newBlocks ).toEqual( [
+			{
+				clientId: blocks[ 0 ].clientId,
+				name: 'sensei-lms/course-outline-module',
+				attributes: {
+					title: 'M1',
+					description: 'Module 1 description updated',
+					id: 2,
+					style: { color: 'red' },
+				},
+				innerBlocks: [],
+				isValid: true,
+			},
+		] );
+	} );
+
+	it( 'merges with existing blocks using the lastTitle', () => {
+		const blocks = [
+			createBlock( 'sensei-lms/course-outline-module', {
+				title: 'M1',
+				type: 'module',
+				description: 'Module 1',
+				id: 1,
+				style: { color: 'red' },
+			} ),
+		];
+
+		const changed = [
+			{
+				description: 'Module 1 description updated',
+				type: 'module',
+				title: 'M1 updated',
+				lastTitle: 'M1',
+				id: 2,
+			},
+		];
+
+		const newBlocks = syncStructureToBlocks( changed, blocks );
+
+		expect( newBlocks ).toEqual( [
+			{
+				clientId: blocks[ 0 ].clientId,
+				name: 'sensei-lms/course-outline-module',
+				attributes: {
+					title: 'M1 updated',
+					lastTitle: 'M1',
+					description: 'Module 1 description updated',
+					id: 2,
+					style: { color: 'red' },
+				},
+				innerBlocks: [],
+				isValid: true,
+			},
+		] );
+	} );
+
+	it( 'merges with existing blocks looking on inner blocks', () => {
+		const innerId = 99;
+		const innerBlock = createBlock( 'sensei-lms/course-outline-lesson', {
+			title: 'lesson 1 title',
+			type: 'lesson',
+			description: 'Lesson 1',
+			id: innerId,
+			style: { color: 'blue' },
+		} );
+
+		const blocks = [
+			createBlock(
+				'sensei-lms/course-outline-module',
+				{
+					title: 'M1',
+					type: 'module',
+					description: 'Module 1',
+					id: 1,
+					style: { color: 'red' },
+				},
+				[ innerBlock ]
+			),
+		];
+
+		const changed = [
+			{
+				description: 'Lesson 1 description updated',
+				type: 'lesson',
+				title: 'Lesson 1 title updated',
+				id: innerId,
+			},
+		];
+
+		const newBlocks = syncStructureToBlocks( changed, blocks );
+
+		expect( newBlocks ).toEqual( [
+			{
+				clientId: innerBlock.clientId,
+				name: 'sensei-lms/course-outline-lesson',
+				attributes: {
+					title: 'Lesson 1 title updated',
+					description: 'Lesson 1 description updated',
+					id: 99,
+					style: { color: 'blue' },
+				},
+				innerBlocks: [],
+				isValid: true,
+			},
+		] );
+	} );
 } );
 
 describe( 'getFirstBlockByName', () => {


### PR DESCRIPTION
Fixes #5346
Currently, when a module title is edited, the backend is creating a new
term 'module' and returns a new id and the front-end is trying to use this
id to get the style configuration from the redux store. 


### Changes proposed in this Pull Request
* Use the last title attribute to identify the module styles stored on the store when the module id is changed by the module renaming. 
* Refactor the `findBlock` method to keep the finding strategies more explicit. 
* Cover the `syncStructureToBlocks` method with more testings, covering the finding scenario.s 


### Testing instructions
* Update a module with any style configuration (Styles> Filled  or Minimal, Border Settings, Color Settings, etcs) 
* Save
* Update the title module title
* Save 
* Check if all style configurations are still applied. 
