### PR TITLE
Fix math issue with player

### DIFF
--- a/assets/shared/helpers/player/index.js
+++ b/assets/shared/helpers/player/index.js
@@ -10,6 +10,7 @@ import * as videoFileAdapter from './video-file-adapter';
 import * as videopressAdapter from './videopress-adapter';
 import * as youtubeAdapter from './youtube-adapter';
 import * as vimeoAdapter from './vimeo-adapter';
+import roundWithDecimals from './round-with-decimals';
 
 const VIDEO_TYPE = videoFileAdapter.ADAPTER_NAME;
 const VIDEOPRESS_TYPE = videopressAdapter.ADAPTER_NAME;
@@ -106,7 +107,7 @@ class Player {
 	 */
 	getCurrentTime() {
 		return this.getPlayer().then( ( player ) =>
-			this.getAdapter().getCurrentTime( player )
+			roundWithDecimals( this.getAdapter().getCurrentTime( player ), 3 )
 		);
 	}
 
@@ -161,8 +162,29 @@ class Player {
 			throw new Error( `Event ${ eventName } not supported` );
 		}
 
+		return this.onTimeUpdate( callback );
+	}
+
+	/**
+	 * Wrapper to the `onTimeUpdate` event from the adapters.
+	 *
+	 * @access private
+	 *
+	 * @param {Function} callback Listener callback.
+	 *
+	 * @return {Promise<Function>} The function to unsubscribe the event through a promise.
+	 */
+	onTimeUpdate( callback ) {
+		const transformedCallback = ( seconds ) => {
+			callback( roundWithDecimals( seconds, 3 ) );
+		};
+
 		return this.getPlayer().then( ( player ) =>
-			this.getAdapter().onTimeupdate( player, callback, this.w )
+			this.getAdapter().onTimeupdate(
+				player,
+				transformedCallback,
+				this.w
+			)
 		);
 	}
 }

--- a/assets/shared/helpers/player/index.js
+++ b/assets/shared/helpers/player/index.js
@@ -106,9 +106,11 @@ class Player {
 	 * @return {Promise<number>} The current video time in seconds through a promise.
 	 */
 	getCurrentTime() {
-		return this.getPlayer().then( ( player ) =>
-			roundWithDecimals( this.getAdapter().getCurrentTime( player ), 3 )
-		);
+		return this.getPlayer()
+			.then( ( player ) => this.getAdapter().getCurrentTime( player ) )
+			.then( ( seconds ) => {
+				return roundWithDecimals( seconds, 3 );
+			} );
 	}
 
 	/**

--- a/assets/shared/helpers/player/round-with-decimals.js
+++ b/assets/shared/helpers/player/round-with-decimals.js
@@ -1,0 +1,15 @@
+/**
+ * Round a number with certain amount of decimal digits.
+ *
+ * @param {number} number The number to be rounded.
+ * @param {number} digits The number of digits to appear after the decimal point.
+ *
+ * @return {number} Rounded number.
+ */
+const roundWithDecimals = ( number, digits ) => {
+	const multiplier = Math.pow( 10, digits );
+
+	return Math.round( ( number + Number.EPSILON ) * multiplier ) / multiplier;
+};
+
+export default roundWithDecimals;

--- a/assets/shared/helpers/player/round-with-decimals.test.js
+++ b/assets/shared/helpers/player/round-with-decimals.test.js
@@ -1,0 +1,30 @@
+/**
+ * Internal dependencies
+ */
+import roundWithDecimals from './round-with-decimals';
+
+describe( 'roundWithDecimals', () => {
+	it( 'Should round with 3 digits to down when down is the nearest', () => {
+		const roundedNumber = roundWithDecimals( 10.1234, 3 );
+
+		expect( roundedNumber ).toEqual( 10.123 );
+	} );
+
+	it( 'Should round with 3 digits to up when up is the nearest', () => {
+		const roundedNumber = roundWithDecimals( 10.1236, 3 );
+
+		expect( roundedNumber ).toEqual( 10.124 );
+	} );
+
+	it( 'Should round with 1 digit', () => {
+		const roundedNumber = roundWithDecimals( 10.1234, 1 );
+
+		expect( roundedNumber ).toEqual( 10.1 );
+	} );
+
+	it( 'Should round with 0 digits', () => {
+		const roundedNumber = roundWithDecimals( 10.1234, 0 );
+
+		expect( roundedNumber ).toEqual( 10 );
+	} );
+} );


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It fixes a JS Math issue with videos.

<img width="437" alt="Screen Shot 2022-08-17 at 12 40 03" src="https://user-images.githubusercontent.com/876340/185190090-e8bb6892-f203-41a8-8105-5093a1d22f44.png">

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* In Sensei Pro, add an Interactive Video Block.
* Add a break point at 00:08.03 with some content.
* Play it in the frontend. Make sure that after closing the modal of this break point, the video continues playing instead of opening the modal again.