### PR TITLE
Add filter by feature option to course list filter

### DIFF
--- a/assets/blocks/course-list-filter-block/course-list-filter-edit.js
+++ b/assets/blocks/course-list-filter-block/course-list-filter-edit.js
@@ -64,11 +64,7 @@ function useFilterOptions( type ) {
 				filters.featured.defaultOption,
 				{
 					label: __( 'Featured', 'sensei-lms' ),
-					value: 'yes',
-				},
-				{
-					label: __( 'Not Featured', 'sensei-lms' ),
-					value: 'no',
+					value: 'featured',
 				},
 			];
 		case 'activity':

--- a/assets/blocks/course-list-filter-block/course-list-filter-edit.js
+++ b/assets/blocks/course-list-filter-block/course-list-filter-edit.js
@@ -17,7 +17,7 @@ const filters = {
 		label: __( 'Featured', 'sensei-lms' ),
 		defaultOption: {
 			label: __( 'All Courses', 'sensei-lms' ),
-			value: 0,
+			value: 'all',
 		},
 	},
 	activity: {
@@ -60,7 +60,17 @@ function useFilterOptions( type ) {
 		case 'categories':
 			return [ filters.categories.defaultOption, ...categories ];
 		case 'featured':
-			return [ filters.featured.defaultOption ];
+			return [
+				filters.featured.defaultOption,
+				{
+					label: __( 'Featured', 'sensei-lms' ),
+					value: 'yes',
+				},
+				{
+					label: __( 'Not Featured', 'sensei-lms' ),
+					value: 'no',
+				},
+			];
 		case 'activity':
 			return [ filters.activity.defaultOption ];
 	}
@@ -100,10 +110,9 @@ function CourseListFilter( {
 				</PanelBody>
 			</InspectorControls>
 			<SelectControl
-				style={ { width: 'auto' } }
 				options={ options }
 				onChange={ () => {} }
-				value={ 0 }
+				value={ filters[ type ].defaultOption.value }
 			/>
 		</div>
 	);

--- a/assets/blocks/course-list-filter-block/course-list-filter-edit.test.js
+++ b/assets/blocks/course-list-filter-block/course-list-filter-edit.test.js
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { render } from '@testing-library/react';
+import { render, within } from '@testing-library/react';
 /**
  * Internal dependencies
  */
@@ -54,14 +54,16 @@ describe( 'CourseListFilterBlockEdit', () => {
 	} );
 
 	it( 'should render the dropdown for featured filter', () => {
-		const { getByText } = render(
+		const { getByRole } = render(
 			<CourseListFilter
 				clientId="some-client-id"
 				attributes={ { type: 'featured' } }
 				context={ context }
 			/>
 		);
-		expect( getByText( 'Featured' ) ).toBeInTheDocument();
+		expect(
+			within( getByRole( 'combobox' ) ).getByText( 'Featured' )
+		).toBeInTheDocument();
 	} );
 
 	it( 'should render the dropdown for activity filter', () => {

--- a/assets/blocks/course-list-filter-block/course-list-filter-edit.test.js
+++ b/assets/blocks/course-list-filter-block/course-list-filter-edit.test.js
@@ -61,7 +61,7 @@ describe( 'CourseListFilterBlockEdit', () => {
 				context={ context }
 			/>
 		);
-		expect( getByText( 'All Courses' ) ).toBeInTheDocument();
+		expect( getByText( 'Featured' ) ).toBeInTheDocument();
 	} );
 
 	it( 'should render the dropdown for activity filter', () => {

--- a/assets/blocks/course-list-filter-block/course-list-filter.js
+++ b/assets/blocks/course-list-filter-block/course-list-filter.js
@@ -1,6 +1,7 @@
 const courseListFeaturedFilterElements = document.querySelectorAll(
 	'.wp-sensei-course-list-block-filter select'
 );
+
 courseListFeaturedFilterElements.forEach( ( element ) => {
 	element.onchange = ( evt ) => {
 		const url = new URL( window.location.href );

--- a/includes/blocks/class-sensei-course-list-featured-filter.php
+++ b/includes/blocks/class-sensei-course-list-featured-filter.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * File containing the Sensei_Course_List_Featured_Filter class.
+ *
+ * @package sensei
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Class Sensei_Course_List_Featured_Filter
+ */
+class Sensei_Course_List_Featured_Filter {
+
+	/**
+	 * Unique key for the filter param.
+	 *
+	 * @var string
+	 */
+	private $param_key = 'course-list-featured-filter-';
+
+	/**
+	 * Options for featured filter.
+	 *
+	 * @var array
+	 */
+	private $featured_options = [];
+
+	/**
+	 * Constructor for Sensei_Course_List_Featured_Filter class.
+	 */
+	public function __construct() {
+		$this->featured_options = [
+			'all' => __( 'All Courses', 'sensei-lms' ),
+			'yes' => __( 'Featured', 'sensei-lms' ),
+			'no'  => __( 'Not Featured', 'sensei-lms' ),
+		];
+	}
+	/**
+	 * Get the content to be be rendered inside the filtered block.
+	 *
+	 * @param int $query_id The id of the Query block this filter is rendering inside.
+	 */
+	public function get_content( $query_id ) : string {
+		$selected_option  = 'all';
+		$filter_param_key = $this->param_key . $query_id;
+		// phpcs:ignore WordPress.Security.NonceVerification
+		if ( isset( $_GET[ $filter_param_key ] ) ) {
+			$selected_option = sanitize_text_field( wp_unslash( $_GET[ $filter_param_key ] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+		}
+
+		return '<select data-param-key="' . $this->param_key . '" data-query-id="' . $query_id . '" >' .
+			join(
+				'',
+				array_map(
+					function ( $key ) use ( $selected_option ) {
+						return '<option ' . selected( $key, $selected_option, false ) . ' value="' . esc_attr( $key ) . '">' . esc_html( $this->featured_options[ $key ] ) . '</option>';
+					},
+					array_keys( $this->featured_options )
+				)
+			) . '</select>';
+	}
+
+	/**
+	 * Get a list of course Ids to be excluded from the course list block filtered by Featured status.
+	 *
+	 * @param int $query_id The id of the Query block this filter is rendering inside.
+	 */
+	public function get_course_ids_to_be_excluded( $query_id ): array {
+		$filter_param_key = $this->param_key . $query_id;
+
+		// phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! isset( $_GET[ $filter_param_key ] ) ) {
+			return [];
+		}
+		// phpcs:ignore WordPress.Security.NonceVerification
+		$selected_option = sanitize_text_field( wp_unslash( $_GET[ $filter_param_key ] ) );
+
+		if ( 'all' === $selected_option || ! in_array( $selected_option, array_keys( $this->featured_options ), true ) ) {
+			return [];
+		}
+
+		$args = array(
+			'post_type'      => 'course',
+			'posts_per_page' => -1,
+			'meta_value'     => 'featured', // phpcs:ignore WordPress.DB.SlowDBQuery
+			'meta_key'       => '_course_featured', // phpcs:ignore WordPress.DB.SlowDBQuery
+			'meta_compare'   => 'yes' === $selected_option ? '!=' : '=',
+			'fields'         => 'ids',
+		);
+
+		return get_posts( $args );
+	}
+}

--- a/includes/blocks/class-sensei-course-list-featured-filter.php
+++ b/includes/blocks/class-sensei-course-list-featured-filter.php
@@ -33,9 +33,8 @@ class Sensei_Course_List_Featured_Filter {
 	 */
 	public function __construct() {
 		$this->featured_options = [
-			'all' => __( 'All Courses', 'sensei-lms' ),
-			'yes' => __( 'Featured', 'sensei-lms' ),
-			'no'  => __( 'Not Featured', 'sensei-lms' ),
+			'all'      => __( 'All Courses', 'sensei-lms' ),
+			'featured' => __( 'Featured', 'sensei-lms' ),
 		];
 	}
 	/**
@@ -85,9 +84,18 @@ class Sensei_Course_List_Featured_Filter {
 		$args = array(
 			'post_type'      => 'course',
 			'posts_per_page' => -1,
-			'meta_value'     => 'featured', // phpcs:ignore WordPress.DB.SlowDBQuery
-			'meta_key'       => '_course_featured', // phpcs:ignore WordPress.DB.SlowDBQuery
-			'meta_compare'   => 'yes' === $selected_option ? '!=' : '=',
+			'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery
+				'relation' => 'OR',
+				[
+					'key'     => '_course_featured',
+					'compare' => 'NOT EXISTS',
+				],
+				[
+					'key'     => '_course_featured',
+					'value'   => 'featured',
+					'compare' => '!=',
+				],
+			],
 			'fields'         => 'ids',
 		);
 

--- a/includes/blocks/class-sensei-course-list-filter-block.php
+++ b/includes/blocks/class-sensei-course-list-filter-block.php
@@ -22,6 +22,13 @@ class Sensei_Course_List_Filter_Block {
 	private $category_filter;
 
 	/**
+	 * Instance of Sensei_Course_List_Featured_Filter class.
+	 *
+	 * @var Sensei_Course_List_Featured_Filter
+	 */
+	private $featured_filter;
+
+	/**
 	 * Sensei_Course_List_Filter_Block constructor.
 	 */
 	public function __construct() {
@@ -30,6 +37,7 @@ class Sensei_Course_List_Filter_Block {
 		add_filter( 'render_block_data', [ $this, 'filter_course_list' ] );
 
 		$this->category_filter = new Sensei_Course_List_Categories_Filter();
+		$this->featured_filter = new Sensei_Course_List_Featured_Filter();
 	}
 
 	/**
@@ -65,6 +73,8 @@ class Sensei_Course_List_Filter_Block {
 				$content = $this->category_filter->get_content( $block->context['queryId'] );
 				break;
 			case 'featured':
+				$content = $this->featured_filter->get_content( $block->context['queryId'] );
+				break;
 			case 'activity':
 			default:
 				break;
@@ -90,6 +100,7 @@ class Sensei_Course_List_Filter_Block {
 			return $parsed_block;
 		}
 		$category_filtered_ids = $this->category_filter->get_course_ids_to_be_excluded( $parsed_block['attrs']['queryId'] );
+		$featured_filtered_ids = $this->featured_filter->get_course_ids_to_be_excluded( $parsed_block['attrs']['queryId'] );
 
 		if ( ! array_key_exists( 'exclude', $parsed_block['attrs']['query'] ) || ! is_array( $parsed_block['attrs']['query']['exclude'] ) ) {
 			$parsed_block['attrs']['query']['exclude'] = [];
@@ -98,7 +109,11 @@ class Sensei_Course_List_Filter_Block {
 		// We are changing updating the attribute of the parent Query Loop block here
 		// Which will be provided to all the children using context. So no need update each child's (pagination, next page etc.) context
 		// separately.
-		$parsed_block['attrs']['query']['exclude'] = array_merge( $parsed_block['attrs']['query']['exclude'], $category_filtered_ids );
+		$parsed_block['attrs']['query']['exclude'] = array_merge(
+			$parsed_block['attrs']['query']['exclude'],
+			$category_filtered_ids,
+			$featured_filtered_ids
+		);
 		return $parsed_block;
 	}
 }

--- a/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
@@ -110,6 +110,72 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 		$this->assertNotContains( $this->course2->post_title, $result );
 	}
 
+	public function testCourseFilterBlock_WhenCalledWithFeaturedFilterParam_ShowsOnlyFeaturedCourses() {
+		if ( $this->skip_tests ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.8 or higher.' );
+		}
+		/* ARRANGE */
+		$_GET['course-list-featured-filter-13'] = 'featured';
+		update_post_meta( $this->course1->ID, '_course_featured', 'featured' );
+
+		/* ACT */
+		$result = do_blocks( self::get_content_for_type( 'featured' ) );
+
+		/* ASSERT */
+		$this->assertContains( $this->course1->post_title, $result );
+		$this->assertNotContains( $this->course2->post_title, $result );
+	}
+
+	public function testCourseFilterBlock_WhenCalledWithFeaturedFilterParamSetAll_ShowsAllCourses() {
+		if ( $this->skip_tests ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.8 or higher.' );
+		}
+		/* ARRANGE */
+		$_GET['course-list-featured-filter-13'] = 'all';
+		update_post_meta( $this->course1->ID, '_course_featured', 'featured' );
+
+		/* ACT */
+		$result = do_blocks( self::get_content_for_type( 'featured' ) );
+
+		/* ASSERT */
+		$this->assertContains( $this->course1->post_title, $result );
+		$this->assertContains( $this->course2->post_title, $result );
+	}
+
+	public function testCourseFilterBlock_WhenCalledFeaturedAndCategoryFilterTogether_ShowsFilteredCoursesProperly() {
+		if ( $this->skip_tests ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.8 or higher.' );
+		}
+		/* ARRANGE */
+		$_GET['course-list-featured-filter-13'] = 'featured';
+		$_GET['course-list-category-filter-13'] = $this->category->term_id;
+		update_post_meta( $this->course1->ID, '_course_featured', 'featured' );
+
+		/* ACT */
+		$result = do_blocks( self::get_content_for_type( 'featured' ) );
+
+		/* ASSERT */
+		$this->assertContains( $this->course1->post_title, $result );
+		$this->assertNotContains( $this->course2->post_title, $result );
+	}
+
+	public function testCourseFilterBlock_WhenCalledFeaturedAndCategoryFilterTogether_ShowsNoCoursesWhenApplicable() {
+		if ( $this->skip_tests ) {
+			$this->markTestSkipped( 'This test requires WordPress 5.8 or higher.' );
+		}
+		/* ARRANGE */
+		$_GET['course-list-featured-filter-13'] = 'featured';
+		$_GET['course-list-category-filter-13'] = $this->category->term_id;
+		update_post_meta( $this->course2->ID, '_course_featured', 'featured' );
+
+		/* ACT */
+		$result = do_blocks( self::get_content_for_type( 'featured' ) );
+
+		/* ASSERT */
+		$this->assertNotContains( $this->course1->post_title, $result );
+		$this->assertNotContains( $this->course2->post_title, $result );
+	}
+
 	/**
 	 * Block content.
 	 */


### PR DESCRIPTION
Implements https://github.com/Automattic/sensei/issues/5560

### Changes proposed in this Pull Request

* Added filter by Featured status to Course List Filter block. "Not Featured" option is not added as per internal discussion.

### Testing instructions

- Create some courses
- Create some course categories
- Assign some courses in some categories
- Add a Course List block on any page
- Add the Course List Filter block inside the Course List block
- Add another Course List Filter block and toggle the Featured option from the right.
- Save and go to frontend
- Make sure it is rendering properly
- Try filtering by changing the dropdown value to different course categories and Featured options.

### Screenshot / Video

https://user-images.githubusercontent.com/6820724/188173590-726bb5e6-1efa-4ae4-9f10-ac42dda168b1.mov