### PR TITLE
Remove 'new' badge for learning mode

### DIFF
--- a/assets/css/global.scss
+++ b/assets/css/global.scss
@@ -130,19 +130,3 @@ body #menu-posts-course {
 .edit-php.post-type-quiz .add-new-h2 {
 	display: none;
 }
-
-.sensei-badge {
-	display: inline-block;
-	padding: 0 5px;
-	border-radius: 9px;
-	font-size: 12px;
-
-	&--success {
-		background-color: #28a745;
-		color: #ffffff;
-	}
-
-	&--after-text {
-		margin-left: 5px;
-	}
-}

--- a/assets/js/admin/course-theme/course-theme-sidebar.js
+++ b/assets/js/admin/course-theme/course-theme-sidebar.js
@@ -103,7 +103,7 @@ const CourseThemeSidebar = () => {
 	return (
 		<PluginDocumentSettingPanel
 			name="sensei-course-theme"
-			title={ <>{ __( 'Learning Mode', 'sensei-lms' ) }</> }
+			title={ __( 'Learning Mode', 'sensei-lms' )  }
 		>
 			{ globalLearningModeEnabled ? (
 				<p>

--- a/assets/js/admin/course-theme/course-theme-sidebar.js
+++ b/assets/js/admin/course-theme/course-theme-sidebar.js
@@ -103,14 +103,7 @@ const CourseThemeSidebar = () => {
 	return (
 		<PluginDocumentSettingPanel
 			name="sensei-course-theme"
-			title={
-				<>
-					{ __( 'Learning Mode', 'sensei-lms' ) }
-					<span className="sensei-badge sensei-badge--success sensei-badge--after-text">
-						{ __( 'New!', 'sensei-lms' ) }
-					</span>
-				</>
-			}
+			title={ <>{ __( 'Learning Mode', 'sensei-lms' ) }</> }
 		>
 			{ globalLearningModeEnabled ? (
 				<p>

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -342,7 +342,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 
 		// Course Settings.
 		$fields['sensei_learning_mode_all'] = array(
-			'name'        => __( 'Learning Mode', 'sensei-lms' ) . '<span class="sensei-badge sensei-badge--success sensei-badge--after-text">' . __( 'New!', 'sensei-lms' ) . '</span>',
+			'name'        => __( 'Learning Mode', 'sensei-lms' ),
 			'description' => __( 'Show an immersive and distraction-free view for lessons and quizzes.', 'sensei-lms' ),
 			'form'        => 'render_learning_mode_setting',
 			'type'        => 'checkbox',


### PR DESCRIPTION
Fixes #4691 

### Changes proposed in this Pull Request

* Remove 'new' badge for learning mode in the course editor side panel and course settings page

### Testing instructions

- On the course editor page and course settings page, ensure the 'new' badge no longer displays.