### PR TITLE
Always enable theme styles

### DIFF
--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -985,6 +985,22 @@ class Sensei_Settings extends Sensei_Settings_API {
 			<?php endforeach; ?>
 			</ul>
 		<?php
+
+		$inline_data = [
+			'name'         => "{$this->token}[{$key}]",
+			'value'        => $value,
+			'options'      => $args['data']['options'],
+			'customizeUrl' => Sensei_Course_Theme::get_sensei_theme_customize_url(),
+			'formId'       => "{$this->token}-form",
+			'section'      => $args['data']['section'],
+		];
+		Sensei()->assets->enqueue( 'learning-mode-templates-styles', 'course-theme/learning-mode-templates/styles.css', [ 'wp-components' ] );
+		Sensei()->assets->enqueue( 'learning-mode-templates-script', 'course-theme/learning-mode-templates/index.js', [ 'wp-element', 'wp-components' ], true );
+		wp_add_inline_script(
+			'learning-mode-templates-script',
+			sprintf( 'window.sensei = window.sensei || {}; window.sensei.learningModeTemplateSetting = %s;', wp_json_encode( $inline_data ) ),
+			'before'
+		);
 	}
 }
 

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -931,7 +931,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 		$options   = $this->get_settings();
 		$key       = $args['key'];
 		$value     = $options[ $key ];
-		$theme_key = 'sensei_learning_mode_theme';
+		$customize_url = Sensei_Course_Theme::get_sensei_theme_customize_url();
 		?>
 		<label for="<?php echo esc_attr( $key ); ?>">
 			<input id="<?php echo esc_attr( $key ); ?>" name="<?php echo esc_attr( "{$this->token}[{$key}]" ); ?>" type="checkbox" value="1" <?php checked( $value, '1' ); ?> />
