### PR TITLE
Fix multiple emails are send when completing a course in the backend

### DIFF
--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -790,8 +790,20 @@ class Sensei_Learner_Management {
 
 			switch ( $post_type ) {
 				case 'course':
+					$base_query_args        = [
+						'posts_per_page' => -1,
+						'fields' => 'ids'
+					];
+					$learner_manager = Sensei_Learner::instance();
+					$courses_query   = $learner_manager->get_enrolled_completed_courses_query( $user_id, $base_query_args );
+
 					// Complete each lesson if course is set to be completed.
-					if ( $result && isset( $_POST['add_complete_course'] ) && 'yes' === $_POST['add_complete_course'] ) {
+					if (
+						$result
+						&& isset( $_POST['add_complete_course'] )
+						&& 'yes' === $_POST['add_complete_course']
+						&& ! in_array( $course_id, $courses_query->posts, true )
+					) {
 						Sensei_Utils::force_complete_user_course( $user_id, $course_id );
 					}
 

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -795,7 +795,7 @@ class Sensei_Learner_Management {
 						$result
 						&& isset( $_POST['add_complete_course'] )
 						&& 'yes' === $_POST['add_complete_course']
-						&& ! Sensei_Utils::user_completed_course( $course_id,  $user_id )
+						&& ! Sensei_Utils::user_completed_course( $course_id, $user_id )
 					) {
 						Sensei_Utils::force_complete_user_course( $user_id, $course_id );
 					}

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -790,11 +790,6 @@ class Sensei_Learner_Management {
 
 			switch ( $post_type ) {
 				case 'course':
-					$base_query_args        = [
-						'posts_per_page' => -1,
-						'fields' => 'ids'
-					];
-
 					// Complete each lesson if course is set to be completed.
 					if (
 						$result

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -794,15 +794,13 @@ class Sensei_Learner_Management {
 						'posts_per_page' => -1,
 						'fields' => 'ids'
 					];
-					$learner_manager = Sensei_Learner::instance();
-					$completed_courses   = $learner_manager->get_enrolled_completed_courses_query( $user_id, $base_query_args );
 
 					// Complete each lesson if course is set to be completed.
 					if (
 						$result
 						&& isset( $_POST['add_complete_course'] )
 						&& 'yes' === $_POST['add_complete_course']
-						&& ! in_array( $course_id, $completed_courses->posts, true )
+						&& ! Sensei_Utils::user_completed_course( $course_id,  $user_id )
 					) {
 						Sensei_Utils::force_complete_user_course( $user_id, $course_id );
 					}

--- a/includes/admin/class-sensei-learner-management.php
+++ b/includes/admin/class-sensei-learner-management.php
@@ -795,14 +795,14 @@ class Sensei_Learner_Management {
 						'fields' => 'ids'
 					];
 					$learner_manager = Sensei_Learner::instance();
-					$courses_query   = $learner_manager->get_enrolled_completed_courses_query( $user_id, $base_query_args );
+					$completed_courses   = $learner_manager->get_enrolled_completed_courses_query( $user_id, $base_query_args );
 
 					// Complete each lesson if course is set to be completed.
 					if (
 						$result
 						&& isset( $_POST['add_complete_course'] )
 						&& 'yes' === $_POST['add_complete_course']
-						&& ! in_array( $course_id, $courses_query->posts, true )
+						&& ! in_array( $course_id, $completed_courses->posts, true )
 					) {
 						Sensei_Utils::force_complete_user_course( $user_id, $course_id );
 					}


### PR DESCRIPTION
Fixes #5391

### Changes proposed in this Pull Request

* When adding a student to a course and selecting `Complete course for selected student(s)` this will check to see if student has already completed this course before forcing completion.  The main reason for this is so that things like Emails won't be triggered multiple times if not needed.

### Testing instructions

* Use something like Mailhog or WP Mail Log to verify what emails are sent
* Go to Courses
* Select "Manage" under the Students Column
* Select a student to manually enrol and check off the `Complete course for selected student(s)` box
* Verify that emails were sent
* Select the same student and manually enrol them again with the `Complete course for selected student(s)` checkbox checked 
* Verify that no additional emails were sent.
