### PR TITLE
Fix editor for classic themes when no front page is set

### DIFF
--- a/includes/course-theme/class-sensei-course-theme-editor.php
+++ b/includes/course-theme/class-sensei-course-theme-editor.php
@@ -118,15 +118,27 @@ class Sensei_Course_Theme_Editor {
 	 */
 	public function maybe_add_site_editor_hooks() {
 
+		if ( $this->is_site_editor_request() ) {
+			$this->add_site_editor_hooks();
+		}
+	}
+
+	/**
+	 * Check if the current request is for the site editor.
+	 *
+	 * @since $next-version$
+	 */
+	public static function is_site_editor_request() {
+
 		$uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
 		$is_site_editor      = preg_match( '#/wp-admin/site-editor.php#i', $uri ) || preg_match( '#/wp-admin/themes.php\?.*page=gutenberg-edit-site#i', $uri );
 		$is_site_editor_rest = preg_match( '#/wp-json/.*/' . self::THEME_PREFIX . '#i', $uri ) || preg_match( '#/wp-json/wp/v2/templates#i', $uri );
 
-		if ( $is_site_editor || $is_site_editor_rest ) {
-			$this->add_site_editor_hooks();
-		}
+		return $is_site_editor || $is_site_editor_rest;
 	}
+
+
 
 	/**
 	 * Add template editing hooks.

--- a/includes/course-theme/class-sensei-course-theme-templates.php
+++ b/includes/course-theme/class-sensei-course-theme-templates.php
@@ -199,8 +199,9 @@ class Sensei_Course_Theme_Templates {
 
 		$supported_template_types = [ 'lesson', 'quiz' ];
 
+		$is_site_editor_request   = Sensei_Course_Theme_Editor::is_site_editor_request();
 		$is_course_theme_override = ! empty( $query['theme'] ) && ( Sensei_Course_Theme::THEME_NAME === $query['theme'] );
-		$is_site_editor           = empty( $query ) || $is_course_theme_override;
+		$is_site_editor           = $is_site_editor_request || $is_course_theme_override;
 		$is_supported_template    = $slugs && ! empty( array_intersect( $supported_template_types, $slugs ) );
 
 		// Remove file templates picked up from the sensei-course-theme theme directory when the theme override is active.
@@ -232,7 +233,7 @@ class Sensei_Course_Theme_Templates {
 		$templates = array_merge( $extra_templates, $templates );
 
 		// Return the lesson template as the default when there are no theme templates in the site editor.
-		if ( $is_course_theme_override && empty( $templates ) ) {
+		if ( $is_site_editor && empty( $templates ) ) {
 			return [ $course_theme_templates['lesson'] ];
 		}
 


### PR DESCRIPTION

### Changes proposed in this Pull Request

* Change how we check for the site editor when adding block templates, to handle it trying to look up the index page

### Testing instructions

- The original issue happens with this option set: WP Settings → Reading → Your homepage displays: Your latest posts
- Set a non-block theme for the site
- Open the site editor and check that it works
- Open the site frontend and check that its template is not broken