@@ -940,18 +940,13 @@ class Sensei_Settings extends Sensei_Settings_API {
 		<p>
 			<span class="description"><?php echo esc_html( $args['data']['description'] ); ?></span>
 		</p>
-		<div class="extra-content">
-			<label for="<?php echo esc_attr( $theme_key ); ?>">
-				<input id="<?php echo esc_attr( $theme_key ); ?>" name="<?php echo esc_attr( "{$this->token}[{$theme_key}]" ); ?>"
-					type="checkbox" value="1" <?php checked( $options[ $theme_key ], '1' ); ?> />
-				<?php esc_html_e( 'Enable theme styles', 'sensei-lms' ); ?>
-			</label>
-			<p>
-				<span
-					class="description"><?php echo esc_html( $this->fields[ $theme_key ]['description'] ); ?></span>
+		<?php if ( $customize_url ) { ?>
+			<p class="extra-content">
+				<a href="<?php echo esc_url( $customize_url ); ?>">
+					<?php esc_html_e( 'Customize', 'sensei-lms' ); ?>
+				</a>
 			</p>
-		</div>
-		<?php
+		<?php }
 	}
 
 	/**

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -471,15 +471,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 			'section'     => 'appearance-settings',
 		);
 
-		// Rendered as part of the 'Learning Mode' setting.
-		$fields['sensei_learning_mode_theme'] = array(
-			'name'        => __( 'Learning Mode Theme Styles', 'sensei-lms' ),
-			'description' => __( 'Load styles and blocks of the active theme in Learning Mode.', 'sensei-lms' ),
-			'type'        => 'checkbox',
-			'default'     => false,
-			'section'     => 'hidden',
-		);
-
 		// Course Settings.
 		$fields['sensei_learning_mode_template'] = array(
 			'name'        => __( 'Learning Mode Templates', 'sensei-lms' ),
@@ -946,7 +937,8 @@ class Sensei_Settings extends Sensei_Settings_API {
 					<?php esc_html_e( 'Customize', 'sensei-lms' ); ?>
 				</a>
 			</p>
-		<?php }
+			<?php
+		}
 	}
 
 	/**

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -919,9 +919,9 @@ class Sensei_Settings extends Sensei_Settings_API {
 	 * @param array $args The field arguments.
 	 */
 	public function render_learning_mode_setting( $args ) {
-		$options   = $this->get_settings();
-		$key       = $args['key'];
-		$value     = $options[ $key ];
+		$options       = $this->get_settings();
+		$key           = $args['key'];
+		$value         = $options[ $key ];
 		$customize_url = Sensei_Course_Theme::get_sensei_theme_customize_url();
 		?>
 		<label for="<?php echo esc_attr( $key ); ?>">

--- a/includes/class-sensei-settings.php
+++ b/includes/class-sensei-settings.php
@@ -950,7 +950,7 @@ class Sensei_Settings extends Sensei_Settings_API {
 	}
 
 	/**
-	 * Renders the Learnin Mode template selection setting.
+	 * Renders the Learning Mode template selection setting.
 	 *
 	 * @param array $args The field arguments.
 	 */
@@ -993,22 +993,6 @@ class Sensei_Settings extends Sensei_Settings_API {
 			<?php endforeach; ?>
 			</ul>
 		<?php
-
-		$inline_data = [
-			'name'         => "{$this->token}[{$key}]",
-			'value'        => $value,
-			'options'      => $args['data']['options'],
-			'customizeUrl' => Sensei_Course_Theme::get_sensei_theme_customize_url(),
-			'formId'       => "{$this->token}-form",
-			'section'      => $args['data']['section'],
-		];
-		Sensei()->assets->enqueue( 'learning-mode-templates-styles', 'course-theme/learning-mode-templates/styles.css', [ 'wp-components' ] );
-		Sensei()->assets->enqueue( 'learning-mode-templates-script', 'course-theme/learning-mode-templates/index.js', [ 'wp-element', 'wp-components' ], true );
-		wp_add_inline_script(
-			'learning-mode-templates-script',
-			sprintf( 'window.sensei = window.sensei || {}; window.sensei.learningModeTemplateSetting = %s;', wp_json_encode( $inline_data ) ),
-			'before'
-		);
 	}
 }
 

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -159,6 +159,7 @@ class Sensei_Course_Theme_Option {
 		 *
 		 * @since 4.0.2
 		 * @hook  sensei_course_learning_mode_theme_override_enabled
+		 * @deprecated $$next-version$$
 		 *
 		 * @param {bool} $enabled True if the learning mode theme override is enabled.
 		 *

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -85,8 +85,7 @@ class Sensei_Course_Theme_Option {
 
 		$url = get_pagenum_link( 1, false );
 		if ( $should_use_theme ) {
-			$url = str_replace( trailingslashit( home_url() ), '', $url );
-			$url = Sensei_Course_Theme::instance()->get_theme_redirect_url( $url );
+			return;
 		} else {
 			$prefix = Sensei_Course_Theme::instance()->get_theme_redirect_url( '' );
 			$url    = str_replace( $prefix, trailingslashit( home_url() ), $url );

--- a/includes/course-theme/class-sensei-course-theme-option.php
+++ b/includes/course-theme/class-sensei-course-theme-option.php
@@ -154,9 +154,6 @@ class Sensei_Course_Theme_Option {
 	 * @return boolean
 	 */
 	public static function should_override_theme() {
-
-		$enabled = ! \Sensei()->settings->get( 'sensei_learning_mode_theme' );
-
 		/**
 		 * Filters if the theme should be overriden for learning mode.
 		 *
@@ -167,7 +164,7 @@ class Sensei_Course_Theme_Option {
 		 *
 		 * @return {bool} The modified learning mode theme override setting.
 		 */
-		return (bool) apply_filters( 'sensei_course_learning_mode_theme_override_enabled', $enabled );
+		return (bool) apply_filters( 'sensei_course_learning_mode_theme_override_enabled', false );
 	}
 
 	/**

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -83,6 +83,7 @@ class Sensei_Course_Theme {
 		add_action( 'setup_theme', [ $this, 'add_query_var' ], 1 );
 		add_action( 'registered_post_type', [ $this, 'add_post_type_rewrite_rules' ], 10, 2 );
 		add_action( 'registered_taxonomy', [ $this, 'add_taxonomy_rewrite_rules' ], 10, 3 );
+		add_action( 'setup_theme', [ $this, 'maybe_override_theme' ], 2 );
 		add_action( 'shutdown', [ $this, 'maybe_flush_rewrite_rules' ] );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Lesson::instance(), 'init' ] );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Quiz::instance(), 'init' ] );
@@ -114,6 +115,27 @@ class Sensei_Course_Theme {
 		}
 
 		return home_url( '/' . self::QUERY_VAR . '/' . $path );
+	}
+
+	/**
+	 * Replace theme for the current request if it's for course theme mode.
+	 */
+	public function maybe_override_theme() {
+
+		// Do a cheaper preliminary check first.
+		$uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification
+		if ( ! preg_match( '#' . preg_quote( '/' . self::QUERY_VAR . '/', '#' ) . '#i', $uri ) && ! isset( $_GET[ self::QUERY_VAR ] ) ) {
+			return;
+		}
+
+		// Then parse the request and make sure the query var is correct.
+		wp_load_translations_early();
+		wp();
+
+		if ( get_query_var( self::QUERY_VAR ) ) {
+			$this->override_theme();
+		}
 	}
 
 	/**

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -117,27 +117,6 @@ class Sensei_Course_Theme {
 	}
 
 	/**
-	 * Replace theme for the current request if it's for course theme mode.
-	 */
-	public function maybe_override_theme() {
-
-		// Do a cheaper preliminary check first.
-		$uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
-		// phpcs:ignore WordPress.Security.NonceVerification
-		if ( ! preg_match( '#' . preg_quote( '/' . self::QUERY_VAR . '/', '#' ) . '#i', $uri ) && ! isset( $_GET[ self::QUERY_VAR ] ) ) {
-			return;
-		}
-
-		// Then parse the request and make sure the query var is correct.
-		wp_load_translations_early();
-		wp();
-
-		if ( get_query_var( self::QUERY_VAR ) ) {
-			$this->override_theme();
-		}
-	}
-
-	/**
 	 * Load course theme styles and add related filters.
 	 *
 	 * @return void

--- a/includes/course-theme/class-sensei-course-theme.php
+++ b/includes/course-theme/class-sensei-course-theme.php
@@ -84,7 +84,6 @@ class Sensei_Course_Theme {
 		add_action( 'registered_post_type', [ $this, 'add_post_type_rewrite_rules' ], 10, 2 );
 		add_action( 'registered_taxonomy', [ $this, 'add_taxonomy_rewrite_rules' ], 10, 3 );
 		add_action( 'shutdown', [ $this, 'maybe_flush_rewrite_rules' ] );
-		add_action( 'setup_theme', [ $this, 'maybe_override_theme' ], 2 );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Lesson::instance(), 'init' ] );
 		add_action( 'template_redirect', [ Sensei_Course_Theme_Quiz::instance(), 'init' ] );
 		add_action( 'template_redirect', [ $this, 'load_theme' ] );


### PR DESCRIPTION
Fixes #5542 

### Changes proposed in this Pull Request

* Disables overriding theme styles with learning mode theme styles
* Removes redirection to `/learn/...`
* Removes “Enable theme styles” option from Sensei settings, `Sensei_Course_Theme_Option::should_override_theme()` should always return false.

### Testing instructions

* Enable learning mode and observe that your current theme styles (eg. colors) are visible on a lesson and quiz page.


### New/Deprecated hooks

- `sensei_course_learning_mode_theme_override_enabled` filter will be deprecated in the next version.