### PR TITLE
Do not save -1 values on quiz meta

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -5143,7 +5143,7 @@ class Sensei_Lesson {
 			}
 
 			// update pass percentage.
-			if ( ! empty( $new_settings['pass_percentage'] ) && is_numeric( $new_settings['pass_percentage'] ) ) {
+			if ( ! empty( $new_settings['pass_percentage'] ) && '-1' !== $new_settings['pass_percentage'] && is_numeric( $new_settings['pass_percentage'] ) ) {
 
 				update_post_meta( $quiz_id, '_quiz_passmark', $new_settings['pass_percentage'] );
 
@@ -5175,7 +5175,7 @@ class Sensei_Lesson {
 			}
 
 			// update number of questions to show.
-			if ( ! empty( $new_settings['show_questions'] ) ) {
+			if ( ! empty( $new_settings['show_questions'] ) && '-1' !== $new_settings['show_questions'] ) {
 
 				update_post_meta( $quiz_id, '_show_questions', $new_settings['show_questions'] );
 


### PR DESCRIPTION
Fixes #5453

There is an issue when a new quiz is created, where answers of the quiz are not displayed on the frontend. Here is a video that describes the issue:
https://d.pr/v/XvpDvb

### Steps to reproduce
- Create a new lesson
- Add a quiz to the lesson
- Add a couple of questions to the quiz
- Publish the lesson, visit the lesson on the frontend and try viewing the quiz

### What I expected
The quiz appears normally

### What happened instead
A warning appears which says that the quiz has no questions

### Changes proposed in this Pull Request

* The issue was caused by storing '-1' as an initial value to some of the quiz meta on quiz creation.
