### PR TITLE
Fix pattern picker list view for course list patterns

### DIFF
--- a/assets/blocks/course-list-block/course-list-block-editor.scss
+++ b/assets/blocks/course-list-block/course-list-block-editor.scss
@@ -5,3 +5,11 @@
 		}
 	}
 }
+.block-editor-block-pattern-setup.view-mode-grid {
+	.block-editor-block-pattern-setup__grid {
+		.block-editor-block-pattern-setup__container.course-list-pattern-picker {
+			display: grid;
+			grid-template-columns: 32.5% 32.5% 32.5%;
+		}
+	}
+}

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -142,6 +142,7 @@ const withQueryLoopPatternsHiddenForCourseList = ( BlockEdit ) => {
 		) {
 			hideCourseListPatternsCarouselViewControl();
 			hideNonCourseListBlockPatternContainers();
+			addClassToPatternPickerContainerForCourseList();
 			return <Fragment />;
 		}
 		return <BlockEdit { ...props } />;
@@ -190,4 +191,13 @@ const hideNonCourseListBlockPatternContainers = () => {
 			pattern.style.display = 'none';
 		}
 	} );
+};
+
+const addClassToPatternPickerContainerForCourseList = () => {
+	const patternPickerContainer = document.querySelector(
+		'.block-editor-block-pattern-setup__container'
+	);
+	if ( patternPickerContainer ) {
+		patternPickerContainer.classList.add( 'course-list-pattern-picker' );
+	}
 };

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -50,11 +50,12 @@ class Sensei_Course_List_Block_Patterns {
 		$patterns = [
 			'course-list-columns'             =>
 			[
-				'title'       => __( 'Grid of courses with details', 'sensei-lms' ),
-				'categories'  => array( 'query' ),
-				'blockTypes'  => array( 'core/query' ),
-				'description' => 'course-list-element',
-				'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
+				'title'         => __( 'Grid of courses with details', 'sensei-lms' ),
+				'categories'    => array( 'query' ),
+				'blockTypes'    => array( 'core/query' ),
+				'description'   => 'course-list-element',
+				'viewportWidth' => 800,
+				'content'       => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":3},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
@@ -71,11 +72,12 @@ class Sensei_Course_List_Block_Patterns {
 			],
 			'course-list-columns-title'       =>
 				[
-					'title'       => __( 'Grid of courses with title', 'sensei-lms' ),
-					'categories'  => array( 'query' ),
-					'blockTypes'  => array( 'core/query' ),
-					'description' => 'course-list-element',
-					'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
+					'title'         => __( 'Grid of courses with title', 'sensei-lms' ),
+					'categories'    => array( 'query' ),
+					'blockTypes'    => array( 'core/query' ),
+					'description'   => 'course-list-element',
+					'viewportWidth' => 800,
+					'content'       => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":2},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
@@ -86,11 +88,12 @@ class Sensei_Course_List_Block_Patterns {
 				],
 			'course-list-columns-description' =>
 				[
-					'title'       => __( 'Grid of courses with title and description', 'sensei-lms' ),
-					'categories'  => array( 'query' ),
-					'blockTypes'  => array( 'core/query' ),
-					'description' => 'course-list-element',
-					'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
+					'title'         => __( 'Grid of courses with title and description', 'sensei-lms' ),
+					'categories'    => array( 'query' ),
+					'blockTypes'    => array( 'core/query' ),
+					'description'   => 'course-list-element',
+					'viewportWidth' => 800,
+					'content'       => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":3},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
@@ -103,11 +106,12 @@ class Sensei_Course_List_Block_Patterns {
 				],
 			'course-list'                     =>
 				[
-					'title'       => __( 'List of courses', 'sensei-lms' ),
-					'categories'  => array( 'query' ),
-					'blockTypes'  => array( 'core/query' ),
-					'description' => 'course-list-element',
-					'content'     => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
+					'title'         => __( 'List of courses', 'sensei-lms' ),
+					'categories'    => array( 'query' ),
+					'blockTypes'    => array( 'core/query' ),
+					'description'   => 'course-list-element',
+					'viewportWidth' => 800,
+					'content'       => '<!-- wp:query {"query":{"perPage":2,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
 						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 						<div class="wp-block-columns alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"30%","layout":{"inherit":false}} -->
@@ -138,11 +142,12 @@ class Sensei_Course_List_Block_Patterns {
 				],
 			'course-list-title'               =>
 				[
-					'title'       => __( 'List of courses with title', 'sensei-lms' ),
-					'categories'  => array( 'query' ),
-					'blockTypes'  => array( 'core/query' ),
-					'description' => 'course-list-element',
-					'content'     => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
+					'title'         => __( 'List of courses with title', 'sensei-lms' ),
+					'categories'    => array( 'query' ),
+					'blockTypes'    => array( 'core/query' ),
+					'description'   => 'course-list-element',
+					'viewportWidth' => 800,
+					'content'       => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
 						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 						<div class="wp-block-columns alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"30%","layout":{"inherit":false}} -->
@@ -169,11 +174,12 @@ class Sensei_Course_List_Block_Patterns {
 				],
 			'course-list-description'         =>
 				[
-					'title'       => __( 'List of courses with title and description', 'sensei-lms' ),
-					'categories'  => array( 'query' ),
-					'blockTypes'  => array( 'core/query' ),
-					'description' => 'course-list-element',
-					'content'     => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
+					'title'         => __( 'List of courses with title and description', 'sensei-lms' ),
+					'categories'    => array( 'query' ),
+					'blockTypes'    => array( 'core/query' ),
+					'description'   => 'course-list-element',
+					'viewportWidth' => 800,
+					'content'       => '<!-- wp:query {"query":{"perPage":2,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
 						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
 						<!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 						<div class="wp-block-columns alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"30%","layout":{"inherit":false}} -->


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/5520

### Changes proposed in this Pull Request

* When we loaded the patterns in the pattern picker, they didn't look very nice because of loading haphazardly all over with different sizes, here we've organized it.

### Testing instructions

- Add a Course List block
- Open the pattern picker
- Make sure they appear in two separated rows, closer to our design
- Add a Query Loop block
- Make sure nothing has changed for its patterns

### Screenshot / Video
### Before


https://user-images.githubusercontent.com/6820724/186264682-d325760a-e2c0-47ac-a64f-0fc1fc706b9a.mov

### After

https://user-images.githubusercontent.com/6820724/186264515-fef90546-b373-4c1f-bb46-1da3bb81df4d.mov