### PR TITLE
Tests: Ensure $factory matches parent test class

### DIFF
--- a/tests/unit-tests/admin/tools/test-class-sensei-tool-module-slugs-mismatch.php
+++ b/tests/unit-tests/admin/tools/test-class-sensei-tool-module-slugs-mismatch.php
@@ -16,7 +16,7 @@ class Sensei_Tool_Module_Slugs_Mismatch_Tests extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/unit-tests/admin/tools/test-class-sensei-tool-remove-deleted-user-data.php
+++ b/tests/unit-tests/admin/tools/test-class-sensei-tool-remove-deleted-user-data.php
@@ -16,7 +16,7 @@ class Sensei_Tool_Remove_Deleted_User_Data_Tests extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/unit-tests/blocks/test-class-sensei-lesson-actions-blocks.php
+++ b/tests/unit-tests/blocks/test-class-sensei-lesson-actions-blocks.php
@@ -15,7 +15,7 @@ class Sensei_Lesson_Actions_Blocks extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Set up the test.

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme-option.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme-option.php
@@ -22,7 +22,7 @@ class Sensei_Course_Theme_Option_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Setup method. Run first on every test execution.

--- a/tests/unit-tests/course-theme/test-class-sensei-course-theme.php
+++ b/tests/unit-tests/course-theme/test-class-sensei-course-theme.php
@@ -25,7 +25,7 @@ class Sensei_Course_Theme_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Instance of `Sensei_Course_Theme_Option` under test.

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-course-model.php
@@ -22,7 +22,7 @@ class Sensei_Import_Course_Model_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Setup function.

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-lesson-model.php
@@ -22,7 +22,7 @@ class Sensei_Import_Lesson_Model_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Setup function.

--- a/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
+++ b/tests/unit-tests/data-port/models/test-class-sensei-data-port-question-model.php
@@ -20,7 +20,7 @@ class Sensei_Import_Question_Model_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Setup function.

--- a/tests/unit-tests/data-port/test-class-sensei-import-block-migrator.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-block-migrator.php
@@ -24,9 +24,9 @@ class Sensei_Import_Block_Migrator_Test extends WP_UnitTestCase {
 	 * Set up the tests.
 	 */
 	public function setUp() {
-		$this->factory = new Sensei_Factory();
+		parent::setUp();
 
-		return parent::setUp();
+		$this->factory = new Sensei_Factory();
 	}
 
 	/**

--- a/tests/unit-tests/data-port/test-class-sensei-import-job.php
+++ b/tests/unit-tests/data-port/test-class-sensei-import-job.php
@@ -20,11 +20,11 @@ class Sensei_Import_Job_Test extends WP_UnitTestCase {
 	 * Set up the tests.
 	 */
 	public function setUp() {
+		parent::setUp();
+
 		// Make sure CSVs are allowed on WordPress multi-site.
 		update_site_option( 'upload_filetypes', 'csv' );
 		$this->factory = new Sensei_Factory();
-
-		return parent::setUp();
 	}
 
 	/**

--- a/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-courses.php
+++ b/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-courses.php
@@ -11,7 +11,7 @@ class Sensei_Reports_Overview_Data_Provider_Courses_Test extends WP_UnitTestCase
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Set up before each test.

--- a/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-lessons.php
+++ b/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-lessons.php
@@ -11,7 +11,7 @@ class Sensei_Reports_Overview_Data_Provider_Lessons_Test extends WP_UnitTestCase
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Set up before each test.

--- a/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-students.php
+++ b/tests/unit-tests/reports/overview/data-provider/test-class-sensei-reports-overview-data-provider-students.php
@@ -13,7 +13,7 @@ class Sensei_Reports_Overview_Data_Provider_Students_Test extends WP_UnitTestCas
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Set up before each test.

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-courses.php
@@ -14,7 +14,7 @@ class Sensei_Reports_Overview_List_Table_Courses_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-lessons.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-lessons.php
@@ -11,7 +11,7 @@ class Sensei_Reports_Overview_List_Table_Lessons_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Set up before each test.

--- a/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
+++ b/tests/unit-tests/reports/overview/list-table/test-class-sensei-reports-overview-list-table-students.php
@@ -12,7 +12,7 @@ class Sensei_Reports_Overview_List_Table_Students_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Set up before each test.

--- a/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-courses.php
+++ b/tests/unit-tests/reports/overview/services/test-class-sensei-reports-overview-service-courses.php
@@ -14,7 +14,7 @@ class Sensei_Reports_Overview_Service_Courses_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	public static function setUpBeforeClass() {
 		parent::setUpBeforeClass();

--- a/tests/unit-tests/test-class-course.php
+++ b/tests/unit-tests/test-class-course.php
@@ -9,7 +9,7 @@ class Sensei_Class_Course_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Setup function.

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -6,7 +6,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 	/**
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Keep initial state of Sensei()->course.

--- a/tests/unit-tests/test-class-sensei-learners-main.php
+++ b/tests/unit-tests/test-class-sensei-learners-main.php
@@ -14,7 +14,7 @@ class Sensei_Learners_Main_Test extends WP_UnitTestCase {
 	use Sensei_Course_Enrolment_Manual_Test_Helpers;
 	use Sensei_Test_Login_Helpers;
 
-	private $factory;
+	protected $factory;
 
 	private $course_id;
 

--- a/tests/unit-tests/test-class-sensei-settings.php
+++ b/tests/unit-tests/test-class-sensei-settings.php
@@ -10,6 +10,20 @@
  */
 class Sensei_Settings_Test extends WP_UnitTestCase {
 	/**
+	 * Tracking original request method.
+	 *
+	 * @var string
+	 */
+	protected $original_request_method;
+
+	/**
+	 * Tracking original screen ID.
+	 *
+	 * @var string
+	 */
+	protected $original_screen;
+
+	/**
 	 * Set up for tests.
 	 */
 	public function setUp() {

--- a/tests/unit-tests/test-class-sensei-updates.php
+++ b/tests/unit-tests/test-class-sensei-updates.php
@@ -19,7 +19,7 @@ class Sensei_Updates_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Setup function.

--- a/tests/unit-tests/test-class-teacher.php
+++ b/tests/unit-tests/test-class-teacher.php
@@ -8,7 +8,7 @@ class Sensei_Class_Teacher_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Constructor function

--- a/tests/unit-tests/update-tasks/test-class-sensei-update-fix-question-author.php
+++ b/tests/unit-tests/update-tasks/test-class-sensei-update-fix-question-author.php
@@ -19,7 +19,7 @@ class Sensei_Update_Fix_Question_Author_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Set up the tests.

--- a/tests/unit-tests/update-tasks/test-class-sensei-update-remove-abandoned-multiple-question.php
+++ b/tests/unit-tests/update-tasks/test-class-sensei-update-remove-abandoned-multiple-question.php
@@ -13,7 +13,7 @@ class Sensei_Update_Remove_Abandoned_Multiple_Question_Test extends WP_UnitTestC
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Set up the tests.


### PR DESCRIPTION
PR to fix unit tests on WP nightly PHP 7.2. 

Context: [Core change commit](https://github.com/WordPress/wordpress-develop/commit/12f501271829ec35f03d5f7fe5643204c38cb400).

### Changes proposed in this Pull Request

* Make `private $factory` attributes `protected $factory` to match parent class. I would remove them entirely, but previous versions don't have this in the parent class.
* Make sure we run `parent::setUp()` _before_ we set up our custom factory.
* Added some missing class properties that PHP was mad about.

### Testing instructions
- Ensure tests pass.