### PR TITLE
Remove block align to avoid error message have different width

### DIFF
--- a/assets/blocks/course-categories-block/block.json
+++ b/assets/blocks/course-categories-block/block.json
@@ -35,6 +35,7 @@
 			"blockGap": true
 		},
 		"textAlign": true,
+        "align": true,
 		"alignWide": true,
 		"typography": {
 			"lineHeight": true,

--- a/assets/blocks/course-categories-block/block.json
+++ b/assets/blocks/course-categories-block/block.json
@@ -35,7 +35,6 @@
 			"blockGap": true
 		},
 		"textAlign": true,
-		"align": true,
 		"alignWide": true,
 		"typography": {
 			"lineHeight": true,

--- a/assets/blocks/course-categories-block/course-categories-edit.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.js
@@ -32,6 +32,7 @@ export function CourseCategoryEdit( props ) {
 		defaultBackgroundColor,
 		defaultTextColor,
 		textColor,
+		setAttributes,
 	} = props;
 	const { textAlign } = attributes;
 	const { postId, postType } = context;
@@ -60,6 +61,7 @@ export function CourseCategoryEdit( props ) {
 	);
 
 	if ( 'course' !== postType ) {
+		setAttributes( { align: false } );
 		return (
 			<InvalidUsageError
 				message={ __(

--- a/assets/blocks/course-categories-block/course-categories-edit.test.js
+++ b/assets/blocks/course-categories-block/course-categories-edit.test.js
@@ -61,6 +61,7 @@ describe( 'CourseCategoryEdit', () => {
 				clientId="some-client-id"
 				attributes={ attributes }
 				context={ context }
+				setAttributes={ () => {} }
 			/>
 		);
 		categories.forEach( ( category ) =>
@@ -77,6 +78,7 @@ describe( 'CourseCategoryEdit', () => {
 					postId: 'some-post-id',
 					postType: 'page',
 				} }
+				setAttributes={ () => {} }
 			/>
 		);
 


### PR DESCRIPTION
Fixes #5517

### Changes proposed in this Pull Request
- remove `align: true` from block settings 
- this parameter adds a wp-block wrapper around the block with alignment, this block dictates the width of the block so it looks weird compared to other blocks like **Course Actions** they don't have that
<img width="277" alt="Screenshot 2022-08-25 at 13 51 09" src="https://user-images.githubusercontent.com/7208249/186659773-69ccb07a-f2dc-4dd1-810b-20836dd63023.png">
<img width="912" alt="Screenshot 2022-08-25 at 13 50 27" src="https://user-images.githubusercontent.com/7208249/186659795-7a0f450f-789f-49e5-9b0d-434b8e8a5a37.png">

- Here is some Github discussion on the topic: [here](https://github.com/WordPress/gutenberg/issues/33142) and 
[here](https://github.com/WordPress/gutenberg/pull/23089)
- This change doesn't affect how the categories are displayed on the course list

| Before | After |
| --- | --- |
| <img width="583" alt="Screenshot 2022-08-25 at 14 03 15" src="https://user-images.githubusercontent.com/7208249/186659535-d7746792-caa9-482b-a492-07b406f6ab93.png"> | <img width="526" alt="image" src="https://user-images.githubusercontent.com/7208249/186659484-4b88d928-3b60-4cab-9e31-d5b109d77c2e.png"> |
| <img width="912" alt="Screenshot 2022-08-25 at 13 50 27" src="https://user-images.githubusercontent.com/7208249/186660112-4ccabc43-f296-43d2-99f3-70a0fb844ca8.png"> | <img width="938" alt="image" src="https://user-images.githubusercontent.com/7208249/186659965-29254053-ec8a-4a1e-bb07-4f54fd7b7f7f.png"> |




### Testing instructions
