### PR TITLE
Add hooks to allow adding filters to reports

### DIFF
--- a/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
+++ b/includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
@@ -74,8 +74,11 @@ class Sensei_Reports_Overview_Data_Provider_Students implements Sensei_Reports_O
 			add_action( 'pre_user_query', [ $this, 'add_orderby_custom_field_to_user_query' ] );
 		}
 
+		add_action( 'pre_user_query', [ $this, 'add_pre_user_query_hook' ] );
+
 		$wp_user_search = new WP_User_Query( $query_args );
 
+		remove_action( 'pre_user_query', [ $this, 'add_pre_user_query_hook' ] );
 		remove_action( 'pre_user_query', [ $this, 'add_orderby_custom_field_to_user_query' ] );
 		remove_action( 'pre_user_query', [ $this, 'add_last_activity_to_user_query' ] );
 		remove_action( 'pre_user_query', [ $this, 'filter_users_by_last_activity' ] );
@@ -84,6 +87,27 @@ class Sensei_Reports_Overview_Data_Provider_Students implements Sensei_Reports_O
 		$this->last_total_items = $wp_user_search->get_total();
 
 		return $learners;
+	}
+
+	/**
+	 * Add a user query hook before querying the users.
+	 * This allows for third parties to alter the query.
+	 *
+	 * @since  $$next-version$$
+	 * @access private
+	 *
+	 * @param WP_User_Query $query The user query.
+	 */
+	public function add_pre_user_query_hook( WP_User_Query $query ) {
+		/**
+		 * Fires before the user query is executed.
+		 *
+		 * @hook sensei_reports_overview_students_data_provider_pre_user_query
+		 * @since $$next-version$$
+		 *
+		 * @param {WP_User_Query} $query The user query.
+		 */
+		do_action( 'sensei_reports_overview_students_data_provider_pre_user_query', $query );
 	}
 
 	/**

--- a/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
+++ b/includes/reports/overview/list-table/class-sensei-reports-overview-list-table-abstract.php
@@ -250,6 +250,18 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 
 			<input type="hidden" name="timezone">
 
+			<?php
+			/**
+			 * Fires before the top filter inputs on the reports overview screen.
+			 *
+			 * @hook sensei_reports_overview_before_top_filters
+			 * @since $$next-version$$
+			 *
+			 * @param {string} $report_type The report type.
+			 */
+			do_action( 'sensei_reports_overview_before_top_filters', $this->type );
+			?>
+
 			<?php if ( 'lessons' === $this->type ) : ?>
 				<label for="sensei-course-filter">
 					<?php esc_html_e( 'Course', 'sensei-lms' ); ?>:
@@ -283,6 +295,18 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 					value="<?php echo esc_attr( $this->get_end_date_filter_value() ); ?>"
 				/>
 			<?php endif ?>
+
+			<?php
+			/**
+			 * Fires after the top filter inputs on the reports overview screen.
+			 *
+			 * @hook sensei_reports_overview_after_top_filters
+			 * @since $$next-version$$
+			 *
+			 * @param {string} $report_type The report type.
+			 */
+			do_action( 'sensei_reports_overview_after_top_filters', $this->type );
+			?>
 
 			<?php submit_button( __( 'Filter', 'sensei-lms' ), '', '', false ); ?>
 		</form>
@@ -351,6 +375,18 @@ abstract class Sensei_Reports_Overview_List_Table_Abstract extends Sensei_List_T
 			),
 			admin_url( 'edit.php' )
 		);
+
+		/**
+		 * Customize the export button URL on the reports overview screen.
+		 *
+		 * @hook  sensei_reports_overview_export_button_url
+		 * @since $$next-version$$
+		 *
+		 * @param {string} $url The export button URL.
+		 *
+		 * @return {string} The export button URL.
+		 */
+		$url = apply_filters( 'sensei_reports_overview_export_button_url', $url );
 
 		echo '<a class="button button-primary" href="' . esc_url( wp_nonce_url( $url, 'sensei_csv_download', '_sdl_nonce' ) ) . '">' . esc_html__( 'Export all rows (CSV)', 'sensei-lms' ) . '</a>';
 	}


### PR DESCRIPTION
Relates to https://github.com/Automattic/sensei-pro/issues/1544.

### Changes proposed in this Pull Request

* Add a hook to allow modifying the students report query.
* Add hooks to allow adding filters to reports

### Testing instructions

* Make sure the reports listing and export features are working as before.

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New Hooks

* `sensei_reports_overview_students_data_provider_pre_user_query` - Fires before the user query is executed.
* `sensei_reports_overview_before_top_filters` - Fires before the top filter inputs on the reports overview screen.
* `sensei_reports_overview_after_top_filters` - Fires after the top filter inputs on the reports overview screen.
* `sensei_reports_overview_export_button_url` - Filter the export button URL on the reports overview screen.