### PR TITLE
Use Ubuntu Latest instead of Ubuntu 18.04 on Github Actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
     build:
         name: Plugin Build
-        runs-on: ubuntu-18.04
+        runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v3
             - name: Get npm cache directory


### PR DESCRIPTION
Fixes #5488 

### Changes proposed in this Pull Request

* Use Ubuntu Latest instead of Ubuntu 18.04 on Github Actions workflow;

### Testing instructions

Make sure all the checks pass.