### PR TITLE
Learning Mode - Do not filter templates for query slugs if it is indexing.

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -81,7 +81,7 @@ class Sensei_Course_Theme_Templates {
 	/**
 	 * Add course theme block templates to single template hierarchy.
 	 *
-	 * @param string[] $templates
+	 * @param string[] $templates The list of template names.
 	 *
 	 * @return string[]
 	 */
@@ -163,9 +163,9 @@ class Sensei_Course_Theme_Templates {
 	/**
 	 * Add Course Theme block templates.
 	 *
-	 * @param array $templates
-	 * @param array $query
-	 * @param array $template_type
+	 * @param array $templates List of WP templates.
+	 * @param array $query The query arguments to retrieve templates.
+	 * @param array $template_type The type of the template.
 	 *
 	 * @access private
 	 *
@@ -199,7 +199,11 @@ class Sensei_Course_Theme_Templates {
 			);
 		}
 
-		if ( $slugs ) {
+		// If the templates are queried for specific slugs
+		// then return templates matching only those slugs.
+		// Except if the slug is an "index". Which means it is
+		// searching for all the available templates.
+		if ( $slugs && ! in_array( 'index', $slugs, true ) ) {
 			$theme_templates = array_filter(
 				$theme_templates,
 				function( $template ) use ( $slugs ) {
@@ -297,7 +301,7 @@ class Sensei_Course_Theme_Templates {
 	/**
 	 * Build a template object from a post.
 	 *
-	 * @param WP_Post $post
+	 * @param WP_Post $post The post.
 	 *
 	 * @return WP_Block_Template
 	 */

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -194,7 +194,7 @@ class Sensei_Course_Theme_Templates {
 			$theme_templates = array_filter(
 				$theme_templates,
 				function( $template ) use ( $post_type ) {
-					return in_array( $post_type, $template->post_types, true );
+					return ! empty( $template->post_types ) && in_array( $post_type, $template->post_types, true );
 				}
 			);
 		}


### PR DESCRIPTION
Fixes #5311 

### Changes proposed in this Pull Request

* Checks if the query slugs are for indexing before filtering the templates.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
**Without a bock-based theme:**

1. Activate Twenty Twenty-One theme (not block-based theme).
2. Go to WP Admin > Appearance > Editor.
3. Confirm the FSE works and you can customize the Learning Mode template.

**With a bock-based theme, but with the theme styles disabled:**

1. Activate Twenty Twenty-Two theme (block-based theme).
2. Go to WP Admin > Sensei LMS > Settings > Courses.
4. Disable the option "Enable theme styles".
5. Go to WP Admin > Appearance > Editor > Browse all templates (this option appears when expanding the "Home >" in the top bar).
6. Click on "Lesson (Learning Mode)".
7. Confirm the FSE works and you can customize the Learning Mode template.

**For Post Type**
- Edit regular post.
- Confirm that it does not have "Learning Mode (Lesson)" template for FSE editing.