### PR TITLE
Enable Course Progress block on pages

### DIFF
--- a/assets/blocks/single-page.js
+++ b/assets/blocks/single-page.js
@@ -2,6 +2,7 @@
  * Internal dependencies
  */
 import registerSenseiBlocks from './register-sensei-blocks';
+import CourseProgressBlock from './course-progress-block';
 import CourseResultsBlock from './course-results-block';
 import LearnerCoursesBlock from './learner-courses-block';
 import LearnerMessagesButtonBlock from './learner-messages-button-block';
@@ -13,6 +14,7 @@ registerCourseCompletedActionsBlock();
 registerCourseListBlock();
 
 registerSenseiBlocks( [
+	CourseProgressBlock,
 	CourseResultsBlock,
 	LearnerCoursesBlock,
 	LearnerMessagesButtonBlock,

--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -27,6 +27,7 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 		new Sensei_Learner_Courses_Block();
 		new Sensei_Learner_Messages_Button_Block();
 		new Sensei_Course_Completed_Actions_Block();
+		new Sensei_Course_Progress_Block();
 		new Sensei_Course_Results_Block();
 	}
 


### PR DESCRIPTION
Fixes #5403.

### Changes proposed in this Pull Request

Makes the Course Progress block available in the block inserter for pages.

**Note:** Ultimately, we won't want the Course Progress bar to be available in the block inserter since it won't make sense to use it outside the context of the Query Loop / Course List block. See https://a8c.slack.com/archives/C02NWDZBL0H/p1660136008867649 for some discussion.

### Testing instructions
- Add a Course List block to a page and set its Post Type setting to "Course".
- Add the Course Progress block inside it.
- Confirm that the progress bar is visible for each course.
- Update the block's settings to ensure they work.
- Publish the page and view it.
- Ensure the progress bar is styled correctly.
- Ensure the progress bar shows the correct number of completed lessons for courses that you are enrolled in.
- Ensure the progress bar is not visible for courses that you are not enrolled in.

### Screenshot / Video
![Screen Shot 2022-08-10 at 12 03 59 PM](https://user-images.githubusercontent.com/1190420/183958218-17d44274-37c6-4790-995a-7e3ff40ec474.jpg)