### PR TITLE
Fix set current time to keep the same behavior for all players

### DIFF
--- a/assets/shared/helpers/player/vimeo-adapter.js
+++ b/assets/shared/helpers/player/vimeo-adapter.js
@@ -65,9 +65,8 @@ export const setCurrentTime = ( player, seconds ) => {
 	}
 
 	// Play the video a first time if it wasn't already played yet.
-	return player
-		.play()
-		.then( () => player.pause() )
+	return play( player )
+		.then( () => pause( player ) )
 		.then( () => player.setCurrentTime( seconds ) );
 };
 


### PR DESCRIPTION
Based on https://github.com/Automattic/sensei/pull/5410

### Changes proposed in this Pull Request

* It updates the `setCurrentTime`, in order to work in the same way for all the players. Basically, we need to have played a video in some players in order to have the frame updated when calling the `setCurrentTime`, so if the video wasn't played yet, we just play and pause to make it work.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Check this branch 1619-gh-Automattic/sensei-pro
* Before playing the videos, add points in the same place, and make sure the video frame will update.
* For YT, it's not working for me in the first frame (it keeps loading), but I don't think there's something we can do about that.