### PR TITLE
Take users to the last lesson they were working on

### DIFF
--- a/includes/blocks/class-sensei-continue-course-block.php
+++ b/includes/blocks/class-sensei-continue-course-block.php
@@ -62,11 +62,56 @@ class Sensei_Continue_Course_Block {
 			return '';
 		}
 
+		$target_post_id = $this->get_target_page_post_id_for_continue_url( $course_id, $user_id );
+
 		return preg_replace(
 			'/<a(.*)>/',
-			'<a href="' . esc_url( get_permalink( absint( $course_id ) ) ) . '" $1>',
+			'<a href="' . esc_url( get_permalink( absint( $target_post_id ?? $course_id ) ) ) . '" $1>',
 			$content,
 			1
 		);
+	}
+
+	/**
+	 * Gets the id for the last lesson the user was working on, or the next lesson, or
+	 * the course id as fallback for fresh users or courses with no lessons.
+	 *
+	 * @access private
+	 *
+	 * @param int $course_id Id of the course.
+	 * @param int $user_id   Id of the user.
+	 *
+	 * @return int
+	 */
+	private function get_target_page_post_id_for_continue_url( $course_id, $user_id ) {
+		$course_lessons = Sensei()->course->course_lessons( $course_id, 'publish', 'ids' );
+
+		if ( empty( $course_lessons ) ) {
+			return $course_id;
+		}
+		// First try to get the lesson the user started or updated last.
+		$activity_args = [
+			'post__in' => $course_lessons,
+			'user_id'  => $user_id,
+			'type'     => 'sensei_lesson_status',
+			'number'   => 1,
+			'orderby'  => 'comment_date',
+			'order'    => 'DESC',
+			'status'   => [ 'in-progress', 'ungraded' ],
+		];
+
+		$last_lesson_activity = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
+
+		if ( ! empty( $last_lesson_activity ) ) {
+			return $last_lesson_activity->comment_post_ID;
+		} else {
+			// If there is no such lesson, get the first lesson that the user has not yet started.
+			$completed_lessons     = Sensei()->course->get_completed_lesson_ids( $course_id, $user_id );
+			$not_completed_lessons = array_diff( $course_lessons, $completed_lessons );
+			if ( count( $course_lessons ) !== count( $not_completed_lessons ) && ! empty( $not_completed_lessons ) ) {
+				return $not_completed_lessons[0];
+			}
+		}
+		return $course_id;
 	}
 }

--- a/tests/unit-tests/blocks/test-class-sensei-continue-course-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-continue-course-block.php
@@ -92,4 +92,22 @@ class Sensei_Continue_Course_Block_Test extends WP_UnitTestCase {
 
 		$this->assertRegExp( '|<a href="http://example.org/\?course=continue-course-block".*>Continue</a>|', $result );
 	}
+
+	public function testRender_EnrolledAndStartedLesson_ReturnsModifiedBlockContentWithLessonUrl() {
+		/* Arrange */
+		$user_id           = $this->factory->user->create();
+		$course_lesson_ids = $this->factory->lesson->create_many( 2, [ 'meta_input' => [ '_lesson_course' => $this->course->ID ] ] );
+
+		$this->login_as( $user_id );
+
+		$this->manuallyEnrolStudentInCourse( $user_id, $this->course->ID );
+		Sensei_Utils::user_start_lesson( $user_id, $course_lesson_ids[0] );
+
+		/* Act */
+		$result = $this->block->render( [], self::CONTENT );
+
+		/* Assert */
+		$lesson_title = get_post( $course_lesson_ids[0] )->post_name;
+		$this->assertRegExp( '|<a href="http://example.org/\?lesson=' . $lesson_title . '".*>Continue</a>|', $result );
+	}
 }


### PR DESCRIPTION
Implements https://github.com/Automattic/sensei/issues/5432

### Changes proposed in this Pull Request

* When the users clicks on continue button, we took them to the course page. We added a bit more functionality to it now, so the users will be taken to the last lesson they started or updated when they click on the 'Continue' button. If there wasn't a lesson under work, then the user will be taken to the next lesson in order. If there's no such lesson or the users have not started working on any lesson and have just started the course, they'll be taken to the course landing page.

### Testing instructions

- Add the course list block to a page
- Add the Course Actions block to the inner template
- Save and go to the front end and login as a user
- Start one or more courses
- The buttons on the courses in course list block will start showing 'Continue'
- Click on any of them and you should be taken to the Course page
- Start a lesson of that course
- Now go back to the front page with Course List block and click on Continue again
- You should be taken to the lesson page
- Complete the lesson
- Now try the continue button again the same way
- You should be taken to the next lesson

### Screenshot / Video

https://user-images.githubusercontent.com/6820724/185689600-232e660a-488a-4182-ae95-f0fcceefe9c6.mov

