### PR TITLE
Fix lesson block template loading

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -87,10 +87,23 @@ class Sensei_Course_Theme_Templates {
 	 * @return string[]
 	 */
 	public function set_single_template_hierarchy( $templates ) {
+
+		// Don't change if a block template is already selected for the post.
+		$is_default_template = count( $templates ) && str_ends_with( $templates[0], '.php' );
+
+		if ( ! $is_default_template ) {
+			return $templates;
+		}
+
 		if ( $this->should_use_quiz_template() ) {
 			return array_merge( [ 'quiz', 'lesson' ], $templates );
 		}
-		return array_merge( [ 'lesson', 'quiz' ], $templates );
+
+		if ( ! in_array( 'lesson', $templates, true ) ) {
+			return array_merge( [ 'lesson' ], $templates );
+		}
+
+		return $templates;
 	}
 
 	/**


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Respect the template selected for a lesson in the Lesson editor > Templates settings section. 

### Testing instructions

- Open a lesson in a course with learning mode
- In the Lesson settings sidebar, under Templates, create a new template for the lesson. Customize it
- Save the template and lesson 
- Check that the selected template is being used on the frontend
