### PR TITLE
Address styling issues in Course List block

### DIFF
--- a/assets/blocks/course-categories-block/course-categories.scss
+++ b/assets/blocks/course-categories-block/course-categories.scss
@@ -1,4 +1,5 @@
 .wp-block-sensei-lms-course-categories {
+	margin: 10px 0;
 	width: 100%;
 
 	> a {
@@ -6,9 +7,12 @@
 		padding: 3px 6px;
 		text-decoration: none;
 		border-radius: 2px;
-		margin-right: 8px;
-		margin-bottom: 8px;
+		margin: 0;
 		white-space: nowrap;
+
+		&:not(:last-child) {
+			margin-right: 10px;
+		}
 	}
 
 	&.alignright{

--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -1,0 +1,5 @@
+.sensei-lms-course-list-block {
+	.wp-block-post-title {
+		text-align: left;
+	}
+}

--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -1,4 +1,4 @@
-.sensei-lms-course-list-block {
+.wp-block-sensei-lms-course-list {
 	.wp-block-post-title {
 		text-align: left;
 	}

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -10,7 +10,7 @@ import { Fragment } from '@wordpress/element';
 
 export const registerCourseListBlock = () => {
 	const DEFAULT_ATTRIBUTES = {
-		className: 'sensei-lms-course-list-block',
+		className: 'wp-block-sensei-lms-course-list',
 		query: {
 			perPage: 3,
 			pages: 0,
@@ -73,7 +73,7 @@ const observeAndRemoveSettingsFromPanel = ( blockSettingsPanel ) => {
 		const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
 		if (
 			'core/query' === selectedBlock?.name &&
-			'sensei-lms-course-list-block' === selectedBlock?.attributes?.className
+			'wp-block-sensei-lms-course-list' === selectedBlock?.attributes?.className
 		) {
 			hideUnnecessarySettingsForCourseList();
 		}
@@ -125,7 +125,7 @@ const withQueryLoopPatternsHiddenForCourseList = ( BlockEdit ) => {
 		const isQueryLoopBlock = 'core/query' === props.name;
 		const isCourseListBlock =
 			isQueryLoopBlock &&
-			'sensei-lms-course-list-block' === props.attributes.className;
+			'wp-block-sensei-lms-course-list' === props.attributes.className;
 
 		if ( isCourseListBlock && props.isSelected ) {
 			isCourseListBlockSelected = true;

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -73,7 +73,8 @@ const observeAndRemoveSettingsFromPanel = ( blockSettingsPanel ) => {
 		const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
 		if (
 			'core/query' === selectedBlock?.name &&
-			'wp-block-sensei-lms-course-list' === selectedBlock?.attributes?.className
+			'wp-block-sensei-lms-course-list' ===
+				selectedBlock?.attributes?.className
 		) {
 			hideUnnecessarySettingsForCourseList();
 		}

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -10,7 +10,7 @@ import { Fragment } from '@wordpress/element';
 
 export const registerCourseListBlock = () => {
 	const DEFAULT_ATTRIBUTES = {
-		className: 'course-list-block',
+		className: 'sensei-lms-course-list-block',
 		query: {
 			perPage: 3,
 			pages: 0,
@@ -73,7 +73,7 @@ const observeAndRemoveSettingsFromPanel = ( blockSettingsPanel ) => {
 		const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
 		if (
 			'core/query' === selectedBlock?.name &&
-			'course-list-block' === selectedBlock?.attributes?.className
+			'sensei-lms-course-list-block' === selectedBlock?.attributes?.className
 		) {
 			hideUnnecessarySettingsForCourseList();
 		}
@@ -125,7 +125,7 @@ const withQueryLoopPatternsHiddenForCourseList = ( BlockEdit ) => {
 		const isQueryLoopBlock = 'core/query' === props.name;
 		const isCourseListBlock =
 			isQueryLoopBlock &&
-			'course-list-block' === props.attributes.className;
+			'sensei-lms-course-list-block' === props.attributes.className;
 
 		if ( isCourseListBlock && props.isSelected ) {
 			isCourseListBlockSelected = true;

--- a/assets/blocks/global-blocks-style.scss
+++ b/assets/blocks/global-blocks-style.scss
@@ -1,3 +1,4 @@
-@import 'course-progress-block/course-progress';
 @import 'button/button';
 @import 'course-categories-block/course-categories';
+@import 'course-list-block/course-list';
+@import 'course-progress-block/course-progress';

--- a/assets/shared/blocks/progress-bar/progress-bar-settings.scss
+++ b/assets/shared/blocks/progress-bar/progress-bar-settings.scss
@@ -7,3 +7,7 @@
 		max-width: 100%;
 	}
 }
+
+.editor-styles-wrapper .wp-block-sensei-lms-course-progress {
+	margin: 10px 0;
+}

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -55,7 +55,7 @@ class Sensei_Course_List_Block_Patterns {
 				'blockTypes'  => array( 'core/query' ),
 				'description' => 'course-list-element',
 				'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
-						<div class="wp-block-query course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query sensei-lms-course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
 						<!-- wp:sensei-lms/course-categories {"textColor":"background","backgroundColor":"accent"} /-->
@@ -76,7 +76,7 @@ class Sensei_Course_List_Block_Patterns {
 					'blockTypes'  => array( 'core/query' ),
 					'description' => 'course-list-element',
 					'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
-						<div class="wp-block-query course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query sensei-lms-course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
 						<!-- wp:sensei-lms/course-categories {"textColor":"background","backgroundColor":"accent"} /-->
@@ -91,7 +91,7 @@ class Sensei_Course_List_Block_Patterns {
 					'blockTypes'  => array( 'core/query' ),
 					'description' => 'course-list-element',
 					'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
-						<div class="wp-block-query course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query sensei-lms-course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
 						<!-- wp:sensei-lms/course-categories {"textColor":"background","backgroundColor":"accent"} /-->
@@ -108,7 +108,7 @@ class Sensei_Course_List_Block_Patterns {
 					'blockTypes'  => array( 'core/query' ),
 					'description' => 'course-list-element',
 					'content'     => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
-						<div class="wp-block-query course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query sensei-lms-course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 						<div class="wp-block-columns alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"30%","layout":{"inherit":false}} -->
 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%"><!-- wp:post-featured-image {"isLink":true,"align":"center"} /--></div>
@@ -143,7 +143,7 @@ class Sensei_Course_List_Block_Patterns {
 					'blockTypes'  => array( 'core/query' ),
 					'description' => 'course-list-element',
 					'content'     => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
-						<div class="wp-block-query course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query sensei-lms-course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 						<div class="wp-block-columns alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"30%","layout":{"inherit":false}} -->
 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%"><!-- wp:post-featured-image {"isLink":true,"align":"center"} /--></div>
@@ -174,7 +174,7 @@ class Sensei_Course_List_Block_Patterns {
 					'blockTypes'  => array( 'core/query' ),
 					'description' => 'course-list-element',
 					'content'     => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
-						<div class="wp-block-query course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query sensei-lms-course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 						<div class="wp-block-columns alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"30%","layout":{"inherit":false}} -->
 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%"><!-- wp:post-featured-image {"isLink":true,"align":"center"} /--></div>

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -55,7 +55,7 @@ class Sensei_Course_List_Block_Patterns {
 				'blockTypes'  => array( 'core/query' ),
 				'description' => 'course-list-element',
 				'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
-						<div class="wp-block-query sensei-lms-course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
 						<!-- wp:sensei-lms/course-categories {"textColor":"background","backgroundColor":"accent"} /-->
@@ -76,7 +76,7 @@ class Sensei_Course_List_Block_Patterns {
 					'blockTypes'  => array( 'core/query' ),
 					'description' => 'course-list-element',
 					'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
-						<div class="wp-block-query sensei-lms-course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
 						<!-- wp:sensei-lms/course-categories {"textColor":"background","backgroundColor":"accent"} /-->
@@ -91,7 +91,7 @@ class Sensei_Course_List_Block_Patterns {
 					'blockTypes'  => array( 'core/query' ),
 					'description' => 'course-list-element',
 					'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
-						<div class="wp-block-query sensei-lms-course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
 						<!-- wp:sensei-lms/course-categories {"textColor":"background","backgroundColor":"accent"} /-->
@@ -108,7 +108,7 @@ class Sensei_Course_List_Block_Patterns {
 					'blockTypes'  => array( 'core/query' ),
 					'description' => 'course-list-element',
 					'content'     => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
-						<div class="wp-block-query sensei-lms-course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 						<div class="wp-block-columns alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"30%","layout":{"inherit":false}} -->
 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%"><!-- wp:post-featured-image {"isLink":true,"align":"center"} /--></div>
@@ -143,7 +143,7 @@ class Sensei_Course_List_Block_Patterns {
 					'blockTypes'  => array( 'core/query' ),
 					'description' => 'course-list-element',
 					'content'     => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
-						<div class="wp-block-query sensei-lms-course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 						<div class="wp-block-columns alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"30%","layout":{"inherit":false}} -->
 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%"><!-- wp:post-featured-image {"isLink":true,"align":"center"} /--></div>
@@ -174,7 +174,7 @@ class Sensei_Course_List_Block_Patterns {
 					'blockTypes'  => array( 'core/query' ),
 					'description' => 'course-list-element',
 					'content'     => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
-						<div class="wp-block-query sensei-lms-course-list-block alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 						<div class="wp-block-columns alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"30%","layout":{"inherit":false}} -->
 						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%"><!-- wp:post-featured-image {"isLink":true,"align":"center"} /--></div>


### PR DESCRIPTION
Fixes #5522.

### Changes proposed in this Pull Request
- Add consistent margins around course categories and course progress blocks
- Ensure the course name is left-aligned
- Update the CSS class name of the patterns to match our other blocks

### Testing instructions
Try the different patterns of the Course List block on different themes (I tried Twenty Twenty and Twenty Twenty Two). Ensure there's enough spacing between elements. Be sure to add a fresh Course List block, as the CSS classes have changed.

### Screenshot / Video

#### Twenty Twenty
![Screen Shot 2022-08-23 at 1 26 06 PM](https://user-images.githubusercontent.com/1190420/186225028-de95d0d7-292a-4e5f-be21-d66fed32c1e1.jpg)

#### Twenty Twenty Two
![2022 - Grid](https://user-images.githubusercontent.com/1190420/186224597-1012410b-eeb8-4462-8f2b-f9d2229e242f.jpg)