### PR TITLE
Fix VideoPress initialization

### DIFF
--- a/assets/shared/helpers/player/videopress-adapter.js
+++ b/assets/shared/helpers/player/videopress-adapter.js
@@ -18,6 +18,12 @@ export const EMBED_PATTERN = /(videopress|video\.wordpress)\.com\/.+/i;
  */
 export const initializePlayer = ( element, w = window ) =>
 	new Promise( ( resolve ) => {
+		// It was already initialized earlier.
+		const { duration } = element.dataset;
+		if ( duration ) {
+			resolve( element );
+		}
+
 		const onDurationChange = ( event ) => {
 			if (
 				event.source !== element.contentWindow ||

--- a/assets/shared/helpers/player/videopress-adapter.js
+++ b/assets/shared/helpers/player/videopress-adapter.js
@@ -22,6 +22,7 @@ export const initializePlayer = ( element, w = window ) =>
 		const { duration } = element.dataset;
 		if ( duration ) {
 			resolve( element );
+			return;
 		}
 
 		const onDurationChange = ( event ) => {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes an issue with VideoPress initialization.
* Basically, our VideoPress initialization was tied to the `videopress_durationchange` event, but it happens just a single time. So if it was already initialized, the `getPlayer` wouldn't work for future uses because the promise would never resolve. So this PR just adds a check to resolve the Promise if it was already initialized.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* It's something a little hard to test without implementing some logic. So I since it's a small change, I hope just checking the code change is enough.