### PR TITLE
Ignore negative numbers for `show_questions` option.

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -2491,6 +2491,7 @@ class Sensei_Lesson {
 	 * Enqueue legacy meta box quiz editor assets.
 	 */
 	private function enqueue_scripts_meta_box_quiz_editor() {
+
 		wp_enqueue_media();
 
 		// Load the lessons script.
@@ -3611,7 +3612,8 @@ class Sensei_Lesson {
 				// Get number of questions to show.
 				$show_questions = (int) get_post_meta( $quiz_id, '_show_questions', true );
 
-				if ( $show_questions ) {
+				// Negative amount is considered as All (same as zero).
+				if ( $show_questions > 0 ) {
 					// Get random set of array keys from selected questions array.
 					$selected_questions = array_rand(
 						$questions_array,


### PR DESCRIPTION
Fixes #5572

### Changes proposed in this Pull Request
* Ignore negative numbers as "_show_questions" setting.

### Testing instructions
* Create a Lesson.
* Add a Quiz.
* Enable random questions option.
* Use "-1" (or any other negative value) as the amount of random questions to show.
* Go check that the quiz is displayed correctly without any warnings.

### Screenshot
<img width="284" alt="image" src="https://user-images.githubusercontent.com/799065/188440117-795c8a92-388a-437c-a2b3-9c4441d021c0.png">
<img width="1013" alt="image" src="https://user-images.githubusercontent.com/799065/188440162-bcdd261d-ffb0-468f-8d34-e588facc0e9c.png">
