### PR TITLE
Add support for passing a custom footer to the Modal component

### DIFF
--- a/assets/shared/components/modal/index.js
+++ b/assets/shared/components/modal/index.js
@@ -20,13 +20,19 @@ import { __ } from '@wordpress/i18n';
  * Modal component.
  *
  * @param {Object}   props
- * @param {string}   props.className A class name for the modal.
- * @param {Function} props.onClose   Callback to run when trying to close the modal.
- * @param {string}   props.title     The title for the modal. Empty by default.
- * @param {Function} props.footer    Render Prop to render the footer. Will be passed the "onClose" as a parameter.
- * @param {Object}   props.children  The content of the modal.
+ * @param {string}   props.className    A class name for the modal.
+ * @param {Function} props.onClose      Callback to run when trying to close the modal.
+ * @param {string}   props.title        The title for the modal. Empty by default.
+ * @param {Function} props.renderFooter Render Prop to render the footer. Will be passed the "onClose" as a parameter.
+ * @param {Object}   props.children     The content of the modal.
  */
-const Modal = ( { className, onClose, title = '', footer, children } ) => {
+const Modal = ( {
+	className,
+	onClose,
+	title = '',
+	renderFooter,
+	children,
+} ) => {
 	const focusOnMountRef = useFocusOnMount();
 	const focusOutsideProps = useFocusOutside( onClose );
 
@@ -60,9 +66,9 @@ const Modal = ( { className, onClose, title = '', footer, children } ) => {
 					</button>
 				</div>
 				<div className="sensei-modal__content">{ children }</div>
-				{ footer && (
+				{ renderFooter && (
 					<div className="sensei-modal__footer">
-						{ footer( onClose ) }
+						{ renderFooter( onClose ) }
 					</div>
 				) }
 			</div>

--- a/assets/shared/components/modal/index.js
+++ b/assets/shared/components/modal/index.js
@@ -23,9 +23,16 @@ import { __ } from '@wordpress/i18n';
  * @param {string}   props.className A class name for the modal.
  * @param {Function} props.onClose   Callback to run when trying to close the modal.
  * @param {string}   props.title     The title for the modal. Empty by default.
+ * @param {Function} props.footer    React Component to render the footer. Will be passed the "onClose" callback as a prop.
  * @param {Object}   props.children  The content of the modal.
  */
-const Modal = ( { className, onClose, title = '', children } ) => {
+const Modal = ( {
+	className,
+	onClose,
+	title = '',
+	footer: Footer,
+	children,
+} ) => {
 	const focusOnMountRef = useFocusOnMount();
 	const focusOutsideProps = useFocusOutside( onClose );
 
@@ -57,6 +64,7 @@ const Modal = ( { className, onClose, title = '', children } ) => {
 					</button>
 				</div>
 				<div className="sensei-modal__content">{ children }</div>
+				{ Footer ? <Footer onClose={ onClose } /> : null }
 			</div>
 		</div>,
 		document.body

--- a/assets/shared/components/modal/index.js
+++ b/assets/shared/components/modal/index.js
@@ -48,7 +48,9 @@ const Modal = ( { className, onClose, title = '', footer, children } ) => {
 				{ ...focusOutsideProps }
 			>
 				<div className="sensei-modal__header">
-					<div className="sensei-modal__title">{ title }</div>
+					{ title && (
+						<div className="sensei-modal__title">{ title }</div>
+					) }
 					<button
 						className="sensei-modal sensei-modal__close-button"
 						onClick={ onClose }

--- a/assets/shared/components/modal/index.js
+++ b/assets/shared/components/modal/index.js
@@ -60,7 +60,11 @@ const Modal = ( { className, onClose, title = '', footer, children } ) => {
 					</button>
 				</div>
 				<div className="sensei-modal__content">{ children }</div>
-				{ footer && footer( onClose ) }
+				{ footer && (
+					<div className="sensei-modal__footer">
+						{ footer( onClose ) }
+					</div>
+				) }
 			</div>
 		</div>,
 		document.body

--- a/assets/shared/components/modal/index.js
+++ b/assets/shared/components/modal/index.js
@@ -23,16 +23,10 @@ import { __ } from '@wordpress/i18n';
  * @param {string}   props.className A class name for the modal.
  * @param {Function} props.onClose   Callback to run when trying to close the modal.
  * @param {string}   props.title     The title for the modal. Empty by default.
- * @param {Function} props.footer    React Component to render the footer. Will be passed the "onClose" callback as a prop.
+ * @param {Function} props.footer    Render Prop to render the footer. Will be passed the "onClose" as a parameter.
  * @param {Object}   props.children  The content of the modal.
  */
-const Modal = ( {
-	className,
-	onClose,
-	title = '',
-	footer: Footer,
-	children,
-} ) => {
+const Modal = ( { className, onClose, title = '', footer, children } ) => {
 	const focusOnMountRef = useFocusOnMount();
 	const focusOutsideProps = useFocusOutside( onClose );
 
@@ -64,7 +58,7 @@ const Modal = ( {
 					</button>
 				</div>
 				<div className="sensei-modal__content">{ children }</div>
-				{ Footer ? <Footer onClose={ onClose } /> : null }
+				{ footer && footer( onClose ) }
 			</div>
 		</div>,
 		document.body

--- a/assets/shared/components/modal/style.scss
+++ b/assets/shared/components/modal/style.scss
@@ -40,6 +40,10 @@
 		box-sizing: border-box;
 	}
 
+	& &__header {
+		min-height: 60px;
+	}
+
 	& &__content {
 		padding: 26px;
 		overflow: auto;

--- a/assets/shared/components/modal/style.scss
+++ b/assets/shared/components/modal/style.scss
@@ -71,4 +71,8 @@
 			background: none;
 		}
 	}
+
+	& &__footer {
+		padding: 26px;
+	}
 }


### PR DESCRIPTION
Related to 1743-gh-Automattic/sensei-pro
 
### Changes proposed in this Pull Request

* Add support for passing a custom footer to the Modal component;
* Also hide the border on the header of the modal when the title isn't specified;

### Testing instructions

Follow the testing instructions in 1720-gh-Automattic/sensei-pro 