### PR TITLE
Add "Beta" label to Course List block

### DIFF
--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -26,7 +26,7 @@ export const registerCourseListBlock = () => {
 
 	registerBlockVariation( 'core/query', {
 		name: 'sensei-lms/course-list',
-		title: __( 'Course List', 'sensei-lms' ),
+		title: __( 'Course List (Beta)', 'sensei-lms' ),
 		description: __( 'Show a list of courses.', 'sensei-lms' ),
 		icon: list,
 		category: 'sensei-lms',


### PR DESCRIPTION
### Changes proposed in this Pull Request
Adds a "Beta" label to the Course List block name.

### Testing instructions
- Open the block inserter for a page.
- Ensure "Course List (Beta)" appears and that the Course List block is added when selected.

### Screenshot / Video

![Screen Shot 2022-08-21 at 7 33 01 AM](https://user-images.githubusercontent.com/1190420/185788934-3e5e5e93-f9e7-4afc-92c9-4ee6d635a59e.jpg)

![Screen Shot 2022-08-21 at 7 32 13 AM](https://user-images.githubusercontent.com/1190420/185788907-260f6e46-a3e9-4ac8-8112-4a103cb409a3.jpg)