### PR TITLE
Add/embed css into lm templates

### DIFF
--- a/assets/course-theme/blocks/index.js
+++ b/assets/course-theme/blocks/index.js
@@ -10,12 +10,14 @@ import courseNavigationBlock from './course-navigation';
 import uiBlocks from './ui';
 import lessonBlocks from './lesson-blocks';
 import quizBlocks from './quiz-blocks';
+import { templateStyleBlock } from './template-style';
 
 const blocks = [
 	...lessonBlocks,
 	...quizBlocks,
 	...uiBlocks,
 	courseNavigationBlock,
+	templateStyleBlock,
 ];
 
 blocks.forEach( ( block ) => {

--- a/assets/course-theme/blocks/template-style/index.js
+++ b/assets/course-theme/blocks/template-style/index.js
@@ -1,0 +1,1 @@
+export { templateStyleBlock } from './template-style-block';

--- a/assets/course-theme/blocks/template-style/template-style-block.js
+++ b/assets/course-theme/blocks/template-style/template-style-block.js
@@ -1,0 +1,26 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Icon } from '@wordpress/components';
+import { brush } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import blockMeta from './template-style.block.json';
+
+const TemplateStyleBlockEditSave = ( { attributes } ) => (
+	<style dangerouslySetInnerHTML={ { __html: attributes.content } } />
+);
+
+export const templateStyleBlock = {
+	...blockMeta,
+	title: __( 'Template Style', 'sensei-lms' ),
+	icon: {
+		src: <Icon icon={ brush } />,
+		foreground: '#43AF99',
+	},
+	edit: TemplateStyleBlockEditSave,
+	save: TemplateStyleBlockEditSave,
+};

--- a/assets/course-theme/blocks/template-style/template-style.block.json
+++ b/assets/course-theme/blocks/template-style/template-style.block.json
@@ -1,0 +1,13 @@
+{
+	"name": "sensei-lms/template-style",
+	"category": "theme",
+	"parent": [],
+	"apiVersion": 2,
+	"attributes": {
+		"content": {
+            "source": "text",
+			"type": "string",
+			"selector": "style"
+		}
+	}
+}

--- a/includes/blocks/course-theme/class-course-theme-blocks.php
+++ b/includes/blocks/course-theme/class-course-theme-blocks.php
@@ -63,6 +63,7 @@ class Course_Theme_Blocks extends Sensei_Blocks_Initializer {
 		new Blocks\Sidebar_Toggle_Button();
 		new Blocks\Quiz_Actions();
 		new Blocks\Page_Actions();
+		new Blocks\Template_Style();
 		new \Sensei_Block_Quiz_Progress();
 	}
 }

