### PR TITLE
Hide"List view" and "Grid view" toolbar options

### DIFF
--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -121,7 +121,7 @@ const hideUnnecessarySettingsForCourseList = () => {
 
 let isCourseListBlockSelected = false;
 
-const withQueryLoopPatternsHiddenForCourseList = ( BlockEdit ) => {
+const withQueryLoopPatternsAndSettingsHiddenForCourseList = ( BlockEdit ) => {
 	return ( props ) => {
 		const isQueryLoopBlock = 'core/query' === props.name;
 		const isCourseListBlock =
@@ -134,6 +134,22 @@ const withQueryLoopPatternsHiddenForCourseList = ( BlockEdit ) => {
 			isCourseListBlockSelected = false;
 		}
 
+		// Hide query loop toolbar settings for grid/list outlook.
+		if (
+			isBlockAlreadyAddedInEditor( props.clientId ) &&
+			isCourseListBlockSelected
+		) {
+			const settingsName = __( 'Grid view', 'sensei-lms' );
+			const outlookSettings = document.querySelector(
+				`[aria-label="${ settingsName }"]`
+			);
+			if ( outlookSettings ) {
+				const toolbarElement = outlookSettings.parentNode;
+				toolbarElement.style.display = 'none';
+			}
+		}
+
+		// Hide query loop patterns for course list.
 		if (
 			isCourseListBlockSelected &&
 			isQueryLoopBlock &&
@@ -151,7 +167,7 @@ const withQueryLoopPatternsHiddenForCourseList = ( BlockEdit ) => {
 addFilter(
 	'editor.BlockEdit',
 	'sensei-lms/course-list-block',
-	withQueryLoopPatternsHiddenForCourseList
+	withQueryLoopPatternsAndSettingsHiddenForCourseList
 );
 
 // Hide patterns control so only Grid view can be selected.


### PR DESCRIPTION
Fixes #5551

### Changes proposed in this Pull Request
- Hide Grid/List view options in toolbar for Course list
- Don't affect Querry Lopp

### Testing instructions
- Go to the New/Edit page
- Add Course List block
- Select Course List block 
- On the toolbar, you should not see Grid/List view buttons (to switch between Grid and List View)
- Make sure Query Loop works as before

Here is a video on the last WP version 6.0.1 

https://user-images.githubusercontent.com/7208249/187422010-6ae314dd-3256-4d77-9ef9-54f22f5f9969.mov

Here is the video for older WP version 5.9.3

https://user-images.githubusercontent.com/7208249/187422067-2102c31e-0022-42ca-b728-b78adaf499e6.mov



