### PR TITLE
Fix comparison that was not properly checking for option

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -635,7 +635,7 @@ class Sensei_Lesson {
 	 */
 	public function meta_box_save( $post_id ) {
 
-		// This should only run on the Classic Editor
+		// This should only run on the Classic Editor.
 		if ( Sensei()->quiz->is_block_based_editor_enabled() ) {
 			return false;
 		}

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -671,12 +671,12 @@ class Sensei_Lesson {
 			}
 		}
 
-		$new_pass_required     = isset( $_POST['pass_required'] ) ? sanitize_text_field( wp_unslash( $_POST['pass_required'] ) ) : '-1';
-		$new_pass_percentage   = isset( $_POST['quiz_passmark'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_passmark'] ) ) : '-1';
-		$new_enable_quiz_reset = isset( $_POST['enable_quiz_reset'] ) ? sanitize_text_field( wp_unslash( $_POST['enable_quiz_reset'] ) ) : '-1';
-		$show_questions        = isset( $_POST['show_questions'] ) ? sanitize_text_field( wp_unslash( $_POST['show_questions'] ) ) : '-1';
-		$random_question_order = isset( $_POST['random_question_order'] ) ? sanitize_text_field( wp_unslash( $_POST['random_question_order'] ) ) : '-1';
-		$quiz_grade_type       = isset( $_POST['quiz_grade_type'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_grade_type'] ) ) : '-1';
+		$new_pass_required     = isset( $_POST['pass_required'] ) ? sanitize_text_field( wp_unslash( $_POST['pass_required'] ) ) : null;
+		$new_pass_percentage   = isset( $_POST['quiz_passmark'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_passmark'] ) ) : null;
+		$new_enable_quiz_reset = isset( $_POST['enable_quiz_reset'] ) ? sanitize_text_field( wp_unslash( $_POST['enable_quiz_reset'] ) ) : null;
+		$show_questions        = isset( $_POST['show_questions'] ) ? sanitize_text_field( wp_unslash( $_POST['show_questions'] ) ) : null;
+		$random_question_order = isset( $_POST['random_question_order'] ) ? sanitize_text_field( wp_unslash( $_POST['random_question_order'] ) ) : null;
+		$quiz_grade_type       = isset( $_POST['quiz_grade_type'] ) ? sanitize_text_field( wp_unslash( $_POST['quiz_grade_type'] ) ) : null;
 
 		$new_settings = array(
 			'pass_required'         => $new_pass_required,
@@ -5137,7 +5137,7 @@ class Sensei_Lesson {
 		if ( isset( $quiz_id ) && 0 < intval( $quiz_id ) ) {
 
 			// update pass required.
-			if ( - 1 !== $new_settings['pass_required'] ) {
+			if ( null !== $new_settings['pass_required'] ) {
 
 				$checked = $new_settings['pass_required'] ? 'on' : 'off';
 				update_post_meta( $quiz_id, '_pass_required', $checked );
@@ -5152,7 +5152,7 @@ class Sensei_Lesson {
 			}
 
 			// update enable quiz reset.
-			if ( - 1 !== $new_settings['enable_quiz_reset'] ) {
+			if ( null !== $new_settings['enable_quiz_reset'] ) {
 
 				$checked = $new_settings['enable_quiz_reset'] ? 'on' : '';
 				update_post_meta( $quiz_id, '_enable_quiz_reset', $checked );
@@ -5161,7 +5161,7 @@ class Sensei_Lesson {
 			}
 
 			// update random question order.
-			if ( '-1' !== $new_settings['random_question_order'] ) {
+			if ( null !== $new_settings['random_question_order'] ) {
 
 				$checked = $new_settings['random_question_order'] ? 'yes' : 'no';
 				update_post_meta( $quiz_id, '_random_question_order', $checked );
@@ -5169,7 +5169,7 @@ class Sensei_Lesson {
 			}
 
 			// update quiz grade type.
-			if ( - 1 !== $new_settings['quiz_grade_type'] ) {
+			if ( null !== $new_settings['quiz_grade_type'] ) {
 
 				$checked = $new_settings['quiz_grade_type'] ? 'auto' : 'manual';
 				update_post_meta( $quiz_id, '_quiz_grade_type', $checked );

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -635,6 +635,11 @@ class Sensei_Lesson {
 	 */
 	public function meta_box_save( $post_id ) {
 
+		// This should only run on the Classic Editor
+		if ( Sensei()->quiz->is_block_based_editor_enabled() ) {
+			return false;
+		}
+
 		// Verify the nonce before proceeding.
 		if ( ( get_post_type( $post_id ) !== $this->token ) || ! isset( $_POST[ 'woo_' . $this->token . '_nonce' ] ) || ! wp_verify_nonce( $_POST[ 'woo_' . $this->token . '_nonce' ], 'sensei-save-post-meta' ) ) {
 			return $post_id;

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -5161,7 +5161,7 @@ class Sensei_Lesson {
 			}
 
 			// update random question order.
-			if ( - 1 !== $new_settings['random_question_order'] ) {
+			if ( '-1' !== $new_settings['random_question_order'] ) {
 
 				$checked = $new_settings['random_question_order'] ? 'yes' : 'no';
 				update_post_meta( $quiz_id, '_random_question_order', $checked );

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -1570,7 +1570,7 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		$lesson->meta_fields = [ 'lesson_video_embed', 'lesson_preview', 'lesson_length' ];
 
 		// We need to enable this filter so that meta_box_save can properly run.
-		add_filter( 'sensei_quiz_enable_block_based_editor', 'return__false' );
+		add_filter( 'sensei_quiz_enable_block_based_editor', '__return_false' );
 		/* Act */
 		$lesson->meta_box_save( $post->ID );
 

--- a/tests/unit-tests/test-class-lesson.php
+++ b/tests/unit-tests/test-class-lesson.php
@@ -1569,6 +1569,8 @@ class Sensei_Class_Lesson_Test extends WP_UnitTestCase {
 		$lesson              = new Sensei_Lesson();
 		$lesson->meta_fields = [ 'lesson_video_embed', 'lesson_preview', 'lesson_length' ];
 
+		// We need to enable this filter so that meta_box_save can properly run.
+		add_filter( 'sensei_quiz_enable_block_based_editor', 'return__false' );
 		/* Act */
 		$lesson->meta_box_save( $post->ID );
 


### PR DESCRIPTION
Fixes #5672

### Changes proposed in this Pull Request

Right now the plugins is comparing a **string** of `-1` with an integer of `-1` which means that any time the option is set to anything it will update, causing a bug.

Would it be better to change the check to a string / stirng comparison, or should I cast an integer to make it an int / int comparison?  In this PR I chose the string / string comparison.

### Testing instructions

- Go to a Lesson
- Enable "Random Question Order"
- Click "Update"
- Disable "Random Question Order"
- Click "Update"
- Click "Update" again without changing anything
- Refresh the page
- Check that "Random Quesion Order" is NOT set.

Edit:  I think maybe we should also check the rest of the comparisons in this file and make it more type friendly?