### PR TITLE
Make the Featured images in course list have fixed height 

### DIFF
--- a/assets/blocks/course-list-block/course-list.scss
+++ b/assets/blocks/course-list-block/course-list.scss
@@ -10,8 +10,26 @@ $block: '.wp-block-sensei-lms-course-list';
 	z-index: 1000;
 }
 
+.editor-styles-wrapper .wp-block-sensei-lms-course-list {
+	.wp-block-post-template .wp-block {
+		width: 100%;
+	}
+
+	.wp-block-post-template .wp-block-post-featured-image {
+		margin: -10px -10px 0px -10px;
+	}
+}
+
 /* Match styles applied to block on single course page. */
 #{$block} {
+
+	.wp-block-post-template .wp-block-post .wp-block-group .wp-block-group__inner-container .wp-block-post-featured-image {
+		margin-top: -10px;
+		margin-right: -10px;
+		margin-left: -10px;
+		width: auto !important;
+	}
+
 	.wp-block-post {
 		border: 0;
 		margin: 0 0 1.618em;
@@ -55,10 +73,11 @@ $block: '.wp-block-sensei-lms-course-list';
 
 	.featured-course-wrapper__featured-image {
 		position: relative;
+		margin-top: -40px;
 
 		.course-list-featured-label__featured-image {
 			position: absolute;
-			top: 5px;
+			top: 15px;
 			left: 5px;
 			background-color: #1d2327;
 			color: #fff;

--- a/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
+++ b/includes/block-patterns/course-list/class-sensei-course-list-block-patterns.php
@@ -50,7 +50,7 @@ class Sensei_Course_List_Block_Patterns {
 							<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"10px","right":"10px","bottom":"10px","left":"10px"}},"border":{"width":"1px","color":"#c7c3c34f"}},"layout":{"inherit":false}} -->
 								<div class="wp-block-group alignfull has-border-color" style="border-color:#c7c3c34f;border-width:1px;padding-top:10px;padding-right:10px;padding-bottom:10px;padding-left:10px">
 
-									<!-- wp:post-featured-image {"isLink":true,"align":"center"} /-->
+									<!-- wp:post-featured-image {"isLink":true,"align":"center", "height":"324px" } /-->
 									<!-- wp:columns -->
 										<div class="wp-block-columns">
 
@@ -111,7 +111,7 @@ class Sensei_Course_List_Block_Patterns {
 								<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"10px","right":"10px","bottom":"10px","left":"10px"},"blockGap":"2px"},"border":{"width":"1px","color":"#c7c3c34f"}},"layout":{"inherit":false}} -->
 									<div class="wp-block-group alignfull has-border-color" style="border-color:#c7c3c34f;border-width:1px;padding-top:10px;padding-right:10px;padding-bottom:10px;padding-left:10px">
 
-										<!-- wp:post-featured-image {"isLink":true,"align":"center","lock":{"move": true}} /-->
+										<!-- wp:post-featured-image {"isLink":true,"align":"wide","lock":{"move": true}, "height":"180px" } /-->
 
 										<!-- wp:sensei-lms/course-categories {"lock":{"move": true}} /-->
 


### PR DESCRIPTION
Fixes #5698

### Changes proposed in this Pull Request
- Make the Featured images in course list have fixed height 
- Remove the boarder around the image so it looks like in the design 

<img width="801" alt="image" src="https://user-images.githubusercontent.com/7208249/190977582-ae69e2f7-002d-4358-87e3-cb93ead8be3f.png">
<img width="703" alt="image" src="https://user-images.githubusercontent.com/7208249/190856810-c6297246-e33e-4b07-886c-82c14cee0db5.png">

### Testing instructions

| Grid view Edit NOW | List View Preview NOW |
| -- | -- |
| <img width="1006" alt="image" src="https://user-images.githubusercontent.com/7208249/190975426-bdc5f95b-dbd3-41ac-9085-c722c12dee0b.png"> |  <img width="958" alt="image" src="https://user-images.githubusercontent.com/7208249/190975475-1752b035-2718-4c5c-90d3-54a798eb97cc.png"> |

| List view edit NOW | List view Preview NOW |
| -- | -- |
| <img width="256" alt="image" src="https://user-images.githubusercontent.com/7208249/190975640-3f253fcf-a90b-4d26-8079-ebd968bc9280.png"> |  <img width="277" alt="image" src="https://user-images.githubusercontent.com/7208249/190975673-90df086d-2247-448d-92e6-3975b5f71ff8.png"> |


### Discussion:
1. Why I didn't use just block property: 
- The view looks very weird and very off compared to the design. Changing other props doesn't fix it 
<img width="735" alt="image" src="https://user-images.githubusercontent.com/7208249/190976172-86f96f0c-d154-4a21-9279-213fa4ab29b1.png">
These settings don't change the way it looks
<img width="153" alt="image" src="https://user-images.githubusercontent.com/7208249/190978353-40e6ef72-4608-4bb1-9ef6-154f50ccab93.png">

2. Why I use !important for width: How every I specify it I coudn't override it
