### PR TITLE
Add Course Actions block

### DIFF
--- a/assets/blocks/course-actions-block/continue-course/index.js
+++ b/assets/blocks/course-actions-block/continue-course/index.js
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import { BlockStyles, createButtonBlockType } from '../../button';
+
+/**
+ * Continue Course block.
+ */
+export default createButtonBlockType( {
+	tagName: 'a',
+	settings: {
+		name: 'sensei-lms/button-continue-course',
+		parent: [ 'sensei-lms/course-actions' ],
+		title: __( 'Continue Course', 'sensei-lms' ),
+		description: __(
+			'Enable a student to pick up where they left off in a course.',
+			'sensei-lms'
+		),
+		keywords: [
+			__( 'Button', 'sensei-lms' ),
+			__( 'Continue', 'sensei-lms' ),
+			__( 'Course', 'sensei-lms' ),
+		],
+		attributes: {
+			text: {
+				default: __( 'Continue', 'sensei-lms' ),
+			},
+		},
+		styles: [
+			{ ...BlockStyles.Fill, isDefault: true },
+			BlockStyles.Outline,
+			BlockStyles.Link,
+		],
+	},
+} );

--- a/assets/blocks/course-actions-block/course-actions/block.json
+++ b/assets/blocks/course-actions-block/course-actions/block.json
@@ -1,0 +1,7 @@
+{
+	"name": "sensei-lms/course-actions",
+	"category": "sensei-lms",
+	"supports": {
+		"html": false
+	}
+}

--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { InnerBlocks } from '@wordpress/block-editor';
+
+const innerBlocksTemplate = [
+	[
+		'sensei-lms/button-take-course',
+		{ text: __( 'Start Course', 'sensei-lms' ) },
+	],
+	[ 'sensei-lms/button-continue-course' ],
+	[
+		'sensei-lms/button-view-results',
+		{
+			className: 'is-style-default',
+			text: __( 'Visit Results', 'sensei-lms' ),
+		},
+	],
+];
+
+/**
+ * Edit course actions block component.
+ *
+ * @param {Object} props
+ * @param {Object} props.className Block className.
+ */
+const CourseActionsEdit = ( { className } ) => (
+	<div className={ className }>
+		<InnerBlocks
+			allowedBlocks={ [
+				'sensei-lms/button-take-course',
+				'sensei-lms/button-continue-course',
+				'sensei-lms/button-view-results',
+			] }
+			template={ innerBlocksTemplate }
+			templateLock="all"
+		/>
+	</div>
+);
+
+export default CourseActionsEdit;

--- a/assets/blocks/course-actions-block/course-actions/course-actions-editor.scss
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-editor.scss
@@ -1,0 +1,6 @@
+.wp-block-sensei-lms-course-actions {
+	.wp-block-sensei-lms-button-continue-course,
+	.wp-block-sensei-lms-button-view-results {
+		display: none;
+	}
+}

--- a/assets/blocks/course-actions-block/course-actions/course-actions-save.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-save.js
@@ -1,0 +1,8 @@
+/**
+ * WordPress dependencies
+ */
+import { InnerBlocks } from '@wordpress/block-editor';
+
+export default function saveCourseActionsBlock() {
+	return <InnerBlocks.Content />;
+}

--- a/assets/blocks/course-actions-block/course-actions/index.js
+++ b/assets/blocks/course-actions-block/course-actions/index.js
@@ -1,0 +1,42 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/**
+ * Internal dependencies
+ */
+import metadata from './block.json';
+import edit from './course-actions-edit';
+import save from './course-actions-save';
+import icon from '../../../icons/buttons.svg';
+
+export default {
+	title: __( 'Course Actions', 'sensei-lms' ),
+	description: __(
+		'Enable a student to perform specific actions for a course.',
+		'sensei-lms'
+	),
+	keywords: [
+		__( 'Course', 'sensei-lms' ),
+		__( 'Actions', 'sensei-lms' ),
+		__( 'Buttons', 'sensei-lms' ),
+		__( 'Start Course', 'sensei-lms' ),
+		__( 'Continue', 'sensei-lms' ),
+		__( 'Visit Results', 'sensei-lms' ),
+	],
+	example: {
+		innerBlocks: [
+			{
+				name: 'sensei-lms/button-take-course',
+				attributes: {
+					text: __( 'Start Course', 'sensei-lms' ),
+				},
+			},
+		],
+	},
+	...metadata,
+	icon,
+	edit,
+	save,
+};

