### PR TITLE
Remove featured label hook for course categories for older wp version

### DIFF
--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -17,10 +17,17 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 	 * Sensei_Page_Blocks constructor.
 	 */
 	public function __construct() {
+		global $wp_version;
+
 		parent::__construct( [ 'page' ] );
 
 		add_filter( 'render_block_core/post-featured-image', [ $this, 'add_badge' ], 10, 3 );
-		add_filter( 'render_block', array( $this, 'add_course_featured_badge' ), 11, 3 );
+
+		$version = str_replace( '-src', '', $wp_version );
+
+		if ( ! version_compare( $version, '5.9', '<' ) ) {
+			add_filter( 'render_block', array( $this, 'add_course_featured_badge' ), 11, 3 );
+		}
 	}
 
 	/**


### PR DESCRIPTION
Fixes issue of render_block hook not having 3 arguments for wp version < 5.9.0

### Changes proposed in this Pull Request

* Added check to not add filter to render_block hook for wp version < 5.9.0 to show featured label in course categories

### Testing instructions

- Run the PHP unit tests for wp 5.8.0, they should pass
- Run wp 5.8 locally, make sure the featured tag is not visible in course categories for courses without featured image, but also there is no error