### PR TITLE
Learning Mode - Fix site editor for non block themes.

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -142,6 +142,7 @@ class Sensei_Course_Theme_Editor {
 
 		if ( ! function_exists( 'wp_is_block_theme' ) || ! wp_is_block_theme() ) {
 			add_filter( 'theme_file_path', [ $this, 'override_theme_block_template_file' ], 10, 2 );
+			add_filter( 'pre_option_stylesheet', [ Sensei_Course_Theme::instance(), 'theme_stylesheet' ] );
 		}
 	}
 


### PR DESCRIPTION
Fixes p1663575330536339-slack-C036R3Y5ET0

### Changes proposed in this Pull Request

I was able to pinpoint the [commit](p1663575330536339-slack-C036R3Y5ET0) that caused the issue. Which essentially stopped executing bunch of hooks here https://github.com/Automattic/sensei/blob/a819c8c53eacd3a929d3f9d09e8f683cb00c2c9b/includes/course-theme/class-sensei-course-theme.php#L168-L178

I tested those hooks one-by-one and found out that the `pre_option_stylesheet` filter needs to be executed for site editor to work properly with non-block based themes.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Activate a non-block based theme.
* Visit "Appearance > Editor (beta)" and confirm that you can see a list of templates to edit.
* Also confirm that the site editor works for block based themes too.