### PR TITLE
Remove "Beta" label from Course List block

### DIFF
--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -27,7 +27,7 @@ export const registerCourseListBlock = () => {
 
 	registerBlockVariation( 'core/query', {
 		name: 'sensei-lms/course-list',
-		title: __( 'Course List (Beta)', 'sensei-lms' ),
+		title: __( 'Course List', 'sensei-lms' ),
 		description: __( 'Show a list of courses.', 'sensei-lms' ),
 		icon: list,
 		category: 'sensei-lms',

--- a/tests/e2e-playwright/pages/admin/post-type/index.js
+++ b/tests/e2e-playwright/pages/admin/post-type/index.js
@@ -28,7 +28,7 @@ class PostType {
 	async addBlock( blockName ) {
 		await this.addBlockButton.click();
 		await this.searchBlock.fill( blockName );
-		await this.page.locator( `button[role="option"]:has-text("${ blockName }")` ).click();
+		await this.page.locator( 'button[role="option"]', { has: this.page.locator( `text="${ blockName }"` ) } ).click();
 
 		return new QueryLoop( this.queryLoopPatternSelection, this.page );
 	}

--- a/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.js
+++ b/tests/e2e-playwright/specs/admin/blocks/course-list-block.spec.js
@@ -49,7 +49,7 @@ describe( 'Courses List Block', () => {
 		const postTypePage = new PostType( page, 'page' );
 
 		await postTypePage.goToPostTypeCreationPage();
-		const courseList = await postTypePage.addBlock( 'Course List (Beta)' );
+		const courseList = await postTypePage.addBlock( 'Course List' );
 		await courseList.choosePattern( 'Courses displayed in a list' );
 
 		await postTypePage.publish();


### PR DESCRIPTION
### Changes proposed in this Pull Request
Removes the "Beta" label from the Course List block name.

### Testing instructions
- Open the block inserter for a page.
- Ensure "Course List" appears and that the Course List block is added when selected.