### PR TITLE
Remove additional line from login redirection code

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -1317,7 +1317,7 @@ class Sensei_Frontend {
 		 // if there's a valid referrer, and it's not the default log-in screen.
 		if ( ! empty( $referrer ) && ! strstr( $referrer, 'wp-login' ) && ! strstr( $referrer, 'wp-admin' ) ) {
 			// let's append some information (login=failed) to the URL for the theme to use.
-			wp_safe_redirect( esc_url_raw( add_query_arg( 'login', 'failed', $referrer ) ) )( esc_url_raw( add_query_arg( 'login', 'failed', $referrer ) ) );
+			wp_safe_redirect( esc_url_raw( add_query_arg( 'login', 'failed', $referrer ) ) );
 			exit;
 		}
 	}


### PR DESCRIPTION
It fixes the issue of not redirecting users to login page on login fail and showing fatal error instead

### Changes proposed in this Pull Request

* Removed a small erroneous part of code.

### Testing instructions

- Go to a course page when you are not logged in
- Try logging in as a student, but with the wrong username/pass
- You should be properly redirected to log in again
