### PR TITLE
Add replace-next-version-tag script

### DIFF
--- a/scripts/includes/chalk-lite.sh
+++ b/scripts/includes/chalk-lite.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+# Test if color is supported.
+function color_supported {
+	[[ -n "$NO_COLOR" ]] && return 1
+	[[ -n "$FORCE_COLOR" ]] && return 0
+	[[ -t 1 ]]
+}
+
+# Print possibly-colored text to standard output.
+#
+# The first parameter is the ANSI SGR parameter string, i.e. the part that
+# goes in between the `\e[` and the `m`.
+#
+# If passed additional parameters, those are printed. Otherwise, lines are read
+# from standard input and printed. Examples:
+#
+#   chalk 31 'This prints red text'
+#
+#   chalk 31 <<EOM
+#   This also prints red text.
+#   EOM
+#
+#   chalk 31 'This prints red text to STDERR' >&2
+function chalk {
+	local CC="$1" LINE FMT
+	shift
+	if color_supported; then
+		FMT="\e[${CC}m%s\e[0m\n"
+	else
+		FMT="%s\n"
+	fi
+	if [[ $# -gt 0 ]]; then
+		printf "$FMT" "$*"
+	else
+		while IFS= read -r LINE; do
+			printf "$FMT" "$LINE"
+		done
+	fi
+}
+
+# All the rest of these functions are just wrappers around `chalk` that
+# supply a particular first argument. `error` and `warn` also output to STDERR
+# by default.
+#
+#   info "Here's some information"
+#
+#   error <<-EOM
+#   Something went wrong!
+#   EOM
+
+
+function debug {
+	chalk '1;30' "$@"
+}
+
+function success {
+	if [[ $(tput colors 2>/dev/null) -gt 8 ]]; then
+		chalk '1;38;5;41' "$@"
+	else
+		chalk '1;32' "$@"
+	fi
+}
+
+function info {
+	chalk '1;37' "$@"
+}
+
+function warn {
+	chalk '1;33' "$@" >&2
+}
+
+function error {
+	chalk '1;31' "$@" >&2
+}
+
+function die {
+	error "$@"
+	exit 1
+}
+
+function prompt {
+	yellow "$@"
+}
+
+function red {
+	chalk '31' "$@"
+}
+
+function green {
+	chalk '32' "$@"
+}
+
+function jetpackGreen {
+	if [[ $(tput colors 2>/dev/null) -gt 8 ]]; then
+		chalk '38;5;41' "$@"
+	else
+		chalk '32' "$@"
+	fi
+}
+
+function yellow {
+	chalk '33' "$@"
+}
+
+function blue {
+	chalk '34' "$@"
+}
+
+function purple {
+	chalk '35' "$@"
+}
+
+function cyan {
+	chalk '36' "$@"
+}

--- a/scripts/includes/proceed_p.sh
+++ b/scripts/includes/proceed_p.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+INTERACTIVE=true
+if [[ ! -t 0 ]]; then
+	INTERACTIVE=false
+fi
+
+. "$(dirname "$BASH_SOURCE[0]")/chalk-lite.sh"
+
+# Ask whether to proceed.
+#
+# Args:
+#  1: The situation that requires prompting.
+#  2: Optional text to replace "Proceed?" as the question.
+#
+# Returns success if "yes", failure if "no" or non-interactive.
+function proceed_p {
+	if ! $INTERACTIVE; then
+		error "$1 Aborting"
+		return 42
+	fi
+	local OK
+
+	# Clear input before prompting
+	while read -r -t 0 OK; do read -r OK; done
+
+	local PROMPT
+	[[ -n "$1" ]] && PROMPT="$1 "
+	PROMPT="${PROMPT}${2:-Proceed?} [y/N] "
+	if color_supported; then
+		PROMPT=$(FORCE_COLOR=1 prompt "$PROMPT")
+	fi
+
+	read -n 1 -p "$PROMPT" OK
+	echo ""
+	[[ "$OK" == "y" || "$OK" == "Y" ]]
+}

--- a/scripts/replace-next-version-tag.sh
+++ b/scripts/replace-next-version-tag.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+
+# Adapted from https://github.com/Automattic/jetpack/blob/b3179d4347dcf73269985e1801b61bf53fbc441a/tools/replace-next-version-tag.sh
+
+set -eo pipefail
+
+BASE=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+. "$BASE/scripts/includes/chalk-lite.sh"
+. "$BASE/scripts/includes/proceed_p.sh"
+
+# Print help and exit.
+function usage {
+	cat <<-'EOH'
+		usage: $0 [-v] <version>
+
+		Replace the `$$next-version$$` token in doc tags with the specified version.
+		Recognized patterns:
+		 - `@since $$next-version$$`
+		 - `@deprecated $$next-version$$`
+		 - `@deprecated since $$next-version$$`
+		 - `_deprecated_function( ..., 'prefix-$$next-version$$' )`
+		   Other WordPress deprecation functions also work. The call must be on one
+		   line, indented with tabs, and the '$$next-version$$' token must be in a
+		   single-quoted string.
+	EOH
+	exit 1
+}
+
+if [[ $# -eq 0 ]]; then
+	usage
+fi
+
+# Sets options.
+VERBOSE=
+while getopts ":vh" opt; do
+	case ${opt} in
+		v)
+			if [[ -n "$VERBOSE" ]]; then
+				VERBOSE="${VERBOSE}v"
+			else
+				VERBOSE="-v"
+			fi
+			;;
+		h)
+			usage
+			;;
+		:)
+			die "Argument -$OPTARG requires a value."
+			;;
+		?)
+			error "Invalid argument: -$OPTARG"
+			echo ""
+			usage
+			;;
+	esac
+done
+shift "$(($OPTIND - 1))"
+
+if [[ -z "$VERBOSE" ]]; then
+	function debug {
+		:
+	}
+fi
+
+# Determine the version
+[[ -z "$1" ]] && die "A version must be specified."
+VERSION="$1"
+if ! grep -E -q '^[0-9]+(\.[0-9]+)+(-(a|alpha|beta)([-.]?[0-9]+)?)?$' <<<"$VERSION"; then
+	proceed_p "Version $VERSION does not seem to be a valid version number." "Continue?"
+fi
+VE=$(sed 's/[&\\/]/\\&/g' <<<"$VERSION")
+
+cd "$BASE"
+EXIT=0
+for FILE in $(git ls-files); do
+	[ "$FILE" == "scripts/replace-next-version-tag.sh" ] && continue;
+	grep -F -q '$$next-version$$' "$FILE" 2>/dev/null || continue
+	debug "Processing $FILE"
+
+	sed -i.bak -E -e 's!(@since|@deprecated( +[sS]ince)?)( +)\$\$next-version\$\$!\1\3'"$VE"'!g' "$FILE"
+	rm "$FILE.bak" # We need a backup file because macOS requires it.
+	sed -i.bak -E -e $'s!(^\t*_deprecated_(function|constructor|file|argument|hook)\\( .*, \'[^\']*)\\$\\$next-version\\$\\$\'!\\1'"$VE"$'\'!g' "$FILE"
+	rm "$FILE.bak" # We need a backup file because macOS requires it.
+
+	if grep -F -q '$$next-version$$' "$FILE"; then
+		EXIT=1
+		while IFS=':' read -r LINE DUMMY; do
+			if [[ -n "$CI" ]]; then
+				echo "::error file=$FILE,line=$LINE::"'Unexpected `$$next-version$$` token.'
+			else
+				error "$FILE:$LINE:"' Unexpected `$$next-version$$` token.'
+			fi
+		done < <( grep --line-number -F '$$next-version$$' "$FILE" || echo "" )
+	fi
+done
+
+exit $EXIT


### PR DESCRIPTION
I took the scripts from sensei-pro which are the adoption of scripts from jetpack.

### Changes proposed in this Pull Request

* Add replace-next-version-tag.sh script.

### Testing instructions

* Checkout the branch (at the moment, there are files with the `$$next-version$$` tag, so we can test the script easily.
* Run `scripts/replace-next-version-tag.sh -v 4.5.4`.
* The expected output:
```
$ scripts/replace-next-version-tag.sh -v 4.5.4
Processing includes/blocks/class-sensei-page-blocks.php
Processing includes/blocks/course-list/class-sensei-course-list-filter-abstract.php
Processing includes/course-video/blocks/class-sensei-course-video-blocks-embed-extension.php
Processing includes/course-video/blocks/class-sensei-course-video-blocks-video-extension.php
Processing includes/course-video/blocks/class-sensei-course-video-blocks-videopress-extension.php
Processing includes/course-video/blocks/class-sensei-course-video-blocks-vimeo-extension.php
Processing includes/course-video/blocks/class-sensei-course-video-blocks-youtube-extension.php
Processing includes/reports/class-sensei-no-users-table-relationship.php
Processing includes/reports/overview/data-provider/class-sensei-reports-overview-data-provider-students.php
```

