### PR TITLE
Align course list block items to bottom

### DIFF
--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -1,4 +1,7 @@
 .wp-block-sensei-lms-course-list {
+	.wp-sensei-block-align-end {
+		align-items: end;
+	}
 	.wp-block-post-title {
 		text-align: left;
 	}

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -55,7 +55,7 @@ class Sensei_Course_List_Block_Patterns {
 				'blockTypes'  => array( 'core/query' ),
 				'description' => 'course-list-element',
 				'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
-						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide","className":"wp-sensei-block-align-end"} -->
 						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
 						<!-- wp:sensei-lms/course-categories {"textColor":"background","backgroundColor":"accent"} /-->
@@ -76,7 +76,7 @@ class Sensei_Course_List_Block_Patterns {
 					'blockTypes'  => array( 'core/query' ),
 					'description' => 'course-list-element',
 					'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
-						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide","className":"wp-sensei-block-align-end"} -->
 						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
 						<!-- wp:sensei-lms/course-categories {"textColor":"background","backgroundColor":"accent"} /-->
@@ -91,7 +91,7 @@ class Sensei_Course_List_Block_Patterns {
 					'blockTypes'  => array( 'core/query' ),
 					'description' => 'course-list-element',
 					'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
-						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
+						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide","className":"wp-sensei-block-align-end"} -->
 						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
 
 						<!-- wp:sensei-lms/course-categories {"textColor":"background","backgroundColor":"accent"} /-->


### PR DESCRIPTION
Fixes https://github.com/Automattic/sensei/issues/5529

### Changes proposed in this Pull Request

* Made the inner blocks of the Courses shown in the Course List block in the three grid patterns align to the bottom.

### Testing instructions

- Add a Course List block to a page
- Select one of the three greed style patterns
- Save and load the page in the frontend
- Make sure all the courses are shown in the block as bottom aligned

### Screenshot / Video

### Before

![Image](https://user-images.githubusercontent.com/6820724/186272576-4577dc41-b2a0-4c55-958c-760c2a85f344.png)

### After

![Image](https://user-images.githubusercontent.com/6820724/186272601-b6708226-c16c-47bc-85ea-2cea09936918.png)