### PR TITLE
Disable Codecov annotations

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,3 +21,6 @@ comment:
     layout: 'reach,diff,flags,files,footer'
     behavior: default
     require_changes: no
+
+github_checks:
+    annotations: false


### PR DESCRIPTION
### Changes proposed in this Pull Request

This PR disables the Codecov annotations (screenshot below). Some team members mentioned that the Codecov annotations aren't very useful and are disrupting their flow.

### Screenshot

![image](https://user-images.githubusercontent.com/1612178/188705703-116d3c1b-6035-4336-8825-9976fe11e4be.png)