### PR TITLE
Fix loading issue where the player wasn't detected correctly on the editor

### DIFF
--- a/assets/shared/helpers/player/use-editor-player.js
+++ b/assets/shared/helpers/player/use-editor-player.js
@@ -24,9 +24,16 @@ const VIMEO_API_SRC = 'https://player.vimeo.com/api/player.js';
  */
 const useTriggerDependencies = ( videoBlock ) => {
 	// Check embed fetching.
-	const { fetching } = useSelect(
+	const { fetching, preview } = useSelect(
 		( select ) => ( {
 			fetching: select( coreStore ).isRequestingEmbedPreview(
+				videoBlock?.attributes?.url
+			),
+			// Sometimes, WordPress can load the data from the Embed API so quickly, that fetching stays false, but
+			// the resource is just instantaneously loaded.
+			// Getting the embed preview from the store guarantees that we can check if the resource was loaded or not,
+			// and then trigger the proper effect.
+			preview: select( coreStore ).getEmbedPreview(
 				videoBlock?.attributes?.url
 			),
 		} ),
@@ -51,7 +58,7 @@ const useTriggerDependencies = ( videoBlock ) => {
 		[ videoBlock?.clientId ]
 	);
 
-	return { fetching, isBlockSelected, lastBlockAttributeChange };
+	return { fetching, preview, isBlockSelected, lastBlockAttributeChange };
 };
 
 /**
@@ -134,6 +141,7 @@ const useEditorPlayer = ( videoBlock ) => {
 
 	const {
 		fetching,
+		preview,
 		isBlockSelected,
 		lastBlockAttributeChange,
 	} = useTriggerDependencies( videoBlock );
@@ -188,7 +196,7 @@ const useEditorPlayer = ( videoBlock ) => {
 				break;
 			}
 		}
-	}, [ fetching, isBlockSelected, lastBlockAttributeChange ] );
+	}, [ fetching, preview, isBlockSelected, lastBlockAttributeChange ] );
 
 	return player;
 };


### PR DESCRIPTION
Thanks to some issue related to asynchronous loading, the fetching field not changing, and Firefox being just a little slower than Chrome, apparently.

### Changes proposed in this Pull Request

* Add the value from `getEmbedPreview` as a dependency to trigger the set-up for the player;

### Testing instructions

This is a tough one to test, because it's not exactly easy to reproduce. But let's try to document:

1. Install Sensei Pro using the feature branch (or some branch containing that feature branch) from this project: p6rkRX-3PI-p2
2. Create a course, and then a lesson;
3. Add 4 of the blocks created on that project to the lesson, each completely configured (with URL and/or file). YouTube must be the last block;
4. Add a few break points to each block;
5. Save the post;
6. On Firefox, try to refresh the page of the lesson editor a few times; 
7. Verify that all the break points are correctly loaded and visible;
