### PR TITLE
Modify title for course theme lesson actions block to avoid confusion

### DIFF
--- a/assets/course-theme/blocks/blocks.js
+++ b/assets/course-theme/blocks/blocks.js
@@ -92,7 +92,7 @@ const blocks = [
 	},
 	{
 		...meta,
-		title: __( 'Lesson Actions', 'sensei-lms' ),
+		title: __( 'Lesson Actions (Learning Mode)', 'sensei-lms' ),
 		name: 'sensei-lms/course-theme-lesson-actions',
 		description: __(
 			'Display buttons for actions the learner can take for the current lesson.',


### PR DESCRIPTION
Fixes #5204 

### Changes proposed in this Pull Request

* Changes the title for lesson actions block in learning mode to differentiate it from the other lesson actions block.

### Testing instructions

- In a lesson editor page, click + to add a new block
- Type 'lesson actions'
- Notice the two lesson action blocks with different titles.
