### PR TITLE
Setup wizard disabled button set to grey background

### DIFF
--- a/assets/shared/styles/wp-components.scss
+++ b/assets/shared/styles/wp-components.scss
@@ -23,7 +23,7 @@ body.sensei-color {
 			color: #000;
 		}
 		&:disabled {
-			background-color: rgba($primary, 0.7);
+			background-color: $gray-5;
 		}
 		&.is-busy {
 			background-size: 100px 100%;


### PR DESCRIPTION
Fixes #5420

### Changes proposed in this Pull Request

* Updated the background of the button to grey when disabled

### Screenshot 
![184868765-40532ce8-fd57-4a8d-9384-b19c5cb0964c](https://user-images.githubusercontent.com/15308261/185798610-011a5fa2-50ee-4ad2-9ebb-2ecb4c9faa08.png)