--- a/assets/blocks/course-actions-block/index.js
+++ b/assets/blocks/course-actions-block/index.js
@@ -1,0 +1,5 @@
+/**
+ * Internal dependencies
+ */
+export { default as ContinueCourse } from './continue-course';
+export { default as CourseActions } from './course-actions';

--- a/assets/blocks/single-page-style-editor.scss
+++ b/assets/blocks/single-page-style-editor.scss
@@ -1,1 +1,2 @@
+@import './course-actions-block/course-actions/course-actions-editor';
 @import './learner-courses-block/learner-courses-editor';

--- a/assets/blocks/single-page.js
+++ b/assets/blocks/single-page.js
@@ -3,9 +3,12 @@
  */
 import registerSenseiBlocks from './register-sensei-blocks';
 import CourseProgressBlock from './course-progress-block';
+import { ContinueCourse, CourseActions } from './course-actions-block';
 import CourseResultsBlock from './course-results-block';
 import LearnerCoursesBlock from './learner-courses-block';
 import LearnerMessagesButtonBlock from './learner-messages-button-block';
+import TakeCourseBlock from './take-course-block';
+import ViewResultsBlock from './view-results-block';
 import { registerCourseCompletedActionsBlock } from './course-completed-actions';
 import { registerCourseListBlock } from './course-list-block';
 
@@ -14,8 +17,12 @@ registerCourseCompletedActionsBlock();
 registerCourseListBlock();
 
 registerSenseiBlocks( [
+	ContinueCourse,
+	CourseActions,
 	CourseProgressBlock,
 	CourseResultsBlock,
 	LearnerCoursesBlock,
 	LearnerMessagesButtonBlock,
+	TakeCourseBlock,
+	ViewResultsBlock,
 ] );

