### PR TITLE
Do not paginate completed quiz

### DIFF
--- a/includes/blocks/course-theme/class-quiz-actions.php
+++ b/includes/blocks/course-theme/class-quiz-actions.php
@@ -47,7 +47,6 @@ class Quiz_Actions {
 	 * @return string The block HTML.
 	 */
 	public function render() : string {
-
 		if ( ! sensei_can_user_view_lesson() || 'quiz' !== get_post_type() ) {
 			return '';
 		}
@@ -55,10 +54,14 @@ class Quiz_Actions {
 		global $sensei_question_loop;
 		$pagination_enabled = $sensei_question_loop && $sensei_question_loop['total_pages'] > 1;
 
+		$lesson_id = \Sensei_Utils::get_current_lesson();
+		$status    = \Sensei_Utils::user_lesson_status( $lesson_id );
+
 		// Get quiz actions. Either actions with pagination
 		// or only action if pagination is not enabled.
+		// Also, don't paginate if quiz has been completed.
 		ob_start();
-		if ( $pagination_enabled ) {
+		if ( $pagination_enabled && $status && 'in-progress' === $status->comment_approved ) {
 			Sensei_Quiz::the_quiz_pagination();
 			Sensei_Quiz::output_quiz_hidden_fields();
 		} else {

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1537,7 +1537,11 @@ class Sensei_Quiz {
 			true
 		);
 
-		if ( ! empty( $pagination_settings['pagination_number'] ) ) {
+		$lesson_id = \Sensei_Utils::get_current_lesson();
+		$status    = \Sensei_Utils::user_lesson_status( $lesson_id );
+
+		// Don't paginate if quiz has been completed.
+		if ( ! empty( $pagination_settings['pagination_number'] ) && $status && 'in-progress' === $status->comment_approved ) {
 			$sensei_question_loop['posts_per_page'] = (int) $pagination_settings['pagination_number'];
 
 			// phpcs:ignore WordPress.Security.NonceVerification -- Argument is used for pagination in the frontend.

--- a/includes/class-sensei-quiz.php
+++ b/includes/class-sensei-quiz.php
@@ -1537,11 +1537,7 @@ class Sensei_Quiz {
 			true
 		);
 
-		$lesson_id = \Sensei_Utils::get_current_lesson();
-		$status    = \Sensei_Utils::user_lesson_status( $lesson_id );
-
-		// Don't paginate if quiz has been completed.
-		if ( ! empty( $pagination_settings['pagination_number'] ) && $status && 'in-progress' === $status->comment_approved ) {
+		if ( ! empty( $pagination_settings['pagination_number'] ) ) {
 			$sensei_question_loop['posts_per_page'] = (int) $pagination_settings['pagination_number'];
 
 			// phpcs:ignore WordPress.Security.NonceVerification -- Argument is used for pagination in the frontend.
@@ -1573,7 +1569,13 @@ class Sensei_Quiz {
 			$loop_questions = $all_questions;
 		}
 
-		$sensei_question_loop['questions'] = $loop_questions;
+		// Don't use pagination if quiz has been completed.
+		$lesson_id = \Sensei_Utils::get_current_lesson();
+		$status    = \Sensei_Utils::user_lesson_status( $lesson_id );
+
+		$quiz_completed = $status && 'in-progress' !== $status->comment_approved;
+
+		$sensei_question_loop['questions'] = $quiz_completed ? $all_questions : $loop_questions;
 		$sensei_question_loop['quiz_id']   = $quiz_id;
 
 	}


### PR DESCRIPTION
Fixes #5665 

### Changes proposed in this Pull Request

* Checks whether a quiz is completed before applying pagination variables.
* Checks whether a quiz is completed before displaying pagination links in quiz action blocks (learning mode).


### Testing instructions

- On a lesson editor page, add a quiz if none already.
- Select the quiz block and enable pagination in the settings panel. Also chose 1 question per page so there's no need to add more than 2 questions.
- Make sure you have multiple questions in the quiz. Then save the lesson.
- Also make sure learning mode is active.
- visit the lesson on the frontend, then take the quiz.
- Notice the quiz is paginated, notice the quiz actions in the footer has pagination links and the actual quiz actions.
- Answer the quiz questions one by one and complete quiz.
- Now notice that all the questions are displayed and there's no pagination links in the footer.

### Screenshot / Video

https://user-images.githubusercontent.com/26160845/190471868-bb12485b-15e0-40c8-a17d-96f95aa34ce3.mov

