### PR TITLE
Add check to load feature label only for newer wp versions

### DIFF
--- a/includes/blocks/class-sensei-page-blocks.php
+++ b/includes/blocks/class-sensei-page-blocks.php
@@ -21,12 +21,11 @@ class Sensei_Page_Blocks extends Sensei_Blocks_Initializer {
 
 		parent::__construct( [ 'page' ] );
 
-		add_filter( 'render_block_core/post-featured-image', [ $this, 'add_badge' ], 10, 3 );
-
 		$version = str_replace( '-src', '', $wp_version );
 
 		if ( ! version_compare( $version, '5.9', '<' ) ) {
 			add_filter( 'render_block', array( $this, 'add_course_featured_badge' ), 11, 3 );
+			add_filter( 'render_block_core/post-featured-image', [ $this, 'add_badge' ], 10, 3 );
 		}
 	}
 


### PR DESCRIPTION
Fixes issue of missing $instance param for `render_block_core/post-featured-image` in wp version < 5.9

### Changes proposed in this Pull Request

* Added a check to to not add featured image to hook for WP version < 5.9

### Testing instructions

- Change your wp version to one below 5.9
- Add the course list block to a page
- load the frontend for that page
- Make sure nothing is breaking and there is no error message
- Now change the version to one above 5.9
- Make sure the featured label is now showing properly
