### PR TITLE
Hide both grid and carousel buttons on patterns selection

### DIFF
--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -161,10 +161,12 @@ const hideCourseListPatternsCarouselViewControl = () => {
 	const controls = document.querySelectorAll( `${ patternsControlClass }` );
 	controls.forEach( ( control ) => {
 		const controlButtons = control.querySelectorAll( 'button' );
-		// Hide carousel pattern view button.
-		controlButtons[ 0 ].style.display = 'none';
-		// Select Grid view button.
+		// Select Grid view.
 		controlButtons[ 1 ].click();
+
+		// Hide all control buttons.
+		controlButtons[ 0 ].style.display = 'none';
+		controlButtons[ 1 ].style.display = 'none';
 	} );
 };
 

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -165,8 +165,9 @@ const hideCourseListPatternsCarouselViewControl = () => {
 		controlButtons[ 1 ].click();
 
 		// Hide all control buttons.
-		controlButtons[ 0 ].style.display = 'none';
-		controlButtons[ 1 ].style.display = 'none';
+		controlButtons.forEach( ( button ) => {
+			button.style.display = 'none';
+		} );
 	} );
 };
 


### PR DESCRIPTION
Fixes #5518

### Changes proposed in this Pull Request
- Hide Grid button on the patterns selection for course list

### Testing instructions
**Main flow:** 
- Go to the page creation/ page edit
- Try adding new Course List
- Make sure that no controls are displayed under the patterns
- Make sure that the same behavior is displayed when you click  **Replace** button on the Course List

**Additional checks:**
- Make sure that it works when adding multiple course lists
- Make sure Query Loop is not affected by the change 

https://user-images.githubusercontent.com/7208249/186156488-fc387c24-a680-4908-b15a-431ae70b0ffa.mov


