### PR TITLE
Fix player API on the editor side when editing embeds with no changes

### DIFF
--- a/assets/shared/helpers/player/use-editor-player.js
+++ b/assets/shared/helpers/player/use-editor-player.js
@@ -40,8 +40,8 @@ const useTriggerDependencies = ( videoBlock ) => {
 			isBlockSelected: select( blockEditorStore ).isBlockSelected(
 				videoBlock.clientId
 			),
-			// This prop is used to for the case when the user edit the embed URL, don't change the
-			// value and click on "Embed" again.
+			// This prop is used to detect the case when the user edits the embed URL, doesn't change the
+			// value and clicks on "Embed" again.
 			lastBlockAttributeChange: select(
 				blockEditorStore
 			).__experimentalGetLastBlockAttributeChanges()?.[

--- a/assets/shared/helpers/player/use-editor-player.js
+++ b/assets/shared/helpers/player/use-editor-player.js
@@ -35,16 +35,23 @@ const useTriggerDependencies = ( videoBlock ) => {
 
 	// Check if block is selected. We need to get the player reference again when it's video block
 	// because it re-creates the video element when it's (un)selected.
-	const { isBlockSelected } = useSelect(
+	const { isBlockSelected, lastBlockAttributeChange } = useSelect(
 		( select ) => ( {
 			isBlockSelected: select( blockEditorStore ).isBlockSelected(
 				videoBlock.clientId
 			),
+			// This prop is used to for the case when the user edit the embed URL, don't change the
+			// value and click on "Embed" again.
+			lastBlockAttributeChange: select(
+				blockEditorStore
+			).__experimentalGetLastBlockAttributeChanges()?.[
+				videoBlock.clientId
+			],
 		} ),
 		[ videoBlock.clientId ]
 	);
 
-	return { fetching, isBlockSelected };
+	return { fetching, isBlockSelected, lastBlockAttributeChange };
 };
 
 /**
@@ -108,7 +115,11 @@ const prepareYouTubeIframe = ( playerIframe, w ) => {
 const useEditorPlayer = ( videoBlock ) => {
 	const [ player, setPlayer ] = useState();
 
-	const { fetching, isBlockSelected } = useTriggerDependencies( videoBlock );
+	const {
+		fetching,
+		isBlockSelected,
+		lastBlockAttributeChange,
+	} = useTriggerDependencies( videoBlock );
 
 	// This is delayed to make sure it will run after the effects of the other blocks, which
 	// creates the iframe and video tags.
@@ -160,7 +171,7 @@ const useEditorPlayer = ( videoBlock ) => {
 				break;
 			}
 		}
-	}, [ videoBlock, isBlockSelected, fetching ] );
+	}, [ fetching, isBlockSelected, lastBlockAttributeChange ] );
 
 	return player;
 };

--- a/assets/shared/helpers/player/use-editor-player.js
+++ b/assets/shared/helpers/player/use-editor-player.js
@@ -33,10 +33,10 @@ const useTriggerDependencies = ( videoBlock ) => {
 		[ videoBlock?.attributes?.url ]
 	);
 
-	// Check if block is selected. We need to get the player reference again when it's video block
-	// because it re-creates the video element when it's (un)selected.
 	const { isBlockSelected, lastBlockAttributeChange } = useSelect(
 		( select ) => ( {
+			// Check if block is selected. We need to get the player reference again when it's video
+			// block because it re-creates the video element when it's (un)selected.
 			isBlockSelected: select( blockEditorStore ).isBlockSelected(
 				videoBlock.clientId
 			),


### PR DESCRIPTION
### Changes proposed in this Pull Request

It fixes an edge case when we try to edit an embed video, but we don't change it, and click in Embed again.

When it happens, the iframe is re-created, but it doesn't change the video block attributes, so it doesn't re-trigger the player script to work with the new iframe. So I inspected the store, and got the only change I found that we could use for this specific case.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* In Sensei Pro checkout `feature/interactive-video-block`.
* Extract the file [temp.diff.zip](https://github.com/Automattic/sensei/files/9221177/temp.diff.zip). In Sensei Pro, apply this diff with `git apply temp.diff`.
* Ad interactive video blocks to the editor of with the embed types (VideoPress, YouTube, and Vimeo).
* Play it, click on the video edit, and click on "Embed" with no changes.
* Play the video again, and make sure the current time updates while the video plays.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

https://user-images.githubusercontent.com/876340/181790997-050d4890-3f92-4b7d-8c38-d7915942fcb9.mov

