### PR TITLE
Fix issue with enrolling students in the course view in a course with no students

### DIFF
--- a/includes/admin/views/html-admin-page-students-course.php
+++ b/includes/admin/views/html-admin-page-students-course.php
@@ -24,8 +24,8 @@ Sensei()->learners->learners_headers();
 <form id="learners-filter" method="get">
 	<?php Sensei_Utils::output_query_params_as_inputs( [ 's' ] ); ?>
 	<?php $sensei_list_table->table_search_form(); ?>
-	<?php $sensei_list_table->display(); ?>
 </form>
+<?php $sensei_list_table->display(); ?>
 <?php
 do_action( 'learners_wrapper_container', 'bottom' );
 do_action( 'learners_after_container' );


### PR DESCRIPTION
Fixes #5504

### Changes proposed in this Pull Request

* Move `$sensei_list_table->display();` out of the `<form>` tag used for the filters, allowing the forms inside the table (and after the table) to work correctly;

### Testing instructions

Follow the instructions on issue #5504 and make sure that the user is enrolled and no notices are shown.

Also, verify if the layout/design is exactly the same as before.