### PR TITLE
Fix html entities bug for question answers.

### DIFF
--- a/includes/class-sensei-question.php
+++ b/includes/class-sensei-question.php
@@ -632,7 +632,7 @@ class Sensei_Question {
 		$question_grade = Sensei()->question->get_question_grade( $question_id );
 
 		$title_html  = '<span class="question question-title">';
-		$title_html .= wp_kses_post( $title );
+		$title_html .= esc_html( $title );
 		$title_html .= Sensei()->view_helper->format_question_points( $question_grade );
 		$title_html .= '</span>';
 
@@ -1469,21 +1469,21 @@ class Sensei_Question {
 		} elseif ( 'multiple-choice' == $type ) {
 
 			$right_answer = (array) $right_answer;
-			$right_answer = implode( ', ', $right_answer );
+			$right_answer = esc_html( implode( ', ', $right_answer ) );
 
 		} elseif ( 'gap-fill' == $type ) {
 
 			$right_answer_array = explode( '||', $right_answer );
 			if ( isset( $right_answer_array[0] ) ) {
-				$gapfill_pre = $right_answer_array[0];
+				$gapfill_pre = esc_html( $right_answer_array[0] );
 			} else {
 				$gapfill_pre = ''; }
 			if ( isset( $right_answer_array[1] ) ) {
-				$gapfill_gap = $right_answer_array[1];
+				$gapfill_gap = esc_html( $right_answer_array[1] );
 			} else {
 				$gapfill_gap = ''; }
 			if ( isset( $right_answer_array[2] ) ) {
-				$gapfill_post = $right_answer_array[2];
+				$gapfill_post = esc_html( $right_answer_array[2] );
 			} else {
 				$gapfill_post = ''; }
 

--- a/templates/single-quiz/question-type-multiple-choice.php
+++ b/templates/single-quiz/question-type-multiple-choice.php
@@ -38,7 +38,7 @@ foreach ( $question_data['answer_options'] as $option ) {
 			/>
 
 		<label for="<?php echo esc_attr( 'question_' . $question_data['ID'] . '-option-' . $count ); ?>">
-			<?php echo wp_kses_post( apply_filters( 'sensei_answer_text', $option['answer'] ) ); ?>
+			<?php echo esc_html( apply_filters( 'sensei_answer_text', $option['answer'] ) ); ?>
 		</label>
 	</li>
 <?php } ?>


### PR DESCRIPTION
Fixes #5321 

### Changes proposed in this Pull Request

* Applies `esc_html` to question answers so users can use html entities in question answers and titles.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Create a multi-choice question and a gap question.
* Use html entities for the answers. E.g.: `<head>, <script>, <tag>`.
* Take the quiz and answer correctly.
* Confirm that the answers are accepted.
* Confirm that the question titles correctly displays the text with html entitites in them.
* Take the quiz and answer incorrectly.
* Confirm that the question answer feedback shows up correctly.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
<img width="806" alt="Screen Shot 2022-08-04 at 13 35 32" src="https://user-images.githubusercontent.com/2578542/182815251-43f8a891-2856-491b-83f3-cfba532a9366.png">
<img width="816" alt="Screen Shot 2022-08-04 at 13 35 56" src="https://user-images.githubusercontent.com/2578542/182815259-e2cb8b14-72c3-40e9-bd0c-db6976a2f3b0.png">
