### PR TITLE
Add current time to player and hook to get the video duration

### DIFF
--- a/assets/shared/helpers/player/index.js
+++ b/assets/shared/helpers/player/index.js
@@ -172,7 +172,7 @@ class Player {
  *
  * @param {Object} player Player instance.
  *
- * @return {number} The video duration.
+ * @return {number|undefined} The video duration.
  */
 export const useVideoDuration = ( player ) => {
 	const [ duration, setDuration ] = useState();

--- a/assets/shared/helpers/player/index.js
+++ b/assets/shared/helpers/player/index.js
@@ -95,6 +95,17 @@ class Player {
 	}
 
 	/**
+	 * Get the video current time.
+	 *
+	 * @return {Promise<number>} The current video time in seconds through a promise.
+	 */
+	getCurrentTime() {
+		return this.getPlayer().then( ( player ) =>
+			this.getAdapter().getCurrentTime( player )
+		);
+	}
+
+	/**
 	 * Set the video to a current time.
 	 *
 	 * @param {number} seconds The video time in seconds to set.

--- a/assets/shared/helpers/player/index.js
+++ b/assets/shared/helpers/player/index.js
@@ -1,4 +1,9 @@
 /**
+ * WordPress dependencies
+ */
+import { useEffect, useState } from '@wordpress/element';
+
+/**
  * Internal dependencies
  */
 import * as videoFileAdapter from './video-file-adapter';
@@ -161,5 +166,22 @@ class Player {
 		);
 	}
 }
+
+/**
+ * Hook to get the video duration.
+ *
+ * @param {Object} player Player instance.
+ *
+ * @return {number} The video duration.
+ */
+export const useVideoDuration = ( player ) => {
+	const [ duration, setDuration ] = useState();
+
+	useEffect( () => {
+		player?.getDuration().then( setDuration );
+	}, [ player ] );
+
+	return duration;
+};
 
 export default Player;

