### PR TITLE
Update videopress event name

### DIFF
--- a/assets/js/frontend/course-video/videopress-extension.js
+++ b/assets/js/frontend/course-video/videopress-extension.js
@@ -31,7 +31,10 @@ const initVideoPressPlayer = ( iframe ) => {
 			if ( event.source !== iframe.contentWindow ) {
 				return;
 			}
-			if ( event.data.event === 'ended' && event.data.id === videoId ) {
+			if (
+				event.data.event === 'videopress_ended' &&
+				event.data.id === videoId
+			) {
 				onVideoEnd();
 			}
 		},


### PR DESCRIPTION
Fixes #5372

### Changes proposed in this Pull Request

* Recently VideoPress had an update adding a prefix to the events. They're going to re-add the old events again for some time for backward compatibility, but the official one will be with the `videopress_` prefix. 700-gh-Automattic/videopress

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
1. Create a course and a lesson.
2. In the course editor sidebar, turn on "Autocomplete Lesson" and "Required". Save the Course.
3. Add a VideoPress block to the lesson with a video. Here is an example video you may use: https://videopress.com/v/o3RiK7Oi
4. Take the course as a user, open the lesson, and watch the video to the end (you may scroll near the end to speed up the process). Notice that the lesson does not auto-complete and the button is not enabled after the video is completed.