--- a/includes/blocks/class-sensei-block-view-results.php
+++ b/includes/blocks/class-sensei-block-view-results.php
@@ -44,20 +44,22 @@ class Sensei_Block_View_Results {
 	 * @return string The HTML of the block.
 	 */
 	public function render( $attributes, $content ): string {
+		$course_id = get_the_ID();
+
 		/**
-		 * Whether render the view results block.
+		 * Whether to render the View Results block.
 		 *
 		 * @since 3.13.3
 		 *
-		 * @param {boolean} $render     Whether render the view results block.
+		 * @param {boolean} $render     Whether to render the View Results block.
 		 * @param {array}   $attributes Block attributes.
 		 * @param {string}  $content    Block HTML.
 		 *
-		 * @return {boolean} Whether render the view results block.
+		 * @return {boolean} Whether to render the View Results block.
 		 */
 		$render = apply_filters(
 			'sensei_render_view_results_block',
-			Sensei()->course::is_user_enrolled( get_the_ID() ),
+			Sensei_Utils::user_completed_course( $course_id, get_current_user_id() ),
 			$attributes,
 			$content
 		);
@@ -68,7 +70,7 @@ class Sensei_Block_View_Results {
 
 		return preg_replace(
 			'/<a(.*)>/',
-			'<a href="' . esc_url( Sensei_Course::get_view_results_link( get_the_ID() ) ) . '" $1>',
+			'<a href="' . esc_url( Sensei_Course::get_view_results_link( $course_id ) ) . '" $1>',
 			$content,
 			1
 		);

--- a/includes/blocks/class-sensei-continue-course-block.php
+++ b/includes/blocks/class-sensei-continue-course-block.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * File containing the Sensei_Continue_Course_Block class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Continue_Course_Block
+ */
+class Sensei_Continue_Course_Block {
+
+	/**
+	 * Sensei_Continue_Course_Block constructor.
+	 */
+	public function __construct() {
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/button-continue-course',
+			[
+				'render_callback' => [ $this, 'render' ],
+			]
+		);
+	}
+
+	/**
+	 * Renders the `sensei-lms/button-continue-course` block on the server.
+	 *
+	 * @param array    $attributes Block attributes.
+	 * @param string   $content    Block default content.
+	 *
+	 * @access private
+	 *
+	 * @return string Returns a Continue button that links to the course page.
+	 */
+	public function render( array $attributes, string $content ) : string {
+		$course_id = get_the_ID();
+		$user_id = get_current_user_id();
+
+		/**
+		 * Whether to render the Continue Course block.
+		 *
+		 * @since x.x.x
+		 *
+		 * @param {boolean} $render     Whether to render the Continue Course block.
+		 * @param {array}   $attributes Block attributes.
+		 * @param {string}  $content    Block content.
+		 *
+		 * @return {boolean} Whether to render the Continue Course block.
+		 */
+		$render = apply_filters(
+			'sensei_render_continue_course_block',
+			Sensei()->course::is_user_enrolled( $course_id, $user_id ) && ! Sensei_Utils::user_completed_course( $course_id, $user_id ),
+			$attributes,
+			$content
+		);
+
+		if ( ! $render ) {
+			return '';
+		}
+
+		return preg_replace(
+			'/<a(.*)>/',
+			'<a href="' . esc_url( get_permalink( absint( $course_id ) ) ) . '" $1>',
+			$content,
+			1
+		);
+	}
+}

--- a/includes/blocks/class-sensei-continue-course-block.php
+++ b/includes/blocks/class-sensei-continue-course-block.php
@@ -29,8 +29,8 @@ class Sensei_Continue_Course_Block {
 	/**
 	 * Renders the `sensei-lms/button-continue-course` block on the server.
 	 *
-	 * @param array    $attributes Block attributes.
-	 * @param string   $content    Block default content.
+	 * @param array  $attributes Block attributes.
+	 * @param string $content    Block default content.
 	 *
 	 * @access private
 	 *
@@ -38,7 +38,7 @@ class Sensei_Continue_Course_Block {
 	 */
 	public function render( array $attributes, string $content ) : string {
 		$course_id = get_the_ID();
-		$user_id = get_current_user_id();
+		$user_id   = get_current_user_id();
 
 		/**
 		 * Whether to render the Continue Course block.

--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -46,6 +46,10 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 			'sensei-single-page-blocks-style',
 			'blocks/single-page-style.css'
 		);
+		Sensei()->assets->enqueue(
+			'sensei-shared-blocks-style',
+			'blocks/shared-style.css'
+		);
 	}
 
 	/**

--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -24,11 +24,14 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	 * Initialize blocks that are used in page post types.
 	 */
 	public function initialize_blocks() {
-		new Sensei_Learner_Courses_Block();
-		new Sensei_Learner_Messages_Button_Block();
+		new Sensei_Block_Take_Course();
+		new Sensei_Block_View_Results();
+		new Sensei_Continue_Course_Block();
 		new Sensei_Course_Completed_Actions_Block();
 		new Sensei_Course_Progress_Block();
 		new Sensei_Course_Results_Block();
+		new Sensei_Learner_Courses_Block();
+		new Sensei_Learner_Messages_Button_Block();
 	}
 
 	/**

--- a/tests/unit-tests/blocks/test-class-sensei-block-view-results.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-view-results.php
@@ -1,0 +1,92 @@
+<?php
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
+
+/**
+ * Tests for Sensei_Block_View_Results class.
+ */
+class Sensei_Block_View_Results_Test extends WP_UnitTestCase {
+
+	use Sensei_Course_Enrolment_Test_Helpers;
+	use Sensei_Course_Enrolment_Manual_Test_Helpers;
+	use Sensei_Test_Login_Helpers;
+
+	/**
+	 * View Results block.
+	 *
+	 * @var Sensei_Block_View_Results
+	 */
+	private $block;
+
+	/**
+	 * Block content.
+	 */
+	const CONTENT = '<!-- wp:sensei-lms/button-view-results -->
+<div class="wp-block-sensei-lms-button-view-results is-style-outline wp-block-sensei-button wp-block-button has-text-align-left"><a class="wp-block-button__link">View Results</a></div>
+<!-- /wp:sensei-lms/button-view-results -->';
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp() {
+		parent::setUp();
+		self::resetEnrolmentProviders();
+		$this->prepareEnrolmentManager();
+
+		$this->factory   = new Sensei_Factory();
+		$this->block     = new Sensei_Block_View_Results();
+		$this->course    = $this->factory->course->create_and_get( [ 'post_name' => 'view-results-block' ] );
+
+		$GLOBALS['post'] = $this->course;
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/button-view-results' );
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+		self::resetEnrolmentProviders();
+	}
+
+	/**
+	 * Doesn't render the block if the student has not completed the course.
+	 *
+	 * @covers Sensei_Block_View_Results::render
+	 */
+	public function testRender_CourseNotCompleted_ReturnsEmptyString() {
+		$user_id = $this->factory->user->create();
+		$this->manuallyEnrolStudentInCourse( $user_id, $this->course->ID );
+		$this->login_as( $user_id );
+
+		$result = $this->block->render( [], self::CONTENT );
+
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Renders the block and links to the Course Completed page if the student has completed the course.
+	 *
+	 * @covers Sensei_Block_View_Results::render
+	 */
+	public function testRender_CourseCompleted_ReturnsModifiedBlockContent() {
+		// Student.
+		$user_id = $this->factory->user->create();
+		$this->manuallyEnrolStudentInCourse( $user_id, $this->course->ID );
+		Sensei_Utils::update_course_status( $user_id, $this->course->ID, 'complete' );
+		$this->login_as( $user_id );
+
+		// Course Completed page.
+		$page_id = $this->factory->post->create(
+			[
+				'post_type'  => 'page',
+				'post_title' => 'Course Completed',
+			]
+		);
+		Sensei()->settings->set( 'course_completed_page', $page_id );
+
+		$result = $this->block->render( [], self::CONTENT );
+
+		$this->assertRegExp( "|<a href=\"http://example.org/\?page_id={$page_id}&#038;course_id={$this->course->ID}\".*>View Results</a>|", $result );
+	}
+}

--- a/tests/unit-tests/blocks/test-class-sensei-block-view-results.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-view-results.php
@@ -32,9 +32,9 @@ class Sensei_Block_View_Results_Test extends WP_UnitTestCase {
 		self::resetEnrolmentProviders();
 		$this->prepareEnrolmentManager();
 
-		$this->factory   = new Sensei_Factory();
-		$this->block     = new Sensei_Block_View_Results();
-		$this->course    = $this->factory->course->create_and_get( [ 'post_name' => 'view-results-block' ] );
+		$this->factory = new Sensei_Factory();
+		$this->block   = new Sensei_Block_View_Results();
+		$this->course  = $this->factory->course->create_and_get( [ 'post_name' => 'view-results-block' ] );
 
 		$GLOBALS['post'] = $this->course;
 	}

--- a/tests/unit-tests/blocks/test-class-sensei-continue-course-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-continue-course-block.php
@@ -32,9 +32,9 @@ class Sensei_Continue_Course_Block_Test extends WP_UnitTestCase {
 		self::resetEnrolmentProviders();
 		$this->prepareEnrolmentManager();
 
-		$this->factory   = new Sensei_Factory();
-		$this->block     = new Sensei_Continue_Course_Block();
-		$this->course    = $this->factory->course->create_and_get( [ 'post_name' => 'continue-course-block' ] );
+		$this->factory = new Sensei_Factory();
+		$this->block   = new Sensei_Continue_Course_Block();
+		$this->course  = $this->factory->course->create_and_get( [ 'post_name' => 'continue-course-block' ] );
 
 		$GLOBALS['post'] = $this->course;
 	}

--- a/tests/unit-tests/blocks/test-class-sensei-continue-course-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-continue-course-block.php
@@ -1,0 +1,95 @@
+<?php
+require_once SENSEI_TEST_FRAMEWORK_DIR . '/trait-sensei-course-enrolment-test-helpers.php';
+
+/**
+ * Tests for Sensei_Continue_Course_Block class.
+ */
+class Sensei_Continue_Course_Block_Test extends WP_UnitTestCase {
+
+	use Sensei_Course_Enrolment_Test_Helpers;
+	use Sensei_Course_Enrolment_Manual_Test_Helpers;
+	use Sensei_Test_Login_Helpers;
+
+	/**
+	 * Continue Course block.
+	 *
+	 * @var Sensei_Continue_Course_Block
+	 */
+	private $block;
+
+	/**
+	 * Block content.
+	 */
+	const CONTENT = '<!-- wp:sensei-lms/button-continue-course -->
+<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-left"><a class="wp-block-button__link">Continue</a></div>
+<!-- /wp:sensei-lms/button-continue-course -->';
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp() {
+		parent::setUp();
+		self::resetEnrolmentProviders();
+		$this->prepareEnrolmentManager();
+
+		$this->factory   = new Sensei_Factory();
+		$this->block     = new Sensei_Continue_Course_Block();
+		$this->course    = $this->factory->course->create_and_get( [ 'post_name' => 'continue-course-block' ] );
+
+		$GLOBALS['post'] = $this->course;
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/button-continue-course' );
+	}
+
+	public static function tearDownAfterClass() {
+		parent::tearDownAfterClass();
+		self::resetEnrolmentProviders();
+	}
+
+	/**
+	 * Doesn't render the block if the student is not enrolled in the course.
+	 *
+	 * @covers Sensei_Continue_Course_Block::render
+	 */
+	public function testRender_NotEnrolled_ReturnsEmptyString() {
+		$this->login_as_student();
+
+		$result = $this->block->render( [], self::CONTENT );
+
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Doesn't render the block if the student is enrolled and has already completed the course.
+	 *
+	 * @covers Sensei_Continue_Course_Block::render
+	 */
+	public function testRender_EnrolledAndCourseCompleted_ReturnsEmptyString() {
+		$user_id = $this->factory->user->create();
+		$this->manuallyEnrolStudentInCourse( $user_id, $this->course->ID );
+		Sensei_Utils::update_course_status( $user_id, $this->course->ID, 'complete' );
+		$this->login_as( $user_id );
+
+		$result = $this->block->render( [], self::CONTENT );
+
+		$this->assertEmpty( $result );
+	}
+
+	/**
+	 * Renders the block and links to the course page if the student is enrolled but has not completed the course.
+	 *
+	 * @covers Sensei_Continue_Course_Block::render
+	 */
+	public function testRender_EnrolledAndCourseNotCompleted_ReturnsModifiedBlockContent() {
+		$user_id = $this->factory->user->create();
+		$this->manuallyEnrolStudentInCourse( $user_id, $this->course->ID );
+		$this->login_as( $user_id );
+
+		$result = $this->block->render( [], self::CONTENT );
+
+		$this->assertRegExp( '|<a href="http://example.org/\?course=continue-course-block".*>Continue</a>|', $result );
+	}
+}


### PR DESCRIPTION
Implements #5396 

### Changes proposed in this Pull Request

* Adds new Continue Course and Course Actions blocks for pages.
* The Course Actions block nests the Course Signup, Continue Course and View Results blocks as inner blocks.
* Only the _Start Course_ button is visible in the editor.
* Fixes the visibility of the View Results button such that it's only visible if the student has completed the course. (It doesn't make sense to enable navigating to the course completed page if they haven't completed the course.)

### Testing instructions
- Add a Course List block to a page and set its Post Type setting to "Course".
- Add the Course Actions block inside it.
- Confirm that the _Start Course_ button is visible for each course.
- Publish the page and view it.
- For a new course that you are not enrolled in, ensure the _Start Course_ button is visible. Clicking it should enrol you in the course and take you to the course page.
- For a course that you are enrolled in but have not completed, ensure the _Continue_ button is visible. Clicking it should go to the course page.
- For a course that you have completed, ensure the _Visit Results_ button is visible. Clicking it should go to the Course Completed Page as defined in Sensei's settings.

### Screenshot / Video
![Screen Shot 2022-08-09 at 1 43 32 PM](https://user-images.githubusercontent.com/1190420/183723204-08181b23-ca43-4109-9843-b49145e1f3b4.jpg)

