### PR TITLE
Skip the featured label rendering when it is outside of a query loop

### DIFF
--- a/assets/blocks/course-categories-block/block.json
+++ b/assets/blocks/course-categories-block/block.json
@@ -35,7 +35,7 @@
 			"type": "array"
 		}
 	},
-	"usesContext": [ "postId", "postType" ],
+	"usesContext": [ "postId", "postType", "queryId" ],
 	"supports": {
 		"html": false,
 		"spacing": {

--- a/assets/blocks/course-list-block/featured-label/index.test.js
+++ b/assets/blocks/course-list-block/featured-label/index.test.js
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import FeaturedLabel from '.';
+
+import { useEntityProp } from '@wordpress/core-data';
+import { when } from 'jest-when';
+
+jest.mock( '@wordpress/core-data' );
+
+const NoFeaturedCourse = {
+	_course_featured: false,
+};
+
+const FeaturedCourse = {
+	_course_featured: 'featured',
+};
+
+const NoFeatureImageAvailable = 0;
+const FeatureImageAvailable = Number.POSITIVE_INFINITY;
+
+describe( 'Featured Label', () => {
+	beforeAll( () => {
+		when( useEntityProp )
+			.calledWith( 'postType', 'course', 'meta', 'some-post-id' )
+			.mockReturnValue( [ NoFeaturedCourse ] );
+
+		when( useEntityProp )
+			.calledWith(
+				'postType',
+				'course',
+				'featured_media',
+				'some-post-id'
+			)
+			.mockReturnValue( [ NoFeatureImageAvailable ] );
+	} );
+
+	it( 'should render the children elements', () => {
+		const { getByText } = render(
+			<FeaturedLabel postId="some-post-id" isFeaturedImage={ true }>
+				<h1>I am wrapped component</h1>
+			</FeaturedLabel>
+		);
+
+		expect( getByText( 'I am wrapped component' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should not render the label when there is a featured image but the course is not featured', () => {
+		const { queryByText } = render(
+			<FeaturedLabel postId="some-post-id" isFeaturedImage={ true }>
+				<h1>I am component wrapped by the featured label</h1>
+			</FeaturedLabel>
+		);
+
+		expect( queryByText( 'Featured' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'should render the label when there is a featured image and the course is featured', () => {
+		when( useEntityProp )
+			.calledWith( 'postType', 'course', 'meta', 'some-post-id' )
+			.mockReturnValue( [ FeaturedCourse ] );
+
+		when( useEntityProp )
+			.calledWith(
+				'postType',
+				'course',
+				'featured_media',
+				'some-post-id'
+			)
+			.mockReturnValue( [ FeatureImageAvailable ] );
+
+		const { queryByText } = render(
+			<FeaturedLabel postId="some-post-id" isFeaturedImage={ true }>
+				<h1>I am component wrapped by the featured label</h1>
+			</FeaturedLabel>
+		);
+
+		expect( queryByText( 'Featured' ) ).toBeInTheDocument();
+	} );
+} );

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -186,7 +186,7 @@ addFilter(
  * @param {Object} settings Block settings.
  * @param {string} name     Block name.
  */
-const addWrapperAroundCourseCategoriesBlock = ( settings, name ) => {
+export function addWrapperAroundCourseCategoriesBlock( settings, name ) {
 	if ( 'sensei-lms/course-categories' !== name ) {
 		return settings;
 	}
@@ -197,6 +197,14 @@ const addWrapperAroundCourseCategoriesBlock = ( settings, name ) => {
 	settings = {
 		...settings,
 		edit: ( props ) => {
+			const shouldWrap =
+				props.context?.postType === 'course' &&
+				!! props.context?.queryId;
+
+			if ( ! shouldWrap ) {
+				return <BlockEdit { ...props } />;
+			}
+
 			return (
 				<FeaturedLabel postId={ props.context.postId }>
 					<BlockEdit { ...props } />
@@ -205,7 +213,7 @@ const addWrapperAroundCourseCategoriesBlock = ( settings, name ) => {
 		},
 	};
 	return settings;
-};
+}
 
 addFilter(
 	'blocks.registerBlockType',

--- a/assets/blocks/course-list-block/index.js
+++ b/assets/blocks/course-list-block/index.js
@@ -143,15 +143,24 @@ const hideUnnecessarySettingsForCourseList = () => {
  * @param {Object} settings Block settings.
  * @param {string} name     Block name.
  */
-function addWrapperAroundFeaturedImageBlock( settings, name ) {
+export function addWrapperAroundFeaturedImageBlock( settings, name ) {
 	if ( 'core/post-featured-image' !== name ) {
 		return settings;
 	}
+
 	const BlockEdit = settings.edit;
 
 	settings = {
 		...settings,
 		edit: ( props ) => {
+			const shouldWrap =
+				props.context?.postType === 'course' &&
+				!! props.context?.queryId;
+
+			if ( ! shouldWrap ) {
+				return <BlockEdit { ...props } />;
+			}
+
 			return (
 				<FeaturedLabel
 					postId={ props.context.postId }

--- a/assets/blocks/course-list-block/index.test.js
+++ b/assets/blocks/course-list-block/index.test.js
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { addWrapperAroundFeaturedImageBlock } from './';
+
+import FeaturedLabel from './featured-label';
+
+jest.mock( './featured-label' );
+
+describe( 'addWrapperAroundFeaturedImageBlock', () => {
+	const settings = {
+		attributes: {},
+		edit: () => <h1>I am a featured image </h1>,
+	};
+
+	beforeAll( () => {
+		FeaturedLabel.mockImplementation( () => <h1>Featured Label</h1> );
+	} );
+
+	it( 'should the original block when it is not a feature image', () => {
+		const result = addWrapperAroundFeaturedImageBlock(
+			settings,
+			'core/another-block'
+		);
+
+		expect( settings ).toEqual( result );
+	} );
+
+	it( 'should render the original block when it is not inside a course context', () => {
+		const { edit: Edit } = addWrapperAroundFeaturedImageBlock(
+			settings,
+			'core/post-featured-image'
+		);
+		const { getByText } = render(
+			<Edit context={ { postType: 'post' } } />
+		);
+
+		expect( getByText( 'I am a featured image' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render the original block when there is not a query id', () => {
+		const { edit: Edit } = addWrapperAroundFeaturedImageBlock(
+			settings,
+			'sensei-lms/course-categories'
+		);
+		const { getByText } = render(
+			<Edit context={ { postType: 'course', queryId: null } } />
+		);
+
+		expect( getByText( 'I am a featured image' ) ).toBeInTheDocument();
+	} );
+
+	it( 'should render the wrapped block when it is inside a course context', () => {
+		const { edit: Edit } = addWrapperAroundFeaturedImageBlock(
+			settings,
+			'core/post-featured-image'
+		);
+		const { getByText } = render(
+			<Edit
+				context={ { postType: 'course', queryId: 'some-query-id' } }
+			/>
+		);
+
+		expect( getByText( 'Featured Label' ) ).toBeInTheDocument();
+	} );
+} );

--- a/assets/blocks/course-list-block/index.test.js
+++ b/assets/blocks/course-list-block/index.test.js
@@ -5,7 +5,10 @@ import { render } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { addWrapperAroundFeaturedImageBlock } from './';
+import {
+	addWrapperAroundFeaturedImageBlock,
+	addWrapperAroundCourseCategoriesBlock,
+} from './';
 
 import FeaturedLabel from './featured-label';
 
@@ -61,6 +64,70 @@ describe( 'addWrapperAroundFeaturedImageBlock', () => {
 		);
 		const { getByText } = render(
 			<Edit
+				context={ { postType: 'course', queryId: 'some-query-id' } }
+			/>
+		);
+
+		expect( getByText( 'Featured Label' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'addWrapperAroundCourseCategoriesBlock', () => {
+	const settings = {
+		edit: () => <h1>I am a course category list</h1>,
+		attributes: {},
+	};
+
+	beforeAll( () => {
+		FeaturedLabel.mockImplementation( () => <h1>Featured Label</h1> );
+	} );
+
+	it( 'should the original block when it is not a feature image', () => {
+		const result = addWrapperAroundCourseCategoriesBlock(
+			settings,
+			'core/another-block'
+		);
+
+		expect( settings ).toEqual( result );
+	} );
+
+	it( 'should render the original block when it is not inside a course context', () => {
+		const { edit: Edit } = addWrapperAroundCourseCategoriesBlock(
+			settings,
+			'sensei-lms/course-categories'
+		);
+		const { getByText } = render(
+			<Edit context={ { postType: 'post' } } />
+		);
+
+		expect(
+			getByText( 'I am a course category list' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render the original block when there is not a query id', () => {
+		const { edit: Edit } = addWrapperAroundCourseCategoriesBlock(
+			settings,
+			'sensei-lms/course-categories'
+		);
+
+		const { getByText } = render(
+			<Edit context={ { postType: 'course', queryId: null } } />
+		);
+
+		expect(
+			getByText( 'I am a course category list' )
+		).toBeInTheDocument();
+	} );
+
+	it( 'should render the wrapped block when it is inside a course context', () => {
+		const { edit: WrappedEdit } = addWrapperAroundCourseCategoriesBlock(
+			settings,
+			'sensei-lms/course-categories'
+		);
+
+		const { getByText } = render(
+			<WrappedEdit
 				context={ { postType: 'course', queryId: 'some-query-id' } }
 			/>
 		);


### PR DESCRIPTION
Fixes #5658 

### Changes proposed in this Pull Request
* Skip the featured label wrapping when the featured image or the course category list block is outside the query loop context.
* Add unit tests to both filters 
* Add unit tests to the featured label.
* Update the course categories list to load the queryId from the context. 


### Extra notes:
We still have opportunities to improve the code, but considering it is a bug fix, I didn't want to make a more aggressive change. We can do it on further PRs.


### Testing instructions

Scenario 1: Regular Post
* Create a regular post 
* Assign a featured image.
* Add the "Post Fatured Image" block
* Check if there is no error on the console
* Check if the image is rendered

Scenario 2: Feature Image in a Course Page
* Create a Course 
* Assign a featured image.
* Add the "Post Fatured Image" block
* Check if there is no error on the console
* Check if the image is rendered

Scenario 3: Feature Image inside a Course List
* Course a Featured Course
* Assign a featured image.
* Set as a Featured Course
*
* Create a Page 
* Add a Course List
* Check if there is no error on the console
* Check if the image is rendered
* Check if the featured label is rendered
