### PR TITLE
Hide query inherit and post type from course list block settings

### DIFF
--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -70,11 +70,8 @@ const observeAndRemoveSettingsFromPanel = ( blockSettingsPanel ) => {
 	const observer = new MutationObserver( () => {
 		const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
 		if (
-			selectedBlock &&
-			'core/query' === selectedBlock.name &&
-			selectedBlock.attributes &&
-			selectedBlock.attributes.className &&
-			'course-list-block' === selectedBlock.attributes.className
+			'core/query' === selectedBlock?.name &&
+			'course-list-block' === selectedBlock?.attributes?.className
 		) {
 			hideUnnecessarySettingsForCourseList();
 		}

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -54,18 +54,38 @@ export const registerCourseListBlock = () => {
 	} );
 };
 
-subscribe( () => {
-	const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
-	if (
-		selectedBlock &&
-		'core/query' === selectedBlock.name &&
-		selectedBlock.attributes &&
-		selectedBlock.attributes.className &&
-		'course-list-block' === selectedBlock.attributes.className
-	) {
-		hideUnnecessarySettingsForCourseList();
+const unsubscribe = subscribe( () => {
+	const blockSettingsPanel = document.querySelector(
+		'.interface-interface-skeleton__sidebar'
+	);
+	if ( ! blockSettingsPanel ) {
+		return;
 	}
+	observeAndRemoveSettingsFromPanel( blockSettingsPanel );
+	unsubscribe();
 } );
+
+const observeAndRemoveSettingsFromPanel = ( blockSettingsPanel ) => {
+	// eslint-disable-next-line no-undef
+	const observer = new MutationObserver( () => {
+		const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
+		if (
+			selectedBlock &&
+			'core/query' === selectedBlock.name &&
+			selectedBlock.attributes &&
+			selectedBlock.attributes.className &&
+			'course-list-block' === selectedBlock.attributes.className
+		) {
+			hideUnnecessarySettingsForCourseList();
+		}
+	} );
+
+	// configuration for settings panel observer.
+	const config = { childList: true, subtree: true };
+
+	// pass in the settings panel node, as well as the options.
+	observer.observe( blockSettingsPanel, config );
+};
 
 // Hide the settings which are inherited from the Query Loop block
 // but not applicable to our Course List block.

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -70,33 +70,31 @@ subscribe( () => {
 // Hide the settings which are inherited from the Query Loop block
 // but not applicable to our Course List block.
 const hideUnnecessarySettingsForCourseList = () => {
-	setTimeout( () => {
-		const postTypeContainerQuery = '.components-input-control__label',
-			inheritContextContainerQuery = '.components-toggle-control__label';
+	const postTypeContainerQuery = '.components-input-control__label',
+		inheritContextContainerQuery = '.components-toggle-control__label';
 
-		const toBeHiddenSettingContainers = document.querySelectorAll(
-			`${ postTypeContainerQuery },${ inheritContextContainerQuery }`
-		);
+	const toBeHiddenSettingContainers = document.querySelectorAll(
+		`${ postTypeContainerQuery },${ inheritContextContainerQuery }`
+	);
 
+	if (
+		! toBeHiddenSettingContainers ||
+		0 === toBeHiddenSettingContainers.length
+	) {
+		return;
+	}
+
+	Array.from( toBeHiddenSettingContainers ).forEach( ( element ) => {
 		if (
-			! toBeHiddenSettingContainers ||
-			0 === toBeHiddenSettingContainers.length
+			[
+				/* eslint-disable-next-line @wordpress/i18n-text-domain */
+				__( 'Post type' ),
+				/* eslint-disable-next-line @wordpress/i18n-text-domain */
+				__( 'Inherit query from template' ),
+			].includes( element.textContent )
 		) {
-			return;
+			element.closest( '.components-base-control' ).style.display =
+				'none';
 		}
-
-		Array.from( toBeHiddenSettingContainers ).forEach( ( element ) => {
-			if (
-				[
-					/* eslint-disable-next-line @wordpress/i18n-text-domain */
-					__( 'Post type' ),
-					/* eslint-disable-next-line @wordpress/i18n-text-domain */
-					__( 'Inherit query from template' ),
-				].includes( element.textContent )
-			) {
-				element.closest( '.components-base-control' ).style.display =
-					'none';
-			}
-		} );
-	}, 0 );
+	} );
 };

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockVariation } from '@wordpress/blocks';
 import { list } from '@wordpress/icons';
+import { addFilter } from '@wordpress/hooks';
 
 export const registerCourseListBlock = () => {
 	const DEFAULT_ATTRIBUTES = {
@@ -52,3 +53,44 @@ export const registerCourseListBlock = () => {
 		scope: [ 'inserter' ],
 	} );
 };
+
+// Hide the settings which are inherited from the Query Loop block
+// but not applicable to our Course List block.
+const withUnnecessarySettingsHidden = ( BlockEdit ) => {
+	return ( props ) => {
+		if (
+			'core/query' === props.name &&
+			props.isSelected &&
+			props.attributes &&
+			props.attributes.className &&
+			'course-list-block' === props.attributes.className
+		) {
+			setTimeout( () => {
+				const postTypeContainerQuery =
+					'.components-input-control__label:contains(' +
+					/* eslint-disable-next-line @wordpress/i18n-text-domain */
+					__( 'Post type' ) +
+					')';
+				const inheritContextContainerQuery =
+					'.components-toggle-control__label:contains(' +
+					/* eslint-disable-next-line @wordpress/i18n-text-domain */
+					__( 'Inherit query from template' ) +
+					')';
+
+				// eslint-disable-next-line no-undef
+				const toBeHiddenSettingContainers = jQuery(
+					`${ postTypeContainerQuery },${ inheritContextContainerQuery }`
+				).parents( '.components-base-control' );
+
+				toBeHiddenSettingContainers.hide();
+			}, 0 );
+		}
+		return <BlockEdit { ...props } />;
+	};
+};
+
+addFilter(
+	'editor.BlockEdit',
+	'sensei-lms/course-list-block',
+	withUnnecessarySettingsHidden
+);

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -67,22 +67,29 @@ const withUnnecessarySettingsHidden = ( BlockEdit ) => {
 		) {
 			setTimeout( () => {
 				const postTypeContainerQuery =
-					'.components-input-control__label:contains(' +
-					/* eslint-disable-next-line @wordpress/i18n-text-domain */
-					__( 'Post type' ) +
-					')';
-				const inheritContextContainerQuery =
-					'.components-toggle-control__label:contains(' +
-					/* eslint-disable-next-line @wordpress/i18n-text-domain */
-					__( 'Inherit query from template' ) +
-					')';
+						'.components-input-control__label',
+					inheritContextContainerQuery =
+						'.components-toggle-control__label';
 
-				// eslint-disable-next-line no-undef
-				const toBeHiddenSettingContainers = jQuery(
+				const toBeHiddenSettingContainers = document.querySelectorAll(
 					`${ postTypeContainerQuery },${ inheritContextContainerQuery }`
-				).parents( '.components-base-control' );
-
-				toBeHiddenSettingContainers.hide();
+				);
+				Array.from( toBeHiddenSettingContainers ).forEach(
+					( element ) => {
+						if (
+							[
+								/* eslint-disable-next-line @wordpress/i18n-text-domain */
+								__( 'Post type' ),
+								/* eslint-disable-next-line @wordpress/i18n-text-domain */
+								__( 'Inherit query from template' ),
+							].includes( element.textContent )
+						) {
+							element.closest(
+								'.components-base-control'
+							).style.display = 'none';
+						}
+					}
+				);
 			}, 0 );
 		}
 		return <BlockEdit { ...props } />;

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockVariation } from '@wordpress/blocks';
 import { list } from '@wordpress/icons';
-import { addFilter } from '@wordpress/hooks';
+import { select, subscribe } from '@wordpress/data';
 
 export const registerCourseListBlock = () => {
 	const DEFAULT_ATTRIBUTES = {
@@ -54,50 +54,49 @@ export const registerCourseListBlock = () => {
 	} );
 };
 
+subscribe( () => {
+	const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
+	if (
+		selectedBlock &&
+		'core/query' === selectedBlock.name &&
+		selectedBlock.attributes &&
+		selectedBlock.attributes.className &&
+		'course-list-block' === selectedBlock.attributes.className
+	) {
+		hideUnnecessarySettingsForCourseList();
+	}
+} );
+
 // Hide the settings which are inherited from the Query Loop block
 // but not applicable to our Course List block.
-const withUnnecessarySettingsHidden = ( BlockEdit ) => {
-	return ( props ) => {
+const hideUnnecessarySettingsForCourseList = () => {
+	setTimeout( () => {
+		const postTypeContainerQuery = '.components-input-control__label',
+			inheritContextContainerQuery = '.components-toggle-control__label';
+
+		const toBeHiddenSettingContainers = document.querySelectorAll(
+			`${ postTypeContainerQuery },${ inheritContextContainerQuery }`
+		);
+
 		if (
-			'core/query' === props.name &&
-			props.isSelected &&
-			props.attributes &&
-			props.attributes.className &&
-			'course-list-block' === props.attributes.className
+			! toBeHiddenSettingContainers ||
+			0 === toBeHiddenSettingContainers.length
 		) {
-			setTimeout( () => {
-				const postTypeContainerQuery =
-						'.components-input-control__label',
-					inheritContextContainerQuery =
-						'.components-toggle-control__label';
-
-				const toBeHiddenSettingContainers = document.querySelectorAll(
-					`${ postTypeContainerQuery },${ inheritContextContainerQuery }`
-				);
-				Array.from( toBeHiddenSettingContainers ).forEach(
-					( element ) => {
-						if (
-							[
-								/* eslint-disable-next-line @wordpress/i18n-text-domain */
-								__( 'Post type' ),
-								/* eslint-disable-next-line @wordpress/i18n-text-domain */
-								__( 'Inherit query from template' ),
-							].includes( element.textContent )
-						) {
-							element.closest(
-								'.components-base-control'
-							).style.display = 'none';
-						}
-					}
-				);
-			}, 0 );
+			return;
 		}
-		return <BlockEdit { ...props } />;
-	};
-};
 
-addFilter(
-	'editor.BlockEdit',
-	'sensei-lms/course-list-block',
-	withUnnecessarySettingsHidden
-);
+		Array.from( toBeHiddenSettingContainers ).forEach( ( element ) => {
+			if (
+				[
+					/* eslint-disable-next-line @wordpress/i18n-text-domain */
+					__( 'Post type' ),
+					/* eslint-disable-next-line @wordpress/i18n-text-domain */
+					__( 'Inherit query from template' ),
+				].includes( element.textContent )
+			) {
+				element.closest( '.components-base-control' ).style.display =
+					'none';
+			}
+		} );
+	}, 0 );
+};


### PR DESCRIPTION
Resolves https://github.com/Automattic/sensei/issues/5415

### Changes proposed in this Pull Request

* Our **Course List** block, being a variation of **Query Loop** block was showing all the Settings of the main block. That includes a couple of settings changing which breaks the functionality of our block. So we've hidden the the "Inherit query from template" and "Post type" settings in this PR.

The solution is a bit hackish here, but GB team is working on making the settings configurable. So this is temporary and we will be able to do it the proper way later.

### Testing instructions

- Add the Course List block in the GB editor
- Select a Course List pattern
- Make sure the Course List block is selected
- Make sure the settings panel on the right does not show Post type and Query Inherit configurations mentioned above
- Add a normal Query Loop block in the GB editor
- Make sure all the configs are available in the settings
- Save the editor and check these behaviors again

### Screenshot / Video

https://user-images.githubusercontent.com/6820724/184234374-eb1c40e2-0f25-4543-9f31-bb42085f23c9.mov