### PR TITLE
Limit template blocks to site editor, widget editor and template editing

### DIFF
--- a/assets/course-theme/blocks/index.js
+++ b/assets/course-theme/blocks/index.js
@@ -1,11 +1,7 @@
 /**
- * WordPress dependencies
- */
-import { registerBlockType } from '@wordpress/blocks';
-
-/**
  * Internal dependencies
  */
+import { registerTemplateBlocks } from './register-template-blocks';
 import courseNavigationBlock from './course-navigation';
 import uiBlocks from './ui';
 import lessonBlocks from './lesson-blocks';
@@ -20,7 +16,4 @@ const blocks = [
 	templateStyleBlock,
 ];
 
-blocks.forEach( ( block ) => {
-	const { name, ...settings } = block;
-	registerBlockType( name, settings );
-} );
+registerTemplateBlocks( blocks );

--- a/assets/course-theme/blocks/register-template-blocks.js
+++ b/assets/course-theme/blocks/register-template-blocks.js
@@ -29,15 +29,15 @@ export function registerTemplateBlocks( blocks ) {
 
 	// TODO Only subscribe when in the post editor.
 	subscribe( () => {
-		const postType = select( 'core/editor' ).getCurrentPostType();
+		const postType = select( 'core/editor' )?.getCurrentPostType();
+		const editPost = select( 'core/edit-post' );
 
-		if ( ! postType ) {
+		if ( ! postType || ! editPost ) {
 			return;
 		}
 
-		const { isEditingTemplate } = select( 'core/edit-post' );
-
-		const isTemplate = 'lesson' === postType && isEditingTemplate();
+		const isTemplate =
+			'lesson' === postType && editPost.isEditingTemplate();
 		toggleBlockRegistration( isTemplate );
 	} );
 }

--- a/assets/course-theme/blocks/register-template-blocks.js
+++ b/assets/course-theme/blocks/register-template-blocks.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { registerBlockType, unregisterBlockType } from '@wordpress/blocks';
+import { select, subscribe } from '@wordpress/data';
+
+/**
+ * Makes sure the template blocks are only registered when in the site or widget editor, or editing the template from
+ * the lesson page.
+ *
+ * @param {Array} blocks
+ */
+export function registerTemplateBlocks( blocks ) {
+	let themeBlocksEnabled = false;
+
+	const toggleBlockRegistration = ( enable ) => {
+		if ( enable === themeBlocksEnabled ) {
+			return;
+		}
+		themeBlocksEnabled = enable;
+		const method = enable ? registerBlockType : unregisterBlockType;
+		blocks.forEach( ( block ) => {
+			const { name, ...settings } = block;
+			method( name, settings );
+		} );
+	};
+
+	toggleBlockRegistration( true );
+
+	// TODO Only subscribe when in the post editor.
+	subscribe( () => {
+		const postType = select( 'core/editor' ).getCurrentPostType();
+
+		if ( ! postType ) {
+			return;
+		}
+
+		const { isEditingTemplate } = select( 'core/edit-post' );
+
+		const isTemplate = 'lesson' === postType && isEditingTemplate();
+		toggleBlockRegistration( isTemplate );
+	} );
+}


### PR DESCRIPTION
Fixes #5699 

### Changes proposed in this Pull Request

* Unregister the LM template blocks when in the post editor
* Enable them when template edit mode is active in the post editor

### Testing instructions

* Open a LM template in the site editor. Make sure Sensei's blocks are working
* Edit a lesson. Check that blocks like 'Fixed Header', 'Course Navigation' etc don't show up in the block inserter
* Using a block theme, edit a lesson, and in the lesson settings sidebar under Template, click Edit. The template should become visible around the lesson content. Check that the Sensei template blocks are working, and new ones can be inserted
* Close template editing mode. The blocks should disappear from the inserter.
