### PR TITLE
Hide Featured Badge from Course Preview

### DIFF
--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -28,10 +28,6 @@ $block: '.wp-block-sensei-lms-course-list';
 		}
 	}
 
-	.sensei-lms-featured-badge {
-		display: none;
-	}
-
 	.featured-image-wrapper {
 		position: relative;
 
@@ -145,5 +141,9 @@ $block: '.wp-block-sensei-lms-course-list';
 	display: none;
 }
 .course-list-featured-label__course-categories {
+	display: none;
+}
+
+.sensei-lms-featured-badge {
 	display: none;
 }


### PR DESCRIPTION
Fixes #5669

### Changes proposed in this Pull Request
- If the `sensei-lms-featured-badge` in CSS is defined under `.wp-block-sensei-lms-course-list` the `display:none` will not be applied on the pages and block that are not course/list, which means we had a **Featured**   tag on course view 

### Testing instructions
Scenario 1: Featured Badge not displayed on course preview 
1. Create a course
2. Make it featured
3. Add featured image 
4. Add featured image block 
5. Go to Preview
6. Featured should NOT be displayed 




<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
*

<!-- Add the following only if there are new/updated actions or filters. Please provide a brief description of what they do and any arguments they may take. Be sure to also add the "Hooks" label to this PR. -->
### New/Updated Hooks

*

<!-- Add the following only if there is any code that is being deprecated. Please list the replacement function or hook that should be called instead, if applicable. Be sure to also add the "Deprecation" label to this PR. -->
### Deprecated Code

*

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video
