### PR TITLE
Remove unneeded mark step complete

### DIFF
--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -40,7 +40,6 @@ class Sensei_Setup_Wizard {
 			'selected' => [],
 			'other'    => '',
 		],
-		'steps'     => [],
 		'__version' => '1',
 	];
 
@@ -268,7 +267,7 @@ class Sensei_Setup_Wizard {
 		}
 
 		$setup_wizard_user_data   = get_option( self::USER_DATA_OPTION, false );
-		$setup_wizard_in_progress = $setup_wizard_user_data && ! empty( $setup_wizard_user_data['steps'] );
+		$setup_wizard_in_progress = $setup_wizard_user_data;
 
 		$setup_url = admin_url( 'admin.php?page=' . $this->page_slug );
 

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -20,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Setup_Wizard {
 	const SUGGEST_SETUP_WIZARD_OPTION = 'sensei_suggest_setup_wizard';
+	const SETUP_WIZARD_STARTED_OPTION = 'sensei_setup_wizard_started';
 	const WCCOM_INSTALLING_TRANSIENT  = 'sensei_setup_wizard_wccom_installing';
 	const USER_DATA_OPTION            = 'sensei_setup_wizard_data';
 	const MC_LIST_ID                  = '4fa225a515';
@@ -266,13 +267,14 @@ class Sensei_Setup_Wizard {
 			return;
 		}
 
-		$setup_wizard_user_data   = get_option( self::USER_DATA_OPTION, false );
-		$setup_wizard_in_progress = $setup_wizard_user_data;
+		$setup_wizard_started = get_option( self::SETUP_WIZARD_STARTED_OPTION );
+
+		// The steps check is for backwards compatibility.
+		$setup_wizard_in_progress = $setup_wizard_started || ! empty( $setup_wizard_user_data['steps'] );
 
 		$setup_url = admin_url( 'admin.php?page=' . $this->page_slug );
-
-		$skip_url = add_query_arg( 'sensei_skip_setup_wizard', '1' );
-		$skip_url = wp_nonce_url( $skip_url, 'sensei_skip_setup_wizard' );
+		$skip_url  = add_query_arg( 'sensei_skip_setup_wizard', '1' );
+		$skip_url  = wp_nonce_url( $skip_url, 'sensei_skip_setup_wizard' );
 		?>
 		<div id="message" class="updated sensei-message sensei-connect">
 			<p><?php echo wp_kses_post( __( '<strong>Welcome to Sensei LMS</strong> &#8211; You\'re almost ready to start creating online courses!', 'sensei-lms' ) ); ?></p>
@@ -294,6 +296,13 @@ class Sensei_Setup_Wizard {
 			</p>
 		</div>
 		<?php
+	}
+
+	/**
+	 * Set setup wizard as started.
+	 */
+	public function set_setup_wizard_as_started() {
+		update_option( self::SETUP_WIZARD_STARTED_OPTION, 1 );
 	}
 
 	/**

--- a/includes/admin/class-sensei-setup-wizard.php
+++ b/includes/admin/class-sensei-setup-wizard.php
@@ -20,7 +20,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sensei_Setup_Wizard {
 	const SUGGEST_SETUP_WIZARD_OPTION = 'sensei_suggest_setup_wizard';
-	const SETUP_WIZARD_STARTED_OPTION = 'sensei_setup_wizard_started';
 	const WCCOM_INSTALLING_TRANSIENT  = 'sensei_setup_wizard_wccom_installing';
 	const USER_DATA_OPTION            = 'sensei_setup_wizard_data';
 	const MC_LIST_ID                  = '4fa225a515';
@@ -267,11 +266,6 @@ class Sensei_Setup_Wizard {
 			return;
 		}
 
-		$setup_wizard_started = get_option( self::SETUP_WIZARD_STARTED_OPTION );
-
-		// The steps check is for backwards compatibility.
-		$setup_wizard_in_progress = $setup_wizard_started || ! empty( $setup_wizard_user_data['steps'] );
-
 		$setup_url = admin_url( 'admin.php?page=' . $this->page_slug );
 		$skip_url  = add_query_arg( 'sensei_skip_setup_wizard', '1' );
 		$skip_url  = wp_nonce_url( $skip_url, 'sensei_skip_setup_wizard' );
@@ -281,13 +275,7 @@ class Sensei_Setup_Wizard {
 
 			<p class="submit">
 				<a href="<?php echo esc_url( $setup_url ); ?>" class="button-primary">
-					<?php
-					if ( $setup_wizard_in_progress ) {
-						esc_html_e( 'Complete Setup', 'sensei-lms' );
-					} else {
-						esc_html_e( 'Run the Setup Wizard', 'sensei-lms' );
-					}
-					?>
+					<?php esc_html_e( 'Run the Setup Wizard', 'sensei-lms' ); ?>
 				</a>
 
 				<a class="button" href="<?php echo esc_url( $skip_url ); ?>">
@@ -296,13 +284,6 @@ class Sensei_Setup_Wizard {
 			</p>
 		</div>
 		<?php
-	}
-
-	/**
-	 * Set setup wizard as started.
-	 */
-	public function set_setup_wizard_as_started() {
-		update_option( self::SETUP_WIZARD_STARTED_OPTION, 1 );
 	}
 
 	/**

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -59,6 +59,7 @@ class Sensei_Data_Cleaner {
 		'sensei_course_order',
 		'skip_install_sensei_pages', // deprecated 3.1.0.
 		'sensei_suggest_setup_wizard',
+		'sensei_setup_wizard_started',
 		'sensei-data-port-jobs',
 		'sensei_setup_wizard_data',
 		'sensei_exit_survey_data',

--- a/includes/class-sensei-data-cleaner.php
+++ b/includes/class-sensei-data-cleaner.php
@@ -59,7 +59,6 @@ class Sensei_Data_Cleaner {
 		'sensei_course_order',
 		'skip_install_sensei_pages', // deprecated 3.1.0.
 		'sensei_suggest_setup_wizard',
-		'sensei_setup_wizard_started',
 		'sensei-data-port-jobs',
 		'sensei_setup_wizard_data',
 		'sensei_exit_survey_data',

--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -397,6 +397,7 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 	 */
 	public function submit_welcome( $data ) {
 		$this->setup_wizard->pages->create_pages();
+		$this->setup_wizard->set_setup_wizard_as_started();
 
 		return true;
 	}

--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -315,11 +315,15 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 	/**
 	 * Mark the given step as completed.
 	 *
+	 * @deprecated $$next-version$$
+	 *
 	 * @param string $step Step.
 	 *
 	 * @return bool Success.
 	 */
 	public function mark_step_complete( $step ) {
+		_deprecated_function( __METHOD__, '$$next-version$$' );
+
 		return $this->setup_wizard->update_wizard_user_data(
 			[
 				'steps' => array_unique( array_merge( $this->setup_wizard->get_wizard_user_data( 'steps' ), [ $step ] ) ),
@@ -392,7 +396,6 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 	 * @return bool Success.
 	 */
 	public function submit_welcome( $data ) {
-		$this->mark_step_complete( 'welcome' );
 		$this->setup_wizard->pages->create_pages();
 
 		return true;
@@ -406,9 +409,6 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 	 * @return bool Success.
 	 */
 	public function submit_purpose( $form ) {
-
-		$this->mark_step_complete( 'purpose' );
-
 		$purpose_data = [
 			'selected' => $form['selected'],
 			'other'    => ( in_array( 'other', $form['selected'], true ) ? $form['other'] : '' ),
@@ -437,8 +437,6 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 	 * @return bool Success.
 	 */
 	public function submit_tracking( $data ) {
-		$this->mark_step_complete( 'tracking' );
-
 		Sensei()->usage_tracking->set_tracking_enabled( (bool) $data['usage_tracking'] );
 		Sensei()->usage_tracking->send_usage_data();
 
@@ -453,9 +451,6 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 	 * @return bool Success.
 	 */
 	public function submit_features( $form ) {
-
-		$this->mark_step_complete( 'features' );
-
 		return $this->setup_wizard->update_wizard_user_data(
 			[
 				'features' => [
@@ -482,7 +477,6 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 	 * Complete setup wizard
 	 */
 	public function complete_setup_wizard() {
-		$this->mark_step_complete( 'ready' );
 		$this->setup_wizard->finish_setup_wizard();
 
 		return true;

--- a/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
+++ b/includes/rest-api/class-sensei-rest-api-setup-wizard-controller.php
@@ -397,7 +397,6 @@ class Sensei_REST_API_Setup_Wizard_Controller extends \WP_REST_Controller {
 	 */
 	public function submit_welcome( $data ) {
 		$this->setup_wizard->pages->create_pages();
-		$this->setup_wizard->set_setup_wizard_as_started();
 
 		return true;
 	}

--- a/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
+++ b/tests/unit-tests/admin/test-class-sensei-setup-wizard.php
@@ -85,31 +85,6 @@ class Sensei_Setup_Wizard_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test setup wizard notice says continue when user completed a step.
-	 *
-	 * @covers Sensei_Setup_Wizard::setup_wizard_notice
-	 * @covers Sensei_Setup_Wizard::should_current_page_display_setup_wizard
-	 */
-	public function testSetupWizardNoticeContinue() {
-		// Create and login as admin.
-		$admin_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
-		wp_set_current_user( $admin_id );
-
-		set_current_screen( 'dashboard' );
-		update_option( \Sensei_Setup_Wizard::SUGGEST_SETUP_WIZARD_OPTION, 1 );
-
-		Sensei()->setup_wizard->update_wizard_user_data( [ 'steps' => [ 'welcome' ] ] );
-
-		ob_start();
-		Sensei()->setup_wizard->setup_wizard_notice();
-		$html = ob_get_clean();
-
-		$pos_setup_button = strpos( $html, 'Complete Setup' );
-
-		$this->assertNotFalse( $pos_setup_button, 'Should return the notice HTML' );
-	}
-
-	/**
 	 * Test setup wizard notice in screen with Sensei prefix.
 	 *
 	 * @covers Sensei_Setup_Wizard::setup_wizard_notice


### PR DESCRIPTION
### Changes proposed in this Pull Request

* It removes the unneeded method to mark a step as complete.

### Testing instructions

<!--
If the functionality of this PR is behind a feature flag, please include the
following testing step, using the correct name for the feature flag. (If you
aren't sure, just ignore this step)

* Enable the feature flag: `add_filter( 'sensei_feature_flag_{THE_FLAG_NAME}', '__return_true' );`
-->
* Navigate through the Setup Wizard, and make sure it continues working properly.
* In the database, set the option `sensei_suggest_setup_wizard` to `1`, and clear the option `sensei_setup_wizard_data`.
* Go to the courses list in the admin (`/wp-admin/edit.php?post_type=course`), and make sure you see the Setup Wizard notice.