### PR TITLE
Render additional css on feedback answers block

### DIFF
--- a/includes/blocks/class-sensei-course-outline-lesson-block.php
+++ b/includes/blocks/class-sensei-course-outline-lesson-block.php
@@ -23,17 +23,23 @@ class Sensei_Course_Outline_Lesson_Block {
 	 * @return string Lesson HTML
 	 */
 	public function render_lesson_block( $block, $course_id ) {
-		$lesson_id = $block['id'];
-		$classes   = [ 'wp-block-sensei-lms-course-outline-lesson' ];
+		$attributes = $block['attributes'];
+
+		$lesson_id   = $block['id'];
+		$class_names = [ 'wp-block-sensei-lms-course-outline-lesson' ];
 
 		$completed = Sensei_Utils::user_completed_lesson( $lesson_id, get_current_user_id() );
 
 		if ( $completed ) {
-			$classes[] = 'completed';
+			$class_names[] = 'completed';
 		}
 
-		$css           = Sensei_Block_Helpers::build_styles( $block['attributes'] ?? [], [], [ 'fontSize' => 'font-size' ] );
+		$css           = Sensei_Block_Helpers::build_styles( $attributes ?? [], [], [ 'fontSize' => 'font-size' ] );
 		$preview_badge = '';
+
+		if ( ! empty( $attributes['className'] ) ) {
+			$class_names[] = $attributes['className'];
+		}
 
 		if ( isset( $block['preview'] ) && true === $block['preview'] && ! Sensei_Course::is_user_enrolled( $course_id ) ) {
 			$preview_badge = '
@@ -47,7 +53,7 @@ class Sensei_Course_Outline_Lesson_Block {
 		$checked_icon_class = 'wp-block-sensei-lms-course-outline-lesson__status';
 
 		return '
-			<a href="' . esc_url( get_permalink( $lesson_id ) ) . '" ' . Sensei_Block_Helpers::render_style_attributes( $classes, $css ) . '>
+			<a href="' . esc_url( get_permalink( $lesson_id ) ) . '" ' . Sensei_Block_Helpers::render_style_attributes( $class_names, $css ) . '>
 				' . ( $completed ? Sensei()->assets->get_icon( 'checked', $checked_icon_class ) : '<svg class="' . $checked_icon_class . '"></svg>' ) . '
 				<span>
 					' . esc_html( $block['title'] ) . '

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -781,16 +781,17 @@ class Sensei_Question {
 	private static function get_answer_feedback_classes( $question_id, bool $answer_correct ): array {
 		if ( $answer_correct ) {
 			$feedback_block = Sensei_Quiz::get_correct_answer_feedback_block( $question_id );
+
 			return [
 				'sensei-lms-question__answer-feedback--correct',
-				$feedback_block['attrs']['className'],
+				isset($feedback_block['attrs']['className']) ? $feedback_block['attrs']['className']: '',
 			];
 
 		} else {
 			$feedback_block = Sensei_Quiz::get_incorrect_answer_feedback_block( $question_id );
 			return [
 				'sensei-lms-question__answer-feedback--incorrect',
-				$feedback_block['attrs']['className'],
+				isset($feedback_block['attrs']['className']) ? $feedback_block['attrs']['className'] : '',
 
 			];
 		}

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -774,8 +774,8 @@ class Sensei_Question {
 	/**
 	 * Return the answer feedback CSS classes (default and custom) based if the answer is correct or not
 	 *
-	 * @param [type] $question_id
-	 * @param [type] $answer_correct
+	 * @param int  $question_id Question id.
+	 * @param bool $answer_correct Flag indicating if the answer is correct or not.
 	 * @return array CSS classes
 	 */
 	private static function get_answer_feedback_classes( $question_id, bool $answer_correct ): array {
@@ -784,14 +784,14 @@ class Sensei_Question {
 
 			return [
 				'sensei-lms-question__answer-feedback--correct',
-				isset($feedback_block['attrs']['className']) ? $feedback_block['attrs']['className']: '',
+				isset( $feedback_block['attrs']['className'] ) ? $feedback_block['attrs']['className'] : '',
 			];
 
 		} else {
 			$feedback_block = Sensei_Quiz::get_incorrect_answer_feedback_block( $question_id );
 			return [
 				'sensei-lms-question__answer-feedback--incorrect',
-				isset($feedback_block['attrs']['className']) ? $feedback_block['attrs']['className'] : '',
+				isset( $feedback_block['attrs']['className'] ) ? $feedback_block['attrs']['className'] : '',
 
 			];
 		}
@@ -801,7 +801,7 @@ class Sensei_Question {
 	 * Special kses processing for media output to allow 'source' video tag.
 	 *
 	 * @since 3.0.0
-	 * @param string $source_string
+	 * @param string $source_string Source string.
 	 * @return string with allowed html elements
 	 */
 	private static function question_media_kses( $source_string ) {

--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -770,6 +770,32 @@ class Sensei_Question {
 		echo self::question_media_kses( self::get_the_question_media( $question_id ) );
 	}
 
+
+	/**
+	 * Return the answer feedback CSS classes (default and custom) based if the answer is correct or not
+	 *
+	 * @param [type] $question_id
+	 * @param [type] $answer_correct
+	 * @return array CSS classes
+	 */
+	private static function get_answer_feedback_classes( $question_id, bool $answer_correct ): array {
+		if ( $answer_correct ) {
+			$feedback_block = Sensei_Quiz::get_correct_answer_feedback_block( $question_id );
+			return [
+				'sensei-lms-question__answer-feedback--correct',
+				$feedback_block['attrs']['className'],
+			];
+
+		} else {
+			$feedback_block = Sensei_Quiz::get_incorrect_answer_feedback_block( $question_id );
+			return [
+				'sensei-lms-question__answer-feedback--incorrect',
+				$feedback_block['attrs']['className'],
+
+			];
+		}
+	}
+
 	/**
 	 * Special kses processing for media output to allow 'source' video tag.
 	 *
@@ -865,16 +891,15 @@ class Sensei_Question {
 		$answer_grade   = (int) Sensei()->quiz->get_user_question_grade( $lesson_id, $question_id, get_current_user_id() );
 		$answer_correct = $answer_grade > 0;
 
-		$answer_notes_classname = '';
-		$answer_feedback_title  = '';
+		$answer_notes_classnames = [];
+		$answer_feedback_title   = '';
 
 		if ( $indicate_incorrect ) {
+			$answer_notes_classnames = self::get_answer_feedback_classes( $question_id, $answer_correct );
 			if ( $answer_correct ) {
-				$answer_notes_classname = 'sensei-lms-question__answer-feedback--correct';
-				$answer_feedback_title  = __( 'Correct', 'sensei-lms' );
+				$answer_feedback_title = __( 'Correct', 'sensei-lms' );
 			} else {
-				$answer_notes_classname = 'sensei-lms-question__answer-feedback--incorrect';
-				$answer_feedback_title  = __( 'Incorrect', 'sensei-lms' );
+				$answer_feedback_title = __( 'Incorrect', 'sensei-lms' );
 			}
 		}
 
@@ -892,10 +917,9 @@ class Sensei_Question {
 		 *
 		 * @return {string} Space-separated CSS classes to apply to answer message.
 		 */
-		$answer_notes_classname = apply_filters( 'sensei_question_answer_message_css_class', $answer_notes_classname, $lesson_id, $question_id, get_current_user_id(), $answer_correct );
+		$answer_notes_classnames = apply_filters( 'sensei_question_answer_message_css_class', $answer_notes_classnames, $lesson_id, $question_id, get_current_user_id(), $answer_correct );
 
 		$answer_notes = $show_feedback_notes ? Sensei()->quiz->get_user_question_feedback( $lesson_id, $question_id, get_current_user_id() ) : null;
-
 		/**
 		 * Filter the answer feedback.
 		 *
@@ -946,12 +970,11 @@ class Sensei_Question {
 		 *
 		 * @return {string} Answer message.
 		 */
-		$correct_answer = apply_filters( 'sensei_question_answer_message_correct_answer', $correct_answer, $lesson_id, $question_id, get_current_user_id(), $answer_correct );
-
+		$correct_answer   = apply_filters( 'sensei_question_answer_message_correct_answer', $correct_answer, $lesson_id, $question_id, get_current_user_id(), $answer_correct );
 		$has_answer_notes = $answer_notes && wp_strip_all_tags( $answer_notes );
 
 		?>
-		<div class="sensei-lms-question__answer-feedback <?php echo esc_attr( $answer_notes_classname ); ?>">
+		<div class="sensei-lms-question__answer-feedback <?php echo esc_attr( implode( ' ', $answer_notes_classnames ) ); ?>">
 			<?php if ( $indicate_incorrect ) { ?>
 				<div class="sensei-lms-question__answer-feedback__header">
 					<span class="sensei-lms-question__answer-feedback__icon"></span>

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1303,9 +1303,8 @@ class Sensei_Quiz {
 	/**
 	 * Get the contents for the correct answer feedback block.
 	 *
-	 * @param int $question_id
-	 *
-	 * @return string
+	 * @param int $question_id Question Id.
+	 * @return string block rendered
 	 */
 	public static function get_correct_answer_feedback( $question_id ) {
 		$block = self::get_correct_answer_feedback_block( $question_id );
@@ -1315,6 +1314,7 @@ class Sensei_Quiz {
 	/**
 	 * Get the contents for the incorrect answer feedback block.
 	 *
+	 * @access public
 	 * @param int $question_id
 	 *
 	 * @return string
@@ -1328,9 +1328,9 @@ class Sensei_Quiz {
 	/**
 	 * Get the contents for the correct answer feedback block.
 	 *
-	 * @since $$next-version$$
 	 * @access public
-	 * @param int $question_id
+	 * @since $$next-version$$
+	 * @param int $question_id Question Id.
 	 *
 	 * @return string
 	 */
@@ -1343,7 +1343,7 @@ class Sensei_Quiz {
 	 *
 	 * @since $$next-version$$
 	 * @access public
-	 * @param int $question_id
+	 * @param int $question_id Question Id.
 	 *
 	 * @return string
 	 */

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1308,7 +1308,7 @@ class Sensei_Quiz {
 	 * @return string
 	 */
 	public static function get_correct_answer_feedback( $question_id ) {
-		$block = self::get_question_inner_block( $question_id, 'sensei-lms/quiz-question-feedback-correct' );
+		$block = self::get_correct_answer_feedback_block( $question_id );
 		return $block ? render_block( $block ) : '';
 	}
 
@@ -1320,8 +1320,35 @@ class Sensei_Quiz {
 	 * @return string
 	 */
 	public static function get_incorrect_answer_feedback( $question_id ) {
-		$block = self::get_question_inner_block( $question_id, 'sensei-lms/quiz-question-feedback-incorrect' );
+		$block = self::get_incorrect_answer_feedback_block( $question_id );
 		return $block ? render_block( $block ) : '';
+	}
+
+
+	/**
+	 * Get the contents for the correct answer feedback block.
+	 *
+	 * @since $$next-version$$
+	 * @access public
+	 * @param int $question_id
+	 *
+	 * @return string
+	 */
+	public static function get_correct_answer_feedback_block( $question_id ) {
+		return self::get_question_inner_block( $question_id, 'sensei-lms/quiz-question-feedback-correct' );
+	}
+
+	/**
+	 * Get the contents for the incorrect answer feedback block.
+	 *
+	 * @since $$next-version$$
+	 * @access public
+	 * @param int $question_id
+	 *
+	 * @return string
+	 */
+	public static function get_incorrect_answer_feedback_block( $question_id ) {
+		return self::get_question_inner_block( $question_id, 'sensei-lms/quiz-question-feedback-incorrect' );
 	}
 
 	/**

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -399,6 +399,37 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 
 	}
 
+
+	function testGeCorrectAnswerCorrectFeedbacBlock_ReturnBlock() {
+		$quiz = $this->factory->quiz->create_and_get(
+			[
+				'post_content' => '<!-- wp:sensei-lms/quiz-question-feedback-correct {"className":"my-feedback success"} -->
+			<!-- /wp:sensei-lms/quiz-question-feedback-correct -->',
+			]
+		);
+
+		$expected = 'sensei-lms/quiz-question-feedback-correct';
+		$actual   = Sensei_Quiz::get_correct_answer_feedback_block( $quiz->ID );
+
+		 $this->assertEquals( $actual['blockName'], $expected );
+
+	}
+
+
+	function testGeCorrectAnswerIncorrectFeedbacBlock_ReturnBlock() {
+		$quiz = $this->factory->quiz->create_and_get(
+			[
+				'post_content' => '<!-- wp:sensei-lms/quiz-question-feedback-incorrect {"className":"my-feedback success"} -->
+			<!-- /wp:sensei-lms/quiz-question-feedback-incorrect -->',
+			]
+		);
+
+		$expected = 'sensei-lms/quiz-question-feedback-incorrect';
+		$actual   = Sensei_Quiz::get_incorrect_answer_feedback_block( $quiz->ID );
+
+		$this->assertEquals( $actual['blockName'], $expected );
+	}
+
 	/**
 	 * This test Woothemes_Sensei()->quiz->get_user_answers transients only.
 	 *

--- a/tests/unit-tests/test-class-quiz.php
+++ b/tests/unit-tests/test-class-quiz.php
@@ -400,7 +400,7 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 	}
 
 
-	function testGeCorrectAnswerCorrectFeedbacBlock_ReturnBlock() {
+	public function testGeCorrectAnswerCorrectFeedbacBlock_ReturnBlock() {
 		$quiz = $this->factory->quiz->create_and_get(
 			[
 				'post_content' => '<!-- wp:sensei-lms/quiz-question-feedback-correct {"className":"my-feedback success"} -->
@@ -411,12 +411,12 @@ class Sensei_Class_Quiz_Test extends WP_UnitTestCase {
 		$expected = 'sensei-lms/quiz-question-feedback-correct';
 		$actual   = Sensei_Quiz::get_correct_answer_feedback_block( $quiz->ID );
 
-		 $this->assertEquals( $actual['blockName'], $expected );
+		$this->assertEquals( $actual['blockName'], $expected );
 
 	}
 
 
-	function testGeCorrectAnswerIncorrectFeedbacBlock_ReturnBlock() {
+	public function testGeCorrectAnswerIncorrectFeedbacBlock_ReturnBlock() {
 		$quiz = $this->factory->quiz->create_and_get(
 			[
 				'post_content' => '<!-- wp:sensei-lms/quiz-question-feedback-incorrect {"className":"my-feedback success"} -->


### PR DESCRIPTION
Fixes #5224

### Changes proposed in this Pull Request
*  Render additional classes set on the **`Additional CSS class(es)** field for Answer Feedback blocks.
*  Render additional classes set on the **`Additional CSS class(es)** field for Course Lesson

### Testing instructions
* Create a quiz
*  Set custom CSS classes using the  `Additional CSS class(es)` (See the attached image)
<img width="1429" alt="Screen Shot 2022-07-20 at 15 12 55" src="https://user-images.githubusercontent.com/38718/180053177-1fa1eb6e-a770-4f48-a1db-7711c229987f.png">
* Save the quiz and check the answer block on the quiz page (See the attached image)


<img width="1717" alt="class_error" src="https://user-images.githubusercontent.com/38718/180053808-0a6ce2a5-b444-4173-87c1-67f48a5c985a.png">

