### PR TITLE
Align buttons to bottom of column in Course List block grid pattern

### DIFF
--- a/assets/blocks/course-list-block/course-list-block-editor.scss
+++ b/assets/blocks/course-list-block/course-list-block-editor.scss
@@ -5,8 +5,18 @@
 		}
 
 		&--is-grid-view {
+			/* Align button to bottom of card. */
 			[data-type="sensei-lms/course-actions"] {
 				margin-top: auto;
+			}
+
+			/* Fix for Divi centre aligning blocks. */
+			.wp-block-post-title,
+			.wp-block-post-author,
+			.wp-block-post-excerpt,
+			[data-type="sensei-lms/course-progress"],
+			[data-type="sensei-lms/course-actions"] {
+				width: 100%;
 			}
 		}
 	}

--- a/assets/blocks/course-list-block/course-list-block-editor.scss
+++ b/assets/blocks/course-list-block/course-list-block-editor.scss
@@ -3,5 +3,11 @@
 		.components-button.is-secondary {
 			display: none;
 		}
+
+		&--is-grid-view {
+			[data-type="sensei-lms/course-actions"] {
+				margin-top: auto;
+			}
+		}
 	}
 }

--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -22,8 +22,18 @@ $block: '.wp-block-sensei-lms-course-list';
 		}
 	}
 
-	@media ( max-width: 599px ) {
-		&--is-grid-view {
+	&--is-grid-view {
+		// Align button to bottom of card.
+		.wp-block-post {
+			display: flex;
+			flex-direction: column;
+
+			.sensei-cta {
+				margin-top: auto;
+			}
+		}
+
+		@media ( max-width: 599px ) {
 			.wp-block-post-template.is-flex-container li.course {
 				width: 100%;
 			}

--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -1,6 +1,6 @@
 $block: '.wp-block-sensei-lms-course-list';
 
-// Match styles applied to block on single course page.
+/* Match styles applied to block on single course page. */
 #{$block} {
 	.course {
 		border: 0;
@@ -23,7 +23,7 @@ $block: '.wp-block-sensei-lms-course-list';
 	}
 
 	&--is-grid-view {
-		// Align button to bottom of card.
+		/* Align button to bottom of card. */
 		.wp-block-post {
 			display: flex;
 			flex-direction: column;

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -94,19 +94,19 @@ class Sensei_Course_List_Block_Patterns {
 					'content'     => '<!-- wp:query {"query":{"offset":0,"postType":"course","order":"desc","orderBy":"date","author":"","search":"","sticky":"","perPage":12},"displayLayout":{"type":"flex","columns":3},"align":"wide","layout":{"inherit":true}} -->
 						<div class="wp-block-query wp-block-sensei-lms-course-list wp-block-sensei-lms-course-list--is-grid-view alignwide">
 							<!-- wp:post-template {"align":"wide"} -->
-								<!-- wp:post-featured-image {"isLink":true,"align":"center"} /-->
+								<!-- wp:post-featured-image {"isLink":true,"align":"center","lock":{"move": true}} /-->
 
-								<!-- wp:sensei-lms/course-categories /-->
+								<!-- wp:sensei-lms/course-categories {"lock":{"move": true}} /-->
 
-								<!-- wp:post-title {"textAlign":"left","isLink":true} /-->
+								<!-- wp:post-title {"textAlign":"left","isLink":true,"lock":{"move": true}} /-->
 
-								<!-- wp:post-author {"textAlign":"left"} /-->
+								<!-- wp:post-author {"textAlign":"left","lock":{"move": true}} /-->
 
-								<!-- wp:post-excerpt {"textAlign":"left"} /-->
+								<!-- wp:post-excerpt {"textAlign":"left","lock":{"move": true}} /-->
 
-								<!-- wp:sensei-lms/course-progress /-->
+								<!-- wp:sensei-lms/course-progress {"lock":{"move": true}} /-->
 
-								<!-- wp:sensei-lms/course-actions -->
+								<!-- wp:sensei-lms/course-actions {"lock":{"move": true}} -->
 									<!-- wp:sensei-lms/button-take-course {"align":"full"} -->
 										<div class="wp-block-sensei-lms-button-take-course is-style-default wp-block-sensei-button wp-block-button has-text-align-full">
 											<button class="wp-block-button__link">Start Course</button>

--- a/includes/blocks/class-sensei-block-take-course.php
+++ b/includes/blocks/class-sensei-block-take-course.php
@@ -75,7 +75,7 @@ class Sensei_Block_Take_Course {
 			$html = $this->render_with_login( $content );
 		}
 
-		return ! empty( $html ) ? '<div class="sensei-block-wrapper">' . $html . '</div>' : '';
+		return ! empty( $html ) ? '<div class="sensei-block-wrapper sensei-cta">' . $html . '</div>' : '';
 	}
 
 	/**

--- a/includes/blocks/class-sensei-block-view-results.php
+++ b/includes/blocks/class-sensei-block-view-results.php
@@ -72,7 +72,7 @@ class Sensei_Block_View_Results {
 			return '';
 		}
 
-		return '<div class="sensei-block-wrapper">' .
+		return '<div class="sensei-block-wrapper sensei-cta">' .
 			preg_replace(
 				'/<a(.*)>/',
 				'<a href="' . esc_url( Sensei_Course::get_view_results_link( $course_id ) ) . '" $1>',

--- a/includes/blocks/class-sensei-continue-course-block.php
+++ b/includes/blocks/class-sensei-continue-course-block.php
@@ -64,7 +64,7 @@ class Sensei_Continue_Course_Block {
 
 		$target_post_id = $this->get_target_page_post_id_for_continue_url( $course_id, $user_id );
 
-		return '<div class="sensei-block-wrapper">' .
+		return '<div class="sensei-block-wrapper sensei-cta">' .
 			preg_replace(
 				'/<a(.*)>/',
 				'<a href="' . esc_url( get_permalink( absint( $target_post_id ?? $course_id ) ) ) . '" $1>',


### PR DESCRIPTION
Fixes #5529.

### Changes proposed in this Pull Request
- Adds a `sensei-cta` class to course action buttons on the frontend to enable better targeting with CSS
- Align buttons to bottom of column for the grid pattern only
- Lock blocks inside Course List so that they can't be moved. Note that the user can still unlock and move them, but I don't think there's a good way of dealing with that scenario, and it's more of an edge case so I'm choosing to ignore it. 🙈 

### Testing instructions
- Add a Course List block with a grid pattern to a page or course.
- Ensure the buttons across all columns are aligned near the bottom in both the editor and on the frontend.
- Try to reorder the blocks inside the Course List. You shouldn't be able to because the blocks are locked.
- Test on both Divi and Astra.

### Screenshot / Video

_Divi_

![Screen Shot 2022-09-01 at 11 59 32 AM](https://user-images.githubusercontent.com/1190420/187960020-1bab7224-03f5-479e-ace3-baa6aa473ed3.jpg)

_Astra_

![Screen Shot 2022-09-01 at 12 00 38 PM](https://user-images.githubusercontent.com/1190420/187960196-34ae0c63-bab5-4a3d-b69a-d0582f9caec4.jpg)