### PR TITLE
Fix interactive video when no video is set

### DIFF
--- a/assets/shared/helpers/player/use-editor-player.js
+++ b/assets/shared/helpers/player/use-editor-player.js
@@ -159,7 +159,9 @@ const useEditorPlayer = ( videoBlock ) => {
 				`#block-${ videoBlock.clientId } video`
 			);
 
-			setPlayer( new Player( video ) );
+			if ( video ) {
+				setPlayer( new Player( video ) );
+			}
 
 			return;
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* We have a check that avoids setting the player if the iframe is not ready for embeds, but we didn't have the same check for the video. So if we added an Interactive Video block of the type video, we would see an error before selecting a video.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Open the editor.
* Add an Interactive Video block of the type video.
* Make sure no errors are logged in your browser console.