### PR TITLE
Fix/last activity sort

### DIFF
--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -474,17 +474,6 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	 * @return array The query args
 	 */
 	private function parse_query_args() {
-		// Handle orderby.
-		$orderby = '';
-
-		// phpcs:ignore WordPress.Security.NonceVerification -- Argument is used to order columns.
-		if ( ! empty( $_GET['orderby'] ) ) {
-			// phpcs:ignore WordPress.Security.NonceVerification
-			$orderby_input = sanitize_text_field( wp_unslash( $_GET['orderby'] ) );
-			if ( array_key_exists( $orderby_input, $this->get_sortable_columns() ) ) {
-				$orderby = $orderby_input;
-			}
-		}
 
 		// Handle order.
 		$order = 'DESC';
@@ -521,9 +510,6 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		if ( ! empty( $paged ) ) {
 			$offset = $per_page * ( $paged - 1 );
 		}
-		if ( empty( $orderby ) ) {
-			$orderby = '';
-		}
 
 		$filter_by_course_id = 0;
 		// phpcs:ignore WordPress.Security.NonceVerification -- Argument is used for filtering.
@@ -542,7 +528,7 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 		$page      = $this->page_slug;
 		$post_type = $this->menu_post_type;
 		$view      = $this->controller->get_view();
-		$args      = compact( 'page', 'post_type', 'view', 'per_page', 'offset', 'orderby', 'order', 'search', 'filter_by_course_id', 'filter_type' );
+		$args      = compact( 'page', 'post_type', 'view', 'per_page', 'offset', 'order', 'search', 'filter_by_course_id', 'filter_type' );
 
 		return $args;
 	}

--- a/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
+++ b/includes/admin/class-sensei-learners-admin-bulk-actions-view.php
@@ -272,6 +272,16 @@ class Sensei_Learners_Admin_Bulk_Actions_View extends Sensei_List_Table {
 	private function get_learners( $args ) {
 		$query             = new Sensei_Db_Query_Learners( $args );
 		$learners          = $query->get_all();
+
+		if ( isset( $_GET['orderby'] ) && 'last_activity_date' === $_GET['orderby'] ) {
+			usort($learners, function ($item1, $item2) {
+				return $item1->last_activity_date <=> $item2->last_activity_date;
+			});
+			if ( isset( $_GET['order'] ) && 'asc' === $_GET['order'] ) {
+				$learners = array_reverse( $learners );
+			}
+		}
+
 		$this->total_items = $query->total_items;
 		return $learners;
 	}


### PR DESCRIPTION
Fixes #5335

### Changes proposed in this Pull Request

Previously, we sorted Students by Last Activity Date by manipulating the DB query.  In https://github.com/Automattic/sensei/pull/5104 we extracted that out of the query and now we add that information to the query results to each user object.  However, doing that broke the sorting by last activity.

What I'm doing here is moving the logic from parsing query arguments before the query to ordering after the query has been done.  

### Testing instructions

* Go to Sensei LMS -> Students
* Have at least 3 students with different `Last Activity` times.
* Click on the `Last Activity` column header
* Make sure both ASC and DESC work as expected

### Screenshot / Video
![last-activity-ordering](https://user-images.githubusercontent.com/3220162/182048995-d0f2c46f-f28d-44aa-b6ca-7c3c66a660d8.gif)

