### PR TITLE
Fix fatal error in Jetpack REST API endpoint

### DIFF
--- a/includes/class-sensei.php
+++ b/includes/class-sensei.php
@@ -433,13 +433,13 @@ class Sensei_Main {
 		// Editor Wizard.
 		Sensei_Editor_Wizard::instance()->init();
 
+		// Load Analysis Reports.
+		$this->analysis = new Sensei_Analysis( $this->main_plugin_file_name );
+
 		// Differentiate between administration and frontend logic.
 		if ( is_admin() ) {
-			// Load Admin Class
+			// Load Admin Class.
 			$this->admin = new Sensei_Admin();
-
-			// Load Analysis Reports
-			$this->analysis = new Sensei_Analysis( $this->main_plugin_file_name );
 
 			new Sensei_Import();
 			new Sensei_Export();


### PR DESCRIPTION
Fixes #5534

### Changes proposed in this Pull Request

* Load `Sensei_Analysis` class when not in admin. This is to prevent fatals when building the `admin_menu` outside of the admin. Jetpack does this in a REST API handler to reproduce the menu in Calypso. 
* It looks like the constructor for `Sensei_Analysis` does the `is_admin()` check as well so this shouldn't have side effects. 

### Testing instructions
On an Atomic site:
- SSH in and enable logging and debugging constants in `wp-config.php`:
```php
defined('WP_DEBUG') || define( 'WP_DEBUG', true );
defined('WP_DEBUG_LOG') || define( 'WP_DEBUG_LOG', true );
```
- Connect Jetpack to your WordPress.com account. Don't worry about signing up for a plan. 
- Install a build from this PR ([sensei-lms-pr-5548.zip](https://github.com/Automattic/sensei/files/9426081/sensei-lms-pr-5548.zip)).
- Go into WordPress.com and manage the site.
- From your SSH terminal, check your `~/htdocs/wp-content/debug.log` file and make sure no fatal errors show up.