### PR TITLE
Add className prop to Sensei modal

### DIFF
--- a/assets/shared/components/modal/index.js
+++ b/assets/shared/components/modal/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { Icon, close as closeIcon } from '@wordpress/icons';
@@ -15,11 +20,12 @@ import { __ } from '@wordpress/i18n';
  * Modal component.
  *
  * @param {Object}   props
- * @param {Function} props.onClose  Callback to run when trying to close the modal.
- * @param {string}   props.title    The title for the modal. Empty by default.
- * @param {Object}   props.children The content of the modal.
+ * @param {Function} props.className A class name for the modal.
+ * @param {Function} props.onClose   Callback to run when trying to close the modal.
+ * @param {string}   props.title     The title for the modal. Empty by default.
+ * @param {Object}   props.children  The content of the modal.
  */
-const Modal = ( { onClose, title = '', children } ) => {
+const Modal = ( { className, onClose, title = '', children } ) => {
 	const focusOnMountRef = useFocusOnMount();
 	const focusOutsideProps = useFocusOutside( onClose );
 
@@ -30,7 +36,7 @@ const Modal = ( { onClose, title = '', children } ) => {
 	};
 
 	return createPortal(
-		<div className="sensei-modal">
+		<div className={ classnames( 'sensei-modal', className ) }>
 			<div className="sensei-modal__overlay" />
 			{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
 			<div

--- a/assets/shared/components/modal/index.js
+++ b/assets/shared/components/modal/index.js
@@ -1,9 +1,4 @@
 /**
- * External dependencies
- */
-import classnames from 'classnames';
-
-/**
  * WordPress dependencies
  */
 import { Icon, close as closeIcon } from '@wordpress/icons';
@@ -36,7 +31,7 @@ const Modal = ( { className, onClose, title = '', children } ) => {
 	};
 
 	return createPortal(
-		<div className={ classnames( 'sensei-modal', className ) }>
+		<div className={ `sensei-modal ${ className }` }>
 			<div className="sensei-modal__overlay" />
 			{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
 			<div


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It adds a `className` prop to the Sensei modal.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* See 1680-gh-Automattic/sensei-pro