### PR TITLE
Show Course Categories preview 

### DIFF
--- a/assets/blocks/course-categories-block/block.json
+++ b/assets/blocks/course-categories-block/block.json
@@ -26,8 +26,7 @@
 			"default": "small"
 		},
         "previewCategories": {
-            "type": "array",
-            "default": []
+            "type": "array"
         }
 	},
 	"usesContext": [ "postId", "postType" ],

--- a/assets/blocks/course-categories-block/block.json
+++ b/assets/blocks/course-categories-block/block.json
@@ -24,7 +24,11 @@
 		"fontSize": {
 			"type": "string",
 			"default": "small"
-		}
+		},
+        "previewCategories": {
+            "type": "array",
+            "default": []
+        }
 	},
 	"usesContext": [ "postId", "postType" ],
 	"supports": {

--- a/assets/blocks/course-categories-block/course-categories-edit.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.js
@@ -73,7 +73,9 @@ export function CourseCategoryEdit( props ) {
 	};
 
 	if ( previewCategories ) {
-		return getCategories( previewCategories );
+		return (
+			<div { ...blockProps }>{ getCategories( previewCategories ) }</div>
+		);
 	}
 
 	if ( 'course' !== postType ) {

--- a/assets/blocks/course-categories-block/course-categories-edit.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.js
@@ -33,10 +33,10 @@ export function CourseCategoryEdit( props ) {
 		defaultTextColor,
 		textColor,
 	} = props;
-	const { textAlign } = attributes;
+
+	const { textAlign, previewCategories } = attributes;
 	const { postId, postType } = context;
 	const term = 'course-category';
-
 	const {
 		postTerms: categories,
 		hasPostTerms: hasCategories,
@@ -59,6 +59,23 @@ export function CourseCategoryEdit( props ) {
 		[ backgroundColor, defaultBackgroundColor, defaultTextColor, textColor ]
 	);
 
+	const getCategories = ( categoriesToDisplay ) => {
+		return categoriesToDisplay.map( ( category ) => (
+			<a
+				key={ category.id }
+				href={ category.link }
+				onClick={ ( event ) => event.preventDefault() }
+				style={ inlineStyle }
+			>
+				{ unescape( category.name ) }
+			</a>
+		) );
+	};
+
+	if ( previewCategories ) {
+		return getCategories( previewCategories );
+	}
+
 	if ( 'course' !== postType ) {
 		return (
 			<InvalidUsageError
@@ -73,18 +90,7 @@ export function CourseCategoryEdit( props ) {
 	return (
 		<div { ...blockProps }>
 			{ isLoading && <Spinner /> }
-			{ ! isLoading &&
-				hasCategories &&
-				categories.map( ( category ) => (
-					<a
-						key={ category.id }
-						href={ category.link }
-						onClick={ ( event ) => event.preventDefault() }
-						style={ inlineStyle }
-					>
-						{ unescape( category.name ) }
-					</a>
-				) ) }
+			{ ! isLoading && hasCategories && getCategories( categories ) }
 		</div>
 	);
 }

--- a/assets/blocks/course-categories-block/index.js
+++ b/assets/blocks/course-categories-block/index.js
@@ -19,6 +19,20 @@ export default {
 		__( 'Lessons', 'sensei-lms' ),
 		__( 'Categories', 'sensei-lms' ),
 	],
+	example: {
+		attributes: {
+			previewCategories: [
+				{
+					id: 1,
+					name: __( 'Music', 'sensei-lms' ),
+				},
+				{
+					id: 2,
+					name: __( 'Movies', 'sensei-lms' ),
+				},
+			],
+		},
+	},
 	icon,
 	edit,
 };


### PR DESCRIPTION
Fixes #5509

### Changes proposed in this Pull Request
- When hovering over course categories display preview
- Here is a nice read about the preview: https://mediaron.com/how-to-enable-gutenberg-block-previews/
## Important information

- Without including `previewCategories` **example attributes** preview would just display 
<img width="330" alt="image" src="https://user-images.githubusercontent.com/7208249/186404584-f4559153-82bd-4256-a937-d1ce492e7901.png">

- There is no other way to have a preview of categories, except to pass some fake categories to preview

<img width="310" alt="image" src="https://user-images.githubusercontent.com/7208249/186405324-440a8e30-0d06-4e50-8c5d-7db897729aeb.png">

- Note that preview for ALL blocks is only on the main block add and not on the in-page adding
<img width="432" alt="image" src="https://user-images.githubusercontent.com/7208249/186406105-b4a398f8-4ba4-46e4-8c55-75c0482242aa.png">
<img width="759" alt="image" src="https://user-images.githubusercontent.com/7208249/186406289-419a8523-d0bd-4205-b79b-d06a6304757c.png">


### Testing instructions
- Go to **new page** or **edit page** and try adding a new block 
- Search for Course Categories
- Hower over Course Categories 
- You should see  
<img width="310" alt="image" src="https://user-images.githubusercontent.com/7208249/186405324-440a8e30-0d06-4e50-8c5d-7db897729aeb.png">


Here is the video 

https://user-images.githubusercontent.com/7208249/186405964-35d84e66-8d78-4056-b083-25d0cbf55cc1.mov


