### PR TITLE
Hide query loop default patterns when in course list 

### DIFF
--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -6,6 +6,7 @@ import { registerBlockVariation } from '@wordpress/blocks';
 import { list } from '@wordpress/icons';
 import { select, subscribe } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
+import { Fragment } from '@wordpress/element';
 
 export const registerCourseListBlock = () => {
 	const DEFAULT_ATTRIBUTES = {
@@ -139,7 +140,7 @@ const withQueryLoopPatternsHiddenForCourseList = ( BlockEdit ) => {
 		) {
 			hideCourseListPatternsCarouselViewControl();
 			hideNonCourseListBlockPatternContainers();
-			return <></>;
+			return <Fragment />;
 		}
 		return <BlockEdit { ...props } />;
 	};

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -118,7 +118,7 @@ const hideUnnecessarySettingsForCourseList = () => {
 	} );
 };
 
-let isCourseListBlockSelected = true;
+let isCourseListBlockSelected = false;
 
 const withQueryLoopPatternsHiddenForCourseList = ( BlockEdit ) => {
 	return ( props ) => {
@@ -136,7 +136,8 @@ const withQueryLoopPatternsHiddenForCourseList = ( BlockEdit ) => {
 		if (
 			isCourseListBlockSelected &&
 			isQueryLoopBlock &&
-			! isCourseListBlock
+			! isCourseListBlock &&
+			! isBlockAlreadyAddedInEditor( props.clientId )
 		) {
 			hideCourseListPatternsCarouselViewControl();
 			hideNonCourseListBlockPatternContainers();
@@ -165,6 +166,10 @@ const hideCourseListPatternsCarouselViewControl = () => {
 		// Select Grid view button.
 		controlButtons[ 1 ].click();
 	} );
+};
+
+const isBlockAlreadyAddedInEditor = ( clientId ) => {
+	return !! document.getElementById( 'block-' + clientId );
 };
 
 // Hide non course list patterns.

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -67,6 +67,20 @@ subscribe( () => {
 	}
 } );
 
+// Hide unnecessary patterns for course list block.
+setInterval( () => {
+	const blocks = select( 'core/block-editor' ).getBlocks();
+	blocks.forEach( ( block ) => {
+		if (
+			block &&
+			block.attributes &&
+			block.attributes.className === 'course-list-block'
+		) {
+			hideUnnecessaryPatternsForCourseList( block.clientId );
+		}
+	} );
+}, 300 );
+
 // Hide the settings which are inherited from the Query Loop block
 // but not applicable to our Course List block.
 const hideUnnecessarySettingsForCourseList = () => {
@@ -99,4 +113,62 @@ const hideUnnecessarySettingsForCourseList = () => {
 			}
 		} );
 	}, 0 );
+};
+
+// Hide the patterns which are inherited from the Query Loop block
+// but not applicable to our Course List block.
+const hideUnnecessaryPatternsForCourseList = ( blockId ) => {
+	const block = document.querySelector( `div[data-block="${ blockId }"]` );
+	setTimeout( () => {
+		// Hide default patterns.
+		hideNonCourseListBlockPatterns( block );
+		// Hide patterns control so only Grid view can be selected.
+		hideCarouselPatternSelectorControl( block );
+	}, 100 );
+};
+
+const hideNonCourseListBlockPatterns = ( block ) => {
+	const patternsClass = '.block-editor-block-pattern-setup-list__list-item';
+	const customPatternDescription = 'course-list-element';
+	const patternHiddenClass = 'patterns-hidden';
+
+	// Brake for checking patterns after it's done once.
+	if ( block.classList.contains( patternHiddenClass ) ) {
+		return;
+	}
+
+	const patterns = block.querySelectorAll( `${ patternsClass }` );
+	patterns.forEach( ( pattern ) => {
+		const isCourseListPattern = [
+			...pattern.querySelectorAll( 'div' ),
+		].find( ( e ) => e.innerText === customPatternDescription );
+		if ( isCourseListPattern ) {
+			pattern.style.display = 'inherit';
+		}
+	} );
+	if ( patterns.length > 0 ) {
+		block.classList.add( patternHiddenClass );
+	}
+};
+
+// Hide patterns control so only Grid view can be selected.
+const hideCarouselPatternSelectorControl = ( block ) => {
+	const patternControlHidden = 'pattern-control-hidden';
+
+	// Brake for checking controls after it's done once.
+	if ( block.classList.contains( patternControlHidden ) ) {
+		return;
+	}
+	block.classList.add( patternControlHidden );
+
+	const patternsControlClass =
+		'.block-editor-block-pattern-setup__display-controls';
+	const controls = block.querySelectorAll( `${ patternsControlClass }` );
+	controls.forEach( ( control ) => {
+		const controlButtons = control.querySelectorAll( 'button' );
+		// Hide carousel pattern view button.
+		controlButtons[ 0 ].style.display = 'none';
+		// Select Grid view button.
+		controlButtons[ 1 ].click();
+	} );
 };

--- a/assets/blocks/single-page-style.scss
+++ b/assets/blocks/single-page-style.scss
@@ -1,2 +1,6 @@
 @import './learner-courses-block/learner-courses';
 @import './course-results-block/course-results';
+
+.course-list-block .block-editor-block-pattern-setup .block-editor-block-pattern-setup__container .block-editor-block-pattern-setup-list__list-item {
+	display: none;
+}

--- a/assets/blocks/single-page-style.scss
+++ b/assets/blocks/single-page-style.scss
@@ -1,6 +1,2 @@
 @import './learner-courses-block/learner-courses';
 @import './course-results-block/course-results';
-
-.course-list-block .block-editor-block-pattern-setup .block-editor-block-pattern-setup__container .block-editor-block-pattern-setup-list__list-item {
-	display: none;
-}

--- a/includes/block-patterns/class-sensei-block-patterns.php
+++ b/includes/block-patterns/class-sensei-block-patterns.php
@@ -71,10 +71,11 @@ class Sensei_Block_Patterns {
 		register_block_pattern(
 			'dummy-course-list-query',
 			[
-				'title'      => __( 'Grid of courses', 'sensei-lms' ),
-				'categories' => array( 'query' ),
-				'blockTypes' => array( 'core/query' ),
-				'content'    => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"layout":{"inherit":false}} -->
+				'title'       => __( 'Grid of courses', 'sensei-lms' ),
+				'categories'  => array( 'query' ),
+				'blockTypes'  => array( 'core/query' ),
+				'description' => 'course-list-element',
+				'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"layout":{"inherit":false}} -->
 						<div class="wp-block-query course-list-block"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 


### PR DESCRIPTION
Fixes #5424

### Changes proposed in this Pull Request
- A short read on how we got to this solution on the topic: https://nexusp2.wordpress.com/2022/08/16/hide-default-patterns-in-block-variation/
- Decided to go with JS solution, since it's the quickest
- How hiding is implemented: 
1. We need to add a description with the text **'course-list-element'** to our custom patterns
2. We use CSS to hide all the patterns and then our js script shows the pattern with **'course-list-element'**  Description
3. Also carousel view id is hidden for Course List Variation Block
4. This change must NOT in any way affect Query Loop
5. Early return added so that we don't have performance issues

### Testing instructions
1. Create a new page
2. Select Course List block
3. You should only see one pattern and only a grid view
4. Create a Query Loop 
5. You should see multiple patterns and both grid and carousel view

Here is a video: 

https://user-images.githubusercontent.com/7208249/185161444-0359703a-806d-4eac-a9fe-b776f3d002c5.mov


