### PR TITLE
Add the course list block

### DIFF
--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -6,7 +6,7 @@ import { registerBlockVariation } from '@wordpress/blocks';
 import { list } from '@wordpress/icons';
 
 export const registerCourseListBlock = () => {
-	const QUERY_DEFAULT_ATTRIBUTES = {
+	const DEFAULT_ATTRIBUTES = {
 		className: 'course-list-block',
 		query: {
 			perPage: 3,
@@ -24,7 +24,7 @@ export const registerCourseListBlock = () => {
 	};
 
 	registerBlockVariation( 'core/query', {
-		name: 'course-list',
+		name: 'sensei-lms/course-list',
 		title: __( 'Course List', 'sensei-lms' ),
 		description: __( 'Show a list of courses.', 'sensei-lms' ),
 		icon: list,
@@ -34,17 +34,21 @@ export const registerCourseListBlock = () => {
 			__( 'List', 'sensei-lms' ),
 			__( 'Courses', 'sensei-lms' ),
 		],
-		attributes: { ...QUERY_DEFAULT_ATTRIBUTES },
+		attributes: { ...DEFAULT_ATTRIBUTES },
 		isActive: ( blockAttributes, variationAttributes ) => {
 			// Using className instead of postType because otherwise a normal Query Loop block
 			// will turn into a Course List block if the post type 'course' is selected. As we're planning
 			// to hide the Post Type dropdown for Course List block, so after changing the type to course,
 			// the Query loop user will not be able to change the post type again. We don't want that to
 			// happen.
-			return blockAttributes.className?.match(
-				variationAttributes.className
+			return (
+				blockAttributes.className?.match(
+					variationAttributes.className
+				) &&
+				blockAttributes.query.postType ===
+					variationAttributes.query.postType
 			);
 		},
-		scope: [ 'block', 'inserter' ],
+		scope: [ 'inserter' ],
 	} );
 };

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -1,0 +1,50 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockVariation } from '@wordpress/blocks';
+import { list } from '@wordpress/icons';
+
+export const registerCourseListBlock = () => {
+	const QUERY_DEFAULT_ATTRIBUTES = {
+		className: 'course-list-block',
+		query: {
+			perPage: 3,
+			pages: 0,
+			offset: 0,
+			postType: 'course',
+			order: 'desc',
+			orderBy: 'date',
+			author: '',
+			search: '',
+			exclude: [],
+			sticky: '',
+			inherit: false,
+		},
+	};
+
+	registerBlockVariation( 'core/query', {
+		name: 'course-list',
+		title: __( 'Course List', 'sensei-lms' ),
+		description: __( 'Show a list of courses.', 'sensei-lms' ),
+		icon: list,
+		category: 'sensei-lms',
+		keywords: [
+			__( 'Course', 'sensei-lms' ),
+			__( 'List', 'sensei-lms' ),
+			__( 'Courses', 'sensei-lms' ),
+		],
+		attributes: { ...QUERY_DEFAULT_ATTRIBUTES },
+		isActive: ( blockAttributes, variationAttributes ) => {
+			// Using className instead of postType because otherwise a normal Query Loop block
+			// will turn into a Course List block if the post type 'course' is selected. As we're planning
+			// to hide the Post Type dropdown for Course List block, so after changing the type to course,
+			// the Query loop user will not be able to change the post type again. We don't want that to
+			// happen.
+			return blockAttributes.className?.match(
+				variationAttributes.className
+			);
+		},
+		scope: [ 'block', 'inserter' ],
+	} );
+};

--- a/assets/blocks/shared.js
+++ b/assets/blocks/shared.js
@@ -10,6 +10,7 @@ import { subscribe, select } from '@wordpress/data';
 import registerSenseiBlocks from './register-sensei-blocks';
 import ContactTeacherBlock from './contact-teacher-block';
 import ConditionalContentBlock from './conditional-content-block';
+import { registerCourseListBlock } from './course-list-block';
 
 // Post types where blocks should be loaded. Or null if it should be loaded for any post type.
 const BLOCKS_PER_POST_TYPE = {
@@ -18,6 +19,8 @@ const BLOCKS_PER_POST_TYPE = {
 };
 
 registerSenseiBlocks( [ ContactTeacherBlock, ConditionalContentBlock ] );
+
+registerCourseListBlock();
 
 let postType = null;
 

--- a/assets/blocks/single-page.js
+++ b/assets/blocks/single-page.js
@@ -6,8 +6,12 @@ import CourseResultsBlock from './course-results-block';
 import LearnerCoursesBlock from './learner-courses-block';
 import LearnerMessagesButtonBlock from './learner-messages-button-block';
 import { registerCourseCompletedActionsBlock } from './course-completed-actions';
+import { registerCourseListBlock } from './course-list-block';
 
 registerCourseCompletedActionsBlock();
+
+registerCourseListBlock();
+
 registerSenseiBlocks( [
 	CourseResultsBlock,
 	LearnerCoursesBlock,

--- a/includes/block-patterns/class-sensei-block-patterns.php
+++ b/includes/block-patterns/class-sensei-block-patterns.php
@@ -39,6 +39,7 @@ class Sensei_Block_Patterns {
 	public function init() {
 		add_action( 'init', [ $this, 'maybe_register_pattern_block_polyfill' ], 99 );
 		add_action( 'init', [ $this, 'register_block_patterns_category' ] );
+		add_action( 'init', [ $this, 'register_course_list_block_pattern' ] );
 		add_action( 'current_screen', [ $this, 'register_block_patterns' ] );
 		add_action( 'enqueue_block_assets', [ $this, 'enqueue_scripts' ] );
 	}
@@ -61,6 +62,44 @@ class Sensei_Block_Patterns {
 		);
 	}
 
+	/**
+	 * Temporary pattern for course list block because default patterns changes the Post Type to 'post' instead of 'course'.
+	 *
+	 * @access private
+	 */
+	public function register_course_list_block_pattern() {
+		register_block_pattern(
+			'dummy-course-list-query',
+			[
+				'title'      => __( 'Grid of courses', 'sensei-lms' ),
+				'categories' => array( 'query' ),
+				'blockTypes' => array( 'core/query' ),
+				'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"layout":{"inherit":false}} -->
+						<div class="wp-block-query course-list-block"><!-- wp:post-template {"align":"wide"} -->
+						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
+
+						<!-- wp:post-title {"isLink":true,"fontSize":"x-large"} /-->
+
+						<!-- wp:post-excerpt /-->
+						<!-- wp:sensei-lms/course-progress {"defaultBarColor":"primary"} /-->
+						<!-- wp:post-date {"format":"F j, Y","isLink":true,"fontSize":"small"} /-->
+						<!-- /wp:post-template -->
+
+						<!-- wp:separator {"align":"wide","className":"is-style-wide"} -->
+						<hr class="wp-block-separator alignwide is-style-wide"/>
+						<!-- /wp:separator -->
+
+						<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+						<!-- wp:query-pagination-previous {"fontSize":"small"} /-->
+
+						<!-- wp:query-pagination-numbers /-->
+
+						<!-- wp:query-pagination-next {"fontSize":"small"} /-->
+						<!-- /wp:query-pagination --></div>
+						<!-- /wp:query -->',
+			]
+		);
+	}
 	/**
 	 * Register block patterns.
 	 *


### PR DESCRIPTION
Implements https://github.com/Automattic/sensei/issues/5413

### Changes proposed in this Pull Request

* Added a course list block in the inserter

We've also added a temporary pattern to be able to test this block because the existing patterns have their own defined post type, so once you select one of them, they override the post type from 'course' to 'post'.

### Testing instructions
- Create a few courses
- Go to pages and go to a new or existing page's block editor page
- Try to add a new block, in the block selector, search for course list block
- After adding the block, click on 'Choose' to select a pattern
- Find the grid pattern that is showing course in the preview list
- Click that pattern
- Make sure Course list is rendered
- Now save the page and reload
- Make sure from the block tree that the Course List block is still in there and is showing the courses

### Screenshot / Video

https://user-images.githubusercontent.com/6820724/183228780-af1a98e6-949e-44ef-96af-f5a7866729a0.mov

