### PR TITLE
Add admin bar course management menu

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -81,6 +81,8 @@ class Sensei_Frontend {
 		add_filter( 'init', array( $this, 'sensei_handle_login_request' ), 10 );
 		add_action( 'init', array( $this, 'sensei_process_registration' ), 2 );
 
+		add_action( 'admin_bar_menu', [ $this, 'add_manage_students' ], 70 );
+
 		add_action( 'sensei_pagination', array( $this, 'sensei_breadcrumb' ), 80, 1 );
 
 		// Fix pagination for course archive pages when filtering by course type.
@@ -1558,6 +1560,60 @@ class Sensei_Frontend {
 
 			Sensei()->notices->add_notice( $message, 'alert' );
 
+	}
+
+	/**
+	 * Add Manage Course menu to the admin bar, linking to Students and Grading admin pages.
+	 *
+	 * @access private
+	 * @since 4.7.0
+	 *
+	 * @param WP_Admin_Bar $wp_admin_bar The WordPress Admin Bar object.
+	 *
+	 * @return void
+	 */
+	public function add_manage_students( $wp_admin_bar ) {
+
+		global $post;
+
+		if ( ! is_single() || ! in_array( get_post_type(), array( 'lesson', 'course', 'quiz' ), true ) ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_sensei_grades' ) || is_admin() ) {
+			return;
+		}
+
+		$course_id = intval( Sensei_Utils::get_current_course() );
+
+		if ( ! $course_id ) {
+			return;
+		}
+
+		$wp_admin_bar->add_node(
+			[
+				'id'    => 'manage-sensei',
+				'title' => __( 'Manage Course', 'sensei-lms' ),
+			]
+		);
+
+		$wp_admin_bar->add_node(
+			[
+				'parent' => 'manage-sensei',
+				'id'     => 'sensei-students',
+				'title'  => __( 'Students', 'sensei-lms' ),
+				'href'   => admin_url( 'edit.php?post_type=course&page=sensei_learners&view=learners&course_id=' . $course_id ),
+			]
+		);
+
+		$wp_admin_bar->add_node(
+			[
+				'parent' => 'manage-sensei',
+				'id'     => 'sensei-grading',
+				'title'  => __( 'Grading', 'sensei-lms' ),
+				'href'   => admin_url( 'edit.php?post_type=course&page=sensei_grading&course_id=' . $course_id ),
+			]
+		);
 	}
 
 }


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Add a 'Manage Course' menu to the frontend admin bar, with links to the course's Students and Grading pages.
   — This makes it easier to quickly navigate to the course admin pages from the frontend

### Testing instructions

- View a course or lesson on the frontend as a teacher/admin
- Click on the Manage course → Students, Grading links in the admin bar. It should take to the correct WP-Admin pages

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video

<img width="835" alt="image" src="https://user-images.githubusercontent.com/176949/184663647-f304ef69-5bf9-4874-91ff-9ae65e590a44.png">