--- a/includes/blocks/course-theme/class-template-style.php
+++ b/includes/blocks/course-theme/class-template-style.php
@@ -18,6 +18,14 @@ use \Sensei_Blocks;
  * Allows to embed css styles into the block templates. Used for Learning Mode block templates.
  */
 class Template_Style {
+
+	/**
+	 * Block name
+	 *
+	 * @var string
+	 */
+	const BLOCK_NAME = 'sensei-lms/template-style';
+
 	/**
 	 * Block JSON file.
 	 */
@@ -29,7 +37,7 @@ class Template_Style {
 	public function __construct() {
 		$block_json_path = Sensei()->assets->src_path( 'course-theme/blocks' ) . self::BLOCK_JSON_FILE;
 		Sensei_Blocks::register_sensei_block(
-			'sensei-lms/template-style',
+			self::BLOCK_NAME,
 			[
 				'render_callback' => [ $this, 'render' ],
 				'style'           => 'sensei-theme-blocks',
@@ -57,13 +65,12 @@ class Template_Style {
 	 *
 	 * @param string $content The css content of the Template_Style block.
 	 */
-	public static function render_embed( string $content = '' ): string {
-		return "
-            <!-- wp:sensei-lms/template-style -->
-            <style>
-                {$content}
-            </style>
-            <!-- /wp:sensei-lms/template-style -->
-		";
+	public static function serialize_block( string $content = '' ): string {
+		return serialize_block(
+			[
+				'blockName'    => self::BLOCK_NAME,
+				'innerContent' => [ '<style>', $content, '</style>' ],
+			]
+		);
 	}
 }

--- a/includes/blocks/course-theme/class-template-style.php
+++ b/includes/blocks/course-theme/class-template-style.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * File containing the Template_Style class.
+ *
+ * @package sensei
+ * @since
+ */
+
+namespace Sensei\Blocks\Course_Theme;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+use \Sensei_Blocks;
+
+/**
+ * Allows to embed css styles into the block templates. Used for Learning Mode block templates.
+ */
+class Template_Style {
+	/**
+	 * Block JSON file.
+	 */
+	const BLOCK_JSON_FILE = '/template-style/template-style.block.json';
+
+	/**
+	 * Style constructor.
+	 */
+	public function __construct() {
+		$block_json_path = Sensei()->assets->src_path( 'course-theme/blocks' ) . self::BLOCK_JSON_FILE;
+		Sensei_Blocks::register_sensei_block(
+			'sensei-lms/template-style',
+			[
+				'render_callback' => [ $this, 'render' ],
+				'style'           => 'sensei-theme-blocks',
+			],
+			$block_json_path
+		);
+	}
+
+	/**
+	 * Renders the block.
+	 *
+	 * @param array  $attributes The block attributes.
+	 * @param string $content The block content.
+	 *
+	 * @access private
+	 *
+	 * @return string The block HTML.
+	 */
+	public function render( array $attributes = [], string $content ): string {
+		return $content;
+	}
+
+	/**
+	 * Returns a string that could be embedded into block template as a block.
+	 *
+	 * @param string $content The css content of the Template_Style block.
+	 */
+	public static function render_embed( string $content = '' ): string {
+		return "
+            <!-- wp:sensei-lms/template-style -->
+            <style>
+                {$content}
+            </style>
+            <!-- /wp:sensei-lms/template-style -->
+		";
+	}
+}

--- a/includes/blocks/course-theme/class-template-style.php
+++ b/includes/blocks/course-theme/class-template-style.php
@@ -70,6 +70,12 @@ class Template_Style {
 			[
 				'blockName'    => self::BLOCK_NAME,
 				'innerContent' => [ '<style>', $content, '</style>' ],
+				'attrs'        => [
+					'lock' => [
+						'move'   => true,
+						'remove' => true,
+					],
+				],
 			]
 		);
 	}

--- a/includes/class-sensei-autoloader.php
+++ b/includes/class-sensei-autoloader.php
@@ -239,6 +239,7 @@ class Sensei_Autoloader {
 			'Sensei\Blocks\Course_Theme\Quiz_Actions'      => 'blocks/course-theme/class-quiz-actions.php',
 			'Sensei\Blocks\Course_Theme\Page_Actions'      => 'blocks/course-theme/class-page-actions.php',
 			'Sensei\Blocks\Course_Theme\Ui'                => 'blocks/course-theme/class-ui.php',
+			'Sensei\Blocks\Course_Theme\Template_Style'    => 'blocks/course-theme/class-template-style.php',
 		);
 	}
 

--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -193,14 +193,6 @@ class Sensei_Course_Theme_Editor {
 		add_editor_style( Sensei()->assets->asset_url( 'css/learning-mode.css' ) );
 		add_editor_style( Sensei()->assets->asset_url( 'css/learning-mode.editor.css' ) );
 		add_editor_style( Sensei()->assets->asset_url( 'css/frontend.css' ) );
-
-		// Also add the extra styles that comes with the active block template.
-		$template = Sensei_Course_Theme_Template_Selection::get_active_template();
-		if ( isset( $template->styles ) && is_array( $template->styles ) ) {
-			foreach ( $template->styles as $url ) {
-				add_editor_style( $url );
-			}
-		}
 	}
 
 	/**

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -286,7 +286,7 @@ class Sensei_Course_Theme_Templates {
 							}
 						}
 					}
-					$template_object->content = $html . Template_Style::render_embed( $css );
+					$template_object->content = $html . Template_Style::serialize_block( $css );
 				}
 				$template_object->wp_id  = null;
 				$template_object->author = null;

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -10,6 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
+use \Sensei\Blocks\Course_Theme\Template_Style;
+
 /**
  * Sensei's block templates.
  *
@@ -158,6 +160,7 @@ class Sensei_Course_Theme_Templates {
 					'slug'        => 'lesson',
 					'id'          => self::THEME_PREFIX . '//lesson',
 					'content'     => $template->content['lesson'],
+					'styles'      => $template->styles,
 				]
 			),
 			'quiz'   => array_merge(
@@ -169,16 +172,10 @@ class Sensei_Course_Theme_Templates {
 					'slug'        => 'quiz',
 					'id'          => self::THEME_PREFIX . '//quiz',
 					'content'     => $template->content['quiz'],
+					'styles'      => $template->styles,
 				]
 			),
 		];
-
-		// Enqueue styles of the current active template.
-		if ( is_array( $template->styles ) ) {
-			foreach ( $template->styles as $index => $style_url ) {
-				wp_enqueue_style( self::THEME_PREFIX . '-' . $template->name . "-styles-$index", $style_url, [], $template->version );
-			}
-		}
 
 		// Enqueue scripts of the current active template.
 		if ( is_array( $template->scripts ) ) {
@@ -265,11 +262,6 @@ class Sensei_Course_Theme_Templates {
 		$templates    = [];
 
 		foreach ( $this->file_templates as $name => $template ) {
-			// Prefill the template contents from their content files.
-			if ( isset( $template['content'] ) && file_exists( $template['content'] ) ) {
-				// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local file usage.
-				$template['content'] = file_get_contents( $template['content'] );
-			}
 
 			$db_template     = $db_templates[ $name ] ?? null;
 			$template_object = (object) $template;
@@ -277,6 +269,25 @@ class Sensei_Course_Theme_Templates {
 			if ( ! empty( $db_template ) ) {
 				$template_object = $this->build_template_from_post( $db_template );
 			} else {
+				// Prefill the template contents from their content files.
+				if ( ! empty( $template['content'] ) && file_exists( $template['content'] ) ) {
+					// Get the block template html.
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local file usage.
+					$html = file_get_contents( $template['content'] );
+
+					// Get the block template styles.
+					$css = '';
+					if ( ! empty( $template['styles'] ) && is_array( $template['styles'] ) ) {
+						foreach ( $template['styles'] as $template_style_url ) {
+							$response = wp_remote_get( $template_style_url );
+							if ( ! is_wp_error( $response ) && ! empty( $response['body'] ) ) {
+								$css .= "\n\n";
+								$css .= $response['body'];
+							}
+						}
+					}
+					$template_object->content = $html . Template_Style::render_embed( $css );
+				}
 				$template_object->wp_id  = null;
 				$template_object->author = null;
 			}


### PR DESCRIPTION
Fixes #5541 

### Changes proposed in this Pull Request

* Adds a "Template Style" (`sensei-lms/template-style`) block that allows to append css into the block template html content.
* Appends the lm template specific styles at `Sensei_Course_Theme_Template->styles` into the block template's content instead of queuing them via `wp_enqueue_style()`. 

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Activate a "Video" template and visit the template editor.
* Open the Block List View and confirm there is a "Template Style" block at the end of the list.
* Edit that block as HTML and change the `background-color` to something else and confirm the background changes.
* Save the updates of the template.
* Confirm the background color change is reflected on the frontend.
* Clear the customizations of the template and confirm everything gets back to original version. Both in the editor and on the frontend.

<!--
Helpful tips for screenshots:
https://en.support.wordpress.com/make-a-screenshot/
-->
### Screenshot / Video


https://user-images.githubusercontent.com/2578542/190599463-1096a4de-e324-4050-a9fe-773c7df0f4f4.mp4

