### PR TITLE
Remove wp-block-sensei-lms-course-list as css indetifier for course categories

### DIFF
--- a/assets/blocks/course-categories-block/course-categories.scss
+++ b/assets/blocks/course-categories-block/course-categories.scss
@@ -1,4 +1,4 @@
-.wp-block-sensei-lms-course-list .wp-block-sensei-lms-course-categories {
+.wp-block-sensei-lms-course-categories {
 	margin: 10px 0;
 	width: 100%;
 

--- a/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
+++ b/tests/unit-tests/blocks/test-class-sensei-course-list-filter-block.php
@@ -15,7 +15,7 @@ class Sensei_Course_List_Filter_Block_Test extends WP_UnitTestCase {
 	 *
 	 * @var Sensei_Factory
 	 */
-	private $factory;
+	protected $factory;
 
 	/**
 	 * Instance of Sensei_Course_List_Filter_Block.


### PR DESCRIPTION
Fixes #5663

### Changes proposed in this Pull Request
- The course categories can be displayed both inside the course list and inside the course post
- The `.wp-block-sensei-lms-course-list` identifier made course categories not have CSS applied in case they are displayed inside course post and not course list

### Testing instructions
Scenario 1: **Course Edit view**
 1. Create a new course
 2. Add a category to the course 
 3. Add a course category block
 4. Make sure that the course category block items have proper CSS (you can compare it to course category added to course list)
 5. Make sure that there is not underscore on the course category
 
Scenario 2: **Course Preview**
 1. Create a new course
 2. Add a category to the course 
 3. Add a course category block
 4. Go to course preview
 5. Make sure that the course category block items have proper CSS (you can compare it to the course category added to the course list)
 6. Make sure that there is no underscore on the course category
 
 Scenario 3: **Course list preview - Make sure it's working as before**
 1. Create a new page
 2. Add course list category (Make sure you have at least one course with a category added)
 3. Make sure the course categories block is there
 4. Make sure it looks like before
 5.  Make sure that there is no underscore on the course category
 
| Course Edit Before | Course Preview Before | Course Edit After | Course Preview After |
| -- | -- | -- | -- |
| <img width="669" alt="image" src="https://user-images.githubusercontent.com/7208249/189898532-f41e5ecd-423c-4def-aaa8-699a74965e4d.png"> | <img width="802" alt="image" src="https://user-images.githubusercontent.com/7208249/189898606-610c945b-9456-4cfa-a62c-8b29eb2f4a87.png"> | <img width="670" alt="image" src="https://user-images.githubusercontent.com/7208249/189898838-dd377eb5-fbe1-4d97-8f47-c07f2fa7f061.png"> | <img width="776" alt="image" src="https://user-images.githubusercontent.com/7208249/189898881-6004d763-4090-429d-9c3e-7c49ec1e8d94.png"> |





 
 ###Notes: 
 
 @donnapep 
I saw that the class `wp-block-sensei-lms-course-list` was added by you for a more specific selection, but when I removed it I didn't see any issues (underline didn't appear) is there some specific use case for this? 
