### PR TITLE
Add Featured Video Thumbnail creation

### DIFF
--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -74,7 +74,7 @@ class Sensei_Lesson {
 			add_action( 'save_post', array( $this, 'quiz_update' ) );
 			add_action( 'save_post', array( $this, 'add_lesson_to_course_order' ) );
 
-			// Lesson Featured Video Thumbnail Creation
+			// Lesson Featured Video Thumbnail Creation.
 			add_action( 'save_post', array( $this, 'save_lesson_featured_video_thumbnail' ) );
 
 			// Custom Write Panel Columns

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -74,6 +74,9 @@ class Sensei_Lesson {
 			add_action( 'save_post', array( $this, 'quiz_update' ) );
 			add_action( 'save_post', array( $this, 'add_lesson_to_course_order' ) );
 
+			// Lesson Featured Video Thumbnail Creation
+			add_action( 'save_post', array( $this, 'save_lesson_featured_video_thumbnail' ) );
+
 			// Custom Write Panel Columns
 			add_filter( 'manage_edit-lesson_columns', array( $this, 'add_column_headings' ), 20, 1 );
 			add_action( 'manage_posts_custom_column', array( $this, 'add_column_data' ), 10, 2 );
@@ -724,6 +727,142 @@ class Sensei_Lesson {
 
 		// Assumes Sensei admin is loaded.
 		Sensei()->admin->save_lesson_order( '', $course_id );
+	}
+
+	/**
+	 * Parses YouTube URL to retrieve thumbnail image.
+	 *
+	 * @param string $url
+	 * @return string|null String if image found, null if not.
+	 */
+	public function get_youtube_thumbnail( $url ) {
+		$re = '/(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/';
+		preg_match($re, $url, $matches);
+		return 'https://img.youtube.com/vi/' . $matches[1] . '/maxresdefault.jpg';
+	}
+
+	/**
+	 * Parses Vimeo URL to retrieve thumbnail image.
+	 *
+	 * @param string $url
+	 * @return string|null String if image found, null if not.
+	 */
+	public function get_vimeo_thumbnail( $url ) {
+		$re = '/(?:http|https)?:?\/?\/?(?:www\.)?(?:player\.)?vimeo\.com\/(?:channels\/(?:\w+\/)?|groups\/(?:[^\/]*)\/videos\/|video\/|)(\d+)(?:|\/\?)/';
+		preg_match($re, $url, $matches);
+		$data = wp_remote_get( 'http://vimeo.com/api/v2/video/' . $matches[1] . '.json' );
+		if ( is_array( $data ) && count( $data ) > 0 ) {
+			$body = json_decode( $data['body'] );
+			return $body[0]->thumbnail_large;
+		} else {
+			return null;
+		}
+	}
+
+	/**
+	 * Parses VideoPress URL to retrieve thumbnail image.
+	 *
+	 * @param string $url
+	 * @return string|null String if image found, null if not.
+	 */
+	public function get_videopress_thumbnail( $url ) {
+		$url_parse = wp_parse_url( $url );
+		$re = '/(?<=\/v\/).*/';
+		preg_match( $re, $url_parse['path'], $matches );
+		$data = wp_remote_get( 'https://public-api.wordpress.com/rest/v1.1/videos/' . $matches[0] . '/poster' );
+		if ( is_array( $data ) ) {
+			$body = json_decode( $data['body'] );
+			return $body->poster;
+		} else {
+			return null;
+		}
+	}
+	/**
+	 * Get Featured Video from "Video Embed Code" legacy metadata in the Classic Editor
+	 *
+	 * @param string $url
+	 * @return string The video thumbnail URL.
+	 */
+	private function get_featured_video_media_from_classic_editor( $url ) {
+		$url_parse = wp_parse_url( $url );
+
+		if ( false !== strpos( $url_parse['host'], 'youtube' ) ) {
+			return $this->get_youtube_thumbnail($url);
+		}
+		if ( false !== strpos( $url_parse['host'], 'vimeo' ) ) {
+			return $this->get_vimeo_thumbnail( $url );
+		}
+		if ( false !== strpos( $url_parse['host'], 'videopress' ) ) {
+			return $this->get_videopress_thumbnail( $url );
+		}
+	}
+	/**
+	 * Get featured video url from the Featured Video Block
+	 *
+	 * @param int $post_id The post id.
+	 * @return string|null The URL string or null if the post does not have one.
+	 */
+	private function get_featured_video_media_from_blocks( $post_id ) {
+		$post   = get_post( $post_id );
+		$blocks = parse_blocks( $post->post_content );
+		foreach ( $blocks as $block ) {
+			if ( 'sensei-lms/featured-video' === $block['blockName'] ) {
+				if ( $block['innerBlocks'][0]['blockName'] === 'sensei-pro/interactive-video' ) {
+					$block = $block['innerBlocks'][0];
+				}
+				if ( 'core/video' === $block['innerBlocks'][0]['blockName'] ) {
+					if ( $block['innerBlocks'][0]['attrs']['videoPressClassNames']  ) {
+						return $block['attrs']['poster'];
+					} else {
+						return wp_get_attachment_url( get_post_thumbnail_id( $block['innerBlocks'][0]['attrs']['id'] ) );
+					}
+				}
+				if ( 'core/embed' === $block['innerBlocks'][0]['blockName'] ) {
+					$url = $block['innerBlocks'][0]['attrs']['url'];
+					if ( 'youtube' === $block['innerBlocks'][0]['attrs']['providerNameSlug'] ) {
+						return $this->get_youtube_thumbnail($url);
+					} else if ( 'vimeo' === $block['innerBlocks'][0]['attrs']['providerNameSlug'] ) {
+						return $this->get_vimeo_thumbnail( $url );
+					} else if ( 'videopress' === $block['innerBlocks'][0]['attrs']['providerNameSlug'] ) {
+						return $this->get_videopress_thumbnail( $url );
+					}
+				}
+			}
+			return null;
+		}
+	}
+
+	/**
+	 * Save Lesson Featured Video thumbnail to post meta
+	 *
+	 * @param int $post_id The Post Id.
+	 *
+	 */
+	public function save_lesson_featured_video_thumbnail( $post_id ){
+		$meta_key = '_featured_video_thumbnail';
+		$thumbnail_meta = get_post_meta( $post_id, $meta_key, true );
+
+		if ( has_blocks( $post_id ) ) {
+			$thumbnail = $this->get_featured_video_media_from_blocks( $post_id );
+		} else {
+			$video_embed = get_post_meta( $post_id, '_lesson_video_embed', true );
+			if ( $video_embed ) {
+				$thumbnail = $this->get_featured_video_media_from_classic_editor( $video_embed );
+			}
+		}
+		if ( null !== $thumbnail && $thumbnail !== $thumbnail_meta ) {
+			update_post_meta( $post_id, $meta_key, $thumbnail );
+		}
+	}
+
+	/**
+	 * Get the featured video thumbnail URL from a Post's metadata.
+	 *
+	 * @param int $post_id
+	 * @return string The video thumbnail URL.
+	 */
+	public static function get_featured_video_thumbnail_url( $post_id ) {
+		return get_post_meta( $post_id, '_featured_video_thumbnail', true );
 	}
 
 	/**

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -732,24 +732,24 @@ class Sensei_Lesson {
 	/**
 	 * Parses YouTube URL to retrieve thumbnail image.
 	 *
-	 * @param string $url
+	 * @param string $url The YouTube Video URL.
 	 * @return string|null String if image found, null if not.
 	 */
 	public function get_youtube_thumbnail( $url ) {
 		$re = '/(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/';
-		preg_match($re, $url, $matches);
+		preg_match( $re, $url, $matches );
 		return 'https://img.youtube.com/vi/' . $matches[1] . '/maxresdefault.jpg';
 	}
 
 	/**
 	 * Parses Vimeo URL to retrieve thumbnail image.
 	 *
-	 * @param string $url
+	 * @param string $url The Vimieo Video URL.
 	 * @return string|null String if image found, null if not.
 	 */
 	public function get_vimeo_thumbnail( $url ) {
 		$re = '/(?:http|https)?:?\/?\/?(?:www\.)?(?:player\.)?vimeo\.com\/(?:channels\/(?:\w+\/)?|groups\/(?:[^\/]*)\/videos\/|video\/|)(\d+)(?:|\/\?)/';
-		preg_match($re, $url, $matches);
+		preg_match( $re, $url, $matches );
 		$data = wp_remote_get( 'http://vimeo.com/api/v2/video/' . $matches[1] . '.json' );
 		if ( is_array( $data ) && count( $data ) > 0 ) {
 			$body = json_decode( $data['body'] );
@@ -762,12 +762,12 @@ class Sensei_Lesson {
 	/**
 	 * Parses VideoPress URL to retrieve thumbnail image.
 	 *
-	 * @param string $url
+	 * @param string $url The VideoPress Video URL.
 	 * @return string|null String if image found, null if not.
 	 */
 	public function get_videopress_thumbnail( $url ) {
 		$url_parse = wp_parse_url( $url );
-		$re = '/(?<=\/v\/).*/';
+		$re        = '/(?<=\/v\/).*/';
 		preg_match( $re, $url_parse['path'], $matches );
 		$data = wp_remote_get( 'https://public-api.wordpress.com/rest/v1.1/videos/' . $matches[0] . '/poster' );
 		if ( is_array( $data ) ) {
@@ -780,14 +780,14 @@ class Sensei_Lesson {
 	/**
 	 * Get Featured Video from "Video Embed Code" legacy metadata in the Classic Editor
 	 *
-	 * @param string $url
+	 * @param string $url The Video Embed URL.
 	 * @return string The video thumbnail URL.
 	 */
 	private function get_featured_video_media_from_classic_editor( $url ) {
 		$url_parse = wp_parse_url( $url );
 
 		if ( false !== strpos( $url_parse['host'], 'youtube' ) ) {
-			return $this->get_youtube_thumbnail($url);
+			return $this->get_youtube_thumbnail( $url );
 		}
 		if ( false !== strpos( $url_parse['host'], 'vimeo' ) ) {
 			return $this->get_vimeo_thumbnail( $url );
@@ -807,11 +807,11 @@ class Sensei_Lesson {
 		$blocks = parse_blocks( $post->post_content );
 		foreach ( $blocks as $block ) {
 			if ( 'sensei-lms/featured-video' === $block['blockName'] ) {
-				if ( $block['innerBlocks'][0]['blockName'] === 'sensei-pro/interactive-video' ) {
+				if ( 'sensei-pro/interactive-video' === $block['innerBlocks'][0]['blockName'] ) {
 					$block = $block['innerBlocks'][0];
 				}
 				if ( 'core/video' === $block['innerBlocks'][0]['blockName'] ) {
-					if ( $block['innerBlocks'][0]['attrs']['videoPressClassNames']  ) {
+					if ( $block['innerBlocks'][0]['attrs']['videoPressClassNames'] ) {
 						return $block['attrs']['poster'];
 					} else {
 						return wp_get_attachment_url( get_post_thumbnail_id( $block['innerBlocks'][0]['attrs']['id'] ) );
@@ -820,10 +820,10 @@ class Sensei_Lesson {
 				if ( 'core/embed' === $block['innerBlocks'][0]['blockName'] ) {
 					$url = $block['innerBlocks'][0]['attrs']['url'];
 					if ( 'youtube' === $block['innerBlocks'][0]['attrs']['providerNameSlug'] ) {
-						return $this->get_youtube_thumbnail($url);
-					} else if ( 'vimeo' === $block['innerBlocks'][0]['attrs']['providerNameSlug'] ) {
+						return $this->get_youtube_thumbnail( $url );
+					} elseif ( 'vimeo' === $block['innerBlocks'][0]['attrs']['providerNameSlug'] ) {
 						return $this->get_vimeo_thumbnail( $url );
-					} else if ( 'videopress' === $block['innerBlocks'][0]['attrs']['providerNameSlug'] ) {
+					} elseif ( 'videopress' === $block['innerBlocks'][0]['attrs']['providerNameSlug'] ) {
 						return $this->get_videopress_thumbnail( $url );
 					}
 				}
@@ -836,10 +836,9 @@ class Sensei_Lesson {
 	 * Save Lesson Featured Video thumbnail to post meta
 	 *
 	 * @param int $post_id The Post Id.
-	 *
 	 */
-	public function save_lesson_featured_video_thumbnail( $post_id ){
-		$meta_key = '_featured_video_thumbnail';
+	public function save_lesson_featured_video_thumbnail( $post_id ) {
+		$meta_key       = '_featured_video_thumbnail';
 		$thumbnail_meta = get_post_meta( $post_id, $meta_key, true );
 
 		if ( has_blocks( $post_id ) ) {
@@ -858,7 +857,7 @@ class Sensei_Lesson {
 	/**
 	 * Get the featured video thumbnail URL from a Post's metadata.
 	 *
-	 * @param int $post_id
+	 * @param int $post_id The Post ID.
 	 * @return string The video thumbnail URL.
 	 */
 	public static function get_featured_video_thumbnail_url( $post_id ) {

--- a/includes/class-sensei-lesson.php
+++ b/includes/class-sensei-lesson.php
@@ -855,16 +855,6 @@ class Sensei_Lesson {
 	}
 
 	/**
-	 * Get the featured video thumbnail URL from a Post's metadata.
-	 *
-	 * @param int $post_id The Post ID.
-	 * @return string The video thumbnail URL.
-	 */
-	public static function get_featured_video_thumbnail_url( $post_id ) {
-		return get_post_meta( $post_id, '_featured_video_thumbnail', true );
-	}
-
-	/**
 	 * to actions when the status of the lesson changes to publish
 	 *
 	 * @deprecated 3.6.0

--- a/includes/class-sensei-utils.php
+++ b/includes/class-sensei-utils.php
@@ -2651,6 +2651,16 @@ class Sensei_Utils {
 			return trim( ob_get_clean() );
 		}
 	}
+
+	/**
+	 * Get the featured video thumbnail URL from a Post's metadata.
+	 *
+	 * @param int $post_id The Post ID.
+	 * @return string The video thumbnail URL.
+	 */
+	public static function get_featured_video_thumbnail_url( $post_id ) {
+		return get_post_meta( $post_id, '_featured_video_thumbnail', true );
+	}
 }
 
 /**


### PR DESCRIPTION
Fixes #5690

### Changes proposed in this Pull Request

- This PR adds a hook on `save_post` for lessons that will store the video thumbnail URL in post meta.
- It supports:
   - YouTube
   - Vimeo
   - VideoPress
   - The WP Media Library
- It also supports the Classic Editor for cases where people are still using the `_lesson_video_embed` meta.
- I also added a method named `get_featured_video_thumbnail_url` to easily get the postmeta value to use in the Video templates later.

### Testing instructions

* Check this PR out
* Add a Lesson
* Add a Featured Video Block
* Add a YouTube Video like `https://www.youtube.com/watch?v=dQw4w9WgXcQ`
* Publish/Update the post
* Check the postmeta for that post to make sure `_featured_video_thumbnail` has the right URL there.
* Repeat the process for VideoPress, WP Media Library Videos, and Vimeo.

 ### Note about VideoPress

There are actually two ways that you can add VideoPress video's to your site - one is through embedding a VideoPress URL which creates an `core/embed` block.  The other is if you have a Jetpack site with VideoPress enabled and you upload a video directly to your site which is then converted to a VideoPress video but aliased to your local Media file - in that case it's a `core/video` block.  Feel free to test for both - if you want to test the Jetpack version you will need to use a site connected to Jetpack with VideoPress enabled.

### Screenshot / Video
![featured-video-thumb](https://user-images.githubusercontent.com/3220162/191377422-61026a2a-8af9-455c-bc8b-f8d28db61d62.gif)

Edit:  Since I branched off of `add/featured-video-method` I PR'd against that branch.  Hope that's ok!
