### PR TITLE
Add/featured video method

### DIFF
--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -837,13 +837,7 @@ class Sensei_Frontend {
 	public function sensei_lesson_video( $post_id = 0 ) {
 		if ( 0 < intval( $post_id ) && sensei_can_user_view_lesson( $post_id ) ) {
 			$lesson_video_embed = get_post_meta( $post_id, '_lesson_video_embed', true );
-			if ( 'http' == substr( $lesson_video_embed, 0, 4 ) ) {
-				// V2 - make width and height a setting for video embed.
-				$lesson_video_embed = wp_oembed_get( esc_url( $lesson_video_embed ) );
-			}
-
-			$lesson_video_embed = do_shortcode( html_entity_decode( $lesson_video_embed ) );
-			$lesson_video_embed = Sensei_Wp_Kses::maybe_sanitize( $lesson_video_embed, $this->allowed_html );
+			$lesson_video_embed = Sensei_Utils::render_video_embed( $lesson_video_embed );
 
 			if ( '' != $lesson_video_embed ) {
 				?>

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -835,7 +835,7 @@ class Sensei_Frontend {
 	 * @param int $post_id Optional. Lesson ID. Default 0.
 	 */
 	public function sensei_lesson_video( $post_id = 0 ) {
-		if ( 0 < intval( $post_id ) ) {
+		if ( 0 < intval( $post_id ) && sensei_can_user_view_lesson( $post_id ) ) {
 			$lesson_video_embed = get_post_meta( $post_id, '_lesson_video_embed', true );
 			if ( 'http' == substr( $lesson_video_embed, 0, 4 ) ) {
 				// V2 - make width and height a setting for video embed.

--- a/includes/class-sensei-frontend.php
+++ b/includes/class-sensei-frontend.php
@@ -835,7 +835,7 @@ class Sensei_Frontend {
 	 * @param int $post_id Optional. Lesson ID. Default 0.
 	 */
 	public function sensei_lesson_video( $post_id = 0 ) {
-		if ( 0 < intval( $post_id ) && sensei_can_user_view_lesson( $post_id ) ) {
+		if ( 0 < intval( $post_id ) ) {
 			$lesson_video_embed = get_post_meta( $post_id, '_lesson_video_embed', true );
 			if ( 'http' == substr( $lesson_video_embed, 0, 4 ) ) {
 				// V2 - make width and height a setting for video embed.

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2632,7 +2632,7 @@ class Sensei_Utils {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param string $post_id
+	 * @param string $post_id the post ID
 	 *
 	 * @return string The featured video HTML output
 	 */

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2641,7 +2641,7 @@ class Sensei_Utils {
 			$post   = get_post( $post_id );
 			$blocks = parse_blocks( $post->post_content );
 			foreach ( $blocks as $block ) {
-				if ( $block['blockName'] === 'sensei-lms/featured-video' ) {
+				if ( 'sensei-lms/featured-video' === $block['blockName'] ) {
 					return trim( render_block( $block ) );
 				}
 			}

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2642,7 +2642,10 @@ class Sensei_Utils {
 			$blocks = parse_blocks( $post->post_content );
 			foreach ( $blocks as $block ) {
 				if ( 'sensei-lms/featured-video' === $block['blockName'] ) {
-					return trim( render_block( $block ) );
+					if ( 'sensei-pro/interactive-video' === $block['innerBlocks'][0]['blockName'] ) {
+						$block = $block['innerBlocks'][0];
+					}
+					return wp_oembed_get( $block['innerBlocks'][0]['attrs']['url'] );
 				}
 			}
 		} else {

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2626,6 +2626,29 @@ class Sensei_Utils {
 
 		return wp_date( get_option( 'date_format' ), $date->getTimestamp(), $timezone );
 	}
+
+	/**
+	 * Get's the HTML content from the Featured Video for a post
+	 *
+	 * @param string $post_id
+	 *
+	 * @return string The featured video HTML output
+	 */
+	public static function get_featured_video_html( $post_id ) {
+		if ( has_blocks( $post_id ) ) {
+			$post   = get_post( $post_id );
+			$blocks = parse_blocks( $post->post_content );
+			foreach ( $blocks as $block ) {
+				if ( $block['blockName'] === 'sensei-lms/featured-video' ) {
+					return trim( render_block( $block ) );
+				}
+			}
+		} else {
+			ob_start();
+			Sensei()->frontend->sensei_lesson_video( $post_id );
+			return trim( ob_get_clean() );
+		}
+	}
 }
 
 /**

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2630,6 +2630,8 @@ class Sensei_Utils {
 	/**
 	 * Get's the HTML content from the Featured Video for a post
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param string $post_id
 	 *
 	 * @return string The featured video HTML output

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2637,7 +2637,7 @@ class Sensei_Utils {
 	 * @return string|false The featured video HTML output if it exists, or false if it doesn't.
 	 */
 	public static function get_featured_video_html( $post_id ) {
-
+		$video_embed  = '';
 		$allowed_html = array(
 			'embed'  => array(),
 			'iframe' => array(
@@ -2650,7 +2650,6 @@ class Sensei_Utils {
 			),
 			'video'  => Sensei_Wp_Kses::get_video_html_tag_allowed_attributes(),
 		);
-
 		if ( has_blocks( $post_id ) ) {
 			$post   = get_post( $post_id );
 			$blocks = parse_blocks( $post->post_content );
@@ -2663,9 +2662,9 @@ class Sensei_Utils {
 				}
 			}
 		} else {
-			$video_embed = get_post_meta($post_id, '_lesson_video_embed', true);
+			$video_embed = get_post_meta( $post_id, '_lesson_video_embed', true );
 		}
-		if ( 'http' == substr( $video_embed, 0, 4 ) ) {
+		if ( 'http' === substr( $video_embed, 0, 4 ) ) {
 			$video_embed = wp_oembed_get( esc_url( $video_embed ) );
 			$video_embed = do_shortcode( html_entity_decode( $video_embed ) );
 			$video_embed = Sensei_Wp_Kses::maybe_sanitize( $video_embed, $allowed_html );

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2632,11 +2632,25 @@ class Sensei_Utils {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param string $post_id the post ID
+	 * @param string $post_id the post ID.
 	 *
-	 * @return string The featured video HTML output
+	 * @return string|false The featured video HTML output if it exists, or false if it doesn't.
 	 */
 	public static function get_featured_video_html( $post_id ) {
+
+		$allowed_html = array(
+			'embed'  => array(),
+			'iframe' => array(
+				'title'           => array(),
+				'width'           => array(),
+				'height'          => array(),
+				'src'             => array(),
+				'frameborder'     => array(),
+				'allowfullscreen' => array(),
+			),
+			'video'  => Sensei_Wp_Kses::get_video_html_tag_allowed_attributes(),
+		);
+
 		if ( has_blocks( $post_id ) ) {
 			$post   = get_post( $post_id );
 			$blocks = parse_blocks( $post->post_content );
@@ -2645,14 +2659,18 @@ class Sensei_Utils {
 					if ( 'sensei-pro/interactive-video' === $block['innerBlocks'][0]['blockName'] ) {
 						$block = $block['innerBlocks'][0];
 					}
-					return wp_oembed_get( $block['innerBlocks'][0]['attrs']['url'] );
+					$video_embed = $block['innerBlocks'][0]['attrs']['url'];
 				}
 			}
 		} else {
-			ob_start();
-			Sensei()->frontend->sensei_lesson_video( $post_id );
-			return trim( ob_get_clean() );
+			$video_embed = get_post_meta($post_id, '_lesson_video_embed', true);
 		}
+		if ( 'http' == substr( $video_embed, 0, 4 ) ) {
+			$video_embed = wp_oembed_get( esc_url( $video_embed ) );
+			$video_embed = do_shortcode( html_entity_decode( $video_embed ) );
+			$video_embed = Sensei_Wp_Kses::maybe_sanitize( $video_embed, $allowed_html );
+		}
+		return $video_embed;
 	}
 }
 

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2650,11 +2650,10 @@ class Sensei_Utils {
 
 		if ( 'http' === substr( $url, 0, 4 ) ) {
 			// V2 - make width and height a setting for video embed.
-			$lesson_video_embed = wp_oembed_get( esc_url( $url ) );
-			$lesson_video_embed = do_shortcode( html_entity_decode( $lesson_video_embed ) );
-			return Sensei_Wp_Kses::maybe_sanitize( $lesson_video_embed, $allowed_html );
+			$url = wp_oembed_get( esc_url( $url ) );
+			$url = do_shortcode( html_entity_decode( $url ) );
 		}
-		return null;
+		return Sensei_Wp_Kses::maybe_sanitize( $url, $allowed_html );
 	}
 	/**
 	 * Gets the HTML content from the Featured Video for a post


### PR DESCRIPTION
Fixes #5607

### Changes proposed in this Pull Request

* Removes `sensei_can_user_view_lesson` from legacy `sensei_lesson_video` method.  I don't think it makes sense in an output function, it should be checked later on.  I don't think this would be a problem because there are likely checks at the template level that should account for this. 
* Creates a new Utility function `get_featured_video_html` which will get either the `sensei-lms/featured-video` HTML or parse the `_lesson_video_embed` postmeta and output an oEmbed for the video. 

Example output of `_lesson_video_embed`: 

```
"<div class="video sensei-video-embed">
<iframe width="525" height="295" src="https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed" frameborder="0" allowfullscreen></iframe>
</div>"
```

Example Featured Video Block output for Media files:

```
"<figure class="wp-block-video">
<video controls src="http://sensei.local/wp-content/uploads/2022/09/Snap-Camera-Video-2.mp4"></video>
</figure>"
```

Example Featured Video Block output for oEmbeds:
```
"<figure class="wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio">
<div class="wp-block-embed__wrapper">\n
https://www.youtube.com/watch?v=dQw4w9WgXcQ\n
</div>
</figure>"
```
### Testing instructions

* Create a lesson with a Featured Video block and add a video
* Install and activate the Classic Editor plugin
* Add a Lesson with the Classic Editor 
* Add a YouTube link to the `Video Embed Code:` section
* You can use `Sensei_Utils::get_featured_video_html($POST_ID);` in wp shell to see the output for both the Block and Classic Editor posts

