### PR TITLE
Tweaks to course categories block

### DIFF
--- a/assets/blocks/course-categories-block/block.json
+++ b/assets/blocks/course-categories-block/block.json
@@ -27,19 +27,6 @@
 		"fontSize": {
 			"type": "string",
 			"default": "small"
-		},
-		"style": {
-			"type": "object",
-			"default": {
-				"spacing": {
-					"margin": {
-						"top": "10px",
-						"right": "0",
-						"bottom": "10px",
-						"left": "0"
-					}
-				}
-			}
 		}
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/assets/blocks/course-categories-block/block.json
+++ b/assets/blocks/course-categories-block/block.json
@@ -9,9 +9,6 @@
 			"type": "string",
 			"default": "left"
 		},
-		"categoryStyle": {
-			"type": "object"
-		},
 		"textColor": {
 			"type": "string"
 		},

--- a/assets/blocks/course-categories-block/block.json
+++ b/assets/blocks/course-categories-block/block.json
@@ -12,19 +12,16 @@
 		"categoryStyle": {
 			"type": "object"
 		},
-
-        "textColor": {
+		"textColor": {
 			"type": "string"
 		},
-
-        "backgroundColor": {
+		"backgroundColor": {
 			"type": "string"
 		},
-
-        "customBackgroundColor": {
+		"customBackgroundColor": {
 			"type": "string"
 		},
-        "customTextColor": {
+		"customTextColor": {
 			"type": "string"
 		},
 		"fontSize": {
@@ -53,7 +50,7 @@
 			"padding": true,
 			"blockGap": true
 		},
-        "textAlign": true,
+		"textAlign": true,
 		"align": true,
 		"alignWide": true,
 		"typography": {

--- a/assets/blocks/course-categories-block/course-categories-edit.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.js
@@ -52,10 +52,11 @@ export function CourseCategoryEdit( props ) {
 
 	const inlineStyle = useMemo(
 		() => ( {
-			backgroundColor: backgroundColor?.color || defaultBackgroundColor?.color,
+			backgroundColor:
+				backgroundColor?.color || defaultBackgroundColor?.color,
 			color: textColor?.color || defaultTextColor?.color,
 		} ),
-		[ textColor, backgroundColor ]
+		[ backgroundColor, defaultBackgroundColor, defaultTextColor, textColor ]
 	);
 
 	if ( 'course' !== postType ) {

--- a/assets/blocks/course-categories-block/course-categories-edit.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.js
@@ -8,6 +8,7 @@ import { unescape } from 'lodash';
  * WordPress dependencies
  */
 import { useBlockProps } from '@wordpress/block-editor';
+import { useMemo } from '@wordpress/element';
 import { Spinner } from '@wordpress/components';
 import { compose } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -15,7 +16,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { useMemo } from 'react';
 import useCourseCategories from './hooks/use-course-categories';
 import InvalidUsageError from '../../shared/components/invalid-usage';
 

--- a/assets/blocks/course-categories-block/course-categories-edit.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.js
@@ -63,23 +63,21 @@ export function CourseCategoryEdit( props ) {
 	}
 
 	return (
-		<>
-			<div { ...blockProps }>
-				{ isLoading && <Spinner /> }
-				{ ! isLoading &&
-					hasCategories &&
-					categories.map( ( category ) => (
-						<a
-							key={ category.id }
-							href={ category.link }
-							onClick={ ( event ) => event.preventDefault() }
-							style={ inlineStyle }
-						>
-							{ unescape( category.name ) }
-						</a>
-					) ) }
-			</div>
-		</>
+		<div { ...blockProps }>
+			{ isLoading && <Spinner /> }
+			{ ! isLoading &&
+				hasCategories &&
+				categories.map( ( category ) => (
+					<a
+						key={ category.id }
+						href={ category.link }
+						onClick={ ( event ) => event.preventDefault() }
+						style={ inlineStyle }
+					>
+						{ unescape( category.name ) }
+					</a>
+				) ) }
+		</div>
 	);
 }
 

--- a/assets/blocks/course-categories-block/course-categories-edit.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.js
@@ -25,7 +25,14 @@ import {
 } from '../../shared/blocks/settings';
 
 export function CourseCategoryEdit( props ) {
-	const { context, attributes, textColor, backgroundColor } = props;
+	const {
+		attributes,
+		backgroundColor,
+		context,
+		defaultBackgroundColor,
+		defaultTextColor,
+		textColor,
+	} = props;
 	const { textAlign } = attributes;
 	const { postId, postType } = context;
 	const term = 'course-category';
@@ -45,8 +52,8 @@ export function CourseCategoryEdit( props ) {
 
 	const inlineStyle = useMemo(
 		() => ( {
-			color: textColor?.color,
-			backgroundColor: backgroundColor?.color,
+			backgroundColor: backgroundColor?.color || defaultBackgroundColor?.color,
+			color: textColor?.color || defaultTextColor?.color,
 		} ),
 		[ textColor, backgroundColor ]
 	);

--- a/assets/blocks/course-categories-block/course-categories.scss
+++ b/assets/blocks/course-categories-block/course-categories.scss
@@ -1,18 +1,20 @@
 .wp-block-sensei-lms-course-categories {
 	width: 100%;
+
 	> a {
 		display: inline-flex;
-
 		padding: 3px 6px;
 		text-decoration: none;
 		border-radius: 2px;
 		margin-right: 8px;
 		margin-bottom: 8px;
-		word-wrap: none;
+		white-space: nowrap;
 	}
+
 	&.alignright{
 		text-align: right;
 	}
+
 	&.aligncenter{
 		text-align: center;
 	}

--- a/tests/unit-tests/blocks/test-class-sensei-course-categories-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-categories-block.php
@@ -35,7 +35,7 @@ class Sensei_Course_Categories_Block_Test extends WP_UnitTestCase {
 	/**
 	 * Block content.
 	 */
-	const CONTENT = '<!-- wp:sensei-lms/course-categories {"align":"center","categoryStyle":{"classes":[],"style":{}},"textColor":"secondary","backgroundColor":"background","style":{"spacing":{"margin":{"top":"10px","right":"0","bottom":"10px","left":"0"}}}} /-->';
+	const CONTENT = '<!-- wp:sensei-lms/course-categories {"align":"center","textColor":"secondary","backgroundColor":"background"} /-->';
 
 	/**
 	 * Set up the test.


### PR DESCRIPTION
### Changes proposed in this Pull Request
- Switch to using `useMemo` from WordPress' library
- Remove an unnecessary wrapper element from the block
- Remove the unused `categoryStyle` attribute
- Remove the `style` attribute as margin is already being set in `course-categories.scss`
- Fixes an invalid CSS property
- Uses the default colors, if applicable

### Testing instructions
Add the Course Categories block to the Course List block and ensure you can update and save its settings as before. Ensure the block renders fine on the frontend.