### PR TITLE
Simplify Course List block patterns and ensure they look good on Divi

### DIFF
--- a/assets/blocks/course-list-block/course-list-block-editor.scss
+++ b/assets/blocks/course-list-block/course-list-block-editor.scss
@@ -3,8 +3,5 @@
 		.components-button.is-secondary {
 			display: none;
 		}
-		.hide-url-underline > a {
-			text-decoration: none;
-		}
 	}
 }

--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -30,3 +30,12 @@ $block: '.wp-block-sensei-lms-course-list';
 		}
 	}
 }
+
+/* Divi overrides */
+#left-area #{$block} {
+	.wp-block-post-template {
+		list-style: none;
+		margin-left: 0;
+		padding: 1.25em;
+	}
+}

--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -1,8 +1,32 @@
-.wp-block-sensei-lms-course-list {
-	.wp-block-post-title {
-		text-align: left;
+$block: '.wp-block-sensei-lms-course-list';
+
+// Match styles applied to block on single course page.
+#{$block} {
+	.course {
+		border: 0;
+		margin: 0 0 1.618em;
+		padding: 0 0 25px;
 	}
-	.hide-url-underline > a  {
-		text-decoration: none;
+
+	.wp-block-post-featured-image {
+		margin: 0 auto 1.618em;
+	}
+
+	@media ( min-width: 782px ) {
+		&--is-list-view {
+			.wp-block-sensei-lms-button-take-course,
+			.wp-block-sensei-lms-button-continue-course,
+			.wp-block-sensei-lms-button-view-results {
+				text-align: right;
+			}
+		}
+	}
+
+	@media ( max-width: 599px ) {
+		&--is-grid-view {
+			.wp-block-post-template.is-flex-container li.course {
+				width: 100%;
+			}
+		}
 	}
 }

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -70,10 +70,12 @@ const observeAndRemoveSettingsFromPanel = ( blockSettingsPanel ) => {
 	// eslint-disable-next-line no-undef
 	const observer = new MutationObserver( () => {
 		const selectedBlock = select( 'core/block-editor' ).getSelectedBlock();
+
 		if (
 			'core/query' === selectedBlock?.name &&
-			'wp-block-sensei-lms-course-list' ===
-				selectedBlock?.attributes?.className
+			selectedBlock?.attributes?.className?.includes(
+				'wp-block-sensei-lms-course-list'
+			)
 		) {
 			hideUnnecessarySettingsForCourseList();
 		}
@@ -125,7 +127,9 @@ const withQueryLoopPatternsHiddenForCourseList = ( BlockEdit ) => {
 		const isQueryLoopBlock = 'core/query' === props.name;
 		const isCourseListBlock =
 			isQueryLoopBlock &&
-			'wp-block-sensei-lms-course-list' === props.attributes.className;
+			props?.attributes?.className?.includes(
+				'wp-block-sensei-lms-course-list'
+			);
 
 		if ( isCourseListBlock && props.isSelected ) {
 			isCourseListBlockSelected = true;

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -6,7 +6,6 @@ import { registerBlockVariation } from '@wordpress/blocks';
 import { list } from '@wordpress/icons';
 import { select, subscribe } from '@wordpress/data';
 import { addFilter } from '@wordpress/hooks';
-import { Fragment } from '@wordpress/element';
 
 export const registerCourseListBlock = () => {
 	const DEFAULT_ATTRIBUTES = {

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -142,8 +142,8 @@ const withQueryLoopPatternsHiddenForCourseList = ( BlockEdit ) => {
 		) {
 			hideCourseListPatternsCarouselViewControl();
 			hideNonCourseListBlockPatternContainers();
-			return <Fragment />;
 		}
+
 		return <BlockEdit { ...props } />;
 	};
 };

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -34,7 +34,7 @@ class Sensei_Course_List_Block_Patterns {
 			<!-- /wp:query-pagination -->';
 
 		$patterns = [
-			'course-list'             =>
+			'course-list' =>
 			[
 				'title'       => __( 'Courses displayed in a list', 'sensei-lms' ),
 				'categories'  => array( 'query' ),
@@ -85,7 +85,7 @@ class Sensei_Course_List_Block_Patterns {
 					'</div>
 				<!-- /wp:query -->',
 			],
-			'course-grid'                     =>
+			'course-grid' =>
 				[
 					'title'       => __( 'Courses displayed in a grid', 'sensei-lms' ),
 					'categories'  => array( 'query' ),

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -20,183 +20,115 @@ class Sensei_Course_List_Block_Patterns {
 	 * @access private
 	 */
 	public function register_course_list_block_patterns() {
-		$pagination = '<!-- wp:separator {"align":"wide","className":"is-style-wide"} -->
-						<hr class="wp-block-separator alignwide is-style-wide"/>
-						<!-- /wp:separator -->
+		$pagination =
+			'<!-- wp:separator {"align":"wide","className":"is-style-wide"} -->
+				<hr class="wp-block-separator alignwide is-style-wide"/>
+			<!-- /wp:separator -->
 
-						<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
-						<!-- wp:query-pagination-previous {"fontSize":"small"} /-->
+			<!-- wp:query-pagination {"paginationArrow":"arrow","align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
+				<!-- wp:query-pagination-previous {"fontSize":"small"} /-->
 
-						<!-- wp:query-pagination-numbers /-->
+				<!-- wp:query-pagination-numbers /-->
 
-						<!-- wp:query-pagination-next {"fontSize":"small"} /-->
-						<!-- /wp:query-pagination --></div>
-						<!-- /wp:query -->';
-
-		$course_action_button = '<!-- wp:sensei-lms/course-actions -->
-						<!-- wp:sensei-lms/button-take-course {"align":"full"} -->
-						<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><button class="wp-block-button__link">Start Course</button></div>
-						<!-- /wp:sensei-lms/button-take-course -->
-
-						<!-- wp:sensei-lms/button-continue-course {"align":"full"} -->
-						<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link">Continue</a></div>
-						<!-- /wp:sensei-lms/button-continue-course -->
-
-						<!-- wp:sensei-lms/button-view-results {"align":"full","className":"is-style-default"} -->
-						<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-full"><a class="wp-block-button__link">Visit Results</a></div>
-						<!-- /wp:sensei-lms/button-view-results -->
-						<!-- /wp:sensei-lms/course-actions -->';
+				<!-- wp:query-pagination-next {"fontSize":"small"} /-->
+			<!-- /wp:query-pagination -->';
 
 		$patterns = [
-			'course-list-columns'             =>
+			'course-list'             =>
 			[
-				'title'       => __( 'Grid of courses with details', 'sensei-lms' ),
+				'title'       => __( 'Courses displayed in a list', 'sensei-lms' ),
 				'categories'  => array( 'query' ),
 				'blockTypes'  => array( 'core/query' ),
 				'description' => 'course-list-element',
-				'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
-						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
-						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
+				'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":6},"displayLayout":{"type":"list"},"layout":{"inherit":true}} -->
+					<div class="wp-block-query wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list--is-list-view">
+						<!-- wp:post-template -->
+							<!-- wp:post-featured-image {"isLink":true,"align":"center"} /-->
+							<!-- wp:columns -->
+								<div class="wp-block-columns">
 
-						<!-- wp:sensei-lms/course-categories /-->
+									<!-- wp:column {"width":"66.66%"} -->
+										<div class="wp-block-column" style="flex-basis:66.66%">
+											<!-- wp:sensei-lms/course-categories /-->
 
-						<!-- wp:post-title {"level":1,"fontSize":"large","isLink":true,"className":"hide-url-underline"} /-->
+											<!-- wp:post-title {"textAlign":"left","isLink":true} /-->
 
-						<!-- wp:post-author /-->
+											<!-- wp:post-author {"textAlign":"left"} /-->
 
-						<!-- wp:post-excerpt {"fontSize":"medium"} /-->
+											<!-- wp:post-excerpt {"textAlign":"left"} /-->
 
-						<!-- wp:sensei-lms/course-progress {"defaultBarColor":"primary"} /-->' . $course_action_button . '
-						<!-- /wp:post-template -->' . $pagination,
+											<!-- wp:sensei-lms/course-progress /-->
+										</div>
+									<!-- /wp:column -->
+
+									<!-- wp:column {"width":"33.33%"} -->
+										<div class="wp-block-column" style="flex-basis:33.33%">
+											<!-- wp:sensei-lms/course-actions -->
+												<!-- wp:sensei-lms/button-take-course {"align":"right"} -->
+													<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><button class="wp-block-button__link">Start Course</button></div>
+												<!-- /wp:sensei-lms/button-take-course -->
+
+												<!-- wp:sensei-lms/button-continue-course {"align":"right"} -->
+													<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link">Continue</a></div>
+												<!-- /wp:sensei-lms/button-continue-course -->
+
+												<!-- wp:sensei-lms/button-view-results {"align":"right","className":"is-style-default"} -->
+													<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-right"><a class="wp-block-button__link">Visit Results</a></div>
+												<!-- /wp:sensei-lms/button-view-results -->
+											<!-- /wp:sensei-lms/course-actions -->
+										</div>
+									<!-- /wp:column -->
+								</div>
+							<!-- /wp:columns -->
+						<!-- /wp:post-template -->' .
+					$pagination .
+					'</div>
+				<!-- /wp:query -->',
 			],
-			'course-list-columns-title'       =>
+			'course-grid'                     =>
 				[
-					'title'       => __( 'Grid of courses with title', 'sensei-lms' ),
+					'title'       => __( 'Courses displayed in a grid', 'sensei-lms' ),
 					'categories'  => array( 'query' ),
 					'blockTypes'  => array( 'core/query' ),
 					'description' => 'course-list-element',
-					'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
-						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
-						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
+					'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
+						<div class="wp-block-query wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list--is-grid-view alignwide">
+							<!-- wp:post-template {"align":"wide"} -->
+								<!-- wp:post-featured-image {"isLink":true,"align":"center"} /-->
 
-						<!-- wp:sensei-lms/course-categories /-->
+								<!-- wp:sensei-lms/course-categories /-->
 
-						<!-- wp:post-title {"level":1,"fontSize":"x-large","isLink":true,"className":"hide-url-underline"} /-->' . $course_action_button . '
-						<!-- /wp:post-template -->' . $pagination,
-				],
-			'course-list-columns-description' =>
-				[
-					'title'       => __( 'Grid of courses with title and description', 'sensei-lms' ),
-					'categories'  => array( 'query' ),
-					'blockTypes'  => array( 'core/query' ),
-					'description' => 'course-list-element',
-					'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":4},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
-						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
-						<!-- wp:post-featured-image {"isLink":true,"width":"100%","height":"318px"} /-->
+								<!-- wp:post-title {"textAlign":"left","isLink":true} /-->
 
-						<!-- wp:sensei-lms/course-categories /-->
+								<!-- wp:post-author {"textAlign":"left"} /-->
 
-						<!-- wp:post-title {"level":1,"fontSize":"x-large","isLink":true,"className":"hide-url-underline"} /-->
+								<!-- wp:post-excerpt {"textAlign":"left"} /-->
 
-						<!-- wp:post-excerpt {"fontSize":"medium"} /-->' . $course_action_button . '
-						<!-- /wp:post-template -->' . $pagination,
-				],
-			'course-list'                     =>
-				[
-					'title'       => __( 'List of courses', 'sensei-lms' ),
-					'categories'  => array( 'query' ),
-					'blockTypes'  => array( 'core/query' ),
-					'description' => 'course-list-element',
-					'content'     => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
-						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
-						<!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-						<div class="wp-block-columns alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"30%","layout":{"inherit":false}} -->
-						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%"><!-- wp:post-featured-image {"isLink":true,"align":"center"} /--></div>
-						<!-- /wp:column -->
+								<!-- wp:sensei-lms/course-progress /-->
 
-						<!-- wp:column {"width":"50%","layout":{"inherit":false}} -->
-						<div class="wp-block-column" style="flex-basis:50%">
+								<!-- wp:sensei-lms/course-actions -->
+									<!-- wp:sensei-lms/button-take-course {"align":"full"} -->
+										<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
+											<button class="wp-block-button__link">Start Course</button>
+										</div>
+									<!-- /wp:sensei-lms/button-take-course -->
 
-						<!-- wp:sensei-lms/course-categories /-->
+									<!-- wp:sensei-lms/button-continue-course {"align":"full"} -->
+										<div class="wp-block-sensei-lms-button-continue-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
+											<a class="wp-block-button__link">Continue</a>
+										</div>
+									<!-- /wp:sensei-lms/button-continue-course -->
 
-						<!-- wp:post-title {"fontSize":"x-large","isLink":true,"className":"hide-url-underline"} /-->
-
-						<!-- wp:post-author /-->
-
-						<!-- wp:post-excerpt /-->
-
-						<!-- wp:sensei-lms/course-progress {"defaultBarColor":"primary"} /--></div>
-						<!-- /wp:column -->
-
-						<!-- wp:column {"verticalAlignment":"top","width":"20%"} -->
-						<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:20%"><!-- wp:spacer {"height":"3px"} -->
-						<div style="height:3px" aria-hidden="true" class="wp-block-spacer"></div>
-						<!-- /wp:spacer -->' . $course_action_button . '</div>
-						<!-- /wp:column --></div>
-						<!-- /wp:columns -->
-						<!-- /wp:post-template -->' . $pagination,
-				],
-			'course-list-title'               =>
-				[
-					'title'       => __( 'List of courses with title', 'sensei-lms' ),
-					'categories'  => array( 'query' ),
-					'blockTypes'  => array( 'core/query' ),
-					'description' => 'course-list-element',
-					'content'     => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
-						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
-						<!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-						<div class="wp-block-columns alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"30%","layout":{"inherit":false}} -->
-						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%"><!-- wp:post-featured-image {"isLink":true,"align":"center"} /--></div>
-						<!-- /wp:column -->
-
-						<!-- wp:column {"width":"50%","layout":{"inherit":false}} -->
-						<div class="wp-block-column" style="flex-basis:50%">
-
-						<!-- wp:sensei-lms/course-categories /-->
-
-						<!-- wp:post-title {"fontSize":"x-large","isLink":true,"className":"hide-url-underline"} /-->
-
-						</div>
-						<!-- /wp:column -->
-
-						<!-- wp:column {"verticalAlignment":"top","width":"20%"} -->
-						<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:20%"><!-- wp:spacer {"height":"3px"} -->
-						<div style="height:3px" aria-hidden="true" class="wp-block-spacer"></div>
-						<!-- /wp:spacer -->' . $course_action_button . '</div>
-						<!-- /wp:column --></div>
-						<!-- /wp:columns -->
-						<!-- /wp:post-template -->' . $pagination,
-				],
-			'course-list-description'         =>
-				[
-					'title'       => __( 'List of courses with title and description', 'sensei-lms' ),
-					'categories'  => array( 'query' ),
-					'blockTypes'  => array( 'core/query' ),
-					'description' => 'course-list-element',
-					'content'     => '<!-- wp:query {"query":{"perPage":3,"pages":0,"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":false},"align":"wide"} -->
-						<div class="wp-block-query wp-block-sensei-lms-course-list alignwide"><!-- wp:post-template {"align":"wide"} -->
-						<!-- wp:columns {"verticalAlignment":null,"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
-						<div class="wp-block-columns alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"30%","layout":{"inherit":false}} -->
-						<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:30%"><!-- wp:post-featured-image {"isLink":true,"align":"center"} /--></div>
-						<!-- /wp:column -->
-
-						<!-- wp:column {"width":"50%","layout":{"inherit":false}} -->
-						<div class="wp-block-column" style="flex-basis:50%">
-
-						<!-- wp:sensei-lms/course-categories /-->
-
-						<!-- wp:post-title {"fontSize":"x-large","isLink":true,"className":"hide-url-underline"} /-->
-						<!-- wp:post-excerpt /-->
-						</div>
-						<!-- /wp:column -->
-
-						<!-- wp:column {"verticalAlignment":"top","width":"20%"} -->
-						<div class="wp-block-column is-vertically-aligned-top" style="flex-basis:20%"><!-- wp:spacer {"height":"3px"} -->
-						<div style="height:3px" aria-hidden="true" class="wp-block-spacer"></div>
-						<!-- /wp:spacer -->' . $course_action_button . '</div>
-						<!-- /wp:column --></div>
-						<!-- /wp:columns -->
-						<!-- /wp:post-template -->' . $pagination,
+									<!-- wp:sensei-lms/button-view-results {"align":"full","className":"is-style-default"} -->
+										<div class="wp-block-sensei-lms-button-view-results is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
+											<a class="wp-block-button__link">Visit Results</a>
+										</div>
+									<!-- /wp:sensei-lms/button-view-results -->
+								<!-- /wp:sensei-lms/course-actions -->
+							<!-- /wp:post-template -->' .
+						$pagination .
+						'</div>
+					<!-- /wp:query -->',
 				],
 		];
 

--- a/includes/blocks/class-sensei-block-view-results.php
+++ b/includes/blocks/class-sensei-block-view-results.php
@@ -72,11 +72,13 @@ class Sensei_Block_View_Results {
 			return '';
 		}
 
-		return preg_replace(
-			'/<a(.*)>/',
-			'<a href="' . esc_url( Sensei_Course::get_view_results_link( $course_id ) ) . '" $1>',
-			$content,
-			1
-		);
+		return '<div class="sensei-block-wrapper">' .
+			preg_replace(
+				'/<a(.*)>/',
+				'<a href="' . esc_url( Sensei_Course::get_view_results_link( $course_id ) ) . '" $1>',
+				$content,
+				1
+			) .
+		'</div>';
 	}
 }

--- a/includes/blocks/class-sensei-continue-course-block.php
+++ b/includes/blocks/class-sensei-continue-course-block.php
@@ -64,12 +64,14 @@ class Sensei_Continue_Course_Block {
 
 		$target_post_id = $this->get_target_page_post_id_for_continue_url( $course_id, $user_id );
 
-		return preg_replace(
-			'/<a(.*)>/',
-			'<a href="' . esc_url( get_permalink( absint( $target_post_id ?? $course_id ) ) ) . '" $1>',
-			$content,
-			1
-		);
+		return '<div class="sensei-block-wrapper">' .
+			preg_replace(
+				'/<a(.*)>/',
+				'<a href="' . esc_url( get_permalink( absint( $target_post_id ?? $course_id ) ) ) . '" $1>',
+				$content,
+				1
+			) .
+		'</div>';
 	}
 
 	/**


### PR DESCRIPTION
Fixes #5550.

### Changes proposed in this Pull Request
- Simplifies the Course List block patterns to a list and grid view.
- Ensures the block looks good at smaller resolutions.
- Overrides some Divi styles to ensure the block looks good on that particular theme.
- Adds some CSS to the block to ensure it looks the same regardless of whether the block is added to a course, post or page. What I would have preferred to do is make the applicable CSS selectors in `frontend.scss` and `grid.scss` more specific so that it wouldn't affect the styling of the Course List block, but I was afraid of breaking existing styles elsewhere within Sensei. 😟 

### Testing instructions
1. Switch to the Divi theme.
2. Add the Course List block to a page and a course and select the list pattern
3. Add a background color to the Course Categories block so that it's visible
4. Ensure the layout looks similar in the editor when comparing the page to the course
5. Ensure the layout looks similar on the frontend when comparing the page to the course
6. View at smaller resolutions and ensure the views are consistent
7. Add the Course List block to a page and a course and select the grid pattern
8. Repeat steps 3 - 7.

Note: The color of the progress bar is different between the course page and a page / post, but I didn't address that in this PR.

### Screenshot / Video

__Grid__
![Screen Shot 2022-08-29 at 4 16 29 PM](https://user-images.githubusercontent.com/1190420/187290385-f16870d4-37dc-4507-b209-c7dd1d64bb93.jpg)

__List__
![Screen Shot 2022-08-29 at 4 17 56 PM](https://user-images.githubusercontent.com/1190420/187290538-fc9bedd0-3e36-40bc-97bb-9bfc39b0a98c.jpg)
