### PR TITLE
Refactor Video Extensions to compute video URL without relying on JS APIs

### DIFF
--- a/assets/js/frontend/course-video/vimeo-extension.js
+++ b/assets/js/frontend/course-video/vimeo-extension.js
@@ -12,21 +12,19 @@ import Player from '../../../shared/helpers/player';
 const initVimeoPlayer = ( iframe ) => {
 	const player = new Player( iframe );
 
-	player
-		.getPlayer()
-		.then( ( nativeVimeoPlayer ) => nativeVimeoPlayer.getVideoUrl() )
-		.then( ( url ) => {
-			registerVideo( {
-				pauseVideo: () => {
-					player.pause();
-				},
-				registerVideoEndHandler: ( cb ) => {
-					player.on( 'ended', cb );
-				},
-				url,
-				blockElement: iframe.closest( 'figure' ),
-			} );
-		} );
+	const videoId = iframe.src.split( '?' )[ 0 ].split( '/' ).pop();
+	const url = 'https://vimeo.com/' + videoId;
+
+	registerVideo( {
+		pauseVideo: () => {
+			player.pause();
+		},
+		registerVideoEndHandler: ( cb ) => {
+			player.on( 'ended', cb );
+		},
+		url,
+		blockElement: iframe.closest( 'figure' ),
+	} );
 };
 
 export const initVimeoExtension = () => {

--- a/assets/js/frontend/course-video/vimeo-extension.js
+++ b/assets/js/frontend/course-video/vimeo-extension.js
@@ -12,7 +12,11 @@ import Player from '../../../shared/helpers/player';
 const initVimeoPlayer = ( iframe ) => {
 	const player = new Player( iframe );
 
+	// iframe.src should be in the format:
+	// https://player.vimeo.com/video/VIDEO_ID?other-query-parameters=and-their-values
 	const videoId = iframe.src.split( '?' )[ 0 ].split( '/' ).pop();
+	// We compute the URL like this to allow backward compatibility with the value returned from
+	// nativeVimeoPlayer.getVideoUrl() - so we just add the videoId to the prefix used by Vimeo for videos.
 	const url = 'https://vimeo.com/' + videoId;
 
 	registerVideo( {

--- a/assets/js/frontend/course-video/youtube-extension.js
+++ b/assets/js/frontend/course-video/youtube-extension.js
@@ -12,17 +12,18 @@ import Player from '../../../shared/helpers/player';
 const initYouTubePlayer = ( iframe ) => {
 	const player = new Player( iframe );
 
-	player.getPlayer().then( ( nativeYoutubePlayer ) => {
-		registerVideo( {
-			pauseVideo: () => {
-				player.pause();
-			},
-			registerVideoEndHandler: ( cb ) => {
-				player.on( 'ended', cb );
-			},
-			url: nativeYoutubePlayer.getVideoUrl(),
-			blockElement: iframe.closest( 'figure' ),
-		} );
+	const videoId = iframe.src.split( '?' )[ 0 ].split( '/' ).pop();
+	const url = 'https://www.youtube.com/watch?v=' + videoId;
+
+	registerVideo( {
+		pauseVideo: () => {
+			player.pause();
+		},
+		registerVideoEndHandler: ( cb ) => {
+			player.on( 'ended', cb );
+		},
+		url,
+		blockElement: iframe.closest( 'figure' ),
 	} );
 };
 

--- a/assets/js/frontend/course-video/youtube-extension.js
+++ b/assets/js/frontend/course-video/youtube-extension.js
@@ -12,7 +12,11 @@ import Player from '../../../shared/helpers/player';
 const initYouTubePlayer = ( iframe ) => {
 	const player = new Player( iframe );
 
+	// iframe.src should be in the format:
+	// https://www.youtube.com/embed/VIDEO_ID?other-query-parameters=and-their-values&origin=https://example.com
 	const videoId = iframe.src.split( '?' )[ 0 ].split( '/' ).pop();
+	// We compute the URL like this to allow backward compatibility with the value returned from
+	// nativeYoutubePlayer.getVideoUrl() - so we just add the videoId to the prefix used by YouTube for videos.
 	const url = 'https://www.youtube.com/watch?v=' + videoId;
 
 	registerVideo( {


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Refactor YouTube extension to compute video URL without relying on YouTube Iframe API;
* Refactor Vimeo extension to compute video URL without relying on Vimeo Player API;

### Testing instructions

In a WP installation with Sensei LMS (on this branch) and Sensei Pro:

1. On Sensei Pro, remove the prop `ref` added by the commit `c4b04616539cb066d1c90312d3a9553927b51795` (or just reverts the commit altogether, but temporarily, please);
2. Follow the testing instructions on this PR and verify that this PR stills allows the code to work:  1764-gh-Automattic/sensei-pro
3. To be more precise, verify that this problem does not occur: 1764-gh-Automattic/sensei-pro#issuecomment-1227271794
