### PR TITLE
Fix timeupdate event on the youtube adapter

### DIFF
--- a/assets/shared/helpers/player/youtube-adapter.js
+++ b/assets/shared/helpers/player/youtube-adapter.js
@@ -122,11 +122,6 @@ export const pause = ( player ) =>
 	} );
 
 /**
- * Variable that saves the last current time.
- */
-let lastCurrentTime;
-
-/**
  * Add an timeupdate event listener to the player.
  *
  * @param {Object}   player   The YouTube player instance.
@@ -137,11 +132,12 @@ let lastCurrentTime;
  */
 export const onTimeupdate = ( player, callback, w = window ) => {
 	const timer = 250;
+	let previousCurrentTime;
 
 	const updateCurrentTime = ( currentTime ) => {
-		if ( lastCurrentTime !== currentTime ) {
+		if ( previousCurrentTime !== currentTime ) {
 			callback( currentTime );
-			lastCurrentTime = currentTime;
+			previousCurrentTime = currentTime;
 		}
 	};
 


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes an issue with the timeupdate event of the youtube adapter. The previous value needs to be checked for every event attached, otherwise it can skip some updates when attaching the event multiple times.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Checkout commit `77b95560fc011410543470a224e96b72813fff47` in Sensei Pro.
* Add an YouTube Interactive Video.
* Play it in the frontend.
* Pause the video.
* Click in different times of the video, and make sure it updates.
* Also make sure the progressbar updates without a significant delay while playing the video.