### PR TITLE
Handle adding course blocks outside of a course context

### DIFF
--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -17,6 +17,7 @@ import { button as icon } from '@wordpress/icons';
 import './color-hooks';
 import ButtonEdit from './button-edit';
 import ButtonSave from './button-save';
+import InvalidUsageError from '../../shared/components/invalid-usage';
 import { withDefaultBlockStyle } from '../../shared/blocks/settings';
 
 /**
@@ -43,11 +44,13 @@ export const BlockStyles = {
  * Settings are merged into block settings, the rest of the options are passed on to the save and edit components.
  *
  * @param {Object}   opts
- * @param {Object}   opts.settings    Block settings.
- * @param {Function} opts.EditWrapper Custom edit wrapper component.
+ * @param {Object}   opts.settings     Block settings.
+ * @param {Object}   opts.invalidUsage Info about whether this block is being used in the proper context.
+ * @param {Function} opts.EditWrapper  Custom edit wrapper component.
  */
 export const createButtonBlockType = ( {
 	settings,
+	invalidUsage,
 	EditWrapper,
 	...options
 } ) => {
@@ -108,6 +111,7 @@ export const createButtonBlockType = ( {
 					default: [],
 				},
 			},
+			usesContext: [ 'postType' ],
 			supports: {
 				color: {
 					gradients: true,
@@ -121,9 +125,16 @@ export const createButtonBlockType = ( {
 			icon,
 			styles,
 			edit( props ) {
+				const { postType } = props.context;
 				const content = (
 					<ButtonEditWithBlockStyle { ...props } { ...options } />
 				);
+
+				if ( invalidUsage?.validPostTypes && ! invalidUsage.validPostTypes.includes( postType ) ) {
+					const message = invalidUsage?.message || __( 'This block can only be used inside the Course List block.', 'sensei-lms' );
+
+					return <InvalidUsageError message={ message } />;
+				}
 
 				if ( EditWrapper ) {
 					return <EditWrapper { ...props }>{ content }</EditWrapper>;

--- a/assets/blocks/button/index.js
+++ b/assets/blocks/button/index.js
@@ -130,8 +130,16 @@ export const createButtonBlockType = ( {
 					<ButtonEditWithBlockStyle { ...props } { ...options } />
 				);
 
-				if ( invalidUsage?.validPostTypes && ! invalidUsage.validPostTypes.includes( postType ) ) {
-					const message = invalidUsage?.message || __( 'This block can only be used inside the Course List block.', 'sensei-lms' );
+				if (
+					invalidUsage?.validPostTypes &&
+					! invalidUsage.validPostTypes.includes( postType )
+				) {
+					const message =
+						invalidUsage?.message ||
+						__(
+							'This block can only be used inside the Course List block.',
+							'sensei-lms'
+						);
 
 					return <InvalidUsageError message={ message } />;
 				}

--- a/assets/blocks/course-actions-block/course-actions/block.json
+++ b/assets/blocks/course-actions-block/course-actions/block.json
@@ -3,5 +3,6 @@
 	"category": "sensei-lms",
 	"supports": {
 		"html": false
-	}
+	},
+	"usesContext": [ "postType" ]
 }

--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -4,6 +4,11 @@
 import { __ } from '@wordpress/i18n';
 import { InnerBlocks } from '@wordpress/block-editor';
 
+/**
+ * Internal dependencies
+ */
+import InvalidUsageError from '../../../shared/components/invalid-usage';
+
 const innerBlocksTemplate = [
 	[
 		'sensei-lms/button-take-course',
@@ -25,18 +30,28 @@ const innerBlocksTemplate = [
  * @param {Object} props
  * @param {Object} props.className Block className.
  */
-const CourseActionsEdit = ( { className } ) => (
-	<div className={ className }>
-		<InnerBlocks
-			allowedBlocks={ [
-				'sensei-lms/button-take-course',
-				'sensei-lms/button-continue-course',
-				'sensei-lms/button-view-results',
-			] }
-			template={ innerBlocksTemplate }
-			templateLock="all"
-		/>
-	</div>
-);
+const CourseActionsEdit = ( { className, context: { postType } } ) => {
+	if ( 'course' !== postType ) {
+		return (
+			<InvalidUsageError
+				message={ __( 'The Course Actions block can only be used inside the Course List block.', 'sensei-lms' ) }
+			/>
+		);
+	}
+
+	return (
+		<div className={ className }>
+			<InnerBlocks
+				allowedBlocks={ [
+					'sensei-lms/button-take-course',
+					'sensei-lms/button-continue-course',
+					'sensei-lms/button-view-results',
+				] }
+				template={ innerBlocksTemplate }
+				templateLock="all"
+			/>
+		</div>
+	);
+}
 
 export default CourseActionsEdit;

--- a/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
+++ b/assets/blocks/course-actions-block/course-actions/course-actions-edit.js
@@ -28,13 +28,18 @@ const innerBlocksTemplate = [
  * Edit course actions block component.
  *
  * @param {Object} props
- * @param {Object} props.className Block className.
+ * @param {Object} props.className        Block className.
+ * @param {Object} props.context          Block context.
+ * @param {Object} props.context.postType Post type.
  */
 const CourseActionsEdit = ( { className, context: { postType } } ) => {
 	if ( 'course' !== postType ) {
 		return (
 			<InvalidUsageError
-				message={ __( 'The Course Actions block can only be used inside the Course List block.', 'sensei-lms' ) }
+				message={ __(
+					'The Course Actions block can only be used inside the Course List block.',
+					'sensei-lms'
+				) }
 			/>
 		);
 	}
@@ -52,6 +57,6 @@ const CourseActionsEdit = ( { className, context: { postType } } ) => {
 			/>
 		</div>
 	);
-}
+};
 
 export default CourseActionsEdit;

--- a/assets/blocks/course-categories-block/course-categories-edit.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.js
@@ -9,6 +9,7 @@ import { unescape } from 'lodash';
  */
 import { useBlockProps } from '@wordpress/block-editor';
 import { Spinner } from '@wordpress/components';
+import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -16,16 +17,17 @@ import { __ } from '@wordpress/i18n';
  */
 import { useMemo } from 'react';
 import useCourseCategories from './hooks/use-course-categories';
+import InvalidUsageError from '../../shared/components/invalid-usage';
+
 import {
 	withColorSettings,
 	withDefaultColor,
 } from '../../shared/blocks/settings';
-import { compose } from '@wordpress/compose';
 
 export function CourseCategoryEdit( props ) {
 	const { context, attributes, textColor, backgroundColor } = props;
 	const { textAlign } = attributes;
-	const { postId } = context;
+	const { postId, postType } = context;
 	const term = 'course-category';
 
 	const {
@@ -48,6 +50,17 @@ export function CourseCategoryEdit( props ) {
 		} ),
 		[ textColor, backgroundColor ]
 	);
+
+	if ( 'course' !== postType ) {
+		return (
+			<InvalidUsageError
+				message={ __(
+					'The Course Categories block can only be used inside the Course List block.',
+					'sensei-lms'
+				) }
+			/>
+		);
+	}
 
 	return (
 		<>

--- a/assets/blocks/course-categories-block/course-categories-edit.test.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.test.js
@@ -8,6 +8,9 @@ import { render } from '@testing-library/react';
 import { CourseCategoryEdit } from './course-categories-edit';
 import useCourseCategories from './hooks/use-course-categories';
 
+const message =
+	'The Course Categories block can only be used inside the Course List block.';
+
 jest.mock( '@wordpress/block-editor', () => ( {
 	useBlockProps: jest.fn(),
 	InspectorControls: ( { children } ) => <>{ children }</>,
@@ -17,7 +20,7 @@ jest.mock( '@wordpress/block-editor', () => ( {
 			<h1>{ props.title } </h1> { props.children }
 		</>
 	),
-	Warning: () => <div></div>,
+	Warning: () => <div>{ message }</div>,
 	withColors: () => ( Component ) => Component,
 } ) );
 
@@ -63,5 +66,20 @@ describe( 'CourseCategoryEdit', () => {
 		categories.forEach( ( category ) =>
 			expect( getByText( category.name ) ).toBeInTheDocument()
 		);
+	} );
+
+	it( 'should render an error', () => {
+		const { getByText } = render(
+			<CourseCategoryEdit
+				clientId="some-client-id"
+				attributes={ attributes }
+				context={ {
+					postId: 'some-post-id',
+					postType: 'page',
+				} }
+			/>
+		);
+
+		expect( getByText( message ) ).toBeInTheDocument();
 	} );
 } );

--- a/assets/blocks/course-categories-block/course-categories-edit.test.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.test.js
@@ -17,6 +17,7 @@ jest.mock( '@wordpress/block-editor', () => ( {
 			<h1>{ props.title } </h1> { props.children }
 		</>
 	),
+	Warning: () => <div></div>,
 	withColors: () => ( Component ) => Component,
 } ) );
 
@@ -28,6 +29,7 @@ const attributes = {
 
 const context = {
 	postId: 'some-post-id',
+	postType: 'course',
 };
 
 const categories = [

--- a/assets/blocks/course-progress-block/block.json
+++ b/assets/blocks/course-progress-block/block.json
@@ -38,6 +38,7 @@
       "default": false
     }
   },
+  "usesContext": [ "postType" ],
   "example": {
     "attributes": {
       "customBarBackgroundColor": "#999999",

--- a/assets/blocks/course-progress-block/course-progress-edit.js
+++ b/assets/blocks/course-progress-block/course-progress-edit.js
@@ -82,7 +82,10 @@ export const CourseProgressEdit = ( props ) => {
 	if ( 'course' !== postType ) {
 		return (
 			<InvalidUsageError
-				message={ __( 'The Course Progress block can only be used inside the Course List block.', 'sensei-lms' ) }
+				message={ __(
+					'The Course Progress block can only be used inside the Course List block.',
+					'sensei-lms'
+				) }
 			/>
 		);
 	}

--- a/assets/blocks/course-progress-block/course-progress-edit.js
+++ b/assets/blocks/course-progress-block/course-progress-edit.js
@@ -21,6 +21,7 @@ import { COURSE_STATUS_STORE } from '../course-outline/status-preview/status-sto
 import ProgressBar, {
 	ProgressBarSettings,
 } from '../../shared/blocks/progress-bar';
+import InvalidUsageError from '../../shared/components/invalid-usage';
 
 /**
  * Edit course progress bar component.
@@ -43,6 +44,7 @@ export const CourseProgressEdit = ( props ) => {
 		defaultBarColor,
 		barBackgroundColor,
 		textColor,
+		context: { postType },
 		attributes: { height, borderRadius },
 		setAttributes,
 	} = props;
@@ -76,6 +78,14 @@ export const CourseProgressEdit = ( props ) => {
 			borderRadius,
 		},
 	};
+
+	if ( 'course' !== postType ) {
+		return (
+			<InvalidUsageError
+				message={ __( 'The Course Progress block can only be used inside the Course List block.', 'sensei-lms' ) }
+			/>
+		);
+	}
 
 	return (
 		<>

--- a/assets/blocks/take-course-block/index.js
+++ b/assets/blocks/take-course-block/index.js
@@ -34,4 +34,11 @@ export default createButtonBlockType( {
 			},
 		},
 	},
+	invalidUsage: {
+		message: __(
+			'The Course Signup block can only be used inside the Course List block.',
+			'sensei-lms'
+		),
+		validPostTypes: [ 'course' ],
+	},
 } );

--- a/assets/blocks/view-results-block/index.js
+++ b/assets/blocks/view-results-block/index.js
@@ -31,4 +31,11 @@ export default createButtonBlockType( {
 			BlockStyles.Link,
 		],
 	},
+	invalidUsage: {
+		message: __(
+			'The View Results block can only be used inside the Course List block.',
+			'sensei-lms'
+		),
+		validPostTypes: [ 'course' ],
+	},
 } );

--- a/assets/shared/components/invalid-usage/index.js
+++ b/assets/shared/components/invalid-usage/index.js
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { useBlockProps, Warning } from '@wordpress/block-editor';
 
 function InvalidUsageError( { message } ) {
@@ -9,9 +8,7 @@ function InvalidUsageError( { message } ) {
 
 	return (
 		<div { ...blockProps }>
-			<Warning>
-				{ message }
-			</Warning>
+			<Warning>{ message }</Warning>
 		</div>
 	);
 }

--- a/assets/shared/components/invalid-usage/index.js
+++ b/assets/shared/components/invalid-usage/index.js
@@ -1,0 +1,19 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { useBlockProps, Warning } from '@wordpress/block-editor';
+
+function InvalidUsageError( { message } ) {
+	const blockProps = useBlockProps();
+
+	return (
+		<div { ...blockProps }>
+			<Warning>
+				{ message }
+			</Warning>
+		</div>
+	);
+}
+
+export default InvalidUsageError;

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -50,6 +50,10 @@ class Sensei_Block_Take_Course {
 		$course_id = $post->ID;
 		$html      = '';
 
+		if ( 'course' !== get_post_type( $course_id ) ) {
+			return '';
+		}
+
 		if ( Sensei_Course::can_current_user_manually_enrol( $course_id ) ) {
 			if ( ! Sensei_Course::is_prerequisite_complete( $course_id ) ) {
 				Sensei()->notices->add_notice( Sensei()->course::get_course_prerequisite_message( $course_id ), 'info', 'sensei-take-course-prerequisite' );

--- a/includes/blocks/class-sensei-block-view-results.php
+++ b/includes/blocks/class-sensei-block-view-results.php
@@ -46,6 +46,10 @@ class Sensei_Block_View_Results {
 	public function render( $attributes, $content ): string {
 		$course_id = get_the_ID();
 
+		if ( 'course' !== get_post_type( $course_id ) ) {
+			return '';
+		}
+
 		/**
 		 * Whether to render the View Results block.
 		 *

--- a/includes/blocks/class-sensei-course-categories-block.php
+++ b/includes/blocks/class-sensei-course-categories-block.php
@@ -45,11 +45,11 @@ class Sensei_Course_Categories_Block {
 
 
 	/**
-	 * Undocumented function
+	 * Render the Course Categories block.
 	 *
-	 * @param Array    $attributes     The block's attributes saved attributes.
-	 * @param string   $content       The block's content.
-	 * @param WP_Block $block   The block instance.
+	 * @param Array    $attributes The block's attributes.
+	 * @param string   $content    The block's content.
+	 * @param WP_Block $block      The block instance.
 	 * @return string
 	 */
 	public function render_block( $attributes, $content, WP_Block $block ): string {
@@ -60,7 +60,13 @@ class Sensei_Course_Categories_Block {
 			return '';
 		}
 
-		$post_terms = get_the_terms( $block->context['postId'], 'course-category' );
+		$post_id = $block->context['postId'];
+
+		if ( 'course' !== get_post_type( $post_id ) ) {
+			return '';
+		}
+
+		$post_terms = get_the_terms( $post_id, 'course-category' );
 
 		if ( is_wp_error( $post_terms ) || empty( $post_terms ) ) {
 			return '';
@@ -76,7 +82,7 @@ class Sensei_Course_Categories_Block {
 
 		$link_attributes = '<a ' . Sensei_Block_Helpers::render_style_attributes( [], $css );
 		$terms           = get_the_term_list(
-			$block->context['postId'],
+			$post_id,
 			'course-category',
 			"<div $wrapper_attributes>",
 			'',

--- a/includes/blocks/class-sensei-course-progress-block.php
+++ b/includes/blocks/class-sensei-course-progress-block.php
@@ -47,6 +47,10 @@ class Sensei_Course_Progress_Block {
 
 		$course_id = $attributes['postId'] ?? get_the_ID();
 
+		if ( 'course' !== get_post_type( $course_id ) ) {
+			return '';
+		}
+
 		if ( ! Sensei()->course::is_user_enrolled( $course_id ) ) {
 			return '';
 		}

--- a/tests/unit-tests/blocks/test-class-sensei-block-course-progress.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-course-progress.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Tests for Sensei_Course_Progress_Block class.
+ */
+class Sensei_Course_Progress_Block_Test extends WP_UnitTestCase {
+	/**
+	 * Course Progress block.
+	 *
+	 * @var Sensei_Course_Progress_Block
+	 */
+	private $block;
+
+	/**
+	 * Block content.
+	 */
+	const CONTENT = '<!-- wp:sensei-lms/course-progress /-->';
+
+	/**
+	 * Set up the test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->factory = new Sensei_Factory();
+		$this->block   = new Sensei_Course_Progress_Block();
+		$this->course  = $this->factory->course->create_and_get( [ 'post_name' => 'course-progress-block' ] );
+
+		$GLOBALS['post'] = $this->course;
+	}
+
+	public function tearDown() {
+		parent::tearDown();
+		WP_Block_Type_Registry::get_instance()->unregister( 'sensei-lms/course-progress' );
+	}
+
+	/**
+	 * Doesn't render the block if it's not running in a course context.
+	 *
+	 * @covers Sensei_Course_Progress_Block::render_course_progress
+	 */
+	public function testRenderCourseProgress_Page_ReturnsEmptyString() {
+		// Update the global post object ID to be the course ID, but change its post type to a page.
+		$GLOBALS['post'] = (object) [
+			'post_type' => 'page',
+		];
+
+		$result = $this->block->render_course_progress( [], self::CONTENT );
+
+		$this->assertEmpty( $result );
+	}
+}

--- a/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-take-course.php
@@ -152,4 +152,19 @@ class Sensei_Block_Take_Course_Test extends WP_UnitTestCase {
 		$this->assertEmpty( $result );
 	}
 
+	/**
+	 * Doesn't render the block if it's not running in a course context.
+	 *
+	 * @covers Sensei_Block_Take_Course::render_take_course_block
+	 */
+	public function testRenderTakeCourseBlock_Page_ReturnsEmptyString() {
+		$GLOBALS['post'] = (object) [
+			'ID'        => 0,
+			'post_type' => 'page',
+		];
+
+		$result = $this->block->render_take_course_block( [], '<button>Take Course</button>' );
+
+		$this->assertEmpty( $result );
+	}
 }

--- a/tests/unit-tests/blocks/test-class-sensei-block-view-results.php
+++ b/tests/unit-tests/blocks/test-class-sensei-block-view-results.php
@@ -89,4 +89,20 @@ class Sensei_Block_View_Results_Test extends WP_UnitTestCase {
 
 		$this->assertRegExp( "|<a href=\"http://example.org/\?page_id={$page_id}&#038;course_id={$this->course->ID}\".*>View Results</a>|", $result );
 	}
+
+	/**
+	 * Doesn't render the block if it's not running in a course context.
+	 *
+	 * @covers Sensei_Block_View_Results::render
+	 */
+	public function testRender_Page_ReturnsEmptyString() {
+		// Update the global post object ID to be the course ID, but change its post type to a page.
+		$GLOBALS['post'] = (object) [
+			'post_type' => 'page',
+		];
+
+		$result = $this->block->render( [], self::CONTENT );
+
+		$this->assertEmpty( $result );
+	}
 }

--- a/tests/unit-tests/blocks/test-class-sensei-course-categories-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-categories-block.php
@@ -33,6 +33,11 @@ class Sensei_Course_Categories_Block_Test extends WP_UnitTestCase {
 	private $category;
 
 	/**
+	 * Block content.
+	 */
+	const CONTENT = '<!-- wp:sensei-lms/course-categories {"align":"center","categoryStyle":{"classes":[],"style":{}},"textColor":"secondary","backgroundColor":"background","style":{"spacing":{"margin":{"top":"10px","right":"0","bottom":"10px","left":"0"}}}} /-->';
+
+	/**
 	 * Set up the test.
 	 */
 	public function setUp() {
@@ -61,12 +66,28 @@ class Sensei_Course_Categories_Block_Test extends WP_UnitTestCase {
 
 	/**
 	 * The course categories block is registered and renders content.
+	 *
+	 * @covers Sensei_Course_Categories_Block::render_block
 	 */
 	public function testBlockRegistered() {
-		$post_content = '<!-- wp:sensei-lms/course-categories {"align":"center","categoryStyle":{"classes":[],"style":{}},"textColor":"secondary","backgroundColor":"background","style":{"spacing":{"margin":{"top":"10px","right":"0","bottom":"10px","left":"0"}}}} /-->';
-		$result       = do_blocks( $post_content );
+		$result = do_blocks( self::CONTENT );
 
 		$this->assertContains( $this->category->name, $result );
 		$this->assertContains( $this->category->slug, $result );
+	}
+
+	/**
+	 * Doesn't render the block if it's not running in a course context.
+	 *
+	 * @covers Sensei_Course_Categories_Block::render_block
+	 */
+	public function testRenderBlock_Page_ReturnsEmptyString() {
+		$GLOBALS['post'] = (object) [
+			'post_type' => 'page',
+		];
+
+		$result = do_blocks( self::CONTENT );
+
+		$this->assertEmpty( $result );
 	}
 }


### PR DESCRIPTION
Fixes #5444.

### Changes proposed in this Pull Request
- Renders a message in the editor if a course block is used outside of a course context (e.g. used directly in a post or page).
- Doesn't render the block on the frontend if a course block is used outside of a course context.

### Testing instructions
See the acceptance critieria in #5444. Note that the items marked TBD are blocked by #5447, so we'll need to test those later. In theory, it shouldn't require any code changes.

### Screenshot / Video

**Note:** I'm not sure why the course categories block is rendering like this in Twenty Twenty theme, but we should probably investigate separately.

![Screen Shot 2022-08-19 at 3 00 34 PM](https://user-images.githubusercontent.com/1190420/185689026-7986bd96-b262-4194-a5dd-069ad1ca4be1.jpg)