### PR TITLE
Enable _lesson_preview show-in-rest meta settings

### DIFF
--- a/includes/rest-api/class-sensei-rest-api-lessons-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-lessons-controller.php
@@ -92,6 +92,17 @@ class Sensei_REST_API_Lessons_Controller extends WP_REST_Posts_Controller {
 				'auth_callback' => [ $this, 'auth_callback' ],
 			]
 		);
+
+		register_post_meta(
+			'lesson',
+			'_lesson_preview',
+			[
+				'show_in_rest'  => true,
+				'single'        => true,
+				'type'          => 'string',
+				'auth_callback' => [ $this, 'auth_callback' ],
+			]
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

### Changes proposed in this Pull Request

* Adds settings to show `lesson_preview` post meta in the lessons REST API.

### Testing instructions

- The easiest way to test this is in the block editor using the following snippet:
`
useSelect(() => {
    return select('core/editor').getCurrentPostAttribute( 'meta' );
})
`

- Ensure `_lesson_preview` key is present in the object returned.