### PR TITLE
Fix fatal error when printing notices on redirect

### DIFF
--- a/includes/class-sensei-notices.php
+++ b/includes/class-sensei-notices.php
@@ -103,9 +103,6 @@ class Sensei_Notices {
 	public function maybe_print_notices() {
 		if ( count( $this->notices ) > 0 ) {
 			foreach ( $this->notices  as  $notice ) {
-
-				$classes = 'sensei-message ' . $notice['type'];
-
 				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Output escaped in generate_notice
 				echo $this->generate_notice( $notice['type'], $notice['content'] );
 			}

--- a/includes/hooks/template.php
+++ b/includes/hooks/template.php
@@ -318,4 +318,4 @@ add_action( 'sensei_teacher_archive_course_loop_before', array( 'Sensei_Teacher'
  *
  * Frontend notices may display on any post, page or custom post type (used in Sensei blocks).
  */
-add_action( 'init', array( $sensei->notices, 'maybe_print_notices' ) );
+add_action( 'wp_body_open', array( $sensei->notices, 'maybe_print_notices' ) );


### PR DESCRIPTION
Fixes #5562

### Changes proposed in this Pull Request

* Call `maybe_print_notices` on the hook `wp_body_open`, instead of using the hook `init`;
* Remove unused variable on `maybe_print_notices`;

### Testing instructions

Follow the testing instructions on #5562 and make sure that the fatal error reported there doesn't happen anymore.

Note that this PR introduces an issue where the notice "Lesson Reset Successfully." simply doesn't appear anymore. This is reported in #5573 and fixed by #5569.
