### PR TITLE
Course Outline - Show private lessons only for those who can view them.

### DIFF
--- a/includes/class-sensei-course-structure.php
+++ b/includes/class-sensei-course-structure.php
@@ -15,8 +15,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @since 3.6.0
  */
 class Sensei_Course_Structure {
-	const PUBLISHED_POST_STATUSES = [ 'publish', 'private' ];
-
 	/**
 	 * Course instances.
 	 *
@@ -80,8 +78,8 @@ class Sensei_Course_Structure {
 
 		$structure = [];
 
-		$published_lessons_only = 'view' === $context;
-		$post_status            = $published_lessons_only ? self::PUBLISHED_POST_STATUSES : 'any';
+		$published_lessons_only = 'view' === $context && ! current_user_can( 'read_private_posts' );
+		$post_status            = $published_lessons_only ? 'publish' : 'any';
 		$no_module_lessons      = wp_list_pluck( Sensei()->modules->get_none_module_lessons( $this->course_id, $post_status ), 'ID' );
 		$modules                = $this->get_modules();
 

--- a/tests/unit-tests/test-class-sensei-course-structure.php
+++ b/tests/unit-tests/test-class-sensei-course-structure.php
@@ -193,8 +193,6 @@ class Sensei_Course_Structure_Test extends WP_UnitTestCase {
 	 * Test getting course structure when a module has no published lessons while in view context.
 	 */
 	public function testGetModulesWithEmptyLessonsView() {
-		$this->login_as_admin();
-
 		$course_id = $this->factory->course->create();
 
 		$lessons            = $this->factory->lesson->create_many( 2 );


### PR DESCRIPTION
Fixes #5032 

### Changes proposed in this Pull Request

* Checks for `current_user_can( 'read_private_posts' )` before including private lessons in the course outline.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Make one of the lessons of the course private.
* Visit the course page as a non admin user.
* Confirm that the private lesson does not show up.
* Turn on the Learning Mode for the course and visit one of the lessons of the course as a non admin user.
* Confirm that the private lesson does not show up on the course navigation sidebar on the left.