### PR TITLE
Fix/learning mode quiz count

### DIFF
--- a/includes/blocks/class-sensei-block-quiz-progress.php
+++ b/includes/blocks/class-sensei-block-quiz-progress.php
@@ -43,7 +43,7 @@ class Sensei_Block_Quiz_Progress {
 
 		$quiz_id = get_the_ID();
 
-		$total         = count( Sensei()->lesson->lesson_quiz_questions( $quiz_id, 'publish' ) );
+		$total         = (int) get_post_meta( $quiz_id, '_show_questions', true );
 		$user_id       = get_current_user_id();
 		$lesson_id     = Sensei()->quiz->get_lesson_id( $quiz_id );
 		$answers       = Sensei()->quiz->get_user_answers( $lesson_id, $user_id );

--- a/includes/blocks/class-sensei-block-quiz-progress.php
+++ b/includes/blocks/class-sensei-block-quiz-progress.php
@@ -43,7 +43,8 @@ class Sensei_Block_Quiz_Progress {
 
 		$quiz_id = get_the_ID();
 
-		$total         = (int) get_post_meta( $quiz_id, '_show_questions', true );
+		$questions     = (int) get_post_meta( $quiz_id, '_show_questions', true );
+		$total         = $questions ? $questions : count( Sensei()->quiz->get_questions( $quiz_id ) );
 		$user_id       = get_current_user_id();
 		$lesson_id     = Sensei()->quiz->get_lesson_id( $quiz_id );
 		$answers       = Sensei()->quiz->get_user_answers( $lesson_id, $user_id );

--- a/includes/blocks/class-sensei-block-quiz-progress.php
+++ b/includes/blocks/class-sensei-block-quiz-progress.php
@@ -43,7 +43,7 @@ class Sensei_Block_Quiz_Progress {
 
 		$quiz_id = get_the_ID();
 
-		$total         = count( Sensei()->quiz->get_questions( $quiz_id ) );
+		$total         = count( Sensei()->lesson->lesson_quiz_questions( $quiz_id, 'publish' ) );
 		$user_id       = get_current_user_id();
 		$lesson_id     = Sensei()->quiz->get_lesson_id( $quiz_id );
 		$answers       = Sensei()->quiz->get_user_answers( $lesson_id, $user_id );


### PR DESCRIPTION
Fixes #4905

### Changes proposed in this Pull Request

Previously, the `get_questions` method returned the total number of questions in a Quiz, so if a Quiz was set to show a random selection of questions, the Learning Mode progress bar would be incorrect with the number.  This change moves the check to just check the postmeta value for `_show_questions` which is how many questions should be shown.

### Testing instructions

* Create a Quiz
* Add 5 questions
* Enable "Random Question Order" on the Quiz Settings
* Select a "Number of Questions" to show less than the number of questions in the quiz
* Enable Learning Mode
* Go view the course in Learning Mode and check the progress bar has the right number shown

### Screenshot / Video
Previously: 

<img width="1228" alt="Screen Shot 2022-09-06 at 3 51 39 PM" src="https://user-images.githubusercontent.com/3220162/188753980-5854b039-971a-408e-86d0-ac0d95aa06cf.png">

Now:
<img width="1239" alt="Screen Shot 2022-09-06 at 3 51 03 PM" src="https://user-images.githubusercontent.com/3220162/188753922-0afbefab-9aa4-4c54-96b8-6c9bd802d6e9.png">
