### PR TITLE
Fix Post Type not getting hidden for older wp versions

### DIFF
--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -105,10 +105,10 @@ const hideUnnecessarySettingsForCourseList = () => {
 		if (
 			[
 				/* eslint-disable-next-line @wordpress/i18n-text-domain */
-				__( 'Post type' ),
+				__( 'Post type' ).toLowerCase(),
 				/* eslint-disable-next-line @wordpress/i18n-text-domain */
-				__( 'Inherit query from template' ),
-			].includes( element.textContent )
+				__( 'Inherit query from template' ).toLowerCase(),
+			].includes( element.textContent.toLowerCase() )
 		) {
 			element.closest( '.components-base-control' ).style.display =
 				'none';


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/5481

### Changes proposed in this Pull Request

* In the older version, the label spelled 'Post Type', it got changed to 'Post type' later. To avoid these scenarios, we've made it case insensitive now.

### Testing instructions

- Add a Course List block in a GB editor in wp version 6.0.1
- Make sure the Query inherit and Post Type settings are hidden
- Try the same with a different WP version (at least 5.9.3)

### Screenshot / Video
![image](https://user-images.githubusercontent.com/6820724/185407720-cbcaf381-0ba3-4e26-b6f6-3b88e40de170.png)
