### PR TITLE
Fix Gutenberg compatibility issue

### DIFF
--- a/includes/class-sensei-messages.php
+++ b/includes/class-sensei-messages.php
@@ -44,27 +44,26 @@ class Sensei_Messages {
 		add_action( 'admin_menu', array( $this, 'remove_meta_box' ) );
 
 		// Save new private message (priority low to ensure sensei_message post type is
-		// registered
+		// registered.
 		add_action( 'init', array( $this, 'save_new_message' ), 101 );
 
 		// Monitor when new reply is posted.
-		add_action('comment_post', [$this, 'message_reply_received'], 10, 1);
-		add_action('rest_insert_comment', [$this, 'message_rest_insert'], 10, 3);
+		add_action( 'comment_post', [ $this, 'message_reply_received' ], 10, 1 );
+		add_action( 'rest_insert_comment', [ $this, 'message_rest_insert' ], 10, 3 );
 
-
-		// Block WordPress from sending comment update emails for the messages post type
+		// Block WordPress from sending comment update emails for the messages post type.
 		add_filter( 'comment_notification_recipients', array( $this, 'stop_wp_comment_emails' ), 20, 2 );
 
-		// Block WordPress from sending comment moderator emails on the sensei messages post types
+		// Block WordPress from sending comment moderator emails on the sensei messages post types.
 		add_filter( 'comment_moderation_recipients', array( $this, 'stop_wp_comment_emails' ), 20, 2 );
 
-		// add message link to lesson
+		// Add message link to lesson.
 		add_action( 'sensei_single_lesson_content_inside_before', array( $this, 'send_message_link' ), 30, 2 );
 
-		// add message link to lesson
+		// Add message link to lesson.
 		add_action( 'sensei_single_quiz_questions_before', array( $this, 'send_message_link' ), 10, 2 );
 
-		// Hide messages and replies from users who do not have access
+		// Hide messages and replies from users who do not have access.
 		add_action( 'template_redirect', array( $this, 'message_login' ), 10, 1 );
 		add_action( 'pre_get_posts', array( $this, 'message_list' ), 10, 1 );
 		add_filter( 'the_title', array( $this, 'message_title' ), 10, 2 );
@@ -76,7 +75,7 @@ class Sensei_Messages {
 		add_filter( 'comment_feed_where', array( $this, 'exclude_message_comments_from_feed_where' ) );
 		add_filter( 'user_has_cap', [ $this, 'user_messages_cap_check' ], 10, 3 );
 		add_action( 'load-edit-comments.php', [ $this, 'check_permissions_edit_comments' ] );
-		add_action('comment_form', [$this, 'add_nonce_to_comment_form']);
+		add_action( 'comment_form', [ $this, 'add_nonce_to_comment_form' ] );
 	}
 
 	public function only_show_messages_to_owner( $query ) {
@@ -397,15 +396,15 @@ class Sensei_Messages {
 			return;
 		}
 
-		$should_verify_nonce = !defined('XMLRPC_REQUEST');
+		$should_verify_nonce = ! defined( 'XMLRPC_REQUEST' );
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Nonce verification.
-		$nonce_verified = !empty($_POST['sensei_message_nonce']) && wp_verify_nonce(wp_unslash($_POST['sensei_message_nonce']), 'sensei_post_message_reply');
+		$nonce_verified = ! empty( $_POST['sensei_message_nonce'] ) && wp_verify_nonce( wp_unslash( $_POST['sensei_message_nonce'] ), 'sensei_post_message_reply' );
 
-		$comment_author   = get_userdata($comment->user_id);
-		$user_can_comment = in_array($comment_author->user_login, [get_post_meta($message->ID, '_receiver', true), get_post_meta($message->ID, '_sender', true)], true);
+		$comment_author   = get_userdata( $comment->user_id );
+		$user_can_comment = in_array( $comment_author->user_login, [ get_post_meta( $message->ID, '_receiver', true ), get_post_meta( $message->ID, '_sender', true ) ], true );
 
-		if (($should_verify_nonce && !$nonce_verified) || !$user_can_comment) {
-			wp_set_comment_status($comment_id, 'spam');
+		if ( ( $should_verify_nonce && ! $nonce_verified ) || ! $user_can_comment ) {
+			wp_set_comment_status( $comment_id, 'spam' );
 			return;
 		}
 
@@ -425,19 +424,18 @@ class Sensei_Messages {
 	 * @param bool            $creating True when creating a comment, false
 	 *                                  when updating.
 	 */
-	public function message_rest_insert(WP_Comment $comment, WP_REST_Request $request, bool $creating)
-	{
-		$message = get_post($comment->comment_post_ID);
+	public function message_rest_insert( WP_Comment $comment, WP_REST_Request $request, bool $creating ) {
+		$message = get_post( $comment->comment_post_ID );
 
-		if ($message->post_type !== $this->post_type) {
+		if ( $message->post_type !== $this->post_type ) {
 			return;
 		}
 
-		$comment_author   = get_userdata($comment->user_id);
-		$user_can_comment = in_array($comment_author->user_login, [get_post_meta($message->ID, '_receiver', true), get_post_meta($message->ID, '_sender', true)], true);
+		$comment_author   = get_userdata( $comment->user_id );
+		$user_can_comment = in_array( $comment_author->user_login, [ get_post_meta( $message->ID, '_receiver', true ), get_post_meta( $message->ID, '_sender', true ) ], true );
 
-		if (!$user_can_comment) {
-			wp_set_comment_status($comment->comment_ID, 'spam');
+		if ( ! $user_can_comment ) {
+			wp_set_comment_status( $comment->comment_ID, 'spam' );
 		}
 	}
 
@@ -448,10 +446,9 @@ class Sensei_Messages {
 	 *
 	 * @return void
 	 */
-	public function add_nonce_to_comment_form()
-	{
-		if (is_singular($this->post_type)) {
-			wp_nonce_field('sensei_post_message_reply', 'sensei_message_nonce');
+	public function add_nonce_to_comment_form() {
+		if ( is_singular( $this->post_type ) ) {
+			wp_nonce_field( 'sensei_post_message_reply', 'sensei_message_nonce' );
 		}
 	}
 

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -125,6 +125,7 @@ class Sensei_Course_Theme {
 		}
 
 		// Then parse the request and make sure the query var is correct.
+		wp_load_translations_early();
 		wp();
 
 		if ( get_query_var( self::QUERY_VAR ) ) {


### PR DESCRIPTION
Based on [version 4.5.2](https://github.com/Automattic/sensei/releases/tag/version%2F4.5.2)

### Changes proposed in this Pull Request

* It fixes a compatibility issue with the latest version of Gutenberg.
* Basically, it initializes the global `$wp_locale` earlier when using Learning Mode.
* It also includes some PHPCS fixes.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Install the latest Gutenberg plugin (`13.7.2`) or pull the code in the Gutenberg repo. 
* Add the following snippet to your code:
  ```php
  add_action(
	  'wp',
	  function() {
		  wp_enqueue_script( 'my-custom-script', 'any-script.js', [], '1.0.0', true );
	  },
	  99
  );
  ```
* Create a course with Learning Mode enabled and some lessons.
* Make sure you don't see the following notices/warnings anymore:
  ```
  PHP Notice:  Trying to get property 'month' of non-object in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.1/date-settings.php on line 48
  PHP Warning:  array_values() expects parameter 1 to be array, null given in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.1/date-settings.php on line 48
  PHP Notice:  Trying to get property 'month_abbrev' of non-object in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.1/date-settings.php on line 49
  PHP Warning:  array_values() expects parameter 1 to be array, null given in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.1/date-settings.php on line 49
  PHP Notice:  Trying to get property 'weekday' of non-object in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.1/date-settings.php on line 50
  PHP Warning:  array_values() expects parameter 1 to be array, null given in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.1/date-settings.php on line 50
  PHP Notice:  Trying to get property 'weekday_abbrev' of non-object in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.1/date-settings.php on line 51
  PHP Warning:  array_values() expects parameter 1 to be array, null given in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.1/date-settings.php on line 51
  PHP Notice:  Trying to get property 'meridiem' of non-object in /var/www/html/wp-content/plugins/gutenberg/lib/compat/wordpress-6.1/date-settings.php on line 52
  ```

### Context

https://github.com/WordPress/gutenberg/commit/12db0a959e4e07243f9852ca7cf46b4fa9328747