### PR TITLE
Revert "Change className prop to not use classnames"

### DIFF
--- a/assets/shared/components/modal/index.js
+++ b/assets/shared/components/modal/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { Icon, close as closeIcon } from '@wordpress/icons';
@@ -31,7 +36,7 @@ const Modal = ( { className, onClose, title = '', children } ) => {
 	};
 
 	return createPortal(
-		<div className={ `sensei-modal ${ className }` }>
+		<div className={ classnames( 'sensei-modal', className ) }>
 			<div className="sensei-modal__overlay" />
 			{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions */ }
 			<div

--- a/assets/shared/components/modal/index.js
+++ b/assets/shared/components/modal/index.js
@@ -20,7 +20,7 @@ import { __ } from '@wordpress/i18n';
  * Modal component.
  *
  * @param {Object}   props
- * @param {Function} props.className A class name for the modal.
+ * @param {string}   props.className A class name for the modal.
  * @param {Function} props.onClose   Callback to run when trying to close the modal.
  * @param {string}   props.title     The title for the modal. Empty by default.
  * @param {Object}   props.children  The content of the modal.


### PR DESCRIPTION
This reverts commit 0d7fca647bbf9699bfaff96b7976c77c64c510e6.

### Changes proposed in this Pull Request

* It reverts that commit to avoid a class like "sensei-modal undefined", for example. We could add some checks to the string, but I think we have the `classnames` dependency to make it easier for us. :)