### PR TITLE
Learning Mode - Add a prerequisite notice to the quiz page.

### DIFF
--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1137,12 +1137,12 @@ class Sensei_Utils {
 									. '</a>';
 					}
 				}
-			} else {  // Lesson/Quiz not complete
+			} else {  // Lesson/Quiz not complete.
 
 				$lesson_prerequisite = \Sensei_Lesson::find_first_prerequisite_lesson( $lesson_id, $user_id );
 
-				if ( !$is_lesson && $lesson_prerequisite > 0 ) {
-					$lesson_status = \Sensei_Utils::user_lesson_status( $lesson_prerequisite, $user_id );
+				if ( ! $is_lesson && $lesson_prerequisite > 0 ) {
+					$lesson_status = self::user_lesson_status( $lesson_prerequisite, $user_id );
 
 					$prerequisite_lesson_link = '<a href="'
 						. esc_url( get_permalink( $lesson_prerequisite ) )
@@ -1158,10 +1158,9 @@ class Sensei_Utils {
 						? sprintf( esc_html__( 'You will be able to access this quiz once the %1$s are completed and graded.', 'sensei-lms' ), $prerequisite_lesson_link )
 						// translators: Placeholder is the link to the prerequisite lesson.
 						: sprintf( esc_html__( 'Please complete the %1$s to access this quiz.', 'sensei-lms' ), $prerequisite_lesson_link );
-				}
 
-				// Lesson/Quiz isn't "complete" instead it's ungraded (previously this "state" meant that it *was* complete)
-				elseif ( isset( $user_lesson_status->comment_approved ) && 'ungraded' == $user_lesson_status->comment_approved ) {
+					// Lesson/Quiz isn't "complete" instead it's ungraded (previously this "state" meant that it *was* complete).
+				} elseif ( isset( $user_lesson_status->comment_approved ) && 'ungraded' == $user_lesson_status->comment_approved ) {
 					$status    = 'complete';
 					$box_class = 'info';
 					if ( $is_lesson ) {
@@ -1171,9 +1170,9 @@ class Sensei_Utils {
 						// translators: Placeholder is the quiz passmark.
 						$message = sprintf( __( 'You have completed this quiz and it will be graded soon. You require %1$s%% to pass.', 'sensei-lms' ), self::round( $quiz_passmark, 2 ) );
 					}
-				}
-				// Lesson status must be "failed"
-				elseif ( isset( $user_lesson_status->comment_approved ) && 'failed' == $user_lesson_status->comment_approved ) {
+
+					// Lesson status must be "failed".
+				} elseif ( isset( $user_lesson_status->comment_approved ) && 'failed' == $user_lesson_status->comment_approved ) {
 					$status    = 'failed';
 					$box_class = 'alert';
 					if ( $is_lesson ) {
@@ -1183,9 +1182,9 @@ class Sensei_Utils {
 						// translators: Placeholders are the quiz passmark and the learner's grade, respectively.
 						$message = sprintf( __( 'You require %1$d%% to pass this quiz. Your grade is %2$s%%', 'sensei-lms' ), self::round( $quiz_passmark, 2 ), self::round( $quiz_grade, 2 ) );
 					}
-				}
-				// Lesson/Quiz requires a pass
-				elseif ( $pass_required ) {
+
+					// Lesson/Quiz requires a pass.
+				} elseif ( $pass_required ) {
 					$status    = 'not_started';
 					$box_class = 'info';
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -1139,8 +1139,29 @@ class Sensei_Utils {
 				}
 			} else {  // Lesson/Quiz not complete
 
+				$lesson_prerequisite = \Sensei_Lesson::find_first_prerequisite_lesson( $lesson_id, $user_id );
+
+				if ( !$is_lesson && $lesson_prerequisite > 0 ) {
+					$lesson_status = \Sensei_Utils::user_lesson_status( $lesson_prerequisite, $user_id );
+
+					$prerequisite_lesson_link = '<a href="'
+						. esc_url( get_permalink( $lesson_prerequisite ) )
+						. '" title="'
+						// translators: Placeholder is the item title.
+						. sprintf( esc_attr__( 'You must first complete: %1$s', 'sensei-lms' ), get_the_title( $lesson_prerequisite ) )
+						. '">'
+						. esc_html__( 'prerequisites', 'sensei-lms' )
+						. '</a>';
+
+					$message = ! empty( $lesson_status ) && 'ungraded' === $lesson_status->comment_approved
+						// translators: Placeholder is the link to the prerequisite lesson.
+						? sprintf( esc_html__( 'You will be able to access this quiz once the %1$s are completed and graded.', 'sensei-lms' ), $prerequisite_lesson_link )
+						// translators: Placeholder is the link to the prerequisite lesson.
+						: sprintf( esc_html__( 'Please complete the %1$s to access this quiz.', 'sensei-lms' ), $prerequisite_lesson_link );
+				}
+
 				// Lesson/Quiz isn't "complete" instead it's ungraded (previously this "state" meant that it *was* complete)
-				if ( isset( $user_lesson_status->comment_approved ) && 'ungraded' == $user_lesson_status->comment_approved ) {
+				elseif ( isset( $user_lesson_status->comment_approved ) && 'ungraded' == $user_lesson_status->comment_approved ) {
 					$status    = 'complete';
 					$box_class = 'info';
 					if ( $is_lesson ) {

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -45,12 +45,14 @@ class Sensei_Course_Theme_Lesson {
 	 * Initializes the class.
 	 */
 	public function init() {
-		if ( 'lesson' !== get_post_type() ) {
+		$post_type = get_post_type();
+		if ( 'lesson' === $post_type || 'quiz' === $post_type ) {
+			$this->maybe_add_lesson_prerequisite_notice();
+		} elseif ( 'lesson' !== get_post_type() ) {
 			return;
 		}
 
 		$this->maybe_add_quiz_results_notice();
-		$this->maybe_add_lesson_prerequisite_notice();
 		$this->maybe_add_not_enrolled_notice();
 	}
 

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -201,12 +201,12 @@ class Sensei_Course_Theme_Lesson {
 
 			$text = ! empty( $lesson_status ) && 'ungraded' === $lesson_status->comment_approved
 				// translators: Placeholder is the link to the prerequisite lesson.
-				? sprintf( esc_html__( 'You will be able to view this lesson once the %1$s are completed and graded.', 'sensei-lms' ), $prerequisite_lesson_link )
+				? sprintf( esc_html__( 'You will be able to view this content once the %1$s are completed and graded.', 'sensei-lms' ), $prerequisite_lesson_link )
 				// translators: Placeholder is the link to the prerequisite lesson.
-				: sprintf( esc_html__( 'Please complete the %1$s to view this lesson content.', 'sensei-lms' ), $prerequisite_lesson_link );
+				: sprintf( esc_html__( 'Please complete the %1$s to view this content.', 'sensei-lms' ), $prerequisite_lesson_link );
 
 			$notices = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' );
-			$notices->add_notice( 'locked_lesson', $text, __( 'You don\'t have access to this lesson', 'sensei-lms' ), [], 'lock' );
+			$notices->add_notice( 'locked_lesson', $text, __( 'You don\'t have access to this content', 'sensei-lms' ), [], 'lock' );
 		}
 	}
 

--- a/includes/course-theme/class-sensei-course-theme-lesson.php
+++ b/includes/course-theme/class-sensei-course-theme-lesson.php
@@ -201,12 +201,12 @@ class Sensei_Course_Theme_Lesson {
 
 			$text = ! empty( $lesson_status ) && 'ungraded' === $lesson_status->comment_approved
 				// translators: Placeholder is the link to the prerequisite lesson.
-				? sprintf( esc_html__( 'You will be able to view this content once the %1$s are completed and graded.', 'sensei-lms' ), $prerequisite_lesson_link )
+				? sprintf( esc_html__( 'You will be able to view this lesson once the %1$s are completed and graded.', 'sensei-lms' ), $prerequisite_lesson_link )
 				// translators: Placeholder is the link to the prerequisite lesson.
-				: sprintf( esc_html__( 'Please complete the %1$s to view this content.', 'sensei-lms' ), $prerequisite_lesson_link );
+				: sprintf( esc_html__( 'Please complete the %1$s to view this lesson content.', 'sensei-lms' ), $prerequisite_lesson_link );
 
 			$notices = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' );
-			$notices->add_notice( 'locked_lesson', $text, __( 'You don\'t have access to this content', 'sensei-lms' ), [], 'lock' );
+			$notices->add_notice( 'locked_lesson', $text, __( 'You don\'t have access to this lesson', 'sensei-lms' ), [], 'lock' );
 		}
 	}
 

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -159,7 +159,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 
 		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
 
-		$this->assertRegExp( '/Please complete the .* to view this content/', $html, 'Should return prerequisite notice' );
+		$this->assertRegExp( '/Please complete the .* to view this lesson content/', $html, 'Should return prerequisite notice' );
 	}
 
 	/**
@@ -184,7 +184,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 
 		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
 
-		$this->assertRegExp( '/You will be able to view this content once the .* are completed and graded./', $html, 'Should return ungraded prerequisite notice' );
+		$this->assertRegExp( '/You will be able to view this lesson once the .* are completed and graded./', $html, 'Should return ungraded prerequisite notice' );
 	}
 
 	/**

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-lesson.php
@@ -159,7 +159,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 
 		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
 
-		$this->assertRegExp( '/Please complete the .* to view this lesson content/', $html, 'Should return prerequisite notice' );
+		$this->assertRegExp( '/Please complete the .* to view this content/', $html, 'Should return prerequisite notice' );
 	}
 
 	/**
@@ -184,7 +184,7 @@ class Sensei_Course_Theme_Lesson_Test extends WP_UnitTestCase {
 
 		$html = \Sensei_Context_Notices::instance( 'course_theme_locked_lesson' )->get_notices_html( 'course-theme/locked-lesson-notice.php' );
 
-		$this->assertRegExp( '/You will be able to view this lesson once the .* are completed and graded./', $html, 'Should return ungraded prerequisite notice' );
+		$this->assertRegExp( '/You will be able to view this content once the .* are completed and graded./', $html, 'Should return ungraded prerequisite notice' );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5170 

### Changes proposed in this Pull Request

* Adds a prerequisite notice to the quiz pages.

This issue is a rare case. Because if the lesson has a prerequisite the quiz page is hidden and/or the "Take Quiz" button is disabled. But there could be the case when students share the link to the lesson quiz with each other and while some students have completed the prerequisites the others might not. Those students that have no completed the prerequisites will not see a blank page but a message with clear directions now.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Make one Lesson A a prerequisite to Lesson B.
* Add a quiz to Lesson B.
* Visit Lesson B and confirm that there is a prerequisite notice for the lesson.
* Visit the quiz for Lesson B. You can update the url and change the `/lesson/lesson-b` to `/quiz/lesson-b`.
* Confirm that the quiz page for Lesson B has a prerequisite notice for the quiz.