### PR TITLE
Use docker repository for gha-mjolnir (the action that closes issues automatically)

### DIFF
--- a/.github/workflows/close-issue-on-merge.yml
+++ b/.github/workflows/close-issue-on-merge.yml
@@ -9,6 +9,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Closes issues related to a merged pull request.
-              uses: fjorgemota/gha-mjolnir@v1.2.0
+              uses: docker://ghcr.io/fjorgemota/gha-mjolnir
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Update the repository to point to the already built docker container for `gha-mjolnir`, which is the action that closes issues automatically for PRs targeting other branches different than the default one;

### Testing instructions

Merge this PR and verify if the action runs successfully.

### Context

p1662756255485579-slack-C02NWDZBL0H