--- a/assets/shared/helpers/player/use-editor-player.js
+++ b/assets/shared/helpers/player/use-editor-player.js
@@ -71,7 +71,7 @@ const useDelayedEffect = ( effect, deps ) => {
 /**
  * Add a script to a body.
  *
- * @param {Document} doc    The body where the script will be appended.
+ * @param {Document} doc    The document where the script will be appended.
  * @param {string}   src    Script src.
  * @param {Function} onLoad Script load callback.
  */

--- a/assets/shared/helpers/player/use-editor-player.js
+++ b/assets/shared/helpers/player/use-editor-player.js
@@ -80,8 +80,8 @@ const addScript = ( body, src, onLoad ) => {
 
 	script.src = src;
 	script.id = API_SCRIPT_ID;
-	script.onload = onLoad;
 
+	script.addEventListener( 'load', onLoad );
 	body.append( script );
 };
 
@@ -144,8 +144,17 @@ const useEditorPlayer = ( videoBlock ) => {
 		const playerIframe = doc?.querySelector( 'iframe' );
 		const playerScript = doc?.getElementById( API_SCRIPT_ID );
 
-		// Skip if iframe is not found or player was already added.
-		if ( ! playerIframe || playerScript ) {
+		// Skip if iframe is not found.
+		if ( ! playerIframe ) {
+			return;
+		}
+
+		// If player script was already added, add load event to make sure player will be set.
+		if ( playerScript ) {
+			playerScript.addEventListener( 'load', () => {
+				setPlayer( new Player( doc.querySelector( 'iframe' ), w ) );
+			} );
+
 			return;
 		}
 

--- a/assets/shared/helpers/player/use-editor-player.js
+++ b/assets/shared/helpers/player/use-editor-player.js
@@ -38,17 +38,17 @@ const useTriggerDependencies = ( videoBlock ) => {
 			// Check if block is selected. We need to get the player reference again when it's video
 			// block because it re-creates the video element when it's (un)selected.
 			isBlockSelected: select( blockEditorStore ).isBlockSelected(
-				videoBlock.clientId
+				videoBlock?.clientId
 			),
 			// This prop is used to detect the case when the user edits the embed URL, doesn't change the
 			// value and clicks on "Embed" again.
 			lastBlockAttributeChange: select(
 				blockEditorStore
 			).__experimentalGetLastBlockAttributeChanges()?.[
-				videoBlock.clientId
+				videoBlock?.clientId
 			],
 		} ),
-		[ videoBlock.clientId ]
+		[ videoBlock?.clientId ]
 	);
 
 	return { fetching, isBlockSelected, lastBlockAttributeChange };
@@ -124,7 +124,11 @@ const useEditorPlayer = ( videoBlock ) => {
 	// This is delayed to make sure it will run after the effects of the other blocks, which
 	// creates the iframe and video tags.
 	useDelayedEffect( () => {
-		// Video block.
+		if ( ! videoBlock ) {
+			return;
+		}
+
+		// Video file block.
 		if ( 'core/video' === videoBlock.name ) {
 			const video = document.querySelector(
 				`#block-${ videoBlock.clientId } video`

--- a/assets/shared/helpers/player/video-file-adapter.js
+++ b/assets/shared/helpers/player/video-file-adapter.js
@@ -39,6 +39,18 @@ export const getDuration = ( player ) =>
 	} );
 
 /**
+ * Get the current video time.
+ *
+ * @param {HTMLVideoElement} player The player element.
+ *
+ * @return {Promise<number>} The current video time in seconds through a promise.
+ */
+export const getCurrentTime = ( player ) =>
+	new Promise( ( resolve ) => {
+		resolve( player.currentTime );
+	} );
+
+/**
  * Set the video to a current time.
  *
  * @param {HTMLVideoElement} player  The player element.

--- a/assets/shared/helpers/player/videopress-adapter.js
+++ b/assets/shared/helpers/player/videopress-adapter.js
@@ -25,25 +25,38 @@ export const initializePlayer = ( element, w = window ) =>
 			return;
 		}
 
-		const onDurationChange = ( event ) => {
-			if (
-				event.source !== element.contentWindow ||
-				event.data.event !== 'videopress_durationchange' ||
-				! event.data.durationMs
-			) {
+		const onVideoPressMessage = ( event ) => {
+			if ( event.source !== element.contentWindow ) {
 				return;
 			}
 
-			// Set the duration to a dataset in order to have it available for later.
-			element.dataset.duration =
-				parseInt( event.data.durationMs, 10 ) / 1000;
+			const { data } = event;
 
-			w.removeEventListener( 'message', onDurationChange );
-			resolve( element );
+			if (
+				data.event === 'videopress_durationchange' &&
+				data.durationMs
+			) {
+				// Set the duration to a dataset in order to be available later,
+				// and consider the initialization done.
+				element.dataset.duration = data.durationMs / 1000;
+
+				// If current time didn't return yet, set it to `0`.
+				if ( ! element.dataset.currentTime ) {
+					element.dataset.currentTime = 0;
+				}
+
+				resolve( element );
+			} else if (
+				data.event === `videopress_timeupdate` &&
+				data.currentTimeMs
+			) {
+				// Set the current time to a dataset in order to be available later.
+				element.dataset.currentTime = data.currentTimeMs / 1000;
+			}
 		};
 
 		// eslint-disable-next-line @wordpress/no-global-event-listener -- Not in a React context.
-		w.addEventListener( 'message', onDurationChange );
+		w.addEventListener( 'message', onVideoPressMessage );
 	} );
 
 /**
@@ -62,6 +75,24 @@ export const getDuration = ( player ) =>
 		}
 
 		resolve( parseFloat( player.dataset.duration ) );
+	} );
+
+/**
+ * Get the current video time.
+ *
+ * @param {HTMLIFrameElement} player The player element.
+ *
+ * @return {Promise<number>} The current video time in seconds through a promise.
+ */
+export const getCurrentTime = ( player ) =>
+	new Promise( ( resolve, reject ) => {
+		const { currentTime } = player.dataset;
+
+		if ( ! currentTime ) {
+			reject( new Error( 'Video current time not found' ) );
+		}
+
+		resolve( parseFloat( player.dataset.currentTime ) );
 	} );
 
 /**

--- a/assets/shared/helpers/player/videopress-adapter.js
+++ b/assets/shared/helpers/player/videopress-adapter.js
@@ -74,7 +74,7 @@ export const getDuration = ( player ) =>
 			reject( new Error( 'Video duration not found' ) );
 		}
 
-		resolve( parseFloat( player.dataset.duration ) );
+		resolve( parseFloat( duration ) );
 	} );
 
 /**

--- a/assets/shared/helpers/player/videopress-adapter.js
+++ b/assets/shared/helpers/player/videopress-adapter.js
@@ -92,7 +92,7 @@ export const getCurrentTime = ( player ) =>
 			reject( new Error( 'Video current time not found' ) );
 		}
 
-		resolve( parseFloat( player.dataset.currentTime ) );
+		resolve( parseFloat( currentTime ) );
 	} );
 
 /**

--- a/assets/shared/helpers/player/videopress-adapter.js
+++ b/assets/shared/helpers/player/videopress-adapter.js
@@ -90,6 +90,7 @@ export const getCurrentTime = ( player ) =>
 
 		if ( ! currentTime ) {
 			reject( new Error( 'Video current time not found' ) );
+			return;
 		}
 
 		resolve( parseFloat( currentTime ) );

--- a/assets/shared/helpers/player/vimeo-adapter.js
+++ b/assets/shared/helpers/player/vimeo-adapter.js
@@ -30,6 +30,15 @@ export const initializePlayer = ( element, w = window ) =>
 export const getDuration = ( player ) => player.getDuration();
 
 /**
+ * Get the current video time.
+ *
+ * @param {Object} player The Vimeo player instance.
+ *
+ * @return {Promise<number>} The current video time in seconds through a promise.
+ */
+export const getCurrentTime = ( player ) => player.getCurrentTime();
+
+/**
  * Set the video to a current time.
  *
  * @param {Object} player  The Vimeo player instance.

--- a/assets/shared/helpers/player/youtube-adapter.js
+++ b/assets/shared/helpers/player/youtube-adapter.js
@@ -49,6 +49,18 @@ export const getDuration = ( player ) =>
 	} );
 
 /**
+ * Get the current video time.
+ *
+ * @param {Object} player The YouTube player instance.
+ *
+ * @return {Promise<number>} The current video time in seconds through a promise.
+ */
+export const getCurrentTime = ( player ) =>
+	new Promise( ( resolve ) => {
+		resolve( player.getCurrentTime() );
+	} );
+
+/**
  * Set the video to a current time.
  *
  * @param {Object} player  The YouTube player instance.


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It adds the current time method to the player.
* It also adds a hook to get the video duration.
* It also fixes some edge cases that I caught while testing multiple instances of the player in the editor.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* See 1619-gh-Automattic/sensei-pro.