### PR TITLE
Fix loading user-customized template for learning mode

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -75,6 +75,7 @@ class Sensei_Course_Theme_Templates {
 		if ( Sensei_Course_Theme_Option::should_use_learning_mode() ) {
 			add_filter( 'sensei_use_sensei_template', '__return_false' );
 			add_filter( 'single_template_hierarchy', [ $this, 'set_single_template_hierarchy' ] );
+			add_theme_support( 'block-templates' );
 		}
 	}
 


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Add the `block-templates` theme support flag when loading a learning mode template on the frontend, so the correct template is picked up for the lesson.

### Testing instructions

* Use a classic theme
* Enable learning mode
* In the Site Editor, customize the Lesson template
* Open the lesson on the frontend
* Check that it is using the customized template
