### PR TITLE
fixes wrapper div issue on all videos

### DIFF
--- a/includes/course-video/blocks/class-sensei-course-video-blocks-embed-extension.php
+++ b/includes/course-video/blocks/class-sensei-course-video-blocks-embed-extension.php
@@ -32,7 +32,7 @@ abstract class Sensei_Course_Video_Blocks_Embed_Extension {
 	 * @return string
 	 */
 	public function wrap_video( $html, $url ): string {
-		if ( ! $this->is_supported( $url ) ) {
+		if ( ! $this->is_supported( $url ) || ! in_array('sensei', get_body_class()) ) {
 			return $html;
 		}
 


### PR DESCRIPTION
Fixes #5418

### Changes proposed in this Pull Request

* Modified the existing if condition to check and return the video without the extra div if the page doesn't contain the class **.sensei** . That is the div will only be added if the video is embedded on any sensei pages like course, lessons, etc.

### Testing instructions

* Embed a video on a normal Wordpress page or post and the same video on the Sensei course, lesson or any other page generated by the plugin and then inspect it from the front-end. With the code added, you can see the extra div before the iframe won't show in the default page/post which is the intended purpose of the fix. 

### Screenshot / Video
The wrapper div removed from the embeded video on a default Wordpress page - 

<img width="1435" alt="embedded on a page" src="https://user-images.githubusercontent.com/15308261/185581919-835f4072-2988-439b-9692-a50fc89575b9.png">

The wrapper div showing fine on sensei course and lesson page - 

<img width="1439" alt="Embedded on a lesson" src="https://user-images.githubusercontent.com/15308261/185582020-6f65993c-2a1f-4818-b453-dffb6991d7f6.png">